### PR TITLE
chore(qodana): exclude aether-derive/tests/ui trybuild fixtures

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -25,6 +25,7 @@ exclude:
       # inspection fires on every one. The detachment is the trybuild
       # contract, not a defect; exclude the fixture trees.
       - crates/aether-data-derive/tests/ui
+      - crates/aether-derive/tests/ui
 
 # Native deps + toolchain bump.
 #


### PR DESCRIPTION
Mirrors the existing `aether-data-derive/tests/ui` exclude pattern. The new aether-derive crate (shipped in iamacoffeepot/aether#1268) ships trybuild compile-fail fixtures under `tests/ui/` — Qodana's "Detached file" inspection fires on every one since they're standalone `.rs` files compiled individually by trybuild, not attached to any cargo target. The detachment is the trybuild contract, not a defect.

Drops 7 of 8 noise findings on the post-g main. The remaining 1 "Unused import" finding will be tracked in a separate small follow-up once located (rust-analyzer inside Qodana sees it; standalone IntelliJ-Rust MCP doesn't reproduce, so it needs the qodana cloud report to locate the file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
