### PR TITLE
fix(mcp): typed submit_dag descriptor so clients send an object

### DIFF
--- a/crates/aether-mcp/src/args.rs
+++ b/crates/aether-mcp/src/args.rs
@@ -2,6 +2,7 @@
 //! (issue 763 P5b). Pure data — `serde` + `schemars::JsonSchema` so
 //! `rmcp` can derive the JSON Schema it advertises to MCP clients.
 
+use aether_data::{KindId, MailboxId, TransformId};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -349,34 +350,175 @@ pub struct CaptureFrameArgs {
     pub after_mails: Vec<CaptureMailSpec>,
 }
 
-/// `submit_dag` arguments (ADR-0047 §9).
+// `SubmitDagArgs` lives in its own module so a *scoped*
+// `#![allow(unused_qualifications)]` can cover schemars' `schema_with`
+// codegen without relaxing the workspace lint anywhere else. The
+// `schema_with` expansion emits a `_SchemarsSchemaWithFunction` wrapper
+// containing `impl schemars::JsonSchema` / `<… as schemars::JsonSchema>`
+// — paths that are redundant in this crate's lint context (we
+// `use schemars::JsonSchema`) and so trip `unused_qualifications`. That
+// generated `impl` is a module-level sibling of the struct, so the lint
+// can only be silenced at module scope (an `#[allow]` on the struct or
+// field never reaches it). Isolating the one struct that uses
+// `schema_with` keeps the allow surgical.
+mod submit_dag_args {
+    #![allow(unused_qualifications)]
+
+    use schemars::JsonSchema;
+    use serde::Deserialize;
+
+    use super::DagDescriptorArg;
+
+    /// `schema_with` hook for [`SubmitDagArgs::descriptor`]: returns the
+    /// `DagDescriptorArg` schema *inline* (`json_schema` yields the
+    /// type's own object definition, not a `subschema_for` `$ref`), so
+    /// the advertised property carries `type: object` with the full
+    /// node/edge structure directly — clients then send a nested object
+    /// rather than stringifying this top-level arg.
+    fn descriptor_inline_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        DagDescriptorArg::json_schema(generator)
+    }
+
+    /// `submit_dag` arguments (ADR-0047 §9).
+    #[derive(Debug, Deserialize, JsonSchema)]
+    pub struct SubmitDagArgs {
+        /// Engine UUID the DAG submits to (from `list_engines`).
+        pub engine_id: String,
+        /// The DAG descriptor, encoded against the `aether.dag.descriptor`
+        /// kind schema. `nodes` is an array of externally-tagged `Node`
+        /// variants (`{ "Source": { id, mailbox, kind_id, payload_path }
+        /// }`, `{ "Observer": { id, recipient, kind_id } }`, `{ "Call": {
+        /// id, recipient, kind_id } }`); `edges` is an array of `{ from,
+        /// to, slot }`; `version` is `1`. Tagged-string ids (`mbx-…`,
+        /// `knd-…`) per ADR-0064/0065.
+        ///
+        /// **`payload_path` is a tool-layer virtual field.** Each
+        /// `Source` carries `payload_path: String` instead of the wire
+        /// `payload: Vec<u8>`: `submit_dag` reads the file at that path
+        /// and substitutes the bytes into the wire `payload` before
+        /// encoding. The path must be readable from the MCP process
+        /// (colocated with the substrate in v1). A `Source` may instead
+        /// carry an inline `payload` byte array; `payload_path` takes
+        /// precedence when both are present.
+        ///
+        /// Deserializes into the typed [`DagDescriptorArg`], so the
+        /// node/edge shape and tagged ids are validated with precise
+        /// parse errors. `schema_with` advertises that type's schema
+        /// *inline* (`type: object` with the full structure on this
+        /// property) rather than a bare `serde_json::Value` "any" or a
+        /// `$ref` — clients then send a nested object instead of
+        /// stringifying this top-level arg (an untyped arg got delivered
+        /// as a string, which `Submit` decode rejected as "expected
+        /// object").
+        #[schemars(schema_with = "descriptor_inline_schema")]
+        pub descriptor: DagDescriptorArg,
+        /// Cap on wall-clock wait for the synchronous validation verdict,
+        /// in milliseconds. Defaults to 5000. Guards against a hung
+        /// validator, not normal latency — validation is microseconds,
+        /// and execution is async (poll via `dag_status`).
+        #[serde(default)]
+        pub timeout_ms: Option<u32>,
+    }
+}
+
+pub use submit_dag_args::SubmitDagArgs;
+
+/// Tool-layer mirror of `aether_kinds::dag::DagDescriptor`. Differs from
+/// the wire kind only where the MCP boundary needs it to: `Source`
+/// carries a `payload_path` (a file the tool reads into the wire
+/// `payload` bytes) instead of inline bytes, and ids arrive as tagged
+/// strings. The id fields are the real `MailboxId` / `KindId` /
+/// `TransformId` — their serde already parses the tagged `mbx-` / `knd-`
+/// / `tfm-` form in JSON; `#[schemars(with = "String")]` only patches
+/// the *advertised* schema to `string` (those types intentionally don't
+/// implement `JsonSchema`, which lives in the tool layer, not the
+/// `no_std` data layer).
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct SubmitDagArgs {
-    /// Engine UUID the DAG submits to (from `list_engines`).
-    pub engine_id: String,
-    /// The DAG descriptor as JSON, encoded against the
-    /// `aether.dag.descriptor` kind schema (read it via `describe_kinds`).
-    /// `nodes` is an array of externally-tagged `Node` variants
-    /// (`{ "Source": { id, mailbox, kind_id, payload_path } }`,
-    /// `{ "Observer": { id, recipient, kind_id } }`,
-    /// `{ "Call": { id, recipient, kind_id } }`); `edges` is an array of
-    /// `{ from, to, slot }`; `version` is `1`. Tagged-string ids
-    /// (`mbx-…`, `knd-…`) per ADR-0064/0065.
-    ///
-    /// **`payload_path` is a tool-layer virtual field.** Each `Source`
-    /// carries `payload_path: String` instead of the wire `payload:
-    /// Vec<u8>`: `submit_dag` reads the file at that path and substitutes
-    /// the bytes into the wire `payload` before encoding. The path must
-    /// be readable from the MCP process (colocated with the substrate in
-    /// v1). A `Source` may instead carry an inline `payload` byte array;
-    /// `payload_path` takes precedence when both are present.
-    pub descriptor: serde_json::Value,
-    /// Cap on wall-clock wait for the synchronous validation verdict, in
-    /// milliseconds. Defaults to 5000. Guards against a hung validator,
-    /// not normal latency — validation is microseconds, and execution is
-    /// async (poll via `dag_status`).
-    #[serde(default)]
-    pub timeout_ms: Option<u32>,
+pub struct DagDescriptorArg {
+    /// Descriptor version (`1` for the current wire shape).
+    pub version: u16,
+    /// DAG nodes — externally-tagged `Source` / `Transform` / `Call` /
+    /// `Observer` variants.
+    pub nodes: Vec<NodeArg>,
+    /// Directed edges wiring a producer node's output into a consumer
+    /// node's input slot.
+    pub edges: Vec<EdgeArg>,
+}
+
+/// One DAG node — tool-layer mirror of `aether_kinds::dag::Node`,
+/// externally tagged (`{ "Source": { … } }`).
+#[derive(Debug, Deserialize, JsonSchema)]
+pub enum NodeArg {
+    /// Root node: dispatches a payload to `mailbox` as `kind_id` and
+    /// feeds the reply downstream. Sources have no incoming edges.
+    Source {
+        /// Descriptor-local node id, unique within this descriptor.
+        id: u32,
+        /// Sink mailbox (tagged `mbx-…`).
+        #[schemars(with = "String")]
+        mailbox: MailboxId,
+        /// Kind dispatched to `mailbox` (tagged `knd-…`).
+        #[schemars(with = "String")]
+        kind_id: KindId,
+        /// Filesystem path the tool reads into the wire payload bytes
+        /// (readable from the MCP process). Takes precedence over inline
+        /// `payload` when both are present.
+        #[serde(default)]
+        payload_path: Option<String>,
+        /// Inline payload bytes — an alternative to `payload_path` for
+        /// small payloads.
+        #[serde(default)]
+        payload: Option<Vec<u8>>,
+    },
+    /// Mid-graph pure native transform (ADR-0048).
+    Transform {
+        /// Descriptor-local node id.
+        id: u32,
+        /// Registered native transform (tagged `tfm-…`).
+        #[schemars(with = "String")]
+        transform_id: TransformId,
+        /// The kind this transform produces (tagged `knd-…`).
+        #[schemars(with = "String")]
+        output_kind_id: KindId,
+        /// Per-call deadline in ms; `None` uses the executor default.
+        #[serde(default)]
+        timeout_ms: Option<u64>,
+    },
+    /// Mid-graph effectful cap dispatch; its output handle is a
+    /// self-describing `Bundle`.
+    Call {
+        /// Descriptor-local node id.
+        id: u32,
+        /// Dispatch recipient (tagged `mbx-…`).
+        #[schemars(with = "String")]
+        recipient: MailboxId,
+        /// Kind dispatched to `recipient` (tagged `knd-…`).
+        #[schemars(with = "String")]
+        kind_id: KindId,
+    },
+    /// Terminal node: assembles `kind_id` from incoming edges and
+    /// dispatches it to `recipient`. Observers have no outgoing edges.
+    Observer {
+        /// Descriptor-local node id.
+        id: u32,
+        /// Dispatch recipient (tagged `mbx-…`).
+        #[schemars(with = "String")]
+        recipient: MailboxId,
+        /// Kind assembled and dispatched to `recipient` (tagged `knd-…`).
+        #[schemars(with = "String")]
+        kind_id: KindId,
+    },
+}
+
+/// One directed DAG edge — mirror of `aether_kinds::dag::Edge`.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct EdgeArg {
+    /// Producing node id.
+    pub from: u32,
+    /// Consuming node id.
+    pub to: u32,
+    /// Consumer-side input slot index.
+    pub slot: u32,
 }
 
 /// `dag_status` arguments (ADR-0047 §9).
@@ -395,4 +537,32 @@ pub struct DagCancelArgs {
     pub engine_id: String,
     /// Tagged DAG id (`dag-…`) returned by `submit_dag`.
     pub dag_id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression: `submit_dag`'s `descriptor` must advertise as an
+    /// object — either inline `type: object` on the property or via a
+    /// named definition it `$ref`s. As a bare `serde_json::Value` it
+    /// advertised no type at all, and MCP clients stringify an untyped
+    /// top-level object arg — the substrate then sees a string at
+    /// `$.descriptor` and rejects it ("expected object"), blocking every
+    /// DAG submission over MCP.
+    #[test]
+    fn submit_dag_descriptor_advertises_object_type() {
+        let schema = schemars::schema_for!(SubmitDagArgs);
+        let v = serde_json::to_value(&schema).expect("schema serializes");
+        let object = serde_json::Value::String("object".to_owned());
+        let defs = v.get("$defs").or_else(|| v.get("definitions"));
+        let advertises_object = v["properties"]["descriptor"]["type"] == object
+            || defs
+                .and_then(|d| d.get("DagDescriptorArg"))
+                .is_some_and(|d| d["type"] == object);
+        assert!(
+            advertises_object,
+            "descriptor must advertise as an object (inline or via a named def); schema: {v}"
+        );
+    }
 }

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -19,8 +19,8 @@ use aether_capabilities::rpc::{MailEnvelope, MailboxAddress};
 use aether_data::MailId;
 use aether_data::canonical::kind_id_from_parts;
 use aether_data::{
-    DagId, EngineId, Kind, KindDescriptor, KindId, MailboxId, Schema, Tag, Uuid,
-    mailbox_id_from_name, tagged_id,
+    DagId, EngineId, Kind, KindDescriptor, KindId, MailboxId, Tag, Uuid, mailbox_id_from_name,
+    tagged_id,
 };
 use aether_kinds::{
     Cancel, CancelResult, CaptureFrame, CaptureFrameResult, ComponentCapabilities, ListEngines,
@@ -32,6 +32,7 @@ use aether_kinds::{
         TRACE_OBSERVER_MAILBOX_NAME,
     },
 };
+use aether_kinds::dag::{DagDescriptor, Edge, Node, NodeId};
 use base64::Engine as _;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
@@ -42,11 +43,11 @@ use crate::args::ActorLogEntry;
 use crate::args::ActorLogsArgs;
 use crate::args::ActorLogsResponse;
 use crate::args::{
-    CaptureFrameArgs, CaptureMailSpec, DagCancelArgs, DagStatusArgs, DescribeComponentArgs,
-    DescribeHandlesArgs, DescribeHandlesResponse, EngineInfo, HandleSummaryJson, LoadComponentArgs,
-    MailIdJson, MailNodeJson, MailSpec, MailStatus, ReplaceComponentArgs, SendMailArgs,
-    SendMailTracedArgs, SendMailTracedResponse, SpawnSubstrateArgs, SubmitDagArgs,
-    TerminateSubstrateArgs, TracedMailSpec, TransformListing,
+    CaptureFrameArgs, CaptureMailSpec, DagCancelArgs, DagDescriptorArg, DagStatusArgs,
+    DescribeComponentArgs, DescribeHandlesArgs, DescribeHandlesResponse, EngineInfo,
+    HandleSummaryJson, LoadComponentArgs, MailIdJson, MailNodeJson, MailSpec, MailStatus, NodeArg,
+    ReplaceComponentArgs, SendMailArgs, SendMailTracedArgs, SendMailTracedResponse,
+    SpawnSubstrateArgs, SubmitDagArgs, TerminateSubstrateArgs, TracedMailSpec, TransformListing,
 };
 use crate::rpc::RpcSession;
 use aether_kinds::descriptors;
@@ -595,17 +596,16 @@ impl Mcp {
         Parameters(args): Parameters<SubmitDagArgs>,
     ) -> Result<String, McpError> {
         let engine = parse_engine_id(&args.engine_id)?;
-        // Resolve each Source's `payload_path` virtual field into wire
-        // `payload` bytes before encoding. A read failure surfaces as a
-        // clean invalid-params error and never touches the wire.
-        let descriptor_json = resolve_payload_paths(args.descriptor)
+        // Build the wire descriptor from the typed arg, reading each
+        // Source's `payload_path` into the wire `payload` bytes. A read
+        // failure surfaces as a clean invalid-params error and never
+        // touches the wire.
+        let descriptor = build_descriptor(args.descriptor)
             .await
             .map_err(|e| McpError::invalid_params(format!("submit_dag descriptor: {e}"), None))?;
-        // Encode `Submit { descriptor }` against the Submit kind schema —
-        // the same encode_schema path send_mail uses for its params.
-        let submit_json = serde_json::json!({ "descriptor": descriptor_json });
-        let payload = aether_codec::encode_schema(&submit_json, &Submit::SCHEMA)
-            .map_err(|e| McpError::invalid_params(format!("submit_dag encode: {e}"), None))?;
+        // Encode via the kind's native (postcard) wire encode — ids
+        // serialize in their u64 form, matching the substrate's decode.
+        let payload = Submit { descriptor }.encode_into_bytes();
         let envelope = MailEnvelope {
             to: MailboxAddress {
                 engine: Some(engine),
@@ -806,52 +806,83 @@ fn parse_dag_id(s: &str) -> Result<DagId, McpError> {
         .map_err(|e| McpError::invalid_params(format!("dag_id: {e}"), None))
 }
 
-/// Resolve the tool-layer `payload_path` virtual field on every `Source`
-/// node of a descriptor JSON into the wire `payload: Vec<u8>` byte array.
-///
-/// The descriptor JSON is the externally-tagged `DagDescriptor` shape
-/// `encode_schema` accepts: `nodes` is an array of `{ "Source": { … } }`
-/// / `{ "Observer": { … } }` / `{ "Call": { … } }` objects. For each
-/// `Source` object carrying a `payload_path` string, this reads the file
-/// at that path, replaces `payload` with the file bytes as a JSON byte
-/// array, and removes `payload_path`. A `Source` with an inline
-/// `payload` array and no `payload_path` is left untouched. The
-/// substrate never sees the path — it gets a normal `Vec<u8>` payload.
-async fn resolve_payload_paths(
-    mut descriptor: serde_json::Value,
-) -> anyhow::Result<serde_json::Value> {
-    let Some(nodes) = descriptor
-        .get_mut("nodes")
-        .and_then(serde_json::Value::as_array_mut)
-    else {
-        // No nodes array — let encode_schema produce the structured
-        // error rather than second-guessing the shape here.
-        return Ok(descriptor);
-    };
-    for node in nodes.iter_mut() {
-        // Externally-tagged: { "Source": { … } }.
-        let Some(source) = node
-            .get_mut("Source")
-            .and_then(serde_json::Value::as_object_mut)
-        else {
-            continue;
+/// Build the wire [`DagDescriptor`] from the typed tool arg, reading each
+/// `Source`'s `payload_path` into the wire `payload` bytes. The wire kind
+/// never learns about filesystem paths — the path is a tool-layer
+/// convenience resolved here; `payload_path` takes precedence over an
+/// inline `payload`. The tagged-string ids were already parsed into their
+/// typed `MailboxId` / `KindId` / `TransformId` form during arg
+/// deserialization, so this is a straight move + a file read.
+async fn build_descriptor(arg: DagDescriptorArg) -> anyhow::Result<DagDescriptor> {
+    let mut nodes = Vec::with_capacity(arg.nodes.len());
+    for node in arg.nodes {
+        let wire = match node {
+            NodeArg::Source {
+                id,
+                mailbox,
+                kind_id,
+                payload_path,
+                payload,
+            } => {
+                let payload = match payload_path {
+                    Some(path) => fs::read(&path)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("reading payload_path {path:?}: {e}"))?,
+                    None => payload.unwrap_or_default(),
+                };
+                Node::Source {
+                    id: NodeId(id),
+                    mailbox,
+                    kind_id,
+                    payload,
+                }
+            }
+            NodeArg::Transform {
+                id,
+                transform_id,
+                output_kind_id,
+                timeout_ms,
+            } => Node::Transform {
+                id: NodeId(id),
+                transform_id,
+                output_kind_id,
+                timeout_ms,
+            },
+            NodeArg::Call {
+                id,
+                recipient,
+                kind_id,
+            } => Node::Call {
+                id: NodeId(id),
+                recipient,
+                kind_id,
+            },
+            NodeArg::Observer {
+                id,
+                recipient,
+                kind_id,
+            } => Node::Observer {
+                id: NodeId(id),
+                recipient,
+                kind_id,
+            },
         };
-        let Some(path) = source
-            .get("payload_path")
-            .and_then(serde_json::Value::as_str)
-        else {
-            continue;
-        };
-        let path = path.to_owned();
-        let bytes = fs::read(&path)
-            .await
-            .map_err(|e| anyhow::anyhow!("reading payload_path {path:?}: {e}"))?;
-        let byte_array: Vec<serde_json::Value> =
-            bytes.into_iter().map(serde_json::Value::from).collect();
-        source.insert("payload".to_owned(), serde_json::Value::Array(byte_array));
-        source.remove("payload_path");
+        nodes.push(wire);
     }
-    Ok(descriptor)
+    let edges = arg
+        .edges
+        .into_iter()
+        .map(|e| Edge {
+            from: NodeId(e.from),
+            to: NodeId(e.to),
+            slot: e.slot,
+        })
+        .collect();
+    Ok(DagDescriptor {
+        version: arg.version,
+        nodes,
+        edges,
+    })
 }
 
 /// Encode a `send_mail_traced` batch into the same `MailEnvelope`
@@ -1433,10 +1464,10 @@ mod tests {
         path
     }
 
-    /// The tool's `payload_path` → wire-`payload` substitution + JSON
-    /// encode path produces the exact same canonical bytes as a direct
-    /// `#[derive(Kind)]` encode of the same descriptor with the bytes
-    /// inlined. Locks against encoding skew between the two paths.
+    /// The typed-arg path (`DagDescriptorArg` deserialize + `payload_path`
+    /// file read + native `encode_into_bytes`) produces the exact same
+    /// canonical bytes as a direct `#[derive(Kind)]` encode of the same
+    /// descriptor with the bytes inlined. Locks against encoding skew.
     #[tokio::test]
     async fn submit_dag_encodes_descriptor() {
         let source_mbx = mailbox_id_from_name("aether.fs");
@@ -1475,41 +1506,38 @@ mod tests {
         }
         .encode_into_bytes();
 
-        // Tool path: descriptor JSON with a `payload_path` virtual field
-        // on the source, externally-tagged Node variants, tagged-string
-        // ids.
+        // Tool path: typed descriptor with a `payload_path` virtual field
+        // on the source, externally-tagged variants, tagged-string ids,
+        // and plain-integer node ids (no `{ "0": n }` schema wrapping).
         let path = stage_temp_file("encode", &payload_bytes);
-        // NodeId is a `#[derive(Schema)]` newtype, so encode_schema reads
-        // its single tuple field as `{ "0": <u32> }` (the schema-correct
-        // JSON the agent authors against `describe_kinds`).
         let descriptor_json = serde_json::json!({
             "version": 1,
             "nodes": [
                 { "Source": {
-                    "id": { "0": 0 },
+                    "id": 0,
                     "mailbox": tagged_id::encode(source_mbx.0).unwrap(),
                     "kind_id": tagged_id::encode(source_kind.0).unwrap(),
                     "payload_path": path.to_str().unwrap(),
                 }},
                 { "Observer": {
-                    "id": { "0": 1 },
+                    "id": 1,
                     "recipient": tagged_id::encode(observer_mbx.0).unwrap(),
                     "kind_id": tagged_id::encode(observer_kind.0).unwrap(),
                 }},
             ],
-            "edges": [ { "from": { "0": 0 }, "to": { "0": 1 }, "slot": 0 } ],
+            "edges": [ { "from": 0, "to": 1, "slot": 0 } ],
         });
-        let resolved = resolve_payload_paths(descriptor_json)
-            .await
-            .expect("payload_path resolves");
-        let submit_json = serde_json::json!({ "descriptor": resolved });
-        let actual =
-            aether_codec::encode_schema(&submit_json, &Submit::SCHEMA).expect("encode_schema ok");
+        let arg: DagDescriptorArg =
+            serde_json::from_value(descriptor_json).expect("descriptor deserializes");
+        let actual = Submit {
+            descriptor: build_descriptor(arg).await.expect("payload_path resolves"),
+        }
+        .encode_into_bytes();
 
         std_fs::remove_file(&path).ok();
         assert_eq!(
             actual, expected,
-            "tool path-loading + JSON encode must match the binary inline-bytes encode",
+            "typed tool path + native encode must match the binary inline-bytes encode",
         );
     }
 
@@ -1539,7 +1567,7 @@ mod tests {
             "version": 1,
             "nodes": [
                 { "Source": {
-                    "id": { "0": 0 },
+                    "id": 0,
                     "mailbox": tagged_id::encode(source_mbx.0).unwrap(),
                     "kind_id": tagged_id::encode(source_kind.0).unwrap(),
                     "payload": payload_bytes,
@@ -1547,12 +1575,12 @@ mod tests {
             ],
             "edges": [],
         });
-        let resolved = resolve_payload_paths(descriptor_json)
-            .await
-            .expect("inline payload untouched");
-        let submit_json = serde_json::json!({ "descriptor": resolved });
-        let actual =
-            aether_codec::encode_schema(&submit_json, &Submit::SCHEMA).expect("encode_schema ok");
+        let arg: DagDescriptorArg =
+            serde_json::from_value(descriptor_json).expect("descriptor deserializes");
+        let actual = Submit {
+            descriptor: build_descriptor(arg).await.expect("inline payload builds"),
+        }
+        .encode_into_bytes();
         assert_eq!(actual, expected);
     }
 
@@ -1563,7 +1591,7 @@ mod tests {
         let (_chassis, port) = boot_hub();
         let mcp = connect_mcp(port);
         let source_mbx = mailbox_id_from_name("aether.fs");
-        let descriptor = serde_json::json!({
+        let descriptor: DagDescriptorArg = serde_json::from_value(serde_json::json!({
             "version": 1,
             "nodes": [
                 { "Source": {
@@ -1574,7 +1602,8 @@ mod tests {
                 }},
             ],
             "edges": [],
-        });
+        }))
+        .expect("descriptor deserializes");
         let result = mcp
             .submit_dag(Parameters(SubmitDagArgs {
                 engine_id: "00000000-0000-0000-0000-000000000001".to_owned(),

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -22,6 +22,7 @@ use aether_data::{
     DagId, EngineId, Kind, KindDescriptor, KindId, MailboxId, Tag, Uuid, mailbox_id_from_name,
     tagged_id,
 };
+use aether_kinds::dag::{DagDescriptor, Edge, Node, NodeId};
 use aether_kinds::{
     Cancel, CancelResult, CaptureFrame, CaptureFrameResult, ComponentCapabilities, ListEngines,
     ListEnginesResult, LoadComponent, LoadResult, MailEnvelope as KindMailEnvelope,
@@ -32,7 +33,6 @@ use aether_kinds::{
         TRACE_OBSERVER_MAILBOX_NAME,
     },
 };
-use aether_kinds::dag::{DagDescriptor, Edge, Node, NodeId};
 use base64::Engine as _;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;


### PR DESCRIPTION
## Summary

`submit_dag` rejected every DAG submission over MCP with an "expected object" error on the `descriptor` field. Root cause: `SubmitDagArgs.descriptor` was a bare `serde_json::Value`, which schemars advertises with no `type`. MCP clients stringify an untyped top-level object arg, so the substrate received a JSON *string* where it wanted the `descriptor` object, and `encode_schema` rejected it.

## Changes

- **Typed descriptor.** `descriptor` is now a `DagDescriptorArg` / `NodeArg` / `EdgeArg` mirror. Id fields reuse the real `MailboxId` / `KindId` / `TransformId` — their serde already parses the tagged `mbx-`/`knd-`/`tfm-` strings in JSON — and node ids are plain `u32` (no `{ "0": n }` schema wrapping the agent had to author).
- **Native encode.** The handler converts to the wire `DagDescriptor` (reading each `Source`'s `payload_path` into bytes) and encodes via the kind's `encode_into_bytes`. An equivalence test pins this to the prior `encode_schema` output, so the wire bytes are unchanged. The old `resolve_payload_paths` JSON-walking is gone.
- **Precise inline schema.** `schema_with` advertises the full `DagDescriptorArg` object inline (`type: object` + properties), not a `$ref`, so clients send a nested object. That codegen emits a redundant `schemars::JsonSchema` path that trips the workspace `unused_qualifications` lint, and the generated impl is a module-level sibling (so a struct/field `#[allow]` can't reach it) — the struct lives in a small submodule with a scoped `#![allow(unused_qualifications)]`.

## Test plan

- [x] `scripts/preflight.sh` green (fmt, clippy -D warnings, doc, nextest, wasm32)
- [x] New `submit_dag_descriptor_advertises_object_type` — schema regression
- [x] `submit_dag_encodes_descriptor` / `submit_dag_inline_payload_encodes` rewired to the typed path, asserting byte-identical output to the canonical inline encode
- [x] **Verified live over MCP**: the same call that returned "expected object" now reaches validation, and a real `aether.fs` + `Read` descriptor validates and mints a DAG (`dag-…` + output handle)

Context: surfaced while smoke-testing the iamacoffeepot/aether#1048 work; follow-on log-legibility cuts filed as iamacoffeepot/aether#1052.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
