### PR TITLE
perf(substrate/scheduler): mail-count + sampled-time local-drain budget

### DIFF
--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -90,7 +90,8 @@ use crate::actor::registry::ActorRegistry;
 use crate::mail::mailer::Mailer;
 use crate::mail::{KindId, Mail, MailboxId, ReplyTo};
 use crate::scheduler::{
-    BatchBudget, CLOCK_CHECK_STRIDE, CycleResult, Drainable, SeizeSeed, SlotState,
+    BatchBudget, CLOCK_CHECK_STRIDE, CycleResult, Drainable, SeizeSeed, SlotState, burst_note_mail,
+    clock_stride, time_budget,
 };
 
 /// Worker-pool-side wrapper for a native actor. One instance per
@@ -217,6 +218,13 @@ where
     // happen to, but the surface mirrors the owning dispatch loop.
     #[allow(clippy::needless_pass_by_value)]
     fn dispatch_one(&self, actor: &mut Box<A>, env: Envelope) {
+        // iamacoffeepot/aether#1160: count this envelope against the
+        // worker's local-drain burst *before* running the handler, so a
+        // blob this handler produces (scheduled at `ctx` drop below) sees
+        // the current envelope in the keep-local budget. Off a pool worker
+        // / in the default-preserving config this is a single `Cell`
+        // increment (no clock).
+        burst_note_mail(clock_stride(), time_budget());
         let inbound_mail_id = env.mail_id;
         // Issue 734 / ADR-0088 §7: stamp the dispatching thread's
         // name-hashed `ThreadId` (a `Copy` u64) onto the `Received`

--- a/crates/aether-substrate/src/scheduler/mod.rs
+++ b/crates/aether-substrate/src/scheduler/mod.rs
@@ -44,4 +44,4 @@ pub use slot::{
     Drainable, SeizeHandle, SeizeSeed, SlotState, SlotStateLabel, WakeHandle, WakeSink,
 };
 pub use spin_park::{Acquired, SpinPark};
-pub use worker_deque::pending_depth;
+pub use worker_deque::{burst_note_mail, clock_stride, pending_depth, time_budget};

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -313,16 +313,20 @@ fn worker_loop(
 /// `Worker`) is the affinity lever: a handler running on this worker
 /// pushes a woken downstream slot there, so a relay chain stays on the
 /// same warm worker and never pays the ~4.3µs parked-worker wakeup. Its
-/// LIFO pop keeps the freshest hop warmest. The local bound is the
-/// stickiness cap (`AETHER_LOCAL_STICKY_MAX`, default 1): at 1 the chain
-/// head stays local and a fan-out spills its extras to the injector
-/// (independent work parallelises by being stolen); higher keeps fan-out
-/// extras local. The own deque is checked first so a pushed slot is never
-/// stranded.
+/// LIFO pop keeps the freshest hop warmest. Whether a fan-out's extra blobs
+/// stay local or spill is the keep-local budget
+/// (`WakeSink::schedule` → `worker_deque::try_push_local_budgeted`,
+/// iamacoffeepot/aether#1160); the default config reproduces the historical
+/// `cap == 1` "spill any fan-out extra" behaviour. The own deque is checked
+/// first so a pushed slot is never stranded.
 ///
-/// When the own deque is empty, the worker steals into it from the
-/// injector (off-worker producers + spilled fan-out + requeued yields)
-/// and its siblings' tails. When that turns up nothing, the coordinator
+/// When the own deque is empty, this resets the local-drain burst
+/// (iamacoffeepot/aether#1160) — one local cascade is one burst, so the
+/// next cascade (this worker's freshly-produced blobs, or work it's about
+/// to steal) starts a fresh keep-local budget — then steals into the deque
+/// from the injector (off-worker producers + spilled fan-out + requeued
+/// yields) and its siblings' tails. When that turns up nothing, the
+/// coordinator
 /// (iamacoffeepot/aether#1064) takes over: it keeps the worker spinning
 /// (re-running the steal scan) for a bounded window so a producer can
 /// route a spill or relay hop to it without a futex wake, then parks it —
@@ -339,6 +343,10 @@ fn acquire_slot(
     if let Some(slot) = worker_deque::pop_local() {
         return Some(slot);
     }
+    // Own deque drained empty — the local cascade is over. Close its
+    // keep-local burst (iamacoffeepot/aether#1160) so stolen work, or this
+    // worker's next cascade, starts under a fresh mail/time budget.
+    worker_deque::burst_reset();
     if let Some(slot) = worker_deque::steal_into_local(idx, stealers, injector) {
         return Some(slot);
     }

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -386,17 +386,26 @@ impl WakeSink {
         }
     }
 
-    /// Schedule a runnable `slot`: push to the current worker's own
-    /// deque when this runs on a pool worker under the local bound (the
-    /// affinity warm path — no notify, the same worker drains it LIFO),
-    /// else spill to the shared injector and notify the coordinator
-    /// (route-to-spinner / unpark-one). This is the non-demux wake
-    /// destination, shared by [`WakeHandle::wake`], the producer-side
-    /// blob push, and an inline recipient that yielded mid-drain
-    /// (ADR-0087 Phase 3b). The injector push is infallible; shutdown is
-    /// observed through the coordinator's flag.
+    /// Schedule a runnable `slot`: push to the current worker's own deque
+    /// when this runs on a pool worker and the keep-local budget says to
+    /// keep it (the affinity warm path — no notify, the same worker drains
+    /// it LIFO), else spill to the shared injector and notify the
+    /// coordinator (route-to-spinner / unpark-one). The keep-local-vs-spill
+    /// decision is the per-burst mail + sampled-time budget
+    /// ([`worker_deque::try_push_local_budgeted`], iamacoffeepot/aether#1160);
+    /// the default config reproduces the historical `cap == 1` spill-any-
+    /// fan-out-extra behaviour. This is the non-demux wake destination,
+    /// shared by [`WakeHandle::wake`], the producer-side blob push, and an
+    /// inline recipient that yielded mid-drain (ADR-0087 Phase 3b). The
+    /// injector push is infallible; shutdown is observed through the
+    /// coordinator's flag.
     pub(crate) fn schedule(&self, slot: Arc<dyn Drainable>) {
-        if let Err(slot) = worker_deque::try_push_local(slot, worker_deque::sticky_cap()) {
+        let kept = worker_deque::try_push_local_budgeted(
+            slot,
+            worker_deque::mail_budget(),
+            worker_deque::hard_cap(),
+        );
+        if let Err(slot) = kept {
             self.injector.push(slot);
             self.spin.notify();
         }

--- a/crates/aether-substrate/src/scheduler/worker_deque.rs
+++ b/crates/aether-substrate/src/scheduler/worker_deque.rs
@@ -10,21 +10,26 @@
 //! This supersedes the issue-1059 single-cell affinity stash: the deque's
 //! **LIFO own-pop is the same warm-chain locality** the cell provided, so
 //! a relay chain stays on one warm worker with no shared-queue round-trip
-//! and no parked-sibling wake (~4.3µs). The stickiness cap is preserved
-//! (the knob is repurposed as the **own-deque local bound** per
-//! iamacoffeepot/aether#1106): a wake pushes to the own deque while it
-//! holds fewer than `cap` slots, else spills to the injector + notifies —
-//! exactly the issue-1074 policy, now backed by a deque whose tail an idle
-//! worker can `steal_batch_and_pop` (the new pull path).
+//! and no parked-sibling wake (~4.3µs). Whether a just-produced blob stays
+//! on the own deque or spills to the injector + notify is the **keep-local
+//! budget** (iamacoffeepot/aether#1160, [`try_push_local_budgeted`]): a
+//! worker keeps draining its own cascade while under a per-burst mail +
+//! sampled-time budget, then spills the backlog once it has done enough
+//! cheap local work to justify waking a sibling. The default-preserving
+//! config (`AETHER_LOCAL_MAIL_BUDGET=0`) reproduces the historical
+//! `cap == 1` "spill any fan-out extra" behaviour; `AETHER_LOCAL_STICKY_MAX`
+//! is repurposed as the deque-length safety backstop ([`hard_cap`]). The
+//! tail an idle worker can `steal_batch_and_pop` is the pull path.
 //!
 //! Only pool-worker threads call [`install`]; on any other thread
-//! (chassis main, the hub, the trace drainer) [`try_push_local`] is a
-//! no-op spill and [`pop_local`] / [`steal_into_local`] yield nothing.
+//! (chassis main, the hub, the trace drainer) [`try_push_local_budgeted`]
+//! is a no-op spill and [`pop_local`] / [`steal_into_local`] yield nothing.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::env;
 use std::sync::Arc;
 use std::sync::OnceLock;
+use std::time::{Duration, Instant};
 
 use crossbeam_deque::{Injector, Steal, Stealer, Worker};
 
@@ -49,6 +54,28 @@ thread_local! {
     /// deposit path; `None` on non-worker threads (chassis main, hub,
     /// off-worker injects), where `pending_depth` reports `0`.
     static INJECTOR: RefCell<Option<Arc<Injector<Slot>>>> = const { RefCell::new(None) };
+
+    /// Per-burst mail counter for the keep-local budget
+    /// (iamacoffeepot/aether#1160). A *burst* is the run of local-deque work
+    /// a worker drains between two "own deque drained empty" transitions —
+    /// one local cascade. [`burst_note_mail`] increments it per dispatched
+    /// envelope; [`burst_over_budget`] consults it per produced blob;
+    /// [`burst_reset`] zeroes it when `acquire_slot` finds the deque empty.
+    /// Single-writer (only the running worker touches it, never across a
+    /// `run_cycle`), so a plain `Cell` — no atomics.
+    static BURST_MAIL: Cell<u32> = const { Cell::new(0) };
+
+    /// First-sampled instant of the current burst, set lazily on the first
+    /// stride-boundary mail (iamacoffeepot/aether#1160). `None` until a
+    /// burst runs past [`clock_stride`] mail, so a short burst never reads
+    /// the clock.
+    static BURST_START: Cell<Option<Instant>> = const { Cell::new(None) };
+
+    /// Sticky "this burst ran past its time budget" flag
+    /// (iamacoffeepot/aether#1160). Set once a stride sample observes
+    /// `elapsed >= time_budget`; read by [`burst_over_budget`] with no
+    /// clock read. Cleared by [`burst_reset`].
+    static BURST_OVER_TIME: Cell<bool> = const { Cell::new(false) };
 }
 
 /// Move this worker's deque into its thread-local. Called once at the top
@@ -83,39 +110,164 @@ pub fn pending_depth() -> u32 {
     u32::try_from(own.saturating_add(injected)).unwrap_or(u32::MAX)
 }
 
-/// Own-deque local bound — the max slots a worker keeps on its own deque
-/// before a wake spills to the injector. Read once from
-/// `AETHER_LOCAL_STICKY_MAX`; values `< 1` and unparseable input fall back
-/// to `1` (the chain head stays local, fan-out extras spill — the
-/// historical single-cell default).
+/// Deque-length safety backstop (iamacoffeepot/aether#1160) — the max
+/// slots a worker keeps on its own deque before [`try_push_local_budgeted`]
+/// is forced to spill regardless of the mail/time budget, so a pathological
+/// unbounded local cascade can't grow the deque without bound. Read once
+/// from `AETHER_LOCAL_STICKY_MAX` (repurposed from the pre-#1160 stickiness
+/// cap); values `< 1` and unparseable input fall back to `256`. This is a
+/// backstop, not the primary governor — the mail/time budget is.
 #[must_use]
-pub fn sticky_cap() -> usize {
+pub fn hard_cap() -> usize {
     static CAP: OnceLock<usize> = OnceLock::new();
     *CAP.get_or_init(|| {
         env::var("AETHER_LOCAL_STICKY_MAX")
             .ok()
             .and_then(|v| v.parse::<usize>().ok())
             .filter(|&k| k >= 1)
-            .unwrap_or(1)
+            .unwrap_or(256)
     })
 }
 
-/// Try to push a just-woken slot onto this worker's own deque. Returns
-/// `Ok(())` when pushed (the caller skips the injector + notify), or
-/// `Err(slot)` to hand the slot back for the injector spill — because
-/// this isn't a pool-worker thread, or the own deque already holds `cap`
-/// slots (the spill keeps independent fan-out work stealable by idle
-/// workers). At `cap == 1` the chain head stays local and every fan-out
-/// extra spills.
-pub fn try_push_local(slot: Slot, cap: usize) -> Result<(), Slot> {
+/// Keep-local mail budget per burst (iamacoffeepot/aether#1160). Read once
+/// from `AETHER_LOCAL_MAIL_BUDGET`; default **0**, which makes
+/// [`burst_over_budget`] always `true` so the decision collapses to "spill
+/// any fan-out extra" — the default-preserving Phase 1 config that
+/// reproduces the historical `cap == 1`. Set `> 0` to opt into keeping a
+/// small local cascade on the producing worker (the keep-local win).
+#[must_use]
+pub fn mail_budget() -> u32 {
+    static B: OnceLock<u32> = OnceLock::new();
+    *B.get_or_init(|| {
+        env::var("AETHER_LOCAL_MAIL_BUDGET")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(0)
+    })
+}
+
+/// Keep-local time budget per burst (iamacoffeepot/aether#1160). Read once
+/// from `AETHER_LOCAL_TIME_BUDGET_US` (microseconds); default **0** =
+/// disabled, so no wall clock is ever read (the default-preserving config).
+/// When set this is roughly the parked-worker wakeup break-even (≈4–8µs, to
+/// be pinned by the Phase 2 sweep): a burst that runs longer spills its
+/// backlog even before the mail count trips.
+#[must_use]
+pub fn time_budget() -> Duration {
+    static B: OnceLock<u64> = OnceLock::new();
+    let us = *B.get_or_init(|| {
+        env::var("AETHER_LOCAL_TIME_BUDGET_US")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(0)
+    });
+    Duration::from_micros(us)
+}
+
+/// Clock-sample stride for the keep-local time budget
+/// (iamacoffeepot/aether#1160). Read once from `AETHER_LOCAL_CLOCK_STRIDE`;
+/// default **8** (matches `CLOCK_CHECK_STRIDE`). [`burst_note_mail`] samples
+/// the wall clock only every Nth mail, so a burst shorter than the stride
+/// never reads it — the same amortization the per-cycle drain uses.
+#[must_use]
+pub fn clock_stride() -> u32 {
+    static S: OnceLock<u32> = OnceLock::new();
+    *S.get_or_init(|| {
+        env::var("AETHER_LOCAL_CLOCK_STRIDE")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .filter(|&n| n >= 1)
+            .unwrap_or(8)
+    })
+}
+
+/// Note one dispatched envelope against the current local-drain burst
+/// (iamacoffeepot/aether#1160). Increments the burst mail counter, and —
+/// only when time budgeting is enabled (`time_budget > 0`) and only on
+/// every `stride`-th mail — samples the wall clock to set the sticky
+/// over-time flag. A burst shorter than `stride` mail never reads the
+/// clock (the `CLOCK_CHECK_STRIDE` amortization); with `time_budget == 0`
+/// (the default-preserving config) the clock is never read at all.
+/// Cheap on the dispatch hot path: one `Cell` increment plus, off the
+/// default config, a strided clock read.
+pub fn burst_note_mail(stride: u32, time_budget: Duration) {
+    let n = BURST_MAIL.get().saturating_add(1);
+    BURST_MAIL.set(n);
+    if time_budget.is_zero() {
+        return;
+    }
+    if n.is_multiple_of(stride.max(1)) {
+        let start = BURST_START.get().unwrap_or_else(Instant::now);
+        BURST_START.set(Some(start));
+        if start.elapsed() >= time_budget {
+            BURST_OVER_TIME.set(true);
+        }
+    }
+}
+
+/// Has the current burst exceeded its keep-local budget
+/// (iamacoffeepot/aether#1160)? `true` once the burst has dispatched
+/// `mail_budget` envelopes or run past its time budget. `mail_budget == 0`
+/// means "always over" — the default-preserving config reproducing the
+/// historical `cap == 1` "spill any fan-out extra" behaviour. No clock
+/// read (the time path is the sticky flag [`burst_note_mail`] maintains).
+#[must_use]
+pub fn burst_over_budget(mail_budget: u32) -> bool {
+    let count_over = mail_budget == 0 || BURST_MAIL.get() >= mail_budget;
+    count_over || BURST_OVER_TIME.get()
+}
+
+/// Reset the local-drain burst counters (iamacoffeepot/aether#1160). Called
+/// by `acquire_slot` the moment `pop_local` reports the own deque drained
+/// empty, so each local cascade is one burst and any subsequently stolen
+/// work starts a fresh budget.
+pub fn burst_reset() {
+    BURST_MAIL.set(0);
+    BURST_START.set(None);
+    BURST_OVER_TIME.set(false);
+}
+
+/// Budget-aware push of a just-produced blob onto this worker's own deque
+/// (iamacoffeepot/aether#1160). Keeps it local unless the keep-local budget
+/// says to spill:
+///
+/// ```text
+/// spill  ⟺  (burst_over_budget(mail_budget) && local_deque_len > 0)
+///           || local_deque_len >= hard_cap
+/// ```
+///
+/// The `local_deque_len > 0` guard is load-bearing: a serial relay chain
+/// has an **empty** deque at schedule time (the current blob was popped,
+/// nothing else queued), so it never spills regardless of depth or
+/// accumulated mail — a chain has no independent work to parallelize, so a
+/// spill would only buy a wakeup. A tree / fan-out builds `len > 0`, so the
+/// budget then governs: a trivial cascade stays local (under budget — no
+/// wakeup, the measured win), a large or heavy one spills past budget
+/// (independent work + idle workers ⇒ parallelism amortizes the wakeup).
+/// `hard_cap` is a deque-length backstop only.
+///
+/// With `mail_budget == 0` (default) [`burst_over_budget`] is always
+/// `true`, so the rule collapses to "spill iff `len > 0`" — identical to
+/// the pre-#1160 `try_push_local(slot, 1)`.
+///
+/// Returns `Ok(())` when kept local (the caller skips injector + notify),
+/// or `Err(slot)` to spill. Off a pool worker there is no own deque, so
+/// always `Err` (spill).
+pub fn try_push_local_budgeted(slot: Slot, mail_budget: u32, hard_cap: usize) -> Result<(), Slot> {
+    let over = burst_over_budget(mail_budget);
     LOCAL.with(|w| {
         let w = w.borrow();
         match w.as_ref() {
-            Some(worker) if worker.len() < cap => {
-                worker.push(slot);
-                Ok(())
+            Some(worker) => {
+                let len = worker.len();
+                if (over && len > 0) || len >= hard_cap {
+                    Err(slot)
+                } else {
+                    worker.push(slot);
+                    Ok(())
+                }
             }
-            _ => Err(slot),
+            None => Err(slot),
         }
     })
 }
@@ -174,8 +326,10 @@ pub fn steal_into_local(
 )]
 mod tests {
     use super::*;
-    use crate::scheduler::slot::{BatchBudget, CycleResult, Drainable};
+    use crate::scheduler::SpinPark;
+    use crate::scheduler::slot::{BatchBudget, CycleResult, Drainable, WakeSink};
     use std::any::Any;
+    use std::thread;
 
     struct Noop;
     impl Drainable for Noop {
@@ -198,42 +352,180 @@ mod tests {
     }
 
     #[test]
-    fn non_pool_thread_never_pushes_local() {
+    fn budgeted_off_worker_always_spills() {
         // This test never calls `install`, so it isn't a pool worker:
-        // every push must spill regardless of cap.
-        assert!(try_push_local(noop(), 4).is_err());
+        // every push must spill regardless of budget or backlog.
+        assert!(try_push_local_budgeted(noop(), 1000, 256).is_err());
         assert!(pop_local().is_none());
     }
 
     #[test]
-    fn push_respects_cap_and_pops_lifo() {
+    fn budgeted_default_reproduces_cap_one() {
+        // `mail_budget == 0` ⇒ always over budget ⇒ spill whenever the own
+        // deque already holds work — exactly the pre-#1160 `cap == 1`
+        // "keep only when the deque is empty" shape.
         install(Worker::new_lifo());
         drain_local();
+        burst_reset();
 
-        // cap 2: first two push, the third spills.
-        assert!(try_push_local(noop(), 2).is_ok());
-        assert!(try_push_local(noop(), 2).is_ok());
+        // Empty deque: kept local.
+        assert!(try_push_local_budgeted(noop(), 0, 256).is_ok());
+        // Deque now at depth 1: the next spills.
         assert!(
-            try_push_local(noop(), 2).is_err(),
-            "third push past cap 2 must spill"
+            try_push_local_budgeted(noop(), 0, 256).is_err(),
+            "default (mail_budget 0) spills any fan-out extra, like cap 1"
         );
-
-        assert!(pop_local().is_some());
-        assert!(pop_local().is_some());
-        assert!(pop_local().is_none());
+        drain_local();
     }
 
     #[test]
-    fn cap_one_keeps_only_the_chain_head() {
+    fn budgeted_chain_never_spills_at_depth_zero() {
+        // The load-bearing guard: a serial chain has an empty deque at
+        // schedule time (the current blob was popped), so it stays local
+        // even when the burst is well over budget — a chain has no
+        // independent work to parallelize, so a spill would only buy a
+        // wakeup.
         install(Worker::new_lifo());
         drain_local();
-
-        assert!(try_push_local(noop(), 1).is_ok());
+        burst_reset();
+        for _ in 0..100 {
+            burst_note_mail(8, Duration::ZERO); // far past any small budget
+        }
         assert!(
-            try_push_local(noop(), 1).is_err(),
-            "cap 1 keeps only the chain head; the extra spills"
+            burst_over_budget(1),
+            "burst should read over a 1-mail budget"
         );
-        assert!(pop_local().is_some());
+        assert!(
+            try_push_local_budgeted(noop(), 1, 256).is_ok(),
+            "depth 0 keeps local even over budget (the chain guard)"
+        );
+        drain_local();
+    }
+
+    #[test]
+    fn budgeted_keeps_local_under_budget() {
+        // Under budget (large mail_budget, small burst) a cascade stacks on
+        // the own deque — the keep-local win the spill cost avoids.
+        install(Worker::new_lifo());
+        drain_local();
+        burst_reset();
+        for _ in 0..5 {
+            assert!(
+                try_push_local_budgeted(noop(), 1000, 256).is_ok(),
+                "under budget keeps local"
+            );
+        }
+        drain_local();
+    }
+
+    #[test]
+    fn budgeted_spills_backlog_over_budget() {
+        // Over budget (burst 10 > mail_budget 4) with real backlog
+        // (depth > 0): spill the extra so an idle sibling can steal it.
+        install(Worker::new_lifo());
+        drain_local();
+        burst_reset();
+        for _ in 0..10 {
+            burst_note_mail(8, Duration::ZERO);
+        }
+        // Empty deque first push keeps (the depth-0 chain guard).
+        assert!(try_push_local_budgeted(noop(), 4, 256).is_ok());
+        // Now depth 1 + over budget → spill.
+        assert!(
+            try_push_local_budgeted(noop(), 4, 256).is_err(),
+            "over budget with backlog spills"
+        );
+        drain_local();
+    }
+
+    #[test]
+    fn budgeted_hard_cap_backstop() {
+        // Even under the mail/time budget, the deque-length backstop forces
+        // a spill once the own deque reaches `hard_cap`.
+        install(Worker::new_lifo());
+        drain_local();
+        burst_reset();
+        // hard_cap 2, large mail_budget (never trips by count).
+        assert!(try_push_local_budgeted(noop(), 1000, 2).is_ok()); // len 0 → 1
+        assert!(try_push_local_budgeted(noop(), 1000, 2).is_ok()); // len 1 → 2
+        assert!(
+            try_push_local_budgeted(noop(), 1000, 2).is_err(),
+            "len == hard_cap spills regardless of budget"
+        );
+        drain_local();
+    }
+
+    #[test]
+    fn burst_counts_and_resets() {
+        burst_reset();
+        for _ in 0..5 {
+            burst_note_mail(8, Duration::ZERO);
+        }
+        assert!(burst_over_budget(5), "5 mail meets a 5-mail budget");
+        assert!(!burst_over_budget(6), "5 mail is under a 6-mail budget");
+        burst_reset();
+        assert!(!burst_over_budget(1), "reset zeroes the counter");
+    }
+
+    #[test]
+    fn burst_mail_budget_zero_is_always_over() {
+        burst_reset();
+        assert!(burst_over_budget(0), "mail_budget 0 trips at zero mail");
+    }
+
+    #[test]
+    fn burst_time_path_trips_over_budget() {
+        // With time budgeting on, a burst that runs past the time budget
+        // trips even when the mail count is nowhere near its budget. Stride
+        // 1 samples every mail; a tiny time budget + a real sleep makes the
+        // elapsed check deterministic.
+        burst_reset();
+        let tiny = Duration::from_nanos(1);
+        burst_note_mail(1, tiny); // sets BURST_START
+        thread::sleep(Duration::from_micros(50));
+        burst_note_mail(1, tiny); // elapsed ≫ 1ns → over-time flag set
+        assert!(
+            burst_over_budget(u32::MAX),
+            "only the time path can trip here (mail count is 2, budget u32::MAX)"
+        );
+        burst_reset();
+        assert!(
+            !burst_over_budget(u32::MAX),
+            "reset clears the over-time flag"
+        );
+    }
+
+    #[test]
+    fn schedule_default_reproduces_cap_one_on_worker() {
+        // Drive the wired decision through `WakeSink::schedule` on a
+        // simulated pool worker (own deque installed on this thread). At the
+        // default config (mail_budget 0) the first schedule stays local
+        // (empty deque) and the second spills — the pre-#1160 `cap == 1`
+        // shape, now routed through the budget gate.
+        //
+        // `schedule` reads the env-cached `mail_budget()`, so this asserts
+        // the *default* wiring; skip it when a keep-local budget is opted in
+        // (e.g. the Phase 2 sweep sets `AETHER_LOCAL_MAIL_BUDGET`), where the
+        // second schedule legitimately stays local instead of spilling.
+        if mail_budget() != 0 {
+            return;
+        }
+        install(Worker::new_lifo());
+        drain_local();
+        burst_reset();
+
+        let injector = Arc::new(Injector::<Slot>::new());
+        let sink = WakeSink::new(Arc::clone(&injector), Arc::new(SpinPark::new()), 8);
+
+        sink.schedule(noop()); // empty deque → kept local
+        sink.schedule(noop()); // depth 1 + always-over default → spills
+
+        assert!(
+            matches!(injector.steal(), Steal::Success(_)),
+            "the second schedule must spill to the injector"
+        );
+        assert!(matches!(injector.steal(), Steal::Empty), "only one spills");
+        assert!(pop_local().is_some(), "the first stays on the local deque");
         assert!(pop_local().is_none());
     }
 


### PR DESCRIPTION
## What

Phase 1 of iamacoffeepot/aether#1160. Re-denominate the keep-local-vs-spill
decision for a just-produced blob (`WakeSink::schedule`) from **deque length**
to a **per-burst mail count with the wall clock sampled every N mail**. Lands
the mechanism **default-preserving** — with no env set the decision is
byte-identical to today's `cap == 1`. The default is **not** flipped here.

## Why

At the old deque-length `cap == 1`, a trivial multi-blob cascade (a tree) spills
its later blobs to a parked sibling, paying `SpinPark::notify`'s unpark slow-path
on work too cheap to amortize it. Measured on `tree-A-BC-DEEF` @ 2 workers (post
the iamacoffeepot/aether#1153 span re-anchor): `queued` p50 **1459ns spilling**
vs **417ns keeping local** — the delta is pure wakeup latency on trivial
handlers. Counting deque slots also treats a 1-recipient hop and a 60-recipient
fan-out identically.

## Mechanism

- **Per-worker burst state** in `worker_deque` (three thread-local `Cell`s: mail
  counter, lazily-sampled start `Instant`, sticky over-time flag). `burst_note_mail`
  increments per dispatched envelope and samples the clock only every
  `clock_stride` mail *when time budgeting is enabled*; `burst_over_budget` reads
  it with no clock; `burst_reset` zeroes it.
- **Decision rule** — `try_push_local_budgeted` replaces `try_push_local`:

  ```
  spill  ⟺  (burst_over_budget(mail_budget) && local_deque_len > 0)
            || local_deque_len >= hard_cap
  ```

  The `local_deque_len > 0` guard is load-bearing: a serial chain has an empty
  deque at schedule time, so it **never spills** regardless of depth or
  accumulated mail (no independent work to parallelize ⇒ a spill only buys a
  wakeup). `hard_cap` is a deque-length backstop only.
- **Edit sites** — increment in `DispatcherSlot::dispatch_one` (the sole envelope
  chokepoint, before the handler so a blob it produces sees the current envelope
  in the budget), decide in `WakeSink::schedule`, reset in `acquire_slot` when the
  own deque drains empty (one burst per local cascade; stolen work starts fresh).

## Env knobs (read once via `OnceLock`)

| var | default | meaning |
| --- | --- | --- |
| `AETHER_LOCAL_MAIL_BUDGET` | `0` | mail per burst before the count trips; `0` ⇒ always over budget ⇒ reproduce `cap == 1` |
| `AETHER_LOCAL_TIME_BUDGET_US` | `0` | per-burst elapsed bound; `0` ⇒ disabled (no clock reads) |
| `AETHER_LOCAL_CLOCK_STRIDE` | `8` | clock sampled every Nth mail (matches `CLOCK_CHECK_STRIDE`) |
| `AETHER_LOCAL_STICKY_MAX` | `256` | **repurposed** as `hard_cap` (deque-length backstop) |

## Validation

- 363 substrate tests + 9 new scheduler unit/integration tests pass at default.
- Full substrate suite re-run with the keep-local budget opted in
  (`AETHER_LOCAL_MAIL_BUDGET=64 AETHER_LOCAL_TIME_BUDGET_US=6`) — 362/362 pass
  (the one default-only assertion test self-skips under the override), confirming
  the keep-local path is sound under live worker pools (no stranding / hangs).
- `scripts/preflight.sh` green (fmt + clippy + doc + nextest + wasm32 cross-build).

## Rollout (not in this PR)

- **Phase 2** — A/B validation sweep on `tree-*` vs chain vs fan-out to pin the
  `MAIL_BUDGET` / `TIME_BUDGET` defaults.
- **Phase 3** — flip the default once the sweep confirms tree↓ / chain·fanout flat
  / heavy still parallelizes.

Per iamacoffeepot/aether#1160 this is a pre-cost-weighting step; the budget then
composes with iamacoffeepot/aether#1128 (handler-cost EWMA) and
iamacoffeepot/aether#1127 (cost-weighted spill/wake admission).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
