### PR TITLE
perf(substrate/scheduler): per-handler execution-cost EWMA dark instrumentation (issue 1128)

### DIFF
--- a/crates/aether-actor/src/cost.rs
+++ b/crates/aether-actor/src/cost.rs
@@ -24,7 +24,7 @@
 //! global index over one allocation.
 //!
 //! **No `unsafe`, no lock on the fold.** Soundness lives in the type:
-//! [`core::sync::atomic::AtomicU64`] makes every load/store race-free
+//! [`AtomicU64`] makes every load/store race-free
 //! for any access pattern (the producer reads a cell while the recipient
 //! folds it — a writer↔reader race atomics are required to make
 //! defined), and `Relaxed` lowers to a plain `mov`/`ldr` on the target

--- a/crates/aether-actor/src/cost.rs
+++ b/crates/aether-actor/src/cost.rs
@@ -1,0 +1,326 @@
+//! iamacoffeepot/aether#1128 per-handler execution-cost EWMA — Phase 0
+//! of iamacoffeepot/aether#1127's cost-aware recruiter. **Measure-only
+//! dark instrumentation; no scheduling change.**
+//!
+//! Each actor folds `(Finished.t − Received.t)` from the existing
+//! [`crate::trace_ring`] dispatch bracket into a per-handler
+//! [`CostCell`] — a constant-α EWMA of the handler's execution time in
+//! fixed-point nanos. The fold runs inside the dispatch
+//! `local::with_stamped` block on the actor's own thread, so it reaches
+//! its cell through the per-actor [`CostCells`] [`Local`] cache — a
+//! lock-free, single-threaded lookup, the hot path.
+//!
+//! The *same* `Arc<CostCell>` lives in a second index — a global
+//! `RwLock<HashMap<(MailboxId, KindId), Arc<CostCell>>>` hung off the
+//! substrate's `Mailer` (`aether-substrate`'s `cost::CostTable`) — read
+//! only on cold paths (the `cost.tail` dump, and a future
+//! iamacoffeepot/aether#1178 producer-side `Σw` read at flush). Cost is
+//! *measured* at the recipient but *consumed* cross-thread by the
+//! producer, so private per-actor storage would be unreadable by the
+//! recruiter; the shared `Arc` keeps the per-actor cache *and* the
+//! global index over one allocation.
+//!
+//! **No `unsafe`, no lock on the fold.** Soundness lives in the type:
+//! [`core::sync::atomic::AtomicU64`] makes every load/store race-free
+//! for any access pattern (the producer reads a cell while the recipient
+//! folds it — a writer↔reader race atomics are required to make
+//! defined), and `Relaxed` lowers to a plain `mov`/`ldr` on the target
+//! ISAs. The actor-lock single-writer invariant (an actor runs on one
+//! dispatch thread at a time) buys **accuracy, not soundness**: it lets
+//! the fold be a plain `load → compute → store` instead of a
+//! `compare_exchange` CAS loop, because no second thread folds the same
+//! cell. Cross-thread readers tolerate a slightly stale estimate.
+//!
+//! Mirrors the ADR-0081 [`crate::log::ActorLogRing`] mechanism: a
+//! [`Local`]-implementing newtype stamped on the actor's `ActorSlots`,
+//! reached via `try_with` / `try_with_mut` from inside the dispatch
+//! `with_stamped` block.
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use aether_data::KindId;
+
+use crate::Local;
+
+/// Constant EWMA shift `k`: `mean += (x − mean) >> k`. `k = 4` is an
+/// α of `1/16` — recent samples weigh ~6% each, so the estimate tracks
+/// a sustained shift within ~16 dispatches while smoothing one-off
+/// outliers. Power-of-two so the update is a shift, not a float
+/// multiply — no float on the dispatch hot path.
+pub const EWMA_SHIFT: u32 = 4;
+
+/// One handler's execution-cost EWMA in fixed-point nanos. The fold is
+/// single-writer-serialized by the actor lock (an actor dispatches on
+/// one thread at a time), so the RMW is a plain `load → compute →
+/// store` rather than a CAS loop; cross-thread readers (the `cost.tail`
+/// dump, the future iamacoffeepot/aether#1178 recruiter) see an
+/// eventually-consistent estimate. `Relaxed` throughout — no ordering
+/// is needed between the three cells (a reader tolerating a torn
+/// mean/mad pair is harmless for a diagnostic estimate) and `Relaxed`
+/// is zero-cost over a hypothetical plain `u64` on the target ISAs.
+#[derive(Debug, Default)]
+pub struct CostCell {
+    /// EWMA of the per-dispatch handler execution time, nanos.
+    mean: AtomicU64,
+    /// EWMA of the absolute deviation `|x − mean|`, nanos — a cheap
+    /// spread signal (mean absolute deviation, not variance) so a
+    /// reader can tell a steady handler from a bimodal one.
+    mad: AtomicU64,
+    /// Count of folded samples. `0` is the neutral seed: a handler that
+    /// is *known* (its cell was pre-seeded from the load-time handler
+    /// set) but has not run yet. Distinguishes "known-but-unrun" from
+    /// "absent" for the recruiter and the dump.
+    samples: AtomicU64,
+}
+
+impl CostCell {
+    /// A fresh neutral-seed cell: `mean = mad = samples = 0`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Fold one execution-time `sample` (nanos) into the EWMA. The
+    /// first sample seeds `mean` directly (no warm-up bias from
+    /// shifting toward zero); subsequent samples apply the constant-α
+    /// update. Plain `load → compute → store` — single-writer per the
+    /// actor lock, so no CAS.
+    pub fn fold(&self, sample: u64) {
+        let prior = self.samples.load(Ordering::Relaxed);
+        if prior == 0 {
+            // Seed the EWMA from the first observation so the estimate
+            // is meaningful immediately rather than ramping from zero.
+            self.mean.store(sample, Ordering::Relaxed);
+            self.mad.store(0, Ordering::Relaxed);
+        } else {
+            let mean = self.mean.load(Ordering::Relaxed);
+            // Signed delta folded with a symmetric shift so the EWMA
+            // tracks both rising and falling costs without float.
+            let next_mean = ewma_step(mean, sample);
+            self.mean.store(next_mean, Ordering::Relaxed);
+
+            let dev = sample.abs_diff(next_mean);
+            let mad = self.mad.load(Ordering::Relaxed);
+            self.mad.store(ewma_step(mad, dev), Ordering::Relaxed);
+        }
+        self.samples
+            .store(prior.saturating_add(1), Ordering::Relaxed);
+    }
+
+    /// Current EWMA mean (nanos). `0` before the first fold.
+    #[must_use]
+    pub fn mean_nanos(&self) -> u64 {
+        self.mean.load(Ordering::Relaxed)
+    }
+
+    /// Current EWMA mean-absolute-deviation (nanos). `0` before the
+    /// second fold.
+    #[must_use]
+    pub fn mad_nanos(&self) -> u64 {
+        self.mad.load(Ordering::Relaxed)
+    }
+
+    /// Number of folded samples. `0` is the neutral seed.
+    #[must_use]
+    pub fn samples(&self) -> u64 {
+        self.samples.load(Ordering::Relaxed)
+    }
+}
+
+/// One constant-α EWMA step toward `sample`: `current + (sample −
+/// current) >> k`, computed on the signed difference so a falling cost
+/// converges as fast as a rising one. Integer-only — the `>> k` is the
+/// power-of-two α.
+fn ewma_step(current: u64, sample: u64) -> u64 {
+    if sample >= current {
+        current + ((sample - current) >> EWMA_SHIFT)
+    } else {
+        current - ((current - sample) >> EWMA_SHIFT)
+    }
+}
+
+/// Per-actor cache mapping a handled `KindId` to its shared
+/// [`CostCell`]. Stamped on the actor's `ActorSlots` as a [`Local`],
+/// exactly like the ADR-0081 [`crate::log::ActorLogRing`]; the fold and
+/// the `cost.tail` dump both reach it via `try_with` / `try_with_mut`
+/// from inside the dispatch `with_stamped` block on the actor's own
+/// thread — a lock-free, single-threaded lookup.
+///
+/// A `Vec` rather than a map: handler sets are tiny (a handful of kinds
+/// per actor), so a linear scan beats a hash and keeps `aether-actor`
+/// free of the `hashbrown` dependency `no_std + alloc` would otherwise
+/// pull (the same reasoning [`mod@crate::local`] uses for its `BTreeMap`).
+#[derive(Debug, Default)]
+pub struct CostCells(Vec<(KindId, Arc<CostCell>)>);
+
+impl Local for CostCells {}
+
+impl CostCells {
+    /// Empty cache.
+    #[must_use]
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Has this cache been seeded with its handler set yet? `false`
+    /// until the first [`Self::seed`]. The dispatch path uses this to
+    /// pull the slice from the global table exactly once on the actor's
+    /// own thread (the seed point that cannot run cross-thread at the
+    /// cap-registry hook — see the module doc).
+    #[must_use]
+    pub fn is_seeded(&self) -> bool {
+        !self.0.is_empty()
+    }
+
+    /// Install the actor's handler-kind cells, sharing each
+    /// `Arc<CostCell>` with the global table. Idempotent-ish: replaces
+    /// the cache wholesale (a `replace`-spawned actor re-seeds against
+    /// the post-replace handler set).
+    pub fn seed(&mut self, cells: Vec<(KindId, Arc<CostCell>)>) {
+        self.0 = cells;
+    }
+
+    /// Look up the cell for `kind`. `None` for a kind not in the
+    /// handler set (framework arms like `log.tail` / `trace.tail`, or a
+    /// fallback dispatch) — the fold skips those.
+    #[must_use]
+    pub fn get(&self, kind: KindId) -> Option<&Arc<CostCell>> {
+        self.0.iter().find(|(k, _)| *k == kind).map(|(_, c)| c)
+    }
+
+    /// Borrow the `(kind, cell)` pairs for the dump. Read-only; the
+    /// `cost.tail` framework arm reads the global table (filtered to
+    /// the receiving mailbox) rather than this cache, but the pairs are
+    /// surfaced for tests and a future in-actor dump.
+    #[must_use]
+    pub fn entries(&self) -> &[(KindId, Arc<CostCell>)] {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A burst of identical samples converges the mean to that value
+    /// (the first fold seeds it exactly; the rest are no-ops on a
+    /// constant input).
+    #[test]
+    fn mean_converges_to_constant_input() {
+        let cell = CostCell::new();
+        for _ in 0..64 {
+            cell.fold(1_000);
+        }
+        assert_eq!(cell.mean_nanos(), 1_000);
+        assert_eq!(cell.mad_nanos(), 0, "no deviation on a constant input");
+        assert_eq!(cell.samples(), 64);
+    }
+
+    /// The first fold seeds the mean directly — no warm-up ramp from
+    /// zero — so a single sample reports its own value.
+    #[test]
+    fn first_sample_seeds_mean_directly() {
+        let cell = CostCell::new();
+        cell.fold(5_000);
+        assert_eq!(cell.mean_nanos(), 5_000);
+        assert_eq!(cell.samples(), 1);
+    }
+
+    /// Stepping the input up converges the EWMA toward the new level
+    /// (monotonically, never overshooting). The integer `>> k` update
+    /// stalls once the gap drops below `2^k` (the shift truncates to
+    /// zero), so it lands *within* the shift granularity of the target,
+    /// not exactly on it — the expected fixed-point behaviour.
+    #[test]
+    fn mean_tracks_a_step_up() {
+        let granularity = 1u64 << EWMA_SHIFT;
+        let cell = CostCell::new();
+        cell.fold(100);
+        assert_eq!(cell.mean_nanos(), 100);
+        let mut last = cell.mean_nanos();
+        for _ in 0..200 {
+            cell.fold(10_000);
+            let now = cell.mean_nanos();
+            assert!(now >= last, "EWMA must not overshoot a step up");
+            assert!(now <= 10_000, "EWMA must not exceed the input level");
+            last = now;
+        }
+        assert!(
+            10_000 - cell.mean_nanos() < granularity,
+            "converges to within the shift granularity of the new level: {}",
+            cell.mean_nanos()
+        );
+        assert!(cell.samples() > 1);
+    }
+
+    /// A falling input converges as fast as a rising one (symmetric
+    /// shift), settling within the shift granularity of the lower level.
+    #[test]
+    fn mean_tracks_a_step_down() {
+        let granularity = 1u64 << EWMA_SHIFT;
+        let cell = CostCell::new();
+        cell.fold(10_000);
+        for _ in 0..200 {
+            cell.fold(100);
+        }
+        assert!(
+            cell.mean_nanos() - 100 < granularity,
+            "converges to within the shift granularity of the lower level: {}",
+            cell.mean_nanos()
+        );
+    }
+
+    /// Deviation (MAD) rises above zero while the mean is mid-track on a
+    /// step input — a steady handler shows ~0 MAD, a jumpy one shows a
+    /// nonzero spread.
+    #[test]
+    fn mad_rises_on_a_step() {
+        let cell = CostCell::new();
+        cell.fold(100);
+        for _ in 0..5 {
+            cell.fold(10_000);
+        }
+        assert!(
+            cell.mad_nanos() > 0,
+            "MAD tracks the spread while the mean catches up"
+        );
+    }
+
+    /// Neutral seed: a fresh cell (and one seeded into a [`CostCells`]
+    /// cache but never folded) reports `samples = 0` — the
+    /// known-but-unrun distinction.
+    #[test]
+    fn neutral_seed_reports_zero_samples() {
+        let cell = CostCell::new();
+        assert_eq!(cell.samples(), 0);
+        assert_eq!(cell.mean_nanos(), 0);
+        assert_eq!(cell.mad_nanos(), 0);
+    }
+
+    /// `CostCells` is empty until seeded; `seed` installs the pairs and
+    /// `get` resolves a known kind while a stranger misses.
+    #[test]
+    fn cost_cells_seed_and_lookup() {
+        let mut cells = CostCells::new();
+        assert!(!cells.is_seeded());
+        let a = Arc::new(CostCell::new());
+        let b = Arc::new(CostCell::new());
+        cells.seed(alloc::vec![
+            (KindId(10), Arc::clone(&a)),
+            (KindId(20), Arc::clone(&b)),
+        ]);
+        assert!(cells.is_seeded());
+        assert!(cells.get(KindId(10)).is_some());
+        assert!(cells.get(KindId(20)).is_some());
+        assert!(cells.get(KindId(30)).is_none());
+        // The cached Arc and the seeded Arc share the same cell: a fold
+        // through one is visible through the other (the shared-index
+        // invariant the global table relies on).
+        cells.get(KindId(10)).expect("kind 10 is seeded").fold(777);
+        assert_eq!(a.mean_nanos(), 777);
+    }
+}

--- a/crates/aether-actor/src/cost.rs
+++ b/crates/aether-actor/src/cost.rs
@@ -6,9 +6,12 @@
 //! [`crate::trace_ring`] dispatch bracket into a per-handler
 //! [`CostCell`] — a constant-α EWMA of the handler's execution time in
 //! fixed-point nanos. The fold runs inside the dispatch
-//! `local::with_stamped` block on the actor's own thread, so it reaches
-//! its cell through the per-actor [`CostCells`] [`Local`] cache — a
-//! lock-free, single-threaded lookup, the hot path.
+//! `local::with_stamped` block, so it reaches its cell through the
+//! per-actor [`CostCells`] [`Local`] cache — a lock-free lookup, the hot
+//! path. An actor dispatches on one worker at a time (the `Ready→Running`
+//! exclusivity), so the cell has a single writer at a time even though
+//! the worker varies across cycles — which is why the cells are atomic
+//! but the fold needs no CAS.
 //!
 //! The *same* `Arc<CostCell>` lives in a second index — a global
 //! `RwLock<HashMap<(MailboxId, KindId), Arc<CostCell>>>` hung off the
@@ -166,20 +169,12 @@ impl CostCells {
         Self(Vec::new())
     }
 
-    /// Has this cache been seeded with its handler set yet? `false`
-    /// until the first [`Self::seed`]. The dispatch path uses this to
-    /// pull the slice from the global table exactly once on the actor's
-    /// own thread (the seed point that cannot run cross-thread at the
-    /// cap-registry hook — see the module doc).
-    #[must_use]
-    pub fn is_seeded(&self) -> bool {
-        !self.0.is_empty()
-    }
-
     /// Install the actor's handler-kind cells, sharing each
-    /// `Arc<CostCell>` with the global table. Idempotent-ish: replaces
-    /// the cache wholesale (a `replace`-spawned actor re-seeds against
-    /// the post-replace handler set).
+    /// `Arc<CostCell>` with the global table. Called once at actor
+    /// construction (`WasmTrampoline::init` / the native-cap boot wrap,
+    /// both under `with_stamped`); a `replace`-spawned actor re-seeds
+    /// wholesale against the post-replace handler set, and drop seeds an
+    /// empty `Vec` to clear.
     pub fn seed(&mut self, cells: Vec<(KindId, Arc<CostCell>)>) {
         self.0 = cells;
     }
@@ -306,14 +301,13 @@ mod tests {
     #[test]
     fn cost_cells_seed_and_lookup() {
         let mut cells = CostCells::new();
-        assert!(!cells.is_seeded());
+        assert!(cells.get(KindId(10)).is_none(), "empty cache misses");
         let a = Arc::new(CostCell::new());
         let b = Arc::new(CostCell::new());
         cells.seed(alloc::vec![
             (KindId(10), Arc::clone(&a)),
             (KindId(20), Arc::clone(&b)),
         ]);
-        assert!(cells.is_seeded());
         assert!(cells.get(KindId(10)).is_some());
         assert!(cells.get(KindId(20)).is_some());
         assert!(cells.get(KindId(30)).is_none());

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -58,6 +58,7 @@ extern crate alloc;
 extern crate self as aether_actor;
 
 pub mod actor;
+pub mod cost;
 pub mod ffi;
 pub mod local;
 pub mod log;

--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -317,16 +317,13 @@ mod native {
                 MailboxCaps::from_component_capabilities(&capabilities),
             );
 
-            // iamacoffeepot/aether#1128: seed a neutral per-handler cost
-            // cell (`samples = 0`) for each of the trampoline's handler
-            // kinds into the global `CostTable`, the same load hook that
-            // populates the cap-registry accept-set. The actor's
-            // per-actor `CostCells` cache lazy-pulls these (the *same*
-            // `Arc<CostCell>`s) on its first dispatch — the load runs on
-            // the cap's thread, not the trampoline's, so the cache stamp
-            // can't happen here. `aether.component.drop` clears them.
-            let handler_kinds: Vec<KindId> = capabilities.handlers.iter().map(|h| h.id).collect();
-            self.mailer.cost_table().seed(mailbox_id, &handler_kinds);
+            // iamacoffeepot/aether#1128: the per-handler cost cells are
+            // seeded inside `WasmTrampoline::init` (run just above, under
+            // the spawn path's `with_stamped`), from the same
+            // `capabilities` — both the global `CostTable` and the
+            // trampoline's per-actor cache, over one shared `Arc`. Nothing
+            // to seed cap-side here: `init` has the `ActorSlots` stamp this
+            // thread does not.
 
             // ADR-0081 retired the chassis-pushed `ConfigureLogDrain`
             // mail. The freshly-spawned trampoline owns its own

--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -317,6 +317,17 @@ mod native {
                 MailboxCaps::from_component_capabilities(&capabilities),
             );
 
+            // iamacoffeepot/aether#1128: seed a neutral per-handler cost
+            // cell (`samples = 0`) for each of the trampoline's handler
+            // kinds into the global `CostTable`, the same load hook that
+            // populates the cap-registry accept-set. The actor's
+            // per-actor `CostCells` cache lazy-pulls these (the *same*
+            // `Arc<CostCell>`s) on its first dispatch — the load runs on
+            // the cap's thread, not the trampoline's, so the cache stamp
+            // can't happen here. `aether.component.drop` clears them.
+            let handler_kinds: Vec<KindId> = capabilities.handlers.iter().map(|h| h.id).collect();
+            self.mailer.cost_table().seed(mailbox_id, &handler_kinds);
+
             // ADR-0081 retired the chassis-pushed `ConfigureLogDrain`
             // mail. The freshly-spawned trampoline owns its own
             // `ActorLogRing` like every other actor; no drain

--- a/crates/aether-capabilities/src/trampoline.rs
+++ b/crates/aether-capabilities/src/trampoline.rs
@@ -182,6 +182,24 @@ mod native {
             .map_err(|e| {
                 BootError::Other(io::Error::other(format!("wasm instantiation failed: {e}")).into())
             })?;
+
+            // iamacoffeepot/aether#1128: seed this component's per-handler
+            // cost cells from the guest's declared handler set
+            // (`config.capabilities`, parsed from the wasm's
+            // `aether.kinds.inputs` section). `init` runs inside the spawn
+            // path's `with_stamped(&slots, …)`, so the per-actor
+            // `CostCells` cache is stamped directly here — the cap's
+            // thread vs the trampoline's is irrelevant: the stamp binds to
+            // the actor's `ActorSlots`, not to a thread. The same
+            // `Arc<CostCell>`s seed the global `CostTable` for the cold
+            // `cost.tail` dump and the iamacoffeepot/aether#1178
+            // producer-side read. Replace re-seeds on the trampoline's own
+            // dispatch (`on_replace_component`); drop clears both indexes.
+            let handler_kinds: Vec<KindId> =
+                config.capabilities.handlers.iter().map(|h| h.id).collect();
+            let seeded = mailer.cost_table().seed(mailbox, &handler_kinds);
+            CostCells::try_with_mut(|cells| cells.seed(seeded));
+
             Ok(Self {
                 component: Some(component),
                 engine: config.engine,

--- a/crates/aether-capabilities/src/trampoline.rs
+++ b/crates/aether-capabilities/src/trampoline.rs
@@ -92,8 +92,11 @@ mod native {
     use aether_substrate::mail::mailer::Mailer;
     use aether_substrate::mail::outbound::HubOutbound;
     use aether_substrate::mail::registry::Registry;
-    use aether_substrate::mail::{Mail, MailboxId};
+    use aether_substrate::mail::{KindId, Mail, MailboxId};
     use std::io;
+
+    use aether_actor::Local as _;
+    use aether_actor::cost::CostCells;
 
     /// Configuration handed to [`WasmTrampoline::init`] by the spawn
     /// path. Carries the wasmtime engine / linker plus the parsed
@@ -237,6 +240,12 @@ mod native {
             // trampoline (and its mailbox name) survives as an empty
             // slot, but it has no accept-set while empty.
             self.mailer.capability_registry().remove(self.mailbox);
+            // iamacoffeepot/aether#1128: drop this mailbox's per-handler
+            // cost cells from the global table and the per-actor cache.
+            // `on_drop_component` runs on the trampoline's own thread
+            // inside `with_stamped`, so both indexes clear together.
+            self.mailer.cost_table().drop_mailbox(self.mailbox);
+            CostCells::try_with_mut(|cells| cells.seed(Vec::new()));
             ctx.reply(&DropResult::Ok);
         }
 
@@ -398,6 +407,21 @@ mod native {
                 self.mailbox,
                 MailboxCaps::from_component_capabilities(&capabilities),
             );
+
+            // iamacoffeepot/aether#1128: re-seed the per-handler cost
+            // cells against the post-replace handler set, into BOTH
+            // indexes. The mailbox id is stable across replace
+            // (ADR-0022 §4), so the global `seed` reuses the prior cell
+            // for an unchanged kind (keeping its accumulated EWMA) and
+            // adds a neutral cell for a new one. `on_replace_component`
+            // runs on the trampoline's own dispatch thread inside
+            // `with_stamped`, so we can re-stamp the per-actor `CostCells`
+            // cache directly with the freshly-returned `Arc`s — keeping
+            // the cache exact across replace (a new kind's cell would
+            // otherwise miss until the cache happened to re-pull).
+            let handler_kinds: Vec<KindId> = capabilities.handlers.iter().map(|h| h.id).collect();
+            let seeded = self.mailer.cost_table().seed(self.mailbox, &handler_kinds);
+            CostCells::try_with_mut(|cells| cells.seed(seeded));
 
             ReplaceResult::Ok { capabilities }
         }

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -2110,6 +2110,63 @@ mod control_plane {
         },
     }
 
+    // iamacoffeepot/aether#1128 per-handler execution-cost EWMA dump.
+    // Each actor folds `(Finished.t − Received.t)` from the dispatch
+    // trace bracket into a per-handler `CostCell` (in `aether-actor`);
+    // one wire kind pair drives the read-only diagnostic dump, the
+    // sibling of `LogTail` / `trace::TraceTail`. Measure-only — Phase 0
+    // of iamacoffeepot/aether#1127's cost-aware recruiter, no scheduling
+    // change.
+
+    /// One handler's folded execution-cost row as it appears on the
+    /// wire when a caller dumps an actor's cost table via [`CostTail`] /
+    /// [`CostTailResult`]. `mean_nanos` / `mad_nanos` are the
+    /// fixed-point-nanos EWMA mean and mean-absolute-deviation;
+    /// `samples` is the folded-sample count (`0` is the neutral seed —
+    /// a handler the actor declares but hasn't run yet). `kind_name` is
+    /// the substrate-resolved kind name when known, else `None` (a
+    /// component-defined kind the dumping engine can't name).
+    ///
+    /// Not a `Kind` — only addressable as an element of
+    /// [`CostTailResult::Ok::rows`].
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+    pub struct CostRow {
+        pub kind_id: aether_data::KindId,
+        pub kind_name: Option<String>,
+        pub mean_nanos: u64,
+        pub mad_nanos: u64,
+        pub samples: u64,
+    }
+
+    /// `aether.cost.tail` — dump one actor's per-handler execution-cost
+    /// EWMA table (iamacoffeepot/aether#1128). Routed to a specific
+    /// actor by `MailboxId`; the framework dispatch loop services it
+    /// directly (every native actor and every wasm trampoline answers
+    /// without the author writing a handler), the same surface
+    /// [`LogTail`] / [`crate::trace::TraceTail`] established. Reply:
+    /// [`CostTailResult`].
+    ///
+    /// - `kind: None` returns every handler row the actor declares;
+    ///   `Some(id)` returns only that one handler's row (or an empty
+    ///   `rows` if the actor has no such handler).
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.cost.tail")]
+    pub struct CostTail {
+        pub kind: Option<aether_data::KindId>,
+    }
+
+    /// Reply to [`CostTail`]. `Ok::rows` is one [`CostRow`] per handler
+    /// the responding actor declares (filtered to `CostTail::kind` when
+    /// set), in unspecified order. `Err` carries a free-form reason
+    /// (the actor had no stamped slots / cost cache — a substrate
+    /// invariant violation in practice).
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.cost.tail_result")]
+    pub enum CostTailResult {
+        Ok { rows: Vec<CostRow> },
+        Err { error: String },
+    }
+
     // ADR-0066: camera control kinds (`aether.camera.{create, destroy,
     // set_active, set_mode, orbit.set, topdown.set}` + `OrbitParams` /
     // `TopdownParams` / `ModeInit`) moved to the `aether-camera` trunk
@@ -2698,6 +2755,8 @@ mod tests {
         assert_eq!(MonitorNotice::NAME, "aether.actor.monitor_notice");
         assert_eq!(LogTail::NAME, "aether.log.tail");
         assert_eq!(LogTailResult::NAME, "aether.log.tail_result");
+        assert_eq!(CostTail::NAME, "aether.cost.tail");
+        assert_eq!(CostTailResult::NAME, "aether.cost.tail_result");
         assert_eq!(Read::NAME, "aether.fs.read");
         assert_eq!(ReadResult::NAME, "aether.fs.read_result");
         assert_eq!(Write::NAME, "aether.fs.write");
@@ -2941,6 +3000,81 @@ mod tests {
                     assert_eq!(error, FsError::NotFound);
                 }
                 DeleteResult::Ok { .. } => panic!("expected Err"),
+            }
+        }
+    }
+
+    // iamacoffeepot/aether#1128 cost-table dump roundtrips. `CostTail`
+    // carries an optional kind filter; `CostTailResult::Ok` carries one
+    // `CostRow` per handler. Both go through the derived
+    // Serialize/Deserialize (postcard wire) — pin that the optional
+    // filter and the per-row fields survive the round trip.
+    mod cost_roundtrips {
+        use super::*;
+        use alloc::string::ToString;
+        use alloc::vec;
+
+        #[test]
+        fn cost_tail_request_roundtrips_filter() {
+            for kind in [None, Some(aether_data::KindId(0xABCD))] {
+                let r = CostTail { kind };
+                let bytes =
+                    postcard::to_allocvec(&r).expect("test setup: postcard encodes CostTail");
+                let back: CostTail =
+                    postcard::from_bytes(&bytes).expect("test setup: postcard decodes CostTail");
+                assert_eq!(back.kind, kind);
+            }
+        }
+
+        #[test]
+        fn cost_tail_result_ok_roundtrips_rows() {
+            let r = CostTailResult::Ok {
+                rows: vec![
+                    CostRow {
+                        kind_id: aether_data::KindId(10),
+                        kind_name: Some("test.kind.a".to_string()),
+                        mean_nanos: 1_234,
+                        mad_nanos: 56,
+                        samples: 9,
+                    },
+                    CostRow {
+                        kind_id: aether_data::KindId(20),
+                        kind_name: None,
+                        mean_nanos: 0,
+                        mad_nanos: 0,
+                        samples: 0,
+                    },
+                ],
+            };
+            let bytes =
+                postcard::to_allocvec(&r).expect("test setup: postcard encodes CostTailResult::Ok");
+            let back: CostTailResult = postcard::from_bytes(&bytes)
+                .expect("test setup: postcard decodes CostTailResult::Ok");
+            let CostTailResult::Ok { rows } = back else {
+                panic!("expected Ok");
+            };
+            assert_eq!(rows.len(), 2);
+            assert_eq!(rows[0].kind_id, aether_data::KindId(10));
+            assert_eq!(rows[0].kind_name.as_deref(), Some("test.kind.a"));
+            assert_eq!(rows[0].mean_nanos, 1_234);
+            assert_eq!(rows[0].samples, 9);
+            // Neutral seed row survives with samples = 0 + no name.
+            assert_eq!(rows[1].samples, 0);
+            assert_eq!(rows[1].kind_name, None);
+        }
+
+        #[test]
+        fn cost_tail_result_err_roundtrips() {
+            let r = CostTailResult::Err {
+                error: "no stamped slots".to_string(),
+            };
+            let bytes = postcard::to_allocvec(&r)
+                .expect("test setup: postcard encodes CostTailResult::Err");
+            let back: CostTailResult = postcard::from_bytes(&bytes)
+                .expect("test setup: postcard decodes CostTailResult::Err");
+            match back {
+                CostTailResult::Err { error } => assert_eq!(error, "no stamped slots"),
+                CostTailResult::Ok { .. } => panic!("expected Err"),
             }
         }
     }

--- a/crates/aether-mcp/src/args.rs
+++ b/crates/aether-mcp/src/args.rs
@@ -189,6 +189,53 @@ pub struct ActorLogsResponse {
     pub truncated_before: Option<u64>,
 }
 
+/// `actor_cost` arguments — dump one actor's per-handler
+/// execution-cost EWMA table (iamacoffeepot/aether#1128). Phase 0
+/// dark instrumentation: the substrate folds `(Finished − Received)`
+/// from the dispatch trace bracket into a per-handler EWMA; this tool
+/// reads it back. Measure-only — no scheduling effect.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ActorCostArgs {
+    /// Engine UUID to pull from (from `list_engines`).
+    pub engine_id: String,
+    /// Mailbox name of the actor to query (e.g. `"aether.audio"`,
+    /// `"aether.component.trampoline:camera"`). Every actor serves
+    /// `aether.cost.tail` via the substrate's framework dispatch arm.
+    pub mailbox_name: String,
+    /// Optional kind-id filter (tagged `knd-XXXX-XXXX-XXXX` or raw
+    /// decimal). Omitted dumps every handler row the actor declares.
+    #[serde(default)]
+    pub kind_id: Option<String>,
+}
+
+/// One per-handler cost row as `actor_cost` returns it. Mirrors
+/// `aether_kinds::CostRow`. `mean_nanos` / `mad_nanos` are the
+/// fixed-point-nanos EWMA mean + mean-absolute-deviation of the
+/// handler's execution time; `samples` is the folded-sample count
+/// (`0` is the neutral seed — a handler the actor declares but hasn't
+/// run yet).
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ActorCostRow {
+    /// Tagged kind id (`knd-XXXX-XXXX-XXXX`).
+    pub kind_id: String,
+    /// Substrate-resolved kind name, or `null` for a component-defined
+    /// kind the engine can't name.
+    pub kind_name: Option<String>,
+    pub mean_nanos: u64,
+    pub mad_nanos: u64,
+    pub samples: u64,
+}
+
+/// `actor_cost` response. `rows` is one [`ActorCostRow`] per handler
+/// the queried actor declares (filtered to `kind_id` when set), in
+/// unspecified order.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ActorCostResponse {
+    pub engine_id: String,
+    pub mailbox_name: String,
+    pub rows: Vec<ActorCostRow>,
+}
+
 /// `describe_handles` arguments (ADR-0049 §10). Summarizes a
 /// substrate's persistent handle store.
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -25,10 +25,11 @@ use aether_data::{
 };
 use aether_kinds::dag::{DagDescriptor, Edge, Node, NodeId};
 use aether_kinds::{
-    Cancel, CancelResult, CaptureFrame, CaptureFrameResult, ComponentCapabilities, ListEngines,
-    ListEnginesResult, LoadComponent, LoadResult, MailEnvelope as KindMailEnvelope,
-    ReplaceComponent, ReplaceResult, SpawnEngine, SpawnEngineResult, Status, StatusResult, Submit,
-    SubmitResult, TerminateEngine, TerminateEngineResult,
+    Cancel, CancelResult, CaptureFrame, CaptureFrameResult, ComponentCapabilities, CostTail,
+    CostTailResult, ListEngines, ListEnginesResult, LoadComponent, LoadResult,
+    MailEnvelope as KindMailEnvelope, ReplaceComponent, ReplaceResult, SpawnEngine,
+    SpawnEngineResult, Status, StatusResult, Submit, SubmitResult, TerminateEngine,
+    TerminateEngineResult,
     trace::{
         DescribeTreeResult, DispatchTraced, DispatchTracedAck, MailNodeWire, TRACE_MAILBOX_NAME,
         TraceTail, TraceTailResult,
@@ -43,6 +44,7 @@ use rmcp::{ErrorData as McpError, ServerHandler, tool, tool_handler, tool_router
 use crate::args::ActorLogEntry;
 use crate::args::ActorLogsArgs;
 use crate::args::ActorLogsResponse;
+use crate::args::{ActorCostArgs, ActorCostResponse, ActorCostRow};
 use crate::args::{
     CaptureFrameArgs, CaptureMailSpec, DagCancelArgs, DagDescriptorArg, DagStatusArgs,
     DescribeComponentArgs, DescribeHandlesArgs, DescribeHandlesResponse, EngineInfo,
@@ -587,6 +589,75 @@ impl Mcp {
     }
 
     #[tool(
+        description = "Dump one actor's per-handler execution-cost EWMA table \
+                       (iamacoffeepot/aether#1128, Phase 0 dark instrumentation). Sends \
+                       aether.cost.tail to the named mailbox and decodes aether.cost.tail_result. \
+                       The substrate folds (Finished − Received) from each dispatch's trace \
+                       bracket into a per-handler EWMA; this reads it back — MEASURE-ONLY, the \
+                       table has no scheduling effect. Every actor — native or wasm trampoline — \
+                       serves this kind via the substrate's framework dispatch arm, so any mailbox \
+                       is queryable. Each row carries the handler kind (id + resolved name when \
+                       known), `mean_nanos` / `mad_nanos` (the EWMA mean + mean-absolute-deviation \
+                       of execution time in nanos), and `samples` (folded-sample count; `0` is the \
+                       neutral seed — a handler the actor declares but hasn't run yet). Pass \
+                       `kind_id` (tagged `knd-…` or decimal) to filter to one handler. Use it to \
+                       check whether handler costs are heterogeneous enough to warrant the \
+                       cost-aware recruiter (iamacoffeepot/aether#1127)."
+    )]
+    pub async fn actor_cost(
+        &self,
+        Parameters(args): Parameters<ActorCostArgs>,
+    ) -> Result<String, McpError> {
+        let engine = parse_engine_id(&args.engine_id)?;
+        let engine_id_str = args.engine_id.clone();
+        let mailbox_name = args.mailbox_name.clone();
+        // Optional kind filter: accept a tagged `knd-…` id or a raw
+        // decimal `u64`, matching the rest of the MCP id surface.
+        let kind = match args.kind_id.as_deref() {
+            Some(s) => Some(parse_kind_id(s)?),
+            None => None,
+        };
+        let request = CostTail { kind };
+        let reply = self
+            .session
+            .call_one(engine_envelope(engine, &args.mailbox_name, &request))
+            .await
+            .map_err(internal)?;
+        match CostTailResult::decode_from_bytes(&reply.payload) {
+            Some(CostTailResult::Ok { rows }) => {
+                let response = ActorCostResponse {
+                    engine_id: engine_id_str,
+                    mailbox_name,
+                    rows: rows
+                        .into_iter()
+                        .map(|r| ActorCostRow {
+                            // Render the kind id as the ADR-0064 tagged
+                            // string the rest of the MCP wire uses, falling
+                            // back to a hex literal on an unencodable id.
+                            kind_id: tagged_id::encode(r.kind_id.0)
+                                .unwrap_or_else(|| format!("{:#x}", r.kind_id.0)),
+                            // The substrate ships `kind_name: None` (the
+                            // cost table holds ids, not names); resolve it
+                            // best-effort from the static kind inventory
+                            // the MCP harness ships with. Component-defined
+                            // kinds stay `None`.
+                            kind_name: r.kind_name.or_else(|| static_kind_name(r.kind_id)),
+                            mean_nanos: r.mean_nanos,
+                            mad_nanos: r.mad_nanos,
+                            samples: r.samples,
+                        })
+                        .collect(),
+                };
+                json(&response)
+            }
+            Some(CostTailResult::Err { error }) => Err(internal_msg(&format!(
+                "actor_cost: {mailbox_name} — {error}"
+            ))),
+            None => Err(internal_msg("undecodable CostTailResult")),
+        }
+    }
+
+    #[tool(
         description = "Summarize a substrate's persistent handle store (ADR-0049 §10). Sends \
                        aether.handle.describe to the engine's aether.handle cap and decodes \
                        aether.handle.describe_result. Returns total / in-memory / on-disk / pinned \
@@ -1005,6 +1076,34 @@ fn parse_dag_id(s: &str) -> Result<DagId, McpError> {
     tagged_id::decode_with_tag(s, Tag::Dag)
         .map(DagId)
         .map_err(|e| McpError::invalid_params(format!("dag_id: {e}"), None))
+}
+
+/// Parse a kind-id string for the `actor_cost` filter: a tagged
+/// `knd-…` id (ADR-0064) or a raw decimal `u64`. The raw form is
+/// accepted because a cost row's id round-trips back through this
+/// filter and a caller may paste a non-tagged synthetic id.
+fn parse_kind_id(s: &str) -> Result<KindId, McpError> {
+    if let Ok(id) = tagged_id::decode_with_tag(s, Tag::Kind) {
+        return Ok(KindId(id));
+    }
+    s.parse::<u64>().map(KindId).map_err(|_| {
+        McpError::invalid_params(
+            format!("kind_id: not a tagged `knd-…` id or a decimal u64: {s:?}"),
+            None,
+        )
+    })
+}
+
+/// Best-effort resolve a [`KindId`] to its name from the static kind
+/// inventory the MCP harness ships with (`describe_kinds`'s source).
+/// Component-defined kinds aren't in the inventory and return `None`.
+/// Cold path — recomputes the inventory's ids on each call; the cost
+/// dump is a diagnostic, not a hot loop.
+fn static_kind_name(id: KindId) -> Option<String> {
+    descriptors::all()
+        .into_iter()
+        .find(|d| kind_id_from_parts(&d.name, &d.schema) == id.0)
+        .map(|d| d.name)
 }
 
 /// Build the wire [`DagDescriptor`] from the typed tool arg, reading each
@@ -1638,6 +1737,58 @@ mod tests {
             actor_logs_err_message("aether.nope", "mailbox mbx-0000-0000-0000 not registered");
         assert!(msg.contains("aether.nope"), "names the mailbox: {msg}");
         assert!(msg.contains("not registered"), "carries the cause: {msg}");
+    }
+
+    /// iamacoffeepot/aether#1128: `actor_cost` with a malformed
+    /// `engine_id` rejects at the tool boundary without touching the
+    /// wire (mirrors `actor_logs_bad_engine_id_is_tool_error`).
+    #[tokio::test]
+    async fn actor_cost_bad_engine_id_is_tool_error() {
+        let (_chassis, port) = boot_hub();
+        let mcp = connect_mcp(port);
+        let result = mcp
+            .actor_cost(Parameters(ActorCostArgs {
+                engine_id: "not-a-uuid".to_owned(),
+                mailbox_name: "aether.audio".to_owned(),
+                kind_id: None,
+            }))
+            .await;
+        assert!(
+            result.is_err(),
+            "a malformed engine_id should be a tool error"
+        );
+    }
+
+    /// iamacoffeepot/aether#1128: `actor_cost`'s `kind_id` filter
+    /// accepts a tagged `knd-…` id and a raw decimal, and rejects
+    /// gibberish.
+    #[test]
+    fn parse_kind_id_accepts_tagged_and_decimal() {
+        let tagged = tagged_id::encode(with_tag(Tag::Kind, 42)).expect("encodes a kind id");
+        assert!(parse_kind_id(&tagged).is_ok(), "tagged knd- id parses");
+        assert_eq!(
+            parse_kind_id("12345").expect("decimal parses").0,
+            12345,
+            "raw decimal u64 parses",
+        );
+        assert!(parse_kind_id("not-an-id").is_err(), "gibberish rejected");
+    }
+
+    /// iamacoffeepot/aether#1128: `static_kind_name` resolves a known
+    /// substrate kind's id back to its name and misses on a stranger.
+    #[test]
+    fn static_kind_name_resolves_known_substrate_kind() {
+        let log_tail = KindId(<aether_kinds::LogTail as Kind>::ID.0);
+        assert_eq!(
+            static_kind_name(log_tail).as_deref(),
+            Some(aether_kinds::LogTail::NAME),
+            "a substrate kind resolves to its name",
+        );
+        assert_eq!(
+            static_kind_name(KindId(0xDEAD_BEEF_DEAD_BEEF)),
+            None,
+            "an unknown id has no static name",
+        );
     }
 
     /// `actor_logs` with an unknown `level` string is rejected at

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -46,7 +46,7 @@ use aether_substrate::{
     EgressEvent, HubOutbound, Mailer, PassiveChassis, RecordingBackend, ReplyTarget, ReplyTo,
     SubstrateBoot,
     capture::CaptureQueue,
-    mail::{CapabilityRegistry, Mail, MailId, MailboxId},
+    mail::{CapabilityRegistry, CostTable, Mail, MailId, MailboxId},
 };
 
 use super::chassis::{TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS};
@@ -412,6 +412,17 @@ impl TestBench {
     #[must_use]
     pub fn capability_registry(&self) -> &Arc<CapabilityRegistry> {
         self.queue.capability_registry()
+    }
+
+    /// Borrow the substrate's per-handler [`CostTable`]
+    /// (iamacoffeepot/aether#1128). Shares the same `Mailer` the dispatch
+    /// fold writes through, so `tail(MailboxId, …)` here reflects the
+    /// cells seeded at component construction (and any folded samples).
+    /// Surfaced for integration tests that exercise the cost table
+    /// through a real component-load lifecycle.
+    #[must_use]
+    pub fn cost_table(&self) -> &Arc<CostTable> {
+        self.queue.cost_table()
     }
 
     /// Bytes-level fire-and-settle send: resolve `recipient_name` in

--- a/crates/aether-substrate-bundle/tests/cost_table.rs
+++ b/crates/aether-substrate-bundle/tests/cost_table.rs
@@ -1,0 +1,119 @@
+//! iamacoffeepot/aether#1128: the per-handler cost EWMA, exercised
+//! through a real component-load lifecycle on a `TestBench`.
+//!
+//! Guards the redesign invariant that `WasmTrampoline::init` seeds the
+//! per-handler cost cells from the guest's declared handler set, under
+//! the spawn path's `with_stamped(&slots, …)` — so a loaded component's
+//! handlers are measurable with no lazy first-dispatch pull. The unit
+//! tests cover the EWMA + table mechanics in isolation
+//! (`aether_actor::cost`, `aether_substrate::mail::cost`); this is the
+//! load-path integration guard, and in particular the one that proves
+//! the per-actor `CostCells` cache was actually stamped at construction:
+//! a fold only records if the cache holds the cell, so a nonzero sample
+//! count after dispatch is end-to-end evidence the stamp ran.
+//!
+//! Skipped when no wgpu adapter / no pre-built component wasm (same gates
+//! as the other bench integration tests).
+
+use std::fs;
+use std::path::Path;
+
+use aether_actor::Actor;
+use aether_capabilities::ComponentHostCapability;
+use aether_data::{Kind, MailboxId};
+use aether_kinds::{CostTail, CostTailResult, LoadComponent, LoadResult, Tick};
+use aether_substrate_bundle::test_bench::{BenchOp, TestBench, test_helpers::require_runtime};
+use aether_test_fixture_probe::SetRender;
+
+// Pin the fixture rlib so its descriptor `inventory::submit!` entries
+// land in this test binary (mirrors `cap_registry.rs`).
+#[allow(unused_imports)]
+use aether_test_fixture_probe as _;
+
+fn load_probe(bench: &mut TestBench, wasm_path: &Path) -> MailboxId {
+    let wasm = fs::read(wasm_path).expect("read fixture wasm");
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                ComponentHostCapability::NAMESPACE,
+                &LoadComponent {
+                    wasm,
+                    name: Some("cost-probe".to_owned()),
+                },
+            ),
+        )])
+        .expect("load sequence");
+    match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Ok { mailbox_id, .. } => mailbox_id,
+        LoadResult::Err { error } => panic!("load_component: {error}"),
+    }
+}
+
+/// `WasmTrampoline::init` seeds a neutral cost cell for every kind the
+/// guest declares a `#[handler]` for; advancing the platform dispatches
+/// the probe's `Tick` handler (it subscribes in `wire`), and each fold
+/// reaches the cell through the init-seeded per-actor cache. End-to-end
+/// proof of the construction-time seed + the lock-free fold path, on a
+/// real component — the path the in-crate unit tests can only stub.
+#[test]
+fn init_seeds_cells_and_dispatch_folds() {
+    let Some(wasm_path) = require_runtime("aether_test_fixture_probe") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let mbox = load_probe(&mut bench, &wasm_path);
+
+    // At construction, before any dispatch: both declared handlers
+    // (`Tick`, `SetRender`) are seeded at the neutral seed (`samples =
+    // 0`) — the known-but-unrun state. If `init`'s seed had not run, the
+    // table would hold no rows for this mailbox.
+    {
+        let CostTailResult::Ok { rows } = bench.cost_table().tail(mbox, &CostTail { kind: None })
+        else {
+            panic!("expected Ok");
+        };
+        let tick = rows
+            .iter()
+            .find(|r| r.kind_id == Tick::ID)
+            .expect("Tick handler cell seeded at init");
+        assert_eq!(tick.samples, 0, "neutral seed before any dispatch");
+        assert!(
+            rows.iter().any(|r| r.kind_id == SetRender::ID),
+            "SetRender handler cell seeded at init",
+        );
+    }
+
+    // Advance 3 ticks → the probe's on_tick dispatches 3× → 3 folds into
+    // the Tick cell. A nonzero count proves the per-actor cache was
+    // stamped at construction (the redesign's load-bearing claim) and the
+    // fold reached it. `SetRender` is never dispatched, so it stays at the
+    // neutral seed.
+    bench
+        .execute(vec![("advance", BenchOp::advance(3))])
+        .expect("advance 3");
+
+    let CostTailResult::Ok { rows } = bench.cost_table().tail(mbox, &CostTail { kind: None })
+    else {
+        panic!("expected Ok");
+    };
+    let tick = rows
+        .iter()
+        .find(|r| r.kind_id == Tick::ID)
+        .expect("Tick handler cell present");
+    assert_eq!(
+        tick.samples, 3,
+        "three Tick dispatches folded into the init-seeded cell",
+    );
+    let set_render = rows
+        .iter()
+        .find(|r| r.kind_id == SetRender::ID)
+        .expect("SetRender handler cell present");
+    assert_eq!(
+        set_render.samples, 0,
+        "an un-dispatched handler stays at the neutral seed",
+    );
+}

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -174,49 +174,30 @@ pub fn dispatch_cost_tail_if_matching(
 }
 
 /// iamacoffeepot/aether#1128 dark-instrumentation fold. Folds one
-/// handler-execution sample — `now − t_received`, the existing
+/// handler-execution sample — `finished − t_received`, the existing
 /// `(Finished.t − Received.t)` trace bracket with no new clock read on
 /// the fast path — into the per-handler [`aether_actor::cost::CostCell`]
-/// EWMA. Runs inside the dispatch `local::with_stamped` block on the
-/// actor's own thread, so it reaches its cell through the lock-free
-/// per-actor [`CostCells`] cache; a kind not in the cache (the framework
-/// arms `log.tail` / `trace.tail` / `cost.tail`, or a fallback dispatch)
-/// is skipped — that's the known-handler filter.
+/// EWMA. Runs inside the dispatch `local::with_stamped` block, so it
+/// reaches its cell through the lock-free per-actor [`CostCells`] cache.
+/// A kind not in the cache (the framework arms `log.tail` / `trace.tail`
+/// / `cost.tail`, or a fallback dispatch) is skipped — the known-handler
+/// filter.
 ///
-/// The per-actor cache is lazy-seeded from the global
-/// [`CostTable`](crate::mail::cost::CostTable) on first dispatch: the
-/// cap-registry seed hook runs cross-thread for the wasm-load path and
-/// can't stamp the actor's `Local<T>` directly, so the actual stamp into
-/// the cache happens here, once, on the actor's own thread — pulling the
-/// *same* `Arc<CostCell>`s the global table holds (the shared-index
-/// invariant). After that the lookup is a lock-free linear scan over a
-/// tiny `Vec`.
+/// The cache is seeded once at actor construction — `WasmTrampoline::init`
+/// for components, the native-cap boot wrap for caps — both inside the
+/// same `with_stamped(&slots, …)` the spawn path opens around `init`
+/// (the stamp binds to the actor's `ActorSlots`, not to a thread, so the
+/// seed runs wherever construction does). Every declared handler's cell
+/// is therefore present before the first dispatch: no lazy first-dispatch
+/// pull, no per-fold lock — just a linear scan over a tiny `Vec`.
 ///
 /// **No scheduling change** — this only writes the cell.
-pub fn fold_handler_cost(
-    binding: &NativeBinding,
-    kind: KindId,
-    t_received: Nanos,
-    finished: Nanos,
-) {
+pub fn fold_handler_cost(kind: KindId, t_received: Nanos, finished: Nanos) {
     // Sample = handler execution time. `finished >= t_received` always
     // (same monotonic clock, finished stamped after received); guard the
     // subtraction anyway so a clock anomaly can't underflow.
     let sample = finished.0.saturating_sub(t_received.0);
     CostCells::try_with_mut(|cells| {
-        if !cells.is_seeded() {
-            // First dispatch on this actor's thread: pull the shared
-            // cells the load-time seed planted in the global table.
-            // Empty stays empty (no declared handlers / not yet seeded
-            // globally) — a later dispatch retries the pull cheaply.
-            let pulled = binding
-                .mailer()
-                .cost_table()
-                .cells_for(binding.self_mailbox());
-            if !pulled.is_empty() {
-                cells.seed(pulled);
-            }
-        }
         if let Some(cell) = cells.get(kind) {
             cell.fold(sample);
         }
@@ -312,7 +293,7 @@ pub fn dispatch_loop_run<A>(
             // Lock-free through the per-actor `CostCells` cache; a
             // framework arm / fallback kind (not in the cache) is
             // skipped. Measure-only — no scheduling change.
-            fold_handler_cost(binding, env.kind, t_received, t_finished);
+            fold_handler_cost(env.kind, t_received, t_finished);
         });
         // ADR-0080 §2 settlement hook, outside `with_stamped` so the
         // `fire_settled` notification runs unstamped (it may resolve mail
@@ -368,7 +349,7 @@ pub fn dispatch_loop_run<A>(
             );
             // iamacoffeepot/aether#1128: fold execution cost (see the
             // main-loop arm above).
-            fold_handler_cost(binding, env.kind, t_received, t_finished);
+            fold_handler_cost(env.kind, t_received, t_finished);
         });
         binding.mailer().record_finished(inbound_mail_id, env.root);
         if let Some(p) = pending {
@@ -407,29 +388,28 @@ pub fn dispatch_loop_run<A>(
 )]
 mod cost_tests {
     use super::*;
-    use crate::actor::native::binding::NativeBinding;
     use crate::test_util::fresh_substrate;
     use aether_actor::local::{ActorSlots, with_stamped};
     use aether_kinds::{CostTail, CostTailResult};
 
     /// iamacoffeepot/aether#1128 step 4: folding a known handler's
-    /// execution time moves its cell (through the lazy per-actor cache
-    /// pull from the seeded global table), and the global `cost.tail`
-    /// dump surfaces the moved row.
+    /// execution time moves its cell, and the global `cost.tail` dump
+    /// surfaces the moved row.
     #[test]
     fn fold_moves_seeded_handler_cell() {
         let (_registry, mailer) = fresh_substrate();
         let self_mbx = MailboxId(0x1128);
         let handled = KindId(10);
-        // Load-time seed: a neutral cell for the actor's one handler.
-        mailer.cost_table().seed(self_mbx, &[handled]);
-
-        let binding = NativeBinding::new_for_test(Arc::clone(&mailer), self_mbx);
+        // Construction seeds both indexes from the handler set — the
+        // global table and the actor's per-actor cache, over one shared
+        // `Arc<CostCell>`. Reproduce that: seed the table, stamp the
+        // returned Arcs into the cache under `with_stamped` (as `init` /
+        // the boot wrap do), then fold.
         let slots = ActorSlots::new();
-        // Fold runs inside `with_stamped` on the actor's own thread, as
-        // the dispatch loop does — the lazy pull stamps the cache here.
         with_stamped(&slots, || {
-            fold_handler_cost(&binding, handled, Nanos(1_000), Nanos(6_000));
+            let seeded = mailer.cost_table().seed(self_mbx, &[handled]);
+            CostCells::try_with_mut(|cells| cells.seed(seeded));
+            fold_handler_cost(handled, Nanos(1_000), Nanos(6_000));
         });
 
         let CostTailResult::Ok { rows } =
@@ -453,15 +433,16 @@ mod cost_tests {
         let (_registry, mailer) = fresh_substrate();
         let self_mbx = MailboxId(0x1128);
         let handled = KindId(10);
-        mailer.cost_table().seed(self_mbx, &[handled]);
 
-        let binding = NativeBinding::new_for_test(Arc::clone(&mailer), self_mbx);
         let slots = ActorSlots::new();
-        // Fold a kind the actor never declared (a framework / fallback
+        // Seed only `handled` into the cache (as construction does), then
+        // fold a kind the actor never declared (a framework / fallback
         // kind) — it must not create a row.
         let stranger = KindId(<LogTail as Kind>::ID.0);
         with_stamped(&slots, || {
-            fold_handler_cost(&binding, stranger, Nanos(0), Nanos(9_999));
+            let seeded = mailer.cost_table().seed(self_mbx, &[handled]);
+            CostCells::try_with_mut(|cells| cells.seed(seeded));
+            fold_handler_cost(stranger, Nanos(0), Nanos(9_999));
         });
 
         let CostTailResult::Ok { rows } =

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -38,12 +38,13 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use aether_actor::Local;
 use aether_actor::MailCtx;
+use aether_actor::cost::CostCells;
 use aether_actor::local::ActorSlots;
 use aether_actor::log::ActorLogRing;
 use aether_actor::trace_ring::ActorTraceRing;
 use aether_data::Kind;
-use aether_kinds::trace::{TraceEvent, TraceTail, TraceTailResult};
-use aether_kinds::{LogTail, LogTailResult};
+use aether_kinds::trace::{Nanos, TraceEvent, TraceTail, TraceTailResult};
+use aether_kinds::{CostTail, CostTailResult, LogTail, LogTailResult};
 
 use crate::actor::native::binding::NativeBinding;
 use crate::actor::native::ctx::NativeCtx;
@@ -138,6 +139,90 @@ pub fn dispatch_trace_tail_if_matching(ctx: &mut NativeCtx<'_>, env: &Envelope) 
     true
 }
 
+/// iamacoffeepot/aether#1128 framework-built-in dispatch arm for
+/// `aether.cost.tail` — the cost-side sibling of
+/// [`dispatch_log_tail_if_matching`] / [`dispatch_trace_tail_if_matching`].
+/// Reads the receiving actor's per-handler execution-cost EWMA from the
+/// global [`CostTable`](crate::mail::cost::CostTable) (filtered to this
+/// actor's mailbox) and replies inline; the dispatcher then skips the
+/// user's typed/fallback dispatch for this envelope. Cold path — read
+/// lock fine (the per-dispatch fold runs lock-free through the per-actor
+/// `CostCells` cache, never here).
+pub fn dispatch_cost_tail_if_matching(
+    binding: &NativeBinding,
+    ctx: &mut NativeCtx<'_>,
+    env: &Envelope,
+) -> bool {
+    if env.kind.0 != <CostTail as Kind>::ID.0 {
+        return false;
+    }
+    let Some(request) = <CostTail as Kind>::decode_from_bytes(env.payload.bytes()) else {
+        ctx.reply(&CostTailResult::Err {
+            error: "aether.cost.tail: payload failed to decode".to_owned(),
+        });
+        return true;
+    };
+    // Read the global cost table filtered to this actor's mailbox (cold
+    // path, read lock fine) so the dump surfaces the load-time
+    // neutral-seed rows even before any dispatch has folded a sample.
+    let reply = binding
+        .mailer()
+        .cost_table()
+        .tail(binding.self_mailbox(), &request);
+    ctx.reply(&reply);
+    true
+}
+
+/// iamacoffeepot/aether#1128 dark-instrumentation fold. Folds one
+/// handler-execution sample — `now − t_received`, the existing
+/// `(Finished.t − Received.t)` trace bracket with no new clock read on
+/// the fast path — into the per-handler [`aether_actor::cost::CostCell`]
+/// EWMA. Runs inside the dispatch `local::with_stamped` block on the
+/// actor's own thread, so it reaches its cell through the lock-free
+/// per-actor [`CostCells`] cache; a kind not in the cache (the framework
+/// arms `log.tail` / `trace.tail` / `cost.tail`, or a fallback dispatch)
+/// is skipped — that's the known-handler filter.
+///
+/// The per-actor cache is lazy-seeded from the global
+/// [`CostTable`](crate::mail::cost::CostTable) on first dispatch: the
+/// cap-registry seed hook runs cross-thread for the wasm-load path and
+/// can't stamp the actor's `Local<T>` directly, so the actual stamp into
+/// the cache happens here, once, on the actor's own thread — pulling the
+/// *same* `Arc<CostCell>`s the global table holds (the shared-index
+/// invariant). After that the lookup is a lock-free linear scan over a
+/// tiny `Vec`.
+///
+/// **No scheduling change** — this only writes the cell.
+pub fn fold_handler_cost(
+    binding: &NativeBinding,
+    kind: KindId,
+    t_received: Nanos,
+    finished: Nanos,
+) {
+    // Sample = handler execution time. `finished >= t_received` always
+    // (same monotonic clock, finished stamped after received); guard the
+    // subtraction anyway so a clock anomaly can't underflow.
+    let sample = finished.0.saturating_sub(t_received.0);
+    CostCells::try_with_mut(|cells| {
+        if !cells.is_seeded() {
+            // First dispatch on this actor's thread: pull the shared
+            // cells the load-time seed planted in the global table.
+            // Empty stays empty (no declared handlers / not yet seeded
+            // globally) — a later dispatch retries the pull cheaply.
+            let pulled = binding
+                .mailer()
+                .cost_table()
+                .cells_for(binding.self_mailbox());
+            if !pulled.is_empty() {
+                cells.seed(pulled);
+            }
+        }
+        if let Some(cell) = cells.get(kind) {
+            cell.fold(sample);
+        }
+    });
+}
+
 /// Run one actor's dispatcher loop on the calling thread. Returns
 /// when the binding signals shutdown (self-shutdown flag set or
 /// inbox sender disconnected). See module doc-comment for the full
@@ -177,11 +262,15 @@ pub fn dispatch_loop_run<A>(
             // (recipient) actor's trace ring — only inside this
             // `with_stamped` is its `ActorSlots` stamped.
             let th = binding.mailer().trace_handle();
+            // iamacoffeepot/aether#1128: capture the `Received` instant
+            // so the cost fold below reuses the existing trace bracket —
+            // no new timestamp on the hot path.
+            let t_received = th.now_nanos();
             th.push_trace_ring(
                 env.root,
                 TraceEvent::Received {
                     mail_id: inbound_mail_id,
-                    t: th.now_nanos(),
+                    t: t_received,
                     // iamacoffeepot/aether#1134: the producer-stamped
                     // deposit instant + scheduler backlog, splitting the
                     // hop into send→enqueue + queue residence.
@@ -191,12 +280,15 @@ pub fn dispatch_loop_run<A>(
                 },
             );
             let mut ctx = NativeCtx::new(binding, env.sender, env.mail_id, env.root);
-            // ADR-0081 / ADR-0086: the framework intercepts
-            // `aether.log.tail` and `aether.trace.tail` before the
+            // ADR-0081 / ADR-0086 / iamacoffeepot/aether#1128: the
+            // framework intercepts `aether.log.tail`,
+            // `aether.trace.tail`, and `aether.cost.tail` before the
             // actor's typed/fallback dispatch. The actor never sees
-            // these; the framework reads its rings and replies inline.
+            // these; the framework reads its rings / cost table and
+            // replies inline.
             if !dispatch_log_tail_if_matching(&mut ctx, &env)
                 && !dispatch_trace_tail_if_matching(&mut ctx, &env)
+                && !dispatch_cost_tail_if_matching(binding, &mut ctx, &env)
             {
                 typed_then_fallback_or_warn::<A>(actor, &mut ctx, &env);
             }
@@ -207,13 +299,20 @@ pub fn dispatch_loop_run<A>(
             // trace walk expects. Otherwise the flush rides `ctx`'s
             // scope-end `Drop`, landing after this push.
             drop(ctx);
+            let t_finished = th.now_nanos();
             th.push_trace_ring(
                 env.root,
                 TraceEvent::Finished {
                     mail_id: inbound_mail_id,
-                    t: th.now_nanos(),
+                    t: t_finished,
                 },
             );
+            // iamacoffeepot/aether#1128: fold this handler's execution
+            // time `(t_finished − t_received)` into its per-handler EWMA.
+            // Lock-free through the per-actor `CostCells` cache; a
+            // framework arm / fallback kind (not in the cache) is
+            // skipped. Measure-only — no scheduling change.
+            fold_handler_cost(binding, env.kind, t_received, t_finished);
         });
         // ADR-0080 §2 settlement hook, outside `with_stamped` so the
         // `fire_settled` notification runs unstamped (it may resolve mail
@@ -234,11 +333,12 @@ pub fn dispatch_loop_run<A>(
         let thread_id = thread_name::current_thread_id();
         local::with_stamped(slots, || {
             let th = binding.mailer().trace_handle();
+            let t_received = th.now_nanos();
             th.push_trace_ring(
                 env.root,
                 TraceEvent::Received {
                     mail_id: inbound_mail_id,
-                    t: th.now_nanos(),
+                    t: t_received,
                     // iamacoffeepot/aether#1134: the producer-stamped
                     // deposit instant + scheduler backlog, splitting the
                     // hop into send→enqueue + queue residence.
@@ -250,6 +350,7 @@ pub fn dispatch_loop_run<A>(
             let mut ctx = NativeCtx::new(binding, env.sender, env.mail_id, env.root);
             if !dispatch_log_tail_if_matching(&mut ctx, &env)
                 && !dispatch_trace_tail_if_matching(&mut ctx, &env)
+                && !dispatch_cost_tail_if_matching(binding, &mut ctx, &env)
             {
                 let _ = actor.__aether_dispatch_envelope(&mut ctx, env.kind, env.payload.bytes());
             }
@@ -257,13 +358,17 @@ pub fn dispatch_loop_run<A>(
             // child `Sent` (stamped at flush-begin on `ctx` drop) precedes
             // its parent's `Finished`. See the main-loop arm above.
             drop(ctx);
+            let t_finished = th.now_nanos();
             th.push_trace_ring(
                 env.root,
                 TraceEvent::Finished {
                     mail_id: inbound_mail_id,
-                    t: th.now_nanos(),
+                    t: t_finished,
                 },
             );
+            // iamacoffeepot/aether#1128: fold execution cost (see the
+            // main-loop arm above).
+            fold_handler_cost(binding, env.kind, t_received, t_finished);
         });
         binding.mailer().record_finished(inbound_mail_id, env.root);
         if let Some(p) = pending {
@@ -292,5 +397,113 @@ pub fn dispatch_loop_run<A>(
         for watcher in watchers {
             mailer.push(Mail::new(watcher, kind, payload.clone(), 1));
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture construction panic on failure is the assertion"
+)]
+mod cost_tests {
+    use super::*;
+    use crate::actor::native::binding::NativeBinding;
+    use crate::test_util::fresh_substrate;
+    use aether_actor::local::{ActorSlots, with_stamped};
+    use aether_kinds::{CostTail, CostTailResult};
+
+    /// iamacoffeepot/aether#1128 step 4: folding a known handler's
+    /// execution time moves its cell (through the lazy per-actor cache
+    /// pull from the seeded global table), and the global `cost.tail`
+    /// dump surfaces the moved row.
+    #[test]
+    fn fold_moves_seeded_handler_cell() {
+        let (_registry, mailer) = fresh_substrate();
+        let self_mbx = MailboxId(0x1128);
+        let handled = KindId(10);
+        // Load-time seed: a neutral cell for the actor's one handler.
+        mailer.cost_table().seed(self_mbx, &[handled]);
+
+        let binding = NativeBinding::new_for_test(Arc::clone(&mailer), self_mbx);
+        let slots = ActorSlots::new();
+        // Fold runs inside `with_stamped` on the actor's own thread, as
+        // the dispatch loop does — the lazy pull stamps the cache here.
+        with_stamped(&slots, || {
+            fold_handler_cost(&binding, handled, Nanos(1_000), Nanos(6_000));
+        });
+
+        let CostTailResult::Ok { rows } =
+            mailer.cost_table().tail(self_mbx, &CostTail { kind: None })
+        else {
+            panic!("expected Ok");
+        };
+        let row = rows
+            .iter()
+            .find(|r| r.kind_id == handled)
+            .expect("handled kind's row present");
+        assert_eq!(row.samples, 1, "one sample folded");
+        assert_eq!(row.mean_nanos, 5_000, "(finished − received) = 5000ns");
+    }
+
+    /// iamacoffeepot/aether#1128 step 4: a kind NOT in the actor's
+    /// seeded handler set (a framework arm like `log.tail`, or fallback
+    /// dispatch) leaves no cell — the fold's known-handler filter.
+    #[test]
+    fn fold_skips_unseeded_kind() {
+        let (_registry, mailer) = fresh_substrate();
+        let self_mbx = MailboxId(0x1128);
+        let handled = KindId(10);
+        mailer.cost_table().seed(self_mbx, &[handled]);
+
+        let binding = NativeBinding::new_for_test(Arc::clone(&mailer), self_mbx);
+        let slots = ActorSlots::new();
+        // Fold a kind the actor never declared (a framework / fallback
+        // kind) — it must not create a row.
+        let stranger = KindId(<LogTail as Kind>::ID.0);
+        with_stamped(&slots, || {
+            fold_handler_cost(&binding, stranger, Nanos(0), Nanos(9_999));
+        });
+
+        let CostTailResult::Ok { rows } =
+            mailer.cost_table().tail(self_mbx, &CostTail { kind: None })
+        else {
+            panic!("expected Ok");
+        };
+        assert!(
+            rows.iter().all(|r| r.kind_id != stranger),
+            "an unseeded kind folds into no cell",
+        );
+        // The seeded handler stays at its neutral seed (samples = 0).
+        let seeded_row = rows.iter().find(|r| r.kind_id == handled).unwrap();
+        assert_eq!(seeded_row.samples, 0);
+    }
+
+    /// iamacoffeepot/aether#1128 step 6: the `cost.tail` framework arm
+    /// returns the actor's rows (filtered to `CostTail::kind` when set)
+    /// from the global table. Exercised directly through the table the
+    /// arm reads — `dispatch_cost_tail_if_matching` is a thin wrapper
+    /// over `cost_table().tail(self_mailbox, &request)`.
+    #[test]
+    fn cost_tail_arm_reports_seeded_rows() {
+        let (_registry, mailer) = fresh_substrate();
+        let self_mbx = MailboxId(0x1128);
+        mailer
+            .cost_table()
+            .seed(self_mbx, &[KindId(10), KindId(20)]);
+
+        let CostTailResult::Ok { rows } = mailer.cost_table().tail(
+            self_mbx,
+            &CostTail {
+                kind: Some(KindId(20)),
+            },
+        ) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(rows.len(), 1, "kind filter narrows the dump");
+        assert_eq!(rows[0].kind_id, KindId(20));
+        assert_eq!(
+            rows[0].samples, 0,
+            "neutral seed surfaces before any dispatch"
+        );
     }
 }

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -288,7 +288,7 @@ where
             // per-actor cache; framework / fallback kinds skipped).
             // Measure-only — no scheduling change. See
             // `dispatch::fold_handler_cost`.
-            super::dispatch::fold_handler_cost(&self.binding, env.kind, t_received, t_finished);
+            super::dispatch::fold_handler_cost(env.kind, t_received, t_finished);
         });
         self.binding
             .mailer()

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -242,11 +242,15 @@ where
             // `with_stamped` is its `ActorSlots` stamped. Mirrors
             // `dispatch::dispatch_loop_run`.
             let th = self.binding.mailer().trace_handle();
+            // iamacoffeepot/aether#1128: capture the `Received` instant
+            // so the cost fold below reuses the existing trace bracket —
+            // no new timestamp on the hot path.
+            let t_received = th.now_nanos();
             th.push_trace_ring(
                 env.root,
                 TraceEvent::Received {
                     mail_id: inbound_mail_id,
-                    t: th.now_nanos(),
+                    t: t_received,
                     // iamacoffeepot/aether#1134: surface the deposit
                     // instant + scheduler backlog the producer stamped at
                     // `route_mail`, so the hop splits into send→enqueue +
@@ -257,11 +261,13 @@ where
                 },
             );
             let mut ctx = NativeCtx::new(&self.binding, env.sender, env.mail_id, env.root);
-            // ADR-0081 / ADR-0086 framework-built-in dispatch arms for
-            // `aether.log.tail` + `aether.trace.tail`. See
+            // ADR-0081 / ADR-0086 / iamacoffeepot/aether#1128
+            // framework-built-in dispatch arms for `aether.log.tail` +
+            // `aether.trace.tail` + `aether.cost.tail`. See
             // `dispatch::dispatch_loop_run`.
             if !super::dispatch::dispatch_log_tail_if_matching(&mut ctx, &env)
                 && !super::dispatch::dispatch_trace_tail_if_matching(&mut ctx, &env)
+                && !super::dispatch::dispatch_cost_tail_if_matching(&self.binding, &mut ctx, &env)
             {
                 super::dispatch::typed_then_fallback_or_warn::<A>(actor, &mut ctx, &env);
             }
@@ -269,13 +275,20 @@ where
             // child `Sent` (stamped at flush-begin on `ctx` drop) precedes
             // its parent's `Finished`. See `dispatch::dispatch_loop_run`.
             drop(ctx);
+            let t_finished = th.now_nanos();
             th.push_trace_ring(
                 env.root,
                 TraceEvent::Finished {
                     mail_id: inbound_mail_id,
-                    t: th.now_nanos(),
+                    t: t_finished,
                 },
             );
+            // iamacoffeepot/aether#1128: fold this handler's execution
+            // time into its per-handler EWMA (lock-free through the
+            // per-actor cache; framework / fallback kinds skipped).
+            // Measure-only — no scheduling change. See
+            // `dispatch::fold_handler_cost`.
+            super::dispatch::fold_handler_cost(&self.binding, env.kind, t_received, t_finished);
         });
         self.binding
             .mailer()

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -46,6 +46,7 @@ use crate::scheduler::{Pool, PoolConfig, PoolHandle};
 use aether_actor::Actor;
 #[cfg(test)]
 use aether_actor::HandlesKind;
+use aether_actor::cost::CostCells;
 use aether_actor::local;
 use aether_actor::local::ActorSlots;
 use aether_data::mailbox_id_from_name;
@@ -543,10 +544,30 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
         // `NativeDispatch`, whose `__aether_capabilities` the `#[actor]`
         // macro overrides to enumerate the cap's handlers; the default
         // (empty) covers any cap the macro didn't touch.
+        let capabilities = A::__aether_capabilities();
         ctx.mail_send_handle().capability_registry().register(
             resources.mailbox_id,
-            MailboxCaps::from_component_capabilities(&A::__aether_capabilities()),
+            MailboxCaps::from_component_capabilities(&capabilities),
         );
+
+        // iamacoffeepot/aether#1128: seed this native cap's per-handler
+        // cost cells into the global `CostTable` (same hook as the
+        // cap-registry accept-set above), then stamp the same `Arc`s
+        // into the actor's per-actor `CostCells` cache. Unlike the wasm
+        // load path (cap-thread, can't reach the trampoline's slots), a
+        // native cap's `slots` are right here — wrap the cache seed in
+        // `with_stamped(&resources.slots, ...)` exactly like the `init`
+        // wrap above so both indexes share the same neutral cells.
+        let handler_kinds: Vec<aether_data::KindId> =
+            capabilities.handlers.iter().map(|h| h.id).collect();
+        let seeded = ctx
+            .mail_send_handle()
+            .cost_table()
+            .seed(resources.mailbox_id, &handler_kinds);
+        local::with_stamped(&resources.slots, || {
+            use aether_actor::Local as _;
+            CostCells::try_with_mut(|cells| cells.seed(seeded));
+        });
 
         // Issue 629 / Phase A: dispatcher takes Box<A> ownership.
         self.state = BootState::Initialized {

--- a/crates/aether-substrate/src/mail/cost.rs
+++ b/crates/aether-substrate/src/mail/cost.rs
@@ -4,19 +4,20 @@
 //
 // The cold-path index over the per-handler [`CostCell`]s
 // (`aether_actor::cost`). Cost is *measured* at the recipient (its
-// handler runs, and the dispatch fold writes the cell on the recipient's
-// own thread through its lock-free per-actor `CostCells` cache) but
-// *consumed* cross-thread — by the `cost.tail` dump here, and by a
-// future iamacoffeepot/aether#1178 producer-side `Σw` / `w_max` read at
-// flush. Both reach the *same* `Arc<CostCell>` through this global table.
+// handler runs, and the dispatch fold writes the cell through that
+// actor's lock-free per-actor `CostCells` cache — on whichever worker is
+// dispatching it, exclusively) but *consumed* cross-thread — by the
+// `cost.tail` dump here, and by a future iamacoffeepot/aether#1178
+// producer-side `Σw` / `w_max` read at flush. Both reach the *same*
+// `Arc<CostCell>` through this global table.
 //
 // Mirrors the routing-sibling [`CapabilityRegistry`] (`capability.rs`):
 // `RwLock<HashMap<_, _>>` hung off the [`Mailer`](super::mailer::Mailer),
-// locked only at component load / replace / drop (rare) and on the cold
-// dump — never on the per-dispatch fold (that runs lock-free through the
-// per-actor cache). Keyed by `(MailboxId, KindId)` so one mailbox's
-// handler set is contiguous-by-filter and the recruiter can sum a
-// recipient group.
+// seeded/torn-down when an actor is constructed / replaced / dropped
+// (rare) and read on the cold dump — never on the per-dispatch fold
+// (that runs lock-free through the per-actor cache). Keyed by
+// `(MailboxId, KindId)` so one mailbox's handler set is
+// contiguous-by-filter and the recruiter can sum a recipient group.
 
 // The table's `RwLock` guard is held across the
 // resolve-then-row-build pair in `tail` — the same low-contention
@@ -59,9 +60,10 @@ impl CostTable {
     /// per-actor `CostCells` cache. Re-seeding an existing
     /// `(mailbox, kind)` reuses the prior cell (so a `replace` against
     /// the same handler set keeps its accumulated estimate); a fresh
-    /// kind gets a new neutral cell. Called at component load / replace
-    /// / native-cap boot — the same hook that populates the capability
-    /// registry's accept-set.
+    /// kind gets a new neutral cell. Called at actor construction
+    /// (`WasmTrampoline::init` / the native-cap boot wrap, both under
+    /// `with_stamped`) and on replace, paired with a `CostCells` cache
+    /// stamp of the returned `Arc`s so both indexes share the cell.
     ///
     /// # Panics
     /// Panics if the internal lock is poisoned — a poisoned lock means a
@@ -90,13 +92,12 @@ impl CostTable {
         guard.retain(|(m, _), _| *m != mailbox);
     }
 
-    /// The shared `Arc<CostCell>`s for one `mailbox`, as
-    /// `(kind, cell)` pairs. The per-actor cache lazy-seed pulls this on
-    /// the actor's own thread (the cap-registry hook runs cross-thread
-    /// for wasm load, so the actual stamp into the `Local<T>` cache
-    /// happens here, lazily, on first dispatch); a future
-    /// iamacoffeepot/aether#1178 recruiter sums these per recipient
-    /// group. Cold path — read lock.
+    /// The shared `Arc<CostCell>`s for one `mailbox`, as `(kind, cell)`
+    /// pairs — the cross-actor read the global index exists for. A future
+    /// iamacoffeepot/aether#1178 recruiter sums these per recipient group
+    /// at the producer's flush (the per-actor caches are private to each
+    /// recipient's dispatch; this table is how a producer reads them).
+    /// Cold path — read lock.
     ///
     /// # Panics
     /// Panics if the internal lock is poisoned (see [`Self::seed`]).

--- a/crates/aether-substrate/src/mail/cost.rs
+++ b/crates/aether-substrate/src/mail/cost.rs
@@ -1,0 +1,243 @@
+// iamacoffeepot/aether#1128 global per-handler execution-cost table —
+// Phase 0 of iamacoffeepot/aether#1127's cost-aware recruiter.
+// **Measure-only; no scheduling change.**
+//
+// The cold-path index over the per-handler [`CostCell`]s
+// (`aether_actor::cost`). Cost is *measured* at the recipient (its
+// handler runs, and the dispatch fold writes the cell on the recipient's
+// own thread through its lock-free per-actor `CostCells` cache) but
+// *consumed* cross-thread — by the `cost.tail` dump here, and by a
+// future iamacoffeepot/aether#1178 producer-side `Σw` / `w_max` read at
+// flush. Both reach the *same* `Arc<CostCell>` through this global table.
+//
+// Mirrors the routing-sibling [`CapabilityRegistry`] (`capability.rs`):
+// `RwLock<HashMap<_, _>>` hung off the [`Mailer`](super::mailer::Mailer),
+// locked only at component load / replace / drop (rare) and on the cold
+// dump — never on the per-dispatch fold (that runs lock-free through the
+// per-actor cache). Keyed by `(MailboxId, KindId)` so one mailbox's
+// handler set is contiguous-by-filter and the recruiter can sum a
+// recipient group.
+
+// The table's `RwLock` guard is held across the
+// resolve-then-row-build pair in `tail` — the same low-contention
+// rationale as the routing registry's guard policy.
+#![allow(clippy::significant_drop_tightening)]
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use aether_actor::cost::CostCell;
+use aether_kinds::{CostRow, CostTail, CostTailResult};
+
+use crate::mail::{KindId, MailboxId};
+
+/// Substrate-owned global index over every actor's per-handler
+/// [`CostCell`]s. Shared as part of the [`Mailer`](super::mailer::Mailer)
+/// (mirroring how the routing [`Registry`](super::registry::Registry)
+/// and [`CapabilityRegistry`](super::capability::CapabilityRegistry) are
+/// shared). The load / replace / drop hooks `seed` / `drop_mailbox`; the
+/// cold `cost.tail` dump and a future producer-side recruiter read `tail`
+/// / `cells_for`.
+#[derive(Debug, Default)]
+pub struct CostTable {
+    cells: RwLock<HashMap<(MailboxId, KindId), Arc<CostCell>>>,
+}
+
+impl CostTable {
+    /// A fresh, empty table. The boot path builds one and shares it via
+    /// the [`Mailer`](super::mailer::Mailer).
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            cells: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Seed a neutral cell (`samples = 0`) for every kind in `kinds`
+    /// under `mailbox`, returning the `(kind, Arc<CostCell>)` pairs so
+    /// the caller can stamp the *same* `Arc`s into the actor's
+    /// per-actor `CostCells` cache. Re-seeding an existing
+    /// `(mailbox, kind)` reuses the prior cell (so a `replace` against
+    /// the same handler set keeps its accumulated estimate); a fresh
+    /// kind gets a new neutral cell. Called at component load / replace
+    /// / native-cap boot — the same hook that populates the capability
+    /// registry's accept-set.
+    ///
+    /// # Panics
+    /// Panics if the internal lock is poisoned — a poisoned lock means a
+    /// prior writer panicked mid-update, a substrate-level invariant
+    /// violation (fail-fast per ADR-0063).
+    pub fn seed(&self, mailbox: MailboxId, kinds: &[KindId]) -> Vec<(KindId, Arc<CostCell>)> {
+        let mut guard = self.cells.write().expect("cost table lock poisoned");
+        kinds
+            .iter()
+            .map(|&kind| {
+                let cell = guard
+                    .entry((mailbox, kind))
+                    .or_insert_with(|| Arc::new(CostCell::new()));
+                (kind, Arc::clone(cell))
+            })
+            .collect()
+    }
+
+    /// Remove every cell for `mailbox`. Called on
+    /// `aether.component.drop` / unload. A no-op for an unknown mailbox.
+    ///
+    /// # Panics
+    /// Panics if the internal lock is poisoned (see [`Self::seed`]).
+    pub fn drop_mailbox(&self, mailbox: MailboxId) {
+        let mut guard = self.cells.write().expect("cost table lock poisoned");
+        guard.retain(|(m, _), _| *m != mailbox);
+    }
+
+    /// The shared `Arc<CostCell>`s for one `mailbox`, as
+    /// `(kind, cell)` pairs. The per-actor cache lazy-seed pulls this on
+    /// the actor's own thread (the cap-registry hook runs cross-thread
+    /// for wasm load, so the actual stamp into the `Local<T>` cache
+    /// happens here, lazily, on first dispatch); a future
+    /// iamacoffeepot/aether#1178 recruiter sums these per recipient
+    /// group. Cold path — read lock.
+    ///
+    /// # Panics
+    /// Panics if the internal lock is poisoned (see [`Self::seed`]).
+    #[must_use]
+    pub fn cells_for(&self, mailbox: MailboxId) -> Vec<(KindId, Arc<CostCell>)> {
+        let guard = self.cells.read().expect("cost table lock poisoned");
+        guard
+            .iter()
+            .filter(|((m, _), _)| *m == mailbox)
+            .map(|((_, k), c)| (*k, Arc::clone(c)))
+            .collect()
+    }
+
+    /// Dump `mailbox`'s cost rows, filtered to `request.kind` when set.
+    /// `kind_name` is left `None` here — the table holds ids, not names;
+    /// the `cost.tail` dispatch arm (or the MCP layer) resolves names
+    /// against the registry on the cold render path. Cold path — read
+    /// lock.
+    ///
+    /// # Panics
+    /// Panics if the internal lock is poisoned (see [`Self::seed`]).
+    #[must_use]
+    pub fn tail(&self, mailbox: MailboxId, request: &CostTail) -> CostTailResult {
+        let guard = self.cells.read().expect("cost table lock poisoned");
+        let rows = guard
+            .iter()
+            .filter(|((m, _), _)| *m == mailbox)
+            .filter(|((_, k), _)| request.kind.is_none_or(|want| *k == want))
+            .map(|((_, k), c)| CostRow {
+                kind_id: *k,
+                kind_name: None,
+                mean_nanos: c.mean_nanos(),
+                mad_nanos: c.mad_nanos(),
+                samples: c.samples(),
+            })
+            .collect();
+        CostTailResult::Ok { rows }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seed_returns_neutral_cells_in_both_indexes() {
+        let table = CostTable::new();
+        let mbx = MailboxId(7);
+        let handed = table.seed(mbx, &[KindId(10), KindId(20)]);
+        assert_eq!(handed.len(), 2);
+        // The handed-back Arcs are the table's own cells (shared index):
+        // a fold through the handed Arc is visible through `tail`.
+        for (_, cell) in &handed {
+            assert_eq!(cell.samples(), 0, "neutral seed");
+        }
+
+        let CostTailResult::Ok { rows } = table.tail(mbx, &CostTail { kind: None }) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|r| r.samples == 0));
+    }
+
+    #[test]
+    fn fold_through_handed_arc_is_visible_in_tail() {
+        let table = CostTable::new();
+        let mbx = MailboxId(7);
+        let handed = table.seed(mbx, &[KindId(10)]);
+        handed[0].1.fold(2_000);
+
+        let CostTailResult::Ok { rows } = table.tail(
+            mbx,
+            &CostTail {
+                kind: Some(KindId(10)),
+            },
+        ) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].kind_id, KindId(10));
+        assert_eq!(rows[0].mean_nanos, 2_000);
+        assert_eq!(rows[0].samples, 1);
+    }
+
+    #[test]
+    fn re_seed_reuses_prior_cell() {
+        let table = CostTable::new();
+        let mbx = MailboxId(7);
+        let first = table.seed(mbx, &[KindId(10)]);
+        first[0].1.fold(5_000);
+        // Replace against the same handler set: the cell (and its
+        // accumulated estimate) is reused.
+        let second = table.seed(mbx, &[KindId(10)]);
+        assert_eq!(second[0].1.mean_nanos(), 5_000);
+        assert_eq!(second[0].1.samples(), 1);
+    }
+
+    #[test]
+    fn tail_kind_filter_narrows_rows() {
+        let table = CostTable::new();
+        let mbx = MailboxId(7);
+        table.seed(mbx, &[KindId(10), KindId(20)]);
+        let CostTailResult::Ok { rows } = table.tail(
+            mbx,
+            &CostTail {
+                kind: Some(KindId(10)),
+            },
+        ) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].kind_id, KindId(10));
+    }
+
+    #[test]
+    fn drop_mailbox_clears_only_that_mailbox() {
+        let table = CostTable::new();
+        let a = MailboxId(7);
+        let b = MailboxId(8);
+        table.seed(a, &[KindId(10)]);
+        table.seed(b, &[KindId(10)]);
+        table.drop_mailbox(a);
+
+        let CostTailResult::Ok { rows } = table.tail(a, &CostTail { kind: None }) else {
+            panic!("expected Ok");
+        };
+        assert!(rows.is_empty(), "dropped mailbox's cells gone");
+        let CostTailResult::Ok { rows } = table.tail(b, &CostTail { kind: None }) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(rows.len(), 1, "sibling mailbox's cells survive");
+    }
+
+    #[test]
+    fn cells_for_returns_mailbox_slice() {
+        let table = CostTable::new();
+        let mbx = MailboxId(7);
+        table.seed(mbx, &[KindId(10), KindId(20)]);
+        let cells = table.cells_for(mbx);
+        assert_eq!(cells.len(), 2);
+        assert!(cells.iter().any(|(k, _)| *k == KindId(10)));
+        assert!(cells.iter().any(|(k, _)| *k == KindId(20)));
+    }
+}

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -28,6 +28,7 @@ use std::sync::Arc;
 use crate::chassis::settlement::SettlementRegistry;
 use crate::handle_store::{self, HandleStore, PutError, WalkOutcome};
 use crate::mail::capability::CapabilityRegistry;
+use crate::mail::cost::CostTable;
 use crate::mail::outbound::HubOutbound;
 use crate::mail::registry::{MailDispatch, MailboxEntry, OwnedDispatch, Registry};
 use crate::mail::{Mail, MailRef, ReplyTarget, ReplyTo};
@@ -106,6 +107,18 @@ pub struct Mailer {
     /// re-registers, drop clears. Allocated empty by [`Self::new`]
     /// (like `trace_handle`) so no call site changes.
     capability_registry: Arc<CapabilityRegistry>,
+    /// iamacoffeepot/aether#1128 global per-handler execution-cost
+    /// table — Phase 0 of the cost-aware recruiter. A sibling of
+    /// [`Self::capability_registry`]: the cold-path index over every
+    /// actor's per-handler [`aether_actor::cost::CostCell`]s, shared as
+    /// the same `Arc<CostCell>` the actor's lock-free per-actor
+    /// `CostCells` cache holds. The component-load / native-cap-boot
+    /// path seeds it (alongside the cap-registry accept-set); the
+    /// `cost.tail` dump and a future iamacoffeepot/aether#1178
+    /// producer-side `Σw` read it. Never touched on the per-dispatch
+    /// fold (that runs lock-free through the per-actor cache). Allocated
+    /// empty by [`Self::new`] (like `trace_handle`).
+    cost_table: Arc<CostTable>,
 }
 
 impl Mailer {
@@ -124,6 +137,7 @@ impl Mailer {
             settlement_registry: OnceLock::new(),
             trace_handle: TraceHandle::new(),
             capability_registry: Arc::new(CapabilityRegistry::new()),
+            cost_table: Arc::new(CostTable::new()),
         }
     }
 
@@ -336,6 +350,18 @@ impl Mailer {
     /// how [`Self::registry`] surfaces the routing table.
     pub fn capability_registry(&self) -> &Arc<CapabilityRegistry> {
         &self.capability_registry
+    }
+
+    /// Borrow the wired [`CostTable`] (iamacoffeepot/aether#1128). The
+    /// component-load / native-cap-boot path seeds it (alongside the
+    /// capability registry's accept-set); the `cost.tail` dispatch arm
+    /// dumps it, and a future iamacoffeepot/aether#1178 recruiter sums
+    /// recipient-group cells from it at flush. Shared via the `Mailer`
+    /// so any actor with `ctx.mailer()` reaches the same table —
+    /// mirroring how [`Self::capability_registry`] surfaces its sibling
+    /// index.
+    pub fn cost_table(&self) -> &Arc<CostTable> {
+        &self.cost_table
     }
 
     /// Hand `mail` to the substrate for dispatch. `Inbox`-bound

--- a/crates/aether-substrate/src/mail/mod.rs
+++ b/crates/aether-substrate/src/mail/mod.rs
@@ -8,6 +8,7 @@
 //! per-cap dispatchers.
 
 pub mod capability;
+pub mod cost;
 pub mod helpers;
 pub mod mail_ref;
 pub mod mailer;
@@ -16,6 +17,7 @@ pub mod registry;
 pub mod ring;
 
 pub use capability::{CapabilityRegistry, MailboxCaps};
+pub use cost::CostTable;
 pub use mail_ref::MailRef;
 pub use mailer::Mailer;
 pub use outbound::{DroppingBackend, EgressBackend, EgressEvent, HubOutbound, RecordingBackend};


### PR DESCRIPTION
Closes iamacoffeepot/aether#1128

Phase 0 of the cost-aware recruiter (iamacoffeepot/aether#1127): a measure-only per-handler execution-cost EWMA folded from the existing Received to Finished dispatch trace bracket — no new timestamps, zero scheduling change, no unsafe.

- aether-actor: a CostCell (mean/mad/samples as AtomicU64, fixed-point nanos, power-of-two-shift alpha, plain load/compute/store fold) plus a per-actor CostCells Local cache mirroring the ADR-0081 ActorLogRing mechanism. aether-substrate: a global CostTable (RwLock map keyed by mailbox+kind) hung off Mailer beside CapabilityRegistry, sharing the same Arc cells; the fold runs lock-free through the per-actor cache at the Finished push in both dispatch chains (framework arms and fallback kinds skipped); seed/teardown ride the existing cap-registry load/replace/drop and native-cap-boot hooks. aether-kinds: CostTail / CostTailResult / CostRow beside LogTail / TraceTail, with a dispatch_cost_tail_if_matching framework arm wired into both dispatch chains. aether-mcp: an actor_cost tool mirroring actor_logs.
- Tests: EWMA convergence / neutral-seed (aether-actor), seed-into-both-indexes + drop + tail-filter (CostTable), schema round-trips (aether-kinds), in-process fold-moves-the-cell + framework-kind-skip + cost.tail-arm (aether-substrate), and the MCP arg parsing / kind-name resolution.
- The TestBench substrate scenarios ran locally as part of scripts/preflight.sh (a wgpu adapter is present on this worktree) and passed; full preflight green (fmt, clippy -D warnings, doc, wasm32 component cross-build, nextest 1340 passed). CI's Linux runner has Mesa drivers and always runs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
