### PR TITLE
refactor(substrate-bundle): rename AETHER_LAT_* env vars to AETHER_LATENCY_*

### DIFF
--- a/crates/aether-substrate-bundle/src/bin/perf-trial.rs
+++ b/crates/aether-substrate-bundle/src/bin/perf-trial.rs
@@ -16,11 +16,11 @@
 //!   iamacoffeepot/aether#1202).
 //! - `AETHER_PERF_BACKLOG` — per-tick `Ping` burst in `saturate` mode
 //!   (default `512`, clamped to the trace ring capacity).
-//! - `AETHER_LAT_PACE_HZ` — `latency` mode only: pace one frame per
+//! - `AETHER_LATENCY_PACE_HZ` — `latency` mode only: pace one frame per
 //!   period (else flat-out).
-//! - `AETHER_LAT_HEAVY_WORK` — when set, append CPU-heavy fan-outs
+//! - `AETHER_LATENCY_HEAVY_WORK` — when set, append CPU-heavy fan-outs
 //!   (iamacoffeepot/aether#1074); unset, the topology set is unchanged.
-//! - `AETHER_LAT_WIDE_FANOUT` — comma list of extra trivial fan-out
+//! - `AETHER_LATENCY_WIDE_FANOUT` — comma list of extra trivial fan-out
 //!   widths to append (iamacoffeepot/aether#1075); unset, unchanged.
 //! - `AETHER_PERF_GIT_SHA` — stamped into the report; falls back to
 //!   `git rev-parse HEAD`.

--- a/crates/aether-substrate-bundle/src/perf/harness.rs
+++ b/crates/aether-substrate-bundle/src/perf/harness.rs
@@ -493,12 +493,12 @@ pub struct SweepConfig {
     pub drive: Drive,
 }
 
-/// Read the optional `AETHER_LAT_PACE_HZ` pacing override (frames/sec;
+/// Read the optional `AETHER_LATENCY_PACE_HZ` pacing override (frames/sec;
 /// `None` = flat-out / warm). Shared by the on-demand harness test and
 /// the `perf-trial` bin so the parse lives in one place.
 #[must_use]
 pub fn pace_hz_from_env() -> Option<u64> {
-    env::var("AETHER_LAT_PACE_HZ")
+    env::var("AETHER_LATENCY_PACE_HZ")
         .ok()
         .and_then(|s| s.parse().ok())
         .filter(|&h| h > 0)
@@ -545,7 +545,7 @@ pub fn drive_from_env() -> Drive {
     }
 }
 
-/// Read the optional heavy-leaf CPU work knob `AETHER_LAT_HEAVY_WORK` (a
+/// Read the optional heavy-leaf CPU work knob `AETHER_LATENCY_HEAVY_WORK` (a
 /// raw `busy_spin` iteration count per heavy leaf handler; see
 /// [`fanout_heavy`]). Unset, unparseable, or `0` means no heavy work —
 /// callers omit the heavy topology entirely, so the trivial sweep is
@@ -559,13 +559,13 @@ pub fn drive_from_env() -> Drive {
 /// measures `t_finished - t_received`), then adjust.
 #[must_use]
 pub fn heavy_work_iters_from_env() -> u64 {
-    env::var("AETHER_LAT_HEAVY_WORK")
+    env::var("AETHER_LATENCY_HEAVY_WORK")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(0)
 }
 
-/// Parse the optional `AETHER_LAT_WIDE_FANOUT` knob — a comma list of
+/// Parse the optional `AETHER_LATENCY_WIDE_FANOUT` knob — a comma list of
 /// *extra* trivial fan-out widths to append to the sweep, e.g.
 /// `"16,32,64,128"`. Unset or empty appends nothing, so the default
 /// sweep is unchanged (iamacoffeepot/aether#1075). Widths should exceed
@@ -580,7 +580,7 @@ pub fn heavy_work_iters_from_env() -> u64 {
 /// and the win should invert somewhere past `W* ≈ handoff / per-child`.
 #[must_use]
 pub fn wide_fanout_widths_from_env() -> Vec<usize> {
-    let Ok(spec) = env::var("AETHER_LAT_WIDE_FANOUT") else {
+    let Ok(spec) = env::var("AETHER_LATENCY_WIDE_FANOUT") else {
         return Vec::new();
     };
     let mut out: Vec<usize> = spec
@@ -634,8 +634,8 @@ pub fn parse_workers() -> Vec<usize> {
 }
 
 /// Parse `AETHER_PERF_TOPOS` (`ci` — a chain/fan-out/tree subset — or
-/// `full`), then append the opt-in heavy (`AETHER_LAT_HEAVY_WORK`) and
-/// wide (`AETHER_LAT_WIDE_FANOUT`) fan-outs. Default `ci`. Shared by the
+/// `full`), then append the opt-in heavy (`AETHER_LATENCY_HEAVY_WORK`) and
+/// wide (`AETHER_LATENCY_WIDE_FANOUT`) fan-outs. Default `ci`. Shared by the
 /// `perf-trial` and `perf-plot` bins.
 #[must_use]
 pub fn parse_topologies() -> Vec<Topology> {

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -628,7 +628,7 @@ const OBSERVE_FRAMES: u32 = 1000;
 /// tables.
 ///
 /// Default is **flat-out** `advance` (warm — isolates per-hop dispatch
-/// cost). `AETHER_LAT_PACE_HZ=60` paces one frame per period instead
+/// cost). `AETHER_LATENCY_PACE_HZ=60` paces one frame per period instead
 /// (workers park in the gaps → realistic frame-loop latency).
 ///
 /// `#[ignore]` — a measurement run, not a correctness gate. Skips
@@ -646,7 +646,7 @@ fn lifecycle_latency_observe() {
 
     let pace_hz = pace_hz_from_env();
 
-    // The trivial default set always runs. When AETHER_LAT_HEAVY_WORK is
+    // The trivial default set always runs. When AETHER_LATENCY_HEAVY_WORK is
     // set, append CPU-heavy fan-outs so the sweep can also exhibit the
     // parallelism-wins regime (iamacoffeepot/aether#1074) — unset, the
     // grid is byte-for-byte the historical one.
@@ -658,7 +658,7 @@ fn lifecycle_latency_observe() {
         }
     }
     // Wide trivial fan-outs to locate the stickiness width-crossover
-    // (iamacoffeepot/aether#1075); empty unless AETHER_LAT_WIDE_FANOUT is
+    // (iamacoffeepot/aether#1075); empty unless AETHER_LATENCY_WIDE_FANOUT is
     // set, so the default grid is unchanged.
     for w in wide_fanout_widths_from_env() {
         topologies.push(fanout(w));


### PR DESCRIPTION
Closes iamacoffeepot/aether#1223.

## Why

The perf harness has three optional override env vars prefixed `AETHER_LAT_` — a legacy abbreviation from when it was the lifecycle-**lat**ency harness. `LAT` reads ambiguously to a human (latitude / lateral / latency), so spell the prefix out.

## What

Pure mechanical rename, code reads and comments alike:

- `AETHER_LAT_PACE_HZ` → `AETHER_LATENCY_PACE_HZ`
- `AETHER_LAT_HEAVY_WORK` → `AETHER_LATENCY_HEAVY_WORK`
- `AETHER_LAT_WIDE_FANOUT` → `AETHER_LATENCY_WIDE_FANOUT`

**No behaviour change.** In particular `AETHER_LATENCY_HEAVY_WORK` keeps its current dual role (it both gates whether the heavy topologies are appended and supplies the `busy_spin` iteration count) — `heavy_work_iters_from_env` still returns the raw count and the caller still gates on `> 0`. Diff is nothing but the string substitutions.

## Scope

Three files in `aether-substrate-bundle` (`perf/harness.rs`, `bin/perf-trial.rs`, `test_bench/mail_latency.rs`). These vars are read-only optional overrides set **nowhere** in `.github/workflows/`, `scripts/`, or docs, so there's no CI/script coordination — it's purely Rust-internal. A whole-repo grep for the three old strings returns zero matches.

## Coordination

The workload-tiers plan (iamacoffeepot/aether#1222) already references the new names; its later semantic change to `AETHER_LATENCY_HEAVY_WORK` (demoting it to magnitude-only once the tier selector takes over gating) builds on this rename.

## Test plan

- `scripts/preflight.sh` — green (fmt + clippy `-D warnings` + doc + nextest + wasm32 component cross-build). 1374 tests passed, 6 skipped (the `#[ignore]` measurement harnesses).
