### PR TITLE
test: prune two no-op tautological tests (aether-data, aether-mesh)

### DIFF
--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -740,12 +740,6 @@ mod tests {
         const ID: KindId = KindId(0xDEAD_BEEF_0000_0003);
     }
 
-    struct Signal;
-    impl Kind for Signal {
-        const NAME: &'static str = "test.signal";
-        const ID: KindId = KindId(0xDEAD_BEEF_0000_0004);
-    }
-
     #[test]
     fn pod_roundtrip_single() {
         let v = TestPod { a: 42, b: 1.5 };
@@ -796,12 +790,6 @@ mod tests {
         let err = decode_struct::<TestStruct>(&[0x00])
             .expect_err("test setup: single-byte buffer must fail postcard decode");
         assert!(matches!(err, DecodeError::Postcard(_)));
-    }
-
-    #[test]
-    fn empty_kind_encodes_to_zero_bytes() {
-        assert!(encode_empty::<Signal>().is_empty());
-        assert_eq!(Signal::NAME, "test.signal");
     }
 
     #[test]

--- a/crates/aether-mesh/src/loop_polygon.rs
+++ b/crates/aether-mesh/src/loop_polygon.rs
@@ -511,37 +511,6 @@ mod tests {
     }
 
     #[test]
-    fn split_points_lie_on_partitioner_within_snap_tolerance() {
-        // The snap step in `compute_intersection` may shift each split
-        // point by up to one fixed-point ULP per axis off the partitioner
-        // plane. For an axis-aligned partitioner that means |side| of a
-        // split point is bounded by `|n_z|` at most — actually 0 in
-        // happy axis-aligned cases. Pin the bound.
-        let poly = Polygon::from_triangle(
-            pt(-1.0, 0.0, -1.0),
-            pt(1.0, 0.0, -1.0),
-            pt(0.0, 0.0, 1.0),
-            0,
-        )
-        .expect("test setup: non-degenerate triangle");
-        let partitioner = xy_partitioner();
-        let (_cof, _cob, f, b) = split_into_buckets(&poly, &partitioner);
-        let threshold = partitioner.coplanar_threshold();
-        for poly in f.iter().chain(b.iter()) {
-            for v in &poly.vertices {
-                let s = partitioner.side(*v).unsigned_abs();
-                // Every fragment vertex must be inside the coplanar
-                // threshold (either on the original side, or a snapped
-                // intersection point on the plane).
-                assert!(
-                    s <= threshold as u128 || s >= threshold as u128,
-                    "fragment vertex side {s} unexpectedly far from partitioner"
-                );
-            }
-        }
-    }
-
-    #[test]
     fn coplanar_plus_back_vertices_route_to_back() {
         // 0 | BACK | BACK == BACK. Untested-before case where polygon
         // has one COPLANAR + two BACK vertices; should route entirely


### PR DESCRIPTION
## What

The final, combined removal from a crate-by-crate test contract review of the whole workspace (~1,380 tests, 14 crates). The suite is ~99% load-bearing; this drops the only two residual tests that **cannot fail** — they assert nothing.

| Test | Why |
|---|---|
| `aether-data` `empty_kind_encodes_to_zero_bytes` | Asserts `encode_empty::<Signal>()` is empty — but the fn unconditionally returns `Vec::new()`, so it can't fail — and `Signal::NAME == "test.signal"`, which restates a test fixture's own literal. Removed with its now-orphaned `Signal` fixture. |
| `aether-mesh` `split_points_lie_on_partitioner_within_snap_tolerance` | Its only assertion is `s <= threshold \|\| s >= threshold`, true for every value — a no-op that gives false confidence. |

No production code changes; `cargo clippy --all-targets -D warnings` clean on both crates.

## Context

This is the tail of the review. Earlier prunings landed separately:
- substrate — PR 1217 (8 cut + 1 fold)
- substrate-bundle — PR 1220 (2 cut)

The other ten crates (capabilities, codec, actor, math, kinds, mcp, actor-derive, mesh-viewer, camera, data-derive) reviewed **clean** — agent-proposed cuts in several were rejected on verification (literal-expected basic-correctness, production wire-name change-detectors, and distinct-property checks are not tautologies).

## Follow-ups (gaps noted, not addressed here)

- `aether-mesh` — the broken test's *intent* (a split-fragment snap-drift bound through `split_into_buckets`) deserves a real spanning-triangle test; the core snap bound is already covered by `compute_intersection_snap_within_one_ulp`.
- `aether-substrate` — the issue-716 settle-before-spawned-send gap still wants a real assertion (the placeholder that only narrated it was removed in PR 1217).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
