### PR TITLE
ci(workflow): pin scheduler budgets per-side in the perf-compare run

### DIFF
--- a/.github/workflows/perf-compare.yml
+++ b/.github/workflows/perf-compare.yml
@@ -98,6 +98,15 @@ jobs:
       - name: Run perf comparison
         env:
           PERF_BASE_CACHE: ${{ github.workspace }}/.perf-cache/aether-perf-trial-base
+          # iamacoffeepot/aether#1160 follow-up: pin the scheduler budgets
+          # per-side instead of relying on each binary's compiled default, so
+          # the comparison is explicit and build-independent. Base is forced
+          # to the pre-flip cap=1 (MAIL_BUDGET=0); the candidate to the
+          # shipped keep-local default — reproducing the keep-local-vs-cap=1
+          # A/B on the CI runner regardless of which default each binary was
+          # built with.
+          PERF_BASE_ENV: AETHER_LOCAL_MAIL_BUDGET=0
+          PERF_CAND_ENV: AETHER_LOCAL_MAIL_BUDGET=64 AETHER_LOCAL_TIME_BUDGET_US=6
         run: scripts/perf-compare.sh
       # iamacoffeepot/aether#1155: render the candidate's per-cell
       # queued/drain/handler sample distributions (the shape the

--- a/scripts/perf-compare.sh
+++ b/scripts/perf-compare.sh
@@ -48,6 +48,24 @@ json_out="$ROOT/perf-report.json"
 md_out="$ROOT/perf-report.md"
 base_cache="${PERF_BASE_CACHE:-}"
 
+# Optional per-side scheduler-knob pins (iamacoffeepot/aether#1160 follow-up).
+# Space-separated KEY=VALUE list applied as env to only the base or only the
+# candidate trial process (via the comparator's `--base-env` / `--cand-env`),
+# so a run can pin a knob to a fixed value per side instead of relying on each
+# binary's compiled default — e.g. PERF_BASE_ENV="AETHER_LOCAL_MAIL_BUDGET=0"
+# forces the base side to the pre-flip cap=1 while the candidate keeps the
+# shipped keep-local default. Unset = no pins (the plain code-vs-merge-base
+# comparison). The `${arr[@]+...}` guard keeps an empty array safe under
+# `set -u`.
+base_env_args=()
+for kv in ${PERF_BASE_ENV:-}; do base_env_args+=(--base-env "$kv"); done
+cand_env_args=()
+for kv in ${PERF_CAND_ENV:-}; do cand_env_args+=(--cand-env "$kv"); done
+pin_note=""
+if [ -n "${PERF_BASE_ENV:-}${PERF_CAND_ENV:-}" ]; then
+    pin_note=" · pinned base[${PERF_BASE_ENV:-default}] cand[${PERF_CAND_ENV:-default}]"
+fi
+
 # Transient working dir for the built binaries, plus the worktree (created
 # only on a base-cache miss). Both cleaned up on exit.
 work="$(mktemp -d "${TMPDIR:-/tmp}/aether-perf.XXXXXX")"
@@ -123,10 +141,12 @@ echo "[perf-compare] running $K interleaved trials per side…"
 "$compare_bin" \
     --base "$base_trial" \
     --cand "$cand_trial" \
+    ${base_env_args[@]+"${base_env_args[@]}"} \
+    ${cand_env_args[@]+"${cand_env_args[@]}"} \
     -k "$K" \
     --out "$json_out" \
     --title "PR vs merge-base $base_short" \
-    --subtitle "baseline $base_short · $K trials/config, interleaved on one runner" \
+    --subtitle "baseline $base_short · $K trials/config, interleaved on one runner$pin_note" \
     > "$md_out"
 
 echo "[perf-compare] wrote $json_out and $md_out"


### PR DESCRIPTION
## What

Pin the scheduler keep-local budgets **per-side** in the perf-compare CI run instead of relying on each binary's compiled default. Two parts:

- `scripts/perf-compare.sh`: `PERF_BASE_ENV` / `PERF_CAND_ENV` passthrough (space-separated `KEY=VALUE`, applied per side via the comparator's existing `--base-env` / `--cand-env`).
- `.github/workflows/perf-compare.yml`: set them so the run is an explicit A/B — base forced to the pre-flip **cap=1** (`AETHER_LOCAL_MAIL_BUDGET=0`), candidate to the shipped **keep-local** default (`64` / `6µs`).

## Why (the investigation behind it)

After the keep-local flip (iamacoffeepot/aether#1160) merged, its perf-compare read **0 improved / 120 stable** on the CI runner, with the tree's `queued` span a tight **~7µs on both sides** — vs ~0.5–1.5µs locally. We chased whether that was a wrong binary / bad env:

- Base source is `unwrap_or(0)` (cap=1); candidate is `unwrap_or(64)` / `unwrap_or(6)` (keep-local) — correctly different.
- No `AETHER_LOCAL_*` anywhere in the workflow or the full CI log — no override.
- **Only the tree is inflated** on CI; depth-1/8 and fan-out-4/8 are normal (~0.6–2.4µs) on the same run — a misconfiguration can't be topology-selective.

So it isn't config. But to remove the compiled-default and base-build variables **entirely**, this run pins both sides explicitly on the **same** binary (this PR touches no scheduler code, so base and candidate are the same main binary; only the env differs). It's a clean check of whether the runner can resolve the keep-local-vs-cap=1 delta at all.

Local pinned A/B (same binary, base env cap=1 vs cand keep-local), K=10: tree `queued` p50 **1.58 → 0.58µs (−61%)**. The CI run on this PR will show whether that survives the shared runner or floors at ~7µs (which would confirm it's the runner, not config).

## Scope / permanence

The reusable, general piece is the `perf-compare.sh` env passthrough. The hard-coded per-side pin in the workflow makes **every** perf-compare a cap=1-vs-keep-local A/B rather than a code-vs-merge-base comparison — appropriate as a standing keep-local-effect monitor, but we should decide that explicitly before merge (vs reverting the workflow pin and keeping only the passthrough). Triggered with the `perf` label since the changed paths don't match the auto-filter.

Follow-up to iamacoffeepot/aether#1160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
