### PR TITLE
fix(substrate-bundle): clamp saturate burst per-cell so wide fan-out throughput cells stay measurable

### DIFF
--- a/crates/aether-substrate-bundle/src/perf/harness.rs
+++ b/crates/aether-substrate-bundle/src/perf/harness.rs
@@ -272,6 +272,18 @@ pub struct Topology {
     pub tier: Tier,
 }
 
+/// The widest fan-out in `topo` — the largest `downstreams[i].len()` over
+/// all relays (0 for a topology with no edges). A relay records
+/// `2 + out_degree` trace-ring slots per inbound mail (`Received` +
+/// `Finished` on dispatch, plus one `Sent` per downstream), so this is the
+/// fan-out multiplier in the per-actor ring-budget bound
+/// `backlog * (2 + max_out_degree) <= ring_cap` that the `Saturate` burst
+/// clamp in [`run_sweep_samples`] enforces (iamacoffeepot/aether#1226).
+#[must_use]
+pub fn max_out_degree(topo: &Topology) -> usize {
+    topo.downstreams.iter().map(Vec::len).max().unwrap_or(0)
+}
+
 /// The downstream adjacency of a `d`-node forward chain `0 -> 1 -> ... ->
 /// d-1`: each node forwards to its successor; the last is a leaf. Shared by
 /// the [`depth_chain`] (light) and [`ui_roundtrip`] (real) factories so the
@@ -748,18 +760,30 @@ pub fn drive_for_tier(drive: Drive, tier: Tier) -> Drive {
 }
 
 /// Default per-tick `Ping` burst for a `Saturate` cell when
-/// `AETHER_PERF_BACKLOG` is unset. Sized comfortably under the per-actor
-/// trace ring capacity ([`DEFAULT_TRACE_RING_CAP`]) so a default-backlog
-/// run never laps the ring (see [`saturate_backlog_from_env`]).
+/// `AETHER_PERF_BACKLOG` is unset. This is the *requested* depth, not the
+/// effective one: a relay writes `2 + out_degree` trace-ring slots per
+/// inbound mail (`Received` + `Finished` on dispatch, plus one `Sent` per
+/// downstream), so the binding constraint on the entry relay's per-actor
+/// ring ([`DEFAULT_TRACE_RING_CAP`]) is `backlog * (2 + out_degree) <=
+/// ring_cap`, not `backlog <= ring_cap`. At 512 a low-fan-out cell stays
+/// well under cap, but a wide fan-out laps it (`fanout-8`:
+/// `512 * (2 + 8) = 5120 > 4096`). [`run_sweep_samples`] therefore clamps
+/// each `Saturate` cell's burst to `ring_cap / (2 + max_out_degree(topo))`
+/// so every cell stays measurable regardless of fan-out
+/// (iamacoffeepot/aether#1226).
 pub const DEFAULT_SATURATE_BACKLOG: u32 = 512;
 
 /// Read the per-tick saturation backlog from `AETHER_PERF_BACKLOG`
 /// (iamacoffeepot/aether#1202), defaulting to [`DEFAULT_SATURATE_BACKLOG`]
-/// when unset / unparseable / `0`. Clamped to the per-actor trace ring
-/// capacity ([`DEFAULT_TRACE_RING_CAP`]): a burst larger than the ring
-/// laps the entry relay's ring, which the harvest detects as `truncated`
-/// and the cell then reports no rate for. Clamping up front keeps a
-/// merely-large backlog measurable instead of silently truncated.
+/// when unset / unparseable / `0`. The `min(cap)` here is the *env ceiling*
+/// only — it bounds the parsed value against the per-actor trace ring
+/// capacity ([`DEFAULT_TRACE_RING_CAP`]) so a wildly-large
+/// `AETHER_PERF_BACKLOG` can't request a depth no topology could ever fit.
+/// It does **not** account for fan-out: a relay records `2 + out_degree`
+/// ring slots per inbound mail, so the tighter per-topology bound
+/// (`backlog * (2 + out_degree) <= ring_cap`) lives at the cell in
+/// [`run_sweep_samples`], which clamps each `Saturate` burst to
+/// `ring_cap / (2 + max_out_degree(topo))` (iamacoffeepot/aether#1226).
 #[must_use]
 pub fn saturate_backlog_from_env() -> u32 {
     let cap = u32::try_from(DEFAULT_TRACE_RING_CAP).unwrap_or(u32::MAX);
@@ -1078,10 +1102,27 @@ pub fn run_sweep_samples(cfg: &SweepConfig) -> Vec<CellSamples> {
             let drive = drive_for_tier(cfg.drive, topo.tier);
             // `burst` is the per-tick `Ping` count: 1 in `Latency` (one
             // root per frame), `backlog` in `Saturate` (a deep ready queue
-            // drained in one frame, iamacoffeepot/aether#1202).
+            // drained in one frame, iamacoffeepot/aether#1202). The
+            // `Saturate` arm is reached only by Light / Heavy cells — the
+            // real tier is forced paced by `drive_for_tier` above — so the
+            // clamp below governs only flooding bursts. A relay writes
+            // `2 + out_degree` trace-ring slots per inbound mail, so a
+            // backlog that fans out wide laps the entry relay's per-actor
+            // ring once `backlog * (2 + max_out_degree) > ring_cap`; clamp
+            // each cell's burst to the deepest backlog its ring allows so
+            // every cell stays measurable instead of silently truncating
+            // (iamacoffeepot/aether#1226). Low-fan-out cells keep full
+            // depth; a wide fan-out (e.g. `fanout-8`: `4096 / 10 = 409`)
+            // drops to fit, and any future wider fan-out stays measurable
+            // automatically.
             let burst = match drive {
                 Drive::Latency { .. } => 1,
-                Drive::Saturate { backlog } => backlog,
+                Drive::Saturate { backlog } => {
+                    let ring_cap = u32::try_from(DEFAULT_TRACE_RING_CAP).unwrap_or(u32::MAX);
+                    let out_degree = u32::try_from(max_out_degree(topo)).unwrap_or(u32::MAX);
+                    let fanout_divisor = out_degree.saturating_add(2);
+                    backlog.min(ring_cap / fanout_divisor)
+                }
             };
             if let Err(e) = tb
                 .spawn_actor::<TickSource>(Subname::Named("src"), (relay_id(0), burst))
@@ -1344,6 +1385,32 @@ mod tests {
     }
 
     #[test]
+    fn fanout_8_at_default_backlog_reports_finite_rate() {
+        // Regression (iamacoffeepot/aether#1226): the entry relay of
+        // `fanout(8)` forwards each inbound root to 8 leaves, so it records
+        // `2 + 8 = 10` trace-ring slots per root. At the default backlog
+        // (512) that is `512 * 10 = 5120 > 4096` (the per-actor ring cap),
+        // which lapped the ring, tripped the truncation gate, and dropped
+        // `fanout-8`'s throughput cell entirely. `fanout(8)` is `Tier::Light`
+        // (the default tier), so the `Saturate` arm survives `drive_for_tier`
+        // and this is the exact reproduction at the default depth. The
+        // per-cell burst clamp (`4096 / 10 = 409`) must keep the cell
+        // measurable: a finite, positive, non-truncated rate.
+        let Some(cell) = saturate_cell(2, fanout(8), DEFAULT_SATURATE_BACKLOG) else {
+            eprintln!("skipping: no wgpu adapter");
+            return;
+        };
+        let mps = cell.throughput_mps.expect(
+            "fanout-8 at the default backlog must report a rate, not truncate to None \
+             (iamacoffeepot/aether#1226)",
+        );
+        assert!(
+            mps.is_finite() && mps > 0.0,
+            "throughput must be positive and finite, got {mps}"
+        );
+    }
+
+    #[test]
     fn throughput_rises_with_backlog_on_fixed_topology() {
         // Latency mode never reports a rate; the historical path is intact.
         let topo = fanout(4);
@@ -1426,26 +1493,14 @@ mod tests {
         );
     }
 
-    #[test]
-    fn over_capacity_backlog_flags_truncation_not_a_wrong_rate() {
-        // A backlog past the per-actor ring capacity laps the entry
-        // source's ring (it holds one `Sent` per root). The harvest detects
-        // the lap and the cell reports no rate, rather than dividing an
-        // undercounted completed-count by the wall window
-        // (iamacoffeepot/aether#1202). depth-1 is the cheapest topology, so
-        // the lap is on the source ring's root count, not a busy relay's
-        // fan-out. The normal env path clamps below the cap, so this
-        // over-cap value is fed straight to the sweep.
-        let cap = u32::try_from(DEFAULT_TRACE_RING_CAP).unwrap_or(u32::MAX);
-        let Some(cell) = saturate_cell(2, depth_chain(1), cap + 1) else {
-            eprintln!("skipping: no wgpu adapter");
-            return;
-        };
-        assert!(
-            cell.throughput_mps.is_none(),
-            "an over-capacity backlog must flag truncation (no rate), not report a wrong one"
-        );
-    }
+    // The former `over_capacity_backlog_flags_truncation_not_a_wrong_rate`
+    // lived here and fed an over-capacity backlog straight to the sweep to
+    // force a lap. The per-cell burst clamp (iamacoffeepot/aether#1226) now
+    // bounds every `Saturate` cell to `ring_cap / (2 + max_out_degree)`, so
+    // the sweep path can no longer lap a ring — its premise is unreachable.
+    // The truncation contract (a `None`-rate cell is surfaced flagged, not
+    // dropped) is now report-side; the assertion moved to
+    // `report::tests::truncated_cell_is_flagged_not_dropped`.
 
     #[test]
     fn over_capacity_backlog_is_clamped_by_env_parse() {

--- a/crates/aether-substrate-bundle/src/perf/report.rs
+++ b/crates/aether-substrate-bundle/src/perf/report.rs
@@ -170,12 +170,20 @@ fn latency_section_renders_verdict(name: &str) -> bool {
 
 /// One cell's measured throughput in a single trial
 /// (iamacoffeepot/aether#1202): completed mails/sec for a (worker ×
-/// topology) cell under saturation.
+/// topology) cell under saturation. `mails_per_sec` is `None` when the
+/// cell **truncated** — the entry relay's trace ring lapped during the run,
+/// so the completed-count is undercounted and any rate computed from it
+/// would be wrong. Such a cell is emitted flagged-not-dropped
+/// (iamacoffeepot/aether#1226) so a missing measurement is visible in the
+/// section rather than silently absent; the comparator treats it as "no
+/// measurement" (`find_throughput_cell` filters `None`-rate cells out of
+/// the hit set).
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ThroughputCell {
     pub workers: usize,
     pub topo: String,
-    pub mails_per_sec: f64,
+    /// `Some(rate)` for a measured cell; `None` when the cell truncated.
+    pub mails_per_sec: Option<f64>,
 }
 
 impl ThroughputCell {
@@ -201,7 +209,11 @@ impl ThroughputSection {
     /// new section iamacoffeepot/aether#1206's fixtures already named.
     pub const NAME: &str = "throughput";
     /// The section version. Bumped when the throughput cell shape changes.
-    pub const VERSION: &str = "v1";
+    /// `v2` (iamacoffeepot/aether#1226): `mails_per_sec` became
+    /// `Option<f64>` so a truncated cell is emitted flagged
+    /// (`mails_per_sec: null`) instead of dropped — an older `v1` base
+    /// trial (rate always present) sections cleanly against the bump.
+    pub const VERSION: &str = "v2";
 }
 
 /// One fresh-process sweep run. The `perf-trial` bin emits this as JSON
@@ -305,10 +317,13 @@ impl TrialReport {
     /// Build a *saturation* trial report from a sweep's [`CellResult`]s
     /// (iamacoffeepot/aether#1202). A saturate run reports **throughput
     /// only** — per-hop latency under saturation is contended and
-    /// high-variance, so pairing it would compare noise. Each cell with a
-    /// measured `throughput_mps` (a truncated cell carries `None` and is
-    /// skipped) contributes one [`ThroughputCell`]; the rows ride in a
-    /// single [`ThroughputSection`].
+    /// high-variance, so pairing it would compare noise. Every cell
+    /// contributes one [`ThroughputCell`]: a measured cell carries its
+    /// `throughput_mps` and a truncated cell carries `None`
+    /// (iamacoffeepot/aether#1226) — emitted flagged-not-dropped so a
+    /// missing measurement is visible in the section rather than silently
+    /// filtered away (the comparator still treats a `None`-rate cell as "no
+    /// measurement"). The rows ride in a single [`ThroughputSection`].
     ///
     /// [`CellResult`]: super::harness::CellResult
     #[must_use]
@@ -319,12 +334,10 @@ impl TrialReport {
     ) -> Self {
         let rows: Vec<ThroughputCell> = cells
             .iter()
-            .filter_map(|c| {
-                c.throughput_mps.map(|mps| ThroughputCell {
-                    workers: c.workers,
-                    topo: c.topo.clone(),
-                    mails_per_sec: mps,
-                })
+            .map(|c| ThroughputCell {
+                workers: c.workers,
+                topo: c.topo.clone(),
+                mails_per_sec: c.throughput_mps,
             })
             .collect();
         let throughput = ThroughputSection { cells: rows };
@@ -799,16 +812,21 @@ fn decode_throughput_cells(trials: &[TrialReport]) -> Vec<Vec<ThroughputCell>> {
         .collect()
 }
 
-/// Find the throughput cell matching `key` in one trial's cells (a free
-/// fn so the returned borrow ties to the slice's lifetime, mirroring
-/// [`find_cell`]).
+/// Find the *measured* throughput cell matching `key` in one trial's cells
+/// (a free fn so the returned borrow ties to the slice's lifetime, mirroring
+/// [`find_cell`]). A truncated cell (`mails_per_sec == None`,
+/// iamacoffeepot/aether#1226) is present in the section but is **not** a
+/// measurement, so it is filtered out here: [`compare_throughput`]'s
+/// "present in every trial" gate then treats the cell as absent (no
+/// measurement, not a regression to zero) without any further comparator
+/// branch.
 fn find_throughput_cell<'a>(
     cells: &'a [ThroughputCell],
     key: &ThroughputKey,
 ) -> Option<&'a ThroughputCell> {
     cells
         .iter()
-        .find(|c| c.workers == key.workers && c.topo == key.topo)
+        .find(|c| c.workers == key.workers && c.topo == key.topo && c.mails_per_sec.is_some())
 }
 
 /// The throughput section's per-cell paired-delta compare
@@ -845,8 +863,10 @@ fn compare_throughput(
             continue; // cell not present in every trial — skip
         }
 
-        let base_vals: Vec<f64> = base_hits.iter().map(|c| c.mails_per_sec).collect();
-        let cand_vals: Vec<f64> = cand_hits.iter().map(|c| c.mails_per_sec).collect();
+        // `find_throughput_cell` only returns measured cells, so every hit
+        // carries `Some` here (iamacoffeepot/aether#1226).
+        let base_vals: Vec<f64> = base_hits.iter().filter_map(|c| c.mails_per_sec).collect();
+        let cand_vals: Vec<f64> = cand_hits.iter().filter_map(|c| c.mails_per_sec).collect();
         let deltas: Vec<f64> = (0..k).map(|t| cand_vals[t] - base_vals[t]).collect();
 
         let base_sorted = sorted(base_vals.clone());
@@ -1541,7 +1561,7 @@ mod tests {
                 let cells = vec![ThroughputCell {
                     workers: 11,
                     topo: "fanout-8".to_owned(),
-                    mails_per_sec,
+                    mails_per_sec: Some(mails_per_sec),
                 }];
                 let body = serde_json::to_value(ThroughputSection { cells })
                     .expect("encode throughput body");
@@ -1617,7 +1637,104 @@ mod tests {
         let tp: ThroughputSection =
             serde_json::from_value(sec.body.clone()).expect("decode throughput body");
         assert_eq!(tp.cells.len(), 1);
-        assert!((tp.cells[0].mails_per_sec - 100_000.0).abs() < f64::EPSILON);
+        let rate = tp.cells[0]
+            .mails_per_sec
+            .expect("a measured cell round-trips its rate");
+        assert!((rate - 100_000.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn truncated_cell_is_flagged_not_dropped() {
+        // Steps 3 + 4 (iamacoffeepot/aether#1226): a cell whose ring lapped
+        // carries `throughput_mps == None`. `from_throughput_cells` used to
+        // `filter_map` that `None` away, so the cell vanished from the
+        // section and from any base-vs-candidate comparison — the only trace
+        // was a stderr warn. It must now appear flagged (`mails_per_sec ==
+        // None`) so a missing measurement is visible in the report. (This is
+        // the relocated truncation contract that
+        // `over_capacity_backlog_flags_truncation_not_a_wrong_rate` once
+        // tested via the sweep path, now unreachable after the per-cell
+        // burst clamp.)
+        use crate::perf::harness::{CellResult, Stats, Tier};
+
+        let cell = |topo: &str, throughput_mps: Option<f64>| CellResult {
+            workers: 2,
+            topo: topo.to_owned(),
+            tier: Tier::Light,
+            construct: Stats::default(),
+            queued: Stats::default(),
+            drain: Stats::default(),
+            handler: Stats::default(),
+            depth: Stats::default(),
+            throughput_mps,
+        };
+        let cells = vec![
+            cell("depth-1", Some(123_456.0)),
+            cell("fanout-8", None), // truncated — ring lapped
+        ];
+
+        let report = TrialReport::from_throughput_cells(&cells, 1, None);
+        let sec = &report.sections[0];
+        assert_eq!(sec.name, ThroughputSection::NAME);
+        assert_eq!(sec.version, ThroughputSection::VERSION); // v2
+        let tp: ThroughputSection =
+            serde_json::from_value(sec.body.clone()).expect("decode throughput body");
+
+        // Both cells are present — the truncated one is flagged, not dropped.
+        assert_eq!(tp.cells.len(), 2, "truncated cell must not be filtered out");
+        let flagged = tp
+            .cells
+            .iter()
+            .find(|c| c.topo == "fanout-8")
+            .expect("the truncated fanout-8 cell is present in the section");
+        assert!(
+            flagged.mails_per_sec.is_none(),
+            "a truncated cell carries no rate (flagged), got {:?}",
+            flagged.mails_per_sec
+        );
+        let measured = tp
+            .cells
+            .iter()
+            .find(|c| c.topo == "depth-1")
+            .expect("the measured depth-1 cell is present");
+        assert_eq!(measured.mails_per_sec, Some(123_456.0));
+    }
+
+    #[test]
+    fn truncated_cell_reads_as_no_measurement_in_compare() {
+        // Step 4 (iamacoffeepot/aether#1226): a flagged-not-dropped truncated
+        // cell must read as "no measurement" in the comparator — skipped by
+        // the existing "present in every trial" gate, not scored as a rate of
+        // zero. `find_throughput_cell` filters out `None`-rate cells, so the
+        // cell is absent from the hit set on both sides and the gate drops it.
+        let truncated_side = |k: usize| -> Vec<Vec<ThroughputCell>> {
+            (0..k)
+                .map(|_| {
+                    vec![ThroughputCell {
+                        workers: 11,
+                        topo: "fanout-8".to_owned(),
+                        mails_per_sec: None,
+                    }]
+                })
+                .collect()
+        };
+        let k = 4;
+        let report = compare_throughput(
+            ThroughputSection::NAME,
+            &truncated_side(k),
+            &truncated_side(k),
+            k,
+            CompareConfig::default(),
+        );
+        // The only cell present is truncated on both sides, so the section
+        // compares with zero scored cells (no regression-to-zero verdict).
+        match report {
+            SectionReport::ThroughputCompared { cells, .. } => assert!(
+                cells.is_empty(),
+                "a truncated cell must produce no scored comparison cell, got {cells:?}"
+            ),
+            other => panic!("expected a compared throughput section, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1865,7 +1982,7 @@ mod tests {
             let cells = vec![ThroughputCell {
                 workers: 11,
                 topo: "fanout-8".to_owned(),
-                mails_per_sec,
+                mails_per_sec: Some(mails_per_sec),
             }];
             let body =
                 serde_json::to_value(ThroughputSection { cells }).expect("encode throughput body");


### PR DESCRIPTION
Closes iamacoffeepot/aether#1226.

## Summary

The saturate-throughput sweep silently produced no data for its highest-contention cells. A `Drive::Saturate` per-tick burst of `DEFAULT_SATURATE_BACKLOG` (512) roots, fanned out at the entry relay, overran that relay's per-actor trace ring (cap 4096): a relay writes `2 + out_degree` ring slots per inbound mail, so the binding constraint is `backlog * (2 + out_degree) <= ring_cap`, not `backlog <= ring_cap`. For `fanout-8` (`512 * (2 + 8) = 5120 > 4096`) the ring lapped, the harvest flagged the cell `truncated`, and `from_throughput_cells` then `filter_map`-ed the `None` rate away — so the loudest-contention topology of the default `ci` sweep vanished from the throughput section and from any base-vs-candidate comparison, with only a `tracing::warn` on stderr as signal. That is exactly the cell a scheduler change is most likely to regress, and it was invisible to the release gate.

Chosen approach (issue §Design notes, option 1): a per-topology backlog cap, paired with the report-side observability fix.

- **Sizing fix.** Clamp each `Saturate` cell's burst in `run_sweep_samples` to `backlog.min(ring_cap / (2 + max_out_degree(topo)))`, where `ring_cap = u32::try_from(DEFAULT_TRACE_RING_CAP)`. This self-scales: low-fan-out cells keep full depth (512), `fanout-8` drops to `4096 / 10 = 409`, and any future wider fan-out stays measurable automatically. A `#[must_use] fn max_out_degree(topo)` helper near the `Topology` definition is shared by the clamp and the regression test. The arm is only ever reached by Light/Heavy cells — the real tier is forced paced by `drive_for_tier` (ADR-0085), so wide real-tier shapes like `socket-server-32` are immune (always burst = 1).
- **Observability fix (defense-in-depth).** `ThroughputCell.mails_per_sec` becomes `Option<f64>` and `from_throughput_cells` emits one cell per `CellResult` — truncated cells flagged, not dropped — so a missing measurement is visible in the section JSON rather than only on stderr. `ThroughputSection::VERSION` bumps v1 to v2 (an older v1 base trial sections cleanly against it). `find_throughput_cell` filters `None`-rate cells out of the hit set, so the comparator's existing "present in every trial" gate treats a flagged cell as "no measurement" (not a regression to zero) with no further comparator change.
- **Docstrings.** Corrected `DEFAULT_SATURATE_BACKLOG` (dropped the false "never laps the ring" claim, stated the real `backlog * (2 + out_degree) <= ring_cap` constraint) and `saturate_backlog_from_env` (its `ring_cap` clamp is the env ceiling; the tighter per-topology bound lives at the cell).

Sibling iamacoffeepot/aether#1227 (saturate throughput is a makespan average) and iamacoffeepot/aether#1233 (latency/real-tier face of the shared trace-ring lapping root cause) are out of scope — this PR is the saturate-mode fix only.

No ADR: a bug fix within the existing perf-harness subsystem, the only serialized-shape change being an additive, version-gated field on an internal trial report.

## Test plan

- `fanout_8_at_default_backlog_reports_finite_rate` (harness) — the exact reproduction: `saturate_cell(2, fanout(8), DEFAULT_SATURATE_BACKLOG)` asserts a finite, positive, non-truncated rate (would fail before the clamp).
- `truncated_cell_is_flagged_not_dropped` (report) — a `CellResult` with `throughput_mps = None` flows through `from_throughput_cells` present-and-flagged (`mails_per_sec == None`), alongside a measured cell; v2 version asserted.
- `truncated_cell_reads_as_no_measurement_in_compare` (report) — a flagged cell produces no scored comparison cell (skipped by the existing gate, not scored as zero).
- The now-unreachable `over_capacity_backlog_flags_truncation_not_a_wrong_rate` sweep test was relocated onto the report-side gate (the per-cell clamp removes the only sweep path that could lap a ring); `over_capacity_backlog_is_clamped_by_env_parse` stays valid as-is.
- Updated the throughput fixtures + round-trip (`throughput_side`, `with_throughput`, `report_json_round_trip_preserves_throughput_section`) for the `Option<f64>` cell shape and v2 version.
- Manual reproduction: `AETHER_PERF_DRIVE=saturate AETHER_PERF_WORKERS=2 AETHER_PERF_TOPOS=ci AETHER_PERF_FRAMES=5` now emits a finite `fanout-8` rate in the throughput section (v2), no lap warning on stderr, all five `ci` cells present.
- Local pre-flight (fmt + clippy + doc + nextest + wasm32 cross-build) green; RustRover inspections clean on both changed files.

## Generated by

`/implement` — agent execution of [scoped issue iamacoffeepot/aether#1226](https://github.com/iamacoffeepot/aether/issues/1226).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
