### PR TITLE
perf(substrate): add wide trivial fan-out widths to the latency harness

### DIFF
--- a/crates/aether-substrate-bundle/src/bin/perf-trial.rs
+++ b/crates/aether-substrate-bundle/src/bin/perf-trial.rs
@@ -14,6 +14,8 @@
 //! - `AETHER_LAT_PACE_HZ` — pace one frame per period (else flat-out).
 //! - `AETHER_LAT_HEAVY_WORK` — when set, append CPU-heavy fan-outs
 //!   (iamacoffeepot/aether#1074); unset, the topology set is unchanged.
+//! - `AETHER_LAT_WIDE_FANOUT` — comma list of extra trivial fan-out
+//!   widths to append (iamacoffeepot/aether#1075); unset, unchanged.
 //! - `AETHER_PERF_GIT_SHA` — stamped into the report; falls back to
 //!   `git rev-parse HEAD`.
 
@@ -26,6 +28,7 @@ use std::thread::available_parallelism;
 use aether_substrate_bundle::perf::harness::{
     SweepConfig, Topology, default_topologies, depth_chain, fanout, fanout_heavy,
     heavy_work_iters_from_env, pace_hz_from_env, run_sweep, two_level_tree,
+    wide_fanout_widths_from_env,
 };
 use aether_substrate_bundle::perf::report::TrialReport;
 
@@ -74,6 +77,13 @@ fn parse_topologies() -> Vec<Topology> {
         for b in [4usize, 8] {
             topos.push(fanout_heavy(b, heavy));
         }
+    }
+    // Opt-in wide trivial fan-outs (iamacoffeepot/aether#1075): when
+    // AETHER_LAT_WIDE_FANOUT is set, append the listed widths so the
+    // stickiness width-crossover can be located through the comparison
+    // too. Unset, the topology set is unchanged.
+    for w in wide_fanout_widths_from_env() {
+        topos.push(fanout(w));
     }
     topos
 }

--- a/crates/aether-substrate-bundle/src/perf/harness.rs
+++ b/crates/aether-substrate-bundle/src/perf/harness.rs
@@ -379,12 +379,53 @@ pub fn heavy_work_iters_from_env() -> u64 {
         .unwrap_or(0)
 }
 
+/// Parse the optional `AETHER_LAT_WIDE_FANOUT` knob — a comma list of
+/// *extra* trivial fan-out widths to append to the sweep, e.g.
+/// `"16,32,64,128"`. Unset or empty appends nothing, so the default
+/// sweep is unchanged (iamacoffeepot/aether#1075). Widths should exceed
+/// the default `≤8` set; values are sorted and de-duplicated.
+///
+/// The point is to push past the default widths and locate the
+/// stickiness width-crossover `W*` — the width at which keeping a
+/// fan-out's children on the producing worker (`AETHER_LOCAL_STICKY_MAX`
+/// `≥ width`) stops winning, because draining `N` children serially on
+/// one worker overtakes the cross-worker handoff that keeping-local
+/// avoided. Sweep this against `AETHER_LOCAL_STICKY_MAX` (`1` vs width)
+/// and the win should invert somewhere past `W* ≈ handoff / per-child`.
+#[must_use]
+pub fn wide_fanout_widths_from_env() -> Vec<usize> {
+    let Ok(spec) = env::var("AETHER_LAT_WIDE_FANOUT") else {
+        return Vec::new();
+    };
+    let mut out: Vec<usize> = spec
+        .split(',')
+        .filter_map(|t| t.trim().parse::<usize>().ok())
+        .filter(|&w| w > 0)
+        .collect();
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
+/// Per-cell cap on harvested trace nodes. The `DescribeWindow` query
+/// refuses windows larger than this (replying `too_many`), and a frame
+/// produces roughly one trace node per relay delivery — so a wide
+/// fan-out at the full frame count would overflow. Kept under the 100k
+/// query cap to leave margin for the per-frame tick/setup nodes the
+/// window also holds (iamacoffeepot/aether#1075).
+const MAX_NODES_PER_CELL: u32 = 90_000;
+
 /// Drive the sweep and return per-cell percentiles. Each cell boots a
 /// fresh [`TestBench`], wires the topology + tick source, advances, and
 /// harvests the trace ring once. A cell whose bench fails to boot (no
 /// wgpu adapter) or whose harvest overflows is logged via `tracing` and
 /// skipped — so a driverless box returns fewer cells (possibly empty)
 /// rather than panicking.
+///
+/// The per-cell frame count is clamped so wide fan-outs stay under
+/// `MAX_NODES_PER_CELL`; this is a no-op for the narrow default
+/// topologies (their full frame count is well under the cap), so their
+/// numbers are unchanged.
 #[allow(clippy::cast_precision_loss, clippy::too_many_lines)]
 #[must_use]
 pub fn run_sweep(cfg: &SweepConfig) -> Vec<CellResult> {
@@ -456,12 +497,23 @@ pub fn run_sweep(cfg: &SweepConfig) -> Vec<CellResult> {
                 }
             }
 
+            // Clamp the per-cell frame count so a wide fan-out stays
+            // under the trace-window node cap. Each frame produces ~one
+            // `Ping` node per relay delivery (every downstream forward
+            // plus the tick source's send into the entry); `+ 8` leaves
+            // slack for the per-frame tick/setup nodes. A no-op for the
+            // narrow default topologies (iamacoffeepot/aether#1075).
+            let deliveries_per_frame = 1 + topo.downstreams.iter().map(Vec::len).sum::<usize>();
+            let frame_cap =
+                MAX_NODES_PER_CELL / u32::try_from(deliveries_per_frame + 8).unwrap_or(u32::MAX);
+            let frames = cfg.frames.min(frame_cap.max(1));
+
             // Drive via the real lifecycle.
             let t0 = Instant::now();
             match cfg.pace_hz {
                 Some(hz) => {
                     let period = Duration::from_secs_f64(1.0 / hz as f64);
-                    for _ in 0..cfg.frames {
+                    for _ in 0..frames {
                         let f = Instant::now();
                         let _ = tb.advance(1);
                         if let Some(rem) = period.checked_sub(f.elapsed()) {
@@ -470,7 +522,7 @@ pub fn run_sweep(cfg: &SweepConfig) -> Vec<CellResult> {
                     }
                 }
                 None => {
-                    let _ = tb.advance(cfg.frames);
+                    let _ = tb.advance(frames);
                 }
             }
             let drive_ms = u64::try_from(t0.elapsed().as_millis()).unwrap_or(u64::MAX);

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -31,8 +31,9 @@ use aether_substrate::{BootError, NativeActor, NativeCtx, NativeDispatch, Native
 
 use super::TestBench;
 use crate::perf::harness::{
-    CellResult, Ping, Relay, RelayConfig, SweepConfig, default_topologies, depth_chain,
+    CellResult, Ping, Relay, RelayConfig, SweepConfig, default_topologies, depth_chain, fanout,
     fanout_heavy, heavy_work_iters_from_env, pace_hz_from_env, relay_id, run_sweep,
+    wide_fanout_widths_from_env,
 };
 
 /// Self-sustaining ring actor for the multi-worker saturation profile.
@@ -272,6 +273,12 @@ fn lifecycle_latency_observe() {
             topologies.push(fanout_heavy(b, heavy));
         }
     }
+    // Wide trivial fan-outs to locate the stickiness width-crossover
+    // (iamacoffeepot/aether#1075); empty unless AETHER_LAT_WIDE_FANOUT is
+    // set, so the default grid is unchanged.
+    for w in wide_fanout_widths_from_env() {
+        topologies.push(fanout(w));
+    }
 
     let cfg = SweepConfig {
         workers: worker_set,
@@ -308,7 +315,13 @@ fn print_observe_tables(rows: &[CellResult], pace_hz: Option<u64>) {
             "heavy leaves: {heavy} spin-iters/handler (*-heavy rows; read HANDLER DUR for actual µs)"
         );
     }
-    println!("{OBSERVE_FRAMES} frames/cell; relay-hop (`Ping`) samples only.");
+    let wide = wide_fanout_widths_from_env();
+    if !wide.is_empty() {
+        println!(
+            "wide fan-outs: {wide:?} (sweep AETHER_LOCAL_STICKY_MAX=1 vs width to find W*; wide cells auto-cap frames)"
+        );
+    }
+    println!("{OBSERVE_FRAMES} frames/cell (wide cells fewer); relay-hop (`Ping`) samples only.");
     println!();
 
     for (label, pick) in [


### PR DESCRIPTION
## Summary

Sibling axis to iamacoffeepot/aether#1083 (heavy-leaf). The harness capped fan-out at width 8 — below the predicted stickiness *width*-crossover — so it could only ever show the keep-local **win** and never the inversion where a large `AETHER_LOCAL_STICKY_MAX` *regresses*: keeping all `N` children on the producing worker drains them serially (~`N x per-child`), which past some width `W*` overtakes the cross-worker handoff that keeping-local was avoiding.

- **`AETHER_LAT_WIDE_FANOUT`** — a comma list of extra trivial fan-out widths (e.g. `"16,32,64,128"`) appended by the on-demand observe sweep and `perf-trial`. Unset, the default grid is byte-for-byte unchanged. `fanout(b)` already takes any width, so no new builder.
- **Per-cell frame clamp in `run_sweep`** — each frame produces ~one trace node per relay delivery, so a wide fan-out at the full frame count would overflow the 100k `DescribeWindow` cap. The clamp caps per-cell frames to stay under `MAX_NODES_PER_CELL` (90k); it's a no-op for the narrow default topologies, so their numbers are unchanged.

## Evidence: the W* inversion (hop p99, workers=max)

| width | scatter `STICKY=1` | keep-all-local `STICKY=200` | winner |
|---|---|---|---|
| 16 | 84.9µs | 23.7µs | keep-local |
| 32 | 76.1 | 42.1 | keep-local |
| 48 | 92.8 | 56.1 | keep-local |
| 64 | 87.6 | 71.2 | keep-local (barely) |
| 96 | 81.7 | 100.8 | **scatter** |
| 128 | 110.0 | 136.4 | **scatter** |

Keep-all-local's serial-drain tail grows ~linearly (~1.06µs/child; the p50 curve 5.5→42µs confirms the mechanism) while scatter's wakeup tail stays ~flat (~85µs), so they cross at **`W* ≈ 64–96`** on a dev box. Past `W*` a large cap visibly regresses — the calibration the adaptive spill bound under iamacoffeepot/aether#1059 needs. Invisible at the old `≤8` widths.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo doc --workspace --no-deps` (rustdoc lints denied)
- [x] `cargo nextest run` workspace (1210 passed, 6 skipped) via `scripts/preflight.sh`
- [x] knob unset: topology set unchanged (no wide cells)
- [x] knob set: wide cells `16..128` present, no trace-window overflow at 128 (frame clamp held)
- [x] `STICKY=1` vs `STICKY=200` reproduces the inversion tabled above

Closes iamacoffeepot/aether#1075

Under the dispatch-latency umbrella iamacoffeepot/aether#1059; extends the harness from iamacoffeepot/aether#1057 / iamacoffeepot/aether#1072.

Generated with [Claude Code](https://claude.com/claude-code)
