### PR TITLE
feat(substrate-bundle): light/heavy workload tiers in the dispatch perf comparison

### DIFF
--- a/crates/aether-substrate-bundle/src/bin/perf-compare.rs
+++ b/crates/aether-substrate-bundle/src/bin/perf-compare.rs
@@ -49,8 +49,8 @@ use std::fs;
 use std::process::{Command, ExitCode};
 
 use aether_substrate_bundle::perf::report::{
-    CompareConfig, ComparisonReport, LatencySection, RawSection, STICKY_MARKER, SectionReport,
-    TRIAL_SCHEMA, TrialReport, compare, markdown, probe_schema,
+    CompareConfig, LatencySection, RawSection, STICKY_MARKER, TRIAL_SCHEMA, TrialReport, compare,
+    headline_counts, markdown, probe_schema,
 };
 
 /// The envelope tag of the last pre-sections report shape: a flat
@@ -297,43 +297,23 @@ fn main() -> ExitCode {
         }
     }
 
-    let (improved, stable, regressed) = roll_up(&report);
+    // The stderr summary uses the same gate-signal rollup the headline
+    // does — the light `latency` section + throughput, excluding the
+    // suppressed-verdict heavy / real tiers (ADR-0085 amendment), so the two
+    // never report different counts.
+    let (improved, stable, regressed) = headline_counts(&report);
     eprintln!(
         "perf-compare: {improved} improved, {stable} stable, {regressed} regressed (informational)"
     );
     ExitCode::SUCCESS
 }
 
-/// Sum improved / stable / regressed across the compared sections of a
-/// report — latency and throughput alike (iamacoffeepot/aether#1202).
-/// Uncompared sections contribute nothing.
-fn roll_up(report: &ComparisonReport) -> (usize, usize, usize) {
-    report
-        .sections
-        .iter()
-        .fold((0, 0, 0), |(i, s, r), sec| match sec {
-            SectionReport::Compared {
-                improved,
-                stable,
-                regressed,
-                ..
-            }
-            | SectionReport::ThroughputCompared {
-                improved,
-                stable,
-                regressed,
-                ..
-            } => (i + improved, s + stable, r + regressed),
-            SectionReport::Uncompared { .. } => (i, s, r),
-        })
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{ComparisonReport, ingest_trial};
+    use super::ingest_trial;
     use aether_substrate_bundle::perf::report::{
-        CellJson, CompareConfig, LatencySection, Metric, RawSection, SectionReport, TRIAL_SCHEMA,
-        TrialReport, Verdict, compare,
+        CellJson, CompareConfig, ComparisonReport, LatencySection, Metric, RawSection,
+        SectionReport, TRIAL_SCHEMA, TrialReport, Verdict, compare,
     };
 
     /// Build a `v4` candidate side with a single `latency` cell whose p50

--- a/crates/aether-substrate-bundle/src/bin/perf-trial.rs
+++ b/crates/aether-substrate-bundle/src/bin/perf-trial.rs
@@ -8,8 +8,14 @@
 //!
 //! - `AETHER_PERF_WORKERS` — comma list of pool sizes; the token `max`
 //!   resolves to `available_parallelism() - 1`. Default `max`.
-//! - `AETHER_PERF_TOPOS` — `ci` (depth-1/8 + fanout-4/8 + tree) or
-//!   `full` (the whole default set). Default `ci`.
+//! - `AETHER_PERF_TIER` — comma list of workload tiers to sweep: `light`,
+//!   `heavy`, `real` (e.g. `light,heavy`). Default `light` (ADR-0085
+//!   amendment). The *tier* axis — which classes of shape run, and which
+//!   carry a verdict (only `light`; heavy / real are characterisation).
+//!   `real` parses but is empty until PR 2.
+//! - `AETHER_PERF_TOPOS` — the breadth knob *within* a tier: `ci`
+//!   (depth-1/8 + fanout-4/8 + tree) or `full` (the whole default set).
+//!   Default `ci`. Orthogonal to `AETHER_PERF_TIER`.
 //! - `AETHER_PERF_FRAMES` — frames advanced per cell. Default `200`.
 //! - `AETHER_PERF_DRIVE` — `latency` (per-hop spans; default) or
 //!   `saturate` (completed mails/sec under a backlog flood,
@@ -18,10 +24,14 @@
 //!   (default `512`, clamped to the trace ring capacity).
 //! - `AETHER_LATENCY_PACE_HZ` — `latency` mode only: pace one frame per
 //!   period (else flat-out).
-//! - `AETHER_LATENCY_HEAVY_WORK` — when set, append CPU-heavy fan-outs
-//!   (iamacoffeepot/aether#1074); unset, the topology set is unchanged.
-//! - `AETHER_LATENCY_WIDE_FANOUT` — comma list of extra trivial fan-out
-//!   widths to append (iamacoffeepot/aether#1075); unset, unchanged.
+//! - `AETHER_LATENCY_HEAVY_WORK` — the heavy-tier per-node `busy_spin`
+//!   *magnitude* (iamacoffeepot/aether#1074). Now magnitude-only: the tier
+//!   selector (`AETHER_PERF_TIER`) gates *whether* heavy shapes run, so
+//!   this just sizes the CPU burn, defaulting to a non-zero count when the
+//!   heavy tier is active and the var is unset. Calibrate as before — set a
+//!   count, read the per-leaf µs off the HANDLER DUR column, adjust.
+//! - `AETHER_LATENCY_WIDE_FANOUT` — comma list of extra trivial (light)
+//!   fan-out widths to append (iamacoffeepot/aether#1075); unset, unchanged.
 //! - `AETHER_PERF_GIT_SHA` — stamped into the report; falls back to
 //!   `git rev-parse HEAD`.
 

--- a/crates/aether-substrate-bundle/src/perf/harness.rs
+++ b/crates/aether-substrate-bundle/src/perf/harness.rs
@@ -29,6 +29,7 @@ use aether_kinds::trace::{MailNodeWire, TraceRingEntry, TraceTail, TraceTailResu
 use aether_kinds::{SubscribeInput, SubscribeInputResult, Tick};
 use aether_substrate::{BootError, NativeActor, NativeCtx, NativeDispatch, NativeInitCtx, Subname};
 
+use crate::perf::report::LatencySection;
 use crate::test_bench::TestBench;
 
 /// Fire-and-forward payload the relay actors pass along. The `seq`
@@ -206,17 +207,69 @@ pub fn ticksrc_id() -> MailboxId {
     MailboxId(mailbox_id_from_name(&format!("{TICKSRC_NS}:src")).0)
 }
 
+/// A workload tier (ADR-0085 amendment 2026-05-27): the three classes of
+/// shape the dispatch perf comparison measures, distinguished by what each
+/// isolates and how much its run-to-run variance lets the report *claim*.
+/// Verdict treatment follows the variance, not the tier's importance — only
+/// [`Tier::Light`] is classified pass/improved/regressed; [`Tier::Heavy`]
+/// and [`Tier::Real`] are characterisation (numbers + direction + graphs, no
+/// verdict). The tier rides on each [`Topology`] (and is threaded through
+/// [`CellSamples`] / [`CellResult`] to the report builder), so the renderer
+/// can suppress the verdict for a non-`light` section.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Tier {
+    /// Trivial micro-shapes (`work_iters = 0`) — isolates dispatch/routing
+    /// mechanics; low variance. The regression gate.
+    Light,
+    /// The same shapes with a `busy_spin` CPU budget per node — exposes the
+    /// parallelism-vs-locality crossover. Medium variance.
+    Heavy,
+    /// Application graphs at representative scale, driven paced. High,
+    /// machine-dependent variance. In PR 1 this parses but yields an empty
+    /// topology set — the `real` factories land in PR 2.
+    Real,
+}
+
+impl Tier {
+    /// The report-section name prefix for this tier. `light` reuses the
+    /// historical `latency` name verbatim (preserving the v3 back-compat
+    /// shim and the existing fixtures); the others are tier-suffixed.
+    #[must_use]
+    pub fn section_name(self) -> &'static str {
+        match self {
+            Self::Light => LatencySection::NAME,
+            Self::Heavy => "latency.heavy",
+            Self::Real => "latency.real",
+        }
+    }
+
+    /// Parse one tier token (case-insensitive); `None` for an unknown token.
+    #[must_use]
+    pub fn parse_token(tok: &str) -> Option<Self> {
+        match tok.trim().to_ascii_lowercase().as_str() {
+            "light" => Some(Self::Light),
+            "heavy" => Some(Self::Heavy),
+            "real" => Some(Self::Real),
+            _ => None,
+        }
+    }
+}
+
 /// A topology is a DAG over relay indices: `downstreams[i]` lists the
 /// relays that relay `i` forwards to. Relay 0 is always the entry. The
 /// number of relays is `downstreams.len()`. `work_iters[i]` is the CPU
 /// spin budget relay `i` burns per inbound `Ping` (see `busy_spin`) —
 /// all-zero for the trivial topologies, non-zero on the heavy ones
 /// (iamacoffeepot/aether#1074). `work_iters.len() == downstreams.len()`.
+/// `tier` carries the workload tier (ADR-0085 amendment) through the sweep
+/// to the report builder, so the renderer can suppress the verdict for a
+/// non-`light` tier.
 #[derive(Clone)]
 pub struct Topology {
     pub name: String,
     pub downstreams: Vec<Vec<usize>>,
     pub work_iters: Vec<u64>,
+    pub tier: Tier,
 }
 
 /// `0 -> 1 -> ... -> d-1`. Each relay forwards to the next; the last is
@@ -229,6 +282,7 @@ pub fn depth_chain(d: usize) -> Topology {
     Topology {
         name: format!("depth-{d}"),
         work_iters: vec![0; downstreams.len()],
+        tier: Tier::Light,
         downstreams,
     }
 }
@@ -241,6 +295,7 @@ pub fn fanout(b: usize) -> Topology {
     Topology {
         name: format!("fanout-{b}"),
         work_iters: vec![0; downstreams.len()],
+        tier: Tier::Light,
         downstreams,
     }
 }
@@ -260,6 +315,7 @@ pub fn fanout(b: usize) -> Topology {
 pub fn fanout_heavy(b: usize, work_iters: u64) -> Topology {
     let mut t = fanout(b);
     t.name = format!("fanout-{b}-heavy");
+    t.tier = Tier::Heavy;
     for leaf in 1..=b {
         t.work_iters[leaf] = work_iters;
     }
@@ -281,6 +337,7 @@ pub fn two_level_tree() -> Topology {
     Topology {
         name: "tree-A-BC-DEEF".to_owned(),
         work_iters: vec![0; downstreams.len()],
+        tier: Tier::Light,
         downstreams,
     }
 }
@@ -301,6 +358,7 @@ pub fn two_level_tree() -> Topology {
 pub fn two_level_tree_heavy(work_iters: u64) -> Topology {
     let mut t = two_level_tree();
     "tree-A-BC-DEEF-heavy".clone_into(&mut t.name);
+    t.tier = Tier::Heavy;
     for w in &mut t.work_iters {
         *w = work_iters;
     }
@@ -321,6 +379,7 @@ pub fn two_level_tree_heavy(work_iters: u64) -> Topology {
 pub fn two_level_tree_router_heavy(work_iters: u64) -> Topology {
     let mut t = two_level_tree();
     "tree-A-BC-DEEF-routed".clone_into(&mut t.name);
+    t.tier = Tier::Heavy;
     for leaf in [3usize, 4, 5] {
         t.work_iters[leaf] = work_iters;
     }
@@ -393,6 +452,10 @@ pub fn summarize(mut samples: Vec<u64>) -> Stats {
 pub struct CellSamples {
     pub workers: usize,
     pub topo: String,
+    /// The workload tier this cell's topology belongs to (ADR-0085
+    /// amendment), threaded to the report builder so the renderer can
+    /// suppress the verdict for a non-`light` tier.
+    pub tier: Tier,
     /// iamacoffeepot/aether#1158: `t_sent − t_construct_start` (flush-begin
     /// → blob open) — the producer building the blob.
     pub construct: Vec<u64>,
@@ -414,6 +477,7 @@ impl CellSamples {
         CellResult {
             workers: self.workers,
             topo: self.topo,
+            tier: self.tier,
             construct: summarize(self.construct),
             queued: summarize(self.queued),
             drain: summarize(self.drain),
@@ -429,6 +493,12 @@ impl CellSamples {
 pub struct CellResult {
     pub workers: usize,
     pub topo: String,
+    /// The workload tier this cell's topology belongs to (ADR-0085
+    /// amendment). [`TrialReport::from_cells`] splits the cell list by this
+    /// field into one report section per tier.
+    ///
+    /// [`TrialReport::from_cells`]: super::report::TrialReport::from_cells
+    pub tier: Tier,
     /// iamacoffeepot/aether#1158: `t_sent − t_construct_start` (blob open →
     /// flush-begin) — the producer-side time spent building the blob, the
     /// first leg of the four-stage lifecycle. ~0 on eager (non-buffered)
@@ -545,24 +615,61 @@ pub fn drive_from_env() -> Drive {
     }
 }
 
-/// Read the optional heavy-leaf CPU work knob `AETHER_LATENCY_HEAVY_WORK` (a
-/// raw `busy_spin` iteration count per heavy leaf handler; see
-/// [`fanout_heavy`]). Unset, unparseable, or `0` means no heavy work —
-/// callers omit the heavy topology entirely, so the trivial sweep is
-/// byte-for-byte unchanged (iamacoffeepot/aether#1074).
+/// Default per-leaf `busy_spin` iteration count for the heavy tier when
+/// `AETHER_LATENCY_HEAVY_WORK` is unset (ADR-0085 amendment). The tier
+/// selector ([`tiers_from_env`]) now gates *whether* heavy shapes run; this
+/// var supplies only the spin magnitude, so an active heavy tier needs a
+/// sensible non-zero default rather than silently degenerating to the
+/// trivial shapes. Sized to give a heavy leaf a clearly-non-trivial
+/// per-handler cost (tens of µs at the harness's measured rate) so the
+/// parallelism-vs-locality crossover the heavy tier exists to expose is
+/// actually present — read the HANDLER DUR column to convert to wall-clock.
+pub const DEFAULT_HEAVY_WORK_ITERS: u64 = 50_000;
+
+/// The heavy-leaf CPU work *magnitude* — a raw `busy_spin` iteration count
+/// per heavy node (see [`fanout_heavy`]). Read from
+/// `AETHER_LATENCY_HEAVY_WORK`; unset / unparseable / `0` falls back to
+/// [`DEFAULT_HEAVY_WORK_ITERS`].
 ///
-/// A raw iteration count, not a microsecond budget, keeps the work
-/// *identical* across processes so a paired base-vs-candidate comparison
-/// (ADR-0085) isn't confounded by per-run calibration drift. To target a
-/// wall-clock budget, set a count and read the actual per-leaf
-/// microseconds off the harness's HANDLER DUR column (it already
-/// measures `t_finished - t_received`), then adjust.
+/// This var no longer *gates* the heavy shapes — that is the tier selector's
+/// job ([`tiers_from_env`]) since the ADR-0085 amendment. It now carries
+/// only the spin count, so the calibration workflow still works: set a count
+/// and read the actual per-leaf microseconds off the harness's HANDLER DUR
+/// column (it measures `t_finished - t_received`), then adjust. A raw
+/// iteration count, not a microsecond budget, keeps the work *identical*
+/// across processes so a paired base-vs-candidate comparison (ADR-0085)
+/// isn't confounded by per-run calibration drift.
 #[must_use]
 pub fn heavy_work_iters_from_env() -> u64 {
     env::var("AETHER_LATENCY_HEAVY_WORK")
         .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0)
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|&w| w > 0)
+        .unwrap_or(DEFAULT_HEAVY_WORK_ITERS)
+}
+
+/// Parse `AETHER_PERF_TIER` — a comma list of workload tiers (`light`,
+/// `heavy`, `real`; e.g. `"light,heavy"`), default `light` when unset /
+/// empty / all-unparseable (ADR-0085 amendment). This is the *tier* axis,
+/// orthogonal to `AETHER_PERF_TOPOS` (`ci` / `full`), which selects the
+/// shape *breadth* within each tier. Unknown tokens are dropped; the result
+/// is order-preserving and de-duplicated. Shared by the `perf-trial` and
+/// `perf-plot` bins and the on-demand observe test.
+#[must_use]
+pub fn tiers_from_env() -> Vec<Tier> {
+    let spec = env::var("AETHER_PERF_TIER").unwrap_or_default();
+    let mut out: Vec<Tier> = Vec::new();
+    for tok in spec.split(',') {
+        if let Some(tier) = Tier::parse_token(tok)
+            && !out.contains(&tier)
+        {
+            out.push(tier);
+        }
+    }
+    if out.is_empty() {
+        out.push(Tier::Light);
+    }
+    out
 }
 
 /// Parse the optional `AETHER_LATENCY_WIDE_FANOUT` knob — a comma list of
@@ -633,35 +740,76 @@ pub fn parse_workers() -> Vec<usize> {
     out
 }
 
-/// Parse `AETHER_PERF_TOPOS` (`ci` — a chain/fan-out/tree subset — or
-/// `full`), then append the opt-in heavy (`AETHER_LATENCY_HEAVY_WORK`) and
-/// wide (`AETHER_LATENCY_WIDE_FANOUT`) fan-outs. Default `ci`. Shared by the
-/// `perf-trial` and `perf-plot` bins.
+/// Read `AETHER_PERF_TOPOS` (`full` → the whole [`default_topologies`] set;
+/// anything else → the `ci` chain/fan-out/tree subset). This is the breadth
+/// knob *within* a tier — the shape set the light tier sweeps and the heavy
+/// tier mirrors with CPU burn — orthogonal to the [`tiers_from_env`] tier
+/// axis.
 #[must_use]
-pub fn parse_topologies() -> Vec<Topology> {
-    let mut topos = match env::var("AETHER_PERF_TOPOS").as_deref() {
-        Ok("full") => default_topologies(),
-        _ => vec![
+fn topos_full() -> bool {
+    matches!(env::var("AETHER_PERF_TOPOS").as_deref(), Ok("full"))
+}
+
+/// The light tier's shapes: the trivial micro-topologies the breadth knob
+/// selects, plus any opt-in wide fan-outs (`AETHER_LATENCY_WIDE_FANOUT`).
+/// All carry [`Tier::Light`] from their factories.
+#[must_use]
+fn light_topologies() -> Vec<Topology> {
+    let mut topos = if topos_full() {
+        default_topologies()
+    } else {
+        vec![
             depth_chain(1),
             depth_chain(8),
             fanout(4),
             fanout(8),
             two_level_tree(),
-        ],
+        ]
     };
-    let heavy = heavy_work_iters_from_env();
-    if heavy > 0 {
-        for b in [4usize, 8] {
-            topos.push(fanout_heavy(b, heavy));
-        }
-        // The narrow-heavy multi-blob cascades that stress the keep-local
-        // time budget (iamacoffeepot/aether#1160): uniform-heavy (the valve
-        // fires) and trivial-router→heavy-leaf (the valve's blind spot).
-        topos.push(two_level_tree_heavy(heavy));
-        topos.push(two_level_tree_router_heavy(heavy));
-    }
     for w in wide_fanout_widths_from_env() {
         topos.push(fanout(w));
+    }
+    topos
+}
+
+/// The heavy tier's shapes: the light fan-outs / two-level trees, each node
+/// burning `work_iters` of `busy_spin` CPU. The narrow-heavy cascades stress
+/// the keep-local time budget (iamacoffeepot/aether#1160): uniform-heavy (the
+/// valve fires) and trivial-router→heavy-leaf (the valve's blind spot). All
+/// carry [`Tier::Heavy`].
+#[must_use]
+fn heavy_topologies(work_iters: u64) -> Vec<Topology> {
+    let mut topos = Vec::new();
+    for b in [4usize, 8] {
+        topos.push(fanout_heavy(b, work_iters));
+    }
+    topos.push(two_level_tree_heavy(work_iters));
+    topos.push(two_level_tree_router_heavy(work_iters));
+    topos
+}
+
+/// The real tier's shapes — empty in PR 1 (the `socket-server` /
+/// `tick-broadcast` / `ui-roundtrip` factories land in PR 2, ADR-0085
+/// amendment). The tier still parses and sections, so the enum stays stable
+/// for PR 2.
+#[must_use]
+fn real_topologies() -> Vec<Topology> {
+    Vec::new()
+}
+
+/// Build the sweep's topology set from the selected tiers
+/// ([`tiers_from_env`]) and the breadth knob (`AETHER_PERF_TOPOS`). Each tier
+/// contributes its own shapes, tagged with its [`Tier`] so the report
+/// sections by tier. Shared by the `perf-trial` and `perf-plot` bins.
+#[must_use]
+pub fn parse_topologies() -> Vec<Topology> {
+    let mut topos = Vec::new();
+    for tier in tiers_from_env() {
+        match tier {
+            Tier::Light => topos.extend(light_topologies()),
+            Tier::Heavy => topos.extend(heavy_topologies(heavy_work_iters_from_env())),
+            Tier::Real => topos.extend(real_topologies()),
+        }
     }
     topos
 }
@@ -935,6 +1083,7 @@ pub fn run_sweep_samples(cfg: &SweepConfig) -> Vec<CellSamples> {
             rows.push(CellSamples {
                 workers,
                 topo: topo.name.clone(),
+                tier: topo.tier,
                 construct,
                 queued,
                 drain,

--- a/crates/aether-substrate-bundle/src/perf/report.rs
+++ b/crates/aether-substrate-bundle/src/perf/report.rs
@@ -1609,28 +1609,34 @@ mod tests {
         assert!(md.contains("throughput full grid"));
     }
 
-    /// Build a K-trial side carrying a single latency cell under the named
-    /// tier section (ADR-0085 amendment) — the tier analog of [`side`]. The
-    /// section name selects the tier (`latency` light, `latency.heavy`,
-    /// `latency.real`).
+    /// One `fanout-8-heavy @ 11w` drain cell at the given `p50` (p90/p99/max
+    /// derived ×1.2 / ×1.5 / ×4) — the shared fixture cell for the tier tests.
     #[allow(
         clippy::cast_precision_loss,
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss
     )]
+    fn heavy_cell(p50: u64) -> CellJson {
+        CellJson {
+            workers: 11,
+            topo: "fanout-8-heavy".to_owned(),
+            metric: Metric::Drain,
+            p50,
+            p90: (p50 as f64 * 1.2) as u64,
+            p99: (p50 as f64 * 1.5) as u64,
+            max: p50 * 4,
+            n: 1800,
+        }
+    }
+
+    /// Build a K-trial side carrying a single latency cell under the named
+    /// tier section (ADR-0085 amendment) — the tier analog of [`side`]. The
+    /// section name selects the tier (`latency` light, `latency.heavy`,
+    /// `latency.real`).
     fn tier_side(section_name: &str, p50s: &[u64]) -> Vec<TrialReport> {
         p50s.iter()
             .map(|&p50| {
-                let cells = vec![CellJson {
-                    workers: 11,
-                    topo: "fanout-8-heavy".to_owned(),
-                    metric: Metric::Drain,
-                    p50,
-                    p90: (p50 as f64 * 1.2) as u64,
-                    p99: (p50 as f64 * 1.5) as u64,
-                    max: p50 * 4,
-                    n: 1800,
-                }];
+                let cells = vec![heavy_cell(p50)];
                 let body = serde_json::to_value(LatencySection { cells })
                     .expect("encode tier latency body");
                 TrialReport {
@@ -1651,23 +1657,9 @@ mod tests {
     /// Attach a `latency.heavy` section's cells to an existing side, so a
     /// trial carries both the light `latency` section and the heavy one (the
     /// realistic `AETHER_PERF_TIER=light,heavy` shape).
-    #[allow(
-        clippy::cast_precision_loss,
-        clippy::cast_possible_truncation,
-        clippy::cast_sign_loss
-    )]
     fn with_heavy_section(mut side: Vec<TrialReport>, p50s: &[u64]) -> Vec<TrialReport> {
         for (t, &p50) in side.iter_mut().zip(p50s.iter()) {
-            let cells = vec![CellJson {
-                workers: 11,
-                topo: "fanout-8-heavy".to_owned(),
-                metric: Metric::Drain,
-                p50,
-                p90: (p50 as f64 * 1.2) as u64,
-                p99: (p50 as f64 * 1.5) as u64,
-                max: p50 * 4,
-                n: 1800,
-            }];
+            let cells = vec![heavy_cell(p50)];
             let body =
                 serde_json::to_value(LatencySection { cells }).expect("encode heavy latency body");
             t.sections.push(RawSection {

--- a/crates/aether-substrate-bundle/src/perf/report.rs
+++ b/crates/aether-substrate-bundle/src/perf/report.rs
@@ -137,11 +137,35 @@ pub struct LatencySection {
 }
 
 impl LatencySection {
-    /// The section name the comparator dispatches on.
+    /// The light tier's section name — the historical `latency`, kept
+    /// verbatim so the v3 back-compat shim and the existing fixtures don't
+    /// churn. The heavy / real tiers use tier-suffixed names
+    /// ([`super::harness::Tier::section_name`]).
     pub const NAME: &str = "latency";
     /// The section version. Bumped when the metric set changes; sibling
     /// sections stay comparable across the bump.
     pub const VERSION: &str = "v1";
+}
+
+/// Is `name` a latency section of *any* tier (ADR-0085 amendment)? The
+/// light tier reuses the bare `latency` name; heavy / real are tier-suffixed
+/// (`latency.heavy`, `latency.real`). The comparator routes all of them to
+/// the same per-cell paired compare — the verdict numbers are wanted for
+/// every tier; suppression is a render-time concern, not a compare-time one.
+#[must_use]
+pub fn is_latency_section(name: &str) -> bool {
+    name == LatencySection::NAME || name == "latency.heavy" || name == "latency.real"
+}
+
+/// Whether a latency section's verdict is *rendered* (ADR-0085 amendment).
+/// Only the light tier (`latency`) carries a verdict; heavy / real are
+/// characterisation — numbers + direction only, no verdict column, no
+/// lifted "rows that moved", no "nothing moved" note. The comparator still
+/// computes the real verdict for every tier (`classify` is untouched); this
+/// gates only the renderer.
+#[must_use]
+fn latency_section_renders_verdict(name: &str) -> bool {
+    name == LatencySection::NAME
 }
 
 /// One cell's measured throughput in a single trial
@@ -215,11 +239,18 @@ impl TrialReport {
     /// expands to four `CellJson` rows (`construct` + `queued` + `drain` +
     /// `handler`, in lifecycle order; iamacoffeepot/aether#1158). `depth`
     /// is a count, not a latency, so it is omitted from the latency compare
-    /// (it lives only in the on-demand observe table). The rows are wrapped
-    /// in a single [`LatencySection`] — the lone section today
-    /// (iamacoffeepot/aether#1206).
+    /// (it lives only in the on-demand observe table).
+    ///
+    /// The cells are split **by workload tier** (ADR-0085 amendment) into
+    /// one [`LatencySection`]-bodied [`RawSection`] per tier present: the
+    /// light tier reuses the historical `latency` name, heavy / real are
+    /// tier-suffixed ([`Tier::section_name`]). Tiers are emitted in
+    /// `light → heavy → real` order so the report reads gate-first. When the
+    /// sweep ran only the light tier (the historical default) the output is
+    /// the single `latency` section, byte-for-byte as before.
     ///
     /// [`CellResult`]: super::harness::CellResult
+    /// [`Tier::section_name`]: super::harness::Tier::section_name
     #[must_use]
     pub fn from_cells(
         cells: &[super::harness::CellResult],
@@ -227,38 +258,47 @@ impl TrialReport {
         pace_hz: Option<u64>,
         git_sha: Option<String>,
     ) -> Self {
-        let mut out = Vec::with_capacity(cells.len() * 4);
-        for c in cells {
-            for (metric, s) in [
-                (Metric::Construct, &c.construct),
-                (Metric::Queued, &c.queued),
-                (Metric::Drain, &c.drain),
-                (Metric::Handler, &c.handler),
-            ] {
-                out.push(CellJson {
-                    workers: c.workers,
-                    topo: c.topo.clone(),
-                    metric,
-                    p50: s.p50,
-                    p90: s.p90,
-                    p99: s.p99,
-                    max: s.max,
-                    n: s.n,
-                });
+        use super::harness::Tier;
+
+        let mut sections = Vec::new();
+        for tier in [Tier::Light, Tier::Heavy, Tier::Real] {
+            let mut rows = Vec::new();
+            for c in cells.iter().filter(|c| c.tier == tier) {
+                for (metric, s) in [
+                    (Metric::Construct, &c.construct),
+                    (Metric::Queued, &c.queued),
+                    (Metric::Drain, &c.drain),
+                    (Metric::Handler, &c.handler),
+                ] {
+                    rows.push(CellJson {
+                        workers: c.workers,
+                        topo: c.topo.clone(),
+                        metric,
+                        p50: s.p50,
+                        p90: s.p90,
+                        p99: s.p99,
+                        max: s.max,
+                        n: s.n,
+                    });
+                }
             }
+            if rows.is_empty() {
+                continue;
+            }
+            let body = serde_json::to_value(LatencySection { cells: rows })
+                .unwrap_or(serde_json::Value::Null);
+            sections.push(RawSection {
+                name: tier.section_name().to_owned(),
+                version: LatencySection::VERSION.to_owned(),
+                body,
+            });
         }
-        let latency = LatencySection { cells: out };
-        let body = serde_json::to_value(&latency).unwrap_or(serde_json::Value::Null);
         Self {
             schema: TRIAL_SCHEMA.to_owned(),
             git_sha,
             pace_hz,
             frames,
-            sections: vec![RawSection {
-                name: LatencySection::NAME.to_owned(),
-                version: LatencySection::VERSION.to_owned(),
-                body,
-            }],
+            sections,
         }
     }
 
@@ -601,21 +641,24 @@ pub fn compare(base: &[TrialReport], cand: &[TrialReport], cfg: CompareConfig) -
             continue;
         }
 
-        match name.as_str() {
-            LatencySection::NAME => {
-                let base_cells = decode_latency_cells(&base[..k]);
-                let cand_cells = decode_latency_cells(&cand[..k]);
-                sections.push(compare_latency(name, &base_cells, &cand_cells, k, cfg));
-            }
-            ThroughputSection::NAME => {
-                let base_cells = decode_throughput_cells(&base[..k]);
-                let cand_cells = decode_throughput_cells(&cand[..k]);
-                sections.push(compare_throughput(name, &base_cells, &cand_cells, k, cfg));
-            }
-            _ => sections.push(SectionReport::Uncompared {
+        // A latency section of any tier (light = `latency`, heavy / real
+        // tier-suffixed; ADR-0085 amendment) routes to the same per-cell
+        // paired compare — the verdict numbers are computed identically for
+        // every tier. Verdict *suppression* for non-light tiers is a
+        // render-time concern (see `push_latency_section`), not here.
+        if is_latency_section(name) {
+            let base_cells = decode_latency_cells(name, &base[..k]);
+            let cand_cells = decode_latency_cells(name, &cand[..k]);
+            sections.push(compare_latency(name, &base_cells, &cand_cells, k, cfg));
+        } else if name == ThroughputSection::NAME {
+            let base_cells = decode_throughput_cells(&base[..k]);
+            let cand_cells = decode_throughput_cells(&cand[..k]);
+            sections.push(compare_throughput(name, &base_cells, &cand_cells, k, cfg));
+        } else {
+            sections.push(SectionReport::Uncompared {
                 name: name.clone(),
                 reason: UncomparedReason::UnknownName,
-            }),
+            });
         }
     }
 
@@ -625,14 +668,16 @@ pub fn compare(base: &[TrialReport], cand: &[TrialReport], cfg: CompareConfig) -
     }
 }
 
-/// Per-trial latency cells: decode each trial's `latency` section body,
-/// dropping any trial whose body doesn't decode (it then can't satisfy
-/// the present-in-every-trial gate below, exactly as a missing cell did).
-fn decode_latency_cells(trials: &[TrialReport]) -> Vec<Vec<CellJson>> {
+/// Per-trial latency cells for the named tier section (`latency`,
+/// `latency.heavy`, or `latency.real`; ADR-0085 amendment), decoding each
+/// trial's body and dropping any trial whose body doesn't decode (it then
+/// can't satisfy the present-in-every-trial gate below, exactly as a missing
+/// cell did).
+fn decode_latency_cells(name: &str, trials: &[TrialReport]) -> Vec<Vec<CellJson>> {
     trials
         .iter()
         .map(|t| {
-            t.section(LatencySection::NAME)
+            t.section(name)
                 .and_then(|s| serde_json::from_value::<LatencySection>(s.body.clone()).ok())
                 .map(|l| l.cells)
                 .unwrap_or_default()
@@ -916,11 +961,46 @@ fn us(ns: f64) -> String {
 /// comment in place rather than spamming new ones.
 pub const STICKY_MARKER: &str = "<!-- aether-perf-report -->";
 
+/// The headline `N improved · N stable · N regressed` rollup — the
+/// **gate-signal** count, so it sums **only** the verdict-carrying sections
+/// (ADR-0085 amendment): the light tier's `latency` section and the
+/// throughput section. Heavy / real latency sections are characterisation —
+/// `compare_latency` still populates their improved/regressed counts (the
+/// numbers are wanted), but their verdict is suppressed at render time, so
+/// summing them into the headline would leak a no-verdict tier into the
+/// signal a reviewer reads as "did this change regress". Shared by
+/// [`markdown`] here and `perf-compare`'s `roll_up` so the two never drift.
+#[must_use]
+pub fn headline_counts(report: &ComparisonReport) -> (usize, usize, usize) {
+    report
+        .sections
+        .iter()
+        .fold((0, 0, 0), |(i, s, r), sec| match sec {
+            SectionReport::Compared {
+                name,
+                improved,
+                stable,
+                regressed,
+                ..
+            } if latency_section_renders_verdict(name) => (i + improved, s + stable, r + regressed),
+            SectionReport::ThroughputCompared {
+                improved,
+                stable,
+                regressed,
+                ..
+            } => (i + improved, s + stable, r + regressed),
+            // A non-light latency section is compared (it carries counts)
+            // but its verdict is suppressed — it must not reach the headline.
+            SectionReport::Compared { .. } | SectionReport::Uncompared { .. } => (i, s, r),
+        })
+}
+
 /// Render the comparison as a sticky PR-comment markdown body: headline
-/// counts (summed across the compared sections), then per section — a
-/// `latency` verdict (non-stable rows up top, full grid collapsed) or a
-/// one-line "new this run" note for an uncompared section
-/// (iamacoffeepot/aether#1206).
+/// counts (the verdict-carrying sections only — see [`headline_counts`]),
+/// then per section — a light `latency` verdict (non-stable rows up top,
+/// full grid collapsed), a heavy / real latency *trend grid* (no verdict,
+/// ADR-0085 amendment), or a one-line "new this run" note for an uncompared
+/// section (iamacoffeepot/aether#1206).
 #[must_use]
 #[allow(clippy::format_push_string)]
 pub fn markdown(report: &ComparisonReport, title: &str, subtitle: &str) -> String {
@@ -930,28 +1010,7 @@ pub fn markdown(report: &ComparisonReport, title: &str, subtitle: &str) -> Strin
     s.push_str(&format!("## dispatch perf — {title}\n"));
     s.push_str(&format!("{subtitle}\n\n"));
 
-    let (mut improved, mut stable, mut regressed) = (0usize, 0usize, 0usize);
-    for sec in &report.sections {
-        match sec {
-            SectionReport::Compared {
-                improved: i,
-                stable: st,
-                regressed: r,
-                ..
-            }
-            | SectionReport::ThroughputCompared {
-                improved: i,
-                stable: st,
-                regressed: r,
-                ..
-            } => {
-                improved += i;
-                stable += st;
-                regressed += r;
-            }
-            SectionReport::Uncompared { .. } => {}
-        }
-    }
+    let (improved, stable, regressed) = headline_counts(report);
     s.push_str(&format!(
         "**{improved} improved · {stable} stable · {regressed} regressed** ({} trials/config, paired)\n\n",
         report.trials
@@ -1011,8 +1070,26 @@ fn push_section_tables(
     s.push_str("\n</details>\n\n");
 }
 
+/// Render a latency section. The renderer learns its tier from the section
+/// name (ADR-0085 amendment): the light tier (`latency`) renders the full
+/// verdict treatment — non-stable rows lifted up top, the verdict column,
+/// the "nothing moved" note. A non-light tier (`latency.heavy` /
+/// `latency.real`) renders a **no-verdict trend grid**: every cell in one
+/// table, no verdict column, no lifted rows, no noise-band note. `classify`
+/// still produced a verdict for these cells (the numbers + direction are
+/// wanted); this just declines to *display* it, since the tier's variance
+/// sits below the band a verdict needs.
 #[allow(clippy::format_push_string)]
 fn push_latency_section(s: &mut String, name: &str, cells: &[CellComparison]) {
+    if latency_section_renders_verdict(name) {
+        push_latency_verdict_section(s, name, cells);
+    } else {
+        push_latency_trend_section(s, name, cells);
+    }
+}
+
+#[allow(clippy::format_push_string)]
+fn push_latency_verdict_section(s: &mut String, name: &str, cells: &[CellComparison]) {
     let header = "| topology | w | metric | pct | base µs | this µs | Δ | verdict |\n|---|--:|---|---|--:|--:|--:|---|\n";
     let row = |c: &CellComparison| -> String {
         let verdict = match c.verdict {
@@ -1042,6 +1119,35 @@ fn push_latency_section(s: &mut String, name: &str, cells: &[CellComparison]) {
         .map(&row)
         .collect();
     push_section_tables(s, name, header, &non_stable, &all);
+}
+
+/// The no-verdict trend grid for a heavy / real latency section: one table,
+/// every cell, no verdict column, base/this/Δ only — characterisation, not
+/// classification (ADR-0085 amendment).
+#[allow(clippy::format_push_string)]
+fn push_latency_trend_section(s: &mut String, name: &str, cells: &[CellComparison]) {
+    let header =
+        "| topology | w | metric | pct | base µs | this µs | Δ |\n|---|--:|---|---|--:|--:|--:|\n";
+    s.push_str(&format!(
+        "<details><summary>{name} trend (no verdict — characterisation) — {} cells</summary>\n\n",
+        cells.len()
+    ));
+    s.push_str(header);
+    for c in cells {
+        s.push_str(&format!(
+            "| {} | {} | {} | {} | {} ±{} | {} ±{} | {:+.0}% |\n",
+            c.topo,
+            c.workers,
+            c.metric.label(),
+            c.percentile,
+            us(c.base_median),
+            us(c.base_iqr),
+            us(c.cand_median),
+            us(c.cand_iqr),
+            c.delta_pct,
+        ));
+    }
+    s.push_str("\n</details>\n\n");
 }
 
 /// Render the throughput section (iamacoffeepot/aether#1202) — the
@@ -1501,5 +1607,201 @@ mod tests {
         assert!(md.contains("| topology | w | base k/s |"));
         assert!(md.contains("improved"));
         assert!(md.contains("throughput full grid"));
+    }
+
+    /// Build a K-trial side carrying a single latency cell under the named
+    /// tier section (ADR-0085 amendment) — the tier analog of [`side`]. The
+    /// section name selects the tier (`latency` light, `latency.heavy`,
+    /// `latency.real`).
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
+    fn tier_side(section_name: &str, p50s: &[u64]) -> Vec<TrialReport> {
+        p50s.iter()
+            .map(|&p50| {
+                let cells = vec![CellJson {
+                    workers: 11,
+                    topo: "fanout-8-heavy".to_owned(),
+                    metric: Metric::Drain,
+                    p50,
+                    p90: (p50 as f64 * 1.2) as u64,
+                    p99: (p50 as f64 * 1.5) as u64,
+                    max: p50 * 4,
+                    n: 1800,
+                }];
+                let body = serde_json::to_value(LatencySection { cells })
+                    .expect("encode tier latency body");
+                TrialReport {
+                    schema: TRIAL_SCHEMA.to_owned(),
+                    git_sha: None,
+                    pace_hz: None,
+                    frames: 200,
+                    sections: vec![RawSection {
+                        name: section_name.to_owned(),
+                        version: LatencySection::VERSION.to_owned(),
+                        body,
+                    }],
+                }
+            })
+            .collect()
+    }
+
+    /// Attach a `latency.heavy` section's cells to an existing side, so a
+    /// trial carries both the light `latency` section and the heavy one (the
+    /// realistic `AETHER_PERF_TIER=light,heavy` shape).
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
+    fn with_heavy_section(mut side: Vec<TrialReport>, p50s: &[u64]) -> Vec<TrialReport> {
+        for (t, &p50) in side.iter_mut().zip(p50s.iter()) {
+            let cells = vec![CellJson {
+                workers: 11,
+                topo: "fanout-8-heavy".to_owned(),
+                metric: Metric::Drain,
+                p50,
+                p90: (p50 as f64 * 1.2) as u64,
+                p99: (p50 as f64 * 1.5) as u64,
+                max: p50 * 4,
+                n: 1800,
+            }];
+            let body =
+                serde_json::to_value(LatencySection { cells }).expect("encode heavy latency body");
+            t.sections.push(RawSection {
+                name: "latency.heavy".to_owned(),
+                version: LatencySection::VERSION.to_owned(),
+                body,
+            });
+        }
+        side
+    }
+
+    #[test]
+    fn from_cells_sections_by_tier() {
+        use crate::perf::harness::{CellResult, Stats, Tier};
+
+        let cell = |topo: &str, tier: Tier| CellResult {
+            workers: 4,
+            topo: topo.to_owned(),
+            tier,
+            construct: Stats::default(),
+            queued: Stats::default(),
+            drain: Stats::default(),
+            handler: Stats::default(),
+            depth: Stats::default(),
+            throughput_mps: None,
+        };
+        let cells = vec![
+            cell("fanout-8", Tier::Light),
+            cell("fanout-8-heavy", Tier::Heavy),
+        ];
+        let report = TrialReport::from_cells(&cells, 200, None, None);
+        // One section per tier present, light named `latency` (back-compat),
+        // heavy named `latency.heavy`. No empty real section.
+        let names: Vec<&str> = report.sections.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec![LatencySection::NAME, "latency.heavy"]);
+    }
+
+    #[test]
+    fn heavy_section_renders_no_verdict() {
+        // A `latency.heavy` section is compared (it carries counts), but the
+        // renderer must suppress the verdict: a no-verdict trend grid, no
+        // verdict column, no "no cells moved" note (ADR-0085 amendment). Use
+        // a base/cand that *would* flag a verdict for the light tier so the
+        // suppression is the thing under test, not a coincidentally-stable
+        // cell.
+        let base = tier_side("latency.heavy", &[167_000, 165_000, 169_000, 166_000]);
+        let cand = tier_side("latency.heavy", &[33_000, 34_000, 32_000, 33_500]);
+        let rep = compare(&base, &cand, CompareConfig::default());
+
+        // The heavy section is Compared (the numbers/direction are wanted) ...
+        let heavy = rep
+            .sections
+            .iter()
+            .find(|s| matches!(s, SectionReport::Compared { name, .. } if name == "latency.heavy"))
+            .expect("heavy latency section compared");
+        // ... and it did compute a non-stable verdict internally.
+        let SectionReport::Compared {
+            improved, cells, ..
+        } = heavy
+        else {
+            panic!("heavy section should be compared");
+        };
+        assert!(*improved > 0, "heavy compare still computes the verdict");
+        assert!(
+            cells.iter().any(|c| c.verdict == Verdict::Improved),
+            "the per-cell verdict is still computed (just not rendered)"
+        );
+
+        // But the rendered markdown carries no verdict column / value and no
+        // noise-band note for the heavy section — only the trend grid.
+        let md = markdown(&rep, "PR 9999 vs main", "test");
+        assert!(
+            md.contains("latency.heavy trend (no verdict"),
+            "heavy section renders as a no-verdict trend grid"
+        );
+        assert!(
+            !md.contains("latency.heavy: no cells moved beyond the noise band"),
+            "the noise-band note is suppressed for a no-verdict tier"
+        );
+        // The trend grid's header omits the verdict column the light table has.
+        assert!(md.contains("| topology | w | metric | pct | base µs | this µs | Δ |\n"));
+    }
+
+    #[test]
+    fn headline_rollup_excludes_heavy_and_real() {
+        // CRITICAL guard (ADR-0085 amendment, #1222): the headline rollup is
+        // the gate signal, so a suppressed-verdict heavy / real tier must not
+        // leak into it. Build a light tier that's all-stable and a heavy tier
+        // with a big swing that classify *would* call improved/regressed; the
+        // headline must reflect the light tier only.
+        let light_base = side(&[1000, 1000, 1000, 1000]);
+        let light_cand = side(&[1010, 990, 1005, 995]); // δ ≈ 0 → stable
+        let base = with_heavy_section(light_base, &[167_000, 165_000, 169_000, 166_000]);
+        let cand = with_heavy_section(light_cand, &[33_000, 34_000, 32_000, 33_500]);
+        let rep = compare(&base, &cand, CompareConfig::default());
+
+        // Sanity: the heavy section *did* compute a non-stable verdict.
+        let heavy_improved = rep.sections.iter().any(|s| {
+            matches!(s, SectionReport::Compared { name, improved, .. }
+                if name == "latency.heavy" && *improved > 0)
+        });
+        assert!(heavy_improved, "heavy section computed an improvement");
+
+        // The headline counts the light tier only — its three p50/p90/p99
+        // cells are all stable, so zero improved / regressed from the heavy
+        // swing leaks in.
+        let (improved, _stable, regressed) = headline_counts(&rep);
+        assert_eq!(
+            (improved, regressed),
+            (0, 0),
+            "the heavy tier's verdict must not reach the gate-signal headline"
+        );
+    }
+
+    #[test]
+    fn real_tier_section_compares_and_is_suppressed() {
+        // The real tier parses and sections in PR 1 (its factories are empty
+        // until PR 2), so a `latency.real` section — if present — routes to
+        // the same compare and is verdict-suppressed at render, exactly like
+        // heavy.
+        let base = tier_side("latency.real", &[167_000, 165_000, 169_000, 166_000]);
+        let cand = tier_side("latency.real", &[33_000, 34_000, 32_000, 33_500]);
+        let rep = compare(&base, &cand, CompareConfig::default());
+        assert!(
+            rep.sections.iter().any(
+                |s| matches!(s, SectionReport::Compared { name, .. } if name == "latency.real")
+            ),
+            "real latency section routes to the per-cell compare"
+        );
+        let (improved, _stable, regressed) = headline_counts(&rep);
+        assert_eq!(
+            (improved, regressed),
+            (0, 0),
+            "the real tier's verdict is excluded from the headline too"
+        );
     }
 }

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -31,9 +31,10 @@ use aether_substrate::{BootError, NativeActor, NativeCtx, NativeDispatch, Native
 
 use super::TestBench;
 use crate::perf::harness::{
-    CellResult, Drive, Ping, Relay, RelayConfig, Stats, SweepConfig, Topology, default_topologies,
-    depth_chain, fanout, fanout_heavy, heavy_work_iters_from_env, pace_hz_from_env, relay_id,
-    run_sweep, summarize, two_level_tree, wide_fanout_widths_from_env,
+    CellResult, Drive, Ping, Relay, RelayConfig, Stats, SweepConfig, Tier, Topology,
+    default_topologies, depth_chain, fanout, fanout_heavy, heavy_work_iters_from_env,
+    pace_hz_from_env, relay_id, run_sweep, summarize, tiers_from_env, two_level_tree,
+    wide_fanout_widths_from_env,
 };
 
 /// Self-sustaining ring actor for the multi-worker saturation profile.
@@ -646,13 +647,15 @@ fn lifecycle_latency_observe() {
 
     let pace_hz = pace_hz_from_env();
 
-    // The trivial default set always runs. When AETHER_LATENCY_HEAVY_WORK is
-    // set, append CPU-heavy fan-outs so the sweep can also exhibit the
-    // parallelism-wins regime (iamacoffeepot/aether#1074) — unset, the
-    // grid is byte-for-byte the historical one.
+    // The trivial (light-tier) default set always runs. With the heavy tier
+    // selected (AETHER_PERF_TIER=light,heavy; ADR-0085 amendment), append
+    // CPU-heavy fan-outs so the sweep can also exhibit the parallelism-wins
+    // regime (iamacoffeepot/aether#1074); the heavy spin magnitude comes from
+    // AETHER_LATENCY_HEAVY_WORK (now magnitude-only, with a non-zero
+    // default). Without the heavy tier the grid is the historical light one.
     let mut topologies = default_topologies();
-    let heavy = heavy_work_iters_from_env();
-    if heavy > 0 {
+    if tiers_from_env().contains(&Tier::Heavy) {
+        let heavy = heavy_work_iters_from_env();
         for b in [2usize, 4, 8] {
             topologies.push(fanout_heavy(b, heavy));
         }
@@ -804,8 +807,8 @@ fn print_observe_tables(rows: &[CellResult], pace_hz: Option<u64>) {
     } else {
         println!("flat-out advance — workers stay warm (isolates per-hop dispatch cost)");
     }
-    let heavy = heavy_work_iters_from_env();
-    if heavy > 0 {
+    if tiers_from_env().contains(&Tier::Heavy) {
+        let heavy = heavy_work_iters_from_env();
         println!(
             "heavy leaves: {heavy} spin-iters/handler (*-heavy rows; read HANDLER DUR for actual µs)"
         );


### PR DESCRIPTION
Part of iamacoffeepot/aether#1222 (PR 1 of 3 — tier abstraction; PR 2 = real shapes, PR 3 = CI graph coverage + fidelity cap). Implements the ADR-0085 workload-tier amendment. Does **not** close the issue — the last PR in the series does.

## Summary

Introduces the light/heavy workload-tier abstraction and sections the perf report by tier, with the verdict suppressed for non-`light` tiers. **No new topology shapes** (real is PR 2) and **no CI/workflow changes** (PR 3).

- **`Tier` enum** (`Light`/`Heavy`/`Real`) in `harness.rs`. `Real` parses but yields an empty topology set until PR 2.
- **`AETHER_PERF_TIER` selector** — comma list (default `light`), orthogonal to the existing `AETHER_PERF_TOPOS` (`ci`/`full`) breadth knob.
- **`AETHER_LATENCY_HEAVY_WORK` demoted to magnitude-only** — the tier selector now gates whether heavy shapes appear; the env var only supplies the `busy_spin` count (defaulting to `DEFAULT_HEAVY_WORK_ITERS` when unset). The existing `fanout_heavy` / `two_level_tree_heavy` / `two_level_tree_router_heavy` shapes are promoted into the `heavy` tier via a new `Topology.tier` field threaded through `CellSamples`/`CellResult`.
- **Report sectioned by tier** — `light` stays the section named `latency` (so the v3 back-compat shim and every existing fixture stay valid), `heavy` → `latency.heavy`. `classify`/`compare_latency` are untouched (the verdict is still *computed* for every tier); suppression is render-time — non-`light` tiers render a no-verdict trend grid (no verdict column, no lifted rows, no noise-band note).
- **Headline rollup filtered to `light`** — `compare_latency` populates improved/regressed counts on the heavy section too, so the `N improved · N regressed` headline now sums only the `light` (`latency`) section + throughput. Without this, a suppressed-verdict tier would leak into the gate signal — guarded by a dedicated test.

## Reviewer notes

- **Heavy is dormant in CI on this PR.** The workflow doesn't set `AETHER_PERF_TIER` yet (that's PR 3), so the perf-compare comment here looks unchanged (light-only). The heavy path is exercised by unit tests; PR 3 turns it on in CI.
- **Two judgment calls to eyeball:** `DEFAULT_HEAVY_WORK_ITERS = 50_000` is a plausible tens-of-µs starting point but a number to validate empirically in PR 2/3 (the issue defers exact magnitudes). And `perf-plot.rs` picked up tier-awareness for free (it reuses the same topology parser) — consistent with PR 3 owning the plot's tier-aware env wiring.

## Test plan

- `scripts/preflight.sh` — green (fmt + clippy `-D warnings` + doc + nextest + wasm32 component cross-build). 1374 workspace tests passed.
- New `report.rs` tests: `from_cells_sections_by_tier`, `heavy_section_renders_no_verdict`, `headline_rollup_excludes_heavy_and_real` (the gate-signal guard), `real_tier_section_compares_and_is_suppressed`.
