### PR TITLE
feat(capabilities): hub-allocate AETHER_HANDLE_STORE_DIR per spawned engine

### DIFF
--- a/crates/aether-capabilities/src/engine/server.rs
+++ b/crates/aether-capabilities/src/engine/server.rs
@@ -58,10 +58,19 @@ mod server_native {
     use aether_substrate::mail::mailer::Mailer;
     use aether_substrate::mail::{ReplyTarget, ReplyTo};
     use std::collections::HashMap;
+    use std::env;
     use std::io;
     use std::net::TcpListener;
+    use std::path::PathBuf;
     use std::process::{Command, Stdio};
     use std::sync::Arc;
+
+    /// Env override for the parent directory under which the cap
+    /// allocates per-engine handle-store dirs (issue 1274). Absent →
+    /// fall through to `dirs::data_dir().join("aether/engines")`, then
+    /// to `std::env::temp_dir().join("aether-engines")` if no data dir
+    /// is resolvable.
+    const ENV_ENGINE_STORE_ROOT: &str = "AETHER_ENGINE_STORE_ROOT";
 
     /// One supervised engine in [`EngineServer`]'s table.
     struct EngineEntry {
@@ -142,9 +151,20 @@ mod server_native {
                 }
             };
 
+            // ADR-0049 §7 reserves each handle-store dir to one
+            // substrate via `lock.pid`; two engines pointing at the
+            // same dir is a `LockError::Held`. Allocate a unique
+            // subdirectory per spawned engine so the hub-managed
+            // multi-engine workflow doesn't have to set
+            // `AETHER_HANDLE_STORE_DIR` by hand (issue 1274).
+            let engine_id = EngineId(Uuid::from_u128(self.next_engine_seq));
+            self.next_engine_seq += 1;
+            let engine_store_dir = engine_store_root().join(engine_id.0.simple().to_string());
+
             let child = match Command::new(&mail.binary_path)
                 .args(&mail.args)
                 .env("AETHER_RPC_PORT", rpc_port.to_string())
+                .env("AETHER_HANDLE_STORE_DIR", &engine_store_dir)
                 .stdin(Stdio::null())
                 .spawn()
             {
@@ -157,8 +177,6 @@ mod server_native {
                 }
             };
 
-            let engine_id = EngineId(Uuid::from_u128(self.next_engine_seq));
-            self.next_engine_seq += 1;
             let subname = engine_id.0.simple().to_string();
             let rpc_addr = format!("127.0.0.1:{rpc_port}");
 
@@ -340,6 +358,27 @@ mod server_native {
         let port = listener.local_addr()?.port();
         drop(listener);
         Ok(port)
+    }
+
+    /// Parent directory under which the cap allocates per-engine
+    /// handle-store dirs (issue 1274). Priority:
+    ///
+    /// 1. `AETHER_ENGINE_STORE_ROOT` env override (ops escape hatch).
+    /// 2. `dirs::data_dir().join("aether/engines")` (cross-platform
+    ///    default — `~/Library/Application Support/aether/engines` on
+    ///    macOS, `$XDG_DATA_HOME/aether/engines` on Linux, etc.).
+    /// 3. `std::env::temp_dir().join("aether-engines")` if no data
+    ///    dir is resolvable.
+    fn engine_store_root() -> PathBuf {
+        if let Ok(raw) = env::var(ENV_ENGINE_STORE_ROOT)
+            && !raw.is_empty()
+        {
+            return PathBuf::from(raw);
+        }
+        if let Some(data) = dirs::data_dir() {
+            return data.join("aether").join("engines");
+        }
+        env::temp_dir().join("aether-engines")
     }
 }
 

--- a/crates/aether-substrate-bundle/tests/engines_cap.rs
+++ b/crates/aether-substrate-bundle/tests/engines_cap.rs
@@ -25,9 +25,13 @@ use aether_substrate::mail::mailer::Mailer;
 use aether_substrate::mail::outbound::HubOutbound;
 use aether_substrate::mail::registry::Registry;
 use aether_substrate::mail::{Mail, ReplyTarget, ReplyTo};
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process;
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 struct TestChassis;
 impl Chassis for TestChassis {
@@ -222,4 +226,122 @@ fn engines_cap_spawns_lists_and_terminates_a_real_headless_substrate() {
         !list_after.engines.iter().any(|e| e.engine_id == engine_id),
         "terminated engine {engine_id} should be gone from ListEngines: {list_after:?}",
     );
+}
+
+/// Two engines spawned via the cap coexist with persistence on: each
+/// gets its own `${AETHER_ENGINE_STORE_ROOT}/<engine_id>` handle-store
+/// dir, so the ADR-0049 §7 `lock.pid` doesn't collide
+/// (iamacoffeepot/aether#1274). Before the fix, both substrates
+/// resolved to the same default `dirs::data_dir()/aether/handles` and
+/// one failed with `LockError::Held`.
+#[test]
+fn two_engines_get_distinct_handle_store_dirs() {
+    let headless = env!("CARGO_BIN_EXE_aether-substrate-headless");
+
+    // Per-test scratch dir under the system temp root. Process pid +
+    // nanos disambiguate against any leftover from a prior run that
+    // didn't clean up (the test below cleans on the success path).
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    let root = env::temp_dir().join(format!("aether-engines-cap-{}-{}", process::id(), nanos));
+
+    // SAFETY: nextest runs each test in its own process, so the env
+    // mutations here don't race sibling tests. We need (a) the cap's
+    // `engine_store_root()` to resolve to `root` (read in the test
+    // process when `on_spawn` runs), (b) the spawned substrates to
+    // NOT inherit a parent `AETHER_HANDLE_STORE_DIR` (which would win
+    // over the cap's per-engine injection), and (c) persistence not
+    // to be globally disabled — the lock-collision case the issue
+    // pins only fires when each substrate writes a `lock.pid`.
+    unsafe {
+        env::set_var("AETHER_ENGINE_STORE_ROOT", &root);
+        env::remove_var("AETHER_HANDLE_STORE_DIR");
+        env::remove_var("AETHER_HANDLE_STORE_PERSIST_DISABLE");
+    }
+
+    let (_chassis, mailer, cells) = boot();
+
+    // Spawn engine A.
+    let a = drive(
+        &mailer,
+        &SpawnEngine {
+            binary_path: headless.to_owned(),
+            args: vec![],
+        },
+        Duration::from_secs(30),
+        || {
+            cells
+                .spawn
+                .lock()
+                .expect("test setup: spawn cell mutex is never poisoned")
+                .take()
+        },
+    );
+    let a_id = match a {
+        SpawnEngineResult::Ok { engine_id, .. } => engine_id,
+        SpawnEngineResult::Err { error } => panic!("spawn A failed: {error}"),
+    };
+
+    // Spawn engine B. Pre-fix this would race the same handle-store
+    // dir and either A or B would die with `LockError::Held`; the
+    // cap's reply to `on_spawn` would be `Err` because the proxy
+    // never connected to a substrate that aborted boot. The assertion
+    // below is structural — both spawn replies are Ok.
+    let b = drive(
+        &mailer,
+        &SpawnEngine {
+            binary_path: headless.to_owned(),
+            args: vec![],
+        },
+        Duration::from_secs(30),
+        || {
+            cells
+                .spawn
+                .lock()
+                .expect("test setup: spawn cell mutex is never poisoned")
+                .take()
+        },
+    );
+    let b_id = match b {
+        SpawnEngineResult::Ok { engine_id, .. } => engine_id,
+        SpawnEngineResult::Err { error } => panic!("spawn B failed: {error}"),
+    };
+    assert_ne!(a_id, b_id, "the cap must mint distinct engine ids");
+
+    // Walk `root/` for the per-engine subdirs the cap allocated.
+    // Each child substrate creates `lock.pid` + `v1/` lazily under
+    // its assigned `AETHER_HANDLE_STORE_DIR`, so we only assert on the
+    // top-level subdir count — the lock collision (the actual bug)
+    // would surface as a missing dir or a failed spawn earlier.
+    let subdirs: Vec<PathBuf> = fs::read_dir(&root)
+        .unwrap_or_else(|e| panic!("read_dir({}): {e}", root.display()))
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|p| p.is_dir())
+        .collect();
+    assert_eq!(
+        subdirs.len(),
+        2,
+        "expected two per-engine handle-store dirs under {}; saw: {subdirs:?}",
+        root.display(),
+    );
+
+    // Terminate both engines so their proxies SIGKILL the substrates;
+    // best-effort cleanup of the scratch root follows.
+    for id in [a_id, b_id] {
+        let _ = drive(
+            &mailer,
+            &TerminateEngine { engine_id: id },
+            Duration::from_secs(5),
+            || {
+                cells
+                    .terminate
+                    .lock()
+                    .expect("test setup: terminate cell mutex is never poisoned")
+                    .take()
+            },
+        );
+    }
+    let _ = fs::remove_dir_all(&root);
 }


### PR DESCRIPTION
Closes iamacoffeepot/aether#1274.

Routes around the ADR-0049 §7 single-substrate-per-store foot-gun for hub-managed multi-engine fleets. The hub already injects `AETHER_RPC_PORT` per spawned engine at fork time (`engine/server.rs`); this adds the parallel `AETHER_HANDLE_STORE_DIR` injection so each engine gets its own isolated handle-store dir by construction.

## What changed

- `engine_store_root()` resolver in `aether-capabilities/src/engine/server.rs` (under `mod server_native`) — 3-tier priority:
  1. `AETHER_ENGINE_STORE_ROOT` env override (ops escape hatch for a non-default parent).
  2. `dirs::data_dir().join("aether/engines")` (cross-platform default).
  3. `std::env::temp_dir().join("aether-engines")` fallback.
- `EngineServer::on_spawn` now computes `${root}/<engine_id_simple>` and injects `.env("AETHER_HANDLE_STORE_DIR", engine_store_dir)` next to the existing `AETHER_RPC_PORT` injection.
- New integration test `two_engines_get_distinct_handle_store_dirs` in `crates/aether-substrate-bundle/tests/engines_cap.rs` — sets `AETHER_ENGINE_STORE_ROOT` to a per-PID/per-nanos tmpdir, spawns two real `aether-substrate-headless` engines through the cap, asserts both spawn replies are `Ok`, then asserts exactly two per-engine subdirs land under `${tmpdir}/`.

## Out of scope

- The ADR-0049 §7 lockfile mechanism stays. This routes around the foot-gun for hub-managed spawns; the single-substrate direct-spawn path is unchanged.
- No cleanup-of-old-engine-dirs.

## Validation

- `cargo nextest run --workspace --all-features`: 1425/1425 passed, 6 skipped.
- Preflight green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
