### PR TITLE
feat(substrate): warn on unknown AETHER_ env and hard-error unparseable known keys

### DIFF
--- a/crates/aether-capabilities/src/anthropic/mod.rs
+++ b/crates/aether-capabilities/src/anthropic/mod.rs
@@ -130,7 +130,7 @@ mod config {
     // confique consumes these through `#[config(parse_env = …)]`; IntelliJ-Rust
     // doesn't trace macro-attr path args (Qodana FP), but rustc + clippy do.
     #[allow(unused_imports)]
-    use crate::config_env::{parse_flag, parse_provider_max_in_flight, parse_u32_ms_or};
+    use crate::config_env::{parse_flag, parse_millis_strict, parse_provider_max_in_flight_strict};
     use std::time::Duration;
 
     /// Resolved configuration for the `aether.anthropic` cap. Chassis
@@ -174,7 +174,7 @@ mod config {
         /// Per-cap concurrency bound (doubles as rate-limit throttling).
         #[cfg_attr(
             feature = "native",
-            config(default = 2, parse = parse_provider_max_in_flight)
+            config(default = 2, parse = parse_provider_max_in_flight_strict)
         )]
         pub max_in_flight: usize,
         /// Per-request timeout for the Messages API. The derive's
@@ -185,7 +185,7 @@ mod config {
             feature = "native",
             config(
                 default = 120_000,
-                parse = parse_u32_ms_or::<DEFAULT_TIMEOUT_MS>,
+                parse = parse_millis_strict::<DEFAULT_TIMEOUT_MS>,
                 ms_duration,
                 layer_field = "timeout_ms"
             )

--- a/crates/aether-capabilities/src/config_env.rs
+++ b/crates/aether-capabilities/src/config_env.rs
@@ -3,12 +3,17 @@
 //! migration doesn't carry its own copy of the identical bool /
 //! `> 0`-filtered concurrency parsers (Qodana `DuplicatedCode`).
 //!
-//! Every helper is total — `Result<T, Infallible>` because confique's
-//! `parse_env` contract mandates the wrapper, even when the parse
-//! cannot fail. The strict (erroring) variants land with the
-//! ADR-0090 §4 validation pass (e1).
+//! Two parser families live here. [`parse_flag`] is total —
+//! `Result<bool, Infallible>` — because a bool reader can't fail (any
+//! non-truthy string is `false`). The **strict** (erroring) numeric
+//! variants are the ADR-0090 §4 hard-error half (unit e1): a malformed
+//! *known* env value returns `Err`, which confique surfaces from
+//! `.load()` and the chassis env resolver converts into a
+//! `ConfigError`. An empty value is treated as unset (falls back to
+//! the default) — only a non-empty unparseable value aborts boot.
 
 use std::convert::Infallible;
+use std::num::ParseIntError;
 
 /// Default per-cap concurrency bound shared by the content-gen
 /// providers (`aether.gemini`, `aether.anthropic`) when their
@@ -24,35 +29,51 @@ pub fn parse_flag(s: &str) -> Result<bool, Infallible> {
     Ok(s == "1" || s.eq_ignore_ascii_case("true"))
 }
 
-/// Provider concurrency bound: positive integer, otherwise fall back
-/// to [`DEFAULT_PROVIDER_MAX_IN_FLIGHT`]. The `> 0` filter rejects
-/// `AETHER_*_MAX_IN_FLIGHT=0` (which would otherwise deadlock the cap
-/// by allowing no in-flight requests). Soft-fall-back today;
-/// ADR-0090 §4's hard-error lands in e1.
-#[allow(clippy::unnecessary_wraps)]
-pub fn parse_provider_max_in_flight(s: &str) -> Result<usize, Infallible> {
-    Ok(s.parse::<usize>()
-        .ok()
-        .filter(|&n| n > 0)
-        .unwrap_or(DEFAULT_PROVIDER_MAX_IN_FLIGHT))
+/// Strict ms parser (ADR-0090 §4 hard-error half): a non-empty value
+/// that doesn't parse as `u32` returns `Err`, which confique surfaces
+/// from `.load()` and the chassis env resolver converts into a
+/// `ConfigError`. An *empty* string is treated as unset and falls back
+/// to `DEFAULT_MILLIS` (an env var set to `""` is not a typo to abort on).
+///
+/// # Errors
+///
+/// Returns the underlying [`ParseIntError`] when a non-empty value is
+/// not a valid `u32`.
+pub fn parse_millis_strict<const DEFAULT_MILLIS: u32>(s: &str) -> Result<u32, ParseIntError> {
+    if s.trim().is_empty() {
+        return Ok(DEFAULT_MILLIS);
+    }
+    s.trim().parse()
 }
 
-/// Generic ms-soft-parse: positive `u32` from the env string, fall back
-/// to `DEFAULT_MS` (the per-cap default literal) on parse failure. Each
-/// caller instantiates with its own turbofish (e.g.
-/// `parse_env = parse_u32_ms_or::<DEFAULT_GEMINI_TIMEOUT_MS>`), so the
-/// expanded bodies are textually distinct — what Qodana's
-/// `DuplicatedCode` looks for. Soft-fall-back today; ADR-0090 §4's
-/// hard-error lands in e1.
-#[allow(clippy::unnecessary_wraps)]
-pub fn parse_u32_ms_or<const DEFAULT_MS: u32>(s: &str) -> Result<u32, Infallible> {
-    Ok(s.parse().unwrap_or(DEFAULT_MS))
+/// Strict provider concurrency bound (ADR-0090 §4 hard-error half).
+/// Empty → [`DEFAULT_PROVIDER_MAX_IN_FLIGHT`] (unset); a non-empty
+/// value that doesn't parse as `usize` errors; a parsed `0` clamps up
+/// to the default (a zero-concurrency provider deadlocks, so it is
+/// treated as "use the default", not a hard error — matching the soft
+/// variant's `> 0` filter).
+///
+/// # Errors
+///
+/// Returns the underlying [`ParseIntError`] when a non-empty value is
+/// not a valid `usize`.
+pub fn parse_provider_max_in_flight_strict(s: &str) -> Result<usize, ParseIntError> {
+    if s.trim().is_empty() {
+        return Ok(DEFAULT_PROVIDER_MAX_IN_FLIGHT);
+    }
+    let n: usize = s.trim().parse()?;
+    Ok(if n > 0 {
+        n
+    } else {
+        DEFAULT_PROVIDER_MAX_IN_FLIGHT
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        DEFAULT_PROVIDER_MAX_IN_FLIGHT, parse_flag, parse_provider_max_in_flight, parse_u32_ms_or,
+        DEFAULT_PROVIDER_MAX_IN_FLIGHT, parse_flag, parse_millis_strict,
+        parse_provider_max_in_flight_strict,
     };
 
     #[test]
@@ -66,29 +87,29 @@ mod tests {
     }
 
     #[test]
-    fn parse_provider_max_in_flight_filters_non_positive_and_unparseable() {
-        assert_eq!(parse_provider_max_in_flight("4").unwrap(), 4);
+    fn parse_provider_max_in_flight_strict_errors_on_garbage() {
+        // ADR-0090 §4: a parseable value passes; `0` clamps to the
+        // default (zero-concurrency deadlocks); empty is unset; a
+        // non-empty non-number errors rather than silently defaulting.
+        assert_eq!(parse_provider_max_in_flight_strict("4"), Ok(4));
         assert_eq!(
-            parse_provider_max_in_flight("0").unwrap(),
-            DEFAULT_PROVIDER_MAX_IN_FLIGHT
+            parse_provider_max_in_flight_strict("0"),
+            Ok(DEFAULT_PROVIDER_MAX_IN_FLIGHT)
         );
         assert_eq!(
-            parse_provider_max_in_flight("garbage").unwrap(),
-            DEFAULT_PROVIDER_MAX_IN_FLIGHT
+            parse_provider_max_in_flight_strict(""),
+            Ok(DEFAULT_PROVIDER_MAX_IN_FLIGHT)
         );
-        assert_eq!(
-            parse_provider_max_in_flight("").unwrap(),
-            DEFAULT_PROVIDER_MAX_IN_FLIGHT
-        );
+        assert!(parse_provider_max_in_flight_strict("garbage").is_err());
     }
 
     #[test]
-    fn parse_u32_ms_or_soft_falls_back_to_const_generic() {
-        assert_eq!(parse_u32_ms_or::<30_000>("5000").unwrap(), 5000);
-        assert_eq!(parse_u32_ms_or::<30_000>("garbage").unwrap(), 30_000);
-        assert_eq!(parse_u32_ms_or::<30_000>("").unwrap(), 30_000);
-        // Different turbofish → different defaults — what makes the
-        // per-cap call sites textually distinct under DuplicatedCode.
-        assert_eq!(parse_u32_ms_or::<120_000>("garbage").unwrap(), 120_000);
+    fn parse_millis_strict_errors_on_garbage() {
+        assert_eq!(parse_millis_strict::<30_000>("5000"), Ok(5000));
+        assert_eq!(parse_millis_strict::<30_000>(""), Ok(30_000));
+        assert!(parse_millis_strict::<30_000>("garbage").is_err());
+        // Different turbofish → different defaults (the unset path),
+        // keeping the per-cap call sites textually distinct.
+        assert_eq!(parse_millis_strict::<120_000>(""), Ok(120_000));
     }
 }

--- a/crates/aether-capabilities/src/gemini/mod.rs
+++ b/crates/aether-capabilities/src/gemini/mod.rs
@@ -64,7 +64,7 @@ mod config {
     // confique consumes these through `#[config(parse_env = …)]`; IntelliJ-Rust
     // doesn't trace macro-attr path args (Qodana FP), but rustc + clippy do.
     #[allow(unused_imports)]
-    use crate::config_env::{parse_flag, parse_provider_max_in_flight, parse_u32_ms_or};
+    use crate::config_env::{parse_flag, parse_millis_strict, parse_provider_max_in_flight_strict};
     use std::time::Duration;
 
     /// Resolved configuration for the `aether.gemini` cap. Chassis mains
@@ -107,7 +107,7 @@ mod config {
         /// Per-cap concurrency bound (doubles as rate-limit throttling).
         #[cfg_attr(
             feature = "native",
-            config(default = 2, parse = parse_provider_max_in_flight)
+            config(default = 2, parse = parse_provider_max_in_flight_strict)
         )]
         pub max_in_flight: usize,
         /// Per-request timeout for the media APIs. The derive's
@@ -118,7 +118,7 @@ mod config {
             feature = "native",
             config(
                 default = 180_000,
-                parse = parse_u32_ms_or::<DEFAULT_TIMEOUT_MS>,
+                parse = parse_millis_strict::<DEFAULT_TIMEOUT_MS>,
                 ms_duration,
                 layer_field = "timeout_ms"
             )

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -13,6 +13,8 @@
 //!   `Fetch.timeout_ms`.
 
 use std::collections::HashSet;
+#[cfg(feature = "native")]
+use std::num::ParseIntError;
 use std::time::Duration;
 
 // Handler-signature kinds must be importable at file root because
@@ -182,21 +184,37 @@ fn parse_allowlist(s: &str) -> Result<HashSet<String>, Infallible> {
         .collect())
 }
 
-/// Parse a byte cap; an unparseable value falls back to
-/// [`DEFAULT_MAX_BODY_BYTES`] (the prior soft-fail — ADR-0090 §4's
-/// hard-error lands in the validation pass, not this migration). Total.
+/// Parse a byte cap (ADR-0090 §4 hard-error half): empty → unset,
+/// falling back to [`DEFAULT_MAX_BODY_BYTES`]; a non-empty value that
+/// doesn't parse as `usize` errors, which confique surfaces from
+/// `.load()` and the chassis env resolver turns into a `ConfigError`.
+///
+/// # Errors
+///
+/// Returns a [`ParseIntError`] for a
+/// non-empty value that isn't a valid `usize`.
 #[cfg(feature = "native")]
-#[allow(clippy::unnecessary_wraps)]
-fn parse_max_body_bytes(s: &str) -> Result<usize, Infallible> {
-    Ok(s.parse().unwrap_or(DEFAULT_MAX_BODY_BYTES))
+fn parse_max_body_bytes(s: &str) -> Result<usize, ParseIntError> {
+    if s.trim().is_empty() {
+        return Ok(DEFAULT_MAX_BODY_BYTES);
+    }
+    s.trim().parse()
 }
 
-/// Parse a timeout in milliseconds; unparseable falls back to
-/// [`DEFAULT_TIMEOUT_MS`]. Total — never errors.
+/// Parse a timeout in milliseconds (ADR-0090 §4 hard-error half):
+/// empty → [`DEFAULT_TIMEOUT_MS`]; a non-empty value that doesn't
+/// parse as `u32` errors.
+///
+/// # Errors
+///
+/// Returns a [`ParseIntError`] for a
+/// non-empty value that isn't a valid `u32`.
 #[cfg(feature = "native")]
-#[allow(clippy::unnecessary_wraps)]
-fn parse_timeout_ms(s: &str) -> Result<u32, Infallible> {
-    Ok(s.parse().unwrap_or(DEFAULT_TIMEOUT_MS))
+fn parse_timeout_ms(s: &str) -> Result<u32, ParseIntError> {
+    if s.trim().is_empty() {
+        return Ok(DEFAULT_TIMEOUT_MS);
+    }
+    s.trim().parse()
 }
 
 /// Sender-side facade for actors addressed via
@@ -602,15 +620,18 @@ mod native {
         }
 
         #[test]
-        fn parse_numbers_soft_fall_back_to_defaults() {
+        fn parse_numbers_strict_error_on_garbage() {
+            // ADR-0090 §4 hard-error half: a valid value parses, an
+            // empty value falls back to the default (unset), and a
+            // non-empty garbage value errors rather than silently
+            // defaulting.
             use super::super::{DEFAULT_TIMEOUT_MS, parse_max_body_bytes, parse_timeout_ms};
-            assert_eq!(parse_max_body_bytes("1024").unwrap(), 1024);
-            assert_eq!(
-                parse_max_body_bytes("not-a-number").unwrap(),
-                DEFAULT_MAX_BODY_BYTES
-            );
-            assert_eq!(parse_timeout_ms("5000").unwrap(), 5000);
-            assert_eq!(parse_timeout_ms("garbage").unwrap(), DEFAULT_TIMEOUT_MS);
+            assert_eq!(parse_max_body_bytes("1024"), Ok(1024));
+            assert_eq!(parse_max_body_bytes(""), Ok(DEFAULT_MAX_BODY_BYTES));
+            assert!(parse_max_body_bytes("not-a-number").is_err());
+            assert_eq!(parse_timeout_ms("5000"), Ok(5000));
+            assert_eq!(parse_timeout_ms(""), Ok(DEFAULT_TIMEOUT_MS));
+            assert!(parse_timeout_ms("garbage").is_err());
         }
 
         #[test]

--- a/crates/aether-derive/src/config.rs
+++ b/crates/aether-derive/src/config.rs
@@ -521,20 +521,38 @@ fn emit_inherent_impl(domain_ident: &Ident, layer_ident: &Ident) -> TokenStream2
             ///
             /// # Panics
             ///
-            /// Panics only if the layer's literal defaults are themselves
-            /// malformed — a programmer error caught by the cap's
-            /// `*_defaults_match` test, never a runtime config fault
-            /// (env values flow through total parsers).
+            /// Panics if a known env value fails its parser (ADR-0090
+            /// §4's hard-error half — a garbage known key aborts boot).
+            /// Use [`Self::try_from_env`] to surface that as a
+            /// [`ConfigError`](::aether_substrate::config::ConfigError)
+            /// instead of panicking.
             #[must_use]
             pub fn from_env() -> Self {
+                match Self::try_from_env() {
+                    Ok(this) => this,
+                    Err(e) => panic!("{} config resolution failed: {e}", stringify!(#domain_ident)),
+                }
+            }
+
+            /// Fallible sibling of [`Self::from_env`]: surfaces an
+            /// unparseable known env value as a
+            /// [`ConfigError`](::aether_substrate::config::ConfigError)
+            /// (ADR-0090 §4 — the e1 hard-error half) rather than
+            /// panicking.
+            ///
+            /// # Errors
+            ///
+            /// Returns [`ConfigError::UnparseableKnown`](::aether_substrate::config::ConfigError::UnparseableKnown)
+            /// when a known env key fails the layer's parser.
+            pub fn try_from_env() -> ::core::result::Result<Self, ::aether_substrate::config::ConfigError> {
                 use ::aether_substrate::FromArgvThenEnv as _;
                 use ::confique::Config as _;
 
                 let layer = #layer_ident::builder()
                     .env()
                     .load()
-                    .expect(concat!(stringify!(#layer_ident), " defaults are well-formed"));
-                <Self as ::aether_substrate::FromArgvThenEnv>::from_layer(layer)
+                    .map_err(::aether_substrate::config::ConfigError::from_confique)?;
+                ::core::result::Result::Ok(<Self as ::aether_substrate::FromArgvThenEnv>::from_layer(layer))
             }
 
             /// Resolve with an argv-derived partial layer shadowing
@@ -549,6 +567,19 @@ fn emit_inherent_impl(domain_ident: &Ident, layer_ident: &Ident) -> TokenStream2
                 argv: <#layer_ident as ::confique::Config>::Layer,
             ) -> Self {
                 <Self as ::aether_substrate::FromArgvThenEnv>::from_argv_then_env(argv)
+            }
+
+            /// Fallible argv-then-env resolution (ADR-0090 §4).
+            ///
+            /// # Errors
+            ///
+            /// Returns [`ConfigError::UnparseableKnown`](::aether_substrate::config::ConfigError::UnparseableKnown)
+            /// when a known env key (or argv overlay value) fails the
+            /// layer's parser.
+            pub fn try_from_argv_then_env(
+                argv: <#layer_ident as ::confique::Config>::Layer,
+            ) -> ::core::result::Result<Self, ::aether_substrate::config::ConfigError> {
+                <Self as ::aether_substrate::FromArgvThenEnv>::try_from_argv_then_env(argv)
             }
         }
     }

--- a/crates/aether-substrate-bundle/src/bin/headless.rs
+++ b/crates/aether-substrate-bundle/src/bin/headless.rs
@@ -11,7 +11,7 @@ use clap::Parser as _;
 
 fn main() -> anyhow::Result<()> {
     let cli = HeadlessCli::parse();
-    let env = HeadlessEnv::from_env_with_argv(cli);
+    let env = HeadlessEnv::from_env_with_argv(cli)?;
     let chassis = HeadlessChassis::build(env)?;
     tracing::info!(
         target: "aether_substrate::boot",

--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -15,6 +15,11 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use aether_actor::Actor;
+use aether_capabilities::anthropic::AnthropicConfigLayer;
+use aether_capabilities::audio::AudioConfigLayer;
+use aether_capabilities::fs::NamespaceRootsLayer;
+use aether_capabilities::gemini::GeminiConfigLayer;
+use aether_capabilities::http::HttpConfigLayer;
 use aether_capabilities::rpc::{PeerKind, RpcServerCapability, RpcServerConfig};
 use aether_capabilities::{
     AnthropicCapability, AnthropicConfig, ComponentHostCapability, ComponentHostConfig,
@@ -26,9 +31,90 @@ use aether_data::{Kind, MailboxId as DataMailboxId, mailbox_id_from_name};
 use aether_kinds::{Shutdown, Tick};
 use aether_substrate::chassis::Chassis;
 use aether_substrate::chassis::builder::Builder;
-use aether_substrate::handle_store::PersistConfig;
+use aether_substrate::config::{KnobKind, KnobRecord, KnownKeys, known_keys};
+use aether_substrate::handle_store::{ENV_MAX_BYTES, PersistConfig, PersistConfigLayer};
 use aether_substrate::runtime::lifecycle::FatalAborter;
 use aether_substrate::{LifecycleDriverConfig, LifecycleGraph};
+use confique::Config as _;
+use confique::meta::Meta;
+
+/// Chassis-direct env knobs that aren't `#[derive(Config)]` fields —
+/// the bare-shadowed knobs the chassis bins read inline
+/// (`AETHER_WORKERS`, `AETHER_TICK_HZ`, `AETHER_RPC_PORT`, the desktop
+/// window knobs) plus the handle-store in-memory budget
+/// (`AETHER_HANDLE_STORE_MAX_BYTES`, which `HandleStore::from_env`
+/// parses outside confique). Registered as [`KnobRecord`]s so e1's
+/// unknown-`AETHER_*` sweep doesn't flag them and e2's `--config`
+/// dump lists them. ADR-0090 §1/§4. The scheduler hot-path knobs are
+/// registered separately by unit b2's `SCHEDULER_KNOBS`.
+pub const CHASSIS_KNOBS: &[KnobRecord] = &[
+    KnobRecord {
+        env_key: "AETHER_WORKERS",
+        doc: "Worker-pool size override (unset → available_parallelism()-1, min 1).",
+        default: None,
+        kind: KnobKind::HandRegistered,
+    },
+    KnobRecord {
+        env_key: "AETHER_TICK_HZ",
+        doc: "Headless tick cadence in hertz.",
+        default: Some("60"),
+        kind: KnobKind::HandRegistered,
+    },
+    KnobRecord {
+        env_key: "AETHER_RPC_PORT",
+        doc: "aether.rpc.server bind port (desktop/headless skip the server when unset).",
+        default: None,
+        kind: KnobKind::HandRegistered,
+    },
+    KnobRecord {
+        env_key: "AETHER_WINDOW_MODE",
+        doc: "Desktop window mode: windowed[:WxH] / fullscreen-borderless / exclusive:WxH@HZ.",
+        default: None,
+        kind: KnobKind::HandRegistered,
+    },
+    KnobRecord {
+        env_key: "AETHER_WINDOW_TITLE",
+        doc: "Desktop window title text.",
+        default: None,
+        kind: KnobKind::HandRegistered,
+    },
+    KnobRecord {
+        env_key: ENV_MAX_BYTES,
+        doc: "Handle-store in-memory soft byte budget (parsed outside confique; \
+              unparseable aborts boot per ADR-0090 §4).",
+        default: Some("268435456"),
+        kind: KnobKind::HandRegistered,
+    },
+];
+
+/// Assemble the chassis-wide [`KnownKeys`] set (ADR-0090 §4): every
+/// migrated `*Layer::META` (http / gemini / anthropic / audio / fs /
+/// persist) plus the hand-registered chassis knobs ([`CHASSIS_KNOBS`])
+/// and scheduler hot-path knobs (b2's
+/// `aether_substrate::scheduler::SCHEDULER_KNOBS`). e1's
+/// [`validate_env`](aether_substrate::config::validate_env) sweeps the
+/// process env against this; e2's `--config` dump walks the same
+/// metas + records.
+///
+/// Lives bundle-side rather than in `aether-substrate::config` because
+/// the cap layer types live in `aether-capabilities`, which depends on
+/// `aether-substrate` (not the reverse) — the generic `known_keys`
+/// assembly fn is in `config`; the concrete chassis registry is here.
+#[must_use]
+pub fn chassis_known_keys() -> KnownKeys {
+    let metas: &[&'static Meta] = &[
+        &HttpConfigLayer::META,
+        &GeminiConfigLayer::META,
+        &AnthropicConfigLayer::META,
+        &AudioConfigLayer::META,
+        &NamespaceRootsLayer::META,
+        &PersistConfigLayer::META,
+    ];
+    // b2 (iamacoffeepot/aether#1255) folds in
+    // `aether_substrate::scheduler::SCHEDULER_KNOBS` alongside
+    // `CHASSIS_KNOBS` once that const lands.
+    known_keys(metas, CHASSIS_KNOBS)
+}
 
 /// Chassis-bin verdict on the handle-store persistence config (ADR-0090
 /// unit d, issue 1258). [`EnvOnly`](Self::EnvOnly) keeps the pre-d

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -11,6 +11,8 @@
 //! the loop so a queued `CaptureQueue` request gets pulled on the
 //! next redraw, even when the window is occluded.
 
+use std::error::Error as StdError;
+use std::fmt;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -28,16 +30,62 @@ use winit::event_loop::EventLoop;
 
 use super::driver::{DesktopDriverCapability, parse_window_mode_env};
 use crate::chassis_common::{
-    CommonBoot, PersistOverride, maybe_with_rpc_server, tick_only_lifecycle_config,
-    with_common_caps,
+    CommonBoot, PersistOverride, chassis_known_keys, maybe_with_rpc_server,
+    tick_only_lifecycle_config, with_common_caps,
 };
 use crate::cli::{CommonOverlay, DesktopCli};
 use crate::hub;
+use aether_substrate::config::{ConfigError, validate_env};
 use aether_substrate::handle_store::PersistConfig;
 use aether_substrate::runtime::lifecycle::FatalAborter;
 use aether_substrate::runtime::lifecycle::OutboundFatalAborter;
 use std::env;
 use winit::event_loop::ControlFlow;
+
+/// Desktop chassis env-resolution failure (ADR-0090 §4 / issue #571).
+/// Widens the historic `EventLoopError`-only return so the desktop
+/// resolver can surface both the winit event-loop fault *and* a config
+/// fault (an unparseable known `AETHER_*` env value). Both arms
+/// `From`-convert in, and the whole enum `From`-converts into
+/// `anyhow::Error` via its `StdError` impl so `main()` keeps using `?`.
+#[derive(Debug)]
+pub enum DesktopBootError {
+    /// winit `EventLoop::build` failed.
+    EventLoop(EventLoopError),
+    /// A known `AETHER_*` env var (or argv overlay value) was
+    /// unparseable (ADR-0090 §4 hard-error half).
+    Config(ConfigError),
+}
+
+impl fmt::Display for DesktopBootError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EventLoop(e) => write!(f, "desktop event loop build failed: {e}"),
+            Self::Config(e) => write!(f, "desktop config resolution failed: {e}"),
+        }
+    }
+}
+
+impl StdError for DesktopBootError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::EventLoop(e) => Some(e),
+            Self::Config(e) => Some(e),
+        }
+    }
+}
+
+impl From<EventLoopError> for DesktopBootError {
+    fn from(e: EventLoopError) -> Self {
+        Self::EventLoop(e)
+    }
+}
+
+impl From<ConfigError> for DesktopBootError {
+    fn from(e: ConfigError) -> Self {
+        Self::Config(e)
+    }
+}
 
 /// Event the event-loop thread consumes from the desktop chassis.
 /// Just one variant today: a wake-up so the loop picks up a queued
@@ -115,10 +163,17 @@ impl DesktopEnv {
     /// issue 464). Tests bypass this by constructing `DesktopEnv`
     /// directly.
     ///
-    /// The only fallible step is `EventLoop::build`; everything else
-    /// is infallible env reads. The signature names that fault rather
-    /// than the historic catch-all `wasmtime::Result` (issue #571).
-    pub fn from_env() -> Result<Self, EventLoopError> {
+    /// The fallible steps are `EventLoop::build` (winit) and the
+    /// ADR-0090 §4 config validation / parse path; both ride
+    /// [`DesktopBootError`] (issue #571 named the winit fault; e1
+    /// widens it to carry the config fault too).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DesktopBootError::EventLoop`] when winit's event loop
+    /// fails to build, or [`DesktopBootError::Config`] when a known
+    /// `AETHER_*` env var holds an unparseable value.
+    pub fn from_env() -> Result<Self, DesktopBootError> {
         Self::from_env_with_argv(DesktopCli::default())
     }
 
@@ -127,7 +182,13 @@ impl DesktopEnv {
     /// unset fields fall through to env-only resolution, so an empty
     /// argv (the path the existing `from_env` callers exercise) is
     /// byte-identical to the pre-d behaviour.
-    pub fn from_env_with_argv(cli: DesktopCli) -> Result<Self, EventLoopError> {
+    ///
+    /// # Errors
+    ///
+    /// See [`Self::from_env`].
+    pub fn from_env_with_argv(cli: DesktopCli) -> Result<Self, DesktopBootError> {
+        // ADR-0090 §4 (e1): warn on any unknown AETHER_ env var.
+        validate_env(&chassis_known_keys())?;
         let DesktopCli {
             common,
             audio: audio_overlay,
@@ -148,11 +209,11 @@ impl DesktopEnv {
         event_loop.set_control_flow(ControlFlow::Poll);
         let capture_queue = CaptureQueue::new();
 
-        let http = HttpConf::from_argv_then_env(http.into_layer());
-        let anthropic = AnthropicConfig::from_argv_then_env(anthropic.into_layer());
-        let gemini = GeminiConfig::from_argv_then_env(gemini.into_layer());
+        let http = HttpConf::try_from_argv_then_env(http.into_layer())?;
+        let anthropic = AnthropicConfig::try_from_argv_then_env(anthropic.into_layer())?;
+        let gemini = GeminiConfig::try_from_argv_then_env(gemini.into_layer())?;
         let namespace_roots = NamespaceRoots::from_argv_then_env(fs.into_layer());
-        let audio = AudioConf::from_argv_then_env(audio_overlay.into_layer());
+        let audio = AudioConf::try_from_argv_then_env(audio_overlay.into_layer())?;
 
         // Window mode: argv wins over `AETHER_WINDOW_MODE` env. The
         // parser is shared (`parse_window_mode_env`); a bad argv string

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -31,11 +31,12 @@ use aether_substrate::{Chassis, LifecycleDriverCapability, SubstrateBoot};
 
 use super::driver::{HeadlessTimerCapability, parse_tick_hz_env};
 use crate::chassis_common::{
-    CommonBoot, PersistOverride, maybe_with_rpc_server, tick_only_lifecycle_config,
-    with_common_caps,
+    CommonBoot, PersistOverride, chassis_known_keys, maybe_with_rpc_server,
+    tick_only_lifecycle_config, with_common_caps,
 };
 use crate::cli::{CommonOverlay, HeadlessCli};
 use crate::hub;
+use aether_substrate::config::{ConfigError, validate_env};
 use aether_substrate::mail::registry::MailDispatch;
 use aether_substrate::runtime::lifecycle::FatalAborter;
 use aether_substrate::runtime::lifecycle::OutboundFatalAborter;
@@ -95,8 +96,13 @@ impl HeadlessEnv {
     /// The single env-reading edge for the headless chassis (per
     /// issue 464). Tests bypass this by constructing `HeadlessEnv`
     /// directly.
-    #[must_use]
-    pub fn from_env() -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] when a known `AETHER_*` env var holds
+    /// an unparseable value (ADR-0090 §4); an unknown `AETHER_*` var
+    /// only warns (non-fatal).
+    pub fn from_env() -> Result<Self, ConfigError> {
         Self::from_env_with_argv(HeadlessCli::default())
     }
 
@@ -105,9 +111,16 @@ impl HeadlessEnv {
     /// unset fields fall through to env-only resolution, so an empty
     /// argv (the path the integration tests and existing `from_env`
     /// callers exercise) is byte-identical to the pre-d behaviour.
-    #[must_use]
-    pub fn from_env_with_argv(cli: HeadlessCli) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] when a known `AETHER_*` env var (or an
+    /// argv overlay value) holds an unparseable value (ADR-0090 §4).
+    pub fn from_env_with_argv(cli: HeadlessCli) -> Result<Self, ConfigError> {
         use std::net::{IpAddr, Ipv4Addr};
+        // ADR-0090 §4 (e1): warn on any unknown AETHER_ env var before
+        // resolving — a typo / stale export is loud but non-fatal.
+        validate_env(&chassis_known_keys())?;
         let HeadlessCli {
             common,
             tick_hz: cli_tick_hz,
@@ -121,9 +134,9 @@ impl HeadlessEnv {
             workers: cli_workers,
             rpc_port: cli_rpc_port,
         } = common;
-        let http = HttpConf::from_argv_then_env(http.into_layer());
-        let anthropic = AnthropicConfig::from_argv_then_env(anthropic.into_layer());
-        let gemini = GeminiConfig::from_argv_then_env(gemini.into_layer());
+        let http = HttpConf::try_from_argv_then_env(http.into_layer())?;
+        let anthropic = AnthropicConfig::try_from_argv_then_env(anthropic.into_layer())?;
+        let gemini = GeminiConfig::try_from_argv_then_env(gemini.into_layer())?;
         let namespace_roots = NamespaceRoots::from_argv_then_env(fs.into_layer());
         // Persistence overlay: the cap accepts the full argv-then-env
         // overlay shape (dir + persist_disable + numeric layer). The
@@ -156,7 +169,7 @@ impl HeadlessEnv {
             .or_else(hub::rpc_port_from_env)
             .map(|p| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), p));
         let workers = cli_workers.or_else(parse_workers_env);
-        Self {
+        Ok(Self {
             namespace_roots,
             http,
             anthropic,
@@ -166,7 +179,7 @@ impl HeadlessEnv {
             workers,
             persist: persist_state,
             handle_store_max_bytes,
-        }
+        })
     }
 }
 

--- a/crates/aether-substrate/src/boot.rs
+++ b/crates/aether-substrate/src/boot.rs
@@ -258,9 +258,10 @@ impl SubstrateBootBuilder<'_> {
             // Chassis bin resolved PersistConfig from argv-then-env;
             // use it verbatim (ADR-0090 unit d). max_bytes follows the
             // same overlay (argv > env > default).
-            let max_bytes = self
-                .handle_store_max_bytes
-                .unwrap_or_else(|| HandleStore::from_env().max_bytes());
+            let max_bytes = match self.handle_store_max_bytes {
+                Some(n) => n,
+                None => HandleStore::from_env()?.max_bytes(),
+            };
             HandleStore::with_persist_validated(
                 max_bytes,
                 self.persist_override,
@@ -276,7 +277,7 @@ impl SubstrateBootBuilder<'_> {
             )
         } else {
             // Pure env-only path — byte-identical to pre-d behaviour.
-            HandleStore::from_env_persistent(self.persist_enabled, Some(kind_resolver))
+            HandleStore::from_env_persistent(self.persist_enabled, Some(kind_resolver))?
         });
         // ADR-0049 §7: acquire the single-substrate-per-store lock
         // before doing any writes. A live conflicting lock aborts boot

--- a/crates/aether-substrate/src/config.rs
+++ b/crates/aether-substrate/src/config.rs
@@ -56,6 +56,15 @@
 //! kept hand-written. The five other caps benefit from the derive;
 //! `PersistConfig` stays inherent.
 
+use std::collections::HashSet;
+use std::env;
+use std::error::Error as StdError;
+use std::fmt;
+
+use confique::meta::{FieldKind, Meta};
+
+use crate::BootError;
+
 /// Build a cap config by overlaying an argv-derived partial confique
 /// layer on top of the env layer (ADR-0090 unit d).
 ///
@@ -95,11 +104,375 @@ pub trait FromArgvThenEnv: Sized {
     /// values flow through total parsers).
     #[must_use]
     fn from_argv_then_env(argv: <Self::Layer as confique::Config>::Layer) -> Self {
+        match Self::try_from_argv_then_env(argv) {
+            Ok(this) => this,
+            Err(e) => panic!("config layer resolution failed: {e}"),
+        }
+    }
+
+    /// Fallible sibling of [`from_argv_then_env`](Self::from_argv_then_env):
+    /// surfaces an unparseable known env value as a [`ConfigError`]
+    /// rather than panicking (ADR-0090 §4 — the e1 hard-error half).
+    /// The chassis env resolvers call this and `?`-propagate.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError::UnparseableKnown`] when a known env key
+    /// (or argv overlay value) fails the layer's parser — the soft
+    /// `.expect()` fall-through is gone.
+    fn try_from_argv_then_env(
+        argv: <Self::Layer as confique::Config>::Layer,
+    ) -> Result<Self, ConfigError> {
         let layer = <Self::Layer as confique::Config>::builder()
             .preloaded(argv)
             .env()
             .load()
-            .expect("config layer defaults are well-formed");
-        Self::from_layer(layer)
+            .map_err(ConfigError::from_confique)?;
+        Ok(Self::from_layer(layer))
+    }
+}
+
+/// Distinguishes a confique-backed knob (one carrying a
+/// `Config::META` leaf with an env key) from a hand-registered
+/// `OnceLock` knob (the scheduler hot-path tuning vars, registered via
+/// [`KnobRecord`] because they have no `Meta`). ADR-0090 §1: the
+/// `Meta` walk is the single source of truth for confique knobs;
+/// `KnobRecord` only carries the ones with no `Meta`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum KnobKind {
+    /// A knob declared as a `#[derive(Config)]` field — its env key
+    /// and default come from the layer `Meta`. `KnobRecord` is used
+    /// for these only when a caller wants a uniform record alongside
+    /// hand-registered ones; the canonical source is the `Meta`.
+    Confique,
+    /// A knob read directly from a process-global `OnceLock`
+    /// (`scheduler/worker_deque.rs`, `calibrate.rs`,
+    /// `lifecycle/driver.rs`) — no `Config::META`, so it must be
+    /// hand-registered to join the known-key set + the `--config`
+    /// dump (ADR-0090 unit b2, iamacoffeepot/aether#1255).
+    HandRegistered,
+}
+
+/// A uniform, hand-registered knob record. b2 builds a
+/// `&[KnobRecord]` of the scheduler hot-path tuning knobs; e2's
+/// `--config` dump renders them; e1's [`KnownKeys`] folds their
+/// `env_key`s into the accepted set so the unknown-`AETHER_*` sweep
+/// doesn't flag them.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct KnobRecord {
+    /// The `AETHER_*` (or bare) env var this knob reads.
+    pub env_key: &'static str,
+    /// One-line human/agent-facing description, lifted verbatim from
+    /// the getter doc-comment.
+    pub doc: &'static str,
+    /// The literal default, if the knob has one. `None` for adaptive
+    /// / unset knobs (`time_budget`, `mail_budget`) — rendered
+    /// "derived/unset" by the dump.
+    pub default: Option<&'static str>,
+    /// Whether this is a confique-backed or hand-registered knob.
+    pub kind: KnobKind,
+}
+
+/// The set of env keys some part of the substrate config surface
+/// claims — every `AETHER_*` (or registered bare) key that resolves
+/// to a real knob. [`validate_env`] warns on any `AETHER_*` env var
+/// absent from this set. Assembled by [`known_keys`] from the migrated
+/// `*Layer` metas plus the hand-registered [`KnobRecord`] slices.
+#[derive(Clone, Debug, Default)]
+pub struct KnownKeys {
+    keys: HashSet<&'static str>,
+}
+
+impl KnownKeys {
+    /// Whether `key` is a claimed env var.
+    #[must_use]
+    pub fn contains(&self, key: &str) -> bool {
+        self.keys.contains(key)
+    }
+
+    /// Number of distinct claimed keys.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.keys.len()
+    }
+
+    /// Whether no key is claimed (only true for an empty assembly).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.keys.is_empty()
+    }
+
+    /// Iterate the claimed keys (order unspecified).
+    pub fn iter(&self) -> impl Iterator<Item = &'static str> + '_ {
+        self.keys.iter().copied()
+    }
+}
+
+/// Walk one `confique::meta::Meta`, collecting every leaf's env key
+/// into `out` (recursing `Nested` metas). Iterative work-stack rather
+/// than recursion (CLAUDE.md: load-bearing tree walks cap depth) — a
+/// `Meta` tree is statically bounded, but the stack keeps it uniform.
+fn collect_meta_env_keys(meta: &'static Meta, out: &mut HashSet<&'static str>) {
+    let mut stack: Vec<&'static Meta> = vec![meta];
+    while let Some(m) = stack.pop() {
+        for field in m.fields {
+            match &field.kind {
+                FieldKind::Leaf { env: Some(key), .. } => {
+                    out.insert(key);
+                }
+                FieldKind::Leaf { env: None, .. } => {}
+                FieldKind::Nested { meta } => stack.push(meta),
+            }
+        }
+    }
+}
+
+/// Assemble a [`KnownKeys`] from a slice of migrated `*Layer` metas
+/// (one `&Meta` per `#[derive(Config)]` cap layer) plus a slice of
+/// hand-registered [`KnobRecord`]s (b2's scheduler knobs). Walks each
+/// `Meta` for `Leaf { env: Some(k) }` (recursing `Nested`) and folds
+/// in each record's `env_key`.
+#[must_use]
+pub fn known_keys(metas: &[&'static Meta], records: &[KnobRecord]) -> KnownKeys {
+    let mut keys = HashSet::new();
+    for meta in metas {
+        collect_meta_env_keys(meta, &mut keys);
+    }
+    for record in records {
+        keys.insert(record.env_key);
+    }
+    KnownKeys { keys }
+}
+
+/// A boot-time config fault (ADR-0090 §4). Distinct from
+/// [`BootError`] so the chassis env resolvers can surface a
+/// config-specific error before the generic boot path; it
+/// `From`-converts into `BootError::Other`.
+#[derive(Debug)]
+pub enum ConfigError {
+    /// A known env key (claimed by a `#[derive(Config)]` field or a
+    /// hand-registered knob) carried a value the parser rejected.
+    /// The soft warn-and-default fall-through is gone (ADR-0090 §4):
+    /// a garbage known value aborts boot loudly. `source` carries the
+    /// underlying parse error (a `confique::Error` or a cap-specific
+    /// `ParseIntError`).
+    UnparseableKnown {
+        /// The env key (or the layer field, when confique didn't
+        /// surface a key) whose value failed to parse.
+        key: String,
+        /// The offending raw value, when the resolver had it in hand.
+        /// confique's own error already embeds the value in its
+        /// `Display`, so this is `None` on the confique path.
+        value: Option<String>,
+        /// The underlying parse error.
+        source: Box<dyn StdError + Send + Sync + 'static>,
+    },
+}
+
+impl ConfigError {
+    /// Wrap a `confique::Error` (always an env-parse failure on the
+    /// load path — defaults are validated by the cap `*_defaults_match`
+    /// tests). The confique error's `Display` already names the field,
+    /// key, and value.
+    #[must_use]
+    pub fn from_confique(err: confique::Error) -> Self {
+        Self::UnparseableKnown {
+            key: String::new(),
+            value: None,
+            source: Box::new(err),
+        }
+    }
+
+    /// Build an `UnparseableKnown` from a hand-resolved env read (the
+    /// handle-store `AETHER_HANDLE_STORE_MAX_BYTES` path, which parses
+    /// outside confique).
+    #[must_use]
+    pub fn unparseable(
+        key: impl Into<String>,
+        value: impl Into<String>,
+        source: impl StdError + Send + Sync + 'static,
+    ) -> Self {
+        Self::UnparseableKnown {
+            key: key.into(),
+            value: Some(value.into()),
+            source: Box::new(source),
+        }
+    }
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnparseableKnown { key, value, source } => {
+                if key.is_empty() {
+                    write!(f, "unparseable config value: {source}")
+                } else if let Some(value) = value {
+                    write!(
+                        f,
+                        "unparseable value {value:?} for known config key {key:?}: {source}"
+                    )
+                } else {
+                    write!(
+                        f,
+                        "unparseable value for known config key {key:?}: {source}"
+                    )
+                }
+            }
+        }
+    }
+}
+
+impl StdError for ConfigError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::UnparseableKnown { source, .. } => Some(&**source),
+        }
+    }
+}
+
+impl From<ConfigError> for BootError {
+    fn from(e: ConfigError) -> Self {
+        Self::Other(Box::new(e))
+    }
+}
+
+/// Validate the process environment against the claimed key set
+/// (ADR-0090 §4). Warns (does not error) on any `AETHER_*` env var
+/// not in `known` — a typo or stray var is loud but non-fatal (§4
+/// rejects strict-reject: a stray CI var must not abort boot). The
+/// hard-error half rides the parse path
+/// ([`FromArgvThenEnv::try_from_argv_then_env`] /
+/// [`HandleStore::from_env`](crate::handle_store::HandleStore::from_env)),
+/// not this sweep. Run once per chassis boot after the env layers
+/// load.
+///
+/// Bare registered keys (e.g. `GEMINI_API_KEY`, `ANTHROPIC_API_KEY`)
+/// that don't carry the `AETHER_` prefix are accepted silently when
+/// present in `known`; only `AETHER_*` keys are *swept* for unknowns,
+/// because the substrate doesn't own the whole bare-env namespace.
+///
+/// # Errors
+///
+/// Never returns `Err` today — the signature returns
+/// `Result<(), ConfigError>` so the hard-error half can join this
+/// pass without a call-site change if §4 evolves.
+pub fn validate_env(known: &KnownKeys) -> Result<(), ConfigError> {
+    for (key, _value) in env::vars() {
+        if key.starts_with("AETHER_") && !known.contains(key.as_str()) {
+            tracing::warn!(
+                target: "aether_substrate::config",
+                env = %key,
+                "unknown AETHER_ env var — not claimed by any registered config knob \
+                 (typo? stale export?); ignored",
+            );
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use confique::Config as _;
+    use std::num::ParseIntError;
+
+    // Plain `#[derive(confique::Config)]` fixture (not the aether
+    // `Config` derive — that emits a clap `Overlay` whose `#[arg]`
+    // attrs need clap in scope, which `aether-substrate` doesn't
+    // carry). This gives a real `META` + `Layer` to walk; the strict
+    // `parse_env` reproduces the ADR-0090 §4 hard-error path.
+    #[derive(Clone, Debug, confique::Config)]
+    #[allow(dead_code)] // fields exercised via META / load, not read directly
+    struct FixtureConfig {
+        #[config(env = "AETHER_TEST_COUNT", parse_env = parse_count, default = 7)]
+        count: u32,
+        #[config(env = "AETHER_TEST_FLAG", default = false)]
+        enabled: bool,
+    }
+
+    fn parse_count(raw: &str) -> Result<u32, ParseIntError> {
+        raw.trim().parse()
+    }
+
+    /// A real `ParseIntError` for the `ConfigError` constructor tests
+    /// (clippy forbids `unwrap_err()` — a parse of a non-number is the
+    /// honest way to obtain one).
+    fn an_int_error() -> ParseIntError {
+        match "x".parse::<u32>() {
+            Ok(_) => unreachable!("\"x\" is not a u32"),
+            Err(e) => e,
+        }
+    }
+
+    const FIXTURE_KNOBS: &[KnobRecord] = &[KnobRecord {
+        env_key: "AETHER_FIXTURE_KNOB",
+        doc: "a hand-registered fixture knob",
+        default: Some("42"),
+        kind: KnobKind::HandRegistered,
+    }];
+
+    fn fixture_meta() -> &'static Meta {
+        &<FixtureConfig as confique::Config>::META
+    }
+
+    #[test]
+    fn known_keys_collects_meta_env_keys() {
+        let known = known_keys(&[fixture_meta()], &[]);
+        assert!(known.contains("AETHER_TEST_COUNT"));
+        assert!(known.contains("AETHER_TEST_FLAG"));
+        assert_eq!(known.len(), 2);
+    }
+
+    #[test]
+    fn known_keys_folds_in_hand_registered_records() {
+        let known = known_keys(&[fixture_meta()], FIXTURE_KNOBS);
+        assert!(known.contains("AETHER_FIXTURE_KNOB"));
+        assert!(known.contains("AETHER_TEST_COUNT"));
+        assert_eq!(known.len(), 3);
+    }
+
+    #[test]
+    fn known_keys_rejects_unclaimed() {
+        let known = known_keys(&[fixture_meta()], FIXTURE_KNOBS);
+        assert!(!known.contains("AETHER_TYPO"));
+    }
+
+    #[test]
+    fn validate_env_is_ok_with_empty_known_set() {
+        // No assertion on the warn output (it depends on ambient env);
+        // the contract is just "never errors on unknowns".
+        assert!(validate_env(&KnownKeys::default()).is_ok());
+    }
+
+    #[test]
+    fn config_error_display_names_key_and_value() {
+        let e = ConfigError::unparseable("AETHER_HANDLE_STORE_MAX_BYTES", "lots", an_int_error());
+        let msg = e.to_string();
+        assert!(msg.contains("AETHER_HANDLE_STORE_MAX_BYTES"));
+        assert!(msg.contains("lots"));
+    }
+
+    #[test]
+    fn config_error_converts_into_boot_error() {
+        let e = ConfigError::unparseable("K", "v", an_int_error());
+        let boot: BootError = e.into();
+        assert!(matches!(boot, BootError::Other(_)));
+    }
+
+    #[test]
+    fn confique_load_errors_on_garbage_known_value() {
+        // The hard-error half (ADR-0090 §4): a garbage known env value
+        // makes confique `.load()` return `Err`, which
+        // `ConfigError::from_confique` wraps. Mirrors the path
+        // `FromArgvThenEnv::try_from_argv_then_env` takes.
+        //
+        // SAFETY: single-threaded test; we set the unique key, load,
+        // then remove it before any other thread could read it.
+        unsafe { env::set_var("AETHER_TEST_COUNT", "not-a-number") };
+        let loaded = FixtureConfig::builder().env().load();
+        // SAFETY: same single-threaded scope; restoring the env.
+        unsafe { env::remove_var("AETHER_TEST_COUNT") };
+        let result = loaded.map_err(ConfigError::from_confique);
+        assert!(matches!(result, Err(ConfigError::UnparseableKnown { .. })));
     }
 }

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -51,6 +51,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use crate::config::ConfigError;
 use crate::mail::Mail;
 use crate::mail::registry::Registry;
 use aether_data::{EnumVariant, Primitive, SchemaType};
@@ -697,30 +698,30 @@ impl HandleStore {
     }
 
     /// Build a store sized from `AETHER_HANDLE_STORE_MAX_BYTES` if
-    /// set, otherwise `DEFAULT_MAX_BYTES`. Unparseable values fall
-    /// back to the default with a warn log so a typo doesn't silently
-    /// shrink the cache to zero.
-    pub fn from_env() -> Self {
-        // Nested match keeps the warn-log path readable.
-        #[allow(clippy::option_if_let_else)]
+    /// set, otherwise `DEFAULT_MAX_BYTES`.
+    ///
+    /// ADR-0090 §4 (unit e1): an *unparseable* value is now a hard
+    /// [`ConfigError`] rather than a soft warn-and-default — the
+    /// soft→hard flip unit b1 deferred. An empty value is treated as
+    /// unset (falls back to the default). The chassis env resolver
+    /// `?`-propagates the error so a garbage budget aborts boot
+    /// loudly rather than silently shrinking the cache.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError::UnparseableKnown`] when
+    /// `AETHER_HANDLE_STORE_MAX_BYTES` is set to a non-empty value
+    /// that doesn't parse as `usize`.
+    pub fn from_env() -> Result<Self, ConfigError> {
         let max_bytes = match env::var(ENV_MAX_BYTES) {
-            Ok(raw) => match raw.parse::<usize>() {
+            Ok(raw) if raw.trim().is_empty() => DEFAULT_MAX_BYTES,
+            Ok(raw) => match raw.trim().parse::<usize>() {
                 Ok(n) => n,
-                Err(e) => {
-                    tracing::warn!(
-                        target: "aether_substrate::handle_store",
-                        env = ENV_MAX_BYTES,
-                        value = %raw,
-                        error = %e,
-                        default = DEFAULT_MAX_BYTES,
-                        "ignoring unparseable env var; falling back to default",
-                    );
-                    DEFAULT_MAX_BYTES
-                }
+                Err(e) => return Err(ConfigError::unparseable(ENV_MAX_BYTES, raw, e)),
             },
             Err(_) => DEFAULT_MAX_BYTES,
         };
-        Self::new(max_bytes)
+        Ok(Self::new(max_bytes))
     }
 
     /// Build a store sized from the environment with on-disk
@@ -730,13 +731,22 @@ impl HandleStore {
     /// drives the schema-evolution check (ADR-0049 §6). When persistence
     /// resolves to `Some`, the boot scan (issue #985) populates the disk
     /// index from the existing tree, dropping schema-stale entries.
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError::UnparseableKnown`] when
+    /// `AETHER_HANDLE_STORE_MAX_BYTES` is set to garbage (ADR-0090
+    /// §4 — via [`Self::from_env`]).
     pub fn from_env_persistent(
         enabled: bool,
         kind_resolver: Option<Arc<dyn KindResolver>>,
-    ) -> Self {
-        let max_bytes = Self::from_env().max_bytes;
-        Self::with_persist_validated(max_bytes, PersistConfig::from_env(enabled), kind_resolver)
+    ) -> Result<Self, ConfigError> {
+        let max_bytes = Self::from_env()?.max_bytes;
+        Ok(Self::with_persist_validated(
+            max_bytes,
+            PersistConfig::from_env(enabled),
+            kind_resolver,
+        ))
     }
 
     /// Mint a fresh ephemeral handle id. Pure counter today; content-

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -82,7 +82,9 @@ pub use chassis::ctx::{
     SharedActorSlots,
 };
 pub use chassis::error::BootError;
-pub use config::FromArgvThenEnv;
+pub use config::{
+    ConfigError, FromArgvThenEnv, KnobKind, KnobRecord, KnownKeys, known_keys, validate_env,
+};
 pub use lifecycle::{LifecycleDriverCapability, LifecycleDriverConfig, LifecycleGraph};
 pub use mail::mailer::Mailer;
 pub use mail::outbound::{


### PR DESCRIPTION
Closes iamacoffeepot/aether#1259.

**Bottom of a 3-PR stack** (ADR-0090 config glue): this PR (e1) → `refactor/issue-1255-...` (b2) → `feat/issue-1260-...` (e2). Review/merge bottom-up.

## Summary

Unit e1 of ADR-0090. Lands the central config glue surface in `aether-substrate::config` (extending unit-d's `FromArgvThenEnv` home — no new module/crate) and flips config parsing from soft-default to fail-fast:

- **Glue shapes**: `KnobRecord { env_key, doc, default: Option<&str>, kind }`, `KnownKeys`, and a generic `known_keys(metas, records)` assembly that walks each migrated layer's confique `Meta` (iterative, collecting `Leaf{env:Some}`, recursing `Nested`) plus hand-registered records.
- **Validation**: `validate_env(&KnownKeys)` warns on any unknown `AETHER_*` var (catches typos without breaking boot).
- **Hard-error half**: the soft `.expect()` on confique `.load()` becomes `try_from_*` returning `Result`; the cap parsers gain strict erroring variants; `HandleStore::from_env*` returns `Result<_, ConfigError>`; `ConfigError` converts into `BootError`.
- **Chassis wiring**: `chassis_known_keys()` lives bundle-side (the cap-layer METAs live in `aether-capabilities`, which depends on `aether-substrate`, not the reverse). `HeadlessEnv::from_env*` returns `Result<_, ConfigError>`; `DesktopEnv::from_env*` widened to `DesktopBootError { EventLoop, Config }`. Both call `validate_env`.

## Test plan

- `known_keys` assembly over confique `Meta` + hand-registered records (env-key collection, nested recursion).
- `validate_env` warns on an unknown `AETHER_*` var; a typo doesn't break boot.
- Strict parse: a known key set to garbage hard-errors boot (the prior soft-fallback test updated to assert erroring).
- Full local preflight green: fmt + clippy (`-D warnings`) + doc + nextest (1454 passed) + wasm32 cross-build.

## Generated by

`/implement` — agent execution of scoped issue 1259 (stop-after-commit; PR opened from the main session).
