### PR TITLE
perf(substrate/scheduler): skip per-hop budget clock reads on warm cycles

### DIFF
--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -295,6 +295,7 @@ where
         };
 
         let mut dispatched = 0u32;
+        let mut cycle_start: Option<Instant> = None;
         let mut shutdown_observed = false;
         let mut budget_hit = false;
         let mut inbox_empty = false;
@@ -309,9 +310,23 @@ where
             };
             self.dispatch_one(actor, env);
             dispatched += 1;
-            if dispatched >= budget.max_mails || Instant::now() >= budget.deadline {
+            // Count cap: hard backstop, checked every dispatch with no
+            // clock read (iamacoffeepot/aether#1067).
+            if dispatched >= budget.max_mails {
                 budget_hit = true;
                 break;
+            }
+            // Time cap: only read the clock once batching past the
+            // stride, so a warm single/few-mail cycle (which drains to
+            // empty first) never touches the clock. The deadline is
+            // measured from the first checked mail — a fairness
+            // backstop, not a hard cycle deadline.
+            if dispatched.is_multiple_of(crate::scheduler::CLOCK_CHECK_STRIDE) {
+                let start = *cycle_start.get_or_insert_with(Instant::now);
+                if start.elapsed() >= budget.max_dur {
+                    budget_hit = true;
+                    break;
+                }
             }
         }
 

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -78,7 +78,7 @@ use crate::actor::native::{NativeActor, NativeDispatch};
 use crate::actor::registry::ActorRegistry;
 use crate::mail::mailer::Mailer;
 use crate::mail::{KindId, Mail, MailboxId, ReplyTo};
-use crate::scheduler::{BatchBudget, CycleResult, Drainable, SlotState};
+use crate::scheduler::{BatchBudget, CLOCK_CHECK_STRIDE, CycleResult, Drainable, SlotState};
 
 /// Worker-pool-side wrapper for a native actor. One instance per
 /// `Pooled` actor; held strongly by the chassis (so `unwire` and
@@ -321,7 +321,7 @@ where
             // empty first) never touches the clock. The deadline is
             // measured from the first checked mail — a fairness
             // backstop, not a hard cycle deadline.
-            if dispatched.is_multiple_of(crate::scheduler::CLOCK_CHECK_STRIDE) {
+            if dispatched.is_multiple_of(CLOCK_CHECK_STRIDE) {
                 let start = *cycle_start.get_or_insert_with(Instant::now);
                 if start.elapsed() >= budget.max_dur {
                     budget_hit = true;

--- a/crates/aether-substrate/src/scheduler/mod.rs
+++ b/crates/aether-substrate/src/scheduler/mod.rs
@@ -40,7 +40,7 @@ mod spin_park;
 
 pub use pool::{Pool, PoolConfig, PoolHandle, PoolWorkerJoin};
 pub use slot::{
-    BATCH_MAX_MAILS, BATCH_MAX_USEC, BatchBudget, CycleResult, DrainOutcome, Drainable, SlotState,
-    SlotStateLabel, WakeHandle, WakeSink,
+    BATCH_MAX_MAILS, BATCH_MAX_USEC, BatchBudget, CLOCK_CHECK_STRIDE, CycleResult, DrainOutcome,
+    Drainable, SlotState, SlotStateLabel, WakeHandle, WakeSink,
 };
 pub use spin_park::{Acquired, SpinPark};

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -31,7 +31,9 @@
 use std::any::Any;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::{Arc, Weak};
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(test)]
+use std::time::Instant;
 
 use crossbeam_channel::Sender;
 
@@ -49,6 +51,13 @@ pub const BATCH_MAX_MAILS: u32 = 64;
 /// it; the cap is a fairness backstop, not a hard deadline). Tunable
 /// in Phase 2.
 pub const BATCH_MAX_USEC: u64 = 200;
+
+/// Check the wallclock deadline only every Nth dispatch (iamacoffeepot/aether#1067).
+/// A warm single/few-mail cycle drains to empty before reaching the
+/// stride, so it never reads the clock; the time cap still engages once
+/// a slot is genuinely batching. The count cap (`BATCH_MAX_MAILS`) is
+/// the hard backstop and is checked every dispatch (no clock).
+pub const CLOCK_CHECK_STRIDE: u32 = 8;
 
 /// `Idle`: inbox empty, slot is not in the ready queue.
 const STATE_IDLE: u8 = 0;
@@ -162,9 +171,12 @@ pub enum SlotStateLabel {
 pub struct BatchBudget {
     /// Max number of envelopes to dispatch this cycle.
     pub max_mails: u32,
-    /// Wallclock deadline. The slot stops draining once `Instant::now()`
-    /// is past this point (checked between envelopes).
-    pub deadline: Instant,
+    /// Max wallclock duration for the drain cycle. The slot computes a
+    /// deadline lazily from this (only once it is batching past
+    /// [`CLOCK_CHECK_STRIDE`]), so constructing a budget no longer reads
+    /// the clock and a warm single-mail cycle never does either
+    /// (iamacoffeepot/aether#1067).
+    pub max_dur: Duration,
 }
 
 impl BatchBudget {
@@ -179,7 +191,7 @@ impl BatchBudget {
     pub fn custom(max_mails: u32, max_duration: Duration) -> Self {
         Self {
             max_mails,
-            deadline: Instant::now() + max_duration,
+            max_dur: max_duration,
         }
     }
 }
@@ -480,6 +492,7 @@ pub mod tests {
                 self.label
             );
 
+            let deadline = Instant::now() + budget.max_dur;
             let outcome = loop {
                 if self.closed.load(Ordering::Acquire) && self.inbox_is_empty() {
                     break DrainOutcome::Closed;
@@ -490,7 +503,7 @@ pub mod tests {
                 self.drain_one(env);
                 let dispatched_this_cycle =
                     self.dispatched.load(Ordering::Acquire) % budget.max_mails.max(1);
-                if dispatched_this_cycle == 0 || Instant::now() >= budget.deadline {
+                if dispatched_this_cycle == 0 || Instant::now() >= deadline {
                     // Mail count or wallclock budget hit. Yield.
                     break DrainOutcome::Yielded;
                 }


### PR DESCRIPTION
## Summary

First step of iamacoffeepot/aether#1067 (cut warm per-hop dispatch overhead). The per-cycle drain budget read the monotonic clock **twice** on the warm path — once constructing the budget (`BatchBudget::custom` precomputed an absolute `deadline: Instant`) and once per dispatch (`run_cycle`'s `Instant::now() >= deadline` check). A warm single/few-mail cycle drains to empty before either cap matters, so both reads were pure overhead.

- `BatchBudget` now carries `max_dur: Duration` instead of a precomputed deadline — constructing a budget no longer touches the clock.
- `run_cycle` checks the time cap only every `CLOCK_CHECK_STRIDE` (8) dispatches, computing the deadline lazily from the first checked mail. A warm single-mail cycle reads the clock **zero** times.
- The count cap (`BATCH_MAX_MAILS`) stays the hard backstop, checked every dispatch with no clock. The time cap still engages once a slot is genuinely batching — a slot can run up to the stride past the deadline before yielding, a bounded fairness backstop rather than a hard deadline.

## Measured impact

Dispatch-path timestamp probes, 1 worker, warm relay loop, ~19.7M hops:

| region | before | after |
|---|---|---|
| scheduler glue (acquire + budget + run_cycle) | 182.6 ns | **125.5 ns** |

−57 ns / −31% on the scheduler-glue region (the two budget clock reads). No change to the count cap or to settlement (the budget governs only when a slot yields mid-drain; mail lineage / in_flight accounting is untouched).

## Test plan
- [x] `scripts/preflight.sh` green (fmt + clippy `-D warnings` + doc + 1200-test nextest + wasm32 cross-build)
- [x] scheduler + slot unit tests pass (incl. the count-cap and post-empty-recheck tests)
- [ ] main CI green (Clippy + Qodana fresh-index)