### PR TITLE
fix(capabilities): bump anthropic messages model allowlist to current lineup

### DIFF
--- a/crates/aether-capabilities/src/anthropic/api.rs
+++ b/crates/aether-capabilities/src/anthropic/api.rs
@@ -178,7 +178,7 @@ mod tests {
         let resp = parse_messages_response(FIXTURE, "fallback-model", 42)
             .expect("fixture is a valid Messages-API response");
         assert_eq!(resp.text, "Hello! How can I help you today?");
-        assert_eq!(resp.model_used, "claude-opus-4-20250514");
+        assert_eq!(resp.model_used, "claude-opus-4-7");
         assert_eq!(resp.usage.input_tokens, 12);
         assert_eq!(resp.usage.output_tokens, 9);
         assert_eq!(resp.usage.wall_clock_ms, 42);

--- a/crates/aether-capabilities/src/anthropic/fixtures/messages_response.json
+++ b/crates/aether-capabilities/src/anthropic/fixtures/messages_response.json
@@ -2,7 +2,7 @@
   "id": "msg_01ABCDEF",
   "type": "message",
   "role": "assistant",
-  "model": "claude-opus-4-20250514",
+  "model": "claude-opus-4-7",
   "content": [
     {
       "type": "text",

--- a/crates/aether-capabilities/src/anthropic/mod.rs
+++ b/crates/aether-capabilities/src/anthropic/mod.rs
@@ -46,12 +46,12 @@ pub const DEFAULT_TIMEOUT_MS: u32 = 120_000;
 /// Models the Messages-API backend accepts. The cap validates a
 /// request's `model` against this before any dispatch; the CLI backend
 /// passes the model through to `claude` and doesn't gate (the CLI
-/// validates). Pinned per the 2026-05 model lineup; bump as new models
+/// validates). Pinned to the 2026-05 model lineup; bump as new models
 /// ship.
 const SUPPORTED_MESSAGES_MODELS: &[&str] = &[
-    "claude-opus-4-20250514",
-    "claude-sonnet-4-20250514",
-    "claude-3-5-haiku-20241022",
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5-20251001",
 ];
 
 /// Adapter returned when `ANTHROPIC_API_KEY` is unset (or
@@ -893,7 +893,7 @@ mod native {
             let adapter = UreqAnthropicAdapter::new(key, Duration::from_secs(30));
             let resp = adapter
                 .messages_send(&AnthropicRequest {
-                    model: "claude-3-5-haiku-20241022".to_string(),
+                    model: "claude-haiku-4-5-20251001".to_string(),
                     prompt: "say hi".to_string(),
                     system: None,
                     max_tokens: Some(5),


### PR DESCRIPTION
Closes iamacoffeepot/aether#1165

- Replace the stale `SUPPORTED_MESSAGES_MODELS` allowlist (May-2025 4.0/3.5 ids) with the current lineup (`claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`), so `aether.anthropic.messages.send` no longer rejects current models with `UnknownModel` before dispatch.
- Correct the comment's claimed date-to-ids mismatch (it claimed the 2026-05 lineup while listing 2024/2025 ids); kept the "bump as new models ship" note.
- Refresh the captured Messages-API fixture + its paired assertion and the ignored live-smoke model id so no stale 2024/2025 literals remain in the crate. Unit tests use the synthetic `"claude-test"` stub, so they're unchanged.

Mechanical bump only; the durable "don't let the list rot" redesign is split to iamacoffeepot/aether#1170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)