### PR TITLE
perf(substrate): add the construct span (blob build → flush)

### DIFF
--- a/crates/aether-actor/src/trace_ring.rs
+++ b/crates/aether-actor/src/trace_ring.rs
@@ -190,6 +190,7 @@ mod tests {
             sender: MailboxId(1),
             recipient: MailboxId(2),
             kind: aether_data::KindId(3),
+            t_construct_start: Nanos(0),
             t: Nanos(0),
         }
     }

--- a/crates/aether-capabilities/src/trace_walk.rs
+++ b/crates/aether-capabilities/src/trace_walk.rs
@@ -173,6 +173,7 @@ pub fn fold_nodes(entries: impl IntoIterator<Item = TraceRingEntry>) -> Vec<Mail
                 sender,
                 recipient,
                 kind,
+                t_construct_start,
                 t,
                 ..
             } => {
@@ -181,6 +182,7 @@ pub fn fold_nodes(entries: impl IntoIterator<Item = TraceRingEntry>) -> Vec<Mail
                     sender,
                     recipient,
                     kind,
+                    t_construct_start,
                     t_sent: t,
                 });
             }
@@ -220,6 +222,7 @@ pub fn fold_nodes(entries: impl IntoIterator<Item = TraceRingEntry>) -> Vec<Mail
                 sender: sent.sender,
                 recipient: sent.recipient,
                 kind: sent.kind,
+                t_construct_start: sent.t_construct_start,
                 t_sent: sent.t_sent,
                 t_enqueue: node.t_enqueue,
                 enqueue_depth: node.enqueue_depth,
@@ -246,6 +249,7 @@ struct SentFields {
     sender: MailboxId,
     recipient: MailboxId,
     kind: KindId,
+    t_construct_start: Nanos,
     t_sent: Nanos,
 }
 
@@ -280,6 +284,9 @@ mod tests {
                 sender: mail_id.sender,
                 recipient: MailboxId(recipient),
                 kind: KindId(0xAB),
+                // iamacoffeepot/aether#1158: fixture construct-start ==
+                // flush-begin (eager-path equivalent, construct ≈ 0).
+                t_construct_start: Nanos(mail_id.correlation_id),
                 t: Nanos(mail_id.correlation_id),
             },
         }

--- a/crates/aether-kinds/src/trace.rs
+++ b/crates/aether-kinds/src/trace.rs
@@ -72,6 +72,16 @@ pub enum TraceEvent {
         sender: MailboxId,
         recipient: MailboxId,
         kind: KindId,
+        /// iamacoffeepot/aether#1158: the instant the producer's
+        /// outbound blob **opened** — the first buffered send of the
+        /// flush window (stamped once when the handler's outbound buffer
+        /// transitions empty→non-empty, shared by every mail in the
+        /// frame). Eager paths (`wait_reply`-free direct routes,
+        /// chassis-root pushes, wasm trampoline) route immediately, so
+        /// their construct-start *is* `t` (construct ≈ 0). `t −
+        /// t_construct_start` is the **construct** span (the producer
+        /// building the blob), the producer-side leg ahead of `queued`.
+        t_construct_start: Nanos,
         /// iamacoffeepot/aether#1150: for buffered sends this is the
         /// frame's **flush-begin** instant (stamped once when the handler's
         /// outbound buffer flushes, shared by every mail in the frame), not
@@ -188,6 +198,13 @@ pub struct MailNodeWire {
     pub sender: MailboxId,
     pub recipient: MailboxId,
     pub kind: KindId,
+    /// iamacoffeepot/aether#1158: the instant the producer's outbound
+    /// blob opened (the first buffered send of the flush window), seeded
+    /// from the `Sent` event's `t_construct_start`. Always present (the
+    /// `Sent` event always carries it). `t_sent − t_construct_start` is
+    /// the **construct** span (the producer building the blob); on eager
+    /// paths it equals `t_sent`, so construct ≈ 0.
+    pub t_construct_start: Nanos,
     pub t_sent: Nanos,
     /// iamacoffeepot/aether#1134, re-anchored by
     /// iamacoffeepot/aether#1150 (the `Received` event's `t_enqueue`):

--- a/crates/aether-mcp/src/args.rs
+++ b/crates/aether-mcp/src/args.rs
@@ -321,6 +321,12 @@ pub struct MailNodeJson {
     pub recipient: String,
     /// Tagged kind id (`knd-…`) of the payload schema.
     pub kind: String,
+    /// iamacoffeepot/aether#1158: the instant the producer's outbound
+    /// blob opened (the first buffered send of the flush window).
+    /// `t_sent − t_construct_start` is the **construct** span (the
+    /// producer building the blob); on eager paths it equals `t_sent`.
+    /// Monotonic nanoseconds since substrate boot.
+    pub t_construct_start: u64,
     /// Monotonic nanoseconds since substrate boot.
     pub t_sent: u64,
     /// Set once the recipient dispatcher entered the handler; `null`

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -1154,6 +1154,7 @@ fn mail_node_to_json(node: MailNodeWire, names: Option<&EngineNames>) -> MailNod
         sender: mailbox_id_to_tagged(node.sender, names),
         recipient: mailbox_id_to_tagged(node.recipient, names),
         kind: kind_id_to_tagged(node.kind, names),
+        t_construct_start: node.t_construct_start.0,
         t_sent: node.t_sent.0,
         t_received: node.t_received.map(|n| n.0),
         t_finished: node.t_finished.map(|n| n.0),

--- a/crates/aether-substrate-bundle/src/bin/perf-plot.rs
+++ b/crates/aether-substrate-bundle/src/bin/perf-plot.rs
@@ -116,16 +116,34 @@ fn quantile_us(sorted: &[u64], q: f64) -> f64 {
     (sorted[idx.min(sorted.len() - 1)].max(1) as f64) / 1000.0
 }
 
-/// Render one cell's three spans as overlaid log-x histograms (outline /
-/// step lines so three series read cleanly), with a legend carrying each
-/// span's p50.
-fn render_cell(path: &Path, c: &CellSamples) -> Result<(), Box<dyn Error>> {
-    let spans: [(&str, &[u64], RGBColor); 4] = [
+/// The cell's four spans paired with their plot colour + label, in
+/// lifecycle order. Shared by both renderers so the mapping lives in one
+/// place (and the array isn't a duplicated fragment across them).
+fn cell_spans(c: &CellSamples) -> [(&'static str, &[u64], RGBColor); 4] {
+    [
         ("construct", &c.construct, CONSTRUCT),
         ("queued", &c.queued, BLUE),
         ("drain", &c.drain, RED),
         ("handler", &c.handler, GREEN),
-    ];
+    ]
+}
+
+/// Encode a finished RGB frame buffer to a PNG at `path` (shared by both
+/// renderers).
+fn write_png(path: &Path, buf: &[u8]) -> Result<(), Box<dyn Error>> {
+    let file = fs::File::create(path)?;
+    let mut enc = png::Encoder::new(BufWriter::new(file), WIDTH, HEIGHT);
+    enc.set_color(png::ColorType::Rgb);
+    enc.set_depth(png::BitDepth::Eight);
+    enc.write_header()?.write_image_data(buf)?;
+    Ok(())
+}
+
+/// Render one cell's three spans as overlaid log-x histograms (outline /
+/// step lines so three series read cleanly), with a legend carrying each
+/// span's p50.
+fn render_cell(path: &Path, c: &CellSamples) -> Result<(), Box<dyn Error>> {
+    let spans = cell_spans(c);
 
     // Combined positive range across the spans, in microseconds. A span
     // sample can be 0ns (sub-resolution); clamp to 1ns so the log axis
@@ -212,12 +230,7 @@ fn render_cell(path: &Path, c: &CellSamples) -> Result<(), Box<dyn Error>> {
         root.present()?;
     }
 
-    let file = fs::File::create(path)?;
-    let mut enc = png::Encoder::new(BufWriter::new(file), WIDTH, HEIGHT);
-    enc.set_color(png::ColorType::Rgb);
-    enc.set_depth(png::BitDepth::Eight);
-    enc.write_header()?.write_image_data(&buf)?;
-    Ok(())
+    write_png(path, &buf)
 }
 
 /// One per-percentile point for the latency-by-percentile plot: the
@@ -243,12 +256,7 @@ struct PctSeries {
 /// steep tail reads as a tall bar and the flat body as a short one.
 /// Companion to the histogram in [`render_cell`] (iamacoffeepot/aether#1155).
 fn render_cell_percentiles(path: &Path, c: &CellSamples) -> Result<(), Box<dyn Error>> {
-    let spans: [(&str, &[u64], RGBColor); 4] = [
-        ("construct", &c.construct, CONSTRUCT),
-        ("queued", &c.queued, BLUE),
-        ("drain", &c.drain, RED),
-        ("handler", &c.handler, GREEN),
-    ];
+    let spans = cell_spans(c);
 
     let percentiles: Vec<u32> = (5..=95).step_by(5).collect();
     let mut series: Vec<PctSeries> = Vec::new();
@@ -339,10 +347,5 @@ fn render_cell_percentiles(path: &Path, c: &CellSamples) -> Result<(), Box<dyn E
         root.present()?;
     }
 
-    let file = fs::File::create(path)?;
-    let mut enc = png::Encoder::new(BufWriter::new(file), WIDTH, HEIGHT);
-    enc.set_color(png::ColorType::Rgb);
-    enc.set_depth(png::BitDepth::Eight);
-    enc.write_header()?.write_image_data(&buf)?;
-    Ok(())
+    write_png(path, &buf)
 }

--- a/crates/aether-substrate-bundle/src/bin/perf-plot.rs
+++ b/crates/aether-substrate-bundle/src/bin/perf-plot.rs
@@ -1,8 +1,8 @@
 //! `aether-perf-plot` (iamacoffeepot/aether#1155): run one latency sweep
-//! and render each cell's `queued` / `drain` / `handler` sample
-//! distributions as a single overlaid PNG, so the shape the percentiles
-//! hide (drain's spread vs the tight queued / handler) is visible at a
-//! glance.
+//! and render each cell's `construct` / `queued` / `drain` / `handler`
+//! sample distributions (iamacoffeepot/aether#1158) as a single overlaid
+//! PNG, so the shape the percentiles hide (drain's spread vs the tight
+//! construct / queued / handler) is visible at a glance.
 //!
 //! Diagnostics go to stderr; PNGs land in `AETHER_PERF_PLOT_DIR`
 //! (default `./perf-plots`), one per `(topology × worker-count)` cell.
@@ -42,6 +42,10 @@ const NBINS: usize = 48;
 /// TTF, rendered at its default (Regular) instance. Embedding keeps the
 /// render deterministic with zero system-font / CI dependency.
 const FONT: &[u8] = include_bytes!("../../assets/fonts/RobotoMono.ttf");
+
+/// iamacoffeepot/aether#1158: the `construct` span's plot color. Orange,
+/// clearly distinct from the queued/drain/handler `BLUE`/`RED`/`GREEN`.
+const CONSTRUCT: RGBColor = RGBColor(255, 140, 0);
 
 fn main() -> ExitCode {
     let frames: u32 = env::var("AETHER_PERF_FRAMES")
@@ -116,7 +120,8 @@ fn quantile_us(sorted: &[u64], q: f64) -> f64 {
 /// step lines so three series read cleanly), with a legend carrying each
 /// span's p50.
 fn render_cell(path: &Path, c: &CellSamples) -> Result<(), Box<dyn Error>> {
-    let spans: [(&str, &[u64], RGBColor); 3] = [
+    let spans: [(&str, &[u64], RGBColor); 4] = [
+        ("construct", &c.construct, CONSTRUCT),
         ("queued", &c.queued, BLUE),
         ("drain", &c.drain, RED),
         ("handler", &c.handler, GREEN),
@@ -238,7 +243,8 @@ struct PctSeries {
 /// steep tail reads as a tall bar and the flat body as a short one.
 /// Companion to the histogram in [`render_cell`] (iamacoffeepot/aether#1155).
 fn render_cell_percentiles(path: &Path, c: &CellSamples) -> Result<(), Box<dyn Error>> {
-    let spans: [(&str, &[u64], RGBColor); 3] = [
+    let spans: [(&str, &[u64], RGBColor); 4] = [
+        ("construct", &c.construct, CONSTRUCT),
         ("queued", &c.queued, BLUE),
         ("drain", &c.drain, RED),
         ("handler", &c.handler, GREEN),

--- a/crates/aether-substrate-bundle/src/perf/harness.rs
+++ b/crates/aether-substrate-bundle/src/perf/harness.rs
@@ -334,6 +334,9 @@ pub fn summarize(mut samples: Vec<u64>) -> Stats {
 pub struct CellSamples {
     pub workers: usize,
     pub topo: String,
+    /// iamacoffeepot/aether#1158: `t_sent − t_construct_start` (flush-begin
+    /// → blob open) — the producer building the blob.
+    pub construct: Vec<u64>,
     pub queued: Vec<u64>,
     pub drain: Vec<u64>,
     pub handler: Vec<u64>,
@@ -347,6 +350,7 @@ impl CellSamples {
         CellResult {
             workers: self.workers,
             topo: self.topo,
+            construct: summarize(self.construct),
             queued: summarize(self.queued),
             drain: summarize(self.drain),
             handler: summarize(self.handler),
@@ -360,6 +364,11 @@ impl CellSamples {
 pub struct CellResult {
     pub workers: usize,
     pub topo: String,
+    /// iamacoffeepot/aether#1158: `t_sent − t_construct_start` (blob open →
+    /// flush-begin) — the producer-side time spent building the blob, the
+    /// first leg of the four-stage lifecycle. ~0 on eager (non-buffered)
+    /// paths, where construct-start *is* `t_sent`.
+    pub construct: Stats,
     /// iamacoffeepot/aether#1150: `t_enqueue − t_sent` (flush-begin → the
     /// worker picks up the blob this mail rode in / the deposit lands) —
     /// wakeup + scheduling latency. ~0 on the producer's own warm worker.
@@ -685,6 +694,7 @@ pub fn run_sweep_samples(cfg: &SweepConfig) -> Vec<CellSamples> {
             }
             let mails = fold_nodes(entries);
 
+            let mut construct = Vec::new();
             let mut queued = Vec::new();
             let mut drain = Vec::new();
             let mut handler = Vec::new();
@@ -697,11 +707,16 @@ pub fn run_sweep_samples(cfg: &SweepConfig) -> Vec<CellSamples> {
                     if let Some(fin) = node.t_finished {
                         handler.push(fin.0.saturating_sub(recv.0));
                     }
+                    // iamacoffeepot/aether#1158: `t_construct_start` (blob
+                    // open) rides the `Sent` event, always present. The
+                    // four spans are non-overlapping and cover first-send →
+                    // handler-done: `construct` = blob open → flush-begin;
                     // iamacoffeepot/aether#1150: `t_enqueue` (blob pickup)
                     // lands with `Received`, so it is present exactly when
                     // `t_received` is. `queued` = flush-begin → pickup;
                     // `drain` = pickup → this mail's handler entry.
                     if let Some(enq) = node.t_enqueue {
+                        construct.push(node.t_sent.0.saturating_sub(node.t_construct_start.0));
                         queued.push(enq.0.saturating_sub(node.t_sent.0));
                         drain.push(recv.0.saturating_sub(enq.0));
                     }
@@ -713,6 +728,7 @@ pub fn run_sweep_samples(cfg: &SweepConfig) -> Vec<CellSamples> {
             rows.push(CellSamples {
                 workers,
                 topo: topo.name.clone(),
+                construct,
                 queued,
                 drain,
                 handler,

--- a/crates/aether-substrate-bundle/src/perf/report.rs
+++ b/crates/aether-substrate-bundle/src/perf/report.rs
@@ -29,6 +29,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum Metric {
+    /// iamacoffeepot/aether#1158: `t_sent − t_construct_start`: blob open →
+    /// flush-begin — the producer-side time spent building the blob, the
+    /// first leg of the four-stage lifecycle. ~0 on eager (non-buffered)
+    /// paths.
+    Construct,
     /// `t_enqueue − t_sent`: flush-begin → the worker picks up the blob —
     /// wakeup / scheduling latency. Tight on a warm worker.
     Queued,
@@ -45,6 +50,7 @@ impl Metric {
     #[must_use]
     pub fn label(self) -> &'static str {
         match self {
+            Self::Construct => "construct",
             Self::Queued => "queued",
             Self::Drain => "drain",
             Self::Handler => "handler",
@@ -104,15 +110,17 @@ pub struct TrialReport {
 
 /// Current trial schema tag. Bumped to `v2` by iamacoffeepot/aether#1150
 /// when `hop` / `send_enqueue` / `residence` gave way to the
-/// `queued` / `drain` / `handler` span model.
-pub const TRIAL_SCHEMA: &str = "aether.perf.trial.v2";
+/// `queued` / `drain` / `handler` span model; to `v3` by
+/// iamacoffeepot/aether#1158 when `construct` joined as the producer-side
+/// first leg, completing the four-stage lifecycle.
+pub const TRIAL_SCHEMA: &str = "aether.perf.trial.v3";
 
 impl TrialReport {
     /// Build a trial report from a sweep's [`CellResult`]s — each cell
-    /// expands to three `CellJson` rows (`queued` + `drain` + `handler`,
-    /// iamacoffeepot/aether#1150). `depth` is a count, not a latency, so it
-    /// is omitted from the latency compare (it lives only in the on-demand
-    /// observe table).
+    /// expands to four `CellJson` rows (`construct` + `queued` + `drain` +
+    /// `handler`, in lifecycle order; iamacoffeepot/aether#1158). `depth`
+    /// is a count, not a latency, so it is omitted from the latency compare
+    /// (it lives only in the on-demand observe table).
     ///
     /// [`CellResult`]: super::harness::CellResult
     #[must_use]
@@ -122,9 +130,10 @@ impl TrialReport {
         pace_hz: Option<u64>,
         git_sha: Option<String>,
     ) -> Self {
-        let mut out = Vec::with_capacity(cells.len() * 3);
+        let mut out = Vec::with_capacity(cells.len() * 4);
         for c in cells {
             for (metric, s) in [
+                (Metric::Construct, &c.construct),
                 (Metric::Queued, &c.queued),
                 (Metric::Drain, &c.drain),
                 (Metric::Handler, &c.handler),

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -819,22 +819,27 @@ fn print_observe_tables(rows: &[CellResult], pace_hz: Option<u64>) {
     println!("{OBSERVE_FRAMES} frames/cell (wide cells fewer); relay-hop (`Ping`) samples only.");
     println!();
 
-    // iamacoffeepot/aether#1150: the per-mail hop decomposes into three
-    // single-property spans. QUEUED + DRAIN sum to the old full hop within
-    // clock granularity; each now measures one thing (wakeup vs in-blob
+    // iamacoffeepot/aether#1158: the per-mail lifecycle decomposes into
+    // four non-overlapping single-property spans covering first-send →
+    // handler-done. CONSTRUCT + QUEUED + DRAIN sum to the producer→pickup
+    // span; each measures one thing (blob build vs wakeup vs in-blob
     // serialization vs handler work).
     for (label, pick) in [
         (
-            "QUEUED       (t_enqueue - t_sent: flush-begin → worker picks up the blob = wakeup/schedule)",
+            "CONSTRUCT    (t_sent - t_construct_start: blob open → flush-begin = producer builds the blob)",
             0usize,
         ),
         (
-            "DRAIN        (t_received - t_enqueue: pickup → handler entry = where in the blob's drain it landed)",
+            "QUEUED       (t_enqueue - t_sent: flush-begin → worker picks up the blob = wakeup/schedule)",
             1,
         ),
         (
-            "HANDLER DUR  (t_finished - t_received: relay forward work)",
+            "DRAIN        (t_received - t_enqueue: pickup → handler entry = where in the blob's drain it landed)",
             2,
+        ),
+        (
+            "HANDLER DUR  (t_finished - t_received: relay forward work)",
+            3,
         ),
     ] {
         println!("-- {label} --");
@@ -844,8 +849,9 @@ fn print_observe_tables(rows: &[CellResult], pace_hz: Option<u64>) {
         );
         for r in rows {
             let s = match pick {
-                0 => r.queued,
-                1 => r.drain,
+                0 => r.construct,
+                1 => r.queued,
+                2 => r.drain,
                 _ => r.handler,
             };
             println!(

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -44,6 +44,8 @@ use std::sync::mpsc::{Receiver, RecvTimeoutError};
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
+use aether_kinds::trace::Nanos;
+
 use crate::actor::native::envelope::Envelope;
 use crate::chassis::ctx::ChassisCtx;
 use crate::mail::mailer::Mailer;
@@ -105,6 +107,14 @@ struct OutboundBuffer {
     /// Whether a ring blob is currently open — between the first send of
     /// a flush window and the flush's `seal`.
     blob_open: bool,
+    /// iamacoffeepot/aether#1158: the instant this flush window's blob
+    /// **opened** — stamped at the first buffered send (the `blob_open`
+    /// false→true transition), shared by every mail in the window. The
+    /// flush reads it as each deferred `Sent`'s `t_construct_start`
+    /// (falling back to `flush_begin` if somehow unset) so `t_sent −
+    /// t_construct_start` is the **construct** span, and resets it to
+    /// `None` after draining so the next window re-stamps.
+    construct_start: Option<Nanos>,
     /// Per-mail route metadata for the current flush window.
     mails: Vec<PendingMail>,
 }
@@ -114,6 +124,7 @@ impl OutboundBuffer {
         Self {
             ring: None,
             blob_open: false,
+            construct_start: None,
             mails: Vec::new(),
         }
     }
@@ -575,13 +586,22 @@ impl NativeBinding {
         // send (after a consumer frees space) can still extend it.
         let payload = {
             let OutboundBuffer {
-                ring, blob_open, ..
+                ring,
+                blob_open,
+                construct_start,
+                ..
             } = &mut *buf;
             let ring =
                 ring.get_or_insert_with(|| Arc::new(MailRing::with_capacity(ACTOR_RING_BYTES)));
             if !*blob_open {
                 ring.open_blob();
                 *blob_open = true;
+                // iamacoffeepot/aether#1158: the blob just opened — stamp
+                // the construct-start instant shared by every mail in this
+                // flush window. `t_sent − t_construct_start` (flush-begin −
+                // this) is the **construct** span (the producer building
+                // the blob).
+                *construct_start = Some(self.mailer.now_nanos());
             }
             match ring.append(recipient, kind, bytes) {
                 Ok(loc) => PendingPayload::InRing(loc),
@@ -666,6 +686,12 @@ impl NativeBinding {
     /// return stays free.
     fn flush_outbound_inner(&self, allow_blob: bool) {
         let flush_begin;
+        // iamacoffeepot/aether#1158: the construct-start anchor stamped
+        // when this window's blob opened (`push_envelope_buffered`). Read
+        // it here and reset for the next window; fall back to `flush_begin`
+        // (construct ≈ 0) on the impossible `None` so the field is never
+        // a wire hole.
+        let construct_start;
         let routed: Vec<Mail> = {
             let mut buf = self
                 .outbound
@@ -680,9 +706,13 @@ impl NativeBinding {
                 buf.blob_open = false;
             }
             if buf.mails.is_empty() {
+                // Reset the stale anchor so the next window re-stamps.
+                buf.construct_start = None;
                 return;
             }
             flush_begin = self.mailer.now_nanos();
+            // Take the anchor and reset so the next blob re-stamps.
+            construct_start = buf.construct_start.take().unwrap_or(flush_begin);
             let OutboundBuffer { ring, mails, .. } = &mut *buf;
             let ring = ring.as_ref();
             mails
@@ -715,6 +745,7 @@ impl NativeBinding {
                 self.self_mailbox,
                 mail.recipient,
                 mail.kind,
+                construct_start,
                 flush_begin,
             );
         }

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -193,6 +193,10 @@ impl Mailer {
     /// explicit flush-begin timestamp (no settlement bump — that fired
     /// eagerly via [`Self::record_sent_inflight`]). The buffered send
     /// path calls this once per mail at flush.
+    ///
+    /// iamacoffeepot/aether#1158: `t_construct_start` is the instant the
+    /// blob opened (the first buffered send of the flush window); `t −
+    /// t_construct_start` is the **construct** span.
     #[allow(clippy::too_many_arguments)]
     pub fn record_sent_event_at(
         &self,
@@ -202,6 +206,7 @@ impl Mailer {
         sender: aether_data::MailboxId,
         recipient: aether_data::MailboxId,
         kind: KindId,
+        t_construct_start: Nanos,
         t: Nanos,
     ) {
         self.trace_handle.record_sent_event_at(
@@ -211,6 +216,7 @@ impl Mailer {
             sender,
             recipient,
             kind,
+            t_construct_start,
             t,
         );
     }

--- a/crates/aether-substrate/src/runtime/trace.rs
+++ b/crates/aether-substrate/src/runtime/trace.rs
@@ -205,6 +205,10 @@ impl TraceHandle {
     /// path splits this — [`Self::record_sent_inflight`] eagerly, then
     /// [`Self::record_sent_event_at`] at flush with the flush-begin
     /// anchor (iamacoffeepot/aether#1150).
+    ///
+    /// iamacoffeepot/aether#1158: eager paths route immediately, so the
+    /// blob never lingered open — `t_construct_start` *is* the same `now`
+    /// the `Sent` timestamp takes, making the **construct** span ≈ 0.
     pub fn record_sent(
         &self,
         mail_id: MailId,
@@ -214,6 +218,7 @@ impl TraceHandle {
         recipient: MailboxId,
         kind: KindId,
     ) {
+        let now = self.now_nanos();
         self.record_sent_event_at(
             mail_id,
             root,
@@ -221,7 +226,8 @@ impl TraceHandle {
             sender,
             recipient,
             kind,
-            self.now_nanos(),
+            now,
+            now,
         );
         self.record_sent_inflight(root);
     }
@@ -234,6 +240,11 @@ impl TraceHandle {
     /// per-send call site — while [`Self::record_sent_inflight`] keeps
     /// `in_flight` exact at send time. `t` is the frame-level flush-begin
     /// stamp; every mail in one flush shares it.
+    ///
+    /// iamacoffeepot/aether#1158: `t_construct_start` is the instant the
+    /// producer's outbound blob opened (the first buffered send of the
+    /// flush window). `t − t_construct_start` is the **construct** span;
+    /// on the eager path the caller passes `t_construct_start == t`.
     #[allow(clippy::too_many_arguments)]
     pub fn record_sent_event_at(
         &self,
@@ -243,6 +254,7 @@ impl TraceHandle {
         sender: MailboxId,
         recipient: MailboxId,
         kind: KindId,
+        t_construct_start: Nanos,
         t: Nanos,
     ) {
         self.push_trace_ring(
@@ -254,6 +266,7 @@ impl TraceHandle {
                 sender,
                 recipient,
                 kind,
+                t_construct_start,
                 t,
             },
         );


### PR DESCRIPTION
## Summary

Adds a fourth latency span, **`construct`** = flush-begin − first-buffered-send, measuring the producer-side time spent building a mail blob. It completes a clean, non-overlapping four-stage breakdown of a mail's full lifecycle — from first send to handler-done:

> **construct → queued → drain → handler**

iamacoffeepot/aether#1150 deliberately anchored `t_sent` at flush-begin (dropping the "rest of the handler" smear), which also dropped the blob-construction time. This brings it back as its own clean span — flush-begin is the construct↔queued boundary, so construction never bleeds into queuing.

## Stamp

`OutboundBuffer` stamps `construct_start` on the `blob_open` false→true transition (the first buffered send of a flush window); `flush_outbound_inner` reads it (`take().unwrap_or(flush_begin)`) as each deferred `Sent`'s `t_construct_start`, then resets it so the next window re-stamps. Eager / non-buffered paths route immediately, so the combined `record_sent` passes `t_construct_start == t` → construct ≈ 0.

`t_construct_start ≤ t_sent`, so no new causal-ordering inversion.

## Surfaces (mirrors the iamacoffeepot/aether#1150 / iamacoffeepot/aether#1151 / iamacoffeepot/aether#1155 stack, one stage deeper)

- **Wire**: `TraceEvent::Sent` + `MailNodeWire` gain `t_construct_start`; the `trace_walk` fold seeds it; MCP `MailNodeJson` surfaces it. Trial schema tag `aether.perf.trial.v2 → v3` (per-build only).
- **Producer**: `OutboundBuffer` + `flush_outbound_inner` (binding.rs), `record_sent_event_at` (runtime/trace.rs, mailer.rs).
- **Consumer**: `CellSamples` / `CellResult` + the `run_sweep_samples` harvest (harness.rs); `Metric::Construct` first (report.rs); the observe table (mail_latency.rs); both `perf-plot` plots gain the `construct` series (orange, first).

## Validation

- `scripts/preflight.sh` green (fmt + clippy `--all-targets` + doc + nextest 1299/1299 + wasm32).
- Rendered the plots locally: all four spans overlay; on a buffered `fanout-8`, `construct` shows a real ~1.21µs p50 producer-build cost (invisible before this).

Closes iamacoffeepot/aether#1158

## Test plan

- [x] preflight green
- [x] `trace_walk`, `mail_latency::guided_walk_reconstructs_causal_tree`, `perf::report::tests` pass with the new field
- [x] local render confirms the four-span construct→queued→drain→handler chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)