### PR TITLE
perf(substrate/trace): shard trace queue by root to cut contention

### DIFF
--- a/crates/aether-capabilities/src/contentgen/dispatch.rs
+++ b/crates/aether-capabilities/src/contentgen/dispatch.rs
@@ -297,7 +297,7 @@ mod tests {
         // hold/release pairing is cumulative across the whole submit ->
         // reply lifecycle, not a one-shot read.
         for ev in scratch {
-            queue.push(ev);
+            queue.restore(ev);
         }
         net
     }

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -32,7 +32,7 @@
 use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::thread::available_parallelism;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use aether_data::{Kind, KindId, MailId, MailboxId, mailbox_id_from_name};
 use aether_kinds::trace::{
@@ -112,6 +112,53 @@ impl NativeDispatch for Relay {
 }
 
 const RELAY_NS: &str = "mlat.relay";
+
+/// Self-sustaining ring actor for the multi-worker saturation profile.
+/// On each `Ping{seq}` it forwards `Ping{seq-1}` to its single `next`
+/// neighbour while `seq > 0`. Seeded with M tokens circulating a ring of
+/// N actors, the pool stays saturated with cross-actor hand-offs and no
+/// injector involvement after seeding — so a profile attributes the
+/// multi-worker load tail (shared-queue contention vs actor
+/// serialization vs settlement).
+struct RingRelay {
+    next: MailboxId,
+}
+
+impl aether_actor::Actor for RingRelay {
+    const NAMESPACE: &'static str = "mlat.ring";
+}
+impl aether_actor::Instanced for RingRelay {}
+impl aether_actor::HandlesKind<Ping> for RingRelay {}
+impl NativeActor for RingRelay {
+    type Config = MailboxId;
+    fn init(next: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        Ok(Self { next })
+    }
+}
+impl NativeDispatch for RingRelay {
+    fn __aether_dispatch_envelope(
+        &mut self,
+        ctx: &mut NativeCtx<'_>,
+        kind: KindId,
+        payload: &[u8],
+    ) -> Option<()> {
+        if kind.0 != Ping::ID.0 {
+            return None;
+        }
+        let ping = Ping::decode_from_bytes(payload)?;
+        if ping.seq > 0 {
+            let bytes = Ping { seq: ping.seq - 1 }.encode_into_bytes();
+            let _ = ctx.send_envelope_traced(self.next, Ping::ID, &bytes);
+        }
+        Some(())
+    }
+}
+
+const RING_NS: &str = "mlat.ring";
+
+fn ring_id(i: usize) -> MailboxId {
+    MailboxId(mailbox_id_from_name(&format!("{RING_NS}:{i}")).0)
+}
 
 /// Deterministic `MailboxId` for relay instance `i`. Mirrors the
 /// substrate's `mailbox_id_from_name("{NAMESPACE}:{subname}")` so the
@@ -450,4 +497,145 @@ fn print_tables(rows: &[Row]) {
         }
         println!();
     }
+}
+
+/// Multi-worker saturation profile target (samply). Boots the pool at
+/// max workers, wires a ring of N `RingRelay` actors, seeds M circulating
+/// tokens, and sleeps `PROFILE_SECS` while the workers churn at
+/// saturation. The tokens self-sustain (each hop re-sends to the next
+/// neighbour with a decremented counter), so all workers stay fed
+/// without the injector bottleneck that starved the single-worker
+/// `mail_hop_profile`. Profile and classify the `aether-worker-N`
+/// threads to attribute the load tail: shared-queue contention
+/// (crossbeam recv/send + CAS + Arc churn — work-stealing-addressable)
+/// vs actor-serialization mutex wait vs settlement/trace.
+///
+/// ```text
+/// cargo test -p aether-substrate-bundle --release mail_saturation_profile --no-run
+/// samply record --rate 4000 --unstable-presymbolicate --save-only -o /tmp/sat.json.gz -- \
+///     <bin> mail_saturation_profile --ignored --nocapture --test-threads=1
+/// ```
+#[test]
+#[ignore = "profiling target — run under samply, not a correctness gate"]
+#[allow(clippy::print_stderr)]
+fn mail_saturation_profile() {
+    let workers = available_parallelism().map_or(2, |n| n.get().saturating_sub(1).max(1));
+    let Ok(tb) = TestBench::builder()
+        .with_workers(Some(workers))
+        .size(16, 16)
+        .build()
+    else {
+        eprintln!("skipping mail_saturation_profile: TestBench boot failed (no wgpu adapter)");
+        return;
+    };
+
+    // N actors in a cycle; actor i forwards to (i+1) % N.
+    let n = 64usize;
+    for i in 0..n {
+        let next = ring_id((i + 1) % n);
+        let sub = i.to_string();
+        tb.spawn_actor::<RingRelay>(Subname::Named(&sub), next)
+            .finish()
+            .expect("spawn ring relay");
+    }
+
+    // Seed M tokens with a high hop budget so they outlast the run; the
+    // tokens circulate without further injection. Spread across the ring
+    // so multiple actors are ready at once and every worker is fed.
+    let m: usize = std::env::var("TOKENS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(6000);
+    let ttl = 100_000_000u32;
+    for k in 0..m {
+        let entry = ring_id(k % n);
+        let _ = tb.inject_root(entry, Ping::ID, Ping { seq: ttl }.encode_into_bytes());
+    }
+
+    let secs: u64 = std::env::var("PROFILE_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(8);
+    let start = Instant::now();
+    std::thread::sleep(Duration::from_secs(secs));
+    eprintln!(
+        "mail_saturation_profile: {workers}w, ring n={n}, m={m} tokens, slept {:?}",
+        start.elapsed()
+    );
+}
+
+/// Regression guard for the per-root trace-queue sharding
+/// (iamacoffeepot/aether#1059): drive many concurrent roots through a
+/// multi-worker pool and assert every one *settles*.
+///
+/// The sharded trace queue keeps each root's events in one FIFO shard so
+/// ADR-0080's per-root `Sent`-before-`Finished` ordering holds. If that
+/// ordering broke, a root's `in_flight` accounting would never balance
+/// and its settlement signal would never fire — so "every injected root
+/// settles within the timeout" is the exactness check. Each surviving
+/// trace tree is also asserted complete (full depth chain), catching a
+/// settle that fired on a truncated chain. Runs on the pool at max
+/// workers so the shard fan-out is actually exercised.
+#[test]
+#[allow(clippy::print_stderr)]
+fn sharded_trace_settles_every_root() {
+    let workers = available_parallelism().map_or(2, |n| n.get().saturating_sub(1).max(1));
+    let Ok(mut tb) = TestBench::builder()
+        .with_workers(Some(workers))
+        .size(16, 16)
+        .build()
+    else {
+        eprintln!("skipping sharded_trace_settles_every_root: TestBench boot failed (no wgpu)");
+        return;
+    };
+
+    let depth = 5;
+    let topo = depth_chain(depth);
+    for i in 0..topo.downstreams.len() {
+        let downs: Arc<[MailboxId]> = topo.downstreams[i].iter().map(|&j| relay_id(j)).collect();
+        let sub = i.to_string();
+        tb.spawn_actor::<Relay>(Subname::Named(&sub), downs)
+            .finish()
+            .expect("spawn relay");
+    }
+    let entry = relay_id(0);
+
+    // 800 roots × depth 5 = 4000 mails — well under the trace ring
+    // capacity (1<<18), so nothing laps and every live root keeps its
+    // settlement state.
+    let roots = 800usize;
+    let mut pending = Vec::with_capacity(roots);
+    for seq in 0..roots {
+        pending.push(tb.inject_root(
+            entry,
+            Ping::ID,
+            Ping { seq: seq as u32 }.encode_into_bytes(),
+        ));
+    }
+
+    for (idx, (_root, rx)) in pending.iter().enumerate() {
+        assert!(
+            rx.recv_timeout(SETTLE_TIMEOUT).is_ok(),
+            "root {idx} never settled — per-root trace ordering may be broken (in_flight stuck)"
+        );
+    }
+
+    for (root, _) in &pending {
+        if let Some(mails) = describe_tree(&mut tb, *root) {
+            assert_eq!(
+                mails.len(),
+                depth,
+                "root {root:?} settled on a truncated tree ({} of {depth} hops)",
+                mails.len()
+            );
+        }
+    }
+}
+
+/// Flake-soak duplicate of [`sharded_trace_settles_every_root`] (the
+/// `flaky_` prefix is the soak selector; see CLAUDE.md "Flake soak").
+#[test]
+#[allow(clippy::print_stderr)]
+fn flaky_sharded_trace_settles_every_root() {
+    sharded_trace_settles_every_root();
 }

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -30,8 +30,9 @@
 //! wake, which a debug build inflates several-fold.
 
 use std::collections::BTreeSet;
+use std::env;
 use std::sync::Arc;
-use std::thread::available_parallelism;
+use std::thread::{self, available_parallelism};
 use std::time::{Duration, Instant};
 
 use aether_data::{Kind, KindId, MailId, MailboxId, mailbox_id_from_name};
@@ -542,7 +543,7 @@ fn mail_saturation_profile() {
     // Seed M tokens with a high hop budget so they outlast the run; the
     // tokens circulate without further injection. Spread across the ring
     // so multiple actors are ready at once and every worker is fed.
-    let m: usize = std::env::var("TOKENS")
+    let m: usize = env::var("TOKENS")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(6000);
@@ -552,12 +553,12 @@ fn mail_saturation_profile() {
         let _ = tb.inject_root(entry, Ping::ID, Ping { seq: ttl }.encode_into_bytes());
     }
 
-    let secs: u64 = std::env::var("PROFILE_SECS")
+    let secs: u64 = env::var("PROFILE_SECS")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(8);
     let start = Instant::now();
-    std::thread::sleep(Duration::from_secs(secs));
+    thread::sleep(Duration::from_secs(secs));
     eprintln!(
         "mail_saturation_profile: {workers}w, ring n={n}, m={m} tokens, slept {:?}",
         start.elapsed()
@@ -603,14 +604,10 @@ fn sharded_trace_settles_every_root() {
     // 800 roots × depth 5 = 4000 mails — well under the trace ring
     // capacity (1<<18), so nothing laps and every live root keeps its
     // settlement state.
-    let roots = 800usize;
-    let mut pending = Vec::with_capacity(roots);
+    let roots = 800u32;
+    let mut pending = Vec::with_capacity(roots as usize);
     for seq in 0..roots {
-        pending.push(tb.inject_root(
-            entry,
-            Ping::ID,
-            Ping { seq: seq as u32 }.encode_into_bytes(),
-        ));
+        pending.push(tb.inject_root(entry, Ping::ID, Ping { seq }.encode_into_bytes()));
     }
 
     for (idx, (_root, rx)) in pending.iter().enumerate() {

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -145,7 +145,7 @@ pub fn dispatch_loop_run<A>(
         let thread_name = thread::current().name().map(str::to_owned);
         binding
             .mailer()
-            .record_received(inbound_mail_id, thread_name);
+            .record_received(inbound_mail_id, env.root, thread_name);
         local::with_stamped(slots, || {
             let mut ctx = NativeCtx::new(binding, env.sender, env.mail_id, env.root);
             // ADR-0081: framework intercepts `aether.log.tail` before
@@ -156,7 +156,7 @@ pub fn dispatch_loop_run<A>(
                 typed_then_fallback_or_warn::<A>(actor, &mut ctx, &env);
             }
         });
-        binding.mailer().record_finished(inbound_mail_id);
+        binding.mailer().record_finished(inbound_mail_id, env.root);
         if let Some(p) = pending {
             p.fetch_sub(1, Ordering::AcqRel);
         }
@@ -172,14 +172,14 @@ pub fn dispatch_loop_run<A>(
         let thread_name = thread::current().name().map(str::to_owned);
         binding
             .mailer()
-            .record_received(inbound_mail_id, thread_name);
+            .record_received(inbound_mail_id, env.root, thread_name);
         local::with_stamped(slots, || {
             let mut ctx = NativeCtx::new(binding, env.sender, env.mail_id, env.root);
             if !dispatch_log_tail_if_matching(&mut ctx, &env) {
                 let _ = actor.__aether_dispatch_envelope(&mut ctx, env.kind, &env.payload);
             }
         });
-        binding.mailer().record_finished(inbound_mail_id);
+        binding.mailer().record_finished(inbound_mail_id, env.root);
         if let Some(p) = pending {
             p.fetch_sub(1, Ordering::AcqRel);
         }

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -214,7 +214,7 @@ where
         let thread_name = thread::current().name().map(str::to_owned);
         self.binding
             .mailer()
-            .record_received(inbound_mail_id, thread_name);
+            .record_received(inbound_mail_id, env.root, thread_name);
         local::with_stamped(&self.slots, || {
             let mut ctx = NativeCtx::new(&self.binding, env.sender, env.mail_id, env.root);
             // ADR-0081 framework-built-in dispatch arm for
@@ -223,7 +223,9 @@ where
                 super::dispatch::typed_then_fallback_or_warn::<A>(actor, &mut ctx, &env);
             }
         });
-        self.binding.mailer().record_finished(inbound_mail_id);
+        self.binding
+            .mailer()
+            .record_finished(inbound_mail_id, env.root);
         if let Some(p) = &self.pending {
             p.fetch_sub(1, Ordering::AcqRel);
         }

--- a/crates/aether-substrate/src/actor/native/spawn_thread.rs
+++ b/crates/aether-substrate/src/actor/native/spawn_thread.rs
@@ -671,7 +671,7 @@ mod tests {
             }
         }
         for ev in leftover {
-            live.push(ev);
+            live.restore(ev);
         }
 
         assert_eq!(ours.len(), 2, "expected one HoldOpen + one Release");
@@ -726,7 +726,7 @@ mod tests {
             }
         }
         for ev in leftover {
-            live.push(ev);
+            live.restore(ev);
         }
         assert_eq!(
             none_events, 0,

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -260,7 +260,7 @@ impl ComponentCtx {
                 let kind_name = self.registry.kind_name(kind).unwrap_or_default();
                 let origin = self.registry.mailbox_name(self.sender);
                 let thread_name = thread::current().name().map(str::to_owned);
-                self.queue.record_received(mail_id, thread_name);
+                self.queue.record_received(mail_id, root, thread_name);
                 handler.dispatch(crate::mail::registry::MailDispatch {
                     kind,
                     kind_name: &kind_name,
@@ -272,7 +272,7 @@ impl ComponentCtx {
                     root,
                     parent_mail,
                 });
-                self.queue.record_finished(mail_id);
+                self.queue.record_finished(mail_id, root);
                 return;
             }
             Some(MailboxEntry::Dropped) | None => {

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -201,14 +201,23 @@ impl Mailer {
             .record_sent(mail_id, root, parent_mail, sender, recipient, kind);
     }
 
-    /// ADR-0080 §2 producer hook for the `Received` event.
-    pub fn record_received(&self, mail_id: aether_data::MailId, thread_name: Option<String>) {
-        self.trace_handle.record_received(mail_id, thread_name);
+    /// ADR-0080 §2 producer hook for the `Received` event. `root` is the
+    /// mail's causal root — the trace queue shards on it so a root's
+    /// whole event stream stays in one FIFO shard (settlement ordering).
+    pub fn record_received(
+        &self,
+        mail_id: aether_data::MailId,
+        root: aether_data::MailId,
+        thread_name: Option<String>,
+    ) {
+        self.trace_handle
+            .record_received(mail_id, root, thread_name);
     }
 
-    /// ADR-0080 §2 producer hook for the `Finished` event.
-    pub fn record_finished(&self, mail_id: aether_data::MailId) {
-        self.trace_handle.record_finished(mail_id);
+    /// ADR-0080 §2 producer hook for the `Finished` event. `root` is the
+    /// mail's causal root (shard key — see [`Self::record_received`]).
+    pub fn record_finished(&self, mail_id: aether_data::MailId, root: aether_data::MailId) {
+        self.trace_handle.record_finished(mail_id, root);
     }
 
     /// ADR-0080 §12 / iamacoffeepot/aether#716: acquire a settlement
@@ -449,9 +458,10 @@ fn route_mail(
         // no-ops. Stamped kinds (future debugger / describe_tree
         // replies) get the symmetric `Received`/`Finished` bracket.
         let inbound_mail_id = mail.mail_id;
+        let inbound_root = mail.root;
         if let Some(router) = chassis_router {
             let thread_name = thread::current().name().map(str::to_owned);
-            trace_handle.record_received(inbound_mail_id, thread_name);
+            trace_handle.record_received(inbound_mail_id, inbound_root, thread_name);
             router(mail);
         } else {
             tracing::warn!(
@@ -460,7 +470,7 @@ fn route_mail(
                 "chassis-addressed mail dropped — no chassis router installed",
             );
         }
-        trace_handle.record_finished(inbound_mail_id);
+        trace_handle.record_finished(inbound_mail_id, inbound_root);
         return;
     }
 
@@ -498,7 +508,7 @@ fn route_mail(
                 // drain (issue 838). Parked mail (the `Ok(WalkOutcome::Parked)`
                 // arm above) is deliberately NOT finished — it's held
                 // for replay when the handle resolves.
-                trace_handle.record_finished(mail.mail_id);
+                trace_handle.record_finished(mail.mail_id, mail.root);
                 return;
             }
         }
@@ -506,6 +516,7 @@ fn route_mail(
 
     let recipient = mail.recipient;
     let inbound_mail_id = mail.mail_id;
+    let inbound_root = mail.root;
     match registry.entry(recipient) {
         Some(MailboxEntry::Inbox(handler)) => {
             let kind_name = registry.kind_name(mail.kind).unwrap_or_default();
@@ -559,7 +570,7 @@ fn route_mail(
             // double-count-prematurely-settle hazard the split
             // avoids.
             let thread_name = thread::current().name().map(str::to_owned);
-            trace_handle.record_received(inbound_mail_id, thread_name);
+            trace_handle.record_received(inbound_mail_id, inbound_root, thread_name);
             handler.dispatch(MailDispatch {
                 kind: mail.kind,
                 kind_name: &kind_name,
@@ -571,7 +582,7 @@ fn route_mail(
                 root: mail.root,
                 parent_mail: mail.parent_mail,
             });
-            trace_handle.record_finished(inbound_mail_id);
+            trace_handle.record_finished(inbound_mail_id, inbound_root);
         }
         Some(MailboxEntry::Dropped) => {
             tracing::warn!(
@@ -581,7 +592,7 @@ fn route_mail(
             );
             // ADR-0080 §2: balance the `Sent` so settlement chains
             // drain (issue 838). No `Received` — no handler ran.
-            trace_handle.record_finished(inbound_mail_id);
+            trace_handle.record_finished(inbound_mail_id, inbound_root);
         }
         None => {
             // ADR-0037 Phase 1: unknown-locally mailboxes bubble up
@@ -625,7 +636,7 @@ fn route_mail(
                 // bubbled-up mail on its own settlement domain; no
                 // wire signal exists today for federated cross-engine
                 // settlement (and the issue body parks that design).
-                trace_handle.record_finished(inbound_mail_id);
+                trace_handle.record_finished(inbound_mail_id, inbound_root);
                 return;
             }
             // Issue 963: `aether.log.tail` (`actor_logs`) to an
@@ -667,7 +678,7 @@ fn route_mail(
                 // The synthesized reply is a fresh un-lineaged mail
                 // (`MailId::NONE`); the inbound still records `Finished`
                 // so its settlement chain balances (issue 838).
-                trace_handle.record_finished(inbound_mail_id);
+                trace_handle.record_finished(inbound_mail_id, inbound_root);
                 return;
             }
             tracing::warn!(
@@ -680,7 +691,7 @@ fn route_mail(
             // unloaded `"camera"` mailbox every tick; without this
             // every Tick chain has an orphaned `Sent` and never
             // settles.
-            trace_handle.record_finished(inbound_mail_id);
+            trace_handle.record_finished(inbound_mail_id, inbound_root);
         }
     }
 }
@@ -1082,7 +1093,8 @@ mod tests {
     /// confuse the assertion.
     use aether_data::MailId;
     use aether_kinds::trace::TraceEvent;
-    use crossbeam_queue::SegQueue;
+
+    use crate::runtime::trace::ShardedTraceQueue;
 
     /// Borrow the queue Arc from a `Mailer`'s default trace handle.
     /// `Mailer::new` allocates a fresh handle per construction
@@ -1090,14 +1102,14 @@ mod tests {
     /// test's queue is naturally isolated. The `drain_events_for`
     /// filter by `sender` is no longer strictly necessary but kept
     /// to match the original assertion shape.
-    fn install_test_trace_handle(mailer: &Mailer) -> Arc<SegQueue<TraceEvent>> {
+    fn install_test_trace_handle(mailer: &Mailer) -> Arc<ShardedTraceQueue> {
         Arc::clone(mailer.trace_handle().queue())
     }
 
     /// Drain the trace queue and return only events whose `mail_id`
     /// is keyed to `sender` — lets parallel tests share the global
     /// queue without false positives.
-    fn drain_events_for(queue: &SegQueue<TraceEvent>, sender: MailboxId) -> Vec<TraceEvent> {
+    fn drain_events_for(queue: &ShardedTraceQueue, sender: MailboxId) -> Vec<TraceEvent> {
         let mut out = Vec::new();
         let mut leftover = Vec::new();
         while let Some(event) = queue.pop() {
@@ -1116,7 +1128,7 @@ mod tests {
             }
         }
         for ev in leftover {
-            queue.push(ev);
+            queue.restore(ev);
         }
         out
     }

--- a/crates/aether-substrate/src/runtime/trace.rs
+++ b/crates/aether-substrate/src/runtime/trace.rs
@@ -72,7 +72,7 @@ pub struct ShardedTraceQueue {
 }
 
 impl ShardedTraceQueue {
-    /// Allocate [`TRACE_SHARD_COUNT`] empty shards.
+    /// Allocate `TRACE_SHARD_COUNT` empty shards.
     #[must_use]
     pub fn new() -> Self {
         let shards = (0..TRACE_SHARD_COUNT)

--- a/crates/aether-substrate/src/runtime/trace.rs
+++ b/crates/aether-substrate/src/runtime/trace.rs
@@ -32,6 +32,7 @@
 //! structurally correct and unlocks future in-process multi-substrate
 //! workflows. Filed as iamacoffeepot/aether#953.
 
+use std::mem;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel};
@@ -46,6 +47,94 @@ use crate::mail::Mail;
 use crate::mail::mailer::Mailer;
 use crate::mail::registry::MailboxEntry;
 
+/// Number of per-root trace shards (power of two; mask is `N - 1`).
+/// Sized generously so concurrent roots spread across distinct queues,
+/// removing the single-`SegQueue` tail contention that dominated
+/// saturated multi-worker mail (~50% of worker CPU). Each empty
+/// `SegQueue` is cheap, so over-provisioning shards costs little.
+const TRACE_SHARD_COUNT: usize = 64;
+
+/// Per-chassis trace-event queue, sharded by causal root: every event
+/// for a given root lands in one FIFO `SegQueue`.
+///
+/// ADR-0080 settlement counts on per-root ordering — a root's `Sent`
+/// must be folded before its matching `Finished`, and its `HoldOpen`
+/// before `Release` — or `in_flight`/`held_open` can hit a false zero
+/// and fire `Settled` early. A `SegQueue` is FIFO and the producer
+/// hooks push a root's events in happens-before order, so keeping a
+/// whole root in one shard preserves that ordering exactly. Distinct
+/// roots spread across shards, so concurrent workers emitting for
+/// different roots no longer contend on one queue's tail.
+#[derive(Debug)]
+pub struct ShardedTraceQueue {
+    shards: Box<[SegQueue<TraceEvent>]>,
+    mask: u64,
+}
+
+impl ShardedTraceQueue {
+    /// Allocate [`TRACE_SHARD_COUNT`] empty shards.
+    #[must_use]
+    pub fn new() -> Self {
+        let shards = (0..TRACE_SHARD_COUNT)
+            .map(|_| SegQueue::new())
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        Self {
+            shards,
+            #[allow(clippy::cast_possible_truncation)]
+            mask: TRACE_SHARD_COUNT as u64 - 1,
+        }
+    }
+
+    /// Shard index for a causal root: a cheap mix of the root's two
+    /// 64-bit words. `correlation_id` is a per-root incrementing counter
+    /// (its low bits already round-robin across shards); folding in a
+    /// scrambled `sender` keeps roots minted by the same mailbox spread.
+    #[inline]
+    #[allow(clippy::cast_possible_truncation)] // masked to < TRACE_SHARD_COUNT, fits usize
+    fn shard_index(&self, root: MailId) -> usize {
+        let h = root.sender.0.wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ root.correlation_id;
+        (h & self.mask) as usize
+    }
+
+    /// Push an event onto its root's shard.
+    #[inline]
+    pub fn push(&self, root: MailId, event: TraceEvent) {
+        self.shards[self.shard_index(root)].push(event);
+    }
+
+    /// Pop one event from the first non-empty shard. Order *across*
+    /// shards is unspecified — per-root order lives *within* a shard —
+    /// so this is for tests that count or filter, not ones that rely on
+    /// a global event order.
+    #[must_use]
+    pub fn pop(&self) -> Option<TraceEvent> {
+        self.shards.iter().find_map(SegQueue::pop)
+    }
+
+    /// Re-enqueue an event that a test popped and wants to put back.
+    /// Sharded by the event's root where it carries one
+    /// (`Sent`/`HoldOpen`/`Release`); `Received`/`Finished` don't, so
+    /// they land on shard 0 — harmless because [`Self::pop`] scans every
+    /// shard and the restore-pattern tests don't assert cross-shard
+    /// order. Not used on the production drain path.
+    pub fn restore(&self, event: TraceEvent) {
+        let shard = match &event {
+            TraceEvent::Sent { root, .. }
+            | TraceEvent::HoldOpen { root, .. }
+            | TraceEvent::Release { root, .. } => self.shard_index(*root),
+            TraceEvent::Received { .. } | TraceEvent::Finished { .. } => 0,
+        };
+        self.shards[shard].push(event);
+    }
+}
+
+impl Default for ShardedTraceQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Per-chassis trace-pipeline handle. Owned by the chassis [`Mailer`];
 /// producer-side hooks reach it via `mailer.trace_handle()` or the
 /// `mailer.record_*` shortcuts that wrap the methods on this type.
@@ -55,7 +144,7 @@ use crate::mail::registry::MailboxEntry;
 /// site can hold an independent `TraceHandle` cheaply.
 #[derive(Clone, Debug)]
 pub struct TraceHandle {
-    queue: Arc<SegQueue<TraceEvent>>,
+    queue: Arc<ShardedTraceQueue>,
     boot_time: Instant,
 }
 
@@ -66,7 +155,7 @@ impl TraceHandle {
     /// its queue is handed to [`start_drainer`].
     #[must_use]
     pub fn new() -> Self {
-        Self::with_queue(Arc::new(SegQueue::new()))
+        Self::with_queue(Arc::new(ShardedTraceQueue::new()))
     }
 
     /// Build a handle that wraps an existing queue Arc. Used by tests
@@ -75,7 +164,7 @@ impl TraceHandle {
     /// `mail_id.sender`. Production chassis use [`Self::new`] instead;
     /// the queue is allocated fresh per chassis.
     #[must_use]
-    pub fn with_queue(queue: Arc<SegQueue<TraceEvent>>) -> Self {
+    pub fn with_queue(queue: Arc<ShardedTraceQueue>) -> Self {
         Self {
             queue,
             boot_time: Instant::now(),
@@ -86,7 +175,7 @@ impl TraceHandle {
     /// [`start_drainer`]. Internal: producer-side call sites go
     /// through the `record_*` methods on this type.
     #[must_use]
-    pub fn queue(&self) -> &Arc<SegQueue<TraceEvent>> {
+    pub fn queue(&self) -> &Arc<ShardedTraceQueue> {
         &self.queue
     }
 
@@ -120,15 +209,18 @@ impl TraceHandle {
         recipient: MailboxId,
         kind: KindId,
     ) {
-        self.queue.push(TraceEvent::Sent {
-            mail_id,
+        self.queue.push(
             root,
-            parent_mail,
-            sender,
-            recipient,
-            kind,
-            t: self.now_nanos(),
-        });
+            TraceEvent::Sent {
+                mail_id,
+                root,
+                parent_mail,
+                sender,
+                recipient,
+                kind,
+                t: self.now_nanos(),
+            },
+        );
     }
 
     /// ADR-0080 §2 producer hook for the `Received` event. Pushed by
@@ -145,29 +237,35 @@ impl TraceHandle {
     /// Issue 734: dispatchers pass `std::thread::current().name()
     /// .map(str::to_owned)` as `thread_name` so the trace renderer
     /// (`hub::mcp::trace`) can stamp each event with a per-thread row.
-    pub fn record_received(&self, mail_id: MailId, thread_name: Option<String>) {
+    pub fn record_received(&self, mail_id: MailId, root: MailId, thread_name: Option<String>) {
         if mail_id == MailId::NONE {
             return;
         }
-        self.queue.push(TraceEvent::Received {
-            mail_id,
-            t: self.now_nanos(),
-            thread_name,
-        });
+        self.queue.push(
+            root,
+            TraceEvent::Received {
+                mail_id,
+                t: self.now_nanos(),
+                thread_name,
+            },
+        );
     }
 
     /// ADR-0080 §2 producer hook for the `Finished` event. Pushed by
     /// the native dispatcher trampoline at handler exit (normal
     /// return). Symmetric `MailId::NONE` short-circuit (see
     /// [`Self::record_received`]).
-    pub fn record_finished(&self, mail_id: MailId) {
+    pub fn record_finished(&self, mail_id: MailId, root: MailId) {
         if mail_id == MailId::NONE {
             return;
         }
-        self.queue.push(TraceEvent::Finished {
-            mail_id,
-            t: self.now_nanos(),
-        });
+        self.queue.push(
+            root,
+            TraceEvent::Finished {
+                mail_id,
+                t: self.now_nanos(),
+            },
+        );
     }
 
     /// ADR-0080 §12 / iamacoffeepot/aether#716: acquire a
@@ -187,10 +285,13 @@ impl TraceHandle {
     /// the worker's lifetime.
     #[must_use = "SettlementHold gates root settlement; storing _ silently fires Release"]
     pub fn acquire_settlement_hold(&self, root: MailId) -> SettlementHold {
-        self.queue.push(TraceEvent::HoldOpen {
+        self.queue.push(
             root,
-            t: self.now_nanos(),
-        });
+            TraceEvent::HoldOpen {
+                root,
+                t: self.now_nanos(),
+            },
+        );
         SettlementHold {
             handle: self.clone(),
             root,
@@ -227,10 +328,13 @@ impl SettlementHold {
 
 impl Drop for SettlementHold {
     fn drop(&mut self) {
-        self.handle.queue.push(TraceEvent::Release {
-            root: self.root,
-            t: self.handle.now_nanos(),
-        });
+        self.handle.queue.push(
+            self.root,
+            TraceEvent::Release {
+                root: self.root,
+                t: self.handle.now_nanos(),
+            },
+        );
     }
 }
 
@@ -279,7 +383,7 @@ impl Drop for TraceDrainerHandle {
 /// Panics if the OS refuses to spawn the drainer thread — fail-fast
 /// per ADR-0063: thread spawn is a substrate-boot prerequisite and a
 /// failure means the process is in an unrecoverable state.
-pub fn start_drainer(queue: Arc<SegQueue<TraceEvent>>, mailer: Arc<Mailer>) -> TraceDrainerHandle {
+pub fn start_drainer(queue: Arc<ShardedTraceQueue>, mailer: Arc<Mailer>) -> TraceDrainerHandle {
     let (shutdown_tx, shutdown_rx) = channel::<()>();
     let handle = thread::Builder::new()
         .name("aether-trace-drainer".to_owned())
@@ -294,19 +398,19 @@ pub fn start_drainer(queue: Arc<SegQueue<TraceEvent>>, mailer: Arc<Mailer>) -> T
 // All arguments are taken by value so the spawned drainer thread
 // owns them for its lifetime.
 #[allow(clippy::needless_pass_by_value)]
-fn drainer_loop(queue: Arc<SegQueue<TraceEvent>>, mailer: Arc<Mailer>, shutdown_rx: Receiver<()>) {
+fn drainer_loop(queue: Arc<ShardedTraceQueue>, mailer: Arc<Mailer>, shutdown_rx: Receiver<()>) {
     let recipient = aether_data::mailbox_id_from_name(TRACE_OBSERVER_MAILBOX_NAME);
     let kind = <BatchedTraceEvents as aether_data::Kind>::ID;
 
     loop {
-        ship_batch(&queue, &mailer, recipient, kind);
+        ship_all(&queue, &mailer, recipient, kind);
 
         // Park BATCH_INTERVAL or until shutdown.
         match shutdown_rx.recv_timeout(BATCH_INTERVAL) {
             Ok(()) | Err(RecvTimeoutError::Disconnected) => {
                 // One last drain on shutdown so events queued just
                 // before signal don't get lost.
-                ship_batch(&queue, &mailer, recipient, kind);
+                ship_all(&queue, &mailer, recipient, kind);
                 break;
             }
             Err(RecvTimeoutError::Timeout) => {}
@@ -314,43 +418,57 @@ fn drainer_loop(queue: Arc<SegQueue<TraceEvent>>, mailer: Arc<Mailer>, shutdown_
     }
 }
 
-/// Drain up to [`BATCH_MAX`] events and ship one
-/// [`BatchedTraceEvents`] mail. Skipped silently if the
-/// [`TRACE_OBSERVER_MAILBOX_NAME`] sink is not registered on this
-/// substrate's [`crate::mail::registry::Registry`] — that's the
-/// case in unit tests that boot a chassis without
-/// `TraceObserverCapability`, and the bubble-up that would otherwise
-/// fire for the unknown mailbox would interfere with the test's own
-/// outbound assertions. Production chassis register the observer so
-/// the drop branch never fires.
-fn ship_batch(
-    queue: &Arc<SegQueue<TraceEvent>>,
+/// Drain every shard once and ship the events as one or more
+/// [`BatchedTraceEvents`] mails (one per [`BATCH_MAX`] events). Each
+/// shard is drained FIFO, so a root's events stay in their
+/// happens-before order within the shipped stream — the ordering ADR-0080
+/// settlement depends on. Events pushed to a shard after it is scanned
+/// wait for the next cycle (still FIFO for their root).
+///
+/// Shipping is skipped silently when the [`TRACE_OBSERVER_MAILBOX_NAME`]
+/// sink is not registered (unit tests that boot a chassis without
+/// `TraceObserverCapability`), but the shards are still drained so the
+/// queue can't grow without bound. Production chassis register the
+/// observer so the skip branch never fires.
+fn ship_all(
+    queue: &Arc<ShardedTraceQueue>,
     mailer: &Arc<Mailer>,
     recipient: MailboxId,
     kind: KindId,
 ) {
-    let mut batch = Vec::with_capacity(BATCH_MAX);
-    for _ in 0..BATCH_MAX {
-        match queue.pop() {
-            Some(event) => batch.push(event),
-            None => break,
-        }
-    }
-    if batch.is_empty() {
-        return;
-    }
-    if !mailer
+    let registered = mailer
         .registry()
         .entry(recipient)
-        .is_some_and(|e| matches!(e, MailboxEntry::Inbox(_)))
-    {
-        // Observer not registered (or dropped); silently discard the
-        // batch. Test isolation: a chassis without
-        // `TraceObserverCapability` should not surface trace mail as
-        // an `UnresolvedMail` egress event on its outbound.
-        return;
+        .is_some_and(|e| matches!(e, MailboxEntry::Inbox(_)));
+
+    let mut batch: Vec<TraceEvent> = Vec::with_capacity(BATCH_MAX);
+    for shard in &queue.shards {
+        while let Some(event) = shard.pop() {
+            batch.push(event);
+            if batch.len() >= BATCH_MAX {
+                let full = mem::take(&mut batch);
+                if registered {
+                    ship_one(mailer, recipient, kind, full);
+                }
+            }
+        }
     }
-    let envelope = BatchedTraceEvents { events: batch };
+    if registered && !batch.is_empty() {
+        ship_one(mailer, recipient, kind, batch);
+    }
+}
+
+/// Encode one batch and push it to the observer mailbox.
+///
+/// Drainer-originated mail is chassis-root; no inheritance,
+/// no `parent_mail`. We push directly through the `Mailer`
+/// (no `Sender::send_detached` wrapper) — the recursion
+/// break (ADR-0080 §7) is structural here: the producer
+/// hook in `NativeBinding::send_mail_with_lineage` is what
+/// would push a `TraceEvent::Sent` for an outbound, and we
+/// bypass that path by going straight to `Mailer::push`.
+fn ship_one(mailer: &Arc<Mailer>, recipient: MailboxId, kind: KindId, events: Vec<TraceEvent>) {
+    let envelope = BatchedTraceEvents { events };
     let payload = match postcard::to_allocvec(&envelope) {
         Ok(p) => p,
         Err(e) => {
@@ -362,12 +480,5 @@ fn ship_batch(
             return;
         }
     };
-    // Drainer-originated mail is chassis-root; no inheritance,
-    // no `parent_mail`. We push directly through the Mailer
-    // (no `Sender::send_detached` wrapper) — the recursion
-    // break (ADR-0080 §7) is structural here: the producer
-    // hook in `NativeBinding::send_mail_with_lineage` is what
-    // would push a `TraceEvent::Sent` for an outbound, and we
-    // bypass that path by going straight to `Mailer::push`.
     mailer.push(Mail::new(recipient, kind, payload, 1));
 }


### PR DESCRIPTION
## Summary

The trace pipeline pushed every Sent/Received/Finished event onto one per-chassis `SegQueue`. Under saturated multi-worker mail that single queue's tail was the dominant cost — a ring-saturation profile (11 workers, 6000 concurrent roots) put ~50% of worker CPU in `SegQueue::push`, and it throttled throughput.

This shards the queue into 64 FIFO shards keyed by causal **root** (`ShardedTraceQueue`). Every event for a root lands in one shard, so ADR-0080's per-root ordering — `Sent` before `Finished`, `HoldOpen` before `Release` — holds exactly (FIFO within a shard plus the producer hooks' happens-before push order). Distinct roots spread across shards, so concurrent workers emitting for different roots no longer contend on one tail. The single drainer drains every shard FIFO each cycle; the single observer is unchanged.

`record_received` / `record_finished` carried only `mail_id`; they now also take the mail's `root` (the shard key), threaded from `env.root` / `mail.root` at every emit site (native dispatch, wasm, mailer loopback) — compiler-enforced, so a missed site is a build error, not a silent mis-shard.

**Per-worker** sharding was rejected: `Sent` and `Finished` for a hop are emitted by *different* workers, so per-worker queues would let the drainer merge a `Finished` ahead of its `Sent` — a root's `in_flight` could hit a false zero and fire `Settled` prematurely. Per-root keeps each root's whole event stream in one place, which is what makes settlement exact.

## Result (ring saturation, 11 workers, 6000 roots)

- `TRACE-EMIT` share of worker CPU: **52.6% -> 9.8%**
- `SegQueue::push` fell from the top leaf (33%) out of the top-16
- on-CPU worker throughput roughly doubled (the contention was the throttle)
- mail-hop latency unchanged — it is emit-side dispatch, orthogonal to the trace queue; warm idle hop stays flat at ~1.4us

The win is throughput under heavy trace volume, not per-hop latency, so it shows up in the saturation profile rather than the latency sweep.

## Test plan
- [x] `cargo nextest run --workspace` — 1196 pass (settlement, trace observer, hold/release, and the rpc-engine-routing reply-ordering canary all green)
- [x] new `sharded_trace_settles_every_root` gate — 800 concurrent roots across a max-worker pool all settle; flake-soaked 30x
- [x] pre-flight: fmt, `clippy --workspace --all-targets -D warnings`, rustdoc, wasm32 component cross-build
- [x] ring-saturation profile re-run confirms the contention drop

Refs iamacoffeepot/aether#1059.