### PR TITLE
chore(qodana): run the CI-equivalent scan locally via scripts/qodana-local.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,10 @@ spikes/*/target/
 # (iamacoffeepot/aether#1084) — populated by scripts/perf-compare.sh,
 # persisted by the workflow's actions/cache, never committed.
 /.perf-cache/
+# Local Qodana scan output (scripts/qodana-local.sh) — SARIF + HTML
+# report copied out of the results volume; regenerated each run.
+/.qodana-local/
+
 # Environment files — may hold secrets (API keys, etc.); never commit.
 # Covers any directory and every variant: .env, .env.local, .env.production, etc.
 .env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,13 +142,17 @@ A Claude-side hook (`.claude/hooks/check-pre-push.sh`) checks the stamp ahead of
 
 ## Qodana pre-flight (local)
 
-Qodana gates merges via the `ci-pass` aggregator, but running `qodana scan` locally is blocked: the container's cargo-metadata pass times out on the colima virtiofs bind mount. The local equivalent is RustRover's inspection set — Qodana's `qodana.recommended` profile rehosts most of its checks from the same IntelliJ inspector RustRover runs in-IDE.
+Qodana gates merges via the `ci-pass` aggregator. Run the **same scan CI submits**, locally, with `scripts/qodana-local.sh` (issue 1099). The naive `qodana scan` times out because it bind-mounts the repo over colima's virtiofs and Qodana's `cargo metadata` pass does thousands of small reads there; the script sidesteps that the way CI does — it syncs the working tree into a Docker named volume (the VM's native fs) and keeps a persistent cache volume for the bootstrapped toolchain + analysis caches. Same linter image / `qodana.recommended` profile / `--fail-threshold 0` as the CI job, reading the same `qodana.yaml`.
 
-- **Per-file**: the gutter + Problems tool window surface the same inspection ids Qodana reports (`RsUnnecessaryParentheses`, `RsApproxConstant`, `DuplicatedCode`, …).
-- **Whole-project**: `Code → Inspect Code…` → scope `Whole project` (or `Uncommitted files` for a fast pre-push check) → profile `Project Default`.
-- **Agent-side**: `mcp__rustrover__get_file_problems` (`errorsOnly: false`) returns the same problem set for one file. Iterate it over `git diff --name-only` before commits on Qodana-touched files. RustRover MCP has no project-wide inspect runner — use the IDE menu for that.
+- **Run it**: `colima start` first (the script won't auto-boot a cold VM), then `scripts/qodana-local.sh`. ~3.3min warm; SARIF + HTML report land in `./.qodana-local/` (gitignored). Exit code is Qodana's gate (non-zero = findings). `--rebuild-cache` drops the cache volume.
+- **Fidelity**: validated against a main CI run — local reproduced 19/22 findings exactly (`RsUnnecessaryQualifications`, `DuplicatedCode`, `RsUnusedImport`, `CargoUnusedDependency` all matched). The one offline gap is `NewCrateVersionAvailable` (queries crates.io; needs `QODANA_TOKEN`) — export the token to close it, else it stays CI-only. Note `CargoUnusedDependency` **does** run locally.
 
-Cargo.toml-level checks (`NewCrateVersionAvailable`, `UnusedDependency`) surface only in CI. Re-baselining (`qodana.sarif.json`) is done by downloading the `qodana-report` workflow artifact from a CI run.
+For a quick single-file check without spinning up the container, RustRover's inspector rehosts most of the same checks:
+
+- **Agent-side**: `mcp__rustrover__get_file_problems` (`errorsOnly: false`) returns the problem set for one file. Iterate it over `git diff --name-only` for a fast pre-commit pass on Qodana-touched files. RustRover MCP has no project-wide runner — use `scripts/qodana-local.sh` (or the IDE's `Code → Inspect Code…`) for whole-project.
+- **Per-file in-IDE**: the gutter + Problems tool window surface the same inspection ids (`RsUnnecessaryParentheses`, `RsApproxConstant`, `DuplicatedCode`, …).
+
+Re-baselining (`qodana.sarif.json`) is done by downloading the `qodana-report` workflow artifact from a CI run.
 
 ## Flake soak (pre-release)
 

--- a/scripts/qodana-local.sh
+++ b/scripts/qodana-local.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Run the CI-equivalent Qodana scan locally — fast.
+#
+# Why this exists: `qodana scan` (and the IDE) bind-mount the repo into
+# the linter container. On colima that mount is virtiofs, and Qodana's
+# `cargo metadata` pass does thousands of small random reads resolving
+# the wasmtime/cranelift/wgpu trees — slow enough to time out
+# (iamacoffeepot/aether#1099, and the CLAUDE.md "Qodana pre-flight"
+# note). CI never hits this: it checks out onto the runner's native
+# ext4 and caches `/data/cache` across runs.
+#
+# This script reproduces both of CI's advantages locally:
+#   1. The project lives in a Docker *named volume* (the colima VM's
+#      native ext4), not the virtiofs host mount — so the analyzer's
+#      file IO is fast.
+#   2. A persistent cache volume holds the bootstrapped toolchain +
+#      cargo registry + analysis caches, so only the FIRST run pays the
+#      ~minutes of bootstrap; later runs are warm.
+#
+# It runs the same linter image, profile, and `--fail-threshold 0` as
+# `.github/workflows/ci.yml`'s Qodana job, reading the same
+# `qodana.yaml` (linter, profile, excludes, bootstrap). Findings match
+# CI: validated against main run 26928217340, local reproduced 19 of 22
+# findings exactly (RsUnnecessaryQualifications, DuplicatedCode,
+# RsUnusedImport, CargoUnusedDependency all matched).
+#
+# Caveat — one inspection can't run offline: `NewCrateVersionAvailable`
+# queries crates.io for newer dep versions and needs the Qodana Cloud /
+# network integration gated behind QODANA_TOKEN, so a tokenless local
+# run skips it (the 3-finding gap above). Export QODANA_TOKEN to close
+# it; otherwise that one check stays CI-only.
+#
+# Timing: first run ~3.5min (bootstraps the toolchain + cold cargo
+# metadata + analysis cache into the persistent cache volume); warm runs
+# ~3.3min. Both well under the virtiofs timeout the naive bind-mount hits.
+#
+# Usage:
+#   scripts/qodana-local.sh            # scan the working tree
+#   scripts/qodana-local.sh --rebuild-cache   # drop the cache volume first
+#
+# Exit code is Qodana's: 0 = no findings over threshold, non-zero =
+# findings (same gate as CI). SARIF + the HTML report land in
+# ./.qodana-local/ (gitignored).
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$repo_root"
+
+image=$(awk -F': *' '/^linter:/{print $2; exit}' qodana.yaml)
+[[ -n "$image" ]] || { echo "qodana-local: could not read linter from qodana.yaml" >&2; exit 1; }
+
+proj_vol=aether-qodana-project
+cache_vol=aether-qodana-cache
+results_vol=aether-qodana-results
+out_dir="$repo_root/.qodana-local"
+
+for arg in "$@"; do
+    case "$arg" in
+        --rebuild-cache) docker volume rm -f "$cache_vol" >/dev/null 2>&1 || true ;;
+        *) echo "qodana-local: unknown arg '$arg'" >&2; exit 2 ;;
+    esac
+done
+
+# colima/docker must be up. Don't auto-start — a cold colima boot is
+# slow enough to look hung; tell the user to start it themselves.
+if ! docker info >/dev/null 2>&1; then
+    echo "qodana-local: docker is not reachable. Start colima first:" >&2
+    echo "    colima start --cpu 6 --memory 12" >&2
+    exit 1
+fi
+
+docker volume create "$proj_vol"   >/dev/null
+docker volume create "$cache_vol"  >/dev/null
+docker volume create "$results_vol" >/dev/null
+
+# Sync the working tree into the project volume. Exclude the heavy
+# non-source trees (target/.git and the artifact dirs) so the copy is
+# ~12MB / sub-second; keep every cargo workspace member (crates/*,
+# demos/sokoban) and the spikes/ paths the root Cargo.toml `exclude`
+# references, or `cargo metadata` breaks.
+echo "qodana-local: syncing working tree → $proj_vol ..."
+# COPYFILE_DISABLE=1 stops macOS `tar` (bsdtar) from emitting AppleDouble
+# `._*` sidecar entries for files carrying extended attributes. Without
+# it those extract as real `._foo.rs` files in the Linux container, and
+# Qodana's "Detached file" inspection fires on every one (~one per source
+# file) — pure noise CI never sees. The `._*` exclude is belt-and-braces.
+COPYFILE_DISABLE=1 tar -C "$repo_root" \
+    --exclude='._*' \
+    --exclude=./target --exclude=./.git --exclude=./.claude \
+    --exclude=./wishes --exclude=./research --exclude=./traces \
+    --exclude=./audits --exclude='./*.png' --exclude=./.qodana-local \
+    -cf - . \
+    | docker run --rm -i -v "$proj_vol":/data/project alpine \
+        sh -c 'cd /data/project && rm -rf ./* ./.[!.]* 2>/dev/null; tar -xf -'
+
+# Qodana wants a git repo at the project root (rev-parse --show-toplevel)
+# for VCS metadata; we dropped .git in the sync, so seed a throwaway one
+# to silence the "not a git repository" log noise. Cosmetic only — the
+# scan runs fine without it (full-scan, no changed-files scoping) — so
+# this is best-effort: `|| true` guarantees a git hiccup never sinks the
+# pre-flight. `safe.directory '*'` defuses git's dubious-ownership guard
+# on the root-owned volume.
+docker run --rm -v "$proj_vol":/data/project -e HOME=/root alpine sh -c '
+    apk add --no-cache git >/dev/null 2>&1 || exit 0
+    git config --global --add safe.directory "*"
+    git config --global user.email local@qodana
+    git config --global user.name local
+    cd /data/project || exit 0
+    if [ ! -d .git ]; then
+        git init -q && git add -A && git commit -qm snapshot
+    fi' || true
+
+rm -rf "$out_dir"; mkdir -p "$out_dir"
+
+echo "qodana-local: scanning ($image) ..."
+set +e
+docker run --rm -u root \
+    -v "$proj_vol":/data/project \
+    -v "$cache_vol":/data/cache \
+    -v "$results_vol":/data/results \
+    ${QODANA_TOKEN:+-e QODANA_TOKEN="$QODANA_TOKEN"} \
+    "$image" \
+    --fail-threshold 0
+scan_status=$?
+set -e
+
+# Copy SARIF + report out of the results volume to the gitignored dir.
+docker run --rm -v "$results_vol":/data/results -v "$out_dir":/out alpine \
+    sh -c 'cp -a /data/results/. /out/ 2>/dev/null || true'
+
+sarif="$out_dir/qodana.sarif.json"
+if [[ -f "$sarif" ]]; then
+    echo
+    echo "qodana-local: findings by severity —"
+    # Summarise the SARIF result set without pulling in jq deps beyond
+    # what's already on the host.
+    if command -v jq >/dev/null 2>&1; then
+        jq -r '
+          [.runs[].results[]?
+           | .level // (.properties.qodanaSeverity // "unknown")] as $lv
+          | ($lv | group_by(.) | map({k:.[0], n:length}))[]
+          | "  \(.k): \(.n)"' "$sarif" 2>/dev/null || echo "  (could not parse SARIF)"
+        total=$(jq '[.runs[].results[]?] | length' "$sarif" 2>/dev/null || echo "?")
+        echo "  total: $total"
+    fi
+    echo "qodana-local: full report → $out_dir (open report/index.html)"
+fi
+
+echo "qodana-local: scan exit status $scan_status"
+exit "$scan_status"


### PR DESCRIPTION
## What

`scripts/qodana-local.sh` — run the **same Qodana scan CI submits**, locally, in ~3.3 min warm. Closes the green-local/red-CI surprise where preflight (fmt + clippy + doc + nextest) passes but the Qodana CI job fails on inspector-only lints with no clippy equivalent.

## Why the naive path didn't work

`qodana scan` bind-mounts the repo into the linter container. On colima that's virtiofs, and Qodana's `cargo metadata` pass does thousands of small random reads resolving the wasmtime/cranelift/wgpu trees — slow enough to time out. CI never hits this: it checks out onto the runner's native ext4 and caches `/data/cache` across runs.

## How the script fixes it

Reproduces both of CI's advantages:

1. Syncs the working tree into a Docker **named volume** (the VM's native fs), so the analyzer's file IO never touches virtiofs. Only the heavy non-source trees (`target`, `.git`, `wishes`, `research`, …) are excluded; every cargo workspace member is kept.
2. A **persistent cache volume** holds the bootstrapped toolchain + cargo registry + analysis caches, so only the first run pays the bootstrap.

Same linter image, `qodana.recommended` profile, and `--fail-threshold 0` as the CI Qodana job, reading the same `qodana.yaml`.

## Fidelity

Validated against main CI run 26928217340 — local reproduced **19 of 22** findings exactly:

| Rule | CI | Local |
|---|---|---|
| RsUnnecessaryQualifications | 10 | 10 |
| DuplicatedCode | 7 | 7 |
| RsUnusedImport | 1 | 1 |
| CargoUnusedDependency | 1 | 1 |
| NewCrateVersionAvailable | 3 | — |

The only gap is `NewCrateVersionAvailable`, which queries crates.io and needs `QODANA_TOKEN` — it stays CI-only offline (export the token to close it). `CargoUnusedDependency` does run locally, so CLAUDE.md's "surfaces only in CI" note for it was outdated and is corrected.

## macOS gotchas handled

- `COPYFILE_DISABLE=1` on the tar so bsdtar's AppleDouble `._*` sidecars don't extract as phantom detached `.rs` files (288 of them in the first run before this).
- A best-effort throwaway `git init` in the volume to silence Qodana's "not a git repository" log noise (non-fatal; cosmetic).

## Notes

- Docs-/config-only change (`scripts/**`, `.gitignore`, `CLAUDE.md`) — preflight short-circuits the Rust pass; CI self-validates.
- Output dir `.qodana-local/` is gitignored.
- Instance that motivated this: iamacoffeepot/aether#1098 (an `Unnecessary path prefix` Notice that passed preflight, failed Qodana CI).

Closes iamacoffeepot/aether#1099
