### PR TITLE
perf(substrate/scheduler): deterministic cost-aware recruit-K (work/longest-pole) (issue 1178)

### DIFF
--- a/crates/aether-substrate/src/actor/native/blob_work.rs
+++ b/crates/aether-substrate/src/actor/native/blob_work.rs
@@ -1316,7 +1316,7 @@ mod tests {
         assert_eq!(recruit_k(100_000, 50_000, 2, 8), 2);
     }
 
-    /// Balanced-wide: many equal groups → `K = min(G, W)`. Σw / w_max ≈ G,
+    /// Balanced-wide: many equal groups → `K = min(G, W)`. `Σw` / `w_max` ≈ G,
     /// clamped by the worker count.
     #[test]
     fn recruit_k_balanced_wide_recruits_to_worker_cap() {

--- a/crates/aether-substrate/src/actor/native/blob_work.rs
+++ b/crates/aether-substrate/src/actor/native/blob_work.rs
@@ -76,19 +76,42 @@
 //! ref kind falls back to [`Mailer::push`] → `route_mail`, inheriting that
 //! path's ref-walk / park / settlement / trace unchanged.
 //!
-//! ## Recruitment gate
+//! ## Recruitment gate (cost-aware, iamacoffeepot/aether#1178)
 //!
-//! Recruiting siblings for a *narrow* fan-out would regress the
+//! Recruiting siblings for a *cheap* fan-out would regress the
 //! iamacoffeepot/aether#1116 narrow-local win (needless wakeups for cheap
-//! handlers). So a flush only broadcast-recruits when its fresh-group count
-//! is `>= AETHER_BLOB_RECRUIT_MIN` (default 9 — narrow `<= 8` fan-outs stay
-//! local, exactly the prior inline-demux behaviour); otherwise it just
-//! schedules the blob on the producer's own deque. **Width is a coarse
-//! proxy for the real signal (handler cost):** it cannot tell a heavy
-//! narrow fan-out (which would benefit) from a trivial one (which would
-//! not). Cost-aware recruitment sizing is deferred to
-//! iamacoffeepot/aether#1127 (fed by iamacoffeepot/aether#1128's per-handler
-//! EWMA); until then a heavy `<= 8` fan-out stays serial.
+//! handlers). The original gate used **width** as a proxy — broadcast only
+//! when the fresh-group count cleared `AETHER_BLOB_RECRUIT_MIN` — but width
+//! cannot tell a heavy narrow fan-out (which benefits from parallelism)
+//! from a trivial one (which does not), so a heavy `<= 8` fan-out stayed
+//! serial and a single global threshold could not be right for two
+//! components at once. iamacoffeepot/aether#1178 replaces width with a
+//! **cost-aware** decision: at flush, sum iamacoffeepot/aether#1128's
+//! per-handler execution-cost EWMA over the flush's fresh recipient groups
+//! and size recruitment by the actual work. The recipient group is the unit
+//! of parallelism (a worker drains a whole group; groups can't split), so
+//! the blob is a parallel-machine makespan problem — optimal
+//! `K ≈ ceil(total_work / longest_pole)`, clamped to `[1, min(G, W)]` and
+//! gated by `total_work > C_WAKE_NANOS` (the wake break-even). [`recruit_k`]
+//! is that closed form. A cheap narrow blob yields `K = 1` and stays local
+//! — preserving the #1116 win for the right reason (cheapness, not
+//! narrowness) — while a heavy narrow blob recruits its full group count.
+//!
+//! When any contributing handler's cell is **unknown cost** — a neutral
+//! seed (`samples == 0`, known-but-never-run) or a high mean-abs-deviation
+//! (bimodal, untrustworthy) — the cost estimate is noise, so the flush
+//! falls back to the **width gate** (`AETHER_BLOB_RECRUIT_MIN`) for that
+//! blob rather than recruiting on a bad number. Width is the confidence
+//! fallback, no longer the primary signal.
+//!
+//! **Aggregation scope (iamacoffeepot/aether#1178 step 5):** `total_work` /
+//! `max_group_work` are summed over **this flush's fresh groups**, matching
+//! the existing per-flush `fresh_groups` width gate — numerator and
+//! denominator share the same scope, the recruit broadcast still fires once
+//! per flush, and a leftover-roll flush (0 fresh groups) recruits nobody.
+//! A worker races the cursor over *all* published groups, but each flush's
+//! recruit sizes the *newly-published* parallelizable work it is waking
+//! siblings for.
 
 use std::any::Any;
 use std::cell::UnsafeCell;
@@ -96,7 +119,7 @@ use std::env;
 use std::hint::spin_loop;
 use std::mem;
 use std::mem::MaybeUninit;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use aether_kinds::trace::Nanos;
@@ -104,8 +127,9 @@ use rustc_hash::FxHashMap;
 
 use crate::actor::native::Envelope;
 use crate::actor::native::blob_lifecycle::{Lifecycle, MAX_GROUPS, Published};
+use crate::mail::cost::CostLookup;
 use crate::mail::mailer::Mailer;
-use crate::mail::{Mail, MailboxId};
+use crate::mail::{KindId, Mail, MailboxId};
 use crate::scheduler::{BatchBudget, CycleResult, Drainable, SeizeHandle, WakeSink};
 
 /// Floor for a fresh blob's group-array capacity — a little headroom so a
@@ -151,6 +175,104 @@ fn recruit_cap() -> usize {
     })
 }
 
+/// Wake break-even in nanos: the measured injector pickup / park-wake
+/// floor (iamacoffeepot/aether#1174's ~7µs tree floor, attributed to the
+/// injector handoff). A flush whose summed group work is below this can
+/// never amortize a sibling wakeup, so [`recruit_k`] returns `K = 1` and
+/// the blob stays producer-local — the cost-aware form of the prior
+/// narrow-local win (iamacoffeepot/aether#1116). A runtime-measured
+/// `C_wake` is a deferred upgrade (iamacoffeepot/aether#1127); for now it
+/// is this const, overridable via `AETHER_WAKE_COST_NANOS`.
+const C_WAKE_NANOS: u64 = 4_300;
+
+/// High-MAD confidence threshold: a handler whose mean-absolute-deviation
+/// exceeds this fraction of its mean is "bimodal / untrustworthy" — its
+/// EWMA mean is a poor predictor of the next dispatch, so the recruiter
+/// treats it as unknown cost and falls back to the width gate. Expressed
+/// as a `>` ratio test (`mad * MAD_CONFIDENCE_DEN > mean *
+/// MAD_CONFIDENCE_NUM`) to stay integer-only on the flush path. `1/1`
+/// means "MAD as large as the mean" — a spread that doubles the estimate's
+/// uncertainty; below that the mean is trustworthy enough to size on.
+const MAD_CONFIDENCE_NUM: u64 = 1;
+const MAD_CONFIDENCE_DEN: u64 = 1;
+
+/// The wake break-even in nanos, honouring an `AETHER_WAKE_COST_NANOS`
+/// override (unparseable / empty falls back to [`C_WAKE_NANOS`]). Read once.
+fn wake_cost_nanos() -> u64 {
+    static WAKE: OnceLock<u64> = OnceLock::new();
+    *WAKE.get_or_init(|| {
+        env::var("AETHER_WAKE_COST_NANOS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(C_WAKE_NANOS)
+    })
+}
+
+/// The cost-aware recruit target `K` (iamacoffeepot/aether#1178): how many
+/// workers (including the producer's own) should drain this flush's fresh
+/// groups. The recipient group is the unit of parallelism (a worker drains
+/// a whole group; groups can't split), so the blob is a parallel-machine
+/// makespan problem and the optimum is `K ≈ ceil(total_work /
+/// longest_pole)`, clamped to `[1, min(G, W)]`:
+///
+/// - `total_work` is `Σw` over the fresh groups (how *much* work there is),
+/// - `max_group_work` is `w_max`, the longest pole (how *spreadable* it is
+///   — no `K` can beat the single fattest group's serial drain),
+/// - `g` is the fresh-group count `G` (can't use more workers than groups),
+/// - `w` is the pool worker count `W` (can't use more workers than exist).
+///
+/// Below the wake break-even ([`wake_cost_nanos`]) the whole blob is too
+/// cheap to amortize a sibling wakeup, so `K = 1` (stay local). The divide
+/// rounds to nearest (`+ w_max/2`) so a blob that needs "just over" one
+/// extra worker gets it. Integer-only — the EWMA is fixed-point nanos
+/// (iamacoffeepot/aether#1128), no float on the flush path.
+fn recruit_k(total_work: u64, max_group_work: u64, g: usize, w: usize) -> usize {
+    if total_work <= wake_cost_nanos() || max_group_work == 0 {
+        // Below the wake floor (or no measurable pole) — stay local.
+        return 1;
+    }
+    // Round-to-nearest integer divide of Σw / w_max, integer-only.
+    let raw = (total_work + max_group_work / 2) / max_group_work;
+    let ceiling = g.min(w).max(1);
+    // `raw >= 1` here (total_work > 0 and the round-half divide never
+    // truncates a positive ratio to 0), but clamp the low end anyway so a
+    // pathological zero can't escape.
+    let k = usize::try_from(raw).unwrap_or(ceiling);
+    k.clamp(1, ceiling)
+}
+
+/// Is a handler's EWMA mean trustworthy enough to size recruitment on,
+/// given its mean-absolute-deviation? `true` when the spread is below the
+/// [`MAD_CONFIDENCE_NUM`] / [`MAD_CONFIDENCE_DEN`] fraction of the mean —
+/// a steady handler. `false` for a bimodal one (MAD as large as the mean),
+/// whose mean poorly predicts the next dispatch. Integer ratio test, no
+/// float. A zero mean (with a nonzero MAD) is treated as untrustworthy.
+fn trustworthy_mad(mean_nanos: u64, mad_nanos: u64) -> bool {
+    // mad / mean <= NUM / DEN  ⇔  mad * DEN <= mean * NUM (no division).
+    mad_nanos.saturating_mul(MAD_CONFIDENCE_DEN) <= mean_nanos.saturating_mul(MAD_CONFIDENCE_NUM)
+}
+
+/// Resolve one mail's handler cost for the recruiter: its EWMA mean
+/// (nanos) plus whether that estimate is *trustworthy*. A handler is
+/// untrustworthy — and so the cost is `0` and `confident` is `false` —
+/// when the cell is absent (`None`), a neutral seed (`samples == 0`,
+/// known-but-never-run), or high-MAD (its spread is as large as its mean,
+/// so the EWMA poorly predicts the next dispatch). One such cell in a fresh
+/// group tips the whole flush to the width-gate fallback
+/// (iamacoffeepot/aether#1178). A trustworthy cell returns
+/// `(mean_nanos, true)`.
+fn group_mail_cost(costs: &CostLookup<'_>, recipient: MailboxId, kind: KindId) -> (u64, bool) {
+    match costs.get(recipient, kind) {
+        Some(sample)
+            if sample.samples > 0 && trustworthy_mad(sample.mean_nanos, sample.mad_nanos) =>
+        {
+            (sample.mean_nanos, true)
+        }
+        // Absent, neutral seed, or high-MAD: unknown cost.
+        _ => (0, false),
+    }
+}
+
 /// One recipient's mail within a blob, behind a closeable buffer. See the
 /// module doc (§Closeable per-group buffer) for the SPSC drain-loop /
 /// close-on-empty FIFO contract.
@@ -174,6 +296,18 @@ struct Group {
     /// Contention is rare by construction (one producer, one cursor-winning
     /// worker — §Closeable per-group buffer), so the spin almost never loops.
     lock: AtomicBool,
+    /// Accumulated handler cost for this group: `Σ cost(recipient, kᵢ)`
+    /// over every mail pushed into it, summing iamacoffeepot/aether#1128's
+    /// per-handler EWMA mean (nanos). A group coalesces mails of different
+    /// kinds (the `index` dedups by recipient, not by kind — `append_flush`),
+    /// so its work is a sum, not a single value — the recruiter's `w_max`
+    /// per-group term (iamacoffeepot/aether#1178). Written by the single
+    /// producer (on push, fresh or appended), never read by a draining
+    /// worker; an `AtomicU64` so the producer accumulates it without taking
+    /// the buffer spinlock and without `&mut Group` (the slot hands out
+    /// `&Group`). `Relaxed` — single-writer, no ordering coupling to the
+    /// buffer.
+    work: AtomicU64,
     buf: UnsafeCell<GroupBuf>,
 }
 
@@ -185,15 +319,35 @@ struct Group {
 unsafe impl Sync for Group {}
 
 impl Group {
-    fn new(recipient: MailboxId, mails: Vec<Mail>) -> Self {
+    fn new(recipient: MailboxId, mails: Vec<Mail>, work: u64) -> Self {
         Self {
             recipient,
             lock: AtomicBool::new(false),
+            work: AtomicU64::new(work),
             buf: UnsafeCell::new(GroupBuf {
                 closed: false,
                 mails,
             }),
         }
+    }
+
+    /// Producer-only: accumulate `cost` (nanos) onto this group's running
+    /// work total when a later mail appends to an already-published group.
+    /// `saturating_add` so a corrupt cost can't wrap (the EWMA is bounded
+    /// fixed-point nanos, ~9 orders below `u64::MAX`, so this only ever
+    /// matters defensively — matching the `saturating_*` idiom elsewhere in
+    /// this module). `Relaxed`: single writer (the producer), and no
+    /// draining worker reads `work`.
+    fn add_work(&self, cost: u64) {
+        let prior = self.work.load(Ordering::Relaxed);
+        self.work
+            .store(prior.saturating_add(cost), Ordering::Relaxed);
+    }
+
+    /// The group's accumulated work `Σ cost(recipient, kᵢ)` (nanos).
+    /// Producer-side read for the recruiter's `w_max` term.
+    fn work(&self) -> u64 {
+        self.work.load(Ordering::Relaxed)
     }
 
     /// Run `f` over the buffer under the spinlock. The closures below are
@@ -335,8 +489,25 @@ struct FlushOutcome {
     /// recipient with this one.
     leftover: Vec<Mail>,
     /// Number of new groups this flush published — the width that drives
-    /// the recruitment gate.
+    /// the confidence-fallback (width) recruitment gate.
     fresh_groups: usize,
+    /// `Σw`: the summed handler cost (nanos) of this flush's **fresh
+    /// groups** — the cost-aware recruiter's numerator
+    /// (iamacoffeepot/aether#1178). Scoped to fresh groups so it matches
+    /// `fresh_groups` (the recruit decision is per-flush) and pairs
+    /// consistently with `max_group_work` (same scope). Existing groups a
+    /// later flush appends to keep their *own* running `Group::work` total
+    /// but do not re-enter another flush's `total_work`.
+    total_work: u64,
+    /// `w_max`: the largest single fresh group's accumulated work (nanos)
+    /// — the longest pole, bounding how spreadable this flush's work is.
+    max_group_work: u64,
+    /// `true` when every fresh group's contributing handler cells were
+    /// **trustworthy** (seeded, run at least once, low MAD). `false` if any
+    /// contributing cell was unknown cost (a neutral seed, an absent
+    /// handler, or high-MAD) — the recruiter then ignores `total_work` /
+    /// `max_group_work` and falls back to the width gate for this blob.
+    cost_confident: bool,
 }
 
 /// One producer's shared cooperative blob. Constructed empty (sized to a
@@ -375,8 +546,10 @@ impl BlobWork {
     /// map (held by the [`BlobProducer`]). New recipients become new groups
     /// (written then published); seen recipients push onto their existing
     /// group's buffer (or, if it has been closed, deposit through
-    /// `route_mail`). Returns the leftover (overflow / retired) and the
-    /// fresh-group count.
+    /// `route_mail`). Returns the leftover (overflow / retired), the
+    /// fresh-group count, and the cost-aware recruit signals (`Σw` /
+    /// `w_max` / confidence) summed over this flush's fresh groups
+    /// (iamacoffeepot/aether#1178).
     fn append_flush(
         &self,
         routed: Vec<Mail>,
@@ -394,6 +567,15 @@ impl BlobWork {
         let cap = self.groups.len();
         let mut staged = 0usize;
         let mut leftover: Vec<Mail> = Vec::new();
+        // iamacoffeepot/aether#1178: one read-lock over the cost table for
+        // the whole flush — every mail's `(recipient, kind)` cost resolves
+        // through this guard, never a `read()` per mail (the rejected
+        // per-mail point lookup). Confidence starts trustworthy and is
+        // cleared by the first unknown-cost cell contributing to a *fresh*
+        // group (this flush's claimable parallelizable work — the recruit
+        // scope, step 5).
+        let costs = self.mailer.cost_table().lookup();
+        let mut cost_confident = true;
         for mail in routed {
             if let Some(&g) = index.get(&mail.recipient) {
                 // Existing group — push in send order; a closed (drained)
@@ -401,6 +583,15 @@ impl BlobWork {
                 // in `index`, so it was written this flush or a prior one by
                 // this producer; the slot is initialized.
                 let group = unsafe { self.groups[g].get() };
+                // Accumulate cost onto the group's running total only when it
+                // is *fresh this flush* (`g >= base`); an append onto a
+                // prior-flush group keeps its own `Group::work` faithful for
+                // diagnostics but does not re-enter this flush's `Σw` scope.
+                if g >= base {
+                    let (cost, confident) = group_mail_cost(&costs, mail.recipient, mail.kind);
+                    group.add_work(cost);
+                    cost_confident &= confident;
+                }
                 if let Err(mail) = group.push(mail) {
                     self.mailer.push(mail);
                 }
@@ -411,20 +602,42 @@ impl BlobWork {
                 leftover.push(mail);
             } else {
                 let recipient = mail.recipient;
+                let (cost, confident) = group_mail_cost(&costs, recipient, mail.kind);
+                cost_confident &= confident;
                 // SAFETY: producer-only; `base + staged` advances
                 // contiguously and is unwritten, and the write is sequenced
                 // before the `publish` below.
-                unsafe { self.groups[base + staged].write(Group::new(recipient, vec![mail])) };
+                unsafe {
+                    self.groups[base + staged].write(Group::new(recipient, vec![mail], cost));
+                }
                 index.insert(recipient, base + staged);
                 staged += 1;
             }
         }
 
         match self.lifecycle.publish(staged) {
-            Published::Ok => FlushOutcome {
-                leftover,
-                fresh_groups: staged,
-            },
+            Published::Ok => {
+                // Sum `Σw` / `w_max` over the freshly-published groups
+                // `[base, base + staged)` — the recruit scope (step 5).
+                let mut total_work = 0u64;
+                let mut max_group_work = 0u64;
+                for j in 0..staged {
+                    // SAFETY: slot `base + j` was just published (`len`
+                    // advanced past it), so it is initialized; `work()` is a
+                    // producer-side relaxed load on the slot we wrote.
+                    let group = unsafe { self.groups[base + j].get() };
+                    let w = group.work();
+                    total_work = total_work.saturating_add(w);
+                    max_group_work = max_group_work.max(w);
+                }
+                FlushOutcome {
+                    leftover,
+                    fresh_groups: staged,
+                    total_work,
+                    max_group_work,
+                    cost_confident,
+                }
+            }
             Published::Retired | Published::Full => {
                 // The blob retired (or hit the wire ceiling) between staging
                 // and publish: the staged groups never became claimable.
@@ -438,9 +651,13 @@ impl BlobWork {
                     index.remove(&group.recipient);
                     leftover.extend(group.into_mails());
                 }
+                // No fresh groups published — no recruit, no cost signal.
                 FlushOutcome {
                     leftover,
                     fresh_groups: 0,
+                    total_work: 0,
+                    max_group_work: 0,
+                    cost_confident: false,
                 }
             }
         }
@@ -609,12 +826,13 @@ impl BlobProducer {
             // Always schedule a drainer so newly-published groups (and any
             // pushes onto still-open groups) are picked up even if every
             // prior worker already drained past the cursor and dropped its
-            // copy. The own-deque schedule keeps a narrow fan-out local
-            // (the #1116 win); a wide fan-out additionally broadcast-
-            // recruits siblings.
+            // copy. The own-deque schedule keeps a cheap fan-out local
+            // (the #1116 win); a heavy / wide fan-out additionally
+            // broadcast-recruits siblings, sized by the cost-aware
+            // recruiter (iamacoffeepot/aether#1178).
             self.sink.schedule(Arc::clone(&blob_dyn));
-            if outcome.fresh_groups >= recruit_min() {
-                let extra = outcome.fresh_groups.min(recruit_cap()).saturating_sub(1);
+            let extra = recruit_extra(&outcome, self.sink.workers());
+            if extra > 0 {
                 self.sink.recruit(&blob_dyn, extra);
             }
 
@@ -641,6 +859,39 @@ impl BlobProducer {
 /// has intra-flush duplicate recipients is harmless headroom.
 fn group_cap_for(routed: &[Mail]) -> usize {
     routed.len().clamp(GROUP_CAP_MIN, MAX_GROUPS)
+}
+
+/// How many *sibling* workers to broadcast-recruit for a flush's outcome —
+/// the value passed to [`WakeSink::recruit`] (`K - 1`, since the producer
+/// drains its own [`WakeSink::schedule`] copy). `w` is the pool worker
+/// count.
+///
+/// When the flush's fresh-group cost is **trustworthy**
+/// (iamacoffeepot/aether#1178), size by [`recruit_k`] — the cost-aware
+/// `Σw / w_max` form — and still bound the injector churn by `recruit_cap`
+/// (over-recruiting past the worker count adds no parallelism). When the
+/// cost is **unknown** (any contributing cell a neutral seed / absent /
+/// high-MAD), fall back to the original **width gate**: recruit only when
+/// the fresh-group count clears `recruit_min`, capped by `recruit_cap`.
+/// Width is the confidence fallback, no longer the primary signal.
+fn recruit_extra(outcome: &FlushOutcome, w: usize) -> usize {
+    if outcome.fresh_groups == 0 {
+        return 0;
+    }
+    if outcome.cost_confident {
+        let k = recruit_k(
+            outcome.total_work,
+            outcome.max_group_work,
+            outcome.fresh_groups,
+            w,
+        );
+        k.min(recruit_cap()).saturating_sub(1)
+    } else if outcome.fresh_groups >= recruit_min() {
+        // Confidence fallback: the unchanged width gate.
+        outcome.fresh_groups.min(recruit_cap()).saturating_sub(1)
+    } else {
+        0
+    }
 }
 
 #[cfg(test)]
@@ -1034,5 +1285,271 @@ mod tests {
     #[test]
     fn flaky_concurrent_pool_drain_delivers_each_recipient_once() {
         concurrent_pool_drain_delivers_each_recipient_once();
+    }
+
+    // iamacoffeepot/aether#1178: the cost-aware recruiter. `recruit_k` is a
+    // pure function over `(total_work, max_group_work, G, W)`; the canonical
+    // cases below use work values well clear of the default
+    // `C_WAKE_NANOS = 4300` so they don't depend on an env override.
+
+    /// Trivial-wide: many tiny groups whose total work is below the wake
+    /// break-even → `K = 1` (stay local, no recruit). This is the cost-aware
+    /// form of the prior narrow-local win — a *cheap* fan-out stays serial
+    /// regardless of width.
+    #[test]
+    fn recruit_k_trivial_wide_stays_local() {
+        // 12 groups × 100ns = 1200ns total, under the 4300ns floor.
+        assert_eq!(recruit_k(1_200, 100, 12, 8), 1);
+        // Even a single tiny group is local.
+        assert_eq!(recruit_k(100, 100, 1, 8), 1);
+    }
+
+    /// Heavy-narrow: a few heavy groups → `K = G` (recruits the full group
+    /// count). This closes the documented width-gate gap — a heavy `<= 8`
+    /// fan-out that the old gate left serial now parallelises.
+    #[test]
+    fn recruit_k_heavy_narrow_recruits_full_width() {
+        // 3 groups × 50_000ns each: total 150_000, w_max 50_000 → round(3) = 3,
+        // clamped to min(G=3, W=8) = 3.
+        assert_eq!(recruit_k(150_000, 50_000, 3, 8), 3);
+        // Two heavy groups, plenty of workers → 2.
+        assert_eq!(recruit_k(100_000, 50_000, 2, 8), 2);
+    }
+
+    /// Balanced-wide: many equal groups → `K = min(G, W)`. Σw / w_max ≈ G,
+    /// clamped by the worker count.
+    #[test]
+    fn recruit_k_balanced_wide_recruits_to_worker_cap() {
+        // 20 equal groups of 10_000ns: round(20) = 20, clamped to W = 8.
+        assert_eq!(recruit_k(200_000, 10_000, 20, 8), 8);
+        // Same balance, fewer groups than workers → clamped to G.
+        assert_eq!(recruit_k(60_000, 10_000, 6, 8), 6);
+    }
+
+    /// Skewed-wide: one fat pole plus many small groups → `K ≈ total /
+    /// longest_pole`, *not* G. The longest pole bounds the achievable
+    /// parallelism: extra workers past `total / w_max` can't beat the fat
+    /// group's serial drain.
+    #[test]
+    fn recruit_k_skewed_wide_sizes_by_longest_pole() {
+        // One 100_000ns pole + 10 × 1_000ns = 110_000 total, w_max 100_000 →
+        // round(1.1) = 1, clamped to [1, min(11, 8)] = 1. The fat pole
+        // dominates: no parallelism helps.
+        assert_eq!(recruit_k(110_000, 100_000, 11, 8), 1);
+        // A milder skew: 100_000 total over a 30_000ns pole → round(3.33) = 3.
+        assert_eq!(recruit_k(100_000, 30_000, 11, 8), 3);
+    }
+
+    /// The wake gate is exact at the boundary: `total_work <= C_WAKE_NANOS`
+    /// is local, one nano over recruits.
+    #[test]
+    fn recruit_k_wake_gate_boundary() {
+        let c = wake_cost_nanos();
+        assert_eq!(recruit_k(c, 10, 5, 8), 1, "exactly at the floor: local");
+        // One nano over the floor with a small pole → recruits.
+        assert!(
+            recruit_k(c + 1, 10, 5, 8) > 1,
+            "just over the floor: recruit"
+        );
+    }
+
+    /// `recruit_k` never exceeds `min(G, W)` and never drops below 1.
+    #[test]
+    fn recruit_k_clamps_to_min_g_w() {
+        // Huge Σw, tiny pole, but only 2 groups → clamped to G = 2.
+        assert_eq!(recruit_k(1_000_000, 1, 2, 8), 2);
+        // Same, but only 1 worker → clamped to W = 1.
+        assert_eq!(recruit_k(1_000_000, 1, 50, 1), 1);
+    }
+
+    /// `trustworthy_mad`: a steady handler (MAD below the mean) is
+    /// trustworthy; a bimodal one (MAD ≈ mean) is not.
+    #[test]
+    fn trustworthy_mad_gates_on_spread() {
+        assert!(trustworthy_mad(10_000, 0), "zero MAD is steady");
+        assert!(
+            trustworthy_mad(10_000, 5_000),
+            "half-mean MAD is trustworthy"
+        );
+        assert!(
+            trustworthy_mad(10_000, 10_000),
+            "MAD == mean is the boundary"
+        );
+        assert!(
+            !trustworthy_mad(10_000, 10_001),
+            "MAD over the mean is bimodal / untrustworthy"
+        );
+        assert!(!trustworthy_mad(0, 1), "a nonzero spread over a zero mean");
+    }
+
+    /// Seed a recipient's `KindId(7)` cost cell to a steady `mean_nanos`
+    /// (folding the same sample repeatedly drives MAD to 0, so the cell is
+    /// trustworthy). Returns nothing — the table is shared via the `Mailer`.
+    fn seed_steady_cost(mailer: &Mailer, recipient: MailboxId, mean_nanos: u64) {
+        let cells = mailer.cost_table().seed(recipient, &[KindId(7)]);
+        for (_, cell) in &cells {
+            for _ in 0..8 {
+                cell.fold(mean_nanos);
+            }
+        }
+    }
+
+    /// `FlushOutcome` carries the hand-summed `Σw` / `w_max` over the fresh
+    /// groups — including two mails to one recipient coalescing into one
+    /// group whose work is the *sum* of both kinds' costs (here the same
+    /// kind twice, so 2× the per-handler cost).
+    #[test]
+    fn flush_outcome_sums_group_work() {
+        let (registry, mailer) = fresh_substrate();
+        let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
+        let (a, _fa, _a_dir, _a_dep) = seizable_recipient(&registry, "a");
+        let (b, _fb, _b_dir, _b_dep) = seizable_recipient(&registry, "b");
+        // a: 10_000ns/handler, two mails → group work 20_000.
+        // b: 5_000ns/handler, one mail → group work 5_000.
+        seed_steady_cost(&mailer, a, 10_000);
+        seed_steady_cost(&mailer, b, 5_000);
+
+        let blob = BlobWork::empty(8, Arc::clone(&mailer), wake_sink(&injector));
+        let mut index = FxHashMap::default();
+        let outcome = blob.append_flush(
+            vec![mail_to(a, 0), mail_to(a, 1), mail_to(b, 2)],
+            &mut index,
+        );
+
+        assert_eq!(outcome.fresh_groups, 2, "two distinct recipients");
+        assert_eq!(outcome.total_work, 25_000, "Σw = a(2×10_000) + b(1×5_000)");
+        assert_eq!(
+            outcome.max_group_work, 20_000,
+            "w_max is a's coalesced group (two mails summed)"
+        );
+        assert!(outcome.cost_confident, "both handlers seeded + steady");
+    }
+
+    /// A blob whose recipient has no EWMA history (a neutral-seed cell, or
+    /// no cell at all) is "unknown cost": `cost_confident` is false, so the
+    /// recruiter falls back to the width gate. Here a wide fan-out of unseen
+    /// recipients clears `recruit_min` and recruits via the *fallback* path,
+    /// not `recruit_k` (which would see Σw = 0 and stay local).
+    #[test]
+    fn unknown_cost_falls_back_to_width_gate() {
+        let (registry, mailer) = fresh_substrate();
+        let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
+        // recruit_min default is 9; build a 12-wide fan-out of unseeded
+        // recipients so the width fallback fires while Σw stays 0.
+        let mut routed = Vec::new();
+        let mut fixtures = Vec::new();
+        for i in 0..12u8 {
+            let (id, fix, _dir, _dep) = seizable_recipient(&registry, &format!("u{i}"));
+            routed.push(mail_to(id, i));
+            fixtures.push(fix);
+        }
+
+        let blob = BlobWork::empty(16, Arc::clone(&mailer), wake_sink(&injector));
+        let mut index = FxHashMap::default();
+        let outcome = blob.append_flush(routed, &mut index);
+
+        assert_eq!(outcome.fresh_groups, 12);
+        assert_eq!(
+            outcome.total_work, 0,
+            "no seeded handlers → no measured work"
+        );
+        assert!(
+            !outcome.cost_confident,
+            "unseeded handlers mark the blob unknown-cost"
+        );
+        // The width fallback recruits (12 >= recruit_min 9): G.min(cap) - 1 =
+        // 11 (the final W cap lives in WakeSink::recruit, as it did pre-#1178).
+        let extra = recruit_extra(&outcome, 8);
+        assert_eq!(extra, 11, "width fallback recruits G.min(recruit_cap) - 1");
+    }
+
+    /// A *narrow* unseeded fan-out (below `recruit_min`) takes the width
+    /// fallback and recruits nobody — the cost-unknown narrow blob behaves
+    /// exactly as the pre-#1178 width gate did.
+    #[test]
+    fn unknown_cost_narrow_stays_local_via_width() {
+        let (registry, mailer) = fresh_substrate();
+        let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
+        let mut routed = Vec::new();
+        let mut fixtures = Vec::new();
+        for i in 0..4u8 {
+            let (id, fix, _dir, _dep) = seizable_recipient(&registry, &format!("n{i}"));
+            routed.push(mail_to(id, i));
+            fixtures.push(fix);
+        }
+
+        let blob = BlobWork::empty(8, Arc::clone(&mailer), wake_sink(&injector));
+        let mut index = FxHashMap::default();
+        let outcome = blob.append_flush(routed, &mut index);
+
+        assert!(!outcome.cost_confident);
+        assert_eq!(
+            recruit_extra(&outcome, 8),
+            0,
+            "narrow unknown-cost fan-out stays local (width fallback, < recruit_min)"
+        );
+    }
+
+    /// A heavy *narrow* fan-out (below `recruit_min`) with trustworthy cost
+    /// recruits its full group count — the headline #1178 win: the old width
+    /// gate left this serial, the cost gate parallelises it without anyone
+    /// touching `AETHER_BLOB_RECRUIT_MIN`.
+    #[test]
+    fn heavy_narrow_recruits_without_width_threshold() {
+        let (registry, mailer) = fresh_substrate();
+        let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
+        let mut routed = Vec::new();
+        let mut fixtures = Vec::new();
+        // 3 recipients (well under recruit_min 9), each a heavy 50_000ns
+        // handler — the documented heavy-narrow case.
+        for i in 0..3u8 {
+            let (id, fix, _dir, _dep) = seizable_recipient(&registry, &format!("h{i}"));
+            seed_steady_cost(&mailer, id, 50_000);
+            routed.push(mail_to(id, i));
+            fixtures.push(fix);
+        }
+
+        let blob = BlobWork::empty(8, Arc::clone(&mailer), wake_sink(&injector));
+        let mut index = FxHashMap::default();
+        let outcome = blob.append_flush(routed, &mut index);
+
+        assert!(outcome.cost_confident, "all three handlers seeded + steady");
+        assert_eq!(outcome.fresh_groups, 3);
+        // Σw = 150_000, w_max = 50_000 → K = 3, extra = 2 — recruited despite
+        // being far below the width threshold.
+        assert_eq!(
+            recruit_extra(&outcome, 8),
+            2,
+            "heavy narrow fan-out recruits K-1 = 2 without the width gate"
+        );
+    }
+
+    /// A *cheap* narrow fan-out with trustworthy cost stays `K = 1` (local) —
+    /// the cost gate subsumes the width threshold for the right reason
+    /// (cheapness), preserving the #1116 narrow-local win.
+    #[test]
+    fn cheap_narrow_stays_local_via_cost() {
+        let (registry, mailer) = fresh_substrate();
+        let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
+        let mut routed = Vec::new();
+        let mut fixtures = Vec::new();
+        for i in 0..3u8 {
+            let (id, fix, _dir, _dep) = seizable_recipient(&registry, &format!("c{i}"));
+            // 200ns handlers → Σw = 600ns, under the 4300ns wake floor.
+            seed_steady_cost(&mailer, id, 200);
+            routed.push(mail_to(id, i));
+            fixtures.push(fix);
+        }
+
+        let blob = BlobWork::empty(8, Arc::clone(&mailer), wake_sink(&injector));
+        let mut index = FxHashMap::default();
+        let outcome = blob.append_flush(routed, &mut index);
+
+        assert!(outcome.cost_confident);
+        assert_eq!(
+            recruit_extra(&outcome, 8),
+            0,
+            "cheap fan-out stays local (Σw below the wake floor)"
+        );
     }
 }

--- a/crates/aether-substrate/src/mail/cost.rs
+++ b/crates/aether-substrate/src/mail/cost.rs
@@ -25,12 +25,28 @@
 #![allow(clippy::significant_drop_tightening)]
 
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, RwLock, RwLockReadGuard};
 
 use aether_actor::cost::CostCell;
 use aether_kinds::{CostRow, CostTail, CostTailResult};
 
 use crate::mail::{KindId, MailboxId};
+
+/// A single handler's measured cost, resolved from a [`CostCell`] under
+/// one read-lock. Carries the EWMA mean plus the two confidence signals
+/// the iamacoffeepot/aether#1178 recruiter gates on (`samples == 0` ⇒
+/// neutral seed; a high `mad_nanos` ⇒ bimodal / untrustworthy), so the
+/// caller never re-touches the cell after the batch read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CostSample {
+    /// EWMA mean execution time (nanos). `0` before the first fold.
+    pub mean_nanos: u64,
+    /// Folded-sample count. `0` is the neutral seed — known handler,
+    /// never run, so the mean is meaningless to the recruiter.
+    pub samples: u64,
+    /// EWMA mean-absolute-deviation (nanos) — the spread signal.
+    pub mad_nanos: u64,
+}
 
 /// Substrate-owned global index over every actor's per-handler
 /// [`CostCell`]s. Shared as part of the [`Mailer`](super::mailer::Mailer)
@@ -111,6 +127,27 @@ impl CostTable {
             .collect()
     }
 
+    /// Acquire one read-lock over the table and hand back a
+    /// [`CostLookup`] that resolves `(MailboxId, KindId)` point lookups
+    /// for the duration of a single flush — iamacoffeepot/aether#1178's
+    /// read side of iamacoffeepot/aether#1128's table. The recruiter
+    /// holds the returned guard across its whole group accumulation pass
+    /// so each mail's cost resolves under the *same* lock acquire, rather
+    /// than a `read()` per mail on the hot flush path (the rejected
+    /// per-mail point lookup). The lock is a low-contention `RwLock`
+    /// (writers are the rare seed / drop hooks), so holding the read-lock
+    /// for one producer's flush adds no measurable contention — the same
+    /// guard policy [`Self::tail`] uses.
+    ///
+    /// # Panics
+    /// Panics if the internal lock is poisoned (see [`Self::seed`]).
+    #[must_use]
+    pub fn lookup(&self) -> CostLookup<'_> {
+        CostLookup {
+            cells: self.cells.read().expect("cost table lock poisoned"),
+        }
+    }
+
     /// Dump `mailbox`'s cost rows, filtered to `request.kind` when set.
     /// `kind_name` is left `None` here — the table holds ids, not names;
     /// the `cost.tail` dispatch arm (or the MCP layer) resolves names
@@ -135,6 +172,33 @@ impl CostTable {
             })
             .collect();
         CostTailResult::Ok { rows }
+    }
+}
+
+/// A read-lock held over a [`CostTable`] for the span of one flush, plus
+/// the point-lookup the recruiter resolves each mail's cost through.
+/// Acquired once via [`CostTable::lookup`] and dropped when the flush's
+/// group accumulation finishes — so the whole `Σw` / `w_max` pass runs
+/// under a single read acquire, not one per mail.
+#[derive(Debug)]
+pub struct CostLookup<'a> {
+    cells: RwLockReadGuard<'a, HashMap<(MailboxId, KindId), Arc<CostCell>>>,
+}
+
+impl CostLookup<'_> {
+    /// Resolve the measured cost of one `(mailbox, kind)` handler, or
+    /// `None` for a `(mailbox, kind)` the table has never seeded (the
+    /// handler is absent — distinct from a *seeded-but-unrun* cell, which
+    /// resolves to `Some` with `samples == 0`). The caller treats `None`
+    /// and `samples == 0` alike — both are "unknown cost" — but the
+    /// distinction is preserved for the dump / future callers.
+    #[must_use]
+    pub fn get(&self, mailbox: MailboxId, kind: KindId) -> Option<CostSample> {
+        self.cells.get(&(mailbox, kind)).map(|cell| CostSample {
+            mean_nanos: cell.mean_nanos(),
+            samples: cell.samples(),
+            mad_nanos: cell.mad_nanos(),
+        })
     }
 }
 
@@ -240,5 +304,57 @@ mod tests {
         assert_eq!(cells.len(), 2);
         assert!(cells.iter().any(|(k, _)| *k == KindId(10)));
         assert!(cells.iter().any(|(k, _)| *k == KindId(20)));
+    }
+
+    /// The batch [`CostTable::lookup`] resolves a seeded handler's folded
+    /// mean under one read-lock; an unseeded `(mailbox, kind)` resolves to
+    /// `None` and a seeded-but-unrun cell resolves to `Some` with
+    /// `samples == 0` (the neutral-seed distinction the recruiter gates on).
+    #[test]
+    fn batch_lookup_resolves_means_and_misses() {
+        let table = CostTable::new();
+        let mbx = MailboxId(7);
+        let handed = table.seed(mbx, &[KindId(10), KindId(20)]);
+        // Fold a sample into kind 10 only; kind 20 stays a neutral seed.
+        for (kind, cell) in &handed {
+            if *kind == KindId(10) {
+                cell.fold(3_000);
+            }
+        }
+
+        let lookup = table.lookup();
+        let ten = lookup.get(mbx, KindId(10)).expect("kind 10 seeded");
+        assert_eq!(ten.mean_nanos, 3_000);
+        assert_eq!(ten.samples, 1);
+
+        let twenty = lookup.get(mbx, KindId(20)).expect("kind 20 seeded");
+        assert_eq!(twenty.mean_nanos, 0, "neutral seed has no mean");
+        assert_eq!(twenty.samples, 0, "neutral seed reports zero samples");
+
+        assert!(
+            lookup.get(mbx, KindId(30)).is_none(),
+            "an unseeded handler resolves to None"
+        );
+        assert!(
+            lookup.get(MailboxId(8), KindId(10)).is_none(),
+            "a different mailbox's same kind id misses"
+        );
+    }
+
+    /// Two mails routed to the *same* handler resolve the same cost under
+    /// one batch read — the per-mail point lookup the recruiter sums into a
+    /// group's `Σw`, without a lock acquire per mail.
+    #[test]
+    fn batch_lookup_repeats_under_one_lock() {
+        let table = CostTable::new();
+        let mbx = MailboxId(7);
+        let handed = table.seed(mbx, &[KindId(10)]);
+        handed[0].1.fold(5_000);
+
+        let lookup = table.lookup();
+        let first = lookup.get(mbx, KindId(10)).expect("seeded");
+        let second = lookup.get(mbx, KindId(10)).expect("seeded");
+        assert_eq!(first, second);
+        assert_eq!(first.mean_nanos, 5_000);
     }
 }

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -413,6 +413,16 @@ impl WakeSink {
         }
     }
 
+    /// The pool's worker count `W` — the recruiter's `min(G, W)` clamp
+    /// (iamacoffeepot/aether#1178). [`Self::recruit`] independently caps
+    /// the injected clone count at `workers - 1` (the producer drains its
+    /// own copy), but the cost-aware sizing needs `W` up front to bound
+    /// `recruit_k` before subtracting the producer's own share.
+    #[must_use]
+    pub(crate) fn workers(&self) -> usize {
+        self.workers
+    }
+
     /// Recruit `count` workers to a shared cooperative blob
     /// (iamacoffeepot/aether#1137): push `count` clones of the same
     /// `Drainable` onto the shared injector, then wake up to `count` parked


### PR DESCRIPTION
Closes iamacoffeepot/aether#1178

Replaces the blob scheduler's static **width** recruit gate with a measure-driven **cost-aware** one (the deterministic rung of iamacoffeepot/aether#1127, spike-validated `K ≈ Σw / w_max`).

- **Cost-aware sizing.** At flush, sum iamacoffeepot/aether#1128's per-handler execution-cost EWMA over the flush's fresh recipient groups and size recruitment by `recruit_k(total_work, max_group_work, G, W) = clamp(round(Σw / w_max), 1, min(G, W))` gated by `total_work > C_WAKE_NANOS` (~4300ns, `AETHER_WAKE_COST_NANOS` override), instead of the fresh-group count. A heavy narrow fan-out now recruits its full group count without anyone setting `AETHER_BLOB_RECRUIT_MIN`; a cheap narrow blob yields `K = 1` and stays local (the iamacoffeepot/aether#1116 win, for the right reason — cheapness, not narrowness).
- **One read-lock per flush.** `CostTable::lookup` hands back a `CostLookup` guard taking a single `RwLock` read-lock; every mail's `(MailboxId, KindId)` cost resolves through it — not a lock acquire per mail. A new `work: u64` (`AtomicU64`, `saturating_add`) on `Group` accumulates `Σ cost(recipient, kᵢ)` so two mails to one recipient sum into one group's `w_max` term.
- **Confidence fallback.** A contributing cell that is a neutral seed (`samples == 0`), absent, or high-MAD (bimodal) marks the blob unknown-cost; the recruiter then falls back to the unchanged width gate for that blob rather than recruiting on a bad number.

**Aggregation scope (step 5).** `total_work` / `max_group_work` are summed over **this flush's fresh groups** — matching the existing per-flush `fresh_groups` width gate. Numerator and denominator share the same scope, the recruit broadcast still fires once per flush, and a leftover-roll flush (0 fresh groups) recruits nobody. A worker still races the cursor over all published groups; each flush's recruit just sizes the newly-published parallelizable work it is waking siblings for. Noted in the module doc + `FlushOutcome` field docs.

**Perf gate.** No wire/kind/trait/lifecycle change — a scheduler-policy refinement under ADR-0087. The full `scripts/preflight.sh` (fmt + clippy `--workspace --all-targets -D warnings` + doc + `cargo nextest run --workspace --profile ci` + wasm32 cross-build) is green: 1359 tests pass, including the existing concurrent-pool blob drain and 16 new unit tests (`recruit_k` canonical cases, `FlushOutcome` Σw/w_max accumulation with a coalesced two-mail group, and the confidence-fallback paths). Behaviour is argued structurally + via the unit/harness counters per the latency-sweep finding (wall-clock A/B cannot resolve the delta).
