### PR TITLE
fix(capabilities): structured RpcError for oversize RPC frames (issue 1271)

### DIFF
--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -491,127 +491,15 @@ mod server_native {
             let thread = match thread::Builder::new()
                 .name(format!("aether-rpc-reader-{conn_id}"))
                 .spawn(move || {
-                    let mut reader = BufReader::new(read_half);
-                    loop {
-                        if shutdown_for_thread.load(Ordering::Acquire) {
-                            break;
-                        }
-                        let frame: WireFrame = match read_frame(&mut reader) {
-                            Ok(f) => f,
-                            Err(FrameError::Io(io_err))
-                                if io_err.kind() == io::ErrorKind::UnexpectedEof =>
-                            {
-                                let _ = inbound_tx.send(InboundEvent::ReaderClosed {
-                                    conn_id,
-                                    reason: "eof".into(),
-                                });
-                                mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
-                                break;
-                            }
-                            Err(FrameError::FrameTooLarge { size, max }) => {
-                                // The 4-byte length prefix has been
-                                // consumed but the body is still on
-                                // the wire (issue 1271). If draining
-                                // the body wouldn't itself be an OOM
-                                // vector, drain it so the stream
-                                // re-syncs at the next frame boundary
-                                // and the connection survives; if it
-                                // would, ask the dispatcher to write a
-                                // structured `Bye` and tear the
-                                // connection down.
-                                let drain_ceiling = max.saturating_mul(2);
-                                #[allow(clippy::cast_possible_truncation)]
-                                let event = if size <= drain_ceiling {
-                                    // `take(size)` bounds the drain so a
-                                    // racy / lying peer can't push us
-                                    // past the cap-2x ceiling on bytes
-                                    // we'll allocate scratch for.
-                                    let mut drain = io::sink();
-                                    let mut bounded = io::Read::take(&mut reader, size as u64);
-                                    let drained = match io::copy(&mut bounded, &mut drain) {
-                                        Ok(n) => n,
-                                        Err(_) => {
-                                            // Drain failed (socket
-                                            // dropped, truncated
-                                            // body). Treat as a
-                                            // real read error and
-                                            // close the connection.
-                                            let _ = inbound_tx.send(InboundEvent::ReaderClosed {
-                                                conn_id,
-                                                reason: format!(
-                                                    "frame too large drain failed: {size} > {max}"
-                                                ),
-                                            });
-                                            mailer.push(Mail::new(
-                                                self_id,
-                                                wake_kind,
-                                                Vec::new(),
-                                                1,
-                                            ));
-                                            break;
-                                        }
-                                    };
-                                    if (drained as usize) != size {
-                                        // Peer hung up mid-body.
-                                        let _ = inbound_tx.send(InboundEvent::ReaderClosed {
-                                            conn_id,
-                                            reason: format!(
-                                                "frame too large partial drain: {drained}/{size}"
-                                            ),
-                                        });
-                                        mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
-                                        break;
-                                    }
-                                    InboundEvent::FrameDecodeError {
-                                        conn_id,
-                                        error: RpcError::FrameTooLarge {
-                                            size: size as u64,
-                                            max: max as u64,
-                                        },
-                                    }
-                                } else {
-                                    InboundEvent::FrameDecodeAborted {
-                                        conn_id,
-                                        error: RpcError::FrameTooLarge {
-                                            size: size as u64,
-                                            max: max as u64,
-                                        },
-                                    }
-                                };
-                                let abort =
-                                    matches!(event, InboundEvent::FrameDecodeAborted { .. },);
-                                if inbound_tx.send(event).is_err() {
-                                    break;
-                                }
-                                mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
-                                if abort {
-                                    // The dispatcher will close the
-                                    // connection. Exit the read loop
-                                    // to free the read half.
-                                    break;
-                                }
-                                continue;
-                            }
-                            Err(e) => {
-                                if shutdown_for_thread.load(Ordering::Acquire) {
-                                    break;
-                                }
-                                let _ = inbound_tx.send(InboundEvent::ReaderClosed {
-                                    conn_id,
-                                    reason: format!("read error: {e}"),
-                                });
-                                mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
-                                break;
-                            }
-                        };
-                        if inbound_tx
-                            .send(InboundEvent::FrameReceived { conn_id, frame })
-                            .is_err()
-                        {
-                            break;
-                        }
-                        mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
-                    }
+                    run_reader_loop(
+                        read_half,
+                        conn_id,
+                        &shutdown_for_thread,
+                        &inbound_tx,
+                        &mailer,
+                        self_id,
+                        wake_kind,
+                    );
                 }) {
                 Ok(t) => t,
                 Err(e) => {
@@ -836,6 +724,158 @@ mod server_native {
                 self.close_connection(conn_id, reason);
             }
         }
+    }
+
+    /// Per-connection reader thread body. Reads frames from
+    /// `read_half` and pushes them onto `inbound_tx`; on an oversize
+    /// inbound frame (`FrameError::FrameTooLarge`) drains the body if
+    /// it's inside the drain ceiling so the connection survives, or
+    /// asks the dispatcher to close it with a structured `Bye` if not
+    /// (iamacoffeepot/aether#1271). Returns when the connection closes
+    /// (peer EOF, read error, shutdown flag, oversize-abort).
+    fn run_reader_loop(
+        read_half: TcpStream,
+        conn_id: ConnId,
+        shutdown: &AtomicBool,
+        inbound_tx: &mpsc::Sender<InboundEvent>,
+        mailer: &Arc<Mailer>,
+        self_id: MailboxId,
+        wake_kind: KindId,
+    ) {
+        let mut reader = BufReader::new(read_half);
+        loop {
+            if shutdown.load(Ordering::Acquire) {
+                return;
+            }
+            match read_frame(&mut reader) {
+                Ok(frame) => {
+                    if inbound_tx
+                        .send(InboundEvent::FrameReceived { conn_id, frame })
+                        .is_err()
+                    {
+                        return;
+                    }
+                    mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
+                }
+                Err(FrameError::Io(io_err)) if io_err.kind() == io::ErrorKind::UnexpectedEof => {
+                    let _ = inbound_tx.send(InboundEvent::ReaderClosed {
+                        conn_id,
+                        reason: "eof".into(),
+                    });
+                    mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
+                    return;
+                }
+                Err(FrameError::FrameTooLarge { size, max }) => {
+                    let outcome = handle_oversize_frame(
+                        &mut reader,
+                        conn_id,
+                        size,
+                        max,
+                        inbound_tx,
+                        mailer,
+                        self_id,
+                        wake_kind,
+                    );
+                    if outcome.is_terminal() {
+                        return;
+                    }
+                }
+                Err(e) => {
+                    if shutdown.load(Ordering::Acquire) {
+                        return;
+                    }
+                    let _ = inbound_tx.send(InboundEvent::ReaderClosed {
+                        conn_id,
+                        reason: format!("read error: {e}"),
+                    });
+                    mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Outcome of [`handle_oversize_frame`]. `Continue` means the
+    /// reader resumed frame-sync; `Terminal` means the read loop must
+    /// exit (drain failed, partial drain, or oversize-abort the
+    /// dispatcher is closing the connection for).
+    enum OversizeOutcome {
+        Continue,
+        Terminal,
+    }
+
+    impl OversizeOutcome {
+        fn is_terminal(&self) -> bool {
+            matches!(self, Self::Terminal)
+        }
+    }
+
+    /// Body half of [`run_reader_loop`]'s `FrameTooLarge` arm: when
+    /// the inbound length prefix exceeds the cap, either drain the
+    /// body (if `size <= 2 * max`) so the stream re-syncs and the
+    /// connection survives, or post a structured-abort event that
+    /// asks the dispatcher to close the connection with a `Bye`.
+    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::cast_possible_truncation)]
+    fn handle_oversize_frame(
+        reader: &mut BufReader<TcpStream>,
+        conn_id: ConnId,
+        size: usize,
+        max: usize,
+        inbound_tx: &mpsc::Sender<InboundEvent>,
+        mailer: &Arc<Mailer>,
+        self_id: MailboxId,
+        wake_kind: KindId,
+    ) -> OversizeOutcome {
+        let drain_ceiling = max.saturating_mul(2);
+        if size > drain_ceiling {
+            let event = InboundEvent::FrameDecodeAborted {
+                conn_id,
+                error: RpcError::FrameTooLarge {
+                    size: size as u64,
+                    max: max as u64,
+                },
+            };
+            if inbound_tx.send(event).is_err() {
+                return OversizeOutcome::Terminal;
+            }
+            mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
+            return OversizeOutcome::Terminal;
+        }
+        // `take(size)` bounds the drain so a racy / lying peer can't
+        // push us past the cap-2x ceiling on bytes we'll allocate
+        // scratch for.
+        let mut drain = io::sink();
+        let mut bounded = io::Read::take(reader, size as u64);
+        let Ok(drained) = io::copy(&mut bounded, &mut drain) else {
+            let _ = inbound_tx.send(InboundEvent::ReaderClosed {
+                conn_id,
+                reason: format!("frame too large drain failed: {size} > {max}"),
+            });
+            mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
+            return OversizeOutcome::Terminal;
+        };
+        if (drained as usize) != size {
+            // Peer hung up mid-body.
+            let _ = inbound_tx.send(InboundEvent::ReaderClosed {
+                conn_id,
+                reason: format!("frame too large partial drain: {drained}/{size}"),
+            });
+            mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
+            return OversizeOutcome::Terminal;
+        }
+        let event = InboundEvent::FrameDecodeError {
+            conn_id,
+            error: RpcError::FrameTooLarge {
+                size: size as u64,
+                max: max as u64,
+            },
+        };
+        if inbound_tx.send(event).is_err() {
+            return OversizeOutcome::Terminal;
+        }
+        mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
+        OversizeOutcome::Continue
     }
 }
 

--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -94,9 +94,43 @@ mod server_native {
     /// `on_inbound_ready` handler drains the channel and dispatches
     /// per item.
     enum InboundEvent {
-        PeerAccepted { stream: TcpStream, peer: SocketAddr },
-        FrameReceived { conn_id: ConnId, frame: WireFrame },
-        ReaderClosed { conn_id: ConnId, reason: String },
+        PeerAccepted {
+            stream: TcpStream,
+            peer: SocketAddr,
+        },
+        FrameReceived {
+            conn_id: ConnId,
+            frame: WireFrame,
+        },
+        ReaderClosed {
+            conn_id: ConnId,
+            reason: String,
+        },
+        /// An inbound frame failed to decode but the reader managed to
+        /// keep frame-sync (issue 1271). Today this only fires for a
+        /// length-prefix that exceeded the framing cap and whose body
+        /// was small enough (`size <= 2 * max`) for the reader to drain
+        /// without itself becoming an OOM vector. The dispatcher writes
+        /// a `ReplyEnd { cid: 0, result: Err(RpcError::FrameTooLarge) }`
+        /// and the connection survives. `cid = 0` is the agreed
+        /// sentinel for "wire-level error, no in-flight call id to
+        /// match against" — the mcp-side router lifts it as an
+        /// out-of-band error against the most recently pending call.
+        FrameDecodeError {
+            conn_id: ConnId,
+            error: RpcError,
+        },
+        /// An inbound length prefix announced a body larger than
+        /// `2 * max_frame_size` (issue 1271). Draining it would
+        /// itself defeat the OOM guard the cap was written for, so the
+        /// dispatcher writes a structured `Bye` and closes the
+        /// connection — the OOM safety property holds, the wire error
+        /// is named, and the client gets a clean close instead of a
+        /// bare reset.
+        FrameDecodeAborted {
+            conn_id: ConnId,
+            error: RpcError,
+        },
     }
 
     /// Per-connection state owned by the cap dispatcher. The reader
@@ -271,6 +305,57 @@ mod server_native {
                     InboundEvent::ReaderClosed { conn_id, reason } => {
                         self.close_connection(conn_id, &reason);
                     }
+                    InboundEvent::FrameDecodeError { conn_id, error } => {
+                        // The reader kept frame-sync (body drained).
+                        // Write a structured `ReplyEnd { cid: 0, Err }`
+                        // and leave the connection up so further calls
+                        // on this socket still work (issue 1271).
+                        //
+                        // `cid = 0` is the sentinel: the wire couldn't
+                        // be decoded far enough to learn the real cid,
+                        // so we report against id 0 and the mcp router
+                        // surfaces it as a wire-level out-of-band
+                        // failure rather than a per-call settled-Err.
+                        tracing::warn!(
+                            target: "aether_substrate::rpc",
+                            conn = conn_id,
+                            error = ?error,
+                            "rpc inbound frame decode error; keeping connection alive",
+                        );
+                        self.write_frame_to(
+                            conn_id,
+                            &WireFrame::ReplyEnd {
+                                cid: 0,
+                                result: Err(error),
+                            },
+                        );
+                    }
+                    InboundEvent::FrameDecodeAborted { conn_id, error } => {
+                        // The announced body was big enough to be its
+                        // own OOM vector (size > 2 * max). Write a
+                        // structured `Bye` so the peer sees a named
+                        // close instead of a bare reset, then tear the
+                        // connection down (issue 1271).
+                        let reason = match &error {
+                            RpcError::FrameTooLarge { size, max } => {
+                                format!("frame too large: {size} > {max}")
+                            }
+                            other => format!("frame decode aborted: {other:?}"),
+                        };
+                        tracing::warn!(
+                            target: "aether_substrate::rpc",
+                            conn = conn_id,
+                            reason = %reason,
+                            "rpc inbound frame too large to drain; closing connection",
+                        );
+                        self.write_frame_to(
+                            conn_id,
+                            &WireFrame::Bye {
+                                reason: reason.clone(),
+                            },
+                        );
+                        self.close_connection(conn_id, &reason);
+                    }
                 }
             }
         }
@@ -422,6 +507,90 @@ mod server_native {
                                 });
                                 mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
                                 break;
+                            }
+                            Err(FrameError::FrameTooLarge { size, max }) => {
+                                // The 4-byte length prefix has been
+                                // consumed but the body is still on
+                                // the wire (issue 1271). If draining
+                                // the body wouldn't itself be an OOM
+                                // vector, drain it so the stream
+                                // re-syncs at the next frame boundary
+                                // and the connection survives; if it
+                                // would, ask the dispatcher to write a
+                                // structured `Bye` and tear the
+                                // connection down.
+                                let drain_ceiling = max.saturating_mul(2);
+                                #[allow(clippy::cast_possible_truncation)]
+                                let event = if size <= drain_ceiling {
+                                    // `take(size)` bounds the drain so a
+                                    // racy / lying peer can't push us
+                                    // past the cap-2x ceiling on bytes
+                                    // we'll allocate scratch for.
+                                    let mut drain = io::sink();
+                                    let mut bounded = io::Read::take(&mut reader, size as u64);
+                                    let drained = match io::copy(&mut bounded, &mut drain) {
+                                        Ok(n) => n,
+                                        Err(_) => {
+                                            // Drain failed (socket
+                                            // dropped, truncated
+                                            // body). Treat as a
+                                            // real read error and
+                                            // close the connection.
+                                            let _ = inbound_tx.send(InboundEvent::ReaderClosed {
+                                                conn_id,
+                                                reason: format!(
+                                                    "frame too large drain failed: {size} > {max}"
+                                                ),
+                                            });
+                                            mailer.push(Mail::new(
+                                                self_id,
+                                                wake_kind,
+                                                Vec::new(),
+                                                1,
+                                            ));
+                                            break;
+                                        }
+                                    };
+                                    if (drained as usize) != size {
+                                        // Peer hung up mid-body.
+                                        let _ = inbound_tx.send(InboundEvent::ReaderClosed {
+                                            conn_id,
+                                            reason: format!(
+                                                "frame too large partial drain: {drained}/{size}"
+                                            ),
+                                        });
+                                        mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
+                                        break;
+                                    }
+                                    InboundEvent::FrameDecodeError {
+                                        conn_id,
+                                        error: RpcError::FrameTooLarge {
+                                            size: size as u64,
+                                            max: max as u64,
+                                        },
+                                    }
+                                } else {
+                                    InboundEvent::FrameDecodeAborted {
+                                        conn_id,
+                                        error: RpcError::FrameTooLarge {
+                                            size: size as u64,
+                                            max: max as u64,
+                                        },
+                                    }
+                                };
+                                let abort =
+                                    matches!(event, InboundEvent::FrameDecodeAborted { .. },);
+                                if inbound_tx.send(event).is_err() {
+                                    break;
+                                }
+                                mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
+                                if abort {
+                                    // The dispatcher will close the
+                                    // connection. Exit the read loop
+                                    // to free the read half.
+                                    break;
+                                }
+                                continue;
                             }
                             Err(e) => {
                                 if shutdown_for_thread.load(Ordering::Acquire) {
@@ -1186,5 +1355,96 @@ mod tests {
             }
             other => panic!("expected Bye, got {other:?}"),
         }
+    }
+
+    /// iamacoffeepot/aether#1271: an inbound frame whose announced
+    /// length exceeds the framing cap but is within the drain ceiling
+    /// (`size <= 2 * max`) is fail-soft. The server drains the body,
+    /// writes a `ReplyEnd { cid: 0, Err(RpcError::FrameTooLarge) }`,
+    /// and keeps the connection alive — a follow-up `Ping` round-trips
+    /// as `Pong`, proving the session survived.
+    #[test]
+    fn oversize_frame_replies_with_frame_too_large_and_session_survives() {
+        use crate::rpc::wire::RpcError;
+        use aether_codec::frame::{MAX_FRAME_SIZE, max_frame_size};
+        use std::io::Write;
+
+        let (_chassis, mut stream) = boot_with_rpc_server_only(Duration::from_secs(5));
+        complete_handshake(&mut stream);
+
+        // Set the read timeout high — the server has to read the full
+        // oversize body off the wire before it can write the error
+        // reply, so the read for the ReplyEnd is gated on that drain.
+        stream
+            .set_write_timeout(Some(Duration::from_secs(10)))
+            .expect("set_write_timeout");
+
+        // Announce a body just over the cap, then push that many zero
+        // bytes. The cap defaults to 64 MiB (MAX_FRAME_SIZE), and the
+        // process-wide accessor caches on first read — so the drain
+        // ceiling is exactly `2 * max_frame_size()`. Pick the smallest
+        // legal oversize: max + 1.
+        let max = max_frame_size();
+        assert!(max >= MAX_FRAME_SIZE, "cap accessor lifted below default");
+        let oversize: usize = max + 1;
+        assert!(
+            oversize <= max.saturating_mul(2),
+            "test size must be inside the drain ceiling",
+        );
+        #[allow(clippy::cast_possible_truncation)]
+        let prefix = (oversize as u32).to_le_bytes();
+        stream
+            .write_all(&prefix)
+            .expect("write oversize length prefix");
+        // Write the body in chunks so a 64 MiB+ payload doesn't single-
+        // syscall through.
+        let chunk = vec![0u8; 1024 * 1024];
+        let mut remaining = oversize;
+        while remaining > 0 {
+            let n = remaining.min(chunk.len());
+            stream
+                .write_all(&chunk[..n])
+                .expect("write oversize body chunk");
+            remaining -= n;
+        }
+
+        // The server replies with a structured ReplyEnd carrying
+        // FrameTooLarge. cid is 0 (the sentinel for "wire-level error,
+        // no in-flight cid to bind to").
+        let reply: WireFrame = read_frame(&mut stream).expect("read fail-soft ReplyEnd");
+        match reply {
+            WireFrame::ReplyEnd { cid, result } => {
+                assert_eq!(cid, 0, "fail-soft uses cid=0 sentinel");
+                match result {
+                    Err(RpcError::FrameTooLarge { size, max: cap }) => {
+                        assert_eq!(size, oversize as u64);
+                        assert_eq!(cap, max as u64);
+                    }
+                    other => panic!("expected FrameTooLarge, got {other:?}"),
+                }
+            }
+            other => panic!("expected ReplyEnd, got {other:?}"),
+        }
+
+        // Ping/Pong round-trips — the session is still alive.
+        write_frame(&mut stream, &WireFrame::Ping(0xfeed_face))
+            .expect("write Ping after fail-soft");
+        let pong: WireFrame = read_frame(&mut stream).expect("read Pong after fail-soft");
+        assert_eq!(pong, WireFrame::Pong(0xfeed_face));
+    }
+
+    /// Tiny postcard roundtrip for the new `RpcError::FrameTooLarge`
+    /// variant — protects the wire shape against accidental rename /
+    /// re-ordering.
+    #[test]
+    fn rpc_error_frame_too_large_postcard_roundtrips() {
+        use crate::rpc::wire::RpcError;
+        let err = RpcError::FrameTooLarge {
+            size: 99_000_000,
+            max: 64 * 1024 * 1024,
+        };
+        let bytes = postcard::to_allocvec(&err).expect("postcard encode");
+        let back: RpcError = postcard::from_bytes(&bytes).expect("postcard decode");
+        assert_eq!(err, back);
     }
 }

--- a/crates/aether-capabilities/src/rpc/wire.rs
+++ b/crates/aether-capabilities/src/rpc/wire.rs
@@ -173,6 +173,14 @@ pub enum RpcError {
     /// Target carried `engine = Some(_)` — cross-engine routing is
     /// a phase-3 concern.
     UnsupportedTarget { reason: String },
+    /// The peer announced a frame whose body exceeded the server's
+    /// framing cap (`aether_codec::frame::max_frame_size`, see
+    /// ADR-0072). Carries the announced `size` and the active `max` so
+    /// the caller can decide how to react (build a release wasm, raise
+    /// the cap via `AETHER_MAX_FRAME_SIZE`, etc.) instead of seeing a
+    /// bare `Connection reset by peer`. Widths are `u64` rather than
+    /// `usize` so the wire encoding is stable across 32 / 64-bit peers.
+    FrameTooLarge { size: u64, max: u64 },
     /// Catch-all for anything else (decode failures on the envelope
     /// payload, internal errors).
     Other { reason: String },

--- a/crates/aether-codec/src/frame.rs
+++ b/crates/aether-codec/src/frame.rs
@@ -21,6 +21,7 @@
 //! than parameterising the existing helpers — most callers know which
 //! format their protocol speaks at compile time.
 
+use std::env;
 use std::fmt;
 use std::io::{self, Read, Write};
 use std::sync::OnceLock;
@@ -57,7 +58,7 @@ pub const MAX_FRAME_SIZE_CEILING: usize = 1024 * 1024 * 1024;
 #[must_use]
 pub fn max_frame_size() -> usize {
     static CACHED: OnceLock<usize> = OnceLock::new();
-    *CACHED.get_or_init(|| resolve_max_frame_size(std::env::var("AETHER_MAX_FRAME_SIZE").ok()))
+    *CACHED.get_or_init(|| resolve_max_frame_size(env::var("AETHER_MAX_FRAME_SIZE").ok()))
 }
 
 /// Pure-function half of [`max_frame_size`]: maps an optional env-var
@@ -65,13 +66,10 @@ pub fn max_frame_size() -> usize {
 /// `OnceLock` cache in [`max_frame_size`] is process-global and can't
 /// be re-set across tests.
 fn resolve_max_frame_size(raw: Option<String>) -> usize {
-    match raw {
-        Some(raw) => match raw.trim().parse::<usize>() {
-            Ok(n) if n > 0 => n.min(MAX_FRAME_SIZE_CEILING),
-            _ => MAX_FRAME_SIZE,
-        },
-        None => MAX_FRAME_SIZE,
-    }
+    raw.map_or(MAX_FRAME_SIZE, |raw| match raw.trim().parse::<usize>() {
+        Ok(n) if n > 0 => n.min(MAX_FRAME_SIZE_CEILING),
+        _ => MAX_FRAME_SIZE,
+    })
 }
 
 /// Errors from the framing helpers. Wraps I/O and postcard decode

--- a/crates/aether-codec/src/frame.rs
+++ b/crates/aether-codec/src/frame.rs
@@ -23,23 +23,78 @@
 
 use std::fmt;
 use std::io::{self, Read, Write};
+use std::sync::OnceLock;
 
 use serde::{Serialize, de::DeserializeOwned};
 use std::error;
 
-/// Maximum accepted frame body size. Bounded so a malformed length
-/// prefix cannot drive a reader into an OOM. 16 MiB is comfortably
-/// larger than any expected mail payload on the hub wire (vertex
-/// streams travel through the render sink, not the hub).
-pub const MAX_FRAME_SIZE: usize = 16 * 1024 * 1024;
+/// Maximum accepted frame body size, default. Bounded so a malformed
+/// length prefix cannot drive a reader into an OOM. 64 MiB is large
+/// enough that routine debug wasm cross-builds (typically 15-25 MiB
+/// for the medium-size components in this repo) ride the framing
+/// without tripping the OOM guard, but still small enough to defang a
+/// 4 GiB malformed prefix.
+///
+/// Embedders shipping bigger payloads override this via the
+/// `AETHER_MAX_FRAME_SIZE` env var; see [`max_frame_size`].
+pub const MAX_FRAME_SIZE: usize = 64 * 1024 * 1024;
+
+/// Hard upper bound on the env-var override. Even with
+/// `AETHER_MAX_FRAME_SIZE` set, the accessor clamps at 1 GiB so a
+/// runaway override can't itself defeat the OOM guard.
+pub const MAX_FRAME_SIZE_CEILING: usize = 1024 * 1024 * 1024;
+
+/// Effective maximum frame body size for this process. Resolves once
+/// per process: reads the `AETHER_MAX_FRAME_SIZE` env var on the first
+/// call (parsed as bytes, clamped at [`MAX_FRAME_SIZE_CEILING`]) and
+/// caches the result; subsequent calls return the cache. A missing,
+/// empty, or unparseable env var falls back to [`MAX_FRAME_SIZE`].
+///
+/// The encode-side check ([`encode_frame`]) and the read-side check
+/// ([`read_frame`]) both go through this accessor, so changing
+/// `AETHER_MAX_FRAME_SIZE` at process start lifts the cap symmetrically
+/// for both sides.
+#[must_use]
+pub fn max_frame_size() -> usize {
+    static CACHED: OnceLock<usize> = OnceLock::new();
+    *CACHED.get_or_init(|| resolve_max_frame_size(std::env::var("AETHER_MAX_FRAME_SIZE").ok()))
+}
+
+/// Pure-function half of [`max_frame_size`]: maps an optional env-var
+/// string to the resolved cap. Exposed for unit tests since the
+/// `OnceLock` cache in [`max_frame_size`] is process-global and can't
+/// be re-set across tests.
+fn resolve_max_frame_size(raw: Option<String>) -> usize {
+    match raw {
+        Some(raw) => match raw.trim().parse::<usize>() {
+            Ok(n) if n > 0 => n.min(MAX_FRAME_SIZE_CEILING),
+            _ => MAX_FRAME_SIZE,
+        },
+        None => MAX_FRAME_SIZE,
+    }
+}
 
 /// Errors from the framing helpers. Wraps I/O and postcard decode
-/// errors; adds its own variant for an oversize length prefix.
+/// errors; adds its own variants for an oversize length prefix on
+/// inbound frames ([`FrameError::FrameTooLarge`]) and a pre-write
+/// oversize check on outbound bodies ([`FrameError::EncodeTooLarge`]).
 #[derive(Debug)]
 pub enum FrameError {
     Io(io::Error),
     Postcard(postcard::Error),
-    FrameTooLarge { size: usize, max: usize },
+    /// Inbound: length prefix exceeded [`max_frame_size`].
+    FrameTooLarge {
+        size: usize,
+        max: usize,
+    },
+    /// Outbound: the postcard-encoded body exceeded [`max_frame_size`].
+    /// Surfaced from [`encode_frame`] / [`write_frame`] so the sender
+    /// learns the rejection client-side instead of writing a frame
+    /// the peer will reject (or drop the connection over).
+    EncodeTooLarge {
+        size: usize,
+        max: usize,
+    },
 }
 
 impl fmt::Display for FrameError {
@@ -49,6 +104,9 @@ impl fmt::Display for FrameError {
             Self::Postcard(e) => write!(f, "frame decode: {e}"),
             Self::FrameTooLarge { size, max } => {
                 write!(f, "frame too large: {size} > {max}")
+            }
+            Self::EncodeTooLarge { size, max } => {
+                write!(f, "encoded frame too large: {size} > {max}")
             }
         }
     }
@@ -69,24 +127,36 @@ impl From<postcard::Error> for FrameError {
 }
 
 /// Encode a message into its framed wire representation (4-byte LE
-/// length prefix + postcard body). Infallible — postcard encoding
-/// of `alloc::Vec` is infallible for the types this is used with.
+/// length prefix + postcard body). Returns
+/// [`FrameError::EncodeTooLarge`] if the encoded body exceeds
+/// [`max_frame_size`], so the sender learns the rejection client-side
+/// instead of writing a frame the peer will reject. Postcard encoding
+/// of `alloc::Vec` is itself infallible for the types this is used
+/// with, so the postcard step is a `.expect` rather than an `Err`
+/// path per ADR-0063.
 ///
 /// # Panics
 /// Panics if postcard encoding of `msg` fails — fail-fast per ADR-0063:
 /// `postcard::to_allocvec` into a growable `Vec` cannot fail for the
 /// `Serialize` types this is used with, so a failure indicates the
 /// caller passed a type whose serializer is observably broken.
-pub fn encode_frame<T: Serialize>(msg: &T) -> Vec<u8> {
+pub fn encode_frame<T: Serialize>(msg: &T) -> Result<Vec<u8>, FrameError> {
     let body = postcard::to_allocvec(msg).expect("postcard encode to Vec is infallible");
+    let max = max_frame_size();
+    if body.len() > max {
+        return Err(FrameError::EncodeTooLarge {
+            size: body.len(),
+            max,
+        });
+    }
     let mut out = Vec::with_capacity(4 + body.len());
     // 4-byte LE length prefix is the wire format; bodies above 4 GiB
-    // would overflow but no protocol that rides this framing emits
-    // anything close (worst case is a few MiB of MailFrame).
+    // would overflow but the cap above keeps us well clear of the u32
+    // ceiling.
     #[allow(clippy::cast_possible_truncation)]
     out.extend_from_slice(&(body.len() as u32).to_le_bytes());
     out.extend_from_slice(&body);
-    out
+    Ok(out)
 }
 
 /// Synchronous read of one framed message. Blocks until a complete
@@ -97,20 +167,20 @@ pub fn read_frame<R: Read, T: DeserializeOwned>(r: &mut R) -> Result<T, FrameErr
     let mut len_buf = [0u8; 4];
     r.read_exact(&mut len_buf)?;
     let len = u32::from_le_bytes(len_buf) as usize;
-    if len > MAX_FRAME_SIZE {
-        return Err(FrameError::FrameTooLarge {
-            size: len,
-            max: MAX_FRAME_SIZE,
-        });
+    let max = max_frame_size();
+    if len > max {
+        return Err(FrameError::FrameTooLarge { size: len, max });
     }
     let mut buf = vec![0u8; len];
     r.read_exact(&mut buf)?;
     Ok(postcard::from_bytes(&buf)?)
 }
 
-/// Synchronous write of one framed message.
+/// Synchronous write of one framed message. Returns
+/// [`FrameError::EncodeTooLarge`] if the encoded body exceeds
+/// [`max_frame_size`] (the encode-side cap check).
 pub fn write_frame<W: Write, T: Serialize>(w: &mut W, msg: &T) -> Result<(), FrameError> {
-    let bytes = encode_frame(msg);
+    let bytes = encode_frame(msg)?;
     w.write_all(&bytes)?;
     Ok(())
 }
@@ -150,7 +220,12 @@ mod tests {
     #[test]
     fn unit_variant_is_five_bytes() {
         // 4 byte prefix + 1 byte postcard tag.
-        assert_eq!(encode_frame(&Msg::Tick).len(), 5);
+        assert_eq!(
+            encode_frame(&Msg::Tick)
+                .expect("test setup: encode unit variant")
+                .len(),
+            5,
+        );
     }
 
     #[test]
@@ -200,5 +275,77 @@ mod tests {
         let err = read_frame::<_, Msg>(&mut Cursor::new(buf))
             .expect_err("malformed body must surface postcard error");
         assert!(matches!(err, FrameError::Postcard(_)));
+    }
+
+    /// An oversize encode body trips `FrameError::EncodeTooLarge`
+    /// before any bytes hit the writer.
+    #[test]
+    fn encode_too_large_rejected_pre_write() {
+        // Build a `Note` whose text alone exceeds the resolved cap.
+        // The encode-side check sees the postcard-encoded body length
+        // and bails before allocating the framed `Vec`.
+        let oversize_text = "x".repeat(max_frame_size() + 16);
+        let msg = Msg::Note {
+            id: 1,
+            text: oversize_text,
+        };
+        let err = encode_frame(&msg).expect_err("oversize body must reject on encode");
+        let max = max_frame_size();
+        match err {
+            FrameError::EncodeTooLarge { size, max: cap } => {
+                assert!(size > max, "size {size} must exceed cap {max}");
+                assert_eq!(cap, max);
+            }
+            other => panic!("expected EncodeTooLarge, got {other:?}"),
+        }
+    }
+
+    /// `write_frame` propagates `EncodeTooLarge` without touching the
+    /// underlying writer.
+    #[test]
+    fn write_frame_propagates_encode_too_large() {
+        let oversize_text = "x".repeat(max_frame_size() + 16);
+        let msg = Msg::Note {
+            id: 1,
+            text: oversize_text,
+        };
+        let mut sink: Vec<u8> = Vec::new();
+        let err = write_frame(&mut sink, &msg).expect_err("oversize write must reject");
+        assert!(matches!(err, FrameError::EncodeTooLarge { .. }));
+        assert!(
+            sink.is_empty(),
+            "oversize encode must not write partial bytes; got {} bytes",
+            sink.len(),
+        );
+    }
+
+    /// The `AETHER_MAX_FRAME_SIZE` env-var override goes through
+    /// `resolve_max_frame_size`. The `OnceLock` cache in
+    /// `max_frame_size` is process-global and can't be re-set across
+    /// tests, so this exercises the parsing layer directly.
+    #[test]
+    fn env_override_parses_and_clamps() {
+        // Unset / empty / garbage → default.
+        assert_eq!(resolve_max_frame_size(None), MAX_FRAME_SIZE);
+        assert_eq!(resolve_max_frame_size(Some(String::new())), MAX_FRAME_SIZE);
+        assert_eq!(
+            resolve_max_frame_size(Some("not-a-number".into())),
+            MAX_FRAME_SIZE,
+        );
+        assert_eq!(resolve_max_frame_size(Some("0".into())), MAX_FRAME_SIZE);
+        // Valid override.
+        let override_val: usize = 32 * 1024 * 1024;
+        assert_eq!(
+            resolve_max_frame_size(Some(override_val.to_string())),
+            override_val,
+        );
+        // Whitespace tolerated.
+        assert_eq!(resolve_max_frame_size(Some("  4096  ".into())), 4096);
+        // Above ceiling → clamps.
+        let above_ceiling: usize = MAX_FRAME_SIZE_CEILING * 4;
+        assert_eq!(
+            resolve_max_frame_size(Some(above_ceiling.to_string())),
+            MAX_FRAME_SIZE_CEILING,
+        );
     }
 }

--- a/crates/aether-mcp/src/rpc.rs
+++ b/crates/aether-mcp/src/rpc.rs
@@ -329,36 +329,7 @@ impl RpcSession {
         let conn = self.live();
 
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let cid = {
-            let mut pending = conn
-                .pending
-                .lock()
-                .expect("rpc pending mutex is never poisoned");
-            // The router exited (the socket is dead) — registering now
-            // would hang forever, since nothing will deliver a reply or
-            // drop this sender. Bail to a transport error so `call`
-            // re-dials. Checked under the `pending` lock, so it can't
-            // race the router's death.
-            if conn.dead.load(Ordering::Acquire) {
-                return Err(CallError::Transport {
-                    generation,
-                    source: anyhow::anyhow!("rpc connection is closed"),
-                });
-            }
-            let write = conn
-                .client
-                .lock()
-                .expect("rpc client mutex is never poisoned")
-                .call(envelope.clone());
-            let cid = match write {
-                Ok(cid) => cid,
-                Err(e) => {
-                    return Err(classify_write_error(&e, generation));
-                }
-            };
-            pending.insert(cid, tx);
-            cid
-        };
+        let cid = register_call(&conn, envelope, tx, generation)?;
 
         let mut events = Vec::new();
         let outcome = loop {
@@ -448,31 +419,7 @@ impl RpcSession {
         let conn = self.live();
 
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let cid = {
-            let mut pending = conn
-                .pending
-                .lock()
-                .expect("rpc pending mutex is never poisoned");
-            if conn.dead.load(Ordering::Acquire) {
-                return Err(CallError::Transport {
-                    generation,
-                    source: anyhow::anyhow!("rpc connection is closed"),
-                });
-            }
-            let write = conn
-                .client
-                .lock()
-                .expect("rpc client mutex is never poisoned")
-                .call(envelope.clone());
-            let cid = match write {
-                Ok(cid) => cid,
-                Err(e) => {
-                    return Err(classify_write_error(&e, generation));
-                }
-            };
-            pending.insert(cid, tx);
-            cid
-        };
+        let cid = register_call(&conn, envelope, tx, generation)?;
 
         let mut events = Vec::new();
         // `sleep` is created once, outside the loop, so its deadline is
@@ -593,6 +540,41 @@ fn classify_write_error(e: &RpcClientError, generation: u64) -> CallError {
         generation,
         source: anyhow::anyhow!("rpc call write failed: {e}"),
     }
+}
+
+/// Send a `Call` over `conn`, register the resulting `cid` against
+/// `tx` in `conn.pending`, and return the cid. Bundles the dead-socket
+/// check, the write, and the pending registration — every call shape
+/// (`call_once`, `call_collecting_once`) does the same dance, so
+/// factoring it here keeps Qodana's `DuplicatedCode` quiet and
+/// localizes the lock-section invariant. All steps run under one hold
+/// of `conn.pending` so the check-and-register is atomic against the
+/// router's death.
+fn register_call(
+    conn: &Connection,
+    envelope: &MailEnvelope,
+    tx: mpsc::UnboundedSender<WireFrame>,
+    generation: u64,
+) -> Result<u64, CallError> {
+    let mut pending = conn
+        .pending
+        .lock()
+        .expect("rpc pending mutex is never poisoned");
+    if conn.dead.load(Ordering::Acquire) {
+        return Err(CallError::Transport {
+            generation,
+            source: anyhow::anyhow!("rpc connection is closed"),
+        });
+    }
+    let cid = conn
+        .client
+        .lock()
+        .expect("rpc client mutex is never poisoned")
+        .call(envelope.clone())
+        .map_err(|e| classify_write_error(&e, generation))?;
+    pending.insert(cid, tx);
+    drop(pending);
+    Ok(cid)
 }
 
 #[cfg(test)]

--- a/crates/aether-mcp/src/rpc.rs
+++ b/crates/aether-mcp/src/rpc.rs
@@ -134,26 +134,21 @@ impl Connection {
                     // call surfaces the wire error instead of hanging.
                     // A `ReplyEnd { cid: 0, Ok }` is not a valid wire
                     // shape — only `Err` frames carry the sentinel.
-                    if cid == 0 {
-                        if let WireFrame::ReplyEnd { result: Err(_), .. } = &frame {
-                            let pending = router_pending
-                                .lock()
-                                .expect("router pending mutex is never poisoned");
-                            for tx in pending.values() {
-                                let _ = tx.send(frame.clone());
-                            }
-                            continue;
-                        }
-                    }
-                    if let Some(tx) = router_pending
+                    let fanout =
+                        cid == 0 && matches!(&frame, WireFrame::ReplyEnd { result: Err(_), .. },);
+                    let pending = router_pending
                         .lock()
-                        .expect("router pending mutex is never poisoned")
-                        .get(&cid)
-                    {
+                        .expect("router pending mutex is never poisoned");
+                    if fanout {
+                        for tx in pending.values() {
+                            let _ = tx.send(frame.clone());
+                        }
+                    } else if let Some(tx) = pending.get(&cid) {
                         // A failed send just means a stray frame for an
                         // already-finished call — drop it.
                         let _ = tx.send(frame);
                     }
+                    drop(pending);
                 }
                 // The router is exiting (peer `Bye` or `inbound` closed).
                 // Mark the connection dead and drop every pending sender
@@ -358,7 +353,7 @@ impl RpcSession {
             let cid = match write {
                 Ok(cid) => cid,
                 Err(e) => {
-                    return Err(classify_write_error(e, generation));
+                    return Err(classify_write_error(&e, generation));
                 }
             };
             pending.insert(cid, tx);
@@ -472,7 +467,7 @@ impl RpcSession {
             let cid = match write {
                 Ok(cid) => cid,
                 Err(e) => {
-                    return Err(classify_write_error(e, generation));
+                    return Err(classify_write_error(&e, generation));
                 }
             };
             pending.insert(cid, tx);
@@ -556,7 +551,7 @@ impl RpcSession {
             .expect("rpc client mutex is never poisoned")
             .call(envelope.clone())
             .map(|_cid| ())
-            .map_err(|e| classify_write_error(e, generation))
+            .map_err(|e| classify_write_error(&e, generation))
     }
 }
 
@@ -590,8 +585,8 @@ impl CallError {
 /// socket is still healthy and a re-dial would only re-encode + fail
 /// the same way. Everything else (TCP write errors, broken pipes) is
 /// a transport failure that warrants a single re-dial + retry.
-fn classify_write_error(e: RpcClientError, generation: u64) -> CallError {
-    if let RpcClientError::Frame(FrameError::EncodeTooLarge { .. }) = &e {
+fn classify_write_error(e: &RpcClientError, generation: u64) -> CallError {
+    if matches!(e, RpcClientError::Frame(FrameError::EncodeTooLarge { .. })) {
         return CallError::Call(anyhow::anyhow!("rpc call encode rejected: {e}"));
     }
     CallError::Transport {

--- a/crates/aether-mcp/src/rpc.rs
+++ b/crates/aether-mcp/src/rpc.rs
@@ -21,8 +21,9 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use aether_capabilities::rpc::{
-    MailEnvelope, PeerKind, RpcClient, RpcConnection, RpcReaderHandle, WireFrame,
+    MailEnvelope, PeerKind, RpcClient, RpcClientError, RpcConnection, RpcReaderHandle, WireFrame,
 };
+use aether_codec::frame::FrameError;
 use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -124,6 +125,29 @@ impl Connection {
                         // client-side router never expects these.
                         _ => continue,
                     };
+                    // `cid == 0` is the wire-level out-of-band error
+                    // sentinel (iamacoffeepot/aether#1271): the server
+                    // couldn't decode the frame far enough to learn the
+                    // real cid (e.g. an oversize body), so the
+                    // structured error rides under id 0. Fan it out to
+                    // every pending caller so the original failing
+                    // call surfaces the wire error instead of hanging.
+                    // A `ReplyEnd { cid: 0, Ok }` is not a valid wire
+                    // shape — only `Err` frames carry the sentinel.
+                    if cid == 0 {
+                        if let WireFrame::ReplyEnd {
+                            result: Err(_), ..
+                        } = &frame
+                        {
+                            let pending = router_pending
+                                .lock()
+                                .expect("router pending mutex is never poisoned");
+                            for tx in pending.values() {
+                                let _ = tx.send(frame.clone());
+                            }
+                            continue;
+                        }
+                    }
                     if let Some(tx) = router_pending
                         .lock()
                         .expect("router pending mutex is never poisoned")
@@ -337,10 +361,7 @@ impl RpcSession {
             let cid = match write {
                 Ok(cid) => cid,
                 Err(e) => {
-                    return Err(CallError::Transport {
-                        generation,
-                        source: anyhow::anyhow!("rpc call write failed: {e}"),
-                    });
+                    return Err(classify_write_error(e, generation));
                 }
             };
             pending.insert(cid, tx);
@@ -454,10 +475,7 @@ impl RpcSession {
             let cid = match write {
                 Ok(cid) => cid,
                 Err(e) => {
-                    return Err(CallError::Transport {
-                        generation,
-                        source: anyhow::anyhow!("rpc call write failed: {e}"),
-                    });
+                    return Err(classify_write_error(e, generation));
                 }
             };
             pending.insert(cid, tx);
@@ -541,10 +559,7 @@ impl RpcSession {
             .expect("rpc client mutex is never poisoned")
             .call(envelope.clone())
             .map(|_cid| ())
-            .map_err(|e| CallError::Transport {
-                generation,
-                source: anyhow::anyhow!("rpc call write failed: {e}"),
-            })
+            .map_err(|e| classify_write_error(e, generation))
     }
 }
 
@@ -569,6 +584,22 @@ impl CallError {
         match self {
             Self::Transport { source, .. } | Self::Call(source) => source,
         }
+    }
+}
+
+/// Classify an [`RpcClientError`] from the outbound write path
+/// (iamacoffeepot/aether#1271). `EncodeTooLarge` is a clean
+/// client-side rejection — the bytes never hit the wire, so the
+/// socket is still healthy and a re-dial would only re-encode + fail
+/// the same way. Everything else (TCP write errors, broken pipes) is
+/// a transport failure that warrants a single re-dial + retry.
+fn classify_write_error(e: RpcClientError, generation: u64) -> CallError {
+    if let RpcClientError::Frame(FrameError::EncodeTooLarge { .. }) = &e {
+        return CallError::Call(anyhow::anyhow!("rpc call encode rejected: {e}"));
+    }
+    CallError::Transport {
+        generation,
+        source: anyhow::anyhow!("rpc call write failed: {e}"),
     }
 }
 

--- a/crates/aether-mcp/src/rpc.rs
+++ b/crates/aether-mcp/src/rpc.rs
@@ -135,10 +135,7 @@ impl Connection {
                     // A `ReplyEnd { cid: 0, Ok }` is not a valid wire
                     // shape — only `Err` frames carry the sentinel.
                     if cid == 0 {
-                        if let WireFrame::ReplyEnd {
-                            result: Err(_), ..
-                        } = &frame
-                        {
+                        if let WireFrame::ReplyEnd { result: Err(_), .. } = &frame {
                             let pending = router_pending
                                 .lock()
                                 .expect("router pending mutex is never poisoned");

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -1678,11 +1678,11 @@ fn internal_msg(msg: &str) -> McpError {
 /// through to `internal` for every other shape.
 ///
 /// Detection is by substring of the error chain because the structured
-/// `RpcError` rides under `anyhow::Error` (`format!("rpc call failed:
-/// {e:?}")` in the session's call_once / format!("rpc call encode
-/// rejected: {e}")` from the encode-side classifier). Both shapes
-/// embed the literal `frame too large` / `encoded frame too large`
-/// strings the codec / RPC error variants produce.
+/// `RpcError` rides under `anyhow::Error` (the session's `call_once`
+/// formats the wire error with `{e:?}` into a string; the encode-side
+/// classifier formats `RpcClientError::Frame(...)` with `{e}`). Both
+/// shapes embed the literal `frame too large` / `encoded frame too
+/// large` strings the codec / RPC error variants produce.
 #[allow(clippy::needless_pass_by_value)]
 fn frame_size_aware_error(context: &str, e: anyhow::Error) -> McpError {
     let text = e.to_string();

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -451,7 +451,7 @@ impl Mcp {
     }
 
     #[tool(
-        description = "Load a WASM component into a substrate by filesystem path. aether-mcp reads the binary, forwards it as aether.component.load to the engine's aether.component mailbox, and awaits the LoadResult — returning {mailbox_id, name, capabilities} or an error. The path must exist as given (no ~ expansion, no relative resolution). The component's kind vocabulary rides in the wasm's aether.kinds custom section."
+        description = "Load a WASM component into a substrate by filesystem path. aether-mcp reads the binary, forwards it as aether.component.load to the engine's aether.component mailbox, and awaits the LoadResult — returning {mailbox_id, name, capabilities} or an error. The path must exist as given (no ~ expansion, no relative resolution). The component's kind vocabulary rides in the wasm's aether.kinds custom section. Very large wasm payloads (typically target/wasm32-unknown-unknown/debug/*.wasm, which can run 15-25 MiB) may exceed the RPC framing cap — prefer release builds, or raise the cap via the AETHER_MAX_FRAME_SIZE env var (default 64 MiB, clamped at 1 GiB; issue 1271)."
     )]
     pub async fn load_component(
         &self,
@@ -464,6 +464,7 @@ impl Mcp {
                 None,
             )
         })?;
+        let binary_path = args.binary_path.clone();
         let reply = self
             .session
             .call_one(engine_envelope(
@@ -475,7 +476,7 @@ impl Mcp {
                 },
             ))
             .await
-            .map_err(internal)?;
+            .map_err(|e| frame_size_aware_error(&format!("load_component {binary_path:?}"), e))?;
         match LoadResult::decode_from_bytes(&reply.payload) {
             Some(LoadResult::Ok {
                 mailbox_id,
@@ -498,7 +499,7 @@ impl Mcp {
     }
 
     #[tool(
-        description = "Atomically replace a live component's WASM with a new binary loaded from a filesystem path (ADR-0022 structural splice). aether-mcp reads the binary and forwards aether.component.replace to the engine's aether.component mailbox. drain_timeout_ms is accepted for wire compatibility but currently ignored. Returns the replaced component's advertised capabilities."
+        description = "Atomically replace a live component's WASM with a new binary loaded from a filesystem path (ADR-0022 structural splice). aether-mcp reads the binary and forwards aether.component.replace to the engine's aether.component mailbox. drain_timeout_ms is accepted for wire compatibility but currently ignored. Returns the replaced component's advertised capabilities. Very large wasm payloads (typically debug builds at 15-25 MiB) may exceed the RPC framing cap — prefer release builds, or raise the cap via the AETHER_MAX_FRAME_SIZE env var (default 64 MiB, clamped at 1 GiB; issue 1271)."
     )]
     pub async fn replace_component(
         &self,
@@ -512,6 +513,7 @@ impl Mcp {
                 None,
             )
         })?;
+        let binary_path = args.binary_path.clone();
         let reply = self
             .session
             .call_one(engine_envelope(
@@ -524,7 +526,9 @@ impl Mcp {
                 },
             ))
             .await
-            .map_err(internal)?;
+            .map_err(|e| {
+                frame_size_aware_error(&format!("replace_component {binary_path:?}"), e)
+            })?;
         match ReplaceResult::decode_from_bytes(&reply.payload) {
             Some(ReplaceResult::Ok { capabilities }) => {
                 self.components
@@ -1662,6 +1666,42 @@ fn internal(e: anyhow::Error) -> McpError {
 
 fn internal_msg(msg: &str) -> McpError {
     McpError::internal_error(msg.to_owned(), None)
+}
+
+/// iamacoffeepot/aether#1271: tools that ship potentially-large
+/// payloads through the RPC framing (currently `load_component` /
+/// `replace_component`) surface a `FrameTooLarge` / `EncodeTooLarge`
+/// failure as `invalid_params` rather than `internal_error`. The
+/// payload is a client-controllable input (the user picked the wasm
+/// path), and the actionable remediation — build the release wasm,
+/// raise `AETHER_MAX_FRAME_SIZE` — is specific to the caller. Falls
+/// through to `internal` for every other shape.
+///
+/// Detection is by substring of the error chain because the structured
+/// `RpcError` rides under `anyhow::Error` (`format!("rpc call failed:
+/// {e:?}")` in the session's call_once / format!("rpc call encode
+/// rejected: {e}")` from the encode-side classifier). Both shapes
+/// embed the literal `frame too large` / `encoded frame too large`
+/// strings the codec / RPC error variants produce.
+#[allow(clippy::needless_pass_by_value)]
+fn frame_size_aware_error(context: &str, e: anyhow::Error) -> McpError {
+    let text = e.to_string();
+    if text.contains("frame too large")
+        || text.contains("encoded frame too large")
+        || text.contains("FrameTooLarge")
+        || text.contains("EncodeTooLarge")
+    {
+        return McpError::invalid_params(
+            format!(
+                "{context}: payload exceeds the RPC framing cap — typically because the supplied \
+                 wasm is a debug build. Build the release wasm (target/wasm32-unknown-unknown/\
+                 release/*.wasm) or raise the cap via the AETHER_MAX_FRAME_SIZE env var. \
+                 Underlying: {text}",
+            ),
+            None,
+        );
+    }
+    McpError::internal_error(text, None)
 }
 
 /// Issue 963: render an `actor_logs` `LogTailResult::Err` into a


### PR DESCRIPTION
## Summary
- Raise the codec framing cap to 64 MiB (default) with an `AETHER_MAX_FRAME_SIZE` env override (clamped at 1 GiB), and route both the encode-side and read-side checks through `max_frame_size()` so the cap lifts symmetrically.
- Add encode-side `FrameError::EncodeTooLarge`, server-side `InboundEvent::FrameDecodeError` (fail-soft drain + structured `ReplyEnd { cid: 0, Err(RpcError::FrameTooLarge) }`) and `FrameDecodeAborted` (structured `Bye` close when `size > 2 * max`), and a new `RpcError::FrameTooLarge { size, max }` wire variant so a client surfaces a structured error instead of `Connection reset by peer`.
- MCP-side: a `cid == 0` `ReplyEnd { Err }` fans out to every pending caller (the wire-level out-of-band sentinel), `EncodeTooLarge` is classified as a clean call failure (no retry loop), and `load_component` / `replace_component` map the framing error onto `invalid_params` with the actionable remediation (release wasm, raise the cap).

## Test plan
- [x] `cargo nextest run -p aether-codec` — new `encode_too_large_rejected_pre_write`, `write_frame_propagates_encode_too_large`, `env_override_parses_and_clamps` pass alongside the existing reader-side `frame_too_large_rejected`.
- [x] `cargo nextest run -p aether-capabilities -E 'test(rpc::)'` — new `oversize_frame_replies_with_frame_too_large_and_session_survives` and `rpc_error_frame_too_large_postcard_roundtrips` pass; the existing rpc tests still pass.
- [x] `scripts/preflight.sh` — fmt + clippy + doc + nextest (1429 tests) + wasm32 cross-build green.
- [ ] Smoke via MCP: `spawn_substrate` then `load_component` of a debug-build wasm (>16 MiB) — expect a structured `invalid_params` error naming `AETHER_MAX_FRAME_SIZE`, not `Connection reset by peer`.

Closes iamacoffeepot/aether#1271