### PR TITLE
perf(substrate): bound the worker-local run-queue (AETHER_LOCAL_STICKY_MAX)

### DIFF
--- a/crates/aether-substrate/src/scheduler/local_slot.rs
+++ b/crates/aether-substrate/src/scheduler/local_slot.rs
@@ -1,25 +1,40 @@
-//! Per-worker "next slot" cell for chain affinity (iamacoffeepot/aether#1059).
+//! Per-worker local run-queue for chain + fan-out affinity (iamacoffeepot/aether#1059).
 //!
 //! When a handler running on a pool worker wakes a downstream actor's
 //! slot, the wake stashes it here instead of the shared ready queue, and
 //! the worker's `acquire_slot` checks here first. A relay chain therefore
 //! stays on one warm worker — no shared-queue round-trip and, crucially,
-//! no parked-sibling futex wake (~4.3µs). The cell holds at most one slot,
-//! so a fan-out spills its extras to the shared queue and stays parallel
-//! across workers.
+//! no parked-sibling futex wake (~4.3µs).
+//!
+//! The queue holds up to a **stickiness cap** slots
+//! (`AETHER_LOCAL_STICKY_MAX`, default `1`). At cap `1` this reproduces the
+//! original single-cell behaviour: the chain head stays local and every
+//! fan-out extra spills to the shared queue, so independent work
+//! parallelises across workers. A higher cap keeps fan-out *extras* on the
+//! same warm worker too — the producing worker drains them itself in
+//! sequence rather than scattering them to sibling workers that pick each
+//! child up cold. The latency harness showed warm fan-out getting *worse*
+//! with more workers (cross-worker handoff + cache-cold pickup outweighs the
+//! parallelism at trivial leaf widths); a cap > 1 trades that scatter for
+//! locality. A load-aware / trace-driven choice of *when* to spill rides on
+//! top of this mechanism later.
 //!
 //! Only pool-worker threads call [`mark_pool_worker`]; on any other thread
 //! (chassis main, the hub, the trace drainer) [`try_stash_next`] is a
 //! no-op and the wake falls through to the shared queue as before.
 
 use std::cell::{Cell, RefCell};
+use std::collections::VecDeque;
+use std::env;
 use std::sync::Arc;
+use std::sync::OnceLock;
 
 use crate::scheduler::slot::Drainable;
 
 thread_local! {
     static IS_POOL_WORKER: Cell<bool> = const { Cell::new(false) };
-    static NEXT_SLOT: RefCell<Option<Arc<dyn Drainable>>> = const { RefCell::new(None) };
+    static LOCAL_QUEUE: RefCell<VecDeque<Arc<dyn Drainable>>> =
+        const { RefCell::new(VecDeque::new()) };
 }
 
 /// Mark the current thread as a pool worker. Called once at the top of
@@ -28,19 +43,36 @@ pub fn mark_pool_worker() {
     IS_POOL_WORKER.with(|w| w.set(true));
 }
 
-/// Try to stash a just-woken slot for this worker to drain next. Returns
-/// `Ok(())` when stashed (the caller skips the shared queue), or
-/// `Err(slot)` to hand the slot back for the shared queue — either because
-/// this isn't a pool-worker thread, or the cell is already occupied (the
-/// fan-out spill path that keeps independent work parallel).
-pub fn try_stash_next(slot: Arc<dyn Drainable>) -> Result<(), Arc<dyn Drainable>> {
+/// Stickiness cap — the max number of slots a worker keeps in its local
+/// run-queue before spilling to the shared queue. Read once from
+/// `AETHER_LOCAL_STICKY_MAX`; values `< 1` and unparseable input fall back
+/// to `1` (the original single-cell behaviour, a no-op default).
+#[must_use]
+pub fn sticky_cap() -> usize {
+    static CAP: OnceLock<usize> = OnceLock::new();
+    *CAP.get_or_init(|| {
+        env::var("AETHER_LOCAL_STICKY_MAX")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&k| k >= 1)
+            .unwrap_or(1)
+    })
+}
+
+/// Try to stash a just-woken slot on this worker's local run-queue.
+/// Returns `Ok(())` when stashed (the caller skips the shared queue), or
+/// `Err(slot)` to hand the slot back for the shared queue — because this
+/// isn't a pool-worker thread, or the local queue already holds `cap`
+/// slots (the spill path that keeps independent work parallel). At
+/// `cap == 1` the chain head stays local and every fan-out extra spills.
+pub fn try_stash_next(slot: Arc<dyn Drainable>, cap: usize) -> Result<(), Arc<dyn Drainable>> {
     if !IS_POOL_WORKER.with(Cell::get) {
         return Err(slot);
     }
-    NEXT_SLOT.with(|cell| {
-        let mut cell = cell.borrow_mut();
-        if cell.is_none() {
-            *cell = Some(slot);
+    LOCAL_QUEUE.with(|q| {
+        let mut q = q.borrow_mut();
+        if q.len() < cap {
+            q.push_back(slot);
             Ok(())
         } else {
             Err(slot)
@@ -48,9 +80,80 @@ pub fn try_stash_next(slot: Arc<dyn Drainable>) -> Result<(), Arc<dyn Drainable>
     })
 }
 
-/// Take this worker's stashed next slot, if any. Checked before the shared
-/// queue and before the shutdown park, so a stashed slot is never
-/// stranded across a worker's loop iteration.
+/// Take this worker's next stashed slot (FIFO), if any. Checked before the
+/// shared queue and before the shutdown park, so a stashed slot is never
+/// stranded across a worker's loop iteration. The queue is only ever
+/// populated by *this* worker during its own `run_cycle`, so one pop per
+/// acquire suffices.
 pub fn take_next() -> Option<Arc<dyn Drainable>> {
-    NEXT_SLOT.with(|cell| cell.borrow_mut().take())
+    LOCAL_QUEUE.with(|q| q.borrow_mut().pop_front())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scheduler::slot::{BatchBudget, CycleResult, Drainable};
+    use std::any::Any;
+
+    struct Noop;
+    impl Drainable for Noop {
+        fn run_cycle(&self, _budget: BatchBudget) -> CycleResult {
+            CycleResult::Idle
+        }
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    fn noop() -> Arc<dyn Drainable> {
+        Arc::new(Noop)
+    }
+
+    /// Drain any residue so the per-thread queue starts empty regardless
+    /// of test scheduling order on a shared thread.
+    fn drain_local() {
+        while take_next().is_some() {}
+    }
+
+    #[test]
+    fn non_pool_thread_never_stashes() {
+        drain_local();
+        // This test never marks itself a pool worker (and runs on its own
+        // process under nextest), so the stash must spill regardless of cap.
+        assert!(try_stash_next(noop(), 4).is_err());
+        assert!(take_next().is_none());
+    }
+
+    #[test]
+    fn stash_respects_cap_and_drains_fifo() {
+        mark_pool_worker();
+        drain_local();
+
+        // cap 2: first two stash, the third spills.
+        assert!(try_stash_next(noop(), 2).is_ok());
+        assert!(try_stash_next(noop(), 2).is_ok());
+        assert!(
+            try_stash_next(noop(), 2).is_err(),
+            "third stash past cap 2 must spill"
+        );
+
+        // FIFO drain of the two stashed, then empty.
+        assert!(take_next().is_some());
+        assert!(take_next().is_some());
+        assert!(take_next().is_none());
+    }
+
+    #[test]
+    fn cap_one_reproduces_single_cell() {
+        mark_pool_worker();
+        drain_local();
+
+        assert!(try_stash_next(noop(), 1).is_ok());
+        assert!(
+            try_stash_next(noop(), 1).is_err(),
+            "cap 1 keeps only the chain head; the extra spills"
+        );
+        assert!(take_next().is_some());
+        assert!(take_next().is_none());
+    }
 }

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -303,15 +303,18 @@ fn worker_loop(
 /// then a `try_recv` fast path, then the spin-then-park coordinator.
 /// Returns `None` only on shutdown.
 ///
-/// The worker-local cell (iamacoffeepot/aether#1059) is the affinity
+/// The worker-local run-queue (iamacoffeepot/aether#1059) is the affinity
 /// lever: when a handler running on this worker wakes a downstream slot,
 /// that slot is stashed here instead of the shared queue, so a relay
 /// chain stays on the same warm worker and never pays the ~4.3µs
-/// parked-worker wakeup. The cell holds at most one slot — a fan-out
-/// spills its extras to the shared queue, so independent work still
-/// parallelises across workers. `take_next` is checked first so a
-/// stashed slot is never stranded; it can only be populated by *this*
-/// worker during its own `run_cycle`, so one check per acquire suffices.
+/// parked-worker wakeup. The queue holds up to the stickiness cap
+/// (`AETHER_LOCAL_STICKY_MAX`, default 1): at 1 the chain head stays local
+/// and a fan-out spills its extras to the shared queue (independent work
+/// parallelises across workers); higher keeps the fan-out extras local for
+/// the producing worker to drain in sequence, trading parallelism for
+/// locality. `take_next` is checked first so a stashed slot is never
+/// stranded; the queue can only be populated by *this* worker during its
+/// own `run_cycle`, so one pop per acquire suffices.
 ///
 /// When neither the cell nor a fast `try_recv` yields work, the
 /// coordinator (iamacoffeepot/aether#1064) takes over: it keeps the

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -356,18 +356,22 @@ impl WakeHandle {
             return false;
         };
         // Affinity (iamacoffeepot/aether#1059): if this wake runs on a
-        // pool worker, stash the slot in that worker's local cell so the
-        // chain stays warm — no shared-queue round-trip, no wakeup. The
-        // local-cell path is invisible to the spin coordinator; the
-        // same worker drains it on its next loop.
+        // pool worker, stash the slot in that worker's local run-queue so
+        // the chain stays warm — no shared-queue round-trip, no wakeup. The
+        // local path is invisible to the spin coordinator; the same worker
+        // drains it on its next loop. The queue holds up to the stickiness
+        // cap (`AETHER_LOCAL_STICKY_MAX`, default 1): at 1 the chain head
+        // stays local and every fan-out extra spills; higher keeps the
+        // fan-out extras local too, trading cross-worker parallelism for
+        // locality.
         //
-        // Otherwise (not a pool thread, or the cell is full — fan-out
+        // Otherwise (not a pool thread, or the local queue is full — fan-out
         // spill), push to the shared queue and notify the coordinator
         // (iamacoffeepot/aether#1064): it routes to a spinning worker
         // when one exists and only unparks a dormant worker when none
         // is. A closed ready queue means the pool is shutting down —
         // skip the notify.
-        if let Err(slot) = local_slot::try_stash_next(slot)
+        if let Err(slot) = local_slot::try_stash_next(slot, local_slot::sticky_cap())
             && self.sink.ready_tx.send(slot).is_ok()
         {
             self.sink.spin.notify();


### PR DESCRIPTION
## Summary

- Grows the per-worker affinity cell (`scheduler/local_slot.rs`) from a single slot to a bounded local run-queue, capped by `AETHER_LOCAL_STICKY_MAX`. The cap is read once; **the default of 1 reproduces the prior single-cell behaviour exactly** (chain head stays local, every fan-out extra spills) — a no-op default, opt-in only.
- A cap >= a fan-out's width keeps the extra children on the producing warm worker instead of scattering them to sibling workers that pick each child up cold — eliminating the cross-worker handoff that dominates warm fan-out cost.
- Chains and single-worker dispatch are unaffected by construction (a 1-wide hop never fills the cell past 1; one worker has nothing to scatter to).

## Why

The lifecycle latency harness (iamacoffeepot/aether#1072) showed warm ~= paced for fan-out, so the fan-out cost is **scatter** (cross-worker handoff + cache-cold pickup + shared-queue contention), not the parked-thread wakeup — which means the notify/trace batching originally floated in iamacoffeepot/aether#1073 isn't the lever; keeping a fan-out's idle children local is. "Skip busy children" is free: a `Running` child fails the `Idle -> Ready` wake CAS, so only idle children are stash candidates. No blocking, no settlement change — sends still emit `Sent` and enqueue as before; only *which worker drains the already-enqueued child* moves.

## Result (warm K-sweep, HOP tail at 11 workers)

| cell | K=1 (ground) | K >= width |
|---|--:|--:|
| fanout-4 p99 | 100.9 us | 5.8 us (K=4) |
| fanout-8 p99 | 167 us | 33 us (K=8) |
| fanout-8 max | 1634 us | 130 us (K=8) |

The win arrives exactly when cap >= fan-out width (fanout-2 at K>=2, fanout-4 at K>=4, fanout-8 at K>=8). Chains and 1-worker cells are flat across K. A **partial** cap (1 < cap < width) is the *worst* setting — some children serialize locally while the rest still scatter — so a useful cap is all-or-nothing relative to the fan-out width.

## Scope / caveats

- Validated for **trivial-leaf** fan-out only: the win exists because serially draining cheap children locally is free while the handoff is not. This does **not** justify a high default, and the default stays 1.
- A large cap is also self-defeating past a width-crossover (serial drain time `width x per-child-cost` overtakes the handoff): the parallel-heavy crossover is iamacoffeepot/aether#1074 and the wide-trivial width-crossover is iamacoffeepot/aether#1075.
- This is the local-run-queue substrate the future load-aware / trace-driven spill policy writes into (umbrella iamacoffeepot/aether#1059).

## Test plan

- [x] `scripts/preflight.sh` green (fmt + clippy + doc + nextest + wasm32; 1203 tests pass, 6 skipped)
- [x] 21 scheduler tests pass at default cap — new `local_slot` cap/FIFO unit tests, relay-chain affinity, cross-worker stress
- [x] Harness K-sweep reproduces the fan-out tail collapse at cap >= width with chains/1-worker flat

🤖 Generated with [Claude Code](https://claude.com/claude-code)