### PR TITLE
perf(substrate): cap blob recruit at the worker count

### DIFF
--- a/crates/aether-substrate/src/actor/native/blob_work.rs
+++ b/crates/aether-substrate/src/actor/native/blob_work.rs
@@ -643,7 +643,7 @@ mod tests {
     use std::sync::mpsc;
 
     fn wake_sink(injector: &Arc<Injector<Arc<dyn Drainable>>>) -> WakeSink {
-        WakeSink::new(Arc::clone(injector), Arc::new(SpinPark::new()))
+        WakeSink::new(Arc::clone(injector), Arc::new(SpinPark::new()), 8)
     }
 
     /// Drain the injector by running every queued `Drainable` to `Idle`

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -121,7 +121,11 @@ impl PoolHandle {
     /// through the coordinator.
     #[must_use]
     pub fn wake_sink(&self) -> WakeSink {
-        WakeSink::new(Arc::clone(&self.injector), Arc::clone(&self.spin))
+        WakeSink::new(
+            Arc::clone(&self.injector),
+            Arc::clone(&self.spin),
+            self.workers.len(),
+        )
     }
 
     /// Shut down the pool, joining every worker, and return each
@@ -533,7 +537,7 @@ mod tests {
         let slot_dyn: Arc<dyn Drainable> = slot.clone();
         let weak: Weak<dyn Drainable> = Arc::downgrade(&slot_dyn);
         drop(slot_dyn);
-        let sink = WakeSink::new(Arc::clone(&injector), Arc::new(SpinPark::new()));
+        let sink = WakeSink::new(Arc::clone(&injector), Arc::new(SpinPark::new()), 8);
         let wake = WakeHandle::new(slot.state.clone(), weak, sink);
 
         slot.push(1);

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -361,14 +361,28 @@ pub trait Drainable: Send + Sync + 'static {
 pub struct WakeSink {
     injector: Arc<Injector<Arc<dyn Drainable>>>,
     spin: Arc<SpinPark>,
+    /// Pool worker count — the hard cap on how many blob clones a recruit
+    /// injects (iamacoffeepot/aether#1147). Recruiting more copies than
+    /// workers cannot add parallelism (no more than `workers` can drain
+    /// concurrently); the excess just churns the injector. See
+    /// [`Self::recruit`].
+    workers: usize,
 }
 
 impl WakeSink {
-    /// Bundle the pool's shared injector and spin/park coordinator.
-    /// The chassis builds one from [`super::PoolHandle::wake_sink`].
+    /// Bundle the pool's shared injector, spin/park coordinator, and worker
+    /// count. The chassis builds one from [`super::PoolHandle::wake_sink`].
     #[must_use]
-    pub fn new(injector: Arc<Injector<Arc<dyn Drainable>>>, spin: Arc<SpinPark>) -> Self {
-        Self { injector, spin }
+    pub fn new(
+        injector: Arc<Injector<Arc<dyn Drainable>>>,
+        spin: Arc<SpinPark>,
+        workers: usize,
+    ) -> Self {
+        Self {
+            injector,
+            spin,
+            workers,
+        }
     }
 
     /// Schedule a runnable `slot`: push to the current worker's own
@@ -403,7 +417,16 @@ impl WakeSink {
     /// recruitment to whoever was already spinning, leaving parked siblings
     /// idle (iamacoffeepot/aether#1143). One batch wake unparks the parked
     /// siblings directly; spinners still scan the clones as a bonus.
+    ///
+    /// `count` is capped at `workers - 1` (iamacoffeepot/aether#1147): the
+    /// producer drains its own [`Self::schedule`] copy, so at most that many
+    /// *other* workers can take clones. A wide fan-out asks for up to
+    /// `recruit_cap` (default 32); injecting more clones than workers cannot
+    /// add parallelism (only `workers` can drain at once) and just churns the
+    /// injector — each excess clone is a push + steal + `Arc` clone/drop and
+    /// a no-op `run_cycle` on an already-drained cursor.
     pub(crate) fn recruit(&self, slot: &Arc<dyn Drainable>, count: usize) {
+        let count = count.min(self.workers.saturating_sub(1));
         for _ in 0..count {
             self.injector.push(Arc::clone(slot));
         }
@@ -881,7 +904,7 @@ pub mod tests {
         let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
         let slot = CounterSlot::new("wake");
         let weak: Weak<dyn Drainable> = Arc::downgrade(&(slot.clone() as Arc<dyn Drainable>));
-        let sink = WakeSink::new(Arc::clone(&injector), Arc::new(SpinPark::new()));
+        let sink = WakeSink::new(Arc::clone(&injector), Arc::new(SpinPark::new()), 8);
         let wake = WakeHandle::new(slot.state.clone(), weak, sink);
 
         // First wake should spill one slot.


### PR DESCRIPTION
## Summary

`WakeSink::recruit` (iamacoffeepot/aether#1137) pushes up to `recruit_cap` blob clones onto the shared injector — default **32** — and the flush gate asks for `min(fresh_groups, recruit_cap)`. But a pool has only ~N worker threads (≈11), and no more than N can drain one blob concurrently. Every clone beyond the worker count is pure churn: an injector push + `Arc` clone, a steal that finds the cursor **already drained** (no-op `run_cycle`), an `Arc` drop — plus injector head/tail contention from all those concurrent pushes. A 128-recipient fan-out pushed 32 clones for ~11 workers; **21 did nothing**.

Thread the pool worker count into `WakeSink` (`PoolHandle::wake_sink` passes `self.workers.len()`) and cap `recruit`'s count at `workers - 1` — the producer drains its own `schedule()` copy, so at most that many *other* workers take clones. `recruit_cap` stays as a secondary env ceiling; `workers - 1` is the binding limit in practice.

This is orthogonal to iamacoffeepot/aether#1143 (a spinner suppressing the *wakeups*) and iamacoffeepot/aether#1127 (*whether* to recruit at all) — this is purely *how many* clones to inject.

## Honest perf note

A **correctness / churn-reduction** fix, not a measured macro speedup. It provably reduces work (10 vs 32 pushes for a 128-fan-out), but the single-producer latency harness shows it macro-neutral (0 improved / 0 regressed across the wide cells) — the dominant wide-cell cost is the trivial-leaf recruitment itself (iamacoffeepot/aether#1127), not the copy churn, and the per-clone churn is sub-µs against the wide cells' run-to-run variance. The payoff shows under **multi-producer injector contention** the synthetic harness doesn't stress. Same shape as iamacoffeepot/aether#1143.

## Test plan

- [x] scheduler + blob tests pass (51) incl. `concurrent_pool_drain` (exactly-once under a live 8-worker pool, now recruiting `workers-1` clones not 31)
- [x] `cargo clippy --all-targets -p aether-substrate` clean; RustRover inspection clean on the 3 changed files
- [x] `scripts/preflight.sh` green (1297/1297)
- [x] wide-cell A/B vs the merge-base: no regression (within the harness noise band)

Closes iamacoffeepot/aether#1147. Phase of iamacoffeepot/aether#1101 under iamacoffeepot/aether#1059; rebased on the iamacoffeepot/aether#1146 machinery trims.