### PR TITLE
perf(substrate): claim-and-dispatch-direct demux (issue 1135)

### DIFF
--- a/crates/aether-capabilities/src/dag/tests.rs
+++ b/crates/aether-capabilities/src/dag/tests.rs
@@ -117,7 +117,7 @@ fn enqueue<K: Kind + serde::Serialize>(
     sender: ReplyTo,
 ) {
     let id = registry.lookup(mailbox_name).expect("mailbox registered");
-    let MailboxEntry::Inbox(handler) = registry.entry(id).expect("entry") else {
+    let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("entry") else {
         panic!("expected inbox mailbox for {mailbox_name}");
     };
     let bytes = postcard::to_allocvec(payload).expect("encode request");

--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -263,7 +263,7 @@ mod native {
             let id = registry
                 .lookup(HandleCapability::NAMESPACE)
                 .expect("mailbox registered");
-            let MailboxEntry::Inbox(handler) = registry.entry(id).expect("entry") else {
+            let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("entry") else {
                 panic!("expected mailbox entry");
             };
 
@@ -347,7 +347,7 @@ mod native {
             let id = registry
                 .lookup(HandleCapability::NAMESPACE)
                 .expect("mailbox registered");
-            let MailboxEntry::Inbox(handler) = registry.entry(id).expect("entry") else {
+            let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("entry") else {
                 panic!("expected mailbox entry");
             };
 

--- a/crates/aether-capabilities/src/input.rs
+++ b/crates/aether-capabilities/src/input.rs
@@ -281,7 +281,7 @@ mod native {
     /// subscribers if any future driver wants one.
     fn validate_subscriber_mailbox(registry: &Registry, id: MailboxId) -> Result<(), String> {
         match registry.entry(id) {
-            Some(MailboxEntry::Inbox(_) | MailboxEntry::Inline(_)) => Ok(()),
+            Some(MailboxEntry::Inbox { .. } | MailboxEntry::Inline(_)) => Ok(()),
             Some(MailboxEntry::Dropped) => Err(format!("mailbox {id:?} already dropped")),
             None => Err(format!("unknown mailbox id {id:?}")),
         }

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -759,7 +759,8 @@ mod native {
 
         fn deliver(registry: &Registry, name: &str, kind: KindId, payload: &[u8]) {
             let id = registry.lookup(name).expect("mailbox registered");
-            let MailboxEntry::Inbox(handler) = registry.entry(id).expect("entry exists") else {
+            let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("entry exists")
+            else {
                 panic!("expected mailbox entry for {name}");
             };
             handler.enqueue(OwnedDispatch {

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -622,7 +622,7 @@ mod cap_native {
             let id = registry
                 .lookup(cap_namespace)
                 .expect("cap mailbox registered");
-            let MailboxEntry::Inbox(handler) = registry.entry(id).expect("cap entry") else {
+            let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("cap entry") else {
                 panic!("expected mailbox entry");
             };
             let bytes = postcard::to_allocvec(mail).expect("encode");

--- a/crates/aether-substrate/src/actor/native/blob_work.rs
+++ b/crates/aether-substrate/src/actor/native/blob_work.rs
@@ -14,7 +14,7 @@
 //!
 //! - **free** recipient (won the `Idle → Running` *seize* CAS, ref-free
 //!   kind) → build the envelope and dispatch it **in place** on this
-//!   worker via [`crate::scheduler::Drainable::seize_and_run`] — no inbox
+//!   worker via [`Drainable::seize_and_run`] — no inbox
 //!   deposit, no `try_recv` repop, residence ≈ 0
 //!   (iamacoffeepot/aether#1135 removed the 3b deposit+collect+repop
 //!   round-trip).
@@ -48,7 +48,7 @@
 //! is today's [`Mailer::push`] → `route_mail`, so the ADR-0045 ref-walk,
 //! the `Inline` / `Dropped` / unknown-bubble-up arms, and that path's
 //! settlement/trace brackets are inherited unchanged. The **direct**
-//! arm runs the recipient's [`crate::scheduler::Drainable::seize_and_run`]
+//! arm runs the recipient's [`Drainable::seize_and_run`]
 //! → `DispatcherSlot::dispatch_one`, the *same* per-envelope wrapper a
 //! pooled `run_cycle` runs — `local::with_stamped`, `Received` /
 //! `Finished` (incl. the iamacoffeepot/aether#1134 `t_enqueue` /
@@ -325,14 +325,23 @@ mod tests {
         }
     }
 
-    /// Register a sink that forwards each delivered mail's first payload
-    /// byte onto `tx`, and return its mailbox id.
-    fn counting_sink(registry: &Registry, tx: mpsc::Sender<u8>) -> MailboxId {
+    /// Register an inbox under `name` that forwards each delivered mail's
+    /// first payload byte onto `tx`; returns the registered mailbox id.
+    fn register_byte_forwarding_inbox(
+        registry: &Registry,
+        name: &str,
+        tx: mpsc::Sender<u8>,
+    ) -> MailboxId {
         let handler: Arc<dyn InboxHandler> = Arc::new(move |d: OwnedDispatch| {
             let _ = tx.send(d.payload.bytes()[0]);
         });
-        registry.register_inbox("sink", handler);
-        registry.lookup("sink").unwrap()
+        registry.register_inbox(name, handler)
+    }
+
+    /// Register a sink at `"sink"` that forwards each delivered mail's
+    /// first payload byte onto `tx`, and return its mailbox id.
+    fn counting_sink(registry: &Registry, tx: mpsc::Sender<u8>) -> MailboxId {
+        register_byte_forwarding_inbox(registry, "sink", tx)
     }
 
     fn owned_mails(recipient: MailboxId, n: u8) -> Vec<Mail> {
@@ -447,10 +456,7 @@ mod tests {
         mpsc::Receiver<u8>,
     ) {
         let (deposit_tx, deposit_rx) = mpsc::channel::<u8>();
-        let handler: Arc<dyn InboxHandler> = Arc::new(move |d: OwnedDispatch| {
-            let _ = deposit_tx.send(d.payload.bytes()[0]);
-        });
-        let id = registry.register_inbox(name, handler);
+        let id = register_byte_forwarding_inbox(registry, name, deposit_tx);
 
         let (direct_tx, direct_rx) = mpsc::channel::<u8>();
         let fixture = Arc::new(SeizableSink {

--- a/crates/aether-substrate/src/actor/native/blob_work.rs
+++ b/crates/aether-substrate/src/actor/native/blob_work.rs
@@ -498,12 +498,14 @@ mod tests {
     #[test]
     fn busy_recipient_deposited() {
         let (registry, mailer) = fresh_substrate();
-        let (recipient, fixture, direct_rx, deposit_rx) =
-            seizable_recipient(&registry, "seizable");
+        let (recipient, fixture, direct_rx, deposit_rx) = seizable_recipient(&registry, "seizable");
 
         // Mark the recipient busy before the demux: its `Idle → Running`
         // seize must lose, falling through to the deposit path.
-        assert!(fixture.state.seize(), "fixture starts Idle, seize wins once");
+        assert!(
+            fixture.state.seize(),
+            "fixture starts Idle, seize wins once"
+        );
 
         let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
         let sink = WakeSink::new(Arc::clone(&injector), Arc::new(SpinPark::new()));
@@ -549,7 +551,12 @@ mod tests {
         // the closure reads). The test asserts the routing *decision*: a
         // ref kind is deposited (so `route_mail` owns the walk), never
         // direct-dispatched.
-        let mails = vec![Mail::new(recipient, ref_kind, MailRef::from(vec![0u8, 0u8]), 1)];
+        let mails = vec![Mail::new(
+            recipient,
+            ref_kind,
+            MailRef::from(vec![0u8, 0u8]),
+            1,
+        )];
         let blob = BlobWork::with_chunk(mails, mailer, sink, usize::MAX);
 
         blob.run_cycle(BatchBudget::standard());

--- a/crates/aether-substrate/src/actor/native/blob_work.rs
+++ b/crates/aether-substrate/src/actor/native/blob_work.rs
@@ -1,5 +1,6 @@
 //! [`BlobWork`] — a handler's buffered fan-out as a single
-//! work-stealing unit (ADR-0087 Phase 3b, iamacoffeepot/aether#1113).
+//! work-stealing unit (ADR-0087 Phase 3b, iamacoffeepot/aether#1113;
+//! claim-and-dispatch-direct demux, iamacoffeepot/aether#1135).
 //!
 //! Phase 2b/2c buffer a native handler's outbound mail into one sealed
 //! ring blob; Phase 3a made per-worker deques the scheduler's queue.
@@ -7,13 +8,21 @@
 //! eagerly (N pushes + up to N parked-worker wakeups for a fan-out of
 //! N), [`crate::actor::native::NativeBinding::flush_outbound`] pushes
 //! the whole blob as **one** `Drainable` onto the producing worker's
-//! deque. A worker pops it (or an idle sibling steals it) and demuxes:
+//! deque. A worker pops it (or an idle sibling steals it) and demuxes
+//! its mail in **send order** (ADR-0087 §4, the order-safe half of the
+//! iamacoffeepot/aether#1059 win):
 //!
-//! - **free** recipient (won the `Idle → Ready` CAS) → run its handler
-//!   **inline** on this worker — no inbox round-trip beyond the deposit,
-//!   no notify.
-//! - **busy** recipient (lost the CAS) → its mail is already deposited;
-//!   the holder draining it picks it up (today's wake-loses-CAS path).
+//! - **free** recipient (won the `Idle → Running` *seize* CAS, ref-free
+//!   kind) → build the envelope and dispatch it **in place** on this
+//!   worker via [`crate::scheduler::Drainable::seize_and_run`] — no inbox
+//!   deposit, no `try_recv` repop, residence ≈ 0
+//!   (iamacoffeepot/aether#1135 removed the 3b deposit+collect+repop
+//!   round-trip).
+//! - **busy** recipient (lost the seize), **non-`Pooled`** recipient (no
+//!   slot to seize), or an **ADR-0045 ref kind** → deposit through
+//!   today's [`Mailer::push`] → `route_mail`; the holder / woken cycle
+//!   drains it (per-recipient FIFO preserved by the inbox's own order),
+//!   and `route_mail` owns the ref handle walk / park.
 //!
 //! ## Chunked spill (Phase 3c, iamacoffeepot/aether#1116)
 //!
@@ -35,40 +44,56 @@
 //!
 //! ## How the demux reuses the one router
 //!
-//! `run_cycle` deposits via today's [`Mailer::push`] → `route_mail` for
-//! every mail, so **all** routing concerns are inherited unchanged:
-//! ADR-0045 ref-walk, the settlement/trace brackets (the inline run
-//! goes through `DispatcherSlot::run_cycle` → `dispatch_one`, which owns
-//! `Received`/`Finished` + `record_finished`), and the
-//! `Inline`/`Dropped`/unknown-bubble-up arms. The *only* thing 3b
-//! changes is the wake's destination: inside the [`run_demux`] window, a
-//! free recipient's wake is collected (not deque-pushed) so we can run it
-//! inline here.
+//! Both arms keep all routing concerns in one place. The **deposit** arm
+//! is today's [`Mailer::push`] → `route_mail`, so the ADR-0045 ref-walk,
+//! the `Inline` / `Dropped` / unknown-bubble-up arms, and that path's
+//! settlement/trace brackets are inherited unchanged. The **direct**
+//! arm runs the recipient's [`crate::scheduler::Drainable::seize_and_run`]
+//! → `DispatcherSlot::dispatch_one`, the *same* per-envelope wrapper a
+//! pooled `run_cycle` runs — `local::with_stamped`, `Received` /
+//! `Finished` (incl. the iamacoffeepot/aether#1134 `t_enqueue` /
+//! `enqueue_depth`), the `record_finished` settlement bracket, and the
+//! `log.tail` / `trace.tail` framework arms — so the only thing it skips
+//! is the mpsc deposit + `try_recv` repop. The demux resolves the
+//! recipient's seize handle (and ref-schema) up front via
+//! `Registry::route_lookup`, the same combined read `route_mail` uses,
+//! and falls back to deposit whenever direct dispatch doesn't apply.
+//!
+//! ## Single-runner, order-safe scope (iamacoffeepot/aether#1135)
+//!
+//! This blob stays **one-shot, single-runner**: `run_cycle` takes the
+//! mail out once (`mails.lock().take()`) and demuxes it on one worker in
+//! send order. The parallel multi-worker demux (cursor-shared groups +
+//! recruitment, which reorders across recipients — sound under the
+//! ordering spine but real concurrency machinery) is deferred to
+//! iamacoffeepot/aether#1137, gated on whether direct dispatch alone
+//! closes the residence gap. The 3c [`Vec::split_off`] spill below is the
+//! one stealable hand-off and is unchanged by #1135.
 //!
 //! ## Alternative not taken — explicit slot-demux registry (revisit?)
 //!
 //! The other shape (iamacoffeepot/aether#1113 design fork) was a
 //! first-class `MailboxId → (SlotState, Weak<slot>)` table the blob
 //! worker resolves directly, depositing via `ActorRegistry::live_sender`
-//! and routing only non-`Inbox` recipients through `route_mail`. It is
-//! more inspectable, but (1) it splits routing into a fast path + a
-//! `route_mail` fallback that must be kept in lockstep for every future
-//! routing concern, and (2) it adds a second shared read-hot map on the
-//! hottest path — a re-centralization against the grain of ADR-0086/0087
-//! (which removed the central `SegQueue` for per-actor/per-worker
-//! structures). The reuse approach here keeps one router and adds no
-//! shared map. **Reconsider the explicit table only if the scheduler
-//! later needs first-class slot addressing for other consumers**
-//! (affinity-as-data, slot introspection, NUMA placement) — at which
-//! point its real consumers exist and the table earns its keep.
+//! and routing only non-`Inbox` recipients through `route_mail`. The
+//! seize handle surfaced on the registry `Inbox` entry
+//! (iamacoffeepot/aether#1135) is the lighter form of that idea — it adds
+//! no second shared map (it rides the entry `route_lookup` already
+//! resolves) and keeps `route_mail` as the single fallback router, so the
+//! fast path and the deposit path don't drift. **Reconsider a dedicated
+//! table only if the scheduler later needs first-class slot addressing
+//! for other consumers** (affinity-as-data, slot introspection, NUMA
+//! placement) — at which point its real consumers exist and it earns its
+//! keep.
 
 use std::any::Any;
 use std::env;
 use std::sync::{Arc, Mutex, OnceLock, PoisonError};
 
+use crate::actor::native::Envelope;
 use crate::mail::Mail;
 use crate::mail::mailer::Mailer;
-use crate::scheduler::{BatchBudget, CycleResult, Drainable, WakeSink, run_demux};
+use crate::scheduler::{BatchBudget, CycleResult, Drainable, SeizeHandle, WakeSink};
 
 /// Inline-demux chunk cap K (ADR-0087 Phase 3c, iamacoffeepot/aether#1116).
 /// A `BlobWork` of more than `K` mails demuxes the first `K` inline and
@@ -108,9 +133,11 @@ pub struct BlobWork {
     /// a blob is demuxed by exactly one worker, so the lock is
     /// uncontended.
     mails: Mutex<Option<Vec<Mail>>>,
-    /// Routes each mail (deposit + wake) on the demuxing worker.
+    /// Resolves each mail's recipient (`route_lookup`) and deposits the
+    /// non-direct-dispatch mails (`push` → `route_mail`) on the demuxing
+    /// worker.
     mailer: Arc<Mailer>,
-    /// Where an inline recipient that yields mid-drain
+    /// Where a direct-dispatched recipient that yields mid-drain
     /// ([`CycleResult::Requeue`]) is re-scheduled — the same own-deque /
     /// injector path a normal wake uses.
     sink: WakeSink,
@@ -182,22 +209,79 @@ impl Drainable for BlobWork {
             ));
         }
 
-        // Deposit every mail through the one router; harvest the free
-        // recipients it woke (those that won the Idle→Ready CAS).
+        // ADR-0087 §4 (iamacoffeepot/aether#1135): walk the blob's mail in
+        // **send order** and dispatch each in place where we can.
+        //
+        // Per mail:
+        // - Resolve the recipient's seize handle + ref-schema under one
+        //   registry read (`route_lookup`).
+        // - **Direct-dispatch** when (1) the recipient exposes a seize
+        //   handle (a `Pooled` actor's slot), (2) the kind is ref-free
+        //   (ADR-0045 ref kinds need `route_mail`'s handle walk / park),
+        //   and (3) we win the `Idle → Running` seize CAS: build the
+        //   envelope and run the full per-envelope wrapper in place
+        //   (`Drainable::seize_and_run` → `dispatch_one` — `Received` /
+        //   `Finished` incl. the #1134 `t_enqueue` / `enqueue_depth`,
+        //   `record_finished` settlement bracket, the `log.tail` /
+        //   `trace.tail` framework arms), then drain the recipient's inbox
+        //   and run the post-empty recheck. No inbox deposit, no
+        //   `try_recv` repop — residence ≈ 0.
+        // - **Deposit** otherwise (no seize handle / busy slot / ref kind)
+        //   via today's `Mailer::push` → `route_mail`: the holder (or a
+        //   woken cycle) drains it, per-recipient FIFO preserved by the
+        //   inbox's own ordering.
+        //
+        // Per-recipient FIFO holds by construction: the send-order walk
+        // hands at most one seize per recipient before the slot returns to
+        // `Idle`, and the busy / deposited path goes through the inbox
+        // FIFO. Cross-recipient is async (the ordering spine's contract),
+        // so a busy recipient running on its own thread is correct.
         let mailer = &self.mailer;
-        let collected = run_demux(|| {
-            for mail in mails {
-                mailer.push(mail);
-            }
-        });
-
-        // Run each free recipient inline on this worker. A recipient
-        // that yields mid-drain (budget hit) is re-scheduled the same
-        // way a normal wake would spill it; Idle/Closed just drop.
-        for slot in collected {
-            match slot.run_cycle(budget) {
-                CycleResult::Requeue => self.sink.schedule(slot),
-                CycleResult::Idle | CycleResult::Closed => {}
+        for mail in mails {
+            let lookup = mailer.registry().route_lookup(mail.kind, mail.recipient);
+            // Direct-dispatch only a ref-free kind whose recipient is a
+            // `Pooled` slot we win the seize on. ADR-0045 ref kinds fall
+            // through to `route_mail` (the handle walk / park); so do
+            // non-`Pooled` recipients (no seize handle) and busy slots
+            // (lost the `Idle → Running` CAS — `try_seize` → `None`).
+            let seized = if lookup.ref_schema.is_some() {
+                None
+            } else {
+                lookup.seize.as_ref().and_then(SeizeHandle::try_seize)
+            };
+            match seized {
+                Some(slot) => {
+                    // Build the seed envelope from the held mail. The
+                    // recipient slot is `Running` (we won the seize); the
+                    // payload `MailRef` moves in directly (an `InRing` ref
+                    // stays pinned — the blob holds the region until this
+                    // demux drains, and the seed dispatches synchronously
+                    // here). `t_enqueue ≈ now` / `enqueue_depth = 0` — no
+                    // queue residence (the #1134 measured win).
+                    let seed = Envelope {
+                        kind: mail.kind,
+                        kind_name: lookup.kind_name,
+                        origin: None,
+                        sender: mail.reply_to,
+                        payload: mail.payload,
+                        count: mail.count,
+                        mail_id: mail.mail_id,
+                        root: mail.root,
+                        parent_mail: mail.parent_mail,
+                        t_enqueue: mailer.now_nanos(),
+                        enqueue_depth: 0,
+                    };
+                    match slot.seize_and_run(seed, budget) {
+                        // Budget hit mid-drain — re-schedule the recipient
+                        // the same way a normal wake would spill it.
+                        CycleResult::Requeue => self.sink.schedule(slot),
+                        CycleResult::Idle | CycleResult::Closed => {}
+                    }
+                }
+                // No seize handle, busy slot, or a ref-carrying kind:
+                // deposit through the one router and let the holder /
+                // woken cycle drain it.
+                None => mailer.push(mail),
             }
         }
         CycleResult::Idle
@@ -310,6 +394,214 @@ mod tests {
             iter::from_fn(|| rx.try_recv().ok()).count(),
             5,
             "all mails delivered in the single pass"
+        );
+    }
+
+    use crate::scheduler::{SeizeSeed, SlotState};
+    use aether_data::{KindDescriptor, SchemaCell, SchemaType};
+
+    /// A `Pooled`-shaped recipient fixture for the claim-and-dispatch-
+    /// direct demux (iamacoffeepot/aether#1135): it carries a real
+    /// [`SlotState`] (so a [`SeizeHandle`] can drive the `Idle → Running`
+    /// seize CAS) and records each **direct-dispatched** seed's first
+    /// payload byte. [`Drainable::seize_and_run`] is the only arm a blob
+    /// demux reaches on this fixture; it stamps the byte and parks the
+    /// slot back to `Idle` (mirroring a real slot draining empty), so a
+    /// later mail to the same recipient can seize again — the send-order
+    /// FIFO property the demux must preserve.
+    struct SeizableSink {
+        state: Arc<SlotState>,
+        direct: mpsc::Sender<u8>,
+    }
+
+    impl Drainable for SeizableSink {
+        fn run_cycle(&self, _budget: BatchBudget) -> CycleResult {
+            CycleResult::Idle
+        }
+        fn seize_and_run(&self, seed: SeizeSeed, _budget: BatchBudget) -> CycleResult {
+            let _ = self.direct.send(seed.payload.bytes()[0]);
+            // Real slots end an empty cycle back in `Idle` via the
+            // post-empty recheck; mirror that so the recipient is
+            // seizable for the next send-order mail.
+            self.state.mark_idle();
+            CycleResult::Idle
+        }
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    /// Register a closure inbox under `name` (the **deposit** target) and
+    /// install a [`SeizeHandle`] over a [`SeizableSink`] fixture (the
+    /// **direct** target). Returns the recipient id plus a receiver for
+    /// each path so a test can tell which one a mail took. The fixture's
+    /// strong `Arc` is returned so the seize handle's `Weak` upgrades for
+    /// the duration of the test.
+    fn seizable_recipient(
+        registry: &Registry,
+        name: &str,
+    ) -> (
+        MailboxId,
+        Arc<SeizableSink>,
+        mpsc::Receiver<u8>,
+        mpsc::Receiver<u8>,
+    ) {
+        let (deposit_tx, deposit_rx) = mpsc::channel::<u8>();
+        let handler: Arc<dyn InboxHandler> = Arc::new(move |d: OwnedDispatch| {
+            let _ = deposit_tx.send(d.payload.bytes()[0]);
+        });
+        let id = registry.register_inbox(name, handler);
+
+        let (direct_tx, direct_rx) = mpsc::channel::<u8>();
+        let fixture = Arc::new(SeizableSink {
+            state: Arc::new(SlotState::new()),
+            direct: direct_tx,
+        });
+        let slot_dyn: Arc<dyn Drainable> = fixture.clone();
+        let installed = registry.install_seize_handle(
+            id,
+            SeizeHandle::new(Arc::clone(&fixture.state), Arc::downgrade(&slot_dyn)),
+        );
+        assert!(installed, "seize handle installs on a live Inbox entry");
+        (id, fixture, direct_rx, deposit_rx)
+    }
+
+    /// Free `Pooled` recipient → the demux seizes it and dispatches in
+    /// place: the seed lands on the **direct** path, the inbox-deposit
+    /// path is never touched.
+    #[test]
+    fn free_recipient_dispatched_direct_no_inbox_bounce() {
+        let (registry, mailer) = fresh_substrate();
+        let (recipient, _fixture, direct_rx, deposit_rx) =
+            seizable_recipient(&registry, "seizable");
+
+        let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
+        let sink = WakeSink::new(Arc::clone(&injector), Arc::new(SpinPark::new()));
+        let blob = BlobWork::with_chunk(owned_mails(recipient, 1), mailer, sink, usize::MAX);
+
+        blob.run_cycle(BatchBudget::standard());
+
+        assert_eq!(
+            direct_rx.try_recv().ok(),
+            Some(0),
+            "seed dispatched in place"
+        );
+        assert!(
+            deposit_rx.try_recv().is_err(),
+            "a direct-dispatched mail never bounces through the inbox"
+        );
+    }
+
+    /// Busy `Pooled` recipient (slot already `Running`) → the seize loses
+    /// the CAS, so the mail is **deposited** through `route_mail`, not
+    /// dispatched in place.
+    #[test]
+    fn busy_recipient_deposited() {
+        let (registry, mailer) = fresh_substrate();
+        let (recipient, fixture, direct_rx, deposit_rx) =
+            seizable_recipient(&registry, "seizable");
+
+        // Mark the recipient busy before the demux: its `Idle → Running`
+        // seize must lose, falling through to the deposit path.
+        assert!(fixture.state.seize(), "fixture starts Idle, seize wins once");
+
+        let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
+        let sink = WakeSink::new(Arc::clone(&injector), Arc::new(SpinPark::new()));
+        let blob = BlobWork::with_chunk(owned_mails(recipient, 1), mailer, sink, usize::MAX);
+
+        blob.run_cycle(BatchBudget::standard());
+
+        assert_eq!(
+            deposit_rx.try_recv().ok(),
+            Some(0),
+            "a busy recipient's mail is deposited"
+        );
+        assert!(
+            direct_rx.try_recv().is_err(),
+            "a busy recipient is not dispatched in place"
+        );
+    }
+
+    /// ADR-0045 ref-carrying kind → never direct-dispatched even to a free
+    /// `Pooled` recipient: `route_mail` owns the handle walk / park, so the
+    /// mail is **deposited**.
+    #[test]
+    fn ref_kind_deposited() {
+        let (registry, mailer) = fresh_substrate();
+        let (recipient, _fixture, direct_rx, deposit_rx) =
+            seizable_recipient(&registry, "seizable");
+
+        // A kind whose schema embeds a `Ref` → `route_lookup.ref_schema`
+        // is `Some`, so the demux falls through to deposit.
+        let ref_kind = registry
+            .register_kind_with_descriptor(KindDescriptor {
+                name: "test.blob.ref_kind".to_owned(),
+                schema: SchemaType::Ref(SchemaCell::owned(SchemaType::Bytes)),
+            })
+            .expect("fresh ref kind registers");
+
+        let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
+        let sink = WakeSink::new(Arc::clone(&injector), Arc::new(SpinPark::new()));
+        // Inline-form `Ref` payload: discriminant 0 (inline) + the inner
+        // `Bytes` value (postcard `varint(len=0)` → empty). The ref-walk
+        // resolves it inline and the recipient's deposit handler receives
+        // the resolved bytes (first byte `0` — the inline discriminant
+        // the closure reads). The test asserts the routing *decision*: a
+        // ref kind is deposited (so `route_mail` owns the walk), never
+        // direct-dispatched.
+        let mails = vec![Mail::new(recipient, ref_kind, MailRef::from(vec![0u8, 0u8]), 1)];
+        let blob = BlobWork::with_chunk(mails, mailer, sink, usize::MAX);
+
+        blob.run_cycle(BatchBudget::standard());
+
+        assert!(
+            direct_rx.try_recv().is_err(),
+            "a ref-carrying kind is never dispatched in place"
+        );
+        assert_eq!(
+            deposit_rx.try_recv().ok(),
+            Some(0),
+            "a ref-carrying kind is deposited so route_mail can walk it"
+        );
+    }
+
+    /// Two mails to one free recipient → both dispatch in place, in send
+    /// order (per-recipient FIFO). The fixture parks `Idle` after each
+    /// seed, so the second mail re-seizes the same slot.
+    #[test]
+    fn two_seeds_to_one_recipient_run_in_send_order() {
+        let (registry, mailer) = fresh_substrate();
+        let (recipient, _fixture, direct_rx, deposit_rx) =
+            seizable_recipient(&registry, "seizable");
+
+        let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
+        let sink = WakeSink::new(Arc::clone(&injector), Arc::new(SpinPark::new()));
+        // Two mails (bytes 0, 1) to the same recipient, in send order.
+        let blob = BlobWork::with_chunk(owned_mails(recipient, 2), mailer, sink, usize::MAX);
+
+        blob.run_cycle(BatchBudget::standard());
+
+        assert_eq!(direct_rx.try_recv().ok(), Some(0), "first seed first");
+        assert_eq!(direct_rx.try_recv().ok(), Some(1), "second seed second");
+        assert!(direct_rx.try_recv().is_err(), "exactly two seeds");
+        assert!(
+            deposit_rx.try_recv().is_err(),
+            "both mails dispatched in place — no inbox deposit"
+        );
+    }
+
+    /// A closure-backed inbox (no slot) exposes no seize handle, so its
+    /// mail is deposited — the path the legacy `counting_sink` tests
+    /// already exercise, asserted here against the seize-resolution.
+    #[test]
+    fn closure_inbox_has_no_seize_handle() {
+        let (registry, _mailer) = fresh_substrate();
+        let (tx, _rx) = mpsc::channel::<u8>();
+        let recipient = counting_sink(&registry, tx);
+        let lookup = registry.route_lookup(KindId(7), recipient);
+        assert!(
+            lookup.seize.is_none(),
+            "a closure-backed inbox has no slot to seize"
         );
     }
 }

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -28,14 +28,24 @@
 //!      post-shutdown drain + `unwire` hook + registry finalize
 //!      sequence and is done forever.
 //!
-//! ## Today (PR C)
+//! ## Scheduling default
 //!
-//! Every actor in the workspace ships `SCHEDULING = Dedicated`, so
-//! this slot is constructed by the `Pooled` branch of
-//! `make_native_actor_boot` / `Spawner::spawn_actor` but never
-//! actually reached at runtime. The branch + slot impl are shaped so
-//! Phase 2 (PR D) can flip a single cap to `Pooled` and have the
-//! pool drive it.
+//! `Actor::SCHEDULING` defaults to `Pooled` (issue 635 Phase 3), so
+//! this slot is the runtime dispatch path for nearly every actor —
+//! chassis caps and loaded wasm trampolines alike. `Dedicated` is the
+//! opt-in escape hatch for actors that park their dispatcher (today only
+//! `ProcessCapability`, which `block_on`s a tokio runtime). The
+//! `Pooled` branch of `make_native_actor_boot` / `Spawner::spawn_actor`
+//! constructs the slot; the chassis worker pool drives it.
+//!
+//! ## In-place demux seed (iamacoffeepot/aether#1135)
+//!
+//! [`Self::seize_and_run`] is the demux-direct counterpart to
+//! [`Self::run_cycle`]: a [`crate::actor::native::blob_work::BlobWork`]
+//! that has **seized** this slot (`Idle → Running`) hands it one
+//! envelope to dispatch in place — skipping the inbox deposit +
+//! `try_recv` repop the deposit-then-wake path paid. Both methods share
+//! the same drain tail ([`Self::drain_after_seed`]).
 
 use std::any::Any;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -79,7 +89,9 @@ use crate::actor::native::{NativeActor, NativeDispatch};
 use crate::actor::registry::ActorRegistry;
 use crate::mail::mailer::Mailer;
 use crate::mail::{KindId, Mail, MailboxId, ReplyTo};
-use crate::scheduler::{BatchBudget, CLOCK_CHECK_STRIDE, CycleResult, Drainable, SlotState};
+use crate::scheduler::{
+    BatchBudget, CLOCK_CHECK_STRIDE, CycleResult, Drainable, SeizeSeed, SlotState,
+};
 
 /// Worker-pool-side wrapper for a native actor. One instance per
 /// `Pooled` actor; held strongly by the chassis (so `unwire` and
@@ -294,28 +306,20 @@ where
             }
         }
     }
-}
 
-impl<A> Drainable for DispatcherSlot<A>
-where
-    A: NativeActor + NativeDispatch,
-{
-    fn run_cycle(&self, budget: BatchBudget) -> CycleResult {
-        if !self.state.enter_running() {
-            // Invariant violation: the worker popped this slot and
-            // its state should have been Ready. Defensive fallback
-            // — bail without touching the actor.
-            tracing::warn!(
-                target: "aether_substrate::scheduler",
-                actor = A::NAMESPACE,
-                "DispatcherSlot::run_cycle entered without Ready state — skipping",
-            );
-            return CycleResult::Idle;
-        }
-
+    /// Shared drain tail for [`Drainable::run_cycle`] (no seed) and
+    /// [`Drainable::seize_and_run`] (one direct-dispatch seed,
+    /// iamacoffeepot/aether#1135). Caller invariant: the slot's
+    /// [`SlotState`] is already `Running` — `run_cycle` won the
+    /// `Ready → Running` CAS, `seize_and_run` won the `Idle → Running`
+    /// seize — so this method owns the actor exclusively. It locks the
+    /// actor, dispatches `seed` (if any) first, then runs the same drain
+    /// loop + shutdown / budget / post-empty-recheck finalization both
+    /// paths share, returning the [`CycleResult`].
+    fn drain_after_seed(&self, seed: Option<Envelope>, budget: BatchBudget) -> CycleResult {
         let mut actor_guard = self.actor.lock().unwrap_or_else(PoisonError::into_inner);
         let Some(actor) = actor_guard.as_mut() else {
-            // Slot already finalized. Nothing to do.
+            // Slot already finalized. Nothing to do — drop any seed.
             drop(actor_guard);
             self.state.mark_idle();
             // Issue 714: a wait that came in after the close cycle
@@ -323,6 +327,14 @@ where
             self.fire_close_done();
             return CycleResult::Closed;
         };
+
+        // iamacoffeepot/aether#1135: the demux-direct seed runs first,
+        // in place — no inbox deposit, no `try_recv` repop. The seed's
+        // `Received` already carries `t_enqueue ≈ now` / `enqueue_depth =
+        // 0` (stamped by the `BlobWork` demuxer), so residence ≈ 0.
+        if let Some(seed) = seed {
+            self.dispatch_one(actor, seed);
+        }
 
         let mut dispatched = 0u32;
         let mut cycle_start: Option<Instant> = None;
@@ -417,6 +429,38 @@ where
             }
             None => CycleResult::Idle,
         }
+    }
+}
+
+impl<A> Drainable for DispatcherSlot<A>
+where
+    A: NativeActor + NativeDispatch,
+{
+    fn run_cycle(&self, budget: BatchBudget) -> CycleResult {
+        if !self.state.enter_running() {
+            // Invariant violation: the worker popped this slot and
+            // its state should have been Ready. Defensive fallback
+            // — bail without touching the actor.
+            tracing::warn!(
+                target: "aether_substrate::scheduler",
+                actor = A::NAMESPACE,
+                "DispatcherSlot::run_cycle entered without Ready state — skipping",
+            );
+            return CycleResult::Idle;
+        }
+        // State is `Running`; drain the inbox with no seed.
+        self.drain_after_seed(None, budget)
+    }
+
+    /// iamacoffeepot/aether#1135: dispatch one direct-dispatch `seed` in
+    /// place, then drain the rest of the inbox. Caller invariant: the
+    /// demuxer just won this slot's [`SlotState::seize`] CAS
+    /// (`Idle → Running`), so the slot is `Running` and exclusively ours
+    /// — no `enter_running` here (it would fail against `Running`). The
+    /// drain tail is shared with [`Self::run_cycle`] via
+    /// [`Self::drain_after_seed`].
+    fn seize_and_run(&self, seed: SeizeSeed, budget: BatchBudget) -> CycleResult {
+        self.drain_after_seed(Some(seed), budget)
     }
 
     fn label(&self) -> &'static str {

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -329,7 +329,9 @@ where
             // its settlement chain still drains (ADR-0080 §2 — the same
             // bracket `route_mail`'s `Dropped` arm records), then drop it.
             if let Some(seed) = seed {
-                self.binding.mailer().record_finished(seed.mail_id, seed.root);
+                self.binding
+                    .mailer()
+                    .record_finished(seed.mail_id, seed.root);
             }
             drop(actor_guard);
             self.state.mark_idle();

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -319,7 +319,18 @@ where
     fn drain_after_seed(&self, seed: Option<Envelope>, budget: BatchBudget) -> CycleResult {
         let mut actor_guard = self.actor.lock().unwrap_or_else(PoisonError::into_inner);
         let Some(actor) = actor_guard.as_mut() else {
-            // Slot already finalized. Nothing to do — drop any seed.
+            // Slot already finalized — the actor box was taken by the
+            // `Closed` path. A `run_cycle` caller can't reach here (it
+            // failed `enter_running` against the `Idle` a finalized slot
+            // parks in), but a `seize_and_run` seed can race the narrow
+            // window between `finalize`'s `actor_guard.take()` and the
+            // strong slot Arc dropping: the `Idle → Running` seize wins
+            // and the `Weak` still upgrades. Balance the seed's `Sent` so
+            // its settlement chain still drains (ADR-0080 §2 — the same
+            // bracket `route_mail`'s `Dropped` arm records), then drop it.
+            if let Some(seed) = seed {
+                self.binding.mailer().record_finished(seed.mail_id, seed.root);
+            }
             drop(actor_guard);
             self.state.mark_idle();
             // Issue 714: a wait that came in after the close cycle

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -40,6 +40,7 @@ use crate::mail::registry::{NameConflict, Registry};
 use crate::mail::{KindId, MailId, MailRef, MailboxId, ReplyTo};
 use crate::runtime::lifecycle::FatalAborter;
 use crate::scheduler::Drainable;
+use crate::scheduler::SeizeHandle;
 use crate::scheduler::WakeHandle;
 use crate::scheduler::WakeSink;
 use aether_actor::local;
@@ -559,6 +560,16 @@ impl Spawner {
                 );
                 let slot_dyn: Arc<dyn Drainable> = slot.clone();
                 let weak: Weak<dyn Drainable> = Arc::downgrade(&slot_dyn);
+                // iamacoffeepot/aether#1135: surface the seize handle on
+                // this instanced actor's `Inbox` entry so the blob
+                // demuxer dispatches its fan-out in place (ADR-0087 §4).
+                // The registry holds the strong slot ref via
+                // `instanced_slots` below; the demuxer's `Weak` upgrade
+                // fails cleanly once the actor is torn down.
+                self.registry.install_seize_handle(
+                    id,
+                    SeizeHandle::new(Arc::clone(slot.state()), Arc::downgrade(&slot_dyn)),
+                );
                 let wake = WakeHandle::new(Arc::clone(slot.state()), weak, self.wake_sink.clone());
                 // Stash the slot's strong Arc so wakes can upgrade their
                 // `Weak`. PR C dropped it here, which broke every wake

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -227,7 +227,7 @@ impl ComponentCtx {
         // downstream dispatch loop records the bracket. See
         // [`MailboxEntry`] docs for the contract.
         match self.registry.entry(recipient) {
-            Some(MailboxEntry::Inbox(handler)) => {
+            Some(MailboxEntry::Inbox { handler, .. }) => {
                 let kind_name = self.registry.kind_name(kind).unwrap_or_default();
                 // Component-originated mail: the sender is this ctx's
                 // mailbox, so its registry name is the `origin` any

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -40,6 +40,7 @@ use crate::mail::mailer::Mailer;
 use crate::mail::registry::Registry;
 use crate::runtime::lifecycle::{FatalAborter, PanicAborter};
 use crate::scheduler::Drainable;
+use crate::scheduler::SeizeHandle;
 use crate::scheduler::WakeHandle;
 use crate::scheduler::{Pool, PoolConfig, PoolHandle};
 use aether_actor::Actor;
@@ -646,6 +647,17 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
                 );
                 let slot_dyn: Arc<dyn Drainable> = slot.clone();
                 let weak: Weak<dyn Drainable> = Arc::downgrade(&slot_dyn);
+                // iamacoffeepot/aether#1135: surface the seize handle on
+                // this actor's `Inbox` entry so the blob demuxer can
+                // dispatch its fan-out in place rather than depositing +
+                // repop'ing through the inbox. Same `(state, weak)` pair
+                // the wake handle carries; the registry owns the strong
+                // slot ref, so the demuxer's `Weak` upgrade fails cleanly
+                // after teardown.
+                ctx.registry().install_seize_handle(
+                    mailbox_id,
+                    SeizeHandle::new(Arc::clone(slot.state()), Arc::downgrade(&slot_dyn)),
+                );
                 drop(slot_dyn);
                 let wake = WakeHandle::new(Arc::clone(slot.state()), weak, ctx.wake_sink().clone());
                 // Issue 697 multi-pass: mail addressed at this actor
@@ -705,8 +717,10 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
 ///    final cycle. The pool's `Drop` joins workers, so any in-flight
 ///    cycle finishes before chassis shutdown returns.
 ///
-/// Today no production cap is `Pooled`, so this struct is reachable
-/// but unused at runtime.
+/// `Pooled` is the `Actor::SCHEDULING` default (issue 635 Phase 3), so
+/// this is the runtime shutdown path for nearly every chassis cap; only
+/// the `Dedicated` opt-outs (today `ProcessCapability`) take the
+/// thread-join `NativeActorShutdown` arm instead.
 struct PooledActorShutdown<A>
 where
     A: NativeActor + NativeDispatch,
@@ -1013,10 +1027,9 @@ struct BootedPassives {
     actor_registry: Arc<crate::ActorRegistry>,
     spawner: Arc<crate::Spawner>,
     /// Issue 635 PR C: chassis-owned worker pool. Boots empty in
-    /// [`boot_passives`] before any cap; today no cap is `Pooled` so
-    /// the pool sits idle, but the infrastructure is live so PR D /
-    /// Phase 2 can flip individual caps without touching this layer
-    /// again. Drops *after* `shutdowns` (per `BootedPassives::Drop` +
+    /// [`boot_passives`] before any cap, then drains every `Pooled` actor
+    /// (the `Actor::SCHEDULING` default since issue 635 Phase 3 — nearly
+    /// every cap). Drops *after* `shutdowns` (per `BootedPassives::Drop` +
     /// implicit field-drop ordering), so every Dedicated dispatcher
     /// thread is gone before pool workers join.
     _pool: PoolHandle,
@@ -1822,7 +1835,7 @@ mod tests {
         let mailbox_id = registry
             .lookup(<ProbeCap as Actor>::NAMESPACE)
             .expect("with_actor claimed the mailbox");
-        let MailboxEntry::Inbox(handler) = registry.entry(mailbox_id).expect("sink registered")
+        let MailboxEntry::Inbox { handler, .. } = registry.entry(mailbox_id).expect("sink registered")
         else {
             panic!("ProbeCap claim must be a sink entry");
         };
@@ -1943,7 +1956,7 @@ mod tests {
         let mailbox_id = registry
             .lookup(<LocalProbe as Actor>::NAMESPACE)
             .expect("with_actor claimed the mailbox");
-        let MailboxEntry::Inbox(handler) = registry.entry(mailbox_id).expect("sink registered")
+        let MailboxEntry::Inbox { handler, .. } = registry.entry(mailbox_id).expect("sink registered")
         else {
             panic!("LocalProbe claim must be a sink entry");
         };
@@ -2115,7 +2128,7 @@ mod tests {
         let parent_id = registry
             .lookup(<ParentCap as Actor>::NAMESPACE)
             .expect("ParentCap claimed");
-        let MailboxEntry::Inbox(handler) = registry.entry(parent_id).expect("sink") else {
+        let MailboxEntry::Inbox { handler, .. } = registry.entry(parent_id).expect("sink") else {
             panic!("expected mailbox entry");
         };
         let bytes = (Hatch { tag: 1 }).encode_into_bytes();
@@ -2233,7 +2246,7 @@ mod tests {
         // registered sink handler. The handler's `ctx.shutdown()`
         // flips the dispatcher's flag; after the handler returns the
         // trampoline drains, runs `unwire`, marks Dead, tombstones.
-        let MailboxEntry::Inbox(handler) = registry.entry(id).expect("sink registered") else {
+        let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("sink registered") else {
             panic!("expected mailbox entry for instanced actor");
         };
         let bytes = (Quit { tag: 1 }).encode_into_bytes();
@@ -2595,7 +2608,7 @@ mod tests {
         // Drive the watcher to register the monitor by pushing a
         // WatchOrder through its sink handler. After this returns
         // the watcher's handle is stored in `self.handle`.
-        let MailboxEntry::Inbox(watcher_handler) =
+        let MailboxEntry::Inbox { handler: watcher_handler, .. } =
             registry.entry(watcher_id).expect("watcher sink registered")
         else {
             panic!("expected mailbox entry for watcher");
@@ -2629,7 +2642,7 @@ mod tests {
         // Fire Quit at the target — its handler self-shuts; the
         // dispatcher's close path runs `close_actor`, which fans out
         // a MonitorNotice mail to watcher_id.
-        let MailboxEntry::Inbox(target_handler) =
+        let MailboxEntry::Inbox { handler: target_handler, .. } =
             registry.entry(target_id).expect("target sink registered")
         else {
             panic!("expected mailbox entry for target");
@@ -2815,7 +2828,7 @@ mod tests {
             .expect("spawn watcher");
 
         // Watcher registers monitor against target.
-        let MailboxEntry::Inbox(watcher_handler) =
+        let MailboxEntry::Inbox { handler: watcher_handler, .. } =
             registry.entry(watcher_id).expect("watcher sink registered")
         else {
             panic!("expected mailbox entry for watcher");
@@ -3000,7 +3013,7 @@ mod tests {
         // Close c — Quit it through the sink handler. After close,
         // resolve_actors drops to two and resolve_actor::<Member>("c")
         // returns None.
-        let MailboxEntry::Inbox(handler) = registry.entry(id_c).expect("c sink registered") else {
+        let MailboxEntry::Inbox { handler, .. } = registry.entry(id_c).expect("c sink registered") else {
             panic!("expected mailbox entry for c");
         };
         handler.enqueue(registry::test_owned_dispatch(
@@ -3293,7 +3306,7 @@ mod tests {
             .expect("spawn parent");
 
         // Trigger parent → grandchild spawn.
-        let MailboxEntry::Inbox(parent_handler) =
+        let MailboxEntry::Inbox { handler: parent_handler, .. } =
             registry.entry(parent_id).expect("parent sink registered")
         else {
             panic!("expected mailbox entry for parent");

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -1835,7 +1835,8 @@ mod tests {
         let mailbox_id = registry
             .lookup(<ProbeCap as Actor>::NAMESPACE)
             .expect("with_actor claimed the mailbox");
-        let MailboxEntry::Inbox { handler, .. } = registry.entry(mailbox_id).expect("sink registered")
+        let MailboxEntry::Inbox { handler, .. } =
+            registry.entry(mailbox_id).expect("sink registered")
         else {
             panic!("ProbeCap claim must be a sink entry");
         };
@@ -1956,7 +1957,8 @@ mod tests {
         let mailbox_id = registry
             .lookup(<LocalProbe as Actor>::NAMESPACE)
             .expect("with_actor claimed the mailbox");
-        let MailboxEntry::Inbox { handler, .. } = registry.entry(mailbox_id).expect("sink registered")
+        let MailboxEntry::Inbox { handler, .. } =
+            registry.entry(mailbox_id).expect("sink registered")
         else {
             panic!("LocalProbe claim must be a sink entry");
         };
@@ -2246,7 +2248,8 @@ mod tests {
         // registered sink handler. The handler's `ctx.shutdown()`
         // flips the dispatcher's flag; after the handler returns the
         // trampoline drains, runs `unwire`, marks Dead, tombstones.
-        let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("sink registered") else {
+        let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("sink registered")
+        else {
             panic!("expected mailbox entry for instanced actor");
         };
         let bytes = (Quit { tag: 1 }).encode_into_bytes();
@@ -2608,8 +2611,10 @@ mod tests {
         // Drive the watcher to register the monitor by pushing a
         // WatchOrder through its sink handler. After this returns
         // the watcher's handle is stored in `self.handle`.
-        let MailboxEntry::Inbox { handler: watcher_handler, .. } =
-            registry.entry(watcher_id).expect("watcher sink registered")
+        let MailboxEntry::Inbox {
+            handler: watcher_handler,
+            ..
+        } = registry.entry(watcher_id).expect("watcher sink registered")
         else {
             panic!("expected mailbox entry for watcher");
         };
@@ -2642,8 +2647,10 @@ mod tests {
         // Fire Quit at the target — its handler self-shuts; the
         // dispatcher's close path runs `close_actor`, which fans out
         // a MonitorNotice mail to watcher_id.
-        let MailboxEntry::Inbox { handler: target_handler, .. } =
-            registry.entry(target_id).expect("target sink registered")
+        let MailboxEntry::Inbox {
+            handler: target_handler,
+            ..
+        } = registry.entry(target_id).expect("target sink registered")
         else {
             panic!("expected mailbox entry for target");
         };
@@ -2828,8 +2835,10 @@ mod tests {
             .expect("spawn watcher");
 
         // Watcher registers monitor against target.
-        let MailboxEntry::Inbox { handler: watcher_handler, .. } =
-            registry.entry(watcher_id).expect("watcher sink registered")
+        let MailboxEntry::Inbox {
+            handler: watcher_handler,
+            ..
+        } = registry.entry(watcher_id).expect("watcher sink registered")
         else {
             panic!("expected mailbox entry for watcher");
         };
@@ -3013,7 +3022,8 @@ mod tests {
         // Close c — Quit it through the sink handler. After close,
         // resolve_actors drops to two and resolve_actor::<Member>("c")
         // returns None.
-        let MailboxEntry::Inbox { handler, .. } = registry.entry(id_c).expect("c sink registered") else {
+        let MailboxEntry::Inbox { handler, .. } = registry.entry(id_c).expect("c sink registered")
+        else {
             panic!("expected mailbox entry for c");
         };
         handler.enqueue(registry::test_owned_dispatch(
@@ -3306,8 +3316,10 @@ mod tests {
             .expect("spawn parent");
 
         // Trigger parent → grandchild spawn.
-        let MailboxEntry::Inbox { handler: parent_handler, .. } =
-            registry.entry(parent_id).expect("parent sink registered")
+        let MailboxEntry::Inbox {
+            handler: parent_handler,
+            ..
+        } = registry.entry(parent_id).expect("parent sink registered")
         else {
             panic!("expected mailbox entry for parent");
         };

--- a/crates/aether-substrate/src/dag/validator.rs
+++ b/crates/aether-substrate/src/dag/validator.rs
@@ -514,7 +514,7 @@ fn declared_kind_id(mailboxes: &Registry, schema: &SchemaType) -> KindId {
 fn mailbox_exists(mailboxes: &Registry, id: MailboxId) -> bool {
     matches!(
         mailboxes.entry(id),
-        Some(MailboxEntry::Inbox(_) | MailboxEntry::Inline(_))
+        Some(MailboxEntry::Inbox { .. } | MailboxEntry::Inline(_))
     )
 }
 

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -554,7 +554,7 @@ fn route_mail(
     }
 
     match lookup.entry {
-        Some(MailboxEntry::Inbox(handler)) => {
+        Some(MailboxEntry::Inbox { handler, .. }) => {
             // Mail reaching a closure-bound mailbox through `push`
             // came from substrate core or a chassis (e.g. the frame
             // loop's FrameStats push, platform input fan-out). Per
@@ -1330,7 +1330,7 @@ mod tests {
         // Comment is normative.
         fn dispatch_path_for_entry(entry: &MailboxEntry) -> &'static str {
             match entry {
-                MailboxEntry::Inbox(_) => "Inbox",
+                MailboxEntry::Inbox { .. } => "Inbox",
                 MailboxEntry::Inline(_) => "Inline",
                 MailboxEntry::Dropped => "Dropped",
             }

--- a/crates/aether-substrate/src/mail/registry.rs
+++ b/crates/aether-substrate/src/mail/registry.rs
@@ -337,7 +337,7 @@ pub enum MailboxEntry {
     /// see [`InboxHandler`] for the full contract.
     ///
     /// iamacoffeepot/aether#1135: `seize` is the deferred
-    /// [`SeizeCell`] — populated by the `Pooled`-branch wiring once the
+    /// `SeizeCell` — populated by the `Pooled`-branch wiring once the
     /// recipient's dispatcher slot exists so the blob demuxer can resolve
     /// recipient → slot and dispatch in place (ADR-0087 §4). Empty for
     /// closure-backed inboxes and `Dedicated` actors (no pool slot).

--- a/crates/aether-substrate/src/mail/registry.rs
+++ b/crates/aether-substrate/src/mail/registry.rs
@@ -30,7 +30,7 @@ use crate::scheduler::SeizeHandle;
 use std::error;
 
 /// Deferred cell holding a `Pooled` actor's
-/// [`SeizeHandle`](crate::scheduler::SeizeHandle), carried on every
+/// [`SeizeHandle`], carried on every
 /// [`MailboxEntry::Inbox`] entry (ADR-0087 §4, iamacoffeepot/aether#1135).
 ///
 /// Registration (`register_inbox` / `try_register_inbox`) happens *before*
@@ -401,7 +401,7 @@ pub(crate) struct RouteLookup {
     pub(crate) kind_name: String,
     pub(crate) ref_schema: Option<SchemaType>,
     /// iamacoffeepot/aether#1135: the recipient's
-    /// [`SeizeHandle`](crate::scheduler::SeizeHandle), resolved under the
+    /// [`SeizeHandle`], resolved under the
     /// same read guard. `Some` only when the recipient is an `Inbox`
     /// entry whose deferred [`SeizeCell`] was populated (a `Pooled`
     /// actor's slot). `None` for closure / `Inline` / `Dropped` / unknown
@@ -836,7 +836,7 @@ impl Registry {
             .map(|m| m.entry.clone())
     }
 
-    /// Install a `Pooled` actor's [`SeizeHandle`](crate::scheduler::SeizeHandle)
+    /// Install a `Pooled` actor's [`SeizeHandle`]
     /// onto its `Inbox` entry's deferred [`SeizeCell`] so the blob
     /// demuxer can resolve recipient → slot and dispatch in place
     /// (ADR-0087 §4, iamacoffeepot/aether#1135). Called by the

--- a/crates/aether-substrate/src/mail/registry.rs
+++ b/crates/aether-substrate/src/mail/registry.rs
@@ -18,7 +18,7 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, OnceLock, RwLock};
 
 use rustc_hash::FxHashMap;
 
@@ -26,7 +26,24 @@ use aether_kinds::trace::Nanos;
 
 use crate::handle_store::schema_contains_ref;
 use crate::mail::{KindId, MailId, MailRef, MailboxId, ReplyTo};
+use crate::scheduler::SeizeHandle;
 use std::error;
+
+/// Deferred cell holding a `Pooled` actor's
+/// [`SeizeHandle`](crate::scheduler::SeizeHandle), carried on every
+/// [`MailboxEntry::Inbox`] entry (ADR-0087 §4, iamacoffeepot/aether#1135).
+///
+/// Registration (`register_inbox` / `try_register_inbox`) happens *before*
+/// the dispatcher slot exists — the actor isn't built into a
+/// `DispatcherSlot` until after `init` / `wire` — so the cell is empty
+/// (`None`) at register time and the `Pooled`-branch wiring in
+/// `chassis/builder.rs` + `actor/native/spawn.rs` installs the handle
+/// once the slot is constructed (mirroring the `MailboxWakeSlot`
+/// deferred-population pattern). The same `Arc` is shared between the
+/// registry entry and the wiring caller. Closure / `Inline` handlers
+/// have no slot to seize, so their cell stays empty forever and the blob
+/// demuxer deposits their mail as usual.
+pub(crate) type SeizeCell = Arc<OnceLock<SeizeHandle>>;
 
 /// Test-only helper that builds a [`MailDispatch`] with empty
 /// `origin` / `ReplyTo::NONE` / `MailId::NONE` defaults from the
@@ -318,7 +335,16 @@ pub enum MailboxEntry {
     /// separate dispatcher loop. Handler receives [`OwnedDispatch`]
     /// so payload + `kind_name` move into the downstream envelope —
     /// see [`InboxHandler`] for the full contract.
-    Inbox(Arc<dyn InboxHandler>),
+    ///
+    /// iamacoffeepot/aether#1135: `seize` is the deferred
+    /// [`SeizeCell`] — populated by the `Pooled`-branch wiring once the
+    /// recipient's dispatcher slot exists so the blob demuxer can resolve
+    /// recipient → slot and dispatch in place (ADR-0087 §4). Empty for
+    /// closure-backed inboxes and `Dedicated` actors (no pool slot).
+    Inbox {
+        handler: Arc<dyn InboxHandler>,
+        seize: SeizeCell,
+    },
     /// The handler body does its work inline on the pushing thread;
     /// there is no actor dispatch loop behind it. `Mailer::push`
     /// brackets this arm with `Received` and `Finished` so the
@@ -374,6 +400,14 @@ pub(crate) struct RouteLookup {
     pub(crate) entry: Option<MailboxEntry>,
     pub(crate) kind_name: String,
     pub(crate) ref_schema: Option<SchemaType>,
+    /// iamacoffeepot/aether#1135: the recipient's
+    /// [`SeizeHandle`](crate::scheduler::SeizeHandle), resolved under the
+    /// same read guard. `Some` only when the recipient is an `Inbox`
+    /// entry whose deferred [`SeizeCell`] was populated (a `Pooled`
+    /// actor's slot). `None` for closure / `Inline` / `Dropped` / unknown
+    /// recipients — the blob demuxer deposits their mail through
+    /// `route_mail` instead of dispatching in place.
+    pub(crate) seize: Option<SeizeHandle>,
 }
 
 /// One kind's bookkeeping, keyed in the registry on the hashed id.
@@ -574,7 +608,7 @@ impl Registry {
             return Err(DropError::UnknownId(id));
         };
         match slot.entry {
-            MailboxEntry::Inbox(_) | MailboxEntry::Inline(_) => {}
+            MailboxEntry::Inbox { .. } | MailboxEntry::Inline(_) => {}
             MailboxEntry::Dropped => return Err(DropError::AlreadyDropped(id)),
         }
         slot.entry = MailboxEntry::Dropped;
@@ -619,7 +653,13 @@ impl Registry {
         name: impl Into<String>,
         handler: Arc<dyn InboxHandler>,
     ) -> MailboxId {
-        match self.insert(name.into(), MailboxEntry::Inbox(handler)) {
+        match self.insert(
+            name.into(),
+            MailboxEntry::Inbox {
+                handler,
+                seize: SeizeCell::default(),
+            },
+        ) {
             Ok(id) => {
                 self.notify_mailbox_change();
                 id
@@ -647,7 +687,13 @@ impl Registry {
         name: impl Into<String>,
         handler: Arc<dyn InboxHandler>,
     ) -> Result<MailboxId, NameConflict> {
-        let result = self.insert(name.into(), MailboxEntry::Inbox(handler));
+        let result = self.insert(
+            name.into(),
+            MailboxEntry::Inbox {
+                handler,
+                seize: SeizeCell::default(),
+            },
+        );
         if result.is_ok() {
             self.notify_mailbox_change();
         }
@@ -737,7 +783,7 @@ impl Registry {
             .expect("registry lock poisoned; fail-fast per ADR-0063");
         match inner.mailboxes.get(&id) {
             Some(slot)
-                if matches!(slot.entry, MailboxEntry::Inbox(_) | MailboxEntry::Inline(_)) =>
+                if matches!(slot.entry, MailboxEntry::Inbox { .. } | MailboxEntry::Inline(_)) =>
             {
                 inner.mailboxes.remove(&id);
                 true
@@ -787,6 +833,31 @@ impl Registry {
             .map(|m| m.entry.clone())
     }
 
+    /// Install a `Pooled` actor's [`SeizeHandle`](crate::scheduler::SeizeHandle)
+    /// onto its `Inbox` entry's deferred [`SeizeCell`] so the blob
+    /// demuxer can resolve recipient → slot and dispatch in place
+    /// (ADR-0087 §4, iamacoffeepot/aether#1135). Called by the
+    /// `Pooled`-branch wiring in `chassis/builder.rs` +
+    /// `actor/native/spawn.rs` once the dispatcher slot exists. Returns
+    /// `true` on a successful install; `false` if the id isn't a live
+    /// `Inbox` entry or the cell was already populated (idempotent — one
+    /// install per slot in production).
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063.
+    pub(crate) fn install_seize_handle(&self, id: MailboxId, handle: SeizeHandle) -> bool {
+        let inner = self
+            .inner
+            .read()
+            .expect("registry lock poisoned; fail-fast per ADR-0063");
+        let Some(MailboxEntry::Inbox { seize, .. }) = inner.mailboxes.get(&id).map(|m| &m.entry)
+        else {
+            return false;
+        };
+        seize.set(handle).is_ok()
+    }
+
     /// Hot-path combined lookup for the mailer's route step: resolves
     /// the recipient's [`MailboxEntry`], the kind's name, and whether
     /// the kind needs ADR-0045 handle resolution — all under a single
@@ -814,10 +885,19 @@ impl Registry {
             .filter(|s| s.has_ref)
             .map(|s| s.descriptor.schema.clone());
         let entry = inner.mailboxes.get(&recipient).map(|m| m.entry.clone());
+        // iamacoffeepot/aether#1135: hand the demuxer the recipient's
+        // seize handle under the same guard. Cloned out of the deferred
+        // cell — `Some` only when the recipient is a `Pooled` actor whose
+        // slot was wired in.
+        let seize = entry.as_ref().and_then(|e| match e {
+            MailboxEntry::Inbox { seize, .. } => seize.get().cloned(),
+            MailboxEntry::Inline(_) | MailboxEntry::Dropped => None,
+        });
         RouteLookup {
             entry,
             kind_name,
             ref_schema,
+            seize,
         }
     }
 
@@ -1134,7 +1214,70 @@ mod tests {
         let id = r.register_inbox("physics", noop_handler());
         assert_eq!(id, MailboxId::from_name("physics"));
         assert_eq!(r.lookup("physics"), Some(id));
-        assert!(matches!(r.entry(id), Some(MailboxEntry::Inbox(_))));
+        assert!(matches!(r.entry(id), Some(MailboxEntry::Inbox { .. })));
+    }
+
+    /// iamacoffeepot/aether#1135: a `Pooled` actor's `Inbox` entry exposes
+    /// a live seize handle once the slot is wired in; a closure-backed
+    /// inbox (no slot) exposes none.
+    #[test]
+    fn pooled_inbox_exposes_seize_handle_closure_does_not() {
+        use crate::scheduler::{BatchBudget, CycleResult, Drainable, SlotState};
+        use std::any::Any;
+
+        // Minimal `Drainable` carrying a real `SlotState` so the installed
+        // seize handle can drive the `Idle → Running` CAS.
+        struct StatefulSlot {
+            state: Arc<SlotState>,
+        }
+        impl Drainable for StatefulSlot {
+            fn run_cycle(&self, _budget: BatchBudget) -> CycleResult {
+                CycleResult::Idle
+            }
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        let r = Registry::new();
+        let kind = r.register_kind("test.seize.kind");
+
+        // Closure-backed inbox: no slot, so no seize handle ever resolves.
+        let closure_id = r.register_inbox("closure", noop_handler());
+        assert!(
+            r.route_lookup(kind, closure_id).seize.is_none(),
+            "a closure-backed inbox exposes no seize handle"
+        );
+
+        // A `Pooled`-shaped inbox: empty before the slot is wired, then a
+        // live handle after `install_seize_handle`.
+        let pooled_id = r.register_inbox("pooled", noop_handler());
+        assert!(
+            r.route_lookup(kind, pooled_id).seize.is_none(),
+            "the seize cell is empty until the Pooled slot is wired"
+        );
+
+        let slot = Arc::new(StatefulSlot {
+            state: Arc::new(SlotState::new()),
+        });
+        let slot_dyn: Arc<dyn Drainable> = slot.clone();
+        let installed = r.install_seize_handle(
+            pooled_id,
+            SeizeHandle::new(Arc::clone(&slot.state), Arc::downgrade(&slot_dyn)),
+        );
+        assert!(installed, "install lands on a live Inbox entry");
+
+        let resolved = r
+            .route_lookup(kind, pooled_id)
+            .seize
+            .expect("Pooled inbox now exposes a seize handle");
+        // The handle is live: it wins the `Idle → Running` seize CAS and
+        // upgrades to the same slot.
+        assert!(
+            resolved.try_seize().is_some(),
+            "the resolved handle seizes a live slot"
+        );
+        let _ = slot_dyn;
     }
 
     #[test]
@@ -1148,7 +1291,7 @@ mod tests {
                 c2.fetch_add(dispatch.count, Ordering::SeqCst);
             }),
         );
-        let Some(MailboxEntry::Inbox(h)) = r.entry(id) else {
+        let Some(MailboxEntry::Inbox { handler: h, .. }) = r.entry(id) else {
             panic!("expected closure entry")
         };
         // Test-side id is irrelevant — the handler ignores it.
@@ -1448,7 +1591,7 @@ mod tests {
         let reloaded = r.try_register_inbox("loaded", noop_handler()).unwrap();
         assert_eq!(reloaded, id);
         assert_eq!(r.lookup("loaded"), Some(reloaded));
-        assert!(matches!(r.entry(reloaded), Some(MailboxEntry::Inbox(_))));
+        assert!(matches!(r.entry(reloaded), Some(MailboxEntry::Inbox { .. })));
     }
 
     #[test]

--- a/crates/aether-substrate/src/mail/registry.rs
+++ b/crates/aether-substrate/src/mail/registry.rs
@@ -783,7 +783,10 @@ impl Registry {
             .expect("registry lock poisoned; fail-fast per ADR-0063");
         match inner.mailboxes.get(&id) {
             Some(slot)
-                if matches!(slot.entry, MailboxEntry::Inbox { .. } | MailboxEntry::Inline(_)) =>
+                if matches!(
+                    slot.entry,
+                    MailboxEntry::Inbox { .. } | MailboxEntry::Inline(_)
+                ) =>
             {
                 inner.mailboxes.remove(&id);
                 true
@@ -1591,7 +1594,10 @@ mod tests {
         let reloaded = r.try_register_inbox("loaded", noop_handler()).unwrap();
         assert_eq!(reloaded, id);
         assert_eq!(r.lookup("loaded"), Some(reloaded));
-        assert!(matches!(r.entry(reloaded), Some(MailboxEntry::Inbox { .. })));
+        assert!(matches!(
+            r.entry(reloaded),
+            Some(MailboxEntry::Inbox { .. })
+        ));
     }
 
     #[test]

--- a/crates/aether-substrate/src/scheduler/mod.rs
+++ b/crates/aether-substrate/src/scheduler/mod.rs
@@ -41,7 +41,7 @@ mod worker_deque;
 pub use pool::{Pool, PoolConfig, PoolHandle, PoolWorkerJoin};
 pub use slot::{
     BATCH_MAX_MAILS, BATCH_MAX_USEC, BatchBudget, CLOCK_CHECK_STRIDE, CycleResult, DrainOutcome,
-    Drainable, SlotState, SlotStateLabel, WakeHandle, WakeSink,
+    Drainable, SeizeHandle, SeizeSeed, SlotState, SlotStateLabel, WakeHandle, WakeSink,
 };
 pub use spin_park::{Acquired, SpinPark};
-pub use worker_deque::{pending_depth, run_demux};
+pub use worker_deque::pending_depth;

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -40,6 +40,16 @@ use crossbeam_deque::Injector;
 
 use super::spin_park::SpinPark;
 use super::worker_deque;
+use crate::actor::native::Envelope;
+
+/// The one envelope a [`Drainable::seize_and_run`] caller hands the
+/// just-seized slot to dispatch in place (ADR-0087 §4,
+/// iamacoffeepot/aether#1135). Alias for the actor-layer
+/// [`Envelope`](crate::actor::native::Envelope) the
+/// [`BlobWork`](crate::actor::native::blob_work::BlobWork) demuxer builds
+/// from the blob's [`Mail`](crate::mail::Mail), with `t_enqueue ≈ now` /
+/// `enqueue_depth = 0` (residence ≈ 0 — the measured win).
+pub type SeizeSeed = Envelope;
 
 /// Default per-cycle envelope cap. Once a worker has dispatched this
 /// many envelopes from a single slot, it yields to other ready slots
@@ -105,6 +115,28 @@ impl SlotState {
         self.state
             .compare_exchange(
                 STATE_READY,
+                STATE_RUNNING,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    /// Demux-side: claim a `free` slot for an *in-place* dispatch
+    /// (ADR-0087 §4, iamacoffeepot/aether#1135). CAS `Idle → Running`,
+    /// returning `true` on the winning transition. Distinct from
+    /// [`Self::enter_running`] (`Ready → Running`): a blob demuxer holds
+    /// the recipient's mail in hand and wants to run it *without* an
+    /// inbox round-trip, so it seizes a slot that no sender has woken
+    /// yet (state `Idle`). A `false` means the slot is already in flight
+    /// (`Ready` — a sender's `try_wake` won; or `Running` — a worker is
+    /// draining): the demuxer falls back to depositing the mail through
+    /// `route_mail`, and the holder/woken cycle drains it (per-recipient
+    /// FIFO preserved by the inbox's own ordering).
+    pub fn seize(&self) -> bool {
+        self.state
+            .compare_exchange(
+                STATE_IDLE,
                 STATE_RUNNING,
                 Ordering::AcqRel,
                 Ordering::Acquire,
@@ -253,6 +285,26 @@ pub trait Drainable: Send + Sync + 'static {
     /// 4. Return the [`CycleResult`] telling the worker what to do.
     fn run_cycle(&self, budget: BatchBudget) -> CycleResult;
 
+    /// In-place demux dispatch (ADR-0087 §4, iamacoffeepot/aether#1135).
+    /// The caller has just **seized** this slot
+    /// ([`SlotState::seize`] / [`SeizeHandle::try_seize`]) — state is
+    /// `Running` — and holds one envelope for it (`seed`). Run the full
+    /// per-envelope wrapper on `seed` *without* an inbox deposit +
+    /// `try_recv` repop, then drain the rest of the inbox under `budget`
+    /// and run the post-empty recheck — i.e. the same drain tail as
+    /// [`Self::run_cycle`]. Returns the [`CycleResult`] telling the
+    /// demuxer what to do with the slot (`Requeue` → re-schedule; `Idle`
+    /// / `Closed` → drop).
+    ///
+    /// Default: deposit-only / unreachable. Mock fixtures (and the
+    /// `BlobWork` blob itself, which has no actor of its own) never get
+    /// seized, so the default just parks the slot back to `Idle` and
+    /// returns. A real [`crate::actor::native::DispatcherSlot`] overrides
+    /// it.
+    fn seize_and_run(&self, _seed: SeizeSeed, _budget: BatchBudget) -> CycleResult {
+        CycleResult::Idle
+    }
+
     /// Debug label — used in tracing events when the worker logs slot
     /// activity. Default `"<unnamed>"`. Implementors override with
     /// something stable (e.g. the actor's namespace).
@@ -375,26 +427,88 @@ impl WakeHandle {
             // gone the state never matters.
             return false;
         };
-        // ADR-0087 Phase 3b: if this wake fires inside a blob-demux
-        // window (a `BlobWork` depositing its fan-out on this worker),
-        // hand the just-woken free recipient to the demuxer so it runs
-        // inline on this worker — no deque push, no notify. The demuxer
-        // owns the slot until it runs it; nothing else can see a slot
-        // that's `Ready` but on no deque.
-        let Err(slot) = worker_deque::try_collect_demux(slot) else {
-            return true;
-        };
-        // Not demuxing — today's affinity / spill path
-        // (iamacoffeepot/aether#1059 own-deque, #1064 route-to-spinner):
-        // own deque under the local bound keeps a chain warm with no
-        // notify; otherwise spill to the injector + notify a spinner (or
-        // unpark one). See [`WakeSink::schedule`].
+        // Today's affinity / spill path (iamacoffeepot/aether#1059
+        // own-deque, #1064 route-to-spinner): own deque under the local
+        // bound keeps a chain warm with no notify; otherwise spill to the
+        // injector + notify a spinner (or unpark one). See
+        // [`WakeSink::schedule`]. The Phase 3b blob-demux deposit+collect
+        // arm retired in iamacoffeepot/aether#1135 — `BlobWork` now
+        // seizes free recipients (`Idle → Running`) and dispatches in
+        // place rather than depositing through `route_mail` and
+        // collecting the woken slot here.
         self.sink.schedule(slot);
         true
     }
 
     /// Borrow the slot state. Tests reach for this; production code
     /// goes through `wake`.
+    #[must_use]
+    pub fn state(&self) -> &Arc<SlotState> {
+        &self.state
+    }
+}
+
+/// Demux-side handle to a recipient's dispatcher slot (ADR-0087 §4,
+/// iamacoffeepot/aether#1135). Surfaced on the registry's
+/// [`MailboxEntry::Inbox`](crate::mail::registry::MailboxEntry) entry so
+/// a [`BlobWork`](crate::actor::native::blob_work::BlobWork) demuxing a
+/// fan-out can resolve recipient → slot up front and dispatch its mail
+/// *in place* — seizing the slot (`Idle → Running`) and running the full
+/// per-envelope wrapper rather than depositing the mail on the inbox mpsc
+/// and bouncing it back out through a `try_recv` repop.
+///
+/// Holds the same pair the [`WakeHandle`] does — the slot's
+/// [`SlotState`] (so the demuxer can drive the `Idle → Running` seize
+/// CAS) and a [`Weak<dyn Drainable>`] (so a seize after the slot dropped
+/// silently no-ops). The chassis registry owns the strong slot ref; this
+/// handle going stale just means the actor was torn down. Only `Pooled`
+/// actors expose one — closure / `Inline` handlers have no slot to seize,
+/// so their entry carries `None` and the demuxer deposits as usual.
+#[derive(Clone)]
+pub struct SeizeHandle {
+    state: Arc<SlotState>,
+    slot: Weak<dyn Drainable>,
+}
+
+impl SeizeHandle {
+    /// Construct a seize handle over a `Pooled` slot. The Pooled-branch
+    /// wiring in `chassis/builder.rs` + `actor/native/spawn.rs` builds
+    /// one once the slot exists and installs it into the registry entry.
+    #[must_use]
+    pub fn new(state: Arc<SlotState>, slot: Weak<dyn Drainable>) -> Self {
+        Self { state, slot }
+    }
+
+    /// Try to claim the recipient slot for an in-place seed dispatch.
+    /// Wins the `Idle → Running` CAS and upgrades the weak slot ref →
+    /// `Some(slot)` (the demuxer then runs [`Drainable::seize_and_run`]
+    /// on it and is responsible for the resulting [`CycleResult`]). A
+    /// `None` means the slot is busy (`Ready`/`Running` — lost the CAS)
+    /// or already dropped: the caller deposits the mail through
+    /// `route_mail` instead.
+    ///
+    /// On a lost CAS the state is untouched (`compare_exchange` only
+    /// flips on success), so a concurrent holder keeps its claim. On a
+    /// won CAS with a dropped slot we revert the state back to `Idle` so
+    /// it doesn't strand in `Running` — there is nothing to run.
+    #[must_use]
+    pub fn try_seize(&self) -> Option<Arc<dyn Drainable>> {
+        if !self.state.seize() {
+            return None;
+        }
+        let upgraded = self.slot.upgrade();
+        if upgraded.is_none() {
+            // Slot dropped between the CAS and the upgrade. We hold a
+            // `Running` claim on a corpse — revert to `Idle` so a later
+            // wake (against a re-registered slot under the same id) isn't
+            // blocked.
+            self.state.mark_idle();
+        }
+        upgraded
+    }
+
+    /// Borrow the slot state. Tests reach for this to assert the
+    /// post-cycle label; production code goes through [`Self::try_seize`].
     #[must_use]
     pub fn state(&self) -> &Arc<SlotState> {
         &self.state
@@ -591,6 +705,31 @@ pub mod tests {
             !state.enter_running(),
             "cannot re-enter Running from Running"
         );
+    }
+
+    #[test]
+    fn seize_only_succeeds_from_idle() {
+        // Demux-side `Idle → Running` (iamacoffeepot/aether#1135),
+        // distinct from `enter_running`'s `Ready → Running`.
+        let state = SlotState::new();
+        assert_eq!(state.current(), SlotStateLabel::Idle);
+        assert!(state.seize(), "Idle → Running seize should win");
+        assert_eq!(state.current(), SlotStateLabel::Running);
+        // A second seize against Running fails — only one runner.
+        assert!(!state.seize(), "cannot seize a Running slot");
+    }
+
+    #[test]
+    fn seize_fails_against_ready() {
+        // A sender's `try_wake` already flipped the slot to `Ready`
+        // (deposited mail, slot queued). The demuxer must lose the
+        // seize and fall back to depositing — per-recipient FIFO is
+        // then preserved by the inbox draining in send order.
+        let state = SlotState::new();
+        assert!(state.try_wake(), "Idle → Ready CAS should win");
+        assert_eq!(state.current(), SlotStateLabel::Ready);
+        assert!(!state.seize(), "cannot seize a Ready slot");
+        assert_eq!(state.current(), SlotStateLabel::Ready);
     }
 
     #[test]

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -45,10 +45,10 @@ use crate::actor::native::Envelope;
 /// The one envelope a [`Drainable::seize_and_run`] caller hands the
 /// just-seized slot to dispatch in place (ADR-0087 §4,
 /// iamacoffeepot/aether#1135). Alias for the actor-layer
-/// [`Envelope`](crate::actor::native::Envelope) the
-/// [`BlobWork`](crate::actor::native::blob_work::BlobWork) demuxer builds
-/// from the blob's [`Mail`](crate::mail::Mail), with `t_enqueue ≈ now` /
-/// `enqueue_depth = 0` (residence ≈ 0 — the measured win).
+/// [`Envelope`](crate::actor::native::Envelope) the `BlobWork` demuxer
+/// builds from the blob's [`Mail`](crate::mail::Mail), with
+/// `t_enqueue ≈ now` / `enqueue_depth = 0` (residence ≈ 0 — the measured
+/// win).
 pub type SeizeSeed = Envelope;
 
 /// Default per-cycle envelope cap. Once a worker has dispatched this
@@ -299,8 +299,7 @@ pub trait Drainable: Send + Sync + 'static {
     /// Default: deposit-only / unreachable. Mock fixtures (and the
     /// `BlobWork` blob itself, which has no actor of its own) never get
     /// seized, so the default just parks the slot back to `Idle` and
-    /// returns. A real [`crate::actor::native::DispatcherSlot`] overrides
-    /// it.
+    /// returns. A real `DispatcherSlot` overrides it.
     fn seize_and_run(&self, _seed: SeizeSeed, _budget: BatchBudget) -> CycleResult {
         CycleResult::Idle
     }
@@ -451,11 +450,11 @@ impl WakeHandle {
 /// Demux-side handle to a recipient's dispatcher slot (ADR-0087 §4,
 /// iamacoffeepot/aether#1135). Surfaced on the registry's
 /// [`MailboxEntry::Inbox`](crate::mail::registry::MailboxEntry) entry so
-/// a [`BlobWork`](crate::actor::native::blob_work::BlobWork) demuxing a
-/// fan-out can resolve recipient → slot up front and dispatch its mail
-/// *in place* — seizing the slot (`Idle → Running`) and running the full
-/// per-envelope wrapper rather than depositing the mail on the inbox mpsc
-/// and bouncing it back out through a `try_recv` repop.
+/// a `BlobWork` demuxing a fan-out can resolve recipient → slot up front
+/// and dispatch its mail *in place* — seizing the slot (`Idle → Running`)
+/// and running the full per-envelope wrapper rather than depositing the
+/// mail on the inbox mpsc and bouncing it back out through a `try_recv`
+/// repop.
 ///
 /// Holds the same pair the [`WakeHandle`] does — the slot's
 /// [`SlotState`] (so the demuxer can drive the `Idle → Running` seize

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -45,7 +45,7 @@ use crate::actor::native::Envelope;
 /// The one envelope a [`Drainable::seize_and_run`] caller hands the
 /// just-seized slot to dispatch in place (ADR-0087 §4,
 /// iamacoffeepot/aether#1135). Alias for the actor-layer
-/// [`Envelope`](crate::actor::native::Envelope) the `BlobWork` demuxer
+/// [`Envelope`] the `BlobWork` demuxer
 /// builds from the blob's [`Mail`](crate::mail::Mail), with
 /// `t_enqueue ≈ now` / `enqueue_depth = 0` (residence ≈ 0 — the measured
 /// win).

--- a/crates/aether-substrate/src/scheduler/worker_deque.rs
+++ b/crates/aether-substrate/src/scheduler/worker_deque.rs
@@ -42,16 +42,6 @@ thread_local! {
     /// don't overlap.
     static LOCAL: RefCell<Option<Worker<Slot>>> = const { RefCell::new(None) };
 
-    /// Blob-demux collect buffer (ADR-0087 Phase 3b,
-    /// iamacoffeepot/aether#1113). `Some` only for the duration of a
-    /// [`run_demux`] window — i.e. while a `BlobWork` is depositing its
-    /// mails into recipient inboxes. While set, [`try_collect_demux`]
-    /// captures each just-woken **free** recipient slot here instead of
-    /// letting the wake push it to a deque, so the demuxing worker can
-    /// run those recipients inline (the Phase 3b fan-out win). Outside a
-    /// demux window it is `None` and the wake takes its normal path.
-    static DEMUX: RefCell<Option<Vec<Slot>>> = const { RefCell::new(None) };
-
     /// The shared off-worker [`Injector`], registered per worker by
     /// [`install_injector`] at the top of the worker loop
     /// (iamacoffeepot/aether#1134). Held only so [`pending_depth`] can read
@@ -177,56 +167,6 @@ pub fn steal_into_local(
     })
 }
 
-/// Run `deposit` inside a blob-demux window (ADR-0087 Phase 3b) and
-/// return the **free** recipient slots it woke. While `deposit` runs,
-/// any [`WakeHandle::wake`](crate::scheduler::WakeHandle::wake) that
-/// wins its recipient's `Idle → Ready` CAS routes the slot into a
-/// thread-local collect buffer (via `try_collect_demux`) instead of
-/// pushing it to a deque — so the caller (`BlobWork::run_cycle`) can run
-/// those recipients **inline** on this worker rather than waking parked
-/// siblings. Busy recipients (lost the CAS) are never collected: their
-/// mail is already deposited and their current holder drains it.
-///
-/// The deposit itself is just today's per-mail routing
-/// (`Mailer::push` → `route_mail`), so every routing concern —
-/// ADR-0045 ref-walk, the settlement/trace brackets, `Inline` /
-/// `Dropped` / unknown bubble-up — is inherited unchanged; only the
-/// wake's *destination* is intercepted.
-///
-/// Panics in debug if a demux window is already open on this thread —
-/// windows never nest (collected recipients run *after* the window
-/// closes, and `Inline` handlers reached during the deposit don't open
-/// their own window), so a nested open is a bug.
-pub fn run_demux<F: FnOnce()>(deposit: F) -> Vec<Slot> {
-    DEMUX.with(|d| {
-        debug_assert!(
-            d.borrow().is_none(),
-            "blob-demux windows must not nest — collected slots run after the window closes"
-        );
-        *d.borrow_mut() = Some(Vec::new());
-    });
-    deposit();
-    DEMUX.with(|d| d.borrow_mut().take().unwrap_or_default())
-}
-
-/// If a blob-demux window is open on this thread, capture `slot` in its
-/// collect buffer and return `Ok(())`; otherwise return `Err(slot)` so
-/// the caller takes its normal wake path. Called by
-/// [`WakeHandle::wake`](crate::scheduler::WakeHandle::wake) after it wins
-/// the `Idle → Ready` CAS — see [`run_demux`].
-pub fn try_collect_demux(slot: Slot) -> Result<(), Slot> {
-    DEMUX.with(|d| {
-        let mut d = d.borrow_mut();
-        match d.as_mut() {
-            Some(buf) => {
-                buf.push(slot);
-                Ok(())
-            }
-            None => Err(slot),
-        }
-    })
-}
-
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,
@@ -236,10 +176,6 @@ mod tests {
     use super::*;
     use crate::scheduler::slot::{BatchBudget, CycleResult, Drainable};
     use std::any::Any;
-
-    use crate::scheduler::slot::{SlotState, WakeHandle, WakeSink};
-    use crate::scheduler::spin_park::SpinPark;
-    use std::sync::Weak;
 
     struct Noop;
     impl Drainable for Noop {
@@ -253,33 +189,6 @@ mod tests {
 
     fn noop() -> Slot {
         Arc::new(Noop)
-    }
-
-    /// A `Drainable` carrying a real [`SlotState`] so a [`WakeHandle`]
-    /// can drive its `Idle → Ready` CAS in the demux-collect tests.
-    struct StatefulNoop {
-        state: Arc<SlotState>,
-    }
-    impl Drainable for StatefulNoop {
-        fn run_cycle(&self, _budget: BatchBudget) -> CycleResult {
-            CycleResult::Idle
-        }
-        fn as_any(&self) -> &dyn Any {
-            self
-        }
-    }
-
-    /// Build a `StatefulNoop` plus a [`WakeHandle`] over it; the strong
-    /// `Arc` is returned so the handle's `Weak` upgrades.
-    fn stateful_with_wake() -> (Arc<StatefulNoop>, WakeHandle) {
-        let slot = Arc::new(StatefulNoop {
-            state: Arc::new(SlotState::new()),
-        });
-        let slot_dyn: Slot = slot.clone();
-        let weak: Weak<dyn Drainable> = Arc::downgrade(&slot_dyn);
-        let sink = WakeSink::new(Arc::new(Injector::new()), Arc::new(SpinPark::new()));
-        let wake = WakeHandle::new(Arc::clone(&slot.state), weak, sink);
-        (slot, wake)
     }
 
     /// Drain any residue so the per-thread deque starts empty regardless
@@ -351,59 +260,5 @@ mod tests {
         // Nothing anywhere → None.
         drain_local();
         assert!(steal_into_local(0, &[], &Injector::new()).is_none());
-    }
-
-    #[test]
-    fn run_demux_collects_woken_free_slot_not_deque() {
-        install(Worker::new_lifo());
-        drain_local();
-        let (_slot, wake) = stateful_with_wake();
-
-        // Inside a demux window, a wake of a free (Idle) recipient is
-        // captured for inline-run, not pushed to the worker's deque.
-        let collected = run_demux(|| {
-            assert!(wake.wake(), "Idle→Ready CAS should win");
-        });
-        assert_eq!(collected.len(), 1, "the free recipient is collected");
-        assert!(
-            pop_local().is_none(),
-            "a collected recipient must not also land on the deque"
-        );
-    }
-
-    #[test]
-    fn run_demux_skips_busy_slot() {
-        install(Worker::new_lifo());
-        drain_local();
-        let (slot, wake) = stateful_with_wake();
-
-        // Mark the recipient busy (Running) before the window: its wake
-        // loses the CAS, so it is neither collected nor deque-pushed —
-        // its current holder drains the deposited mail.
-        assert!(slot.state.try_wake());
-        assert!(slot.state.enter_running());
-
-        let collected = run_demux(|| {
-            assert!(!wake.wake(), "wake against Running is a no-op");
-        });
-        assert!(collected.is_empty(), "a busy recipient is not collected");
-        assert!(pop_local().is_none());
-    }
-
-    #[test]
-    fn wake_outside_demux_window_takes_normal_path() {
-        // Not a pool worker (no `install`): with no demux window open, a
-        // wake spills to the injector — the normal path is unchanged.
-        let collected = run_demux(|| {});
-        assert!(collected.is_empty(), "empty window collects nothing");
-        let (_slot, wake) = stateful_with_wake();
-        // Outside any `run_demux`, the wake spills (StatefulNoop's sink
-        // injector); `try_collect_demux` returns Err so the slot routes
-        // normally. We assert the demux buffer stays absent.
-        assert!(wake.wake());
-        assert!(
-            try_collect_demux(noop()).is_err(),
-            "no demux window is open outside run_demux"
-        );
     }
 }

--- a/crates/aether-substrate/tests/native_actor_macro.rs
+++ b/crates/aether-substrate/tests/native_actor_macro.rs
@@ -134,7 +134,7 @@ fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
 fn push_envelope<K: Kind>(registry: &Registry, recipient: &str, payload: &K) {
     use aether_substrate::mail::registry::MailboxEntry;
     let id: MailboxId = registry.lookup(recipient).expect("mailbox registered");
-    let MailboxEntry::Inbox(handler) = registry.entry(id).expect("entry exists") else {
+    let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("entry exists") else {
         panic!("expected mailbox entry under {recipient}");
     };
     let bytes = payload.encode_into_bytes();
@@ -182,6 +182,90 @@ fn macro_emitted_cap_routes_postcard_kind_through_dispatch() {
         "macro dispatcher should route Greet → on_greet within budget"
     );
     assert_eq!(ping_total.load(AtomicOrdering::SeqCst), 0);
+
+    drop(chassis);
+}
+
+/// iamacoffeepot/aether#1135: a blob demuxer seeds a free `Pooled` actor
+/// via `seize_and_run` — the seed dispatches in place (no inbox deposit /
+/// `try_recv` repop) and the slot returns to `Idle`. Boots a real Pooled
+/// actor through the chassis, lets it quiesce, then resolves the seize
+/// handle off its registry `Inbox` entry, wins the `Idle → Running` seize,
+/// and runs one seed envelope.
+#[test]
+fn seize_and_run_dispatches_seed_in_place() {
+    use aether_substrate::mail::registry::MailboxEntry;
+    use aether_substrate::scheduler::{BatchBudget, SlotStateLabel};
+
+    let (registry, mailer) = fresh_substrate();
+    let greet_total = Arc::new(AtomicU32::new(0));
+    let ping_total = Arc::new(AtomicU32::new(0));
+
+    let chassis: PassiveChassis<TestChassis> =
+        Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<MacroProbeCap>(ProbeConfig {
+                greet_total: Arc::clone(&greet_total),
+                ping_total: Arc::clone(&ping_total),
+            })
+            .build_passive()
+            .expect("macro-emitted cap boots");
+
+    let id = registry
+        .lookup(MacroProbeCap::NAMESPACE)
+        .expect("cap mailbox registered");
+
+    // The cap boots with no pre-load mail, so its slot quiesces to `Idle`.
+    // Resolve the seize handle off the `Inbox` entry's deferred cell (the
+    // #1135 surfacing) and wait for the slot to be seizable.
+    let MailboxEntry::Inbox { seize, .. } = registry.entry(id).expect("entry exists") else {
+        panic!("expected an Inbox entry for the Pooled cap");
+    };
+    let seize = seize.get().expect("a Pooled actor exposes a seize handle");
+
+    let deadline = Instant::now() + Duration::from_millis(500);
+    let slot = loop {
+        if let Some(slot) = seize.try_seize() {
+            break slot;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "Pooled slot should quiesce to Idle and become seizable"
+        );
+        thread::sleep(Duration::from_millis(5));
+    };
+    // The seize put the slot in `Running`.
+    assert_eq!(seize.state().current(), SlotStateLabel::Running);
+
+    // Build one seed envelope and dispatch it in place — no inbox bounce.
+    let payload = Greet { tag: 11 }.encode_into_bytes();
+    let seed = OwnedDispatch {
+        kind: <Greet as Kind>::ID,
+        kind_name: Greet::NAME.to_owned(),
+        origin: None,
+        sender: ReplyTo::NONE,
+        payload: MailRef::from(payload),
+        count: 1,
+        mail_id: MailId::NONE,
+        root: MailId::NONE,
+        parent_mail: None,
+        // The #1135 contract: a direct-dispatched seed has residence ≈ 0.
+        t_enqueue: Nanos(0),
+        enqueue_depth: 0,
+    };
+    slot.seize_and_run(seed, BatchBudget::standard());
+
+    // Handler ran exactly once; the slot drained empty back to `Idle`.
+    assert_eq!(
+        greet_total.load(AtomicOrdering::SeqCst),
+        11,
+        "the seed dispatched through on_greet in place"
+    );
+    assert_eq!(ping_total.load(AtomicOrdering::SeqCst), 0);
+    assert_eq!(
+        seize.state().current(),
+        SlotStateLabel::Idle,
+        "the slot drained empty and returned to Idle"
+    );
 
     drop(chassis);
 }


### PR DESCRIPTION
Closes iamacoffeepot/aether#1135

## Summary
- A BlobWork demuxing a handler fan-out now seizes a free recipient (Idle to Running) and dispatches its mail in place via DispatcherSlot::seize_and_run, removing the deposit + try_recv repop round-trip that dominated fan-out residence (ADR-0087 section 4, the order-safe half of the issue 1059 win). Ref-kinds, busy slots, and non-Pooled recipients fall back to route_mail.
- The recipient seize handle (SlotState plus Weak slot) is surfaced on the registry Inbox entry, populated by the Pooled-branch wiring and resolved through route_lookup; the deposit-collect machinery (run_demux / try_collect_demux / DEMUX thread-local + the WakeHandle::wake collect arm) is retired.
- Single-worker, in send order: BlobWork stays one-shot/single-runner, the 3c split_off spill is unchanged, and per-recipient FIFO holds by construction. The parallel multi-worker demux remains deferred to iamacoffeepot/aether#1137. Also fixes the stale dispatcher_slot.rs / builder.rs doc comments claiming every actor is Dedicated (default is Pooled since issue 635).

## TestBench scenarios
Ran locally on the macOS worktree via the full preflight (cargo nextest run --workspace --all-features --profile ci): all 1284 tests passed, including the in-process full-chassis TestBench load/dispatch coverage (boot_advance_capture_round_trip, spawn_instanced_actor_smoke, tick_fanout_propagates_chassis_root_lineage) that exercises the new demux end to end. fmt / clippy / doc / wasm32 component cross-build all clean.

## Test plan
- [x] SlotState::seize unit tests (Idle to Running wins; Ready/Running fail)
- [x] seize_and_run integration test (native_actor_macro style): seed a Pooled actor, handler ran, slot returns Idle
- [x] blob_work demux tests: free to direct (no inbox bounce), busy to deposit, ref-kind to deposit, two seeds to one recipient in send order, closure exposes no seize handle
- [x] registry test: Pooled inbox exposes a live seize handle, closure exposes none
- [x] full preflight green

Generated with Claude Code