### PR TITLE
perf(substrate): per-actor trace rings, dormant (ADR-0086 phase 3a)

### DIFF
--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -62,6 +62,7 @@ pub mod ffi;
 pub mod local;
 pub mod log;
 pub mod mail;
+pub mod trace_ring;
 
 pub use actor::ctx::{LifecycleControl, MailSender, OutboundReply, Persistence, Resolver};
 pub use actor::sender::{MailCtx, Sender};

--- a/crates/aether-actor/src/trace_ring.rs
+++ b/crates/aether-actor/src/trace_ring.rs
@@ -22,7 +22,7 @@
 //! (one OS thread per actor at a time), so the `sequence` counter and
 //! the `VecDeque` need no lock internally. Cross-thread reads run
 //! through the `Local` path on the responding actor's dispatcher (the
-//! framework-built-in `aether.trace.tail` arm invokes [`Self::tail`]
+//! framework-built-in `aether.trace.tail` arm invokes [`ActorTraceRing::tail`]
 //! from inside the dispatch loop). Off-actor `Sent`s (chassis-root /
 //! injected mail produced outside any actor's dispatch) have no
 //! `ActorSlots` to land in; the chassis trace handle keeps a separate

--- a/crates/aether-actor/src/trace_ring.rs
+++ b/crates/aether-actor/src/trace_ring.rs
@@ -1,0 +1,323 @@
+//! ADR-0086 Phase 3 per-actor trace storage. Every actor — native or
+//! wasm trampoline — owns an [`ActorTraceRing`] in its
+//! [`crate::local::ActorSlots`], the trace-side sibling of ADR-0081's
+//! [`crate::log::ActorLogRing`]. The producer hooks
+//! (`record_sent` / `record_received` / `record_finished`) push the
+//! mail-graph events for the current actor into its ring; a coordinator
+//! reconstructs a trace tree on demand by fanning out
+//! [`aether_kinds::trace::TraceTail`] across live actors and stitching
+//! the per-ring slices by lineage keys.
+//!
+//! The ring stores only the mail-graph events — `Sent` lands in the
+//! sender's ring, `Received` / `Finished` in the recipient's. Each entry
+//! is tagged with its causal `root` (the producer hook has it at push
+//! time, even for `Received` / `Finished` whose wire variants don't
+//! carry it), so a root-filtered [`TraceTail`] resolves a single tree's
+//! events from a ring without the central observer's by-mail join.
+//! Settlement holds (`HoldOpen` / `Release`) are *not* stored: they
+//! aren't tree nodes and settlement no longer rides the trace stream
+//! (ADR-0086 Phase 2 — the emit-time counter owns them).
+//!
+//! Single-writer: the actor's dispatcher thread is the sole producer
+//! (one OS thread per actor at a time), so the `sequence` counter and
+//! the `VecDeque` need no lock internally. Cross-thread reads run
+//! through the `Local` path on the responding actor's dispatcher (the
+//! framework-built-in `aether.trace.tail` arm invokes [`Self::tail`]
+//! from inside the dispatch loop). Off-actor `Sent`s (chassis-root /
+//! injected mail produced outside any actor's dispatch) have no
+//! `ActorSlots` to land in; the chassis trace handle keeps a separate
+//! locked chassis-host ring for those (ADR-0086 Phase 3 §B).
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use alloc::collections::VecDeque;
+
+use aether_data::MailId;
+use aether_kinds::trace::{TraceEvent, TraceRingEntry, TraceTail, TraceTailResult};
+
+use crate::Local;
+
+/// Default per-actor trace-ring capacity. Larger than the log ring's
+/// 1024 because a busy actor emits up to three trace events per mail
+/// (`Sent` on send, `Received` + `Finished` on dispatch). 4096 keeps
+/// the worst-case memory near 4096 × ~64 B = ~256 KiB per actor.
+pub const DEFAULT_TRACE_RING_CAP: usize = 4096;
+
+/// Substrate-default cap on entries returned per [`TraceTail`] when the
+/// caller passes `max == 0`. Mirrors the log ring's tail default.
+pub const DEFAULT_TAIL_MAX: u32 = 256;
+
+/// Absolute ceiling on entries returned per [`TraceTail`]; caller
+/// `max` above this clamps down. The ring capacity is the natural
+/// upper bound — one ring can never reply with more than it holds.
+pub const MAX_TAIL_MAX: u32 = 4096;
+
+/// Per-actor bounded ring of trace events (ADR-0086 Phase 3). The
+/// trace-side sibling of [`crate::log::ActorLogRing`]: same
+/// `(ring, ring_cap, sequence)` triple, same FIFO drop-oldest eviction,
+/// same `truncated_before` gap cursor. Entries carry their causal
+/// `root` so a root-filtered [`Self::tail`] resolves one tree's events
+/// directly.
+pub struct ActorTraceRing {
+    ring: VecDeque<TraceRingEntry>,
+    ring_cap: usize,
+    /// Monotonic per-ring sequence; starts at 1. Persists across
+    /// eviction so a caller's `since` cursor stays meaningful (it
+    /// resolves into a `truncated_before` gap signal rather than
+    /// silently re-pulling).
+    sequence: u64,
+}
+
+impl Default for ActorTraceRing {
+    fn default() -> Self {
+        Self::with_capacity(DEFAULT_TRACE_RING_CAP)
+    }
+}
+
+impl Local for ActorTraceRing {}
+
+impl ActorTraceRing {
+    /// Build an empty ring with the supplied capacity, clamped to
+    /// `max(1, _)` — a zero-cap ring would drop every entry.
+    #[must_use]
+    pub fn with_capacity(ring_cap: usize) -> Self {
+        let ring_cap = ring_cap.max(1);
+        Self {
+            ring: VecDeque::with_capacity(ring_cap),
+            ring_cap,
+            sequence: 1,
+        }
+    }
+
+    /// Push one trace event tagged with its causal `root`, stamping the
+    /// next-available `sequence`. Evicts the oldest entry when the ring
+    /// is at cap.
+    pub fn push(&mut self, root: MailId, event: TraceEvent) {
+        let sequence = self.sequence;
+        self.sequence += 1;
+        if self.ring.len() == self.ring_cap {
+            self.ring.pop_front();
+        }
+        self.ring.push_back(TraceRingEntry {
+            sequence,
+            root,
+            event,
+        });
+    }
+
+    /// Pure read-side: filter on `since` (and `root`, when set), cap at
+    /// `max` (with `0 → DEFAULT_TAIL_MAX` and `> MAX_TAIL_MAX → ceiling`
+    /// clamping), compute the `truncated_before` cursor. Ordered
+    /// oldest-to-newest.
+    #[must_use]
+    pub fn tail(&self, request: &TraceTail) -> TraceTailResult {
+        let max = resolve_max(request.max) as usize;
+        let since = request.since.unwrap_or(0);
+
+        let earliest = self.ring.front().map(|e| e.sequence);
+        let truncated_before = match earliest {
+            Some(e) if e > since + 1 => Some(e),
+            _ => None,
+        };
+
+        let entries: Vec<TraceRingEntry> = self
+            .ring
+            .iter()
+            .filter(|e| e.sequence > since)
+            .filter(|e| request.root.is_none_or(|r| e.root == r))
+            .take(max)
+            .cloned()
+            .collect();
+
+        let next_since = entries.last().map_or(since, |e| e.sequence);
+
+        TraceTailResult::Ok {
+            entries,
+            next_since,
+            truncated_before,
+        }
+    }
+
+    /// Snapshot every entry currently in the ring, oldest-to-newest, no
+    /// filter. For the panic-hook dump path and tests.
+    #[must_use]
+    pub fn snapshot(&self) -> Vec<TraceRingEntry> {
+        self.ring.iter().cloned().collect()
+    }
+
+    /// Number of entries currently in the ring.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.ring.len()
+    }
+
+    /// Is the ring empty?
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.ring.is_empty()
+    }
+}
+
+/// Clamp `max == 0` to [`DEFAULT_TAIL_MAX`] and any value over
+/// [`MAX_TAIL_MAX`] down to the ceiling.
+fn resolve_max(max: u32) -> u32 {
+    if max == 0 {
+        DEFAULT_TAIL_MAX
+    } else {
+        max.min(MAX_TAIL_MAX)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_data::MailboxId;
+    use aether_kinds::trace::Nanos;
+
+    fn mid(sender: u64, cid: u64) -> MailId {
+        MailId {
+            sender: MailboxId(sender),
+            correlation_id: cid,
+        }
+    }
+
+    fn sent(root: MailId) -> TraceEvent {
+        TraceEvent::Sent {
+            mail_id: root,
+            root,
+            parent_mail: None,
+            sender: MailboxId(1),
+            recipient: MailboxId(2),
+            kind: aether_data::KindId(3),
+            t: Nanos(0),
+        }
+    }
+
+    fn finished(mail_id: MailId) -> TraceEvent {
+        TraceEvent::Finished {
+            mail_id,
+            t: Nanos(0),
+        }
+    }
+
+    fn ok(result: TraceTailResult) -> (Vec<TraceRingEntry>, u64, Option<u64>) {
+        match result {
+            TraceTailResult::Ok {
+                entries,
+                next_since,
+                truncated_before,
+            } => (entries, next_since, truncated_before),
+            TraceTailResult::Err { error } => panic!("expected Ok, got Err: {error}"),
+        }
+    }
+
+    fn unfiltered() -> TraceTail {
+        TraceTail {
+            max: 0,
+            since: None,
+            root: None,
+        }
+    }
+
+    #[test]
+    fn tail_returns_entries_in_push_order_with_monotonic_sequence() {
+        let mut ring = ActorTraceRing::with_capacity(8);
+        let r = mid(1, 1);
+        ring.push(r, sent(r));
+        ring.push(r, finished(r));
+        let (entries, next_since, truncated_before) = ok(ring.tail(&unfiltered()));
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].sequence, 1);
+        assert_eq!(entries[1].sequence, 2);
+        assert_eq!(next_since, 2);
+        assert_eq!(truncated_before, None);
+    }
+
+    #[test]
+    fn tail_filters_by_root() {
+        let mut ring = ActorTraceRing::with_capacity(8);
+        let a = mid(1, 1);
+        let b = mid(1, 2);
+        ring.push(a, sent(a));
+        ring.push(b, sent(b));
+        ring.push(a, finished(a));
+        let (entries, ..) = ok(ring.tail(&TraceTail {
+            max: 0,
+            since: None,
+            root: Some(a),
+        }));
+        assert_eq!(entries.len(), 2, "only root a's two events");
+        assert!(entries.iter().all(|e| e.root == a));
+    }
+
+    #[test]
+    fn tail_since_cursor_paginates_without_double_pulling() {
+        let mut ring = ActorTraceRing::with_capacity(8);
+        let r = mid(1, 1);
+        for _ in 0..5 {
+            ring.push(r, sent(r));
+        }
+        let (entries, next_since, _) = ok(ring.tail(&TraceTail {
+            max: 0,
+            since: Some(2),
+            root: None,
+        }));
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].sequence, 3);
+        assert_eq!(next_since, 5);
+
+        let (entries, next_since, _) = ok(ring.tail(&TraceTail {
+            max: 0,
+            since: Some(next_since),
+            root: None,
+        }));
+        assert!(entries.is_empty());
+        assert_eq!(next_since, 5);
+    }
+
+    #[test]
+    fn tail_max_caps_returned_slice() {
+        let mut ring = ActorTraceRing::with_capacity(8);
+        let r = mid(1, 1);
+        for _ in 0..5 {
+            ring.push(r, sent(r));
+        }
+        let (entries, next_since, _) = ok(ring.tail(&TraceTail {
+            max: 2,
+            since: None,
+            root: None,
+        }));
+        assert_eq!(entries.len(), 2);
+        assert_eq!(next_since, 2);
+    }
+
+    #[test]
+    fn tail_signals_truncated_before_when_ring_evicted_prefix() {
+        let mut ring = ActorTraceRing::with_capacity(3);
+        let r = mid(1, 1);
+        for _ in 0..5 {
+            ring.push(r, sent(r));
+        }
+        let (entries, _, truncated_before) = ok(ring.tail(&unfiltered()));
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].sequence, 3);
+        assert_eq!(truncated_before, Some(3));
+    }
+
+    #[test]
+    fn resolve_max_clamps_to_documented_bounds() {
+        assert_eq!(resolve_max(0), DEFAULT_TAIL_MAX);
+        assert_eq!(resolve_max(50), 50);
+        assert_eq!(resolve_max(MAX_TAIL_MAX), MAX_TAIL_MAX);
+        assert_eq!(resolve_max(MAX_TAIL_MAX + 5_000), MAX_TAIL_MAX);
+    }
+
+    #[test]
+    fn zero_cap_is_clamped_to_one() {
+        let mut ring = ActorTraceRing::with_capacity(0);
+        let r = mid(1, 1);
+        ring.push(r, sent(r));
+        assert_eq!(ring.len(), 1);
+    }
+}

--- a/crates/aether-actor/src/trace_ring.rs
+++ b/crates/aether-actor/src/trace_ring.rs
@@ -30,8 +30,8 @@
 
 extern crate alloc;
 
-use alloc::vec::Vec;
 use alloc::collections::VecDeque;
+use alloc::vec::Vec;
 
 use aether_data::MailId;
 use aether_kinds::trace::{TraceEvent, TraceRingEntry, TraceTail, TraceTailResult};

--- a/crates/aether-kinds/src/trace.rs
+++ b/crates/aether-kinds/src/trace.rs
@@ -327,6 +327,71 @@ pub enum DescribeWindowResult {
     Err { too_many: Option<u32> },
 }
 
+/// ADR-0086 Phase 3: one entry in an actor's `ActorTraceRing` as it
+/// appears on the wire when a coordinator queries the ring via
+/// [`TraceTail`] / [`TraceTailResult`].
+///
+/// `sequence` is monotonic *per ring*, starting at 1 — the cursor for
+/// [`TraceTail::since`]. `root` is stored explicitly even for
+/// `Received` / `Finished` events (whose [`TraceEvent`] variants don't
+/// carry it on the wire) because the producer hooks have it at push
+/// time; this lets a coordinator filter a ring by root server-side and
+/// stitch the tree without the central observer's by-mail join.
+///
+/// Not a `Kind` — only addressable as an element of
+/// [`TraceTailResult::Ok::entries`].
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Schema)]
+pub struct TraceRingEntry {
+    pub sequence: u64,
+    pub root: MailId,
+    pub event: TraceEvent,
+}
+
+/// ADR-0086 Phase 3: `aether.trace.tail` — query one actor's
+/// `ActorTraceRing`. Routed to a specific actor by `MailboxId`; the
+/// framework dispatch loop services it directly (every native actor and
+/// every wasm trampoline answers without the author writing a handler),
+/// the same surface [`crate::LogTail`] established for log rings. The
+/// trace-tree coordinator fans this out across live actors and stitches
+/// the per-ring slices by lineage keys. Reply: [`TraceTailResult`].
+///
+/// - `max == 0` resolves to the substrate-default cap; the reply slice
+///   never exceeds the ring's hard ceiling even on a full ring.
+/// - `since: None` returns from the oldest entry; `Some(n)` returns only
+///   entries with `sequence > n` (the per-ring cursor).
+/// - `root: None` returns every event in the ring; `Some(r)` returns
+///   only the events tagged with root `r` — the targeted/guided-walk
+///   strategy that touches only the actors in one tree.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.trace.tail")]
+pub struct TraceTail {
+    pub max: u32,
+    pub since: Option<u64>,
+    pub root: Option<MailId>,
+}
+
+/// Reply to [`TraceTail`]. `Ok::entries` slices the responder's ring
+/// matching `(since, root)`, ordered oldest-to-newest (ascending
+/// `sequence`). `next_since` is the highest `sequence` in `entries` (or
+/// the caller's `since` echoed back on an empty reply) — thread it into
+/// the next [`TraceTail::since`] for a stable per-ring cursor.
+/// `truncated_before` is set when the ring evicted entries the caller
+/// hadn't seen yet (the lowest `sequence` still in the ring), so a
+/// reconstructed tree can flag itself known-incomplete rather than fail
+/// silently.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.trace.tail_result")]
+pub enum TraceTailResult {
+    Ok {
+        entries: Vec<TraceRingEntry>,
+        next_since: u64,
+        truncated_before: Option<u64>,
+    },
+    Err {
+        error: String,
+    },
+}
+
 /// ADR-0080 §6 settlement notification. Emitted by
 /// [`BatchedTraceEvents`]'s consumer
 /// (`TraceObserverCapability`) when a causal chain's `in_flight`

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -34,6 +34,8 @@ use aether_data::{Kind, KindId, SessionToken, Uuid, encode_empty, encode_struct}
 #[cfg(test)]
 use aether_kinds::Tick;
 use aether_kinds::{Advance, AdvanceResult, CaptureFrame, CaptureFrameResult};
+#[cfg(test)]
+use aether_kinds::trace::{TraceTail, TraceTailResult};
 // `encode_struct` is used for control kinds (postcard-shape); cast-
 // shape kinds (e.g. FrameStats) flow through `frame_loop` helpers.
 use aether_actor::Actor;
@@ -515,6 +517,16 @@ impl TestBench {
             .push_chassis_root_mail(cid, recipient, kind, payload, 1);
         let rx = registry.subscribe_settlement(root);
         (root, rx)
+    }
+
+    /// ADR-0086 Phase 3: read the chassis-host trace ring — where the
+    /// `Sent` for off-actor / injected root mail (e.g. [`Self::inject_root`])
+    /// lands, since it's produced outside any actor's stamped slots.
+    /// Per-actor rings are queried via `aether.trace.tail` mail; this
+    /// ring belongs to no actor, so the test reads it directly.
+    #[cfg(test)]
+    pub(crate) fn chassis_host_trace_tail(&self, request: &TraceTail) -> TraceTailResult {
+        self.queue.trace_handle().chassis_host_tail(request)
     }
 
     /// Bytes-level request/reply: push `(kind, payload)` to

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -33,9 +33,9 @@ use std::time::{Duration, Instant};
 use aether_data::{Kind, KindId, SessionToken, Uuid, encode_empty, encode_struct};
 #[cfg(test)]
 use aether_kinds::Tick;
-use aether_kinds::{Advance, AdvanceResult, CaptureFrame, CaptureFrameResult};
 #[cfg(test)]
 use aether_kinds::trace::{TraceTail, TraceTailResult};
+use aether_kinds::{Advance, AdvanceResult, CaptureFrame, CaptureFrameResult};
 // `encode_struct` is used for control kinds (postcard-shape); cast-
 // shape kinds (e.g. FrameStats) flow through `frame_loop` helpers.
 use aether_actor::Actor;

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -25,7 +25,8 @@ use std::time::{Duration, Instant};
 
 use aether_data::{Kind, KindId, MailId, MailboxId, mailbox_id_from_name};
 use aether_kinds::trace::{
-    DescribeTree, DescribeTreeResult, MailNodeWire, TRACE_OBSERVER_MAILBOX_NAME,
+    DescribeTree, DescribeTreeResult, MailNodeWire, TRACE_OBSERVER_MAILBOX_NAME, TraceEvent,
+    TraceRingEntry, TraceTail, TraceTailResult,
 };
 use aether_substrate::{BootError, NativeActor, NativeCtx, NativeDispatch, NativeInitCtx, Subname};
 
@@ -376,6 +377,88 @@ fn emit_settlement_settles_with_holds() {
             "hold root {idx} never settled — the hold's Release must fire the counter"
         );
     }
+}
+
+/// Query one actor's per-actor trace ring over the mail wire
+/// (`aether.trace.tail`), filtered to `root`. Returns the ring slice.
+fn trace_tail(tb: &mut TestBench, mailbox_name: &str, root: MailId) -> Vec<TraceRingEntry> {
+    let req = TraceTail {
+        max: 0,
+        since: None,
+        root: Some(root),
+    }
+    .encode_into_bytes();
+    let reply = tb
+        .send_bytes_and_await(mailbox_name, TraceTail::ID, req)
+        .expect("aether.trace.tail reply");
+    match TraceTailResult::decode_from_bytes(&reply).expect("decode TraceTailResult") {
+        TraceTailResult::Ok { entries, .. } => entries,
+        TraceTailResult::Err { error } => panic!("trace.tail error: {error}"),
+    }
+}
+
+/// ADR-0086 Phase 3a: the producer hooks dual-write into the per-actor
+/// trace rings (and the chassis-host ring for off-actor sends) alongside
+/// the central observer. Inject a single-mail root at a leaf relay,
+/// settle it, then assert the rings recorded the right events on the
+/// right owners: the injected `Sent` (produced off-actor on the inject
+/// thread) lands in the chassis-host ring; the recipient relay's
+/// `Received` + `Finished` land in its own per-actor ring, queryable via
+/// `aether.trace.tail`. Validates the dispatch-arm + the `root` filter
+/// too (the trace-query mail's own events carry a different root and are
+/// excluded).
+#[test]
+#[allow(clippy::print_stderr)]
+fn trace_ring_dual_write_routes_events_to_owning_rings() {
+    let Ok(mut tb) = TestBench::builder()
+        .with_workers(Some(2))
+        .size(16, 16)
+        .build()
+    else {
+        eprintln!("skipping trace_ring_dual_write_routes_events_to_owning_rings: no wgpu adapter");
+        return;
+    };
+
+    spawn_topology(&tb, &depth_chain(1));
+    let (root, rx) = tb.inject_root(relay_id(0), Ping::ID, Ping { seq: 0 }.encode_into_bytes());
+    assert!(
+        rx.recv_timeout(SETTLE_TIMEOUT).is_ok(),
+        "injected root never settled"
+    );
+
+    // The recipient relay's own ring holds the mail's Received + Finished.
+    let relay = trace_tail(&mut tb, "mlat.relay:0", root);
+    assert!(
+        relay
+            .iter()
+            .any(|e| matches!(e.event, TraceEvent::Received { .. })),
+        "relay ring missing Received; got {relay:?}"
+    );
+    assert!(
+        relay
+            .iter()
+            .any(|e| matches!(e.event, TraceEvent::Finished { .. })),
+        "relay ring missing Finished; got {relay:?}"
+    );
+    assert!(
+        relay.iter().all(|e| e.root == root),
+        "root filter leaked other roots (e.g. the trace-query mail): {relay:?}"
+    );
+
+    // The off-actor injected Sent landed in the chassis-host ring.
+    let host = match tb.chassis_host_trace_tail(&TraceTail {
+        max: 0,
+        since: None,
+        root: Some(root),
+    }) {
+        TraceTailResult::Ok { entries, .. } => entries,
+        TraceTailResult::Err { error } => panic!("chassis-host trace.tail error: {error}"),
+    };
+    assert!(
+        host.iter()
+            .any(|e| matches!(e.event, TraceEvent::Sent { .. }) && e.root == root),
+        "chassis-host ring missing the injected Sent; got {host:?}"
+    );
 }
 
 const OBSERVE_FRAMES: u32 = 1000;

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -40,7 +40,9 @@ use aether_actor::Local;
 use aether_actor::MailCtx;
 use aether_actor::local::ActorSlots;
 use aether_actor::log::ActorLogRing;
+use aether_actor::trace_ring::ActorTraceRing;
 use aether_data::Kind;
+use aether_kinds::trace::{TraceEvent, TraceTail, TraceTailResult};
 use aether_kinds::{LogTail, LogTailResult};
 
 use crate::actor::native::binding::NativeBinding;
@@ -110,6 +112,32 @@ pub fn dispatch_log_tail_if_matching(ctx: &mut NativeCtx<'_>, env: &Envelope) ->
     true
 }
 
+/// ADR-0086 Phase 3 framework-built-in dispatch arm for
+/// `aether.trace.tail` — the trace-side sibling of
+/// [`dispatch_log_tail_if_matching`]. Reads the receiving actor's
+/// [`ActorTraceRing`] via the currently-stamped `ActorSlots` and
+/// replies inline; the dispatcher then skips the user's typed/fallback
+/// dispatch for this envelope. The trace-tree coordinator fans this out
+/// across live actors and stitches the per-ring slices.
+pub fn dispatch_trace_tail_if_matching(ctx: &mut NativeCtx<'_>, env: &Envelope) -> bool {
+    if env.kind.0 != <TraceTail as Kind>::ID.0 {
+        return false;
+    }
+    let Some(request) = <TraceTail as Kind>::decode_from_bytes(&env.payload) else {
+        ctx.reply(&TraceTailResult::Err {
+            error: "aether.trace.tail: payload failed to decode".to_owned(),
+        });
+        return true;
+    };
+    let reply = ActorTraceRing::try_with(|ring| ring.tail(&request)).unwrap_or_else(|| {
+        TraceTailResult::Err {
+            error: "aether.trace.tail: actor has no stamped slots".to_owned(),
+        }
+    });
+    ctx.reply(&reply);
+    true
+}
+
 /// Run one actor's dispatcher loop on the calling thread. Returns
 /// when the binding signals shutdown (self-shutdown flag set or
 /// inbox sender disconnected). See module doc-comment for the full
@@ -145,16 +173,38 @@ pub fn dispatch_loop_run<A>(
         let thread_name = thread::current().name().map(str::to_owned);
         binding
             .mailer()
-            .record_received(inbound_mail_id, env.root, thread_name);
+            .record_received(inbound_mail_id, env.root, thread_name.clone());
         local::with_stamped(slots, || {
+            // ADR-0086 Phase 3 dual-write: `Received` lands in this
+            // (recipient) actor's trace ring — only inside this
+            // `with_stamped` is its `ActorSlots` stamped. The central
+            // `record_received` above keeps the queue path until 3c.
+            let th = binding.mailer().trace_handle();
+            th.push_trace_ring(
+                env.root,
+                TraceEvent::Received {
+                    mail_id: inbound_mail_id,
+                    t: th.now_nanos(),
+                    thread_name,
+                },
+            );
             let mut ctx = NativeCtx::new(binding, env.sender, env.mail_id, env.root);
-            // ADR-0081: framework intercepts `aether.log.tail` before
-            // the actor's typed/fallback dispatch. The actor never
-            // sees the envelope; the framework reads its ring and
-            // replies inline.
-            if !dispatch_log_tail_if_matching(&mut ctx, &env) {
+            // ADR-0081 / ADR-0086: the framework intercepts
+            // `aether.log.tail` and `aether.trace.tail` before the
+            // actor's typed/fallback dispatch. The actor never sees
+            // these; the framework reads its rings and replies inline.
+            if !dispatch_log_tail_if_matching(&mut ctx, &env)
+                && !dispatch_trace_tail_if_matching(&mut ctx, &env)
+            {
                 typed_then_fallback_or_warn::<A>(actor, &mut ctx, &env);
             }
+            th.push_trace_ring(
+                env.root,
+                TraceEvent::Finished {
+                    mail_id: inbound_mail_id,
+                    t: th.now_nanos(),
+                },
+            );
         });
         binding.mailer().record_finished(inbound_mail_id, env.root);
         if let Some(p) = pending {
@@ -172,12 +222,30 @@ pub fn dispatch_loop_run<A>(
         let thread_name = thread::current().name().map(str::to_owned);
         binding
             .mailer()
-            .record_received(inbound_mail_id, env.root, thread_name);
+            .record_received(inbound_mail_id, env.root, thread_name.clone());
         local::with_stamped(slots, || {
+            let th = binding.mailer().trace_handle();
+            th.push_trace_ring(
+                env.root,
+                TraceEvent::Received {
+                    mail_id: inbound_mail_id,
+                    t: th.now_nanos(),
+                    thread_name,
+                },
+            );
             let mut ctx = NativeCtx::new(binding, env.sender, env.mail_id, env.root);
-            if !dispatch_log_tail_if_matching(&mut ctx, &env) {
+            if !dispatch_log_tail_if_matching(&mut ctx, &env)
+                && !dispatch_trace_tail_if_matching(&mut ctx, &env)
+            {
                 let _ = actor.__aether_dispatch_envelope(&mut ctx, env.kind, &env.payload);
             }
+            th.push_trace_ring(
+                env.root,
+                TraceEvent::Finished {
+                    mail_id: inbound_mail_id,
+                    t: th.now_nanos(),
+                },
+            );
         });
         binding.mailer().record_finished(inbound_mail_id, env.root);
         if let Some(p) = pending {

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -45,6 +45,7 @@ use std::time::Instant;
 use crate::actor::native::Envelope;
 use aether_actor::local;
 use aether_actor::local::ActorSlots;
+use aether_kinds::trace::TraceEvent;
 use std::ops::Deref;
 use std::sync::PoisonError;
 use std::thread;
@@ -214,14 +215,37 @@ where
         let thread_name = thread::current().name().map(str::to_owned);
         self.binding
             .mailer()
-            .record_received(inbound_mail_id, env.root, thread_name);
+            .record_received(inbound_mail_id, env.root, thread_name.clone());
         local::with_stamped(&self.slots, || {
+            // ADR-0086 Phase 3 dual-write: `Received` / `Finished` land
+            // in this (recipient) actor's trace ring — only inside this
+            // `with_stamped` is its `ActorSlots` stamped. Mirrors
+            // `dispatch::dispatch_loop_run`.
+            let th = self.binding.mailer().trace_handle();
+            th.push_trace_ring(
+                env.root,
+                TraceEvent::Received {
+                    mail_id: inbound_mail_id,
+                    t: th.now_nanos(),
+                    thread_name,
+                },
+            );
             let mut ctx = NativeCtx::new(&self.binding, env.sender, env.mail_id, env.root);
-            // ADR-0081 framework-built-in dispatch arm for
-            // `aether.log.tail`. See `dispatch::dispatch_loop_run`.
-            if !super::dispatch::dispatch_log_tail_if_matching(&mut ctx, &env) {
+            // ADR-0081 / ADR-0086 framework-built-in dispatch arms for
+            // `aether.log.tail` + `aether.trace.tail`. See
+            // `dispatch::dispatch_loop_run`.
+            if !super::dispatch::dispatch_log_tail_if_matching(&mut ctx, &env)
+                && !super::dispatch::dispatch_trace_tail_if_matching(&mut ctx, &env)
+            {
                 super::dispatch::typed_then_fallback_or_warn::<A>(actor, &mut ctx, &env);
             }
+            th.push_trace_ring(
+                env.root,
+                TraceEvent::Finished {
+                    mail_id: inbound_mail_id,
+                    t: th.now_nanos(),
+                },
+            );
         });
         self.binding
             .mailer()

--- a/crates/aether-substrate/src/runtime/trace.rs
+++ b/crates/aether-substrate/src/runtime/trace.rs
@@ -42,8 +42,13 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 use aether_data::{KindId, MailId, MailboxId};
-use aether_kinds::trace::{BatchedTraceEvents, Nanos, TRACE_OBSERVER_MAILBOX_NAME, TraceEvent};
+use aether_kinds::trace::{
+    BatchedTraceEvents, Nanos, TRACE_OBSERVER_MAILBOX_NAME, TraceEvent, TraceTail, TraceTailResult,
+};
 use crossbeam_queue::SegQueue;
+
+use aether_actor::Local;
+use aether_actor::trace_ring::ActorTraceRing;
 
 use crate::chassis::settlement::SettlementRegistry;
 use crate::chassis::settlement_counter::SettlementCounter;
@@ -162,6 +167,13 @@ pub struct TraceHandle {
     boot_time: Instant,
     settlement_counter: Arc<SettlementCounter>,
     settlement_registry: Arc<OnceLock<Arc<SettlementRegistry>>>,
+    /// ADR-0086 Phase 3: ring for trace events produced *outside* any
+    /// actor's dispatch — chassis-root / injected mail (`Tick`, MCP
+    /// sends, test injects) records its `Sent` off any actor's stamped
+    /// `ActorSlots`. A `Mutex` (not the `Local` per-actor rings' lock-
+    /// free path) because off-actor producers run on arbitrary threads.
+    /// The trace-tree coordinator includes this ring in its fan-out.
+    chassis_host_ring: Arc<Mutex<ActorTraceRing>>,
 }
 
 // Manual `Debug` — `SettlementRegistry` carries non-`Debug` subscriber
@@ -201,6 +213,7 @@ impl TraceHandle {
             boot_time: Instant::now(),
             settlement_counter: Arc::new(SettlementCounter::new()),
             settlement_registry: Arc::new(OnceLock::new()),
+            chassis_host_ring: Arc::new(Mutex::new(ActorTraceRing::default())),
         }
     }
 
@@ -229,6 +242,54 @@ impl TraceHandle {
         if let Some(registry) = self.settlement_registry.get() {
             registry.fire_settled(root);
         }
+    }
+
+    /// ADR-0086 Phase 3: dual-write a trace event into the per-actor
+    /// [`ActorTraceRing`] alongside the central queue. Lands in the
+    /// current actor's ring when one is stamped — `Sent` on the
+    /// sender's dispatch (this hook runs inside the sender's handler),
+    /// `Received` / `Finished` on the recipient's (the dispatch loop
+    /// calls this inside its `with_stamped`). Off any actor's dispatch
+    /// (chassis-root / injected mail) it falls back to the chassis-host
+    /// ring. Additive until Phase 3c retires the central queue.
+    ///
+    /// # Panics
+    /// Panics if the chassis-host ring mutex is poisoned (fail-fast per
+    /// ADR-0063) — only reachable on the off-actor fallback path.
+    pub fn push_trace_ring(&self, root: MailId, event: TraceEvent) {
+        // Move the event into whichever ring applies. `try_with_mut`
+        // skips the closure entirely when no actor is stamped, leaving
+        // `slot` populated for the chassis-host fallback — so the event
+        // moves exactly once with no clone.
+        let mut slot = Some(event);
+        ActorTraceRing::try_with_mut(|ring| {
+            if let Some(event) = slot.take() {
+                ring.push(root, event);
+            }
+        });
+        if let Some(event) = slot.take() {
+            self.chassis_host_ring
+                .lock()
+                .expect("chassis-host trace ring mutex poisoned; fail-fast per ADR-0063")
+                .push(root, event);
+        }
+    }
+
+    /// Read the chassis-host ring (ADR-0086 Phase 3). The trace-tree
+    /// coordinator queries the per-actor rings via `aether.trace.tail`
+    /// mail, but the chassis-host ring belongs to no actor, so it is
+    /// read directly through this handle. Returns the same
+    /// `TraceTailResult` shape for a uniform stitch.
+    ///
+    /// # Panics
+    /// Panics if the chassis-host ring mutex is poisoned (fail-fast per
+    /// ADR-0063).
+    #[must_use]
+    pub fn chassis_host_tail(&self, request: &TraceTail) -> TraceTailResult {
+        self.chassis_host_ring
+            .lock()
+            .expect("chassis-host trace ring mutex poisoned; fail-fast per ADR-0063")
+            .tail(request)
     }
 
     /// Borrow the queue Arc so the chassis builder can pass it to
@@ -269,18 +330,17 @@ impl TraceHandle {
         recipient: MailboxId,
         kind: KindId,
     ) {
-        self.queue.push(
+        let event = TraceEvent::Sent {
+            mail_id,
             root,
-            TraceEvent::Sent {
-                mail_id,
-                root,
-                parent_mail,
-                sender,
-                recipient,
-                kind,
-                t: self.now_nanos(),
-            },
-        );
+            parent_mail,
+            sender,
+            recipient,
+            kind,
+            t: self.now_nanos(),
+        };
+        self.queue.push(root, event.clone());
+        self.push_trace_ring(root, event);
         if root != MailId::NONE {
             self.settlement_counter.record_sent(root);
         }


### PR DESCRIPTION
## Summary

Phase 3a of the trace decentralization (ADR-0086), tracked by iamacoffeepot/aether#1092 (full plan in the comment thread). Lands the per-actor trace **storage + query surface, dual-written** alongside the central observer — **dormant**: nothing queries the rings yet, so there is no behavior change. 3b builds the fan-out-and-stitch coordinator and flips `DescribeTree`/`DescribeWindow` onto it (cross-checked against the observer); 3c retires the central queue + drainer + observer fold.

- **`ActorTraceRing`** (`aether-actor`) — the trace-side sibling of ADR-0081's `ActorLogRing`: a bounded per-actor `VecDeque` of mail-graph events, FIFO eviction, a `truncated_before` cursor. Each entry carries its causal `root` — the producer hooks have it at push time even for `Received`/`Finished`, whose wire variants don't — so a root-filtered query resolves one tree's events without the central observer's by-mail join. Holds aren't stored: not tree nodes, and settlement left the trace stream in Phase 2.
- **`aether.trace.tail` / `TraceTailResult` / `TraceRingEntry`** (`aether-kinds`) — the per-actor query kind mirroring `aether.log.tail`: `max` + `since` cursor + optional `root` filter, answered by a framework dispatch arm on every actor (no handler authored).
- **Dual-write** at the producer hooks, routed by which actor's `ActorSlots` is stamped: `Sent` → the sender's ring (in `record_sent`, which already runs in-stamp on the sender); `Received`/`Finished` → the recipient's ring (inside the dispatch loops' `with_stamped` — both the default pooled `DispatcherSlot` path and `dispatch_loop_run`); off-actor injected `Sent` (chassis-root mail) → a locked chassis-host ring on the trace handle. **The Phase-2 emit-time settlement fire is untouched** — the ring-writes sit beside `record_finished`, not inside it.

## Cost note

The dual-write is additive on the dispatch hot path (central queue *and* ring) for the 3a/3b window. 3c removes the central queue, at which point the per-actor ring — single-writer, lock-free `Local` — replaces the contended central `SegQueue`, a net dispatch win. The added per-event work is a `VecDeque` push (~tens of ns), well below the wakeup-dominated dispatch noise floor; `Detect dispatch-path changes` will trip the perf-compare gate since dispatch files changed — the transitional overhead is expected.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` (all touched crates)
- [x] `cargo doc` with `-D rustdoc::broken_intra_doc_links`
- [x] `cargo nextest run` — 467 pass, 4 ignored; no regression in the settlement / lifecycle / trace suites
- [x] `ActorTraceRing` unit tests (push / tail / `since` cursor / `root` filter / eviction `truncated_before` / max clamp)
- [x] end-to-end `trace_ring_dual_write_routes_events_to_owning_rings`: injected `Sent` lands in the chassis-host ring; the recipient relay's `Received` + `Finished` land in its own ring (read over `aether.trace.tail`); the `root` filter excludes the trace-query mail's own events
- [x] Reviewer: confirm the dual-write seam (settlement path untouched; ring-writes at the in-stamp points)

Refs: ADR-0086 (design), ADR-0081 (per-actor rings), iamacoffeepot/aether#1092 (tracking)
