### PR TITLE
chore(substrate): tagged-id Debug + enriched drop-warn + fs log wording

### DIFF
--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -555,7 +555,7 @@ mod native {
                 save = %roots.save.display(),
                 assets = %roots.assets.display(),
                 config = %roots.config.display(),
-                "io adapters registered",
+                "adapters registered",
             );
             Ok(Self { registry })
         }

--- a/crates/aether-data/src/ids.rs
+++ b/crates/aether-data/src/ids.rs
@@ -145,7 +145,7 @@ pub const fn type_name_for_type_id(type_id: u64) -> Option<&'static str> {
 /// bits in the high nibble. `#[repr(transparent)]` over `u64` so
 /// cast-shape kinds keep their layouts.
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
+#[derive(Copy, Clone, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
 pub struct MailboxId(pub u64);
 
 impl MailboxId {
@@ -199,6 +199,16 @@ impl fmt::Display for MailboxId {
     }
 }
 
+// Manual `Debug` (not derived) so `?id` in tracing and assert-failure
+// messages renders the tagged `mbx-…` form instead of the opaque numeric
+// hash — same body as `Display`, since the tag prefix already names the
+// id type so a `MailboxId(…)` wrapper would be redundant (iamacoffeepot/aether#1052).
+impl fmt::Debug for MailboxId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_tagged(self.0, f)
+    }
+}
+
 impl Serialize for MailboxId {
     fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         serialize_id(self.0, s)
@@ -215,7 +225,7 @@ impl<'de> Deserialize<'de> for MailboxId {
 /// `Tag::Kind` discriminator + a 60-bit FNV-1a hash of the kind's
 /// canonical schema bytes. `#[repr(transparent)]` over `u64`.
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
+#[derive(Copy, Clone, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
 pub struct KindId(pub u64);
 
 impl KindId {
@@ -224,6 +234,13 @@ impl KindId {
 }
 
 impl fmt::Display for KindId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_tagged(self.0, f)
+    }
+}
+
+// Tagged `Debug` — see the note on `MailboxId`'s impl.
+impl fmt::Debug for KindId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt_tagged(self.0, f)
     }
@@ -246,7 +263,7 @@ impl<'de> Deserialize<'de> for KindId {
 /// counter masked into the low bits. `#[repr(transparent)]` over
 /// `u64`.
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
+#[derive(Copy, Clone, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
 pub struct HandleId(pub u64);
 
 impl HandleId {
@@ -255,6 +272,13 @@ impl HandleId {
 }
 
 impl fmt::Display for HandleId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_tagged(self.0, f)
+    }
+}
+
+// Tagged `Debug` — see the note on `MailboxId`'s impl.
+impl fmt::Debug for HandleId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt_tagged(self.0, f)
     }
@@ -278,7 +302,7 @@ impl<'de> Deserialize<'de> for HandleId {
 /// session salt, analogous to [`HandleId`] rather than a name hash.
 /// `#[repr(transparent)]` over `u64`.
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
+#[derive(Copy, Clone, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
 pub struct DagId(pub u64);
 
 impl DagId {
@@ -287,6 +311,13 @@ impl DagId {
 }
 
 impl fmt::Display for DagId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_tagged(self.0, f)
+    }
+}
+
+// Tagged `Debug` — see the note on `MailboxId`'s impl.
+impl fmt::Debug for DagId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt_tagged(self.0, f)
     }
@@ -313,7 +344,7 @@ impl<'de> Deserialize<'de> for DagId {
 /// shape so the descriptor's `Transform` node encodes/decodes.
 /// `#[repr(transparent)]` over `u64`.
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
+#[derive(Copy, Clone, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
 pub struct TransformId(pub u64);
 
 impl TransformId {
@@ -322,6 +353,13 @@ impl TransformId {
 }
 
 impl fmt::Display for TransformId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_tagged(self.0, f)
+    }
+}
+
+// Tagged `Debug` — see the note on `MailboxId`'s impl.
+impl fmt::Debug for TransformId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt_tagged(self.0, f)
     }
@@ -347,7 +385,7 @@ impl<'de> Deserialize<'de> for TransformId {
 /// per hop; the cold render path reverses it to a display name through
 /// the runtime registry. `#[repr(transparent)]` over `u64`.
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
+#[derive(Copy, Clone, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
 pub struct ThreadId(pub u64);
 
 impl ThreadId {
@@ -365,6 +403,13 @@ impl ThreadId {
 }
 
 impl fmt::Display for ThreadId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_tagged(self.0, f)
+    }
+}
+
+// Tagged `Debug` — see the note on `MailboxId`'s impl.
+impl fmt::Debug for ThreadId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt_tagged(self.0, f)
     }

--- a/crates/aether-substrate/src/lifecycle/driver.rs
+++ b/crates/aether-substrate/src/lifecycle/driver.rs
@@ -352,9 +352,25 @@ impl<C: 'static + Send + Sync> NativeActor for LifecycleDriverCapability<C> {
             // of wedging forever, then fall through to process *this*
             // advance against the now-advanced state.
             if !self.pending_timed_out() {
+                // Name what's still in flight so a slow settlement is
+                // diagnosable from the drop warn alone: the stuck root
+                // (tagged), how long it's been pending, which broadcast
+                // stage hasn't settled, and the first-level fan-out it
+                // dispatched to (iamacoffeepot/aether#1052). The
+                // descendant mail *currently* executing lives in the
+                // trace observer's graph, not here — cross-reference it
+                // by `pending_root`.
+                let pending = self
+                    .pending
+                    .as_ref()
+                    .expect("pending.is_some() checked above");
                 tracing::warn!(
                     target: "aether_substrate::lifecycle",
                     current = ?self.current_state,
+                    pending_root = ?pending.root,
+                    pending_for_millis = pending.started.elapsed().as_millis(),
+                    stuck_stage = %pending.completed_kind,
+                    fanout = ?self.subscribers.get(&pending.completed_kind),
                     "LifecycleAdvance received while a prior advance is still in flight; dropping"
                 );
                 return;

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -589,7 +589,7 @@ fn route_mail(
                     target: "aether_substrate::handle_store",
                     handle = %handle,
                     kind = %kind,
-                    recipient = ?mail.recipient,
+                    recipient = %mail.recipient,
                     "parking mail on missing handle",
                 );
                 // A parked mail sits in the store until the handle
@@ -605,7 +605,7 @@ fn route_mail(
                     target: "aether_substrate::handle_store",
                     kind = %mail.kind,
                     error = ?e,
-                    recipient = ?mail.recipient,
+                    recipient = %mail.recipient,
                     "ref-walk failed against registered schema; mail dropped",
                 );
                 // ADR-0080 §2: balance the `Sent` so settlement chains


### PR DESCRIPTION
## What

The legibility half of iamacoffeepot/aether#1052 — three observability paper cuts. (The trace-observer slow-root diagnostic is PR 2, which closes the issue.)

### 1. Typed ids render the tagged form in `?` contexts

Logs showed `current=KindId(3046647901680548256)` instead of `knd-d4pi-ja7k-dnob`. The id newtypes already `Display` as the tagged form via `fmt_tagged`; the logs just used `?` (derived numeric `Debug`). Replaced the derived `Debug` on all six newtypes (`MailboxId`, `KindId`, `HandleId`, `DagId`, `TransformId`, `ThreadId`) with a manual one delegating to `fmt_tagged` — bare, since the tag prefix already names the type, so `KindId(knd-…)` would be redundant.

Now **every** `?id` (logs *and* assert-failure messages) reads legibly, and `MailId`'s derived `Debug` renders its `sender` tagged for free. No test asserted the numeric `Debug` string (the `KindId(0xCAFE)`-style sites are value constructors in `assert_eq!`, unaffected). Also swept the two `recipient = ?mail.recipient` mailer sites to `%` to match their `%`-rendered siblings (`handle`, `kind`).

### 2. Enriched dropped-advance warn

When the lifecycle drops an overlapping advance, the warn only said `current=<state>`. It now names what's in flight (all from `self.pending`): `pending_root` (tagged), `pending_for_millis`, the stuck broadcast `stuck_stage`, and the first-level `fanout` it dispatched to — enough to diagnose a slow settlement from the warn alone. The descendant mail *currently executing* lives in the trace observer's graph (PR 2); the warn cross-references it by `pending_root`.

### 3. fs boot-log wording

`io adapters registered` → `adapters registered` — `io` was stale from the `aether.io` → `aether.fs` rename (iamacoffeepot/aether#633), and the log target is already `aether_substrate::fs`.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean; preflight green.
- Dogfooded `scripts/qodana-local.sh` (the new local Qodana from iamacoffeepot/aether#1099): **zero new findings** — `DuplicatedCode` unchanged at 7, so the six tiny fmt impls stay below the duplication threshold (like the existing six `Display` impls).

Part 1 of iamacoffeepot/aether#1052.
