### PR TITLE
perf(substrate): guided-walk trace reconstruction (ADR-0086 phase 3b)

### DIFF
--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -58,6 +58,11 @@ pub mod test_bench;
 #[cfg(test)]
 pub(crate) mod test_chassis;
 pub mod trace;
+// ADR-0086 Phase 3b decentralized trace-tree reconstruction. Pure,
+// transport-agnostic guided walk + stitch over the per-actor trace
+// rings; the MCP and the in-process harness each supply their own
+// fetch. No `native` deps — reachable in every feature config.
+pub mod trace_walk;
 pub mod trampoline;
 pub mod window;
 

--- a/crates/aether-capabilities/src/trace.rs
+++ b/crates/aether-capabilities/src/trace.rs
@@ -18,18 +18,15 @@
 
 use aether_kinds::trace::{
     BatchedTraceEvents, DescribeTree, DescribeTreeResult, DescribeWindow, DescribeWindowResult,
-    DispatchTraced, DispatchTracedAck, ListActiveRoots, ListActiveRootsResult, MailNodeWire,
-    RootSummaryWire, TraceWindow,
+    DispatchTraced, DispatchTracedAck, MailNodeWire, TraceWindow,
 };
 
 #[aether_actor::bridge(singleton)]
 mod native {
     use super::{
         BatchedTraceEvents, DescribeTree, DescribeTreeResult, DescribeWindow, DescribeWindowResult,
-        DispatchTraced, DispatchTracedAck, ListActiveRoots, ListActiveRootsResult, MailNodeWire,
-        RootSummaryWire, TraceWindow,
+        DispatchTraced, DispatchTracedAck, MailNodeWire, TraceWindow,
     };
-    use std::cmp::Reverse;
     #[cfg(test)]
     use std::collections::HashSet;
     use std::env;
@@ -502,47 +499,6 @@ mod native {
             }
         }
 
-        /// Issue 718: pure compute path for `on_list_active_roots`.
-        /// `now` is injected so tests can drive deterministic windows
-        /// without depending on `SUBSTRATE_START` being initialised.
-        pub(crate) fn build_list_active_roots(
-            &self,
-            request: ListActiveRoots,
-            now: Nanos,
-        ) -> ListActiveRootsResult {
-            const DEFAULT_SINCE_MS: u32 = 60_000;
-            const DEFAULT_MAX: u32 = 50;
-            const HARD_MAX: u32 = 1000;
-
-            let since_ms = request.since_ms.unwrap_or(DEFAULT_SINCE_MS);
-            let max = request.max.unwrap_or(DEFAULT_MAX).min(HARD_MAX) as usize;
-            let cutoff_ns = u64::from(since_ms).saturating_mul(1_000_000);
-
-            let mut summaries: Vec<RootSummaryWire> = self
-                .roots
-                .iter()
-                .filter_map(|(root_id, root_state)| {
-                    // The root mail (mail_id == root) is live whenever the
-                    // root is; an orphan-hold root with no mail is skipped.
-                    let slot = self.slot_for(*root_id)?;
-                    if now.0.saturating_sub(slot.t_sent.0) > cutoff_ns {
-                        return None;
-                    }
-                    Some(RootSummaryWire {
-                        root: *root_id,
-                        kind: slot.kind,
-                        sender: slot.sender,
-                        recipient: slot.recipient,
-                        t_sent: slot.t_sent,
-                        in_flight: root_state.in_flight,
-                    })
-                })
-                .collect();
-            summaries.sort_by_key(|s| Reverse(s.t_sent));
-            summaries.truncate(max);
-            ListActiveRootsResult { roots: summaries }
-        }
-
         /// Issue 735: pure compute path for `on_describe_window`.
         /// `now` is injected so tests can drive deterministic windows
         /// without depending on `SUBSTRATE_START` being initialised.
@@ -702,19 +658,6 @@ mod native {
         #[handler]
         fn on_describe_tree(&mut self, ctx: &mut NativeCtx<'_>, request: DescribeTree) {
             let result = self.build_describe_tree(request.root);
-            ctx.reply(&result);
-        }
-
-        /// # Agent
-        /// Returns recent root summaries for agent root-discovery.
-        /// `since_ms` filters by the root's originating `Sent`
-        /// timestamp (default `60_000`); `max` caps the reply length
-        /// (default 50, hard cap 1000). Sorted by `t_sent` descending.
-        /// Issue 718 / ADR-0080 Phase 2.
-        #[handler]
-        fn on_list_active_roots(&mut self, ctx: &mut NativeCtx<'_>, request: ListActiveRoots) {
-            let now = ctx.mailer().now_nanos();
-            let result = self.build_list_active_roots(request, now);
             ctx.reply(&result);
         }
 
@@ -1462,69 +1405,6 @@ mod native {
                 obs.build_describe_tree(missing),
                 DescribeTreeResult::Err { not_found: missing }
             );
-        }
-
-        #[test]
-        fn list_active_roots_filters_by_window_and_sorts() {
-            let mut obs = boot_observer();
-            // Three roots at t = 100, 5_000_000_000 (5s), 10_000_000_000 (10s).
-            // Window since_ms = 6000 keeps the latter two.
-            for (cid, t) in [(1u64, 100u64), (2, 5_000_000_000), (3, 10_000_000_000)] {
-                let m = mail(1, cid);
-                apply_sent_event(
-                    &mut obs,
-                    m,
-                    m,
-                    None,
-                    MailboxId(1),
-                    MailboxId(2),
-                    KindId(0xABCD),
-                    Nanos(t),
-                );
-            }
-
-            // "Now" is 11s past boot.
-            let now = Nanos(11_000_000_000);
-            let result = obs.build_list_active_roots(
-                ListActiveRoots {
-                    since_ms: Some(6_000),
-                    max: None,
-                },
-                now,
-            );
-            assert_eq!(result.roots.len(), 2);
-            // Sorted desc by t_sent — newer first.
-            assert_eq!(result.roots[0].root, mail(1, 3));
-            assert_eq!(result.roots[1].root, mail(1, 2));
-        }
-
-        #[test]
-        fn list_active_roots_caps_to_max() {
-            let mut obs = boot_observer();
-            for cid in 1..=5 {
-                let m = mail(1, cid);
-                apply_sent_event(
-                    &mut obs,
-                    m,
-                    m,
-                    None,
-                    MailboxId(1),
-                    MailboxId(2),
-                    KindId(0xABCD),
-                    Nanos(cid * 100),
-                );
-            }
-            let result = obs.build_list_active_roots(
-                ListActiveRoots {
-                    since_ms: Some(60_000),
-                    max: Some(2),
-                },
-                Nanos(1_000),
-            );
-            assert_eq!(result.roots.len(), 2);
-            // Top 2 by t_sent desc: cid 5 (t=500), cid 4 (t=400).
-            assert_eq!(result.roots[0].root, mail(1, 5));
-            assert_eq!(result.roots[1].root, mail(1, 4));
         }
 
         #[test]

--- a/crates/aether-capabilities/src/trace_walk.rs
+++ b/crates/aether-capabilities/src/trace_walk.rs
@@ -1,0 +1,457 @@
+//! ADR-0086 Phase 3b decentralized trace-tree reconstruction. The
+//! central observer's `build_describe_tree` walks a single in-memory
+//! `mails_by_root` index; this module reconstructs the same tree by a
+//! guided fan-out across the per-actor trace rings (ADR-0086 Phase 3a),
+//! stitched client-side.
+//!
+//! The walk self-directs. It seeds at the root mail's `sender` — the
+//! chassis-host pseudo-mailbox ([`aether_data::MailboxId::CHASSIS_MAILBOX_ID`])
+//! for an injected root, an actor otherwise — to pick up the root's own
+//! `Sent`, then follows every `Sent` event's `recipient`. Each
+//! recipient's ring holds that mail's `Received` / `Finished` plus any
+//! onward `Sent`s, so the frontier expands purely from observed
+//! recipients: the walk visits exactly the actors participating in the
+//! tree and never enumerates the full actor set. (That bound is what
+//! lets a query during a barrier touch O(tree) actors rather than
+//! O(live actors) — ADR-0086 Phase 3b cost note.)
+//!
+//! Transport is the caller's: the MCP issues `aether.trace.tail` over
+//! the wire (addressing each mailbox by id, routing
+//! `CHASSIS_MAILBOX_ID` to the chassis-host ring), the in-process
+//! harness calls the per-actor ring tail / `chassis_host_tail`
+//! directly. [`TreeWalk`] owns the seed, frontier, dedup, and stitch;
+//! the caller owns only the fetch.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use aether_data::{KindId, MailId, MailboxId};
+use aether_kinds::trace::{DescribeTreeResult, MailNodeWire, Nanos, TraceEvent, TraceRingEntry};
+
+/// A guided breadth-first walk of one root's mail tree across per-actor
+/// trace rings. Construct with [`TreeWalk::new`], then drive the loop:
+/// call [`TreeWalk::next_mailbox`] for the next ring to query, fetch
+/// that mailbox's `root`-filtered tail, feed the entries to
+/// [`TreeWalk::absorb`]. When `next_mailbox` returns `None` the frontier
+/// is exhausted; [`TreeWalk::finish`] stitches the collected events into
+/// a [`DescribeTreeResult`].
+pub struct TreeWalk {
+    root: MailId,
+    visited: BTreeSet<MailboxId>,
+    frontier: VecDeque<MailboxId>,
+    collected: Vec<TraceRingEntry>,
+}
+
+impl TreeWalk {
+    /// Begin a walk for `root`, seeding the frontier with the root
+    /// mail's `sender` (where the root's own `Sent` lives).
+    #[must_use]
+    pub fn new(root: MailId) -> Self {
+        let mut frontier = VecDeque::new();
+        frontier.push_back(root.sender);
+        Self {
+            root,
+            visited: BTreeSet::new(),
+            frontier,
+            collected: Vec::new(),
+        }
+    }
+
+    /// The next mailbox whose trace ring should be queried, or `None`
+    /// when the frontier is exhausted. Skips mailboxes already visited
+    /// (a diamond in the mail graph enqueues the same recipient twice).
+    pub fn next_mailbox(&mut self) -> Option<MailboxId> {
+        while let Some(mbx) = self.frontier.pop_front() {
+            if self.visited.insert(mbx) {
+                return Some(mbx);
+            }
+        }
+        None
+    }
+
+    /// Feed the entries returned for the mailbox handed out by the most
+    /// recent [`Self::next_mailbox`]. Entries for other roots are
+    /// ignored (a `root`-filtered tail keeps the fetch cheap, but the
+    /// guard is belt-and-braces). Each in-tree `Sent` enqueues its
+    /// recipient onto the frontier.
+    pub fn absorb(&mut self, entries: impl IntoIterator<Item = TraceRingEntry>) {
+        for entry in entries {
+            if entry.root != self.root {
+                continue;
+            }
+            if let TraceEvent::Sent { recipient, .. } = entry.event
+                && !self.visited.contains(&recipient)
+            {
+                self.frontier.push_back(recipient);
+            }
+            self.collected.push(entry);
+        }
+    }
+
+    /// Stitch the collected events into a [`DescribeTreeResult`].
+    #[must_use]
+    pub fn finish(self) -> DescribeTreeResult {
+        stitch(self.root, self.collected)
+    }
+}
+
+/// Fold a flat set of [`TraceRingEntry`]s — gathered from however many
+/// per-actor rings a walk visited — into one [`MailNodeWire`] per
+/// `mail_id`. `Sent` seeds the node's topology fields and `t_sent`;
+/// `Received` adds `t_received` + `thread_name`; `Finished` adds
+/// `t_finished`. Holds (`HoldOpen` / `Release`) carry no `mail_id` and
+/// are skipped — they aren't tree nodes (ADR-0086 Phase 3 §C). The fold
+/// is order-independent, so a node first seen via `Received` (its `Sent`
+/// in a ring absorbed later) resolves once the `Sent` lands.
+///
+/// Returns `Err { not_found }` when the root produced no `Sent` — the
+/// tree never existed or its seed ring evicted it — matching the
+/// central observer's contract. `in_flight` counts nodes with a `Sent`
+/// but no `Finished`; the only caller today walks post-settlement, so
+/// it sees `0`.
+#[must_use]
+pub fn stitch(
+    root: MailId,
+    entries: impl IntoIterator<Item = TraceRingEntry>,
+) -> DescribeTreeResult {
+    let mut nodes: BTreeMap<MailId, PartialNode> = BTreeMap::new();
+    for entry in entries {
+        match entry.event {
+            TraceEvent::Sent {
+                mail_id,
+                parent_mail,
+                sender,
+                recipient,
+                kind,
+                t,
+                ..
+            } => {
+                nodes.entry(mail_id).or_default().sent = Some(SentFields {
+                    parent: parent_mail,
+                    sender,
+                    recipient,
+                    kind,
+                    t_sent: t,
+                });
+            }
+            TraceEvent::Received {
+                mail_id,
+                t,
+                thread_name,
+            } => {
+                let node = nodes.entry(mail_id).or_default();
+                node.t_received = Some(t);
+                node.thread_name = thread_name;
+            }
+            TraceEvent::Finished { mail_id, t } => {
+                nodes.entry(mail_id).or_default().t_finished = Some(t);
+            }
+            TraceEvent::HoldOpen { .. } | TraceEvent::Release { .. } => {}
+        }
+    }
+
+    if nodes.get(&root).is_none_or(|n| n.sent.is_none()) {
+        return DescribeTreeResult::Err { not_found: root };
+    }
+
+    let mut in_flight: u32 = 0;
+    let mails: Vec<MailNodeWire> = nodes
+        .into_iter()
+        .filter_map(|(mail_id, node)| {
+            let sent = node.sent?;
+            if node.t_finished.is_none() {
+                in_flight = in_flight.saturating_add(1);
+            }
+            Some(MailNodeWire {
+                mail_id,
+                parent: sent.parent,
+                sender: sent.sender,
+                recipient: sent.recipient,
+                kind: sent.kind,
+                t_sent: sent.t_sent,
+                t_received: node.t_received,
+                t_finished: node.t_finished,
+                thread_name: node.thread_name,
+            })
+        })
+        .collect();
+
+    DescribeTreeResult::Ok {
+        root,
+        in_flight,
+        mails,
+    }
+}
+
+#[derive(Default)]
+struct PartialNode {
+    sent: Option<SentFields>,
+    t_received: Option<Nanos>,
+    t_finished: Option<Nanos>,
+    thread_name: Option<String>,
+}
+
+struct SentFields {
+    parent: Option<MailId>,
+    sender: MailboxId,
+    recipient: MailboxId,
+    kind: KindId,
+    t_sent: Nanos,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mid(sender: u64, cid: u64) -> MailId {
+        MailId {
+            sender: MailboxId(sender),
+            correlation_id: cid,
+        }
+    }
+
+    fn sent(mail_id: MailId, root: MailId, recipient: u64) -> TraceRingEntry {
+        sent_parent(mail_id, root, None, recipient)
+    }
+
+    fn sent_parent(
+        mail_id: MailId,
+        root: MailId,
+        parent: Option<MailId>,
+        recipient: u64,
+    ) -> TraceRingEntry {
+        TraceRingEntry {
+            sequence: 0,
+            root,
+            event: TraceEvent::Sent {
+                mail_id,
+                root,
+                parent_mail: parent,
+                sender: mail_id.sender,
+                recipient: MailboxId(recipient),
+                kind: KindId(0xAB),
+                t: Nanos(mail_id.correlation_id),
+            },
+        }
+    }
+
+    fn received(mail_id: MailId, root: MailId) -> TraceRingEntry {
+        TraceRingEntry {
+            sequence: 0,
+            root,
+            event: TraceEvent::Received {
+                mail_id,
+                t: Nanos(mail_id.correlation_id + 1),
+                thread_name: Some("aether-worker-0".into()),
+            },
+        }
+    }
+
+    fn finished(mail_id: MailId, root: MailId) -> TraceRingEntry {
+        TraceRingEntry {
+            sequence: 0,
+            root,
+            event: TraceEvent::Finished {
+                mail_id,
+                t: Nanos(mail_id.correlation_id + 2),
+            },
+        }
+    }
+
+    fn ok(result: DescribeTreeResult) -> (MailId, u32, Vec<MailNodeWire>) {
+        match result {
+            DescribeTreeResult::Ok {
+                root,
+                in_flight,
+                mails,
+            } => (root, in_flight, mails),
+            DescribeTreeResult::Err { not_found } => panic!("expected Ok, got Err {not_found:?}"),
+        }
+    }
+
+    /// Stitch is order-independent: feeding `Finished` before its
+    /// `Sent` still produces one complete node.
+    #[test]
+    fn stitch_folds_events_per_mail_id_regardless_of_order() {
+        let root = mid(1, 1);
+        let entries = vec![
+            finished(root, root),
+            received(root, root),
+            sent(root, root, 2),
+        ];
+        let (got_root, in_flight, mails) = ok(stitch(root, entries));
+        assert_eq!(got_root, root);
+        assert_eq!(in_flight, 0, "node has a Finished");
+        assert_eq!(mails.len(), 1);
+        let node = &mails[0];
+        assert_eq!(node.mail_id, root);
+        assert_eq!(node.recipient, MailboxId(2));
+        assert_eq!(node.t_sent, Nanos(1));
+        assert_eq!(node.t_received, Some(Nanos(2)));
+        assert_eq!(node.t_finished, Some(Nanos(3)));
+        assert_eq!(node.thread_name.as_deref(), Some("aether-worker-0"));
+    }
+
+    /// A root that produced no `Sent` (never seen / seed ring evicted)
+    /// reports `Err { not_found }`, matching the observer.
+    #[test]
+    fn stitch_missing_root_sent_is_not_found() {
+        let root = mid(1, 1);
+        // Only Received/Finished for the root, no Sent.
+        let entries = vec![received(root, root), finished(root, root)];
+        match stitch(root, entries) {
+            DescribeTreeResult::Err { not_found } => assert_eq!(not_found, root),
+            ok @ DescribeTreeResult::Ok { .. } => panic!("expected Err, got {ok:?}"),
+        }
+    }
+
+    /// A node still in flight (Sent, no Finished) is counted.
+    #[test]
+    fn stitch_counts_unfinished_nodes_as_in_flight() {
+        let root = mid(1, 1);
+        let child = mid(2, 1);
+        let entries = vec![
+            sent(root, root, 2),
+            received(root, root),
+            finished(root, root),
+            sent_parent(child, root, Some(root), 3), // child sent, never finished
+        ];
+        let (_, in_flight, mails) = ok(stitch(root, entries));
+        assert_eq!(mails.len(), 2);
+        assert_eq!(in_flight, 1, "the child has no Finished");
+    }
+
+    /// End-to-end guided walk over a fake multi-ring substrate. The
+    /// topology mirrors a `send_mail_traced` tree: an injected root
+    /// (chassis -> observer) whose handler re-sends to two recipients,
+    /// one of which forwards once more. Each `Sent` lands in the
+    /// sender's ring, each `Received`/`Finished` in the recipient's.
+    #[test]
+    fn guided_walk_reconstructs_tree_across_rings() {
+        // Mailbox ids: 0 = chassis-host, 10 = observer, 20/21 = leaves,
+        // 30 = a grandchild reached only by following 20's onward send.
+        let chassis = 0u64;
+        let observer = 10u64;
+        let leaf_a = 20u64;
+        let leaf_b = 21u64;
+        let grandchild = 30u64;
+
+        let root = MailId {
+            sender: MailboxId(chassis),
+            correlation_id: 1,
+        };
+        let child_a = mid(observer, 2);
+        let child_b = mid(observer, 3);
+        let gc = mid(leaf_a, 4);
+
+        // Per-mailbox rings. Sent in the sender's ring; Received +
+        // Finished in the recipient's ring.
+        let mut rings: BTreeMap<MailboxId, Vec<TraceRingEntry>> = BTreeMap::new();
+        // chassis-host: the root's Sent (chassis -> observer).
+        rings
+            .entry(MailboxId(chassis))
+            .or_default()
+            .push(sent(root, root, observer));
+        // observer: root's Received/Finished + the two children's Sents.
+        rings.entry(MailboxId(observer)).or_default().extend([
+            received(root, root),
+            finished(root, root),
+            sent_parent(child_a, root, Some(root), leaf_a),
+            sent_parent(child_b, root, Some(root), leaf_b),
+        ]);
+        // leaf_a: child_a's Received/Finished + an onward Sent to gc.
+        rings.entry(MailboxId(leaf_a)).or_default().extend([
+            received(child_a, root),
+            finished(child_a, root),
+            sent_parent(gc, root, Some(child_a), grandchild),
+        ]);
+        // leaf_b: child_b's Received/Finished, no onward send.
+        rings
+            .entry(MailboxId(leaf_b))
+            .or_default()
+            .extend([received(child_b, root), finished(child_b, root)]);
+        // grandchild: gc's Received/Finished.
+        rings
+            .entry(MailboxId(grandchild))
+            .or_default()
+            .extend([received(gc, root), finished(gc, root)]);
+
+        // Drive the walk against the fake substrate.
+        let mut walk = TreeWalk::new(root);
+        let mut visited_order = Vec::new();
+        while let Some(mbx) = walk.next_mailbox() {
+            visited_order.push(mbx);
+            let entries = rings.get(&mbx).cloned().unwrap_or_default();
+            walk.absorb(entries);
+        }
+        let (got_root, in_flight, mails) = ok(walk.finish());
+
+        assert_eq!(got_root, root);
+        assert_eq!(in_flight, 0, "fully settled tree");
+        // Four mails: root + two children + one grandchild.
+        assert_eq!(mails.len(), 4, "root, child_a, child_b, grandchild");
+
+        let by_id: BTreeMap<MailId, &MailNodeWire> = mails.iter().map(|n| (n.mail_id, n)).collect();
+        assert_eq!(by_id[&root].parent, None);
+        assert_eq!(by_id[&child_a].parent, Some(root));
+        assert_eq!(by_id[&child_b].parent, Some(root));
+        assert_eq!(by_id[&gc].parent, Some(child_a));
+        // Every node carries Received + Finished — the walk visited
+        // every recipient ring.
+        assert!(
+            mails
+                .iter()
+                .all(|n| n.t_received.is_some() && n.t_finished.is_some())
+        );
+
+        // The walk visited only the five participating mailboxes, never
+        // an actor outside the tree.
+        assert_eq!(visited_order.len(), 5);
+        let visited: BTreeSet<MailboxId> = visited_order.into_iter().collect();
+        assert_eq!(
+            visited,
+            [chassis, observer, leaf_a, leaf_b, grandchild]
+                .into_iter()
+                .map(MailboxId)
+                .collect()
+        );
+    }
+
+    /// A diamond (two parents send to the same recipient) visits the
+    /// shared recipient's ring exactly once.
+    #[test]
+    fn guided_walk_dedups_diamond_recipient() {
+        let root = mid(0, 1);
+        let child_a = mid(10, 2);
+        let child_b = mid(10, 3);
+        let shared = 40u64;
+
+        let mut rings: BTreeMap<MailboxId, Vec<TraceRingEntry>> = BTreeMap::new();
+        rings
+            .entry(MailboxId(0))
+            .or_default()
+            .push(sent(root, root, 10));
+        rings.entry(MailboxId(10)).or_default().extend([
+            received(root, root),
+            finished(root, root),
+            sent_parent(child_a, root, Some(root), shared),
+            sent_parent(child_b, root, Some(root), shared),
+        ]);
+        // The shared recipient receives both children.
+        rings.entry(MailboxId(shared)).or_default().extend([
+            received(child_a, root),
+            finished(child_a, root),
+            received(child_b, root),
+            finished(child_b, root),
+        ]);
+
+        let mut walk = TreeWalk::new(root);
+        let mut visits = 0;
+        while let Some(mbx) = walk.next_mailbox() {
+            visits += 1;
+            walk.absorb(rings.get(&mbx).cloned().unwrap_or_default());
+        }
+        let (_, _, mails) = ok(walk.finish());
+        assert_eq!(visits, 3, "chassis, observer, shared — shared once");
+        assert_eq!(mails.len(), 3, "root + two children");
+    }
+}

--- a/crates/aether-capabilities/src/trace_walk.rs
+++ b/crates/aether-capabilities/src/trace_walk.rs
@@ -113,6 +113,28 @@ pub fn stitch(
     root: MailId,
     entries: impl IntoIterator<Item = TraceRingEntry>,
 ) -> DescribeTreeResult {
+    let mails = fold_nodes(entries);
+    if !mails.iter().any(|n| n.mail_id == root) {
+        return DescribeTreeResult::Err { not_found: root };
+    }
+    let in_flight =
+        u32::try_from(mails.iter().filter(|n| n.t_finished.is_none()).count()).unwrap_or(u32::MAX);
+    DescribeTreeResult::Ok {
+        root,
+        in_flight,
+        mails,
+    }
+}
+
+/// The order-independent fold under [`stitch`], without the root /
+/// `in_flight` framing: collapse a flat event stream into one
+/// [`MailNodeWire`] per `mail_id`. A node with no `Sent` (its sender's
+/// ring never visited, or evicted) is dropped — `MailNodeWire` requires
+/// the topology fields a `Sent` carries. Exposed for callers that
+/// aggregate across many roots' rings at once (the latency harness folds
+/// every relay's ring this way) rather than reconstructing one tree.
+#[must_use]
+pub fn fold_nodes(entries: impl IntoIterator<Item = TraceRingEntry>) -> Vec<MailNodeWire> {
     let mut nodes: BTreeMap<MailId, PartialNode> = BTreeMap::new();
     for entry in entries {
         match entry.event {
@@ -149,18 +171,10 @@ pub fn stitch(
         }
     }
 
-    if nodes.get(&root).is_none_or(|n| n.sent.is_none()) {
-        return DescribeTreeResult::Err { not_found: root };
-    }
-
-    let mut in_flight: u32 = 0;
-    let mails: Vec<MailNodeWire> = nodes
+    nodes
         .into_iter()
         .filter_map(|(mail_id, node)| {
             let sent = node.sent?;
-            if node.t_finished.is_none() {
-                in_flight = in_flight.saturating_add(1);
-            }
             Some(MailNodeWire {
                 mail_id,
                 parent: sent.parent,
@@ -173,13 +187,7 @@ pub fn stitch(
                 thread_name: node.thread_name,
             })
         })
-        .collect();
-
-    DescribeTreeResult::Ok {
-        root,
-        in_flight,
-        mails,
-    }
+        .collect()
 }
 
 #[derive(Default)]

--- a/crates/aether-kinds/src/trace.rs
+++ b/crates/aether-kinds/src/trace.rs
@@ -203,61 +203,6 @@ pub struct MailNodeWire {
     pub thread_name: Option<String>,
 }
 
-/// Issue 718: request kind for the recent-roots summary. `since_ms`
-/// filters to roots whose originating `Sent` event is no older than
-/// the given window (default `60_000` ms). `max` caps the reply length
-/// (default 50, hard cap 1000).
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    Default,
-    PartialEq,
-    Eq,
-    Serialize,
-    Deserialize,
-    aether_data::Kind,
-    aether_data::Schema,
-)]
-#[kind(name = "aether.trace.list_active_roots")]
-pub struct ListActiveRoots {
-    pub since_ms: Option<u32>,
-    pub max: Option<u32>,
-}
-
-/// Issue 718: reply to [`ListActiveRoots`]. `roots` is sorted by
-/// `t_sent` descending (most recent first). Empty when the observer
-/// has no roots in the requested window.
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    PartialEq,
-    Eq,
-    Serialize,
-    Deserialize,
-    aether_data::Kind,
-    aether_data::Schema,
-)]
-#[kind(name = "aether.trace.list_active_roots_result")]
-pub struct ListActiveRootsResult {
-    pub roots: Vec<RootSummaryWire>,
-}
-
-/// Issue 718: per-root summary in [`ListActiveRootsResult`]. The
-/// non-counter fields (`kind`, `sender`, `recipient`, `t_sent`) come
-/// from the root's own `MailNode` — the observer guarantees the root
-/// node lives as long as the root entry, so the lookup never misses.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Schema)]
-pub struct RootSummaryWire {
-    pub root: MailId,
-    pub kind: KindId,
-    pub sender: MailboxId,
-    pub recipient: MailboxId,
-    pub t_sent: Nanos,
-    pub in_flight: u32,
-}
-
 /// Issue 735: window selector for the time-window trace queries
 /// ([`DescribeWindow`] today; `dump_trace_window` Phase 3 reuses the
 /// same enum). The substrate resolves [`TraceWindow::Relative`] using

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use aether_capabilities::rpc::{MailEnvelope, MailboxAddress};
+use aether_capabilities::trace_walk::TreeWalk;
 use aether_data::MailId;
 use aether_data::canonical::kind_id_from_parts;
 use aether_data::{
@@ -29,8 +30,8 @@ use aether_kinds::{
     ReplaceComponent, ReplaceResult, SpawnEngine, SpawnEngineResult, Status, StatusResult, Submit,
     SubmitResult, TerminateEngine, TerminateEngineResult,
     trace::{
-        DescribeTree, DescribeTreeResult, DispatchTraced, DispatchTracedAck, MailNodeWire,
-        TRACE_OBSERVER_MAILBOX_NAME,
+        DescribeTreeResult, DispatchTraced, DispatchTracedAck, MailNodeWire,
+        TRACE_OBSERVER_MAILBOX_NAME, TraceTail, TraceTailResult,
     },
 };
 use base64::Engine as _;
@@ -255,21 +256,37 @@ impl Mcp {
             }
         };
 
-        // Round 2: pull the populated tree. Microseconds — already
-        // in-memory in the substrate's TraceObserver at this point.
-        let tree_reply = self
-            .session
-            .call_one(engine_envelope(
-                engine,
-                TRACE_OBSERVER_MAILBOX_NAME,
-                &DescribeTree { root },
-            ))
-            .await
-            .map_err(internal)?;
-        let tree = DescribeTreeResult::decode_from_bytes(&tree_reply.payload)
-            .ok_or_else(|| internal_msg("undecodable DescribeTreeResult"))?;
+        // Round 2: reconstruct the tree by a guided walk over the
+        // per-actor trace rings (ADR-0086 Phase 3b). Seed at
+        // `root.sender` (`CHASSIS_MAILBOX_ID` for this chassis-rooted
+        // dispatch), follow each `Sent`'s recipient, fetch every ring
+        // with one `aether.trace.tail` addressed by id — the chassis-
+        // host ring answers at `CHASSIS_MAILBOX_ID`. The walk touches
+        // only the actors in the tree; the rings are in-memory and the
+        // chain has already settled, so each hop is microseconds. A
+        // failed or undecodable per-ring reply contributes no entries —
+        // the walk completes from the rings that answer.
+        let mut walk = TreeWalk::new(root);
+        while let Some(mailbox) = walk.next_mailbox() {
+            let request = TraceTail {
+                max: 0,
+                since: None,
+                root: Some(root),
+            };
+            let entries = match self
+                .session
+                .call_one(engine_envelope_by_id(engine, mailbox, &request))
+                .await
+                .ok()
+                .and_then(|reply| TraceTailResult::decode_from_bytes(&reply.payload))
+            {
+                Some(TraceTailResult::Ok { entries, .. }) => entries,
+                Some(TraceTailResult::Err { .. }) | None => Vec::new(),
+            };
+            walk.absorb(entries);
+        }
 
-        match tree {
+        match walk.finish() {
             DescribeTreeResult::Ok {
                 root,
                 in_flight,
@@ -770,10 +787,23 @@ fn engine_envelope<K: Kind + serde::Serialize>(
     mailbox: &str,
     kind: &K,
 ) -> MailEnvelope {
+    engine_envelope_by_id(engine, mailbox_id_from_name(mailbox), kind)
+}
+
+/// Like [`engine_envelope`] but addresses the recipient by
+/// [`MailboxId`] directly. The trace-tree guided walk (ADR-0086 Phase
+/// 3b) discovers recipients as ids embedded in `Sent` events, never as
+/// names — a `MailboxId` is a one-way name hash, so there's no name to
+/// reconstruct.
+fn engine_envelope_by_id<K: Kind + serde::Serialize>(
+    engine: EngineId,
+    mailbox: MailboxId,
+    kind: &K,
+) -> MailEnvelope {
     MailEnvelope {
         to: MailboxAddress {
             engine: Some(engine),
-            mailbox: mailbox_id_from_name(mailbox),
+            mailbox,
         },
         from: None,
         kind: K::ID,

--- a/crates/aether-substrate-bundle/src/perf/harness.rs
+++ b/crates/aether-substrate-bundle/src/perf/harness.rs
@@ -22,10 +22,9 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
+use aether_capabilities::trace_walk::fold_nodes;
 use aether_data::{Kind, KindId, MailboxId, mailbox_id_from_name};
-use aether_kinds::trace::{
-    DescribeWindow, DescribeWindowResult, TRACE_OBSERVER_MAILBOX_NAME, TraceWindow,
-};
+use aether_kinds::trace::{TraceRingEntry, TraceTail, TraceTailResult};
 use aether_kinds::{SubscribeInput, SubscribeInputResult, Tick};
 use aether_substrate::{BootError, NativeActor, NativeCtx, NativeDispatch, NativeInitCtx, Subname};
 
@@ -407,25 +406,19 @@ pub fn wide_fanout_widths_from_env() -> Vec<usize> {
     out
 }
 
-/// Per-cell cap on harvested trace nodes. The `DescribeWindow` query
-/// refuses windows larger than this (replying `too_many`), and a frame
-/// produces roughly one trace node per relay delivery — so a wide
-/// fan-out at the full frame count would overflow. Kept under the 100k
-/// query cap to leave margin for the per-frame tick/setup nodes the
-/// window also holds (iamacoffeepot/aether#1075).
-const MAX_NODES_PER_CELL: u32 = 90_000;
-
 /// Drive the sweep and return per-cell percentiles. Each cell boots a
-/// fresh [`TestBench`], wires the topology + tick source, advances, and
-/// harvests the trace ring once. A cell whose bench fails to boot (no
-/// wgpu adapter) or whose harvest overflows is logged via `tracing` and
-/// skipped — so a driverless box returns fewer cells (possibly empty)
-/// rather than panicking.
+/// fresh [`TestBench`], wires the topology + tick source, advances, then
+/// harvests every participating actor's per-actor trace ring (ADR-0086
+/// Phase 3) directly by name and folds them into one node set. A cell
+/// whose bench fails to boot (no wgpu adapter) or whose ring harvest
+/// errors is logged via `tracing` and skipped — so a driverless box
+/// returns fewer cells (possibly empty) rather than panicking.
 ///
-/// The per-cell frame count is clamped so wide fan-outs stay under
-/// `MAX_NODES_PER_CELL`; this is a no-op for the narrow default
-/// topologies (their full frame count is well under the cap), so their
-/// numbers are unchanged.
+/// The full frame count runs unclamped: the per-actor rings self-bound
+/// at their capacity and self-report truncation, so a long wide fan-out
+/// laps a busy relay's ring and the cell's stats come from the
+/// most-recent window (valid percentiles, fewer samples) with a logged
+/// note, instead of being capped up front.
 #[allow(clippy::cast_precision_loss, clippy::too_many_lines)]
 #[must_use]
 pub fn run_sweep(cfg: &SweepConfig) -> Vec<CellResult> {
@@ -497,19 +490,13 @@ pub fn run_sweep(cfg: &SweepConfig) -> Vec<CellResult> {
                 }
             }
 
-            // Clamp the per-cell frame count so a wide fan-out stays
-            // under the trace-window node cap. Each frame produces ~one
-            // `Ping` node per relay delivery (every downstream forward
-            // plus the tick source's send into the entry); `+ 8` leaves
-            // slack for the per-frame tick/setup nodes. A no-op for the
-            // narrow default topologies (iamacoffeepot/aether#1075).
-            let deliveries_per_frame = 1 + topo.downstreams.iter().map(Vec::len).sum::<usize>();
-            let frame_cap =
-                MAX_NODES_PER_CELL / u32::try_from(deliveries_per_frame + 8).unwrap_or(u32::MAX);
-            let frames = cfg.frames.min(frame_cap.max(1));
+            // Per-actor rings (ADR-0086 Phase 3) self-bound at their
+            // capacity, so there's no central node cap to clamp against —
+            // run the full frame count. A busy relay's ring laps under a
+            // long wide fan-out and self-reports it (handled at harvest).
+            let frames = cfg.frames;
 
             // Drive via the real lifecycle.
-            let t0 = Instant::now();
             match cfg.pace_hz {
                 Some(hz) => {
                     let period = Duration::from_secs_f64(1.0 / hz as f64);
@@ -525,43 +512,72 @@ pub fn run_sweep(cfg: &SweepConfig) -> Vec<CellResult> {
                     let _ = tb.advance(frames);
                 }
             }
-            let drive_ms = u64::try_from(t0.elapsed().as_millis()).unwrap_or(u64::MAX);
 
-            // Harvest the resident ring once, after the run. The
-            // `Ping`-kind filter isolates relay hops, so setup / Tick /
-            // query mail never counts.
-            let req = DescribeWindow {
-                window: TraceWindow::Relative {
-                    last_ms: drive_ms.saturating_add(1_000),
-                },
-                max_mails: Some(100_000),
-            }
-            .encode_into_bytes();
-            let mails = match tb.send_bytes_and_await(
-                TRACE_OBSERVER_MAILBOX_NAME,
-                DescribeWindow::ID,
-                req,
-            ) {
-                Ok(reply) => match DescribeWindowResult::decode_from_bytes(&reply) {
-                    Some(DescribeWindowResult::Ok { mails }) => mails,
-                    Some(DescribeWindowResult::Err { too_many }) => {
-                        tracing::warn!(
-                            target: "aether_perf",
-                            topo = %topo.name, workers, ?too_many,
-                            "describe_window over cap — lower frames or raise AETHER_TRACE_RING_CAPACITY",
-                        );
-                        continue;
-                    }
-                    None => {
-                        tracing::warn!(target: "aether_perf", topo = %topo.name, "describe_window decode failed");
-                        continue;
-                    }
-                },
-                Err(e) => {
-                    tracing::warn!(target: "aether_perf", topo = %topo.name, error = ?e, "describe_window send failed");
-                    continue;
+            // Harvest each participating actor's trace ring directly
+            // (ADR-0086 Phase 3, decentralized trace): we built the
+            // topology, so we know the tick source + relays by name — no
+            // central window query, no root enumeration. Fold every ring
+            // into one node set; the `Ping`-kind filter below isolates
+            // relay hops (the per-actor `aether.trace.tail` query mail
+            // carries a different kind and is dropped). Rings self-report
+            // truncation: a relay ring (cap 4096) laps under a long wide
+            // fan-out, leaving stats from the most-recent window — valid
+            // percentiles, fewer samples.
+            let mut names: Vec<String> = Vec::with_capacity(n + 1);
+            names.push(format!("{TICKSRC_NS}:src"));
+            names.extend((0..n).map(|i| format!("{RELAY_NS}:{i}")));
+
+            let mut entries: Vec<TraceRingEntry> = Vec::new();
+            let mut truncated = false;
+            let mut harvest_failed = false;
+            for name in &names {
+                // `max: u32::MAX` clamps to the ring capacity — pull the
+                // whole ring, `root: None` across every tree in the run.
+                let req = TraceTail {
+                    max: u32::MAX,
+                    since: None,
+                    root: None,
                 }
-            };
+                .encode_into_bytes();
+                match tb.send_bytes_and_await(name, TraceTail::ID, req) {
+                    Ok(reply) => match TraceTailResult::decode_from_bytes(&reply) {
+                        Some(TraceTailResult::Ok {
+                            entries: ring,
+                            truncated_before,
+                            ..
+                        }) => {
+                            truncated |= truncated_before.is_some();
+                            entries.extend(ring);
+                        }
+                        Some(TraceTailResult::Err { error }) => {
+                            tracing::warn!(target: "aether_perf", topo = %topo.name, %name, %error, "trace.tail error");
+                            harvest_failed = true;
+                            break;
+                        }
+                        None => {
+                            tracing::warn!(target: "aether_perf", topo = %topo.name, %name, "trace.tail decode failed");
+                            harvest_failed = true;
+                            break;
+                        }
+                    },
+                    Err(e) => {
+                        tracing::warn!(target: "aether_perf", topo = %topo.name, %name, error = ?e, "trace.tail send failed");
+                        harvest_failed = true;
+                        break;
+                    }
+                }
+            }
+            if harvest_failed {
+                continue;
+            }
+            if truncated {
+                tracing::warn!(
+                    target: "aether_perf",
+                    topo = %topo.name, workers,
+                    "a relay ring lapped during the run — stats are from the most-recent window",
+                );
+            }
+            let mails = fold_nodes(entries);
 
             let mut hop = Vec::new();
             let mut handler = Vec::new();

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -553,10 +553,13 @@ impl TestBench {
     /// decentralized guided walk over per-actor rings — the in-process
     /// counterpart to the central observer's `DescribeTree`, and the
     /// model the MCP mirrors over the wire. Seeds at `root.sender`
-    /// (the chassis-host ring for an injected root, an actor
-    /// otherwise), then fans out across each `Sent`'s recipient. The
-    /// `root` filter on every tail isolates the tree from the
-    /// trace-query traffic itself.
+    /// (`CHASSIS_MAILBOX_ID` for an injected root, an actor otherwise),
+    /// then fans out across each `Sent`'s recipient. Every ring —
+    /// including the chassis-host ring, reached by the ADR-0086 Phase 3b
+    /// wire route at `CHASSIS_MAILBOX_ID` — answers the same
+    /// `aether.trace.tail` mail, so this drives the identical path the
+    /// MCP does. The `root` filter on every tail isolates the tree from
+    /// the trace-query traffic itself.
     #[cfg(test)]
     pub(crate) fn describe_tree_walked(&mut self, root: MailId) -> DescribeTreeResult {
         let mut walk = TreeWalk::new(root);
@@ -566,21 +569,18 @@ impl TestBench {
                 since: None,
                 root: Some(root),
             };
-            let result = if mailbox == MailboxId::CHASSIS_MAILBOX_ID {
-                self.chassis_host_trace_tail(&request)
-            } else {
-                // A send error (no live actor at this id) or an
-                // undecodable reply yields no entries; the walk still
-                // completes from the rings that do answer.
-                self.send_bytes_and_await_id(mailbox, TraceTail::ID, request.encode_into_bytes())
-                    .ok()
-                    .and_then(|reply| TraceTailResult::decode_from_bytes(&reply))
-                    .unwrap_or(TraceTailResult::Ok {
-                        entries: Vec::new(),
-                        next_since: 0,
-                        truncated_before: None,
-                    })
-            };
+            // A send error (no live actor at this id) or an undecodable
+            // reply yields no entries; the walk still completes from the
+            // rings that do answer.
+            let result = self
+                .send_bytes_and_await_id(mailbox, TraceTail::ID, request.encode_into_bytes())
+                .ok()
+                .and_then(|reply| TraceTailResult::decode_from_bytes(&reply))
+                .unwrap_or(TraceTailResult::Ok {
+                    entries: Vec::new(),
+                    next_since: 0,
+                    truncated_before: None,
+                });
             if let TraceTailResult::Ok { entries, .. } = result {
                 walk.absorb(entries);
             }

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -30,11 +30,13 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
+#[cfg(test)]
+use aether_capabilities::trace_walk::TreeWalk;
 use aether_data::{Kind, KindId, SessionToken, Uuid, encode_empty, encode_struct};
 #[cfg(test)]
 use aether_kinds::Tick;
 #[cfg(test)]
-use aether_kinds::trace::{TraceTail, TraceTailResult};
+use aether_kinds::trace::{DescribeTreeResult, TraceTail, TraceTailResult};
 use aether_kinds::{Advance, AdvanceResult, CaptureFrame, CaptureFrameResult};
 // `encode_struct` is used for control kinds (postcard-shape); cast-
 // shape kinds (e.g. FrameStats) flow through `frame_loop` helpers.
@@ -527,6 +529,63 @@ impl TestBench {
     #[cfg(test)]
     pub(crate) fn chassis_host_trace_tail(&self, request: &TraceTail) -> TraceTailResult {
         self.queue.trace_handle().chassis_host_tail(request)
+    }
+
+    /// Like [`Self::send_bytes_and_await`] but addresses the recipient
+    /// by [`MailboxId`] directly. The trace-tree guided walk (ADR-0086
+    /// Phase 3b) discovers recipients as ids from `Sent` events, never
+    /// as names — there's no name to resolve back from a hash.
+    #[cfg(test)]
+    pub(crate) fn send_bytes_and_await_id(
+        &mut self,
+        mailbox: MailboxId,
+        kind: KindId,
+        payload: Vec<u8>,
+    ) -> Result<Vec<u8>, TestBenchError> {
+        let cid = self.fresh_correlation_id();
+        let reply_to = ReplyTo::with_correlation(ReplyTarget::Session(self.session), cid);
+        self.queue
+            .push(Mail::new(mailbox, kind, payload, 1).with_reply_to(reply_to));
+        self.pump_until_reply_bytes(cid, "<await-reply bytes>")
+    }
+
+    /// ADR-0086 Phase 3b: reconstruct `root`'s trace tree via the
+    /// decentralized guided walk over per-actor rings — the in-process
+    /// counterpart to the central observer's `DescribeTree`, and the
+    /// model the MCP mirrors over the wire. Seeds at `root.sender`
+    /// (the chassis-host ring for an injected root, an actor
+    /// otherwise), then fans out across each `Sent`'s recipient. The
+    /// `root` filter on every tail isolates the tree from the
+    /// trace-query traffic itself.
+    #[cfg(test)]
+    pub(crate) fn describe_tree_walked(&mut self, root: MailId) -> DescribeTreeResult {
+        let mut walk = TreeWalk::new(root);
+        while let Some(mailbox) = walk.next_mailbox() {
+            let request = TraceTail {
+                max: 0,
+                since: None,
+                root: Some(root),
+            };
+            let result = if mailbox == MailboxId::CHASSIS_MAILBOX_ID {
+                self.chassis_host_trace_tail(&request)
+            } else {
+                // A send error (no live actor at this id) or an
+                // undecodable reply yields no entries; the walk still
+                // completes from the rings that do answer.
+                self.send_bytes_and_await_id(mailbox, TraceTail::ID, request.encode_into_bytes())
+                    .ok()
+                    .and_then(|reply| TraceTailResult::decode_from_bytes(&reply))
+                    .unwrap_or(TraceTailResult::Ok {
+                        entries: Vec::new(),
+                        next_since: 0,
+                        truncated_before: None,
+                    })
+            };
+            if let TraceTailResult::Ok { entries, .. } = result {
+                walk.absorb(entries);
+            }
+        }
+        walk.finish()
     }
 
     /// Bytes-level request/reply: push `(kind, payload)` to

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -17,7 +17,7 @@
 //! Release matters: the numbers are dominated by enqueue + worker wake,
 //! which a debug build inflates several-fold.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::sync::Arc;
 use std::thread::{self, available_parallelism};
@@ -459,6 +459,194 @@ fn trace_ring_dual_write_routes_events_to_owning_rings() {
             .any(|e| matches!(e.event, TraceEvent::Sent { .. }) && e.root == root),
         "chassis-host ring missing the injected Sent; got {host:?}"
     );
+}
+
+/// ADR-0086 Phase 3b: the decentralized guided walk reconstructs the
+/// exact same tree as the central observer. Drive a branching topology
+/// (the diamond `two_level_tree`, where relay 4 has two parents),
+/// settle one injected root, then describe it both ways — the
+/// observer's `DescribeTree` over its central `mails_by_root` index,
+/// and the guided fan-out across per-actor rings — and assert the node
+/// sets match structurally: same mail-ids, same parent/sender/recipient/
+/// kind/`thread_name` per node, same `t_received`/`t_finished` presence.
+/// On convergence both trees are also checked for causal coherence (see
+/// [`assert_causal_order`]).
+///
+/// Exact timestamps are *not* compared. `record_sent` writes one
+/// `TraceEvent` clone to both the central queue and the ring (so
+/// `t_sent` agrees), but `record_received`/`record_finished` push only
+/// to the central queue — the ring's `Received`/`Finished` are sampled
+/// separately in the dispatch loop, so their nanos differ by sampling
+/// jitter. That divergence is a harmless dual-write transient (the ring
+/// is internally consistent and becomes the sole source once Phase 3c
+/// retires the observer); the *topology* is what this gate guards.
+///
+/// The observer is fed by ADR-0080's async batch drainer, which Phase 2
+/// decoupled from settlement — so the observer's tree lags the `rx`
+/// settlement signal by a drainer hop, while the guided walk reads the
+/// rings synchronously at the producer hook (never stale). We poll the
+/// lagging observer until it converges with the walk; non-convergence
+/// within the timeout is the failure.
+#[test]
+#[allow(clippy::print_stderr)]
+fn guided_walk_matches_observer_tree() {
+    let Ok(mut tb) = TestBench::builder()
+        .with_workers(Some(2))
+        .size(16, 16)
+        .build()
+    else {
+        eprintln!("skipping guided_walk_matches_observer_tree: no wgpu adapter");
+        return;
+    };
+
+    spawn_topology(&tb, &two_level_tree());
+    let (root, rx) = tb.inject_root(relay_id(0), Ping::ID, Ping { seq: 0 }.encode_into_bytes());
+    assert!(
+        rx.recv_timeout(SETTLE_TIMEOUT).is_ok(),
+        "injected root never settled"
+    );
+
+    // The guided walk is synchronously complete; the observer catches up
+    // a drainer hop later. Poll until they agree, then assert exact
+    // equality (the timeout-path assert prints the diff on a real bug).
+    //
+    // Poll cadence is deliberately slow (20 ms): each `describe_tree_walked`
+    // sends a `trace.tail` query mail to every visited actor, and the
+    // dispatch loop records that query's own `Received`/`Finished` into
+    // the queried actor's ring (under the query's root). A tight poll
+    // floods relay 0's bounded ring and evicts the very tree events being
+    // queried — so the walk would truncate. At 20 ms cadence the handful
+    // of iterations needed for the drainer to catch up stays far under the
+    // ring cap.
+    let deadline = Instant::now() + SETTLE_TIMEOUT;
+    loop {
+        let walked = match tb.describe_tree_walked(root) {
+            DescribeTreeResult::Ok { mails, .. } => mails,
+            DescribeTreeResult::Err { not_found } => panic!("guided walk lost root {not_found:?}"),
+        };
+
+        if let Some(observed) = describe_tree(&mut tb, root) {
+            if node_shapes(&walked) == node_shapes(&observed) {
+                // root (chassis -> relay 0) + 0->{1,2} + 1->{3,4} +
+                // 2->{4,5} = 7 mails (relay 4 receives two).
+                assert_eq!(walked.len(), 7, "two_level_tree under one root is 7 mails");
+                // Both trees must be causally coherent on their own
+                // timestamps; a violation on the trusted observer would
+                // flag the invariant itself, not the walk.
+                assert_causal_order(&walked);
+                assert_causal_order(&observed);
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "guided-walk tree never converged with observer:\n walked={:#?}\n observer={:#?}",
+                node_shapes(&walked),
+                node_shapes(&observed)
+            );
+        } else {
+            assert!(
+                Instant::now() < deadline,
+                "observer never populated the root tree within the timeout"
+            );
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+/// Structural projection of a `MailNodeWire` — every field but the exact
+/// timestamps (which differ by dual-write sampling jitter; see
+/// [`guided_walk_matches_observer_tree`]). `t_received` / `t_finished`
+/// collapse to presence bools. Returned sorted, for set comparison.
+type NodeShape = (
+    MailId,
+    Option<MailId>,
+    MailboxId,
+    MailboxId,
+    KindId,
+    bool,
+    bool,
+    Option<String>,
+);
+
+fn node_shapes(mails: &[MailNodeWire]) -> Vec<NodeShape> {
+    let mut v: Vec<NodeShape> = mails
+        .iter()
+        .map(|n| {
+            (
+                n.mail_id,
+                n.parent,
+                n.sender,
+                n.recipient,
+                n.kind,
+                n.t_received.is_some(),
+                n.t_finished.is_some(),
+                n.thread_name.clone(),
+            )
+        })
+        .collect();
+    v.sort();
+    v
+}
+
+/// Assert the causal invariants a correct trace tree must satisfy on its
+/// own timestamps:
+///
+/// - per node, `t_sent <= t_received <= t_finished` (sent, then
+///   received, then the handler returns);
+/// - per parent->child edge, `parent.t_received <= child.t_sent <=
+///   parent.t_finished` — a child is sent from inside its parent's
+///   handler, and all three reads land on the parent's dispatch thread
+///   (one monotonic clock), so this holds even under the multi-worker
+///   pool. (`child.t_received` is deliberately *not* bounded by
+///   `parent.t_finished`: parallelism lets a child be received before
+///   its parent's handler returns.)
+fn assert_causal_order(mails: &[MailNodeWire]) {
+    let by_id: BTreeMap<MailId, &MailNodeWire> = mails.iter().map(|n| (n.mail_id, n)).collect();
+    for n in mails {
+        if let Some(received) = n.t_received {
+            assert!(
+                n.t_sent.0 <= received.0,
+                "node {:?}: t_sent {} > t_received {}",
+                n.mail_id,
+                n.t_sent.0,
+                received.0
+            );
+            if let Some(finished) = n.t_finished {
+                assert!(
+                    received.0 <= finished.0,
+                    "node {:?}: t_received {} > t_finished {}",
+                    n.mail_id,
+                    received.0,
+                    finished.0
+                );
+            }
+        }
+        if let Some(parent_id) = n.parent {
+            let parent = by_id
+                .get(&parent_id)
+                .unwrap_or_else(|| panic!("parent {parent_id:?} of {:?} absent", n.mail_id));
+            if let Some(parent_received) = parent.t_received {
+                assert!(
+                    parent_received.0 <= n.t_sent.0,
+                    "child {:?} sent at {} before parent {:?} received at {}",
+                    n.mail_id,
+                    n.t_sent.0,
+                    parent_id,
+                    parent_received.0
+                );
+            }
+            if let Some(parent_finished) = parent.t_finished {
+                assert!(
+                    n.t_sent.0 <= parent_finished.0,
+                    "child {:?} sent at {} after parent {:?} finished at {}",
+                    n.mail_id,
+                    n.t_sent.0,
+                    parent_id,
+                    parent_finished.0
+                );
+            }
+        }
+    }
 }
 
 const OBSERVE_FRAMES: u32 = 1000;

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -827,7 +827,9 @@ fn print_observe_tables(rows: &[CellResult], pace_hz: Option<u64>) {
     println!();
     println!("=== lifecycle-driven mail latency (all values µs; n = sample count) ===");
     println!("driven by `advance` (real Tick fan-out → source → relay chain); harvested from the");
-    println!("trace ring via one DescribeWindow — no injector, no per-root block.");
+    println!(
+        "per-actor trace rings (aether.trace.tail per relay) — no injector, no per-root block."
+    );
     if let Some(hz) = pace_hz {
         println!("paced @ {hz} Hz — workers park between frames (realistic frame loop)");
     } else {

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -33,8 +33,8 @@ use crate::mail::outbound::HubOutbound;
 use crate::mail::registry::{MailDispatch, MailboxEntry, OwnedDispatch, Registry};
 use crate::mail::{Mail, ReplyTarget, ReplyTo};
 use crate::runtime::trace::{SettlementHold, TraceHandle};
-use aether_data::{HandleId, KindId};
-use aether_kinds::trace::Nanos;
+use aether_data::{HandleId, Kind, KindId};
+use aether_kinds::trace::{Nanos, TraceTail, TraceTailResult};
 use std::sync::OnceLock;
 
 pub struct Mailer {
@@ -386,7 +386,7 @@ impl Mailer {
     /// receive mail.
     pub fn send_reply<K>(&self, sender: ReplyTo, result: &K) -> bool
     where
-        K: aether_data::Kind + serde::Serialize,
+        K: Kind + serde::Serialize,
     {
         match sender.target {
             ReplyTarget::None => false,
@@ -459,9 +459,57 @@ fn route_mail(
         // replies) get the symmetric `Received`/`Finished` bracket.
         let inbound_mail_id = mail.mail_id;
         let inbound_root = mail.root;
-        if let Some(router) = chassis_router {
+        // `Received` brackets a mail only when something handles it
+        // (the `TraceTail` arm answers; a router consumes). A
+        // chassis-addressed mail that no handler claims is dropped and
+        // records `Finished` only — enough to balance its `Sent` so
+        // settlement drains, without a phantom `Received`.
+        if mail.kind == TraceTail::ID || chassis_router.is_some() {
             let thread_name = thread::current().name().map(str::to_owned);
             trace_handle.record_received(inbound_mail_id, inbound_root, thread_name);
+        }
+        if mail.kind == TraceTail::ID {
+            // ADR-0086 Phase 3b: the chassis-host trace ring holds the
+            // off-actor root `Sent`s — every injected root carries
+            // `sender = CHASSIS_MAILBOX_ID`, so the guided walk seeds at
+            // `root.sender`, which lands here over the wire. Answer the
+            // tail and reply to the caller. (In-process callers reach
+            // the same ring via `TraceHandle::chassis_host_tail`.)
+            let result = TraceTail::decode_from_bytes(&mail.payload).map_or_else(
+                || TraceTailResult::Err {
+                    error: "undecodable TraceTail to chassis-host ring".to_owned(),
+                },
+                |request| trace_handle.chassis_host_tail(&request),
+            );
+            match mail.reply_to.target {
+                ReplyTarget::Session(_) | ReplyTarget::EngineMailbox { .. } => {
+                    if let Some(outbound) = outbound {
+                        outbound.send_reply(mail.reply_to, &result);
+                    }
+                }
+                ReplyTarget::Component(target) => {
+                    // The MCP Call path replies via Component (mirrors
+                    // the `LogTail`-to-unknown arm below): re-route a
+                    // fresh, un-lineaged reply into the target's inbox.
+                    if let Ok(payload) = postcard::to_allocvec(&result) {
+                        let reply_to = ReplyTo::with_correlation(
+                            ReplyTarget::None,
+                            mail.reply_to.correlation_id,
+                        );
+                        route_mail(
+                            Mail::new(target, TraceTailResult::ID, payload, 1)
+                                .with_reply_to(reply_to),
+                            registry,
+                            outbound,
+                            store,
+                            chassis_router,
+                            trace_handle,
+                        );
+                    }
+                }
+                ReplyTarget::None => {}
+            }
+        } else if let Some(router) = chassis_router {
             router(mail);
         } else {
             tracing::warn!(
@@ -660,7 +708,7 @@ fn route_mail(
             // takes via `RpcServerCapability::handle_call`) is routed;
             // `Session`/`EngineMailbox` targets fall through to the
             // warn-drop, keeping the blast radius minimal.
-            if mail.kind.0 == <aether_kinds::LogTail as aether_data::Kind>::ID.0 {
+            if mail.kind.0 == <aether_kinds::LogTail as Kind>::ID.0 {
                 let err = aether_kinds::LogTailResult::Err {
                     error: format!("mailbox {recipient} not registered on engine"),
                 };
@@ -672,7 +720,7 @@ fn route_mail(
                     route_mail(
                         Mail::new(
                             target,
-                            <aether_kinds::LogTailResult as aether_data::Kind>::ID,
+                            <aether_kinds::LogTailResult as Kind>::ID,
                             payload,
                             1,
                         )
@@ -868,6 +916,67 @@ mod tests {
             recorded.read().unwrap().is_empty(),
             "non-LogTail unknown-mailbox mail warn-drops with no reply",
         );
+    }
+
+    /// ADR-0086 Phase 3b: `aether.trace.tail` to `CHASSIS_MAILBOX_ID`
+    /// answers from the chassis-host ring and replies to the inbound's
+    /// `Component` target — the hop the MCP's `send_mail_traced` guided
+    /// walk takes to fetch the off-actor root `Sent` over the wire (the
+    /// in-process harness reaches the same ring via
+    /// `TraceHandle::chassis_host_tail`). Seeds the ring with one
+    /// chassis-root `Sent`, queries it, and asserts the recorded reply
+    /// is a `TraceTailResult::Ok` carrying that `Sent`, correlation
+    /// echoed.
+    #[test]
+    fn chassis_host_trace_tail_replies_to_component_target() {
+        use aether_kinds::trace::{TraceEvent, TraceTail, TraceTailResult};
+
+        let registry = Arc::new(Registry::new());
+        let store = Arc::new(HandleStore::new(64 * 1024));
+        let mailer = Mailer::new(Arc::clone(&registry), store);
+
+        let (recorder_id, recorded) = record_inline(&registry);
+
+        // An off-actor chassis-root mail records its `Sent` in the
+        // chassis-host ring (the recipient is unregistered and the mail
+        // itself warn-drops, but the off-actor `Sent` still lands).
+        let root =
+            mailer.push_chassis_root_mail(0x55, MailboxId(0x1234), KindId(0xFEED), vec![], 1);
+
+        // Query the chassis-host ring for that root, replying to a
+        // `Component` target (the MCP RPC-server reply hop).
+        let request = TraceTail {
+            max: 0,
+            since: None,
+            root: Some(root),
+        };
+        mailer.push(
+            Mail::new(
+                MailboxId::CHASSIS_MAILBOX_ID,
+                TraceTail::ID,
+                request.encode_into_bytes(),
+                1,
+            )
+            .with_reply_to(ReplyTo::with_correlation(
+                ReplyTarget::Component(recorder_id),
+                0xCAFE,
+            )),
+        );
+
+        let recorded = recorded.read().unwrap();
+        assert_eq!(recorded.len(), 1, "exactly one TraceTailResult reply");
+        let (kind, correlation, payload) = &recorded[0];
+        assert_eq!(*kind, TraceTailResult::ID);
+        assert_eq!(*correlation, 0xCAFE, "correlation echoed onto the reply");
+        match postcard::from_bytes::<TraceTailResult>(payload).unwrap() {
+            TraceTailResult::Ok { entries, .. } => assert!(
+                entries
+                    .iter()
+                    .any(|e| e.root == root && matches!(e.event, TraceEvent::Sent { .. })),
+                "the chassis-host root Sent came back: {entries:?}",
+            ),
+            TraceTailResult::Err { error } => panic!("expected Ok, got Err {error}"),
+        }
     }
 
     // ------------------------------------------------------------

--- a/docs/adr/0086-decouple-settlement-from-trace.md
+++ b/docs/adr/0086-decouple-settlement-from-trace.md
@@ -80,3 +80,32 @@ Each phase lands independently and is measurable on its own.
 - **Weighted reference counting / credit-passing** (credit rides on each mail, splits on send, returns on finish; root settles on full reclaim). Reduces updates to the shared cell but still needs a convergence point, and is more machinery than our scale (one frame root, modest fan-out) warrants. Noted as a future optimization if counter contention ever bites.
 - **Keep per-root sharding, tune it.** Rejected: a band-aid that keeps a contended shared structure in the hot path and exists only to preserve the stream ordering the decouple makes unnecessary. The decision is to install permanent infrastructure, not a better band-aid.
 - **Leave settlement on the trace pipeline; only shorten/eagerly-wake the drainer.** Rejected: trades latency for drain overhead and does nothing about the critical-path coupling #1048 flagged — the same band-aid posture.
+
+## Phase 3 as built (amendment, 2026-05-23)
+
+Implementation split the original "Phase 3 — Decentralize trace" into three landable steps (3a/3b/3c). The decentralized **reader** turned out to want a sharper shape than the "fan-out-and-stitch coordinator" the Decision sketched. Recorded here so the deviation and its rationale survive.
+
+### Reconstruction is a guided walk from a known root, not a broad fan-out
+
+The original framing — fan `tail` queries out across actors and stitch — implies enumerating actors. There is no client-side actor-enumeration surface (the MCP exposes `list_engines` and `describe_component`-by-id, never "list this engine's actors"), and adding one would invite exactly the "I don't know what I'm looking for" fishing query. Instead, reconstruction is a **guided walk**: seed at the root mail's `sender`, follow each `Sent` event's `recipient` (each recipient's ring holds that mail's `Received`/`Finished` plus any onward `Sent`s), recurse. The frontier expands purely from observed recipients, so the walk visits **exactly the actors in the tree** and never enumerates the full set.
+
+This directly bounds the cost concern a barrier raises: a trace query issued during a settlement barrier costs `hop × nodes-on-the-path`, touching `O(tree)` actors, not `O(live actors)`. (Per-frontier-level parallel fetch is a future option; the first cut walks sequentially.) It also means every query *starts from a root the caller already holds* — `send_mail_traced` gets its root from the dispatch ack — which is the model the engine should encourage.
+
+### Decisions
+
+- **(A) The stitch coordinator is client-side.** A pure, transport-agnostic `TreeWalk` + `stitch` (in `aether-capabilities::trace_walk`) is driven by both `aether-mcp` (over the RPC wire) and the in-process harness, each owning only its `fetch`. No substrate-side aggregator — mirroring ADR-0081's client-side log aggregation (substrate fan-out hit friction, #960). Revisit if a substrate-side coordinator ever earns its keep.
+- **(B) Off-actor `Sent`s land in a chassis-host ring.** A root injected from outside any actor's dispatch (every such root carries `sender = CHASSIS_MAILBOX_ID`) records its `Sent` in a locked chassis-host ring on the trace handle, since there's no `ActorSlots` to stamp. The walk seeds at `root.sender`, so over the wire it addresses `aether.trace.tail` to `CHASSIS_MAILBOX_ID`; `route_mail`'s chassis arm answers from that ring (replying to both `Session` and `Component` targets). The in-process harness reaches the same ring directly.
+- **(C) Settlement holds are not stored in trace rings.** `HoldOpen` / `Release` aren't tree nodes, and settlement no longer rides the trace stream after Phase 2 — the emit-time counter owns them. The rings store only `Sent` / `Received` / `Finished`.
+
+### `list_active_roots` dropped; `describe_window` deferred to cleanup
+
+`list_active_roots` (recent-roots discovery) had zero callers and is the fishing query the guided-walk model makes unnecessary — removed in 3b. `describe_window`'s only caller is the `#[ignore]` latency harness's window-harvest; it stays observer-served until the harness moves off it. Because the harness rework is coupled to observer removal (both die together), `describe_window` removal + the harness rework + retiring the `ShardedTraceQueue` / drainer / observer group into the cleanup phase. The harness reworks to query the per-actor relay rings *directly* — it built the topology, so it knows its actors by name — folding `Ping` events the same way the walk stitches.
+
+### Findings carried out of 3b
+
+- **Timestamp sampling jitter is expected during dual-write.** `record_sent` writes one `TraceEvent` clone to both the central queue and the ring, so `t_sent` agrees; but `record_received` / `record_finished` push only to the queue, and the ring's `Received` / `Finished` are sampled by a separate `now_nanos()` in the dispatch loop. So those nanos differ by ~µs between the observer's tree and the walked tree. Harmless: each tree is internally consistent, and the ring becomes the sole source at cleanup. The cross-check gate compares topology + timestamp *presence* + causal ordering (`t_sent ≤ t_received ≤ t_finished`; a child is sent within its parent's handler window), not exact nanos.
+- **A `tail` query self-pollutes the queried actor's ring.** The query mail is dispatched to the actor, so its own `Received` / `Finished` land in that actor's ring (under the query's own root — filtered out of results, but consuming ring capacity). Negligible for ordinary queries; a tight poll can evict the very events being queried. Candidate for cleanup: exclude framework-arm mails (`trace.tail` / `log.tail`) from ring recording.
+
+### Trust gate
+
+3b keeps the observer live as an oracle: an in-process cross-check settles a branching tree, reconstructs it both via the observer and via the guided walk, and asserts the node sets match (topology + presence + causal order). Cleanup retires the observer only once the walk is the trusted path.


### PR DESCRIPTION
## Summary

Phase 3b of the trace decentralization (ADR-0086), tracked by iamacoffeepot/aether#1092. Phase 3a (iamacoffeepot/aether#1097, merged) added the per-actor trace rings + `aether.trace.tail` and dual-wrote into them, dormant. 3b builds the **reader** on those rings and moves the trace queries onto it, cross-checked against the still-live central observer. The observer, the central `ShardedTraceQueue`, the drainer, and the dual-write all retire in the cleanup phase (3c) — this PR does not remove them, so dispatch behavior is unchanged.

The reconstruction shape sharpened from the ADR's "fan-out-and-stitch coordinator" into a **guided walk from a known root**: seed at the root mail's `sender`, follow each `Sent` event's `recipient`. The frontier expands purely from observed recipients, so the walk visits exactly the actors in the tree and never enumerates the full actor set — which both removes the need for an actor-enumeration surface (there is none, by design) and bounds a trace query's cost during a barrier to `O(tree)` rather than `O(live actors)`.

- **`TreeWalk` + `stitch` / `fold_nodes`** (`aether-capabilities/trace_walk`) — a pure, transport-agnostic guided walk + per-`mail_id` fold, driven by `aether-mcp` (over the RPC wire) and the in-process harness, each owning only its `fetch`.
- **`send_mail_traced` repointed** — Round 2 stops calling the observer's `DescribeTree` and drives the guided walk, fetching each ring with one `aether.trace.tail` addressed by id. The observer stays live as the cross-check oracle.
- **Chassis-host ring over the wire** — off-actor root `Sent`s (every injected root carries `sender = CHASSIS_MAILBOX_ID`) live in the chassis-host ring; `route_mail`'s chassis arm answers `aether.trace.tail` addressed to `CHASSIS_MAILBOX_ID`, replying to both `Session` and `Component` targets. `Received` brackets only when handled, so a dropped chassis mail still records `Finished`-only (settlement balance preserved).
- **`list_active_roots` dropped** — zero callers; the recent-roots "fishing" query the guided-walk model makes unnecessary (you always start from a root you hold).
- **Latency harness off `describe_window`** — it now harvests each relay's per-actor ring directly by name (it builds the topology) and folds them. Rings self-report truncation: a busy relay's ring laps under a long wide fan-out, so stats come from the most-recent window (valid percentiles, fewer samples).
- **ADR-0086 amended** with the as-built design (decisions A/B/C, the guided-walk refinement, the timestamp-jitter + query-self-pollution findings, the trust gate).

## Perf

`perf-compare.yml` would auto-run (mail/perf paths touched), but `perf-skip` is set to **defer** it for now — run it later by removing `perf-skip` (or adding `perf`). Expected **flat** when it runs: the dual-write is intact and the `route_mail` change is on the chassis arm only (trace queries), so the dispatch hot path is untouched. The contention win (removing the central `SegQueue` + dual-write) lands in 3c — that's the PR worth comparing.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` (touched crates)
- [x] `cargo nextest run` — touched crates + trace/settlement integration suites green
- [x] `trace_walk` unit tests (walk reconstructs across rings, diamond dedup, stitch fold, missing-root → Err)
- [x] `guided_walk_matches_observer_tree` — settles a diamond topology, reconstructs it via the observer and the guided walk, asserts the node sets match (topology + timestamp presence + causal order: `t_sent ≤ t_received ≤ t_finished`, child sent within parent's handler window). Exercises the chassis-host wire route in-process.
- [x] mailer unit test: chassis-host `TraceTail` replies to a `Component` target with the seeded root `Sent`
- [x] manual `lifecycle_latency_observe --ignored --release`: warm hop p50 ~1µs (depth chains) scaling for fan-outs, handler p50 ~0.1-0.6µs — consistent with the prior `describe_window` numbers; fan-out cells correctly show reduced `n` (ring lapped, self-reported)
- [x] reviewer: confirm the chassis-host route's settlement balance + the observer-as-oracle trust gate

Refs: ADR-0086 (design + as-built amendment), ADR-0081 (per-actor rings), iamacoffeepot/aether#1092 (tracking)
