### PR TITLE
chore(substrate): name the magic worker-count literal in WakeSink tests

### DIFF
--- a/crates/aether-substrate/src/actor/native/blob_work.rs
+++ b/crates/aether-substrate/src/actor/native/blob_work.rs
@@ -914,8 +914,19 @@ mod tests {
     use crossbeam_deque::{Injector, Steal};
     use std::sync::mpsc;
 
+    /// Pool size for the wake helper. Immaterial here: these tests
+    /// exercise the wake/drain path below the recruit gate, so the
+    /// `workers - 1` recruit cap (iamacoffeepot/aether#1147) never
+    /// engages. Local copy of `scheduler::slot::tests::TEST_WORKERS`,
+    /// which isn't reachable from outside `scheduler`.
+    const TEST_WORKERS: usize = 8;
+
     fn wake_sink(injector: &Arc<Injector<Arc<dyn Drainable>>>) -> WakeSink {
-        WakeSink::new(Arc::clone(injector), Arc::new(SpinPark::new()), 8)
+        WakeSink::new(
+            Arc::clone(injector),
+            Arc::new(SpinPark::new()),
+            TEST_WORKERS,
+        )
     }
 
     /// Drain the injector by running every queued `Drainable` to `Idle`

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -386,7 +386,7 @@ mod tests {
     use super::*;
     use crate::runtime::lifecycle::PanicAborter;
     use crate::scheduler::slot::BATCH_MAX_USEC;
-    use crate::scheduler::slot::tests::CounterSlot;
+    use crate::scheduler::slot::tests::{CounterSlot, TEST_WORKERS};
     use crate::scheduler::{SlotStateLabel, WakeHandle};
     use crossbeam_deque::Steal;
     use std::sync::Weak;
@@ -552,7 +552,11 @@ mod tests {
         let slot_dyn: Arc<dyn Drainable> = slot.clone();
         let weak: Weak<dyn Drainable> = Arc::downgrade(&slot_dyn);
         drop(slot_dyn);
-        let sink = WakeSink::new(Arc::clone(&injector), Arc::new(SpinPark::new()), 8);
+        let sink = WakeSink::new(
+            Arc::clone(&injector),
+            Arc::new(SpinPark::new()),
+            TEST_WORKERS,
+        );
         let wake = WakeHandle::new(slot.state.clone(), weak, sink);
 
         slot.push(1);

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -599,6 +599,15 @@ pub mod tests {
     use std::hint;
     use std::thread;
 
+    /// Pool size handed to `WakeSink::new` in the wake/schedule tests.
+    /// The exact value is immaterial: these tests drive the wake +
+    /// ready-queue path, which sits below the recruit gate, so the
+    /// `workers - 1` recruit cap (iamacoffeepot/aether#1147) never
+    /// engages — any plausible pool size behaves identically. Shared
+    /// with `pool::tests` (same parent module); `blob_work::tests`
+    /// keeps its own local copy since it lives outside `scheduler`.
+    pub const TEST_WORKERS: usize = 8;
+
     /// Test fixture: a slot with a `Vec<u32>` inbox and a counter
     /// incremented per dispatch. Exercises the [`Drainable`] surface
     /// without dragging in the real chassis machinery.
@@ -926,7 +935,11 @@ pub mod tests {
         let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
         let slot = CounterSlot::new("wake");
         let weak: Weak<dyn Drainable> = Arc::downgrade(&(slot.clone() as Arc<dyn Drainable>));
-        let sink = WakeSink::new(Arc::clone(&injector), Arc::new(SpinPark::new()), 8);
+        let sink = WakeSink::new(
+            Arc::clone(&injector),
+            Arc::new(SpinPark::new()),
+            TEST_WORKERS,
+        );
         let wake = WakeHandle::new(slot.state.clone(), weak, sink);
 
         // First wake should spill one slot.


### PR DESCRIPTION
## What

Replace the bare `8` passed as `WakeSink::new`'s `workers` arg at three test call sites with a named, documented `TEST_WORKERS` const.

- `scheduler/slot.rs` — `wake_handle_pushes_to_ready_queue_once_per_idle`
- `scheduler/pool.rs` — `wake_during_running_does_not_duplicate_queue_entry`
- `actor/native/blob_work.rs` — the `wake_sink` test helper

## Why

`8` was a magic literal — nothing at the call site said what it meant or why any value was fine. The doc on the new const explains it: these tests drive the wake / ready-queue path, which sits below the recruit gate, so the `workers - 1` recruit cap (added by the worker-count cap, iamacoffeepot/aether#1147) never engages and the exact pool size is immaterial.

`slot` is a private module, so a shared `pub const` in `slot::tests` reaches `pool::tests` (same parent — `pool` already imports `CounterSlot` from there) but not `blob_work::tests` (outside `scheduler`); widening `slot`'s visibility for a test const isn't warranted, so `blob_work::tests` keeps a local copy.

Pure test hygiene, no behaviour change. Follow-up cleanup for iamacoffeepot/aether#1148.

## Test

Full preflight green (fmt + clippy + doc + nextest 1459 passed + wasm32 cross-build). The two named tests pass; `cargo check --tests` clean.

Closes iamacoffeepot/aether#1149
