### PR TITLE
ci(workflow): revert blacksmith runner migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   changes:
     name: Detect changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
       qodana: ${{ steps.filter.outputs.qodana }}
@@ -40,7 +40,7 @@ jobs:
 
   fmt:
     name: Format
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -52,7 +52,7 @@ jobs:
     name: Clippy
     needs: changes
     if: needs.changes.outputs.code == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -68,7 +68,7 @@ jobs:
     name: Docs
     needs: changes
     if: needs.changes.outputs.code == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -99,7 +99,7 @@ jobs:
     name: Test (workspace, linux)
     needs: changes
     if: needs.changes.outputs.code == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     # Normal run is ≤ 2 min; cap at 15 so a hang doesn't eat the
     # default 6h quota before anyone notices. If this tripping
     # becomes routine, lower it — routine failure is a signal.
@@ -193,7 +193,7 @@ jobs:
     name: Qodana scan
     needs: changes
     if: needs.changes.outputs.qodana == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
@@ -286,7 +286,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, blacksmith-4vcpu-windows-2025 ]
+        os: [ macos-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -299,7 +299,7 @@ jobs:
     name: CI pass
     if: always()
     needs: [ changes, fmt, clippy, docs, test, desktop, qodana ]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Verify required jobs
         run: |

--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   enforce:
     name: Lint title and auto-apply type/crate labels
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/perf-compare.yml
+++ b/.github/workflows/perf-compare.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   changes:
     name: Detect dispatch-path changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       perf: ${{ steps.filter.outputs.perf }}
     steps:
@@ -51,7 +51,7 @@ jobs:
       !contains(github.event.pull_request.labels.*.name, 'perf-skip') &&
       (needs.changes.outputs.perf == 'true' ||
        contains(github.event.pull_request.labels.*.name, 'perf'))
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       # write — push the rendered plots to the `perf-plots` branch (a blob
       # store) so the public-repo raw URLs render inline in the sticky

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   lint:
     name: Lint PR title
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:


### PR DESCRIPTION
Reverts iamacoffeepot/aether#1209 (commit `30d7c1c`), restoring `runs-on: ubuntu-latest` across `ci.yml`, `issue-labels.yml`, `perf-compare.yml`, and `pr-title.yml`.

## Why

The CI stall that prompted the Blacksmith migration was a **transient GitHub Actions platform incident** (status red on 2026-05-26), not an account-level runner restriction. With Actions recovered, GitHub-hosted runners work normally, and the migrated workflows point at `blacksmith-4vcpu-*` runners that aren't provisioned — so they must return to GitHub-hosted to run at all.

Pure CI-config revert — no source change. A faster-runner setup (self-hosted box) can be revisited separately, without coupling it to a non-existent throttle.

## Note

Touches only `.github/**` (CI/repo-config-only preflight class). Must merge before iamacoffeepot/aether#1207 can go green, since that PR's CI inherits the runner labels from `main`.
