### PR TITLE
feat(actor-derive): #[handler(task)] completion handlers routed by output type

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -1517,6 +1517,140 @@ fn attr_is_fallback(attr: &Attribute) -> bool {
         .is_some_and(|s| s.ident == "fallback")
 }
 
+/// The category of a `#[handler]` method (ADR-0093 §3). `#[handler]` and
+/// `#[handler(mail)]` both mean an inbound-mail handler (the default);
+/// `#[handler(task)]` marks a hold-until-resolve dispatch completion,
+/// matched by its `TaskDone<O, C>` output type rather than a kind id.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum HandlerVariant {
+    Mail,
+    Task,
+}
+
+/// Parse the parenthesized argument of a `#[handler(...)]` attribute into
+/// a [`HandlerVariant`]. Bare `#[handler]` (no parens) is `Mail`. The
+/// only accepted parenthesized spellings are `mail` and `task`; anything
+/// else is a pointed compile error spanned at the attribute.
+fn parse_handler_variant(attr: &Attribute) -> syn::Result<HandlerVariant> {
+    match &attr.meta {
+        // Bare `#[handler]` — the default inbound-mail handler.
+        Meta::Path(_) => Ok(HandlerVariant::Mail),
+        // `#[handler(mail)]` / `#[handler(task)]` — parse the single
+        // ident argument.
+        Meta::List(_) => {
+            let ident: syn::Ident = attr.parse_args().map_err(|_| {
+                syn::Error::new_spanned(
+                    attr,
+                    "#[handler(...)] accepts exactly `mail` or `task` — \
+                     `#[handler]` and `#[handler(mail)]` are inbound mail, \
+                     `#[handler(task)]` is a dispatch completion (ADR-0093 §3)",
+                )
+            })?;
+            if ident == "mail" {
+                Ok(HandlerVariant::Mail)
+            } else if ident == "task" {
+                Ok(HandlerVariant::Task)
+            } else {
+                Err(syn::Error::new_spanned(
+                    &ident,
+                    "unknown #[handler] variant — accepts exactly `mail` or `task` \
+                     (`#[handler]` / `#[handler(mail)]` = inbound mail, \
+                     `#[handler(task)]` = a dispatch completion, ADR-0093 §3)",
+                ))
+            }
+        }
+        Meta::NameValue(nv) => Err(syn::Error::new_spanned(
+            nv,
+            "#[handler] takes no `= value` — write `#[handler]`, `#[handler(mail)]`, \
+             or `#[handler(task)]`",
+        )),
+    }
+}
+
+/// Extract `(O, C)` from a `#[handler(task)]` method's third parameter,
+/// which must be `done: TaskDone<O>` (where `C` defaults to `()`) or
+/// `done: TaskDone<O, C>`. Unlike a mail handler's third parameter (a
+/// `Kind`), a task completion's parameter is the framework's
+/// `TaskDone<...>` — `O` / `C` are its generic arguments, not a kind.
+fn extract_task_handler_types(sig: &Signature) -> syn::Result<(Type, Type)> {
+    if sig.inputs.len() != 3 {
+        return Err(syn::Error::new_spanned(
+            sig,
+            "#[handler(task)] method must have signature \
+             `(&self | &mut self, ctx: &mut NativeCtx<'_>, done: TaskDone<O>)` \
+             (or `TaskDone<O, C>` with an opt-in context)",
+        ));
+    }
+    let first = &sig.inputs[0];
+    if !matches!(first, FnArg::Receiver(_)) {
+        return Err(syn::Error::new_spanned(
+            first,
+            "#[handler(task)] first parameter must be `&self` or `&mut self`",
+        ));
+    }
+    let third = &sig.inputs[2];
+    let FnArg::Typed(pt) = third else {
+        return Err(syn::Error::new_spanned(
+            third,
+            "#[handler(task)] third parameter must be `done: TaskDone<O>` or `TaskDone<O, C>`",
+        ));
+    };
+    let Type::Path(type_path) = &*pt.ty else {
+        return Err(syn::Error::new_spanned(
+            &pt.ty,
+            "#[handler(task)] third parameter must be a `TaskDone<O>` / `TaskDone<O, C>` path type",
+        ));
+    };
+    let last = type_path.path.segments.last().ok_or_else(|| {
+        syn::Error::new_spanned(
+            &pt.ty,
+            "#[handler(task)] third parameter must be `TaskDone<…>`",
+        )
+    })?;
+    if last.ident != "TaskDone" {
+        return Err(syn::Error::new_spanned(
+            &pt.ty,
+            "#[handler(task)] third parameter must be `TaskDone<O>` or `TaskDone<O, C>` \
+             (the framework completion type, ADR-0093 §3)",
+        ));
+    }
+    let PathArguments::AngleBracketed(args) = &last.arguments else {
+        return Err(syn::Error::new_spanned(
+            last,
+            "#[handler(task)] `TaskDone` needs an output type argument: `TaskDone<O>` or \
+             `TaskDone<O, C>`",
+        ));
+    };
+    let type_args: Vec<&Type> = args
+        .args
+        .iter()
+        .filter_map(|a| match a {
+            GenericArgument::Type(t) => Some(t),
+            _ => None,
+        })
+        .collect();
+    let output = match type_args.first() {
+        Some(t) => (*t).clone(),
+        None => {
+            return Err(syn::Error::new_spanned(
+                last,
+                "#[handler(task)] `TaskDone` needs an output type argument: `TaskDone<O>`",
+            ));
+        }
+    };
+    // `C` defaults to `()` (a bare `TaskDone<O>` / `dispatch_blocking`).
+    let context = type_args
+        .get(1)
+        .map_or_else(|| syn::parse_quote!(()), |t| (*t).clone());
+    if type_args.len() > 2 {
+        return Err(syn::Error::new_spanned(
+            last,
+            "#[handler(task)] `TaskDone` takes at most two type arguments: `TaskDone<O, C>`",
+        ));
+    }
+    Ok((output, context))
+}
+
 /// Wasm-actor expansion — `#[actor] impl FfiActor for X` (or
 /// the back-compat `impl Component for X`). Emits the full wasm
 /// surface: dispatch table referencing `aether_actor::FfiCtx<'_>`,
@@ -1579,6 +1713,19 @@ fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
                 }
 
                 if let Some(idx) = handler_attr_idx {
+                    // ADR-0093 §7: dispatch completions are native-only.
+                    // `try_take_task_done` lives on `NativeCtx`; the
+                    // wasm/bridge path has no umbrella-aware blocking
+                    // dispatch yet. Reject `#[handler(task)]` here with a
+                    // clear diagnostic rather than letting it expand into
+                    // a guest dispatch table that can't satisfy it.
+                    if parse_handler_variant(&f.attrs[idx])? == HandlerVariant::Task {
+                        return Err(syn::Error::new_spanned(
+                            &f,
+                            "dispatch completions are native-only (ADR-0093 §7); \
+                             `#[handler(task)]` is not supported in wasm components",
+                        ));
+                    }
                     let kind_ty = extract_handler_kind_type(&f.sig)?;
                     let agent_doc = extract_agent_doc(&f.attrs);
                     f.attrs.remove(idx);
@@ -1816,6 +1963,12 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
     let mut init_method: Option<syn::ImplItemFn> = None;
     let mut config_type: Option<syn::ImplItemType> = None;
     let mut handlers: Vec<NativeActorHandlerFn> = Vec::new();
+    // ADR-0093 §3: `#[handler(task)]` completion handlers, collected
+    // separately from mail handlers — they get no `HandlesKind<K>` impl
+    // and aren't in the `aether.kinds.inputs` manifest (a completion is
+    // not inbound mail), and they route by output type via a single
+    // `TaskCompletionWake` dispatch arm rather than per-kind arms.
+    let mut task_handlers: Vec<NativeActorTaskHandlerFn> = Vec::new();
     let mut fallback: Option<NativeFallbackFn> = None;
     let mut helpers: Vec<syn::ImplItemFn> = Vec::new();
     let mut consts: Vec<syn::ImplItemConst> = Vec::new();
@@ -1855,13 +2008,26 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
                     ));
                 }
                 if let Some(idx) = handler_attr_idx {
-                    let (kind_ty, is_slice) = extract_native_actor_handler_kind(&f.sig)?;
+                    let variant = parse_handler_variant(&f.attrs[idx])?;
                     f.attrs.remove(idx);
-                    handlers.push(NativeActorHandlerFn {
-                        method: f,
-                        kind_ty,
-                        is_slice,
-                    });
+                    match variant {
+                        HandlerVariant::Mail => {
+                            let (kind_ty, is_slice) = extract_native_actor_handler_kind(&f.sig)?;
+                            handlers.push(NativeActorHandlerFn {
+                                method: f,
+                                kind_ty,
+                                is_slice,
+                            });
+                        }
+                        HandlerVariant::Task => {
+                            let (output_ty, context_ty) = extract_task_handler_types(&f.sig)?;
+                            task_handlers.push(NativeActorTaskHandlerFn {
+                                method: f,
+                                output_ty,
+                                context_ty,
+                            });
+                        }
+                    }
                 } else if let Some(idx) = fallback_attr_idx {
                     if fallback.is_some() {
                         return Err(syn::Error::new_spanned(
@@ -1916,12 +2082,34 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
     // misses, so per-handler `HandlesKind<K>` markers are still
     // authoritative at the type system — `ctx.actor::<X>().send(K)`
     // compiles only for declared K.
-    if handlers.is_empty() && fallback.is_none() {
+    if handlers.is_empty() && fallback.is_none() && task_handlers.is_empty() {
         return Err(syn::Error::new_spanned(
             self_ty,
             "#[actor] impl NativeActor requires at least one #[handler] method \
              or a #[fallback] method",
         ));
+    }
+
+    // ADR-0093 §3: two `#[handler(task)]` methods with the same
+    // `TaskDone<O>` output type are ambiguous — completions route by `O`,
+    // so a duplicate `O` would let the first-tried handler shadow the
+    // second. Reject it at compile time, spanned at the later handler.
+    for (i, later) in task_handlers.iter().enumerate() {
+        if let Some(earlier) = task_handlers[..i]
+            .iter()
+            .find(|earlier| types_token_eq(&earlier.output_ty, &later.output_ty))
+        {
+            let earlier_name = &earlier.method.sig.ident;
+            return Err(syn::Error::new_spanned(
+                &later.method.sig.ident,
+                format!(
+                    "two #[handler(task)] methods share the `TaskDone<O>` output type \
+                     (also on `{earlier_name}`) — completions route by output type, so a \
+                     duplicate `O` is ambiguous (ADR-0093 §3). Give each task handler a \
+                     distinct output type."
+                ),
+            ));
+        }
     }
 
     // `NAMESPACE` is declared on the supertrait `Actor`, but the user
@@ -2034,7 +2222,53 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
         }
     });
 
+    // ADR-0093 §3: a SINGLE dispatch arm for all task completions. They
+    // all arrive as `TaskCompletionWake` (carrying just a `DispatchId`);
+    // the discriminant between task handlers is their `TaskDone<O, C>`
+    // output type, not a kind id. Decode the id once, then try each task
+    // handler's `(O, C)` via the non-consuming `try_take_task_done` — a
+    // wrong-type probe leaves the ledger entry intact for a later
+    // handler. `None` falls through to the default (unknown id / already
+    // taken).
+    let task_completion_arm = if task_handlers.is_empty() {
+        quote! {}
+    } else {
+        let try_take_lines = task_handlers.iter().map(|t| {
+            let output_ty = &t.output_ty;
+            let context_ty = &t.context_ty;
+            let method_ident = &t.method.sig.ident;
+            quote! {
+                if let ::core::option::Option::Some(__aether_done) =
+                    __aether_ctx.try_take_task_done::<#output_ty, #context_ty>(__aether_dispatch_id)
+                {
+                    self.#method_ident(__aether_ctx, __aether_done);
+                    return ::core::option::Option::Some(());
+                }
+            }
+        });
+        quote! {
+            if __aether_kind.0
+                == <::aether_substrate::actor::native::TaskCompletionWake
+                    as ::aether_data::Kind>::ID.0
+            {
+                let __aether_wake = match
+                    <::aether_substrate::actor::native::TaskCompletionWake
+                        as ::aether_data::Kind>::decode_from_bytes(__aether_payload)
+                {
+                    ::core::option::Option::Some(__aether_w) => __aether_w,
+                    ::core::option::Option::None => return ::core::option::Option::None,
+                };
+                let __aether_dispatch_id =
+                    ::aether_substrate::actor::native::DispatchId(__aether_wake.dispatch_id);
+                #(#try_take_lines)*
+                return ::core::option::Option::None;
+            }
+        }
+    };
+
     let handler_methods: Vec<&syn::ImplItemFn> = handlers.iter().map(|h| &h.method).collect();
+    let task_handler_methods: Vec<&syn::ImplItemFn> =
+        task_handlers.iter().map(|t| &t.method).collect();
     let fallback_method = fallback.as_ref().map(|f| &f.method);
     let helper_methods = helpers.iter();
 
@@ -2136,6 +2370,7 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
                 __aether_payload: &[u8],
             ) -> ::core::option::Option<()> {
                 #(#dispatch_arms)*
+                #task_completion_arm
                 ::core::option::Option::None
             }
 
@@ -2147,6 +2382,7 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
         #[cfg(not(target_arch = "wasm32"))]
         impl #impl_generics #self_ty #where_clause {
             #(#handler_methods)*
+            #(#task_handler_methods)*
             #fallback_method
             #(#helper_methods)*
         }
@@ -2160,6 +2396,27 @@ struct NativeActorHandlerFn {
     /// than `K`. The dispatcher decodes via `decode_cast_slice` so a
     /// single envelope with `count > 1` reaches the handler intact.
     is_slice: bool,
+}
+
+/// A `#[handler(task)]` completion handler (ADR-0093 §3). Its third
+/// parameter is `done: TaskDone<O, C>` (C defaults to `()`); `output_ty`
+/// / `context_ty` are the extracted `O` / `C`. Routed not by a kind id
+/// but by output type, via a non-consuming `try_take_task_done::<O, C>`
+/// probe in the single `TaskCompletionWake` dispatch arm.
+struct NativeActorTaskHandlerFn {
+    method: syn::ImplItemFn,
+    output_ty: Type,
+    context_ty: Type,
+}
+
+/// Token-level type equality, used to reject duplicate `TaskDone<O>`
+/// output types across `#[handler(task)]` methods. `syn::Type` is not
+/// `PartialEq`, so compare the pretty-printed token streams — exact
+/// enough for the duplicate-`O` ambiguity check (two spellings of the
+/// same type that tokenize differently are a corner case the author can
+/// resolve by normalising).
+fn types_token_eq(a: &Type, b: &Type) -> bool {
+    quote!(#a).to_string() == quote!(#b).to_string()
 }
 
 /// Issue 576: native-side `#[fallback]` collected on a

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -876,6 +876,26 @@ impl NativeBinding {
             .expect("in-flight ledger poisoned; fail-fast per ADR-0063")
             .dispatch_take(id)
     }
+
+    /// Non-consuming peek-then-take of the named dispatch entry: probe its
+    /// boxed output + context against `O` / `C` and only remove + rebuild
+    /// the [`TaskDone`](super::dispatch_blocking::TaskDone) on a match,
+    /// leaving the entry intact on a mismatch. The `#[handler(task)]`
+    /// dispatch chain calls this to route a completion to the right
+    /// output-typed handler without a wrong-type probe consuming the entry.
+    ///
+    /// # Panics
+    /// Panics if the in-flight ledger mutex is poisoned — fail-fast per
+    /// ADR-0063.
+    pub(crate) fn dispatch_try_take<O: 'static, C: 'static>(
+        &self,
+        id: super::dispatch_blocking::DispatchId,
+    ) -> Option<super::dispatch_blocking::TaskDone<O, C>> {
+        self.inflight
+            .lock()
+            .expect("in-flight ledger poisoned; fail-fast per ADR-0063")
+            .dispatch_try_take(id)
+    }
 }
 
 #[cfg(test)]

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -255,6 +255,28 @@ impl<'a> NativeCtx<'a> {
         self.binding.dispatch_take::<O, C>(id)
     }
 
+    /// Non-consuming sibling of [`Self::take_task_done`]: probe the
+    /// in-flight entry named by `id` against `O` / `C` and only remove +
+    /// rebuild the [`TaskDone<O, C>`] on a match, leaving the entry intact
+    /// on a mismatch.
+    ///
+    /// This is the routing primitive behind `#[handler(task)]`. Multiple
+    /// task handlers on one actor are discriminated by their `TaskDone<O>`
+    /// output type, not a kind id — all completions arrive as the single
+    /// [`TaskCompletionWake`] kind. The generated dispatch arm tries each
+    /// task handler's `(O, C)` in
+    /// turn; a wrong-type probe must *not* consume the entry, or the first
+    /// handler tried would swallow a completion destined for a later one.
+    ///
+    /// `None` for an unknown id (cancelled / double-landed), an unfilled
+    /// output, or an `O` / `C` that doesn't match this entry's dispatch.
+    pub fn try_take_task_done<O: 'static, C: 'static>(
+        &mut self,
+        id: DispatchId,
+    ) -> Option<TaskDone<O, C>> {
+        self.binding.dispatch_try_take::<O, C>(id)
+    }
+
     /// ADR-0080 §5: the [`MailId`] of the mail currently being
     /// dispatched. Read by outbound `send` paths to stamp
     /// `parent_mail` on child mail. `MailId::NONE` when the ctx was

--- a/crates/aether-substrate/src/actor/native/dispatch_blocking.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch_blocking.rs
@@ -330,6 +330,33 @@ impl InflightTable {
             resolved: false,
         })
     }
+
+    /// Non-consuming peek-then-take (ADR-0093 §3, peek variant). Look the
+    /// entry up by `id` and *probe* the boxed `output` + `context` against
+    /// `O` / `C` via `downcast_ref` **without removing the entry**. Only
+    /// when both probes succeed is the entry removed and rebuilt into a
+    /// typed [`TaskDone`]; a probe miss leaves the entry intact and returns
+    /// `None`.
+    ///
+    /// This is what the `#[handler(task)]` dispatch chain needs:
+    /// completions all arrive as the single [`TaskCompletionWake`] kind and
+    /// are routed to the right task handler by *output type*, so the
+    /// generated arm tries each handler's `(O, C)` in turn. A wrong-type
+    /// attempt must not consume the entry, or the first probed handler
+    /// would swallow a completion meant for a later one. Returns `None` for
+    /// an unknown id, an unfilled output (worker not finished — in practice
+    /// the unknown-id case, since the wake lands after the fill), or a type
+    /// mismatch on either downcast.
+    fn try_take<O: 'static, C: 'static>(&mut self, id: DispatchId) -> Option<TaskDone<O, C>> {
+        let entry = self.entries.get(&id)?;
+        // Probe both boxes without disturbing the entry — an unfilled
+        // output slot or a type mismatch on either box short-circuits to
+        // `None` (the entry stays intact for a later handler to claim).
+        entry.output.as_deref()?.downcast_ref::<O>()?;
+        entry.context.downcast_ref::<C>()?;
+        // Both match — now it's safe to remove and rebuild.
+        self.take(id)
+    }
 }
 
 /// Crate-internal accessors the [`NativeBinding`](super::binding) wraps
@@ -356,6 +383,13 @@ impl InflightTable {
         id: DispatchId,
     ) -> Option<TaskDone<O, C>> {
         self.take(id)
+    }
+
+    pub(crate) fn dispatch_try_take<O: 'static, C: 'static>(
+        &mut self,
+        id: DispatchId,
+    ) -> Option<TaskDone<O, C>> {
+        self.try_take(id)
     }
 }
 

--- a/crates/aether-substrate/tests/native_actor_macro.rs
+++ b/crates/aether-substrate/tests/native_actor_macro.rs
@@ -20,11 +20,12 @@
 #![allow(clippy::needless_pass_by_value)]
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering as AtomicOrdering};
 use std::time::{Duration, Instant};
 
 use aether_data::{Kind, ReplyTo};
 use aether_kinds::trace::Nanos;
+use aether_substrate::actor::native::TaskDone;
 use aether_substrate::handle_store::HandleStore;
 use aether_substrate::mail::registry::OwnedDispatch;
 use aether_substrate::mail::{MailId, MailRef};
@@ -354,6 +355,224 @@ fn macro_emitted_cap_drops_unknown_kind_via_dispatch() {
     thread::sleep(Duration::from_millis(50));
     assert_eq!(greet_total.load(AtomicOrdering::SeqCst), 0);
     assert_eq!(ping_total.load(AtomicOrdering::SeqCst), 0);
+
+    drop(chassis);
+}
+
+// ADR-0093 §3: `#[handler(task)]` completion handlers, routed by their
+// `TaskDone<O>` output type rather than a kind id. The cap below has two
+// task handlers of distinct `O` (`ResultA` / `ResultB`); a single
+// `TaskCompletionWake` arm tries each via the non-consuming
+// `try_take_task_done` probe, so each completion lands on exactly the
+// handler whose output type matches.
+
+/// First completion output type. Distinct from `ResultB` so the macro's
+/// output-type routing has two arms to discriminate.
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    ::aether_data::Kind,
+    ::aether_data::Schema,
+)]
+#[kind(name = "test.macro_native_actor.result_a")]
+struct ResultA {
+    value: u64,
+}
+
+/// Second completion output type — a structurally different shape so a
+/// mis-route to the `ResultA` handler couldn't accidentally type-check.
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    ::aether_data::Kind,
+    ::aether_data::Schema,
+)]
+#[kind(name = "test.macro_native_actor.result_b")]
+struct ResultB {
+    tag: u32,
+}
+
+/// Trigger that makes the cap dispatch a `ResultA`-producing worker.
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    ::aether_data::Kind,
+    ::aether_data::Schema,
+)]
+#[kind(name = "test.macro_native_actor.kick_a")]
+struct KickA {
+    seed: u64,
+}
+
+/// Trigger that makes the cap dispatch a `ResultB`-producing worker.
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    ::aether_data::Kind,
+    ::aether_data::Schema,
+)]
+#[kind(name = "test.macro_native_actor.kick_b")]
+struct KickB {
+    seed: u32,
+}
+
+/// Where each task handler records what it observed, so the test can
+/// assert routing landed on the correct handler with the correct value.
+#[derive(Clone)]
+struct TaskObservations {
+    /// How many times each kick handler dispatched a worker, so the cap's
+    /// mail handlers touch `self` (and the test can sanity-check the
+    /// dispatch side fired).
+    dispatched: Arc<AtomicU32>,
+    /// `value` the `ResultA` completion handler saw + how many times it
+    /// fired.
+    a_value: Arc<AtomicU64>,
+    a_calls: Arc<AtomicU32>,
+    /// `tag` the `ResultB` completion handler saw + its call count.
+    b_tag: Arc<AtomicU32>,
+    b_calls: Arc<AtomicU32>,
+}
+
+struct TaskRouteCap {
+    obs: TaskObservations,
+}
+
+impl aether_actor::Singleton for TaskRouteCap {}
+
+#[aether_data::actor]
+impl NativeActor for TaskRouteCap {
+    type Config = TaskObservations;
+    const NAMESPACE: &'static str = "test.macro_native_actor.task_route";
+
+    fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        Ok(Self { obs: config })
+    }
+
+    /// Dispatch a worker that produces a `ResultA`. The completion routes
+    /// to `on_result_a` by output type.
+    #[aether_data::handler]
+    fn on_kick_a(&self, ctx: &mut NativeCtx<'_>, mail: KickA) {
+        self.obs.dispatched.fetch_add(1, AtomicOrdering::SeqCst);
+        let seed = mail.seed;
+        ctx.dispatch_blocking(move || ResultA { value: seed });
+    }
+
+    /// Dispatch a worker that produces a `ResultB`.
+    #[aether_data::handler]
+    fn on_kick_b(&self, ctx: &mut NativeCtx<'_>, mail: KickB) {
+        self.obs.dispatched.fetch_add(1, AtomicOrdering::SeqCst);
+        let seed = mail.seed;
+        ctx.dispatch_blocking(move || ResultB { tag: seed });
+    }
+
+    /// `ResultA` completion handler. Records the value + a call so the
+    /// test can confirm only the `ResultA` dispatch reached it.
+    #[aether_data::handler(task)]
+    fn on_result_a(&self, ctx: &mut NativeCtx<'_>, done: TaskDone<ResultA>) {
+        self.obs
+            .a_value
+            .store(done.output().value, AtomicOrdering::SeqCst);
+        self.obs.a_calls.fetch_add(1, AtomicOrdering::SeqCst);
+        // No caller behind these test dispatches (ReplyTo::NONE), so the
+        // re-reply is a no-op; resolve still consumes the TaskDone and
+        // releases the hold (avoiding the drop-without-resolve assert).
+        done.resolve(ctx);
+    }
+
+    /// `ResultB` completion handler.
+    #[aether_data::handler(task)]
+    fn on_result_b(&self, ctx: &mut NativeCtx<'_>, done: TaskDone<ResultB>) {
+        self.obs
+            .b_tag
+            .store(done.output().tag, AtomicOrdering::SeqCst);
+        self.obs.b_calls.fetch_add(1, AtomicOrdering::SeqCst);
+        done.resolve(ctx);
+    }
+}
+
+#[test]
+fn macro_routes_task_completions_by_output_type() {
+    let (registry, mailer) = fresh_substrate();
+    let obs = TaskObservations {
+        dispatched: Arc::new(AtomicU32::new(0)),
+        a_value: Arc::new(AtomicU64::new(0)),
+        a_calls: Arc::new(AtomicU32::new(0)),
+        b_tag: Arc::new(AtomicU32::new(0)),
+        b_calls: Arc::new(AtomicU32::new(0)),
+    };
+
+    let chassis: PassiveChassis<TestChassis> =
+        Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<TaskRouteCap>(obs.clone())
+            .build_passive()
+            .expect("task-routing cap boots");
+
+    // Kick off both dispatches. Each handler spawns a worker that fills
+    // the ledger and pushes a `TaskCompletionWake` back to this actor's
+    // own mailbox; the chassis redelivers those wakes through the macro's
+    // single completion arm, which routes each to its output-typed
+    // handler.
+    push_envelope(&registry, TaskRouteCap::NAMESPACE, &KickA { seed: 7 });
+    push_envelope(&registry, TaskRouteCap::NAMESPACE, &KickB { seed: 9 });
+
+    assert!(
+        wait_for(1, &obs.a_calls, Duration::from_secs(2)),
+        "the ResultA completion routed to on_result_a"
+    );
+    assert!(
+        wait_for(1, &obs.b_calls, Duration::from_secs(2)),
+        "the ResultB completion routed to on_result_b"
+    );
+
+    // Each completion landed on the correct handler with the correct
+    // payload — output-type routing, not a kind id.
+    assert_eq!(
+        obs.a_value.load(AtomicOrdering::SeqCst),
+        7,
+        "on_result_a saw its own dispatch's value"
+    );
+    assert_eq!(
+        obs.b_tag.load(AtomicOrdering::SeqCst),
+        9,
+        "on_result_b saw its own dispatch's tag"
+    );
+
+    // Neither completion was mis-delivered to the other-typed handler:
+    // each task handler fired exactly once. A wrong-type probe in the
+    // completion arm must leave the ledger entry intact (non-consuming
+    // `try_take_task_done`) — if it consumed, one handler would swallow
+    // the other's completion and its call count would be 0.
+    assert_eq!(
+        obs.a_calls.load(AtomicOrdering::SeqCst),
+        1,
+        "on_result_a fired exactly once (no mis-routed extra completion)"
+    );
+    assert_eq!(
+        obs.b_calls.load(AtomicOrdering::SeqCst),
+        1,
+        "on_result_b fired exactly once"
+    );
+    assert_eq!(
+        obs.dispatched.load(AtomicOrdering::SeqCst),
+        2,
+        "both kick handlers dispatched a worker"
+    );
 
     drop(chassis);
 }


### PR DESCRIPTION
Part 1b of iamacoffeepot/aether#1313 (ADR-0093) — the `#[handler(task)]` macro sugar on top of the PR iamacoffeepot/aether#1320 runtime.

## What landed

Caps now declare a completion handler instead of hand-wiring `TaskCompletionWake` + `take_task_done`:

```rust
#[handler(task)]
fn on_image_done(&mut self, ctx, done: TaskDone<NanobananaResult>) { done.resolve(ctx); }

#[handler(task)]
fn on_audio_done(&mut self, ctx, done: TaskDone<LyriaResult>) { done.resolve(ctx); }
```

- **`#[handler(task)]` is a variant of `#[handler]`** — three spellings: `#[handler]` / `#[handler(mail)]` (inbound mail, default, unchanged) and `#[handler(task)]` (a dispatch completion). A bad arg is a pointed compile error.
- **Multiple task handlers per actor, routed by output type.** All completions arrive as the single `TaskCompletionWake` kind, so the macro emits **one** native dispatch arm that decodes the `DispatchId` then tries each task handler's `(O, C)` via a **non-consuming** `try_take_task_done` — a wrong-type probe leaves the ledger entry intact so a later handler still claims its completion. Routed by `O`, not a kind id.
- **Duplicate `O` across task handlers is a compile error** (ambiguous routing). Task handlers get no `HandlesKind<K>` impl and stay out of the `aether.kinds.inputs` manifest — a completion is not inbound mail.
- **Native-only**: the wasm/bridge path rejects `#[handler(task)]` (ADR-0093 §7).

## Runtime tweak (the peek-then-take half)

PR1a's `take_task_done` removes-then-downcasts (a wrong type consumes the entry — fine for one handler). This adds the non-consuming sibling `try_take_task_done` / `dispatch_try_take` / `InflightTable::try_take`: `get` + `downcast_ref` probes on both the output and context boxes, taking (removing) only when both match. That's what makes the multi-handler try-chain safe. `take_task_done` stays for the single-handler / hand-wired path.

## Tested

New `tests/native_actor_macro.rs::macro_routes_task_completions_by_output_type`: a cap with two `#[handler(task)]` of distinct `O`, driven through real chassis dispatch — asserts each completion lands on the correct handler with the correct payload, exactly once, and is not mis-delivered to the wrong-type handler.

`scripts/preflight.sh` green — fmt, clippy `--all-targets -D warnings`, doc (`RUSTDOCFLAGS=-D warnings`), nextest (1469 passed across the workspace), wasm32 cross-build.

## Next

PR2 migrates Gemini + Anthropic onto `dispatch_blocking` / `#[handler(task)]` and retires `InFlightDispatch` (Gemini keeps `NanobananaResult` and `LyriaResult` as *separate* task handlers, no enum). The deferred `max_in_flight` rate-limit bound (ADR-0050 §2) lands there; the thread-per-request → work-stealing pool swap is iamacoffeepot/aether#1322.

Part of iamacoffeepot/aether#1313 (closes on the final migration PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
