### PR TITLE
chore: gitignore all .env files (any directory and variant)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,8 @@ spikes/*/target/
 # (iamacoffeepot/aether#1084) — populated by scripts/perf-compare.sh,
 # persisted by the workflow's actions/cache, never committed.
 /.perf-cache/
+# Environment files — may hold secrets (API keys, etc.); never commit.
+# Covers any directory and every variant: .env, .env.local, .env.production, etc.
+.env
+.env.*
+*.env


### PR DESCRIPTION
The committed `.gitignore` had no `.env` entry — the only protection was an uncommitted local `/.env` line in one worktree. On a fresh checkout, a `.env` (which may hold secrets like API keys) would be untracked and one `git add .` away from being committed.

This ignores `.env`, `.env.*`, and `*.env` in any directory and every variant. Gitignore-only change — no `.env` file is included in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
