### PR TITLE
test(substrate-bundle): prune two mpsc round-trip tautologies

### DIFF
--- a/crates/aether-substrate-bundle/src/test_bench/events.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/events.rs
@@ -78,38 +78,7 @@ pub fn channel() -> (EventSender, EventReceiver) {
 
 #[cfg(test)]
 mod tests {
-    use aether_data::{SessionToken, Uuid};
-    use aether_substrate::ReplyTarget;
-
     use super::*;
-
-    fn reply_to(u: u128) -> ReplyTo {
-        ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::from_u128(u))))
-    }
-
-    #[test]
-    fn advance_round_trips_through_channel() {
-        let (tx, rx) = channel();
-        tx.send(ChassisEvent::Advance {
-            reply_to: reply_to(1),
-            ticks: 3,
-        })
-        .expect("send");
-        match rx.recv().expect("recv") {
-            ChassisEvent::Advance { ticks, .. } => assert_eq!(ticks, 3),
-            ChassisEvent::CaptureRequested => panic!("got CaptureRequested, expected Advance"),
-        }
-    }
-
-    #[test]
-    fn capture_requested_round_trips_through_channel() {
-        let (tx, rx) = channel();
-        tx.send(ChassisEvent::CaptureRequested).expect("send");
-        assert!(matches!(
-            rx.recv().expect("recv"),
-            ChassisEvent::CaptureRequested
-        ));
-    }
 
     #[test]
     fn recv_errors_after_all_senders_drop() {


### PR DESCRIPTION
## What

The `aether-substrate-bundle` pass of the crate-by-crate test contract review. The crate's ~89 tests are otherwise fully load-bearing, so this removes just **two tautologies** from `test_bench/events.rs`.

## Removed

| Test | Why |
|---|---|
| `advance_round_trips_through_channel` | Sends `ChassisEvent::Advance { ticks: 3 }` through an `std::mpsc` channel and asserts `ticks == 3`. The channel *moves* the enum — no encode/decode — so it asserts a Rust language guarantee, not aether code. |
| `capture_requested_round_trips_through_channel` | Same: a unit variant survives a move through mpsc. |

The one real channel semantic — sender-drop unblocks `recv` with `Err` (the chassis-loop shutdown signal) — stays covered by `recv_errors_after_all_senders_drop`. Removing the two orphaned the `reply_to` test helper and its `aether_data` / `ReplyTarget` imports, trimmed with them.

## Kept (notable)

- **perf/** (22) — verdict classification, schema-evolution-tolerant comparison, v3→v4 envelope lift, saturation/backlog/ring-truncation invariants.
- **`tests/`** (23) — chassis / cap-registry / input-subscription / rpc-routing integration.
- **3 `#[ignore]` harnesses in `mail_latency.rs`** — `lifecycle_latency_observe`, `settlement_detection_latency` (latency tables / histogram for release sign-off) and `mail_saturation_profile` (samply profiling entry point). These are standing measurement/profiling tooling that drives real end-to-end paths — distinct from the throwaway A/B micro-benchmarks pruned in the substrate pass — so they stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
