### PR TITLE
fix(repo): evaluate the claude pre-push hook in the command's target worktree

### DIFF
--- a/.claude/hooks/check-pre-push.sh
+++ b/.claude/hooks/check-pre-push.sh
@@ -42,6 +42,21 @@ if ! command -v git >/dev/null 2>&1; then
     exit 0
 fi
 
+# iamacoffeepot/aether#1199: the gated command may target a worktree via a
+# leading `cd <path> &&` — the /implement and /delegate skills push from
+# `.claude/worktrees/<slug>` / `/tmp/aether-*`. Evaluate git state in that
+# directory rather than the hook's own cwd (the main checkout); otherwise
+# HEAD and the stamp gitdir resolve against the wrong tree and a clean
+# in-worktree preflight is false-blocked. No `cd` prefix (the main-checkout
+# push) leaves cwd untouched, so that path is unchanged.
+cd_prefix_re='^[[:space:]]*cd[[:space:]]+([^[:space:];&|]+)'
+if [[ "$command" =~ $cd_prefix_re ]]; then
+    target_dir="${BASH_REMATCH[1]}"
+    if [[ -n "$target_dir" && -d "$target_dir" ]]; then
+        cd "$target_dir" || true
+    fi
+fi
+
 if ! git rev-parse --git-dir >/dev/null 2>&1; then
     exit 0
 fi


### PR DESCRIPTION
Closes iamacoffeepot/aether#1199.

## Summary

The Claude-side pre-push gate `.claude/hooks/check-pre-push.sh` evaluated git state (`HEAD`, the stamp gitdir, the `origin/main` diff) in the hook process's own cwd — the main checkout — even when the gated command targeted a **worktree** via a leading `cd <path> &&`. The `/implement` and `/delegate` skills push from `.claude/worktrees/<slug>`, so a clean in-worktree `scripts/preflight.sh` was false-blocked: the hook read the main checkout's HEAD + stamp, not the worktree's, and the only escape was `--no-verify` (which also skips the real git pre-push gate).

The hook now parses a leading `cd <path>` out of the command and, when the path is a real directory, evaluates git state there. No `cd` prefix (the main-checkout push) leaves cwd untouched — that path is byte-for-byte unchanged.

## Test plan

Behavioral test (a hook is shell-only; there's no Rust harness for it):

- `cd <worktree> && git push` with a matching in-worktree stamp → **allowed** (was blocked before the fix).
- bare `git push` with no matching stamp → **still blocks** (main-checkout behavior unchanged).
- `cd <missing-dir> && git push` → falls back to cwd, no crash.
- a body that merely *mentions* `git push` → still allowed (command-position match intact).

`bash -n` clean. Config-only change (`.claude/**`) — rides the repo-config preflight exception; CI self-validates.

## Generated by

`/implement` — agent execution of [scoped issue 1199](https://github.com/iamacoffeepot/aether/issues/1199).
