### PR TITLE
perf(substrate/scheduler): route woken work to spinning workers

### DIFF
--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -40,6 +40,7 @@ use crate::mail::{KindId, MailId, MailboxId, ReplyTo};
 use crate::runtime::lifecycle::FatalAborter;
 use crate::scheduler::Drainable;
 use crate::scheduler::WakeHandle;
+use crate::scheduler::WakeSink;
 use aether_actor::local;
 use aether_actor::local::ActorSlots;
 use std::sync::Weak;
@@ -104,10 +105,11 @@ pub struct Spawner {
     /// Monotonic counter for [`Subname::Counter`]. Per-Spawner so each
     /// chassis runs its own sequence; not shared across substrates.
     counter: AtomicU64,
-    /// Issue 635 PR C: chassis worker pool's ready-queue sender.
-    /// Cloned into [`WakeHandle`]s when the
-    /// Pooled spawn branch lands a slot.
-    pool_ready_tx: crossbeam_channel::Sender<Arc<dyn Drainable>>,
+    /// Issue 635 PR C: chassis worker pool's wake sink — the ready-queue
+    /// sender bundled with the spin/park coordinator (iamacoffeepot/aether#1064).
+    /// Cloned into [`WakeHandle`]s when the Pooled spawn branch lands a
+    /// slot.
+    wake_sink: WakeSink,
     /// Issue 635 Phase 3: strong-Arc store for instanced
     /// [`Drainable`] slots spawned via the Pooled
     /// branch. Without this the slot dropped at end of `spawn_actor`
@@ -140,7 +142,7 @@ impl Spawner {
         actor_registry: Arc<ActorRegistry>,
         mailer: Arc<Mailer>,
         aborter: Arc<dyn FatalAborter>,
-        pool_ready_tx: crossbeam_channel::Sender<Arc<dyn Drainable>>,
+        wake_sink: WakeSink,
     ) -> Self {
         Self {
             registry,
@@ -148,16 +150,16 @@ impl Spawner {
             mailer,
             aborter,
             counter: AtomicU64::new(0),
-            pool_ready_tx,
+            wake_sink,
             instanced_slots: Mutex::new(HashMap::new()),
         }
     }
 
-    /// Borrow the chassis worker pool's ready-queue sender. PR D
-    /// reaches for this when a Pooled instanced actor spawns.
-    #[allow(dead_code)] // wired in PR D
-    pub(crate) fn pool_ready_tx(&self) -> &crossbeam_channel::Sender<Arc<dyn Drainable>> {
-        &self.pool_ready_tx
+    /// Borrow the chassis worker pool's wake sink (ready-queue sender +
+    /// spin/park coordinator). The Pooled instanced spawn branch clones
+    /// it into each slot's [`WakeHandle`].
+    pub(crate) fn wake_sink(&self) -> &WakeSink {
+        &self.wake_sink
     }
 
     /// Issue 685: walk every spawned instanced slot, signal shutdown
@@ -556,8 +558,7 @@ impl Spawner {
                 );
                 let slot_dyn: Arc<dyn Drainable> = slot.clone();
                 let weak: Weak<dyn Drainable> = Arc::downgrade(&slot_dyn);
-                let wake =
-                    WakeHandle::new(Arc::clone(slot.state()), weak, self.pool_ready_tx.clone());
+                let wake = WakeHandle::new(Arc::clone(slot.state()), weak, self.wake_sink.clone());
                 // Stash the slot's strong Arc so wakes can upgrade their
                 // `Weak`. PR C dropped it here, which broke every wake
                 // after spawn (the registry only holds the inbox

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -649,8 +649,7 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
                 let slot_dyn: Arc<dyn Drainable> = slot.clone();
                 let weak: Weak<dyn Drainable> = Arc::downgrade(&slot_dyn);
                 drop(slot_dyn);
-                let wake =
-                    WakeHandle::new(Arc::clone(slot.state()), weak, ctx.pool_ready_tx().clone());
+                let wake = WakeHandle::new(Arc::clone(slot.state()), weak, ctx.wake_sink().clone());
                 // Issue 697 multi-pass: mail addressed at this actor
                 // during the wire pass landed in its inbox before the
                 // wake hook was installed, so the closure-side wake
@@ -1088,7 +1087,7 @@ fn boot_passives(
     let mut claimed_actor_mailboxes: Vec<MailboxId> = Vec::new();
     let actor_registry: Arc<crate::ActorRegistry> = Arc::new(crate::ActorRegistry::new());
     // Issue 635 PR C: stand up the worker pool before any cap boots.
-    // The pool's ready_tx is cloned into the Spawner (for instanced
+    // The pool's wake sink is cloned into the Spawner (for instanced
     // Pooled actors) and into the ChassisCtx (for singleton Pooled
     // caps). Today every cap is Dedicated so the pool sits idle, but
     // booting it here means PR D / Phase 2 can flip a cap to Pooled
@@ -1151,7 +1150,7 @@ fn boot_passives(
         Arc::clone(&actor_registry),
         Arc::clone(mailer),
         Arc::clone(aborter),
-        pool.ready_tx(),
+        pool.wake_sink(),
     ));
     // Issue 697: multi-pass boot — claim → init → wire → spawn,
     // synchronized across all passives. Each pass below walks every

--- a/crates/aether-substrate/src/chassis/ctx.rs
+++ b/crates/aether-substrate/src/chassis/ctx.rs
@@ -17,7 +17,7 @@ use crate::mail::mailer::Mailer;
 use crate::mail::registry::OwnedDispatch;
 use crate::mail::registry::Registry;
 use crate::runtime::lifecycle::FatalAborter;
-use crate::scheduler::Drainable;
+use crate::scheduler::WakeSink;
 use std::fmt;
 use std::sync::OnceLock;
 
@@ -60,7 +60,7 @@ pub struct DropOnShutdownClaim {
     /// Issue 635 PR C: optional wake hook for `Pooled` actors. The
     /// mailbox closure invokes this after a successful inbox push so
     /// the chassis worker pool re-queues the actor's
-    /// [`Drainable`] slot. `Dedicated` actors
+    /// [`crate::scheduler::Drainable`] slot. `Dedicated` actors
     /// (today: every cap) leave this empty — the closure's `get()`
     /// is a single atomic load, ~free.
     ///
@@ -73,7 +73,7 @@ pub struct DropOnShutdownClaim {
 /// Cell holding the optional wake hook a `Pooled` mailbox fires after
 /// each accepted send. The mailbox closure captures `Arc<MailboxWakeSlot>`
 /// at registration time; the spawn path populates it once the
-/// [`Drainable`] slot exists.
+/// [`crate::scheduler::Drainable`] slot exists.
 #[derive(Default)]
 pub struct MailboxWakeSlot {
     inner: OnceLock<MailboxWakeFn>,
@@ -390,12 +390,13 @@ impl<'a> ChassisCtx<'a> {
         self.spawner
     }
 
-    /// Issue 635 PR C: borrow the chassis worker pool's ready-queue
-    /// sender. The `Pooled` branch of `make_native_actor_boot` clones
-    /// this into the [`crate::scheduler::WakeHandle`] that fires when
-    /// the actor's mailbox accepts a send.
-    pub(crate) fn pool_ready_tx(&self) -> &crossbeam_channel::Sender<Arc<dyn Drainable>> {
-        self.spawner.pool_ready_tx()
+    /// Issue 635 PR C: borrow the chassis worker pool's wake sink
+    /// (ready-queue sender + spin/park coordinator). The `Pooled` branch
+    /// of `make_native_actor_boot` clones this into the
+    /// [`crate::scheduler::WakeHandle`] that fires when the actor's
+    /// mailbox accepts a send.
+    pub(crate) fn wake_sink(&self) -> &WakeSink {
+        self.spawner.wake_sink()
     }
 
     /// Install the fallback-router handler. At most one capability

--- a/crates/aether-substrate/src/scheduler/mod.rs
+++ b/crates/aether-substrate/src/scheduler/mod.rs
@@ -36,9 +36,11 @@
 mod local_slot;
 mod pool;
 mod slot;
+mod spin_park;
 
 pub use pool::{Pool, PoolConfig, PoolHandle, PoolWorkerJoin};
 pub use slot::{
     BATCH_MAX_MAILS, BATCH_MAX_USEC, BatchBudget, CycleResult, DrainOutcome, Drainable, SlotState,
-    SlotStateLabel, WakeHandle,
+    SlotStateLabel, WakeHandle, WakeSink,
 };
+pub use spin_park::{Acquired, SpinPark};

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -27,16 +27,18 @@
 //! ADR.
 
 use std::any::Any;
+use std::env;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
-use crossbeam_channel::{Receiver, Sender, bounded, select, unbounded};
+use crossbeam_channel::{Receiver, Sender, unbounded};
 
 use crate::scheduler::local_slot;
+use crate::scheduler::spin_park::{Acquired, DEFAULT_SPIN_WINDOW_USEC, SpinPark};
 
 use crate::runtime::lifecycle::FatalAborter;
-use crate::scheduler::slot::{BatchBudget, CycleResult, Drainable};
+use crate::scheduler::slot::{BatchBudget, CycleResult, Drainable, WakeSink};
 use std::mem;
 use std::panic;
 use std::time::Duration;
@@ -90,41 +92,45 @@ impl BudgetTemplate {
 }
 
 /// Handle to a running [`Pool`]. The chassis owns this; calling
-/// [`PoolHandle::shutdown_with_results`] drops the shutdown sender,
-/// which disconnects each worker's `select!` arm and tells them to
-/// exit after the current cycle. Joining the worker threads is part
-/// of shutdown.
+/// [`PoolHandle::shutdown_with_results`] sets the coordinator's
+/// shutdown flag and unparks every worker so each exits after its
+/// current cycle. Joining the worker threads is part of shutdown.
 ///
-/// Why a separate shutdown channel? Workers hold their own clones of
-/// `ready_tx` (for re-queueing yielded slots). That keeps the ready
-/// queue alive even after every external sender drops, so a worker's
-/// blocking `recv` would never see a disconnect. The shutdown channel
-/// is held only by the pool — dropping it is the unambiguous signal.
+/// Shutdown is signalled through the [`SpinPark`] coordinator (a flag
+/// the workers observe in their spin loop / park-commit recheck) plus
+/// an explicit unpark of every worker thread — workers no longer block
+/// on the ready queue, so dropping a sender is not the stop signal it
+/// was under the old `select!` park.
 pub struct PoolHandle {
     // `Option` so `Drop` and the consuming `shutdown` method can both
-    // take the senders without a clone. Production drops on `PoolHandle`
+    // take the sender without a clone. Production drops on `PoolHandle`
     // drop, tests consume via `shutdown_with_results` to inspect any
     // worker-thread panics.
     ready_tx: Option<Sender<Arc<dyn Drainable>>>,
-    shutdown_tx: Option<Sender<()>>,
+    spin: Arc<SpinPark>,
     workers: Vec<PoolWorkerJoin>,
 }
 
 impl PoolHandle {
-    /// Hand out a clone of the ready-queue sender. PR C wires this
-    /// into [`crate::scheduler::WakeHandle`]s when registering
-    /// dispatcher slots.
+    /// Hand out a [`WakeSink`] — the ready-queue sender plus the
+    /// spin/park coordinator. The chassis bundles this into each
+    /// [`crate::scheduler::WakeHandle`] when registering a dispatcher
+    /// slot, so a wake both enqueues the slot and routes the
+    /// notification through the coordinator.
     ///
     /// # Panics
     /// Panics if the pool has already been shut down (the sender slot
     /// is `None`) — fail-fast per ADR-0063: registering a wake handle
     /// after pool shutdown is a chassis-lifecycle bug.
     #[must_use]
-    pub fn ready_tx(&self) -> Sender<Arc<dyn Drainable>> {
-        self.ready_tx
-            .as_ref()
-            .expect("pool already shut down")
-            .clone()
+    pub fn wake_sink(&self) -> WakeSink {
+        WakeSink::new(
+            self.ready_tx
+                .as_ref()
+                .expect("pool already shut down")
+                .clone(),
+            Arc::clone(&self.spin),
+        )
     }
 
     /// Shut down the pool, joining every worker, and return each
@@ -136,12 +142,17 @@ impl PoolHandle {
     }
 
     fn shutdown_inner(&mut self) -> Vec<thread::Result<()>> {
-        // Drop the shutdown sender — fires every worker's `select!`
-        // shutdown arm. Then drop the ready-queue sender (any future
-        // wake.wake() calls silently no-op via SendError). Finally
-        // join every worker thread. Idempotent — re-calling drains the
-        // (empty) workers Vec and returns an empty Vec.
-        self.shutdown_tx.take();
+        // Signal shutdown via the coordinator flag, then unpark every
+        // worker: parked workers wake and observe the flag, spinning
+        // workers see it in their loop. Drop the ready-queue sender so
+        // any future `wake` no-ops via SendError. Finally join. The
+        // unpark must precede the join — a parked worker that's never
+        // unparked would block the join forever. Idempotent: re-calling
+        // drains the (empty) workers Vec and returns an empty Vec.
+        self.spin.set_shutdown();
+        for w in &self.workers {
+            w.handle.thread().unpark();
+        }
         self.ready_tx.take();
         mem::take(&mut self.workers)
             .into_iter()
@@ -193,31 +204,40 @@ impl Pool {
     pub fn start(config: PoolConfig, aborter: Arc<dyn FatalAborter>) -> PoolHandle {
         assert!(config.workers >= 1, "pool needs at least one worker");
         let (ready_tx, ready_rx) = unbounded::<Arc<dyn Drainable>>();
-        // Shutdown signal: bounded(0) is a rendezvous channel, but we
-        // never send on it. Dropping `shutdown_tx` (held only by the
-        // pool) is what disconnects every worker's `select!` arm.
-        let (shutdown_tx, shutdown_rx) = bounded::<()>(0);
+        let spin = Arc::new(SpinPark::with_spin_window(spin_window_from_env()));
         let mut workers = Vec::with_capacity(config.workers);
         for n in 0..config.workers {
             let name = format!("aether-worker-{n}");
             let rx = ready_rx.clone();
             let tx = ready_tx.clone();
-            let shutdown = shutdown_rx.clone();
+            let spin = Arc::clone(&spin);
             let aborter = Arc::clone(&aborter);
             let template = config.budget_template;
             let thread_name = name.clone();
             let handle = thread::Builder::new()
                 .name(thread_name)
-                .spawn(move || worker_loop(rx, tx, shutdown, aborter, template))
+                .spawn(move || worker_loop(rx, tx, spin, aborter, template))
                 .expect("spawn pool worker thread");
             workers.push(PoolWorkerJoin { handle, name });
         }
         PoolHandle {
             ready_tx: Some(ready_tx),
-            shutdown_tx: Some(shutdown_tx),
+            spin,
             workers,
         }
     }
+}
+
+/// Read the spin-window override (`AETHER_SPIN_WINDOW_USEC`) for the
+/// route-to-spinner coordinator, falling back to the default. The
+/// experiment's latency sweep retunes this without a recompile; a
+/// malformed value falls back rather than aborting boot.
+fn spin_window_from_env() -> Duration {
+    let usec = env::var("AETHER_SPIN_WINDOW_USEC")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_SPIN_WINDOW_USEC);
+    Duration::from_micros(usec)
 }
 
 // All arguments are taken by value so the spawned thread owns them
@@ -226,7 +246,7 @@ impl Pool {
 fn worker_loop(
     ready_rx: Receiver<Arc<dyn Drainable>>,
     ready_tx: Sender<Arc<dyn Drainable>>,
-    shutdown_rx: Receiver<()>,
+    spin: Arc<SpinPark>,
     aborter: Arc<dyn FatalAborter>,
     template: BudgetTemplate,
 ) {
@@ -235,9 +255,8 @@ fn worker_loop(
     // rather than the shared queue. iamacoffeepot/aether#1059.
     local_slot::mark_pool_worker();
     loop {
-        let Some(slot) = acquire_slot(&ready_rx, &shutdown_rx) else {
-            // Shutdown signalled (or, impossibly, the ready queue
-            // disconnected while we hold a `ready_tx` clone). Exit.
+        let Some(slot) = acquire_slot(&ready_rx, &spin) else {
+            // Shutdown signalled. Exit.
             return;
         };
         let budget = template.build();
@@ -250,10 +269,17 @@ fn worker_loop(
                 drop(slot);
             }
             Ok(CycleResult::Requeue) => {
+                // Yielded mid-drain (budget hit) or post-empty recheck
+                // found new work. Re-push and notify the coordinator so
+                // a parked worker can run the slot in parallel if no
+                // worker is already spinning. This worker also loops
+                // straight into `acquire_slot` and may pick it up first
+                // — the `enter_running` CAS ensures only one wins.
                 if ready_tx.send(slot).is_err() {
                     // Pool shutting down: ready queue closed. Exit.
                     return;
                 }
+                spin.notify();
             }
             Err(payload) => {
                 // Handler panicked. Per ADR-0063 / OQ8: escalate to
@@ -274,8 +300,8 @@ fn worker_loop(
 }
 
 /// Acquire the next ready slot for a worker: worker-local hand-off first,
-/// then a `try_recv` fast path, then a blocking park. Returns `None` only
-/// on shutdown.
+/// then a `try_recv` fast path, then the spin-then-park coordinator.
+/// Returns `None` only on shutdown.
 ///
 /// The worker-local cell (iamacoffeepot/aether#1059) is the affinity
 /// lever: when a handler running on this worker wakes a downstream slot,
@@ -283,16 +309,19 @@ fn worker_loop(
 /// chain stays on the same warm worker and never pays the ~4.3µs
 /// parked-worker wakeup. The cell holds at most one slot — a fan-out
 /// spills its extras to the shared queue, so independent work still
-/// parallelises across workers. `take_next` is checked first (even
-/// before shutdown) so a stashed slot is never stranded.
+/// parallelises across workers. `take_next` is checked first so a
+/// stashed slot is never stranded; it can only be populated by *this*
+/// worker during its own `run_cycle`, so one check per acquire suffices.
 ///
-/// `ready_rx` cannot disconnect while the caller holds its own `ready_tx`
-/// clone, so `try_recv` here is only ever `Ok` or `Empty`; shutdown is
-/// signalled solely through `shutdown_rx`, and the park's `select!` arm
-/// on it stays the one clean stop signal (issue 635 deadlock class).
+/// When neither the cell nor a fast `try_recv` yields work, the
+/// coordinator (iamacoffeepot/aether#1064) takes over: it keeps the
+/// worker spinning (scanning `try_recv`) for a bounded window so a
+/// producer can route a spill or relay hop to it without a futex wake,
+/// then parks it. Shutdown is observed inside the coordinator (a flag +
+/// an explicit unpark of every worker on teardown).
 fn acquire_slot(
     ready_rx: &Receiver<Arc<dyn Drainable>>,
-    shutdown_rx: &Receiver<()>,
+    spin: &SpinPark,
 ) -> Option<Arc<dyn Drainable>> {
     if let Some(slot) = local_slot::take_next() {
         return Some(slot);
@@ -300,9 +329,9 @@ fn acquire_slot(
     if let Ok(slot) = ready_rx.try_recv() {
         return Some(slot);
     }
-    select! {
-        recv(ready_rx) -> result => result.ok(),
-        recv(shutdown_rx) -> _ => None,
+    match spin.acquire(|| ready_rx.try_recv().ok()) {
+        Acquired::Slot(slot) => Some(slot),
+        Acquired::Shutdown => None,
     }
 }
 
@@ -365,7 +394,7 @@ mod tests {
         let slot_dyn: Arc<dyn Drainable> = slot.clone();
         let weak: Weak<dyn Drainable> = Arc::downgrade(&slot_dyn);
         drop(slot_dyn);
-        let wake = WakeHandle::new(slot.state.clone(), weak, handle.ready_tx());
+        let wake = WakeHandle::new(slot.state.clone(), weak, handle.wake_sink());
 
         for n in 0..200 {
             slot.push(n);
@@ -411,8 +440,8 @@ mod tests {
         let b_weak: Weak<dyn Drainable> = Arc::downgrade(&b_dyn);
         drop(a_dyn);
         drop(b_dyn);
-        let wake_a = WakeHandle::new(a.state.clone(), a_weak, handle.ready_tx());
-        let wake_b = WakeHandle::new(b.state.clone(), b_weak, handle.ready_tx());
+        let wake_a = WakeHandle::new(a.state.clone(), a_weak, handle.wake_sink());
+        let wake_b = WakeHandle::new(b.state.clone(), b_weak, handle.wake_sink());
 
         for n in 0..40 {
             a.push(n);
@@ -458,7 +487,7 @@ mod tests {
         let slot_dyn: Arc<dyn Drainable> = slot.clone();
         let weak: Weak<dyn Drainable> = Arc::downgrade(&slot_dyn);
         drop(slot_dyn);
-        let wake = WakeHandle::new(slot.state.clone(), weak, handle.ready_tx());
+        let wake = WakeHandle::new(slot.state.clone(), weak, handle.wake_sink());
 
         slot.push(1);
         slot.push(2); // this one panics
@@ -493,7 +522,8 @@ mod tests {
         let slot_dyn: Arc<dyn Drainable> = slot.clone();
         let weak: Weak<dyn Drainable> = Arc::downgrade(&slot_dyn);
         drop(slot_dyn);
-        let wake = WakeHandle::new(slot.state.clone(), weak, ready_tx);
+        let sink = WakeSink::new(ready_tx, Arc::new(SpinPark::new()));
+        let wake = WakeHandle::new(slot.state.clone(), weak, sink);
 
         slot.push(1);
         assert!(wake.wake(), "first wake transitions Idle→Ready");
@@ -525,7 +555,7 @@ mod tests {
                 let slot_dyn: Arc<dyn Drainable> = slot.clone();
                 let weak: Weak<dyn Drainable> = Arc::downgrade(&slot_dyn);
                 drop(slot_dyn);
-                WakeHandle::new(slot.state.clone(), weak, handle.ready_tx())
+                WakeHandle::new(slot.state.clone(), weak, handle.wake_sink())
             })
             .collect();
 
@@ -572,7 +602,7 @@ mod tests {
             let target_dyn: Arc<dyn Drainable> = target.clone();
             let weak: Weak<dyn Drainable> = Arc::downgrade(&target_dyn);
             drop(target_dyn);
-            let wake = WakeHandle::new(target.state.clone(), weak, handle.ready_tx());
+            let wake = WakeHandle::new(target.state.clone(), weak, handle.wake_sink());
             *slots[i].forward.lock().unwrap() = Some((target, wake));
         }
         slots
@@ -594,7 +624,7 @@ mod tests {
         let entry_dyn: Arc<dyn Drainable> = entry.clone();
         let weak: Weak<dyn Drainable> = Arc::downgrade(&entry_dyn);
         drop(entry_dyn);
-        let entry_wake = WakeHandle::new(entry.state.clone(), weak, handle.ready_tx());
+        let entry_wake = WakeHandle::new(entry.state.clone(), weak, handle.wake_sink());
 
         entry.push(1);
         assert!(entry_wake.wake());

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -36,6 +36,7 @@ use std::time::{Duration, Instant};
 use crossbeam_channel::Sender;
 
 use super::local_slot;
+use super::spin_park::SpinPark;
 
 /// Default per-cycle envelope cap. Once a worker has dispatched this
 /// many envelopes from a single slot, it yields to other ready slots
@@ -284,6 +285,26 @@ pub trait Drainable: Send + Sync + 'static {
     fn as_any(&self) -> &dyn Any;
 }
 
+/// The destination a [`WakeHandle`] routes a spilled slot to: the
+/// shared ready queue plus the [`SpinPark`] coordinator it notifies
+/// after pushing. Bundled so the "where woken work goes + how we wake a
+/// worker" pair travels as one value through the chassis wiring rather
+/// than two parallel fields. Cloned per registered slot.
+#[derive(Clone)]
+pub struct WakeSink {
+    ready_tx: Sender<Arc<dyn Drainable>>,
+    spin: Arc<SpinPark>,
+}
+
+impl WakeSink {
+    /// Bundle the pool's ready-queue sender and spin/park coordinator.
+    /// The chassis builds one from [`super::PoolHandle::wake_sink`].
+    #[must_use]
+    pub fn new(ready_tx: Sender<Arc<dyn Drainable>>, spin: Arc<SpinPark>) -> Self {
+        Self { ready_tx, spin }
+    }
+}
+
 /// Sender-side wake hook the chassis hands to the inbox sender path
 /// (PR C wires this into `MailboxSender`). Holds a [`Weak<dyn
 /// Drainable>`] to the slot — the chassis registry owns the strong
@@ -293,22 +314,14 @@ pub trait Drainable: Send + Sync + 'static {
 pub struct WakeHandle {
     state: Arc<SlotState>,
     slot: Weak<dyn Drainable>,
-    ready_tx: Sender<Arc<dyn Drainable>>,
+    sink: WakeSink,
 }
 
 impl WakeHandle {
     /// Construct a wake handle. The chassis registry calls this when
     /// it wires a new dispatcher slot.
-    pub fn new(
-        state: Arc<SlotState>,
-        slot: Weak<dyn Drainable>,
-        ready_tx: Sender<Arc<dyn Drainable>>,
-    ) -> Self {
-        Self {
-            state,
-            slot,
-            ready_tx,
-        }
+    pub fn new(state: Arc<SlotState>, slot: Weak<dyn Drainable>, sink: WakeSink) -> Self {
+        Self { state, slot, sink }
     }
 
     /// Wake the slot if it isn't already in flight. Called from the
@@ -332,11 +345,20 @@ impl WakeHandle {
         };
         // Affinity (iamacoffeepot/aether#1059): if this wake runs on a
         // pool worker, stash the slot in that worker's local cell so the
-        // chain stays warm. Otherwise (or if the cell is full — fan-out
-        // spill) fall through to the shared ready queue. A closed ready
-        // queue means the pool is shutting down; treat as a no-op.
-        if let Err(slot) = local_slot::try_stash_next(slot) {
-            let _ = self.ready_tx.send(slot);
+        // chain stays warm — no shared-queue round-trip, no wakeup. The
+        // local-cell path is invisible to the spin coordinator; the
+        // same worker drains it on its next loop.
+        //
+        // Otherwise (not a pool thread, or the cell is full — fan-out
+        // spill), push to the shared queue and notify the coordinator
+        // (iamacoffeepot/aether#1064): it routes to a spinning worker
+        // when one exists and only unparks a dormant worker when none
+        // is. A closed ready queue means the pool is shutting down —
+        // skip the notify.
+        if let Err(slot) = local_slot::try_stash_next(slot)
+            && self.sink.ready_tx.send(slot).is_ok()
+        {
+            self.sink.spin.notify();
         }
         true
     }
@@ -665,7 +687,8 @@ pub mod tests {
         let (ready_tx, ready_rx) = unbounded::<Arc<dyn Drainable>>();
         let slot = CounterSlot::new("wake");
         let weak: Weak<dyn Drainable> = Arc::downgrade(&(slot.clone() as Arc<dyn Drainable>));
-        let wake = WakeHandle::new(slot.state.clone(), weak, ready_tx);
+        let sink = WakeSink::new(ready_tx, Arc::new(SpinPark::new()));
+        let wake = WakeHandle::new(slot.state.clone(), weak, sink);
 
         // First wake should push.
         assert!(wake.wake());

--- a/crates/aether-substrate/src/scheduler/spin_park.rs
+++ b/crates/aether-substrate/src/scheduler/spin_park.rs
@@ -1,0 +1,393 @@
+//! Spin-then-park worker coordinator — route-to-spinner dispatch
+//! (iamacoffeepot/aether#1064).
+//!
+//! Replaces the worker's blocking `recv(ready_rx)` park with a
+//! self-managed two-phase wait: a bounded **spin** phase (the worker
+//! keeps scanning the ready queue, staying warm) followed by a
+//! **park** phase (the worker blocks on its own thread token). The
+//! point of taking ownership of the park is the producer-side gate:
+//!
+//! - With crossbeam's blocking `recv`, *every* `send` futex-wakes a
+//!   blocked receiver (~4.3µs), regardless of whether another worker
+//!   was already awake and able to pick the work up.
+//! - Here, workers never block on the queue. A producer that just
+//!   pushed work calls [`SpinPark::notify`], which **skips the unpark
+//!   entirely when a worker is already spinning** — the spinner will
+//!   scan the freshly-pushed slot with no futex involved. Only the
+//!   genuine idle → first-event edge (no spinner available) pays a
+//!   wakeup.
+//!
+//! This is the "route-to-spinner" lever. It differs from the
+//! uncoordinated spin-before-park already tried and rejected
+//! (iamacoffeepot/aether#1059): there the worker spun but the producer
+//! still went through crossbeam's wake path, so the pool paid the spin
+//! CPU *and* the wakeup. The win requires spin **with** the producer
+//! consulting the spin count, not spin alone.
+//!
+//! ## Lost-wakeup safety
+//!
+//! The producer (`push; notify`) and a worker deciding to park
+//! (`stop spinning; recheck; park`) form a classic `StoreLoad` race: if
+//! the producer reads "a spinner exists" and skips the unpark, but
+//! that spinner simultaneously stops spinning and parks without seeing
+//! the work, the slot is stranded with every worker asleep.
+//!
+//! Two rules close it:
+//!
+//! 1. **Symmetric `SeqCst` fences.** The producer does
+//!    `push → fence(SeqCst) → load(spinning)`; a parking worker does
+//!    `store(spinning) → fence(SeqCst) → rescan`. The two fences are
+//!    totally ordered, so at least one side observes the other's store
+//!    (Dekker): either the producer sees the decremented count and
+//!    unparks, or the worker's rescan sees the pushed work. The queue's
+//!    own acquire/release ops compose with the fences, so a scan
+//!    ordered after both fences sees a push ordered before both.
+//! 2. **Register-before-decrement.** A worker about to park pushes its
+//!    thread handle into the idle list *before* it decrements
+//!    `spinning`. So at the instant the count reaches zero, the worker
+//!    is already visible to a producer's `notify` pop — there is no
+//!    window where the count is zero but the worker is unreachable.
+//!
+//! The producer-side `notify` fast path (a spinner exists) takes no
+//! lock; only the slow path (no spinner → must unpark a specific parked
+//! worker) touches the idle-list mutex. Parking is the path we optimise
+//! *away*, so a lock there is fine.
+
+use std::hint;
+use std::sync::PoisonError;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering, fence};
+use std::sync::{Mutex, MutexGuard};
+use std::thread::{self, Thread, ThreadId};
+use std::time::{Duration, Instant};
+
+/// Default spin-window length. The issue calls for "tens of µs": long
+/// enough to absorb a fan-out spill or a back-to-back relay hop without
+/// a futex wake, short enough that the idle tail between frames parks
+/// quickly. Overridable per [`SpinPark::with_spin_window`] (the chassis
+/// reads `AETHER_SPIN_WINDOW_USEC` so the latency sweep can retune
+/// without a recompile).
+pub const DEFAULT_SPIN_WINDOW_USEC: u64 = 50;
+
+/// How often (in spin iterations) to re-read the wallclock. Reading
+/// `Instant::now()` every iteration would dominate the loop; sampling
+/// every `CLOCK_CHECK_STRIDE` iterations keeps the window bound tight
+/// enough (the stride is a few hundred ns of polling) while leaving the
+/// scan as the hot operation.
+const CLOCK_CHECK_STRIDE: u32 = 64;
+
+/// What [`SpinPark::acquire`] resolved to.
+pub enum Acquired<T> {
+    /// A slot was scanned out of the ready queue.
+    Slot(T),
+    /// Shutdown was signalled; the worker should exit its loop.
+    Shutdown,
+}
+
+/// Shared spin/park coordinator. One per [`crate::scheduler::Pool`],
+/// held in an `Arc` and shared by every worker (the wait side) and by
+/// every [`crate::scheduler::WakeHandle`] (the notify side).
+#[derive(Debug)]
+pub struct SpinPark {
+    /// Workers currently in the spin phase (running, scanning the ready
+    /// queue) — *not* parked, *not* processing. The route-to-spinner
+    /// gate reads this: a producer that observes `spinning > 0` skips
+    /// the unpark.
+    spinning: AtomicUsize,
+    /// Thread handles of currently-parked workers, available to unpark.
+    /// Only the notify slow path (no spinner) and the park path touch
+    /// it — the fast path never locks.
+    idle: Mutex<Vec<Thread>>,
+    /// Set once at chassis teardown; observed by workers in both the
+    /// spin loop and the park-commit recheck so they exit promptly.
+    shutdown: AtomicBool,
+    /// Bounded spin window — see [`DEFAULT_SPIN_WINDOW_USEC`].
+    spin_window: Duration,
+}
+
+impl SpinPark {
+    /// Construct with the default spin window.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_spin_window(Duration::from_micros(DEFAULT_SPIN_WINDOW_USEC))
+    }
+
+    /// Construct with an explicit spin window (chassis env override /
+    /// tests).
+    #[must_use]
+    pub fn with_spin_window(spin_window: Duration) -> Self {
+        Self {
+            spinning: AtomicUsize::new(0),
+            idle: Mutex::new(Vec::new()),
+            shutdown: AtomicBool::new(false),
+            spin_window,
+        }
+    }
+
+    fn idle(&self) -> MutexGuard<'_, Vec<Thread>> {
+        // A handler panic never unwinds while the idle lock is held
+        // (the lock is only taken for the push/pop/remove book-keeping
+        // here, never across a `run_cycle`), so poisoning shouldn't
+        // happen — but recover rather than propagate so a poisoned lock
+        // can't wedge the whole pool.
+        self.idle.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Producer side: call **after** pushing a slot onto the ready
+    /// queue. Wakes a parked worker only if no worker is currently
+    /// spinning (route-to-spinner). See the module docs for why the
+    /// fence + register-before-decrement discipline makes this
+    /// lost-wakeup-safe.
+    pub fn notify(&self) {
+        // StoreLoad barrier: the caller's queue push is sequenced before
+        // this fence; the `spinning` load is sequenced after it. Paired
+        // with the parking worker's fence (between its `spinning` store
+        // and its rescan), this guarantees at least one side observes
+        // the other.
+        fence(Ordering::SeqCst);
+        if self.spinning.load(Ordering::Relaxed) != 0 {
+            // A spinner is scanning; it will pick the slot up with no
+            // futex wake. This is the win.
+            return;
+        }
+        // No spinner — wake one parked worker, if any. If none are
+        // parked either, every worker is processing and will rescan
+        // when it finishes its current cycle. Bind the pop result so the
+        // idle-list guard is released before the `unpark` (and isn't a
+        // live temporary across the `if let`).
+        let parked = self.idle().pop();
+        if let Some(t) = parked {
+            t.unpark();
+        }
+    }
+
+    /// Worker side: wait for work. The caller has already tried its
+    /// worker-local affinity cell and one non-blocking `scan`; this
+    /// runs the spin-then-park loop until `scan` yields a slot or
+    /// shutdown is signalled.
+    ///
+    /// `scan` is the non-blocking ready-queue probe (e.g.
+    /// `|| ready_rx.try_recv().ok()`). It is called repeatedly; it must
+    /// be cheap and must not block.
+    pub fn acquire<T, F: Fn() -> Option<T>>(&self, scan: F) -> Acquired<T> {
+        loop {
+            if self.shutdown.load(Ordering::Acquire) {
+                return Acquired::Shutdown;
+            }
+
+            // Spin phase: stay warm, scanning the ready queue.
+            self.spinning.fetch_add(1, Ordering::Relaxed);
+            // Pair with the producer's notify fence: a producer that
+            // pushed before our entry fence is visible to the scans
+            // below.
+            fence(Ordering::SeqCst);
+            let found = self.spin(&scan);
+            if let Some(slot) = found {
+                self.spinning.fetch_sub(1, Ordering::Relaxed);
+                return Acquired::Slot(slot);
+            }
+
+            // Park-commit: register in the idle list BEFORE decrementing
+            // `spinning`, so the instant the count can read zero we are
+            // already reachable by a producer's `notify` pop.
+            let me = thread::current();
+            self.idle().push(me.clone());
+            self.spinning.fetch_sub(1, Ordering::Relaxed);
+            // StoreLoad barrier mirroring the producer's: our `spinning`
+            // store is before this fence, the recheck scan is after it.
+            fence(Ordering::SeqCst);
+            if let Some(slot) = scan() {
+                self.remove_idle(me.id());
+                return Acquired::Slot(slot);
+            }
+            if self.shutdown.load(Ordering::Acquire) {
+                self.remove_idle(me.id());
+                return Acquired::Shutdown;
+            }
+
+            // Genuinely idle: block. `thread::park` may return
+            // spuriously and the unpark token is sticky (a notify that
+            // raced ahead of this call returns immediately), so the
+            // outer loop re-spins and rescans on every wake — no wakeup
+            // is lost to a spurious return.
+            thread::park();
+            self.remove_idle(me.id());
+        }
+    }
+
+    /// The bounded spin: scan until a slot turns up, the window
+    /// elapses, or shutdown. Returns the slot if found.
+    fn spin<T, F: Fn() -> Option<T>>(&self, scan: &F) -> Option<T> {
+        let deadline = Instant::now() + self.spin_window;
+        let mut i: u32 = 0;
+        loop {
+            if let Some(slot) = scan() {
+                return Some(slot);
+            }
+            i = i.wrapping_add(1);
+            if i.is_multiple_of(CLOCK_CHECK_STRIDE)
+                && (self.shutdown.load(Ordering::Relaxed) || Instant::now() >= deadline)
+            {
+                return None;
+            }
+            hint::spin_loop();
+        }
+    }
+
+    fn remove_idle(&self, id: ThreadId) {
+        let mut idle = self.idle();
+        if let Some(pos) = idle.iter().position(|t| t.id() == id) {
+            idle.swap_remove(pos);
+        }
+    }
+
+    /// Signal shutdown. Workers observe the flag in the spin loop and
+    /// the park-commit recheck; any already blocked in `thread::park`
+    /// are released by the caller unparking every worker thread
+    /// (the [`crate::scheduler::Pool`] holds the join handles and
+    /// unparks them on teardown).
+    pub fn set_shutdown(&self) {
+        self.shutdown.store(true, Ordering::Release);
+    }
+}
+
+impl Default for SpinPark {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: a failed recv/join is the assertion"
+)]
+mod tests {
+    use super::*;
+    use crossbeam_channel::{Receiver, Sender, unbounded};
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicU64;
+
+    /// `notify` with a spinner present must not pop the idle list —
+    /// the spinner is trusted to scan. With no spinner it pops and
+    /// unparks a registered worker.
+    #[test]
+    fn notify_skips_unpark_when_spinning() {
+        let coord = SpinPark::new();
+        // Pretend a worker is spinning and another is parked.
+        coord.spinning.fetch_add(1, Ordering::Relaxed);
+        coord.idle().push(thread::current());
+
+        coord.notify();
+        // Spinner present → idle list untouched.
+        assert_eq!(coord.idle().len(), 1, "notify must not pop while spinning");
+
+        // Spinner leaves; now notify must route to the parked worker.
+        coord.spinning.fetch_sub(1, Ordering::Relaxed);
+        coord.notify();
+        assert_eq!(coord.idle().len(), 0, "notify must pop when no spinner");
+        // We unparked ourselves; consume the sticky token so it doesn't
+        // leak into a later `park` in this test thread.
+        thread::park_timeout(Duration::from_millis(0));
+    }
+
+    /// Shutdown signalled while a worker is in `acquire` resolves to
+    /// `Shutdown` rather than hanging.
+    #[test]
+    fn acquire_resolves_shutdown() {
+        let coord = Arc::new(SpinPark::with_spin_window(Duration::from_micros(50)));
+        let c2 = Arc::clone(&coord);
+        let worker =
+            thread::spawn(move || matches!(c2.acquire(|| None::<u32>), Acquired::Shutdown));
+        // Let it cycle into the park, then signal + unpark.
+        thread::sleep(Duration::from_millis(20));
+        coord.set_shutdown();
+        worker.thread().unpark();
+        assert!(worker.join().unwrap(), "acquire should resolve Shutdown");
+    }
+
+    /// Lost-wakeup stress: many producers push tokens onto a shared
+    /// queue + `notify`; many workers `acquire`-drain. Every pushed
+    /// token must be consumed exactly once — a stranded token (work in
+    /// the queue, all workers parked, no pending unpark) hangs the
+    /// drain and trips the timeout. This is the highest-risk surface;
+    /// the `flaky_` wrapper below is the soak target.
+    fn lost_wakeup_stress() {
+        const WORKERS: usize = 6;
+        const PRODUCERS: usize = 4;
+        const PER_PRODUCER: u64 = 5_000;
+
+        let coord = Arc::new(SpinPark::with_spin_window(Duration::from_micros(30)));
+        let (tx, rx): (Sender<u64>, Receiver<u64>) = unbounded();
+        let consumed = Arc::new(AtomicU64::new(0));
+        let total = PRODUCERS as u64 * PER_PRODUCER;
+
+        let workers: Vec<_> = (0..WORKERS)
+            .map(|_| {
+                let coord = Arc::clone(&coord);
+                let rx = rx.clone();
+                let consumed = Arc::clone(&consumed);
+                thread::spawn(move || {
+                    loop {
+                        match coord.acquire(|| rx.try_recv().ok()) {
+                            Acquired::Slot(_) => {
+                                consumed.fetch_add(1, Ordering::Relaxed);
+                            }
+                            Acquired::Shutdown => return,
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        let producers: Vec<_> = (0..PRODUCERS)
+            .map(|p| {
+                let coord = Arc::clone(&coord);
+                let tx = tx.clone();
+                thread::spawn(move || {
+                    for n in 0..PER_PRODUCER {
+                        tx.send(p as u64 * PER_PRODUCER + n).unwrap();
+                        coord.notify();
+                    }
+                })
+            })
+            .collect();
+        for p in producers {
+            p.join().unwrap();
+        }
+
+        // Wait for full drain — a lost wakeup strands the tail and this
+        // times out.
+        let start = Instant::now();
+        while consumed.load(Ordering::Relaxed) < total {
+            assert!(
+                start.elapsed() < Duration::from_secs(10),
+                "drain stalled at {}/{} — likely a lost wakeup",
+                consumed.load(Ordering::Relaxed),
+                total,
+            );
+            thread::sleep(Duration::from_millis(5));
+        }
+
+        coord.set_shutdown();
+        for w in &workers {
+            w.thread().unpark();
+        }
+        for w in workers {
+            w.join().unwrap();
+        }
+        assert_eq!(consumed.load(Ordering::Relaxed), total);
+    }
+
+    #[test]
+    fn lost_wakeup_stress_once() {
+        lost_wakeup_stress();
+    }
+
+    /// Flake-soak wrapper (iamacoffeepot/aether#1064). `scripts/flake-soak.sh`
+    /// re-runs the lost-wakeup stress in fresh processes to catch the
+    /// `StoreLoad` race that a single green run can mask.
+    #[test]
+    fn flaky_lost_wakeup_stress() {
+        lost_wakeup_stress();
+    }
+}


### PR DESCRIPTION
## Summary

First sub-branch of the spin-until-settlement experiment (iamacoffeepot/aether#1064). Replaces the worker pool's blocking `recv(ready_rx)` park with a self-managed **spin-then-park coordinator** (`SpinPark`) and a producer-side **route-to-spinner** gate:

- Workers spin a bounded window (default 50µs, `AETHER_SPIN_WINDOW_USEC`) scanning the ready queue before parking.
- A producer that just enqueued work consults the spin count and **skips the futex unpark when a worker is already spinning** — the spinner picks the slot up with no wakeup. Only the genuine idle → first-event edge pays a cold wake.
- This differs from the uncoordinated spin-before-park already tried and rejected in iamacoffeepot/aether#1059: the win needs spin **with** the producer consulting the spin count, not spin alone.

The iamacoffeepot/aether#1059 worker-local affinity cell is untouched — same-worker relay hops still bypass the coordinator. Shutdown moves from the dropped `select!` channel to a coordinator flag + an explicit unpark of every worker.

**Lost-wakeup safety** (the highest-risk surface): symmetric `SeqCst` fences (producer `push → fence → load`; worker `store → fence → rescan`) plus registering in the idle list *before* decrementing the spin count close the StoreLoad race. Settlement exactness is untouched — spinning is a read-only hint.

## Measurement (full results on iamacoffeepot/aether#1064)

Against the post-iamacoffeepot/aether#1063 baseline, 3 runs, median p50:

- **Win:** multi-worker fan-out spill — fanout-8 idle HOP p50 17.8µs → 10.1µs at 11 workers (−43%), scaling with branch factor.
- **No regression:** warm serial path (depth-8) stays at the ~1.3µs floor — the affinity cell survives the park rewrite.
- **Wake is clean:** measured ~once per participating thread per barrier (depth-8 = 8 mails, ~1.17 cold wakes), not per mail.
- Cold single-hop entry is unchanged (unhelpable — no warm spinner on a cold engine), and the spill *tail* is flat.

It is a **narrow win on an already-well-optimised path**, not a fix for something broken. Per the experiment's own kill criteria it is not yet promotion-worthy — promotion to `main` waits on a real workload that is actually pressured by multi-worker fan-out.

## Scope

Lands on the `experiment/spin-until-settlement` **trunk**, not `main` — per the experiment's branching model (sub-branches merge into the trunk; `main` stays clean until a single promotion PR or the trunk is abandoned).

## Test plan

- [x] 281-test substrate suite green
- [x] 200× flaky-soak on the three concurrent scheduler tests (lost-wakeup, multi-worker stress, relay chain) in fresh processes
- [x] 40× settlement-integration soak
- [x] `scripts/preflight.sh` green (fmt + clippy + doc + 1200-test workspace nextest + wasm32 cross-build)
