### PR TITLE
perf(substrate/scheduler): throughput-under-saturation harness mode

### DIFF
--- a/.github/workflows/perf-compare.yml
+++ b/.github/workflows/perf-compare.yml
@@ -62,7 +62,10 @@ jobs:
       pull-requests: write
     # Candidate build + interleaved trials. The base build is skipped on a
     # cache hit (iamacoffeepot/aether#1084) and shares the candidate's
-    # target dir when cold. Cap so a stall doesn't burn the quota.
+    # target dir when cold. The comparator runs twice — a latency pass and
+    # a saturate pass (iamacoffeepot/aether#1202) — so the *measurement*
+    # roughly doubles (the two release builds are shared across both
+    # passes; only the K interleaved trials repeat), still inside this cap.
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/crates/aether-substrate-bundle/src/bin/perf-compare.rs
+++ b/crates/aether-substrate-bundle/src/bin/perf-compare.rs
@@ -305,21 +305,27 @@ fn main() -> ExitCode {
 }
 
 /// Sum improved / stable / regressed across the compared sections of a
-/// report (uncompared sections contribute nothing).
+/// report — latency and throughput alike (iamacoffeepot/aether#1202).
+/// Uncompared sections contribute nothing.
 fn roll_up(report: &ComparisonReport) -> (usize, usize, usize) {
-    report.sections.iter().fold((0, 0, 0), |(i, s, r), sec| {
-        if let SectionReport::Compared {
-            improved,
-            stable,
-            regressed,
-            ..
-        } = sec
-        {
-            (i + improved, s + stable, r + regressed)
-        } else {
-            (i, s, r)
-        }
-    })
+    report
+        .sections
+        .iter()
+        .fold((0, 0, 0), |(i, s, r), sec| match sec {
+            SectionReport::Compared {
+                improved,
+                stable,
+                regressed,
+                ..
+            }
+            | SectionReport::ThroughputCompared {
+                improved,
+                stable,
+                regressed,
+                ..
+            } => (i + improved, s + stable, r + regressed),
+            SectionReport::Uncompared { .. } => (i, s, r),
+        })
 }
 
 #[cfg(test)]

--- a/crates/aether-substrate-bundle/src/bin/perf-plot.rs
+++ b/crates/aether-substrate-bundle/src/bin/perf-plot.rs
@@ -27,7 +27,7 @@ use std::path::Path;
 use std::process::ExitCode;
 
 use aether_substrate_bundle::perf::harness::{
-    CellSamples, SweepConfig, pace_hz_from_env, parse_topologies, parse_workers, run_sweep_samples,
+    CellSamples, SweepConfig, drive_from_env, parse_topologies, parse_workers, run_sweep_samples,
 };
 use plotters::prelude::*;
 use plotters::style::register_font;
@@ -63,7 +63,7 @@ fn main() -> ExitCode {
         workers: parse_workers(),
         topologies: parse_topologies(),
         frames,
-        pace_hz: pace_hz_from_env(),
+        drive: drive_from_env(),
     };
 
     let cells = run_sweep_samples(&cfg);

--- a/crates/aether-substrate-bundle/src/bin/perf-trial.rs
+++ b/crates/aether-substrate-bundle/src/bin/perf-trial.rs
@@ -11,7 +11,13 @@
 //! - `AETHER_PERF_TOPOS` — `ci` (depth-1/8 + fanout-4/8 + tree) or
 //!   `full` (the whole default set). Default `ci`.
 //! - `AETHER_PERF_FRAMES` — frames advanced per cell. Default `200`.
-//! - `AETHER_LAT_PACE_HZ` — pace one frame per period (else flat-out).
+//! - `AETHER_PERF_DRIVE` — `latency` (per-hop spans; default) or
+//!   `saturate` (completed mails/sec under a backlog flood,
+//!   iamacoffeepot/aether#1202).
+//! - `AETHER_PERF_BACKLOG` — per-tick `Ping` burst in `saturate` mode
+//!   (default `512`, clamped to the trace ring capacity).
+//! - `AETHER_LAT_PACE_HZ` — `latency` mode only: pace one frame per
+//!   period (else flat-out).
 //! - `AETHER_LAT_HEAVY_WORK` — when set, append CPU-heavy fan-outs
 //!   (iamacoffeepot/aether#1074); unset, the topology set is unchanged.
 //! - `AETHER_LAT_WIDE_FANOUT` — comma list of extra trivial fan-out
@@ -25,7 +31,7 @@ use std::env;
 use std::process::{Command, ExitCode};
 
 use aether_substrate_bundle::perf::harness::{
-    SweepConfig, pace_hz_from_env, parse_topologies, parse_workers, run_sweep,
+    Drive, SweepConfig, drive_from_env, parse_topologies, parse_workers, run_sweep,
 };
 use aether_substrate_bundle::perf::report::TrialReport;
 
@@ -50,20 +56,26 @@ fn main() -> ExitCode {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(200);
-    let pace_hz = pace_hz_from_env();
+    let drive = drive_from_env();
 
     let cfg = SweepConfig {
         workers: parse_workers(),
         topologies: parse_topologies(),
         frames,
-        pace_hz,
+        drive,
     };
     let cells = run_sweep(&cfg);
     if cells.is_empty() {
         eprintln!("perf-trial: no cells measured (no wgpu adapter, or every cell boot failed)");
         return ExitCode::from(2);
     }
-    let report = TrialReport::from_cells(&cells, frames, pace_hz, git_sha());
+    // A `Saturate` run emits the throughput section only (latency under
+    // saturation is contended noise); a `Latency` run emits the latency
+    // section as before (iamacoffeepot/aether#1202).
+    let report = match drive {
+        Drive::Saturate { .. } => TrialReport::from_throughput_cells(&cells, frames, git_sha()),
+        Drive::Latency { pace_hz } => TrialReport::from_cells(&cells, frames, pace_hz, git_sha()),
+    };
     match serde_json::to_string(&report) {
         Ok(json) => {
             println!("{json}");

--- a/crates/aether-substrate-bundle/src/perf/harness.rs
+++ b/crates/aether-substrate-bundle/src/perf/harness.rs
@@ -22,9 +22,10 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
+use aether_actor::trace_ring::DEFAULT_TRACE_RING_CAP;
 use aether_capabilities::trace_walk::fold_nodes;
 use aether_data::{Kind, KindId, MailboxId, mailbox_id_from_name};
-use aether_kinds::trace::{TraceRingEntry, TraceTail, TraceTailResult};
+use aether_kinds::trace::{MailNodeWire, TraceRingEntry, TraceTail, TraceTailResult};
 use aether_kinds::{SubscribeInput, SubscribeInputResult, Tick};
 use aether_substrate::{BootError, NativeActor, NativeCtx, NativeDispatch, NativeInitCtx, Subname};
 
@@ -143,13 +144,20 @@ pub fn relay_id(i: usize) -> MailboxId {
 }
 
 /// Lifecycle bridge for the sweep: subscribed to the `Tick` input
-/// stream, it emits one `Ping` into the entry relay per frame,
-/// inheriting the tick's trace lineage so the whole per-frame chain is
-/// one causal tree. The honest stand-in for a real tick-reactive
-/// component — the substrate's own `Tick` fan-out drives the work, no
-/// synthetic injector, no per-root settlement block.
+/// stream, it emits a burst of `burst` `Ping`s into the entry relay per
+/// frame, each inheriting the tick's trace lineage so the whole
+/// per-frame fan-out is one causal forest. The honest stand-in for a
+/// real tick-reactive component — the substrate's own `Tick` fan-out
+/// drives the work, no synthetic injector, no per-root settlement block.
+///
+/// `burst == 1` is the latency regime (one root per tick, settles within
+/// its frame). A larger `burst` is the saturation regime
+/// (iamacoffeepot/aether#1202): the whole burst lands on relay 0's inbox
+/// in one tick, so a single `advance(1)` drains a deep ready queue — the
+/// contention the per-frame `advance` quiescence otherwise prevents.
 pub struct TickSource {
     entry: MailboxId,
+    burst: u32,
     seq: u32,
 }
 
@@ -159,9 +167,16 @@ impl aether_actor::Actor for TickSource {
 impl aether_actor::Instanced for TickSource {}
 impl aether_actor::HandlesKind<Tick> for TickSource {}
 impl NativeActor for TickSource {
-    type Config = MailboxId;
-    fn init(entry: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-        Ok(Self { entry, seq: 0 })
+    /// `(entry, burst)`: the relay-0 mailbox and the number of `Ping`s to
+    /// emit per `Tick` (`1` in `Latency`, `backlog` in `Saturate`).
+    type Config = (MailboxId, u32);
+    fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        let (entry, burst) = config;
+        Ok(Self {
+            entry,
+            burst,
+            seq: 0,
+        })
     }
 }
 impl NativeDispatch for TickSource {
@@ -174,9 +189,11 @@ impl NativeDispatch for TickSource {
         if kind.0 != Tick::ID.0 {
             return None;
         }
-        let bytes = Ping { seq: self.seq }.encode_into_bytes();
-        self.seq = self.seq.wrapping_add(1);
-        let _ = ctx.send_envelope_traced(self.entry, Ping::ID, &bytes);
+        for _ in 0..self.burst {
+            let bytes = Ping { seq: self.seq }.encode_into_bytes();
+            self.seq = self.seq.wrapping_add(1);
+            let _ = ctx.send_envelope_traced(self.entry, Ping::ID, &bytes);
+        }
         Some(())
     }
 }
@@ -383,6 +400,11 @@ pub struct CellSamples {
     pub drain: Vec<u64>,
     pub handler: Vec<u64>,
     pub depth: Vec<u64>,
+    /// iamacoffeepot/aether#1202: completed mails/sec under saturation —
+    /// `Some` in `Drive::Saturate` (computed from the same folded nodes
+    /// the latency spans come from), `None` in `Drive::Latency`. A cell
+    /// whose entry ring lapped reports `None` rather than a wrong rate.
+    pub throughput_mps: Option<f64>,
 }
 
 impl CellSamples {
@@ -397,6 +419,7 @@ impl CellSamples {
             drain: summarize(self.drain),
             handler: summarize(self.handler),
             depth: summarize(self.depth),
+            throughput_mps: self.throughput_mps,
         }
     }
 }
@@ -429,19 +452,45 @@ pub struct CellResult {
     /// nanoseconds*. p50 ≈ 0 means `queued` is wakeup-dominated (empty
     /// queue); a rising tail means wait-behind-N (offered load).
     pub depth: Stats,
+    /// iamacoffeepot/aether#1202: completed mails/sec under saturation.
+    /// `Some` only in `Drive::Saturate` (`None` for a latency cell);
+    /// `None` too when the entry ring lapped, so a truncated cell never
+    /// reports a wrong rate.
+    pub throughput_mps: Option<f64>,
+}
+
+/// How a sweep cell drives its topology (iamacoffeepot/aether#1202). The
+/// two modes measure orthogonal properties from the *same* harvested
+/// trace nodes:
+///
+/// - `Latency` emits one `Ping` per `Tick` and measures per-hop spans
+///   (construct / queued / drain / handler). `pace_hz` `Some(hz)` paces
+///   one frame per period (workers park between frames → realistic
+///   frame-loop latency), `None` runs flat-out (warm — isolates per-hop
+///   dispatch cost). This is the harness's historical behaviour,
+///   verbatim.
+/// - `Saturate` emits a burst of `backlog` `Ping`s on each tick and
+///   measures completed mails/sec. `TestBench::advance` drains the queue
+///   to quiescence every frame (`bench.rs:630`), so one Ping per tick can
+///   never build a backlog — the burst is what creates the deep ready
+///   queue the throughput metric is meant to capture. Per-hop latency
+///   under saturation is contended and high-variance, so a saturate cell
+///   reports throughput only, not the latency spans.
+#[derive(Clone, Copy, Debug)]
+pub enum Drive {
+    Latency { pace_hz: Option<u64> },
+    Saturate { backlog: u32 },
 }
 
 /// Inputs to one sweep. `workers` is the outer axis (pool sizes);
-/// `topologies` the inner. `frames` advances per cell; `pace_hz`
-/// `Some(hz)` paces one frame per period (workers park between frames →
-/// realistic frame-loop latency), `None` runs flat-out (warm — isolates
-/// per-hop dispatch cost).
+/// `topologies` the inner. `frames` advances per cell; `drive` selects
+/// the latency or saturation regime (iamacoffeepot/aether#1202).
 #[derive(Clone)]
 pub struct SweepConfig {
     pub workers: Vec<usize>,
     pub topologies: Vec<Topology>,
     pub frames: u32,
-    pub pace_hz: Option<u64>,
+    pub drive: Drive,
 }
 
 /// Read the optional `AETHER_LAT_PACE_HZ` pacing override (frames/sec;
@@ -453,6 +502,47 @@ pub fn pace_hz_from_env() -> Option<u64> {
         .ok()
         .and_then(|s| s.parse().ok())
         .filter(|&h| h > 0)
+}
+
+/// Default per-tick `Ping` burst for a `Saturate` cell when
+/// `AETHER_PERF_BACKLOG` is unset. Sized comfortably under the per-actor
+/// trace ring capacity ([`DEFAULT_TRACE_RING_CAP`]) so a default-backlog
+/// run never laps the ring (see [`saturate_backlog_from_env`]).
+pub const DEFAULT_SATURATE_BACKLOG: u32 = 512;
+
+/// Read the per-tick saturation backlog from `AETHER_PERF_BACKLOG`
+/// (iamacoffeepot/aether#1202), defaulting to [`DEFAULT_SATURATE_BACKLOG`]
+/// when unset / unparseable / `0`. Clamped to the per-actor trace ring
+/// capacity ([`DEFAULT_TRACE_RING_CAP`]): a burst larger than the ring
+/// laps the entry relay's ring, which the harvest detects as `truncated`
+/// and the cell then reports no rate for. Clamping up front keeps a
+/// merely-large backlog measurable instead of silently truncated.
+#[must_use]
+pub fn saturate_backlog_from_env() -> u32 {
+    let cap = u32::try_from(DEFAULT_TRACE_RING_CAP).unwrap_or(u32::MAX);
+    env::var("AETHER_PERF_BACKLOG")
+        .ok()
+        .and_then(|s| s.parse::<u32>().ok())
+        .filter(|&b| b > 0)
+        .unwrap_or(DEFAULT_SATURATE_BACKLOG)
+        .min(cap)
+}
+
+/// Parse the `Drive` mode from `AETHER_PERF_DRIVE` (`latency` |
+/// `saturate`; default `latency`), composing `pace_hz_from_env` /
+/// `saturate_backlog_from_env` for the mode's own knob
+/// (iamacoffeepot/aether#1202). Shared by the `perf-trial` and `perf-plot`
+/// bins and the on-demand observe test so the parse lives in one place.
+#[must_use]
+pub fn drive_from_env() -> Drive {
+    match env::var("AETHER_PERF_DRIVE").as_deref() {
+        Ok("saturate") => Drive::Saturate {
+            backlog: saturate_backlog_from_env(),
+        },
+        _ => Drive::Latency {
+            pace_hz: pace_hz_from_env(),
+        },
+    }
 }
 
 /// Read the optional heavy-leaf CPU work knob `AETHER_LAT_HEAVY_WORK` (a
@@ -576,6 +666,38 @@ pub fn parse_topologies() -> Vec<Topology> {
     topos
 }
 
+/// Completed mails/sec from a cell's folded trace nodes
+/// (iamacoffeepot/aether#1202). Completed = `Ping` nodes that reached
+/// `t_finished`; the drive elapsed is `max(t_finished) − min(t_construct
+/// start)` across those nodes (construct-start is the earliest instant any
+/// participating mail was built, the honest start of the burst's
+/// processing). Returns `None` when nothing completed or the window
+/// collapsed to zero (single sample / clock-coincident), so the caller
+/// stores `None` rather than a divide-by-zero or infinite rate.
+#[allow(clippy::cast_precision_loss)]
+fn throughput_from_nodes(mails: &[MailNodeWire]) -> Option<f64> {
+    let mut completed = 0u64;
+    let mut min_start = u64::MAX;
+    let mut max_finish = 0u64;
+    for node in mails {
+        if node.kind.0 != Ping::ID.0 {
+            continue;
+        }
+        let Some(fin) = node.t_finished else { continue };
+        completed += 1;
+        min_start = min_start.min(node.t_construct_start.0);
+        max_finish = max_finish.max(fin.0);
+    }
+    if completed == 0 || max_finish <= min_start {
+        return None;
+    }
+    let elapsed_secs = (max_finish - min_start) as f64 / 1e9;
+    if elapsed_secs <= 0.0 {
+        return None;
+    }
+    Some(completed as f64 / elapsed_secs)
+}
+
 /// Drive the sweep and return each cell's **raw** per-span samples
 /// (un-summarized). [`run_sweep`] wraps this and collapses to
 /// [`CellResult`]; the `perf-plot` bin (iamacoffeepot/aether#1155) reads
@@ -623,8 +745,15 @@ pub fn run_sweep_samples(cfg: &SweepConfig) -> Vec<CellSamples> {
             if !spawned_ok {
                 continue;
             }
+            // `burst` is the per-tick `Ping` count: 1 in `Latency` (one
+            // root per frame), `backlog` in `Saturate` (a deep ready queue
+            // drained in one frame, iamacoffeepot/aether#1202).
+            let burst = match cfg.drive {
+                Drive::Latency { .. } => 1,
+                Drive::Saturate { backlog } => backlog,
+            };
             if let Err(e) = tb
-                .spawn_actor::<TickSource>(Subname::Named("src"), relay_id(0))
+                .spawn_actor::<TickSource>(Subname::Named("src"), (relay_id(0), burst))
                 .finish()
             {
                 tracing::warn!(target: "aether_perf", topo = %topo.name, error = ?e, "tick source spawn failed");
@@ -659,8 +788,10 @@ pub fn run_sweep_samples(cfg: &SweepConfig) -> Vec<CellSamples> {
             let frames = cfg.frames;
 
             // Drive via the real lifecycle.
-            match cfg.pace_hz {
-                Some(hz) => {
+            match cfg.drive {
+                Drive::Latency {
+                    pace_hz: Some(hz), ..
+                } => {
                     let period = Duration::from_secs_f64(1.0 / hz as f64);
                     for _ in 0..frames {
                         let f = Instant::now();
@@ -670,8 +801,23 @@ pub fn run_sweep_samples(cfg: &SweepConfig) -> Vec<CellSamples> {
                         }
                     }
                 }
-                None => {
+                Drive::Latency { pace_hz: None } => {
                     let _ = tb.advance(frames);
+                }
+                // Saturate: the tick source bursts `backlog` roots onto
+                // relay 0's inbox on a single tick, and one `advance(1)`
+                // drains the whole burst to quiescence in that frame
+                // (iamacoffeepot/aether#1202). The pool contends on a deep
+                // ready queue — the load the throughput metric captures —
+                // instead of the one-root-settles-per-frame latency path.
+                //
+                // It advances exactly once regardless of `cfg.frames`: the
+                // backlog *is* the offered load, so re-bursting every frame
+                // would multiply it by `frames` and lap the 4096-entry trace
+                // rings, tripping the truncation gate below and nulling the
+                // rate (the bug the `frames > 1` regression test guards).
+                Drive::Saturate { .. } => {
+                    let _ = tb.advance(1);
                 }
             }
 
@@ -772,6 +918,20 @@ pub fn run_sweep_samples(cfg: &SweepConfig) -> Vec<CellSamples> {
                     depth.push(u64::from(d));
                 }
             }
+
+            // iamacoffeepot/aether#1202: throughput rides the *same* folded
+            // nodes — completed = `Ping` nodes that reached `t_finished`,
+            // and the drive elapsed is `max(t_finished) − min(t_construct
+            // start)` across them. Only meaningful under `Saturate` (the
+            // latency modes never build a backlog), and only when the
+            // harvest is complete: a lapped ring drops finished nodes, so a
+            // truncated cell would report a low rate — refuse it rather than
+            // mislead.
+            let throughput_mps = match cfg.drive {
+                Drive::Saturate { .. } if !truncated => throughput_from_nodes(&mails),
+                _ => None,
+            };
+
             rows.push(CellSamples {
                 workers,
                 topo: topo.name.clone(),
@@ -780,6 +940,7 @@ pub fn run_sweep_samples(cfg: &SweepConfig) -> Vec<CellSamples> {
                 drain,
                 handler,
                 depth,
+                throughput_mps,
             });
         }
     }
@@ -796,4 +957,195 @@ pub fn run_sweep(cfg: &SweepConfig) -> Vec<CellResult> {
         .into_iter()
         .map(CellSamples::summarize)
         .collect()
+}
+
+#[cfg(test)]
+#[allow(clippy::print_stderr)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    /// Number of `Ping` nodes one root produces in `topo`: the entry send
+    /// (source → relay 0) plus one per edge in the DAG. A saturate cell's
+    /// completed count should be `backlog × this`.
+    fn hops_per_root(topo: &Topology) -> usize {
+        1 + topo.downstreams.iter().map(Vec::len).sum::<usize>()
+    }
+
+    /// Run a single (workers × topology) saturate cell and return its
+    /// samples, or `None` when no wgpu adapter is available (the cell list
+    /// comes back empty — a driverless box skips cleanly rather than
+    /// failing).
+    fn saturate_cell(workers: usize, topo: Topology, backlog: u32) -> Option<CellSamples> {
+        let cfg = SweepConfig {
+            workers: vec![workers],
+            topologies: vec![topo],
+            frames: 1,
+            drive: Drive::Saturate { backlog },
+        };
+        run_sweep_samples(&cfg).into_iter().next()
+    }
+
+    #[test]
+    fn saturate_cell_drains_full_backlog_and_reports_finite_rate() {
+        let topo = depth_chain(2);
+        let hops = hops_per_root(&topo);
+        let backlog = 64u32;
+        let Some(cell) = saturate_cell(2, topo, backlog) else {
+            eprintln!("skipping: no wgpu adapter");
+            return;
+        };
+        // One frame bursts `backlog` roots; `advance(1)` drains them all.
+        // Every relay hop completes (`t_received` + `t_finished`), so the
+        // handler-sample count is the completed-`Ping` count.
+        assert_eq!(
+            cell.handler.len(),
+            backlog as usize * hops,
+            "saturate should drain the whole backlog × hops-per-root"
+        );
+        let mps = cell.throughput_mps.expect("saturate cell reports a rate");
+        assert!(
+            mps.is_finite() && mps > 0.0,
+            "throughput must be positive and finite, got {mps}"
+        );
+    }
+
+    #[test]
+    fn throughput_rises_with_backlog_on_fixed_topology() {
+        // Latency mode never reports a rate; the historical path is intact.
+        let topo = fanout(4);
+        let small = saturate_cell(2, topo.clone(), 32);
+        let large = saturate_cell(2, topo, 256);
+        let (Some(small), Some(large)) = (small, large) else {
+            eprintln!("skipping: no wgpu adapter");
+            return;
+        };
+        // A wall-clock rate compared across two independently-timed runs is
+        // not robust under a contended test run: the two measurements see
+        // different system load, so even a generous tolerance flakes. The
+        // load-independent expression of "throughput scales with backlog" is
+        // the completed-work count — `advance(1)` drains to quiescence, so a
+        // larger backlog drains strictly more mails on a fixed topology
+        // regardless of how busy the machine is (the handler-sample count is
+        // the completed-`Ping` count). Assert that, plus that each run yields
+        // a well-formed (positive, finite) rate. The rate's *magnitude*
+        // relationship is the paired-delta comparator's job (ADR-0085), which
+        // cancels runner drift by pairing base/candidate on one runner.
+        for mps in [&small, &large].map(|c| c.throughput_mps.expect("saturate rate")) {
+            assert!(
+                mps.is_finite() && mps > 0.0,
+                "rate must be positive + finite: {mps}"
+            );
+        }
+        assert!(
+            large.handler.len() > small.handler.len(),
+            "more backlog must drain more mails: small={}, large={}",
+            small.handler.len(),
+            large.handler.len(),
+        );
+    }
+
+    #[test]
+    fn saturate_ignores_frame_count_and_still_reports_a_rate() {
+        // Regression guard (iamacoffeepot/aether#1202): `saturate_cell` above
+        // hardcodes `frames: 1`, but the `perf-trial` bin builds the sweep
+        // with AETHER_PERF_FRAMES (default 200). Saturate must advance
+        // exactly once regardless — re-bursting `backlog` roots every frame
+        // would multiply the offered load by `frames`, lap the 4096-entry
+        // trace rings, and trip the truncation gate so the cell reports no
+        // rate. That was the original bug: the trial emitted a throughput
+        // section with zero cells. A large frame count must still yield a
+        // finite rate.
+        let cfg = SweepConfig {
+            workers: vec![2],
+            topologies: vec![fanout(4)],
+            frames: 200,
+            drive: Drive::Saturate { backlog: 64 },
+        };
+        let Some(cell) = run_sweep_samples(&cfg).into_iter().next() else {
+            eprintln!("skipping: no wgpu adapter");
+            return;
+        };
+        let mps = cell
+            .throughput_mps
+            .expect("frames>1 saturate must still report a rate, not truncate to None");
+        assert!(
+            mps.is_finite() && mps > 0.0,
+            "rate must be positive + finite: {mps}"
+        );
+    }
+
+    #[test]
+    fn latency_mode_reports_no_throughput() {
+        let cfg = SweepConfig {
+            workers: vec![2],
+            topologies: vec![depth_chain(1)],
+            frames: 4,
+            drive: Drive::Latency { pace_hz: None },
+        };
+        let Some(cell) = run_sweep_samples(&cfg).into_iter().next() else {
+            eprintln!("skipping: no wgpu adapter");
+            return;
+        };
+        assert!(
+            cell.throughput_mps.is_none(),
+            "latency mode must not report a throughput rate"
+        );
+    }
+
+    #[test]
+    fn over_capacity_backlog_flags_truncation_not_a_wrong_rate() {
+        // A backlog past the per-actor ring capacity laps the entry
+        // source's ring (it holds one `Sent` per root). The harvest detects
+        // the lap and the cell reports no rate, rather than dividing an
+        // undercounted completed-count by the wall window
+        // (iamacoffeepot/aether#1202). depth-1 is the cheapest topology, so
+        // the lap is on the source ring's root count, not a busy relay's
+        // fan-out. The normal env path clamps below the cap, so this
+        // over-cap value is fed straight to the sweep.
+        let cap = u32::try_from(DEFAULT_TRACE_RING_CAP).unwrap_or(u32::MAX);
+        let Some(cell) = saturate_cell(2, depth_chain(1), cap + 1) else {
+            eprintln!("skipping: no wgpu adapter");
+            return;
+        };
+        assert!(
+            cell.throughput_mps.is_none(),
+            "an over-capacity backlog must flag truncation (no rate), not report a wrong one"
+        );
+    }
+
+    #[test]
+    fn over_capacity_backlog_is_clamped_by_env_parse() {
+        // The env parse clamps a backlog past the trace ring capacity so a
+        // merely-large `AETHER_PERF_BACKLOG` stays measurable. Serialised
+        // against the other env-reading test via a shared lock, since
+        // nextest runs tests in one process across threads.
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let cap = u32::try_from(DEFAULT_TRACE_RING_CAP).unwrap_or(u32::MAX);
+        // Safety: process-wide env mutation, serialised by `ENV_LOCK` and
+        // restored before the guard drops.
+        unsafe {
+            env::set_var("AETHER_PERF_BACKLOG", (cap + 10_000).to_string());
+        }
+        let parsed = saturate_backlog_from_env();
+        // Safety: same serialised env mutation — restore the cleared state.
+        unsafe {
+            env::remove_var("AETHER_PERF_BACKLOG");
+        }
+        assert_eq!(
+            parsed, cap,
+            "an over-capacity backlog clamps to the ring cap"
+        );
+    }
+
+    /// Serialises the `AETHER_PERF_BACKLOG`-mutating test against any other
+    /// env-reading test in this module.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn throughput_from_nodes_handles_degenerate_windows() {
+        // No completed nodes → no rate (rather than a divide-by-zero).
+        assert!(throughput_from_nodes(&[]).is_none());
+    }
 }

--- a/crates/aether-substrate-bundle/src/perf/report.rs
+++ b/crates/aether-substrate-bundle/src/perf/report.rs
@@ -144,6 +144,42 @@ impl LatencySection {
     pub const VERSION: &str = "v1";
 }
 
+/// One cell's measured throughput in a single trial
+/// (iamacoffeepot/aether#1202): completed mails/sec for a (worker ×
+/// topology) cell under saturation.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct ThroughputCell {
+    pub workers: usize,
+    pub topo: String,
+    pub mails_per_sec: f64,
+}
+
+impl ThroughputCell {
+    fn key(&self) -> ThroughputKey {
+        ThroughputKey {
+            workers: self.workers,
+            topo: self.topo.clone(),
+        }
+    }
+}
+
+/// The throughput section (iamacoffeepot/aether#1202): one
+/// completed-mails/sec rate per (worker × topology) cell, emitted only by
+/// a `Drive::Saturate` trial. Its own `version` evolves independently of
+/// the latency section's, so adding it never blinds the latency verdict.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct ThroughputSection {
+    pub cells: Vec<ThroughputCell>,
+}
+
+impl ThroughputSection {
+    /// The section name the comparator dispatches on. Mirrors the example
+    /// new section iamacoffeepot/aether#1206's fixtures already named.
+    pub const NAME: &str = "throughput";
+    /// The section version. Bumped when the throughput cell shape changes.
+    pub const VERSION: &str = "v1";
+}
+
 /// One fresh-process sweep run. The `perf-trial` bin emits this as JSON
 /// on stdout; the `perf-compare` bin collects K of each side.
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -226,6 +262,48 @@ impl TrialReport {
         }
     }
 
+    /// Build a *saturation* trial report from a sweep's [`CellResult`]s
+    /// (iamacoffeepot/aether#1202). A saturate run reports **throughput
+    /// only** — per-hop latency under saturation is contended and
+    /// high-variance, so pairing it would compare noise. Each cell with a
+    /// measured `throughput_mps` (a truncated cell carries `None` and is
+    /// skipped) contributes one [`ThroughputCell`]; the rows ride in a
+    /// single [`ThroughputSection`].
+    ///
+    /// [`CellResult`]: super::harness::CellResult
+    #[must_use]
+    pub fn from_throughput_cells(
+        cells: &[super::harness::CellResult],
+        frames: u32,
+        git_sha: Option<String>,
+    ) -> Self {
+        let rows: Vec<ThroughputCell> = cells
+            .iter()
+            .filter_map(|c| {
+                c.throughput_mps.map(|mps| ThroughputCell {
+                    workers: c.workers,
+                    topo: c.topo.clone(),
+                    mails_per_sec: mps,
+                })
+            })
+            .collect();
+        let throughput = ThroughputSection { cells: rows };
+        let body = serde_json::to_value(&throughput).unwrap_or(serde_json::Value::Null);
+        Self {
+            schema: TRIAL_SCHEMA.to_owned(),
+            git_sha,
+            // Saturation isn't paced — the backlog drains flat-out per
+            // frame — so `pace_hz` is `None`.
+            pace_hz: None,
+            frames,
+            sections: vec![RawSection {
+                name: ThroughputSection::NAME.to_owned(),
+                version: ThroughputSection::VERSION.to_owned(),
+                body,
+            }],
+        }
+    }
+
     /// The section with the given name, if present.
     fn section(&self, name: &str) -> Option<&RawSection> {
         self.sections.iter().find(|s| s.name == name)
@@ -276,6 +354,25 @@ struct CellKey {
     metric: Metric,
 }
 
+/// Pairing key for a throughput cell (iamacoffeepot/aether#1202) — a
+/// (worker × topology) cell, no metric/percentile axis since throughput
+/// is a single rate per cell.
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct ThroughputKey {
+    workers: usize,
+    topo: String,
+}
+
+/// Which direction of paired delta is the win (iamacoffeepot/aether#1202).
+/// Latency is lower-is-better (a negative delta improves); throughput is
+/// higher-is-better (a positive delta improves). The only verdict knob
+/// that differs between the two sections.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Direction {
+    LowerIsBetter,
+    HigherIsBetter,
+}
+
 /// Find the cell matching `key` in one trial's latency cells (a free fn,
 /// not a closure, so the borrow of the returned `&CellJson` ties to the
 /// slice's lifetime).
@@ -312,6 +409,25 @@ pub struct CellComparison {
     pub verdict: Verdict,
 }
 
+/// One compared throughput cell (iamacoffeepot/aether#1202): the
+/// base/candidate median rate (mails/sec) with its across-trial IQR band,
+/// plus the higher-is-better paired-delta verdict. The throughput analog
+/// of [`CellComparison`] — no metric/percentile axis, since throughput is
+/// a single rate per (worker × topology) cell.
+#[derive(Serialize, Clone, Debug)]
+pub struct ThroughputComparison {
+    pub workers: usize,
+    pub topo: String,
+    /// Mails/sec.
+    pub base_median: f64,
+    pub base_iqr: f64,
+    pub cand_median: f64,
+    pub cand_iqr: f64,
+    pub delta_median: f64,
+    pub delta_pct: f64,
+    pub verdict: Verdict,
+}
+
 /// Why a section couldn't be paired into a verdict
 /// (iamacoffeepot/aether#1206). Picked per case so the markdown note and
 /// the JSON report both spell out the reason rather than a bare "skipped".
@@ -332,8 +448,12 @@ pub enum UncomparedReason {
     UnknownName,
 }
 
-/// One section's outcome in a [`ComparisonReport`]: either a typed
-/// verdict grid (`Compared`) or a reasoned skip (`Uncompared`).
+/// One section's outcome in a [`ComparisonReport`]: a typed verdict grid
+/// (`Compared` for latency, `ThroughputCompared` for the saturation rate,
+/// iamacoffeepot/aether#1202) or a reasoned skip (`Uncompared`). The two
+/// compared variants carry the same headline counts so the rollup sums
+/// over both, but distinct cell payloads so each renders with its own
+/// table.
 #[derive(Serialize, Clone, Debug)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum SectionReport {
@@ -343,6 +463,13 @@ pub enum SectionReport {
         stable: usize,
         regressed: usize,
         cells: Vec<CellComparison>,
+    },
+    ThroughputCompared {
+        name: String,
+        improved: usize,
+        stable: usize,
+        regressed: usize,
+        cells: Vec<ThroughputComparison>,
     },
     Uncompared {
         name: String,
@@ -480,6 +607,11 @@ pub fn compare(base: &[TrialReport], cand: &[TrialReport], cfg: CompareConfig) -
                 let cand_cells = decode_latency_cells(&cand[..k]);
                 sections.push(compare_latency(name, &base_cells, &cand_cells, k, cfg));
             }
+            ThroughputSection::NAME => {
+                let base_cells = decode_throughput_cells(&base[..k]);
+                let cand_cells = decode_throughput_cells(&cand[..k]);
+                sections.push(compare_throughput(name, &base_cells, &cand_cells, k, cfg));
+            }
             _ => sections.push(SectionReport::Uncompared {
                 name: name.clone(),
                 reason: UncomparedReason::UnknownName,
@@ -558,7 +690,14 @@ fn compare_latency(
             let delta_median = median_sorted(&delta_sorted);
             let delta_iqr = iqr_sorted(&delta_sorted);
 
-            let verdict = classify(&deltas, delta_median, delta_iqr, base_median, cfg);
+            let verdict = classify(
+                &deltas,
+                delta_median,
+                delta_iqr,
+                base_median,
+                Direction::LowerIsBetter,
+                cfg,
+            );
             let delta_pct = if base_median > 0.0 {
                 delta_median / base_median * 100.0
             } else {
@@ -599,12 +738,133 @@ fn compare_latency(
     }
 }
 
+/// Per-trial throughput cells: decode each trial's `throughput` section
+/// body, dropping any trial whose body doesn't decode (it then can't
+/// satisfy the present-in-every-trial gate below, exactly as a missing
+/// cell does for latency).
+fn decode_throughput_cells(trials: &[TrialReport]) -> Vec<Vec<ThroughputCell>> {
+    trials
+        .iter()
+        .map(|t| {
+            t.section(ThroughputSection::NAME)
+                .and_then(|s| serde_json::from_value::<ThroughputSection>(s.body.clone()).ok())
+                .map(|tp| tp.cells)
+                .unwrap_or_default()
+        })
+        .collect()
+}
+
+/// Find the throughput cell matching `key` in one trial's cells (a free
+/// fn so the returned borrow ties to the slice's lifetime, mirroring
+/// [`find_cell`]).
+fn find_throughput_cell<'a>(
+    cells: &'a [ThroughputCell],
+    key: &ThroughputKey,
+) -> Option<&'a ThroughputCell> {
+    cells
+        .iter()
+        .find(|c| c.workers == key.workers && c.topo == key.topo)
+}
+
+/// The throughput section's per-cell paired-delta compare
+/// (iamacoffeepot/aether#1202) — mirrors [`compare_latency`], but keyed by
+/// (workers, topo) only (throughput is a single rate per cell, no
+/// metric/percentile axis) and classified higher-is-better. A cell missing
+/// from any trial of either side is dropped, exactly as in the latency
+/// compare.
+#[allow(clippy::cast_precision_loss)]
+fn compare_throughput(
+    name: &str,
+    base_cells: &[Vec<ThroughputCell>],
+    cand_cells: &[Vec<ThroughputCell>],
+    k: usize,
+    cfg: CompareConfig,
+) -> SectionReport {
+    let mut cells: Vec<ThroughputComparison> = Vec::new();
+
+    let keys: Vec<ThroughputKey> = base_cells
+        .first()
+        .map(|c| c.iter().map(ThroughputCell::key).collect())
+        .unwrap_or_default();
+
+    for key in &keys {
+        let base_hits: Vec<&ThroughputCell> = base_cells[..k.min(base_cells.len())]
+            .iter()
+            .filter_map(|c| find_throughput_cell(c, key))
+            .collect();
+        let cand_hits: Vec<&ThroughputCell> = cand_cells[..k.min(cand_cells.len())]
+            .iter()
+            .filter_map(|c| find_throughput_cell(c, key))
+            .collect();
+        if base_hits.len() != k || cand_hits.len() != k || k == 0 {
+            continue; // cell not present in every trial — skip
+        }
+
+        let base_vals: Vec<f64> = base_hits.iter().map(|c| c.mails_per_sec).collect();
+        let cand_vals: Vec<f64> = cand_hits.iter().map(|c| c.mails_per_sec).collect();
+        let deltas: Vec<f64> = (0..k).map(|t| cand_vals[t] - base_vals[t]).collect();
+
+        let base_sorted = sorted(base_vals.clone());
+        let cand_sorted = sorted(cand_vals.clone());
+        let delta_sorted = sorted(deltas.clone());
+
+        let base_median = median_sorted(&base_sorted);
+        let cand_median = median_sorted(&cand_sorted);
+        let delta_median = median_sorted(&delta_sorted);
+        let delta_iqr = iqr_sorted(&delta_sorted);
+
+        let verdict = classify(
+            &deltas,
+            delta_median,
+            delta_iqr,
+            base_median,
+            Direction::HigherIsBetter,
+            cfg,
+        );
+        let delta_pct = if base_median > 0.0 {
+            delta_median / base_median * 100.0
+        } else {
+            0.0
+        };
+
+        cells.push(ThroughputComparison {
+            workers: key.workers,
+            topo: key.topo.clone(),
+            base_median,
+            base_iqr: iqr_sorted(&base_sorted),
+            cand_median,
+            cand_iqr: iqr_sorted(&cand_sorted),
+            delta_median,
+            delta_pct,
+            verdict,
+        });
+    }
+
+    let improved = cells
+        .iter()
+        .filter(|c| c.verdict == Verdict::Improved)
+        .count();
+    let regressed = cells
+        .iter()
+        .filter(|c| c.verdict == Verdict::Regressed)
+        .count();
+    let stable = cells.len() - improved - regressed;
+    SectionReport::ThroughputCompared {
+        name: name.to_owned(),
+        improved,
+        stable,
+        regressed,
+        cells,
+    }
+}
+
 #[allow(clippy::cast_precision_loss)]
 fn classify(
     deltas: &[f64],
     delta_median: f64,
     delta_iqr: f64,
     base_median: f64,
+    dir: Direction,
     cfg: CompareConfig,
 ) -> Verdict {
     if deltas.is_empty() || delta_median == 0.0 {
@@ -617,19 +877,34 @@ fn classify(
         .count() as f64;
     let consistent = same_sign / n >= cfg.consistency;
 
+    // The absolute floor (`abs_floor_ns`) is a *nanosecond* resolution
+    // floor — meaningful for a latency span, meaningless for a mails/sec
+    // rate (iamacoffeepot/aether#1202). For a higher-is-better rate the
+    // verdict rests on the IQR + relative floors only; the ns floor is
+    // neutralised to zero.
+    let abs_floor = match dir {
+        Direction::LowerIsBetter => cfg.abs_floor_ns,
+        Direction::HigherIsBetter => 0.0,
+    };
     let floor = (cfg.effect_floor_iqr * delta_iqr)
         .max(cfg.rel_floor * base_median)
-        .max(cfg.abs_floor_ns);
+        .max(abs_floor);
     let large = delta_median.abs() > floor;
 
-    if consistent && large {
-        if delta_median < 0.0 {
-            Verdict::Improved
-        } else {
-            Verdict::Regressed
-        }
+    if !(consistent && large) {
+        return Verdict::Stable;
+    }
+    // A negative paired delta means the candidate's value fell; whether
+    // that reads `Improved` depends on the metric's direction.
+    let value_fell = delta_median < 0.0;
+    let improved = match dir {
+        Direction::LowerIsBetter => value_fell,
+        Direction::HigherIsBetter => !value_fell,
+    };
+    if improved {
+        Verdict::Improved
     } else {
-        Verdict::Stable
+        Verdict::Regressed
     }
 }
 
@@ -657,16 +932,24 @@ pub fn markdown(report: &ComparisonReport, title: &str, subtitle: &str) -> Strin
 
     let (mut improved, mut stable, mut regressed) = (0usize, 0usize, 0usize);
     for sec in &report.sections {
-        if let SectionReport::Compared {
-            improved: i,
-            stable: st,
-            regressed: r,
-            ..
-        } = sec
-        {
-            improved += i;
-            stable += st;
-            regressed += r;
+        match sec {
+            SectionReport::Compared {
+                improved: i,
+                stable: st,
+                regressed: r,
+                ..
+            }
+            | SectionReport::ThroughputCompared {
+                improved: i,
+                stable: st,
+                regressed: r,
+                ..
+            } => {
+                improved += i;
+                stable += st;
+                regressed += r;
+            }
+            SectionReport::Uncompared { .. } => {}
         }
     }
     s.push_str(&format!(
@@ -679,6 +962,9 @@ pub fn markdown(report: &ComparisonReport, title: &str, subtitle: &str) -> Strin
             SectionReport::Compared { name, cells, .. } => {
                 push_latency_section(&mut s, name, cells);
             }
+            SectionReport::ThroughputCompared { name, cells, .. } => {
+                push_throughput_section(&mut s, name, cells);
+            }
             SectionReport::Uncompared { name, .. } => {
                 s.push_str(&format!(
                     "_{name}: new this run — no baseline to compare_\n\n"
@@ -687,6 +973,42 @@ pub fn markdown(report: &ComparisonReport, title: &str, subtitle: &str) -> Strin
         }
     }
     s
+}
+
+/// Shared tail for a compared section's markdown: the non-stable rows (or
+/// a "no cells moved" note when none did), then the collapsed full grid.
+/// `push_latency_section` and `push_throughput_section` each build their
+/// own header + per-row rendering and hand the rendered rows here, so the
+/// table scaffolding lives in one place.
+#[allow(clippy::format_push_string)]
+fn push_section_tables(
+    s: &mut String,
+    name: &str,
+    header: &str,
+    non_stable: &[String],
+    all: &[String],
+) {
+    if non_stable.is_empty() {
+        s.push_str(&format!(
+            "_{name}: no cells moved beyond the noise band._\n\n"
+        ));
+    } else {
+        s.push_str(header);
+        for r in non_stable {
+            s.push_str(r);
+        }
+        s.push('\n');
+    }
+
+    s.push_str(&format!(
+        "<details><summary>{name} full grid — {} cells</summary>\n\n",
+        all.len()
+    ));
+    s.push_str(header);
+    for r in all {
+        s.push_str(r);
+    }
+    s.push_str("\n</details>\n\n");
 }
 
 #[allow(clippy::format_push_string)]
@@ -713,31 +1035,55 @@ fn push_latency_section(s: &mut String, name: &str, cells: &[CellComparison]) {
         )
     };
 
-    let non_stable: Vec<&CellComparison> = cells
+    let all: Vec<String> = cells.iter().map(&row).collect();
+    let non_stable: Vec<String> = cells
         .iter()
         .filter(|c| c.verdict != Verdict::Stable)
+        .map(&row)
         .collect();
-    if non_stable.is_empty() {
-        s.push_str(&format!(
-            "_{name}: no cells moved beyond the noise band._\n\n"
-        ));
-    } else {
-        s.push_str(header);
-        for c in non_stable {
-            s.push_str(&row(c));
-        }
-        s.push('\n');
-    }
+    push_section_tables(s, name, header, &non_stable, &all);
+}
 
-    s.push_str(&format!(
-        "<details><summary>{name} full grid — {} cells</summary>\n\n",
-        cells.len()
-    ));
-    s.push_str(header);
-    for c in cells {
-        s.push_str(&row(c));
-    }
-    s.push_str("\n</details>\n\n");
+/// Render the throughput section (iamacoffeepot/aether#1202) — the
+/// higher-is-better mails/sec analog of [`push_latency_section`]:
+/// non-stable rows up top, full grid collapsed, rates in thousands of
+/// mails/sec.
+#[allow(clippy::format_push_string)]
+fn push_throughput_section(s: &mut String, name: &str, cells: &[ThroughputComparison]) {
+    let header =
+        "| topology | w | base k/s | this k/s | Δ | verdict |\n|---|--:|--:|--:|--:|---|\n";
+    let row = |c: &ThroughputComparison| -> String {
+        let verdict = match c.verdict {
+            Verdict::Improved => "improved",
+            Verdict::Stable => "stable",
+            Verdict::Regressed => "regressed",
+        };
+        format!(
+            "| {} | {} | {} ±{} | {} ±{} | {:+.0}% | {} |\n",
+            c.topo,
+            c.workers,
+            kps(c.base_median),
+            kps(c.base_iqr),
+            kps(c.cand_median),
+            kps(c.cand_iqr),
+            c.delta_pct,
+            verdict,
+        )
+    };
+
+    let all: Vec<String> = cells.iter().map(&row).collect();
+    let non_stable: Vec<String> = cells
+        .iter()
+        .filter(|c| c.verdict != Verdict::Stable)
+        .map(&row)
+        .collect();
+    push_section_tables(s, name, header, &non_stable, &all);
+}
+
+/// Format a mails/sec rate in thousands (k/s), mirroring [`us`]'s
+/// scale-and-fixed-precision rendering for the latency table.
+fn kps(mps: f64) -> String {
+    format!("{:.1}", mps / 1000.0)
 }
 
 #[cfg(test)]
@@ -949,7 +1295,7 @@ mod tests {
             SectionReport::Uncompared { reason, .. } => {
                 assert_eq!(*reason, UncomparedReason::NewThisRun);
             }
-            SectionReport::Compared { .. } => panic!("throughput should not be compared"),
+            _ => panic!("throughput should not be compared"),
         }
     }
 
@@ -957,20 +1303,22 @@ mod tests {
     fn unknown_section_on_both_sides_reads_unknown_name() {
         // Present on both sides at an agreed version but with no typed
         // compare — that's the UnknownName reason, distinct from
-        // NewThisRun.
-        let base = with_extra_section(side(&[1000, 1000, 1000]), "throughput", "v1");
-        let cand = with_extra_section(side(&[1000, 1000, 1000]), "throughput", "v1");
+        // NewThisRun. (`throughput` is now a *known* section — this guard
+        // needs a name the comparator still has no compare for, so it uses
+        // `experimental`. iamacoffeepot/aether#1202.)
+        let base = with_extra_section(side(&[1000, 1000, 1000]), "experimental", "v1");
+        let cand = with_extra_section(side(&[1000, 1000, 1000]), "experimental", "v1");
         let rep = compare(&base, &cand, CompareConfig::default());
         let unknown = rep
             .sections
             .iter()
-            .find(|s| matches!(s, SectionReport::Uncompared { name, .. } if name == "throughput"))
-            .expect("uncompared throughput section present");
+            .find(|s| matches!(s, SectionReport::Uncompared { name, .. } if name == "experimental"))
+            .expect("uncompared experimental section present");
         match unknown {
             SectionReport::Uncompared { reason, .. } => {
                 assert_eq!(*reason, UncomparedReason::UnknownName);
             }
-            SectionReport::Compared { .. } => panic!("throughput should not be compared"),
+            _ => panic!("experimental should not be compared"),
         }
     }
 
@@ -1013,7 +1361,7 @@ mod tests {
                     }
                 );
             }
-            SectionReport::Compared { .. } => panic!("latency should not compare across versions"),
+            _ => panic!("latency should not compare across versions"),
         }
 
         // The `extra` section (v1 on both) still resolves — to UnknownName,
@@ -1036,5 +1384,122 @@ mod tests {
         assert!(md.contains("| topology | w | metric |"));
         // ... and the uncompared section's note rides alongside it.
         assert!(md.contains("throughput: new this run"));
+    }
+
+    /// Build a K-trial side carrying a single `throughput` section cell
+    /// (`fanout-8 @ 11w`) whose rate follows `rates` (mails/sec). The
+    /// throughput analog of [`side`] (iamacoffeepot/aether#1202).
+    fn throughput_side(rates: &[f64]) -> Vec<TrialReport> {
+        rates
+            .iter()
+            .map(|&mails_per_sec| {
+                let cells = vec![ThroughputCell {
+                    workers: 11,
+                    topo: "fanout-8".to_owned(),
+                    mails_per_sec,
+                }];
+                let body = serde_json::to_value(ThroughputSection { cells })
+                    .expect("encode throughput body");
+                TrialReport {
+                    schema: TRIAL_SCHEMA.to_owned(),
+                    git_sha: None,
+                    pace_hz: None,
+                    frames: 200,
+                    sections: vec![RawSection {
+                        name: ThroughputSection::NAME.to_owned(),
+                        version: ThroughputSection::VERSION.to_owned(),
+                        body,
+                    }],
+                }
+            })
+            .collect()
+    }
+
+    /// The single throughput cell's verdict in a comparison report.
+    fn throughput_verdict(rep: &ComparisonReport) -> Verdict {
+        rep.sections
+            .iter()
+            .find_map(|s| match s {
+                SectionReport::ThroughputCompared { cells, .. } => cells.first().map(|c| c.verdict),
+                _ => None,
+            })
+            .expect("compared throughput cell present")
+    }
+
+    #[test]
+    fn higher_throughput_reads_improved_not_regressed() {
+        // Throughput is higher-is-better: a clearly-higher candidate rate
+        // is an Improvement, even though its paired delta is *positive*
+        // (the opposite of a latency win).
+        let base = throughput_side(&[
+            100_000.0, 98_000.0, 102_000.0, 99_000.0, 101_000.0, 100_500.0,
+        ]);
+        let cand = throughput_side(&[
+            200_000.0, 198_000.0, 202_000.0, 199_000.0, 201_000.0, 200_500.0,
+        ]);
+        let rep = compare(&base, &cand, CompareConfig::default());
+        assert_eq!(throughput_verdict(&rep), Verdict::Improved);
+    }
+
+    #[test]
+    fn lower_throughput_reads_regressed() {
+        // A clearly-lower candidate rate is a regression (a negative
+        // paired delta, the inverse of the latency direction).
+        let base = throughput_side(&[
+            200_000.0, 198_000.0, 202_000.0, 199_000.0, 201_000.0, 200_500.0,
+        ]);
+        let cand = throughput_side(&[
+            100_000.0, 98_000.0, 102_000.0, 99_000.0, 101_000.0, 100_500.0,
+        ]);
+        let rep = compare(&base, &cand, CompareConfig::default());
+        assert_eq!(throughput_verdict(&rep), Verdict::Regressed);
+    }
+
+    #[test]
+    fn equal_throughput_reads_stable() {
+        // Near-identical rates pair to δ ≈ 0 — below the noise band, so
+        // stable regardless of the ns floor (neutralised for a rate).
+        let base = throughput_side(&[
+            100_000.0, 99_000.0, 101_000.0, 100_500.0, 99_500.0, 100_000.0,
+        ]);
+        let cand = throughput_side(&[
+            100_200.0, 99_100.0, 101_100.0, 100_400.0, 99_600.0, 100_100.0,
+        ]);
+        let rep = compare(&base, &cand, CompareConfig::default());
+        assert_eq!(throughput_verdict(&rep), Verdict::Stable);
+    }
+
+    #[test]
+    fn report_json_round_trip_preserves_throughput_section() {
+        let trials = throughput_side(&[100_000.0, 110_000.0, 120_000.0]);
+        let report = &trials[0];
+        let json = serde_json::to_string(report).expect("serialize trial");
+        let back: TrialReport = serde_json::from_str(&json).expect("deserialize trial");
+        assert_eq!(back.sections.len(), 1);
+        let sec = &back.sections[0];
+        assert_eq!(sec.name, ThroughputSection::NAME);
+        assert_eq!(sec.version, ThroughputSection::VERSION);
+        let tp: ThroughputSection =
+            serde_json::from_value(sec.body.clone()).expect("decode throughput body");
+        assert_eq!(tp.cells.len(), 1);
+        assert!((tp.cells[0].mails_per_sec - 100_000.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn throughput_verdict_renders_in_markdown() {
+        // Step 4 round-trip: a report carrying a throughput section flows
+        // through `compare` → `markdown` and the higher-is-better verdict
+        // shows in the rendered body (the per-section dispatch routes it,
+        // no perf-compare change needed).
+        let base = throughput_side(&[100_000.0, 98_000.0, 102_000.0, 99_000.0]);
+        let cand = throughput_side(&[200_000.0, 198_000.0, 202_000.0, 199_000.0]);
+        let rep = compare(&base, &cand, CompareConfig::default());
+        let md = markdown(&rep, "PR 9999 vs main", "test");
+        assert!(md.contains(STICKY_MARKER));
+        // The throughput table header (k/s units), the headline rollup
+        // counting the win, and the improved verdict are all present.
+        assert!(md.contains("| topology | w | base k/s |"));
+        assert!(md.contains("improved"));
+        assert!(md.contains("throughput full grid"));
     }
 }

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -31,7 +31,7 @@ use aether_substrate::{BootError, NativeActor, NativeCtx, NativeDispatch, Native
 
 use super::TestBench;
 use crate::perf::harness::{
-    CellResult, Ping, Relay, RelayConfig, Stats, SweepConfig, Topology, default_topologies,
+    CellResult, Drive, Ping, Relay, RelayConfig, Stats, SweepConfig, Topology, default_topologies,
     depth_chain, fanout, fanout_heavy, heavy_work_iters_from_env, pace_hz_from_env, relay_id,
     run_sweep, summarize, two_level_tree, wide_fanout_widths_from_env,
 };
@@ -668,7 +668,7 @@ fn lifecycle_latency_observe() {
         workers: worker_set,
         topologies,
         frames: OBSERVE_FRAMES,
-        pace_hz,
+        drive: Drive::Latency { pace_hz },
     };
     let rows = run_sweep(&cfg);
     if rows.is_empty() {

--- a/scripts/perf-compare.sh
+++ b/scripts/perf-compare.sh
@@ -29,6 +29,11 @@
 #   AETHER_PERF_WORKERS  pool sizes (default "max,2")
 #   AETHER_PERF_FRAMES   frames per cell (default 200)
 #   AETHER_PERF_TOPOS    "ci" | "full" (default "ci")
+#   AETHER_PERF_BACKLOG  per-tick Ping burst for the saturate pass
+#                        (default 512; iamacoffeepot/aether#1202). Set
+#                        per pass internally — AETHER_PERF_DRIVE is NOT a
+#                        caller knob here; the script always runs both a
+#                        latency and a saturate pass and merges them.
 #   PERF_BASE_CACHE      file path for the cross-run base-binary cache
 #                        (set by the workflow; unset locally = always build)
 #   PERF_BASE_ENV        space-separated KEY=VALUE list applied as env to
@@ -149,17 +154,59 @@ EOF
     fi
 fi
 
-# Interleave K trials per side on this runner; render JSON + markdown.
-echo "[perf-compare] running $K interleaved trials per side…"
-"$compare_bin" \
+# A single comparator run is single-mode: AETHER_PERF_DRIVE applies to
+# *both* the base and candidate trial subprocesses, so one run yields
+# either the latency section or the throughput section, never both
+# (iamacoffeepot/aether#1202). Run the comparator twice — a latency pass
+# and a saturate pass — then concatenate the two rendered bodies into one
+# perf-report.md, stripping the second body's duplicate STICKY_MARKER (its
+# first line) so the workflow's marker-based upsert still matches a single
+# sticky comment. Each metric is then measured in its proper regime and
+# both land in the same comment. The release builds above are shared
+# across both passes; only the K interleaved trials repeat.
+sticky_marker='<!-- aether-perf-report -->'
+backlog="${AETHER_PERF_BACKLOG:-512}"
+
+# Pass 1: latency (today's behaviour). Writes the JSON report + the
+# primary markdown body (the STICKY_MARKER rides on its first line).
+echo "[perf-compare] pass 1/2: latency — $K interleaved trials per side…"
+AETHER_PERF_DRIVE=latency "$compare_bin" \
     --base "$base_trial" \
     --cand "$cand_trial" \
     ${base_env_args[@]+"${base_env_args[@]}"} \
     ${cand_env_args[@]+"${cand_env_args[@]}"} \
     -k "$K" \
     --out "$json_out" \
-    --title "PR vs merge-base $base_short" \
+    --title "latency — PR vs merge-base $base_short" \
     --subtitle "baseline $base_short · $K trials/config, interleaved on one runner$pin_note" \
     > "$md_out"
+
+# Pass 2: throughput under saturation. Drive both subprocesses in
+# saturate mode with the same backlog. Append its body to perf-report.md
+# with the leading STICKY_MARKER line dropped (tail -n +2), keeping a
+# single marker in the merged comment.
+echo "[perf-compare] pass 2/2: saturate (backlog=$backlog) — $K interleaved trials per side…"
+sat_md="$work/perf-report-saturate.md"
+AETHER_PERF_DRIVE=saturate AETHER_PERF_BACKLOG="$backlog" "$compare_bin" \
+    --base "$base_trial" \
+    --cand "$cand_trial" \
+    ${base_env_args[@]+"${base_env_args[@]}"} \
+    ${cand_env_args[@]+"${cand_env_args[@]}"} \
+    -k "$K" \
+    --title "throughput (saturation, backlog $backlog) — PR vs merge-base $base_short" \
+    --subtitle "baseline $base_short · $K trials/config, interleaved on one runner$pin_note" \
+    > "$sat_md"
+
+{
+    printf '\n'
+    tail -n +2 "$sat_md"
+} >> "$md_out"
+
+# Belt-and-braces: the merged body must carry exactly one sticky marker so
+# the workflow's upsert edits a single comment in place.
+marker_count="$(grep -cF "$sticky_marker" "$md_out" || true)"
+if [ "$marker_count" -ne 1 ]; then
+    echo "[perf-compare] WARNING: merged perf-report.md has $marker_count sticky markers (expected 1)" >&2
+fi
 
 echo "[perf-compare] wrote $json_out and $md_out"


### PR DESCRIPTION
Closes iamacoffeepot/aether#1202.

## Summary

The dispatch perf harness measured only per-hop latency; it had no way to *saturate* a topology and measure completed mails/sec — the metric that exposes a cost/locality scheduling change as better worker utilization under load. This adds a saturation drive mode and surfaces throughput end-to-end on iamacoffeepot/aether#1208's per-section report.

- **Drive mode** (`perf/harness.rs`): `SweepConfig.pace_hz` generalised to a `Drive { Latency { pace_hz }, Saturate { backlog } }` enum. The entry `TickSource` gained a per-tick burst (`1` in latency, `backlog` in saturate); because `TestBench::advance` drains the queue to quiescence every frame, saturation bursts `backlog` roots on one tick and `advance(1)`-drains a deep ready queue. `AETHER_PERF_DRIVE` / `AETHER_PERF_BACKLOG` env knobs; backlog clamped to the trace-ring capacity.
- **Throughput harvest**: read off the same folded trace nodes the latency path walks — completed = `Ping` nodes with `t_finished`, `elapsed = max(t_finished) − min(t_construct_start)`. `throughput_mps: Option<f64>` on the cell; computed only under saturate and only when the harvest didn't lap the ring (a truncated harvest yields `None`, never a wrong rate).
- **Report** (`perf/report.rs`): a `throughput` section (its own `RawSection`, version `v1`) compared by `compare_throughput` mirroring the extracted `compare_latency`. `classify` gained a `Direction` — latency stays lower-is-better, throughput is higher-is-better (the ns absolute floor is neutralised for a rate). Rendered by `push_throughput_section`; the markdown headline rolls up across both compared section kinds.
- **CI surfacing**: `perf-trial` emits the throughput section under saturate; `scripts/perf-compare.sh` runs the comparator twice (a latency pass + a saturate pass) and merges the two bodies into one sticky comment under a single marker, so the "Compare dispatch perf vs merge-base" comment carries both metrics, each measured in its own regime.

## Test plan

- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo doc` — clean.
- `cargo nextest run` (full workspace, via `scripts/preflight.sh`) — green. New tests: saturate drains the full backlog + reports a finite rate; completed-count scales with backlog; latency mode reports no throughput; over-capacity backlog flags truncation / is clamped; throughput verdict fixtures (higher reads improved, lower reads regressed, equal reads stable); JSON round-trip preserves the throughput section; throughput renders in markdown.
- End-to-end smoke: ran `aether-perf-trial` in both modes (saturate yields a throughput section, ~411k mails/sec; latency yields a latency section) and the full two-pass comparator pipeline (merged body: one sticky marker, both tables).
- The throughput-scaling test was hardened before push to assert the load-independent completed-`Ping` count plus a well-formed (positive, finite) rate, leaving rate *magnitude* to the paired comparator (ADR-0085) — so it stays deterministic under a contended CI nextest rather than comparing two independently-timed wall-clock rates.

## Generated by

`/implement` — agent execution of scoped issue iamacoffeepot/aether#1202, with a parent-side flake-hardening pass on the throughput-scaling test before push.
