### PR TITLE
feat(substrate): dispatch_blocking + TaskDone hold-until-resolve runtime

### DIFF
--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -36,6 +36,7 @@
 //! traits in `aether_actor::actor::ctx` are the only cross-target
 //! abstraction.
 
+use std::any::Any;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::Receiver;
@@ -49,6 +50,7 @@ use crate::mail::mailer::Mailer;
 use crate::mail::ring::{MailLoc, MailRing, RingFull};
 use crate::mail::{KindId, Mail, MailId, MailRef, MailboxId, ReplyTarget, ReplyTo};
 use crate::runtime::lifecycle::{FatalAborter, PanicAborter};
+use crate::runtime::trace::SettlementHold;
 
 /// Per-actor outbound ring capacity (ADR-0087). Sized to hold a typical
 /// handler's small-mail fan-out as one blob; a mail that doesn't fit (a
@@ -202,6 +204,16 @@ pub struct NativeBinding {
     /// eager per-mail route. `Mutex` only for `&self` interior mutability —
     /// driven solely from this actor's dispatch thread, so uncontended.
     blob_producer: Mutex<Option<super::blob_work::BlobProducer>>,
+    /// ADR-0093: the hold-until-resolve in-flight ledger. Maps a
+    /// [`DispatchId`](super::dispatch_blocking::DispatchId) minted by
+    /// [`super::ctx::NativeCtx::dispatch_blocking`] to its held
+    /// `(SettlementHold, ReplyTo, context)` plus the worker's eventual
+    /// output. The actor thread writes the entry at dispatch and reads +
+    /// removes it when the completion-wake lands; the worker thread fills
+    /// the output slot once. `Mutex` only for `&self` interior
+    /// mutability — the same single-logical-writer discipline as
+    /// `outbound` / `blob_producer`.
+    inflight: super::dispatch_blocking::InflightLedger,
 }
 
 impl NativeBinding {
@@ -236,6 +248,7 @@ impl NativeBinding {
             shutdown_flag: Arc::new(AtomicBool::new(false)),
             outbound: Mutex::new(OutboundBuffer::new()),
             blob_producer: Mutex::new(None),
+            inflight: Mutex::new(super::dispatch_blocking::InflightTable::new()),
         }
     }
 
@@ -798,6 +811,70 @@ impl NativeBinding {
     /// reply with the request it sent.
     pub fn prev_correlation(&self) -> u64 {
         self.correlation.load(Ordering::Acquire)
+    }
+}
+
+/// ADR-0093 hold-until-resolve dispatch: the `&self`-interior-mutability
+/// bridge between [`super::ctx::NativeCtx`]'s dispatch primitive and the
+/// per-actor [`super::dispatch_blocking::InflightTable`]. Each method
+/// takes the table lock for one operation — mint+insert at dispatch,
+/// fill-output from the worker, take at completion — matching the
+/// `outbound` / `blob_producer` locking pattern (uncontended, single
+/// logical writer).
+impl NativeBinding {
+    /// Insert a freshly-minted in-flight dispatch entry and return its
+    /// [`DispatchId`](super::dispatch_blocking::DispatchId). Called on
+    /// the actor thread at dispatch time, after the hold is acquired and
+    /// before the worker spawns.
+    ///
+    /// # Panics
+    /// Panics if the in-flight ledger mutex is poisoned — fail-fast per
+    /// ADR-0063.
+    pub(crate) fn dispatch_insert(
+        &self,
+        hold: SettlementHold,
+        reply_to: ReplyTo,
+        context: Box<dyn Any + Send>,
+    ) -> super::dispatch_blocking::DispatchId {
+        self.inflight
+            .lock()
+            .expect("in-flight ledger poisoned; fail-fast per ADR-0063")
+            .dispatch_insert(hold, reply_to, context)
+    }
+
+    /// Fill the worker's output into the named dispatch's completion
+    /// slot. Called once, on the worker thread, before it pushes the
+    /// [`TaskCompletionWake`](super::dispatch_blocking::TaskCompletionWake).
+    ///
+    /// # Panics
+    /// Panics if the in-flight ledger mutex is poisoned — fail-fast per
+    /// ADR-0063.
+    pub(crate) fn dispatch_fill_output(
+        &self,
+        id: super::dispatch_blocking::DispatchId,
+        output: Box<dyn Any + Send>,
+    ) {
+        self.inflight
+            .lock()
+            .expect("in-flight ledger poisoned; fail-fast per ADR-0063")
+            .dispatch_fill_output(id, output);
+    }
+
+    /// Remove the named dispatch entry and rebuild its
+    /// [`TaskDone`](super::dispatch_blocking::TaskDone). Called on the
+    /// actor thread when the completion-wake mail lands.
+    ///
+    /// # Panics
+    /// Panics if the in-flight ledger mutex is poisoned — fail-fast per
+    /// ADR-0063.
+    pub(crate) fn dispatch_take<O: 'static, C: 'static>(
+        &self,
+        id: super::dispatch_blocking::DispatchId,
+    ) -> Option<super::dispatch_blocking::TaskDone<O, C>> {
+        self.inflight
+            .lock()
+            .expect("in-flight ledger poisoned; fail-fast per ADR-0063")
+            .dispatch_take(id)
     }
 }
 

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -36,9 +36,10 @@ use crate::mail::mailer::Mailer;
 use super::{NativeActor, NativeDispatch};
 use crate::actor::native::InheritCtx;
 use crate::actor::native::RootCtx;
+use crate::actor::native::dispatch_blocking::{DispatchId, TaskCompletionWake, TaskDone};
 use crate::actor::native::spawn_thread;
-use crate::mail::ReplyTarget;
-use std::thread::JoinHandle;
+use crate::mail::{Mail, ReplyTarget};
+use std::thread::{Builder as ThreadBuilder, JoinHandle};
 
 /// Per-mail context for a [`NativeActor`] handler. Borrows the
 /// actor's [`NativeBinding`] for outbound mail and carries the
@@ -146,6 +147,114 @@ impl<'a> NativeCtx<'a> {
         spawn_thread::spawn_detached::<A, F>(Arc::clone(self.binding), f)
     }
 
+    /// ADR-0093 hold-until-resolve dispatch: run the blocking closure
+    /// `f` on a worker thread and reply to the current caller in a
+    /// *later* handler turn, when the worker's output lands.
+    ///
+    /// The settlement hold is acquired **eagerly on this thread, before
+    /// the worker spawns** (so `HoldOpen` precedes this handler's
+    /// `Finished` and the #716 premature-settlement window is closed by
+    /// construction), then parked in the per-actor in-flight ledger
+    /// alongside the originating [`ReplyTo`] — it outlives the worker
+    /// (which holds nothing) and releases only when the completion is
+    /// resolved. `MailId::NONE` for [`Self::in_flight_root`] skips the
+    /// hold cleanly (no chain to hold), matching `spawn_inherit`.
+    ///
+    /// When `f` returns, the worker stores the output in the ledger's
+    /// completion slot and pushes a [`TaskCompletionWake`] to this
+    /// actor's own mailbox (the loopback-wake mechanism). The actor's
+    /// completion handler decodes that wake's [`DispatchId`] and calls
+    /// [`Self::take_task_done`] to rebuild the [`TaskDone`], then
+    /// `resolve`s it.
+    ///
+    /// Returns the [`DispatchId`] for *optional* cancellation; the happy
+    /// path ignores it.
+    pub fn dispatch_blocking<O, F>(&mut self, f: F) -> DispatchId
+    where
+        O: Send + 'static,
+        F: FnOnce() -> O + Send + 'static,
+    {
+        self.dispatch_blocking_with::<O, (), F>((), f)
+    }
+
+    /// Context-carrying variant of [`Self::dispatch_blocking`]
+    /// (ADR-0093 §5): parks `cx` in the in-flight ledger alongside the
+    /// hold + reply target so the completion handler receives a
+    /// [`TaskDone<O, C>`] whose [`TaskDone::context`] is `cx`. Use when
+    /// the completion genuinely needs actor-thread state the pure worker
+    /// shouldn't take.
+    pub fn dispatch_blocking_with<O, C, F>(&mut self, cx: C, f: F) -> DispatchId
+    where
+        O: Send + 'static,
+        C: Send + 'static,
+        F: FnOnce() -> O + Send + 'static,
+    {
+        // Two deferred follow-ups, both behind this exact call-site API:
+        //   - per-source concurrency bound + pending queue
+        //     (InFlightDispatch::max_in_flight, default 4) so the paid-
+        //     endpoint rate limit (ADR-0050 §2) is honoured — lands with
+        //     the content-gen migration (#1313). PR1a dispatches at once.
+        //   - the per-request thread spawn below is a placeholder; the
+        //     scalable form is a reused work-stealing blocking pool,
+        //     isolated from the cooperative scheduler so blocking work
+        //     can't starve it (#1322).
+        //
+        // ADR-0093 §1 / ADR-0080 §12: eager-acquire the hold on this
+        // thread before spawning, exactly like `spawn_inherit`. The
+        // `MailId::NONE` root skips it — no chain to keep open.
+        let root = self.in_flight_root;
+        let hold = self.mailer().acquire_settlement_hold(root);
+        let reply_to = self.sender;
+        let id = self.binding.dispatch_insert(hold, reply_to, Box::new(cx));
+
+        // The worker captures the binding + dispatch id, runs the
+        // blocking closure, parks its output in the ledger, then pushes
+        // the completion-wake to the actor's own mailbox. It touches no
+        // actor state beyond the ledger slot it owns and dies after the
+        // push. This is the one sanctioned raw spawn for the
+        // hold-until-resolve shape (ADR-0093) — umbrella-aware because
+        // the hold (held in the ledger, not here) keeps the chain open
+        // until the resolve.
+        let binding = Arc::clone(self.binding);
+        let spawned = ThreadBuilder::new()
+            .name(String::from("aether-dispatch-blocking"))
+            .spawn(move || {
+                let output = f();
+                binding.dispatch_fill_output(id, Box::new(output));
+                let wake = TaskCompletionWake { dispatch_id: id.0 };
+                let self_id = binding.self_mailbox();
+                binding.mailer().push(Mail::new(
+                    self_id,
+                    TaskCompletionWake::ID,
+                    wake.encode_into_bytes(),
+                    1,
+                ));
+            });
+        if let Err(e) = spawned {
+            tracing::error!(
+                target: "aether_substrate::actor::native::dispatch_blocking",
+                error = %e,
+                "failed to spawn dispatch_blocking worker thread",
+            );
+        }
+        id
+    }
+
+    /// ADR-0093 completion-routing entry point: remove the in-flight
+    /// ledger entry named by `id` (decoded from a landed
+    /// [`TaskCompletionWake`]) and rebuild its [`TaskDone<O, C>`]. The
+    /// (future) `#[handler(task)]` macro — and, for now, a hand-wired
+    /// completion handler — calls this and then `resolve`s the result.
+    ///
+    /// `None` for an unknown id (cancelled or double-landed) or an `O` /
+    /// `C` that doesn't match the dispatch's types (a wiring bug).
+    pub fn take_task_done<O: 'static, C: 'static>(
+        &mut self,
+        id: DispatchId,
+    ) -> Option<TaskDone<O, C>> {
+        self.binding.dispatch_take::<O, C>(id)
+    }
+
     /// ADR-0080 §5: the [`MailId`] of the mail currently being
     /// dispatched. Read by outbound `send` paths to stamp
     /// `parent_mail` on child mail. `MailId::NONE` when the ctx was
@@ -202,6 +311,19 @@ impl<'a> NativeCtx<'a> {
     #[must_use]
     pub fn resolve_actor<R: Actor>(&self, name: &str) -> NativeActorMailbox<'_, R> {
         NativeActorMailbox::__new(mailbox_id_from_name(name).0, self.binding)
+    }
+
+    /// Reply to an explicit [`ReplyTo`] rather than the inbound's own
+    /// sender. The ADR-0093 hold-until-resolve path reaches for this:
+    /// [`TaskDone::resolve`](super::dispatch_blocking::TaskDone::resolve)
+    /// re-replies through the *originating* caller's reply target
+    /// (captured at dispatch, parked in the in-flight ledger), not the
+    /// completion-wake's sender (the worker thread's loopback mail, which
+    /// has no caller behind it). Routes through the same
+    /// [`NativeBinding::send_reply_for_handler`] path as
+    /// [`MailCtx::reply`].
+    pub fn reply_to_target<K: Kind + serde::Serialize>(&mut self, sender: ReplyTo, payload: &K) {
+        self.binding.send_reply_for_handler(sender, payload);
     }
 
     /// Issue 607 Phase 4a (ADR-0079): self-shutdown signal. Sets a

--- a/crates/aether-substrate/src/actor/native/dispatch_blocking.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch_blocking.rs
@@ -1,0 +1,656 @@
+//! ADR-0093 hold-until-resolve dispatch primitive (runtime half).
+//!
+//! The third spawn shape (alongside `spawn_inherit` and
+//! `spawn_detached`, see [`super::spawn_thread`]): *work that replies in a
+//! later handler turn*. A handler kicks off a slow blocking call, the
+//! worker pushes its result and dies, and the real reply is sent from a
+//! *subsequent* handler invocation when that result lands. The
+//! settlement hold must outlive the worker — it spans accept → the later
+//! re-reply — so neither `spawn_inherit` (hold dies with the worker) nor
+//! `spawn_detached` (no hold) fits.
+//!
+//! This generalises the content-gen `InFlightDispatch` prototype
+//! (`aether_capabilities::contentgen::dispatch`) into a first-class
+//! ctx primitive. The pieces:
+//!
+//! - [`DispatchId`] — a `Copy` correlation token minted per dispatch.
+//! - [`TaskDone`] — a move-only completion that carries the worker's
+//!   output, the originating [`ReplyTo`], the held [`SettlementHold`],
+//!   and an opt-in context `C`. Its consuming [`TaskDone::resolve`]
+//!   re-replies through the carried reply target **first**, then drops
+//!   the hold (`Sent` before `Release`, ADR-0080 §12). Dropping a
+//!   `TaskDone` without resolving releases the hold and `debug_assert`s
+//!   (a silent lost reply).
+//! - the in-flight ledger (`InflightTable`) — a per-actor map from
+//!   `DispatchId` to its held `(hold, reply_to, context)` plus a
+//!   completion output slot the worker fills. Lives behind a `&self`
+//!   interior-mutability `Mutex` on [`NativeBinding`](super::binding),
+//!   like `outbound` / `blob_producer`; the single logical writer is the
+//!   actor's own dispatch thread.
+//! - [`TaskCompletionWake`] — a substrate-internal framework kind the
+//!   worker pushes (carrying just the `DispatchId`) to the actor's own
+//!   mailbox, the same loopback-wake mechanism `InFlightDispatch`'s
+//!   worker uses to wake the actor.
+//!
+//! The request side and completion routing live on
+//! [`NativeCtx`](super::ctx): `dispatch_blocking` /
+//! `dispatch_blocking_with` spawn the worker, and `take_task_done`
+//! reunites the worker's output with the held `(hold, reply_to,
+//! context)` when the completion-wake mail lands. The
+//! `#[handler(task)]` macro sugar that hand-wires the completion handler
+//! is a separate later PR; for now a handler matches
+//! [`TaskCompletionWake`] explicitly and calls `take_task_done` itself.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use aether_data::{Kind, KindId};
+
+use crate::mail::ReplyTo;
+use crate::runtime::trace::SettlementHold;
+
+use super::ctx::NativeCtx;
+
+/// A `Copy` correlation token minted monotonically per
+/// [`dispatch_blocking`](NativeCtx::dispatch_blocking). Names one
+/// in-flight dispatch in the `InflightTable`; rides the
+/// [`TaskCompletionWake`] mail so the completion routes back to the
+/// right ledger entry. Returned to the call site for *optional*
+/// cancellation — the happy path ignores it.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct DispatchId(pub u64);
+
+/// Substrate-internal framework kind the dispatch worker pushes to the
+/// actor's own mailbox when its blocking closure finishes. Carries only
+/// the [`DispatchId`] — the worker's output rides the ledger entry's
+/// completion slot, not the wire — so a non-serializable `O` never has
+/// to encode. The actor's completion handler decodes this, then calls
+/// [`NativeCtx::take_task_done`] to reunite output + held state.
+///
+/// Hand-rolled `Kind` (the cast-shape path): a `#[repr(C)]` `u64` body
+/// that casts to / from bytes. Substrate-internal, so it is not derived
+/// (no inventory submission, no `describe_kinds` surface) — it never
+/// crosses the wire to a guest or the hub.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct TaskCompletionWake {
+    /// The [`DispatchId`] of the dispatch whose worker just finished.
+    pub dispatch_id: u64,
+}
+
+impl Kind for TaskCompletionWake {
+    const NAME: &'static str = "aether.dispatch.task_completion_wake";
+    // Minted the same way `#[derive(Kind)]` mints a tagged kind id, so
+    // the id is stable and tag-checks like any other kind on the wire
+    // path the worker pushes through.
+    const ID: KindId = KindId(aether_data::with_tag(
+        aether_data::Tag::Kind,
+        aether_data::fnv1a_64_prefixed(aether_data::KIND_DOMAIN, Self::NAME.as_bytes()),
+    ));
+
+    fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() != size_of::<Self>() {
+            return None;
+        }
+        Some(bytemuck::pod_read_unaligned(bytes))
+    }
+
+    fn encode_into_bytes(&self) -> Vec<u8> {
+        bytemuck::bytes_of(self).to_vec()
+    }
+}
+
+/// One in-flight dispatch's held state, parked in the [`InflightTable`]
+/// from the dispatching handler's return until its completion lands.
+///
+/// The actor thread writes the entry at dispatch time (the hold, reply
+/// target, and context, with the output empty); the worker fills
+/// `output` under the table mutex when its closure returns and pushes the
+/// [`TaskCompletionWake`]; the actor reads + removes the entry when that
+/// wake lands ([`NativeCtx::take_task_done`]).
+struct InflightEntry {
+    /// The [`SettlementHold`] acquired eagerly in the dispatching
+    /// handler (before it returned), keeping the chain root open across
+    /// the async worker. Released only after the re-reply, via
+    /// [`TaskDone::resolve`].
+    hold: SettlementHold,
+    /// The originating caller's reply target, captured at dispatch. The
+    /// re-reply routes through this.
+    reply_to: ReplyTo,
+    /// The opt-in completion context (`()` for the bare
+    /// [`dispatch_blocking`](NativeCtx::dispatch_blocking)). Boxed so
+    /// heterogeneous `C`s share one table type; downcast in
+    /// `take_task_done`.
+    context: Box<dyn Any + Send>,
+    /// The worker's output, filled under the table mutex when the
+    /// closure returns and taken in `take_task_done`. Boxed for the same
+    /// heterogeneity reason; `None` until the worker finishes.
+    output: Option<Box<dyn Any + Send>>,
+}
+
+/// Per-actor in-flight ledger for hold-until-resolve dispatch (ADR-0093
+/// §2). Maps a [`DispatchId`] to its held `(hold, reply_to, context)`
+/// plus the worker's eventual output. Opaque framework plumbing — it
+/// holds none of the cap's *business* state, only the primitive's own
+/// bookkeeping, so centralising it here doesn't violate the
+/// plain-actor-state rule (ADR-0038).
+///
+/// The `Mutex` is for `&self` interior mutability + `Sync` only, like
+/// [`NativeBinding`](super::binding)'s `outbound` / `blob_producer`: the
+/// actor's own dispatch thread is the single logical writer of the
+/// `(hold, reply_to, context)` slot and the reader of the output, while
+/// the worker thread fills the output slot once. Contention is the brief
+/// worker-fill / actor-read overlap, not a steady-state hot path.
+pub(crate) struct InflightTable {
+    next_id: u64,
+    entries: HashMap<DispatchId, InflightEntry>,
+}
+
+impl InflightTable {
+    pub(crate) fn new() -> Self {
+        Self {
+            next_id: 0,
+            entries: HashMap::new(),
+        }
+    }
+
+    /// Mint the next monotonic [`DispatchId`]. Called on the actor
+    /// thread under the table lock, so the bump is uncontended.
+    fn mint_id(&mut self) -> DispatchId {
+        self.next_id += 1;
+        DispatchId(self.next_id)
+    }
+}
+
+/// A move-only dispatch completion (ADR-0093 §3-§4). Carries the
+/// worker's `output`, the originating [`ReplyTo`], the held
+/// [`SettlementHold`], and an opt-in context `C` (unit by default).
+///
+/// Move-only by construction — no `Clone` / `Copy` — so the held state
+/// can't be duplicated and the hold's release can't be issued twice. The
+/// consuming `resolve` family re-replies **first**, then drops the hold,
+/// making the `Sent`-before-`Release` ordering (ADR-0080 §12) structural
+/// rather than a remembered drop order. Dropping a `TaskDone` without
+/// resolving releases the hold and `debug_assert`s — catching the silent
+/// lost reply that discipline misses today.
+#[must_use = "a TaskDone holds the chain open; resolve it (or resolve_err) to send the deferred reply and release the hold"]
+pub struct TaskDone<O, C = ()> {
+    output: O,
+    context: C,
+    /// `Option` so `resolve` can `take` the hold out and drop it
+    /// *after* the reply is sent, leaving `Drop` nothing to release. A
+    /// resolved `TaskDone` carries `None` here; an un-resolved one
+    /// carries `Some` and `Drop` trips the assertion.
+    hold: Option<SettlementHold>,
+    reply_to: ReplyTo,
+    /// Set true by every `resolve*` path before it consumes `self`, so
+    /// `Drop` can tell a resolved completion (clean) from a dropped-
+    /// without-resolve one (the lost-reply bug).
+    resolved: bool,
+}
+
+impl<O, C> TaskDone<O, C> {
+    /// Borrow the worker's output. The common `resolve` re-replies this
+    /// directly; `resolve_with` maps it.
+    pub fn output(&self) -> &O {
+        &self.output
+    }
+
+    /// Borrow the opt-in completion context (`()` for the bare
+    /// [`dispatch_blocking`](NativeCtx::dispatch_blocking)).
+    pub fn context(&self) -> &C {
+        &self.context
+    }
+
+    /// Mark resolved and drop the hold **after** the caller has sent the
+    /// reply. Shared tail of every `resolve*` path: take the hold out so
+    /// `Drop` sees `None` (no double release, no assertion), then let it
+    /// fall out of scope here — strictly after the reply the caller
+    /// already pushed, so `Sent` precedes `Release`.
+    fn release(&mut self) {
+        self.resolved = true;
+        drop(self.hold.take());
+    }
+
+    /// Re-reply the carried `output` through the carried `reply_to`,
+    /// then release the hold (ADR-0093 §4). The worker already shaped
+    /// `output` into the reply value, so this is the common one-liner.
+    pub fn resolve(mut self, ctx: &mut NativeCtx<'_>)
+    where
+        O: Kind + serde::Serialize,
+    {
+        ctx.reply_to_target(self.reply_to, &self.output);
+        self.release();
+    }
+
+    /// Map `(&output, &context)` to a reply value via `f`, send it
+    /// through the carried `reply_to`, then release the hold. For
+    /// completion handlers that shape a different reply from the carried
+    /// output (and context, when present) than the raw `output`.
+    pub fn resolve_with<R, F>(mut self, ctx: &mut NativeCtx<'_>, f: F)
+    where
+        R: Kind + serde::Serialize,
+        F: FnOnce(&O, &C) -> R,
+    {
+        let reply = f(&self.output, &self.context);
+        ctx.reply_to_target(self.reply_to, &reply);
+        self.release();
+    }
+
+    /// Send an error reply (a provider-failure shape the cap builds)
+    /// through the carried `reply_to`, then release the hold. The
+    /// carried `output` is discarded — used when the completion is a
+    /// failure rather than a result.
+    pub fn resolve_err<E>(mut self, ctx: &mut NativeCtx<'_>, err: &E)
+    where
+        E: Kind + serde::Serialize,
+    {
+        ctx.reply_to_target(self.reply_to, err);
+        self.release();
+    }
+}
+
+impl<O, C> Drop for TaskDone<O, C> {
+    /// A `TaskDone` dropped without a `resolve*` call is a silent lost
+    /// reply: the caller was owed a deferred reply that never went out.
+    /// Release the hold so the chain can still settle (a stuck hold
+    /// would wedge settlement forever), then `debug_assert` so the bug
+    /// is loud in debug builds — the failure surface discipline misses
+    /// today (ADR-0093 §4 / Consequences).
+    fn drop(&mut self) {
+        if self.hold.is_some() {
+            drop(self.hold.take());
+            debug_assert!(
+                false,
+                "TaskDone dropped without resolve — the deferred reply was never sent (the \
+                 carried hold has been released so settlement isn't wedged, but the caller is \
+                 owed a reply that never went out)"
+            );
+        }
+    }
+}
+
+impl InflightTable {
+    /// Insert a freshly-minted in-flight entry at dispatch time and
+    /// return its [`DispatchId`]. The actor thread calls this (under the
+    /// table lock) right after acquiring the hold, before spawning the
+    /// worker.
+    fn insert(
+        &mut self,
+        hold: SettlementHold,
+        reply_to: ReplyTo,
+        context: Box<dyn Any + Send>,
+    ) -> DispatchId {
+        let id = self.mint_id();
+        self.entries.insert(
+            id,
+            InflightEntry {
+                hold,
+                reply_to,
+                context,
+                output: None,
+            },
+        );
+        id
+    }
+
+    /// Fill the worker's `output` into the named entry's completion slot.
+    /// Called once, on the worker thread, under the table lock. A no-op
+    /// for an unknown id (the dispatch was cancelled out of the table
+    /// before the worker finished).
+    fn fill_output(&mut self, id: DispatchId, output: Box<dyn Any + Send>) {
+        if let Some(entry) = self.entries.get_mut(&id) {
+            entry.output = Some(output);
+        }
+    }
+
+    /// Remove the named entry and downcast its boxed `context` + filled
+    /// `output` into a typed [`TaskDone`]. Returns `None` for an unknown
+    /// id (cancelled / double-landed) or if the worker hasn't filled the
+    /// output yet (the completion-wake must land after the fill, so this
+    /// is the unknown-id case in practice). A type mismatch on either
+    /// downcast also yields `None` — a wiring bug where the handler's
+    /// `O` / `C` don't match the dispatch's.
+    fn take<O: 'static, C: 'static>(&mut self, id: DispatchId) -> Option<TaskDone<O, C>> {
+        let entry = self.entries.remove(&id)?;
+        let InflightEntry {
+            hold,
+            reply_to,
+            context,
+            output,
+        } = entry;
+        let output = output?.downcast::<O>().ok()?;
+        let context = context.downcast::<C>().ok()?;
+        Some(TaskDone {
+            output: *output,
+            context: *context,
+            hold: Some(hold),
+            reply_to,
+            resolved: false,
+        })
+    }
+}
+
+/// Crate-internal accessors the [`NativeBinding`](super::binding) wraps
+/// in its `Mutex<InflightTable>` field expose to
+/// [`NativeCtx`](super::ctx). Kept here next to the table so the
+/// ledger's invariants (mint-then-insert, fill-once, take-removes) stay
+/// in one file.
+impl InflightTable {
+    pub(crate) fn dispatch_insert(
+        &mut self,
+        hold: SettlementHold,
+        reply_to: ReplyTo,
+        context: Box<dyn Any + Send>,
+    ) -> DispatchId {
+        self.insert(hold, reply_to, context)
+    }
+
+    pub(crate) fn dispatch_fill_output(&mut self, id: DispatchId, output: Box<dyn Any + Send>) {
+        self.fill_output(id, output);
+    }
+
+    pub(crate) fn dispatch_take<O: 'static, C: 'static>(
+        &mut self,
+        id: DispatchId,
+    ) -> Option<TaskDone<O, C>> {
+        self.take(id)
+    }
+}
+
+/// Wrap [`InflightTable`] for the [`NativeBinding`](super::binding)
+/// field: a `Mutex` for `&self` interior mutability matching the binding's
+/// other single-writer buffers.
+pub(crate) type InflightLedger = Mutex<InflightTable>;
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture construction panic on failure is the assertion"
+)]
+mod tests {
+    use super::*;
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+    use std::sync::Arc;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    use aether_data::{MailId, MailboxId, ReplyTarget, ReplyTo, mailbox_id_from_name};
+
+    use crate::actor::native::NativeBinding;
+    use crate::actor::native::ctx::NativeCtx;
+    use crate::mail::registry::{InboxHandler, OwnedDispatch};
+    use crate::test_util::fresh_substrate;
+
+    /// A `#[repr(C)]` `Pod` reply kind the worker produces and `resolve`
+    /// re-replies. Carries a `u64` so a test can assert the routed reply
+    /// payload is exactly the worker's output.
+    #[repr(C)]
+    #[derive(
+        Copy,
+        Clone,
+        Debug,
+        PartialEq,
+        Eq,
+        bytemuck::Pod,
+        bytemuck::Zeroable,
+        serde::Serialize,
+        serde::Deserialize,
+    )]
+    struct Answer {
+        value: u64,
+    }
+
+    impl Kind for Answer {
+        const NAME: &'static str = "test.dispatch_blocking.answer";
+        const ID: KindId = KindId(0xD15B_0CC1_0000_0001);
+        fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+            if bytes.len() != size_of::<Self>() {
+                return None;
+            }
+            Some(bytemuck::pod_read_unaligned(bytes))
+        }
+        fn encode_into_bytes(&self) -> Vec<u8> {
+            bytemuck::bytes_of(self).to_vec()
+        }
+    }
+
+    /// Forward every dispatched envelope onto `tx` so a test can observe
+    /// the routed reply. The reply lands at the caller's
+    /// `ReplyTarget::Component(sink)` mailbox.
+    fn forward_to(tx: mpsc::Sender<OwnedDispatch>) -> Arc<dyn InboxHandler> {
+        Arc::new(move |dispatch: OwnedDispatch| {
+            let _ = tx.send(dispatch);
+        })
+    }
+
+    /// A synthetic chain root the dispatching handler reads from
+    /// `ctx.in_flight_root()` — distinct so the hold accounting is
+    /// isolated.
+    fn root_id(cid: u64) -> MailId {
+        MailId {
+            sender: MailboxId(0xAB),
+            correlation_id: cid,
+        }
+    }
+
+    /// Block until the worker's [`TaskCompletionWake`] lands on the
+    /// registered actor inbox channel, returning its decoded
+    /// [`DispatchId`]. The worker fills the ledger output slot before
+    /// pushing the wake, so by the time the wake is observable
+    /// `take_task_done` will find the output.
+    fn await_wake(wake_rx: &mpsc::Receiver<OwnedDispatch>) -> DispatchId {
+        let env = wake_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("completion wake never landed");
+        assert_eq!(
+            env.kind,
+            TaskCompletionWake::ID,
+            "only the wake is expected"
+        );
+        let wake =
+            TaskCompletionWake::decode_from_bytes(env.payload.bytes()).expect("wake decodes");
+        DispatchId(wake.dispatch_id)
+    }
+
+    /// End-to-end happy path: dispatch a blocking closure, drive the
+    /// completion through `take_task_done` + `resolve`, and assert the
+    /// reply reached the original caller AND the hold released only after
+    /// the reply was sent (the chain settles).
+    #[test]
+    fn dispatch_blocking_replies_and_releases_after_reply() {
+        let (registry, mailer) = fresh_substrate();
+        let counter = Arc::clone(mailer.trace_handle().settlement_counter());
+
+        // The original caller: a registered inbox we observe the re-reply
+        // landing on (the reply routes to ReplyTarget::Component(caller)).
+        let (reply_tx, reply_rx) = mpsc::channel::<OwnedDispatch>();
+        let caller = registry.register_inbox("test.dispatch_blocking.caller", forward_to(reply_tx));
+
+        // The actor's own mailbox — name-derived so the worker's wake
+        // push (recipient = self_mailbox) routes to a registered inbox we
+        // observe, rather than warn-dropping.
+        let actor_mailbox = mailbox_id_from_name("test.dispatch_blocking.actor");
+        let binding = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            actor_mailbox,
+        ));
+        let (wake_tx, wake_rx) = mpsc::channel::<OwnedDispatch>();
+        registry.register_inbox("test.dispatch_blocking.actor", forward_to(wake_tx));
+
+        let root = root_id(1);
+        let caller_reply_to = ReplyTo::with_correlation(ReplyTarget::Component(caller), 77);
+
+        // The dispatching handler: eager-acquire the hold, spawn the
+        // worker, return.
+        {
+            let mut ctx = NativeCtx::new(&binding, caller_reply_to, MailId::NONE, root);
+            let _id = ctx.dispatch_blocking(move || Answer { value: 42 });
+        }
+
+        // The handler returned but the chain is held: settlement is
+        // gated until the reply lands.
+        assert_eq!(
+            counter.held_open(root),
+            1,
+            "the chain stays held after the dispatching handler returns"
+        );
+
+        // The worker ran, filled the ledger, and pushed the wake.
+        let id = await_wake(&wake_rx);
+        assert_eq!(
+            counter.held_open(root),
+            1,
+            "the worker finishing does not release the chain"
+        );
+
+        // The completion handler runs: rebuild the TaskDone and resolve.
+        {
+            let mut ctx = NativeCtx::new(&binding, ReplyTo::NONE, MailId::NONE, MailId::NONE);
+            let done = ctx
+                .take_task_done::<Answer, ()>(id)
+                .expect("the dispatch is in the ledger");
+            assert_eq!(*done.output(), Answer { value: 42 });
+            done.resolve(&mut ctx);
+        }
+
+        // The reply reached the original caller.
+        let reply = reply_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("the re-reply lands on the caller's mailbox");
+        assert_eq!(
+            reply.kind,
+            Answer::ID,
+            "reply carries the worker's output kind"
+        );
+        // A Component-targeted reply is postcard-encoded by
+        // `Mailer::send_reply` (not cast), so decode it the same way.
+        let answer: Answer = postcard::from_bytes(reply.payload.bytes()).expect("reply decodes");
+        assert_eq!(answer, Answer { value: 42 });
+        assert_eq!(
+            reply.sender.correlation_id, 77,
+            "the caller's correlation is echoed onto the reply"
+        );
+
+        // Hold released after the reply — chain may settle.
+        assert_eq!(
+            counter.held_open(root),
+            0,
+            "resolve releases the hold after re-replying"
+        );
+    }
+
+    /// `dispatch_blocking_with` carries an opt-in context the completion
+    /// handler reads via `TaskDone::context`, and `resolve_with` maps
+    /// `(output, context)` to the reply.
+    #[test]
+    fn dispatch_blocking_with_context_resolve_with() {
+        let (registry, mailer) = fresh_substrate();
+
+        let (reply_tx, reply_rx) = mpsc::channel::<OwnedDispatch>();
+        let caller =
+            registry.register_inbox("test.dispatch_blocking.caller2", forward_to(reply_tx));
+
+        let actor_mailbox = mailbox_id_from_name("test.dispatch_blocking.actor2");
+        let binding = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            actor_mailbox,
+        ));
+        let (wake_tx, wake_rx) = mpsc::channel::<OwnedDispatch>();
+        registry.register_inbox("test.dispatch_blocking.actor2", forward_to(wake_tx));
+
+        let root = root_id(2);
+        let caller_reply_to = ReplyTo::with_correlation(ReplyTarget::Component(caller), 5);
+
+        {
+            let mut ctx = NativeCtx::new(&binding, caller_reply_to, MailId::NONE, root);
+            // Worker produces a raw count; context carries an offset the
+            // completion handler folds in.
+            let _id = ctx.dispatch_blocking_with(100u64, move || 7u64);
+        }
+
+        let id = await_wake(&wake_rx);
+        {
+            let mut ctx = NativeCtx::new(&binding, ReplyTo::NONE, MailId::NONE, MailId::NONE);
+            let done = ctx
+                .take_task_done::<u64, u64>(id)
+                .expect("the dispatch is in the ledger");
+            assert_eq!(*done.output(), 7);
+            assert_eq!(*done.context(), 100);
+            done.resolve_with(&mut ctx, |output, cx| Answer { value: output + cx });
+        }
+
+        let reply = reply_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("the mapped re-reply lands");
+        // A Component-targeted reply is postcard-encoded by
+        // `Mailer::send_reply` (not cast), so decode it the same way.
+        let answer: Answer = postcard::from_bytes(reply.payload.bytes()).expect("reply decodes");
+        assert_eq!(
+            answer,
+            Answer { value: 107 },
+            "resolve_with folds output + context"
+        );
+    }
+
+    /// Dropping a `TaskDone` without resolving releases the hold (so
+    /// settlement isn't wedged) and `debug_assert`s. Gated `#[should_panic]`
+    /// — the assertion only fires in debug builds, which is where tests run.
+    #[test]
+    #[should_panic(expected = "TaskDone dropped without resolve")]
+    #[cfg(debug_assertions)]
+    fn dropping_task_done_without_resolve_releases_and_asserts() {
+        let (_registry, mailer) = fresh_substrate();
+        let counter = Arc::clone(mailer.trace_handle().settlement_counter());
+
+        let root = root_id(3);
+        // Acquire a hold the same way dispatch does and hand it to a
+        // TaskDone we then drop unresolved.
+        let hold = mailer.acquire_settlement_hold(root);
+        assert_eq!(counter.held_open(root), 1, "hold acquired");
+
+        let done: TaskDone<u64, ()> = TaskDone {
+            output: 1,
+            context: (),
+            hold: Some(hold),
+            reply_to: ReplyTo::NONE,
+            resolved: false,
+        };
+        // The drop releases the hold (verified indirectly: the chain
+        // returns to 0 even as the assertion unwinds) then debug_asserts.
+        drop(done);
+    }
+
+    /// Companion to the panic test: a [`TaskDone`] dropped unresolved still
+    /// releases its hold (so settlement isn't permanently wedged). Built
+    /// with the assertion compiled out — verifies the release half in
+    /// isolation by catching the unwind.
+    #[test]
+    fn dropping_task_done_releases_hold_even_when_unresolved() {
+        let (_registry, mailer) = fresh_substrate();
+        let counter = Arc::clone(mailer.trace_handle().settlement_counter());
+        let root = root_id(4);
+        let hold = mailer.acquire_settlement_hold(root);
+        assert_eq!(counter.held_open(root), 1);
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let done: TaskDone<u64, ()> = TaskDone {
+                output: 1,
+                context: (),
+                hold: Some(hold),
+                reply_to: ReplyTo::NONE,
+                resolved: false,
+            };
+            drop(done);
+        }));
+        // In debug the drop asserts (unwinds); in release it doesn't.
+        // Either way the hold released.
+        let _ = result;
+        assert_eq!(
+            counter.held_open(root),
+            0,
+            "an unresolved TaskDone releases its hold on drop"
+        );
+    }
+}

--- a/crates/aether-substrate/src/actor/native/mod.rs
+++ b/crates/aether-substrate/src/actor/native/mod.rs
@@ -67,6 +67,7 @@ pub(crate) mod blob_lifecycle;
 pub(crate) mod blob_work;
 pub mod ctx;
 pub(crate) mod dispatch;
+pub mod dispatch_blocking;
 pub(crate) mod dispatcher_slot;
 pub mod envelope;
 pub mod mailbox;
@@ -75,6 +76,7 @@ pub mod spawn_thread;
 
 pub use binding::NativeBinding;
 pub use ctx::{ExportedHandles, NativeCtx, NativeInitCtx};
+pub use dispatch_blocking::{DispatchId, TaskCompletionWake, TaskDone};
 // iamacoffeepot/aether#1272: driver-as-actor capabilities that own
 // their inbox drain inline (today only the desktop window driver)
 // reach for the `NativeCtx`-free variants of the framework dispatch

--- a/docs/adr/0093-hold-until-resolve-dispatch-primitive.md
+++ b/docs/adr/0093-hold-until-resolve-dispatch-primitive.md
@@ -1,6 +1,6 @@
 # ADR-0093: Hold-until-resolve dispatch primitive
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-06-04
 
 ## Context


### PR DESCRIPTION
Part 1a of iamacoffeepot/aether#1313 (ADR-0093) — the **runtime half** of the hold-until-resolve dispatch primitive. Native-only; no proc-macro work.

## What landed

The "reply in a later handler turn" spawn shape — the gap between `spawn_inherit` (hold dies with the worker) and `spawn_detached` (no hold). Generalizes the content-gen `InFlightDispatch` prototype into a substrate ctx primitive:

- **`TaskDone<O, C = ()>`** — move-only completion carrying the worker's output, the originating `ReplyTo`, the held `SettlementHold`, and an opt-in context `C`. `resolve` / `resolve_with` / `resolve_err` re-reply through the carried target **first**, then drop the hold — `Sent`-before-`Release` (ADR-0080 §12) is structural via `hold: Option<_>` + take-after-reply, not a remembered drop order. Drop-without-resolve releases the hold (so settlement can't wedge) then `debug_assert`s the lost reply.
- **`NativeCtx::dispatch_blocking` / `dispatch_blocking_with`** — eager-acquire the hold on the current root *before* spawning (so `HoldOpen` precedes the handler's `Finished`), park `(hold, reply_to, context)` in the in-flight ledger, spawn the one sanctioned worker. Returns a `Copy` `DispatchId` for optional cancellation.
- **In-flight ledger** on `NativeBinding` (`Mutex<InflightTable>`, like `outbound` / `blob_producer`) — opaque framework plumbing; the cap stores nothing. The worker parks its output in the ledger slot (so a non-serializable `O` never encodes) and pushes a cast-shape `TaskCompletionWake` carrying only the `DispatchId`.
- **`NativeCtx::take_task_done::<O, C>`** — reunites the worker's output with the held state into a `TaskDone` when the wake lands.

Flips ADR-0093 → Accepted.

## Tested

In-process `NativeBinding`/`NativeCtx` tests drive the full path with a hand-wired completion handler: the reply reaches the original caller and the hold releases only after the reply; context round-trips through `resolve_with`; unresolved drop releases + asserts.

`scripts/preflight.sh` green — fmt, clippy `--all-targets -D warnings`, doc, nextest (1468 passed), wasm32 cross-build.

## Deferred (follow-ups)

- **`#[handler(task)]` macro sugar** — PR1b (`aether-actor-derive`). Until then a completion handler matches `TaskCompletionWake` explicitly and calls `take_task_done`. This PR exercises that path by hand.
- **Per-source concurrency bound + pending queue** (`max_in_flight`, default 4) — a `TODO` at the spawn site (iamacoffeepot/aether#1313); lands with the content-gen migration so the paid-endpoint rate limit (ADR-0050 §2) is honoured.
- **Per-request thread spawn → work-stealing blocking pool** — the worker is spawned per request (fine for content-gen's bounded, multi-second calls; a footgun for high-frequency use). The scalable replacement — a reused pool isolated from the cooperative scheduler so blocking can't starve it — is iamacoffeepot/aether#1322.
- **wasm/FFI** — deferred per ADR-0093 §7.

Part of iamacoffeepot/aether#1313 (closes on the final migration PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
