### PR TITLE
chore(substrate-bundle): co-locate perf plots with their report section

### DIFF
--- a/crates/aether-substrate-bundle/src/bin/perf-plot.rs
+++ b/crates/aether-substrate-bundle/src/bin/perf-plot.rs
@@ -78,12 +78,18 @@ fn main() -> ExitCode {
 
     let mut rendered = 0usize;
     for c in &cells {
-        let hist = format!("{dir}/{}-{}w.png", c.topo, c.workers);
+        // Prefix each filename with the cell's tier section name
+        // (iamacoffeepot/aether#1228) — `latency` / `latency.heavy` /
+        // `latency.real`, the same string `report.rs` anchors against — so
+        // `perf-publish-plots.sh` can group the PNGs under their report
+        // section by reading the `{tier}__` prefix, no topo-name matching.
+        let tier = c.tier.section_name();
+        let hist = format!("{dir}/{tier}__{}-{}w.png", c.topo, c.workers);
         match render_cell(Path::new(&hist), c) {
             Ok(()) => rendered += 1,
             Err(e) => eprintln!("perf-plot: render {hist} failed: {e}"),
         }
-        let pct = format!("{dir}/{}-{}w-percentiles.png", c.topo, c.workers);
+        let pct = format!("{dir}/{tier}__{}-{}w-percentiles.png", c.topo, c.workers);
         match render_cell_percentiles(Path::new(&pct), c) {
             Ok(()) => rendered += 1,
             Err(e) => eprintln!("perf-plot: render {pct} failed: {e}"),

--- a/crates/aether-substrate-bundle/src/perf/report.rs
+++ b/crates/aether-substrate-bundle/src/perf/report.rs
@@ -1104,7 +1104,7 @@ fn push_plot_anchor(s: &mut String, name: &str) {
 
 /// Marker prefix the plot publisher (iamacoffeepot/aether#1228) scans for to
 /// co-locate each section's plots. One `<!-- aether-perf-plots: TIER -->`
-/// comment is emitted after each latency section by [`push_plot_anchor`].
+/// comment is emitted after each latency section by `push_plot_anchor`.
 pub const PLOT_ANCHOR_PREFIX: &str = "<!-- aether-perf-plots:";
 
 #[allow(clippy::format_push_string)]

--- a/crates/aether-substrate-bundle/src/perf/report.rs
+++ b/crates/aether-substrate-bundle/src/perf/report.rs
@@ -1086,7 +1086,26 @@ fn push_latency_section(s: &mut String, name: &str, cells: &[CellComparison]) {
     } else {
         push_latency_trend_section(s, name, cells);
     }
+    push_plot_anchor(s, name);
 }
+
+/// Emit the per-section plot anchor (iamacoffeepot/aether#1228): an HTML
+/// comment `perf-publish-plots.sh` find-replaces with this section's
+/// candidate span-distribution plots (grouped by the matching `{tier}__`
+/// filename prefix). Only latency sections get plots — `perf-plot` renders
+/// one PNG per latency cell and nothing for the throughput section — so this
+/// is the only place an anchor is emitted. The marker carries the section
+/// name verbatim (`latency` / `latency.heavy` / `latency.real`) so the script
+/// matches a plot's tier prefix to its anchor exactly.
+#[allow(clippy::format_push_string)]
+fn push_plot_anchor(s: &mut String, name: &str) {
+    s.push_str(&format!("<!-- aether-perf-plots: {name} -->\n\n"));
+}
+
+/// Marker prefix the plot publisher (iamacoffeepot/aether#1228) scans for to
+/// co-locate each section's plots. One `<!-- aether-perf-plots: TIER -->`
+/// comment is emitted after each latency section by [`push_plot_anchor`].
+pub const PLOT_ANCHOR_PREFIX: &str = "<!-- aether-perf-plots:";
 
 #[allow(clippy::format_push_string)]
 fn push_latency_verdict_section(s: &mut String, name: &str, cells: &[CellComparison]) {
@@ -1128,8 +1147,12 @@ fn push_latency_verdict_section(s: &mut String, name: &str, cells: &[CellCompari
 fn push_latency_trend_section(s: &mut String, name: &str, cells: &[CellComparison]) {
     let header =
         "| topology | w | metric | pct | base µs | this µs | Δ |\n|---|--:|---|---|--:|--:|--:|\n";
+    // A plain trend label — cell count + an explicit "no verdict"
+    // (iamacoffeepot/aether#1228). The improved/stable/regressed tally is
+    // reserved for the verdict-carrying sections (light latency + throughput);
+    // a no-verdict tier showing one would read as a misleading gate signal.
     s.push_str(&format!(
-        "<details><summary>{name} trend (no verdict — characterisation) — {} cells</summary>\n\n",
+        "<details><summary>{name} — {} cells, trend (no verdict)</summary>\n\n",
         cells.len()
     ));
     s.push_str(header);
@@ -1196,41 +1219,57 @@ fn kps(mps: f64) -> String {
 mod tests {
     use super::*;
 
-    /// Build a K-trial side from a per-trial `p50` series for one cell
-    /// (`fanout-8 @ 11w`, drain). Other percentiles track p50 ×1.2 / ×1.5
-    /// so the cell is well-formed; tests assert on p50. The cell rides in
-    /// a single `latency` section (iamacoffeepot/aether#1206).
+    /// One drain cell at `topo @ 11w` with the given `p50` (p90 / p99 / max
+    /// derived ×1.2 / ×1.5 / ×4 so the cell is well-formed; tests assert on
+    /// p50). Shared by the `fanout-8` (light) and `fanout-8-heavy` fixtures so
+    /// the derive lives in one place (`DuplicatedCode` guard).
     #[allow(
         clippy::cast_precision_loss,
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss
     )]
+    fn cell_json(topo: &str, p50: u64) -> CellJson {
+        CellJson {
+            workers: 11,
+            topo: topo.to_owned(),
+            metric: Metric::Drain,
+            p50,
+            p90: (p50 as f64 * 1.2) as u64,
+            p99: (p50 as f64 * 1.5) as u64,
+            max: p50 * 4,
+            n: 1800,
+        }
+    }
+
+    /// Build a single-section [`TrialReport`] envelope (`DuplicatedCode` guard).
+    /// Every fixture trial here carries exactly one section; the envelope
+    /// fields (`schema` / `git_sha` / `pace_hz` / `frames`) are identical
+    /// across them, so factoring this stops the `TrialReport { .. }` block
+    /// from repeating in each builder.
+    fn single_section_trial(name: &str, version: &str, body: serde_json::Value) -> TrialReport {
+        TrialReport {
+            schema: TRIAL_SCHEMA.to_owned(),
+            git_sha: None,
+            pace_hz: None,
+            frames: 200,
+            sections: vec![RawSection {
+                name: name.to_owned(),
+                version: version.to_owned(),
+                body,
+            }],
+        }
+    }
+
+    /// Build a K-trial side from a per-trial `p50` series for one cell
+    /// (`fanout-8 @ 11w`, drain). The cell rides in a single `latency` section
+    /// (iamacoffeepot/aether#1206).
     fn side(p50s: &[u64]) -> Vec<TrialReport> {
         p50s.iter()
             .map(|&p50| {
-                let cells = vec![CellJson {
-                    workers: 11,
-                    topo: "fanout-8".to_owned(),
-                    metric: Metric::Drain,
-                    p50,
-                    p90: (p50 as f64 * 1.2) as u64,
-                    p99: (p50 as f64 * 1.5) as u64,
-                    max: p50 * 4,
-                    n: 1800,
-                }];
+                let cells = vec![cell_json("fanout-8", p50)];
                 let body =
                     serde_json::to_value(LatencySection { cells }).expect("encode latency body");
-                TrialReport {
-                    schema: TRIAL_SCHEMA.to_owned(),
-                    git_sha: None,
-                    pace_hz: None,
-                    frames: 200,
-                    sections: vec![RawSection {
-                        name: LatencySection::NAME.to_owned(),
-                        version: LatencySection::VERSION.to_owned(),
-                        body,
-                    }],
-                }
+                single_section_trial(LatencySection::NAME, LatencySection::VERSION, body)
             })
             .collect()
     }
@@ -1506,17 +1545,7 @@ mod tests {
                 }];
                 let body = serde_json::to_value(ThroughputSection { cells })
                     .expect("encode throughput body");
-                TrialReport {
-                    schema: TRIAL_SCHEMA.to_owned(),
-                    git_sha: None,
-                    pace_hz: None,
-                    frames: 200,
-                    sections: vec![RawSection {
-                        name: ThroughputSection::NAME.to_owned(),
-                        version: ThroughputSection::VERSION.to_owned(),
-                        body,
-                    }],
-                }
+                single_section_trial(ThroughputSection::NAME, ThroughputSection::VERSION, body)
             })
             .collect()
     }
@@ -1609,47 +1638,17 @@ mod tests {
         assert!(md.contains("throughput full grid"));
     }
 
-    /// One `fanout-8-heavy @ 11w` drain cell at the given `p50` (p90/p99/max
-    /// derived ×1.2 / ×1.5 / ×4) — the shared fixture cell for the tier tests.
-    #[allow(
-        clippy::cast_precision_loss,
-        clippy::cast_possible_truncation,
-        clippy::cast_sign_loss
-    )]
-    fn heavy_cell(p50: u64) -> CellJson {
-        CellJson {
-            workers: 11,
-            topo: "fanout-8-heavy".to_owned(),
-            metric: Metric::Drain,
-            p50,
-            p90: (p50 as f64 * 1.2) as u64,
-            p99: (p50 as f64 * 1.5) as u64,
-            max: p50 * 4,
-            n: 1800,
-        }
-    }
-
     /// Build a K-trial side carrying a single latency cell under the named
     /// tier section (ADR-0085 amendment) — the tier analog of [`side`]. The
     /// section name selects the tier (`latency` light, `latency.heavy`,
-    /// `latency.real`).
+    /// `latency.real`); the cell topology is `fanout-8-heavy` throughout.
     fn tier_side(section_name: &str, p50s: &[u64]) -> Vec<TrialReport> {
         p50s.iter()
             .map(|&p50| {
-                let cells = vec![heavy_cell(p50)];
+                let cells = vec![cell_json("fanout-8-heavy", p50)];
                 let body = serde_json::to_value(LatencySection { cells })
                     .expect("encode tier latency body");
-                TrialReport {
-                    schema: TRIAL_SCHEMA.to_owned(),
-                    git_sha: None,
-                    pace_hz: None,
-                    frames: 200,
-                    sections: vec![RawSection {
-                        name: section_name.to_owned(),
-                        version: LatencySection::VERSION.to_owned(),
-                        body,
-                    }],
-                }
+                single_section_trial(section_name, LatencySection::VERSION, body)
             })
             .collect()
     }
@@ -1659,7 +1658,7 @@ mod tests {
     /// realistic `AETHER_PERF_TIER=light,heavy` shape).
     fn with_heavy_section(mut side: Vec<TrialReport>, p50s: &[u64]) -> Vec<TrialReport> {
         for (t, &p50) in side.iter_mut().zip(p50s.iter()) {
-            let cells = vec![heavy_cell(p50)];
+            let cells = vec![cell_json("fanout-8-heavy", p50)];
             let body =
                 serde_json::to_value(LatencySection { cells }).expect("encode heavy latency body");
             t.sections.push(RawSection {
@@ -1732,8 +1731,8 @@ mod tests {
         // noise-band note for the heavy section — only the trend grid.
         let md = markdown(&rep, "PR 9999 vs main", "test");
         assert!(
-            md.contains("latency.heavy trend (no verdict"),
-            "heavy section renders as a no-verdict trend grid"
+            md.contains("latency.heavy — 3 cells, trend (no verdict)"),
+            "heavy section renders as a plain no-verdict trend grid"
         );
         assert!(
             !md.contains("latency.heavy: no cells moved beyond the noise band"),
@@ -1795,5 +1794,87 @@ mod tests {
             (0, 0),
             "the real tier's verdict is excluded from the headline too"
         );
+    }
+
+    #[test]
+    fn latency_sections_emit_plot_anchors_throughput_does_not() {
+        // iamacoffeepot/aether#1228: each latency section (any tier) emits a
+        // per-section plot anchor `perf-publish-plots.sh` find-replaces; the
+        // throughput section emits none (perf-plot renders no throughput PNGs).
+        // Build a report carrying light + heavy latency sections *and* a
+        // throughput section so all three render in one body.
+        let light_base = with_heavy_section(
+            side(&[167_000, 165_000, 169_000, 166_000]),
+            &[167_000, 165_000, 169_000, 166_000],
+        );
+        let light_cand = with_heavy_section(
+            side(&[33_000, 34_000, 32_000, 33_500]),
+            &[33_000, 34_000, 32_000, 33_500],
+        );
+        // Splice a throughput section onto each side.
+        let base = with_throughput(light_base, &[100_000.0, 98_000.0, 102_000.0, 99_000.0]);
+        let cand = with_throughput(light_cand, &[200_000.0, 198_000.0, 202_000.0, 199_000.0]);
+        let rep = compare(&base, &cand, CompareConfig::default());
+        let md = markdown(&rep, "PR 9999 vs main", "test");
+
+        assert!(
+            md.contains("<!-- aether-perf-plots: latency -->"),
+            "light latency section emits its plot anchor"
+        );
+        assert!(
+            md.contains("<!-- aether-perf-plots: latency.heavy -->"),
+            "heavy latency section emits its plot anchor"
+        );
+        // The throughput section renders a verdict table but no plot anchor.
+        assert!(
+            md.contains("| topology | w | base k/s |"),
+            "throughput table is present"
+        );
+        assert!(
+            !md.contains("<!-- aether-perf-plots: throughput -->"),
+            "throughput section emits no plot anchor (perf-plot is latency-only)"
+        );
+    }
+
+    #[test]
+    fn trend_section_carries_no_verdict_tally() {
+        // iamacoffeepot/aether#1228 secondary: a non-light latency section's
+        // summary is a plain trend label (cell count + "no verdict"), never an
+        // improved/stable/regressed tally — the tally would read as a gate
+        // signal for a section that carries none.
+        let base = tier_side("latency.heavy", &[167_000, 165_000, 169_000, 166_000]);
+        let cand = tier_side("latency.heavy", &[33_000, 34_000, 32_000, 33_500]);
+        let rep = compare(&base, &cand, CompareConfig::default());
+        let md = markdown(&rep, "PR 9999 vs main", "test");
+        assert!(
+            md.contains("latency.heavy — 3 cells, trend (no verdict)"),
+            "the trend summary is a plain cell-count + no-verdict label"
+        );
+        assert!(
+            !md.contains("latency.heavy: improved") && !md.contains("latency.heavy improved"),
+            "no verdict tally leaks into the trend section header"
+        );
+    }
+
+    /// Attach a `throughput` section (one `fanout-8 @ 11w` cell per trial,
+    /// rate from `rates`) to an existing side, so a trial carries both its
+    /// latency section(s) and the throughput one — the realistic saturate +
+    /// latency shape used by the anchor test.
+    fn with_throughput(mut side: Vec<TrialReport>, rates: &[f64]) -> Vec<TrialReport> {
+        for (t, &mails_per_sec) in side.iter_mut().zip(rates.iter()) {
+            let cells = vec![ThroughputCell {
+                workers: 11,
+                topo: "fanout-8".to_owned(),
+                mails_per_sec,
+            }];
+            let body =
+                serde_json::to_value(ThroughputSection { cells }).expect("encode throughput body");
+            t.sections.push(RawSection {
+                name: ThroughputSection::NAME.to_owned(),
+                version: ThroughputSection::VERSION.to_owned(),
+                body,
+            });
+        }
+        side
     }
 }

--- a/scripts/perf-publish-plots.sh
+++ b/scripts/perf-publish-plots.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 # iamacoffeepot/aether#1155: publish the candidate span-distribution PNGs
 # (rendered by `aether-perf-plot` into $PLOT_DIR) to the `perf-plots`
-# branch — a blob store with no source history — under pr-<N>/, then
-# append inline image embeds to the sticky-comment body ($MD_OUT).
+# branch — a blob store with no source history — under pr-<N>/, then embed
+# inline image references into the sticky-comment body ($MD_OUT).
+#
+# iamacoffeepot/aether#1228: instead of one end-of-comment lump, each plot
+# is co-located under the report section it describes. `perf-plot` prefixes
+# every PNG with its tier section name (`{tier}__{topo}-{workers}w.png`,
+# tier ∈ latency / latency.heavy / latency.real) and `report.rs` emits a
+# per-section anchor `<!-- aether-perf-plots: TIER -->`. This script
+# find-replaces each anchor with that tier's plots wrapped in one collapsed
+# <details>. The throughput section gets no anchor (perf-plot is latency-only).
 #
 # Why a branch: GitHub's comment image proxy (camo) fetches `![](url)`
 # anonymously, so the PNGs need a public URL it can reach. The repo is
@@ -45,15 +53,76 @@ git -C "$pp" add "$dir"
 git -C "$pp" commit --quiet -m "perf plots: PR #${PR}"
 git -C "$pp" push --quiet origin "HEAD:${branch}"
 
-# Append inline embeds to the sticky-comment body.
-{
-    printf '\n<details><summary>span distributions (candidate)</summary>\n\n'
+# Co-locate each section's plots at its anchor (iamacoffeepot/aether#1228).
+# For each `<!-- aether-perf-plots: TIER -->` anchor in $MD_OUT, replace it
+# with a collapsed <details> holding the plots whose filename begins with
+# `TIER__`. Anchors with no matching plots collapse to nothing; plots whose
+# tier matched no anchor (shouldn't happen) are appended at the end so none
+# are silently dropped. The single `<!-- aether-perf-report -->` sticky
+# marker is untouched — the upsert finds the comment by it.
+#
+# Render one section's <details> block for tier $1 to stdout (empty if the
+# tier has no plots). The URL embeds the full basename (the committed file
+# name, prefix included).
+emit_section_plots() {
+    local tier="$1"
+    local prefix="${tier}__"
+    local any=0
     for f in "${pngs[@]}"; do
+        local n
         n="$(basename "$f" .png)"
+        case "$n" in
+            "$prefix"*) ;;
+            *) continue ;;
+        esac
+        if [ "$any" -eq 0 ]; then
+            printf '<details><summary>span distributions (candidate)</summary>\n\n'
+            any=1
+        fi
         printf '![%s](https://github.com/%s/raw/%s/%s/%s.png)\n\n' \
             "$n" "$REPO" "$branch" "$dir" "$n"
     done
-    printf '</details>\n'
-} >> "$MD_OUT"
+    if [ "$any" -eq 1 ]; then
+        printf '</details>\n\n'
+    fi
+}
 
-echo "perf-publish-plots: published ${#pngs[@]} plot(s) to ${branch}/${dir}, embedded in ${MD_OUT}" >&2
+# Tiers a plot filename can carry, longest-prefix-first so `latency.heavy`
+# is tested before the bare `latency` (otherwise `latency.heavy__...` would
+# match the `latency__` prefix test — it doesn't, the `__` is exact, but the
+# explicit order documents the intent and guards a future bare-`latency`
+# glob). Mirrors report.rs's anchored section names.
+tiers=(latency.heavy latency.real latency)
+
+out="$(mktemp)"
+matched_tiers=""
+while IFS= read -r line || [ -n "$line" ]; do
+    anchored=""
+    for tier in "${tiers[@]}"; do
+        if [ "$line" = "<!-- aether-perf-plots: ${tier} -->" ]; then
+            anchored="$tier"
+            break
+        fi
+    done
+    if [ -n "$anchored" ]; then
+        emit_section_plots "$anchored"
+        matched_tiers="${matched_tiers} ${anchored}"
+    else
+        printf '%s\n' "$line"
+    fi
+done <"$MD_OUT" >"$out"
+
+# Fallback: any plot whose tier never matched an anchor is appended so it
+# isn't silently lost (e.g. a tier with plots but no rendered section).
+{
+    for tier in "${tiers[@]}"; do
+        case " ${matched_tiers} " in
+            *" ${tier} "*) continue ;;
+        esac
+        emit_section_plots "$tier"
+    done
+} >>"$out"
+
+mv "$out" "$MD_OUT"
+
+echo "perf-publish-plots: published ${#pngs[@]} plot(s) to ${branch}/${dir}, co-located in ${MD_OUT}" >&2


### PR DESCRIPTION
Closes iamacoffeepot/aether#1228.

## Summary

Co-locates each perf-compare plot under the report section it belongs to, instead of dumping every PNG into one `<details>` block at the end of the sticky comment.

- **`perf-plot.rs`** — names each PNG `{tier}__{topo}-{workers}w.png` (and the `-percentiles` variant), where `tier` is `Tier::section_name()` (`latency` / `latency.heavy` / `latency.real`). `CellSamples` already carried `tier`, so this is just a filename prefix.
- **`report.rs`** — emits a per-section anchor `<!-- aether-perf-plots: TIER -->` at the end of each latency section (new `push_plot_anchor`). The `throughput` section gets no anchor — `perf-plot` renders span distributions for latency cells only, so throughput has no plots (asserted in a test).
- **`perf-publish-plots.sh`** — replaces the single end-of-comment block: each anchor is replaced in place with a collapsed `<details>` holding that tier's plots (longest-prefix-first so `latency.heavy` matches before bare `latency`; a fallback appends any unmatched tier so nothing is silently dropped). The `perf-plots`-branch push, the fork-PR read-only-token tolerance, and the single `<!-- aether-perf-report -->` sticky marker are all preserved.

## Secondary

Drops the misleading `0 improved · 0 stable · 0 regressed` tally from the no-verdict trend section's summary (`{name} — N cells, trend (no verdict)`); the verdict tally now appears only on the sections that actually carry a verdict (light latency + throughput).

## Test plan

- `scripts/preflight.sh` — green (fmt + clippy `-D warnings` + doc + nextest + wasm32 cross-build).
- New/updated `report.rs` tests: plot anchors emitted for latency sections + absent for throughput, trend section carries no verdict tally, the heavy-section trend label. Shared fixtures factored (`cell_json` / `single_section_trial`) to pre-clear `DuplicatedCode` (RustRover reports zero problems on both edited files).
- A functional bash test of the co-location logic against mock markdown + PNGs: three `<details>` blocks land under the correct sections, exactly one sticky marker, zero anchors left, throughput plot-free.
- **End-to-end placement in the live comment is only verifiable via this PR's own perf-compare run** (it needs the CI runner to render + push the PNGs and upsert the comment) — label the PR `perf` to exercise it, as with iamacoffeepot/aether#1231.

## Note

This is comment *layout* only — it co-locates whatever plots exist. The real-tier plots themselves remain unreliable until iamacoffeepot/aether#1233 (the socket-server N² shape + trace-ring limits); that's tracked separately.
