### PR TITLE
perf(substrate): feed the box-calibrated wake cost into recruit-K

### DIFF
--- a/crates/aether-substrate/src/actor/native/blob_work.rs
+++ b/crates/aether-substrate/src/actor/native/blob_work.rs
@@ -92,7 +92,7 @@
 //! of parallelism (a worker drains a whole group; groups can't split), so
 //! the blob is a parallel-machine makespan problem — optimal
 //! `K ≈ ceil(total_work / longest_pole)`, clamped to `[1, min(G, W)]` and
-//! gated by `total_work > DEFAULT_WAKE_COST_NANOS` (the wake break-even). [`recruit_k`]
+//! gated by `total_work > wake_cost_nanos()` (the box-calibrated wake break-even). [`recruit_k`]
 //! is that closed form. A cheap narrow blob yields `K = 1` and stays local
 //! — preserving the #1116 win for the right reason (cheapness, not
 //! narrowness) — while a heavy narrow blob recruits its full group count.
@@ -130,7 +130,7 @@ use crate::actor::native::blob_lifecycle::{Lifecycle, MAX_GROUPS, Published};
 use crate::mail::cost::CostLookup;
 use crate::mail::mailer::Mailer;
 use crate::mail::{KindId, Mail, MailboxId};
-use crate::scheduler::{BatchBudget, CycleResult, Drainable, SeizeHandle, WakeSink};
+use crate::scheduler::{BatchBudget, CycleResult, Drainable, SeizeHandle, WakeSink, handoff_cost};
 
 /// Floor for a fresh blob's group-array capacity — a little headroom so a
 /// couple of subsequent flushes to *new* recipients can accumulate before
@@ -175,16 +175,19 @@ fn recruit_cap() -> usize {
     })
 }
 
-/// Default wake break-even in nanos, used when `AETHER_WAKE_COST_NANOS`
-/// is unset: the measured injector pickup / park-wake floor
-/// (iamacoffeepot/aether#1174's ~7µs tree floor, attributed to the
-/// injector handoff). A flush whose summed group work is below this can
-/// never amortize a sibling wakeup, so [`recruit_k`] returns `K = 1` and
-/// the blob stays producer-local — the cost-aware form of the prior
-/// narrow-local win (iamacoffeepot/aether#1116). A runtime-measured
-/// `C_wake` is a deferred upgrade (iamacoffeepot/aether#1127); for now
-/// it is this const.
-const DEFAULT_WAKE_COST_NANOS: u64 = 4_300;
+/// Fallback wake break-even in nanos. The live gate ([`wake_cost_nanos`])
+/// now reads the box-calibrated cross-worker handoff cost
+/// ([`handoff_cost`], iamacoffeepot/aether#1182) — the runtime-measured
+/// `C_wake` that iamacoffeepot/aether#1127 deferred, landed by
+/// iamacoffeepot/aether#1192. This const survives only as the
+/// `u64`-overflow fallback for that `Duration → nanos` conversion (never
+/// hit in practice — a handoff is µs-scale). `4_300` was the prior baked
+/// default (iamacoffeepot/aether#1200 named it `DEFAULT_`): iamacoffeepot/
+/// aether#1174's ~7µs injector pickup / park-wake floor. Below the
+/// break-even a flush can't amortize a sibling wakeup, so [`recruit_k`]
+/// returns `K = 1` and the blob stays producer-local — the cost-aware form
+/// of the prior narrow-local win (iamacoffeepot/aether#1116).
+const FALLBACK_WAKE_COST_NANOS: u64 = 4_300;
 
 /// High-MAD confidence threshold: a handler whose mean-absolute-deviation
 /// exceeds this fraction of its mean is "bimodal / untrustworthy" — its
@@ -197,16 +200,25 @@ const DEFAULT_WAKE_COST_NANOS: u64 = 4_300;
 const MAD_CONFIDENCE_NUM: u64 = 1;
 const MAD_CONFIDENCE_DEN: u64 = 1;
 
-/// The wake break-even in nanos, honouring an `AETHER_WAKE_COST_NANOS`
-/// override (unparseable / empty falls back to [`DEFAULT_WAKE_COST_NANOS`]). Read once.
+/// The wake break-even in nanos. An `AETHER_WAKE_COST_NANOS` override wins
+/// and is fixed for the run (cached); otherwise this is the box-calibrated
+/// cross-worker handoff cost ([`handoff_cost`], iamacoffeepot/aether#1182),
+/// read live so it tracks the EWMA as it refines — the runtime-measured
+/// `C_wake` that iamacoffeepot/aether#1127 deferred. Mirrors the keep-local
+/// valve's source ([`crate::scheduler::time_budget`]), so both consumers of
+/// the shared handoff-cost seam scale with the box. [`FALLBACK_WAKE_COST_NANOS`]
+/// is only used if the measured nanos overflow `u64` (never in practice — a
+/// handoff is µs-scale).
 fn wake_cost_nanos() -> u64 {
-    static WAKE: OnceLock<u64> = OnceLock::new();
-    *WAKE.get_or_init(|| {
+    static OVERRIDE: OnceLock<Option<u64>> = OnceLock::new();
+    if let Some(ns) = *OVERRIDE.get_or_init(|| {
         env::var("AETHER_WAKE_COST_NANOS")
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
-            .unwrap_or(DEFAULT_WAKE_COST_NANOS)
-    })
+    }) {
+        return ns;
+    }
+    u64::try_from(handoff_cost().as_nanos()).unwrap_or(FALLBACK_WAKE_COST_NANOS)
 }
 
 /// The cost-aware recruit target `K` (iamacoffeepot/aether#1178): how many
@@ -1290,8 +1302,10 @@ mod tests {
 
     // iamacoffeepot/aether#1178: the cost-aware recruiter. `recruit_k` is a
     // pure function over `(total_work, max_group_work, G, W)`; the canonical
-    // cases below use work values well clear of the default
-    // `DEFAULT_WAKE_COST_NANOS = 4300` so they don't depend on an env override.
+    // cases below use work values well clear of the wake floor (now the
+    // box-measured `handoff_cost`, µs-scale, iamacoffeepot/aether#1192) so
+    // they don't depend on it. The one floor-sensitive case reads
+    // `wake_cost_nanos()` directly rather than baking a constant.
 
     /// Trivial-wide: many tiny groups whose total work is below the wake
     /// break-even → `K = 1` (stay local, no recruit). This is the cost-aware
@@ -1299,9 +1313,14 @@ mod tests {
     /// regardless of width.
     #[test]
     fn recruit_k_trivial_wide_stays_local() {
-        // 12 groups × 100ns = 1200ns total, under the 4300ns floor.
-        assert_eq!(recruit_k(1_200, 100, 12, 8), 1);
-        // Even a single tiny group is local.
+        // Wide-but-cheap: total work at the wake floor → local regardless of
+        // width. Read the floor from `wake_cost_nanos` (now the box-measured
+        // handoff cost, iamacoffeepot/aether#1192) so this holds on any box
+        // rather than baking the old 4300ns const. The gate is `<=`, so work
+        // *at* the floor stays local.
+        let floor = wake_cost_nanos();
+        assert_eq!(recruit_k(floor, 100, 12, 8), 1);
+        // Even a single tiny group is local (clamped by G = 1).
         assert_eq!(recruit_k(100, 100, 1, 8), 1);
     }
 
@@ -1341,7 +1360,7 @@ mod tests {
         assert_eq!(recruit_k(100_000, 30_000, 11, 8), 3);
     }
 
-    /// The wake gate is exact at the boundary: `total_work <= DEFAULT_WAKE_COST_NANOS`
+    /// The wake gate is exact at the boundary: `total_work <= wake_cost_nanos()`
     /// is local, one nano over recruits.
     #[test]
     fn recruit_k_wake_gate_boundary() {


### PR DESCRIPTION
Closes iamacoffeepot/aether#1192.

## Summary

The recruit-K wake gate (`recruit_k` in `blob_work.rs`, iamacoffeepot/aether#1178) decided whether a recipient group's summed work is worth waking a parked sibling by comparing it against a baked `C_WAKE_NANOS = 4_300` ns. That constant is machine-dependent — the same flaw iamacoffeepot/aether#1182 fixed for the keep-local valve. iamacoffeepot/aether#1182 introduced a box-calibrated cross-worker handoff cost (`scheduler::calibrate::handoff_cost` — boot-probe seed + live `notify → wake` EWMA) and wired the valve to it; the recruiter is the second consumer named in that function's own doc and still read the const.

This re-points `wake_cost_nanos` at `handoff_cost`, mirroring the valve's access pattern (`worker_deque::time_budget`): the `AETHER_WAKE_COST_NANOS` override is cached in a `OnceLock` and wins; otherwise the live box-measured cost is read each call, tracking the EWMA as it refines. The recruiter uses the **raw 1×** handoff (a single wake's break-even), deliberately unlike the valve's `6×` (which amortizes repeatedly not spilling). `recruit_k`'s signature and formula are byte-unchanged — only the value `wake_cost_nanos` yields when no override is set moves from a const to the measurement. `C_WAKE_NANOS` survives only as the `u64`-overflow fallback for the `Duration → nanos` conversion (never hit in practice — a handoff is µs-scale), so the const stays live rather than dead.

Note vs the scoped plan: step 1 (add a `pub(crate)` re-export of `handoff_cost`) turned out to be a no-op — `scheduler/mod.rs` already re-exports it (`pub use calibrate::{handoff_cost, ...}`), so the seam was reachable crate-wide already. Net change is one file.

Intended behaviour shift, flagged at scope time: on the box `4_300` was tuned on, the gate now reads the calibrate measurement (~2 µs), so the recruiter recruits marginally more aggressively there. `4_300` was a coarse over-estimate conflating iamacoffeepot/aether#1174's ~7µs injector floor; `handoff_cost` is the accurate single-wake cost, and the point is to track the box.

## Test plan

- Existing `recruit_k_*` unit tests pass unchanged; the heavy-work cases use values that dwarf any plausible handoff floor.
- `recruit_k_trivial_wide_stays_local` rewritten to read the floor from `wake_cost_nanos` (mirroring the existing `recruit_k_wake_gate_boundary` test) so the wide-but-cheap assertion holds on any box rather than baking the old 4300 ns.
- `recruit_k`'s body confirmed byte-unchanged.
- Full `scripts/preflight.sh` green locally: workspace clippy `-D warnings`, doc `-D warnings` (intra-doc links resolve), 1367 nextest tests, wasm32 component cross-build.

## Generated by

`/implement` — agent execution of [scoped issue 1192](https://github.com/iamacoffeepot/aether/issues/1192).
