### PR TITLE
feat(mcp): await correlated replies by default on send_mail and send_mail_traced (issue 1242)

### DIFF
--- a/crates/aether-mcp/src/args.rs
+++ b/crates/aether-mcp/src/args.rs
@@ -33,6 +33,16 @@ pub struct SendMailArgs {
     /// failure doesn't abort the batch; the response carries a
     /// per-item status.
     pub mails: Vec<MailSpec>,
+    /// When `true`, dispatch every item without awaiting its reply
+    /// (today's pre-issue-1242 behaviour): each `status` is
+    /// `"dispatched"` and `replies` is empty. Default `false` — `send_mail`
+    /// now blocks per item until the dispatch chain settles and surfaces
+    /// the correlated reply payloads. Set this for a fire-and-poke item
+    /// (e.g. a `DrawTriangle` before a `capture_frame`) or a cap that
+    /// never replies, so the call returns immediately instead of waiting
+    /// out the await timeout.
+    #[serde(default)]
+    pub fire_and_forget: bool,
 }
 
 /// One item in a `send_mail` batch.
@@ -65,9 +75,44 @@ pub struct EngineInfo {
 pub struct MailStatus {
     /// Index into the `mails` array the caller supplied.
     pub index: usize,
-    /// `"delivered"` once the call reached the substrate and its
-    /// dispatch chain settled, or `"error: <reason>"` on failure.
+    /// `"delivered"` once the call reached the substrate, its dispatch
+    /// chain settled, and any correlated replies are in `replies`;
+    /// `"dispatched"` when `fire_and_forget` was set (no await);
+    /// `"timeout"` when the await hit the cap before settlement (any
+    /// replies collected so far are still in `replies`, and `timed_out`
+    /// is `true`); or `"error: <reason>"` on a transport / encode
+    /// failure.
     pub status: String,
+    /// Correlated reply payloads the substrate emitted for this item, in
+    /// arrival order. Empty for a fire-and-forget item, an item that
+    /// produced no reply, or an error item.
+    #[serde(default)]
+    pub replies: Vec<ReplyEventJson>,
+    /// `true` when the await hit the timeout before the chain settled.
+    /// `replies` still carries whatever arrived before the cap.
+    #[serde(default)]
+    pub timed_out: bool,
+}
+
+/// One correlated reply the substrate emitted in response to a
+/// `send_mail` / `send_mail_traced` item (issue 1242). `params` is the
+/// best-effort schema-decode of `payload_bytes`; the raw bytes are
+/// always present as the fallback for a reply kind the static
+/// vocabulary can't name or decode.
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct ReplyEventJson {
+    /// Tagged kind id (`knd-…`, ADR-0064) of the reply payload.
+    pub kind_id: String,
+    /// Substrate kind name resolved from the static vocabulary, or
+    /// `null` for a component-defined kind `aether-mcp` can't name.
+    pub kind_name: Option<String>,
+    /// Best-effort `decode_schema` of `payload_bytes` against the kind's
+    /// descriptor, or `null` when the kind is unknown or the decode
+    /// failed. Pair with `payload_bytes` (the raw fallback).
+    pub params: Option<serde_json::Value>,
+    /// The reply's raw wire payload, always present — the fallback when
+    /// `params` is `null`.
+    pub payload_bytes: Vec<u8>,
 }
 
 /// `load_component` arguments.
@@ -301,9 +346,18 @@ pub struct SendMailTracedArgs {
     /// moves (mirrors `capture_frame`'s bundle semantics).
     pub mails: Vec<TracedMailSpec>,
     /// Cap on wall-clock wait for the batch's chain to settle, in
-    /// milliseconds. Defaults to 5000; clamped to 30000.
+    /// milliseconds. Defaults to 300000 (300s); clamped to 600000
+    /// (600s) — sized to clear a provider cap's API timeout (e.g. the
+    /// gemini cap's 180s) with margin, not the old 30s ceiling.
     #[serde(default)]
     pub settlement_timeout_ms: Option<u32>,
+    /// When `true`, return the synchronous ack (the shared `root`)
+    /// without awaiting chain settlement: `status` is `"dispatched"`,
+    /// and `mails` / `in_flight` / `replies` are `null`. Default
+    /// `false` — the call now blocks until the batch settles and
+    /// returns the trace tree plus the correlated replies.
+    #[serde(default)]
+    pub fire_and_forget: bool,
 }
 
 /// One mail in a `send_mail_traced` batch. Like [`CaptureMailSpec`] but
@@ -328,18 +382,26 @@ pub struct TracedMailSpec {
 pub struct SendMailTracedResponse {
     /// `"settled"` once the batch's chain settled and the tree is
     /// populated, `"timeout"` when the substrate didn't reply within
-    /// the `settlement_timeout_ms` window.
+    /// the `settlement_timeout_ms` window, or `"dispatched"` when
+    /// `fire_and_forget` was set (ack only, no settlement wait).
     pub status: String,
     /// Chassis-root `MailId` every spec inherited. Populated on
-    /// `settled`, `null` on `timeout`.
+    /// `settled` and `dispatched`, `null` on `timeout`.
     pub root: Option<MailIdJson>,
     /// Mail nodes in the settled tree. Order is unspecified — agents
-    /// reconstruct chains via `parent` edges.
+    /// reconstruct chains via `parent` edges. `null` on `dispatched` /
+    /// `timeout`.
     pub mails: Option<Vec<MailNodeJson>>,
     /// Root's `in_flight` count at describe time. `0` for a fully-
     /// settled batch; non-zero indicates the chain re-armed after the
     /// initial settle (rare; reflects late-arriving descendants).
     pub in_flight: Option<u32>,
+    /// Correlated reply payloads the batch's shared `cid` collected, in
+    /// arrival order — one flat list for the whole atomic batch (the
+    /// batch is one wire `Call`, so there is no per-item correlation to
+    /// group by). `null` on `dispatched`; an empty list on `settled`
+    /// when no reply was emitted.
+    pub replies: Option<Vec<ReplyEventJson>>,
 }
 
 /// `MailId` rendered for MCP: the sender mailbox as a tagged-id

--- a/crates/aether-mcp/src/rpc.rs
+++ b/crates/aether-mcp/src/rpc.rs
@@ -385,11 +385,166 @@ impl RpcSession {
         }
     }
 
-    /// [`Self::call`], discarding any reply events — for mail whose
-    /// only interesting outcome is "did the call reach the substrate
-    /// and settle". The terminal `ReplyEnd` still gates the result.
-    pub async fn call_settled(&self, envelope: MailEnvelope) -> anyhow::Result<()> {
-        self.call(envelope).await.map(|_events| ())
+    /// Like [`Self::call`], but bounded by `timeout` and **partial-aware**:
+    /// on timeout it returns the `ReplyEvent`s collected *so far* plus a
+    /// `timed_out: true` flag, rather than discarding the in-flight
+    /// future's buffered events (issue 1242).
+    ///
+    /// The collection loop runs *inside* the timeout scope — a plain
+    /// `tokio::time::timeout(call(...))` would drop the `call` future on
+    /// the timeout arm, losing both the partial `Vec` and the `cid`
+    /// de-registration. Here the `select!` between `rx.recv()` and a
+    /// `sleep(timeout)` writes into a buffer this fn owns, and the `cid`
+    /// is removed from `pending` on every exit (settle, timeout, or
+    /// transport error), so a timed-out call leaks no `pending` entry.
+    ///
+    /// Self-healing on a dead socket is the same single re-dial + retry
+    /// as [`Self::call`]; the `timed_out` flag is `false` on every
+    /// non-timeout terminal (settle / error).
+    pub async fn call_collecting(
+        &self,
+        envelope: MailEnvelope,
+        timeout: Duration,
+    ) -> anyhow::Result<(Vec<MailEnvelope>, bool)> {
+        match self.call_collecting_once(&envelope, timeout).await {
+            Ok(outcome) => Ok(outcome),
+            Err(CallError::Transport { generation, source }) => {
+                tracing::warn!(
+                    target: "aether_mcp::rpc",
+                    error = %source,
+                    "rpc call_collecting hit a dead socket; re-dialing the hub",
+                );
+                self.reconnect(generation).await?;
+                self.call_collecting_once(&envelope, timeout)
+                    .await
+                    .map_err(CallError::into_anyhow)
+            }
+            Err(other) => Err(other.into_anyhow()),
+        }
+    }
+
+    /// One attempt of [`Self::call_collecting`] against the live
+    /// connection. Mirrors [`Self::call_once`]'s register / write /
+    /// drain / deregister bracket, adding the timeout arm.
+    async fn call_collecting_once(
+        &self,
+        envelope: &MailEnvelope,
+        timeout: Duration,
+    ) -> Result<(Vec<MailEnvelope>, bool), CallError> {
+        let generation = self.generation.load(Ordering::Acquire);
+        let conn = self.live();
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let cid = {
+            let mut pending = conn
+                .pending
+                .lock()
+                .expect("rpc pending mutex is never poisoned");
+            if conn.dead.load(Ordering::Acquire) {
+                return Err(CallError::Transport {
+                    generation,
+                    source: anyhow::anyhow!("rpc connection is closed"),
+                });
+            }
+            let write = conn
+                .client
+                .lock()
+                .expect("rpc client mutex is never poisoned")
+                .call(envelope.clone());
+            let cid = match write {
+                Ok(cid) => cid,
+                Err(e) => {
+                    return Err(CallError::Transport {
+                        generation,
+                        source: anyhow::anyhow!("rpc call write failed: {e}"),
+                    });
+                }
+            };
+            pending.insert(cid, tx);
+            cid
+        };
+
+        let mut events = Vec::new();
+        // `sleep` is created once, outside the loop, so its deadline is
+        // the wall-clock cap on the *whole* collection — not reset on
+        // each `ReplyEvent`.
+        let sleep = time::sleep(timeout);
+        tokio::pin!(sleep);
+        let outcome = loop {
+            tokio::select! {
+                frame = rx.recv() => match frame {
+                    Some(WireFrame::ReplyEvent { envelope, .. }) => events.push(envelope),
+                    Some(WireFrame::ReplyEnd { result, .. }) => {
+                        break result
+                            .map(|()| false)
+                            .map_err(|e| {
+                                CallError::Call(anyhow::anyhow!("rpc call failed: {e:?}"))
+                            });
+                    }
+                    Some(_) => {}
+                    None => {
+                        break Err(CallError::Transport {
+                            generation,
+                            source: anyhow::anyhow!(
+                                "rpc connection closed before the call ended"
+                            ),
+                        });
+                    }
+                },
+                () = &mut sleep => break Ok(true),
+            }
+        };
+        conn.pending
+            .lock()
+            .expect("rpc pending mutex is never poisoned")
+            .remove(&cid);
+        outcome.map(|timed_out| (events, timed_out))
+    }
+
+    /// Write a `Call` carrying `envelope` and return *without* awaiting
+    /// any reply — the fire-and-forget path (issue 1242). The server
+    /// still answers with `ReplyEnd` server-side, but no `pending` entry
+    /// is registered for the `cid`, so the router drops the inbound
+    /// `ReplyEvent` / `ReplyEnd` as unrouted (its `get(&cid)` misses) and
+    /// no state accumulates. A dead socket re-dials once, mirroring
+    /// [`Self::call`], so a poke against a just-bounced hub still lands.
+    pub async fn fire(&self, envelope: MailEnvelope) -> anyhow::Result<()> {
+        match self.fire_once(&envelope) {
+            Ok(()) => Ok(()),
+            Err(CallError::Transport { generation, source }) => {
+                tracing::warn!(
+                    target: "aether_mcp::rpc",
+                    error = %source,
+                    "rpc fire hit a dead socket; re-dialing the hub",
+                );
+                self.reconnect(generation).await?;
+                self.fire_once(&envelope).map_err(CallError::into_anyhow)
+            }
+            Err(other) => Err(other.into_anyhow()),
+        }
+    }
+
+    /// One attempt of [`Self::fire`]: write the `Call` on the live
+    /// connection without registering a `pending` entry. Synchronous —
+    /// there's nothing to await.
+    fn fire_once(&self, envelope: &MailEnvelope) -> Result<(), CallError> {
+        let generation = self.generation.load(Ordering::Acquire);
+        let conn = self.live();
+        if conn.dead.load(Ordering::Acquire) {
+            return Err(CallError::Transport {
+                generation,
+                source: anyhow::anyhow!("rpc connection is closed"),
+            });
+        }
+        conn.client
+            .lock()
+            .expect("rpc client mutex is never poisoned")
+            .call(envelope.clone())
+            .map(|_cid| ())
+            .map_err(|e| CallError::Transport {
+                generation,
+                source: anyhow::anyhow!("rpc call write failed: {e}"),
+            })
     }
 }
 
@@ -450,10 +605,42 @@ mod tests {
         thread: Option<JoinHandle<()>>,
     }
 
+    /// How a [`FakeHub`] session answers each `Call` (issue 1242 tests).
+    /// The default echo (`reply_events: 1`, `send_end: true`) is the
+    /// pre-1242 behaviour the older re-dial tests depend on.
+    #[derive(Clone, Copy)]
+    struct ServeMode {
+        /// How many `ReplyEvent`s (each echoing the call's envelope) to
+        /// emit before the terminal. `>1` exercises multi-reply
+        /// collection.
+        reply_events: usize,
+        /// Whether to write the terminal `ReplyEnd { Ok }`. `false`
+        /// withholds it so a `call_collecting` hits its timeout with the
+        /// chain still "open" — the partial-on-timeout path.
+        send_end: bool,
+    }
+
+    impl ServeMode {
+        /// One `ReplyEvent` + `ReplyEnd` — the original echo behaviour.
+        fn echo() -> Self {
+            Self {
+                reply_events: 1,
+                send_end: true,
+            }
+        }
+    }
+
     impl FakeHub {
         /// Bind, accept, handshake, and echo `Call`s on `port`. `port`
         /// 0 lets the OS pick; the chosen port is returned alongside.
         fn serve(port: u16) -> (Self, u16) {
+            Self::serve_with(port, ServeMode::echo())
+        }
+
+        /// [`Self::serve`] with an explicit [`ServeMode`] — lets a test
+        /// drive multi-reply collection or withhold the terminal
+        /// `ReplyEnd` to force a timeout.
+        fn serve_with(port: u16, mode: ServeMode) -> (Self, u16) {
             let listener = TcpListener::bind(("127.0.0.1", port)).expect("fake hub bind");
             let bound_port = listener.local_addr().expect("local_addr").port();
             // Non-blocking accept so the loop can observe the shutdown
@@ -485,7 +672,7 @@ mod tests {
                                 sessions.push(
                                     thread::Builder::new()
                                         .name("fake-hub-session".into())
-                                        .spawn(move || Self::run_session(&stream, &shutdown))
+                                        .spawn(move || Self::run_session(&stream, &shutdown, mode))
                                         .expect("spawn session"),
                                 );
                             }
@@ -513,9 +700,12 @@ mod tests {
         }
 
         /// Handshake + blocking echo loop for one accepted connection.
-        /// Returns when the connection closes (`stop` shuts it down, or
-        /// the client drops) — `read_frame` then errors.
-        fn run_session(stream: &TcpStream, shutdown: &AtomicBool) {
+        /// Per [`ServeMode`] it emits `mode.reply_events` `ReplyEvent`s
+        /// (each echoing the call's envelope) and, when `mode.send_end`,
+        /// the terminal `ReplyEnd { Ok }`. Returns when the connection
+        /// closes (`stop` shuts it down, or the client drops) —
+        /// `read_frame` then errors.
+        fn run_session(stream: &TcpStream, shutdown: &AtomicBool, mode: ServeMode) {
             let mut write_half = stream.try_clone().expect("clone write half");
             let mut reader = BufReader::new(stream.try_clone().expect("clone read half"));
 
@@ -550,22 +740,26 @@ mod tests {
                     envelope,
                 } = frame
                 {
-                    write_frame(
-                        &mut write_half,
-                        &WireFrame::ReplyEvent {
-                            cid,
-                            envelope: envelope.clone(),
-                        },
-                    )
-                    .expect("write ReplyEvent");
-                    write_frame(
-                        &mut write_half,
-                        &WireFrame::ReplyEnd {
-                            cid,
-                            result: Ok(()),
-                        },
-                    )
-                    .expect("write ReplyEnd");
+                    for _ in 0..mode.reply_events {
+                        write_frame(
+                            &mut write_half,
+                            &WireFrame::ReplyEvent {
+                                cid,
+                                envelope: envelope.clone(),
+                            },
+                        )
+                        .expect("write ReplyEvent");
+                    }
+                    if mode.send_end {
+                        write_frame(
+                            &mut write_half,
+                            &WireFrame::ReplyEnd {
+                                cid,
+                                result: Ok(()),
+                            },
+                        )
+                        .expect("write ReplyEnd");
+                    }
                 }
             }
         }
@@ -715,5 +909,125 @@ mod tests {
         );
 
         hub2.stop();
+    }
+
+    /// The count of registered `pending` entries on the live connection
+    /// — a timed-out / fired call must leave this at zero, proving no
+    /// `cid` leaks (issue 1242).
+    fn pending_count(session: &RpcSession) -> usize {
+        session.live().pending.lock().expect("pending mutex").len()
+    }
+
+    /// Issue 1242: `call_collecting` surfaces every `ReplyEvent` the hub
+    /// emitted before the terminal, in arrival order, with
+    /// `timed_out == false` — and de-registers the `cid` so `pending` is
+    /// clean afterward. Two reply events per call exercises the
+    /// multi-reply collection the single-event `call_one` discarded.
+    #[tokio::test]
+    async fn call_collecting_returns_events_in_order() {
+        let (hub, port) = FakeHub::serve_with(
+            0,
+            ServeMode {
+                reply_events: 2,
+                send_end: true,
+            },
+        );
+        let session =
+            task::spawn_blocking(move || RpcSession::connect(&format!("127.0.0.1:{port}")))
+                .await
+                .expect("connect task")
+                .expect("connect");
+
+        let (events, timed_out) = session
+            .call_collecting(probe_envelope(), Duration::from_secs(5))
+            .await
+            .expect("call_collecting succeeds against the live hub");
+
+        assert!(!timed_out, "a settled call is not a timeout");
+        assert_eq!(events.len(), 2, "both echoed reply events are surfaced");
+        for event in &events {
+            assert_eq!(
+                event.payload,
+                probe_envelope().payload,
+                "each reply echoes the probe envelope",
+            );
+        }
+        assert_eq!(
+            pending_count(&session),
+            0,
+            "a settled call de-registers its cid",
+        );
+
+        hub.stop();
+    }
+
+    /// Issue 1242: when the hub withholds the terminal `ReplyEnd`,
+    /// `call_collecting` returns the events collected before the short
+    /// timeout with `timed_out == true`, and leaves no `cid` in
+    /// `pending` — the partial-on-timeout path the new logic must get
+    /// right (the buffer is owned outside the `select!`, so it survives
+    /// the timeout arm, and the `cid` is removed on every exit).
+    #[tokio::test]
+    async fn call_collecting_times_out_with_partial_and_clean_pending() {
+        let (hub, port) = FakeHub::serve_with(
+            0,
+            ServeMode {
+                reply_events: 1,
+                // No terminal — the call can only end via the timeout.
+                send_end: false,
+            },
+        );
+        let session =
+            task::spawn_blocking(move || RpcSession::connect(&format!("127.0.0.1:{port}")))
+                .await
+                .expect("connect task")
+                .expect("connect");
+
+        let (events, timed_out) = session
+            .call_collecting(probe_envelope(), Duration::from_millis(250))
+            .await
+            .expect("a timeout is not a transport error");
+
+        assert!(timed_out, "withholding ReplyEnd forces the timeout arm");
+        assert_eq!(
+            events.len(),
+            1,
+            "the reply that arrived before the timeout is still returned",
+        );
+        assert_eq!(
+            pending_count(&session),
+            0,
+            "a timed-out call must not leak its cid in pending",
+        );
+
+        hub.stop();
+    }
+
+    /// Issue 1242: `fire` writes the `Call` and returns without awaiting
+    /// any reply, registering no `pending` entry — the fire-and-forget
+    /// path. The hub's eventual `ReplyEnd` is dropped as an unrouted
+    /// frame (its `cid` has no `pending` sender), so no state
+    /// accumulates.
+    #[tokio::test]
+    async fn fire_does_not_register_pending() {
+        let (hub, port) = FakeHub::serve(0);
+        let session =
+            task::spawn_blocking(move || RpcSession::connect(&format!("127.0.0.1:{port}")))
+                .await
+                .expect("connect task")
+                .expect("connect");
+
+        session
+            .fire(probe_envelope())
+            .await
+            .expect("fire writes the call");
+
+        assert_eq!(
+            pending_count(&session),
+            0,
+            "fire registers nothing in pending",
+        );
+
+        hub.stop();
     }
 }

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -49,7 +49,7 @@ use crate::args::{
     CaptureFrameArgs, CaptureMailSpec, DagCancelArgs, DagDescriptorArg, DagStatusArgs,
     DescribeComponentArgs, DescribeHandlesArgs, DescribeHandlesResponse, EngineInfo,
     HandleSummaryJson, LoadComponentArgs, MailIdJson, MailNodeJson, MailSpec, MailStatus, NodeArg,
-    ReplaceComponentArgs, SendMailArgs, SendMailTracedArgs, SendMailTracedResponse,
+    ReplaceComponentArgs, ReplyEventJson, SendMailArgs, SendMailTracedArgs, SendMailTracedResponse,
     SpawnSubstrateArgs, SubmitDagArgs, TerminateSubstrateArgs, TracedMailSpec, TransformListing,
 };
 use crate::reverse::EngineNames;
@@ -60,6 +60,16 @@ use base64::engine::general_purpose::STANDARD;
 use std::time::Duration;
 use tokio::fs;
 use tokio::time;
+
+/// Default wall-clock cap on `send_mail` / `send_mail_traced` awaiting a
+/// chain to settle (issue 1242). 300s — clears a provider cap's API
+/// timeout (the gemini cap's 180s, anthropic's 120s) with margin for
+/// queue / dispatch / staging overhead.
+const AWAIT_TIMEOUT_DEFAULT_MS: u32 = 300_000;
+/// Hard ceiling on the caller-supplied await timeout (issue 1242). A
+/// `settlement_timeout_ms` above this is clamped down. 600s — twice the
+/// default, the locked upper bound for a legitimately-long provider call.
+const AWAIT_TIMEOUT_CAP_MS: u32 = 600_000;
 
 /// Mailbox name of the hub's engines cap — the `engine = None` target
 /// for the engine-management tools.
@@ -209,7 +219,7 @@ impl Mcp {
     }
 
     #[tool(
-        description = "Send one or more mail items to substrate mailboxes. Each item carries structured `params`, schema-encoded against the substrate kind vocabulary. Best-effort batch: per-item status is returned and one failure doesn't abort siblings. 'delivered' means the call reached the substrate and its dispatch chain settled."
+        description = "Send one or more mail items to substrate mailboxes. Each item carries structured `params`, schema-encoded against the substrate kind vocabulary. Best-effort batch: per-item status is returned and one failure doesn't abort siblings. By default each item BLOCKS until its dispatch chain settles and the item's correlated reply payloads are returned in `replies` (status 'delivered'); each reply is {kind_id, kind_name, params (best-effort decode, null on miss), payload_bytes}. The await cap is 600s (gated by the batch-level settlement against a slow provider cap); on timeout the item reports status 'timeout' with timed_out:true and any replies collected so far. Set fire_and_forget:true to restore non-blocking dispatch (status 'dispatched', empty replies) — use it for a fire-and-poke (e.g. a DrawTriangle before a capture_frame) or a cap that never replies."
     )]
     pub async fn send_mail(
         &self,
@@ -218,19 +228,38 @@ impl Mcp {
         // Snapshot the substrate descriptor inventory once for the
         // whole batch rather than per item.
         let descriptors = descriptors::all();
+        let fire_and_forget = args.fire_and_forget;
         let mut statuses = Vec::with_capacity(args.mails.len());
         for (index, spec) in args.mails.into_iter().enumerate() {
-            let status = match self.deliver_one(&descriptors, spec).await {
-                Ok(()) => "delivered".to_owned(),
-                Err(e) => format!("error: {e}"),
+            let mut replies = Vec::new();
+            let mut timed_out = false;
+            let status = if fire_and_forget {
+                match self.deliver_one_fire(&descriptors, spec).await {
+                    Ok(()) => "dispatched".to_owned(),
+                    Err(e) => format!("error: {e}"),
+                }
+            } else {
+                match self.deliver_one(&descriptors, spec).await {
+                    Ok((events, hit_timeout)) => {
+                        replies = decode_reply_events(&events);
+                        timed_out = hit_timeout;
+                        if hit_timeout { "timeout" } else { "delivered" }.to_owned()
+                    }
+                    Err(e) => format!("error: {e}"),
+                }
             };
-            statuses.push(MailStatus { index, status });
+            statuses.push(MailStatus {
+                index,
+                status,
+                replies,
+                timed_out,
+            });
         }
         json(&statuses)
     }
 
     #[tool(
-        description = "Atomic batched dispatch with combined trace tree. Like send_mail but every spec lands on the engine's aether.trace mailbox under one shared chassis root, and the response returns the full trace subtree once the chain settles — no window guessing, no separate describe_tree call. Two-call protocol behind the scenes: the substrate emits a synchronous ack with the root id, the caller waits for chain settlement on the wire, then issues a describe_tree against the captured root. Bad specs abort the whole batch before any mail moves (mirrors capture_frame). settlement_timeout_ms caps wall-clock wait (default 5000, max 30000); on timeout the response carries status:timeout with no root or tree."
+        description = "Atomic batched dispatch with combined trace tree. Like send_mail but every spec lands on the engine's aether.trace mailbox under one shared chassis root, and the response returns the full trace subtree once the chain settles — no window guessing, no separate describe_tree call. By default it BLOCKS until settlement and also returns the batch's correlated reply payloads as a flat arrival-ordered `replies` list (the batch is one wire Call, so replies aren't per-item) alongside the tree; each reply is {kind_id, kind_name, params, payload_bytes}. Two-call protocol behind the scenes: the substrate emits a synchronous ack with the root id, the caller waits for chain settlement on the wire collecting reply events, then issues a describe_tree against the captured root. Bad specs abort the whole batch before any mail moves (mirrors capture_frame). settlement_timeout_ms caps wall-clock wait (default 300000, max 600000); on timeout the response carries status:timeout with no root, tree, or replies. Set fire_and_forget:true to return the ack only (status:dispatched with root populated, mails/replies null) without awaiting settlement."
     )]
     pub async fn send_mail_traced(
         &self,
@@ -245,39 +274,77 @@ impl Mcp {
         // time via `resolve_bundle`.
         let mails = encode_traced_bundle(&descriptors, &args.mails)
             .map_err(|e| McpError::invalid_params(format!("send_mail_traced batch: {e}"), None))?;
-        let timeout_ms = args.settlement_timeout_ms.unwrap_or(5000).min(30000);
+        let timeout_ms = args
+            .settlement_timeout_ms
+            .unwrap_or(AWAIT_TIMEOUT_DEFAULT_MS)
+            .min(AWAIT_TIMEOUT_CAP_MS);
         let dispatch_envelope =
             engine_envelope(engine, TRACE_MAILBOX_NAME, &DispatchTraced { mails });
 
-        // Round 1: ack carries the chassis-root MailId; ReplyEnd
-        // closes when the chain settles substrate-side.
-        let ack_reply = match time::timeout(
-            Duration::from_millis(u64::from(timeout_ms)),
-            self.session.call_one(dispatch_envelope),
-        )
-        .await
-        {
-            Ok(Ok(reply)) => reply,
-            Ok(Err(e)) => return Err(internal(e)),
-            Err(_) => {
+        // Fire-and-forget: write the dispatch without awaiting the chain
+        // to settle. We still need the synchronous ack's `root`, so this
+        // path isn't a bare `fire` — issue the call, read the ack from
+        // the (immediately-available) first reply, and skip the tree
+        // walk. Bound it by the same timeout so a wedged ack doesn't hang.
+        if args.fire_and_forget {
+            let (events, ack_timed_out) = self
+                .session
+                .call_collecting(
+                    dispatch_envelope,
+                    Duration::from_millis(u64::from(timeout_ms)),
+                )
+                .await
+                .map_err(internal)?;
+            if ack_timed_out {
                 return json(&SendMailTracedResponse {
                     status: "timeout".into(),
                     root: None,
                     mails: None,
                     in_flight: None,
+                    replies: None,
                 });
             }
-        };
-        let ack = DispatchTracedAck::decode_from_bytes(&ack_reply.payload)
-            .ok_or_else(|| internal_msg("undecodable DispatchTracedAck"))?;
-        let root = match ack {
-            DispatchTracedAck::Ok { root } => root,
-            DispatchTracedAck::Err { error } => {
-                return Err(internal_msg(&format!(
-                    "send_mail_traced dispatch failed: {error}"
-                )));
-            }
-        };
+            let root = decode_traced_ack(&events)?;
+            let root_json = {
+                self.ensure_names(engine).await;
+                let cache = self
+                    .names
+                    .lock()
+                    .expect("reverse-name cache mutex is never poisoned");
+                mail_id_to_json(root, cache.get(&engine))
+            };
+            return json(&SendMailTracedResponse {
+                status: "dispatched".into(),
+                root: Some(root_json),
+                mails: None,
+                in_flight: None,
+                replies: None,
+            });
+        }
+
+        // Round 1: ack carries the chassis-root MailId; ReplyEnd
+        // closes when the chain settles substrate-side. `call_collecting`
+        // keeps every correlated `ReplyEvent` (the ack plus any cap
+        // replies) instead of `call_one`'s single-event discard.
+        let (events, ack_timed_out) = self
+            .session
+            .call_collecting(
+                dispatch_envelope,
+                Duration::from_millis(u64::from(timeout_ms)),
+            )
+            .await
+            .map_err(internal)?;
+        if ack_timed_out {
+            return json(&SendMailTracedResponse {
+                status: "timeout".into(),
+                root: None,
+                mails: None,
+                in_flight: None,
+                replies: None,
+            });
+        }
+        let replies = decode_reply_events(strip_ack(&events));
+        let root = decode_traced_ack(&events)?;
 
         // Round 2: reconstruct the tree by a guided walk over the
         // per-actor trace rings (ADR-0086 Phase 3b). Seed at
@@ -333,6 +400,7 @@ impl Mcp {
                     root: Some(root),
                     mails: Some(mails),
                     in_flight: Some(in_flight),
+                    replies: Some(replies),
                 })
             }
             DescribeTreeResult::Err { not_found } => Err(internal_msg(&format!(
@@ -827,19 +895,45 @@ impl Mcp {
 
 impl Mcp {
     /// Build one `MailSpec` into an `engine = Some` envelope and route
-    /// it through the hub, awaiting the substrate's terminal settle.
+    /// it through the hub, awaiting the substrate's terminal settle and
+    /// surfacing the correlated reply events (issue 1242). Returns the
+    /// collected reply envelopes plus a `timed_out` flag — the await is
+    /// bounded by [`AWAIT_TIMEOUT_DEFAULT_MS`] so a cap that never
+    /// replies returns at the cap rather than hanging.
     async fn deliver_one(
         &self,
         descriptors: &[KindDescriptor],
         spec: MailSpec,
+    ) -> anyhow::Result<(Vec<MailEnvelope>, bool)> {
+        let envelope = Self::build_mail_envelope(descriptors, spec)?;
+        let timeout = Duration::from_millis(u64::from(AWAIT_TIMEOUT_DEFAULT_MS));
+        self.session.call_collecting(envelope, timeout).await
+    }
+
+    /// [`Self::deliver_one`]'s fire-and-forget twin: build the envelope
+    /// and write the `Call` without awaiting any reply (issue 1242).
+    async fn deliver_one_fire(
+        &self,
+        descriptors: &[KindDescriptor],
+        spec: MailSpec,
     ) -> anyhow::Result<()> {
+        let envelope = Self::build_mail_envelope(descriptors, spec)?;
+        self.session.fire(envelope).await
+    }
+
+    /// Resolve a `MailSpec` against the substrate vocabulary baked into
+    /// `aether-kinds` and build the `engine = Some` wire envelope — the
+    /// shared front half of [`Self::deliver_one`] /
+    /// [`Self::deliver_one_fire`]. The same descriptor set the scenario
+    /// runner and the embedded hub encode `send_mail` params against.
+    fn build_mail_envelope(
+        descriptors: &[KindDescriptor],
+        spec: MailSpec,
+    ) -> anyhow::Result<MailEnvelope> {
         let engine = EngineId(
             Uuid::parse_str(&spec.engine_id)
                 .map_err(|e| anyhow::anyhow!("engine_id is not a valid UUID: {e}"))?,
         );
-        // Resolve the kind against the substrate vocabulary baked into
-        // `aether-kinds` — the same descriptor set the scenario runner
-        // and the embedded hub encode `send_mail` params against.
         let desc = descriptors
             .iter()
             .find(|d| d.name == spec.kind_name)
@@ -847,7 +941,7 @@ impl Mcp {
         let params = spec.params.unwrap_or(serde_json::Value::Null);
         let payload = aether_codec::encode_schema(&params, &desc.schema)
             .map_err(|e| anyhow::anyhow!("param encode failed: {e}"))?;
-        let envelope = MailEnvelope {
+        Ok(MailEnvelope {
             to: MailboxAddress {
                 engine: Some(engine),
                 mailbox: mailbox_id_from_name(&spec.recipient_name),
@@ -856,8 +950,7 @@ impl Mcp {
             kind: KindId(kind_id_from_parts(&desc.name, &desc.schema)),
             correlation_id: None,
             payload,
-        };
-        self.session.call_settled(envelope).await
+        })
     }
 
     /// Ensure `engine`'s reverse-name map is built (ADR-0088 §8). On the
@@ -1104,6 +1197,61 @@ fn static_kind_name(id: KindId) -> Option<String> {
         .into_iter()
         .find(|d| kind_id_from_parts(&d.name, &d.schema) == id.0)
         .map(|d| d.name)
+}
+
+/// Transcode the correlated reply envelopes a `call_collecting` returned
+/// into the MCP wire shape (issue 1242). Per envelope: the tagged kind
+/// id, the best-effort static kind name, the best-effort `decode_schema`
+/// of the payload against the matching descriptor (`None` on an unknown
+/// kind or a decode miss), and the raw bytes as the always-present
+/// fallback. Order is preserved — arrival order.
+fn decode_reply_events(envelopes: &[MailEnvelope]) -> Vec<ReplyEventJson> {
+    let descriptors = descriptors::all();
+    envelopes
+        .iter()
+        .map(|env| {
+            let params = descriptors
+                .iter()
+                .find(|d| kind_id_from_parts(&d.name, &d.schema) == env.kind.0)
+                .and_then(|d| aether_codec::decode_schema(&env.payload, &d.schema).ok());
+            ReplyEventJson {
+                // Render the kind id as the ADR-0064 tagged string the
+                // rest of the MCP wire uses, falling back to a hex
+                // literal on an unencodable (non-kind-domain) id.
+                kind_id: tagged_id::encode(env.kind.0)
+                    .unwrap_or_else(|| format!("{:#x}", env.kind.0)),
+                kind_name: static_kind_name(env.kind),
+                params,
+                payload_bytes: env.payload.clone(),
+            }
+        })
+        .collect()
+}
+
+/// Decode the `DispatchTracedAck` from a `send_mail_traced` ack call's
+/// collected events (issue 1242). The synchronous ack is the *first*
+/// reply event the trace cap emits on the dispatch cid; later events are
+/// downstream cap replies handled separately. An absent or undecodable
+/// ack, or an `Err` ack, is a tool error.
+fn decode_traced_ack(events: &[MailEnvelope]) -> Result<MailId, McpError> {
+    let ack_env = events
+        .first()
+        .ok_or_else(|| internal_msg("send_mail_traced: no ack reply from the trace cap"))?;
+    let ack = DispatchTracedAck::decode_from_bytes(&ack_env.payload)
+        .ok_or_else(|| internal_msg("undecodable DispatchTracedAck"))?;
+    match ack {
+        DispatchTracedAck::Ok { root } => Ok(root),
+        DispatchTracedAck::Err { error } => Err(internal_msg(&format!(
+            "send_mail_traced dispatch failed: {error}"
+        ))),
+    }
+}
+
+/// The collected `send_mail_traced` events minus the leading ack (the
+/// `DispatchTracedAck` [`decode_traced_ack`] consumes), leaving the flat
+/// list of downstream cap replies to surface as `replies` (issue 1242).
+fn strip_ack(events: &[MailEnvelope]) -> &[MailEnvelope] {
+    events.get(1..).unwrap_or(&[])
 }
 
 /// Build the wire [`DagDescriptor`] from the typed tool arg, reading each
@@ -1511,6 +1659,7 @@ mod tests {
                         params: Some(serde_json::json!({ "namespace": "save", "prefix": "" })),
                     },
                 ],
+                fire_and_forget: false,
             }))
             .await
             .expect("send_mail returns a status array, not a tool error");
@@ -1593,6 +1742,7 @@ mod tests {
                     params: None,
                 }],
                 settlement_timeout_ms: None,
+                fire_and_forget: false,
             }))
             .await;
         assert!(
@@ -2043,5 +2193,124 @@ mod tests {
             }))
             .await;
         assert!(status.is_err(), "malformed engine_id is a tool error");
+    }
+
+    /// Issue 1242: `decode_reply_events` transcodes a correlated reply
+    /// into the MCP wire shape — a known substrate kind decodes to its
+    /// name + params, and the raw bytes are always present as the
+    /// fallback. This is the surfacing the await-by-default change adds;
+    /// the decode is the reusable core both tools share.
+    #[test]
+    fn decode_reply_events_decodes_known_substrate_kind() {
+        // Pick a real substrate kind out of the static inventory and
+        // round-trip a params object through `encode_schema` into the
+        // reply envelope the substrate would have produced.
+        let descriptors = descriptors::all();
+        let desc = descriptors
+            .iter()
+            .find(|d| d.name == "aether.fs.list")
+            .expect("aether.fs.list is in the static vocabulary");
+        let params = serde_json::json!({ "namespace": "save", "prefix": "" });
+        let payload =
+            aether_codec::encode_schema(&params, &desc.schema).expect("encode list params");
+        let kind = KindId(kind_id_from_parts(&desc.name, &desc.schema));
+        let reply = MailEnvelope {
+            to: MailboxAddress::local(mailbox_id_from_name("aether.fs")),
+            from: None,
+            kind,
+            correlation_id: Some(7),
+            payload: payload.clone(),
+        };
+
+        let decoded = decode_reply_events(&[reply]);
+        assert_eq!(decoded.len(), 1, "one reply in, one out");
+        let only = &decoded[0];
+        assert_eq!(
+            only.kind_name.as_deref(),
+            Some("aether.fs.list"),
+            "the known kind resolves to its name",
+        );
+        assert_eq!(
+            only.params.as_ref(),
+            Some(&params),
+            "params decode back to the original JSON",
+        );
+        assert_eq!(
+            only.payload_bytes, payload,
+            "the raw payload is always present as the fallback",
+        );
+        assert!(
+            only.kind_id.starts_with("knd-"),
+            "the kind id renders as the ADR-0064 tagged string: {}",
+            only.kind_id,
+        );
+    }
+
+    /// Issue 1242: an unknown / undecodable reply kind never fails the
+    /// surfacing — `params` is `null`, `kind_name` is `null`, and the
+    /// raw bytes are still returned (the disconnected-engine fallback
+    /// contract).
+    #[test]
+    fn decode_reply_events_falls_back_on_unknown_kind() {
+        let reply = MailEnvelope {
+            to: MailboxAddress::local(MailboxId(1)),
+            from: None,
+            kind: KindId(0xDEAD_BEEF_DEAD_BEEF),
+            correlation_id: None,
+            payload: vec![1, 2, 3],
+        };
+        let decoded = decode_reply_events(&[reply]);
+        assert_eq!(decoded.len(), 1);
+        let only = &decoded[0];
+        assert_eq!(only.kind_name, None, "an unknown kind has no name");
+        assert_eq!(only.params, None, "an unknown kind doesn't decode");
+        assert_eq!(only.payload_bytes, vec![1, 2, 3], "raw bytes survive");
+    }
+
+    /// Issue 1242: `fire_and_forget: true` is non-blocking — a
+    /// well-formed item is dispatched without awaiting any reply, so the
+    /// call returns `status: "dispatched"` with empty `replies` well
+    /// under the await timeout, even against an unknown engine (the
+    /// server's eventual error `ReplyEnd` is dropped as an unrouted
+    /// frame, never awaited). Contrast `delivered`, which blocks on
+    /// settlement.
+    #[tokio::test]
+    async fn send_mail_fire_and_forget_is_non_blocking() {
+        use std::time::Instant;
+
+        let (_chassis, port) = boot_hub();
+        let mcp = connect_mcp(port);
+        let started = Instant::now();
+        let out = mcp
+            .send_mail(Parameters(SendMailArgs {
+                mails: vec![MailSpec {
+                    // A well-formed item to an engine the hub doesn't
+                    // supervise: the dispatch chain never settles with a
+                    // reply, so a blocking call would wait — fire-and-
+                    // forget returns at once.
+                    engine_id: "00000000-0000-0000-0000-000000000099".to_owned(),
+                    recipient_name: "aether.fs".to_owned(),
+                    kind_name: "aether.fs.list".to_owned(),
+                    params: Some(serde_json::json!({ "namespace": "save", "prefix": "" })),
+                }],
+                fire_and_forget: true,
+            }))
+            .await
+            .expect("send_mail returns a status array");
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "fire-and-forget must not block on settlement",
+        );
+        let statuses: Vec<MailStatus> = serde_json::from_str(&out).expect("status array");
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(
+            statuses[0].status, "dispatched",
+            "fire-and-forget reports dispatched, not delivered",
+        );
+        assert!(
+            statuses[0].replies.is_empty(),
+            "fire-and-forget carries no replies",
+        );
+        assert!(!statuses[0].timed_out, "dispatch is not a timeout");
     }
 }


### PR DESCRIPTION
Closes iamacoffeepot/aether#1242

Makes awaiting correlated replies the default for both send_mail and send_mail_traced, with a batch-level fire_and_forget flag (default false) to opt back into non-blocking dispatch. No new tools, no wire-protocol change — RpcSession::call already walked to ReplyEnd collecting every ReplyEvent; the tools just discarded the vec. This surfaces it.

- Return shape: each reply as {kind_id (tagged), kind_name (static-vocab name or null), params (best-effort decode_schema, null on miss), payload_bytes (always present fallback)}. send_mail groups replies per item by batch index (each item is its own cid); send_mail_traced returns one flat arrival-ordered replies list alongside the existing trace tree.
- Timeout: default 300s, cap 600s (was 5s/30s on traced). Partial-on-timeout via a select!-based call_collecting that owns its buffer outside the timeout scope and de-registers the cid on every exit, so a timed-out call returns what arrived (status timeout, timed_out true) and leaks no pending entry. fire uses a non-registering write for the fire-and-forget path.
- All MailStatus / response additions are serde-additive; the two existing error-path tests pass unchanged. Scope is aether-mcp only (args + rpc + tools + tests).

Reviewers should eyeball the new ReplyEventJson shape and the MailStatus/SendMailTracedResponse additions in crates/aether-mcp/src/args.rs — that JSON is the agent-facing contract. End-to-end reply collection is tested at the rpc layer against a controllable fake hub (multi-event ordering + partial-on-timeout + clean pending), and the decode is unit-tested over a real substrate kind, since boot_hub has no live replying engine behind engine=Some routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
