### PR TITLE
fix(substrate-bundle): desktop chassis replies via the mailer, not hub outbound

### DIFF
--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -93,10 +93,20 @@ pub struct App {
     render_handles: RenderHandles,
     /// Shared single-slot queue with the control plane. On each
     /// redraw we `take()` any pending capture and, if present, use
-    /// `render_and_capture`, then reply-to-sender on `outbound`.
+    /// `render_and_capture`, then reply to the sender via
+    /// `queue.send_reply` (the `Mailer`, which routes every
+    /// `ReplyTarget` — see `outbound`).
     capture_queue: CaptureQueue,
-    /// Hub outbound — shared with the log-capture layer and the
-    /// capture-reply path.
+    /// Hub outbound — held for log egress to the hub and
+    /// `lifecycle::fatal_abort`. NOT used for chassis replies:
+    /// `HubOutbound::send_reply` only routes `Session` / `EngineMailbox`
+    /// targets and silently drops `ReplyTarget::Component`, but mail
+    /// dispatched by this engine's own `RpcServerCapability` (every
+    /// hub/MCP call lands via the proxy → local RPC server) carries a
+    /// `Component(rpc_server)` reply target. Replies go through
+    /// `self.queue.send_reply` (the `Mailer`) instead, which pushes the
+    /// reply as local mail so the RPC server's `on_any` lifts it into a
+    /// `ReplyEvent` (iamacoffeepot/aether#1316).
     outbound: Arc<HubOutbound>,
     window: Option<Arc<Window>>,
     gpu: Option<Gpu>,
@@ -450,7 +460,7 @@ impl App {
             let payload: SetWindowMode = match postcard::from_bytes(env.payload.bytes()) {
                 Ok(p) => p,
                 Err(e) => {
-                    self.outbound.send_reply(
+                    self.queue.send_reply(
                         env.sender,
                         &SetWindowModeResult::Err {
                             error: format!("postcard decode failed: {e}"),
@@ -460,12 +470,12 @@ impl App {
                 }
             };
             let result = self.apply_window_mode(payload.mode, payload.width, payload.height);
-            self.outbound.send_reply(env.sender, &result);
+            self.queue.send_reply(env.sender, &result);
         } else if env.kind == self.kind_set_window_title {
             let payload: SetWindowTitle = match postcard::from_bytes(env.payload.bytes()) {
                 Ok(p) => p,
                 Err(e) => {
-                    self.outbound.send_reply(
+                    self.queue.send_reply(
                         env.sender,
                         &SetWindowTitleResult::Err {
                             error: format!("postcard decode failed: {e}"),
@@ -475,7 +485,7 @@ impl App {
                 }
             };
             let result = self.apply_window_title(payload.title);
-            self.outbound.send_reply(env.sender, &result);
+            self.queue.send_reply(env.sender, &result);
         } else {
             tracing::warn!(
                 target: "aether_substrate::driver",
@@ -643,7 +653,7 @@ impl ApplicationHandler<UserEvent> for App {
                                 //noinspection DuplicatedCode
                                 self.queue.push(mail);
                             }
-                            self.outbound.send_reply(req.reply_to, &result);
+                            self.queue.send_reply(req.reply_to, &result);
                             // iamacoffeepot/aether#1273: `req` still owns
                             // `PendingCapture._hold` after the partial moves
                             // above; the field drops at end of this scope —
@@ -657,7 +667,7 @@ impl ApplicationHandler<UserEvent> for App {
                         }
                     }
                 } else if let Some(req) = pending_capture {
-                    self.outbound.send_reply(
+                    self.queue.send_reply(
                         req.reply_to,
                         &CaptureFrameResult::Err {
                             error: "capture requested before GPU initialized".to_owned(),


### PR DESCRIPTION
## Summary

`capture_frame` against a hub-spawned desktop engine failed with `expected exactly one reply event, got 0` — the call's terminal `ReplyEnd` reached `aether-mcp` with zero `ReplyEvent`s. Occlusion was ruled out: a visible, actively-rendering window failed identically.

## Root cause

The desktop driver replied to chassis calls — the deferred `capture_frame` reply, and `set_window_mode` / `set_window_title` — through `HubOutbound::send_reply`, which only routes `Session` / `EngineMailbox` targets and **silently drops `ReplyTarget::Component`**.

But an MCP-spawned engine receives mail via its own `RpcServerCapability` (the hub's proxy dials the substrate's RPC port), and that dispatch tags the reply target `Component(rpc_server)` so replies route back **locally** to the server's `on_any`, which lifts them into a wire `ReplyEvent`. The driver's reply was dropped before it ever reached `on_any`; only `Settled` arrived, closing the call with a bare `ReplyEnd` and no events.

Confirmed by instrumenting the path: the driver rendered and called `send_reply` (Ok), `on_settled` fired, and `on_any` was **never** called.

## Fix

Route these replies through `self.queue.send_reply` (the `Mailer`) instead. The `Mailer` is the complete router: it delegates `Session` / `EngineMailbox` to the same `HubOutbound` (unchanged for hub-originated calls) and handles `Component` by pushing the reply as local mail with the correlation echoed — exactly what the RPC server's reply correlation needs. `HubOutbound` stays on the struct for log egress and `lifecycle::fatal_abort`.

This also fixes the same latent drop in the window `set_mode` / `set_title` replies (masked because `send_mail` tolerates zero reply events, while `capture_frame`'s `call_one` requires exactly one).

## Verification

The windowed RPC reply path isn't reachable from the test-bench / headless chassis (no surface, no proxy), so this is verified manually over the MCP harness rather than by an added test (the in-process test-bench capture test passes because its loopback reply target is `Session` — which is exactly why this slipped through). `capture_frame` on a spawned desktop engine now returns the PNG: confirmed on a bare clear-color frame and on a rendered mesh.

Closes iamacoffeepot/aether#1316
