### PR TITLE
fix(substrate): cap passive-build worker pool to de-starve tests under load

### DIFF
--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -737,6 +737,15 @@ fn make_driver_boot<D: DriverCapability>(driver: D) -> DriverBoot {
     })
 }
 
+/// Default worker-pool size for the passive ([`Builder::build_passive`])
+/// build path when no explicit [`Builder::with_workers`] override is set.
+/// Small on purpose: the passive path is the test / `TestBench` embedder
+/// path (no production callers), and a near-full `available_parallelism()`
+/// pool per test over-subscribes nextest's `num_cpus`-wide run. See
+/// [`Builder::build_passive`] for the full rationale
+/// (iamacoffeepot/aether#1295, iamacoffeepot/aether#1142).
+const PASSIVE_DEFAULT_WORKERS: usize = 2;
+
 /// Declarative chassis builder, parametric over the chassis kind `C`
 /// and a type-state `S` tracking whether a driver has been supplied.
 /// `Builder<C, NoDriver>` accepts [`Self::with_actor`] /
@@ -855,11 +864,25 @@ impl<C: Chassis> Builder<C, NoDriver> {
     /// and returns a [`PassiveChassis`] whose embedder is responsible
     /// for driving the loop manually (`TestBench`).
     pub fn build_passive(self) -> Result<PassiveChassis<C>, BootError> {
+        // The passive (manually-driven) path has no production callers —
+        // every chassis main goes through `.driver(_).build()`. It is the
+        // build path for `TestBench` and the hundreds of substrate-booting
+        // unit tests. Inheriting `PoolConfig::default()`'s
+        // `available_parallelism() - 1` here means each such test spawns a
+        // near-full worker pool; under nextest's `num_cpus`-wide run that is
+        // ~`num_cpus^2` live threads, and the resulting multi-second
+        // scheduling stalls starve settlement / teardown cycles past their
+        // deadlines — the load-only flakes in iamacoffeepot/aether#1295 and
+        // iamacoffeepot/aether#1142 (green in isolation and on 2-core CI,
+        // red under a saturated local `--workspace` run). A small default
+        // keeps the manual-drive path light; the perf benches that want a
+        // real pool already pass `.with_workers(_)` explicitly, which wins.
+        let workers = self.workers.or(Some(PASSIVE_DEFAULT_WORKERS));
         let booted = boot_passives(
             &self.registry,
             &self.mailer,
             &self.aborter,
-            self.workers,
+            workers,
             self.passives,
         )?;
         // ADR-0081 retired the chassis-pushed `ConfigureLogDrain` mail


### PR DESCRIPTION
## Root cause

`Builder::build_passive` has **no production callers** — every chassis main goes through `.driver(_).build()`. It is the build path for `TestBench` and the hundreds of substrate-booting unit tests. With no explicit `with_workers` override it inherited `PoolConfig::default()`'s `available_parallelism() - 1`, so each such test spawned a near-full worker pool.

Under nextest's `num_cpus`-wide run that is ~`num_cpus²` live worker threads. The resulting multi-second scheduling stalls starve settlement / teardown cycles past their deadlines:

- iamacoffeepot/aether#1295 — the 2 s chassis-teardown `unwire` wait (`shutdown_instanced`) times out, so `close_observed` stays 0.
- iamacoffeepot/aether#1142 — the `dag_executor_*` settlement waits (5 s) don't complete; a *different* test fails each run at the same ~999/1296 position.

Both pass in isolation and on 2-core CI, and go red only under a saturated local `--workspace` run — the signature of CPU starvation, not a product bug.

## Fix

Default the passive path to a small pool (`PASSIVE_DEFAULT_WORKERS = 2`) when unset. This collapses peak concurrent worker threads from ~`num_cpus²` to ~`2·num_cpus` across the whole test population and removes the starvation. Perf benches that want a real pool already pass `.with_workers(_)`, which still wins. Production `.build()` is untouched.

## Verify

Repeated saturated `cargo nextest run --workspace --all-features --profile ci`: **5× green, ~20 s each** (vs the prior flaky runs; the smaller pools also cut wall-clock).

This flake class only reproduces under full-workspace saturation, so the in-isolation `flaky_` / `--stress-count` soak cannot exercise it (it would always pass and give false confidence). It is deliberately **not** added — repeated full runs are the correct soak here.

Closes iamacoffeepot/aether#1295
Closes iamacoffeepot/aether#1142