### PR TITLE
fix(capabilities): capture_frame acquires settlement hold for deferred reply

### DIFF
--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -373,10 +373,25 @@ mod native {
                 }
             }
 
+            // ADR-0086 §12 / iamacoffeepot/aether#1273: capture is a
+            // deferred reply — the render thread sends the reply after
+            // the cap handler has returned. Acquire the settlement hold
+            // *before* the queue handoff so `HoldOpen` is visible to
+            // the settlement counter ahead of this handler's
+            // `Finished`; the hold rides on `PendingCapture` and drops
+            // with `req` after `outbound.send_reply` on the render
+            // thread (`desktop/driver.rs` line ~568, `test_bench/
+            // bench.rs` line ~1019). Mirrors the `contentgen::dispatch`
+            // submit path. The early-return branches above reply
+            // synchronously inside this handler's own dispatch window,
+            // so they're naturally covered by the handler's in-flight
+            // `Finished` bracket and don't need the hold.
+            let hold = ctx.mailer().acquire_settlement_hold(ctx.in_flight_root());
             let pending = PendingCapture {
                 reply_to: sender,
                 after_mails: after,
                 pre_settlements,
+                hold,
             };
             if !backend.queue.request(pending) {
                 backend.outbound.send_reply(

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -566,6 +566,13 @@ impl ApplicationHandler<UserEvent> for App {
                                 self.queue.push(mail);
                             }
                             self.outbound.send_reply(req.reply_to, &result);
+                            // iamacoffeepot/aether#1273: `req` still owns
+                            // `PendingCapture._hold` after the partial moves
+                            // above; the field drops at end of this scope —
+                            // *after* `send_reply` returns — firing
+                            // `Release` on the trace root so `Settled{root}`
+                            // is exact at post-reply. Don't restructure to
+                            // move the reply below other work in this arm.
                         }
                         None => {
                             gpu.render();

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -1017,6 +1017,13 @@ impl TestBench {
                     self.queue.push(mail);
                 }
                 self.outbound.send_reply(req.reply_to, &result);
+                // iamacoffeepot/aether#1273: `req` still owns
+                // `PendingCapture._hold` after the partial moves above; the
+                // field drops at end of this match arm — *after*
+                // `send_reply` returns — firing `Release` on the trace
+                // root so `Settled{root}` is exact at post-reply. Don't
+                // restructure to move the reply below other work in this
+                // arm.
             }
             None => {
                 self.gpu.render();
@@ -1083,6 +1090,60 @@ mod tests {
             "captured bytes are not a PNG: first 8 bytes={:?}",
             &png.iter().take(8).copied().collect::<Vec<u8>>(),
         );
+    }
+
+    /// iamacoffeepot/aether#1273: `on_capture_frame` parks the request
+    /// on the capture queue and returns immediately — the reply happens
+    /// later on the chassis main thread. ADR-0086 §12 says deferred
+    /// replies MUST hold-open against the trace root; without that hold
+    /// `Settled{root}` fires before the reply lands and the wire `Call`
+    /// driving the MCP tool ends with zero collected reply events.
+    ///
+    /// This test sends `CaptureFrame` via `BenchOp::send_and_await` (the
+    /// shape the issue's regression test calls for) and asserts the
+    /// reply decodes to `CaptureFrameResult::Ok { png: <non-empty> }`.
+    /// The PNG comes back through the loopback's `EgressEvent::ToSession`
+    /// — same correlation-id round-trip the MCP harness uses, but
+    /// in-process.
+    #[test]
+    fn capture_frame_send_and_await_returns_png() {
+        let mut tb = match TestBench::start_with_size(64, 48) {
+            Ok(tb) => tb,
+            Err(e) => {
+                eprintln!("skipping: TestBench boot failed (likely no wgpu adapter): {e}");
+                return;
+            }
+        };
+        let result = tb
+            .execute(vec![
+                ("tick", BenchOp::advance(1)),
+                (
+                    "capture",
+                    BenchOp::send_and_await(
+                        RenderCapability::NAMESPACE,
+                        &CaptureFrame {
+                            mails: Vec::new(),
+                            after_mails: Vec::new(),
+                        },
+                    ),
+                ),
+            ])
+            .expect("advance + send_and_await(CaptureFrame)");
+        let reply: CaptureFrameResult = result
+            .reply("capture")
+            .expect("capture step replied with CaptureFrameResult");
+        match reply {
+            CaptureFrameResult::Ok { png } => {
+                assert!(
+                    png.starts_with(&[0x89, 0x50, 0x4E, 0x47]),
+                    "captured bytes are not a PNG: first 8 bytes={:?}",
+                    &png.iter().take(8).copied().collect::<Vec<u8>>(),
+                );
+            }
+            CaptureFrameResult::Err { error } => {
+                panic!("capture_frame replied Err: {error}");
+            }
+        }
     }
 
     /// Issue iamacoffeepot/aether#723: chassis-source ticks are minted

--- a/crates/aether-substrate/src/capture.rs
+++ b/crates/aether-substrate/src/capture.rs
@@ -30,6 +30,7 @@ use std::sync::{Arc, Mutex};
 use crossbeam_channel::Receiver;
 
 use crate::mail::{Mail, ReplyTo};
+use crate::runtime::trace::SettlementHold;
 
 /// One pending capture request. Carries the reply handle so the
 /// render thread can reply once it has bytes, plus a resolved list
@@ -50,6 +51,23 @@ pub struct PendingCapture {
     pub reply_to: ReplyTo,
     pub after_mails: Vec<Mail>,
     pub pre_settlements: Vec<Receiver<()>>,
+    /// ADR-0086 §12 settlement hold: held from `on_capture_frame` accept
+    /// until the render thread's `send_reply` returns; drops with
+    /// `PendingCapture` at end of the reply scope, firing `Release` so
+    /// `Settled{root}` becomes exact post-reply. Without this guard the
+    /// cap handler's `Finished` lands before the readback reply, the
+    /// trace observer settles the chain, and the wire `Call` ends with
+    /// zero reply events (iamacoffeepot/aether#1273). The pattern
+    /// mirrors `contentgen::dispatch` (acquired before queue handoff so
+    /// `HoldOpen` is visible to the settlement counter ahead of
+    /// `Finished`).
+    ///
+    /// The field is never read — its sole job is to keep the
+    /// [`SettlementHold`]'s `Drop` impl tied to the lifetime of this
+    /// `PendingCapture`. `SettlementHold` carries `#[must_use]`, so
+    /// stashing it on a named field (rather than `_`) is the only way
+    /// to keep it alive across the queue handoff.
+    pub hold: SettlementHold,
 }
 
 /// Single-slot queue. Cheaply cloneable (wraps an `Arc`), shared
@@ -106,17 +124,24 @@ impl CaptureQueue {
 mod tests {
     use super::*;
     use crate::ReplyTarget;
-    use aether_data::{SessionToken, Uuid};
+    use crate::runtime::trace::TraceHandle;
+    use aether_data::{MailId, SessionToken, Uuid};
 
     fn reply_to(u: u128) -> ReplyTo {
         ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::from_u128(u))))
     }
 
     fn pending(u: u128) -> PendingCapture {
+        // Sentinel `MailId::NONE` keeps the acquire/release pair a no-op
+        // in the settlement counter — the test exercises queue mechanics,
+        // not the trace pipeline. `TraceHandle::new()` builds a stand-
+        // alone handle with no installed registry.
+        let hold = TraceHandle::new().acquire_settlement_hold(MailId::NONE);
         PendingCapture {
             reply_to: reply_to(u),
             after_mails: Vec::new(),
             pre_settlements: Vec::new(),
+            hold,
         }
     }
 


### PR DESCRIPTION
Closes iamacoffeepot/aether#1273.

`on_capture_frame` parked the request on `CaptureBackend.queue` and returned immediately; the actual reply happened later on the chassis main thread. ADR-0086 says deferred replies MUST hold-open against the trace root, but the capture path never acquired one — `Settled{root}` fired before the reply landed and MCP saw "expected exactly one reply event, got 0."

## What changed

- `aether-substrate/src/capture.rs` — `PendingCapture` gains a `pub hold: SettlementHold` field; doc comment notes ownership-only role.
- `aether-capabilities/src/render.rs` — `on_capture_frame` acquires `ctx.mailer().acquire_settlement_hold(ctx.in_flight_root())` immediately before `backend.queue.request(pending)` and carries the guard on `PendingCapture`.
- `aether-substrate-bundle/src/desktop/driver.rs` — sanity comment at the reply site noting that `req` still owns the hold after partial moves and drops at end-of-scope after `send_reply`.
- `aether-substrate-bundle/src/test_bench/bench.rs` — same sanity comment; new regression test `capture_frame_send_and_await_returns_png` that exercises the new path and asserts the reply decodes to `CaptureFrameResult::Ok { png: <magic> }`.

## Deviation from issue body

Field renamed `_hold` → `hold`: clippy `pub_underscore_fields` blocks a `pub` field with a leading underscore. Matches the existing precedent at `contentgen::dispatch::QueuedRequest.hold`. The field is never read; ownership keeps it alive.

## Surfaced for review attention

The regression test exercises the new code path (acquires + drops the hold; asserts the PNG round-trip stays green) but does not actually reproduce the bug end-to-end. `test_bench`'s `pump_until_reply` polls `EgressEvent::ToSession` on the loopback channel directly without settlement gating, so the reply arrives whether or not the hold was acquired. The real symptom — `Settled{root}` firing before the reply on the MCP wire — is only observable via the MCP harness (`send_mail_traced`). Manual `/verify` smoke is the only path that exercises the actual ADR-0086 settlement gate end-to-end.

## Validation

- `cargo nextest run --workspace --all-features`: 1425/1425 passed, 6 skipped.
- Preflight green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
