### PR TITLE
feat(substrate): aether.inventory actor — manifest + resolve over mail (ADR-0088 phase 3)

### DIFF
--- a/crates/aether-capabilities/src/inventory.rs
+++ b/crates/aether-capabilities/src/inventory.rs
@@ -1,0 +1,317 @@
+//! `aether.inventory` cap (ADR-0088 §6). Serves the reverse-lookup
+//! inventory over mail so an out-of-process observer (the MCP harness)
+//! reads the running substrate's **own, per-build** inventory instead of
+//! a drift-prone compiled-in copy.
+//!
+//! Two request kinds, both replying synchronously via `ctx.reply`:
+//!
+//! - [`Manifest`] → [`ManifestResult`]: the compile-time manifest —
+//!   every link-time [`NameEntry`](aether_data::name_inventory::NameEntry)
+//!   (declared mailbox namespaces + kinds + transforms) and every
+//!   [`TemplateEntry`](aether_data::name_inventory::TemplateEntry)
+//!   (instanced families). Templates ship their *family shape*
+//!   (`Bounded` range / `Declared` domain / `Dynamic`) so the client
+//!   expands or prehashes them locally — the manifest is NOT flattened to
+//!   a hash → name map (ADR-0088 §6). The client folds this once at
+//!   connect and reconstructs its own static reverse map.
+//! - [`Resolve`] → [`ResolveResult`]: per-id reverse lookup of
+//!   dynamically-minted instance ids the client can't compute from the
+//!   manifest alone (the runtime-registry arm of the ADR-0088 §2 chain,
+//!   `thread_name::resolve_runtime`). `None` on a miss so the client
+//!   falls back to rendering the ADR-0064 tagged-id string itself.
+//!
+//! The cap holds no state — it reads the link-time inventories and the
+//! process-global runtime registry directly at request time, both of
+//! which are fixed (inventories) or write-rarely (registry) for the
+//! process lifetime. `#[bridge(singleton)]` auto-submits its own
+//! `NameEntry` for `NAMESPACE`, so `aether.inventory` reverses through
+//! the same static map it serves.
+
+use aether_kinds::{Manifest, ManifestResult, Resolve, ResolveResult};
+
+#[aether_actor::bridge(singleton)]
+mod native {
+    use super::{Manifest, ManifestResult, Resolve, ResolveResult};
+
+    use aether_actor::{MailCtx, actor};
+    use aether_data::name_inventory::{ParamKind, name_entries, template_entries};
+    use aether_data::tagged_id;
+    use aether_kinds::{NameEntryWire, ParamKindWire, ResolvedName, TemplateEntryWire};
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+    use aether_substrate::runtime::thread_name::resolve_runtime;
+
+    /// `aether.inventory` cap (ADR-0088 §6). Stateless — both handlers
+    /// read process-global tables (the link-time inventories, the
+    /// runtime registry) directly, so there is nothing to carry across
+    /// handler calls.
+    pub struct InventoryCapability;
+
+    /// Project one link-time `ParamKind` onto its wire mirror. `Bounded`
+    /// / `Declared` carry their range / domain so the client expands the
+    /// family locally; `Dynamic` carries only the shape (its instances
+    /// reverse via [`Resolve`]).
+    fn param_kind_wire(param: &ParamKind) -> ParamKindWire {
+        match *param {
+            ParamKind::Bounded { lo, hi } => ParamKindWire::Bounded { lo, hi },
+            ParamKind::Declared { domain } => ParamKindWire::Declared {
+                domain: domain.to_vec(),
+            },
+            ParamKind::Dynamic => ParamKindWire::Dynamic,
+        }
+    }
+
+    #[actor]
+    impl NativeActor for InventoryCapability {
+        type Config = ();
+
+        /// ADR-0088 §6 chassis-owned mailbox. Registered on the desktop +
+        /// headless chassis (via `with_common_caps`), matching `aether.fs`.
+        const NAMESPACE: &'static str = "aether.inventory";
+
+        fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            Ok(Self)
+        }
+
+        /// Reply with the per-build reverse-lookup manifest: every
+        /// declared name + every instanced-family template.
+        ///
+        /// # Agent
+        /// Reply: `ManifestResult`. Carries `names` (declared mailbox
+        /// namespaces, kinds, transforms) + `templates` (instanced
+        /// families, preserving their `Bounded`/`Declared`/`Dynamic`
+        /// shape). Fold `names` into a hash → name map and expand the
+        /// `Bounded`/`Declared` templates locally; resolve `Dynamic`
+        /// families per-id via `aether.inventory.resolve`.
+        // Stateless cap — the manifest is read from the process-global
+        // link-time inventories, not from `self`. `&mut self` is the
+        // `#[handler]` dispatch signature, not a state read.
+        #[allow(clippy::unused_self)]
+        #[handler]
+        fn on_manifest(&mut self, ctx: &mut NativeCtx<'_>, _mail: Manifest) {
+            let names = name_entries()
+                .map(|entry| NameEntryWire {
+                    domain: entry.domain.to_vec(),
+                    name: entry.name.into(),
+                })
+                .collect();
+            let templates = template_entries()
+                .map(|entry| TemplateEntryWire {
+                    domain: entry.domain.to_vec(),
+                    template: entry.template.into(),
+                    param: param_kind_wire(&entry.param),
+                })
+                .collect();
+            ctx.reply(&ManifestResult { names, templates });
+        }
+
+        /// Resolve each requested tagged-id string to its origin name via
+        /// the runtime-registry arm of the reverse-lookup chain.
+        ///
+        /// # Agent
+        /// Reply: `ResolveResult`. One `ResolvedName { id, name }` per
+        /// requested id, in request order and echoing `id` for
+        /// correlation. `name` is `Some` for a dynamically-minted
+        /// instance the substrate has registered; `None` on a miss (or an
+        /// unparseable id), at which point the caller renders the
+        /// ADR-0064 tagged-id string itself. Call this only for ids a
+        /// locally-folded manifest couldn't resolve.
+        // Stateless cap — `resolve` reads the process-global runtime
+        // registry, not `self`. `&mut self` is the `#[handler]` dispatch
+        // signature, not a state read.
+        #[allow(clippy::unused_self)]
+        #[handler]
+        fn on_resolve(&mut self, ctx: &mut NativeCtx<'_>, mail: Resolve) {
+            let resolved = mail
+                .ids
+                .into_iter()
+                .map(|id| {
+                    // A malformed tagged-id string reports `None` rather
+                    // than aborting the batch — one bad id doesn't sink
+                    // its siblings.
+                    let name = tagged_id::decode(&id).ok().and_then(resolve_runtime);
+                    ResolvedName { id, name }
+                })
+                .collect();
+            ctx.reply(&ResolveResult { resolved });
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use aether_data::{
+            MailboxId, SessionToken, ThreadId, Uuid, mailbox_id_from_name, thread_id_from_name,
+        };
+        use aether_substrate::actor::native::binding::NativeBinding;
+        use aether_substrate::handle_store::HandleStore;
+        use aether_substrate::mail::mailer::Mailer;
+        use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
+        use aether_substrate::mail::registry::Registry;
+        use aether_substrate::mail::{ReplyTarget, ReplyTo};
+        use aether_substrate::runtime::thread_name::register;
+        use serde::de::DeserializeOwned;
+        use std::sync::Arc;
+        use std::sync::mpsc::Receiver;
+        use std::time::Duration;
+
+        /// Cap + loopback mailer + transport wired so `ctx.reply`
+        /// egresses as a `ToSession` event the test can decode. Mirrors
+        /// the `trace.rs` `DispatchTracedFixture` shape.
+        struct Fixture {
+            rx: Receiver<EgressEvent>,
+            transport: Arc<NativeBinding>,
+            cap: InventoryCapability,
+        }
+
+        fn fixture() -> Fixture {
+            let registry = Arc::new(Registry::new());
+            let store = Arc::new(HandleStore::new(1024 * 1024));
+            let (outbound, rx) = HubOutbound::attached_loopback();
+            let mailer = Arc::new(
+                Mailer::new(Arc::clone(&registry), Arc::clone(&store)).with_outbound(outbound),
+            );
+            let transport = Arc::new(NativeBinding::new_for_test(
+                Arc::clone(&mailer),
+                MailboxId(0x1117),
+            ));
+            Fixture {
+                rx,
+                transport,
+                cap: InventoryCapability,
+            }
+        }
+
+        fn session_ctx(transport: &Arc<NativeBinding>) -> NativeCtx<'_> {
+            let sender = ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::nil())));
+            NativeCtx::new(
+                transport,
+                sender,
+                aether_data::MailId::NONE,
+                aether_data::MailId::NONE,
+            )
+        }
+
+        fn decode_reply<K: aether_data::Kind + DeserializeOwned>(rx: &Receiver<EgressEvent>) -> K {
+            let event = rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("test: egress event arrives within 1s deadline");
+            let EgressEvent::ToSession {
+                kind_name, payload, ..
+            } = event
+            else {
+                panic!("expected ToSession egress, got {event:?}");
+            };
+            assert_eq!(kind_name, K::NAME);
+            postcard::from_bytes(&payload).expect("test: reply payload decodes via postcard")
+        }
+
+        /// The served manifest carries a known chassis mailbox name
+        /// (`aether.fs`, a declared `NameEntry`) and a known instanced
+        /// family (`aether-worker-{N}`, a `Bounded` `TemplateEntry`).
+        /// Touching `FsCapability` forces its module — and the macro-
+        /// auto-emitted `NameEntry` — into this unit-test binary; the
+        /// substrate's `thread_name` module submits the worker template.
+        #[test]
+        fn manifest_contains_chassis_name_and_worker_template() {
+            // Force `FsCapability`'s `NameEntry` submission to link.
+            use crate::fs::FsCapability;
+            use aether_actor::Actor;
+            assert_eq!(FsCapability::NAMESPACE, "aether.fs");
+            // Force the substrate's worker / root / instanced thread-name
+            // templates to link by referencing the resolve chain.
+            let _ = resolve_runtime(0);
+
+            let mut fix = fixture();
+            let mut ctx = session_ctx(&fix.transport);
+            fix.cap.on_manifest(&mut ctx, Manifest {});
+            drop(ctx);
+
+            let result = decode_reply::<ManifestResult>(&fix.rx);
+            assert!(
+                result.names.iter().any(|n| n.name == "aether.fs"),
+                "manifest should carry the aether.fs chassis mailbox NameEntry; names: {:?}",
+                result.names.iter().map(|n| &n.name).collect::<Vec<_>>(),
+            );
+            assert!(
+                result.templates.iter().any(|t| {
+                    t.template == "aether-worker-{N}"
+                        && matches!(t.param, ParamKindWire::Bounded { .. })
+                }),
+                "manifest should carry the aether-worker-{{N}} Bounded template; templates: {:?}",
+                result
+                    .templates
+                    .iter()
+                    .map(|t| &t.template)
+                    .collect::<Vec<_>>(),
+            );
+        }
+
+        /// A registered dynamic-instance id resolves to its name; an
+        /// unregistered id and a malformed string both report `None`
+        /// (the latter without sinking its siblings). Order + `id` echo
+        /// are preserved.
+        #[test]
+        fn resolve_returns_registered_name_and_none_on_miss() {
+            // Register a dynamic instance name the way the runtime name
+            // builders do (a name no static template instantiates).
+            let registered = ThreadId::from_name("aether-instanced-inventory-test:7");
+            register(registered.0, "aether-instanced-inventory-test:7");
+            let registered_tag =
+                tagged_id::encode(registered.0).expect("ThreadId always tag-encodes");
+
+            // An id the registry has never seen.
+            let unseen = thread_id_from_name("aether-instanced-never-registered");
+            let unseen_tag = tagged_id::encode(unseen.0).expect("ThreadId always tag-encodes");
+
+            // A well-formed mailbox id that the runtime registry doesn't
+            // hold (statics live in the static map, not the dynamic arm),
+            // so `resolve_runtime` misses it -> None.
+            let mailbox = mailbox_id_from_name("aether.fs");
+            let mailbox_tag = tagged_id::encode(mailbox.0).expect("MailboxId tag-encodes");
+
+            let mut fix = fixture();
+            let mut ctx = session_ctx(&fix.transport);
+            fix.cap.on_resolve(
+                &mut ctx,
+                Resolve {
+                    ids: vec![
+                        registered_tag.clone(),
+                        unseen_tag.clone(),
+                        mailbox_tag.clone(),
+                        "not-a-tagged-id".to_string(),
+                    ],
+                },
+            );
+            drop(ctx);
+
+            let result = decode_reply::<ResolveResult>(&fix.rx);
+            assert_eq!(result.resolved.len(), 4, "one entry per requested id");
+
+            assert_eq!(result.resolved[0].id, registered_tag);
+            assert_eq!(
+                result.resolved[0].name.as_deref(),
+                Some("aether-instanced-inventory-test:7"),
+                "registered dynamic instance reverses to its name",
+            );
+
+            assert_eq!(result.resolved[1].id, unseen_tag);
+            assert_eq!(
+                result.resolved[1].name, None,
+                "unregistered id misses the runtime registry",
+            );
+
+            assert_eq!(result.resolved[2].id, mailbox_tag);
+            assert_eq!(
+                result.resolved[2].name, None,
+                "a static name lives in the manifest, not the dynamic arm",
+            );
+
+            assert_eq!(result.resolved[3].id, "not-a-tagged-id");
+            assert_eq!(
+                result.resolved[3].name, None,
+                "a malformed id reports None without aborting the batch",
+            );
+        }
+    }
+}

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -50,6 +50,10 @@ pub mod gemini;
 pub mod handle;
 pub mod http;
 pub mod input;
+// `aether.inventory` reverse-lookup inventory cap (ADR-0088 §6, issue
+// 1122). Serves the per-build name/template manifest + dynamic-instance
+// resolve over mail.
+pub mod inventory;
 #[cfg(feature = "render")]
 pub mod render;
 pub mod rpc;
@@ -99,6 +103,7 @@ pub use http::{HttpCapability, HttpConfig};
 pub use input::InputCapability;
 #[cfg(not(target_arch = "wasm32"))]
 pub use input::InputConfig;
+pub use inventory::InventoryCapability;
 
 pub use fs::FsCapability;
 // ADR-0050 `aether.gemini` cap (issue 1015).

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1519,6 +1519,138 @@ mod control_plane {
         },
     }
 
+    // ADR-0088 §6 reverse-lookup inventory actor. The `aether.inventory`
+    // mailbox serves the per-build reverse-lookup inventory over mail so
+    // an out-of-process observer (the MCP harness) reads the running
+    // substrate's *own* inventory instead of a drift-prone compiled-in
+    // copy. Two request kinds:
+    //
+    //   - `aether.inventory.manifest` → the compile-time manifest: every
+    //     declared `NameEntry` + every instanced-family `TemplateEntry`.
+    //     Templates keep their *family shape* (the client expands a
+    //     `Bounded` range / `Declared` domain itself); the manifest does
+    //     NOT flatten to a hash → name map (ADR-0088 §6).
+    //   - `aether.inventory.resolve { ids }` → per-id `Option<String>`,
+    //     the dynamic-instance arm of the resolve chain (ADR-0088 §5) the
+    //     client can't compute from the manifest alone.
+    //
+    // The link-time `aether_data::name_inventory::{NameEntry,
+    // TemplateEntry, ParamKind}` are `&'static` (not wire types), so the
+    // shapes below are owned, schema-hashed mirrors. `domain` rides as
+    // raw bytes (the byte-domain prefix an id is hashed under, e.g.
+    // `MAILBOX_DOMAIN` / `THREAD_DOMAIN`) so the client recomputes hashes
+    // exactly without depending on the substrate's domain consts.
+
+    /// How a [`TemplateEntryWire`]'s single `{…}` hole is filled — the
+    /// wire mirror of `aether_data::name_inventory::ParamKind` (ADR-0088
+    /// §4). The variants preserve the family shape so the client can
+    /// expand / prehash a `Bounded` range or `Declared` domain locally
+    /// the same way the substrate's static reverse map does at boot.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.inventory.param_kind")]
+    pub enum ParamKindWire {
+        /// Finite inclusive integer range (`aether-worker-{0..=255}`).
+        /// The client enumerates `lo..=hi`, substitutes each value into
+        /// the template, and hashes the result for an exact reverse.
+        Bounded { lo: u64, hi: u64 },
+        /// The hole ranges over every [`NameEntryWire`] whose `domain`
+        /// equals `domain` (`aether-root-{NAMESPACE}` over the declared
+        /// mailbox namespaces).
+        Declared { domain: Vec<u8> },
+        /// Instances are minted at runtime from an unbounded parameter
+        /// (`aether-instanced-{full_name}`). The template declares only
+        /// the family's existence + shape; individual instances reverse
+        /// via `aether.inventory.resolve`, not local expansion.
+        Dynamic,
+    }
+
+    /// A declared name on the wire — the mirror of
+    /// `aether_data::name_inventory::NameEntry` (ADR-0088 §3). `domain`
+    /// is the byte-domain prefix the name is hashed under; `name` is the
+    /// declared name (`"aether.fs"`). The client rehashes `name` under
+    /// `domain` to recover the id space exactly.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+    pub struct NameEntryWire {
+        pub domain: Vec<u8>,
+        pub name: String,
+    }
+
+    /// A name template for an instanced family on the wire — the mirror
+    /// of `aether_data::name_inventory::TemplateEntry` (ADR-0088 §4).
+    /// `template` carries one `{…}` hole; [`ParamKindWire`] says how it
+    /// is filled. Preserving the template (rather than its expansion)
+    /// keeps the family shape so the client can declare "ids in this
+    /// family exist and look like *this*" even for `Dynamic` families it
+    /// cannot enumerate.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    pub struct TemplateEntryWire {
+        pub domain: Vec<u8>,
+        pub template: String,
+        pub param: ParamKindWire,
+    }
+
+    /// `aether.inventory.manifest` — request the running substrate's
+    /// compile-time reverse-lookup manifest (ADR-0088 §6). Empty payload;
+    /// the request *is* the signal. Mailed to the `"aether.inventory"`
+    /// mailbox; reply: [`ManifestResult`].
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.inventory.manifest")]
+    pub struct Manifest {}
+
+    /// Reply to [`Manifest`] (ADR-0088 §6). Carries every link-time
+    /// [`NameEntryWire`] (declared names: chassis mailbox namespaces +
+    /// kinds + transforms) and every [`TemplateEntryWire`] (instanced
+    /// families, `Bounded`/`Declared`/`Dynamic`). The client folds
+    /// `names` into a hash → name map and expands `Bounded`/`Declared`
+    /// templates locally; `Dynamic` templates resolve per-id via
+    /// [`Resolve`]. This is the *authoritative, per-build* inventory —
+    /// the served form is always the running substrate's own.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.inventory.manifest_result")]
+    pub struct ManifestResult {
+        pub names: Vec<NameEntryWire>,
+        pub templates: Vec<TemplateEntryWire>,
+    }
+
+    /// `aether.inventory.resolve` — request per-id reverse lookup
+    /// (ADR-0088 §5/§6). `ids` are ADR-0064 tagged-id strings
+    /// (`mbx-…` / `knd-…` / `thr-…` / `trn-…`) — the same wire form the
+    /// MCP surface carries elsewhere. Used on a *local miss*: the client
+    /// resolves statics + expandable templates from the manifest itself,
+    /// then asks the substrate only for dynamic-instance ids it can't
+    /// compute. Mailed to the `"aether.inventory"` mailbox; reply:
+    /// [`ResolveResult`].
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.inventory.resolve")]
+    pub struct Resolve {
+        pub ids: Vec<String>,
+    }
+
+    /// One id → name pairing in a [`ResolveResult`] (ADR-0088 §6). `id`
+    /// echoes the request's tagged-id string so the caller correlates
+    /// without relying on positional order; `name` is the resolved origin
+    /// name, or `None` on a full miss (the id wasn't in the static map,
+    /// any prehashed template, or the runtime registry — the caller falls
+    /// back to rendering the tagged-id string per ADR-0064, exactly what
+    /// it showed before the inventory existed). Per the explicit-nulls
+    /// convention every entry addresses its `name` Option directly.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+    pub struct ResolvedName {
+        pub id: String,
+        pub name: Option<String>,
+    }
+
+    /// Reply to [`Resolve`] (ADR-0088 §6). One [`ResolvedName`] per
+    /// requested id, in request order (and each echoing its `id` so the
+    /// caller can correlate without depending on order). An id that fails
+    /// to parse as a tagged-id string is reported as `name: None` rather
+    /// than aborting the batch — one bad id doesn't sink its siblings.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.inventory.resolve_result")]
+    pub struct ResolveResult {
+        pub resolved: Vec<ResolvedName>,
+    }
+
     // Mesh-viewer structured load replies (issue 964). The mesh-viewer
     // component's `aether.mesh.load` was fire-and-forget — failures
     // warn-logged and the prior cache stayed, with no wire signal a
@@ -2534,6 +2666,10 @@ mod tests {
         assert_eq!(DeleteResult::NAME, "aether.fs.delete_result");
         assert_eq!(List::NAME, "aether.fs.list");
         assert_eq!(ListResult::NAME, "aether.fs.list_result");
+        assert_eq!(Manifest::NAME, "aether.inventory.manifest");
+        assert_eq!(ManifestResult::NAME, "aether.inventory.manifest_result");
+        assert_eq!(Resolve::NAME, "aether.inventory.resolve");
+        assert_eq!(ResolveResult::NAME, "aether.inventory.resolve_result");
     }
 
     // ADR-0019 PR 3 — every kind below now has a derived `Schema` impl

--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -19,8 +19,8 @@ use aether_capabilities::rpc::{PeerKind, RpcServerCapability, RpcServerConfig};
 use aether_capabilities::{
     AnthropicCapability, AnthropicConfig, ComponentHostCapability, ComponentHostConfig,
     DagCapability, FsCapability, GeminiCapability, GeminiConfig, HandleCapability, HttpCapability,
-    InputCapability, InputConfig, TcpCapability, fs::NamespaceRoots, http::HttpConfig,
-    trace::TraceDispatchCapability,
+    InputCapability, InputConfig, InventoryCapability, TcpCapability, fs::NamespaceRoots,
+    http::HttpConfig, trace::TraceDispatchCapability,
 };
 use aether_data::{Kind, MailboxId as DataMailboxId, mailbox_id_from_name};
 use aether_kinds::{Shutdown, Tick};
@@ -91,6 +91,7 @@ pub fn with_common_caps<C: Chassis>(builder: Builder<C>, boot: CommonBoot) -> Bu
         .with_actor::<InputCapability>(boot.input_config)
         .with_actor::<ComponentHostCapability>(boot.component_host_config)
         .with_actor::<FsCapability>(boot.namespace_roots)
+        .with_actor::<InventoryCapability>(())
         .with_actor::<HttpCapability>(boot.http)
         .with_actor::<TcpCapability>(())
         .with_actor::<AnthropicCapability>(boot.anthropic)

--- a/crates/aether-substrate/src/runtime/thread_name.rs
+++ b/crates/aether-substrate/src/runtime/thread_name.rs
@@ -138,7 +138,16 @@ fn static_map() -> &'static BTreeMap<u64, String> {
 /// Separate from [`resolve`] so the four-step chain reads cleanly and so
 /// callers that specifically want the runtime arm (tests, diagnostics)
 /// can reach it without the static-map / hex-fallback steps.
-fn resolve_runtime(id: u64) -> Option<String> {
+///
+/// This is the arm the `aether.inventory.resolve` actor (ADR-0088 §6)
+/// serves: a client folds the manifest's declared names + expandable
+/// templates locally, so the only thing it *can't* compute is a
+/// dynamically-minted instance — exactly what this map holds. Returning
+/// `None` on a miss (rather than the hex fallback [`resolve`] applies)
+/// lets the wire reply carry `Option<String>` with `None` meaning "fall
+/// back to rendering the ADR-0064 tagged-id string yourself."
+#[must_use]
+pub fn resolve_runtime(id: u64) -> Option<String> {
     registry()
         .read()
         .unwrap_or_else(PoisonError::into_inner)


### PR DESCRIPTION
## Summary

Phase 3 of ADR-0088 (tracker iamacoffeepot/aether#1124): the **`aether.inventory` actor** (ADR-0088 §6) serves the reverse-lookup inventory over mail, so the out-of-process MCP reads the running substrate's **own, per-build** inventory instead of a drift-prone compiled-in copy.

- **`aether.inventory`** chassis mailbox — a `#[bridge(singleton)]` `InventoryCapability`, registered on desktop + headless via `with_common_caps` (not hub), matching `aether.fs`. (It auto-submits its own `NameEntry` via the phase-2 macro.)
- **`aether.inventory.manifest` -> `ManifestResult { names, templates }`** — owned wire mirrors (`NameEntryWire` / `TemplateEntryWire` / `ParamKindWire`) of the link-time inventories. Ships the **templates with their family shape** (`Bounded` / `Declared` / `Dynamic`), so the client expands/prehashes locally — *not* flattened to a hash->name map (§6). `domain` rides as raw bytes so the client recomputes hashes exactly.
- **`aether.inventory.resolve { ids } -> ResolveResult`** — per-id, order-preserving, `id`-echoing reverse lookup of dynamic-instance ids via the runtime-registry arm (`resolve_runtime`). `None` on a miss or a malformed id (one bad id doesn't sink the batch); the caller renders the ADR-0064 tagged-id string itself.

## Validation

- `scripts/preflight.sh` green: fmt + clippy (`-D warnings`) + doc + wasm32 cross-build + nextest (1259 passed, 0 failed).
- Cap unit tests: the served manifest carries a real chassis name (`aether.fs`) + a known `Bounded` template (`aether-worker-{N}`); `resolve` returns a registered dynamic instance's name and `None` for unregistered / static / malformed ids (order + `id` echo preserved).

Closes iamacoffeepot/aether#1122. ADR-0088; tracker iamacoffeepot/aether#1124. Follows iamacoffeepot/aether#1126 (phase 2).