### PR TITLE
feat(substrate): migrate remaining chassis-resolved config structs to confique

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,7 @@ dependencies = [
  "aether-data",
  "aether-kinds",
  "bytemuck",
+ "confique",
  "cpal",
  "crossbeam-channel",
  "crossbeam-deque",

--- a/crates/aether-capabilities/src/anthropic/mod.rs
+++ b/crates/aether-capabilities/src/anthropic/mod.rs
@@ -126,7 +126,8 @@ impl AnthropicAdapter for CombinedAnthropicAdapter {
 
 mod config {
     use super::{DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MS};
-    use std::env;
+    #[cfg(feature = "native")]
+    use std::convert::Infallible;
     use std::time::Duration;
 
     /// Resolved configuration for the `aether.anthropic` cap. Chassis
@@ -160,29 +161,167 @@ mod config {
         }
     }
 
+    // confique is a `native`-feature dep (ADR-0090), so env resolution —
+    // the layer struct, its parsers, and `from_env` — is gated to match.
+    // The wasm-marker build carries only the `AnthropicConfig` type. (The
+    // `anthropic` module is itself `not(target_arch = "wasm32")`, so the
+    // wasm cross-build never sees this; the `feature = "native"` gate
+    // guards the non-wasm `default-features = false` build.)
+    #[cfg(feature = "native")]
     impl AnthropicConfig {
         /// Resolve every field from env. Chassis-main edge only — the
         /// cap itself never reads env.
+        ///
+        /// Resolution runs through confique (ADR-0090): the private
+        /// `AnthropicConfigLayer` declares each knob's env key + default
+        /// in one place, and this maps the env-shaped layer onto the
+        /// domain-shaped `AnthropicConfig` (ms → `Duration`). Behaviour is
+        /// byte-identical to the prior hand-rolled reader. The hard-error
+        /// stance (ADR-0090 §4) lands with the chassis-env validation pass.
+        ///
+        /// # Panics
+        ///
+        /// Panics only if the layer's literal defaults are themselves
+        /// malformed — a programmer error caught by the
+        /// `anthropic_from_env_defaults_match` test, never a runtime config
+        /// fault (the env values flow through total parsers).
         #[must_use]
         pub fn from_env() -> Self {
-            let api_key = env::var("ANTHROPIC_API_KEY").ok().filter(|s| !s.is_empty());
-            let disabled = env::var("AETHER_ANTHROPIC_DISABLE")
-                .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
-            let max_in_flight = env::var("AETHER_ANTHROPIC_MAX_IN_FLIGHT")
-                .ok()
-                .and_then(|s| s.parse::<usize>().ok())
-                .filter(|n| *n > 0)
-                .unwrap_or(DEFAULT_MAX_IN_FLIGHT);
-            let timeout_ms = env::var("AETHER_ANTHROPIC_TIMEOUT_MS")
-                .ok()
-                .and_then(|s| s.parse::<u32>().ok())
-                .unwrap_or(DEFAULT_TIMEOUT_MS);
+            use confique::Config as _;
+
+            let layer = AnthropicConfigLayer::builder()
+                .env()
+                .load()
+                .expect("AnthropicConfigLayer defaults are well-formed");
             Self {
-                api_key,
-                disabled,
-                max_in_flight,
-                timeout: Duration::from_millis(u64::from(timeout_ms)),
+                api_key: layer.api_key.filter(|s| !s.is_empty()),
+                disabled: layer.disabled,
+                max_in_flight: layer.max_in_flight,
+                timeout: Duration::from_millis(u64::from(layer.timeout_ms)),
             }
+        }
+    }
+
+    /// Env-shaped confique layer behind `AnthropicConfig` (ADR-0090). Each
+    /// field is the primitive its env var carries; `AnthropicConfig::from_env`
+    /// maps them onto the domain types (ms → `Duration`, empty key →
+    /// `None`). Kept private — the public consumed shape stays
+    /// `AnthropicConfig`.
+    #[cfg(feature = "native")]
+    #[derive(confique::Config)]
+    struct AnthropicConfigLayer {
+        /// `ANTHROPIC_API_KEY` (bare, un-prefixed). Empty/unset → `None`
+        /// after the `from_env` filter.
+        #[config(env = "ANTHROPIC_API_KEY")]
+        api_key: Option<String>,
+        /// `AETHER_ANTHROPIC_DISABLE=1`/`true` forces the disabled adapter.
+        #[config(env = "AETHER_ANTHROPIC_DISABLE", parse_env = parse_flag, default = false)]
+        disabled: bool,
+        /// Per-cap concurrency bound. A non-positive / unparseable value
+        /// falls back to the default (`> 0` filter preserved).
+        #[config(
+            env = "AETHER_ANTHROPIC_MAX_IN_FLIGHT",
+            parse_env = parse_max_in_flight,
+            default = 2
+        )]
+        max_in_flight: usize,
+        /// Per-request timeout in milliseconds. Literal default mirrors
+        /// `DEFAULT_TIMEOUT_MS` (120 s).
+        #[config(
+            env = "AETHER_ANTHROPIC_TIMEOUT_MS",
+            parse_env = parse_timeout_ms,
+            default = 120_000
+        )]
+        timeout_ms: u32,
+    }
+
+    // confique's `parse_env` contract is `fn(&str) -> Result<T, impl Error>`,
+    // so these total helpers carry a `Result` they never fill with `Err`.
+    // The strict (erroring) variants land with the ADR-0090 §4 validation
+    // pass; hence the per-fn `unnecessary_wraps` allow.
+
+    /// `"1"` or `"true"` (case-insensitive) → `true`, else `false`.
+    /// Total — never errors.
+    #[cfg(feature = "native")]
+    #[allow(clippy::unnecessary_wraps)]
+    fn parse_flag(s: &str) -> Result<bool, Infallible> {
+        Ok(s == "1" || s.eq_ignore_ascii_case("true"))
+    }
+
+    /// Parse the concurrency bound; a non-positive or unparseable value
+    /// falls back to `DEFAULT_MAX_IN_FLIGHT` (the prior `> 0` filter +
+    /// soft-fail). Total — never errors.
+    #[cfg(feature = "native")]
+    #[allow(clippy::unnecessary_wraps)]
+    fn parse_max_in_flight(s: &str) -> Result<usize, Infallible> {
+        Ok(s.parse::<usize>()
+            .ok()
+            .filter(|n| *n > 0)
+            .unwrap_or(DEFAULT_MAX_IN_FLIGHT))
+    }
+
+    /// Parse a timeout in milliseconds; unparseable falls back to
+    /// `DEFAULT_TIMEOUT_MS`. Total — never errors.
+    #[cfg(feature = "native")]
+    #[allow(clippy::unnecessary_wraps)]
+    fn parse_timeout_ms(s: &str) -> Result<u32, Infallible> {
+        Ok(s.parse().unwrap_or(DEFAULT_TIMEOUT_MS))
+    }
+
+    #[cfg(all(test, feature = "native"))]
+    mod tests {
+        use super::{
+            AnthropicConfig, AnthropicConfigLayer, DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MS,
+            parse_flag, parse_max_in_flight, parse_timeout_ms,
+        };
+        use confique::Config as _;
+        use std::time::Duration;
+
+        // ADR-0090: byte-identical to the prior hand-rolled reader,
+        // exercised without touching process env (issue 464).
+
+        #[test]
+        fn parse_flag_matches_legacy_bool_reader() {
+            for truthy in ["1", "true", "TRUE", "True"] {
+                assert!(parse_flag(truthy).unwrap(), "{truthy} should be truthy");
+            }
+            for falsy in ["0", "", "yes", "false", "garbage"] {
+                assert!(!parse_flag(falsy).unwrap(), "{falsy} should be falsy");
+            }
+        }
+
+        #[test]
+        fn parse_max_in_flight_filters_non_positive_and_unparseable() {
+            assert_eq!(parse_max_in_flight("4").unwrap(), 4);
+            assert_eq!(parse_max_in_flight("0").unwrap(), DEFAULT_MAX_IN_FLIGHT);
+            assert_eq!(
+                parse_max_in_flight("garbage").unwrap(),
+                DEFAULT_MAX_IN_FLIGHT
+            );
+        }
+
+        #[test]
+        fn parse_timeout_ms_soft_falls_back() {
+            assert_eq!(parse_timeout_ms("5000").unwrap(), 5000);
+            assert_eq!(parse_timeout_ms("garbage").unwrap(), DEFAULT_TIMEOUT_MS);
+        }
+
+        #[test]
+        fn anthropic_from_env_defaults_match() {
+            // No `.env()` source: loads literal defaults only — env-free,
+            // guards the layer defaults against the consts + default().
+            let layer = AnthropicConfigLayer::builder()
+                .load()
+                .expect("defaults load");
+            let default = AnthropicConfig::default();
+            assert_eq!(layer.api_key, None);
+            assert!(!layer.disabled);
+            assert_eq!(layer.max_in_flight, DEFAULT_MAX_IN_FLIGHT);
+            assert_eq!(layer.timeout_ms, DEFAULT_TIMEOUT_MS);
+            assert_eq!(
+                Duration::from_millis(u64::from(layer.timeout_ms)),
+                default.timeout
+            );
         }
     }
 }

--- a/crates/aether-capabilities/src/anthropic/mod.rs
+++ b/crates/aether-capabilities/src/anthropic/mod.rs
@@ -127,9 +127,10 @@ impl AnthropicAdapter for CombinedAnthropicAdapter {
 
 mod config {
     use super::{DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MS};
-    use crate::config_env::{parse_flag, parse_provider_max_in_flight};
-    #[cfg(feature = "native")]
-    use std::convert::Infallible;
+    // confique consumes these through `#[config(parse_env = …)]`; IntelliJ-Rust
+    // doesn't trace macro-attr path args (Qodana FP), but rustc + clippy do.
+    #[allow(unused_imports)]
+    use crate::config_env::{parse_flag, parse_provider_max_in_flight, parse_u32_ms_or};
     use std::time::Duration;
 
     /// Resolved configuration for the `aether.anthropic` cap. Chassis
@@ -231,42 +232,22 @@ mod config {
         /// `DEFAULT_TIMEOUT_MS` (120 s).
         #[config(
             env = "AETHER_ANTHROPIC_TIMEOUT_MS",
-            parse_env = parse_timeout_ms,
+            parse_env = parse_u32_ms_or::<DEFAULT_TIMEOUT_MS>,
             default = 120_000
         )]
         timeout_ms: u32,
-    }
-
-    // confique's `parse_env` contract is `fn(&str) -> Result<T, impl Error>`,
-    // so these total helpers carry a `Result` they never fill with `Err`.
-    // The strict (erroring) variants land with the ADR-0090 §4 validation
-    // pass; hence the per-fn `unnecessary_wraps` allow.
-
-    /// Parse a timeout in milliseconds; unparseable falls back to
-    /// `DEFAULT_TIMEOUT_MS`. Total — never errors.
-    #[cfg(feature = "native")]
-    #[allow(clippy::unnecessary_wraps)]
-    fn parse_timeout_ms(s: &str) -> Result<u32, Infallible> {
-        Ok(s.parse().unwrap_or(DEFAULT_TIMEOUT_MS))
     }
 
     #[cfg(all(test, feature = "native"))]
     mod tests {
         use super::{
             AnthropicConfig, AnthropicConfigLayer, DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MS,
-            parse_timeout_ms,
         };
         use confique::Config as _;
         use std::time::Duration;
 
         // ADR-0090: byte-identical to the prior hand-rolled reader,
         // exercised without touching process env (issue 464).
-
-        #[test]
-        fn parse_timeout_ms_soft_falls_back() {
-            assert_eq!(parse_timeout_ms("5000").unwrap(), 5000);
-            assert_eq!(parse_timeout_ms("garbage").unwrap(), DEFAULT_TIMEOUT_MS);
-        }
 
         #[test]
         fn anthropic_from_env_defaults_match() {

--- a/crates/aether-capabilities/src/anthropic/mod.rs
+++ b/crates/aether-capabilities/src/anthropic/mod.rs
@@ -30,6 +30,7 @@ use std::time::Duration;
 
 use crate::contentgen::adapter::{AnthropicAdapter, AnthropicRequest, AnthropicResponse};
 
+use crate::config_env::DEFAULT_PROVIDER_MAX_IN_FLIGHT;
 pub use api::UreqAnthropicAdapter;
 pub use cli::ClaudeCliAdapter;
 pub use config::AnthropicConfig;
@@ -37,7 +38,7 @@ pub use config::AnthropicConfig;
 /// Default per-cap concurrency bound when `AETHER_ANTHROPIC_MAX_IN_FLIGHT`
 /// is unset. Conservative — paid-endpoint throttling matters more than
 /// throughput here.
-pub const DEFAULT_MAX_IN_FLIGHT: usize = 2;
+pub const DEFAULT_MAX_IN_FLIGHT: usize = DEFAULT_PROVIDER_MAX_IN_FLIGHT;
 
 /// Default per-request timeout when `AETHER_ANTHROPIC_TIMEOUT_MS` is
 /// unset. A long completion can run tens of seconds.
@@ -126,6 +127,7 @@ impl AnthropicAdapter for CombinedAnthropicAdapter {
 
 mod config {
     use super::{DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MS};
+    use crate::config_env::{parse_flag, parse_provider_max_in_flight};
     #[cfg(feature = "native")]
     use std::convert::Infallible;
     use std::time::Duration;
@@ -221,7 +223,7 @@ mod config {
         /// falls back to the default (`> 0` filter preserved).
         #[config(
             env = "AETHER_ANTHROPIC_MAX_IN_FLIGHT",
-            parse_env = parse_max_in_flight,
+            parse_env = parse_provider_max_in_flight,
             default = 2
         )]
         max_in_flight: usize,
@@ -240,26 +242,6 @@ mod config {
     // The strict (erroring) variants land with the ADR-0090 §4 validation
     // pass; hence the per-fn `unnecessary_wraps` allow.
 
-    /// `"1"` or `"true"` (case-insensitive) → `true`, else `false`.
-    /// Total — never errors.
-    #[cfg(feature = "native")]
-    #[allow(clippy::unnecessary_wraps)]
-    fn parse_flag(s: &str) -> Result<bool, Infallible> {
-        Ok(s == "1" || s.eq_ignore_ascii_case("true"))
-    }
-
-    /// Parse the concurrency bound; a non-positive or unparseable value
-    /// falls back to `DEFAULT_MAX_IN_FLIGHT` (the prior `> 0` filter +
-    /// soft-fail). Total — never errors.
-    #[cfg(feature = "native")]
-    #[allow(clippy::unnecessary_wraps)]
-    fn parse_max_in_flight(s: &str) -> Result<usize, Infallible> {
-        Ok(s.parse::<usize>()
-            .ok()
-            .filter(|n| *n > 0)
-            .unwrap_or(DEFAULT_MAX_IN_FLIGHT))
-    }
-
     /// Parse a timeout in milliseconds; unparseable falls back to
     /// `DEFAULT_TIMEOUT_MS`. Total — never errors.
     #[cfg(feature = "native")]
@@ -272,33 +254,13 @@ mod config {
     mod tests {
         use super::{
             AnthropicConfig, AnthropicConfigLayer, DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MS,
-            parse_flag, parse_max_in_flight, parse_timeout_ms,
+            parse_timeout_ms,
         };
         use confique::Config as _;
         use std::time::Duration;
 
         // ADR-0090: byte-identical to the prior hand-rolled reader,
         // exercised without touching process env (issue 464).
-
-        #[test]
-        fn parse_flag_matches_legacy_bool_reader() {
-            for truthy in ["1", "true", "TRUE", "True"] {
-                assert!(parse_flag(truthy).unwrap(), "{truthy} should be truthy");
-            }
-            for falsy in ["0", "", "yes", "false", "garbage"] {
-                assert!(!parse_flag(falsy).unwrap(), "{falsy} should be falsy");
-            }
-        }
-
-        #[test]
-        fn parse_max_in_flight_filters_non_positive_and_unparseable() {
-            assert_eq!(parse_max_in_flight("4").unwrap(), 4);
-            assert_eq!(parse_max_in_flight("0").unwrap(), DEFAULT_MAX_IN_FLIGHT);
-            assert_eq!(
-                parse_max_in_flight("garbage").unwrap(),
-                DEFAULT_MAX_IN_FLIGHT
-            );
-        }
 
         #[test]
         fn parse_timeout_ms_soft_falls_back() {

--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -80,6 +80,10 @@ mod native {
     use aether_substrate::chassis::error::BootError;
 
     use super::{NoteOff, NoteOn, SetMasterGain};
+    // confique consumes `parse_flag` through `#[config(parse_env = …)]`;
+    // IntelliJ-Rust doesn't trace macro-attr path args (Qodana FP), but
+    // rustc + clippy do.
+    #[allow(unused_imports)]
     use crate::config_env::parse_flag;
     use core::fmt;
 

--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -80,8 +80,8 @@ mod native {
     use aether_substrate::chassis::error::BootError;
 
     use super::{NoteOff, NoteOn, SetMasterGain};
+    use crate::config_env::parse_flag;
     use core::fmt;
-    use std::convert::Infallible;
 
     /// Capacity of the event queue between the cap's handlers and the
     /// audio-callback consumer. 1024 slots hold ~10 seconds of a dense
@@ -167,18 +167,6 @@ mod native {
         /// confique numeric field would hard-error on bad input instead.
         #[config(env = "AETHER_AUDIO_SAMPLE_RATE")]
         requested_sample_rate: Option<String>,
-    }
-
-    // confique's `parse_env` contract is `fn(&str) -> Result<T, impl Error>`,
-    // so this total helper carries a `Result` it never fills with `Err`.
-    // The strict (erroring) variant lands with the ADR-0090 §4 validation
-    // pass; hence the per-fn `unnecessary_wraps` allow.
-
-    /// `"1"` or `"true"` (case-insensitive) → `true`, else `false`.
-    /// Total — never errors.
-    #[allow(clippy::unnecessary_wraps)]
-    fn parse_flag(s: &str) -> Result<bool, Infallible> {
-        Ok(s == "1" || s.eq_ignore_ascii_case("true"))
     }
 
     /// Event a handler pushes into the audio callback's queue. The
@@ -955,16 +943,6 @@ mod native {
         // ADR-0090: the confique migration is byte-identical to the prior
         // hand-rolled reader. These exercise resolution without touching
         // process env (issue 464).
-
-        #[test]
-        fn parse_flag_matches_legacy_bool_reader() {
-            for truthy in ["1", "true", "TRUE", "True"] {
-                assert!(parse_flag(truthy).unwrap(), "{truthy} should be truthy");
-            }
-            for falsy in ["0", "", "yes", "false", "garbage"] {
-                assert!(!parse_flag(falsy).unwrap(), "{falsy} should be falsy");
-            }
-        }
 
         #[test]
         fn audio_from_env_defaults_match() {

--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -81,7 +81,7 @@ mod native {
 
     use super::{NoteOff, NoteOn, SetMasterGain};
     use core::fmt;
-    use std::env;
+    use std::convert::Infallible;
 
     /// Capacity of the event queue between the cap's handlers and the
     /// audio-callback consumer. 1024 slots hold ~10 seconds of a dense
@@ -113,18 +113,72 @@ mod native {
     }
 
     impl AudioConfig {
+        /// Resolve every field from env. Chassis-main edge only.
+        ///
+        /// Resolution runs through confique (ADR-0090): the private
+        /// `AudioConfigLayer` declares each knob's env key + default in
+        /// one place, and this maps the env-shaped layer onto the
+        /// domain-shaped `AudioConfig`. Behaviour is byte-identical to the
+        /// prior hand-rolled reader — an unparseable sample rate resolves
+        /// to `None` (the field stays optional, so a bad value is
+        /// indistinguishable from unset, matching the prior `.ok()`).
+        ///
+        /// # Panics
+        ///
+        /// Panics only if the layer's literal defaults are themselves
+        /// malformed — a programmer error caught by the
+        /// `audio_from_env_defaults_match` test, never a runtime config
+        /// fault (the env values flow through a total parser / raw capture).
         #[must_use]
         pub fn from_env() -> Self {
-            let disabled = env::var("AETHER_AUDIO_DISABLE")
-                .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
-            let requested_sample_rate = env::var("AETHER_AUDIO_SAMPLE_RATE")
-                .ok()
-                .and_then(|s| s.parse::<u32>().ok());
+            use confique::Config as _;
+
+            let layer = AudioConfigLayer::builder()
+                .env()
+                .load()
+                .expect("AudioConfigLayer defaults are well-formed");
             Self {
-                disabled,
-                requested_sample_rate,
+                disabled: layer.disabled,
+                // Prior behaviour: `.parse::<u32>().ok()` — an unparseable
+                // rate is silently `None`, indistinguishable from unset.
+                // Confique's parse path would *error* on a non-empty bad
+                // value (not byte-identical), so the layer captures the raw
+                // string and the soft `.ok()` parse stays here. The
+                // hard-error stance (ADR-0090 §4) lands later.
+                requested_sample_rate: layer
+                    .requested_sample_rate
+                    .and_then(|s| s.parse::<u32>().ok()),
             }
         }
+    }
+
+    /// Env-shaped confique layer behind `AudioConfig` (ADR-0090). Kept
+    /// private — the public consumed shape stays `AudioConfig`. Lives
+    /// inside the `audio-native` bridge mod (which implies the `native`
+    /// feature), so confique is always available here.
+    #[derive(confique::Config)]
+    struct AudioConfigLayer {
+        /// `AETHER_AUDIO_DISABLE=1`/`true` skips cpal init entirely.
+        #[config(env = "AETHER_AUDIO_DISABLE", parse_env = parse_flag, default = false)]
+        disabled: bool,
+        /// `AETHER_AUDIO_SAMPLE_RATE=<hz>` requests a specific rate. Held
+        /// as the raw string so `AudioConfig::from_env` can apply the
+        /// soft `.parse().ok()` (an unparseable value → `None`); a
+        /// confique numeric field would hard-error on bad input instead.
+        #[config(env = "AETHER_AUDIO_SAMPLE_RATE")]
+        requested_sample_rate: Option<String>,
+    }
+
+    // confique's `parse_env` contract is `fn(&str) -> Result<T, impl Error>`,
+    // so this total helper carries a `Result` it never fills with `Err`.
+    // The strict (erroring) variant lands with the ADR-0090 §4 validation
+    // pass; hence the per-fn `unnecessary_wraps` allow.
+
+    /// `"1"` or `"true"` (case-insensitive) → `true`, else `false`.
+    /// Total — never errors.
+    #[allow(clippy::unnecessary_wraps)]
+    fn parse_flag(s: &str) -> Result<bool, Infallible> {
+        Ok(s == "1" || s.eq_ignore_ascii_case("true"))
     }
 
     /// Event a handler pushes into the audio callback's queue. The
@@ -896,6 +950,31 @@ mod native {
             assert_eq!(builtin_count(), 5);
             assert_eq!(BUILTINS[0].name, "sine_lead");
             assert_eq!(BUILTINS[4].name, "pluck");
+        }
+
+        // ADR-0090: the confique migration is byte-identical to the prior
+        // hand-rolled reader. These exercise resolution without touching
+        // process env (issue 464).
+
+        #[test]
+        fn parse_flag_matches_legacy_bool_reader() {
+            for truthy in ["1", "true", "TRUE", "True"] {
+                assert!(parse_flag(truthy).unwrap(), "{truthy} should be truthy");
+            }
+            for falsy in ["0", "", "yes", "false", "garbage"] {
+                assert!(!parse_flag(falsy).unwrap(), "{falsy} should be falsy");
+            }
+        }
+
+        #[test]
+        fn audio_from_env_defaults_match() {
+            use confique::Config as _;
+            // No `.env()` source: literal defaults only — env-free.
+            let layer = AudioConfigLayer::builder().load().expect("defaults load");
+            let default = AudioConfig::default();
+            assert_eq!(layer.disabled, default.disabled);
+            assert_eq!(layer.requested_sample_rate, None);
+            assert_eq!(default.requested_sample_rate, None);
         }
 
         #[test]

--- a/crates/aether-capabilities/src/config_env.rs
+++ b/crates/aether-capabilities/src/config_env.rs
@@ -37,9 +37,23 @@ pub fn parse_provider_max_in_flight(s: &str) -> Result<usize, Infallible> {
         .unwrap_or(DEFAULT_PROVIDER_MAX_IN_FLIGHT))
 }
 
+/// Generic ms-soft-parse: positive `u32` from the env string, fall back
+/// to `DEFAULT_MS` (the per-cap default literal) on parse failure. Each
+/// caller instantiates with its own turbofish (e.g.
+/// `parse_env = parse_u32_ms_or::<DEFAULT_GEMINI_TIMEOUT_MS>`), so the
+/// expanded bodies are textually distinct — what Qodana's
+/// `DuplicatedCode` looks for. Soft-fall-back today; ADR-0090 §4's
+/// hard-error lands in e1.
+#[allow(clippy::unnecessary_wraps)]
+pub fn parse_u32_ms_or<const DEFAULT_MS: u32>(s: &str) -> Result<u32, Infallible> {
+    Ok(s.parse().unwrap_or(DEFAULT_MS))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{DEFAULT_PROVIDER_MAX_IN_FLIGHT, parse_flag, parse_provider_max_in_flight};
+    use super::{
+        DEFAULT_PROVIDER_MAX_IN_FLIGHT, parse_flag, parse_provider_max_in_flight, parse_u32_ms_or,
+    };
 
     #[test]
     fn parse_flag_matches_legacy_bool_reader() {
@@ -66,5 +80,15 @@ mod tests {
             parse_provider_max_in_flight("").unwrap(),
             DEFAULT_PROVIDER_MAX_IN_FLIGHT
         );
+    }
+
+    #[test]
+    fn parse_u32_ms_or_soft_falls_back_to_const_generic() {
+        assert_eq!(parse_u32_ms_or::<30_000>("5000").unwrap(), 5000);
+        assert_eq!(parse_u32_ms_or::<30_000>("garbage").unwrap(), 30_000);
+        assert_eq!(parse_u32_ms_or::<30_000>("").unwrap(), 30_000);
+        // Different turbofish → different defaults — what makes the
+        // per-cap call sites textually distinct under DuplicatedCode.
+        assert_eq!(parse_u32_ms_or::<120_000>("garbage").unwrap(), 120_000);
     }
 }

--- a/crates/aether-capabilities/src/config_env.rs
+++ b/crates/aether-capabilities/src/config_env.rs
@@ -1,0 +1,70 @@
+//! Shared confique `parse_env` helpers used by the capabilities'
+//! `*Layer` structs (ADR-0090). Centralized here so each per-cap
+//! migration doesn't carry its own copy of the identical bool /
+//! `> 0`-filtered concurrency parsers (Qodana `DuplicatedCode`).
+//!
+//! Every helper is total — `Result<T, Infallible>` because confique's
+//! `parse_env` contract mandates the wrapper, even when the parse
+//! cannot fail. The strict (erroring) variants land with the
+//! ADR-0090 §4 validation pass (e1).
+
+use std::convert::Infallible;
+
+/// Default per-cap concurrency bound shared by the content-gen
+/// providers (`aether.gemini`, `aether.anthropic`) when their
+/// `AETHER_*_MAX_IN_FLIGHT` env var is unset, non-positive, or
+/// unparseable. ADR-0050.
+pub const DEFAULT_PROVIDER_MAX_IN_FLIGHT: usize = 2;
+
+/// `"1"` or `"true"` (case-insensitive) → `true`, anything else
+/// `false`, matching the prior hand-rolled flag readers across
+/// http / gemini / anthropic / audio.
+#[allow(clippy::unnecessary_wraps)]
+pub fn parse_flag(s: &str) -> Result<bool, Infallible> {
+    Ok(s == "1" || s.eq_ignore_ascii_case("true"))
+}
+
+/// Provider concurrency bound: positive integer, otherwise fall back
+/// to [`DEFAULT_PROVIDER_MAX_IN_FLIGHT`]. The `> 0` filter rejects
+/// `AETHER_*_MAX_IN_FLIGHT=0` (which would otherwise deadlock the cap
+/// by allowing no in-flight requests). Soft-fall-back today;
+/// ADR-0090 §4's hard-error lands in e1.
+#[allow(clippy::unnecessary_wraps)]
+pub fn parse_provider_max_in_flight(s: &str) -> Result<usize, Infallible> {
+    Ok(s.parse::<usize>()
+        .ok()
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_PROVIDER_MAX_IN_FLIGHT))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DEFAULT_PROVIDER_MAX_IN_FLIGHT, parse_flag, parse_provider_max_in_flight};
+
+    #[test]
+    fn parse_flag_matches_legacy_bool_reader() {
+        for truthy in ["1", "true", "TRUE", "True"] {
+            assert!(parse_flag(truthy).unwrap(), "{truthy} should be truthy");
+        }
+        for falsy in ["0", "", "yes", "false", "garbage"] {
+            assert!(!parse_flag(falsy).unwrap(), "{falsy} should be falsy");
+        }
+    }
+
+    #[test]
+    fn parse_provider_max_in_flight_filters_non_positive_and_unparseable() {
+        assert_eq!(parse_provider_max_in_flight("4").unwrap(), 4);
+        assert_eq!(
+            parse_provider_max_in_flight("0").unwrap(),
+            DEFAULT_PROVIDER_MAX_IN_FLIGHT
+        );
+        assert_eq!(
+            parse_provider_max_in_flight("garbage").unwrap(),
+            DEFAULT_PROVIDER_MAX_IN_FLIGHT
+        );
+        assert_eq!(
+            parse_provider_max_in_flight("").unwrap(),
+            DEFAULT_PROVIDER_MAX_IN_FLIGHT
+        );
+    }
+}

--- a/crates/aether-capabilities/src/dag.rs
+++ b/crates/aether-capabilities/src/dag.rs
@@ -49,7 +49,7 @@ mod native {
     use aether_substrate::actor::native::envelope::Envelope;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
-    use aether_substrate::dag::executor::{Executor, SubmitOutcome};
+    use aether_substrate::dag::executor::{Executor, ExecutorConfig, SubmitOutcome};
     use aether_substrate::mail::mailer::Mailer;
 
     /// Reaping cadence (ADR-0047 §7) — the timer thread fires a
@@ -78,7 +78,7 @@ mod native {
         fn init((): (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             let mailer: Arc<Mailer> = ctx.mailer();
             let self_id: MailboxId = ctx.self_id();
-            let executor = Executor::new(Arc::clone(&mailer), self_id);
+            let executor = Executor::new(Arc::clone(&mailer), self_id, ExecutorConfig::from_env());
 
             // Detached timer thread: fire a `DagReapTick` wake mail at
             // the cap every `REAP_INTERVAL`. The mail wakes the

--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -390,6 +390,10 @@ mod native {
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
     use std::env;
+    #[cfg(feature = "native")]
+    use std::error::Error;
+    #[cfg(feature = "native")]
+    use std::fmt;
 
     impl NamespaceRoots {
         /// Resolve each root from its env-var override, falling back to
@@ -413,42 +417,103 @@ mod native {
         /// `NamespaceRoots` directly so tests and chassis-as-library
         /// embedders can supply their own roots without process-env
         /// mutation.
+        ///
+        /// Resolution runs through confique (ADR-0090): the private
+        /// `NamespaceRootsLayer` declares each root's env key. The
+        /// defaults are *computed at runtime* (via the `dirs` crate /
+        /// `current_exe`), not literals, so the layer fields are
+        /// `Option<PathBuf>` (unset / empty env → `None`) and the
+        /// platform fallbacks are applied here — byte-identical to the
+        /// prior `env_or_default` reader.
+        ///
+        /// # Panics
+        ///
+        /// Never in practice: the layer has no literal defaults to
+        /// malform and the only parser (`parse_dir`) errors only on the
+        /// empty string (folded to the runtime fallback). The `.expect`
+        /// guards against a future confique misconfiguration.
+        #[cfg(feature = "native")]
         #[must_use]
         pub fn from_env() -> Self {
-            let save = env_or_default("AETHER_SAVE_DIR", || {
-                dirs::data_dir()
-                    .unwrap_or_else(env::temp_dir)
-                    .join("aether")
-                    .join("save")
-            });
-            let assets = env_or_default("AETHER_ASSETS_DIR", || {
-                env::current_exe()
-                    .ok()
-                    .and_then(|p| p.parent().map(Path::to_path_buf))
-                    .map_or_else(
-                        || env::temp_dir().join("aether").join("assets"),
-                        |p| p.join("assets"),
-                    )
-            });
-            let config = env_or_default("AETHER_CONFIG_DIR", || {
-                dirs::config_dir()
-                    .unwrap_or_else(env::temp_dir)
-                    .join("aether")
-            });
+            use confique::Config as _;
+
+            let layer = NamespaceRootsLayer::builder()
+                .env()
+                .load()
+                .expect("NamespaceRootsLayer has no literal defaults to malform");
             Self {
-                save,
-                assets,
-                config,
+                save: layer.save.unwrap_or_else(|| {
+                    dirs::data_dir()
+                        .unwrap_or_else(env::temp_dir)
+                        .join("aether")
+                        .join("save")
+                }),
+                assets: layer.assets.unwrap_or_else(|| {
+                    env::current_exe()
+                        .ok()
+                        .and_then(|p| p.parent().map(Path::to_path_buf))
+                        .map_or_else(
+                            || env::temp_dir().join("aether").join("assets"),
+                            |p| p.join("assets"),
+                        )
+                }),
+                config: layer.config.unwrap_or_else(|| {
+                    dirs::config_dir()
+                        .unwrap_or_else(env::temp_dir)
+                        .join("aether")
+                }),
             }
         }
     }
 
-    fn env_or_default(var: &str, default: impl FnOnce() -> PathBuf) -> PathBuf {
-        match env::var(var) {
-            Ok(s) if !s.is_empty() => PathBuf::from(s),
-            _ => default(),
+    /// Env-shaped confique layer behind `NamespaceRoots` (ADR-0090). Each
+    /// root is `Option<PathBuf>` because the defaults are runtime-computed
+    /// (`dirs` / `current_exe`), not literals confique can hold — an
+    /// unset *or empty* env var resolves to `None` and
+    /// `NamespaceRoots::from_env` applies the platform fallback. The
+    /// `parse_dir` parser errors on an empty string so confique treats an
+    /// empty value as unset (matching the prior `env_or_default`).
+    /// Gated on `feature = "native"`: the enclosing `mod native` is only
+    /// `not(target_arch = "wasm32")`-gated, but confique is a
+    /// `native`-feature dep.
+    #[cfg(feature = "native")]
+    #[derive(confique::Config)]
+    struct NamespaceRootsLayer {
+        #[config(env = "AETHER_SAVE_DIR", parse_env = parse_dir)]
+        save: Option<PathBuf>,
+        #[config(env = "AETHER_ASSETS_DIR", parse_env = parse_dir)]
+        assets: Option<PathBuf>,
+        #[config(env = "AETHER_CONFIG_DIR", parse_env = parse_dir)]
+        config: Option<PathBuf>,
+    }
+
+    /// Parse a directory override. An empty string errors so confique
+    /// treats it as unset (preserving the prior `env_or_default`'s
+    /// `Ok(s) if !s.is_empty()` guard); any non-empty value is a path.
+    #[cfg(feature = "native")]
+    fn parse_dir(s: &str) -> Result<PathBuf, EmptyDir> {
+        if s.is_empty() {
+            Err(EmptyDir)
+        } else {
+            Ok(PathBuf::from(s))
         }
     }
+
+    /// Sentinel error: an empty `AETHER_*_DIR` value, treated as unset by
+    /// confique's parse path (`Err` + empty → `None`).
+    #[cfg(feature = "native")]
+    #[derive(Debug)]
+    struct EmptyDir;
+
+    #[cfg(feature = "native")]
+    impl fmt::Display for EmptyDir {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("empty directory override")
+        }
+    }
+
+    #[cfg(feature = "native")]
+    impl Error for EmptyDir {}
 
     /// `aether.fs` mailbox cap. Owns the resolved adapter registry +
     /// namespace roots. The dispatcher thread holds an `Arc<Self>` and
@@ -642,6 +707,36 @@ mod native {
         use std::time::Duration;
         use std::time::SystemTime;
         use std::time::UNIX_EPOCH;
+
+        // ADR-0090: the confique migration is byte-identical to the prior
+        // `env_or_default` reader. These exercise resolution without
+        // touching process env (issue 464) — the parser is pure, and the
+        // defaults check loads the layer with no `.env()` source.
+
+        #[test]
+        fn parse_dir_treats_empty_as_unset() {
+            use super::parse_dir;
+            assert!(parse_dir("").is_err(), "empty → unset (Err → None)");
+            assert_eq!(
+                parse_dir("/tmp/aether-save").expect("non-empty parses to a path"),
+                PathBuf::from("/tmp/aether-save")
+            );
+        }
+
+        #[test]
+        fn namespace_roots_layer_defaults_are_none() {
+            use super::NamespaceRootsLayer;
+            use confique::Config as _;
+            // No `.env()` source: each root has no literal default, so it
+            // resolves to `None` and `from_env` applies the runtime
+            // platform fallback. Env-free.
+            let layer = NamespaceRootsLayer::builder()
+                .load()
+                .expect("defaults load");
+            assert_eq!(layer.save, None);
+            assert_eq!(layer.assets, None);
+            assert_eq!(layer.config, None);
+        }
 
         /// Test fixture that bundles the cap, a fully-wired test mailer,
         /// and a `NativeBinding` long enough for handlers to borrow.

--- a/crates/aether-capabilities/src/gemini/mod.rs
+++ b/crates/aether-capabilities/src/gemini/mod.rs
@@ -31,12 +31,13 @@ use crate::contentgen::adapter::{
 };
 use crate::contentgen::shared;
 
+use crate::config_env::DEFAULT_PROVIDER_MAX_IN_FLIGHT;
 pub use config::GeminiConfig;
 
 /// Default per-cap concurrency bound when `AETHER_GEMINI_MAX_IN_FLIGHT`
 /// is unset. Conservative — image / music generation is multi-second
 /// and paid.
-pub const DEFAULT_MAX_IN_FLIGHT: usize = 2;
+pub const DEFAULT_MAX_IN_FLIGHT: usize = DEFAULT_PROVIDER_MAX_IN_FLIGHT;
 
 /// Default per-request timeout when `AETHER_GEMINI_TIMEOUT_MS` is unset.
 /// Media generation can run a couple minutes.
@@ -60,6 +61,7 @@ impl GeminiAdapter for DisabledGeminiAdapter {
 
 mod config {
     use super::{DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MS};
+    use crate::config_env::{parse_flag, parse_provider_max_in_flight};
     #[cfg(feature = "native")]
     use std::convert::Infallible;
     use std::time::Duration;
@@ -155,7 +157,7 @@ mod config {
         /// falls back to the default (`> 0` filter preserved).
         #[config(
             env = "AETHER_GEMINI_MAX_IN_FLIGHT",
-            parse_env = parse_max_in_flight,
+            parse_env = parse_provider_max_in_flight,
             default = 2
         )]
         max_in_flight: usize,
@@ -174,26 +176,6 @@ mod config {
     // The strict (erroring) variants land with the ADR-0090 §4 validation
     // pass; hence the per-fn `unnecessary_wraps` allow.
 
-    /// `"1"` or `"true"` (case-insensitive) → `true`, else `false`.
-    /// Total — never errors.
-    #[cfg(feature = "native")]
-    #[allow(clippy::unnecessary_wraps)]
-    fn parse_flag(s: &str) -> Result<bool, Infallible> {
-        Ok(s == "1" || s.eq_ignore_ascii_case("true"))
-    }
-
-    /// Parse the concurrency bound; a non-positive or unparseable value
-    /// falls back to `DEFAULT_MAX_IN_FLIGHT` (the prior `> 0` filter +
-    /// soft-fail). Total — never errors.
-    #[cfg(feature = "native")]
-    #[allow(clippy::unnecessary_wraps)]
-    fn parse_max_in_flight(s: &str) -> Result<usize, Infallible> {
-        Ok(s.parse::<usize>()
-            .ok()
-            .filter(|n| *n > 0)
-            .unwrap_or(DEFAULT_MAX_IN_FLIGHT))
-    }
-
     /// Parse a timeout in milliseconds; unparseable falls back to
     /// `DEFAULT_TIMEOUT_MS`. Total — never errors.
     #[cfg(feature = "native")]
@@ -205,8 +187,8 @@ mod config {
     #[cfg(all(test, feature = "native"))]
     mod tests {
         use super::{
-            DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MS, GeminiConfig, GeminiConfigLayer, parse_flag,
-            parse_max_in_flight, parse_timeout_ms,
+            DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MS, GeminiConfig, GeminiConfigLayer,
+            parse_timeout_ms,
         };
         use confique::Config as _;
         use std::time::Duration;
@@ -214,26 +196,6 @@ mod config {
         // ADR-0090: the confique migration is byte-identical to the prior
         // hand-rolled reader. These exercise the resolution logic without
         // touching process env (issue 464).
-
-        #[test]
-        fn parse_flag_matches_legacy_bool_reader() {
-            for truthy in ["1", "true", "TRUE", "True"] {
-                assert!(parse_flag(truthy).unwrap(), "{truthy} should be truthy");
-            }
-            for falsy in ["0", "", "yes", "false", "garbage"] {
-                assert!(!parse_flag(falsy).unwrap(), "{falsy} should be falsy");
-            }
-        }
-
-        #[test]
-        fn parse_max_in_flight_filters_non_positive_and_unparseable() {
-            assert_eq!(parse_max_in_flight("4").unwrap(), 4);
-            assert_eq!(parse_max_in_flight("0").unwrap(), DEFAULT_MAX_IN_FLIGHT);
-            assert_eq!(
-                parse_max_in_flight("garbage").unwrap(),
-                DEFAULT_MAX_IN_FLIGHT
-            );
-        }
 
         #[test]
         fn parse_timeout_ms_soft_falls_back() {

--- a/crates/aether-capabilities/src/gemini/mod.rs
+++ b/crates/aether-capabilities/src/gemini/mod.rs
@@ -61,9 +61,10 @@ impl GeminiAdapter for DisabledGeminiAdapter {
 
 mod config {
     use super::{DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MS};
-    use crate::config_env::{parse_flag, parse_provider_max_in_flight};
-    #[cfg(feature = "native")]
-    use std::convert::Infallible;
+    // confique consumes these through `#[config(parse_env = …)]`; IntelliJ-Rust
+    // doesn't trace macro-attr path args (Qodana FP), but rustc + clippy do.
+    #[allow(unused_imports)]
+    use crate::config_env::{parse_flag, parse_provider_max_in_flight, parse_u32_ms_or};
     use std::time::Duration;
 
     /// Resolved configuration for the `aether.gemini` cap. Chassis mains
@@ -165,7 +166,7 @@ mod config {
         /// `DEFAULT_TIMEOUT_MS` (180 s).
         #[config(
             env = "AETHER_GEMINI_TIMEOUT_MS",
-            parse_env = parse_timeout_ms,
+            parse_env = parse_u32_ms_or::<DEFAULT_TIMEOUT_MS>,
             default = 180_000
         )]
         timeout_ms: u32,
@@ -176,32 +177,15 @@ mod config {
     // The strict (erroring) variants land with the ADR-0090 §4 validation
     // pass; hence the per-fn `unnecessary_wraps` allow.
 
-    /// Parse a timeout in milliseconds; unparseable falls back to
-    /// `DEFAULT_TIMEOUT_MS`. Total — never errors.
-    #[cfg(feature = "native")]
-    #[allow(clippy::unnecessary_wraps)]
-    fn parse_timeout_ms(s: &str) -> Result<u32, Infallible> {
-        Ok(s.parse().unwrap_or(DEFAULT_TIMEOUT_MS))
-    }
-
     #[cfg(all(test, feature = "native"))]
     mod tests {
-        use super::{
-            DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MS, GeminiConfig, GeminiConfigLayer,
-            parse_timeout_ms,
-        };
+        use super::{DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MS, GeminiConfig, GeminiConfigLayer};
         use confique::Config as _;
         use std::time::Duration;
 
         // ADR-0090: the confique migration is byte-identical to the prior
         // hand-rolled reader. These exercise the resolution logic without
         // touching process env (issue 464).
-
-        #[test]
-        fn parse_timeout_ms_soft_falls_back() {
-            assert_eq!(parse_timeout_ms("5000").unwrap(), 5000);
-            assert_eq!(parse_timeout_ms("garbage").unwrap(), DEFAULT_TIMEOUT_MS);
-        }
 
         #[test]
         fn gemini_from_env_defaults_match() {

--- a/crates/aether-capabilities/src/gemini/mod.rs
+++ b/crates/aether-capabilities/src/gemini/mod.rs
@@ -60,7 +60,8 @@ impl GeminiAdapter for DisabledGeminiAdapter {
 
 mod config {
     use super::{DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MS};
-    use std::env;
+    #[cfg(feature = "native")]
+    use std::convert::Infallible;
     use std::time::Duration;
 
     /// Resolved configuration for the `aether.gemini` cap. Chassis mains
@@ -92,28 +93,169 @@ mod config {
         }
     }
 
+    // confique is a `native`-feature dep (ADR-0090), so env resolution —
+    // the layer struct, its parsers, and `from_env` — is gated to match.
+    // The wasm-marker build carries only the `GeminiConfig` type. (The
+    // `gemini` module is itself `not(target_arch = "wasm32")`, so the
+    // wasm cross-build never sees this; the `feature = "native"` gate
+    // guards the non-wasm `default-features = false` build.)
+    #[cfg(feature = "native")]
     impl GeminiConfig {
         /// Resolve every field from env. Chassis-main edge only.
+        ///
+        /// Resolution runs through confique (ADR-0090): the private
+        /// `GeminiConfigLayer` declares each knob's env key + default in
+        /// one place, and this maps the env-shaped layer onto the
+        /// domain-shaped `GeminiConfig` (ms → `Duration`). Behaviour is
+        /// byte-identical to the prior hand-rolled reader — an empty key
+        /// resolves to `None`, an unparseable / non-positive
+        /// `max_in_flight` falls back to the default, and an unparseable
+        /// timeout falls back. The hard-error-on-unparseable stance
+        /// (ADR-0090 §4) lands with the chassis-env validation pass.
+        ///
+        /// # Panics
+        ///
+        /// Panics only if the layer's literal defaults are themselves
+        /// malformed — a programmer error caught by the
+        /// `gemini_from_env_defaults_match` test, never a runtime config
+        /// fault (the env values flow through total parsers).
         #[must_use]
         pub fn from_env() -> Self {
-            let api_key = env::var("GEMINI_API_KEY").ok().filter(|s| !s.is_empty());
-            let disabled = env::var("AETHER_GEMINI_DISABLE")
-                .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
-            let max_in_flight = env::var("AETHER_GEMINI_MAX_IN_FLIGHT")
-                .ok()
-                .and_then(|s| s.parse::<usize>().ok())
-                .filter(|n| *n > 0)
-                .unwrap_or(DEFAULT_MAX_IN_FLIGHT);
-            let timeout_ms = env::var("AETHER_GEMINI_TIMEOUT_MS")
-                .ok()
-                .and_then(|s| s.parse::<u32>().ok())
-                .unwrap_or(DEFAULT_TIMEOUT_MS);
+            use confique::Config as _;
+
+            let layer = GeminiConfigLayer::builder()
+                .env()
+                .load()
+                .expect("GeminiConfigLayer defaults are well-formed");
             Self {
-                api_key,
-                disabled,
-                max_in_flight,
-                timeout: Duration::from_millis(u64::from(timeout_ms)),
+                api_key: layer.api_key.filter(|s| !s.is_empty()),
+                disabled: layer.disabled,
+                max_in_flight: layer.max_in_flight,
+                timeout: Duration::from_millis(u64::from(layer.timeout_ms)),
             }
+        }
+    }
+
+    /// Env-shaped confique layer behind `GeminiConfig` (ADR-0090). Each
+    /// field is the primitive its env var carries; `GeminiConfig::from_env`
+    /// maps them onto the domain types (ms → `Duration`, empty key →
+    /// `None`). Kept private — the public consumed shape stays
+    /// `GeminiConfig`.
+    #[cfg(feature = "native")]
+    #[derive(confique::Config)]
+    struct GeminiConfigLayer {
+        /// `GEMINI_API_KEY` (bare, un-prefixed). Empty/unset → `None`
+        /// after the `from_env` filter.
+        #[config(env = "GEMINI_API_KEY")]
+        api_key: Option<String>,
+        /// `AETHER_GEMINI_DISABLE=1`/`true` forces the disabled adapter.
+        #[config(env = "AETHER_GEMINI_DISABLE", parse_env = parse_flag, default = false)]
+        disabled: bool,
+        /// Per-cap concurrency bound. A non-positive / unparseable value
+        /// falls back to the default (`> 0` filter preserved).
+        #[config(
+            env = "AETHER_GEMINI_MAX_IN_FLIGHT",
+            parse_env = parse_max_in_flight,
+            default = 2
+        )]
+        max_in_flight: usize,
+        /// Per-request timeout in milliseconds. Literal default mirrors
+        /// `DEFAULT_TIMEOUT_MS` (180 s).
+        #[config(
+            env = "AETHER_GEMINI_TIMEOUT_MS",
+            parse_env = parse_timeout_ms,
+            default = 180_000
+        )]
+        timeout_ms: u32,
+    }
+
+    // confique's `parse_env` contract is `fn(&str) -> Result<T, impl Error>`,
+    // so these total helpers carry a `Result` they never fill with `Err`.
+    // The strict (erroring) variants land with the ADR-0090 §4 validation
+    // pass; hence the per-fn `unnecessary_wraps` allow.
+
+    /// `"1"` or `"true"` (case-insensitive) → `true`, else `false`.
+    /// Total — never errors.
+    #[cfg(feature = "native")]
+    #[allow(clippy::unnecessary_wraps)]
+    fn parse_flag(s: &str) -> Result<bool, Infallible> {
+        Ok(s == "1" || s.eq_ignore_ascii_case("true"))
+    }
+
+    /// Parse the concurrency bound; a non-positive or unparseable value
+    /// falls back to `DEFAULT_MAX_IN_FLIGHT` (the prior `> 0` filter +
+    /// soft-fail). Total — never errors.
+    #[cfg(feature = "native")]
+    #[allow(clippy::unnecessary_wraps)]
+    fn parse_max_in_flight(s: &str) -> Result<usize, Infallible> {
+        Ok(s.parse::<usize>()
+            .ok()
+            .filter(|n| *n > 0)
+            .unwrap_or(DEFAULT_MAX_IN_FLIGHT))
+    }
+
+    /// Parse a timeout in milliseconds; unparseable falls back to
+    /// `DEFAULT_TIMEOUT_MS`. Total — never errors.
+    #[cfg(feature = "native")]
+    #[allow(clippy::unnecessary_wraps)]
+    fn parse_timeout_ms(s: &str) -> Result<u32, Infallible> {
+        Ok(s.parse().unwrap_or(DEFAULT_TIMEOUT_MS))
+    }
+
+    #[cfg(all(test, feature = "native"))]
+    mod tests {
+        use super::{
+            DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MS, GeminiConfig, GeminiConfigLayer, parse_flag,
+            parse_max_in_flight, parse_timeout_ms,
+        };
+        use confique::Config as _;
+        use std::time::Duration;
+
+        // ADR-0090: the confique migration is byte-identical to the prior
+        // hand-rolled reader. These exercise the resolution logic without
+        // touching process env (issue 464).
+
+        #[test]
+        fn parse_flag_matches_legacy_bool_reader() {
+            for truthy in ["1", "true", "TRUE", "True"] {
+                assert!(parse_flag(truthy).unwrap(), "{truthy} should be truthy");
+            }
+            for falsy in ["0", "", "yes", "false", "garbage"] {
+                assert!(!parse_flag(falsy).unwrap(), "{falsy} should be falsy");
+            }
+        }
+
+        #[test]
+        fn parse_max_in_flight_filters_non_positive_and_unparseable() {
+            assert_eq!(parse_max_in_flight("4").unwrap(), 4);
+            assert_eq!(parse_max_in_flight("0").unwrap(), DEFAULT_MAX_IN_FLIGHT);
+            assert_eq!(
+                parse_max_in_flight("garbage").unwrap(),
+                DEFAULT_MAX_IN_FLIGHT
+            );
+        }
+
+        #[test]
+        fn parse_timeout_ms_soft_falls_back() {
+            assert_eq!(parse_timeout_ms("5000").unwrap(), 5000);
+            assert_eq!(parse_timeout_ms("garbage").unwrap(), DEFAULT_TIMEOUT_MS);
+        }
+
+        #[test]
+        fn gemini_from_env_defaults_match() {
+            // No `.env()` source: loads literal defaults only, so this is
+            // env-free and guards the layer's defaults against the named
+            // consts + `GeminiConfig::default()`.
+            let layer = GeminiConfigLayer::builder().load().expect("defaults load");
+            let default = GeminiConfig::default();
+            assert_eq!(layer.api_key, None);
+            assert!(!layer.disabled);
+            assert_eq!(layer.max_in_flight, DEFAULT_MAX_IN_FLIGHT);
+            assert_eq!(layer.timeout_ms, DEFAULT_TIMEOUT_MS);
+            assert_eq!(
+                Duration::from_millis(u64::from(layer.timeout_ms)),
+                default.timeout
+            );
         }
     }
 }

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -18,7 +18,11 @@ use std::time::Duration;
 // Handler-signature kinds must be importable at file root because
 // `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
 // of the mod (always-on, outside the cfg gate).
+// confique consumes `parse_flag` through the `#[config(parse_env = …)]`
+// attribute path; IntelliJ-Rust doesn't trace macro-attr path args and
+// flags this as unused (Qodana FP), but rustc + clippy resolve it.
 #[cfg(feature = "native")]
+#[allow(unused_imports)]
 use crate::config_env::parse_flag;
 use aether_actor::FfiActorMailbox;
 use aether_kinds::{Fetch, HttpError, HttpHeader, HttpMethod};

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -18,6 +18,8 @@ use std::time::Duration;
 // Handler-signature kinds must be importable at file root because
 // `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
 // of the mod (always-on, outside the cfg gate).
+#[cfg(feature = "native")]
+use crate::config_env::parse_flag;
 use aether_actor::FfiActorMailbox;
 use aether_kinds::{Fetch, HttpError, HttpHeader, HttpMethod};
 #[cfg(not(target_arch = "wasm32"))]
@@ -199,14 +201,6 @@ struct HttpConfigLayer {
 // list, and a default-on-unparseable number are all total. Hence the per-fn
 // `unnecessary_wraps` allow; the strict (erroring) variants land with the
 // ADR-0090 §4 validation pass.
-
-/// `"1"` or `"true"` (case-insensitive) → `true`, anything else `false`,
-/// matching the prior hand-rolled flag reader. Total — never errors.
-#[cfg(feature = "native")]
-#[allow(clippy::unnecessary_wraps)]
-fn parse_flag(s: &str) -> Result<bool, Infallible> {
-    Ok(s == "1" || s.eq_ignore_ascii_case("true"))
-}
 
 /// Split a comma-separated host list, trimming and dropping empties.
 /// Total — never errors.
@@ -626,17 +620,6 @@ mod native {
         // hand-rolled reader. These exercise the resolution logic without
         // touching process env (issue 464) — the parsers are pure, and the
         // defaults check loads the layer with no `.env()` source.
-
-        #[test]
-        fn parse_flag_matches_legacy_bool_reader() {
-            use super::super::parse_flag;
-            for truthy in ["1", "true", "TRUE", "True"] {
-                assert!(parse_flag(truthy).unwrap(), "{truthy} should be truthy");
-            }
-            for falsy in ["0", "", "yes", "false", "garbage"] {
-                assert!(!parse_flag(falsy).unwrap(), "{falsy} should be falsy");
-            }
-        }
 
         #[test]
         fn parse_allowlist_splits_trims_and_drops_empties() {

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -39,6 +39,12 @@ pub mod component;
 // elides cleanly on the wasm-component build.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod contentgen;
+// Shared confique `parse_env` helpers + provider defaults (ADR-0090).
+// Kept ungated so the per-provider `DEFAULT_MAX_IN_FLIGHT` constants can
+// alias `DEFAULT_PROVIDER_MAX_IN_FLIGHT` at file top level; the parser
+// fns are tiny pure-Rust dead code on non-native builds.
+mod config_env;
+
 // `aether.dag` computation-DAG executor cap (ADR-0047, issue 976).
 pub mod dag;
 pub mod engine;

--- a/crates/aether-substrate/Cargo.toml
+++ b/crates/aether-substrate/Cargo.toml
@@ -32,6 +32,14 @@ aether-actor = { path = "../aether-actor" }
 aether-data = { path = "../aether-data" }
 aether-kinds = { path = "../aether-kinds" }
 bytemuck = "1.19"
+# ADR-0090: typed, layered config resolution. Backs the env-shaped
+# `*Layer` structs (`PersistConfig`, the DAG `Caps` + `ExecutorConfig`)
+# that resolve each chassis-resolved config's `from_env`.
+# `default-features = false` keeps it env-only — no TOML/YAML file
+# parsers until ADR-0090's config-file step. aether-substrate is a
+# native-only crate (wasmtime always on), so this is a plain dep, not
+# feature-gated like the capabilities crate's confique.
+confique = { version = "0.4", default-features = false }
 # ADR-0049 on-disk handle store: resolve the default persistence root
 # (`dirs::data_dir()/aether/handles`). Same crate the fs cap uses.
 dirs = "6"

--- a/crates/aether-substrate/src/dag/executor.rs
+++ b/crates/aether-substrate/src/dag/executor.rs
@@ -60,7 +60,7 @@ use crate::handle_store::HandleStore;
 use crate::mail::mailer::Mailer;
 use crate::mail::registry::Registry;
 
-use std::env;
+use std::convert::Infallible;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::thread;
@@ -102,6 +102,179 @@ pub const DEFAULT_TRANSFORM_TIMEOUT_MS: u64 = 30_000;
 /// Default transform output-byte cap (ADR-0048 §6). Encoded output
 /// exceeding this hard-fails the node.
 pub const DEFAULT_TRANSFORM_MAX_OUTPUT_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Resolved executor tuning knobs (ADR-0047 §4/§7, ADR-0048 §3/§6), read
+/// once at [`Executor::new`]. Extracted from the formerly-inline env reads
+/// (issue #1254) so the resolution lives in one named place. Chassis code
+/// builds it via [`ExecutorConfig::from_env`]; tests can build it directly
+/// without touching process env (issue 464).
+#[derive(Clone, Copy, Debug)]
+pub struct ExecutorConfig {
+    /// Per-`Call` settlement timeout in ms (ADR-0047 §4).
+    pub call_timeout_ms: u64,
+    /// Default per-`Transform` wall-clock deadline in ms (ADR-0048 §3/§6).
+    pub transform_timeout_ms: u64,
+    /// Transform output-byte cap (ADR-0048 §6).
+    pub transform_max_output_bytes: u64,
+    /// Completed-DAG retention window in ms (ADR-0047 §7).
+    pub retention_complete_ms: u64,
+    /// Failed/cancelled-DAG retention window in ms (ADR-0047 §7).
+    pub retention_failed_ms: u64,
+    /// Transform compute-pool thread count (ADR-0048 §3). Resolved at
+    /// [`ExecutorConfig::from_env`] from available parallelism when unset.
+    pub pool_threads: usize,
+}
+
+impl Default for ExecutorConfig {
+    fn default() -> Self {
+        Self {
+            call_timeout_ms: DEFAULT_CALL_TIMEOUT_MS,
+            transform_timeout_ms: DEFAULT_TRANSFORM_TIMEOUT_MS,
+            transform_max_output_bytes: DEFAULT_TRANSFORM_MAX_OUTPUT_BYTES,
+            retention_complete_ms: DEFAULT_RETENTION_COMPLETE_MS,
+            retention_failed_ms: DEFAULT_RETENTION_FAILED_MS,
+            pool_threads: default_pool_threads(),
+        }
+    }
+}
+
+impl ExecutorConfig {
+    /// Resolve every knob from its `AETHER_*` env var. Chassis-internal
+    /// edge only.
+    ///
+    /// Resolution runs through confique (ADR-0090): the private
+    /// `ExecutorConfigLayer` declares each knob's env key + default in one
+    /// place. Behaviour is byte-identical to the prior inline reads — an
+    /// unparseable numeric value still falls back to its default, and the
+    /// pool-thread count still defaults to available parallelism (clamped
+    /// ≥ 1) when unset. The hard-error stance (ADR-0090 §4) lands with the
+    /// chassis-env validation pass.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if the layer's literal defaults are themselves
+    /// malformed — a programmer error caught by the
+    /// `executor_config_layer_defaults_match` test, never a runtime config
+    /// fault (the env values flow through total parsers).
+    #[must_use]
+    pub fn from_env() -> Self {
+        use confique::Config as _;
+
+        let layer = ExecutorConfigLayer::builder()
+            .env()
+            .load()
+            .expect("ExecutorConfigLayer defaults are well-formed");
+        Self {
+            call_timeout_ms: layer.call_timeout_ms,
+            transform_timeout_ms: layer.transform_timeout_ms,
+            transform_max_output_bytes: layer.transform_max_output_bytes,
+            retention_complete_ms: layer.retention_complete_ms,
+            retention_failed_ms: layer.retention_failed_ms,
+            // Runtime-computed default (not a literal confique can hold):
+            // unset *or* unparseable → available parallelism (clamped ≥ 1).
+            // A parseable value (incl `0`) is honoured verbatim — the prior
+            // `parse_env_usize` disposition. Captured as a raw string so
+            // confique's parse path can't hard-error on bad input.
+            pool_threads: layer
+                .pool_threads
+                .and_then(|s| s.parse::<usize>().ok())
+                .unwrap_or_else(default_pool_threads),
+        }
+    }
+}
+
+/// The transform compute-pool default: available parallelism, clamped to
+/// ≥ 1. Used when `AETHER_TRANSFORM_POOL_THREADS` is unset.
+fn default_pool_threads() -> usize {
+    thread::available_parallelism().map_or(1, NonZeroUsize::get)
+}
+
+/// Env-shaped confique layer behind [`ExecutorConfig`] (ADR-0090). Each
+/// numeric knob carries a literal default; `pool_threads` is `Option`
+/// because its default is runtime-computed (available parallelism), not a
+/// literal. Kept private — the consumed shape stays `ExecutorConfig`.
+#[derive(confique::Config)]
+struct ExecutorConfigLayer {
+    #[config(
+        env = "AETHER_DAG_CALL_TIMEOUT_MS",
+        parse_env = parse_call_timeout_ms,
+        default = 30_000u64
+    )]
+    call_timeout_ms: u64,
+    #[config(
+        env = "AETHER_TRANSFORM_TIMEOUT_MS",
+        parse_env = parse_transform_timeout_ms,
+        default = 30_000u64
+    )]
+    transform_timeout_ms: u64,
+    #[config(
+        env = "AETHER_TRANSFORM_MAX_OUTPUT_BYTES",
+        parse_env = parse_transform_max_output_bytes,
+        default = 67_108_864u64
+    )]
+    transform_max_output_bytes: u64,
+    #[config(
+        env = "AETHER_DAG_RETENTION_COMPLETE_MS",
+        parse_env = parse_retention_complete_ms,
+        default = 60_000u64
+    )]
+    retention_complete_ms: u64,
+    #[config(
+        env = "AETHER_DAG_RETENTION_FAILED_MS",
+        parse_env = parse_retention_failed_ms,
+        default = 300_000u64
+    )]
+    retention_failed_ms: u64,
+    /// Held as the raw string so `ExecutorConfig::from_env` can apply the
+    /// soft `.parse().ok()` then fall back to available parallelism on an
+    /// unset *or* unparseable value (a confique numeric field would
+    /// hard-error on bad input). A parseable value (incl `0`) is honoured
+    /// verbatim, byte-identical to the prior `parse_env_usize` read.
+    #[config(env = "AETHER_TRANSFORM_POOL_THREADS")]
+    pool_threads: Option<String>,
+}
+
+// confique's `parse_env` contract is `fn(&str) -> Result<T, impl Error>`,
+// so these total helpers carry a `Result` they never fill with `Err` — an
+// unparseable value folds back to the same default as the prior inline
+// `parse_env_u64` / `parse_env_usize` reads (the warn-on-malformed log is
+// dropped, the disposition is byte-identical). The strict (erroring)
+// variants land with the ADR-0090 §4 validation pass; hence the per-fn
+// `unnecessary_wraps` allow.
+
+/// Parse the per-`Call` timeout; unparseable → [`DEFAULT_CALL_TIMEOUT_MS`].
+#[allow(clippy::unnecessary_wraps)]
+fn parse_call_timeout_ms(s: &str) -> Result<u64, Infallible> {
+    Ok(s.parse().unwrap_or(DEFAULT_CALL_TIMEOUT_MS))
+}
+
+/// Parse the transform deadline; unparseable →
+/// [`DEFAULT_TRANSFORM_TIMEOUT_MS`].
+#[allow(clippy::unnecessary_wraps)]
+fn parse_transform_timeout_ms(s: &str) -> Result<u64, Infallible> {
+    Ok(s.parse().unwrap_or(DEFAULT_TRANSFORM_TIMEOUT_MS))
+}
+
+/// Parse the transform output cap; unparseable →
+/// [`DEFAULT_TRANSFORM_MAX_OUTPUT_BYTES`].
+#[allow(clippy::unnecessary_wraps)]
+fn parse_transform_max_output_bytes(s: &str) -> Result<u64, Infallible> {
+    Ok(s.parse().unwrap_or(DEFAULT_TRANSFORM_MAX_OUTPUT_BYTES))
+}
+
+/// Parse the completed-DAG retention; unparseable →
+/// [`DEFAULT_RETENTION_COMPLETE_MS`].
+#[allow(clippy::unnecessary_wraps)]
+fn parse_retention_complete_ms(s: &str) -> Result<u64, Infallible> {
+    Ok(s.parse().unwrap_or(DEFAULT_RETENTION_COMPLETE_MS))
+}
+
+/// Parse the failed-DAG retention; unparseable →
+/// [`DEFAULT_RETENTION_FAILED_MS`].
+#[allow(clippy::unnecessary_wraps)]
+fn parse_retention_failed_ms(s: &str) -> Result<u64, Infallible> {
+    Ok(s.parse().unwrap_or(DEFAULT_RETENTION_FAILED_MS))
+}
 
 /// What a landed reply correlates to (ADR-0047 §4). Sources resolve a
 /// stored handle and flush downstream; `Call`s accumulate into a
@@ -184,17 +357,14 @@ pub struct Executor {
 
 impl Executor {
     /// Build a fresh executor bound to the cap's `Arc<Mailer>` + own
-    /// mailbox id. Reads the retention / timeout env knobs once, builds
+    /// mailbox id. Takes the resolved [`ExecutorConfig`] (chassis builds it
+    /// via [`ExecutorConfig::from_env`]; tests build it directly), builds
     /// the native-transform registry from the link-time inventory
     /// (ADR-0048 §2), and spins up the dedicated transform compute pool
     /// (ADR-0048 §3).
     #[must_use]
-    pub fn new(mailer: Arc<Mailer>, self_mailbox: MailboxId) -> Self {
-        let pool_threads = parse_env_usize(
-            ENV_TRANSFORM_POOL_THREADS,
-            thread::available_parallelism().map_or(1, NonZeroUsize::get),
-        );
-        let transform_pool = TransformPool::new(pool_threads, &mailer);
+    pub fn new(mailer: Arc<Mailer>, self_mailbox: MailboxId, config: ExecutorConfig) -> Self {
+        let transform_pool = TransformPool::new(config.pool_threads, &mailer);
         Self {
             mailer,
             self_mailbox,
@@ -203,27 +373,12 @@ impl Executor {
             pending: HashMap::new(),
             in_flight_calls: HashMap::new(),
             in_flight_transforms: HashMap::new(),
-            call_timeout: Duration::from_millis(parse_env_u64(
-                ENV_CALL_TIMEOUT_MS,
-                DEFAULT_CALL_TIMEOUT_MS,
-            )),
-            transform_timeout: Duration::from_millis(parse_env_u64(
-                ENV_TRANSFORM_TIMEOUT_MS,
-                DEFAULT_TRANSFORM_TIMEOUT_MS,
-            )),
-            transform_max_output_bytes: usize::try_from(parse_env_u64(
-                ENV_TRANSFORM_MAX_OUTPUT_BYTES,
-                DEFAULT_TRANSFORM_MAX_OUTPUT_BYTES,
-            ))
-            .unwrap_or(usize::MAX),
-            retention_complete: Duration::from_millis(parse_env_u64(
-                ENV_RETENTION_COMPLETE_MS,
-                DEFAULT_RETENTION_COMPLETE_MS,
-            )),
-            retention_failed: Duration::from_millis(parse_env_u64(
-                ENV_RETENTION_FAILED_MS,
-                DEFAULT_RETENTION_FAILED_MS,
-            )),
+            call_timeout: Duration::from_millis(config.call_timeout_ms),
+            transform_timeout: Duration::from_millis(config.transform_timeout_ms),
+            transform_max_output_bytes: usize::try_from(config.transform_max_output_bytes)
+                .unwrap_or(usize::MAX),
+            retention_complete: Duration::from_millis(config.retention_complete_ms),
+            retention_failed: Duration::from_millis(config.retention_failed_ms),
             transform_registry: Arc::new(TransformRegistry::from_inventory()),
             transform_pool,
         }
@@ -1220,48 +1375,72 @@ fn slot_inner_kind_id(registry: &Registry, cell: &aether_data::SchemaCell) -> Ki
         })
 }
 
-/// Parse a `u64` env var, warning + falling back on a malformed value
-/// (same shape as the validator's parser).
-#[allow(clippy::option_if_let_else)]
-fn parse_env_u64(name: &str, default: u64) -> u64 {
-    match env::var(name) {
-        Ok(raw) => match raw.parse::<u64>() {
-            Ok(n) => n,
-            Err(e) => {
-                tracing::warn!(
-                    target: TARGET,
-                    env = name,
-                    value = %raw,
-                    error = %e,
-                    default,
-                    "ignoring unparseable DAG env var; using default",
-                );
-                default
-            }
-        },
-        Err(_) => default,
-    }
-}
+#[cfg(test)]
+mod config_tests {
+    use super::{
+        DEFAULT_CALL_TIMEOUT_MS, DEFAULT_RETENTION_COMPLETE_MS, DEFAULT_RETENTION_FAILED_MS,
+        DEFAULT_TRANSFORM_MAX_OUTPUT_BYTES, DEFAULT_TRANSFORM_TIMEOUT_MS, ExecutorConfig,
+        ExecutorConfigLayer, default_pool_threads, parse_call_timeout_ms,
+        parse_retention_complete_ms, parse_retention_failed_ms, parse_transform_max_output_bytes,
+        parse_transform_timeout_ms,
+    };
 
-/// Parse a `usize` env var, warning + falling back on a malformed value.
-/// Used for the transform compute-pool thread count (ADR-0048 §3).
-#[allow(clippy::option_if_let_else)]
-fn parse_env_usize(name: &str, default: usize) -> usize {
-    match env::var(name) {
-        Ok(raw) => match raw.parse::<usize>() {
-            Ok(n) => n,
-            Err(e) => {
-                tracing::warn!(
-                    target: TARGET,
-                    env = name,
-                    value = %raw,
-                    error = %e,
-                    default,
-                    "ignoring unparseable transform pool env var; using default",
-                );
-                default
-            }
-        },
-        Err(_) => default,
+    // ADR-0090: the confique migration is byte-identical to the prior
+    // inline env reads. These exercise resolution without touching process
+    // env (issue 464) — the parsers are pure, and the defaults check loads
+    // the layer with no `.env()` source.
+
+    #[test]
+    fn parse_numbers_soft_fall_back_to_defaults() {
+        assert_eq!(parse_call_timeout_ms("100").unwrap(), 100);
+        assert_eq!(
+            parse_call_timeout_ms("nope").unwrap(),
+            DEFAULT_CALL_TIMEOUT_MS
+        );
+        assert_eq!(parse_transform_timeout_ms("200").unwrap(), 200);
+        assert_eq!(
+            parse_transform_timeout_ms("nope").unwrap(),
+            DEFAULT_TRANSFORM_TIMEOUT_MS
+        );
+        assert_eq!(parse_transform_max_output_bytes("4096").unwrap(), 4096);
+        assert_eq!(
+            parse_transform_max_output_bytes("nope").unwrap(),
+            DEFAULT_TRANSFORM_MAX_OUTPUT_BYTES
+        );
+        assert_eq!(parse_retention_complete_ms("300").unwrap(), 300);
+        assert_eq!(
+            parse_retention_complete_ms("nope").unwrap(),
+            DEFAULT_RETENTION_COMPLETE_MS
+        );
+        assert_eq!(parse_retention_failed_ms("400").unwrap(), 400);
+        assert_eq!(
+            parse_retention_failed_ms("nope").unwrap(),
+            DEFAULT_RETENTION_FAILED_MS
+        );
+    }
+
+    #[test]
+    fn executor_config_layer_defaults_match() {
+        use confique::Config as _;
+        // No `.env()` source: literal defaults only, env-free. Guards the
+        // layer defaults against the named consts + `ExecutorConfig::default`.
+        let layer = ExecutorConfigLayer::builder()
+            .load()
+            .expect("defaults load");
+        let default = ExecutorConfig::default();
+        assert_eq!(layer.call_timeout_ms, DEFAULT_CALL_TIMEOUT_MS);
+        assert_eq!(layer.call_timeout_ms, default.call_timeout_ms);
+        assert_eq!(layer.transform_timeout_ms, DEFAULT_TRANSFORM_TIMEOUT_MS);
+        assert_eq!(
+            layer.transform_max_output_bytes,
+            DEFAULT_TRANSFORM_MAX_OUTPUT_BYTES
+        );
+        assert_eq!(layer.retention_complete_ms, DEFAULT_RETENTION_COMPLETE_MS);
+        assert_eq!(layer.retention_failed_ms, DEFAULT_RETENTION_FAILED_MS);
+        // Pool threads has no literal default — the layer field is `None`
+        // when unset, resolved to available parallelism in `from_env`.
+        assert_eq!(layer.pool_threads, None);
+        assert!(default.pool_threads >= 1);
+        assert_eq!(default.pool_threads, default_pool_threads());
     }
 }

--- a/crates/aether-substrate/src/dag/validator.rs
+++ b/crates/aether-substrate/src/dag/validator.rs
@@ -22,7 +22,7 @@
 //! reply-kind resolution anywhere in this validator.
 
 use std::collections::{BTreeSet, HashMap};
-use std::env;
+use std::convert::Infallible;
 
 use aether_data::canonical::canonical_kind_bytes;
 use aether_data::{Kind, Schema, SchemaType};
@@ -30,8 +30,6 @@ use aether_kinds::{Bundle, DagDescriptor, DagError, Edge, Node, NodeId};
 
 use crate::dag::transform_registry::TransformRegistry;
 use crate::mail::{CapabilityRegistry, KindId, MailboxEntry, MailboxId, Registry};
-
-const TARGET: &str = "aether::dag::validator";
 
 /// Env override for the node-count cap (ADR-0047 §3). Default
 /// [`DEFAULT_MAX_NODES`].
@@ -530,6 +528,13 @@ fn mailbox_label(mailboxes: &Registry, id: MailboxId) -> String {
 
 /// Resolved structural caps (ADR-0047 §3), read once per validation from
 /// the environment with the documented defaults.
+///
+/// Resolution runs through confique (ADR-0090): the private `CapsLayer`
+/// declares each cap's `AETHER_DAG_MAX_*` env key + default in one place.
+/// Behaviour is byte-identical to the prior hand-rolled `parse_env_u64`
+/// reader — an unparseable value still falls back to its default. The
+/// hard-error stance (ADR-0090 §4) lands with the chassis-env validation
+/// pass.
 struct Caps {
     nodes: u64,
     edges: u64,
@@ -538,33 +543,103 @@ struct Caps {
 
 impl Caps {
     fn from_env() -> Self {
+        use confique::Config as _;
+
+        // Every field has a literal default and a total parser, so the
+        // layer always resolves; a failure would be a malformed default
+        // literal (caught by `caps_layer_defaults_match`).
+        let layer = CapsLayer::builder()
+            .env()
+            .load()
+            .expect("CapsLayer defaults are well-formed");
         Self {
-            nodes: parse_env_u64(ENV_MAX_NODES, DEFAULT_MAX_NODES),
-            edges: parse_env_u64(ENV_MAX_EDGES, DEFAULT_MAX_EDGES),
-            descriptor_bytes: parse_env_u64(ENV_MAX_DESCRIPTOR_BYTES, DEFAULT_MAX_DESCRIPTOR_BYTES),
+            nodes: layer.nodes,
+            edges: layer.edges,
+            descriptor_bytes: layer.descriptor_bytes,
         }
     }
 }
 
-/// Parse a `u64` env var, warning and falling back to `default` on a
-/// malformed value (same shape as the handle-store cap parser).
-#[allow(clippy::option_if_let_else)]
-fn parse_env_u64(name: &str, default: u64) -> u64 {
-    match env::var(name) {
-        Ok(raw) => match raw.parse::<u64>() {
-            Ok(n) => n,
-            Err(e) => {
-                tracing::warn!(
-                    target: TARGET,
-                    env = name,
-                    value = %raw,
-                    error = %e,
-                    default,
-                    "ignoring unparseable DAG cap env var; using default",
-                );
-                default
-            }
-        },
-        Err(_) => default,
+/// Env-shaped confique layer behind the structural `Caps` (ADR-0090).
+/// Kept private — the consumed shape stays `Caps`.
+#[derive(confique::Config)]
+struct CapsLayer {
+    /// Max node count. Literal default mirrors [`DEFAULT_MAX_NODES`]
+    /// (256); `caps_layer_defaults_match` guards the match.
+    #[config(env = "AETHER_DAG_MAX_NODES", parse_env = parse_max_nodes, default = 256u64)]
+    nodes: u64,
+    /// Max edge count. Literal default mirrors [`DEFAULT_MAX_EDGES`] (1024).
+    #[config(env = "AETHER_DAG_MAX_EDGES", parse_env = parse_max_edges, default = 1024u64)]
+    edges: u64,
+    /// Max descriptor bytes. Literal default mirrors
+    /// [`DEFAULT_MAX_DESCRIPTOR_BYTES`] (1 MiB).
+    #[config(
+        env = "AETHER_DAG_MAX_DESCRIPTOR_BYTES",
+        parse_env = parse_max_descriptor_bytes,
+        default = 1_048_576u64
+    )]
+    descriptor_bytes: u64,
+}
+
+// confique's `parse_env` contract is `fn(&str) -> Result<T, impl Error>`,
+// so these total helpers carry a `Result` they never fill with `Err` — an
+// unparseable value folds back to the same default as the prior
+// `parse_env_u64` (the warn-on-malformed log is dropped, the disposition is
+// byte-identical). The strict (erroring) variant lands with the ADR-0090 §4
+// validation pass; hence the per-fn `unnecessary_wraps` allow.
+
+/// Parse the node cap; unparseable falls back to [`DEFAULT_MAX_NODES`].
+#[allow(clippy::unnecessary_wraps)]
+fn parse_max_nodes(s: &str) -> Result<u64, Infallible> {
+    Ok(s.parse().unwrap_or(DEFAULT_MAX_NODES))
+}
+
+/// Parse the edge cap; unparseable falls back to [`DEFAULT_MAX_EDGES`].
+#[allow(clippy::unnecessary_wraps)]
+fn parse_max_edges(s: &str) -> Result<u64, Infallible> {
+    Ok(s.parse().unwrap_or(DEFAULT_MAX_EDGES))
+}
+
+/// Parse the descriptor-bytes cap; unparseable falls back to
+/// [`DEFAULT_MAX_DESCRIPTOR_BYTES`].
+#[allow(clippy::unnecessary_wraps)]
+fn parse_max_descriptor_bytes(s: &str) -> Result<u64, Infallible> {
+    Ok(s.parse().unwrap_or(DEFAULT_MAX_DESCRIPTOR_BYTES))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CapsLayer, DEFAULT_MAX_DESCRIPTOR_BYTES, DEFAULT_MAX_EDGES, DEFAULT_MAX_NODES,
+        parse_max_descriptor_bytes, parse_max_edges, parse_max_nodes,
+    };
+
+    // ADR-0090: the confique migration is byte-identical to the prior
+    // hand-rolled `parse_env_u64` reader. These exercise resolution
+    // without touching process env (issue 464) — the parsers are pure,
+    // and the defaults check loads the layer with no `.env()` source.
+
+    #[test]
+    fn parse_caps_soft_fall_back_to_defaults() {
+        assert_eq!(parse_max_nodes("8").unwrap(), 8);
+        assert_eq!(parse_max_nodes("nope").unwrap(), DEFAULT_MAX_NODES);
+        assert_eq!(parse_max_edges("16").unwrap(), 16);
+        assert_eq!(parse_max_edges("nope").unwrap(), DEFAULT_MAX_EDGES);
+        assert_eq!(parse_max_descriptor_bytes("2048").unwrap(), 2048);
+        assert_eq!(
+            parse_max_descriptor_bytes("nope").unwrap(),
+            DEFAULT_MAX_DESCRIPTOR_BYTES
+        );
+    }
+
+    #[test]
+    fn caps_layer_defaults_match() {
+        use confique::Config as _;
+        // No `.env()` source: literal defaults only, env-free. Guards the
+        // layer defaults against the named consts.
+        let layer = CapsLayer::builder().load().expect("defaults load");
+        assert_eq!(layer.nodes, DEFAULT_MAX_NODES);
+        assert_eq!(layer.edges, DEFAULT_MAX_EDGES);
+        assert_eq!(layer.descriptor_bytes, DEFAULT_MAX_DESCRIPTOR_BYTES);
     }
 }

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -40,6 +40,7 @@
 
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::convert::Infallible;
 use std::error::Error as StdError;
 use std::fmt;
 use std::fs;
@@ -123,8 +124,26 @@ impl PersistConfig {
     /// `enabled` is the chassis's verdict: desktop + headless pass
     /// `true`; the hub passes `false` (ADR-0049 §9). A `false` chassis
     /// vote short-circuits to `None` regardless of env.
+    /// Resolution runs through confique (ADR-0090) for the two numeric
+    /// budget / tick knobs via the private `PersistConfigLayer`; the
+    /// `enabled` chassis vote, the `ENV_PERSIST_DISABLE` short-circuit,
+    /// and the root-or-`None` resolution stay hand-written because their
+    /// outcome is structural (a missing data dir disables persistence
+    /// entirely, not a literal default confique could hold). Behaviour is
+    /// byte-identical to the prior hand-rolled reader — an unparseable
+    /// budget / tick still falls back to its default. The hard-error
+    /// stance (ADR-0090 §4) lands with the chassis-env validation pass.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if the layer's literal defaults are themselves
+    /// malformed — a programmer error caught by the
+    /// `persist_config_layer_defaults_match` test, never a runtime config
+    /// fault (the env values flow through total parsers).
     #[must_use]
     pub fn from_env(enabled: bool) -> Option<Self> {
+        use confique::Config as _;
+
         if !enabled {
             return None;
         }
@@ -144,13 +163,17 @@ impl PersistConfig {
                 data.join("aether").join("handles")
             }
         };
+        // Every layer field has a literal default and a total parser, so
+        // the layer always resolves; a failure here would be a malformed
+        // default literal (caught by `persist_config_layer_defaults_match`).
+        let layer = PersistConfigLayer::builder()
+            .env()
+            .load()
+            .expect("PersistConfigLayer defaults are well-formed");
         Some(Self {
             root: base.join(LAYOUT_VERSION_DIR),
-            disk_budget_bytes: parse_env_u64(ENV_DISK_BUDGET_BYTES, DEFAULT_DISK_BUDGET_BYTES),
-            eviction_tick_secs: parse_env_u64(
-                ENV_DISK_EVICTION_TICK_SECS,
-                DEFAULT_DISK_EVICTION_TICK_SECS,
-            ),
+            disk_budget_bytes: layer.disk_budget_bytes,
+            eviction_tick_secs: layer.eviction_tick_secs,
         })
     }
 
@@ -350,28 +373,52 @@ pub fn entry_paths(root: &Path, id: HandleId) -> (PathBuf, PathBuf) {
     )
 }
 
-/// Parse a `u64` env var, falling back to `default` on absence or a
-/// parse failure (with a warn for the malformed case).
-// Nested match keeps the warn-log path readable (same shape as `from_env`).
-#[allow(clippy::option_if_let_else)]
-fn parse_env_u64(name: &str, default: u64) -> u64 {
-    match env::var(name) {
-        Ok(raw) => match raw.parse::<u64>() {
-            Ok(n) => n,
-            Err(e) => {
-                tracing::warn!(
-                    target: TARGET,
-                    env = name,
-                    value = %raw,
-                    error = %e,
-                    default,
-                    "ignoring unparseable env var; using default",
-                );
-                default
-            }
-        },
-        Err(_) => default,
-    }
+/// Env-shaped confique layer behind the numeric knobs of
+/// [`PersistConfig`] (ADR-0090). `disk_budget_bytes` and
+/// `eviction_tick_secs` carry their `AETHER_HANDLE_STORE_*` values; the
+/// `root` resolution stays hand-written in [`PersistConfig::from_env`]
+/// (its default is structural — a missing data dir disables persistence,
+/// not a literal). Kept private; the consumed shape stays `PersistConfig`.
+#[derive(confique::Config)]
+struct PersistConfigLayer {
+    /// On-disk byte budget. Literal default mirrors
+    /// [`DEFAULT_DISK_BUDGET_BYTES`] (16 GiB); the
+    /// `persist_config_layer_defaults_match` test guards the match.
+    #[config(
+        env = "AETHER_HANDLE_STORE_DISK_BUDGET_BYTES",
+        parse_env = parse_disk_budget_bytes,
+        default = 17_179_869_184u64
+    )]
+    disk_budget_bytes: u64,
+    /// Eviction tick interval in seconds. Literal default mirrors
+    /// [`DEFAULT_DISK_EVICTION_TICK_SECS`] (60 s).
+    #[config(
+        env = "AETHER_HANDLE_STORE_DISK_EVICTION_TICK_SECS",
+        parse_env = parse_eviction_tick_secs,
+        default = 60u64
+    )]
+    eviction_tick_secs: u64,
+}
+
+// confique's `parse_env` contract is `fn(&str) -> Result<T, impl Error>`,
+// so these total helpers carry a `Result` they never fill with `Err` — an
+// unparseable value folds back to the same default as the prior
+// `parse_env_u64` (the warn-on-malformed log is dropped, the disposition is
+// byte-identical). The strict (erroring) variant lands with the ADR-0090 §4
+// validation pass; hence the per-fn `unnecessary_wraps` allow.
+
+/// Parse the disk byte budget; unparseable falls back to
+/// [`DEFAULT_DISK_BUDGET_BYTES`]. Total — never errors.
+#[allow(clippy::unnecessary_wraps)]
+fn parse_disk_budget_bytes(s: &str) -> Result<u64, Infallible> {
+    Ok(s.parse().unwrap_or(DEFAULT_DISK_BUDGET_BYTES))
+}
+
+/// Parse the eviction tick seconds; unparseable falls back to
+/// [`DEFAULT_DISK_EVICTION_TICK_SECS`]. Total — never errors.
+#[allow(clippy::unnecessary_wraps)]
+fn parse_eviction_tick_secs(s: &str) -> Result<u64, Infallible> {
+    Ok(s.parse().unwrap_or(DEFAULT_DISK_EVICTION_TICK_SECS))
 }
 
 /// Millis since the unix epoch, saturating to 0 if the clock is before
@@ -2035,6 +2082,35 @@ mod tests {
 
     use super::*;
     use aether_data::tagged_id;
+
+    // ADR-0090: the confique migration is byte-identical to the prior
+    // hand-rolled `parse_env_u64` reader. These exercise resolution
+    // without touching process env (issue 464) — the parsers are pure,
+    // and the defaults check loads the layer with no `.env()` source.
+
+    #[test]
+    fn parse_persist_numbers_soft_fall_back_to_defaults() {
+        assert_eq!(parse_disk_budget_bytes("1024").unwrap(), 1024);
+        assert_eq!(
+            parse_disk_budget_bytes("nope").unwrap(),
+            DEFAULT_DISK_BUDGET_BYTES
+        );
+        assert_eq!(parse_eviction_tick_secs("30").unwrap(), 30);
+        assert_eq!(
+            parse_eviction_tick_secs("nope").unwrap(),
+            DEFAULT_DISK_EVICTION_TICK_SECS
+        );
+    }
+
+    #[test]
+    fn persist_config_layer_defaults_match() {
+        use confique::Config as _;
+        // No `.env()` source: literal defaults only, env-free. Guards the
+        // layer defaults against the named consts.
+        let layer = PersistConfigLayer::builder().load().expect("defaults load");
+        assert_eq!(layer.disk_budget_bytes, DEFAULT_DISK_BUDGET_BYTES);
+        assert_eq!(layer.eviction_tick_secs, DEFAULT_DISK_EVICTION_TICK_SECS);
+    }
 
     // ------------------------------------------------------------
     // HandleStore unit tests


### PR DESCRIPTION
Unit b1 of ADR-0090 — the env-track sweep applying the unit-(a) confique pattern to the remaining chassis-resolved config structs. Closes iamacoffeepot/aether#1254. Epic: iamacoffeepot/aether#1235.

## What
Migrated `GeminiConfig`, `AnthropicConfig`, `AudioConfig`, `NamespaceRoots`, `PersistConfig`, the DAG validator `Caps`, and a newly-extracted `ExecutorConfig` to confique — each via a private env-shaped `*Layer` struct mapped to the unchanged public domain type. Deleted the three duplicated `parse_env_u64`, the `parse_env_usize`, and `env_or_default` helpers (grep-zero). Behaviour is byte-identical; the hard-error-on-unparseable flip (ADR §4) stays deferred to e1 (iamacoffeepot/aether#1259).

## Deviations from the HttpConfig template (all to preserve byte-identical soft-fail)
- **Non-literal defaults** can't go in `#[config(default = …)]` (confique wants a literal). Fields with runtime-computed defaults — `NamespaceRoots` / `PersistConfig` dirs (via `dirs` / `current_exe`) and `ExecutorConfig.pool_threads` (via `available_parallelism`) — are held as raw `Option` in the layer and resolved in `from_env`, identical to the prior fallbacks.
- **Option soft-parse**: confique's `parse_env` on an `Option` field hard-errors on a non-empty bad value, which isn't byte-identical to the old `.parse().ok()`. So `AudioConfig.requested_sample_rate` and `ExecutorConfig.pool_threads` keep a raw `Option<String>` layer field + `.parse().ok()` in `from_env`.
- `confique` added to `aether-substrate/Cargo.toml` (native-only crate, so ungated). Its `default = N` literals there needed `u64` suffixes — confique infers `i32`, which the 16 GiB disk-budget literal overflowed.
- `Executor::new` gained a `config: ExecutorConfig` param; its sole call site (`dag.rs`) passes `ExecutorConfig::from_env()`.

## Tests
Env-free (issue 464): per-struct pure-function parser tests + defaults checks via `Layer::builder().load()` (no `.env()` source). Full local pre-flight green: fmt + clippy (incl. audio-native / render-native) + doc + wasm32 cross-build + 1419 nextest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
