### PR TITLE
chore(substrate): lint raw thread spawns against the ctx/task umbrella

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,13 @@
+# Raw OS-thread spawns bypass the trace + settlement umbrella (ADR-0080 §12):
+# the spawned work emits no HoldOpen/Release and any mail it pushes is rootless,
+# so it is invisible to settlement and the trace tree. Handler/capability code
+# must instead route through a sanctioned primitive:
+#   - NativeCtx::spawn_inherit / spawn_detached  (ADR-0080 §12) for chain-continuing async work
+#   - the ADR-0093 task system (dispatch_blocking / TaskQueue / #[handler(task)]) for per-handler blocking work
+# Every remaining raw spawn is infra below the actor/mail layer (transport sockets,
+# worker pools, device-callback threads, periodic timers, the primitive's own impl)
+# and must carry an explicit #[allow(clippy::disallowed_methods)] + a one-line reason.
+disallowed-methods = [
+    { path = "std::thread::spawn", reason = "raw thread spawn bypasses the settlement/trace umbrella; use NativeCtx::spawn_inherit/spawn_detached or the ADR-0093 task system, or #[allow] with a reason for infra threads" },
+    { path = "std::thread::Builder::spawn", reason = "raw thread spawn bypasses the settlement/trace umbrella; use NativeCtx::spawn_inherit/spawn_detached or the ADR-0093 task system, or #[allow] with a reason for infra threads" },
+]

--- a/crates/aether-actor/src/local.rs
+++ b/crates/aether-actor/src/local.rs
@@ -385,6 +385,7 @@ pub trait Local: Default + 'static {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // test scaffolding — threads here hold no settlement contract
 mod tests {
     extern crate std;
 

--- a/crates/aether-capabilities/src/anthropic/cli.rs
+++ b/crates/aether-capabilities/src/anthropic/cli.rs
@@ -100,6 +100,10 @@ impl ClaudeCliAdapter {
         // `claude` (and thus the deadline poll) while we own the `Child`
         // on this thread. stderr is small and drained after the wait.
         let stdout = child.stdout.take();
+        // Scoped stdout-drain sub-thread inside the blocking call (joined before
+        // return, just below) — the blocking call itself already runs on a
+        // task-system worker; this thread touches no mail and holds no chain.
+        #[allow(clippy::disallowed_methods)]
         let stdout_reader = thread::spawn(move || {
             let mut buf = Vec::new();
             if let Some(mut out) = stdout {

--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -855,6 +855,9 @@ mod native {
         let (init_tx, init_rx) = mpsc::channel::<Result<AudioEventSender, AudioBuildError>>();
         let (shutdown_tx, shutdown_rx) = mpsc::channel::<()>();
 
+        // cpal device-callback thread, owned by the audio backend — not actor work,
+        // no ctx, no inbound chain; the audio peripheral runs outside the mail layer.
+        #[allow(clippy::disallowed_methods)]
         let thread = thread::Builder::new()
             .name("aether-audio-cpal".into())
             .spawn(move || {

--- a/crates/aether-capabilities/src/dag.rs
+++ b/crates/aether-capabilities/src/dag.rs
@@ -88,6 +88,10 @@ mod native {
             let reap_shutdown_for_thread = Arc::clone(&reap_shutdown);
             let reap_kind = KindId(<DagReapTick as Kind>::ID.0);
             let timer_mailer = Arc::clone(&mailer);
+            // Periodic reap timer spawned at init — no inbound chain to inherit and no
+            // ctx here. Its wake is currently a rootless Mail::new; routing that through a
+            // tracked chassis-root path is tracked by iamacoffeepot/aether#1335.
+            #[allow(clippy::disallowed_methods)]
             let spawned = thread::Builder::new()
                 .name("aether-dag-reaper".to_owned())
                 .spawn(move || {

--- a/crates/aether-capabilities/src/rpc/client.rs
+++ b/crates/aether-capabilities/src/rpc/client.rs
@@ -180,6 +180,9 @@ impl RpcClient {
         let shutdown_for_thread = Arc::clone(&shutdown);
         let (inbound_tx, inbound_rx) = mpsc::channel::<WireFrame>();
 
+        // Transport thread below the mail layer — it carries inbound mail in;
+        // no inbound chain to inherit, so no settlement umbrella to honor.
+        #[allow(clippy::disallowed_methods)]
         let thread = thread::Builder::new()
             .name("aether-rpc-client-reader".into())
             .spawn(move || {
@@ -266,6 +269,7 @@ impl RpcClient {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // test scaffolding — threads here hold no settlement contract
 mod tests {
     use super::{RpcClient, RpcClientError};
     use crate::rpc::server::{RpcServerCapability, RpcServerConfig, RpcServerHandle};

--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -211,6 +211,9 @@ mod server_native {
             let self_id = ctx.self_id();
             let wake_kind = KindId(<RpcInboundReady as Kind>::ID.0);
 
+            // Transport thread below the mail layer — it accepts sockets that carry
+            // inbound mail in; no inbound chain to inherit, no settlement umbrella.
+            #[allow(clippy::disallowed_methods)]
             let thread = thread::Builder::new()
                 .name(format!("aether-rpc-accept-{port}"))
                 .spawn(move || {
@@ -488,6 +491,9 @@ mod server_native {
             let wake_kind = KindId(<RpcInboundReady as Kind>::ID.0);
             let inbound_tx = self.inbound_tx.clone();
 
+            // Per-connection transport reader below the mail layer — carries inbound
+            // mail in; no inbound chain to inherit, no settlement umbrella.
+            #[allow(clippy::disallowed_methods)]
             let thread = match thread::Builder::new()
                 .name(format!("aether-rpc-reader-{conn_id}"))
                 .spawn(move || {

--- a/crates/aether-capabilities/src/tcp/listener.rs
+++ b/crates/aether-capabilities/src/tcp/listener.rs
@@ -103,6 +103,9 @@ mod listener_native {
             let self_id = ctx.self_id();
             let connection_ready_kind = KindId(<ConnectionReady as Kind>::ID.0);
 
+            // Transport thread below the mail layer — it carries inbound mail in;
+            // no inbound chain to inherit, so no settlement umbrella to honor.
+            #[allow(clippy::disallowed_methods)]
             let thread = thread::Builder::new()
                 .name(format!("aether-tcp-accept-{port}"))
                 .spawn(move || {

--- a/crates/aether-capabilities/src/tcp/session.rs
+++ b/crates/aether-capabilities/src/tcp/session.rs
@@ -123,6 +123,9 @@ mod session_native {
             let data_ready_kind = KindId(<SessionDataReady as Kind>::ID.0);
 
             let thread_name = format!("aether-tcp-read-{}", config.session_name);
+            // Transport thread below the mail layer — it carries inbound mail in;
+            // no inbound chain to inherit, so no settlement umbrella to honor.
+            #[allow(clippy::disallowed_methods)]
             let thread = thread::Builder::new()
                 .name(thread_name)
                 .spawn(move || {

--- a/crates/aether-mcp/src/rpc.rs
+++ b/crates/aether-mcp/src/rpc.rs
@@ -105,6 +105,9 @@ impl Connection {
         let dead = Arc::new(AtomicBool::new(false));
         let router_pending = Arc::clone(&pending);
         let router_dead = Arc::clone(&dead);
+        // Out-of-process aether-mcp router — not an engine actor; there is no
+        // settlement/trace umbrella in this process to opt out of.
+        #[allow(clippy::disallowed_methods)]
         let router = thread::Builder::new()
             .name("aether-mcp-rpc-router".into())
             .spawn(move || {
@@ -578,6 +581,7 @@ fn register_call(
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // test scaffolding — threads here hold no settlement contract
 mod tests {
     use super::RpcSession;
     use aether_capabilities::rpc::{

--- a/crates/aether-substrate-bundle/tests/spawn_args_overlay.rs
+++ b/crates/aether-substrate-bundle/tests/spawn_args_overlay.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_methods)] // integration test — spawns helper binaries/threads; no settlement contract
 // ADR-0090 unit d (issue 1258) acceptance test: argv reaches the
 // headless chassis binary and shadows `AETHER_TICK_HZ`. Spawns
 // `aether-substrate-headless` three times with the bin's

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -903,6 +903,7 @@ impl NativeBinding {
     clippy::unwrap_used,
     reason = "test-setup unwraps: fixture construction panic on failure is the assertion"
 )]
+#[allow(clippy::disallowed_methods)] // test scaffolding — threads here hold no settlement contract
 mod tests {
     use super::*;
     use crate::mail::registry::{InboxHandler, OwnedDispatch};

--- a/crates/aether-substrate/src/actor/native/blob_lifecycle.rs
+++ b/crates/aether-substrate/src/actor/native/blob_lifecycle.rs
@@ -215,6 +215,7 @@ impl Lifecycle {
     clippy::needless_collect,
     reason = "test setup: unwraps signal failure; thread handles are collected so every worker is spawned before any join"
 )]
+#[allow(clippy::disallowed_methods)] // test scaffolding — threads here hold no settlement contract
 mod tests {
     use super::*;
     use std::collections::BTreeSet;

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -263,6 +263,9 @@ impl<'a> NativeCtx<'a> {
         // scalable form is a reused work-stealing blocking pool isolated
         // from the cooperative scheduler (#1322).
         let binding = Arc::clone(self.binding);
+        // This IS the ADR-0093 dispatch_blocking primitive — the hold lives in the
+        // ledger (not on this worker), so the chain stays open until the resolve.
+        #[allow(clippy::disallowed_methods)]
         let spawned = ThreadBuilder::new()
             .name(String::from("aether-dispatch-blocking"))
             .spawn(move || {

--- a/crates/aether-substrate/src/actor/native/spawn_thread.rs
+++ b/crates/aether-substrate/src/actor/native/spawn_thread.rs
@@ -310,6 +310,9 @@ impl<A: Actor> MailSender for RootCtx<A> {
 /// `spawn_inherit` entry point on
 /// [`super::ctx::NativeCtx`]; this function is the crate-private
 /// runtime body it delegates to.
+// This IS the spawn_inherit primitive (ADR-0080 §12) — the sanctioned raw spawn
+// the lint points callers at; it cannot route through itself.
+#[allow(clippy::disallowed_methods)]
 pub(crate) fn spawn_inherit<A, F>(
     binding: Arc<NativeBinding>,
     in_flight_mail_id: MailId,
@@ -348,6 +351,9 @@ where
 /// ADR-0080 §12 thread-spawn helper. Spawns a thread carrying a
 /// [`RootCtx<A>`] — each send the worker emits mints a fresh root
 /// chain with `A`'s mailbox as producer.
+// This IS the spawn_detached primitive (ADR-0080 §12) — the sanctioned raw spawn
+// the lint points callers at; it cannot route through itself.
+#[allow(clippy::disallowed_methods)]
 pub(crate) fn spawn_detached<A, F>(binding: Arc<NativeBinding>, f: F) -> JoinHandle<()>
 where
     A: Actor + Singleton + 'static,

--- a/crates/aether-substrate/src/chassis/settlement.rs
+++ b/crates/aether-substrate/src/chassis/settlement.rs
@@ -471,6 +471,7 @@ fn wedge(
     clippy::unwrap_used,
     reason = "test-setup unwraps: fixture construction and decode panic on failure is the assertion"
 )]
+#[allow(clippy::disallowed_methods)] // test scaffolding — threads here hold no settlement contract
 mod tests {
     use super::*;
     use crate::handle_store::HandleStore;

--- a/crates/aether-substrate/src/chassis/settlement_counter.rs
+++ b/crates/aether-substrate/src/chassis/settlement_counter.rs
@@ -308,6 +308,7 @@ impl Default for SettlementCounter {
     clippy::cast_sign_loss,
     reason = "test arithmetic: thread joins and small bounded loop counters"
 )]
+#[allow(clippy::disallowed_methods)] // test scaffolding — threads here hold no settlement contract
 mod tests {
     use super::*;
     use aether_data::MailboxId;

--- a/crates/aether-substrate/src/chassis/settlement_table.rs
+++ b/crates/aether-substrate/src/chassis/settlement_table.rs
@@ -444,6 +444,7 @@ impl Default for SettlementTable {
     clippy::cast_sign_loss,
     reason = "test arithmetic: thread joins and small bounded loop counters"
 )]
+#[allow(clippy::disallowed_methods)] // test scaffolding — threads here hold no settlement contract
 mod tests {
     use super::*;
     use aether_data::MailboxId;

--- a/crates/aether-substrate/src/dag/transform_pool.rs
+++ b/crates/aether-substrate/src/dag/transform_pool.rs
@@ -97,6 +97,9 @@ impl TransformPool {
             let outcomes = Arc::clone(&outcomes);
             let invoke_count = Arc::clone(&invoke_count);
             let mailer = Arc::clone(mailer);
+            // DAG transform worker pool — execution floor below the actor model,
+            // built without a ctx; not per-handler chain work.
+            #[allow(clippy::disallowed_methods)]
             let spawned = thread::Builder::new()
                 .name(format!("aether-transform-{i}"))
                 .spawn(move || worker_loop(&rx, &outcomes, &invoke_count, &mailer));

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -1462,6 +1462,9 @@ impl HandleStore {
         };
         let weak = Arc::downgrade(self);
         let tick = Duration::from_secs(cfg.eviction_tick_secs.max(1));
+        // Long-lived eviction timer — spawned without a ctx, no inbound chain to
+        // inherit; periodic infra, not per-handler work.
+        #[allow(clippy::disallowed_methods)]
         thread::Builder::new()
             .name("handle-store-evict".to_owned())
             .spawn(move || {

--- a/crates/aether-substrate/src/mail/ring.rs
+++ b/crates/aether-substrate/src/mail/ring.rs
@@ -784,6 +784,7 @@ impl MailRing {
     clippy::needless_collect,
     reason = "test code: unwraps assert via panic; unsafe blocks exercise the ring API whose safety contracts are documented on the methods and upheld by construction here; casts are capacity-bounded; the consumer-handle collect forces every thread to spawn before any join"
 )]
+#[allow(clippy::disallowed_methods)] // test scaffolding — threads here hold no settlement contract
 mod tests {
     use std::collections::BTreeSet;
 

--- a/crates/aether-substrate/src/runtime/thread_name.rs
+++ b/crates/aether-substrate/src/runtime/thread_name.rs
@@ -236,6 +236,7 @@ pub fn current_thread_id() -> Option<ThreadId> {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // test scaffolding — threads here hold no settlement contract
 mod tests {
     use super::*;
 

--- a/crates/aether-substrate/src/scheduler/calibrate.rs
+++ b/crates/aether-substrate/src/scheduler/calibrate.rs
@@ -276,6 +276,10 @@ pub fn log_handoff_calibration() {
 /// round trip. The flags guard each `park` against a spurious return so
 /// the lockstep can't desync into a deadlock, and the sticky unpark token
 /// means an `unpark` that races ahead of its `park` is not lost.
+// Boot-time scheduler calibration probe — measures handoff cost before any actor
+// runs; no mail, no ctx, no settlement chain. (Spawn is a block-tail expression, so
+// the allow sits on the fn rather than the statement.)
+#[allow(clippy::disallowed_methods)]
 fn measure_handoff_cost_nanos() -> u64 {
     let rounds = WARMUP + TRIALS;
     // request: waker → worker hand-off signal; reply: worker → waker.
@@ -337,6 +341,7 @@ fn median_nanos(samples: &mut [u64]) -> u64 {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // test scaffolding — threads here hold no settlement contract
 mod tests {
     use super::*;
 

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -215,6 +215,9 @@ impl Pool {
             let aborter = Arc::clone(&aborter);
             let template = config.budget_template;
             let thread_name = name.clone();
+            // Scheduler worker pool — the execution floor that *runs* actors; spawned
+            // at boot, below the actor model. A handler's spawn_inherit work runs here.
+            #[allow(clippy::disallowed_methods)]
             let handle = thread::Builder::new()
                 .name(thread_name)
                 .spawn(move || worker_loop(idx, deque, stealers, injector, spin, aborter, template))

--- a/crates/aether-substrate/src/scheduler/spin_park.rs
+++ b/crates/aether-substrate/src/scheduler/spin_park.rs
@@ -368,6 +368,7 @@ impl Default for SpinPark {
     clippy::unwrap_used,
     reason = "test-setup unwraps: a failed recv/join is the assertion"
 )]
+#[allow(clippy::disallowed_methods)] // test scaffolding — threads here hold no settlement contract
 mod tests {
     use super::*;
     use crossbeam_channel::{Receiver, Sender, unbounded};

--- a/crates/aether-substrate/tests/handle_store_disk_eviction.rs
+++ b/crates/aether-substrate/tests/handle_store_disk_eviction.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_methods)] // integration test — spawns threads; no settlement contract
 //! Issue #986: disk eviction by created_at-LRU (ADR-0049 §5).
 //!
 //! When the on-disk byte ledger exceeds the budget, the eviction tick

--- a/crates/aether-substrate/tests/handle_store_persistence.rs
+++ b/crates/aether-substrate/tests/handle_store_persistence.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_methods)] // integration test — spawns threads; no settlement contract
 //! Issue #984: on-disk layout + atomic write path for the persistent
 //! handle store (ADR-0049 §2 + §3).
 //!


### PR DESCRIPTION
Closes iamacoffeepot/aether#1050.

## Summary

Raw `std::thread::spawn` / `Builder::spawn` in handler/capability code bypasses the trace + settlement umbrella (ADR-0080 §12): the spawned work emits no `HoldOpen`/`Release` and any mail it pushes is rootless, invisible to settlement and the trace tree. The sanctioned primitives already exist (`NativeCtx::spawn_inherit`/`spawn_detached`; the ADR-0093 task system) and the one chain-continuing raw spawn was already retired by iamacoffeepot/aether#1331 — but nothing *enforced* the boundary, so the next raw spawn added to a handler would compile clean and escape observability silently (which is how iamacoffeepot/aether#1048 happened).

This adds a workspace-root `clippy.toml` `disallowed-methods` rule for both spawn paths, with a message pointing at the primitives. It rides the existing `clippy --all-targets -- -D warnings` gate — no new CI job. Every remaining raw spawn now carries an explicit `#[allow]` + reason, so each opt-out is conscious and documented.

The lint's efficacy is proven by construction: before annotation it flagged **41 sites**; after the dispositions below, `cargo clippy --workspace --all-targets -- -D warnings` is green.

## Audit table

**Primitive — definitionally raw (the lint points callers here):**

| Site | Disposition |
|------|-------------|
| `actor/native/spawn_thread.rs` (`spawn_inherit`, `spawn_detached`) | fn-level `#[allow]` — these *are* the ADR-0080 §12 primitive |
| `actor/native/ctx.rs` (`dispatch_blocking` worker) | `#[allow]` — this *is* the ADR-0093 hold-until-resolve primitive (hold lives in the ledger) |

**Production infra below the actor/mail layer — per-site `#[allow]` + reason:**

| Site | Why raw |
|------|---------|
| `capabilities/dag.rs` | DAG reaper periodic timer; no inbound chain (rootless-wake fix tracked by iamacoffeepot/aether#1335) |
| `capabilities/audio.rs` | cpal device-callback thread, owned by the backend |
| `capabilities/tcp/{listener,session}.rs` | TCP transport — carries inbound mail in; below the mail layer |
| `capabilities/rpc/{client,server}.rs` (×3) | RPC transport — accept + per-connection readers below the mail layer |
| `capabilities/anthropic/cli.rs` | scoped stdout-drain inside the blocking call (joined before return) |
| `substrate/scheduler/pool.rs` | scheduler worker pool — the execution floor that runs actors |
| `substrate/scheduler/calibrate.rs` | boot-time handoff-cost probe; no mail/ctx |
| `substrate/dag/transform_pool.rs` | DAG transform worker pool; built without a ctx |
| `substrate/handle_store.rs` | eviction timer; spawned without a ctx |
| `aether-mcp/src/rpc.rs` | out-of-process router — not an engine actor; no umbrella in this process |

**Test scaffolding — outer `#[allow]` on the test module / file (threads honor no settlement contract):**

12 unit-test modules (`local`, `rpc/client`, `aether-mcp/rpc`, `binding`, `blob_lifecycle`, `settlement`, `settlement_counter`, `settlement_table`, `mail/ring`, `thread_name`, `calibrate`, `spin_park`) + 3 integration-test files (`spawn_args_overlay`, `handle_store_disk_eviction`, `handle_store_persistence`).

## Test plan

- `cargo clippy --workspace --all-targets -- -D warnings` green (the new rule rides this gate; a raw spawn added to handler code without an `#[allow]` fails it — empirically, it flagged 41 sites before annotation).
- `scripts/preflight.sh` green — fmt, clippy, `cargo doc`, nextest, wasm32 component cross-build.

## Generated by

`/implement` — agent execution of [scoped issue 1050](https://github.com/iamacoffeepot/aether/issues/1050).
