### PR TITLE
feat(substrate-bundle): perf-compare harness mode (trial JSON + paired comparison)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,7 @@ dependencies = [
  "pollster",
  "postcard",
  "serde",
+ "serde_json",
  "signal-hook",
  "thiserror 2.0.18",
  "tracing",

--- a/crates/aether-substrate-bundle/Cargo.toml
+++ b/crates/aether-substrate-bundle/Cargo.toml
@@ -32,6 +32,18 @@ path = "src/bin/hub.rs"
 name = "aether-substrate-test-bench"
 path = "src/bin/test-bench.rs"
 
+# Perf-comparison tooling (iamacoffeepot/aether#1077). `perf-trial` runs
+# one latency sweep and emits a TrialReport JSON; `perf-compare`
+# interleaves K base/candidate trials and renders the noise-aware paired
+# comparison (ADR-0085).
+[[bin]]
+name = "aether-perf-trial"
+path = "src/bin/perf-trial.rs"
+
+[[bin]]
+name = "aether-perf-compare"
+path = "src/bin/perf-compare.rs"
+
 [dependencies]
 aether-substrate = { path = "../aether-substrate", features = ["render", "audio"] }
 aether-capabilities = { path = "../aether-capabilities", features = ["render-native", "audio-native"] }
@@ -51,6 +63,8 @@ postcard = { version = "1.1", default-features = false, features = ["alloc"] }
 # server (issue 763 P5e) — the harness moved out-of-process into the
 # `aether-mcp` crate, which owns those deps now.
 serde = { version = "1", features = ["derive"] }
+# Trial reports + comparison output are JSON (perf tooling, #1077).
+serde_json = "1"
 # `test_bench::visual::ImageError` derives `thiserror::Error` (moved
 # from `aether-scenario` per issue 821). New runtime dep here because
 # `aether-substrate-bundle` had no prior thiserror consumer.

--- a/crates/aether-substrate-bundle/src/bin/perf-compare.rs
+++ b/crates/aether-substrate-bundle/src/bin/perf-compare.rs
@@ -1,0 +1,175 @@
+//! `perf-compare` (iamacoffeepot/aether#1077): interleave K base /
+//! candidate `perf-trial` runs on one runner and render the noise-aware
+//! paired comparison (ADR-0085) as a sticky-comment markdown body
+//! (stdout) plus an optional JSON report (`--out`).
+//!
+//! Base and candidate run on the *same* runner, interleaved trial by
+//! trial, so shared run-to-run drift cancels in the per-trial paired
+//! delta (ADR-0085 §3). Each side is invoked as a subprocess so every
+//! trial is a fresh process (§1).
+//!
+//! ```text
+//! # two checkouts (CI):
+//! aether-perf-compare --base ./base/perf-trial --cand ./pr/perf-trial -k 12 --out report.json
+//!
+//! # env A/B on one binary (the #1076 stickiness self-test):
+//! aether-perf-compare --base ./perf-trial --cand ./perf-trial \
+//!     --base-env AETHER_LOCAL_STICKY_MAX=1 --cand-env AETHER_LOCAL_STICKY_MAX=8 -k 12
+//! ```
+//!
+//! Informational, never gating: a comparison run exits 0 even with
+//! regressions present; a non-zero exit means an *operational* failure
+//! (a trial crashed, bad args). ADR-0085 §4.
+
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+
+use std::env;
+use std::fs;
+use std::process::{Command, ExitCode};
+
+use aether_substrate_bundle::perf::report::{CompareConfig, TrialReport, compare, markdown};
+
+struct Args {
+    base: String,
+    cand: String,
+    base_env: Vec<(String, String)>,
+    cand_env: Vec<(String, String)>,
+    k: usize,
+    out: Option<String>,
+    title: String,
+    subtitle: Option<String>,
+}
+
+fn split_kv(s: &str) -> Result<(String, String), String> {
+    let (k, v) = s
+        .split_once('=')
+        .ok_or_else(|| format!("env must be KEY=VALUE: {s}"))?;
+    Ok((k.to_owned(), v.to_owned()))
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut base = None;
+    let mut cand = None;
+    let mut base_env = Vec::new();
+    let mut cand_env = Vec::new();
+    let mut k = 12usize;
+    let mut out = None;
+    let mut title = "candidate vs base".to_owned();
+    let mut subtitle = None;
+
+    let mut it = env::args().skip(1);
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--base" => base = it.next(),
+            "--cand" => cand = it.next(),
+            "--base-env" => {
+                if let Some(kv) = it.next() {
+                    base_env.push(split_kv(&kv)?);
+                }
+            }
+            "--cand-env" => {
+                if let Some(kv) = it.next() {
+                    cand_env.push(split_kv(&kv)?);
+                }
+            }
+            "-k" | "--trials" => {
+                let n = it.next().ok_or("-k needs a value")?;
+                k = n.parse().map_err(|_| format!("bad -k: {n}"))?;
+            }
+            "--out" => out = it.next(),
+            "--title" => {
+                if let Some(t) = it.next() {
+                    title = t;
+                }
+            }
+            "--subtitle" => subtitle = it.next(),
+            other => return Err(format!("unknown arg: {other}")),
+        }
+    }
+    if k == 0 {
+        return Err("-k must be >= 1".to_owned());
+    }
+    Ok(Args {
+        base: base.ok_or("--base <path> required")?,
+        cand: cand.ok_or("--cand <path> required")?,
+        base_env,
+        cand_env,
+        k,
+        out,
+        title,
+        subtitle,
+    })
+}
+
+fn run_trial(path: &str, extra: &[(String, String)]) -> Result<TrialReport, String> {
+    let out = Command::new(path)
+        .envs(extra.iter().cloned())
+        .output()
+        .map_err(|e| format!("spawn {path}: {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "{path} exited {:?}: {}",
+            out.status.code(),
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    serde_json::from_slice::<TrialReport>(&out.stdout)
+        .map_err(|e| format!("parse trial json from {path}: {e}"))
+}
+
+fn main() -> ExitCode {
+    let args = match parse_args() {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("perf-compare: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let mut base_reports = Vec::with_capacity(args.k);
+    let mut cand_reports = Vec::with_capacity(args.k);
+    for t in 0..args.k {
+        eprintln!("perf-compare: trial {}/{}", t + 1, args.k);
+        match run_trial(&args.base, &args.base_env) {
+            Ok(r) => base_reports.push(r),
+            Err(e) => {
+                eprintln!("perf-compare: base trial {t} failed: {e}");
+                return ExitCode::from(1);
+            }
+        }
+        match run_trial(&args.cand, &args.cand_env) {
+            Ok(r) => cand_reports.push(r),
+            Err(e) => {
+                eprintln!("perf-compare: candidate trial {t} failed: {e}");
+                return ExitCode::from(1);
+            }
+        }
+    }
+
+    let report = compare(&base_reports, &cand_reports, CompareConfig::default());
+    let subtitle = args
+        .subtitle
+        .unwrap_or_else(|| format!("{} trials/config, interleaved on one runner", report.trials));
+    println!("{}", markdown(&report, &args.title, &subtitle));
+
+    if let Some(path) = &args.out {
+        match serde_json::to_string_pretty(&report) {
+            Ok(j) => {
+                if let Err(e) = fs::write(path, j) {
+                    eprintln!("perf-compare: write {path}: {e}");
+                    return ExitCode::from(1);
+                }
+            }
+            Err(e) => {
+                eprintln!("perf-compare: serialize report: {e}");
+                return ExitCode::from(1);
+            }
+        }
+    }
+
+    eprintln!(
+        "perf-compare: {} improved, {} stable, {} regressed (informational)",
+        report.improved, report.stable, report.regressed
+    );
+    ExitCode::SUCCESS
+}

--- a/crates/aether-substrate-bundle/src/bin/perf-trial.rs
+++ b/crates/aether-substrate-bundle/src/bin/perf-trial.rs
@@ -1,0 +1,114 @@
+//! `perf-trial` (iamacoffeepot/aether#1077): run one lifecycle latency
+//! sweep and emit a [`TrialReport`] as JSON on stdout — the
+//! fresh-process unit the `perf-compare` orchestrator runs K times per
+//! side (ADR-0085 §1). Diagnostics go to stderr, so stdout stays pure
+//! JSON.
+//!
+//! Config via env (so the orchestrator sets it once for both sides):
+//!
+//! - `AETHER_PERF_WORKERS` — comma list of pool sizes; the token `max`
+//!   resolves to `available_parallelism() - 1`. Default `max`.
+//! - `AETHER_PERF_TOPOS` — `ci` (depth-1/8 + fanout-4/8 + tree) or
+//!   `full` (the whole default set). Default `ci`.
+//! - `AETHER_PERF_FRAMES` — frames advanced per cell. Default `200`.
+//! - `AETHER_LAT_PACE_HZ` — pace one frame per period (else flat-out).
+//! - `AETHER_PERF_GIT_SHA` — stamped into the report; falls back to
+//!   `git rev-parse HEAD`.
+
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+
+use std::env;
+use std::process::{Command, ExitCode};
+use std::thread::available_parallelism;
+
+use aether_substrate_bundle::perf::harness::{
+    SweepConfig, Topology, default_topologies, depth_chain, fanout, run_sweep, two_level_tree,
+};
+use aether_substrate_bundle::perf::report::TrialReport;
+
+fn parse_workers() -> Vec<usize> {
+    let max = available_parallelism().map_or(2, |n| n.get().saturating_sub(1).max(1));
+    let spec = env::var("AETHER_PERF_WORKERS").unwrap_or_else(|_| "max".to_owned());
+    let mut out: Vec<usize> = spec
+        .split(',')
+        .filter_map(|tok| {
+            let t = tok.trim();
+            if t.eq_ignore_ascii_case("max") {
+                Some(max)
+            } else {
+                t.parse::<usize>().ok().map(|w| w.max(1))
+            }
+        })
+        .collect();
+    out.sort_unstable();
+    out.dedup();
+    if out.is_empty() {
+        out.push(max);
+    }
+    out
+}
+
+fn parse_topologies() -> Vec<Topology> {
+    match env::var("AETHER_PERF_TOPOS").as_deref() {
+        Ok("full") => default_topologies(),
+        // `ci` (default): the cells scheduler changes actually move —
+        // a short chain, a long chain, two fan-out widths, the tree.
+        _ => vec![
+            depth_chain(1),
+            depth_chain(8),
+            fanout(4),
+            fanout(8),
+            two_level_tree(),
+        ],
+    }
+}
+
+fn git_sha() -> Option<String> {
+    if let Ok(s) = env::var("AETHER_PERF_GIT_SHA")
+        && !s.is_empty()
+    {
+        return Some(s);
+    }
+    Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+}
+
+fn main() -> ExitCode {
+    let frames: u32 = env::var("AETHER_PERF_FRAMES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(200);
+    let pace_hz: Option<u64> = env::var("AETHER_LAT_PACE_HZ")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .filter(|&h| h > 0);
+
+    let cfg = SweepConfig {
+        workers: parse_workers(),
+        topologies: parse_topologies(),
+        frames,
+        pace_hz,
+    };
+    let cells = run_sweep(&cfg);
+    if cells.is_empty() {
+        eprintln!("perf-trial: no cells measured (no wgpu adapter, or every cell boot failed)");
+        return ExitCode::from(2);
+    }
+    let report = TrialReport::from_cells(&cells, frames, pace_hz, git_sha());
+    match serde_json::to_string(&report) {
+        Ok(json) => {
+            println!("{json}");
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("perf-trial: serialize failed: {e}");
+            ExitCode::from(3)
+        }
+    }
+}

--- a/crates/aether-substrate-bundle/src/lib.rs
+++ b/crates/aether-substrate-bundle/src/lib.rs
@@ -29,6 +29,7 @@ pub mod chassis_root;
 pub mod desktop;
 pub mod headless;
 pub mod hub;
+pub mod perf;
 pub mod test_bench;
 
 pub use aether_capabilities as capabilities;

--- a/crates/aether-substrate-bundle/src/perf/harness.rs
+++ b/crates/aether-substrate-bundle/src/perf/harness.rs
@@ -1,0 +1,434 @@
+//! Lifecycle latency sweep engine (iamacoffeepot/aether#1057, #1077).
+//!
+//! The reusable core of the latency harness, lifted out of the
+//! `#[cfg(test)]` `mail_latency` module so the `perf-trial` binary can
+//! drive it (iamacoffeepot/aether#1077). [`run_sweep`] wires synthetic
+//! relay actors into a topology, drives the substrate's real lifecycle
+//! (`advance` → `Tick` fan-out → a tick-reactive source → the relay
+//! chain), harvests the resident trace ring (ADR-0080) once per cell,
+//! and returns per-cell [`CellResult`] percentiles. It performs no I/O
+//! itself — callers render (the harness test prints a table; the
+//! `perf-trial` bin emits JSON).
+//!
+//! **Worker count is the dominant variable.** Post issue #635 actors
+//! are `Pooled` by default — they share a worker pool, not one thread
+//! each. A depth chain with one root in flight serialises regardless of
+//! pool size; a fan-out either parallelises across workers or queues on
+//! a small pool. So the sweep takes the worker set as an axis.
+
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use aether_data::{Kind, KindId, MailboxId, mailbox_id_from_name};
+use aether_kinds::trace::{
+    DescribeWindow, DescribeWindowResult, TRACE_OBSERVER_MAILBOX_NAME, TraceWindow,
+};
+use aether_kinds::{SubscribeInput, SubscribeInputResult, Tick};
+use aether_substrate::{BootError, NativeActor, NativeCtx, NativeDispatch, NativeInitCtx, Subname};
+
+use crate::test_bench::TestBench;
+
+/// Fire-and-forward payload the relay actors pass along. The `seq`
+/// field is carried for legibility when eyeballing a trace; the relay
+/// forwards the bytes verbatim, so the wire shape is irrelevant to the
+/// measurement. The schema-hashed `ID` is what the relay matches and
+/// the trace records.
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "mlat.ping")]
+pub struct Ping {
+    pub seq: u32,
+}
+
+/// A relay forwards each inbound `Ping` to every configured downstream
+/// mailbox, inheriting the trace lineage so the whole topology is one
+/// causal tree. A leaf relay (empty `downstreams`) just receives and
+/// returns. Pooled (the `Actor` default).
+pub struct Relay {
+    downstreams: Arc<[MailboxId]>,
+}
+
+impl aether_actor::Actor for Relay {
+    const NAMESPACE: &'static str = "mlat.relay";
+}
+impl aether_actor::Instanced for Relay {}
+impl aether_actor::HandlesKind<Ping> for Relay {}
+impl NativeActor for Relay {
+    type Config = Arc<[MailboxId]>;
+    fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        Ok(Self {
+            downstreams: config,
+        })
+    }
+}
+impl NativeDispatch for Relay {
+    fn __aether_dispatch_envelope(
+        &mut self,
+        ctx: &mut NativeCtx<'_>,
+        kind: KindId,
+        payload: &[u8],
+    ) -> Option<()> {
+        if kind.0 != Ping::ID.0 {
+            return None;
+        }
+        // Forward the bytes verbatim to each downstream. Each push
+        // stamps its own `t_sent`, so later children in a fan-out reveal
+        // any per-child enqueue skew.
+        for &down in self.downstreams.iter() {
+            let _ = ctx.send_envelope_traced(down, Ping::ID, payload);
+        }
+        Some(())
+    }
+}
+
+const RELAY_NS: &str = "mlat.relay";
+
+/// Deterministic `MailboxId` for relay instance `i`. Mirrors the
+/// substrate's `mailbox_id_from_name("{NAMESPACE}:{subname}")` so the
+/// whole topology can be wired from precomputed ids before any actor is
+/// spawned (sidesteps spawn-ordering between a relay and its
+/// downstreams).
+#[must_use]
+pub fn relay_id(i: usize) -> MailboxId {
+    MailboxId(mailbox_id_from_name(&format!("{RELAY_NS}:{i}")).0)
+}
+
+/// Lifecycle bridge for the sweep: subscribed to the `Tick` input
+/// stream, it emits one `Ping` into the entry relay per frame,
+/// inheriting the tick's trace lineage so the whole per-frame chain is
+/// one causal tree. The honest stand-in for a real tick-reactive
+/// component — the substrate's own `Tick` fan-out drives the work, no
+/// synthetic injector, no per-root settlement block.
+pub struct TickSource {
+    entry: MailboxId,
+    seq: u32,
+}
+
+impl aether_actor::Actor for TickSource {
+    const NAMESPACE: &'static str = "mlat.ticksrc";
+}
+impl aether_actor::Instanced for TickSource {}
+impl aether_actor::HandlesKind<Tick> for TickSource {}
+impl NativeActor for TickSource {
+    type Config = MailboxId;
+    fn init(entry: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        Ok(Self { entry, seq: 0 })
+    }
+}
+impl NativeDispatch for TickSource {
+    fn __aether_dispatch_envelope(
+        &mut self,
+        ctx: &mut NativeCtx<'_>,
+        kind: KindId,
+        _payload: &[u8],
+    ) -> Option<()> {
+        if kind.0 != Tick::ID.0 {
+            return None;
+        }
+        let bytes = Ping { seq: self.seq }.encode_into_bytes();
+        self.seq = self.seq.wrapping_add(1);
+        let _ = ctx.send_envelope_traced(self.entry, Ping::ID, &bytes);
+        Some(())
+    }
+}
+
+const TICKSRC_NS: &str = "mlat.ticksrc";
+
+/// Deterministic id for the single tick source (subname `"src"`).
+#[must_use]
+pub fn ticksrc_id() -> MailboxId {
+    MailboxId(mailbox_id_from_name(&format!("{TICKSRC_NS}:src")).0)
+}
+
+/// A topology is a DAG over relay indices: `downstreams[i]` lists the
+/// relays that relay `i` forwards to. Relay 0 is always the entry. The
+/// number of relays is `downstreams.len()`.
+#[derive(Clone)]
+pub struct Topology {
+    pub name: String,
+    pub downstreams: Vec<Vec<usize>>,
+}
+
+/// `0 -> 1 -> ... -> d-1`. Each relay forwards to the next; the last is
+/// a leaf.
+#[must_use]
+pub fn depth_chain(d: usize) -> Topology {
+    let downstreams = (0..d)
+        .map(|i| if i + 1 < d { vec![i + 1] } else { vec![] })
+        .collect();
+    Topology {
+        name: format!("depth-{d}"),
+        downstreams,
+    }
+}
+
+/// `0 -> {1, 2, ..., b}`. Entry fans to b leaves.
+#[must_use]
+pub fn fanout(b: usize) -> Topology {
+    let mut downstreams = vec![vec![]; b + 1];
+    downstreams[0] = (1..=b).collect();
+    Topology {
+        name: format!("fanout-{b}"),
+        downstreams,
+    }
+}
+
+/// `A -> {B, C} -> {D, E}, {E, F}`. E (index 4) has two parents (B and
+/// C) — the shared-node contention case.
+#[must_use]
+pub fn two_level_tree() -> Topology {
+    Topology {
+        name: "tree-A-BC-DEEF".to_owned(),
+        downstreams: vec![
+            vec![1, 2], // A -> B, C
+            vec![3, 4], // B -> D, E
+            vec![4, 5], // C -> E, F
+            vec![],     // D
+            vec![],     // E
+            vec![],     // F
+        ],
+    }
+}
+
+/// The full default topology set (depth chains 1/2/4/8, fan-outs 2/4/8,
+/// the two-level tree) — what the on-demand `lifecycle_latency_observe`
+/// harness sweeps.
+#[must_use]
+pub fn default_topologies() -> Vec<Topology> {
+    let mut t = Vec::new();
+    for d in [1usize, 2, 4, 8] {
+        t.push(depth_chain(d));
+    }
+    for b in [2usize, 4, 8] {
+        t.push(fanout(b));
+    }
+    t.push(two_level_tree());
+    t
+}
+
+/// p50 / p90 / p99 / max over a sample set, plus the sample count. All
+/// values are nanoseconds.
+#[derive(Clone, Copy, Default, Debug)]
+pub struct Stats {
+    pub p50: u64,
+    pub p90: u64,
+    pub p99: u64,
+    pub max: u64,
+    pub n: usize,
+}
+
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+fn nearest_rank(sorted: &[u64], q: f64) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let idx = ((sorted.len() - 1) as f64 * q).round() as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+/// Summarise a sample set into [`Stats`] (consumes + sorts the input).
+#[must_use]
+pub fn summarize(mut samples: Vec<u64>) -> Stats {
+    let n = samples.len();
+    if n == 0 {
+        return Stats::default();
+    }
+    samples.sort_unstable();
+    Stats {
+        p50: nearest_rank(&samples, 0.50),
+        p90: nearest_rank(&samples, 0.90),
+        p99: nearest_rank(&samples, 0.99),
+        max: samples[n - 1],
+        n,
+    }
+}
+
+/// One fully-measured cell (per worker count × topology).
+#[derive(Clone, Debug)]
+pub struct CellResult {
+    pub workers: usize,
+    pub topo: String,
+    pub hop: Stats,
+    pub handler: Stats,
+}
+
+/// Inputs to one sweep. `workers` is the outer axis (pool sizes);
+/// `topologies` the inner. `frames` advances per cell; `pace_hz`
+/// `Some(hz)` paces one frame per period (workers park between frames →
+/// realistic frame-loop latency), `None` runs flat-out (warm — isolates
+/// per-hop dispatch cost).
+#[derive(Clone)]
+pub struct SweepConfig {
+    pub workers: Vec<usize>,
+    pub topologies: Vec<Topology>,
+    pub frames: u32,
+    pub pace_hz: Option<u64>,
+}
+
+/// Drive the sweep and return per-cell percentiles. Each cell boots a
+/// fresh [`TestBench`], wires the topology + tick source, advances, and
+/// harvests the trace ring once. A cell whose bench fails to boot (no
+/// wgpu adapter) or whose harvest overflows is logged via `tracing` and
+/// skipped — so a driverless box returns fewer cells (possibly empty)
+/// rather than panicking.
+#[allow(clippy::cast_precision_loss, clippy::too_many_lines)]
+#[must_use]
+pub fn run_sweep(cfg: &SweepConfig) -> Vec<CellResult> {
+    let mut rows: Vec<CellResult> = Vec::new();
+
+    for &workers in &cfg.workers {
+        for topo in &cfg.topologies {
+            let Ok(mut tb) = TestBench::builder()
+                .with_workers(Some(workers))
+                .size(16, 16)
+                .build()
+            else {
+                tracing::warn!(
+                    target: "aether_perf",
+                    topo = %topo.name, workers,
+                    "sweep cell skipped: TestBench boot failed (likely no wgpu adapter)",
+                );
+                continue;
+            };
+
+            let n = topo.downstreams.len();
+            let mut spawned_ok = true;
+            for i in 0..n {
+                let downs: Arc<[MailboxId]> =
+                    topo.downstreams[i].iter().map(|&j| relay_id(j)).collect();
+                let sub = i.to_string();
+                if let Err(e) = tb
+                    .spawn_actor::<Relay>(Subname::Named(&sub), downs)
+                    .finish()
+                {
+                    tracing::warn!(target: "aether_perf", topo = %topo.name, relay = i, error = ?e, "relay spawn failed");
+                    spawned_ok = false;
+                    break;
+                }
+            }
+            if !spawned_ok {
+                continue;
+            }
+            if let Err(e) = tb
+                .spawn_actor::<TickSource>(Subname::Named("src"), relay_id(0))
+                .finish()
+            {
+                tracing::warn!(target: "aether_perf", topo = %topo.name, error = ?e, "tick source spawn failed");
+                continue;
+            }
+
+            // Wire the source into the platform `Tick` stream so
+            // `advance` delivers a tick to it each frame (ADR-0021).
+            let sub_req = SubscribeInput {
+                kind: Tick::ID,
+                mailbox: ticksrc_id(),
+            }
+            .encode_into_bytes();
+            match tb.send_bytes_and_await("aether.input", SubscribeInput::ID, sub_req) {
+                Ok(reply) => match SubscribeInputResult::decode_from_bytes(&reply) {
+                    Some(SubscribeInputResult::Ok) => {}
+                    other => {
+                        tracing::warn!(target: "aether_perf", topo = %topo.name, ?other, "Tick subscribe failed");
+                        continue;
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!(target: "aether_perf", topo = %topo.name, error = ?e, "Tick subscribe send failed");
+                    continue;
+                }
+            }
+
+            // Drive via the real lifecycle.
+            let t0 = Instant::now();
+            match cfg.pace_hz {
+                Some(hz) => {
+                    let period = Duration::from_secs_f64(1.0 / hz as f64);
+                    for _ in 0..cfg.frames {
+                        let f = Instant::now();
+                        let _ = tb.advance(1);
+                        if let Some(rem) = period.checked_sub(f.elapsed()) {
+                            thread::sleep(rem);
+                        }
+                    }
+                }
+                None => {
+                    let _ = tb.advance(cfg.frames);
+                }
+            }
+            let drive_ms = u64::try_from(t0.elapsed().as_millis()).unwrap_or(u64::MAX);
+
+            // Harvest the resident ring once, after the run. The
+            // `Ping`-kind filter isolates relay hops, so setup / Tick /
+            // query mail never counts.
+            let req = DescribeWindow {
+                window: TraceWindow::Relative {
+                    last_ms: drive_ms.saturating_add(1_000),
+                },
+                max_mails: Some(100_000),
+            }
+            .encode_into_bytes();
+            let mails = match tb.send_bytes_and_await(
+                TRACE_OBSERVER_MAILBOX_NAME,
+                DescribeWindow::ID,
+                req,
+            ) {
+                Ok(reply) => match DescribeWindowResult::decode_from_bytes(&reply) {
+                    Some(DescribeWindowResult::Ok { mails }) => mails,
+                    Some(DescribeWindowResult::Err { too_many }) => {
+                        tracing::warn!(
+                            target: "aether_perf",
+                            topo = %topo.name, workers, ?too_many,
+                            "describe_window over cap — lower frames or raise AETHER_TRACE_RING_CAPACITY",
+                        );
+                        continue;
+                    }
+                    None => {
+                        tracing::warn!(target: "aether_perf", topo = %topo.name, "describe_window decode failed");
+                        continue;
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!(target: "aether_perf", topo = %topo.name, error = ?e, "describe_window send failed");
+                    continue;
+                }
+            };
+
+            let mut hop = Vec::new();
+            let mut handler = Vec::new();
+            for node in &mails {
+                if node.kind.0 != Ping::ID.0 {
+                    continue;
+                }
+                if let Some(recv) = node.t_received {
+                    hop.push(recv.0.saturating_sub(node.t_sent.0));
+                    if let Some(fin) = node.t_finished {
+                        handler.push(fin.0.saturating_sub(recv.0));
+                    }
+                }
+            }
+            rows.push(CellResult {
+                workers,
+                topo: topo.name.clone(),
+                hop: summarize(hop),
+                handler: summarize(handler),
+            });
+        }
+    }
+    rows
+}

--- a/crates/aether-substrate-bundle/src/perf/mod.rs
+++ b/crates/aether-substrate-bundle/src/perf/mod.rs
@@ -1,0 +1,15 @@
+//! Lifecycle-latency perf tooling (iamacoffeepot/aether#1077).
+//!
+//! - [`harness`] — the sweep engine ([`harness::run_sweep`]) lifted out
+//!   of the `#[cfg(test)]` latency harness so the `perf-trial` bin can
+//!   drive it.
+//! - [`report`] — the trial JSON schema ([`report::TrialReport`]) and
+//!   the noise-aware paired comparison ([`report::compare`], ADR-0085)
+//!   the `perf-compare` bin renders into a sticky PR comment.
+//!
+//! The bins (`src/bin/perf-trial.rs`, `src/bin/perf-compare.rs`) are
+//! thin shells over these; the logic lives here so it is in-crate
+//! (reaching `TestBench`'s `pub(crate)` drive methods) and unit-testable.
+
+pub mod harness;
+pub mod report;

--- a/crates/aether-substrate-bundle/src/perf/report.rs
+++ b/crates/aether-substrate-bundle/src/perf/report.rs
@@ -1,0 +1,548 @@
+//! Trial JSON schema + the noise-aware paired comparison (ADR-0085).
+//!
+//! A [`TrialReport`] is one fresh-process run of the sweep, serialised
+//! as JSON by the `perf-trial` bin. [`compare`] takes K base + K
+//! candidate trials (interleaved on one runner) and, per
+//! (worker-count × topology × metric × percentile) cell, computes the
+//! **paired delta** `δ_t = cand_t − base_t`. Because base and candidate
+//! ran adjacent on the same runner, shared run-to-run drift cancels in
+//! each δ — so the verdict rests on the *change* distribution, not on
+//! two independent clouds (ADR-0085 §3).
+//!
+//! Verdict rule (a deterministic paired test in the ADR's posture — no
+//! bootstrap RNG, so it is reproducible and the fixtures below pin it):
+//! a cell flags `improved` / `regressed` only when the paired deltas
+//! both (a) **agree on direction** for at least `consistency` of trials
+//! and (b) have a median whose magnitude clears
+//! `max(effect_floor × IQR(δ), rel_floor × base_median)` — i.e. the
+//! change is large relative to its own spread *and* above a practical
+//! relative-significance floor. Otherwise `stable`. This is what makes
+//! uniform run-order drift (δ ≈ 0 after pairing) and one-off tail
+//! outliers (median is robust) read as stable rather than false
+//! regressions.
+
+use serde::{Deserialize, Serialize};
+
+/// Which leg of the per-hop measurement a cell reports.
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum Metric {
+    /// `t_received − t_sent`: enqueue + worker pickup.
+    Hop,
+    /// `t_finished − t_received`: in-handler work.
+    Handler,
+}
+
+impl Metric {
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Hop => "hop",
+            Self::Handler => "handler",
+        }
+    }
+}
+
+/// One cell's percentiles in a single trial. All latency values are
+/// nanoseconds.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct CellJson {
+    pub workers: usize,
+    pub topo: String,
+    pub metric: Metric,
+    pub p50: u64,
+    pub p90: u64,
+    pub p99: u64,
+    pub max: u64,
+    pub n: usize,
+}
+
+impl CellJson {
+    #[allow(clippy::cast_precision_loss)]
+    fn percentile(&self, p: Pct) -> f64 {
+        let ns = match p {
+            Pct::P50 => self.p50,
+            Pct::P90 => self.p90,
+            Pct::P99 => self.p99,
+        };
+        ns as f64
+    }
+
+    fn key(&self) -> CellKey {
+        CellKey {
+            workers: self.workers,
+            topo: self.topo.clone(),
+            metric: self.metric,
+        }
+    }
+}
+
+/// One fresh-process sweep run. The `perf-trial` bin emits this as JSON
+/// on stdout; the `perf-compare` bin collects K of each side.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct TrialReport {
+    /// Schema tag for forward-compat decode checks.
+    pub schema: String,
+    /// Commit the trial binary was built from, if the bin could resolve
+    /// it (best-effort; `None` outside a git checkout).
+    pub git_sha: Option<String>,
+    /// `Some(hz)` if the sweep paced; `None` if flat-out (warm).
+    pub pace_hz: Option<u64>,
+    /// Frames advanced per cell.
+    pub frames: u32,
+    pub cells: Vec<CellJson>,
+}
+
+/// Current trial schema tag.
+pub const TRIAL_SCHEMA: &str = "aether.perf.trial.v1";
+
+impl TrialReport {
+    /// Build a trial report from a sweep's [`CellResult`]s — each cell
+    /// expands to two `CellJson` rows (hop + handler).
+    ///
+    /// [`CellResult`]: super::harness::CellResult
+    #[must_use]
+    pub fn from_cells(
+        cells: &[super::harness::CellResult],
+        frames: u32,
+        pace_hz: Option<u64>,
+        git_sha: Option<String>,
+    ) -> Self {
+        let mut out = Vec::with_capacity(cells.len() * 2);
+        for c in cells {
+            for (metric, s) in [(Metric::Hop, &c.hop), (Metric::Handler, &c.handler)] {
+                out.push(CellJson {
+                    workers: c.workers,
+                    topo: c.topo.clone(),
+                    metric,
+                    p50: s.p50,
+                    p90: s.p90,
+                    p99: s.p99,
+                    max: s.max,
+                    n: s.n,
+                });
+            }
+        }
+        Self {
+            schema: TRIAL_SCHEMA.to_owned(),
+            git_sha,
+            pace_hz,
+            frames,
+            cells: out,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Pct {
+    P50,
+    P90,
+    P99,
+}
+
+impl Pct {
+    fn label(self) -> &'static str {
+        match self {
+            Self::P50 => "p50",
+            Self::P90 => "p90",
+            Self::P99 => "p99",
+        }
+    }
+    const ALL: [Self; 3] = [Self::P50, Self::P90, Self::P99];
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct CellKey {
+    workers: usize,
+    topo: String,
+    metric: Metric,
+}
+
+/// Find the cell matching `key` in one trial (a free fn, not a closure,
+/// so the borrow of the returned `&CellJson` ties to `t`'s lifetime).
+fn find_cell<'a>(t: &'a TrialReport, key: &CellKey) -> Option<&'a CellJson> {
+    t.cells
+        .iter()
+        .find(|c| c.workers == key.workers && c.topo == key.topo && c.metric == key.metric)
+}
+
+/// improved / stable / regressed verdict for one (cell × percentile).
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum Verdict {
+    Improved,
+    Stable,
+    Regressed,
+}
+
+/// One compared cell — display bands per side (IQR across trials) plus
+/// the paired-delta verdict.
+#[derive(Serialize, Clone, Debug)]
+pub struct CellComparison {
+    pub workers: usize,
+    pub topo: String,
+    pub metric: Metric,
+    pub percentile: &'static str,
+    /// Nanoseconds.
+    pub base_median: f64,
+    pub base_iqr: f64,
+    pub cand_median: f64,
+    pub cand_iqr: f64,
+    pub delta_median: f64,
+    pub delta_pct: f64,
+    pub verdict: Verdict,
+}
+
+/// Full comparison output — headline counts + per-cell rows.
+#[derive(Serialize, Clone, Debug)]
+pub struct ComparisonReport {
+    pub trials: usize,
+    pub improved: usize,
+    pub stable: usize,
+    pub regressed: usize,
+    pub cells: Vec<CellComparison>,
+}
+
+/// Tunables for the verdict rule. Defaults are conservative —
+/// informational reports should under-call rather than cry wolf
+/// (ADR-0085 §4).
+#[derive(Clone, Copy)]
+pub struct CompareConfig {
+    /// Multiplier on the paired-delta IQR: the effect must exceed this
+    /// many IQRs to be "large relative to its own spread".
+    pub effect_floor_iqr: f64,
+    /// Minimum fractional change relative to the base median (practical
+    /// significance) — suppresses tiny-but-consistent deltas.
+    pub rel_floor: f64,
+    /// Fraction of trials whose delta must share the effect's sign.
+    pub consistency: f64,
+}
+
+impl Default for CompareConfig {
+    fn default() -> Self {
+        Self {
+            effect_floor_iqr: 1.5,
+            rel_floor: 0.10,
+            consistency: 0.75,
+        }
+    }
+}
+
+fn sorted(mut v: Vec<f64>) -> Vec<f64> {
+    v.sort_by(f64::total_cmp);
+    v
+}
+
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+fn quantile_sorted(s: &[f64], q: f64) -> f64 {
+    if s.is_empty() {
+        return 0.0;
+    }
+    let idx = ((s.len() - 1) as f64 * q).round() as usize;
+    s[idx.min(s.len() - 1)]
+}
+
+fn median_sorted(s: &[f64]) -> f64 {
+    quantile_sorted(s, 0.5)
+}
+
+fn iqr_sorted(s: &[f64]) -> f64 {
+    quantile_sorted(s, 0.75) - quantile_sorted(s, 0.25)
+}
+
+/// Compare K interleaved base/candidate trials. Trials pair by index:
+/// `base[t]` against `cand[t]`. Cells present in every trial of both
+/// sides are compared; a cell missing from any trial (a skipped boot)
+/// is dropped.
+#[must_use]
+#[allow(clippy::cast_precision_loss)]
+pub fn compare(base: &[TrialReport], cand: &[TrialReport], cfg: CompareConfig) -> ComparisonReport {
+    let k = base.len().min(cand.len());
+    let mut cells: Vec<CellComparison> = Vec::new();
+
+    // Key set = cells in the first base trial; verified present across
+    // all trials of both sides before comparing.
+    let keys: Vec<CellKey> = base
+        .first()
+        .map(|t| t.cells.iter().map(CellJson::key).collect())
+        .unwrap_or_default();
+
+    for key in &keys {
+        // Per-trial lookup of this cell on each side.
+        let base_cells: Vec<&CellJson> =
+            base[..k].iter().filter_map(|t| find_cell(t, key)).collect();
+        let cand_cells: Vec<&CellJson> =
+            cand[..k].iter().filter_map(|t| find_cell(t, key)).collect();
+        if base_cells.len() != k || cand_cells.len() != k || k == 0 {
+            continue; // cell not present in every trial — skip
+        }
+
+        for p in Pct::ALL {
+            let base_vals: Vec<f64> = base_cells.iter().map(|c| c.percentile(p)).collect();
+            let cand_vals: Vec<f64> = cand_cells.iter().map(|c| c.percentile(p)).collect();
+            let deltas: Vec<f64> = (0..k).map(|t| cand_vals[t] - base_vals[t]).collect();
+
+            let base_sorted = sorted(base_vals.clone());
+            let cand_sorted = sorted(cand_vals.clone());
+            let delta_sorted = sorted(deltas.clone());
+
+            let base_median = median_sorted(&base_sorted);
+            let cand_median = median_sorted(&cand_sorted);
+            let delta_median = median_sorted(&delta_sorted);
+            let delta_iqr = iqr_sorted(&delta_sorted);
+
+            let verdict = classify(&deltas, delta_median, delta_iqr, base_median, cfg);
+            let delta_pct = if base_median > 0.0 {
+                delta_median / base_median * 100.0
+            } else {
+                0.0
+            };
+
+            cells.push(CellComparison {
+                workers: key.workers,
+                topo: key.topo.clone(),
+                metric: key.metric,
+                percentile: p.label(),
+                base_median,
+                base_iqr: iqr_sorted(&base_sorted),
+                cand_median,
+                cand_iqr: iqr_sorted(&cand_sorted),
+                delta_median,
+                delta_pct,
+                verdict,
+            });
+        }
+    }
+
+    let improved = cells
+        .iter()
+        .filter(|c| c.verdict == Verdict::Improved)
+        .count();
+    let regressed = cells
+        .iter()
+        .filter(|c| c.verdict == Verdict::Regressed)
+        .count();
+    let stable = cells.len() - improved - regressed;
+    ComparisonReport {
+        trials: k,
+        improved,
+        stable,
+        regressed,
+        cells,
+    }
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn classify(
+    deltas: &[f64],
+    delta_median: f64,
+    delta_iqr: f64,
+    base_median: f64,
+    cfg: CompareConfig,
+) -> Verdict {
+    if deltas.is_empty() || delta_median == 0.0 {
+        return Verdict::Stable;
+    }
+    let n = deltas.len() as f64;
+    let same_sign = deltas
+        .iter()
+        .filter(|&&d| d != 0.0 && d.signum() == delta_median.signum())
+        .count() as f64;
+    let consistent = same_sign / n >= cfg.consistency;
+
+    let floor = (cfg.effect_floor_iqr * delta_iqr).max(cfg.rel_floor * base_median);
+    let large = delta_median.abs() > floor;
+
+    if consistent && large {
+        if delta_median < 0.0 {
+            Verdict::Improved
+        } else {
+            Verdict::Regressed
+        }
+    } else {
+        Verdict::Stable
+    }
+}
+
+fn us(ns: f64) -> String {
+    format!("{:.2}", ns / 1000.0)
+}
+
+/// Hidden marker so the CI poster (PR 2) can find-and-update its sticky
+/// comment in place rather than spamming new ones.
+pub const STICKY_MARKER: &str = "<!-- aether-perf-report -->";
+
+/// Render the comparison as a sticky PR-comment markdown body: headline
+/// counts, the non-stable rows up top, and the full grid collapsed.
+#[must_use]
+#[allow(clippy::format_push_string)]
+pub fn markdown(report: &ComparisonReport, title: &str, subtitle: &str) -> String {
+    let mut s = String::new();
+    s.push_str(STICKY_MARKER);
+    s.push('\n');
+    s.push_str(&format!("## dispatch perf — {title}\n"));
+    s.push_str(&format!("{subtitle}\n\n"));
+    s.push_str(&format!(
+        "**{} improved · {} stable · {} regressed** ({} trials/config, paired)\n\n",
+        report.improved, report.stable, report.regressed, report.trials
+    ));
+
+    let header = "| topology | w | metric | pct | base µs | this µs | Δ | verdict |\n|---|--:|---|---|--:|--:|--:|---|\n";
+    let row = |c: &CellComparison| -> String {
+        let verdict = match c.verdict {
+            Verdict::Improved => "improved",
+            Verdict::Stable => "stable",
+            Verdict::Regressed => "regressed",
+        };
+        format!(
+            "| {} | {} | {} | {} | {} ±{} | {} ±{} | {:+.0}% | {} |\n",
+            c.topo,
+            c.workers,
+            c.metric.label(),
+            c.percentile,
+            us(c.base_median),
+            us(c.base_iqr),
+            us(c.cand_median),
+            us(c.cand_iqr),
+            c.delta_pct,
+            verdict,
+        )
+    };
+
+    let non_stable: Vec<&CellComparison> = report
+        .cells
+        .iter()
+        .filter(|c| c.verdict != Verdict::Stable)
+        .collect();
+    if non_stable.is_empty() {
+        s.push_str("_No cells moved beyond the noise band._\n\n");
+    } else {
+        s.push_str(header);
+        for c in non_stable {
+            s.push_str(&row(c));
+        }
+        s.push('\n');
+    }
+
+    s.push_str(&format!(
+        "<details><summary>full grid — {} cells</summary>\n\n",
+        report.cells.len()
+    ));
+    s.push_str(header);
+    for c in &report.cells {
+        s.push_str(&row(c));
+    }
+    s.push_str("\n</details>\n");
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a K-trial side from a per-trial `p50` series for one cell
+    /// (`fanout-8 @ 11w`, hop). Other percentiles track p50 ×1.2 / ×1.5
+    /// so the cell is well-formed; tests assert on p50.
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
+    fn side(p50s: &[u64]) -> Vec<TrialReport> {
+        p50s.iter()
+            .map(|&p50| TrialReport {
+                schema: TRIAL_SCHEMA.to_owned(),
+                git_sha: None,
+                pace_hz: None,
+                frames: 200,
+                cells: vec![CellJson {
+                    workers: 11,
+                    topo: "fanout-8".to_owned(),
+                    metric: Metric::Hop,
+                    p50,
+                    p90: (p50 as f64 * 1.2) as u64,
+                    p99: (p50 as f64 * 1.5) as u64,
+                    max: p50 * 4,
+                    n: 1800,
+                }],
+            })
+            .collect()
+    }
+
+    fn p50_verdict(rep: &ComparisonReport) -> Verdict {
+        rep.cells
+            .iter()
+            .find(|c| c.percentile == "p50")
+            .expect("p50 cell present")
+            .verdict
+    }
+
+    #[test]
+    fn consistent_win_reads_improved() {
+        // base ~167µs, cand ~33µs, every trial — the fan-out win.
+        let base = side(&[
+            167_000, 165_000, 169_000, 166_000, 168_000, 170_000, 164_000, 167_000,
+        ]);
+        let cand = side(&[
+            33_000, 34_000, 32_000, 33_500, 33_000, 31_000, 34_000, 33_000,
+        ]);
+        let rep = compare(&base, &cand, CompareConfig::default());
+        assert_eq!(p50_verdict(&rep), Verdict::Improved);
+    }
+
+    #[test]
+    fn consistent_regression_reads_regressed() {
+        // base ~1.0µs, cand ~1.4µs every trial (+40%, the depth-8 example).
+        let base = side(&[1000, 960, 1040, 980, 1010, 990, 1020, 1000]);
+        let cand = side(&[1400, 1360, 1440, 1380, 1410, 1390, 1420, 1400]);
+        let rep = compare(&base, &cand, CompareConfig::default());
+        assert_eq!(p50_verdict(&rep), Verdict::Regressed);
+    }
+
+    #[test]
+    fn uniform_run_order_drift_reads_stable() {
+        // Both sides drift hard across trials (thermal/background), but
+        // the candidate tracks the baseline within ~30ns per paired
+        // trial. Unpaired this is two wide clouds; paired, δ ≈ 0.
+        let base = side(&[1000, 1300, 1600, 1900, 2200, 2500, 2800, 3100]);
+        let cand = side(&[1030, 1330, 1570, 1930, 2170, 2530, 2770, 3130]);
+        let rep = compare(&base, &cand, CompareConfig::default());
+        assert_eq!(p50_verdict(&rep), Verdict::Stable);
+    }
+
+    #[test]
+    fn one_off_outlier_reads_stable() {
+        // Steady ~1µs both sides, except one candidate trial spikes —
+        // the median of paired deltas shrugs it off.
+        let base = side(&[1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000]);
+        let cand = side(&[1010, 990, 1000, 600_000, 1000, 1005, 995, 1000]);
+        let rep = compare(&base, &cand, CompareConfig::default());
+        assert_eq!(p50_verdict(&rep), Verdict::Stable);
+    }
+
+    #[test]
+    fn tiny_consistent_change_is_below_practical_floor() {
+        // +30ns on a 1µs base is perfectly consistent but only 3% —
+        // below the 10% relative floor, so it stays stable rather than
+        // crying wolf on a sub-noise dispatch-glue change.
+        let base = side(&[1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000]);
+        let cand = side(&[1030, 1030, 1030, 1030, 1030, 1030, 1030, 1030]);
+        let rep = compare(&base, &cand, CompareConfig::default());
+        assert_eq!(p50_verdict(&rep), Verdict::Stable);
+    }
+
+    #[test]
+    fn markdown_includes_marker_and_counts() {
+        let base = side(&[167_000, 165_000, 169_000, 166_000]);
+        let cand = side(&[33_000, 34_000, 32_000, 33_500]);
+        let rep = compare(&base, &cand, CompareConfig::default());
+        let md = markdown(&rep, "PR 9999 vs main", "test");
+        assert!(md.contains(STICKY_MARKER));
+        assert!(md.contains("improved"));
+        assert!(md.contains("full grid"));
+    }
+}

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -468,10 +468,10 @@ impl TestBench {
     /// the caller chains `after_init` / `finish` against — the same
     /// shape callers reach for from the chassis-builder scope. Used by
     /// integration tests that exercise the spawn lifecycle without
-    /// going through a parent-actor handler. Test-only: the spawn
-    /// lifecycle is exercised by the in-crate unit test, and `execute`
-    /// (the public driver) doesn't model spawning.
-    #[cfg(test)]
+    /// going through a parent-actor handler, and by the perf sweep
+    /// harness ([`crate::perf::harness::run_sweep`], #1077) which the
+    /// `perf-trial` bin drives. `pub(crate)` — the public `execute`
+    /// driver doesn't model spawning.
     pub(crate) fn spawn_actor<'a, A>(
         &'a self,
         subname: aether_substrate::Subname<'a>,

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -1,33 +1,21 @@
-//! Mail-latency measurement harness (iamacoffeepot/aether#1057).
+//! Mail-latency measurement harness tests (iamacoffeepot/aether#1057).
 //!
-//! Measures the per-hop and end-to-end cost of inter-actor mail across
-//! controlled topologies, so the mail system has a numeric regression
-//! surface. The trace observer (ADR-0080) already stamps every mail
-//! with `t_sent` (producer enqueue), `t_received` (dispatcher pickup),
-//! and `t_finished` (handler return) from one monotonic clock, so the
-//! data is recorded for free — this harness just wires synthetic relay
-//! actors into a topology, injects traced root mails, reads the trace
-//! tree back over the `aether.trace` mail surface, and computes
-//! percentiles.
+//! The reusable sweep engine (relay actors, topologies, `run_sweep`)
+//! lives in [`crate::perf::harness`] so the `perf-trial` bin can drive
+//! it too (iamacoffeepot/aether#1077). This module keeps the on-demand
+//! `#[ignore]` measurement test ([`lifecycle_latency_observe`]), the
+//! settlement regression guard, and the saturation profiling target —
+//! the test-only consumers of that engine.
 //!
-//! **Worker count is the dominant variable.** Post issue #635 actors
-//! are `Pooled` by default — they share a worker pool of
-//! `available_parallelism() - 1` threads, not one thread each. So a
-//! depth-8 chain with one root in flight serialises regardless of pool
-//! size (only one slot is ever ready), but a fan-out of 8 — or many
-//! concurrent roots — either parallelises across workers or queues on a
-//! small pool. The harness therefore sweeps pool size as an outer axis
-//! (`TestBenchBuilder::with_workers`) and reports it as a column.
-//!
-//! Run on demand (it is `#[ignore]`d — zero CI cost):
+//! Run the latency table on demand (it is `#[ignore]`d — zero CI cost):
 //!
 //! ```text
 //! cargo test -p aether-substrate-bundle --release lifecycle_latency_observe \
 //!     -- --ignored --nocapture
 //! ```
 //!
-//! Release matters: the numbers are dominated by enqueue + worker
-//! wake, which a debug build inflates several-fold.
+//! Release matters: the numbers are dominated by enqueue + worker wake,
+//! which a debug build inflates several-fold.
 
 use std::collections::BTreeSet;
 use std::env;
@@ -37,84 +25,14 @@ use std::time::{Duration, Instant};
 
 use aether_data::{Kind, KindId, MailId, MailboxId, mailbox_id_from_name};
 use aether_kinds::trace::{
-    DescribeTree, DescribeTreeResult, DescribeWindow, DescribeWindowResult, MailNodeWire,
-    TRACE_OBSERVER_MAILBOX_NAME, TraceWindow,
+    DescribeTree, DescribeTreeResult, MailNodeWire, TRACE_OBSERVER_MAILBOX_NAME,
 };
-use aether_kinds::{SubscribeInput, SubscribeInputResult, Tick};
 use aether_substrate::{BootError, NativeActor, NativeCtx, NativeDispatch, NativeInitCtx, Subname};
 
 use super::TestBench;
-
-/// Fire-and-forward payload the relay actors pass along. The `seq`
-/// field is carried for legibility when eyeballing a trace; the relay
-/// forwards the bytes verbatim, so the wire shape is irrelevant to the
-/// measurement. Derived `Kind` (cast codec) — the schema-hashed `ID`
-/// is what the relay matches and the trace records; the value is
-/// immaterial.
-#[repr(C)]
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    Default,
-    PartialEq,
-    Eq,
-    bytemuck::Pod,
-    bytemuck::Zeroable,
-    aether_data::Kind,
-    aether_data::Schema,
-)]
-#[kind(name = "mlat.ping")]
-struct Ping {
-    seq: u32,
-}
-
-/// A relay forwards each inbound `Ping` to every configured downstream
-/// mailbox, inheriting the trace lineage so the whole topology is one
-/// causal tree. A leaf relay (empty `downstreams`) just receives and
-/// returns. Pooled (the `Actor` default) — so the worker-pool size
-/// gates how its fan-out and any concurrent load behave.
-struct Relay {
-    downstreams: Arc<[MailboxId]>,
-}
-
-impl aether_actor::Actor for Relay {
-    const NAMESPACE: &'static str = "mlat.relay";
-}
-impl aether_actor::Instanced for Relay {}
-impl aether_actor::HandlesKind<Ping> for Relay {}
-impl NativeActor for Relay {
-    type Config = Arc<[MailboxId]>;
-    fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-        Ok(Self {
-            downstreams: config,
-        })
-    }
-}
-impl NativeDispatch for Relay {
-    fn __aether_dispatch_envelope(
-        &mut self,
-        ctx: &mut NativeCtx<'_>,
-        kind: KindId,
-        payload: &[u8],
-    ) -> Option<()> {
-        if kind.0 != Ping::ID.0 {
-            return None;
-        }
-        // Forward the bytes verbatim to each downstream. The loop is
-        // the "one sender pushing to N inboxes" shape: each push stamps
-        // its own `t_sent`, so later children in a fan-out reveal any
-        // per-child enqueue skew.
-        for &down in self.downstreams.iter() {
-            // The minted child `MailId` isn't needed here — the trace
-            // observer records it; the relay only forwards.
-            let _ = ctx.send_envelope_traced(down, Ping::ID, payload);
-        }
-        Some(())
-    }
-}
-
-const RELAY_NS: &str = "mlat.relay";
+use crate::perf::harness::{
+    CellResult, Ping, Relay, SweepConfig, default_topologies, depth_chain, relay_id, run_sweep,
+};
 
 /// Self-sustaining ring actor for the multi-worker saturation profile.
 /// On each `Ping{seq}` it forwards `Ping{seq-1}` to its single `next`
@@ -163,122 +81,6 @@ fn ring_id(i: usize) -> MailboxId {
     MailboxId(mailbox_id_from_name(&format!("{RING_NS}:{i}")).0)
 }
 
-/// Deterministic `MailboxId` for relay instance `i`. Mirrors the
-/// substrate's `mailbox_id_from_name("{NAMESPACE}:{subname}")` so the
-/// whole topology can be wired from precomputed ids before any actor is
-/// spawned (sidesteps spawn-ordering between a relay and its
-/// downstreams).
-fn relay_id(i: usize) -> MailboxId {
-    MailboxId(mailbox_id_from_name(&format!("{RELAY_NS}:{i}")).0)
-}
-
-/// A topology is a DAG over relay indices: `downstreams[i]` lists the
-/// relays that relay `i` forwards to. Relay 0 is always the entry. The
-/// number of relays is `downstreams.len()`.
-struct Topology {
-    name: String,
-    downstreams: Vec<Vec<usize>>,
-}
-
-fn depth_chain(d: usize) -> Topology {
-    // 0 -> 1 -> ... -> d-1. Each relay forwards to the next; the last
-    // is a leaf.
-    let downstreams = (0..d)
-        .map(|i| if i + 1 < d { vec![i + 1] } else { vec![] })
-        .collect();
-    Topology {
-        name: format!("depth-{d}"),
-        downstreams,
-    }
-}
-
-fn fanout(b: usize) -> Topology {
-    // 0 -> {1, 2, ..., b}. Entry fans to b leaves.
-    let mut downstreams = vec![vec![]; b + 1];
-    downstreams[0] = (1..=b).collect();
-    Topology {
-        name: format!("fanout-{b}"),
-        downstreams,
-    }
-}
-
-fn two_level_tree() -> Topology {
-    // A -> {B, C} -> {D, E}, {E, F}. E (index 4) has two parents (B and
-    // C) — the shared-node contention case.
-    //   0=A 1=B 2=C 3=D 4=E 5=F
-    Topology {
-        name: "tree-A-BC-DEEF".to_owned(),
-        downstreams: vec![
-            vec![1, 2], // A -> B, C
-            vec![3, 4], // B -> D, E
-            vec![4, 5], // C -> E, F
-            vec![],     // D
-            vec![],     // E
-            vec![],     // F
-        ],
-    }
-}
-
-fn topologies() -> Vec<Topology> {
-    let mut t = Vec::new();
-    for d in [1usize, 2, 4, 8] {
-        t.push(depth_chain(d));
-    }
-    for b in [2usize, 4, 8] {
-        t.push(fanout(b));
-    }
-    t.push(two_level_tree());
-    t
-}
-
-/// p50 / p90 / p99 / max over a sample set, plus the sample count. All
-/// values are nanoseconds.
-#[derive(Clone, Copy, Default)]
-struct Stats {
-    p50: u64,
-    p90: u64,
-    p99: u64,
-    max: u64,
-    n: usize,
-}
-
-#[allow(
-    clippy::cast_precision_loss,
-    clippy::cast_possible_truncation,
-    clippy::cast_sign_loss
-)]
-fn nearest_rank(sorted: &[u64], q: f64) -> u64 {
-    if sorted.is_empty() {
-        return 0;
-    }
-    let idx = ((sorted.len() - 1) as f64 * q).round() as usize;
-    sorted[idx.min(sorted.len() - 1)]
-}
-
-fn summarize(mut samples: Vec<u64>) -> Stats {
-    let n = samples.len();
-    if n == 0 {
-        return Stats::default();
-    }
-    samples.sort_unstable();
-    Stats {
-        p50: nearest_rank(&samples, 0.50),
-        p90: nearest_rank(&samples, 0.90),
-        p99: nearest_rank(&samples, 0.99),
-        max: samples[n - 1],
-        n,
-    }
-}
-
-/// One fully-measured cell (per worker count × topology).
-struct Row {
-    workers: usize,
-    topo: String,
-    cond: &'static str,
-    hop: Stats,
-    handler: Stats,
-}
-
 /// Query the trace observer for one root's whole tree over the mail
 /// wire. Returns the node list, or `None` if the observer no longer has
 /// the root (only happens if the ring lapped it — not expected at these
@@ -302,10 +104,7 @@ const SETTLE_TIMEOUT: Duration = Duration::from_secs(10);
 /// saturation. The tokens self-sustain (each hop re-sends to the next
 /// neighbour with a decremented counter), so all workers stay fed
 /// without the injector bottleneck that starved the single-worker
-/// `mail_hop_profile`. Profile and classify the `aether-worker-N`
-/// threads to attribute the load tail: shared-queue contention
-/// (crossbeam recv/send + CAS + Arc churn — work-stealing-addressable)
-/// vs actor-serialization mutex wait vs settlement/trace.
+/// `mail_hop_profile`.
 ///
 /// ```text
 /// cargo test -p aether-substrate-bundle --release mail_saturation_profile --no-run
@@ -326,7 +125,6 @@ fn mail_saturation_profile() {
         return;
     };
 
-    // N actors in a cycle; actor i forwards to (i+1) % N.
     let n = 64usize;
     for i in 0..n {
         let next = ring_id((i + 1) % n);
@@ -336,9 +134,6 @@ fn mail_saturation_profile() {
             .expect("spawn ring relay");
     }
 
-    // Seed M tokens with a high hop budget so they outlast the run; the
-    // tokens circulate without further injection. Spread across the ring
-    // so multiple actors are ready at once and every worker is fed.
     let m: usize = env::var("TOKENS")
         .ok()
         .and_then(|s| s.parse().ok())
@@ -371,8 +166,7 @@ fn mail_saturation_profile() {
 /// and its settlement signal would never fire — so "every injected root
 /// settles within the timeout" is the exactness check. Each surviving
 /// trace tree is also asserted complete (full depth chain), catching a
-/// settle that fired on a truncated chain. Runs on the pool at max
-/// workers so the shard fan-out is actually exercised.
+/// settle that fired on a truncated chain.
 #[test]
 #[allow(clippy::print_stderr)]
 fn sharded_trace_settles_every_root() {
@@ -433,259 +227,56 @@ fn flaky_sharded_trace_settles_every_root() {
     sharded_trace_settles_every_root();
 }
 
-/// Lifecycle bridge for [`lifecycle_latency_observe`]: subscribed to the
-/// `Tick` input stream, it emits one `Ping` into the entry relay per
-/// frame, inheriting the tick's trace lineage so the whole per-frame
-/// chain is one causal tree. The honest stand-in for a real tick-reactive
-/// component (player, camera): the substrate's own `Tick` fan-out drives
-/// the work — no synthetic injector, no per-root settlement block.
-struct TickSource {
-    entry: MailboxId,
-    seq: u32,
-}
-
-impl aether_actor::Actor for TickSource {
-    const NAMESPACE: &'static str = "mlat.ticksrc";
-}
-impl aether_actor::Instanced for TickSource {}
-impl aether_actor::HandlesKind<Tick> for TickSource {}
-impl NativeActor for TickSource {
-    type Config = MailboxId;
-    fn init(entry: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-        Ok(Self { entry, seq: 0 })
-    }
-}
-impl NativeDispatch for TickSource {
-    fn __aether_dispatch_envelope(
-        &mut self,
-        ctx: &mut NativeCtx<'_>,
-        kind: KindId,
-        _payload: &[u8],
-    ) -> Option<()> {
-        if kind.0 != Tick::ID.0 {
-            return None;
-        }
-        // One Ping per tick into the entry relay, inheriting the tick's
-        // lineage (`send_envelope_traced`) so the per-frame chain settles
-        // as one tree the trace observer records. `seq` is for legibility
-        // only — relays forward the bytes verbatim.
-        let bytes = Ping { seq: self.seq }.encode_into_bytes();
-        self.seq = self.seq.wrapping_add(1);
-        let _ = ctx.send_envelope_traced(self.entry, Ping::ID, &bytes);
-        Some(())
-    }
-}
-
-const TICKSRC_NS: &str = "mlat.ticksrc";
-
-/// Deterministic id for the single tick source (subname `"src"`).
-fn ticksrc_id() -> MailboxId {
-    MailboxId(mailbox_id_from_name(&format!("{TICKSRC_NS}:src")).0)
-}
-
 const OBSERVE_FRAMES: u32 = 1000;
 
 /// Non-perturbing latency harness: drive the substrate with its **real
 /// lifecycle** (`advance` → `Tick` fan-out → a tick-reactive source →
-/// the relay topology) and **harvest the trace ring after the fact** via
-/// one [`DescribeWindow`] query. The sibling to [`mail_latency_sweep`],
-/// minus its two methodology hazards:
+/// the relay topology) and **harvest the trace ring after the fact**.
+/// Delegates the sweep to [`run_sweep`]; this test just builds the
+/// default config (the four-worker × full-topology grid) and prints the
+/// tables.
 ///
-/// - **No synthetic injector.** The work is produced by the substrate's
-///   own `Tick` delivery to an input-subscribed actor — the real
-///   mechanic a component sees — not by a test thread pushing roots.
-/// - **No per-root blocking.** `mail_latency_sweep`'s idle mode injects
-///   one root and blocks on its settlement before the next, so the pool
-///   goes cold between roots and every hop pays a fresh wakeup. Here the
-///   only block is the single `advance` round-trip for the whole run, and
-///   the measurement is a passive read of the resident ring afterward.
+/// Default is **flat-out** `advance` (warm — isolates per-hop dispatch
+/// cost). `AETHER_LAT_PACE_HZ=60` paces one frame per period instead
+/// (workers park in the gaps → realistic frame-loop latency).
 ///
-/// Default is **flat-out** `advance` — frames run back-to-back, workers
-/// stay warm, so the numbers isolate the per-hop dispatch cost.
-/// `AETHER_LAT_PACE_HZ=60` paces one frame per period instead (workers
-/// park in the gaps → realistic frame-loop latency including the
-/// once-per-frame wakeup).
-///
-/// `#[ignore]` — a measurement run, not a correctness gate. Skips cleanly
-/// when no wgpu adapter is available.
+/// `#[ignore]` — a measurement run, not a correctness gate. Skips
+/// cleanly (empty result) when no wgpu adapter is available.
 #[test]
 #[ignore = "measurement harness — run on demand with --ignored --nocapture --release"]
-#[allow(
-    clippy::print_stdout,
-    clippy::print_stderr,
-    clippy::cast_precision_loss,
-    clippy::too_many_lines
-)]
+#[allow(clippy::print_stdout, clippy::print_stderr)]
 fn lifecycle_latency_observe() {
     let max_workers = available_parallelism().map_or(2, |n| n.get().saturating_sub(1).max(1));
-    let worker_set: BTreeSet<usize> = [1usize, 2, 4, max_workers].into_iter().collect();
+    let worker_set: Vec<usize> = [1usize, 2, 4, max_workers]
+        .into_iter()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
 
-    if let Err(e) = TestBench::builder().size(16, 16).build() {
-        eprintln!(
-            "skipping lifecycle_latency_observe: TestBench boot failed (likely no wgpu adapter): {e}"
-        );
-        return;
-    }
-
-    // `AETHER_LAT_PACE_HZ=N` → pace one frame per 1/N s (workers park
-    // between frames). Unset → flat-out (warm).
     let pace_hz: Option<u64> = env::var("AETHER_LAT_PACE_HZ")
         .ok()
         .and_then(|s| s.parse().ok())
         .filter(|&h| h > 0);
-    let cond = if pace_hz.is_some() { "paced" } else { "warm" };
 
-    let mut rows: Vec<Row> = Vec::new();
-
-    for &workers in &worker_set {
-        for topo in topologies() {
-            let Ok(mut tb) = TestBench::builder()
-                .with_workers(Some(workers))
-                .size(16, 16)
-                .build()
-            else {
-                eprintln!("skipping {} @ {workers}w: boot failed", topo.name);
-                continue;
-            };
-
-            // Relay topology (entry = relay 0), then the tick source
-            // pointed at it. Ids are deterministic, so spawn order is
-            // irrelevant.
-            let n = topo.downstreams.len();
-            let mut spawned_ok = true;
-            for i in 0..n {
-                let downs: Arc<[MailboxId]> =
-                    topo.downstreams[i].iter().map(|&j| relay_id(j)).collect();
-                let sub = i.to_string();
-                if let Err(e) = tb
-                    .spawn_actor::<Relay>(Subname::Named(&sub), downs)
-                    .finish()
-                {
-                    eprintln!("spawn failed for {} relay {i}: {e:?}", topo.name);
-                    spawned_ok = false;
-                    break;
-                }
-            }
-            if !spawned_ok {
-                continue;
-            }
-            if let Err(e) = tb
-                .spawn_actor::<TickSource>(Subname::Named("src"), relay_id(0))
-                .finish()
-            {
-                eprintln!("tick source spawn failed for {}: {e:?}", topo.name);
-                continue;
-            }
-
-            // Wire the source into the platform `Tick` stream so `advance`
-            // delivers a tick to it each frame (ADR-0021 explicit
-            // subscribe; auto-subscribe retired in #403 / #640).
-            let sub_req = SubscribeInput {
-                kind: Tick::ID,
-                mailbox: ticksrc_id(),
-            }
-            .encode_into_bytes();
-            match tb.send_bytes_and_await("aether.input", SubscribeInput::ID, sub_req) {
-                Ok(reply) => match SubscribeInputResult::decode_from_bytes(&reply) {
-                    Some(SubscribeInputResult::Ok) => {}
-                    other => {
-                        eprintln!("Tick subscribe failed for {}: {other:?}", topo.name);
-                        continue;
-                    }
-                },
-                Err(e) => {
-                    eprintln!("Tick subscribe send failed for {}: {e:?}", topo.name);
-                    continue;
-                }
-            }
-
-            // Drive via the real lifecycle. The only block is the single
-            // `advance` round-trip for the whole run (flat-out), or one
-            // per paced frame.
-            let t0 = Instant::now();
-            match pace_hz {
-                Some(hz) => {
-                    let period = Duration::from_secs_f64(1.0 / hz as f64);
-                    for _ in 0..OBSERVE_FRAMES {
-                        let f = Instant::now();
-                        let _ = tb.advance(1);
-                        if let Some(rem) = period.checked_sub(f.elapsed()) {
-                            thread::sleep(rem);
-                        }
-                    }
-                }
-                None => {
-                    let _ = tb.advance(OBSERVE_FRAMES);
-                }
-            }
-            let drive_ms = u64::try_from(t0.elapsed().as_millis()).unwrap_or(u64::MAX);
-
-            // Harvest the resident ring once, after the run. The window is
-            // generous; the `Ping`-kind filter below isolates the relay
-            // hops regardless, so setup / Tick / query mail never counts.
-            let req = DescribeWindow {
-                window: TraceWindow::Relative {
-                    last_ms: drive_ms.saturating_add(1_000),
-                },
-                max_mails: Some(100_000),
-            }
-            .encode_into_bytes();
-            let mails = match tb.send_bytes_and_await(
-                TRACE_OBSERVER_MAILBOX_NAME,
-                DescribeWindow::ID,
-                req,
-            ) {
-                Ok(reply) => match DescribeWindowResult::decode_from_bytes(&reply) {
-                    Some(DescribeWindowResult::Ok { mails }) => mails,
-                    Some(DescribeWindowResult::Err { too_many }) => {
-                        eprintln!(
-                            "describe_window over cap ({too_many:?}) for {} @ {workers}w — lower OBSERVE_FRAMES or raise AETHER_TRACE_RING_CAPACITY",
-                            topo.name
-                        );
-                        continue;
-                    }
-                    None => {
-                        eprintln!("describe_window decode failed for {}", topo.name);
-                        continue;
-                    }
-                },
-                Err(e) => {
-                    eprintln!("describe_window send failed for {}: {e:?}", topo.name);
-                    continue;
-                }
-            };
-
-            // Per-relay-hop samples, filtered to the local `Ping` kind.
-            let mut hop = Vec::new();
-            let mut handler = Vec::new();
-            for node in &mails {
-                if node.kind.0 != Ping::ID.0 {
-                    continue;
-                }
-                if let Some(recv) = node.t_received {
-                    hop.push(recv.0.saturating_sub(node.t_sent.0));
-                    if let Some(fin) = node.t_finished {
-                        handler.push(fin.0.saturating_sub(recv.0));
-                    }
-                }
-            }
-            rows.push(Row {
-                workers,
-                topo: topo.name.clone(),
-                cond,
-                hop: summarize(hop),
-                handler: summarize(handler),
-            });
-        }
+    let cfg = SweepConfig {
+        workers: worker_set,
+        topologies: default_topologies(),
+        frames: OBSERVE_FRAMES,
+        pace_hz,
+    };
+    let rows = run_sweep(&cfg);
+    if rows.is_empty() {
+        eprintln!("skipping lifecycle_latency_observe: no cells measured (likely no wgpu adapter)");
+        return;
     }
-
     print_observe_tables(&rows, pace_hz);
 }
 
 /// Print the lifecycle-harness HOP + HANDLER tables.
 #[allow(clippy::print_stdout, clippy::cast_precision_loss)]
-fn print_observe_tables(rows: &[Row], pace_hz: Option<u64>) {
+fn print_observe_tables(rows: &[CellResult], pace_hz: Option<u64>) {
     let us = |ns: u64| -> String { format!("{:.2}", ns as f64 / 1000.0) };
+    let cond = if pace_hz.is_some() { "paced" } else { "warm" };
 
     println!();
     println!("=== lifecycle-driven mail latency (all values µs; n = sample count) ===");
@@ -720,7 +311,7 @@ fn print_observe_tables(rows: &[Row], pace_hz: Option<u64>) {
                 "{:>3}   {:<16} {:<5} {:>9} {:>9} {:>9} {:>9} {:>7}",
                 r.workers,
                 r.topo,
-                r.cond,
+                cond,
                 us(s.p50),
                 us(s.p90),
                 us(s.p99),


### PR DESCRIPTION
## Summary

The **harness comparison mode** for the noise-aware perf report (ADR-0085) — build-breakdown item 1 of iamacoffeepot/aether#1077. PR 1 of 2; the CI workflow + sticky-comment poster follow in PR 2.

- Lifts the lifecycle latency sweep engine (relay actors, topologies, `run_sweep`) out of the `#[cfg(test)]` `mail_latency` module into a non-test `pub mod perf` so the new `perf-trial` bin can drive it. `TestBench::spawn_actor` is un-gated from `#[cfg(test)]` (still `pub(crate)`) so the in-crate harness reaches it; the on-demand `lifecycle_latency_observe` table test now calls `run_sweep`.
- **`perf::report`** — the `TrialReport` JSON schema + `compare()`. Per (worker-count × topology × metric × percentile) cell it pairs the per-trial delta `δ_t = cand_t − base_t` (so shared runner drift cancels, ADR-0085 §3), then a deterministic paired test (sign-consistency + a robust effect floor with a relative-significance minimum) classifies **improved / stable / regressed**. Markdown renderer for the sticky comment.
- **`perf-trial` bin** — one sweep → `TrialReport` JSON on stdout (env-configured workers/topos/frames/pace).
- **`perf-compare` bin** — interleave K base/candidate `perf-trial` runs on one runner (fresh process each, ADR-0085 §1), compare, emit JSON + markdown. Supports same-binary **env A/B** (the iamacoffeepot/aether#1076 stickiness self-test), and is **informational** — exits 0 even with regressions; non-zero only on operational failure (ADR-0085 §4).

## Acceptance — it reproduces the iamacoffeepot/aether#1076 verdicts

Running the env A/B (`AETHER_LOCAL_STICKY_MAX=1` vs `=8`) on one `perf-trial` binary, even at a smoke-level K=2, reproduces the by-hand iamacoffeepot/aether#1076 verdict structure:

- every fan-out cell (`fanout-4`, `fanout-8`, `tree`) reads **improved** (hop p99 −76% / −69% / −86%),
- every chain cell (`depth-1`, `depth-8`) reads **stable**.

It ran on this branch (pre-iamacoffeepot/aether#1079), so both sides share the slow-poll cost — and pairing cancels it, so the stickiness signal shows through cleanly. That is the paired-delta design doing its job.

The fixture unit tests pin the three ADR-0085 worked-example calls: consistent win → improved, uniform run-order drift → stable (pairing cancels), one-off tail outlier → stable (median is robust), plus a regression case and a tiny-but-consistent change below the practical floor → stable.

## Scope / follow-ups

- **PR 2:** the CI workflow (path-filter + `perf` label, one job, base+PR same runner) and the sticky-comment poster.
- **Live iamacoffeepot/aether#1076 reproduction run:** deferred until iamacoffeepot/aether#1079 lands, so the warm baseline is genuinely warm rather than ~100 Hz poll-contaminated. The tooling and the fixture-backed verdict logic are complete and tested here.

## Test plan

- [x] `cargo fmt --all -- --check`; `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `scripts/preflight.sh` — 1209 tests pass (+6 `perf::report` fixtures), incl. the settlement tests that consume the lifted harness
- [x] `perf-trial` emits valid `TrialReport` JSON (schema tag + correct per-cell sample counts)
- [x] `perf-compare` env A/B end-to-end reproduces the iamacoffeepot/aether#1076 fan-out-improved / chains-stable structure

Refs iamacoffeepot/aether#1077.
