### PR TITLE
refactor(substrate): register scheduler hot-path tuning knobs for config discovery

### DIFF
--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -34,6 +34,7 @@ use aether_substrate::chassis::builder::Builder;
 use aether_substrate::config::{KnobKind, KnobRecord, KnownKeys, known_keys};
 use aether_substrate::handle_store::{ENV_MAX_BYTES, PersistConfig, PersistConfigLayer};
 use aether_substrate::runtime::lifecycle::FatalAborter;
+use aether_substrate::scheduler::SCHEDULER_KNOBS;
 use aether_substrate::{LifecycleDriverConfig, LifecycleGraph};
 use confique::Config as _;
 use confique::meta::Meta;
@@ -110,10 +111,12 @@ pub fn chassis_known_keys() -> KnownKeys {
         &NamespaceRootsLayer::META,
         &PersistConfigLayer::META,
     ];
-    // b2 (iamacoffeepot/aether#1255) folds in
-    // `aether_substrate::scheduler::SCHEDULER_KNOBS` alongside
-    // `CHASSIS_KNOBS` once that const lands.
-    known_keys(metas, CHASSIS_KNOBS)
+    // CHASSIS_KNOBS (bare chassis knobs) + the scheduler / lifecycle
+    // hot-path tuning knobs (ADR-0090 unit b2): both join the known-key
+    // set so e1's sweep doesn't flag them and e2's dump lists them.
+    let mut records: Vec<KnobRecord> = CHASSIS_KNOBS.to_vec();
+    records.extend_from_slice(SCHEDULER_KNOBS);
+    known_keys(metas, &records)
 }
 
 /// Chassis-bin verdict on the handle-store persistence config (ADR-0090
@@ -220,4 +223,38 @@ pub fn maybe_with_rpc_server<C: Chassis>(
             kinds: vec![],
         },
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::chassis_known_keys;
+
+    #[test]
+    fn chassis_known_keys_includes_scheduler_hot_path_knobs() {
+        // ADR-0090 unit b2: the six scheduler / lifecycle hot-path
+        // knobs join the known-key set, so e1's unknown-AETHER_ sweep
+        // doesn't flag them.
+        let known = chassis_known_keys();
+        for key in [
+            "AETHER_LOCAL_STICKY_MAX",
+            "AETHER_LOCAL_MAIL_BUDGET",
+            "AETHER_LOCAL_TIME_BUDGET_US",
+            "AETHER_PEER_STEAL",
+            "AETHER_HANDOFF_COST_NS",
+            "AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS",
+        ] {
+            assert!(known.contains(key), "chassis_known_keys missing {key}");
+        }
+    }
+
+    #[test]
+    fn chassis_known_keys_includes_a_representative_cap_key() {
+        // The cap layer META walk lands the per-cap env keys (a
+        // representative from each migrated cap) plus the bare chassis
+        // knobs — the set is non-empty and covers more than scheduler.
+        let known = chassis_known_keys();
+        assert!(known.contains("AETHER_HTTP_DISABLE"));
+        assert!(known.contains("AETHER_WORKERS"));
+        assert!(!known.is_empty());
+    }
 }

--- a/crates/aether-substrate/src/lifecycle/driver.rs
+++ b/crates/aether-substrate/src/lifecycle/driver.rs
@@ -47,6 +47,7 @@ use aether_kinds::{
 use super::graph::{LifecycleGraph, LifecycleState};
 use crate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
 use crate::chassis::error::BootError;
+use crate::config::{KnobKind, KnobRecord};
 use crate::mail::mailer::Mailer;
 use crate::mail::{MailId, MailboxId, ReplyTo};
 
@@ -75,6 +76,20 @@ enum Step {
 /// a permanent wedge into a visible stutter rather than tripping on
 /// ordinary jitter.
 const ADVANCE_TIMEOUT_MS_DEFAULT: u64 = 1_000;
+
+/// Discovery records for the lifecycle advance-timeout knob (ADR-0090
+/// unit b2, iamacoffeepot/aether#1255). Describes the
+/// `AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS` override read in the driver's
+/// `init` so the e1 sweep / e2 dump cover it; the inline env read
+/// stays exactly as-is.
+pub const LIFECYCLE_KNOBS: &[KnobRecord] = &[KnobRecord {
+    env_key: "AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS",
+    doc: "Deadline (ms) for a pending lifecycle advance's Settled before the next \
+          inbound advance force-completes it (degrades a wedged settlement pipeline \
+          into a visible stutter).",
+    default: Some("1000"),
+    kind: KnobKind::HandRegistered,
+}];
 
 /// Construction-time configuration for [`LifecycleDriverCapability`].
 /// Carries the compiled graph + initial chassis context. Constructed

--- a/crates/aether-substrate/src/lifecycle/mod.rs
+++ b/crates/aether-substrate/src/lifecycle/mod.rs
@@ -17,7 +17,7 @@
 mod driver;
 mod graph;
 
-pub use driver::{LifecycleDriverCapability, LifecycleDriverConfig};
+pub use driver::{LIFECYCLE_KNOBS, LifecycleDriverCapability, LifecycleDriverConfig};
 pub use graph::{
     BuildError, LifecycleGraph, LifecycleGraphBuilder, NoOpen, OpenNoNext, OpenWithNext,
 };

--- a/crates/aether-substrate/src/scheduler/calibrate.rs
+++ b/crates/aether-substrate/src/scheduler/calibrate.rs
@@ -53,6 +53,21 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use crate::config::{KnobKind, KnobRecord};
+
+/// Discovery records for the handoff-cost calibration knob (ADR-0090
+/// unit b2). Describes the `AETHER_HANDOFF_COST_NS` override read in
+/// [`ensure_seeded`] so the e1 sweep / e2 dump cover it; the seed path
+/// stays untouched.
+pub const CALIBRATE_KNOBS: &[KnobRecord] = &[KnobRecord {
+    env_key: "AETHER_HANDOFF_COST_NS",
+    doc: "Pins the cross-worker handoff-cost estimate (nanoseconds) and freezes \
+          live refinement — deterministic tests / a known-good number on a noisy \
+          box. Unset → boot-probed and live-refined.",
+    default: None,
+    kind: KnobKind::HandRegistered,
+}];
+
 /// Round trips measured (after warmup). Even, so the median averages the
 /// two central samples; large enough to median out scheduler jitter,
 /// small enough that the whole probe is sub-millisecond.

--- a/crates/aether-substrate/src/scheduler/mod.rs
+++ b/crates/aether-substrate/src/scheduler/mod.rs
@@ -48,3 +48,82 @@ pub use slot::{
 };
 pub use spin_park::{Acquired, SpinPark};
 pub use worker_deque::{burst_note_mail, pending_depth, time_budget};
+
+use crate::config::KnobRecord;
+use crate::lifecycle::LIFECYCLE_KNOBS;
+
+/// The scheduler + lifecycle hot-path tuning knobs registered for
+/// config discovery (ADR-0090 unit b2, iamacoffeepot/aether#1255).
+/// Concatenates the four deque / keep-local-valve knobs
+/// (`worker_deque::DEQUE_KNOBS`), the handoff-cost calibration knob
+/// (`calibrate::CALIBRATE_KNOBS`), and the lifecycle advance-timeout
+/// knob ([`LIFECYCLE_KNOBS`]) into the single
+/// slice e1's `chassis_known_keys()` folds into the known-key set and
+/// e2's `--config` dump renders. Pure `&'static` metadata — there is
+/// no change to any hot-path `OnceLock` read.
+///
+/// The element-by-element array (rather than a runtime concat) keeps
+/// `SCHEDULER_KNOBS` a `const`: each record is still *defined* once in
+/// its owning module; this only *references* it.
+pub const SCHEDULER_KNOBS: &[KnobRecord] = &[
+    worker_deque::DEQUE_KNOBS[0],
+    worker_deque::DEQUE_KNOBS[1],
+    worker_deque::DEQUE_KNOBS[2],
+    worker_deque::DEQUE_KNOBS[3],
+    calibrate::CALIBRATE_KNOBS[0],
+    LIFECYCLE_KNOBS[0],
+];
+
+#[cfg(test)]
+mod knob_tests {
+    use super::SCHEDULER_KNOBS;
+    use crate::config::KnobKind;
+
+    #[test]
+    fn scheduler_knobs_cover_all_six_hot_path_env_keys() {
+        let keys: Vec<&str> = SCHEDULER_KNOBS.iter().map(|r| r.env_key).collect();
+        for expected in [
+            "AETHER_LOCAL_STICKY_MAX",
+            "AETHER_LOCAL_MAIL_BUDGET",
+            "AETHER_LOCAL_TIME_BUDGET_US",
+            "AETHER_PEER_STEAL",
+            "AETHER_HANDOFF_COST_NS",
+            "AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS",
+        ] {
+            assert!(
+                keys.contains(&expected),
+                "SCHEDULER_KNOBS missing {expected}; has {keys:?}",
+            );
+        }
+        assert_eq!(SCHEDULER_KNOBS.len(), 6);
+    }
+
+    #[test]
+    fn scheduler_knobs_are_all_hand_registered() {
+        // None are confique fields — they ride OnceLock getters, so
+        // every record is HandRegistered (the discriminator e2's dump
+        // uses to know there's no Meta to walk).
+        assert!(
+            SCHEDULER_KNOBS
+                .iter()
+                .all(|r| matches!(r.kind, KnobKind::HandRegistered))
+        );
+    }
+
+    #[test]
+    fn adaptive_knobs_have_no_literal_default() {
+        // time_budget / mail_budget are adaptive / off-by-default with
+        // no single literal default (ADR-0090 unit b2): their record
+        // default is None ("derived/unset"), satisfied by the doc text.
+        for key in ["AETHER_LOCAL_TIME_BUDGET_US", "AETHER_LOCAL_MAIL_BUDGET"] {
+            let rec = SCHEDULER_KNOBS
+                .iter()
+                .find(|r| r.env_key == key)
+                .expect("knob present");
+            assert!(
+                rec.default.is_none(),
+                "{key} should have no literal default"
+            );
+        }
+    }
+}

--- a/crates/aether-substrate/src/scheduler/worker_deque.rs
+++ b/crates/aether-substrate/src/scheduler/worker_deque.rs
@@ -48,8 +48,52 @@ use std::time::{Duration, Instant};
 
 use crossbeam_deque::{Injector, Steal, Stealer, Worker};
 
+use crate::config::{KnobKind, KnobRecord};
 use crate::scheduler::calibrate::handoff_cost;
 use crate::scheduler::slot::Drainable;
+
+/// Discovery records for the four deque / keep-local-valve hot-path
+/// tuning knobs (ADR-0090 unit b2, iamacoffeepot/aether#1255). These
+/// describe the `OnceLock` getters below ([`hard_cap`], [`mail_budget`],
+/// [`time_budget`], [`peer_steal_enabled`]) so e1's unknown-`AETHER_*`
+/// sweep doesn't flag them and e2's `--config` dump lists them. The
+/// hot-path read stays exactly as-is — these are pure `&'static`
+/// metadata assembled once at boot, never on the dispatch path. Docs +
+/// defaults are lifted verbatim from the getter doc-comments;
+/// `time_budget` / `mail_budget` are adaptive / off-by-default with no
+/// literal default, so their `default` is `None` (rendered
+/// "derived/unset").
+pub const DEQUE_KNOBS: &[KnobRecord] = &[
+    KnobRecord {
+        env_key: "AETHER_LOCAL_STICKY_MAX",
+        doc: "Deque-length backstop: max slots a worker keeps on its own deque \
+              before forcing a spill (values < 1 / unparseable fall back).",
+        default: Some("256"),
+        kind: KnobKind::HandRegistered,
+    },
+    KnobRecord {
+        env_key: "AETHER_LOCAL_MAIL_BUDGET",
+        doc: "Keep-local mail-count budget per burst, off by default \
+              (Some(n) spills after n mail; Some(0) reproduces cap == 1).",
+        default: None,
+        kind: KnobKind::HandRegistered,
+    },
+    KnobRecord {
+        env_key: "AETHER_LOCAL_TIME_BUDGET_US",
+        doc: "Keep-local time valve (microseconds): pins/disables the burst spill \
+              valve. Unset → adaptive, derived from the measured handoff cost; \
+              0 disables the valve (pure inline-cascade).",
+        default: None,
+        kind: KnobKind::HandRegistered,
+    },
+    KnobRecord {
+        env_key: "AETHER_PEER_STEAL",
+        doc: "Whether idle workers may raid siblings' deques (peer-deque stealing). \
+              Default off (owner-only); set 1/true to opt the sibling raid back in.",
+        default: Some("off"),
+        kind: KnobKind::HandRegistered,
+    },
+];
 
 /// The unit on the deques: a chassis-registered dispatcher slot. (Phase
 /// 3b makes the blob the unit; 3a keeps the slot.)


### PR DESCRIPTION
Closes iamacoffeepot/aether#1255.

**Middle of a 3-PR stack** — based on `feat/issue-1259-config-validation` (e1), not `main`. Merge iamacoffeepot/aether#1259 first; this retargets to `main` on its merge. Followed by `feat/issue-1260-...` (e2).

## Summary

Unit b2 of ADR-0090. Registers the scheduler hot-path tuning knobs into e1's discovery/validation surface as records — **no change to the hot-path read path**:

- `pub const SCHEDULER_KNOBS: &[KnobRecord]` (scheduler/mod.rs) concatenating `worker_deque::DEQUE_KNOBS` (4: `AETHER_LOCAL_STICKY_MAX`, `AETHER_LOCAL_MAIL_BUDGET`, `AETHER_LOCAL_TIME_BUDGET_US`, `AETHER_PEER_STEAL`) + `calibrate::CALIBRATE_KNOBS` (`AETHER_HANDOFF_COST_NS`) + `lifecycle::LIFECYCLE_KNOBS` (`AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS`).
- The `OnceLock` env getters are untouched; the knob records are pure metadata co-located with them.
- `time_budget` / `mail_budget` are adaptive with no literal default, so their `KnobRecord.default` is `None`.
- Folded into `chassis_known_keys()` so the unknown-`AETHER_*` sweep no longer flags these vars, and `--config` lists them.

## Test plan

- `SCHEDULER_KNOBS` contains all six knobs with correct env keys/defaults.
- The unknown-var sweep recognizes them (no longer flagged).
- No hot-path change — the `OnceLock` getters are byte-identical.
- Validated under the stack's full preflight (fmt + clippy `-D warnings` + nextest + wasm32); independently `cargo check --workspace` green.

## Generated by

`/implement` — agent execution of scoped issue 1255 (stop-after-commit; PR opened from the main session).
