### PR TITLE
perf(substrate): blob is the work-stealing unit + inline demux (3b)

### DIFF
--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -315,6 +315,26 @@ fn flaky_emit_settlement_settles_two_level_tree() {
     emit_settlement_settles_two_level_tree();
 }
 
+/// ADR-0087 Phase 3b focused guard: a wide single-source fan-out — one
+/// handler emits to N free recipients in **one blob**, the exact shape
+/// the blob demux runs (claim-or-deposit per recipient, free ones inline
+/// on the demuxing worker). Every injected root must settle, proving the
+/// inline-demux path balances `Sent`/`Finished` for every fanned mail —
+/// a dropped or double-counted demux mail would wedge `in_flight` and
+/// the root would never settle.
+#[test]
+fn emit_settlement_settles_wide_fanout() {
+    emit_settlement_settles_every_root(&fanout(8));
+}
+
+/// Flake-soak duplicate of the 3b wide-fan-out demux — the
+/// inline-vs-deposit (free-vs-busy) claim race across workers is
+/// timing-sensitive (see CLAUDE.md "Flake soak").
+#[test]
+fn flaky_emit_settlement_settles_wide_fanout() {
+    emit_settlement_settles_wide_fanout();
+}
+
 /// Hold path: a `spawn_inherit` worker keeps the root open past the
 /// handler's `Finished`, so settlement is gated on the worker's `Release`
 /// (ADR-0080 §12). Exercises the `HoldOpen` / `Release` producer hooks —

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -617,10 +617,10 @@ impl NativeBinding {
     ///
     /// ADR-0087 Phase 3b: when a pool [`WakeSink`](crate::scheduler::WakeSink)
     /// is wired (every production binding — derived from the chassis
-    /// `Spawner`), the whole blob is pushed as **one**
-    /// [`BlobWork`](super::blob_work::BlobWork) work item rather than
-    /// routed per mail, so a fan-out of N costs one deque push + an
-    /// inline demux instead of N pushes + up to N parked-worker wakeups.
+    /// `Spawner`), the whole blob is pushed as **one** `BlobWork` work
+    /// item rather than routed per mail, so a fan-out of N costs one
+    /// deque push + an inline demux instead of N pushes + up to N
+    /// parked-worker wakeups.
     /// A binding with no `Spawner` (test transports built via
     /// [`Self::new_for_test`]) keeps the eager per-mail route.
     ///

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -615,10 +615,38 @@ impl NativeBinding {
     /// routing (inline handlers receive a `MailDispatch`, not a
     /// buffering `NativeCtx`).
     ///
+    /// ADR-0087 Phase 3b: when a pool [`WakeSink`](crate::scheduler::WakeSink)
+    /// is wired (every production binding — derived from the chassis
+    /// `Spawner`), the whole blob is pushed as **one**
+    /// [`BlobWork`](super::blob_work::BlobWork) work item rather than
+    /// routed per mail, so a fan-out of N costs one deque push + an
+    /// inline demux instead of N pushes + up to N parked-worker wakeups.
+    /// A binding with no `Spawner` (test transports built via
+    /// [`Self::new_for_test`]) keeps the eager per-mail route.
+    ///
     /// # Panics
     /// Panics if the outbound-buffer mutex is poisoned — fail-fast per
     /// ADR-0063.
     pub fn flush_outbound(&self) {
+        self.flush_outbound_inner(true);
+    }
+
+    /// `wait_reply`-side flush: routes the buffered blob **eagerly**
+    /// (per-mail, never as a deferred `BlobWork`). A send-then-`wait_reply`
+    /// handler blocks this thread on the reply, which depends on the sent
+    /// mail being delivered first — deferring it to a `BlobWork` that
+    /// only a worker drains could wedge the wait (e.g. if this binding's
+    /// own worker is the one now parked in the wait). Eager routing
+    /// matches the pre-3b delivery point exactly.
+    fn flush_outbound_eager(&self) {
+        self.flush_outbound_inner(false);
+    }
+
+    /// Seal the open blob, mint a [`MailRef`] per buffered mail, and
+    /// route. `allow_blob` picks the deferred [`BlobWork`] path (handler
+    /// end) vs eager per-mail routing (`wait_reply`); both are no-ops
+    /// when nothing is buffered.
+    fn flush_outbound_inner(&self, allow_blob: bool) {
         let routed: Vec<Mail> = {
             let mut buf = self
                 .outbound
@@ -653,8 +681,19 @@ impl NativeBinding {
                 })
                 .collect()
         };
-        for mail in routed {
-            self.mailer.push(mail);
+
+        // ADR-0087 Phase 3b: push the whole blob as one work item when a
+        // pool sink is wired and the caller allows deferral; the demuxing
+        // worker runs free recipients inline. Otherwise route per mail
+        // (eager `wait_reply` flush, or a test binding with no Spawner).
+        if let (true, Some(sink)) = (allow_blob, self.spawner.as_ref().map(|s| s.wake_sink())) {
+            let blob =
+                super::blob_work::BlobWork::new(routed, Arc::clone(&self.mailer), sink.clone());
+            sink.schedule(blob);
+        } else {
+            for mail in routed {
+                self.mailer.push(mail);
+            }
         }
     }
 
@@ -682,8 +721,10 @@ impl NativeBinding {
         // ADR-0087 / 2b: flush buffered outbound mail before blocking —
         // a send-then-wait_reply in the same handler would otherwise
         // deadlock, since the awaited reply depends on a mail still
-        // sitting unsent in the blob buffer.
-        self.flush_outbound();
+        // sitting unsent in the blob buffer. Route eagerly (3b): the
+        // reply depends on delivery happening before we park, so this
+        // flush must not defer the blob to a worker that might be us.
+        self.flush_outbound_eager();
         let Some(inbox_mutex) = self.inbox.get() else {
             tracing::error!(
                 target: "aether_substrate::native_transport",

--- a/crates/aether-substrate/src/actor/native/blob_work.rs
+++ b/crates/aether-substrate/src/actor/native/blob_work.rs
@@ -1,0 +1,125 @@
+//! [`BlobWork`] — a handler's buffered fan-out as a single
+//! work-stealing unit (ADR-0087 Phase 3b, iamacoffeepot/aether#1113).
+//!
+//! Phase 2b/2c buffer a native handler's outbound mail into one sealed
+//! ring blob; Phase 3a made per-worker deques the scheduler's queue.
+//! 3b ties them together: instead of routing each buffered mail
+//! eagerly (N pushes + up to N parked-worker wakeups for a fan-out of
+//! N), [`crate::actor::native::NativeBinding::flush_outbound`] pushes
+//! the whole blob as **one** `Drainable` onto the producing worker's
+//! deque. A worker pops it (or an idle sibling steals it) and demuxes:
+//!
+//! - **free** recipient (won the `Idle → Ready` CAS) → run its handler
+//!   **inline** on this worker — no inbox round-trip beyond the deposit,
+//!   no notify.
+//! - **busy** recipient (lost the CAS) → its mail is already deposited;
+//!   the holder draining it picks it up (today's wake-loses-CAS path).
+//!
+//! ## How the demux reuses the one router
+//!
+//! `run_cycle` deposits via today's [`Mailer::push`] → `route_mail` for
+//! every mail, so **all** routing concerns are inherited unchanged:
+//! ADR-0045 ref-walk, the settlement/trace brackets (the inline run
+//! goes through `DispatcherSlot::run_cycle` → `dispatch_one`, which owns
+//! `Received`/`Finished` + `record_finished`), and the
+//! `Inline`/`Dropped`/unknown-bubble-up arms. The *only* thing 3b
+//! changes is the wake's destination: inside the [`run_demux`] window, a
+//! free recipient's wake is collected (not deque-pushed) so we can run it
+//! inline here.
+//!
+//! ## Alternative not taken — explicit slot-demux registry (revisit?)
+//!
+//! The other shape (iamacoffeepot/aether#1113 design fork) was a
+//! first-class `MailboxId → (SlotState, Weak<slot>)` table the blob
+//! worker resolves directly, depositing via `ActorRegistry::live_sender`
+//! and routing only non-`Inbox` recipients through `route_mail`. It is
+//! more inspectable, but (1) it splits routing into a fast path + a
+//! `route_mail` fallback that must be kept in lockstep for every future
+//! routing concern, and (2) it adds a second shared read-hot map on the
+//! hottest path — a re-centralization against the grain of ADR-0086/0087
+//! (which removed the central `SegQueue` for per-actor/per-worker
+//! structures). The reuse approach here keeps one router and adds no
+//! shared map. **Reconsider the explicit table only if the scheduler
+//! later needs first-class slot addressing for other consumers**
+//! (affinity-as-data, slot introspection, NUMA placement) — at which
+//! point its real consumers exist and the table earns its keep.
+
+use std::any::Any;
+use std::sync::{Arc, Mutex, PoisonError};
+
+use crate::mail::Mail;
+use crate::mail::mailer::Mailer;
+use crate::scheduler::{BatchBudget, CycleResult, Drainable, WakeSink, run_demux};
+
+/// One sealed ring blob's worth of routed mail, scheduled as a single
+/// `Drainable` (ADR-0087 Phase 3b). One-shot: `run_cycle` demuxes the
+/// mail once and returns [`CycleResult::Idle`]; the popped `Arc` then
+/// drops.
+pub struct BlobWork {
+    /// The blob's mail. `Option` so `run_cycle` (which takes `&self`)
+    /// can `take` the owned `Vec` out for the one-shot demux; `Mutex`
+    /// only for the `&self` interior-mutability + `Sync` requirement —
+    /// a blob is demuxed by exactly one worker, so the lock is
+    /// uncontended.
+    mails: Mutex<Option<Vec<Mail>>>,
+    /// Routes each mail (deposit + wake) on the demuxing worker.
+    mailer: Arc<Mailer>,
+    /// Where an inline recipient that yields mid-drain
+    /// ([`CycleResult::Requeue`]) is re-scheduled — the same own-deque /
+    /// injector path a normal wake uses.
+    sink: WakeSink,
+}
+
+impl BlobWork {
+    /// Wrap a flushed blob's routed mail as a schedulable unit.
+    pub fn new(mails: Vec<Mail>, mailer: Arc<Mailer>, sink: WakeSink) -> Arc<Self> {
+        Arc::new(Self {
+            mails: Mutex::new(Some(mails)),
+            mailer,
+            sink,
+        })
+    }
+}
+
+impl Drainable for BlobWork {
+    fn run_cycle(&self, budget: BatchBudget) -> CycleResult {
+        let Some(mails) = self
+            .mails
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .take()
+        else {
+            // Already demuxed (a blob is one-shot). Defensive — the
+            // scheduler never runs a slot twice without a re-push.
+            return CycleResult::Idle;
+        };
+
+        // Deposit every mail through the one router; harvest the free
+        // recipients it woke (those that won the Idle→Ready CAS).
+        let mailer = &self.mailer;
+        let collected = run_demux(|| {
+            for mail in mails {
+                mailer.push(mail);
+            }
+        });
+
+        // Run each free recipient inline on this worker. A recipient
+        // that yields mid-drain (budget hit) is re-scheduled the same
+        // way a normal wake would spill it; Idle/Closed just drop.
+        for slot in collected {
+            match slot.run_cycle(budget) {
+                CycleResult::Requeue => self.sink.schedule(slot),
+                CycleResult::Idle | CycleResult::Closed => {}
+            }
+        }
+        CycleResult::Idle
+    }
+
+    fn label(&self) -> &'static str {
+        "blob"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/crates/aether-substrate/src/actor/native/mod.rs
+++ b/crates/aether-substrate/src/actor/native/mod.rs
@@ -63,6 +63,7 @@
 //! unknown kinds.
 
 pub mod binding;
+pub(crate) mod blob_work;
 pub mod ctx;
 pub(crate) mod dispatch;
 pub(crate) mod dispatcher_slot;

--- a/crates/aether-substrate/src/scheduler/mod.rs
+++ b/crates/aether-substrate/src/scheduler/mod.rs
@@ -44,3 +44,4 @@ pub use slot::{
     Drainable, SlotState, SlotStateLabel, WakeHandle, WakeSink,
 };
 pub use spin_park::{Acquired, SpinPark};
+pub use worker_deque::run_demux;

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -319,6 +319,22 @@ impl WakeSink {
     pub fn new(injector: Arc<Injector<Arc<dyn Drainable>>>, spin: Arc<SpinPark>) -> Self {
         Self { injector, spin }
     }
+
+    /// Schedule a runnable `slot`: push to the current worker's own
+    /// deque when this runs on a pool worker under the local bound (the
+    /// affinity warm path — no notify, the same worker drains it LIFO),
+    /// else spill to the shared injector and notify the coordinator
+    /// (route-to-spinner / unpark-one). This is the non-demux wake
+    /// destination, shared by [`WakeHandle::wake`], the producer-side
+    /// blob push, and an inline recipient that yielded mid-drain
+    /// (ADR-0087 Phase 3b). The injector push is infallible; shutdown is
+    /// observed through the coordinator's flag.
+    pub(crate) fn schedule(&self, slot: Arc<dyn Drainable>) {
+        if let Err(slot) = worker_deque::try_push_local(slot, worker_deque::sticky_cap()) {
+            self.injector.push(slot);
+            self.spin.notify();
+        }
+    }
 }
 
 /// Sender-side wake hook the chassis hands to the inbox sender path
@@ -359,27 +375,21 @@ impl WakeHandle {
             // gone the state never matters.
             return false;
         };
-        // Affinity (iamacoffeepot/aether#1059, now the deque's own-pop):
-        // if this wake runs on a pool worker and its own deque is under
-        // the local bound, push the slot there so the chain stays warm —
-        // no injector round-trip, no wakeup; the same worker drains it
-        // LIFO on its next loop, invisible to the spin coordinator. The
-        // bound is the stickiness cap (`AETHER_LOCAL_STICKY_MAX`, default
-        // 1): at 1 the chain head stays local and every fan-out extra
-        // spills; higher keeps fan-out extras local too, trading
-        // cross-worker parallelism for locality.
-        //
-        // Otherwise (not a pool thread, or the own deque is at the bound —
-        // fan-out spill), push to the shared injector and notify the
-        // coordinator (iamacoffeepot/aether#1064): it routes to a spinning
-        // worker when one exists and only unparks a dormant worker when
-        // none is. The injector push is infallible; shutdown is observed
-        // through the coordinator's flag, so there is no closed-channel
-        // case to skip here.
-        if let Err(slot) = worker_deque::try_push_local(slot, worker_deque::sticky_cap()) {
-            self.sink.injector.push(slot);
-            self.sink.spin.notify();
-        }
+        // ADR-0087 Phase 3b: if this wake fires inside a blob-demux
+        // window (a `BlobWork` depositing its fan-out on this worker),
+        // hand the just-woken free recipient to the demuxer so it runs
+        // inline on this worker — no deque push, no notify. The demuxer
+        // owns the slot until it runs it; nothing else can see a slot
+        // that's `Ready` but on no deque.
+        let Err(slot) = worker_deque::try_collect_demux(slot) else {
+            return true;
+        };
+        // Not demuxing — today's affinity / spill path
+        // (iamacoffeepot/aether#1059 own-deque, #1064 route-to-spinner):
+        // own deque under the local bound keeps a chain warm with no
+        // notify; otherwise spill to the injector + notify a spinner (or
+        // unpark one). See [`WakeSink::schedule`].
+        self.sink.schedule(slot);
         true
     }
 

--- a/crates/aether-substrate/src/scheduler/worker_deque.rs
+++ b/crates/aether-substrate/src/scheduler/worker_deque.rs
@@ -41,6 +41,16 @@ thread_local! {
     /// on the same thread — never across a `run_cycle`, so the borrows
     /// don't overlap.
     static LOCAL: RefCell<Option<Worker<Slot>>> = const { RefCell::new(None) };
+
+    /// Blob-demux collect buffer (ADR-0087 Phase 3b,
+    /// iamacoffeepot/aether#1113). `Some` only for the duration of a
+    /// [`run_demux`] window — i.e. while a `BlobWork` is depositing its
+    /// mails into recipient inboxes. While set, [`try_collect_demux`]
+    /// captures each just-woken **free** recipient slot here instead of
+    /// letting the wake push it to a deque, so the demuxing worker can
+    /// run those recipients inline (the Phase 3b fan-out win). Outside a
+    /// demux window it is `None` and the wake takes its normal path.
+    static DEMUX: RefCell<Option<Vec<Slot>>> = const { RefCell::new(None) };
 }
 
 /// Move this worker's deque into its thread-local. Called once at the top
@@ -133,6 +143,56 @@ pub fn steal_into_local(
     })
 }
 
+/// Run `deposit` inside a blob-demux window (ADR-0087 Phase 3b) and
+/// return the **free** recipient slots it woke. While `deposit` runs,
+/// any [`WakeHandle::wake`](crate::scheduler::WakeHandle::wake) that
+/// wins its recipient's `Idle → Ready` CAS routes the slot into a
+/// thread-local collect buffer (via [`try_collect_demux`]) instead of
+/// pushing it to a deque — so the caller (`BlobWork::run_cycle`) can run
+/// those recipients **inline** on this worker rather than waking parked
+/// siblings. Busy recipients (lost the CAS) are never collected: their
+/// mail is already deposited and their current holder drains it.
+///
+/// The deposit itself is just today's per-mail routing
+/// (`Mailer::push` → `route_mail`), so every routing concern —
+/// ADR-0045 ref-walk, the settlement/trace brackets, `Inline` /
+/// `Dropped` / unknown bubble-up — is inherited unchanged; only the
+/// wake's *destination* is intercepted.
+///
+/// Panics in debug if a demux window is already open on this thread —
+/// windows never nest (collected recipients run *after* the window
+/// closes, and `Inline` handlers reached during the deposit don't open
+/// their own window), so a nested open is a bug.
+pub fn run_demux<F: FnOnce()>(deposit: F) -> Vec<Slot> {
+    DEMUX.with(|d| {
+        debug_assert!(
+            d.borrow().is_none(),
+            "blob-demux windows must not nest — collected slots run after the window closes"
+        );
+        *d.borrow_mut() = Some(Vec::new());
+    });
+    deposit();
+    DEMUX.with(|d| d.borrow_mut().take().unwrap_or_default())
+}
+
+/// If a blob-demux window is open on this thread, capture `slot` in its
+/// collect buffer and return `Ok(())`; otherwise return `Err(slot)` so
+/// the caller takes its normal wake path. Called by
+/// [`WakeHandle::wake`](crate::scheduler::WakeHandle::wake) after it wins
+/// the `Idle → Ready` CAS — see [`run_demux`].
+pub fn try_collect_demux(slot: Slot) -> Result<(), Slot> {
+    DEMUX.with(|d| {
+        let mut d = d.borrow_mut();
+        match d.as_mut() {
+            Some(buf) => {
+                buf.push(slot);
+                Ok(())
+            }
+            None => Err(slot),
+        }
+    })
+}
+
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,
@@ -142,6 +202,10 @@ mod tests {
     use super::*;
     use crate::scheduler::slot::{BatchBudget, CycleResult, Drainable};
     use std::any::Any;
+
+    use crate::scheduler::slot::{SlotState, WakeHandle, WakeSink};
+    use crate::scheduler::spin_park::SpinPark;
+    use std::sync::Weak;
 
     struct Noop;
     impl Drainable for Noop {
@@ -155,6 +219,33 @@ mod tests {
 
     fn noop() -> Slot {
         Arc::new(Noop)
+    }
+
+    /// A `Drainable` carrying a real [`SlotState`] so a [`WakeHandle`]
+    /// can drive its `Idle → Ready` CAS in the demux-collect tests.
+    struct StatefulNoop {
+        state: Arc<SlotState>,
+    }
+    impl Drainable for StatefulNoop {
+        fn run_cycle(&self, _budget: BatchBudget) -> CycleResult {
+            CycleResult::Idle
+        }
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    /// Build a `StatefulNoop` plus a [`WakeHandle`] over it; the strong
+    /// `Arc` is returned so the handle's `Weak` upgrades.
+    fn stateful_with_wake() -> (Arc<StatefulNoop>, WakeHandle) {
+        let slot = Arc::new(StatefulNoop {
+            state: Arc::new(SlotState::new()),
+        });
+        let slot_dyn: Slot = slot.clone();
+        let weak: Weak<dyn Drainable> = Arc::downgrade(&slot_dyn);
+        let sink = WakeSink::new(Arc::new(Injector::new()), Arc::new(SpinPark::new()));
+        let wake = WakeHandle::new(Arc::clone(&slot.state), weak, sink);
+        (slot, wake)
     }
 
     /// Drain any residue so the per-thread deque starts empty regardless
@@ -226,5 +317,59 @@ mod tests {
         // Nothing anywhere → None.
         drain_local();
         assert!(steal_into_local(0, &[], &Injector::new()).is_none());
+    }
+
+    #[test]
+    fn run_demux_collects_woken_free_slot_not_deque() {
+        install(Worker::new_lifo());
+        drain_local();
+        let (_slot, wake) = stateful_with_wake();
+
+        // Inside a demux window, a wake of a free (Idle) recipient is
+        // captured for inline-run, not pushed to the worker's deque.
+        let collected = run_demux(|| {
+            assert!(wake.wake(), "Idle→Ready CAS should win");
+        });
+        assert_eq!(collected.len(), 1, "the free recipient is collected");
+        assert!(
+            pop_local().is_none(),
+            "a collected recipient must not also land on the deque"
+        );
+    }
+
+    #[test]
+    fn run_demux_skips_busy_slot() {
+        install(Worker::new_lifo());
+        drain_local();
+        let (slot, wake) = stateful_with_wake();
+
+        // Mark the recipient busy (Running) before the window: its wake
+        // loses the CAS, so it is neither collected nor deque-pushed —
+        // its current holder drains the deposited mail.
+        assert!(slot.state.try_wake());
+        assert!(slot.state.enter_running());
+
+        let collected = run_demux(|| {
+            assert!(!wake.wake(), "wake against Running is a no-op");
+        });
+        assert!(collected.is_empty(), "a busy recipient is not collected");
+        assert!(pop_local().is_none());
+    }
+
+    #[test]
+    fn wake_outside_demux_window_takes_normal_path() {
+        // Not a pool worker (no `install`): with no demux window open, a
+        // wake spills to the injector — the normal path is unchanged.
+        let collected = run_demux(|| {});
+        assert!(collected.is_empty(), "empty window collects nothing");
+        let (_slot, wake) = stateful_with_wake();
+        // Outside any `run_demux`, the wake spills (StatefulNoop's sink
+        // injector); `try_collect_demux` returns Err so the slot routes
+        // normally. We assert the demux buffer stays absent.
+        assert!(wake.wake());
+        assert!(
+            try_collect_demux(noop()).is_err(),
+            "no demux window is open outside run_demux"
+        );
     }
 }

--- a/crates/aether-substrate/src/scheduler/worker_deque.rs
+++ b/crates/aether-substrate/src/scheduler/worker_deque.rs
@@ -147,7 +147,7 @@ pub fn steal_into_local(
 /// return the **free** recipient slots it woke. While `deposit` runs,
 /// any [`WakeHandle::wake`](crate::scheduler::WakeHandle::wake) that
 /// wins its recipient's `Idle → Ready` CAS routes the slot into a
-/// thread-local collect buffer (via [`try_collect_demux`]) instead of
+/// thread-local collect buffer (via `try_collect_demux`) instead of
 /// pushing it to a deque — so the caller (`BlobWork::run_cycle`) can run
 /// those recipients **inline** on this worker rather than waking parked
 /// siblings. Busy recipients (lost the CAS) are never collected: their


### PR DESCRIPTION
## Summary

Phase 3b of ADR-0087 — the payoff. The **blob** (a handler's buffered fan-out, one sealed ring region) becomes the work-stealing unit, and a worker demuxes it across recipients. A fan-out of N now costs **one** deque push + an inline demux instead of N per-mail routes + up to N parked-worker wakeups (~4.3µs each, the dominant cost per the iamacoffeepot/aether#1059 latency breakdown). **Closes** iamacoffeepot/aether#1113 and iamacoffeepot/aether#1106.

## What lands

- **`BlobWork`** (`actor/native/blob_work.rs`) — a `Drainable` wrapping one flushed blob's mail. Making it a `Drainable` keeps the 3a deque / injector / `WakeSink` plumbing unchanged: the blob is just another work item whose `run_cycle` demuxes.
- **`flush_outbound` pushes one blob** instead of routing per mail (`actor/native/binding.rs`). The `WakeSink` is derived from the binding's existing `Spawner` field — no new constructor param. A binding with no `Spawner` (test transports) keeps the eager per-mail route.
- **The demux reuses the one router.** `BlobWork::run_cycle` runs today's `Mailer::push` to `route_mail` for every mail inside a `worker_deque::run_demux` window. While the window is open, `WakeHandle::wake` **collects** a just-woken free recipient (won the `Idle to Ready` CAS) instead of pushing it to a deque; the blob then runs those recipients **inline** on the demuxing worker. Busy recipients (lost the CAS) are already deposited and drained by their current holder — today's path.
- **Correctness is inherited, not re-derived.** Because the deposit is the existing router, ADR-0045 ref-walk, the settlement / trace brackets (the inline run goes through `DispatcherSlot::run_cycle` to `dispatch_one`, which owns `Received` / `Finished` + `record_finished`), and the `Inline` / `Dropped` / unknown bubble-up arms all behave exactly as before. The only behavioral change is the wake's destination.
- **`wait_reply` flushes eagerly.** A send-then-wait handler blocks on the reply, which depends on the sent mail being delivered before the producer parks — so that path routes per mail (never deferred to a blob a parked worker could fail to drain). Eager routing matches the pre-3b delivery point exactly.

## Why this shape (design fork)

The demux needs to resolve `recipient to slot` to claim free recipients, and there is no `MailboxId to slot` map today. Two mechanisms were on the table; this PR takes the **reuse-the-router** one. The alternative — an explicit `MailboxId to (SlotState, Weak<slot>)` table the demux resolves directly — was rejected because it (1) splits routing into a fast path plus a `route_mail` fallback that must stay in lockstep for every future routing concern, and (2) adds a second shared read-hot map on the hottest path, a re-centralization against the grain of ADR-0086/0087 (which removed the central queue for per-actor / per-worker structures). The reuse approach keeps one router and adds no shared map. A doc note in `blob_work.rs` records the explicit-table alternative to reconsider only if the scheduler later needs first-class slot addressing for other consumers (affinity-as-data, slot introspection, placement).

## Stickiness-cap sweep (informs 3c, not this PR)

A full-matrix sweep of `AETHER_LOCAL_STICKY_MAX` ∈ {1, 4, 16} on this branch (hop p50, 11 workers) found that **single-level fan-outs are cap-insensitive** here: a handler's direct fan-out runs *inline* on the demuxing worker (collected in the demux buffer), so it never touches `try_push_local`/the cap. fanout-2/4/8, wide-16/32, and the heavy variants stay flat across caps. Only the **multi-level tree** (`A→{B,C}→{D,E,F}`) improves with cap>1 (p50 ~4.4us→~2.4us at cap=16) — there an inline recipient's *own* downstream blob hits the cap, and cap>1 keeps it local instead of spill+notify. So the cap is a lever for multi-level fan-out only; the default stays 1 in this PR. (Single run per cap — directional, not authoritative.)

## Deferred — 3c, tracked in iamacoffeepot/aether#1116

Chunked steal for **wide / heavy** fan-outs — cap inline demux at K and spill the remainder as a stealable sub-blob so idle workers parallelise. 3b runs a blob's whole fan-out inline on **one** worker; a heavy/wide fan-out that the pre-3b path scattered across workers now serializes on the demuxing worker, and the stickiness cap can't fix that (it doesn't gate the inline leaves) — chunked steal is the lever. An idle sibling can already steal the *whole* blob, so only intra-blob parallelism is deferred. The cap-sweep above is the measured forcing function; full design + open questions in iamacoffeepot/aether#1116.

## Test plan

- [x] `cargo nextest run` over `aether-substrate` + `aether-substrate-bundle` — 379 passed, 0 failed, through the `BlobWork` path. Settlement stays exact across fan-out / two-level-tree / depth-chain / hold topologies (`emit_settlement_*`, `depth_chain_settles_every_root`), tick fan-out lineage, and the end-to-end roundtrips.
- [x] New focused guard `emit_settlement_settles_wide_fanout` (`fanout(8)` — one handler to 8 free recipients in one blob) + `flaky_` soak, 150x in fresh processes: 0 failures.
- [x] 3 new `worker_deque` unit tests — `run_demux` collects woken free slots, skips busy ones, no-ops outside a window.
- [x] `scripts/preflight.sh` — fmt + clippy + doc + nextest + wasm32 cross-build green; RustRover `get_file_problems` over the changed files clean.
- [x] Branch fan-out perf sweep (regression sanity): fan-out hop latency stays in-band (fanout-4 p50 ~1.6us / p99 ~11us, fanout-8 p50 ~6us / p99 ~25us). The A/B makespan sweep can't resolve dispatch-glue deltas (iamacoffeepot/aether#1064 finding), so the win is structural — free recipients run inline, dropping the N-1 fan-out notifies — backed by the settlement-exactness correctness gate.

Closes iamacoffeepot/aether#1113. Closes iamacoffeepot/aether#1106. Reference ADR-0087, iamacoffeepot/aether#1101.
