### PR TITLE
feat(data): cardinality-typed instance templates for the reverse-lookup inventory

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -840,16 +840,28 @@ enum BridgeCardinality {
 struct BridgeOpts {
     cardinality: Option<BridgeCardinality>,
     feature: Option<String>,
+    /// The `one_per = "entity"` instance-cardinality declaration
+    /// (ADR-0088 §4 v2). Only meaningful with `instanced`: it rides into
+    /// the emitted `TemplateEntry` as `Cardinality::OnePer(entity)`,
+    /// making the reverse-lookup manifest self-describing ("one mailbox
+    /// per loaded component") instead of an opaque `Dynamic` family.
+    /// Absent on an instanced actor ⇒ `Cardinality::Unbounded`.
+    one_per: Option<String>,
 }
 
 /// Parse `#[bridge]`'s optional arguments. Recognised:
 /// - `singleton` (positional flag) — emit `impl Singleton for X`
 /// - `instanced` (positional flag) — emit `impl Instanced for X`
+/// - `one_per = "entity"` — instanced cardinality (ADR-0088 §4 v2);
+///   `instanced`-only
 /// - `feature = "name"` — gate the inner mod on the named feature
 ///
 /// Empty attr (`#[bridge]`) emits no cardinality marker; the author is
 /// expected to hand-roll one (test fixtures, future cases). Mixing
 /// `singleton` and `instanced` is rejected — a cap is one or the other.
+/// `one_per` on a non-instanced bridge is rejected (the entity-relationship
+/// only describes an instanced family); it is validated in `expand_bridge`
+/// where both flags are known, since attribute arg order is unspecified.
 fn parse_bridge_attr(attr: TokenStream) -> syn::Result<BridgeOpts> {
     let mut opts = BridgeOpts::default();
     if attr.is_empty() {
@@ -874,14 +886,21 @@ fn parse_bridge_attr(attr: TokenStream) -> syn::Result<BridgeOpts> {
             }
             opts.cardinality = Some(BridgeCardinality::Instanced);
             Ok(())
+        } else if meta.path.is_ident("one_per") {
+            let value = meta.value()?;
+            let lit: syn::LitStr = value.parse()?;
+            opts.one_per = Some(lit.value());
+            Ok(())
         } else if meta.path.is_ident("feature") {
             let value = meta.value()?;
             let lit: syn::LitStr = value.parse()?;
             opts.feature = Some(lit.value());
             Ok(())
         } else {
-            Err(meta
-                .error("#[bridge] only accepts `singleton`, `instanced`, or `feature = \"name\"`"))
+            Err(meta.error(
+                "#[bridge] only accepts `singleton`, `instanced`, \
+                 `one_per = \"entity\"`, or `feature = \"name\"`",
+            ))
         }
     });
     Parser::parse(parser, attr)?;
@@ -898,7 +917,20 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
     let BridgeOpts {
         cardinality,
         feature,
+        one_per,
     } = opts;
+    // `one_per` only describes an instanced family's entity relationship.
+    // On a singleton (or a bare `#[bridge]`) it is meaningless — reject it
+    // rather than silently dropping it. Validated here (not in the parser)
+    // because attribute arg order is unspecified, so `cardinality` may not
+    // be known yet when `one_per` is seen.
+    if one_per.is_some() && !matches!(cardinality, Some(BridgeCardinality::Instanced)) {
+        return Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "#[bridge] `one_per` requires `instanced` — it declares the entity \
+             relationship of an instanced family (ADR-0088 §4 v2)",
+        ));
+    }
     let Some((brace, items)) = item_mod.content.take() else {
         return Err(syn::Error::new_spanned(
             &item_mod,
@@ -1116,10 +1148,19 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
     // `TemplateEntry` — the family's shape is declared, individual
     // instances reverse via the runtime registry. (Typed instance
     // parameters are future work; for now the convention is a single
-    // `:<subname>` string hole.) Both submissions are gated by the same
-    // `native_cfg` as the rest of the native surface (the `inventory`
-    // crate doesn't link on wasm32, and a feature-gated cap's entry
-    // tracks the cap's availability).
+    // `:<subname>` string hole.) ADR-0088 §4 v2 adds the orthogonal
+    // `cardinality`: `one_per = "entity"` ⇒ `Cardinality::OnePer(entity)`
+    // (the relationship every instanced actor actually has — one per
+    // component / connection / …), absent ⇒ `Cardinality::Unbounded`.
+    // Both submissions are gated by the same `native_cfg` as the rest of
+    // the native surface (the `inventory` crate doesn't link on wasm32,
+    // and a feature-gated cap's entry tracks the cap's availability).
+    let instanced_cardinality = if let Some(entity) = one_per.as_deref() {
+        let entity = syn::LitStr::new(entity, proc_macro2::Span::call_site());
+        quote! { ::aether_data::name_inventory::Cardinality::OnePer(#entity) }
+    } else {
+        quote! { ::aether_data::name_inventory::Cardinality::Unbounded }
+    };
     let cardinality_marker = match cardinality {
         Some(BridgeCardinality::Singleton) => quote! {
             impl #impl_generics ::aether_actor::Singleton for #self_ty #where_clause {}
@@ -1139,6 +1180,7 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
                     domain: ::aether_data::MAILBOX_DOMAIN,
                     template: concat!(#namespace_expr, ":{subname}"),
                     param: ::aether_data::name_inventory::ParamKind::Dynamic,
+                    cardinality: #instanced_cardinality,
                 }
             }
         },

--- a/crates/aether-capabilities/src/engine/proxy.rs
+++ b/crates/aether-capabilities/src/engine/proxy.rs
@@ -45,7 +45,7 @@ use aether_kinds::{ForwardEnvelope, RpcInboundReady, TerminateEngine};
 #[cfg(not(target_arch = "wasm32"))]
 pub use proxy_native::EngineProxyConfig;
 
-#[aether_actor::bridge(instanced)]
+#[aether_actor::bridge(instanced, one_per = "engine")]
 mod proxy_native {
     use super::{ForwardEnvelope, RpcInboundReady, TerminateEngine};
     use crate::rpc::{

--- a/crates/aether-capabilities/src/inventory.rs
+++ b/crates/aether-capabilities/src/inventory.rs
@@ -34,9 +34,11 @@ mod native {
     use super::{Manifest, ManifestResult, Resolve, ResolveResult};
 
     use aether_actor::{MailCtx, actor};
-    use aether_data::name_inventory::{ParamKind, name_entries, template_entries};
+    use aether_data::name_inventory::{Cardinality, ParamKind, name_entries, template_entries};
     use aether_data::tagged_id;
-    use aether_kinds::{NameEntryWire, ParamKindWire, ResolvedName, TemplateEntryWire};
+    use aether_kinds::{
+        CardinalityWire, NameEntryWire, ParamKindWire, ResolvedName, TemplateEntryWire,
+    };
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
     use aether_substrate::runtime::thread_name::resolve_runtime;
@@ -58,6 +60,18 @@ mod native {
                 domain: domain.to_vec(),
             },
             ParamKind::Dynamic => ParamKindWire::Dynamic,
+        }
+    }
+
+    /// Project one link-time `Cardinality` onto its wire mirror (ADR-0088
+    /// §4 v2) — the orthogonal how-many axis the client surfaces verbatim.
+    fn cardinality_wire(cardinality: &Cardinality) -> CardinalityWire {
+        match *cardinality {
+            Cardinality::Bounded(count) => CardinalityWire::Bounded { count },
+            Cardinality::OnePer(entity) => CardinalityWire::OnePer {
+                entity: entity.into(),
+            },
+            Cardinality::Unbounded => CardinalityWire::Unbounded,
         }
     }
 
@@ -100,6 +114,7 @@ mod native {
                     domain: entry.domain.to_vec(),
                     template: entry.template.into(),
                     param: param_kind_wire(&entry.param),
+                    cardinality: cardinality_wire(&entry.cardinality),
                 })
                 .collect();
             ctx.reply(&ManifestResult { names, templates });
@@ -233,10 +248,14 @@ mod native {
                 "manifest should carry the aether.fs chassis mailbox NameEntry; names: {:?}",
                 result.names.iter().map(|n| &n.name).collect::<Vec<_>>(),
             );
+            // The worker template is `Bounded` on both axes: a `Bounded`
+            // `param` (enumerable integer hole) and a `Bounded` cardinality
+            // (the prehashed instance ceiling) — ADR-0088 §4 v2.
             assert!(
                 result.templates.iter().any(|t| {
                     t.template == "aether-worker-{N}"
                         && matches!(t.param, ParamKindWire::Bounded { .. })
+                        && matches!(t.cardinality, CardinalityWire::Bounded { .. })
                 }),
                 "manifest should carry the aether-worker-{{N}} Bounded template; templates: {:?}",
                 result
@@ -244,6 +263,40 @@ mod native {
                     .iter()
                     .map(|t| &t.template)
                     .collect::<Vec<_>>(),
+            );
+        }
+
+        /// ADR-0088 §4 v2: an instanced actor declaring `one_per` surfaces
+        /// a `OnePer(<entity>)` cardinality in the manifest, so a consumer
+        /// reads "trampoline = one mailbox per loaded component" instead of
+        /// an opaque `Dynamic` family. `WasmTrampoline` is the canonical
+        /// case (`#[bridge(instanced, one_per = "component")]`); touching
+        /// its `NAMESPACE` forces the macro-emitted `TemplateEntry` into
+        /// this test binary.
+        #[test]
+        fn manifest_surfaces_one_per_cardinality_for_trampoline() {
+            use crate::trampoline::WasmTrampoline;
+            use aether_actor::Actor;
+            assert_eq!(WasmTrampoline::NAMESPACE, "aether.component.trampoline");
+
+            let mut fix = fixture();
+            let mut ctx = session_ctx(&fix.transport);
+            fix.cap.on_manifest(&mut ctx, Manifest {});
+            drop(ctx);
+
+            let result = decode_reply::<ManifestResult>(&fix.rx);
+            let trampoline = result
+                .templates
+                .iter()
+                .find(|t| t.template == "aether.component.trampoline:{subname}")
+                .expect("manifest should carry the trampoline instanced-family template");
+            // Shape axis unchanged (opaque runtime string); cardinality
+            // axis now names the entity each instance tracks.
+            assert!(matches!(trampoline.param, ParamKindWire::Dynamic));
+            assert!(
+                matches!(&trampoline.cardinality, CardinalityWire::OnePer { entity } if entity == "component"),
+                "trampoline cardinality should be OnePer(\"component\"); got {:?}",
+                trampoline.cardinality,
             );
         }
 

--- a/crates/aether-capabilities/src/tcp/listener.rs
+++ b/crates/aether-capabilities/src/tcp/listener.rs
@@ -23,7 +23,7 @@ use aether_kinds::{Close, ConnectionReady};
 #[cfg(not(target_arch = "wasm32"))]
 pub use listener_native::TcpListenerConfig;
 
-#[aether_actor::bridge(instanced)]
+#[aether_actor::bridge(instanced, one_per = "listener")]
 mod listener_native {
     use super::{Close, ConnectionReady};
     use aether_actor::actor;

--- a/crates/aether-capabilities/src/tcp/session.rs
+++ b/crates/aether-capabilities/src/tcp/session.rs
@@ -39,7 +39,7 @@ use aether_kinds::{SessionClose, SessionDataReady, SessionWrite};
 #[cfg(not(target_arch = "wasm32"))]
 pub use session_native::TcpSessionConfig;
 
-#[aether_actor::bridge(instanced)]
+#[aether_actor::bridge(instanced, one_per = "connection")]
 mod session_native {
     use super::{SessionClose, SessionDataReady, SessionWrite};
     use aether_actor::actor;

--- a/crates/aether-capabilities/src/trampoline.rs
+++ b/crates/aether-capabilities/src/trampoline.rs
@@ -72,7 +72,7 @@ use aether_kinds::{DropComponent, ReplaceComponent};
 #[cfg(not(target_arch = "wasm32"))]
 pub use native::WasmTrampolineConfig;
 
-#[aether_actor::bridge(instanced)]
+#[aether_actor::bridge(instanced, one_per = "component")]
 mod native {
     use std::sync::Arc;
 

--- a/crates/aether-data/src/name_inventory.rs
+++ b/crates/aether-data/src/name_inventory.rs
@@ -17,9 +17,13 @@
 //!   [`TransformEntry`] (its `name` field), so a declared kind /
 //!   transform needs no second submission.
 //! - [`TemplateEntry`] — an instanced family (`{ domain, template,
-//!   param }`). The `template` is a pattern with one `{…}` hole
-//!   (`"aether-worker-{N}"`), and [`ParamKind`] says how the hole is
-//!   filled:
+//!   param, cardinality }`). The `template` is a pattern with one `{…}`
+//!   hole (`"aether-worker-{N}"`); two orthogonal axes describe it.
+//!   [`ParamKind`] is the **shape** axis — how the hole is filled and
+//!   whether the family is statically enumerable; [`Cardinality`] is the
+//!   **how-many** axis — manifest metadata that makes the family
+//!   self-describing (`OnePer("component")` rather than an opaque
+//!   `Dynamic`). The reverse-map builder reads only [`ParamKind`]:
 //!     - [`ParamKind::Bounded`] — a finite integer range, enumerated and
 //!       pre-hashed at boot (the common-case "embed the expected hashes"
 //!       path).
@@ -112,18 +116,58 @@ pub enum ParamKind {
     Dynamic,
 }
 
+/// *How many* instances a [`TemplateEntry`] family can have, and the
+/// relationship each instance bears to a live entity (ADR-0088 §4 v2).
+///
+/// This is the **cardinality** axis, orthogonal to [`ParamKind`] (which
+/// is the *shape* axis — the type of the `{…}` hole and whether the
+/// family is statically enumerable). `ParamKind` is what
+/// [`build_static_reverse_map`] reads to enumerate; `Cardinality` is pure
+/// manifest metadata, never consulted by the reverse-map builder. It
+/// makes the served manifest self-describing: a consumer reads "trampoline
+/// = one mailbox per loaded component" instead of an opaque `Dynamic`
+/// family. Both axes are stated explicitly on every template — the same
+/// shape may pair with different cardinalities (every instanced actor is
+/// `ParamKind::Dynamic`, but `aether.component.trampoline` is
+/// `OnePer("component")` while `aether-instanced-{full_name}` is
+/// `Unbounded`).
+#[derive(Clone, Copy)]
+pub enum Cardinality {
+    /// A compile-time-known finite count (`aether-worker-{N}` prehashes a
+    /// fixed ceiling). The integer is the family's static instance bound,
+    /// not necessarily the count live at any moment.
+    Bounded(u64),
+    /// One instance per live entity of the named kind — the relationship
+    /// that the four instanced actors actually have: not "N instances" but
+    /// "as many as there are components / connections / listeners /
+    /// engines". The string is a bare entity tag (`"component"`); typed
+    /// entity holes (reverse-chaining an embedded `EngineId`) are deferred
+    /// (ADR-0088 §4 v2 "deferred").
+    OnePer(&'static str),
+    /// Open-ended, runtime-minted, no fixed relationship — the family is
+    /// unbounded (`aether-instanced-{full_name}`). The old `ParamKind`
+    /// `Dynamic`-only semantics, now a cardinality statement in its own
+    /// right.
+    Unbounded,
+}
+
 /// A name template for an instanced family, collected at link time
 /// (ADR-0088 §4). The `template` carries one `{…}` hole; [`ParamKind`]
-/// says how it is filled. Owns nothing but `'static` data so it is
-/// const-constructible from `inventory::submit!`.
+/// says how it is filled (the *shape* axis) and [`Cardinality`] says how
+/// many instances exist (the *cardinality* axis). Owns nothing but
+/// `'static` data so it is const-constructible from `inventory::submit!`.
 pub struct TemplateEntry {
     /// Byte-domain prefix the instantiated names are hashed under
     /// (e.g. [`crate::THREAD_DOMAIN`] for thread-name families).
     pub domain: &'static [u8],
     /// Pattern with one `{…}` hole, e.g. `"aether-worker-{N}"`.
     pub template: &'static str,
-    /// How the hole is filled.
+    /// How the hole is filled — the shape axis. Drives
+    /// [`build_static_reverse_map`].
     pub param: ParamKind,
+    /// How many instances the family can have — the cardinality axis.
+    /// Manifest metadata only; not read by the reverse-map builder.
+    pub cardinality: Cardinality,
 }
 
 inventory::collect!(TemplateEntry);
@@ -278,6 +322,7 @@ mod tests {
             domain: THREAD_DOMAIN,
             template: "aether-test-worker-{N}",
             param: ParamKind::Bounded { lo: 0, hi: 3 },
+            cardinality: Cardinality::Bounded(4),
         }
     }
     inventory::submit! {
@@ -285,6 +330,7 @@ mod tests {
             domain: THREAD_DOMAIN,
             template: "aether-test-root-{NAMESPACE}",
             param: ParamKind::Declared { domain: MAILBOX_DOMAIN },
+            cardinality: Cardinality::OnePer("mailbox"),
         }
     }
 

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1564,6 +1564,30 @@ mod control_plane {
         Dynamic,
     }
 
+    /// *How many* instances a [`TemplateEntryWire`] family can have — the
+    /// wire mirror of `aether_data::name_inventory::Cardinality` (ADR-0088
+    /// §4 v2). Orthogonal to [`ParamKindWire`] (the *shape* axis): the
+    /// client expands / prehashes templates off `param`, while
+    /// `cardinality` is the self-describing "how many" the manifest
+    /// surfaces so a consumer reads "trampoline = one mailbox per loaded
+    /// component" rather than an opaque `Dynamic` family. Struct variants
+    /// (not tuple) so the wire JSON carries named fields, matching
+    /// [`ParamKindWire`].
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.inventory.cardinality")]
+    pub enum CardinalityWire {
+        /// A compile-time-known finite instance bound (`aether-worker-{N}`
+        /// prehashes `count` instantiations).
+        Bounded { count: u64 },
+        /// One instance per live entity of the named kind — the
+        /// relationship the four instanced actors carry (`"component"`,
+        /// `"connection"`, `"listener"`, `"engine"`).
+        OnePer { entity: String },
+        /// Open-ended, runtime-minted, no fixed relationship
+        /// (`aether-instanced-{full_name}`).
+        Unbounded,
+    }
+
     /// A declared name on the wire — the mirror of
     /// `aether_data::name_inventory::NameEntry` (ADR-0088 §3). `domain`
     /// is the byte-domain prefix the name is hashed under; `name` is the
@@ -1577,16 +1601,19 @@ mod control_plane {
 
     /// A name template for an instanced family on the wire — the mirror
     /// of `aether_data::name_inventory::TemplateEntry` (ADR-0088 §4).
-    /// `template` carries one `{…}` hole; [`ParamKindWire`] says how it
-    /// is filled. Preserving the template (rather than its expansion)
-    /// keeps the family shape so the client can declare "ids in this
-    /// family exist and look like *this*" even for `Dynamic` families it
-    /// cannot enumerate.
+    /// `template` carries one `{…}` hole; [`ParamKindWire`] (the shape
+    /// axis) says how it is filled and [`CardinalityWire`] (the how-many
+    /// axis) says how many instances exist. Preserving the template
+    /// (rather than its expansion) keeps the family shape so the client
+    /// can declare "ids in this family exist and look like *this*" even
+    /// for `Dynamic` families it cannot enumerate; `cardinality` makes
+    /// that declaration self-describing.
     #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
     pub struct TemplateEntryWire {
         pub domain: Vec<u8>,
         pub template: String,
         pub param: ParamKindWire,
+        pub cardinality: CardinalityWire,
     }
 
     /// `aether.inventory.manifest` — request the running substrate's

--- a/crates/aether-mcp/src/reverse.rs
+++ b/crates/aether-mcp/src/reverse.rs
@@ -195,6 +195,7 @@ mod tests {
     use super::*;
     use aether_data::hash::{mailbox_id_from_name, thread_id_from_name};
     use aether_data::{KIND_DOMAIN, MAILBOX_DOMAIN, THREAD_DOMAIN};
+    use aether_kinds::CardinalityWire;
 
     /// Build a synthetic manifest with a `NameEntry` (a mailbox name + a
     /// kind name), a `Bounded` template (`aether-test-worker-{N}`), and a
@@ -217,12 +218,16 @@ mod tests {
                     domain: THREAD_DOMAIN.to_vec(),
                     template: "aether-test-worker-{N}".to_string(),
                     param: ParamKindWire::Bounded { lo: 0, hi: 3 },
+                    cardinality: CardinalityWire::Bounded { count: 4 },
                 },
                 TemplateEntryWire {
                     domain: THREAD_DOMAIN.to_vec(),
                     template: "aether-test-root-{NAMESPACE}".to_string(),
                     param: ParamKindWire::Declared {
                         domain: MAILBOX_DOMAIN.to_vec(),
+                    },
+                    cardinality: CardinalityWire::OnePer {
+                        entity: "mailbox".to_string(),
                     },
                 },
             ],

--- a/crates/aether-substrate/src/runtime/thread_name.rs
+++ b/crates/aether-substrate/src/runtime/thread_name.rs
@@ -56,7 +56,7 @@ use std::thread;
 use aether_data::ThreadId;
 use aether_data::build_static_reverse_map;
 use aether_data::hash::{MAILBOX_DOMAIN, THREAD_DOMAIN};
-use aether_data::name_inventory::{ParamKind, TemplateEntry, inventory};
+use aether_data::name_inventory::{Cardinality, ParamKind, TemplateEntry, inventory};
 use aether_data::tagged_id;
 
 /// Upper bound on the worker-id range the `aether-worker-{N}` template
@@ -70,12 +70,17 @@ const WORKER_TEMPLATE_HI: u64 = 255;
 // ADR-0088 §4 thread-name families. The pool names workers
 // `aether-worker-N`; native-actor root threads `aether-root-<NAMESPACE>`
 // (over the declared mailbox namespaces); instanced-actor threads
-// `aether-instanced-<full_name>` (an unbounded runtime parameter).
+// `aether-instanced-<full_name>` (an unbounded runtime parameter). The
+// `cardinality` (ADR-0088 §4 v2) states how many of each can exist:
+// workers prehash a fixed ceiling (`Bounded`); one root thread per
+// declared mailbox (`OnePer`); instanced threads are open-ended
+// (`Unbounded`).
 inventory::submit! {
     TemplateEntry {
         domain: THREAD_DOMAIN,
         template: "aether-worker-{N}",
         param: ParamKind::Bounded { lo: 0, hi: WORKER_TEMPLATE_HI },
+        cardinality: Cardinality::Bounded(WORKER_TEMPLATE_HI + 1),
     }
 }
 inventory::submit! {
@@ -83,6 +88,7 @@ inventory::submit! {
         domain: THREAD_DOMAIN,
         template: "aether-root-{NAMESPACE}",
         param: ParamKind::Declared { domain: MAILBOX_DOMAIN },
+        cardinality: Cardinality::OnePer("mailbox"),
     }
 }
 inventory::submit! {
@@ -90,6 +96,7 @@ inventory::submit! {
         domain: THREAD_DOMAIN,
         template: "aether-instanced-{full_name}",
         param: ParamKind::Dynamic,
+        cardinality: Cardinality::Unbounded,
     }
 }
 

--- a/docs/adr/0088-identifier-reverse-lookup-inventory.md
+++ b/docs/adr/0088-identifier-reverse-lookup-inventory.md
@@ -49,6 +49,20 @@ A `NameEntry { domain, name: &'static str }` link-time inventory, sibling to `De
 
 A template thus declares "ids in this family exist and look like *this*" even when it cannot say *which* exist — the distinction that a flat name list can't express.
 
+### 4 (v2). Cardinality — the how-many axis
+
+*Amendment, issue #1132.* §4's `ParamKind` conflated two questions: *how* a template's hole is filled (its **shape** — integer range / declared name / opaque string) and *how many* instances the family can have. v1 punted on the second: every instanced actor emitted `ParamKind::Dynamic`, so a manifest consumer saw four identical opaque families (trampoline, tcp session, tcp listener, engine proxy) and learned nothing about what each instance corresponds to.
+
+v2 splits the axes. `ParamKind` keeps the shape role (and drives the reverse-map enumeration unchanged). A new `Cardinality`, stated explicitly on **every** `TemplateEntry`, carries the how-many:
+
+- **`Bounded(u64)`** — a compile-time-known finite instance bound (`aether-worker-{N}` prehashes a ceiling).
+- **`OnePer(<entity>)`** — one instance per live entity of a named kind. This is the relationship all four instanced actors actually have: not "N instances" but "as many as there are components / connections / listeners / engines."
+- **`Unbounded`** — open-ended, runtime-minted, no fixed relationship (`aether-instanced-{full_name}`; the old `Dynamic`-only semantics, now a cardinality in its own right).
+
+`OnePer` is the load-bearing addition — it is what makes the manifest self-describing about instance shape. The axes are orthogonal: the same shape pairs with different cardinalities (every instanced actor is `ParamKind::Dynamic`, but the trampoline is `OnePer("component")` while the instanced thread-name fallback is `Unbounded`). The reverse-map builder reads only `ParamKind`; `Cardinality` is manifest metadata. Cardinality is declared at the `#[bridge(instanced, one_per = "component")]` site (absent ⇒ `Unbounded`) and rides through `TemplateEntryWire` to the served manifest.
+
+**Deferred (over-reach for v2):** typed-id holes — e.g. `aether.engine.proxy:{engine: EngineId}` where the hole is a tagged-id type rather than a bare string, enabling *chained* reversal (reverse the embedded `EngineId` to its engine name as part of reversing the instance name). That is a meaningfully larger change to the inventory's hole model and isn't needed to make the manifest expose cardinality shape; `OnePer(<entity>)` over a string hole delivers the self-describing-manifest win on its own.
+
 ### 5. Runtime registry for dynamic instances
 
 A process-global registry (substrate-side, `std` `RwLock<HashMap<u64, Box<str>>>`) maps id → name for dynamically-minted names. It is populated at the moment a name is minted — the thread-spawn name builders (`alloc_instanced_thread_name`, the `aether-worker-N` formatter), the trampoline mailbox registration, etc. Registration is lazy-safe: the same code path that builds the name and derives its hash also registers it, so any id that can appear in a trace or diagnostic is registered before it can be observed. Writes are rare (instance creation), reads are cold (render time), so the lock is uncontended in practice and off the dispatch hot path entirely.


### PR DESCRIPTION
Follow-up to ADR-0088 (reverse-lookup identifier inventory). v1 gave every instanced actor a `TemplateEntry` with `ParamKind::Dynamic`, declaring only that a string-keyed family exists — not its shape. A manifest consumer read four identical opaque families and learned nothing about what each instance corresponds to.

## What changed

Split the two axes `ParamKind` conflated:

- **`ParamKind`** stays the *shape* axis (how the hole is filled / whether the family is statically enumerable). Unchanged — the reverse-map builder still reads only this, so no match-arm churn.
- **`Cardinality`** is a new orthogonal axis, stated explicitly on **every** `TemplateEntry`: `Bounded(u64)`, `OnePer(<entity>)`, `Unbounded`.

`OnePer` is the load-bearing addition — it makes the served manifest self-describing: a consumer now reads "trampoline = one mailbox per loaded component" instead of an opaque `Dynamic` family.

## Surfaces

- `aether-data::name_inventory` — `Cardinality` enum + required `TemplateEntry.cardinality` field.
- `aether-actor-derive` — `#[bridge(instanced, one_per = "entity")]` emits `Cardinality::OnePer(entity)` (absent ⇒ `Unbounded`); rejected on a non-instanced bridge.
- `aether-kinds` — `CardinalityWire` mirror + `TemplateEntryWire.cardinality`.
- `aether-capabilities/inventory.rs` — maps the new axis into the served manifest.
- The four instanced actors annotated: trampoline → component, tcp session → connection, tcp listener → listener, engine proxy → engine. Thread-name templates gain explicit cardinalities too.

Typed-id holes (chained `EngineId` reversal) stay deferred, per the issue. Documented as a v2 amendment to ADR-0088 §4 (extends an accepted ADR; not load-bearing enough for a new one).

## Validation

`scripts/preflight.sh` green: fmt + clippy + doc + nextest (1298 passed) + wasm32 cross-build. New end-to-end test asserts the trampoline surfaces `OnePer("component")` through the actual manifest wire.

Closes iamacoffeepot/aether#1132