### PR TITLE
perf(substrate): emit-time settlement counter in shadow mode, ADR-0086 phase 1

### DIFF
--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -45,6 +45,9 @@ use aether_substrate::{
     mail::{CapabilityRegistry, Mail, MailId, MailboxId},
 };
 
+#[cfg(test)]
+use aether_substrate::chassis::settlement_shadow::ShadowSettlement;
+
 use super::chassis::{TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS};
 use super::events::{ChassisEvent, EventReceiver, channel as event_channel};
 use super::render::Gpu;
@@ -408,6 +411,17 @@ impl TestBench {
     #[must_use]
     pub fn capability_registry(&self) -> &Arc<CapabilityRegistry> {
         self.queue.capability_registry()
+    }
+
+    /// ADR-0086 Phase 1: the shadow-settlement apparatus on this bench's
+    /// trace handle. Tests enable the cross-check
+    /// (`settlement_shadow().set_enabled(true)`) before driving traffic
+    /// and assert `cross_check().outstanding()` / `disagreements()`
+    /// afterwards. `pub(crate)` — exercised by the in-crate agreement
+    /// tests, not part of the public bench surface.
+    #[cfg(test)]
+    pub(crate) fn settlement_shadow(&self) -> &Arc<ShadowSettlement> {
+        self.queue.trace_handle().shadow()
     }
 
     /// Bytes-level fire-and-settle send: resolve `recipient_name` in

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -134,6 +134,22 @@ fn hold_id() -> MailboxId {
     MailboxId(mailbox_id_from_name(&format!("{HOLD_NS}:0")).0)
 }
 
+/// Spawn every relay in `topo` onto `tb` (subname = relay index), wiring
+/// each relay's downstream ids. Shared by the settlement guards.
+fn spawn_topology(tb: &TestBench, topo: &Topology) {
+    for i in 0..topo.downstreams.len() {
+        let downstreams: Arc<[MailboxId]> =
+            topo.downstreams[i].iter().map(|&j| relay_id(j)).collect();
+        let config = RelayConfig {
+            downstreams,
+            work_iters: topo.work_iters[i],
+        };
+        tb.spawn_actor::<Relay>(Subname::Named(&i.to_string()), config)
+            .finish()
+            .expect("spawn relay");
+    }
+}
+
 /// Query the trace observer for one root's whole tree over the mail
 /// wire. Returns the node list, or `None` if the observer no longer has
 /// the root (only happens if the ring lapped it — not expected at these
@@ -235,18 +251,7 @@ fn sharded_trace_settles_every_root() {
 
     let depth = 5;
     let topo = depth_chain(depth);
-    for i in 0..topo.downstreams.len() {
-        let downstreams: Arc<[MailboxId]> =
-            topo.downstreams[i].iter().map(|&j| relay_id(j)).collect();
-        let sub = i.to_string();
-        let config = RelayConfig {
-            downstreams,
-            work_iters: topo.work_iters[i],
-        };
-        tb.spawn_actor::<Relay>(Subname::Named(&sub), config)
-            .finish()
-            .expect("spawn relay");
-    }
+    spawn_topology(&tb, &topo);
     let entry = relay_id(0);
 
     // 800 roots × depth 5 = 4000 mails — well under the trace ring
@@ -316,18 +321,7 @@ fn shadow_settlement_agrees_with_observer(topo: &Topology) {
     // enable, which would desync the counter).
     tb.settlement_shadow().set_enabled(true);
 
-    for i in 0..topo.downstreams.len() {
-        let downstreams: Arc<[MailboxId]> =
-            topo.downstreams[i].iter().map(|&j| relay_id(j)).collect();
-        let sub = i.to_string();
-        let config = RelayConfig {
-            downstreams,
-            work_iters: topo.work_iters[i],
-        };
-        tb.spawn_actor::<Relay>(Subname::Named(&sub), config)
-            .finish()
-            .expect("spawn relay");
-    }
+    spawn_topology(&tb, topo);
     let entry = relay_id(0);
 
     let roots = 500u32;

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -31,9 +31,9 @@ use aether_substrate::{BootError, NativeActor, NativeCtx, NativeDispatch, Native
 
 use super::TestBench;
 use crate::perf::harness::{
-    CellResult, Ping, Relay, RelayConfig, Stats, SweepConfig, default_topologies, depth_chain,
-    fanout, fanout_heavy, heavy_work_iters_from_env, pace_hz_from_env, relay_id, run_sweep,
-    summarize, wide_fanout_widths_from_env,
+    CellResult, Ping, Relay, RelayConfig, Stats, SweepConfig, Topology, default_topologies,
+    depth_chain, fanout, fanout_heavy, heavy_work_iters_from_env, pace_hz_from_env, relay_id,
+    run_sweep, summarize, two_level_tree, wide_fanout_widths_from_env,
 };
 
 /// Self-sustaining ring actor for the multi-worker saturation profile.
@@ -81,6 +81,57 @@ const RING_NS: &str = "mlat.ring";
 
 fn ring_id(i: usize) -> MailboxId {
     MailboxId(mailbox_id_from_name(&format!("{RING_NS}:{i}")).0)
+}
+
+/// On each `Ping`, spawns an inherited worker thread (ADR-0080 §12) that
+/// outlives the handler by a short sleep before exiting. The
+/// `spawn_inherit` acquires a settlement hold before the worker starts;
+/// the handler then returns (dropping `in_flight` to zero) but the root
+/// must NOT settle until the worker exits and releases the hold. Used to
+/// exercise the `HoldOpen` / `Release` producer hooks end-to-end against
+/// the shadow cross-check.
+struct HoldRelay;
+
+impl aether_actor::Actor for HoldRelay {
+    const NAMESPACE: &'static str = "mlat.hold";
+}
+// Both markers: `Instanced` lets the bench's `spawn_actor` place it,
+// `Singleton` satisfies `spawn_inherit`'s bound (the worker-thread hold
+// primitive is singleton-oriented). A test fixture only — production
+// actors pick one role.
+impl aether_actor::Instanced for HoldRelay {}
+impl aether_actor::Singleton for HoldRelay {}
+impl aether_actor::HandlesKind<Ping> for HoldRelay {}
+impl NativeActor for HoldRelay {
+    type Config = ();
+    fn init((): Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        Ok(Self)
+    }
+}
+impl NativeDispatch for HoldRelay {
+    fn __aether_dispatch_envelope(
+        &mut self,
+        ctx: &mut NativeCtx<'_>,
+        kind: KindId,
+        _payload: &[u8],
+    ) -> Option<()> {
+        if kind.0 != Ping::ID.0 {
+            return None;
+        }
+        // Hold acquired before the worker spawns; the worker sleeps so
+        // the handler's `Finished` lands first (in_flight 0, held_open 1
+        // — not settled), then exits to release the hold (settle).
+        let _join = ctx.spawn_inherit::<Self, _>(|_inherit| {
+            thread::sleep(Duration::from_millis(1));
+        });
+        Some(())
+    }
+}
+
+const HOLD_NS: &str = "mlat.hold";
+
+fn hold_id() -> MailboxId {
+    MailboxId(mailbox_id_from_name(&format!("{HOLD_NS}:0")).0)
 }
 
 /// Query the trace observer for one root's whole tree over the mail
@@ -232,6 +283,156 @@ fn sharded_trace_settles_every_root() {
 #[allow(clippy::print_stderr)]
 fn flaky_sharded_trace_settles_every_root() {
     sharded_trace_settles_every_root();
+}
+
+/// ADR-0086 Phase 1 shadow-mode agreement guard: with the emit-time
+/// `SettlementCounter` enabled alongside the incumbent observer fold,
+/// every root must settle identically on both paths. Drives `topo` with
+/// many concurrent roots through a multi-worker pool, waits for the
+/// observer's authoritative settle on each, then asserts the shadow
+/// cross-check is balanced (no root settled by one path but not the
+/// other) with zero disagreements.
+///
+/// The emit-time settle fires synchronously on the producer thread; the
+/// observer settle follows ~1 ms later (drainer + fold) and is what
+/// `inject_root`'s receiver waits on. The chassis-router notes the
+/// observer settle *before* firing the receiver, so by the time every
+/// receiver has fired, both notes are in for every root and the balance
+/// must be zero.
+#[allow(clippy::print_stderr)]
+fn shadow_settlement_agrees_with_observer(topo: &Topology) {
+    let workers = available_parallelism().map_or(2, |n| n.get().saturating_sub(1).max(1));
+    let Ok(tb) = TestBench::builder()
+        .with_workers(Some(workers))
+        .size(16, 16)
+        .build()
+    else {
+        eprintln!("skipping shadow_settlement_agrees_with_observer: no wgpu adapter");
+        return;
+    };
+    // Enable shadow before any traffic. The bench is quiescent after a
+    // synchronous multi-pass boot, so the counter sees every injected
+    // root's full Sent/Finished from the first event (no mid-stream
+    // enable, which would desync the counter).
+    tb.settlement_shadow().set_enabled(true);
+
+    for i in 0..topo.downstreams.len() {
+        let downstreams: Arc<[MailboxId]> =
+            topo.downstreams[i].iter().map(|&j| relay_id(j)).collect();
+        let sub = i.to_string();
+        let config = RelayConfig {
+            downstreams,
+            work_iters: topo.work_iters[i],
+        };
+        tb.spawn_actor::<Relay>(Subname::Named(&sub), config)
+            .finish()
+            .expect("spawn relay");
+    }
+    let entry = relay_id(0);
+
+    let roots = 500u32;
+    let mut pending = Vec::with_capacity(roots as usize);
+    for seq in 0..roots {
+        pending.push(tb.inject_root(entry, Ping::ID, Ping { seq }.encode_into_bytes()));
+    }
+    for (idx, (_root, rx)) in pending.iter().enumerate() {
+        assert!(
+            rx.recv_timeout(SETTLE_TIMEOUT).is_ok(),
+            "root {idx} never settled (observer side)"
+        );
+    }
+
+    let xc = tb.settlement_shadow().cross_check();
+    // Non-vacuity: the emit path must actually have run. Each injected
+    // root settles exactly once on each path (no re-open via inject), so
+    // both monotonic counts equal the root count. Without this, a
+    // silently-disabled shadow would pass with an empty, never-touched
+    // ledger.
+    assert_eq!(
+        xc.emit_settles(),
+        u64::from(roots),
+        "emit-time counter did not settle every root (shadow inactive?)"
+    );
+    assert_eq!(xc.observer_settles(), u64::from(roots));
+    let outstanding = xc.outstanding();
+    assert!(
+        outstanding.is_empty(),
+        "shadow disagreement — roots settled by one path only: {outstanding:?}"
+    );
+    assert_eq!(
+        xc.disagreements(),
+        0,
+        "observer settled a root the emit-time counter missed (negative balance)"
+    );
+}
+
+/// Rich topology: fan-out + a shared (two-parent) node + depth.
+#[test]
+fn shadow_settlement_agrees_two_level_tree() {
+    shadow_settlement_agrees_with_observer(&two_level_tree());
+}
+
+/// Flake-soak duplicate (concurrent multi-worker dispatch; see CLAUDE.md).
+#[test]
+fn flaky_shadow_settlement_agrees_two_level_tree() {
+    shadow_settlement_agrees_two_level_tree();
+}
+
+/// Depth chain — exercises the per-root `Sent`-before-`Finished` ordering
+/// the counter relies on across a serial hand-off.
+#[test]
+fn shadow_settlement_agrees_depth_chain() {
+    shadow_settlement_agrees_with_observer(&depth_chain(6));
+}
+
+/// Hold-path agreement: a `spawn_inherit` worker keeps the root open past
+/// the handler's `Finished`, so settlement is gated on the worker's
+/// `Release` (ADR-0080 §12). Exercises the `HoldOpen` / `Release`
+/// producer hooks — the only ones the topology tests above don't hit —
+/// against the shadow cross-check.
+#[test]
+#[allow(clippy::print_stderr)]
+fn shadow_settlement_agrees_with_holds() {
+    let workers = available_parallelism().map_or(2, |n| n.get().saturating_sub(1).max(1));
+    let Ok(tb) = TestBench::builder()
+        .with_workers(Some(workers))
+        .size(16, 16)
+        .build()
+    else {
+        eprintln!("skipping shadow_settlement_agrees_with_holds: no wgpu adapter");
+        return;
+    };
+    tb.settlement_shadow().set_enabled(true);
+    tb.spawn_actor::<HoldRelay>(Subname::Named("0"), ())
+        .finish()
+        .expect("spawn hold relay");
+    let entry = hold_id();
+
+    let roots = 50u32;
+    let mut pending = Vec::with_capacity(roots as usize);
+    for seq in 0..roots {
+        pending.push(tb.inject_root(entry, Ping::ID, Ping { seq }.encode_into_bytes()));
+    }
+    for (idx, (_root, rx)) in pending.iter().enumerate() {
+        assert!(
+            rx.recv_timeout(SETTLE_TIMEOUT).is_ok(),
+            "hold root {idx} never settled — Release may not have fired"
+        );
+    }
+
+    let xc = tb.settlement_shadow().cross_check();
+    assert_eq!(
+        xc.emit_settles(),
+        u64::from(roots),
+        "emit-time counter did not settle every held root"
+    );
+    assert_eq!(xc.observer_settles(), u64::from(roots));
+    assert!(
+        xc.outstanding().is_empty(),
+        "shadow disagreement on the hold path: {:?}",
+        xc.outstanding()
+    );
+    assert_eq!(xc.disagreements(), 0);
 }
 
 const OBSERVE_FRAMES: u32 = 1000;

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -1126,11 +1126,18 @@ fn boot_passives(
     let settlement_registry: Arc<SettlementRegistry> = Arc::new(SettlementRegistry::new());
     mailer.install_settlement_registry(Arc::clone(&settlement_registry));
     let registry_for_router = Arc::clone(&settlement_registry);
+    // ADR-0086 Phase 1: feed the observer's authoritative `Settled` into
+    // the shadow cross-check so it can be matched against the emit-time
+    // counter's settle for the same root. Inert unless shadow is enabled.
+    let shadow_for_router = Arc::clone(mailer.trace_handle().shadow());
     let settled_kind = <Settled as aether_data::Kind>::ID;
     mailer.install_chassis_router(Box::new(move |mail| {
         if mail.kind == settled_kind {
             match postcard::from_bytes::<Settled>(&mail.payload) {
-                Ok(notice) => registry_for_router.fire_settled(notice.root),
+                Ok(notice) => {
+                    shadow_for_router.on_observer_settled(notice.root);
+                    registry_for_router.fire_settled(notice.root);
+                }
                 Err(e) => tracing::warn!(
                     target: "aether_substrate::chassis::settlement",
                     error = %e,

--- a/crates/aether-substrate/src/chassis/mod.rs
+++ b/crates/aether-substrate/src/chassis/mod.rs
@@ -25,6 +25,7 @@ pub mod frame_loop;
 pub mod helpers;
 pub mod settlement;
 pub mod settlement_counter;
+pub mod settlement_shadow;
 
 use crate::chassis::builder::{BuiltChassis, DriverCapability};
 use crate::chassis::error::BootError;

--- a/crates/aether-substrate/src/chassis/settlement_shadow.rs
+++ b/crates/aether-substrate/src/chassis/settlement_shadow.rs
@@ -1,0 +1,327 @@
+//! ADR-0086 Phase 1 — shadow-mode settlement validation.
+//!
+//! Wires the emit-time [`SettlementCounter`] alongside the incumbent
+//! trace pipeline and cross-checks that the two agree, **without driving
+//! the lifecycle** — the `TraceObserverCapability` fold remains the
+//! settlement authority until Phase 2 flips frame-gating onto the
+//! counter. The point of this phase is to land the (new, concurrent)
+//! counting kernel in production paths and prove on real workloads that
+//! its zero-transitions match the incumbent's, before anything depends
+//! on it.
+//!
+//! **Off by default.** The apparatus is gated by an [`AtomicBool`] seeded
+//! from `AETHER_SETTLEMENT_SHADOW` (`"1"` → on). When off, every producer
+//! hook is a single relaxed atomic load and a branch — so a normal
+//! substrate (and the perf harness) pays effectively nothing. Tests and
+//! shadow-validation runs turn it on via [`ShadowSettlement::set_enabled`]
+//! (or the env var) *before* any traffic flows — toggling it mid-run
+//! would desync the counter (it would miss the earlier `Sent`s its later
+//! `Finished`s balance against).
+//!
+//! Removed or repurposed in Phase 2: when the counter becomes the
+//! authority it fires `fire_settled` directly and the observer's role
+//! (and this cross-check) goes away.
+
+use std::collections::HashMap;
+use std::env;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use aether_data::MailId;
+
+use super::settlement_counter::SettlementCounter;
+
+/// Self-bounding agreement ledger between the two settlement paths.
+///
+/// `+1` when the emit-time counter settles a root, `-1` when the
+/// observer's authoritative `Settled` is routed (the chassis-router
+/// tap). The emit side fires first (synchronously, on the producing
+/// thread); the observer side follows once the drainer ships and the
+/// fold catches up. So a healthy root's balance goes `+1` then back to
+/// `0` within that window, and the entry is reclaimed — the map only
+/// ever holds roots currently *inside* the `[emit, observer]` window,
+/// never the cumulative history (the self-bounding property; see the
+/// `self-bounding-over-keep-and-gc` rule).
+///
+/// A balance that goes **negative** means the observer settled a root
+/// the emit counter did not — a real disagreement (the emit counter
+/// under-counted), logged immediately. A balance that **lingers
+/// positive** past quiescence means the emit counter settled a root the
+/// observer never did; tests assert [`Self::outstanding`] is empty after
+/// the work drains to catch that direction.
+#[derive(Debug, Default)]
+pub struct SettlementCrossCheck {
+    balance: Mutex<HashMap<MailId, i64>>,
+    disagreements: AtomicU64,
+    /// Monotonic count of emit-time / observer settles seen. Exposed so
+    /// tests can confirm the apparatus actually ran (a balanced ledger is
+    /// otherwise indistinguishable from a disabled, never-touched one).
+    emit_settles: AtomicU64,
+    observer_settles: AtomicU64,
+}
+
+impl SettlementCrossCheck {
+    /// Apply `delta` to `root`'s balance, reclaiming the entry when it
+    /// returns to zero. Returns the post-update balance.
+    fn apply(&self, root: MailId, delta: i64) -> i64 {
+        let mut bal = self
+            .balance
+            .lock()
+            .expect("settlement cross-check mutex poisoned; fail-fast per ADR-0063");
+        let entry = bal.entry(root).or_insert(0);
+        *entry += delta;
+        let post = *entry;
+        if post == 0 {
+            bal.remove(&root);
+        }
+        post
+    }
+
+    /// Record an emit-time settle for `root`.
+    pub fn note_emit(&self, root: MailId) {
+        self.emit_settles.fetch_add(1, Ordering::Relaxed);
+        self.apply(root, 1);
+    }
+
+    /// Record the observer's authoritative settle for `root`. A balance
+    /// that drops below zero is a disagreement (the observer settled a
+    /// root the emit counter never did).
+    pub fn note_observer(&self, root: MailId) {
+        self.observer_settles.fetch_add(1, Ordering::Relaxed);
+        if self.apply(root, -1) < 0 {
+            self.disagreements.fetch_add(1, Ordering::Relaxed);
+            tracing::error!(
+                target: "aether_substrate::settlement_shadow",
+                ?root,
+                "settlement shadow disagreement: observer settled a root the emit-time \
+                 counter did not (ADR-0086 Phase 1 cross-check)"
+            );
+        }
+    }
+
+    /// Count of disagreements detected so far (observer-settled roots the
+    /// emit counter missed). Tests assert this is zero.
+    #[must_use]
+    pub fn disagreements(&self) -> u64 {
+        self.disagreements.load(Ordering::Relaxed)
+    }
+
+    /// Total emit-time settles recorded (monotonic). Lets a test confirm
+    /// the emit path actually ran rather than passing vacuously.
+    #[must_use]
+    pub fn emit_settles(&self) -> u64 {
+        self.emit_settles.load(Ordering::Relaxed)
+    }
+
+    /// Total observer settles recorded (monotonic).
+    #[must_use]
+    pub fn observer_settles(&self) -> u64 {
+        self.observer_settles.load(Ordering::Relaxed)
+    }
+
+    /// Roots whose balance is currently non-zero — i.e. settled by one
+    /// path but not (yet) the other. After the workload quiesces (the
+    /// drainer has flushed and the observer has caught up) this must be
+    /// empty; a lingering entry is a disagreement in the
+    /// emit-settled-but-observer-didn't direction.
+    ///
+    /// # Panics
+    /// Panics on a poisoned ledger mutex (fail-fast per ADR-0063).
+    #[must_use]
+    pub fn outstanding(&self) -> Vec<(MailId, i64)> {
+        self.balance
+            .lock()
+            .expect("settlement cross-check mutex poisoned; fail-fast per ADR-0063")
+            .iter()
+            .map(|(&root, &bal)| (root, bal))
+            .collect()
+    }
+}
+
+/// Reads the `AETHER_SETTLEMENT_SHADOW` env var: shadow on iff it is
+/// exactly `"1"`.
+fn shadow_enabled_from_env() -> bool {
+    env::var("AETHER_SETTLEMENT_SHADOW").is_ok_and(|v| v == "1")
+}
+
+/// The Phase-1 shadow apparatus carried by the chassis trace handle: the
+/// emit-time [`SettlementCounter`], the [`SettlementCrossCheck`] against
+/// the observer, and an enable flag.
+///
+/// Cloned cheaply via the `Arc` the trace handle holds; every producer
+/// hook routes through one instance per chassis.
+#[derive(Debug)]
+pub struct ShadowSettlement {
+    enabled: AtomicBool,
+    counter: SettlementCounter,
+    cross_check: SettlementCrossCheck,
+}
+
+impl ShadowSettlement {
+    /// Construct with the enable flag seeded from
+    /// `AETHER_SETTLEMENT_SHADOW`.
+    #[must_use]
+    pub fn from_env() -> Self {
+        Self {
+            enabled: AtomicBool::new(shadow_enabled_from_env()),
+            counter: SettlementCounter::new(),
+            cross_check: SettlementCrossCheck::default(),
+        }
+    }
+
+    /// Enable or disable the shadow apparatus. Call **before** any
+    /// traffic — flipping it on mid-run desyncs the counter (see the
+    /// module docs).
+    pub fn set_enabled(&self, on: bool) {
+        self.enabled.store(on, Ordering::Relaxed);
+    }
+
+    /// Whether the shadow apparatus is currently active.
+    #[must_use]
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+
+    /// The agreement ledger, for test assertions.
+    #[must_use]
+    pub fn cross_check(&self) -> &SettlementCrossCheck {
+        &self.cross_check
+    }
+
+    /// True iff the apparatus is active and `root` is a real root.
+    /// `MailId::NONE` is the chassis-root / recursion-break sentinel and
+    /// never carries settlement accounting.
+    #[inline]
+    fn active(&self, root: MailId) -> bool {
+        self.is_enabled() && root != MailId::NONE
+    }
+
+    /// Emit-side hook for a `Sent`: `in_flight += 1`.
+    pub fn on_sent(&self, root: MailId) {
+        if self.active(root) {
+            self.counter.record_sent(root);
+        }
+    }
+
+    /// Emit-side hook for a settlement `HoldOpen`: `held_open += 1`.
+    pub fn on_hold_open(&self, root: MailId) {
+        if self.active(root) {
+            self.counter.record_hold_open(root);
+        }
+    }
+
+    /// Emit-side hook for a `Finished`: `in_flight -= 1`. On the
+    /// zero-transition, note the emit-time settle to the cross-check.
+    pub fn on_finished(&self, root: MailId) {
+        if self.active(root) && self.counter.record_finished(root) {
+            self.cross_check.note_emit(root);
+        }
+    }
+
+    /// Emit-side hook for a hold `Release`: `held_open -= 1`. On the
+    /// zero-transition, note the emit-time settle.
+    pub fn on_release(&self, root: MailId) {
+        if self.active(root) && self.counter.record_release(root) {
+            self.cross_check.note_emit(root);
+        }
+    }
+
+    /// Observer-side hook: the authoritative `Settled { root }` was just
+    /// routed (chassis-router). Note it against the emit-time settle.
+    pub fn on_observer_settled(&self, root: MailId) {
+        if self.active(root) {
+            self.cross_check.note_observer(root);
+        }
+    }
+}
+
+impl Default for ShadowSettlement {
+    fn default() -> Self {
+        Self::from_env()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_data::MailboxId;
+
+    fn root(sender: u64, cid: u64) -> MailId {
+        MailId {
+            sender: MailboxId(sender),
+            correlation_id: cid,
+        }
+    }
+
+    #[test]
+    fn cross_check_balances_and_reclaims() {
+        let xc = SettlementCrossCheck::default();
+        let r = root(1, 1);
+        xc.note_emit(r);
+        assert_eq!(xc.outstanding(), vec![(r, 1)]);
+        xc.note_observer(r);
+        assert!(
+            xc.outstanding().is_empty(),
+            "matched emit+observer reclaims the entry"
+        );
+        assert_eq!(xc.disagreements(), 0);
+    }
+
+    #[test]
+    fn cross_check_flags_observer_only_settle() {
+        let xc = SettlementCrossCheck::default();
+        let r = root(1, 2);
+        // Observer settles a root the emit counter never did.
+        xc.note_observer(r);
+        assert_eq!(xc.disagreements(), 1);
+    }
+
+    #[test]
+    fn cross_check_handles_reopen_multiplicity() {
+        // A root that settles twice (re-open) must net to zero across two
+        // emit + two observer notes, in any interleaving.
+        let xc = SettlementCrossCheck::default();
+        let r = root(1, 3);
+        xc.note_emit(r);
+        xc.note_emit(r);
+        xc.note_observer(r);
+        xc.note_observer(r);
+        assert!(xc.outstanding().is_empty());
+        assert_eq!(xc.disagreements(), 0);
+    }
+
+    #[test]
+    fn disabled_shadow_is_inert() {
+        let s = ShadowSettlement::from_env();
+        s.set_enabled(false);
+        let r = root(1, 4);
+        s.on_sent(r);
+        s.on_finished(r);
+        // Nothing recorded — the cross-check never saw an emit.
+        assert!(s.cross_check().outstanding().is_empty());
+        assert_eq!(s.cross_check().disagreements(), 0);
+    }
+
+    #[test]
+    fn enabled_shadow_records_emit_settle() {
+        let s = ShadowSettlement::from_env();
+        s.set_enabled(true);
+        let r = root(1, 5);
+        s.on_sent(r);
+        s.on_finished(r); // in_flight 1 -> 0 -> emit settle noted
+        assert_eq!(s.cross_check().outstanding(), vec![(r, 1)]);
+        s.on_observer_settled(r);
+        assert!(s.cross_check().outstanding().is_empty());
+        assert_eq!(s.cross_check().disagreements(), 0);
+    }
+
+    #[test]
+    fn none_root_is_ignored() {
+        let s = ShadowSettlement::from_env();
+        s.set_enabled(true);
+        // The recursion-break sentinel carries no accounting.
+        s.on_sent(MailId::NONE);
+        s.on_finished(MailId::NONE);
+        assert!(s.cross_check().outstanding().is_empty());
+    }
+}

--- a/crates/aether-substrate/src/runtime/trace.rs
+++ b/crates/aether-substrate/src/runtime/trace.rs
@@ -43,6 +43,7 @@ use aether_data::{KindId, MailId, MailboxId};
 use aether_kinds::trace::{BatchedTraceEvents, Nanos, TRACE_OBSERVER_MAILBOX_NAME, TraceEvent};
 use crossbeam_queue::SegQueue;
 
+use crate::chassis::settlement_shadow::ShadowSettlement;
 use crate::mail::Mail;
 use crate::mail::mailer::Mailer;
 use crate::mail::registry::MailboxEntry;
@@ -142,10 +143,18 @@ impl Default for ShardedTraceQueue {
 /// Cloning shares the underlying [`SegQueue`] (Arc) and copies the
 /// boot-time anchor (Copy), so the chassis drainer and every producer
 /// site can hold an independent `TraceHandle` cheaply.
+///
+/// The handle also carries the ADR-0086 Phase-1 [`ShadowSettlement`]
+/// apparatus (shared via `Arc` across clones — one per chassis). Every
+/// producer hook on this type funnels the same event into it, so the
+/// emit-time settlement counter sees exactly what the trace queue does;
+/// it is inert unless `AETHER_SETTLEMENT_SHADOW` (or the test setter)
+/// turns it on.
 #[derive(Clone, Debug)]
 pub struct TraceHandle {
     queue: Arc<ShardedTraceQueue>,
     boot_time: Instant,
+    shadow: Arc<ShadowSettlement>,
 }
 
 impl TraceHandle {
@@ -168,7 +177,17 @@ impl TraceHandle {
         Self {
             queue,
             boot_time: Instant::now(),
+            shadow: Arc::new(ShadowSettlement::from_env()),
         }
+    }
+
+    /// The ADR-0086 Phase-1 shadow-settlement apparatus. Tests and
+    /// shadow-validation runs reach it to enable the cross-check and
+    /// inspect agreement; the chassis-router reaches it to feed the
+    /// observer's authoritative `Settled` into the cross-check.
+    #[must_use]
+    pub fn shadow(&self) -> &Arc<ShadowSettlement> {
+        &self.shadow
     }
 
     /// Borrow the queue Arc so the chassis builder can pass it to
@@ -221,6 +240,7 @@ impl TraceHandle {
                 t: self.now_nanos(),
             },
         );
+        self.shadow.on_sent(root);
     }
 
     /// ADR-0080 §2 producer hook for the `Received` event. Pushed by
@@ -266,6 +286,7 @@ impl TraceHandle {
                 t: self.now_nanos(),
             },
         );
+        self.shadow.on_finished(root);
     }
 
     /// ADR-0080 §12 / iamacoffeepot/aether#716: acquire a
@@ -292,6 +313,7 @@ impl TraceHandle {
                 t: self.now_nanos(),
             },
         );
+        self.shadow.on_hold_open(root);
         SettlementHold {
             handle: self.clone(),
             root,
@@ -335,6 +357,7 @@ impl Drop for SettlementHold {
                 t: self.handle.now_nanos(),
             },
         );
+        self.handle.shadow.on_release(self.root);
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 1 of the settlement/trace decoupling (ADR-0086), tracked by iamacoffeepot/aether#1092. Runs the emit-time `SettlementCounter` (landed standalone in Phase 0, iamacoffeepot/aether#1094) alongside the incumbent `TraceObserverCapability` fold and cross-checks that the two settle identically — **without driving the lifecycle**. The observer stays the settlement authority until Phase 2 flips frame-gating onto the counter.

- **`chassis::settlement_shadow`** — `ShadowSettlement` wraps the counter + a self-bounding `SettlementCrossCheck`. The emit side notes a settle (`+1`) synchronously on the producer thread; the chassis-router notes the observer's authoritative `Settled` (`-1`) ~1 ms later. A balanced entry reclaims (so the ledger only holds roots inside the `[emit, observer]` window — never cumulative); a negative balance is a logged disagreement; a lingering positive is caught by the at-quiescence assertion.
- **Wired at `TraceHandle`** — the single producer choke point every `record_sent` / `record_finished` / `acquire_settlement_hold` / hold-`Release` routes through, so the counter sees exactly what the trace queue does.
- **Off by default** (`AETHER_SETTLEMENT_SHADOW`). A disabled hook is one relaxed atomic load + branch, so a normal substrate and the perf harness pay effectively nothing. Tests enable it on the bench before driving traffic.
- **Agreement tests** — a fan-out + shared-node + depth topology, a depth chain, and a `spawn_inherit` hold path all settle identically on both paths under multi-worker concurrency (`emit_settles == observer_settles == roots`, empty ledger, zero disagreements). A non-vacuity assertion (`emit_settles == roots`) rules out a silently-disabled shadow passing trivially.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` (both touched crates)
- [x] `cargo doc` with `-D rustdoc::broken_intra_doc_links`
- [x] `cargo nextest run` — 356 pass, 4 ignored (measurement harnesses)
- [x] RustRover/Qodana: `DuplicatedCode` in the test resolved via a shared `spawn_topology` helper
- [ ] Reviewer: confirm the shadow-mode approach and the cross-check before Phase 2 flips frame-gating onto the counter
