### PR TITLE
perf(substrate): thread-name reverse-lookup via tagged ThreadId (ADR-0088 phase 1)

### DIFF
--- a/crates/aether-capabilities/src/trace_walk.rs
+++ b/crates/aether-capabilities/src/trace_walk.rs
@@ -24,8 +24,35 @@
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
-use aether_data::{KindId, MailId, MailboxId};
+use aether_data::{KindId, MailId, MailboxId, ThreadId};
 use aether_kinds::trace::{DescribeTreeResult, MailNodeWire, Nanos, TraceEvent, TraceRingEntry};
+
+/// Resolve a `Received` event's optional [`ThreadId`] (ADR-0088 §7) to a
+/// display name. The trace event carries a `Copy` [`ThreadId`] (no
+/// per-hop alloc); this cold fold path reverses it to the
+/// `aether-worker-N` / `aether-instanced-…` string for
+/// [`MailNodeWire::thread_name`].
+///
+/// `trace_walk` stays transport-agnostic and compiles in every feature
+/// config (including the wasm-component build), so the registry lookup
+/// is `native`-gated: the in-process substrate reverses through its
+/// process-global registry; the wasm build and the out-of-process MCP
+/// (which can't reach a substrate's registry until the ADR-0088 §6
+/// inventory actor lands) get `None` and the renderer falls back exactly
+/// as before — nothing regresses.
+fn resolve_thread_name(thread_id: Option<ThreadId>) -> Option<String> {
+    let thread_id = thread_id?;
+    #[cfg(feature = "native")]
+    {
+        use aether_substrate::runtime::thread_name;
+        thread_name::resolve(thread_id.0)
+    }
+    #[cfg(not(feature = "native"))]
+    {
+        let _ = thread_id;
+        None
+    }
+}
 
 /// A guided breadth-first walk of one root's mail tree across per-actor
 /// trace rings. Construct with [`TreeWalk::new`], then drive the loop:
@@ -97,7 +124,9 @@ impl TreeWalk {
 /// Fold a flat set of [`TraceRingEntry`]s — gathered from however many
 /// per-actor rings a walk visited — into one [`MailNodeWire`] per
 /// `mail_id`. `Sent` seeds the node's topology fields and `t_sent`;
-/// `Received` adds `t_received` + `thread_name`; `Finished` adds
+/// `Received` adds `t_received` + the dispatching thread's display name
+/// (resolved from the event's `Copy` [`ThreadId`] via the installed
+/// reverse-lookup resolver, ADR-0088 §7); `Finished` adds
 /// `t_finished`. Holds (`HoldOpen` / `Release`) carry no `mail_id` and
 /// are skipped — they aren't tree nodes (ADR-0086 Phase 3 §C). The fold
 /// is order-independent, so a node first seen via `Received` (its `Sent`
@@ -158,11 +187,13 @@ pub fn fold_nodes(entries: impl IntoIterator<Item = TraceRingEntry>) -> Vec<Mail
             TraceEvent::Received {
                 mail_id,
                 t,
-                thread_name,
+                thread_id,
             } => {
                 let node = nodes.entry(mail_id).or_default();
                 node.t_received = Some(t);
-                node.thread_name = thread_name;
+                // ADR-0088 §7: the event carries a `Copy` `ThreadId`;
+                // resolve it to a display name on this cold fold path.
+                node.thread_name = resolve_thread_name(thread_id);
             }
             TraceEvent::Finished { mail_id, t } => {
                 nodes.entry(mail_id).or_default().t_finished = Some(t);
@@ -242,6 +273,12 @@ mod tests {
         }
     }
 
+    /// The thread name every `received` fixture event hashes into a
+    /// `ThreadId`. [`register_fixture_thread_name`] seeds the substrate's
+    /// reverse-lookup registry so the `native`-gated fold path reverses
+    /// it back.
+    const FIXTURE_THREAD_NAME: &str = "aether-worker-0";
+
     fn received(mail_id: MailId, root: MailId) -> TraceRingEntry {
         TraceRingEntry {
             sequence: 0,
@@ -249,9 +286,19 @@ mod tests {
             event: TraceEvent::Received {
                 mail_id,
                 t: Nanos(mail_id.correlation_id + 1),
-                thread_name: Some("aether-worker-0".into()),
+                thread_id: Some(ThreadId::from_name(FIXTURE_THREAD_NAME)),
             },
         }
+    }
+
+    /// Register the fixture thread name in the substrate's process-global
+    /// reverse-lookup registry so [`resolve_thread_name`] reverses the
+    /// fixture `ThreadId` back to its display name (ADR-0088 §7).
+    /// Idempotent — `register` no-ops on a duplicate.
+    fn register_fixture_thread_name() {
+        use aether_substrate::runtime::thread_name;
+        let id = ThreadId::from_name(FIXTURE_THREAD_NAME);
+        thread_name::register(id.0, FIXTURE_THREAD_NAME);
     }
 
     fn finished(mail_id: MailId, root: MailId) -> TraceRingEntry {
@@ -280,6 +327,7 @@ mod tests {
     /// `Sent` still produces one complete node.
     #[test]
     fn stitch_folds_events_per_mail_id_regardless_of_order() {
+        register_fixture_thread_name();
         let root = mid(1, 1);
         let entries = vec![
             finished(root, root),
@@ -296,6 +344,8 @@ mod tests {
         assert_eq!(node.t_sent, Nanos(1));
         assert_eq!(node.t_received, Some(Nanos(2)));
         assert_eq!(node.t_finished, Some(Nanos(3)));
+        // The cold fold resolved the event's `ThreadId` back to the
+        // fixture display name via the test resolver (ADR-0088 §7).
         assert_eq!(node.thread_name.as_deref(), Some("aether-worker-0"));
     }
 

--- a/crates/aether-data/src/hash.rs
+++ b/crates/aether-data/src/hash.rs
@@ -6,7 +6,7 @@
 //! `MailboxId`-into-`KindId` slot (or vice versa) hashes to a
 //! different value rather than colliding silently.
 
-use crate::ids::{HandleId, MailboxId, TransformId};
+use crate::ids::{HandleId, MailboxId, ThreadId, TransformId};
 use crate::tagged_id::{Tag, with_tag};
 
 /// Domain tag prefixed to every mailbox-name hash so the `MailboxId`
@@ -28,6 +28,16 @@ pub const KIND_DOMAIN: &[u8] = b"kind:";
 /// `"type:aether.mailbox_id"`). Disjoint from mailbox / kind domains
 /// so a typed-id `TYPE_ID` cannot alias either space.
 pub const TYPE_DOMAIN: &[u8] = b"type:";
+
+/// ADR-0088 §7: domain prefix for thread-name hashes. Hashed input is
+/// `THREAD_DOMAIN ++ thread_name.as_bytes()` (e.g.
+/// `"thread:aether-worker-0"`). See `MAILBOX_DOMAIN` for the
+/// disjointness rationale; a `ThreadId` carries `Tag::Thread` bits and
+/// hashes under this prefix so it can't alias the mailbox / kind / type
+/// spaces. The reverse-lookup registry recovers the origin name from a
+/// `ThreadId` so the dispatch hot path can store a `Copy` u64 instead
+/// of allocating the thread name string per hop.
+pub const THREAD_DOMAIN: &[u8] = b"thread:";
 
 /// ADR-0048 §1: 16-byte domain prefix for native-transform id hashes.
 /// Hashed input is `TRANSFORM_DOMAIN ++ "{crate}::{module}::{fn}"`. A
@@ -134,5 +144,20 @@ pub const fn mailbox_id_from_name(name: &str) -> MailboxId {
     MailboxId(with_tag(
         Tag::Mailbox,
         fnv1a_64_prefixed(MAILBOX_DOMAIN, name.as_bytes()),
+    ))
+}
+
+/// ADR-0088 §7: compute the deterministic [`ThreadId`] for an OS thread
+/// name. FNV-1a with the `THREAD_DOMAIN` prefix, ADR-0064 tag bits
+/// stamped into the high nibble. Uniform with [`mailbox_id_from_name`]
+/// so a thread id encodes to the `thr-XXXX-XXXX-XXXX` string form and
+/// reverses through the same inventory chain. Computed once per worker
+/// thread off the dispatch hot path (the value is `Copy`), so storing
+/// it in a trace event costs no per-hop allocation.
+#[must_use]
+pub const fn thread_id_from_name(name: &str) -> ThreadId {
+    ThreadId(with_tag(
+        Tag::Thread,
+        fnv1a_64_prefixed(THREAD_DOMAIN, name.as_bytes()),
     ))
 }

--- a/crates/aether-data/src/ids.rs
+++ b/crates/aether-data/src/ids.rs
@@ -18,7 +18,7 @@ use core::fmt;
 use bytemuck::{Pod, Zeroable};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::hash::{TYPE_DOMAIN, fnv1a_64_prefixed, mailbox_id_from_name};
+use crate::hash::{TYPE_DOMAIN, fnv1a_64_prefixed, mailbox_id_from_name, thread_id_from_name};
 use crate::tagged_id::{self, Tag};
 
 /// Shared `Display` body — render tagged-string form when the tag
@@ -111,6 +111,8 @@ pub const fn tag_for_type_id(type_id: u64) -> Option<Tag> {
         Some(Tag::Dag)
     } else if type_id == TransformId::TYPE_ID {
         Some(Tag::Transform)
+    } else if type_id == ThreadId::TYPE_ID {
+        Some(Tag::Thread)
     } else {
         None
     }
@@ -131,6 +133,8 @@ pub const fn type_name_for_type_id(type_id: u64) -> Option<&'static str> {
         Some(DagId::TYPE_NAME)
     } else if type_id == TransformId::TYPE_ID {
         Some(TransformId::TYPE_NAME)
+    } else if type_id == ThreadId::TYPE_ID {
+        Some(ThreadId::TYPE_NAME)
     } else {
         None
     }
@@ -335,6 +339,49 @@ impl<'de> Deserialize<'de> for TransformId {
     }
 }
 
+/// ADR-0088 §7 name-hashed identity for an OS thread (`aether-worker-N`,
+/// `aether-root-<NAMESPACE>`, `aether-instanced-<full_name>`). Carries
+/// the `Tag::Thread` discriminator + a 60-bit FNV-1a hash of the thread
+/// name under `THREAD_DOMAIN`. The dispatch hot path stores this `Copy`
+/// id in `TraceEvent::Received` instead of allocating the name string
+/// per hop; the cold render path reverses it to a display name through
+/// the runtime registry. `#[repr(transparent)]` over `u64`.
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
+pub struct ThreadId(pub u64);
+
+impl ThreadId {
+    pub const TYPE_ID: u64 = fnv1a_64_prefixed(TYPE_DOMAIN, b"aether.thread_id");
+    pub const TYPE_NAME: &'static str = "aether.thread_id";
+
+    /// Compute the deterministic id for an OS thread name. Same
+    /// algorithm as [`crate::hash::thread_id_from_name`]; the dispatch
+    /// hot path calls this once per worker thread (cached in a
+    /// thread-local) so the per-hop cost is a `Copy`, not an alloc.
+    #[must_use]
+    pub fn from_name(name: &str) -> Self {
+        thread_id_from_name(name)
+    }
+}
+
+impl fmt::Display for ThreadId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_tagged(self.0, f)
+    }
+}
+
+impl Serialize for ThreadId {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        serialize_id(self.0, s)
+    }
+}
+
+impl<'de> Deserialize<'de> for ThreadId {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        deserialize_id(d, Tag::Thread).map(ThreadId)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -400,5 +447,31 @@ mod tests {
         let decoded = tagged_id::decode_with_tag(&encoded, Tag::Transform)
             .expect("TransformId round-trips via decode");
         assert_eq!(decoded, id);
+    }
+
+    /// ADR-0088 §7: a `ThreadId` carrying `Tag::Thread` bits encodes to
+    /// the `thr-XXXX-XXXX-XXXX` form, resolves its codec arm, and
+    /// `from_name` is deterministic + tag-stamped — uniform with the
+    /// mailbox / kind id derivation.
+    #[test]
+    fn thread_id_is_tagged_and_resolves_codec_arm() {
+        assert_eq!(tag_for_type_id(ThreadId::TYPE_ID), Some(Tag::Thread));
+        assert_eq!(
+            type_name_for_type_id(ThreadId::TYPE_ID),
+            Some("aether.thread_id")
+        );
+        let id = tagged_id::with_tag(Tag::Thread, 0x77);
+        let encoded = tagged_id::encode(id).expect("ThreadId tag-encodes");
+        assert!(encoded.starts_with("thr-"), "expected tagged: {encoded}");
+        let decoded = tagged_id::decode_with_tag(&encoded, Tag::Thread)
+            .expect("ThreadId round-trips via decode");
+        assert_eq!(decoded, id);
+
+        let a = ThreadId::from_name("aether-worker-0");
+        let b = ThreadId::from_name("aether-worker-0");
+        let c = ThreadId::from_name("aether-worker-1");
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        assert_eq!(tagged_id::tag_of(a.0), Some(Tag::Thread));
     }
 }

--- a/crates/aether-data/src/ids.rs
+++ b/crates/aether-data/src/ids.rs
@@ -355,7 +355,7 @@ impl ThreadId {
     pub const TYPE_NAME: &'static str = "aether.thread_id";
 
     /// Compute the deterministic id for an OS thread name. Same
-    /// algorithm as [`crate::hash::thread_id_from_name`]; the dispatch
+    /// algorithm as [`thread_id_from_name`]; the dispatch
     /// hot path calls this once per worker thread (cached in a
     /// thread-local) so the per-hop cost is a `Copy`, not an alloc.
     #[must_use]

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -54,11 +54,13 @@ pub mod tagged_id;
 pub mod transform;
 pub mod wire_id;
 pub use hash::{
-    HANDLE_DOMAIN, KIND_DOMAIN, MAILBOX_DOMAIN, TRANSFORM_DOMAIN, TYPE_DOMAIN,
+    HANDLE_DOMAIN, KIND_DOMAIN, MAILBOX_DOMAIN, THREAD_DOMAIN, TRANSFORM_DOMAIN, TYPE_DOMAIN,
     content_addressed_handle_id, fnv1a_64_bytes, fnv1a_64_prefixed, mailbox_id_from_name,
+    thread_id_from_name,
 };
 pub use ids::{
-    DagId, HandleId, KindId, MailboxId, TransformId, tag_for_type_id, type_name_for_type_id,
+    DagId, HandleId, KindId, MailboxId, ThreadId, TransformId, tag_for_type_id,
+    type_name_for_type_id,
 };
 pub use mail::{MailId, ReplyTarget, ReplyTo};
 pub use schema::*;
@@ -186,6 +188,9 @@ impl CastEligible for DagId {
     const ELIGIBLE: bool = true;
 }
 impl CastEligible for TransformId {
+    const ELIGIBLE: bool = true;
+}
+impl CastEligible for ThreadId {
     const ELIGIBLE: bool = true;
 }
 
@@ -330,7 +335,7 @@ mod schema_impls {
     use alloc::vec::Vec;
 
     use crate::schema::{LabelCell, LabelNode, Primitive, SchemaCell, SchemaType};
-    use crate::{DagId, HandleId, KindId, MailboxId, Schema, TransformId};
+    use crate::{DagId, HandleId, KindId, MailboxId, Schema, ThreadId, TransformId};
     use alloc::collections::BTreeMap;
 
     macro_rules! scalar {
@@ -427,6 +432,12 @@ mod schema_impls {
     }
 
     impl Schema for TransformId {
+        const SCHEMA: SchemaType = SchemaType::TypeId(Self::TYPE_ID);
+        const LABEL: Option<&'static str> = Some(Self::TYPE_NAME);
+        const LABEL_NODE: LabelNode = LabelNode::Anonymous;
+    }
+
+    impl Schema for ThreadId {
         const SCHEMA: SchemaType = SchemaType::TypeId(Self::TYPE_ID);
         const LABEL: Option<&'static str> = Some(Self::TYPE_NAME);
         const LABEL_NODE: LabelNode = LabelNode::Anonymous;

--- a/crates/aether-data/src/tag_bits.rs
+++ b/crates/aether-data/src/tag_bits.rs
@@ -31,3 +31,8 @@ pub const TAG_DAG: u8 = 0x4;
 /// Tag value for native-transform ids (ADR-0048). Name-hashed global
 /// identity for a registered transform.
 pub const TAG_TRANSFORM: u8 = 0x5;
+
+/// Tag value for thread ids (ADR-0088 §7). Name-hashed identity for an
+/// OS thread (`aether-worker-N`, `aether-root-<NAMESPACE>`, …),
+/// reversed to a display name through the inventory.
+pub const TAG_THREAD: u8 = 0x6;

--- a/crates/aether-data/src/tagged_id.rs
+++ b/crates/aether-data/src/tagged_id.rs
@@ -19,7 +19,7 @@ use alloc::string::String;
 use core::fmt;
 
 pub use crate::tag_bits::{
-    HASH_MASK, TAG_DAG, TAG_HANDLE, TAG_KIND, TAG_MAILBOX, TAG_SHIFT, TAG_TRANSFORM,
+    HASH_MASK, TAG_DAG, TAG_HANDLE, TAG_KIND, TAG_MAILBOX, TAG_SHIFT, TAG_THREAD, TAG_TRANSFORM,
 };
 
 /// Type tag identifying an id space. Encoded in the high 4 bits of
@@ -42,6 +42,9 @@ pub enum Tag {
     /// Native-transform id (ADR-0048) — name-hashed global identity for
     /// a registered transform.
     Transform = TAG_TRANSFORM,
+    /// Thread id (ADR-0088 §7) — name-hashed identity for an OS thread,
+    /// reversed to a display name through the inventory.
+    Thread = TAG_THREAD,
 }
 
 impl Tag {
@@ -56,12 +59,13 @@ impl Tag {
             Self::Handle => "hdl",
             Self::Dag => "dag",
             Self::Transform => "trn",
+            Self::Thread => "thr",
         }
     }
 
     /// Decode a 4-bit tag value from the high nibble of a `u64`.
     /// Returns `None` for `0x0` (the reserved invalid sentinel) and
-    /// for any reserved-future value (`0x6..=0xF`).
+    /// for any reserved-future value (`0x7..=0xF`).
     #[must_use]
     pub const fn from_bits(bits: u8) -> Option<Self> {
         match bits {
@@ -70,6 +74,7 @@ impl Tag {
             TAG_HANDLE => Some(Self::Handle),
             TAG_DAG => Some(Self::Dag),
             TAG_TRANSFORM => Some(Self::Transform),
+            TAG_THREAD => Some(Self::Thread),
             _ => None,
         }
     }
@@ -172,6 +177,7 @@ pub fn decode(s: &str) -> Result<u64, DecodeError> {
         b"hdl" | b"HDL" => Tag::Handle,
         b"dag" | b"DAG" => Tag::Dag,
         b"trn" | b"TRN" => Tag::Transform,
+        b"thr" | b"THR" => Tag::Thread,
         _ => return Err(DecodeError::Malformed),
     };
     if bytes[3] != b'-' || bytes[8] != b'-' || bytes[13] != b'-' {
@@ -223,6 +229,7 @@ mod tests {
             Tag::Handle,
             Tag::Dag,
             Tag::Transform,
+            Tag::Thread,
         ] {
             for hash in [0u64, 0x1, 0x0FFF_FFFF_FFFF_FFFF, 0xDEAD_BEEF_CAFE_BABE] {
                 let id = with_tag(tag, hash);
@@ -264,6 +271,16 @@ mod tests {
         assert!(s.starts_with("trn-"));
         assert_eq!(s, "trn-aaaa-aaaa-aaaa");
         assert_eq!(decode(&s).expect("test setup: transform id decodes"), id);
+    }
+
+    #[test]
+    fn thread_tag_encoding_shape() {
+        let id = with_tag(Tag::Thread, 0);
+        let s = encode(id).expect("test setup: Thread id encodes (tag is non-zero)");
+        assert_eq!(s.len(), 18);
+        assert!(s.starts_with("thr-"));
+        assert_eq!(s, "thr-aaaa-aaaa-aaaa");
+        assert_eq!(decode(&s).expect("test setup: thread id decodes"), id);
     }
 
     #[test]

--- a/crates/aether-kinds/src/trace.rs
+++ b/crates/aether-kinds/src/trace.rs
@@ -16,7 +16,7 @@
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use aether_data::{KindId, MailId, MailboxId};
+use aether_data::{KindId, MailId, MailboxId, ThreadId};
 use serde::{Deserialize, Serialize};
 
 use crate::MailEnvelope;
@@ -77,18 +77,20 @@ pub enum TraceEvent {
     Received {
         mail_id: MailId,
         t: Nanos,
-        /// Issue 734: OS thread name captured at the dispatcher's
-        /// receive hook (`std::thread::current().name()`). The
-        /// substrate's default `Pooled` scheduler (post-issue-635)
-        /// names worker threads `aether-worker-N`, so the trace
-        /// renderer (`hub::mcp::trace`) can distinguish per-thread
-        /// rows even when one OS thread serves multiple actors. Actors that opt into
-        /// the `Thread` scheduler get `aether-instanced-<full_name>` /
-        /// `aether-root-<NAMESPACE>` from `actor::native::spawn` and
-        /// `spawn_thread`. `None` when the OS thread has no name
-        /// (anonymous test threads, `std::thread::spawn` without
-        /// `Builder::new().name(...)`).
-        thread_name: Option<String>,
+        /// Issue 734 / ADR-0088 §7: the dispatching OS thread's
+        /// name-hashed [`ThreadId`], captured at the dispatcher's receive
+        /// hook. Stored as a `Copy` tagged id rather than a fresh
+        /// `String` per hop — the per-hop `str::to_owned` (~25% of the
+        /// warm dispatch hop) was the forcing function for the
+        /// reverse-lookup inventory. The substrate's default `Pooled`
+        /// scheduler names worker threads `aether-worker-N`; `Thread`-
+        /// scheduled actors land on `aether-instanced-<full_name>` /
+        /// `aether-root-<NAMESPACE>`. The display name is recovered on
+        /// the cold render path (`trace_walk::fold_nodes` ->
+        /// `MailNodeWire.thread_name`) via the runtime registry. `None`
+        /// when the OS thread has no name (anonymous test threads,
+        /// `std::thread::spawn` without `Builder::new().name(...)`).
+        thread_id: Option<ThreadId>,
     },
     Finished {
         mail_id: MailId,
@@ -155,10 +157,13 @@ pub struct MailNodeWire {
     pub t_sent: Nanos,
     pub t_received: Option<Nanos>,
     pub t_finished: Option<Nanos>,
-    /// Issue 734: OS thread name captured at the dispatcher's receive
-    /// hook (`std::thread::current().name()`). `None` until the
-    /// `Received` event lands. See [`TraceEvent::Received::thread_name`]
-    /// for the producer-side semantics.
+    /// Issue 734 / ADR-0088 §7: the dispatching OS thread's display
+    /// name, resolved on the cold fold path (`trace_walk::fold_nodes`)
+    /// from the `Received` event's [`ThreadId`] via the runtime
+    /// reverse-lookup registry. `None` until the `Received` event lands,
+    /// or when the thread was anonymous / the id wasn't registered (the
+    /// fold falls back to no name rather than a hex tag here, since this
+    /// field is the human display string the renderer prints directly).
     pub thread_name: Option<String>,
 }
 

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -169,7 +169,16 @@ const SETTLE_TIMEOUT: Duration = Duration::from_secs(10);
 #[ignore = "profiling target — run under samply, not a correctness gate"]
 #[allow(clippy::print_stderr)]
 fn mail_saturation_profile() {
-    let workers = available_parallelism().map_or(2, |n| n.get().saturating_sub(1).max(1));
+    // `WORKERS=1` isolates the warm per-hop dispatch glue with zero
+    // cross-worker contention (the inline demux keeps every ring hop on
+    // the one worker, which is always fed by the circulating tokens) —
+    // the clean profile for the warm-floor decomposition. Unset, the
+    // default saturates the whole pool (the throughput/contention view).
+    let workers = env::var("WORKERS")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|&w| w >= 1)
+        .unwrap_or_else(|| available_parallelism().map_or(2, |n| n.get().saturating_sub(1).max(1)));
     let Ok(tb) = TestBench::builder()
         .with_workers(Some(workers))
         .size(16, 16)

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -52,8 +52,8 @@ use crate::actor::native::{NativeActor, NativeDispatch};
 use crate::actor::registry::ActorRegistry;
 use crate::mail::mailer::Mailer;
 use crate::mail::{KindId, Mail, MailId, MailboxId, ReplyTo};
+use crate::runtime::thread_name;
 use aether_actor::local;
-use std::thread;
 
 /// Try the typed `#[handler]` dispatch; if no typed arm matches and
 /// the actor's `#[fallback]` also returns `false`, warn that the kind
@@ -169,9 +169,9 @@ pub fn dispatch_loop_run<A>(
             break;
         };
         let inbound_mail_id = env.mail_id;
-        // Issue 734: capture the OS thread name at the dispatcher's
-        // receive hook so the trace renderer can stamp per-thread rows.
-        let thread_name = thread::current().name().map(str::to_owned);
+        // Issue 734 / ADR-0088 §7: stamp the dispatching thread's
+        // name-hashed `ThreadId` (cached per thread, zero per-hop alloc).
+        let thread_id = thread_name::current_thread_id();
         local::with_stamped(slots, || {
             // ADR-0086 Phase 3: `Received` / `Finished` land in this
             // (recipient) actor's trace ring — only inside this
@@ -182,7 +182,7 @@ pub fn dispatch_loop_run<A>(
                 TraceEvent::Received {
                     mail_id: inbound_mail_id,
                     t: th.now_nanos(),
-                    thread_name,
+                    thread_id,
                 },
             );
             let mut ctx = NativeCtx::new(binding, env.sender, env.mail_id, env.root);
@@ -219,7 +219,7 @@ pub fn dispatch_loop_run<A>(
     // the full inbox.
     while let Some(env) = binding.try_recv() {
         let inbound_mail_id = env.mail_id;
-        let thread_name = thread::current().name().map(str::to_owned);
+        let thread_id = thread_name::current_thread_id();
         local::with_stamped(slots, || {
             let th = binding.mailer().trace_handle();
             th.push_trace_ring(
@@ -227,7 +227,7 @@ pub fn dispatch_loop_run<A>(
                 TraceEvent::Received {
                     mail_id: inbound_mail_id,
                     t: th.now_nanos(),
-                    thread_name,
+                    thread_id,
                 },
             );
             let mut ctx = NativeCtx::new(binding, env.sender, env.mail_id, env.root);

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -43,12 +43,12 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use crate::actor::native::Envelope;
+use crate::runtime::thread_name;
 use aether_actor::local;
 use aether_actor::local::ActorSlots;
 use aether_kinds::trace::TraceEvent;
 use std::ops::Deref;
 use std::sync::PoisonError;
-use std::thread;
 
 /// `ActorSlots` uses `RefCell` internally because the dedicated-thread
 /// dispatcher path only ever reaches it from one OS thread. Worker-pool
@@ -206,13 +206,16 @@ where
     #[allow(clippy::needless_pass_by_value)]
     fn dispatch_one(&self, actor: &mut Box<A>, env: Envelope) {
         let inbound_mail_id = env.mail_id;
-        // Issue 734: capture the OS thread name at the dispatcher's
-        // receive hook so the trace renderer can stamp each event
-        // with a per-thread tid + thread_name M event. With the
-        // `Pooled` default scheduler (issue 635) this is the worker's
-        // `aether-worker-N` name (shared across actors); `Thread`-
-        // scheduled actors land on a per-actor name.
-        let thread_name = thread::current().name().map(str::to_owned);
+        // Issue 734 / ADR-0088 §7: stamp the dispatching thread's
+        // name-hashed `ThreadId` (a `Copy` u64) onto the `Received`
+        // event. Resolved once per worker thread via a thread-local
+        // cache — no per-hop `str::to_owned`, no `thread::current()`
+        // `Arc` bump. The display name is recovered on the cold render
+        // path through the reverse-lookup registry. With the `Pooled`
+        // default scheduler (issue 635) this is the worker's
+        // `aether-worker-N`; `Thread`-scheduled actors land on a
+        // per-actor name.
+        let thread_id = thread_name::current_thread_id();
         local::with_stamped(&self.slots, || {
             // ADR-0086 Phase 3: `Received` / `Finished` land in this
             // (recipient) actor's trace ring — only inside this
@@ -224,7 +227,7 @@ where
                 TraceEvent::Received {
                     mail_id: inbound_mail_id,
                     t: th.now_nanos(),
-                    thread_name,
+                    thread_id,
                 },
             );
             let mut ctx = NativeCtx::new(&self.binding, env.sender, env.mail_id, env.root);

--- a/crates/aether-substrate/src/runtime/mod.rs
+++ b/crates/aether-substrate/src/runtime/mod.rs
@@ -7,6 +7,7 @@
 pub mod lifecycle;
 pub mod log_install;
 pub mod panic_hook;
+pub mod thread_name;
 pub mod trace;
 
 pub use panic_hook::init_panic_hook;

--- a/crates/aether-substrate/src/runtime/thread_name.rs
+++ b/crates/aether-substrate/src/runtime/thread_name.rs
@@ -1,0 +1,177 @@
+//! ADR-0088 §5/§7 reverse-lookup registry for dynamically-minted names,
+//! plus the dispatch-hot-path thread-name cache that is its first
+//! producer (Phase 1).
+//!
+//! ## Why
+//!
+//! Substrate ids are one-way hashes (ADR-0029/0030/0064): you cannot
+//! recover the origin name from the id. The reverse-lookup inventory
+//! (ADR-0088) layers a side table over them; this module holds the
+//! runtime arm — a process-global `id -> name` map populated the moment
+//! a dynamic name is minted, read cold at render time.
+//!
+//! ## The thread-name perf shave (the forcing function)
+//!
+//! The dispatch hot path used to build a fresh `String` per mail hop via
+//! `thread::current().name().map(str::to_owned)` to stamp
+//! [`aether_kinds::trace::TraceEvent::Received`]. The name is the
+//! constant `aether-worker-N` for a given worker, so allocating it per
+//! hop was pure waste (~25% of the warm hop, a 1-worker saturation
+//! profile under macOS `sample` — iamacoffeepot/aether#1059 /
+//! iamacoffeepot/aether#1101).
+//!
+//! [`current_thread_id`] resolves the calling thread's name to a `Copy`
+//! [`ThreadId`] **once per thread** (cached in a thread-local) and
+//! registers `name -> id` in the process-global registry on that first
+//! compute. The trace event then stores the `Copy` id; the display name
+//! is recovered on the cold render path via [`resolve`]. This kills both
+//! the per-hop `str::to_owned` and the `thread::current()` `Arc` bump.
+
+use std::cell::Cell;
+use std::collections::HashMap;
+use std::sync::{OnceLock, PoisonError, RwLock};
+use std::thread;
+
+use aether_data::ThreadId;
+
+/// Process-global reverse-lookup map: tagged id -> origin name. Keyed on
+/// the raw `u64` so the same table can hold any id family that mints
+/// dynamic names (ADR-0088 §5); Phase 1 only registers [`ThreadId`]s.
+///
+/// `RwLock` because writes are rare (a name is minted once per
+/// instance / once per worker thread) and reads are cold (render time),
+/// so the lock is uncontended in practice and never on the dispatch hot
+/// path. Initialised lazily on first use so the map costs nothing in a
+/// process that never traces.
+fn registry() -> &'static RwLock<HashMap<u64, Box<str>>> {
+    static REGISTRY: OnceLock<RwLock<HashMap<u64, Box<str>>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// Register `id -> name` in the process-global reverse-lookup registry.
+/// Idempotent — re-registering the same id with the same name is a
+/// no-op; an id is never expected to map to two different names (the
+/// hash is name-derived), so a second insert simply overwrites with the
+/// identical value. Off the dispatch hot path: called at name-mint
+/// time, not per hop.
+///
+/// Poison recovery: a writer that panicked mid-update is tolerated — the
+/// registry is a best-effort observability side table, never load-
+/// bearing for dispatch, so a poisoned lock recovers its inner map
+/// rather than aborting the process.
+pub fn register(id: u64, name: &str) {
+    let mut map = registry().write().unwrap_or_else(PoisonError::into_inner);
+    // Only allocate a `Box<str>` on a genuine first insert.
+    map.entry(id).or_insert_with(|| name.into());
+}
+
+/// Resolve a tagged id back to its registered origin name, if any. The
+/// cold render path (`trace_walk::fold_nodes`, MCP) calls this to turn a
+/// [`ThreadId`] (or any future dynamically-registered id) into a display
+/// name. `None` means the id was never registered — the caller falls
+/// back to the ADR-0064 hex tag, which is exactly what it showed before.
+#[must_use]
+pub fn resolve(id: u64) -> Option<String> {
+    registry()
+        .read()
+        .unwrap_or_else(PoisonError::into_inner)
+        .get(&id)
+        .map(ToString::to_string)
+}
+
+/// Per-thread cache state for [`current_thread_id`], distinguishing the
+/// three cases clippy's `option_option` lint asks us to name:
+/// not-yet-computed, computed-to-a-name, and computed-but-anonymous (an
+/// OS thread with no `Builder::name`).
+#[derive(Copy, Clone)]
+enum CachedThreadId {
+    /// First [`current_thread_id`] call on this thread hasn't run yet.
+    Uncomputed,
+    /// Resolved once: `Some` for a named thread, `None` for an anonymous
+    /// one.
+    Computed(Option<ThreadId>),
+}
+
+thread_local! {
+    /// Per-thread cache of this thread's resolved [`ThreadId`]. Computed
+    /// once on first [`current_thread_id`] call (reads the OS thread
+    /// name, hashes it, registers name -> id), then reused for every
+    /// subsequent hop on that thread with zero allocation. `Cell` because
+    /// [`CachedThreadId`] is `Copy`.
+    static CACHED_THREAD_ID: Cell<CachedThreadId> =
+        const { Cell::new(CachedThreadId::Uncomputed) };
+}
+
+/// The calling thread's [`ThreadId`], computed once per thread and cached
+/// in a thread-local. Returns `None` for an anonymous OS thread (no
+/// `Builder::name`) — e.g. a `std::thread::spawn` worker or an
+/// unnamed test thread — matching the prior `thread_name: None`.
+///
+/// On the first call from a thread this reads `thread::current().name()`,
+/// hashes it via [`ThreadId::from_name`], and registers `name -> id` in
+/// the process-global registry so the cold render path can reverse it.
+/// Every later call is a thread-local read of a `Copy` value — no alloc,
+/// no `thread::current()` `Arc` bump — which is the dispatch-hot-path
+/// win (ADR-0088 §7).
+#[must_use]
+pub fn current_thread_id() -> Option<ThreadId> {
+    CACHED_THREAD_ID.with(|cell| {
+        if let CachedThreadId::Computed(cached) = cell.get() {
+            return cached;
+        }
+        let resolved = thread::current().name().map(|name| {
+            let id = ThreadId::from_name(name);
+            register(id.0, name);
+            id
+        });
+        cell.set(CachedThreadId::Computed(resolved));
+        resolved
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A named thread resolves to a stable `ThreadId`, registers its
+    /// name, and `resolve` recovers the original name from the id.
+    #[test]
+    fn named_thread_resolves_and_registers() {
+        let handle = thread::Builder::new()
+            .name("aether-test-worker-7".to_owned())
+            .spawn(|| {
+                let first = current_thread_id().expect("named thread has a ThreadId");
+                // Cached: a second call yields the identical id.
+                let second = current_thread_id().expect("cached ThreadId");
+                assert_eq!(first, second);
+                first
+            })
+            .expect("spawn named thread");
+        let id = handle.join().expect("join named thread");
+
+        // The id is the name-derived hash, deterministically recomputable.
+        assert_eq!(id, ThreadId::from_name("aether-test-worker-7"));
+        // The registry reversed it to the origin name.
+        assert_eq!(resolve(id.0).as_deref(), Some("aether-test-worker-7"));
+    }
+
+    /// An anonymous thread (no `Builder::name`) resolves to `None` —
+    /// matching the prior `thread_name: None` behaviour — and registers
+    /// nothing.
+    #[test]
+    fn anonymous_thread_resolves_to_none() {
+        let resolved = thread::spawn(current_thread_id)
+            .join()
+            .expect("join anonymous thread");
+        assert_eq!(resolved, None);
+    }
+
+    /// `resolve` on an unregistered id returns `None`, so the cold path
+    /// falls back to the hex tag (no regression vs. the prior behaviour).
+    #[test]
+    fn resolve_unregistered_id_is_none() {
+        // A fresh hash that the test never registers.
+        let unseen = ThreadId::from_name("aether-never-registered-xyz");
+        assert_eq!(resolve(unseen.0), None);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of ADR-0088 (tracker iamacoffeepot/aether#1124): the id-space foundations + the first consumer, **thread-name reverse-lookup**, which lands a Phase 4 warm-dispatch shave (iamacoffeepot/aether#1059 / iamacoffeepot/aether#1101).

The warm mail-dispatch hop spent ~25% of its time allocating a fresh `thread_name` `String` per hop (`thread::current().name().to_owned()`) to stamp the `Received` trace event — though the name is the constant `aether-worker-N` per worker. This replaces it with a `Copy` tagged `ThreadId`:

- **Hot path**: a thread-local cache resolves the name to a `ThreadId` once per thread (registering `name -> id` in a process-global reverse-lookup registry on first compute). Every later hop is a thread-local read of a `Copy` value — no `str::to_owned`, no `thread::current()` `Arc` bump.
- **Cold path**: `trace_walk::fold_nodes` reverses the `ThreadId` to the display name via the registry, so the trace renderer is unchanged.

## Foundations (ADR-0088)

- `Tag::Thread` (`thr-…`), `THREAD_DOMAIN`, and the `ThreadId` newtype + codec arms — added exactly like `DagId` / `TransformId` (the multi-site registration iamacoffeepot/aether#1036 flags; manual pattern followed, macro cleanup stays separate).
- A process-global `id -> name` runtime registry (`runtime::thread_name`) — the ADR-0088 section 5 runtime arm, thread-names as its first producer.
- `TraceEvent::Received.thread_name: Option<String>` becomes `Option<ThreadId>`; `MailNodeWire.thread_name` stays `Option<String>` (resolved at fold). The fold's registry lookup is `native`-gated so the wasm / out-of-process MCP build falls back to `None` (no regression) until the section 6 inventory actor lands.

## Validation

- `scripts/preflight.sh` green: fmt + clippy (`-D warnings`) + doc + wasm32 cross-build + nextest (1250 passed, 0 failed).
- Tagged-id round-trip covers `Tag::Thread`; `runtime::thread_name` unit tests (named resolves + registers, anonymous to `None`, unregistered to `None`); the fold test resolves a `ThreadId` to its display name.
- Warm-hop perf re-measurement posted as a follow-up comment.

Closes iamacoffeepot/aether#1120. ADR-0088; tracker iamacoffeepot/aether#1124.