### PR TITLE
ci(perf-compare): render distribution plots from the candidate binary, not a stale rebuild

### DIFF
--- a/.github/workflows/perf-compare.yml
+++ b/.github/workflows/perf-compare.yml
@@ -114,9 +114,17 @@ jobs:
           AETHER_PERF_FRAMES: "200"
           AETHER_PERF_PLOT_DIR: perf-plots
         run: |
-          cargo build --release -p aether-substrate-bundle \
-            --bin aether-perf-plot
-          ./target/release/aether-perf-plot
+          # Render from the candidate aether-perf-plot that
+          # scripts/perf-compare.sh built + copied aside BEFORE its base build
+          # clobbered the shared target dir. A `cargo build --bin
+          # aether-perf-plot` here would relink it against the base-clobbered
+          # aether-substrate and plot the stale merge-base default — making the
+          # distributions disagree with the percentile table.
+          if [ -x ./target/aether-perf-plot-cand ]; then
+            ./target/aether-perf-plot-cand
+          else
+            echo "no candidate perf-plot binary from perf-compare.sh; skipping plots"
+          fi
       - name: Upload span-distribution plots
         if: always()
         uses: actions/upload-artifact@v4

--- a/scripts/perf-compare.sh
+++ b/scripts/perf-compare.sh
@@ -100,9 +100,17 @@ echo "[perf-compare] baseline = merge-base $base_short; K=$K, workers=$AETHER_PE
 # first keeps the base build from clobbering it.
 echo "[perf-compare] building candidate (PR) binaries…"
 cargo build --release -p aether-substrate-bundle \
-    --bin aether-perf-trial --bin aether-perf-compare
+    --bin aether-perf-trial --bin aether-perf-compare --bin aether-perf-plot
 cp "$ROOT/target/release/aether-perf-trial" "$cand_trial"
 cp "$ROOT/target/release/aether-perf-compare" "$compare_bin"
+# Copy the candidate `aether-perf-plot` aside too. The workflow's plot step
+# renders from THIS binary instead of rebuilding, because the base build below
+# clobbers the shared target's `aether-substrate` artifacts — a `cargo build
+# --bin aether-perf-plot` afterward links the stale merge-base substrate and
+# plots the wrong default (the distributions then diverge from the percentile
+# table the comparison reports). Lands in `target/` (gitignored; survives this
+# script's cleanup trap and persists across workflow steps).
+cp "$ROOT/target/release/aether-perf-plot" "$ROOT/target/aether-perf-plot-cand"
 
 # Resolve the base trial binary: prefer the cross-run cache, else build it
 # from a throwaway worktree (sharing the candidate's target dir).


### PR DESCRIPTION
## What

Render the perf-compare distribution plots from the candidate `aether-perf-plot` that `scripts/perf-compare.sh` builds (and copies aside) *before* its base build clobbers the shared `CARGO_TARGET_DIR` — instead of rebuilding `aether-perf-plot` in the workflow's plot step afterward.

## Why

The plot step ran `cargo build --bin aether-perf-plot` *after* `perf-compare.sh`, by which point the base (merge-base) build had recompiled `aether-substrate` from the **merge-base** source into the shared target dir. So perf-plot linked the **stale merge-base** substrate and rendered the *baseline* default. The trial binary dodges this (copied aside before the base build); perf-plot didn't.

Observed on iamacoffeepot/aether#1179: the embedded `queued` distribution plots showed the **old** keep-local default's bimodal cliff (~p40, p50 up in the ~7µs zone), while the percentile table — from the correctly-built candidate trial — reported the **new** default (p50 ~1µs). Plot and table disagreed; the plot was the stale one.

## Fix

- `perf-compare.sh`: add `--bin aether-perf-plot` to the candidate build and `cp` it to `target/aether-perf-plot-cand`, before the base build — the same copy-aside discipline the trial binary already uses.
- `perf-compare.yml`: the plot step renders from `target/aether-perf-plot-cand` instead of rebuilding.

`target/` is gitignored, survives `perf-compare.sh`'s cleanup trap, and persists across workflow steps. CI-config-only (`scripts/` + `.github/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
