### PR TITLE
perf(substrate): retire peer-deque work-stealing by default (owner-only)

### DIFF
--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -262,8 +262,12 @@ fn worker_loop(
     // on this worker can read the scheduler ready-queue depth
     // (`worker_deque::pending_depth`) for the latency harness.
     worker_deque::install_injector(Arc::clone(&injector));
+    // Whether this worker may raid siblings' deques, or is owner-only over
+    // its own (iamacoffeepot/aether#1174). A per-process constant — read once
+    // here, not per `acquire_slot`, and threaded into the steal scan.
+    let peer_steal = worker_deque::peer_steal_enabled();
     loop {
-        let Some(slot) = acquire_slot(idx, &stealers, &injector, &spin) else {
+        let Some(slot) = acquire_slot(idx, &stealers, &injector, &spin, peer_steal) else {
             // Shutdown signalled. Exit.
             return;
         };
@@ -325,7 +329,8 @@ fn worker_loop(
 /// next cascade (this worker's freshly-produced blobs, or work it's about
 /// to steal) starts a fresh keep-local budget — then steals into the deque
 /// from the injector (off-worker producers + spilled fan-out + requeued
-/// yields) and its siblings' tails. When that turns up nothing, the
+/// yields) and, when `peer_steal` is set, its siblings' tails (owner-only
+/// when off, iamacoffeepot/aether#1174). When that turns up nothing, the
 /// coordinator
 /// (iamacoffeepot/aether#1064) takes over: it keeps the worker spinning
 /// (re-running the steal scan) for a bounded window so a producer can
@@ -339,6 +344,7 @@ fn acquire_slot(
     stealers: &[Stealer<Arc<dyn Drainable>>],
     injector: &Injector<Arc<dyn Drainable>>,
     spin: &SpinPark,
+    peer_steal: bool,
 ) -> Option<Arc<dyn Drainable>> {
     if let Some(slot) = worker_deque::pop_local() {
         return Some(slot);
@@ -347,10 +353,10 @@ fn acquire_slot(
     // keep-local burst (iamacoffeepot/aether#1160) so stolen work, or this
     // worker's next cascade, starts under a fresh mail/time budget.
     worker_deque::burst_reset();
-    if let Some(slot) = worker_deque::steal_into_local(idx, stealers, injector) {
+    if let Some(slot) = worker_deque::steal_into_local(idx, stealers, injector, peer_steal) {
         return Some(slot);
     }
-    match spin.acquire(|| worker_deque::steal_into_local(idx, stealers, injector)) {
+    match spin.acquire(|| worker_deque::steal_into_local(idx, stealers, injector, peer_steal)) {
         Acquired::Slot(slot) => Some(slot),
         Acquired::Shutdown => None,
     }

--- a/crates/aether-substrate/src/scheduler/worker_deque.rs
+++ b/crates/aether-substrate/src/scheduler/worker_deque.rs
@@ -20,8 +20,10 @@
 //! iamacoffeepot/aether#1160); set `AETHER_LOCAL_MAIL_BUDGET=0` to restore
 //! the historical `cap == 1` "spill any fan-out extra" behaviour.
 //! `AETHER_LOCAL_STICKY_MAX` is the deque-length safety backstop
-//! ([`hard_cap`]). The tail an idle worker can `steal_batch_and_pop` is the
-//! pull path.
+//! ([`hard_cap`]). A worker is **owner-only** over its own deque by default
+//! ([`peer_steal_enabled`], iamacoffeepot/aether#1174): it pulls only the
+//! shared injector, never a sibling's keep-local cascade. Set
+//! `AETHER_PEER_STEAL=1` to opt the sibling-tail raid back in.
 //!
 //! Only pool-worker threads call [`install`]; on any other thread
 //! (chassis main, the hub, the trace drainer) [`try_push_local_budgeted`]
@@ -164,6 +166,35 @@ pub fn time_budget() -> Duration {
     Duration::from_micros(us)
 }
 
+/// Whether idle workers may raid siblings' deques (peer-deque stealing),
+/// read once from `AETHER_PEER_STEAL`; default **off** — each worker is
+/// **owner-only** over its own deque (iamacoffeepot/aether#1174). Set
+/// **1** (or `true`) to opt the sibling raid back in.
+///
+/// The default flipped to owner-only because peer-deque stealing stopped
+/// being load-bearing after seize-direct (iamacoffeepot/aether#1135),
+/// cursor-shared cooperative blob (iamacoffeepot/aether#1141), and the
+/// keep-local budget (iamacoffeepot/aether#1160): a blob on a worker's own
+/// deque is there *because the budget judged it cheap* — it didn't spill.
+/// Raiding it pays a cache-cold cross-worker handoff for sub-threshold work,
+/// so the steal can cost more than the work is worth, and it contradicts the
+/// decision that kept the blob local. Worthwhile (wide / heavy) work
+/// parallelises through the injector via spill + recruit, which the
+/// unconditional injector drain still serves. The cost of owner-only is the
+/// loss of the budget-misclassification safety net — heavy work the budget
+/// *wrongly* keeps local strands on its owner with no idle-sibling rescue,
+/// raising the stakes on the iamacoffeepot/aether#1128 cost classification;
+/// `AETHER_PEER_STEAL=1` restores the rescue.
+#[must_use]
+pub fn peer_steal_enabled() -> bool {
+    static E: OnceLock<bool> = OnceLock::new();
+    *E.get_or_init(|| {
+        env::var("AETHER_PEER_STEAL")
+            .ok()
+            .is_some_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+    })
+}
+
 /// Note one dispatched envelope against the current local-drain burst
 /// (iamacoffeepot/aether#1160). Increments the burst mail counter and, when
 /// time budgeting is on (`time_budget > 0`), anchors the burst start on the
@@ -281,14 +312,22 @@ pub fn pop_local() -> Option<Slot> {
 /// Steal work into this worker's own deque and return one slot to run.
 /// Prefers the [`Injector`] (off-worker producers + spilled fan-out +
 /// requeued yields, so external work isn't starved by sibling stealing),
-/// then each sibling's [`Stealer`] (skipping our own `my_idx`). Returns
-/// `None` when every source is empty. Non-blocking — safe as the
-/// `SpinPark::acquire` scan closure (its spin loop + park-commit recheck
-/// call it repeatedly).
+/// then — only when `peer_steal` is set — each sibling's [`Stealer`]
+/// (skipping our own `my_idx`). Returns `None` when every consulted source
+/// is empty. Non-blocking — safe as the `SpinPark::acquire` scan closure
+/// (its spin loop + park-commit recheck call it repeatedly).
+///
+/// `peer_steal` (read once per worker from [`peer_steal_enabled`]) gates the
+/// sibling raid only — the injector drain is unconditional and load-bearing.
+/// With it off, this worker is **owner-only** over its deque
+/// (iamacoffeepot/aether#1174): it never pulls a sibling's keep-local
+/// cascade, so a cheap blob the budget kept local isn't dragged
+/// cross-worker.
 pub fn steal_into_local(
     my_idx: usize,
     stealers: &[Stealer<Slot>],
     injector: &Injector<Slot>,
+    peer_steal: bool,
 ) -> Option<Slot> {
     LOCAL.with(|w| {
         let w = w.borrow();
@@ -302,12 +341,14 @@ pub fn steal_into_local(
                 Steal::Retry => retry = true,
                 Steal::Empty => {}
             }
-            for (i, stealer) in stealers.iter().enumerate() {
-                if i != my_idx {
-                    match stealer.steal_batch_and_pop(worker) {
-                        Steal::Success(slot) => return Some(slot),
-                        Steal::Retry => retry = true,
-                        Steal::Empty => {}
+            if peer_steal {
+                for (i, stealer) in stealers.iter().enumerate() {
+                    if i != my_idx {
+                        match stealer.steal_batch_and_pop(worker) {
+                            Steal::Success(slot) => return Some(slot),
+                            Steal::Retry => retry = true,
+                            Steal::Empty => {}
+                        }
                     }
                 }
             }
@@ -583,7 +624,7 @@ mod tests {
         // Injector work is pulled.
         let injector: Injector<Slot> = Injector::new();
         injector.push(noop());
-        assert!(steal_into_local(0, &[], &injector).is_some());
+        assert!(steal_into_local(0, &[], &injector, true).is_some());
 
         // A sibling's deque is stolen from (own index 0 is skipped).
         let sibling: Worker<Slot> = Worker::new_lifo();
@@ -591,12 +632,46 @@ mod tests {
         sibling.push(noop());
         let stealers = [Worker::<Slot>::new_lifo().stealer(), sibling.stealer()];
         assert!(
-            steal_into_local(0, &stealers, &Injector::new()).is_some(),
+            steal_into_local(0, &stealers, &Injector::new(), true).is_some(),
             "should steal from sibling index 1"
         );
 
         // Nothing anywhere → None.
         drain_local();
-        assert!(steal_into_local(0, &[], &Injector::new()).is_none());
+        assert!(steal_into_local(0, &[], &Injector::new(), true).is_none());
+    }
+
+    #[test]
+    fn steal_owner_only_skips_siblings() {
+        // With `peer_steal == false` the injector drain stays load-bearing
+        // but a sibling's deque is left untouched — owner-only
+        // (iamacoffeepot/aether#1174).
+        install(Worker::new_lifo());
+        drain_local();
+
+        // Injector is still drained regardless of peer_steal.
+        let injector: Injector<Slot> = Injector::new();
+        injector.push(noop());
+        assert!(
+            steal_into_local(0, &[], &injector, false).is_some(),
+            "injector drain is load-bearing — unaffected by peer_steal"
+        );
+
+        // A sibling holds work; owner-only must NOT raid it.
+        let sibling: Worker<Slot> = Worker::new_lifo();
+        sibling.push(noop());
+        let stealers = [Worker::<Slot>::new_lifo().stealer(), sibling.stealer()];
+        assert!(
+            steal_into_local(0, &stealers, &Injector::new(), false).is_none(),
+            "owner-only leaves the sibling's keep-local cascade alone"
+        );
+        // The same sibling IS raided once peer steal is back on — proving the
+        // flag is the only thing that changed (the work was there all along).
+        assert!(
+            steal_into_local(0, &stealers, &Injector::new(), true).is_some(),
+            "peer_steal on raids the untouched sibling"
+        );
+
+        drain_local();
     }
 }

--- a/scripts/perf-compare.sh
+++ b/scripts/perf-compare.sh
@@ -31,6 +31,15 @@
 #   AETHER_PERF_TOPOS    "ci" | "full" (default "ci")
 #   PERF_BASE_CACHE      file path for the cross-run base-binary cache
 #                        (set by the workflow; unset locally = always build)
+#   PERF_BASE_ENV        space-separated KEY=VALUE list applied as env to
+#   PERF_CAND_ENV        only the base / only the candidate trial process
+#                        (via the comparator's --base-env / --cand-env), so a
+#                        run can pin a scheduler knob per side instead of
+#                        relying on each binary's compiled default — e.g.
+#                        PERF_BASE_ENV="AETHER_PEER_STEAL=1" measures the
+#                        owner-only default candidate against a steal-on base
+#                        on the same binary (iamacoffeepot/aether#1174). Unset
+#                        = the plain code-vs-merge-base comparison.
 #
 # Usage: scripts/perf-compare.sh
 
@@ -47,6 +56,20 @@ export AETHER_PERF_TOPOS="${AETHER_PERF_TOPOS:-ci}"
 json_out="$ROOT/perf-report.json"
 md_out="$ROOT/perf-report.md"
 base_cache="${PERF_BASE_CACHE:-}"
+
+# Optional per-side scheduler-knob pins (iamacoffeepot/aether#1174). Each
+# space-separated KEY=VALUE in PERF_BASE_ENV / PERF_CAND_ENV becomes a
+# --base-env / --cand-env flag on the comparator, applied to only that side's
+# trial process. The `${arr[@]+...}` guard keeps an empty array safe under
+# `set -u`.
+base_env_args=()
+for kv in ${PERF_BASE_ENV:-}; do base_env_args+=(--base-env "$kv"); done
+cand_env_args=()
+for kv in ${PERF_CAND_ENV:-}; do cand_env_args+=(--cand-env "$kv"); done
+pin_note=""
+if [ -n "${PERF_BASE_ENV:-}${PERF_CAND_ENV:-}" ]; then
+    pin_note=" · pinned base[${PERF_BASE_ENV:-default}] cand[${PERF_CAND_ENV:-default}]"
+fi
 
 # Transient working dir for the built binaries, plus the worktree (created
 # only on a base-cache miss). Both cleaned up on exit.
@@ -123,10 +146,12 @@ echo "[perf-compare] running $K interleaved trials per side…"
 "$compare_bin" \
     --base "$base_trial" \
     --cand "$cand_trial" \
+    ${base_env_args[@]+"${base_env_args[@]}"} \
+    ${cand_env_args[@]+"${cand_env_args[@]}"} \
     -k "$K" \
     --out "$json_out" \
     --title "PR vs merge-base $base_short" \
-    --subtitle "baseline $base_short · $K trials/config, interleaved on one runner" \
+    --subtitle "baseline $base_short · $K trials/config, interleaved on one runner$pin_note" \
     > "$md_out"
 
 echo "[perf-compare] wrote $json_out and $md_out"


### PR DESCRIPTION
## What

Make each pool worker **owner-only** over its own deque by default: drop the sibling-deque raid from the steal scan, keep the shared-injector drain. Gated behind `AETHER_PEER_STEAL` (default off; `=1` opts the raid back in).

## Why

After seize-direct (iamacoffeepot/aether#1135), the cursor-shared cooperative blob (iamacoffeepot/aether#1141), and the keep-local budget (iamacoffeepot/aether#1160), peer-deque work-stealing stopped being load-bearing. `steal_into_local` consumes two sources:

1. `injector.steal_batch_and_pop` — the shared ready-queue drain. **Load-bearing**: root mail, spills, recruit clones, and requeues reach workers only through it.
2. the `for stealer in stealers` loop — raids siblings' local deques. **Vestigial**: a local deque holds *only* blobs the keep-local budget judged cheap (they didn't spill), so raiding one pays a cache-cold cross-worker handoff for sub-threshold work — and contradicts the decision that kept the blob local. Worthwhile (wide / heavy) work parallelises through the injector via spill + recruit.

This PR retires source 2 by default and keeps source 1 unconditional.

## Measurement — perf-neutral (a simplification, not a win)

Two paired A/B sweeps (owner-only candidate vs steal-on base, ADR-0085):

- **Local** (same binary, CI topologies + heavy cells, `max,2` workers, K=12): **0 / 216 / 0** — flat everywhere, including `tree-A-BC-DEEF-routed`, the trivial-router→heavy-leaf blind-spot the steal was meant to rescue.
- **CI** (this PR's perf-compare, owner-only default vs steal-on merge-base, shared Linux runner): **0 / 120 / 0** — flat.

We hypothesised the steal might be dragging the trivial tree cascade cross-worker and causing the shared-runner's ~7µs `tree` `queued` floor. **It isn't**: that floor is identical on both sides (p50 7.12→7.24µs at w=2, 7.06→7.12µs at w=3 — stable). The floor survives owner-only, so it lives in the **injector handoff / park-wake path** — the tree's shared node forces a genuine cross-worker fan-in that owner-only doesn't touch — not the peer raid. That handoff (the `queued` span, iamacoffeepot/aether#1153) is the next place to look.

So removing peer-deque stealing is **perf-neutral** across every box / topology / percentile. Its value is **simplification**: a cleaner scheduler model — own-deque (warm, keep-local) + shared injector, no sibling raid.

## Cost / safety

Owner-only removes the budget-misclassification safety net — heavy work the budget *wrongly* keeps local would strand on its owner with no idle-sibling rescue. The local routed-heavy cell showed no such regression (the net caught nothing measurable), but this raises the stakes on the per-handler cost classification (iamacoffeepot/aether#1128). `AETHER_PEER_STEAL=1` restores the rescue as an escape hatch.

## Scope

Implements Proposal 1 of iamacoffeepot/aether#1174. Proposal 2 (pull-join cooperative drain for wide in-flight blobs) is a separate follow-up. Also re-adds the `PERF_BASE_ENV` / `PERF_CAND_ENV` passthrough to `perf-compare.sh` (the durable piece from the closed pinning PR) for same-binary A/Bs.

Part of iamacoffeepot/aether#1174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
