### PR TITLE
feat(substrate): dispatch_blocking_resumed for deferred (hold, reply_to) handoff

### DIFF
--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -32,6 +32,7 @@ use crate::actor::native::binding::NativeBinding;
 use crate::actor::registry::MonitorError;
 use crate::mail::ReplyTo;
 use crate::mail::mailer::Mailer;
+use crate::runtime::trace::SettlementHold;
 
 use super::{NativeActor, NativeDispatch};
 use crate::actor::native::InheritCtx;
@@ -189,22 +190,66 @@ impl<'a> NativeCtx<'a> {
         C: Send + 'static,
         F: FnOnce() -> O + Send + 'static,
     {
-        // Two deferred follow-ups, both behind this exact call-site API:
-        //   - per-source concurrency bound + pending queue
-        //     (InFlightDispatch::max_in_flight, default 4) so the paid-
-        //     endpoint rate limit (ADR-0050 §2) is honoured — lands with
-        //     the content-gen migration (#1313). PR1a dispatches at once.
-        //   - the per-request thread spawn below is a placeholder; the
-        //     scalable form is a reused work-stealing blocking pool,
-        //     isolated from the cooperative scheduler so blocking work
-        //     can't starve it (#1322).
-        //
-        // ADR-0093 §1 / ADR-0080 §12: eager-acquire the hold on this
-        // thread before spawning, exactly like `spawn_inherit`. The
-        // `MailId::NONE` root skips it — no chain to keep open.
-        let root = self.in_flight_root;
-        let hold = self.mailer().acquire_settlement_hold(root);
-        let reply_to = self.sender;
+        // ADR-0093 §1 / ADR-0080 §12: acquire the hold on the current root
+        // and capture the reply target from *this* handler, then hand them
+        // to the resumed core. The `MailId::NONE` root skips the hold — no
+        // chain to keep open. A bounded `TaskQueue` (aether-capabilities)
+        // instead captures `(hold, reply_to)` at accept time and replays
+        // them via `dispatch_blocking_resumed` when a slot frees, so a
+        // deferred request keeps its own chain held and replies to its own
+        // caller.
+        let hold = self.acquire_settlement_hold();
+        let reply_to = self.reply_target();
+        self.dispatch_blocking_resumed_with(hold, reply_to, cx, f)
+    }
+
+    /// Acquire a [`SettlementHold`] on the current in-flight root
+    /// (ADR-0080 §12). `MailId::NONE` (no inbound chain) yields a no-op
+    /// hold. Use to keep a chain open across deferred work — e.g. a
+    /// `TaskQueue` buffering an over-limit request holds it until a slot
+    /// frees, then moves it into [`Self::dispatch_blocking_resumed`].
+    #[must_use]
+    pub fn acquire_settlement_hold(&self) -> SettlementHold {
+        self.mailer().acquire_settlement_hold(self.in_flight_root)
+    }
+
+    /// ADR-0093: dispatch a blocking closure with an externally-supplied
+    /// `(hold, reply_to)` — *moved in* rather than read from this ctx.
+    /// [`Self::dispatch_blocking`] is sugar over this that supplies them
+    /// from the current handler. The bound/queue path (`TaskQueue`)
+    /// captures the hold + reply target when a request is accepted and
+    /// replays them here when the request finally dispatches from a later
+    /// handler turn — so the deferred work keeps its *own* chain held and
+    /// replies to its *own* caller, not the completion handler's.
+    pub fn dispatch_blocking_resumed<O, F>(
+        &mut self,
+        hold: SettlementHold,
+        reply_to: ReplyTo,
+        f: F,
+    ) -> DispatchId
+    where
+        O: Send + 'static,
+        F: FnOnce() -> O + Send + 'static,
+    {
+        self.dispatch_blocking_resumed_with(hold, reply_to, (), f)
+    }
+
+    /// Context-carrying core of the resumed dispatch — the single worker
+    /// spawn site for every `dispatch_blocking*` path. Inserts the ledger
+    /// entry with the supplied `(hold, reply_to, cx)` and spawns the
+    /// worker that runs `f`, parks its output, and wakes the actor.
+    pub fn dispatch_blocking_resumed_with<O, C, F>(
+        &mut self,
+        hold: SettlementHold,
+        reply_to: ReplyTo,
+        cx: C,
+        f: F,
+    ) -> DispatchId
+    where
+        O: Send + 'static,
+        C: Send + 'static,
+        F: FnOnce() -> O + Send + 'static,
+    {
         let id = self.binding.dispatch_insert(hold, reply_to, Box::new(cx));
 
         // The worker captures the binding + dispatch id, runs the
@@ -214,7 +259,9 @@ impl<'a> NativeCtx<'a> {
         // push. This is the one sanctioned raw spawn for the
         // hold-until-resolve shape (ADR-0093) — umbrella-aware because
         // the hold (held in the ledger, not here) keeps the chain open
-        // until the resolve.
+        // until the resolve. The per-request spawn is a placeholder; the
+        // scalable form is a reused work-stealing blocking pool isolated
+        // from the cooperative scheduler (#1322).
         let binding = Arc::clone(self.binding);
         let spawned = ThreadBuilder::new()
             .name(String::from("aether-dispatch-blocking"))

--- a/crates/aether-substrate/src/actor/native/dispatch_blocking.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch_blocking.rs
@@ -575,6 +575,99 @@ mod tests {
         );
     }
 
+    /// The resumed entry uses the *supplied* `(hold, reply_to)`, not the
+    /// dispatching ctx's — the property a bounded `TaskQueue` relies on
+    /// when it drains a buffered request from a *different* handler's turn.
+    /// Accept on one root/caller, dispatch via `dispatch_blocking_resumed`
+    /// from a ctx with a different root and reply target, then assert the
+    /// *accept* chain is the one held and the *original* caller is replied
+    /// to.
+    #[test]
+    fn dispatch_blocking_resumed_uses_supplied_hold_and_reply_to() {
+        let (registry, mailer) = fresh_substrate();
+        let counter = Arc::clone(mailer.trace_handle().settlement_counter());
+
+        let (reply_tx, reply_rx) = mpsc::channel::<OwnedDispatch>();
+        let caller = registry.register_inbox("test.dispatch_resumed.caller", forward_to(reply_tx));
+
+        let actor_mailbox = mailbox_id_from_name("test.dispatch_resumed.actor");
+        let binding = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            actor_mailbox,
+        ));
+        let (wake_tx, wake_rx) = mpsc::channel::<OwnedDispatch>();
+        registry.register_inbox("test.dispatch_resumed.actor", forward_to(wake_tx));
+
+        let accept_root = root_id(1);
+        let caller_reply_to = ReplyTo::with_correlation(ReplyTarget::Component(caller), 77);
+
+        // "Accept": acquire the hold on the accept root + capture the
+        // caller, as a TaskQueue does when buffering an over-limit request.
+        let buffered_hold = {
+            let ctx = NativeCtx::new(&binding, caller_reply_to, MailId::NONE, accept_root);
+            ctx.acquire_settlement_hold()
+        };
+        assert_eq!(
+            counter.held_open(accept_root),
+            1,
+            "the accept-time hold keeps the chain open while buffered"
+        );
+
+        // "Drain": dispatch the buffered work from a *different* handler
+        // turn — a ctx with a different root and reply target — passing the
+        // captured `(hold, reply_to)` explicitly.
+        let other_root = root_id(2);
+        let id = {
+            let mut ctx = NativeCtx::new(
+                &binding,
+                ReplyTo::with_correlation(ReplyTarget::None, 99),
+                MailId::NONE,
+                other_root,
+            );
+            ctx.dispatch_blocking_resumed(buffered_hold, caller_reply_to, move || Answer {
+                value: 7,
+            })
+        };
+
+        // The held chain is the accept root, not the drain ctx's root.
+        assert_eq!(
+            counter.held_open(accept_root),
+            1,
+            "the supplied hold keeps the accept chain open across the resumed dispatch"
+        );
+        assert_eq!(
+            counter.held_open(other_root),
+            0,
+            "the drain ctx's own chain is never held"
+        );
+
+        let landed = await_wake(&wake_rx);
+        assert_eq!(landed, id);
+
+        {
+            let mut ctx = NativeCtx::new(&binding, ReplyTo::NONE, MailId::NONE, MailId::NONE);
+            let done = ctx
+                .take_task_done::<Answer, ()>(id)
+                .expect("the resumed dispatch is in the ledger");
+            assert_eq!(*done.output(), Answer { value: 7 });
+            done.resolve(&mut ctx);
+        }
+
+        // Reply went to the *original* caller (corr 77), not the drain ctx.
+        let reply = reply_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("the re-reply lands on the captured caller, not the drain ctx");
+        assert_eq!(
+            reply.sender.correlation_id, 77,
+            "the resumed dispatch replies to the captured caller, not the drain ctx"
+        );
+        assert_eq!(
+            counter.held_open(accept_root),
+            0,
+            "resolve releases the captured hold"
+        );
+    }
+
     /// `dispatch_blocking_with` carries an opt-in context the completion
     /// handler reads via `TaskDone::context`, and `resolve_with` maps
     /// `(output, context)` to the reply.


### PR DESCRIPTION
Part 1c of iamacoffeepot/aether#1313 (ADR-0093) — the small framework hook the bounded `TaskQueue` (PR2) needs.

## What changed

`dispatch_blocking` acquired its settlement hold and read its reply target from the *current* handler's ctx. That's correct for the immediate path, but a bounded queue that **buffers** an over-limit request and dispatches it **later** — from a different handler's turn (a completion) — would then stamp it with the wrong chain root and wrong caller.

So this splits `dispatch_blocking` into the ctx-reading sugar and an explicit-context core:

- **`dispatch_blocking_resumed{,_with}(hold, reply_to, ...)`** — takes the `SettlementHold` and `ReplyTo` *by value* (moved in) instead of reading them from ctx.
- **`NativeCtx::acquire_settlement_hold()`** — acquires a hold on the current in-flight root (`MailId::NONE` → no-op), so a caller can capture the chain context at accept time.
- **`dispatch_blocking(work)` is now sugar** over the resumed core: acquire the hold from the current root, read the current reply target, hand them in. No behavior change to existing callers (all dispatch tests unchanged + green).

This is the "pick up the hold" mechanism: a `TaskQueue` captures `(hold, reply_to)` when it accepts an over-limit request (holding the chain while it waits), then **moves** them into `dispatch_blocking_resumed` when a slot frees — so the deferred work keeps its *own* chain held and replies to its *own* caller, not the completion handler's. The hold-threading lives in the helper, once; no cap touches a `SettlementHold` by hand.

## Tested

New `dispatch_blocking_resumed_uses_supplied_hold_and_reply_to`: accepts on one root/caller, dispatches via `dispatch_blocking_resumed` from a ctx with a *different* root and reply target, and asserts the **accept** chain is the one held (not the drain ctx's) and the **original** caller is replied to (not the drain ctx's). The existing `dispatch_blocking` tests are unchanged and green (they now exercise the resumed core through the sugar).

`scripts/preflight.sh` green — fmt, clippy `--all-targets -D warnings`, doc, nextest (1470 passed), wasm32 cross-build.

## Next

PR2: `TaskQueue` (the slimmed `InFlightDispatch` — buffer + slot count + hold-handoff over this entry) + migrate Gemini/Anthropic onto `submit`/`on_complete` + `#[handler(task)]`, retiring `InFlightDispatch`. (Tasks-as-first-class / actor-declared task behaviors tracked separately in iamacoffeepot/aether#1328.)

Part of iamacoffeepot/aether#1313 (closes on the final migration PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
