### PR TITLE
fix(camera): use TAU constant in orbit yaw wrap

### DIFF
--- a/crates/aether-camera/src/runtime.rs
+++ b/crates/aether-camera/src/runtime.rs
@@ -48,7 +48,7 @@ use aether_capabilities::input::InputMailboxExt;
 use aether_capabilities::{InputCapability, RenderCapability};
 use aether_data::{Kind, MailboxId};
 use aether_kinds::{Camera, Tick, WindowSize};
-use aether_math::{Mat4, PI, Quat, Vec2, Vec3};
+use aether_math::{Mat4, PI, Quat, TAU, Vec2, Vec3};
 
 use crate::{
     CameraCreate, CameraDestroy, CameraOrbitSet, CameraSetActive, CameraSetMode, CameraTopdownSet,
@@ -132,10 +132,10 @@ impl OrbitState {
 
     fn tick(&mut self) {
         self.yaw += self.speed;
-        if self.yaw > PI * 2.0 {
-            self.yaw -= PI * 2.0;
+        if self.yaw > TAU {
+            self.yaw -= TAU;
         } else if self.yaw < 0.0 {
-            self.yaw += PI * 2.0;
+            self.yaw += TAU;
         }
     }
 


### PR DESCRIPTION
## Summary

The orbit-mode yaw wrap in `aether-camera` used `PI * 2.0`, which a newer floating `dtolnay/rust-toolchain@stable` clippy flags as `suboptimal_flops` (suggests `mul_add`). The expression is a compile-time constant so the suggestion is moot — switched to `aether_math::TAU`, which is clearer and carries no multiply for the lint to flag.

## Why it surfaced now

The lint is latent on `main`: `cargo clippy --workspace` lints aether-camera on every run, but `rust-cache` had been serving its clippy result clean, and `main`'s last green run predates the stable bump. Every fresh PR build now cache-misses aether-camera's clippy and trips it — so this currently blocks the in-flight config PRs (1257, 1259, 1255, 1260) even though none of them touch aether-camera.

There is no toolchain pin (CI floats `@stable`); a follow-up to pin the toolchain (or sweep latent lints) would stop this recurring. Out of scope here — this is the minimal unblock.

## Test plan

- `cargo clippy --workspace --all-targets -- -D warnings` clean (aether-camera no longer trips `suboptimal_flops`).
- Full local preflight green: fmt + clippy + doc + nextest + wasm32 cross-build.
- Behavior identical — `TAU == 2*PI`; the yaw wrap is unchanged.
