### PR TITLE
feat(substrate): native DAG transforms (macro, content-addressing, executor invocation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,11 +118,26 @@ name = "aether-data"
 version = "0.3.0-alpha"
 dependencies = [
  "aether-actor-derive",
+ "aether-data-derive",
  "bytemuck",
  "inventory",
  "postcard",
  "serde",
  "uuid",
+]
+
+[[package]]
+name = "aether-data-derive"
+version = "0.3.0-alpha"
+dependencies = [
+ "aether-data",
+ "bytemuck",
+ "inventory",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "trybuild",
 ]
 
 [[package]]
@@ -1525,6 +1540,12 @@ dependencies = [
  "log",
  "xml-rs",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glow"
@@ -3697,6 +3718,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3869,6 +3896,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.1",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4001,6 +4043,21 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -4407,7 +4464,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "wasmtime-environ",
  "windows-sys 0.61.2",
  "zstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/aether-math",
     "crates/aether-actor",
     "crates/aether-actor-derive",
+    "crates/aether-data-derive",
     "crates/aether-mesh",
     "crates/aether-camera",
     "crates/aether-capabilities",

--- a/crates/aether-capabilities/src/dag.rs
+++ b/crates/aether-capabilities/src/dag.rs
@@ -32,7 +32,7 @@
 // Handler-signature kinds must be importable at file root because
 // `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
 // of the mod (always-on, outside the cfg gate).
-use aether_kinds::{Cancel, DagReapTick, Status, Submit, trace::Settled};
+use aether_kinds::{Cancel, DagReapTick, DagTransformDone, Status, Submit, trace::Settled};
 
 #[aether_actor::bridge(singleton)]
 mod native {
@@ -41,7 +41,7 @@ mod native {
     use std::thread;
     use std::time::Duration;
 
-    use super::{Cancel, DagReapTick, Settled, Status, Submit};
+    use super::{Cancel, DagReapTick, DagTransformDone, Settled, Status, Submit};
     use aether_actor::{MailCtx, actor};
     use aether_data::{Kind, KindId, MailId, MailboxId};
     use aether_kinds::{StatusResult, SubmitResult};
@@ -115,6 +115,8 @@ mod native {
 
         fn unwire(&mut self, _ctx: &mut NativeCtx<'_>) {
             self.reap_shutdown.store(true, Ordering::Release);
+            // Join the transform compute-pool workers (ADR-0048 §3).
+            self.executor.shutdown();
         }
 
         /// Submit a computation DAG for validation + execution. Validation
@@ -188,6 +190,19 @@ mod native {
         #[handler]
         fn on_reap_tick(&mut self, _ctx: &mut NativeCtx<'_>, _mail: DagReapTick) {
             let _ = self.executor.reap();
+        }
+
+        /// Off-thread native-transform completion wake (ADR-0048 §3).
+        /// The compute pool fires this after a transform `fn` returns (or
+        /// panics); forward it to the executor, which pulls the stashed
+        /// outcome and resolves / fails the node on this actor's own
+        /// thread. Fires from the pool, not from external mail.
+        ///
+        /// # Agent
+        /// Internal — not part of the cap's external surface.
+        #[handler]
+        fn on_transform_done(&mut self, ctx: &mut NativeCtx<'_>, mail: DagTransformDone) {
+            self.executor.on_transform_complete(ctx, mail.job_id);
         }
 
         /// Catch-all reply interception. A source / `Call` reply lands

--- a/crates/aether-capabilities/src/dag/test_support.rs
+++ b/crates/aether-capabilities/src/dag/test_support.rs
@@ -18,11 +18,14 @@
 //!   content-gen `InFlightDispatch` (spawn-and-die worker + settlement
 //!   hold), exercising the exact-settlement-through-the-hold path.
 
+use std::hint::spin_loop;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
 
 use aether_data::Ref;
+use aether_data::transform;
 use aether_kinds::Bundle;
 
 /// Source request — the DAG `Source` node's opaque payload. `fail`
@@ -407,6 +410,246 @@ mod test_deferred_call {
                 .on_reply_landed(&self.mailer, self.self_mailbox);
         }
     }
+}
+
+/// A postcard-shape number kind — the transform fixtures' input +
+/// output (ADR-0048 §3, iamacoffeepot/aether#1012). Postcard (serde)
+/// rather than cast because `ctx.reply` requires `Serialize`; the
+/// transform's decode / encode picks postcard automatically from the
+/// non-`#[repr(C)]` shape, so source bytes and transform input bytes
+/// agree.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "aether.dag.test.number")]
+pub struct TestNumber {
+    pub value: u64,
+    // A structurally-distinguishing second field. Canonical schema
+    // bytes are positional-only (no field names), so a bare `{ value:
+    // u64 }` would collide with every other single-`u64` kind in the
+    // test vocabulary (`TestNumberRequest`, `TestCallReply`, …) and the
+    // observer's `Ref<TestNumber>` slot would resolve to the wrong kind
+    // id. The extra `u32` makes the `{ u64, u32 }` shape unique.
+    pub tag: u32,
+}
+
+/// Source request for the number source — `value` seeds the reply.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "aether.dag.test.number_request")]
+pub struct TestNumberRequest {
+    pub value: u64,
+}
+
+/// Observer request consuming one `Ref<TestNumber>` slot — the
+/// transform fixtures wire a transform's output into this so the test
+/// asserts the resolved value.
+#[derive(
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "aether.dag.test.number_observed")]
+pub struct TestNumberObserved {
+    pub input: Ref<TestNumber>,
+}
+
+/// Variable-length output kind for the `big_output` fixture.
+#[derive(
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "aether.dag.test.bytes")]
+pub struct TestBytes {
+    pub bytes: Vec<u8>,
+}
+
+/// Gate the `slow` transform spins on. The timeout / off-thread fixtures
+/// open it (set `true`) after asserting the executor behaviour, so the
+/// orphaned worker can finish and the pool joins cleanly on shutdown.
+/// A transform fn references this `static` directly (a path expression
+/// to a static is not on the deny-list); the busy-spin keeps the body
+/// free of any `std::time` / `core::time` path the purity scan rejects.
+pub static SLOW_TRANSFORM_GATE: AtomicBool = AtomicBool::new(false);
+
+/// Pure transform: double the wrapped value. The headline happy-path
+/// fixture's compute.
+#[transform]
+fn double(x: TestNumber) -> TestNumber {
+    TestNumber {
+        value: x.value.wrapping_mul(2),
+        tag: x.tag,
+    }
+}
+
+/// Panicking transform — exercises ADR-0048 §6 panic = failure.
+#[transform]
+fn boom(_x: TestNumber) -> TestNumber {
+    panic!("boom");
+}
+
+/// Counts actual `seed` invocations — the cache-hit fixture asserts it
+/// stays at 1 across two identical DAGs (a re-invocation would bump it).
+/// Incrementing a `static` atomic from a transform body is permitted by
+/// the deny-list (no host fn / context / time path); it makes the
+/// invoke count directly observable from the test thread, which the
+/// cap-owned executor's `transform_call_count` is not.
+pub static SEED_INVOKE_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+/// Zero-input transform — produces a constant. Two DAGs each containing
+/// just this node share the same content-address (`f(transform_id,
+/// [])`), so the second hits the cache: the
+/// `transform_skips_invoke_on_cache_hit` fixture (ADR-0048 §4,
+/// iamacoffeepot/aether#982) asserts [`SEED_INVOKE_COUNT`] stays at 1.
+#[transform]
+fn seed() -> TestNumber {
+    SEED_INVOKE_COUNT.fetch_add(1, Ordering::AcqRel);
+    TestNumber { value: 7, tag: 0 }
+}
+
+/// Spinning transform — busy-waits on `SLOW_TRANSFORM_GATE` so the
+/// timeout / off-thread fixtures can hold it open. No `std::time` path
+/// (the deny-list forbids it); a bare spin loop over a `static` flag.
+#[transform]
+fn slow(x: TestNumber) -> TestNumber {
+    while !SLOW_TRANSFORM_GATE.load(Ordering::Acquire) {
+        spin_loop();
+    }
+    x
+}
+
+/// Transform that produces a large output — exercises the ADR-0048 §6
+/// output-byte cap when paired with a tiny
+/// `AETHER_TRANSFORM_MAX_OUTPUT_BYTES`.
+#[transform]
+fn big_output(x: TestNumber) -> TestBytes {
+    let len = usize::try_from(x.value).unwrap_or(usize::MAX).min(1 << 20);
+    TestBytes {
+        bytes: vec![0u8; len],
+    }
+}
+
+#[aether_actor::bridge(singleton)]
+mod test_number_source {
+    use super::{TestNumber, TestNumberRequest};
+    use aether_actor::{MailCtx, actor};
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+
+    /// Source replying a [`TestNumber`] — feeds a transform's input
+    /// handle with the cast-shape bytes the transform decodes.
+    pub struct TestNumberSourceActor;
+
+    #[actor]
+    impl NativeActor for TestNumberSourceActor {
+        type Config = ();
+        const NAMESPACE: &'static str = "aether.dag.test.number_source";
+
+        fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            Ok(Self)
+        }
+
+        #[allow(clippy::unused_self, clippy::needless_pass_by_value)]
+        #[handler]
+        fn on_request(&mut self, ctx: &mut NativeCtx<'_>, mail: TestNumberRequest) {
+            ctx.reply(&TestNumber {
+                value: mail.value,
+                tag: 0,
+            });
+        }
+    }
+}
+
+#[aether_actor::bridge(singleton)]
+mod test_number_observer {
+    use super::{Recorder, TestNumberObserved};
+    use aether_actor::actor;
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+
+    /// Observer recording the resolved `Ref<TestNumber>` it receives —
+    /// the transform fixtures assert against the recorded value.
+    pub struct TestNumberObserverActor {
+        recorder: Recorder<TestNumberObserved>,
+    }
+
+    #[actor]
+    impl NativeActor for TestNumberObserverActor {
+        type Config = Recorder<TestNumberObserved>;
+        const NAMESPACE: &'static str = "aether.dag.test.number_observer";
+
+        fn init(
+            recorder: Recorder<TestNumberObserved>,
+            _ctx: &mut NativeInitCtx<'_>,
+        ) -> Result<Self, BootError> {
+            Ok(Self { recorder })
+        }
+
+        #[allow(clippy::needless_pass_by_value)]
+        #[handler]
+        fn on_number_observed(&mut self, _ctx: &mut NativeCtx<'_>, mail: TestNumberObserved) {
+            self.recorder
+                .lock()
+                .expect("recorder mutex poisoned")
+                .push(mail);
+        }
+    }
+}
+
+/// Resolve the `double` transform's global id from the link-time
+/// inventory, for descriptor construction in the fixtures.
+#[must_use]
+pub fn double_transform_id() -> aether_data::TransformId {
+    transform_id_by_name("double")
+}
+
+/// Resolve the `boom` transform's id.
+#[must_use]
+pub fn boom_transform_id() -> aether_data::TransformId {
+    transform_id_by_name("boom")
+}
+
+/// Resolve the `slow` transform's id.
+#[must_use]
+pub fn slow_transform_id() -> aether_data::TransformId {
+    transform_id_by_name("slow")
+}
+
+/// Resolve the `big_output` transform's id.
+#[must_use]
+pub fn big_output_transform_id() -> aether_data::TransformId {
+    transform_id_by_name("big_output")
+}
+
+/// Resolve the zero-input `seed` transform's id.
+#[must_use]
+pub fn seed_transform_id() -> aether_data::TransformId {
+    transform_id_by_name("seed")
+}
+
+/// Look up a registered transform's id by its fn-name tail.
+fn transform_id_by_name(tail: &str) -> aether_data::TransformId {
+    let Some(entry) = aether_data::transforms().find(|t| t.name.ends_with(&format!("::{tail}")))
+    else {
+        panic!("transform `{tail}` not registered in link-time inventory");
+    };
+    entry.transform_id
 }
 
 // The actor structs are re-exported at this module's root by the

--- a/crates/aether-capabilities/src/dag/tests.rs
+++ b/crates/aether-capabilities/src/dag/tests.rs
@@ -18,6 +18,7 @@
 
 #![allow(clippy::unwrap_used)]
 
+use std::sync::atomic::Ordering;
 use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -41,9 +42,11 @@ use aether_substrate::mail::{ReplyTarget, ReplyTo};
 
 use super::DagCapability;
 use super::test_support::{
-    Recorder, TestBundleObserverActor, TestCallActor, TestCallConfig, TestCallReply,
-    TestDeferredCallActor, TestObserved, TestObserved2, TestObserverActor,
-    TestParallelObserverActor, TestReadResult, TestSourceActor,
+    Recorder, SLOW_TRANSFORM_GATE, TestBundleObserverActor, TestCallActor, TestCallConfig,
+    TestCallReply, TestDeferredCallActor, TestNumber, TestNumberObserved, TestNumberObserverActor,
+    TestNumberRequest, TestNumberSourceActor, TestObserved, TestObserved2, TestObserverActor,
+    TestParallelObserverActor, TestReadResult, TestSourceActor, big_output_transform_id,
+    boom_transform_id, double_transform_id, seed_transform_id, slow_transform_id,
 };
 use crate::test_chassis::TestChassis;
 use crate::trace::TraceObserverCapability;
@@ -841,4 +844,352 @@ fn run_call_dag_to(
         aether_data::Ref::Inline(bundle) => bundle,
         aether_data::Ref::Handle { .. } => panic!("bundle slot should be resolved inline"),
     }
+}
+
+/// Base builder plus the number source + number observer the transform
+/// fixtures wire (ADR-0048 §3, iamacoffeepot/aether#1012). The
+/// `DagCapability` builds its `TransformRegistry` from the link-time
+/// inventory at boot, so the `double` / `boom` / `slow` / `big_output` /
+/// `seed` transforms from `test_support` are dispatchable.
+fn transform_builder(
+    registry: &Arc<Registry>,
+    mailer: &Arc<Mailer>,
+    recorder: &Recorder<TestNumberObserved>,
+) -> PassiveChassis<TestChassis> {
+    base_builder(registry, mailer)
+        .with_actor::<TestNumberSourceActor>(())
+        .with_actor::<TestNumberObserverActor>(Arc::clone(recorder))
+        .build_passive()
+        .expect("caps boot")
+}
+
+/// A `TestNumberRequest` payload (cast-shape bytes).
+fn number_req(value: u64) -> Vec<u8> {
+    <TestNumberRequest as Kind>::encode_into_bytes(&TestNumberRequest { value })
+}
+
+/// number-source → transform(`tx`, output `TestNumber`) → number-observer.
+fn number_transform_dag(tx: aether_data::TransformId, value: u64) -> DagDescriptor {
+    DagDescriptor {
+        version: 1,
+        nodes: vec![
+            Node::Source {
+                id: NodeId(0),
+                mailbox: mbx::<TestNumberSourceActor>(),
+                kind_id: <TestNumberRequest as Kind>::ID,
+                payload: number_req(value),
+            },
+            Node::Transform {
+                id: NodeId(1),
+                transform_id: tx,
+                output_kind_id: <TestNumber as Kind>::ID,
+                timeout_ms: None,
+            },
+            Node::Observer {
+                id: NodeId(2),
+                recipient: mbx::<TestNumberObserverActor>(),
+                kind_id: <TestNumberObserved as Kind>::ID,
+            },
+        ],
+        edges: vec![
+            Edge {
+                from: NodeId(0),
+                to: NodeId(1),
+                slot: 0,
+            },
+            Edge {
+                from: NodeId(1),
+                to: NodeId(2),
+                slot: 0,
+            },
+        ],
+    }
+}
+
+/// source → `double` transform → observer. The observer receives the
+/// doubled value resolved inline; the DAG reaches `Complete` (ADR-0048
+/// §3 invocation path).
+#[test]
+fn transform_invoke_resolves_handle() {
+    let (registry, mailer, rx) = fresh_substrate_with_rx();
+    let recorder: Recorder<TestNumberObserved> = Arc::new(Mutex::new(Vec::new()));
+    let chassis = transform_builder(&registry, &mailer, &recorder);
+
+    let dag_id = submit_ok(&registry, &rx, number_transform_dag(double_transform_id(), 21), 1);
+
+    assert!(
+        poll_until(Duration::from_secs(5), || recorder.lock().unwrap().len()
+            == 1),
+        "observer never received the transform output",
+    );
+    let observed = recorder.lock().unwrap()[0].clone();
+    assert_eq!(
+        observed.input,
+        aether_data::Ref::Inline(TestNumber { value: 42, tag: 0 }),
+        "double(21) should resolve to 42",
+    );
+    assert!(poll_until(Duration::from_secs(5), || matches!(
+        query_status(&registry, &rx, dag_id, 100),
+        StatusResult::Complete { .. }
+    )));
+
+    drop(chassis);
+}
+
+/// A panicking transform maps to `Failed` with the panic message in the
+/// diagnostic; the executor + sibling branches survive (ADR-0048 §6).
+#[test]
+fn transform_panic_fails_node() {
+    let (registry, mailer, rx) = fresh_substrate_with_rx();
+    let recorder: Recorder<TestNumberObserved> = Arc::new(Mutex::new(Vec::new()));
+    let chassis = transform_builder(&registry, &mailer, &recorder);
+
+    let dag_id = submit_ok(&registry, &rx, number_transform_dag(boom_transform_id(), 1), 1);
+
+    let failed = poll_until(Duration::from_secs(5), || {
+        matches!(
+            query_status(&registry, &rx, dag_id, 100),
+            StatusResult::Failed { ref error, .. } if error.contains("panicked")
+        )
+    });
+    assert!(failed, "panicking transform should fail the node");
+    assert_eq!(
+        recorder.lock().unwrap().len(),
+        0,
+        "downstream observer must not run on a failed transform",
+    );
+
+    // The executor survives: a fresh DAG still resolves.
+    let recorder2: Recorder<TestNumberObserved> = recorder;
+    let dag2 = submit_ok(&registry, &rx, number_transform_dag(double_transform_id(), 5), 2);
+    assert!(poll_until(Duration::from_secs(5), || matches!(
+        query_status(&registry, &rx, dag2, 101),
+        StatusResult::Complete { .. }
+    )));
+    assert_eq!(recorder2.lock().unwrap().len(), 1);
+
+    drop(chassis);
+}
+
+/// A transform exceeding its `timeout_ms` marks the node `Failed
+/// { error: "timeout: ..." }`; the thread orphans (the executor
+/// continues). The fixture releases the gate afterward so the pool
+/// joins cleanly (ADR-0048 §6).
+#[test]
+fn transform_timeout_fails_node() {
+    SLOW_TRANSFORM_GATE.store(false, Ordering::Release);
+    // SAFETY: nextest runs each test in its own process.
+    unsafe {
+        env::set_var("AETHER_TRANSFORM_TIMEOUT_MS", "50");
+    }
+    let (registry, mailer, rx) = fresh_substrate_with_rx();
+    let recorder: Recorder<TestNumberObserved> = Arc::new(Mutex::new(Vec::new()));
+    let chassis = transform_builder(&registry, &mailer, &recorder);
+
+    let dag_id = submit_ok(&registry, &rx, number_transform_dag(slow_transform_id(), 1), 1);
+
+    thread::sleep(Duration::from_millis(80));
+    let failed = poll_until(Duration::from_secs(5), || {
+        enqueue(&registry, dag_mailbox(), &DagReapTick {}, session(300));
+        thread::sleep(Duration::from_millis(20));
+        matches!(
+            query_status(&registry, &rx, dag_id, 301),
+            StatusResult::Failed { ref error, .. } if error.contains("timeout")
+        )
+    });
+    assert!(failed, "slow transform should fail on timeout");
+
+    // Release the spinning worker so the pool can join on drop.
+    SLOW_TRANSFORM_GATE.store(true, Ordering::Release);
+    // SAFETY: nextest process isolation.
+    unsafe {
+        env::remove_var("AETHER_TRANSFORM_TIMEOUT_MS");
+    }
+    drop(chassis);
+}
+
+/// A transform whose encoded output exceeds
+/// `AETHER_TRANSFORM_MAX_OUTPUT_BYTES` hard-fails the node (ADR-0048
+/// §6).
+#[test]
+fn transform_output_overflow_fails_node() {
+    // SAFETY: nextest process isolation.
+    unsafe {
+        env::set_var("AETHER_TRANSFORM_MAX_OUTPUT_BYTES", "8");
+    }
+    let (registry, mailer, rx) = fresh_substrate_with_rx();
+    let recorder: Recorder<TestNumberObserved> = Arc::new(Mutex::new(Vec::new()));
+    let chassis = transform_builder(&registry, &mailer, &recorder);
+
+    // `big_output` produces `value` zero bytes; 64 > the 8-byte cap.
+    let descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![
+            Node::Source {
+                id: NodeId(0),
+                mailbox: mbx::<TestNumberSourceActor>(),
+                kind_id: <TestNumberRequest as Kind>::ID,
+                payload: number_req(64),
+            },
+            Node::Transform {
+                id: NodeId(1),
+                transform_id: big_output_transform_id(),
+                output_kind_id: <super::test_support::TestBytes as Kind>::ID,
+                timeout_ms: None,
+            },
+        ],
+        edges: vec![Edge {
+            from: NodeId(0),
+            to: NodeId(1),
+            slot: 0,
+        }],
+    };
+    let dag_id = submit_ok(&registry, &rx, descriptor, 1);
+
+    let failed = poll_until(Duration::from_secs(5), || {
+        matches!(
+            query_status(&registry, &rx, dag_id, 100),
+            StatusResult::Failed { ref error, .. } if error.contains("exceeded")
+        )
+    });
+    assert!(failed, "oversized transform output should fail the node");
+
+    // SAFETY: nextest process isolation.
+    unsafe {
+        env::remove_var("AETHER_TRANSFORM_MAX_OUTPUT_BYTES");
+    }
+    drop(chassis);
+}
+
+/// A second DAG with the same `transform_id` + input handle ids (here a
+/// zero-input `seed`, whose content-address `f(transform_id, [])` is
+/// identical across DAGs) skips the invoke entirely — the cache hit
+/// resolves the node. The pool's invoke count reports 1, not 2
+/// (ADR-0048 §4, iamacoffeepot/aether#982).
+#[test]
+fn transform_skips_invoke_on_cache_hit() {
+    super::test_support::SEED_INVOKE_COUNT.store(0, Ordering::Release);
+    let (registry, mailer, rx) = fresh_substrate_with_rx();
+    let recorder: Recorder<TestNumberObserved> = Arc::new(Mutex::new(Vec::new()));
+
+    // A zero-input transform feeding a number observer.
+    let seed_dag = || DagDescriptor {
+        version: 1,
+        nodes: vec![
+            Node::Transform {
+                id: NodeId(0),
+                transform_id: seed_transform_id(),
+                output_kind_id: <TestNumber as Kind>::ID,
+                timeout_ms: None,
+            },
+            Node::Observer {
+                id: NodeId(1),
+                recipient: mbx::<TestNumberObserverActor>(),
+                kind_id: <TestNumberObserved as Kind>::ID,
+            },
+        ],
+        edges: vec![Edge {
+            from: NodeId(0),
+            to: NodeId(1),
+            slot: 0,
+        }],
+    };
+
+    let chassis = transform_builder(&registry, &mailer, &recorder);
+
+    let dag1 = submit_ok(&registry, &rx, seed_dag(), 1);
+    assert!(poll_until(Duration::from_secs(5), || matches!(
+        query_status(&registry, &rx, dag1, 100),
+        StatusResult::Complete { .. }
+    )));
+    assert_eq!(
+        recorder.lock().unwrap().len(),
+        1,
+        "first seed DAG observer should run",
+    );
+
+    // Second DAG: same transform, same (empty) inputs -> same
+    // content-address -> cache hit -> no second invoke.
+    recorder.lock().unwrap().clear();
+    let dag2 = submit_ok(&registry, &rx, seed_dag(), 2);
+    assert!(poll_until(Duration::from_secs(5), || matches!(
+        query_status(&registry, &rx, dag2, 101),
+        StatusResult::Complete { .. }
+    )));
+    assert_eq!(
+        recorder.lock().unwrap().len(),
+        1,
+        "second seed DAG observer should still resolve from cache",
+    );
+    assert_eq!(
+        recorder.lock().unwrap()[0].input,
+        aether_data::Ref::Inline(TestNumber { value: 7, tag: 0 }),
+    );
+
+    let invoke_count =
+        super::test_support::SEED_INVOKE_COUNT.load(Ordering::Acquire);
+    assert_eq!(
+        invoke_count, 1,
+        "second identical transform must hit the cache, not re-invoke",
+    );
+
+    drop(chassis);
+}
+
+/// A transform that blocks briefly does not stall the executor's
+/// parking / reaping of other DAG branches: a sibling DAG's pure
+/// `double` resolves while the `slow` transform spins (ADR-0048 §3 off
+/// the executor thread).
+#[test]
+fn transform_runs_off_executor_thread() {
+    SLOW_TRANSFORM_GATE.store(false, Ordering::Release);
+    let (registry, mailer, rx) = fresh_substrate_with_rx();
+    let recorder: Recorder<TestNumberObserved> = Arc::new(Mutex::new(Vec::new()));
+    let chassis = transform_builder(&registry, &mailer, &recorder);
+
+    // DAG 1: a long-blocking `slow` transform (terminal, no observer).
+    let slow_descriptor = DagDescriptor {
+        version: 1,
+        nodes: vec![
+            Node::Source {
+                id: NodeId(0),
+                mailbox: mbx::<TestNumberSourceActor>(),
+                kind_id: <TestNumberRequest as Kind>::ID,
+                payload: number_req(99),
+            },
+            Node::Transform {
+                id: NodeId(1),
+                transform_id: slow_transform_id(),
+                output_kind_id: <TestNumber as Kind>::ID,
+                timeout_ms: Some(60_000),
+            },
+        ],
+        edges: vec![Edge {
+            from: NodeId(0),
+            to: NodeId(1),
+            slot: 0,
+        }],
+    };
+    let _slow_dag = submit_ok(&registry, &rx, slow_descriptor, 1);
+
+    // DAG 2: a pure `double` that must resolve while DAG 1 is blocked.
+    let dag2 = submit_ok(&registry, &rx, number_transform_dag(double_transform_id(), 4), 2);
+    let completed = poll_until(Duration::from_secs(5), || {
+        matches!(
+            query_status(&registry, &rx, dag2, 101),
+            StatusResult::Complete { .. }
+        )
+    });
+    assert!(
+        completed,
+        "the executor must advance a sibling DAG while a transform blocks off-thread",
+    );
+    assert_eq!(
+        recorder.lock().unwrap()[0].input,
+        aether_data::Ref::Inline(TestNumber { value: 8, tag: 0 }),
+    );
+
+    // Release the spinning worker so the pool joins cleanly.
+    SLOW_TRANSFORM_GATE.store(true, Ordering::Release);
+    drop(chassis);
 }

--- a/crates/aether-capabilities/src/dag/tests.rs
+++ b/crates/aether-capabilities/src/dag/tests.rs
@@ -915,7 +915,12 @@ fn transform_invoke_resolves_handle() {
     let recorder: Recorder<TestNumberObserved> = Arc::new(Mutex::new(Vec::new()));
     let chassis = transform_builder(&registry, &mailer, &recorder);
 
-    let dag_id = submit_ok(&registry, &rx, number_transform_dag(double_transform_id(), 21), 1);
+    let dag_id = submit_ok(
+        &registry,
+        &rx,
+        number_transform_dag(double_transform_id(), 21),
+        1,
+    );
 
     assert!(
         poll_until(Duration::from_secs(5), || recorder.lock().unwrap().len()
@@ -944,7 +949,12 @@ fn transform_panic_fails_node() {
     let recorder: Recorder<TestNumberObserved> = Arc::new(Mutex::new(Vec::new()));
     let chassis = transform_builder(&registry, &mailer, &recorder);
 
-    let dag_id = submit_ok(&registry, &rx, number_transform_dag(boom_transform_id(), 1), 1);
+    let dag_id = submit_ok(
+        &registry,
+        &rx,
+        number_transform_dag(boom_transform_id(), 1),
+        1,
+    );
 
     let failed = poll_until(Duration::from_secs(5), || {
         matches!(
@@ -961,7 +971,12 @@ fn transform_panic_fails_node() {
 
     // The executor survives: a fresh DAG still resolves.
     let recorder2: Recorder<TestNumberObserved> = recorder;
-    let dag2 = submit_ok(&registry, &rx, number_transform_dag(double_transform_id(), 5), 2);
+    let dag2 = submit_ok(
+        &registry,
+        &rx,
+        number_transform_dag(double_transform_id(), 5),
+        2,
+    );
     assert!(poll_until(Duration::from_secs(5), || matches!(
         query_status(&registry, &rx, dag2, 101),
         StatusResult::Complete { .. }
@@ -986,7 +1001,12 @@ fn transform_timeout_fails_node() {
     let recorder: Recorder<TestNumberObserved> = Arc::new(Mutex::new(Vec::new()));
     let chassis = transform_builder(&registry, &mailer, &recorder);
 
-    let dag_id = submit_ok(&registry, &rx, number_transform_dag(slow_transform_id(), 1), 1);
+    let dag_id = submit_ok(
+        &registry,
+        &rx,
+        number_transform_dag(slow_transform_id(), 1),
+        1,
+    );
 
     thread::sleep(Duration::from_millis(80));
     let failed = poll_until(Duration::from_secs(5), || {
@@ -1126,8 +1146,7 @@ fn transform_skips_invoke_on_cache_hit() {
         aether_data::Ref::Inline(TestNumber { value: 7, tag: 0 }),
     );
 
-    let invoke_count =
-        super::test_support::SEED_INVOKE_COUNT.load(Ordering::Acquire);
+    let invoke_count = super::test_support::SEED_INVOKE_COUNT.load(Ordering::Acquire);
     assert_eq!(
         invoke_count, 1,
         "second identical transform must hit the cache, not re-invoke",
@@ -1173,7 +1192,12 @@ fn transform_runs_off_executor_thread() {
     let _slow_dag = submit_ok(&registry, &rx, slow_descriptor, 1);
 
     // DAG 2: a pure `double` that must resolve while DAG 1 is blocked.
-    let dag2 = submit_ok(&registry, &rx, number_transform_dag(double_transform_id(), 4), 2);
+    let dag2 = submit_ok(
+        &registry,
+        &rx,
+        number_transform_dag(double_transform_id(), 4),
+        2,
+    );
     let completed = poll_until(Duration::from_secs(5), || {
         matches!(
             query_status(&registry, &rx, dag2, 101),

--- a/crates/aether-data-derive/Cargo.toml
+++ b/crates/aether-data-derive/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "aether-data-derive"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full", "visit"] }
+
+[dev-dependencies]
+aether-data = { path = "../aether-data", features = ["derive"] }
+bytemuck = { version = "1.19", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+inventory = "0.3"
+trybuild = "1"
+
+[lints]
+workspace = true

--- a/crates/aether-data-derive/src/lib.rs
+++ b/crates/aether-data-derive/src/lib.rs
@@ -1,0 +1,384 @@
+// The deny-list visitor builds a flat scan over the body's expression
+// paths; `if let Some(..)` over the matched-prefix branch reads clearer
+// than `map_or_else`. Allow at the crate root because cargo doesn't
+// permit `[lints.clippy]` overrides alongside `lints.workspace = true`
+// in the manifest (mirrors `aether-actor-derive`).
+#![allow(clippy::option_if_let_else)]
+
+//! Proc-macro home for the `#[transform]` attribute (ADR-0048 §1).
+//!
+//! A transform is a **data-layer primitive** — a pure `Kind -> Kind`
+//! function with zero dependence on the actor framework. Its runtime
+//! types ([`TransformEntry`](aether_data::TransformEntry),
+//! [`TransformError`](aether_data::TransformError), the link-time
+//! inventory) live in `aether-data`; this crate is the sibling
+//! proc-macro that `aether-data` cannot itself be (`proc-macro = true`
+//! forbids exporting runtime items). `aether-data` re-exports the macro
+//! as `aether_data::transform` behind the `derive` feature.
+//!
+//! The macro's three ADR-0048 §1 responsibilities:
+//!
+//! 1. **Stable name-based `transform_id`.**
+//!    `fnv1a_64(TRANSFORM_DOMAIN ++ "{crate}::{module_path}::{fn}")`,
+//!    tagged `Tag::Transform`. Built at the *consumer's* compile time
+//!    from `concat!(env!("CARGO_PKG_NAME"), "::", module_path!(), "::",
+//!    fn)` so identity tracks the fully-qualified name, not the
+//!    position in the file.
+//! 2. **Deny-list purity scan.** Walks the body's expression paths and
+//!    rejects host-fn imports, handler-context types, the sync
+//!    request/reply primitive, and compile-time-catchable
+//!    nondeterminism sources (`std::env`, `std::time`, `core::time`).
+//!    Best-effort: it sees only the immediate body, not helper-fn
+//!    bodies, and there is no runtime sandbox (ADR-0048
+//!    Consequences/Negative). First-party review is the other defense.
+//! 3. **Link-time inventory submission.** Emits an `inventory::submit!`
+//!    of a `TransformEntry` carrying the id, input/output kind ids, the
+//!    name, and a type-erased `invoke` thunk that decodes each input
+//!    slice, calls the user fn, and encodes the output.
+//!
+//! There is no FFI shim, no `extern "C"`, no custom section — the
+//! original wasm-export design was deferred (ADR-0048 revision
+//! 2026-05-20).
+
+use core::iter;
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Expr, FnArg, ItemFn, ReturnType, Type, parse_macro_input};
+
+/// ADR-0048 §1 cap on input parameters.
+const MAX_TRANSFORM_INPUTS: usize = 8;
+
+/// `#[transform]` — register a pure `Kind -> Kind` function as a native
+/// transform (ADR-0048 §1). The annotated fn is left intact (so it
+/// stays unit-testable as an ordinary fn) and gains a link-time
+/// inventory entry the substrate's `TransformRegistry` collects at
+/// startup.
+///
+/// See the crate docs for the three responsibilities (id derivation,
+/// purity scan, inventory submission). The macro emits `compile_error!`
+/// for a non-fn item, a `self` receiver, generics, a 9th input
+/// parameter, a missing return type, or a body that names a denied
+/// path.
+#[proc_macro_attribute]
+pub fn transform(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let func = parse_macro_input!(item as ItemFn);
+    match expand_transform(&func) {
+        Ok(ts) => ts.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+fn expand_transform(func: &ItemFn) -> syn::Result<TokenStream2> {
+    let (input_types, output_type) = validate_signature(func)?;
+
+    // Deny-list purity scan over the immediate body (ADR-0048 §1). Best
+    // effort — helper-fn bodies aren't visible here.
+    purity_scan(&func.block)?;
+
+    let inventory = emit_inventory(func, &input_types, output_type);
+    Ok(quote! {
+        #func
+        #inventory
+    })
+}
+
+/// Enforce the ADR-0048 §1 signature contract: no generics, no `self`,
+/// ≤ 8 inputs, and a single (non-`()`) return type. Returns the input
+/// parameter types in slot order plus the output type.
+fn validate_signature(func: &ItemFn) -> syn::Result<(Vec<&Type>, &Type)> {
+    let sig = &func.sig;
+
+    // No generics — transforms are monomorphic (ADR-0048 §1).
+    if !sig.generics.params.is_empty() {
+        return Err(syn::Error::new(
+            sig.generics.span(),
+            "transforms cannot be generic -- they are monomorphic Kind -> Kind functions \
+             (ADR-0048 §1)",
+        ));
+    }
+
+    // Collect the input parameter types, rejecting any `self` receiver
+    // and capping at 8 (ADR-0048 §1).
+    let mut input_types: Vec<&Type> = Vec::new();
+    for arg in &sig.inputs {
+        match arg {
+            FnArg::Receiver(recv) => {
+                return Err(syn::Error::new(
+                    recv.span(),
+                    "transforms cannot take `self` -- they are free-standing pure functions \
+                     (ADR-0048 §1)",
+                ));
+            }
+            FnArg::Typed(pat) => input_types.push(&pat.ty),
+        }
+    }
+    if input_types.len() > MAX_TRANSFORM_INPUTS {
+        return Err(syn::Error::new(
+            sig.inputs.span(),
+            format!(
+                "transforms accept at most {MAX_TRANSFORM_INPUTS} inputs (ADR-0048 §1); found {}",
+                input_types.len(),
+            ),
+        ));
+    }
+
+    // Single return type, also a `Kind` (ADR-0048 §1). A bare `()`
+    // return is rejected — a transform produces a kind value.
+    let output_type: &Type = match &sig.output {
+        ReturnType::Type(_, ty) => ty,
+        ReturnType::Default => {
+            return Err(syn::Error::new(
+                sig.span(),
+                "transforms must return a single Kind value (ADR-0048 §1)",
+            ));
+        }
+    };
+
+    Ok((input_types, output_type))
+}
+
+/// Emit the per-type `Kind` bound assertions + the link-time inventory
+/// submission (id derivation, the static input-kind-id slice, and the
+/// type-erased `invoke` thunk). Codegen only — the signature is already
+/// validated and the body already purity-scanned.
+fn emit_inventory(func: &ItemFn, input_types: &[&Type], output_type: &Type) -> TokenStream2 {
+    let fn_name = &func.sig.ident;
+    let fn_name_str = fn_name.to_string();
+
+    // Per-type `Kind` bound assertions: the macro can't check trait
+    // bounds at expansion time, so emit a `const _: fn() = || { <T as
+    // Kind>::ID; };` per input + output. A build error fires if any type
+    // doesn't impl `Kind` (ADR-0048 §1).
+    let bound_assertions = input_types.iter().chain(iter::once(&output_type)).map(|ty| {
+        quote! {
+            const _: fn() = || {
+                let _ = <#ty as ::aether_data::transform::__transform_runtime::Kind>::ID;
+            };
+        }
+    });
+
+    // Fully-qualified name string at the consumer's compile time:
+    // `"{crate}::{module_path}::{fn}"`. `module_path!()` already begins
+    // with the crate's lib/bin name as the first segment, so prefixing
+    // `CARGO_PKG_NAME` keeps the id stable even when two crates share a
+    // module path tail.
+    let name_expr = quote! {
+        ::core::concat!(
+            ::core::env!("CARGO_PKG_NAME"), "::",
+            ::core::module_path!(), "::",
+            #fn_name_str,
+        )
+    };
+
+    // The `invoke` thunk: decode each input slice (slot-index order)
+    // against its declared kind via `Kind::decode_from_bytes`, call the
+    // user fn, encode the output via `Kind::encode_into_bytes`. Decode
+    // failure -> `InputDecode { slot }`; arity mismatch ->
+    // `InputArity`. The output-byte cap is the executor's job, not the
+    // thunk's.
+    let arity = input_types.len();
+    let decode_bindings = input_types.iter().enumerate().map(|(slot, ty)| {
+        let local = format_ident!("__in{slot}");
+        quote! {
+            let #local: #ty = match
+                <#ty as ::aether_data::transform::__transform_runtime::Kind>::decode_from_bytes(
+                    __inputs[#slot],
+                )
+            {
+                ::core::option::Option::Some(v) => v,
+                ::core::option::Option::None => {
+                    return ::core::result::Result::Err(
+                        ::aether_data::transform::__transform_runtime::TransformError::InputDecode {
+                            slot: #slot,
+                        },
+                    );
+                }
+            };
+        }
+    });
+    let decode_locals = (0..arity).map(|slot| format_ident!("__in{slot}"));
+
+    let entry_static = format_ident!("__AETHER_TRANSFORM_ENTRY_{}", fn_name_str.to_uppercase());
+
+    // Static slices the inventory entry borrows. `inventory::submit!`
+    // needs const-constructible borrows, so the input-kind-id list is a
+    // file-scoped `static` array rather than an inline literal.
+    let input_kinds_static = format_ident!("__AETHER_TRANSFORM_INPUTS_{}", fn_name_str.to_uppercase());
+    let input_kind_exprs = input_types.iter().map(|ty| {
+        quote! {
+            <#ty as ::aether_data::transform::__transform_runtime::Kind>::ID
+        }
+    });
+
+    quote! {
+        #(#bound_assertions)*
+
+        // Link-time inventory submission (ADR-0048 §1). Cfg-gated to
+        // non-wasm targets because `inventory` doesn't link on
+        // `wasm32-unknown-unknown` (same gate as the Kind derive's
+        // descriptor inventory).
+        #[cfg(not(target_arch = "wasm32"))]
+        const _: () = {
+            static #input_kinds_static:
+                [::aether_data::transform::__transform_runtime::KindId; #arity] = [
+                    #(#input_kind_exprs),*
+                ];
+
+            fn #entry_static(__inputs: &[&[u8]])
+                -> ::core::result::Result<
+                    ::aether_data::transform::__transform_runtime::Vec<u8>,
+                    ::aether_data::transform::__transform_runtime::TransformError,
+                >
+            {
+                if __inputs.len() != #arity {
+                    return ::core::result::Result::Err(
+                        ::aether_data::transform::__transform_runtime::TransformError::InputArity {
+                            expected: #arity,
+                            actual: __inputs.len(),
+                        },
+                    );
+                }
+                #(#decode_bindings)*
+                let __out: #output_type = #fn_name(#(#decode_locals),*);
+                ::core::result::Result::Ok(
+                    <#output_type as ::aether_data::transform::__transform_runtime::Kind>::encode_into_bytes(
+                        &__out,
+                    ),
+                )
+            }
+
+            ::aether_data::transform::__transform_runtime::inventory::submit! {
+                ::aether_data::transform::__transform_runtime::TransformEntry {
+                    transform_id:
+                        ::aether_data::transform::__transform_runtime::TransformId(
+                            ::aether_data::with_tag(
+                                ::aether_data::Tag::Transform,
+                                ::aether_data::fnv1a_64_prefixed(
+                                    &::aether_data::TRANSFORM_DOMAIN,
+                                    #name_expr.as_bytes(),
+                                ),
+                            ),
+                        ),
+                    input_kind_ids: &#input_kinds_static,
+                    output_kind_id:
+                        <#output_type as ::aether_data::transform::__transform_runtime::Kind>::ID,
+                    name: #name_expr,
+                    invoke: #entry_static
+                        as ::aether_data::transform::__transform_runtime::InvokeFn,
+                }
+            }
+        };
+    }
+}
+
+/// Walk a function body's expression paths and reject any that name a
+/// denied path (ADR-0048 §1 deny-list). Returns the first violation as
+/// a span-located `compile_error!`.
+fn purity_scan(block: &syn::Block) -> syn::Result<()> {
+    let mut scanner = PurityScanner { violation: None };
+    scanner.visit_block(block);
+    match scanner.violation {
+        Some(span) => Err(syn::Error::new(
+            span,
+            "transforms cannot call host functions or access handler context -- see ADR-0048",
+        )),
+        None => Ok(()),
+    }
+}
+
+/// One denied path: a sequence of `::`-joined segment tails. A body path
+/// matches if its trailing segments end with this sequence (so both
+/// `aether::send_mail_p32` and a `use`-shortened `send_mail_p32` are
+/// caught for the single-segment entries, and qualified `std::time::*`
+/// is caught by the two-segment prefix entries).
+struct DeniedPath {
+    /// Segments to match against the *trailing* run of a body path.
+    tail: &'static [&'static str],
+}
+
+/// The deny-list (ADR-0048 §1):
+/// - host-fn imports (`aether::send_mail_p32`, `reply_mail_p32`,
+///   `resolve_*_p32`, and the other SDK host fns),
+/// - handler-context types (`aether_actor::Ctx`, `MailCtx`),
+/// - the sync request/reply primitive (`aether_actor::wait_reply`),
+/// - compile-time-catchable nondeterminism (`std::env::*`,
+///   `std::time::*`, `core::time::*`).
+const DENY_LIST: &[DeniedPath] = &[
+    // Host fns — match the bare fn tail so both qualified and
+    // use-shortened call sites are caught.
+    DeniedPath { tail: &["send_mail_p32"] },
+    DeniedPath { tail: &["reply_mail_p32"] },
+    DeniedPath { tail: &["send_mail_traced_p32"] },
+    DeniedPath { tail: &["save_state_p32"] },
+    DeniedPath { tail: &["resolve_mailbox_p32"] },
+    DeniedPath { tail: &["resolve_kind_p32"] },
+    DeniedPath { tail: &["wait_reply"] },
+    // Handler-context types.
+    DeniedPath { tail: &["aether_actor", "Ctx"] },
+    DeniedPath { tail: &["aether_actor", "MailCtx"] },
+    // Nondeterminism sources, by two-segment prefix so any item under
+    // them (`now`, `Instant`, `var`, etc.) is rejected.
+    DeniedPath { tail: &["std", "env"] },
+    DeniedPath { tail: &["std", "time"] },
+    DeniedPath { tail: &["core", "time"] },
+];
+
+/// Body-path collector + matcher. Records the span of the first path
+/// whose trailing segments match a deny-list entry.
+struct PurityScanner {
+    violation: Option<proc_macro2::Span>,
+}
+
+impl PurityScanner {
+    /// Check one path's segment idents against the deny-list. A
+    /// deny-entry matches if the path's trailing segments equal the
+    /// entry's `tail` sequence (so `std::time::Instant::now` matches the
+    /// `["std", "time"]` entry, and a use-shortened `send_mail_p32`
+    /// matches the single-segment `["send_mail_p32"]` entry).
+    fn check_path(&mut self, path: &syn::Path) {
+        if self.violation.is_some() {
+            return;
+        }
+        let segs: Vec<String> = path.segments.iter().map(|s| s.ident.to_string()).collect();
+        for denied in DENY_LIST {
+            // Single-segment fn entries match the fn ident anywhere in
+            // the path (catches both `aether::send_mail_p32` and a
+            // `use`-shortened `send_mail_p32`). Multi-segment prefix
+            // entries (the `std::time` / `core::time` / `std::env`
+            // nondeterminism roots, plus the `aether_actor::Ctx` types)
+            // anchor at the path head so any item beneath them is
+            // rejected.
+            let matched = if denied.tail.len() == 1 {
+                segs.iter().any(|s| s == denied.tail[0])
+            } else {
+                segs.len() >= denied.tail.len() && segs[..denied.tail.len()] == *denied.tail
+            };
+            if matched {
+                self.violation = Some(path.span());
+                return;
+            }
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for PurityScanner {
+    fn visit_expr_path(&mut self, node: &'ast syn::ExprPath) {
+        self.check_path(&node.path);
+        visit::visit_expr_path(self, node);
+    }
+
+    fn visit_expr_call(&mut self, node: &'ast syn::ExprCall) {
+        // A call's callee is an `Expr::Path` for free-fn / path calls;
+        // `visit_expr_path` handles it. Method calls (`x.foo()`) carry
+        // no callee path, so a `std::time::Instant::now()` written as a
+        // path-call is the case that matters here — already covered.
+        if let Expr::Path(p) = &*node.func {
+            self.check_path(&p.path);
+        }
+        visit::visit_expr_call(self, node);
+    }
+}

--- a/crates/aether-data-derive/src/lib.rs
+++ b/crates/aether-data-derive/src/lib.rs
@@ -9,12 +9,11 @@
 //!
 //! A transform is a **data-layer primitive** — a pure `Kind -> Kind`
 //! function with zero dependence on the actor framework. Its runtime
-//! types ([`TransformEntry`](aether_data::TransformEntry),
-//! [`TransformError`](aether_data::TransformError), the link-time
-//! inventory) live in `aether-data`; this crate is the sibling
-//! proc-macro that `aether-data` cannot itself be (`proc-macro = true`
-//! forbids exporting runtime items). `aether-data` re-exports the macro
-//! as `aether_data::transform` behind the `derive` feature.
+//! types (`TransformEntry`, `TransformError`, the link-time inventory)
+//! live in `aether-data`; this crate is the sibling proc-macro that
+//! `aether-data` cannot itself be (`proc-macro = true` forbids
+//! exporting runtime items). `aether-data` re-exports the macro as
+//! `aether_data::transform` behind the `derive` feature.
 //!
 //! The macro's three ADR-0048 §1 responsibilities:
 //!

--- a/crates/aether-data-derive/src/lib.rs
+++ b/crates/aether-data-derive/src/lib.rs
@@ -393,11 +393,6 @@ impl PurityScanner {
 }
 
 impl<'ast> Visit<'ast> for PurityScanner {
-    fn visit_expr_path(&mut self, node: &'ast syn::ExprPath) {
-        self.check_path(&node.path);
-        visit::visit_expr_path(self, node);
-    }
-
     fn visit_expr_call(&mut self, node: &'ast syn::ExprCall) {
         // A call's callee is an `Expr::Path` for free-fn / path calls;
         // `visit_expr_path` handles it. Method calls (`x.foo()`) carry
@@ -407,5 +402,10 @@ impl<'ast> Visit<'ast> for PurityScanner {
             self.check_path(&p.path);
         }
         visit::visit_expr_call(self, node);
+    }
+
+    fn visit_expr_path(&mut self, node: &'ast syn::ExprPath) {
+        self.check_path(&node.path);
+        visit::visit_expr_path(self, node);
     }
 }

--- a/crates/aether-data-derive/src/lib.rs
+++ b/crates/aether-data-derive/src/lib.rs
@@ -153,13 +153,16 @@ fn emit_inventory(func: &ItemFn, input_types: &[&Type], output_type: &Type) -> T
     // bounds at expansion time, so emit a `const _: fn() = || { <T as
     // Kind>::ID; };` per input + output. A build error fires if any type
     // doesn't impl `Kind` (ADR-0048 §1).
-    let bound_assertions = input_types.iter().chain(iter::once(&output_type)).map(|ty| {
-        quote! {
-            const _: fn() = || {
-                let _ = <#ty as ::aether_data::transform::__transform_runtime::Kind>::ID;
-            };
-        }
-    });
+    let bound_assertions = input_types
+        .iter()
+        .chain(iter::once(&output_type))
+        .map(|ty| {
+            quote! {
+                const _: fn() = || {
+                    let _ = <#ty as ::aether_data::transform::__transform_runtime::Kind>::ID;
+                };
+            }
+        });
 
     // Fully-qualified name string at the consumer's compile time:
     // `"{crate}::{module_path}::{fn}"`. `module_path!()` already begins
@@ -207,7 +210,8 @@ fn emit_inventory(func: &ItemFn, input_types: &[&Type], output_type: &Type) -> T
     // Static slices the inventory entry borrows. `inventory::submit!`
     // needs const-constructible borrows, so the input-kind-id list is a
     // file-scoped `static` array rather than an inline literal.
-    let input_kinds_static = format_ident!("__AETHER_TRANSFORM_INPUTS_{}", fn_name_str.to_uppercase());
+    let input_kinds_static =
+        format_ident!("__AETHER_TRANSFORM_INPUTS_{}", fn_name_str.to_uppercase());
     let input_kind_exprs = input_types.iter().map(|ty| {
         quote! {
             <#ty as ::aether_data::transform::__transform_runtime::Kind>::ID
@@ -310,21 +314,45 @@ struct DeniedPath {
 const DENY_LIST: &[DeniedPath] = &[
     // Host fns — match the bare fn tail so both qualified and
     // use-shortened call sites are caught.
-    DeniedPath { tail: &["send_mail_p32"] },
-    DeniedPath { tail: &["reply_mail_p32"] },
-    DeniedPath { tail: &["send_mail_traced_p32"] },
-    DeniedPath { tail: &["save_state_p32"] },
-    DeniedPath { tail: &["resolve_mailbox_p32"] },
-    DeniedPath { tail: &["resolve_kind_p32"] },
-    DeniedPath { tail: &["wait_reply"] },
+    DeniedPath {
+        tail: &["send_mail_p32"],
+    },
+    DeniedPath {
+        tail: &["reply_mail_p32"],
+    },
+    DeniedPath {
+        tail: &["send_mail_traced_p32"],
+    },
+    DeniedPath {
+        tail: &["save_state_p32"],
+    },
+    DeniedPath {
+        tail: &["resolve_mailbox_p32"],
+    },
+    DeniedPath {
+        tail: &["resolve_kind_p32"],
+    },
+    DeniedPath {
+        tail: &["wait_reply"],
+    },
     // Handler-context types.
-    DeniedPath { tail: &["aether_actor", "Ctx"] },
-    DeniedPath { tail: &["aether_actor", "MailCtx"] },
+    DeniedPath {
+        tail: &["aether_actor", "Ctx"],
+    },
+    DeniedPath {
+        tail: &["aether_actor", "MailCtx"],
+    },
     // Nondeterminism sources, by two-segment prefix so any item under
     // them (`now`, `Instant`, `var`, etc.) is rejected.
-    DeniedPath { tail: &["std", "env"] },
-    DeniedPath { tail: &["std", "time"] },
-    DeniedPath { tail: &["core", "time"] },
+    DeniedPath {
+        tail: &["std", "env"],
+    },
+    DeniedPath {
+        tail: &["std", "time"],
+    },
+    DeniedPath {
+        tail: &["core", "time"],
+    },
 ];
 
 /// Body-path collector + matcher. Records the span of the first path

--- a/crates/aether-data-derive/tests/transform.rs
+++ b/crates/aether-data-derive/tests/transform.rs
@@ -1,0 +1,68 @@
+//! `#[transform]` macro tests (ADR-0048 §1, iamacoffeepot/aether#979).
+//!
+//! The trybuild fixtures under `tests/ui/` exercise the macro's
+//! accept/reject surface: a pure single-input body and a multi-input
+//! body compile; a `Ctx` reference, a host-fn call, a `std::time` read,
+//! and a 9th parameter are rejected with the deny-list / cap
+//! `compile_error!`. The `transform_determinism` test calls a real
+//! generated `invoke` thunk twice on identical bytes and asserts
+//! byte-identical output (the content-addressing precondition).
+
+#![allow(clippy::unwrap_used)]
+
+use aether_data::transform;
+
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/ui/accepts_pure_body.rs");
+    t.pass("tests/ui/accepts_multi_input.rs");
+    t.compile_fail("tests/ui/rejects_ctx_param.rs");
+    t.compile_fail("tests/ui/rejects_host_fn.rs");
+    t.compile_fail("tests/ui/rejects_std_time.rs");
+    t.compile_fail("tests/ui/rejects_nine_inputs.rs");
+}
+
+#[repr(C)]
+#[derive(
+    Copy, Clone, Debug, PartialEq, bytemuck::Pod, bytemuck::Zeroable, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "test.det_scalar")]
+struct DetScalar {
+    value: u32,
+}
+
+/// A pure transform whose generated `invoke` the determinism test
+/// drives. Body is deterministic — same input bytes always produce the
+/// same output bytes.
+#[transform]
+fn det_double(x: DetScalar) -> DetScalar {
+    DetScalar {
+        value: x.value.wrapping_mul(2),
+    }
+}
+
+/// ADR-0048 §"Determinism": calling the generated `invoke` twice on
+/// identical input bytes yields byte-identical output. This is the CI
+/// determinism check the content-addressing scheme depends on.
+#[test]
+fn transform_determinism() {
+    use aether_data::Kind;
+
+    // Find the `det_double` entry in the link-time inventory.
+    let entry = aether_data::transforms()
+        .find(|e| e.name.ends_with("det_double"))
+        .expect("det_double transform registered in link-time inventory");
+
+    let input = DetScalar { value: 21 };
+    let input_bytes = input.encode_into_bytes();
+    let slices: [&[u8]; 1] = [input_bytes.as_slice()];
+
+    let out_a = (entry.invoke)(&slices).expect("first invoke succeeds");
+    let out_b = (entry.invoke)(&slices).expect("second invoke succeeds");
+    assert_eq!(out_a, out_b, "transform output must be byte-deterministic");
+
+    // Sanity: the decoded output is the doubled value.
+    let decoded = DetScalar::decode_from_bytes(&out_a).expect("output decodes");
+    assert_eq!(decoded, DetScalar { value: 42 });
+}

--- a/crates/aether-data-derive/tests/transform.rs
+++ b/crates/aether-data-derive/tests/transform.rs
@@ -25,7 +25,14 @@ fn ui() {
 
 #[repr(C)]
 #[derive(
-    Copy, Clone, Debug, PartialEq, bytemuck::Pod, bytemuck::Zeroable, aether_data::Kind, aether_data::Schema,
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
 )]
 #[kind(name = "test.det_scalar")]
 struct DetScalar {

--- a/crates/aether-data-derive/tests/ui/accepts_multi_input.rs
+++ b/crates/aether-data-derive/tests/ui/accepts_multi_input.rs
@@ -1,0 +1,35 @@
+//! `transform_accepts_multi_input` — a multi-input (≤ 8) pure transform
+//! compiles (ADR-0048 §1).
+
+use aether_data::transform;
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, aether_data::Kind, aether_data::Schema)]
+#[kind(name = "test.foo")]
+struct Foo {
+    a: u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, aether_data::Kind, aether_data::Schema)]
+#[kind(name = "test.bar")]
+struct Bar {
+    b: u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, aether_data::Kind, aether_data::Schema)]
+#[kind(name = "test.baz")]
+struct Baz {
+    sum: u32,
+}
+
+/// Joins two inputs into a sum.
+#[transform]
+fn join(a: Foo, b: Bar) -> Baz {
+    Baz {
+        sum: a.a + b.b,
+    }
+}
+
+fn main() {}

--- a/crates/aether-data-derive/tests/ui/accepts_pure_body.rs
+++ b/crates/aether-data-derive/tests/ui/accepts_pure_body.rs
@@ -1,0 +1,21 @@
+//! `transform_accepts_pure_body` — a pure single-input transform
+//! compiles (ADR-0048 §1).
+
+use aether_data::transform;
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, aether_data::Kind, aether_data::Schema)]
+#[kind(name = "test.scalar")]
+struct Scalar {
+    value: u32,
+}
+
+/// Doubles the wrapped value. Pure — no host calls, no nondeterminism.
+#[transform]
+fn double(x: Scalar) -> Scalar {
+    Scalar {
+        value: x.value * 2,
+    }
+}
+
+fn main() {}

--- a/crates/aether-data-derive/tests/ui/rejects_ctx_param.rs
+++ b/crates/aether-data-derive/tests/ui/rejects_ctx_param.rs
@@ -1,0 +1,20 @@
+//! `transform_rejects_ctx_param` — a transform whose body names the
+//! handler-context type `aether_actor::Ctx` is rejected by the
+//! deny-list scan (ADR-0048 §1).
+
+use aether_data::transform;
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, aether_data::Kind, aether_data::Schema)]
+#[kind(name = "test.scalar")]
+struct Scalar {
+    value: u32,
+}
+
+#[transform]
+fn bad(x: Scalar) -> Scalar {
+    let _ = aether_actor::Ctx::nothing();
+    x
+}
+
+fn main() {}

--- a/crates/aether-data-derive/tests/ui/rejects_ctx_param.stderr
+++ b/crates/aether-data-derive/tests/ui/rejects_ctx_param.stderr
@@ -1,0 +1,5 @@
+error: transforms cannot call host functions or access handler context -- see ADR-0048
+  --> tests/ui/rejects_ctx_param.rs:16:13
+   |
+16 |     let _ = aether_actor::Ctx::nothing();
+   |             ^^^^^^^^^^^^

--- a/crates/aether-data-derive/tests/ui/rejects_host_fn.rs
+++ b/crates/aether-data-derive/tests/ui/rejects_host_fn.rs
@@ -1,0 +1,20 @@
+//! `transform_rejects_host_fn` — a transform body that calls a host fn
+//! (`aether::send_mail_p32`) is rejected by the deny-list scan
+//! (ADR-0048 §1).
+
+use aether_data::transform;
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, aether_data::Kind, aether_data::Schema)]
+#[kind(name = "test.scalar")]
+struct Scalar {
+    value: u32,
+}
+
+#[transform]
+fn bad(x: Scalar) -> Scalar {
+    aether::send_mail_p32(0, 0, 0, 0);
+    x
+}
+
+fn main() {}

--- a/crates/aether-data-derive/tests/ui/rejects_host_fn.stderr
+++ b/crates/aether-data-derive/tests/ui/rejects_host_fn.stderr
@@ -1,0 +1,5 @@
+error: transforms cannot call host functions or access handler context -- see ADR-0048
+  --> tests/ui/rejects_host_fn.rs:16:5
+   |
+16 |     aether::send_mail_p32(0, 0, 0, 0);
+   |     ^^^^^^

--- a/crates/aether-data-derive/tests/ui/rejects_nine_inputs.rs
+++ b/crates/aether-data-derive/tests/ui/rejects_nine_inputs.rs
@@ -1,0 +1,28 @@
+//! `transform_rejects_nine_inputs` — a 9-parameter transform exceeds
+//! the ADR-0048 §1 cap of 8 inputs and is rejected.
+
+use aether_data::transform;
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, aether_data::Kind, aether_data::Schema)]
+#[kind(name = "test.scalar")]
+struct Scalar {
+    value: u32,
+}
+
+#[transform]
+fn too_many(
+    a: Scalar,
+    b: Scalar,
+    c: Scalar,
+    d: Scalar,
+    e: Scalar,
+    f: Scalar,
+    g: Scalar,
+    h: Scalar,
+    i: Scalar,
+) -> Scalar {
+    a
+}
+
+fn main() {}

--- a/crates/aether-data-derive/tests/ui/rejects_nine_inputs.stderr
+++ b/crates/aether-data-derive/tests/ui/rejects_nine_inputs.stderr
@@ -1,0 +1,5 @@
+error: transforms accept at most 8 inputs (ADR-0048 §1); found 9
+  --> tests/ui/rejects_nine_inputs.rs:15:5
+   |
+15 |     a: Scalar,
+   |     ^

--- a/crates/aether-data-derive/tests/ui/rejects_std_time.rs
+++ b/crates/aether-data-derive/tests/ui/rejects_std_time.rs
@@ -1,0 +1,20 @@
+//! `transform_rejects_std_time` — a transform body that reads
+//! `std::time::Instant::now()` is rejected by the deny-list scan as a
+//! nondeterminism source (ADR-0048 §1).
+
+use aether_data::transform;
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, aether_data::Kind, aether_data::Schema)]
+#[kind(name = "test.scalar")]
+struct Scalar {
+    value: u32,
+}
+
+#[transform]
+fn bad(x: Scalar) -> Scalar {
+    let _ = std::time::Instant::now();
+    x
+}
+
+fn main() {}

--- a/crates/aether-data-derive/tests/ui/rejects_std_time.stderr
+++ b/crates/aether-data-derive/tests/ui/rejects_std_time.stderr
@@ -1,0 +1,5 @@
+error: transforms cannot call host functions or access handler context -- see ADR-0048
+  --> tests/ui/rejects_std_time.rs:16:13
+   |
+16 |     let _ = std::time::Instant::now();
+   |             ^^^

--- a/crates/aether-data/Cargo.toml
+++ b/crates/aether-data/Cargo.toml
@@ -7,12 +7,16 @@ edition.workspace = true
 # Re-export `#[derive(Kind)]` and `#[derive(Schema)]` from
 # `aether-actor-derive` (ADR-0077 / issue 552 stage 0: the kind +
 # actor proc-macros consolidated into one crate so the derive home
-# matches the SDK home). Off by default so guests that hand-write
-# `impl Kind for ...` don't pay the proc-macro compile cost.
-derive = ["dep:aether-actor-derive"]
+# matches the SDK home), plus the `#[transform]` attribute macro from
+# `aether-data-derive` (ADR-0048 §1: a transform is a pure data-layer
+# primitive, so its macro re-exports from the data layer). Off by
+# default so guests that hand-write `impl Kind for ...` don't pay the
+# proc-macro compile cost.
+derive = ["dep:aether-actor-derive", "dep:aether-data-derive"]
 
 [dependencies]
 aether-actor-derive = { path = "../aether-actor-derive", optional = true }
+aether-data-derive = { path = "../aether-data-derive", optional = true }
 bytemuck = { version = "1.19", features = ["derive"] }
 postcard = { version = "1.1", default-features = false, features = ["alloc"] }
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }

--- a/crates/aether-data/src/hash.rs
+++ b/crates/aether-data/src/hash.rs
@@ -29,6 +29,16 @@ pub const KIND_DOMAIN: &[u8] = b"kind:";
 /// so a typed-id `TYPE_ID` cannot alias either space.
 pub const TYPE_DOMAIN: &[u8] = b"type:";
 
+/// ADR-0048 §1: 16-byte domain prefix for native-transform id hashes.
+/// Hashed input is `TRANSFORM_DOMAIN ++ "{crate}::{module}::{fn}"`. A
+/// transform's identity is name-based (not position-based), so
+/// inserting / reordering transforms in a file leaves every id stable;
+/// renaming or moving a transform fn changes its id. Disjoint from the
+/// mailbox / kind / handle domains so a `TransformId` can't alias any
+/// of those spaces. The `#[transform]` macro prepends this before the
+/// canonical name bytes.
+pub const TRANSFORM_DOMAIN: [u8; 16] = *b"aether/xform/v1\0";
+
 /// FNV-1a 64 over a byte slice. Retained for the few call sites that
 /// hash neither a mailbox name nor a kind schema. New callers should
 /// prefer `fnv1a_64_prefixed` with an explicit domain so the output

--- a/crates/aether-data/src/hash.rs
+++ b/crates/aether-data/src/hash.rs
@@ -6,7 +6,7 @@
 //! `MailboxId`-into-`KindId` slot (or vice versa) hashes to a
 //! different value rather than colliding silently.
 
-use crate::ids::MailboxId;
+use crate::ids::{HandleId, MailboxId, TransformId};
 use crate::tagged_id::{Tag, with_tag};
 
 /// Domain tag prefixed to every mailbox-name hash so the `MailboxId`
@@ -38,6 +38,60 @@ pub const TYPE_DOMAIN: &[u8] = b"type:";
 /// of those spaces. The `#[transform]` macro prepends this before the
 /// canonical name bytes.
 pub const TRANSFORM_DOMAIN: [u8; 16] = *b"aether/xform/v1\0";
+
+/// ADR-0048 §4: 16-byte domain prefix for content-addressed handle-id
+/// derivation. Disjoint from `KIND_DOMAIN`, `MAILBOX_DOMAIN`,
+/// `TRANSFORM_DOMAIN`, and `TYPE_DOMAIN` so a 64-bit collision within
+/// the handle space can't cross-pollinate the other registries.
+pub const HANDLE_DOMAIN: [u8; 16] = *b"aether/handle/v1";
+
+/// ADR-0048 §4: derive the content-addressed [`HandleId`] for a native
+/// transform applied to a set of input handles.
+///
+/// `inputs` are the input handle ids in **slot-index order** (the
+/// caller resolves `Edge.slot` ascending to build the list). The id
+/// keys on the global `transform_id` — a native transform is global to
+/// the substrate build, not owned by a component instance — so
+/// identical compute dedups engine-wide and across restarts.
+///
+/// Derivation (ADR-0048 §4):
+///
+/// ```text
+/// HANDLE_DOMAIN
+///   ++ transform_id.0.to_le_bytes()
+///   ++ [inputs.len() as u8]
+///   ++ for (slot, handle) in inputs: [slot as u8] ++ handle.0.to_le_bytes()
+/// ```
+///
+/// The explicit `slot` byte before each input handle id protects the
+/// `compose(a, b)` vs `compose(b, a)` case — swapping the two slots
+/// changes the hash, so semantically different transforms get different
+/// cache entries. The `inputs.len()` byte distinguishes `foo(a)` from
+/// `foo(a, a)`. The result carries `Tag::Handle` bits so it lives in the
+/// same id space as ephemeral handles (the executor's cache check keys
+/// on the full tagged id).
+///
+/// `inputs.len()` is truncated to a `u8`; the ADR-0048 §1 input cap is
+/// 8, so a transform never reaches the 256-input wraparound.
+#[must_use]
+#[allow(clippy::cast_possible_truncation)]
+pub fn content_addressed_handle_id(transform_id: TransformId, inputs: &[HandleId]) -> HandleId {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    let mut feed = |bytes: &[u8]| {
+        for &b in bytes {
+            hash ^= u64::from(b);
+            hash = hash.wrapping_mul(0x0100_0000_01b3);
+        }
+    };
+    feed(&HANDLE_DOMAIN);
+    feed(&transform_id.0.to_le_bytes());
+    feed(&[inputs.len() as u8]);
+    for (slot, handle) in inputs.iter().enumerate() {
+        feed(&[slot as u8]);
+        feed(&handle.0.to_le_bytes());
+    }
+    HandleId(with_tag(Tag::Handle, hash))
+}
 
 /// FNV-1a 64 over a byte slice. Retained for the few call sites that
 /// hash neither a mailbox name nor a kind schema. New callers should

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -51,11 +51,15 @@ pub mod mail;
 pub mod schema;
 pub mod tag_bits;
 pub mod tagged_id;
+pub mod transform;
 pub mod wire_id;
 pub use hash::{
-    KIND_DOMAIN, MAILBOX_DOMAIN, TYPE_DOMAIN, fnv1a_64_bytes, fnv1a_64_prefixed,
+    KIND_DOMAIN, MAILBOX_DOMAIN, TRANSFORM_DOMAIN, TYPE_DOMAIN, fnv1a_64_bytes, fnv1a_64_prefixed,
     mailbox_id_from_name,
 };
+pub use transform::{InvokeFn, TransformError};
+#[cfg(not(target_arch = "wasm32"))]
+pub use transform::{TransformEntry, transforms};
 pub use ids::{
     DagId, HandleId, KindId, MailboxId, TransformId, tag_for_type_id, type_name_for_type_id,
 };
@@ -79,6 +83,16 @@ pub use wire_id::{EngineId, SessionToken, Uuid};
 pub use aether_actor_derive::{
     Instanced, Kind, Schema, Singleton, actor, bridge, capability, fallback, handler, local,
 };
+
+/// Re-exported `#[transform]` attribute macro from `aether-data-derive`
+/// (ADR-0048 §1). A transform is a pure `Kind -> Kind` data-layer
+/// primitive — no actor dependence — so its macro re-exports from the
+/// data layer as `aether_data::transform`, not from the actor SDK. Lives
+/// in the sibling `aether-data-derive` crate because `aether-data` is
+/// `no_std` + `alloc` and cannot itself be `proc-macro = true`. Behind
+/// the `derive` feature like the other macros.
+#[cfg(feature = "derive")]
+pub use aether_data_derive::transform;
 
 /// Identifies a mail kind by a stable, namespaced string name (e.g.
 /// `"aether.tick"`, `"hello.npc_health"`) and a `u64` id derived from

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -54,8 +54,8 @@ pub mod tagged_id;
 pub mod transform;
 pub mod wire_id;
 pub use hash::{
-    KIND_DOMAIN, MAILBOX_DOMAIN, TRANSFORM_DOMAIN, TYPE_DOMAIN, fnv1a_64_bytes, fnv1a_64_prefixed,
-    mailbox_id_from_name,
+    HANDLE_DOMAIN, KIND_DOMAIN, MAILBOX_DOMAIN, TRANSFORM_DOMAIN, TYPE_DOMAIN,
+    content_addressed_handle_id, fnv1a_64_bytes, fnv1a_64_prefixed, mailbox_id_from_name,
 };
 pub use transform::{InvokeFn, TransformError};
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -57,15 +57,15 @@ pub use hash::{
     HANDLE_DOMAIN, KIND_DOMAIN, MAILBOX_DOMAIN, TRANSFORM_DOMAIN, TYPE_DOMAIN,
     content_addressed_handle_id, fnv1a_64_bytes, fnv1a_64_prefixed, mailbox_id_from_name,
 };
-pub use transform::{InvokeFn, TransformError};
-#[cfg(not(target_arch = "wasm32"))]
-pub use transform::{TransformEntry, transforms};
 pub use ids::{
     DagId, HandleId, KindId, MailboxId, TransformId, tag_for_type_id, type_name_for_type_id,
 };
 pub use mail::{MailId, ReplyTarget, ReplyTo};
 pub use schema::*;
 pub use tagged_id::{Tag, with_tag};
+pub use transform::{InvokeFn, TransformError};
+#[cfg(not(target_arch = "wasm32"))]
+pub use transform::{TransformEntry, transforms};
 pub use wire_id::{EngineId, SessionToken, Uuid};
 
 /// Re-exported derive macros from `aether-actor-derive`. Behind the

--- a/crates/aether-data/src/transform.rs
+++ b/crates/aether-data/src/transform.rs
@@ -110,12 +110,12 @@ pub fn transforms() -> impl Iterator<Item = &'static TransformEntry> {
 /// Not part of the public API; the macro is the only intended caller.
 #[doc(hidden)]
 pub mod __transform_runtime {
+    #[cfg(not(target_arch = "wasm32"))]
+    pub use super::TransformEntry;
     pub use super::{InvokeFn, TransformError};
     pub use crate::Kind;
     pub use crate::KindId;
     pub use crate::ids::TransformId;
-    #[cfg(not(target_arch = "wasm32"))]
-    pub use super::TransformEntry;
     #[cfg(not(target_arch = "wasm32"))]
     pub use ::inventory;
     pub use alloc::vec::Vec;

--- a/crates/aether-data/src/transform.rs
+++ b/crates/aether-data/src/transform.rs
@@ -1,0 +1,122 @@
+//! ADR-0048 §1 native-transform runtime types + link-time inventory.
+//!
+//! A transform is a **data-layer primitive** — a pure `Kind -> Kind`
+//! function with zero dependence on the actor framework (no `Ctx`, no
+//! mail, no lifecycle). Its surface therefore lives here, next to
+//! `Kind` and the native descriptor inventory, not in the actor SDK.
+//! The authoring macro `#[transform]` re-exports from `aether-data` as
+//! `aether_data::transform` (impl in the sibling `aether-data-derive`
+//! crate, which `aether-data` cannot itself be — a proc-macro crate
+//! can't export runtime items).
+//!
+//! There is no FFI shim, no `extern "C"`, no `aether.dag.transforms`
+//! custom section — the original wasm-export design was deferred before
+//! implementation (ADR-0048 revision 2026-05-20). A transform is plain
+//! native Rust collected at link time through [`TransformEntry`].
+
+use alloc::vec::Vec;
+use core::fmt;
+
+use crate::KindId;
+use crate::ids::TransformId;
+
+/// Why a transform invocation failed (ADR-0048 §6). Encoding /
+/// decoding the typed inputs and output is the only failure surface —
+/// the transform fn itself returns a `Kind` value (a domain `Err` is a
+/// successful, content-addressed output, not a [`TransformError`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TransformError {
+    /// One input slice didn't decode against its declared input kind's
+    /// canonical-bytes path. `slot` is the slot index (0-based).
+    InputDecode { slot: usize },
+    /// The number of supplied input slices didn't match the transform's
+    /// declared input arity.
+    InputArity { expected: usize, actual: usize },
+    /// The encoded output exceeded the executor's output-byte cap
+    /// (ADR-0048 §6). The cap itself lives in the executor; the macro's
+    /// `invoke` thunk never enforces it, but the variant is reserved
+    /// here so the executor and the thunk share one error type.
+    OutputOverflow { limit: usize, actual: usize },
+}
+
+impl fmt::Display for TransformError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InputDecode { slot } => {
+                write!(f, "transform input slot {slot} failed to decode")
+            }
+            Self::InputArity { expected, actual } => {
+                write!(
+                    f,
+                    "transform input arity mismatch: expected {expected}, got {actual}"
+                )
+            }
+            Self::OutputOverflow { limit, actual } => {
+                write!(
+                    f,
+                    "transform output exceeded {limit} bytes (encoded {actual})"
+                )
+            }
+        }
+    }
+}
+
+/// Type-erased invocation thunk shape (ADR-0048 §1). The `#[transform]`
+/// macro generates one of these per transform fn: it decodes each input
+/// slice against its declared kind, calls the user fn, and encodes the
+/// output. Inputs arrive in **slot-index order**.
+pub type InvokeFn = fn(&[&[u8]]) -> Result<Vec<u8>, TransformError>;
+
+/// Static-friendly mirror of a registered native transform, submitted
+/// at link time by the `#[transform]` macro (the same `inventory`
+/// pattern as `aether-data`'s native descriptor inventory). Owns
+/// nothing but `&'static` data + a fn pointer so it is
+/// const-constructible from `inventory::submit!`.
+///
+/// The substrate builds its `TransformRegistry`
+/// (iamacoffeepot/aether#1012) by iterating [`transforms()`] once at
+/// startup, keying on [`Self::transform_id`].
+#[cfg(not(target_arch = "wasm32"))]
+pub struct TransformEntry {
+    /// Stable name-based id (ADR-0048 §1):
+    /// `fnv1a_64(TRANSFORM_DOMAIN ++ "{crate}::{module_path}::{fn}")`,
+    /// tagged `Tag::Transform`.
+    pub transform_id: TransformId,
+    /// Declared input kind ids, in parameter (slot) order. Up to 8.
+    pub input_kind_ids: &'static [KindId],
+    /// Declared output kind id.
+    pub output_kind_id: KindId,
+    /// `"{crate}::{module_path}::{fn}"` — diagnostics + MCP
+    /// introspection.
+    pub name: &'static str,
+    /// Type-erased decode → call → encode thunk.
+    pub invoke: InvokeFn,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+inventory::collect!(TransformEntry);
+
+/// Iterate every native transform collected at link time (ADR-0048
+/// §1/§2). The substrate's `TransformRegistry` materializes from this
+/// at startup; the set is fixed for the process lifetime.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn transforms() -> impl Iterator<Item = &'static TransformEntry> {
+    inventory::iter::<TransformEntry>.into_iter()
+}
+
+/// Re-exports the `#[transform]` macro points at so its generated
+/// `invoke` thunk + inventory submission compile in a consumer crate
+/// without that crate naming `inventory` or the runtime types directly.
+/// Not part of the public API; the macro is the only intended caller.
+#[doc(hidden)]
+pub mod __transform_runtime {
+    pub use super::{InvokeFn, TransformError};
+    pub use crate::Kind;
+    pub use crate::KindId;
+    pub use crate::ids::TransformId;
+    #[cfg(not(target_arch = "wasm32"))]
+    pub use super::TransformEntry;
+    #[cfg(not(target_arch = "wasm32"))]
+    pub use ::inventory;
+    pub use alloc::vec::Vec;
+}

--- a/crates/aether-data/tests/content_addressed_handles.rs
+++ b/crates/aether-data/tests/content_addressed_handles.rs
@@ -1,0 +1,117 @@
+//! ADR-0048 §4 content-addressed handle-id derivation tests
+//! (iamacoffeepot/aether#982).
+//!
+//! Exercises `content_addressed_handle_id`: determinism, slot-order
+//! sensitivity, input-count sensitivity, transform-id sensitivity,
+//! cross-domain disjointness, and a 10k-tuple collision smoke test.
+
+#![allow(clippy::unwrap_used)]
+
+use std::collections::HashSet;
+
+use aether_data::tagged_id::tag_of;
+use aether_data::{HandleId, KindId, Tag, TransformId, content_addressed_handle_id, with_tag};
+
+/// A `TransformId` tagged in the transform space.
+fn tx(body: u64) -> TransformId {
+    TransformId(with_tag(Tag::Transform, body))
+}
+
+/// A `HandleId` tagged in the handle space.
+fn hid(body: u64) -> HandleId {
+    HandleId(with_tag(Tag::Handle, body))
+}
+
+/// Same `(transform_id, inputs)` in the same order produces the same id
+/// across 1000 iterations.
+#[test]
+fn content_addressed_handles_deterministic() {
+    let transform = tx(0x1111);
+    let inputs = [hid(0xaaaa), hid(0xbbbb), hid(0xcccc)];
+    let first = content_addressed_handle_id(transform, &inputs);
+    for _ in 0..1000 {
+        assert_eq!(content_addressed_handle_id(transform, &inputs), first);
+    }
+}
+
+/// `compose(a, b)` and `compose(b, a)` produce different ids — the slot
+/// byte before each input handle id makes the order load-bearing.
+#[test]
+fn content_addressed_handles_slot_order_matters() {
+    let transform = tx(0x2222);
+    let a = hid(0x1234);
+    let b = hid(0x5678);
+    let ab = content_addressed_handle_id(transform, &[a, b]);
+    let ba = content_addressed_handle_id(transform, &[b, a]);
+    assert_ne!(ab, ba);
+}
+
+/// `foo(a)` and `foo(a, a)` produce different ids — the `input_count`
+/// byte distinguishes arities.
+#[test]
+fn content_addressed_handles_input_count_matters() {
+    let transform = tx(0x3333);
+    let a = hid(0x9999);
+    let one = content_addressed_handle_id(transform, &[a]);
+    let two = content_addressed_handle_id(transform, &[a, a]);
+    assert_ne!(one, two);
+}
+
+/// Same inputs, different `transform_id` produce different ids.
+#[test]
+fn content_addressed_handles_transform_id_matters() {
+    let inputs = [hid(0xdead), hid(0xbeef)];
+    let one = content_addressed_handle_id(tx(0x4444), &inputs);
+    let two = content_addressed_handle_id(tx(0x5555), &inputs);
+    assert_ne!(one, two);
+}
+
+/// A fabricated value treated as a `KindId` vs as a `TransformId` /
+/// `HandleId` produces a different content-address id — the
+/// `HANDLE_DOMAIN` prefix separates the spaces. Cross-domain collision
+/// sanity check.
+#[test]
+fn content_addressed_handles_disjoint_domain() {
+    // Same raw 60-bit body interpreted as a transform id vs as a
+    // (mis-tagged) kind id. The handle-domain salt + the tag bits both
+    // contribute, so the derived ids differ.
+    let body = 0x0fed_cba9_8765_4321 & 0x0fff_ffff_ffff_ffff;
+    let as_transform = tx(body);
+    // A KindId carrying the same body bits but the kind tag. Feeding its
+    // raw u64 through the transform slot of the derivation must not
+    // collide with the transform-tagged derivation.
+    let as_kind = KindId(with_tag(Tag::Kind, body));
+    let via_transform = content_addressed_handle_id(as_transform, &[hid(0x1)]);
+    let via_kind_bits = content_addressed_handle_id(TransformId(as_kind.0), &[hid(0x1)]);
+    assert_ne!(
+        via_transform, via_kind_bits,
+        "transform-tagged vs kind-tagged input bits must derive distinct handle ids",
+    );
+    // And the derived id is itself tagged in the handle space.
+    assert_eq!(tag_of(via_transform.0), Some(Tag::Handle));
+}
+
+/// 10k random `(transform_id, inputs)` tuples — no id collides. 10k vs
+/// 64-bit (60-bit body) is well under the birthday bound; a collision
+/// would indicate a derivation bug. Uses a deterministic xorshift PRNG
+/// so the test is reproducible without a `rand` dep.
+#[test]
+fn content_addressed_handles_collision_resistance_smoke() {
+    let mut state: u64 = 0x9e37_79b9_7f4a_7c15;
+    let mut next = || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state
+    };
+
+    let mut ids: HashSet<HandleId> = HashSet::with_capacity(10_000);
+    for _ in 0..10_000 {
+        let transform = tx(next());
+        let arity = (next() % 5) as usize; // 0..=4 inputs
+        let inputs: Vec<HandleId> = (0..arity).map(|_| hid(next())).collect();
+        let id = content_addressed_handle_id(transform, &inputs);
+        assert!(ids.insert(id), "content-address collision in 10k smoke test");
+    }
+    assert_eq!(ids.len(), 10_000);
+}

--- a/crates/aether-data/tests/content_addressed_handles.rs
+++ b/crates/aether-data/tests/content_addressed_handles.rs
@@ -111,7 +111,10 @@ fn content_addressed_handles_collision_resistance_smoke() {
         let arity = (next() % 5) as usize; // 0..=4 inputs
         let inputs: Vec<HandleId> = (0..arity).map(|_| hid(next())).collect();
         let id = content_addressed_handle_id(transform, &inputs);
-        assert!(ids.insert(id), "content-address collision in 10k smoke test");
+        assert!(
+            ids.insert(id),
+            "content-address collision in 10k smoke test"
+        );
     }
     assert_eq!(ids.len(), 10_000);
 }

--- a/crates/aether-kinds/src/dag.rs
+++ b/crates/aether-kinds/src/dag.rs
@@ -64,12 +64,22 @@ pub enum Node {
     },
     /// Mid-graph pure transform (ADR-0048 native-transform shape).
     /// Identity is the global `transform_id`; `output_kind_id`
-    /// declares what the node produces. Dispatch lights up in Phase 3
-    /// (iamacoffeepot/aether#976) — Phase 2 reserves the wire shape.
+    /// declares what the node produces. Dispatch is the native
+    /// invocation path (iamacoffeepot/aether#1012): the executor runs
+    /// the registered `fn` off-thread on a compute pool, caches the
+    /// content-addressed output, and resolves the node's handle.
     Transform {
         id: NodeId,
         transform_id: TransformId,
         output_kind_id: KindId,
+        /// Per-call wall-clock deadline, in milliseconds (ADR-0048 §3,
+        /// §6). `None` uses the executor's default
+        /// (`AETHER_TRANSFORM_TIMEOUT_MS`). A native thread can't be
+        /// safely preempted, so on deadline the executor fails the node
+        /// and orphans the runaway thread — best-effort, acceptable only
+        /// because transforms are first-party reviewed code. Wire-additive
+        /// (appended field, `Option` so existing descriptors decode).
+        timeout_ms: Option<u64>,
     },
     /// Mid-graph effectful cap dispatch (ADR-0047 rev 2026-05-20). Its
     /// request is assembled from incoming edges (the observer-side
@@ -366,3 +376,33 @@ pub enum DagError {
 )]
 #[kind(name = "aether.dag.reap_tick")]
 pub struct DagReapTick {}
+
+/// `aether.dag.transform_done` — internal wake mail signalling that an
+/// off-thread native-transform invocation finished (ADR-0048 §3). The
+/// executor's transform compute pool fires this (carrying the `job_id`
+/// of the completed invocation) at the `aether.dag` mailbox so the
+/// executor pulls the stashed result and resolves / fails the node on
+/// its own single-threaded actor thread (the `DagState` map is
+/// lock-free actor state — the pool thread can't touch it directly).
+/// Mirrors the `DagReapTick` / `aether.tcp` sidecar-wake pattern: the
+/// mail is only the signal; the result lives in a shared completion
+/// map keyed by `job_id`.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "aether.dag.transform_done")]
+pub struct DagTransformDone {
+    /// Identifies the completed invocation in the executor's in-flight
+    /// transform table + the pool's completion map.
+    pub job_id: u64,
+}

--- a/crates/aether-kinds/tests/dag_descriptor_with_transform_node.rs
+++ b/crates/aether-kinds/tests/dag_descriptor_with_transform_node.rs
@@ -20,6 +20,7 @@ fn descriptor_with_transform_node_roundtrips() {
                 id: NodeId(1),
                 transform_id: TransformId(0x5000),
                 output_kind_id: KindId(0x6000),
+                timeout_ms: None,
             },
             Node::Observer {
                 id: NodeId(2),

--- a/crates/aether-mcp/src/args.rs
+++ b/crates/aether-mcp/src/args.rs
@@ -200,6 +200,17 @@ pub struct DescribeHandlesArgs {
     pub max: Option<u32>,
 }
 
+/// One native transform's metadata as `describe_transforms` renders it
+/// (ADR-0048 §2). `transform_id` / `*_kind_id` are tagged-id strings
+/// (ADR-0064).
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct TransformListing {
+    pub transform_id: String,
+    pub name: &'static str,
+    pub input_kind_ids: Vec<String>,
+    pub output_kind_id: String,
+}
+
 /// One handle's summary line as `describe_handles` renders it. `handle_id`
 /// and `kind_id` are tagged-id strings (ADR-0064).
 #[derive(Debug, Serialize, JsonSchema)]

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -46,7 +46,7 @@ use crate::args::{
     DescribeHandlesArgs, DescribeHandlesResponse, EngineInfo, HandleSummaryJson, LoadComponentArgs,
     MailIdJson, MailNodeJson, MailSpec, MailStatus, ReplaceComponentArgs, SendMailArgs,
     SendMailTracedArgs, SendMailTracedResponse, SpawnSubstrateArgs, SubmitDagArgs,
-    TerminateSubstrateArgs, TracedMailSpec,
+    TerminateSubstrateArgs, TracedMailSpec, TransformListing,
 };
 use crate::rpc::RpcSession;
 use aether_kinds::descriptors;
@@ -417,6 +417,21 @@ impl Mcp {
     )]
     pub async fn describe_kinds(&self) -> Result<String, McpError> {
         json(&descriptors::all())
+    }
+
+    #[tool(
+        description = "List the native transforms collected at link time (ADR-0048): every #[transform] fn with its global transform_id, fully-qualified name, declared input kind ids (slot order), and output kind id. These are pure Kind -> Kind functions a DAG Transform node dispatches; this is the static inventory aether-mcp ships with (a transform set is a build-time property). Empty when no first-party transforms are linked."
+    )]
+    pub async fn describe_transforms(&self) -> Result<String, McpError> {
+        let listing: Vec<TransformListing> = aether_data::transforms()
+            .map(|t| TransformListing {
+                transform_id: t.transform_id.to_string(),
+                name: t.name,
+                input_kind_ids: t.input_kind_ids.iter().map(ToString::to_string).collect(),
+                output_kind_id: t.output_kind_id.to_string(),
+            })
+            .collect();
+        json(&listing)
     }
 
     #[tool(

--- a/crates/aether-substrate/src/dag/executor.rs
+++ b/crates/aether-substrate/src/dag/executor.rs
@@ -42,20 +42,28 @@ use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 use aether_data::canonical::canonical_kind_bytes;
-use aether_data::{DagId, HandleId, KindId, MailId, MailboxId, Ref, SchemaType, Tag, with_tag};
+use aether_data::{
+    DagId, HandleId, KindId, MailId, MailboxId, Ref, SchemaType, Tag, TransformId,
+    content_addressed_handle_id, with_tag,
+};
 use aether_kinds::{
-    Bundle, BundleElement, CancelResult, DagDescriptor, Node, NodeId, StatusResult, trace::Settled,
+    Bundle, BundleElement, CancelResult, DagDescriptor, DagTransformDone, Node, NodeId,
+    StatusResult, trace::Settled,
 };
 
 use crate::actor::native::NativeCtx;
 use crate::dag::state::{CallBuffer, DagState, DagStatus};
+use crate::dag::transform_pool::{TransformOutcome, TransformPool};
+use crate::dag::transform_registry::TransformRegistry;
 use crate::dag::validator::validate;
 use crate::handle_store::HandleStore;
 use crate::mail::mailer::Mailer;
 use crate::mail::registry::Registry;
 
 use std::env;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
+use std::thread;
 
 const TARGET: &str = "aether::dag::executor";
 
@@ -68,6 +76,16 @@ pub const ENV_RETENTION_FAILED_MS: &str = "AETHER_DAG_RETENTION_FAILED_MS";
 /// Env override for the per-`Call` settlement timeout (ADR-0047 §4 —
 /// never-settling caps). Default [`DEFAULT_CALL_TIMEOUT_MS`].
 pub const ENV_CALL_TIMEOUT_MS: &str = "AETHER_DAG_CALL_TIMEOUT_MS";
+/// Env override for the default per-`Transform` wall-clock deadline
+/// (ADR-0048 §3/§6). A `Node::Transform.timeout_ms` overrides per node.
+/// Default [`DEFAULT_TRANSFORM_TIMEOUT_MS`].
+pub const ENV_TRANSFORM_TIMEOUT_MS: &str = "AETHER_TRANSFORM_TIMEOUT_MS";
+/// Env override for the transform output-byte cap (ADR-0048 §6).
+/// Default [`DEFAULT_TRANSFORM_MAX_OUTPUT_BYTES`].
+pub const ENV_TRANSFORM_MAX_OUTPUT_BYTES: &str = "AETHER_TRANSFORM_MAX_OUTPUT_BYTES";
+/// Env override for the transform compute-pool thread count (ADR-0048
+/// §3). Default: available parallelism (clamped to ≥ 1).
+pub const ENV_TRANSFORM_POOL_THREADS: &str = "AETHER_TRANSFORM_POOL_THREADS";
 
 /// Default completed-DAG retention before reaping (ADR-0047 §7).
 pub const DEFAULT_RETENTION_COMPLETE_MS: u64 = 60_000;
@@ -77,6 +95,13 @@ pub const DEFAULT_RETENTION_FAILED_MS: u64 = 300_000;
 /// settles (never replies or streams forever). On expiry the `Call`
 /// node fails (ADR-0047 §4).
 pub const DEFAULT_CALL_TIMEOUT_MS: u64 = 30_000;
+/// Default per-`Transform` wall-clock deadline (ADR-0048 §3/§6). A
+/// native thread can't be preempted, so on expiry the executor fails
+/// the node + orphans the runaway thread.
+pub const DEFAULT_TRANSFORM_TIMEOUT_MS: u64 = 30_000;
+/// Default transform output-byte cap (ADR-0048 §6). Encoded output
+/// exceeding this hard-fails the node.
+pub const DEFAULT_TRANSFORM_MAX_OUTPUT_BYTES: u64 = 64 * 1024 * 1024;
 
 /// What a landed reply correlates to (ADR-0047 §4). Sources resolve a
 /// stored handle and flush downstream; `Call`s accumulate into a
@@ -105,6 +130,23 @@ struct InFlightCall {
     deadline: Instant,
 }
 
+/// One off-thread `Transform` invocation in flight, for the per-call
+/// deadline sweep (ADR-0048 §3/§6). The pool's wake mail resolves the
+/// node when the `fn` returns; the reaper fails it if the deadline
+/// passes first (the runaway thread is then orphaned).
+#[derive(Copy, Clone, Debug)]
+struct InFlightTransform {
+    dag_id: DagId,
+    node_id: NodeId,
+    handle_id: HandleId,
+    /// Content-addressed id the output is stored under on success.
+    content_id: HandleId,
+    output_kind_id: KindId,
+    deadline: Instant,
+    /// The deadline expressed in millis, for the timeout diagnostic.
+    timeout_ms: u64,
+}
+
 /// The DAG executor. Holds every live + recently-terminal DAG plus the
 /// reply-correlation table the cap routes landings through.
 pub struct Executor {
@@ -119,19 +161,40 @@ pub struct Executor {
     pending: HashMap<u64, Pending>,
     /// In-flight `Call`s with a settlement deadline, swept by [`Self::reap`].
     in_flight_calls: HashMap<u64, InFlightCall>,
+    /// In-flight off-thread `Transform`s, keyed by the pool's `job_id`,
+    /// swept for deadline by [`Self::reap`] and resolved on the pool's
+    /// `DagTransformDone` wake (ADR-0048 §3).
+    in_flight_transforms: HashMap<u64, InFlightTransform>,
     /// Cached per-`Call` settlement timeout.
     call_timeout: Duration,
+    /// Cached default per-`Transform` deadline (ADR-0048 §3).
+    transform_timeout: Duration,
+    /// Cached transform output-byte cap (ADR-0048 §6).
+    transform_max_output_bytes: usize,
     /// Cached completed-DAG retention window.
     retention_complete: Duration,
     /// Cached failed/cancelled-DAG retention window.
     retention_failed: Duration,
+    /// Native-transform registry, shared with the validator's submit
+    /// path (ADR-0048 §2).
+    transform_registry: Arc<TransformRegistry>,
+    /// Dedicated transform compute pool (ADR-0048 §3).
+    transform_pool: TransformPool,
 }
 
 impl Executor {
     /// Build a fresh executor bound to the cap's `Arc<Mailer>` + own
-    /// mailbox id. Reads the retention / timeout env knobs once.
+    /// mailbox id. Reads the retention / timeout env knobs once, builds
+    /// the native-transform registry from the link-time inventory
+    /// (ADR-0048 §2), and spins up the dedicated transform compute pool
+    /// (ADR-0048 §3).
     #[must_use]
     pub fn new(mailer: Arc<Mailer>, self_mailbox: MailboxId) -> Self {
+        let pool_threads = parse_env_usize(
+            ENV_TRANSFORM_POOL_THREADS,
+            thread::available_parallelism().map_or(1, NonZeroUsize::get),
+        );
+        let transform_pool = TransformPool::new(pool_threads, &mailer);
         Self {
             mailer,
             self_mailbox,
@@ -139,10 +202,20 @@ impl Executor {
             dags: HashMap::new(),
             pending: HashMap::new(),
             in_flight_calls: HashMap::new(),
+            in_flight_transforms: HashMap::new(),
             call_timeout: Duration::from_millis(parse_env_u64(
                 ENV_CALL_TIMEOUT_MS,
                 DEFAULT_CALL_TIMEOUT_MS,
             )),
+            transform_timeout: Duration::from_millis(parse_env_u64(
+                ENV_TRANSFORM_TIMEOUT_MS,
+                DEFAULT_TRANSFORM_TIMEOUT_MS,
+            )),
+            transform_max_output_bytes: usize::try_from(parse_env_u64(
+                ENV_TRANSFORM_MAX_OUTPUT_BYTES,
+                DEFAULT_TRANSFORM_MAX_OUTPUT_BYTES,
+            ))
+            .unwrap_or(usize::MAX),
             retention_complete: Duration::from_millis(parse_env_u64(
                 ENV_RETENTION_COMPLETE_MS,
                 DEFAULT_RETENTION_COMPLETE_MS,
@@ -151,7 +224,25 @@ impl Executor {
                 ENV_RETENTION_FAILED_MS,
                 DEFAULT_RETENTION_FAILED_MS,
             )),
+            transform_registry: Arc::new(TransformRegistry::from_inventory()),
+            transform_pool,
         }
+    }
+
+    /// Shut the transform compute pool down (join its workers). Called
+    /// from the cap's `unwire`.
+    pub fn shutdown(&mut self) {
+        self.transform_pool.shutdown();
+    }
+
+    /// Test-only: total native-transform `invoke` calls the compute pool
+    /// has started. Cache hits never reach the pool, so this excludes
+    /// them — the `transform_skips_invoke_on_cache_hit` fixture asserts
+    /// it stays at 1 across two DAGs with the same content-address
+    /// (ADR-0048 §4, iamacoffeepot/aether#982).
+    #[must_use]
+    pub fn transform_call_count(&self) -> usize {
+        self.transform_pool.invoke_count()
     }
 
     /// Borrow the handle store the executor publishes resolved values
@@ -189,7 +280,7 @@ impl Executor {
         let validated = {
             let registry = self.mailer.registry();
             let caps = self.mailer.capability_registry();
-            match validate(&descriptor, registry, caps) {
+            match validate(&descriptor, registry, caps, Some(&self.transform_registry)) {
                 Ok(v) => v,
                 Err(error) => return SubmitOutcome::Err { error },
             }
@@ -215,11 +306,13 @@ impl Executor {
         };
 
         // Begin execution. Order: sources first (so a zero-input `Call`
-        // or observer with already-resolved inputs sees them), then
-        // observers (park), then `Call`s (gate / dispatch if no inputs).
+        // / `Transform` / observer with already-resolved inputs sees
+        // them), then observers (park), then `Call`s + `Transform`s
+        // (gate / dispatch if no inputs).
         self.dispatch_sources(ctx, dag_id);
         self.dispatch_observers(ctx, dag_id);
         self.dispatch_ready_calls(ctx, dag_id);
+        self.dispatch_ready_transforms(ctx, dag_id);
 
         SubmitOutcome::Ok {
             dag_id,
@@ -345,6 +438,253 @@ impl Executor {
         };
         for node_id in ready {
             self.dispatch_call(ctx, dag_id, node_id);
+        }
+    }
+
+    /// Dispatch every `Transform` node of `dag_id` whose inputs are
+    /// already resolved (`pending_inputs == 0`). At submit only
+    /// zero-input transforms fire here; downstream transforms fire from
+    /// [`Self::resolve_node`] as their inputs land (ADR-0048 §3).
+    fn dispatch_ready_transforms(&mut self, ctx: &mut NativeCtx<'_>, dag_id: DagId) {
+        let ready: Vec<NodeId> = {
+            let Some(state) = self.dags.get(&dag_id) else {
+                return;
+            };
+            state
+                .descriptor
+                .nodes
+                .iter()
+                .filter_map(|n| match n {
+                    Node::Transform { id, .. } => (state
+                        .pending_inputs
+                        .get(id)
+                        .copied()
+                        .unwrap_or(0)
+                        == 0
+                        && !state.resolved.contains(id))
+                    .then_some(*id),
+                    _ => None,
+                })
+                .collect()
+        };
+        for node_id in ready {
+            self.dispatch_transform(ctx, dag_id, node_id);
+        }
+    }
+
+    /// Dispatch one `Transform` node (ADR-0048 §3). Resolves the node's
+    /// `transform_id` against the registry, computes the
+    /// content-addressed handle id from the input handles in slot order,
+    /// and:
+    ///
+    /// - **cache hit** (`HandleStore::contains`): the cached output
+    ///   resolves the node directly — the invoke call is skipped
+    ///   entirely (auto-dedup, the headline value, ADR-0048 §4);
+    /// - **cache miss**: resolves each input handle to its canonical
+    ///   bytes, submits the type-erased thunk to the off-thread compute
+    ///   pool, and registers the in-flight deadline. The pool's
+    ///   `DagTransformDone` wake lands the result via
+    ///   [`Self::on_transform_complete`].
+    fn dispatch_transform(&mut self, ctx: &mut NativeCtx<'_>, dag_id: DagId, node_id: NodeId) {
+        // Resolve the node's transform_id + output kind + per-node
+        // timeout + assigned handle.
+        let Some((transform_id, output_kind_id, node_timeout)) = self.transform_node_meta(dag_id, node_id) else {
+            return;
+        };
+        let Some(state) = self.dags.get(&dag_id) else {
+            return;
+        };
+        if state.status.is_terminal() || state.resolved.contains(&node_id) {
+            return;
+        }
+        let Some(handle_id) = state.handles.get(&node_id).copied() else {
+            if let Some(state) = self.dags.get_mut(&dag_id) {
+                state.mark_failed(node_id, "transform node missing handle assignment".to_owned());
+            }
+            return;
+        };
+
+        // The input handle ids in slot-index order (ADR-0048 §4). The
+        // executor walks `Edge.slot` ascending for the consumer.
+        let mut slotted: Vec<(u32, HandleId)> = state
+            .descriptor
+            .edges
+            .iter()
+            .filter(|e| e.to == node_id)
+            .filter_map(|e| state.handles.get(&e.from).map(|h| (e.slot, *h)))
+            .collect();
+        slotted.sort_by_key(|(slot, _)| *slot);
+        let inputs_in_order: Vec<HandleId> = slotted.iter().map(|(_, h)| *h).collect();
+
+        let Some(entry) = self.transform_registry.lookup(transform_id) else {
+            // Validation already rejected unknown ids; a miss here is a
+            // substrate invariant violation. Fail the node rather than
+            // silently stall.
+            if let Some(state) = self.dags.get_mut(&dag_id) {
+                state.mark_failed(node_id, format!("transform {transform_id} not registered"));
+            }
+            return;
+        };
+
+        // Content-addressed cache check (ADR-0048 §4, iamacoffeepot/aether#982).
+        let content_id = content_addressed_handle_id(transform_id, &inputs_in_order);
+        if self.store().contains(content_id) {
+            // Cache hit: the cached output resolves the node directly —
+            // skip the invoke entirely. Read the bytes + kind back and
+            // resolve through the node's handle.
+            self.store().inc_ref(content_id);
+            if let Some((kind, bytes)) = self.store().get(content_id) {
+                self.resolve_node(ctx, dag_id, node_id, handle_id, kind, &bytes);
+            } else if let Some(state) = self.dags.get_mut(&dag_id) {
+                state.mark_failed(node_id, "transform cache hit but value vanished".to_owned());
+            }
+            return;
+        }
+
+        // Cache miss: resolve each input handle to its canonical bytes
+        // (slot order). A missing input handle is a substrate invariant
+        // violation — fail the node.
+        let mut input_bytes: Vec<Vec<u8>> = Vec::with_capacity(inputs_in_order.len());
+        for handle in &inputs_in_order {
+            let Some((_, bytes)) = self.store().get(*handle) else {
+                if let Some(state) = self.dags.get_mut(&dag_id) {
+                    state.mark_failed(
+                        node_id,
+                        "transform input handle unresolved at dispatch".to_owned(),
+                    );
+                }
+                return;
+            };
+            input_bytes.push(bytes);
+        }
+
+        // Submit to the off-thread compute pool (ADR-0048 §3). The wake
+        // mail lands `DagTransformDone { job_id }` at this cap.
+        let job_id = self.transform_pool.submit(
+            entry.invoke,
+            input_bytes,
+            self.self_mailbox,
+            KindId(<DagTransformDone as aether_data::Kind>::ID.0),
+        );
+        let timeout = node_timeout.map_or(self.transform_timeout, Duration::from_millis);
+        let timeout_ms = u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX);
+        self.in_flight_transforms.insert(
+            job_id,
+            InFlightTransform {
+                dag_id,
+                node_id,
+                handle_id,
+                content_id,
+                output_kind_id,
+                deadline: Instant::now() + timeout,
+                timeout_ms,
+            },
+        );
+    }
+
+    /// Resolve a `Transform` node's `(transform_id, output_kind_id,
+    /// timeout_ms)`. `None` if the node isn't a `Transform` (or the DAG
+    /// is gone).
+    fn transform_node_meta(
+        &self,
+        dag_id: DagId,
+        node_id: NodeId,
+    ) -> Option<(TransformId, KindId, Option<u64>)> {
+        self.dags.get(&dag_id)?.descriptor.nodes.iter().find_map(|n| match n {
+            Node::Transform {
+                id,
+                transform_id,
+                output_kind_id,
+                timeout_ms,
+            } if *id == node_id => Some((*transform_id, *output_kind_id, *timeout_ms)),
+            _ => None,
+        })
+    }
+
+    /// An off-thread transform invocation finished (ADR-0048 §3). Pull
+    /// the stashed outcome from the pool and resolve / fail the node:
+    ///
+    /// - `Ok(bytes)`: enforce the output-byte cap (ADR-0048 §6), store
+    ///   the bytes under the content-addressed id, and resolve the
+    ///   node's handle (flushing parked downstream mail). A domain `Err`
+    ///   value is inside these bytes — it is a successful, cached output,
+    ///   not a DAG failure.
+    /// - decode / arity / panic: fail the node with the diagnostic.
+    ///
+    /// A wake for a node the executor already failed (timeout fired
+    /// first, or the DAG was cancelled) is discarded — the stashed
+    /// outcome is forgotten so the completion map doesn't leak.
+    pub fn on_transform_complete(&mut self, ctx: &mut NativeCtx<'_>, job_id: u64) {
+        let Some(in_flight) = self.in_flight_transforms.remove(&job_id) else {
+            // Already timed out / cancelled — forget any stashed outcome.
+            self.transform_pool.forget(job_id);
+            return;
+        };
+        let Some(outcome) = self.transform_pool.take_outcome(job_id) else {
+            // Wake arrived before the outcome was stashed (should not
+            // happen — the worker stashes before posting the wake). Put
+            // the in-flight entry back so the reaper / a re-wake can
+            // still resolve it.
+            self.in_flight_transforms.insert(job_id, in_flight);
+            return;
+        };
+
+        let InFlightTransform {
+            dag_id,
+            node_id,
+            handle_id,
+            content_id,
+            output_kind_id,
+            ..
+        } = in_flight;
+
+        // Drop the result for a cancelled / completed DAG.
+        if self.dags.get(&dag_id).is_none_or(|s| s.status.is_terminal()) {
+            return;
+        }
+
+        match outcome {
+            TransformOutcome::Ok { bytes } => {
+                if bytes.len() > self.transform_max_output_bytes {
+                    if let Some(state) = self.dags.get_mut(&dag_id) {
+                        state.mark_failed(
+                            node_id,
+                            format!(
+                                "transform output exceeded {} bytes",
+                                self.transform_max_output_bytes
+                            ),
+                        );
+                    }
+                    return;
+                }
+                // Store the output under the content-addressed id so a
+                // future identical compute hits the cache (ADR-0048 §4),
+                // hold a ref for the DAG, then resolve the node's handle.
+                if let Err(e) =
+                    self.store()
+                        .put(content_id, output_kind_id, bytes.clone())
+                {
+                    tracing::warn!(
+                        target: TARGET,
+                        error = ?e,
+                        ?node_id,
+                        "failed to store content-addressed transform output",
+                    );
+                } else {
+                    self.store().inc_ref(content_id);
+                }
+                self.resolve_node(ctx, dag_id, node_id, handle_id, output_kind_id, &bytes);
+            }
+            TransformOutcome::Err { error } => {
+                if let Some(state) = self.dags.get_mut(&dag_id) {
+                    state.mark_failed(node_id, format!("transform failed: {error}"));
+                }
+            }
+            TransformOutcome::Panicked { message } => {
+                if let Some(state) = self.dags.get_mut(&dag_id) {
+                    state.mark_failed(node_id, format!("transform panicked: {message}"));
+                }
+            }
         }
     }
 
@@ -574,9 +914,27 @@ impl Executor {
             }
             ready
         };
-        for call in newly_ready {
-            self.dispatch_call(ctx, dag_id, call);
+        // A counter-gated consumer is either a `Call` (dispatch as a
+        // causal root awaiting settlement) or a `Transform` (run the
+        // pure fn off-thread). Dispatch each by its node type.
+        for consumer in newly_ready {
+            if self.node_is_transform(dag_id, consumer) {
+                self.dispatch_transform(ctx, dag_id, consumer);
+            } else {
+                self.dispatch_call(ctx, dag_id, consumer);
+            }
         }
+    }
+
+    /// `true` if `node_id` is a `Transform` node in `dag_id`.
+    fn node_is_transform(&self, dag_id: DagId, node_id: NodeId) -> bool {
+        self.dags.get(&dag_id).is_some_and(|state| {
+            state
+                .descriptor
+                .nodes
+                .iter()
+                .any(|n| n.id() == node_id && matches!(n, Node::Transform { .. }))
+        })
     }
 
     /// A `Settled { call_root }` notification landed (ADR-0047 §4 step
@@ -650,10 +1008,13 @@ impl Executor {
             let _ = self.store().take_parked(*id);
             self.store().dec_ref(*id);
         }
-        // Drop the DAG's reply correlations + in-flight call entries so a
-        // late source reply / `Settled` finds no entry and is a no-op.
+        // Drop the DAG's reply correlations + in-flight call / transform
+        // entries so a late source reply / `Settled` / `DagTransformDone`
+        // finds no entry and is a no-op. An orphaned transform thread
+        // still runs to completion but its result is dropped.
         self.pending.retain(|_, p| p.dag_id != dag_id);
         self.in_flight_calls.retain(|_, c| c.dag_id != dag_id);
+        self.in_flight_transforms.retain(|_, t| t.dag_id != dag_id);
         if let Some(state) = self.dags.get_mut(&dag_id) {
             state.call_buffers.clear();
         }
@@ -669,12 +1030,14 @@ impl Executor {
         self.dags.get(&dag_id).map(DagState::status_result)
     }
 
-    /// The reaping tick (ADR-0047 §7). Sweeps terminal DAGs whose
-    /// `completed_at` is past retention (separate windows for completed
-    /// vs failed / cancelled), and times out in-flight `Call`s whose
-    /// settlement deadline has passed (failing the node — a never-
-    /// settling cap is a node failure, not a partial bundle). Returns
-    /// the number of DAGs reaped.
+    /// The reaping tick (ADR-0047 §7, ADR-0048 §6). Sweeps terminal DAGs
+    /// whose `completed_at` is past retention (separate windows for
+    /// completed vs failed / cancelled), times out in-flight `Call`s
+    /// whose settlement deadline has passed (failing the node — a never-
+    /// settling cap is a node failure, not a partial bundle), and times
+    /// out in-flight `Transform`s past their deadline (failing the node;
+    /// the runaway thread orphans, ADR-0048 §6). Returns the number of
+    /// DAGs reaped.
     pub fn reap(&mut self) -> usize {
         let now = Instant::now();
 
@@ -691,6 +1054,24 @@ impl Executor {
             if let Some(state) = self.dags.get_mut(&dag_id) {
                 state.call_buffers.remove(&correlation);
                 state.mark_failed(node_id, "call timed out waiting for settlement".to_owned());
+            }
+        }
+
+        // Time out in-flight transforms past their deadline (ADR-0048
+        // §6). The node fails; the runaway thread is orphaned (a native
+        // thread can't be safely preempted) and its eventual outcome is
+        // discarded when its wake lands with no in-flight entry.
+        let timed_out_transforms: Vec<(u64, DagId, NodeId, u64)> = self
+            .in_flight_transforms
+            .iter()
+            .filter(|(_, t)| now >= t.deadline)
+            .map(|(job, t)| (*job, t.dag_id, t.node_id, t.timeout_ms))
+            .collect();
+        for (job_id, dag_id, node_id, timeout_ms) in timed_out_transforms {
+            self.in_flight_transforms.remove(&job_id);
+            self.transform_pool.forget(job_id);
+            if let Some(state) = self.dags.get_mut(&dag_id) {
+                state.mark_failed(node_id, format!("timeout: {timeout_ms}ms"));
             }
         }
 
@@ -846,6 +1227,29 @@ fn parse_env_u64(name: &str, default: u64) -> u64 {
                     error = %e,
                     default,
                     "ignoring unparseable DAG env var; using default",
+                );
+                default
+            }
+        },
+        Err(_) => default,
+    }
+}
+
+/// Parse a `usize` env var, warning + falling back on a malformed value.
+/// Used for the transform compute-pool thread count (ADR-0048 §3).
+#[allow(clippy::option_if_let_else)]
+fn parse_env_usize(name: &str, default: usize) -> usize {
+    match env::var(name) {
+        Ok(raw) => match raw.parse::<usize>() {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(
+                    target: TARGET,
+                    env = name,
+                    value = %raw,
+                    error = %e,
+                    default,
+                    "ignoring unparseable transform pool env var; using default",
                 );
                 default
             }

--- a/crates/aether-substrate/src/dag/executor.rs
+++ b/crates/aether-substrate/src/dag/executor.rs
@@ -455,14 +455,11 @@ impl Executor {
                 .nodes
                 .iter()
                 .filter_map(|n| match n {
-                    Node::Transform { id, .. } => (state
-                        .pending_inputs
-                        .get(id)
-                        .copied()
-                        .unwrap_or(0)
-                        == 0
-                        && !state.resolved.contains(id))
-                    .then_some(*id),
+                    Node::Transform { id, .. } => {
+                        (state.pending_inputs.get(id).copied().unwrap_or(0) == 0
+                            && !state.resolved.contains(id))
+                        .then_some(*id)
+                    }
                     _ => None,
                 })
                 .collect()
@@ -488,7 +485,9 @@ impl Executor {
     fn dispatch_transform(&mut self, ctx: &mut NativeCtx<'_>, dag_id: DagId, node_id: NodeId) {
         // Resolve the node's transform_id + output kind + per-node
         // timeout + assigned handle.
-        let Some((transform_id, output_kind_id, node_timeout)) = self.transform_node_meta(dag_id, node_id) else {
+        let Some((transform_id, output_kind_id, node_timeout)) =
+            self.transform_node_meta(dag_id, node_id)
+        else {
             return;
         };
         let Some(state) = self.dags.get(&dag_id) else {
@@ -499,7 +498,10 @@ impl Executor {
         }
         let Some(handle_id) = state.handles.get(&node_id).copied() else {
             if let Some(state) = self.dags.get_mut(&dag_id) {
-                state.mark_failed(node_id, "transform node missing handle assignment".to_owned());
+                state.mark_failed(
+                    node_id,
+                    "transform node missing handle assignment".to_owned(),
+                );
             }
             return;
         };
@@ -590,15 +592,20 @@ impl Executor {
         dag_id: DagId,
         node_id: NodeId,
     ) -> Option<(TransformId, KindId, Option<u64>)> {
-        self.dags.get(&dag_id)?.descriptor.nodes.iter().find_map(|n| match n {
-            Node::Transform {
-                id,
-                transform_id,
-                output_kind_id,
-                timeout_ms,
-            } if *id == node_id => Some((*transform_id, *output_kind_id, *timeout_ms)),
-            _ => None,
-        })
+        self.dags
+            .get(&dag_id)?
+            .descriptor
+            .nodes
+            .iter()
+            .find_map(|n| match n {
+                Node::Transform {
+                    id,
+                    transform_id,
+                    output_kind_id,
+                    timeout_ms,
+                } if *id == node_id => Some((*transform_id, *output_kind_id, *timeout_ms)),
+                _ => None,
+            })
     }
 
     /// An off-thread transform invocation finished (ADR-0048 §3). Pull
@@ -639,7 +646,11 @@ impl Executor {
         } = in_flight;
 
         // Drop the result for a cancelled / completed DAG.
-        if self.dags.get(&dag_id).is_none_or(|s| s.status.is_terminal()) {
+        if self
+            .dags
+            .get(&dag_id)
+            .is_none_or(|s| s.status.is_terminal())
+        {
             return;
         }
 
@@ -660,10 +671,7 @@ impl Executor {
                 // Store the output under the content-addressed id so a
                 // future identical compute hits the cache (ADR-0048 §4),
                 // hold a ref for the DAG, then resolve the node's handle.
-                if let Err(e) =
-                    self.store()
-                        .put(content_id, output_kind_id, bytes.clone())
-                {
+                if let Err(e) = self.store().put(content_id, output_kind_id, bytes.clone()) {
                     tracing::warn!(
                         target: TARGET,
                         error = ?e,

--- a/crates/aether-substrate/src/dag/mod.rs
+++ b/crates/aether-substrate/src/dag/mod.rs
@@ -18,4 +18,6 @@
 
 pub mod executor;
 pub mod state;
+pub mod transform_pool;
+pub mod transform_registry;
 pub mod validator;

--- a/crates/aether-substrate/src/dag/state.rs
+++ b/crates/aether-substrate/src/dag/state.rs
@@ -114,21 +114,24 @@ impl DagState {
             topo_order,
         } = validated;
 
-        // Per-`Call` input-edge counts gate dispatch (ADR-0047 §4). Seed
-        // every `Call` at 0 so a no-input call dispatches immediately,
-        // then bump one per incoming edge.
+        // Per-`Call` + per-`Transform` input-edge counts gate dispatch
+        // (ADR-0047 §4, ADR-0048 §3). Both are mid-graph nodes that fire
+        // once every input handle resolves; observers gate through the
+        // parking table instead. Seed every counter-gated node at 0 so a
+        // no-input one dispatches immediately, then bump one per incoming
+        // edge.
         let mut pending_inputs: HashMap<NodeId, u32> = HashMap::new();
-        let call_ids: HashSet<NodeId> = descriptor
+        let counter_gated: HashSet<NodeId> = descriptor
             .nodes
             .iter()
-            .filter(|n| matches!(n, Node::Call { .. }))
+            .filter(|n| matches!(n, Node::Call { .. } | Node::Transform { .. }))
             .map(Node::id)
             .collect();
-        for id in &call_ids {
+        for id in &counter_gated {
             pending_inputs.insert(*id, 0);
         }
         for edge in &descriptor.edges {
-            if call_ids.contains(&edge.to) {
+            if counter_gated.contains(&edge.to) {
                 *pending_inputs.entry(edge.to).or_insert(0) += 1;
             }
         }

--- a/crates/aether-substrate/src/dag/transform_pool.rs
+++ b/crates/aether-substrate/src/dag/transform_pool.rs
@@ -1,0 +1,273 @@
+//! ADR-0048 §3 dedicated transform compute pool
+//! (iamacoffeepot/aether#1012).
+//!
+//! A native transform is a pure `fn` with no instance and no thread
+//! affinity — it is `Send`. The executor does **not** run transforms
+//! inline (a slow transform would stall the parking/reaping loop) and
+//! does **not** run them on any actor thread. Instead they run on this
+//! dedicated pool — a bounded set of OS threads, separate from every
+//! actor thread, sized independently (default: available parallelism).
+//!
+//! This is emphatically **not** the actor worker-pool ADR-0038 retired
+//! — that was actor dispatch (instances, lifecycles, strand-claims);
+//! this is a pure-compute pool of stateless `fn` calls with none of
+//! that machinery.
+//!
+//! Completion is signalled the same way the reaper timer wakes the
+//! executor: the worker stashes the outcome in a shared map keyed by
+//! `job_id`, then pushes a `DagTransformDone { job_id }` mail at the
+//! `aether.dag` mailbox so the executor pulls the result and resolves /
+//! fails the node on its own single-threaded actor thread.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::panic::{self, AssertUnwindSafe};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc::{self, Sender};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+
+use aether_data::{InvokeFn, KindId, MailboxId, TransformError};
+use aether_kinds::DagTransformDone;
+
+use crate::mail::mailer::Mailer;
+use crate::mail::Mail;
+
+const TARGET: &str = "aether::dag::transform_pool";
+
+/// The result of one off-thread transform invocation (ADR-0048 §3/§6).
+/// A domain `Err` value the transform itself returns is **not** here —
+/// that's a successful `Ok(bytes)` whose bytes encode an `Err` variant
+/// (ADR-0048 §6 "domain Err is not a DAG failure"). This enum captures
+/// only the runtime-abort classes the executor maps to node failure.
+pub enum TransformOutcome {
+    /// The transform returned; `bytes` is its encoded output.
+    Ok { bytes: Vec<u8> },
+    /// The thunk reported a decode / arity error (ADR-0048 §1).
+    Err { error: TransformError },
+    /// The transform `panic!`d; `message` is the unwind payload as a
+    /// string (ADR-0048 §6 panic = failure).
+    Panicked { message: String },
+}
+
+/// One queued invocation. The pool worker owns the inputs (copied off
+/// the handle store before submission so the worker borrows no shared
+/// state) and the type-erased `invoke` thunk.
+struct Job {
+    id: u64,
+    invoke: InvokeFn,
+    inputs: Vec<Vec<u8>>,
+    /// Where to post the completion wake.
+    wake_mailbox: MailboxId,
+    wake_kind: KindId,
+}
+
+/// Dedicated transform compute pool. Owned by the executor.
+pub struct TransformPool {
+    tx: Option<Sender<Job>>,
+    workers: Vec<JoinHandle<()>>,
+    /// Completed outcomes keyed by `job_id`, drained by the executor on
+    /// the `DagTransformDone` wake.
+    outcomes: Arc<Mutex<HashMap<u64, TransformOutcome>>>,
+    /// Count of actual `invoke` calls (cache hits never reach the pool,
+    /// so this excludes them). Test instrumentation for the
+    /// `transform_skips_invoke_on_cache_hit` fixture.
+    invoke_count: Arc<AtomicUsize>,
+    /// Monotonic job-id allocator.
+    next_job: u64,
+}
+
+impl TransformPool {
+    /// Spawn `threads` worker threads (clamped to at least 1) fed by a
+    /// shared job channel. The workers hold a clone of the `Mailer` so
+    /// they can post the completion wake; they do **not** touch the
+    /// handle store or any `DagState` directly.
+    #[must_use]
+    pub fn new(threads: usize, mailer: &Arc<Mailer>) -> Self {
+        let threads = threads.max(1);
+        let (tx, rx) = mpsc::channel::<Job>();
+        let rx = Arc::new(Mutex::new(rx));
+        let outcomes: Arc<Mutex<HashMap<u64, TransformOutcome>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let invoke_count = Arc::new(AtomicUsize::new(0));
+
+        let mut workers = Vec::with_capacity(threads);
+        for i in 0..threads {
+            let rx = Arc::clone(&rx);
+            let outcomes = Arc::clone(&outcomes);
+            let invoke_count = Arc::clone(&invoke_count);
+            let mailer = Arc::clone(mailer);
+            let spawned = thread::Builder::new()
+                .name(format!("aether-transform-{i}"))
+                .spawn(move || worker_loop(&rx, &outcomes, &invoke_count, &mailer));
+            match spawned {
+                Ok(handle) => workers.push(handle),
+                Err(e) => {
+                    tracing::warn!(
+                        target: TARGET,
+                        error = %e,
+                        worker = i,
+                        "failed to spawn transform compute worker",
+                    );
+                }
+            }
+        }
+
+        Self {
+            tx: Some(tx),
+            workers,
+            outcomes,
+            invoke_count,
+            next_job: 1,
+        }
+    }
+
+    /// Submit a transform invocation to the pool. Returns the allocated
+    /// `job_id`; the worker posts a `DagTransformDone { job_id }` wake
+    /// once the call returns (or panics), and the executor reads the
+    /// outcome via [`Self::take_outcome`].
+    pub fn submit(
+        &mut self,
+        invoke: InvokeFn,
+        inputs: Vec<Vec<u8>>,
+        wake_mailbox: MailboxId,
+        wake_kind: KindId,
+    ) -> u64 {
+        let job_id = self.next_job;
+        self.next_job = self.next_job.wrapping_add(1);
+        if self.next_job == 0 {
+            self.next_job = 1;
+        }
+        let job = Job {
+            id: job_id,
+            invoke,
+            inputs,
+            wake_mailbox,
+            wake_kind,
+        };
+        if let Some(tx) = &self.tx
+            && tx.send(job).is_err()
+        {
+            tracing::warn!(
+                target: TARGET,
+                job_id,
+                "transform pool channel closed; invocation dropped",
+            );
+        }
+        job_id
+    }
+
+    /// Drain the outcome for a completed `job_id`, or `None` if the
+    /// worker hasn't posted it yet (or it was already taken). Called by
+    /// the executor on the `DagTransformDone` wake.
+    ///
+    /// # Panics
+    /// Panics if the outcome mutex is poisoned — fail-fast per ADR-0063.
+    #[must_use]
+    pub fn take_outcome(&self, job_id: u64) -> Option<TransformOutcome> {
+        self.outcomes
+            .lock()
+            .expect("transform pool outcome mutex poisoned; fail-fast per ADR-0063")
+            .remove(&job_id)
+    }
+
+    /// Discard a stashed outcome for a job the executor already failed
+    /// (e.g. a timeout fired before the worker finished). Keeps the
+    /// completion map from leaking entries for orphaned threads.
+    ///
+    /// # Panics
+    /// Panics if the outcome mutex is poisoned — fail-fast per ADR-0063.
+    pub fn forget(&self, job_id: u64) {
+        self.outcomes
+            .lock()
+            .expect("transform pool outcome mutex poisoned; fail-fast per ADR-0063")
+            .remove(&job_id);
+    }
+
+    /// Total `invoke` calls the pool has started (excludes cache hits,
+    /// which never reach the pool). Test instrumentation.
+    #[must_use]
+    pub fn invoke_count(&self) -> usize {
+        self.invoke_count.load(Ordering::Acquire)
+    }
+
+    /// Shut the pool down: close the job channel + join every worker.
+    /// Called from the cap's `unwire`. Idempotent.
+    pub fn shutdown(&mut self) {
+        // Dropping the only `Sender` closes the channel; workers see
+        // `Err(RecvError)` and exit their loop.
+        self.tx = None;
+        for handle in self.workers.drain(..) {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Drop for TransformPool {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+/// One worker thread's loop: pull a job, run its thunk under
+/// `catch_unwind`, stash the outcome, post the wake.
+fn worker_loop(
+    rx: &Arc<Mutex<mpsc::Receiver<Job>>>,
+    outcomes: &Arc<Mutex<HashMap<u64, TransformOutcome>>>,
+    invoke_count: &Arc<AtomicUsize>,
+    mailer: &Arc<Mailer>,
+) {
+    loop {
+        // Hold the receiver lock only across `recv`, so siblings can
+        // pick up the next job while this one computes.
+        let job = {
+            let guard = rx
+                .lock()
+                .expect("transform pool receiver mutex poisoned; fail-fast per ADR-0063");
+            guard.recv()
+        };
+        let Ok(job) = job else {
+            // Channel closed (pool dropped) — exit.
+            return;
+        };
+
+        invoke_count.fetch_add(1, Ordering::AcqRel);
+        let outcome = run_job(&job);
+
+        outcomes
+            .lock()
+            .expect("transform pool outcome mutex poisoned; fail-fast per ADR-0063")
+            .insert(job.id, outcome);
+
+        // Wake the executor on its own thread. The payload carries the
+        // job id so the executor can pull the stashed outcome.
+        let payload = aether_data::Kind::encode_into_bytes(&DagTransformDone { job_id: job.id });
+        mailer.push(Mail::new(job.wake_mailbox, job.wake_kind, payload, 1));
+    }
+}
+
+/// Run one job's thunk under `catch_unwind` (ADR-0048 §6 panic =
+/// failure). A panic inside the transform is contained here — the pure
+/// `fn` shares no mutable state, so a panic can't poison the executor or
+/// any actor.
+fn run_job(job: &Job) -> TransformOutcome {
+    let slices: Vec<&[u8]> = job.inputs.iter().map(Vec::as_slice).collect();
+    let invoke = job.invoke;
+    let result = panic::catch_unwind(AssertUnwindSafe(|| invoke(&slices)));
+    match result {
+        Ok(Ok(bytes)) => TransformOutcome::Ok { bytes },
+        Ok(Err(error)) => TransformOutcome::Err { error },
+        Err(payload) => TransformOutcome::Panicked {
+            message: panic_message(payload.as_ref()),
+        },
+    }
+}
+
+/// Best-effort extraction of a panic payload's message.
+fn panic_message(payload: &(dyn Any + Send)) -> String {
+    payload
+        .downcast_ref::<&'static str>()
+        .map(|s| (*s).to_owned())
+        .or_else(|| payload.downcast_ref::<String>().cloned())
+        .unwrap_or_else(|| "<non-string panic payload>".to_owned())
+}

--- a/crates/aether-substrate/src/dag/transform_pool.rs
+++ b/crates/aether-substrate/src/dag/transform_pool.rs
@@ -30,8 +30,8 @@ use std::thread::{self, JoinHandle};
 use aether_data::{InvokeFn, KindId, MailboxId, TransformError};
 use aether_kinds::DagTransformDone;
 
-use crate::mail::mailer::Mailer;
 use crate::mail::Mail;
+use crate::mail::mailer::Mailer;
 
 const TARGET: &str = "aether::dag::transform_pool";
 

--- a/crates/aether-substrate/src/dag/transform_registry.rs
+++ b/crates/aether-substrate/src/dag/transform_registry.rs
@@ -9,8 +9,8 @@
 //!
 //! The validator's dispatchability phase cross-checks each
 //! `Transform { transform_id, output_kind_id }` node against this
-//! registry (unknown id → [`DagError::UnknownTransform`], output-kind
-//! mismatch → [`DagError::TransformOutputMismatch`]). Post-validation
+//! registry (unknown id → `DagError::UnknownTransform`, output-kind
+//! mismatch → `DagError::TransformOutputMismatch`). Post-validation
 //! lookup is an infallible hashmap hit.
 
 use std::collections::HashMap;
@@ -18,9 +18,8 @@ use std::collections::HashMap;
 use aether_data::{KindId, TransformEntry, TransformId};
 
 /// A registered native transform's static metadata + invocation thunk
-/// (ADR-0048 §2). A thin borrow over the link-time
-/// [`TransformEntry`](aether_data::TransformEntry) — every field is
-/// `'static`.
+/// (ADR-0048 §2). A thin borrow over the link-time [`TransformEntry`] —
+/// every field is `'static`.
 #[derive(Copy, Clone)]
 pub struct RegisteredTransform {
     /// Declared input kind ids, in slot order (≤ 8).

--- a/crates/aether-substrate/src/dag/transform_registry.rs
+++ b/crates/aether-substrate/src/dag/transform_registry.rs
@@ -1,0 +1,116 @@
+//! ADR-0048 §2 native-transform registry (iamacoffeepot/aether#1012).
+//!
+//! Native transforms are collected at link time into the inventory the
+//! `#[transform]` macro populates (iamacoffeepot/aether#979). The
+//! substrate builds one [`TransformRegistry`] at startup by iterating
+//! [`aether_data::transforms()`]; the set is fixed for the process
+//! lifetime — a transform set is a build-time property, not a load-time
+//! one.
+//!
+//! The validator's dispatchability phase cross-checks each
+//! `Transform { transform_id, output_kind_id }` node against this
+//! registry (unknown id → [`DagError::UnknownTransform`], output-kind
+//! mismatch → [`DagError::TransformOutputMismatch`]). Post-validation
+//! lookup is an infallible hashmap hit.
+
+use std::collections::HashMap;
+
+use aether_data::{KindId, TransformEntry, TransformId};
+
+/// A registered native transform's static metadata + invocation thunk
+/// (ADR-0048 §2). A thin borrow over the link-time
+/// [`TransformEntry`](aether_data::TransformEntry) — every field is
+/// `'static`.
+#[derive(Copy, Clone)]
+pub struct RegisteredTransform {
+    /// Declared input kind ids, in slot order (≤ 8).
+    pub input_kind_ids: &'static [KindId],
+    /// Declared output kind id.
+    pub output_kind_id: KindId,
+    /// `"{crate}::{module}::{fn}"` — diagnostics + MCP introspection.
+    pub name: &'static str,
+    /// Type-erased decode → call → encode thunk (ADR-0048 §1).
+    pub invoke: aether_data::InvokeFn,
+}
+
+/// Substrate-global native-transform registry (ADR-0048 §2). Built once
+/// at startup from the link-time inventory; immutable thereafter.
+#[derive(Default)]
+pub struct TransformRegistry {
+    by_id: HashMap<TransformId, RegisteredTransform>,
+}
+
+impl TransformRegistry {
+    /// Materialize the registry from the link-time inventory
+    /// ([`aether_data::transforms()`]). A duplicate `transform_id`
+    /// (two transforms hashing to the same name — practically
+    /// impossible, but possible if two crates declare a transform with
+    /// the same fully-qualified path) keeps the first and warns.
+    #[must_use]
+    pub fn from_inventory() -> Self {
+        let mut by_id: HashMap<TransformId, RegisteredTransform> = HashMap::new();
+        for entry in aether_data::transforms() {
+            Self::insert_entry(&mut by_id, entry);
+        }
+        Self { by_id }
+    }
+
+    /// An empty registry — no native transforms. Used by the validator's
+    /// tests and any chassis that doesn't host the executor.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            by_id: HashMap::new(),
+        }
+    }
+
+    fn insert_entry(
+        by_id: &mut HashMap<TransformId, RegisteredTransform>,
+        entry: &'static TransformEntry,
+    ) {
+        let registered = RegisteredTransform {
+            input_kind_ids: entry.input_kind_ids,
+            output_kind_id: entry.output_kind_id,
+            name: entry.name,
+            invoke: entry.invoke,
+        };
+        if let Some(prior) = by_id.insert(entry.transform_id, registered) {
+            tracing::warn!(
+                target: "aether::dag::transform_registry",
+                transform_id = %entry.transform_id,
+                kept = prior.name,
+                dropped = entry.name,
+                "duplicate transform_id in link-time inventory; keeping the first",
+            );
+            // Restore the first-seen entry (HashMap::insert returned the
+            // prior value, which we just clobbered).
+            by_id.insert(entry.transform_id, prior);
+        }
+    }
+
+    /// Resolve a transform by its global id. Post-validation this is an
+    /// infallible hit (validation already rejected unknown ids).
+    #[must_use]
+    pub fn lookup(&self, id: TransformId) -> Option<RegisteredTransform> {
+        self.by_id.get(&id).copied()
+    }
+
+    /// Number of registered transforms. Diagnostics / introspection.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.by_id.len()
+    }
+
+    /// `true` when no native transforms are registered.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.by_id.is_empty()
+    }
+
+    /// Iterate `(transform_id, metadata)` for every registered
+    /// transform, for MCP introspection (the transform listing
+    /// ADR-0048 §2 names).
+    pub fn iter(&self) -> impl Iterator<Item = (TransformId, RegisteredTransform)> + '_ {
+        self.by_id.iter().map(|(id, t)| (*id, *t))
+    }
+}

--- a/crates/aether-substrate/src/dag/validator.rs
+++ b/crates/aether-substrate/src/dag/validator.rs
@@ -28,6 +28,7 @@ use aether_data::canonical::canonical_kind_bytes;
 use aether_data::{Kind, Schema, SchemaType};
 use aether_kinds::{Bundle, DagDescriptor, DagError, Edge, Node, NodeId};
 
+use crate::dag::transform_registry::TransformRegistry;
 use crate::mail::{CapabilityRegistry, KindId, MailboxEntry, MailboxId, Registry};
 
 const TARGET: &str = "aether::dag::validator";
@@ -89,11 +90,12 @@ pub fn validate(
     descriptor: &DagDescriptor,
     mailboxes: &Registry,
     caps: &CapabilityRegistry,
+    transforms: Option<&TransformRegistry>,
 ) -> Result<ValidatedDag, DagError> {
     check_version(descriptor)?;
     let structure = check_structure(descriptor)?;
-    check_dispatchability(descriptor, mailboxes, caps)?;
-    check_edge_types(descriptor, mailboxes)?;
+    check_dispatchability(descriptor, mailboxes, caps, transforms)?;
+    check_edge_types(descriptor, mailboxes, transforms)?;
     Ok(ValidatedDag {
         descriptor: descriptor.clone(),
         topo_order: structure.topo_order,
@@ -265,16 +267,20 @@ fn toposort(node_ids: &BTreeSet<NodeId>, edges: &[Edge]) -> Result<Vec<NodeId>, 
     Ok(order)
 }
 
-/// Phase 2 — dispatchability (ADR-0047 §3). Each effectful node's target
-/// mailbox must exist (routing `Registry`) and accept the node's kind
-/// (`CapabilityRegistry`). `Transform` nodes always fail here in this
-/// issue's scope — no native transform is registered yet, so a
-/// `Transform` is wire-reserved but dispatch-disabled
-/// (iamacoffeepot/aether#976 lights it up).
+/// Phase 2 — dispatchability (ADR-0047 §3, ADR-0048 §2). Each effectful
+/// node's target mailbox must exist (routing `Registry`) and accept the
+/// node's kind (`CapabilityRegistry`). A `Transform` node's
+/// `transform_id` must resolve in the native-transform registry
+/// (`UnknownTransform` otherwise), and its declared `output_kind_id`
+/// must equal the registered transform's manifest output kind
+/// (`TransformOutputMismatch` otherwise). A `None` transform registry
+/// (a chassis that doesn't host the executor, or a validator test)
+/// treats every `Transform` as `UnknownTransform`.
 fn check_dispatchability(
     descriptor: &DagDescriptor,
     mailboxes: &Registry,
     caps: &CapabilityRegistry,
+    transforms: Option<&TransformRegistry>,
 ) -> Result<(), DagError> {
     for node in &descriptor.nodes {
         match node {
@@ -337,32 +343,56 @@ fn check_dispatchability(
                 }
             }
             Node::Transform {
-                id, transform_id, ..
+                id,
+                transform_id,
+                output_kind_id,
+                ..
             } => {
-                // No native-transform catalog exists yet
-                // (iamacoffeepot/aether#976) — a Transform node is
-                // wire-reserved but dispatch-disabled, so every one
-                // fails Phase 2 here. This is the intended surface.
-                return Err(DagError::UnknownTransform {
-                    node: *id,
-                    transform_id: *transform_id,
-                });
+                // Resolve the transform against the native-transform
+                // registry. Unknown id (or no registry on this chassis)
+                // -> UnknownTransform; output-kind disagreement ->
+                // TransformOutputMismatch (ADR-0048 §2).
+                let Some(entry) = transforms.and_then(|r| r.lookup(*transform_id)) else {
+                    return Err(DagError::UnknownTransform {
+                        node: *id,
+                        transform_id: *transform_id,
+                    });
+                };
+                if entry.output_kind_id != *output_kind_id {
+                    return Err(DagError::TransformOutputMismatch {
+                        node: *id,
+                        declared: *output_kind_id,
+                        manifest: entry.output_kind_id,
+                    });
+                }
             }
         }
     }
     Ok(())
 }
 
-/// Phase 3 — type compatibility on edges (ADR-0047 §3, re-scoped). Only
-/// statically-declared output kinds are checkable. The single such kind
-/// in this issue's scope is a `Call`'s output, which is always the
-/// `Bundle` meta-type: an edge out of a `Call` requires the consumer at
-/// `to` to declare a `Bundle` input at the matching `slot`. Edges out of
-/// a `Source` are skipped — a source's output kind depends on what the
-/// cap replies, which a handler never declares. (When transforms land,
-/// a `Transform`-output arm joins here, checking the consumer's slot
-/// against `Transform.output_kind_id`.)
-fn check_edge_types(descriptor: &DagDescriptor, mailboxes: &Registry) -> Result<(), DagError> {
+/// Phase 3 — type compatibility on edges (ADR-0047 §3, ADR-0048 §2,
+/// re-scoped). Only statically-declared output kinds are checkable.
+/// Two producers carry one:
+///
+/// - a `Call`'s output is always the `Bundle` meta-type — an edge out of
+///   a `Call` requires the consumer at `to` to declare a `Bundle` input
+///   at the matching `slot`;
+/// - a `Transform`'s output is its registered manifest `output_kind_id`
+///   — an edge out of a `Transform` requires the consumer's slot to
+///   declare that exact kind.
+///
+/// Edges out of a `Source` are skipped — a source's output kind depends
+/// on what the cap replies, which a handler never declares. A
+/// `Transform` consumer has no registered input schema (its inputs are
+/// raw byte slices keyed by slot), so nothing checks an edge *into* a
+/// `Transform` here; the transform's declared input arity is the
+/// registry's business at dispatch, not the edge type-check's.
+fn check_edge_types(
+    descriptor: &DagDescriptor,
+    mailboxes: &Registry,
+    transforms: Option<&TransformRegistry>,
+) -> Result<(), DagError> {
     // Node lookup by id for resolving each edge's producer / consumer.
     let by_id: HashMap<NodeId, &Node> = descriptor.nodes.iter().map(|n| (n.id(), n)).collect();
 
@@ -374,39 +404,59 @@ fn check_edge_types(descriptor: &DagDescriptor, mailboxes: &Registry) -> Result<
             continue;
         };
 
-        // Only a `Call` has a statically-knowable output kind in this
-        // issue's scope (the `Bundle` meta-type). Everything else —
-        // sources especially — is not type-checked.
-        if !matches!(producer, Node::Call { .. }) {
+        // The statically-knowable output of this producer as
+        // `(expected_kind_id, expected_schema)`, or `None` for an
+        // un-checkable producer (a `Source`, whose output is whatever
+        // the cap replies). A `Call` produces a `Bundle`; a `Transform`
+        // produces its registered manifest output kind.
+        let expected = match producer {
+            Node::Call { .. } => Some((Bundle::ID, Bundle::SCHEMA)),
+            Node::Transform {
+                transform_id,
+                output_kind_id,
+                ..
+            } => {
+                let kind = transforms
+                    .and_then(|r| r.lookup(*transform_id))
+                    .map_or(*output_kind_id, |entry| entry.output_kind_id);
+                // The transform's output schema, for the canonical
+                // comparison. `None` when the output kind isn't
+                // registered — fall back to an id-only check below.
+                mailboxes.kind_descriptor(kind).map(|d| (kind, d.schema))
+            }
+            Node::Source { .. } | Node::Observer { .. } => None,
+        };
+        let Some((expected_kind, expected_schema)) = expected else {
             continue;
-        }
+        };
 
         let Some(consumer) = by_id.get(&edge.to) else {
             continue;
         };
         let consumer_kind = match consumer {
             Node::Observer { kind_id, .. } | Node::Call { kind_id, .. } => *kind_id,
-            // A `Call` cannot feed a `Source` (sources have no incoming
+            // A producer cannot feed a `Source` (sources have no incoming
             // edges, enforced in Phase 1) and `Transform` consumers have
-            // no registered input schema yet, so nothing else is
-            // checkable here.
+            // no registered input schema, so nothing else is checkable
+            // here.
             Node::Source { .. } | Node::Transform { .. } => continue,
         };
 
         // The consumer's slot maps to a `Ref<K>` field of its
         // assembled-request schema. Resolve `K`'s schema; the edge is
-        // type-valid iff that `K` is a `Bundle`.
+        // type-valid iff that `K` canonically matches the producer's
+        // output schema.
         let slot_schema = consumer_slot_kind(mailboxes, consumer_kind, edge.slot);
-        let accepts_bundle = slot_schema.as_ref().is_some_and(|s| {
-            canonical_kind_bytes("", s) == canonical_kind_bytes("", &Bundle::SCHEMA)
+        let matches = slot_schema.as_ref().is_some_and(|s| {
+            canonical_kind_bytes("", s) == canonical_kind_bytes("", &expected_schema)
         });
-        if !accepts_bundle {
+        if !matches {
             let got_kind = slot_schema
                 .as_ref()
                 .map_or(KindId(0), |s| declared_kind_id(mailboxes, s));
             return Err(DagError::EdgeTypeMismatch {
                 edge_index: u32::try_from(edge_index).unwrap_or(u32::MAX),
-                expected_kind: Bundle::ID,
+                expected_kind,
                 got_kind,
             });
         }

--- a/crates/aether-substrate/tests/dag_validator.rs
+++ b/crates/aether-substrate/tests/dag_validator.rs
@@ -149,7 +149,7 @@ fn validator_accepts_minimal_dag() {
         }],
     };
 
-    let validated = validator::validate(&descriptor, &reg, &caps).expect("minimal dag validates");
+    let validated = validator::validate(&descriptor, &reg, &caps, None).expect("minimal dag validates");
     assert_eq!(validated.topo_order.len(), 2);
     // Source must precede the observer in topo order.
     let src_pos = validated.topo_order.iter().position(|n| *n == NodeId(0));
@@ -166,7 +166,7 @@ fn validator_rejects_unsupported_version() {
         nodes: vec![],
         edges: vec![],
     };
-    match validator::validate(&descriptor, &reg, &caps) {
+    match validator::validate(&descriptor, &reg, &caps, None) {
         Err(DagError::TooLarge { reason }) => {
             assert!(
                 reason.contains("version"),
@@ -203,7 +203,7 @@ fn validator_rejects_duplicate_node_id() {
         edges: vec![],
     };
     assert_eq!(
-        validator::validate(&descriptor, &reg, &caps),
+        validator::validate(&descriptor, &reg, &caps, None),
         Err(DagError::DuplicateNodeId(NodeId(0)))
     );
 }
@@ -227,7 +227,7 @@ fn validator_rejects_unknown_endpoint() {
         }],
     };
     assert_eq!(
-        validator::validate(&descriptor, &reg, &caps),
+        validator::validate(&descriptor, &reg, &caps, None),
         Err(DagError::UnknownNodeId(NodeId(99)))
     );
 }
@@ -269,7 +269,7 @@ fn validator_rejects_cycle() {
             },
         ],
     };
-    match validator::validate(&descriptor, &reg, &caps) {
+    match validator::validate(&descriptor, &reg, &caps, None) {
         Err(DagError::Cycle(residual)) => {
             let set: BTreeSet<NodeId> = residual.into_iter().collect();
             assert_eq!(set, [NodeId(0), NodeId(1), NodeId(2)].into_iter().collect());
@@ -306,7 +306,7 @@ fn validator_rejects_source_with_incoming_edge() {
         }],
     };
     assert_eq!(
-        validator::validate(&descriptor, &reg, &caps),
+        validator::validate(&descriptor, &reg, &caps, None),
         Err(DagError::SourceWithIncomingEdge(NodeId(0)))
     );
 }
@@ -337,7 +337,7 @@ fn validator_rejects_observer_with_outgoing_edge() {
         }],
     };
     assert_eq!(
-        validator::validate(&descriptor, &reg, &caps),
+        validator::validate(&descriptor, &reg, &caps, None),
         Err(DagError::ObserverWithOutgoingEdge(NodeId(0)))
     );
 }
@@ -358,7 +358,7 @@ fn validator_rejects_unknown_sink() {
         }],
         edges: vec![],
     };
-    match validator::validate(&descriptor, &reg, &caps) {
+    match validator::validate(&descriptor, &reg, &caps, None) {
         Err(DagError::UnknownSink(_)) => {}
         other => panic!("expected UnknownSink, got {other:?}"),
     }
@@ -378,7 +378,7 @@ fn validator_rejects_unknown_recipient() {
         }],
         edges: vec![],
     };
-    match validator::validate(&descriptor, &reg, &caps) {
+    match validator::validate(&descriptor, &reg, &caps, None) {
         Err(DagError::UnknownRecipient(_)) => {}
         other => panic!("expected UnknownRecipient, got {other:?}"),
     }
@@ -401,7 +401,7 @@ fn validator_rejects_kind_not_accepted() {
         }],
         edges: vec![],
     };
-    match validator::validate(&descriptor, &reg, &caps) {
+    match validator::validate(&descriptor, &reg, &caps, None) {
         Err(DagError::KindNotAccepted { node, kind_id, .. }) => {
             assert_eq!(node, NodeId(0));
             assert_eq!(kind_id, Signal::ID);
@@ -425,7 +425,7 @@ fn validator_rejects_observer_kind_not_accepted_no_fallback() {
         }],
         edges: vec![],
     };
-    match validator::validate(&descriptor, &reg, &caps) {
+    match validator::validate(&descriptor, &reg, &caps, None) {
         Err(DagError::KindNotAccepted { node, .. }) => assert_eq!(node, NodeId(0)),
         other => panic!("expected KindNotAccepted, got {other:?}"),
     }
@@ -447,7 +447,7 @@ fn validator_accepts_observer_via_fallback() {
         }],
         edges: vec![],
     };
-    assert!(validator::validate(&descriptor, &reg, &caps).is_ok());
+    assert!(validator::validate(&descriptor, &reg, &caps, None).is_ok());
 }
 
 #[test]
@@ -467,7 +467,7 @@ fn validator_rejects_too_large_nodes() {
         nodes,
         edges: vec![],
     };
-    match validator::validate(&descriptor, &reg, &caps) {
+    match validator::validate(&descriptor, &reg, &caps, None) {
         Err(DagError::TooLarge { reason }) => {
             assert!(reason.contains("node count"), "reason: {reason}");
         }
@@ -485,10 +485,11 @@ fn validator_rejects_transform_node() {
             id: NodeId(0),
             transform_id: TransformId(0x1234),
             output_kind_id: Signal::ID,
+            timeout_ms: None,
         }],
         edges: vec![],
     };
-    match validator::validate(&descriptor, &reg, &caps) {
+    match validator::validate(&descriptor, &reg, &caps, None) {
         Err(DagError::UnknownTransform { node, transform_id }) => {
             assert_eq!(node, NodeId(0));
             assert_eq!(transform_id, TransformId(0x1234));
@@ -549,7 +550,7 @@ fn validator_accepts_call_node() {
         ],
     };
 
-    validator::validate(&descriptor, &reg, &caps).expect("call dag validates");
+    validator::validate(&descriptor, &reg, &caps, None).expect("call dag validates");
 }
 
 #[test]
@@ -566,7 +567,7 @@ fn validator_rejects_call_unknown_recipient() {
         }],
         edges: vec![],
     };
-    match validator::validate(&descriptor, &reg, &caps) {
+    match validator::validate(&descriptor, &reg, &caps, None) {
         Err(DagError::UnknownRecipient(_)) => {}
         other => panic!("expected UnknownRecipient, got {other:?}"),
     }
@@ -587,7 +588,7 @@ fn validator_rejects_call_kind_not_accepted() {
         }],
         edges: vec![],
     };
-    match validator::validate(&descriptor, &reg, &caps) {
+    match validator::validate(&descriptor, &reg, &caps, None) {
         Err(DagError::KindNotAccepted { node, kind_id, .. }) => {
             assert_eq!(node, NodeId(0));
             assert_eq!(kind_id, Signal::ID);
@@ -633,7 +634,7 @@ fn validator_rejects_call_consumer_not_accepting_bundle() {
         }],
     };
 
-    match validator::validate(&descriptor, &reg, &caps) {
+    match validator::validate(&descriptor, &reg, &caps, None) {
         Err(DagError::EdgeTypeMismatch {
             edge_index,
             expected_kind,

--- a/crates/aether-substrate/tests/dag_validator.rs
+++ b/crates/aether-substrate/tests/dag_validator.rs
@@ -149,7 +149,8 @@ fn validator_accepts_minimal_dag() {
         }],
     };
 
-    let validated = validator::validate(&descriptor, &reg, &caps, None).expect("minimal dag validates");
+    let validated =
+        validator::validate(&descriptor, &reg, &caps, None).expect("minimal dag validates");
     assert_eq!(validated.topo_order.len(), 2);
     // Source must precede the observer in topo order.
     let src_pos = validated.topo_order.iter().position(|n| *n == NodeId(0));

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -18,6 +18,13 @@ exclude:
       - .cargo
       - archive
       - spikes
+      # trybuild compile-fixtures (e.g. the #[transform] macro's
+      # accept/reject cases) are standalone .rs files compiled
+      # individually by trybuild — they are intentionally not `mod`-
+      # attached to any cargo target, so Qodana's "Detached file"
+      # inspection fires on every one. The detachment is the trybuild
+      # contract, not a defect; exclude the fixture trees.
+      - crates/aether-data-derive/tests/ui
 
 # Native deps + toolchain bump.
 #


### PR DESCRIPTION
ADR-0048 native transforms — pure Rust `Kind -> Kind` functions collected at link time, no wasm. Implements release unit `transforms` (three issues, one branch, built in order).

Closes iamacoffeepot/aether#979
Closes iamacoffeepot/aether#982
Closes iamacoffeepot/aether#1012

## Summary

### iamacoffeepot/aether#979 — `#[transform]` attribute macro (data layer)
A transform is a pure `Kind -> Kind` data-layer primitive (no `Ctx`, no mail, no lifecycle), so its authoring macro lives in the data layer (re-exported as `aether_data::transform`), not the actor SDK. New sibling proc-macro crate `aether-data-derive` holds the attribute (`aether-data` is `no_std`+`alloc` and cannot itself be `proc-macro = true`). The macro enforces the signature contract (no `self`, no generics, up to 8 `Kind` inputs, single `Kind` output), runs a best-effort deny-list purity scan over the body (host fns, handler-context types, `wait_reply`, `std`/`core` time + `std` env), and submits a link-time inventory `TransformEntry` carrying a stable name-based `transform_id`, the input/output kind ids, the name, and a type-erased decode-call-encode `invoke` thunk. Runtime types + the 16-byte `TRANSFORM_DOMAIN` salt live in `aether-data`. trybuild fixtures cover accept/reject; a determinism test asserts byte-identical output across two `invoke` calls.

### iamacoffeepot/aether#982 — content-addressed transform handle id
`content_addressed_handle_id(transform_id, inputs)` = `fnv1a_64(HANDLE_DOMAIN ++ transform_id ++ input_count ++ slot-indexed input handle ids)`, tagged `Tag::Handle`. Keys on the global `transform_id`, so identical compute dedups engine-wide and across restarts. The explicit slot byte keeps `compose(a, b)` vs `compose(b, a)` on distinct entries; the `input_count` byte distinguishes `foo(a)` from `foo(a, a)`. `HANDLE_DOMAIN` is disjoint from the kind / mailbox / transform / type domains. Tests cover determinism (1000 iters), slot-order / input-count / transform-id sensitivity, cross-domain disjointness, and a 10k-tuple collision smoke.

### iamacoffeepot/aether#1012 — native invocation in the DAG executor
The executor builds a substrate-global `TransformRegistry` from the link-time inventory at boot; the validator's dispatchability + edge-type phases cross-check each `Transform` node (`UnknownTransform` / `TransformOutputMismatch` / `EdgeTypeMismatch`). A resolved `Transform` node dispatches off the executor thread onto a dedicated bounded compute pool (default available parallelism) — a pure `fn` is `Send`, so a slow transform never stalls the parking/reaping loop. The pre-dispatch content-addressed cache check short-circuits the invoke entirely on a hit (engine-wide auto-dedup); on a miss the pool runs the thunk under `catch_unwind`, stashes the outcome, and wakes the executor with `aether.dag.transform_done` so it resolves / fails the node on its own single-threaded actor thread. Panic = node failure; a per-node `timeout_ms` (wire-additive) fails the node and orphans the runaway thread (a native thread can't be preempted); output over the cap (default 64MB) hard-fails; a domain `Err` is a successful cached output, not a DAG failure. MCP gains a `describe_transforms` listing.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo doc --workspace --no-deps` under the denied rustdoc lints (no broken-link warnings)
- [x] wasm32 component cross-build (all four component crates, one at a time)
- [x] `cargo nextest run --workspace --all-features --profile ci` (1191 passed)
- [x] new tests: `#[transform]` trybuild accept/reject + determinism; content-addressed handle derivation suite; executor invoke / panic / timeout / output-overflow / cache-hit / off-thread fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
