### PR TITLE
feat(substrate): carry init config on load/spawn and surface the config kind

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -1685,9 +1685,21 @@ fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
     let fallback_method_tokens = fallback.as_ref().map(|f| &f.method);
     let helper_methods_tokens = helpers.iter();
 
-    let inputs_manifest_consts =
-        build_inputs_manifest_consts(&handlers, fallback.as_ref(), component_doc.as_ref());
-    let kind_retention_statics = build_kinds_section_retention_statics(self_ty, &handlers);
+    // ADR-0090 (issue 1257): surface the component's declared boot-config
+    // kind. The macro emits a `Config` inputs record + a config-kind
+    // retention static ONLY when the user explicitly declared
+    // `type Config` (the synthesized `= ()` case stays clean — gating on
+    // `config_type.is_some()` at macro time, NOT on `Config != ()` at
+    // runtime, keeps `aether.unit` out of every component's capability).
+    let config_kind_ty: Option<&Type> = config_type.as_ref().map(|it| &it.ty);
+    let inputs_manifest_consts = build_inputs_manifest_consts(
+        &handlers,
+        fallback.as_ref(),
+        component_doc.as_ref(),
+        config_kind_ty,
+    );
+    let kind_retention_statics =
+        build_kinds_section_retention_statics(self_ty, &handlers, config_kind_ty);
 
     // Issue 525 Phase 4: trait consts (today just NAMESPACE) live
     // on the `Actor` super-trait, not `Component` / `FfiActor`. Route
@@ -2082,6 +2094,9 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
                 handlers: ::std::vec![#(#capability_handler_entries),*],
                 fallback: #capability_fallback,
                 doc: ::core::option::Option::None,
+                // ADR-0090 (issue 1257): native chassis caps don't carry
+                // a describe-surfaced boot-config kind.
+                config: ::core::option::Option::None,
             }
         }
     };
@@ -2359,7 +2374,7 @@ fn build_dispatch_body(handlers: &[HandlerFn], fallback: Option<&FallbackFn>) ->
 /// `__AETHER_INPUTS_MANIFEST_LEN: usize` and
 /// `__AETHER_INPUTS_MANIFEST: [u8; …LEN]` — carrying the
 /// concatenated `aether.kinds.inputs` record bytes. Each record is
-/// `[INPUTS_SECTION_VERSION (0x01), ..postcard(InputsRecord)..]`,
+/// `[INPUTS_SECTION_VERSION (0x02), ..postcard(InputsRecord)..]`,
 /// assembled at const-eval via the hub-protocol const-fn encoders.
 /// `aether_actor::export!()` reads these consts and emits the
 /// `#[unsafe(link_section = "aether.kinds.inputs")]` static in the
@@ -2367,10 +2382,15 @@ fn build_dispatch_body(handlers: &[HandlerFn], fallback: Option<&FallbackFn>) ->
 /// is what prevents the section from stacking when a `#[actor]`-
 /// using crate is pulled in as a wasm32 rlib by another cdylib (a
 /// rlib that doesn't call `export!()` contributes no section bytes).
+// One const-eval byte-copy block per record kind (handler / fallback /
+// component-doc / config); inlining them in one walk keeps each emitted
+// block contiguous and reads better than four near-identical helpers.
+#[allow(clippy::too_many_lines)]
 fn build_inputs_manifest_consts(
     handlers: &[HandlerFn],
     fallback: Option<&FallbackFn>,
     component_doc: Option<&String>,
+    config_kind_ty: Option<&Type>,
 ) -> TokenStream2 {
     let mut len_terms: Vec<TokenStream2> = Vec::new();
     let mut copy_blocks: Vec<TokenStream2> = Vec::new();
@@ -2402,7 +2422,10 @@ fn build_inputs_manifest_consts(
                         <#k as ::aether_actor::__macro_internals::Kind>::NAME,
                         #doc_expr,
                     );
-                out[pos] = 0x01;
+                // ADR-0090 (issue 1257): per-record section version byte
+                // bumped 0x01 -> 0x02 alongside the new `Config` variant.
+                // Keep this in lockstep with `INPUTS_SECTION_VERSION`.
+                out[pos] = 0x02;
                 pos += 1;
                 let mut i = 0;
                 while i < REC_LEN {
@@ -2425,7 +2448,10 @@ fn build_inputs_manifest_consts(
                     ::aether_actor::__macro_internals::canonical::inputs_fallback_len(#doc_expr);
                 const REC_BYTES: [u8; REC_LEN] =
                     ::aether_actor::__macro_internals::canonical::write_inputs_fallback::<REC_LEN>(#doc_expr);
-                out[pos] = 0x01;
+                // ADR-0090 (issue 1257): per-record section version byte
+                // bumped 0x01 -> 0x02 alongside the new `Config` variant.
+                // Keep this in lockstep with `INPUTS_SECTION_VERSION`.
+                out[pos] = 0x02;
                 pos += 1;
                 let mut i = 0;
                 while i < REC_LEN {
@@ -2448,7 +2474,46 @@ fn build_inputs_manifest_consts(
                     ::aether_actor::__macro_internals::canonical::inputs_component_len(#doc_lit);
                 const REC_BYTES: [u8; REC_LEN] =
                     ::aether_actor::__macro_internals::canonical::write_inputs_component::<REC_LEN>(#doc_lit);
-                out[pos] = 0x01;
+                // ADR-0090 (issue 1257): per-record section version byte
+                // bumped 0x01 -> 0x02 alongside the new `Config` variant.
+                // Keep this in lockstep with `INPUTS_SECTION_VERSION`.
+                out[pos] = 0x02;
+                pos += 1;
+                let mut i = 0;
+                while i < REC_LEN {
+                    out[pos] = REC_BYTES[i];
+                    pos += 1;
+                    i += 1;
+                }
+            }
+        });
+    }
+
+    // ADR-0090 (issue 1257): emit a `Config` record keyed by the
+    // declared config kind's `Kind::ID` / `NAME`. Only present when the
+    // user spelled `type Config = …` — `config_kind_ty` is `None` for
+    // the macro-synthesized `()` case, so a no-config component stays
+    // clean. Variant tag `0x03` matches `InputsRecord::Config`.
+    if let Some(cfg) = config_kind_ty {
+        len_terms.push(quote! {
+            (1 + ::aether_actor::__macro_internals::canonical::inputs_config_len(
+                <#cfg as ::aether_actor::__macro_internals::Kind>::ID.0,
+                <#cfg as ::aether_actor::__macro_internals::Kind>::NAME,
+            ))
+        });
+        copy_blocks.push(quote! {
+            {
+                const REC_LEN: usize =
+                    ::aether_actor::__macro_internals::canonical::inputs_config_len(
+                        <#cfg as ::aether_actor::__macro_internals::Kind>::ID.0,
+                        <#cfg as ::aether_actor::__macro_internals::Kind>::NAME,
+                    );
+                const REC_BYTES: [u8; REC_LEN] =
+                    ::aether_actor::__macro_internals::canonical::write_inputs_config::<REC_LEN>(
+                        <#cfg as ::aether_actor::__macro_internals::Kind>::ID.0,
+                        <#cfg as ::aether_actor::__macro_internals::Kind>::NAME,
+                    );
+                out[pos] = 0x02;
                 pos += 1;
                 let mut i = 0;
                 while i < REC_LEN {
@@ -2514,11 +2579,31 @@ fn build_inputs_manifest_consts(
 /// component). If that assumption ever breaks, extend this emitter to
 /// walk `Sink<K>` resolutions too.
 #[allow(clippy::too_many_lines)] // per-handler retention static block; one walk keeps each emitted static contiguous
-fn build_kinds_section_retention_statics(self_ty: &Type, handlers: &[HandlerFn]) -> TokenStream2 {
+fn build_kinds_section_retention_statics(
+    self_ty: &Type,
+    handlers: &[HandlerFn],
+    config_kind_ty: Option<&Type>,
+) -> TokenStream2 {
     let self_ty_hint = type_hint(self_ty);
 
-    let statics = handlers.iter().enumerate().map(|(idx, h)| {
-        let k = &h.kind_ty;
+    // ADR-0090 (issue 1257): the declared config kind needs the same
+    // `aether.kinds` / `aether.kinds.labels` retention as handler kinds
+    // so its schema + labels survive the rlib→cdylib dead-section strip
+    // and `describe_kinds` can resolve it by id. Tack it onto the walk
+    // with a distinct index suffix so it never collides with a handler
+    // static. `None` (synthesized `()` config) contributes nothing.
+    // The suffix is a plain `String` (e.g. "0", "1", "CONFIG") spliced
+    // into the larger static identifiers below — a bare numeric ident
+    // isn't valid on its own, so it must stay a format arg, not a
+    // standalone `Ident`.
+    let retained_kinds: Vec<(Type, String)> = handlers
+        .iter()
+        .enumerate()
+        .map(|(idx, h)| (h.kind_ty.clone(), idx.to_string()))
+        .chain(config_kind_ty.map(|cfg| (cfg.clone(), "CONFIG".to_string())))
+        .collect();
+
+    let statics = retained_kinds.iter().map(|(k, idx)| {
         let schema_ident = quote::format_ident!(
             "__AETHER_HANDLERS_KIND_SCHEMA_{}_{}",
             self_ty_hint,

--- a/crates/aether-actor/tests/handlers_manifest.rs
+++ b/crates/aether-actor/tests/handlers_manifest.rs
@@ -121,6 +121,11 @@ fn manifest_const_round_trips_to_expected_records() {
             }
             InputsRecord::Fallback { .. } => fallback_count += 1,
             InputsRecord::Component { .. } => {}
+            // ADR-0090 (issue 1257): this fixture declares no `type
+            // Config`, so the macro emits no Config record.
+            InputsRecord::Config { .. } => {
+                panic!("unexpected Config record for a no-config component")
+            }
         }
     }
 

--- a/crates/aether-camera/tests/scenario.rs
+++ b/crates/aether-camera/tests/scenario.rs
@@ -70,6 +70,7 @@ fn load_camera(bench: &mut TestBench, wasm_path: &Path) {
                 &LoadComponent {
                     wasm,
                     name: Some(COMPONENT_NAME.to_owned()),
+                    config: Vec::new(),
                 },
             ),
         )])

--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -291,6 +291,10 @@ mod native {
                 registry: Arc::clone(&self.registry),
                 outbound: Arc::clone(&self.outbound),
                 capabilities: capabilities.clone(),
+                // ADR-0090 (issue 1257): carry the load mail's init-config
+                // bytes into the trampoline; `WasmTrampoline::init` hands
+                // them to the guest's typed `init`.
+                config: payload.config,
             };
             let mailbox_id = match ctx
                 .spawn_child::<WasmTrampoline>(Subname::Named(&name), trampoline_config)

--- a/crates/aether-capabilities/src/trampoline.rs
+++ b/crates/aether-capabilities/src/trampoline.rs
@@ -113,6 +113,11 @@ mod native {
         /// `LoadResult::Ok.capabilities` at the cap. The trampoline
         /// keeps a handle so it can rehydrate after a replace.
         pub capabilities: ComponentCapabilities,
+        /// ADR-0090 (issue 1257): init-config bytes from the
+        /// `aether.component.load` mail, handed to the guest's typed
+        /// `FfiActor::init` via `Component::instantiate`. Empty means
+        /// "no config" — a `Config = ()` guest decodes `&[]` uniformly.
+        pub config: Vec<u8>,
     }
 
     /// Per-component trampoline. Holds the wasm `Component`
@@ -173,16 +178,17 @@ mod native {
             // binding (issue 634 Phase 4 PR 3 — single source of inbox
             // truth lives on `NativeBinding`, not on `ComponentCtx`).
             substrate_ctx.install_binding(Arc::clone(ctx.binding()));
-            // ADR-0090 (issue 1256): config bytes are not yet threaded
-            // from the load mail; c2 of the rollout wires them. For
-            // now pass `&[]` — guests whose `Config = ()` decode this
-            // uniformly via `impl Kind for ()`.
+            // ADR-0090 (issue 1257): thread the load mail's config bytes
+            // into the guest's typed `init`. An empty slice ("no config")
+            // is decoded uniformly by a `Config = ()` guest via
+            // `impl Kind for ()`; a typed-config guest decodes its
+            // `Self::Config` from these bytes.
             let component = Component::instantiate(
                 &config.engine,
                 &config.linker,
                 &config.module,
                 substrate_ctx,
-                &[],
+                &config.config,
             )
             .map_err(|e| {
                 BootError::Other(io::Error::other(format!("wasm instantiation failed: {e}")).into())
@@ -396,16 +402,16 @@ mod native {
                 Arc::clone(&self.outbound),
             );
 
-            // ADR-0090 (issue 1256): replace does not yet thread config
-            // bytes through (c2). Pass `&[]` so `Config = ()` guests
-            // decode cleanly; typed-config replaces will surface once
-            // the replace ABI carries config alongside the wasm bytes.
+            // ADR-0090 (issue 1257): thread the replace mail's config
+            // bytes into the new instance's typed `init`, the same way
+            // the load path does. Empty means "no config"; a typed-config
+            // guest decodes its `Self::Config` from these bytes.
             let mut new_component = match Component::instantiate(
                 &self.engine,
                 &self.linker,
                 &module,
                 substrate_ctx,
-                &[],
+                &payload.config,
             ) {
                 Ok(c) => c,
                 Err(e) => {

--- a/crates/aether-data/src/canonical/inputs.rs
+++ b/crates/aether-data/src/canonical/inputs.rs
@@ -77,3 +77,26 @@ pub const fn write_inputs_component<const N: usize>(doc: &str) -> [u8; N] {
     let _ = pos;
     out
 }
+
+/// Byte length of a `Config` record's postcard encoding (ADR-0090 /
+/// issue 1257). One-byte enum-variant tag (`0x03`) + `varint(id)` +
+/// `postcard(name)`.
+#[must_use]
+pub const fn inputs_config_len(id: u64, name: &str) -> usize {
+    1 + varint_u64_len(id) + str_len(name)
+}
+
+/// Serialize an `InputsRecord::Config` into a fixed-size array sized by
+/// `inputs_config_len`. Exact postcard wire shape for
+/// `InputsRecord::Config { id, name }`.
+#[must_use]
+pub const fn write_inputs_config<const N: usize>(id: u64, name: &str) -> [u8; N] {
+    let mut out = [0u8; N];
+    let mut pos = 0usize;
+    out[pos] = 3; // variant tag: Config
+    pos += 1;
+    pos = write_varint_u64(id, &mut out, pos);
+    pos = write_str(name, &mut out, pos);
+    let _ = pos;
+    out
+}

--- a/crates/aether-data/src/canonical/mod.rs
+++ b/crates/aether-data/src/canonical/mod.rs
@@ -42,8 +42,8 @@ mod primitives;
 mod schema;
 
 pub use inputs::{
-    inputs_component_len, inputs_fallback_len, inputs_handler_len, write_inputs_component,
-    write_inputs_fallback, write_inputs_handler,
+    inputs_component_len, inputs_config_len, inputs_fallback_len, inputs_handler_len,
+    write_inputs_component, write_inputs_config, write_inputs_fallback, write_inputs_handler,
 };
 pub use labels::{canonical_len_labels, canonical_serialize_labels};
 pub use primitives::{varint_u32_len, varint_u64_len, varint_usize_len};
@@ -458,6 +458,25 @@ mod tests {
         const BYTES: [u8; N] = write_inputs_component::<N>(DOC);
         let decoded: InputsRecord = postcard::from_bytes(&BYTES).expect("decode");
         assert_eq!(decoded, InputsRecord::Component { doc: DOC.into() });
+    }
+
+    #[test]
+    fn inputs_config_const_round_trips() {
+        // ADR-0090 (issue 1257): the `Config` record's const-eval bytes
+        // must decode to `InputsRecord::Config` byte-for-byte so the
+        // substrate reader lifts the config kind id + name verbatim.
+        const ID: u64 = 0x0123_4567_89ab_cdef;
+        const NAME: &str = "aether.test_fixtures.probe_config";
+        const N: usize = inputs_config_len(ID, NAME);
+        const BYTES: [u8; N] = write_inputs_config::<N>(ID, NAME);
+        let decoded: InputsRecord = postcard::from_bytes(&BYTES).expect("decode");
+        assert_eq!(
+            decoded,
+            InputsRecord::Config {
+                id: KindId(ID),
+                name: NAME.into(),
+            }
+        );
     }
 
     #[test]

--- a/crates/aether-data/src/schema.rs
+++ b/crates/aether-data/src/schema.rs
@@ -819,6 +819,12 @@ pub enum InputsRecord {
     Fallback { doc: Option<Cow<'static, str>> },
     /// Component-wide rustdoc lifted from the `#[actor]` impl block.
     Component { doc: Cow<'static, str> },
+    /// ADR-0090 (issue 1257): the component's declared boot-config kind.
+    /// `id` is the compile-time `<C::Config as Kind>::ID`; `name` is
+    /// `C::Config::NAME`. Emitted by `#[actor]` only when the user
+    /// declared a `type Config` other than the synthesized `()` — the
+    /// reader lifts it into `ComponentCapabilities.config`.
+    Config { id: KindId, name: Cow<'static, str> },
 }
 
 /// Custom-section name for the inputs manifest (ADR-0033). Paired
@@ -829,5 +835,9 @@ pub const INPUTS_SECTION: &str = "aether.kinds.inputs";
 
 /// Version byte prefixing every record in the `aether.kinds.inputs`
 /// section. Follows ADR-0028's per-record versioning convention —
-/// unknown versions abort the read rather than silently skip.
-pub const INPUTS_SECTION_VERSION: u8 = 0x01;
+/// unknown versions abort the read rather than silently skip. v0x02
+/// (ADR-0090 / issue 1257) added the `InputsRecord::Config` variant; a
+/// substrate that understands config delivery and a component built
+/// before it would otherwise silently disagree on the config seam, so
+/// the reader rejects v0x01 loudly — a hard rebuild boundary.
+pub const INPUTS_SECTION_VERSION: u8 = 0x02;

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1043,6 +1043,15 @@ mod control_plane {
     pub struct LoadComponent {
         pub wasm: Vec<u8>,
         pub name: Option<String>,
+        /// ADR-0090 (issue 1257): optional init-config bytes handed to
+        /// the guest's typed `FfiActor::init` at instantiate-time. An
+        /// empty vec means "no config" — the c1 ABI short-circuits it
+        /// to `&[]`, which a `Config = ()` guest decodes uniformly via
+        /// `impl Kind for ()`. The carrier is raw bytes, not a typed
+        /// kind, so the substrate stays byte-transparent: the hub /
+        /// MCP encode the config struct to bytes at the edge
+        /// (SDK-typed, not wire-typed), matching `wasm`'s `Vec<u8>`.
+        pub config: Vec<u8>,
     }
 
     /// Reply to `LoadComponent`. `Ok` carries the assigned mailbox id,
@@ -1078,6 +1087,15 @@ mod control_plane {
         pub handlers: Vec<HandlerCapability>,
         pub fallback: Option<FallbackCapability>,
         pub doc: Option<String>,
+        /// ADR-0090 (issue 1257): the kind the component expects as its
+        /// boot config, when it declared a `type Config` other than the
+        /// synthesized `()`. `None` for a no-config component. The
+        /// capability carries the config kind's id + name; its full
+        /// schema is reachable through the engine registry /
+        /// `describe_kinds` because the `#[actor]` macro emits a
+        /// retention static for the config kind on load, exactly as for
+        /// handler kinds.
+        pub config: Option<ConfigCapability>,
     }
 
     /// One `#[handler]` method's advertised capability. `id` is the
@@ -1098,6 +1116,19 @@ mod control_plane {
     #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
     pub struct FallbackCapability {
         pub doc: Option<String>,
+    }
+
+    /// ADR-0090 (issue 1257) the component's declared boot-config kind.
+    /// `id` is the compile-time `<C::Config as Kind>::ID`; `name` is
+    /// `C::Config::NAME`. Present only when the component declared a
+    /// `type Config` other than the synthesized `()` — a no-config
+    /// component leaves `ComponentCapabilities.config` `None`. The
+    /// kind's full schema rides the `aether.kinds` section (the macro's
+    /// retention static), so `describe_kinds` resolves it by id.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    pub struct ConfigCapability {
+        pub id: aether_data::KindId,
+        pub name: String,
     }
 
     /// `aether.component.drop` — remove a component from the
@@ -1131,6 +1162,11 @@ mod control_plane {
         pub mailbox_id: aether_data::MailboxId,
         pub wasm: Vec<u8>,
         pub drain_timeout_ms: Option<u32>,
+        /// ADR-0090 (issue 1257): optional init-config bytes for the
+        /// replacement instance, threaded through to its typed `init`
+        /// the same way [`LoadComponent::config`] is on first load. An
+        /// empty vec means "no config".
+        pub config: Vec<u8>,
     }
 
     /// Reply to `ReplaceComponent`. Carries the new component's
@@ -3307,6 +3343,45 @@ mod tests {
                     .expect("test setup: postcard decodes HttpMethod variant");
                 assert_eq!(back, m);
             }
+        }
+    }
+
+    mod control_plane_roundtrips {
+        use super::*;
+        use alloc::string::ToString;
+        use alloc::vec;
+
+        #[test]
+        fn load_component_roundtrips_config_bytes() {
+            // ADR-0090 c2: the optional init-config carrier must survive
+            // the postcard wire path intact so the substrate hands the
+            // exact bytes to the guest's typed `init`.
+            let load = LoadComponent {
+                wasm: vec![0x00, 0x61, 0x73, 0x6d],
+                name: Some("probe_with_config".to_string()),
+                config: vec![0xde, 0xad, 0xbe, 0xef],
+            };
+            let bytes = load.encode_into_bytes();
+            let back =
+                LoadComponent::decode_from_bytes(&bytes).expect("decode LoadComponent round-trip");
+            assert_eq!(back.config, vec![0xde, 0xad, 0xbe, 0xef]);
+            assert_eq!(back.wasm, vec![0x00, 0x61, 0x73, 0x6d]);
+            assert_eq!(back.name.as_deref(), Some("probe_with_config"));
+        }
+
+        #[test]
+        fn replace_component_roundtrips_config_bytes() {
+            let replace = ReplaceComponent {
+                mailbox_id: aether_data::MailboxId(7),
+                wasm: vec![0x00, 0x61, 0x73, 0x6d],
+                drain_timeout_ms: Some(2500),
+                config: vec![0x01, 0x02, 0x03],
+            };
+            let bytes = replace.encode_into_bytes();
+            let back = ReplaceComponent::decode_from_bytes(&bytes)
+                .expect("decode ReplaceComponent round-trip");
+            assert_eq!(back.config, vec![0x01, 0x02, 0x03]);
+            assert_eq!(back.mailbox_id, aether_data::MailboxId(7));
         }
     }
 }

--- a/crates/aether-mcp/src/args.rs
+++ b/crates/aether-mcp/src/args.rs
@@ -132,6 +132,14 @@ pub struct LoadComponentArgs {
     /// the wasm if omitted; the reply echoes the resolved name.
     #[serde(default)]
     pub name: Option<String>,
+    /// ADR-0090 (issue 1257): optional absolute path to a file holding
+    /// the component's init-config bytes (already encoded to the
+    /// component's `Config` kind wire shape). `aether-mcp` reads the
+    /// file and forwards the bytes on the load mail — paths, not inline
+    /// bytes, per the MCP convention. Omit for a no-config component;
+    /// `describe_component` reports the expected config kind.
+    #[serde(default)]
+    pub config_path: Option<String>,
 }
 
 /// `replace_component` arguments.
@@ -148,6 +156,12 @@ pub struct ReplaceComponentArgs {
     /// substrate (post-ADR-0038 the splice is structural).
     #[serde(default)]
     pub drain_timeout_ms: Option<u32>,
+    /// ADR-0090 (issue 1257): optional absolute path to a file holding
+    /// the replacement instance's init-config bytes, threaded to its
+    /// typed `init` the same way [`LoadComponentArgs::config_path`] is
+    /// on first load.
+    #[serde(default)]
+    pub config_path: Option<String>,
 }
 
 /// `describe_component` arguments.

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -451,7 +451,7 @@ impl Mcp {
     }
 
     #[tool(
-        description = "Load a WASM component into a substrate by filesystem path. aether-mcp reads the binary, forwards it as aether.component.load to the engine's aether.component mailbox, and awaits the LoadResult — returning {mailbox_id, name, capabilities} or an error. The path must exist as given (no ~ expansion, no relative resolution). The component's kind vocabulary rides in the wasm's aether.kinds custom section. Very large wasm payloads (typically target/wasm32-unknown-unknown/debug/*.wasm, which can run 15-25 MiB) may exceed the RPC framing cap — prefer release builds, or raise the cap via the AETHER_MAX_FRAME_SIZE env var (default 64 MiB, clamped at 1 GiB; issue 1271)."
+        description = "Load a WASM component into a substrate by filesystem path. aether-mcp reads the binary, forwards it as aether.component.load to the engine's aether.component mailbox, and awaits the LoadResult — returning {mailbox_id, name, capabilities} or an error. The path must exist as given (no ~ expansion, no relative resolution). The component's kind vocabulary rides in the wasm's aether.kinds custom section. Pass config_path to deliver init-config bytes to a typed-config component (ADR-0090): the file must already hold the component's Config kind wire bytes — describe_component reports the expected config kind. Very large wasm payloads (typically target/wasm32-unknown-unknown/debug/*.wasm, which can run 15-25 MiB) may exceed the RPC framing cap — prefer release builds, or raise the cap via the AETHER_MAX_FRAME_SIZE env var (default 64 MiB, clamped at 1 GiB; issue 1271)."
     )]
     pub async fn load_component(
         &self,
@@ -465,6 +465,16 @@ impl Mcp {
             )
         })?;
         let binary_path = args.binary_path.clone();
+        // ADR-0090 (issue 1257): read optional init-config bytes from a
+        // file path (already encoded to the component's `Config` kind
+        // wire shape). Absent → empty vec → the substrate hands `&[]` to
+        // a `Config = ()` guest's `init`.
+        let config = match args.config_path {
+            Some(ref path) => fs::read(path).await.map_err(|e| {
+                McpError::invalid_params(format!("reading config_path {path:?}: {e}"), None)
+            })?,
+            None => Vec::new(),
+        };
         let reply = self
             .session
             .call_one(engine_envelope(
@@ -473,6 +483,7 @@ impl Mcp {
                 &LoadComponent {
                     wasm,
                     name: args.name,
+                    config,
                 },
             ))
             .await
@@ -514,6 +525,14 @@ impl Mcp {
             )
         })?;
         let binary_path = args.binary_path.clone();
+        // ADR-0090 (issue 1257): optional init-config bytes for the
+        // replacement instance, read from a file path like the load path.
+        let config = match args.config_path {
+            Some(ref path) => fs::read(path).await.map_err(|e| {
+                McpError::invalid_params(format!("reading config_path {path:?}: {e}"), None)
+            })?,
+            None => Vec::new(),
+        };
         let reply = self
             .session
             .call_one(engine_envelope(
@@ -523,6 +542,7 @@ impl Mcp {
                     mailbox_id,
                     wasm,
                     drain_timeout_ms: args.drain_timeout_ms,
+                    config,
                 },
             ))
             .await
@@ -613,7 +633,7 @@ impl Mcp {
     }
 
     #[tool(
-        description = "Describe a loaded component's receive-side capabilities (ADR-0033): the kinds it typed-handles with per-handler docs, whether it has a fallback catchall, and its top-level doc. Reads aether-mcp's component cache, populated by load_component / replace_component — describing a component aether-mcp didn't load (or after an aether-mcp restart) returns an error."
+        description = "Describe a loaded component's receive-side capabilities (ADR-0033): the kinds it typed-handles with per-handler docs, whether it has a fallback catchall, its top-level doc, and (ADR-0090) its boot-config kind id+name when it declared a typed Config. Reads aether-mcp's component cache, populated by load_component / replace_component — describing a component aether-mcp didn't load (or after an aether-mcp restart) returns an error."
     )]
     pub async fn describe_component(
         &self,
@@ -1985,6 +2005,7 @@ mod tests {
                 engine_id: "00000000-0000-0000-0000-000000000001".to_owned(),
                 binary_path: "/nonexistent/does-not-exist.wasm".to_owned(),
                 name: None,
+                config_path: None,
             }))
             .await;
         assert!(result.is_err(), "a missing binary should be a tool error");
@@ -2002,6 +2023,7 @@ mod tests {
                 mailbox_id: "not-a-tagged-id".to_owned(),
                 binary_path: "/tmp/whatever.wasm".to_owned(),
                 drain_timeout_ms: None,
+                config_path: None,
             }))
             .await;
         assert!(

--- a/crates/aether-mesh-viewer/tests/scenario.rs
+++ b/crates/aether-mesh-viewer/tests/scenario.rs
@@ -80,6 +80,7 @@ fn load_viewer(bench: &mut TestBench, wasm_path: &Path) {
                 &LoadComponent {
                     wasm,
                     name: Some(COMPONENT_NAME.to_owned()),
+                    config: Vec::new(),
                 },
             ),
         )])

--- a/crates/aether-substrate-bundle/tests/cap_registry.rs
+++ b/crates/aether-substrate-bundle/tests/cap_registry.rs
@@ -51,6 +51,7 @@ fn load_named(bench: &mut TestBench, wasm_path: &Path, name: &str) -> MailboxId 
                 &LoadComponent {
                     wasm,
                     name: Some(name.to_owned()),
+                    config: Vec::new(),
                 },
             ),
         )])
@@ -160,6 +161,7 @@ fn cap_registry_updates_on_replace() {
                     mailbox_id: mbox,
                     wasm: camera_wasm,
                     drain_timeout_ms: None,
+                    config: Vec::new(),
                 },
             ),
         )])

--- a/crates/aether-substrate-bundle/tests/cost_table.rs
+++ b/crates/aether-substrate-bundle/tests/cost_table.rs
@@ -40,6 +40,7 @@ fn load_probe(bench: &mut TestBench, wasm_path: &Path) -> MailboxId {
                 &LoadComponent {
                     wasm,
                     name: Some("cost-probe".to_owned()),
+                    config: Vec::new(),
                 },
             ),
         )])

--- a/crates/aether-substrate-bundle/tests/end_to_end.rs
+++ b/crates/aether-substrate-bundle/tests/end_to_end.rs
@@ -37,6 +37,7 @@ fn load_probe(bench: &mut TestBench, wasm_path: &Path) -> MailboxId {
                 &LoadComponent {
                     wasm,
                     name: Some(PROBE_NAME.to_owned()),
+                    config: Vec::new(),
                 },
             ),
         )])

--- a/crates/aether-substrate-bundle/tests/input_subscriptions.rs
+++ b/crates/aether-substrate-bundle/tests/input_subscriptions.rs
@@ -30,6 +30,7 @@ fn load_probe_named(bench: &mut TestBench, wasm_path: &Path, name: &str) -> Mail
                 &LoadComponent {
                     wasm,
                     name: Some(name.to_owned()),
+                    config: Vec::new(),
                 },
             ),
         )])

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -100,6 +100,7 @@ fn load_probe(bench: &mut TestBench, wasm_path: &Path) -> MailboxId {
                 &LoadComponent {
                     wasm,
                     name: Some(PROBE_NAME.to_owned()),
+                    config: Vec::new(),
                 },
             ),
         )])
@@ -312,6 +313,7 @@ fn replace_component_preserves_mailbox_identity() {
                     mailbox_id: probe_mbox,
                     wasm,
                     drain_timeout_ms: None,
+                    config: Vec::new(),
                 },
             ),
         )])

--- a/crates/aether-substrate-bundle/tests/typed_config.rs
+++ b/crates/aether-substrate-bundle/tests/typed_config.rs
@@ -9,9 +9,10 @@
 //! still passes `&[]` MUST fail loudly with a decode error, not load
 //! silently with garbage state.
 //!
-//! Once c2 lands and the load mail carries `config_bytes`, the
-//! companion positive test (currently skipped under
-//! `AETHER_CONFIG_C2`) flips on.
+//! c2 (issue 1257) lands the delivery seam: the load mail now carries
+//! `config` bytes threaded through `Component::instantiate`, so the
+//! companion positive test (`..._with_config_bytes_round_trips`) runs
+//! unconditionally — the parked `AETHER_CONFIG_C2` gate is retired.
 
 #![allow(clippy::print_stderr)]
 
@@ -19,8 +20,10 @@ use std::path::Path;
 
 use aether_actor::Actor;
 use aether_capabilities::ComponentHostCapability;
+use aether_data::Kind;
 use aether_kinds::{LoadComponent, LoadResult};
 use aether_substrate_bundle::test_bench::{BenchOp, TestBench, test_helpers::require_runtime};
+use aether_test_fixtures::{ConfigEcho, ConfigQuery, ProbeConfig};
 use std::fs;
 
 // Pin the fixture rlib so its `inventory::submit!` `KindDescriptor`
@@ -50,6 +53,7 @@ fn typed_config_guest_without_config_bytes_surfaces_decode_error() {
                 &LoadComponent {
                     wasm,
                     name: Some("probe_with_config".to_owned()),
+                    config: Vec::new(),
                 },
             ),
         )])
@@ -69,4 +73,80 @@ fn typed_config_guest_without_config_bytes_surfaces_decode_error() {
             panic!("typed-config guest loaded with no config bytes; expected a decode-error path")
         }
     }
+}
+
+/// ADR-0090 c2 (issue 1257) positive path: load the typed-config
+/// fixture WITH real `ProbeConfig` bytes on the load mail, then query
+/// it — the `ConfigEcho` reply must echo the exact `(seed, label)` the
+/// guest decoded at `init`. This proves the full c2 delivery seam: the
+/// load mail's `config` bytes reach `Component::instantiate`, the c1
+/// ABI writes them into the guest's linear memory, and `init_v2_p32`
+/// decodes them into `Probe::init(config, ctx)`.
+///
+/// c1 parked this behind `AETHER_CONFIG_C2` because the delivery seam
+/// hardcoded `&[]`; c2 wires it, so the test runs unconditionally now.
+#[test]
+fn typed_config_guest_with_config_bytes_round_trips() {
+    let Some(wasm_path) = require_runtime("probe_with_config") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let wasm = fs::read::<&Path>(wasm_path.as_ref()).expect("read fixture wasm");
+
+    let config = ProbeConfig {
+        seed: 0xABCD_1234,
+        label: "c2-round-trip".to_owned(),
+    };
+    let config_bytes = config.encode_into_bytes();
+
+    let report = bench
+        .execute(vec![
+            (
+                "load",
+                BenchOp::send_and_await(
+                    ComponentHostCapability::NAMESPACE,
+                    &LoadComponent {
+                        wasm,
+                        name: Some("probe_with_config".to_owned()),
+                        config: config_bytes,
+                    },
+                ),
+            ),
+            (
+                "echo",
+                BenchOp::send_and_await(
+                    format!(
+                        "{}:probe_with_config",
+                        aether_capabilities::WasmTrampoline::NAMESPACE
+                    ),
+                    &ConfigQuery,
+                ),
+            ),
+        ])
+        .expect("load + query sequence");
+
+    match report
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Ok { capabilities, .. } => {
+            let cfg = capabilities
+                .config
+                .expect("typed-config component advertises its config kind");
+            assert_eq!(cfg.id, <ProbeConfig as Kind>::ID);
+            assert_eq!(cfg.name, <ProbeConfig as Kind>::NAME);
+        }
+        LoadResult::Err { error } => {
+            panic!("typed-config guest with config bytes failed to load: {error}")
+        }
+    }
+
+    let echo = report
+        .reply::<ConfigEcho>("echo")
+        .expect("decode ConfigEcho");
+    assert_eq!(echo.seed, 0xABCD_1234, "seed round-trips through init");
+    assert_eq!(
+        echo.label, "c2-round-trip",
+        "label round-trips through init"
+    );
 }

--- a/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
+++ b/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
@@ -48,7 +48,9 @@ use aether_data::{
     KindShape, LabelNode, NamedField, SchemaCell, SchemaShape, SchemaType, VariantLabel,
     canonical::kind_id_from_shape,
 };
-use aether_kinds::{ComponentCapabilities, FallbackCapability, HandlerCapability};
+use aether_kinds::{
+    ComponentCapabilities, ConfigCapability, FallbackCapability, HandlerCapability,
+};
 use serde::de::DeserializeOwned;
 use std::str;
 use wasmparser::{Parser, Payload};
@@ -195,13 +197,14 @@ pub fn read_namespace_from_bytes(wasm: &[u8]) -> Result<Option<String>, String> 
 /// produceable after phase 3 retired the `type Kinds` / `fn receive`
 /// surface.
 ///
-/// Record shape: `[0x01][postcard(InputsRecord)]` back-to-back. The
+/// Record shape: `[0x02][postcard(InputsRecord)]` back-to-back. The
 /// classifier walks the records in declaration order: every Handler
-/// enters `handlers`, at most one Fallback populates `fallback`, and
-/// at most one Component populates `doc`. Duplicate Fallback /
-/// Component records are a substrate-rejected load error — the macro
-/// emits at most one of each so seeing two means the component
-/// binary was built against a different manifest contract.
+/// enters `handlers`, at most one Fallback populates `fallback`, at
+/// most one Component populates `doc`, and at most one Config
+/// populates `config` (ADR-0090 / issue 1257). Duplicate Fallback /
+/// Component / Config records are a substrate-rejected load error —
+/// the macro emits at most one of each so seeing two means the
+/// component binary was built against a different manifest contract.
 pub fn read_inputs_from_bytes(wasm: &[u8]) -> Result<ComponentCapabilities, String> {
     let mut records: Vec<InputsRecord> = Vec::new();
 
@@ -243,6 +246,17 @@ pub fn read_inputs_from_bytes(wasm: &[u8]) -> Result<ComponentCapabilities, Stri
                     ));
                 }
                 caps.doc = Some(doc.into_owned());
+            }
+            InputsRecord::Config { id, name } => {
+                if caps.config.is_some() {
+                    return Err(format!(
+                        "{INPUTS_SECTION}: duplicate Config record — macro emits at most one"
+                    ));
+                }
+                caps.config = Some(ConfigCapability {
+                    id,
+                    name: name.into_owned(),
+                });
             }
         }
     }
@@ -955,6 +969,58 @@ mod tests {
         assert_eq!(caps.handlers[1].name, "aether.ping");
         assert!(caps.handlers[1].doc.is_none());
         assert!(caps.fallback.is_none());
+    }
+
+    #[test]
+    fn reads_config_record() {
+        // ADR-0090 (issue 1257): a `Config` record lifts into
+        // `caps.config` carrying the config kind's id + name.
+        let section = inputs_section(&[
+            InputsRecord::Handler {
+                id: aether_data::KindId(7),
+                name: "aether.config_query".into(),
+                doc: None,
+            },
+            InputsRecord::Config {
+                id: aether_data::KindId(0x00c0_ffee),
+                name: "aether.test_fixtures.probe_config".into(),
+            },
+        ]);
+        let wasm = wasm_with_section(INPUTS_SECTION, &section);
+        let caps = read_inputs_from_bytes(&wasm).unwrap();
+        assert_eq!(caps.handlers.len(), 1);
+        let config = caps.config.expect("config capability present");
+        assert_eq!(config.id, aether_data::KindId(0x00c0_ffee));
+        assert_eq!(config.name, "aether.test_fixtures.probe_config");
+    }
+
+    #[test]
+    fn duplicate_config_is_rejected() {
+        let section = inputs_section(&[
+            InputsRecord::Config {
+                id: aether_data::KindId(1),
+                name: "a".into(),
+            },
+            InputsRecord::Config {
+                id: aether_data::KindId(2),
+                name: "b".into(),
+            },
+        ]);
+        let wasm = wasm_with_section(INPUTS_SECTION, &section);
+        let err = read_inputs_from_bytes(&wasm).unwrap_err();
+        assert!(err.contains("duplicate Config"), "err: {err}");
+    }
+
+    #[test]
+    fn absent_config_is_none() {
+        let section = inputs_section(&[InputsRecord::Handler {
+            id: aether_data::KindId(7),
+            name: "aether.tick".into(),
+            doc: None,
+        }]);
+        let wasm = wasm_with_section(INPUTS_SECTION, &section);
+        let caps = read_inputs_from_bytes(&wasm).unwrap();
+        assert!(caps.config.is_none());
     }
 
     #[test]

--- a/crates/aether-substrate/src/mail/capability.rs
+++ b/crates/aether-substrate/src/mail/capability.rs
@@ -154,6 +154,7 @@ mod tests {
                 .collect(),
             fallback: fallback.then_some(FallbackCapability { doc: None }),
             doc: None,
+            config: None,
         }
     }
 

--- a/crates/aether-substrate/tests/dag_validator.rs
+++ b/crates/aether-substrate/tests/dag_validator.rs
@@ -102,6 +102,7 @@ fn register_caps_with_fallback(
             .collect(),
         fallback: fallback.then_some(aether_kinds::FallbackCapability { doc: None }),
         doc: None,
+        config: None,
     };
     caps.register(
         mailbox,

--- a/demos/sokoban/tests/scenario.rs
+++ b/demos/sokoban/tests/scenario.rs
@@ -65,6 +65,7 @@ fn load_sokoban(bench: &mut TestBench, wasm_path: &Path) {
                 &LoadComponent {
                     wasm,
                     name: Some(COMPONENT_NAME.to_owned()),
+                    config: Vec::new(),
                 },
             ),
         )])


### PR DESCRIPTION
Closes iamacoffeepot/aether#1257.

## Summary

Unit c2 of ADR-0090. c1 landed `FfiActor::Config` + the guest `init_v2` ABI but left the supply side stubbed (`&[]` with a "c2 wires this" TODO). This wires it:

- Threads an optional `config: Vec<u8>` carrier through `LoadComponent`/`ReplaceComponent` → `WasmTrampolineConfig` → `Component::instantiate` (both the init and replace paths), keeping the substrate byte-transparent.
- Surfaces the config kind via a new `InputsRecord::Config { id, name }` variant in the `aether.kinds.inputs` manifest (section version `0x01`→`0x02`), emitted by `#[actor]` only when the guest declares `type Config` (compile-time gate, so `aether.unit` does not leak into every component).
- The manifest reader classifies the record into `ComponentCapabilities.config`, which `describe_component` already returns from cache — so config-kind discovery comes for free.
- `load_component`/`replace_component` MCP tools accept an optional `config_path` (read to bytes, wired onto the mail).

The manifest version bump is a hard rebuild boundary, so wire + format + macro + reader land together as one atomic change (no broken intermediate state).

## Test plan

- `aether-kinds`: `LoadComponent`/`ReplaceComponent`/`ComponentCapabilities` round-trip tests with the new fields.
- `aether-data`: const-eval round-trip test for the `Config` inputs record (tag 3) + version `0x02`.
- `aether-substrate` `kind_manifest`: reader tests — reads a config record, rejects duplicates, handles absent.
- New end-to-end test `typed_config_guest_with_config_bytes_round_trips`: loads `probe_with_config` with real `ProbeConfig` bytes, asserts `LoadResult.capabilities.config` is populated with the right kind id/name, and that the guest's typed `init` round-trips seed+label via a `ConfigEcho` reply. The previously-parked positive test is now unconditional (the `AETHER_CONFIG_C2` env gate is retired); the existing negative (`Config = ()`) test still passes.
- Full local preflight green: fmt + clippy (`-D warnings`) + doc + nextest (1444 passed) + wasm32 component cross-build.

## Generated by

`/implement` — agent execution of scoped issue 1257 (stop-after-commit; PR opened from the main session).
