### PR TITLE
refactor(substrate): wait-gate helper + migrate shutdown_instanced

### DIFF
--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -33,6 +33,7 @@ use crate::actor::native::{NativeActor, NativeDispatch, NativeInitCtx};
 use crate::actor::registry::ActorRegistry;
 use crate::chassis::ctx::MailboxWakeSlot;
 use crate::chassis::error::BootError;
+use crate::chassis::settlement::{TerminalDisposition, WaitOutcome, await_internal_signal};
 use crate::mail::mailer::Mailer;
 use crate::mail::registry::OwnedDispatch;
 use crate::mail::registry::{NameConflict, Registry};
@@ -46,7 +47,6 @@ use aether_actor::local;
 use aether_actor::local::ActorSlots;
 use std::sync::Weak;
 use std::time::Duration;
-use std::time::Instant;
 
 /// How to derive the subname for a [`SpawnBuilder::finish`] call. The
 /// full mailbox name is `"{A::NAMESPACE}:{subname}"`; the substrate
@@ -188,11 +188,21 @@ impl Spawner {
     /// close cycle fires it after `unwire` + registry close land, so
     /// teardown wakes the instant the cycle settles instead of polling.
     ///
-    /// On timeout: logs at warn level and returns. The slot Arcs we
-    /// drained out of `instanced_slots` will then drop, and any actor
-    /// whose close cycle didn't run misses its `unwire` (matches
-    /// the today behavior pre-685).
-    pub(crate) fn shutdown_instanced(&self, timeout: Duration) {
+    /// Issue #1305: each close-done receiver is waited on via
+    /// [`await_internal_signal`] with escalating patience rather than a
+    /// bare wall-clock `recv_timeout`. A genuinely wedged close cycle is
+    /// unrecoverable — `unwire` never ran, so teardown invariants are
+    /// already corrupt — so the disposition is `Abort` in release
+    /// (route the wedge through the Spawner's
+    /// [`FatalAborter`]) and `Panic` in test/debug (so #1295's
+    /// assertion fails attributably at the gate site instead of as a
+    /// downstream `0 != 1`). The old silent `warn!`-and-return-anyway
+    /// path that left an un-closed actor is gone.
+    ///
+    /// `round_budget` is the per-round patience interval (the log
+    /// cadence); `cumulative_cap` is the total patience per slot before
+    /// declaring a wedge.
+    pub(crate) fn shutdown_instanced(&self, round_budget: Duration, cumulative_cap: Duration) {
         let entries: Vec<InstancedSlotEntry> = {
             let mut guard = self
                 .instanced_slots
@@ -222,35 +232,32 @@ impl Spawner {
             // we just need *some* worker to pick the slot up.
             let _ = entry.wake.wake();
         }
-        let deadline = Instant::now() + timeout;
-        let mut stuck = 0usize;
+        // `Panic` in test/debug (attributable failure at the gate),
+        // `Abort` in release (the wedge is unrecoverable — route it
+        // through the Spawner's aborter). The helper diverges itself on
+        // `Panic`; on `Abort` it hands back the wedge for us to abort.
+        let disposition = if cfg!(debug_assertions) {
+            TerminalDisposition::Panic
+        } else {
+            TerminalDisposition::Abort
+        };
         for rx in &waiters {
-            let now = Instant::now();
-            let remaining = deadline.saturating_duration_since(now);
-            // `remaining == 0` means the deadline has passed; pass
-            // `Duration::ZERO` to `recv_timeout` and treat as a
-            // timeout. crossbeam channels return Timeout for the
-            // zero-duration call when the channel has nothing to
-            // recv, which is exactly what we want.
-            match rx.recv_timeout(remaining) {
-                Ok(()) => {}
-                Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
-                    stuck += 1;
-                }
-                Err(crossbeam_channel::RecvTimeoutError::Disconnected) => {
-                    // Slot dropped its sender without firing — treat
-                    // the same as a timeout (close cycle didn't run).
-                    stuck += 1;
+            match await_internal_signal(
+                rx,
+                "shutdown_instanced.close_done",
+                round_budget,
+                cumulative_cap,
+                disposition,
+            ) {
+                WaitOutcome::Settled => {}
+                WaitOutcome::Wedged(wedge) => {
+                    // `Abort` disposition (release): the close cycle
+                    // never ran `unwire`; teardown invariants are
+                    // corrupt and unrecoverable. Route through the
+                    // Spawner's aborter — diverges.
+                    self.aborter.abort(wedge.reason());
                 }
             }
-        }
-        if stuck > 0 {
-            tracing::warn!(
-                target: "aether_substrate::spawner",
-                stuck_count = stuck,
-                total = entries.len(),
-                "shutdown_instanced timed out waiting for spawned actors to run close path",
-            );
         }
     }
 

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -1036,7 +1036,14 @@ impl BootedPassives {
         // point (drops via `_pool` field order after this method
         // returns), so workers can drain the close cycles the
         // `shutdown_instanced` wakes queue.
-        self.spawner.shutdown_instanced(Duration::from_secs(2));
+        // Issue #1305: escalating patience replaces the old 2s
+        // wall-clock deadline that false-fired under `--workspace`
+        // saturation (flake #1295). The per-round budget is the log
+        // cadence; the cumulative cap is generous (a healthy close
+        // cycle resolves well before it; a genuine wedge exhausts it
+        // and aborts/panics).
+        self.spawner
+            .shutdown_instanced(Duration::from_secs(2), Duration::from_secs(30));
         while let Some(s) = self.shutdowns.pop() {
             s.shutdown_dyn();
         }

--- a/crates/aether-substrate/src/chassis/settlement.rs
+++ b/crates/aether-substrate/src/chassis/settlement.rs
@@ -40,11 +40,12 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use crate::mail::Mail;
 use crate::mail::mailer::Mailer;
 use aether_data::{KindId, MailId, MailboxId};
-use crossbeam_channel::{Receiver, Sender, bounded};
+use crossbeam_channel::{Receiver, RecvTimeoutError, Sender, bounded};
 
 /// Chassis-owned settlement notification registry. Owned by the
 /// chassis (one per substrate); cloned via `Arc` into the
@@ -286,6 +287,181 @@ fn push_settlement_notice(mailer: &Mailer, target: MailboxId, kind: KindId, root
     mailer.push(Mail::new(target, kind, payload, 1));
 }
 
+/// What a call site wants done when a wait on an internal completion
+/// signal exhausts its cumulative patience budget without the signal
+/// firing (issue #1305). The helper owns the *patience strategy*
+/// (escalating re-arm + per-round log); the disposition names what a
+/// genuine wedge means here so the same "wait for an internal signal"
+/// gate doesn't re-roll five divergent terminal behaviors by hand.
+///
+/// The variants line up with the five behaviors already scattered
+/// across the substrate + its bundle. The helper dispenses `Proceed`,
+/// `ReplyErr`, and `Panic` directly via its return value / a `panic!`;
+/// `Abort` is the one disposition that needs an aborter (a
+/// [`crate::runtime::lifecycle::FatalAborter`]), which the caller holds
+/// — the helper stays free of any `HubOutbound` coupling and hands the
+/// caller a [`GateWedge`] to route through its own aborter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminalDisposition {
+    /// Best-effort gate: log loud and let the caller carry on. Never
+    /// blocks process exit. The helper returns
+    /// [`WaitOutcome::Wedged`] so the caller can branch, but takes no
+    /// terminal action itself.
+    Proceed,
+    /// The wedge is recoverable from the caller's vantage — it surfaces
+    /// a typed error to someone who can retry. The helper returns
+    /// [`WaitOutcome::Wedged`]; the caller maps it to its error type.
+    ReplyErr,
+    /// The wedge is unrecoverable: the caller must route the returned
+    /// [`GateWedge`] through its [`crate::runtime::lifecycle::FatalAborter`].
+    /// The helper does *not* call `fatal_abort` itself — that would
+    /// couple this module to the desktop chassis's `HubOutbound`.
+    Abort,
+    /// Test/debug attributable failure: the helper `panic!`s on a wedge
+    /// so a stuck gate fails at the gate site rather than as a
+    /// downstream `0 != 1`. (A `panic!` needs no aborter, so the helper
+    /// can dispense this one without coupling to the outbound.)
+    Panic,
+}
+
+/// A wedge detected by [`await_internal_signal`]: the internal signal
+/// did not fire within the cumulative patience budget. Carries enough
+/// context for the caller to log / surface / abort attributably.
+#[derive(Debug, Clone)]
+pub struct GateWedge {
+    /// The gate name passed to [`await_internal_signal`].
+    pub gate: String,
+    /// Total wall-clock time waited before giving up.
+    pub waited: Duration,
+    /// Whether the channel disconnected (sender dropped without firing)
+    /// rather than simply staying silent to the cap. Both are wedges;
+    /// the distinction is diagnostic.
+    pub disconnected: bool,
+}
+
+impl GateWedge {
+    /// Render the wedge as the `reason` string a
+    /// [`crate::runtime::lifecycle::FatalAborter`] consumes.
+    #[must_use]
+    pub fn reason(&self) -> String {
+        let cause = if self.disconnected {
+            "signal channel disconnected without firing"
+        } else {
+            "internal signal never fired within patience budget"
+        };
+        format!(
+            "gate {} wedged: {cause}, waited {:?}",
+            self.gate, self.waited
+        )
+    }
+}
+
+/// Outcome of an [`await_internal_signal`] wait.
+#[derive(Debug)]
+#[must_use]
+pub enum WaitOutcome {
+    /// The internal signal fired before the cumulative cap. Proceed
+    /// normally.
+    Settled,
+    /// The signal never fired (silent to the cap, or the channel
+    /// disconnected). The caller dispenses its [`TerminalDisposition`]
+    /// against the carried [`GateWedge`]. Only returned for the
+    /// non-`Panic` dispositions — `Panic` diverges inside the helper.
+    Wedged(GateWedge),
+}
+
+/// Escalating-patience wait on an internal completion signal — a
+/// settlement [`Receiver`] or a pooled-actor teardown close-done
+/// channel (issue #1305). Replaces the hand-rolled wall-clock
+/// `recv_timeout(N)` that can't tell *starved-but-healthy* (the causal
+/// chain is merely slow under load) from *genuinely wedged*: under
+/// `nextest --workspace` saturation a healthy-but-slow gate trips a
+/// fixed deadline and false-fires (flake #1295).
+///
+/// Loops `rx.recv_timeout(round_budget)`:
+///
+/// - `Ok(())` → [`WaitOutcome::Settled`].
+/// - `Timeout` → log `gate <name> slow: waited <cumulative>, extending`
+///   at warn and re-arm, until the cumulative wait reaches
+///   `cumulative_cap`. The signal is a one-shot the worker fires
+///   whenever it is next scheduled, so re-arming `recv` is patient
+///   waiting with logged checkpoints, not a re-poke — a healthy gate
+///   resolves before the cap; a genuine wedge exhausts it.
+/// - `Disconnected` → the sender dropped without firing; the same
+///   terminal path as cap-exhaustion, with [`GateWedge::disconnected`]
+///   set so the wedge is attributable.
+///
+/// On a wedge the helper dispenses `disposition`:
+///
+/// - [`TerminalDisposition::Panic`] → diverges via `panic!` (no aborter
+///   needed; keeps the wedge attributable in test/debug).
+/// - [`TerminalDisposition::Proceed`] / [`TerminalDisposition::ReplyErr`]
+///   / [`TerminalDisposition::Abort`] → returns [`WaitOutcome::Wedged`]
+///   carrying the [`GateWedge`]; the caller acts on it (log-and-carry,
+///   typed error, or route through its `FatalAborter`). `Abort` is
+///   *not* performed here — that would couple this module to the
+///   desktop chassis's `HubOutbound`.
+///
+/// `round_budget` is one re-arm interval (the log cadence);
+/// `cumulative_cap` is the total patience before declaring a wedge. A
+/// `round_budget` of zero is clamped up to a small floor so the loop
+/// can't spin.
+pub fn await_internal_signal(
+    rx: &Receiver<()>,
+    gate: &str,
+    round_budget: Duration,
+    cumulative_cap: Duration,
+    disposition: TerminalDisposition,
+) -> WaitOutcome {
+    // Clamp the per-round budget off zero so a misconfigured caller
+    // can't turn the loop into a busy-spin.
+    let round = round_budget.max(Duration::from_millis(1));
+    let start = Instant::now();
+    loop {
+        match rx.recv_timeout(round) {
+            Ok(()) => return WaitOutcome::Settled,
+            Err(RecvTimeoutError::Timeout) => {
+                let waited = start.elapsed();
+                if waited >= cumulative_cap {
+                    return wedge(gate, waited, false, disposition);
+                }
+                tracing::warn!(
+                    target: "aether_substrate::settlement",
+                    gate,
+                    waited_millis = waited.as_millis(),
+                    cap_millis = cumulative_cap.as_millis(),
+                    "gate {gate} slow: waited {waited:?}, extending",
+                );
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                return wedge(gate, start.elapsed(), true, disposition);
+            }
+        }
+    }
+}
+
+/// Build the wedge verdict and dispense the one disposition the helper
+/// owns (`Panic`); the rest ride back to the caller in
+/// [`WaitOutcome::Wedged`].
+fn wedge(
+    gate: &str,
+    waited: Duration,
+    disconnected: bool,
+    disposition: TerminalDisposition,
+) -> WaitOutcome {
+    let wedge = GateWedge {
+        gate: gate.to_owned(),
+        waited,
+        disconnected,
+    };
+    match disposition {
+        TerminalDisposition::Panic => panic!("{}", wedge.reason()),
+        TerminalDisposition::Proceed
+        | TerminalDisposition::ReplyErr
+        | TerminalDisposition::Abort => WaitOutcome::Wedged(wedge),
+    }
+}
+
 #[cfg(test)]
 // Settlement tests hold per-test `Mutex` guards across the assertion
 // sequence so the captured state stays consistent against the
@@ -302,6 +478,7 @@ mod tests {
     use crate::mail::registry::OwnedDispatch;
     use crate::mail::registry::Registry;
     use std::sync::Mutex as StdMutex;
+    use std::thread;
 
     fn root(sender: u64, cid: u64) -> MailId {
         MailId {
@@ -541,6 +718,92 @@ mod tests {
         assert_eq!(after_r2.len(), 2);
         let decoded: MailId = postcard::from_bytes(&after_r2[1].payload).expect("decode MailId");
         assert_eq!(decoded, r2);
+    }
+
+    /// Resolves-within-cap: the signal fires after one round elapses
+    /// (exercising the re-arm path), and the helper returns `Settled`.
+    #[test]
+    fn await_internal_signal_resolves_after_rearm() {
+        let (tx, rx) = bounded::<()>(1);
+        // Fire from a sibling thread after roughly one round budget so
+        // the first `recv_timeout` times out (logging + re-arm) and the
+        // second resolves.
+        let handle = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(30));
+            let _ = tx.try_send(());
+        });
+        let outcome = await_internal_signal(
+            &rx,
+            "test.rearm",
+            Duration::from_millis(10),
+            Duration::from_secs(5),
+            TerminalDisposition::Proceed,
+        );
+        handle.join().expect("firing thread joins");
+        assert!(matches!(outcome, WaitOutcome::Settled));
+    }
+
+    /// Cap-exhaustion: the signal never fires, so the helper exhausts
+    /// the cumulative cap and returns `Wedged` (not disconnected) for a
+    /// non-`Panic` disposition.
+    #[test]
+    fn await_internal_signal_cap_exhaustion_wedges() {
+        // Hold the sender alive so the channel doesn't disconnect —
+        // this is the silent-to-cap path, distinct from `Disconnected`.
+        let (_tx, rx) = bounded::<()>(1);
+        let outcome = await_internal_signal(
+            &rx,
+            "test.cap",
+            Duration::from_millis(5),
+            Duration::from_millis(20),
+            TerminalDisposition::ReplyErr,
+        );
+        match outcome {
+            WaitOutcome::Wedged(w) => {
+                assert!(!w.disconnected);
+                assert_eq!(w.gate, "test.cap");
+                assert!(w.waited >= Duration::from_millis(20));
+            }
+            WaitOutcome::Settled => panic!("expected a wedge, got Settled"),
+        }
+    }
+
+    /// `Disconnected`: dropping the sender takes the same terminal path
+    /// as cap-exhaustion, with `disconnected` set.
+    #[test]
+    fn await_internal_signal_disconnect_wedges() {
+        let (tx, rx) = bounded::<()>(1);
+        drop(tx);
+        let outcome = await_internal_signal(
+            &rx,
+            "test.disconnect",
+            Duration::from_millis(50),
+            Duration::from_secs(5),
+            TerminalDisposition::Proceed,
+        );
+        match outcome {
+            WaitOutcome::Wedged(w) => {
+                assert!(w.disconnected);
+                assert_eq!(w.gate, "test.disconnect");
+            }
+            WaitOutcome::Settled => panic!("expected a wedge, got Settled"),
+        }
+    }
+
+    /// `Panic` disposition diverges inside the helper on a wedge —
+    /// asserts the gate fails attributably at the gate site.
+    #[test]
+    #[should_panic(expected = "gate test.panic wedged")]
+    fn await_internal_signal_panic_disposition_diverges() {
+        let (tx, rx) = bounded::<()>(1);
+        drop(tx);
+        let _ = await_internal_signal(
+            &rx,
+            "test.panic",
+            Duration::from_millis(5),
+            Duration::from_millis(20),
+            TerminalDisposition::Panic,
+        );
     }
 
     /// The settlement-notice payload postcard-decodes back to the


### PR DESCRIPTION
Part 1 of iamacoffeepot/aether#1305 — lands the shared wait-gate helper and migrates the canonical `shutdown_instanced` site.

## What changed

- New `await_internal_signal` helper + `TerminalDisposition` enum beside `SettlementRegistry` (`crates/aether-substrate/src/chassis/settlement.rs`). Escalating-patience wait on the close-done / settlement `Receiver<()>`: per-round `recv_timeout`, a per-round `gate <name> slow: waited <cumulative>, extending` log, and a bounded cumulative cap. Returns a `WaitOutcome` the caller dispenses — `Abort` / `ReplyErr` / `Proceed` hand back a `GateWedge`; only `Panic` is taken inside the helper, so the settlement module keeps no `HubOutbound` dependency.
- `Spawner::shutdown_instanced` (`crates/aether-substrate/src/actor/native/spawn.rs`) migrated to the helper: `Panic` in test/debug, `Abort` (via the Spawner's existing `FatalAborter`) in release. Drops the old `stuck`-count `warn!`-and-return that left an un-closed actor — the root cause of the flake.
- Sole caller (`chassis/builder.rs`) updated to pass a 2s round budget / 30s cumulative cap.

## Why

A wall-clock `recv_timeout` can't tell a starved-but-healthy gate from a wedged one, so under `nextest --workspace` saturation a healthy teardown trips the deadline and fails. Escalating patience resolves a slow-but-healthy gate before the cap and surfaces a genuine wedge loudly instead of silently proceeding with a half-closed actor.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 1464 passed
- `cargo doc --workspace --no-deps` + wasm32 component cross-build (`scripts/preflight.sh`) — clean
- `chassis_teardown_runs_unwire_for_pooled_spawned_actors` and its many-actors sibling pass under the new `Panic` (debug) path

Part 2 — the `aether-substrate-bundle` settlement gates — follows in iamacoffeepot/aether#1307, which depends on this.

Closes iamacoffeepot/aether#1295
Closes iamacoffeepot/aether#1306

🤖 Generated with [Claude Code](https://claude.com/claude-code)
