### PR TITLE
perf(substrate/scheduler): worker-local next-slot keeps chains on a warm worker

### DIFF
--- a/crates/aether-substrate/src/scheduler/local_slot.rs
+++ b/crates/aether-substrate/src/scheduler/local_slot.rs
@@ -1,0 +1,56 @@
+//! Per-worker "next slot" cell for chain affinity (iamacoffeepot/aether#1059).
+//!
+//! When a handler running on a pool worker wakes a downstream actor's
+//! slot, the wake stashes it here instead of the shared ready queue, and
+//! the worker's `acquire_slot` checks here first. A relay chain therefore
+//! stays on one warm worker — no shared-queue round-trip and, crucially,
+//! no parked-sibling futex wake (~4.3µs). The cell holds at most one slot,
+//! so a fan-out spills its extras to the shared queue and stays parallel
+//! across workers.
+//!
+//! Only pool-worker threads call [`mark_pool_worker`]; on any other thread
+//! (chassis main, the hub, the trace drainer) [`try_stash_next`] is a
+//! no-op and the wake falls through to the shared queue as before.
+
+use std::cell::{Cell, RefCell};
+use std::sync::Arc;
+
+use crate::scheduler::slot::Drainable;
+
+thread_local! {
+    static IS_POOL_WORKER: Cell<bool> = const { Cell::new(false) };
+    static NEXT_SLOT: RefCell<Option<Arc<dyn Drainable>>> = const { RefCell::new(None) };
+}
+
+/// Mark the current thread as a pool worker. Called once at the top of
+/// each worker's loop; enables local stashing on this thread.
+pub fn mark_pool_worker() {
+    IS_POOL_WORKER.with(|w| w.set(true));
+}
+
+/// Try to stash a just-woken slot for this worker to drain next. Returns
+/// `Ok(())` when stashed (the caller skips the shared queue), or
+/// `Err(slot)` to hand the slot back for the shared queue — either because
+/// this isn't a pool-worker thread, or the cell is already occupied (the
+/// fan-out spill path that keeps independent work parallel).
+pub fn try_stash_next(slot: Arc<dyn Drainable>) -> Result<(), Arc<dyn Drainable>> {
+    if !IS_POOL_WORKER.with(Cell::get) {
+        return Err(slot);
+    }
+    NEXT_SLOT.with(|cell| {
+        let mut cell = cell.borrow_mut();
+        if cell.is_none() {
+            *cell = Some(slot);
+            Ok(())
+        } else {
+            Err(slot)
+        }
+    })
+}
+
+/// Take this worker's stashed next slot, if any. Checked before the shared
+/// queue and before the shutdown park, so a stashed slot is never
+/// stranded across a worker's loop iteration.
+pub fn take_next() -> Option<Arc<dyn Drainable>> {
+    NEXT_SLOT.with(|cell| cell.borrow_mut().take())
+}

--- a/crates/aether-substrate/src/scheduler/mod.rs
+++ b/crates/aether-substrate/src/scheduler/mod.rs
@@ -33,6 +33,7 @@
 //! actually run on the pool. Phase 2 flips one cap to `Pooled`; Phase
 //! 3 sweeps the rest. Until PR C the pool is unused infrastructure.
 
+mod local_slot;
 mod pool;
 mod slot;
 

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -9,7 +9,7 @@
 //!
 //! ```text
 //! loop {
-//!     slot = ready_rx.recv()?;            // blocks
+//!     slot = acquire_slot()?;             // try_recv → spin → park
 //!     match catch_unwind(|| slot.run_cycle()) {
 //!         Ok(Idle | Closed) => drop(slot),
 //!         Ok(Requeue)       => ready_tx.send(slot)?,
@@ -32,6 +32,8 @@ use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
 use crossbeam_channel::{Receiver, Sender, bounded, select, unbounded};
+
+use crate::scheduler::local_slot;
 
 use crate::runtime::lifecycle::FatalAborter;
 use crate::scheduler::slot::{BatchBudget, CycleResult, Drainable};
@@ -228,22 +230,15 @@ fn worker_loop(
     aborter: Arc<dyn FatalAborter>,
     template: BudgetTemplate,
 ) {
+    // Mark this thread as a pool worker so a handler's wake of a
+    // downstream slot can stash it in this worker's local cell (affinity)
+    // rather than the shared queue. iamacoffeepot/aether#1059.
+    local_slot::mark_pool_worker();
     loop {
-        let slot = select! {
-            recv(ready_rx) -> result => match result {
-                Ok(s) => s,
-                // All sender clones are gone (including our own — the
-                // pool's shutdown both drops `ready_tx` and disconnects
-                // `shutdown_rx`, but in either order the channel only
-                // disconnects once every clone drops). Exit either way.
-                Err(_) => return,
-            },
-            recv(shutdown_rx) -> _ => {
-                // Pool dropped `shutdown_tx`. Disconnect on this arm
-                // is the unambiguous "stop now" signal — works even
-                // while we still hold our own `ready_tx` clone.
-                return;
-            }
+        let Some(slot) = acquire_slot(&ready_rx, &shutdown_rx) else {
+            // Shutdown signalled (or, impossibly, the ready queue
+            // disconnected while we hold a `ready_tx` clone). Exit.
+            return;
         };
         let budget = template.build();
         let result = panic::catch_unwind(AssertUnwindSafe(|| slot.run_cycle(budget)));
@@ -275,6 +270,39 @@ fn worker_loop(
                 aborter.abort(reason);
             }
         }
+    }
+}
+
+/// Acquire the next ready slot for a worker: worker-local hand-off first,
+/// then a `try_recv` fast path, then a blocking park. Returns `None` only
+/// on shutdown.
+///
+/// The worker-local cell (iamacoffeepot/aether#1059) is the affinity
+/// lever: when a handler running on this worker wakes a downstream slot,
+/// that slot is stashed here instead of the shared queue, so a relay
+/// chain stays on the same warm worker and never pays the ~4.3µs
+/// parked-worker wakeup. The cell holds at most one slot — a fan-out
+/// spills its extras to the shared queue, so independent work still
+/// parallelises across workers. `take_next` is checked first (even
+/// before shutdown) so a stashed slot is never stranded.
+///
+/// `ready_rx` cannot disconnect while the caller holds its own `ready_tx`
+/// clone, so `try_recv` here is only ever `Ok` or `Empty`; shutdown is
+/// signalled solely through `shutdown_rx`, and the park's `select!` arm
+/// on it stays the one clean stop signal (issue 635 deadlock class).
+fn acquire_slot(
+    ready_rx: &Receiver<Arc<dyn Drainable>>,
+    shutdown_rx: &Receiver<()>,
+) -> Option<Arc<dyn Drainable>> {
+    if let Some(slot) = local_slot::take_next() {
+        return Some(slot);
+    }
+    if let Ok(slot) = ready_rx.try_recv() {
+        return Some(slot);
+    }
+    select! {
+        recv(ready_rx) -> result => result.ok(),
+        recv(shutdown_rx) -> _ => None,
     }
 }
 
@@ -521,6 +549,64 @@ mod tests {
         }
 
         drop(wakes);
+        let _ = handle.shutdown_with_results();
+    }
+
+    /// Flake-soak wrapper (iamacoffeepot/aether#1059). Re-runs the
+    /// multi-worker stress under a `flaky_` name so `scripts/flake-soak.sh`
+    /// repeat-runs the rewritten `acquire_slot` dispatch path. The original
+    /// still runs once in normal CI; this duplicate is the soak target.
+    #[test]
+    fn flaky_stress_many_slots_across_workers() {
+        stress_many_slots_across_workers();
+    }
+
+    /// Build a depth-`d` relay chain of `CounterSlot`s: slot[i] forwards
+    /// each dispatched env to slot[i+1] and wakes it. The forwarding wake
+    /// runs on a pool worker, so the chain drives the worker-local stash
+    /// path that `acquire_slot` reads first (iamacoffeepot/aether#1059).
+    fn relay_chain(handle: &PoolHandle, depth: usize) -> Vec<Arc<CounterSlot>> {
+        let slots: Vec<Arc<CounterSlot>> = (0..depth).map(|_| CounterSlot::new("relay")).collect();
+        for i in 0..depth.saturating_sub(1) {
+            let target = slots[i + 1].clone();
+            let target_dyn: Arc<dyn Drainable> = target.clone();
+            let weak: Weak<dyn Drainable> = Arc::downgrade(&target_dyn);
+            drop(target_dyn);
+            let wake = WakeHandle::new(target.state.clone(), weak, handle.ready_tx());
+            *slots[i].forward.lock().unwrap() = Some((target, wake));
+        }
+        slots
+    }
+
+    /// Flake-soak (iamacoffeepot/aether#1059): a relay chain on a
+    /// multi-worker pool. Each hop's wake stashes the downstream in the
+    /// running worker's local cell, so the chain stays on one warm worker
+    /// instead of bouncing across parked siblings. Soaked because the
+    /// stash path is concurrency-sensitive (worker thread-local + the
+    /// `Idle → Ready` CAS) and fires only on real worker threads — which
+    /// the other slot tests, driven from the test thread, never hit.
+    #[test]
+    fn flaky_relay_chain_stays_on_worker() {
+        let handle = standard_handle(4);
+        let slots = relay_chain(&handle, 8);
+
+        let entry = slots[0].clone();
+        let entry_dyn: Arc<dyn Drainable> = entry.clone();
+        let weak: Weak<dyn Drainable> = Arc::downgrade(&entry_dyn);
+        drop(entry_dyn);
+        let entry_wake = WakeHandle::new(entry.state.clone(), weak, handle.ready_tx());
+
+        entry.push(1);
+        assert!(entry_wake.wake());
+
+        assert!(
+            wait_until(Duration::from_secs(5), || slots
+                .iter()
+                .all(|s| s.dispatched() >= 1)),
+            "every slot in the relay chain should dispatch its forwarded env"
+        );
+
+        drop(entry_wake);
         let _ = handle.shutdown_with_results();
     }
 

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -35,6 +35,8 @@ use std::time::{Duration, Instant};
 
 use crossbeam_channel::Sender;
 
+use super::local_slot;
+
 /// Default per-cycle envelope cap. Once a worker has dispatched this
 /// many envelopes from a single slot, it yields to other ready slots
 /// to keep one chatty actor from monopolising the pool. Tunable in
@@ -328,9 +330,14 @@ impl WakeHandle {
             // gone the state never matters.
             return false;
         };
-        // Ready queue closed = pool is shutting down; treat as a no-op
-        // rather than panicking.
-        let _ = self.ready_tx.send(slot);
+        // Affinity (iamacoffeepot/aether#1059): if this wake runs on a
+        // pool worker, stash the slot in that worker's local cell so the
+        // chain stays warm. Otherwise (or if the cell is full — fan-out
+        // spill) fall through to the shared ready queue. A closed ready
+        // queue means the pool is shutting down; treat as a no-op.
+        if let Err(slot) = local_slot::try_stash_next(slot) {
+            let _ = self.ready_tx.send(slot);
+        }
         true
     }
 
@@ -373,6 +380,11 @@ pub mod tests {
         /// Per-envelope work duration. Used by the time-budget test.
         pub work_per_env: Duration,
         pub label: &'static str,
+        /// Optional downstream relay: on each dispatch, forward the env to
+        /// this slot's inbox and wake it. The wake runs on the pool
+        /// worker, so a chain of these exercises the worker-local stash
+        /// path (iamacoffeepot/aether#1059).
+        pub forward: Mutex<Option<(Arc<Self>, WakeHandle)>>,
     }
 
     impl CounterSlot {
@@ -385,6 +397,7 @@ pub mod tests {
                 panic_at: None,
                 work_per_env: Duration::ZERO,
                 label,
+                forward: Mutex::new(None),
             })
         }
 
@@ -424,6 +437,13 @@ pub mod tests {
             hint::black_box(env);
             if !self.work_per_env.is_zero() {
                 thread::sleep(self.work_per_env);
+            }
+            // Relay: forward to the downstream slot and wake it. On a pool
+            // worker this wake stashes the downstream in the worker-local
+            // cell (the path under test).
+            if let Some((down, wake)) = &*self.forward.lock().unwrap() {
+                down.push(env);
+                let _ = wake.wake();
             }
         }
     }


### PR DESCRIPTION
## Summary

A relay chain bouncing across pool workers paid a **~4.3µs parked-worker wakeup per hop** — the dominant mail-hop cost (per-op microbench; channels/CAS/trace are tens of ns by comparison). That's what made the warm hop climb from 1.4µs at 1 worker to 6µs at 11.

This adds a per-worker **"next slot" cell**: when a handler running on a pool worker wakes a downstream slot, it stashes it in a thread-local that `acquire_slot` reads *before* the shared ready queue. So a chain stays on the same warm worker and never pays the wakeup. The cell holds **one** slot, so a fan-out spills its extras to the shared queue and independent work stays parallel. On non-worker threads (chassis, hub, drainer) it's a no-op — the wake falls through to the shared queue as before.

## Result (release, the iamacoffeepot/aether#1058 harness)

`depth-8 idle`, warm hop p50:

| workers | before | after |
|--|--|--|
| 1 | 1.42µs | 1.29µs |
| 4 | 3.58µs | 1.50µs |
| 11 | **6.08µs** | **1.38µs** |

Flat at ~1.3µs across worker counts instead of climbing to 6µs — **4.4× at 11 workers**; end-to-end 94µs→34µs. Fan-out and high-concurrency load are unchanged (the cell keeps one child warm; the rest spill — separate levers).

## What changed
- `scheduler/local_slot.rs` — the thread-local cell (`mark_pool_worker` / `try_stash_next` / `take_next`).
- `acquire_slot` checks the local cell, then the shared queue, then parks. (An earlier Backoff spin-before-park was tried and dropped — net-negative under load.)
- `WakeHandle::wake` stashes locally when on a worker, else sends to the shared queue.
- The `CounterSlot` test fixture grows an optional forward target; `flaky_relay_chain_stays_on_worker` soaks the stash path, which the test-thread-driven slot tests don't exercise.

## Test plan
- [x] `scripts/flake-soak.sh 600` → 600/600 (incl. the new relay-chain stash-path test + the pool stress)
- [x] `scripts/preflight.sh` green (fmt + clippy + doc + nextest 1194 passed/5 skipped + wasm32 cross-build)
- [x] 14 scheduler tests pass; shutdown intact (the local cell is drained before the park)

Toward iamacoffeepot/aether#1059 — one affinity increment; the broader question (heavy work-stealing/phased redesign vs more incremental wins) stays open on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)