### PR TITLE
chore(repo): nextest --stress-count flake-soak gate for concurrent tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,3 +5,13 @@ final-status-level = "slow"
 # Don't fail fast in CI to run the full test suite.
 fail-fast = false
 slow-timeout = { period = "60s", terminate-after = 1 }
+
+# Repeat-run ("soak") flake detection for concurrent tests, driven by
+# `scripts/flake-soak.sh` with nextest `--stress-count`. Each repeat is a
+# fresh process. `fail-fast = false` so one flaky test doesn't hide the
+# rest of the marked set. Profiles don't inherit, so the timeout is
+# repeated here to bound a hung run at high counts.
+[profile.flake-soak]
+fail-fast = false
+final-status-level = "fail"
+slow-timeout = { period = "60s", terminate-after = 1 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,3 +137,9 @@ Qodana gates merges via the `ci-pass` aggregator (iamacoffeepot/aether#941), but
 - **Agent-side** (Claude): `mcp__rustrover__get_file_problems` returns the same problem set for one file (`errorsOnly: false` for the full qodana-equivalent surface). Iterate it over `git diff --name-only` before commits on Qodana-touched files (path-prefix sweeps, duplicated-code refactors, etc.) instead of waiting for the CI gate. RustRover MCP has no project-wide inspect runner — for whole-project pre-flight fall back to the IDE menu above.
 
 Caveats: IDE inspections don't run Qodana's Cargo.toml-level checks (`NewCrateVersionAvailable`, `UnusedDependency`) — those still surface only in CI. Re-baselining (`qodana.sarif.json` updates) still happens by downloading the `qodana-report` workflow artifact from a CI run.
+
+## Flake soak (pre-release)
+
+Concurrent / scheduler / mail-dispatch tests are timing-flaky — they pass on a lucky run and fail intermittently, so a single green CI pass does not clear one. Mark such a test by adding a thin **duplicate wrapper** next to it — keep the original, add `#[test] fn flaky_<name>() { <name>(); }`. `nextest` selects tests by name/path (not by a Rust attribute), so a `flaky_`-named duplicate is the simplest marker — no macro, no rename of the original.
+
+Before a release, soak the marked set with `scripts/flake-soak.sh [count]` (default 200). It runs `cargo nextest run --profile flake-soak --stress-count <count> -E 'test(/flaky/)'` — each `flaky_` duplicate runs `count` times, **each in a fresh process** (the isolation that reproduces timing flakes), failing if any iteration fails. The original runs once in normal CI; the per-PR pre-flight (`profile.ci`) doesn't stress, so the duplicate adds one extra run per PR and nothing more. Override the selector with `AETHER_FLAKE_FILTER`.

--- a/crates/aether-capabilities/src/dag/tests.rs
+++ b/crates/aether-capabilities/src/dag/tests.rs
@@ -1158,6 +1158,18 @@ fn transform_skips_invoke_on_cache_hit() {
     drop(chassis);
 }
 
+/// Flake-soak wrapper (iamacoffeepot/aether#1060). Re-runs
+/// [`transform_skips_invoke_on_cache_hit`] under a `flaky_` name so the
+/// `scripts/flake-soak.sh` filterset (`test(/flaky/)`) repeat-runs it
+/// before a release — it asserts on async observer recording, the race
+/// the trace ring-buffer change (iamacoffeepot/aether#1056) exposed
+/// here. The original still runs once in normal CI; this duplicate is
+/// the soak target.
+#[test]
+fn flaky_transform_skips_invoke_on_cache_hit() {
+    transform_skips_invoke_on_cache_hit();
+}
+
 /// A transform that blocks briefly does not stall the executor's
 /// parking / reaping of other DAG branches: a sibling DAG's pure
 /// `double` resolves while the `slow` transform spins (ADR-0048 §3 off

--- a/scripts/flake-soak.sh
+++ b/scripts/flake-soak.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Repeat-run ("soak") the flake-marked concurrent tests to surface timing
+# flakes before a release. Concurrent programming is hard and timing flakes
+# pass on a lucky run, so a single green CI pass does not clear a concurrent
+# test (iamacoffeepot/aether#1060).
+#
+# Marking is by name, because nextest selects on test name/path, not on a
+# Rust attribute: a flake-prone test carries a `flaky_` name prefix (or lives
+# in a `mod flaky`, whose path shows in the test name). nextest's
+# `--stress-count` then runs each selected test N times, each in a fresh
+# process — the process isolation that matters for timing flakes.
+#
+# Usage:
+#   scripts/flake-soak.sh [count]     # default 200
+#   AETHER_FLAKE_FILTER='test(/flaky/)' scripts/flake-soak.sh 1000
+#
+# Exits non-zero if any iteration of any marked test fails.
+set -euo pipefail
+
+count="${1:-200}"
+filter="${AETHER_FLAKE_FILTER:-test(/flaky/)}"
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "[flake-soak] soaking '${filter}' ×${count} (fresh process per run)…"
+exec cargo nextest run \
+    --workspace --all-features \
+    --profile flake-soak \
+    --stress-count "${count}" \
+    -E "${filter}"


### PR DESCRIPTION
## Summary

Concurrent / scheduler / mail-dispatch tests are timing-flaky — they pass on a lucky run and fail intermittently, so a single green CI pass doesn't clear one. This adds a pre-release **soak** built on nextest's native repeat, plus a zero-infrastructure way to mark which tests to soak.

- **Repeat: nextest `--stress-count`** (no custom macro or crate). cargo-nextest 0.9.133 runs each selected test N times, each in a **fresh process** — the isolation that reproduces timing flakes. `--stress-duration <24h>` is also available for time-boxed soaks.
- **Mark: a thin duplicate wrapper.** nextest selects by test name/path, not by a Rust attribute, so the simplest marker is a sibling `#[test] fn flaky_<name>() { <name>(); }`. The original keeps its name and runs once in normal CI; the `flaky_` duplicate is the soak target.
- `[profile.flake-soak]` in `.config/nextest.toml` (`fail-fast = false` so one flaky test doesn't hide the rest of the set).
- `scripts/flake-soak.sh [count]` (default 200) → `cargo nextest run --profile flake-soak --stress-count <count> -E 'test(/flaky/)'`.
- **Worked example:** the dag cache-hit race (asserts on async observer recording — the race the trace ring-buffer change exposed) gets a `flaky_` duplicate. Soaks clean at 200×.
- CLAUDE.md documents the convention.

Lands ahead of the pool-latency rework (iamacoffeepot/aether#1059), which will breed exactly these flakes, so that work ships with soak coverage.

## Test plan

- [x] `scripts/flake-soak.sh 200` → 200/200 pass, fresh process per run, selecting only `dag::tests::flaky_transform_skips_invoke_on_cache_hit`
- [x] `scripts/preflight.sh` green (fmt + clippy + doc + nextest 1192 passed/5 skipped + wasm32 cross-build)
- [x] Per-PR pre-flight (`profile.ci`) unchanged — no stress, so the duplicate adds one extra run per PR and nothing more

Closes iamacoffeepot/aether#1060.

🤖 Generated with [Claude Code](https://claude.com/claude-code)