### PR TITLE
refactor(substrate-bundle): migrate settlement gates onto the wait-gate helper

### DIFF
--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -21,10 +21,19 @@ use aether_actor::Actor;
 use aether_capabilities::fs::NamespaceRoots;
 use aether_data::{Kind, encode_empty, mailbox_id_from_name};
 use aether_kinds::{AdvanceResult, CaptureFrameResult, LifecycleAdvance};
-use aether_substrate::chassis::settlement::SettlementRegistry;
+use aether_substrate::chassis::settlement::{
+    SettlementRegistry, TerminalDisposition, WaitOutcome, await_internal_signal,
+};
+use aether_substrate::runtime::lifecycle;
 use aether_substrate::{
     Chassis, LifecycleDriverCapability, capture::CaptureQueue, chassis::frame_loop, mail::MailboxId,
 };
+
+/// Cumulative patience cap for the per-frame settlement gates (advance +
+/// capture pre-mail), matching the desktop driver. The per-round budget
+/// is `frame_loop::DRAIN_BUDGET`; a starved-but-healthy chain resolves
+/// before this cap, a genuine wedge exhausts it (issue #1305).
+const FRAME_SETTLEMENT_CAP: Duration = Duration::from_secs(30);
 use aether_substrate_bundle::chassis_root::next_chassis_correlation;
 use aether_substrate_bundle::test_bench::{
     TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS,
@@ -207,12 +216,18 @@ fn run_frame(
             1,
         );
         let rx = settlement_registry.subscribe_settlement(advance_root);
-        if rx.recv_timeout(frame_loop::DRAIN_BUDGET).is_err() {
-            tracing::error!(
-                target: "aether_substrate::lifecycle",
-                root = ?advance_root,
-                "frame chain did not settle within drain budget; submitting anyway",
-            );
+        // Reconciled to `Abort` to match the desktop advance gate
+        // (issue #1305): a frame chain that never settles is a wedged
+        // dispatcher, not a "submit anyway" — escalating patience under
+        // the wait, fail-fast on a genuine wedge (ADR-0063).
+        if let WaitOutcome::Wedged(wedge) = await_internal_signal(
+            &rx,
+            "test_bench_bin.frame_advance",
+            frame_loop::DRAIN_BUDGET,
+            FRAME_SETTLEMENT_CAP,
+            TerminalDisposition::Abort,
+        ) {
+            lifecycle::fatal_abort(outbound, wedge.reason());
         }
     }
 
@@ -224,12 +239,14 @@ fn run_frame(
             // bailing out of the frame loop.
             let mut pre_failed: Option<String> = None;
             for rx in req.pre_settlements {
-                if rx.recv_timeout(Duration::from_secs(5)).is_err() {
-                    pre_failed = Some(
-                        "capture pre-mail chain failed to settle within 5s — \
-                         a downstream cap is wedged"
-                            .to_owned(),
-                    );
+                if let WaitOutcome::Wedged(wedge) = await_internal_signal(
+                    &rx,
+                    "test_bench_bin.capture_pre_mail",
+                    frame_loop::DRAIN_BUDGET,
+                    FRAME_SETTLEMENT_CAP,
+                    TerminalDisposition::ReplyErr,
+                ) {
+                    pre_failed = Some(wedge.reason());
                     break;
                 }
             }

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -38,6 +38,9 @@ use aether_substrate::actor::native::{
 };
 use aether_substrate::chassis::builder::{DriverCapability, DriverCtx, DriverRunning, RunError};
 use aether_substrate::chassis::error::BootError;
+use aether_substrate::chassis::settlement::{
+    TerminalDisposition, WaitOutcome, await_internal_signal,
+};
 use aether_substrate::runtime::lifecycle;
 use aether_substrate::{
     HubOutbound, Mailer, SharedActorSlots, SubstrateBoot,
@@ -58,6 +61,12 @@ use std::io;
 use std::sync::mpsc::Receiver;
 use std::time::Duration;
 use winit::dpi::PhysicalSize;
+
+/// Cumulative patience cap for the per-frame settlement gates (advance +
+/// capture pre-mail). The per-round budget is `frame_loop::DRAIN_BUDGET`
+/// (the log cadence); a starved-but-healthy chain resolves before this
+/// cap, a genuine wedge exhausts it (issue #1305).
+const FRAME_SETTLEMENT_CAP: Duration = Duration::from_secs(30);
 
 pub struct App {
     queue: Arc<Mailer>,
@@ -585,19 +594,20 @@ impl ApplicationHandler<UserEvent> for App {
                 }
                 if let Some(registry) = self.queue.settlement_registry() {
                     let rx = registry.subscribe_settlement(advance_root);
-                    if rx.recv_timeout(frame_loop::DRAIN_BUDGET).is_err() {
-                        // A frame chain that doesn't settle within the
-                        // drain budget is a wedged dispatcher — same
-                        // fail-fast disposition the old drain barrier
-                        // had (ADR-0063).
-                        lifecycle::fatal_abort(
-                            &self.outbound,
-                            format!(
-                                "frame chain wedged: LifecycleAdvance root {advance_root:?} did \
-                                 not settle within {:?}",
-                                frame_loop::DRAIN_BUDGET
-                            ),
-                        );
+                    // A frame chain that doesn't settle is a wedged
+                    // dispatcher — same fail-fast disposition the old
+                    // drain barrier had (ADR-0063). Escalating-patience
+                    // wait (issue #1305) replaces the bare wall-clock:
+                    // a starved-but-healthy chain resolves before the
+                    // cumulative cap, a genuine wedge exhausts it.
+                    if let WaitOutcome::Wedged(wedge) = await_internal_signal(
+                        &rx,
+                        "desktop.frame_advance",
+                        frame_loop::DRAIN_BUDGET,
+                        FRAME_SETTLEMENT_CAP,
+                        TerminalDisposition::Abort,
+                    ) {
+                        lifecycle::fatal_abort(&self.outbound, wedge.reason());
                     }
                 }
                 if let Some(gpu) = self.gpu.as_mut() {
@@ -614,12 +624,14 @@ impl ApplicationHandler<UserEvent> for App {
                             // the chassis).
                             let mut pre_failed: Option<String> = None;
                             for rx in req.pre_settlements {
-                                if rx.recv_timeout(Duration::from_secs(5)).is_err() {
-                                    pre_failed = Some(
-                                        "capture pre-mail chain failed to settle within 5s — \
-                                         a downstream cap is wedged"
-                                            .to_owned(),
-                                    );
+                                if let WaitOutcome::Wedged(wedge) = await_internal_signal(
+                                    &rx,
+                                    "desktop.capture_pre_mail",
+                                    frame_loop::DRAIN_BUDGET,
+                                    FRAME_SETTLEMENT_CAP,
+                                    TerminalDisposition::ReplyErr,
+                                ) {
+                                    pre_failed = Some(wedge.reason());
                                     break;
                                 }
                             }

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -42,6 +42,9 @@ use aether_kinds::{Advance, AdvanceResult, CaptureFrame, CaptureFrameResult};
 // shape kinds (e.g. FrameStats) flow through `frame_loop` helpers.
 use aether_actor::Actor;
 use aether_capabilities::{RenderCapability, fs::NamespaceRoots};
+use aether_substrate::chassis::settlement::{
+    TerminalDisposition, WaitOutcome, await_internal_signal,
+};
 use aether_substrate::{
     EgressEvent, HubOutbound, Mailer, PassiveChassis, RecordingBackend, ReplyTarget, ReplyTo,
     SubstrateBoot,
@@ -118,10 +121,16 @@ impl fmt::Display for TestBenchError {
     }
 }
 
-/// Per-send settlement timeout. Mirrors the `run_frame` tick wait at
-/// `bench.rs::run_frame`; long enough to absorb wasm compile + cap
-/// dispatcher wake under nextest CPU contention.
+/// Per-round settlement patience (the log cadence of the escalating
+/// wait). Mirrors the `run_frame` tick wait at `bench.rs::run_frame`;
+/// long enough to absorb wasm compile + cap dispatcher wake under
+/// nextest CPU contention.
 const SETTLEMENT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Cumulative patience cap before a settlement gate is declared wedged
+/// (issue #1305). A starved-but-healthy chain resolves before this cap;
+/// a genuine wedge exhausts it and surfaces `SettlementTimeout`.
+const SETTLEMENT_CAP: Duration = Duration::from_secs(30);
 
 impl error::Error for TestBenchError {}
 
@@ -469,9 +478,15 @@ impl TestBench {
             .queue
             .push_chassis_root_mail(cid, mailbox, kind, payload, 1);
         let rx = registry.subscribe_settlement(root);
-        match rx.recv_timeout(SETTLEMENT_TIMEOUT) {
-            Ok(()) => Ok(()),
-            Err(_) => Err(TestBenchError::SettlementTimeout {
+        match await_internal_signal(
+            &rx,
+            "test_bench.push_and_settle",
+            SETTLEMENT_TIMEOUT,
+            SETTLEMENT_CAP,
+            TerminalDisposition::ReplyErr,
+        ) {
+            WaitOutcome::Settled => Ok(()),
+            WaitOutcome::Wedged(_) => Err(TestBenchError::SettlementTimeout {
                 recipient: recipient_name.to_owned(),
                 kind_name,
             }),
@@ -1005,7 +1020,13 @@ impl TestBench {
                 // (no pre-mails, or a chassis without trace pipeline)
                 // skips the loop cleanly.
                 for rx in req.pre_settlements {
-                    if rx.recv_timeout(SETTLEMENT_TIMEOUT).is_err() {
+                    if let WaitOutcome::Wedged(_) = await_internal_signal(
+                        &rx,
+                        "test_bench.capture_pre_mail",
+                        SETTLEMENT_TIMEOUT,
+                        SETTLEMENT_CAP,
+                        TerminalDisposition::ReplyErr,
+                    ) {
                         return Err(TestBenchError::SettlementTimeout {
                             recipient: "capture pre-mail chain".to_owned(),
                             kind_name: "<pre-mail>",

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -27,6 +27,9 @@ use aether_data::{Kind, KindId, MailId, MailboxId, mailbox_id_from_name};
 use aether_kinds::trace::{
     DescribeTreeResult, MailNodeWire, TraceEvent, TraceRingEntry, TraceTail, TraceTailResult,
 };
+use aether_substrate::chassis::settlement::{
+    TerminalDisposition, WaitOutcome, await_internal_signal,
+};
 use aether_substrate::{BootError, NativeActor, NativeCtx, NativeDispatch, NativeInitCtx, Subname};
 
 use super::TestBench;
@@ -151,7 +154,31 @@ fn spawn_topology(tb: &TestBench, topo: &Topology) {
     }
 }
 
+/// Per-round settlement patience (the log cadence of the escalating
+/// wait, issue #1305).
 const SETTLE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Cumulative patience cap before a settlement gate panics attributably
+/// (issue #1305). A starved-but-healthy chain settles before this cap; a
+/// genuine wedge exhausts it and the helper `panic!`s at the gate site.
+const SETTLE_CAP: Duration = Duration::from_secs(50);
+
+/// Panic-on-wedge settlement wait shared by the mail-latency assertions:
+/// escalating patience under the wait, attributable panic at the gate on
+/// a genuine wedge instead of a downstream assertion. `Panic` diverges
+/// inside the helper, so a return means the chain settled.
+fn assert_settled(rx: &crossbeam_channel::Receiver<()>, gate: &str) {
+    match await_internal_signal(
+        rx,
+        gate,
+        SETTLE_TIMEOUT,
+        SETTLE_CAP,
+        TerminalDisposition::Panic,
+    ) {
+        WaitOutcome::Settled => {}
+        WaitOutcome::Wedged(_) => unreachable!("Panic disposition diverges on a wedge"),
+    }
+}
 
 /// Multi-worker saturation profile target (samply). Boots the pool at
 /// max workers, wires a ring of N `RingRelay` actors, seeds M circulating
@@ -257,10 +284,7 @@ fn depth_chain_settles_every_root() {
     }
 
     for (idx, (_root, rx)) in pending.iter().enumerate() {
-        assert!(
-            rx.recv_timeout(SETTLE_TIMEOUT).is_ok(),
-            "root {idx} never settled — per-root lineage accounting may be broken (in_flight stuck)"
-        );
+        assert_settled(rx, &format!("mlat.per_root_lineage[{idx}]"));
     }
 }
 
@@ -306,10 +330,7 @@ fn emit_settlement_settles_every_root(topo: &Topology) {
         pending.push(tb.inject_root(entry, Ping::ID, Ping { seq }.encode_into_bytes()));
     }
     for (idx, (_root, rx)) in pending.iter().enumerate() {
-        assert!(
-            rx.recv_timeout(SETTLE_TIMEOUT).is_ok(),
-            "root {idx} never settled — the emit-time counter must fire Settled"
-        );
+        assert_settled(rx, &format!("mlat.emit_time_counter[{idx}]"));
     }
 }
 
@@ -405,10 +426,7 @@ fn emit_settlement_settles_with_holds() {
         pending.push(tb.inject_root(entry, Ping::ID, Ping { seq }.encode_into_bytes()));
     }
     for (idx, (_root, rx)) in pending.iter().enumerate() {
-        assert!(
-            rx.recv_timeout(SETTLE_TIMEOUT).is_ok(),
-            "hold root {idx} never settled — the hold's Release must fire the counter"
-        );
+        assert_settled(rx, &format!("mlat.hold_release[{idx}]"));
     }
 }
 
@@ -454,10 +472,7 @@ fn trace_ring_dual_write_routes_events_to_owning_rings() {
 
     spawn_topology(&tb, &depth_chain(1));
     let (root, rx) = tb.inject_root(relay_id(0), Ping::ID, Ping { seq: 0 }.encode_into_bytes());
-    assert!(
-        rx.recv_timeout(SETTLE_TIMEOUT).is_ok(),
-        "injected root never settled"
-    );
+    assert_settled(&rx, "mlat.trace_ring_dual_write");
 
     // The recipient relay's own ring holds the mail's Received + Finished.
     let relay = trace_tail(&mut tb, "mlat.relay:0", root);
@@ -521,10 +536,7 @@ fn guided_walk_reconstructs_causal_tree() {
 
     spawn_topology(&tb, &two_level_tree());
     let (root, rx) = tb.inject_root(relay_id(0), Ping::ID, Ping { seq: 0 }.encode_into_bytes());
-    assert!(
-        rx.recv_timeout(SETTLE_TIMEOUT).is_ok(),
-        "injected root never settled"
-    );
+    assert_settled(&rx, "mlat.guided_walk");
 
     let mails = match tb.describe_tree_walked(root) {
         DescribeTreeResult::Ok { mails, .. } => mails,
@@ -761,10 +773,7 @@ fn settlement_detection_latency() {
         let t0 = Instant::now();
         let seq = u32::try_from(seq).unwrap_or(u32::MAX);
         let (_root, rx) = tb.inject_root(entry, Ping::ID, Ping { seq }.encode_into_bytes());
-        if rx.recv_timeout(SETTLE_TIMEOUT).is_err() {
-            eprintln!("settlement_detection_latency: root {seq} never settled");
-            return;
-        }
+        assert_settled(&rx, &format!("mlat.settlement_detection_latency[{seq}]"));
         lat.push(u64::try_from(t0.elapsed().as_nanos()).unwrap_or(u64::MAX));
     }
 


### PR DESCRIPTION
Part 2 of iamacoffeepot/aether#1305 — migrate the `aether-substrate-bundle` settlement gates onto the `await_internal_signal` helper landed in iamacoffeepot/aether#1306.

## What changed

Replaces seven hand-rolled `recv_timeout`-on-a-settlement-`Receiver` wall-clocks with the shared escalating-patience helper, preserving each gate's existing terminal behavior:

| Site | Disposition |
|------|-------------|
| `desktop/driver.rs` frame advance | `Abort` (wedge → existing `lifecycle::fatal_abort`) |
| `desktop/driver.rs` capture pre-mail | `ReplyErr` (reply `Err`, continue frame loop) |
| `bin/test-bench.rs` frame advance | `Abort` — reconciled from the prior `error!`-and-"submitting anyway" to match the desktop advance gate |
| `bin/test-bench.rs` capture pre-mail | `ReplyErr` |
| `test_bench/bench.rs` `push_and_settle` | `ReplyErr` → `TestBenchError::SettlementTimeout` |
| `test_bench/bench.rs` capture pre-mail | `ReplyErr` → `SettlementTimeout` |
| `test_bench/mail_latency.rs` ×6 | `Panic` via a local `assert_settled` wrapper |

Per-round budgets keep the prior wall-clock values (frame gates `frame_loop::DRAIN_BUDGET`, bench `SETTLEMENT_TIMEOUT`, latency `SETTLE_TIMEOUT`) as the log cadence, with new generous cumulative caps (`30s` frame/bench, `50s` latency) — the iamacoffeepot/aether#1306 precedent.

## Audit sites — all left as Bucket B (not migrated)

`test_chassis.rs:118`, `dag/tests.rs:149`, `inventory.rs:287` are all egress-drain loops on `Receiver<EgressEvent>` decoding a `ToSession` reply — external/loopback reply waits with the wrong receiver type, not internal-signal one-shots. Left unchanged.

## One behavior change worth noting

`mail_latency.rs` `settlement_detection_latency` (an `#[ignore]` on-demand measurement, not a CI gate) previously soft-skipped a non-settling sample; it now `Panic`s after the escalating-patience cap. For a deliberately-run latency measurement a wedged sample should fail loudly rather than print a bogus table. The driverless-box early `return` skip is preserved. The other five `mail_latency.rs` sites were already `assert!`s; their bespoke messages are preserved as distinct per-site gate names.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 1464 passed
- `cargo doc --workspace --no-deps` + wasm32 component cross-build (`scripts/preflight.sh`) — clean

This completes the iamacoffeepot/aether#1305 umbrella (Part 1 = iamacoffeepot/aether#1306, merged).

Closes iamacoffeepot/aether#1307

🤖 Generated with [Claude Code](https://claude.com/claude-code)
