### PR TITLE
perf(substrate/scheduler): mechanism counters for dispatch validation

### DIFF
--- a/crates/aether-substrate-bundle/src/bin/perf-compare.rs
+++ b/crates/aether-substrate-bundle/src/bin/perf-compare.rs
@@ -210,8 +210,9 @@ fn main() -> ExitCode {
     }
 
     eprintln!(
-        "perf-compare: {} improved, {} stable, {} regressed (informational)",
-        report.improved, report.stable, report.regressed
+        "perf-compare: {} improved, {} stable, {} regressed; {} counter cells changed \
+         (informational)",
+        report.improved, report.stable, report.regressed, report.counters_changed
     );
     ExitCode::SUCCESS
 }

--- a/crates/aether-substrate-bundle/src/perf/harness.rs
+++ b/crates/aether-substrate-bundle/src/perf/harness.rs
@@ -26,6 +26,7 @@ use aether_capabilities::trace_walk::fold_nodes;
 use aether_data::{Kind, KindId, MailboxId, mailbox_id_from_name};
 use aether_kinds::trace::{TraceRingEntry, TraceTail, TraceTailResult};
 use aether_kinds::{SubscribeInput, SubscribeInputResult, Tick};
+use aether_substrate::scheduler::SchedulerCountersSnapshot;
 use aether_substrate::{BootError, NativeActor, NativeCtx, NativeDispatch, NativeInitCtx, Subname};
 
 use crate::test_bench::TestBench;
@@ -383,6 +384,12 @@ pub struct CellSamples {
     pub drain: Vec<u64>,
     pub handler: Vec<u64>,
     pub depth: Vec<u64>,
+    /// iamacoffeepot/aether#1129: the scheduler mechanism-counter delta
+    /// over this cell's `advance` (notify slow-path unparks, recruiter-
+    /// suppressed wakeups, injector / sibling steals, inline-runs). A
+    /// single per-cell count delta, not a sample distribution — it passes
+    /// through [`Self::summarize`] unchanged.
+    pub counters: SchedulerCountersSnapshot,
 }
 
 impl CellSamples {
@@ -397,6 +404,7 @@ impl CellSamples {
             drain: summarize(self.drain),
             handler: summarize(self.handler),
             depth: summarize(self.depth),
+            counters: self.counters,
         }
     }
 }
@@ -429,6 +437,12 @@ pub struct CellResult {
     /// nanoseconds*. p50 ≈ 0 means `queued` is wakeup-dominated (empty
     /// queue); a rising tail means wait-behind-N (offered load).
     pub depth: Stats,
+    /// iamacoffeepot/aether#1129: the scheduler mechanism-counter delta
+    /// over this cell's `advance` — near-deterministic for a fixed
+    /// workload (a wakeup is a wakeup), so the trial report carries the
+    /// raw counts and the comparator gives them a deterministic verdict
+    /// rather than the noise-aware paired test the latency spans use.
+    pub counters: SchedulerCountersSnapshot,
 }
 
 /// Inputs to one sweep. `workers` is the outer axis (pool sizes);
@@ -658,6 +672,12 @@ pub fn run_sweep_samples(cfg: &SweepConfig) -> Vec<CellSamples> {
             // long wide fan-out and self-reports it (handled at harvest).
             let frames = cfg.frames;
 
+            // iamacoffeepot/aether#1129: bracket the advance with two
+            // mechanism-counter snapshots so the delta attributes only the
+            // measured frames — not the boot / spawn / subscribe traffic
+            // before, nor the trace-ring harvest mail after.
+            let counters_before = tb.scheduler_counters();
+
             // Drive via the real lifecycle.
             match cfg.pace_hz {
                 Some(hz) => {
@@ -674,6 +694,8 @@ pub fn run_sweep_samples(cfg: &SweepConfig) -> Vec<CellSamples> {
                     let _ = tb.advance(frames);
                 }
             }
+
+            let counters = tb.scheduler_counters().delta_since(&counters_before);
 
             // Harvest each participating actor's trace ring directly
             // (ADR-0086 Phase 3, decentralized trace): we built the
@@ -780,6 +802,7 @@ pub fn run_sweep_samples(cfg: &SweepConfig) -> Vec<CellSamples> {
                 drain,
                 handler,
                 depth,
+                counters,
             });
         }
     }

--- a/crates/aether-substrate-bundle/src/perf/report.rs
+++ b/crates/aether-substrate-bundle/src/perf/report.rs
@@ -21,6 +21,7 @@
 //! outliers (median is robust) read as stable rather than false
 //! regressions.
 
+use aether_substrate::scheduler::SchedulerCountersSnapshot;
 use serde::{Deserialize, Serialize};
 
 /// Which per-mail span a cell reports (iamacoffeepot/aether#1150). Each
@@ -54,6 +55,67 @@ impl Metric {
             Self::Queued => "queued",
             Self::Drain => "drain",
             Self::Handler => "handler",
+        }
+    }
+}
+
+/// Which scheduler mechanism counter a count-cell reports
+/// (iamacoffeepot/aether#1129). Each is a per-cell delta — a count, not a
+/// latency — and near-deterministic for a fixed workload, so the
+/// comparator gives them a deterministic (non-noise-banded) verdict
+/// rather than the latency [`Metric`]'s paired IQR test.
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum CounterMetric {
+    /// `SpinPark::notify` slow-path futex unparks — a producer woke a
+    /// parked worker (no spinner was available to route to). The ~4.3µs
+    /// handoff events the route-to-spinner fast path exists to avoid.
+    NotifySlowUnparks,
+    /// Recruiter-suppressed wakeups — a recruit asked for more siblings
+    /// than the pool could field (`workers − 1`); the clamped difference
+    /// is the suppressed count.
+    RecruitSuppressed,
+    /// Steals that pulled work from the shared injector (off-worker
+    /// producers, spilled fan-out, requeued yields).
+    StealsInjector,
+    /// Steals that raided a sibling worker's deque tail (only when
+    /// `AETHER_PEER_STEAL` is opted in).
+    StealsSibling,
+    /// Inline-runs — a wake kept its slot on the producing worker's own
+    /// deque (the affinity warm path), so it ran without a futex wakeup.
+    InlineRuns,
+}
+
+impl CounterMetric {
+    /// The four-plus counters in report order.
+    pub const ALL: [Self; 5] = [
+        Self::NotifySlowUnparks,
+        Self::RecruitSuppressed,
+        Self::StealsInjector,
+        Self::StealsSibling,
+        Self::InlineRuns,
+    ];
+
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::NotifySlowUnparks => "notify_slow_unparks",
+            Self::RecruitSuppressed => "recruit_suppressed",
+            Self::StealsInjector => "steals_injector",
+            Self::StealsSibling => "steals_sibling",
+            Self::InlineRuns => "inline_runs",
+        }
+    }
+
+    /// Read this counter's field out of a snapshot delta.
+    #[must_use]
+    pub fn read(self, snap: &SchedulerCountersSnapshot) -> u64 {
+        match self {
+            Self::NotifySlowUnparks => snap.notify_slow_unparks,
+            Self::RecruitSuppressed => snap.recruit_suppressed,
+            Self::StealsInjector => snap.steals_injector,
+            Self::StealsSibling => snap.steals_sibling,
+            Self::InlineRuns => snap.inline_runs,
         }
     }
 }
@@ -92,6 +154,28 @@ impl CellJson {
     }
 }
 
+/// One scheduler mechanism counter's per-cell delta in a single trial
+/// (iamacoffeepot/aether#1129). `count` is a count, not a latency — the
+/// number of events of `counter` kind the worker pool produced over this
+/// cell's `advance`.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct CounterCellJson {
+    pub workers: usize,
+    pub topo: String,
+    pub counter: CounterMetric,
+    pub count: u64,
+}
+
+impl CounterCellJson {
+    fn key(&self) -> CounterCellKey {
+        CounterCellKey {
+            workers: self.workers,
+            topo: self.topo.clone(),
+            counter: self.counter,
+        }
+    }
+}
+
 /// One fresh-process sweep run. The `perf-trial` bin emits this as JSON
 /// on stdout; the `perf-compare` bin collects K of each side.
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -106,14 +190,21 @@ pub struct TrialReport {
     /// Frames advanced per cell.
     pub frames: u32,
     pub cells: Vec<CellJson>,
+    /// iamacoffeepot/aether#1129: the scheduler mechanism-counter cells,
+    /// one row per (workers × topology × counter). A count class, separate
+    /// from the latency `cells` because counts get a deterministic verdict,
+    /// not the noise-aware paired test.
+    pub counters: Vec<CounterCellJson>,
 }
 
 /// Current trial schema tag. Bumped to `v2` by iamacoffeepot/aether#1150
 /// when `hop` / `send_enqueue` / `residence` gave way to the
 /// `queued` / `drain` / `handler` span model; to `v3` by
 /// iamacoffeepot/aether#1158 when `construct` joined as the producer-side
-/// first leg, completing the four-stage lifecycle.
-pub const TRIAL_SCHEMA: &str = "aether.perf.trial.v3";
+/// first leg, completing the four-stage lifecycle; to `v4` by
+/// iamacoffeepot/aether#1129 when the scheduler mechanism counters joined
+/// as the `counters` count-cell list.
+pub const TRIAL_SCHEMA: &str = "aether.perf.trial.v4";
 
 impl TrialReport {
     /// Build a trial report from a sweep's [`CellResult`]s — each cell
@@ -131,6 +222,7 @@ impl TrialReport {
         git_sha: Option<String>,
     ) -> Self {
         let mut out = Vec::with_capacity(cells.len() * 4);
+        let mut counter_rows = Vec::with_capacity(cells.len() * CounterMetric::ALL.len());
         for c in cells {
             for (metric, s) in [
                 (Metric::Construct, &c.construct),
@@ -149,6 +241,15 @@ impl TrialReport {
                     n: s.n,
                 });
             }
+            // iamacoffeepot/aether#1129: one count-cell per mechanism counter.
+            for counter in CounterMetric::ALL {
+                counter_rows.push(CounterCellJson {
+                    workers: c.workers,
+                    topo: c.topo.clone(),
+                    counter,
+                    count: counter.read(&c.counters),
+                });
+            }
         }
         Self {
             schema: TRIAL_SCHEMA.to_owned(),
@@ -156,6 +257,7 @@ impl TrialReport {
             pace_hz,
             frames,
             cells: out,
+            counters: counter_rows,
         }
     }
 }
@@ -204,6 +306,13 @@ struct CellKey {
     metric: Metric,
 }
 
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct CounterCellKey {
+    workers: usize,
+    topo: String,
+    counter: CounterMetric,
+}
+
 /// Find the cell matching `key` in one trial (a free fn, not a closure,
 /// so the borrow of the returned `&CellJson` ties to `t`'s lifetime).
 fn find_cell<'a>(t: &'a TrialReport, key: &CellKey) -> Option<&'a CellJson> {
@@ -219,6 +328,33 @@ pub enum Verdict {
     Improved,
     Stable,
     Regressed,
+}
+
+/// changed / stable verdict for one counter cell (iamacoffeepot/aether#1129).
+/// Deterministic — the counts are near-deterministic for a fixed workload,
+/// so a change above a small absolute tolerance is real, not noise. No
+/// improved/regressed direction: whether more steals or fewer unparks is
+/// "better" is mechanism-dependent and the reader's call; the verdict only
+/// asserts *whether the mechanism behaviour moved*.
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum CounterVerdict {
+    Stable,
+    Changed,
+}
+
+/// One compared counter cell — the median count per side (across the K
+/// trials) plus the deterministic [`CounterVerdict`].
+#[derive(Serialize, Clone, Debug)]
+pub struct CounterComparison {
+    pub workers: usize,
+    pub topo: String,
+    pub counter: CounterMetric,
+    pub base_count: u64,
+    pub cand_count: u64,
+    /// `cand_count − base_count` (signed).
+    pub delta: i64,
+    pub verdict: CounterVerdict,
 }
 
 /// One compared cell — display bands per side (IQR across trials) plus
@@ -247,6 +383,11 @@ pub struct ComparisonReport {
     pub stable: usize,
     pub regressed: usize,
     pub cells: Vec<CellComparison>,
+    /// iamacoffeepot/aether#1129: how many counter cells moved past the
+    /// absolute tolerance (deterministic verdict, not noise-banded).
+    pub counters_changed: usize,
+    /// The per-counter-cell comparison rows.
+    pub counters: Vec<CounterComparison>,
 }
 
 /// Tunables for the verdict rule. Defaults are conservative —
@@ -268,6 +409,17 @@ pub struct CompareConfig {
     pub abs_floor_ns: f64,
     /// Fraction of trials whose delta must share the effect's sign.
     pub consistency: f64,
+    /// iamacoffeepot/aether#1129: absolute tolerance (in events) for the
+    /// mechanism counters' deterministic verdict. A counter cell flags
+    /// `Changed` only when the median-count delta strictly exceeds this.
+    /// Small but non-zero: the counts are near-deterministic, but a lost
+    /// relaxed increment or a racing wakeup can jitter a count by one or
+    /// two across trials, and the median across K trials already absorbs
+    /// most of that — the tolerance is the final guard against a 1-event
+    /// wobble reading as a behaviour change. No IQR / noise band, by
+    /// design: the whole point of the counters is that they are stable
+    /// where latency is not.
+    pub counter_abs_tolerance: u64,
 }
 
 impl Default for CompareConfig {
@@ -277,6 +429,7 @@ impl Default for CompareConfig {
             rel_floor: 0.10,
             abs_floor_ns: 300.0,
             consistency: 0.75,
+            counter_abs_tolerance: 2,
         }
     }
 }
@@ -380,13 +533,98 @@ pub fn compare(base: &[TrialReport], cand: &[TrialReport], cfg: CompareConfig) -
         .filter(|c| c.verdict == Verdict::Regressed)
         .count();
     let stable = cells.len() - improved - regressed;
+
+    let counters = compare_counters(base, cand, k, cfg);
+    let counters_changed = counters
+        .iter()
+        .filter(|c| c.verdict == CounterVerdict::Changed)
+        .count();
+
     ComparisonReport {
         trials: k,
         improved,
         stable,
         regressed,
         cells,
+        counters_changed,
+        counters,
     }
+}
+
+/// Find the counter cell matching `key` in one trial.
+fn find_counter<'a>(t: &'a TrialReport, key: &CounterCellKey) -> Option<&'a CounterCellJson> {
+    t.counters
+        .iter()
+        .find(|c| c.workers == key.workers && c.topo == key.topo && c.counter == key.counter)
+}
+
+/// Median of an unsorted `u64` slice (nearest-rank, like the latency
+/// percentiles). `0` on an empty slice.
+fn median_counts(counts: &[u64]) -> u64 {
+    if counts.is_empty() {
+        return 0;
+    }
+    let mut s = counts.to_vec();
+    s.sort_unstable();
+    s[(s.len() - 1) / 2]
+}
+
+/// Deterministic counter comparison (iamacoffeepot/aether#1129). Per
+/// counter cell present in every trial of both sides, take the median
+/// count per side across the K trials and flag `Changed` when their
+/// absolute difference exceeds [`CompareConfig::counter_abs_tolerance`].
+/// No IQR / noise band — the counts are near-deterministic, so a change
+/// past the (tiny) tolerance is real.
+fn compare_counters(
+    base: &[TrialReport],
+    cand: &[TrialReport],
+    k: usize,
+    cfg: CompareConfig,
+) -> Vec<CounterComparison> {
+    if k == 0 {
+        return Vec::new();
+    }
+    let keys: Vec<CounterCellKey> = base
+        .first()
+        .map(|t| t.counters.iter().map(CounterCellJson::key).collect())
+        .unwrap_or_default();
+
+    let mut out = Vec::new();
+    for key in &keys {
+        let base_counts: Vec<u64> = base[..k]
+            .iter()
+            .filter_map(|t| find_counter(t, key))
+            .map(|c| c.count)
+            .collect();
+        let cand_counts: Vec<u64> = cand[..k]
+            .iter()
+            .filter_map(|t| find_counter(t, key))
+            .map(|c| c.count)
+            .collect();
+        if base_counts.len() != k || cand_counts.len() != k {
+            continue; // cell not present in every trial — skip
+        }
+
+        let base_count = median_counts(&base_counts);
+        let cand_count = median_counts(&cand_counts);
+        let delta = i64::try_from(cand_count).unwrap_or(i64::MAX)
+            - i64::try_from(base_count).unwrap_or(i64::MAX);
+        let verdict = if delta.unsigned_abs() > cfg.counter_abs_tolerance {
+            CounterVerdict::Changed
+        } else {
+            CounterVerdict::Stable
+        };
+        out.push(CounterComparison {
+            workers: key.workers,
+            topo: key.topo.clone(),
+            counter: key.counter,
+            base_count,
+            cand_count,
+            delta,
+            verdict,
+        });
+    }
+    out
 }
 
 #[allow(clippy::cast_precision_loss)]
@@ -492,6 +730,70 @@ pub fn markdown(report: &ComparisonReport, title: &str, subtitle: &str) -> Strin
         s.push_str(&row(c));
     }
     s.push_str("\n</details>\n");
+
+    s.push_str(&counters_markdown(report));
+    s
+}
+
+/// Render the mechanism-counter (iamacoffeepot/aether#1129) section: a
+/// headline change count, the changed rows up top, and the full counter
+/// grid collapsed. Counts are deterministic, so a non-zero delta past the
+/// tolerance is a real behaviour change (no noise band).
+#[allow(clippy::format_push_string)]
+fn counters_markdown(report: &ComparisonReport) -> String {
+    if report.counters.is_empty() {
+        return String::new();
+    }
+    let mut s = String::new();
+    s.push_str(&format!(
+        "\n### scheduler mechanism counters\n\n**{} of {} counter cells changed** (deterministic, abs-tolerance verdict)\n\n",
+        report.counters_changed,
+        report.counters.len()
+    ));
+
+    let header =
+        "| topology | w | counter | base | this | Δ | verdict |\n|---|--:|---|--:|--:|--:|---|\n";
+    let row = |c: &CounterComparison| -> String {
+        let verdict = match c.verdict {
+            CounterVerdict::Stable => "stable",
+            CounterVerdict::Changed => "changed",
+        };
+        format!(
+            "| {} | {} | {} | {} | {} | {:+} | {} |\n",
+            c.topo,
+            c.workers,
+            c.counter.label(),
+            c.base_count,
+            c.cand_count,
+            c.delta,
+            verdict,
+        )
+    };
+
+    let changed: Vec<&CounterComparison> = report
+        .counters
+        .iter()
+        .filter(|c| c.verdict == CounterVerdict::Changed)
+        .collect();
+    if changed.is_empty() {
+        s.push_str("_No counter cell moved past the tolerance._\n\n");
+    } else {
+        s.push_str(header);
+        for c in changed {
+            s.push_str(&row(c));
+        }
+        s.push('\n');
+    }
+
+    s.push_str(&format!(
+        "<details><summary>full counter grid — {} cells</summary>\n\n",
+        report.counters.len()
+    ));
+    s.push_str(header);
+    for c in &report.counters {
+        s.push_str(&row(c));
+    }
+    s.push_str("\n</details>\n");
     s
 }
 
@@ -524,8 +826,40 @@ mod tests {
                     max: p50 * 4,
                     n: 1800,
                 }],
+                counters: Vec::new(),
             })
             .collect()
+    }
+
+    /// Build a K-trial side carrying one counter cell (`fanout-8 @ 11w`,
+    /// `inline_runs`) with the per-trial counts in `series`. The latency
+    /// `cells` are left empty — the counter-verdict tests assert only on
+    /// the counter comparison.
+    fn counter_side(series: &[u64]) -> Vec<TrialReport> {
+        series
+            .iter()
+            .map(|&count| TrialReport {
+                schema: TRIAL_SCHEMA.to_owned(),
+                git_sha: None,
+                pace_hz: None,
+                frames: 200,
+                cells: Vec::new(),
+                counters: vec![CounterCellJson {
+                    workers: 11,
+                    topo: "fanout-8".to_owned(),
+                    counter: CounterMetric::InlineRuns,
+                    count,
+                }],
+            })
+            .collect()
+    }
+
+    fn inline_runs_verdict(rep: &ComparisonReport) -> CounterVerdict {
+        rep.counters
+            .iter()
+            .find(|c| c.counter == CounterMetric::InlineRuns)
+            .expect("inline_runs counter cell present")
+            .verdict
     }
 
     fn p50_verdict(rep: &ComparisonReport) -> Verdict {
@@ -623,5 +957,89 @@ mod tests {
         assert!(md.contains(STICKY_MARKER));
         assert!(md.contains("improved"));
         assert!(md.contains("full grid"));
+    }
+
+    #[test]
+    fn schema_tag_is_v4() {
+        // iamacoffeepot/aether#1129: the count-cell list bumped the schema.
+        assert_eq!(TRIAL_SCHEMA, "aether.perf.trial.v4");
+    }
+
+    #[test]
+    fn trial_report_round_trips_with_counter_cells() {
+        // iamacoffeepot/aether#1129: a v4 report carries both latency cells
+        // and counter cells; both survive a JSON round-trip, and the schema
+        // probe reads the v4 tag.
+        let mut t = side(&[1000]).remove(0);
+        t.counters = CounterMetric::ALL
+            .iter()
+            .map(|&counter| CounterCellJson {
+                workers: 11,
+                topo: "fanout-8".to_owned(),
+                counter,
+                count: 42,
+            })
+            .collect();
+        let json = serde_json::to_vec(&t).expect("serialize v4 trial");
+        assert_eq!(probe_schema(&json).as_deref(), Some(TRIAL_SCHEMA));
+        let back: TrialReport = serde_json::from_slice(&json).expect("round-trip v4 trial");
+        assert_eq!(back.counters.len(), CounterMetric::ALL.len());
+        assert!(back.counters.iter().all(|c| c.count == 42));
+        // The snake_case counter labels survive the enum serde round-trip.
+        assert!(
+            back.counters
+                .iter()
+                .any(|c| c.counter == CounterMetric::NotifySlowUnparks)
+        );
+    }
+
+    #[test]
+    fn equal_counts_read_stable() {
+        // Identical counts both sides — deterministic stable.
+        let base = counter_side(&[500, 500, 500, 500]);
+        let cand = counter_side(&[500, 500, 500, 500]);
+        let rep = compare(&base, &cand, CompareConfig::default());
+        assert_eq!(inline_runs_verdict(&rep), CounterVerdict::Stable);
+        assert_eq!(rep.counters_changed, 0);
+    }
+
+    #[test]
+    fn one_event_jitter_is_within_tolerance() {
+        // A 1-event wobble (a lost relaxed increment / racing wakeup) is
+        // inside the default abs-tolerance of 2 — must read stable.
+        let base = counter_side(&[500, 500, 501, 500]);
+        let cand = counter_side(&[501, 500, 500, 502]);
+        let rep = compare(&base, &cand, CompareConfig::default());
+        assert_eq!(inline_runs_verdict(&rep), CounterVerdict::Stable);
+    }
+
+    #[test]
+    fn clear_count_delta_reads_changed() {
+        // A workload-level shift (500 -> 50 inline-runs) is far past the
+        // tolerance — deterministically flagged, no noise band.
+        let base = counter_side(&[500, 500, 500, 500]);
+        let cand = counter_side(&[50, 48, 52, 50]);
+        let rep = compare(&base, &cand, CompareConfig::default());
+        assert_eq!(inline_runs_verdict(&rep), CounterVerdict::Changed);
+        assert_eq!(rep.counters_changed, 1);
+        let cell = rep
+            .counters
+            .iter()
+            .find(|c| c.counter == CounterMetric::InlineRuns)
+            .expect("inline_runs cell");
+        assert_eq!(cell.base_count, 500);
+        assert_eq!(cell.cand_count, 50);
+        assert_eq!(cell.delta, -450);
+    }
+
+    #[test]
+    fn markdown_renders_counter_section() {
+        let base = counter_side(&[500, 500, 500, 500]);
+        let cand = counter_side(&[50, 48, 52, 50]);
+        let rep = compare(&base, &cand, CompareConfig::default());
+        let md = markdown(&rep, "PR 9999 vs main", "test");
+        assert!(md.contains("scheduler mechanism counters"));
+        assert!(md.contains("inline_runs"));
+        assert!(md.contains("changed"));
     }
 }

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -1126,7 +1126,7 @@ mod tests {
         let width = 4usize;
         for i in 1..=width {
             let cfg = RelayConfig {
-                downstreams: Arc::from([] as [MailboxId; 0]),
+                downstreams: Arc::<[MailboxId]>::from([]),
                 work_iters: 0,
             };
             tb.spawn_actor::<Relay>(Subname::Named(&i.to_string()), cfg)

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -47,6 +47,7 @@ use aether_substrate::{
     SubstrateBoot,
     capture::CaptureQueue,
     mail::{CapabilityRegistry, CostTable, Mail, MailId, MailboxId},
+    scheduler::SchedulerCountersSnapshot,
 };
 
 use super::chassis::{TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS};
@@ -423,6 +424,18 @@ impl TestBench {
     #[must_use]
     pub fn cost_table(&self) -> &Arc<CostTable> {
         self.queue.cost_table()
+    }
+
+    /// Snapshot the worker pool's mechanism counters
+    /// (iamacoffeepot/aether#1129): notify slow-path unparks, recruiter-
+    /// suppressed wakeups, injector / sibling steals, and inline-runs. The
+    /// perf harness brackets each cell's `advance` with two snapshots and
+    /// records the field-wise delta as the cell's count-metrics. A plain
+    /// relaxed copy — near-deterministic for a fixed workload, so the
+    /// comparator gives it a deterministic (non-noise-banded) verdict.
+    #[must_use]
+    pub fn scheduler_counters(&self) -> SchedulerCountersSnapshot {
+        self.passive.scheduler_counters()
     }
 
     /// Bytes-level fire-and-settle send: resolve `recipient_name` in
@@ -1082,6 +1095,84 @@ mod tests {
             png.starts_with(&[0x89, 0x50, 0x4E, 0x47]),
             "captured bytes are not a PNG: first 8 bytes={:?}",
             &png.iter().take(8).copied().collect::<Vec<u8>>(),
+        );
+    }
+
+    /// iamacoffeepot/aether#1129: `TestBench::scheduler_counters` reads a
+    /// live snapshot, and a fan-out advance moves the mechanism counters
+    /// off zero. A relay fan-out (one root → N leaves) drives the
+    /// substrate's real lifecycle through the worker pool, so at least one
+    /// dispatch mechanism (inline-run on the producing worker, or an
+    /// injector steal of spilled work) fires. The delta over the advance
+    /// must therefore be non-zero on some counter — the harvest the perf
+    /// harness relies on.
+    #[test]
+    fn scheduler_counters_move_after_fanout_advance() {
+        use crate::perf::harness::{Relay, RelayConfig, TickSource, relay_id, ticksrc_id};
+        use aether_data::{Kind as DataKind, MailboxId};
+        use aether_kinds::{SubscribeInput, SubscribeInputResult};
+        use aether_substrate::Subname;
+        use std::sync::Arc;
+
+        let mut tb = match TestBench::start_with_size(16, 16) {
+            Ok(tb) => tb,
+            Err(e) => {
+                eprintln!("skipping: TestBench boot failed (likely no wgpu adapter): {e}");
+                return;
+            }
+        };
+
+        // Fan-out: relay 0 -> {1, 2, 3, 4}. Spawn leaves then the entry.
+        let width = 4usize;
+        for i in 1..=width {
+            let cfg = RelayConfig {
+                downstreams: Arc::from([] as [MailboxId; 0]),
+                work_iters: 0,
+            };
+            tb.spawn_actor::<Relay>(Subname::Named(&i.to_string()), cfg)
+                .finish()
+                .expect("leaf relay spawns");
+        }
+        let entry_downstreams: Arc<[MailboxId]> = (1..=width).map(relay_id).collect();
+        tb.spawn_actor::<Relay>(
+            Subname::Named("0"),
+            RelayConfig {
+                downstreams: entry_downstreams,
+                work_iters: 0,
+            },
+        )
+        .finish()
+        .expect("entry relay spawns");
+        tb.spawn_actor::<TickSource>(Subname::Named("src"), relay_id(0))
+            .finish()
+            .expect("tick source spawns");
+
+        // Subscribe the source to the Tick stream so `advance` drives it.
+        let sub = SubscribeInput {
+            kind: Tick::ID,
+            mailbox: ticksrc_id(),
+        };
+        let reply = tb
+            .send_bytes_and_await("aether.input", SubscribeInput::ID, sub.encode_into_bytes())
+            .expect("subscribe send");
+        assert!(
+            matches!(
+                SubscribeInputResult::decode_from_bytes(&reply),
+                Some(SubscribeInputResult::Ok)
+            ),
+            "Tick subscribe should succeed"
+        );
+
+        let before = tb.scheduler_counters();
+        tb.advance(20).expect("advance");
+        let delta = tb.scheduler_counters().delta_since(&before);
+
+        // Some dispatch mechanism must have fired over 20 fan-out frames —
+        // the counters are no longer all-zero.
+        assert_ne!(
+            delta,
+            SchedulerCountersSnapshot::default(),
+            "a fan-out advance should move at least one mechanism counter, got {delta:?}"
         );
     }
 

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -42,7 +42,7 @@ use crate::scheduler::Drainable;
 use crate::scheduler::SeizeHandle;
 use crate::scheduler::WakeHandle;
 use crate::scheduler::log_handoff_calibration;
-use crate::scheduler::{Pool, PoolConfig, PoolHandle};
+use crate::scheduler::{Pool, PoolConfig, PoolHandle, SchedulerCountersSnapshot};
 #[cfg(test)]
 use aether_actor::Actor;
 #[cfg(test)]
@@ -985,8 +985,10 @@ struct BootedPassives {
     /// pool-dispatched since issue 635 Phase 3 / issue 1187). Drops
     /// *after* `shutdowns` (per `BootedPassives::Drop` + implicit
     /// field-drop ordering), so every dispatcher slot has signalled
-    /// shutdown before pool workers join.
-    _pool: PoolHandle,
+    /// shutdown before pool workers join. Held (not `_pool`) since
+    /// iamacoffeepot/aether#1129 reads its mechanism counters via
+    /// [`Self::scheduler_counters`].
+    pool: PoolHandle,
     /// ADR-0080 §6 settlement registry. Cloned into the Mailer's
     /// chassis-router closure (which decodes `Settled { root }`
     /// mail addressed to `CHASSIS_MAILBOX_ID` and signals
@@ -1003,6 +1005,13 @@ impl BootedPassives {
     /// `subscribe_settlement(root)` and wait on the returned receiver.
     pub fn settlement_registry(&self) -> &Arc<SettlementRegistry> {
         &self.settlement_registry
+    }
+
+    /// iamacoffeepot/aether#1129: snapshot the worker pool's mechanism
+    /// counters. The perf harness brackets a quiesced `advance` with two
+    /// of these and records the field-wise delta.
+    pub fn scheduler_counters(&self) -> SchedulerCountersSnapshot {
+        self.pool.scheduler_counters()
     }
 
     fn shutdown_in_place(&mut self) {
@@ -1266,7 +1275,7 @@ fn boot_passives(
         claimed_actor_mailboxes,
         actor_registry,
         spawner,
-        _pool: pool,
+        pool,
         settlement_registry,
     })
 }
@@ -1441,6 +1450,15 @@ impl<C: Chassis> PassiveChassis<C> {
     #[must_use]
     pub fn settlement_registry(&self) -> &Arc<SettlementRegistry> {
         self.booted.settlement_registry()
+    }
+
+    /// iamacoffeepot/aether#1129: snapshot the worker pool's mechanism
+    /// counters. The in-process [`TestBench`](crate) surfaces this to the
+    /// perf harness, which brackets each cell's `advance` with two
+    /// snapshots and records the field-wise delta.
+    #[must_use]
+    pub fn scheduler_counters(&self) -> SchedulerCountersSnapshot {
+        self.booted.scheduler_counters()
     }
 
     /// Issue 607 Phase 5 (ADR-0079): mirror of

--- a/crates/aether-substrate/src/scheduler/counters.rs
+++ b/crates/aether-substrate/src/scheduler/counters.rs
@@ -1,0 +1,130 @@
+//! Per-pool scheduler mechanism counters (iamacoffeepot/aether#1129).
+//!
+//! Pure instrumentation: a handful of relaxed [`AtomicU64`] bumped at the
+//! four dispatch-mechanism sites the perf methodology can't see through
+//! latency percentiles —
+//!
+//! - **`notify_slow_unparks`** — the producer-side `notify` slow path took
+//!   the futex `unpark` (no spinner was available, the ~4.3µs handoff
+//!   [`crate::scheduler::SpinPark`] exists to route *away*). The
+//!   route-to-spinner fast path bumps nothing.
+//! - **`recruit_suppressed`** — a recruit asked for more siblings than the
+//!   pool could give and the clamp reduced it. A cost-aware recruiter
+//!   (iamacoffeepot/aether#1178) sizing `recruit_k` below the available
+//!   group count surfaces here as a suppressed wakeup.
+//! - **`steals_injector`** / **`steals_sibling`** — a worker pulled work
+//!   from the shared injector vs. raided a sibling's deque tail.
+//! - **`inline_runs`** — a wake kept its slot on the producing worker's own
+//!   deque (the affinity warm path), so it ran without a futex wakeup.
+//!
+//! These are near-deterministic for a fixed workload and machine-portable
+//! (a wakeup is a wakeup), so — unlike latency, whose run-to-run variance is
+//! wakeup-dominated — they support a deterministic, CI-gateable verdict.
+//!
+//! **Benign-race discipline (mirrors `aether_actor::cost::CostCell` /
+//! [`crate::scheduler::calibrate`]).** Every increment is a relaxed
+//! `fetch_add`; a lost increment only *undercounts a diagnostic* and never
+//! gates a dispatch / recruit / park decision. So the counters add a single
+//! relaxed atomic to each hot site and carry no ordering obligation against
+//! the lost-wakeup fences they sit beside.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Shared, per-pool counter block. Built once at
+/// [`crate::scheduler::Pool::start`], wrapped in an `Arc`, and cloned into
+/// the [`crate::scheduler::SpinPark`], each worker's deque thread-local, and
+/// the [`crate::scheduler::WakeSink`]. Read with [`Self::snapshot`] from any
+/// thread.
+#[derive(Debug, Default)]
+pub struct SchedulerCounters {
+    notify_slow_unparks: AtomicU64,
+    recruit_suppressed: AtomicU64,
+    steals_injector: AtomicU64,
+    steals_sibling: AtomicU64,
+    inline_runs: AtomicU64,
+}
+
+impl SchedulerCounters {
+    /// A fresh, all-zero counter block.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// One `notify` slow-path futex unpark (no spinner was available).
+    pub fn note_notify_slow_unpark(&self) {
+        self.notify_slow_unparks.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// A recruit was clamped below what it asked for — `requested - granted`
+    /// sibling wakeups were suppressed. `0` (granted >= requested) bumps
+    /// nothing.
+    pub fn note_recruit_suppressed(&self, suppressed: usize) {
+        if suppressed > 0 {
+            self.recruit_suppressed
+                .fetch_add(suppressed as u64, Ordering::Relaxed);
+        }
+    }
+
+    /// One steal that pulled from the shared injector.
+    pub fn note_steal_injector(&self) {
+        self.steals_injector.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// One steal that raided a sibling worker's deque tail.
+    pub fn note_steal_sibling(&self) {
+        self.steals_sibling.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// One wake that kept its slot on the producing worker's own deque (ran
+    /// without a futex wakeup).
+    pub fn note_inline_run(&self) {
+        self.inline_runs.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// A plain copy of the current counts. Relaxed loads — a snapshot taken
+    /// concurrently with an increment may miss the in-flight bump, which is
+    /// fine for a profiling delta (the harness brackets a quiesced advance).
+    #[must_use]
+    pub fn snapshot(&self) -> SchedulerCountersSnapshot {
+        SchedulerCountersSnapshot {
+            notify_slow_unparks: self.notify_slow_unparks.load(Ordering::Relaxed),
+            recruit_suppressed: self.recruit_suppressed.load(Ordering::Relaxed),
+            steals_injector: self.steals_injector.load(Ordering::Relaxed),
+            steals_sibling: self.steals_sibling.load(Ordering::Relaxed),
+            inline_runs: self.inline_runs.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// A point-in-time copy of [`SchedulerCounters`]. The harness snapshots
+/// before/after each cell and records the field-wise delta
+/// ([`Self::delta_since`]).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SchedulerCountersSnapshot {
+    pub notify_slow_unparks: u64,
+    pub recruit_suppressed: u64,
+    pub steals_injector: u64,
+    pub steals_sibling: u64,
+    pub inline_runs: u64,
+}
+
+impl SchedulerCountersSnapshot {
+    /// Field-wise `self - earlier`. Saturating, so a counter that wrapped
+    /// (it won't in any realistic run) or an out-of-order read reads `0`
+    /// rather than a huge bogus delta.
+    #[must_use]
+    pub fn delta_since(&self, earlier: &Self) -> Self {
+        Self {
+            notify_slow_unparks: self
+                .notify_slow_unparks
+                .saturating_sub(earlier.notify_slow_unparks),
+            recruit_suppressed: self
+                .recruit_suppressed
+                .saturating_sub(earlier.recruit_suppressed),
+            steals_injector: self.steals_injector.saturating_sub(earlier.steals_injector),
+            steals_sibling: self.steals_sibling.saturating_sub(earlier.steals_sibling),
+            inline_runs: self.inline_runs.saturating_sub(earlier.inline_runs),
+        }
+    }
+}

--- a/crates/aether-substrate/src/scheduler/mod.rs
+++ b/crates/aether-substrate/src/scheduler/mod.rs
@@ -35,12 +35,14 @@
 //! the sole dispatch path.
 
 mod calibrate;
+mod counters;
 mod pool;
 mod slot;
 mod spin_park;
 mod worker_deque;
 
 pub use calibrate::{handoff_cost, log_handoff_calibration};
+pub use counters::{SchedulerCounters, SchedulerCountersSnapshot};
 pub use pool::{Pool, PoolConfig, PoolHandle, PoolWorkerJoin};
 pub use slot::{
     BATCH_MAX_MAILS, BATCH_MAX_USEC, BatchBudget, CLOCK_CHECK_STRIDE, CycleResult, DrainOutcome,

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -36,6 +36,7 @@ use std::thread::{self, JoinHandle};
 
 use crossbeam_deque::{Injector, Stealer, Worker};
 
+use crate::scheduler::counters::{SchedulerCounters, SchedulerCountersSnapshot};
 use crate::scheduler::spin_park::{Acquired, DEFAULT_SPIN_WINDOW_USEC, SpinPark};
 use crate::scheduler::worker_deque;
 
@@ -109,6 +110,13 @@ pub struct PoolHandle {
     /// own deque is at the local bound). Cloned into every [`WakeSink`].
     injector: Arc<Injector<Arc<dyn Drainable>>>,
     spin: Arc<SpinPark>,
+    /// Shared per-pool mechanism counters (iamacoffeepot/aether#1129).
+    /// One Arc, built at [`Pool::start`] and threaded into the
+    /// [`SpinPark`] (which the [`WakeSink`] reaches for the inline-run /
+    /// recruit-suppressed bumps) and every worker thread-local (the
+    /// steal bumps). [`Self::scheduler_counters`] snapshots it for the
+    /// perf harness.
+    counters: Arc<SchedulerCounters>,
     workers: Vec<PoolWorkerJoin>,
 }
 
@@ -160,6 +168,15 @@ impl PoolHandle {
     pub fn worker_count(&self) -> usize {
         self.workers.len()
     }
+
+    /// Snapshot the per-pool mechanism counters
+    /// (iamacoffeepot/aether#1129). A plain relaxed copy from any thread;
+    /// the perf harness brackets a quiesced `advance` with two of these
+    /// and records the field-wise delta.
+    #[must_use]
+    pub fn scheduler_counters(&self) -> SchedulerCountersSnapshot {
+        self.counters.snapshot()
+    }
 }
 
 impl Drop for PoolHandle {
@@ -198,7 +215,15 @@ impl Pool {
     #[allow(clippy::needless_pass_by_value)]
     pub fn start(config: PoolConfig, aborter: Arc<dyn FatalAborter>) -> PoolHandle {
         assert!(config.workers >= 1, "pool needs at least one worker");
-        let spin = Arc::new(SpinPark::with_spin_window(spin_window_from_env()));
+        // iamacoffeepot/aether#1129: one per-pool counter block, shared into
+        // the spin-park (and through it the wake sink) and every worker's
+        // thread-local. Pure instrumentation — built before any worker runs
+        // so the harness's first snapshot reads a live block.
+        let counters = Arc::new(SchedulerCounters::new());
+        let spin = Arc::new(SpinPark::with_spin_window_and_counters(
+            spin_window_from_env(),
+            Arc::clone(&counters),
+        ));
         let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
         // One LIFO deque per worker; collect every stealer so each worker
         // can steal from its siblings' tails when its own deque runs dry.
@@ -213,17 +238,23 @@ impl Pool {
             let injector = Arc::clone(&injector);
             let spin = Arc::clone(&spin);
             let aborter = Arc::clone(&aborter);
+            let counters = Arc::clone(&counters);
             let template = config.budget_template;
             let thread_name = name.clone();
             let handle = thread::Builder::new()
                 .name(thread_name)
-                .spawn(move || worker_loop(idx, deque, stealers, injector, spin, aborter, template))
+                .spawn(move || {
+                    worker_loop(
+                        idx, deque, stealers, injector, spin, aborter, counters, template,
+                    );
+                })
                 .expect("spawn pool worker thread");
             workers.push(PoolWorkerJoin { handle, name });
         }
         PoolHandle {
             injector,
             spin,
+            counters,
             workers,
         }
     }
@@ -242,8 +273,12 @@ fn spin_window_from_env() -> Duration {
 }
 
 // All arguments are taken by value so the spawned thread owns them
-// for its lifetime — the function is the worker thread's body.
-#[allow(clippy::needless_pass_by_value)]
+// for its lifetime — the function is the worker thread's body. The
+// per-worker shared handles (deques, stealers, injector, spin/park
+// coordinator, aborter, counters) are each independent and read once at
+// boot; bundling them into a struct would obscure the worker boot, so the
+// thread body carries them as positional params.
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 fn worker_loop(
     idx: usize,
     deque: Worker<Arc<dyn Drainable>>,
@@ -251,6 +286,7 @@ fn worker_loop(
     injector: Arc<Injector<Arc<dyn Drainable>>>,
     spin: Arc<SpinPark>,
     aborter: Arc<dyn FatalAborter>,
+    counters: Arc<SchedulerCounters>,
     template: BudgetTemplate,
 ) {
     // Hand this worker's deque to the thread-local so a handler's wake of
@@ -262,6 +298,10 @@ fn worker_loop(
     // on this worker can read the scheduler ready-queue depth
     // (`worker_deque::pending_depth`) for the latency harness.
     worker_deque::install_injector(Arc::clone(&injector));
+    // iamacoffeepot/aether#1129: register the per-pool counters so this
+    // worker's steal scan can attribute its injector / sibling steals
+    // without threading the Arc through the scan. Pure instrumentation.
+    worker_deque::install_counters(counters);
     // Whether this worker may raid siblings' deques, or is owner-only over
     // its own (iamacoffeepot/aether#1174). A per-process constant — read once
     // here, not per `acquire_slot`, and threaded into the steal scan.
@@ -680,4 +720,87 @@ mod tests {
     // is enough for the test harness to dispatch a handful of
     // counters before yielding.
     const BATCH_MAX_USEC_TEST: u64 = BATCH_MAX_USEC;
+
+    /// iamacoffeepot/aether#1129: the per-pool mechanism counters move in
+    /// the expected direction for a known topology. A relay chain on a
+    /// **single** worker keeps every forwarded hop on that worker's own
+    /// deque (the affinity warm path), so each forwarding wake is an
+    /// inline-run, never a futex unpark. Drives the inline-run counter
+    /// (the `WakeSink::schedule` `Ok` arm) and the injector-steal counter
+    /// (the entry wake spills from the test thread, which is off-worker).
+    #[test]
+    fn counters_track_inline_runs_on_single_worker_relay() {
+        let handle = standard_handle(1);
+        // Fresh pool — counters start at zero.
+        assert_eq!(
+            handle.scheduler_counters(),
+            SchedulerCountersSnapshot::default()
+        );
+
+        let depth = 8;
+        let slots = relay_chain(&handle, depth);
+        let entry = slots[0].clone();
+        let entry_dyn: Arc<dyn Drainable> = entry.clone();
+        let weak: Weak<dyn Drainable> = Arc::downgrade(&entry_dyn);
+        drop(entry_dyn);
+        let entry_wake = WakeHandle::new(entry.state.clone(), weak, handle.wake_sink());
+
+        let before = handle.scheduler_counters();
+        entry.push(1);
+        // The entry wake fires from the test thread (off-worker), so it
+        // spills to the injector and the lone worker steals it.
+        assert!(entry_wake.wake());
+
+        assert!(
+            wait_until(Duration::from_secs(5), || slots
+                .iter()
+                .all(|s| s.dispatched() >= 1)),
+            "every slot in the relay chain should dispatch its forwarded env"
+        );
+
+        let after = handle.scheduler_counters();
+        let delta = after.delta_since(&before);
+
+        // Each of the `depth - 1` forwarding hops runs on the single
+        // worker, which keeps the woken downstream slot on its own deque —
+        // an inline run, not a wakeup. At least one such hop must have
+        // inlined (the chain ran end-to-end on one worker).
+        assert!(
+            delta.inline_runs >= 1,
+            "single-worker relay should inline its forwarded hops, got {delta:?}"
+        );
+        // The entry slot was woken off-worker, so it spilled to the
+        // injector and the worker pulled it from there.
+        assert!(
+            delta.steals_injector >= 1,
+            "the off-worker entry wake should produce an injector steal, got {delta:?}"
+        );
+
+        drop(entry_wake);
+        let _ = handle.shutdown_with_results();
+    }
+
+    /// iamacoffeepot/aether#1129: `WakeSink::recruit` bumps the
+    /// recruiter-suppressed counter by exactly `requested − granted` when a
+    /// recruit asks for more siblings than the pool can field (the producer
+    /// drains its own copy, so the ceiling is `workers − 1`). A 2-worker
+    /// pool can grant only one sibling, so a request for three suppresses
+    /// two.
+    #[test]
+    fn counters_track_recruit_suppression() {
+        let handle = standard_handle(2);
+        let sink = handle.wake_sink();
+        let slot: Arc<dyn Drainable> = CounterSlot::new("recruit-target");
+
+        let before = handle.scheduler_counters();
+        // Ask for 3; the pool can field `workers - 1 == 1`, so 2 are suppressed.
+        sink.recruit(&slot, 3);
+        let delta = handle.scheduler_counters().delta_since(&before);
+        assert_eq!(
+            delta.recruit_suppressed, 2,
+            "recruit(3) on a 2-worker pool suppresses requested - (workers - 1) = 2"
+        );
+
+        let _ = handle.shutdown_with_results();
+    }
 }

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -407,9 +407,17 @@ impl WakeSink {
             worker_deque::time_budget(),
             worker_deque::hard_cap(),
         );
-        if let Err(slot) = kept {
-            self.injector.push(slot);
-            self.spin.notify();
+        match kept {
+            Ok(()) => {
+                // iamacoffeepot/aether#1129: kept on the producing worker's
+                // own deque — it runs LIFO without a futex wake. The win this
+                // counter measures (vs the slow-path unpark below).
+                self.spin.counters().note_inline_run();
+            }
+            Err(slot) => {
+                self.injector.push(slot);
+                self.spin.notify();
+            }
         }
     }
 
@@ -448,11 +456,20 @@ impl WakeSink {
     /// injector — each excess clone is a push + steal + `Arc` clone/drop and
     /// a no-op `run_cycle` on an already-drained cursor.
     pub(crate) fn recruit(&self, slot: &Arc<dyn Drainable>, count: usize) {
-        let count = count.min(self.workers.saturating_sub(1));
-        for _ in 0..count {
+        let granted = count.min(self.workers.saturating_sub(1));
+        // iamacoffeepot/aether#1129: the recruiter asked for `count` siblings
+        // but the pool could only field `granted` (the producer drains its own
+        // copy, so the ceiling is `workers - 1`). The clamped difference is the
+        // suppressed wakeups — the cost-aware recruiter (iamacoffeepot/aether#1178)
+        // sizing `recruit_k` below the available group count surfaces here.
+        // Pure instrumentation; never alters the wake count below.
+        self.spin
+            .counters()
+            .note_recruit_suppressed(count.saturating_sub(granted));
+        for _ in 0..granted {
             self.injector.push(Arc::clone(slot));
         }
-        self.spin.wake_workers(count);
+        self.spin.wake_workers(granted);
     }
 }
 

--- a/crates/aether-substrate/src/scheduler/spin_park.rs
+++ b/crates/aether-substrate/src/scheduler/spin_park.rs
@@ -60,6 +60,8 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread::{self, Thread, ThreadId};
 use std::time::{Duration, Instant};
 
+use crate::scheduler::counters::SchedulerCounters;
+
 /// Default spin-window length. The issue calls for "tens of µs": long
 /// enough to absorb a fan-out spill or a back-to-back relay hop without
 /// a futex wake, short enough that the idle tail between frames parks
@@ -133,26 +135,53 @@ pub struct SpinPark {
     /// it, so their difference is the live handoff latency
     /// (iamacoffeepot/aether#1182 Part 2).
     base: Instant,
+    /// Shared per-pool mechanism counters (iamacoffeepot/aether#1129). The
+    /// `notify` slow path bumps `notify_slow_unparks` here; the same Arc is
+    /// reached by [`crate::scheduler::WakeSink`] (via [`Self::counters`]) and
+    /// the worker-deque thread-local. Pure instrumentation — never gates a
+    /// wakeup decision, so it cannot affect lost-wakeup safety.
+    counters: Arc<SchedulerCounters>,
 }
 
 impl SpinPark {
-    /// Construct with the default spin window.
+    /// Construct with the default spin window and a fresh counter block.
     #[must_use]
     pub fn new() -> Self {
         Self::with_spin_window(Duration::from_micros(DEFAULT_SPIN_WINDOW_USEC))
     }
 
     /// Construct with an explicit spin window (chassis env override /
-    /// tests).
+    /// tests) and a fresh counter block.
     #[must_use]
     pub fn with_spin_window(spin_window: Duration) -> Self {
+        Self::with_spin_window_and_counters(spin_window, Arc::new(SchedulerCounters::new()))
+    }
+
+    /// Construct with an explicit spin window and a caller-supplied counter
+    /// block (iamacoffeepot/aether#1129). [`crate::scheduler::Pool::start`]
+    /// uses this so the spin-park, the worker deques, and the wake sink all
+    /// share one per-pool counter Arc.
+    #[must_use]
+    pub fn with_spin_window_and_counters(
+        spin_window: Duration,
+        counters: Arc<SchedulerCounters>,
+    ) -> Self {
         Self {
             spinning: AtomicUsize::new(0),
             idle: Mutex::new(Vec::new()),
             shutdown: AtomicBool::new(false),
             spin_window,
             base: Instant::now(),
+            counters,
         }
+    }
+
+    /// Borrow this coordinator's shared counter block — the
+    /// [`crate::scheduler::WakeSink`] reaches the per-pool counters through
+    /// it (iamacoffeepot/aether#1129).
+    #[must_use]
+    pub fn counters(&self) -> &Arc<SchedulerCounters> {
+        &self.counters
     }
 
     /// Nanos since [`Self::base`], saturating into `u64` — the stamp unit
@@ -199,6 +228,11 @@ impl SpinPark {
             // Diagnostic only — ordered after the lost-wakeup discipline,
             // never part of it.
             p.stamp.store(self.now_nanos(), Ordering::Relaxed);
+            // iamacoffeepot/aether#1129: count the slow-path futex unpark —
+            // the ~4.3µs handoff this coordinator routes away from. Bumped
+            // only on the genuine idle → first-event edge (no spinner); the
+            // route-to-spinner fast path above returned before reaching here.
+            self.counters.note_notify_slow_unpark();
             p.thread.unpark();
         }
     }

--- a/crates/aether-substrate/src/scheduler/worker_deque.rs
+++ b/crates/aether-substrate/src/scheduler/worker_deque.rs
@@ -432,30 +432,43 @@ pub fn steal_into_local(
         let worker = w.as_ref()?;
         // Retry the whole pass while any source reports transient
         // contention; return on the first success; `None` once all empty.
+        // Fold one source's `steal_batch_and_pop` outcome: a hit bumps the
+        // attributing counter (iamacoffeepot/aether#1129) and yields the slot;
+        // a transient-contention `Retry` sets the pass's retry flag; `Empty`
+        // yields nothing. Shared by the injector drain and each sibling raid.
+        let take =
+            |outcome: Steal<Slot>, note: fn(&SchedulerCounters), retry: &mut bool| match outcome {
+                Steal::Success(slot) => {
+                    with_counters(note);
+                    Some(slot)
+                }
+                Steal::Retry => {
+                    *retry = true;
+                    None
+                }
+                Steal::Empty => None,
+            };
         loop {
             let mut retry = false;
-            match injector.steal_batch_and_pop(worker) {
-                Steal::Success(slot) => {
-                    // iamacoffeepot/aether#1129: off-worker producers +
-                    // spilled fan-out + requeued yields.
-                    with_counters(SchedulerCounters::note_steal_injector);
-                    return Some(slot);
-                }
-                Steal::Retry => retry = true,
-                Steal::Empty => {}
+            // Injector drain (off-worker producers + spilled fan-out +
+            // requeued yields) — unconditional and load-bearing.
+            if let Some(slot) = take(
+                injector.steal_batch_and_pop(worker),
+                SchedulerCounters::note_steal_injector,
+                &mut retry,
+            ) {
+                return Some(slot);
             }
             if peer_steal {
                 for (i, stealer) in stealers.iter().enumerate() {
                     if i != my_idx {
-                        match stealer.steal_batch_and_pop(worker) {
-                            Steal::Success(slot) => {
-                                // iamacoffeepot/aether#1129: a sibling-tail
-                                // raid (only when `peer_steal` is opted in).
-                                with_counters(SchedulerCounters::note_steal_sibling);
-                                return Some(slot);
-                            }
-                            Steal::Retry => retry = true,
-                            Steal::Empty => {}
+                        // Sibling-tail raid (only when `peer_steal` is opted in).
+                        if let Some(slot) = take(
+                            stealer.steal_batch_and_pop(worker),
+                            SchedulerCounters::note_steal_sibling,
+                            &mut retry,
+                        ) {
+                            return Some(slot);
                         }
                     }
                 }

--- a/crates/aether-substrate/src/scheduler/worker_deque.rs
+++ b/crates/aether-substrate/src/scheduler/worker_deque.rs
@@ -49,6 +49,7 @@ use std::time::{Duration, Instant};
 use crossbeam_deque::{Injector, Steal, Stealer, Worker};
 
 use crate::scheduler::calibrate::handoff_cost;
+use crate::scheduler::counters::SchedulerCounters;
 use crate::scheduler::slot::Drainable;
 
 /// The unit on the deques: a chassis-registered dispatcher slot. (Phase
@@ -70,6 +71,13 @@ thread_local! {
     /// deposit path; `None` on non-worker threads (chassis main, hub,
     /// off-worker injects), where `pending_depth` reports `0`.
     static INJECTOR: RefCell<Option<Arc<Injector<Slot>>>> = const { RefCell::new(None) };
+
+    /// The shared per-pool mechanism counters (iamacoffeepot/aether#1129),
+    /// registered per worker by [`install_counters`] at the top of the
+    /// worker loop. [`steal_into_local`] bumps the injector / sibling steal
+    /// counts through it without threading a reference into the steal scan;
+    /// `None` on non-worker threads, where the steal-counting arms no-op.
+    static COUNTERS: RefCell<Option<Arc<SchedulerCounters>>> = const { RefCell::new(None) };
 
     /// Per-burst mail counter for the keep-local budget
     /// (iamacoffeepot/aether#1160). A *burst* is the run of local-deque work
@@ -101,6 +109,25 @@ pub fn install(worker: Worker<Slot>) {
 /// no-op effect on dispatch (depth is measurement-only).
 pub fn install_injector(injector: Arc<Injector<Slot>>) {
     INJECTOR.with(|i| *i.borrow_mut() = Some(injector));
+}
+
+/// Register the shared per-pool mechanism counters for this worker thread
+/// (iamacoffeepot/aether#1129) so [`steal_into_local`] can attribute its
+/// steals (injector vs sibling) without threading a reference into the
+/// scan. Called once alongside [`install`] at the top of the worker loop;
+/// pure instrumentation, no dispatch effect.
+pub fn install_counters(counters: Arc<SchedulerCounters>) {
+    COUNTERS.with(|c| *c.borrow_mut() = Some(counters));
+}
+
+/// Run `bump` against this worker's installed counter block, if any. A
+/// no-op off a pool worker (no counters installed).
+fn with_counters(bump: impl FnOnce(&SchedulerCounters)) {
+    COUNTERS.with(|c| {
+        if let Some(counters) = c.borrow().as_ref() {
+            bump(counters);
+        }
+    });
 }
 
 /// Scheduler ready-queue depth observed from this thread: this worker's
@@ -408,7 +435,12 @@ pub fn steal_into_local(
         loop {
             let mut retry = false;
             match injector.steal_batch_and_pop(worker) {
-                Steal::Success(slot) => return Some(slot),
+                Steal::Success(slot) => {
+                    // iamacoffeepot/aether#1129: off-worker producers +
+                    // spilled fan-out + requeued yields.
+                    with_counters(SchedulerCounters::note_steal_injector);
+                    return Some(slot);
+                }
                 Steal::Retry => retry = true,
                 Steal::Empty => {}
             }
@@ -416,7 +448,12 @@ pub fn steal_into_local(
                 for (i, stealer) in stealers.iter().enumerate() {
                     if i != my_idx {
                         match stealer.steal_batch_and_pop(worker) {
-                            Steal::Success(slot) => return Some(slot),
+                            Steal::Success(slot) => {
+                                // iamacoffeepot/aether#1129: a sibling-tail
+                                // raid (only when `peer_steal` is opted in).
+                                with_counters(SchedulerCounters::note_steal_sibling);
+                                return Some(slot);
+                            }
                             Steal::Retry => retry = true,
                             Steal::Empty => {}
                         }


### PR DESCRIPTION
Closes iamacoffeepot/aether#1129.

## Summary

The dispatch perf methodology couldn't see scheduling changes that trade wakeups for locality: the trial report measures only per-hop latency percentiles, but the win of a cost/locality change is *fewer wasted wakeups* — a count, not a latency — and run-to-run p50 variance is wakeup-dominated (100–1000× the signal), so no paired latency test can resolve it. (The other half of the original issue — a heterogeneous-cost workload — had already shipped via `busy_spin` / `work_iters` / the `*_heavy` topologies.)

This adds per-pool **mechanism counters** — an `Arc<SchedulerCounters>` of relaxed atomics (`notify_slow_unparks`, `recruit_suppressed`, `steals_injector`, `steals_sibling`, `inline_runs`) built at pool start and incremented at the four mechanism sites (notify slow-path unpark, injector/sibling steal, inline-run, recruiter suppression). They are a benign-race hint surface — a lost increment only undercounts a diagnostic, never affects dispatch. The harness brackets each cell's advance with two snapshots and records the delta; the trial report carries the counts (schema `aether.perf.trial.v4`) with a **deterministic** count-verdict (flag a change above a small absolute tolerance — no IQR/noise band, since counts are stable where latency isn't), surfaced in the "Compare dispatch perf vs merge-base" CI comment. Pure instrumentation — no scheduling-behavior change.

The throughput-under-saturation mode (the original issue's second deliverable) is carved into iamacoffeepot/aether#1202, which builds on this v4 report.

## Test plan

- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo doc --workspace --no-deps` (`-D warnings`), `cargo fmt -- --check`, wasm32 component cross-build — all green via `scripts/preflight.sh`.
- `cargo nextest run --workspace` — 1361 passed, 9 skipped. New unit tests: counter deltas move as expected across a 1-worker vs N-worker fan-out (`pool.rs`); `TestBench::scheduler_counters()` reads a non-zero delta after a fan-out advance; count-verdict fixtures (stable on equal, flagged on a clear delta) in `report.rs`.

## Generated by

`/implement` — agent execution of [scoped issue 1129](https://github.com/iamacoffeepot/aether/issues/1129).
