### PR TITLE
feat(mcp): let the harness encode component-defined kinds (issue 1232)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,7 @@ dependencies = [
  "base64",
  "futures-util",
  "libc",
+ "postcard",
  "reqwest",
  "rmcp",
  "schemars",

--- a/crates/aether-capabilities/src/inventory.rs
+++ b/crates/aether-capabilities/src/inventory.rs
@@ -1,9 +1,10 @@
-//! `aether.inventory` cap (ADR-0088 §6). Serves the reverse-lookup
-//! inventory over mail so an out-of-process observer (the MCP harness)
-//! reads the running substrate's **own, per-build** inventory instead of
-//! a drift-prone compiled-in copy.
+//! `aether.inventory` cap (ADR-0088 §6, widened by ADR-0091 §5). Serves
+//! the per-build reverse-lookup inventory **and** the per-engine live
+//! kind-schema registry view over mail so an out-of-process observer
+//! (the MCP harness) reads the running substrate's **own, per-build**
+//! state instead of a drift-prone compiled-in copy.
 //!
-//! Two request kinds, both replying synchronously via `ctx.reply`:
+//! Three request kinds, each replying synchronously via `ctx.reply`:
 //!
 //! - [`Manifest`] → [`ManifestResult`]: the compile-time manifest —
 //!   every link-time [`NameEntry`](aether_data::name_inventory::NameEntry)
@@ -19,35 +20,58 @@
 //!   manifest alone (the runtime-registry arm of the ADR-0088 §2 chain,
 //!   `thread_name::resolve_runtime`). `None` on a miss so the client
 //!   falls back to rendering the ADR-0064 tagged-id string itself.
+//! - [`ListKinds`] → [`ListKindsResult`] (ADR-0091): every
+//!   [`KindId`](aether_data::KindId) currently registered in the
+//!   substrate's `Registry`, with its full
+//!   [`SchemaType`](aether_data::SchemaType). The harness folds the
+//!   reply into a per-engine encode cache so a `send_mail` against a
+//!   component-defined kind encodes correctly the moment the
+//!   `aether.component.load` returns — no per-kind hand-promotion into
+//!   `aether-kinds`.
 //!
-//! The cap holds no state — it reads the link-time inventories and the
-//! process-global runtime registry directly at request time, both of
-//! which are fixed (inventories) or write-rarely (registry) for the
-//! process lifetime. `#[bridge(singleton)]` auto-submits its own
+//! The cap holds a clone of the substrate's `Arc<Registry>` (taken in
+//! `init` via `NativeInitCtx::mailer().registry()` — the same `Arc` the
+//! component-host cap clones for `register_or_match_all`), so a
+//! `load_component`'s registrations are visible to `ListKinds` the
+//! moment they return; no event channel, no cache invalidation. The
+//! manifest / resolve arms remain stateless reads of process-global
+//! link-time tables. `#[bridge(singleton)]` auto-submits its own
 //! `NameEntry` for `NAMESPACE`, so `aether.inventory` reverses through
 //! the same static map it serves.
 
-use aether_kinds::{Manifest, ManifestResult, Resolve, ResolveResult};
+use aether_kinds::{ListKinds, ListKindsResult, Manifest, ManifestResult, Resolve, ResolveResult};
 
 #[aether_actor::bridge(singleton)]
 mod native {
-    use super::{Manifest, ManifestResult, Resolve, ResolveResult};
+    use super::{ListKinds, ListKindsResult, Manifest, ManifestResult, Resolve, ResolveResult};
 
     use aether_actor::{MailCtx, actor};
+    use aether_data::KindId;
+    use aether_data::canonical::kind_id_from_parts;
     use aether_data::name_inventory::{Cardinality, ParamKind, name_entries, template_entries};
     use aether_data::tagged_id;
     use aether_kinds::{
-        CardinalityWire, NameEntryWire, ParamKindWire, ResolvedName, TemplateEntryWire,
+        CardinalityWire, KindDescriptorWire, NameEntryWire, ParamKindWire, ResolvedName,
+        TemplateEntryWire,
     };
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
+    use aether_substrate::mail::registry::Registry;
     use aether_substrate::runtime::thread_name::resolve_runtime;
+    use std::sync::Arc;
 
-    /// `aether.inventory` cap (ADR-0088 §6). Stateless — both handlers
-    /// read process-global tables (the link-time inventories, the
-    /// runtime registry) directly, so there is nothing to carry across
-    /// handler calls.
-    pub struct InventoryCapability;
+    /// `aether.inventory` cap (ADR-0088 §6, widened by ADR-0091 §5). The
+    /// `Manifest` and `Resolve` arms read process-global tables (the
+    /// link-time inventories, the runtime registry) directly with no
+    /// per-cap state. The `ListKinds` arm projects the substrate's
+    /// shared `Arc<Registry>`, captured in `init` from the bench /
+    /// chassis mailer — load-time registrations performed by
+    /// `ComponentHostCapability` mutate the same `Arc<Registry>`, so the
+    /// reply reflects whatever vocabulary the substrate currently holds
+    /// without any cross-cap event channel.
+    pub struct InventoryCapability {
+        registry: Arc<Registry>,
+    }
 
     /// Project one link-time `ParamKind` onto its wire mirror. `Bounded`
     /// / `Declared` carry their range / domain so the client expands the
@@ -83,8 +107,15 @@ mod native {
         /// headless chassis (via `with_common_caps`), matching `aether.fs`.
         const NAMESPACE: &'static str = "aether.inventory";
 
-        fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            Ok(Self)
+        fn init((): (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            // Clone the substrate's shared `Arc<Registry>` — the same
+            // `Arc` `ComponentHostCapability` clones for
+            // `register_or_match_all` at `component.rs:170`. The shared
+            // `Arc` is the propagation channel per ADR-0091 §2: a
+            // load-time registration is visible to `on_list_kinds` the
+            // moment it returns.
+            let registry = Arc::clone(ctx.mailer().registry());
+            Ok(Self { registry })
         }
 
         /// Reply with the per-build reverse-lookup manifest: every
@@ -97,9 +128,10 @@ mod native {
         /// shape). Fold `names` into a hash → name map and expand the
         /// `Bounded`/`Declared` templates locally; resolve `Dynamic`
         /// families per-id via `aether.inventory.resolve`.
-        // Stateless cap — the manifest is read from the process-global
-        // link-time inventories, not from `self`. `&mut self` is the
-        // `#[handler]` dispatch signature, not a state read.
+        // The manifest is read from the process-global link-time
+        // inventories — `self.registry` is only consulted by
+        // `on_list_kinds`. `&mut self` is the `#[handler]` dispatch
+        // signature, not a state read here.
         #[allow(clippy::unused_self)]
         #[handler]
         fn on_manifest(&mut self, ctx: &mut NativeCtx<'_>, _mail: Manifest) {
@@ -118,6 +150,47 @@ mod native {
                 })
                 .collect();
             ctx.reply(&ManifestResult { names, templates });
+        }
+
+        /// Reply with the substrate's live kind vocabulary: every
+        /// [`KindDescriptor`](aether_data::KindDescriptor) currently
+        /// registered in the engine's `Registry`, projected onto the
+        /// wire (id + name + postcard-encoded
+        /// [`SchemaType`](aether_data::SchemaType)). ADR-0091 §1–§2.
+        ///
+        /// # Agent
+        /// Reply: `ListKindsResult`. The harness folds this into a
+        /// per-engine encode cache so a `send_mail` against a
+        /// component-defined kind encodes correctly the moment the
+        /// `aether.component.load` returns. Lazy-on-miss: the harness
+        /// calls this on the first `send_mail` for an unknown kind
+        /// name, then reuses the cached vocabulary until the next miss
+        /// (no TTL, no background poll). The schema rides as opaque
+        /// postcard bytes (`schema_postcard`) because `SchemaType` has
+        /// no `Schema` impl of its own; decode it with
+        /// `postcard::from_bytes::<SchemaType>(&desc.schema_postcard)`.
+        #[handler]
+        fn on_list_kinds(&mut self, ctx: &mut NativeCtx<'_>, _mail: ListKinds) {
+            let kinds = self
+                .registry
+                .list_kind_descriptors()
+                .into_iter()
+                .map(|desc| {
+                    // The schema rides as opaque postcard bytes — see
+                    // `KindDescriptorWire` for the rationale. The
+                    // serialization is infallible for `SchemaType`
+                    // (no `Map<String, _>` non-string-key edge cases
+                    // because every nested field is a derive output).
+                    let schema_postcard = postcard::to_allocvec(&desc.schema)
+                        .expect("SchemaType always postcard-encodes (ADR-0030 canonical form)");
+                    KindDescriptorWire {
+                        id: KindId(kind_id_from_parts(&desc.name, &desc.schema)),
+                        name: desc.name,
+                        schema_postcard,
+                    }
+                })
+                .collect();
+            ctx.reply(&ListKindsResult { kinds });
         }
 
         /// Resolve each requested tagged-id string to its origin name via
@@ -193,7 +266,9 @@ mod native {
             Fixture {
                 rx,
                 transport,
-                cap: InventoryCapability,
+                cap: InventoryCapability {
+                    registry: Arc::clone(&registry),
+                },
             }
         }
 
@@ -297,6 +372,62 @@ mod native {
                 matches!(&trampoline.cardinality, CardinalityWire::OnePer { entity } if entity == "component"),
                 "trampoline cardinality should be OnePer(\"component\"); got {:?}",
                 trampoline.cardinality,
+            );
+        }
+
+        /// ADR-0091: `ListKinds` returns the substrate's authoritative
+        /// kind vocabulary. A kind registered in the bench's `Registry`
+        /// — emulating the `register_or_match_all` path
+        /// `ComponentHostCapability::handle_load` follows — shows up in
+        /// the reply with the matching `KindId`, name, and a
+        /// postcard-encoded `SchemaType` that decodes back to the
+        /// original schema. This is the live-projection ADR-0091
+        /// requires: the same `Arc<Registry>` `component.rs` mutates is
+        /// what the cap reads on every call.
+        #[test]
+        fn list_kinds_projects_a_registered_kind() {
+            use aether_data::{KindDescriptor, KindId, SchemaType, canonical::kind_id_from_parts};
+
+            let mut fix = fixture();
+
+            // Register a fresh kind directly on the registry — same
+            // entry point `register_or_match_all` walks per descriptor.
+            // A `String`-shaped param keeps the schema lookup distinct
+            // from any link-time entry the static vocabulary already
+            // submits.
+            let desc = KindDescriptor {
+                name: "aether.test.list_kinds_projection".to_owned(),
+                schema: SchemaType::String,
+            };
+            let expected_id = KindId(kind_id_from_parts(&desc.name, &desc.schema));
+            // Use the bench's registry (the one the cap also cloned in
+            // `fixture`) so the read sees what we just wrote.
+            fix.cap
+                .registry
+                .register_kind_with_descriptor(desc.clone())
+                .expect("register fresh kind");
+
+            let mut ctx = session_ctx(&fix.transport);
+            fix.cap.on_list_kinds(&mut ctx, ListKinds {});
+            drop(ctx);
+
+            let result = decode_reply::<ListKindsResult>(&fix.rx);
+            let entry = result
+                .kinds
+                .iter()
+                .find(|k| k.name == desc.name)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "ListKindsResult should carry the registered kind; names: {:?}",
+                        result.kinds.iter().map(|k| &k.name).collect::<Vec<_>>(),
+                    )
+                });
+            assert_eq!(entry.id, expected_id, "id matches kind_id_from_parts");
+            let schema: SchemaType = postcard::from_bytes(&entry.schema_postcard)
+                .expect("schema_postcard round-trips through postcard");
+            assert!(
+                matches!(schema, SchemaType::String),
+                "schema decodes back to the originally registered SchemaType",
             );
         }
 

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1689,10 +1689,10 @@ mod control_plane {
     /// `Schema` impl (it *is* the schema vocabulary, not a value in
     /// it); shipping it as `Bytes` keeps `KindDescriptorWire` and the
     /// whole reply derivable via [`aether_data::Schema`] without a
-    /// hand-roll, at the cost of one extra `postcard::from_bytes`
-    /// on the harness side. Cap encodes via [`postcard::to_allocvec`]
+    /// hand-roll, at the cost of one extra `postcard::from_bytes` on
+    /// the harness side. Cap encodes via `postcard::to_allocvec`
     /// against `descriptor.schema`; client decodes via
-    /// [`postcard::from_bytes`].
+    /// `postcard::from_bytes`.
     #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
     pub struct KindDescriptorWire {
         pub id: aether_data::KindId,
@@ -1701,11 +1701,12 @@ mod control_plane {
     }
 
     /// `aether.inventory.kinds` — request the running substrate's
-    /// authoritative kind vocabulary (ADR-0091): every [`KindId`] the
-    /// engine's `Registry` currently holds, with its full
-    /// [`SchemaType`]. Empty payload; the request *is* the signal.
-    /// Mailed to the `"aether.inventory"` mailbox; reply:
-    /// [`ListKindsResult`].
+    /// authoritative kind vocabulary (ADR-0091): every
+    /// [`KindId`](aether_data::KindId) the engine's `Registry`
+    /// currently holds, with its full
+    /// [`SchemaType`](aether_data::SchemaType). Empty payload; the
+    /// request *is* the signal. Mailed to the `"aether.inventory"`
+    /// mailbox; reply: [`ListKindsResult`].
     ///
     /// The MCP harness uses this to refresh its per-engine encode-
     /// cache after a `load_component` registers a component's own

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1678,6 +1678,56 @@ mod control_plane {
         pub resolved: Vec<ResolvedName>,
     }
 
+    /// One kind in a [`ListKindsResult`] (ADR-0091). `id` is the
+    /// substrate's authoritative [`KindId`](aether_data::KindId) for the
+    /// kind; `name` is its declared `Kind::NAME`; `schema_postcard` is
+    /// the kind's [`SchemaType`](aether_data::SchemaType) postcard-
+    /// serialized (the wire enum carries the full nominal shape).
+    ///
+    /// The schema rides as opaque postcard bytes rather than a directly
+    /// embedded `SchemaType` because `SchemaType` itself has no
+    /// `Schema` impl (it *is* the schema vocabulary, not a value in
+    /// it); shipping it as `Bytes` keeps `KindDescriptorWire` and the
+    /// whole reply derivable via [`aether_data::Schema`] without a
+    /// hand-roll, at the cost of one extra `postcard::from_bytes`
+    /// on the harness side. Cap encodes via [`postcard::to_allocvec`]
+    /// against `descriptor.schema`; client decodes via
+    /// [`postcard::from_bytes`].
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    pub struct KindDescriptorWire {
+        pub id: aether_data::KindId,
+        pub name: String,
+        pub schema_postcard: Vec<u8>,
+    }
+
+    /// `aether.inventory.kinds` — request the running substrate's
+    /// authoritative kind vocabulary (ADR-0091): every [`KindId`] the
+    /// engine's `Registry` currently holds, with its full
+    /// [`SchemaType`]. Empty payload; the request *is* the signal.
+    /// Mailed to the `"aether.inventory"` mailbox; reply:
+    /// [`ListKindsResult`].
+    ///
+    /// The MCP harness uses this to refresh its per-engine encode-
+    /// cache after a `load_component` registers a component's own
+    /// kinds — the substrate's `Registry` is the single source of
+    /// truth, projected onto the wire by the inventory cap.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.inventory.kinds")]
+    pub struct ListKinds {}
+
+    /// Reply to [`ListKinds`] (ADR-0091). One [`KindDescriptorWire`] per
+    /// kind currently registered in the substrate's `Registry`, sorted
+    /// by name (the registry's `list_kind_descriptors` ordering). The
+    /// harness folds this into its per-engine encode cache; component-
+    /// defined kinds (loaded via `aether.component.load`) show up here
+    /// alongside the substrate's static vocabulary the moment the load
+    /// returns, no separate notification.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.inventory.kinds_result")]
+    pub struct ListKindsResult {
+        pub kinds: Vec<KindDescriptorWire>,
+    }
+
     // Mesh-viewer structured load replies (issue 964). The mesh-viewer
     // component's `aether.mesh.load` was fire-and-forget — failures
     // warn-logged and the prior cache stayed, with no wire signal a
@@ -2776,6 +2826,8 @@ mod tests {
         assert_eq!(ManifestResult::NAME, "aether.inventory.manifest_result");
         assert_eq!(Resolve::NAME, "aether.inventory.resolve");
         assert_eq!(ResolveResult::NAME, "aether.inventory.resolve_result");
+        assert_eq!(ListKinds::NAME, "aether.inventory.kinds");
+        assert_eq!(ListKindsResult::NAME, "aether.inventory.kinds_result");
     }
 
     // ADR-0019 PR 3 — every kind below now has a derived `Schema` impl

--- a/crates/aether-mcp/Cargo.toml
+++ b/crates/aether-mcp/Cargo.toml
@@ -44,6 +44,11 @@ libc = "0.2"
 # through incrementally rather than buffered to EOF. Default features
 # (TLS, etc.) are off — the upstream is plain-HTTP localhost.
 reqwest = { version = "0.13", default-features = false, features = ["stream"] }
+# Used by the per-engine kind cache (ADR-0091) to round-trip a
+# `SchemaType` through the `KindDescriptorWire.schema_postcard` field —
+# `SchemaType` has no `Schema` impl of its own, so it rides as opaque
+# bytes within the `aether.inventory.kinds_result` wire kind.
+postcard = "1"
 rmcp = { version = "1.7", features = [
     "server",
     "macros",

--- a/crates/aether-mcp/src/main.rs
+++ b/crates/aether-mcp/src/main.rs
@@ -26,7 +26,7 @@ use rmcp::transport::streamable_http_server::session::local::LocalSessionManager
 use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
 
 use crate::rpc::RpcSession;
-use crate::tools::{ComponentCache, Mcp, ReverseNameCache};
+use crate::tools::{ComponentCache, KindsCache, Mcp, ReverseNameCache};
 
 /// Default port the MCP HTTP server binds. Distinct from the embedded
 /// hub MCP's 8888 so the two coexist until the P5d cutover.
@@ -79,15 +79,24 @@ async fn main() -> anyhow::Result<()> {
     // for that engine, then reused across tool calls and sessions.
     let names: Arc<ReverseNameCache> = Arc::new(ReverseNameCache::default());
 
+    // Process-wide per-engine kind-encode cache (ADR-0091), shared into
+    // every per-session `Mcp` — prefilled lazily from the substrate's
+    // static `descriptors::all()` baseline on first touch, refreshed
+    // on encode miss via `aether.inventory.kinds`, then reused across
+    // tool calls and sessions.
+    let kinds: Arc<KindsCache> = Arc::new(KindsCache::default());
+
     let factory_session = Arc::clone(&session);
     let factory_components = Arc::clone(&components);
     let factory_names = Arc::clone(&names);
+    let factory_kinds = Arc::clone(&kinds);
     let service = StreamableHttpService::new(
         move || {
             Ok(Mcp::new(
                 Arc::clone(&factory_session),
                 Arc::clone(&factory_components),
                 Arc::clone(&factory_names),
+                Arc::clone(&factory_kinds),
             ))
         },
         Arc::new(LocalSessionManager::default()),

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -15,6 +15,11 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
+// `tokio::sync::Mutex` (the async one used by the per-engine refresh-
+// collapse guard) imported under an alias so the struct-field path
+// stays short — `std::sync::Mutex` is the bare `Mutex`.
+use tokio::sync::Mutex as AsyncMutex;
+
 use aether_capabilities::rpc::{MailEnvelope, MailboxAddress};
 use aether_capabilities::trace_walk::TreeWalk;
 use aether_data::MailId;
@@ -23,11 +28,12 @@ use aether_data::{
     DagId, EngineId, Kind, KindDescriptor, KindId, MailboxId, Tag, Uuid, mailbox_id_from_name,
     tagged_id,
 };
+use aether_data::SchemaType;
 use aether_kinds::dag::{DagDescriptor, Edge, Node, NodeId};
 use aether_kinds::{
     Cancel, CancelResult, CaptureFrame, CaptureFrameResult, ComponentCapabilities, CostTail,
-    CostTailResult, ListEngines, ListEnginesResult, LoadComponent, LoadResult,
-    MailEnvelope as KindMailEnvelope, ReplaceComponent, ReplaceResult, SpawnEngine,
+    CostTailResult, ListEngines, ListEnginesResult, ListKinds, ListKindsResult, LoadComponent,
+    LoadResult, MailEnvelope as KindMailEnvelope, ReplaceComponent, ReplaceResult, SpawnEngine,
     SpawnEngineResult, Status, StatusResult, Submit, SubmitResult, TerminateEngine,
     TerminateEngineResult,
     trace::{
@@ -103,6 +109,34 @@ pub type ComponentCache = Mutex<HashMap<(EngineId, MailboxId), ComponentCapabili
 /// than erroring the tool.
 pub type ReverseNameCache = Mutex<HashMap<EngineId, EngineNames>>;
 
+/// Per-engine kind-encode cache (ADR-0091): a `kind_name → KindDescriptor`
+/// map per engine, plus the per-engine async mutex that collapses
+/// concurrent refreshes. Built lazily on first send for an engine
+/// (prefilled from the substrate's static vocabulary via
+/// `descriptors::all`); refreshed on encode miss via
+/// `aether.inventory.kinds`. Component-defined kinds enter on the
+/// first miss after `load_component`.
+///
+/// Two halves so the cache can be read under the synchronous `Mutex`
+/// without holding the lock across the async refresh RPC: the outer
+/// `descriptors` map is the read path, and `refresh_guards` holds the
+/// per-engine `AsyncMutex<()>` two concurrent misses on
+/// different unknown names collapse on (the second waiter awaits the
+/// first's result, then retries the lookup against the freshly-
+/// populated map without re-fetching).
+#[derive(Default)]
+pub struct KindsCache {
+    /// `engine → kind_name → descriptor`. Read with the std `Mutex`
+    /// uncontended on cache hits (no await inside the critical
+    /// section).
+    descriptors: Mutex<HashMap<EngineId, HashMap<String, KindDescriptor>>>,
+    /// `engine → refresh-collapse mutex`. Looked up under
+    /// `descriptors`'s lock to fetch-or-insert, then acquired
+    /// out-of-band via `tokio::sync::Mutex::lock().await` so the
+    /// refresh RPC doesn't pin the cache lock.
+    refresh_guards: Mutex<HashMap<EngineId, Arc<AsyncMutex<()>>>>,
+}
+
 /// Per-session MCP service. `rmcp` calls the factory once per session
 /// and may clone the result for concurrent tool dispatch — `session`
 /// and `components` are `Arc`s, so clones share the one hub connection
@@ -114,6 +148,10 @@ pub struct Mcp {
     /// Per-engine reverse-lookup maps (ADR-0088 §8), shared across cloned
     /// sessions so a manifest fetched for one tool call serves the next.
     names: Arc<ReverseNameCache>,
+    /// Per-engine kind-encode cache (ADR-0091), shared across cloned
+    /// sessions so a `ListKinds` refresh fetched for one tool call
+    /// serves the next.
+    kinds: Arc<KindsCache>,
     // The `#[tool_router]` macro stores the router instance here; it's
     // consumed by `#[tool_handler]` codegen rather than read by name, so
     // the dead-code lint fires under `-D warnings` despite the field
@@ -124,16 +162,19 @@ pub struct Mcp {
 
 impl Mcp {
     /// Construct a per-session service over an established hub
-    /// connection + the process-wide component and reverse-name caches.
+    /// connection + the process-wide component, reverse-name, and
+    /// kind-encode caches.
     pub fn new(
         session: Arc<RpcSession>,
         components: Arc<ComponentCache>,
         names: Arc<ReverseNameCache>,
+        kinds: Arc<KindsCache>,
     ) -> Self {
         Self {
             session,
             components,
             names,
+            kinds,
             tool_router: Self::tool_router(),
         }
     }
@@ -225,21 +266,18 @@ impl Mcp {
         &self,
         Parameters(args): Parameters<SendMailArgs>,
     ) -> Result<String, McpError> {
-        // Snapshot the substrate descriptor inventory once for the
-        // whole batch rather than per item.
-        let descriptors = descriptors::all();
         let fire_and_forget = args.fire_and_forget;
         let mut statuses = Vec::with_capacity(args.mails.len());
         for (index, spec) in args.mails.into_iter().enumerate() {
             let mut replies = Vec::new();
             let mut timed_out = false;
             let status = if fire_and_forget {
-                match self.deliver_one_fire(&descriptors, spec).await {
+                match self.deliver_one_fire(spec).await {
                     Ok(()) => "dispatched".to_owned(),
                     Err(e) => format!("error: {e}"),
                 }
             } else {
-                match self.deliver_one(&descriptors, spec).await {
+                match self.deliver_one(spec).await {
                     Ok((events, hit_timeout)) => {
                         replies = decode_reply_events(&events);
                         timed_out = hit_timeout;
@@ -266,13 +304,16 @@ impl Mcp {
         Parameters(args): Parameters<SendMailTracedArgs>,
     ) -> Result<String, McpError> {
         let engine = parse_engine_id(&args.engine_id)?;
-        let descriptors = descriptors::all();
         // Encode the batch before sending — a bad spec produces a
         // clean invalid-params error and never touches the wire.
         // Same shape `CaptureFrame` carries: `Vec<MailEnvelope>` with
         // name-level addressing the substrate resolves at dispatch
-        // time via `resolve_bundle`.
-        let mails = encode_traced_bundle(&descriptors, &args.mails)
+        // time via `resolve_bundle`. ADR-0091: descriptors come from
+        // the per-engine merged view so a component's own kinds
+        // encode after `load_component`.
+        let mails = self
+            .encode_traced_bundle(engine, &args.mails)
+            .await
             .map_err(|e| McpError::invalid_params(format!("send_mail_traced batch: {e}"), None))?;
         let timeout_ms = args
             .settlement_timeout_ms
@@ -507,13 +548,22 @@ impl Mcp {
         let engine = parse_engine_id(&args.engine_id)?;
         // Encode both bundles before sending — a bad entry produces a
         // clean invalid-params error and never touches the wire.
-        let descriptors = descriptors::all();
-        let mails = encode_capture_bundle(&descriptors, &args.mails).map_err(|e| {
-            McpError::invalid_params(format!("capture_frame mails bundle: {e}"), None)
-        })?;
-        let after_mails = encode_capture_bundle(&descriptors, &args.after_mails).map_err(|e| {
-            McpError::invalid_params(format!("capture_frame after_mails bundle: {e}"), None)
-        })?;
+        // ADR-0091: descriptors come from the per-engine merged view
+        // so a `capture_frame` referencing a component-defined kind
+        // (e.g. an `aether.mesh.load` pre-mail) encodes correctly
+        // after `load_component`.
+        let mails = self
+            .encode_capture_bundle(engine, &args.mails)
+            .await
+            .map_err(|e| {
+                McpError::invalid_params(format!("capture_frame mails bundle: {e}"), None)
+            })?;
+        let after_mails = self
+            .encode_capture_bundle(engine, &args.after_mails)
+            .await
+            .map_err(|e| {
+                McpError::invalid_params(format!("capture_frame after_mails bundle: {e}"), None)
+            })?;
         let reply = self
             .session
             .call_one(engine_envelope(
@@ -900,44 +950,32 @@ impl Mcp {
     /// collected reply envelopes plus a `timed_out` flag — the await is
     /// bounded by [`AWAIT_TIMEOUT_DEFAULT_MS`] so a cap that never
     /// replies returns at the cap rather than hanging.
-    async fn deliver_one(
-        &self,
-        descriptors: &[KindDescriptor],
-        spec: MailSpec,
-    ) -> anyhow::Result<(Vec<MailEnvelope>, bool)> {
-        let envelope = Self::build_mail_envelope(descriptors, spec)?;
+    async fn deliver_one(&self, spec: MailSpec) -> anyhow::Result<(Vec<MailEnvelope>, bool)> {
+        let envelope = self.build_mail_envelope(spec).await?;
         let timeout = Duration::from_millis(u64::from(AWAIT_TIMEOUT_DEFAULT_MS));
         self.session.call_collecting(envelope, timeout).await
     }
 
     /// [`Self::deliver_one`]'s fire-and-forget twin: build the envelope
     /// and write the `Call` without awaiting any reply (issue 1242).
-    async fn deliver_one_fire(
-        &self,
-        descriptors: &[KindDescriptor],
-        spec: MailSpec,
-    ) -> anyhow::Result<()> {
-        let envelope = Self::build_mail_envelope(descriptors, spec)?;
+    async fn deliver_one_fire(&self, spec: MailSpec) -> anyhow::Result<()> {
+        let envelope = self.build_mail_envelope(spec).await?;
         self.session.fire(envelope).await
     }
 
-    /// Resolve a `MailSpec` against the substrate vocabulary baked into
-    /// `aether-kinds` and build the `engine = Some` wire envelope — the
-    /// shared front half of [`Self::deliver_one`] /
-    /// [`Self::deliver_one_fire`]. The same descriptor set the scenario
-    /// runner and the embedded hub encode `send_mail` params against.
-    fn build_mail_envelope(
-        descriptors: &[KindDescriptor],
-        spec: MailSpec,
-    ) -> anyhow::Result<MailEnvelope> {
+    /// Resolve a `MailSpec` against the per-engine merged kind view
+    /// (static prefill + cached `ListKinds` reply, ADR-0091) and build
+    /// the `engine = Some` wire envelope — the shared front half of
+    /// [`Self::deliver_one`] / [`Self::deliver_one_fire`]. A miss
+    /// against an engine that has loaded a component triggers one
+    /// `aether.inventory.kinds` refresh before erroring "unknown
+    /// kind"; the encode then succeeds for the component's own kinds.
+    async fn build_mail_envelope(&self, spec: MailSpec) -> anyhow::Result<MailEnvelope> {
         let engine = EngineId(
             Uuid::parse_str(&spec.engine_id)
                 .map_err(|e| anyhow::anyhow!("engine_id is not a valid UUID: {e}"))?,
         );
-        let desc = descriptors
-            .iter()
-            .find(|d| d.name == spec.kind_name)
-            .ok_or_else(|| anyhow::anyhow!("unknown kind: {}", spec.kind_name))?;
+        let desc = self.lookup_descriptor(engine, &spec.kind_name).await?;
         let params = spec.params.unwrap_or(serde_json::Value::Null);
         let payload = aether_codec::encode_schema(&params, &desc.schema)
             .map_err(|e| anyhow::anyhow!("param encode failed: {e}"))?;
@@ -991,6 +1029,151 @@ impl Mcp {
         cache
             .entry(engine)
             .or_insert_with(|| EngineNames::from_manifest(&manifest));
+    }
+
+    /// ADR-0091 §3 lookup → miss → refresh → retry → error flow. Look
+    /// up `kind_name` in the engine's encode cache; on a miss, fetch
+    /// the substrate's authoritative vocabulary via
+    /// `aether.inventory.kinds` and retry. The per-engine refresh is
+    /// collapsed under an async mutex so two concurrent misses on
+    /// different unknown names trigger one RPC, not two.
+    ///
+    /// Returns the matched descriptor; errors with `unknown kind: …`
+    /// after one refresh round-trip if the engine doesn't recognise
+    /// the name (a typoed kind, or a kind belonging to a component
+    /// that hasn't been loaded yet — distinguishable by the error
+    /// type at the substrate's later dispatch attempt).
+    async fn lookup_descriptor(
+        &self,
+        engine: EngineId,
+        kind_name: &str,
+    ) -> anyhow::Result<KindDescriptor> {
+        // Fast path: hit on the cache as it stands. `prefill_engine`
+        // populates the static `descriptors::all()` baseline on first
+        // touch so the very first send for a substrate-vocab kind
+        // doesn't trip a refresh.
+        self.prefill_engine(engine);
+        if let Some(desc) = self.cache_lookup(engine, kind_name) {
+            return Ok(desc);
+        }
+
+        // Miss: take the per-engine refresh mutex, then re-check (a
+        // concurrent waiter may have just refreshed) and refresh
+        // ourselves if still missing.
+        let guard = self.refresh_guard(engine);
+        let _refresh = guard.lock().await;
+        if let Some(desc) = self.cache_lookup(engine, kind_name) {
+            return Ok(desc);
+        }
+        self.refresh_engine_kinds(engine).await;
+        self.cache_lookup(engine, kind_name)
+            .ok_or_else(|| anyhow::anyhow!("unknown kind: {kind_name}"))
+    }
+
+    /// Seed `engine`'s cache from the substrate's static vocabulary
+    /// (`descriptors::all`) the first time the harness touches it. The
+    /// static set is process-global so a second engine with the same
+    /// build sees the same prefill, but the cache is keyed per-engine
+    /// because component-defined kinds aren't shared across engines.
+    #[allow(clippy::significant_drop_tightening)] // tight scope already
+    fn prefill_engine(&self, engine: EngineId) {
+        let mut cache = self
+            .kinds
+            .descriptors
+            .lock()
+            .expect("kinds-cache mutex is never poisoned");
+        cache.entry(engine).or_insert_with(|| {
+            descriptors::all()
+                .into_iter()
+                .map(|d| (d.name.clone(), d))
+                .collect()
+        });
+    }
+
+    /// Synchronous cache hit/miss check — no await, holds the std
+    /// `Mutex` only across the cloning lookup.
+    fn cache_lookup(&self, engine: EngineId, kind_name: &str) -> Option<KindDescriptor> {
+        let cache = self
+            .kinds
+            .descriptors
+            .lock()
+            .expect("kinds-cache mutex is never poisoned");
+        cache.get(&engine).and_then(|m| m.get(kind_name).cloned())
+    }
+
+    /// Fetch-or-create the per-engine refresh mutex. The mutex is
+    /// wrapped in an `Arc` so we can drop the cache lock before
+    /// awaiting; the only writers to `refresh_guards` are this
+    /// function itself, so it's a small concurrent-insert with no
+    /// upstream contention.
+    fn refresh_guard(&self, engine: EngineId) -> Arc<AsyncMutex<()>> {
+        let mut guards = self
+            .kinds
+            .refresh_guards
+            .lock()
+            .expect("kinds-cache refresh-guards mutex is never poisoned");
+        guards
+            .entry(engine)
+            .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+            .clone()
+    }
+
+    /// Issue `ListKinds` against the engine's `aether.inventory`
+    /// mailbox and replace this engine's cache with the reply (folded
+    /// over the static prefill — a component's own kinds layer on top
+    /// of the substrate baseline, neither side wins exclusively).
+    /// A failed RPC / undecodable reply leaves the cache untouched so
+    /// the caller's retry surfaces the original "unknown kind" miss
+    /// rather than a transient RPC error.
+    async fn refresh_engine_kinds(&self, engine: EngineId) {
+        let Some(ListKindsResult { kinds }) = self
+            .session
+            .call_one(engine_envelope(engine, INVENTORY_CAP, &ListKinds {}))
+            .await
+            .ok()
+            .and_then(|reply| ListKindsResult::decode_from_bytes(&reply.payload))
+        else {
+            return;
+        };
+
+        // Decode each `schema_postcard` back into a `SchemaType`; an
+        // entry whose schema fails to decode is dropped (the
+        // substrate's wire form is canonical, so a decode failure is
+        // a substrate / aether-data version mismatch — better to skip
+        // the entry than panic the tool call).
+        let fresh: Vec<KindDescriptor> = kinds
+            .into_iter()
+            .filter_map(|wire| {
+                let schema = postcard::from_bytes::<SchemaType>(&wire.schema_postcard).ok()?;
+                Some(KindDescriptor {
+                    name: wire.name,
+                    schema,
+                })
+            })
+            .collect();
+
+        // Hold the cache lock only for the merge; the await above is
+        // already complete, so the `MutexGuard`'s significant `Drop`
+        // doesn't span any await point.
+        self.merge_into_engine_cache(engine, fresh);
+    }
+
+    /// Merge `fresh` into `engine`'s cache map, replacing any prior
+    /// entries with the same name. Factored out of `refresh_engine_kinds`
+    /// so the cache lock is acquired in a tight scope — no other state
+    /// hangs off the same critical section, and no await crosses the
+    /// guard.
+    #[allow(clippy::significant_drop_tightening)] // tight scope already
+    fn merge_into_engine_cache(&self, engine: EngineId, fresh: Vec<KindDescriptor>) {
+        let mut cache = self
+            .kinds
+            .descriptors
+            .lock()
+            .expect("kinds-cache mutex is never poisoned");
+        let map = cache.entry(engine).or_default();
+        for desc in fresh {
+            map.insert(desc.name.clone(), desc);
+        }
     }
 
     /// Batch-resolve `ids` that the engine's static map missed via
@@ -1343,34 +1526,33 @@ async fn build_descriptor(arg: DagDescriptorArg) -> anyhow::Result<DagDescriptor
     })
 }
 
-/// Encode a `send_mail_traced` batch into the same `MailEnvelope`
-/// shape `CaptureFrame` carries: name-level addressing + schema-encoded
-/// payload. The substrate's `TraceObserver` resolves the names through
-/// its registry at dispatch time. Same `resolve_payload` path
-/// `encode_capture_bundle` uses, just over `TracedMailSpec` instead of
-/// `CaptureMailSpec`.
-fn encode_traced_bundle(
-    descriptors: &[KindDescriptor],
-    specs: &[TracedMailSpec],
-) -> anyhow::Result<Vec<KindMailEnvelope>> {
-    specs
-        .iter()
-        .map(|spec| {
-            let desc = descriptors
-                .iter()
-                .find(|d| d.name == spec.kind_name)
-                .ok_or_else(|| anyhow::anyhow!("unknown kind: {}", spec.kind_name))?;
+impl Mcp {
+    /// Encode a `send_mail_traced` batch into the same `MailEnvelope`
+    /// shape `CaptureFrame` carries: name-level addressing + schema-
+    /// encoded payload. The substrate's `TraceObserver` resolves the
+    /// names through its registry at dispatch time. Same lookup path
+    /// `encode_capture_bundle` uses (per-engine merged view, ADR-0091),
+    /// just over `TracedMailSpec` instead of `CaptureMailSpec`.
+    async fn encode_traced_bundle(
+        &self,
+        engine: EngineId,
+        specs: &[TracedMailSpec],
+    ) -> anyhow::Result<Vec<KindMailEnvelope>> {
+        let mut out = Vec::with_capacity(specs.len());
+        for spec in specs {
+            let desc = self.lookup_descriptor(engine, &spec.kind_name).await?;
             let params = spec.params.clone().unwrap_or(serde_json::Value::Null);
             let payload = aether_codec::encode_schema(&params, &desc.schema)
                 .map_err(|e| anyhow::anyhow!("param encode failed for {}: {e}", spec.kind_name))?;
-            Ok(KindMailEnvelope {
+            out.push(KindMailEnvelope {
                 recipient_name: spec.recipient_name.clone(),
                 kind_name: spec.kind_name.clone(),
                 payload,
                 count: 1,
-            })
-        })
-        .collect()
+            });
+        }
+        Ok(out)
+    }
 }
 
 /// Render a raw `u64` mailbox / kind / thread id to its display string
@@ -1437,32 +1619,32 @@ fn node_reversible_ids(node: &MailNodeWire) -> Vec<u64> {
     ids
 }
 
-/// Encode a `capture_frame` mail bundle: resolve each spec's kind
-/// against the substrate descriptor inventory, schema-encode its
-/// params, and wrap into the substrate-side `aether_kinds::MailEnvelope`
-/// shape (name-level addressing + pre-encoded payload).
-fn encode_capture_bundle(
-    descriptors: &[KindDescriptor],
-    specs: &[CaptureMailSpec],
-) -> anyhow::Result<Vec<aether_kinds::MailEnvelope>> {
-    specs
-        .iter()
-        .map(|spec| {
-            let desc = descriptors
-                .iter()
-                .find(|d| d.name == spec.kind_name)
-                .ok_or_else(|| anyhow::anyhow!("unknown kind: {}", spec.kind_name))?;
+impl Mcp {
+    /// Encode a `capture_frame` mail bundle: resolve each spec's kind
+    /// against the per-engine merged view (ADR-0091, static prefill +
+    /// cached `ListKinds` reply), schema-encode its params, and wrap
+    /// into the substrate-side `aether_kinds::MailEnvelope` shape
+    /// (name-level addressing + pre-encoded payload).
+    async fn encode_capture_bundle(
+        &self,
+        engine: EngineId,
+        specs: &[CaptureMailSpec],
+    ) -> anyhow::Result<Vec<aether_kinds::MailEnvelope>> {
+        let mut out = Vec::with_capacity(specs.len());
+        for spec in specs {
+            let desc = self.lookup_descriptor(engine, &spec.kind_name).await?;
             let params = spec.params.clone().unwrap_or(serde_json::Value::Null);
             let payload = aether_codec::encode_schema(&params, &desc.schema)
                 .map_err(|e| anyhow::anyhow!("param encode failed for {}: {e}", spec.kind_name))?;
-            Ok(aether_kinds::MailEnvelope {
+            out.push(aether_kinds::MailEnvelope {
                 recipient_name: spec.recipient_name.clone(),
                 kind_name: spec.kind_name.clone(),
                 payload,
                 count: 1,
-            })
-        })
-        .collect()
+            });
+        }
+        Ok(out)
+    }
 }
 
 /// Serialize a tool result to the JSON string `rmcp` wraps as text
@@ -1585,14 +1767,68 @@ mod tests {
     }
 
     /// Connect an `RpcSession` + wrap it in an `Mcp` against a booted
-    /// hub chassis, with fresh component + reverse-name caches.
+    /// hub chassis, with fresh component, reverse-name, and kind-encode
+    /// caches.
     fn connect_mcp(port: u16) -> Mcp {
         let session = RpcSession::connect(&format!("127.0.0.1:{port}")).expect("session connects");
         Mcp::new(
             Arc::new(session),
             Arc::new(ComponentCache::default()),
             Arc::new(ReverseNameCache::default()),
+            Arc::new(KindsCache::default()),
         )
+    }
+
+    /// Hub-shape chassis with `InventoryCapability` installed and a
+    /// caller-supplied descriptor registered against the bench's
+    /// `Registry` — emulating the post-`load_component` state where
+    /// a component's own kind is in the substrate's vocab but not in
+    /// `descriptors::all()`. Used by ADR-0091's end-to-end check that
+    /// the MCP encode path picks the registered kind up via
+    /// `aether.inventory.kinds`.
+    fn boot_hub_with_inventory(
+        extras: &[KindDescriptor],
+    ) -> (PassiveChassis<TestChassis>, u16) {
+        use aether_capabilities::InventoryCapability;
+
+        let registry = Arc::new(Registry::new());
+        for d in descriptors::all() {
+            let _ = registry.register_kind_with_descriptor(d);
+        }
+        for d in extras {
+            // Component-defined kinds enter the substrate's `Registry`
+            // via `ComponentHostCapability::handle_load` →
+            // `register_or_match_all`; here we shortcut that with a
+            // direct register so the test doesn't need a real wasm
+            // load lifecycle (the ADR-0091 surface under test is the
+            // *projection*, not the loader).
+            let _ = registry.register_kind_with_descriptor(d.clone());
+        }
+        let (outbound, _rx) = HubOutbound::attached_loopback();
+        let store = Arc::new(HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<TraceDispatchCapability>(())
+            .with_actor::<EngineServer>(())
+            // The inventory cap pulls `Arc::clone(ctx.mailer().registry())`
+            // in `init`, so it sees the same `Registry` we just wrote
+            // the extra kinds into.
+            .with_actor::<InventoryCapability>(())
+            .with_actor::<RpcServerCapability>(RpcServerConfig {
+                bind_addr: "127.0.0.1:0".into(),
+                peer_kind: PeerKind::Substrate {
+                    engine_name: "test-hub".into(),
+                    engine_version: "0.1.0".into(),
+                    kinds: vec![],
+                },
+            })
+            .build_passive()
+            .expect("hub caps boot");
+        let port = chassis
+            .handle::<RpcServerHandle>()
+            .expect("RpcServerHandle published")
+            .local_port;
+        (chassis, port)
     }
 
     /// `list_engines` over the RPC round-trip yields an empty array on
@@ -2312,6 +2548,135 @@ mod tests {
             "a clean decode omits the payload_bytes key entirely: {json}",
         );
         assert!(obj.contains_key("params"), "params is still present");
+    }
+
+    /// ADR-0091 issue 1232 (end-to-end): a kind registered in the
+    /// substrate's `Registry` — emulating the post-`load_component`
+    /// state for a component-defined kind like `aether.mesh.load` —
+    /// flows through `InventoryCapability`'s `ListKinds` projection
+    /// onto the wire, lands in the harness's per-engine encode cache,
+    /// and the next `send_mail` encodes correctly. This is the
+    /// forcing-function path the issue calls out: a kind NOT in
+    /// `descriptors::all()` becomes encodable the moment the substrate
+    /// holds it.
+    ///
+    /// Test addresses the engines cap with `engine = None` (the hub
+    /// fixture's local dispatch path) so the round-trip closes against
+    /// the same chassis without needing a separately-routed engine
+    /// proxy; the cache machinery under test is engine-keyed but
+    /// engine-agnostic at the RPC layer.
+    #[tokio::test]
+    async fn lookup_descriptor_picks_up_a_post_load_kind_via_inventory() {
+        use aether_data::{KindDescriptor, SchemaType};
+
+        // The component-defined kind in this scenario: present in the
+        // substrate's `Registry` but not in `descriptors::all()`.
+        let component_kind = KindDescriptor {
+            name: "aether.test.component_defined_kind".to_owned(),
+            schema: SchemaType::String,
+        };
+
+        let extras = vec![component_kind.clone()];
+        let (_chassis, port) = boot_hub_with_inventory(&extras);
+        let session =
+            RpcSession::connect(&format!("127.0.0.1:{port}")).expect("session connects");
+        let mcp = Mcp::new(
+            Arc::new(session),
+            Arc::new(ComponentCache::default()),
+            Arc::new(ReverseNameCache::default()),
+            Arc::new(KindsCache::default()),
+        );
+
+        // Pre-condition: the static prefill does NOT carry the
+        // component's kind. (If a future change accidentally promotes
+        // it to native, the test surfaces immediately rather than
+        // silently bypassing the cache-refresh path.)
+        assert!(
+            !descriptors::all()
+                .iter()
+                .any(|d| d.name == component_kind.name),
+            "test invariant: the component kind must not be in the static descriptors",
+        );
+
+        // Address the hub's local `aether.inventory` via the engines-
+        // cap path: the hub-fixture's RPC server routes
+        // `engine = Some(uuid)` envelopes through the engines cap,
+        // which knows no matching engine and warn-drops. To exercise
+        // the cache against the local cap, route as a local Call
+        // by stamping `engine = None`. We bypass `lookup_descriptor`'s
+        // `engine_envelope` here because the test fixture is hub-
+        // shaped (the engines cap doesn't proxy to a separate
+        // substrate); in production the hub forwards to the engine
+        // and the engine answers via its local `aether.inventory`.
+        let reply = mcp
+            .session
+            .call_one(local_envelope(INVENTORY_CAP, &ListKinds {}))
+            .await
+            .expect("aether.inventory.kinds reply");
+        let result = ListKindsResult::decode_from_bytes(&reply.payload)
+            .expect("ListKindsResult decodes");
+        // The reply must include the registered component kind with a
+        // schema that decodes back to the originally registered shape
+        // — the wire path the harness's cache reads from.
+        let entry = result
+            .kinds
+            .iter()
+            .find(|k| k.name == component_kind.name)
+            .unwrap_or_else(|| {
+                panic!(
+                    "ListKindsResult should include the registered component kind; \
+                     got {:?}",
+                    result.kinds.iter().map(|k| &k.name).collect::<Vec<_>>(),
+                )
+            });
+        let decoded_schema: SchemaType = postcard::from_bytes(&entry.schema_postcard)
+            .expect("schema_postcard decodes");
+        assert!(
+            matches!(decoded_schema, SchemaType::String),
+            "the registered schema round-trips through the wire",
+        );
+
+        // Now drive the harness's encode path directly. Seed the
+        // per-engine cache the way a real refresh would (engine id is
+        // synthetic; the cache is engine-keyed so any uuid suffices
+        // for this assertion), then verify `build_mail_envelope`
+        // encodes a `MailSpec` against the component kind without
+        // ever consulting `descriptors::all()`. This is the surface
+        // the production `send_mail` reaches for after a
+        // `load_component` populates the cache via the same wire
+        // path the assertion above exercised.
+        let engine = EngineId(Uuid::from_u128(0x1232_dead_beef));
+        // Seed the per-engine cache the way `refresh_engine_kinds` would
+        // on a hit — the cache merge helper is the single writer.
+        mcp.merge_into_engine_cache(engine, vec![component_kind.clone()]);
+        let envelope = mcp
+            .build_mail_envelope(MailSpec {
+                engine_id: engine.0.to_string(),
+                recipient_name: "aether.component.trampoline:test".to_owned(),
+                kind_name: component_kind.name.clone(),
+                params: Some(serde_json::Value::String("hello".to_owned())),
+            })
+            .await
+            .expect("build_mail_envelope encodes the component-defined kind");
+        // The schema-encoded payload for a `SchemaType::String` is the
+        // postcard string wire shape; decoding back via the same
+        // schema must yield the original JSON value.
+        let decoded =
+            aether_codec::decode_schema(&envelope.payload, &component_kind.schema)
+                .expect("payload decodes against the cached schema");
+        assert_eq!(
+            decoded,
+            serde_json::Value::String("hello".to_owned()),
+            "the encoded payload round-trips through aether_codec against the live schema",
+        );
+        assert_eq!(
+            envelope.kind,
+            KindId(kind_id_from_parts(
+                &component_kind.name,
+                &component_kind.schema
+            )),
+            "envelope kind id matches the live KindId of the component-defined kind",
+        );
     }
 
     /// Issue 1242: `fire_and_forget: true` is non-blocking — a

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -23,12 +23,12 @@ use tokio::sync::Mutex as AsyncMutex;
 use aether_capabilities::rpc::{MailEnvelope, MailboxAddress};
 use aether_capabilities::trace_walk::TreeWalk;
 use aether_data::MailId;
+use aether_data::SchemaType;
 use aether_data::canonical::kind_id_from_parts;
 use aether_data::{
     DagId, EngineId, Kind, KindDescriptor, KindId, MailboxId, Tag, Uuid, mailbox_id_from_name,
     tagged_id,
 };
-use aether_data::SchemaType;
 use aether_kinds::dag::{DagDescriptor, Edge, Node, NodeId};
 use aether_kinds::{
     Cancel, CancelResult, CaptureFrame, CaptureFrameResult, ComponentCapabilities, CostTail,
@@ -1786,9 +1786,7 @@ mod tests {
     /// `descriptors::all()`. Used by ADR-0091's end-to-end check that
     /// the MCP encode path picks the registered kind up via
     /// `aether.inventory.kinds`.
-    fn boot_hub_with_inventory(
-        extras: &[KindDescriptor],
-    ) -> (PassiveChassis<TestChassis>, u16) {
+    fn boot_hub_with_inventory(extras: &[KindDescriptor]) -> (PassiveChassis<TestChassis>, u16) {
         use aether_capabilities::InventoryCapability;
 
         let registry = Arc::new(Registry::new());
@@ -2578,8 +2576,7 @@ mod tests {
 
         let extras = vec![component_kind.clone()];
         let (_chassis, port) = boot_hub_with_inventory(&extras);
-        let session =
-            RpcSession::connect(&format!("127.0.0.1:{port}")).expect("session connects");
+        let session = RpcSession::connect(&format!("127.0.0.1:{port}")).expect("session connects");
         let mcp = Mcp::new(
             Arc::new(session),
             Arc::new(ComponentCache::default()),
@@ -2613,8 +2610,8 @@ mod tests {
             .call_one(local_envelope(INVENTORY_CAP, &ListKinds {}))
             .await
             .expect("aether.inventory.kinds reply");
-        let result = ListKindsResult::decode_from_bytes(&reply.payload)
-            .expect("ListKindsResult decodes");
+        let result =
+            ListKindsResult::decode_from_bytes(&reply.payload).expect("ListKindsResult decodes");
         // The reply must include the registered component kind with a
         // schema that decodes back to the originally registered shape
         // — the wire path the harness's cache reads from.
@@ -2629,8 +2626,8 @@ mod tests {
                     result.kinds.iter().map(|k| &k.name).collect::<Vec<_>>(),
                 )
             });
-        let decoded_schema: SchemaType = postcard::from_bytes(&entry.schema_postcard)
-            .expect("schema_postcard decodes");
+        let decoded_schema: SchemaType =
+            postcard::from_bytes(&entry.schema_postcard).expect("schema_postcard decodes");
         assert!(
             matches!(decoded_schema, SchemaType::String),
             "the registered schema round-trips through the wire",
@@ -2661,9 +2658,8 @@ mod tests {
         // The schema-encoded payload for a `SchemaType::String` is the
         // postcard string wire shape; decoding back via the same
         // schema must yield the original JSON value.
-        let decoded =
-            aether_codec::decode_schema(&envelope.payload, &component_kind.schema)
-                .expect("payload decodes against the cached schema");
+        let decoded = aether_codec::decode_schema(&envelope.payload, &component_kind.schema)
+            .expect("payload decodes against the cached schema");
         assert_eq!(
             decoded,
             serde_json::Value::String("hello".to_owned()),


### PR DESCRIPTION
## Summary

- ADR-0091 §1–§3 implementation. Widen the `aether.inventory` cap from a compile-time reverse-lookup actor to a live per-engine kind-schema registry view; add lazy-on-miss caching to the MCP harness's encode path so a `send_mail` / `send_mail_traced` / `capture_frame` against a kind the substrate just registered (typical case: a component's own kinds after `aether.component.load`) encodes correctly without the kind being promoted into `aether-kinds`.
- One new request/reply kind pair (`ListKinds` / `ListKindsResult` carrying `KindDescriptorWire { id, name, schema_postcard }`), one new handler on `InventoryCapability` pulling the substrate's `Arc<Registry>` in `init`, and a new `KindsCache` parallel to `ComponentCache` / `ReverseNameCache` in `aether-mcp`. The three encode sites (`send_mail`, `send_mail_traced`, `capture_frame`) and their helpers route through a new `Mcp::lookup_descriptor` that hits the per-engine cache first and refreshes on miss via `aether.inventory.kinds`; concurrent misses collapse under a per-engine async mutex. The decode-side surfaces (`static_kind_name`, `decode_reply_events`, `describe_kinds`) keep `descriptors::all()` per ADR-0091 §3.
- One implementation-discovered tweak from the ADR's literal struct shape: `KindDescriptorWire.schema` rides as opaque postcard bytes (`schema_postcard: Vec<u8>`) because `SchemaType` has no `Schema` impl of its own — surfacing for review. Avoids touching `aether-data`; cap encodes via `postcard::to_allocvec`, harness decodes via `postcard::from_bytes`.

## Test plan

- [x] `cargo test -p aether-kinds --lib kind_names` — new `ListKinds` / `ListKindsResult` names added to the pinned-name assertion
- [x] `cargo test -p aether-capabilities --lib inventory` — new `list_kinds_projects_a_registered_kind` covers the cap's projection of `Registry::list_kind_descriptors` onto the wire
- [x] `cargo test -p aether-mcp --bin aether-mcp` — new `lookup_descriptor_picks_up_a_post_load_kind_via_inventory` end-to-end: registers a kind not in `descriptors::all()` against the bench's `Registry`, fires `aether.inventory.kinds` over RPC, decodes the reply's `schema_postcard` back to `SchemaType::String`, then drives `Mcp::build_mail_envelope` through the cache and round-trips the payload via `aether_codec::decode_schema` against the live schema
- [x] `scripts/preflight.sh` — fmt + clippy + doc + workspace nextest + wasm32 cross-build all green (with `AETHER_HANDLE_STORE_DIR` overridden to avoid contamination from a sibling-worktree leftover substrate)

Closes iamacoffeepot/aether#1232