### PR TITLE
test(substrate-bundle): worker-swept mail-latency harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,7 @@ dependencies = [
  "aether-test-fixture-probe",
  "anyhow",
  "bytemuck",
+ "crossbeam-channel",
  "ctrlc",
  "png",
  "pollster",

--- a/crates/aether-substrate-bundle/Cargo.toml
+++ b/crates/aether-substrate-bundle/Cargo.toml
@@ -89,6 +89,12 @@ aether-test-fixture-probe = { path = "../aether-test-fixture-probe" }
 # only and inert in a host rlib anyway, but skipping it keeps the host
 # test build lean.
 aether-camera = { path = "../aether-camera", default-features = false }
+# iamacoffeepot/aether#1057: the mail-latency harness (`test_bench::mail_latency`)
+# subscribes to per-root `Settled` notifications to wait for injected
+# trace trees to drain; naming the settlement `Receiver<()>` returned by
+# `SettlementRegistry::subscribe_settlement` needs crossbeam-channel in
+# direct scope. Test-only.
+crossbeam-channel = "0.5"
 
 [lints]
 workspace = true

--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -73,6 +73,7 @@ fn main() -> anyhow::Result<()> {
         name: "test-bench".to_owned(),
         version: env!("CARGO_PKG_VERSION").to_owned(),
         workers: WORKERS,
+        pool_workers: None,
         observed_kinds: None,
         events_tx,
         capture_queue: capture_queue.clone(),

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -208,6 +208,7 @@ pub struct TestBenchBuilder {
     width: u32,
     height: u32,
     namespace_roots: Option<NamespaceRoots>,
+    pool_workers: Option<usize>,
 }
 
 impl Default for TestBenchBuilder {
@@ -216,6 +217,7 @@ impl Default for TestBenchBuilder {
             width: DEFAULT_WIDTH,
             height: DEFAULT_HEIGHT,
             namespace_roots: None,
+            pool_workers: None,
         }
     }
 }
@@ -241,12 +243,28 @@ impl TestBenchBuilder {
         self
     }
 
+    /// Override the scheduler worker-pool size. `None` (the default)
+    /// keeps `PoolConfig::default` (`available_parallelism() - 1`, min
+    /// 1); `Some(n)` pins the pool to `n` workers. The mail-latency
+    /// harness sweeps this to expose how pool size gates fan-out
+    /// parallelism and under-load inbox queueing (iamacoffeepot/aether#1057).
+    #[must_use]
+    pub fn with_workers(mut self, workers: Option<usize>) -> Self {
+        self.pool_workers = workers;
+        self
+    }
+
     /// Boot the bench. Equivalent to `TestBench::start_with_size` for
     /// the default builder; overrides applied via the builder methods
     /// flow through to `SubstrateBoot::builder` and the chassis-side
     /// IO sink wiring.
     pub fn build(self) -> Result<TestBench, TestBenchError> {
-        TestBench::start_inner(self.width, self.height, self.namespace_roots)
+        TestBench::start_inner(
+            self.width,
+            self.height,
+            self.namespace_roots,
+            self.pool_workers,
+        )
     }
 }
 
@@ -267,13 +285,14 @@ impl TestBench {
     /// Boot a `TestBench` with a specific offscreen target size.
     /// Width / height are clamped to a minimum of 1 inside `Gpu::new`.
     pub fn start_with_size(width: u32, height: u32) -> Result<Self, TestBenchError> {
-        Self::start_inner(width, height, None)
+        Self::start_inner(width, height, None, None)
     }
 
     fn start_inner(
         width: u32,
         height: u32,
         namespace_roots: Option<NamespaceRoots>,
+        pool_workers: Option<usize>,
     ) -> Result<Self, TestBenchError> {
         let capture_queue = CaptureQueue::new();
         let (events_tx, events_rx) = event_channel();
@@ -290,6 +309,7 @@ impl TestBench {
             name: "test-bench".to_owned(),
             version: env!("CARGO_PKG_VERSION").to_owned(),
             workers: WORKERS,
+            pool_workers,
             observed_kinds: Some(Arc::clone(&observed_kinds)),
             events_tx,
             capture_queue: capture_queue.clone(),
@@ -472,6 +492,29 @@ impl TestBench {
     #[cfg(test)]
     pub(crate) fn actor_registry(&self) -> &Arc<aether_substrate::ActorRegistry> {
         self.passive.actor_registry()
+    }
+
+    /// iamacoffeepot/aether#1057: inject a chassis-root mail and return its
+    /// `MailId` plus a settlement [`Receiver`] that fires when the whole
+    /// causal tree drains. Unlike [`Self::send_bytes`] this does NOT
+    /// block — the mail-latency harness injects many roots back-to-back
+    /// (to build inbox queueing) and waits on the collected receivers
+    /// afterward. Subscription is race-safe: `subscribe_settlement`
+    /// pre-fires if the tree settled between the push and the subscribe.
+    #[cfg(test)]
+    pub(crate) fn inject_root(
+        &self,
+        recipient: MailboxId,
+        kind: KindId,
+        payload: Vec<u8>,
+    ) -> (MailId, crossbeam_channel::Receiver<()>) {
+        let cid = self.fresh_correlation_id();
+        let registry = self.passive.settlement_registry();
+        let root = self
+            .queue
+            .push_chassis_root_mail(cid, recipient, kind, payload, 1);
+        let rx = registry.subscribe_settlement(root);
+        (root, rx)
     }
 
     /// Bytes-level request/reply: push `(kind, payload)` to

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -109,6 +109,14 @@ pub struct TestBenchEnv {
     /// Number of workers for the wire-stable `EngineInfo.workers`
     /// field. Defaults to [`WORKERS`].
     pub workers: usize,
+    /// Override for the scheduler worker-pool size (`PoolConfig::workers`).
+    /// `None` keeps `PoolConfig::default` (`available_parallelism() - 1`,
+    /// min 1) — the behaviour every `TestBench` had before
+    /// iamacoffeepot/aether#1057.
+    /// The mail-latency harness sets this to sweep pool size, since the
+    /// pool-default dispatch model makes worker count the dominant
+    /// latency variable for fan-out and under-load topologies.
+    pub pool_workers: Option<usize>,
     /// Optional observation log: when `Some`, both render and
     /// camera dispatchers push every inbound mail's kind name to it.
     /// In-process API uses this to assert what the sinks have seen;
@@ -182,6 +190,7 @@ impl TestBenchChassis {
             name,
             version,
             workers,
+            pool_workers,
             observed_kinds,
             events_tx,
             capture_queue,
@@ -293,6 +302,7 @@ impl TestBenchChassis {
         // TestBench's own pumping logic; the driver broadcasts Tick to
         // `aether.input` via the relay subscriber.
         let mut builder = Builder::<Self>::new(Arc::clone(&boot.registry), Arc::clone(&boot.queue))
+            .with_workers(pool_workers)
             .with_actor::<HandleCapability>(())
             .with_actor::<TraceObserverCapability>(())
             .with_actor::<InputCapability>(input_config)

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -1,0 +1,453 @@
+//! Mail-latency measurement harness (iamacoffeepot/aether#1057).
+//!
+//! Measures the per-hop and end-to-end cost of inter-actor mail across
+//! controlled topologies, so the mail system has a numeric regression
+//! surface. The trace observer (ADR-0080) already stamps every mail
+//! with `t_sent` (producer enqueue), `t_received` (dispatcher pickup),
+//! and `t_finished` (handler return) from one monotonic clock, so the
+//! data is recorded for free — this harness just wires synthetic relay
+//! actors into a topology, injects traced root mails, reads the trace
+//! tree back over the `aether.trace` mail surface, and computes
+//! percentiles.
+//!
+//! **Worker count is the dominant variable.** Post issue #635 actors
+//! are `Pooled` by default — they share a worker pool of
+//! `available_parallelism() - 1` threads, not one thread each. So a
+//! depth-8 chain with one root in flight serialises regardless of pool
+//! size (only one slot is ever ready), but a fan-out of 8 — or many
+//! concurrent roots — either parallelises across workers or queues on a
+//! small pool. The harness therefore sweeps pool size as an outer axis
+//! (`TestBenchBuilder::with_workers`) and reports it as a column.
+//!
+//! Run on demand (it is `#[ignore]`d — zero CI cost):
+//!
+//! ```text
+//! cargo test -p aether-substrate-bundle --release mail_latency_sweep \
+//!     -- --ignored --nocapture
+//! ```
+//!
+//! Release matters: the numbers are dominated by enqueue + worker
+//! wake, which a debug build inflates several-fold.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use std::thread::available_parallelism;
+use std::time::Duration;
+
+use aether_data::{Kind, KindId, MailId, MailboxId, mailbox_id_from_name};
+use aether_kinds::trace::{
+    DescribeTree, DescribeTreeResult, MailNodeWire, TRACE_OBSERVER_MAILBOX_NAME,
+};
+use aether_substrate::{BootError, NativeActor, NativeCtx, NativeDispatch, NativeInitCtx, Subname};
+
+use super::TestBench;
+
+/// Fire-and-forward payload the relay actors pass along. The `seq`
+/// field is carried for legibility when eyeballing a trace; the relay
+/// forwards the bytes verbatim, so the wire shape is irrelevant to the
+/// measurement. Derived `Kind` (cast codec) — the schema-hashed `ID`
+/// is what the relay matches and the trace records; the value is
+/// immaterial.
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "mlat.ping")]
+struct Ping {
+    seq: u32,
+}
+
+/// A relay forwards each inbound `Ping` to every configured downstream
+/// mailbox, inheriting the trace lineage so the whole topology is one
+/// causal tree. A leaf relay (empty `downstreams`) just receives and
+/// returns. Pooled (the `Actor` default) — so the worker-pool size
+/// gates how its fan-out and any concurrent load behave.
+struct Relay {
+    downstreams: Arc<[MailboxId]>,
+}
+
+impl aether_actor::Actor for Relay {
+    const NAMESPACE: &'static str = "mlat.relay";
+}
+impl aether_actor::Instanced for Relay {}
+impl aether_actor::HandlesKind<Ping> for Relay {}
+impl NativeActor for Relay {
+    type Config = Arc<[MailboxId]>;
+    fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        Ok(Self {
+            downstreams: config,
+        })
+    }
+}
+impl NativeDispatch for Relay {
+    fn __aether_dispatch_envelope(
+        &mut self,
+        ctx: &mut NativeCtx<'_>,
+        kind: KindId,
+        payload: &[u8],
+    ) -> Option<()> {
+        if kind.0 != Ping::ID.0 {
+            return None;
+        }
+        // Forward the bytes verbatim to each downstream. The loop is
+        // the "one sender pushing to N inboxes" shape: each push stamps
+        // its own `t_sent`, so later children in a fan-out reveal any
+        // per-child enqueue skew.
+        for &down in self.downstreams.iter() {
+            // The minted child `MailId` isn't needed here — the trace
+            // observer records it; the relay only forwards.
+            let _ = ctx.send_envelope_traced(down, Ping::ID, payload);
+        }
+        Some(())
+    }
+}
+
+const RELAY_NS: &str = "mlat.relay";
+
+/// Deterministic `MailboxId` for relay instance `i`. Mirrors the
+/// substrate's `mailbox_id_from_name("{NAMESPACE}:{subname}")` so the
+/// whole topology can be wired from precomputed ids before any actor is
+/// spawned (sidesteps spawn-ordering between a relay and its
+/// downstreams).
+fn relay_id(i: usize) -> MailboxId {
+    MailboxId(mailbox_id_from_name(&format!("{RELAY_NS}:{i}")).0)
+}
+
+/// A topology is a DAG over relay indices: `downstreams[i]` lists the
+/// relays that relay `i` forwards to. Relay 0 is always the entry. The
+/// number of relays is `downstreams.len()`.
+struct Topology {
+    name: String,
+    downstreams: Vec<Vec<usize>>,
+}
+
+fn depth_chain(d: usize) -> Topology {
+    // 0 -> 1 -> ... -> d-1. Each relay forwards to the next; the last
+    // is a leaf.
+    let downstreams = (0..d)
+        .map(|i| if i + 1 < d { vec![i + 1] } else { vec![] })
+        .collect();
+    Topology {
+        name: format!("depth-{d}"),
+        downstreams,
+    }
+}
+
+fn fanout(b: usize) -> Topology {
+    // 0 -> {1, 2, ..., b}. Entry fans to b leaves.
+    let mut downstreams = vec![vec![]; b + 1];
+    downstreams[0] = (1..=b).collect();
+    Topology {
+        name: format!("fanout-{b}"),
+        downstreams,
+    }
+}
+
+fn two_level_tree() -> Topology {
+    // A -> {B, C} -> {D, E}, {E, F}. E (index 4) has two parents (B and
+    // C) — the shared-node contention case.
+    //   0=A 1=B 2=C 3=D 4=E 5=F
+    Topology {
+        name: "tree-A-BC-DEEF".to_owned(),
+        downstreams: vec![
+            vec![1, 2], // A -> B, C
+            vec![3, 4], // B -> D, E
+            vec![4, 5], // C -> E, F
+            vec![],     // D
+            vec![],     // E
+            vec![],     // F
+        ],
+    }
+}
+
+fn topologies() -> Vec<Topology> {
+    let mut t = Vec::new();
+    for d in [1usize, 2, 4, 8] {
+        t.push(depth_chain(d));
+    }
+    for b in [2usize, 4, 8] {
+        t.push(fanout(b));
+    }
+    t.push(two_level_tree());
+    t
+}
+
+/// p50 / p90 / p99 / max over a sample set, plus the sample count. All
+/// values are nanoseconds.
+#[derive(Clone, Copy, Default)]
+struct Stats {
+    p50: u64,
+    p90: u64,
+    p99: u64,
+    max: u64,
+    n: usize,
+}
+
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+fn nearest_rank(sorted: &[u64], q: f64) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let idx = ((sorted.len() - 1) as f64 * q).round() as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+fn summarize(mut samples: Vec<u64>) -> Stats {
+    let n = samples.len();
+    if n == 0 {
+        return Stats::default();
+    }
+    samples.sort_unstable();
+    Stats {
+        p50: nearest_rank(&samples, 0.50),
+        p90: nearest_rank(&samples, 0.90),
+        p99: nearest_rank(&samples, 0.99),
+        max: samples[n - 1],
+        n,
+    }
+}
+
+/// Raw per-condition sample buckets accumulated across every measured
+/// tree, summarized into [`Stats`] at the end.
+#[derive(Default)]
+struct Samples {
+    hop: Vec<u64>,
+    handler: Vec<u64>,
+    e2e: Vec<u64>,
+}
+
+impl Samples {
+    /// Fold one settled trace tree into the buckets: a hop sample per
+    /// node (`t_received - t_sent`), a handler sample per node
+    /// (`t_finished - t_received`), and one end-to-end sample for the
+    /// tree (last finish minus the root's send).
+    fn ingest(&mut self, mails: &[MailNodeWire]) {
+        let mut tree_start: Option<u64> = None;
+        let mut tree_end: Option<u64> = None;
+        for node in mails {
+            let sent = node.t_sent.0;
+            if node.parent.is_none() {
+                tree_start = Some(sent);
+            }
+            if let Some(recv) = node.t_received {
+                self.hop.push(recv.0.saturating_sub(sent));
+                if let Some(fin) = node.t_finished {
+                    self.handler.push(fin.0.saturating_sub(recv.0));
+                }
+            }
+            if let Some(fin) = node.t_finished {
+                tree_end = Some(tree_end.map_or(fin.0, |e: u64| e.max(fin.0)));
+            }
+        }
+        if let (Some(start), Some(end)) = (tree_start, tree_end) {
+            self.e2e.push(end.saturating_sub(start));
+        }
+    }
+}
+
+/// One fully-measured cell of the sweep.
+struct Row {
+    workers: usize,
+    topo: String,
+    cond: &'static str,
+    hop: Stats,
+    handler: Stats,
+    e2e: Stats,
+}
+
+/// Query the trace observer for one root's whole tree over the mail
+/// wire. Returns the node list, or `None` if the observer no longer has
+/// the root (only happens if the ring lapped it — not expected at these
+/// volumes).
+fn describe_tree(tb: &mut TestBench, root: MailId) -> Option<Vec<MailNodeWire>> {
+    let req = DescribeTree { root }.encode_into_bytes();
+    let reply = tb
+        .send_bytes_and_await(TRACE_OBSERVER_MAILBOX_NAME, DescribeTree::ID, req)
+        .ok()?;
+    match DescribeTreeResult::decode_from_bytes(&reply)? {
+        DescribeTreeResult::Ok { mails, .. } => Some(mails),
+        DescribeTreeResult::Err { .. } => None,
+    }
+}
+
+const SETTLE_TIMEOUT: Duration = Duration::from_secs(10);
+const IDLE_SAMPLES: u32 = 120;
+const LOAD_ROOTS: u32 = 200;
+
+/// Sweep worker-pool size × topology × {idle, under-load} and print the
+/// mail-latency percentile tables.
+///
+/// `#[ignore]` — a measurement run, not a correctness gate. Skips
+/// cleanly when no wgpu adapter is available ([`TestBench`] needs an
+/// offscreen render target to boot).
+#[test]
+#[ignore = "measurement harness — run on demand with --ignored --nocapture --release"]
+#[allow(
+    clippy::print_stdout,
+    clippy::print_stderr,
+    clippy::cast_precision_loss
+)]
+fn mail_latency_sweep() {
+    let max_workers = available_parallelism().map_or(2, |n| n.get().saturating_sub(1).max(1));
+    let worker_set: BTreeSet<usize> = [1usize, 2, 4, max_workers].into_iter().collect();
+
+    // Probe once so a driverless box prints a skip line instead of a
+    // confusing per-cell failure storm.
+    if let Err(e) = TestBench::builder().size(16, 16).build() {
+        eprintln!(
+            "skipping mail_latency_sweep: TestBench boot failed (likely no wgpu adapter): {e}"
+        );
+        return;
+    }
+
+    let mut rows: Vec<Row> = Vec::new();
+
+    for &workers in &worker_set {
+        for topo in topologies() {
+            let Ok(mut tb) = TestBench::builder()
+                .with_workers(Some(workers))
+                .size(16, 16)
+                .build()
+            else {
+                eprintln!("skipping {} @ {workers}w: boot failed", topo.name);
+                continue;
+            };
+
+            // Spawn every relay with its precomputed downstream ids.
+            // Ids are deterministic, so spawn order is irrelevant.
+            let n = topo.downstreams.len();
+            let mut spawned_ok = true;
+            for i in 0..n {
+                let downs: Arc<[MailboxId]> =
+                    topo.downstreams[i].iter().map(|&j| relay_id(j)).collect();
+                let sub = i.to_string();
+                if let Err(e) = tb
+                    .spawn_actor::<Relay>(Subname::Named(&sub), downs)
+                    .finish()
+                {
+                    eprintln!("spawn failed for {} relay {i}: {e:?}", topo.name);
+                    spawned_ok = false;
+                    break;
+                }
+            }
+            if !spawned_ok {
+                continue;
+            }
+            let entry = relay_id(0);
+
+            // idle: one root in flight at a time, for clean per-hop cost.
+            let mut idle = Samples::default();
+            for seq in 0..IDLE_SAMPLES {
+                let (root, rx) = tb.inject_root(entry, Ping::ID, Ping { seq }.encode_into_bytes());
+                if rx.recv_timeout(SETTLE_TIMEOUT).is_err() {
+                    eprintln!("idle settle timeout: {} @ {workers}w", topo.name);
+                    break;
+                }
+                if let Some(mails) = describe_tree(&mut tb, root) {
+                    idle.ingest(&mails);
+                }
+            }
+            rows.push(Row {
+                workers,
+                topo: topo.name.clone(),
+                cond: "idle",
+                hop: summarize(idle.hop),
+                handler: summarize(idle.handler),
+                e2e: summarize(idle.e2e),
+            });
+
+            // load: many concurrent roots, to surface inbox queueing.
+            let mut pending = Vec::with_capacity(LOAD_ROOTS as usize);
+            for seq in 0..LOAD_ROOTS {
+                pending.push(tb.inject_root(entry, Ping::ID, Ping { seq }.encode_into_bytes()));
+            }
+            let mut all_settled = true;
+            for (_, rx) in &pending {
+                if rx.recv_timeout(SETTLE_TIMEOUT).is_err() {
+                    all_settled = false;
+                    break;
+                }
+            }
+            let mut load = Samples::default();
+            if all_settled {
+                for (root, _) in &pending {
+                    if let Some(mails) = describe_tree(&mut tb, *root) {
+                        load.ingest(&mails);
+                    }
+                }
+            } else {
+                eprintln!("load settle timeout: {} @ {workers}w", topo.name);
+            }
+            rows.push(Row {
+                workers,
+                topo: topo.name.clone(),
+                cond: "load",
+                hop: summarize(load.hop),
+                handler: summarize(load.handler),
+                e2e: summarize(load.e2e),
+            });
+        }
+    }
+
+    print_tables(&rows);
+}
+
+#[allow(clippy::print_stdout, clippy::cast_precision_loss)]
+fn print_tables(rows: &[Row]) {
+    let us = |ns: u64| -> String { format!("{:.2}", ns as f64 / 1000.0) };
+
+    println!();
+    println!("=== mail latency sweep (all values µs; n = sample count) ===");
+    println!("idle = one root in flight; load = {LOAD_ROOTS} concurrent roots");
+    println!();
+
+    for (label, pick) in [
+        (
+            "HOP LATENCY  (t_received - t_sent: enqueue + worker pickup)",
+            0usize,
+        ),
+        (
+            "HANDLER DUR  (t_finished - t_received: relay forward work)",
+            1,
+        ),
+        ("END-TO-END   (last finish - root send)", 2),
+    ] {
+        println!("-- {label} --");
+        println!(
+            "{:>3}w  {:<16} {:<5} {:>9} {:>9} {:>9} {:>9} {:>7}",
+            "", "topology", "cond", "p50", "p90", "p99", "max", "n"
+        );
+        for r in rows {
+            let s = match pick {
+                0 => r.hop,
+                1 => r.handler,
+                _ => r.e2e,
+            };
+            println!(
+                "{:>3}   {:<16} {:<5} {:>9} {:>9} {:>9} {:>9} {:>7}",
+                r.workers,
+                r.topo,
+                r.cond,
+                us(s.p50),
+                us(s.p90),
+                us(s.p99),
+                us(s.max),
+                s.n
+            );
+        }
+        println!();
+    }
+}

--- a/crates/aether-substrate-bundle/src/test_bench/mod.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mod.rs
@@ -18,6 +18,8 @@ pub mod cap;
 pub mod chassis;
 pub mod events;
 mod execute;
+#[cfg(test)]
+mod mail_latency;
 pub mod render;
 pub mod test_helpers;
 pub mod visual;


### PR DESCRIPTION
## Summary

An `#[ignore]`d measurement harness (`test_bench::mail_latency`) for inter-actor mail latency. It wires synthetic relay actors into controlled topologies, injects traced root mails, reads each causal tree back over the `aether.trace` surface (ADR-0080 already stamps `t_sent` / `t_received` / `t_finished` from one monotonic clock), and reports **hop latency**, **handler duration**, and **end-to-end** as p50/p90/p99/max per cell.

- **Topologies**: depth chains (1/2/4/8), fan-out trees (2/4/8), and the two-level shared-node tree `A -> {B,C} -> {D,E},{E,F}` (E has two parents).
- **Conditions**: idle (one root in flight — clean per-hop cost) and under-load (200 concurrent roots — inbox queueing).
- **Worker sweep**: pooled dispatch (issue 635) makes worker-pool size the dominant variable, so it is the outer axis — `{1, 2, 4, available_parallelism()-1}` via a new `TestBenchBuilder::with_workers` knob.

Run on demand (zero CI cost):

    cargo test -p aether-substrate-bundle --release mail_latency_sweep -- --ignored --nocapture

## What the numbers say (release, 12-core dev box)

Worker count is not a free dial — the pool has a sweet spot:

- **Serial chains prefer a small pool.** `depth-8 idle` end-to-end p50 grows with workers: 33 / 36 / 61 / 94 us at 1/2/4/11w. One root migrates across cold workers on a big pool; a small pool keeps it on a warm core.
- **Load saturates ~4 workers, then regresses.** `depth-8 load` e2e p50: 768 / 560 / 252 / 526 us. `fanout-8 load` is monotonically worse past 2w: 512 / 376 / 925 / 1463 us — pointing at ready-queue / slot-CAS contention as the next scheduler target.
- **Handler work is negligible** (p50 0.04–5 us everywhere): latency lives in the hop (enqueue + worker pickup), not the work. Internal consistency check: `depth-8 idle` hop p50 = 1.4 us but p90 = 18 us — exactly the single cold chassis→entry hop (1 of 8) surfacing at the 87th percentile.

Numbers are a snapshot, not a gate; p50 is the stable signal, tails are noisy run-to-run.

## What changed

- `test_bench/mail_latency.rs` — the harness: relay actor + derived `Ping` kind, topology builder, percentile math, table printer.
- `TestBenchBuilder::with_workers(Option<usize>)` + `TestBenchEnv::pool_workers`, threaded to the chassis `Builder::with_workers`. `None` keeps `PoolConfig::default`, so every existing bench is unchanged; the legacy `EngineInfo.workers` field is untouched.
- `TestBench::inject_root` (cfg(test)) — push a chassis-root mail and return its settlement `Receiver`, so the harness injects many roots concurrently and waits afterward (race-safe: `subscribe_settlement` pre-fires on already-settled roots).
- `crossbeam-channel` dev-dep, to name that `Receiver`.

## Scope

This lands the on-demand measurement-test stage of the standing homeostasis harness (iamacoffeepot/aether#1057). The sustained-workload / memory-and-settlement-siblings / cross-version-comparison evolution is the follow-on — left open intentionally, no closing keyword.

## Test plan

- [x] `scripts/preflight.sh` green (fmt + clippy + doc + nextest 1191 passed/5 skipped + wasm32 cross-build)
- [x] `mcp__rustrover__get_file_problems` clean on every changed file (the `Ping` codec DuplicatedCode finding was fixed by deriving `Kind`, not baselined)
- [x] Harness runs green in debug + release; trees populate, no settle timeouts, no spawn failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)