### PR TITLE
fix(capabilities): reject anthropic cli.send params the claude binary can't honor

### DIFF
--- a/crates/aether-capabilities/src/anthropic/mod.rs
+++ b/crates/aether-capabilities/src/anthropic/mod.rs
@@ -591,6 +591,7 @@ mod native {
         use aether_substrate::actor::native::binding::NativeBinding;
         use aether_substrate::actor::native::ctx::NativeCtx;
         use aether_substrate::chassis::builder::Builder;
+        use aether_substrate::mail::mailer::Mailer;
         use aether_substrate::mail::outbound::EgressEvent;
         use serde::de::DeserializeOwned;
         use std::sync::Arc;
@@ -775,7 +776,7 @@ mod native {
         /// the caller can assert `test_in_flight()`. The reply lands on
         /// the `mailer`'s loopback rx (held separately by the caller).
         fn cli_send_with(
-            mailer: &Arc<aether_substrate::mail::mailer::Mailer>,
+            mailer: &Arc<Mailer>,
             max_tokens: Option<u32>,
             temperature: Option<f32>,
         ) -> AnthropicCapability {

--- a/crates/aether-capabilities/src/anthropic/mod.rs
+++ b/crates/aether-capabilities/src/anthropic/mod.rs
@@ -505,9 +505,33 @@ mod native {
         /// # Agent
         /// Reply: `CliSendResult`. Replies `Err { CliNotFound }` when
         /// `claude` isn't on PATH. The CLI uses the user's subscription,
-        /// so it works even when `ANTHROPIC_API_KEY` is unset.
+        /// so it works even when `ANTHROPIC_API_KEY` is unset. The
+        /// `claude` binary exposes no `--max-tokens` / `--temperature`
+        /// flag, so setting either replies `Err { ParamNotSupported }`
+        /// synchronously (no dispatch) rather than silently dropping it —
+        /// route sampling knobs through `aether.anthropic.messages.send`.
         #[handler]
         fn on_cli_send(&mut self, ctx: &mut NativeCtx<'_>, mail: CliSend) {
+            // The `claude` CLI has no flag for either knob; reject when
+            // set instead of silently dropping (the outcome to avoid —
+            // `feedback_explicit_nulls_over_absent_fields`).
+            let mut unsupported = Vec::new();
+            if mail.max_tokens.is_some() {
+                unsupported.push("max_tokens");
+            }
+            if mail.temperature.is_some() {
+                unsupported.push("temperature");
+            }
+            if !unsupported.is_empty() {
+                let error = AnthropicError::ParamNotSupported {
+                    param: unsupported.join(", "),
+                    reason:
+                        "the claude CLI has no flag for this; use aether.anthropic.messages.send"
+                            .to_string(),
+                };
+                Self::reply_err(ctx, SendPath::Cli, mail.request_id, error);
+                return;
+            }
             let req = AnthropicRequest {
                 prompt: flatten_prompt(&mail.messages),
                 model: mail.model,
@@ -744,6 +768,102 @@ mod native {
             // No in-flight work was spawned — the synchronous error path
             // never touched the dispatch helper.
             assert_eq!(cap_in_flight(&cap), 0);
+        }
+
+        /// Boot a cap against the recording stub and fire a `CliSend`
+        /// carrying the given knobs at `on_cli_send`, returning the cap so
+        /// the caller can assert `test_in_flight()`. The reply lands on
+        /// the `mailer`'s loopback rx (held separately by the caller).
+        fn cli_send_with(
+            mailer: &Arc<aether_substrate::mail::mailer::Mailer>,
+            max_tokens: Option<u32>,
+            temperature: Option<f32>,
+        ) -> AnthropicCapability {
+            let cap_mailbox = MailboxId(0);
+            let mut cap = AnthropicCapability::from_parts(
+                Arc::new(RecordingStub {
+                    inner: StubAnthropicAdapter::default(),
+                }),
+                Arc::clone(mailer),
+                cap_mailbox,
+                4,
+            );
+            let transport = Arc::new(NativeBinding::new_for_test(
+                Arc::clone(mailer),
+                cap_mailbox,
+            ));
+            let mut ctx = NativeCtx::new(
+                &transport,
+                session_sender(),
+                aether_data::MailId::NONE,
+                aether_data::MailId::NONE,
+            );
+            cap.on_cli_send(
+                &mut ctx,
+                CliSend {
+                    request_id: 11,
+                    model: "claude-test".to_string(),
+                    messages: user_msg("hi"),
+                    max_tokens,
+                    temperature,
+                    system: None,
+                },
+            );
+            cap
+        }
+
+        /// `on_cli_send` with `max_tokens` set replies
+        /// `Err { ParamNotSupported }` synchronously and spawns no work —
+        /// the `claude` CLI has no flag to honor it.
+        #[test]
+        fn anthropic_cli_rejects_max_tokens() {
+            let (mailer, rx) = test_mailer_and_rx();
+            let cap = cli_send_with(&mailer, Some(256), None);
+            match decode_reply::<CliSendResult>(&rx) {
+                CliSendResult::Err {
+                    request_id,
+                    error: AnthropicError::ParamNotSupported { param, reason },
+                } => {
+                    assert_eq!(request_id, 11);
+                    assert!(param.contains("max_tokens"), "param was {param:?}");
+                    assert!(reason.contains("messages.send"), "reason was {reason:?}");
+                }
+                other => panic!("expected ParamNotSupported, got {other:?}"),
+            }
+            // Synchronous error path never touched the dispatch helper.
+            assert_eq!(cap_in_flight(&cap), 0);
+        }
+
+        /// `on_cli_send` with `temperature` set replies
+        /// `Err { ParamNotSupported }` synchronously and spawns no work.
+        #[test]
+        fn anthropic_cli_rejects_temperature() {
+            let (mailer, rx) = test_mailer_and_rx();
+            let cap = cli_send_with(&mailer, None, Some(0.7));
+            match decode_reply::<CliSendResult>(&rx) {
+                CliSendResult::Err {
+                    request_id,
+                    error: AnthropicError::ParamNotSupported { param, .. },
+                } => {
+                    assert_eq!(request_id, 11);
+                    assert!(param.contains("temperature"), "param was {param:?}");
+                }
+                other => panic!("expected ParamNotSupported, got {other:?}"),
+            }
+            assert_eq!(cap_in_flight(&cap), 0);
+        }
+
+        /// A `CliSend` with both knobs `None` dispatches normally — the
+        /// synchronous reject path is skipped and work is spawned.
+        #[test]
+        fn anthropic_cli_no_params_dispatches() {
+            let (mailer, _rx) = test_mailer_and_rx();
+            let cap = cli_send_with(&mailer, None, None);
+            assert_eq!(
+                cap_in_flight(&cap),
+                1,
+                "a param-free CliSend should dispatch one in-flight call"
+            );
         }
 
         /// CLI send with a missing `claude` binary replies

--- a/crates/aether-capabilities/src/anthropic/mod.rs
+++ b/crates/aether-capabilities/src/anthropic/mod.rs
@@ -788,10 +788,7 @@ mod native {
                 cap_mailbox,
                 4,
             );
-            let transport = Arc::new(NativeBinding::new_for_test(
-                Arc::clone(mailer),
-                cap_mailbox,
-            ));
+            let transport = Arc::new(NativeBinding::new_for_test(Arc::clone(mailer), cap_mailbox));
             let mut ctx = NativeCtx::new(
                 &transport,
                 session_sender(),

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -2301,8 +2301,12 @@ mod control_plane {
     /// `ContextLengthExceeded` → trim the prompt, `Unauthorized` →
     /// config issue, `ContentPolicyRefused` → surface to the user,
     /// `CliNotFound` → the `claude` binary isn't on PATH,
-    /// `UnknownModel` → typo / unsupported id. `AdapterError` is the
-    /// catchall preserving backend-specific detail as free-form text.
+    /// `UnknownModel` → typo / unsupported id,
+    /// `ParamNotSupported` → the request set a knob the backend has no
+    /// way to honor (e.g. `max_tokens` / `temperature` on the CLI path,
+    /// which the `claude` binary exposes no flag for — reject rather than
+    /// silently drop). `AdapterError` is the catchall preserving
+    /// backend-specific detail as free-form text.
     #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
     pub enum AnthropicError {
         Overloaded,
@@ -2318,6 +2322,10 @@ mod control_plane {
         UnknownModel {
             model: String,
             supported: Vec<String>,
+        },
+        ParamNotSupported {
+            param: String,
+            reason: String,
         },
         AdapterError(String),
     }


### PR DESCRIPTION
The claude CLI exposes no max-tokens / temperature flag, so the CLI backend silently dropped both — a caller set them, the request "succeeded," and they had no effect.

- Adds AnthropicError::ParamNotSupported { param, reason } to aether-kinds; the exhaustive-match surfaces (anthropic/error.rs status table, the cap reply builders) compiled unchanged since none match the enum without a wildcard.
- on_cli_send now replies Err { ParamNotSupported } synchronously (no dispatch) when max_tokens or temperature is set, listing whichever param(s) are present, mirroring the dispatch_send unknown-model early return. The Messages path is untouched (it honors both). CliSend keeps both fields — removing them would be a breaking wire-schema change.
- Tests: cli.send with max_tokens (and separately temperature) replies ParamNotSupported and spawns no work (in-flight == 0); a both-None cli.send still dispatches.

Note: PR 1175 (issue 1166) also adds a variant to AnthropicError — a trivial rebase may be needed depending on merge order.

Closes iamacoffeepot/aether#1169