### PR TITLE
refactor(substrate): centralize the handoff-cost Duration→nanos conversion in a calibrate helper

### DIFF
--- a/crates/aether-substrate/src/actor/native/blob_work.rs
+++ b/crates/aether-substrate/src/actor/native/blob_work.rs
@@ -130,7 +130,9 @@ use crate::actor::native::blob_lifecycle::{Lifecycle, MAX_GROUPS, Published};
 use crate::mail::cost::CostLookup;
 use crate::mail::mailer::Mailer;
 use crate::mail::{KindId, Mail, MailboxId};
-use crate::scheduler::{BatchBudget, CycleResult, Drainable, SeizeHandle, WakeSink, handoff_cost};
+use crate::scheduler::{
+    BatchBudget, CycleResult, Drainable, SeizeHandle, WakeSink, handoff_cost_nanos,
+};
 
 /// Floor for a fresh blob's group-array capacity — a little headroom so a
 /// couple of subsequent flushes to *new* recipients can accumulate before
@@ -175,20 +177,6 @@ fn recruit_cap() -> usize {
     })
 }
 
-/// Fallback wake break-even in nanos. The live gate ([`wake_cost_nanos`])
-/// now reads the box-calibrated cross-worker handoff cost
-/// ([`handoff_cost`], iamacoffeepot/aether#1182) — the runtime-measured
-/// `C_wake` that iamacoffeepot/aether#1127 deferred, landed by
-/// iamacoffeepot/aether#1192. This const survives only as the
-/// `u64`-overflow fallback for that `Duration → nanos` conversion (never
-/// hit in practice — a handoff is µs-scale). `4_300` was the prior baked
-/// default (iamacoffeepot/aether#1200 named it `DEFAULT_`): iamacoffeepot/
-/// aether#1174's ~7µs injector pickup / park-wake floor. Below the
-/// break-even a flush can't amortize a sibling wakeup, so [`recruit_k`]
-/// returns `K = 1` and the blob stays producer-local — the cost-aware form
-/// of the prior narrow-local win (iamacoffeepot/aether#1116).
-const FALLBACK_WAKE_COST_NANOS: u64 = 4_300;
-
 /// High-MAD confidence threshold: a handler whose mean-absolute-deviation
 /// exceeds this fraction of its mean is "bimodal / untrustworthy" — its
 /// EWMA mean is a poor predictor of the next dispatch, so the recruiter
@@ -202,13 +190,14 @@ const MAD_CONFIDENCE_DEN: u64 = 1;
 
 /// The wake break-even in nanos. An `AETHER_WAKE_COST_NANOS` override wins
 /// and is fixed for the run (cached); otherwise this is the box-calibrated
-/// cross-worker handoff cost ([`handoff_cost`], iamacoffeepot/aether#1182),
-/// read live so it tracks the EWMA as it refines — the runtime-measured
-/// `C_wake` that iamacoffeepot/aether#1127 deferred. Mirrors the keep-local
-/// valve's source ([`crate::scheduler::time_budget`]), so both consumers of
-/// the shared handoff-cost seam scale with the box. [`FALLBACK_WAKE_COST_NANOS`]
-/// is only used if the measured nanos overflow `u64` (never in practice — a
-/// handoff is µs-scale).
+/// cross-worker handoff cost ([`crate::scheduler::handoff_cost`],
+/// iamacoffeepot/aether#1182) as a flat `u64` via [`handoff_cost_nanos`],
+/// read live so it tracks the
+/// EWMA as it refines — the runtime-measured `C_wake` that
+/// iamacoffeepot/aether#1127 deferred. Mirrors the keep-local valve's
+/// source ([`crate::scheduler::time_budget`]), so both consumers of the
+/// shared handoff-cost seam scale with the box. The conversion's saturating
+/// floor now lives in `handoff_cost_nanos`.
 fn wake_cost_nanos() -> u64 {
     static OVERRIDE: OnceLock<Option<u64>> = OnceLock::new();
     if let Some(ns) = *OVERRIDE.get_or_init(|| {
@@ -218,7 +207,7 @@ fn wake_cost_nanos() -> u64 {
     }) {
         return ns;
     }
-    u64::try_from(handoff_cost().as_nanos()).unwrap_or(FALLBACK_WAKE_COST_NANOS)
+    handoff_cost_nanos()
 }
 
 /// The cost-aware recruit target `K` (iamacoffeepot/aether#1178): how many

--- a/crates/aether-substrate/src/scheduler/calibrate.rs
+++ b/crates/aether-substrate/src/scheduler/calibrate.rs
@@ -181,6 +181,17 @@ pub fn handoff_cost() -> Duration {
     Duration::from_nanos(HANDOFF.mean().max(1))
 }
 
+/// [`handoff_cost`] as a flat `u64` of nanoseconds. Both nanos consumers
+/// — the boot-time keep-local calibration log and the recruit-K wake gate
+/// — read this so the `Duration → nanos` conversion lives in one place;
+/// the 1 ns floor stays in [`handoff_cost`]. Saturates to `u64::MAX` on
+/// overflow, which is unreachable: the estimate is a `u64` of nanos by
+/// construction, so the `Duration` can never exceed `u64::MAX` nanos.
+#[must_use]
+pub fn handoff_cost_nanos() -> u64 {
+    u64::try_from(handoff_cost().as_nanos()).unwrap_or(u64::MAX)
+}
+
 /// Fold one live `notify → wake` latency (nanos) into the estimate —
 /// called from [`super::spin_park`] each time a parked worker resumes from
 /// a producer's `unpark`. A no-op when the estimate is pinned. Dark: drives
@@ -218,7 +229,7 @@ fn parse_cost_override(raw: Option<String>) -> Option<u64> {
 /// `actor_logs` on any box (especially the CI VM) to confirm the budget
 /// landed where intended. Called once at chassis boot.
 pub fn log_handoff_calibration() {
-    let cost_ns = u64::try_from(handoff_cost().as_nanos()).unwrap_or(u64::MAX);
+    let cost_ns = handoff_cost_nanos();
     let budget_ns =
         u64::try_from(super::worker_deque::time_budget().as_nanos()).unwrap_or(u64::MAX);
     // Realized handoffs-per-budget on this box: `BUDGET_HANDOFF_MULTIPLIER`
@@ -337,6 +348,20 @@ mod tests {
         let b = handoff_cost();
         assert_eq!(a, b, "cached handoff cost must be stable across calls");
         assert!(a >= Duration::from_nanos(1));
+    }
+
+    #[test]
+    fn handoff_cost_nanos_matches_duration_view() {
+        let nanos = handoff_cost_nanos();
+        assert_eq!(
+            nanos,
+            u64::try_from(handoff_cost().as_nanos())
+                .expect("handoff_cost nanos fit u64 by construction")
+        );
+        assert!(
+            nanos >= 1,
+            "the 1 ns floor in handoff_cost must carry through"
+        );
     }
 
     #[test]

--- a/crates/aether-substrate/src/scheduler/mod.rs
+++ b/crates/aether-substrate/src/scheduler/mod.rs
@@ -40,7 +40,7 @@ mod slot;
 mod spin_park;
 mod worker_deque;
 
-pub use calibrate::{handoff_cost, log_handoff_calibration};
+pub use calibrate::{handoff_cost, handoff_cost_nanos, log_handoff_calibration};
 pub use pool::{Pool, PoolConfig, PoolHandle, PoolWorkerJoin};
 pub use slot::{
     BATCH_MAX_MAILS, BATCH_MAX_USEC, BatchBudget, CLOCK_CHECK_STRIDE, CycleResult, DrainOutcome,


### PR DESCRIPTION
Closes iamacoffeepot/aether#1196.

## Summary

`calibrate::handoff_cost()` returns a `Duration`, but its two nanos consumers each open-coded the same `u64::try_from(handoff_cost().as_nanos()).unwrap_or(_)` round-trip — `calibrate::log_handoff_calibration` and `blob_work::wake_cost_nanos` (the latter landed by iamacoffeepot/aether#1197). This folds the conversion into a single `calibrate::handoff_cost_nanos() -> u64` that delegates to `handoff_cost()`, so the seed and the 1 ns floor stay single-sourced and both call sites read a flat `u64`.

The two sites used different `unwrap_or` fallbacks (`u64::MAX` vs `FALLBACK_WAKE_COST_NANOS` = 4_300), but on a provably unreachable branch — `handoff_cost()` is `Duration::from_nanos` of a value that was already a `u64`, so `try_from` never fails. Collapsing on `u64::MAX` is therefore a true no-behaviour-change. `FALLBACK_WAKE_COST_NANOS` existed only to feed `wake_cost_nanos`'s now-removed `unwrap_or` (per its own doc), so it is dropped.

Pure refactor, no behaviour change. `worker_deque::derive_budget` keeps the `Duration` form untouched.

## Test plan

- New unit test `handoff_cost_nanos_matches_duration_view` asserts the helper equals the open-coded `Duration → nanos` view and that the 1 ns floor carries through.
- Existing `wake_gate` boundary tests cover the recruit-K gate behaviour at the break-even.
- Full local preflight green: fmt, clippy `--all-targets -D warnings`, `cargo doc` under the denied rustdoc lints (confirms no dangling intra-doc links after the import/const changes), nextest (1353 passed), wasm32 component cross-build.

## Generated by

`/implement` — agent execution of the scoped release issue.
