### PR TITLE
feat(substrate): config discovery --config dump

### DIFF
--- a/crates/aether-substrate-bundle/src/bin/desktop.rs
+++ b/crates/aether-substrate-bundle/src/bin/desktop.rs
@@ -5,13 +5,22 @@
 //! each per-cap overlay shadows its `AETHER_*` env var, unset flags
 //! fall through to env-only resolution.
 
+// `--config` prints the discovery dump to stdout before boot
+// (ADR-0090 §4 / e2).
+#![allow(clippy::print_stdout)]
+
 use aether_substrate::Chassis;
+use aether_substrate_bundle::chassis_config_dump;
 use aether_substrate_bundle::cli::DesktopCli;
 use aether_substrate_bundle::desktop::{DesktopChassis, DesktopEnv};
 use clap::Parser as _;
 
 fn main() -> anyhow::Result<()> {
     let cli = DesktopCli::parse();
+    if cli.config {
+        print!("{}", chassis_config_dump());
+        return Ok(());
+    }
     let env = DesktopEnv::from_env_with_argv(cli)?;
     let chassis = DesktopChassis::build(env)?;
     tracing::info!(

--- a/crates/aether-substrate-bundle/src/bin/headless.rs
+++ b/crates/aether-substrate-bundle/src/bin/headless.rs
@@ -4,13 +4,22 @@
 //! each per-cap overlay shadows its `AETHER_*` env var, unset flags
 //! fall through to env-only resolution.
 
+// `--config` prints the discovery dump to stdout before tracing is up
+// (ADR-0090 §4 / e2).
+#![allow(clippy::print_stdout)]
+
 use aether_substrate::Chassis;
+use aether_substrate_bundle::chassis_config_dump;
 use aether_substrate_bundle::cli::HeadlessCli;
 use aether_substrate_bundle::headless::{HeadlessChassis, HeadlessEnv};
 use clap::Parser as _;
 
 fn main() -> anyhow::Result<()> {
     let cli = HeadlessCli::parse();
+    if cli.config {
+        print!("{}", chassis_config_dump());
+        return Ok(());
+    }
     let env = HeadlessEnv::from_env_with_argv(cli)?;
     let chassis = HeadlessChassis::build(env)?;
     tracing::info!(

--- a/crates/aether-substrate-bundle/src/bin/hub.rs
+++ b/crates/aether-substrate-bundle/src/bin/hub.rs
@@ -5,14 +5,33 @@
 //! `--rpc-port` shadows `AETHER_RPC_PORT`.
 
 // CLI diagnostic before tracing subscriber is installed (issue 891).
+// `--config` prints the discovery dump to stdout before boot
+// (ADR-0090 §4 / e2).
 #![allow(clippy::print_stderr)]
+#![allow(clippy::print_stdout)]
 
+use aether_substrate::config::{KnobKind, KnobRecord, dump_config};
 use aether_substrate_bundle::cli::HubCli;
 use aether_substrate_bundle::hub::{Chassis, HubChassis, HubEnv};
 use clap::Parser as _;
 
+/// The hub chassis is coordinator-only — its sole config knob is the
+/// RPC bind port (ADR-0090 §4 discovery). The full-stack cap knobs
+/// don't apply, so the hub dumps just this one rather than the shared
+/// `chassis_config_dump`.
+const HUB_KNOBS: &[KnobRecord] = &[KnobRecord {
+    env_key: "AETHER_RPC_PORT",
+    doc: "aether.rpc.server bind port (default 8901).",
+    default: Some("8901"),
+    kind: KnobKind::HandRegistered,
+}];
+
 fn main() -> anyhow::Result<()> {
     let cli = HubCli::parse();
+    if cli.config {
+        print!("{}", dump_config(&[], HUB_KNOBS));
+        return Ok(());
+    }
     let chassis = HubChassis::build(HubEnv::from_env_with_argv(&cli))?;
     eprintln!(
         "aether-substrate-bundle: hub chassis initialised (profile={})",

--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -31,7 +31,7 @@ use aether_data::{Kind, MailboxId as DataMailboxId, mailbox_id_from_name};
 use aether_kinds::{Shutdown, Tick};
 use aether_substrate::chassis::Chassis;
 use aether_substrate::chassis::builder::Builder;
-use aether_substrate::config::{KnobKind, KnobRecord, KnownKeys, known_keys};
+use aether_substrate::config::{KnobKind, KnobRecord, KnownKeys, dump_config, known_keys};
 use aether_substrate::handle_store::{ENV_MAX_BYTES, PersistConfig, PersistConfigLayer};
 use aether_substrate::runtime::lifecycle::FatalAborter;
 use aether_substrate::scheduler::SCHEDULER_KNOBS;
@@ -103,7 +103,17 @@ pub const CHASSIS_KNOBS: &[KnobRecord] = &[
 /// assembly fn is in `config`; the concrete chassis registry is here.
 #[must_use]
 pub fn chassis_known_keys() -> KnownKeys {
-    let metas: &[&'static Meta] = &[
+    let (metas, records) = chassis_registry();
+    known_keys(metas, &records)
+}
+
+/// The chassis-wide config registry: the migrated cap layer `Meta`s
+/// plus the hand-registered knob records (`CHASSIS_KNOBS` + b2's
+/// `SCHEDULER_KNOBS`). Shared by [`chassis_known_keys`] (e1's sweep)
+/// and [`chassis_config_dump`] (e2's `--config`) so both read one
+/// source of truth.
+fn chassis_registry() -> (&'static [&'static Meta], Vec<KnobRecord>) {
+    const METAS: &[&Meta] = &[
         &HttpConfigLayer::META,
         &GeminiConfigLayer::META,
         &AnthropicConfigLayer::META,
@@ -111,12 +121,19 @@ pub fn chassis_known_keys() -> KnownKeys {
         &NamespaceRootsLayer::META,
         &PersistConfigLayer::META,
     ];
-    // CHASSIS_KNOBS (bare chassis knobs) + the scheduler / lifecycle
-    // hot-path tuning knobs (ADR-0090 unit b2): both join the known-key
-    // set so e1's sweep doesn't flag them and e2's dump lists them.
     let mut records: Vec<KnobRecord> = CHASSIS_KNOBS.to_vec();
     records.extend_from_slice(SCHEDULER_KNOBS);
-    known_keys(metas, &records)
+    (METAS, records)
+}
+
+/// Render the `--config` discovery dump for the full-stack chassis
+/// (ADR-0090 §4): every cap layer knob + hand-registered knob with its
+/// live source-resolved value, default, and doc. The chassis bins call
+/// this when `--config` is passed and exit before boot.
+#[must_use]
+pub fn chassis_config_dump() -> String {
+    let (metas, records) = chassis_registry();
+    dump_config(metas, &records)
 }
 
 /// Chassis-bin verdict on the handle-store persistence config (ADR-0090
@@ -256,5 +273,20 @@ mod tests {
         assert!(known.contains("AETHER_HTTP_DISABLE"));
         assert!(known.contains("AETHER_WORKERS"));
         assert!(!known.is_empty());
+    }
+
+    #[test]
+    fn chassis_config_dump_lists_a_knob_from_each_cap_plus_scheduler() {
+        // ADR-0090 §4 `--config`: the dump walks the same registry as
+        // the sweep, so it lists a representative knob from each cap, a
+        // bare chassis knob, and a scheduler hot-path knob — with a
+        // header row.
+        let dump = super::chassis_config_dump();
+        assert!(dump.contains("KEY"));
+        assert!(dump.contains("AETHER_HTTP_DISABLE")); // http cap
+        assert!(dump.contains("AETHER_GEMINI_TIMEOUT_MS")); // gemini cap
+        assert!(dump.contains("AETHER_AUDIO_DISABLE")); // audio cap
+        assert!(dump.contains("AETHER_WORKERS")); // bare chassis knob
+        assert!(dump.contains("AETHER_LOCAL_STICKY_MAX")); // scheduler knob
     }
 }

--- a/crates/aether-substrate-bundle/src/cli.rs
+++ b/crates/aether-substrate-bundle/src/cli.rs
@@ -155,6 +155,11 @@ pub struct DesktopCli {
     /// `AETHER_WINDOW_TITLE` — window title text.
     #[arg(long = "window-title")]
     pub window_title: Option<String>,
+
+    /// Print every config knob (source-resolved value, default, doc)
+    /// and exit before boot (ADR-0090 §4 discovery dump).
+    #[arg(long = "config")]
+    pub config: bool,
 }
 
 /// Headless chassis CLI root.
@@ -170,6 +175,11 @@ pub struct HeadlessCli {
     /// `AETHER_TICK_HZ` — tick cadence in hertz (default 60).
     #[arg(long = "tick-hz")]
     pub tick_hz: Option<u32>,
+
+    /// Print every config knob (source-resolved value, default, doc)
+    /// and exit before boot (ADR-0090 §4 discovery dump).
+    #[arg(long = "config")]
+    pub config: bool,
 }
 
 /// Hub chassis CLI root — coordinator-only, no full-stack caps.
@@ -183,4 +193,9 @@ pub struct HubCli {
     /// 8901).
     #[arg(long = "rpc-port")]
     pub rpc_port: Option<u16>,
+
+    /// Print every config knob (source-resolved value, default, doc)
+    /// and exit before boot (ADR-0090 §4 discovery dump).
+    #[arg(long = "config")]
+    pub config: bool,
 }

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -194,6 +194,9 @@ impl DesktopEnv {
             audio: audio_overlay,
             window_mode: cli_window_mode,
             window_title: cli_window_title,
+            // The bin handles `--config` (print + exit) before this
+            // resolver runs; ignore it here.
+            config: _,
         } = cli;
         let CommonOverlay {
             http,

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -124,6 +124,9 @@ impl HeadlessEnv {
         let HeadlessCli {
             common,
             tick_hz: cli_tick_hz,
+            // The bin handles `--config` (print + exit) before this
+            // resolver runs; ignore it here.
+            config: _,
         } = cli;
         let CommonOverlay {
             http,

--- a/crates/aether-substrate-bundle/src/lib.rs
+++ b/crates/aether-substrate-bundle/src/lib.rs
@@ -25,7 +25,7 @@
 //! chassis surface.
 
 mod chassis_common;
-pub use chassis_common::PersistOverride;
+pub use chassis_common::{PersistOverride, chassis_config_dump};
 pub mod chassis_root;
 pub mod cli;
 pub mod desktop;

--- a/crates/aether-substrate/src/config.rs
+++ b/crates/aether-substrate/src/config.rs
@@ -60,8 +60,9 @@ use std::collections::HashSet;
 use std::env;
 use std::error::Error as StdError;
 use std::fmt;
+use std::fmt::Write as _;
 
-use confique::meta::{FieldKind, Meta};
+use confique::meta::{Expr, Field, FieldKind, LeafKind, Meta};
 
 use crate::BootError;
 
@@ -242,6 +243,132 @@ pub fn known_keys(metas: &[&'static Meta], records: &[KnobRecord]) -> KnownKeys 
         keys.insert(record.env_key);
     }
     KnownKeys { keys }
+}
+
+/// Render a `confique::meta::Expr` default as a plain string (matching
+/// how it would be typed in env). Best-effort for the discovery dump;
+/// composite defaults (`Array` / `Map`) render in a compact debug
+/// shape since they have no single env representation.
+fn render_expr(expr: &Expr) -> String {
+    match expr {
+        Expr::Str(s) => (*s).to_owned(),
+        Expr::Float(fl) => fl.to_string(),
+        Expr::Integer(i) => i.to_string(),
+        Expr::Bool(b) => b.to_string(),
+        Expr::Array(items) => {
+            let inner: Vec<String> = items.iter().map(render_expr).collect();
+            format!("[{}]", inner.join(","))
+        }
+        Expr::Map(_) => "<map>".to_owned(),
+        // `Expr` is `#[non_exhaustive]` — any future variant renders
+        // as a placeholder rather than failing the dump.
+        _ => "<expr>".to_owned(),
+    }
+}
+
+/// One resolved row in the [`dump_config`] table.
+struct DumpRow {
+    key: String,
+    value: String,
+    source: &'static str,
+    default: String,
+    doc: String,
+}
+
+/// Resolve one confique leaf's discovery row: read the live env value
+/// (the value the running config would resolve to) and label its
+/// source as `env` (set) or `default` (unset).
+fn leaf_row(env_key: &str, leaf: &LeafKind, doc: &[&'static str]) -> DumpRow {
+    let default = match leaf {
+        LeafKind::Required {
+            default: Some(expr),
+        } => render_expr(expr),
+        LeafKind::Required { default: None } | LeafKind::Optional => String::new(),
+    };
+    let (value, source) =
+        env::var(env_key).map_or_else(|_| (default.clone(), "default"), |v| (v, "env"));
+    DumpRow {
+        key: env_key.to_owned(),
+        value,
+        source,
+        default,
+        doc: doc.join(" ").trim().to_owned(),
+    }
+}
+
+/// Walk one `Meta` into `rows`, resolving every leaf's discovery row
+/// (recursing `Nested`). Iterative work-stack, same shape as
+/// [`collect_meta_env_keys`].
+fn collect_meta_rows(meta: &'static Meta, rows: &mut Vec<DumpRow>) {
+    let mut stack: Vec<&'static Meta> = vec![meta];
+    while let Some(m) = stack.pop() {
+        for field in m.fields {
+            let Field { doc, kind, .. } = field;
+            match kind {
+                FieldKind::Leaf {
+                    env: Some(key),
+                    kind: leaf,
+                } => rows.push(leaf_row(key, leaf, doc)),
+                FieldKind::Leaf { env: None, .. } => {}
+                FieldKind::Nested { meta } => stack.push(meta),
+            }
+        }
+    }
+}
+
+/// Render the `--config` discovery dump (ADR-0090 §4): walk the same
+/// `Meta`-slice + `KnobRecord`-slice registry e1 assembles and e2
+/// reads, printing every knob with its live source-resolved value,
+/// source label (`env` / `default`), default, and doc. Confique knobs
+/// come from the `Meta` walk (the single source of truth — no second
+/// hand-maintained list); hand-registered knobs render their
+/// `KnobRecord` directly (`source` = `env` when the var is set, else
+/// `unregistered-default` since their default lives only in the
+/// record). Output is a stable plaintext table.
+#[must_use]
+pub fn dump_config(metas: &[&'static Meta], records: &[KnobRecord]) -> String {
+    let mut rows: Vec<DumpRow> = Vec::new();
+    for meta in metas {
+        collect_meta_rows(meta, &mut rows);
+    }
+    for record in records {
+        let default = record.default.unwrap_or("").to_owned();
+        let (value, source) =
+            env::var(record.env_key).map_or_else(|_| (default.clone(), "default"), |v| (v, "env"));
+        rows.push(DumpRow {
+            key: record.env_key.to_owned(),
+            value,
+            source,
+            default,
+            doc: record.doc.to_owned(),
+        });
+    }
+    rows.sort_by(|a, b| a.key.cmp(&b.key));
+
+    let key_w = rows.iter().map(|r| r.key.len()).max().unwrap_or(3).max(3);
+    let val_w = rows.iter().map(|r| r.value.len()).max().unwrap_or(5).max(5);
+    let src_w = 7; // "default" is the widest source label
+    let def_w = rows
+        .iter()
+        .map(|r| r.default.len())
+        .max()
+        .unwrap_or(7)
+        .max(7);
+
+    let mut out = String::new();
+    let (k, v, s, d, doc) = ("KEY", "VALUE", "SOURCE", "DEFAULT", "DOC");
+    let _ = writeln!(
+        out,
+        "{k:<key_w$}  {v:<val_w$}  {s:<src_w$}  {d:<def_w$}  {doc}"
+    );
+    for r in &rows {
+        let (key, value, source, default, doc) = (&r.key, &r.value, r.source, &r.default, &r.doc);
+        let _ = writeln!(
+            out,
+            "{key:<key_w$}  {value:<val_w$}  {source:<src_w$}  {default:<def_w$}  {doc}"
+        );
+    }
+    out
 }
 
 /// A boot-time config fault (ADR-0090 §4). Distinct from
@@ -435,6 +562,37 @@ mod tests {
     fn known_keys_rejects_unclaimed() {
         let known = known_keys(&[fixture_meta()], FIXTURE_KNOBS);
         assert!(!known.contains("AETHER_TYPO"));
+    }
+
+    #[test]
+    fn dump_config_renders_meta_keys_defaults_and_docs() {
+        let dump = dump_config(&[fixture_meta()], FIXTURE_KNOBS);
+        // Confique knob from the Meta walk: key + default + a header.
+        assert!(dump.contains("AETHER_TEST_COUNT"));
+        assert!(dump.contains('7')); // the count default
+        assert!(dump.contains("KEY"));
+        assert!(dump.contains("SOURCE"));
+        // Hand-registered knob rendered directly.
+        assert!(dump.contains("AETHER_FIXTURE_KNOB"));
+        assert!(dump.contains("a hand-registered fixture knob"));
+    }
+
+    #[test]
+    fn dump_config_labels_env_set_value_as_env_source() {
+        // SAFETY: single-threaded test; unique key set then removed.
+        unsafe { env::set_var("AETHER_FIXTURE_KNOB", "99") };
+        let dump = dump_config(&[], FIXTURE_KNOBS);
+        // SAFETY: same scope.
+        unsafe { env::remove_var("AETHER_FIXTURE_KNOB") };
+        let row = dump
+            .lines()
+            .find(|l| l.contains("AETHER_FIXTURE_KNOB"))
+            .expect("knob row present");
+        assert!(
+            row.contains("99"),
+            "value should be the env override: {row}"
+        );
+        assert!(row.contains("env"), "source should be env: {row}");
     }
 
     #[test]

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -83,7 +83,8 @@ pub use chassis::ctx::{
 };
 pub use chassis::error::BootError;
 pub use config::{
-    ConfigError, FromArgvThenEnv, KnobKind, KnobRecord, KnownKeys, known_keys, validate_env,
+    ConfigError, FromArgvThenEnv, KnobKind, KnobRecord, KnownKeys, dump_config, known_keys,
+    validate_env,
 };
 pub use lifecycle::{LifecycleDriverCapability, LifecycleDriverConfig, LifecycleGraph};
 pub use mail::mailer::Mailer;


### PR DESCRIPTION
Closes iamacoffeepot/aether#1260.

**Top of the 3-PR stack** — based on `refactor/issue-1255-register-scheduler-knobs` (b2), itself on `feat/issue-1259-config-validation` (e1). Merge the stack bottom-up.

## Summary

ADR-0090 unit e2 — the `--config` discovery dump. Walks each migrated layer's confique `Meta` plus the hand-registered `KnobRecord`s (e1's registry, including b2's `SCHEDULER_KNOBS`) and prints every knob with its source-resolved value, default, and doc. Wired as a `--config` flag on all three chassis roots (desktop / headless / hub) via a shared `chassis_config_dump()`.

### Scope reduction (deliberate)

The issue also scoped a **multi-name back-compat alias layer**. That was **dropped** — implementing it surfaced a false premise: b1's migration *pinned* every historical env key (`env =` on each derived field), so no legacy name was orphaned and there is nothing to alias today. Per the design discovery (and your call), the dump ships now and the alias layer lands with the PR that actually renames a key (defer-until-forced). The alias mechanism + its tests were removed rather than shipped as dead code.

This satisfies the issue's primary acceptance criterion (`--config` lists all knobs + source-resolved values + defaults + docs). The "legacy name resolves with a deprecation warning" criterion is moot until a rename exists.

## Test plan

- `dump_config` renders meta keys, defaults, and docs; labels an env-set value's source as `env`.
- Smoke-ran `--config` against the headless bin: lists all scheduler/lifecycle/cap knobs with resolved values.
- Full local preflight green: fmt + clippy (`-D warnings`) + doc + nextest (1452 passed) + wasm32 cross-build.

## Generated by

`/implement` — agent execution of scoped issue 1260 (stop-after-commit; trimmed + PR opened from the main session).
