### PR TITLE
fix(substrate): send_mail_traced settles before deferred replies in batched dispatch

### DIFF
--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -968,6 +968,137 @@ mod tests {
         }
     }
 
+    /// A `Call` carrying a `DispatchTraced` batch with **two**
+    /// `DeferredEchoRequest` envelopes — the empirical `send_mail_traced`
+    /// failure shape: each child is itself a deferred-reply path
+    /// (spawn → loopback → re-reply), routed through the trace cap rather
+    /// than directly. Pre-fix the trace cap dispatched each child via
+    /// `ctx.send_envelope_traced` which stamps `reply_to` at the
+    /// dispatcher's own mailbox (the `push_envelope_buffered` default);
+    /// child deferred replies landed at the trace cap, which has no
+    /// handler for the reply kind and no `#[fallback]`, so they were
+    /// silently dropped. The wire call closed via the (still correct)
+    /// settlement signal with `replies: []`. The fix forwards each
+    /// child's `reply_to` to the trace cap's own inbound `reply_target`
+    /// (typically the RPC server holding the wire `cid`'s in-flight
+    /// entry), so child replies — sync or deferred — bubble through to
+    /// the wire as `ReplyEvent`s, and settlement still fires only after
+    /// each `InFlightDispatch` hold drops.
+    ///
+    /// Test asserts: TWO `ReplyEvent`s (one `DeferredEchoReply` per
+    /// request), then exactly ONE `ReplyEnd`. Order of the two events is
+    /// unspecified (the two deferred-echo handlers run in parallel
+    /// behind 50ms sleeps); the test pairs by `value`.
+    #[test]
+    fn dispatch_traced_with_deferred_replies_routes_each_event_then_settles() {
+        use crate::rpc::test_echo::{DeferredEchoActor, DeferredEchoReply, DeferredEchoRequest};
+        use crate::rpc::wire::{MailEnvelope, MailboxAddress};
+        use crate::trace::TraceDispatchCapability;
+        use aether_actor::Actor;
+        use aether_data::{Kind, mailbox_id_from_name};
+        use aether_kinds::MailEnvelope as TracedEnvelope;
+        use aether_kinds::trace::DispatchTraced;
+
+        let (registry, mailer) = fresh_substrate();
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<TraceDispatchCapability>(())
+            .with_actor::<DeferredEchoActor>(())
+            .with_actor::<RpcServerCapability>(RpcServerConfig {
+                bind_addr: "127.0.0.1:0".into(),
+                peer_kind: test_peer_kind(),
+            })
+            .build_passive()
+            .expect("caps boot");
+
+        let mut stream = connect_to_rpc_server(&chassis, Duration::from_secs(10));
+        complete_handshake(&mut stream);
+
+        // Build a batched DispatchTraced with two DeferredEchoRequest
+        // envelopes, addressed at the deferred-echo actor by name (the
+        // trace cap resolves names through the registry).
+        let batch = DispatchTraced {
+            mails: vec![
+                TracedEnvelope {
+                    recipient_name: <DeferredEchoActor as Actor>::NAMESPACE.into(),
+                    kind_name: <DeferredEchoRequest as Kind>::NAME.into(),
+                    payload: postcard::to_allocvec(&DeferredEchoRequest { value: 11 })
+                        .expect("encode req 11"),
+                    count: 1,
+                },
+                TracedEnvelope {
+                    recipient_name: <DeferredEchoActor as Actor>::NAMESPACE.into(),
+                    kind_name: <DeferredEchoRequest as Kind>::NAME.into(),
+                    payload: postcard::to_allocvec(&DeferredEchoRequest { value: 22 })
+                        .expect("encode req 22"),
+                    count: 1,
+                },
+            ],
+        };
+        let trace_mailbox = mailbox_id_from_name(<TraceDispatchCapability as Actor>::NAMESPACE);
+        let payload = postcard::to_allocvec(&batch).expect("encode DispatchTraced");
+        write_frame(
+            &mut stream,
+            &WireFrame::Call {
+                cid: Some(0xbeef),
+                envelope: MailEnvelope {
+                    to: MailboxAddress::local(trace_mailbox),
+                    from: None,
+                    kind: <DispatchTraced as Kind>::ID,
+                    correlation_id: None,
+                    payload,
+                },
+            },
+        )
+        .expect("test: write_frame Call DispatchTraced to rpc server");
+
+        // The trace cap's synchronous `DispatchTracedAck::Ok` reply
+        // arrives as a ReplyEvent. Drain it before scanning for the two
+        // deferred replies — its ordering is well-defined (the trace
+        // handler replies before the children run), so we can read it
+        // first without an unbound search.
+        let mut deferred_values: Vec<u64> = Vec::new();
+        let mut saw_ack = false;
+        // Drain up to 4 ReplyEvent frames (ack + 2 deferred + safety
+        // margin) before the ReplyEnd. Each iteration consumes one
+        // frame; the ReplyEnd breaks.
+        loop {
+            let frame: WireFrame = read_frame(&mut stream).expect("read frame");
+            match frame {
+                WireFrame::ReplyEvent { cid, envelope } => {
+                    assert_eq!(cid, 0xbeef);
+                    if envelope.kind == <DeferredEchoReply as Kind>::ID {
+                        let decoded: DeferredEchoReply =
+                            postcard::from_bytes(&envelope.payload).expect("decode deferred reply");
+                        deferred_values.push(decoded.value);
+                    } else {
+                        // Otherwise this is the DispatchTracedAck::Ok
+                        // reply; mark it observed but don't assert on
+                        // its payload here (the ack carries the root
+                        // MailId; the test's load-bearing assertions are
+                        // on the deferred-reply payloads).
+                        saw_ack = true;
+                    }
+                }
+                WireFrame::ReplyEnd { cid, result } => {
+                    assert_eq!(cid, 0xbeef);
+                    result.expect("ReplyEnd result Ok");
+                    break;
+                }
+                other => panic!("expected ReplyEvent / ReplyEnd, got {other:?}"),
+            }
+        }
+        assert!(
+            saw_ack,
+            "expected DispatchTracedAck reply event before ReplyEnd",
+        );
+        deferred_values.sort_unstable();
+        assert_eq!(
+            deferred_values,
+            vec![11, 22],
+            "expected one DeferredEchoReply per request, sorted by value",
+        );
+    }
+
     /// Fire-and-forget `Call { cid: None }` skips reply correlation
     /// entirely — no settlement subscription is created, no
     /// `ReplyEnd` is written. Verify by sending a Call with cid None

--- a/crates/aether-capabilities/src/trace.rs
+++ b/crates/aether-capabilities/src/trace.rs
@@ -77,9 +77,24 @@ mod native {
         /// settled), then reconstructs the populated tree by walking the
         /// per-actor trace rings from this root (`aether.trace.tail`,
         /// stitched client-side — ADR-0086 Phase 3b). Issue 749.
+        ///
+        /// **Reply forwarding (issue 1265).** Each child is dispatched
+        /// with `reply_to = ctx.reply_target()` (the caller of this
+        /// `DispatchTraced` — typically the RPC server holding the wire
+        /// `cid`'s in-flight entry) rather than the default
+        /// `Component(self_mailbox)`. This trace cap is a re-dispatcher
+        /// with no handler for child reply kinds, so without the
+        /// forward each child's deferred reply (the `InFlightDispatch`
+        /// spawn-and-die pattern in content-gen caps) lands here and
+        /// silently drops, leaving the wire call with no `ReplyEvent`s.
+        /// Forwarding lets every child's reply (sync or deferred)
+        /// bubble straight to the original caller with the same
+        /// `correlation_id`, so the RPC server's `on_any` fallback wraps
+        /// each into a `ReplyEvent` on the wire.
         #[handler]
         fn on_dispatch_traced(&mut self, ctx: &mut NativeCtx<'_>, batch: DispatchTraced) {
             let root = ctx.in_flight_mail_id();
+            let forward_reply_to = ctx.reply_target();
             let DispatchTraced { mails } = batch;
             // Resolve every envelope's name addressing through the
             // substrate registry — same path `CaptureFrame`'s bundle
@@ -94,7 +109,12 @@ mod native {
                 }
             };
             for mail in resolved {
-                let _ = ctx.send_envelope_traced(mail.recipient, mail.kind, mail.payload.bytes());
+                let _ = ctx.send_envelope_traced_with_reply_to(
+                    mail.recipient,
+                    mail.kind,
+                    mail.payload.bytes(),
+                    forward_reply_to,
+                );
             }
             ctx.reply(&DispatchTracedAck::Ok { root });
         }

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -541,9 +541,57 @@ impl NativeBinding {
         parent_mail: Option<MailId>,
         inherited_root: Option<MailId>,
     ) -> MailId {
+        self.push_envelope_buffered_with_reply_to(
+            recipient,
+            kind,
+            bytes,
+            count,
+            parent_mail,
+            inherited_root,
+            None,
+        )
+    }
+
+    /// Re-dispatcher variant of [`Self::push_envelope_buffered`] that
+    /// accepts an explicit `reply_to` instead of stamping the default
+    /// `ReplyTo::with_correlation(ReplyTarget::Component(self_mailbox),
+    /// auto_correlation)`. The minted [`MailId`] and the `in_flight`
+    /// settlement increment are unaffected — they still use this
+    /// actor's correlation counter — only the recipient's
+    /// `OutboundReply::reply_target()` view changes.
+    ///
+    /// Used by re-dispatch caps (today: `TraceDispatchCapability`
+    /// servicing `DispatchTraced`) that forward someone else's call:
+    /// the children's deferred replies must bubble up to the original
+    /// caller (e.g. the RPC server holding the wire `cid`'s in-flight
+    /// entry), not get stranded at the re-dispatcher's mailbox where
+    /// no handler exists for them.
+    ///
+    /// `reply_to_override = None` is the same shape as
+    /// [`Self::push_envelope_buffered`].
+    ///
+    /// # Panics
+    /// Panics if the outbound-buffer mutex is poisoned — fail-fast per
+    /// ADR-0063.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "re-dispatch variant adds reply_to_override to the existing 6-arg shape; \
+                  splitting would force callers through two separate code paths"
+    )]
+    pub fn push_envelope_buffered_with_reply_to(
+        &self,
+        recipient: u64,
+        kind: u64,
+        bytes: &[u8],
+        count: u32,
+        parent_mail: Option<MailId>,
+        inherited_root: Option<MailId>,
+        reply_to_override: Option<ReplyTo>,
+    ) -> MailId {
         let correlation = self.correlation.fetch_add(1, Ordering::AcqRel) + 1;
-        let reply_to =
-            ReplyTo::with_correlation(ReplyTarget::Component(self.self_mailbox), correlation);
+        let reply_to = reply_to_override.unwrap_or_else(|| {
+            ReplyTo::with_correlation(ReplyTarget::Component(self.self_mailbox), correlation)
+        });
         let mail_id = MailId::new(self.self_mailbox, correlation);
         let root = inherited_root.unwrap_or(mail_id);
         // iamacoffeepot/aether#1150: only the settlement increment is

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -405,6 +405,46 @@ impl NativeCtx<'_> {
         )
     }
 
+    /// Re-dispatch variant of [`Self::send_envelope_traced`] that pins the
+    /// child mail's `reply_to` to the supplied [`ReplyTo`] instead of
+    /// stamping the default `(Component(self_mailbox), auto_correlation)`.
+    /// The minted [`MailId`] and the chain's `in_flight` accounting are
+    /// unchanged — only the recipient's
+    /// [`aether_actor::actor::ctx::OutboundReply::reply_target`]
+    /// view changes.
+    ///
+    /// Use this when a cap is **forwarding** another actor's call rather
+    /// than originating one: the trace cap servicing `DispatchTraced`
+    /// (issue 1265 — the `send_mail_traced` batched-dispatch path)
+    /// re-dispatches each child envelope but wants the child's deferred
+    /// reply to land at the **original** caller's `reply_to` (the RPC
+    /// server holding the wire `cid`'s in-flight entry), not stranded at
+    /// the trace cap's own mailbox where no handler exists for it.
+    ///
+    /// Pass `ctx.reply_target()` as `reply_to` to forward to whoever
+    /// invoked this cap. Single-Call paths (the RPC server's
+    /// `send_envelope_as_root` dispatching directly at the receiver)
+    /// never reach this method — the default `reply_to` lands at the
+    /// dispatcher which is also the call-correlation owner.
+    #[must_use]
+    pub fn send_envelope_traced_with_reply_to(
+        &self,
+        recipient: MailboxId,
+        kind: KindId,
+        bytes: &[u8],
+        reply_to: ReplyTo,
+    ) -> MailId {
+        self.binding.push_envelope_buffered_with_reply_to(
+            recipient.0,
+            kind.0,
+            bytes,
+            1,
+            self.outbound_parent(),
+            self.outbound_root(),
+            Some(reply_to),
+        )
+    }
+
     /// Like [`Self::send_envelope_traced`] but always starts a fresh
     /// causal chain — ignores the ctx's in-flight lineage and passes
     /// `parent_mail = None, inherited_root = None` to the dispatch


### PR DESCRIPTION
**Bug.** `send_mail_traced` returns `status: settled` with `replies: []` whenever a batched child defers its reply through `InFlightDispatch` (the content-gen spawn-and-die pattern — `aether.gemini.nanobanana.generate`, the future `aether.anthropic.messages`, etc.). The wall-clock wait matches gen completion and the artifacts land on disk correctly, so the settlement contract is honored end-to-end — only the typed reply payloads disappear before they hit the wire.

**Root cause.** `TraceDispatchCapability::on_dispatch_traced` re-dispatches each child via `ctx.send_envelope_traced(...)`, which routes through `push_envelope_buffered` and unconditionally stamps the new mail's `reply_to` at `ReplyTarget::Component(self_mailbox)` — i.e. the trace cap's own mailbox. The trace cap is a pure re-dispatcher with no handler for the children's reply kinds and no `#[fallback]`, so the gemini cap's `OutboundReply::reply_to(ctx, landed.reply_to, &result)` (in the deferred-reply landing path) drops at the trace cap and never reaches the RPC server's `on_any` fallback.

**Fix.** Adds `NativeBinding::push_envelope_buffered_with_reply_to(.., Option<ReplyTo>)` and `NativeCtx::send_envelope_traced_with_reply_to(.., ReplyTo)` — re-dispatch variants that let a forwarding cap pin a child's `reply_to` explicitly. The trace cap reads `ctx.reply_target()` (the chassis-root mail's reply target, typically the RPC server's in-flight correlation) and forwards each child with it. The minted `MailId`, the `in_flight` settlement increment, and the chain lineage are unaffected — only the recipient's `OutboundReply::reply_target()` view changes. The existing 6-arg `push_envelope_buffered` delegates with `None`, preserving every other caller path.

**Test.** New `rpc::server::tests::dispatch_traced_with_deferred_replies_routes_each_event_then_settles` — boots `RpcServerCapability` + `TraceDispatchCapability` + `DeferredEchoActor`, sends a wire `Call { DispatchTraced { mails: [DeferredEchoRequest { 11 }, DeferredEchoRequest { 22 }] } }`, asserts the `DispatchTracedAck` event + two `DeferredEchoReply` events (set-equality on values) + one `ReplyEnd`. Pre-fix fails with `replies: []`; post-fix passes in ~75ms. The existing `call_deferred_echo_settles_after_reply` regression-guard stays green.

Closes iamacoffeepot/aether#1265

🤖 Generated with [Claude Code](https://claude.com/claude-code)
