### PR TITLE
ci(perf): on-PR dispatch perf comparison workflow + orchestration

### DIFF
--- a/.github/workflows/perf-compare.yml
+++ b/.github/workflows/perf-compare.yml
@@ -1,0 +1,87 @@
+name: Perf compare
+
+# Noise-aware dispatch perf comparison for a PR (iamacoffeepot/aether#1077,
+# ADR-0085). Builds the latency sweep binary from the PR and its
+# merge-base, interleaves K trials of each on one runner (the pairing
+# that cancels run-to-run drift), and posts a sticky comparison comment.
+#
+# Informational by construction: this workflow's job is NOT in ci.yml's
+# `ci-pass` aggregator, so a regression never blocks a merge (ADR-0085
+# §4). Cost-bounded: path-filtered + label-gated, so it does not run on
+# every PR.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+# Perf runs are expensive (two release builds + K interleaved trials);
+# cancel a superseded run when the PR is pushed again.
+concurrency:
+  group: perf-compare-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Detect dispatch-path changes
+    runs-on: ubuntu-latest
+    outputs:
+      perf: ${{ steps.filter.outputs.perf }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            perf:
+              - 'crates/aether-substrate/src/scheduler/**'
+              - 'crates/aether-substrate/src/mail/**'
+              - 'crates/aether-substrate-bundle/src/perf/**'
+
+  compare:
+    name: Compare dispatch perf vs merge-base
+    needs: changes
+    # Auto-run on scheduler / mail / perf path changes, or when the
+    # `perf` label is present; force-skip with `perf-skip`.
+    if: >-
+      !contains(github.event.pull_request.labels.*.name, 'perf-skip') &&
+      (needs.changes.outputs.perf == 'true' ||
+       contains(github.event.pull_request.labels.*.name, 'perf'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    # Two release builds (base build is cache-cold in its worktree) plus
+    # the interleaved trials. Cap so a stall doesn't burn the quota.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # merge-base needs full history (scripts/perf-compare.sh).
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Linux deps (ALSA for cpal, Mesa lavapipe for wgpu)
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+          mesa-vulkan-drivers
+      - uses: Swatinem/rust-cache@v2
+      - name: Run perf comparison
+        run: scripts/perf-compare.sh
+      - name: Upsert sticky PR comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          marker='<!-- aether-perf-report -->'
+          body="$(cat perf-report.md)"
+          # Find an existing comment carrying our marker (sticky upsert,
+          # so a re-push edits in place instead of spamming new comments).
+          existing="$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            --jq "map(select(.body | contains(\"$marker\"))) | .[0].id // empty")"
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$existing" -f body="$body" >/dev/null
+            echo "updated sticky comment $existing"
+          else
+            gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="$body" >/dev/null
+            echo "created sticky comment"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,8 @@ spikes/*/target/
 /traces/*
 !/traces/.gitkeep
 .claude/release-state.json
+# Perf-comparison artifacts written by scripts/perf-compare.sh
+# (iamacoffeepot/aether#1077) — per-run JSON + sticky-comment markdown,
+# regenerated each CI run, never committed.
+/perf-report.json
+/perf-report.md

--- a/crates/aether-substrate-bundle/src/bin/perf-trial.rs
+++ b/crates/aether-substrate-bundle/src/bin/perf-trial.rs
@@ -22,7 +22,8 @@ use std::process::{Command, ExitCode};
 use std::thread::available_parallelism;
 
 use aether_substrate_bundle::perf::harness::{
-    SweepConfig, Topology, default_topologies, depth_chain, fanout, run_sweep, two_level_tree,
+    SweepConfig, Topology, default_topologies, depth_chain, fanout, pace_hz_from_env, run_sweep,
+    two_level_tree,
 };
 use aether_substrate_bundle::perf::report::TrialReport;
 
@@ -84,10 +85,7 @@ fn main() -> ExitCode {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(200);
-    let pace_hz: Option<u64> = env::var("AETHER_LAT_PACE_HZ")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .filter(|&h| h > 0);
+    let pace_hz = pace_hz_from_env();
 
     let cfg = SweepConfig {
         workers: parse_workers(),

--- a/crates/aether-substrate-bundle/src/perf/harness.rs
+++ b/crates/aether-substrate-bundle/src/perf/harness.rs
@@ -16,6 +16,7 @@
 //! pool size; a fan-out either parallelises across workers or queues on
 //! a small pool. So the sweep takes the worker set as an axis.
 
+use std::env;
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -279,6 +280,17 @@ pub struct SweepConfig {
     pub topologies: Vec<Topology>,
     pub frames: u32,
     pub pace_hz: Option<u64>,
+}
+
+/// Read the optional `AETHER_LAT_PACE_HZ` pacing override (frames/sec;
+/// `None` = flat-out / warm). Shared by the on-demand harness test and
+/// the `perf-trial` bin so the parse lives in one place.
+#[must_use]
+pub fn pace_hz_from_env() -> Option<u64> {
+    env::var("AETHER_LAT_PACE_HZ")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .filter(|&h| h > 0)
 }
 
 /// Drive the sweep and return per-cell percentiles. Each cell boots a

--- a/crates/aether-substrate-bundle/src/perf/report.rs
+++ b/crates/aether-substrate-bundle/src/perf/report.rs
@@ -214,6 +214,12 @@ pub struct CompareConfig {
     /// Minimum fractional change relative to the base median (practical
     /// significance) — suppresses tiny-but-consistent deltas.
     pub rel_floor: f64,
+    /// Absolute floor in nanoseconds — a change smaller than this is
+    /// below the harness's resolution (sub-microsecond dispatch-glue
+    /// differences read as noise; see the latency-sweep finding that
+    /// ~100ns deltas are unresolvable). Without it, a 50ns shift on a
+    /// 170ns sub-µs handler cell reads as a 30% "regression".
+    pub abs_floor_ns: f64,
     /// Fraction of trials whose delta must share the effect's sign.
     pub consistency: f64,
 }
@@ -223,6 +229,7 @@ impl Default for CompareConfig {
         Self {
             effect_floor_iqr: 1.5,
             rel_floor: 0.10,
+            abs_floor_ns: 300.0,
             consistency: 0.75,
         }
     }
@@ -354,7 +361,9 @@ fn classify(
         .count() as f64;
     let consistent = same_sign / n >= cfg.consistency;
 
-    let floor = (cfg.effect_floor_iqr * delta_iqr).max(cfg.rel_floor * base_median);
+    let floor = (cfg.effect_floor_iqr * delta_iqr)
+        .max(cfg.rel_floor * base_median)
+        .max(cfg.abs_floor_ns);
     let large = delta_median.abs() > floor;
 
     if consistent && large {
@@ -531,6 +540,19 @@ mod tests {
         // crying wolf on a sub-noise dispatch-glue change.
         let base = side(&[1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000]);
         let cand = side(&[1030, 1030, 1030, 1030, 1030, 1030, 1030, 1030]);
+        let rep = compare(&base, &cand, CompareConfig::default());
+        assert_eq!(p50_verdict(&rep), Verdict::Stable);
+    }
+
+    #[test]
+    fn sub_microsecond_consistent_shift_is_below_absolute_floor() {
+        // A consistent 170ns -> 120ns shift (50ns) on a sub-µs handler
+        // cell is a 30% relative change but below the harness's
+        // resolution — must read stable, not "improved". (Regression
+        // guard for the dry-run finding where identical binaries
+        // differed ~50ns on depth-1 handler and flagged a false win.)
+        let base = side(&[170, 170, 165, 172, 168, 170, 169, 171]);
+        let cand = side(&[120, 122, 118, 121, 119, 120, 123, 120]);
         let rep = compare(&base, &cand, CompareConfig::default());
         assert_eq!(p50_verdict(&rep), Verdict::Stable);
     }

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -31,7 +31,8 @@ use aether_substrate::{BootError, NativeActor, NativeCtx, NativeDispatch, Native
 
 use super::TestBench;
 use crate::perf::harness::{
-    CellResult, Ping, Relay, SweepConfig, default_topologies, depth_chain, relay_id, run_sweep,
+    CellResult, Ping, Relay, SweepConfig, default_topologies, depth_chain, pace_hz_from_env,
+    relay_id, run_sweep,
 };
 
 /// Self-sustaining ring actor for the multi-worker saturation profile.
@@ -253,10 +254,7 @@ fn lifecycle_latency_observe() {
         .into_iter()
         .collect();
 
-    let pace_hz: Option<u64> = env::var("AETHER_LAT_PACE_HZ")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .filter(|&h| h > 0);
+    let pace_hz = pace_hz_from_env();
 
     let cfg = SweepConfig {
         workers: worker_set,

--- a/scripts/perf-compare.sh
+++ b/scripts/perf-compare.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Noise-aware dispatch perf comparison for a PR (iamacoffeepot/aether#1077,
+# ADR-0085). Builds the `aether-perf-trial` sweep binary from both the PR
+# tip and its merge-base with main, then interleaves K trials of each on
+# THIS runner (same machine — the pairing that cancels run-to-run drift)
+# and renders the comparison.
+#
+# Outputs (in repo root):
+#   perf-report.json   machine-readable ComparisonReport
+#   perf-report.md     sticky PR-comment markdown body
+#
+# Informational only — exits 0 even with regressions present (a non-zero
+# exit means an operational failure: a build broke, a trial crashed).
+#
+# Env knobs (defaults tuned for the CI preset — warm, a fan-out + chain
+# subset, ~1 min of measurement once iamacoffeepot/aether#1079 landed):
+#   PERF_K               trials per side (default 12)
+#   AETHER_PERF_WORKERS  pool sizes (default "max,2")
+#   AETHER_PERF_FRAMES   frames per cell (default 200)
+#   AETHER_PERF_TOPOS    "ci" | "full" (default "ci")
+#
+# Usage: scripts/perf-compare.sh
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+K="${PERF_K:-12}"
+export AETHER_PERF_WORKERS="${AETHER_PERF_WORKERS:-max,2}"
+export AETHER_PERF_FRAMES="${AETHER_PERF_FRAMES:-200}"
+export AETHER_PERF_TOPOS="${AETHER_PERF_TOPOS:-ci}"
+
+json_out="$ROOT/perf-report.json"
+md_out="$ROOT/perf-report.md"
+
+# Resolve the baseline: the merge-base of the PR tip and main, so the
+# comparison isolates THIS PR's changes (not whatever else merged since
+# the branch forked).
+git fetch --no-tags --quiet origin main
+base_sha="$(git merge-base HEAD FETCH_HEAD)"
+base_short="$(git rev-parse --short "$base_sha")"
+echo "[perf-compare] baseline = merge-base $base_short; K=$K, workers=$AETHER_PERF_WORKERS, frames=$AETHER_PERF_FRAMES, topos=$AETHER_PERF_TOPOS"
+
+# Base checkout in a throwaway worktree, cleaned up on exit.
+base_wt="$(mktemp -d "${TMPDIR:-/tmp}/aether-perf-base.XXXXXX")"
+cleanup() {
+    git worktree remove --force "$base_wt" 2>/dev/null || true
+}
+trap cleanup EXIT
+git worktree add --quiet --detach "$base_wt" "$base_sha"
+
+# Build the candidate (PR) trial + compare binaries, and the base trial.
+echo "[perf-compare] building candidate (PR) binaries…"
+cargo build --release -p aether-substrate-bundle \
+    --bin aether-perf-trial --bin aether-perf-compare
+
+cand_trial="$ROOT/target/release/aether-perf-trial"
+compare_bin="$ROOT/target/release/aether-perf-compare"
+base_trial="$base_wt/target/release/aether-perf-trial"
+
+echo "[perf-compare] building base ($base_short) trial binary…"
+if ! (cd "$base_wt" && cargo build --release -p aether-substrate-bundle --bin aether-perf-trial); then
+    # The merge-base predates the perf-trial bin (a PR forked before
+    # iamacoffeepot/aether#1081). Nothing to compare against — emit a note,
+    # not a failure (this job is informational).
+    cat > "$md_out" <<EOF
+<!-- aether-perf-report -->
+## dispatch perf
+
+_Baseline ($base_short) predates the \`perf-trial\` harness — no comparison available for this PR._
+EOF
+    echo "[perf-compare] base build failed (baseline predates perf-trial); wrote note to $md_out"
+    exit 0
+fi
+
+# Interleave K trials per side on this runner; render JSON + markdown.
+echo "[perf-compare] running $K interleaved trials per side…"
+"$compare_bin" \
+    --base "$base_trial" \
+    --cand "$cand_trial" \
+    -k "$K" \
+    --out "$json_out" \
+    --title "PR vs merge-base $base_short" \
+    --subtitle "baseline $base_short · $K trials/config, interleaved on one runner" \
+    > "$md_out"
+
+echo "[perf-compare] wrote $json_out and $md_out"


### PR DESCRIPTION
## Summary

PR 2 of the noise-aware perf report (ADR-0085, iamacoffeepot/aether#1077) — wires the comparison tool from PR 1 (iamacoffeepot/aether#1081) into CI.

- **`scripts/perf-compare.sh`** — resolves the merge-base with `main`, builds `aether-perf-trial` from both the PR tip and the base (in a throwaway `git worktree`), then interleaves K trials of each **on one runner** (the pairing that cancels run-to-run drift, ADR-0085 §3) and renders `perf-report.{json,md}`. Guards a baseline that predates the `perf-trial` bin (emits a note, not a failure). Informational — exits 0 even with regressions present.
- **`.github/workflows/perf-compare.yml`** — one job on `ubuntu-latest` + `mesa-vulkan-drivers` (lavapipe, same as the scenario tests). Gated by a `scheduler/` `mail/` `perf/` path-filter **or** a `perf` label, force-skip via `perf-skip`. Upserts a **sticky comment** keyed on a hidden marker (`<!-- aether-perf-report -->`). **Not in `ci.yml`'s `ci-pass` aggregator**, so it never blocks a merge (ADR-0085 §4).
- **Classifier hardening** — added an **absolute floor (~0.3µs)** to the verdict rule. A self-compare of a behaviour-identical binary was flagging sub-µs cells (a 50ns shift on a 170ns handler cell read as a 30% "win"); the floor suppresses changes below the harness's resolution (consistent with the prior finding that ~100ns dispatch-glue deltas are unresolvable). Fixture test added.
- **Dedup** the `AETHER_LAT_PACE_HZ` parse into `perf::harness::pace_hz_from_env()` (was duplicated in `mail_latency.rs` + `perf-trial.rs` — the Qodana `DuplicatedCode` finding from PR 1).
- `.gitignore` the per-run `perf-report.{json,md}` artifacts.

## Validation

The classifier is now calibrated both directions — sensitive to real change, robust to noise:

- **Real signal (PR 1's env A/B):** `AETHER_LOCAL_STICKY_MAX=1` vs `=8` on one binary flags every fan-out cell `improved` (hop p99 −76% / −69% / −86%) and every chain `stable` — reproduces the iamacoffeepot/aether#1076 verdicts. The large fan-out deltas are far above the new absolute floor, so it doesn't touch them.
- **Noise (this PR):** a self-compare of a behaviour-identical binary (base vs base + the no-op dedup) at the CI default **K=12 reads 60/60 stable, 0 improved, 0 regressed** — no false positives. (At K=4 before the floor it falsely flagged 9 cells; the dry-run that surfaced that is what motivated the absolute floor.)
- The full `perf-compare.sh` path (worktree + dual release build + merge-base + interleaved compare + JSON/markdown output) ran end-to-end locally.

## Caveat

The workflow YAML can only be *fully* exercised by a real CI run — the first PR that trips the path-filter or carries the `perf` label will be its live test. Everything testable locally (the script path, the classifier, the dedup, fmt/clippy/preflight) is green.

## Test plan

- [x] `cargo fmt --all -- --check`; `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `scripts/preflight.sh` — 1210 tests pass (+1 abs-floor fixture)
- [x] `perf-compare.sh` end-to-end dry-run (worktree, dual build, compare, output)
- [x] K=12 identical-binary self-compare → 60/60 stable (no false positives)
- [x] workflow YAML parses; gating / sticky-upsert / not-in-`ci-pass` reviewed by hand

Refs iamacoffeepot/aether#1077.
