### PR TITLE
fix(substrate-bundle): desktop window driver routes framework dispatch first

### DIFF
--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -21,6 +21,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use aether_actor::Actor;
+use aether_actor::local;
 use aether_capabilities::InputCapability;
 use aether_capabilities::RenderHandles;
 use aether_data::Kind;
@@ -31,11 +32,15 @@ use aether_kinds::{
     keycode,
 };
 use aether_substrate::actor::native::envelope::Envelope;
+use aether_substrate::actor::native::{
+    dispatch_cost_tail_if_matching_free, dispatch_log_tail_if_matching_free,
+    dispatch_trace_tail_if_matching_free,
+};
 use aether_substrate::chassis::builder::{DriverCapability, DriverCtx, DriverRunning, RunError};
 use aether_substrate::chassis::error::BootError;
 use aether_substrate::runtime::lifecycle;
 use aether_substrate::{
-    HubOutbound, Mailer, SubstrateBoot,
+    HubOutbound, Mailer, SharedActorSlots, SubstrateBoot,
     chassis::frame_loop,
     mail::{MailId, MailboxId},
 };
@@ -117,6 +122,22 @@ pub struct App {
     /// window-kind mail can stall briefly until the user nudges the
     /// window — accepted limitation for v1.
     window_inbox: Receiver<Envelope>,
+    /// Per-actor [`aether_actor::local::ActorSlots`] carried out of the
+    /// [`aether_substrate::MailboxClaim`] this driver produced at boot.
+    /// Stamped into TLS via [`aether_actor::local::with_stamped`] around
+    /// the bespoke `aether.window` inbox drain so framework-built-in
+    /// dispatch arms (`aether.log.tail` / `aether.trace.tail` /
+    /// `aether.cost.tail`) reach the driver's per-actor `Local<T>`
+    /// rings — the same shape the standard
+    /// `DispatcherSlot::run_cycle` path opens for every other actor
+    /// (iamacoffeepot/aether#1272).
+    actor_slots: SharedActorSlots,
+    /// The driver's own mailbox id (`aether.window` claim). Threaded
+    /// through to the cost-tail dispatch arm, which filters the global
+    /// cost table by `self_mailbox` (the standard variant pulls this
+    /// from `NativeBinding::self_mailbox`; driver-as-actor has no
+    /// binding, so we cache the id directly).
+    window_mailbox: MailboxId,
     kind_set_window_mode: aether_data::KindId,
     kind_set_window_title: aether_data::KindId,
     /// ADR-0080 §6 chassis-root correlation counter (issue
@@ -287,6 +308,26 @@ fn resolve_fullscreen(
     }
 }
 
+/// iamacoffeepot/aether#1272: route an inbound `aether.window` envelope
+/// through the framework-built-in dispatch arms (`aether.log.tail` /
+/// `aether.trace.tail` / `aether.cost.tail`) before the driver-specific
+/// `SetWindowMode` / `SetWindowTitle` arms get their turn. Returns
+/// `true` when one of the framework arms matched (a reply has already
+/// been routed); `false` otherwise. ADR-0081 §1 promises every mailbox
+/// serves these kinds — see the issue body for the contract.
+///
+/// Caller invariant: must run inside a `local::with_stamped` block
+/// against the driver's [`aether_actor::local::ActorSlots`] so the
+/// log / trace arms reach the driver's per-actor ring. Factored out of
+/// [`App::dispatch_window_envelope`] so the unit test directly drives
+/// the routing shape without standing up a winit `App`.
+fn try_framework_dispatch(mailer: &Arc<Mailer>, self_mailbox: MailboxId, env: &Envelope) -> bool {
+    let m = mailer.as_ref();
+    dispatch_log_tail_if_matching_free(m, env.sender, env)
+        || dispatch_trace_tail_if_matching_free(m, env.sender, env)
+        || dispatch_cost_tail_if_matching_free(m, env.sender, self_mailbox, env)
+}
+
 impl App {
     /// ADR-0080 §6 chassis-source push helper (issue
     /// iamacoffeepot/aether#723). Mints a fresh correlation, calls
@@ -353,16 +394,33 @@ impl App {
 
     /// Drain the `aether.window` inbox without blocking. Called from
     /// `about_to_wait` (per-frame cadence). Each envelope dispatches
-    /// inline against `kind_set_window_mode` / `kind_set_window_title`;
-    /// any other kind warns and drops.
+    /// inline against the framework-built-in arms first
+    /// (`aether.log.tail` / `aether.trace.tail` / `aether.cost.tail`,
+    /// iamacoffeepot/aether#1272) and only then the driver-specific
+    /// `kind_set_window_mode` / `kind_set_window_title` arms; anything
+    /// else warns and drops.
+    ///
+    /// The whole drain is wrapped in
+    /// [`aether_actor::local::with_stamped`] against
+    /// [`Self::actor_slots`] so the framework arms reach this driver's
+    /// per-actor `ActorLogRing` / `ActorTraceRing` (the same property
+    /// `DispatcherSlot::run_cycle` opens for every standard actor).
     fn drain_window_inbox(&mut self) {
         use std::sync::mpsc::TryRecvError;
-        loop {
-            match self.window_inbox.try_recv() {
-                Ok(env) => self.dispatch_window_envelope(env),
-                Err(TryRecvError::Empty | TryRecvError::Disconnected) => return,
+        // Stamp once around the whole drain rather than per-envelope —
+        // the stamp is cheap (single TLS write + RAII guard) but keeping
+        // it open across the full burst means a handler that fires
+        // `tracing::*` (e.g. apply_window_mode's failure log) also lands
+        // in the driver's ring.
+        let slots = self.actor_slots.clone();
+        local::with_stamped(slots.slots(), || {
+            loop {
+                match self.window_inbox.try_recv() {
+                    Ok(env) => self.dispatch_window_envelope(env),
+                    Err(TryRecvError::Empty | TryRecvError::Disconnected) => return,
+                }
             }
-        }
+        });
     }
 
     // `env` is owned because the dispatch borrows `env.sender`,
@@ -371,6 +429,14 @@ impl App {
     // owning-handoff symmetry with the rest of the dispatch surface.
     #[allow(clippy::needless_pass_by_value)]
     fn dispatch_window_envelope(&mut self, env: Envelope) {
+        // iamacoffeepot/aether#1272: framework-built-in dispatch arms
+        // run BEFORE the driver-specific kinds, matching
+        // `DispatcherSlot::run_cycle`'s ordering. Factored into a free
+        // fn so the desktop-driver unit test exercises the routing
+        // shape directly without standing up a winit `App`.
+        if try_framework_dispatch(&self.queue, self.window_mailbox, &env) {
+            return;
+        }
         if env.kind == self.kind_set_window_mode {
             let payload: SetWindowMode = match postcard::from_bytes(env.payload.bytes()) {
                 Ok(p) => p,
@@ -769,6 +835,8 @@ impl DriverCapability for DesktopDriverCapability {
             boot_title,
             current_mode: boot_mode,
             window_inbox: window_claim.receiver,
+            actor_slots: window_claim.actor_slots,
+            window_mailbox: window_claim.id,
             kind_set_window_mode,
             kind_set_window_title,
             // 0 is the "no correlation" sentinel; mirror NativeBinding's
@@ -877,5 +945,130 @@ mod tests {
         let (m, _) = parse_window_mode_env("  windowed  ")
             .expect("test setup: surrounding whitespace is trimmed");
         assert!(matches!(m, WindowMode::Windowed));
+    }
+
+    /// iamacoffeepot/aether#1272: a `LogTail` envelope routed at the
+    /// driver's `aether.window` mailbox produces a `LogTailResult`
+    /// reply via the framework-built-in dispatch arm. Pre-fix the
+    /// driver's bespoke "unrecognised kind → warn-drop" tail ate the
+    /// envelope and `actor_logs aether.window` hung waiting for a
+    /// reply that never came; this test pins the fix at the
+    /// driver-dispatch layer without standing up wgpu/winit.
+    #[test]
+    fn try_framework_dispatch_replies_to_log_tail() {
+        use aether_actor::local::{ActorSlots, with_stamped};
+        use aether_data::KindId;
+        use aether_data::{MailId, SessionToken};
+        use aether_kinds::descriptors;
+        use aether_kinds::trace::Nanos;
+        use aether_kinds::{LogTail, LogTailResult};
+        use aether_substrate::handle_store::HandleStore;
+        use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
+        use aether_substrate::mail::registry::Registry;
+        use aether_substrate::mail::{MailRef, ReplyTarget, ReplyTo};
+
+        let registry = Arc::new(Registry::new());
+        for d in descriptors::all() {
+            let _ = registry.register_kind_with_descriptor(d);
+        }
+        let (outbound, rx) = HubOutbound::attached_loopback();
+        let store = Arc::new(HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(registry, store).with_outbound(outbound));
+
+        let request = LogTail {
+            max: 8,
+            min_level: None,
+            since: None,
+        };
+        let bytes = postcard::to_allocvec(&request).expect("encode LogTail");
+        let session = SessionToken::NIL;
+        let reply_to = ReplyTo::with_correlation(ReplyTarget::Session(session), 0x99);
+        let env = Envelope {
+            kind: KindId(<LogTail as Kind>::ID.0),
+            kind_name: <LogTail as Kind>::NAME.to_owned(),
+            origin: None,
+            sender: reply_to,
+            payload: MailRef::from(bytes),
+            count: 1,
+            mail_id: MailId::NONE,
+            root: MailId::NONE,
+            parent_mail: None,
+            t_enqueue: Nanos(0),
+            enqueue_depth: 0,
+        };
+
+        let window_mailbox = mailbox_id_from_name("aether.window");
+        let slots = ActorSlots::new();
+        let matched = with_stamped(&slots, || {
+            try_framework_dispatch(&mailer, window_mailbox, &env)
+        });
+        assert!(
+            matched,
+            "framework dispatch arm must match a LogTail envelope at aether.window",
+        );
+
+        let event = rx.try_recv().expect("framework arm routed a reply");
+        match event {
+            EgressEvent::ToSession {
+                kind_name,
+                correlation_id,
+                ..
+            } => {
+                assert_eq!(kind_name, <LogTailResult as Kind>::NAME);
+                assert_eq!(correlation_id, 0x99);
+            }
+            other => panic!("expected ToSession reply, got {other:?}"),
+        }
+    }
+
+    /// A non-framework kind (here `SetWindowTitle`) does NOT trip the
+    /// framework arms — the driver-specific path keeps its turn so
+    /// `actor_logs`-style queries don't shadow the existing window
+    /// controls.
+    #[test]
+    fn try_framework_dispatch_skips_window_kinds() {
+        use aether_actor::local::{ActorSlots, with_stamped};
+        use aether_data::KindId;
+        use aether_data::MailId;
+        use aether_kinds::descriptors;
+        use aether_kinds::trace::Nanos;
+        use aether_substrate::handle_store::HandleStore;
+        use aether_substrate::mail::outbound::HubOutbound;
+        use aether_substrate::mail::registry::Registry;
+        use aether_substrate::mail::{MailRef, ReplyTo};
+
+        let registry = Arc::new(Registry::new());
+        for d in descriptors::all() {
+            let _ = registry.register_kind_with_descriptor(d);
+        }
+        let (outbound, rx) = HubOutbound::attached_loopback();
+        let store = Arc::new(HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(registry, store).with_outbound(outbound));
+
+        let payload = postcard::to_allocvec(&SetWindowTitle {
+            title: "ignored".to_owned(),
+        })
+        .expect("encode SetWindowTitle");
+        let env = Envelope {
+            kind: KindId(<SetWindowTitle as Kind>::ID.0),
+            kind_name: <SetWindowTitle as Kind>::NAME.to_owned(),
+            origin: None,
+            sender: ReplyTo::NONE,
+            payload: MailRef::from(payload),
+            count: 1,
+            mail_id: MailId::NONE,
+            root: MailId::NONE,
+            parent_mail: None,
+            t_enqueue: Nanos(0),
+            enqueue_depth: 0,
+        };
+
+        let window_mailbox = mailbox_id_from_name("aether.window");
+        let slots = ActorSlots::new();
+        let matched = with_stamped(&slots, || {
+            try_framework_dispatch(&mailer, window_mailbox, &env)
+        });
+        assert!(!matched, "SetWindowTitle is a driver-specific kind");
+        assert!(rx.try_recv().is_err(), "no reply emitted on skip path");
     }
 }

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -32,7 +32,8 @@ use crate::actor::native::binding::NativeBinding;
 use crate::actor::native::ctx::NativeCtx;
 use crate::actor::native::envelope::Envelope;
 use crate::actor::native::{NativeActor, NativeDispatch};
-use crate::mail::KindId;
+use crate::mail::mailer::Mailer;
+use crate::mail::{KindId, MailboxId, ReplyTo};
 
 /// Try the typed `#[handler]` dispatch; if no typed arm matches and
 /// the actor's `#[fallback]` also returns `false`, warn that the kind
@@ -147,6 +148,98 @@ pub fn dispatch_cost_tail_if_matching(
         .cost_table()
         .tail(binding.self_mailbox(), &request);
     ctx.reply(&reply);
+    true
+}
+
+/// iamacoffeepot/aether#1272: `NativeCtx`-free variant of
+/// `dispatch_log_tail_if_matching` for driver-as-actor capabilities
+/// that own their inbox drain inline (today only the desktop window
+/// driver). Reads the receiving actor's `ActorLogRing` through the
+/// currently-stamped `ActorSlots` and routes the reply via the supplied
+/// `Mailer::send_reply` — the same path `NativeCtx::reply` goes through.
+///
+/// Caller invariant: this must be called inside a
+/// `local::with_stamped(&actor_slots, …)` block so `ActorLogRing::try_with`
+/// resolves to the driver's per-actor ring.
+pub fn dispatch_log_tail_if_matching_free(
+    mailer: &Mailer,
+    reply_to: ReplyTo,
+    env: &Envelope,
+) -> bool {
+    if env.kind.0 != <LogTail as Kind>::ID.0 {
+        return false;
+    }
+    let Some(request) = <LogTail as Kind>::decode_from_bytes(env.payload.bytes()) else {
+        mailer.send_reply(
+            reply_to,
+            &LogTailResult::Err {
+                error: "aether.log.tail: payload failed to decode".to_owned(),
+            },
+        );
+        return true;
+    };
+    let reply =
+        ActorLogRing::try_with(|ring| ring.tail(&request)).unwrap_or_else(|| LogTailResult::Err {
+            error: "aether.log.tail: actor has no stamped slots".to_owned(),
+        });
+    mailer.send_reply(reply_to, &reply);
+    true
+}
+
+/// iamacoffeepot/aether#1272: `NativeCtx`-free counterpart of
+/// `dispatch_trace_tail_if_matching`. See
+/// [`dispatch_log_tail_if_matching_free`] for the caller invariant.
+pub fn dispatch_trace_tail_if_matching_free(
+    mailer: &Mailer,
+    reply_to: ReplyTo,
+    env: &Envelope,
+) -> bool {
+    if env.kind.0 != <TraceTail as Kind>::ID.0 {
+        return false;
+    }
+    let Some(request) = <TraceTail as Kind>::decode_from_bytes(env.payload.bytes()) else {
+        mailer.send_reply(
+            reply_to,
+            &TraceTailResult::Err {
+                error: "aether.trace.tail: payload failed to decode".to_owned(),
+            },
+        );
+        return true;
+    };
+    let reply = ActorTraceRing::try_with(|ring| ring.tail(&request)).unwrap_or_else(|| {
+        TraceTailResult::Err {
+            error: "aether.trace.tail: actor has no stamped slots".to_owned(),
+        }
+    });
+    mailer.send_reply(reply_to, &reply);
+    true
+}
+
+/// iamacoffeepot/aether#1272: `NativeCtx`-free counterpart of
+/// `dispatch_cost_tail_if_matching`. The cost table doesn't depend on
+/// stamped `ActorSlots` — it's read directly off the mailer — so the
+/// `self_mailbox` rides along explicitly (the standard variant pulls it
+/// from `binding.self_mailbox()`).
+pub fn dispatch_cost_tail_if_matching_free(
+    mailer: &Mailer,
+    reply_to: ReplyTo,
+    self_mailbox: MailboxId,
+    env: &Envelope,
+) -> bool {
+    if env.kind.0 != <CostTail as Kind>::ID.0 {
+        return false;
+    }
+    let Some(request) = <CostTail as Kind>::decode_from_bytes(env.payload.bytes()) else {
+        mailer.send_reply(
+            reply_to,
+            &CostTailResult::Err {
+                error: "aether.cost.tail: payload failed to decode".to_owned(),
+            },
+        );
+        return true;
+    };
+    let reply = mailer.cost_table().tail(self_mailbox, &request);
+    mailer.send_reply(reply_to, &reply);
     true
 }
 
@@ -287,5 +380,168 @@ mod cost_tests {
             rows[0].samples, 0,
             "neutral seed surfaces before any dispatch"
         );
+    }
+}
+
+/// iamacoffeepot/aether#1272: regression coverage for the `NativeCtx`-
+/// free framework dispatch arm variants the desktop window driver
+/// reaches for from its bespoke inbox drain.
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture construction panic on failure is the assertion"
+)]
+mod free_dispatch_tests {
+    use super::*;
+    use crate::handle_store::HandleStore;
+    use crate::mail::mailer::Mailer;
+    use crate::mail::outbound::{EgressEvent, HubOutbound};
+    use crate::mail::registry::Registry;
+    use crate::mail::{MailRef, ReplyTarget};
+    use aether_actor::local::{ActorSlots, with_stamped};
+    use aether_data::{MailId, SessionToken};
+    use aether_kinds::SetWindowTitle;
+    use aether_kinds::descriptors;
+    use aether_kinds::trace::Nanos;
+    use std::sync::Arc;
+    use std::sync::mpsc;
+
+    fn fresh_substrate_with_outbound() -> (Arc<Mailer>, mpsc::Receiver<EgressEvent>) {
+        let registry = Arc::new(Registry::new());
+        for d in descriptors::all() {
+            let _ = registry.register_kind_with_descriptor(d);
+        }
+        let (outbound, rx) = HubOutbound::attached_loopback();
+        let store = Arc::new(HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(registry, store).with_outbound(outbound));
+        (mailer, rx)
+    }
+
+    fn build_envelope<K: Kind + serde::Serialize>(payload: &K, reply_to: ReplyTo) -> Envelope {
+        let bytes = postcard::to_allocvec(payload).expect("postcard encode");
+        Envelope {
+            kind: KindId(<K as Kind>::ID.0),
+            kind_name: <K as Kind>::NAME.to_owned(),
+            origin: None,
+            sender: reply_to,
+            payload: MailRef::from(bytes),
+            count: 1,
+            mail_id: MailId::NONE,
+            root: MailId::NONE,
+            parent_mail: None,
+            t_enqueue: Nanos(0),
+            enqueue_depth: 0,
+        }
+    }
+
+    /// The free-fn log-tail arm fires a `LogTailResult` reply to the
+    /// envelope's `sender` when the kind matches — the property the
+    /// desktop window driver (iamacoffeepot/aether#1272) relies on so
+    /// `actor_logs aether.window` resolves instead of hanging on a
+    /// never-arriving reply.
+    #[test]
+    fn dispatch_log_tail_free_replies_on_match() {
+        let (mailer, rx) = fresh_substrate_with_outbound();
+        let session = SessionToken::NIL;
+        let reply_to = ReplyTo::with_correlation(ReplyTarget::Session(session), 0x1272_4242);
+        let env = build_envelope(
+            &LogTail {
+                max: 10,
+                min_level: None,
+                since: None,
+            },
+            reply_to,
+        );
+
+        // The arm reads `ActorLogRing::try_with`, so it must run inside a
+        // `with_stamped` block. Stamping with a fresh slot map makes the
+        // ring resolve to its default (empty) — the reply lands as
+        // `LogTailResult::Ok { entries: [] }`.
+        let slots = ActorSlots::new();
+        let matched = with_stamped(&slots, || {
+            dispatch_log_tail_if_matching_free(&mailer, reply_to, &env)
+        });
+        assert!(matched, "log.tail kind matches");
+
+        let event = rx.try_recv().expect("reply egress recorded");
+        match event {
+            EgressEvent::ToSession {
+                session: got_session,
+                kind_name,
+                correlation_id,
+                ..
+            } => {
+                assert_eq!(got_session, session);
+                assert_eq!(kind_name, <LogTailResult as Kind>::NAME);
+                assert_eq!(correlation_id, 0x1272_4242);
+            }
+            other => panic!("expected ToSession egress, got {other:?}"),
+        }
+    }
+
+    /// Non-matching kinds fall through without replying — the driver's
+    /// existing `kind_set_window_mode` / `kind_set_window_title` arms
+    /// still get their chance after the framework arms return `false`.
+    #[test]
+    fn dispatch_log_tail_free_skips_non_match() {
+        let (mailer, rx) = fresh_substrate_with_outbound();
+        let session = SessionToken::NIL;
+        let reply_to = ReplyTo::with_correlation(ReplyTarget::Session(session), 0);
+        // Build an envelope of a different kind (`SetWindowTitle`); the
+        // arm must early-return `false` and emit nothing.
+        let env = build_envelope(
+            &SetWindowTitle {
+                title: "test".to_owned(),
+            },
+            reply_to,
+        );
+
+        let slots = ActorSlots::new();
+        let matched = with_stamped(&slots, || {
+            dispatch_log_tail_if_matching_free(&mailer, reply_to, &env)
+        });
+        assert!(!matched, "non-log.tail kind doesn't match");
+        assert!(rx.try_recv().is_err(), "skip path emits no reply egress");
+    }
+
+    /// The trace-tail and cost-tail free fns are siblings of the log-tail
+    /// arm; smoke-test both fire their reply on a matched envelope so a
+    /// future contract slip on either kind doesn't silently regress
+    /// `actor_logs`-style queries against the desktop driver.
+    #[test]
+    fn dispatch_trace_and_cost_tail_free_reply_on_match() {
+        let (mailer, rx) = fresh_substrate_with_outbound();
+        let self_mbx = MailboxId(0x1272_AAAA);
+        let session = SessionToken::NIL;
+        let reply_to = ReplyTo::with_correlation(ReplyTarget::Session(session), 0xCAFE);
+
+        let trace_env = build_envelope(
+            &TraceTail {
+                max: 16,
+                since: None,
+                root: None,
+            },
+            reply_to,
+        );
+        let cost_env = build_envelope(&CostTail { kind: None }, reply_to);
+
+        let slots = ActorSlots::new();
+        let (trace_match, cost_match) = with_stamped(&slots, || {
+            let trace = dispatch_trace_tail_if_matching_free(&mailer, reply_to, &trace_env);
+            let cost = dispatch_cost_tail_if_matching_free(&mailer, reply_to, self_mbx, &cost_env);
+            (trace, cost)
+        });
+        assert!(trace_match);
+        assert!(cost_match);
+
+        // Two replies must have been routed; both `ToSession`.
+        let names: Vec<String> = (0..2)
+            .map(|_| match rx.try_recv().expect("reply egress recorded") {
+                EgressEvent::ToSession { kind_name, .. } => kind_name,
+                other => panic!("expected ToSession egress, got {other:?}"),
+            })
+            .collect();
+        assert!(names.iter().any(|n| n == <TraceTailResult as Kind>::NAME));
+        assert!(names.iter().any(|n| n == <CostTailResult as Kind>::NAME));
     }
 }

--- a/crates/aether-substrate/src/actor/native/mod.rs
+++ b/crates/aether-substrate/src/actor/native/mod.rs
@@ -75,6 +75,15 @@ pub mod spawn_thread;
 
 pub use binding::NativeBinding;
 pub use ctx::{ExportedHandles, NativeCtx, NativeInitCtx};
+// iamacoffeepot/aether#1272: driver-as-actor capabilities that own
+// their inbox drain inline (today only the desktop window driver)
+// reach for the `NativeCtx`-free variants of the framework dispatch
+// arms so `actor_logs aether.window` reaches the log/trace/cost rings
+// the same way every standard-dispatcher-slot actor does.
+pub use dispatch::{
+    dispatch_cost_tail_if_matching_free, dispatch_log_tail_if_matching_free,
+    dispatch_trace_tail_if_matching_free,
+};
 pub use envelope::Envelope;
 pub use mailbox::NativeActorMailbox;
 pub use spawn::{SpawnBuilder, SpawnError, Spawner, Subname};

--- a/crates/aether-substrate/src/chassis/ctx.rs
+++ b/crates/aether-substrate/src/chassis/ctx.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use std::sync::mpsc;
 
 use aether_actor::Actor;
+use aether_actor::local::ActorSlots;
 
 use crate::actor::native::envelope::Envelope;
 use crate::chassis::error::BootError;
@@ -33,10 +34,86 @@ use std::sync::OnceLock;
 /// The capability owns the receiver afterward; the slot is consumed
 /// from the registry, so a second claim for the same name fails
 /// loud with [`BootError::MailboxAlreadyClaimed`].
-#[derive(Debug)]
+///
+/// `actor_slots` carries this claim's per-actor [`ActorSlots`] — the
+/// chassis [`crate::chassis::builder::Builder::with_actor`] path
+/// stamps this into TLS via [`aether_actor::local::with_stamped`]
+/// around `init` / `wire` / each dispatch so per-actor `Local<T>`
+/// lookups (notably the ADR-0081 `ActorLogRing`) resolve to the
+/// caller's storage. Driver-as-actor capabilities (issue 603 Phase 3,
+/// today only the desktop window driver) that bypass the standard
+/// dispatcher slot need to stamp the same slots around their bespoke
+/// drain so the framework-built-in `aether.log.tail` /
+/// `aether.trace.tail` / `aether.cost.tail` dispatch arms reach the
+/// expected ring (iamacoffeepot/aether#1272).
 pub struct MailboxClaim {
     pub id: MailboxId,
     pub receiver: mpsc::Receiver<Envelope>,
+    pub actor_slots: SharedActorSlots,
+}
+
+impl fmt::Debug for MailboxClaim {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // `ActorSlots` doesn't impl `Debug` (interior `RefCell<HashMap>`
+        // of type-erased boxes), so hand-roll Debug on `MailboxClaim`
+        // and finish non-exhaustively rather than deriving.
+        f.debug_struct("MailboxClaim")
+            .field("id", &self.id)
+            .field("receiver", &self.receiver)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Driver-as-actor's [`ActorSlots`] handle (iamacoffeepot/aether#1272).
+///
+/// `ActorSlots` uses interior `RefCell` (a single dispatcher thread is
+/// the sole owner per ADR-0038), so a bare `Arc<ActorSlots>` is neither
+/// `Send` nor `Sync`. Driver-as-actor capabilities access these slots
+/// only from their bespoke drain thread (the winit main thread for the
+/// desktop window driver), so the interior cell stays effectively
+/// single-threaded — mirrors the pooled dispatcher's `PooledSlots`
+/// wrapper, but here the access invariant is stricter (one fixed
+/// thread, not "at most one pool worker at a time"). The `unsafe impl
+/// Sync` / `Send` are the safety story.
+#[derive(Clone)]
+#[allow(
+    clippy::non_send_fields_in_send_ty,
+    reason = "driver-as-actor invariant: slots only touched on one fixed thread; see type docs"
+)]
+pub struct SharedActorSlots(Arc<ActorSlots>);
+
+// SAFETY: see the doc-comment on `SharedActorSlots`. The driver-as-actor
+// invariant is that the slots are only ever read inside
+// `local::with_stamped` on the driver's bespoke drain thread. No other
+// thread holds an `Arc` clone, so the interior `RefCell` accesses are
+// single-threaded by construction.
+unsafe impl Sync for SharedActorSlots {}
+// SAFETY: same justification — single-thread access.
+unsafe impl Send for SharedActorSlots {}
+
+impl SharedActorSlots {
+    /// Allocate a fresh per-actor slot map.
+    #[must_use]
+    #[allow(
+        clippy::arc_with_non_send_sync,
+        reason = "SharedActorSlots's unsafe impl Send/Sync covers this Arc; see type docs"
+    )]
+    pub fn new() -> Self {
+        Self(Arc::new(ActorSlots::new()))
+    }
+
+    /// Borrow the inner [`ActorSlots`] for an
+    /// [`aether_actor::local::with_stamped`] call.
+    #[must_use]
+    pub fn slots(&self) -> &ActorSlots {
+        &self.0
+    }
+}
+
+impl Default for SharedActorSlots {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 /// Result returned from [`ChassisCtx::claim_mailbox_drop_on_shutdown`].
@@ -249,7 +326,19 @@ impl<'a> ChassisCtx<'a> {
             }),
         )?;
         self.claimed_actor_mailboxes.push(id);
-        Ok(MailboxClaim { id, receiver: rx })
+        // iamacoffeepot/aether#1272: every claim returns its
+        // per-actor [`ActorSlots`] wrapped in [`SharedActorSlots`]. The
+        // `with_actor` boot path allocates its own [`ActorSlots`] (via
+        // `Box<ActorSlots>` in `ClaimResources`) and ignores this one;
+        // driver-as-actor capabilities that own the drain inline (the
+        // desktop window driver) wrap their bespoke drain in
+        // `local::with_stamped(slots.as_ref(), …)` so framework dispatch
+        // arms reach the actor's per-actor `Local<T>` rings.
+        Ok(MailboxClaim {
+            id,
+            receiver: rx,
+            actor_slots: SharedActorSlots::new(),
+        })
     }
 
     /// Variant of [`Self::claim_mailbox`] that returns a strong
@@ -417,5 +506,93 @@ impl<'a> ChassisCtx<'a> {
         }
         *self.fallback = Some(handler);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture construction panic on failure is the assertion"
+)]
+mod tests {
+    use super::*;
+
+    use aether_actor::Local;
+    use aether_actor::local::with_stamped;
+    use aether_kinds::descriptors;
+
+    use crate::actor::registry::ActorRegistry;
+    use crate::handle_store::HandleStore;
+    use crate::runtime::lifecycle::PanicAborter;
+    use crate::scheduler::{Pool, PoolConfig};
+
+    /// Per-actor scratch type for the iamacoffeepot/aether#1272 round-trip
+    /// test. Mirrors the `ActorLogRing` shape (`Default + Local`) at the
+    /// level the framework dispatch arm reaches it through.
+    #[derive(Default)]
+    struct Probe(u32);
+    impl Local for Probe {}
+
+    /// iamacoffeepot/aether#1272: a `MailboxClaim` returns its per-actor
+    /// `ActorSlots`. Driver-as-actor capabilities (today only the desktop
+    /// window driver) wrap their bespoke drain in
+    /// `local::with_stamped(&claim.actor_slots, …)` so framework dispatch
+    /// arms (`aether.log.tail` / `aether.trace.tail` / `aether.cost.tail`)
+    /// reach the actor's per-actor `Local<T>` rings.
+    #[test]
+    fn claim_mailbox_returns_stampable_actor_slots() {
+        let registry = Arc::new(Registry::new());
+        for d in descriptors::all() {
+            let _ = registry.register_kind_with_descriptor(d);
+        }
+        let store = Arc::new(HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
+        let aborter: Arc<dyn FatalAborter> = Arc::new(PanicAborter);
+        let actor_registry = Arc::new(ActorRegistry::new());
+        let pool = Pool::start(PoolConfig::default(), Arc::clone(&aborter));
+        let spawner = Arc::new(crate::Spawner::new(
+            Arc::clone(&registry),
+            actor_registry,
+            Arc::clone(&mailer),
+            Arc::clone(&aborter),
+            pool.wake_sink(),
+        ));
+        let mut fallback: Option<FallbackRouter> = None;
+        let mut claimed_actor_mailboxes: Vec<MailboxId> = Vec::new();
+        let mut ctx = ChassisCtx::new(
+            &registry,
+            &mailer,
+            &mut fallback,
+            &aborter,
+            &mut claimed_actor_mailboxes,
+            &spawner,
+        );
+
+        let claim = ctx
+            .claim_mailbox_with_override("test.iamacoffeepot.1272.driver")
+            .expect("first claim succeeds");
+
+        // Stamp the claim's slots into TLS and write through a `Local<T>`;
+        // a second `with_stamped` round-trips reads back through the same
+        // slot — the property the framework dispatch arm relies on when
+        // it calls `ActorLogRing::try_with(...)` inside the driver's
+        // bespoke drain.
+        with_stamped(claim.actor_slots.slots(), || {
+            Probe::with_mut(|p| p.0 = 0x1272);
+        });
+        let read_back = with_stamped(claim.actor_slots.slots(), || {
+            Probe::try_with(|p| p.0).expect("stamped slots carry Probe")
+        });
+        assert_eq!(read_back, 0x1272);
+
+        // A fresh `ActorSlots` (not the one carried on the claim) must
+        // see the Local at its default — confirms the round-trip above
+        // actually went through the claim's slots and not a stale TLS
+        // remnant.
+        let other = SharedActorSlots::new();
+        let other_read = with_stamped(other.slots(), || {
+            Probe::try_with(|p| p.0).expect("any stamped slots carry Probe")
+        });
+        assert_eq!(other_read, 0, "fresh slots see the Local at its default");
     }
 }

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -73,6 +73,7 @@ pub use chassis::builder::{
 };
 pub use chassis::ctx::{
     ActorErased, ChassisCtx, DropOnShutdownClaim, FallbackRouter, MailboxClaim, MailboxSender,
+    SharedActorSlots,
 };
 pub use chassis::error::BootError;
 pub use config::FromArgvThenEnv;


### PR DESCRIPTION
Closes iamacoffeepot/aether#1272.

`actor_logs aether.window` hung indefinitely against a desktop engine because the desktop driver's bespoke inbox drain handled `SetWindowMode` / `SetWindowTitle` and dropped everything else into a `tracing::warn!` arm — including the framework's `aether.log.tail` dispatch the contract in ADR-0081 §1 promises every mailbox serves.

The driver doesn't flow through `DispatcherSlot::run_cycle` (winit main-thread ordering, iamacoffeepot/aether#603 Phase 3), so the log/trace/cost.tail arms that the pooled dispatcher runs never fired for the driver's mailbox.

## What changed

- `aether-substrate/src/chassis/ctx.rs` — `MailboxClaim` exposes the chassis-side `ActorSlots` via a new `SharedActorSlots` newtype (Send+Sync wrapper with the same safety story as `PooledSlots`; driver-as-actor only touches the slots from the fixed winit main thread).
- `aether-substrate/src/actor/native/dispatch.rs` — added `NativeCtx`-free variants `dispatch_log_tail_if_matching_free` / `dispatch_trace_tail_if_matching_free` / `dispatch_cost_tail_if_matching_free` that take `&Mailer` + `ReplyTo` directly. Per the issue body's side findings note: the driver doesn't have a `NativeBinding` (driver-as-actor pre-dates that path), so the free-fn route is the surgical fix.
- `aether-substrate-bundle/src/desktop/driver.rs` — wraps `drain_window_inbox` in `local::with_stamped` so the driver's per-actor ring is reachable; new `try_framework_dispatch` free fn called FIRST at the head of `dispatch_window_envelope`; existing `SetWindowMode` / `SetWindowTitle` arms run only after no framework arm matched.
- 6 new unit tests cover the new dispatch paths and the driver's framework-first routing.

## Validation

- `cargo nextest run --workspace --all-features`: **1430 passed, 0 failed, 6 skipped** (1424 baseline + 6 new).
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo doc --workspace --no-deps` clean.
- wasm32 cross-build for `aether-camera` and `aether-mesh-viewer` clean.
- Preflight green.

## Surfaced for review attention

The `with_actor` chassis boot path allocates its own `Box<ActorSlots>` (in `ClaimResources` at `chassis/builder.rs:484`) and ignores `claim.actor_slots`. Today there's no other consumer than the desktop driver, so the extra `Arc<ActorSlots>` per `claim_mailbox_with_override` is fractionally wasted — non-load-bearing, but worth noting for a future tightening if a second driver-as-actor cap appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)