### PR TITLE
feat(mcp): ensure-tunnel SessionStart bootstrap hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,16 @@
     ]
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/scripts/ensure-tunnel.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,14 +42,17 @@ The guest/actor SDK is **`aether-actor`** — the `Actor` / `FfiActor` traits, `
 
 ## MCP harness
 
-Claude drives a running engine through MCP — the concrete form of the "Claude-in-harness" vision. The harness is the out-of-process **`aether-mcp`** crate: an RPC client that dials the hub's `RpcServerCapability` and relays each tool call as a wire `Call`. Dev workflow is two processes:
+Claude drives a running engine through MCP — the concrete form of the "Claude-in-harness" vision. The harness is the out-of-process **`aether-mcp`** crate: an RPC client that dials the hub's `RpcServerCapability` and relays each tool call as a wire `Call`. The whole stack is fronted by a long-lived **tunnel** (`aether-tunnel`, ADR-0089) so Claude can restart the volatile backends without losing its MCP connection. Three processes, one nested under the other:
 
 ```
-cargo run -p aether-substrate-bundle --bin aether-substrate-hub   # RPC server on 127.0.0.1:8901
-cargo run -p aether-mcp                                           # serves MCP HTTP on 127.0.0.1:8890
+:8890  aether-tunnel  — stable MCP front; reverse-proxies /mcp, supervises the two below
+:8891  aether-mcp     — forked by the tunnel; dials + re-dials the hub
+:8901  aether-substrate-hub — forked by the tunnel; the RPC server the fleet talks to
 ```
 
-`.mcp.json` points Claude Code at `:8890`. Env overrides: `AETHER_RPC_PORT` (hub, default 8901), `AETHER_HUB_RPC_ADDR` (aether-mcp's dial target), `AETHER_MCP_PORT` (default 8890). Get a substrate with `spawn_substrate`; the hub forks it, assigns its RPC port, and tracks the fleet via its `aether.engine` cap.
+The tunnel binds `:8890` (the port `.mcp.json` targets) and forks `aether-mcp` (`AETHER_MCP_PORT=8891`) and the hub (`AETHER_RPC_PORT=8901`, reached via `AETHER_HUB_RPC_ADDR`) itself. You don't start these by hand — the `SessionStart` hook runs `scripts/ensure-tunnel.sh`, which is a no-op if `:8890` is already bound and otherwise launches the tunnel detached. Env overrides: `AETHER_TUNNEL_PORT` (default 8890), `AETHER_MCP_PORT` (default 8891), `AETHER_RPC_PORT` / `AETHER_HUB_RPC_PORT` (hub, default 8901). Get a substrate with `spawn_substrate`; the hub forks it, assigns its RPC port, and tracks the fleet via its `aether.engine` cap.
+
+To restart the hub after a rebuild **without dropping the MCP session**, hit the tunnel's out-of-band admin endpoint from a shell — `curl -fsS -X POST http://127.0.0.1:8890/admin/restart-hub`. The tunnel SIGTERMs + re-forks the hub child; `aether-mcp` (and Claude's MCP session) stay up and re-dial the fresh hub on the next tool call. `GET http://127.0.0.1:8890/admin/status` reports child liveness + the resolved ports. Restarting `aether-mcp` itself is rare and *does* invalidate the MCP session (Claude re-initialises) — prefer `restart-hub`.
 
 Tools (`mcp__aether-hub__*`):
 

--- a/scripts/ensure-tunnel.sh
+++ b/scripts/ensure-tunnel.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Ensure the aether MCP tunnel is up. Registered as a `SessionStart` hook
+# (.claude/settings.json), so it runs on every Claude session start.
+#
+# The tunnel (`aether-tunnel`, iamacoffeepot/aether#1212 PR 2) binds :8890 —
+# the port `.mcp.json` targets — and forks + supervises `aether-mcp` (:8891)
+# and the hub (:8901) behind it. This script is the idempotent bootstrap:
+#
+#   - If :8890 already answers, it is a no-op (the common case).
+#   - Otherwise it launches the tunnel detached and waits, bounded, for the
+#     port to come up.
+#
+# A SessionStart hook MUST NOT block the session or return non-zero, so this
+# script is non-blocking (bounded wait) and never-fatal (always exits 0 on
+# the best-effort path). `set -e` is on inside the work, but the launch /
+# probe path is guarded so a failed probe or launch can't propagate a
+# non-zero exit.
+
+set -euo pipefail
+
+TUNNEL_PORT="${AETHER_TUNNEL_PORT:-8890}"
+STATUS_URL="http://127.0.0.1:${TUNNEL_PORT}/admin/status"
+
+# Where the detached tunnel's stdout/stderr go.
+LOG_DIR="${TMPDIR:-/tmp}/aether-tunnel"
+LOG_FILE="${LOG_DIR}/tunnel.log"
+
+# How long to wait for a freshly-launched tunnel to bind :8890 before
+# giving up (and still exiting 0).
+STARTUP_TIMEOUT_SECS=15
+
+# Resolve the project root so we can find a pre-built binary / run cargo.
+# `CLAUDE_PROJECT_DIR` is set by the harness; fall back to the script's
+# repo when run by hand.
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-}"
+if [[ -z "$PROJECT_DIR" ]]; then
+    PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+# Probe :8890 — true if the tunnel is answering. Prefers the /admin/status
+# HTTP probe (curl), falls back to a bare TCP connect (nc). Both swallow
+# their own failure so the caller controls the exit.
+tunnel_is_up() {
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsS --max-time 1 -o /dev/null "$STATUS_URL" 2>/dev/null && return 0
+    fi
+    if command -v nc >/dev/null 2>&1; then
+        nc -z -w 1 127.0.0.1 "$TUNNEL_PORT" >/dev/null 2>&1 && return 0
+    fi
+    return 1
+}
+
+# The :8890 check at the top is the double-launch guard: if a tunnel is
+# already bound we never launch a second one.
+if tunnel_is_up; then
+    echo "[ensure-tunnel] tunnel already up on :${TUNNEL_PORT} — nothing to do."
+    exit 0
+fi
+
+# Pick a launch command: prefer a pre-built binary (fast, clean reap), else
+# fall back to `cargo run` (rebuild-friendly).
+RELEASE_BIN="${PROJECT_DIR}/target/release/aether-tunnel"
+DEBUG_BIN="${PROJECT_DIR}/target/debug/aether-tunnel"
+if [[ -x "$RELEASE_BIN" ]]; then
+    LAUNCH=("$RELEASE_BIN")
+elif [[ -x "$DEBUG_BIN" ]]; then
+    LAUNCH=("$DEBUG_BIN")
+else
+    LAUNCH=(cargo run --release -p aether-mcp --bin aether-tunnel)
+fi
+
+mkdir -p "$LOG_DIR"
+echo "[ensure-tunnel] :${TUNNEL_PORT} not answering — launching: ${LAUNCH[*]}"
+echo "[ensure-tunnel] logs: ${LOG_FILE}"
+
+# Launch detached: background, redirect output to the log, and disown so the
+# tunnel outlives this hook process and the session. `|| true` keeps a spawn
+# failure from tripping `set -e`.
+(
+    cd "$PROJECT_DIR" || exit 0
+    nohup "${LAUNCH[@]}" >"$LOG_FILE" 2>&1 &
+    disown
+) || true
+
+# Bounded wait for the tunnel to bind. Exit 0 the moment it answers; exit 0
+# anyway if it never does — a SessionStart hook must not block the session.
+deadline=$((SECONDS + STARTUP_TIMEOUT_SECS))
+while (( SECONDS < deadline )); do
+    if tunnel_is_up; then
+        echo "[ensure-tunnel] tunnel is up on :${TUNNEL_PORT}."
+        exit 0
+    fi
+    sleep 1
+done
+
+echo "[ensure-tunnel] tunnel not up after ${STARTUP_TIMEOUT_SECS}s; continuing (see ${LOG_FILE})."
+exit 0


### PR DESCRIPTION
Closes iamacoffeepot/aether#1212 (PR 3 of 3 — the bootstrap; PR 1 re-dial = iamacoffeepot/aether#1214, PR 2 tunnel binary = iamacoffeepot/aether#1215). Implements ADR-0089.

## Summary

The capstone that auto-starts the tunnel, so the MCP harness comes up without a manual two-process launch.

- **`scripts/ensure-tunnel.sh`** — idempotent bootstrap. Probes `:8890` (`GET /admin/status`, `nc` fallback) and **no-ops if the tunnel is already up** (the common case + the double-launch guard). Otherwise launches the tunnel **detached** (`nohup … & disown`, logs to a tmp file), preferring a pre-built `aether-tunnel` binary, falling back to `cargo run --release -p aether-mcp --bin aether-tunnel`, then waits up to 15s for `:8890` to answer. **Non-blocking and never-fatal**: every path exits 0, so it can't block or break a session start.
- **`.claude/settings.json`** — registers it as a `SessionStart` hook. ⚠️ **Behavior change worth a conscious review:** with this merged, every Claude session in this repo runs `ensure-tunnel.sh` on start, which launches the tunnel (and the hub + `aether-mcp` it forks) as detached background processes if they aren't already running. It's idempotent and best-effort, but it *is* persistent auto-launch — that's the intended end state of ADR-0089, called out here so the persistence isn't a surprise.
- **`CLAUDE.md`** — updates the MCP-harness section: the three-tier port layout (`:8890` tunnel → `:8891` aether-mcp → `:8901` hub), that `.mcp.json` targets the tunnel, the `SessionStart` auto-start, and `POST :8890/admin/restart-hub` (restart the hub without dropping the MCP session) + `GET /admin/status`.

## Merge note

This is the **cutover**. PR 2 was additive (changed nothing live); merging *this* means the next session — once your `main` checkout has it — auto-runs the hook and routes `.mcp.json`'s `:8890` through the tunnel for the first time. Worth being at a keyboard for that first session in case `ensure-tunnel.sh` wants a tweak.

## Test plan

- `bash -n scripts/ensure-tunnel.sh` — OK. (`shellcheck` not installed on the dev box; the script is conservatively quoted — all expansions quoted, launch command as an array.)
- `python3 -m json.tool .claude/settings.json` — valid JSON.
- `scripts/preflight.sh --files scripts/ensure-tunnel.sh .claude/settings.json CLAUDE.md` — exit 0, took the docs/config skip (no Rust change).

## Generated by

Agent execution of PR 3 of the iamacoffeepot/aether#1212 plan. Note: the implementing agent's run carried a security flag (self-modification + persistence) for the `.claude/settings.json` SessionStart hook — reviewed and authorized as the scoped, ADR-0089 bootstrap before push.
