### PR TITLE
fix(capabilities): allow NB2 to use K1/K2/K4 image sizes

### DIFF
--- a/crates/aether-capabilities/src/gemini/nanobanana.rs
+++ b/crates/aether-capabilities/src/gemini/nanobanana.rs
@@ -46,12 +46,12 @@ pub const MODELS: &[ModelShape] = &[
         max_object_refs: 6,
         max_character_refs: 5,
     },
-    // NB2 — flash image preview (default). S512; 10 object / 4 character
-    // refs; the NB2-only knobs + extreme aspect ratios.
+    // NB2 — flash image preview (default). S512/K1/K2/K4; 10 object / 4
+    // character refs; the NB2-only knobs + extreme aspect ratios.
     ModelShape {
         id: "gemini-3.1-flash-image-preview",
         is_nb2: true,
-        image_sizes: &[ImageSize::S512],
+        image_sizes: &[ImageSize::S512, ImageSize::K1, ImageSize::K2, ImageSize::K4],
         max_object_refs: 10,
         max_character_refs: 4,
     },
@@ -385,6 +385,16 @@ mod tests {
             err,
             GeminiError::ImageSizeNotSupportedByModel { .. }
         ));
+    }
+
+    #[test]
+    fn nb2_accepts_high_res_sizes() {
+        // NB2 (gemini-3.1-flash-image-preview) supports 512/1K/2K/4K — not
+        // S512-only. K1/K2/K4 must all validate.
+        for size in [ImageSize::K1, ImageSize::K2, ImageSize::K4] {
+            validate(nb2(), &inputs(AspectRatio::ASPECT_RATIO_1_1, Some(size)))
+                .unwrap_or_else(|e| panic!("NB2 should accept {size:?}: {e:?}"));
+        }
     }
 
     #[test]

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -2500,9 +2500,9 @@ mod control_plane {
         ASPECT_RATIO_8_1,
     }
 
-    /// Output image size for a Nano Banana image. `S512` is NB2; `K1`
-    /// is NB1 / NB Pro; `K2` / `K4` are NB Pro only. The adapter
-    /// enforces the per-model support matrix.
+    /// Output image size for a Nano Banana image. `S512` is NB2-only;
+    /// `K1` is supported by every model; `K2` / `K4` by NB Pro and NB2
+    /// (not the legacy NB1). The adapter enforces the per-model matrix.
     #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
     pub enum ImageSize {
         S512,


### PR DESCRIPTION
NB2 (`gemini-3.1-flash-image-preview`) was capped at `S512` in the `MODELS` table, but it supports `512`/`1K`/`2K`/`4K` per the Gemini image API. This adds `K1`/`K2`/`K4` to its `image_sizes` so requests at those resolutions validate instead of being rejected before dispatch.

Surfaced while driving image generation over MCP: NB2 at `K2` (2048px) was rejected by per-model validation, even though the model supports it and the request path already maps `ImageSize::K2 → "2K"` (the named token `imageConfig.imageSize` expects).

## Changes
- `nanobanana.rs`: NB2 `image_sizes` → `[S512, K1, K2, K4]`.
- `lib.rs`: correct the stale `ImageSize` doc comment — `K2`/`K4` are NB Pro **and** NB2, not Pro-only; `S512` is NB2-only; `K1` is universal.
- `nanobanana.rs`: add `nb2_accepts_high_res_sizes` (validates `K1`/`K2`/`K4` on NB2).

## Validation
- Preflight green (fmt + clippy + doc + nextest + wasm cross-build).
- Verified end-to-end over MCP: NB2 generated at `K2` after the change (the API accepted the `"2K"` token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
