### PR TITLE
refactor(substrate): carry mail payloads as MailRef on inbox envelopes

### DIFF
--- a/crates/aether-capabilities/src/dag.rs
+++ b/crates/aether-capabilities/src/dag.rs
@@ -218,7 +218,7 @@ mod native {
             let correlation = env.sender.correlation_id;
             let matched =
                 self.executor
-                    .on_reply(ctx, correlation, KindId(env.kind.0), &env.payload);
+                    .on_reply(ctx, correlation, KindId(env.kind.0), env.payload.bytes());
             if !matched {
                 tracing::debug!(
                     target: "aether_substrate::dag",

--- a/crates/aether-capabilities/src/dag/tests.rs
+++ b/crates/aether-capabilities/src/dag/tests.rs
@@ -38,7 +38,7 @@ use aether_substrate::handle_store::HandleStore;
 use aether_substrate::mail::mailer::Mailer;
 use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
 use aether_substrate::mail::registry::{MailboxEntry, OwnedDispatch, Registry};
-use aether_substrate::mail::{ReplyTarget, ReplyTo};
+use aether_substrate::mail::{MailRef, ReplyTarget, ReplyTo};
 
 use super::DagCapability;
 use super::test_support::{
@@ -125,7 +125,7 @@ fn enqueue<K: Kind + serde::Serialize>(
         kind_name: K::NAME.to_owned(),
         origin: None,
         sender,
-        payload: bytes,
+        payload: MailRef::from(bytes),
         count: 1,
         mail_id: MailId::NONE,
         root: MailId::NONE,

--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -223,7 +223,7 @@ mod native {
         use aether_substrate::mail::registry;
         use aether_substrate::mail::registry::OwnedDispatch;
         use aether_substrate::mail::registry::{MailboxEntry, Registry};
-        use aether_substrate::mail::{ReplyTarget, ReplyTo};
+        use aether_substrate::mail::{MailRef, ReplyTarget, ReplyTo};
 
         fn fresh_substrate() -> (
             Arc<HandleStore>,
@@ -277,7 +277,7 @@ mod native {
                 kind_name: "aether.handle.publish".to_owned(),
                 origin: None,
                 sender: session_reply_to(),
-                payload: bytes,
+                payload: MailRef::from(bytes),
                 count: 1,
                 mail_id: MailId::NONE,
                 root: MailId::NONE,
@@ -355,7 +355,7 @@ mod native {
                 kind_name: "aether.handle.describe".to_owned(),
                 origin: None,
                 sender: session_reply_to(),
-                payload: bytes,
+                payload: MailRef::from(bytes),
                 count: 1,
                 mail_id: MailId::NONE,
                 root: MailId::NONE,

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -731,6 +731,7 @@ mod native {
         use aether_actor::Actor;
         use aether_substrate::chassis::builder::{Builder, PassiveChassis};
         use aether_substrate::mail::MailId;
+        use aether_substrate::mail::MailRef;
         use aether_substrate::mail::mailer::Mailer;
         use aether_substrate::mail::registry::OwnedDispatch;
         use aether_substrate::mail::registry::{MailboxEntry, Registry};
@@ -762,7 +763,7 @@ mod native {
                 kind_name: "test.kind".to_owned(),
                 origin: None,
                 sender: ReplyTo::NONE,
-                payload: payload.to_vec(),
+                payload: MailRef::from(payload.to_vec()),
                 count: 1,
                 mail_id: MailId::NONE,
                 root: MailId::NONE,

--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -332,7 +332,7 @@ mod server_native {
             // to catch. Recognize it here, write the wire `ReplyEnd`,
             // and clear the in-flight entry.
             if env.kind == <CallSettled as Kind>::ID {
-                let result = match CallSettled::decode_from_bytes(&env.payload) {
+                let result = match CallSettled::decode_from_bytes(env.payload.bytes()) {
                     Some(CallSettled::Ok) => Ok(()),
                     Some(CallSettled::Err { error }) => Err(RpcError::Other { reason: error }),
                     None => Err(RpcError::Other {
@@ -358,7 +358,7 @@ mod server_native {
                 },
                 kind: env.kind,
                 correlation_id: Some(entry.wire_cid),
-                payload: env.payload.clone(),
+                payload: env.payload.bytes().to_vec(),
             };
             self.write_frame_to(
                 entry.conn_id,

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -563,7 +563,7 @@ mod cap_native {
         use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
         use aether_substrate::mail::registry::OwnedDispatch;
         use aether_substrate::mail::registry::{MailboxEntry, Registry};
-        use aether_substrate::mail::{ReplyTarget, ReplyTo};
+        use aether_substrate::mail::{MailRef, ReplyTarget, ReplyTo};
         use serde::de::DeserializeOwned;
 
         fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>, mpsc::Receiver<EgressEvent>) {
@@ -630,7 +630,7 @@ mod cap_native {
                 kind_name: K::NAME.to_owned(),
                 origin: None,
                 sender: session_reply(),
-                payload: bytes,
+                payload: MailRef::from(bytes),
                 count: 1,
                 mail_id: MailId::NONE,
                 root: MailId::NONE,

--- a/crates/aether-capabilities/src/trampoline.rs
+++ b/crates/aether-capabilities/src/trampoline.rs
@@ -281,9 +281,14 @@ mod native {
             // `root`. Without this, the trampoline's wrapped Mail
             // defaults to `MailId::NONE` and the guest's outbound looks
             // like a fresh root.
-            let mail = Mail::new(self.mailbox, env.kind, env.payload.clone(), env.count)
-                .with_reply_to(env.sender)
-                .with_lineage(env.mail_id, env.root, env.parent_mail);
+            let mail = Mail::new(
+                self.mailbox,
+                env.kind,
+                env.payload.bytes().to_vec(),
+                env.count,
+            )
+            .with_reply_to(env.sender)
+            .with_lineage(env.mail_id, env.root, env.parent_mail);
             if let Err(e) = component.deliver(&mail) {
                 // ADR-0063 fail-fast: a wasm trap (or host-fn error
                 // returned through `Component::deliver`) kills the

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -372,7 +372,7 @@ impl App {
     #[allow(clippy::needless_pass_by_value)]
     fn dispatch_window_envelope(&mut self, env: Envelope) {
         if env.kind == self.kind_set_window_mode {
-            let payload: SetWindowMode = match postcard::from_bytes(&env.payload) {
+            let payload: SetWindowMode = match postcard::from_bytes(env.payload.bytes()) {
                 Ok(p) => p,
                 Err(e) => {
                     self.outbound.send_reply(
@@ -387,7 +387,7 @@ impl App {
             let result = self.apply_window_mode(payload.mode, payload.width, payload.height);
             self.outbound.send_reply(env.sender, &result);
         } else if env.kind == self.kind_set_window_title {
-            let payload: SetWindowTitle = match postcard::from_bytes(&env.payload) {
+            let payload: SetWindowTitle = match postcard::from_bytes(env.payload.bytes()) {
                 Ok(p) => p,
                 Err(e) => {
                     self.outbound.send_reply(

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -552,7 +552,7 @@ fn write_payload(env: &Envelope, out: &mut [u8]) -> i32 {
     if env.payload.len() > out.len() {
         return -2;
     }
-    out[..env.payload.len()].copy_from_slice(&env.payload);
+    out[..env.payload.len()].copy_from_slice(env.payload.bytes());
     env.payload.len() as i32
 }
 
@@ -563,6 +563,7 @@ fn write_payload(env: &Envelope, out: &mut [u8]) -> i32 {
 )]
 mod tests {
     use super::*;
+    use crate::mail::MailRef;
     use crate::mail::registry::{InboxHandler, OwnedDispatch};
     use crate::test_util::fresh_substrate;
     use std::sync::mpsc;
@@ -647,7 +648,7 @@ mod tests {
             kind_name: String::new(),
             origin: None,
             sender: ReplyTo::with_correlation(ReplyTarget::None, correlation),
-            payload,
+            payload: MailRef::from(payload),
             count: 1,
             mail_id: MailId::NONE,
             root: MailId::NONE,

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -68,7 +68,7 @@ where
     A: NativeActor + NativeDispatch,
 {
     if actor
-        .__aether_dispatch_envelope(ctx, env.kind, &env.payload)
+        .__aether_dispatch_envelope(ctx, env.kind, env.payload.bytes())
         .is_none()
         && !actor.__aether_dispatch_fallback(ctx, env)
     {
@@ -98,7 +98,7 @@ pub fn dispatch_log_tail_if_matching(ctx: &mut NativeCtx<'_>, env: &Envelope) ->
     if env.kind.0 != <LogTail as Kind>::ID.0 {
         return false;
     }
-    let Some(request) = <LogTail as Kind>::decode_from_bytes(&env.payload) else {
+    let Some(request) = <LogTail as Kind>::decode_from_bytes(env.payload.bytes()) else {
         ctx.reply(&LogTailResult::Err {
             error: "aether.log.tail: payload failed to decode".to_owned(),
         });
@@ -123,7 +123,7 @@ pub fn dispatch_trace_tail_if_matching(ctx: &mut NativeCtx<'_>, env: &Envelope) 
     if env.kind.0 != <TraceTail as Kind>::ID.0 {
         return false;
     }
-    let Some(request) = <TraceTail as Kind>::decode_from_bytes(&env.payload) else {
+    let Some(request) = <TraceTail as Kind>::decode_from_bytes(env.payload.bytes()) else {
         ctx.reply(&TraceTailResult::Err {
             error: "aether.trace.tail: payload failed to decode".to_owned(),
         });
@@ -234,7 +234,7 @@ pub fn dispatch_loop_run<A>(
             if !dispatch_log_tail_if_matching(&mut ctx, &env)
                 && !dispatch_trace_tail_if_matching(&mut ctx, &env)
             {
-                let _ = actor.__aether_dispatch_envelope(&mut ctx, env.kind, &env.payload);
+                let _ = actor.__aether_dispatch_envelope(&mut ctx, env.kind, env.payload.bytes());
             }
             th.push_trace_ring(
                 env.root,

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -36,7 +36,7 @@ use crate::chassis::error::BootError;
 use crate::mail::mailer::Mailer;
 use crate::mail::registry::OwnedDispatch;
 use crate::mail::registry::{NameConflict, Registry};
-use crate::mail::{KindId, MailId, MailboxId, ReplyTo};
+use crate::mail::{KindId, MailId, MailRef, MailboxId, ReplyTo};
 use crate::runtime::lifecycle::FatalAborter;
 use crate::scheduler::Drainable;
 use crate::scheduler::WakeHandle;
@@ -679,7 +679,7 @@ impl<'ctx, A: Instanced + NativeActor + NativeDispatch> SpawnBuilder<'ctx, A> {
             kind_name: <K as Kind>::NAME.to_owned(),
             origin: None,
             sender: self.sender,
-            payload,
+            payload: MailRef::from(payload),
             count: 1,
             mail_id: MailId::NONE,
             root: MailId::NONE,

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -20,7 +20,7 @@ use crate::mail::mailer::Mailer;
 use crate::mail::outbound::HubOutbound;
 use crate::mail::registry::OwnedDispatch;
 use crate::mail::registry::{MailboxEntry, Registry};
-use crate::mail::{Mail, MailId, MailKind, MailboxId, ReplyTarget, ReplyTo};
+use crate::mail::{Mail, MailId, MailKind, MailRef, MailboxId, ReplyTarget, ReplyTo};
 
 const MAIL_OFFSET: u32 = 1024;
 
@@ -247,7 +247,7 @@ impl ComponentCtx {
                     kind_name,
                     origin,
                     sender: reply_to,
-                    payload,
+                    payload: MailRef::from(payload),
                     count,
                     mail_id,
                     root,

--- a/crates/aether-substrate/src/chassis/settlement.rs
+++ b/crates/aether-substrate/src/chassis/settlement.rs
@@ -340,7 +340,7 @@ mod tests {
             Arc::new(move |dispatch: OwnedDispatch| {
                 captured_clone.lock().unwrap().push(CapturedDispatch {
                     kind: dispatch.kind,
-                    payload: dispatch.payload,
+                    payload: dispatch.payload.into_vec(),
                     count: dispatch.count,
                 });
             }),

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -79,7 +79,7 @@ pub use mail::outbound::{
     DroppingBackend, EgressBackend, EgressEvent, HubOutbound, RecordingBackend,
 };
 pub use mail::registry::{InboxHandler, InlineHandler, MailboxEntry, OwnedDispatch, Registry};
-pub use mail::{KindId, Mail, MailKind, MailboxId, ReplyTarget, ReplyTo};
+pub use mail::{KindId, Mail, MailKind, MailRef, MailboxId, ReplyTarget, ReplyTo};
 pub use runtime::panic_hook::init_panic_hook;
 
 /// Well-known mailbox name for substrate-level diagnostic events

--- a/crates/aether-substrate/src/mail/mail_ref.rs
+++ b/crates/aether-substrate/src/mail/mail_ref.rs
@@ -1,0 +1,82 @@
+//! `MailRef` — the payload handle an actor inbox envelope carries
+//! (ADR-0087).
+//!
+//! Phase 1 (iamacoffeepot/aether#1104) ships only the `Owned` variant: a
+//! heap-owned byte buffer, byte-for-byte the `Vec<u8>` payload it
+//! replaces, with no behaviour change. The zero-copy `InRing` variant —
+//! a reference into a per-producer ring — lands in Phase 2
+//! (iamacoffeepot/aether#1105) once the rings exist. `MailRef` is an
+//! enum from the start (not a newtype) so every construction site
+//! already reads `MailRef::Owned(..)` and the second variant slots in
+//! without churning them; reads go through [`MailRef::bytes`] so the
+//! `InRing` resolution lands in one place.
+
+/// A handle to one mail's payload bytes carried on an actor inbox
+/// envelope ([`crate::mail::registry::OwnedDispatch`]).
+#[derive(Clone, Debug)]
+pub enum MailRef {
+    /// A heap-owned payload. The cross-boundary form (hub / MCP mail,
+    /// substrate-generated mail) and — post-Phase-2 — the copy-out
+    /// fallback when a producer ring is full.
+    Owned(Box<[u8]>),
+}
+
+impl MailRef {
+    /// Borrow the payload bytes for decoding. The single read accessor:
+    /// Phase 2's `InRing` resolution is added here, so call sites that
+    /// `decode_from_bytes(mail.bytes())` are unaffected by the variant
+    /// gaining a second arm.
+    #[must_use]
+    pub fn bytes(&self) -> &[u8] {
+        match self {
+            Self::Owned(bytes) => bytes,
+        }
+    }
+
+    /// Consume into an owned `Vec<u8>`. For the few sites that move the
+    /// payload into a downstream owned buffer or a test capture row.
+    #[must_use]
+    pub fn into_vec(self) -> Vec<u8> {
+        match self {
+            Self::Owned(bytes) => bytes.into_vec(),
+        }
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.bytes().len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.bytes().is_empty()
+    }
+}
+
+impl From<Vec<u8>> for MailRef {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self::Owned(bytes.into_boxed_slice())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn owned_round_trips_bytes_and_vec() {
+        let r = MailRef::from(vec![1u8, 2, 3, 4]);
+        assert_eq!(r.bytes(), &[1, 2, 3, 4]);
+        assert_eq!(r.len(), 4);
+        assert!(!r.is_empty());
+        assert_eq!(r.into_vec(), vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn empty_owned_is_empty() {
+        let r = MailRef::from(Vec::new());
+        assert!(r.is_empty());
+        assert_eq!(r.len(), 0);
+        assert_eq!(r.bytes(), &[] as &[u8]);
+    }
+}

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -30,7 +30,7 @@ use crate::handle_store::{self, HandleStore, PutError, WalkOutcome};
 use crate::mail::capability::CapabilityRegistry;
 use crate::mail::outbound::HubOutbound;
 use crate::mail::registry::{MailDispatch, MailboxEntry, OwnedDispatch, Registry};
-use crate::mail::{Mail, ReplyTarget, ReplyTo};
+use crate::mail::{Mail, MailRef, ReplyTarget, ReplyTo};
 use crate::runtime::trace::{SettlementHold, TraceHandle};
 use aether_data::{HandleId, Kind, KindId};
 use aether_kinds::trace::{Nanos, TraceTail, TraceTailResult};
@@ -582,7 +582,7 @@ fn route_mail(
                 kind_name: lookup.kind_name,
                 origin: None,
                 sender: mail.reply_to,
-                payload: mail.payload,
+                payload: MailRef::from(mail.payload),
                 count: mail.count,
                 mail_id: mail.mail_id,
                 root: mail.root,
@@ -1043,7 +1043,7 @@ mod tests {
             let captured = Arc::clone(&self.captured);
             let count = Arc::clone(&self.delivery_count);
             Arc::new(move |dispatch: OwnedDispatch| {
-                captured.write().unwrap().push(dispatch.payload);
+                captured.write().unwrap().push(dispatch.payload.into_vec());
                 count.fetch_add(1, Ordering::SeqCst);
             })
         }

--- a/crates/aether-substrate/src/mail/mod.rs
+++ b/crates/aether-substrate/src/mail/mod.rs
@@ -9,11 +9,13 @@
 
 pub mod capability;
 pub mod helpers;
+pub mod mail_ref;
 pub mod mailer;
 pub mod outbound;
 pub mod registry;
 
 pub use capability::{CapabilityRegistry, MailboxCaps};
+pub use mail_ref::MailRef;
 pub use mailer::Mailer;
 pub use outbound::{DroppingBackend, EgressBackend, EgressEvent, HubOutbound, RecordingBackend};
 pub use registry::{InboxHandler, InlineHandler, MailboxEntry, OwnedDispatch, Registry};

--- a/crates/aether-substrate/src/mail/registry.rs
+++ b/crates/aether-substrate/src/mail/registry.rs
@@ -23,7 +23,7 @@ use std::sync::{Arc, RwLock};
 use rustc_hash::FxHashMap;
 
 use crate::handle_store::schema_contains_ref;
-use crate::mail::{KindId, MailId, MailboxId, ReplyTo};
+use crate::mail::{KindId, MailId, MailRef, MailboxId, ReplyTo};
 use std::error;
 
 /// Test-only helper that builds a [`MailDispatch`] with empty
@@ -72,7 +72,7 @@ pub(crate) fn test_owned_dispatch(
         kind_name: kind_name.to_owned(),
         origin: None,
         sender: ReplyTo::NONE,
-        payload: payload.to_vec(),
+        payload: MailRef::from(payload.to_vec()),
         count,
         mail_id: MailId::NONE,
         root: MailId::NONE,
@@ -163,11 +163,13 @@ pub struct OwnedDispatch {
     /// Remote reply target of the mail (ADR-0008 / ADR-0037 /
     /// ADR-0042). Carries the correlation id for reply-routing.
     pub sender: ReplyTo,
-    /// Payload bytes (the kind's encoded representation per ADR-0019).
-    /// Owned `Vec<u8>` — handlers move this into the downstream
-    /// envelope rather than cloning the borrowed slice every
-    /// dispatch (the perf win called out in iamacoffeepot/aether#848).
-    pub payload: Vec<u8>,
+    /// Payload bytes (the kind's encoded representation per ADR-0019),
+    /// held as a [`MailRef`] (ADR-0087, iamacoffeepot/aether#1104).
+    /// Phase 1 only ever carries `MailRef::Owned` — handlers move it
+    /// into the downstream envelope rather than cloning every dispatch
+    /// (the perf win called out in iamacoffeepot/aether#848); Phase 2
+    /// adds the zero-copy `InRing` ref. Read via [`MailRef::bytes`].
+    pub payload: MailRef,
     /// Kind-implied item count.
     pub count: u32,
     /// ADR-0080 §1: the producer-minted identity of this mail.
@@ -1135,7 +1137,7 @@ mod tests {
             kind_name: "aether.tick".to_owned(),
             origin: Some("physics".to_owned()),
             sender: ReplyTo::NONE,
-            payload: Vec::new(),
+            payload: MailRef::from(Vec::new()),
             count: 3,
             mail_id: MailId::NONE,
             root: MailId::NONE,
@@ -1622,7 +1624,10 @@ mod tests {
         let handler: Arc<dyn InboxHandler> = Arc::new(move |dispatch: OwnedDispatch| {
             // Payload moves straight into the captured Vec — no clone
             // or `to_vec()` on a borrowed slice.
-            collected_for_handler.lock().unwrap().push(dispatch.payload);
+            collected_for_handler
+                .lock()
+                .unwrap()
+                .push(dispatch.payload.into_vec());
         });
 
         handler.enqueue(OwnedDispatch {
@@ -1630,7 +1635,7 @@ mod tests {
             kind_name: "aether.audio.note_on".to_owned(),
             origin: None,
             sender: ReplyTo::NONE,
-            payload: vec![1, 2, 3],
+            payload: MailRef::from(vec![1, 2, 3]),
             count: 1,
             mail_id: MailId::NONE,
             root: MailId::NONE,
@@ -1641,7 +1646,7 @@ mod tests {
             kind_name: "aether.audio.note_on".to_owned(),
             origin: None,
             sender: ReplyTo::NONE,
-            payload: vec![4, 5, 6, 7],
+            payload: MailRef::from(vec![4, 5, 6, 7]),
             count: 1,
             mail_id: MailId::NONE,
             root: MailId::NONE,
@@ -1679,7 +1684,7 @@ mod tests {
             kind_name: "aether.fs.write".to_owned(),
             origin: Some("aether.fs".to_owned()),
             sender: ReplyTo::NONE,
-            payload: vec![0xAB, 0xCD],
+            payload: MailRef::from(vec![0xAB, 0xCD]),
             count: 1,
             mail_id: MailId::NONE,
             root: MailId::NONE,
@@ -1689,7 +1694,7 @@ mod tests {
         let received = rx.try_recv().expect("hand-rolled enqueue should send");
         assert_eq!(received.kind, KindId(42));
         assert_eq!(received.kind_name, "aether.fs.write");
-        assert_eq!(received.payload, vec![0xAB, 0xCD]);
+        assert_eq!(received.payload.into_vec(), vec![0xAB, 0xCD]);
         assert!(
             rx.try_recv().is_err(),
             "exactly one enqueue should send exactly one envelope",

--- a/crates/aether-substrate/tests/native_actor_macro.rs
+++ b/crates/aether-substrate/tests/native_actor_macro.rs
@@ -25,8 +25,8 @@ use std::time::{Duration, Instant};
 
 use aether_data::{Kind, ReplyTo};
 use aether_substrate::handle_store::HandleStore;
-use aether_substrate::mail::MailId;
 use aether_substrate::mail::registry::OwnedDispatch;
+use aether_substrate::mail::{MailId, MailRef};
 use aether_substrate::{
     Actor, BootError, Builder, BuiltChassis, Chassis, Mailer, NativeActor, NativeCtx,
     NativeInitCtx, NeverDriver, PassiveChassis, Registry, mail::MailboxId,
@@ -142,7 +142,7 @@ fn push_envelope<K: Kind>(registry: &Registry, recipient: &str, payload: &K) {
         kind_name: K::NAME.to_owned(),
         origin: None,
         sender: ReplyTo::NONE,
-        payload: bytes,
+        payload: MailRef::from(bytes),
         count: 1,
         mail_id: MailId::NONE,
         root: MailId::NONE,


### PR DESCRIPTION
## Summary

Phase 1 of ADR-0087 (the mail blob is the unit of dispatch), under tracker iamacoffeepot/aether#1101. Introduces `MailRef` — the payload handle an actor inbox envelope (`OwnedDispatch`) carries — and threads it through every construction, read, and move site. Reads go through `MailRef::bytes()`; the few move/clone sites use `into_vec()` / `bytes().to_vec()`.

Phase 1 ships **only the `Owned` variant** — a heap `Box<[u8]>`, byte-for-byte the `Vec<u8>` payload it replaces. **No behaviour change.** This is the representation step that de-risks the per-producer rings before the zero-copy `InRing` variant lands in Phase 2 (iamacoffeepot/aether#1105).

## Design note

`MailRef` is a single-variant `enum { Owned(Box<[u8]>) }` rather than declaring `InRing { ring, off }` up front. Declaring `InRing` now would add an unused `RingId` type and `unreachable!()` accessor arms (`bytes` / `into_vec` can't resolve a ring that does not exist yet) — dead code Phase 2 rewrites anyway, since those accessors need ring context. The single-variant enum still locks the construction shape (`MailRef::Owned(..)`), so Phase 2 adds the second variant without churning any construction site, which was the de-risking goal.

The ripple into `aether-capabilities` is intended: capabilities receive `OwnedDispatch` on their inboxes too, so they carry ref-inboxes alongside native actors per ADR-0087.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` — 1214 passed, 0 failed (incl. 2 new `MailRef` unit tests)
- [x] `cargo fmt --check`
- [x] wasm32 component cross-build (all four component crates)
- [x] RustRover `get_file_problems` (`errorsOnly:false`, qodana-equivalent) over all 19 changed files — clean

Closes iamacoffeepot/aether#1104

🤖 Generated with [Claude Code](https://claude.com/claude-code)
