### PR TITLE
fix(capabilities): headless window cap replies via the mailer, not hub outbound

### DIFF
--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -1099,6 +1099,89 @@ mod tests {
         }
     }
 
+    /// iamacoffeepot/aether#1321 regression: a `Call` routed through the
+    /// RPC server tags its reply `ReplyTarget::Component(rpc_server)`, so
+    /// a capability that replies via `HubOutbound::send_reply` (which
+    /// only routes `Session` / `EngineMailbox`) drops the reply silently —
+    /// the same drop #1316/#1319 fixed for the desktop driver. The
+    /// `HeadlessWindowCapability` `Err`-replies on `set_window_mode`; with
+    /// the bug present this `Call` would yield a bare `ReplyEnd` and zero
+    /// `ReplyEvent`s. Routing through the `Mailer` (the complete router)
+    /// pushes the reply back locally to the server's `on_any`, so the
+    /// `Err` rides home as a `ReplyEvent` before the `ReplyEnd`.
+    #[test]
+    fn call_headless_window_set_mode_err_reaches_component_reply() {
+        use crate::rpc::wire::{MailEnvelope, MailboxAddress};
+        use crate::trace::TraceDispatchCapability;
+        use crate::window::HeadlessWindowCapability;
+        use aether_actor::Actor;
+        use aether_data::{Kind, mailbox_id_from_name};
+        use aether_kinds::{SetWindowMode, SetWindowModeResult, WindowMode};
+
+        let (registry, mailer) = fresh_substrate();
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<TraceDispatchCapability>(())
+            .with_actor::<HeadlessWindowCapability>(())
+            .with_actor::<RpcServerCapability>(RpcServerConfig {
+                bind_addr: "127.0.0.1:0".into(),
+                peer_kind: test_peer_kind(),
+            })
+            .build_passive()
+            .expect("caps boot");
+
+        let mut stream = connect_to_rpc_server(&chassis, Duration::from_secs(5));
+        complete_handshake(&mut stream);
+
+        let payload = postcard::to_allocvec(&SetWindowMode {
+            mode: WindowMode::Windowed,
+            width: None,
+            height: None,
+        })
+        .expect("test setup: SetWindowMode serializes via postcard");
+        let window_mailbox = mailbox_id_from_name(<HeadlessWindowCapability as Actor>::NAMESPACE);
+        write_frame(
+            &mut stream,
+            &WireFrame::Call {
+                cid: Some(0xdef),
+                envelope: MailEnvelope {
+                    to: MailboxAddress::local(window_mailbox),
+                    from: None,
+                    kind: <SetWindowMode as Kind>::ID,
+                    correlation_id: None,
+                    payload,
+                },
+            },
+        )
+        .expect("test: write_frame Call to rpc server");
+
+        // The `Err` reply must arrive as a ReplyEvent — the drop this
+        // test guards against would leave zero events before ReplyEnd.
+        let event: WireFrame = read_frame(&mut stream).expect("read ReplyEvent");
+        let envelope = match event {
+            WireFrame::ReplyEvent { cid, envelope } => {
+                assert_eq!(cid, 0xdef);
+                envelope
+            }
+            other => panic!("expected ReplyEvent, got {other:?}"),
+        };
+        assert_eq!(envelope.kind, <SetWindowModeResult as Kind>::ID);
+        let decoded: SetWindowModeResult =
+            postcard::from_bytes(&envelope.payload).expect("decode SetWindowModeResult");
+        assert!(
+            matches!(decoded, SetWindowModeResult::Err { .. }),
+            "headless window cap replies Err, got {decoded:?}"
+        );
+
+        let end: WireFrame = read_frame(&mut stream).expect("read ReplyEnd");
+        match end {
+            WireFrame::ReplyEnd { cid, result } => {
+                assert_eq!(cid, 0xdef);
+                result.expect("ReplyEnd result Ok");
+            }
+            other => panic!("expected ReplyEnd, got {other:?}"),
+        }
+    }
+
     /// iamacoffeepot/aether#1031 end-to-end: a `Call` against an actor
     /// that replies through the ADR-0093 hold-until-resolve dispatch
     /// (spawned worker -> completion wake -> re-reply) must still

--- a/crates/aether-capabilities/src/window.rs
+++ b/crates/aether-capabilities/src/window.rs
@@ -15,16 +15,12 @@ use aether_kinds::{FocusWindow, SetWindowMode, SetWindowTitle};
 
 #[aether_actor::bridge(singleton)]
 mod native {
-    use std::sync::Arc;
-
     use aether_actor::actor;
     use aether_kinds::{FocusWindowResult, SetWindowModeResult, SetWindowTitleResult};
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
-    use aether_substrate::mail::outbound::HubOutbound;
 
     use super::{FocusWindow, SetWindowMode, SetWindowTitle};
-    use std::io;
 
     /// Chassis-without-window companion to the desktop driver's
     /// driver-as-actor `aether.window` claim. Mirrors
@@ -35,9 +31,7 @@ mod native {
     ///
     /// Each chassis composes one of {desktop driver, this cap}, never
     /// both — the chassis builder rejects double-claiming a mailbox.
-    pub struct HeadlessWindowCapability {
-        outbound: Arc<HubOutbound>,
-    }
+    pub struct HeadlessWindowCapability;
 
     #[actor]
     impl NativeActor for HeadlessWindowCapability {
@@ -45,22 +39,24 @@ mod native {
 
         const NAMESPACE: &'static str = "aether.window";
 
-        fn init(_config: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            let outbound = ctx.mailer().outbound().cloned().ok_or_else(|| {
-                BootError::Other(Box::new(io::Error::other(
-                    "HubOutbound must be wired on Mailer before \
-                     HeadlessWindowCapability::init (chassis main connects the hub before \
-                     the Builder chain)",
-                )))
-            })?;
-            Ok(Self { outbound })
+        fn init(_config: (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            Ok(Self)
         }
 
         /// Reply `Err` so MCP `set_window_mode` fails fast instead of
         /// hanging on a reply that never comes.
+        ///
+        /// Reply through `ctx.mailer().send_reply` (the `Mailer`, the
+        /// complete router) rather than `HubOutbound::send_reply`, which
+        /// silently drops `ReplyTarget::Component` — the local-RPC-server
+        /// reply target an MCP-spawned engine tags (iamacoffeepot/aether#1321,
+        /// matching the desktop driver fix in #1319).
+        // `&self` keeps the dispatch ABI (ADR-0033 / ADR-0038); the
+        // capability is stateless, so the reply routes purely off `ctx`.
+        #[allow(clippy::unused_self)]
         #[handler]
         fn on_set_mode(&self, ctx: &mut NativeCtx<'_>, _mail: SetWindowMode) {
-            self.outbound.send_reply(
+            ctx.mailer().send_reply(
                 ctx.reply_target(),
                 &SetWindowModeResult::Err {
                     error: "unsupported on this chassis — no window peripheral".to_owned(),
@@ -69,9 +65,10 @@ mod native {
         }
 
         /// Reply `Err` for the same reason as `on_set_mode`.
+        #[allow(clippy::unused_self)]
         #[handler]
         fn on_set_title(&self, ctx: &mut NativeCtx<'_>, _mail: SetWindowTitle) {
-            self.outbound.send_reply(
+            ctx.mailer().send_reply(
                 ctx.reply_target(),
                 &SetWindowTitleResult::Err {
                     error: "unsupported on this chassis — no window peripheral".to_owned(),
@@ -82,9 +79,10 @@ mod native {
         /// Reply `Err` for the same reason as `on_set_mode`
         /// (iamacoffeepot/aether#1318): a chassis without a window
         /// peripheral can't foreground one.
+        #[allow(clippy::unused_self)]
         #[handler]
         fn on_focus(&self, ctx: &mut NativeCtx<'_>, _mail: FocusWindow) {
-            self.outbound.send_reply(
+            ctx.mailer().send_reply(
                 ctx.reply_target(),
                 &FocusWindowResult::Err {
                     error: "unsupported on this chassis — no window peripheral".to_owned(),


### PR DESCRIPTION
## Summary

`HeadlessWindowCapability` (`crates/aether-capabilities/src/window.rs`) replied to `set_window_mode` / `set_window_title` / `focus` through `HubOutbound::send_reply`, which only routes `ReplyTarget::Session` / `EngineMailbox` and **silently drops `ReplyTarget::Component`** (and `None`). This is the same drop iamacoffeepot/aether#1316 / iamacoffeepot/aether#1319 fixed for the desktop driver.

On headless / test-bench this was latent, not live: hub- and MCP-routed calls arrive with `Session` / `EngineMailbox` targets, which `HubOutbound` handles. The drop bites only when a local-RPC-server dispatch reaches the cap — that path tags replies `ReplyTarget::Component(rpc_server)` so they route back locally to the server's `on_any`, and `HubOutbound` drops them first, yielding a bare `ReplyEnd` with zero reply events.

## Fix

Route through `ctx.mailer().send_reply` (the complete router, which handles `Component` by pushing the reply as local mail), so the cap is correct regardless of reply target rather than relying on headless never seeing a `Component` target. The struct no longer holds the `HubOutbound` it only used for this — it becomes stateless (`&self` kept for the dispatch ABI, `#[allow(clippy::unused_self)]`).

## Test

Unlike the desktop path (iamacoffeepot/aether#1319, not reachable in-crate), the headless cap's Component reply path *is* exercisable through the in-crate RPC-server harness. Added `call_headless_window_set_mode_err_reaches_component_reply`: it fires a `Call` at the `aether.window` mailbox through the RPC server (Component reply target) and asserts the `Err` rides home as a `ReplyEvent` before `ReplyEnd`. Against the old `HubOutbound` path it fails with the exact `expected ReplyEvent, got ReplyEnd { result: Ok(()) }` signature — the iamacoffeepot/aether#1316 failure mode — confirming it is a real regression guard.

Preflight green (fmt + clippy + doc + nextest + wasm32 cross-build).

Closes iamacoffeepot/aether#1321

🤖 Generated with [Claude Code](https://claude.com/claude-code)