### PR TITLE
feat(substrate): split mail hop into send-enqueue + residence + depth

### DIFF
--- a/crates/aether-capabilities/src/dag/tests.rs
+++ b/crates/aether-capabilities/src/dag/tests.rs
@@ -27,6 +27,7 @@ use std::{env, thread};
 use aether_actor::Actor;
 use aether_data::{DagId, Kind, KindId, MailId, MailboxId, SessionToken, Uuid};
 use aether_kinds::descriptors;
+use aether_kinds::trace::Nanos;
 use aether_kinds::{
     Bundle, Cancel, CancelResult, DagDescriptor, DagReapTick, Edge, Node, NodeId, Status,
     StatusResult, Submit, SubmitResult,
@@ -130,6 +131,8 @@ fn enqueue<K: Kind + serde::Serialize>(
         mail_id: MailId::NONE,
         root: MailId::NONE,
         parent_mail: None,
+        t_enqueue: Nanos(0),
+        enqueue_depth: 0,
     });
 }
 

--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -215,6 +215,7 @@ mod native {
         };
         use crate::test_chassis::{TestChassis, boot_test_chassis_with};
         use aether_kinds::descriptors;
+        use aether_kinds::trace::Nanos;
         use aether_substrate::chassis::builder::Builder;
         use aether_substrate::mail::MailId;
         use aether_substrate::mail::mailer::Mailer;
@@ -282,6 +283,8 @@ mod native {
                 mail_id: MailId::NONE,
                 root: MailId::NONE,
                 parent_mail: None,
+                t_enqueue: Nanos(0),
+                enqueue_depth: 0,
             });
 
             let deadline = Instant::now() + Duration::from_secs(2);
@@ -360,6 +363,8 @@ mod native {
                 mail_id: MailId::NONE,
                 root: MailId::NONE,
                 parent_mail: None,
+                t_enqueue: Nanos(0),
+                enqueue_depth: 0,
             });
 
             let deadline = Instant::now() + Duration::from_secs(2);

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -732,6 +732,7 @@ mod native {
         use super::*;
         use crate::test_chassis::TestChassis;
         use aether_actor::Actor;
+        use aether_kinds::trace::Nanos;
         use aether_substrate::chassis::builder::{Builder, PassiveChassis};
         use aether_substrate::mail::MailId;
         use aether_substrate::mail::MailRef;
@@ -771,6 +772,8 @@ mod native {
                 mail_id: MailId::NONE,
                 root: MailId::NONE,
                 parent_mail: None,
+                t_enqueue: Nanos(0),
+                enqueue_depth: 0,
             });
         }
 

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -556,6 +556,7 @@ mod cap_native {
         use aether_actor::Actor;
         use aether_data::{Kind, SessionToken, Uuid};
         use aether_kinds::descriptors;
+        use aether_kinds::trace::Nanos;
         use aether_substrate::chassis::builder::{Builder, PassiveChassis};
         use aether_substrate::handle_store::HandleStore;
         use aether_substrate::mail::MailId;
@@ -635,6 +636,8 @@ mod cap_native {
                 mail_id: MailId::NONE,
                 root: MailId::NONE,
                 parent_mail: None,
+                t_enqueue: Nanos(0),
+                enqueue_depth: 0,
             });
 
             let deadline = Instant::now() + Duration::from_secs(2);

--- a/crates/aether-capabilities/src/trace_walk.rs
+++ b/crates/aether-capabilities/src/trace_walk.rs
@@ -187,10 +187,18 @@ pub fn fold_nodes(entries: impl IntoIterator<Item = TraceRingEntry>) -> Vec<Mail
             TraceEvent::Received {
                 mail_id,
                 t,
+                t_enqueue,
+                enqueue_depth,
                 thread_id,
             } => {
                 let node = nodes.entry(mail_id).or_default();
                 node.t_received = Some(t);
+                // iamacoffeepot/aether#1134: the deposit instant + backlog
+                // ride the `Received` event; carry them onto the node so
+                // the harness can split the hop into send→enqueue +
+                // residence.
+                node.t_enqueue = Some(t_enqueue);
+                node.enqueue_depth = Some(enqueue_depth);
                 // ADR-0088 §7: the event carries a `Copy` `ThreadId`;
                 // resolve it to a display name on this cold fold path.
                 node.thread_name = resolve_thread_name(thread_id);
@@ -213,6 +221,8 @@ pub fn fold_nodes(entries: impl IntoIterator<Item = TraceRingEntry>) -> Vec<Mail
                 recipient: sent.recipient,
                 kind: sent.kind,
                 t_sent: sent.t_sent,
+                t_enqueue: node.t_enqueue,
+                enqueue_depth: node.enqueue_depth,
                 t_received: node.t_received,
                 t_finished: node.t_finished,
                 thread_name: node.thread_name,
@@ -224,6 +234,8 @@ pub fn fold_nodes(entries: impl IntoIterator<Item = TraceRingEntry>) -> Vec<Mail
 #[derive(Default)]
 struct PartialNode {
     sent: Option<SentFields>,
+    t_enqueue: Option<Nanos>,
+    enqueue_depth: Option<u32>,
     t_received: Option<Nanos>,
     t_finished: Option<Nanos>,
     thread_name: Option<String>,
@@ -286,6 +298,10 @@ mod tests {
             event: TraceEvent::Received {
                 mail_id,
                 t: Nanos(mail_id.correlation_id + 1),
+                // iamacoffeepot/aether#1134: fixture deposit just before
+                // receive (correlation_id) at depth 0 (warm chain).
+                t_enqueue: Nanos(mail_id.correlation_id),
+                enqueue_depth: 0,
                 thread_id: Some(ThreadId::from_name(FIXTURE_THREAD_NAME)),
             },
         }

--- a/crates/aether-kinds/src/trace.rs
+++ b/crates/aether-kinds/src/trace.rs
@@ -77,6 +77,27 @@ pub enum TraceEvent {
     Received {
         mail_id: MailId,
         t: Nanos,
+        /// iamacoffeepot/aether#1134: the timestamp the mail was deposited
+        /// into the recipient's inbox (`route_mail`'s Inbox arm — the
+        /// single deposit chokepoint). Stamped onto the envelope at
+        /// deposit and read here at the recipient's dispatcher entry, so
+        /// the span splits into **send→enqueue** (`t_enqueue − t_sent`:
+        /// the producer's remaining handler + flush + blob pickup + demux)
+        /// and **queue residence** (`t − t_enqueue`: deposit → this
+        /// dispatcher picking it up = slot schedule + worker wakeup +
+        /// recv). Riding the existing `Received` event avoids a per-mail
+        /// ring entry and a second clock read on the recipient side. Equal
+        /// to `t` for the rare paths with no distinct deposit instant
+        /// (none today — every Inbox mail is deposited).
+        t_enqueue: Nanos,
+        /// iamacoffeepot/aether#1134: the scheduler ready-queue depth at
+        /// deposit — this worker's own-deque len plus the shared injector
+        /// len (`worker_deque::pending_depth`). Splits residence into
+        /// *wakeup* (depth 0 → the deposit had to wake/schedule a worker)
+        /// vs *wait-behind-N* (depth N → N runnable slots/blobs already
+        /// ahead = offered load). `0` when the deposit ran off any pool
+        /// worker (chassis-root injects: `Tick`, MCP sends, test injects).
+        enqueue_depth: u32,
         /// Issue 734 / ADR-0088 §7: the dispatching OS thread's
         /// name-hashed [`ThreadId`], captured at the dispatcher's receive
         /// hook. Stored as a `Copy` tagged id rather than a fresh
@@ -155,6 +176,17 @@ pub struct MailNodeWire {
     pub recipient: MailboxId,
     pub kind: KindId,
     pub t_sent: Nanos,
+    /// iamacoffeepot/aether#1134: when this mail was deposited into the
+    /// recipient's inbox (the `Received` event's `t_enqueue`). `None`
+    /// until the `Received` event lands. `t_enqueue − t_sent` is the
+    /// send→enqueue (producer-side) span; `t_received − t_enqueue` is
+    /// queue residence (consumer-side wakeup / wait).
+    pub t_enqueue: Option<Nanos>,
+    /// iamacoffeepot/aether#1134: scheduler ready-queue depth at deposit
+    /// (own-deque + injector len). `None` until the `Received` event
+    /// lands. `Some(0)` distinguishes "woke a worker" from `Some(n)`
+    /// "queued behind n runnable slots."
+    pub enqueue_depth: Option<u32>,
     pub t_received: Option<Nanos>,
     pub t_finished: Option<Nanos>,
     /// Issue 734 / ADR-0088 §7: the dispatching OS thread's display

--- a/crates/aether-substrate-bundle/src/perf/harness.rs
+++ b/crates/aether-substrate-bundle/src/perf/harness.rs
@@ -330,8 +330,26 @@ pub fn summarize(mut samples: Vec<u64>) -> Stats {
 pub struct CellResult {
     pub workers: usize,
     pub topo: String,
+    /// `t_received − t_sent` — the whole hop. Kept as the headline /
+    /// backward-compatible metric; equals `send_enqueue + residence`
+    /// within clock granularity.
     pub hop: Stats,
+    /// iamacoffeepot/aether#1134: `t_enqueue − t_sent` — producer-side
+    /// span (rest of the sender's handler + flush + blob pickup + demux
+    /// up to the recipient-inbox deposit).
+    pub send_enqueue: Stats,
+    /// iamacoffeepot/aether#1134: `t_received − t_enqueue` — consumer-side
+    /// queue residence (deposit → the recipient's dispatcher picks it up
+    /// = slot schedule + worker wakeup + recv). The span the fast-path
+    /// inbox-bypass would attack.
+    pub residence: Stats,
+    /// `t_finished − t_received` — in-handler work.
     pub handler: Stats,
+    /// iamacoffeepot/aether#1134: scheduler ready-queue depth at deposit
+    /// (`enqueue_depth`), as a distribution — *counts, not nanoseconds*.
+    /// p50 ≈ 0 means residence is dominated by wakeup (empty queue); a
+    /// rising tail means wait-behind-N (offered load).
+    pub depth: Stats,
 }
 
 /// Inputs to one sweep. `workers` is the outer axis (pool sizes);
@@ -580,7 +598,10 @@ pub fn run_sweep(cfg: &SweepConfig) -> Vec<CellResult> {
             let mails = fold_nodes(entries);
 
             let mut hop = Vec::new();
+            let mut send_enqueue = Vec::new();
+            let mut residence = Vec::new();
             let mut handler = Vec::new();
+            let mut depth = Vec::new();
             for node in &mails {
                 if node.kind.0 != Ping::ID.0 {
                     continue;
@@ -590,13 +611,26 @@ pub fn run_sweep(cfg: &SweepConfig) -> Vec<CellResult> {
                     if let Some(fin) = node.t_finished {
                         handler.push(fin.0.saturating_sub(recv.0));
                     }
+                    // iamacoffeepot/aether#1134: split the hop at the
+                    // deposit instant. `t_enqueue` lands with `Received`,
+                    // so it is present exactly when `t_received` is.
+                    if let Some(enq) = node.t_enqueue {
+                        send_enqueue.push(enq.0.saturating_sub(node.t_sent.0));
+                        residence.push(recv.0.saturating_sub(enq.0));
+                    }
+                }
+                if let Some(d) = node.enqueue_depth {
+                    depth.push(u64::from(d));
                 }
             }
             rows.push(CellResult {
                 workers,
                 topo: topo.name.clone(),
                 hop: summarize(hop),
+                send_enqueue: summarize(send_enqueue),
+                residence: summarize(residence),
                 handler: summarize(handler),
+                depth: summarize(depth),
             });
         }
     }

--- a/crates/aether-substrate-bundle/src/perf/report.rs
+++ b/crates/aether-substrate-bundle/src/perf/report.rs
@@ -27,8 +27,14 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum Metric {
-    /// `t_received − t_sent`: enqueue + worker pickup.
+    /// `t_received − t_sent`: the whole hop (enqueue + worker pickup).
     Hop,
+    /// iamacoffeepot/aether#1134: `t_enqueue − t_sent`: producer-side
+    /// (rest of the sender's handler + flush + blob pickup + demux).
+    SendEnqueue,
+    /// iamacoffeepot/aether#1134: `t_received − t_enqueue`: consumer-side
+    /// queue residence (slot schedule + worker wakeup + recv).
+    Residence,
     /// `t_finished − t_received`: in-handler work.
     Handler,
 }
@@ -38,6 +44,8 @@ impl Metric {
     pub fn label(self) -> &'static str {
         match self {
             Self::Hop => "hop",
+            Self::SendEnqueue => "send_enqueue",
+            Self::Residence => "residence",
             Self::Handler => "handler",
         }
     }
@@ -98,7 +106,10 @@ pub const TRIAL_SCHEMA: &str = "aether.perf.trial.v1";
 
 impl TrialReport {
     /// Build a trial report from a sweep's [`CellResult`]s — each cell
-    /// expands to two `CellJson` rows (hop + handler).
+    /// expands to four `CellJson` rows (`hop` + `send_enqueue` +
+    /// `residence` + `handler`). `depth` is a count, not a latency, so it
+    /// is omitted from the latency compare (it lives only in the on-demand
+    /// observe table).
     ///
     /// [`CellResult`]: super::harness::CellResult
     #[must_use]
@@ -108,9 +119,14 @@ impl TrialReport {
         pace_hz: Option<u64>,
         git_sha: Option<String>,
     ) -> Self {
-        let mut out = Vec::with_capacity(cells.len() * 2);
+        let mut out = Vec::with_capacity(cells.len() * 4);
         for c in cells {
-            for (metric, s) in [(Metric::Hop, &c.hop), (Metric::Handler, &c.handler)] {
+            for (metric, s) in [
+                (Metric::Hop, &c.hop),
+                (Metric::SendEnqueue, &c.send_enqueue),
+                (Metric::Residence, &c.residence),
+                (Metric::Handler, &c.handler),
+            ] {
                 out.push(CellJson {
                     workers: c.workers,
                     topo: c.topo.clone(),

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -538,8 +538,9 @@ fn guided_walk_reconstructs_causal_tree() {
 /// Assert the causal invariants a correct trace tree must satisfy on its
 /// own timestamps:
 ///
-/// - per node, `t_sent <= t_received <= t_finished` (sent, then
-///   received, then the handler returns);
+/// - per node, `t_sent <= t_enqueue <= t_received <= t_finished` (sent,
+///   deposited into the recipient inbox, received, then the handler
+///   returns — iamacoffeepot/aether#1134 inserts the deposit instant);
 /// - per parent->child edge, `parent.t_received <= child.t_sent <=
 ///   parent.t_finished` — a child is sent from inside its parent's
 ///   handler, and all three reads land on the parent's dispatch thread
@@ -556,6 +557,27 @@ fn assert_causal_order(mails: &[MailNodeWire]) {
                 "node {:?}: t_sent {} > t_received {}",
                 n.mail_id,
                 n.t_sent.0,
+                received.0
+            );
+            // iamacoffeepot/aether#1134: the deposit stamp rides the same
+            // `Received` event, so it must be present whenever a node is
+            // received, and must fall between send and receive (monotonic
+            // process clock; deposit happens-after send, before pickup).
+            let enq = n
+                .t_enqueue
+                .expect("a received node must carry t_enqueue (#1134)");
+            assert!(
+                n.t_sent.0 <= enq.0,
+                "node {:?}: t_sent {} > t_enqueue {}",
+                n.mail_id,
+                n.t_sent.0,
+                enq.0
+            );
+            assert!(
+                enq.0 <= received.0,
+                "node {:?}: t_enqueue {} > t_received {}",
+                n.mail_id,
+                enq.0,
                 received.0
             );
             if let Some(finished) = n.t_finished {
@@ -797,14 +819,25 @@ fn print_observe_tables(rows: &[CellResult], pace_hz: Option<u64>) {
     println!("{OBSERVE_FRAMES} frames/cell (wide cells fewer); relay-hop (`Ping`) samples only.");
     println!();
 
+    // iamacoffeepot/aether#1134: HOP now splits into SEND→ENQUEUE
+    // (producer side) + QUEUE RESIDENCE (consumer side). HOP ≈ their sum
+    // within clock granularity; it stays as the headline continuity row.
     for (label, pick) in [
         (
-            "HOP LATENCY  (t_received - t_sent: enqueue + worker pickup)",
+            "HOP          (t_received - t_sent: full hop = send→enqueue + residence)",
             0usize,
         ),
         (
-            "HANDLER DUR  (t_finished - t_received: relay forward work)",
+            "SEND→ENQUEUE (t_enqueue - t_sent: producer handler + flush + blob demux to deposit)",
             1,
+        ),
+        (
+            "QUEUE RESID. (t_received - t_enqueue: deposit → dispatcher pickup = schedule + wakeup)",
+            2,
+        ),
+        (
+            "HANDLER DUR  (t_finished - t_received: relay forward work)",
+            3,
         ),
     ] {
         println!("-- {label} --");
@@ -813,7 +846,12 @@ fn print_observe_tables(rows: &[CellResult], pace_hz: Option<u64>) {
             "", "topology", "cond", "p50", "p90", "p99", "max", "n"
         );
         for r in rows {
-            let s = if pick == 0 { r.hop } else { r.handler };
+            let s = match pick {
+                0 => r.hop,
+                1 => r.send_enqueue,
+                2 => r.residence,
+                _ => r.handler,
+            };
             println!(
                 "{:>3}   {:<16} {:<5} {:>9} {:>9} {:>9} {:>9} {:>7}",
                 r.workers,
@@ -828,4 +866,24 @@ fn print_observe_tables(rows: &[CellResult], pace_hz: Option<u64>) {
         }
         println!();
     }
+
+    // iamacoffeepot/aether#1134: enqueue depth is a *count* (scheduler
+    // ready-queue len at deposit), printed raw — not µs. p50 ≈ 0 means
+    // residence is wakeup-dominated (empty queue); a rising tail is
+    // wait-behind-N offered load (the fan-out queueing signal).
+    println!(
+        "-- ENQUEUE DEPTH (scheduler ready-queue len at deposit; counts, not µs: 0 = wakeup, n = behind-n) --"
+    );
+    println!(
+        "{:>3}w  {:<16} {:<5} {:>9} {:>9} {:>9} {:>9} {:>7}",
+        "", "topology", "cond", "p50", "p90", "p99", "max", "n"
+    );
+    for r in rows {
+        let s = r.depth;
+        println!(
+            "{:>3}   {:<16} {:<5} {:>9} {:>9} {:>9} {:>9} {:>7}",
+            r.workers, r.topo, cond, s.p50, s.p90, s.p99, s.max, s.n
+        );
+    }
+    println!();
 }

--- a/crates/aether-substrate/Cargo.toml
+++ b/crates/aether-substrate/Cargo.toml
@@ -89,6 +89,11 @@ wat = "1"
 # test binary picks up the derive macros without the lib pulling them
 # in for non-test builds.
 aether-data = { path = "../aether-data", features = ["derive"] }
+# iamacoffeepot/aether#1134: integration tests build `OwnedDispatch`
+# literals, which now carry a `t_enqueue: Nanos` field — naming the type
+# needs aether-kinds in scope (integration tests see only the lib +
+# dev-deps, not the lib's regular deps).
+aether-kinds = { path = "../aether-kinds" }
 bytemuck = { version = "1.19", features = ["derive"] }
 
 [lints]

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -843,6 +843,7 @@ mod tests {
     use crate::mail::MailRef;
     use crate::mail::registry::{InboxHandler, OwnedDispatch};
     use crate::test_util::fresh_substrate;
+    use aether_kinds::trace::Nanos;
     use std::sync::mpsc;
 
     /// Build a registry handler that forwards every [`MailDispatch`]
@@ -930,6 +931,8 @@ mod tests {
             mail_id: MailId::NONE,
             root: MailId::NONE,
             parent_mail: None,
+            t_enqueue: Nanos(0),
+            enqueue_depth: 0,
         }
     }
 

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -182,6 +182,11 @@ pub fn dispatch_loop_run<A>(
                 TraceEvent::Received {
                     mail_id: inbound_mail_id,
                     t: th.now_nanos(),
+                    // iamacoffeepot/aether#1134: the producer-stamped
+                    // deposit instant + scheduler backlog, splitting the
+                    // hop into send→enqueue + queue residence.
+                    t_enqueue: env.t_enqueue,
+                    enqueue_depth: env.enqueue_depth,
                     thread_id,
                 },
             );
@@ -227,6 +232,11 @@ pub fn dispatch_loop_run<A>(
                 TraceEvent::Received {
                     mail_id: inbound_mail_id,
                     t: th.now_nanos(),
+                    // iamacoffeepot/aether#1134: the producer-stamped
+                    // deposit instant + scheduler backlog, splitting the
+                    // hop into send→enqueue + queue residence.
+                    t_enqueue: env.t_enqueue,
+                    enqueue_depth: env.enqueue_depth,
                     thread_id,
                 },
             );

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -227,6 +227,12 @@ where
                 TraceEvent::Received {
                     mail_id: inbound_mail_id,
                     t: th.now_nanos(),
+                    // iamacoffeepot/aether#1134: surface the deposit
+                    // instant + scheduler backlog the producer stamped at
+                    // `route_mail`, so the hop splits into send→enqueue +
+                    // queue residence.
+                    t_enqueue: env.t_enqueue,
+                    enqueue_depth: env.enqueue_depth,
                     thread_id,
                 },
             );

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -24,6 +24,7 @@ use std::sync::{Arc, Mutex};
 
 use aether_actor::{HandlesKind, Instanced, NamespaceError, validate_namespace_segment};
 use aether_data::{Kind, mailbox_id_from_name};
+use aether_kinds::trace::Nanos;
 
 use crate::actor::native::binding::NativeBinding;
 use crate::actor::native::dispatch;
@@ -684,6 +685,11 @@ impl<'ctx, A: Instanced + NativeActor + NativeDispatch> SpawnBuilder<'ctx, A> {
             mail_id: MailId::NONE,
             root: MailId::NONE,
             parent_mail: None,
+            // Bootstrap seed carries no lineage (`MailId::NONE`), so it
+            // never folds into a traced tree node — no deposit instant to
+            // record (iamacoffeepot/aether#1134).
+            t_enqueue: Nanos(0),
+            enqueue_depth: 0,
         };
         self.after_init.push(env);
         self

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -21,6 +21,7 @@ use crate::mail::outbound::HubOutbound;
 use crate::mail::registry::OwnedDispatch;
 use crate::mail::registry::{MailboxEntry, Registry};
 use crate::mail::{Mail, MailId, MailKind, MailRef, MailboxId, ReplyTarget, ReplyTo};
+use crate::scheduler::pending_depth;
 
 const MAIL_OFFSET: u32 = 1024;
 
@@ -252,6 +253,13 @@ impl ComponentCtx {
                     mail_id,
                     root,
                     parent_mail,
+                    // iamacoffeepot/aether#1134: the second production
+                    // deposit chokepoint (ComponentCtx's inline send
+                    // bypasses `route_mail`), so stamp the deposit instant
+                    // + scheduler backlog here too — else the recipient's
+                    // `Received` would read a zeroed `t_enqueue`.
+                    t_enqueue: self.queue.now_nanos(),
+                    enqueue_depth: pending_depth(),
                 });
                 return;
             }

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -32,6 +32,7 @@ use crate::mail::outbound::HubOutbound;
 use crate::mail::registry::{MailDispatch, MailboxEntry, OwnedDispatch, Registry};
 use crate::mail::{Mail, MailRef, ReplyTarget, ReplyTo};
 use crate::runtime::trace::{SettlementHold, TraceHandle};
+use crate::scheduler::pending_depth;
 use aether_data::{HandleId, Kind, KindId};
 use aether_kinds::trace::{Nanos, TraceTail, TraceTailResult};
 use std::sync::OnceLock;
@@ -592,6 +593,14 @@ fn route_mail(
                 mail_id: mail.mail_id,
                 root: mail.root,
                 parent_mail: mail.parent_mail,
+                // iamacoffeepot/aether#1134: stamp the deposit instant +
+                // scheduler backlog here — the single Inbox chokepoint
+                // every mail-to-an-actor funnels through. Read back at the
+                // recipient's `Received` hook to split the hop into
+                // send→enqueue vs queue residence. One clock read on the
+                // already-traced path; depth is `0` off a pool worker.
+                t_enqueue: trace_handle.now_nanos(),
+                enqueue_depth: pending_depth(),
             });
         }
         Some(MailboxEntry::Inline(handler)) => {

--- a/crates/aether-substrate/src/mail/registry.rs
+++ b/crates/aether-substrate/src/mail/registry.rs
@@ -22,6 +22,8 @@ use std::sync::{Arc, RwLock};
 
 use rustc_hash::FxHashMap;
 
+use aether_kinds::trace::Nanos;
+
 use crate::handle_store::schema_contains_ref;
 use crate::mail::{KindId, MailId, MailRef, MailboxId, ReplyTo};
 use std::error;
@@ -77,6 +79,8 @@ pub(crate) fn test_owned_dispatch(
         mail_id: MailId::NONE,
         root: MailId::NONE,
         parent_mail: None,
+        t_enqueue: Nanos(0),
+        enqueue_depth: 0,
     }
 }
 
@@ -180,6 +184,23 @@ pub struct OwnedDispatch {
     /// ADR-0080 §5: the in-flight mail at the sender, or `None` for
     /// chassis-root sends.
     pub parent_mail: Option<MailId>,
+    /// iamacoffeepot/aether#1134: the deposit timestamp — when this
+    /// envelope was placed into the recipient's inbox at `route_mail`'s
+    /// Inbox arm. The recipient's dispatcher reads it at its `Received`
+    /// hook and folds it into [`TraceEvent::Received`]'s `t_enqueue` so
+    /// the hop splits into send→enqueue (`t_enqueue − t_sent`) and queue
+    /// residence (`t_received − t_enqueue`). `Nanos(0)` on construction
+    /// sites that don't stamp it (chassis-internal / test envelopes that
+    /// never enter the traced relay path).
+    ///
+    /// [`TraceEvent::Received`]: aether_kinds::trace::TraceEvent
+    pub t_enqueue: Nanos,
+    /// iamacoffeepot/aether#1134: scheduler ready-queue depth at deposit
+    /// (`worker_deque::pending_depth`) — folded into
+    /// [`TraceEvent::Received`]'s `enqueue_depth`. `0` off any pool worker.
+    ///
+    /// [`TraceEvent::Received`]: aether_kinds::trace::TraceEvent
+    pub enqueue_depth: u32,
 }
 
 /// Synchronous handler installed under [`MailboxEntry::Inline`]. Runs
@@ -1142,6 +1163,8 @@ mod tests {
             mail_id: MailId::NONE,
             root: MailId::NONE,
             parent_mail: None,
+            t_enqueue: Nanos(0),
+            enqueue_depth: 0,
         });
         assert_eq!(counter.load(Ordering::SeqCst), 10);
     }
@@ -1640,6 +1663,8 @@ mod tests {
             mail_id: MailId::NONE,
             root: MailId::NONE,
             parent_mail: None,
+            t_enqueue: Nanos(0),
+            enqueue_depth: 0,
         });
         handler.enqueue(OwnedDispatch {
             kind: KindId(0),
@@ -1651,6 +1676,8 @@ mod tests {
             mail_id: MailId::NONE,
             root: MailId::NONE,
             parent_mail: None,
+            t_enqueue: Nanos(0),
+            enqueue_depth: 0,
         });
 
         let collected = collected.lock().unwrap();
@@ -1689,6 +1716,8 @@ mod tests {
             mail_id: MailId::NONE,
             root: MailId::NONE,
             parent_mail: None,
+            t_enqueue: Nanos(0),
+            enqueue_depth: 0,
         });
 
         let received = rx.try_recv().expect("hand-rolled enqueue should send");

--- a/crates/aether-substrate/src/scheduler/mod.rs
+++ b/crates/aether-substrate/src/scheduler/mod.rs
@@ -44,4 +44,4 @@ pub use slot::{
     Drainable, SlotState, SlotStateLabel, WakeHandle, WakeSink,
 };
 pub use spin_park::{Acquired, SpinPark};
-pub use worker_deque::run_demux;
+pub use worker_deque::{pending_depth, run_demux};

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -254,6 +254,10 @@ fn worker_loop(
     // the affinity path that keeps a relay chain on one warm worker
     // (iamacoffeepot/aether#1059, now the deque's LIFO own-pop).
     worker_deque::install(deque);
+    // iamacoffeepot/aether#1134: register the shared injector so a deposit
+    // on this worker can read the scheduler ready-queue depth
+    // (`worker_deque::pending_depth`) for the latency harness.
+    worker_deque::install_injector(Arc::clone(&injector));
     loop {
         let Some(slot) = acquire_slot(idx, &stealers, &injector, &spin) else {
             // Shutdown signalled. Exit.

--- a/crates/aether-substrate/src/scheduler/worker_deque.rs
+++ b/crates/aether-substrate/src/scheduler/worker_deque.rs
@@ -51,12 +51,46 @@ thread_local! {
     /// run those recipients inline (the Phase 3b fan-out win). Outside a
     /// demux window it is `None` and the wake takes its normal path.
     static DEMUX: RefCell<Option<Vec<Slot>>> = const { RefCell::new(None) };
+
+    /// The shared off-worker [`Injector`], registered per worker by
+    /// [`install_injector`] at the top of the worker loop
+    /// (iamacoffeepot/aether#1134). Held only so [`pending_depth`] can read
+    /// the injector backlog without threading a reference through the
+    /// deposit path; `None` on non-worker threads (chassis main, hub,
+    /// off-worker injects), where `pending_depth` reports `0`.
+    static INJECTOR: RefCell<Option<Arc<Injector<Slot>>>> = const { RefCell::new(None) };
 }
 
 /// Move this worker's deque into its thread-local. Called once at the top
 /// of the worker loop; enables local push/pop on this thread.
 pub fn install(worker: Worker<Slot>) {
     LOCAL.with(|w| *w.borrow_mut() = Some(worker));
+}
+
+/// Register the shared injector for this worker thread so
+/// [`pending_depth`] can read its backlog (iamacoffeepot/aether#1134).
+/// Called once alongside [`install`] at the top of the worker loop;
+/// no-op effect on dispatch (depth is measurement-only).
+pub fn install_injector(injector: Arc<Injector<Slot>>) {
+    INJECTOR.with(|i| *i.borrow_mut() = Some(injector));
+}
+
+/// Scheduler ready-queue depth observed from this thread: this worker's
+/// own-deque len plus the shared injector len (iamacoffeepot/aether#1134).
+/// `0` off any pool worker (no own deque installed) — chassis-root
+/// injects and other off-worker deposits report no backlog. Read at mail
+/// deposit and carried on the envelope so the latency harness can split
+/// queue residence into *wakeup* (depth 0) vs *wait-behind-N* (load).
+///
+/// Both `Worker::len` and `Injector::len` are cheap O(1)-ish reads; this
+/// is a relaxed snapshot, not a synchronization point — a racing push by
+/// a sibling may land just after the read, which is fine for a profiling
+/// signal.
+#[must_use]
+pub fn pending_depth() -> u32 {
+    let own = LOCAL.with(|w| w.borrow().as_ref().map_or(0, Worker::len));
+    let injected = INJECTOR.with(|i| i.borrow().as_ref().map_or(0, |inj| inj.len()));
+    u32::try_from(own.saturating_add(injected)).unwrap_or(u32::MAX)
 }
 
 /// Own-deque local bound — the max slots a worker keeps on its own deque

--- a/crates/aether-substrate/tests/native_actor_macro.rs
+++ b/crates/aether-substrate/tests/native_actor_macro.rs
@@ -24,6 +24,7 @@ use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 use std::time::{Duration, Instant};
 
 use aether_data::{Kind, ReplyTo};
+use aether_kinds::trace::Nanos;
 use aether_substrate::handle_store::HandleStore;
 use aether_substrate::mail::registry::OwnedDispatch;
 use aether_substrate::mail::{MailId, MailRef};
@@ -147,6 +148,8 @@ fn push_envelope<K: Kind>(registry: &Registry, recipient: &str, payload: &K) {
         mail_id: MailId::NONE,
         root: MailId::NONE,
         parent_mail: None,
+        t_enqueue: Nanos(0),
+        enqueue_depth: 0,
     });
 }
 


### PR DESCRIPTION
## Summary

The latency harness reported HOP as `t_received − t_sent`, conflating producer-side cost with consumer-side queue residence — so it could not tell "the mechanism is slow" from "the mail waited for a worker." This adds a deposit instant + scheduler ready-queue depth, splitting the hop:

- **send→enqueue** (`t_enqueue − t_sent`) — producer side: rest of the sender's handler + flush + blob demux to the inbox deposit.
- **queue residence** (`t_received − t_enqueue`) — consumer side: deposit → the recipient's dispatcher picks it up (slot schedule + worker wakeup + recv).
- **enqueue depth** — scheduler ready-queue len at deposit (own-deque + injector): `0` = wakeup, `n` = wait-behind-`n`.

Mechanism: stamp `t_enqueue` + `enqueue_depth` onto the envelope at the inbox deposit (both production chokepoints — `route_mail`'s Inbox arm and `ComponentCtx`'s inline send), read them back at the recipient's `Received` hook (no new ring entry; one clock read on the already-traced path), fold onto `MailNodeWire`. The observe table prints HOP / SEND→ENQUEUE / QUEUE RESIDENCE / HANDLER + an ENQUEUE DEPTH row; the two new latency legs thread into the perf-compare trial JSON (depth stays out — it is a count, not µs). `Sent` stays eager, so `in_flight` settlement (ADR-0080/0082) is untouched.

## What the numbers say (warm, 1 worker, p50 µs)

- chain `depth-1`: hop 0.92 = send→enq 0.62 + resid 0.29; depth 0
- fan-out `fanout-8`: hop 3.33 = send→enq 1.42 + resid 1.83; depth 0

Chains are producer-glue-dominated; fan-out flips to residence-dominated and grows with width (offered-load serialization). Depth 0 throughout: no parked-worker wakeup in the warm regime, and fan-out cost is demux serialization, not scheduler saturation. Motivates the demux-bypass follow-up (iamacoffeepot/aether#1135).

## Test plan

- [x] `scripts/preflight.sh --force` green (fmt + clippy + doc + nextest 1278 + wasm32)
- [x] RustRover `get_file_problems` clean across all touched files
- [x] `assert_causal_order` extended to assert `t_sent ≤ t_enqueue ≤ t_received` (runs in the non-ignored `guided_walk_reconstructs_causal_tree`)
- [x] `lifecycle_latency_observe` prints the split end-to-end

Closes iamacoffeepot/aether#1134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)