### PR TITLE
fix(capabilities): wire gemini nanobanana request params into the api

### DIFF
--- a/crates/aether-capabilities/src/contentgen/adapter.rs
+++ b/crates/aether-capabilities/src/contentgen/adapter.rs
@@ -60,6 +60,12 @@ pub struct GeminiResponse {
     /// NB2-only opaque signature the caller passes back unchanged for a
     /// multi-turn image edit. `None` for Lyria and older image models.
     pub thought_signature: Option<String>,
+    /// Grounding metadata (search queries + source URLs) parsed from the
+    /// response when `use_grounding` produced a `groundingMetadata`
+    /// block. `(Vec<search_queries>, Vec<source_urls>)`; `None` when the
+    /// block was absent. Kept as inline tuples so the shared adapter
+    /// types don't depend on the provider kinds in `aether-kinds`.
+    pub grounding: Option<(Vec<String>, Vec<String>)>,
 }
 
 /// Adapter-layer usage accounting. Carries the same four fields as the
@@ -137,12 +143,22 @@ pub trait GeminiAdapter: Send + Sync {
 /// validation before constructing this; the adapter just dispatches the
 /// HTTP call. `aspect_ratio` rides as the provider's `W:H` string;
 /// `reference_images` are the already-read reference bytes.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct GeminiImageRequest {
     pub model: String,
     pub prompt: String,
     /// Provider `W:H` aspect-ratio string (e.g. `"16:9"`).
     pub aspect_ratio: String,
+    /// Provider image-size string (`"512"` / `"1K"` / `"2K"` / `"4K"`),
+    /// `None` when the caller left `image_size` unset.
+    pub image_size: Option<String>,
+    /// Provider `thinkingLevel` string (`"minimal"` / `"high"`), `None`
+    /// when the caller left `thinking_level` unset.
+    pub thinking_level: Option<String>,
+    /// `thinkingConfig.includeThoughts`, `None` when unset.
+    pub include_thoughts: Option<bool>,
+    /// Whether to add the `google_search` grounding tool.
+    pub use_grounding: bool,
     /// Reference-image bytes the cap read from the supplied paths.
     pub reference_images: Vec<Vec<u8>>,
 }
@@ -269,6 +285,7 @@ impl GeminiAdapter for StubGeminiAdapter {
             model_used: req.model,
             usage: AdapterUsage::default(),
             thought_signature: None,
+            grounding: None,
         })
     }
 
@@ -285,6 +302,7 @@ impl GeminiAdapter for StubGeminiAdapter {
             model_used: req.model,
             usage: AdapterUsage::default(),
             thought_signature: None,
+            grounding: None,
         })
     }
 }
@@ -334,6 +352,7 @@ mod tests {
                 prompt: String::from("a cat"),
                 aspect_ratio: String::from("1:1"),
                 reference_images: Vec::new(),
+                ..Default::default()
             })
             .expect("stub nanobanana is infallible");
         assert_eq!(resp.artifacts.len(), 1);

--- a/crates/aether-capabilities/src/gemini/fixtures/nanobanana_grounded_response.json
+++ b/crates/aether-capabilities/src/gemini/fixtures/nanobanana_grounded_response.json
@@ -1,0 +1,38 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "inlineData": {
+              "mimeType": "image/png",
+              "data": "TWFu"
+            }
+          }
+        ],
+        "role": "model"
+      },
+      "groundingMetadata": {
+        "webSearchQueries": [
+          "current eiffel tower height",
+          "eiffel tower color 2026"
+        ],
+        "groundingChunks": [
+          {
+            "uri": "https://en.wikipedia.org/wiki/Eiffel_Tower"
+          },
+          {
+            "uri": "https://www.toureiffel.paris/en"
+          }
+        ]
+      },
+      "finishReason": "STOP"
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 12,
+    "candidatesTokenCount": 0,
+    "totalTokenCount": 12
+  },
+  "modelVersion": "gemini-3.1-flash-image-preview"
+}

--- a/crates/aether-capabilities/src/gemini/mod.rs
+++ b/crates/aether-capabilities/src/gemini/mod.rs
@@ -169,26 +169,69 @@ impl UreqGeminiAdapter {
     }
 }
 
+/// Build the `generateContent` request body for a Nano Banana image
+/// request: the prompt plus any reference images as inline-data parts,
+/// and the per-request knobs in `generationConfig`. Each optional field
+/// is emitted only when its source `Option` is `Some(..)` so an unset
+/// knob leaves no key in the body. Factored out so a unit test can lock
+/// the JSON shape without an HTTP call.
+fn build_nanobanana_body(req: &GeminiImageRequest) -> Value {
+    use serde_json::{Map, json};
+
+    let mut parts = vec![json!({ "text": req.prompt })];
+    for img in &req.reference_images {
+        parts.push(json!({
+            "inlineData": {
+                "mimeType": "image/png",
+                "data": base64_encode(img),
+            }
+        }));
+    }
+
+    // `imageConfig` always carries the aspect ratio; `imageSize` rides
+    // alongside it under the same object when set (issue 1167 — do not
+    // switch to `responseFormat.image`).
+    let mut image_config = Map::new();
+    image_config.insert("aspectRatio".to_string(), json!(req.aspect_ratio));
+    if let Some(size) = &req.image_size {
+        image_config.insert("imageSize".to_string(), json!(size));
+    }
+
+    let mut generation_config = Map::new();
+    generation_config.insert("imageConfig".to_string(), Value::Object(image_config));
+
+    // `thinkingConfig` only appears when at least one of its fields is
+    // set; each field is emitted independently.
+    let mut thinking_config = Map::new();
+    if let Some(level) = &req.thinking_level {
+        thinking_config.insert("thinkingLevel".to_string(), json!(level));
+    }
+    if let Some(include) = req.include_thoughts {
+        thinking_config.insert("includeThoughts".to_string(), json!(include));
+    }
+    if !thinking_config.is_empty() {
+        generation_config.insert("thinkingConfig".to_string(), Value::Object(thinking_config));
+    }
+
+    let mut body = Map::new();
+    body.insert(
+        "contents".to_string(),
+        json!([{ "role": "user", "parts": parts }]),
+    );
+    body.insert(
+        "generationConfig".to_string(),
+        Value::Object(generation_config),
+    );
+    if req.use_grounding {
+        body.insert("tools".to_string(), json!([{ "google_search": {} }]));
+    }
+
+    Value::Object(body)
+}
+
 impl GeminiAdapter for UreqGeminiAdapter {
     fn nanobanana_generate(&self, req: GeminiImageRequest) -> Result<GeminiResponse, String> {
-        use serde_json::json;
-
-        // Build the generateContent body: the prompt plus any reference
-        // images as inline-data parts, and the aspect ratio in the
-        // image-generation config.
-        let mut parts = vec![json!({ "text": req.prompt })];
-        for img in &req.reference_images {
-            parts.push(json!({
-                "inlineData": {
-                    "mimeType": "image/png",
-                    "data": base64_encode(img),
-                }
-            }));
-        }
-        let body = json!({
-            "contents": [{ "role": "user", "parts": parts }],
-            "generationConfig": { "imageConfig": { "aspectRatio": req.aspect_ratio } },
-        });
+        let body = build_nanobanana_body(&req);
         let text = self.post_json(&req.model, "generateContent", &body)?;
 
         let parsed = nanobanana::parse_image_response(&text)?;
@@ -200,6 +243,7 @@ impl GeminiAdapter for UreqGeminiAdapter {
             model_used: req.model,
             usage: AdapterUsage::default(),
             thought_signature: parsed.thought_signature,
+            grounding: parsed.grounding,
         })
     }
 
@@ -225,6 +269,7 @@ impl GeminiAdapter for UreqGeminiAdapter {
             model_used: req.model,
             usage: AdapterUsage::default(),
             thought_signature: None,
+            grounding: None,
         })
     }
 }
@@ -276,6 +321,28 @@ fn aspect_ratio_str(ar: aether_kinds::AspectRatio) -> &'static str {
     }
 }
 
+/// Map the wire `ImageSize` to the provider's `imageConfig.imageSize`
+/// string. Uppercase `K`; `"512"` has no `K`.
+fn image_size_str(size: aether_kinds::ImageSize) -> &'static str {
+    use aether_kinds::ImageSize as S;
+    match size {
+        S::S512 => "512",
+        S::K1 => "1K",
+        S::K2 => "2K",
+        S::K4 => "4K",
+    }
+}
+
+/// Map the wire `ThinkingLevel` to the provider's
+/// `thinkingConfig.thinkingLevel` string.
+fn thinking_level_str(level: aether_kinds::ThinkingLevel) -> &'static str {
+    use aether_kinds::ThinkingLevel as T;
+    match level {
+        T::Minimal => "minimal",
+        T::High => "high",
+    }
+}
+
 // Handler-signature kinds must be importable at file root because
 // `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
 // of the mod.
@@ -295,7 +362,8 @@ mod native {
     use super::{
         DisabledGeminiAdapter, GeminiAdapter, GeminiConfig, GeminiImageRequest, GeminiMusicRequest,
         LyriaGenerate, LyriaGenerateResult, NanobananaGenerate, NanobananaGenerateResult,
-        UreqGeminiAdapter, aspect_ratio_str, lyria, map_adapter_error, nanobanana,
+        UreqGeminiAdapter, aspect_ratio_str, image_size_str, lyria, map_adapter_error, nanobanana,
+        thinking_level_str,
     };
     use crate::contentgen::adapter::{AdapterUsage, GeminiResponse};
     use crate::contentgen::dispatch::{BlockingCall, InFlightDispatch};
@@ -303,7 +371,7 @@ mod native {
     use crate::fs::{FileAdapter, LocalFileAdapter};
     use aether_actor::{OutboundReply, actor};
     use aether_data::{Kind, KindId, MailboxId, ReplyTo};
-    use aether_kinds::{GeminiError, Usage};
+    use aether_kinds::{GeminiError, GroundingMetadata, Usage};
     use aether_substrate::Mailer;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
@@ -472,6 +540,12 @@ mod native {
                 let model_used = resp.model_used;
                 let usage = to_usage(resp.usage);
                 let thought_signature = resp.thought_signature;
+                let grounding =
+                    resp.grounding
+                        .map(|(search_queries, source_urls)| GroundingMetadata {
+                            search_queries,
+                            source_urls,
+                        });
                 let Some(artifact) = resp.artifacts.into_iter().next() else {
                     return NanobananaGenerateResult::Err {
                         request_id,
@@ -485,7 +559,7 @@ mod native {
                         model_used,
                         usage,
                         thought_signature,
-                        grounding: None,
+                        grounding,
                     },
                     Err(e) => NanobananaGenerateResult::Err {
                         request_id,
@@ -599,6 +673,12 @@ mod native {
                 model: mail.model,
                 prompt: mail.prompt,
                 aspect_ratio: aspect_ratio_str(mail.aspect_ratio).to_string(),
+                image_size: mail.image_size.map(|s| image_size_str(s).to_string()),
+                thinking_level: mail
+                    .thinking_level
+                    .map(|l| thinking_level_str(l).to_string()),
+                include_thoughts: mail.include_thoughts,
+                use_grounding: mail.use_grounding.unwrap_or(false),
                 reference_images,
             };
             let reply_to = OutboundReply::reply_target(ctx).unwrap_or(ReplyTo::NONE);
@@ -1064,6 +1144,7 @@ mod native {
                     prompt: "a single red dot on white".to_string(),
                     aspect_ratio: "1:1".to_string(),
                     reference_images: Vec::new(),
+                    ..Default::default()
                 })
                 .expect("live nanobanana request succeeds");
             assert!(!resp.artifacts.is_empty());
@@ -1093,6 +1174,50 @@ mod native {
                 let n = d.as_nanos() as u64;
                 n
             })
+        }
+
+        /// With every knob set, the request body carries
+        /// `imageConfig.imageSize`, `thinkingConfig.thinkingLevel` /
+        /// `includeThoughts`, and `tools[0].google_search` (issue 1167).
+        #[test]
+        fn nanobanana_body_carries_set_params() {
+            use crate::contentgen::adapter::GeminiImageRequest;
+            let body = super::super::build_nanobanana_body(&GeminiImageRequest {
+                model: "gemini-3.1-flash-image-preview".to_string(),
+                prompt: "a cat".to_string(),
+                aspect_ratio: "16:9".to_string(),
+                image_size: Some("2K".to_string()),
+                thinking_level: Some("high".to_string()),
+                include_thoughts: Some(true),
+                use_grounding: true,
+                reference_images: Vec::new(),
+            });
+            let gcfg = &body["generationConfig"];
+            assert_eq!(gcfg["imageConfig"]["aspectRatio"], "16:9");
+            assert_eq!(gcfg["imageConfig"]["imageSize"], "2K");
+            assert_eq!(gcfg["thinkingConfig"]["thinkingLevel"], "high");
+            assert_eq!(gcfg["thinkingConfig"]["includeThoughts"], true);
+            assert_eq!(body["tools"][0]["google_search"], serde_json::json!({}));
+        }
+
+        /// With the optional knobs unset, the body has no `imageSize`,
+        /// no `thinkingConfig`, and no `tools` key — only the always-on
+        /// `aspectRatio` survives under `imageConfig`.
+        #[test]
+        fn nanobanana_body_omits_unset_params() {
+            use crate::contentgen::adapter::GeminiImageRequest;
+            let body = super::super::build_nanobanana_body(&GeminiImageRequest {
+                model: "gemini-3.1-flash-image-preview".to_string(),
+                prompt: "a cat".to_string(),
+                aspect_ratio: "1:1".to_string(),
+                reference_images: Vec::new(),
+                ..Default::default()
+            });
+            let gcfg = &body["generationConfig"];
+            assert_eq!(gcfg["imageConfig"]["aspectRatio"], "1:1");
+            assert!(gcfg["imageConfig"].get("imageSize").is_none());
+            assert!(gcfg.get("thinkingConfig").is_none());
+            assert!(body.get("tools").is_none());
         }
     }
 }

--- a/crates/aether-capabilities/src/gemini/nanobanana.rs
+++ b/crates/aether-capabilities/src/gemini/nanobanana.rs
@@ -182,20 +182,23 @@ pub fn validate(shape: &ModelShape, inputs: &ValidationInputs) -> Result<(), Gem
 }
 
 /// Parse the base64 image payload + grounding/thought metadata out of a
-/// Nano Banana response. Returns `(image_bytes, thought_signature,
-/// grounding)`. Factored out so a fixture-replay test locks the shape.
+/// Nano Banana response. Factored out so a fixture-replay test locks the
+/// shape.
 pub fn parse_image_response(json: &str) -> Result<ParsedImage, String> {
     use serde_json::Value;
 
     let parsed: Value = serde_json::from_str(json).map_err(|e| format!("parse response: {e}"))?;
 
-    // The image rides as an inline-data part inside the first
-    // candidate's content parts.
-    let parts = parsed
+    let candidate = parsed
         .get("candidates")
         .and_then(Value::as_array)
         .and_then(|c| c.first())
-        .and_then(|c| c.get("content"))
+        .ok_or_else(|| "response missing candidates[0]".to_string())?;
+
+    // The image rides as an inline-data part inside the first
+    // candidate's content parts.
+    let parts = candidate
+        .get("content")
         .and_then(|c| c.get("parts"))
         .and_then(Value::as_array)
         .ok_or_else(|| "response missing candidates[0].content.parts".to_string())?;
@@ -213,16 +216,63 @@ pub fn parse_image_response(json: &str) -> Result<ParsedImage, String> {
         .find_map(|p| p.get("thoughtSignature").and_then(Value::as_str))
         .map(ToString::to_string);
 
+    let grounding = parse_grounding(candidate);
+
     Ok(ParsedImage {
         bytes,
         thought_signature,
+        grounding,
     })
+}
+
+/// Pull the `groundingMetadata` block off a candidate, mapping
+/// `webSearchQueries` to search queries and `groundingChunks[].uri` to
+/// source URLs. Returns `None` when the block is absent. The grounding
+/// is carried as inline `(search_queries, source_urls)` so the adapter
+/// layer doesn't depend on the provider kinds in `aether-kinds`.
+fn parse_grounding(candidate: &serde_json::Value) -> Option<(Vec<String>, Vec<String>)> {
+    use serde_json::Value;
+
+    let meta = candidate.get("groundingMetadata")?;
+
+    let search_queries = meta
+        .get("webSearchQueries")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(Value::as_str)
+                .map(ToString::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let source_urls = meta
+        .get("groundingChunks")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|chunk| {
+                    chunk
+                        .get("web")
+                        .and_then(|w| w.get("uri"))
+                        .or_else(|| chunk.get("uri"))
+                        .and_then(Value::as_str)
+                        .map(ToString::to_string)
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Some((search_queries, source_urls))
 }
 
 /// Result of [`parse_image_response`].
 pub struct ParsedImage {
     pub bytes: Vec<u8>,
     pub thought_signature: Option<String>,
+    /// Grounding `(search_queries, source_urls)` parsed from
+    /// `candidates[0].groundingMetadata`; `None` when absent.
+    pub grounding: Option<(Vec<String>, Vec<String>)>,
 }
 
 /// Shared base64 decode for the media backends (the image path here and
@@ -368,6 +418,33 @@ mod tests {
         // The fixture embeds the base64 of "Man" as a stand-in image.
         assert_eq!(parsed.bytes, b"Man");
         assert_eq!(parsed.thought_signature.as_deref(), Some("sig-abc"));
+        // No `groundingMetadata` block in the v2 fixture.
+        assert!(parsed.grounding.is_none());
+    }
+
+    #[test]
+    fn parses_grounded_fixture_response() {
+        const FIXTURE: &str = include_str!("fixtures/nanobanana_grounded_response.json");
+        let parsed =
+            parse_image_response(FIXTURE).expect("grounded fixture is a valid NB response");
+        assert_eq!(parsed.bytes, b"Man");
+        let (search_queries, source_urls) = parsed
+            .grounding
+            .expect("groundingMetadata block is present");
+        assert_eq!(
+            search_queries,
+            vec![
+                "current eiffel tower height".to_string(),
+                "eiffel tower color 2026".to_string(),
+            ]
+        );
+        assert_eq!(
+            source_urls,
+            vec![
+                "https://en.wikipedia.org/wiki/Eiffel_Tower".to_string(),
+                "https://www.toureiffel.paris/en".to_string(),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes iamacoffeepot/aether#1167

`aether.gemini` validated several `NanobananaGenerate` params but never sent them, and the `Ok` reply hardcoded `grounding: None`. This wires them through:

- Request body: `imageSize` rides under the existing `imageConfig` object alongside `aspectRatio` (kept the current path per the issue; not switched to `responseFormat.image`); `thinkingConfig.thinkingLevel`/`includeThoughts`; top-level `tools: [{ google_search: {} }]` when `use_grounding`. Each field is emitted only when its source `Option` is `Some`. Enums map exactly as the issue specifies (`ImageSize` S512 to "512", K1/K2/K4 to "1K"/"2K"/"4K"; `ThinkingLevel` Minimal/High to "minimal"/"high").
- Response: `parse_image_response` now reads `candidates[0].groundingMetadata` (`webSearchQueries` to `search_queries`, `groundingChunks[].uri` to `source_urls`) and threads it into the reply's `grounding`, replacing the hardcoded `None`.

Tests: added a request-body builder unit test (set-vs-unset key presence), a `nanobanana_grounded_response.json` fixture, and a `parse_image_response` grounding assertion. Local full `scripts/preflight.sh` passed (fmt + clippy + doc + nextest 1310 tests + wasm32 cross-build); `aether-capabilities` nextest green.
