### PR TITLE
feat(mcp): render real names via the inventory (ADR-0088 phase 4)

### DIFF
--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -67,7 +67,8 @@ pub use ids::{
 pub use mail::{MailId, ReplyTarget, ReplyTo};
 #[cfg(not(target_arch = "wasm32"))]
 pub use name_inventory::{
-    NameEntry, ParamKind, TemplateEntry, build_static_reverse_map, name_entries, template_entries,
+    NameEntry, ParamKind, TemplateEntry, build_static_reverse_map, fill_template, id_for_name,
+    name_entries, template_entries,
 };
 pub use schema::*;
 pub use tagged_id::{Tag, with_tag};

--- a/crates/aether-data/src/name_inventory.rs
+++ b/crates/aether-data/src/name_inventory.rs
@@ -158,7 +158,13 @@ fn tag_for_domain(domain: &[u8]) -> Option<Tag> {
 
 /// Reconstruct the tagged id for `name` under `domain`, matching the id
 /// space exactly. `None` if `domain` isn't a known tagged-id family.
-fn id_for_name(domain: &[u8], name: &str) -> Option<u64> {
+///
+/// Public so the `aether-mcp` client arm (ADR-0088 §8) reconstructs ids
+/// from a served manifest's wire `domain` bytes through the *same* hash +
+/// tag derivation the substrate uses to build its static reverse map —
+/// one shared helper rather than a drift-prone re-implementation.
+#[must_use]
+pub fn id_for_name(domain: &[u8], name: &str) -> Option<u64> {
     let tag = tag_for_domain(domain)?;
     Some(with_tag(tag, fnv1a_64_prefixed(domain, name.as_bytes())))
 }
@@ -166,7 +172,11 @@ fn id_for_name(domain: &[u8], name: &str) -> Option<u64> {
 /// Substitute `value` for the single `{…}` hole in `template`. Returns
 /// `None` if the template has no `{` / `}` pair, which is an authoring
 /// error (a template with no hole is just a `NameEntry`).
-fn fill_template(template: &str, value: &str) -> Option<String> {
+///
+/// Public so the `aether-mcp` client arm (ADR-0088 §8) expands templates
+/// the same way [`build_static_reverse_map`] does — see [`id_for_name`].
+#[must_use]
+pub fn fill_template(template: &str, value: &str) -> Option<String> {
     let open = template.find('{')?;
     let close = template[open..].find('}')? + open;
     let mut out = String::with_capacity(template.len() + value.len());

--- a/crates/aether-mcp/src/main.rs
+++ b/crates/aether-mcp/src/main.rs
@@ -14,6 +14,7 @@ use std::env;
 use tokio::net::TcpListener;
 use tokio::task;
 mod args;
+mod reverse;
 mod rpc;
 #[cfg(test)]
 mod test_chassis;
@@ -25,7 +26,7 @@ use rmcp::transport::streamable_http_server::session::local::LocalSessionManager
 use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
 
 use crate::rpc::RpcSession;
-use crate::tools::{ComponentCache, Mcp};
+use crate::tools::{ComponentCache, Mcp, ReverseNameCache};
 
 /// Default port the MCP HTTP server binds. Distinct from the embedded
 /// hub MCP's 8888 so the two coexist until the P5d cutover.
@@ -72,13 +73,21 @@ async fn main() -> anyhow::Result<()> {
     // populate it, `describe_component` reads it.
     let components: Arc<ComponentCache> = Arc::new(ComponentCache::default());
 
+    // Process-wide per-engine reverse-name cache (ADR-0088 §8), shared
+    // into every per-session `Mcp` — built lazily from each engine's
+    // served `aether.inventory` manifest the first time MCP renders an id
+    // for that engine, then reused across tool calls and sessions.
+    let names: Arc<ReverseNameCache> = Arc::new(ReverseNameCache::default());
+
     let factory_session = Arc::clone(&session);
     let factory_components = Arc::clone(&components);
+    let factory_names = Arc::clone(&names);
     let service = StreamableHttpService::new(
         move || {
             Ok(Mcp::new(
                 Arc::clone(&factory_session),
                 Arc::clone(&factory_components),
+                Arc::clone(&factory_names),
             ))
         },
         Arc::new(LocalSessionManager::default()),

--- a/crates/aether-mcp/src/reverse.rs
+++ b/crates/aether-mcp/src/reverse.rs
@@ -1,0 +1,329 @@
+//! ADR-0088 §8 client-side reverse-lookup map — the `aether-mcp` arm of
+//! the identifier reverse-lookup inventory.
+//!
+//! Every substrate id is a one-way hash (ADR-0029/0030/0064): you cannot
+//! recover the origin name from the id. ADR-0088 layers an additive side
+//! table over the ids; the substrate serves it over mail through the
+//! `aether.inventory` cap. This module folds that served manifest into a
+//! local `hash → name` map so MCP renders real names (`aether.audio`,
+//! `aether.fs.read`, `aether-worker-3`) instead of the ADR-0064 hex tag
+//! (`mbx-q3lr-…`) it shows today — with the hex tag as the unchanged
+//! fallback on a miss.
+//!
+//! ## The reverse-lookup chain (ADR-0088 §2)
+//!
+//! Given an id, [`EngineNames::render`] recovers its origin name by:
+//!
+//! 1. **Static + template map** — the manifest's [`NameEntryWire`]s
+//!    (rehashed under their `domain`) and its expandable templates
+//!    (`Bounded` enumerated `lo..=hi`; `Declared` over the matching-domain
+//!    names). Built once per engine by [`build_static_reverse_map`].
+//! 2. **Dynamic-resolve cache** — runtime-minted instance ids (the
+//!    `Dynamic` template families) resolved per-id via
+//!    `aether.inventory.resolve` and cached here (positive *and* negative,
+//!    so a miss isn't re-queried every render).
+//! 3. **Miss → ADR-0064 hex tag** — exactly what MCP showed before the
+//!    inventory existed. Reversal is a strict upgrade; nothing regresses.
+//!
+//! `Handle` / `Dag` ids stay hex — they are counter-backed, with no origin
+//! name to recover, so they never enter this map.
+//!
+//! The expansion in [`build_static_reverse_map`] mirrors the substrate's
+//! own `aether_data::build_static_reverse_map` (the `Bounded` /
+//! `Declared` / `Dynamic` handling and the `domain`-rehash), reusing its
+//! `id_for_name` + `fill_template` helpers verbatim so the hash + tag
+//! derivation can't drift; it only differs in reading the served wire
+//! types (`Vec<u8>` domains) rather than the link-time inventory — the
+//! served manifest is the *authoritative per-build* copy.
+
+use std::collections::HashMap;
+
+use aether_data::tagged_id;
+use aether_data::{fill_template, id_for_name};
+use aether_kinds::{ManifestResult, NameEntryWire, ParamKindWire, TemplateEntryWire};
+
+/// Fold a served [`ManifestResult`] into a `hash → name` reverse map
+/// (ADR-0088 §3/§4), mirroring the substrate's
+/// `name_inventory::build_static_reverse_map` over the wire types.
+///
+/// Contributions, in insertion order (later inserts win on the
+/// vanishingly-unlikely 60-bit collision):
+///
+/// 1. Every [`NameEntryWire`], rehashed under its `domain` (covers
+///    declared mailbox namespaces, kinds, and transforms — the substrate
+///    submits all three as name entries on the wire).
+/// 2. Every `Bounded` [`TemplateEntryWire`], each `lo..=hi` instantiation
+///    enumerated + prehashed.
+/// 3. Every `Declared` [`TemplateEntryWire`], instantiated over the
+///    matching-`domain` [`NameEntryWire`] names.
+///
+/// `Dynamic` templates contribute nothing — their instances reverse via
+/// `aether.inventory.resolve` (the dynamic-resolve cache), not this map.
+#[must_use]
+pub fn build_static_reverse_map(manifest: &ManifestResult) -> HashMap<u64, String> {
+    let mut map: HashMap<u64, String> = HashMap::new();
+
+    // 1. Declared names (mailbox namespaces, kinds, transforms).
+    for entry in &manifest.names {
+        if let Some(id) = id_for_name(&entry.domain, &entry.name) {
+            map.insert(id, entry.name.clone());
+        }
+    }
+
+    // 2 + 3. Templates: enumerate Bounded / Declared, prehash each
+    //         instantiation. Dynamic templates declare shape only.
+    for tmpl in &manifest.templates {
+        match &tmpl.param {
+            ParamKindWire::Bounded { lo, hi } => {
+                for n in *lo..=*hi {
+                    let value = n.to_string();
+                    if let Some(name) = fill_template(&tmpl.template, &value)
+                        && let Some(id) = id_for_name(&tmpl.domain, &name)
+                    {
+                        map.insert(id, name);
+                    }
+                }
+            }
+            ParamKindWire::Declared { domain } => {
+                expand_declared(&mut map, tmpl, domain, &manifest.names);
+            }
+            ParamKindWire::Dynamic => {}
+        }
+    }
+
+    map
+}
+
+/// Instantiate a `Declared` template over every [`NameEntryWire`] whose
+/// `domain` matches `domain`, inserting each into `map`. Factored out of
+/// [`build_static_reverse_map`] to keep the match arms flat.
+fn expand_declared(
+    map: &mut HashMap<u64, String>,
+    tmpl: &TemplateEntryWire,
+    domain: &[u8],
+    names: &[NameEntryWire],
+) {
+    for entry in names {
+        if entry.domain != domain {
+            continue;
+        }
+        if let Some(name) = fill_template(&tmpl.template, &entry.name)
+            && let Some(id) = id_for_name(&tmpl.domain, &name)
+        {
+            map.insert(id, name);
+        }
+    }
+}
+
+/// One engine's reverse-lookup state: the static + template map folded
+/// from its served manifest, plus a per-id dynamic-resolve cache
+/// (positive and negative) for runtime-minted instance ids.
+///
+/// Per-engine because statics are build-identical across engines but the
+/// dynamic instances differ (each substrate mints its own
+/// `aether-instanced-…` / trampoline names). Cached for the engine's
+/// lifetime; `aether-mcp` rebuilds it lazily on first need.
+pub struct EngineNames {
+    /// Folded static + expandable-template reverse map (step 1 of the
+    /// chain). Empty if the engine never answered the manifest — every
+    /// lookup then falls through to the dynamic cache / hex tag.
+    static_map: HashMap<u64, String>,
+    /// Per-id results of `aether.inventory.resolve` (step 2). `Some(name)`
+    /// for a resolved dynamic instance; `None` for a confirmed miss, so a
+    /// missing id isn't re-queried on every render. Keyed on the raw
+    /// `u64` id (the tagged-string is reconstructable from it).
+    dynamic: HashMap<u64, Option<String>>,
+}
+
+impl EngineNames {
+    /// Build the per-engine state from a served manifest. The dynamic
+    /// cache starts empty and fills on demand from `resolve` replies.
+    #[must_use]
+    pub fn from_manifest(manifest: &ManifestResult) -> Self {
+        Self {
+            static_map: build_static_reverse_map(manifest),
+            dynamic: HashMap::new(),
+        }
+    }
+
+    /// Look up `id` in the static + template map (step 1) and then the
+    /// dynamic-resolve cache (step 2). `None` if neither holds it — the
+    /// caller batches it into an `aether.inventory.resolve` query and,
+    /// failing that, falls back to the hex tag.
+    #[must_use]
+    pub fn lookup(&self, id: u64) -> Option<&str> {
+        if let Some(name) = self.static_map.get(&id) {
+            return Some(name);
+        }
+        // A cached negative (`Some(&None)`) is a confirmed dynamic miss —
+        // report it as "not found" so the caller renders the hex tag,
+        // without re-issuing a resolve query.
+        self.dynamic.get(&id).and_then(Option::as_deref)
+    }
+
+    /// `true` if `id` is neither in the static map nor the dynamic cache
+    /// — i.e. it needs an `aether.inventory.resolve` round trip. A
+    /// confirmed dynamic miss (cached `None`) returns `false`: it has been
+    /// resolved, just to "no name".
+    #[must_use]
+    pub fn needs_resolve(&self, id: u64) -> bool {
+        !self.static_map.contains_key(&id) && !self.dynamic.contains_key(&id)
+    }
+
+    /// Record a `resolve` reply for `id` — `Some(name)` for a hit,
+    /// `None` for a confirmed miss (cached so it isn't re-queried).
+    pub fn cache_resolved(&mut self, id: u64, name: Option<String>) {
+        self.dynamic.insert(id, name);
+    }
+
+    /// Render `id` as a display string: its real name on a hit (step 1 /
+    /// step 2), else the ADR-0064 tagged-id string, else a hex literal if
+    /// even the tag bits are unencodable (the `0x0` sentinel / a reserved
+    /// tag). Never queries — call [`Self::needs_resolve`] +
+    /// [`Self::cache_resolved`] first to fill dynamic misses.
+    #[must_use]
+    pub fn render(&self, id: u64) -> String {
+        if let Some(name) = self.lookup(id) {
+            return name.to_owned();
+        }
+        tagged_id::encode(id).unwrap_or_else(|| format!("{id:#x}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_data::hash::{mailbox_id_from_name, thread_id_from_name};
+    use aether_data::{KIND_DOMAIN, MAILBOX_DOMAIN, THREAD_DOMAIN};
+
+    /// Build a synthetic manifest with a `NameEntry` (a mailbox name + a
+    /// kind name), a `Bounded` template (`aether-test-worker-{N}`), and a
+    /// `Declared` template (`aether-test-root-{NAMESPACE}` over the
+    /// mailbox names). Mirrors the shapes the substrate serves.
+    fn synthetic_manifest() -> ManifestResult {
+        ManifestResult {
+            names: vec![
+                NameEntryWire {
+                    domain: MAILBOX_DOMAIN.to_vec(),
+                    name: "aether.audio".to_string(),
+                },
+                NameEntryWire {
+                    domain: KIND_DOMAIN.to_vec(),
+                    name: "aether.fs.read".to_string(),
+                },
+            ],
+            templates: vec![
+                TemplateEntryWire {
+                    domain: THREAD_DOMAIN.to_vec(),
+                    template: "aether-test-worker-{N}".to_string(),
+                    param: ParamKindWire::Bounded { lo: 0, hi: 3 },
+                },
+                TemplateEntryWire {
+                    domain: THREAD_DOMAIN.to_vec(),
+                    template: "aether-test-root-{NAMESPACE}".to_string(),
+                    param: ParamKindWire::Declared {
+                        domain: MAILBOX_DOMAIN.to_vec(),
+                    },
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn static_mailbox_name_reverses() {
+        let names = EngineNames::from_manifest(&synthetic_manifest());
+        let id = mailbox_id_from_name("aether.audio");
+        assert_eq!(names.render(id.0), "aether.audio");
+    }
+
+    #[test]
+    fn static_kind_name_reverses() {
+        let names = EngineNames::from_manifest(&synthetic_manifest());
+        // A kind id is `with_tag(Kind, fnv1a_64_prefixed(KIND_DOMAIN, name))`.
+        let id = id_for_name(KIND_DOMAIN, "aether.fs.read").expect("kind domain is taggable");
+        assert_eq!(names.render(id), "aether.fs.read");
+    }
+
+    #[test]
+    fn bounded_template_instance_reverses() {
+        let names = EngineNames::from_manifest(&synthetic_manifest());
+        for n in 0..=3 {
+            let name = format!("aether-test-worker-{n}");
+            let id = thread_id_from_name(&name);
+            assert_eq!(
+                names.render(id.0),
+                name,
+                "bounded template instance {name} should reverse",
+            );
+        }
+    }
+
+    #[test]
+    fn declared_template_instance_reverses() {
+        let names = EngineNames::from_manifest(&synthetic_manifest());
+        // `aether-test-root-{NAMESPACE}` ranges over the mailbox names —
+        // `aether.audio` is the one mailbox-domain NameEntry.
+        let name = "aether-test-root-aether.audio";
+        let id = thread_id_from_name(name);
+        assert_eq!(names.render(id.0), name);
+    }
+
+    #[test]
+    fn unknown_id_falls_back_to_hex_tag() {
+        let names = EngineNames::from_manifest(&synthetic_manifest());
+        // A thread name outside the bounded range and never declared.
+        let id = thread_id_from_name("aether-test-worker-99");
+        let rendered = names.render(id.0);
+        let expected = tagged_id::encode(id.0).expect("thread id is taggable");
+        assert_eq!(rendered, expected, "an unknown id renders the hex tag");
+        assert!(rendered.starts_with("thr-"));
+    }
+
+    #[test]
+    fn needs_resolve_then_dynamic_cache_resolves() {
+        let mut names = EngineNames::from_manifest(&synthetic_manifest());
+        // A dynamic instance id — not in any static / template entry.
+        let id = thread_id_from_name("aether-instanced-player:42");
+        assert!(names.needs_resolve(id.0), "a dynamic id needs a resolve");
+        // Hex tag until resolved.
+        let tag = tagged_id::encode(id.0).expect("thread id is taggable");
+        assert_eq!(names.render(id.0), tag);
+
+        names.cache_resolved(id.0, Some("aether-instanced-player:42".to_string()));
+        assert!(
+            !names.needs_resolve(id.0),
+            "a resolved id no longer needs a query",
+        );
+        assert_eq!(names.render(id.0), "aether-instanced-player:42");
+    }
+
+    #[test]
+    fn cached_negative_resolve_is_not_requeried() {
+        let mut names = EngineNames::from_manifest(&synthetic_manifest());
+        let id = thread_id_from_name("aether-instanced-gone:1");
+        names.cache_resolved(id.0, None);
+        assert!(
+            !names.needs_resolve(id.0),
+            "a confirmed miss is cached, not re-queried",
+        );
+        // Still renders the hex tag — the miss didn't manufacture a name.
+        let tag = tagged_id::encode(id.0).expect("thread id is taggable");
+        assert_eq!(names.render(id.0), tag);
+    }
+
+    #[test]
+    fn empty_manifest_falls_back_to_hex() {
+        let empty = ManifestResult {
+            names: vec![],
+            templates: vec![],
+        };
+        let names = EngineNames::from_manifest(&empty);
+        let id = mailbox_id_from_name("aether.audio");
+        let tag = tagged_id::encode(id.0).expect("mailbox id is taggable");
+        assert_eq!(
+            names.render(id.0),
+            tag,
+            "with no manifest folded, every id renders the hex tag",
+        );
+    }
+}

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -50,8 +50,10 @@ use crate::args::{
     ReplaceComponentArgs, SendMailArgs, SendMailTracedArgs, SendMailTracedResponse,
     SpawnSubstrateArgs, SubmitDagArgs, TerminateSubstrateArgs, TracedMailSpec, TransformListing,
 };
+use crate::reverse::EngineNames;
 use crate::rpc::RpcSession;
 use aether_kinds::descriptors;
+use aether_kinds::{Manifest, ManifestResult, Resolve, ResolveResult};
 use base64::engine::general_purpose::STANDARD;
 use std::time::Duration;
 use tokio::fs;
@@ -68,12 +70,26 @@ const RENDER_CAP: &str = "aether.render";
 const HANDLE_CAP: &str = "aether.handle";
 /// Mailbox name of a substrate's DAG-executor cap (ADR-0047).
 const DAG_CAP: &str = "aether.dag";
+/// Mailbox name of a substrate's reverse-lookup inventory cap
+/// (ADR-0088 §6) — the `aether.inventory.manifest` / `resolve` target.
+const INVENTORY_CAP: &str = "aether.inventory";
 
 /// Component receive-side capabilities, keyed by `(engine, mailbox)`.
 /// Populated from `load_component` / `replace_component` replies and
 /// read by `describe_component` — the forward-model stand-in for the
 /// embedded hub's component registry.
 pub type ComponentCache = Mutex<HashMap<(EngineId, MailboxId), ComponentCapabilities>>;
+
+/// Per-engine reverse-lookup state, keyed by [`EngineId`] (ADR-0088 §8).
+/// Each [`EngineNames`] folds that engine's served `aether.inventory`
+/// manifest into a `hash → name` map plus a dynamic-resolve cache. Built
+/// lazily on first need (the first id render for an engine), cached for
+/// the engine's lifetime, and shared across cloned [`Mcp`] sessions —
+/// statics are build-identical but dynamic instances are per-engine, so
+/// the map can't be process-global. An engine that doesn't answer the
+/// manifest gets an empty map (every lookup falls back to hex) rather
+/// than erroring the tool.
+pub type ReverseNameCache = Mutex<HashMap<EngineId, EngineNames>>;
 
 /// Per-session MCP service. `rmcp` calls the factory once per session
 /// and may clone the result for concurrent tool dispatch — `session`
@@ -83,6 +99,9 @@ pub type ComponentCache = Mutex<HashMap<(EngineId, MailboxId), ComponentCapabili
 pub struct Mcp {
     session: Arc<RpcSession>,
     components: Arc<ComponentCache>,
+    /// Per-engine reverse-lookup maps (ADR-0088 §8), shared across cloned
+    /// sessions so a manifest fetched for one tool call serves the next.
+    names: Arc<ReverseNameCache>,
     // The `#[tool_router]` macro stores the router instance here; it's
     // consumed by `#[tool_handler]` codegen rather than read by name, so
     // the dead-code lint fires under `-D warnings` despite the field
@@ -93,11 +112,16 @@ pub struct Mcp {
 
 impl Mcp {
     /// Construct a per-session service over an established hub
-    /// connection + the process-wide component cache.
-    pub fn new(session: Arc<RpcSession>, components: Arc<ComponentCache>) -> Self {
+    /// connection + the process-wide component and reverse-name caches.
+    pub fn new(
+        session: Arc<RpcSession>,
+        components: Arc<ComponentCache>,
+        names: Arc<ReverseNameCache>,
+    ) -> Self {
         Self {
             session,
             components,
+            names,
             tool_router: Self::tool_router(),
         }
     }
@@ -288,12 +312,27 @@ impl Mcp {
                 root,
                 in_flight,
                 mails,
-            } => json(&SendMailTracedResponse {
-                status: "settled".into(),
-                root: Some(mail_id_to_json(root)),
-                mails: Some(mails.into_iter().map(mail_node_to_json).collect()),
-                in_flight: Some(in_flight),
-            }),
+            } => {
+                // Reverse mailbox / kind ids to real names through the
+                // engine's inventory map (ADR-0088 §8). `render_mail_nodes`
+                // builds + resolves the map; the root id then renders
+                // through the now-populated cache (its sender is the
+                // chassis mailbox — a static name).
+                let mails = self.render_mail_nodes(engine, mails).await;
+                let root = {
+                    let cache = self
+                        .names
+                        .lock()
+                        .expect("reverse-name cache mutex is never poisoned");
+                    mail_id_to_json(root, cache.get(&engine))
+                };
+                json(&SendMailTracedResponse {
+                    status: "settled".into(),
+                    root: Some(root),
+                    mails: Some(mails),
+                    in_flight: Some(in_flight),
+                })
+            }
             DescribeTreeResult::Err { not_found } => Err(internal_msg(&format!(
                 "describe_tree: root {not_found:?} not found"
             ))),
@@ -749,6 +788,141 @@ impl Mcp {
         };
         self.session.call_settled(envelope).await
     }
+
+    /// Ensure `engine`'s reverse-name map is built (ADR-0088 §8). On the
+    /// first need for an engine, fetch `aether.inventory.manifest` and
+    /// fold it into an [`EngineNames`]; on any subsequent call the cached
+    /// map is reused. An engine that doesn't answer the manifest (older
+    /// build, headless without the cap, transient error) gets an empty
+    /// map cached — every lookup then falls back to the hex tag rather
+    /// than erroring the tool or re-fetching on every render.
+    async fn ensure_names(&self, engine: EngineId) {
+        if self
+            .names
+            .lock()
+            .expect("reverse-name cache mutex is never poisoned")
+            .contains_key(&engine)
+        {
+            return;
+        }
+        // Fetch outside the lock — the await must not hold a std Mutex.
+        // No / undecodable reply caches an empty map so we fall back to
+        // hex for this engine without re-querying every render.
+        let manifest = self
+            .session
+            .call_one(engine_envelope(engine, INVENTORY_CAP, &Manifest {}))
+            .await
+            .ok()
+            .and_then(|reply| ManifestResult::decode_from_bytes(&reply.payload))
+            .unwrap_or_else(|| ManifestResult {
+                names: Vec::new(),
+                templates: Vec::new(),
+            });
+        let mut cache = self
+            .names
+            .lock()
+            .expect("reverse-name cache mutex is never poisoned");
+        // A concurrent session may have populated it while we awaited —
+        // first writer wins, both maps are equivalent.
+        cache
+            .entry(engine)
+            .or_insert_with(|| EngineNames::from_manifest(&manifest));
+    }
+
+    /// Batch-resolve `ids` that the engine's static map missed via
+    /// `aether.inventory.resolve` and fold the answers (positive *and*
+    /// negative) into the per-engine dynamic cache. A no-op when `ids` is
+    /// empty or the resolve call fails — the unresolved ids then render
+    /// as hex tags. `ids` are raw `u64`s; the resolve wire takes tagged
+    /// strings, so each is encoded for the request and decoded back for
+    /// the cache key.
+    async fn resolve_dynamic(&self, engine: EngineId, ids: &[u64]) {
+        if ids.is_empty() {
+            return;
+        }
+        let tagged: Vec<String> = ids.iter().filter_map(|id| tagged_id::encode(*id)).collect();
+        if tagged.is_empty() {
+            return;
+        }
+        let Some(ResolveResult { resolved }) = self
+            .session
+            .call_one(engine_envelope(
+                engine,
+                INVENTORY_CAP,
+                &Resolve { ids: tagged },
+            ))
+            .await
+            .ok()
+            .and_then(|reply| ResolveResult::decode_from_bytes(&reply.payload))
+        else {
+            return;
+        };
+        let mut cache = self
+            .names
+            .lock()
+            .expect("reverse-name cache mutex is never poisoned");
+        if let Some(names) = cache.get_mut(&engine) {
+            for entry in resolved {
+                if let Ok(id) = tagged_id::decode(&entry.id) {
+                    names.cache_resolved(id, entry.name);
+                }
+            }
+        }
+    }
+
+    /// Reverse-render every id in a settled trace tree to a real name
+    /// (ADR-0088 §8). Builds the engine's reverse map if needed, collects
+    /// the ids that the static map misses, resolves them in one batched
+    /// `aether.inventory.resolve` query, then renders each `MailNodeWire`
+    /// through the now-populated map — falling back to the ADR-0064 hex
+    /// tag for any id that resolves to nothing. `Handle` / `Dag` ids stay
+    /// hex (they never enter the reverse map).
+    async fn render_mail_nodes(
+        &self,
+        engine: EngineId,
+        nodes: Vec<MailNodeWire>,
+    ) -> Vec<MailNodeJson> {
+        self.ensure_names(engine).await;
+
+        // Collect the mailbox / kind / thread ids that the static map
+        // misses, so one batched resolve covers the whole tree.
+        let mut misses: Vec<u64> = Vec::new();
+        {
+            let cache = self
+                .names
+                .lock()
+                .expect("reverse-name cache mutex is never poisoned");
+            if let Some(names) = cache.get(&engine) {
+                for node in &nodes {
+                    for id in node_reversible_ids(node) {
+                        if names.needs_resolve(id) {
+                            misses.push(id);
+                        }
+                    }
+                }
+            }
+        }
+        misses.sort_unstable();
+        misses.dedup();
+        self.resolve_dynamic(engine, &misses).await;
+
+        let cache = self
+            .names
+            .lock()
+            .expect("reverse-name cache mutex is never poisoned");
+        match cache.get(&engine) {
+            Some(names) => nodes
+                .into_iter()
+                .map(|node| mail_node_to_json(node, Some(names)))
+                .collect(),
+            // No map for this engine (shouldn't happen post-ensure, but
+            // be defensive): render every id as a hex tag.
+            None => nodes
+                .into_iter()
+                .map(|n| mail_node_to_json(n, None))
+                .collect(),
+        }
+    }
 }
 
 #[tool_handler]
@@ -942,36 +1116,67 @@ fn encode_traced_bundle(
         .collect()
 }
 
-/// Encode an unwrapped raw `u64` mailbox id as the tagged-id string the
-/// MCP wire surfaces (`mbx-…`, ADR-0064). Panics only if the id has
-/// no tag bits set — chassis-minted ids always do.
-fn mailbox_id_to_tagged(id: MailboxId) -> String {
-    tagged_id::encode(id.0).expect("mailbox id is taggable")
+/// Render a raw `u64` mailbox / kind / thread id to its display string
+/// (ADR-0088 §8): the engine's real name when `names` resolves it, else
+/// the ADR-0064 tagged-id string (`mbx-…` / `knd-…` / `thr-…`), else a
+/// hex literal if the tag bits are unencodable. `names == None` (no
+/// reverse map for the engine) renders the tag directly — the unchanged
+/// pre-inventory output.
+fn render_id(id: u64, names: Option<&EngineNames>) -> String {
+    names.map_or_else(
+        || tagged_id::encode(id).unwrap_or_else(|| format!("{id:#x}")),
+        |names| names.render(id),
+    )
 }
 
-fn kind_id_to_tagged(id: KindId) -> String {
-    tagged_id::encode(id.0).expect("kind id is taggable")
+/// Reverse-render a [`MailboxId`] through the engine's name map (or the
+/// hex tag on a miss / no map). Chassis-minted ids always carry tag bits,
+/// so the hex fallback never reaches the `{:#x}` arm in practice.
+fn mailbox_id_to_tagged(id: MailboxId, names: Option<&EngineNames>) -> String {
+    render_id(id.0, names)
 }
 
-fn mail_id_to_json(id: MailId) -> MailIdJson {
+fn kind_id_to_tagged(id: KindId, names: Option<&EngineNames>) -> String {
+    render_id(id.0, names)
+}
+
+fn mail_id_to_json(id: MailId, names: Option<&EngineNames>) -> MailIdJson {
     MailIdJson {
-        sender: mailbox_id_to_tagged(id.sender),
+        sender: mailbox_id_to_tagged(id.sender, names),
         correlation_id: id.correlation_id,
     }
 }
 
-fn mail_node_to_json(node: MailNodeWire) -> MailNodeJson {
+fn mail_node_to_json(node: MailNodeWire, names: Option<&EngineNames>) -> MailNodeJson {
     MailNodeJson {
-        mail_id: mail_id_to_json(node.mail_id),
-        parent: node.parent.map(mail_id_to_json),
-        sender: mailbox_id_to_tagged(node.sender),
-        recipient: mailbox_id_to_tagged(node.recipient),
-        kind: kind_id_to_tagged(node.kind),
+        mail_id: mail_id_to_json(node.mail_id, names),
+        parent: node.parent.map(|p| mail_id_to_json(p, names)),
+        sender: mailbox_id_to_tagged(node.sender, names),
+        recipient: mailbox_id_to_tagged(node.recipient, names),
+        kind: kind_id_to_tagged(node.kind, names),
         t_sent: node.t_sent.0,
         t_received: node.t_received.map(|n| n.0),
         t_finished: node.t_finished.map(|n| n.0),
         thread_name: node.thread_name,
     }
+}
+
+/// The mailbox / kind / thread ids in one `MailNodeWire` that reverse
+/// through the inventory (ADR-0088 §8): the two mailbox endpoints, the
+/// kind, and both `MailId` senders. `correlation_id` is a `Uuid`, not a
+/// tagged id, so it's excluded. Thread ids ride in `thread_name` already
+/// resolved substrate-side, so they aren't re-resolved here.
+fn node_reversible_ids(node: &MailNodeWire) -> Vec<u64> {
+    let mut ids = vec![
+        node.sender.0,
+        node.recipient.0,
+        node.kind.0,
+        node.mail_id.sender.0,
+    ];
+    if let Some(parent) = &node.parent {
+        ids.push(parent.sender.0);
+    }
+    ids
 }
 
 /// Encode a `capture_frame` mail bundle: resolve each spec's kind
@@ -1122,10 +1327,14 @@ mod tests {
     }
 
     /// Connect an `RpcSession` + wrap it in an `Mcp` against a booted
-    /// hub chassis, with a fresh component cache.
+    /// hub chassis, with fresh component + reverse-name caches.
     fn connect_mcp(port: u16) -> Mcp {
         let session = RpcSession::connect(&format!("127.0.0.1:{port}")).expect("session connects");
-        Mcp::new(Arc::new(session), Arc::new(ComponentCache::default()))
+        Mcp::new(
+            Arc::new(session),
+            Arc::new(ComponentCache::default()),
+            Arc::new(ReverseNameCache::default()),
+        )
     }
 
     /// `list_engines` over the RPC round-trip yields an empty array on


### PR DESCRIPTION
## Summary

The final phase of ADR-0088 (tracker iamacoffeepot/aether#1124): **MCP renders real names instead of hex tags.** It fetches each engine's `aether.inventory.manifest`, folds it into a per-engine reverse map, and reverses mailbox / kind / thread ids to their origin names (`aether.audio`, `aether.fs.read`, `aether-worker-3`) — falling back to the ADR-0064 tagged-string on a miss (a strict upgrade; nothing regresses). `Handle` / `Dag` ids stay hex (counter-backed, no origin name).

- **`aether-mcp/src/reverse.rs`** (new): `build_static_reverse_map(&ManifestResult)` folds the served manifest (static `NameEntry`s rehashed under `domain`; `Bounded` enumerated; `Declared` over matching-domain names; `Dynamic` skipped), **reusing the substrate's `id_for_name` + `fill_template`** verbatim so the hash+tag derivation can't drift. `EngineNames` holds that map + a positive/negative dynamic-resolve cache; `render`/`lookup`/`needs_resolve`/`cache_resolved` implement the §2 chain. 7 unit tests.
- **`aether-mcp/src/tools.rs`**: per-engine manifest fetch (lazy, keyed by `EngineId`, cached for the engine's lifetime; empty-map-on-no-answer → hex fallback, no re-query), batched `aether.inventory.resolve` of static-map misses, and reversal applied in `send_mail_traced`'s trace-tree render. Thread names already arrive resolved substrate-side (`fold_nodes`), so they're real names with no MCP-side work.
- **`aether-data`**: `id_for_name` + `fill_template` made `pub` so the MCP client reuses them (no duplication).

## Validation

- `scripts/preflight.sh` green: fmt + clippy (`-D warnings`) + doc + wasm32 cross-build + nextest (1267 passed, 0 failed; incl. 7 new `reverse::tests`).
- Unit-tested the pure reverse-map logic (static mailbox/kind + `Bounded`/`Declared` instances reverse; unknown → hex; dynamic resolve-cache positive + negative; empty manifest → hex). Live end-to-end MCP smoke (spawned engine → a tool response showing `aether.audio` instead of `mbx-…`) is manual follow-up.

Closes iamacoffeepot/aether#1123. ADR-0088 v1 complete; tracker iamacoffeepot/aether#1124. Follows iamacoffeepot/aether#1130 (phase 3).