### PR TITLE
refactor(substrate): remove the singlethreaded (Dedicated) actor dispatch opt-in (issue 1187)

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -961,7 +961,7 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
 
     // Collect everything we need from the inner actor impl into owned
     // values so the borrow on `items` ends before we mutate it below.
-    let (self_ty, type_ident, generics, namespace_expr, scheduling_expr, handler_kinds, catch_all) = {
+    let (self_ty, type_ident, generics, namespace_expr, handler_kinds, catch_all) = {
         let Item::Impl(actor_impl) = &items[actor_idx] else {
             unreachable!("actor_idx points to an Item::Impl by construction");
         };
@@ -1014,7 +1014,6 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
         let mut handler_kinds: Vec<Type> = Vec::new();
         let mut has_fallback = false;
         let mut namespace_expr: Option<Expr> = None;
-        let mut scheduling_expr: Option<Expr> = None;
         for impl_item in &actor_impl.items {
             match impl_item {
                 ImplItem::Fn(f) if f.attrs.iter().any(attr_is_handler) => {
@@ -1028,7 +1027,18 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
                     if c.ident == "NAMESPACE" {
                         namespace_expr = Some(c.expr.clone());
                     } else if c.ident == "SCHEDULING" {
-                        scheduling_expr = Some(c.expr.clone());
+                        // Issue 1187: dispatch placement is no longer
+                        // authorable — the scheduling enum + trait const
+                        // were removed. Reject a leftover const with a
+                        // pointed diagnostic rather than letting it fall
+                        // through to a surfaceless-trait error.
+                        return Err(syn::Error::new_spanned(
+                            c,
+                            "`SCHEDULING` was removed (issue 1187): every actor drains on the \
+                             chassis worker pool. Drop the const — never block a handler; \
+                             offload blocking work to a `ctx.spawn`'d thread that feeds results \
+                             back as mail.",
+                        ));
                     }
                 }
                 _ => {}
@@ -1064,7 +1074,6 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
             type_ident,
             actor_impl.generics.clone(),
             namespace_expr,
-            scheduling_expr,
             handler_kinds,
             has_fallback,
         )
@@ -1085,21 +1094,6 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
     //   (chassis builders, tests in sibling mods) keep working.
     // - Singleton, Actor, and HandlesKind impls are always-on so wasm
     //   consumers compile typed sends without the substrate runtime.
-    // Self-contained emission: the bridge lifts the user's expression
-    // from inside `mod native` (where `Scheduling` is in scope via an
-    // inner-mod import) to a sibling `impl Actor` at file root (where
-    // it isn't). Wrap the expression in a block with a local `use` so
-    // the lifted expression resolves regardless of the file-root
-    // import surface — the user keeps typing `Scheduling::Dedicated`
-    // ergonomically without having to remember a second file-root use.
-    let scheduling_const = scheduling_expr.map(|expr| {
-        quote! {
-            const SCHEDULING: ::aether_actor::Scheduling = {
-                use ::aether_actor::Scheduling;
-                #expr
-            };
-        }
-    });
     // When the bridge declares `feature = "X"`, the wasm stub also
     // covers "native target without the feature" so consumers that
     // build with `default-features = false` keep a reachable type for
@@ -1132,7 +1126,6 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
     let actor_marker = quote! {
         impl #impl_generics ::aether_actor::Actor for #self_ty #where_clause {
             const NAMESPACE: &'static str = #namespace_expr;
-            #scheduling_const
         }
     };
     // The cardinality marker (issue 625 / ADR-0079) plus its ADR-0088
@@ -1884,30 +1877,24 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
     // rewrites this `#[actor]` to `#[actor(skip_markers)]` so this
     // expansion does not duplicate them. The native-only impls below
     // still emit unchanged.
-    // Wrap the `SCHEDULING` const value in a self-contained block with
-    // a local `use ::aether_actor::Scheduling`. Symmetric with the
-    // bridge path: the user types `Scheduling::Dedicated` ergonomically
-    // without needing a file-level `use aether_actor::Scheduling`
-    // import. NAMESPACE / FRAME_BARRIER pass through unchanged because
-    // their RHSes are primitives that don't require resolution.
-    let const_tokens: Vec<TokenStream2> = consts
-        .iter()
-        .map(|c| {
-            if c.ident == "SCHEDULING" {
-                let expr = &c.expr;
-                let attrs = &c.attrs;
-                quote! {
-                    #(#attrs)*
-                    const SCHEDULING: ::aether_actor::Scheduling = {
-                        use ::aether_actor::Scheduling;
-                        #expr
-                    };
-                }
-            } else {
-                quote! { #c }
-            }
-        })
-        .collect();
+    //
+    // Dispatch placement is no longer authorable (issue 1187): the
+    // scheduling enum + trait const were removed — every actor drains on
+    // the chassis worker pool. Reject a leftover `SCHEDULING` const with
+    // a pointed diagnostic instead of letting it pass through to a
+    // "no associated const SCHEDULING" error against the surfaceless
+    // `Actor` trait.
+    if let Some(c) = consts.iter().find(|c| c.ident == "SCHEDULING") {
+        return Err(syn::Error::new_spanned(
+            c,
+            "`SCHEDULING` was removed (issue 1187): every actor drains on the chassis \
+             worker pool. Drop the const — never block a handler; offload blocking work \
+             to a `ctx.spawn`'d thread that feeds results back as mail.",
+        ));
+    }
+    // NAMESPACE / FRAME_BARRIER pass through unchanged because their
+    // RHSes are primitives that don't require resolution.
+    let const_tokens: Vec<TokenStream2> = consts.iter().map(|c| quote! { #c }).collect();
     let actor_impl = if opts.skip_markers || consts.is_empty() {
         quote! {}
     } else {

--- a/crates/aether-actor/src/actor/mod.rs
+++ b/crates/aether-actor/src/actor/mod.rs
@@ -27,49 +27,26 @@ pub mod slot;
 
 use aether_data::Kind;
 
-/// The symmetric trait every actor implements: name + scheduling class.
-/// Lifecycle methods (`boot` for native chassis caps, `init` for wasm
-/// components) live on per-transport subtraits; this trait stays
-/// ctx-free so the same shape applies to both sides.
+/// The symmetric trait every actor implements: the recipient name it
+/// claims. Lifecycle methods (`boot` for native chassis caps, `init`
+/// for wasm components) live on per-transport subtraits; this trait
+/// stays ctx-free so the same shape applies to both sides.
+///
+/// Dispatch invariant: every actor drains cooperatively on the chassis
+/// worker pool. A handler must never block the dispatcher — offload
+/// blocking work (a `wait_reply`-shaped request/reply, sync disk I/O, a
+/// runloop on a non-mail external source like TCP `accept` or a
+/// file-watch source) to a `ctx.spawn`'d thread that blocks off-pool
+/// and feeds its results back as mail. A request/reply-shaped need is
+/// served by an FSM that carries state across handler invocations
+/// (send → return → handle the reply) rather than by parking a pool
+/// worker in-handler.
 pub trait Actor: Sized + Send + 'static {
     /// The recipient name this actor claims. For native capabilities
     /// it's the chassis-owned mailbox name (`aether.<name>`); for wasm
     /// components it's the default name `load_component` registers
     /// under when the load payload omits an explicit override.
     const NAMESPACE: &'static str;
-
-    /// Issue 635 dispatch placement. `Pooled` (the default) registers
-    /// a dispatcher slot with the chassis worker pool so many actors
-    /// share a small thread set. `Dedicated` is the opt-in escape
-    /// hatch: it keeps the actor on its own OS thread for actors
-    /// whose handlers can park the dispatcher (today: `wait_reply`,
-    /// `ureq.fetch`, sync disk I/O, blocking external sources the
-    /// chassis can't reify as mail — see `Scheduling::Dedicated`).
-    ///
-    /// Phase 3 flipped this default from `Dedicated` (Phase 1's
-    /// behavior-preserving choice) to `Pooled` after the entire cap
-    /// set was audited. Today only `ProcessCapability` (which uses
-    /// `tokio::Runtime::block_on` to coordinate child-process
-    /// lifecycle) opts back into `Dedicated`.
-    ///
-    const SCHEDULING: Scheduling = Scheduling::Pooled;
-}
-
-/// Issue 635 dispatch placement (see [`Actor::SCHEDULING`]). Equality
-/// is structural — the runtime does `match A::SCHEDULING { Pooled => …,
-/// Dedicated => … }` once at boot.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Scheduling {
-    /// Drain the actor's inbox cooperatively on the chassis worker
-    /// pool. Default. Suitable for actors whose handlers return
-    /// promptly — drain a mail, push state, return.
-    Pooled,
-    /// Drain the actor on its own OS thread. Required for actors that
-    /// call `wait_reply` from a handler or own a runloop blocking on a
-    /// non-mail external source the chassis can't reify (TCP `accept`,
-    /// file-watch event sources). Until the ladder of caps converts
-    /// to the pool path, every shipped actor is `Dedicated`.
-    Dedicated,
 }
 
 /// Cardinality marker: only one instance of this actor can be live per

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -134,9 +134,9 @@ impl From<String> for BootError {
 /// from `#[actor]`.
 ///
 /// Issue 525 Phase 4 split the trait surface: the [`crate::Actor`]
-/// super-trait owns the symmetric bits (`NAMESPACE`, `SCHEDULING`)
-/// shared with the substrate-side `NativeActor`; `FfiActor` adds the
-/// FFI lifecycle methods (`init`, `wire`, `unwire`). Hot-swap hooks
+/// super-trait owns the symmetric `NAMESPACE` shared with the
+/// substrate-side `NativeActor`; `FfiActor` adds the FFI lifecycle
+/// methods (`init`, `wire`, `unwire`). Hot-swap hooks
 /// (`on_replace`, `on_rehydrate`) moved to the opt-in [`Replaceable`]
 /// sub-trait. (Issue 584 Phase 3 retired `on_drop` — `unwire` now
 /// covers the pre-shutdown mail-allowed cleanup role.)

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -69,8 +69,8 @@ pub use actor::ctx::{LifecycleControl, MailSender, OutboundReply, Persistence, R
 pub use actor::sender::{MailCtx, Sender};
 pub use actor::slot::Slot;
 pub use actor::{
-    Actor, HandlesKind, Instanced, NAMESPACE_SEGMENT_MAX_LEN, NamespaceError, Scheduling,
-    Singleton, validate_namespace_segment,
+    Actor, HandlesKind, Instanced, NAMESPACE_SEGMENT_MAX_LEN, NamespaceError, Singleton,
+    validate_namespace_segment,
 };
 pub use local::Local;
 // Issue 665: `Mailbox<K, T>` and `ActorMailbox<'_, R, T>` retired; the

--- a/crates/aether-capabilities/src/trace.rs
+++ b/crates/aether-capabilities/src/trace.rs
@@ -235,8 +235,9 @@ mod native {
             // 2b: the handler buffers its forwarded envelopes into the
             // actor's send-side ring; they route on handler-end flush.
             // Driving the handler directly (no dispatch loop), we drop the
-            // ctx to trigger that flush — mirroring `dispatch_loop_run`
-            // dropping its per-envelope ctx — before inspecting the sink.
+            // ctx to trigger that flush — mirroring the per-envelope ctx
+            // drop in `DispatcherSlot::dispatch_one` — before inspecting
+            // the sink.
             drop(ctx);
 
             let snapshot = captured

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -835,7 +835,6 @@ mod tests {
 
     impl Actor for StubActor {
         const NAMESPACE: &'static str = "test.stub";
-        const SCHEDULING: aether_actor::Scheduling = aether_actor::Scheduling::Dedicated;
     }
 
     impl Singleton for StubActor {}

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -1,65 +1,42 @@
-//! Shared dispatcher loop for native actors (issue 672).
+//! Shared dispatch helpers for the pooled `DispatcherSlot` path
+//! (issue 672; per-thread `Dedicated` dispatch removed in issue 1187).
 //!
-//! `dispatch_loop_run<A>` is the body every native-actor dispatcher
-//! thread runs. Singleton boots through `chassis::builder` and
-//! instanced spawns through `actor::native::spawn` both call into
-//! this — eliminating the historical divergence where instanced
-//! actors lacked the `local::with_stamped` wrapping the singleton
-//! path had.
+//! Every native actor — singleton chassis cap or instanced spawn —
+//! drains cooperatively on the chassis worker pool via
+//! [`crate::actor::native::dispatcher_slot::DispatcherSlot::run_cycle`].
+//! That loop owns the lifecycle (recv → per-envelope `local::with_stamped`
+//! dispatch → drain-on-shutdown → `unwire` → registry close + monitor
+//! fan-out); this module holds the per-envelope helpers it calls:
 //!
-//! ## Lifecycle
-//!
-//! 1. **Outer loop.** Polls `binding.should_shutdown()` (set by
-//!    `NativeCtx::shutdown`), then `binding.recv_blocking()`. Either
-//!    signal exits the loop.
-//! 2. **Per-envelope dispatch.** Each envelope runs inside
-//!    `local::with_stamped(slots, ...)` so the per-actor `ActorSlots`
-//!    are visible to `Local<T>` lookups — including the per-actor
-//!    [`ActorLogRing`] the `ActorAwareLayer` pushes into and the
-//!    framework-built-in `aether.log.tail` handler reads from
-//!    (ADR-0081 §1). Before the user dispatch runs, the framework
-//!    intercepts `aether.log.tail` envelopes and replies from the
-//!    actor's ring directly. Two-step typed → fallback dispatch
-//!    follows for everything else.
-//! 3. **Drain after shutdown.** Any envelope already in the inbox
-//!    when the shutdown signal fired is processed synchronously
-//!    before `unwire` runs (matches the existing singleton
-//!    semantics).
-//! 4. **`unwire`.** Last-chance hook with `ReplyTo::NONE`. Wrapped
-//!    in the same `with_stamped` so any final tracing or `Local<T>`
-//!    access works.
-//! 5. **Registry close + monitor fan-out.** `actor_registry.close_actor(id)`
-//!    drains `monitors_of[id]`, prunes `monitoring[id]` from each
-//!    target, marks the slot Dead. Returned watchers receive a
-//!    `MonitorNotice` mail through the supplied `Mailer`.
-
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+//! - [`typed_then_fallback_or_warn`] — typed `#[handler]` → `#[fallback]`
+//!   → warn-on-miss, the user-dispatch step.
+//! - [`dispatch_log_tail_if_matching`] / [`dispatch_trace_tail_if_matching`]
+//!   / [`dispatch_cost_tail_if_matching`] — the framework-built-in arms
+//!   for `aether.{log,trace,cost}.tail`, which read the receiving
+//!   actor's stamped per-actor rings / cost table and reply inline
+//!   before the user dispatch runs (ADR-0081 §1 / ADR-0086 Phase 3 /
+//!   iamacoffeepot/aether#1128).
+//! - [`fold_handler_cost`] — folds one handler-execution sample into
+//!   the per-handler EWMA (iamacoffeepot/aether#1128, measure-only).
 
 use aether_actor::Local;
 use aether_actor::MailCtx;
 use aether_actor::cost::CostCells;
-use aether_actor::local::ActorSlots;
 use aether_actor::log::ActorLogRing;
 use aether_actor::trace_ring::ActorTraceRing;
 use aether_data::Kind;
-use aether_kinds::trace::{Nanos, TraceEvent, TraceTail, TraceTailResult};
+use aether_kinds::trace::{Nanos, TraceTail, TraceTailResult};
 use aether_kinds::{CostTail, CostTailResult, LogTail, LogTailResult};
 
 use crate::actor::native::binding::NativeBinding;
 use crate::actor::native::ctx::NativeCtx;
 use crate::actor::native::envelope::Envelope;
 use crate::actor::native::{NativeActor, NativeDispatch};
-use crate::actor::registry::ActorRegistry;
-use crate::mail::mailer::Mailer;
-use crate::mail::{KindId, Mail, MailId, MailboxId, ReplyTo};
-use crate::runtime::thread_name;
-use aether_actor::local;
+use crate::mail::KindId;
 
 /// Try the typed `#[handler]` dispatch; if no typed arm matches and
 /// the actor's `#[fallback]` also returns `false`, warn that the kind
-/// fell through. Shared by `dispatch_loop_run`'s main loop and
-/// `DispatcherSlot::run_cycle`'s pool path.
+/// fell through. Called from `DispatcherSlot::run_cycle`'s pool path.
 ///
 /// Issue 576 framing: catch-all caps that own a `#[fallback]` return
 /// `true` after their fallback runs, which suppresses the warn.
@@ -204,183 +181,6 @@ pub fn fold_handler_cost(kind: KindId, t_received: Nanos, finished: Nanos) {
     });
 }
 
-/// Run one actor's dispatcher loop on the calling thread. Returns
-/// when the binding signals shutdown (self-shutdown flag set or
-/// inbox sender disconnected). See module doc-comment for the full
-/// lifecycle.
-///
-/// `pending` is decremented after every dispatched envelope when
-/// `Some`. Singletons now always pass `None` — ADR-0082 retired the
-/// frame-bound drain barrier that was the singleton consumer.
-/// Instanced actors pass their per-actor counter, which
-/// `Spawner::shutdown_instanced` reads to coordinate teardown (issue
-/// 685).
-pub fn dispatch_loop_run<A>(
-    binding: &Arc<NativeBinding>,
-    actor: &mut Box<A>,
-    slots: &ActorSlots,
-    pending: Option<&Arc<AtomicU64>>,
-    actor_registry: &Arc<ActorRegistry>,
-    mailer: &Arc<Mailer>,
-    self_id: MailboxId,
-) where
-    A: NativeActor + NativeDispatch,
-{
-    // Phase 1: main dispatch loop.
-    loop {
-        if binding.should_shutdown() {
-            break;
-        }
-        let Some(env) = binding.recv_blocking() else {
-            break;
-        };
-        let inbound_mail_id = env.mail_id;
-        // Issue 734 / ADR-0088 §7: stamp the dispatching thread's
-        // name-hashed `ThreadId` (cached per thread, zero per-hop alloc).
-        let thread_id = thread_name::current_thread_id();
-        local::with_stamped(slots, || {
-            // ADR-0086 Phase 3: `Received` / `Finished` land in this
-            // (recipient) actor's trace ring — only inside this
-            // `with_stamped` is its `ActorSlots` stamped.
-            let th = binding.mailer().trace_handle();
-            // iamacoffeepot/aether#1128: capture the `Received` instant
-            // so the cost fold below reuses the existing trace bracket —
-            // no new timestamp on the hot path.
-            let t_received = th.now_nanos();
-            th.push_trace_ring(
-                env.root,
-                TraceEvent::Received {
-                    mail_id: inbound_mail_id,
-                    t: t_received,
-                    // iamacoffeepot/aether#1134: the producer-stamped
-                    // deposit instant + scheduler backlog, splitting the
-                    // hop into send→enqueue + queue residence.
-                    t_enqueue: env.t_enqueue,
-                    enqueue_depth: env.enqueue_depth,
-                    thread_id,
-                },
-            );
-            let mut ctx = NativeCtx::new(binding, env.sender, env.mail_id, env.root);
-            // ADR-0081 / ADR-0086 / iamacoffeepot/aether#1128: the
-            // framework intercepts `aether.log.tail`,
-            // `aether.trace.tail`, and `aether.cost.tail` before the
-            // actor's typed/fallback dispatch. The actor never sees
-            // these; the framework reads its rings / cost table and
-            // replies inline.
-            if !dispatch_log_tail_if_matching(&mut ctx, &env)
-                && !dispatch_trace_tail_if_matching(&mut ctx, &env)
-                && !dispatch_cost_tail_if_matching(binding, &mut ctx, &env)
-            {
-                typed_then_fallback_or_warn::<A>(actor, &mut ctx, &env);
-            }
-            // iamacoffeepot/aether#1150: drop `ctx` now to flush the
-            // handler's buffered sends (stamping each child `Sent` at
-            // flush-begin) before `Finished`, so a child's `t_sent`
-            // precedes its parent's `t_finished` — the causal order the
-            // trace walk expects. Otherwise the flush rides `ctx`'s
-            // scope-end `Drop`, landing after this push.
-            drop(ctx);
-            let t_finished = th.now_nanos();
-            th.push_trace_ring(
-                env.root,
-                TraceEvent::Finished {
-                    mail_id: inbound_mail_id,
-                    t: t_finished,
-                },
-            );
-            // iamacoffeepot/aether#1128: fold this handler's execution
-            // time `(t_finished − t_received)` into its per-handler EWMA.
-            // Lock-free through the per-actor `CostCells` cache; a
-            // framework arm / fallback kind (not in the cache) is
-            // skipped. Measure-only — no scheduling change.
-            fold_handler_cost(env.kind, t_received, t_finished);
-        });
-        // ADR-0080 §2 settlement hook, outside `with_stamped` so the
-        // `fire_settled` notification runs unstamped (it may resolve mail
-        // subscribers inline).
-        binding.mailer().record_finished(inbound_mail_id, env.root);
-        if let Some(p) = pending {
-            p.fetch_sub(1, Ordering::AcqRel);
-        }
-    }
-
-    // Phase 2: drain remaining inbox synchronously. The shutdown
-    // flag / disconnect raced against any in-flight mail the sink
-    // handler already pushed; the actor sees it before `unwire`
-    // runs so a "please close" handler that flushes state observes
-    // the full inbox.
-    while let Some(env) = binding.try_recv() {
-        let inbound_mail_id = env.mail_id;
-        let thread_id = thread_name::current_thread_id();
-        local::with_stamped(slots, || {
-            let th = binding.mailer().trace_handle();
-            let t_received = th.now_nanos();
-            th.push_trace_ring(
-                env.root,
-                TraceEvent::Received {
-                    mail_id: inbound_mail_id,
-                    t: t_received,
-                    // iamacoffeepot/aether#1134: the producer-stamped
-                    // deposit instant + scheduler backlog, splitting the
-                    // hop into send→enqueue + queue residence.
-                    t_enqueue: env.t_enqueue,
-                    enqueue_depth: env.enqueue_depth,
-                    thread_id,
-                },
-            );
-            let mut ctx = NativeCtx::new(binding, env.sender, env.mail_id, env.root);
-            if !dispatch_log_tail_if_matching(&mut ctx, &env)
-                && !dispatch_trace_tail_if_matching(&mut ctx, &env)
-                && !dispatch_cost_tail_if_matching(binding, &mut ctx, &env)
-            {
-                let _ = actor.__aether_dispatch_envelope(&mut ctx, env.kind, env.payload.bytes());
-            }
-            // iamacoffeepot/aether#1150: flush before `Finished` so a
-            // child `Sent` (stamped at flush-begin on `ctx` drop) precedes
-            // its parent's `Finished`. See the main-loop arm above.
-            drop(ctx);
-            let t_finished = th.now_nanos();
-            th.push_trace_ring(
-                env.root,
-                TraceEvent::Finished {
-                    mail_id: inbound_mail_id,
-                    t: t_finished,
-                },
-            );
-            // iamacoffeepot/aether#1128: fold execution cost (see the
-            // main-loop arm above).
-            fold_handler_cost(env.kind, t_received, t_finished);
-        });
-        binding.mailer().record_finished(inbound_mail_id, env.root);
-        if let Some(p) = pending {
-            p.fetch_sub(1, Ordering::AcqRel);
-        }
-    }
-
-    // Phase 3: last-chance close hook. ReplyTo is None — no inbound
-    // envelope produced this call.
-    local::with_stamped(slots, || {
-        let mut close_ctx = NativeCtx::new(binding, ReplyTo::NONE, MailId::NONE, MailId::NONE);
-        actor.unwire(&mut close_ctx);
-    });
-
-    // Phase 4: close in the registry — drains `monitors_of[id]` for
-    // fan-out, prunes `monitoring[id]` from each watched target,
-    // marks Dead + tombstones the id. Singletons today don't sit in
-    // `actors` as `Live`, so the slot transition is purely sentinel;
-    // the reverse-prune is the load-bearing step. Instanced actors
-    // do sit Live and transition Live → Dead here.
-    let watchers = actor_registry.close_actor(self_id);
-    if !watchers.is_empty() {
-        let notice = aether_kinds::MonitorNotice { target: self_id };
-        let payload = <aether_kinds::MonitorNotice as Kind>::encode_into_bytes(&notice);
-        let kind = KindId(<aether_kinds::MonitorNotice as Kind>::ID.0);
-        for watcher in watchers {
-            mailer.push(Mail::new(watcher, kind, payload.clone(), 1));
-        }
-    }
-}
-
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,
@@ -388,6 +188,7 @@ pub fn dispatch_loop_run<A>(
 )]
 mod cost_tests {
     use super::*;
+    use crate::mail::MailboxId;
     use crate::test_util::fresh_substrate;
     use aether_actor::local::{ActorSlots, with_stamped};
     use aether_kinds::{CostTail, CostTailResult};

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -1,24 +1,21 @@
 //! [`DispatcherSlot<A>`] — the [`Drainable`] adapter that wraps a
 //! native actor for chassis worker-pool dispatch (issue 635 PR C).
 //!
-//! ## Relationship to `dispatch_loop_run`
+//! ## The dispatch cycle
 //!
-//! [`crate::actor::native::dispatch::dispatch_loop_run`] is the loop a
-//! `Dedicated` actor runs on its own thread. It owns the actor, blocks
-//! on `recv_blocking`, and runs the four-phase lifecycle
-//! (main loop → drain after shutdown → unwire → registry close).
-//!
-//! `DispatcherSlot::run_cycle` is the *budget-bounded* version of the
-//! same logic for the `Pooled` path. Each call to `run_cycle` does:
+//! `DispatcherSlot::run_cycle` is the *budget-bounded* dispatch body the
+//! chassis worker pool runs against this slot. Each call to `run_cycle`
+//! does:
 //!
 //! 1. CAS `Ready → Running` on the [`SlotState`] (caller invariant:
 //!    the slot was just popped from the ready queue).
 //! 2. Drains envelopes via [`NativeBinding::try_recv`] until
 //!    inbox is empty, the budget is exhausted, or shutdown fires.
 //!    Per-envelope wrapping is `local::with_stamped(slots, ...)` +
-//!    `log_install::with_actor_dispatch(binding, ...)` — same as
-//!    `dispatch_loop_run`'s body so traces / `Local<T>` lookups behave
-//!    identically.
+//!    `log_install::with_actor_dispatch(binding, ...)` so traces /
+//!    `Local<T>` lookups behave identically across every actor, and the
+//!    per-envelope dispatch reuses the shared helpers in
+//!    [`crate::actor::native::dispatch`].
 //! 3. Returns one of:
 //!    - [`CycleResult::Idle`] — inbox drained, post-empty recheck saw
 //!      no race; worker drops the slot Arc.
@@ -28,15 +25,14 @@
 //!      post-shutdown drain + `unwire` hook + registry finalize
 //!      sequence and is done forever.
 //!
-//! ## Scheduling default
+//! ## Sole dispatch path
 //!
-//! `Actor::SCHEDULING` defaults to `Pooled` (issue 635 Phase 3), so
-//! this slot is the runtime dispatch path for nearly every actor —
-//! chassis caps and loaded wasm trampolines alike. `Dedicated` is the
-//! opt-in escape hatch for actors that park their dispatcher (today only
-//! `ProcessCapability`, which `block_on`s a tokio runtime). The
-//! `Pooled` branch of `make_native_actor_boot` / `Spawner::spawn_actor`
-//! constructs the slot; the chassis worker pool drives it.
+//! Every actor drains on the chassis worker pool (issue 635 Phase 3 made
+//! `Pooled` the default; issue 1187 removed the per-thread opt-out), so
+//! this slot is the runtime dispatch path for every actor — chassis caps
+//! and loaded wasm trampolines alike. `make_native_actor_boot` /
+//! `Spawner::spawn_actor` construct the slot; the chassis worker pool
+//! drives it.
 //!
 //! ## In-place demux seed (iamacoffeepot/aether#1135)
 //!
@@ -207,12 +203,12 @@ where
         }
     }
 
-    /// Per-envelope dispatch matching
-    /// [`crate::actor::native::dispatch::dispatch_loop_run`]'s body.
-    /// Wraps the dispatch call in `local::with_stamped` so per-actor
-    /// `Local<T>` lookups (including the ADR-0081 `ActorLogRing`)
-    /// resolve to this actor's slots. ADR-0081 retired the prior
-    /// `log_install::with_actor_dispatch` wrap + per-handler flush hop.
+    /// Per-envelope dispatch over the shared helpers in
+    /// [`crate::actor::native::dispatch`]. Wraps the dispatch call in
+    /// `local::with_stamped` so per-actor `Local<T>` lookups (including
+    /// the ADR-0081 `ActorLogRing`) resolve to this actor's slots.
+    /// ADR-0081 retired the prior `log_install::with_actor_dispatch`
+    /// wrap + per-handler flush hop.
     // `env` is taken by value because dispatch may move fields out
     // (reply_to, payload) into the actor; the helper here doesn't
     // happen to, but the surface mirrors the owning dispatch loop.
@@ -231,16 +227,14 @@ where
         // event. Resolved once per worker thread via a thread-local
         // cache — no per-hop `str::to_owned`, no `thread::current()`
         // `Arc` bump. The display name is recovered on the cold render
-        // path through the reverse-lookup registry. With the `Pooled`
-        // default scheduler (issue 635) this is the worker's
-        // `aether-worker-N`; `Thread`-scheduled actors land on a
-        // per-actor name.
+        // path through the reverse-lookup registry. Every actor drains on
+        // the pool (issue 635 / issue 1187), so this is always the
+        // worker's `aether-worker-N`.
         let thread_id = thread_name::current_thread_id();
         local::with_stamped(&self.slots, || {
             // ADR-0086 Phase 3: `Received` / `Finished` land in this
             // (recipient) actor's trace ring — only inside this
-            // `with_stamped` is its `ActorSlots` stamped. Mirrors
-            // `dispatch::dispatch_loop_run`.
+            // `with_stamped` is its `ActorSlots` stamped.
             let th = self.binding.mailer().trace_handle();
             // iamacoffeepot/aether#1128: capture the `Received` instant
             // so the cost fold below reuses the existing trace bracket —
@@ -263,8 +257,8 @@ where
             let mut ctx = NativeCtx::new(&self.binding, env.sender, env.mail_id, env.root);
             // ADR-0081 / ADR-0086 / iamacoffeepot/aether#1128
             // framework-built-in dispatch arms for `aether.log.tail` +
-            // `aether.trace.tail` + `aether.cost.tail`. See
-            // `dispatch::dispatch_loop_run`.
+            // `aether.trace.tail` + `aether.cost.tail`. See the helper
+            // docs in `dispatch`.
             if !super::dispatch::dispatch_log_tail_if_matching(&mut ctx, &env)
                 && !super::dispatch::dispatch_trace_tail_if_matching(&mut ctx, &env)
                 && !super::dispatch::dispatch_cost_tail_if_matching(&self.binding, &mut ctx, &env)
@@ -273,7 +267,7 @@ where
             }
             // iamacoffeepot/aether#1150: flush before `Finished` so a
             // child `Sent` (stamped at flush-begin on `ctx` drop) precedes
-            // its parent's `Finished`. See `dispatch::dispatch_loop_run`.
+            // its parent's `Finished`.
             drop(ctx);
             let t_finished = th.now_nanos();
             th.push_trace_ring(
@@ -298,7 +292,7 @@ where
         }
     }
 
-    /// Phase 3 of the `dispatch_loop_run` lifecycle. Wraps `actor.unwire`
+    /// The close hook in the slot teardown sequence. Wraps `actor.unwire`
     /// in `with_stamped` so any final tracing or `Local<T>` access from
     /// the close hook resolves to this actor's slots.
     fn run_close_hook(&self, actor: &mut Box<A>) {

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -27,7 +27,6 @@ use aether_data::{Kind, mailbox_id_from_name};
 use aether_kinds::trace::Nanos;
 
 use crate::actor::native::binding::NativeBinding;
-use crate::actor::native::dispatch;
 use crate::actor::native::dispatcher_slot::DispatcherSlot;
 use crate::actor::native::envelope::Envelope;
 use crate::actor::native::{NativeActor, NativeDispatch, NativeInitCtx};
@@ -46,7 +45,6 @@ use crate::scheduler::WakeSink;
 use aether_actor::local;
 use aether_actor::local::ActorSlots;
 use std::sync::Weak;
-use std::thread;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -387,19 +385,18 @@ impl Spawner {
         let strong_sender: Arc<mpsc::Sender<Envelope>> = Arc::new(tx.clone());
         let weak_for_handler = Arc::downgrade(&strong_sender);
         // Per-actor inbox-pending counter. Sink handler ++ on push;
-        // dispatcher loop -- after handling. Pre-PR-4 the test bench's
+        // dispatcher slot -- after handling. Pre-PR-4 the test bench's
         // `wait_instanced_quiesce` queried this through
         // `Spawner::instanced_pending`; ADR-0080 settlement gating
-        // retires that polling path. The counter survives because
-        // `dispatch_loop_run` still threads it as the optional
-        // `pending` arg, but nothing queries the value today —
-        // a future cleanup PR can drop it entirely.
+        // retires that polling path. The counter survives because the
+        // `DispatcherSlot` still threads it as the optional `pending`
+        // arg, but nothing queries the value today — a future cleanup
+        // PR can drop it entirely.
         let pending = Arc::new(AtomicU64::new(0));
         let pending_for_handler = Arc::clone(&pending);
-        // Issue 635 PR C: optional pool wake hook for `Pooled` actors.
-        // Populated post-init by the `Pooled` branch below; left empty
-        // for `Dedicated` (today's only path) so the closure's `get()`
-        // is a single relaxed atomic load.
+        // Issue 635 PR C: pool wake hook. Populated post-init below
+        // (every actor is pool-dispatched since issue 1187); empty until
+        // then so the closure's `get()` is a single relaxed atomic load.
         let wake_slot: Arc<MailboxWakeSlot> = Arc::new(MailboxWakeSlot::default());
         let wake_for_handler = Arc::clone(&wake_slot);
         // iamacoffeepot/aether#848 PR 3: closure takes `OwnedDispatch`
@@ -516,110 +513,74 @@ impl Spawner {
             let _ = tx.send(env);
         }
 
-        // 8. Spawn dispatcher (or pool-register) per `A::SCHEDULING`.
+        // 8. Pool-register the dispatcher (every actor is pool-dispatched
+        // since issue 1187 removed the per-thread `Dedicated` opt-out).
         // The local strong Arc was the populator for the Weak handler
         // ref; the actor_registry now holds an `Arc::clone` of the
         // same Arc, so dropping the local doesn't break the weak.
         drop(strong_sender);
-        match A::SCHEDULING {
-            aether_actor::Scheduling::Dedicated => {
-                // Today's path: one OS thread per instanced actor.
-                let transport_for_thread = Arc::clone(&transport);
-                let actor_registry_for_thread = Arc::clone(&self.actor_registry);
-                let mailer_for_thread = Arc::clone(&self.mailer);
-                let pending_for_thread = Arc::clone(&pending);
-                let thread_name = alloc_instanced_thread_name(&full_name);
-                let _ = thread::Builder::new()
-                    .name(thread_name)
-                    .spawn(move || {
-                        dispatch::dispatch_loop_run::<A>(
-                            &transport_for_thread,
-                            &mut actor,
-                            &slots,
-                            Some(&pending_for_thread),
-                            &actor_registry_for_thread,
-                            &mailer_for_thread,
-                            id,
-                        );
-                    })
-                    .expect("dispatcher thread spawn must succeed");
-            }
-            aether_actor::Scheduling::Pooled => {
-                // Issue 635 PR C + Phase 3: register a `DispatcherSlot`
-                // with the chassis worker pool. No per-actor thread.
-                // The wake hook on the closure pushes the slot to the
-                // ready queue when an envelope lands.
-                let slot = DispatcherSlot::<A>::new(
-                    actor,
-                    Arc::clone(&transport),
-                    slots,
-                    Some(Arc::clone(&pending)),
-                    Arc::clone(&self.actor_registry),
-                    Arc::clone(&self.mailer),
-                    id,
-                );
-                let slot_dyn: Arc<dyn Drainable> = slot.clone();
-                let weak: Weak<dyn Drainable> = Arc::downgrade(&slot_dyn);
-                // iamacoffeepot/aether#1135: surface the seize handle on
-                // this instanced actor's `Inbox` entry so the blob
-                // demuxer dispatches its fan-out in place (ADR-0087 §4).
-                // The registry holds the strong slot ref via
-                // `instanced_slots` below; the demuxer's `Weak` upgrade
-                // fails cleanly once the actor is torn down.
-                self.registry.install_seize_handle(
-                    id,
-                    SeizeHandle::new(Arc::clone(slot.state()), Arc::downgrade(&slot_dyn)),
-                );
-                let wake = WakeHandle::new(Arc::clone(slot.state()), weak, self.wake_sink.clone());
-                // Stash the slot's strong Arc so wakes can upgrade their
-                // `Weak`. PR C dropped it here, which broke every wake
-                // after spawn (the registry only holds the inbox
-                // sender, not the slot — the comment claiming
-                // otherwise was wrong). Slots live until the Spawner
-                // itself drops at chassis teardown. Issue 685 also
-                // stashes a wake clone so chassis teardown can fire
-                // one wake per slot after signaling shutdown.
-                drop(slot);
-                let teardown_wake = wake.clone();
-                self.instanced_slots
-                    .lock()
-                    .expect("instanced_slots mutex poisoned; fail-fast per ADR-0063")
-                    .insert(
-                        id,
-                        InstancedSlotEntry {
-                            slot: slot_dyn,
-                            wake: teardown_wake,
-                        },
-                    );
-                // Pre-loaded `after_init` mail (lines above) was sent
-                // straight to the inbox via `tx.send`, which bypasses
-                // the closure's wake hook. Fire one wake now so the
-                // slot enters the ready queue and the worker drains
-                // those envelopes; subsequent peer sends route through
-                // the closure and wake on their own.
-                let manual_wake = wake.clone();
-                wake_slot.set(Arc::new(move || {
-                    // Inbox-sender hook: the CAS-win bool would tell us
-                    // whether *this* sender owns the schedule push, but
-                    // the scheduler self-deduplicates so either outcome
-                    // is fine.
-                    let _ = wake.wake();
-                }));
-                // Manual catch-up wake for inbox mail that landed
-                // before the closure was installed (see comment above).
-                let _ = manual_wake.wake();
-            }
-        }
+        // Issue 635 PR C + Phase 3: register a `DispatcherSlot` with the
+        // chassis worker pool. No per-actor thread. The wake hook on the
+        // closure pushes the slot to the ready queue when an envelope
+        // lands.
+        let slot = DispatcherSlot::<A>::new(
+            actor,
+            Arc::clone(&transport),
+            slots,
+            Some(Arc::clone(&pending)),
+            Arc::clone(&self.actor_registry),
+            Arc::clone(&self.mailer),
+            id,
+        );
+        let slot_dyn: Arc<dyn Drainable> = slot.clone();
+        let weak: Weak<dyn Drainable> = Arc::downgrade(&slot_dyn);
+        // iamacoffeepot/aether#1135: surface the seize handle on this
+        // instanced actor's `Inbox` entry so the blob demuxer dispatches
+        // its fan-out in place (ADR-0087 §4). The registry holds the
+        // strong slot ref via `instanced_slots` below; the demuxer's
+        // `Weak` upgrade fails cleanly once the actor is torn down.
+        self.registry.install_seize_handle(
+            id,
+            SeizeHandle::new(Arc::clone(slot.state()), Arc::downgrade(&slot_dyn)),
+        );
+        let wake = WakeHandle::new(Arc::clone(slot.state()), weak, self.wake_sink.clone());
+        // Stash the slot's strong Arc so wakes can upgrade their `Weak`.
+        // PR C dropped it here, which broke every wake after spawn (the
+        // registry only holds the inbox sender, not the slot — the
+        // comment claiming otherwise was wrong). Slots live until the
+        // Spawner itself drops at chassis teardown. Issue 685 also
+        // stashes a wake clone so chassis teardown can fire one wake per
+        // slot after signaling shutdown.
+        drop(slot);
+        let teardown_wake = wake.clone();
+        self.instanced_slots
+            .lock()
+            .expect("instanced_slots mutex poisoned; fail-fast per ADR-0063")
+            .insert(
+                id,
+                InstancedSlotEntry {
+                    slot: slot_dyn,
+                    wake: teardown_wake,
+                },
+            );
+        // Pre-loaded `after_init` mail (lines above) was sent straight to
+        // the inbox via `tx.send`, which bypasses the closure's wake
+        // hook. Fire one wake now so the slot enters the ready queue and
+        // the worker drains those envelopes; subsequent peer sends route
+        // through the closure and wake on their own.
+        let manual_wake = wake.clone();
+        wake_slot.set(Arc::new(move || {
+            // Inbox-sender hook: the CAS-win bool would tell us whether
+            // *this* sender owns the schedule push, but the scheduler
+            // self-deduplicates so either outcome is fine.
+            let _ = wake.wake();
+        }));
+        // Manual catch-up wake for inbox mail that landed before the
+        // closure was installed (see comment above).
+        let _ = manual_wake.wake();
 
         Ok(id)
     }
-}
-
-fn alloc_instanced_thread_name(full_name: &str) -> String {
-    let mut s = String::with_capacity("aether-instanced-".len() + full_name.len());
-    s.push_str("aether-instanced-");
-    s.push_str(full_name);
-    s
 }
 
 /// Builder returned from `NativeCtx::spawn_child` /

--- a/crates/aether-substrate/src/actor/native/spawn_thread.rs
+++ b/crates/aether-substrate/src/actor/native/spawn_thread.rs
@@ -390,7 +390,6 @@ mod tests {
 
     impl Actor for StubActor {
         const NAMESPACE: &'static str = "test.spawn_thread.stub";
-        const SCHEDULING: aether_actor::Scheduling = aether_actor::Scheduling::Dedicated;
     }
 
     impl Singleton for StubActor {}

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -25,7 +25,6 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 
 use crate::actor::native::binding::NativeBinding;
-use crate::actor::native::dispatch;
 use crate::actor::native::dispatcher_slot::DispatcherSlot;
 use crate::actor::native::{ExportedHandles, NativeActor, NativeDispatch, NativeInitCtx};
 use crate::chassis::Chassis;
@@ -44,6 +43,7 @@ use crate::scheduler::SeizeHandle;
 use crate::scheduler::WakeHandle;
 use crate::scheduler::log_handoff_calibration;
 use crate::scheduler::{Pool, PoolConfig, PoolHandle};
+#[cfg(test)]
 use aether_actor::Actor;
 #[cfg(test)]
 use aether_actor::HandlesKind;
@@ -57,8 +57,6 @@ use std::any::TypeId;
 use std::io;
 use std::mem;
 use std::sync::Weak;
-use std::thread;
-use std::thread::JoinHandle;
 use std::time::Duration;
 
 /// Failure mode raised by [`DriverRunning::run`].
@@ -622,87 +620,54 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
             slots,
         } = resources;
 
-        match A::SCHEDULING {
-            aether_actor::Scheduling::Dedicated => {
-                // Today's path: spawn one OS thread per actor.
-                let mut actor = actor;
-                let transport_for_thread = Arc::clone(&transport);
-                let actor_registry_for_thread = Arc::clone(ctx.spawner_arc().actor_registry());
-                let mailer_for_thread = ctx.mail_send_handle();
-                let self_id_for_thread = mailbox_id;
-                let thread_name = alloc_native_actor_thread_name::<A>();
-                let thread = thread::Builder::new()
-                    .name(thread_name)
-                    .spawn(move || {
-                        dispatch::dispatch_loop_run::<A>(
-                            &transport_for_thread,
-                            &mut actor,
-                            &slots,
-                            pending.as_ref(),
-                            &actor_registry_for_thread,
-                            &mailer_for_thread,
-                            self_id_for_thread,
-                        );
-                    })
-                    .map_err(|e| BootError::Other(Box::new(e)))?;
-
-                Ok(Box::new(NativeActorShutdown {
-                    thread: Some(thread),
-                    mailbox_sender: Some(mailbox_sender),
-                }) as Box<dyn DynShutdown>)
-            }
-            aether_actor::Scheduling::Pooled => {
-                // Issue 635 PR C path: register a `DispatcherSlot`
-                // with the chassis worker pool. No per-actor thread.
-                // The `wake_slot` in the mailbox closure fires the
-                // pool wake hook on every accepted send.
-                let actor_registry = Arc::clone(ctx.spawner_arc().actor_registry());
-                let mailer_clone = ctx.mail_send_handle();
-                let slot = DispatcherSlot::<A>::new(
-                    actor,
-                    Arc::clone(&transport),
-                    slots,
-                    pending,
-                    actor_registry,
-                    mailer_clone,
-                    mailbox_id,
-                );
-                let slot_dyn: Arc<dyn Drainable> = slot.clone();
-                let weak: Weak<dyn Drainable> = Arc::downgrade(&slot_dyn);
-                // iamacoffeepot/aether#1135: surface the seize handle on
-                // this actor's `Inbox` entry so the blob demuxer can
-                // dispatch its fan-out in place rather than depositing +
-                // repop'ing through the inbox. Same `(state, weak)` pair
-                // the wake handle carries; the registry owns the strong
-                // slot ref, so the demuxer's `Weak` upgrade fails cleanly
-                // after teardown.
-                ctx.registry().install_seize_handle(
-                    mailbox_id,
-                    SeizeHandle::new(Arc::clone(slot.state()), Arc::downgrade(&slot_dyn)),
-                );
-                drop(slot_dyn);
-                let wake = WakeHandle::new(Arc::clone(slot.state()), weak, ctx.wake_sink().clone());
-                // Issue 697 multi-pass: mail addressed at this actor
-                // during the wire pass landed in its inbox before the
-                // wake hook was installed, so the closure-side wake
-                // fired against an empty `wake_slot`. Fire one wake
-                // here so a populated inbox enters the ready queue.
-                // Mirrors the same fix `Spawner::spawn_actor`'s
-                // Pooled branch carries (issue 635 Phase 3).
-                let manual_wake = wake.clone();
-                wake_slot.set(Arc::new(move || {
-                    // Inbox-sender hook — same fire-and-forget shape
-                    // as the spawn.rs analogue: scheduler deduplicates
-                    // the CAS, so the bool is irrelevant here.
-                    let _ = wake.wake();
-                }));
-                let _ = manual_wake.wake();
-                Ok(Box::new(PooledActorShutdown::<A> {
-                    slot: Some(slot),
-                    mailbox_sender: Some(mailbox_sender),
-                }) as Box<dyn DynShutdown>)
-            }
-        }
+        // Register a `DispatcherSlot` with the chassis worker pool. No
+        // per-actor thread (issue 635 Phase 3 made `Pooled` the only
+        // path; issue 1187 removed the `Dedicated` opt-out). The
+        // `wake_slot` in the mailbox closure fires the pool wake hook on
+        // every accepted send.
+        let actor_registry = Arc::clone(ctx.spawner_arc().actor_registry());
+        let mailer_clone = ctx.mail_send_handle();
+        let slot = DispatcherSlot::<A>::new(
+            actor,
+            Arc::clone(&transport),
+            slots,
+            pending,
+            actor_registry,
+            mailer_clone,
+            mailbox_id,
+        );
+        let slot_dyn: Arc<dyn Drainable> = slot.clone();
+        let weak: Weak<dyn Drainable> = Arc::downgrade(&slot_dyn);
+        // iamacoffeepot/aether#1135: surface the seize handle on this
+        // actor's `Inbox` entry so the blob demuxer can dispatch its
+        // fan-out in place rather than depositing + repop'ing through the
+        // inbox. Same `(state, weak)` pair the wake handle carries; the
+        // registry owns the strong slot ref, so the demuxer's `Weak`
+        // upgrade fails cleanly after teardown.
+        ctx.registry().install_seize_handle(
+            mailbox_id,
+            SeizeHandle::new(Arc::clone(slot.state()), Arc::downgrade(&slot_dyn)),
+        );
+        drop(slot_dyn);
+        let wake = WakeHandle::new(Arc::clone(slot.state()), weak, ctx.wake_sink().clone());
+        // Issue 697 multi-pass: mail addressed at this actor during the
+        // wire pass landed in its inbox before the wake hook was
+        // installed, so the closure-side wake fired against an empty
+        // `wake_slot`. Fire one wake here so a populated inbox enters the
+        // ready queue. Mirrors the same fix `Spawner::spawn_actor`'s
+        // Pooled branch carries (issue 635 Phase 3).
+        let manual_wake = wake.clone();
+        wake_slot.set(Arc::new(move || {
+            // Inbox-sender hook — same fire-and-forget shape as the
+            // spawn.rs analogue: scheduler deduplicates the CAS, so the
+            // bool is irrelevant here.
+            let _ = wake.wake();
+        }));
+        let _ = manual_wake.wake();
+        Ok(Box::new(PooledActorShutdown::<A> {
+            slot: Some(slot),
+            mailbox_sender: Some(mailbox_sender),
+        }) as Box<dyn DynShutdown>)
     }
 
     fn cleanup_after_failure(self: Box<Self>, ctx: &mut ChassisCtx<'_>) {
@@ -739,10 +704,9 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
 ///    final cycle. The pool's `Drop` joins workers, so any in-flight
 ///    cycle finishes before chassis shutdown returns.
 ///
-/// `Pooled` is the `Actor::SCHEDULING` default (issue 635 Phase 3), so
-/// this is the runtime shutdown path for nearly every chassis cap; only
-/// the `Dedicated` opt-outs (today `ProcessCapability`) take the
-/// thread-join `NativeActorShutdown` arm instead.
+/// Every actor drains on the pool (issue 635 Phase 3 made `Pooled` the
+/// default; issue 1187 removed the `Dedicated` opt-out), so this is the
+/// runtime shutdown path for every chassis cap.
 struct PooledActorShutdown<A>
 where
     A: NativeActor + NativeDispatch,
@@ -763,38 +727,6 @@ where
         // silently no-op via WakeHandle's Weak failing to upgrade.
         self.mailbox_sender.take();
         drop(self.slot.take());
-    }
-}
-
-/// Build a stable `aether-actor-<namespace>` thread name for the
-/// dispatcher. Mirrors the legacy capability path's helper but lives
-/// in this module so `make_native_actor_boot` doesn't depend on a
-/// `pub(crate)` shim from `capability.rs`.
-fn alloc_native_actor_thread_name<A: Actor>() -> String {
-    let mut name = String::with_capacity("aether-actor-".len() + A::NAMESPACE.len());
-    name.push_str("aether-actor-");
-    name.push_str(A::NAMESPACE);
-    name
-}
-
-/// Shutdown adapter for a [`NativeActor`] booted through
-/// [`Builder::with_actor`]. Drops the [`MailboxSender`]
-/// to disconnect the channel (the dispatcher's `recv_blocking` returns
-/// `None` and the thread exits), then joins the thread.
-struct NativeActorShutdown {
-    thread: Option<JoinHandle<()>>,
-    mailbox_sender: Option<MailboxSender>,
-}
-
-impl DynShutdown for NativeActorShutdown {
-    fn shutdown_dyn(mut self: Box<Self>) {
-        // Sender first — disconnects the channel and lets the
-        // dispatcher's `recv_blocking` return None so the thread
-        // exits. Joining a still-attached sender would hang.
-        self.mailbox_sender.take();
-        if let Some(t) = self.thread.take() {
-            let _ = t.join();
-        }
     }
 }
 
@@ -1049,11 +981,11 @@ struct BootedPassives {
     actor_registry: Arc<crate::ActorRegistry>,
     spawner: Arc<crate::Spawner>,
     /// Issue 635 PR C: chassis-owned worker pool. Boots empty in
-    /// [`boot_passives`] before any cap, then drains every `Pooled` actor
-    /// (the `Actor::SCHEDULING` default since issue 635 Phase 3 — nearly
-    /// every cap). Drops *after* `shutdowns` (per `BootedPassives::Drop` +
-    /// implicit field-drop ordering), so every Dedicated dispatcher
-    /// thread is gone before pool workers join.
+    /// [`boot_passives`] before any cap, then drains every actor (all
+    /// pool-dispatched since issue 635 Phase 3 / issue 1187). Drops
+    /// *after* `shutdowns` (per `BootedPassives::Drop` + implicit
+    /// field-drop ordering), so every dispatcher slot has signalled
+    /// shutdown before pool workers join.
     _pool: PoolHandle,
     /// ADR-0080 §6 settlement registry. Cloned into the Mailer's
     /// chassis-router closure (which decodes `Settled { root }`
@@ -1114,10 +1046,9 @@ fn boot_passives(
     let actor_registry: Arc<crate::ActorRegistry> = Arc::new(crate::ActorRegistry::new());
     // Issue 635 PR C: stand up the worker pool before any cap boots.
     // The pool's wake sink is cloned into the Spawner (for instanced
-    // Pooled actors) and into the ChassisCtx (for singleton Pooled
-    // caps). Today every cap is Dedicated so the pool sits idle, but
-    // booting it here means PR D / Phase 2 can flip a cap to Pooled
-    // without re-plumbing the boot order.
+    // actors) and into the ChassisCtx (for singleton caps). Every actor
+    // drains on this pool — issue 635 Phase 3 made `Pooled` the default
+    // and issue 1187 removed the per-actor-thread opt-out entirely.
     //
     // Issue 745: `workers` is the `AETHER_WORKERS` override threaded
     // through `Builder::with_workers`. `None` keeps `PoolConfig::default`

--- a/crates/aether-substrate/src/chassis/ctx.rs
+++ b/crates/aether-substrate/src/chassis/ctx.rs
@@ -57,16 +57,16 @@ pub struct DropOnShutdownClaim {
     pub id: MailboxId,
     pub receiver: mpsc::Receiver<Envelope>,
     pub mailbox_sender: MailboxSender,
-    /// Issue 635 PR C: optional wake hook for `Pooled` actors. The
-    /// mailbox closure invokes this after a successful inbox push so
-    /// the chassis worker pool re-queues the actor's
-    /// [`crate::scheduler::Drainable`] slot. `Dedicated` actors
-    /// (today: every cap) leave this empty — the closure's `get()`
-    /// is a single atomic load, ~free.
+    /// Issue 635 PR C: the pool wake hook. The mailbox closure invokes
+    /// it after a successful inbox push so the chassis worker pool
+    /// re-queues the actor's [`crate::scheduler::Drainable`] slot. Every
+    /// actor is pool-dispatched (issue 1187), so this is always
+    /// populated post-slot-construction; the [`OnceLock`] shape lets the
+    /// closure's `get()` stay a single relaxed atomic load while the
+    /// slot is still being built.
     ///
-    /// Populated post-claim by the `Pooled` branch of
-    /// `make_native_actor_boot` / `Spawner::spawn_actor` after the
-    /// slot exists.
+    /// Populated post-claim by `make_native_actor_boot` /
+    /// `Spawner::spawn_actor` after the slot exists.
     pub wake_slot: Arc<MailboxWakeSlot>,
 }
 
@@ -98,9 +98,11 @@ impl MailboxWakeSlot {
         let _ = self.inner.set(fn_);
     }
 
-    /// Borrow the installed hook. Returns `None` when the claim is
-    /// for a `Dedicated` actor (no hook ever installed). Hot path —
-    /// `OnceLock::get` is a single relaxed load.
+    /// Borrow the installed hook. Returns `None` only during the boot
+    /// window before the slot is constructed and the hook is set; every
+    /// actor is pool-dispatched (issue 1187), so a live actor always has
+    /// one installed. Hot path — `OnceLock::get` is a single relaxed
+    /// load.
     pub(crate) fn get(&self) -> Option<&MailboxWakeFn> {
         self.inner.get()
     }
@@ -312,10 +314,10 @@ impl<'a> ChassisCtx<'a> {
                     );
                     return;
                 }
-                // Issue 635 PR C: fire the `Pooled` wake hook (if
-                // installed). `Dedicated` actors leave it empty,
-                // so this is a single relaxed atomic load on the
-                // hot path.
+                // Issue 635 PR C: fire the pool wake hook (if installed).
+                // `get()` returns `None` only during the boot window
+                // before the slot is built, so this is a single relaxed
+                // atomic load on the hot path.
                 if let Some(wake) = wake_for_handler.get() {
                     wake();
                 }

--- a/crates/aether-substrate/src/mail/registry.rs
+++ b/crates/aether-substrate/src/mail/registry.rs
@@ -342,10 +342,10 @@ pub enum MailboxEntry {
     /// see [`InboxHandler`] for the full contract.
     ///
     /// iamacoffeepot/aether#1135: `seize` is the deferred
-    /// `SeizeCell` — populated by the `Pooled`-branch wiring once the
-    /// recipient's dispatcher slot exists so the blob demuxer can resolve
-    /// recipient → slot and dispatch in place (ADR-0087 §4). Empty for
-    /// closure-backed inboxes and `Dedicated` actors (no pool slot).
+    /// `SeizeCell` — populated once the recipient's dispatcher slot
+    /// exists so the blob demuxer can resolve recipient → slot and
+    /// dispatch in place (ADR-0087 §4). Empty for closure-backed inboxes
+    /// (no pool slot behind them).
     Inbox {
         handler: Arc<dyn InboxHandler>,
         seize: SeizeCell,

--- a/crates/aether-substrate/src/scheduler/mod.rs
+++ b/crates/aether-substrate/src/scheduler/mod.rs
@@ -1,22 +1,23 @@
-//! Worker pool scheduler for `Pooled` actor dispatch (issue 635 PR B).
+//! Worker pool scheduler for actor dispatch (issue 635 PR B).
 //!
-//! The actor model post-ADR-0038 spawns one OS thread per actor. With
-//! ~10 chassis caps the model is fine; with N instanced actors (per
+//! The actor model post-ADR-0038 spawned one OS thread per actor. With
+//! ~10 chassis caps that was fine; with N instanced actors (per
 //! ADR-0079, the forcing function for issue 635) it isn't. The
 //! scheduler replaces 1:1 with M:N — a small set of pool workers
-//! cooperatively drains many `Pooled` actors. Actors that own a long-
-//! running blocking primitive (TCP `accept`, file-watch reads, parking
-//! `wait_reply`) opt out via `Actor::SCHEDULING = Dedicated` and keep
-//! their own thread.
+//! cooperatively drains every actor. Blocking work (TCP `accept`,
+//! file-watch reads, a parking `wait_reply`-shaped request) never
+//! blocks a handler: it offloads to a `ctx.spawn`'d thread that feeds
+//! results back as mail (issue 635 Phase 3 made `Pooled` the default;
+//! issue 1187 removed the per-thread `Dedicated` opt-out entirely).
 //!
 //! ## Components
 //!
 //! - [`Pool`] owns the pool worker threads + the ready-queue sender.
 //!   Constructed once at chassis boot.
 //! - [`Drainable`] is the trait [`crate::actor`]-side dispatcher slots
-//!   implement (PR C wires the concrete `DispatcherSlot<A>` over the
-//!   crate-internal `dispatch_loop_run` body in
-//!   `crate::actor::native::dispatch`).
+//!   implement; the concrete `DispatcherSlot<A>` runs its `run_cycle`
+//!   over the shared per-envelope helpers in
+//!   `crate::actor::native::dispatch`.
 //! - [`SlotState`] is the per-slot atomic that orchestrates Idle ↔
 //!   Ready ↔ Running transitions between sender-side wakeups and
 //!   worker-side drain claims.
@@ -27,11 +28,11 @@
 //!
 //! ## Phasing
 //!
-//! PR B (this) lands the pool primitive standalone and tested via a
-//! mock [`Drainable`] fixture. PR C wires real
-//! `DispatcherSlot<A>` instances at boot time so `Pooled` actors
-//! actually run on the pool. Phase 2 flips one cap to `Pooled`; Phase
-//! 3 sweeps the rest. Until PR C the pool is unused infrastructure.
+//! PR B landed the pool primitive standalone (tested via a mock
+//! [`Drainable`] fixture). PR C wired real `DispatcherSlot<A>` instances
+//! at boot time; Phase 3 flipped the default so every cap drains on the
+//! pool, and issue 1187 removed the per-thread opt-out — the pool is now
+//! the sole dispatch path.
 
 mod calibrate;
 mod pool;

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -265,16 +265,16 @@ pub enum CycleResult {
 }
 
 /// Trait the chassis-side dispatcher slot implements. PR C will
-/// implement this for `DispatcherSlot<A>` (one per `Pooled` actor).
+/// implement this for `DispatcherSlot<A>` (one per actor).
 /// PR B exercises it via an in-module `CounterSlot` test fixture.
 ///
 /// Implementors own:
 /// - The per-slot [`SlotState`] (so this trait can poll it).
 /// - The actor's inbox (so [`run_cycle`](Self::run_cycle) can drain).
 /// - Whatever the actor's handler invocation needs (a `Box<A>` plus
-///   the per-envelope wrapping that the crate-internal
-///   `dispatch_loop_run` does in `crate::actor::native::dispatch` —
-///   `local::with_stamped`, `log_install::with_actor_dispatch`, etc).
+///   the per-envelope wrapping `DispatcherSlot::dispatch_one` applies
+///   around the shared helpers in `crate::actor::native::dispatch` —
+///   `local::with_stamped`, etc).
 pub trait Drainable: Send + Sync + 'static {
     /// One drain cycle. Sequence:
     /// 1. CAS `Ready → Running` (caller holds the invariant: this


### PR DESCRIPTION
Removes the singlethreaded (Dedicated) actor dispatch opt-in. Every actor now drains on the chassis worker pool; the per-actor-thread escape hatch was dead (its one production consumer, ProcessCapability, retired with the hub collapse, leaving only two test stubs).

- aether-actor: dropped the Scheduling enum + Actor::SCHEDULING const + the lib.rs re-export, and recorded the "never block a handler — offload to a ctx.spawn'd thread that feeds mail back" invariant in the Actor trait docs.
- aether-actor-derive: the actor and bridge macros no longer parse/forward a SCHEDULING const; a leftover one now fails with a pointed diagnostic instead of a surfaceless-trait error.
- aether-substrate: collapsed both boot match arms to their unconditional pooled body and deleted the now-dead dispatch_loop_run, NativeActorShutdown, and the two thread-name helpers; swept the stale Dedicated / ProcessCapability prose across dispatch, scheduler, builder, and slot docs.

Touches substrate dispatch boot, so the TestBench scenarios are load-bearing here. Preflight ran the full set locally under nextest (fmt + clippy -D warnings + doc + wasm32 component cross-build + nextest, 1350 passed / 9 skipped). This macOS worktree has a wgpu adapter, so the mesh-viewer and test-bench scenario suites exercised the full chassis rather than skipping; CI's Linux runner has Mesa and always exercises them.

Closes iamacoffeepot/aether#1187

🤖 Generated with [Claude Code](https://claude.com/claude-code)
