### PR TITLE
docs(adr): codify where orchestration lives in the actor model

### DIFF
--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -1399,9 +1399,16 @@ impl<C: Chassis> BuiltChassis<C> {
         )
     }
 
-    /// Borrow the chassis's [`crate::ActorRegistry`]. Read-only;
-    /// embedders that want to introspect live instanced actors
-    /// (test assertions, diagnostics) reach for this.
+    /// Borrow the chassis's [`crate::ActorRegistry`]. Read-only,
+    /// introspection only: embedders that want to inspect live
+    /// instanced actors (test assertions, diagnostics) reach for this.
+    /// It is **not** the seam for in-handler fleet supervision or
+    /// fan-out-and-collect — orchestration is an async-layer concern,
+    /// not a handler one (ADR-0074 §9; `wait_reply` was retired in
+    /// #1201). A cap that needs to fan a request out to N peers does
+    /// it from the chassis driver, the DAG executor, or the
+    /// out-of-process client, never by walking this registry from a
+    /// handler.
     #[must_use]
     pub fn actor_registry(&self) -> &Arc<crate::ActorRegistry> {
         &self.booted.actor_registry
@@ -1536,9 +1543,16 @@ impl<C: Chassis> PassiveChassis<C> {
         )
     }
 
-    /// Borrow the chassis's [`crate::ActorRegistry`]. Read-only;
-    /// embedders that want to introspect live instanced actors
-    /// (test assertions, diagnostics) reach for this.
+    /// Borrow the chassis's [`crate::ActorRegistry`]. Read-only,
+    /// introspection only: embedders that want to inspect live
+    /// instanced actors (test assertions, diagnostics) reach for this.
+    /// It is **not** the seam for in-handler fleet supervision or
+    /// fan-out-and-collect — orchestration is an async-layer concern,
+    /// not a handler one (ADR-0074 §9; `wait_reply` was retired in
+    /// #1201). A cap that needs to fan a request out to N peers does
+    /// it from the chassis driver, the DAG executor, or the
+    /// out-of-process client, never by walking this registry from a
+    /// handler.
     #[must_use]
     pub fn actor_registry(&self) -> &Arc<crate::ActorRegistry> {
         &self.booted.actor_registry

--- a/docs/adr/0074-unified-actor-model-for-substrate-and-guests.md
+++ b/docs/adr/0074-unified-actor-model-for-substrate-and-guests.md
@@ -175,6 +175,20 @@ Capabilities communicate with each other the same way components communicate wit
 
 The frame-bound→free-running guard from decision 6 lives at the top of this function.
 
+**Amendment (2026-06-04): `wait_reply` retired; orchestration is not a handler concern.**
+
+The host-side `wait_reply` described above shipped (phase 4) but went unused and was retired in #1201. The unified model settled on a stricter stance, decided by attrition rather than fiat: **cap/actor handlers do not block on replies, and do not orchestrate.** A handler runs to completion as a single-threaded unit on the blob scheduler (ADR-0087); a blocking in-handler wait parks a scheduler worker and couples handler latency to peer latency.
+
+Request/reply between actors is still mail — the responder `ctx.reply()`s and the originator observes the reply asynchronously. What does *not* belong in a handler is fan-out-and-collect ("wait for N peers' replies"). That is orchestration, and it lives in one of three async homes:
+
+- the **chassis driver** — the free-running run loop plus settlement subscriptions (`SettlementRegistry::subscribe_settlement`, ADR-0080/0086);
+- the **DAG executor** — a typed transform graph (ADR-0047), for compute fan-out;
+- the **out-of-process MCP client** — e.g. `send_mail_traced`, an atomic batch under one trace root that returns the settled reply subtree.
+
+Settlement is the "tell me when this chain is done" mechanism, and it is consumed from the async layer, never from a handler. The frame-bound → free-running guard from decision 6 still applies to any remaining synchronous cross-class call.
+
+Background: issue #960 catalogued the frictions of building an in-handler fan-out aggregator (the per-actor log aggregator for ADR-0081) and posed the fork "ship `ctx.gather()` vs codify orchestration-lives-elsewhere." Retiring `wait_reply` answered it: elsewhere.
+
 ### 10. Scoping: runtime contact surface vs chassis-driver-internal
 
 "Everything is mail" applies to the **runtime contact surface** — the surface reachable by components, the hub, peer capabilities, and any other actor in the system. Through that surface, every actor is reached only via its mailbox.


### PR DESCRIPTION
Codifies the architectural rule that emerged from iamacoffeepot/aether#960, and closes it.

## Background

iamacoffeepot/aether#960 catalogued the frictions of building a substrate-side fan-out aggregator (the per-actor log aggregator for ADR-0081) and posed a fork: ship an in-handler `ctx.gather()` primitive, or codify "orchestration lives in the chassis driver / out-of-process." It was parked with no forcing function.

The codebase answered the fork by attrition. The primitive every friction in that issue was anchored on — `NativeCtx::wait_reply<K, E: WaitError>` — shipped (ADR-0074 phase 4), went unused, and was **retired in iamacoffeepot/aether#1201**. There is now no way for a handler to block on a reply at all. ~70% of iamacoffeepot/aether#960's body describes APIs (`wait_reply`, `WaitError`, the old `actor_registry()` anti-pattern doc-comment) that no longer exist. The decision is made; the durable thing to keep is the rule, written down.

## What changed

- **ADR-0074 §9** gets a dated amendment: `wait_reply` retired; cap/actor handlers run to completion and do not block on or orchestrate replies. Request/reply stays mail (responder `ctx.reply()`s, originator observes asynchronously); fan-out-and-collect is orchestration and lives in one of three async homes — the chassis driver + settlement subscriptions (ADR-0080/0086), the DAG executor (ADR-0047), or the out-of-process MCP client (`send_mail_traced`). The historical decision text is preserved; the amendment records the reversal and the rationale (a blocking in-handler wait parks a blob-scheduler worker and couples handler latency to peer latency, ADR-0087).
- **`actor_registry()` doc-comments** (both builder types) tightened to "introspection only — not the seam for in-handler fleet supervision or fan-out," pointing at the ADR-0074 amendment. Restores the intent of the anti-pattern warning friction 3 cited, which had been dropped.

Docs + doc-comments only; no behavior change.

## Verification

`scripts/preflight.sh` — fmt, clippy `--all-targets -D warnings`, doc, nextest (1464 passed), wasm32 component cross-build — all green.

Closes iamacoffeepot/aether#960

🤖 Generated with [Claude Code](https://claude.com/claude-code)
