### PR TITLE
fix(repo): pin the preflight stamp to the sha it validated

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -22,6 +22,12 @@ set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
+# iamacoffeepot/aether#1156: pin the sha the checks actually run against.
+# `stamp_pass` stamps *this* value and refuses to write if HEAD has moved
+# since, so a rebase / amend / concurrent op / worktree churn mid-run can't
+# leave a stamp attesting a sha the checks never validated.
+HEAD_AT_START="$(git rev-parse HEAD)"
+
 force=0
 explicit=0
 explicit_files=()
@@ -51,8 +57,14 @@ while [[ $# -gt 0 ]]; do
 done
 
 stamp_pass() {
+    local now
+    now="$(git rev-parse HEAD)"
+    if [[ "$now" != "$HEAD_AT_START" ]]; then
+        echo "[preflight] HEAD moved during the run ($HEAD_AT_START -> $now) — re-run pre-flight." >&2
+        exit 1
+    fi
     mkdir -p "$(git rev-parse --git-dir)"
-    echo "$(git rev-parse HEAD) $(date -u +%s)" \
+    echo "$HEAD_AT_START $(date -u +%s)" \
         > "$(git rev-parse --git-dir)/aether-preflight-passed"
 }
 


### PR DESCRIPTION
Closes iamacoffeepot/aether#1156.

## Summary

`scripts/preflight.sh`'s `stamp_pass` wrote `$(git rev-parse HEAD)` at stamp time — the end of the run — rather than pinning the sha the checks actually ran against. If HEAD moved during the run (a rebase, an amend, a concurrent op, multi-worktree churn), the stamp attested a sha that was never validated; the pre-push hook then saw a matching stamp, skipped pre-flight, and green-lit unvalidated code. The usual failure is the *safe* direction (a stale stamp re-runs pre-flight); this is the *dangerous* one — stamping a HEAD that only came into existence after the checks ran.

The fix captures `HEAD_AT_START` at the top and has `stamp_pass` stamp **that** value, refusing to write (exit 1, `HEAD moved during the run — re-run pre-flight`) when current HEAD no longer matches. This guards all three `stamp_pass` call sites (no-change / config-skip / full-check paths).

## Test plan

Unit test of the guard (the fix only manifests when HEAD moves mid-run, so `git` is faked):

- HEAD unchanged across the run → stamp written, pinned to the validated sha.
- HEAD moved during the run → refuse (exit 1), no stamp written, diagnostic emitted.

`bash -n` clean. Config-only change (`scripts/**`) — rides the repo-config preflight exception; CI self-validates.

## Generated by

`/implement` — agent execution of [scoped issue 1156](https://github.com/iamacoffeepot/aether/issues/1156).
