### PR TITLE
perf(substrate): buffer native handler sends into per-actor rings (2b)

### DIFF
--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -363,8 +363,11 @@ mod native {
             let settlement_registry = self.mailer.settlement_registry().cloned();
             let mut pre_settlements = Vec::with_capacity(pre.len());
             for envelope in pre {
-                let mail_id =
-                    ctx.send_envelope_as_root(envelope.recipient, envelope.kind, &envelope.payload);
+                let mail_id = ctx.send_envelope_as_root(
+                    envelope.recipient,
+                    envelope.kind,
+                    envelope.payload.bytes(),
+                );
                 if let Some(reg) = settlement_registry.as_deref() {
                     pre_settlements.push(reg.subscribe_settlement(mail_id));
                 }

--- a/crates/aether-capabilities/src/trace.rs
+++ b/crates/aether-capabilities/src/trace.rs
@@ -94,7 +94,7 @@ mod native {
                 }
             };
             for mail in resolved {
-                let _ = ctx.send_envelope_traced(mail.recipient, mail.kind, &mail.payload);
+                let _ = ctx.send_envelope_traced(mail.recipient, mail.kind, mail.payload.bytes());
             }
             ctx.reply(&DispatchTracedAck::Ok { root });
         }
@@ -232,6 +232,12 @@ mod native {
                     ],
                 },
             );
+            // 2b: the handler buffers its forwarded envelopes into the
+            // actor's send-side ring; they route on handler-end flush.
+            // Driving the handler directly (no dispatch loop), we drop the
+            // ctx to trigger that flush — mirroring `dispatch_loop_run`
+            // dropping its per-envelope ctx — before inspecting the sink.
+            drop(ctx);
 
             let snapshot = captured
                 .lock()

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -47,8 +47,65 @@ use std::time::{Duration, Instant};
 use crate::actor::native::envelope::Envelope;
 use crate::chassis::ctx::ChassisCtx;
 use crate::mail::mailer::Mailer;
-use crate::mail::{KindId, Mail, MailId, MailboxId, ReplyTarget, ReplyTo};
+use crate::mail::ring::{MailRing, OutMail, RingFull};
+use crate::mail::{KindId, Mail, MailId, MailRef, MailboxId, ReplyTarget, ReplyTo};
 use crate::runtime::lifecycle::{FatalAborter, PanicAborter};
+
+/// Per-actor outbound ring capacity (ADR-0087 / 2b). Sized to hold a
+/// typical handler's small-mail fan-out as one blob; a blob that
+/// doesn't fit (a large payload, or a very wide fan-out) degrades to
+/// the [`MailRef::Owned`] copy-out valve in [`NativeBinding::flush_outbound`]
+/// rather than blocking — the large-payload zero-copy path is the
+/// deferred fork on iamacoffeepot/aether#1105.
+const ACTOR_RING_BYTES: usize = 64 * 1024;
+
+/// One outbound mail a handler buffered, pending flush. The payload
+/// bytes live in [`OutboundBuffer::scratch`] at `[payload_off,
+/// payload_off + payload_len)`; everything else is the route metadata
+/// (correlation-derived `reply_to`/`mail_id`, inherited lineage) the
+/// flush stamps onto the [`Mail`] it builds.
+struct PendingMail {
+    recipient: u64,
+    kind: u64,
+    payload_off: usize,
+    payload_len: usize,
+    count: u32,
+    reply_to: ReplyTo,
+    mail_id: MailId,
+    root: MailId,
+    parent_mail: Option<MailId>,
+}
+
+/// Per-actor send-side buffer that forms blobs (ADR-0087 / 2b). A
+/// handler's outbound mail accumulates here during dispatch and flushes
+/// as one ring blob at handler end (or before a blocking `wait_reply`).
+///
+/// `scratch` and `mails` are **reused** across handlers (cleared, not
+/// freed, after each flush) so buffering a send is allocation-free once
+/// warm — the win the blob is after, since a per-send heap allocation is
+/// exactly the cost Phase 0 located. `ring` is lazily created on first
+/// flush so actors that never buffer (wasm trampolines, inline-only
+/// caps) pay no ring allocation.
+struct OutboundBuffer {
+    /// Lazily allocated on first flush. `Arc` so each minted
+    /// [`MailRef::InRing`] carries the ring's lifetime by refcount.
+    ring: Option<Arc<MailRing>>,
+    /// Reused payload arena: each buffered send appends its bytes here.
+    scratch: Vec<u8>,
+    /// Reused per-mail metadata, parallel to the payload slices in
+    /// `scratch`.
+    mails: Vec<PendingMail>,
+}
+
+impl OutboundBuffer {
+    fn new() -> Self {
+        Self {
+            ring: None,
+            scratch: Vec::new(),
+            mails: Vec::new(),
+        }
+    }
+}
 
 /// Per-actor binding state every native capability owns. Each
 /// capability constructs one at boot via [`NativeBinding::new`] and
@@ -111,6 +168,22 @@ pub struct NativeBinding {
     /// Substrate-shutdown (channel disconnect) flows through the same
     /// drain → close → exit path without setting the flag.
     shutdown_flag: Arc<AtomicBool>,
+    /// ADR-0087 / 2b (iamacoffeepot/aether#1105): per-actor send-side
+    /// blob buffer. The per-handler [`super::ctx::NativeCtx`] /
+    /// [`super::mailbox::NativeActorMailbox`] send path buffers into
+    /// this (via [`Self::push_envelope_buffered`]); the handler-end
+    /// flush ([`Self::flush_outbound`], driven by `NativeCtx`'s `Drop`
+    /// and `wait_reply`) forms one ring blob and routes a
+    /// [`MailRef::InRing`] per mail.
+    ///
+    /// `Mutex` only for the `&self` interior-mutability + `Sync`
+    /// requirements — the buffer has a single logical producer (this
+    /// actor's dispatcher thread, only during its own handler dispatch),
+    /// so the lock is uncontended. Spawned-worker sends
+    /// ([`super::spawn_thread`]) and wasm-guest sends run on other
+    /// threads / a different path and stay on the eager [`Self::send_mail`]
+    /// route, preserving the ring's single-writer discipline.
+    outbound: Mutex<OutboundBuffer>,
 }
 
 impl NativeBinding {
@@ -144,6 +217,7 @@ impl NativeBinding {
             aborter,
             spawner,
             shutdown_flag: Arc::new(AtomicBool::new(false)),
+            outbound: Mutex::new(OutboundBuffer::new()),
         }
     }
 
@@ -427,6 +501,155 @@ impl NativeBinding {
         mail_id
     }
 
+    /// ADR-0087 / 2b: the buffering counterpart to
+    /// [`Self::push_envelope_returning_root`], used by the per-handler
+    /// send surface ([`super::ctx::NativeCtx`] /
+    /// [`super::mailbox::NativeActorMailbox`]). Rather than allocating an
+    /// owned `Vec` and routing immediately, it copies the bytes into the
+    /// reused per-actor scratch arena and records the route
+    /// metadata; [`Self::flush_outbound`] forms the blob and routes at
+    /// handler end (or before a blocking `wait_reply`).
+    ///
+    /// `record_sent` stays **eager** (fired here, at send time, not at
+    /// flush) so the chain's `in_flight` is exact and settlement
+    /// (ADR-0082) never settles early — only the route + enqueue is
+    /// deferred. Returns the minted `MailId` (== the new root when
+    /// `inherited_root.is_none()`) exactly like the eager variant, so
+    /// settlement subscription works unchanged.
+    ///
+    /// # Panics
+    /// Panics if the outbound-buffer mutex is poisoned — fail-fast per
+    /// ADR-0063.
+    pub fn push_envelope_buffered(
+        &self,
+        recipient: u64,
+        kind: u64,
+        bytes: &[u8],
+        count: u32,
+        parent_mail: Option<MailId>,
+        inherited_root: Option<MailId>,
+    ) -> MailId {
+        let correlation = self.correlation.fetch_add(1, Ordering::AcqRel) + 1;
+        let recipient_id = MailboxId(recipient);
+        let reply_to =
+            ReplyTo::with_correlation(ReplyTarget::Component(self.self_mailbox), correlation);
+        let mail_id = MailId::new(self.self_mailbox, correlation);
+        let root = inherited_root.unwrap_or(mail_id);
+        // Eager producer hook (see doc) — identical to the eager path.
+        self.mailer.record_sent(
+            mail_id,
+            root,
+            parent_mail,
+            self.self_mailbox,
+            recipient_id,
+            KindId(kind),
+        );
+        let mut buf = self
+            .outbound
+            .lock()
+            .expect("outbound buffer poisoned; fail-fast per ADR-0063");
+        let payload_off = buf.scratch.len();
+        buf.scratch.extend_from_slice(bytes);
+        buf.mails.push(PendingMail {
+            recipient,
+            kind,
+            payload_off,
+            payload_len: bytes.len(),
+            count,
+            reply_to,
+            mail_id,
+            root,
+            parent_mail,
+        });
+        mail_id
+    }
+
+    /// ADR-0087 / 2b: flush the buffered outbound mail as one ring blob.
+    /// Called at handler end (via [`super::ctx::NativeCtx`]'s `Drop`) and
+    /// before a blocking [`Self::wait_reply`] (else the awaited mail
+    /// never goes out). A no-op when nothing is buffered.
+    ///
+    /// Forms the blob with one [`MailRing::push_blob`]; on success mints
+    /// one [`MailRef::InRing`] per mail (the recipient reads the bytes in
+    /// place). On [`RingFull`] — a transient-full ring or a blob larger
+    /// than the ring — the never-block copy-out valve materializes each
+    /// mail as [`MailRef::Owned`] instead (the same allocation the eager
+    /// path pays). Either way the route metadata is identical, so the
+    /// dispatch read path is unchanged.
+    ///
+    /// The buffer lock is released **before** routing: `Mailer::push` can
+    /// run an inline handler synchronously, and holding the lock across
+    /// arbitrary handler code would be a needless contention/re-entrancy
+    /// hazard. A single drain suffices — the buffer is written only by
+    /// this actor's per-handler send path, never re-entrantly during
+    /// routing (inline handlers receive a `MailDispatch`, not a
+    /// buffering `NativeCtx`).
+    ///
+    /// # Panics
+    /// Panics if the outbound-buffer mutex is poisoned — fail-fast per
+    /// ADR-0063.
+    pub fn flush_outbound(&self) {
+        let routed: Vec<Mail> = {
+            let mut buf = self
+                .outbound
+                .lock()
+                .expect("outbound buffer poisoned; fail-fast per ADR-0063");
+            if buf.mails.is_empty() {
+                return;
+            }
+            let build = |p: &PendingMail, payload: MailRef| {
+                Mail::new(MailboxId(p.recipient), KindId(p.kind), payload, p.count)
+                    .with_reply_to(p.reply_to)
+                    .with_lineage(p.mail_id, p.root, p.parent_mail)
+            };
+            // Inner scope: the destructured borrows + `out_mails` (which
+            // borrows `scratch`) must end before the `clear()`s reborrow
+            // `buf`. `routed` owns its data (owned `MailRef`s / `Arc`
+            // clones), so it escapes the scope cleanly.
+            let routed: Vec<Mail> = {
+                let OutboundBuffer {
+                    ring,
+                    scratch,
+                    mails,
+                } = &mut *buf;
+                let ring =
+                    ring.get_or_insert_with(|| Arc::new(MailRing::with_capacity(ACTOR_RING_BYTES)));
+                // Lazy front-advance so prior blobs whose consumers have
+                // released free their space before we size this write.
+                ring.reclaim();
+                let out_mails: Vec<OutMail<'_>> = mails
+                    .iter()
+                    .map(|p| OutMail {
+                        recipient: p.recipient,
+                        kind: p.kind,
+                        payload: &scratch[p.payload_off..p.payload_off + p.payload_len],
+                    })
+                    .collect();
+                match ring.push_blob(&out_mails) {
+                    Ok(locs) => mails
+                        .iter()
+                        .zip(locs)
+                        .map(|(p, loc)| build(p, MailRef::in_ring(Arc::clone(ring), loc)))
+                        .collect(),
+                    Err(RingFull) => mails
+                        .iter()
+                        .map(|p| {
+                            let bytes =
+                                scratch[p.payload_off..p.payload_off + p.payload_len].to_vec();
+                            build(p, MailRef::from(bytes))
+                        })
+                        .collect(),
+                }
+            };
+            buf.scratch.clear();
+            buf.mails.clear();
+            routed
+        };
+        for mail in routed {
+            self.mailer.push(mail);
+        }
+    }
+
     /// Block this actor's thread until a mail of `expected_kind`
     /// (and, when `expected_correlation != 0`, also matching that
     /// correlation id) arrives, then copy up to `out.len()` bytes of
@@ -448,6 +671,11 @@ impl NativeBinding {
         timeout_ms: u32,
         expected_correlation: u64,
     ) -> i32 {
+        // ADR-0087 / 2b: flush buffered outbound mail before blocking —
+        // a send-then-wait_reply in the same handler would otherwise
+        // deadlock, since the awaited reply depends on a mail still
+        // sitting unsent in the blob buffer.
+        self.flush_outbound();
         let Some(inbox_mutex) = self.inbox.get() else {
             tracing::error!(
                 target: "aether_substrate::native_transport",
@@ -772,5 +1000,155 @@ mod tests {
         let mut buf = [0u8; 16];
         let rc = transport.wait_reply(0xABCD, &mut buf, 100, 0);
         assert_eq!(rc, -3);
+    }
+
+    /// 2b: the buffered send path holds mail until flush, then forms one
+    /// blob and routes each mail to its recipient with bytes + kind
+    /// intact. Nothing reaches the sink before `flush_outbound`.
+    #[test]
+    fn buffered_sends_route_only_after_flush() {
+        let (registry, mailer) = fresh_substrate();
+        let (tx, rx) = mpsc::channel::<Envelope>();
+        registry.register_inbox("test.sink", forward_to_envelope_sender(tx));
+        let recipient = registry.lookup("test.sink").unwrap();
+        let transport = NativeBinding::new_for_test(mailer, MailboxId(0x5151));
+
+        transport.push_envelope_buffered(recipient.0, 7, &[1, 2, 3], 1, None, None);
+        transport.push_envelope_buffered(recipient.0, 9, &[4, 5], 1, None, None);
+        assert!(
+            rx.try_recv().is_err(),
+            "buffered sends must not route before flush"
+        );
+
+        transport.flush_outbound();
+        let a = rx.try_recv().expect("first mail delivered after flush");
+        let b = rx.try_recv().expect("second mail delivered after flush");
+        assert_eq!(a.payload.bytes(), &[1, 2, 3]);
+        assert_eq!(a.kind, KindId(7));
+        assert_eq!(b.payload.bytes(), &[4, 5]);
+        assert_eq!(b.kind, KindId(9));
+        // Buffer drained — a second flush is a no-op.
+        transport.flush_outbound();
+        assert!(rx.try_recv().is_err());
+    }
+
+    /// 2b: a payload larger than the per-actor ring degrades to the
+    /// `Owned` copy-out valve rather than panicking, still delivering the
+    /// bytes intact (the large-payload zero-copy path is deferred).
+    #[test]
+    fn buffered_oversized_payload_flushes_via_copy_out() {
+        let (registry, mailer) = fresh_substrate();
+        let (tx, rx) = mpsc::channel::<Envelope>();
+        registry.register_inbox("test.sink", forward_to_envelope_sender(tx));
+        let recipient = registry.lookup("test.sink").unwrap();
+        let transport = NativeBinding::new_for_test(mailer, MailboxId(0x6262));
+
+        // Larger than the whole ring — never fits, so the valve copies out.
+        let big = vec![0xABu8; ACTOR_RING_BYTES + 4096];
+        transport.push_envelope_buffered(recipient.0, 3, &big, 1, None, None);
+        transport.flush_outbound();
+
+        let env = rx
+            .try_recv()
+            .expect("oversized mail still delivered via copy-out");
+        assert_eq!(env.payload.len(), big.len());
+        assert_eq!(env.payload.bytes(), &big[..]);
+    }
+
+    /// 2b: flushing an empty buffer is a no-op — the common idempotent
+    /// case, since `NativeCtx::Drop` flushes every handler and most send
+    /// nothing. Must not panic or allocate a ring.
+    #[test]
+    fn buffered_flush_empty_is_noop() {
+        let (_registry, mailer) = fresh_substrate();
+        let transport = NativeBinding::new_for_test(mailer, MailboxId(0x7373));
+        transport.flush_outbound();
+        transport.flush_outbound();
+    }
+
+    /// 2b load-bearing race: the producer flushes tagged blobs into its
+    /// ring while consumer threads read each `InRing` payload in place
+    /// and drop the envelope (RAII-releasing the blob lock). A reused
+    /// region — the producer overwriting bytes a consumer is mid-read on
+    /// — would surface as a tag mismatch. This lifts the 2a ring stress
+    /// test onto the full 2b path: buffer → flush → route → mpsc →
+    /// consumer drop. Soaked via the `flaky_` duplicate below.
+    #[test]
+    fn buffered_concurrent_flush_and_consumer_release() {
+        use std::thread;
+
+        let (registry, mailer) = fresh_substrate();
+        let (tx, rx) = mpsc::channel::<Envelope>();
+        registry.register_inbox("test.sink", forward_to_envelope_sender(tx));
+        let recipient = registry.lookup("test.sink").unwrap();
+        let transport = NativeBinding::new_for_test(mailer, MailboxId(0x9191));
+
+        let rx = Arc::new(Mutex::new(rx));
+        let done = Arc::new(AtomicBool::new(false));
+        let consumed = Arc::new(AtomicU64::new(0));
+        let n_consumers = 4;
+
+        let consumers: Vec<_> = (0..n_consumers)
+            .map(|_| {
+                let rx = Arc::clone(&rx);
+                let done = Arc::clone(&done);
+                let consumed = Arc::clone(&consumed);
+                thread::spawn(move || {
+                    loop {
+                        let got = {
+                            let guard = rx.lock().expect("rx mutex poisoned");
+                            guard.recv_timeout(Duration::from_millis(20))
+                        };
+                        match got {
+                            Ok(env) => {
+                                let bytes = env.payload.bytes();
+                                let tag = bytes[0];
+                                assert!(
+                                    bytes.iter().all(|&b| b == tag),
+                                    "decode-in-place saw a reused region: expected tag {tag}"
+                                );
+                                drop(env); // RAII release of the blob lock
+                                consumed.fetch_add(1, Ordering::AcqRel);
+                            }
+                            // Empty for the timeout: exit only once the
+                            // producer is done (channel fully drained).
+                            Err(_) if done.load(Ordering::Acquire) => break,
+                            Err(_) => {}
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        let mut sent = 0u64;
+        for i in 0..4_000u32 {
+            let tag = (i & 0xff) as u8;
+            let n = (i % 4 + 1) as usize;
+            let payload = vec![tag; 8 + (i as usize % 24)];
+            for _ in 0..n {
+                transport.push_envelope_buffered(recipient.0, 7, &payload, 1, None, None);
+                sent += 1;
+            }
+            transport.flush_outbound();
+        }
+        // All flushes returned synchronously, so every envelope is in the
+        // channel before we signal done.
+        done.store(true, Ordering::Release);
+        for h in consumers {
+            h.join().expect("consumer thread joins");
+        }
+        assert_eq!(
+            consumed.load(Ordering::Acquire),
+            sent,
+            "every flushed mail must be consumed"
+        );
+    }
+
+    /// Flake-soak duplicate (per `scripts/flake-soak.sh`) of the 2b
+    /// producer-flush / consumer-release race — run many times in fresh
+    /// processes to surface timing-dependent reclaim bugs.
+    #[test]
+    fn flaky_buffered_concurrent_flush_and_consumer_release() {
+        buffered_concurrent_flush_and_consumer_release();
     }
 }

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -362,10 +362,10 @@ impl NativeCtx<'_> {
         let root = self.outbound_root();
         let kind = K::ID.0;
         self.binding
-            .send_mail_with_lineage(first.0, kind, &bytes, 1, parent, root);
+            .push_envelope_buffered(first.0, kind, &bytes, 1, parent, root);
         for recipient in recipients {
             self.binding
-                .send_mail_with_lineage(recipient.0, kind, &bytes, 1, parent, root);
+                .push_envelope_buffered(recipient.0, kind, &bytes, 1, parent, root);
         }
     }
 
@@ -398,7 +398,7 @@ impl NativeCtx<'_> {
     /// fire-and-forget case.
     #[must_use]
     pub fn send_envelope_traced(&self, recipient: MailboxId, kind: KindId, bytes: &[u8]) -> MailId {
-        self.binding.push_envelope_returning_root(
+        self.binding.push_envelope_buffered(
             recipient.0,
             kind.0,
             bytes,
@@ -433,7 +433,24 @@ impl NativeCtx<'_> {
         bytes: &[u8],
     ) -> MailId {
         self.binding
-            .push_envelope_returning_root(recipient.0, kind.0, bytes, 1, None, None)
+            .push_envelope_buffered(recipient.0, kind.0, bytes, 1, None, None)
+    }
+}
+
+impl Drop for NativeCtx<'_> {
+    /// ADR-0087 / 2b (iamacoffeepot/aether#1105): handler-end flush. One
+    /// `NativeCtx` is built per dispatched envelope (and one for
+    /// `unwire`), so its scope *is* the handler's lifetime — dropping it
+    /// is the universal "handler finished" hook. Flushing the binding's
+    /// outbound buffer here forms the handler's buffered sends into one
+    /// ring blob and routes them, covering the main dispatch loop, the
+    /// shutdown-drain loop, and `unwire` with a single hook (no
+    /// per-call-site flush to forget and silently drop mail). A
+    /// mid-handler `wait_reply` flushes eagerly
+    /// ([`NativeBinding::wait_reply`]); this catches everything sent
+    /// after the last such flush. Idempotent — an empty buffer no-ops.
+    fn drop(&mut self) {
+        self.binding.flush_outbound();
     }
 }
 
@@ -445,7 +462,7 @@ impl Sender for NativeCtx<'_> {
         K: Kind,
     {
         let bytes = payload.encode_into_bytes();
-        self.binding.send_mail_with_lineage(
+        self.binding.push_envelope_buffered(
             mailbox_id_from_name(R::NAMESPACE).0,
             K::ID.0,
             &bytes,
@@ -466,7 +483,7 @@ impl Sender for NativeCtx<'_> {
         // realistic mail batches stay well below `u32::MAX`.
         #[allow(clippy::cast_possible_truncation)]
         let count = payloads.len() as u32;
-        self.binding.send_mail_with_lineage(
+        self.binding.push_envelope_buffered(
             mailbox_id_from_name(R::NAMESPACE).0,
             K::ID.0,
             bytes,
@@ -479,7 +496,7 @@ impl Sender for NativeCtx<'_> {
     //noinspection DuplicatedCode
     fn send_to_named<K: Kind>(&mut self, name: &str, payload: &K) {
         let bytes = payload.encode_into_bytes();
-        self.binding.send_mail_with_lineage(
+        self.binding.push_envelope_buffered(
             mailbox_id_from_name(name).0,
             K::ID.0,
             &bytes,
@@ -627,7 +644,7 @@ impl MailSender for NativeCtx<'_> {
         K: Kind,
     {
         let bytes = payload.encode_into_bytes();
-        self.binding.send_mail_with_lineage(
+        self.binding.push_envelope_buffered(
             mailbox_id_from_name(R::NAMESPACE).0,
             K::ID.0,
             &bytes,
@@ -648,7 +665,7 @@ impl MailSender for NativeCtx<'_> {
         // realistic mail batches stay well below `u32::MAX`.
         #[allow(clippy::cast_possible_truncation)]
         let count = payloads.len() as u32;
-        self.binding.send_mail_with_lineage(
+        self.binding.push_envelope_buffered(
             mailbox_id_from_name(R::NAMESPACE).0,
             K::ID.0,
             bytes,
@@ -661,7 +678,7 @@ impl MailSender for NativeCtx<'_> {
     //noinspection DuplicatedCode
     fn send_to_named<K: Kind>(&mut self, name: &str, payload: &K) {
         let bytes = payload.encode_into_bytes();
-        self.binding.send_mail_with_lineage(
+        self.binding.push_envelope_buffered(
             mailbox_id_from_name(name).0,
             K::ID.0,
             &bytes,

--- a/crates/aether-substrate/src/actor/native/mailbox.rs
+++ b/crates/aether-substrate/src/actor/native/mailbox.rs
@@ -85,7 +85,12 @@ impl<R: Actor> NativeActorMailbox<'_, R> {
         K: Kind,
     {
         let bytes = payload.encode_into_bytes();
-        self.binding.send_mail(self.mailbox, K::ID.0, &bytes, 1);
+        // 2b: buffer into the actor's send-side ring (chassis-root —
+        // `send` mints a fresh chain, unlike the lineage-aware
+        // `send_traced`). Flushed at handler end by `NativeCtx`'s `Drop`.
+        let _ = self
+            .binding
+            .push_envelope_buffered(self.mailbox, K::ID.0, &bytes, 1, None, None);
     }
 
     /// Send a slice of payloads as a contiguous batch. Cast-only.
@@ -99,7 +104,9 @@ impl<R: Actor> NativeActorMailbox<'_, R> {
         // realistic mail batches stay well below `u32::MAX`.
         #[allow(clippy::cast_possible_truncation)]
         let count = payloads.len() as u32;
-        self.binding.send_mail(self.mailbox, K::ID.0, bytes, count);
+        let _ =
+            self.binding
+                .push_envelope_buffered(self.mailbox, K::ID.0, bytes, count, None, None);
     }
 
     /// ADR-0080: like [`Self::send`] but returns the minted `MailId`
@@ -126,7 +133,7 @@ impl<R: Actor> NativeActorMailbox<'_, R> {
         K: Kind,
     {
         let bytes = payload.encode_into_bytes();
-        self.binding.push_envelope_returning_root(
+        self.binding.push_envelope_buffered(
             self.mailbox,
             K::ID.0,
             &bytes,

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -544,7 +544,7 @@ impl Component {
             None => NO_REPLY_HANDLE,
         };
         self.memory
-            .write(&mut self.store, MAIL_OFFSET as usize, &mail.payload)?;
+            .write(&mut self.store, MAIL_OFFSET as usize, mail.payload.bytes())?;
         // Wasm32 ABI carries `u32` byte lengths; mail payloads are
         // bounded by guest memory size (well below `u32::MAX`).
         #[allow(clippy::cast_possible_truncation)]

--- a/crates/aether-substrate/src/mail/mail_ref.rs
+++ b/crates/aether-substrate/src/mail/mail_ref.rs
@@ -94,6 +94,20 @@ impl MailRef {
         self.bytes().to_vec()
     }
 
+    /// Materialize into the `Owned` variant, releasing any ring lock.
+    /// `Owned` is returned unchanged (no copy); `InRing` copies its
+    /// region out to a heap buffer and drops, freeing the ring region.
+    /// Used where a mail may be held for an unbounded window — parked on
+    /// a missing handle, or queued for cross-engine egress — so it never
+    /// pins a producer ring region for that whole time (2b).
+    #[must_use]
+    pub fn into_owned(self) -> Self {
+        match self {
+            owned @ Self::Owned(_) => owned,
+            in_ring => Self::Owned(in_ring.bytes().to_vec().into_boxed_slice()),
+        }
+    }
+
     /// Payload length in bytes. Reads the `InRing` length field directly —
     /// no region access — so it is valid even without holding the borrow.
     #[must_use]

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -446,7 +446,7 @@ fn route_mail(
             // `root.sender`, which lands here over the wire. Answer the
             // tail and reply to the caller. (In-process callers reach
             // the same ring via `TraceHandle::chassis_host_tail`.)
-            let result = TraceTail::decode_from_bytes(&mail.payload).map_or_else(
+            let result = TraceTail::decode_from_bytes(mail.payload.bytes()).map_or_else(
                 || TraceTailResult::Err {
                     error: "undecodable TraceTail to chassis-host ring".to_owned(),
                 },
@@ -510,10 +510,10 @@ fn route_mail(
     // through with the original bytes. `ref_schema` is `Some` only on
     // that ref-carrying path.
     if let Some(schema) = &lookup.ref_schema {
-        match handle_store::walk_and_resolve(schema, &mail.payload, store) {
+        match handle_store::walk_and_resolve(schema, mail.payload.bytes(), store) {
             Ok(WalkOutcome::Resolved { payload }) => {
                 if let Cow::Owned(bytes) = payload {
-                    mail.payload = bytes;
+                    mail.payload = MailRef::from(bytes);
                 }
                 // Cow::Borrowed: mail.payload already matches the
                 // resolved bytes (no substitutions happened).
@@ -526,6 +526,11 @@ fn route_mail(
                     recipient = ?mail.recipient,
                     "parking mail on missing handle",
                 );
+                // A parked mail sits in the store until the handle
+                // resolves (an unbounded window); materialize it to
+                // `Owned` so it never pins a producer ring region for
+                // that whole time (2b, iamacoffeepot/aether#1105).
+                mail.payload = mail.payload.into_owned();
                 store.park(handle, mail);
                 return;
             }
@@ -582,7 +587,7 @@ fn route_mail(
                 kind_name: lookup.kind_name,
                 origin: None,
                 sender: mail.reply_to,
-                payload: MailRef::from(mail.payload),
+                payload: mail.payload,
                 count: mail.count,
                 mail_id: mail.mail_id,
                 root: mail.root,
@@ -603,7 +608,7 @@ fn route_mail(
                 kind_name: &lookup.kind_name,
                 origin: None,
                 sender: mail.reply_to,
-                payload: &mail.payload,
+                payload: mail.payload.bytes(),
                 count: mail.count,
                 mail_id: mail.mail_id,
                 root: mail.root,
@@ -652,7 +657,7 @@ fn route_mail(
                 outbound.egress_unresolved_mail(
                     recipient,
                     mail.kind,
-                    mail.payload,
+                    mail.payload.into_vec(),
                     mail.count,
                     source_mailbox_id,
                     correlation_id,

--- a/crates/aether-substrate/src/mail/mod.rs
+++ b/crates/aether-substrate/src/mail/mod.rs
@@ -66,7 +66,14 @@ pub type MailKind = KindId;
 pub struct Mail {
     pub recipient: MailboxId,
     pub kind: MailKind,
-    pub payload: Vec<u8>,
+    /// The payload bytes, carried as a [`MailRef`] so a producer that
+    /// buffered this mail into its per-actor ring (ADR-0087 / 2b) routes
+    /// a zero-copy `InRing` reference, while cross-boundary and
+    /// substrate-generated mail carries an `Owned` heap buffer. The whole
+    /// routing path (`route_mail`) is variant-agnostic — it reads
+    /// `payload.bytes()` and only materializes to `Owned` at the few
+    /// sites that move bytes off-engine.
+    pub payload: MailRef,
     pub count: u32,
     pub reply_to: ReplyTo,
     /// ADR-0080 §1: this mail's identity. The producer mints it from
@@ -89,11 +96,16 @@ pub struct Mail {
 
 impl Mail {
     #[must_use]
-    pub fn new(recipient: MailboxId, kind: MailKind, payload: Vec<u8>, count: u32) -> Self {
+    pub fn new(
+        recipient: MailboxId,
+        kind: MailKind,
+        payload: impl Into<MailRef>,
+        count: u32,
+    ) -> Self {
         Self {
             recipient,
             kind,
-            payload,
+            payload: payload.into(),
             count,
             reply_to: ReplyTo::NONE,
             mail_id: MailId::NONE,

--- a/crates/aether-substrate/src/mail/ring.rs
+++ b/crates/aether-substrate/src/mail/ring.rs
@@ -268,13 +268,17 @@ impl MailRing {
     /// return where each mail landed. Initializes the blob lock to
     /// `mails.len()`. **Producer-only.**
     ///
-    /// Returns [`RingFull`] if the blob does not fit even after a wrap;
-    /// the caller's copy-out valve handles that without blocking.
+    /// Returns [`RingFull`] if the blob does not fit — either transiently
+    /// (the ring is full of un-reclaimed blobs) or structurally (the blob
+    /// is larger than the whole ring). Both cases route to the caller's
+    /// copy-out valve, which materializes the mails as owned buffers
+    /// without blocking. A producer (a handler's fan-out) can emit an
+    /// arbitrarily large blob, so an oversized one must degrade rather
+    /// than panic the substrate (2b, iamacoffeepot/aether#1105).
     ///
     /// # Panics
     /// Panics if `mails` is empty (a blob always carries at least one
-    /// mail) or if a single blob is larger than the whole ring (a
-    /// misconfiguration — the ring must be sized for the largest blob).
+    /// mail).
     #[allow(
         clippy::cast_possible_truncation,
         reason = "offsets are bounded by capacity, asserted <= u32::MAX in with_capacity"
@@ -282,11 +286,11 @@ impl MailRing {
     pub fn push_blob(&self, mails: &[OutMail<'_>]) -> Result<Vec<MailLoc>, RingFull> {
         assert!(!mails.is_empty(), "push_blob requires at least one mail");
         let size = Self::blob_size(mails);
-        assert!(
-            size <= self.cap,
-            "blob ({size} B) larger than ring capacity ({} B)",
-            self.cap
-        );
+        // A blob larger than the whole ring can never fit; hand it to the
+        // copy-out valve instead of panicking.
+        if size > self.cap {
+            return Err(RingFull);
+        }
 
         let write = self.write.load(Ordering::Relaxed) as usize;
         let tail_room = self.cap - write;
@@ -617,6 +621,19 @@ mod tests {
         // space (nothing released), so the valve must trigger.
         let r = ring.push_blob(&[out(2, 2, &[0; 64])]);
         assert_eq!(r, Err(RingFull));
+    }
+
+    #[test]
+    fn oversized_blob_returns_ring_full_not_panic() {
+        // A single blob larger than the whole ring degrades to the
+        // copy-out valve rather than panicking (2b: handler fan-out is
+        // unbounded; the substrate must not crash on a big blob).
+        let ring = MailRing::with_capacity(128);
+        let r = ring.push_blob(&[out(1, 1, &[0; 256])]);
+        assert_eq!(r, Err(RingFull));
+        // The ring is untouched — a later in-bounds blob still fits.
+        assert_eq!(ring.live_bytes(), 0);
+        assert!(ring.push_blob(&[out(2, 2, &[7; 16])]).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Phase 2b of ADR-0087 (the mail blob is the unit of dispatch). **Closes** the integration that 2a (iamacoffeepot/aether#1108) set up: wires the per-producer `MailRing` into the live native dispatch path so a handler's fan-out is buffered into one ring blob and recipients receive a zero-copy `MailRef::InRing` instead of a per-send heap allocation. No wire-format or API change for callers; behavior is unchanged end-to-end (1230 tests green).

Greenlit by Phase 0 (iamacoffeepot/aether#1103): fan-out *coordination* dominates the sub-µs handler, and the blob is the substrate for amortizing it. 2b lands the blob **formation + reclamation** on the hot path; the coordination win (work-stealing over blobs) is Phase 3 (iamacoffeepot/aether#1106).

## What lands

- **`Mail.payload: Vec<u8>` → `MailRef`.** The whole routing path (`route_mail`) is now variant-agnostic — it reads `payload.bytes()` and only materializes to `Owned` at the few sites that move bytes off-engine (hub egress) or hold a mail for an unbounded window (handle-park). `Mail::new` takes `impl Into<MailRef>`, so the dozens of `Vec`-passing call sites are unchanged.
- **Per-actor send-side ring + reused scratch buffer on `NativeBinding`.** The per-handler send surface (`NativeCtx` / `NativeActorMailbox`) buffers each send into a reused scratch arena (allocation-free once warm) via `push_envelope_buffered`; `flush_outbound` forms one ring blob and routes a `MailRef::InRing` per mail. `record_sent` stays **eager** so settlement (ADR-0082) is exact.
- **Flush hooks.** `NativeCtx::Drop` is the universal handler-end flush (one ctx per dispatched envelope, so it covers the main loop, the shutdown-drain loop, and `unwire` with a single hook); `wait_reply` flushes first so a send-then-wait in the same handler can't deadlock.
- **Copy-out valve.** `push_blob` now returns `RingFull` (instead of panicking) when a blob exceeds the ring; `flush_outbound` falls back to a `MailRef::Owned` copy — the same allocation the eager path pays — so an oversized fan-out degrades gracefully rather than crashing the substrate.

## Scope decisions

- **Single-producer discipline is preserved.** Only the per-handler `NativeCtx`/`NativeActorMailbox` path buffers. Spawned workers (`InheritCtx`/`RootCtx`) share the parent's `Arc<NativeBinding>` but run on **other threads**, and wasm guests send through `ComponentCtx`, not the binding — both stay on the eager `Owned` path, so exactly one thread ever writes a given ring.
- **Chassis ring deferred.** Off-actor producers (Tick / MCP / lifecycle) are low-rate, single-mail, no fan-out — a width-1 blob is slower than `Owned` (2a microbench), so they keep the proven eager path. Additive later if a forcing function appears.
- **Large-payload zero-copy is the deferred fork** (recorded on iamacoffeepot/aether#1101): a blob bigger than the ring copies out today; landing the bytes once in a pre-allocated buffer is settled when large-file I/O forces ring sizing.

## Test plan

- [x] `cargo nextest run --workspace` — 1230 passed, 0 failed
- [x] New: buffered sends route only after flush (bytes + kind intact); oversized payload degrades via copy-out; empty flush is a no-op
- [x] New **concurrency** test (+ `flaky_` soak duplicate): producer flushes tagged blobs while consumer threads read `InRing` payloads in place and drop (RAII-release) — a reused region would surface as a tag mismatch. Soaked 80× locally, 0 failures.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, `cargo doc`, wasm32 component cross-build — full `scripts/preflight.sh` green

Closes iamacoffeepot/aether#1105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)