### PR TITLE
perf(substrate): chunked steal for wide fan-out blobs (3c)

### DIFF
--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -335,6 +335,38 @@ fn flaky_emit_settlement_settles_wide_fanout() {
     emit_settlement_settles_wide_fanout();
 }
 
+/// ADR-0087 Phase 3c: with the inline-demux chunk cap forced small
+/// (`K=2`), a wide fan-out splits into stealable sub-blobs that cascade
+/// across workers (`split_off` moves the mail handles — zero ring-byte
+/// copy). Settlement must stay **exact** across the split: the per-mail
+/// eager `Sent` (at buffer time) + dispatch-time `Finished` accounting is
+/// split-invariant, so a dropped or double-counted chunk mail would wedge
+/// `in_flight` and a root would never settle. Also drives the
+/// steal-mid-demux race (a sibling steals a remainder sub-blob while the
+/// producer runs its own chunk).
+#[test]
+#[allow(clippy::print_stderr)]
+fn emit_settlement_settles_under_chunked_demux() {
+    // Force chunking on for this process. SAFETY: set before any actor is
+    // booted (so before any blob flushes / `demux_chunk` is first read),
+    // and nextest isolates each test in its own process — the memoised
+    // first read picks up this value. No restore needed: the OnceLock is
+    // process-lived and the process ends with the test.
+    unsafe {
+        env::set_var("AETHER_BLOB_DEMUX_CHUNK", "2");
+    }
+    emit_settlement_settles_every_root(&fanout(8));
+}
+
+/// Flake-soak duplicate (iamacoffeepot/aether#1116) of the 3c chunked
+/// demux — the steal-mid-demux / inline-vs-deposit race across workers is
+/// timing-sensitive (see CLAUDE.md "Flake soak").
+#[test]
+#[allow(clippy::print_stderr)]
+fn flaky_emit_settlement_settles_under_chunked_demux() {
+    emit_settlement_settles_under_chunked_demux();
+}
+
 /// Hold path: a `spawn_inherit` worker keeps the root open past the
 /// handler's `Finished`, so settlement is gated on the worker's `Release`
 /// (ADR-0080 §12). Exercises the `HoldOpen` / `Release` producer hooks —

--- a/crates/aether-substrate/src/actor/native/blob_work.rs
+++ b/crates/aether-substrate/src/actor/native/blob_work.rs
@@ -15,6 +15,24 @@
 //! - **busy** recipient (lost the CAS) → its mail is already deposited;
 //!   the holder draining it picks it up (today's wake-loses-CAS path).
 //!
+//! ## Chunked spill (Phase 3c, iamacoffeepot/aether#1116)
+//!
+//! 3b runs a whole fan-out blob inline on one worker — optimal latency,
+//! but a heavy / wide fan-out serialises (the pre-blob path scattered the
+//! leaves across workers). 3c caps the inline demux at `K` mails
+//! ([`demux_chunk`], `AETHER_BLOB_DEMUX_CHUNK`): a blob wider than `K`
+//! `split_off`s the remainder and pushes it as a stealable sub-blob
+//! *before* demuxing its own `K` chunk, so an idle sibling can steal the
+//! remainder while this worker runs its chunk (the throughput path); with
+//! no idle worker the producer pops the remainder itself next loop and
+//! continues in `K`-chunks (the latency path, LIFO-warm). The split is a
+//! [`Vec::split_off`] of `Mail` handles — `MailRef`s (ring offsets / owned
+//! boxes) are **moved, never copied**, so the sub-blob references the same
+//! ring regions and the reclaim-lock counts travel with the moved refs.
+//! (Consequence: a spilled sub-blob pins its producer ring region until
+//! its chunk drains; under sustained heavy fan-out the 2a ring-full →
+//! `Owned` valve absorbs the back-pressure — no producer block.)
+//!
 //! ## How the demux reuses the one router
 //!
 //! `run_cycle` deposits via today's [`Mailer::push`] → `route_mail` for
@@ -45,11 +63,39 @@
 //! point its real consumers exist and the table earns its keep.
 
 use std::any::Any;
-use std::sync::{Arc, Mutex, PoisonError};
+use std::env;
+use std::sync::{Arc, Mutex, OnceLock, PoisonError};
 
 use crate::mail::Mail;
 use crate::mail::mailer::Mailer;
 use crate::scheduler::{BatchBudget, CycleResult, Drainable, WakeSink, run_demux};
+
+/// Inline-demux chunk cap K (ADR-0087 Phase 3c, iamacoffeepot/aether#1116).
+/// A `BlobWork` of more than `K` mails demuxes the first `K` inline and
+/// spills the remainder as a stealable sub-blob, so a wide fan-out
+/// parallelises across idle workers (each chunk is at most `K` mails of
+/// work before a steal point) instead of serialising on the one demuxing
+/// worker. Read once from `AETHER_BLOB_DEMUX_CHUNK`; values `< 1` and
+/// unparseable input fall back to the default.
+///
+/// **Default `8`**, set from the iamacoffeepot/aether#1116 K-sweep
+/// (3-sample medians, 11 workers): fan-outs wider than 8 win — fanout-16
+/// ~0.92× / fanout-32 ~0.84× hop-p50 vs the chunking-off 3b baseline, p99
+/// flat-to-better — while fan-outs of `≤ 8` (the common case, and the
+/// narrow-heavy case, which showed no clean win when chunked) stay on the
+/// zero-overhead single-pass demux. Set the knob to `usize::MAX` to
+/// disable chunking entirely (the 3b single-pass behaviour).
+#[must_use]
+fn demux_chunk() -> usize {
+    static CHUNK: OnceLock<usize> = OnceLock::new();
+    *CHUNK.get_or_init(|| {
+        env::var("AETHER_BLOB_DEMUX_CHUNK")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&k| k >= 1)
+            .unwrap_or(8)
+    })
+}
 
 /// One sealed ring blob's worth of routed mail, scheduled as a single
 /// `Drainable` (ADR-0087 Phase 3b). One-shot: `run_cycle` demuxes the
@@ -68,22 +114,42 @@ pub struct BlobWork {
     /// ([`CycleResult::Requeue`]) is re-scheduled — the same own-deque /
     /// injector path a normal wake uses.
     sink: WakeSink,
+    /// Inline-demux chunk cap K (3c). Set from [`demux_chunk`] at
+    /// construction and inherited by spilled sub-blobs, so a blob's whole
+    /// chunk-cascade uses one consistent K (and tests can pin it without
+    /// the process-global env knob).
+    chunk: usize,
 }
 
 impl BlobWork {
-    /// Wrap a flushed blob's routed mail as a schedulable unit.
+    /// Wrap a flushed blob's routed mail as a schedulable unit. The
+    /// chunk cap is read from [`demux_chunk`] (`AETHER_BLOB_DEMUX_CHUNK`).
     pub fn new(mails: Vec<Mail>, mailer: Arc<Mailer>, sink: WakeSink) -> Arc<Self> {
+        Self::with_chunk(mails, mailer, sink, demux_chunk())
+    }
+
+    /// Construct with an explicit chunk cap — the production path goes
+    /// through [`Self::new`] (which reads the env knob); `run_cycle`
+    /// threads `self.chunk` into the spilled sub-blob, and tests pin a
+    /// small `K` to exercise the spill without the process-global knob.
+    fn with_chunk(
+        mails: Vec<Mail>,
+        mailer: Arc<Mailer>,
+        sink: WakeSink,
+        chunk: usize,
+    ) -> Arc<Self> {
         Arc::new(Self {
             mails: Mutex::new(Some(mails)),
             mailer,
             sink,
+            chunk,
         })
     }
 }
 
 impl Drainable for BlobWork {
     fn run_cycle(&self, budget: BatchBudget) -> CycleResult {
-        let Some(mails) = self
+        let Some(mut mails) = self
             .mails
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
@@ -93,6 +159,28 @@ impl Drainable for BlobWork {
             // scheduler never runs a slot twice without a re-push.
             return CycleResult::Idle;
         };
+
+        // ADR-0087 Phase 3c: cap the inline demux at K mails and spill the
+        // remainder as a stealable sub-blob, so a wide / heavy fan-out
+        // parallelises across idle workers instead of serialising here.
+        // `split_off` **moves** the tail `Mail` handles into the new blob
+        // — each carries its `MailRef` (an `Arc<MailRing>` + offsets, or an
+        // owned box), so the payload bytes are never copied; the sub-blob
+        // references the same ring regions and the per-blob reclaim lock
+        // counts travel with the moved refs. Spill *before* demuxing our
+        // chunk so an idle sibling can steal the remainder off our deque
+        // tail while we work; if none is idle we pop it ourselves next loop
+        // (LIFO) and continue — bounded work-before-steal-point is K.
+        let k = self.chunk;
+        if mails.len() > k {
+            let rest = mails.split_off(k);
+            self.sink.schedule(Self::with_chunk(
+                rest,
+                Arc::clone(&self.mailer),
+                self.sink.clone(),
+                k,
+            ));
+        }
 
         // Deposit every mail through the one router; harvest the free
         // recipients it woke (those that won the Idle→Ready CAS).
@@ -121,5 +209,107 @@ impl Drainable for BlobWork {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: a failed lookup/recv is the test signal"
+)]
+mod tests {
+    use super::*;
+    use crate::mail::Registry;
+    use crate::mail::registry::{InboxHandler, OwnedDispatch};
+    use crate::mail::{KindId, MailRef, MailboxId};
+    use crate::scheduler::SpinPark;
+    use crate::test_util::fresh_substrate;
+    use crossbeam_deque::{Injector, Steal};
+    use std::iter;
+    use std::sync::mpsc;
+
+    /// Pop one spilled sub-blob from the injector (the off-pool spill
+    /// target — the test thread isn't a pool worker, so a spill lands
+    /// here rather than on a deque).
+    fn drain_one(inj: &Injector<Arc<dyn Drainable>>) -> Option<Arc<dyn Drainable>> {
+        loop {
+            match inj.steal() {
+                Steal::Success(s) => return Some(s),
+                Steal::Retry => {}
+                Steal::Empty => return None,
+            }
+        }
+    }
+
+    /// Register a sink that forwards each delivered mail's first payload
+    /// byte onto `tx`, and return its mailbox id.
+    fn counting_sink(registry: &Registry, tx: mpsc::Sender<u8>) -> MailboxId {
+        let handler: Arc<dyn InboxHandler> = Arc::new(move |d: OwnedDispatch| {
+            let _ = tx.send(d.payload.bytes()[0]);
+        });
+        registry.register_inbox("sink", handler);
+        registry.lookup("sink").unwrap()
+    }
+
+    fn owned_mails(recipient: MailboxId, n: u8) -> Vec<Mail> {
+        (0..n)
+            .map(|i| Mail::new(recipient, KindId(7), MailRef::from(vec![i]), 1))
+            .collect()
+    }
+
+    /// 3c: a blob wider than `K` splits the first `K` off to demux inline
+    /// and spills the remainder as a sub-blob; running the cascade
+    /// delivers every mail exactly once (no loss, no duplication). 5 mails
+    /// at K=2 -> chunks [0,1] | [2,3] | [4] = 3 `run_cycle`s.
+    #[test]
+    fn chunked_spill_delivers_every_mail_once() {
+        let (registry, mailer) = fresh_substrate();
+        let (tx, rx) = mpsc::channel::<u8>();
+        let recipient = counting_sink(&registry, tx);
+
+        let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
+        let sink = WakeSink::new(Arc::clone(&injector), Arc::new(SpinPark::new()));
+        let blob = BlobWork::with_chunk(owned_mails(recipient, 5), Arc::clone(&mailer), sink, 2);
+
+        let budget = BatchBudget::standard();
+        blob.run_cycle(budget);
+        let mut chunks_run = 1;
+        while let Some(sub) = drain_one(&injector) {
+            sub.run_cycle(budget);
+            chunks_run += 1;
+        }
+
+        assert_eq!(chunks_run, 3, "5 mails at K=2 cascade into 3 chunks");
+        let mut got: Vec<u8> = iter::from_fn(|| rx.try_recv().ok()).collect();
+        got.sort_unstable();
+        assert_eq!(
+            got,
+            vec![0, 1, 2, 3, 4],
+            "every mail delivered exactly once across the chunk cascade"
+        );
+    }
+
+    /// 3c: at the default K (`usize::MAX`, chunking off) a blob demuxes in
+    /// one pass — byte-for-byte the 3b behaviour, no spill.
+    #[test]
+    fn chunk_off_demuxes_single_pass() {
+        let (registry, mailer) = fresh_substrate();
+        let (tx, rx) = mpsc::channel::<u8>();
+        let recipient = counting_sink(&registry, tx);
+
+        let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
+        let sink = WakeSink::new(Arc::clone(&injector), Arc::new(SpinPark::new()));
+        let blob = BlobWork::with_chunk(owned_mails(recipient, 5), mailer, sink, usize::MAX);
+
+        blob.run_cycle(BatchBudget::standard());
+        assert!(
+            matches!(injector.steal(), Steal::Empty),
+            "K=MAX never spills a sub-blob"
+        );
+        assert_eq!(
+            iter::from_fn(|| rx.try_recv().ok()).count(),
+            5,
+            "all mails delivered in the single pass"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Phase 3c of ADR-0087 — the throughput lever 3b deferred. A `BlobWork` wider than `K` demuxes its first `K` mails inline and **spills the remainder as a stealable sub-blob**, so a wide fan-out parallelises across idle workers instead of serialising on the one demuxing worker (the measured 3b regression). **Closes** iamacoffeepot/aether#1116.

## What lands

- **Chunked spill in `BlobWork::run_cycle`** (`actor/native/blob_work.rs`). If `mails.len() > K`, `split_off(K)` and push `BlobWork(remainder)` onto the deque *before* demuxing the K-chunk, so an idle sibling can steal the remainder off the deque tail while this worker runs its chunk (the throughput path); with no idle worker the producer pops it itself next loop (LIFO) and continues in K-chunks (the latency path). Bounded work-before-steal-point is K. A width-N fan-out cascades into `⌈N/K⌉` chunks across whichever workers free up.
- **Zero payload copy.** The split is a `Vec::split_off` of `Mail` **handles** — each carries its `MailRef` (an `Arc<MailRing>` + offsets for `InRing`, or an owned box), which is *moved*, not cloned. So the sub-blob references the same ring regions, the `Arc` isn't even refcount-bumped, and each blob's reclaim-lock count travels with the moved ref. The only ring-byte-copy paths (`into_vec` / `into_owned`) are never on the split path. (A shared-array sub-view was rejected precisely because dispatch can't move out of a shared slice — it would have to `clone`, and cloning an `Owned` payload copies bytes.)
- **`K` is an env knob** (`AETHER_BLOB_DEMUX_CHUNK`, `demux_chunk()`), default **8** (below), set to `usize::MAX` to disable (the 3b single-pass behaviour). The cap is a field on `BlobWork` set at construction and inherited by spilled sub-blobs, so a blob's whole cascade uses one consistent K.
- **Correctness inherited.** Settlement is split-invariant by construction: `Sent` fires eagerly at buffer time (before any blob exists) and `Finished` at dispatch (wherever the mail lands), so partitioning the Vec changes only *which worker* dispatches each mail, never the accounting. Trace, ref-walk, and the `Inline`/`Dropped`/bubble-up arms are unchanged (the demux still routes through `route_mail`).

## Default K=8 — from the iamacoffeepot/aether#1116 K-sweep

Swept `AETHER_BLOB_DEMUX_CHUNK ∈ {off, 4, 8, 16, 64}` on the full topo set + wide {16, 32} + heavy, 11 workers, flat-out. The 3b baseline is the `off` (`K=usize::MAX`) cell on this same binary — chunking-off *is* 3b, so it's an apples-to-apples baseline with no separate build. Hop p50, 3-sample medians for the K=8 vs off decision:

| topology | off p50 | K=8 p50 | Δ | chunks at K=8? |
|---|---|---|---|---|
| fanout-32 | 20542 | 17208 | **0.84×** | yes (32>8) |
| fanout-16 | 10833 | 9917 | **0.92×** | yes (16>8) |
| fanout-8 | 5792 | 5625 | 0.97× | no (≤8) |
| fanout-8-heavy | 15250 | 16541 | 1.08× (noise) | no (≤8) |
| depth-1/2/4/8, tree | — | — | 0.92–1.15× (noise) | no |

The win scales with width (32 > 16), p99 flat-to-better. Fan-outs of ≤8 — the common case *and* narrow-heavy, which showed no clean win when chunked at K=4 — stay on the zero-overhead single-pass path. **High-K smoke (K=64, chunks nothing since max width is 32):** every cell ≈1.0× vs off, and fanout-16/32 snap back from their K=8 wins to ~1.0× — confirming the win is causally the chunking and the machinery is overhead-free when inactive.

Caveat: single machine, flat-out (saturated pool); the parallelism win is conservative here and would be larger with idle cores. The A/B makespan sweep can't resolve sub-µs glue deltas (iamacoffeepot/aether#1064), but the wide-fan-out effect is large and consistent across widths + samples + the K=64 control.

## Test plan

- [x] Unit (`blob_work`): a 5-mail blob at K=2 cascades into 3 chunks delivering every mail exactly once (no loss/dup); K=`usize::MAX` demuxes single-pass with no spill.
- [x] End-to-end (`emit_settlement_settles_under_chunked_demux`, `AETHER_BLOB_DEMUX_CHUNK=2` + `fanout(8)`): settlement stays exact across the chunk-cascade-across-workers + the steal-mid-demux race; `flaky_` soak duplicate.
- [x] Full `cargo nextest` over `aether-substrate` + `aether-substrate-bundle` at the new default K=8 — all green (settlement/fan-out/tick/end-to-end unaffected; nothing in the suite fans out >8).
- [x] `scripts/preflight.sh` — fmt + clippy + doc + nextest + wasm32 cross-build green.
- [x] K-sweep (above) — the validation that set the default.

Closes iamacoffeepot/aether#1116. Reference ADR-0087, iamacoffeepot/aether#1101. Follows iamacoffeepot/aether#1115 (3b).
