### PR TITLE
chore(repo): scrub machine-specific path from skill docs

### DIFF
--- a/.claude/skills/secretary/SKILL.md
+++ b/.claude/skills/secretary/SKILL.md
@@ -45,7 +45,7 @@ Don't post a blocker for anything in this list — the scan finds them.
 
 ## Sources scanned (posted blockers)
 
-Path: `~/.claude/projects/-Users-hadynfitzgerald-workspace-aether/secretary/blockers.jsonl`
+Path: `~/.claude/projects/<project-slug>/secretary/blockers.jsonl` (`<project-slug>` is the Claude Code project directory that also holds your auto-memory `MEMORY.md` — the project's absolute path with each `/` replaced by `-`).
 
 Format — one JSON object per line:
 
@@ -186,6 +186,6 @@ Posted blockers stay in the JSONL with `resolved: false` until explicitly resolv
 
 ## Storage
 
-Posted blockers: `~/.claude/projects/-Users-hadynfitzgerald-workspace-aether/secretary/blockers.jsonl` (per-user, not in repo).
+Posted blockers: `~/.claude/projects/<project-slug>/secretary/blockers.jsonl` (per-user, not in repo; same project directory as your auto-memory `MEMORY.md`).
 
 The skill creates the directory if absent; the file is `chmod 644` (readable, not sensitive but personal).

--- a/.claude/skills/wish/SKILL.md
+++ b/.claude/skills/wish/SKILL.md
@@ -258,7 +258,7 @@ Read, selective on the theme:
 - `CLAUDE.md` — current architectural state + "Notes on …" prose where friction patterns surface.
 - `docs/adr/` — *Rejected alternatives* and *Future work* sections; parked aspirations live there.
 - `gh issue list --state open --limit 100 --json number,title,body,labels`.
-- `~/.claude/projects/-Users-hadynfitzgerald-workspace-aether/capture/log-*.jsonl` — grep `"I wish"` literally; scan for repeated tool calls hitting the same wall, manual workarounds, frustration markers.
+- `~/.claude/projects/<project-slug>/capture/log-*.jsonl` (`<project-slug>` = the Claude Code project directory that holds your auto-memory `MEMORY.md`) — grep `"I wish"` literally; scan for repeated tool calls hitting the same wall, manual workarounds, frustration markers.
 - `git log --oneline main | head -50`.
 - Empathy material (especially for non-agent roles): general knowledge of how the role works in similar engines/contexts, the user's published vision in memory entries, domain patterns from training.
 


### PR DESCRIPTION
## Summary

- The `/secretary` and `/wish` skill docs hardcoded a machine-specific absolute Claude project-directory path. Replaced all three occurrences with a runtime-resolved `<project-slug>` placeholder, so the checked-in docs carry no machine-specific identity and resolve correctly on any clone.
- Docs-only, under `.claude/skills/`. No code or behavior change — the agent already resolves that directory at runtime (it is the same project dir that holds `MEMORY.md`).

## Test plan

- [x] `git grep` finds no machine-specific path in tracked files.
- [x] The placeholder points at the same project directory the agent uses for auto-memory, so `/secretary` and `/wish` resolve their state files unchanged.

Generated with [Claude Code](https://claude.com/claude-code)