### PR TITLE
feat(substrate-bundle): parse argv above env in chassis mains via clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,8 @@ dependencies = [
  "aether-test-fixtures",
  "anyhow",
  "bytemuck",
+ "clap",
+ "confique",
  "crossbeam-channel",
  "ctrlc",
  "plotters",
@@ -377,6 +379,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -683,6 +735,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,6 +793,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -1978,6 +2076,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2763,6 +2867,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "option-ext"
@@ -4292,6 +4402,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,12 @@ exclude = [
 version = "0.3.0-alpha"
 edition = "2024"
 
+[workspace.dependencies]
+# Chassis-binary argv parsing (ADR-0090 unit d, issue 1258). One
+# consumer today (`aether-substrate-bundle`); workspaced so future CLI
+# surfaces reach for the same major.
+clap = { version = "4", features = ["derive"] }
+
 [workspace.lints.rust]
 # Phase 5 of iamacoffeepot/aether#913 swept ~244 RsUnnecessaryQualifications
 # findings across the workspace. Enabling rustc's matching lint here at

--- a/crates/aether-capabilities/src/anthropic/mod.rs
+++ b/crates/aether-capabilities/src/anthropic/mod.rs
@@ -190,6 +190,7 @@ mod config {
         /// fault (the env values flow through total parsers).
         #[must_use]
         pub fn from_env() -> Self {
+            use aether_substrate::FromArgvThenEnv as _;
             use confique::Config as _;
 
             let layer = AnthropicConfigLayer::builder()
@@ -199,25 +200,13 @@ mod config {
             Self::from_layer(layer)
         }
 
-        /// Resolve from a chassis-CLI argv overlay shadowing env (ADR-0090
-        /// unit d, issue 1258). Argv-set fields win; unset (`None`) fall
-        /// through to `ANTHROPIC_API_KEY` / `AETHER_ANTHROPIC_*` env,
-        /// then literal defaults.
-        ///
-        /// # Panics
-        ///
-        /// Same as [`Self::from_env`].
-        #[must_use]
-        pub fn from_argv_then_env(argv: <AnthropicConfigLayer as confique::Config>::Layer) -> Self {
-            use confique::Config as _;
+        // `from_argv_then_env` and `from_layer` come from the
+        // `FromArgvThenEnv` impl below (ADR-0090 unit d).
+    }
 
-            let layer = AnthropicConfigLayer::builder()
-                .preloaded(argv)
-                .env()
-                .load()
-                .expect("AnthropicConfigLayer defaults are well-formed");
-            Self::from_layer(layer)
-        }
+    #[cfg(feature = "native")]
+    impl aether_substrate::FromArgvThenEnv for AnthropicConfig {
+        type Layer = AnthropicConfigLayer;
 
         fn from_layer(layer: AnthropicConfigLayer) -> Self {
             Self {

--- a/crates/aether-capabilities/src/anthropic/mod.rs
+++ b/crates/aether-capabilities/src/anthropic/mod.rs
@@ -33,7 +33,7 @@ use crate::contentgen::adapter::{AnthropicAdapter, AnthropicRequest, AnthropicRe
 use crate::config_env::DEFAULT_PROVIDER_MAX_IN_FLIGHT;
 pub use api::UreqAnthropicAdapter;
 pub use cli::ClaudeCliAdapter;
-pub use config::AnthropicConfig;
+pub use config::{AnthropicConfig, AnthropicConfigLayer};
 
 /// Default per-cap concurrency bound when `AETHER_ANTHROPIC_MAX_IN_FLIGHT`
 /// is unset. Conservative — paid-endpoint throttling matters more than
@@ -196,6 +196,30 @@ mod config {
                 .env()
                 .load()
                 .expect("AnthropicConfigLayer defaults are well-formed");
+            Self::from_layer(layer)
+        }
+
+        /// Resolve from a chassis-CLI argv overlay shadowing env (ADR-0090
+        /// unit d, issue 1258). Argv-set fields win; unset (`None`) fall
+        /// through to `ANTHROPIC_API_KEY` / `AETHER_ANTHROPIC_*` env,
+        /// then literal defaults.
+        ///
+        /// # Panics
+        ///
+        /// Same as [`Self::from_env`].
+        #[must_use]
+        pub fn from_argv_then_env(argv: <AnthropicConfigLayer as confique::Config>::Layer) -> Self {
+            use confique::Config as _;
+
+            let layer = AnthropicConfigLayer::builder()
+                .preloaded(argv)
+                .env()
+                .load()
+                .expect("AnthropicConfigLayer defaults are well-formed");
+            Self::from_layer(layer)
+        }
+
+        fn from_layer(layer: AnthropicConfigLayer) -> Self {
             Self {
                 api_key: layer.api_key.filter(|s| !s.is_empty()),
                 disabled: layer.disabled,
@@ -208,18 +232,20 @@ mod config {
     /// Env-shaped confique layer behind `AnthropicConfig` (ADR-0090). Each
     /// field is the primitive its env var carries; `AnthropicConfig::from_env`
     /// maps them onto the domain types (ms → `Duration`, empty key →
-    /// `None`). Kept private — the public consumed shape stays
-    /// `AnthropicConfig`.
+    /// `None`). Public so chassis CLI overlays (ADR-0090 unit d,
+    /// issue 1258) can preload a `<AnthropicConfigLayer as
+    /// confique::Config>::Layer` before `.env()`; the consumed shape
+    /// stays `AnthropicConfig`.
     #[cfg(feature = "native")]
     #[derive(confique::Config)]
-    struct AnthropicConfigLayer {
+    pub struct AnthropicConfigLayer {
         /// `ANTHROPIC_API_KEY` (bare, un-prefixed). Empty/unset → `None`
         /// after the `from_env` filter.
         #[config(env = "ANTHROPIC_API_KEY")]
-        api_key: Option<String>,
+        pub api_key: Option<String>,
         /// `AETHER_ANTHROPIC_DISABLE=1`/`true` forces the disabled adapter.
         #[config(env = "AETHER_ANTHROPIC_DISABLE", parse_env = parse_flag, default = false)]
-        disabled: bool,
+        pub disabled: bool,
         /// Per-cap concurrency bound. A non-positive / unparseable value
         /// falls back to the default (`> 0` filter preserved).
         #[config(
@@ -227,7 +253,7 @@ mod config {
             parse_env = parse_provider_max_in_flight,
             default = 2
         )]
-        max_in_flight: usize,
+        pub max_in_flight: usize,
         /// Per-request timeout in milliseconds. Literal default mirrors
         /// `DEFAULT_TIMEOUT_MS` (120 s).
         #[config(
@@ -235,7 +261,7 @@ mod config {
             parse_env = parse_u32_ms_or::<DEFAULT_TIMEOUT_MS>,
             default = 120_000
         )]
-        timeout_ms: u32,
+        pub timeout_ms: u32,
     }
 
     #[cfg(all(test, feature = "native"))]

--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -60,7 +60,7 @@ use aether_kinds::{NoteOff, NoteOn, SetMasterGain};
 // the config struct (sends are typed; config is the chassis's
 // concern).
 #[cfg(all(not(target_arch = "wasm32"), feature = "audio-native"))]
-pub use native::AudioConfig;
+pub use native::{AudioConfig, AudioConfigLayer};
 
 #[aether_actor::bridge(singleton, feature = "audio-native")]
 mod native {
@@ -141,6 +141,29 @@ mod native {
                 .env()
                 .load()
                 .expect("AudioConfigLayer defaults are well-formed");
+            Self::from_layer(layer)
+        }
+
+        /// Resolve from a chassis-CLI argv overlay shadowing env (ADR-0090
+        /// unit d, issue 1258). Argv-set fields win; unset (`None`) fall
+        /// through to `AETHER_AUDIO_*` env and then literal defaults.
+        ///
+        /// # Panics
+        ///
+        /// Same as [`Self::from_env`].
+        #[must_use]
+        pub fn from_argv_then_env(argv: <AudioConfigLayer as confique::Config>::Layer) -> Self {
+            use confique::Config as _;
+
+            let layer = AudioConfigLayer::builder()
+                .preloaded(argv)
+                .env()
+                .load()
+                .expect("AudioConfigLayer defaults are well-formed");
+            Self::from_layer(layer)
+        }
+
+        fn from_layer(layer: AudioConfigLayer) -> Self {
             Self {
                 disabled: layer.disabled,
                 // Prior behaviour: `.parse::<u32>().ok()` — an unparseable
@@ -156,21 +179,23 @@ mod native {
         }
     }
 
-    /// Env-shaped confique layer behind `AudioConfig` (ADR-0090). Kept
-    /// private — the public consumed shape stays `AudioConfig`. Lives
-    /// inside the `audio-native` bridge mod (which implies the `native`
-    /// feature), so confique is always available here.
+    /// Env-shaped confique layer behind `AudioConfig` (ADR-0090). Public
+    /// so chassis CLI overlays (ADR-0090 unit d, issue 1258) can preload
+    /// a `<AudioConfigLayer as confique::Config>::Layer` before
+    /// `.env()`; the consumed shape stays `AudioConfig`. Lives inside the
+    /// `audio-native` bridge mod (which implies the `native` feature), so
+    /// confique is always available here.
     #[derive(confique::Config)]
-    struct AudioConfigLayer {
+    pub struct AudioConfigLayer {
         /// `AETHER_AUDIO_DISABLE=1`/`true` skips cpal init entirely.
         #[config(env = "AETHER_AUDIO_DISABLE", parse_env = parse_flag, default = false)]
-        disabled: bool,
+        pub disabled: bool,
         /// `AETHER_AUDIO_SAMPLE_RATE=<hz>` requests a specific rate. Held
         /// as the raw string so `AudioConfig::from_env` can apply the
         /// soft `.parse().ok()` (an unparseable value → `None`); a
         /// confique numeric field would hard-error on bad input instead.
         #[config(env = "AETHER_AUDIO_SAMPLE_RATE")]
-        requested_sample_rate: Option<String>,
+        pub requested_sample_rate: Option<String>,
     }
 
     /// Event a handler pushes into the audio callback's queue. The

--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -135,6 +135,7 @@ mod native {
         /// fault (the env values flow through a total parser / raw capture).
         #[must_use]
         pub fn from_env() -> Self {
+            use aether_substrate::FromArgvThenEnv as _;
             use confique::Config as _;
 
             let layer = AudioConfigLayer::builder()
@@ -144,24 +145,12 @@ mod native {
             Self::from_layer(layer)
         }
 
-        /// Resolve from a chassis-CLI argv overlay shadowing env (ADR-0090
-        /// unit d, issue 1258). Argv-set fields win; unset (`None`) fall
-        /// through to `AETHER_AUDIO_*` env and then literal defaults.
-        ///
-        /// # Panics
-        ///
-        /// Same as [`Self::from_env`].
-        #[must_use]
-        pub fn from_argv_then_env(argv: <AudioConfigLayer as confique::Config>::Layer) -> Self {
-            use confique::Config as _;
+        // `from_argv_then_env` and `from_layer` come from the
+        // `FromArgvThenEnv` impl below (ADR-0090 unit d).
+    }
 
-            let layer = AudioConfigLayer::builder()
-                .preloaded(argv)
-                .env()
-                .load()
-                .expect("AudioConfigLayer defaults are well-formed");
-            Self::from_layer(layer)
-        }
+    impl aether_substrate::FromArgvThenEnv for AudioConfig {
+        type Layer = AudioConfigLayer;
 
         fn from_layer(layer: AudioConfigLayer) -> Self {
             Self {

--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -443,6 +443,7 @@ mod native {
         #[cfg(feature = "native")]
         #[must_use]
         pub fn from_env() -> Self {
+            use aether_substrate::FromArgvThenEnv as _;
             use confique::Config as _;
 
             let layer = NamespaceRootsLayer::builder()
@@ -452,32 +453,14 @@ mod native {
             Self::from_layer(layer)
         }
 
-        /// Resolve from a chassis-CLI argv overlay shadowing env (ADR-0090
-        /// unit d, issue 1258). Argv-set roots win; unset (`None`) fall
-        /// through to `AETHER_SAVE_DIR` / `AETHER_ASSETS_DIR` /
-        /// `AETHER_CONFIG_DIR` env, then platform-default fallbacks.
-        ///
-        /// # Panics
-        ///
-        /// Same as [`Self::from_env`]: only on a future confique
-        /// misconfiguration (the layer has no literal defaults today).
-        #[cfg(feature = "native")]
-        #[must_use]
-        pub fn from_argv_then_env(argv: <NamespaceRootsLayer as confique::Config>::Layer) -> Self {
-            use confique::Config as _;
+        // `from_argv_then_env` and `from_layer` come from the
+        // `FromArgvThenEnv` impl below (ADR-0090 unit d).
+    }
 
-            let layer = NamespaceRootsLayer::builder()
-                .preloaded(argv)
-                .env()
-                .load()
-                .expect("NamespaceRootsLayer has no literal defaults to malform");
-            Self::from_layer(layer)
-        }
+    #[cfg(feature = "native")]
+    impl aether_substrate::FromArgvThenEnv for NamespaceRoots {
+        type Layer = NamespaceRootsLayer;
 
-        /// Shared platform-default fallback mapping. Kept private so the
-        /// layer shape stays an implementation detail of
-        /// [`Self::from_env`] / [`Self::from_argv_then_env`].
-        #[cfg(feature = "native")]
         fn from_layer(layer: NamespaceRootsLayer) -> Self {
             Self {
                 save: layer.save.unwrap_or_else(|| {

--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -377,6 +377,14 @@ impl FsMailboxExt for NativeActorMailbox<'_, FsCapability> {
     }
 }
 
+/// Re-export the env-shaped confique layer for chassis CLI overlays
+/// (ADR-0090 unit d, issue 1258). The layer lives inside the bridge
+/// `mod native` (cfg-gated); the file-root re-export gives chassis
+/// bins a stable path (`aether_capabilities::fs::NamespaceRootsLayer`)
+/// without reaching into the bridge module.
+#[cfg(all(not(target_arch = "wasm32"), feature = "native"))]
+pub use native::NamespaceRootsLayer;
+
 #[aether_actor::bridge(singleton)]
 mod native {
     use std::path::{Path, PathBuf};
@@ -441,6 +449,36 @@ mod native {
                 .env()
                 .load()
                 .expect("NamespaceRootsLayer has no literal defaults to malform");
+            Self::from_layer(layer)
+        }
+
+        /// Resolve from a chassis-CLI argv overlay shadowing env (ADR-0090
+        /// unit d, issue 1258). Argv-set roots win; unset (`None`) fall
+        /// through to `AETHER_SAVE_DIR` / `AETHER_ASSETS_DIR` /
+        /// `AETHER_CONFIG_DIR` env, then platform-default fallbacks.
+        ///
+        /// # Panics
+        ///
+        /// Same as [`Self::from_env`]: only on a future confique
+        /// misconfiguration (the layer has no literal defaults today).
+        #[cfg(feature = "native")]
+        #[must_use]
+        pub fn from_argv_then_env(argv: <NamespaceRootsLayer as confique::Config>::Layer) -> Self {
+            use confique::Config as _;
+
+            let layer = NamespaceRootsLayer::builder()
+                .preloaded(argv)
+                .env()
+                .load()
+                .expect("NamespaceRootsLayer has no literal defaults to malform");
+            Self::from_layer(layer)
+        }
+
+        /// Shared platform-default fallback mapping. Kept private so the
+        /// layer shape stays an implementation detail of
+        /// [`Self::from_env`] / [`Self::from_argv_then_env`].
+        #[cfg(feature = "native")]
+        fn from_layer(layer: NamespaceRootsLayer) -> Self {
             Self {
                 save: layer.save.unwrap_or_else(|| {
                     dirs::data_dir()
@@ -473,18 +511,21 @@ mod native {
     /// `NamespaceRoots::from_env` applies the platform fallback. The
     /// `parse_dir` parser errors on an empty string so confique treats an
     /// empty value as unset (matching the prior `env_or_default`).
+    /// Public so chassis CLI overlays (ADR-0090 unit d, issue 1258) can
+    /// preload a `<NamespaceRootsLayer as confique::Config>::Layer`
+    /// before `.env()`; the consumed shape stays `NamespaceRoots`.
     /// Gated on `feature = "native"`: the enclosing `mod native` is only
     /// `not(target_arch = "wasm32")`-gated, but confique is a
     /// `native`-feature dep.
     #[cfg(feature = "native")]
     #[derive(confique::Config)]
-    struct NamespaceRootsLayer {
+    pub struct NamespaceRootsLayer {
         #[config(env = "AETHER_SAVE_DIR", parse_env = parse_dir)]
-        save: Option<PathBuf>,
+        pub save: Option<PathBuf>,
         #[config(env = "AETHER_ASSETS_DIR", parse_env = parse_dir)]
-        assets: Option<PathBuf>,
+        pub assets: Option<PathBuf>,
         #[config(env = "AETHER_CONFIG_DIR", parse_env = parse_dir)]
-        config: Option<PathBuf>,
+        pub config: Option<PathBuf>,
     }
 
     /// Parse a directory override. An empty string errors so confique

--- a/crates/aether-capabilities/src/gemini/mod.rs
+++ b/crates/aether-capabilities/src/gemini/mod.rs
@@ -124,6 +124,7 @@ mod config {
         /// fault (the env values flow through total parsers).
         #[must_use]
         pub fn from_env() -> Self {
+            use aether_substrate::FromArgvThenEnv as _;
             use confique::Config as _;
 
             let layer = GeminiConfigLayer::builder()
@@ -133,25 +134,13 @@ mod config {
             Self::from_layer(layer)
         }
 
-        /// Resolve from a chassis-CLI argv overlay shadowing env (ADR-0090
-        /// unit d, issue 1258). Argv-set fields win; unset (`None`) fall
-        /// through to `GEMINI_API_KEY` / `AETHER_GEMINI_*` env, then
-        /// literal defaults.
-        ///
-        /// # Panics
-        ///
-        /// Same as [`Self::from_env`].
-        #[must_use]
-        pub fn from_argv_then_env(argv: <GeminiConfigLayer as confique::Config>::Layer) -> Self {
-            use confique::Config as _;
+        // `from_argv_then_env` and `from_layer` come from the
+        // `FromArgvThenEnv` impl below (ADR-0090 unit d).
+    }
 
-            let layer = GeminiConfigLayer::builder()
-                .preloaded(argv)
-                .env()
-                .load()
-                .expect("GeminiConfigLayer defaults are well-formed");
-            Self::from_layer(layer)
-        }
+    #[cfg(feature = "native")]
+    impl aether_substrate::FromArgvThenEnv for GeminiConfig {
+        type Layer = GeminiConfigLayer;
 
         fn from_layer(layer: GeminiConfigLayer) -> Self {
             Self {

--- a/crates/aether-capabilities/src/gemini/mod.rs
+++ b/crates/aether-capabilities/src/gemini/mod.rs
@@ -32,7 +32,7 @@ use crate::contentgen::adapter::{
 use crate::contentgen::shared;
 
 use crate::config_env::DEFAULT_PROVIDER_MAX_IN_FLIGHT;
-pub use config::GeminiConfig;
+pub use config::{GeminiConfig, GeminiConfigLayer};
 
 /// Default per-cap concurrency bound when `AETHER_GEMINI_MAX_IN_FLIGHT`
 /// is unset. Conservative — image / music generation is multi-second
@@ -130,6 +130,30 @@ mod config {
                 .env()
                 .load()
                 .expect("GeminiConfigLayer defaults are well-formed");
+            Self::from_layer(layer)
+        }
+
+        /// Resolve from a chassis-CLI argv overlay shadowing env (ADR-0090
+        /// unit d, issue 1258). Argv-set fields win; unset (`None`) fall
+        /// through to `GEMINI_API_KEY` / `AETHER_GEMINI_*` env, then
+        /// literal defaults.
+        ///
+        /// # Panics
+        ///
+        /// Same as [`Self::from_env`].
+        #[must_use]
+        pub fn from_argv_then_env(argv: <GeminiConfigLayer as confique::Config>::Layer) -> Self {
+            use confique::Config as _;
+
+            let layer = GeminiConfigLayer::builder()
+                .preloaded(argv)
+                .env()
+                .load()
+                .expect("GeminiConfigLayer defaults are well-formed");
+            Self::from_layer(layer)
+        }
+
+        fn from_layer(layer: GeminiConfigLayer) -> Self {
             Self {
                 api_key: layer.api_key.filter(|s| !s.is_empty()),
                 disabled: layer.disabled,
@@ -142,18 +166,20 @@ mod config {
     /// Env-shaped confique layer behind `GeminiConfig` (ADR-0090). Each
     /// field is the primitive its env var carries; `GeminiConfig::from_env`
     /// maps them onto the domain types (ms → `Duration`, empty key →
-    /// `None`). Kept private — the public consumed shape stays
-    /// `GeminiConfig`.
+    /// `None`). Public so chassis CLI overlays (ADR-0090 unit d,
+    /// issue 1258) can preload a `<GeminiConfigLayer as
+    /// confique::Config>::Layer` before `.env()`; the consumed shape
+    /// stays `GeminiConfig`.
     #[cfg(feature = "native")]
     #[derive(confique::Config)]
-    struct GeminiConfigLayer {
+    pub struct GeminiConfigLayer {
         /// `GEMINI_API_KEY` (bare, un-prefixed). Empty/unset → `None`
         /// after the `from_env` filter.
         #[config(env = "GEMINI_API_KEY")]
-        api_key: Option<String>,
+        pub api_key: Option<String>,
         /// `AETHER_GEMINI_DISABLE=1`/`true` forces the disabled adapter.
         #[config(env = "AETHER_GEMINI_DISABLE", parse_env = parse_flag, default = false)]
-        disabled: bool,
+        pub disabled: bool,
         /// Per-cap concurrency bound. A non-positive / unparseable value
         /// falls back to the default (`> 0` filter preserved).
         #[config(
@@ -161,7 +187,7 @@ mod config {
             parse_env = parse_provider_max_in_flight,
             default = 2
         )]
-        max_in_flight: usize,
+        pub max_in_flight: usize,
         /// Per-request timeout in milliseconds. Literal default mirrors
         /// `DEFAULT_TIMEOUT_MS` (180 s).
         #[config(
@@ -169,7 +195,7 @@ mod config {
             parse_env = parse_u32_ms_or::<DEFAULT_TIMEOUT_MS>,
             default = 180_000
         )]
-        timeout_ms: u32,
+        pub timeout_ms: u32,
     }
 
     // confique's `parse_env` contract is `fn(&str) -> Result<T, impl Error>`,

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -143,6 +143,7 @@ impl HttpConfig {
     /// (the env values flow through total parsers).
     #[must_use]
     pub fn from_env() -> Self {
+        use aether_substrate::FromArgvThenEnv as _;
         use confique::Config as _;
 
         // Every field has a literal default and a total `parse_env`, so the
@@ -156,31 +157,17 @@ impl HttpConfig {
         Self::from_layer(layer)
     }
 
-    /// Resolve from a chassis-CLI argv overlay shadowing env (ADR-0090
-    /// unit d, issue 1258). Argv-set fields win; unset (`None`) fall
-    /// through to `AETHER_HTTP_*` env and then literal defaults. Used by
-    /// chassis bins after parsing the per-chassis [`crate::http::HttpConfigLayer`]
-    /// partial via clap; tests still build `HttpConfig` directly.
-    ///
-    /// # Panics
-    ///
-    /// Same as [`Self::from_env`]: only on a malformed literal default
-    /// (programmer error caught by `http_from_env_defaults_match`).
-    #[must_use]
-    pub fn from_argv_then_env(argv: <HttpConfigLayer as confique::Config>::Layer) -> Self {
-        use confique::Config as _;
+    // `from_argv_then_env` and `from_layer` come from the
+    // `FromArgvThenEnv` impl below (ADR-0090 unit d). Documentation
+    // for the per-cap argv-overlay behaviour lives on the trait method;
+    // call sites use the cap-namespaced form
+    // `HttpConfig::from_argv_then_env(argv)` with the trait imported.
+}
 
-        let layer = HttpConfigLayer::builder()
-            .preloaded(argv)
-            .env()
-            .load()
-            .expect("HttpConfigLayer defaults are well-formed");
-        Self::from_layer(layer)
-    }
+#[cfg(feature = "native")]
+impl aether_substrate::FromArgvThenEnv for HttpConfig {
+    type Layer = HttpConfigLayer;
 
-    /// Shared layer-to-domain mapping. Kept private so the layer shape
-    /// stays an implementation detail of [`Self::from_env`] /
-    /// [`Self::from_argv_then_env`].
     fn from_layer(layer: HttpConfigLayer) -> Self {
         Self {
             disabled: layer.disabled,

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -153,6 +153,35 @@ impl HttpConfig {
             .env()
             .load()
             .expect("HttpConfigLayer defaults are well-formed");
+        Self::from_layer(layer)
+    }
+
+    /// Resolve from a chassis-CLI argv overlay shadowing env (ADR-0090
+    /// unit d, issue 1258). Argv-set fields win; unset (`None`) fall
+    /// through to `AETHER_HTTP_*` env and then literal defaults. Used by
+    /// chassis bins after parsing the per-chassis [`crate::http::HttpConfigLayer`]
+    /// partial via clap; tests still build `HttpConfig` directly.
+    ///
+    /// # Panics
+    ///
+    /// Same as [`Self::from_env`]: only on a malformed literal default
+    /// (programmer error caught by `http_from_env_defaults_match`).
+    #[must_use]
+    pub fn from_argv_then_env(argv: <HttpConfigLayer as confique::Config>::Layer) -> Self {
+        use confique::Config as _;
+
+        let layer = HttpConfigLayer::builder()
+            .preloaded(argv)
+            .env()
+            .load()
+            .expect("HttpConfigLayer defaults are well-formed");
+        Self::from_layer(layer)
+    }
+
+    /// Shared layer-to-domain mapping. Kept private so the layer shape
+    /// stays an implementation detail of [`Self::from_env`] /
+    /// [`Self::from_argv_then_env`].
+    fn from_layer(layer: HttpConfigLayer) -> Self {
         Self {
             disabled: layer.disabled,
             allowlist: layer.allowlist,
@@ -167,20 +196,22 @@ impl HttpConfig {
 /// is the primitive representation its `AETHER_HTTP_*` variable carries —
 /// notably the timeout as `u32` milliseconds and the allowlist as a
 /// comma-separated string parsed into a set — which [`HttpConfig::from_env`]
-/// maps onto the domain types. Kept private: the public, consumed shape
-/// stays [`HttpConfig`].
+/// maps onto the domain types. Public so chassis CLI overlays
+/// (ADR-0090 unit d, issue 1258) can preload a `<HttpConfigLayer as
+/// confique::Config>::Layer` before `.env()`; the consumed shape stays
+/// [`HttpConfig`].
 #[cfg(feature = "native")]
 #[derive(confique::Config)]
-struct HttpConfigLayer {
+pub struct HttpConfigLayer {
     /// `AETHER_HTTP_DISABLE=1`/`true` swaps in the disabled adapter.
     #[config(env = "AETHER_HTTP_DISABLE", parse_env = parse_flag, default = false)]
-    disabled: bool,
+    pub disabled: bool,
     /// Comma-separated hostnames; empty/unset = deny all (ADR-0043).
     #[config(env = "AETHER_HTTP_ALLOWLIST", parse_env = parse_allowlist, default = [])]
-    allowlist: HashSet<String>,
+    pub allowlist: HashSet<String>,
     /// `AETHER_HTTP_REQUIRE_HTTPS=1`/`true` rejects `http://` URLs.
     #[config(env = "AETHER_HTTP_REQUIRE_HTTPS", parse_env = parse_flag, default = false)]
-    require_https: bool,
+    pub require_https: bool,
     /// Body cap in bytes. The literal default mirrors
     /// [`DEFAULT_MAX_BODY_BYTES`] (confique `default` takes a literal, not
     /// the named const); `http_from_env_defaults_match` guards the match.
@@ -189,7 +220,7 @@ struct HttpConfigLayer {
         parse_env = parse_max_body_bytes,
         default = 16_777_216
     )]
-    max_body_bytes: usize,
+    pub max_body_bytes: usize,
     /// Per-request timeout in milliseconds. Literal default mirrors
     /// [`DEFAULT_TIMEOUT_MS`] (30 s).
     #[config(
@@ -197,7 +228,7 @@ struct HttpConfigLayer {
         parse_env = parse_timeout_ms,
         default = 30_000
     )]
-    timeout_ms: u32,
+    pub timeout_ms: u32,
 }
 
 // confique's `parse_env` contract is `fn(&str) -> Result<T, impl Error>`, so

--- a/crates/aether-substrate-bundle/Cargo.toml
+++ b/crates/aether-substrate-bundle/Cargo.toml
@@ -57,6 +57,16 @@ aether-actor = { path = "../aether-actor" }
 aether-data = { path = "../aether-data" }
 aether-codec = { path = "../aether-codec" }
 aether-kinds = { path = "../aether-kinds" }
+# Chassis-binary argv parsing (ADR-0090 unit d, issue 1258). The
+# `cli` module declares per-chassis Parser roots and per-cap overlay
+# structs; each chassis bin calls `<Cli>::parse()` and threads the
+# resolved overlays through `*Env::from_env_with_argv(cli)`.
+clap = { workspace = true }
+# Each overlay assembles a partial `<*ConfigLayer as confique::Config>::Layer`;
+# the cap's `from_argv_then_env` then preloads it into the confique
+# builder ahead of `.env()`. Direct dep so cli.rs can name the
+# `confique::Layer` trait without reaching through aether-capabilities.
+confique = { version = "0.4", default-features = false }
 # Catch-all error type for chassis main()s + build_passive that
 # bridge BootError / wasmtime / io faults purely to bubble up.
 # Same crate as `wasmtime::Result` re-exports (issue #571).

--- a/crates/aether-substrate-bundle/src/bin/desktop.rs
+++ b/crates/aether-substrate-bundle/src/bin/desktop.rs
@@ -1,11 +1,18 @@
 //! Desktop substrate binary entry point. See
 //! `aether_substrate_bundle::desktop` for the chassis impl.
+//!
+//! Parses argv with [`DesktopCli`] (ADR-0090 unit d, issue 1258);
+//! each per-cap overlay shadows its `AETHER_*` env var, unset flags
+//! fall through to env-only resolution.
 
 use aether_substrate::Chassis;
+use aether_substrate_bundle::cli::DesktopCli;
 use aether_substrate_bundle::desktop::{DesktopChassis, DesktopEnv};
+use clap::Parser as _;
 
 fn main() -> anyhow::Result<()> {
-    let env = DesktopEnv::from_env()?;
+    let cli = DesktopCli::parse();
+    let env = DesktopEnv::from_env_with_argv(cli)?;
     let chassis = DesktopChassis::build(env)?;
     tracing::info!(
         target: "aether_substrate::boot",

--- a/crates/aether-substrate-bundle/src/bin/headless.rs
+++ b/crates/aether-substrate-bundle/src/bin/headless.rs
@@ -1,10 +1,17 @@
 //! Headless substrate binary entry point.
+//!
+//! Parses argv with [`HeadlessCli`] (ADR-0090 unit d, issue 1258);
+//! each per-cap overlay shadows its `AETHER_*` env var, unset flags
+//! fall through to env-only resolution.
 
 use aether_substrate::Chassis;
+use aether_substrate_bundle::cli::HeadlessCli;
 use aether_substrate_bundle::headless::{HeadlessChassis, HeadlessEnv};
+use clap::Parser as _;
 
 fn main() -> anyhow::Result<()> {
-    let env = HeadlessEnv::from_env();
+    let cli = HeadlessCli::parse();
+    let env = HeadlessEnv::from_env_with_argv(cli);
     let chassis = HeadlessChassis::build(env)?;
     tracing::info!(
         target: "aether_substrate::boot",

--- a/crates/aether-substrate-bundle/src/bin/hub.rs
+++ b/crates/aether-substrate-bundle/src/bin/hub.rs
@@ -1,13 +1,19 @@
 //! Hub chassis binary entry point. The hub chassis lives in
-//! `aether-hub`; this binary just reads env and runs.
+//! `aether-hub`; this binary just reads argv-then-env and runs.
+//!
+//! Parses argv with [`HubCli`] (ADR-0090 unit d, issue 1258);
+//! `--rpc-port` shadows `AETHER_RPC_PORT`.
 
 // CLI diagnostic before tracing subscriber is installed (issue 891).
 #![allow(clippy::print_stderr)]
 
+use aether_substrate_bundle::cli::HubCli;
 use aether_substrate_bundle::hub::{Chassis, HubChassis, HubEnv};
+use clap::Parser as _;
 
 fn main() -> anyhow::Result<()> {
-    let chassis = HubChassis::build(HubEnv::from_env())?;
+    let cli = HubCli::parse();
+    let chassis = HubChassis::build(HubEnv::from_env_with_argv(&cli))?;
     eprintln!(
         "aether-substrate-bundle: hub chassis initialised (profile={})",
         HubChassis::PROFILE,

--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -26,8 +26,24 @@ use aether_data::{Kind, MailboxId as DataMailboxId, mailbox_id_from_name};
 use aether_kinds::{Shutdown, Tick};
 use aether_substrate::chassis::Chassis;
 use aether_substrate::chassis::builder::Builder;
+use aether_substrate::handle_store::PersistConfig;
 use aether_substrate::runtime::lifecycle::FatalAborter;
 use aether_substrate::{LifecycleDriverConfig, LifecycleGraph};
+
+/// Chassis-bin verdict on the handle-store persistence config (ADR-0090
+/// unit d, issue 1258). [`EnvOnly`](Self::EnvOnly) keeps the pre-d
+/// `HandleStore::from_env_persistent` resolution; [`Argv`](Self::Argv)
+/// carries the argv-then-env-resolved `PersistConfig` (with the inner
+/// `None` meaning "argv said persistence is off"). The two-variant
+/// enum avoids `Option<Option<_>>` (`clippy::option_option`).
+#[derive(Clone, Debug, Default)]
+pub enum PersistOverride {
+    /// No argv overlay; resolve persistence from env at build time.
+    #[default]
+    EnvOnly,
+    /// Argv overlay resolved: use this verbatim.
+    Argv(Option<PersistConfig>),
+}
 
 /// Build the standard single-stage lifecycle config every Tick-driven
 /// chassis shares today (ADR-0082 PR 3b): a `Tick` self-loop with a

--- a/crates/aether-substrate-bundle/src/cli.rs
+++ b/crates/aether-substrate-bundle/src/cli.rs
@@ -1,0 +1,386 @@
+//! Per-chassis clap CLI roots and per-cap argv overlays (ADR-0090 unit
+//! d, issue 1258). Each chassis bin calls `<Cli>::parse()` and threads
+//! the resolved overlays through `*Env::from_env_with_argv(cli)`; each
+//! overlay's `into_layer()` writes argv-set fields into a partial
+//! `<*ConfigLayer as confique::Config>::Layer`, which the cap's
+//! `from_argv_then_env(...)` then preloads ahead of `.env()` so argv
+//! beats env beats literal defaults. Absent flags resolve `None` and
+//! fall through to env-only resolution — boot is byte-identical when
+//! argv is empty.
+//!
+//! Flag naming is mechanical: strip an `AETHER_` (or top-level)
+//! prefix, lowercase, hyphenate. `AETHER_HTTP_TIMEOUT_MS` →
+//! `--http-timeout-ms`, `GEMINI_API_KEY` → `--gemini-api-key`,
+//! `AETHER_HANDLE_STORE_DISK_BUDGET_BYTES` → `--handle-store-disk-budget-bytes`.
+//! Bool flags accept zero or one value (`--http-disable` ⇒ `true`,
+//! `--http-disable=false` ⇒ `false`, absent ⇒ `None`), matching the
+//! env-side `parse_flag` semantics.
+//!
+//! Chassis-wide knobs (`workers`, `tick_hz`, `window_mode`,
+//! `window_title`, `rpc_port`) live as plain `Option<T>` fields on the
+//! root `CommonOverlay` / `DesktopCli` / `HeadlessCli` and are
+//! ad-hoc-shadowed in the bin (`cli.workers.or_else(parse_workers_env)`).
+//! Unit e1 will lift them into their own confique layers.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use aether_capabilities::anthropic::AnthropicConfigLayer;
+use aether_capabilities::audio::AudioConfigLayer;
+use aether_capabilities::fs::NamespaceRootsLayer;
+use aether_capabilities::gemini::GeminiConfigLayer;
+use aether_capabilities::http::HttpConfigLayer;
+use aether_substrate::handle_store::PersistConfigLayer;
+use clap::{Args, Parser};
+use confique::{Config, Layer};
+
+/// Argv overlay for the `aether.http` cap. One `Option<T>` per
+/// `HttpConfigLayer` field; [`Self::into_layer`] maps unset → partial
+/// `None`, set → partial `Some(v)`.
+#[derive(Args, Debug, Default, Clone)]
+pub struct HttpOverlay {
+    /// `AETHER_HTTP_DISABLE` — swap in the disabled adapter.
+    #[arg(id = "http_disable", long = "http-disable", num_args = 0..=1, default_missing_value = "true")]
+    pub disable: Option<bool>,
+    /// `AETHER_HTTP_ALLOWLIST` — comma-separated hostnames.
+    #[arg(id = "http_allowlist", long = "http-allowlist")]
+    pub allowlist: Option<String>,
+    /// `AETHER_HTTP_REQUIRE_HTTPS` — reject `http://` URLs.
+    #[arg(id = "http_require_https", long = "http-require-https", num_args = 0..=1, default_missing_value = "true")]
+    pub require_https: Option<bool>,
+    /// `AETHER_HTTP_MAX_BODY_BYTES` — response body cap.
+    #[arg(id = "http_max_body_bytes", long = "http-max-body-bytes")]
+    pub max_body_bytes: Option<usize>,
+    /// `AETHER_HTTP_TIMEOUT_MS` — default per-request timeout.
+    #[arg(id = "http_timeout_ms", long = "http-timeout-ms")]
+    pub timeout_ms: Option<u32>,
+}
+
+impl HttpOverlay {
+    /// Write argv-set fields into a fresh partial layer. `None` →
+    /// partial `None` (env / default takes over); `Some(v)` → partial
+    /// `Some(v)`.
+    #[must_use]
+    pub fn into_layer(self) -> <HttpConfigLayer as Config>::Layer {
+        let Self {
+            disable,
+            allowlist,
+            require_https,
+            max_body_bytes,
+            timeout_ms,
+        } = self;
+        let mut layer = <HttpConfigLayer as Config>::Layer::empty();
+        if let Some(v) = disable {
+            layer.disabled = Some(v);
+        }
+        if let Some(s) = allowlist {
+            // Same total parser the env side uses (CSV → HashSet, trim,
+            // drop empties). Mirrored inline to avoid making the
+            // parser pub on the cap.
+            let set: HashSet<String> = s
+                .split(',')
+                .map(str::trim)
+                .filter(|h| !h.is_empty())
+                .map(str::to_string)
+                .collect();
+            layer.allowlist = Some(set);
+        }
+        if let Some(v) = require_https {
+            layer.require_https = Some(v);
+        }
+        if let Some(v) = max_body_bytes {
+            layer.max_body_bytes = Some(v);
+        }
+        if let Some(v) = timeout_ms {
+            layer.timeout_ms = Some(v);
+        }
+        layer
+    }
+}
+
+/// Argv overlay for the `aether.audio` cap (desktop only). Headless
+/// runs without an audio device, so [`DesktopCli`] is the only chassis
+/// that flatten-includes this.
+#[derive(Args, Debug, Default, Clone)]
+pub struct AudioOverlay {
+    /// `AETHER_AUDIO_DISABLE` — skip cpal init entirely.
+    #[arg(id = "audio_disable", long = "audio-disable", num_args = 0..=1, default_missing_value = "true")]
+    pub disable: Option<bool>,
+    /// `AETHER_AUDIO_SAMPLE_RATE` — requested sample rate in Hz.
+    #[arg(id = "audio_sample_rate", long = "audio-sample-rate")]
+    pub sample_rate: Option<u32>,
+}
+
+impl AudioOverlay {
+    #[must_use]
+    pub fn into_layer(self) -> <AudioConfigLayer as Config>::Layer {
+        let Self {
+            disable,
+            sample_rate,
+        } = self;
+        let mut layer = <AudioConfigLayer as Config>::Layer::empty();
+        if let Some(v) = disable {
+            layer.disabled = Some(v);
+        }
+        if let Some(v) = sample_rate {
+            // The layer holds the raw string so the cap can apply the
+            // soft `.parse::<u32>().ok()` (an unparseable env value →
+            // `None`). On the argv path the value is already typed.
+            layer.requested_sample_rate = Some(v.to_string());
+        }
+        layer
+    }
+}
+
+/// Argv overlay for the `aether.fs` cap namespace roots.
+#[derive(Args, Debug, Default, Clone)]
+pub struct FsOverlay {
+    /// `AETHER_SAVE_DIR` — writable per-user persistent root.
+    #[arg(id = "save_dir", long = "save-dir")]
+    pub save_dir: Option<PathBuf>,
+    /// `AETHER_ASSETS_DIR` — read-only assets root.
+    #[arg(id = "assets_dir", long = "assets-dir")]
+    pub assets_dir: Option<PathBuf>,
+    /// `AETHER_CONFIG_DIR` — writable per-user config root.
+    #[arg(id = "config_dir", long = "config-dir")]
+    pub config_dir: Option<PathBuf>,
+}
+
+impl FsOverlay {
+    #[must_use]
+    pub fn into_layer(self) -> <NamespaceRootsLayer as Config>::Layer {
+        let Self {
+            save_dir,
+            assets_dir,
+            config_dir,
+        } = self;
+        let mut layer = <NamespaceRootsLayer as Config>::Layer::empty();
+        if let Some(p) = save_dir {
+            layer.save = Some(p);
+        }
+        if let Some(p) = assets_dir {
+            layer.assets = Some(p);
+        }
+        if let Some(p) = config_dir {
+            layer.config = Some(p);
+        }
+        layer
+    }
+}
+
+/// Argv overlay for the `aether.anthropic` cap (ADR-0050).
+#[derive(Args, Debug, Default, Clone)]
+pub struct AnthropicOverlay {
+    /// `ANTHROPIC_API_KEY` — Messages-API key. Empty → disabled
+    /// adapter.
+    #[arg(id = "anthropic_api_key", long = "anthropic-api-key")]
+    pub api_key: Option<String>,
+    /// `AETHER_ANTHROPIC_DISABLE` — force the disabled adapter.
+    #[arg(id = "anthropic_disable", long = "anthropic-disable", num_args = 0..=1, default_missing_value = "true")]
+    pub disable: Option<bool>,
+    /// `AETHER_ANTHROPIC_MAX_IN_FLIGHT` — per-cap concurrency bound.
+    #[arg(id = "anthropic_max_in_flight", long = "anthropic-max-in-flight")]
+    pub max_in_flight: Option<usize>,
+    /// `AETHER_ANTHROPIC_TIMEOUT_MS` — per-request timeout.
+    #[arg(id = "anthropic_timeout_ms", long = "anthropic-timeout-ms")]
+    pub timeout_ms: Option<u32>,
+}
+
+impl AnthropicOverlay {
+    #[must_use]
+    pub fn into_layer(self) -> <AnthropicConfigLayer as Config>::Layer {
+        let Self {
+            api_key,
+            disable,
+            max_in_flight,
+            timeout_ms,
+        } = self;
+        let mut layer = <AnthropicConfigLayer as Config>::Layer::empty();
+        if let Some(v) = api_key {
+            layer.api_key = Some(v);
+        }
+        if let Some(v) = disable {
+            layer.disabled = Some(v);
+        }
+        if let Some(v) = max_in_flight {
+            layer.max_in_flight = Some(v);
+        }
+        if let Some(v) = timeout_ms {
+            layer.timeout_ms = Some(v);
+        }
+        layer
+    }
+}
+
+/// Argv overlay for the `aether.gemini` cap (ADR-0050).
+#[derive(Args, Debug, Default, Clone)]
+pub struct GeminiOverlay {
+    /// `GEMINI_API_KEY` — Google API key. Empty → disabled adapter.
+    #[arg(id = "gemini_api_key", long = "gemini-api-key")]
+    pub api_key: Option<String>,
+    /// `AETHER_GEMINI_DISABLE` — force the disabled adapter.
+    #[arg(id = "gemini_disable", long = "gemini-disable", num_args = 0..=1, default_missing_value = "true")]
+    pub disable: Option<bool>,
+    /// `AETHER_GEMINI_MAX_IN_FLIGHT` — per-cap concurrency bound.
+    #[arg(id = "gemini_max_in_flight", long = "gemini-max-in-flight")]
+    pub max_in_flight: Option<usize>,
+    /// `AETHER_GEMINI_TIMEOUT_MS` — per-request timeout.
+    #[arg(id = "gemini_timeout_ms", long = "gemini-timeout-ms")]
+    pub timeout_ms: Option<u32>,
+}
+
+impl GeminiOverlay {
+    #[must_use]
+    pub fn into_layer(self) -> <GeminiConfigLayer as Config>::Layer {
+        let Self {
+            api_key,
+            disable,
+            max_in_flight,
+            timeout_ms,
+        } = self;
+        let mut layer = <GeminiConfigLayer as Config>::Layer::empty();
+        if let Some(v) = api_key {
+            layer.api_key = Some(v);
+        }
+        if let Some(v) = disable {
+            layer.disabled = Some(v);
+        }
+        if let Some(v) = max_in_flight {
+            layer.max_in_flight = Some(v);
+        }
+        if let Some(v) = timeout_ms {
+            layer.timeout_ms = Some(v);
+        }
+        layer
+    }
+}
+
+/// Argv overlay for the ADR-0049 handle-store persistence knobs. The
+/// `dir` / `persist_disable` flags shadow `AETHER_HANDLE_STORE_DIR` /
+/// `AETHER_HANDLE_STORE_PERSIST_DISABLE` directly; `disk_budget_bytes`
+/// / `eviction_tick_secs` ride [`PersistConfigLayer`] and merge with
+/// env via the confique builder. `max_bytes` is the in-memory soft
+/// budget (`AETHER_HANDLE_STORE_MAX_BYTES`), structurally separate
+/// from the on-disk persist config.
+#[derive(Args, Debug, Default, Clone)]
+pub struct PersistOverlay {
+    /// `AETHER_HANDLE_STORE_DIR` — on-disk persistence root.
+    #[arg(id = "handle_store_dir", long = "handle-store-dir")]
+    pub dir: Option<PathBuf>,
+    /// `AETHER_HANDLE_STORE_PERSIST_DISABLE` — skip on-disk
+    /// persistence entirely (chassis runs in-memory only).
+    #[arg(id = "handle_store_persist_disable", long = "handle-store-persist-disable", num_args = 0..=1, default_missing_value = "true")]
+    pub persist_disable: Option<bool>,
+    /// `AETHER_HANDLE_STORE_MAX_BYTES` — in-memory soft byte budget.
+    #[arg(id = "handle_store_max_bytes", long = "handle-store-max-bytes")]
+    pub max_bytes: Option<usize>,
+    /// `AETHER_HANDLE_STORE_DISK_BUDGET_BYTES` — on-disk byte budget.
+    #[arg(
+        id = "handle_store_disk_budget_bytes",
+        long = "handle-store-disk-budget-bytes"
+    )]
+    pub disk_budget_bytes: Option<u64>,
+    /// `AETHER_HANDLE_STORE_DISK_EVICTION_TICK_SECS` — eviction tick
+    /// interval.
+    #[arg(
+        id = "handle_store_disk_eviction_tick_secs",
+        long = "handle-store-disk-eviction-tick-secs"
+    )]
+    pub eviction_tick_secs: Option<u64>,
+}
+
+impl PersistOverlay {
+    /// Map the numeric overlay knobs into a partial layer. The
+    /// `dir` / `persist_disable` / `max_bytes` axes are structural —
+    /// they live outside `PersistConfigLayer` and ride the bin's
+    /// composition instead, so [`Self::numeric_layer`] takes `&self`
+    /// rather than consuming the overlay.
+    #[must_use]
+    pub fn numeric_layer(&self) -> <PersistConfigLayer as Config>::Layer {
+        let mut layer = <PersistConfigLayer as Config>::Layer::empty();
+        if let Some(v) = self.disk_budget_bytes {
+            layer.disk_budget_bytes = Some(v);
+        }
+        if let Some(v) = self.eviction_tick_secs {
+            layer.eviction_tick_secs = Some(v);
+        }
+        layer
+    }
+}
+
+/// Argv overlay shared by every full-stack chassis (desktop +
+/// headless). Captures every cap whose config layer is the same on
+/// both chassis. Per-chassis extras (audio for desktop, tick-hz +
+/// window-* for desktop) live on their own root struct.
+#[derive(Args, Debug, Default, Clone)]
+pub struct CommonOverlay {
+    #[command(flatten)]
+    pub http: HttpOverlay,
+    #[command(flatten)]
+    pub fs: FsOverlay,
+    #[command(flatten)]
+    pub anthropic: AnthropicOverlay,
+    #[command(flatten)]
+    pub gemini: GeminiOverlay,
+    #[command(flatten)]
+    pub persist: PersistOverlay,
+
+    /// `AETHER_WORKERS` — worker pool size override.
+    #[arg(long)]
+    pub workers: Option<usize>,
+
+    /// `AETHER_RPC_PORT` — `aether.rpc.server` bind port. Absent →
+    /// chassis-specific default (desktop / headless skip the RPC
+    /// server entirely; hub falls back to `DEFAULT_RPC_PORT`).
+    #[arg(long = "rpc-port")]
+    pub rpc_port: Option<u16>,
+}
+
+/// Desktop chassis CLI root.
+#[derive(Parser, Debug, Default, Clone)]
+#[command(
+    name = "aether-substrate",
+    about = "Desktop chassis — winit window + wgpu render + cpal audio. ADR-0035 / ADR-0090."
+)]
+pub struct DesktopCli {
+    #[command(flatten)]
+    pub common: CommonOverlay,
+    #[command(flatten)]
+    pub audio: AudioOverlay,
+
+    /// `AETHER_WINDOW_MODE` — `windowed[:WxH]` /
+    /// `fullscreen-borderless` / `exclusive:WxH@HZ`.
+    #[arg(long = "window-mode")]
+    pub window_mode: Option<String>,
+    /// `AETHER_WINDOW_TITLE` — window title text.
+    #[arg(long = "window-title")]
+    pub window_title: Option<String>,
+}
+
+/// Headless chassis CLI root.
+#[derive(Parser, Debug, Default, Clone)]
+#[command(
+    name = "aether-substrate-headless",
+    about = "Headless chassis — std-timer tick driver, nop render. ADR-0035 / ADR-0090."
+)]
+pub struct HeadlessCli {
+    #[command(flatten)]
+    pub common: CommonOverlay,
+
+    /// `AETHER_TICK_HZ` — tick cadence in hertz (default 60).
+    #[arg(long = "tick-hz")]
+    pub tick_hz: Option<u32>,
+}
+
+/// Hub chassis CLI root — coordinator-only, no full-stack caps.
+#[derive(Parser, Debug, Default, Clone)]
+#[command(
+    name = "aether-substrate-hub",
+    about = "Hub chassis — coordinator between aether-mcp + substrate fleet. ADR-0073."
+)]
+pub struct HubCli {
+    /// `AETHER_RPC_PORT` — `aether.rpc.server` bind port (default
+    /// 8901).
+    #[arg(long = "rpc-port")]
+    pub rpc_port: Option<u16>,
+}

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -28,9 +28,12 @@ use winit::event_loop::EventLoop;
 
 use super::driver::{DesktopDriverCapability, parse_window_mode_env};
 use crate::chassis_common::{
-    CommonBoot, maybe_with_rpc_server, tick_only_lifecycle_config, with_common_caps,
+    CommonBoot, PersistOverride, maybe_with_rpc_server, tick_only_lifecycle_config,
+    with_common_caps,
 };
+use crate::cli::{CommonOverlay, DesktopCli};
 use crate::hub;
+use aether_substrate::handle_store::PersistConfig;
 use aether_substrate::runtime::lifecycle::FatalAborter;
 use aether_substrate::runtime::lifecycle::OutboundFatalAborter;
 use std::env;
@@ -95,6 +98,14 @@ pub struct DesktopEnv {
     /// `AETHER_WORKERS`; `None` keeps `PoolConfig::default()` behavior
     /// (`available_parallelism() - 1`, min 1).
     pub workers: Option<usize>,
+    /// ADR-0090 unit d (issue 1258): chassis-bin verdict on handle-
+    /// store persistence. See [`PersistOverride`] for variant
+    /// semantics.
+    pub persist: PersistOverride,
+    /// ADR-0090 unit d (issue 1258): argv overlay for the handle-store
+    /// in-memory byte budget. `None` falls through to env-only
+    /// `AETHER_HANDLE_STORE_MAX_BYTES`.
+    pub handle_store_max_bytes: Option<usize>,
 }
 
 impl DesktopEnv {
@@ -108,44 +119,106 @@ impl DesktopEnv {
     /// is infallible env reads. The signature names that fault rather
     /// than the historic catch-all `wasmtime::Result` (issue #571).
     pub fn from_env() -> Result<Self, EventLoopError> {
+        Self::from_env_with_argv(DesktopCli::default())
+    }
+
+    /// ADR-0090 unit d (issue 1258): resolve every cap config through
+    /// the argv-then-env overlay. `cli` carries `Option<T>` flags;
+    /// unset fields fall through to env-only resolution, so an empty
+    /// argv (the path the existing `from_env` callers exercise) is
+    /// byte-identical to the pre-d behaviour.
+    pub fn from_env_with_argv(cli: DesktopCli) -> Result<Self, EventLoopError> {
+        let DesktopCli {
+            common,
+            audio: audio_overlay,
+            window_mode: cli_window_mode,
+            window_title: cli_window_title,
+        } = cli;
+        let CommonOverlay {
+            http,
+            fs,
+            anthropic,
+            gemini,
+            persist,
+            workers: cli_workers,
+            rpc_port: cli_rpc_port,
+        } = common;
+
         let event_loop = EventLoop::<UserEvent>::with_user_event().build()?;
         event_loop.set_control_flow(ControlFlow::Poll);
         let capture_queue = CaptureQueue::new();
 
-        let http = HttpConf::from_env();
-        let anthropic = AnthropicConfig::from_env();
-        let gemini = GeminiConfig::from_env();
-        let namespace_roots = NamespaceRoots::from_env();
-        let audio = AudioConf::from_env();
+        let http = HttpConf::from_argv_then_env(http.into_layer());
+        let anthropic = AnthropicConfig::from_argv_then_env(anthropic.into_layer());
+        let gemini = GeminiConfig::from_argv_then_env(gemini.into_layer());
+        let namespace_roots = NamespaceRoots::from_argv_then_env(fs.into_layer());
+        let audio = AudioConf::from_argv_then_env(audio_overlay.into_layer());
 
-        // nested matches read clearer than `map_or_else` here because both
-        // arms have multi-line bodies (warn-log path on parse failure).
+        // Window mode: argv wins over `AETHER_WINDOW_MODE` env. The
+        // parser is shared (`parse_window_mode_env`); a bad argv string
+        // warn-logs and falls back to Windowed, matching the env path.
         #[allow(clippy::option_if_let_else)]
-        let (boot_mode, boot_size) = match env::var("AETHER_WINDOW_MODE") {
-            Ok(s) => match parse_window_mode_env(&s) {
+        let (boot_mode, boot_size) = if let Some(s) = cli_window_mode {
+            match parse_window_mode_env(&s) {
                 Ok(parsed) => parsed,
                 Err(e) => {
                     tracing::warn!(
                         target: "aether_substrate::boot",
                         value = %s,
                         error = %e,
-                        "AETHER_WINDOW_MODE unparseable — falling back to Windowed",
+                        "--window-mode unparseable — falling back to Windowed",
                     );
                     (WindowMode::Windowed, None)
                 }
-            },
-            Err(_) => (WindowMode::Windowed, None),
+            }
+        } else {
+            match env::var("AETHER_WINDOW_MODE") {
+                Ok(s) => match parse_window_mode_env(&s) {
+                    Ok(parsed) => parsed,
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "aether_substrate::boot",
+                            value = %s,
+                            error = %e,
+                            "AETHER_WINDOW_MODE unparseable — falling back to Windowed",
+                        );
+                        (WindowMode::Windowed, None)
+                    }
+                },
+                Err(_) => (WindowMode::Windowed, None),
+            }
         };
-        let boot_title = env::var("AETHER_WINDOW_TITLE").unwrap_or_else(|_| "aether".to_owned());
+        let boot_title = cli_window_title
+            .or_else(|| env::var("AETHER_WINDOW_TITLE").ok())
+            .unwrap_or_else(|| "aether".to_owned());
 
-        // `AETHER_RPC_PORT` has no default — absent means RpcServer
-        // doesn't boot. Binds `127.0.0.1`, matching the hub chassis.
         let rpc_addr = {
             use std::net::{IpAddr, Ipv4Addr};
-            hub::rpc_port_from_env().map(|p| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), p))
+            cli_rpc_port
+                .or_else(hub::rpc_port_from_env)
+                .map(|p| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), p))
         };
 
-        let workers = parse_workers_env();
+        let workers = cli_workers.or_else(parse_workers_env);
+
+        // Persistence overlay: parallel to headless (issue 1258). The
+        // chassis-bin vote is `persist_enabled=true` (desktop opts into
+        // on-disk persistence per ADR-0049 §9).
+        let persist_argv_set = persist.dir.is_some()
+            || persist.persist_disable.is_some()
+            || persist.disk_budget_bytes.is_some()
+            || persist.eviction_tick_secs.is_some();
+        let persist_state = if persist_argv_set {
+            PersistOverride::Argv(PersistConfig::from_argv_then_env(
+                true,
+                persist.dir.clone(),
+                persist.persist_disable,
+                persist.numeric_layer(),
+            ))
+        } else {
+            PersistOverride::EnvOnly
+        };
+        let handle_store_max_bytes = persist.max_bytes;
 
         Ok(Self {
             event_loop,
@@ -160,6 +233,8 @@ impl DesktopEnv {
             boot_title,
             rpc_addr,
             workers,
+            persist: persist_state,
+            handle_store_max_bytes,
         })
     }
 }
@@ -216,12 +291,21 @@ impl DesktopChassis {
             boot_title,
             rpc_addr,
             workers,
+            persist,
+            handle_store_max_bytes,
         } = env;
 
         // ADR-0049 §9: desktop enables on-disk handle persistence.
-        let boot = SubstrateBoot::builder("hello-triangle", env!("CARGO_PKG_VERSION"))
+        // ADR-0090 unit d: when the chassis bin parsed an argv overlay
+        // for persist config / max_bytes, those override the env-only
+        // resolution `SubstrateBoot` would otherwise run.
+        let mut boot_builder = SubstrateBoot::builder("hello-triangle", env!("CARGO_PKG_VERSION"))
             .persist_enabled(true)
-            .build()?;
+            .handle_store_max_bytes(handle_store_max_bytes);
+        if let PersistOverride::Argv(p) = persist {
+            boot_builder = boot_builder.persist_config(p);
+        }
+        let boot = boot_builder.build()?;
 
         let component_host_config = ComponentHostConfig {
             engine: Arc::clone(&boot.engine),

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -22,7 +22,9 @@ use aether_capabilities::{
 use aether_kinds::WindowMode;
 use aether_substrate::chassis::builder::{Builder, BuiltChassis};
 use aether_substrate::chassis::error::BootError;
-use aether_substrate::{Chassis, LifecycleDriverCapability, SubstrateBoot, capture::CaptureQueue};
+use aether_substrate::{
+    Chassis, FromArgvThenEnv, LifecycleDriverCapability, SubstrateBoot, capture::CaptureQueue,
+};
 use winit::error::EventLoopError;
 use winit::event_loop::EventLoop;
 

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -27,7 +27,7 @@ use aether_kinds::{SetMasterGain, SetMasterGainResult, Tick};
 use aether_substrate::chassis::builder::{Builder, BuiltChassis};
 use aether_substrate::chassis::error::BootError;
 use aether_substrate::handle_store::PersistConfig;
-use aether_substrate::{Chassis, LifecycleDriverCapability, SubstrateBoot};
+use aether_substrate::{Chassis, FromArgvThenEnv, LifecycleDriverCapability, SubstrateBoot};
 
 use super::driver::{HeadlessTimerCapability, parse_tick_hz_env};
 use crate::chassis_common::{

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -26,12 +26,15 @@ use aether_data::Kind;
 use aether_kinds::{SetMasterGain, SetMasterGainResult, Tick};
 use aether_substrate::chassis::builder::{Builder, BuiltChassis};
 use aether_substrate::chassis::error::BootError;
+use aether_substrate::handle_store::PersistConfig;
 use aether_substrate::{Chassis, LifecycleDriverCapability, SubstrateBoot};
 
 use super::driver::{HeadlessTimerCapability, parse_tick_hz_env};
 use crate::chassis_common::{
-    CommonBoot, maybe_with_rpc_server, tick_only_lifecycle_config, with_common_caps,
+    CommonBoot, PersistOverride, maybe_with_rpc_server, tick_only_lifecycle_config,
+    with_common_caps,
 };
+use crate::cli::{CommonOverlay, HeadlessCli};
 use crate::hub;
 use aether_substrate::mail::registry::MailDispatch;
 use aether_substrate::runtime::lifecycle::FatalAborter;
@@ -75,6 +78,16 @@ pub struct HeadlessEnv {
     /// `AETHER_WORKERS`; `None` keeps `PoolConfig::default()` behavior
     /// (`available_parallelism() - 1`, min 1).
     pub workers: Option<usize>,
+    /// ADR-0090 unit d (issue 1258): chassis-bin verdict on handle-
+    /// store persistence. [`PersistOverride::EnvOnly`] (the default,
+    /// what `from_env()` builds) preserves the pre-d env-only path
+    /// byte-identically; [`PersistOverride::Argv`] threads the argv
+    /// overlay through to `SubstrateBoot`.
+    pub persist: PersistOverride,
+    /// ADR-0090 unit d (issue 1258): argv overlay for the handle-store
+    /// in-memory byte budget. `None` falls through to env-only
+    /// `AETHER_HANDLE_STORE_MAX_BYTES`.
+    pub handle_store_max_bytes: Option<usize>,
 }
 
 impl HeadlessEnv {
@@ -84,18 +97,65 @@ impl HeadlessEnv {
     /// directly.
     #[must_use]
     pub fn from_env() -> Self {
+        Self::from_env_with_argv(HeadlessCli::default())
+    }
+
+    /// ADR-0090 unit d (issue 1258): resolve every cap config through
+    /// the argv-then-env overlay. `cli` carries `Option<T>` flags;
+    /// unset fields fall through to env-only resolution, so an empty
+    /// argv (the path the integration tests and existing `from_env`
+    /// callers exercise) is byte-identical to the pre-d behaviour.
+    #[must_use]
+    pub fn from_env_with_argv(cli: HeadlessCli) -> Self {
         use std::net::{IpAddr, Ipv4Addr};
-        let http = HttpConf::from_env();
-        let anthropic = AnthropicConfig::from_env();
-        let gemini = GeminiConfig::from_env();
-        let namespace_roots = NamespaceRoots::from_env();
-        let tick_hz = parse_tick_hz_env();
+        let HeadlessCli {
+            common,
+            tick_hz: cli_tick_hz,
+        } = cli;
+        let CommonOverlay {
+            http,
+            fs,
+            anthropic,
+            gemini,
+            persist,
+            workers: cli_workers,
+            rpc_port: cli_rpc_port,
+        } = common;
+        let http = HttpConf::from_argv_then_env(http.into_layer());
+        let anthropic = AnthropicConfig::from_argv_then_env(anthropic.into_layer());
+        let gemini = GeminiConfig::from_argv_then_env(gemini.into_layer());
+        let namespace_roots = NamespaceRoots::from_argv_then_env(fs.into_layer());
+        // Persistence overlay: the cap accepts the full argv-then-env
+        // overlay shape (dir + persist_disable + numeric layer). The
+        // chassis-bin verdict is `persist_enabled=true` (headless opts
+        // into on-disk persistence per ADR-0049 §9); the cap layer
+        // applies the argv → env → default precedence.
+        let persist_argv_set = persist.dir.is_some()
+            || persist.persist_disable.is_some()
+            || persist.disk_budget_bytes.is_some()
+            || persist.eviction_tick_secs.is_some();
+        let persist_state = if persist_argv_set {
+            PersistOverride::Argv(PersistConfig::from_argv_then_env(
+                true,
+                persist.dir.clone(),
+                persist.persist_disable,
+                persist.numeric_layer(),
+            ))
+        } else {
+            PersistOverride::EnvOnly
+        };
+        let handle_store_max_bytes = persist.max_bytes;
+        // Chassis-wide knobs: argv-then-env shadow (ad-hoc, lifted to
+        // confique in unit e1). `cli.tick_hz` wins when `Some`, falls
+        // through to `AETHER_TICK_HZ` / default otherwise.
+        let tick_hz = cli_tick_hz
+            .filter(|hz| *hz > 0)
+            .unwrap_or_else(parse_tick_hz_env);
         let tick_period = Duration::from_nanos(1_000_000_000 / u64::from(tick_hz));
-        // `AETHER_RPC_PORT` has no default — absent means RpcServer
-        // doesn't boot. Binds `127.0.0.1`, matching the hub chassis.
-        let rpc_addr =
-            hub::rpc_port_from_env().map(|p| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), p));
-        let workers = parse_workers_env();
+        let rpc_addr = cli_rpc_port
+            .or_else(hub::rpc_port_from_env)
+            .map(|p| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), p));
+        let workers = cli_workers.or_else(parse_workers_env);
         Self {
             namespace_roots,
             http,
@@ -104,6 +164,8 @@ impl HeadlessEnv {
             tick_period,
             rpc_addr,
             workers,
+            persist: persist_state,
+            handle_store_max_bytes,
         }
     }
 }
@@ -154,12 +216,21 @@ impl HeadlessChassis {
             tick_period,
             rpc_addr,
             workers,
+            persist,
+            handle_store_max_bytes,
         } = env;
 
         // ADR-0049 §9: headless enables on-disk handle persistence.
-        let boot = SubstrateBoot::builder("headless", env!("CARGO_PKG_VERSION"))
+        // ADR-0090 unit d: when the chassis bin parsed an argv overlay
+        // for persist config / max_bytes, those override the env-only
+        // resolution `SubstrateBoot` would otherwise run.
+        let mut boot_builder = SubstrateBoot::builder("headless", env!("CARGO_PKG_VERSION"))
             .persist_enabled(true)
-            .build()?;
+            .handle_store_max_bytes(handle_store_max_bytes);
+        if let PersistOverride::Argv(p) = persist {
+            boot_builder = boot_builder.persist_config(p);
+        }
+        let boot = boot_builder.build()?;
         let component_host_config = ComponentHostConfig {
             engine: Arc::clone(&boot.engine),
             linker: Arc::clone(&boot.linker),

--- a/crates/aether-substrate-bundle/src/hub/chassis.rs
+++ b/crates/aether-substrate-bundle/src/hub/chassis.rs
@@ -22,6 +22,7 @@ use aether_substrate::chassis::builder::{
 use aether_substrate::chassis::error::BootError;
 use aether_substrate::{Chassis, SubstrateBoot};
 
+use crate::cli::HubCli;
 use crate::hub::DEFAULT_RPC_PORT;
 use std::thread;
 
@@ -56,8 +57,22 @@ impl HubEnv {
     /// development story.
     #[must_use]
     pub fn from_env() -> Self {
+        Self::from_env_with_argv(&HubCli::default())
+    }
+
+    /// ADR-0090 unit d (issue 1258): resolve from argv-then-env.
+    /// `cli.rpc_port` shadows `AETHER_RPC_PORT`; falling through still
+    /// lands on [`DEFAULT_RPC_PORT`] (the hub always binds an RPC
+    /// server, unlike desktop / headless). Takes `&HubCli` since the
+    /// only field today is a `Copy` `Option<u16>` — owned ownership
+    /// would be a needless move.
+    #[must_use]
+    pub fn from_env_with_argv(cli: &HubCli) -> Self {
         use std::net::{IpAddr, Ipv4Addr};
-        let rpc_port = super::rpc_port_from_env().unwrap_or(DEFAULT_RPC_PORT);
+        let rpc_port = cli
+            .rpc_port
+            .or_else(super::rpc_port_from_env)
+            .unwrap_or(DEFAULT_RPC_PORT);
         Self {
             rpc_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), rpc_port),
         }

--- a/crates/aether-substrate-bundle/src/lib.rs
+++ b/crates/aether-substrate-bundle/src/lib.rs
@@ -26,6 +26,7 @@
 
 mod chassis_common;
 pub mod chassis_root;
+pub mod cli;
 pub mod desktop;
 pub mod headless;
 pub mod hub;

--- a/crates/aether-substrate-bundle/src/lib.rs
+++ b/crates/aether-substrate-bundle/src/lib.rs
@@ -25,6 +25,7 @@
 //! chassis surface.
 
 mod chassis_common;
+pub use chassis_common::PersistOverride;
 pub mod chassis_root;
 pub mod cli;
 pub mod desktop;

--- a/crates/aether-substrate-bundle/tests/spawn_args_overlay.rs
+++ b/crates/aether-substrate-bundle/tests/spawn_args_overlay.rs
@@ -1,0 +1,158 @@
+// ADR-0090 unit d (issue 1258) acceptance test: argv reaches the
+// headless chassis binary and shadows `AETHER_TICK_HZ`. Spawns
+// `aether-substrate-headless` three times with the bin's
+// `CARGO_BIN_EXE_*` path:
+//
+// 1. `--tick-hz 30`  — argv overlay, low cadence.
+// 2. `--tick-hz 120` — argv overlay, high cadence.
+// 3. `args: vec![]`  — env-only path (with `AETHER_TICK_HZ` unset),
+//    the regression bar for the "empty argv ⇒ byte-identical to
+//    `from_env()`" invariant.
+//
+// We grep each child's stderr for the boot tracing line that emits
+// `tick_hz` post-resolution (`headless/chassis.rs:235`); that line is
+// the externally-observable end of the chassis-bin's argv overlay,
+// upstream of any wall-clock noise that a cadence-based assertion
+// would otherwise have to tolerate. Each child is given a short
+// settle window, then SIGTERM'd; the assertion is structural —
+// "logged tick_hz matches argv" — not timing.
+
+use std::io::{BufRead as _, BufReader};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Drive the headless binary with `args`; harvest stderr for ~`wait`
+/// then SIGTERM and join. Returns every stderr line observed.
+fn run_headless_capture(args: &[&str], wait: Duration) -> Vec<String> {
+    let bin = env!("CARGO_BIN_EXE_aether-substrate-headless");
+    let mut cmd = Command::new(bin);
+    cmd.args(args)
+        // Force every chassis-write off a shared system path so two
+        // children don't race the handle-store lock. `AETHER_TICK_HZ`
+        // is intentionally unset so the env-only fall-through has a
+        // known disposition (default 60 Hz).
+        .env_remove("AETHER_TICK_HZ")
+        .env("AETHER_HANDLE_STORE_PERSIST_DISABLE", "1")
+        .env("RUST_LOG", "info")
+        // tracing's default subscriber writes to stderr — explicit
+        // here so the boot log line we grep stays observable.
+        .env("AETHER_LOG_FILTER", "info")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    let mut child = cmd.spawn().expect("spawn aether-substrate-headless");
+    let stderr = child.stderr.take().expect("captured stderr handle");
+
+    let (tx, rx) = mpsc::channel::<String>();
+    let reader_thread = thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines().map_while(Result::ok) {
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+
+    let deadline = Instant::now() + wait;
+    let mut lines = Vec::new();
+    while Instant::now() < deadline {
+        match rx.recv_timeout(Duration::from_millis(50)) {
+            Ok(line) => {
+                lines.push(line);
+            }
+            Err(_) => {
+                // No line within the slice; check if the child died.
+                if let Ok(Some(_)) = child.try_wait() {
+                    break;
+                }
+            }
+        }
+    }
+
+    // SIGTERM (Unix) / kill (Windows) — graceful shutdown is fine,
+    // the assertion has already locked onto its tick_hz line if the
+    // bin booted correctly. `kill` is the portable surface; the
+    // child's signal handler routes through chassis_root::shutdown.
+    let _ = child.kill();
+    // Drain any straggler lines emitted between SIGTERM and exit.
+    while let Ok(line) = rx.recv_timeout(Duration::from_millis(100)) {
+        lines.push(line);
+    }
+    let _ = child.wait();
+    drop(reader_thread.join());
+    lines
+}
+
+/// Pluck the resolved `tick_hz` off the chassis boot tracing line
+/// emitted at `headless/chassis.rs:235`. The line has the shape
+/// `... tick_hz=NN ...`. Returns the parsed value of the first
+/// match; `None` if no matching line was observed.
+///
+/// tracing's default formatter wraps each field name and the `=` in
+/// ANSI escapes (`\x1b[3mtick_hz\x1b[0m\x1b[2m=\x1b[0m120`), so we
+/// strip ESC sequences before searching to keep the test robust
+/// against the CLI-color default.
+fn find_tick_hz(lines: &[String]) -> Option<u32> {
+    fn strip_ansi(s: &str) -> String {
+        // ESC `[` ... letter — the common CSI shape `tracing-subscriber`
+        // emits. A drop-in tiny stripper avoids pulling in an ANSI dep.
+        let mut out = String::with_capacity(s.len());
+        let mut chars = s.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c == '\x1b' && chars.peek() == Some(&'[') {
+                chars.next(); // consume `[`
+                for next in chars.by_ref() {
+                    if next.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+    for line in lines {
+        let clean = strip_ansi(line);
+        if let Some(rest) = clean.split("tick_hz=").nth(1) {
+            let n: String = rest.chars().take_while(char::is_ascii_digit).collect();
+            if let Ok(hz) = n.parse::<u32>() {
+                return Some(hz);
+            }
+        }
+    }
+    None
+}
+
+#[test]
+fn argv_tick_hz_30_reaches_child() {
+    // 1.5 s is well above the chassis boot wall-clock (debug build
+    // headless cold-starts in ~300-500 ms on the supported runners)
+    // and the boot tracing line lands as soon as the chassis builder
+    // finishes, well before the first tick fires.
+    let lines = run_headless_capture(&["--tick-hz", "30"], Duration::from_secs(2));
+    let hz = find_tick_hz(&lines)
+        .unwrap_or_else(|| panic!("no tick_hz tracing line observed; stderr was:\n{lines:?}"));
+    assert_eq!(hz, 30, "--tick-hz 30 must reach the child's chassis env");
+}
+
+#[test]
+fn argv_tick_hz_120_reaches_child() {
+    let lines = run_headless_capture(&["--tick-hz", "120"], Duration::from_secs(2));
+    let hz = find_tick_hz(&lines)
+        .unwrap_or_else(|| panic!("no tick_hz tracing line observed; stderr was:\n{lines:?}"));
+    assert_eq!(hz, 120, "--tick-hz 120 must reach the child's chassis env");
+}
+
+#[test]
+fn empty_argv_falls_through_to_env_default() {
+    // The regression bar: `args: vec![]` is byte-identical to the
+    // pre-d `HeadlessEnv::from_env()` path. With `AETHER_TICK_HZ`
+    // unset (the env mutator above clears it), the chassis lands on
+    // the env-only `DEFAULT_TICK_HZ` (60 Hz).
+    let lines = run_headless_capture(&[], Duration::from_secs(2));
+    let hz = find_tick_hz(&lines)
+        .unwrap_or_else(|| panic!("no tick_hz tracing line observed; stderr was:\n{lines:?}"));
+    assert_eq!(hz, 60, "empty argv must fall through to default tick rate");
+}

--- a/crates/aether-substrate/src/boot.rs
+++ b/crates/aether-substrate/src/boot.rs
@@ -40,6 +40,7 @@ use std::sync::Arc;
 use aether_data::KindDescriptor;
 use wasmtime::{Engine, Linker};
 
+use crate::handle_store::PersistConfig;
 use crate::mail::registry::MailDispatch;
 use crate::runtime::log_install;
 use crate::runtime::panic_hook;
@@ -99,6 +100,20 @@ pub struct SubstrateBootBuilder<'a> {
     /// in-memory-only rather than silently writing to the user's data
     /// dir.
     persist_enabled: bool,
+    /// Pre-resolved persistence config from a chassis-CLI argv overlay
+    /// (ADR-0090 unit d, issue 1258). When the override has been set
+    /// (`persist_override_set`), `persist_override` is the verdict and
+    /// bypasses `HandleStore::from_env_persistent`'s env-only
+    /// resolution; otherwise env-only resolution runs as before. The
+    /// `Option<PersistConfig>` carries the verdict including
+    /// "persistence off" (`None`). Set via [`Self::persist_config`].
+    persist_override_set: bool,
+    persist_override: Option<PersistConfig>,
+    /// Argv-resolved in-memory byte budget for the handle store
+    /// (ADR-0090 unit d, issue 1258). `None` keeps the env-only
+    /// `AETHER_HANDLE_STORE_MAX_BYTES` resolution. Set via
+    /// [`Self::handle_store_max_bytes`].
+    handle_store_max_bytes: Option<usize>,
 }
 
 impl SubstrateBoot {
@@ -112,6 +127,9 @@ impl SubstrateBoot {
             name,
             version,
             persist_enabled: false,
+            persist_override_set: false,
+            persist_override: None,
+            handle_store_max_bytes: None,
         }
     }
 }
@@ -125,6 +143,29 @@ impl SubstrateBootBuilder<'_> {
     #[must_use]
     pub fn persist_enabled(mut self, enabled: bool) -> Self {
         self.persist_enabled = enabled;
+        self
+    }
+
+    /// Inject a pre-resolved persistence config (ADR-0090 unit d,
+    /// issue 1258). When chassis bins have parsed argv overlays, they
+    /// resolve `PersistConfig::from_argv_then_env(...)` themselves and
+    /// hand the result in here, bypassing the env-only resolution baked
+    /// into [`crate::handle_store::HandleStore::from_env_persistent`].
+    /// `None` means "argv said persistence is off". When not called,
+    /// env-only resolution runs.
+    #[must_use]
+    pub fn persist_config(mut self, config: Option<PersistConfig>) -> Self {
+        self.persist_override_set = true;
+        self.persist_override = config;
+        self
+    }
+
+    /// Inject an argv-resolved handle-store in-memory byte budget
+    /// (ADR-0090 unit d, issue 1258). `None` (or not called) keeps the
+    /// env-only `AETHER_HANDLE_STORE_MAX_BYTES` resolution.
+    #[must_use]
+    pub fn handle_store_max_bytes(mut self, bytes: Option<usize>) -> Self {
+        self.handle_store_max_bytes = bytes;
         self
     }
 }
@@ -213,10 +254,30 @@ impl SubstrateBootBuilder<'_> {
         // schema-evolution check on the boot scan — a kind whose schema
         // changed or was retired invalidates its stale on-disk entries.
         let kind_resolver: Arc<dyn KindResolver> = registry.clone();
-        let handle_store = Arc::new(HandleStore::from_env_persistent(
-            self.persist_enabled,
-            Some(kind_resolver),
-        ));
+        let handle_store = Arc::new(if self.persist_override_set {
+            // Chassis bin resolved PersistConfig from argv-then-env;
+            // use it verbatim (ADR-0090 unit d). max_bytes follows the
+            // same overlay (argv > env > default).
+            let max_bytes = self
+                .handle_store_max_bytes
+                .unwrap_or_else(|| HandleStore::from_env().max_bytes());
+            HandleStore::with_persist_validated(
+                max_bytes,
+                self.persist_override,
+                Some(kind_resolver),
+            )
+        } else if let Some(max_bytes) = self.handle_store_max_bytes {
+            // No argv overlay for persist config but max_bytes was
+            // overridden independently; env-only persist resolution.
+            HandleStore::with_persist_validated(
+                max_bytes,
+                PersistConfig::from_env(self.persist_enabled),
+                Some(kind_resolver),
+            )
+        } else {
+            // Pure env-only path — byte-identical to pre-d behaviour.
+            HandleStore::from_env_persistent(self.persist_enabled, Some(kind_resolver))
+        });
         // ADR-0049 §7: acquire the single-substrate-per-store lock
         // before doing any writes. A live conflicting lock aborts boot
         // with a clear error. No-op when persistence is disabled.

--- a/crates/aether-substrate/src/config.rs
+++ b/crates/aether-substrate/src/config.rs
@@ -1,0 +1,79 @@
+//! Shared confique-overlay glue for resolved cap configs (ADR-0090
+//! unit d).
+//!
+//! Every cap that opted into confique (`HttpConfig`, `AudioConfig`,
+//! `GeminiConfig`, `AnthropicConfig`, `NamespaceRoots`) ships a
+//! mechanical `from_argv_then_env(argv) -> Self`: build the
+//! cap's `*ConfigLayer` with the argv overlay preloaded, run
+//! `.env().load()`, hand the loaded layer to a per-cap `from_layer`
+//! mapping. Only `from_layer` actually differs across caps — the
+//! builder boilerplate is identical.
+//!
+//! [`FromArgvThenEnv`] hoists the boilerplate into a default method.
+//! Each cap impls just `from_layer` (and names its `Layer` associated
+//! type); the trait's default `from_argv_then_env` is inherited
+//! verbatim.
+//!
+//! # Why not `PersistConfig` too?
+//!
+//! `aether_substrate::handle_store::PersistConfig::from_argv_then_env`
+//! takes four arguments (`enabled: bool`, `dir: Option<PathBuf>`,
+//! `disable: Option<bool>`, `numeric: <_>::Layer`) because two of its
+//! overlays are *not* confique fields — `enabled` is the chassis's
+//! structural vote (a `false` short-circuits to `None` regardless of
+//! env), and `dir` / `disable` interact with `dirs::data_dir()` lookup
+//! and an `ENV_PERSIST_DISABLE` short-circuit that don't fit confique's
+//! literal-default model. Only the numeric budget / tick knobs flow
+//! through a `Layer`. Forcing it into a `(Layer) -> Self` shape would
+//! mean re-deriving the structural inputs from environment reads inside
+//! the trait body, which is exactly the structure the cap deliberately
+//! kept hand-written. The five other caps still benefit from the trait;
+//! `PersistConfig` stays inherent.
+
+/// Build a cap config by overlaying an argv-derived partial confique
+/// layer on top of the env layer (ADR-0090 unit d).
+///
+/// The cap declares its env-shaped layer via [`Layer`] (a
+/// `#[derive(confique::Config)]` struct) and its per-cap mapping via
+/// [`from_layer`]. The default [`from_argv_then_env`] builds the
+/// preloaded `Layer`, runs the env-plus-defaults resolution, and hands
+/// off to `from_layer`. Argv-set fields win against env; unset
+/// (`None`) fields fall through to env, then to the literal defaults
+/// declared on `Layer`.
+///
+/// [`Layer`]: Self::Layer
+/// [`from_layer`]: Self::from_layer
+/// [`from_argv_then_env`]: Self::from_argv_then_env
+pub trait FromArgvThenEnv: Sized {
+    /// The env-shaped confique layer behind this config — the
+    /// `#[derive(confique::Config)]` struct whose fields carry the
+    /// `AETHER_*` env keys + literal defaults.
+    type Layer: confique::Config;
+
+    /// Per-cap mapping from the loaded confique layer onto the
+    /// domain-shaped config struct. This is the only part that
+    /// actually differs across caps (ms → `Duration`, CSV → `HashSet`,
+    /// raw `Option<String>` → soft-parsed numeric, etc.).
+    fn from_layer(layer: Self::Layer) -> Self;
+
+    /// Resolve the config from a chassis-CLI argv overlay shadowing
+    /// `AETHER_*` env (ADR-0090 unit d, issue 1258). Argv-set fields
+    /// win; unset (`None`) fall through to env, then literal defaults.
+    /// Defaulted — every cap inherits this verbatim.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if the cap's layer literal defaults are themselves
+    /// malformed — a programmer error caught by each cap's
+    /// `*_defaults_match` test, never a runtime config fault (env
+    /// values flow through total parsers).
+    #[must_use]
+    fn from_argv_then_env(argv: <Self::Layer as confique::Config>::Layer) -> Self {
+        let layer = <Self::Layer as confique::Config>::builder()
+            .preloaded(argv)
+            .env()
+            .load()
+            .expect("config layer defaults are well-formed");
+        Self::from_layer(layer)
+    }
+}

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -142,31 +142,77 @@ impl PersistConfig {
     /// fault (the env values flow through total parsers).
     #[must_use]
     pub fn from_env(enabled: bool) -> Option<Self> {
+        Self::resolve(enabled, None, None, None)
+    }
+
+    /// Resolve from a chassis-CLI argv overlay shadowing env (ADR-0090
+    /// unit d, issue 1258). `dir` / `disable` win against
+    /// `AETHER_HANDLE_STORE_DIR` / `AETHER_HANDLE_STORE_PERSIST_DISABLE`
+    /// when `Some`; the numeric-knob overlay is preloaded into the
+    /// confique builder so argv-set budget / tick win against
+    /// `AETHER_HANDLE_STORE_*` env. `enabled` is the chassis's vote (a
+    /// `false` short-circuits to `None` regardless of argv).
+    ///
+    /// # Panics
+    ///
+    /// Same as [`Self::from_env`]: only on a malformed literal default
+    /// (programmer error caught by
+    /// `persist_config_layer_defaults_match`).
+    #[must_use]
+    pub fn from_argv_then_env(
+        enabled: bool,
+        dir: Option<PathBuf>,
+        disable: Option<bool>,
+        numeric: <PersistConfigLayer as confique::Config>::Layer,
+    ) -> Option<Self> {
+        Self::resolve(enabled, dir, disable, Some(numeric))
+    }
+
+    /// Shared resolution path. Argv overrides (when `Some`) win against
+    /// the env variable; absent argv falls through to env, then to the
+    /// platform default.
+    fn resolve(
+        enabled: bool,
+        dir_argv: Option<PathBuf>,
+        disable_argv: Option<bool>,
+        numeric_argv: Option<<PersistConfigLayer as confique::Config>::Layer>,
+    ) -> Option<Self> {
         use confique::Config as _;
 
         if !enabled {
             return None;
         }
-        if env::var(ENV_PERSIST_DISABLE).is_ok_and(|v| v == "1") {
+        // disable: argv wins; absent falls through to env (=`1` ⇒ true).
+        let disabled =
+            disable_argv.unwrap_or_else(|| env::var(ENV_PERSIST_DISABLE).is_ok_and(|v| v == "1"));
+        if disabled {
             return None;
         }
-        let base = match env::var(ENV_PERSIST_DIR) {
-            Ok(raw) if !raw.is_empty() => PathBuf::from(raw),
-            _ => {
-                let Some(data) = dirs::data_dir() else {
-                    tracing::warn!(
-                        target: TARGET,
-                        "no data dir and no AETHER_HANDLE_STORE_DIR; persistence disabled",
-                    );
-                    return None;
-                };
-                data.join("aether").join("handles")
+        let base = if let Some(d) = dir_argv {
+            d
+        } else {
+            match env::var(ENV_PERSIST_DIR) {
+                Ok(raw) if !raw.is_empty() => PathBuf::from(raw),
+                _ => {
+                    let Some(data) = dirs::data_dir() else {
+                        tracing::warn!(
+                            target: TARGET,
+                            "no data dir and no AETHER_HANDLE_STORE_DIR; persistence disabled",
+                        );
+                        return None;
+                    };
+                    data.join("aether").join("handles")
+                }
             }
         };
         // Every layer field has a literal default and a total parser, so
         // the layer always resolves; a failure here would be a malformed
         // default literal (caught by `persist_config_layer_defaults_match`).
-        let layer = PersistConfigLayer::builder()
+        let mut builder = PersistConfigLayer::builder();
+        if let Some(argv) = numeric_argv {
+            builder = builder.preloaded(argv);
+        }
+        let layer = builder
             .env()
             .load()
             .expect("PersistConfigLayer defaults are well-formed");
@@ -378,9 +424,12 @@ pub fn entry_paths(root: &Path, id: HandleId) -> (PathBuf, PathBuf) {
 /// `eviction_tick_secs` carry their `AETHER_HANDLE_STORE_*` values; the
 /// `root` resolution stays hand-written in [`PersistConfig::from_env`]
 /// (its default is structural — a missing data dir disables persistence,
-/// not a literal). Kept private; the consumed shape stays `PersistConfig`.
+/// not a literal). Public so chassis CLI overlays (ADR-0090 unit d,
+/// issue 1258) can preload a `<PersistConfigLayer as
+/// confique::Config>::Layer` before `.env()`; the consumed shape stays
+/// `PersistConfig`.
 #[derive(confique::Config)]
-struct PersistConfigLayer {
+pub struct PersistConfigLayer {
     /// On-disk byte budget. Literal default mirrors
     /// [`DEFAULT_DISK_BUDGET_BYTES`] (16 GiB); the
     /// `persist_config_layer_defaults_match` test guards the match.
@@ -389,7 +438,7 @@ struct PersistConfigLayer {
         parse_env = parse_disk_budget_bytes,
         default = 17_179_869_184u64
     )]
-    disk_budget_bytes: u64,
+    pub disk_budget_bytes: u64,
     /// Eviction tick interval in seconds. Literal default mirrors
     /// [`DEFAULT_DISK_EVICTION_TICK_SECS`] (60 s).
     #[config(
@@ -397,7 +446,7 @@ struct PersistConfigLayer {
         parse_env = parse_eviction_tick_secs,
         default = 60u64
     )]
-    eviction_tick_secs: u64,
+    pub eviction_tick_secs: u64,
 }
 
 // confique's `parse_env` contract is `fn(&str) -> Result<T, impl Error>`,

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -43,6 +43,7 @@ pub mod actor;
 pub mod boot;
 pub mod capture;
 pub mod chassis;
+pub mod config;
 pub mod dag;
 pub mod handle_store;
 pub mod lifecycle;
@@ -73,6 +74,7 @@ pub use chassis::ctx::{
     ActorErased, ChassisCtx, DropOnShutdownClaim, FallbackRouter, MailboxClaim, MailboxSender,
 };
 pub use chassis::error::BootError;
+pub use config::FromArgvThenEnv;
 pub use lifecycle::{LifecycleDriverCapability, LifecycleDriverConfig, LifecycleGraph};
 pub use mail::mailer::Mailer;
 pub use mail::outbound::{


### PR DESCRIPTION
Unit (d) of the ADR-0090 application-configuration rollout (epic iamacoffeepot/aether#1235; ADR at `docs/adr/0090-application-configuration.md`).

Adds `clap` argv parsing to the three chassis bin mains so per-spawn `args` finally land as a load-bearing overlay on top of confique's env layer. Precedence: defaults < env < argv. `Command::args(&mail.args)` at `engine/server.rs:146` was already plumbed end-to-end — d teaches the child to parse it.

## Load-bearing pieces

- **`crates/aether-substrate-bundle/src/cli.rs` (new)** — shared `CommonOverlay` (clap-flatten-able) + per-chassis `DesktopCli` / `HeadlessCli` / `HubCli`. Per-cap `*Overlay` structs build a confique partial-layer (`<Cap as Config>::Layer`) from `Option<T>` fields; merge via `Layer::builder().preloaded(argv).env().load()`.
- **Per-cap `from_argv_then_env(argv: Self::Layer) -> Self`** in `http`, `audio`, `gemini`, `anthropic`, `fs` (under `aether-capabilities`) and `PersistConfig` (under `aether-substrate`). Each `*Layer` is now `pub`; `from_env()` stays untouched as the default-arg path. Shared private `from_layer` extracts the layer→domain mapping to keep the new constructor free of duplication.
- **Three chassis bin mains** parse their `<Cli>::parse()`, build per-cap overlays, and call new `*Env::from_env_with_argv(cli)` constructors. The chassis-wide knobs (`AETHER_WORKERS`, `AETHER_TICK_HZ`, `AETHER_WINDOW_*`, `AETHER_RPC_PORT`) shadow env via `cli.<knob>.or_else(parse_*_env)` — those are still hand-rolled parsers, paired naturally with e1's confique-ification pass.

## Flag naming

Flat shape: `AETHER_HTTP_TIMEOUT_MS` -> `--http-timeout-ms`. API keys included (`--gemini-api-key`, `--anthropic-api-key`) for spawn-time convenience; ps-leak surface acknowledged for the single-user-shell context.

## Plan deviations (worth flagging)

1. **Clap `id = "<overlay>_<field>"` per conflicting field** — flattened structs collided on names like `disable`, `api_key`, `max_in_flight`. Each carries an explicit `id` to disambiguate while the user-facing `long =` stays per the flag-naming rule. Help-output value-name shows the disambiguated id (`<http_disable>` etc).
2. **`PersistOverride` enum** in `chassis_common` replaces `Option<Option<PersistConfig>>` (clippy `option_option`) to disambiguate "argv said off" from "no argv". `SubstrateBootBuilder` gained `persist_config(...)` / `handle_store_max_bytes(...)` to thread the chassis-bin verdict through to `SubstrateBoot`. The enum is re-exported from the bundle's lib for rustdoc visibility.
3. **Acceptance test uses log-grep** for the diverge demo — the plan offered tick-cadence-via-RPC or boot-log-pin; the log-pin (chassis boot tracing line surfaces `tick_hz=NN`) is structural and avoids wall-clock noise. Three tests in `tests/spawn_args_overlay.rs`: `--tick-hz 30`, `--tick-hz 120`, and `args: vec![]` (env-only regression bar, redundant with `tests/engines_cap.rs:155-158` but explicit).
4. **`from_argv_then_env` body dedupe** — extracted a private `from_layer(layer)` per cap so `from_env` and `from_argv_then_env` share the layer-to-domain mapping (no body duplication).

## Out of scope (per ADR-0090 sequencing)

- **DAG executor / validator argv** — sub-actor; not chassis-built. Deferred to a follow-on.
- **`AETHER_LOG_FILTER` argv** — read pre-clap during early `EnvFilter::try_from_env`; lifting it is its own refactor (e1 territory).
- **Tunnel / MCP ports** — out-of-process; `aether-tunnel` and `aether-mcp` read their own env.
- **Confique-ifying `AETHER_WORKERS` / `AETHER_TICK_HZ` / `AETHER_WINDOW_*` / `AETHER_RPC_PORT`** — pairs with e1.
- **Validation hard-error** — e1. **`--config <path>` + multi-name aliases** — e2.

## Acceptance

- `--tick-hz 30` vs `--tick-hz 120` spawn-substrate paths produce divergent boot configs (pinned in `tests/spawn_args_overlay.rs`).
- `tests/engines_cap.rs:155-158` (the `args: vec![]` env-only spawn) — regression bar held.
- `.mcp.json`, `scripts/ensure-tunnel.sh`, CI env-only path: behaviour-identical.
- `cargo nextest run --workspace --all-features` — **1420 passed, 6 skipped** (1417 baseline + 3 new). Clippy + rustdoc + wasm32 cross-build green.

Closes iamacoffeepot/aether#1258

🤖 Generated with [Claude Code](https://claude.com/claude-code)
