### PR TITLE
ci(workflow): broaden perf-compare filter to the whole substrate runtime

### DIFF
--- a/.github/workflows/perf-compare.yml
+++ b/.github/workflows/perf-compare.yml
@@ -8,7 +8,13 @@ name: Perf compare
 # Informational by construction: this workflow's job is NOT in ci.yml's
 # `ci-pass` aggregator, so a regression never blocks a merge (ADR-0085
 # §4). Cost-bounded: path-filtered + label-gated, so it does not run on
-# every PR.
+# every PR. The path filter watches the whole substrate runtime, not a
+# hand-picked file list — the dispatch hot path is spread across
+# scheduler / mail / actor / chassis and moves over time (a narrow list
+# silently went stale and skipped the iamacoffeepot/aether#1116 blob-demux
+# change, which lives in `actor/native/`). Substrate changes the harness
+# can't measure (fs adapters, handle store, capture) produce a no-delta
+# run; suppress those per-PR with the `perf-skip` label.
 
 on:
   pull_request:
@@ -33,15 +39,14 @@ jobs:
         with:
           filters: |
             perf:
-              - 'crates/aether-substrate/src/scheduler/**'
-              - 'crates/aether-substrate/src/mail/**'
+              - 'crates/aether-substrate/src/**'
               - 'crates/aether-substrate-bundle/src/perf/**'
 
   compare:
     name: Compare dispatch perf vs merge-base
     needs: changes
-    # Auto-run on scheduler / mail / perf path changes, or when the
-    # `perf` label is present; force-skip with `perf-skip`.
+    # Auto-run on any substrate-runtime / perf-harness path change, or
+    # when the `perf` label is present; force-skip with `perf-skip`.
     if: >-
       !contains(github.event.pull_request.labels.*.name, 'perf-skip') &&
       (needs.changes.outputs.perf == 'true' ||


### PR DESCRIPTION
## Summary

Broaden the `perf-compare` (ADR-0085 noise-aware dispatch A/B) path filter to watch the **whole substrate runtime** instead of a hand-picked dir list.

## Why

The filter watched `scheduler/** + mail/** + perf/**`. That list silently went stale: the iamacoffeepot/aether#1116 blob-demux change lives in `crates/aether-substrate/src/actor/native/blob_work.rs` — the *unit of dispatch* per ADR-0087 — which isn't under any watched glob, so the perf A/B **skipped entirely** on that PR (caught only because the manual K-sweep ran). The dispatch hot path is spread across `scheduler/ + mail/ + actor/ + chassis/` and moves over time; a hand-picked file list can't track that.

## Change

`crates/aether-substrate/src/**` (the whole runtime) replaces the three narrow globs; `aether-substrate-bundle/src/perf/**` (the harness) stays. Substrate changes the synthetic harness can't measure (fs adapters, handle store, capture) produce a no-delta run — suppress those per-PR with the `perf-skip` label (now created in the repo, alongside `perf`). The job stays informational + label-gated (not in `ci-pass`), so this only widens what *auto-triggers*, never what blocks a merge.

## Test plan

- [x] CI-config-only change; CI self-validates the workflow shape (no Rust touched).
- [x] Verified the gap on iamacoffeepot/aether#1117: the job was `skipping`; adding the `perf` label triggered it (the `labeled` event + condition), confirming the override path works.

Refs ADR-0085, iamacoffeepot/aether#1077. Surfaced while reviewing iamacoffeepot/aether#1117.
