### PR TITLE
perf(substrate/mail): fold route_mail's registry reads into one guard

### DIFF
--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -474,10 +474,24 @@ fn route_mail(
         return;
     }
 
-    if let Some(descriptor) = registry.kind_descriptor(mail.kind)
-        && handle_store::schema_contains_ref(&descriptor.schema)
-    {
-        match handle_store::walk_and_resolve(&descriptor.schema, &mail.payload, store) {
+    let recipient = mail.recipient;
+    let inbound_mail_id = mail.mail_id;
+    let inbound_root = mail.root;
+
+    // One read guard resolves the recipient entry, the kind name, and
+    // whether the kind needs ADR-0045 handle resolution. `route_mail`
+    // previously took three separate registry reads (descriptor + entry
+    // + name) and cloned the whole descriptor every mail just to run the
+    // ref check; the cached `has_ref` behind `route_lookup` keeps the
+    // common no-ref path clone-free.
+    let lookup = registry.route_lookup(mail.kind, recipient);
+
+    // ADR-0045: kinds whose schema embeds a `Ref` get their handles
+    // resolved against the store before delivery; everything else flows
+    // through with the original bytes. `ref_schema` is `Some` only on
+    // that ref-carrying path.
+    if let Some(schema) = &lookup.ref_schema {
+        match handle_store::walk_and_resolve(schema, &mail.payload, store) {
             Ok(WalkOutcome::Resolved { payload }) => {
                 if let Cow::Owned(bytes) = payload {
                     mail.payload = bytes;
@@ -514,12 +528,8 @@ fn route_mail(
         }
     }
 
-    let recipient = mail.recipient;
-    let inbound_mail_id = mail.mail_id;
-    let inbound_root = mail.root;
-    match registry.entry(recipient) {
+    match lookup.entry {
         Some(MailboxEntry::Inbox(handler)) => {
-            let kind_name = registry.kind_name(mail.kind).unwrap_or_default();
             // Mail reaching a closure-bound mailbox through `push`
             // came from substrate core or a chassis (e.g. the frame
             // loop's FrameStats push, platform input fan-out). Per
@@ -550,7 +560,7 @@ fn route_mail(
             // copies.
             handler.enqueue(OwnedDispatch {
                 kind: mail.kind,
-                kind_name,
+                kind_name: lookup.kind_name,
                 origin: None,
                 sender: mail.reply_to,
                 payload: mail.payload,
@@ -561,7 +571,6 @@ fn route_mail(
             });
         }
         Some(MailboxEntry::Inline(handler)) => {
-            let kind_name = registry.kind_name(mail.kind).unwrap_or_default();
             // ADR-0080 §2 producer hook: synchronous handler.
             // Bracket the inline call with `Received`/`Finished`
             // so the chain's `in_flight` balances and settlement
@@ -573,7 +582,7 @@ fn route_mail(
             trace_handle.record_received(inbound_mail_id, inbound_root, thread_name);
             handler.dispatch(MailDispatch {
                 kind: mail.kind,
-                kind_name: &kind_name,
+                kind_name: &lookup.kind_name,
                 origin: None,
                 sender: mail.reply_to,
                 payload: &mail.payload,

--- a/crates/aether-substrate/src/mail/registry.rs
+++ b/crates/aether-substrate/src/mail/registry.rs
@@ -22,6 +22,7 @@ use std::sync::{Arc, RwLock};
 
 use rustc_hash::FxHashMap;
 
+use crate::handle_store::schema_contains_ref;
 use crate::mail::{KindId, MailId, MailboxId, ReplyTo};
 use std::error;
 
@@ -342,10 +343,25 @@ struct Mailbox {
     entry: MailboxEntry,
 }
 
+/// Everything [`Registry::route_lookup`] hands `route_mail` for one
+/// mail, resolved under a single read guard. `ref_schema` is `Some`
+/// only when the kind embeds a `Ref` (its cached `has_ref`); see the
+/// method doc.
+pub(crate) struct RouteLookup {
+    pub(crate) entry: Option<MailboxEntry>,
+    pub(crate) kind_name: String,
+    pub(crate) ref_schema: Option<SchemaType>,
+}
+
 /// One kind's bookkeeping, keyed in the registry on the hashed id.
 struct KindSlot {
     name: String,
     descriptor: KindDescriptor,
+    /// `schema_contains_ref(&descriptor.schema)`, computed once at
+    /// registration. The route path reads this bool instead of cloning
+    /// the descriptor and re-walking the schema tree per mail just to
+    /// decide whether ADR-0045 handle resolution is needed.
+    has_ref: bool,
 }
 
 #[derive(Default)]
@@ -748,6 +764,40 @@ impl Registry {
             .map(|m| m.entry.clone())
     }
 
+    /// Hot-path combined lookup for the mailer's route step: resolves
+    /// the recipient's [`MailboxEntry`], the kind's name, and whether
+    /// the kind needs ADR-0045 handle resolution — all under a single
+    /// read guard, where `route_mail` previously took three separate
+    /// reads (`kind_descriptor` + `entry` + `kind_name`).
+    ///
+    /// Like [`entry`](Self::entry), everything is cloned out so the
+    /// caller drops the lock before touching a handler. The common case
+    /// clones only the (cheap) kind name + entry: `ref_schema` is `Some`
+    /// **iff** the kind's schema embeds a `Ref` (the cached `has_ref`),
+    /// so the schema is cloned only on the rare ref-carrying path rather
+    /// than every mail.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063.
+    pub(crate) fn route_lookup(&self, kind: KindId, recipient: MailboxId) -> RouteLookup {
+        let inner = self
+            .inner
+            .read()
+            .expect("registry lock poisoned; fail-fast per ADR-0063");
+        let kind_slot = inner.kinds.get(&kind);
+        let kind_name = kind_slot.map(|s| s.name.clone()).unwrap_or_default();
+        let ref_schema = kind_slot
+            .filter(|s| s.has_ref)
+            .map(|s| s.descriptor.schema.clone());
+        let entry = inner.mailboxes.get(&recipient).map(|m| m.entry.clone());
+        RouteLookup {
+            entry,
+            kind_name,
+            ref_schema,
+        }
+    }
+
     /// Reverse of `lookup`: name for a given mailbox id, or `None` if
     /// the id is unknown. Used by the closure dispatch path to stamp
     /// `origin` on observation mail (ADR-0011).
@@ -849,11 +899,13 @@ impl Registry {
             return Ok(id);
         }
         inner.name_index.insert(descriptor.name.clone(), id);
+        let has_ref = schema_contains_ref(&descriptor.schema);
         inner.kinds.insert(
             id,
             KindSlot {
                 name: descriptor.name.clone(),
                 descriptor,
+                has_ref,
             },
         );
         Ok(id)


### PR DESCRIPTION
## Summary

Iteration 3 of the dispatch-glue series (iamacoffeepot/aether#1067), on top of the merged FxHash change (iamacoffeepot/aether#1070).

`route_mail` resolved the recipient entry, the kind name, and the ADR-0045 ref-check through three separate `Registry` methods — each taking its own read lock — and `kind_descriptor` cloned the whole descriptor (name `String` + schema tree) on **every** mail just to run `schema_contains_ref` and discard it on the common no-Ref path.

- **`has_ref` cached at registration.** The ref-check answer is fixed once a kind's schema is, so it's computed once in `register_kind_internal` and stored as a `bool` in `KindSlot`.
- **Single read guard.** New `Registry::route_lookup(kind, recipient)` resolves entry + kind name + ref-need under one `inner.read()` hold (was three). The schema is cloned only on the rare Ref-carrying path (`ref_schema` is `Some` iff `has_ref`).

Same walk, same parking, same handle resolution — only the per-mail "do I need to check?" gate moves to registration. No path regresses; even the bubble-to-hub `None` path drops a lock acquire net.

## Measured

Hot microbench: `RwLock` read acquire+release ~7.6 ns, kind-name `String::clone` ~20.7 ns. For the common native kinds (`Tick`, `DrawTriangle`, every frame):

| component | saving / mail |
|---|---|
| lock-fold (3 reads -> 1) | ~15 ns |
| clone-kill (descriptor clone) | ~20 ns |
| walk-kill | ~1 ns |
| **total (native kind)** | **~36 ns** |

More for component-defined kinds — their `descriptor.clone()` is a full schema-tree deep copy (postcard-decoded `Owned`), not the `Cow::Borrowed` pointer copies native kinds get.

## Test plan
- [x] `scripts/preflight.sh` — fmt + clippy + doc + nextest (1200 passed, 6 skipped) + wasm32 component cross-build
- [x] 5 Ref-path mailer tests pass unchanged (ref-free passthrough, park-then-resolve, malformed-drop, parked-defers-finished, inline bracket)
- [x] RustRover inspection on `registry.rs` + `mailer.rs` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)