### PR TITLE
ci(repo): cache perf-compare base build, share its cold target dir

### DIFF
--- a/.github/workflows/perf-compare.yml
+++ b/.github/workflows/perf-compare.yml
@@ -50,8 +50,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    # Two release builds (base build is cache-cold in its worktree) plus
-    # the interleaved trials. Cap so a stall doesn't burn the quota.
+    # Candidate build + interleaved trials. The base build is skipped on a
+    # cache hit (iamacoffeepot/aether#1084) and shares the candidate's
+    # target dir when cold. Cap so a stall doesn't burn the quota.
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -63,7 +64,30 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev
           mesa-vulkan-drivers
       - uses: Swatinem/rust-cache@v2
+      # Cache the base (merge-base) trial binary across pushes
+      # (iamacoffeepot/aether#1084). The merge-base is fixed for a PR's
+      # life, so once built it can be reused on every re-push, skipping
+      # the cold dependency compile. Key on the merge-base sha + the
+      # toolchain (rustc tracks `stable`, so a compiler bump rebuilds the
+      # base with the same rustc as the candidate — keeping the paired
+      # comparison apples-to-apples).
+      - name: Resolve base cache key
+        id: perfbase
+        run: |
+          git fetch --no-tags --quiet origin main
+          {
+            echo "base=$(git merge-base HEAD FETCH_HEAD)"
+            echo "rustc=$(rustc -V | sha256sum | cut -c1-12)"
+          } >> "$GITHUB_OUTPUT"
+      - name: Cache base perf-trial binary
+        uses: actions/cache@v4
+        with:
+          path: .perf-cache/aether-perf-trial-base
+          key: >-
+            perf-base-${{ runner.os }}-${{ steps.perfbase.outputs.rustc }}-${{ steps.perfbase.outputs.base }}
       - name: Run perf comparison
+        env:
+          PERF_BASE_CACHE: ${{ github.workspace }}/.perf-cache/aether-perf-trial-base
         run: scripts/perf-compare.sh
       - name: Upsert sticky PR comment
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ spikes/*/target/
 # regenerated each CI run, never committed.
 /perf-report.json
 /perf-report.md
+# Cross-run cache slot for the base perf-trial binary
+# (iamacoffeepot/aether#1084) — populated by scripts/perf-compare.sh,
+# persisted by the workflow's actions/cache, never committed.
+/.perf-cache/

--- a/scripts/perf-compare.sh
+++ b/scripts/perf-compare.sh
@@ -12,12 +12,25 @@
 # Informational only — exits 0 even with regressions present (a non-zero
 # exit means an operational failure: a build broke, a trial crashed).
 #
+# Build cost (iamacoffeepot/aether#1084). The base side used to recompile
+# the whole dependency tree from scratch in its own worktree target dir.
+# Two levers cut that:
+#   - PERF_BASE_CACHE: if set to a file path, a cached base binary there
+#     is reused as-is (the merge-base is fixed for a PR's life, so a
+#     re-push skips the base build entirely); a freshly built base binary
+#     is copied there for the workflow's actions/cache to persist.
+#   - The cold base build shares the candidate's CARGO_TARGET_DIR, so it
+#     reuses the already-compiled release deps and only the changed
+#     workspace crates recompile.
+#
 # Env knobs (defaults tuned for the CI preset — warm, a fan-out + chain
-# subset, ~1 min of measurement once iamacoffeepot/aether#1079 landed):
+# subset, ~1 min of measurement):
 #   PERF_K               trials per side (default 12)
 #   AETHER_PERF_WORKERS  pool sizes (default "max,2")
 #   AETHER_PERF_FRAMES   frames per cell (default 200)
 #   AETHER_PERF_TOPOS    "ci" | "full" (default "ci")
+#   PERF_BASE_CACHE      file path for the cross-run base-binary cache
+#                        (set by the workflow; unset locally = always build)
 #
 # Usage: scripts/perf-compare.sh
 
@@ -33,6 +46,22 @@ export AETHER_PERF_TOPOS="${AETHER_PERF_TOPOS:-ci}"
 
 json_out="$ROOT/perf-report.json"
 md_out="$ROOT/perf-report.md"
+base_cache="${PERF_BASE_CACHE:-}"
+
+# Transient working dir for the built binaries, plus the worktree (created
+# only on a base-cache miss). Both cleaned up on exit.
+work="$(mktemp -d "${TMPDIR:-/tmp}/aether-perf.XXXXXX")"
+base_wt=""
+cleanup() {
+    if [ -n "$base_wt" ]; then
+        git worktree remove --force "$base_wt" 2>/dev/null || true
+    fi
+    rm -rf "$work"
+}
+trap cleanup EXIT
+
+cand_trial="$work/aether-perf-trial-cand"
+compare_bin="$work/aether-perf-compare"
 
 # Resolve the baseline: the merge-base of the PR tip and main, so the
 # comparison isolates THIS PR's changes (not whatever else merged since
@@ -42,36 +71,51 @@ base_sha="$(git merge-base HEAD FETCH_HEAD)"
 base_short="$(git rev-parse --short "$base_sha")"
 echo "[perf-compare] baseline = merge-base $base_short; K=$K, workers=$AETHER_PERF_WORKERS, frames=$AETHER_PERF_FRAMES, topos=$AETHER_PERF_TOPOS"
 
-# Base checkout in a throwaway worktree, cleaned up on exit.
-base_wt="$(mktemp -d "${TMPDIR:-/tmp}/aether-perf-base.XXXXXX")"
-cleanup() {
-    git worktree remove --force "$base_wt" 2>/dev/null || true
-}
-trap cleanup EXIT
-git worktree add --quiet --detach "$base_wt" "$base_sha"
-
-# Build the candidate (PR) trial + compare binaries, and the base trial.
+# Build the candidate (PR) binaries into the shared target, then copy them
+# aside. The base build below reuses this same target dir, and both crates
+# emit `aether-perf-trial` at the same path — copying the candidate out
+# first keeps the base build from clobbering it.
 echo "[perf-compare] building candidate (PR) binaries…"
 cargo build --release -p aether-substrate-bundle \
     --bin aether-perf-trial --bin aether-perf-compare
+cp "$ROOT/target/release/aether-perf-trial" "$cand_trial"
+cp "$ROOT/target/release/aether-perf-compare" "$compare_bin"
 
-cand_trial="$ROOT/target/release/aether-perf-trial"
-compare_bin="$ROOT/target/release/aether-perf-compare"
-base_trial="$base_wt/target/release/aether-perf-trial"
+# Resolve the base trial binary: prefer the cross-run cache, else build it
+# from a throwaway worktree (sharing the candidate's target dir).
+base_trial=""
+if [ -n "$base_cache" ] && [ -x "$base_cache" ]; then
+    echo "[perf-compare] base cache hit ($base_cache) — skipping base build"
+    base_trial="$base_cache"
+else
+    base_wt="$(mktemp -d "${TMPDIR:-/tmp}/aether-perf-base.XXXXXX")"
+    git worktree add --quiet --detach "$base_wt" "$base_sha"
 
-echo "[perf-compare] building base ($base_short) trial binary…"
-if ! (cd "$base_wt" && cargo build --release -p aether-substrate-bundle --bin aether-perf-trial); then
-    # The merge-base predates the perf-trial bin (a PR forked before
-    # iamacoffeepot/aether#1081). Nothing to compare against — emit a note,
-    # not a failure (this job is informational).
-    cat > "$md_out" <<EOF
+    echo "[perf-compare] building base ($base_short) trial binary (shared target)…"
+    if (cd "$base_wt" && CARGO_TARGET_DIR="$ROOT/target" \
+            cargo build --release -p aether-substrate-bundle --bin aether-perf-trial); then
+        built="$ROOT/target/release/aether-perf-trial"
+        if [ -n "$base_cache" ]; then
+            mkdir -p "$(dirname "$base_cache")"
+            cp "$built" "$base_cache"
+            base_trial="$base_cache"
+        else
+            base_trial="$work/aether-perf-trial-base"
+            cp "$built" "$base_trial"
+        fi
+    else
+        # The merge-base predates the perf-trial bin (a PR forked before
+        # iamacoffeepot/aether#1081). Nothing to compare against — emit a
+        # note, not a failure (this job is informational).
+        cat > "$md_out" <<EOF
 <!-- aether-perf-report -->
 ## dispatch perf
 
 _Baseline ($base_short) predates the \`perf-trial\` harness — no comparison available for this PR._
 EOF
-    echo "[perf-compare] base build failed (baseline predates perf-trial); wrote note to $md_out"
-    exit 0
+        echo "[perf-compare] base build failed (baseline predates perf-trial); wrote note to $md_out"
+        exit 0
+    fi
 fi
 
 # Interleave K trials per side on this runner; render JSON + markdown.


### PR DESCRIPTION
## Summary

The on-PR dispatch perf comparison spent ~10 min rebuilding the **base** side from scratch every run: `scripts/perf-compare.sh` built the merge-base binary inside a throwaway worktree with its own `target/`, which `Swatinem/rust-cache` never restores — so the full dependency tree (wgpu, winit, naga, …) recompiled each time. (Diagnosis confirmed: rust-cache only snapshots the workspace `target/`, and the per-job key isolation is its default, so no cross-job sharing reaches the worktree.)

Two levers:

1. **Cache the base binary by merge-base sha.** The workflow resolves `merge-base + rustc` into an `actions/cache` key and points `PERF_BASE_CACHE` at the cached path; the script reuses a cached binary as-is and skips the worktree build entirely. The merge-base is fixed for a PR's life, so **every re-push after the first skips the base build**. Keying on the rustc hash (the toolchain tracks `stable`) forces a rebuild on a compiler bump, so the paired comparison stays apples-to-apples.
2. **Share the candidate's target dir for the cold build.** On a cache miss, the base build runs with `CARGO_TARGET_DIR` pointed at the candidate's `target/`, reusing the already-compiled release deps so only the changed workspace crates recompile. The candidate binaries are copied aside first so the base build's `aether-perf-trial` (same output path) doesn't clobber them.

Net: re-pushes pay ~trial-time + candidate-build only; even the cold first build drops from full-tree to workspace-crates-only.

## Test plan

- [x] Local cold path (no `PERF_BASE_CACHE`): builds both sides via shared target, produces `perf-report.{json,md}` (~23s at `PERF_K=2`).
- [x] Local cache-hit path (`PERF_BASE_CACHE` pre-seeded): logs "base cache hit — skipping base build", creates **no** worktree, produces the report.
- [x] `perf-compare.yml` parses as valid YAML; the folded cache `key` resolves to a single interpolated line.
- [x] "base predates perf-trial" fallback path preserved (emits the note, exits 0).
- [x] CI: first run on this PR populates the base cache; a follow-up push should show the cache hit and a much shorter job.

Informational job (not in `ci-pass`) — comparison output is unchanged.

Closes iamacoffeepot/aether#1084

Generated with [Claude Code](https://claude.com/claude-code)
