### PR TITLE
chore(repo): make issue/PR creation hooks prescriptive, fix false-positives

### DIFF
--- a/.claude/hooks/check-pr-body.sh
+++ b/.claude/hooks/check-pr-body.sh
@@ -132,16 +132,22 @@ fi
 
 # Pattern E: issue title must match `{type}({crate}): subject` (or
 # `{type}({crate}/{subfeat}): subject` for subfeatures). Scope must be
-# a registered `crate:*` label. Mirrors the server-side workflow at
-# `.github/workflows/issue-labels.yml`. Fires only on `gh issue
-# create` / `gh issue edit`.
+# a registered `crate:*` label OR a meta-scope. Mirrors the server-side
+# workflow at `.github/workflows/issue-labels.yml` (keep META_SCOPES in
+# sync). Fires only on `gh issue create` / `gh issue edit`.
 if [[ ",$allowed," != *",e,"* ]] && (( is_issue_cmd == 1 )) && [[ -n "$title" ]]; then
     title_re='^(feat|fix|chore|docs|perf|refactor|flake)\(([a-z0-9-]+)(/[a-z0-9-]+)?\):[[:space:]].+$'
+    # Meta-scopes: cross-cutting work that isn't a single crate. Must
+    # match META_SCOPES in .github/workflows/issue-labels.yml — the
+    # server accepts these, so the local hook must too or it
+    # false-positives on a title the server would pass.
+    meta_scopes=" ci docs adr qodana repo release workflow "
     if [[ "$title" =~ $title_re ]]; then
         scope="${BASH_REMATCH[2]}"
-        if ! gh label list --search "crate:$scope" --json name --jq '.[].name' 2>/dev/null | grep -qx "crate:$scope"; then
+        if [[ "$meta_scopes" != *" $scope "* ]] \
+            && ! gh label list --search "crate:$scope" --json name --jq '.[].name' 2>/dev/null | grep -qx "crate:$scope"; then
             valid_crates=$(gh label list --limit 100 --json name --jq '.[].name | select(startswith("crate:")) | sub("^crate:"; "")' 2>/dev/null | sort | tr '\n' ' ' | sed 's/ $//')
-            issues+=("Pattern E: issue title scope '$scope' is not a known crate. Valid: $valid_crates")
+            issues+=("Pattern E: issue title scope '$scope' is not a known crate or meta-scope. Valid crates: $valid_crates. Valid meta-scopes:${meta_scopes}")
         fi
     else
         issues+=("Pattern E: issue title must match {type}({crate}): subject (subfeatures via {type}({crate}/{subfeat}): subject). Allowed types: feat, fix, chore, docs, perf, refactor, flake")
@@ -154,8 +160,14 @@ if (( ${#issues[@]} )); then
         for i in "${issues[@]}"; do
             printf '  - %s\n' "$i"
         done
-        printf '\nSee feedback_heredoc_no_backtick_escape.md (auto-memory) for context.\n'
-        printf 'To override deliberately, include `<!-- pr-body-ok: <letters> — <reason> -->` (letters: a/b/c/d/e, comma-separated; only listed patterns are skipped).\n'
+        printf '\nRules reference (so the next attempt is right, not another guess):\n'
+        printf '  - Issue title: {type}({scope}): <subject>. Types: feat fix chore docs perf refactor flake.\n'
+        printf '  - PR title: same {type}({scope}): <subject> shape; PR types additionally allow test build ci style revert.\n'
+        printf '  - Subject (issue + PR) must start lowercase.\n'
+        printf '  - Scope is a crate name OR a meta-scope: ci docs adr qodana repo release workflow.\n'
+        printf '  - Body: no backslash before a backtick/dollar (A); no bare hash-number, use owner/repo#NNN (B); no dollar-delimited math span, use backticks (D).\n'
+        printf '\nTo override deliberately, include `<!-- pr-body-ok: <letters> — <reason> -->` (letters: a/b/c/d/e, comma-separated; only listed patterns are skipped).\n'
+        printf 'Context: feedback_heredoc_no_backtick_escape.md (auto-memory).\n'
     } >&2
     exit 2
 fi

--- a/.claude/hooks/check-pre-push.sh
+++ b/.claude/hooks/check-pre-push.sh
@@ -22,10 +22,16 @@ set -u
 input=$(cat)
 command=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
 
-case "$command" in
-    *"git push"*|*"gh pr create"*) ;;
-    *) exit 0 ;;
-esac
+# Match `git push` / `gh pr create` only in command position — at the
+# start of a line or right after a separator (`;`, `&`, `|`, and thus
+# `&&` / `||`). A real invocation is always in command position; a
+# heredoc or quoted body that merely *mentions* the command name (e.g.
+# an issue describing `gh pr create`) is not, so it no longer
+# false-positives a `gh issue create` whose body quotes the name.
+if ! printf '%s' "$command" \
+    | grep -qE '(^|[;&|])[[:space:]]*(git[[:space:]]+push|gh[[:space:]]+pr[[:space:]]+create)'; then
+    exit 0
+fi
 
 # User-elected bypass. The git pre-push hook will also see --no-verify.
 case "$command" in


### PR DESCRIPTION
## Summary

The `gh issue` / `gh pr` creation pre-flight hooks were prohibitive without being prescriptive, and two matchers false-positived. This is the prescriptive-direction fix for iamacoffeepot/aether#1087.

- **Pattern E meta-scope parity** (`check-pr-body.sh`). Pattern E rejected any issue-title scope that wasn't a `crate:*` label, but the server-side `issue-labels.yml` also accepts meta-scopes (ci, docs, adr, qodana, repo, release, workflow). A server-valid title like `chore(repo): ...` was blocked locally. The hook now accepts the same meta-scope set.
- **Prescriptive failure output** (`check-pr-body.sh`). On any block, the hook prints a compact rules reference — allowed types per surface (issue vs PR), that the subject must start lowercase, that the scope is a crate name or a meta-scope, and the body content rules — so the next attempt is informed rather than another guess.
- **Command-position matching** (`check-pre-push.sh`). It matched the push and PR-creation command names as a bare substring anywhere in the command, so an issue body that merely quoted those names tripped the push gate. It now matches only in command position (line start or right after a separator); a real invocation is always in command position, a quoted mention is not.

## Test plan

Verified with a local harness that pipes crafted tool-call JSON into each hook (10 cases, all green):

- check-pre-push: a quoted mention in an issue body no longer blocks; a real push and a real PR-create still block (no stamp); the no-verify bypass still works; a chained invocation is still caught.
- check-pr-body: `chore(repo)` and `chore(ci)` accepted; an unknown scope still rejected (now with the rules reference); a real crate scope still accepted; a PR title with an uppercase subject still caught.

- [x] `bash -n` clean on both hooks.
- [x] 10/10 harness cases pass.

Closes iamacoffeepot/aether#1087

Generated with [Claude Code](https://claude.com/claude-code)