### PR TITLE
fix(substrate-bundle): bound desktop present loop to one frame in flight

### DIFF
--- a/crates/aether-substrate-bundle/src/desktop/render.rs
+++ b/crates/aether-substrate-bundle/src/desktop/render.rs
@@ -67,6 +67,21 @@ pub struct Gpu {
     /// pipeline as an extra inside the same render pass.
     wire_pipeline: Option<wgpu::RenderPipeline>,
     render_handles: RenderHandles,
+    /// Submission index of the previous frame's `queue.submit`, drained
+    /// at the top of the next `render_impl` to bound the window present
+    /// loop to one frame in flight (iamacoffeepot/aether#1312).
+    ///
+    /// Without this bound the loop submits + presents as fast as
+    /// `nextDrawable` backpressure allows (up to `maximumDrawableCount`
+    /// = 3 frames of command buffers overlapping). Under sustained
+    /// rendering that exposes a use-after-free in Metal/IOGPU's command-
+    /// buffer completion path (`IOGPUMetalCommandBufferStorageReset` on
+    /// `com.Metal.CompletionQueueDispatch`): the completion handler for
+    /// an earlier frame tears its command buffer down while the main
+    /// thread is acquiring/submitting a later one. Draining the prior
+    /// submission first means that teardown runs while this thread is
+    /// parked in `device.poll`, never racing the next submit.
+    last_submission: Option<wgpu::SubmissionIndex>,
 }
 
 /// Wireframe rendering mode, set at boot via `AETHER_WIREFRAME`.
@@ -276,6 +291,7 @@ impl Gpu {
             limits,
             wire_pipeline,
             render_handles,
+            last_submission: None,
         }
     }
 
@@ -315,6 +331,28 @@ impl Gpu {
     fn render_impl(&mut self, capture: bool) -> Option<Result<Vec<u8>, String>> {
         let device = self.render_handles.device();
         let queue = self.render_handles.queue();
+
+        // Bound the loop to one frame in flight (iamacoffeepot/aether#1312):
+        // block until the previous frame's submission has fully completed
+        // before recording the next. This drains the prior frame's command-
+        // buffer completion (and its Metal/IOGPU teardown) while this thread
+        // is parked here, so it can't race the acquire/submit below — and it
+        // serialises writes to the shared persistent vertex/camera buffers
+        // against the prior frame's reads. `poll` errors (a lost device)
+        // fall through to `acquire_surface_texture`, which reconfigures.
+        if let Some(index) = self.last_submission.take()
+            && let Err(error) = device.poll(wgpu::PollType::Wait {
+                submission_index: Some(index),
+                timeout: None,
+            })
+        {
+            tracing::warn!(
+                target: "aether_substrate::render",
+                ?error,
+                "device.poll for previous frame failed; continuing",
+            );
+        }
+
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             label: Some("frame encoder"),
         });
@@ -378,7 +416,11 @@ impl Gpu {
             });
         }
 
-        queue.submit(iter::once(encoder.finish()));
+        // Retain the submission index so the next frame can wait on it
+        // (see `last_submission`). The present command buffer wgpu creates
+        // internally is committed after this submit and bounded by
+        // `nextDrawable`, so it needs no separate tracking.
+        self.last_submission = Some(queue.submit(iter::once(encoder.finish())));
         if let Some(tex) = surface_tex {
             tex.present();
         }


### PR DESCRIPTION
## Summary

The desktop chassis SIGSEGVs under sustained windowed rendering — an `EXC_BAD_ACCESS` on the `com.Metal.CompletionQueueDispatch` thread inside `IOGPUMetalCommandBufferStorageReset` (faulting near-null at `0x100000018`), while the main thread is parked in `CAMetalLayer nextDrawable`. An idle, componentless boot is stable; the crash needs a component driving a full redraw every tick.

## Root cause

The present path is correct per wgpu's contract — retained command-buffer references are on, so Metal keeps encoded resources (offscreen targets, the drawable's texture, the drawable itself) alive until completion. So the use-after-free is upstream in Metal/IOGPU's command-buffer completion teardown, and it only surfaces when **several frames' command buffers overlap in flight**: the swapchain allows `maximumDrawableCount = desired_maximum_frame_latency + 1 = 3`, so the completion handler for an earlier frame can tear its command buffer down on the dispatch thread while the main thread is acquiring/submitting a later one. That overlap is exactly the state the crash report captures.

## Fix

Bound the loop to one frame in flight: retain each frame's `SubmissionIndex` and, at the top of the next `render_impl`, block on `device.poll(Wait)` until that submission has fully completed before recording the next frame. The prior frame's completion (and its Metal/IOGPU teardown) then runs while the thread is parked in `poll`, never racing the next submit, and writes to the shared persistent vertex/camera buffers are serialised against the prior frame's reads.

wgpu-hal's Metal wait sleeps in 1 ms increments, so the per-frame sync is cheap for an interactive viewer; on a 39k-triangle scene the substrate's CPU drops noticeably (the thread parks rather than spinning the redraw loop as fast as `nextDrawable` allows).

## Verification

The fault is in the windowed present path, which CI cannot exercise (the test-bench and headless chassis have no surface), so there is no added automated test — this is verified manually against the live desktop chassis via the hub harness:

- fmt / clippy (`-D warnings`) / the RustRover inspector all clean on the change.
- The patched binary loads and renders a 39k-triangle scene; CPU profile confirms the one-frame-in-flight serialisation (the thread parks in `poll` instead of spinning).
- No crash across sustained runs.

Note on the limits: the crash is a rare upstream race. The baseline binary did not reproduce it on demand across ~15 minutes of heavy sustained rendering this session, so a clean crashed-before / clean-after A/B was not achievable — the fix is justified by the crash signature plus the analysis above, and removes the overlapping-presentation precondition the report shows.

Closes iamacoffeepot/aether#1312
