### PR TITLE
feat(substrate): derive macro for app config — collapse domain+layer+overlay+mapping into one struct

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,7 +13,7 @@ slow-timeout = { period = "60s", terminate-after = 1 }
 # exclusively host trybuild-style fixtures, so widening the cap is
 # scoped — no fast unit tests hide behind the longer window.
 [[profile.ci.overrides]]
-filter = "binary(aether-data-derive) | binary(aether-derive)"
+filter = "package(=aether-data-derive) | package(=aether-derive)"
 slow-timeout = { period = "300s", terminate-after = 1 }
 
 # Repeat-run ("soak") flake detection for concurrent tests, driven by

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,6 +6,16 @@ final-status-level = "slow"
 fail-fast = false
 slow-timeout = { period = "60s", terminate-after = 1 }
 
+# Trybuild fixtures (aether-data-derive, aether-derive) spawn a nested
+# `cargo` build per `.rs` fixture. Local runs finish under 30s; CI
+# runners are slower and contended, and running both crates' UI tests
+# in parallel can push each past 60s. Both crates' test binaries
+# exclusively host trybuild-style fixtures, so widening the cap is
+# scoped — no fast unit tests hide behind the longer window.
+[[profile.ci.overrides]]
+filter = "binary(aether-data-derive) | binary(aether-derive)"
+slow-timeout = { period = "300s", terminate-after = 1 }
+
 # Repeat-run ("soak") flake detection for concurrent tests, driven by
 # `scripts/flake-soak.sh` with nextest `--stress-count`. Each repeat is a
 # fresh process. `fail-fast = false` so one flaky test doesn't hide the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
  "aether-kinds",
  "aether-substrate",
  "bytemuck",
+ "clap",
  "confique",
  "cpal",
  "crossbeam-queue",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "aether-derive"
+version = "0.3.0-alpha"
+dependencies = [
+ "aether-derive",
+ "aether-substrate",
+ "clap",
+ "confique",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "trybuild",
+]
+
+[[package]]
 name = "aether-kinds"
 version = "0.3.0-alpha"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,7 @@ version = "0.3.0-alpha"
 dependencies = [
  "aether-actor",
  "aether-data",
+ "aether-derive",
  "aether-kinds",
  "bytemuck",
  "confique",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/aether-actor",
     "crates/aether-actor-derive",
     "crates/aether-data-derive",
+    "crates/aether-derive",
     "crates/aether-mesh",
     "crates/aether-camera",
     "crates/aether-capabilities",

--- a/crates/aether-capabilities/Cargo.toml
+++ b/crates/aether-capabilities/Cargo.toml
@@ -36,6 +36,7 @@ default = ["native"]
 native = [
     "dep:aether-substrate",
     "dep:bytemuck",
+    "dep:clap",
     "dep:confique",
     "dep:dirs",
     "dep:postcard",
@@ -78,6 +79,12 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 # don't drag in wasmtime / cpal / wgpu transitively.
 aether-substrate = { path = "../aether-substrate", optional = true }
 bytemuck = { version = "1.19", optional = true }
+# ADR-0090 unit g (iamacoffeepot/aether#1264): the `Config` derive
+# emits per-cap `*Overlay` structs (`#[derive(clap::Args)]`) next to
+# the domain struct, retiring the hand-rolled overlays that used to
+# live in `aether-substrate-bundle::cli`. clap rides the `native`
+# feature so wasm builds skip it.
+clap = { workspace = true, optional = true }
 # ADR-0090: typed, layered config resolution. Used by the env-shaped
 # `*Layer` structs (e.g. `HttpConfigLayer`) that back each cap's
 # `*Config::from_env`. `default-features = false` keeps it env-only —

--- a/crates/aether-capabilities/src/anthropic/mod.rs
+++ b/crates/aether-capabilities/src/anthropic/mod.rs
@@ -33,7 +33,7 @@ use crate::contentgen::adapter::{AnthropicAdapter, AnthropicRequest, AnthropicRe
 use crate::config_env::DEFAULT_PROVIDER_MAX_IN_FLIGHT;
 pub use api::UreqAnthropicAdapter;
 pub use cli::ClaudeCliAdapter;
-pub use config::{AnthropicConfig, AnthropicConfigLayer};
+pub use config::{AnthropicConfig, AnthropicConfigLayer, AnthropicOverlay};
 
 /// Default per-cap concurrency bound when `AETHER_ANTHROPIC_MAX_IN_FLIGHT`
 /// is unset. Conservative — paid-endpoint throttling matters more than

--- a/crates/aether-capabilities/src/anthropic/mod.rs
+++ b/crates/aether-capabilities/src/anthropic/mod.rs
@@ -138,18 +138,58 @@ mod config {
     /// `AETHER_ANTHROPIC_MAX_IN_FLIGHT`, `AETHER_ANTHROPIC_TIMEOUT_MS`)
     /// into this and pass it to `with_actor::<AnthropicCapability>(cfg)`.
     /// Tests build it directly so they never read process env.
+    ///
+    /// ADR-0090 unit g (iamacoffeepot/aether#1264): the
+    /// `#[derive(aether_substrate::Config)]` emits the env-shaped
+    /// `AnthropicConfigLayer`, the clap-shaped `AnthropicOverlay`, the
+    /// `FromArgvThenEnv` impl, and the inherent `from_env` shims under
+    /// `feature = "native"`. The wasm-marker build carries only the
+    /// domain struct.
     #[derive(Clone, Debug)]
+    #[cfg_attr(feature = "native", derive(aether_substrate::Config))]
+    #[cfg_attr(
+        feature = "native",
+        config(env_prefix = "AETHER_ANTHROPIC", cli_prefix = "anthropic")
+    )]
     pub struct AnthropicConfig {
         /// The Messages-API key. `None` (or `disabled`) wires the
         /// `DisabledAnthropicAdapter` so Messages requests reply
-        /// `Unauthorized` while the CLI path still works.
+        /// `Unauthorized` while the CLI path still works. `env`
+        /// override pins the unprefixed `ANTHROPIC_API_KEY` key.
+        #[cfg_attr(feature = "native", config(env = "ANTHROPIC_API_KEY"))]
         pub api_key: Option<String>,
         /// `AETHER_ANTHROPIC_DISABLE=1` forces the disabled adapter
-        /// even when a key is present.
+        /// even when a key is present. `env` + `cli_long` overrides
+        /// pin the historical wire shape (no `D` suffix on `DISABLE`).
+        #[cfg_attr(
+            feature = "native",
+            config(
+                env = "AETHER_ANTHROPIC_DISABLE",
+                cli_long = "anthropic-disable",
+                default = false,
+                parse = parse_flag
+            )
+        )]
         pub disabled: bool,
         /// Per-cap concurrency bound (doubles as rate-limit throttling).
+        #[cfg_attr(
+            feature = "native",
+            config(default = 2, parse = parse_provider_max_in_flight)
+        )]
         pub max_in_flight: usize,
-        /// Per-request timeout for the Messages API.
+        /// Per-request timeout for the Messages API. The derive's
+        /// `ms_duration` hint + `layer_field = "timeout_ms"` pin the
+        /// Layer / env / CLI shape to the pre-derive name
+        /// (`AETHER_ANTHROPIC_TIMEOUT_MS`, `--anthropic-timeout-ms`).
+        #[cfg_attr(
+            feature = "native",
+            config(
+                default = 120_000,
+                parse = parse_u32_ms_or::<DEFAULT_TIMEOUT_MS>,
+                ms_duration,
+                layer_field = "timeout_ms"
+            )
+        )]
         pub timeout: Duration,
     }
 
@@ -162,95 +202,6 @@ mod config {
                 timeout: Duration::from_millis(u64::from(DEFAULT_TIMEOUT_MS)),
             }
         }
-    }
-
-    // confique is a `native`-feature dep (ADR-0090), so env resolution —
-    // the layer struct, its parsers, and `from_env` — is gated to match.
-    // The wasm-marker build carries only the `AnthropicConfig` type. (The
-    // `anthropic` module is itself `not(target_arch = "wasm32")`, so the
-    // wasm cross-build never sees this; the `feature = "native"` gate
-    // guards the non-wasm `default-features = false` build.)
-    #[cfg(feature = "native")]
-    impl AnthropicConfig {
-        /// Resolve every field from env. Chassis-main edge only — the
-        /// cap itself never reads env.
-        ///
-        /// Resolution runs through confique (ADR-0090): the private
-        /// `AnthropicConfigLayer` declares each knob's env key + default
-        /// in one place, and this maps the env-shaped layer onto the
-        /// domain-shaped `AnthropicConfig` (ms → `Duration`). Behaviour is
-        /// byte-identical to the prior hand-rolled reader. The hard-error
-        /// stance (ADR-0090 §4) lands with the chassis-env validation pass.
-        ///
-        /// # Panics
-        ///
-        /// Panics only if the layer's literal defaults are themselves
-        /// malformed — a programmer error caught by the
-        /// `anthropic_from_env_defaults_match` test, never a runtime config
-        /// fault (the env values flow through total parsers).
-        #[must_use]
-        pub fn from_env() -> Self {
-            use aether_substrate::FromArgvThenEnv as _;
-            use confique::Config as _;
-
-            let layer = AnthropicConfigLayer::builder()
-                .env()
-                .load()
-                .expect("AnthropicConfigLayer defaults are well-formed");
-            Self::from_layer(layer)
-        }
-
-        // `from_argv_then_env` and `from_layer` come from the
-        // `FromArgvThenEnv` impl below (ADR-0090 unit d).
-    }
-
-    #[cfg(feature = "native")]
-    impl aether_substrate::FromArgvThenEnv for AnthropicConfig {
-        type Layer = AnthropicConfigLayer;
-
-        fn from_layer(layer: AnthropicConfigLayer) -> Self {
-            Self {
-                api_key: layer.api_key.filter(|s| !s.is_empty()),
-                disabled: layer.disabled,
-                max_in_flight: layer.max_in_flight,
-                timeout: Duration::from_millis(u64::from(layer.timeout_ms)),
-            }
-        }
-    }
-
-    /// Env-shaped confique layer behind `AnthropicConfig` (ADR-0090). Each
-    /// field is the primitive its env var carries; `AnthropicConfig::from_env`
-    /// maps them onto the domain types (ms → `Duration`, empty key →
-    /// `None`). Public so chassis CLI overlays (ADR-0090 unit d,
-    /// issue 1258) can preload a `<AnthropicConfigLayer as
-    /// confique::Config>::Layer` before `.env()`; the consumed shape
-    /// stays `AnthropicConfig`.
-    #[cfg(feature = "native")]
-    #[derive(confique::Config)]
-    pub struct AnthropicConfigLayer {
-        /// `ANTHROPIC_API_KEY` (bare, un-prefixed). Empty/unset → `None`
-        /// after the `from_env` filter.
-        #[config(env = "ANTHROPIC_API_KEY")]
-        pub api_key: Option<String>,
-        /// `AETHER_ANTHROPIC_DISABLE=1`/`true` forces the disabled adapter.
-        #[config(env = "AETHER_ANTHROPIC_DISABLE", parse_env = parse_flag, default = false)]
-        pub disabled: bool,
-        /// Per-cap concurrency bound. A non-positive / unparseable value
-        /// falls back to the default (`> 0` filter preserved).
-        #[config(
-            env = "AETHER_ANTHROPIC_MAX_IN_FLIGHT",
-            parse_env = parse_provider_max_in_flight,
-            default = 2
-        )]
-        pub max_in_flight: usize,
-        /// Per-request timeout in milliseconds. Literal default mirrors
-        /// `DEFAULT_TIMEOUT_MS` (120 s).
-        #[config(
-            env = "AETHER_ANTHROPIC_TIMEOUT_MS",
-            parse_env = parse_u32_ms_or::<DEFAULT_TIMEOUT_MS>,
-            default = 120_000
-        )]
-        pub timeout_ms: u32,
     }
 
     #[cfg(all(test, feature = "native"))]

--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -60,7 +60,7 @@ use aether_kinds::{NoteOff, NoteOn, SetMasterGain};
 // the config struct (sends are typed; config is the chassis's
 // concern).
 #[cfg(all(not(target_arch = "wasm32"), feature = "audio-native"))]
-pub use native::{AudioConfig, AudioConfigLayer};
+pub use native::{AudioConfig, AudioConfigLayer, AudioOverlay};
 
 #[aether_actor::bridge(singleton, feature = "audio-native")]
 mod native {

--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -104,87 +104,39 @@ mod native {
     /// env vars (`AETHER_AUDIO_DISABLE`, `AETHER_AUDIO_SAMPLE_RATE`)
     /// into an `AudioConfig` and pass it to `with_actor::<AudioCapability>(cfg)`
     /// (issue 464). Tests build an `AudioConfig` directly.
-    #[derive(Clone, Debug, Default)]
+    ///
+    /// ADR-0090 unit g (iamacoffeepot/aether#1264): the
+    /// `#[derive(aether_substrate::Config)]` emits the env-shaped
+    /// `AudioConfigLayer`, the clap-shaped `AudioOverlay`, the
+    /// `FromArgvThenEnv` impl, and the inherent `from_env` /
+    /// `from_argv_then_env` shims. `requested_sample_rate`'s type
+    /// `Option<u32>` triggers the macro's type-driven
+    /// `Option<numeric>` shape: the Layer holds `Option<String>` and
+    /// `from_layer` does the soft `.parse().ok()` so an unparseable
+    /// value lands as `None` (indistinguishable from unset, matching
+    /// the prior reader).
+    #[derive(Clone, Debug, Default, aether_substrate::Config)]
+    #[config(env_prefix = "AETHER_AUDIO", cli_prefix = "audio")]
     pub struct AudioConfig {
         /// `AETHER_AUDIO_DISABLE=1` skips cpal init entirely. The cap
         /// still claims its mailbox and replies `Err` to `SetMasterGain`
-        /// so agents fail fast instead of hanging.
+        /// so agents fail fast instead of hanging. `env` + `cli_long`
+        /// overrides pin the historical wire shape (no `D` suffix on
+        /// `DISABLE`; `--audio-disable` not `--audio-disabled`).
+        #[config(
+            env = "AETHER_AUDIO_DISABLE",
+            cli_long = "audio-disable",
+            default = false,
+            parse = parse_flag
+        )]
         pub disabled: bool,
         /// `AETHER_AUDIO_SAMPLE_RATE=<hz>` requests a specific rate. If
         /// the device doesn't support it, boot falls back to nop
-        /// (ADR-0039 — non-fatal).
+        /// (ADR-0039 — non-fatal). `layer_field = "sample_rate"` drops
+        /// the `requested_` prefix on the Layer / env / CLI side so the
+        /// historical names are unchanged.
+        #[config(layer_field = "sample_rate", env = "AETHER_AUDIO_SAMPLE_RATE")]
         pub requested_sample_rate: Option<u32>,
-    }
-
-    impl AudioConfig {
-        /// Resolve every field from env. Chassis-main edge only.
-        ///
-        /// Resolution runs through confique (ADR-0090): the private
-        /// `AudioConfigLayer` declares each knob's env key + default in
-        /// one place, and this maps the env-shaped layer onto the
-        /// domain-shaped `AudioConfig`. Behaviour is byte-identical to the
-        /// prior hand-rolled reader — an unparseable sample rate resolves
-        /// to `None` (the field stays optional, so a bad value is
-        /// indistinguishable from unset, matching the prior `.ok()`).
-        ///
-        /// # Panics
-        ///
-        /// Panics only if the layer's literal defaults are themselves
-        /// malformed — a programmer error caught by the
-        /// `audio_from_env_defaults_match` test, never a runtime config
-        /// fault (the env values flow through a total parser / raw capture).
-        #[must_use]
-        pub fn from_env() -> Self {
-            use aether_substrate::FromArgvThenEnv as _;
-            use confique::Config as _;
-
-            let layer = AudioConfigLayer::builder()
-                .env()
-                .load()
-                .expect("AudioConfigLayer defaults are well-formed");
-            Self::from_layer(layer)
-        }
-
-        // `from_argv_then_env` and `from_layer` come from the
-        // `FromArgvThenEnv` impl below (ADR-0090 unit d).
-    }
-
-    impl aether_substrate::FromArgvThenEnv for AudioConfig {
-        type Layer = AudioConfigLayer;
-
-        fn from_layer(layer: AudioConfigLayer) -> Self {
-            Self {
-                disabled: layer.disabled,
-                // Prior behaviour: `.parse::<u32>().ok()` — an unparseable
-                // rate is silently `None`, indistinguishable from unset.
-                // Confique's parse path would *error* on a non-empty bad
-                // value (not byte-identical), so the layer captures the raw
-                // string and the soft `.ok()` parse stays here. The
-                // hard-error stance (ADR-0090 §4) lands later.
-                requested_sample_rate: layer
-                    .requested_sample_rate
-                    .and_then(|s| s.parse::<u32>().ok()),
-            }
-        }
-    }
-
-    /// Env-shaped confique layer behind `AudioConfig` (ADR-0090). Public
-    /// so chassis CLI overlays (ADR-0090 unit d, issue 1258) can preload
-    /// a `<AudioConfigLayer as confique::Config>::Layer` before
-    /// `.env()`; the consumed shape stays `AudioConfig`. Lives inside the
-    /// `audio-native` bridge mod (which implies the `native` feature), so
-    /// confique is always available here.
-    #[derive(confique::Config)]
-    pub struct AudioConfigLayer {
-        /// `AETHER_AUDIO_DISABLE=1`/`true` skips cpal init entirely.
-        #[config(env = "AETHER_AUDIO_DISABLE", parse_env = parse_flag, default = false)]
-        pub disabled: bool,
-        /// `AETHER_AUDIO_SAMPLE_RATE=<hz>` requests a specific rate. Held
-        /// as the raw string so `AudioConfig::from_env` can apply the
-        /// soft `.parse().ok()` (an unparseable value → `None`); a
-        /// confique numeric field would hard-error on bad input instead.
-        #[config(env = "AETHER_AUDIO_SAMPLE_RATE")]
-        pub requested_sample_rate: Option<String>,
     }
 
     /// Event a handler pushes into the audio callback's queue. The
@@ -966,10 +918,14 @@ mod native {
         fn audio_from_env_defaults_match() {
             use confique::Config as _;
             // No `.env()` source: literal defaults only — env-free.
+            // The Layer field is `sample_rate` (the derive's
+            // `layer_field = "sample_rate"` drops the `requested_`
+            // prefix on the wire shape); the domain field stays
+            // `requested_sample_rate`.
             let layer = AudioConfigLayer::builder().load().expect("defaults load");
             let default = AudioConfig::default();
             assert_eq!(layer.disabled, default.disabled);
-            assert_eq!(layer.requested_sample_rate, None);
+            assert_eq!(layer.sample_rate, None);
             assert_eq!(default.requested_sample_rate, None);
         }
 

--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -227,10 +227,49 @@ fn fs_error_from_std(err: io::Error) -> FsError {
 /// chassis reads this at boot, hands each path to a `LocalFileAdapter`,
 /// and registers the result in an `AdapterRegistry` keyed on the
 /// namespace short name (`"save"`, `"assets"`, `"config"`).
+///
+/// ADR-0090 unit g (iamacoffeepot/aether#1264) escape hatch: the
+/// `#[derive(aether_substrate::Config)]` emits the Layer +
+/// `NamespaceRootsOverlay` + inherent `from_env` / `from_argv_then_env`
+/// shims, but `#[config(skip_from_layer)]` opts the cap out of the
+/// auto-generated `FromArgvThenEnv::from_layer`. The hand-written impl
+/// (below, in the `native` bridge mod) applies the runtime-computed
+/// `dirs::data_dir()` / `current_exe()` / `dirs::config_dir()`
+/// fallbacks that confique cannot express as literals. Per-field
+/// `env = "..."` overrides pin the unprefixed `AETHER_*_DIR` env keys.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "native", derive(aether_substrate::Config))]
+#[cfg_attr(
+    feature = "native",
+    config(env_prefix = "AETHER", cli_prefix = "", skip_from_layer)
+)]
 pub struct NamespaceRoots {
+    #[cfg_attr(
+        feature = "native",
+        config(
+            env = "AETHER_SAVE_DIR",
+            cli_long = "save-dir",
+            parse = parse_dir
+        )
+    )]
     pub save: PathBuf,
+    #[cfg_attr(
+        feature = "native",
+        config(
+            env = "AETHER_ASSETS_DIR",
+            cli_long = "assets-dir",
+            parse = parse_dir
+        )
+    )]
     pub assets: PathBuf,
+    #[cfg_attr(
+        feature = "native",
+        config(
+            env = "AETHER_CONFIG_DIR",
+            cli_long = "config-dir",
+            parse = parse_dir
+        )
+    )]
     pub config: PathBuf,
 }
 
@@ -377,13 +416,20 @@ impl FsMailboxExt for NativeActorMailbox<'_, FsCapability> {
     }
 }
 
-/// Re-export the env-shaped confique layer for chassis CLI overlays
-/// (ADR-0090 unit d, issue 1258). The layer lives inside the bridge
-/// `mod native` (cfg-gated); the file-root re-export gives chassis
-/// bins a stable path (`aether_capabilities::fs::NamespaceRootsLayer`)
-/// without reaching into the bridge module.
+// The derive's emitted Layer + Overlay + `from_env` shims live at the
+// file root (same scope as the `NamespaceRoots` struct itself). The
+// `parse_dir` helper they reference must therefore also live at file
+// root; the legacy bridge-mod-local helper is re-exported via the
+// re-export below.
+//
+// The Layer type re-export is no longer needed — the derive emits
+// `NamespaceRootsLayer` at this very scope.
+
+// `parse_dir` is reachable from the derive-emitted Layer fields via
+// the file-root scope. The bridge mod re-exports its definitions
+// (`parse_dir`, `EmptyDir`) so the prior layout doesn't need to move.
 #[cfg(all(not(target_arch = "wasm32"), feature = "native"))]
-pub use native::NamespaceRootsLayer;
+use native::parse_dir;
 
 #[aether_actor::bridge(singleton)]
 mod native {
@@ -391,7 +437,8 @@ mod native {
     use std::sync::Arc;
 
     use super::{
-        AdapterRegistry, Delete, FsError, List, NamespaceRoots, Read, Write, build_registry,
+        AdapterRegistry, Delete, FsError, List, NamespaceRoots, NamespaceRootsLayer, Read, Write,
+        build_registry,
     };
     use aether_actor::{MailCtx, actor};
     use aether_kinds::{DeleteResult, ListResult, ReadResult, WriteResult};
@@ -403,60 +450,22 @@ mod native {
     #[cfg(feature = "native")]
     use std::fmt;
 
-    impl NamespaceRoots {
-        /// Resolve each root from its env-var override, falling back to
-        /// the `dirs`-crate platform default. v1 ships the env layer;
-        /// ADR-0041's precedence order (CLI > env > TOML > defaults)
-        /// leaves room for TOML and CLI to sit in front of this without
-        /// changing the cap or adapter code.
-        ///
-        /// Defaults:
-        /// - `save` → `data_dir()/aether/save`
-        /// - `assets` → `{current_exe}/../assets`
-        /// - `config` → `config_dir()/aether`
-        ///
-        /// If a platform directory lookup fails (e.g. no HOME) or
-        /// `current_exe()` can't resolve, the fallback is `temp_dir()/aether/...`
-        /// so a boot always finishes even on headless CI.
-        ///
-        /// Per issue 464, this is the chassis-main edge — substrate-core
-        /// itself never reads env. The builder
-        /// (`SubstrateBootBuilder::namespace_roots`) accepts a resolved
-        /// `NamespaceRoots` directly so tests and chassis-as-library
-        /// embedders can supply their own roots without process-env
-        /// mutation.
-        ///
-        /// Resolution runs through confique (ADR-0090): the private
-        /// `NamespaceRootsLayer` declares each root's env key. The
-        /// defaults are *computed at runtime* (via the `dirs` crate /
-        /// `current_exe`), not literals, so the layer fields are
-        /// `Option<PathBuf>` (unset / empty env → `None`) and the
-        /// platform fallbacks are applied here — byte-identical to the
-        /// prior `env_or_default` reader.
-        ///
-        /// # Panics
-        ///
-        /// Never in practice: the layer has no literal defaults to
-        /// malform and the only parser (`parse_dir`) errors only on the
-        /// empty string (folded to the runtime fallback). The `.expect`
-        /// guards against a future confique misconfiguration.
-        #[cfg(feature = "native")]
-        #[must_use]
-        pub fn from_env() -> Self {
-            use aether_substrate::FromArgvThenEnv as _;
-            use confique::Config as _;
-
-            let layer = NamespaceRootsLayer::builder()
-                .env()
-                .load()
-                .expect("NamespaceRootsLayer has no literal defaults to malform");
-            Self::from_layer(layer)
-        }
-
-        // `from_argv_then_env` and `from_layer` come from the
-        // `FromArgvThenEnv` impl below (ADR-0090 unit d).
-    }
-
+    /// Hand-written `FromArgvThenEnv` impl for the `NamespaceRoots`
+    /// escape hatch (ADR-0090 unit g, iamacoffeepot/aether#1264). The
+    /// derive's `skip_from_layer` opt-out delegates `from_layer` here
+    /// because the defaults are *runtime-computed*
+    /// (`dirs::data_dir()` / `current_exe()` / `dirs::config_dir()`),
+    /// not literals confique can hold. Behaviour is byte-identical to
+    /// the prior `env_or_default` reader — an unset / empty
+    /// `AETHER_*_DIR` lands as `None` (the macro auto-promotes the
+    /// `PathBuf` domain to `Option<PathBuf>` on the Layer side when no
+    /// literal default is supplied), then the platform fallback
+    /// resolves it here.
+    ///
+    /// On a platform-directory lookup failure (e.g. no `HOME`) or
+    /// `current_exe()` resolution failure, the fallback is
+    /// `temp_dir()/aether/...` so a boot always finishes even on
+    /// headless CI.
     #[cfg(feature = "native")]
     impl aether_substrate::FromArgvThenEnv for NamespaceRoots {
         type Layer = NamespaceRootsLayer;
@@ -487,35 +496,11 @@ mod native {
         }
     }
 
-    /// Env-shaped confique layer behind `NamespaceRoots` (ADR-0090). Each
-    /// root is `Option<PathBuf>` because the defaults are runtime-computed
-    /// (`dirs` / `current_exe`), not literals confique can hold — an
-    /// unset *or empty* env var resolves to `None` and
-    /// `NamespaceRoots::from_env` applies the platform fallback. The
-    /// `parse_dir` parser errors on an empty string so confique treats an
-    /// empty value as unset (matching the prior `env_or_default`).
-    /// Public so chassis CLI overlays (ADR-0090 unit d, issue 1258) can
-    /// preload a `<NamespaceRootsLayer as confique::Config>::Layer`
-    /// before `.env()`; the consumed shape stays `NamespaceRoots`.
-    /// Gated on `feature = "native"`: the enclosing `mod native` is only
-    /// `not(target_arch = "wasm32")`-gated, but confique is a
-    /// `native`-feature dep.
-    #[cfg(feature = "native")]
-    #[derive(confique::Config)]
-    pub struct NamespaceRootsLayer {
-        #[config(env = "AETHER_SAVE_DIR", parse_env = parse_dir)]
-        pub save: Option<PathBuf>,
-        #[config(env = "AETHER_ASSETS_DIR", parse_env = parse_dir)]
-        pub assets: Option<PathBuf>,
-        #[config(env = "AETHER_CONFIG_DIR", parse_env = parse_dir)]
-        pub config: Option<PathBuf>,
-    }
-
     /// Parse a directory override. An empty string errors so confique
     /// treats it as unset (preserving the prior `env_or_default`'s
     /// `Ok(s) if !s.is_empty()` guard); any non-empty value is a path.
     #[cfg(feature = "native")]
-    fn parse_dir(s: &str) -> Result<PathBuf, EmptyDir> {
+    pub(super) fn parse_dir(s: &str) -> Result<PathBuf, EmptyDir> {
         if s.is_empty() {
             Err(EmptyDir)
         } else {
@@ -527,7 +512,7 @@ mod native {
     /// confique's parse path (`Err` + empty → `None`).
     #[cfg(feature = "native")]
     #[derive(Debug)]
-    struct EmptyDir;
+    pub(super) struct EmptyDir;
 
     #[cfg(feature = "native")]
     impl fmt::Display for EmptyDir {

--- a/crates/aether-capabilities/src/gemini/mod.rs
+++ b/crates/aether-capabilities/src/gemini/mod.rs
@@ -32,7 +32,7 @@ use crate::contentgen::adapter::{
 use crate::contentgen::shared;
 
 use crate::config_env::DEFAULT_PROVIDER_MAX_IN_FLIGHT;
-pub use config::{GeminiConfig, GeminiConfigLayer};
+pub use config::{GeminiConfig, GeminiConfigLayer, GeminiOverlay};
 
 /// Default per-cap concurrency bound when `AETHER_GEMINI_MAX_IN_FLIGHT`
 /// is unset. Conservative — image / music generation is multi-second

--- a/crates/aether-capabilities/src/gemini/mod.rs
+++ b/crates/aether-capabilities/src/gemini/mod.rs
@@ -72,16 +72,57 @@ mod config {
     /// `AETHER_GEMINI_MAX_IN_FLIGHT`, `AETHER_GEMINI_TIMEOUT_MS`); the
     /// staging root reads `AETHER_GEN_DIR` at stage time (shared with
     /// issue 1013 / 1014). Tests build it directly.
+    ///
+    /// ADR-0090 unit g (iamacoffeepot/aether#1264): the
+    /// `#[derive(aether_substrate::Config)]` emits the env-shaped
+    /// `GeminiConfigLayer`, the clap-shaped `GeminiOverlay`, the
+    /// `FromArgvThenEnv` impl, and the inherent `from_env` shims under
+    /// `feature = "native"`. The wasm-marker build carries only the
+    /// domain struct.
     #[derive(Clone, Debug)]
+    #[cfg_attr(feature = "native", derive(aether_substrate::Config))]
+    #[cfg_attr(
+        feature = "native",
+        config(env_prefix = "AETHER_GEMINI", cli_prefix = "gemini")
+    )]
     pub struct GeminiConfig {
         /// The Google API key. `None` (or `disabled`) wires the
-        /// `DisabledGeminiAdapter`.
+        /// `DisabledGeminiAdapter`. `env` override pins the unprefixed
+        /// `GEMINI_API_KEY` key.
+        #[cfg_attr(feature = "native", config(env = "GEMINI_API_KEY"))]
         pub api_key: Option<String>,
         /// `AETHER_GEMINI_DISABLE=1` forces the disabled adapter.
+        /// `env` + `cli_long` overrides pin the historical wire shape
+        /// (no `D` suffix on `DISABLE`).
+        #[cfg_attr(
+            feature = "native",
+            config(
+                env = "AETHER_GEMINI_DISABLE",
+                cli_long = "gemini-disable",
+                default = false,
+                parse = parse_flag
+            )
+        )]
         pub disabled: bool,
         /// Per-cap concurrency bound (doubles as rate-limit throttling).
+        #[cfg_attr(
+            feature = "native",
+            config(default = 2, parse = parse_provider_max_in_flight)
+        )]
         pub max_in_flight: usize,
-        /// Per-request timeout for the media APIs.
+        /// Per-request timeout for the media APIs. The derive's
+        /// `ms_duration` hint + `layer_field = "timeout_ms"` pin the
+        /// Layer / env / CLI shape to the pre-derive name
+        /// (`AETHER_GEMINI_TIMEOUT_MS`, `--gemini-timeout-ms`).
+        #[cfg_attr(
+            feature = "native",
+            config(
+                default = 180_000,
+                parse = parse_u32_ms_or::<DEFAULT_TIMEOUT_MS>,
+                ms_duration,
+                layer_field = "timeout_ms"
+            )
+        )]
         pub timeout: Duration,
     }
 
@@ -94,97 +135,6 @@ mod config {
                 timeout: Duration::from_millis(u64::from(DEFAULT_TIMEOUT_MS)),
             }
         }
-    }
-
-    // confique is a `native`-feature dep (ADR-0090), so env resolution —
-    // the layer struct, its parsers, and `from_env` — is gated to match.
-    // The wasm-marker build carries only the `GeminiConfig` type. (The
-    // `gemini` module is itself `not(target_arch = "wasm32")`, so the
-    // wasm cross-build never sees this; the `feature = "native"` gate
-    // guards the non-wasm `default-features = false` build.)
-    #[cfg(feature = "native")]
-    impl GeminiConfig {
-        /// Resolve every field from env. Chassis-main edge only.
-        ///
-        /// Resolution runs through confique (ADR-0090): the private
-        /// `GeminiConfigLayer` declares each knob's env key + default in
-        /// one place, and this maps the env-shaped layer onto the
-        /// domain-shaped `GeminiConfig` (ms → `Duration`). Behaviour is
-        /// byte-identical to the prior hand-rolled reader — an empty key
-        /// resolves to `None`, an unparseable / non-positive
-        /// `max_in_flight` falls back to the default, and an unparseable
-        /// timeout falls back. The hard-error-on-unparseable stance
-        /// (ADR-0090 §4) lands with the chassis-env validation pass.
-        ///
-        /// # Panics
-        ///
-        /// Panics only if the layer's literal defaults are themselves
-        /// malformed — a programmer error caught by the
-        /// `gemini_from_env_defaults_match` test, never a runtime config
-        /// fault (the env values flow through total parsers).
-        #[must_use]
-        pub fn from_env() -> Self {
-            use aether_substrate::FromArgvThenEnv as _;
-            use confique::Config as _;
-
-            let layer = GeminiConfigLayer::builder()
-                .env()
-                .load()
-                .expect("GeminiConfigLayer defaults are well-formed");
-            Self::from_layer(layer)
-        }
-
-        // `from_argv_then_env` and `from_layer` come from the
-        // `FromArgvThenEnv` impl below (ADR-0090 unit d).
-    }
-
-    #[cfg(feature = "native")]
-    impl aether_substrate::FromArgvThenEnv for GeminiConfig {
-        type Layer = GeminiConfigLayer;
-
-        fn from_layer(layer: GeminiConfigLayer) -> Self {
-            Self {
-                api_key: layer.api_key.filter(|s| !s.is_empty()),
-                disabled: layer.disabled,
-                max_in_flight: layer.max_in_flight,
-                timeout: Duration::from_millis(u64::from(layer.timeout_ms)),
-            }
-        }
-    }
-
-    /// Env-shaped confique layer behind `GeminiConfig` (ADR-0090). Each
-    /// field is the primitive its env var carries; `GeminiConfig::from_env`
-    /// maps them onto the domain types (ms → `Duration`, empty key →
-    /// `None`). Public so chassis CLI overlays (ADR-0090 unit d,
-    /// issue 1258) can preload a `<GeminiConfigLayer as
-    /// confique::Config>::Layer` before `.env()`; the consumed shape
-    /// stays `GeminiConfig`.
-    #[cfg(feature = "native")]
-    #[derive(confique::Config)]
-    pub struct GeminiConfigLayer {
-        /// `GEMINI_API_KEY` (bare, un-prefixed). Empty/unset → `None`
-        /// after the `from_env` filter.
-        #[config(env = "GEMINI_API_KEY")]
-        pub api_key: Option<String>,
-        /// `AETHER_GEMINI_DISABLE=1`/`true` forces the disabled adapter.
-        #[config(env = "AETHER_GEMINI_DISABLE", parse_env = parse_flag, default = false)]
-        pub disabled: bool,
-        /// Per-cap concurrency bound. A non-positive / unparseable value
-        /// falls back to the default (`> 0` filter preserved).
-        #[config(
-            env = "AETHER_GEMINI_MAX_IN_FLIGHT",
-            parse_env = parse_provider_max_in_flight,
-            default = 2
-        )]
-        pub max_in_flight: usize,
-        /// Per-request timeout in milliseconds. Literal default mirrors
-        /// `DEFAULT_TIMEOUT_MS` (180 s).
-        #[config(
-            env = "AETHER_GEMINI_TIMEOUT_MS",
-            parse_env = parse_u32_ms_or::<DEFAULT_TIMEOUT_MS>,
-            default = 180_000
-        )]
-        pub timeout_ms: u32,
     }
 
     // confique's `parse_env` contract is `fn(&str) -> Result<T, impl Error>`,

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -85,23 +85,70 @@ impl HttpAdapter for DisabledHttpAdapter {
 /// `AETHER_HTTP_TIMEOUT_MS`) into a `HttpConfig` and pass it to
 /// `HttpCapability::new`. Tests build a `HttpConfig` directly,
 /// never touching process env (issue 464).
+///
+/// ADR-0090 unit g (iamacoffeepot/aether#1264): the
+/// `#[derive(aether_substrate::Config)]` emits the env-shaped
+/// `HttpConfigLayer`, the clap-shaped `HttpOverlay`, the
+/// `FromArgvThenEnv` impl, and the inherent `from_env` /
+/// `from_argv_then_env` shims under `feature = "native"`. The
+/// wasm-marker build carries only the domain struct.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "native", derive(aether_substrate::Config))]
+#[cfg_attr(
+    feature = "native",
+    config(env_prefix = "AETHER_HTTP", cli_prefix = "http")
+)]
 pub struct HttpConfig {
     /// `AETHER_HTTP_DISABLE=1` swaps the `UreqHttpAdapter` for a
     /// `DisabledHttpAdapter` that replies `HttpError::Disabled` to
-    /// every fetch.
+    /// every fetch. `env` + `cli_long` overrides pin the wire shape
+    /// (`AETHER_HTTP_DISABLE`, `--http-disable`) to the pre-derive
+    /// names while the domain field stays `disabled` for read-site
+    /// clarity.
+    #[cfg_attr(
+        feature = "native",
+        config(
+            env = "AETHER_HTTP_DISABLE",
+            cli_long = "http-disable",
+            default = false,
+            parse = parse_flag
+        )
+    )]
     pub disabled: bool,
     /// Hostnames the adapter will dial. Empty = deny all
     /// (deny-by-default per ADR-0043).
+    #[cfg_attr(
+        feature = "native",
+        config(default = [], parse = parse_allowlist, csv_set)
+    )]
     pub allowlist: HashSet<String>,
     /// `AETHER_HTTP_REQUIRE_HTTPS=1` rejects `http://` URLs with
     /// `HttpError::InvalidUrl`.
+    #[cfg_attr(feature = "native", config(default = false, parse = parse_flag))]
     pub require_https: bool,
     /// Cap on inbound and outbound body bytes. Defaults to
     /// [`DEFAULT_MAX_BODY_BYTES`] (16 MB).
+    #[cfg_attr(
+        feature = "native",
+        config(default = 16_777_216, parse = parse_max_body_bytes)
+    )]
     pub max_body_bytes: usize,
     /// Default per-request timeout when `Fetch.timeout_ms` is
-    /// `None`. Defaults to [`DEFAULT_TIMEOUT_MS`] (30 s).
+    /// `None`. Defaults to [`DEFAULT_TIMEOUT_MS`] (30 s). The derive's
+    /// `ms_duration` hint stores the Layer field as `u32`-ms and
+    /// bridges via `Duration::from_millis(u64::from(...))`;
+    /// `layer_field = "timeout_ms"` pins the Layer / env / CLI shape to
+    /// the pre-derive name (`AETHER_HTTP_TIMEOUT_MS`,
+    /// `--http-timeout-ms`) for byte-identical compat.
+    #[cfg_attr(
+        feature = "native",
+        config(
+            default = 30_000,
+            parse = parse_timeout_ms,
+            ms_duration,
+            layer_field = "timeout_ms"
+        )
+    )]
     pub default_timeout: Duration,
 }
 
@@ -115,107 +162,6 @@ impl Default for HttpConfig {
             default_timeout: Duration::from_millis(u64::from(DEFAULT_TIMEOUT_MS)),
         }
     }
-}
-
-// confique is a `native`-feature dep (ADR-0090), so env resolution — the
-// layer struct, its parsers, and `from_env` — is gated to match. The
-// wasm-marker build of this crate carries only the `HttpConfig` type.
-#[cfg(feature = "native")]
-impl HttpConfig {
-    /// Resolve every field from the corresponding `AETHER_HTTP_*`
-    /// environment variable. Used by chassis mains; tests build
-    /// `HttpConfig` directly so they never read process env.
-    ///
-    /// Resolution runs through confique (ADR-0090): the private
-    /// `HttpConfigLayer` declares each knob's env key + default in one
-    /// place, and this maps
-    /// the env-shaped layer onto the domain-shaped `HttpConfig` (ms →
-    /// `Duration`, CSV → `HashSet`). Behaviour is byte-identical to the
-    /// prior hand-rolled reader — an unparseable number still falls back
-    /// to its default. The hard-error-on-unparseable stance (ADR-0090 §4)
-    /// lands with the chassis-env validation pass, not this migration.
-    ///
-    /// # Panics
-    ///
-    /// Panics only if the layer's literal defaults are themselves
-    /// malformed — a programmer error caught by the
-    /// `http_from_env_defaults_match` test, never a runtime config fault
-    /// (the env values flow through total parsers).
-    #[must_use]
-    pub fn from_env() -> Self {
-        use aether_substrate::FromArgvThenEnv as _;
-        use confique::Config as _;
-
-        // Every field has a literal default and a total `parse_env`, so the
-        // layer always resolves; a failure here is a malformed default
-        // literal (a programmer error the `http_from_env_defaults_match`
-        // test catches), not a runtime config fault.
-        let layer = HttpConfigLayer::builder()
-            .env()
-            .load()
-            .expect("HttpConfigLayer defaults are well-formed");
-        Self::from_layer(layer)
-    }
-
-    // `from_argv_then_env` and `from_layer` come from the
-    // `FromArgvThenEnv` impl below (ADR-0090 unit d). Documentation
-    // for the per-cap argv-overlay behaviour lives on the trait method;
-    // call sites use the cap-namespaced form
-    // `HttpConfig::from_argv_then_env(argv)` with the trait imported.
-}
-
-#[cfg(feature = "native")]
-impl aether_substrate::FromArgvThenEnv for HttpConfig {
-    type Layer = HttpConfigLayer;
-
-    fn from_layer(layer: HttpConfigLayer) -> Self {
-        Self {
-            disabled: layer.disabled,
-            allowlist: layer.allowlist,
-            require_https: layer.require_https,
-            max_body_bytes: layer.max_body_bytes,
-            default_timeout: Duration::from_millis(u64::from(layer.timeout_ms)),
-        }
-    }
-}
-
-/// Env-shaped confique layer behind [`HttpConfig`] (ADR-0090). Each field
-/// is the primitive representation its `AETHER_HTTP_*` variable carries —
-/// notably the timeout as `u32` milliseconds and the allowlist as a
-/// comma-separated string parsed into a set — which [`HttpConfig::from_env`]
-/// maps onto the domain types. Public so chassis CLI overlays
-/// (ADR-0090 unit d, issue 1258) can preload a `<HttpConfigLayer as
-/// confique::Config>::Layer` before `.env()`; the consumed shape stays
-/// [`HttpConfig`].
-#[cfg(feature = "native")]
-#[derive(confique::Config)]
-pub struct HttpConfigLayer {
-    /// `AETHER_HTTP_DISABLE=1`/`true` swaps in the disabled adapter.
-    #[config(env = "AETHER_HTTP_DISABLE", parse_env = parse_flag, default = false)]
-    pub disabled: bool,
-    /// Comma-separated hostnames; empty/unset = deny all (ADR-0043).
-    #[config(env = "AETHER_HTTP_ALLOWLIST", parse_env = parse_allowlist, default = [])]
-    pub allowlist: HashSet<String>,
-    /// `AETHER_HTTP_REQUIRE_HTTPS=1`/`true` rejects `http://` URLs.
-    #[config(env = "AETHER_HTTP_REQUIRE_HTTPS", parse_env = parse_flag, default = false)]
-    pub require_https: bool,
-    /// Body cap in bytes. The literal default mirrors
-    /// [`DEFAULT_MAX_BODY_BYTES`] (confique `default` takes a literal, not
-    /// the named const); `http_from_env_defaults_match` guards the match.
-    #[config(
-        env = "AETHER_HTTP_MAX_BODY_BYTES",
-        parse_env = parse_max_body_bytes,
-        default = 16_777_216
-    )]
-    pub max_body_bytes: usize,
-    /// Per-request timeout in milliseconds. Literal default mirrors
-    /// [`DEFAULT_TIMEOUT_MS`] (30 s).
-    #[config(
-        env = "AETHER_HTTP_TIMEOUT_MS",
-        parse_env = parse_timeout_ms,
-        default = 30_000
-    )]
-    pub timeout_ms: u32,
 }
 
 // confique's `parse_env` contract is `fn(&str) -> Result<T, impl Error>`, so

--- a/crates/aether-derive/Cargo.toml
+++ b/crates/aether-derive/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "aether-derive"
+version.workspace = true
+edition.workspace = true
+
+# Engine-wide derive macros that don't fit the actor or data
+# categories. The `Config` derive (ADR-0090 unit g, issue 1264)
+# collapses a cap's domain struct + confique `*Layer` + clap
+# `*Overlay` + `from_layer` mapping into a single `#[derive]`.
+# Re-exported from `aether-substrate::Config` so consumers write
+# `#[derive(aether_substrate::Config)]`.
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }
+
+[dev-dependencies]
+# trybuild compile-pass / compile-fail fixtures under tests/ui/. Each
+# fixture is its own tiny crate; the dev-deps below ride into those.
+trybuild = "1"
+# The macro emits `::aether_substrate::FromArgvThenEnv`-typed impls, so
+# every fixture needs aether-substrate (which itself re-exports the
+# derive). `confique` and `clap` are reached for by the macro's emitted
+# Layer + Overlay structs. Each fixture brings the deps it needs from
+# this set.
+aether-substrate = { path = "../aether-substrate" }
+aether-derive = { path = "." }
+confique = { version = "0.4", default-features = false }
+clap = { version = "4", features = ["derive"] }
+
+[lints]
+workspace = true

--- a/crates/aether-derive/src/config.rs
+++ b/crates/aether-derive/src/config.rs
@@ -1,0 +1,640 @@
+//! `#[derive(aether_substrate::Config)]` — full ADR-0090 quartet
+//! generation (ADR-0090 unit g, iamacoffeepot/aether#1264).
+//!
+//! Architecture: parse the container + per-field attrs into a
+//! `ConfigInput` IR, then quote out four pieces gated on
+//! `#[cfg(feature = "native")]`:
+//!
+//!   1. A `<Name>Layer` struct (`#[derive(confique::Config)]`) carrying
+//!      the wire-shape primitive per field.
+//!   2. An `impl aether_substrate::FromArgvThenEnv for <Name>` whose
+//!      `from_layer` body is assembled from per-field hints.
+//!   3. Inherent `pub fn from_env()` + `pub fn from_argv_then_env(argv)`
+//!      delegating to the trait so call sites needn't import it.
+//!   4. A `<Name>Overlay` struct (`#[derive(clap::Args, ...)]`) with
+//!      `Option<T>` per field + a `pub fn into_layer(self)`.
+//!
+//! The attribute parser is hand-rolled (`Attribute::parse_nested_meta`)
+//! — same pattern as `aether-actor-derive` and `aether-data-derive`,
+//! deliberately no `darling` dep.
+
+use proc_macro::TokenStream;
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use quote::{format_ident, quote};
+use syn::{
+    Attribute, Data, DataStruct, DeriveInput, Expr, Field, Fields, GenericArgument, Ident, LitStr,
+    Path, PathArguments, Type, TypePath, parse_macro_input, spanned::Spanned,
+};
+
+/// Container-level `#[config(env_prefix = "...", cli_prefix = "...")]`.
+struct ContainerAttr {
+    env_prefix: String,
+    cli_prefix: String,
+    /// `#[config(skip_from_layer)]` — opt the cap out of the
+    /// auto-emitted `FromArgvThenEnv` impl when its `from_layer` body
+    /// can't be assembled mechanically (`NamespaceRoots`'s
+    /// runtime-computed defaults). The Layer + Overlay + inherent
+    /// shims still ride the derive; the cap hand-writes the impl.
+    skip_from_layer: bool,
+}
+
+/// Per-field `#[config(...)]` parsing result.
+#[derive(Default)]
+struct FieldAttr {
+    /// `env = "..."` — overrides the prefix-joined env key.
+    env: Option<String>,
+    /// `cli_long = "..."` — overrides the prefix-joined `--cli-flag`
+    /// (the long form). Used when the domain field name doesn't match
+    /// the historical flag (e.g. domain `default_timeout` but the
+    /// chassis flag has shipped as `--http-timeout-ms`). `cli_id` is
+    /// derived from `cli_long` by `s/-/_/g`.
+    cli_long: Option<String>,
+    /// `default = <lit>` — confique default literal expression.
+    default: Option<Expr>,
+    /// `parse = <fn_path>` — confique `parse_env`. Stored as `Path` so
+    /// turbofish (`parse_u32_ms_or::<DEFAULT_TIMEOUT_MS>`) round-trips.
+    parse: Option<Path>,
+    /// `ms_duration` hint — domain field is `Duration`, Layer carries
+    /// `<field>_ms: u32`.
+    ms_duration: bool,
+    /// `csv_set` hint — overlay accepts `Option<String>` and splits CSV.
+    csv_set: bool,
+    /// `layer_field = "..."` — overrides the Layer-side field
+    /// identifier (and the env key derivation if `env` isn't also set).
+    /// Used when the domain name differs from the historical Layer
+    /// shape (e.g. `default_timeout` → Layer field `timeout_ms` not
+    /// `default_timeout_ms`).
+    layer_field: Option<String>,
+}
+
+/// One field's resolved shape after attribute + type-driven inference.
+struct FieldInfo {
+    /// Original field identifier (domain + most Layer field names).
+    ident: Ident,
+    /// Layer field type (often the same as the domain; differs under
+    /// `ms_duration`, `Option<numeric>`).
+    layer_ty: Type,
+    /// Overlay field type (typically `Option<Layer field's inner>`).
+    overlay_ty: Type,
+    /// Layer ident — usually the same as the domain ident; under
+    /// `ms_duration` it's `<field>_ms`.
+    layer_ident: Ident,
+    /// `from_layer` body fragment that constructs this domain field.
+    /// `field_name: <expr from layer>`.
+    from_layer_expr: TokenStream2,
+    /// Attribute fragments for the Layer field (`#[config(env = …, parse_env = …, default = …)]`).
+    layer_attrs: TokenStream2,
+    /// Attribute fragments for the Overlay field (`#[arg(id = …, long = …, …)]`).
+    overlay_attrs: TokenStream2,
+    /// `into_layer` body fragment that pushes this overlay field into
+    /// the partial layer (`if let Some(v) = self.foo { layer.bar = Some(v); }`).
+    into_layer_stmt: TokenStream2,
+}
+
+pub fn derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match expand(&input) {
+        Ok(ts) => ts.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
+    let container = parse_container_attr(&input.attrs)?;
+    let domain_ident = &input.ident;
+    let layer_ident = format_ident!("{}Layer", domain_ident);
+    let overlay_ident = format_ident!(
+        "{}Overlay",
+        // Strip the trailing `Config` so `HttpConfig` → `HttpOverlay`.
+        // `NamespaceRoots` (no `Config` suffix) stays `NamespaceRootsOverlay`.
+        domain_ident
+            .to_string()
+            .strip_suffix("Config")
+            .unwrap_or(&domain_ident.to_string())
+    );
+    let vis = &input.vis;
+
+    let fields = collect_fields(input, &container)?;
+
+    let layer_struct = emit_layer_struct(&layer_ident, vis, &fields);
+    let trait_impl = if container.skip_from_layer {
+        TokenStream2::new()
+    } else {
+        emit_trait_impl(domain_ident, &layer_ident, &fields)
+    };
+    let inherent_impl = emit_inherent_impl(domain_ident, &layer_ident);
+    let overlay_struct = emit_overlay_struct(&overlay_ident, &layer_ident, vis, &fields);
+
+    Ok(quote! {
+        #layer_struct
+        #trait_impl
+        #inherent_impl
+        #overlay_struct
+    })
+}
+
+fn parse_container_attr(attrs: &[Attribute]) -> syn::Result<ContainerAttr> {
+    let mut env_prefix: Option<String> = None;
+    let mut cli_prefix: Option<String> = None;
+    let mut skip_from_layer = false;
+
+    for attr in attrs {
+        if !attr.path().is_ident("config") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("env_prefix") {
+                env_prefix = Some(meta.value()?.parse::<LitStr>()?.value());
+                Ok(())
+            } else if meta.path.is_ident("cli_prefix") {
+                cli_prefix = Some(meta.value()?.parse::<LitStr>()?.value());
+                Ok(())
+            } else if meta.path.is_ident("skip_from_layer") {
+                skip_from_layer = true;
+                Ok(())
+            } else {
+                Err(meta.error(
+                    "unknown container attribute; expected one of \
+                     `env_prefix = \"...\"`, `cli_prefix = \"...\"`, \
+                     `skip_from_layer`",
+                ))
+            }
+        })?;
+    }
+
+    let env_prefix = env_prefix.ok_or_else(|| {
+        let span = attrs.first().map_or_else(Span::call_site, Spanned::span);
+        syn::Error::new(
+            span,
+            "missing `#[config(env_prefix = \"...\")]` container attribute",
+        )
+    })?;
+    let cli_prefix = cli_prefix.ok_or_else(|| {
+        let span = attrs.first().map_or_else(Span::call_site, Spanned::span);
+        syn::Error::new(
+            span,
+            "missing `#[config(cli_prefix = \"...\")]` container attribute",
+        )
+    })?;
+
+    Ok(ContainerAttr {
+        env_prefix,
+        cli_prefix,
+        skip_from_layer,
+    })
+}
+
+fn parse_field_attr(attrs: &[Attribute]) -> syn::Result<FieldAttr> {
+    let mut out = FieldAttr::default();
+    for attr in attrs {
+        if !attr.path().is_ident("config") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("env") {
+                out.env = Some(meta.value()?.parse::<LitStr>()?.value());
+                Ok(())
+            } else if meta.path.is_ident("cli_long") {
+                out.cli_long = Some(meta.value()?.parse::<LitStr>()?.value());
+                Ok(())
+            } else if meta.path.is_ident("default") {
+                out.default = Some(meta.value()?.parse::<Expr>()?);
+                Ok(())
+            } else if meta.path.is_ident("parse") {
+                out.parse = Some(meta.value()?.parse::<Path>()?);
+                Ok(())
+            } else if meta.path.is_ident("ms_duration") {
+                out.ms_duration = true;
+                Ok(())
+            } else if meta.path.is_ident("csv_set") {
+                out.csv_set = true;
+                Ok(())
+            } else if meta.path.is_ident("layer_field") {
+                out.layer_field = Some(meta.value()?.parse::<LitStr>()?.value());
+                Ok(())
+            } else {
+                Err(meta.error(
+                    "unknown field attribute; expected one of \
+                     `env = \"...\"`, `cli_long = \"...\"`, `default = <lit>`, \
+                     `parse = <fn_path>`, `ms_duration`, `csv_set`, \
+                     `layer_field = \"...\"`",
+                ))
+            }
+        })?;
+    }
+    Ok(out)
+}
+
+fn collect_fields(input: &DeriveInput, container: &ContainerAttr) -> syn::Result<Vec<FieldInfo>> {
+    let Data::Struct(DataStruct { fields, .. }) = &input.data else {
+        return Err(syn::Error::new_spanned(
+            &input.ident,
+            "`#[derive(Config)]` only supports structs with named fields",
+        ));
+    };
+    let Fields::Named(named) = fields else {
+        return Err(syn::Error::new_spanned(
+            fields,
+            "`#[derive(Config)]` only supports structs with named fields",
+        ));
+    };
+
+    named
+        .named
+        .iter()
+        .map(|f| field_info(f, container))
+        .collect()
+}
+
+fn field_info(field: &Field, container: &ContainerAttr) -> syn::Result<FieldInfo> {
+    let ident = field
+        .ident
+        .clone()
+        .expect("checked by `collect_fields` — named struct");
+    let attr = parse_field_attr(&field.attrs)?;
+    let domain_ty = field.ty.clone();
+    let span = field.span();
+
+    if attr.ms_duration && !is_duration_type(&domain_ty) {
+        return Err(syn::Error::new(
+            span,
+            "`ms_duration` hint requires field type `std::time::Duration`",
+        ));
+    }
+
+    let is_bool = is_bool_type(&domain_ty);
+    let inner_option_ty = unwrap_option(&domain_ty);
+    // Whether this is `Option<numeric>` whose Layer rep is `Option<String>`.
+    let is_option_numeric = inner_option_ty.as_ref().is_some_and(is_numeric_type);
+    let is_option_string = inner_option_ty
+        .as_ref()
+        .is_some_and(|t| matches!(t, Type::Path(tp) if path_is(&tp.path, "String")));
+
+    // Layer ident:
+    //   - `layer_field = "..."` override always wins.
+    //   - else `ms_duration` renames to `<field>_ms`.
+    //   - else same as domain ident.
+    let layer_ident = if let Some(name) = &attr.layer_field {
+        Ident::new(name, span)
+    } else if attr.ms_duration {
+        format_ident!("{}_ms", ident)
+    } else {
+        ident.clone()
+    };
+
+    // Layer field type:
+    // - `ms_duration` → `u32`
+    // - `Option<numeric>` → `Option<String>` (preserves soft-parse on bad input)
+    // - everything else → domain type
+    //
+    // The `Option<...>` shape is the bare identifier (not the
+    // ::core::option::Option absolute path) — `clap`'s `Args` derive
+    // detects optionality by matching the literal `Option` segment in
+    // the field type. An absolute path defeats that match and clap
+    // tries to value-parse the whole `Option<T>` (which never works).
+    let layer_ty: Type = if attr.ms_duration {
+        syn::parse_quote!(u32)
+    } else if is_option_numeric {
+        syn::parse_quote!(Option<String>)
+    } else {
+        domain_ty.clone()
+    };
+
+    // Overlay field type — `Option<inner of layer or domain>`:
+    // - `ms_duration` → `Option<u32>`
+    // - `Option<T>` (already optional) → `Option<T>` keeps T
+    // - `csv_set` → `Option<String>`
+    // - bool → `Option<bool>`
+    // - other → `Option<T>`
+    let overlay_ty: Type = if attr.ms_duration {
+        syn::parse_quote!(Option<u32>)
+    } else if attr.csv_set {
+        syn::parse_quote!(Option<String>)
+    } else if inner_option_ty.is_some() {
+        // domain is already `Option<X>` — the overlay slot is the same
+        // `Option<X>` (the env-side soft `Option<String>` is internal
+        // to the Layer; on the argv side the value is already typed).
+        domain_ty.clone()
+    } else {
+        let inner = &domain_ty;
+        syn::parse_quote!(Option<#inner>)
+    };
+
+    // Env key: explicit `env` override > layer-ident-derived
+    //   `<PREFIX>_<LAYER_IDENT_UPPER>` > domain-ident-derived
+    //   `<PREFIX>_<DOMAIN_IDENT_UPPER>`. The layer-ident path covers
+    //   the common `ms_duration` shape so the env key follows the
+    //   stored-as-ms convention without an explicit override.
+    let env_key = attr
+        .env
+        .clone()
+        .unwrap_or_else(|| format!("{}_{}", container.env_prefix, layer_ident).to_uppercase());
+    // CLI flag: explicit `cli_long` override > prefix-joined
+    //   layer-ident. Using the layer ident (rather than the domain
+    //   ident) keeps the flag honest about the wire shape — the user
+    //   typing `--http-timeout-ms 5000` is setting the millisecond
+    //   knob, not the `Duration`.
+    let cli_long = attr.cli_long.clone().unwrap_or_else(|| {
+        format!(
+            "{}-{}",
+            container.cli_prefix,
+            layer_ident.to_string().replace('_', "-")
+        )
+    });
+    let cli_id = cli_long.replace('-', "_");
+
+    let layer_attrs = build_layer_attrs(&env_key, attr.default.as_ref(), attr.parse.as_ref());
+    let overlay_attrs = build_overlay_attrs(&cli_id, &cli_long, is_bool);
+
+    let from_layer_expr = build_from_layer_expr(
+        &ident,
+        &layer_ident,
+        &domain_ty,
+        attr.ms_duration,
+        is_option_string,
+        is_option_numeric,
+    );
+    let into_layer_stmt =
+        build_into_layer_stmt(&ident, &layer_ident, attr.csv_set, is_option_numeric);
+
+    Ok(FieldInfo {
+        ident,
+        layer_ty,
+        overlay_ty,
+        layer_ident,
+        from_layer_expr,
+        layer_attrs,
+        overlay_attrs,
+        into_layer_stmt,
+    })
+}
+
+fn build_layer_attrs(env_key: &str, default: Option<&Expr>, parse: Option<&Path>) -> TokenStream2 {
+    let mut inner = TokenStream2::new();
+    inner.extend(quote! { env = #env_key });
+    if let Some(parse) = parse {
+        inner.extend(quote! { , parse_env = #parse });
+    }
+    if let Some(default) = default {
+        inner.extend(quote! { , default = #default });
+    }
+    quote! { #[config(#inner)] }
+}
+
+fn build_overlay_attrs(cli_id: &str, cli_long: &str, is_bool: bool) -> TokenStream2 {
+    if is_bool {
+        quote! {
+            #[arg(
+                id = #cli_id,
+                long = #cli_long,
+                num_args = 0..=1,
+                default_missing_value = "true"
+            )]
+        }
+    } else {
+        quote! {
+            #[arg(id = #cli_id, long = #cli_long)]
+        }
+    }
+}
+
+fn build_from_layer_expr(
+    domain_ident: &Ident,
+    layer_ident: &Ident,
+    domain_ty: &Type,
+    ms_duration: bool,
+    is_option_string: bool,
+    is_option_numeric: bool,
+) -> TokenStream2 {
+    if ms_duration {
+        // Domain stays the domain ident; layer is `<ident>_ms`.
+        quote! {
+            #domain_ident: ::std::time::Duration::from_millis(::core::convert::From::from(layer.#layer_ident))
+        }
+    } else if is_option_string {
+        // `Option<String>` — empty string ≡ unset.
+        quote! {
+            #domain_ident: layer.#layer_ident.filter(|s| !s.is_empty())
+        }
+    } else if is_option_numeric {
+        // Layer holds `Option<String>`; parse softly here.
+        let inner = unwrap_option(domain_ty).expect("checked is_option_numeric");
+        quote! {
+            #domain_ident: layer.#layer_ident.and_then(|s| s.parse::<#inner>().ok())
+        }
+    } else {
+        quote! {
+            #domain_ident: layer.#layer_ident
+        }
+    }
+}
+
+fn build_into_layer_stmt(
+    domain_ident: &Ident,
+    layer_ident: &Ident,
+    csv_set: bool,
+    is_option_numeric: bool,
+) -> TokenStream2 {
+    if csv_set {
+        // Overlay value is `Option<String>` — split CSV into a `HashSet`.
+        quote! {
+            if let ::core::option::Option::Some(s) = self.#domain_ident {
+                let set: ::std::collections::HashSet<::std::string::String> = s
+                    .split(',')
+                    .map(::core::primitive::str::trim)
+                    .filter(|h| !h.is_empty())
+                    .map(::core::primitive::str::to_string)
+                    .collect();
+                layer.#layer_ident = ::core::option::Option::Some(set);
+            }
+        }
+    } else if is_option_numeric {
+        // Layer slot is `Option<String>` — stringify the typed argv.
+        quote! {
+            if let ::core::option::Option::Some(v) = self.#domain_ident {
+                layer.#layer_ident = ::core::option::Option::Some(::std::string::ToString::to_string(&v));
+            }
+        }
+    } else {
+        quote! {
+            if let ::core::option::Option::Some(v) = self.#domain_ident {
+                layer.#layer_ident = ::core::option::Option::Some(v);
+            }
+        }
+    }
+}
+
+fn emit_layer_struct(
+    layer_ident: &Ident,
+    vis: &syn::Visibility,
+    fields: &[FieldInfo],
+) -> TokenStream2 {
+    let field_decls = fields.iter().map(|f| {
+        let attrs = &f.layer_attrs;
+        let ident = &f.layer_ident;
+        let ty = &f.layer_ty;
+        quote! {
+            #attrs
+            #vis #ident: #ty,
+        }
+    });
+    quote! {
+        #[derive(::confique::Config)]
+        #vis struct #layer_ident {
+            #(#field_decls)*
+        }
+    }
+}
+
+fn emit_trait_impl(
+    domain_ident: &Ident,
+    layer_ident: &Ident,
+    fields: &[FieldInfo],
+) -> TokenStream2 {
+    let body = fields.iter().map(|f| &f.from_layer_expr);
+    quote! {
+        impl ::aether_substrate::FromArgvThenEnv for #domain_ident {
+            type Layer = #layer_ident;
+
+            fn from_layer(layer: #layer_ident) -> Self {
+                Self {
+                    #( #body, )*
+                }
+            }
+        }
+    }
+}
+
+fn emit_inherent_impl(domain_ident: &Ident, layer_ident: &Ident) -> TokenStream2 {
+    quote! {
+        impl #domain_ident {
+            /// Resolve every field from `AETHER_*` (or per-field override)
+            /// env vars. Chassis-main edge only — substrate-core never
+            /// reads process env (issue 464).
+            ///
+            /// # Panics
+            ///
+            /// Panics only if the layer's literal defaults are themselves
+            /// malformed — a programmer error caught by the cap's
+            /// `*_defaults_match` test, never a runtime config fault
+            /// (env values flow through total parsers).
+            #[must_use]
+            pub fn from_env() -> Self {
+                use ::aether_substrate::FromArgvThenEnv as _;
+                use ::confique::Config as _;
+
+                let layer = #layer_ident::builder()
+                    .env()
+                    .load()
+                    .expect(concat!(stringify!(#layer_ident), " defaults are well-formed"));
+                <Self as ::aether_substrate::FromArgvThenEnv>::from_layer(layer)
+            }
+
+            /// Resolve with an argv-derived partial layer shadowing
+            /// `AETHER_*` env (ADR-0090 unit d). Argv-set fields win;
+            /// unset (`None`) fall through to env, then literal defaults.
+            ///
+            /// # Panics
+            ///
+            /// Same condition as [`Self::from_env`].
+            #[must_use]
+            pub fn from_argv_then_env(
+                argv: <#layer_ident as ::confique::Config>::Layer,
+            ) -> Self {
+                <Self as ::aether_substrate::FromArgvThenEnv>::from_argv_then_env(argv)
+            }
+        }
+    }
+}
+
+fn emit_overlay_struct(
+    overlay_ident: &Ident,
+    layer_ident: &Ident,
+    vis: &syn::Visibility,
+    fields: &[FieldInfo],
+) -> TokenStream2 {
+    let field_decls = fields.iter().map(|f| {
+        let attrs = &f.overlay_attrs;
+        let ident = &f.ident;
+        let ty = &f.overlay_ty;
+        quote! {
+            #attrs
+            #vis #ident: #ty,
+        }
+    });
+    let into_layer_stmts = fields.iter().map(|f| &f.into_layer_stmt);
+    quote! {
+        #[derive(::clap::Args, ::core::fmt::Debug, ::core::default::Default, ::core::clone::Clone)]
+        #vis struct #overlay_ident {
+            #(#field_decls)*
+        }
+
+        impl #overlay_ident {
+            /// Write argv-set fields into a fresh partial layer. `None`
+            /// → partial `None` (env / default takes over); `Some(v)` →
+            /// partial `Some(v)`.
+            #[must_use]
+            pub fn into_layer(self) -> <#layer_ident as ::confique::Config>::Layer {
+                use ::confique::Layer as _;
+                let mut layer = <<#layer_ident as ::confique::Config>::Layer as ::confique::Layer>::empty();
+                #( #into_layer_stmts )*
+                layer
+            }
+        }
+    }
+}
+
+fn is_duration_type(ty: &Type) -> bool {
+    if let Type::Path(TypePath { path, .. }) = ty {
+        return path.segments.last().is_some_and(|s| s.ident == "Duration");
+    }
+    false
+}
+
+fn is_bool_type(ty: &Type) -> bool {
+    if let Type::Path(TypePath { path, .. }) = ty {
+        return path_is(path, "bool");
+    }
+    false
+}
+
+fn is_numeric_type(ty: &Type) -> bool {
+    if let Type::Path(TypePath { path, .. }) = ty
+        && let Some(seg) = path.segments.last()
+    {
+        let name = seg.ident.to_string();
+        return matches!(
+            name.as_str(),
+            "u8" | "u16"
+                | "u32"
+                | "u64"
+                | "u128"
+                | "usize"
+                | "i8"
+                | "i16"
+                | "i32"
+                | "i64"
+                | "i128"
+                | "isize"
+                | "f32"
+                | "f64"
+        );
+    }
+    false
+}
+
+fn unwrap_option(ty: &Type) -> Option<Type> {
+    if let Type::Path(TypePath { path, .. }) = ty
+        && let Some(seg) = path.segments.last()
+        && seg.ident == "Option"
+        && let PathArguments::AngleBracketed(args) = &seg.arguments
+        && let Some(GenericArgument::Type(inner)) = args.args.first()
+    {
+        return Some(inner.clone());
+    }
+    None
+}
+
+fn path_is(path: &Path, name: &str) -> bool {
+    path.segments.last().is_some_and(|s| s.ident == name)
+}

--- a/crates/aether-derive/src/config.rs
+++ b/crates/aether-derive/src/config.rs
@@ -285,6 +285,10 @@ fn field_info(field: &Field, container: &ContainerAttr) -> syn::Result<FieldInfo
     // Layer field type:
     // - `ms_duration` → `u32`
     // - `Option<numeric>` → `Option<String>` (preserves soft-parse on bad input)
+    // - non-Option domain *without* a literal `default` → `Option<T>`
+    //   (confique requires either a default or `Option` — used by the
+    //   NamespaceRoots escape hatch where `dirs::data_dir()` defaults
+    //   are computed at runtime and the cap hand-writes `from_layer`).
     // - everything else → domain type
     //
     // The `Option<...>` shape is the bare identifier (not the
@@ -296,6 +300,9 @@ fn field_info(field: &Field, container: &ContainerAttr) -> syn::Result<FieldInfo
         syn::parse_quote!(u32)
     } else if is_option_numeric {
         syn::parse_quote!(Option<String>)
+    } else if inner_option_ty.is_none() && attr.default.is_none() {
+        let inner = &domain_ty;
+        syn::parse_quote!(Option<#inner>)
     } else {
         domain_ty.clone()
     };

--- a/crates/aether-derive/src/lib.rs
+++ b/crates/aether-derive/src/lib.rs
@@ -1,0 +1,73 @@
+//! Engine-wide derive macros (ADR-0090 unit g, iamacoffeepot/aether#1264).
+//!
+//! The `Config` derive collapses a cap's domain struct + confique
+//! `*Layer` + clap `*Overlay` + `from_layer` mapping into one
+//! `#[derive(aether_substrate::Config)]` annotation. Re-exported from
+//! `aether-substrate::Config`; downstream callers write the
+//! `aether_substrate::Config` path rather than reaching in here.
+//!
+//! Crate skeleton — the actual emission lives in subsequent commits.
+
+use proc_macro::TokenStream;
+
+mod config;
+
+/// Derive macro that turns a cap's resolved-config struct into the full
+/// ADR-0090 quartet (Layer / Overlay / `FromArgvThenEnv` /
+/// inherent `from_env` + `from_argv_then_env`).
+///
+/// ## Container attribute (required)
+///
+/// ```ignore
+/// #[config(env_prefix = "AETHER_HTTP", cli_prefix = "http")]
+/// ```
+///
+/// `env_prefix` joins with the upper-snake field name to form the env
+/// key (`AETHER_HTTP_TIMEOUT_MS`). Override per-field via `env = "..."`
+/// for unprefixed keys (`GEMINI_API_KEY`). `cli_prefix` joins with the
+/// hyphen-lower field name to form the long flag (`--http-timeout-ms`).
+///
+/// ## Field attributes
+///
+/// - `#[config(default = <lit>)]` — confique default literal.
+/// - `#[config(parse = <fn_path>)]` — confique `parse_env` function;
+///   turbofish-bearing paths are supported (`parse_u32_ms_or::<DEFAULT_TIMEOUT_MS>`).
+/// - `#[config(ms_duration)]` — domain field is `Duration`; Layer
+///   carries `<field>_ms: u32`; `from_layer` does the millis → Duration
+///   map.
+/// - `#[config(csv_set)]` — domain + Layer share `HashSet<String>`;
+///   overlay carries `Option<String>` and splits CSV inline.
+/// - `#[config(env = "...")]` — per-field env-name override (used for
+///   un-prefixed keys like `GEMINI_API_KEY`).
+///
+/// ## Type-driven emission (no explicit hint)
+///
+/// - `Option<String>` — `from_layer` always applies `.filter(|s| !s.is_empty())`
+///   (empty env ≡ unset).
+/// - `Option<<numeric>>` — Layer holds `Option<String>`; `from_layer`
+///   does a soft `.parse().ok()` to preserve the prior
+///   indistinguishable-from-unset semantics for unparseable values.
+///
+/// ## Cfg gating
+///
+/// The macro emits Layer + Overlay + `FromArgvThenEnv` impl + inherent
+/// shims **unconditionally**. Cap authors who want the emission to ride
+/// a `native` feature (so wasm builds skip confique + clap entirely)
+/// wrap the derive in `#[cfg_attr(feature = "native", derive(...))]`
+/// instead of `#[derive(...)]`. The domain struct itself stays
+/// unconditional.
+///
+/// ## Escape hatch
+///
+/// `NamespaceRoots` (`aether-capabilities::fs`) carries runtime-computed
+/// defaults (`dirs::data_dir()` / `current_exe()`) that confique cannot
+/// express as literals. The cap declares `#[config(skip_from_layer)]`
+/// at the container level — the derive emits the Layer + Overlay +
+/// inherent shims, but skips the `FromArgvThenEnv` impl so the cap can
+/// hand-write the `from_layer` body with the runtime fallbacks. This
+/// is an exception, not a general feature — every other cap uses the
+/// auto-emitted `from_layer`.
+#[proc_macro_derive(Config, attributes(config))]
+pub fn derive_config(input: TokenStream) -> TokenStream {
+    config::derive(input)
+}

--- a/crates/aether-derive/tests/expand.rs
+++ b/crates/aether-derive/tests/expand.rs
@@ -1,0 +1,19 @@
+//! `#[derive(Config)]` trybuild fixtures (ADR-0090 unit g,
+//! iamacoffeepot/aether#1264).
+//!
+//! Pattern mirrors `aether-data-derive/tests/transform.rs`: a single
+//! entry point that hands the `tests/ui/` directory to `trybuild`. The
+//! per-fixture `.rs` files exercise the macro's accept/reject surface;
+//! each compile-fail fixture pairs with a `.stderr` checked-in alongside.
+
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/ui/accepts_minimal.rs");
+    t.pass("tests/ui/accepts_full_http.rs");
+    t.pass("tests/ui/accepts_optional_field.rs");
+    t.pass("tests/ui/accepts_ms_duration.rs");
+    t.compile_fail("tests/ui/rejects_ms_duration_on_non_duration.rs");
+    t.compile_fail("tests/ui/rejects_missing_env_prefix.rs");
+    t.compile_fail("tests/ui/rejects_unknown_hint.rs");
+}

--- a/crates/aether-derive/tests/ui/accepts_full_http.rs
+++ b/crates/aether-derive/tests/ui/accepts_full_http.rs
@@ -1,0 +1,51 @@
+//! Full-surface accept: a copy of `HttpConfig`'s field shape, proving
+//! the derive handles `bool`, `HashSet<String>` (csv_set), `usize`,
+//! and `Duration` (ms_duration) in one go.
+
+use std::collections::HashSet;
+use std::convert::Infallible;
+use std::time::Duration;
+
+pub const DEFAULT_MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
+pub const DEFAULT_TIMEOUT_MS: u32 = 30_000;
+
+#[allow(clippy::unnecessary_wraps)]
+fn parse_flag(s: &str) -> Result<bool, Infallible> {
+    Ok(s == "1" || s.eq_ignore_ascii_case("true"))
+}
+
+#[allow(clippy::unnecessary_wraps)]
+fn parse_allowlist(s: &str) -> Result<HashSet<String>, Infallible> {
+    Ok(s.split(',')
+        .map(str::trim)
+        .filter(|h| !h.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+#[allow(clippy::unnecessary_wraps)]
+fn parse_max_body_bytes(s: &str) -> Result<usize, Infallible> {
+    Ok(s.parse().unwrap_or(DEFAULT_MAX_BODY_BYTES))
+}
+
+#[allow(clippy::unnecessary_wraps)]
+fn parse_timeout_ms(s: &str) -> Result<u32, Infallible> {
+    Ok(s.parse().unwrap_or(DEFAULT_TIMEOUT_MS))
+}
+
+#[derive(aether_derive::Config)]
+#[config(env_prefix = "AETHER_HTTP", cli_prefix = "http")]
+pub struct HttpConfig {
+    #[config(default = false, parse = parse_flag)]
+    pub disabled: bool,
+    #[config(default = [], parse = parse_allowlist, csv_set)]
+    pub allowlist: HashSet<String>,
+    #[config(default = false, parse = parse_flag)]
+    pub require_https: bool,
+    #[config(default = 16_777_216, parse = parse_max_body_bytes)]
+    pub max_body_bytes: usize,
+    #[config(default = 30_000, parse = parse_timeout_ms, ms_duration)]
+    pub default_timeout: Duration,
+}
+
+fn main() {}

--- a/crates/aether-derive/tests/ui/accepts_minimal.rs
+++ b/crates/aether-derive/tests/ui/accepts_minimal.rs
@@ -1,0 +1,20 @@
+//! Minimal accept case: one numeric field, container with both
+//! prefixes, a `default` + `parse` pass-through. Proves the
+//! happy-path Layer + Overlay + impls compile and the `parse_env`
+//! turbofish-free shape works.
+
+use std::convert::Infallible;
+
+#[allow(clippy::unnecessary_wraps)]
+fn identity_fn(s: &str) -> Result<u32, Infallible> {
+    Ok(s.parse().unwrap_or(0))
+}
+
+#[derive(aether_derive::Config)]
+#[config(env_prefix = "AETHER_MIN", cli_prefix = "min")]
+pub struct MinimalConfig {
+    #[config(default = 0, parse = identity_fn)]
+    pub value: u32,
+}
+
+fn main() {}

--- a/crates/aether-derive/tests/ui/accepts_ms_duration.rs
+++ b/crates/aether-derive/tests/ui/accepts_ms_duration.rs
@@ -1,0 +1,22 @@
+//! `ms_duration` hint: domain field `Duration`, Layer field `<n>_ms: u32`.
+//! The macro emits the `Duration::from_millis(u64::from(layer.<n>_ms))`
+//! bridge in `from_layer` automatically.
+
+use std::convert::Infallible;
+use std::time::Duration;
+
+pub const DEFAULT_TIMEOUT_MS: u32 = 30_000;
+
+#[allow(clippy::unnecessary_wraps)]
+fn parse_timeout_ms(s: &str) -> Result<u32, Infallible> {
+    Ok(s.parse().unwrap_or(DEFAULT_TIMEOUT_MS))
+}
+
+#[derive(aether_derive::Config)]
+#[config(env_prefix = "AETHER_MS", cli_prefix = "ms")]
+pub struct MsDurationConfig {
+    #[config(default = 30_000, parse = parse_timeout_ms, ms_duration)]
+    pub timeout: Duration,
+}
+
+fn main() {}

--- a/crates/aether-derive/tests/ui/accepts_optional_field.rs
+++ b/crates/aether-derive/tests/ui/accepts_optional_field.rs
@@ -1,0 +1,12 @@
+//! `Option<String>` — type-driven empty-string ≡ unset behavior. The
+//! `env = "..."` per-field override pins an unprefixed env key (the
+//! shape `GEMINI_API_KEY` / `ANTHROPIC_API_KEY` use in the real caps).
+
+#[derive(aether_derive::Config)]
+#[config(env_prefix = "AETHER_OPT", cli_prefix = "opt")]
+pub struct OptionalConfig {
+    #[config(env = "SOME_BARE_KEY")]
+    pub api_key: Option<String>,
+}
+
+fn main() {}

--- a/crates/aether-derive/tests/ui/rejects_missing_env_prefix.rs
+++ b/crates/aether-derive/tests/ui/rejects_missing_env_prefix.rs
@@ -1,0 +1,11 @@
+//! Container attribute `env_prefix` is mandatory. Omitting it (here
+//! the container only declares `cli_prefix`) is a deterministic
+//! compile-error.
+
+#[derive(aether_derive::Config)]
+#[config(cli_prefix = "missing")]
+pub struct MissingPrefixConfig {
+    pub value: u32,
+}
+
+fn main() {}

--- a/crates/aether-derive/tests/ui/rejects_missing_env_prefix.stderr
+++ b/crates/aether-derive/tests/ui/rejects_missing_env_prefix.stderr
@@ -1,0 +1,5 @@
+error: missing `#[config(env_prefix = "...")]` container attribute
+ --> tests/ui/rejects_missing_env_prefix.rs:6:1
+  |
+6 | #[config(cli_prefix = "missing")]
+  | ^

--- a/crates/aether-derive/tests/ui/rejects_ms_duration_on_non_duration.rs
+++ b/crates/aether-derive/tests/ui/rejects_ms_duration_on_non_duration.rs
@@ -1,0 +1,11 @@
+//! `ms_duration` is only valid on a `Duration` field — applying it to
+//! a `u32` is a programmer error caught at expansion time.
+
+#[derive(aether_derive::Config)]
+#[config(env_prefix = "AETHER_BAD", cli_prefix = "bad")]
+pub struct BadConfig {
+    #[config(default = 30_000, ms_duration)]
+    pub timeout: u32,
+}
+
+fn main() {}

--- a/crates/aether-derive/tests/ui/rejects_ms_duration_on_non_duration.stderr
+++ b/crates/aether-derive/tests/ui/rejects_ms_duration_on_non_duration.stderr
@@ -1,0 +1,5 @@
+error: `ms_duration` hint requires field type `std::time::Duration`
+ --> tests/ui/rejects_ms_duration_on_non_duration.rs:7:5
+  |
+7 |     #[config(default = 30_000, ms_duration)]
+  |     ^

--- a/crates/aether-derive/tests/ui/rejects_unknown_hint.rs
+++ b/crates/aether-derive/tests/ui/rejects_unknown_hint.rs
@@ -1,0 +1,11 @@
+//! A field attribute the macro doesn't know about errors with the
+//! list of accepted hints so the author sees what's available.
+
+#[derive(aether_derive::Config)]
+#[config(env_prefix = "AETHER_UNK", cli_prefix = "unk")]
+pub struct UnknownHintConfig {
+    #[config(magic)]
+    pub value: u32,
+}
+
+fn main() {}

--- a/crates/aether-derive/tests/ui/rejects_unknown_hint.stderr
+++ b/crates/aether-derive/tests/ui/rejects_unknown_hint.stderr
@@ -1,0 +1,5 @@
+error: unknown field attribute; expected one of `env = "..."`, `cli_long = "..."`, `default = <lit>`, `parse = <fn_path>`, `ms_duration`, `csv_set`, `layer_field = "..."`
+ --> tests/ui/rejects_unknown_hint.rs:7:14
+  |
+7 |     #[config(magic)]
+  |              ^^^^^

--- a/crates/aether-substrate-bundle/src/cli.rs
+++ b/crates/aether-substrate-bundle/src/cli.rs
@@ -1,7 +1,7 @@
-//! Per-chassis clap CLI roots and per-cap argv overlays (ADR-0090 unit
-//! d, issue 1258). Each chassis bin calls `<Cli>::parse()` and threads
-//! the resolved overlays through `*Env::from_env_with_argv(cli)`; each
-//! overlay's `into_layer()` writes argv-set fields into a partial
+//! Per-chassis clap CLI roots (ADR-0090 unit d, issue 1258). Each
+//! chassis bin calls `<Cli>::parse()` and threads the resolved
+//! overlays through `*Env::from_env_with_argv(cli)`; each overlay's
+//! `into_layer()` writes argv-set fields into a partial
 //! `<*ConfigLayer as confique::Config>::Layer`, which the cap's
 //! `from_argv_then_env(...)` then preloads ahead of `.env()` so argv
 //! beats env beats literal defaults. Absent flags resolve `None` and
@@ -21,239 +21,33 @@
 //! root `CommonOverlay` / `DesktopCli` / `HeadlessCli` and are
 //! ad-hoc-shadowed in the bin (`cli.workers.or_else(parse_workers_env)`).
 //! Unit e1 will lift them into their own confique layers.
+//!
+//! ADR-0090 unit g (iamacoffeepot/aether#1264): the per-cap `*Overlay`
+//! structs now ride the `#[derive(aether_substrate::Config)]` next to
+//! the domain struct in the cap crate. This file re-exports them so
+//! `cli.common.http.into_layer()` call sites stay unchanged; the
+//! `PersistOverlay` + chassis-root CLI structs stay hand-written
+//! because they cover chassis-shape (cross-cap) composition the
+//! derive deliberately doesn't try to model.
 
-use std::collections::HashSet;
 use std::path::PathBuf;
 
-use aether_capabilities::anthropic::AnthropicConfigLayer;
-use aether_capabilities::audio::AudioConfigLayer;
-use aether_capabilities::fs::NamespaceRootsLayer;
-use aether_capabilities::gemini::GeminiConfigLayer;
-use aether_capabilities::http::HttpConfigLayer;
 use aether_substrate::handle_store::PersistConfigLayer;
 use clap::{Args, Parser};
 use confique::{Config, Layer};
 
-/// Argv overlay for the `aether.http` cap. One `Option<T>` per
-/// `HttpConfigLayer` field; [`Self::into_layer`] maps unset → partial
-/// `None`, set → partial `Some(v)`.
-#[derive(Args, Debug, Default, Clone)]
-pub struct HttpOverlay {
-    /// `AETHER_HTTP_DISABLE` — swap in the disabled adapter.
-    #[arg(id = "http_disable", long = "http-disable", num_args = 0..=1, default_missing_value = "true")]
-    pub disable: Option<bool>,
-    /// `AETHER_HTTP_ALLOWLIST` — comma-separated hostnames.
-    #[arg(id = "http_allowlist", long = "http-allowlist")]
-    pub allowlist: Option<String>,
-    /// `AETHER_HTTP_REQUIRE_HTTPS` — reject `http://` URLs.
-    #[arg(id = "http_require_https", long = "http-require-https", num_args = 0..=1, default_missing_value = "true")]
-    pub require_https: Option<bool>,
-    /// `AETHER_HTTP_MAX_BODY_BYTES` — response body cap.
-    #[arg(id = "http_max_body_bytes", long = "http-max-body-bytes")]
-    pub max_body_bytes: Option<usize>,
-    /// `AETHER_HTTP_TIMEOUT_MS` — default per-request timeout.
-    #[arg(id = "http_timeout_ms", long = "http-timeout-ms")]
-    pub timeout_ms: Option<u32>,
-}
-
-impl HttpOverlay {
-    /// Write argv-set fields into a fresh partial layer. `None` →
-    /// partial `None` (env / default takes over); `Some(v)` → partial
-    /// `Some(v)`.
-    #[must_use]
-    pub fn into_layer(self) -> <HttpConfigLayer as Config>::Layer {
-        let Self {
-            disable,
-            allowlist,
-            require_https,
-            max_body_bytes,
-            timeout_ms,
-        } = self;
-        let mut layer = <HttpConfigLayer as Config>::Layer::empty();
-        if let Some(v) = disable {
-            layer.disabled = Some(v);
-        }
-        if let Some(s) = allowlist {
-            // Same total parser the env side uses (CSV → HashSet, trim,
-            // drop empties). Mirrored inline to avoid making the
-            // parser pub on the cap.
-            let set: HashSet<String> = s
-                .split(',')
-                .map(str::trim)
-                .filter(|h| !h.is_empty())
-                .map(str::to_string)
-                .collect();
-            layer.allowlist = Some(set);
-        }
-        if let Some(v) = require_https {
-            layer.require_https = Some(v);
-        }
-        if let Some(v) = max_body_bytes {
-            layer.max_body_bytes = Some(v);
-        }
-        if let Some(v) = timeout_ms {
-            layer.timeout_ms = Some(v);
-        }
-        layer
-    }
-}
-
-/// Argv overlay for the `aether.audio` cap (desktop only). Headless
-/// runs without an audio device, so [`DesktopCli`] is the only chassis
-/// that flatten-includes this.
-#[derive(Args, Debug, Default, Clone)]
-pub struct AudioOverlay {
-    /// `AETHER_AUDIO_DISABLE` — skip cpal init entirely.
-    #[arg(id = "audio_disable", long = "audio-disable", num_args = 0..=1, default_missing_value = "true")]
-    pub disable: Option<bool>,
-    /// `AETHER_AUDIO_SAMPLE_RATE` — requested sample rate in Hz.
-    #[arg(id = "audio_sample_rate", long = "audio-sample-rate")]
-    pub sample_rate: Option<u32>,
-}
-
-impl AudioOverlay {
-    #[must_use]
-    pub fn into_layer(self) -> <AudioConfigLayer as Config>::Layer {
-        let Self {
-            disable,
-            sample_rate,
-        } = self;
-        let mut layer = <AudioConfigLayer as Config>::Layer::empty();
-        if let Some(v) = disable {
-            layer.disabled = Some(v);
-        }
-        if let Some(v) = sample_rate {
-            // The layer holds the raw string so the cap can apply the
-            // soft `.parse::<u32>().ok()` (an unparseable env value →
-            // `None`). On the argv path the value is already typed.
-            layer.requested_sample_rate = Some(v.to_string());
-        }
-        layer
-    }
-}
-
-/// Argv overlay for the `aether.fs` cap namespace roots.
-#[derive(Args, Debug, Default, Clone)]
-pub struct FsOverlay {
-    /// `AETHER_SAVE_DIR` — writable per-user persistent root.
-    #[arg(id = "save_dir", long = "save-dir")]
-    pub save_dir: Option<PathBuf>,
-    /// `AETHER_ASSETS_DIR` — read-only assets root.
-    #[arg(id = "assets_dir", long = "assets-dir")]
-    pub assets_dir: Option<PathBuf>,
-    /// `AETHER_CONFIG_DIR` — writable per-user config root.
-    #[arg(id = "config_dir", long = "config-dir")]
-    pub config_dir: Option<PathBuf>,
-}
-
-impl FsOverlay {
-    #[must_use]
-    pub fn into_layer(self) -> <NamespaceRootsLayer as Config>::Layer {
-        let Self {
-            save_dir,
-            assets_dir,
-            config_dir,
-        } = self;
-        let mut layer = <NamespaceRootsLayer as Config>::Layer::empty();
-        if let Some(p) = save_dir {
-            layer.save = Some(p);
-        }
-        if let Some(p) = assets_dir {
-            layer.assets = Some(p);
-        }
-        if let Some(p) = config_dir {
-            layer.config = Some(p);
-        }
-        layer
-    }
-}
-
-/// Argv overlay for the `aether.anthropic` cap (ADR-0050).
-#[derive(Args, Debug, Default, Clone)]
-pub struct AnthropicOverlay {
-    /// `ANTHROPIC_API_KEY` — Messages-API key. Empty → disabled
-    /// adapter.
-    #[arg(id = "anthropic_api_key", long = "anthropic-api-key")]
-    pub api_key: Option<String>,
-    /// `AETHER_ANTHROPIC_DISABLE` — force the disabled adapter.
-    #[arg(id = "anthropic_disable", long = "anthropic-disable", num_args = 0..=1, default_missing_value = "true")]
-    pub disable: Option<bool>,
-    /// `AETHER_ANTHROPIC_MAX_IN_FLIGHT` — per-cap concurrency bound.
-    #[arg(id = "anthropic_max_in_flight", long = "anthropic-max-in-flight")]
-    pub max_in_flight: Option<usize>,
-    /// `AETHER_ANTHROPIC_TIMEOUT_MS` — per-request timeout.
-    #[arg(id = "anthropic_timeout_ms", long = "anthropic-timeout-ms")]
-    pub timeout_ms: Option<u32>,
-}
-
-impl AnthropicOverlay {
-    #[must_use]
-    pub fn into_layer(self) -> <AnthropicConfigLayer as Config>::Layer {
-        let Self {
-            api_key,
-            disable,
-            max_in_flight,
-            timeout_ms,
-        } = self;
-        let mut layer = <AnthropicConfigLayer as Config>::Layer::empty();
-        if let Some(v) = api_key {
-            layer.api_key = Some(v);
-        }
-        if let Some(v) = disable {
-            layer.disabled = Some(v);
-        }
-        if let Some(v) = max_in_flight {
-            layer.max_in_flight = Some(v);
-        }
-        if let Some(v) = timeout_ms {
-            layer.timeout_ms = Some(v);
-        }
-        layer
-    }
-}
-
-/// Argv overlay for the `aether.gemini` cap (ADR-0050).
-#[derive(Args, Debug, Default, Clone)]
-pub struct GeminiOverlay {
-    /// `GEMINI_API_KEY` — Google API key. Empty → disabled adapter.
-    #[arg(id = "gemini_api_key", long = "gemini-api-key")]
-    pub api_key: Option<String>,
-    /// `AETHER_GEMINI_DISABLE` — force the disabled adapter.
-    #[arg(id = "gemini_disable", long = "gemini-disable", num_args = 0..=1, default_missing_value = "true")]
-    pub disable: Option<bool>,
-    /// `AETHER_GEMINI_MAX_IN_FLIGHT` — per-cap concurrency bound.
-    #[arg(id = "gemini_max_in_flight", long = "gemini-max-in-flight")]
-    pub max_in_flight: Option<usize>,
-    /// `AETHER_GEMINI_TIMEOUT_MS` — per-request timeout.
-    #[arg(id = "gemini_timeout_ms", long = "gemini-timeout-ms")]
-    pub timeout_ms: Option<u32>,
-}
-
-impl GeminiOverlay {
-    #[must_use]
-    pub fn into_layer(self) -> <GeminiConfigLayer as Config>::Layer {
-        let Self {
-            api_key,
-            disable,
-            max_in_flight,
-            timeout_ms,
-        } = self;
-        let mut layer = <GeminiConfigLayer as Config>::Layer::empty();
-        if let Some(v) = api_key {
-            layer.api_key = Some(v);
-        }
-        if let Some(v) = disable {
-            layer.disabled = Some(v);
-        }
-        if let Some(v) = max_in_flight {
-            layer.max_in_flight = Some(v);
-        }
-        if let Some(v) = timeout_ms {
-            layer.timeout_ms = Some(v);
-        }
-        layer
-    }
-}
+// Per-cap overlays are emitted by `#[derive(aether_substrate::Config)]`
+// next to the domain struct in `aether-capabilities`. Re-exporting them
+// here keeps the `cli.common.<cap>.into_layer()` call sites unchanged.
+// The `NamespaceRoots` overlay's name follows the domain struct
+// (`NamespaceRootsOverlay`), not the namespace prefix (`FsOverlay`) —
+// alias the historical name so the bundle's compose code keeps
+// reading.
+pub use aether_capabilities::anthropic::AnthropicOverlay;
+pub use aether_capabilities::audio::AudioOverlay;
+pub use aether_capabilities::fs::NamespaceRootsOverlay as FsOverlay;
+pub use aether_capabilities::gemini::GeminiOverlay;
+pub use aether_capabilities::http::HttpOverlay;
 
 /// Argv overlay for the ADR-0049 handle-store persistence knobs. The
 /// `dir` / `persist_disable` flags shadow `AETHER_HANDLE_STORE_DIR` /
@@ -262,6 +56,12 @@ impl GeminiOverlay {
 /// env via the confique builder. `max_bytes` is the in-memory soft
 /// budget (`AETHER_HANDLE_STORE_MAX_BYTES`), structurally separate
 /// from the on-disk persist config.
+///
+/// Stays hand-written (not derive-emitted) because `PersistConfig`'s
+/// `from_argv_then_env` takes four arguments (chassis vote + dir
+/// lookup + env short-circuit + numeric layer) that don't fit the
+/// derive's `Layer → Self` shape. The `aether-substrate::config`
+/// module docs hold the rationale verbatim.
 #[derive(Args, Debug, Default, Clone)]
 pub struct PersistOverlay {
     /// `AETHER_HANDLE_STORE_DIR` — on-disk persistence root.

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -22,9 +22,7 @@ use aether_capabilities::{
 use aether_kinds::WindowMode;
 use aether_substrate::chassis::builder::{Builder, BuiltChassis};
 use aether_substrate::chassis::error::BootError;
-use aether_substrate::{
-    Chassis, FromArgvThenEnv, LifecycleDriverCapability, SubstrateBoot, capture::CaptureQueue,
-};
+use aether_substrate::{Chassis, LifecycleDriverCapability, SubstrateBoot, capture::CaptureQueue};
 use winit::error::EventLoopError;
 use winit::event_loop::EventLoop;
 

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -27,7 +27,7 @@ use aether_kinds::{SetMasterGain, SetMasterGainResult, Tick};
 use aether_substrate::chassis::builder::{Builder, BuiltChassis};
 use aether_substrate::chassis::error::BootError;
 use aether_substrate::handle_store::PersistConfig;
-use aether_substrate::{Chassis, FromArgvThenEnv, LifecycleDriverCapability, SubstrateBoot};
+use aether_substrate::{Chassis, LifecycleDriverCapability, SubstrateBoot};
 
 use super::driver::{HeadlessTimerCapability, parse_tick_hz_env};
 use crate::chassis_common::{

--- a/crates/aether-substrate/Cargo.toml
+++ b/crates/aether-substrate/Cargo.toml
@@ -30,6 +30,11 @@ audio = ["dep:cpal"]
 # state lives in struct fields, not a thread-local.
 aether-actor = { path = "../aether-actor" }
 aether-data = { path = "../aether-data" }
+# ADR-0090 unit g (iamacoffeepot/aether#1264): `#[derive(Config)]` lives
+# in `aether-derive` and is re-exported here as `aether_substrate::Config`,
+# the user-facing path callers write. Mirrors how `aether-data`
+# re-exports `aether-data-derive`'s `#[derive(Kind, Schema)]`.
+aether-derive = { path = "../aether-derive" }
 aether-kinds = { path = "../aether-kinds" }
 bytemuck = "1.19"
 # ADR-0090: typed, layered config resolution. Backs the env-shaped

--- a/crates/aether-substrate/src/config.rs
+++ b/crates/aether-substrate/src/config.rs
@@ -1,18 +1,44 @@
 //! Shared confique-overlay glue for resolved cap configs (ADR-0090
-//! unit d).
+//! unit d), and the trait that ADR-0090 unit g
+//! (iamacoffeepot/aether#1264) plumbs the per-cap
+//! `#[derive(aether_substrate::Config)]` against.
 //!
-//! Every cap that opted into confique (`HttpConfig`, `AudioConfig`,
-//! `GeminiConfig`, `AnthropicConfig`, `NamespaceRoots`) ships a
-//! mechanical `from_argv_then_env(argv) -> Self`: build the
-//! cap's `*ConfigLayer` with the argv overlay preloaded, run
-//! `.env().load()`, hand the loaded layer to a per-cap `from_layer`
-//! mapping. Only `from_layer` actually differs across caps — the
-//! builder boilerplate is identical.
+//! # Preferred shape — `#[derive(aether_substrate::Config)]`
 //!
-//! [`FromArgvThenEnv`] hoists the boilerplate into a default method.
-//! Each cap impls just `from_layer` (and names its `Layer` associated
-//! type); the trait's default `from_argv_then_env` is inherited
-//! verbatim.
+//! Cap authors should reach for the derive on the resolved-config
+//! struct rather than hand-writing the trio + impl:
+//!
+//! ```ignore
+//! #[derive(Clone, Debug)]
+//! #[cfg_attr(feature = "native", derive(aether_substrate::Config))]
+//! #[cfg_attr(
+//!     feature = "native",
+//!     config(env_prefix = "AETHER_HTTP", cli_prefix = "http")
+//! )]
+//! pub struct HttpConfig {
+//!     #[cfg_attr(feature = "native", config(default = false, parse = parse_flag))]
+//!     pub disabled: bool,
+//!     #[cfg_attr(
+//!         feature = "native",
+//!         config(default = 30_000, parse = parse_timeout_ms, ms_duration)
+//!     )]
+//!     pub default_timeout: Duration,
+//! }
+//! ```
+//!
+//! The derive emits the env-shaped `*Layer`, the clap-shaped
+//! `*Overlay` (next to the domain struct in the cap crate; the
+//! bundle's `cli.rs` `pub use`s them), the `FromArgvThenEnv` impl,
+//! and inherent `from_env()` / `from_argv_then_env(argv)` shims. Per-
+//! field hints (`default`, `parse`, `env`, `cli_long`, `ms_duration`,
+//! `csv_set`, `layer_field`) cover the d-era wire shapes; the
+//! container `skip_from_layer` opt-out lets a cap hand-write
+//! `from_layer` when its defaults are runtime-computed (the
+//! `NamespaceRoots` case).
+//!
+//! [`FromArgvThenEnv`] still exists as the underlying trait — the
+//! derive emits an impl of it. Hand-written impls remain valid where
+//! the derive doesn't fit.
 //!
 //! # Why not `PersistConfig` too?
 //!
@@ -27,7 +53,7 @@
 //! through a `Layer`. Forcing it into a `(Layer) -> Self` shape would
 //! mean re-deriving the structural inputs from environment reads inside
 //! the trait body, which is exactly the structure the cap deliberately
-//! kept hand-written. The five other caps still benefit from the trait;
+//! kept hand-written. The five other caps benefit from the derive;
 //! `PersistConfig` stays inherent.
 
 /// Build a cap config by overlaying an argv-derived partial confique

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -64,6 +64,7 @@ pub use actor::native::{NativeActor, NativeDispatch};
 pub use actor::registry::{ActorEntry, ActorRegistry, MonitorEntry, MonitorError};
 pub use actor::wasm::component::{Component, ComponentCtx};
 pub use aether_actor::Actor;
+pub use aether_derive::Config;
 pub use boot::{SubstrateBoot, SubstrateBootBuilder};
 pub use chassis::Chassis;
 pub use chassis::builder::{


### PR DESCRIPTION
Unit (g) of the ADR-0090 application-configuration rollout (epic iamacoffeepot/aether#1235; ADR at `docs/adr/0090-application-configuration.md`).

Retires the trait+impl boilerplate from d (iamacoffeepot/aether#1263) by collapsing each cap's Config + Layer + CLI Overlay + `FromArgvThenEnv` impl into one struct + `#[derive(aether_substrate::Config)]`. New `aether-derive` crate hosts the derive in a sibling slot to `aether-actor-derive` / `aether-data-derive` — engine-wide macros land here going forward.

## Cap author UX before/after

Before: ~120 LoC per cap across Config + Layer + `from_env` + `FromArgvThenEnv` impl + the `*Overlay` struct in `bundle/src/cli.rs`. After:

```rust
#[derive(aether_substrate::Config)]
#[config(env_prefix = "AETHER_HTTP", cli_prefix = "http")]
pub struct HttpConfig {
    #[config(default = false, parse = parse_flag, cli_long = "http-disable")]
    pub disabled: bool,

    #[config(default = "", parse = parse_allowlist, csv_set)]
    pub allowlist: HashSet<String>,

    #[config(default = 30_000, parse = parse_timeout_ms, layer_field = "timeout_ms", ms_duration)]
    pub default_timeout: Duration,
    // …
}
```

The derive emits the hidden `HttpConfigLayer` (confique-derived), the `From<Layer>`, the `FromArgvThenEnv` impl, the `HttpOverlay` clap struct, and inherent `from_env` / `from_argv_then_env` shims. PersistConfig stays inherent (the documented exception in `aether-substrate::config`; its 4-arg shape doesn't fit `Layer → Self`).

## Attribute vocabulary (locked + spec deviations)

Container: `env_prefix`, `cli_prefix`, `skip_from_layer` (new — the NamespaceRoots escape hatch).
Field: `default`, `parse`, `env`, `ms_duration`, `csv_set` (all from the locked spec). Plus two additions agent surfaced during implementation:

1. **`cli_long = "..."`** — explicit clap flag long-form override. Needed because the domain ident `disabled` would otherwise mechanically produce `--http-disabled`, but the d-era wire ships `--http-disable`. Without this, the byte-identical contract breaks. Additive to the locked vocabulary.
2. **`layer_field = "..."`** — explicit Layer-side field-name override. Needed because the domain `default_timeout` would otherwise mechanically produce Layer `default_timeout_ms` + env `AETHER_HTTP_DEFAULT_TIMEOUT_MS`, but the d-era wire ships `timeout_ms` / `AETHER_HTTP_TIMEOUT_MS`. Additive.

Both are documented in the macro's rustdoc + each retrofit commit message. They preserve the existing wire surface unchanged.

Type-driven (no explicit hint, as locked):
- `Option<String>` always auto-applies `.filter(|s| !s.is_empty())` in `from_layer`.
- `Option<numeric>` (audio `requested_sample_rate: Option<u32>`) → Layer holds `Option<String>`, `from_layer` does soft `.parse().ok()`.

## Retrofit scope

- `HttpConfig`, `AudioConfig`, `GeminiConfig`, `AnthropicConfig` — full retrofit.
- `NamespaceRoots` — `skip_from_layer` escape hatch: derive emits Layer + Overlay + inherent shims; `from_layer` is hand-written because three fields' defaults are computed at runtime via `dirs::data_dir()`.
- `PersistConfig` — unchanged, stays inherent per the spec.

The 5 per-cap `*Overlay` structs (~250 LoC) deleted from `crates/aether-substrate-bundle/src/cli.rs`; chassis bins `pub use` the macro-emitted ones from each cap crate. `CommonOverlay`, `DesktopCli`, `HeadlessCli`, `HubCli`, `PersistOverlay` stay (chassis-shape, not per-cap).

## Byte-identical contract — verified

- Every env key + default literal: matches d-era output of `cargo expand --features native` field-for-field.
- Every CLI `id =` + `long =`: byte-for-byte (cap's clap dep now optional under `feature = "native"`).
- Every cap's `*_defaults_match` test passes unmodified, **except** `audio_from_env_defaults_match` where one assertion field name updated (`layer.requested_sample_rate` → `layer.sample_rate`) because the macro names the Layer field after `layer_field` override. Asserted values unchanged.
- `tests/spawn_args_overlay.rs` (d's regression bar): passes unmodified.

## Macro crate shape

- `crates/aether-derive/` — `proc-macro2` + `quote` + `syn 2`. Hand-rolled `parse_nested_meta` (mirrors `aether-actor-derive`'s style). No `darling`.
- `tests/ui/` trybuild fixtures: 4 accept (minimal / full http / optional / ms_duration) + 3 reject (`ms_duration` on non-Duration / missing `env_prefix` / unknown hint).
- Re-exported as `aether_substrate::Config` (next to `aether_substrate::FromArgvThenEnv`).

## Validation

- `cargo nextest run --workspace --all-features` — **1422 passed**, 6 skipped (d's baseline 1420 + 2 new trybuild-driven tests).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo doc --workspace --no-deps` — clean.
- wasm32 cross-build green.
- Net diff: +1270 / −700.

## Out of scope (preserved)

- e1's `Result` flip lands AFTER g — the derive emits infallible `from_env` / `from_argv_then_env` today; e1 flips both bodies in macro-emitted output.
- No env name changes, no CLI flag-name changes, no default-value changes.
- No confique replacement; confique stays under the macro as implementation detail.

Closes iamacoffeepot/aether#1264

🤖 Generated with [Claude Code](https://claude.com/claude-code)
