### PR TITLE
perf(substrate): cursor-shared cooperative blob demux

### DIFF
--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -196,6 +196,13 @@ pub struct NativeBinding {
     /// threads / a different path and stay on the eager [`Self::send_mail`]
     /// route, preserving the ring's single-writer discipline.
     outbound: Mutex<OutboundBuffer>,
+    /// iamacoffeepot/aether#1137: this actor's single active cursor-shared
+    /// blob + its recruitment. Built lazily on the first deferred flush
+    /// from the spawner's [`WakeSink`](crate::scheduler::WakeSink), so a
+    /// test binding with no `Spawner` never builds one and stays on the
+    /// eager per-mail route. `Mutex` only for `&self` interior mutability —
+    /// driven solely from this actor's dispatch thread, so uncontended.
+    blob_producer: Mutex<Option<super::blob_work::BlobProducer>>,
 }
 
 impl NativeBinding {
@@ -230,6 +237,7 @@ impl NativeBinding {
             spawner,
             shutdown_flag: Arc::new(AtomicBool::new(false)),
             outbound: Mutex::new(OutboundBuffer::new()),
+            blob_producer: Mutex::new(None),
         }
     }
 
@@ -682,14 +690,27 @@ impl NativeBinding {
                 .collect()
         };
 
-        // ADR-0087 Phase 3b: push the whole blob as one work item when a
-        // pool sink is wired and the caller allows deferral; the demuxing
-        // worker runs free recipients inline. Otherwise route per mail
-        // (eager `wait_reply` flush, or a test binding with no Spawner).
-        if let (true, Some(sink)) = (allow_blob, self.spawner.as_ref().map(|s| s.wake_sink())) {
-            let blob =
-                super::blob_work::BlobWork::new(routed, Arc::clone(&self.mailer), sink.clone());
-            sink.schedule(blob);
+        // ADR-0087 / iamacoffeepot/aether#1137: fold the blob into this
+        // actor's single active cursor-shared blob (recipient-grouped,
+        // cooperatively drained, broadcast-recruited for wide fan-outs)
+        // when a pool sink is wired and the caller allows deferral.
+        // Otherwise route per mail (eager `wait_reply` flush, or a test
+        // binding with no `Spawner`).
+        if allow_blob && self.spawner.is_some() {
+            let mut guard = self
+                .blob_producer
+                .lock()
+                .expect("blob_producer poisoned; fail-fast per ADR-0063");
+            let producer = guard.get_or_insert_with(|| {
+                let sink = self
+                    .spawner
+                    .as_ref()
+                    .expect("spawner present in this branch")
+                    .wake_sink()
+                    .clone();
+                super::blob_work::BlobProducer::new(Arc::clone(&self.mailer), sink)
+            });
+            producer.flush(routed);
         } else {
             for mail in routed {
                 self.mailer.push(mail);

--- a/crates/aether-substrate/src/actor/native/blob_lifecycle.rs
+++ b/crates/aether-substrate/src/actor/native/blob_lifecycle.rs
@@ -1,0 +1,387 @@
+//! Packed lifecycle word for the cursor-shared cooperative blob
+//! (iamacoffeepot/aether#1137). One `AtomicU64` coordinates a single
+//! producer publishing recipient-groups and many workers cooperatively
+//! draining them:
+//!
+//! ```text
+//! bit   63        42..62       21..41       0..20
+//!     [seal:1]  [ done:21 ]  [ len:21 ]  [ cursor:21 ]
+//! ```
+//!
+//! - `cursor` — index of the next group a worker will claim (monotonic;
+//!   only ever increases).
+//! - `len`    — number of groups published so far. **Single-writer**: only
+//!   the producing actor's thread bumps it ([`Lifecycle::publish`]).
+//! - `done`   — number of groups a worker has finished draining.
+//! - `seal`   — set by the worker whose `complete` brings `done == len`
+//!   (which implies `cursor == len`, all groups claimed and drained): the
+//!   blob is retired and accepts no further appends.
+//!
+//! Each op is a CAS on the whole word and retries on contention. `len`
+//! moves only under the single producer, so a [`Lifecycle::publish`] CAS
+//! only ever loses to a concurrent `claim` (cursor) or `complete` (done)
+//! and retries with the same intended `len + count`.
+//!
+//! ## Publication ordering
+//!
+//! The producer writes a new group into the shared array **before**
+//! calling [`Lifecycle::publish`]; `publish`'s `AcqRel` CAS release-stores
+//! the bumped `len`, and a worker's [`Lifecycle::claim`] `Acquire`-loads
+//! the word. A worker that claims index `i` observed `len > i`, so it
+//! synchronizes-with the `publish` that bumped `len` past `i` and sees the
+//! group write that preceded it.
+
+// Every `u64 -> usize` cast below is a packed field bounded by
+// `FIELD_MASK` (`< 2^21`), which fits `usize` on every target aether
+// builds for (wasm32 / x86-64 / aarch64, all >= 32-bit), so the truncation
+// the lint warns about cannot occur.
+#![allow(
+    clippy::cast_possible_truncation,
+    reason = "packed fields are < 2^21, fit usize on all supported targets"
+)]
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Bits per packed field (`cursor` / `len` / `done`). Three fields plus
+/// the seal bit fill the 64-bit word: `3 * 21 + 1 == 64`.
+const FIELD_BITS: u32 = 21;
+const FIELD_MASK: u64 = (1 << FIELD_BITS) - 1;
+const LEN_SHIFT: u32 = FIELD_BITS;
+const DONE_SHIFT: u32 = 2 * FIELD_BITS;
+const SEAL_BIT: u64 = 1 << 63;
+
+/// Max groups a single blob can hold — the 21-bit `len` ceiling. A blob
+/// whose producer would publish past this seals and the producer rolls a
+/// fresh blob for the remainder. The shared group array is sized far
+/// below this in practice (to the flush width); this is the hard wire
+/// ceiling, not the typical cap.
+pub const MAX_GROUPS: usize = FIELD_MASK as usize;
+
+#[inline]
+fn cursor_of(w: u64) -> u64 {
+    w & FIELD_MASK
+}
+#[inline]
+fn len_of(w: u64) -> u64 {
+    (w >> LEN_SHIFT) & FIELD_MASK
+}
+#[inline]
+fn done_of(w: u64) -> u64 {
+    (w >> DONE_SHIFT) & FIELD_MASK
+}
+#[inline]
+fn sealed_of(w: u64) -> bool {
+    w & SEAL_BIT != 0
+}
+#[inline]
+fn pack(cursor: u64, len: u64, done: u64, seal: bool) -> u64 {
+    cursor | (len << LEN_SHIFT) | (done << DONE_SHIFT) | if seal { SEAL_BIT } else { 0 }
+}
+
+/// Outcome of a producer's [`Lifecycle::publish`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum Published {
+    /// Groups published; `len` advanced by the requested count.
+    Ok,
+    /// The blob already sealed (a worker retired it). The producer must
+    /// roll a fresh blob for these groups.
+    Retired,
+    /// Publishing would exceed [`MAX_GROUPS`]. The producer must roll a
+    /// fresh blob.
+    Full,
+}
+
+/// The packed lifecycle word. See the module doc for the bit layout and
+/// the single-producer / many-worker contract.
+pub struct Lifecycle {
+    word: AtomicU64,
+}
+
+impl Lifecycle {
+    /// A fresh blob with `initial_len` groups already published (the first
+    /// flush's groups, written into the array before construction).
+    pub fn new(initial_len: usize) -> Self {
+        debug_assert!(
+            initial_len <= MAX_GROUPS,
+            "initial_len exceeds field ceiling"
+        );
+        Self {
+            word: AtomicU64::new(pack(0, initial_len as u64, 0, false)),
+        }
+    }
+
+    /// Worker: claim the next group index, or `None` if the cursor has
+    /// caught up to `len` (nothing left to drain right now). A claimed
+    /// index is handed to exactly one worker — the monotonic cursor CAS is
+    /// the exactly-once gate for groups.
+    pub fn claim(&self) -> Option<usize> {
+        let mut w = self.word.load(Ordering::Acquire);
+        loop {
+            let (c, l) = (cursor_of(w), len_of(w));
+            if c >= l {
+                return None;
+            }
+            let next = pack(c + 1, l, done_of(w), sealed_of(w));
+            match self
+                .word
+                .compare_exchange_weak(w, next, Ordering::AcqRel, Ordering::Acquire)
+            {
+                Ok(_) => return Some(c as usize),
+                Err(actual) => w = actual,
+            }
+        }
+    }
+
+    /// Producer (single writer): the index the next published group will
+    /// occupy. The producer writes the group(s) into the shared array at
+    /// `peek_len()..peek_len()+count` and then calls [`Self::publish`].
+    /// Valid as a plain load because `len` has a single writer.
+    pub fn peek_len(&self) -> usize {
+        len_of(self.word.load(Ordering::Acquire)) as usize
+    }
+
+    /// Producer (single writer): publish `count` newly-written groups by
+    /// advancing `len`. Rejects with [`Published::Retired`] if a worker
+    /// already sealed the blob, or [`Published::Full`] if the bump would
+    /// exceed [`MAX_GROUPS`]; in both cases the producer rolls a fresh
+    /// blob. The `AcqRel` CAS release-stores the new `len`, publishing the
+    /// array writes that preceded this call.
+    pub fn publish(&self, count: usize) -> Published {
+        if count == 0 {
+            return Published::Ok;
+        }
+        let mut w = self.word.load(Ordering::Acquire);
+        loop {
+            if sealed_of(w) {
+                return Published::Retired;
+            }
+            let l = len_of(w);
+            if l as usize + count > MAX_GROUPS {
+                return Published::Full;
+            }
+            let next = pack(cursor_of(w), l + count as u64, done_of(w), false);
+            match self
+                .word
+                .compare_exchange_weak(w, next, Ordering::AcqRel, Ordering::Acquire)
+            {
+                Ok(_) => return Published::Ok,
+                Err(actual) => w = actual,
+            }
+        }
+    }
+
+    /// Worker: mark one claimed group finished. Sets the seal bit when this
+    /// completion brings `done == len` (all groups drained), retiring the
+    /// blob. Returns `true` if this call retired the blob.
+    pub fn complete(&self) -> bool {
+        let mut w = self.word.load(Ordering::Acquire);
+        loop {
+            let new_done = done_of(w) + 1;
+            let retire = new_done == len_of(w);
+            let next = pack(cursor_of(w), len_of(w), new_done, sealed_of(w) || retire);
+            match self
+                .word
+                .compare_exchange_weak(w, next, Ordering::AcqRel, Ordering::Acquire)
+            {
+                Ok(_) => return retire,
+                Err(actual) => w = actual,
+            }
+        }
+    }
+
+    /// `true` once the blob has sealed (retired). The producer reads this
+    /// to decide whether to append to this blob or roll a fresh one.
+    pub fn is_retired(&self) -> bool {
+        sealed_of(self.word.load(Ordering::Acquire))
+    }
+
+    /// `(cursor, len, done, sealed)` snapshot. Tests + diagnostics only;
+    /// production scheduling goes through the ops above.
+    #[cfg(test)]
+    pub fn snapshot(&self) -> (usize, usize, usize, bool) {
+        let w = self.word.load(Ordering::Acquire);
+        (
+            cursor_of(w) as usize,
+            len_of(w) as usize,
+            done_of(w) as usize,
+            sealed_of(w),
+        )
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::needless_collect,
+    reason = "test setup: unwraps signal failure; thread handles are collected so every worker is spawned before any join"
+)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+    use std::sync::Arc;
+    use std::thread;
+
+    #[test]
+    fn new_starts_at_zero_cursor_unsealed() {
+        let lc = Lifecycle::new(4);
+        assert_eq!(lc.snapshot(), (0, 4, 0, false));
+        assert_eq!(lc.peek_len(), 4);
+        assert!(!lc.is_retired());
+    }
+
+    #[test]
+    fn claim_hands_out_each_index_once_then_drains() {
+        let lc = Lifecycle::new(3);
+        assert_eq!(lc.claim(), Some(0));
+        assert_eq!(lc.claim(), Some(1));
+        assert_eq!(lc.claim(), Some(2));
+        assert_eq!(lc.claim(), None, "cursor caught up to len");
+        assert_eq!(lc.claim(), None, "stays drained");
+    }
+
+    #[test]
+    fn publish_extends_claimable_range() {
+        let lc = Lifecycle::new(1);
+        assert_eq!(lc.claim(), Some(0));
+        assert_eq!(lc.claim(), None);
+        assert_eq!(lc.peek_len(), 1);
+        assert_eq!(lc.publish(2), Published::Ok);
+        assert_eq!(lc.snapshot().1, 3, "len advanced by 2");
+        assert_eq!(lc.claim(), Some(1), "the appended groups are now claimable");
+        assert_eq!(lc.claim(), Some(2));
+        assert_eq!(lc.claim(), None);
+    }
+
+    #[test]
+    fn complete_sets_seal_when_done_reaches_len() {
+        let lc = Lifecycle::new(2);
+        assert_eq!(lc.claim(), Some(0));
+        assert_eq!(lc.claim(), Some(1));
+        assert!(!lc.complete(), "first completion does not retire");
+        assert!(!lc.is_retired());
+        assert!(lc.complete(), "completion bringing done==len retires");
+        assert!(lc.is_retired());
+        assert_eq!(lc.snapshot(), (2, 2, 2, true));
+    }
+
+    #[test]
+    fn publish_after_seal_is_rejected() {
+        let lc = Lifecycle::new(1);
+        let _ = lc.claim();
+        assert!(lc.complete(), "single group completes -> retire");
+        assert_eq!(
+            lc.publish(1),
+            Published::Retired,
+            "no append onto a retired blob"
+        );
+    }
+
+    #[test]
+    fn publish_past_ceiling_is_full() {
+        let lc = Lifecycle::new(MAX_GROUPS);
+        assert_eq!(lc.publish(1), Published::Full);
+    }
+
+    #[test]
+    fn publish_zero_is_noop_ok() {
+        let lc = Lifecycle::new(2);
+        assert_eq!(lc.publish(0), Published::Ok);
+        assert_eq!(lc.snapshot().1, 2);
+    }
+
+    /// Concurrent claimers hand out every index in `0..len` exactly once,
+    /// none twice, none skipped — the cursor CAS is the exactly-once gate.
+    #[test]
+    fn concurrent_claims_partition_the_range() {
+        const LEN: usize = 4096;
+        let lc = Arc::new(Lifecycle::new(LEN));
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let lc = Arc::clone(&lc);
+                thread::spawn(move || {
+                    let mut got = Vec::new();
+                    while let Some(i) = lc.claim() {
+                        got.push(i);
+                    }
+                    got
+                })
+            })
+            .collect();
+        let mut all: Vec<usize> = handles
+            .into_iter()
+            .flat_map(|h| h.join().unwrap())
+            .collect();
+        all.sort_unstable();
+        let unique: BTreeSet<usize> = all.iter().copied().collect();
+        assert_eq!(all.len(), LEN, "every claim accounted for, no duplicates");
+        assert_eq!(unique.len(), LEN, "no index handed out twice");
+        assert_eq!(*unique.iter().next().unwrap(), 0);
+        assert_eq!(*unique.iter().next_back().unwrap(), LEN - 1);
+    }
+
+    /// A single producer publishing concurrently with many claimers never
+    /// loses or duplicates a group index: the published range `0..len` is
+    /// partitioned across the claimers exactly once. (Completion / retire
+    /// is exercised single-threaded above and end-to-end by the blob's own
+    /// concurrency tests — this isolates the publish-vs-claim race, so the
+    /// workers here don't `complete` and the blob never seals mid-stream.)
+    #[test]
+    fn producer_publishes_while_workers_claim() {
+        use std::sync::Mutex;
+        use std::sync::atomic::AtomicBool;
+        const BATCHES: usize = 2000;
+        let lc = Arc::new(Lifecycle::new(1));
+        let producer_done = Arc::new(AtomicBool::new(false));
+        let claimed: Arc<Mutex<Vec<usize>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let producer = {
+            let lc = Arc::clone(&lc);
+            let producer_done = Arc::clone(&producer_done);
+            thread::spawn(move || {
+                for _ in 0..BATCHES {
+                    assert_eq!(
+                        lc.publish(1),
+                        Published::Ok,
+                        "no completer -> never retires"
+                    );
+                }
+                producer_done.store(true, Ordering::Release);
+            })
+        };
+        let workers: Vec<_> = (0..4)
+            .map(|_| {
+                let lc = Arc::clone(&lc);
+                let producer_done = Arc::clone(&producer_done);
+                let claimed = Arc::clone(&claimed);
+                thread::spawn(move || {
+                    let mut mine = Vec::new();
+                    loop {
+                        if let Some(i) = lc.claim() {
+                            mine.push(i);
+                        } else if producer_done.load(Ordering::Acquire) && lc.claim().is_none() {
+                            break;
+                        } else {
+                            thread::yield_now();
+                        }
+                    }
+                    claimed.lock().unwrap().extend(mine);
+                })
+            })
+            .collect();
+
+        producer.join().unwrap();
+        for w in workers {
+            w.join().unwrap();
+        }
+        let mut all = Arc::try_unwrap(claimed).unwrap().into_inner().unwrap();
+        all.sort_unstable();
+        let unique: BTreeSet<usize> = all.iter().copied().collect();
+        assert_eq!(
+            all.len(),
+            1 + BATCHES,
+            "every published group claimed exactly once"
+        );
+        assert_eq!(unique.len(), 1 + BATCHES, "no index handed out twice");
+        assert_eq!(*unique.iter().next_back().unwrap(), BATCHES);
+    }
+}

--- a/crates/aether-substrate/src/actor/native/blob_work.rs
+++ b/crates/aether-substrate/src/actor/native/blob_work.rs
@@ -391,27 +391,24 @@ impl BlobWork {
 
 impl Drainable for BlobWork {
     fn run_cycle(&self, budget: BatchBudget) -> CycleResult {
-        // Claim and drain groups off the shared cursor until the cursor is
-        // exhausted (Idle — drop this copy of the Arc) or the per-cycle
-        // group budget is hit (Requeue — the pool re-injects the blob so
-        // the cursor keeps being shared). Late appends past this worker's
-        // exhaustion are handled by the producer's re-submit on the next
-        // flush.
-        let mut ran: u32 = 0;
-        loop {
-            if ran >= budget.max_mails {
-                return CycleResult::Requeue;
-            }
-            let Some(g) = self.lifecycle.claim() else {
-                return CycleResult::Idle;
-            };
+        // Drain to cursor exhaustion: a worker that picks up the blob runs
+        // it in full, claiming and dispatching every group it wins off the
+        // shared cursor until the cursor is drained. The parallelism is
+        // cooperative — recruitment puts N copies of this blob in flight, so
+        // N workers race the one cursor and split the groups between them —
+        // not a per-worker yield. A blob is a finite, one-shot fan-out, so
+        // (unlike an actor's ongoing inbox) it needs no fairness throttle;
+        // the per-recipient `budget` still bounds each recipient's own inbox
+        // drain inside `dispatch_group`. Late appends past the cursor are
+        // picked up by the producer's re-submit on the next flush.
+        while let Some(g) = self.lifecycle.claim() {
             let group = self.groups[g]
                 .get()
                 .expect("claimed index < len is published");
             self.dispatch_group(group, budget);
             self.lifecycle.complete();
-            ran += 1;
         }
+        CycleResult::Idle
     }
 
     fn label(&self) -> &'static str {

--- a/crates/aether-substrate/src/actor/native/blob_work.rs
+++ b/crates/aether-substrate/src/actor/native/blob_work.rs
@@ -1,290 +1,417 @@
-//! [`BlobWork`] — a handler's buffered fan-out as a single
-//! work-stealing unit (ADR-0087 Phase 3b, iamacoffeepot/aether#1113;
-//! claim-and-dispatch-direct demux, iamacoffeepot/aether#1135).
+//! [`BlobWork`] — a producer's buffered fan-out as a single **cursor-shared
+//! cooperative** work unit (ADR-0087, iamacoffeepot/aether#1137; builds on
+//! the Phase 3b blob + the iamacoffeepot/aether#1135 claim-and-dispatch-
+//! direct demux).
 //!
-//! Phase 2b/2c buffer a native handler's outbound mail into one sealed
-//! ring blob; Phase 3a made per-worker deques the scheduler's queue.
-//! 3b ties them together: instead of routing each buffered mail
-//! eagerly (N pushes + up to N parked-worker wakeups for a fan-out of
-//! N), [`crate::actor::native::NativeBinding::flush_outbound`] pushes
-//! the whole blob as **one** `Drainable` onto the producing worker's
-//! deque. A worker pops it (or an idle sibling steals it) and demuxes
-//! its mail in **send order** (ADR-0087 §4, the order-safe half of the
-//! iamacoffeepot/aether#1059 win):
+//! A handler's outbound mail is grouped **by recipient** into one shared
+//! blob and scheduled once. Many workers drain it cooperatively: each
+//! claims a whole recipient-group off a shared cursor (the packed
+//! [`Lifecycle`] word), seizes that recipient, and dispatches its mail
+//! **in place** — the iamacoffeepot/aether#1135 fast path, now run by N
+//! workers in parallel instead of one. A wide / heavy fan-out parallelises
+//! across the pool instead of serialising on the demuxing worker
+//! (iamacoffeepot/aether#1134 measured that serialisation; #1137 closes
+//! it). Recruitment is a **broadcast** — the producer re-submits the blob
+//! `Arc` to the shared injector + notify (`WakeSink::recruit`), so parked
+//! siblings wake and race the cursor — not the own-deque spill the prior
+//! 3c path used (which kept work local and never woke a sibling, so it
+//! could not parallelise a fan-out at all).
 //!
-//! - **free** recipient (won the `Idle → Running` *seize* CAS, ref-free
-//!   kind) → build the envelope and dispatch it **in place** on this
-//!   worker via [`Drainable::seize_and_run`] — no inbox
-//!   deposit, no `try_recv` repop, residence ≈ 0
-//!   (iamacoffeepot/aether#1135 removed the 3b deposit+collect+repop
-//!   round-trip).
-//! - **busy** recipient (lost the seize), **non-`Pooled`** recipient (no
-//!   slot to seize), or an **ADR-0045 ref kind** → deposit through
-//!   today's [`Mailer::push`] → `route_mail`; the holder / woken cycle
-//!   drains it (per-recipient FIFO preserved by the inbox's own order),
-//!   and `route_mail` owns the ref handle walk / park.
+//! ## Recipient-grouped, each recipient once
 //!
-//! ## Chunked spill (Phase 3c, iamacoffeepot/aether#1116)
+//! A worker owns a whole recipient-group, so **per-recipient FIFO is free**
+//! (the ordering spine, ADR-0087 amendment): one worker dispatches all of a
+//! recipient's mail, in send order. Cross-recipient groups run concurrently
+//! — the spine makes that explicitly sound (different recipients → async,
+//! no ordering guarantee). Each recipient appears in **at most one** group
+//! per blob; successive flushes to the same recipient append to its
+//! existing group (preserving cross-flush FIFO) rather than racing a second
+//! group.
 //!
-//! 3b runs a whole fan-out blob inline on one worker — optimal latency,
-//! but a heavy / wide fan-out serialises (the pre-blob path scattered the
-//! leaves across workers). 3c caps the inline demux at `K` mails
-//! ([`demux_chunk`], `AETHER_BLOB_DEMUX_CHUNK`): a blob wider than `K`
-//! `split_off`s the remainder and pushes it as a stealable sub-blob
-//! *before* demuxing its own `K` chunk, so an idle sibling can steal the
-//! remainder while this worker runs its chunk (the throughput path); with
-//! no idle worker the producer pops the remainder itself next loop and
-//! continues in `K`-chunks (the latency path, LIFO-warm). The split is a
-//! [`Vec::split_off`] of `Mail` handles — `MailRef`s (ring offsets / owned
-//! boxes) are **moved, never copied**, so the sub-blob references the same
-//! ring regions and the reclaim-lock counts travel with the moved refs.
-//! (Consequence: a spilled sub-blob pins its producer ring region until
-//! its chunk drains; under sustained heavy fan-out the 2a ring-full →
-//! `Owned` valve absorbs the back-pressure — no producer block.)
+//! ## Single active blob + append (cross-flush FIFO)
 //!
-//! ## How the demux reuses the one router
+//! [`BlobProducer`] keeps **one active blob per producing actor**.
+//! Successive flushes append (new recipients → new groups via
+//! [`Lifecycle::publish`]; seen recipients → push onto the existing group's
+//! buffer). The blob retires when fully drained; the next flush rolls a
+//! fresh one. Accumulation is what preserves per-recipient FIFO across
+//! flushes under burst: a second flush to a not-yet-drained recipient lands
+//! in the same group rather than a second group two workers could seize
+//! out of order. A flush that overflows the group array (or hits a retired
+//! blob) rolls the remainder into a fresh blob — and the overflow remainder
+//! is always *new* recipients (seen recipients push to existing groups, no
+//! new-group pressure), so a rolled blob never shares a recipient with the
+//! one it rolled from: no cross-blob same-recipient race.
 //!
-//! Both arms keep all routing concerns in one place. The **deposit** arm
-//! is today's [`Mailer::push`] → `route_mail`, so the ADR-0045 ref-walk,
-//! the `Inline` / `Dropped` / unknown-bubble-up arms, and that path's
-//! settlement/trace brackets are inherited unchanged. The **direct**
-//! arm runs the recipient's [`Drainable::seize_and_run`]
-//! → `DispatcherSlot::dispatch_one`, the *same* per-envelope wrapper a
-//! pooled `run_cycle` runs — `local::with_stamped`, `Received` /
-//! `Finished` (incl. the iamacoffeepot/aether#1134 `t_enqueue` /
-//! `enqueue_depth`), the `record_finished` settlement bracket, and the
-//! `log.tail` / `trace.tail` framework arms — so the only thing it skips
-//! is the mpsc deposit + `try_recv` repop. The demux resolves the
-//! recipient's seize handle (and ref-schema) up front via
-//! `Registry::route_lookup`, the same combined read `route_mail` uses,
-//! and falls back to deposit whenever direct dispatch doesn't apply.
+//! ## Closeable per-group buffer (the merge-vs-claim handshake)
 //!
-//! ## Single-runner, order-safe scope (iamacoffeepot/aether#1135)
+//! Each group's mail lives behind a [`Mutex`]-guarded closeable buffer.
+//! This is **SPSC**: the producing actor's thread pushes; exactly one
+//! cursor-winning worker drains+closes. The worker drains in a loop —
+//! taking whatever the buffer holds, dispatching it, then re-locking —
+//! and **closes only when it locks and finds the buffer empty**. That
+//! makes `close` a FIFO barrier: every mail the producer pushed before the
+//! close is captured and dispatched (in order); a push that loses the race
+//! sees `closed` and is deposited through `route_mail`, landing in the
+//! recipient inbox strictly *after* everything the worker dispatched. So a
+//! late cross-flush append never jumps ahead of earlier mail. (A
+//! lock-free Treiber stack is a possible future optimisation; on this
+//! low-contention SPSC path a mutex is trivially correct and FIFO-
+//! preserving, and mirrors the pre-#1137 `BlobWork`'s own
+//! `Mutex<Option<Vec<Mail>>>`.)
 //!
-//! This blob stays **one-shot, single-runner**: `run_cycle` takes the
-//! mail out once (`mails.lock().take()`) and demuxes it on one worker in
-//! send order. The parallel multi-worker demux (cursor-shared groups +
-//! recruitment, which reorders across recipients — sound under the
-//! ordering spine but real concurrency machinery) is deferred to
-//! iamacoffeepot/aether#1137, gated on whether direct dispatch alone
-//! closes the residence gap. The 3c [`Vec::split_off`] spill below is the
-//! one stealable hand-off and is unchanged by #1135.
+//! ## Reusing the one router (unchanged from #1135)
 //!
-//! ## Alternative not taken — explicit slot-demux registry (revisit?)
+//! In-place dispatch resolves the recipient's seize handle + ref-schema via
+//! [`Registry::route_lookup`](crate::mail::Registry) and, on a won
+//! `Idle → Running` seize of a ref-free kind, runs
+//! [`Drainable::seize_and_run`] → `DispatcherSlot::dispatch_one` (the same
+//! per-envelope wrapper a pooled `run_cycle` runs — `Received` / `Finished`
+//! incl. the #1134 `t_enqueue` / `enqueue_depth`, the `record_finished`
+//! settlement bracket, the `log.tail` / `trace.tail` arms). A busy slot
+//! (lost seize), a non-`Pooled` recipient (no seize handle), or an ADR-0045
+//! ref kind falls back to [`Mailer::push`] → `route_mail`, inheriting that
+//! path's ref-walk / park / settlement / trace unchanged.
 //!
-//! The other shape (iamacoffeepot/aether#1113 design fork) was a
-//! first-class `MailboxId → (SlotState, Weak<slot>)` table the blob
-//! worker resolves directly, depositing via `ActorRegistry::live_sender`
-//! and routing only non-`Inbox` recipients through `route_mail`. The
-//! seize handle surfaced on the registry `Inbox` entry
-//! (iamacoffeepot/aether#1135) is the lighter form of that idea — it adds
-//! no second shared map (it rides the entry `route_lookup` already
-//! resolves) and keeps `route_mail` as the single fallback router, so the
-//! fast path and the deposit path don't drift. **Reconsider a dedicated
-//! table only if the scheduler later needs first-class slot addressing
-//! for other consumers** (affinity-as-data, slot introspection, NUMA
-//! placement) — at which point its real consumers exist and it earns its
-//! keep.
+//! ## Recruitment gate
+//!
+//! Recruiting siblings for a *narrow* fan-out would regress the
+//! iamacoffeepot/aether#1116 narrow-local win (needless wakeups for cheap
+//! handlers). So a flush only broadcast-recruits when its fresh-group count
+//! is `>= AETHER_BLOB_RECRUIT_MIN` (default 9 — narrow `<= 8` fan-outs stay
+//! local, exactly the prior inline-demux behaviour); otherwise it just
+//! schedules the blob on the producer's own deque. **Width is a coarse
+//! proxy for the real signal (handler cost):** it cannot tell a heavy
+//! narrow fan-out (which would benefit) from a trivial one (which would
+//! not). Cost-aware recruitment sizing is deferred to
+//! iamacoffeepot/aether#1127 (fed by iamacoffeepot/aether#1128's per-handler
+//! EWMA); until then a heavy `<= 8` fan-out stays serial.
 
 use std::any::Any;
+use std::collections::{HashMap, HashSet};
 use std::env;
+use std::mem;
 use std::sync::{Arc, Mutex, OnceLock, PoisonError};
 
 use crate::actor::native::Envelope;
-use crate::mail::Mail;
+use crate::actor::native::blob_lifecycle::{Lifecycle, MAX_GROUPS, Published};
 use crate::mail::mailer::Mailer;
+use crate::mail::{Mail, MailboxId};
 use crate::scheduler::{BatchBudget, CycleResult, Drainable, SeizeHandle, WakeSink};
 
-/// Inline-demux chunk cap K (ADR-0087 Phase 3c, iamacoffeepot/aether#1116).
-/// A `BlobWork` of more than `K` mails demuxes the first `K` inline and
-/// spills the remainder as a stealable sub-blob, so a wide fan-out
-/// parallelises across idle workers (each chunk is at most `K` mails of
-/// work before a steal point) instead of serialising on the one demuxing
-/// worker. Read once from `AETHER_BLOB_DEMUX_CHUNK`; values `< 1` and
-/// unparseable input fall back to the default.
-///
-/// **Default `8`**, set from the iamacoffeepot/aether#1116 K-sweep
-/// (3-sample medians, 11 workers): fan-outs wider than 8 win — fanout-16
-/// ~0.92× / fanout-32 ~0.84× hop-p50 vs the chunking-off 3b baseline, p99
-/// flat-to-better — while fan-outs of `≤ 8` (the common case, and the
-/// narrow-heavy case, which showed no clean win when chunked) stay on the
-/// zero-overhead single-pass demux. Set the knob to `usize::MAX` to
-/// disable chunking entirely (the 3b single-pass behaviour).
-#[must_use]
-fn demux_chunk() -> usize {
-    static CHUNK: OnceLock<usize> = OnceLock::new();
-    *CHUNK.get_or_init(|| {
-        env::var("AETHER_BLOB_DEMUX_CHUNK")
+/// Floor for a fresh blob's group-array capacity. A blob sized to its
+/// first flush still gets at least this many slots so a few subsequent
+/// flushes to new recipients can accumulate before the array overflows and
+/// the producer rolls a fresh blob.
+const GROUP_CAP_MIN: usize = 16;
+
+/// Minimum fresh-group count for a flush to broadcast-recruit siblings.
+/// Read once from `AETHER_BLOB_RECRUIT_MIN`; values `< 1` and unparseable
+/// input fall back to the default. **Default 9** keeps narrow `<= 8`
+/// fan-outs on the producer-local inline path (the
+/// iamacoffeepot/aether#1116 narrow-local win) and recruits only wider
+/// fan-outs. See the module doc on the width-vs-cost proxy limitation
+/// (iamacoffeepot/aether#1127).
+fn recruit_min() -> usize {
+    static MIN: OnceLock<usize> = OnceLock::new();
+    *MIN.get_or_init(|| {
+        env::var("AETHER_BLOB_RECRUIT_MIN")
             .ok()
             .and_then(|v| v.parse::<usize>().ok())
             .filter(|&k| k >= 1)
-            .unwrap_or(8)
+            .unwrap_or(9)
     })
 }
 
-/// One sealed ring blob's worth of routed mail, scheduled as a single
-/// `Drainable` (ADR-0087 Phase 3b). One-shot: `run_cycle` demuxes the
-/// mail once and returns [`CycleResult::Idle`]; the popped `Arc` then
-/// drops.
+/// Cap on the number of sibling copies a single flush injects when
+/// recruiting. Read once from `AETHER_BLOB_RECRUIT_MAX`; bounds the
+/// injector churn for a very wide fan-out (over-recruiting past the worker
+/// count just re-parks the extra workers — harmless but wasteful). Default
+/// 32.
+fn recruit_cap() -> usize {
+    static CAP: OnceLock<usize> = OnceLock::new();
+    *CAP.get_or_init(|| {
+        env::var("AETHER_BLOB_RECRUIT_MAX")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&k| k >= 1)
+            .unwrap_or(32)
+    })
+}
+
+/// One recipient's mail within a blob, behind a closeable buffer. See the
+/// module doc (§Closeable per-group buffer) for the SPSC drain-loop /
+/// close-on-empty FIFO contract.
+struct GroupBuf {
+    /// Set by the claiming worker once it drains the buffer empty. A
+    /// producer push after this is rejected (deposited via `route_mail`).
+    closed: bool,
+    /// Pending mail in send order. Drained in batches by the claiming
+    /// worker; appended by the producer until `closed`.
+    mails: Vec<Mail>,
+}
+
+struct Group {
+    recipient: MailboxId,
+    buf: Mutex<GroupBuf>,
+}
+
+impl Group {
+    fn new(recipient: MailboxId, mails: Vec<Mail>) -> Self {
+        Self {
+            recipient,
+            buf: Mutex::new(GroupBuf {
+                closed: false,
+                mails,
+            }),
+        }
+    }
+
+    /// Producer: append `mail`, or hand it back (`Err`) if the group has
+    /// been drained+closed — the caller deposits it through `route_mail`,
+    /// where it lands strictly after everything the claiming worker
+    /// dispatched (the close barrier).
+    #[allow(
+        clippy::result_large_err,
+        reason = "the rejected Mail moves back to the caller for deposit on the cold closed-group path; boxing it would add a cold-path alloc and break the Mail-by-value convention"
+    )]
+    fn push(&self, mail: Mail) -> Result<(), Mail> {
+        let mut b = self.buf.lock().unwrap_or_else(PoisonError::into_inner);
+        let result = if b.closed {
+            Err(mail)
+        } else {
+            b.mails.push(mail);
+            Ok(())
+        };
+        drop(b);
+        result
+    }
+
+    /// Claiming worker: take the next batch of pending mail (send order),
+    /// or `None` once the buffer is empty — at which point this call closes
+    /// the group (the FIFO barrier). The worker loops until `None`.
+    fn take_or_close(&self) -> Option<Vec<Mail>> {
+        let mut b = self.buf.lock().unwrap_or_else(PoisonError::into_inner);
+        if b.mails.is_empty() {
+            b.closed = true;
+            None
+        } else {
+            Some(mem::take(&mut b.mails))
+        }
+    }
+
+    /// Reclaim mail from a group that was staged into the array but whose
+    /// [`Lifecycle::publish`] failed (retired / full), so it was never
+    /// claimable. The producer rolls these into a fresh blob. No worker can
+    /// have touched it (the cursor never reached its index).
+    fn reclaim(&self) -> Vec<Mail> {
+        let mut b = self.buf.lock().unwrap_or_else(PoisonError::into_inner);
+        mem::take(&mut b.mails)
+    }
+}
+
+/// Outcome of folding one flush into a blob ([`BlobWork::append_flush`]).
+struct FlushOutcome {
+    /// Mail that did not fit (blob retired or group array full) — the
+    /// producer rolls it into a fresh blob. Always *new* recipients (seen
+    /// recipients push to existing groups), so a rolled blob shares no
+    /// recipient with this one.
+    leftover: Vec<Mail>,
+    /// Number of new groups this flush published — the width that drives
+    /// the recruitment gate.
+    fresh_groups: usize,
+}
+
+/// One producer's shared cooperative blob. Constructed empty (sized to a
+/// flush) and filled via [`Self::append_flush`]; drained by any number of
+/// workers via the [`Drainable`] impl.
 pub struct BlobWork {
-    /// The blob's mail. `Option` so `run_cycle` (which takes `&self`)
-    /// can `take` the owned `Vec` out for the one-shot demux; `Mutex`
-    /// only for the `&self` interior-mutability + `Sync` requirement —
-    /// a blob is demuxed by exactly one worker, so the lock is
-    /// uncontended.
-    mails: Mutex<Option<Vec<Mail>>>,
-    /// Resolves each mail's recipient (`route_lookup`) and deposits the
-    /// non-direct-dispatch mails (`push` → `route_mail`) on the demuxing
-    /// worker.
+    lifecycle: Lifecycle,
+    /// Fixed-capacity group array. Index `< lifecycle.len()` is published
+    /// (the producer wrote it before the `publish` that advanced `len`, so
+    /// a worker that claims the index sees it `Some`). Sized to the first
+    /// flush (with a [`GROUP_CAP_MIN`] floor); the producer rolls a fresh
+    /// blob on overflow.
+    groups: Box<[OnceLock<Group>]>,
     mailer: Arc<Mailer>,
-    /// Where a direct-dispatched recipient that yields mid-drain
-    /// ([`CycleResult::Requeue`]) is re-scheduled — the same own-deque /
-    /// injector path a normal wake uses.
+    /// Where a recipient that yields mid-drain ([`CycleResult::Requeue`]) is
+    /// re-scheduled — the same path a normal wake uses.
     sink: WakeSink,
-    /// Inline-demux chunk cap K (3c). Set from [`demux_chunk`] at
-    /// construction and inherited by spilled sub-blobs, so a blob's whole
-    /// chunk-cascade uses one consistent K (and tests can pin it without
-    /// the process-global env knob).
-    chunk: usize,
 }
 
 impl BlobWork {
-    /// Wrap a flushed blob's routed mail as a schedulable unit. The
-    /// chunk cap is read from [`demux_chunk`] (`AETHER_BLOB_DEMUX_CHUNK`).
-    pub fn new(mails: Vec<Mail>, mailer: Arc<Mailer>, sink: WakeSink) -> Arc<Self> {
-        Self::with_chunk(mails, mailer, sink, demux_chunk())
-    }
-
-    /// Construct with an explicit chunk cap — the production path goes
-    /// through [`Self::new`] (which reads the env knob); `run_cycle`
-    /// threads `self.chunk` into the spilled sub-blob, and tests pin a
-    /// small `K` to exercise the spill without the process-global knob.
-    fn with_chunk(
-        mails: Vec<Mail>,
-        mailer: Arc<Mailer>,
-        sink: WakeSink,
-        chunk: usize,
-    ) -> Arc<Self> {
+    /// An empty blob with a `cap`-slot group array.
+    fn empty(cap: usize, mailer: Arc<Mailer>, sink: WakeSink) -> Arc<Self> {
+        let groups = (0..cap).map(|_| OnceLock::new()).collect();
         Arc::new(Self {
-            mails: Mutex::new(Some(mails)),
+            lifecycle: Lifecycle::new(0),
+            groups,
             mailer,
             sink,
-            chunk,
         })
+    }
+
+    /// Producer (single-threaded for a given blob): fold one flush's mail
+    /// in. `index` is this blob's producer-private recipient → group-index
+    /// map (held by the [`BlobProducer`]). New recipients become new groups
+    /// (written then published); seen recipients push onto their existing
+    /// group's buffer (or, if it has been closed, deposit through
+    /// `route_mail`). Returns the leftover (overflow / retired) and the
+    /// fresh-group count.
+    fn append_flush(
+        &self,
+        routed: Vec<Mail>,
+        index: &mut HashMap<MailboxId, usize>,
+    ) -> FlushOutcome {
+        // Partition the flush: pushes onto already-known groups vs new
+        // recipients (bucketed in first-seen order so a recipient that
+        // appears twice in one flush becomes one group with both mails in
+        // order).
+        let mut new_order: Vec<MailboxId> = Vec::new();
+        let mut new_buckets: HashMap<MailboxId, Vec<Mail>> = HashMap::new();
+        for mail in routed {
+            if let Some(&g) = index.get(&mail.recipient) {
+                // Seen recipient → push onto its group; a closed group
+                // (already drained) deposits through the router instead.
+                let group = self.groups[g].get().expect("indexed group is published");
+                if let Err(mail) = group.push(mail) {
+                    self.mailer.push(mail);
+                }
+            } else {
+                new_buckets
+                    .entry(mail.recipient)
+                    .or_insert_with(|| {
+                        new_order.push(mail.recipient);
+                        Vec::new()
+                    })
+                    .push(mail);
+            }
+        }
+
+        if new_order.is_empty() {
+            return FlushOutcome {
+                leftover: Vec::new(),
+                fresh_groups: 0,
+            };
+        }
+
+        // Stage new groups into the array starting at the current len, then
+        // publish. `peek_len` is valid as a plain load — len has a single
+        // writer (this producer).
+        let base = self.lifecycle.peek_len();
+        let cap = self.groups.len();
+        let mut staged = 0usize;
+        let mut leftover: Vec<Mail> = Vec::new();
+        for recipient in new_order {
+            let mails = new_buckets.remove(&recipient).expect("bucket exists");
+            let idx = base + staged;
+            if idx >= cap {
+                // Group array full — roll the rest into a fresh blob. These
+                // are new recipients, so no overlap with this blob.
+                leftover.extend(mails);
+                continue;
+            }
+            self.groups[idx]
+                .set(Group::new(recipient, mails))
+                .ok()
+                .expect("group slot written once");
+            index.insert(recipient, idx);
+            staged += 1;
+        }
+
+        match self.lifecycle.publish(staged) {
+            Published::Ok => FlushOutcome {
+                leftover,
+                fresh_groups: staged,
+            },
+            Published::Retired | Published::Full => {
+                // The blob retired (or hit the wire ceiling) between staging
+                // and publish: the staged groups never became claimable.
+                // Reclaim their mail and roll everything into a fresh blob.
+                for j in 0..staged {
+                    let group = self.groups[base + j].get().expect("staged group present");
+                    index.remove(&group.recipient);
+                    leftover.extend(group.reclaim());
+                }
+                FlushOutcome {
+                    leftover,
+                    fresh_groups: 0,
+                }
+            }
+        }
+    }
+
+    /// Dispatch one group's mail to its recipient, draining the closeable
+    /// buffer in batches until empty (then the buffer self-closes — the
+    /// FIFO barrier). Each batch's mail dispatches in send order via the
+    /// #1135 per-mail fast path.
+    fn dispatch_group(&self, group: &Group, budget: BatchBudget) {
+        while let Some(batch) = group.take_or_close() {
+            for mail in batch {
+                self.dispatch_one(group.recipient, mail, budget);
+            }
+        }
+    }
+
+    /// The iamacoffeepot/aether#1135 per-mail demux step: seize the
+    /// recipient and dispatch in place, or deposit through `route_mail`.
+    fn dispatch_one(&self, recipient: MailboxId, mail: Mail, budget: BatchBudget) {
+        let lookup = self.mailer.registry().route_lookup(mail.kind, recipient);
+        // Direct-dispatch only a ref-free kind whose recipient is a
+        // `Pooled` slot we win the seize on; everything else deposits.
+        let seized = if lookup.ref_schema.is_some() {
+            None
+        } else {
+            lookup.seize.as_ref().and_then(SeizeHandle::try_seize)
+        };
+        match seized {
+            Some(slot) => {
+                let seed = Envelope {
+                    kind: mail.kind,
+                    kind_name: lookup.kind_name,
+                    origin: None,
+                    sender: mail.reply_to,
+                    payload: mail.payload,
+                    count: mail.count,
+                    mail_id: mail.mail_id,
+                    root: mail.root,
+                    parent_mail: mail.parent_mail,
+                    t_enqueue: self.mailer.now_nanos(),
+                    enqueue_depth: 0,
+                };
+                match slot.seize_and_run(seed, budget) {
+                    CycleResult::Requeue => self.sink.schedule(slot),
+                    CycleResult::Idle | CycleResult::Closed => {}
+                }
+            }
+            None => self.mailer.push(mail),
+        }
     }
 }
 
 impl Drainable for BlobWork {
     fn run_cycle(&self, budget: BatchBudget) -> CycleResult {
-        let Some(mut mails) = self
-            .mails
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .take()
-        else {
-            // Already demuxed (a blob is one-shot). Defensive — the
-            // scheduler never runs a slot twice without a re-push.
-            return CycleResult::Idle;
-        };
-
-        // ADR-0087 Phase 3c: cap the inline demux at K mails and spill the
-        // remainder as a stealable sub-blob, so a wide / heavy fan-out
-        // parallelises across idle workers instead of serialising here.
-        // `split_off` **moves** the tail `Mail` handles into the new blob
-        // — each carries its `MailRef` (an `Arc<MailRing>` + offsets, or an
-        // owned box), so the payload bytes are never copied; the sub-blob
-        // references the same ring regions and the per-blob reclaim lock
-        // counts travel with the moved refs. Spill *before* demuxing our
-        // chunk so an idle sibling can steal the remainder off our deque
-        // tail while we work; if none is idle we pop it ourselves next loop
-        // (LIFO) and continue — bounded work-before-steal-point is K.
-        let k = self.chunk;
-        if mails.len() > k {
-            let rest = mails.split_off(k);
-            self.sink.schedule(Self::with_chunk(
-                rest,
-                Arc::clone(&self.mailer),
-                self.sink.clone(),
-                k,
-            ));
-        }
-
-        // ADR-0087 §4 (iamacoffeepot/aether#1135): walk the blob's mail in
-        // **send order** and dispatch each in place where we can.
-        //
-        // Per mail:
-        // - Resolve the recipient's seize handle + ref-schema under one
-        //   registry read (`route_lookup`).
-        // - **Direct-dispatch** when (1) the recipient exposes a seize
-        //   handle (a `Pooled` actor's slot), (2) the kind is ref-free
-        //   (ADR-0045 ref kinds need `route_mail`'s handle walk / park),
-        //   and (3) we win the `Idle → Running` seize CAS: build the
-        //   envelope and run the full per-envelope wrapper in place
-        //   (`Drainable::seize_and_run` → `dispatch_one` — `Received` /
-        //   `Finished` incl. the #1134 `t_enqueue` / `enqueue_depth`,
-        //   `record_finished` settlement bracket, the `log.tail` /
-        //   `trace.tail` framework arms), then drain the recipient's inbox
-        //   and run the post-empty recheck. No inbox deposit, no
-        //   `try_recv` repop — residence ≈ 0.
-        // - **Deposit** otherwise (no seize handle / busy slot / ref kind)
-        //   via today's `Mailer::push` → `route_mail`: the holder (or a
-        //   woken cycle) drains it, per-recipient FIFO preserved by the
-        //   inbox's own ordering.
-        //
-        // Per-recipient FIFO holds by construction: the send-order walk
-        // hands at most one seize per recipient before the slot returns to
-        // `Idle`, and the busy / deposited path goes through the inbox
-        // FIFO. Cross-recipient is async (the ordering spine's contract),
-        // so a busy recipient running on its own thread is correct.
-        let mailer = &self.mailer;
-        for mail in mails {
-            let lookup = mailer.registry().route_lookup(mail.kind, mail.recipient);
-            // Direct-dispatch only a ref-free kind whose recipient is a
-            // `Pooled` slot we win the seize on. ADR-0045 ref kinds fall
-            // through to `route_mail` (the handle walk / park); so do
-            // non-`Pooled` recipients (no seize handle) and busy slots
-            // (lost the `Idle → Running` CAS — `try_seize` → `None`).
-            let seized = if lookup.ref_schema.is_some() {
-                None
-            } else {
-                lookup.seize.as_ref().and_then(SeizeHandle::try_seize)
-            };
-            match seized {
-                Some(slot) => {
-                    // Build the seed envelope from the held mail. The
-                    // recipient slot is `Running` (we won the seize); the
-                    // payload `MailRef` moves in directly (an `InRing` ref
-                    // stays pinned — the blob holds the region until this
-                    // demux drains, and the seed dispatches synchronously
-                    // here). `t_enqueue ≈ now` / `enqueue_depth = 0` — no
-                    // queue residence (the #1134 measured win).
-                    let seed = Envelope {
-                        kind: mail.kind,
-                        kind_name: lookup.kind_name,
-                        origin: None,
-                        sender: mail.reply_to,
-                        payload: mail.payload,
-                        count: mail.count,
-                        mail_id: mail.mail_id,
-                        root: mail.root,
-                        parent_mail: mail.parent_mail,
-                        t_enqueue: mailer.now_nanos(),
-                        enqueue_depth: 0,
-                    };
-                    match slot.seize_and_run(seed, budget) {
-                        // Budget hit mid-drain — re-schedule the recipient
-                        // the same way a normal wake would spill it.
-                        CycleResult::Requeue => self.sink.schedule(slot),
-                        CycleResult::Idle | CycleResult::Closed => {}
-                    }
-                }
-                // No seize handle, busy slot, or a ref-carrying kind:
-                // deposit through the one router and let the holder /
-                // woken cycle drain it.
-                None => mailer.push(mail),
+        // Claim and drain groups off the shared cursor until the cursor is
+        // exhausted (Idle — drop this copy of the Arc) or the per-cycle
+        // group budget is hit (Requeue — the pool re-injects the blob so
+        // the cursor keeps being shared). Late appends past this worker's
+        // exhaustion are handled by the producer's re-submit on the next
+        // flush.
+        let mut ran: u32 = 0;
+        loop {
+            if ran >= budget.max_mails {
+                return CycleResult::Requeue;
             }
+            let Some(g) = self.lifecycle.claim() else {
+                return CycleResult::Idle;
+            };
+            let group = self.groups[g]
+                .get()
+                .expect("claimed index < len is published");
+            self.dispatch_group(group, budget);
+            self.lifecycle.complete();
+            ran += 1;
         }
-        CycleResult::Idle
     }
 
     fn label(&self) -> &'static str {
@@ -296,31 +423,124 @@ impl Drainable for BlobWork {
     }
 }
 
+/// One producing actor's blob lifecycle: keeps a single active blob,
+/// appends each flush to it (rolling a fresh one when it retires or
+/// overflows), and recruits drainers. Lives on the actor's [`NativeBinding`]
+/// and is driven only from the actor's own thread, so `&mut self` access is
+/// single-threaded.
+pub struct BlobProducer {
+    mailer: Arc<Mailer>,
+    sink: WakeSink,
+    /// The active blob + its producer-private recipient → group-index map.
+    /// `None` until the first flush, and after a retired blob is dropped.
+    active: Option<(Arc<BlobWork>, HashMap<MailboxId, usize>)>,
+}
+
+impl BlobProducer {
+    /// Build a producer over the pool's [`WakeSink`] and the shared
+    /// [`Mailer`].
+    pub fn new(mailer: Arc<Mailer>, sink: WakeSink) -> Self {
+        Self {
+            mailer,
+            sink,
+            active: None,
+        }
+    }
+
+    /// Fold one flush's routed mail into the active blob (or fresh blobs),
+    /// scheduling a drainer and broadcast-recruiting siblings for wide
+    /// fan-outs. Called on the producing actor's thread.
+    pub fn flush(&mut self, routed: Vec<Mail>) {
+        let mut pending = routed;
+        while !pending.is_empty() {
+            // Ensure a live (un-retired) active blob, sized to the pending
+            // mail if we have to make a fresh one.
+            let need_new = match &self.active {
+                Some((blob, _)) => blob.lifecycle.is_retired(),
+                None => true,
+            };
+            if need_new {
+                let cap = group_cap_for(&pending);
+                let blob = BlobWork::empty(cap, Arc::clone(&self.mailer), self.sink.clone());
+                self.active = Some((blob, HashMap::new()));
+            }
+
+            let (blob, index) = self.active.as_mut().expect("active set above");
+            let outcome = blob.append_flush(mem::take(&mut pending), index);
+            let blob_arc: Arc<BlobWork> = Arc::clone(blob);
+            let blob_dyn: Arc<dyn Drainable> = blob_arc;
+
+            // Always schedule a drainer so newly-published groups (and any
+            // pushes onto still-open groups) are picked up even if every
+            // prior worker already drained past the cursor and dropped its
+            // copy. The own-deque schedule keeps a narrow fan-out local
+            // (the #1116 win); a wide fan-out additionally broadcast-
+            // recruits siblings.
+            self.sink.schedule(Arc::clone(&blob_dyn));
+            if outcome.fresh_groups >= recruit_min() {
+                let extra = outcome.fresh_groups.min(recruit_cap()).saturating_sub(1);
+                self.sink.recruit(&blob_dyn, extra);
+            }
+
+            pending = outcome.leftover;
+            // Non-empty leftover means the active blob could not take these
+            // groups — its array is full (or it retired mid-publish). Detach
+            // it so the remainder rolls into a fresh blob next iteration;
+            // otherwise we'd re-append to the same full blob forever. The
+            // detached blob stays alive via its in-flight `Arc` copies until
+            // drained, and the leftover is always *new* recipients, so the
+            // fresh blob shares none of its groups.
+            if !pending.is_empty() {
+                self.active = None;
+            }
+        }
+    }
+}
+
+/// Size a fresh blob's group array to a flush's distinct recipient count
+/// (with the [`GROUP_CAP_MIN`] floor, capped at the wire ceiling).
+fn group_cap_for(routed: &[Mail]) -> usize {
+    let distinct: HashSet<MailboxId> = routed.iter().map(|m| m.recipient).collect();
+    distinct.len().clamp(GROUP_CAP_MIN, MAX_GROUPS)
+}
+
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,
-    reason = "test-setup unwraps: a failed lookup/recv is the test signal"
+    clippy::collection_is_never_read,
+    clippy::cast_possible_truncation,
+    reason = "test setup: unwraps signal failure; fixture Vecs are held only to keep seize-handle Weaks alive; small loop indices cast to a marker byte"
 )]
 mod tests {
     use super::*;
     use crate::mail::Registry;
     use crate::mail::registry::{InboxHandler, OwnedDispatch};
-    use crate::mail::{KindId, MailRef, MailboxId};
-    use crate::scheduler::SpinPark;
+    use crate::mail::{KindId, MailRef};
+    use crate::scheduler::{SeizeSeed, SlotState, SpinPark};
     use crate::test_util::fresh_substrate;
+    use aether_data::{KindDescriptor, SchemaCell, SchemaType};
     use crossbeam_deque::{Injector, Steal};
-    use std::iter;
     use std::sync::mpsc;
 
-    /// Pop one spilled sub-blob from the injector (the off-pool spill
-    /// target — the test thread isn't a pool worker, so a spill lands
-    /// here rather than on a deque).
-    fn drain_one(inj: &Injector<Arc<dyn Drainable>>) -> Option<Arc<dyn Drainable>> {
+    fn wake_sink(injector: &Arc<Injector<Arc<dyn Drainable>>>) -> WakeSink {
+        WakeSink::new(Arc::clone(injector), Arc::new(SpinPark::new()))
+    }
+
+    /// Drain the injector by running every queued `Drainable` to `Idle`
+    /// (re-running on `Requeue`), simulating the worker pool from the test
+    /// thread. Returns the number of `run_cycle` calls.
+    fn drain_injector(injector: &Injector<Arc<dyn Drainable>>) -> usize {
+        let mut runs = 0;
         loop {
-            match inj.steal() {
-                Steal::Success(s) => return Some(s),
+            match injector.steal() {
+                Steal::Success(slot) => {
+                    runs += 1;
+                    if slot.run_cycle(BatchBudget::standard()) == CycleResult::Requeue {
+                        injector.push(slot);
+                    }
+                }
                 Steal::Retry => {}
-                Steal::Empty => return None,
+                Steal::Empty => return runs,
             }
         }
     }
@@ -338,100 +558,24 @@ mod tests {
         registry.register_inbox(name, handler)
     }
 
-    /// Register a sink at `"sink"` that forwards each delivered mail's
-    /// first payload byte onto `tx`, and return its mailbox id.
-    fn counting_sink(registry: &Registry, tx: mpsc::Sender<u8>) -> MailboxId {
-        register_byte_forwarding_inbox(registry, "sink", tx)
+    fn mail_to(recipient: MailboxId, byte: u8) -> Mail {
+        Mail::new(recipient, KindId(7), MailRef::from(vec![byte]), 1)
     }
 
-    fn owned_mails(recipient: MailboxId, n: u8) -> Vec<Mail> {
-        (0..n)
-            .map(|i| Mail::new(recipient, KindId(7), MailRef::from(vec![i]), 1))
-            .collect()
-    }
-
-    /// 3c: a blob wider than `K` splits the first `K` off to demux inline
-    /// and spills the remainder as a sub-blob; running the cascade
-    /// delivers every mail exactly once (no loss, no duplication). 5 mails
-    /// at K=2 -> chunks [0,1] | [2,3] | [4] = 3 `run_cycle`s.
-    #[test]
-    fn chunked_spill_delivers_every_mail_once() {
-        let (registry, mailer) = fresh_substrate();
-        let (tx, rx) = mpsc::channel::<u8>();
-        let recipient = counting_sink(&registry, tx);
-
-        let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
-        let sink = WakeSink::new(Arc::clone(&injector), Arc::new(SpinPark::new()));
-        let blob = BlobWork::with_chunk(owned_mails(recipient, 5), Arc::clone(&mailer), sink, 2);
-
-        let budget = BatchBudget::standard();
-        blob.run_cycle(budget);
-        let mut chunks_run = 1;
-        while let Some(sub) = drain_one(&injector) {
-            sub.run_cycle(budget);
-            chunks_run += 1;
-        }
-
-        assert_eq!(chunks_run, 3, "5 mails at K=2 cascade into 3 chunks");
-        let mut got: Vec<u8> = iter::from_fn(|| rx.try_recv().ok()).collect();
-        got.sort_unstable();
-        assert_eq!(
-            got,
-            vec![0, 1, 2, 3, 4],
-            "every mail delivered exactly once across the chunk cascade"
-        );
-    }
-
-    /// 3c: at the default K (`usize::MAX`, chunking off) a blob demuxes in
-    /// one pass — byte-for-byte the 3b behaviour, no spill.
-    #[test]
-    fn chunk_off_demuxes_single_pass() {
-        let (registry, mailer) = fresh_substrate();
-        let (tx, rx) = mpsc::channel::<u8>();
-        let recipient = counting_sink(&registry, tx);
-
-        let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
-        let sink = WakeSink::new(Arc::clone(&injector), Arc::new(SpinPark::new()));
-        let blob = BlobWork::with_chunk(owned_mails(recipient, 5), mailer, sink, usize::MAX);
-
-        blob.run_cycle(BatchBudget::standard());
-        assert!(
-            matches!(injector.steal(), Steal::Empty),
-            "K=MAX never spills a sub-blob"
-        );
-        assert_eq!(
-            iter::from_fn(|| rx.try_recv().ok()).count(),
-            5,
-            "all mails delivered in the single pass"
-        );
-    }
-
-    use crate::scheduler::{SeizeSeed, SlotState};
-    use aether_data::{KindDescriptor, SchemaCell, SchemaType};
-
-    /// A `Pooled`-shaped recipient fixture for the claim-and-dispatch-
-    /// direct demux (iamacoffeepot/aether#1135): it carries a real
-    /// [`SlotState`] (so a [`SeizeHandle`] can drive the `Idle → Running`
-    /// seize CAS) and records each **direct-dispatched** seed's first
-    /// payload byte. [`Drainable::seize_and_run`] is the only arm a blob
-    /// demux reaches on this fixture; it stamps the byte and parks the
-    /// slot back to `Idle` (mirroring a real slot draining empty), so a
-    /// later mail to the same recipient can seize again — the send-order
-    /// FIFO property the demux must preserve.
+    /// A `Pooled`-shaped recipient fixture (mirrors the #1135 demux test
+    /// fixture): a real [`SlotState`] so a [`SeizeHandle`] can drive the
+    /// seize CAS, recording each direct-dispatched seed's first byte. Parks
+    /// the slot back to `Idle` after each seed so the next mail can seize.
     struct SeizableSink {
         state: Arc<SlotState>,
         direct: mpsc::Sender<u8>,
     }
-
     impl Drainable for SeizableSink {
         fn run_cycle(&self, _budget: BatchBudget) -> CycleResult {
             CycleResult::Idle
         }
         fn seize_and_run(&self, seed: SeizeSeed, _budget: BatchBudget) -> CycleResult {
             let _ = self.direct.send(seed.payload.bytes()[0]);
-            // Real slots end an empty cycle back in `Idle` via the
-            // post-empty recheck; mirror that so the recipient is
-            // seizable for the next send-order mail.
             self.state.mark_idle();
             CycleResult::Idle
         }
@@ -440,12 +584,9 @@ mod tests {
         }
     }
 
-    /// Register a closure inbox under `name` (the **deposit** target) and
-    /// install a [`SeizeHandle`] over a [`SeizableSink`] fixture (the
-    /// **direct** target). Returns the recipient id plus a receiver for
-    /// each path so a test can tell which one a mail took. The fixture's
-    /// strong `Arc` is returned so the seize handle's `Weak` upgrades for
-    /// the duration of the test.
+    /// Register a deposit inbox under `name` and install a seize handle over
+    /// a [`SeizableSink`]. Returns the id + the fixture (keeps the slot
+    /// `Weak` alive) + a receiver for each path.
     fn seizable_recipient(
         registry: &Registry,
         name: &str,
@@ -457,7 +598,6 @@ mod tests {
     ) {
         let (deposit_tx, deposit_rx) = mpsc::channel::<u8>();
         let id = register_byte_forwarding_inbox(registry, name, deposit_tx);
-
         let (direct_tx, direct_rx) = mpsc::channel::<u8>();
         let fixture = Arc::new(SeizableSink {
             state: Arc::new(SlotState::new()),
@@ -472,75 +612,107 @@ mod tests {
         (id, fixture, direct_rx, deposit_rx)
     }
 
-    /// Free `Pooled` recipient → the demux seizes it and dispatches in
-    /// place: the seed lands on the **direct** path, the inbox-deposit
-    /// path is never touched.
+    /// A single-recipient fan-out: each leaf gets its mail exactly once, via
+    /// the in-place seize path (closure deposit untouched).
     #[test]
-    fn free_recipient_dispatched_direct_no_inbox_bounce() {
+    fn fanout_dispatches_each_recipient_once_in_place() {
         let (registry, mailer) = fresh_substrate();
-        let (recipient, _fixture, direct_rx, deposit_rx) =
-            seizable_recipient(&registry, "seizable");
-
         let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
-        let sink = WakeSink::new(Arc::clone(&injector), Arc::new(SpinPark::new()));
-        let blob = BlobWork::with_chunk(owned_mails(recipient, 1), mailer, sink, usize::MAX);
+        let mut fixtures = Vec::new();
+        let mut directs = Vec::new();
+        let mut routed = Vec::new();
+        for i in 0..6u8 {
+            let (id, fix, direct_rx, _dep) = seizable_recipient(&registry, &format!("r{i}"));
+            routed.push(mail_to(id, i));
+            fixtures.push(fix);
+            directs.push(direct_rx);
+        }
 
-        blob.run_cycle(BatchBudget::standard());
+        let mut producer = BlobProducer::new(Arc::clone(&mailer), wake_sink(&injector));
+        producer.flush(routed);
+        drain_injector(&injector);
 
-        assert_eq!(
-            direct_rx.try_recv().ok(),
-            Some(0),
-            "seed dispatched in place"
-        );
-        assert!(
-            deposit_rx.try_recv().is_err(),
-            "a direct-dispatched mail never bounces through the inbox"
-        );
+        for (i, rx) in directs.iter().enumerate() {
+            #[allow(clippy::cast_possible_truncation)]
+            let want = i as u8;
+            assert_eq!(
+                rx.try_recv().ok(),
+                Some(want),
+                "leaf {i} dispatched in place once"
+            );
+            assert!(rx.try_recv().is_err(), "leaf {i} dispatched exactly once");
+        }
     }
 
-    /// Busy `Pooled` recipient (slot already `Running`) → the seize loses
-    /// the CAS, so the mail is **deposited** through `route_mail`, not
+    /// Two mails to the **same** recipient in one flush form one group and
+    /// dispatch in send order (per-recipient FIFO).
+    #[test]
+    fn same_recipient_grouped_in_send_order() {
+        let (registry, mailer) = fresh_substrate();
+        let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
+        let (id, _fix, direct_rx, _dep) = seizable_recipient(&registry, "r");
+
+        let mut producer = BlobProducer::new(Arc::clone(&mailer), wake_sink(&injector));
+        producer.flush(vec![mail_to(id, 0), mail_to(id, 1), mail_to(id, 2)]);
+        drain_injector(&injector);
+
+        assert_eq!(direct_rx.try_recv().ok(), Some(0));
+        assert_eq!(direct_rx.try_recv().ok(), Some(1));
+        assert_eq!(direct_rx.try_recv().ok(), Some(2));
+        assert!(direct_rx.try_recv().is_err());
+    }
+
+    /// A busy recipient (slot already `Running`) is deposited, not
     /// dispatched in place.
     #[test]
     fn busy_recipient_deposited() {
         let (registry, mailer) = fresh_substrate();
-        let (recipient, fixture, direct_rx, deposit_rx) = seizable_recipient(&registry, "seizable");
-
-        // Mark the recipient busy before the demux: its `Idle → Running`
-        // seize must lose, falling through to the deposit path.
+        let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
+        let (id, fixture, direct_rx, deposit_rx) = seizable_recipient(&registry, "r");
         assert!(
             fixture.state.seize(),
-            "fixture starts Idle, seize wins once"
+            "mark the recipient busy before the demux"
         );
 
-        let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
-        let sink = WakeSink::new(Arc::clone(&injector), Arc::new(SpinPark::new()));
-        let blob = BlobWork::with_chunk(owned_mails(recipient, 1), mailer, sink, usize::MAX);
-
-        blob.run_cycle(BatchBudget::standard());
+        let mut producer = BlobProducer::new(Arc::clone(&mailer), wake_sink(&injector));
+        producer.flush(vec![mail_to(id, 9)]);
+        drain_injector(&injector);
 
         assert_eq!(
             deposit_rx.try_recv().ok(),
-            Some(0),
-            "a busy recipient's mail is deposited"
+            Some(9),
+            "busy recipient deposited"
         );
-        assert!(
-            direct_rx.try_recv().is_err(),
-            "a busy recipient is not dispatched in place"
+        assert!(direct_rx.try_recv().is_err(), "not dispatched in place");
+    }
+
+    /// A closure-backed inbox (no slot) has no seize handle, so its mail is
+    /// deposited through the router.
+    #[test]
+    fn closure_inbox_deposited() {
+        let (registry, mailer) = fresh_substrate();
+        let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
+        let (tx, rx) = mpsc::channel::<u8>();
+        let id = register_byte_forwarding_inbox(&registry, "sink", tx);
+
+        let mut producer = BlobProducer::new(Arc::clone(&mailer), wake_sink(&injector));
+        producer.flush(vec![mail_to(id, 3)]);
+        drain_injector(&injector);
+
+        assert_eq!(
+            rx.try_recv().ok(),
+            Some(3),
+            "closure inbox receives via deposit"
         );
     }
 
-    /// ADR-0045 ref-carrying kind → never direct-dispatched even to a free
-    /// `Pooled` recipient: `route_mail` owns the handle walk / park, so the
-    /// mail is **deposited**.
+    /// An ADR-0045 ref-carrying kind is never dispatched in place even to a
+    /// free `Pooled` recipient — it is deposited so `route_mail` walks it.
     #[test]
     fn ref_kind_deposited() {
         let (registry, mailer) = fresh_substrate();
-        let (recipient, _fixture, direct_rx, deposit_rx) =
-            seizable_recipient(&registry, "seizable");
-
-        // A kind whose schema embeds a `Ref` → `route_lookup.ref_schema`
-        // is `Some`, so the demux falls through to deposit.
+        let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
+        let (id, _fix, direct_rx, deposit_rx) = seizable_recipient(&registry, "r");
         let ref_kind = registry
             .register_kind_with_descriptor(KindDescriptor {
                 name: "test.blob.ref_kind".to_owned(),
@@ -548,73 +720,180 @@ mod tests {
             })
             .expect("fresh ref kind registers");
 
-        let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
-        let sink = WakeSink::new(Arc::clone(&injector), Arc::new(SpinPark::new()));
-        // Inline-form `Ref` payload: discriminant 0 (inline) + the inner
-        // `Bytes` value (postcard `varint(len=0)` → empty). The ref-walk
-        // resolves it inline and the recipient's deposit handler receives
-        // the resolved bytes (first byte `0` — the inline discriminant
-        // the closure reads). The test asserts the routing *decision*: a
-        // ref kind is deposited (so `route_mail` owns the walk), never
-        // direct-dispatched.
-        let mails = vec![Mail::new(
-            recipient,
+        let mut producer = BlobProducer::new(Arc::clone(&mailer), wake_sink(&injector));
+        producer.flush(vec![Mail::new(
+            id,
             ref_kind,
             MailRef::from(vec![0u8, 0u8]),
             1,
-        )];
-        let blob = BlobWork::with_chunk(mails, mailer, sink, usize::MAX);
-
-        blob.run_cycle(BatchBudget::standard());
+        )]);
+        drain_injector(&injector);
 
         assert!(
             direct_rx.try_recv().is_err(),
-            "a ref-carrying kind is never dispatched in place"
+            "ref kind never dispatched in place"
         );
         assert_eq!(
             deposit_rx.try_recv().ok(),
             Some(0),
-            "a ref-carrying kind is deposited so route_mail can walk it"
+            "ref kind deposited for the ref-walk"
         );
     }
 
-    /// Two mails to one free recipient → both dispatch in place, in send
-    /// order (per-recipient FIFO). The fixture parks `Idle` after each
-    /// seed, so the second mail re-seizes the same slot.
+    /// Two recipients across two flushes: the second flush to a fresh
+    /// recipient appends a new group; both deliver exactly once.
     #[test]
-    fn two_seeds_to_one_recipient_run_in_send_order() {
+    fn second_flush_new_recipient_appends_group() {
         let (registry, mailer) = fresh_substrate();
-        let (recipient, _fixture, direct_rx, deposit_rx) =
-            seizable_recipient(&registry, "seizable");
-
         let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
-        let sink = WakeSink::new(Arc::clone(&injector), Arc::new(SpinPark::new()));
-        // Two mails (bytes 0, 1) to the same recipient, in send order.
-        let blob = BlobWork::with_chunk(owned_mails(recipient, 2), mailer, sink, usize::MAX);
+        let (a, _fa, a_rx, _ad) = seizable_recipient(&registry, "a");
+        let (b, _fb, b_rx, _bd) = seizable_recipient(&registry, "b");
 
-        blob.run_cycle(BatchBudget::standard());
+        let mut producer = BlobProducer::new(Arc::clone(&mailer), wake_sink(&injector));
+        producer.flush(vec![mail_to(a, 1)]);
+        drain_injector(&injector);
+        producer.flush(vec![mail_to(b, 2)]);
+        drain_injector(&injector);
 
-        assert_eq!(direct_rx.try_recv().ok(), Some(0), "first seed first");
-        assert_eq!(direct_rx.try_recv().ok(), Some(1), "second seed second");
-        assert!(direct_rx.try_recv().is_err(), "exactly two seeds");
-        assert!(
-            deposit_rx.try_recv().is_err(),
-            "both mails dispatched in place — no inbox deposit"
+        assert_eq!(a_rx.try_recv().ok(), Some(1));
+        assert_eq!(b_rx.try_recv().ok(), Some(2));
+    }
+
+    /// Overflowing the group array rolls the remainder into a fresh blob;
+    /// every recipient still gets its mail exactly once. Flush 1 of
+    /// `GROUP_CAP_MIN` distinct recipients sizes the array to exactly that
+    /// (full); flush 2's brand-new recipients overflow and roll into a
+    /// second blob. (Two flushes with no drain between also exercises the
+    /// full-but-not-retired roll path — the case that previously looped.)
+    #[test]
+    fn overflow_rolls_fresh_blob_no_loss() {
+        let (registry, mailer) = fresh_substrate();
+        let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
+        let mut producer = BlobProducer::new(Arc::clone(&mailer), wake_sink(&injector));
+        // Keep every fixture (and its receivers) alive to drain time — the
+        // seize handle holds only a `Weak` to the fixture, so a dropped
+        // fixture would make `try_seize` upgrade to `None` and silently
+        // deposit-then-drop.
+        let mut fixtures = Vec::new();
+        let mut rxs: Vec<(mpsc::Receiver<u8>, mpsc::Receiver<u8>)> = Vec::new();
+
+        let mut routed1 = Vec::new();
+        for i in 0..GROUP_CAP_MIN as u8 {
+            let (id, fix, direct_rx, deposit_rx) = seizable_recipient(&registry, &format!("p{i}"));
+            routed1.push(mail_to(id, i));
+            fixtures.push(fix);
+            rxs.push((direct_rx, deposit_rx));
+        }
+        producer.flush(routed1);
+        let mut routed2 = Vec::new();
+        for i in 0..5u8 {
+            let (id, fix, direct_rx, deposit_rx) = seizable_recipient(&registry, &format!("q{i}"));
+            routed2.push(mail_to(id, 100 + i));
+            fixtures.push(fix);
+            rxs.push((direct_rx, deposit_rx));
+        }
+        producer.flush(routed2);
+        drain_injector(&injector);
+
+        // Collect from both paths (all should be direct here, but be robust).
+        let mut got: Vec<u8> = rxs
+            .iter()
+            .filter_map(|(d, p)| d.try_recv().ok().or_else(|| p.try_recv().ok()))
+            .collect();
+        got.sort_unstable();
+        let mut want: Vec<u8> = (0..GROUP_CAP_MIN as u8).collect();
+        want.extend((0..5u8).map(|i| 100 + i));
+        want.sort_unstable();
+        assert_eq!(
+            got, want,
+            "every recipient delivered exactly once across the roll"
         );
     }
 
-    /// A closure-backed inbox (no slot) exposes no seize handle, so its
-    /// mail is deposited — the path the legacy `counting_sink` tests
-    /// already exercise, asserted here against the seize-resolution.
+    /// Empty flush is a no-op.
     #[test]
-    fn closure_inbox_has_no_seize_handle() {
-        let (registry, _mailer) = fresh_substrate();
-        let (tx, _rx) = mpsc::channel::<u8>();
-        let recipient = counting_sink(&registry, tx);
-        let lookup = registry.route_lookup(KindId(7), recipient);
-        assert!(
-            lookup.seize.is_none(),
-            "a closure-backed inbox has no slot to seize"
+    fn empty_flush_noop() {
+        let (_registry, mailer) = fresh_substrate();
+        let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
+        let mut producer = BlobProducer::new(Arc::clone(&mailer), wake_sink(&injector));
+        producer.flush(Vec::new());
+        assert_eq!(
+            drain_injector(&injector),
+            0,
+            "no work scheduled for an empty flush"
         );
+    }
+
+    /// End-to-end under a live multi-worker pool: a wide fan-out recruits
+    /// siblings, and every recipient is dispatched **exactly once** while
+    /// many workers race the shared cursor. The exactly-once gate is the
+    /// cursor CAS (each group to one worker) + the per-recipient seize.
+    #[test]
+    fn concurrent_pool_drain_delivers_each_recipient_once() {
+        use crate::runtime::lifecycle::PanicAborter;
+        use crate::scheduler::{Pool, PoolConfig};
+        use std::thread;
+        use std::time::{Duration, Instant};
+
+        // A wide fan-out (> recruit_min) so the flush broadcast-recruits.
+        // N < 256 keeps the per-recipient marker byte unique.
+        const N: usize = 60;
+
+        let pool = Pool::start(
+            PoolConfig {
+                workers: 8,
+                ..PoolConfig::default()
+            },
+            Arc::new(PanicAborter),
+        );
+        let (registry, mailer) = fresh_substrate();
+        let mut producer = BlobProducer::new(Arc::clone(&mailer), pool.wake_sink());
+
+        let mut fixtures = Vec::new();
+        let mut rxs = Vec::new();
+        let mut routed = Vec::new();
+        for i in 0..N {
+            let (id, fix, direct_rx, deposit_rx) = seizable_recipient(&registry, &format!("c{i}"));
+            #[allow(clippy::cast_possible_truncation)]
+            let byte = i as u8;
+            routed.push(Mail::new(id, KindId(7), MailRef::from(vec![byte]), 1));
+            fixtures.push((fix, deposit_rx));
+            rxs.push(direct_rx);
+        }
+        producer.flush(routed);
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut got: Vec<u8> = Vec::new();
+        while got.len() < N && Instant::now() < deadline {
+            for rx in &rxs {
+                while let Ok(b) = rx.try_recv() {
+                    got.push(b);
+                }
+            }
+            if got.len() < N {
+                thread::yield_now();
+            }
+        }
+
+        let results = pool.shutdown_with_results();
+        assert!(
+            results.iter().all(thread::Result::is_ok),
+            "no worker thread panicked during concurrent drain"
+        );
+        got.sort_unstable();
+        let want: Vec<u8> = (0..N as u8).collect();
+        assert_eq!(
+            got, want,
+            "each recipient dispatched exactly once under concurrent drain"
+        );
+    }
+
+    /// Flake-soak duplicate (iamacoffeepot/aether#1137): the concurrent
+    /// drain is timing-sensitive (cursor race + seize CAS across 8
+    /// workers), so it gets a `flaky_` wrapper for `scripts/flake-soak.sh`.
+    /// The original runs once in normal CI.
+    #[test]
+    fn flaky_concurrent_pool_drain_delivers_each_recipient_once() {
+        concurrent_pool_drain_delivers_each_recipient_once();
     }
 }

--- a/crates/aether-substrate/src/actor/native/mod.rs
+++ b/crates/aether-substrate/src/actor/native/mod.rs
@@ -63,6 +63,7 @@
 //! unknown kinds.
 
 pub mod binding;
+pub(crate) mod blob_lifecycle;
 pub(crate) mod blob_work;
 pub mod ctx;
 pub(crate) mod dispatch;

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -386,6 +386,22 @@ impl WakeSink {
             self.spin.notify();
         }
     }
+
+    /// Recruit `count` workers to a shared cooperative blob
+    /// (iamacoffeepot/aether#1137): push `count` clones of the same
+    /// `Drainable` onto the shared injector and notify the coordinator
+    /// once per clone, so parked siblings wake and race its cursor. This is
+    /// the broadcast-recruit the own-deque [`Self::schedule`] cannot do
+    /// (that path keeps work local with no notify). Over-recruiting is
+    /// harmless: a worker that pops a copy after the cursor is drained
+    /// finds no group to claim and drops the clone. `count == 0` is a
+    /// no-op.
+    pub(crate) fn recruit(&self, slot: &Arc<dyn Drainable>, count: usize) {
+        for _ in 0..count {
+            self.injector.push(Arc::clone(slot));
+            self.spin.notify();
+        }
+    }
 }
 
 /// Sender-side wake hook the chassis hands to the inbox sender path


### PR DESCRIPTION
## Summary

Replaces the one-shot single-runner blob demux with a **cursor-shared cooperative blob**: a producer's fan-out is grouped by recipient into one shared blob that many workers drain in parallel by racing a packed `AtomicU64` lifecycle word (`[seal | done | len | cursor]`), each seizing a recipient and dispatching in place (reusing the iamacoffeepot/aether#1135 seize CAS + `route_mail` fallback). Wide fan-outs **broadcast-recruit** parked siblings through the shared injector, instead of the prior own-deque spill that kept work local and could not parallelise a fan-out at all.

- **Packed lifecycle word** (`blob_lifecycle.rs`): single-producer `publish`, many-worker `claim` (the monotonic cursor CAS is the exactly-once gate), `complete` with auto-seal on full drain.
- **Closeable per-group buffer**: SPSC drain-loop that closes only on empty, making `close` a FIFO barrier — a late cross-flush append is deposited via `route_mail` and lands strictly after everything dispatched.
- **Single active blob per producer** with append + roll-on-overflow; recruitment gated on width (`AETHER_BLOB_RECRUIT_MIN`, default 9) so narrow fan-outs are not woken needlessly.
- A worker drains the blob to **cursor exhaustion** (it is a finite one-shot fan-out, not an actor inbox — no per-worker yield); parallelism is N recruited workers racing the one cursor. The per-recipient batch budget still bounds each recipient's own inbox drain.

## Performance

Heavy fan-out (CPU-bound leaves ~31µs, 11 workers, hop p50), this branch vs `main` (serial):

| width | this branch | main (serial) | speedup |
|------:|------------:|--------------:|--------:|
| 8 | 124µs | 120µs | ~1× (below recruit gate, stays local — by design) |
| 16 | 107µs | 270µs | **2.5×** |
| 32 | 202µs | 516µs | **2.6×** |
| 64 | 375µs | 1107µs | **3.0×** |
| 128 | 584µs | 2176µs | **3.7×** |

Scales ~4× across the worker axis (width-128: 2333µs at 1 worker → 584µs at 11). The widest case is ~1.57× the 11-worker parallel floor; the residual is recruitment / wakeup overhead (the cost-aware-sizing target, iamacoffeepot/aether#1127).

### Known regression (follow-up filed)

Every flush — including a 1-mail chain hop — currently runs the full cursor machinery (group-array alloc + `HashMap` + `OnceLock` + lifecycle CAS + per-group `Mutex`), so **narrow / trivial dispatch regresses ~2×** (depth-1 1584ns vs 1000ns; fanout-8 7458ns vs 3166ns). This is deliberate for now — the universal single-blob model is kept and the narrow path is optimised separately in **iamacoffeepot/aether#1140** (gate the machinery to wide fan-outs, keeping the iamacoffeepot/aether#1135 inline demux for narrow). The on-PR perf-compare will show this regression on the trivial cells; it is informational (ADR-0085, not in the `ci-pass` aggregator) and expected.

## Test plan

- [x] `blob_lifecycle` unit tests (9) incl. concurrent claim-partition (every index handed out exactly once across 8 threads)
- [x] `blob_work` tests (10) incl. recipient grouping, FIFO, busy/ref/closure deposit, overflow-roll, and an **end-to-end exactly-once test under a live 8-worker pool** (+ `flaky_` soak duplicate)
- [x] full `aether-substrate` crate: 355/355 pass
- [x] `scripts/preflight.sh` green (fmt + clippy + doc + workspace nextest 1296/1296 + wasm32 cross-build)
- [x] RustRover inspection clean on all changed files (Qodana-equivalent)
- [x] perf sweep: wide-fan-out win confirmed (table above)

Closes iamacoffeepot/aether#1137
