### PR TITLE
perf(substrate): batch-wake recruited workers instead of per-clone route-to-spinner notify

### DIFF
--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -389,18 +389,25 @@ impl WakeSink {
 
     /// Recruit `count` workers to a shared cooperative blob
     /// (iamacoffeepot/aether#1137): push `count` clones of the same
-    /// `Drainable` onto the shared injector and notify the coordinator
-    /// once per clone, so parked siblings wake and race its cursor. This is
-    /// the broadcast-recruit the own-deque [`Self::schedule`] cannot do
-    /// (that path keeps work local with no notify). Over-recruiting is
-    /// harmless: a worker that pops a copy after the cursor is drained
-    /// finds no group to claim and drops the clone. `count == 0` is a
-    /// no-op.
+    /// `Drainable` onto the shared injector, then wake up to `count` parked
+    /// siblings to race its cursor. This is the broadcast-recruit the
+    /// own-deque [`Self::schedule`] cannot do (that path keeps work local
+    /// with no notify). Over-recruiting is harmless: a worker that pops a
+    /// copy after the cursor is drained finds no group to claim and drops
+    /// the clone. `count == 0` is a no-op.
+    ///
+    /// The wake goes through [`SpinPark::wake_workers`], **not** a per-clone
+    /// [`SpinPark::notify`]: `notify` routes-to-spinner (skips the unpark
+    /// when any worker is spinning), and a single spinner cannot drain
+    /// `count` independent clones — so per-clone notifies collapse the
+    /// recruitment to whoever was already spinning, leaving parked siblings
+    /// idle (iamacoffeepot/aether#1143). One batch wake unparks the parked
+    /// siblings directly; spinners still scan the clones as a bonus.
     pub(crate) fn recruit(&self, slot: &Arc<dyn Drainable>, count: usize) {
         for _ in 0..count {
             self.injector.push(Arc::clone(slot));
-            self.spin.notify();
         }
+        self.spin.wake_workers(count);
     }
 }
 

--- a/crates/aether-substrate/src/scheduler/spin_park.rs
+++ b/crates/aether-substrate/src/scheduler/spin_park.rs
@@ -160,6 +160,44 @@ impl SpinPark {
         }
     }
 
+    /// Producer side: call **after** pushing `n` slots, to wake up to `n`
+    /// parked workers to drain them in parallel. Unlike [`Self::notify`],
+    /// this does **not** route-to-spinner — a single spinner cannot drain
+    /// `n` independent slots, so a batch producer must wake the parked
+    /// siblings directly (iamacoffeepot/aether#1137 recruitment). Spinners
+    /// still opportunistically scan the pushed slots, so the effective
+    /// drainer count is the woken parked workers *plus* any spinners; over-
+    /// waking is harmless (a worker that finds no work re-parks).
+    ///
+    /// Lost-wakeup-safe by the same discipline as [`Self::notify`]: the
+    /// `SeqCst` fence orders the caller's pushes before the idle-list read,
+    /// and the parking worker's register-before-decrement makes any worker
+    /// that committed to parking visible to the pop. The unpark token is
+    /// sticky, so a worker that re-enters its spin loop between our pop and
+    /// its park still observes the work.
+    pub fn wake_workers(&self, n: usize) {
+        if n == 0 {
+            return;
+        }
+        // StoreLoad barrier: pushes-before, idle-read-after (see `notify`).
+        fence(Ordering::SeqCst);
+        // Pop up to `n` parked handles under one lock, then unpark them all
+        // after releasing the guard (no unpark while holding the lock).
+        let mut woken: Vec<Thread> = Vec::new();
+        {
+            let mut idle = self.idle();
+            for _ in 0..n {
+                match idle.pop() {
+                    Some(t) => woken.push(t),
+                    None => break,
+                }
+            }
+        }
+        for t in woken {
+            t.unpark();
+        }
+    }
+
     /// Worker side: wait for work. The caller has already tried its
     /// worker-local affinity cell and one non-blocking `scan`; this
     /// runs the spin-then-park loop until `scan` yields a slot or
@@ -289,6 +327,37 @@ mod tests {
         assert_eq!(coord.idle().len(), 0, "notify must pop when no spinner");
         // We unparked ourselves; consume the sticky token so it doesn't
         // leak into a later `park` in this test thread.
+        thread::park_timeout(Duration::from_millis(0));
+    }
+
+    /// `wake_workers` must unpark up to `n` parked workers **even when a
+    /// spinner is present** — unlike `notify`, it does not route-to-spinner
+    /// (a lone spinner cannot drain `n` independent recruited clones). It
+    /// also caps at the parked count rather than under/over-running.
+    /// Regression guard for the recruit under-wake (iamacoffeepot/aether#1143).
+    #[test]
+    fn wake_workers_unparks_despite_spinner() {
+        let coord = SpinPark::new();
+        // A spinner is present (this would make `notify` skip the unpark),
+        // and three workers are parked.
+        coord.spinning.fetch_add(1, Ordering::Relaxed);
+        for _ in 0..3 {
+            coord.idle().push(thread::current());
+        }
+
+        coord.wake_workers(3);
+        assert_eq!(
+            coord.idle().len(),
+            0,
+            "wake_workers must unpark all n parked despite the spinner"
+        );
+
+        // n beyond the parked count is a no-op tail (no panic / underflow).
+        coord.wake_workers(5);
+        assert_eq!(coord.idle().len(), 0, "empty idle list stays empty");
+
+        // Consume the sticky unpark token(s) delivered to this thread so
+        // they don't leak into a later `park`.
         thread::park_timeout(Duration::from_millis(0));
     }
 


### PR DESCRIPTION
## Summary

`WakeSink::recruit` (the iamacoffeepot/aether#1137 broadcast-recruit) pushed `count` blob clones and called `SpinPark::notify` **once per clone**. `notify` routes-to-spinner — it skips the unpark whenever any worker is spinning — so a single spinner suppressed all `count` wakeups, collapsing a wide/heavy fan-out's recruitment to whoever was already spinning instead of `count` parallel drainers. (Amplified by `Injector::steal_batch_and_pop`: the lone awake worker batch-steals ~half the clones into its own deque and drains them serially.)

- Add `SpinPark::wake_workers(n)`: after the pushes, unpark up to `n` parked workers directly, **ignoring the spinner gate** (over-waking is harmless — an extra woken worker finds the cursor drained and re-parks). Spinners still scan the clones as a bonus.
- Rewire `recruit` to push all clones, then `wake_workers(count)`.
- Same lost-wakeup discipline as `notify`: one `SeqCst` fence after the pushes, register-before-decrement on the park side, sticky unpark token.

## Honest perf note

This is a **correctness / latent-serialization fix, not a measured speedup.** The bug's worst case — one lingering spinner + many parked siblings + N clones the spinner can't cover — is a transient the synthetic latency harness doesn't reliably reproduce:

- **Flat-out (saturated):** spinners are abundant and grab the clones via route-to-spinner, so heavy fan-outs already drain near-parallel on both sides. The fix shaved a sub-threshold −6%/−10% off the `fanout-8-heavy` tail.
- **Paced (idle gaps):** the pool is fully parked at recruit-time (`spinning==0`), so even the buggy per-clone `notify` wakes everyone.

The defect is still wrong-by-construction (a batch of N pushes intends ~N drainers; one spinner suppressing all N is a logic error), and it would bite under real nested / back-to-back wide fan-outs from a partly-parked pool. The fix removes the latent serialization and pins the corrected behavior with a unit test.

## Test plan

- [x] new unit test `wake_workers_unparks_despite_spinner` (wakes n despite a present spinner; caps at the parked count)
- [x] `lost_wakeup_stress` + `flaky_` soak duplicate still green
- [x] `cargo clippy --all-targets -p aether-substrate` clean
- [x] RustRover inspection clean on both changed files
- [x] `scripts/preflight.sh` green (1297/1297)
- [x] heavy A/B (flat-out + paced 1kHz) vs main: no regression, sub-threshold tail improvement

Closes iamacoffeepot/aether#1143