### PR TITLE
perf(substrate): re-anchor latency stamps for blob-batch spans

### DIFF
--- a/crates/aether-kinds/src/trace.rs
+++ b/crates/aether-kinds/src/trace.rs
@@ -72,23 +72,36 @@ pub enum TraceEvent {
         sender: MailboxId,
         recipient: MailboxId,
         kind: KindId,
+        /// iamacoffeepot/aether#1150: for buffered sends this is the
+        /// frame's **flush-begin** instant (stamped once when the handler's
+        /// outbound buffer flushes, shared by every mail in the frame), not
+        /// the per-send call site. Eager paths (`wait_reply`-free direct
+        /// routes, chassis-root pushes) route immediately, so their call
+        /// site *is* the flush instant. Anchoring here drops the smear of
+        /// "the rest of the handler that ran after the send" that the
+        /// call-site stamp folded into the producer-side span.
         t: Nanos,
     },
     Received {
         mail_id: MailId,
         t: Nanos,
-        /// iamacoffeepot/aether#1134: the timestamp the mail was deposited
-        /// into the recipient's inbox (`route_mail`'s Inbox arm — the
-        /// single deposit chokepoint). Stamped onto the envelope at
-        /// deposit and read here at the recipient's dispatcher entry, so
-        /// the span splits into **send→enqueue** (`t_enqueue − t_sent`:
-        /// the producer's remaining handler + flush + blob pickup + demux)
-        /// and **queue residence** (`t − t_enqueue`: deposit → this
-        /// dispatcher picking it up = slot schedule + worker wakeup +
-        /// recv). Riding the existing `Received` event avoids a per-mail
-        /// ring entry and a second clock read on the recipient side. Equal
-        /// to `t` for the rare paths with no distinct deposit instant
-        /// (none today — every Inbox mail is deposited).
+        /// iamacoffeepot/aether#1134, re-anchored by
+        /// iamacoffeepot/aether#1150: the instant the consumer side first
+        /// took responsibility for this mail. On the #1135 in-place blob
+        /// path it is the **blob-pickup** stamp — when the draining worker
+        /// entered `run_cycle` for the blob this mail rode in (shared by
+        /// every mail that worker dispatches that cycle). On the
+        /// `route_mail` Inbox path it remains the **deposit** instant. With
+        /// `t_sent` now anchored at flush-begin (also #1150), the hop
+        /// decomposes cleanly: **queued** (`t_enqueue − t_sent`:
+        /// flush-begin → the worker picks up the blob / the deposit lands
+        /// = wakeup + scheduling) and **drain** (`t − t_enqueue`: pickup →
+        /// this mail's handler entry = where in the blob's drain it
+        /// landed, the in-blob serialization a serial fan-out pays). Riding
+        /// the existing `Received` event avoids a per-mail ring entry and a
+        /// second clock read on the recipient side. Pre-#1150 the in-place
+        /// path stamped this at pop time (≈ `t`), collapsing `drain` to ~0
+        /// — the latent bug #1150 fixes.
         t_enqueue: Nanos,
         /// iamacoffeepot/aether#1134: the scheduler ready-queue depth at
         /// deposit — this worker's own-deque len plus the shared injector
@@ -176,11 +189,14 @@ pub struct MailNodeWire {
     pub recipient: MailboxId,
     pub kind: KindId,
     pub t_sent: Nanos,
-    /// iamacoffeepot/aether#1134: when this mail was deposited into the
-    /// recipient's inbox (the `Received` event's `t_enqueue`). `None`
-    /// until the `Received` event lands. `t_enqueue − t_sent` is the
-    /// send→enqueue (producer-side) span; `t_received − t_enqueue` is
-    /// queue residence (consumer-side wakeup / wait).
+    /// iamacoffeepot/aether#1134, re-anchored by
+    /// iamacoffeepot/aether#1150 (the `Received` event's `t_enqueue`):
+    /// when the consumer side first took the mail — the blob-pickup
+    /// instant on the in-place path, or the inbox deposit on the
+    /// `route_mail` path. `None` until the `Received` event lands.
+    /// `t_enqueue − t_sent` is the **queued** span (flush-begin →
+    /// pickup); `t_received − t_enqueue` is the **drain** span (pickup →
+    /// handler entry).
     pub t_enqueue: Option<Nanos>,
     /// iamacoffeepot/aether#1134: scheduler ready-queue depth at deposit
     /// (own-deque + injector len). `None` until the `Received` event

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -530,12 +530,16 @@ impl NativeBinding {
     /// metadata; [`Self::flush_outbound`] forms the blob and routes at
     /// handler end (or before a blocking `wait_reply`).
     ///
-    /// `record_sent` stays **eager** (fired here, at send time, not at
-    /// flush) so the chain's `in_flight` is exact and settlement
-    /// (ADR-0082) never settles early — only the route + enqueue is
-    /// deferred. Returns the minted `MailId` (== the new root when
-    /// `inherited_root.is_none()`) exactly like the eager variant, so
-    /// settlement subscription works unchanged.
+    /// The settlement-counter increment stays **eager** (fired here, at
+    /// send time, not at flush) so the chain's `in_flight` is exact and
+    /// settlement (ADR-0082) never settles early. The `Sent` *trace*
+    /// event, by contrast, is deferred to [`Self::flush_outbound`] and
+    /// stamped with the frame-level flush-begin instant
+    /// (iamacoffeepot/aether#1150) — anchoring it there instead of this
+    /// smeared per-send call site, which otherwise absorbs the rest of
+    /// the handler that ran after the send. Returns the minted `MailId`
+    /// (== the new root when `inherited_root.is_none()`) exactly like the
+    /// eager variant, so settlement subscription works unchanged.
     ///
     /// # Panics
     /// Panics if the outbound-buffer mutex is poisoned — fail-fast per
@@ -550,20 +554,16 @@ impl NativeBinding {
         inherited_root: Option<MailId>,
     ) -> MailId {
         let correlation = self.correlation.fetch_add(1, Ordering::AcqRel) + 1;
-        let recipient_id = MailboxId(recipient);
         let reply_to =
             ReplyTo::with_correlation(ReplyTarget::Component(self.self_mailbox), correlation);
         let mail_id = MailId::new(self.self_mailbox, correlation);
         let root = inherited_root.unwrap_or(mail_id);
-        // Eager producer hook (see doc) — identical to the eager path.
-        self.mailer.record_sent(
-            mail_id,
-            root,
-            parent_mail,
-            self.self_mailbox,
-            recipient_id,
-            KindId(kind),
-        );
+        // iamacoffeepot/aether#1150: only the settlement increment is
+        // eager here; the `Sent` trace event emits at flush against the
+        // flush-begin anchor (see `flush_outbound_inner`). The recipient
+        // id, kind, and lineage ride the `PendingMail` to flush, where the
+        // deferred `Sent` is built from the routed `Mail`.
+        self.mailer.record_sent_inflight(root);
         let mut buf = self
             .outbound
             .lock()
@@ -654,7 +654,18 @@ impl NativeBinding {
     /// route. `allow_blob` picks the deferred [`BlobWork`] path (handler
     /// end) vs eager per-mail routing (`wait_reply`); both are no-ops
     /// when nothing is buffered.
+    ///
+    /// iamacoffeepot/aether#1150: this is the frame's flush-begin
+    /// instant. Once the buffer is known non-empty, one `now_nanos` read
+    /// stamps `flush_begin`, and every mail in the frame emits its
+    /// deferred `Sent` trace event against that shared anchor (the
+    /// per-send call site only bumped `in_flight`). Anchoring `Sent`
+    /// here, not at the send call, drops the smear of "the rest of the
+    /// handler that ran after the send" from the producer-side span. The
+    /// clock read sits behind the emptiness check so a no-send handler
+    /// return stays free.
     fn flush_outbound_inner(&self, allow_blob: bool) {
+        let flush_begin;
         let routed: Vec<Mail> = {
             let mut buf = self
                 .outbound
@@ -671,6 +682,7 @@ impl NativeBinding {
             if buf.mails.is_empty() {
                 return;
             }
+            flush_begin = self.mailer.now_nanos();
             let OutboundBuffer { ring, mails, .. } = &mut *buf;
             let ring = ring.as_ref();
             mails
@@ -689,6 +701,23 @@ impl NativeBinding {
                 })
                 .collect()
         };
+
+        // iamacoffeepot/aether#1150: emit each buffered mail's deferred
+        // `Sent` trace event against the shared flush-begin anchor before
+        // routing (the lock is already released — `push_trace_ring` runs
+        // off the actor's own ring). `in_flight` was bumped eagerly at
+        // the send call, so this is purely the trace-event half.
+        for mail in &routed {
+            self.mailer.record_sent_event_at(
+                mail.mail_id,
+                mail.root,
+                mail.parent_mail,
+                self.self_mailbox,
+                mail.recipient,
+                mail.kind,
+                flush_begin,
+            );
+        }
 
         // ADR-0087 / iamacoffeepot/aether#1137: fold the blob into this
         // actor's single active cursor-shared blob (recipient-grouped,

--- a/crates/aether-substrate/src/actor/native/blob_work.rs
+++ b/crates/aether-substrate/src/actor/native/blob_work.rs
@@ -99,6 +99,7 @@ use std::mem::MaybeUninit;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
+use aether_kinds::trace::Nanos;
 use rustc_hash::FxHashMap;
 
 use crate::actor::native::Envelope;
@@ -448,18 +449,23 @@ impl BlobWork {
     /// Dispatch one group's mail to its recipient, draining the closeable
     /// buffer in batches until empty (then the buffer self-closes — the
     /// FIFO barrier). Each batch's mail dispatches in send order via the
-    /// #1135 per-mail fast path.
-    fn dispatch_group(&self, group: &Group, budget: BatchBudget) {
+    /// #1135 per-mail fast path. `received` is the blob-pickup stamp this
+    /// worker took at `run_cycle` entry (iamacoffeepot/aether#1150),
+    /// threaded onto each dispatched mail's `t_enqueue`.
+    fn dispatch_group(&self, group: &Group, budget: BatchBudget, received: Nanos) {
         while let Some(batch) = group.take_or_close() {
             for mail in batch {
-                self.dispatch_one(group.recipient, mail, budget);
+                self.dispatch_one(group.recipient, mail, budget, received);
             }
         }
     }
 
     /// The iamacoffeepot/aether#1135 per-mail demux step: seize the
     /// recipient and dispatch in place, or deposit through `route_mail`.
-    fn dispatch_one(&self, recipient: MailboxId, mail: Mail, budget: BatchBudget) {
+    /// `received` is this worker's blob-pickup stamp
+    /// (iamacoffeepot/aether#1150), carried onto the in-place seed's
+    /// `t_enqueue`.
+    fn dispatch_one(&self, recipient: MailboxId, mail: Mail, budget: BatchBudget, received: Nanos) {
         let lookup = self.mailer.registry().route_lookup(mail.kind, recipient);
         // Direct-dispatch only a ref-free kind whose recipient is a
         // `Pooled` slot we win the seize on; everything else deposits.
@@ -480,7 +486,11 @@ impl BlobWork {
                     mail_id: mail.mail_id,
                     root: mail.root,
                     parent_mail: mail.parent_mail,
-                    t_enqueue: self.mailer.now_nanos(),
+                    // iamacoffeepot/aether#1150: the blob-pickup stamp, not
+                    // a fresh `now` — `now` here ≈ `t_received` and collapsed
+                    // residence to ~0. With the pickup instant, the recipient's
+                    // `Received` reads a real `t_received − t_enqueue` drain.
+                    t_enqueue: received,
                     enqueue_depth: 0,
                 };
                 match slot.seize_and_run(seed, budget) {
@@ -495,6 +505,15 @@ impl BlobWork {
 
 impl Drainable for BlobWork {
     fn run_cycle(&self, budget: BatchBudget) -> CycleResult {
+        // iamacoffeepot/aether#1150: the blob-received stamp. One clock
+        // read marks when this worker picked up the blob and began
+        // draining; every mail it dispatches this cycle inherits it as
+        // `t_enqueue`, so `t_received − t_enqueue` measures where in the
+        // drain that mail's handler entry landed (the in-blob
+        // serialization a serial fan-out pays), not ~0. Stamped per
+        // `run_cycle`, so a recruited sibling worker anchors its own
+        // share of the groups against its own pickup instant.
+        let received = self.mailer.now_nanos();
         // Drain to cursor exhaustion: a worker that picks up the blob runs
         // it in full, claiming and dispatching every group it wins off the
         // shared cursor until the cursor is drained. The parallelism is
@@ -510,7 +529,7 @@ impl Drainable for BlobWork {
             // the `publish` that wrote slot `g`; the slot is initialized and
             // never mutated after that write.
             let group = unsafe { self.groups[g].get() };
-            self.dispatch_group(group, budget);
+            self.dispatch_group(group, budget, received);
             self.lifecycle.complete();
         }
         CycleResult::Idle

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -200,6 +200,13 @@ pub fn dispatch_loop_run<A>(
             {
                 typed_then_fallback_or_warn::<A>(actor, &mut ctx, &env);
             }
+            // iamacoffeepot/aether#1150: drop `ctx` now to flush the
+            // handler's buffered sends (stamping each child `Sent` at
+            // flush-begin) before `Finished`, so a child's `t_sent`
+            // precedes its parent's `t_finished` — the causal order the
+            // trace walk expects. Otherwise the flush rides `ctx`'s
+            // scope-end `Drop`, landing after this push.
+            drop(ctx);
             th.push_trace_ring(
                 env.root,
                 TraceEvent::Finished {
@@ -246,6 +253,10 @@ pub fn dispatch_loop_run<A>(
             {
                 let _ = actor.__aether_dispatch_envelope(&mut ctx, env.kind, env.payload.bytes());
             }
+            // iamacoffeepot/aether#1150: flush before `Finished` so a
+            // child `Sent` (stamped at flush-begin on `ctx` drop) precedes
+            // its parent's `Finished`. See the main-loop arm above.
+            drop(ctx);
             th.push_trace_ring(
                 env.root,
                 TraceEvent::Finished {

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -257,6 +257,10 @@ where
             {
                 super::dispatch::typed_then_fallback_or_warn::<A>(actor, &mut ctx, &env);
             }
+            // iamacoffeepot/aether#1150: flush before `Finished` so a
+            // child `Sent` (stamped at flush-begin on `ctx` drop) precedes
+            // its parent's `Finished`. See `dispatch::dispatch_loop_run`.
+            drop(ctx);
             th.push_trace_ring(
                 env.root,
                 TraceEvent::Finished {
@@ -343,8 +347,10 @@ where
 
         // iamacoffeepot/aether#1135: the demux-direct seed runs first,
         // in place — no inbox deposit, no `try_recv` repop. The seed's
-        // `Received` already carries `t_enqueue ≈ now` / `enqueue_depth =
-        // 0` (stamped by the `BlobWork` demuxer), so residence ≈ 0.
+        // `Received` carries `enqueue_depth = 0` and (iamacoffeepot/aether#1150)
+        // `t_enqueue` = the blob-pickup stamp the `BlobWork` demuxer took at
+        // `run_cycle` entry, so `t_received − t_enqueue` is the real in-blob
+        // drain (pre-#1150 the pop-time stamp made it ≈ 0).
         if let Some(seed) = seed {
             self.dispatch_one(actor, seed);
         }

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -189,6 +189,39 @@ impl Mailer {
             .record_sent(mail_id, root, parent_mail, sender, recipient, kind);
     }
 
+    /// iamacoffeepot/aether#1150: push the `Sent` trace event with an
+    /// explicit flush-begin timestamp (no settlement bump — that fired
+    /// eagerly via [`Self::record_sent_inflight`]). The buffered send
+    /// path calls this once per mail at flush.
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_sent_event_at(
+        &self,
+        mail_id: aether_data::MailId,
+        root: aether_data::MailId,
+        parent_mail: Option<aether_data::MailId>,
+        sender: aether_data::MailboxId,
+        recipient: aether_data::MailboxId,
+        kind: KindId,
+        t: Nanos,
+    ) {
+        self.trace_handle.record_sent_event_at(
+            mail_id,
+            root,
+            parent_mail,
+            sender,
+            recipient,
+            kind,
+            t,
+        );
+    }
+
+    /// iamacoffeepot/aether#1150: eager settlement-counter increment for
+    /// an outbound mail's `root`, split from the `Sent` trace event so
+    /// the buffered path keeps `in_flight` exact at send time.
+    pub fn record_sent_inflight(&self, root: aether_data::MailId) {
+        self.trace_handle.record_sent_inflight(root);
+    }
+
     /// ADR-0080 §2 settlement hook for the `Finished` event: decrements
     /// the root's emit-time `in_flight` count and fires `Settled` on the
     /// zero-transition. (The `Finished` trace event itself is pushed into

--- a/crates/aether-substrate/src/mail/registry.rs
+++ b/crates/aether-substrate/src/mail/registry.rs
@@ -201,14 +201,19 @@ pub struct OwnedDispatch {
     /// ADR-0080 §5: the in-flight mail at the sender, or `None` for
     /// chassis-root sends.
     pub parent_mail: Option<MailId>,
-    /// iamacoffeepot/aether#1134: the deposit timestamp — when this
-    /// envelope was placed into the recipient's inbox at `route_mail`'s
-    /// Inbox arm. The recipient's dispatcher reads it at its `Received`
-    /// hook and folds it into [`TraceEvent::Received`]'s `t_enqueue` so
-    /// the hop splits into send→enqueue (`t_enqueue − t_sent`) and queue
-    /// residence (`t_received − t_enqueue`). `Nanos(0)` on construction
-    /// sites that don't stamp it (chassis-internal / test envelopes that
-    /// never enter the traced relay path).
+    /// iamacoffeepot/aether#1134, re-anchored by
+    /// iamacoffeepot/aether#1150: when the consumer side took this
+    /// envelope. On the `route_mail` Inbox arm it is the **deposit**
+    /// instant (placed into the recipient's inbox); on the #1135 in-place
+    /// blob path the `BlobWork` demuxer stamps it with the **blob-pickup**
+    /// instant instead (when the draining worker entered `run_cycle`),
+    /// shared by every mail that worker dispatches. The recipient's
+    /// dispatcher reads it at its `Received` hook and folds it into
+    /// [`TraceEvent::Received`]'s `t_enqueue`, so the hop splits into
+    /// **queued** (`t_enqueue − t_sent`) and **drain**
+    /// (`t_received − t_enqueue`). `Nanos(0)` on construction sites that
+    /// don't stamp it (chassis-internal / test envelopes that never enter
+    /// the traced relay path).
     ///
     /// [`TraceEvent::Received`]: aether_kinds::trace::TraceEvent
     pub t_enqueue: Nanos,

--- a/crates/aether-substrate/src/runtime/trace.rs
+++ b/crates/aether-substrate/src/runtime/trace.rs
@@ -199,7 +199,12 @@ impl TraceHandle {
 
     /// ADR-0080 §2 producer hook for the `Sent` event. Pushes the event
     /// into the producing actor's ring (chassis-host ring off-actor) and
-    /// increments the root's emit-time `in_flight` count.
+    /// increments the root's emit-time `in_flight` count. Stamps the
+    /// `Sent` timestamp at the call (eager paths route immediately, so
+    /// the call site *is* the frame-flush instant). The buffered send
+    /// path splits this — [`Self::record_sent_inflight`] eagerly, then
+    /// [`Self::record_sent_event_at`] at flush with the flush-begin
+    /// anchor (iamacoffeepot/aether#1150).
     pub fn record_sent(
         &self,
         mail_id: MailId,
@@ -208,6 +213,37 @@ impl TraceHandle {
         sender: MailboxId,
         recipient: MailboxId,
         kind: KindId,
+    ) {
+        self.record_sent_event_at(
+            mail_id,
+            root,
+            parent_mail,
+            sender,
+            recipient,
+            kind,
+            self.now_nanos(),
+        );
+        self.record_sent_inflight(root);
+    }
+
+    /// iamacoffeepot/aether#1150: push the `Sent` trace event with an
+    /// explicit timestamp, leaving the settlement counter untouched.
+    /// Split from [`Self::record_sent`] so the buffered send path can
+    /// defer the timestamp to flush-begin (the frame's first flush
+    /// instant) — anchoring `Sent` there instead of the smeared
+    /// per-send call site — while [`Self::record_sent_inflight`] keeps
+    /// `in_flight` exact at send time. `t` is the frame-level flush-begin
+    /// stamp; every mail in one flush shares it.
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_sent_event_at(
+        &self,
+        mail_id: MailId,
+        root: MailId,
+        parent_mail: Option<MailId>,
+        sender: MailboxId,
+        recipient: MailboxId,
+        kind: KindId,
+        t: Nanos,
     ) {
         self.push_trace_ring(
             root,
@@ -218,9 +254,17 @@ impl TraceHandle {
                 sender,
                 recipient,
                 kind,
-                t: self.now_nanos(),
+                t,
             },
         );
+    }
+
+    /// iamacoffeepot/aether#1150: the eager half of the producer `Sent`
+    /// hook — increment the root's emit-time `in_flight` count. The
+    /// buffered send path calls this at send time (so settlement stays
+    /// exact and never fires early, per ADR-0082) and defers the `Sent`
+    /// *trace* event to flush via [`Self::record_sent_event_at`].
+    pub fn record_sent_inflight(&self, root: MailId) {
         if root != MailId::NONE {
             self.settlement_counter.record_sent(root);
         }

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -47,8 +47,9 @@ use crate::actor::native::Envelope;
 /// iamacoffeepot/aether#1135). Alias for the actor-layer
 /// [`Envelope`] the `BlobWork` demuxer
 /// builds from the blob's [`Mail`](crate::mail::Mail), with
-/// `t_enqueue ≈ now` / `enqueue_depth = 0` (residence ≈ 0 — the measured
-/// win).
+/// `enqueue_depth = 0` and (iamacoffeepot/aether#1150) `t_enqueue` set to
+/// the blob-pickup instant, so the recipient's `Received` reads a real
+/// `t_received − t_enqueue` drain rather than the pre-#1150 ≈ 0.
 pub type SeizeSeed = Envelope;
 
 /// Default per-cycle envelope cap. Once a worker has dispatched this


### PR DESCRIPTION
## Summary

Producer-side half of the per-mail blob-batch latency spans. Relocates the two trace stamps that the hop decomposes from, **with no wire-schema change** — the `TraceEvent` shape is untouched, only *where* each timestamp is taken moves:

- **`Sent.t` → frame flush-begin.** Stamped once per non-empty flush (top of `flush_outbound_inner`, shared by every mail in the frame) instead of at the per-send call site. The call-site stamp folded "the rest of the handler that ran after the send" into the producer span; the flush-begin anchor drops that smear. The eager settlement-counter increment **stays** at the send call so `in_flight` is exact and chains never settle early (ADR-0082) — `record_sent` splits into `record_sent_inflight` (eager) + `record_sent_event_at` (at flush).
- **In-place blob `t_enqueue` → blob pickup.** Stamped at `BlobWork::run_cycle` entry instead of pop time. Pop time was ≈ `t_received`, collapsing residence to ~0 — the latent bug this fixes. With the pickup anchor, `t_received − t_enqueue` is the real in-blob drain.

The stamp is **per worker**: `run_cycle` takes its own `received` at entry, so a recruited sibling anchors only the groups it claims against its own pickup instant — a mail inherits the pickup of the worker that actually dispatched it. A late-recruited worker's wakeup lands in the queued span, not drain; the serial case keeps a single `received` so a late group's drain grows with its position (the in-blob-serialization signal).

Resulting decomposition (relabeled in the follow-up consumer PR): `t_sent → t_enqueue` = queued, `t_enqueue → t_received` = drain, `t_received → t_finished` = handler.

## Causal-ordering fix

Deferring `Sent` to flush surfaced an ordering inversion: the dispatch loop pushed a parent's `Finished` trace event *before* `ctx` dropped, and `ctx` drop is what flushes a child's buffered `Sent` — so a child's recorded `t_sent` landed just after its parent's `t_finished`, which the trace-walk's causal-tree check rejects. Fixed by dropping `ctx` (flushing child `Sent`s at flush-begin) *before* the `Finished` push, in all three dispatch sites. The invariant is genuinely true (a child is sent during its parent's handler); the deferral just made the recorded stamp race the finish.

## Scope

Substrate producer change only. The harness/report consumption that relabels these to queued/drain/handler columns is the follow-up iamacoffeepot/aether#1151 (blocked on these stamps). Builds on the iamacoffeepot/aether#1135 in-place demux. No public-API or wire change.

Closes iamacoffeepot/aether#1150

## Test plan

- [x] `scripts/preflight.sh` green (fmt + clippy + doc + nextest 1297/1297 + wasm32 cross-build)
- [x] `mail_latency::guided_walk_reconstructs_causal_tree` passes (was the regression the reorder fixes)
- [x] full `mail_latency` + settlement suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)