### PR TITLE
chore(mcp): source a gitignored .env in ensure-tunnel.sh when present

### DIFF
--- a/scripts/ensure-tunnel.sh
+++ b/scripts/ensure-tunnel.sh
@@ -38,6 +38,15 @@ if [[ -z "$PROJECT_DIR" ]]; then
     PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fi
 
+# Load a developer-local .env if present (gitignored — never committed). Auto-export
+# so the tunnel and everything it forks inherit it. No-op when the file is absent.
+if [[ -f "$PROJECT_DIR/.env" ]]; then
+    set -a
+    # shellcheck disable=SC1091
+    . "$PROJECT_DIR/.env"
+    set +a
+fi
+
 # Probe :8890 — true if the tunnel is answering. Prefers the /admin/status
 # HTTP probe (curl), falls back to a bare TCP connect (nc). Both swallow
 # their own failure so the caller controls the exit.


### PR DESCRIPTION
Closes iamacoffeepot/aether#1239

Source a developer-local project-root .env (when present) in scripts/ensure-tunnel.sh before the tunnel launch, so harness config flows into the tunnel → hub → spawned substrates via the existing env-inheritance chain without a manual export step.

- Adds only the guarded sourcing block, after PROJECT_DIR is resolved and before the tunnel launch; auto-exports via set -a so forked children inherit it.
- No .env file is created, added, or committed; .gitignore is unchanged; contents are never echoed.
- No-op when the .env is absent (the file-exists guard), so behavior is identical to before. Scripts-only change, CI self-validates.
