### PR TITLE
feat(substrate): dag executor + submit/status/cancel mcp tools

### DIFF
--- a/crates/aether-capabilities/src/dag.rs
+++ b/crates/aether-capabilities/src/dag.rs
@@ -7,7 +7,7 @@
 //!
 //! Same construction shape as `HandleCapability` and
 //! `RpcServerCapability`: a singleton
-//! [`NativeActor`](aether_substrate::actor::native::NativeActor) registered at
+//! [`NativeActor`](aether_substrate::NativeActor) registered at
 //! chassis boot under the `aether.dag` namespace (ADR-0078
 //! chassis-internal actor). `init` caches the `Arc<Mailer>` + own
 //! mailbox id off the init ctx and builds the executor against them,

--- a/crates/aether-capabilities/src/dag.rs
+++ b/crates/aether-capabilities/src/dag.rs
@@ -155,12 +155,13 @@ mod native {
         /// Reply: `StatusResult`.
         #[handler]
         fn on_status(&mut self, ctx: &mut NativeCtx<'_>, mail: Status) {
-            let reply = self.executor.status(mail.dag_id).unwrap_or_else(|| {
-                StatusResult::Failed {
+            let reply = self
+                .executor
+                .status(mail.dag_id)
+                .unwrap_or_else(|| StatusResult::Failed {
                     node_id: aether_kinds::NodeId(0),
                     error: format!("unknown dag {}", mail.dag_id),
-                }
-            });
+                });
             ctx.reply(&reply);
         }
 
@@ -197,9 +198,9 @@ mod native {
         #[fallback]
         fn on_reply(&mut self, ctx: &mut NativeCtx<'_>, env: &Envelope) {
             let correlation = env.sender.correlation_id;
-            let matched = self
-                .executor
-                .on_reply(ctx, correlation, KindId(env.kind.0), &env.payload);
+            let matched =
+                self.executor
+                    .on_reply(ctx, correlation, KindId(env.kind.0), &env.payload);
             if !matched {
                 tracing::debug!(
                     target: "aether_substrate::dag",

--- a/crates/aether-capabilities/src/dag.rs
+++ b/crates/aether-capabilities/src/dag.rs
@@ -6,7 +6,8 @@
 //! timer) — into it.
 //!
 //! Same construction shape as `HandleCapability` and
-//! `RpcServerCapability`: a singleton [`NativeActor`] registered at
+//! `RpcServerCapability`: a singleton
+//! [`NativeActor`](aether_substrate::actor::native::NativeActor) registered at
 //! chassis boot under the `aether.dag` namespace (ADR-0078
 //! chassis-internal actor). `init` caches the `Arc<Mailer>` + own
 //! mailbox id off the init ctx and builds the executor against them,
@@ -16,7 +17,9 @@
 //!
 //! Source / `Call` replies arrive as arbitrary kinds correlated by the
 //! dispatch's correlation id; the `#[fallback]` forwards them to the
-//! executor's [`Executor::on_reply`]. The hub chassis doesn't register
+//! executor's
+//! [`Executor::on_reply`](aether_substrate::dag::executor::Executor::on_reply).
+//! The hub chassis doesn't register
 //! this cap (ADR-0035 / ADR-0047 §8) — a `aether.dag.submit` to a hub
 //! substrate warn-drops as an unknown mailbox, the right shape for
 //! "DAG submission is not supported here".

--- a/crates/aether-capabilities/src/dag.rs
+++ b/crates/aether-capabilities/src/dag.rs
@@ -1,0 +1,235 @@
+//! `aether.dag` cap (ADR-0047 §4, iamacoffeepot/aether#976). Owns the
+//! substrate-side [`Executor`](aether_substrate::dag::executor::Executor)
+//! and routes the three request kinds (`aether.dag.{submit,cancel,
+//! status}`) plus the executor's two internal wake kinds — `Settled`
+//! (the per-`Call` settlement notice) and `DagReapTick` (the reaping
+//! timer) — into it.
+//!
+//! Same construction shape as `HandleCapability` and
+//! `RpcServerCapability`: a singleton [`NativeActor`] registered at
+//! chassis boot under the `aether.dag` namespace (ADR-0078
+//! chassis-internal actor). `init` caches the `Arc<Mailer>` + own
+//! mailbox id off the init ctx and builds the executor against them,
+//! then spawns a detached timer thread that fires `DagReapTick` every
+//! ~30s so the reaping sweep runs on this actor's own dispatcher
+//! thread (the executor's `DagState` map is lock-free actor state).
+//!
+//! Source / `Call` replies arrive as arbitrary kinds correlated by the
+//! dispatch's correlation id; the `#[fallback]` forwards them to the
+//! executor's [`Executor::on_reply`]. The hub chassis doesn't register
+//! this cap (ADR-0035 / ADR-0047 §8) — a `aether.dag.submit` to a hub
+//! substrate warn-drops as an unknown mailbox, the right shape for
+//! "DAG submission is not supported here".
+
+// `#[handler]` methods take their decoded payload by value per the
+// ADR-0033 dispatch ABI; the macro-generated trampoline owns the
+// decoded bytes so callers can't see references.
+#![allow(clippy::needless_pass_by_value)]
+
+// Handler-signature kinds must be importable at file root because
+// `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
+// of the mod (always-on, outside the cfg gate).
+use aether_kinds::{Cancel, DagReapTick, Status, Submit, trace::Settled};
+
+#[aether_actor::bridge(singleton)]
+mod native {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::thread;
+    use std::time::Duration;
+
+    use super::{Cancel, DagReapTick, Settled, Status, Submit};
+    use aether_actor::{MailCtx, actor};
+    use aether_data::{Kind, KindId, MailId, MailboxId};
+    use aether_kinds::{StatusResult, SubmitResult};
+    use aether_substrate::Mail;
+    use aether_substrate::actor::native::envelope::Envelope;
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+    use aether_substrate::dag::executor::{Executor, SubmitOutcome};
+    use aether_substrate::mail::mailer::Mailer;
+
+    /// Reaping cadence (ADR-0047 §7) — the timer thread fires a
+    /// `DagReapTick` at this interval so the executor sweeps terminal
+    /// DAGs + times out never-settling `Call`s.
+    const REAP_INTERVAL: Duration = Duration::from_secs(30);
+
+    /// `aether.dag` cap. Owns the per-substrate [`Executor`].
+    pub struct DagCapability {
+        executor: Executor,
+        /// Cached so `unwire` can stop the reaping timer thread.
+        reap_shutdown: Arc<AtomicBool>,
+    }
+
+    #[actor]
+    impl NativeActor for DagCapability {
+        type Config = ();
+        /// ADR-0047 §4 + ADR-0078: chassis-internal actor under the
+        /// `aether.<name>` namespace.
+        const NAMESPACE: &'static str = "aether.dag";
+
+        /// Build the executor against the substrate's shared `Mailer`
+        /// (which surfaces the routing registry, capability registry,
+        /// handle store, and settlement registry the executor needs)
+        /// and spawn the reaping timer.
+        fn init((): (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            let mailer: Arc<Mailer> = ctx.mailer();
+            let self_id: MailboxId = ctx.self_id();
+            let executor = Executor::new(Arc::clone(&mailer), self_id);
+
+            // Detached timer thread: fire a `DagReapTick` wake mail at
+            // the cap every `REAP_INTERVAL`. The mail wakes the
+            // single-threaded dispatcher, which runs the sweep on the
+            // executor's own thread.
+            let reap_shutdown = Arc::new(AtomicBool::new(false));
+            let reap_shutdown_for_thread = Arc::clone(&reap_shutdown);
+            let reap_kind = KindId(<DagReapTick as Kind>::ID.0);
+            let timer_mailer = Arc::clone(&mailer);
+            let spawned = thread::Builder::new()
+                .name("aether-dag-reaper".to_owned())
+                .spawn(move || {
+                    while !reap_shutdown_for_thread.load(Ordering::Acquire) {
+                        thread::sleep(REAP_INTERVAL);
+                        if reap_shutdown_for_thread.load(Ordering::Acquire) {
+                            break;
+                        }
+                        timer_mailer.push(Mail::new(self_id, reap_kind, Vec::new(), 1));
+                    }
+                });
+            if let Err(e) = spawned {
+                tracing::warn!(
+                    target: "aether_substrate::dag",
+                    error = %e,
+                    "failed to spawn DAG reaping timer thread; reaping disabled",
+                );
+            }
+
+            Ok(Self {
+                executor,
+                reap_shutdown,
+            })
+        }
+
+        fn unwire(&mut self, _ctx: &mut NativeCtx<'_>) {
+            self.reap_shutdown.store(true, Ordering::Release);
+        }
+
+        /// Submit a computation DAG for validation + execution. Validation
+        /// runs synchronously; the reply carries the structured
+        /// [`DagError`](aether_kinds::DagError) on failure or the minted
+        /// `DagId` + per-node output handles on success (ADR-0047 §1).
+        ///
+        /// # Agent
+        /// Reply: `SubmitResult`.
+        #[handler]
+        fn on_submit(&mut self, ctx: &mut NativeCtx<'_>, mail: Submit) {
+            let reply = match self.executor.submit(ctx, mail.descriptor) {
+                SubmitOutcome::Ok {
+                    dag_id,
+                    output_handles,
+                } => SubmitResult::Ok {
+                    dag_id,
+                    output_handles,
+                },
+                SubmitOutcome::Err { error } => SubmitResult::Err { error },
+            };
+            ctx.reply(&reply);
+        }
+
+        /// Cancel an in-flight DAG by its `DagId` (ADR-0047 §5).
+        ///
+        /// # Agent
+        /// Reply: `CancelResult`.
+        #[handler]
+        fn on_cancel(&mut self, ctx: &mut NativeCtx<'_>, mail: Cancel) {
+            let reply = self.executor.cancel(mail.dag_id);
+            ctx.reply(&reply);
+        }
+
+        /// Query a DAG's execution status (ADR-0047 §1/§6). An unknown
+        /// `DagId` (never submitted, or already reaped) reports as
+        /// `Failed { error: "unknown dag <id>" }` — the existing error
+        /// shape, no new wire variant.
+        ///
+        /// # Agent
+        /// Reply: `StatusResult`.
+        #[handler]
+        fn on_status(&mut self, ctx: &mut NativeCtx<'_>, mail: Status) {
+            let reply = self.executor.status(mail.dag_id).unwrap_or_else(|| {
+                StatusResult::Failed {
+                    node_id: aether_kinds::NodeId(0),
+                    error: format!("unknown dag {}", mail.dag_id),
+                }
+            });
+            ctx.reply(&reply);
+        }
+
+        /// Settlement notice for a `Call` dispatch (ADR-0047 §4 step 4).
+        /// Closes the call's bundle. Fires from the chassis settlement
+        /// registry, not from external mail.
+        ///
+        /// # Agent
+        /// Internal — not part of the cap's external surface.
+        #[handler]
+        fn on_settled(&mut self, ctx: &mut NativeCtx<'_>, mail: Settled) {
+            self.executor.on_settled(ctx, mail.root);
+        }
+
+        /// Reaping timer wake (ADR-0047 §7). Sweeps terminal DAGs past
+        /// retention + times out never-settling `Call`s. Fires from the
+        /// cap's own timer thread, not from external mail.
+        ///
+        /// # Agent
+        /// Internal — not part of the cap's external surface.
+        #[handler]
+        fn on_reap_tick(&mut self, _ctx: &mut NativeCtx<'_>, _mail: DagReapTick) {
+            let _ = self.executor.reap();
+        }
+
+        /// Catch-all reply interception. A source / `Call` reply lands
+        /// here as an arbitrary kind correlated by the dispatch's
+        /// correlation id; forward it to the executor. A reply with no
+        /// matching pending dispatch (a late reply for a cancelled /
+        /// completed DAG) is a silent no-op.
+        ///
+        /// # Agent
+        /// Not user-callable — the executor's reply-correlation path.
+        #[fallback]
+        fn on_reply(&mut self, ctx: &mut NativeCtx<'_>, env: &Envelope) {
+            let correlation = env.sender.correlation_id;
+            let matched = self
+                .executor
+                .on_reply(ctx, correlation, KindId(env.kind.0), &env.payload);
+            if !matched {
+                tracing::debug!(
+                    target: "aether_substrate::dag",
+                    kind = %env.kind_name,
+                    correlation,
+                    "dag reply with no matching pending dispatch; dropping",
+                );
+            }
+            let _ = MailId::NONE;
+        }
+    }
+}
+
+/// Address-resolution helper: the cap's mailbox id, derived from its
+/// `NAMESPACE` via the standard name-hash. Convenience for chassis code
+/// addressing the cap without a runtime lookup.
+#[must_use]
+pub fn dag_mailbox_id() -> aether_data::MailboxId {
+    use aether_actor::Actor;
+    aether_data::mailbox_id_from_name(<DagCapability as Actor>::NAMESPACE)
+}
+
+// Test-support kinds + actors for the DAG-executor scenario tests
+// (iamacoffeepot/aether#976). Defined at module root (not nested in
+// `mod tests`) so the `Kind` derive's inventory submission stays
+// addressable from a path the linker keeps — and so the derive
+// registers them in `aether_kinds::descriptors::all()` for the test
+// substrate's registry walk. Whole module is `#[cfg(test)]`.
+#[cfg(test)]
+mod test_support;
+
+#[cfg(test)]
+mod tests;

--- a/crates/aether-capabilities/src/dag/test_support.rs
+++ b/crates/aether-capabilities/src/dag/test_support.rs
@@ -1,0 +1,415 @@
+//! Test-support kinds + actors for the DAG-executor scenario tests
+//! (iamacoffeepot/aether#976). Mirrors `rpc::test_echo`: the kinds live
+//! at module root so the `Kind` derive's inventory submission registers
+//! them in `aether_kinds::descriptors::all()` for the test substrate's
+//! registry walk, and the actors are real `NativeActor`s booted through
+//! the same `Builder` the production caps use.
+//!
+//! - [`TestSourceActor`] answers a [`TestSourceRequest`] with a
+//!   [`TestReadResult`] (`Ok`/`Err`) — stands in for `aether.fs` /
+//!   any effectful source.
+//! - [`TestObserverActor`] / [`TestParallelObserverActor`] /
+//!   [`TestBundleObserverActor`] consume `Ref<...>` slots and record
+//!   the resolved values into a shared buffer the test asserts against.
+//! - [`TestCallActor`] is the mid-graph `Call` target: configurable to
+//!   reply once, N times, or never; the never-reply mode exercises the
+//!   per-`Call` settlement timeout.
+//! - [`TestDeferredCallActor`] answers off-thread through the
+//!   content-gen `InFlightDispatch` (spawn-and-die worker + settlement
+//!   hold), exercising the exact-settlement-through-the-hold path.
+
+use std::sync::{Arc, Mutex};
+
+use serde::{Deserialize, Serialize};
+
+use aether_data::Ref;
+use aether_kinds::Bundle;
+
+/// Source request — the DAG `Source` node's opaque payload. `fail`
+/// makes the source reply an `Err` variant (the
+/// `propagates_source_err` fixture).
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "aether.dag.test.source_request")]
+pub struct TestSourceRequest {
+    pub value: u64,
+    pub fail: bool,
+}
+
+/// Source reply kind — an `Ok`/`Err` enum so the
+/// `propagates_source_err` fixture can assert the `Err` variant
+/// resolves into the observer's `Ref<TestReadResult>` slot inline.
+#[derive(
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "aether.dag.test.read_result")]
+pub enum TestReadResult {
+    Ok { value: u64 },
+    Err { message: String },
+}
+
+/// Observer request — one `Ref<TestReadResult>` input slot.
+#[derive(
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "aether.dag.test.observed")]
+pub struct TestObserved {
+    pub input: Ref<TestReadResult>,
+}
+
+/// Two-slot observer request — for the parallel-sources fixture.
+#[derive(
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "aether.dag.test.observed2")]
+pub struct TestObserved2 {
+    pub a: Ref<TestReadResult>,
+    pub b: Ref<TestReadResult>,
+}
+
+/// Bundle-consuming observer request — for the `Call`-output fixtures.
+#[derive(
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "aether.dag.test.bundle_observed")]
+pub struct TestBundleObserved {
+    pub input: Ref<Bundle>,
+}
+
+/// `Call` request — the mid-graph effectful dispatch's payload. Like an
+/// observer it carries a `Ref<TestReadResult>` input slot fed by an
+/// upstream edge; the cap reads the resolved value to seed its replies.
+#[derive(
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "aether.dag.test.call_request")]
+pub struct TestCallRequest {
+    pub input: Ref<TestReadResult>,
+}
+
+/// Read the `value` out of a resolved [`TestReadResult`] ref slot, or
+/// `0` for an `Err` / unresolved slot. Used by the `Call` test caps to
+/// seed their replies from the upstream source.
+#[must_use]
+pub fn ref_value(input: &Ref<TestReadResult>) -> u64 {
+    match input {
+        Ref::Inline(TestReadResult::Ok { value }) => *value,
+        _ => 0,
+    }
+}
+
+/// `Call` reply — one element per emission.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "aether.dag.test.call_reply")]
+pub struct TestCallReply {
+    pub index: u64,
+}
+
+/// Shared recording buffer the observer caps push their resolved
+/// payloads into, so the test thread can assert what the observer saw.
+pub type Recorder<T> = Arc<Mutex<Vec<T>>>;
+
+/// Config for [`TestCallActor`]: how many correlated replies to emit
+/// before the handler returns (so the chain settles), or `never` to
+/// spin a worker thread that holds the chain open forever (the
+/// settlement-timeout fixture).
+#[derive(Clone)]
+pub struct TestCallConfig {
+    pub replies: u64,
+    pub never: bool,
+}
+
+#[aether_actor::bridge(singleton)]
+mod test_source {
+    use super::{TestReadResult, TestSourceRequest};
+    use aether_actor::{MailCtx, actor};
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+
+    pub struct TestSourceActor;
+
+    #[actor]
+    impl NativeActor for TestSourceActor {
+        type Config = ();
+        const NAMESPACE: &'static str = "aether.dag.test.source";
+
+        fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            Ok(Self)
+        }
+
+        #[allow(clippy::unused_self, clippy::needless_pass_by_value)]
+        #[handler]
+        fn on_source(&mut self, ctx: &mut NativeCtx<'_>, mail: TestSourceRequest) {
+            let reply = if mail.fail {
+                TestReadResult::Err {
+                    message: format!("source {} failed", mail.value),
+                }
+            } else {
+                TestReadResult::Ok { value: mail.value }
+            };
+            ctx.reply(&reply);
+        }
+    }
+}
+
+#[aether_actor::bridge(singleton)]
+mod test_observer {
+    use super::{Recorder, TestObserved};
+    use aether_actor::actor;
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+
+    pub struct TestObserverActor {
+        recorder: Recorder<TestObserved>,
+    }
+
+    #[actor]
+    impl NativeActor for TestObserverActor {
+        type Config = Recorder<TestObserved>;
+        const NAMESPACE: &'static str = "aether.dag.test.observer";
+
+        fn init(
+            recorder: Recorder<TestObserved>,
+            _ctx: &mut NativeInitCtx<'_>,
+        ) -> Result<Self, BootError> {
+            Ok(Self { recorder })
+        }
+
+        #[allow(clippy::needless_pass_by_value)]
+        #[handler]
+        fn on_observed(&mut self, _ctx: &mut NativeCtx<'_>, mail: TestObserved) {
+            self.recorder
+                .lock()
+                .expect("recorder mutex poisoned")
+                .push(mail);
+        }
+    }
+}
+
+#[aether_actor::bridge(singleton)]
+mod test_parallel_observer {
+    use super::{Recorder, TestObserved2};
+    use aether_actor::actor;
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+
+    pub struct TestParallelObserverActor {
+        recorder: Recorder<TestObserved2>,
+    }
+
+    #[actor]
+    impl NativeActor for TestParallelObserverActor {
+        type Config = Recorder<TestObserved2>;
+        const NAMESPACE: &'static str = "aether.dag.test.parallel_observer";
+
+        fn init(
+            recorder: Recorder<TestObserved2>,
+            _ctx: &mut NativeInitCtx<'_>,
+        ) -> Result<Self, BootError> {
+            Ok(Self { recorder })
+        }
+
+        #[allow(clippy::needless_pass_by_value)]
+        #[handler]
+        fn on_observed2(&mut self, _ctx: &mut NativeCtx<'_>, mail: TestObserved2) {
+            self.recorder
+                .lock()
+                .expect("recorder mutex poisoned")
+                .push(mail);
+        }
+    }
+}
+
+#[aether_actor::bridge(singleton)]
+mod test_bundle_observer {
+    use super::{Recorder, TestBundleObserved};
+    use aether_actor::actor;
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+
+    pub struct TestBundleObserverActor {
+        recorder: Recorder<TestBundleObserved>,
+    }
+
+    #[actor]
+    impl NativeActor for TestBundleObserverActor {
+        type Config = Recorder<TestBundleObserved>;
+        const NAMESPACE: &'static str = "aether.dag.test.bundle_observer";
+
+        fn init(
+            recorder: Recorder<TestBundleObserved>,
+            _ctx: &mut NativeInitCtx<'_>,
+        ) -> Result<Self, BootError> {
+            Ok(Self { recorder })
+        }
+
+        #[allow(clippy::needless_pass_by_value)]
+        #[handler]
+        fn on_bundle_observed(&mut self, _ctx: &mut NativeCtx<'_>, mail: TestBundleObserved) {
+            self.recorder
+                .lock()
+                .expect("recorder mutex poisoned")
+                .push(mail);
+        }
+    }
+}
+
+#[aether_actor::bridge(singleton)]
+mod test_call {
+    use super::{TestCallConfig, TestCallReply, TestCallRequest};
+    use aether_actor::{MailCtx, actor};
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+    use aether_substrate::runtime::trace::SettlementHold;
+
+    /// Mid-graph `Call` target. Synchronous-reply mode: emit `replies`
+    /// correlated [`TestCallReply`]s in the handler (so all `Sent`
+    /// events precede the handler's `Finished`, and the call's chain
+    /// settles when the handler returns). `never` mode acquires a
+    /// [`SettlementHold`] on `call_root` and never releases it (stashed
+    /// in actor state), so the chain genuinely never reaches
+    /// `(in_flight == 0 && held_open == 0)` and `Settled` never fires —
+    /// the per-`Call` timeout fixture pairs it with a tiny timeout to
+    /// assert node failure (a never-settling producer is a node failure,
+    /// not a partial bundle).
+    pub struct TestCallActor {
+        config: TestCallConfig,
+        /// Held-forever guards for `never` mode — never dropped, so the
+        /// chain never settles. Lives in single-threaded actor state.
+        held: Vec<SettlementHold>,
+    }
+
+    #[actor]
+    impl NativeActor for TestCallActor {
+        type Config = TestCallConfig;
+        const NAMESPACE: &'static str = "aether.dag.test.call";
+
+        fn init(config: TestCallConfig, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            Ok(Self {
+                config,
+                held: Vec::new(),
+            })
+        }
+
+        #[allow(clippy::needless_pass_by_value)]
+        #[handler]
+        fn on_call(&mut self, ctx: &mut NativeCtx<'_>, mail: TestCallRequest) {
+            let _ = &mail.input;
+            if self.config.never {
+                // Acquire a hold on the call's chain root and never
+                // release it: the chain never settles, so `Settled`
+                // never fires and only the per-`Call` timeout can close
+                // the node (as a failure). Acquired before the handler
+                // returns so `HoldOpen` precedes `Finished`.
+                let hold = ctx
+                    .mailer()
+                    .acquire_settlement_hold(ctx.in_flight_root());
+                self.held.push(hold);
+                return;
+            }
+            for index in 0..self.config.replies {
+                ctx.reply(&TestCallReply { index });
+            }
+        }
+    }
+}
+
+#[aether_actor::bridge(singleton)]
+mod test_deferred_call {
+    use super::{TestCallReply, TestCallRequest, ref_value};
+    use crate::contentgen::dispatch::{BlockingCall, InFlightDispatch};
+    use aether_actor::{actor, actor::ctx::OutboundReply};
+    use aether_data::{Kind, KindId, MailboxId, ReplyTo};
+    use aether_substrate::Mailer;
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::Duration;
+
+    /// `Call` target that answers off-thread through the content-gen
+    /// [`InFlightDispatch`] — spawn-and-die worker + a [`SettlementHold`]
+    /// that keeps `call_root` open across the async reply
+    /// (iamacoffeepot/aether#1031). Exercises that the executor's bundle
+    /// stays open until the worker's deferred reply lands.
+    pub struct TestDeferredCallActor {
+        dispatch: InFlightDispatch,
+        mailer: Arc<Mailer>,
+        self_mailbox: MailboxId,
+    }
+
+    #[actor]
+    impl NativeActor for TestDeferredCallActor {
+        type Config = ();
+        const NAMESPACE: &'static str = "aether.dag.test.deferred_call";
+
+        fn init((): (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            Ok(Self {
+                dispatch: InFlightDispatch::new(4),
+                mailer: ctx.mailer(),
+                self_mailbox: ctx.self_id(),
+            })
+        }
+
+        #[allow(clippy::needless_pass_by_value)]
+        #[handler]
+        fn on_call(&mut self, ctx: &mut NativeCtx<'_>, mail: TestCallRequest) {
+            let value = ref_value(&mail.input);
+            let request_id = value;
+            let reply_to = OutboundReply::reply_target(ctx).unwrap_or(ReplyTo::NONE);
+            let root = ctx.in_flight_root();
+            let call: BlockingCall = Box::new(move || {
+                thread::sleep(Duration::from_millis(50));
+                let reply = TestCallReply { index: value };
+                (
+                    KindId(<TestCallReply as Kind>::ID.0),
+                    reply.encode_into_bytes(),
+                )
+            });
+            self.dispatch.submit(
+                &self.mailer,
+                self.self_mailbox,
+                root,
+                request_id,
+                reply_to,
+                call,
+            );
+        }
+
+        #[allow(clippy::needless_pass_by_value)]
+        #[handler]
+        fn on_result(&mut self, ctx: &mut NativeCtx<'_>, mail: TestCallReply) {
+            if let Some(landed) = self.dispatch.take_landed(mail.index) {
+                OutboundReply::reply_to(ctx, landed.reply_to, &mail);
+                drop(landed);
+            }
+            let _ = self
+                .dispatch
+                .on_reply_landed(&self.mailer, self.self_mailbox);
+        }
+    }
+}
+
+// The actor structs are re-exported at this module's root by the
+// `#[bridge]` macro itself — no explicit `pub use` needed.

--- a/crates/aether-capabilities/src/dag/test_support.rs
+++ b/crates/aether-capabilities/src/dag/test_support.rs
@@ -322,9 +322,7 @@ mod test_call {
                 // never fires and only the per-`Call` timeout can close
                 // the node (as a failure). Acquired before the handler
                 // returns so `HoldOpen` precedes `Finished`.
-                let hold = ctx
-                    .mailer()
-                    .acquire_settlement_hold(ctx.in_flight_root());
+                let hold = ctx.mailer().acquire_settlement_hold(ctx.in_flight_root());
                 self.held.push(hold);
                 return;
             }

--- a/crates/aether-capabilities/src/dag/tests.rs
+++ b/crates/aether-capabilities/src/dag/tests.rs
@@ -24,13 +24,13 @@ use std::time::{Duration, Instant};
 use std::{env, thread};
 
 use aether_actor::Actor;
-use serde::de::DeserializeOwned;
 use aether_data::{DagId, Kind, KindId, MailId, MailboxId, SessionToken, Uuid};
 use aether_kinds::descriptors;
 use aether_kinds::{
     Bundle, Cancel, CancelResult, DagDescriptor, DagReapTick, Edge, Node, NodeId, Status,
     StatusResult, Submit, SubmitResult,
 };
+use serde::de::DeserializeOwned;
 
 use aether_substrate::chassis::builder::Builder;
 use aether_substrate::handle_store::HandleStore;
@@ -52,8 +52,7 @@ use crate::trace::TraceObserverCapability;
 /// mailer wired to a drainable loopback egress). Like the crate's
 /// `fresh_substrate` but exposes the egress receiver so a test can read
 /// the `SubmitResult` / `CancelResult` / `StatusResult` reply.
-fn fresh_substrate_with_rx()
--> (Arc<Registry>, Arc<Mailer>, Receiver<EgressEvent>) {
+fn fresh_substrate_with_rx() -> (Arc<Registry>, Arc<Mailer>, Receiver<EgressEvent>) {
     let registry = Arc::new(Registry::new());
     for d in descriptors::all() {
         let _ = registry.register_kind_with_descriptor(d);
@@ -150,7 +149,12 @@ fn submit_ok(
     descriptor: DagDescriptor,
     corr: u64,
 ) -> DagId {
-    enqueue(registry, dag_mailbox(), &Submit { descriptor }, session(corr));
+    enqueue(
+        registry,
+        dag_mailbox(),
+        &Submit { descriptor },
+        session(corr),
+    );
     match await_session_reply::<SubmitResult>(rx, Duration::from_secs(5)) {
         SubmitResult::Ok { dag_id, .. } => dag_id,
         SubmitResult::Err { error } => panic!("submit failed: {error:?}"),
@@ -211,7 +215,12 @@ fn dag_executor_runs_two_node_dag() {
     let descriptor = DagDescriptor {
         version: 1,
         nodes: vec![
-            source_node(0, mbx::<TestSourceActor>(), source_kind(), source_req(42, false)),
+            source_node(
+                0,
+                mbx::<TestSourceActor>(),
+                source_kind(),
+                source_req(42, false),
+            ),
             Node::Observer {
                 id: NodeId(1),
                 recipient: mbx::<TestObserverActor>(),
@@ -266,7 +275,12 @@ fn dag_executor_parks_observer_until_source_resolves() {
     let descriptor = DagDescriptor {
         version: 1,
         nodes: vec![
-            source_node(0, mbx::<TestSourceActor>(), source_kind(), source_req(7, false)),
+            source_node(
+                0,
+                mbx::<TestSourceActor>(),
+                source_kind(),
+                source_req(7, false),
+            ),
             Node::Observer {
                 id: NodeId(1),
                 recipient: mbx::<TestObserverActor>(),
@@ -320,8 +334,18 @@ fn dag_executor_runs_parallel_sources() {
     let descriptor = DagDescriptor {
         version: 1,
         nodes: vec![
-            source_node(0, mbx::<TestSourceActor>(), source_kind(), source_req(10, false)),
-            source_node(1, mbx::<TestSourceActor>(), source_kind(), source_req(20, false)),
+            source_node(
+                0,
+                mbx::<TestSourceActor>(),
+                source_kind(),
+                source_req(10, false),
+            ),
+            source_node(
+                1,
+                mbx::<TestSourceActor>(),
+                source_kind(),
+                source_req(20, false),
+            ),
             Node::Observer {
                 id: NodeId(2),
                 recipient: mbx::<TestParallelObserverActor>(),
@@ -381,7 +405,12 @@ fn dag_executor_propagates_source_err_as_observer_input() {
     let descriptor = DagDescriptor {
         version: 1,
         nodes: vec![
-            source_node(0, mbx::<TestSourceActor>(), source_kind(), source_req(9, true)),
+            source_node(
+                0,
+                mbx::<TestSourceActor>(),
+                source_kind(),
+                source_req(9, true),
+            ),
             Node::Observer {
                 id: NodeId(1),
                 recipient: mbx::<TestObserverActor>(),
@@ -432,7 +461,12 @@ fn dag_executor_cancels_running_dag() {
     let descriptor = DagDescriptor {
         version: 1,
         nodes: vec![
-            source_node(0, mbx::<TestSourceActor>(), source_kind(), source_req(1, false)),
+            source_node(
+                0,
+                mbx::<TestSourceActor>(),
+                source_kind(),
+                source_req(1, false),
+            ),
             Node::Observer {
                 id: NodeId(1),
                 recipient: mbx::<TestObserverActor>(),
@@ -487,7 +521,12 @@ fn dag_executor_status_reports_running() {
     let descriptor = DagDescriptor {
         version: 1,
         nodes: vec![
-            source_node(0, mbx::<TestSourceActor>(), source_kind(), source_req(5, false)),
+            source_node(
+                0,
+                mbx::<TestSourceActor>(),
+                source_kind(),
+                source_req(5, false),
+            ),
             Node::Observer {
                 id: NodeId(1),
                 recipient: mbx::<TestObserverActor>(),
@@ -546,7 +585,12 @@ fn dag_executor_status_reports_complete_then_reaps() {
     let descriptor = DagDescriptor {
         version: 1,
         nodes: vec![
-            source_node(0, mbx::<TestSourceActor>(), source_kind(), source_req(3, false)),
+            source_node(
+                0,
+                mbx::<TestSourceActor>(),
+                source_kind(),
+                source_req(3, false),
+            ),
             Node::Observer {
                 id: NodeId(1),
                 recipient: mbx::<TestObserverActor>(),
@@ -751,15 +795,16 @@ fn dag_executor_call_dispatches_as_own_root() {
 
 /// Build + submit a source → Call → bundle-observer DAG with the Call
 /// addressed at `call_mbx`, and return the `DagId`.
-fn submit_call_dag(
-    registry: &Registry,
-    rx: &Receiver<EgressEvent>,
-    call_mbx: MailboxId,
-) -> DagId {
+fn submit_call_dag(registry: &Registry, rx: &Receiver<EgressEvent>, call_mbx: MailboxId) -> DagId {
     let descriptor = DagDescriptor {
         version: 1,
         nodes: vec![
-            source_node(0, mbx::<TestSourceActor>(), source_kind(), source_req(1, false)),
+            source_node(
+                0,
+                mbx::<TestSourceActor>(),
+                source_kind(),
+                source_req(1, false),
+            ),
             Node::Call {
                 id: NodeId(1),
                 recipient: call_mbx,

--- a/crates/aether-capabilities/src/dag/tests.rs
+++ b/crates/aether-capabilities/src/dag/tests.rs
@@ -32,7 +32,7 @@ use aether_kinds::{
 };
 use serde::de::DeserializeOwned;
 
-use aether_substrate::chassis::builder::Builder;
+use aether_substrate::chassis::builder::{Builder, PassiveChassis};
 use aether_substrate::handle_store::HandleStore;
 use aether_substrate::mail::mailer::Mailer;
 use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
@@ -75,6 +75,23 @@ fn base_builder(registry: &Arc<Registry>, mailer: &Arc<Mailer>) -> Builder<TestC
         .with_actor::<crate::HandleCapability>(())
         .with_actor::<DagCapability>(())
         .with_actor::<TestSourceActor>(())
+}
+
+/// Boot a `Call`-fixture chassis: the base caps plus a `TestCallActor`
+/// (configured by `config`) and a `TestBundleObserverActor` recording
+/// into `recorder`. Shared by the source → `Call` → bundle-observer
+/// fixtures so each only declares the call config it varies.
+fn boot_call_fixture(
+    registry: &Arc<Registry>,
+    mailer: &Arc<Mailer>,
+    config: TestCallConfig,
+    recorder: &Recorder<super::test_support::TestBundleObserved>,
+) -> PassiveChassis<TestChassis> {
+    base_builder(registry, mailer)
+        .with_actor::<TestCallActor>(config)
+        .with_actor::<TestBundleObserverActor>(Arc::clone(recorder))
+        .build_passive()
+        .expect("caps boot")
 }
 
 /// A distinct session reply target per `corr` so multiple in-flight
@@ -623,14 +640,15 @@ fn dag_executor_status_reports_complete_then_reaps() {
 fn dag_executor_call_collects_single_reply_bundle() {
     let (registry, mailer, rx) = fresh_substrate_with_rx();
     let recorder = Arc::new(Mutex::new(Vec::new()));
-    let chassis = base_builder(&registry, &mailer)
-        .with_actor::<TestCallActor>(TestCallConfig {
+    let chassis = boot_call_fixture(
+        &registry,
+        &mailer,
+        TestCallConfig {
             replies: 1,
             never: false,
-        })
-        .with_actor::<TestBundleObserverActor>(Arc::clone(&recorder))
-        .build_passive()
-        .expect("caps boot");
+        },
+        &recorder,
+    );
 
     let bundle = run_call_dag_to(&registry, &rx, &recorder, mbx::<TestCallActor>());
     assert_eq!(bundle.elements.len(), 1);
@@ -645,14 +663,15 @@ fn dag_executor_call_collects_single_reply_bundle() {
 fn dag_executor_call_collects_multi_reply_bundle() {
     let (registry, mailer, rx) = fresh_substrate_with_rx();
     let recorder = Arc::new(Mutex::new(Vec::new()));
-    let chassis = base_builder(&registry, &mailer)
-        .with_actor::<TestCallActor>(TestCallConfig {
+    let chassis = boot_call_fixture(
+        &registry,
+        &mailer,
+        TestCallConfig {
             replies: 3,
             never: false,
-        })
-        .with_actor::<TestBundleObserverActor>(Arc::clone(&recorder))
-        .build_passive()
-        .expect("caps boot");
+        },
+        &recorder,
+    );
 
     let bundle = run_call_dag_to(&registry, &rx, &recorder, mbx::<TestCallActor>());
     assert_eq!(bundle.elements.len(), 3);
@@ -701,14 +720,15 @@ fn dag_executor_call_times_out_nonsettling_cap() {
     }
     let (registry, mailer, rx) = fresh_substrate_with_rx();
     let recorder = Arc::new(Mutex::new(Vec::new()));
-    let chassis = base_builder(&registry, &mailer)
-        .with_actor::<TestCallActor>(TestCallConfig {
+    let chassis = boot_call_fixture(
+        &registry,
+        &mailer,
+        TestCallConfig {
             replies: 0,
             never: true,
-        })
-        .with_actor::<TestBundleObserverActor>(Arc::clone(&recorder))
-        .build_passive()
-        .expect("caps boot");
+        },
+        &recorder,
+    );
 
     let dag_id = submit_call_dag(&registry, &rx, mbx::<TestCallActor>());
 
@@ -740,14 +760,15 @@ fn dag_executor_call_times_out_nonsettling_cap() {
 fn dag_executor_call_dispatches_as_own_root() {
     let (registry, mailer, rx) = fresh_substrate_with_rx();
     let recorder = Arc::new(Mutex::new(Vec::new()));
-    let chassis = base_builder(&registry, &mailer)
-        .with_actor::<TestCallActor>(TestCallConfig {
+    let chassis = boot_call_fixture(
+        &registry,
+        &mailer,
+        TestCallConfig {
             replies: 1,
             never: false,
-        })
-        .with_actor::<TestBundleObserverActor>(Arc::clone(&recorder))
-        .build_passive()
-        .expect("caps boot");
+        },
+        &recorder,
+    );
 
     let bundle = run_call_dag_to(&registry, &rx, &recorder, mbx::<TestCallActor>());
     assert_eq!(

--- a/crates/aether-capabilities/src/dag/tests.rs
+++ b/crates/aether-capabilities/src/dag/tests.rs
@@ -63,6 +63,20 @@ fn fresh_substrate_with_rx() -> (Arc<Registry>, Arc<Mailer>, Receiver<EgressEven
     (registry, mailer, rx)
 }
 
+/// A `Builder` carrying the base every DAG fixture shares —
+/// `TraceObserverCapability` (fires `Settled` so `Call` settlement
+/// subscriptions wake), `HandleCapability` (the store the executor
+/// resolves into), `DagCapability` (the executor under test), and
+/// `TestSourceActor` (the universal source). Each fixture chains its
+/// specific observer / call cap before `build_passive`.
+fn base_builder(registry: &Arc<Registry>, mailer: &Arc<Mailer>) -> Builder<TestChassis> {
+    Builder::<TestChassis>::new(Arc::clone(registry), Arc::clone(mailer))
+        .with_actor::<TraceObserverCapability>(())
+        .with_actor::<crate::HandleCapability>(())
+        .with_actor::<DagCapability>(())
+        .with_actor::<TestSourceActor>(())
+}
+
 /// A distinct session reply target per `corr` so multiple in-flight
 /// requests don't collide.
 fn session(corr: u64) -> ReplyTo {
@@ -203,11 +217,7 @@ fn source_kind() -> KindId {
 fn dag_executor_runs_two_node_dag() {
     let (registry, mailer, rx) = fresh_substrate_with_rx();
     let recorder: Recorder<TestObserved> = Arc::new(Mutex::new(Vec::new()));
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<TraceObserverCapability>(())
-        .with_actor::<crate::HandleCapability>(())
-        .with_actor::<DagCapability>(())
-        .with_actor::<TestSourceActor>(())
+    let chassis = base_builder(&registry, &mailer)
         .with_actor::<TestObserverActor>(Arc::clone(&recorder))
         .build_passive()
         .expect("caps boot");
@@ -263,12 +273,8 @@ fn dag_executor_parks_observer_until_source_resolves() {
     let (registry, mailer, rx) = fresh_substrate_with_rx();
     let recorder: Recorder<TestObserved> = Arc::new(Mutex::new(Vec::new()));
     let store = Arc::clone(mailer.handle_store());
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<TraceObserverCapability>(())
-        .with_actor::<crate::HandleCapability>(())
-        .with_actor::<DagCapability>(())
+    let chassis = base_builder(&registry, &mailer)
         .with_actor::<TestObserverActor>(Arc::clone(&recorder))
-        .with_actor::<TestSourceActor>(())
         .build_passive()
         .expect("caps boot");
 
@@ -322,11 +328,7 @@ fn dag_executor_parks_observer_until_source_resolves() {
 fn dag_executor_runs_parallel_sources() {
     let (registry, mailer, rx) = fresh_substrate_with_rx();
     let recorder: Recorder<TestObserved2> = Arc::new(Mutex::new(Vec::new()));
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<TraceObserverCapability>(())
-        .with_actor::<crate::HandleCapability>(())
-        .with_actor::<DagCapability>(())
-        .with_actor::<TestSourceActor>(())
+    let chassis = base_builder(&registry, &mailer)
         .with_actor::<TestParallelObserverActor>(Arc::clone(&recorder))
         .build_passive()
         .expect("caps boot");
@@ -393,11 +395,7 @@ fn dag_executor_runs_parallel_sources() {
 fn dag_executor_propagates_source_err_as_observer_input() {
     let (registry, mailer, rx) = fresh_substrate_with_rx();
     let recorder: Recorder<TestObserved> = Arc::new(Mutex::new(Vec::new()));
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<TraceObserverCapability>(())
-        .with_actor::<crate::HandleCapability>(())
-        .with_actor::<DagCapability>(())
-        .with_actor::<TestSourceActor>(())
+    let chassis = base_builder(&registry, &mailer)
         .with_actor::<TestObserverActor>(Arc::clone(&recorder))
         .build_passive()
         .expect("caps boot");
@@ -449,12 +447,8 @@ fn dag_executor_propagates_source_err_as_observer_input() {
 fn dag_executor_cancels_running_dag() {
     let (registry, mailer, rx) = fresh_substrate_with_rx();
     let recorder: Recorder<TestObserved> = Arc::new(Mutex::new(Vec::new()));
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<TraceObserverCapability>(())
-        .with_actor::<crate::HandleCapability>(())
-        .with_actor::<DagCapability>(())
+    let chassis = base_builder(&registry, &mailer)
         .with_actor::<TestObserverActor>(Arc::clone(&recorder))
-        .with_actor::<TestSourceActor>(())
         .build_passive()
         .expect("caps boot");
 
@@ -509,11 +503,7 @@ fn dag_executor_cancels_running_dag() {
 fn dag_executor_status_reports_running() {
     let (registry, mailer, rx) = fresh_substrate_with_rx();
     let recorder: Recorder<TestObserved> = Arc::new(Mutex::new(Vec::new()));
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<TraceObserverCapability>(())
-        .with_actor::<crate::HandleCapability>(())
-        .with_actor::<DagCapability>(())
-        .with_actor::<TestSourceActor>(())
+    let chassis = base_builder(&registry, &mailer)
         .with_actor::<TestObserverActor>(Arc::clone(&recorder))
         .build_passive()
         .expect("caps boot");
@@ -573,11 +563,7 @@ fn dag_executor_status_reports_complete_then_reaps() {
     }
     let (registry, mailer, rx) = fresh_substrate_with_rx();
     let recorder: Recorder<TestObserved> = Arc::new(Mutex::new(Vec::new()));
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<TraceObserverCapability>(())
-        .with_actor::<crate::HandleCapability>(())
-        .with_actor::<DagCapability>(())
-        .with_actor::<TestSourceActor>(())
+    let chassis = base_builder(&registry, &mailer)
         .with_actor::<TestObserverActor>(Arc::clone(&recorder))
         .build_passive()
         .expect("caps boot");
@@ -637,11 +623,7 @@ fn dag_executor_status_reports_complete_then_reaps() {
 fn dag_executor_call_collects_single_reply_bundle() {
     let (registry, mailer, rx) = fresh_substrate_with_rx();
     let recorder = Arc::new(Mutex::new(Vec::new()));
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<TraceObserverCapability>(())
-        .with_actor::<crate::HandleCapability>(())
-        .with_actor::<DagCapability>(())
-        .with_actor::<TestSourceActor>(())
+    let chassis = base_builder(&registry, &mailer)
         .with_actor::<TestCallActor>(TestCallConfig {
             replies: 1,
             never: false,
@@ -663,11 +645,7 @@ fn dag_executor_call_collects_single_reply_bundle() {
 fn dag_executor_call_collects_multi_reply_bundle() {
     let (registry, mailer, rx) = fresh_substrate_with_rx();
     let recorder = Arc::new(Mutex::new(Vec::new()));
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<TraceObserverCapability>(())
-        .with_actor::<crate::HandleCapability>(())
-        .with_actor::<DagCapability>(())
-        .with_actor::<TestSourceActor>(())
+    let chassis = base_builder(&registry, &mailer)
         .with_actor::<TestCallActor>(TestCallConfig {
             replies: 3,
             never: false,
@@ -694,11 +672,7 @@ fn dag_executor_call_collects_multi_reply_bundle() {
 fn dag_executor_call_inherited_worker_counts_toward_settlement() {
     let (registry, mailer, rx) = fresh_substrate_with_rx();
     let recorder = Arc::new(Mutex::new(Vec::new()));
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<TraceObserverCapability>(())
-        .with_actor::<crate::HandleCapability>(())
-        .with_actor::<DagCapability>(())
-        .with_actor::<TestSourceActor>(())
+    let chassis = base_builder(&registry, &mailer)
         .with_actor::<TestDeferredCallActor>(())
         .with_actor::<TestBundleObserverActor>(Arc::clone(&recorder))
         .build_passive()
@@ -727,11 +701,7 @@ fn dag_executor_call_times_out_nonsettling_cap() {
     }
     let (registry, mailer, rx) = fresh_substrate_with_rx();
     let recorder = Arc::new(Mutex::new(Vec::new()));
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<TraceObserverCapability>(())
-        .with_actor::<crate::HandleCapability>(())
-        .with_actor::<DagCapability>(())
-        .with_actor::<TestSourceActor>(())
+    let chassis = base_builder(&registry, &mailer)
         .with_actor::<TestCallActor>(TestCallConfig {
             replies: 0,
             never: true,
@@ -770,11 +740,7 @@ fn dag_executor_call_times_out_nonsettling_cap() {
 fn dag_executor_call_dispatches_as_own_root() {
     let (registry, mailer, rx) = fresh_substrate_with_rx();
     let recorder = Arc::new(Mutex::new(Vec::new()));
-    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<TraceObserverCapability>(())
-        .with_actor::<crate::HandleCapability>(())
-        .with_actor::<DagCapability>(())
-        .with_actor::<TestSourceActor>(())
+    let chassis = base_builder(&registry, &mailer)
         .with_actor::<TestCallActor>(TestCallConfig {
             replies: 1,
             never: false,

--- a/crates/aether-capabilities/src/dag/tests.rs
+++ b/crates/aether-capabilities/src/dag/tests.rs
@@ -1,0 +1,812 @@
+//! DAG-executor scenario tests (iamacoffeepot/aether#976).
+//!
+//! Each fixture boots a real chassis (`TraceObserverCapability` +
+//! `HandleCapability` + `DagCapability` + the relevant test caps from
+//! [`super::test_support`]) through the same `Builder` the production
+//! chassis uses, enqueues an `aether.dag.submit` at the dag cap's
+//! mailbox with a session reply target, drains the substrate's egress
+//! for the `SubmitResult`, then drives the DAG through the live actor
+//! dispatch + parking + settlement path and asserts on the observer's
+//! recorded payloads / the DAG's `status`.
+//!
+//! `TraceObserverCapability` is load-bearing for every `Call` fixture:
+//! it folds substrate-wide trace events into per-root counters and
+//! fires `Settled { root }` mail once a root drains — without it the
+//! executor's per-`Call` settlement subscription never wakes and the
+//! bundle never closes (same dependency the RPC server's `Call` tests
+//! carry).
+
+#![allow(clippy::unwrap_used)]
+
+use std::sync::mpsc::Receiver;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use std::{env, thread};
+
+use aether_actor::Actor;
+use serde::de::DeserializeOwned;
+use aether_data::{DagId, Kind, KindId, MailId, MailboxId, SessionToken, Uuid};
+use aether_kinds::descriptors;
+use aether_kinds::{
+    Bundle, Cancel, CancelResult, DagDescriptor, DagReapTick, Edge, Node, NodeId, Status,
+    StatusResult, Submit, SubmitResult,
+};
+
+use aether_substrate::chassis::builder::Builder;
+use aether_substrate::handle_store::HandleStore;
+use aether_substrate::mail::mailer::Mailer;
+use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
+use aether_substrate::mail::registry::{MailboxEntry, OwnedDispatch, Registry};
+use aether_substrate::mail::{ReplyTarget, ReplyTo};
+
+use super::DagCapability;
+use super::test_support::{
+    Recorder, TestBundleObserverActor, TestCallActor, TestCallConfig, TestCallReply,
+    TestDeferredCallActor, TestObserved, TestObserved2, TestObserverActor,
+    TestParallelObserverActor, TestReadResult, TestSourceActor,
+};
+use crate::test_chassis::TestChassis;
+use crate::trace::TraceObserverCapability;
+
+/// Build a substrate seed (registry pre-loaded with `descriptors::all()`,
+/// mailer wired to a drainable loopback egress). Like the crate's
+/// `fresh_substrate` but exposes the egress receiver so a test can read
+/// the `SubmitResult` / `CancelResult` / `StatusResult` reply.
+fn fresh_substrate_with_rx()
+-> (Arc<Registry>, Arc<Mailer>, Receiver<EgressEvent>) {
+    let registry = Arc::new(Registry::new());
+    for d in descriptors::all() {
+        let _ = registry.register_kind_with_descriptor(d);
+    }
+    let (outbound, rx) = HubOutbound::attached_loopback();
+    let store = Arc::new(HandleStore::new(1024 * 1024));
+    let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
+    (registry, mailer, rx)
+}
+
+/// A distinct session reply target per `corr` so multiple in-flight
+/// requests don't collide.
+fn session(corr: u64) -> ReplyTo {
+    ReplyTo::with_correlation(
+        ReplyTarget::Session(SessionToken(Uuid::from_u128(u128::from(corr)))),
+        corr,
+    )
+}
+
+/// Enqueue an already-encoded request kind at `mailbox_name` with a
+/// session reply target. Drives the request through the cap's live
+/// dispatcher thread.
+fn enqueue<K: Kind + serde::Serialize>(
+    registry: &Registry,
+    mailbox_name: &str,
+    payload: &K,
+    sender: ReplyTo,
+) {
+    let id = registry.lookup(mailbox_name).expect("mailbox registered");
+    let MailboxEntry::Inbox(handler) = registry.entry(id).expect("entry") else {
+        panic!("expected inbox mailbox for {mailbox_name}");
+    };
+    let bytes = postcard::to_allocvec(payload).expect("encode request");
+    handler.enqueue(OwnedDispatch {
+        kind: K::ID,
+        kind_name: K::NAME.to_owned(),
+        origin: None,
+        sender,
+        payload: bytes,
+        count: 1,
+        mail_id: MailId::NONE,
+        root: MailId::NONE,
+        parent_mail: None,
+    });
+}
+
+/// Drain egress until a `ToSession` reply of kind `K` arrives, decoding
+/// it via postcard. Panics on timeout.
+fn await_session_reply<K: Kind + DeserializeOwned>(
+    rx: &Receiver<EgressEvent>,
+    timeout: Duration,
+) -> K {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let event = rx
+            .recv_timeout(remaining)
+            .unwrap_or_else(|_| panic!("no {} reply within deadline", K::NAME));
+        if let EgressEvent::ToSession {
+            kind_name, payload, ..
+        } = event
+            && kind_name == K::NAME
+        {
+            return postcard::from_bytes(&payload).expect("decode session reply");
+        }
+    }
+}
+
+/// The dag cap's mailbox name.
+fn dag_mailbox() -> &'static str {
+    <DagCapability as Actor>::NAMESPACE
+}
+
+/// Poll `f` until it returns `true` or the deadline passes; returns the
+/// final value of `f`.
+fn poll_until(timeout: Duration, mut f: impl FnMut() -> bool) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if f() {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return f();
+        }
+        thread::sleep(Duration::from_millis(5));
+    }
+}
+
+/// Submit `descriptor` through the dag cap and return the minted
+/// `DagId` (asserting the submit succeeded).
+fn submit_ok(
+    registry: &Registry,
+    rx: &Receiver<EgressEvent>,
+    descriptor: DagDescriptor,
+    corr: u64,
+) -> DagId {
+    enqueue(registry, dag_mailbox(), &Submit { descriptor }, session(corr));
+    match await_session_reply::<SubmitResult>(rx, Duration::from_secs(5)) {
+        SubmitResult::Ok { dag_id, .. } => dag_id,
+        SubmitResult::Err { error } => panic!("submit failed: {error:?}"),
+    }
+}
+
+/// Query the DAG's status through the cap.
+fn query_status(
+    registry: &Registry,
+    rx: &Receiver<EgressEvent>,
+    dag_id: DagId,
+    corr: u64,
+) -> StatusResult {
+    enqueue(registry, dag_mailbox(), &Status { dag_id }, session(corr));
+    await_session_reply::<StatusResult>(rx, Duration::from_secs(5))
+}
+
+/// A `Source` node feeding kind `K` to `mailbox` with `payload`.
+fn source_node(id: u32, mailbox: MailboxId, kind: KindId, payload: Vec<u8>) -> Node {
+    Node::Source {
+        id: NodeId(id),
+        mailbox,
+        kind_id: kind,
+        payload,
+    }
+}
+
+/// Mailbox id for an actor by its namespace.
+fn mbx<A: Actor>() -> MailboxId {
+    MailboxId(aether_data::mailbox_id_from_name(A::NAMESPACE).0)
+}
+
+/// Postcard-encode a `TestSourceRequest`.
+fn source_req(value: u64, fail: bool) -> Vec<u8> {
+    postcard::to_allocvec(&super::test_support::TestSourceRequest { value, fail }).unwrap()
+}
+
+/// The `TestSourceRequest` kind id.
+fn source_kind() -> KindId {
+    <super::test_support::TestSourceRequest as Kind>::ID
+}
+
+/// DAG: read-source → observer. The observer receives the source's
+/// resolved reply inline; status reaches `Complete`.
+#[test]
+fn dag_executor_runs_two_node_dag() {
+    let (registry, mailer, rx) = fresh_substrate_with_rx();
+    let recorder: Recorder<TestObserved> = Arc::new(Mutex::new(Vec::new()));
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<TraceObserverCapability>(())
+        .with_actor::<crate::HandleCapability>(())
+        .with_actor::<DagCapability>(())
+        .with_actor::<TestSourceActor>(())
+        .with_actor::<TestObserverActor>(Arc::clone(&recorder))
+        .build_passive()
+        .expect("caps boot");
+
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![
+            source_node(0, mbx::<TestSourceActor>(), source_kind(), source_req(42, false)),
+            Node::Observer {
+                id: NodeId(1),
+                recipient: mbx::<TestObserverActor>(),
+                kind_id: <TestObserved as Kind>::ID,
+            },
+        ],
+        edges: vec![Edge {
+            from: NodeId(0),
+            to: NodeId(1),
+            slot: 0,
+        }],
+    };
+
+    let dag_id = submit_ok(&registry, &rx, descriptor, 1);
+
+    assert!(
+        poll_until(Duration::from_secs(5), || recorder.lock().unwrap().len()
+            == 1),
+        "observer never received the source reply",
+    );
+    let observed = recorder.lock().unwrap()[0].clone();
+    assert_eq!(
+        observed.input,
+        aether_data::Ref::Inline(TestReadResult::Ok { value: 42 })
+    );
+
+    assert!(poll_until(Duration::from_secs(5), || matches!(
+        query_status(&registry, &rx, dag_id, 100),
+        StatusResult::Complete { .. }
+    )));
+
+    drop(chassis);
+}
+
+/// Same DAG: after the source resolves, no parked mail remains on the
+/// source handle (the eagerly-dispatched observer parked there until the
+/// reply landed, then un-parked).
+#[test]
+fn dag_executor_parks_observer_until_source_resolves() {
+    let (registry, mailer, rx) = fresh_substrate_with_rx();
+    let recorder: Recorder<TestObserved> = Arc::new(Mutex::new(Vec::new()));
+    let store = Arc::clone(mailer.handle_store());
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<TraceObserverCapability>(())
+        .with_actor::<crate::HandleCapability>(())
+        .with_actor::<DagCapability>(())
+        .with_actor::<TestObserverActor>(Arc::clone(&recorder))
+        .with_actor::<TestSourceActor>(())
+        .build_passive()
+        .expect("caps boot");
+
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![
+            source_node(0, mbx::<TestSourceActor>(), source_kind(), source_req(7, false)),
+            Node::Observer {
+                id: NodeId(1),
+                recipient: mbx::<TestObserverActor>(),
+                kind_id: <TestObserved as Kind>::ID,
+            },
+        ],
+        edges: vec![Edge {
+            from: NodeId(0),
+            to: NodeId(1),
+            slot: 0,
+        }],
+    };
+
+    enqueue(&registry, dag_mailbox(), &Submit { descriptor }, session(1));
+    let source_handle = match await_session_reply::<SubmitResult>(&rx, Duration::from_secs(5)) {
+        SubmitResult::Ok { output_handles, .. } => {
+            output_handles
+                .iter()
+                .find(|h| h.node_id == NodeId(0))
+                .expect("source has an output handle")
+                .handle_id
+        }
+        SubmitResult::Err { error } => panic!("submit failed: {error:?}"),
+    };
+
+    assert!(
+        poll_until(Duration::from_secs(5), || recorder.lock().unwrap().len()
+            == 1),
+        "observer never ran",
+    );
+    assert_eq!(store.parked_count(source_handle), 0);
+
+    drop(chassis);
+}
+
+/// DAG: two reads → one observer with two input slots. The observer
+/// fires once both sources resolve, both slots filled.
+#[test]
+fn dag_executor_runs_parallel_sources() {
+    let (registry, mailer, rx) = fresh_substrate_with_rx();
+    let recorder: Recorder<TestObserved2> = Arc::new(Mutex::new(Vec::new()));
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<TraceObserverCapability>(())
+        .with_actor::<crate::HandleCapability>(())
+        .with_actor::<DagCapability>(())
+        .with_actor::<TestSourceActor>(())
+        .with_actor::<TestParallelObserverActor>(Arc::clone(&recorder))
+        .build_passive()
+        .expect("caps boot");
+
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![
+            source_node(0, mbx::<TestSourceActor>(), source_kind(), source_req(10, false)),
+            source_node(1, mbx::<TestSourceActor>(), source_kind(), source_req(20, false)),
+            Node::Observer {
+                id: NodeId(2),
+                recipient: mbx::<TestParallelObserverActor>(),
+                kind_id: <TestObserved2 as Kind>::ID,
+            },
+        ],
+        edges: vec![
+            Edge {
+                from: NodeId(0),
+                to: NodeId(2),
+                slot: 0,
+            },
+            Edge {
+                from: NodeId(1),
+                to: NodeId(2),
+                slot: 1,
+            },
+        ],
+    };
+
+    let _dag = submit_ok(&registry, &rx, descriptor, 1);
+
+    assert!(
+        poll_until(Duration::from_secs(5), || recorder.lock().unwrap().len()
+            == 1),
+        "two-slot observer never ran",
+    );
+    let observed = recorder.lock().unwrap()[0].clone();
+    assert_eq!(
+        observed.a,
+        aether_data::Ref::Inline(TestReadResult::Ok { value: 10 })
+    );
+    assert_eq!(
+        observed.b,
+        aether_data::Ref::Inline(TestReadResult::Ok { value: 20 })
+    );
+
+    drop(chassis);
+}
+
+/// A read source whose reply is an `Err` variant: the observer's
+/// `Ref<TestReadResult>` slot resolves to the `Err` inline, and the
+/// observer is still dispatched.
+#[test]
+fn dag_executor_propagates_source_err_as_observer_input() {
+    let (registry, mailer, rx) = fresh_substrate_with_rx();
+    let recorder: Recorder<TestObserved> = Arc::new(Mutex::new(Vec::new()));
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<TraceObserverCapability>(())
+        .with_actor::<crate::HandleCapability>(())
+        .with_actor::<DagCapability>(())
+        .with_actor::<TestSourceActor>(())
+        .with_actor::<TestObserverActor>(Arc::clone(&recorder))
+        .build_passive()
+        .expect("caps boot");
+
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![
+            source_node(0, mbx::<TestSourceActor>(), source_kind(), source_req(9, true)),
+            Node::Observer {
+                id: NodeId(1),
+                recipient: mbx::<TestObserverActor>(),
+                kind_id: <TestObserved as Kind>::ID,
+            },
+        ],
+        edges: vec![Edge {
+            from: NodeId(0),
+            to: NodeId(1),
+            slot: 0,
+        }],
+    };
+
+    let _dag = submit_ok(&registry, &rx, descriptor, 1);
+
+    assert!(
+        poll_until(Duration::from_secs(5), || recorder.lock().unwrap().len()
+            == 1),
+        "observer never received the Err source reply",
+    );
+    let observed = recorder.lock().unwrap()[0].clone();
+    match observed.input {
+        aether_data::Ref::Inline(TestReadResult::Err { message }) => {
+            assert!(message.contains("failed"), "got {message}");
+        }
+        other => panic!("expected inline Err, got {other:?}"),
+    }
+
+    drop(chassis);
+}
+
+/// Cancel a DAG: `Ok { cancelled: true }` for a still-running DAG (status
+/// then reads `Failed { error: "cancelled" }`), or `Ok { cancelled:
+/// false }` if it had already completed (a tolerated race).
+#[test]
+fn dag_executor_cancels_running_dag() {
+    let (registry, mailer, rx) = fresh_substrate_with_rx();
+    let recorder: Recorder<TestObserved> = Arc::new(Mutex::new(Vec::new()));
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<TraceObserverCapability>(())
+        .with_actor::<crate::HandleCapability>(())
+        .with_actor::<DagCapability>(())
+        .with_actor::<TestObserverActor>(Arc::clone(&recorder))
+        .with_actor::<TestSourceActor>(())
+        .build_passive()
+        .expect("caps boot");
+
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![
+            source_node(0, mbx::<TestSourceActor>(), source_kind(), source_req(1, false)),
+            Node::Observer {
+                id: NodeId(1),
+                recipient: mbx::<TestObserverActor>(),
+                kind_id: <TestObserved as Kind>::ID,
+            },
+        ],
+        edges: vec![Edge {
+            from: NodeId(0),
+            to: NodeId(1),
+            slot: 0,
+        }],
+    };
+
+    let dag_id = submit_ok(&registry, &rx, descriptor, 1);
+    enqueue(&registry, dag_mailbox(), &Cancel { dag_id }, session(2));
+    match await_session_reply::<CancelResult>(&rx, Duration::from_secs(5)) {
+        CancelResult::Ok { cancelled: true } => {
+            assert!(poll_until(Duration::from_secs(5), || matches!(
+                query_status(&registry, &rx, dag_id, 100),
+                StatusResult::Failed { ref error, .. } if error == "cancelled"
+            )));
+            assert_eq!(recorder.lock().unwrap().len(), 0);
+        }
+        CancelResult::Ok { cancelled: false } => {
+            assert!(matches!(
+                query_status(&registry, &rx, dag_id, 100),
+                StatusResult::Complete { .. }
+            ));
+        }
+        CancelResult::Err { error } => panic!("cancel errored: {error}"),
+    }
+
+    drop(chassis);
+}
+
+/// A DAG polled mid-flight reports `Running` (with a per-node progress
+/// list naming both nodes), `Pending`, or `Complete`; it always reaches
+/// `Complete`.
+#[test]
+fn dag_executor_status_reports_running() {
+    let (registry, mailer, rx) = fresh_substrate_with_rx();
+    let recorder: Recorder<TestObserved> = Arc::new(Mutex::new(Vec::new()));
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<TraceObserverCapability>(())
+        .with_actor::<crate::HandleCapability>(())
+        .with_actor::<DagCapability>(())
+        .with_actor::<TestSourceActor>(())
+        .with_actor::<TestObserverActor>(Arc::clone(&recorder))
+        .build_passive()
+        .expect("caps boot");
+
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![
+            source_node(0, mbx::<TestSourceActor>(), source_kind(), source_req(5, false)),
+            Node::Observer {
+                id: NodeId(1),
+                recipient: mbx::<TestObserverActor>(),
+                kind_id: <TestObserved as Kind>::ID,
+            },
+        ],
+        edges: vec![Edge {
+            from: NodeId(0),
+            to: NodeId(1),
+            slot: 0,
+        }],
+    };
+
+    let dag_id = submit_ok(&registry, &rx, descriptor, 1);
+    match query_status(&registry, &rx, dag_id, 2) {
+        StatusResult::Running { progress } => {
+            assert_eq!(progress.len(), 2);
+            assert!(progress.iter().any(|p| p.node_id == NodeId(0)));
+            assert!(progress.iter().any(|p| p.node_id == NodeId(1)));
+        }
+        StatusResult::Pending | StatusResult::Complete { .. } => {}
+        StatusResult::Failed { node_id, error } => {
+            panic!("unexpected Failed({node_id:?}, {error})")
+        }
+    }
+    assert!(poll_until(Duration::from_secs(5), || matches!(
+        query_status(&registry, &rx, dag_id, 100),
+        StatusResult::Complete { .. }
+    )));
+
+    drop(chassis);
+}
+
+/// With tiny retention windows, a completed DAG is observable as
+/// `Complete`, then reaped — after which `status` reports the unknown-dag
+/// shape (`Failed { error: "unknown dag .." }`).
+#[test]
+fn dag_executor_status_reports_complete_then_reaps() {
+    // SAFETY: nextest runs each test in its own process, so the env set
+    // here doesn't race sibling tests.
+    unsafe {
+        env::set_var("AETHER_DAG_RETENTION_COMPLETE_MS", "50");
+        env::set_var("AETHER_DAG_RETENTION_FAILED_MS", "50");
+    }
+    let (registry, mailer, rx) = fresh_substrate_with_rx();
+    let recorder: Recorder<TestObserved> = Arc::new(Mutex::new(Vec::new()));
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<TraceObserverCapability>(())
+        .with_actor::<crate::HandleCapability>(())
+        .with_actor::<DagCapability>(())
+        .with_actor::<TestSourceActor>(())
+        .with_actor::<TestObserverActor>(Arc::clone(&recorder))
+        .build_passive()
+        .expect("caps boot");
+
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![
+            source_node(0, mbx::<TestSourceActor>(), source_kind(), source_req(3, false)),
+            Node::Observer {
+                id: NodeId(1),
+                recipient: mbx::<TestObserverActor>(),
+                kind_id: <TestObserved as Kind>::ID,
+            },
+        ],
+        edges: vec![Edge {
+            from: NodeId(0),
+            to: NodeId(1),
+            slot: 0,
+        }],
+    };
+
+    let dag_id = submit_ok(&registry, &rx, descriptor, 1);
+    assert!(poll_until(Duration::from_secs(5), || matches!(
+        query_status(&registry, &rx, dag_id, 100),
+        StatusResult::Complete { .. }
+    )));
+
+    thread::sleep(Duration::from_millis(120));
+    let unknown = poll_until(Duration::from_secs(5), || {
+        enqueue(&registry, dag_mailbox(), &DagReapTick {}, session(200));
+        thread::sleep(Duration::from_millis(20));
+        matches!(
+            query_status(&registry, &rx, dag_id, 201),
+            StatusResult::Failed { ref error, .. } if error.starts_with("unknown dag")
+        )
+    });
+    assert!(unknown, "reaped DAG should report unknown-dag");
+
+    // SAFETY: nextest runs each test in its own process; no sibling
+    // thread reads these env vars concurrently.
+    unsafe {
+        env::remove_var("AETHER_DAG_RETENTION_COMPLETE_MS");
+        env::remove_var("AETHER_DAG_RETENTION_FAILED_MS");
+    }
+    drop(chassis);
+}
+
+/// source → Call (single-reply cap) → observer consuming the Bundle.
+/// The observer receives a 1-element Bundle whose element is the cap's
+/// reply.
+#[test]
+fn dag_executor_call_collects_single_reply_bundle() {
+    let (registry, mailer, rx) = fresh_substrate_with_rx();
+    let recorder = Arc::new(Mutex::new(Vec::new()));
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<TraceObserverCapability>(())
+        .with_actor::<crate::HandleCapability>(())
+        .with_actor::<DagCapability>(())
+        .with_actor::<TestSourceActor>(())
+        .with_actor::<TestCallActor>(TestCallConfig {
+            replies: 1,
+            never: false,
+        })
+        .with_actor::<TestBundleObserverActor>(Arc::clone(&recorder))
+        .build_passive()
+        .expect("caps boot");
+
+    let bundle = run_call_dag_to(&registry, &rx, &recorder, mbx::<TestCallActor>());
+    assert_eq!(bundle.elements.len(), 1);
+    assert_eq!(bundle.elements[0].kind_id, <TestCallReply as Kind>::ID);
+
+    drop(chassis);
+}
+
+/// Call to a cap that emits N correlated replies before settling. The
+/// resolved Bundle has N elements in emission order.
+#[test]
+fn dag_executor_call_collects_multi_reply_bundle() {
+    let (registry, mailer, rx) = fresh_substrate_with_rx();
+    let recorder = Arc::new(Mutex::new(Vec::new()));
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<TraceObserverCapability>(())
+        .with_actor::<crate::HandleCapability>(())
+        .with_actor::<DagCapability>(())
+        .with_actor::<TestSourceActor>(())
+        .with_actor::<TestCallActor>(TestCallConfig {
+            replies: 3,
+            never: false,
+        })
+        .with_actor::<TestBundleObserverActor>(Arc::clone(&recorder))
+        .build_passive()
+        .expect("caps boot");
+
+    let bundle = run_call_dag_to(&registry, &rx, &recorder, mbx::<TestCallActor>());
+    assert_eq!(bundle.elements.len(), 3);
+    for (i, el) in bundle.elements.iter().enumerate() {
+        let reply: TestCallReply = postcard::from_bytes(&el.payload).unwrap();
+        assert_eq!(reply.index, i as u64);
+    }
+
+    drop(chassis);
+}
+
+/// A spawn-and-die-worker `Call` cap: the bundle must not close until the
+/// worker's deferred reply lands (the `SettlementHold` keeps the chain
+/// open). The element is the worker's reply, proving it wasn't dropped
+/// into an already-settled bundle.
+#[test]
+fn dag_executor_call_inherited_worker_counts_toward_settlement() {
+    let (registry, mailer, rx) = fresh_substrate_with_rx();
+    let recorder = Arc::new(Mutex::new(Vec::new()));
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<TraceObserverCapability>(())
+        .with_actor::<crate::HandleCapability>(())
+        .with_actor::<DagCapability>(())
+        .with_actor::<TestSourceActor>(())
+        .with_actor::<TestDeferredCallActor>(())
+        .with_actor::<TestBundleObserverActor>(Arc::clone(&recorder))
+        .build_passive()
+        .expect("caps boot");
+
+    let bundle = run_call_dag_to(&registry, &rx, &recorder, mbx::<TestDeferredCallActor>());
+    assert_eq!(
+        bundle.elements.len(),
+        1,
+        "the deferred worker's reply must land in the bundle, not an already-closed one",
+    );
+    let reply: TestCallReply = postcard::from_bytes(&bundle.elements[0].payload).unwrap();
+    assert_eq!(reply.index, 1);
+
+    drop(chassis);
+}
+
+/// Call to a cap that never settles (holds the chain open forever): with
+/// a tiny per-`Call` timeout the node fails rather than buffering forever
+/// or truncating to a partial bundle.
+#[test]
+fn dag_executor_call_times_out_nonsettling_cap() {
+    // SAFETY: nextest runs each test in its own process.
+    unsafe {
+        env::set_var("AETHER_DAG_CALL_TIMEOUT_MS", "100");
+    }
+    let (registry, mailer, rx) = fresh_substrate_with_rx();
+    let recorder = Arc::new(Mutex::new(Vec::new()));
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<TraceObserverCapability>(())
+        .with_actor::<crate::HandleCapability>(())
+        .with_actor::<DagCapability>(())
+        .with_actor::<TestSourceActor>(())
+        .with_actor::<TestCallActor>(TestCallConfig {
+            replies: 0,
+            never: true,
+        })
+        .with_actor::<TestBundleObserverActor>(Arc::clone(&recorder))
+        .build_passive()
+        .expect("caps boot");
+
+    let dag_id = submit_call_dag(&registry, &rx, mbx::<TestCallActor>());
+
+    thread::sleep(Duration::from_millis(150));
+    let failed = poll_until(Duration::from_secs(5), || {
+        enqueue(&registry, dag_mailbox(), &DagReapTick {}, session(300));
+        thread::sleep(Duration::from_millis(20));
+        matches!(
+            query_status(&registry, &rx, dag_id, 301),
+            StatusResult::Failed { ref error, .. } if error.contains("timed out")
+        )
+    });
+    assert!(failed, "non-settling Call should fail on timeout");
+    assert_eq!(recorder.lock().unwrap().len(), 0);
+
+    // SAFETY: nextest runs each test in its own process; no sibling
+    // thread reads this env var concurrently.
+    unsafe {
+        env::remove_var("AETHER_DAG_CALL_TIMEOUT_MS");
+    }
+    drop(chassis);
+}
+
+/// The call dispatch mints a fresh `call_root` distinct from the DAG
+/// root: a non-empty bundle can only close if the executor subscribed to
+/// the call's own root (a DAG-root subscription would never fire
+/// mid-graph).
+#[test]
+fn dag_executor_call_dispatches_as_own_root() {
+    let (registry, mailer, rx) = fresh_substrate_with_rx();
+    let recorder = Arc::new(Mutex::new(Vec::new()));
+    let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+        .with_actor::<TraceObserverCapability>(())
+        .with_actor::<crate::HandleCapability>(())
+        .with_actor::<DagCapability>(())
+        .with_actor::<TestSourceActor>(())
+        .with_actor::<TestCallActor>(TestCallConfig {
+            replies: 1,
+            never: false,
+        })
+        .with_actor::<TestBundleObserverActor>(Arc::clone(&recorder))
+        .build_passive()
+        .expect("caps boot");
+
+    let bundle = run_call_dag_to(&registry, &rx, &recorder, mbx::<TestCallActor>());
+    assert_eq!(
+        bundle.elements.len(),
+        1,
+        "the per-call settlement subscription must fire to close a non-empty bundle",
+    );
+
+    drop(chassis);
+}
+
+/// Build + submit a source → Call → bundle-observer DAG with the Call
+/// addressed at `call_mbx`, and return the `DagId`.
+fn submit_call_dag(
+    registry: &Registry,
+    rx: &Receiver<EgressEvent>,
+    call_mbx: MailboxId,
+) -> DagId {
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![
+            source_node(0, mbx::<TestSourceActor>(), source_kind(), source_req(1, false)),
+            Node::Call {
+                id: NodeId(1),
+                recipient: call_mbx,
+                kind_id: <super::test_support::TestCallRequest as Kind>::ID,
+            },
+            Node::Observer {
+                id: NodeId(2),
+                recipient: mbx::<TestBundleObserverActor>(),
+                kind_id: <super::test_support::TestBundleObserved as Kind>::ID,
+            },
+        ],
+        edges: vec![
+            // source gates the Call's dispatch (TestCallRequest has no
+            // Ref slots, so the edge contributes no substitution).
+            Edge {
+                from: NodeId(0),
+                to: NodeId(1),
+                slot: 0,
+            },
+            // Call's Bundle output feeds the observer's slot 0.
+            Edge {
+                from: NodeId(1),
+                to: NodeId(2),
+                slot: 0,
+            },
+        ],
+    };
+    submit_ok(registry, rx, descriptor, 1)
+}
+
+/// Run the Call DAG against a specific Call mailbox + return the Bundle
+/// the observer received.
+fn run_call_dag_to(
+    registry: &Registry,
+    rx: &Receiver<EgressEvent>,
+    recorder: &Recorder<super::test_support::TestBundleObserved>,
+    call_mbx: MailboxId,
+) -> Bundle {
+    let _dag = submit_call_dag(registry, rx, call_mbx);
+    assert!(
+        poll_until(Duration::from_secs(8), || recorder.lock().unwrap().len()
+            == 1),
+        "bundle observer never ran",
+    );
+    let observed = recorder.lock().unwrap()[0].clone();
+    match observed.input {
+        aether_data::Ref::Inline(bundle) => bundle,
+        aether_data::Ref::Handle { .. } => panic!("bundle slot should be resolved inline"),
+    }
+}

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -39,6 +39,8 @@ pub mod component;
 // elides cleanly on the wasm-component build.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod contentgen;
+// `aether.dag` computation-DAG executor cap (ADR-0047, issue 976).
+pub mod dag;
 pub mod engine;
 pub mod fs;
 // `aether.gemini` content-gen cap (ADR-0050, issue 1015). Native-only
@@ -68,6 +70,7 @@ pub use audio::AudioConfig;
 #[cfg(not(target_arch = "wasm32"))]
 pub use anthropic::{AnthropicCapability, AnthropicConfig};
 pub use component::ComponentHostCapability;
+pub use dag::DagCapability;
 // ADR-0050 §2 shared content-gen infrastructure. Native-only — the two
 // provider caps (issue 1014 / 1015) embed these.
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/aether-kinds/src/dag.rs
+++ b/crates/aether-kinds/src/dag.rs
@@ -343,3 +343,26 @@ pub enum DagError {
     /// version (ADR-0047 §3/§8 wire-churn-avoiding reuse).
     TooLarge { reason: String },
 }
+
+/// `aether.dag.reap_tick` — internal wake mail for the DAG executor's
+/// reaping sweep (ADR-0047 §7). A sidecar timer thread fires this
+/// (empty-payload) mail at the `aether.dag` mailbox every ~30s so the
+/// executor's reaping runs on its own single-threaded actor thread
+/// (the `DagState` map lives in lock-free actor state — the timer
+/// thread can't touch it directly). Mirrors the `RpcInboundReady` /
+/// `aether.tcp` sidecar-wake pattern: the mail is only the signal.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "aether.dag.reap_tick")]
+pub struct DagReapTick {}

--- a/crates/aether-mcp/src/args.rs
+++ b/crates/aether-mcp/src/args.rs
@@ -337,3 +337,51 @@ pub struct CaptureFrameArgs {
     #[serde(default)]
     pub after_mails: Vec<CaptureMailSpec>,
 }
+
+/// `submit_dag` arguments (ADR-0047 §9).
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SubmitDagArgs {
+    /// Engine UUID the DAG submits to (from `list_engines`).
+    pub engine_id: String,
+    /// The DAG descriptor as JSON, encoded against the
+    /// `aether.dag.descriptor` kind schema (read it via `describe_kinds`).
+    /// `nodes` is an array of externally-tagged `Node` variants
+    /// (`{ "Source": { id, mailbox, kind_id, payload_path } }`,
+    /// `{ "Observer": { id, recipient, kind_id } }`,
+    /// `{ "Call": { id, recipient, kind_id } }`); `edges` is an array of
+    /// `{ from, to, slot }`; `version` is `1`. Tagged-string ids
+    /// (`mbx-…`, `knd-…`) per ADR-0064/0065.
+    ///
+    /// **`payload_path` is a tool-layer virtual field.** Each `Source`
+    /// carries `payload_path: String` instead of the wire `payload:
+    /// Vec<u8>`: `submit_dag` reads the file at that path and substitutes
+    /// the bytes into the wire `payload` before encoding. The path must
+    /// be readable from the MCP process (colocated with the substrate in
+    /// v1). A `Source` may instead carry an inline `payload` byte array;
+    /// `payload_path` takes precedence when both are present.
+    pub descriptor: serde_json::Value,
+    /// Cap on wall-clock wait for the synchronous validation verdict, in
+    /// milliseconds. Defaults to 5000. Guards against a hung validator,
+    /// not normal latency — validation is microseconds, and execution is
+    /// async (poll via `dag_status`).
+    #[serde(default)]
+    pub timeout_ms: Option<u32>,
+}
+
+/// `dag_status` arguments (ADR-0047 §9).
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DagStatusArgs {
+    /// Engine UUID hosting the DAG (from `list_engines`).
+    pub engine_id: String,
+    /// Tagged DAG id (`dag-…`) returned by `submit_dag`.
+    pub dag_id: String,
+}
+
+/// `dag_cancel` arguments (ADR-0047 §9).
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DagCancelArgs {
+    /// Engine UUID hosting the DAG (from `list_engines`).
+    pub engine_id: String,
+    /// Tagged DAG id (`dag-…`) returned by `submit_dag`.
+    pub dag_id: String,
+}

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -19,12 +19,14 @@ use aether_capabilities::rpc::{MailEnvelope, MailboxAddress};
 use aether_data::MailId;
 use aether_data::canonical::kind_id_from_parts;
 use aether_data::{
-    EngineId, Kind, KindDescriptor, KindId, MailboxId, Tag, Uuid, mailbox_id_from_name, tagged_id,
+    DagId, EngineId, Kind, KindDescriptor, KindId, MailboxId, Schema, Tag, Uuid,
+    mailbox_id_from_name, tagged_id,
 };
 use aether_kinds::{
-    CaptureFrame, CaptureFrameResult, ComponentCapabilities, ListEngines, ListEnginesResult,
-    LoadComponent, LoadResult, MailEnvelope as KindMailEnvelope, ReplaceComponent, ReplaceResult,
-    SpawnEngine, SpawnEngineResult, TerminateEngine, TerminateEngineResult,
+    Cancel, CancelResult, CaptureFrame, CaptureFrameResult, ComponentCapabilities, ListEngines,
+    ListEnginesResult, LoadComponent, LoadResult, MailEnvelope as KindMailEnvelope,
+    ReplaceComponent, ReplaceResult, SpawnEngine, SpawnEngineResult, Status, StatusResult, Submit,
+    SubmitResult, TerminateEngine, TerminateEngineResult,
     trace::{
         DescribeTree, DescribeTreeResult, DispatchTraced, DispatchTracedAck, MailNodeWire,
         TRACE_OBSERVER_MAILBOX_NAME,
@@ -40,10 +42,11 @@ use crate::args::ActorLogEntry;
 use crate::args::ActorLogsArgs;
 use crate::args::ActorLogsResponse;
 use crate::args::{
-    CaptureFrameArgs, CaptureMailSpec, DescribeComponentArgs, DescribeHandlesArgs,
-    DescribeHandlesResponse, EngineInfo, HandleSummaryJson, LoadComponentArgs, MailIdJson,
-    MailNodeJson, MailSpec, MailStatus, ReplaceComponentArgs, SendMailArgs, SendMailTracedArgs,
-    SendMailTracedResponse, SpawnSubstrateArgs, TerminateSubstrateArgs, TracedMailSpec,
+    CaptureFrameArgs, CaptureMailSpec, DagCancelArgs, DagStatusArgs, DescribeComponentArgs,
+    DescribeHandlesArgs, DescribeHandlesResponse, EngineInfo, HandleSummaryJson, LoadComponentArgs,
+    MailIdJson, MailNodeJson, MailSpec, MailStatus, ReplaceComponentArgs, SendMailArgs,
+    SendMailTracedArgs, SendMailTracedResponse, SpawnSubstrateArgs, SubmitDagArgs,
+    TerminateSubstrateArgs, TracedMailSpec,
 };
 use crate::rpc::RpcSession;
 use aether_kinds::descriptors;
@@ -61,6 +64,8 @@ const COMPONENT_CAP: &str = "aether.component";
 const RENDER_CAP: &str = "aether.render";
 /// Mailbox name of a substrate's handle-store cap (ADR-0045 / ADR-0049).
 const HANDLE_CAP: &str = "aether.handle";
+/// Mailbox name of a substrate's DAG-executor cap (ADR-0047).
+const DAG_CAP: &str = "aether.dag";
 
 /// Component receive-side capabilities, keyed by `(engine, mailbox)`.
 /// Populated from `load_component` / `replace_component` replies and
@@ -566,6 +571,121 @@ impl Mcp {
         };
         json(&response)
     }
+
+    #[tool(
+        description = "Submit a computation DAG to a substrate (ADR-0047). Validation runs SYNCHRONOUSLY on this call: returns {dag_id, output_handles:[{node_id, handle_id}]} once the descriptor passes, or {error: <DagError>} immediately on a bad descriptor (cycle, unknown sink/recipient, kind-not-accepted, etc.) — no dag_id minted, nothing dispatched. Sources execute asynchronously AFTER this ack; the returned output_handles are the per-node handle ids (allocated at submit) you can stamp into downstream Ref<K> slots before their values resolve. Poll dag_status for execution state. The descriptor is JSON encoded against the aether.dag.descriptor kind schema (see describe_kinds): each Source carries a virtual `payload_path` (a filesystem path readable by this process) that submit_dag reads and substitutes into the wire `payload` bytes — so large source payloads stage to a file instead of bloating the tool call. timeout_ms (default 5000) guards a hung validator, not normal latency."
+    )]
+    pub async fn submit_dag(
+        &self,
+        Parameters(args): Parameters<SubmitDagArgs>,
+    ) -> Result<String, McpError> {
+        let engine = parse_engine_id(&args.engine_id)?;
+        // Resolve each Source's `payload_path` virtual field into wire
+        // `payload` bytes before encoding. A read failure surfaces as a
+        // clean invalid-params error and never touches the wire.
+        let descriptor_json = resolve_payload_paths(args.descriptor)
+            .await
+            .map_err(|e| McpError::invalid_params(format!("submit_dag descriptor: {e}"), None))?;
+        // Encode `Submit { descriptor }` against the Submit kind schema —
+        // the same encode_schema path send_mail uses for its params.
+        let submit_json = serde_json::json!({ "descriptor": descriptor_json });
+        let payload = aether_codec::encode_schema(&submit_json, &Submit::SCHEMA)
+            .map_err(|e| McpError::invalid_params(format!("submit_dag encode: {e}"), None))?;
+        let envelope = MailEnvelope {
+            to: MailboxAddress {
+                engine: Some(engine),
+                mailbox: mailbox_id_from_name(DAG_CAP),
+            },
+            from: None,
+            kind: Submit::ID,
+            correlation_id: None,
+            payload,
+        };
+        let timeout_ms = args.timeout_ms.unwrap_or(5000);
+        let reply = match time::timeout(
+            Duration::from_millis(u64::from(timeout_ms)),
+            self.session.call_one(envelope),
+        )
+        .await
+        {
+            Ok(Ok(reply)) => reply,
+            Ok(Err(e)) => return Err(internal(e)),
+            Err(_) => {
+                return Err(internal_msg(
+                    "submit_dag timed out waiting for the validation verdict",
+                ));
+            }
+        };
+        match SubmitResult::decode_from_bytes(&reply.payload) {
+            Some(SubmitResult::Ok {
+                dag_id,
+                output_handles,
+            }) => {
+                let handles: Vec<serde_json::Value> = output_handles
+                    .iter()
+                    .map(|h| {
+                        serde_json::json!({
+                            "node_id": h.node_id.0,
+                            "handle_id": tagged_id::encode(h.handle_id.0)
+                                .unwrap_or_else(|| h.handle_id.0.to_string()),
+                        })
+                    })
+                    .collect();
+                json(&serde_json::json!({
+                    "dag_id": tagged_id::encode(dag_id.0)
+                        .unwrap_or_else(|| dag_id.0.to_string()),
+                    "output_handles": handles,
+                }))
+            }
+            Some(SubmitResult::Err { error }) => {
+                json(&serde_json::json!({ "error": error }))
+            }
+            None => Err(internal_msg("undecodable SubmitResult")),
+        }
+    }
+
+    #[tool(
+        description = "Poll a submitted DAG's execution status by its dag_id (ADR-0047). Returns the discriminated-union variant directly: \"Pending\" (acked, no source dispatched yet — transient), {\"Running\": {progress:[{node_id, state}]}}, {\"Complete\": {outputs:[{node_id, handle_id}]}}, or {\"Failed\": {node_id, error}}. Validation failures already came back synchronously on submit_dag, so this only ever reports execution-time failures (a source/Call timeout, a malformed reply) — or, for an unknown/reaped dag_id, a Failed with error \"unknown dag …\"."
+    )]
+    pub async fn dag_status(
+        &self,
+        Parameters(args): Parameters<DagStatusArgs>,
+    ) -> Result<String, McpError> {
+        let engine = parse_engine_id(&args.engine_id)?;
+        let dag_id = parse_dag_id(&args.dag_id)?;
+        let reply = self
+            .session
+            .call_one(engine_envelope(engine, DAG_CAP, &Status { dag_id }))
+            .await
+            .map_err(internal)?;
+        StatusResult::decode_from_bytes(&reply.payload).map_or_else(
+            || Err(internal_msg("undecodable StatusResult")),
+            |result| json(&result),
+        )
+    }
+
+    #[tool(
+        description = "Cancel an in-flight DAG by its dag_id (ADR-0047 §5). Returns {\"cancelled\": true} for a still-running DAG (its parked downstream mail is dropped; in-flight cap calls complete server-side but their results discard), {\"cancelled\": false} if it had already completed, or an error for an unknown dag_id."
+    )]
+    pub async fn dag_cancel(
+        &self,
+        Parameters(args): Parameters<DagCancelArgs>,
+    ) -> Result<String, McpError> {
+        let engine = parse_engine_id(&args.engine_id)?;
+        let dag_id = parse_dag_id(&args.dag_id)?;
+        let reply = self
+            .session
+            .call_one(engine_envelope(engine, DAG_CAP, &Cancel { dag_id }))
+            .await
+            .map_err(internal)?;
+        match CancelResult::decode_from_bytes(&reply.payload) {
+            Some(CancelResult::Ok { cancelled }) => {
+                json(&serde_json::json!({ "cancelled": cancelled }))
+            }
+            Some(CancelResult::Err { error }) => Err(internal_msg(&error)),
+            None => Err(internal_msg("undecodable CancelResult")),
+        }
+    }
 }
 
 impl Mcp {
@@ -663,6 +783,54 @@ fn parse_mailbox_id(s: &str) -> Result<MailboxId, McpError> {
     tagged_id::decode_with_tag(s, Tag::Mailbox)
         .map(MailboxId)
         .map_err(|e| McpError::invalid_params(format!("mailbox_id: {e}"), None))
+}
+
+/// Parse a tagged DAG-id string (`dag-…`, ADR-0064/0065) into a
+/// `DagId`.
+fn parse_dag_id(s: &str) -> Result<DagId, McpError> {
+    tagged_id::decode_with_tag(s, Tag::Dag)
+        .map(DagId)
+        .map_err(|e| McpError::invalid_params(format!("dag_id: {e}"), None))
+}
+
+/// Resolve the tool-layer `payload_path` virtual field on every `Source`
+/// node of a descriptor JSON into the wire `payload: Vec<u8>` byte array.
+///
+/// The descriptor JSON is the externally-tagged `DagDescriptor` shape
+/// `encode_schema` accepts: `nodes` is an array of `{ "Source": { … } }`
+/// / `{ "Observer": { … } }` / `{ "Call": { … } }` objects. For each
+/// `Source` object carrying a `payload_path` string, this reads the file
+/// at that path, replaces `payload` with the file bytes as a JSON byte
+/// array, and removes `payload_path`. A `Source` with an inline
+/// `payload` array and no `payload_path` is left untouched. The
+/// substrate never sees the path — it gets a normal `Vec<u8>` payload.
+async fn resolve_payload_paths(mut descriptor: serde_json::Value) -> anyhow::Result<serde_json::Value> {
+    let Some(nodes) = descriptor
+        .get_mut("nodes")
+        .and_then(serde_json::Value::as_array_mut)
+    else {
+        // No nodes array — let encode_schema produce the structured
+        // error rather than second-guessing the shape here.
+        return Ok(descriptor);
+    };
+    for node in nodes.iter_mut() {
+        // Externally-tagged: { "Source": { … } }.
+        let Some(source) = node.get_mut("Source").and_then(serde_json::Value::as_object_mut) else {
+            continue;
+        };
+        let Some(path) = source.get("payload_path").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        let path = path.to_owned();
+        let bytes = fs::read(&path)
+            .await
+            .map_err(|e| anyhow::anyhow!("reading payload_path {path:?}: {e}"))?;
+        let byte_array: Vec<serde_json::Value> =
+            bytes.into_iter().map(serde_json::Value::from).collect();
+        source.insert("payload".to_owned(), serde_json::Value::Array(byte_array));
+        source.remove("payload_path");
+    }
+    Ok(descriptor)
 }
 
 /// Encode a `send_mail_traced` batch into the same `MailEnvelope`
@@ -815,6 +983,9 @@ fn level_to_str(level: u8) -> &'static str {
 }
 
 #[cfg(test)]
+// Test-setup unwraps (tagged-id encode of literal ids, JSON build) panic
+// on failure, which is the assertion; the DAG-tool fixtures lean on them.
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::args::{
@@ -1214,5 +1385,225 @@ mod tests {
             result.is_err(),
             "a malformed engine_id should be a tool error"
         );
+    }
+
+    // DAG tools (issue 977).
+
+    use crate::args::{DagCancelArgs, DagStatusArgs, SubmitDagArgs};
+    use aether_data::with_tag;
+    use aether_kinds::{DagDescriptor, Edge, Node, NodeId, Submit};
+    use std::path::PathBuf;
+    use std::process;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::{env as std_env, fs as std_fs};
+
+    /// Write `bytes` to a unique temp file and return its path. nextest's
+    /// process-per-test isolation keeps the filename collision-free
+    /// across the suite; the `pid + nanos` suffix guards within a process.
+    fn stage_temp_file(tag: &str, bytes: &[u8]) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        let path = std_env::temp_dir().join(format!(
+            "aether-mcp-dag-{tag}-{}-{nanos}.bin",
+            process::id()
+        ));
+        std_fs::write(&path, bytes).expect("stage temp file");
+        path
+    }
+
+    /// The tool's `payload_path` → wire-`payload` substitution + JSON
+    /// encode path produces the exact same canonical bytes as a direct
+    /// `#[derive(Kind)]` encode of the same descriptor with the bytes
+    /// inlined. Locks against encoding skew between the two paths.
+    #[tokio::test]
+    async fn submit_dag_encodes_descriptor() {
+        let source_mbx = mailbox_id_from_name("aether.fs");
+        let observer_mbx = mailbox_id_from_name("aether.render");
+        // Use real registered kind ids so the tagged-string round-trip is
+        // exercised against the actual TypeId encode arm.
+        let source_kind = aether_kinds::Read::ID;
+        let observer_kind = aether_kinds::DrawTriangle::ID;
+        let payload_bytes = vec![0x01u8, 0x02, 0x03, 0xFF, 0x00, 0x42];
+
+        // Expected: a typed DagDescriptor with the payload inlined,
+        // wrapped in Submit and encoded via the Kind derive.
+        let expected_descriptor = DagDescriptor {
+            version: 1,
+            nodes: vec![
+                Node::Source {
+                    id: NodeId(0),
+                    mailbox: source_mbx,
+                    kind_id: source_kind,
+                    payload: payload_bytes.clone(),
+                },
+                Node::Observer {
+                    id: NodeId(1),
+                    recipient: observer_mbx,
+                    kind_id: observer_kind,
+                },
+            ],
+            edges: vec![Edge {
+                from: NodeId(0),
+                to: NodeId(1),
+                slot: 0,
+            }],
+        };
+        let expected = Submit {
+            descriptor: expected_descriptor,
+        }
+        .encode_into_bytes();
+
+        // Tool path: descriptor JSON with a `payload_path` virtual field
+        // on the source, externally-tagged Node variants, tagged-string
+        // ids.
+        let path = stage_temp_file("encode", &payload_bytes);
+        // NodeId is a `#[derive(Schema)]` newtype, so encode_schema reads
+        // its single tuple field as `{ "0": <u32> }` (the schema-correct
+        // JSON the agent authors against `describe_kinds`).
+        let descriptor_json = serde_json::json!({
+            "version": 1,
+            "nodes": [
+                { "Source": {
+                    "id": { "0": 0 },
+                    "mailbox": tagged_id::encode(source_mbx.0).unwrap(),
+                    "kind_id": tagged_id::encode(source_kind.0).unwrap(),
+                    "payload_path": path.to_str().unwrap(),
+                }},
+                { "Observer": {
+                    "id": { "0": 1 },
+                    "recipient": tagged_id::encode(observer_mbx.0).unwrap(),
+                    "kind_id": tagged_id::encode(observer_kind.0).unwrap(),
+                }},
+            ],
+            "edges": [ { "from": { "0": 0 }, "to": { "0": 1 }, "slot": 0 } ],
+        });
+        let resolved = resolve_payload_paths(descriptor_json)
+            .await
+            .expect("payload_path resolves");
+        let submit_json = serde_json::json!({ "descriptor": resolved });
+        let actual =
+            aether_codec::encode_schema(&submit_json, &Submit::SCHEMA).expect("encode_schema ok");
+
+        std_fs::remove_file(&path).ok();
+        assert_eq!(
+            actual, expected,
+            "tool path-loading + JSON encode must match the binary inline-bytes encode",
+        );
+    }
+
+    /// A `Source` carrying an inline `payload` byte array (no
+    /// `payload_path`) is left untouched by `resolve_payload_paths` and
+    /// encodes identically to the typed form.
+    #[tokio::test]
+    async fn submit_dag_inline_payload_encodes() {
+        let source_mbx = mailbox_id_from_name("aether.fs");
+        let source_kind = aether_kinds::Read::ID;
+        let payload_bytes = vec![9u8, 8, 7];
+        let expected = Submit {
+            descriptor: DagDescriptor {
+                version: 1,
+                nodes: vec![Node::Source {
+                    id: NodeId(0),
+                    mailbox: source_mbx,
+                    kind_id: source_kind,
+                    payload: payload_bytes.clone(),
+                }],
+                edges: vec![],
+            },
+        }
+        .encode_into_bytes();
+
+        let descriptor_json = serde_json::json!({
+            "version": 1,
+            "nodes": [
+                { "Source": {
+                    "id": { "0": 0 },
+                    "mailbox": tagged_id::encode(source_mbx.0).unwrap(),
+                    "kind_id": tagged_id::encode(source_kind.0).unwrap(),
+                    "payload": payload_bytes,
+                }},
+            ],
+            "edges": [],
+        });
+        let resolved = resolve_payload_paths(descriptor_json)
+            .await
+            .expect("inline payload untouched");
+        let submit_json = serde_json::json!({ "descriptor": resolved });
+        let actual =
+            aether_codec::encode_schema(&submit_json, &Submit::SCHEMA).expect("encode_schema ok");
+        assert_eq!(actual, expected);
+    }
+
+    /// `submit_dag` with a `payload_path` that doesn't exist returns a
+    /// structured tool error before any call hits the engine.
+    #[tokio::test]
+    async fn submit_dag_rejects_missing_payload_path() {
+        let (_chassis, port) = boot_hub();
+        let mcp = connect_mcp(port);
+        let source_mbx = mailbox_id_from_name("aether.fs");
+        let descriptor = serde_json::json!({
+            "version": 1,
+            "nodes": [
+                { "Source": {
+                    "id": 0,
+                    "mailbox": tagged_id::encode(source_mbx.0).unwrap(),
+                    "kind_id": tagged_id::encode(aether_kinds::Read::ID.0).unwrap(),
+                    "payload_path": "/nonexistent/aether-dag-source.bin",
+                }},
+            ],
+            "edges": [],
+        });
+        let result = mcp
+            .submit_dag(Parameters(SubmitDagArgs {
+                engine_id: "00000000-0000-0000-0000-000000000001".to_owned(),
+                descriptor,
+                timeout_ms: None,
+            }))
+            .await;
+        assert!(
+            result.is_err(),
+            "a missing payload_path should be a tool error before any RPC",
+        );
+    }
+
+    /// `dag_status` / `dag_cancel` reject a malformed (non-`dag-…`)
+    /// `dag_id` at the tool boundary, before any RPC.
+    #[tokio::test]
+    async fn dag_status_and_cancel_reject_bad_dag_id() {
+        let (_chassis, port) = boot_hub();
+        let mcp = connect_mcp(port);
+        let status = mcp
+            .dag_status(Parameters(DagStatusArgs {
+                engine_id: "00000000-0000-0000-0000-000000000001".to_owned(),
+                dag_id: "not-a-dag-id".to_owned(),
+            }))
+            .await;
+        assert!(status.is_err(), "malformed dag_id is a tool error");
+        let cancel = mcp
+            .dag_cancel(Parameters(DagCancelArgs {
+                engine_id: "00000000-0000-0000-0000-000000000001".to_owned(),
+                dag_id: "mbx-aaaa-aaaa-aaaa".to_owned(),
+            }))
+            .await;
+        assert!(
+            cancel.is_err(),
+            "a mailbox-tagged id is not a dag id — tool error",
+        );
+    }
+
+    /// `dag_status` / `dag_cancel` reject a malformed `engine_id` at the
+    /// tool boundary.
+    #[tokio::test]
+    async fn dag_tools_reject_bad_engine_id() {
+        let (_chassis, port) = boot_hub();
+        let mcp = connect_mcp(port);
+        let status = mcp
+            .dag_status(Parameters(DagStatusArgs {
+                engine_id: "not-a-uuid".to_owned(),
+                dag_id: tagged_id::encode(with_tag(Tag::Dag, 1)).unwrap(),
+            }))
+            .await;
+        assert!(status.is_err(), "malformed engine_id is a tool error");
     }
 }

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -637,9 +637,7 @@ impl Mcp {
                     "output_handles": handles,
                 }))
             }
-            Some(SubmitResult::Err { error }) => {
-                json(&serde_json::json!({ "error": error }))
-            }
+            Some(SubmitResult::Err { error }) => json(&serde_json::json!({ "error": error })),
             None => Err(internal_msg("undecodable SubmitResult")),
         }
     }
@@ -804,7 +802,9 @@ fn parse_dag_id(s: &str) -> Result<DagId, McpError> {
 /// array, and removes `payload_path`. A `Source` with an inline
 /// `payload` array and no `payload_path` is left untouched. The
 /// substrate never sees the path — it gets a normal `Vec<u8>` payload.
-async fn resolve_payload_paths(mut descriptor: serde_json::Value) -> anyhow::Result<serde_json::Value> {
+async fn resolve_payload_paths(
+    mut descriptor: serde_json::Value,
+) -> anyhow::Result<serde_json::Value> {
     let Some(nodes) = descriptor
         .get_mut("nodes")
         .and_then(serde_json::Value::as_array_mut)
@@ -815,10 +815,16 @@ async fn resolve_payload_paths(mut descriptor: serde_json::Value) -> anyhow::Res
     };
     for node in nodes.iter_mut() {
         // Externally-tagged: { "Source": { … } }.
-        let Some(source) = node.get_mut("Source").and_then(serde_json::Value::as_object_mut) else {
+        let Some(source) = node
+            .get_mut("Source")
+            .and_then(serde_json::Value::as_object_mut)
+        else {
             continue;
         };
-        let Some(path) = source.get("payload_path").and_then(serde_json::Value::as_str) else {
+        let Some(path) = source
+            .get("payload_path")
+            .and_then(serde_json::Value::as_str)
+        else {
             continue;
         };
         let path = path.to_owned();

--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -18,7 +18,7 @@ use aether_actor::Actor;
 use aether_capabilities::rpc::{PeerKind, RpcServerCapability, RpcServerConfig};
 use aether_capabilities::{
     AnthropicCapability, AnthropicConfig, ComponentHostCapability, ComponentHostConfig,
-    FsCapability, GeminiCapability, GeminiConfig, HandleCapability, HttpCapability,
+    DagCapability, FsCapability, GeminiCapability, GeminiConfig, HandleCapability, HttpCapability,
     InputCapability, InputConfig, TcpCapability, fs::NamespaceRoots, http::HttpConfig,
     trace::TraceObserverCapability,
 };
@@ -87,6 +87,7 @@ pub fn with_common_caps<C: Chassis>(builder: Builder<C>, boot: CommonBoot) -> Bu
         .with_workers(boot.workers)
         .with_actor::<HandleCapability>(())
         .with_actor::<TraceObserverCapability>(())
+        .with_actor::<DagCapability>(())
         .with_actor::<InputCapability>(boot.input_config)
         .with_actor::<ComponentHostCapability>(boot.component_host_config)
         .with_actor::<FsCapability>(boot.namespace_roots)

--- a/crates/aether-substrate/src/dag/executor.rs
+++ b/crates/aether-substrate/src/dag/executor.rs
@@ -175,8 +175,8 @@ impl Executor {
     /// success mints the [`DagId`], allocates one handle per node,
     /// kicks off source dispatch + eager observer dispatch + zero-input
     /// `Call` dispatch, and returns the `(dag_id, output_handles)`. On a
-    /// validation failure returns the structured [`DagError`] and
-    /// dispatches nothing.
+    /// validation failure returns the structured
+    /// [`DagError`](aether_kinds::DagError) and dispatches nothing.
     ///
     /// The returned [`SubmitOutcome`] is the wire `SubmitResult` shape;
     /// the cap replies it verbatim.

--- a/crates/aether-substrate/src/dag/executor.rs
+++ b/crates/aether-substrate/src/dag/executor.rs
@@ -1,0 +1,846 @@
+//! ADR-0047 §4 DAG executor (iamacoffeepot/aether#976).
+//!
+//! [`Executor`] is the substrate-side machinery that drives a validated
+//! [`DagDescriptor`] to completion. It lives inside the `aether.dag`
+//! cap (a single-threaded [`NativeActor`](crate::actor::native::NativeActor)),
+//! so every method here runs on that one dispatcher thread — no locks,
+//! plain `&mut self` state.
+//!
+//! ## Dispatch model (ADR-0047 §4)
+//!
+//! At submit the executor mints one ephemeral [`HandleId`] per node,
+//! returns them in the `submit_result` so downstream `Ref::Handle`
+//! slots can be stamped, then begins execution:
+//!
+//! - **Sources** dispatch immediately. Each is sent to its mailbox via
+//!   the inherited send path with reply correlation routed back to the
+//!   executor's own mailbox (not the submitter). The reply resolves the
+//!   source's handle in the [`HandleStore`].
+//! - **Observers** dispatch *eagerly* at submit with `Ref::Handle`
+//!   slots into their input handle ids. The substrate's parking table
+//!   ([`HandleStore::park`] via [`crate::mail::Mailer::push`]) gates
+//!   them: the mail parks on the first unresolved handle and re-routes
+//!   when [`crate::mail::Mailer::resolve_handle`] flushes it — so a
+//!   multi-input observer naturally waits for every slot.
+//! - **`Call`s** gate on an explicit `pending_inputs` counter rather
+//!   than the parking table: a `Call` must dispatch as *its own causal
+//!   root* (`send_envelope_as_root`) so the executor can subscribe to
+//!   `Settled { call_root }` and accumulate the cap's correlated replies
+//!   into an ordered [`Bundle`]. The bundle closes exactly on
+//!   settlement (no quiescence window — ADR-0047 §2 rev 2026-05-20,
+//!   the hold contract from iamacoffeepot/aether#1031 guarantees the
+//!   counter never transiently zeroes with work still coming). A
+//!   per-`Call` timeout bounds a never-settling cap.
+//!
+//! The cap wraps the executor and forwards: `submit` → [`Executor::submit`],
+//! source/`Call` reply landings → [`Executor::on_reply`], `Settled`
+//! notifications → [`Executor::on_settled`], `aether.dag.cancel` →
+//! [`Executor::cancel`], `aether.dag.status` → [`Executor::status`],
+//! and the reaping tick → [`Executor::reap`].
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use aether_data::canonical::canonical_kind_bytes;
+use aether_data::{DagId, HandleId, KindId, MailId, MailboxId, Ref, SchemaType, Tag, with_tag};
+use aether_kinds::{
+    Bundle, BundleElement, CancelResult, DagDescriptor, Node, NodeId, StatusResult, trace::Settled,
+};
+
+use crate::actor::native::NativeCtx;
+use crate::dag::state::{CallBuffer, DagState, DagStatus};
+use crate::dag::validator::validate;
+use crate::handle_store::HandleStore;
+use crate::mail::mailer::Mailer;
+use crate::mail::registry::Registry;
+
+use std::env;
+use std::sync::Arc;
+
+const TARGET: &str = "aether::dag::executor";
+
+/// Env override for the completed-DAG retention window (ADR-0047 §7).
+/// Default [`DEFAULT_RETENTION_COMPLETE_MS`].
+pub const ENV_RETENTION_COMPLETE_MS: &str = "AETHER_DAG_RETENTION_COMPLETE_MS";
+/// Env override for the failed-DAG retention window (ADR-0047 §7).
+/// Default [`DEFAULT_RETENTION_FAILED_MS`].
+pub const ENV_RETENTION_FAILED_MS: &str = "AETHER_DAG_RETENTION_FAILED_MS";
+/// Env override for the per-`Call` settlement timeout (ADR-0047 §4 —
+/// never-settling caps). Default [`DEFAULT_CALL_TIMEOUT_MS`].
+pub const ENV_CALL_TIMEOUT_MS: &str = "AETHER_DAG_CALL_TIMEOUT_MS";
+
+/// Default completed-DAG retention before reaping (ADR-0047 §7).
+pub const DEFAULT_RETENTION_COMPLETE_MS: u64 = 60_000;
+/// Default failed-DAG retention before reaping (ADR-0047 §7).
+pub const DEFAULT_RETENTION_FAILED_MS: u64 = 300_000;
+/// Default per-`Call` settlement timeout — bounds a cap that never
+/// settles (never replies or streams forever). On expiry the `Call`
+/// node fails (ADR-0047 §4).
+pub const DEFAULT_CALL_TIMEOUT_MS: u64 = 30_000;
+
+/// What a landed reply correlates to (ADR-0047 §4). Sources resolve a
+/// stored handle and flush downstream; `Call`s accumulate into a
+/// bundle that closes on settlement.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum NodeRole {
+    Source,
+    Call,
+}
+
+/// One outstanding reply correlation the executor is waiting on.
+#[derive(Copy, Clone, Debug)]
+struct Pending {
+    dag_id: DagId,
+    node_id: NodeId,
+    handle_id: HandleId,
+    role: NodeRole,
+}
+
+/// One in-flight `Call` awaiting settlement, for the per-`Call` timeout
+/// sweep (ADR-0047 §4 never-settling caps).
+#[derive(Copy, Clone, Debug)]
+struct InFlightCall {
+    dag_id: DagId,
+    node_id: NodeId,
+    deadline: Instant,
+}
+
+/// The DAG executor. Holds every live + recently-terminal DAG plus the
+/// reply-correlation table the cap routes landings through.
+pub struct Executor {
+    mailer: Arc<Mailer>,
+    self_mailbox: MailboxId,
+    /// Monotonic per-substrate counter behind every minted [`DagId`].
+    next_dag: u64,
+    /// Live + recently-terminal DAGs, keyed by id.
+    dags: HashMap<DagId, DagState>,
+    /// Reply-correlation table: the correlation minted on a source /
+    /// `Call` dispatch maps back to the node it resolves.
+    pending: HashMap<u64, Pending>,
+    /// In-flight `Call`s with a settlement deadline, swept by [`Self::reap`].
+    in_flight_calls: HashMap<u64, InFlightCall>,
+    /// Cached per-`Call` settlement timeout.
+    call_timeout: Duration,
+    /// Cached completed-DAG retention window.
+    retention_complete: Duration,
+    /// Cached failed/cancelled-DAG retention window.
+    retention_failed: Duration,
+}
+
+impl Executor {
+    /// Build a fresh executor bound to the cap's `Arc<Mailer>` + own
+    /// mailbox id. Reads the retention / timeout env knobs once.
+    #[must_use]
+    pub fn new(mailer: Arc<Mailer>, self_mailbox: MailboxId) -> Self {
+        Self {
+            mailer,
+            self_mailbox,
+            next_dag: 1,
+            dags: HashMap::new(),
+            pending: HashMap::new(),
+            in_flight_calls: HashMap::new(),
+            call_timeout: Duration::from_millis(parse_env_u64(
+                ENV_CALL_TIMEOUT_MS,
+                DEFAULT_CALL_TIMEOUT_MS,
+            )),
+            retention_complete: Duration::from_millis(parse_env_u64(
+                ENV_RETENTION_COMPLETE_MS,
+                DEFAULT_RETENTION_COMPLETE_MS,
+            )),
+            retention_failed: Duration::from_millis(parse_env_u64(
+                ENV_RETENTION_FAILED_MS,
+                DEFAULT_RETENTION_FAILED_MS,
+            )),
+        }
+    }
+
+    /// Borrow the handle store the executor publishes resolved values
+    /// into. Sourced from the cap's `Arc<Mailer>`.
+    fn store(&self) -> &Arc<HandleStore> {
+        self.mailer.handle_store()
+    }
+
+    /// Mint the next [`DagId`] (ADR-0047 §4: monotonic-per-substrate
+    /// with the `Tag::Dag` discriminator).
+    fn mint_dag_id(&mut self) -> DagId {
+        let counter = self.next_dag;
+        self.next_dag = self.next_dag.wrapping_add(1);
+        if self.next_dag == 0 {
+            self.next_dag = 1;
+        }
+        DagId(with_tag(Tag::Dag, counter))
+    }
+
+    /// Submit one DAG. Validates synchronously (ADR-0047 §1/§3); on
+    /// success mints the [`DagId`], allocates one handle per node,
+    /// kicks off source dispatch + eager observer dispatch + zero-input
+    /// `Call` dispatch, and returns the `(dag_id, output_handles)`. On a
+    /// validation failure returns the structured [`DagError`] and
+    /// dispatches nothing.
+    ///
+    /// The returned [`SubmitOutcome`] is the wire `SubmitResult` shape;
+    /// the cap replies it verbatim.
+    ///
+    /// Takes the descriptor by value — the cap owns it off the decoded
+    /// `Submit` mail and the validator clones it into the `ValidatedDag`
+    /// it hands back, so owning here keeps the call site clean.
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn submit(&mut self, ctx: &mut NativeCtx<'_>, descriptor: DagDescriptor) -> SubmitOutcome {
+        let validated = {
+            let registry = self.mailer.registry();
+            let caps = self.mailer.capability_registry();
+            match validate(&descriptor, registry, caps) {
+                Ok(v) => v,
+                Err(error) => return SubmitOutcome::Err { error },
+            }
+        };
+
+        let dag_id = self.mint_dag_id();
+
+        // Allocate one ephemeral handle per node, holding a ref on
+        // behalf of the DAG (ADR-0047 §1: handle ids available before
+        // sources dispatch). Released on reaping / cancellation.
+        let mut handles: HashMap<NodeId, HandleId> = HashMap::new();
+        for node in &validated.descriptor.nodes {
+            let id = self.store().next_ephemeral();
+            self.store().inc_ref(id);
+            handles.insert(node.id(), id);
+        }
+
+        let output_handles = {
+            let state = DagState::new(dag_id, validated, handles);
+            let outputs = state.output_handles();
+            self.dags.insert(dag_id, state);
+            outputs
+        };
+
+        // Begin execution. Order: sources first (so a zero-input `Call`
+        // or observer with already-resolved inputs sees them), then
+        // observers (park), then `Call`s (gate / dispatch if no inputs).
+        self.dispatch_sources(ctx, dag_id);
+        self.dispatch_observers(ctx, dag_id);
+        self.dispatch_ready_calls(ctx, dag_id);
+
+        SubmitOutcome::Ok {
+            dag_id,
+            output_handles,
+        }
+    }
+
+    /// Dispatch every `Source` node of `dag_id`: send its opaque payload
+    /// to its mailbox with reply correlation routed back here, and stash
+    /// the correlation so the reply resolves the source's handle.
+    fn dispatch_sources(&mut self, ctx: &mut NativeCtx<'_>, dag_id: DagId) {
+        let Some(state) = self.dags.get(&dag_id) else {
+            return;
+        };
+        let sources: Vec<(NodeId, MailboxId, KindId, Vec<u8>, HandleId)> = state
+            .descriptor
+            .nodes
+            .iter()
+            .filter_map(|n| match n {
+                Node::Source {
+                    id,
+                    mailbox,
+                    kind_id,
+                    payload,
+                } => state
+                    .handles
+                    .get(id)
+                    .map(|h| (*id, *mailbox, *kind_id, payload.clone(), *h)),
+                _ => None,
+            })
+            .collect();
+        for (node_id, mailbox, kind_id, payload, handle_id) in sources {
+            // Inherited send (the submit chain) — the reply routes back
+            // to this cap via the ReplyTarget::Component tag the binding
+            // stamps. The minted MailId's correlation keys the table.
+            let mail_id = ctx.send_envelope_traced(mailbox, kind_id, &payload);
+            self.pending.insert(
+                mail_id.correlation_id,
+                Pending {
+                    dag_id,
+                    node_id,
+                    handle_id,
+                    role: NodeRole::Source,
+                },
+            );
+        }
+    }
+
+    /// Dispatch every `Observer` node of `dag_id` eagerly with
+    /// `Ref::Handle` slots. The substrate parking table gates them: the
+    /// mail parks until every input handle resolves, then re-routes and
+    /// dispatches to the observer's recipient with the resolved values
+    /// spliced inline.
+    fn dispatch_observers(&mut self, ctx: &mut NativeCtx<'_>, dag_id: DagId) {
+        let registry = Arc::clone(self.mailer.registry());
+        let Some(state) = self.dags.get(&dag_id) else {
+            return;
+        };
+        // Collect `(node_id, recipient, kind_id, payload, has_inputs)`.
+        // `has_inputs` distinguishes a gated observer (parks until its
+        // sources resolve) from a degenerate zero-input observer that
+        // dispatches at once and is marked resolved here.
+        let observers: Vec<(NodeId, MailboxId, KindId, Vec<u8>, bool)> = state
+            .descriptor
+            .nodes
+            .iter()
+            .filter_map(|n| match n {
+                Node::Observer {
+                    id,
+                    recipient,
+                    kind_id,
+                } => {
+                    let has_inputs = state.descriptor.edges.iter().any(|e| e.to == *id);
+                    assemble_request(state, &registry, *id, *kind_id)
+                        .map(|p| (*id, *recipient, *kind_id, p, has_inputs))
+                }
+                _ => None,
+            })
+            .collect();
+        for (node_id, recipient, kind_id, payload, has_inputs) in observers {
+            // The eager dispatch is the executor's own chain — observer
+            // mail rides on the submit chain via the inherited path. A
+            // gated observer parks on its first unresolved input handle.
+            let _ = ctx.send_envelope_traced(recipient, kind_id, &payload);
+            if !has_inputs {
+                // A zero-input observer dispatches immediately and is
+                // terminal-resolved right away — no source ever resolves
+                // it via `resolve_node`.
+                if let Some(state) = self.dags.get_mut(&dag_id) {
+                    state.mark_resolved(node_id);
+                }
+            }
+        }
+    }
+
+    /// Dispatch every `Call` node of `dag_id` whose inputs are already
+    /// resolved (`pending_inputs == 0`). At submit only zero-input calls
+    /// fire here; downstream calls fire from [`Self::on_reply`] as their
+    /// inputs land.
+    fn dispatch_ready_calls(&mut self, ctx: &mut NativeCtx<'_>, dag_id: DagId) {
+        let ready: Vec<NodeId> = {
+            let Some(state) = self.dags.get(&dag_id) else {
+                return;
+            };
+            state
+                .descriptor
+                .nodes
+                .iter()
+                .filter_map(|n| match n {
+                    Node::Call { id, .. } => {
+                        (state.pending_inputs.get(id).copied().unwrap_or(0) == 0
+                            && !state.resolved.contains(id))
+                        .then_some(*id)
+                    }
+                    _ => None,
+                })
+                .collect()
+        };
+        for node_id in ready {
+            self.dispatch_call(ctx, dag_id, node_id);
+        }
+    }
+
+    /// Dispatch one `Call` node as its own causal root (ADR-0047 §4 step
+    /// 2). Assembles the request from resolved input handles, sends via
+    /// `send_envelope_as_root` (mints `call_root`), subscribes
+    /// `Settled { call_root }`, and opens an accumulation buffer keyed
+    /// on the call's correlation. A no-input call dispatches an empty
+    /// request.
+    fn dispatch_call(&mut self, ctx: &mut NativeCtx<'_>, dag_id: DagId, node_id: NodeId) {
+        let registry = Arc::clone(self.mailer.registry());
+        let Some(state) = self.dags.get_mut(&dag_id) else {
+            return;
+        };
+        if state.status.is_terminal() {
+            return;
+        }
+        // Already dispatched? (a re-entrant input landing). The buffer
+        // keyed on this node guards against double-dispatch via the
+        // resolved set below.
+        let Some((recipient, kind_id)) = state.descriptor.nodes.iter().find_map(|n| match n {
+            Node::Call {
+                id,
+                recipient,
+                kind_id,
+            } if *id == node_id => Some((*recipient, *kind_id)),
+            _ => None,
+        }) else {
+            return;
+        };
+        let Some(payload) = assemble_request(state, &registry, node_id, kind_id) else {
+            // Missing handle assignment is a substrate invariant
+            // violation — fail the node rather than dispatch a malformed
+            // request.
+            state.mark_failed(node_id, "call request assembly failed".to_owned());
+            return;
+        };
+
+        // Dispatch as a fresh causal root so settlement scopes to this
+        // call, not the whole DAG (ADR-0047 §2 per-Call root).
+        let call_root: MailId = ctx.send_envelope_as_root(recipient, kind_id, &payload);
+
+        // Open the accumulation buffer + register the in-flight call.
+        let dag_id_copy = dag_id;
+        self.pending.insert(
+            call_root.correlation_id,
+            Pending {
+                dag_id: dag_id_copy,
+                node_id,
+                handle_id: *state.handles.get(&node_id).unwrap_or(&HandleId(0)),
+                role: NodeRole::Call,
+            },
+        );
+        if let Some(state) = self.dags.get_mut(&dag_id) {
+            state.call_buffers.insert(
+                call_root.correlation_id,
+                CallBuffer {
+                    node_id,
+                    elements: Vec::new(),
+                },
+            );
+        }
+        self.in_flight_calls.insert(
+            call_root.correlation_id,
+            InFlightCall {
+                dag_id,
+                node_id,
+                deadline: Instant::now() + self.call_timeout,
+            },
+        );
+
+        // Subscribe to settlement of the call's chain. The chassis
+        // settlement registry pushes a `Settled { call_root }` mail back
+        // at this cap when the chain quiesces (ADR-0047 §4 step 4). On a
+        // chassis with no registry the bundle can't close on settlement;
+        // the per-Call timeout still bounds it.
+        if let Some(reg) = self.mailer.settlement_registry() {
+            reg.subscribe_settlement_mail(
+                call_root,
+                self.self_mailbox,
+                <Settled as aether_data::Kind>::ID,
+                Arc::clone(&self.mailer),
+            );
+        } else {
+            tracing::warn!(
+                target: TARGET,
+                "no settlement registry on this chassis; Call bundles close only on timeout",
+            );
+        }
+    }
+
+    /// A source / `Call` reply landed on the cap's mailbox. `correlation`
+    /// is the reply envelope's correlation id; `kind` / `payload` are
+    /// the reply's. Returns `true` when the correlation matched a
+    /// pending dispatch (so the cap suppresses the fallback warn).
+    ///
+    /// A source reply resolves the source's handle (publishing the
+    /// reply bytes into the store + flushing parked observers) and
+    /// decrements downstream `Call` input counters. A `Call` reply
+    /// appends to the call's accumulation buffer; the buffer closes
+    /// later on `Settled`.
+    pub fn on_reply(
+        &mut self,
+        ctx: &mut NativeCtx<'_>,
+        correlation: u64,
+        kind: KindId,
+        payload: &[u8],
+    ) -> bool {
+        let Some(pending) = self.pending.get(&correlation).copied() else {
+            return false;
+        };
+
+        match pending.role {
+            NodeRole::Source => {
+                // Single-reply node: consume the correlation.
+                self.pending.remove(&correlation);
+                self.resolve_node(ctx, pending.dag_id, pending.node_id, pending.handle_id, kind, payload);
+                true
+            }
+            NodeRole::Call => {
+                // Multi-reply: keep the correlation until settlement.
+                if let Some(state) = self.dags.get_mut(&pending.dag_id)
+                    && let Some(buf) = state.call_buffers.get_mut(&correlation)
+                {
+                    buf.elements.push((kind, payload.to_vec()));
+                }
+                true
+            }
+        }
+    }
+
+    /// Resolve one source node's output handle: publish the reply bytes
+    /// under the node's handle (so the parking-table walk splices them
+    /// into downstream observer / call requests), flush parked mail,
+    /// mark the node resolved, and decrement / dispatch downstream
+    /// `Call`s whose last input just landed.
+    fn resolve_node(
+        &mut self,
+        ctx: &mut NativeCtx<'_>,
+        dag_id: DagId,
+        node_id: NodeId,
+        handle_id: HandleId,
+        kind: KindId,
+        payload: &[u8],
+    ) {
+        // Drop late replies for a cancelled / completed DAG.
+        let Some(state) = self.dags.get(&dag_id) else {
+            return;
+        };
+        if state.status.is_terminal() {
+            return;
+        }
+
+        // Publish + flush parked observer mail. `resolve_handle` puts the
+        // bytes then re-routes everything parked on this handle.
+        if let Err(e) = self
+            .mailer
+            .resolve_handle(handle_id, kind, payload.to_vec())
+        {
+            tracing::warn!(
+                target: TARGET,
+                error = ?e,
+                ?node_id,
+                "failed to resolve source handle; downstream consumers stay parked",
+            );
+        }
+
+        if let Some(state) = self.dags.get_mut(&dag_id) {
+            state.mark_resolved(node_id);
+        }
+
+        // Decrement downstream `Call` inputs; mark downstream observers
+        // resolved once every input handle they consume has landed (the
+        // parked observer mail un-parks and dispatches at that point);
+        // collect `Call`s now ready to dispatch.
+        let newly_ready: Vec<NodeId> = {
+            let Some(state) = self.dags.get_mut(&dag_id) else {
+                return;
+            };
+            let consumers: Vec<NodeId> = state
+                .descriptor
+                .edges
+                .iter()
+                .filter(|e| e.from == node_id)
+                .map(|e| e.to)
+                .collect();
+            let mut ready = Vec::new();
+            let mut observers_done = Vec::new();
+            for consumer in consumers {
+                // `Call` consumers gate on the explicit counter.
+                if let Some(remaining) = state.pending_inputs.get_mut(&consumer) {
+                    *remaining = remaining.saturating_sub(1);
+                    if *remaining == 0 && !state.resolved.contains(&consumer) {
+                        ready.push(consumer);
+                    }
+                    continue;
+                }
+                // Observer consumers gate through the parking table; mark
+                // resolved once every source feeding the observer's slots
+                // is resolved (so its mail has un-parked).
+                let is_observer = state
+                    .descriptor
+                    .nodes
+                    .iter()
+                    .any(|n| n.id() == consumer && matches!(n, Node::Observer { .. }));
+                if is_observer && !state.resolved.contains(&consumer) {
+                    let all_inputs_resolved = state
+                        .descriptor
+                        .edges
+                        .iter()
+                        .filter(|e| e.to == consumer)
+                        .all(|e| state.resolved.contains(&e.from));
+                    if all_inputs_resolved {
+                        observers_done.push(consumer);
+                    }
+                }
+            }
+            for observer in observers_done {
+                state.mark_resolved(observer);
+            }
+            ready
+        };
+        for call in newly_ready {
+            self.dispatch_call(ctx, dag_id, call);
+        }
+    }
+
+    /// A `Settled { call_root }` notification landed (ADR-0047 §4 step
+    /// 4). Close the call's bundle: drain the accumulation buffer into
+    /// the call's `Bundle` handle, mark the call resolved, flush
+    /// downstream consumers, and dispatch any downstream `Call`s whose
+    /// last input just landed. Returns `true` if the root matched an
+    /// in-flight call.
+    pub fn on_settled(&mut self, ctx: &mut NativeCtx<'_>, call_root: MailId) -> bool {
+        let correlation = call_root.correlation_id;
+        let Some(pending) = self.pending.remove(&correlation) else {
+            return false;
+        };
+        self.in_flight_calls.remove(&correlation);
+
+        let (node_id, handle_id, elements) = {
+            let Some(state) = self.dags.get_mut(&pending.dag_id) else {
+                return true;
+            };
+            if state.status.is_terminal() {
+                state.call_buffers.remove(&correlation);
+                return true;
+            }
+            let Some(buf) = state.call_buffers.remove(&correlation) else {
+                return true;
+            };
+            (pending.node_id, pending.handle_id, buf.elements)
+        };
+        let _ = node_id;
+
+        // Build the ordered, self-describing Bundle from the accumulated
+        // replies and resolve the call's handle to it.
+        let bundle = Bundle {
+            elements: elements
+                .into_iter()
+                .map(|(kind_id, payload)| BundleElement { kind_id, payload })
+                .collect(),
+        };
+        let bundle_bytes = <Bundle as aether_data::Kind>::encode_into_bytes(&bundle);
+        self.resolve_node(
+            ctx,
+            pending.dag_id,
+            pending.node_id,
+            handle_id,
+            <Bundle as aether_data::Kind>::ID,
+            &bundle_bytes,
+        );
+        true
+    }
+
+    /// Cancel a DAG (ADR-0047 §5). Marks it cancelled, drops every
+    /// parked mail on the DAG's handles, releases the executor's refs,
+    /// and drops outstanding reply correlations + settlement
+    /// subscriptions for the DAG so late replies / `Settled` are no-ops.
+    /// Replies `Ok { cancelled: true }` for a live DAG, `Ok { cancelled:
+    /// false }` for one that already completed, `Err` for an unknown id.
+    pub fn cancel(&mut self, dag_id: DagId) -> CancelResult {
+        let Some(state) = self.dags.get_mut(&dag_id) else {
+            return CancelResult::Err {
+                error: format!("unknown dag {dag_id}"),
+            };
+        };
+        if state.status.is_terminal() {
+            return CancelResult::Ok { cancelled: false };
+        }
+        state.mark_cancelled();
+
+        // Drop parked mail + release refs on every handle the DAG owns.
+        let handle_ids: Vec<HandleId> = state.handles.values().copied().collect();
+        for id in &handle_ids {
+            let _ = self.store().take_parked(*id);
+            self.store().dec_ref(*id);
+        }
+        // Drop the DAG's reply correlations + in-flight call entries so a
+        // late source reply / `Settled` finds no entry and is a no-op.
+        self.pending.retain(|_, p| p.dag_id != dag_id);
+        self.in_flight_calls.retain(|_, c| c.dag_id != dag_id);
+        if let Some(state) = self.dags.get_mut(&dag_id) {
+            state.call_buffers.clear();
+        }
+
+        CancelResult::Ok { cancelled: true }
+    }
+
+    /// Query a DAG's status (ADR-0047 §1/§6). Returns the wire
+    /// `StatusResult` for a known DAG, or `None` for an unknown id (the
+    /// cap maps `None` to its `UnknownDag` reply shape).
+    #[must_use]
+    pub fn status(&self, dag_id: DagId) -> Option<StatusResult> {
+        self.dags.get(&dag_id).map(DagState::status_result)
+    }
+
+    /// The reaping tick (ADR-0047 §7). Sweeps terminal DAGs whose
+    /// `completed_at` is past retention (separate windows for completed
+    /// vs failed / cancelled), and times out in-flight `Call`s whose
+    /// settlement deadline has passed (failing the node — a never-
+    /// settling cap is a node failure, not a partial bundle). Returns
+    /// the number of DAGs reaped.
+    pub fn reap(&mut self) -> usize {
+        let now = Instant::now();
+
+        // Time out in-flight calls past their deadline.
+        let timed_out: Vec<(u64, DagId, NodeId)> = self
+            .in_flight_calls
+            .iter()
+            .filter(|(_, c)| now >= c.deadline)
+            .map(|(corr, c)| (*corr, c.dag_id, c.node_id))
+            .collect();
+        for (correlation, dag_id, node_id) in timed_out {
+            self.in_flight_calls.remove(&correlation);
+            self.pending.remove(&correlation);
+            if let Some(state) = self.dags.get_mut(&dag_id) {
+                state.call_buffers.remove(&correlation);
+                state.mark_failed(
+                    node_id,
+                    "call timed out waiting for settlement".to_owned(),
+                );
+            }
+        }
+
+        // Sweep terminal DAGs past retention.
+        let reapable: Vec<DagId> = self
+            .dags
+            .iter()
+            .filter(|(_, state)| {
+                let Some(at) = state.completed_at else {
+                    return false;
+                };
+                let window = match &state.status {
+                    DagStatus::Complete => self.retention_complete,
+                    DagStatus::Failed { .. } | DagStatus::Cancelled => self.retention_failed,
+                    DagStatus::Pending | DagStatus::Running => return false,
+                };
+                now.duration_since(at) >= window
+            })
+            .map(|(id, _)| *id)
+            .collect();
+        let reaped = reapable.len();
+        for dag_id in reapable {
+            if let Some(state) = self.dags.remove(&dag_id) {
+                // Release the executor's refs on the DAG's handles. The
+                // entries evict per the global LRU once refcount hits
+                // zero (Phase 1 semantics).
+                for id in state.handles.values() {
+                    self.store().dec_ref(*id);
+                }
+                self.pending.retain(|_, p| p.dag_id != dag_id);
+                self.in_flight_calls.retain(|_, c| c.dag_id != dag_id);
+            }
+        }
+        reaped
+    }
+
+    /// Count of live + recently-terminal DAGs. Test introspection.
+    #[must_use]
+    pub fn dag_count(&self) -> usize {
+        self.dags.len()
+    }
+}
+
+/// Wire-shaped submit outcome — the cap replies it as
+/// [`aether_kinds::SubmitResult`] verbatim.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SubmitOutcome {
+    Ok {
+        dag_id: DagId,
+        output_handles: Vec<aether_kinds::NodeHandle>,
+    },
+    Err {
+        error: aether_kinds::DagError,
+    },
+}
+
+/// Assemble an observer / `Call` request payload for `consumer` from the
+/// DAG's handle assignment: every `Ref<K>` slot of the consumer's
+/// request schema (in declaration order) is filled with a
+/// `Ref::Handle { id, kind_id }` pointing at the upstream node feeding
+/// that slot. Returns `None` if the consumer's kind isn't registered or
+/// an edge references a node with no handle assignment.
+///
+/// The slot → upstream-node mapping comes from the descriptor edges: an
+/// edge `{ from, to: consumer, slot }` says slot `slot` is fed by
+/// `from`'s output handle. The walk-and-resolve path
+/// ([`crate::handle_store::walk_and_resolve`]) substitutes each handle's
+/// stored bytes inline when the mail dispatches (or parks until they
+/// resolve).
+///
+/// `registry` is the routing registry the consumer's request schema is
+/// resolved against (the executor passes `self.mailer.registry()`).
+fn assemble_request(
+    state: &DagState,
+    registry: &Registry,
+    consumer: NodeId,
+    kind_id: KindId,
+) -> Option<Vec<u8>> {
+    // Resolve the consumer's request schema: the registered descriptor
+    // for `kind_id`, which must be a struct of `Ref<K>` fields.
+    let descriptor = registry.kind_descriptor(kind_id)?;
+    let SchemaType::Struct { fields, .. } = &descriptor.schema else {
+        return None;
+    };
+    // The declared inner kind id of each `Ref<K>` slot, in declaration
+    // order — emitted onto the wire `Ref::Handle.kind_id`.
+    let ref_slot_kinds: Vec<KindId> = fields
+        .iter()
+        .filter_map(|f| match &f.ty {
+            SchemaType::Ref(cell) => Some(slot_inner_kind_id(registry, cell)),
+            _ => None,
+        })
+        .collect();
+
+    // Map slot index -> the upstream node feeding it.
+    let mut slot_source: HashMap<u32, NodeId> = HashMap::new();
+    for edge in &state.descriptor.edges {
+        if edge.to == consumer {
+            slot_source.insert(edge.slot, edge.from);
+        }
+    }
+
+    let mut out: Vec<u8> = Vec::new();
+    for (slot_index, expected_kind) in ref_slot_kinds.iter().enumerate() {
+        let slot = u32::try_from(slot_index).unwrap_or(u32::MAX);
+        let from = slot_source.get(&slot)?;
+        let handle = *state.handles.get(from)?;
+        // The Handle variant carries no `K`, so any marker type works —
+        // emit the wire `Ref::Handle { id, kind_id }`. The walk-and-
+        // resolve path validates against the *field's* expected type at
+        // dispatch, splicing the stored bytes inline (or parking).
+        let r: Ref<u8> = Ref::Handle {
+            id: handle.0,
+            kind_id: expected_kind.0,
+        };
+        let mut field_bytes = postcard::to_allocvec(&r).ok()?;
+        out.append(&mut field_bytes);
+    }
+    Some(out)
+}
+
+/// The declared inner kind id of a `Ref<K>` slot. The schema cell
+/// carries `K`'s schema; look up its registered kind id so the emitted
+/// `Ref::Handle.kind_id` matches what the consumer declared. Falls back
+/// to `KindId(0)` when no registered kind matches — the walk-and-resolve
+/// path validates against the *field's* expected type, not this id, so a
+/// fallback id still resolves for the common case where the producer's
+/// stored kind equals the slot type.
+fn slot_inner_kind_id(registry: &Registry, cell: &aether_data::SchemaCell) -> KindId {
+    let inner: &SchemaType = cell;
+    let target = canonical_kind_bytes("", inner);
+    registry
+        .list_kind_descriptors()
+        .into_iter()
+        .find(|d| canonical_kind_bytes("", &d.schema) == target)
+        .map_or(KindId(0), |d| {
+            registry.kind_id(&d.name).unwrap_or(KindId(0))
+        })
+}
+
+/// Parse a `u64` env var, warning + falling back on a malformed value
+/// (same shape as the validator's parser).
+#[allow(clippy::option_if_let_else)]
+fn parse_env_u64(name: &str, default: u64) -> u64 {
+    match env::var(name) {
+        Ok(raw) => match raw.parse::<u64>() {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(
+                    target: TARGET,
+                    env = name,
+                    value = %raw,
+                    error = %e,
+                    default,
+                    "ignoring unparseable DAG env var; using default",
+                );
+                default
+            }
+        },
+        Err(_) => default,
+    }
+}

--- a/crates/aether-substrate/src/dag/executor.rs
+++ b/crates/aether-substrate/src/dag/executor.rs
@@ -18,10 +18,10 @@
 //!   source's handle in the [`HandleStore`].
 //! - **Observers** dispatch *eagerly* at submit with `Ref::Handle`
 //!   slots into their input handle ids. The substrate's parking table
-//!   ([`HandleStore::park`] via [`crate::mail::Mailer::push`]) gates
-//!   them: the mail parks on the first unresolved handle and re-routes
-//!   when [`crate::mail::Mailer::resolve_handle`] flushes it — so a
-//!   multi-input observer naturally waits for every slot.
+//!   ([`HandleStore::park`] via [`Mailer::push`]) gates them: the mail
+//!   parks on the first unresolved handle and re-routes when
+//!   [`Mailer::resolve_handle`] flushes it — so a multi-input observer
+//!   naturally waits for every slot.
 //! - **`Call`s** gate on an explicit `pending_inputs` counter rather
 //!   than the parking table: a `Call` must dispatch as *its own causal
 //!   root* (`send_envelope_as_root`) so the executor can subscribe to

--- a/crates/aether-substrate/src/dag/executor.rs
+++ b/crates/aether-substrate/src/dag/executor.rs
@@ -335,11 +335,10 @@ impl Executor {
                 .nodes
                 .iter()
                 .filter_map(|n| match n {
-                    Node::Call { id, .. } => {
-                        (state.pending_inputs.get(id).copied().unwrap_or(0) == 0
-                            && !state.resolved.contains(id))
-                        .then_some(*id)
-                    }
+                    Node::Call { id, .. } => (state.pending_inputs.get(id).copied().unwrap_or(0)
+                        == 0
+                        && !state.resolved.contains(id))
+                    .then_some(*id),
                     _ => None,
                 })
                 .collect()
@@ -462,7 +461,14 @@ impl Executor {
             NodeRole::Source => {
                 // Single-reply node: consume the correlation.
                 self.pending.remove(&correlation);
-                self.resolve_node(ctx, pending.dag_id, pending.node_id, pending.handle_id, kind, payload);
+                self.resolve_node(
+                    ctx,
+                    pending.dag_id,
+                    pending.node_id,
+                    pending.handle_id,
+                    kind,
+                    payload,
+                );
                 true
             }
             NodeRole::Call => {
@@ -684,10 +690,7 @@ impl Executor {
             self.pending.remove(&correlation);
             if let Some(state) = self.dags.get_mut(&dag_id) {
                 state.call_buffers.remove(&correlation);
-                state.mark_failed(
-                    node_id,
-                    "call timed out waiting for settlement".to_owned(),
-                );
+                state.mark_failed(node_id, "call timed out waiting for settlement".to_owned());
             }
         }
 

--- a/crates/aether-substrate/src/dag/executor.rs
+++ b/crates/aether-substrate/src/dag/executor.rs
@@ -252,10 +252,14 @@ impl Executor {
             })
             .collect();
         for (node_id, mailbox, kind_id, payload, handle_id) in sources {
-            // Inherited send (the submit chain) — the reply routes back
-            // to this cap via the ReplyTarget::Component tag the binding
-            // stamps. The minted MailId's correlation keys the table.
-            let mail_id = ctx.send_envelope_traced(mailbox, kind_id, &payload);
+            // Dispatch as the source's own causal root — NOT inheriting
+            // the submit chain (ADR-0047 §1: sources dispatch async
+            // *after* the submit ack, so the submit reply settles
+            // independently of the DAG's execution). The reply still
+            // routes back to this cap via the ReplyTarget::Component tag
+            // the binding stamps; the minted MailId's correlation keys
+            // the table.
+            let mail_id = ctx.send_envelope_as_root(mailbox, kind_id, &payload);
             self.pending.insert(
                 mail_id.correlation_id,
                 Pending {
@@ -300,10 +304,12 @@ impl Executor {
             })
             .collect();
         for (node_id, recipient, kind_id, payload, has_inputs) in observers {
-            // The eager dispatch is the executor's own chain — observer
-            // mail rides on the submit chain via the inherited path. A
-            // gated observer parks on its first unresolved input handle.
-            let _ = ctx.send_envelope_traced(recipient, kind_id, &payload);
+            // Dispatch as the observer's own causal root — NOT inheriting
+            // the submit chain. A gated observer parks on its first
+            // unresolved input handle; parked mail would otherwise hold
+            // the submit chain's `in_flight` non-zero forever and the
+            // submit ack would never settle (ADR-0047 §1 async execution).
+            let _ = ctx.send_envelope_as_root(recipient, kind_id, &payload);
             if !has_inputs {
                 // A zero-input observer dispatches immediately and is
                 // terminal-resolved right away — no source ever resolves

--- a/crates/aether-substrate/src/dag/mod.rs
+++ b/crates/aether-substrate/src/dag/mod.rs
@@ -10,8 +10,12 @@
 //! three-phase submit-path check that turns a descriptor into a
 //! topologically-sorted [`ValidatedDag`](validator::ValidatedDag) the
 //! executor can dispatch from directly, or a structured
-//! [`DagError`](aether_kinds::DagError) on the first rule violation. The
-//! executor (iamacoffeepot/aether#976) and its `DagState` land as
-//! sibling modules here.
+//! [`DagError`](aether_kinds::DagError) on the first rule violation; the
+//! [`executor`] (iamacoffeepot/aether#976) that drives a validated DAG
+//! to completion (source dispatch, observer parking, `Call`
+//! collect-and-settle, cancellation, reaping); and its per-DAG
+//! [`state`].
 
+pub mod executor;
+pub mod state;
 pub mod validator;

--- a/crates/aether-substrate/src/dag/state.rs
+++ b/crates/aether-substrate/src/dag/state.rs
@@ -1,0 +1,251 @@
+//! ADR-0047 §4 per-DAG executor state (iamacoffeepot/aether#976).
+//!
+//! [`DagState`] is the executor's bookkeeping for one submitted,
+//! validated DAG: the topologically-ordered node list, the per-node
+//! handle-id assignment minted at submit time, the per-`Call` input
+//! gating counters, the resolved-node set that drives `status`, and
+//! the lifecycle status itself. One [`DagState`] is created per
+//! `aether.dag.submit` and lives in the executor cap's single-threaded
+//! actor state until it's reaped (ADR-0047 §7).
+//!
+//! The executor ([`super::executor`]) drives transitions; this module
+//! holds only the data + the small derived queries (`status_result`,
+//! `is_terminal`) that both the executor and the `aether.dag.status`
+//! handler read.
+
+use std::collections::{HashMap, HashSet};
+use std::time::Instant;
+
+use aether_data::{DagId, HandleId};
+use aether_kinds::{
+    DagDescriptor, Node, NodeHandle, NodeId, NodeState, NodeStatus, StatusResult,
+};
+
+use crate::dag::validator::ValidatedDag;
+
+/// Lifecycle status of one submitted DAG (ADR-0047 §6). `Cancelled`
+/// is an internal terminal state distinct from `Failed`; both surface
+/// to the wire as `StatusResult::Failed` (cancellation reports
+/// `error == "cancelled"` per ADR-0047 §5), but the executor keeps
+/// them apart so reaping can apply the right retention window.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DagStatus {
+    /// Submitted + validated; no source has resolved yet.
+    Pending,
+    /// At least one node resolved; some haven't.
+    Running,
+    /// Every node resolved.
+    Complete,
+    /// A node failed (a source/`Call` timeout, a malformed reply, or a
+    /// dispatch error). Carries the failing node + a human-readable
+    /// reason.
+    Failed { node_id: NodeId, error: String },
+    /// The DAG was cancelled (ADR-0047 §5). Surfaces to the wire as
+    /// `Failed { error: "cancelled" }`.
+    Cancelled,
+}
+
+impl DagStatus {
+    /// `true` once the DAG can no longer make progress — `Complete`,
+    /// `Failed`, or `Cancelled`. The reaping tick (ADR-0047 §7)
+    /// sweeps terminal DAGs whose `completed_at` is past retention.
+    #[must_use]
+    pub const fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            Self::Complete | Self::Failed { .. } | Self::Cancelled
+        )
+    }
+}
+
+/// One in-flight `Call` node's accumulation buffer (ADR-0047 §4 step
+/// 3). Replies correlated to the call's dispatch append here in
+/// arrival order; the buffer drains into the call's `Bundle` handle on
+/// `Settled { call_root }`.
+#[derive(Debug, Default)]
+pub struct CallBuffer {
+    /// The node this buffer belongs to.
+    pub node_id: NodeId,
+    /// Ordered `(KindId, payload_bytes)` elements — one per correlated
+    /// reply, in the cap's emission order (FIFO per sender).
+    pub elements: Vec<(aether_data::KindId, Vec<u8>)>,
+}
+
+/// Per-DAG executor state (ADR-0047 §4).
+pub struct DagState {
+    /// The substrate-minted id this DAG is addressed by.
+    pub dag_id: DagId,
+    /// The validated descriptor (owned past the submit-path borrow).
+    pub descriptor: DagDescriptor,
+    /// Topological order the executor dispatches from (Kahn's order
+    /// from the validator — never re-sorted here).
+    pub topo_order: Vec<NodeId>,
+    /// Handle id assigned to every node at submit time. Sources / calls
+    /// resolve to a stored value / `Bundle`; observers' entries are
+    /// allocated for uniformity but never resolved (observers consume).
+    pub handles: HashMap<NodeId, HandleId>,
+    /// Remaining unresolved input edges per `Call` node. Decremented as
+    /// upstream handles resolve; the call dispatches at zero (ADR-0047
+    /// §4). Observers gate through the parking table instead, so they
+    /// don't appear here.
+    pub pending_inputs: HashMap<NodeId, u32>,
+    /// Nodes whose output handle has resolved (sources / calls) or
+    /// which have been dispatched (observers). Drives the `status`
+    /// progress list + the `Complete` transition.
+    pub resolved: HashSet<NodeId>,
+    /// Per-`call_root` accumulation buffers, keyed by the correlation
+    /// id of the call's dispatch (the `call_root.correlation_id`). A
+    /// reply correlated to one of these appends; `Settled` drains it.
+    pub call_buffers: HashMap<u64, CallBuffer>,
+    /// Lifecycle status.
+    pub status: DagStatus,
+    /// When the DAG was submitted (for diagnostics + reaping age).
+    pub submitted_at: Instant,
+    /// When the DAG reached a terminal status (for reaping retention).
+    pub completed_at: Option<Instant>,
+}
+
+impl DagState {
+    /// Build the per-DAG state from a validated descriptor, minting the
+    /// per-node handle assignment + per-`Call` input counters. The
+    /// caller supplies the `dag_id` and the handle-id allocator output
+    /// (one per node, in `topo_order`) since handle allocation goes
+    /// through the shared [`crate::handle_store::HandleStore`], which
+    /// the executor owns the handle to.
+    #[must_use]
+    pub fn new(dag_id: DagId, validated: ValidatedDag, handles: HashMap<NodeId, HandleId>) -> Self {
+        let ValidatedDag {
+            descriptor,
+            topo_order,
+        } = validated;
+
+        // Per-`Call` input-edge counts gate dispatch (ADR-0047 §4). Seed
+        // every `Call` at 0 so a no-input call dispatches immediately,
+        // then bump one per incoming edge.
+        let mut pending_inputs: HashMap<NodeId, u32> = HashMap::new();
+        let call_ids: HashSet<NodeId> = descriptor
+            .nodes
+            .iter()
+            .filter(|n| matches!(n, Node::Call { .. }))
+            .map(Node::id)
+            .collect();
+        for id in &call_ids {
+            pending_inputs.insert(*id, 0);
+        }
+        for edge in &descriptor.edges {
+            if call_ids.contains(&edge.to) {
+                *pending_inputs.entry(edge.to).or_insert(0) += 1;
+            }
+        }
+
+        Self {
+            dag_id,
+            descriptor,
+            topo_order,
+            handles,
+            pending_inputs,
+            resolved: HashSet::new(),
+            call_buffers: HashMap::new(),
+            status: DagStatus::Pending,
+            submitted_at: Instant::now(),
+            completed_at: None,
+        }
+    }
+
+    /// The submit-reply output-handle list: every node's `(node_id,
+    /// handle_id)` pair, in descriptor node order (ADR-0047 §1).
+    #[must_use]
+    pub fn output_handles(&self) -> Vec<NodeHandle> {
+        self.descriptor
+            .nodes
+            .iter()
+            .filter_map(|n| {
+                self.handles.get(&n.id()).map(|h| NodeHandle {
+                    node_id: n.id(),
+                    handle_id: *h,
+                })
+            })
+            .collect()
+    }
+
+    /// Mark `node` resolved and advance the lifecycle status. Transitions
+    /// `Pending`/`Running` toward `Complete` once every node is in the
+    /// resolved set; a terminal status (already `Complete` / `Failed` /
+    /// `Cancelled`) is sticky and never regresses.
+    pub fn mark_resolved(&mut self, node: NodeId) {
+        if self.status.is_terminal() {
+            return;
+        }
+        self.resolved.insert(node);
+        if self.resolved.len() >= self.descriptor.nodes.len() {
+            self.status = DagStatus::Complete;
+            self.completed_at = Some(Instant::now());
+        } else {
+            self.status = DagStatus::Running;
+        }
+    }
+
+    /// Move the DAG to `Failed`, stamping `completed_at`. Sticky against
+    /// a prior terminal status.
+    pub fn mark_failed(&mut self, node_id: NodeId, error: String) {
+        if self.status.is_terminal() {
+            return;
+        }
+        self.status = DagStatus::Failed { node_id, error };
+        self.completed_at = Some(Instant::now());
+    }
+
+    /// Move the DAG to `Cancelled`, stamping `completed_at`. Sticky
+    /// against a prior terminal status.
+    pub fn mark_cancelled(&mut self) {
+        if self.status.is_terminal() {
+            return;
+        }
+        self.status = DagStatus::Cancelled;
+        self.completed_at = Some(Instant::now());
+    }
+
+    /// Project the internal status onto the wire `StatusResult`
+    /// (ADR-0047 §1/§6). `Cancelled` surfaces as `Failed { error:
+    /// "cancelled" }`; `Running` carries the per-node progress list.
+    #[must_use]
+    pub fn status_result(&self) -> StatusResult {
+        match &self.status {
+            DagStatus::Pending => StatusResult::Pending,
+            DagStatus::Running => StatusResult::Running {
+                progress: self.progress(),
+            },
+            DagStatus::Complete => StatusResult::Complete {
+                outputs: self.output_handles(),
+            },
+            DagStatus::Failed { node_id, error } => StatusResult::Failed {
+                node_id: *node_id,
+                error: error.clone(),
+            },
+            DagStatus::Cancelled => StatusResult::Failed {
+                node_id: NodeId(0),
+                error: "cancelled".to_owned(),
+            },
+        }
+    }
+
+    /// The per-node progress list for a `Running` status — one
+    /// [`NodeStatus`] per descriptor node, in descriptor order.
+    fn progress(&self) -> Vec<NodeStatus> {
+        self.descriptor
+            .nodes
+            .iter()
+            .map(|n| {
+                let state = if self.resolved.contains(&n.id()) {
+                    NodeState::Resolved
+                } else {
+                    NodeState::Pending
+                };
+                NodeStatus {
+                    node_id: n.id(),
+                    state,
+                }
+            })
+            .collect()
+    }
+}

--- a/crates/aether-substrate/src/dag/state.rs
+++ b/crates/aether-substrate/src/dag/state.rs
@@ -17,9 +17,7 @@ use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
 use aether_data::{DagId, HandleId};
-use aether_kinds::{
-    DagDescriptor, Node, NodeHandle, NodeId, NodeState, NodeStatus, StatusResult,
-};
+use aether_kinds::{DagDescriptor, Node, NodeHandle, NodeId, NodeState, NodeStatus, StatusResult};
 
 use crate::dag::validator::ValidatedDag;
 
@@ -51,10 +49,7 @@ impl DagStatus {
     /// sweeps terminal DAGs whose `completed_at` is past retention.
     #[must_use]
     pub const fn is_terminal(&self) -> bool {
-        matches!(
-            self,
-            Self::Complete | Self::Failed { .. } | Self::Cancelled
-        )
+        matches!(self, Self::Complete | Self::Failed { .. } | Self::Cancelled)
     }
 }
 


### PR DESCRIPTION
Implements release unit `dag-exec` of aether 0.4: the ADR-0047 §4 DAG executor and the ADR-0047 §9 MCP tool surface, on one branch.

Closes iamacoffeepot/aether#976
Closes iamacoffeepot/aether#977

## issue 976 — DAG executor (substrate)

New `aether-substrate` `dag::{state, executor}` driving a validated `DagDescriptor` to completion, plus a new `aether.dag` cap (`aether-capabilities`) wrapping it, wired into the desktop + headless chassis via `with_common_caps`.

- **Submit-time handle allocation** — one ephemeral `HandleId` per node, returned in `SubmitResult.output_handles` so downstream `Ref<K>` slots can be stamped before values resolve.
- **Source dispatch** — each source is sent to its mailbox as its own causal root with reply correlation routed back to the executor (not the submitter); the reply resolves the source's handle in the `HandleStore`.
- **Observer dispatch** — observers dispatch eagerly with `Ref::Handle` slots and gate through the substrate parking table (a multi-input observer naturally waits for every slot; un-parks when the last input resolves).
- **`Call` collect-and-close** — a `Call` gates on an explicit input counter, then dispatches as its own `call_root` via `send_envelope_as_root`, subscribes `Settled { call_root }`, accumulates correlated replies into an ordered `Bundle`, and closes the bundle exactly on settlement — no quiescence window. The cap's deferred-work hold contract (iamacoffeepot/aether#1031) keeps the chain open across async replies; a per-`Call` timeout bounds a never-settling cap (node failure, not a partial bundle).
- **Cancellation** drops parked mail + reply correlations + settlement subscriptions; surfaces as `Failed { error: "cancelled" }`.
- **Reaping** — a 30s timer wake sweeps terminal DAGs past retention and times out in-flight calls.

Twelve scenario fixtures drive the full dispatch / parking / settlement path through a live chassis (including the deferred-worker hold and the timeout).

## issue 977 — submit_dag / dag_status / dag_cancel (MCP)

Three tools in `aether-mcp`:

- `submit_dag` encodes the descriptor JSON against the `aether.dag.descriptor` kind schema (same `encode_schema` path `send_mail` uses) and forwards `Submit` to `aether.dag`, returning the **synchronous** validation verdict — `Err { DagError }` on a bad descriptor or `Ok { dag_id, output_handles }` once it passes. Each `Source` carries a tool-layer virtual `payload_path` the tool reads and substitutes into the wire `payload` bytes, so large source payloads stage to a file (same pattern as `load_component`'s `binary_path`); the substrate only sees `Vec<u8>`.
- `dag_status` returns the `StatusResult` variant directly (unknown / reaped dag reports `Failed { error: "unknown dag …" }`).
- `dag_cancel` returns the `cancelled` bool.

Tests lock the encode-skew contract (path-loading + JSON encode matches a direct `#[derive(Kind)]` encode with bytes inlined), the inline-payload path, the missing-payload-path rejection before any RPC, and tagged `dag_id` / `engine_id` parsing.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo doc --workspace --no-deps` (strict rustdoc lints)
- [x] `cargo nextest run --workspace --all-features --profile ci` — 1177 passed, 3 skipped
- [x] wasm32 component cross-build (all four component crates)

Generated with Claude Code.