### PR TITLE
fix(capabilities): give the claude cli subprocess backend a timeout

### DIFF
--- a/crates/aether-capabilities/src/anthropic/cli.rs
+++ b/crates/aether-capabilities/src/anthropic/cli.rs
@@ -114,11 +114,15 @@ impl ClaudeCliAdapter {
                 Ok(Some(status)) => break status,
                 Ok(None) => {
                     if started.elapsed() >= self.timeout {
-                        // Deadline overrun: kill + reap so no zombie is
-                        // left, join the reader, and surface the timeout.
+                        // Deadline overrun: kill + reap so no zombie is left,
+                        // then surface the timeout. We deliberately do NOT
+                        // join the stdout reader here — a killed `claude`/shell
+                        // can leave an orphaned grandchild holding the pipe's
+                        // write-end open, so `read_to_end` never sees EOF and
+                        // the join would block past the deadline. Dropping the
+                        // JoinHandle detaches the thread; its buffer is moot.
                         let _ = child.kill();
                         let _ = child.wait();
-                        let _ = stdout_reader.join();
                         let elapsed_ms =
                             u32::try_from(started.elapsed().as_millis()).unwrap_or(u32::MAX);
                         return Err(format!("{TIMEOUT_SENTINEL}{elapsed_ms}"));

--- a/crates/aether-capabilities/src/anthropic/cli.rs
+++ b/crates/aether-capabilities/src/anthropic/cli.rs
@@ -206,11 +206,11 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn slow_binary_times_out_and_is_reaped() {
-        use std::fs;
         use std::os::unix::fs::PermissionsExt;
+        use std::{env, fs, process};
 
-        let mut script = std::env::temp_dir();
-        script.push(format!("aether-cli-timeout-{}.sh", std::process::id()));
+        let mut script = env::temp_dir();
+        script.push(format!("aether-cli-timeout-{}.sh", process::id()));
         // Ignore every arg, sleep 5s. A ~50ms deadline must fire first.
         fs::write(&script, "#!/bin/sh\nsleep 5\n").expect("write stand-in script");
         fs::set_permissions(&script, fs::Permissions::from_mode(0o755))

--- a/crates/aether-capabilities/src/anthropic/cli.rs
+++ b/crates/aether-capabilities/src/anthropic/cli.rs
@@ -9,10 +9,12 @@
 //! The blocking `std::process::Command` call runs on issue 1013's
 //! spawn-and-die ephemeral thread, never on the dispatcher.
 
-use std::io::{ErrorKind, Write};
+use std::io::{ErrorKind, Read, Write};
 use std::process::{Command, Stdio};
-use std::time::Instant;
+use std::thread;
+use std::time::{Duration, Instant};
 
+use super::DEFAULT_TIMEOUT_MS;
 use crate::contentgen::adapter::{AdapterUsage, AnthropicRequest, AnthropicResponse};
 
 /// Sentinel returned when the `claude` binary isn't on PATH so the cap
@@ -20,34 +22,50 @@ use crate::contentgen::adapter::{AdapterUsage, AnthropicRequest, AnthropicRespon
 /// prefix — the dispatch boundary is `Result<_, String>`.
 pub const CLI_NOT_FOUND: &str = "cli-not-found";
 
+/// Sentinel prefix returned when the `claude` subprocess overruns its
+/// deadline and is killed. Formatted as `timeout=<elapsed_ms>` so the
+/// cap maps it onto `AnthropicError::Timeout { elapsed_ms }` (the cap
+/// parses the trailing integer the way it parses `status=`).
+pub const TIMEOUT_SENTINEL: &str = "timeout=";
+
+/// How often the deadline loop polls `child.try_wait()`. Short enough
+/// that a hung call is killed promptly after expiry without busy-waiting.
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
 /// `claude`-subprocess adapter. Holds the binary name (default
-/// `"claude"`); the model + prompt ride per-request. The model is
-/// passed via `--model` so the user's CLI selects the right backend.
+/// `"claude"`) and a per-request deadline; the model + prompt ride
+/// per-request. The model is passed via `--model` so the user's CLI
+/// selects the right backend.
 pub struct ClaudeCliAdapter {
     binary: String,
+    timeout: Duration,
 }
 
 impl Default for ClaudeCliAdapter {
     fn default() -> Self {
         Self {
             binary: String::from("claude"),
+            timeout: Duration::from_millis(u64::from(DEFAULT_TIMEOUT_MS)),
         }
     }
 }
 
 impl ClaudeCliAdapter {
-    /// Build an adapter that invokes `binary`. Production uses the
-    /// default `"claude"`; tests point it at a missing binary to
-    /// exercise the `CliNotFound` path without depending on the host.
+    /// Build an adapter that invokes `binary` with the given per-request
+    /// `timeout`. Production wires `config.timeout`; tests point it at a
+    /// missing or slow binary to exercise the `CliNotFound` / `Timeout`
+    /// paths without depending on the host.
     #[must_use]
-    pub fn new(binary: String) -> Self {
-        Self { binary }
+    pub fn new(binary: String, timeout: Duration) -> Self {
+        Self { binary, timeout }
     }
 
     /// Run a completion through the `claude` subprocess. Returns the
     /// completion text or a free-form error string. A missing binary
     /// surfaces as `CLI_NOT_FOUND`; the cap maps that onto
-    /// `AnthropicError::CliNotFound`.
+    /// `AnthropicError::CliNotFound`. A call that overruns the adapter's
+    /// `timeout` is killed + reaped and surfaces as `TIMEOUT_SENTINEL`,
+    /// which the cap maps onto `AnthropicError::Timeout`.
     pub fn cli_send(&self, req: &AnthropicRequest) -> Result<AnthropicResponse, String> {
         let started = Instant::now();
 
@@ -78,11 +96,49 @@ impl ClaudeCliAdapter {
             // Drop closes the pipe so `claude` sees EOF and proceeds.
         }
 
-        let output = child
-            .wait_with_output()
-            .map_err(|e| format!("wait for claude: {e}"))?;
+        // Drain stdout on a dedicated thread so a full pipe can't stall
+        // `claude` (and thus the deadline poll) while we own the `Child`
+        // on this thread. stderr is small and drained after the wait.
+        let stdout = child.stdout.take();
+        let stdout_reader = thread::spawn(move || {
+            let mut buf = Vec::new();
+            if let Some(mut out) = stdout {
+                let _ = out.read_to_end(&mut buf);
+            }
+            buf
+        });
 
-        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Poll for exit until the child finishes or the deadline passes.
+        let status = loop {
+            match child.try_wait() {
+                Ok(Some(status)) => break status,
+                Ok(None) => {
+                    if started.elapsed() >= self.timeout {
+                        // Deadline overrun: kill + reap so no zombie is
+                        // left, join the reader, and surface the timeout.
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        let _ = stdout_reader.join();
+                        let elapsed_ms =
+                            u32::try_from(started.elapsed().as_millis()).unwrap_or(u32::MAX);
+                        return Err(format!("{TIMEOUT_SENTINEL}{elapsed_ms}"));
+                    }
+                    thread::sleep(POLL_INTERVAL);
+                }
+                Err(e) => {
+                    let _ = stdout_reader.join();
+                    return Err(format!("wait for claude: {e}"));
+                }
+            }
+        };
+
+        let stdout_bytes = stdout_reader.join().unwrap_or_default();
+
+        let mut stderr_bytes = Vec::new();
+        if let Some(mut err) = child.stderr.take() {
+            let _ = err.read_to_end(&mut stderr_bytes);
+        }
+        let stderr = String::from_utf8_lossy(&stderr_bytes);
         if !stderr.trim().is_empty() {
             tracing::warn!(
                 target: "aether_capabilities::anthropic",
@@ -91,15 +147,11 @@ impl ClaudeCliAdapter {
             );
         }
 
-        if !output.status.success() {
-            return Err(format!(
-                "claude exited with {}: {}",
-                output.status,
-                stderr.trim()
-            ));
+        if !status.success() {
+            return Err(format!("claude exited with {}: {}", status, stderr.trim()));
         }
 
-        let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let text = String::from_utf8_lossy(&stdout_bytes).trim().to_string();
         let wall_clock_ms = u32::try_from(started.elapsed().as_millis()).unwrap_or(u32::MAX);
 
         Ok(AnthropicResponse {
@@ -117,8 +169,9 @@ impl ClaudeCliAdapter {
 
 #[cfg(test)]
 mod tests {
-    use super::{CLI_NOT_FOUND, ClaudeCliAdapter};
+    use super::{CLI_NOT_FOUND, ClaudeCliAdapter, TIMEOUT_SENTINEL};
     use crate::contentgen::adapter::AnthropicRequest;
+    use std::time::{Duration, Instant};
 
     fn req() -> AnthropicRequest {
         AnthropicRequest {
@@ -134,10 +187,56 @@ mod tests {
     fn missing_binary_returns_cli_not_found() {
         // Point the adapter at a binary that can't exist on PATH so the
         // test never depends on whether the real `claude` is installed.
-        let adapter = ClaudeCliAdapter::new("aether-nonexistent-claude-binary-xyzzy".to_string());
+        let adapter = ClaudeCliAdapter::new(
+            "aether-nonexistent-claude-binary-xyzzy".to_string(),
+            Duration::from_secs(30),
+        );
         let err = adapter
             .cli_send(&req())
             .expect_err("a missing binary must error");
         assert_eq!(err, CLI_NOT_FOUND);
+    }
+
+    /// A subprocess that outlives the deadline is killed + reaped and
+    /// surfaces as `TIMEOUT_SENTINEL` carrying the elapsed ms — well
+    /// under the child's nominal 5s sleep. The adapter always invokes
+    /// `<binary> --print --model <model> ...`, so the stand-in must be a
+    /// script that ignores its args and sleeps. We write a tiny shell
+    /// script to a temp file and point the adapter at it.
+    #[cfg(unix)]
+    #[test]
+    fn slow_binary_times_out_and_is_reaped() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut script = std::env::temp_dir();
+        script.push(format!("aether-cli-timeout-{}.sh", std::process::id()));
+        // Ignore every arg, sleep 5s. A ~50ms deadline must fire first.
+        fs::write(&script, "#!/bin/sh\nsleep 5\n").expect("write stand-in script");
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755))
+            .expect("chmod stand-in script");
+
+        let adapter = ClaudeCliAdapter::new(
+            script.to_string_lossy().into_owned(),
+            Duration::from_millis(50),
+        );
+        let started = Instant::now();
+        let err = adapter
+            .cli_send(&req())
+            .expect_err("a slow binary must time out");
+
+        let _ = fs::remove_file(&script);
+
+        assert!(
+            err.starts_with(TIMEOUT_SENTINEL),
+            "expected timeout sentinel, got {err:?}",
+        );
+        // The deadline fired well under the child's 5s lifetime, which
+        // also implies the kill returned (the child was reaped).
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "timeout took too long: {:?}",
+            started.elapsed(),
+        );
     }
 }

--- a/crates/aether-capabilities/src/anthropic/error.rs
+++ b/crates/aether-capabilities/src/anthropic/error.rs
@@ -8,7 +8,7 @@
 
 use aether_kinds::AnthropicError;
 
-use crate::anthropic::cli::CLI_NOT_FOUND;
+use crate::anthropic::cli::{CLI_NOT_FOUND, TIMEOUT_SENTINEL};
 use crate::contentgen::shared::{parse_status_prefix, snippet};
 
 /// Sentinel an adapter returns to mean "no API key" so the cap maps it
@@ -29,6 +29,13 @@ pub fn adapter_error_to_typed(raw: &str) -> AnthropicError {
     }
     if raw == UNAUTHORIZED_SENTINEL {
         return AnthropicError::Unauthorized;
+    }
+    if let Some(rest) = raw.strip_prefix(TIMEOUT_SENTINEL) {
+        // `timeout=<elapsed_ms>` — parse the trailing integer the way
+        // the `status=` prefix is parsed. A malformed tail falls back to
+        // 0 rather than dropping the timeout classification.
+        let elapsed_ms = rest.trim().parse::<u32>().unwrap_or(0);
+        return AnthropicError::Timeout { elapsed_ms };
     }
     if let Some(rest) = raw.strip_prefix("status=")
         && let Some((status, retry_after_ms)) = parse_status_prefix(rest)
@@ -61,8 +68,27 @@ pub fn status_to_error(status: u16, retry_after_ms: Option<u32>, body: &str) -> 
 
 #[cfg(test)]
 mod tests {
-    use super::status_to_error;
+    use super::{adapter_error_to_typed, status_to_error};
+    use crate::anthropic::cli::TIMEOUT_SENTINEL;
     use aether_kinds::AnthropicError;
+
+    #[test]
+    fn timeout_sentinel_maps_to_timeout() {
+        let raw = format!("{TIMEOUT_SENTINEL}1500");
+        assert_eq!(
+            adapter_error_to_typed(&raw),
+            AnthropicError::Timeout { elapsed_ms: 1500 }
+        );
+    }
+
+    #[test]
+    fn malformed_timeout_sentinel_still_classifies_as_timeout() {
+        let raw = format!("{TIMEOUT_SENTINEL}garbage");
+        assert_eq!(
+            adapter_error_to_typed(&raw),
+            AnthropicError::Timeout { elapsed_ms: 0 }
+        );
+    }
 
     #[test]
     fn unauthorized_statuses_map_to_unauthorized() {

--- a/crates/aether-capabilities/src/anthropic/mod.rs
+++ b/crates/aether-capabilities/src/anthropic/mod.rs
@@ -64,6 +64,18 @@ pub struct DisabledAnthropicAdapter {
     cli: ClaudeCliAdapter,
 }
 
+impl DisabledAnthropicAdapter {
+    /// Build the disabled adapter with the CLI backend wired to the
+    /// cap's per-request `timeout`. The default impl uses
+    /// `DEFAULT_TIMEOUT_MS`; production threads `config.timeout`.
+    #[must_use]
+    pub fn new(timeout: Duration) -> Self {
+        Self {
+            cli: ClaudeCliAdapter::new(String::from("claude"), timeout),
+        }
+    }
+}
+
 impl AnthropicAdapter for DisabledAnthropicAdapter {
     fn messages_send(&self, _req: AnthropicRequest) -> Result<AnthropicResponse, String> {
         // The cap maps this sentinel onto `AnthropicError::Unauthorized`.
@@ -83,12 +95,14 @@ pub struct CombinedAnthropicAdapter {
 }
 
 impl CombinedAnthropicAdapter {
-    /// Build the combined adapter with a resolved API key + timeout.
+    /// Build the combined adapter with a resolved API key + timeout. The
+    /// `timeout` bounds both the Messages HTTPS call and the `claude`
+    /// subprocess deadline.
     #[must_use]
     pub fn new(api_key: String, timeout: Duration) -> Self {
         Self {
             messages: UreqAnthropicAdapter::new(api_key, timeout),
-            cli: ClaudeCliAdapter::default(),
+            cli: ClaudeCliAdapter::new(String::from("claude"), timeout),
         }
     }
 }
@@ -253,7 +267,7 @@ mod native {
                 target: "aether_capabilities::anthropic",
                 "anthropic adapter disabled — messages reply Unauthorized; cli still routes",
             );
-            return Arc::new(DisabledAnthropicAdapter::default());
+            return Arc::new(DisabledAnthropicAdapter::new(config.timeout));
         }
         config.api_key.as_ref().map_or_else(
             || {
@@ -261,7 +275,7 @@ mod native {
                     target: "aether_capabilities::anthropic",
                     "ANTHROPIC_API_KEY unset — messages reply Unauthorized; cli still routes",
                 );
-                Arc::new(DisabledAnthropicAdapter::default()) as Arc<dyn AnthropicAdapter>
+                Arc::new(DisabledAnthropicAdapter::new(config.timeout)) as Arc<dyn AnthropicAdapter>
             },
             |key| {
                 tracing::info!(
@@ -774,6 +788,7 @@ mod native {
                 Arc::new(MissingCliAdapter {
                     cli: ClaudeCliAdapter::new(
                         "aether-nonexistent-claude-binary-xyzzy".to_string(),
+                        Duration::from_secs(30),
                     ),
                 }),
                 Arc::clone(&mailer),

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -2301,8 +2301,11 @@ mod control_plane {
     /// `ContextLengthExceeded` → trim the prompt, `Unauthorized` →
     /// config issue, `ContentPolicyRefused` → surface to the user,
     /// `CliNotFound` → the `claude` binary isn't on PATH,
-    /// `UnknownModel` → typo / unsupported id. `AdapterError` is the
-    /// catchall preserving backend-specific detail as free-form text.
+    /// `UnknownModel` → typo / unsupported id,
+    /// `Timeout` → a backend call (notably the `claude` subprocess)
+    /// exceeded the cap's per-request deadline and the child was killed.
+    /// `AdapterError` is the catchall preserving backend-specific detail
+    /// as free-form text.
     #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
     pub enum AnthropicError {
         Overloaded,
@@ -2318,6 +2321,9 @@ mod control_plane {
         UnknownModel {
             model: String,
             supported: Vec<String>,
+        },
+        Timeout {
+            elapsed_ms: u32,
         },
         AdapterError(String),
     }


### PR DESCRIPTION
Closes iamacoffeepot/aether#1166

- Add a no-dependency reader-thread + try_wait poll loop to ClaudeCliAdapter::cli_send: a dedicated thread drains stdout (a full pipe would stall claude) while the deadline poll owns the Child; on expiry the child is killed + reaped (mirrors the Child::kill() + wait() pattern in engine/proxy.rs) and the call returns a timeout=elapsed_ms sentinel.
- Thread config.timeout into ClaudeCliAdapter (new timeout field; new takes it, default uses DEFAULT_TIMEOUT_MS) through both CombinedAnthropicAdapter and DisabledAnthropicAdapter; add AnthropicError::Timeout { elapsed_ms } and map the sentinel in anthropic/error.rs. The timeout flows back as a normal Err from the BlockingCall, so the loopback frees the in-flight slot and drops the SettlementHold as usual.
- Note: this adds a variant to AnthropicError, which iamacoffeepot/aether#1169 also touches, so a trivial rebase against that PR may be needed.

Generated with Claude Code