### PR TITLE
perf(substrate): adopt queued/drain/handler spans in the perf harness

### DIFF
--- a/crates/aether-substrate-bundle/src/bin/perf-compare.rs
+++ b/crates/aether-substrate-bundle/src/bin/perf-compare.rs
@@ -27,7 +27,22 @@ use std::env;
 use std::fs;
 use std::process::{Command, ExitCode};
 
-use aether_substrate_bundle::perf::report::{CompareConfig, TrialReport, compare, markdown};
+use aether_substrate_bundle::perf::report::{
+    CompareConfig, STICKY_MARKER, TRIAL_SCHEMA, TrialReport, compare, markdown, probe_schema,
+};
+
+/// A trial subprocess run that didn't yield a comparable [`TrialReport`].
+enum TrialErr {
+    /// An operational failure — the trial crashed, bad args, unparseable
+    /// output. Non-zero exit (this is what gates the *operational*
+    /// health of the run, ADR-0085 §4).
+    Op(String),
+    /// The trial used a different schema tag than this comparator expects
+    /// — the metric set changed (iamacoffeepot/aether#1151). A paired
+    /// comparison across the change is meaningless, so it is an
+    /// informational skip, not a crash. Carries the trial's tag.
+    Schema(String),
+}
 
 struct Args {
     base: String,
@@ -101,20 +116,45 @@ fn parse_args() -> Result<Args, String> {
     })
 }
 
-fn run_trial(path: &str, extra: &[(String, String)]) -> Result<TrialReport, String> {
+fn run_trial(path: &str, extra: &[(String, String)]) -> Result<TrialReport, TrialErr> {
     let out = Command::new(path)
         .envs(extra.iter().cloned())
         .output()
-        .map_err(|e| format!("spawn {path}: {e}"))?;
+        .map_err(|e| TrialErr::Op(format!("spawn {path}: {e}")))?;
     if !out.status.success() {
-        return Err(format!(
+        return Err(TrialErr::Op(format!(
             "{path} exited {:?}: {}",
             out.status.code(),
             String::from_utf8_lossy(&out.stderr).trim()
-        ));
+        )));
+    }
+    // iamacoffeepot/aether#1151: read the schema tag before the full
+    // parse. A base trial built before the queued/drain/handler migration
+    // carries the retired metric names, and `from_slice::<TrialReport>`
+    // would hard-fail on serde's unknown-`Metric`-variant error. Surface
+    // the transition as its own case so the comparison skips gracefully
+    // rather than reading as an operational crash.
+    if let Some(tag) = probe_schema(&out.stdout)
+        && tag != TRIAL_SCHEMA
+    {
+        return Err(TrialErr::Schema(tag));
     }
     serde_json::from_slice::<TrialReport>(&out.stdout)
-        .map_err(|e| format!("parse trial json from {path}: {e}"))
+        .map_err(|e| TrialErr::Op(format!("parse trial json from {path}: {e}")))
+}
+
+/// A trial used a schema tag this comparator doesn't speak (the metric
+/// set changed, iamacoffeepot/aether#1151). Emit an informational sticky
+/// note and exit 0 — this job never gates (ADR-0085 §4), and the next
+/// comparison resumes once the new schema is on both sides.
+fn schema_skip(side: &str, got: &str) -> ExitCode {
+    println!(
+        "{STICKY_MARKER}\n## dispatch perf\n\n_The {side} trial uses schema `{got}`, but this comparator expects `{TRIAL_SCHEMA}` — the metric set changed (iamacoffeepot/aether#1151), so a paired comparison isn't meaningful this run. The next comparison resumes once the new schema is on both sides._\n"
+    );
+    eprintln!(
+        "perf-compare: {side} schema {got} != expected {TRIAL_SCHEMA} — schema transition, comparison skipped (informational)"
+    );
+    ExitCode::SUCCESS
 }
 
 fn main() -> ExitCode {
@@ -132,14 +172,16 @@ fn main() -> ExitCode {
         eprintln!("perf-compare: trial {}/{}", t + 1, args.k);
         match run_trial(&args.base, &args.base_env) {
             Ok(r) => base_reports.push(r),
-            Err(e) => {
+            Err(TrialErr::Schema(tag)) => return schema_skip("base", &tag),
+            Err(TrialErr::Op(e)) => {
                 eprintln!("perf-compare: base trial {t} failed: {e}");
                 return ExitCode::from(1);
             }
         }
         match run_trial(&args.cand, &args.cand_env) {
             Ok(r) => cand_reports.push(r),
-            Err(e) => {
+            Err(TrialErr::Schema(tag)) => return schema_skip("candidate", &tag),
+            Err(TrialErr::Op(e)) => {
                 eprintln!("perf-compare: candidate trial {t} failed: {e}");
                 return ExitCode::from(1);
             }

--- a/crates/aether-substrate-bundle/src/perf/harness.rs
+++ b/crates/aether-substrate-bundle/src/perf/harness.rs
@@ -330,25 +330,23 @@ pub fn summarize(mut samples: Vec<u64>) -> Stats {
 pub struct CellResult {
     pub workers: usize,
     pub topo: String,
-    /// `t_received − t_sent` — the whole hop. Kept as the headline /
-    /// backward-compatible metric; equals `send_enqueue + residence`
-    /// within clock granularity.
-    pub hop: Stats,
-    /// iamacoffeepot/aether#1134: `t_enqueue − t_sent` — producer-side
-    /// span (rest of the sender's handler + flush + blob pickup + demux
-    /// up to the recipient-inbox deposit).
-    pub send_enqueue: Stats,
-    /// iamacoffeepot/aether#1134: `t_received − t_enqueue` — consumer-side
-    /// queue residence (deposit → the recipient's dispatcher picks it up
-    /// = slot schedule + worker wakeup + recv). The span the fast-path
-    /// inbox-bypass would attack.
-    pub residence: Stats,
-    /// `t_finished − t_received` — in-handler work.
+    /// iamacoffeepot/aether#1150: `t_enqueue − t_sent` (flush-begin → the
+    /// worker picks up the blob this mail rode in / the deposit lands) —
+    /// wakeup + scheduling latency. ~0 on the producer's own warm worker.
+    pub queued: Stats,
+    /// iamacoffeepot/aether#1150: `t_received − t_enqueue` (blob pickup →
+    /// this mail's handler entry) — where in the blob's drain the mail
+    /// landed. The only cardinality-sensitive span: a serial fan-out's
+    /// late leaf waited behind its siblings here, so it reads high by
+    /// design (the scheduler's serialize-vs-recruit choice, not per-mail
+    /// cost — cross-reference `handler` to judge it).
+    pub drain: Stats,
+    /// `t_finished − t_received` — the recipient's own handler work.
     pub handler: Stats,
-    /// iamacoffeepot/aether#1134: scheduler ready-queue depth at deposit
-    /// (`enqueue_depth`), as a distribution — *counts, not nanoseconds*.
-    /// p50 ≈ 0 means residence is dominated by wakeup (empty queue); a
-    /// rising tail means wait-behind-N (offered load).
+    /// iamacoffeepot/aether#1134: scheduler ready-queue depth at the
+    /// deposit (`enqueue_depth`), as a distribution — *counts, not
+    /// nanoseconds*. p50 ≈ 0 means `queued` is wakeup-dominated (empty
+    /// queue); a rising tail means wait-behind-N (offered load).
     pub depth: Stats,
 }
 
@@ -597,9 +595,8 @@ pub fn run_sweep(cfg: &SweepConfig) -> Vec<CellResult> {
             }
             let mails = fold_nodes(entries);
 
-            let mut hop = Vec::new();
-            let mut send_enqueue = Vec::new();
-            let mut residence = Vec::new();
+            let mut queued = Vec::new();
+            let mut drain = Vec::new();
             let mut handler = Vec::new();
             let mut depth = Vec::new();
             for node in &mails {
@@ -607,16 +604,16 @@ pub fn run_sweep(cfg: &SweepConfig) -> Vec<CellResult> {
                     continue;
                 }
                 if let Some(recv) = node.t_received {
-                    hop.push(recv.0.saturating_sub(node.t_sent.0));
                     if let Some(fin) = node.t_finished {
                         handler.push(fin.0.saturating_sub(recv.0));
                     }
-                    // iamacoffeepot/aether#1134: split the hop at the
-                    // deposit instant. `t_enqueue` lands with `Received`,
-                    // so it is present exactly when `t_received` is.
+                    // iamacoffeepot/aether#1150: `t_enqueue` (blob pickup)
+                    // lands with `Received`, so it is present exactly when
+                    // `t_received` is. `queued` = flush-begin → pickup;
+                    // `drain` = pickup → this mail's handler entry.
                     if let Some(enq) = node.t_enqueue {
-                        send_enqueue.push(enq.0.saturating_sub(node.t_sent.0));
-                        residence.push(recv.0.saturating_sub(enq.0));
+                        queued.push(enq.0.saturating_sub(node.t_sent.0));
+                        drain.push(recv.0.saturating_sub(enq.0));
                     }
                 }
                 if let Some(d) = node.enqueue_depth {
@@ -626,9 +623,8 @@ pub fn run_sweep(cfg: &SweepConfig) -> Vec<CellResult> {
             rows.push(CellResult {
                 workers,
                 topo: topo.name.clone(),
-                hop: summarize(hop),
-                send_enqueue: summarize(send_enqueue),
-                residence: summarize(residence),
+                queued: summarize(queued),
+                drain: summarize(drain),
                 handler: summarize(handler),
                 depth: summarize(depth),
             });

--- a/crates/aether-substrate-bundle/src/perf/report.rs
+++ b/crates/aether-substrate-bundle/src/perf/report.rs
@@ -23,19 +23,21 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Which leg of the per-hop measurement a cell reports.
+/// Which per-mail span a cell reports (iamacoffeepot/aether#1150). Each
+/// measures one property, so a regression points at a mechanism rather
+/// than a smeared rollup.
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum Metric {
-    /// `t_received − t_sent`: the whole hop (enqueue + worker pickup).
-    Hop,
-    /// iamacoffeepot/aether#1134: `t_enqueue − t_sent`: producer-side
-    /// (rest of the sender's handler + flush + blob pickup + demux).
-    SendEnqueue,
-    /// iamacoffeepot/aether#1134: `t_received − t_enqueue`: consumer-side
-    /// queue residence (slot schedule + worker wakeup + recv).
-    Residence,
-    /// `t_finished − t_received`: in-handler work.
+    /// `t_enqueue − t_sent`: flush-begin → the worker picks up the blob —
+    /// wakeup / scheduling latency. Tight on a warm worker.
+    Queued,
+    /// `t_received − t_enqueue`: blob pickup → this mail's handler entry —
+    /// where in the blob's drain it landed. The only cardinality-sensitive
+    /// span (a serial fan-out's late leaf waited behind its siblings), so
+    /// high-variance by design.
+    Drain,
+    /// `t_finished − t_received`: the recipient's own handler work.
     Handler,
 }
 
@@ -43,9 +45,8 @@ impl Metric {
     #[must_use]
     pub fn label(self) -> &'static str {
         match self {
-            Self::Hop => "hop",
-            Self::SendEnqueue => "send_enqueue",
-            Self::Residence => "residence",
+            Self::Queued => "queued",
+            Self::Drain => "drain",
             Self::Handler => "handler",
         }
     }
@@ -101,13 +102,15 @@ pub struct TrialReport {
     pub cells: Vec<CellJson>,
 }
 
-/// Current trial schema tag.
-pub const TRIAL_SCHEMA: &str = "aether.perf.trial.v1";
+/// Current trial schema tag. Bumped to `v2` by iamacoffeepot/aether#1150
+/// when `hop` / `send_enqueue` / `residence` gave way to the
+/// `queued` / `drain` / `handler` span model.
+pub const TRIAL_SCHEMA: &str = "aether.perf.trial.v2";
 
 impl TrialReport {
     /// Build a trial report from a sweep's [`CellResult`]s — each cell
-    /// expands to four `CellJson` rows (`hop` + `send_enqueue` +
-    /// `residence` + `handler`). `depth` is a count, not a latency, so it
+    /// expands to three `CellJson` rows (`queued` + `drain` + `handler`,
+    /// iamacoffeepot/aether#1150). `depth` is a count, not a latency, so it
     /// is omitted from the latency compare (it lives only in the on-demand
     /// observe table).
     ///
@@ -119,12 +122,11 @@ impl TrialReport {
         pace_hz: Option<u64>,
         git_sha: Option<String>,
     ) -> Self {
-        let mut out = Vec::with_capacity(cells.len() * 4);
+        let mut out = Vec::with_capacity(cells.len() * 3);
         for c in cells {
             for (metric, s) in [
-                (Metric::Hop, &c.hop),
-                (Metric::SendEnqueue, &c.send_enqueue),
-                (Metric::Residence, &c.residence),
+                (Metric::Queued, &c.queued),
+                (Metric::Drain, &c.drain),
                 (Metric::Handler, &c.handler),
             ] {
                 out.push(CellJson {
@@ -470,7 +472,7 @@ mod tests {
     use super::*;
 
     /// Build a K-trial side from a per-trial `p50` series for one cell
-    /// (`fanout-8 @ 11w`, hop). Other percentiles track p50 ×1.2 / ×1.5
+    /// (`fanout-8 @ 11w`, drain). Other percentiles track p50 ×1.2 / ×1.5
     /// so the cell is well-formed; tests assert on p50.
     #[allow(
         clippy::cast_precision_loss,
@@ -487,7 +489,7 @@ mod tests {
                 cells: vec![CellJson {
                     workers: 11,
                     topo: "fanout-8".to_owned(),
-                    metric: Metric::Hop,
+                    metric: Metric::Drain,
                     p50,
                     p90: (p50 as f64 * 1.2) as u64,
                     p99: (p50 as f64 * 1.5) as u64,

--- a/crates/aether-substrate-bundle/src/perf/report.rs
+++ b/crates/aether-substrate-bundle/src/perf/report.rs
@@ -151,6 +151,25 @@ impl TrialReport {
     }
 }
 
+/// Read just the `schema` tag from a trial's JSON, ignoring the rest.
+/// The comparator uses this to detect a base-vs-candidate schema
+/// transition (a changed metric set) *before* the full [`TrialReport`]
+/// parse — which would otherwise hard-fail on serde's
+/// unknown-`Metric`-variant error when an older base trial still carries
+/// the retired `hop` / `send_enqueue` / `residence` names
+/// (iamacoffeepot/aether#1151). `None` if the bytes aren't a JSON object
+/// carrying a string `schema` field.
+#[must_use]
+pub fn probe_schema(json: &[u8]) -> Option<String> {
+    #[derive(Deserialize)]
+    struct SchemaProbe {
+        schema: String,
+    }
+    serde_json::from_slice::<SchemaProbe>(json)
+        .ok()
+        .map(|p| p.schema)
+}
+
 #[derive(Clone, Copy)]
 enum Pct {
     P50,
@@ -519,6 +538,17 @@ mod tests {
         ]);
         let rep = compare(&base, &cand, CompareConfig::default());
         assert_eq!(p50_verdict(&rep), Verdict::Improved);
+    }
+
+    #[test]
+    fn probe_schema_reads_tag_past_unknown_metric_variants() {
+        // An older base trial carries the retired `hop` variant; the probe
+        // must read its schema tag without choking on it (a full parse
+        // would hard-fail on the unknown `Metric` variant — that is the
+        // whole point of probing first, iamacoffeepot/aether#1151).
+        let v1 = br#"{"schema":"aether.perf.trial.v1","cells":[{"metric":"hop","p50":1}]}"#;
+        assert_eq!(probe_schema(v1).as_deref(), Some("aether.perf.trial.v1"));
+        assert_eq!(probe_schema(b"not json"), None);
     }
 
     #[test]

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -819,25 +819,22 @@ fn print_observe_tables(rows: &[CellResult], pace_hz: Option<u64>) {
     println!("{OBSERVE_FRAMES} frames/cell (wide cells fewer); relay-hop (`Ping`) samples only.");
     println!();
 
-    // iamacoffeepot/aether#1134: HOP now splits into SEND→ENQUEUE
-    // (producer side) + QUEUE RESIDENCE (consumer side). HOP ≈ their sum
-    // within clock granularity; it stays as the headline continuity row.
+    // iamacoffeepot/aether#1150: the per-mail hop decomposes into three
+    // single-property spans. QUEUED + DRAIN sum to the old full hop within
+    // clock granularity; each now measures one thing (wakeup vs in-blob
+    // serialization vs handler work).
     for (label, pick) in [
         (
-            "HOP          (t_received - t_sent: full hop = send→enqueue + residence)",
+            "QUEUED       (t_enqueue - t_sent: flush-begin → worker picks up the blob = wakeup/schedule)",
             0usize,
         ),
         (
-            "SEND→ENQUEUE (t_enqueue - t_sent: producer handler + flush + blob demux to deposit)",
+            "DRAIN        (t_received - t_enqueue: pickup → handler entry = where in the blob's drain it landed)",
             1,
         ),
         (
-            "QUEUE RESID. (t_received - t_enqueue: deposit → dispatcher pickup = schedule + wakeup)",
-            2,
-        ),
-        (
             "HANDLER DUR  (t_finished - t_received: relay forward work)",
-            3,
+            2,
         ),
     ] {
         println!("-- {label} --");
@@ -847,9 +844,8 @@ fn print_observe_tables(rows: &[CellResult], pace_hz: Option<u64>) {
         );
         for r in rows {
             let s = match pick {
-                0 => r.hop,
-                1 => r.send_enqueue,
-                2 => r.residence,
+                0 => r.queued,
+                1 => r.drain,
                 _ => r.handler,
             };
             println!(
@@ -869,7 +865,7 @@ fn print_observe_tables(rows: &[CellResult], pace_hz: Option<u64>) {
 
     // iamacoffeepot/aether#1134: enqueue depth is a *count* (scheduler
     // ready-queue len at deposit), printed raw — not µs. p50 ≈ 0 means
-    // residence is wakeup-dominated (empty queue); a rising tail is
+    // `queued` is wakeup-dominated (empty queue); a rising tail is
     // wait-behind-N offered load (the fan-out queueing signal).
     println!(
         "-- ENQUEUE DEPTH (scheduler ready-queue len at deposit; counts, not µs: 0 = wakeup, n = behind-n) --"


### PR DESCRIPTION
## Summary

Consumer half of iamacoffeepot/aether#1150 (the producer-side stamps merged in iamacoffeepot/aether#1153). Rolls the relocated stamps through every performance-measurement surface, replacing the old `hop` / `send_enqueue` / `residence` triple with three single-property spans so a regression points at a mechanism instead of a smeared rollup:

- **queued** = `t_enqueue − t_sent` (flush-begin → the worker picks up the blob): wakeup / scheduling latency, ~0 on a warm worker.
- **drain** = `t_received − t_enqueue` (blob pickup → this mail's handler entry): where in the blob's drain the mail landed. The only cardinality-sensitive span — a serial fan-out's late leaf waited behind its siblings here — so high-variance by design.
- **handler** = `t_finished − t_received`: the recipient's own work.

## Surfaces

- `perf/harness.rs` — `CellResult` fields + the `run_sweep` harvest/fold (the spans were already computed under the old names, so this is a rename + dropping the `hop` accumulator).
- `perf/report.rs` — the `Metric` enum + labels, `from_cells` (3 rows/cell), the trial schema tag `aether.perf.trial.v1 → v2`, and a new `probe_schema` helper (reads only the schema tag, ignoring the cells).
- `bin/perf-compare.rs` — **decodes by schema tag**: across the `v1 → v2` migration the merge-base trial still emits the retired metric names, which would crash the v2 comparator's full parse on serde's unknown-variant error. It now probes the tag first and, on a base-vs-candidate mismatch, emits an informational sticky note and exits 0 (this job never gates — ADR-0085 §4). The next comparison resumes once the new schema is on both sides.
- `test_bench/mail_latency.rs` — the on-demand observe table (column swap, HOP row dropped).
- `bin/perf-trial.rs` — no change (goes through `from_cells`); column labels flow from `Metric::label`, and the ADR-0085 CI sticky comment re-renders the new labels automatically.

## Decisions

- **`hop` dropped** rather than kept as a rollup column: the `v1 → v2` schema break already severs historical continuity, and `queued + drain` recovers it.
- **`CompareConfig` stays one global rule.** Its floor is `max(effect_floor_iqr × IQR, rel_floor × base, abs_floor)`, so the IQR term already self-widens the bar for high-variance `drain` while the abs/rel floors govern the tight `queued` / `handler` spans. Static per-span bands would just be guessed constants — the existing rule adapts.

## Validation

Ran the live matrix (`lifecycle_latency_observe`, release, flat-out). `drain` p50 is flat at ~0.08µs for chains and climbs ~10× to ~0.83µs at fanout-8 — the in-blob serialization signal, which read ≈0 before the stamp fix. `queued` rises gently with width; `handler` stays isolated.

Closes iamacoffeepot/aether#1151

## Test plan

- [x] `scripts/preflight.sh` green (fmt + clippy + doc + nextest 1299/1299 + wasm32 cross-build)
- [x] `perf::report::tests` verdict suite + `probe_schema` test pass
- [x] `mail_latency` suite green
- [x] live matrix renders the new spans with the expected fanout-8 `drain` signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)