### PR TITLE
feat(substrate-bundle): hub liveness heartbeat to evict dead engines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,8 +57,8 @@ To restart the hub after a rebuild **without dropping the MCP session**, hit the
 
 Tools (`mcp__aether-hub__*`):
 
-- `list_engines` — every engine the hub supervises: `{engine_id, rpc_port}`.
-- `spawn_substrate(binary_path, args?)` — fork+exec a substrate (RPC port injected as `AETHER_RPC_PORT`). Returns `{engine_id, rpc_port}`.
+- `list_engines` — every engine the hub supervises: `{engine_id, rpc_port, last_heartbeat_age_millis}`. The hub heartbeats each engine (`AETHER_HUB_HEARTBEAT_INTERVAL_SECS` / `_MISS_LIMIT`, default 5 s × 3) and evicts a dead/wedged one from this list once it crosses the miss limit, so a listed engine is live (ADR-0090 / issue 1339); `last_heartbeat_age_millis` shows staleness short of eviction.
+- `spawn_substrate(binary_path, args?)` — fork+exec a substrate (RPC port injected as `AETHER_RPC_PORT`). Returns `{engine_id, rpc_port, last_heartbeat_age_millis}` (`0` — just spawned).
 - `terminate_substrate(engine_id)` — the engine's proxy SIGKILLs the child and self-shuts-down.
 - `send_mail(mails)` — best-effort batch; each item `{engine_id, recipient_name, kind_name, params}` is schema-encoded against the substrate vocabulary and routed as a wire `Call`. Per-item status.
 - `send_mail_traced(engine_id, mails, settlement_timeout_ms?)` — atomic batch under one shared trace root (the `aether.trace` mailbox); returns the full trace subtree once the chain settles, no window guessing (ADR-0080/0086). A bad spec aborts the whole batch.

--- a/crates/aether-capabilities/src/engine/mod.rs
+++ b/crates/aether-capabilities/src/engine/mod.rs
@@ -16,3 +16,5 @@ pub use proxy::EngineProxy;
 #[cfg(not(target_arch = "wasm32"))]
 pub use proxy::EngineProxyConfig;
 pub use server::EngineServer;
+#[cfg(not(target_arch = "wasm32"))]
+pub use server::{EngineConfig, EngineOverlay};

--- a/crates/aether-capabilities/src/engine/proxy.rs
+++ b/crates/aether-capabilities/src/engine/proxy.rs
@@ -37,24 +37,24 @@
 // Handler-signature kinds must be importable at file root — the
 // `#[bridge]` macro emits `impl HandlesKind<K>` markers as siblings of
 // the mod.
-use aether_kinds::{ForwardEnvelope, RpcInboundReady, TerminateEngine};
+use aether_kinds::{EngineHeartbeatTick, ForwardEnvelope, RpcInboundReady, TerminateEngine};
 
-// `EngineProxyConfig` carries only wasm-safe types, but it lives inside
-// the bridge mod (which the macro elides on wasm), so the re-export is
-// gated like `TcpListenerConfig`.
+// `EngineProxyConfig` / `HeartbeatParams` carry only wasm-safe types,
+// but they live inside the bridge mod (which the macro elides on wasm),
+// so the re-export is gated like `TcpListenerConfig`.
 #[cfg(not(target_arch = "wasm32"))]
-pub use proxy_native::EngineProxyConfig;
+pub use proxy_native::{EngineProxyConfig, HeartbeatParams};
 
 #[aether_actor::bridge(instanced, one_per = "engine")]
 mod proxy_native {
-    use super::{ForwardEnvelope, RpcInboundReady, TerminateEngine};
+    use super::{EngineHeartbeatTick, ForwardEnvelope, RpcInboundReady, TerminateEngine};
     use crate::rpc::{
         MailEnvelope, MailboxAddress, PeerKind, RpcClient, RpcClientError, RpcConnection, RpcError,
         WireFrame,
     };
     use aether_actor::actor;
-    use aether_data::{EngineId, Kind, KindId};
-    use aether_kinds::CallSettled;
+    use aether_data::{EngineId, Kind, KindId, MailboxId, mailbox_id_from_name};
+    use aether_kinds::{CallSettled, EngineAlive, EngineDied};
     use aether_substrate::Mail;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
@@ -64,8 +64,18 @@ mod proxy_native {
     use std::io::ErrorKind;
     use std::process::Child;
     use std::sync::Arc;
-    use std::thread;
+    use std::sync::mpsc;
+    use std::thread::{self, JoinHandle};
     use std::time::{Duration, Instant};
+
+    /// Mailbox of the engines cap (`aether.engine`) — where a proxy
+    /// reports its own liveness transitions (`EngineAlive` / `EngineDied`,
+    /// issue 1339). A compile-time const from the well-known name, so no
+    /// host round-trip; matches the `RpcServerCapability`'s own
+    /// `mailbox_id_from_name("aether.engine")` route lookup.
+    fn engine_cap_mailbox() -> MailboxId {
+        mailbox_id_from_name("aether.engine")
+    }
 
     /// Total time [`connect_proxy`] keeps retrying a refused dial when
     /// the proxy just forked the substrate and it may still be coming
@@ -88,10 +98,52 @@ mod proxy_native {
     /// failed boot, and SIGKILLs + reaps it on `Drop`. `None` for an
     /// adopted / externally-running substrate, whose lifetime the
     /// proxy doesn't manage.
+    ///
+    /// `heartbeat` is the liveness-probe tuning the cap resolved from
+    /// its [`EngineConfig`](crate::engine::server) (issue 1339). `None`
+    /// disables the heartbeat (the engine is then only evicted on a
+    /// connection-close `Bye`, never on a wedge); `Some` arms the
+    /// timer sidecar.
     pub struct EngineProxyConfig {
         pub engine_id: EngineId,
         pub rpc_addr: String,
         pub spawned: Option<Child>,
+        pub heartbeat: Option<HeartbeatParams>,
+    }
+
+    /// Resolved liveness-heartbeat tuning for one proxy (issue 1339).
+    /// `interval` is the ping cadence; `miss_limit` is how many
+    /// consecutive unanswered pings mark the engine dead — a small N
+    /// tolerates a transient hiccup without flapping. Detection latency
+    /// is `miss_limit × interval`. Built by the engines cap from its
+    /// `EngineConfig` and handed down via [`EngineProxyConfig`].
+    #[derive(Clone, Copy, Debug)]
+    pub struct HeartbeatParams {
+        pub interval: Duration,
+        pub miss_limit: u32,
+    }
+
+    /// Owns the per-proxy heartbeat timer thread (issue 1339). The
+    /// thread sleeps `interval` on a `recv_timeout` over the stop
+    /// channel and fires an [`EngineHeartbeatTick`] wake-mail at the
+    /// proxy's own mailbox each interval — the same sidecar-wake shape
+    /// the RPC reader uses. `Drop` disconnects the channel (so the
+    /// thread's `recv_timeout` returns `Disconnected` and it breaks)
+    /// then joins, mirroring `RpcReaderHandle`'s orderly teardown.
+    struct HeartbeatHandle {
+        stop: Option<mpsc::Sender<()>>,
+        thread: Option<JoinHandle<()>>,
+    }
+
+    impl Drop for HeartbeatHandle {
+        fn drop(&mut self) {
+            // Dropping the sender disconnects the channel; the thread's
+            // next `recv_timeout` returns `Disconnected` and it exits.
+            drop(self.stop.take());
+            if let Some(t) = self.thread.take() {
+                let _ = t.join();
+            }
+        }
     }
 
     /// Per-engine proxy: one outbound RPC connection to one substrate,
@@ -115,6 +167,23 @@ mod proxy_native {
         /// (see [`EngineProxyConfig::spawned`]). `Drop` SIGKILLs +
         /// reaps it; `None` once taken or for an adopted substrate.
         spawned: Option<Child>,
+        /// Consecutive heartbeat pings sent without a `Pong` reply
+        /// (issue 1339). Incremented each `on_heartbeat_tick`, reset to
+        /// `0` on any inbound `Pong`. Crossing `miss_limit` evicts the
+        /// engine.
+        missed_heartbeats: u32,
+        /// Consecutive-miss threshold that marks the engine dead. `0`
+        /// when the heartbeat is disabled (`heartbeat: None`), in which
+        /// case `on_heartbeat_tick` never fires anyway.
+        miss_limit: u32,
+        /// Monotonic nonce stamped on each heartbeat `Ping` — for log
+        /// correlation only; a `Pong` carrying any nonce counts as
+        /// liveness, since there is at most one heartbeat outstanding.
+        heartbeat_seq: u64,
+        /// The heartbeat timer thread, when armed. `Drop` stops + joins
+        /// it. Held as the field's RAII guard — the leading `_` marks
+        /// it as owned-for-its-Drop, not read.
+        _heartbeat: Option<HeartbeatHandle>,
     }
 
     #[actor]
@@ -158,12 +227,30 @@ mod proxy_native {
                 "engine proxy connected",
             );
 
+            // Arm the liveness heartbeat, if configured. The sidecar
+            // thread fires an `EngineHeartbeatTick` at this proxy's own
+            // mailbox every `interval`; `on_heartbeat_tick` does the
+            // ping + miss accounting on the dispatcher thread (so the
+            // RPC write and all proxy state stay single-threaded).
+            let (heartbeat, miss_limit) = match config.heartbeat {
+                Some(params) if !params.interval.is_zero() && params.miss_limit > 0 => {
+                    let handle =
+                        spawn_heartbeat(Arc::clone(&mailer), self_mailbox, params.interval);
+                    (Some(handle), params.miss_limit)
+                }
+                _ => (None, 0),
+            };
+
             Ok(Self {
                 engine_id: config.engine_id,
                 mailer,
                 conn,
                 in_flight: HashMap::new(),
                 spawned: config.spawned,
+                missed_heartbeats: 0,
+                miss_limit,
+                heartbeat_seq: 0,
+                _heartbeat: heartbeat,
             })
         }
 
@@ -210,6 +297,16 @@ mod proxy_native {
                 match frame {
                     WireFrame::ReplyEvent { cid, envelope } => self.route_reply(cid, envelope),
                     WireFrame::ReplyEnd { cid, result } => self.route_settled(cid, result),
+                    // A `Pong` answers this proxy's heartbeat `Ping`
+                    // (issue 1339): the substrate is alive. Clear the
+                    // miss counter and report the liveness up to the
+                    // engines cap so `list_engines` can show a fresh
+                    // heartbeat age. The nonce is for log correlation
+                    // only — any `Pong` is a liveness signal.
+                    WireFrame::Pong(_nonce) => {
+                        self.missed_heartbeats = 0;
+                        self.report_alive(ctx);
+                    }
                     WireFrame::Bye { reason } => {
                         tracing::info!(
                             target: "aether_substrate::engine_proxy",
@@ -217,12 +314,17 @@ mod proxy_native {
                             reason = %reason,
                             "engine proxy: substrate closed the connection; shutting down",
                         );
+                        // Tell the engines cap the engine is gone so it
+                        // drops the registry entry — without this the
+                        // proxy dies but `list_engines` keeps reporting
+                        // a corpse (issue 1339).
+                        self.report_died(ctx);
                         ctx.shutdown();
                         return;
                     }
-                    // Hello / HelloAck / Call / Ping / Pong: a client-
-                    // side proxy never expects these inbound. Drop with
-                    // a debug line rather than warn-storming.
+                    // Hello / HelloAck / Call / Ping: a client-side proxy
+                    // never expects these inbound. Drop with a debug
+                    // line rather than warn-storming.
                     other => {
                         tracing::debug!(
                             target: "aether_substrate::engine_proxy",
@@ -251,7 +353,89 @@ mod proxy_native {
                 engine_id = ?self.engine_id,
                 "engine proxy: terminate requested; shutting down",
             );
+            // No `report_died` here: the engines cap initiated this
+            // terminate and already dropped the registry entry, so the
+            // proxy reporting back would be a redundant (idempotent)
+            // no-op. The self-death paths (`Bye`, heartbeat timeout) are
+            // the ones the cap doesn't already know about.
             ctx.shutdown();
+        }
+
+        /// Liveness-heartbeat timer wake (issue 1339).
+        ///
+        /// # Agent
+        /// Internal wake mail — not part of the proxy's external
+        /// surface. The heartbeat sidecar thread fires this every
+        /// interval. The handler counts the tick as an outstanding miss
+        /// (a `Pong` since the last tick would have cleared the
+        /// counter), and once `miss_limit` consecutive ticks go
+        /// unanswered it declares the engine dead: reports `EngineDied`
+        /// to the engines cap and self-shuts-down (its `Drop` SIGKILLs
+        /// the wedged child). Otherwise it sends a fresh `Ping`.
+        #[handler]
+        fn on_heartbeat_tick(&mut self, ctx: &mut NativeCtx<'_>, _mail: EngineHeartbeatTick) {
+            self.heartbeat_seq += 1;
+            // A write failure means the socket is already broken — the
+            // reader sidecar will surface a `Bye` and `on_inbound_ready`
+            // handles the eviction. Count it as a miss and carry on so
+            // the miss-limit path also covers it (whichever fires first
+            // evicts; the cap side is idempotent).
+            if let Err(e) = self.conn.client.ping(self.heartbeat_seq) {
+                tracing::debug!(
+                    target: "aether_substrate::engine_proxy",
+                    engine_id = ?self.engine_id,
+                    error = %e,
+                    "engine proxy: heartbeat ping write failed",
+                );
+            }
+            self.missed_heartbeats += 1;
+            if self.missed_heartbeats >= self.miss_limit {
+                tracing::warn!(
+                    target: "aether_substrate::engine_proxy",
+                    engine_id = ?self.engine_id,
+                    missed = self.missed_heartbeats,
+                    miss_limit = self.miss_limit,
+                    "engine proxy: heartbeat miss limit crossed; evicting engine",
+                );
+                self.report_died(ctx);
+                ctx.shutdown();
+            }
+        }
+    }
+
+    /// Spawn the per-proxy heartbeat timer thread. It sleeps `interval`
+    /// on a `recv_timeout` over the returned handle's stop channel and
+    /// pushes an [`EngineHeartbeatTick`] wake-mail at `self_mailbox`
+    /// each interval — the empty-payload wake shape the RPC reader
+    /// sidecar uses (the timer carries no data, only the schedule). The
+    /// handle's `Drop` stops + joins the thread.
+    fn spawn_heartbeat(
+        mailer: Arc<Mailer>,
+        self_mailbox: MailboxId,
+        interval: Duration,
+    ) -> HeartbeatHandle {
+        let (stop_tx, stop_rx) = mpsc::channel::<()>();
+        let tick_kind = KindId(<EngineHeartbeatTick as Kind>::ID.0);
+        // Infra timer thread below the mail layer — like the RPC reader
+        // sidecar it only fires a wake-mail (no inbound chain to inherit,
+        // so no settlement umbrella to honor), and the proxy is instanced
+        // so `spawn_detached` (Singleton-only) doesn't apply.
+        #[allow(clippy::disallowed_methods)]
+        let thread = thread::Builder::new()
+            .name("aether-engine-heartbeat".into())
+            .spawn(move || {
+                // `recv_timeout` returns `Timeout` each interval (fire a
+                // tick); a stop signal or a disconnected channel (the
+                // proxy dropped the sender) returns otherwise and ends
+                // the loop.
+                while stop_rx.recv_timeout(interval) == Err(mpsc::RecvTimeoutError::Timeout) {
+                    mailer.push(Mail::new(self_mailbox, tick_kind, Vec::new(), 1));
+                }
+            })
+            .expect("spawn aether-engine-heartbeat thread");
+        HeartbeatHandle {
+            stop: Some(stop_tx),
+            thread: Some(thread),
         }
     }
 
@@ -265,7 +449,7 @@ mod proxy_native {
     fn connect_proxy(
         addr: &str,
         mailer: &Arc<Mailer>,
-        self_mailbox: aether_data::MailboxId,
+        self_mailbox: MailboxId,
         wake_kind: KindId,
         retry: bool,
     ) -> Result<RpcConnection, RpcClientError> {
@@ -326,6 +510,37 @@ mod proxy_native {
     }
 
     impl EngineProxy {
+        /// Report a confirmed liveness signal to the engines cap so it
+        /// refreshes this engine's last-heartbeat timestamp (issue
+        /// 1339). Sent as a fresh root: the `Pong` that triggered it is
+        /// an external event causally unrelated to whatever inbound
+        /// mail woke the handler.
+        fn report_alive(&self, ctx: &NativeCtx<'_>) {
+            let alive = EngineAlive {
+                engine_id: self.engine_id.0.to_string(),
+            };
+            let _ = ctx.send_envelope_as_root(
+                engine_cap_mailbox(),
+                <EngineAlive as Kind>::ID,
+                &alive.encode_into_bytes(),
+            );
+        }
+
+        /// Report this engine's death to the engines cap so it drops the
+        /// registry entry (issue 1339). Idempotent on the cap side — a
+        /// `died` for an already-evicted engine is a no-op. Sent as a
+        /// fresh root for the same reason as [`Self::report_alive`].
+        fn report_died(&self, ctx: &NativeCtx<'_>) {
+            let died = EngineDied {
+                engine_id: self.engine_id.0.to_string(),
+            };
+            let _ = ctx.send_envelope_as_root(
+                engine_cap_mailbox(),
+                <EngineDied as Kind>::ID,
+                &died.encode_into_bytes(),
+            );
+        }
+
         /// Route a `ReplyEvent`'s envelope back to whoever sent the
         /// `ForwardEnvelope` that opened `cid`. Mirrors
         /// `Mailer::send_reply`'s `Component` branch: push a `Mail`
@@ -401,6 +616,70 @@ mod proxy_native {
 
 #[cfg(test)]
 use crate::rpc::test_echo::TestEchoReply;
+// Handler-signature kinds for the test sink below — must be importable
+// at file root so the `#[bridge]` macro's `HandlesKind` markers stay
+// addressable, the same constraint as the proxy's own handler kinds.
+#[cfg(test)]
+use aether_kinds::{EngineAlive, EngineDied};
+#[cfg(test)]
+use std::sync::{Arc, Mutex};
+
+/// Shared capture cells for [`EngineCapSink`]. Lives at file root (not
+/// inside the bridge mod) like `EngineServer`'s `ReplyCells` — it's the
+/// sink actor's `Config`, so it must be addressable as `super::…` from
+/// the bridge mod.
+#[cfg(test)]
+#[derive(Clone, Default)]
+pub struct EngineCapCells {
+    pub alive: Arc<Mutex<Vec<String>>>,
+    pub died: Arc<Mutex<Vec<String>>>,
+}
+
+/// Test-only stand-in for the engines cap, registered at the cap's own
+/// `aether.engine` mailbox so a proxy's `EngineAlive` / `EngineDied`
+/// reports land here without booting the real `EngineServer`. Records
+/// the reported `engine_id`s into shared vecs the heartbeat tests
+/// assert on. Lives at file root for `#[bridge]` marker addressability.
+#[cfg(test)]
+#[aether_actor::bridge(singleton)]
+mod engine_cap_sink {
+    use super::{EngineAlive, EngineCapCells, EngineDied};
+    use aether_actor::actor;
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+
+    pub struct EngineCapSink {
+        cells: EngineCapCells,
+    }
+
+    #[actor]
+    impl NativeActor for EngineCapSink {
+        type Config = EngineCapCells;
+        const NAMESPACE: &'static str = "aether.engine";
+
+        fn init(cells: EngineCapCells, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            Ok(Self { cells })
+        }
+
+        #[handler]
+        fn on_alive(&mut self, _ctx: &mut NativeCtx<'_>, mail: EngineAlive) {
+            self.cells
+                .alive
+                .lock()
+                .expect("test setup: alive cell mutex poisoned")
+                .push(mail.engine_id);
+        }
+
+        #[handler]
+        fn on_died(&mut self, _ctx: &mut NativeCtx<'_>, mail: EngineDied) {
+            self.cells
+                .died
+                .lock()
+                .expect("test setup: died cell mutex poisoned")
+                .push(mail.engine_id);
+        }
+    }
+}
 
 /// Test-only sink: records the `value` of every [`TestEchoReply`] it
 /// receives into a shared cell so the round-trip test can observe a
@@ -444,17 +723,22 @@ mod proxy_reply_sink {
 
 #[cfg(test)]
 mod tests {
-    use super::{EngineProxy, EngineProxyConfig, ProxyReplySink};
+    use super::{
+        EngineCapCells, EngineCapSink, EngineProxy, EngineProxyConfig, HeartbeatParams,
+        ProxyReplySink,
+    };
     use crate::rpc::server::{RpcServerCapability, RpcServerConfig, RpcServerHandle};
     use crate::rpc::test_echo::{TestEchoActor, TestEchoRequest};
-    use crate::rpc::wire::PeerKind;
+    use crate::rpc::wire::{HelloAck, PeerKind, WIRE_VERSION, WireFrame};
     use crate::test_chassis::{TestChassis, fresh_substrate};
     use crate::trace::TraceDispatchCapability;
     use aether_actor::Actor;
+    use aether_codec::frame::{read_frame, write_frame};
     use aether_data::{EngineId, Kind, Uuid, mailbox_id_from_name};
     use aether_substrate::Subname;
-    use aether_substrate::chassis::builder::Builder;
+    use aether_substrate::chassis::builder::{Builder, PassiveChassis};
     use aether_substrate::mail::{Mail, ReplyTarget, ReplyTo};
+    use std::io::BufReader;
     use std::net::TcpListener;
     use std::sync::{Arc, Mutex};
     use std::thread;
@@ -508,6 +792,7 @@ mod tests {
                     engine_id: EngineId(Uuid::from_u128(1)),
                     rpc_addr: format!("127.0.0.1:{port}"),
                     spawned: None,
+                    heartbeat: None,
                 },
             )
             .finish()
@@ -584,6 +869,7 @@ mod tests {
                     engine_id: EngineId(Uuid::from_u128(2)),
                     rpc_addr: format!("127.0.0.1:{port}"),
                     spawned: None,
+                    heartbeat: None,
                 },
             )
             .finish();
@@ -591,5 +877,188 @@ mod tests {
             result.is_err(),
             "spawning a proxy at a closed port should fail at init",
         );
+    }
+
+    /// How a [`fake_server`] treats the proxy's heartbeat pings after
+    /// the handshake.
+    #[derive(Clone, Copy)]
+    enum Behavior {
+        /// Mirror every `Ping(n)` back as `Pong(n)` — a healthy engine.
+        Pong,
+        /// Read and drop pings without answering — a wedged engine.
+        Ignore,
+        /// Drop the connection right after the handshake — the
+        /// connection-close (`Bye`) eviction path.
+        Close,
+    }
+
+    /// Spin a one-shot fake substrate RPC server on an OS-picked port:
+    /// accept one connection, run the `Hello` / `HelloAck` handshake,
+    /// then behave per `behavior`. Returns the port and the server
+    /// thread handle (detached — it exits when the proxy disconnects on
+    /// test teardown).
+    fn fake_server(behavior: Behavior) -> (u16, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake server");
+        let port = listener.local_addr().expect("local_addr").port();
+        // Test-only fake substrate server thread (infra, no mail layer).
+        #[allow(clippy::disallowed_methods)]
+        let handle = thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("fake server accept");
+            let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+            let mut writer = stream;
+            let _hello: WireFrame = read_frame(&mut reader).expect("read Hello");
+            write_frame(
+                &mut writer,
+                &WireFrame::HelloAck(HelloAck {
+                    wire_version: WIRE_VERSION,
+                    server: substrate_peer_kind(),
+                }),
+            )
+            .expect("write HelloAck");
+            if matches!(behavior, Behavior::Close) {
+                return; // drop the stream → the proxy reads eof → Bye
+            }
+            // Service pings until the proxy hangs up (read error ends
+            // the `while let`).
+            while let Ok::<WireFrame, _>(frame) = read_frame(&mut reader) {
+                if let (WireFrame::Ping(n), Behavior::Pong) = (&frame, behavior)
+                    && write_frame(&mut writer, &WireFrame::Pong(*n)).is_err()
+                {
+                    break;
+                }
+            }
+        });
+        (port, handle)
+    }
+
+    /// Boot a chassis hosting the engine-cap sink, point an
+    /// `EngineProxy` (with the given heartbeat) at `port`, and return
+    /// the chassis (kept alive for its dispatcher threads) + the sink
+    /// cells. `engine_id` is `Uuid::from_u128(seed)`.
+    fn spawn_proxy_with_heartbeat(
+        seed: u128,
+        port: u16,
+        heartbeat: Option<HeartbeatParams>,
+    ) -> (PassiveChassis<TestChassis>, EngineCapCells, String) {
+        let (registry, mailer) = fresh_substrate();
+        let cells = EngineCapCells::default();
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<EngineCapSink>(cells.clone())
+            .build_passive()
+            .expect("caps boot");
+        let engine_id = EngineId(Uuid::from_u128(seed));
+        chassis
+            .spawn_actor::<EngineProxy>(
+                Subname::Named("e"),
+                EngineProxyConfig {
+                    engine_id,
+                    rpc_addr: format!("127.0.0.1:{port}"),
+                    spawned: None,
+                    heartbeat,
+                },
+            )
+            .finish()
+            .expect("proxy connects");
+        (chassis, cells, engine_id.0.to_string())
+    }
+
+    /// Block until `cell` holds at least one entry (returning the
+    /// first), or the deadline passes (panicking with `what`).
+    fn await_first(cell: &Arc<Mutex<Vec<String>>>, what: &str) -> String {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            // Clone out under the guard, then drop it before the branch
+            // (clippy `significant_drop_in_scrutinee`).
+            let first = cell
+                .lock()
+                .expect("test setup: cell mutex poisoned")
+                .first()
+                .cloned();
+            if let Some(first) = first {
+                return first;
+            }
+            assert!(Instant::now() < deadline, "{what} within 5s");
+            thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    /// A wedged engine (handshakes, then never answers a heartbeat
+    /// `Ping`) is evicted: after `miss_limit` missed pongs the proxy
+    /// reports `EngineDied` to the engines cap. This is the wedge case
+    /// the lazy connection-drop path misses.
+    #[test]
+    fn heartbeat_evicts_engine_after_missed_pongs() {
+        let (port, _server) = fake_server(Behavior::Ignore);
+        let (_chassis, cells, engine_id) = spawn_proxy_with_heartbeat(
+            42,
+            port,
+            Some(HeartbeatParams {
+                interval: Duration::from_millis(40),
+                miss_limit: 3,
+            }),
+        );
+        let died = await_first(&cells.died, "wedged engine not evicted");
+        assert_eq!(died, engine_id, "the wedged engine's id is reported dead");
+    }
+
+    /// A healthy engine (pongs every heartbeat) is reported alive and
+    /// never evicted.
+    #[test]
+    fn heartbeat_reports_alive_on_pong() {
+        let (port, _server) = fake_server(Behavior::Pong);
+        let (_chassis, cells, engine_id) = spawn_proxy_with_heartbeat(
+            7,
+            port,
+            Some(HeartbeatParams {
+                interval: Duration::from_millis(40),
+                miss_limit: 3,
+            }),
+        );
+        let alive = await_first(&cells.alive, "healthy engine never reported alive");
+        assert_eq!(
+            alive, engine_id,
+            "the healthy engine's id is reported alive"
+        );
+        // Give the miss-limit window a chance to (wrongly) fire, then
+        // confirm a ponging engine is never declared dead.
+        thread::sleep(Duration::from_millis(200));
+        assert!(
+            cells
+                .died
+                .lock()
+                .expect("test setup: died cell mutex poisoned")
+                .is_empty(),
+            "a ponging engine must not be evicted",
+        );
+    }
+
+    /// A proxy whose substrate closes the connection reports
+    /// `EngineDied` so the cap drops the registry entry — the reactive
+    /// path that, before issue 1339, left `list_engines` reporting a
+    /// corpse. No heartbeat needed; the `Bye` drives it.
+    #[test]
+    fn proxy_reports_died_when_connection_closes() {
+        let (port, _server) = fake_server(Behavior::Close);
+        let (_chassis, cells, engine_id) = spawn_proxy_with_heartbeat(99, port, None);
+        let died = await_first(&cells.died, "closed engine not reported dead");
+        assert_eq!(died, engine_id, "the closed engine's id is reported dead");
+    }
+
+    // Heartbeat eviction / alive reporting ride timer + dispatcher
+    // threads (timing-flaky); duplicate-wrap them for the pre-release
+    // flake soak (CLAUDE.md "Flake soak").
+    #[test]
+    fn flaky_heartbeat_evicts_engine_after_missed_pongs() {
+        heartbeat_evicts_engine_after_missed_pongs();
+    }
+
+    #[test]
+    fn flaky_heartbeat_reports_alive_on_pong() {
+        heartbeat_reports_alive_on_pong();
+    }
+
+    #[test]
+    fn flaky_proxy_reports_died_when_connection_closes() {
+        proxy_reports_died_when_connection_closes();
     }
 }

--- a/crates/aether-capabilities/src/engine/server.rs
+++ b/crates/aether-capabilities/src/engine/server.rs
@@ -37,14 +37,26 @@
 // Handler-signature kinds must be importable at file root — the
 // `#[bridge]` macro emits `impl HandlesKind<K>` markers as siblings of
 // the mod.
-use aether_kinds::{ListEngines, RouteEnvelope, SpawnEngine, TerminateEngine};
+use aether_kinds::{
+    EngineAlive, EngineDied, ListEngines, RouteEnvelope, SpawnEngine, TerminateEngine,
+};
 #[cfg(test)]
 use std::sync::{Arc, Mutex};
 
+// `EngineConfig` (+ its derive-emitted `EngineOverlay`) ride through
+// file root for the hub chassis bin, which flattens the overlay into
+// `HubCli`, resolves argv-then-env, and passes the config to
+// `with_actor::<EngineServer>(cfg)` (ADR-0090). Native-only re-export —
+// the engines cap is native-only, so the config has no wasm consumer.
+#[cfg(not(target_arch = "wasm32"))]
+pub use server_native::{EngineConfig, EngineOverlay};
+
 #[aether_actor::bridge(singleton)]
 mod server_native {
-    use super::{ListEngines, RouteEnvelope, SpawnEngine, TerminateEngine};
-    use crate::engine::proxy::{EngineProxy, EngineProxyConfig};
+    use super::{
+        EngineAlive, EngineDied, ListEngines, RouteEnvelope, SpawnEngine, TerminateEngine,
+    };
+    use crate::engine::proxy::{EngineProxy, EngineProxyConfig, HeartbeatParams};
     use aether_actor::{MailCtx, actor};
     use aether_data::{EngineId, Kind, MailboxId, Uuid};
     use aether_kinds::{
@@ -58,12 +70,14 @@ mod server_native {
     use aether_substrate::mail::mailer::Mailer;
     use aether_substrate::mail::{ReplyTarget, ReplyTo};
     use std::collections::HashMap;
+    use std::convert::Infallible;
     use std::env;
     use std::io;
     use std::net::TcpListener;
     use std::path::PathBuf;
     use std::process::{Command, Stdio};
     use std::sync::Arc;
+    use std::time::{Duration, Instant};
 
     /// Env override for the parent directory under which the cap
     /// allocates per-engine handle-store dirs (issue 1274). Absent →
@@ -72,6 +86,81 @@ mod server_native {
     /// is resolvable.
     const ENV_ENGINE_STORE_ROOT: &str = "AETHER_ENGINE_STORE_ROOT";
 
+    /// Default heartbeat ping cadence (issue 1339). 5 s × the miss
+    /// limit is the detection-latency vs. flap-tolerance tradeoff.
+    const DEFAULT_HEARTBEAT_INTERVAL_SECS: u64 = 5;
+    /// Default consecutive-miss threshold before an engine is declared
+    /// dead. Small N tolerates a transient hiccup / GC pause.
+    const DEFAULT_HEARTBEAT_MISS_LIMIT: u32 = 3;
+
+    /// Resolved engines-cap configuration (ADR-0090, issue 1339).
+    /// Today this is just the liveness-heartbeat tuning; the inline
+    /// `AETHER_ENGINE_STORE_ROOT` reader (`engine_store_root`) is a
+    /// pre-ADR-0090 holdover left to a separate migration.
+    ///
+    /// `#[derive(aether_substrate::Config)]` emits the env-shaped
+    /// `EngineConfigLayer`, the clap-shaped `EngineOverlay`, and the
+    /// inherent `from_env` / `from_argv_then_env` shims (argv beats env
+    /// beats the literal default). The hub chassis resolves it with
+    /// `EngineConfig::from_argv_then_env(cli.engine.into_layer())` and
+    /// hands it to `with_actor::<EngineServer>(cfg)`; tests build it
+    /// directly. `env_prefix = "AETHER_HUB"` + the `heartbeat_*` field
+    /// names compose the `AETHER_HUB_HEARTBEAT_*` env keys and
+    /// `--hub-heartbeat-*` flags. `Default` (the test constructor)
+    /// resolves to `0/0` = heartbeat-disabled; production picks up the
+    /// `default = 5/3` literals through the layer.
+    #[derive(Clone, Debug, Default, aether_substrate::Config)]
+    #[config(env_prefix = "AETHER_HUB", cli_prefix = "hub")]
+    pub struct EngineConfig {
+        /// Heartbeat ping cadence in seconds
+        /// (`AETHER_HUB_HEARTBEAT_INTERVAL_SECS` /
+        /// `--hub-heartbeat-interval-secs`). `0` disables the heartbeat
+        /// entirely (engines are then only evicted on a
+        /// connection-close, never on a wedge).
+        #[config(default = 5, parse = parse_heartbeat_interval_secs)]
+        pub heartbeat_interval_secs: u64,
+        /// Consecutive missed pings that mark an engine dead
+        /// (`AETHER_HUB_HEARTBEAT_MISS_LIMIT` /
+        /// `--hub-heartbeat-miss-limit`). Small N tolerates a transient
+        /// hiccup; `0` also disables the heartbeat. Detection latency is
+        /// `miss_limit × interval_secs`.
+        #[config(default = 3, parse = parse_heartbeat_miss_limit)]
+        pub heartbeat_miss_limit: u32,
+    }
+
+    impl EngineConfig {
+        /// The [`HeartbeatParams`] to arm each proxy with, or `None`
+        /// when the heartbeat is disabled (`0` interval or miss limit).
+        fn heartbeat_params(&self) -> Option<HeartbeatParams> {
+            if self.heartbeat_interval_secs == 0 || self.heartbeat_miss_limit == 0 {
+                None
+            } else {
+                Some(HeartbeatParams {
+                    interval: Duration::from_secs(self.heartbeat_interval_secs),
+                    miss_limit: self.heartbeat_miss_limit,
+                })
+            }
+        }
+    }
+
+    // confique's `parse_env` contract is `fn(&str) -> Result<T, impl
+    // Error>`; these total helpers carry a `Result` they never fill with
+    // `Err` — an unparseable value folds back to the default (soft, like
+    // the DAG validator's caps; the ADR-0090 §4 strict/erroring variant
+    // is a follow-up). Hence the `unnecessary_wraps` allow.
+
+    /// Parse the heartbeat interval; unparseable → the default.
+    #[allow(clippy::unnecessary_wraps)]
+    fn parse_heartbeat_interval_secs(s: &str) -> Result<u64, Infallible> {
+        Ok(s.trim().parse().unwrap_or(DEFAULT_HEARTBEAT_INTERVAL_SECS))
+    }
+
+    /// Parse the heartbeat miss limit; unparseable → the default.
+    #[allow(clippy::unnecessary_wraps)]
+    fn parse_heartbeat_miss_limit(s: &str) -> Result<u32, Infallible> {
+        Ok(s.trim().parse().unwrap_or(DEFAULT_HEARTBEAT_MISS_LIMIT))
+    }
+
     /// One supervised engine in [`EngineServer`]'s table.
     struct EngineEntry {
         /// Mailbox of the `aether.engine.proxy:<id>` actor — the
@@ -79,6 +168,11 @@ mod server_native {
         proxy_mailbox: MailboxId,
         /// The localhost RPC port the cap assigned this substrate.
         rpc_port: u16,
+        /// When the cap last saw this engine alive (issue 1339): set at
+        /// spawn (just-connected = alive) and refreshed on each
+        /// `EngineAlive` the proxy reports from a confirmed `Pong`.
+        /// `on_list` reports `now - last_alive` as the heartbeat age.
+        last_alive: Instant,
     }
 
     /// Engines capability: supervises a fleet of [`EngineProxy`]
@@ -96,18 +190,23 @@ mod server_native {
         /// sends stamp the cap as sender, but a routed call's reply
         /// must reach the originating `RpcServerCapability`, not here.
         mailer: Arc<Mailer>,
+        /// Liveness-heartbeat tuning each spawned proxy is armed with
+        /// (issue 1339), resolved once from [`EngineConfig`] at init.
+        /// `None` disables the heartbeat fleet-wide.
+        heartbeat: Option<HeartbeatParams>,
     }
 
     #[actor]
     impl NativeActor for EngineServer {
-        type Config = ();
+        type Config = EngineConfig;
         const NAMESPACE: &'static str = "aether.engine";
 
-        fn init(_config: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        fn init(config: EngineConfig, ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
             Ok(Self {
                 engines: HashMap::new(),
                 next_engine_seq: 1,
                 mailer: ctx.mailer(),
+                heartbeat: config.heartbeat_params(),
             })
         }
 
@@ -115,15 +214,20 @@ mod server_native {
         ///
         /// # Agent
         /// Send `ListEngines` (fieldless). Reply: `ListEnginesResult
-        /// { engines: [{ engine_id, rpc_port }] }`.
+        /// { engines: [{ engine_id, rpc_port, last_heartbeat_age_millis }] }`.
         #[handler]
         fn on_list(&mut self, ctx: &mut NativeCtx<'_>, _mail: ListEngines) {
+            let now = Instant::now();
             let engines = self
                 .engines
                 .iter()
                 .map(|(id, entry)| EngineDescriptor {
                     engine_id: id.0.to_string(),
                     rpc_port: entry.rpc_port,
+                    last_heartbeat_age_millis: u64::try_from(
+                        now.saturating_duration_since(entry.last_alive).as_millis(),
+                    )
+                    .unwrap_or(u64::MAX),
                 })
                 .collect();
             ctx.reply(&ListEnginesResult { engines });
@@ -191,6 +295,7 @@ mod server_native {
                         engine_id,
                         rpc_addr,
                         spawned: Some(child),
+                        heartbeat: self.heartbeat,
                     },
                 )
                 .finish();
@@ -202,6 +307,9 @@ mod server_native {
                         EngineEntry {
                             proxy_mailbox,
                             rpc_port,
+                            // Just connected = alive; the heartbeat
+                            // refreshes this on each confirmed Pong.
+                            last_alive: Instant::now(),
                         },
                     );
                     ctx.reply(&SpawnEngineResult::Ok {
@@ -330,6 +438,53 @@ mod server_native {
                 .with_reply_to(reply_to),
             );
         }
+
+        /// Evict a dead engine from the table (issue 1339).
+        ///
+        /// # Agent
+        /// Not a user-facing tool — a proxy sends `EngineDied` when it
+        /// observes its substrate's connection close or its liveness
+        /// heartbeat cross the miss limit. The cap drops the table entry
+        /// so `list_engines` stops reporting a corpse. Idempotent: a
+        /// `died` for an already-removed engine (e.g. one a concurrent
+        /// `terminate_substrate` already dropped) is a logged no-op, so
+        /// it can't race the terminate path.
+        #[handler]
+        fn on_engine_died(&mut self, _ctx: &mut NativeCtx<'_>, mail: EngineDied) {
+            let Ok(uuid) = Uuid::parse_str(&mail.engine_id) else {
+                tracing::warn!(
+                    target: "aether_substrate::engine_server",
+                    engine_id = %mail.engine_id,
+                    "engine died: unparseable engine_id; ignoring",
+                );
+                return;
+            };
+            if self.engines.remove(&EngineId(uuid)).is_some() {
+                tracing::info!(
+                    target: "aether_substrate::engine_server",
+                    engine_id = %mail.engine_id,
+                    "engine evicted: proxy reported death",
+                );
+            }
+        }
+
+        /// Refresh an engine's last-seen-alive time (issue 1339).
+        ///
+        /// # Agent
+        /// Not a user-facing tool — a proxy sends `EngineAlive` each
+        /// time it confirms a heartbeat `Pong`. The cap stamps the
+        /// table entry so `list_engines` reports a fresh
+        /// `last_heartbeat_age_millis`. An `alive` for an unknown engine
+        /// (already evicted) is a silent no-op.
+        #[handler]
+        fn on_engine_alive(&mut self, _ctx: &mut NativeCtx<'_>, mail: EngineAlive) {
+            let Ok(uuid) = Uuid::parse_str(&mail.engine_id) else {
+                return;
+            };
+            if let Some(entry) = self.engines.get_mut(&EngineId(uuid)) {
+                entry.last_alive = Instant::now();
+            }
+        }
     }
 
     /// Push a `CallSettled::Err` back to `target` (correlation
@@ -456,13 +611,14 @@ mod sink {
 
 #[cfg(test)]
 mod tests {
-    use super::{EngineServer, ReplyCells, ReplySink};
+    use super::{EngineConfig, EngineServer, ReplyCells, ReplySink};
     use crate::test_chassis::TestChassis;
     use aether_actor::Actor;
     use aether_data::{Kind, mailbox_id_from_name};
     use aether_kinds::descriptors;
     use aether_kinds::{
-        ListEngines, SpawnEngine, SpawnEngineResult, TerminateEngine, TerminateEngineResult,
+        EngineAlive, EngineDied, ListEngines, SpawnEngine, SpawnEngineResult, TerminateEngine,
+        TerminateEngineResult,
     };
     use aether_substrate::chassis::builder::{Builder, PassiveChassis};
     use aether_substrate::handle_store::HandleStore;
@@ -487,7 +643,7 @@ mod tests {
         let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
         let cells = ReplyCells::default();
         let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<EngineServer>(())
+            .with_actor::<EngineServer>(EngineConfig::default())
             .with_actor::<ReplySink>(cells.clone())
             .build_passive()
             .expect("caps boot");
@@ -603,6 +759,79 @@ mod tests {
         assert!(
             matches!(unknown, TerminateEngineResult::Err { .. }),
             "a well-formed but unknown engine_id should be rejected",
+        );
+    }
+
+    /// Push a fire-and-forget kind at the cap, then drive a `ListEngines`
+    /// so the assertion runs only after the cap has processed the
+    /// earlier mail (single-threaded actor, in-order mailbox). Returns
+    /// the engine list the cap reports afterward.
+    fn push_then_list<K: Kind + serde::Serialize>(
+        mailer: &Arc<Mailer>,
+        cells: &ReplyCells,
+        fire: &K,
+    ) -> Vec<aether_kinds::EngineDescriptor> {
+        let server = mailbox_id_from_name(<EngineServer as Actor>::NAMESPACE);
+        mailer.push(Mail::new(server, K::ID, fire.encode_into_bytes(), 1));
+        drive(mailer, &ListEngines {}, || {
+            cells
+                .list
+                .lock()
+                .expect("test setup: list cell mutex poisoned")
+                .take()
+        })
+        .engines
+    }
+
+    /// `on_engine_died` for an engine the cap never supervised — the
+    /// terminate-race / double-report case — is an idempotent no-op,
+    /// not a panic, and inserts nothing. Covers both a malformed and a
+    /// well-formed-but-unknown `engine_id` (issue 1339).
+    #[test]
+    fn engine_died_for_unknown_is_noop() {
+        let (_chassis, mailer, cells) = boot();
+
+        let after_malformed = push_then_list(
+            &mailer,
+            &cells,
+            &EngineDied {
+                engine_id: "not-a-uuid".to_owned(),
+            },
+        );
+        assert!(
+            after_malformed.is_empty(),
+            "a malformed died must not panic or insert",
+        );
+
+        let after_unknown = push_then_list(
+            &mailer,
+            &cells,
+            &EngineDied {
+                engine_id: "00000000-0000-0000-0000-000000000000".to_owned(),
+            },
+        );
+        assert!(
+            after_unknown.is_empty(),
+            "a died for an unknown engine is a no-op",
+        );
+    }
+
+    /// `on_engine_alive` for an unknown engine is a silent no-op (no
+    /// panic, no spurious insert) — a stale `alive` racing an eviction
+    /// must not resurrect the engine (issue 1339).
+    #[test]
+    fn engine_alive_for_unknown_is_noop() {
+        let (_chassis, mailer, cells) = boot();
+        let after = push_then_list(
+            &mailer,
+            &cells,
+            &EngineAlive {
+                engine_id: "00000000-0000-0000-0000-000000000000".to_owned(),
+            },
+        );
+        assert!(
+            after.is_empty(),
+            "an alive for an unknown engine must not insert it",
         );
     }
 }

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -104,6 +104,8 @@ pub use engine::EngineProxy;
 #[cfg(not(target_arch = "wasm32"))]
 pub use engine::EngineProxyConfig;
 pub use engine::EngineServer;
+#[cfg(not(target_arch = "wasm32"))]
+pub use engine::{EngineConfig, EngineOverlay};
 pub use handle::HandleCapability;
 pub use http::{HttpCapability, HttpConfig};
 pub use input::InputCapability;

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -913,10 +913,18 @@ mod engine {
     /// the wire carries the string form (the same convention the
     /// `aether.process.*` kinds use). `rpc_port` is the localhost port
     /// the cap assigned the substrate's `RpcServerCapability`.
+    ///
+    /// `last_heartbeat_age_millis` is how long ago the cap last saw a
+    /// liveness signal from this engine (issue 1339) — `0` right after
+    /// spawn, refreshed each time the engine's proxy confirms a `Pong`.
+    /// A value climbing past the heartbeat interval means the engine is
+    /// going stale; the cap evicts it (drops it from this list) once it
+    /// crosses the miss limit.
     #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
     pub struct EngineDescriptor {
         pub engine_id: String,
         pub rpc_port: u16,
+        pub last_heartbeat_age_millis: u64,
     }
 
     /// `aether.engine.list_result` — reply to [`ListEngines`]: every
@@ -1021,6 +1029,48 @@ mod engine {
     pub enum CallSettled {
         Ok,
         Err { error: String },
+    }
+
+    /// `aether.engine.heartbeat_tick` — the per-engine proxy's own
+    /// liveness timer wake (issue 1339). Internal control-plane mail,
+    /// not a user surface: a sidecar thread the proxy spawns at init
+    /// fires this (empty-payload) at the proxy's own mailbox every
+    /// heartbeat interval, the same wake-mail shape `RpcInboundReady`
+    /// uses for the reader sidecar. The handler pings the substrate and
+    /// counts consecutive misses, evicting the engine once the miss
+    /// limit is crossed.
+    #[derive(
+        aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default,
+    )]
+    #[kind(name = "aether.engine.heartbeat_tick")]
+    pub struct EngineHeartbeatTick {}
+
+    /// `aether.engine.died` — a per-engine proxy telling the engines
+    /// cap (`aether.engine`) that its substrate is gone, so the cap
+    /// drops it from the supervised-engine table (issue 1339). The
+    /// proxy sends this when it observes the connection close (`Bye` /
+    /// `eof`) or when the liveness heartbeat crosses its miss limit —
+    /// the positive signal the lazy connection-drop path misses for a
+    /// wedged-but-alive engine. Idempotent on the cap side: a `died`
+    /// for an already-removed engine (e.g. one a concurrent
+    /// `TerminateEngine` already dropped) is a no-op. `engine_id` is
+    /// the plain UUID string, matching [`TerminateEngine`].
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.engine.died")]
+    pub struct EngineDied {
+        pub engine_id: String,
+    }
+
+    /// `aether.engine.alive` — a per-engine proxy reporting a confirmed
+    /// liveness signal (a `Pong` answering its heartbeat `Ping`) to the
+    /// engines cap (issue 1339). The cap stamps the engine's
+    /// last-seen-alive time so [`ListEnginesResult`] can report
+    /// `last_heartbeat_age_millis`. Fire-and-forget; an `alive` for an
+    /// unknown engine is a no-op. `engine_id` is the plain UUID string.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.engine.alive")]
+    pub struct EngineAlive {
+        pub engine_id: String,
     }
 }
 

--- a/crates/aether-mcp/src/args.rs
+++ b/crates/aether-mcp/src/args.rs
@@ -68,6 +68,12 @@ pub struct EngineInfo {
     pub engine_id: String,
     /// The localhost RPC port the hub assigned this substrate.
     pub rpc_port: u16,
+    /// Milliseconds since the hub last confirmed this engine alive
+    /// (issue 1339): `0` right after spawn, refreshed each heartbeat
+    /// interval. A value climbing past the heartbeat interval means the
+    /// engine is going stale; the hub evicts it (drops it from this
+    /// list) once it crosses the miss limit.
+    pub last_heartbeat_age_millis: u64,
 }
 
 /// Per-item outcome from a `send_mail` batch.

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -199,6 +199,7 @@ impl Mcp {
             .map(|e| EngineInfo {
                 engine_id: e.engine_id,
                 rpc_port: e.rpc_port,
+                last_heartbeat_age_millis: e.last_heartbeat_age_millis,
             })
             .collect();
         json(&engines)
@@ -229,6 +230,8 @@ impl Mcp {
             }) => json(&EngineInfo {
                 engine_id,
                 rpc_port,
+                // A just-spawned engine is alive as of now.
+                last_heartbeat_age_millis: 0,
             }),
             Some(SpawnEngineResult::Err { error }) => Err(internal_msg(&error)),
             None => Err(internal_msg("undecodable SpawnEngineResult")),
@@ -1777,11 +1780,11 @@ mod tests {
         ReplaceComponentArgs, SendMailArgs, SendMailTracedArgs, SpawnSubstrateArgs,
         TerminateSubstrateArgs, TracedMailSpec,
     };
-    use aether_capabilities::EngineServer;
     use aether_capabilities::rpc::{
         PeerKind, RpcServerCapability, RpcServerConfig, RpcServerHandle,
     };
     use aether_capabilities::trace::TraceDispatchCapability;
+    use aether_capabilities::{EngineConfig, EngineServer};
     use aether_substrate::chassis::builder::{Builder, PassiveChassis};
     use aether_substrate::handle_store::HandleStore;
     use aether_substrate::mail::mailer::Mailer;
@@ -1808,7 +1811,7 @@ mod tests {
         let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
         let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
             .with_actor::<TraceDispatchCapability>(())
-            .with_actor::<EngineServer>(())
+            .with_actor::<EngineServer>(EngineConfig::default())
             .with_actor::<RpcServerCapability>(RpcServerConfig {
                 bind_addr: "127.0.0.1:0".into(),
                 peer_kind: PeerKind::Substrate {
@@ -1867,7 +1870,7 @@ mod tests {
         let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
         let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
             .with_actor::<TraceDispatchCapability>(())
-            .with_actor::<EngineServer>(())
+            .with_actor::<EngineServer>(EngineConfig::default())
             // The inventory cap pulls `Arc::clone(ctx.mailer().registry())`
             // in `init`, so it sees the same `Registry` we just wrote
             // the extra kinds into.

--- a/crates/aether-substrate-bundle/src/bin/hub.rs
+++ b/crates/aether-substrate-bundle/src/bin/hub.rs
@@ -15,16 +15,30 @@ use aether_substrate_bundle::cli::HubCli;
 use aether_substrate_bundle::hub::{Chassis, HubChassis, HubEnv};
 use clap::Parser as _;
 
-/// The hub chassis is coordinator-only — its sole config knob is the
-/// RPC bind port (ADR-0090 §4 discovery). The full-stack cap knobs
-/// don't apply, so the hub dumps just this one rather than the shared
+/// The hub chassis is coordinator-only — the full-stack cap knobs
+/// don't apply, so the hub dumps just its own (RPC bind port + the
+/// engines-cap liveness heartbeat, issue 1339) rather than the shared
 /// `chassis_config_dump`.
-const HUB_KNOBS: &[KnobRecord] = &[KnobRecord {
-    env_key: "AETHER_RPC_PORT",
-    doc: "aether.rpc.server bind port (default 8901).",
-    default: Some("8901"),
-    kind: KnobKind::HandRegistered,
-}];
+const HUB_KNOBS: &[KnobRecord] = &[
+    KnobRecord {
+        env_key: "AETHER_RPC_PORT",
+        doc: "aether.rpc.server bind port (default 8901).",
+        default: Some("8901"),
+        kind: KnobKind::HandRegistered,
+    },
+    KnobRecord {
+        env_key: "AETHER_HUB_HEARTBEAT_INTERVAL_SECS",
+        doc: "Engine liveness-heartbeat ping cadence in seconds; 0 disables (--hub-heartbeat-interval-secs).",
+        default: Some("5"),
+        kind: KnobKind::HandRegistered,
+    },
+    KnobRecord {
+        env_key: "AETHER_HUB_HEARTBEAT_MISS_LIMIT",
+        doc: "Consecutive missed pings before an engine is evicted (--hub-heartbeat-miss-limit).",
+        default: Some("3"),
+        kind: KnobKind::HandRegistered,
+    },
+];
 
 fn main() -> anyhow::Result<()> {
     let cli = HubCli::parse();

--- a/crates/aether-substrate-bundle/src/cli.rs
+++ b/crates/aether-substrate-bundle/src/cli.rs
@@ -43,6 +43,7 @@ use confique::{Config, Layer};
 // (`NamespaceRootsOverlay`), not the namespace prefix (`FsOverlay`) —
 // alias the historical name so the bundle's compose code keeps
 // reading.
+pub use aether_capabilities::EngineOverlay;
 pub use aether_capabilities::anthropic::AnthropicOverlay;
 pub use aether_capabilities::audio::AudioOverlay;
 pub use aether_capabilities::fs::NamespaceRootsOverlay as FsOverlay;
@@ -193,6 +194,12 @@ pub struct HubCli {
     /// 8901).
     #[arg(long = "rpc-port")]
     pub rpc_port: Option<u16>,
+
+    /// Engines-cap knobs — the liveness-heartbeat tuning
+    /// (`--hub-heartbeat-interval-secs` / `--hub-heartbeat-miss-limit`,
+    /// issue 1339). Flattened from the derive-emitted overlay.
+    #[command(flatten)]
+    pub engine: EngineOverlay,
 
     /// Print every config knob (source-resolved value, default, doc)
     /// and exit before boot (ADR-0090 §4 discovery dump).

--- a/crates/aether-substrate-bundle/src/hub/chassis.rs
+++ b/crates/aether-substrate-bundle/src/hub/chassis.rs
@@ -15,7 +15,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use aether_capabilities::rpc::{PeerKind, RpcServerCapability, RpcServerConfig};
-use aether_capabilities::{EngineServer, trace::TraceDispatchCapability};
+use aether_capabilities::{EngineConfig, EngineServer, trace::TraceDispatchCapability};
 use aether_substrate::chassis::builder::{
     Builder, BuiltChassis, DriverCapability, DriverCtx, DriverRunning, RunError,
 };
@@ -44,10 +44,12 @@ impl Chassis for HubChassis {
 /// Resolved configuration the hub chassis takes at build time.
 /// `rpc_addr` is the `aether.rpc.server` bind — the target the
 /// out-of-process `aether-mcp` coordinator dials. `AETHER_RPC_PORT`
-/// overrides the port.
-#[derive(Clone, Copy)]
+/// overrides the port. `engine` is the engines-cap config — today the
+/// liveness-heartbeat tuning (issue 1339), resolved argv-then-env.
+#[derive(Clone)]
 pub struct HubEnv {
     pub rpc_addr: SocketAddr,
+    pub engine: EngineConfig,
 }
 
 impl HubEnv {
@@ -63,9 +65,12 @@ impl HubEnv {
     /// ADR-0090 unit d (issue 1258): resolve from argv-then-env.
     /// `cli.rpc_port` shadows `AETHER_RPC_PORT`; falling through still
     /// lands on [`DEFAULT_RPC_PORT`] (the hub always binds an RPC
-    /// server, unlike desktop / headless). Takes `&HubCli` since the
-    /// only field today is a `Copy` `Option<u16>` — owned ownership
-    /// would be a needless move.
+    /// server, unlike desktop / headless). The engines overlay
+    /// (`--hub-heartbeat-*`, issue 1339) resolves through the
+    /// derive-emitted `from_argv_then_env` (argv beats
+    /// `AETHER_HUB_HEARTBEAT_*` env beats the literal default). Takes
+    /// `&HubCli`, cloning the overlay rather than consuming `cli` so the
+    /// bin keeps it for the `--config` dump.
     #[must_use]
     pub fn from_env_with_argv(cli: &HubCli) -> Self {
         use std::net::{IpAddr, Ipv4Addr};
@@ -75,13 +80,14 @@ impl HubEnv {
             .unwrap_or(DEFAULT_RPC_PORT);
         Self {
             rpc_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), rpc_port),
+            engine: EngineConfig::from_argv_then_env(cli.engine.clone().into_layer()),
         }
     }
 }
 
 impl HubChassis {
     fn build_inner(env: HubEnv) -> Result<BuiltChassis<Self>, BootError> {
-        let HubEnv { rpc_addr } = env;
+        let HubEnv { rpc_addr, engine } = env;
         let boot = SubstrateBoot::builder("aether-hub", env!("CARGO_PKG_VERSION")).build()?;
         let registry = Arc::clone(&boot.registry);
         let mailer = Arc::clone(&boot.queue);
@@ -90,7 +96,9 @@ impl HubChassis {
 
         Builder::<Self>::new(registry, mailer)
             .with_actor::<TraceDispatchCapability>(())
-            .with_actor::<EngineServer>(())
+            // Liveness-heartbeat tuning (issue 1339), resolved
+            // argv-then-env in `HubEnv::from_env_with_argv`.
+            .with_actor::<EngineServer>(engine)
             .with_actor::<RpcServerCapability>(RpcServerConfig {
                 bind_addr: rpc_addr.to_string(),
                 peer_kind: PeerKind::Substrate {

--- a/crates/aether-substrate-bundle/tests/engines_cap.rs
+++ b/crates/aether-substrate-bundle/tests/engines_cap.rs
@@ -10,7 +10,7 @@
 // `EngineServer` unit tests cover the error arms in-process.
 
 use aether_actor::Actor;
-use aether_capabilities::EngineServer;
+use aether_capabilities::{EngineConfig, EngineServer};
 use aether_data::{Kind, mailbox_id_from_name};
 use aether_kinds::descriptors;
 use aether_kinds::{
@@ -115,7 +115,7 @@ fn boot() -> (PassiveChassis<TestChassis>, Arc<Mailer>, ReplyCells) {
     let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
     let cells = ReplyCells::default();
     let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<EngineServer>(())
+        .with_actor::<EngineServer>(EngineConfig::default())
         .with_actor::<ReplySink>(cells.clone())
         .build_passive()
         .expect("caps boot");

--- a/crates/aether-substrate-bundle/tests/rpc_engine_routing.rs
+++ b/crates/aether-substrate-bundle/tests/rpc_engine_routing.rs
@@ -16,13 +16,13 @@
 // Step 2 is the P5a proof: before this phase, `engine = Some` Calls
 // were rejected with `RpcError::UnsupportedTarget`.
 
-use aether_capabilities::EngineServer;
 use aether_capabilities::rpc::RpcServerHandle;
 use aether_capabilities::rpc::{
     Hello, HelloAck, MailEnvelope, MailboxAddress, PeerKind, RpcServerCapability, RpcServerConfig,
     WIRE_VERSION, WireFrame,
 };
 use aether_capabilities::trace::TraceDispatchCapability;
+use aether_capabilities::{EngineConfig, EngineServer};
 use aether_codec::frame::{read_frame, write_frame};
 use aether_data::{EngineId, Kind, Uuid, mailbox_id_from_name};
 use aether_kinds::descriptors;
@@ -62,7 +62,7 @@ fn boot_hub() -> (PassiveChassis<TestChassis>, u16) {
     let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
     let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
         .with_actor::<TraceDispatchCapability>(())
-        .with_actor::<EngineServer>(())
+        .with_actor::<EngineServer>(EngineConfig::default())
         .with_actor::<RpcServerCapability>(RpcServerConfig {
             bind_addr: "127.0.0.1:0".into(),
             peer_kind: PeerKind::Substrate {


### PR DESCRIPTION
## Problem

When a spawned substrate dies (crash, fatal abort, killed, or wedged-but-alive), the hub kept it in the active-engine registry — `list_engines` reported a corpse and the MCP tools happily addressed it — until something downstream noticed the dropped connection. Two gaps: the per-engine proxy died (on a connection-close `Bye`/eof) without ever telling the engines cap to drop the table entry, and a wedged-but-alive engine (CPU-loop guest, deadlock) never tripped the eof path at all. Closes iamacoffeepot/aether#1339.

## What changed

- **Reactive eviction.** New `EngineDied` / `EngineAlive` proxy→cap notifications. On any self-death the proxy reports `EngineDied` to `aether.engine`, and the cap drops the registry entry — idempotent, so it can't race `terminate_substrate`. This alone fixes the long-standing "proxy dies, list_engines keeps reporting it" leak on the `Bye` path.
- **Proactive heartbeat.** The proxy arms a timer sidecar (mirroring the RPC reader sidecar; stopped via a dropped channel on `Drop`) that pings the substrate each interval, counts consecutive missed `Pong`s, and on the miss limit reports `EngineDied` + self-shuts-down — its `Drop` SIGKILLs the wedged child. Reuses the existing wire `Ping`/`Pong`; no substrate-side change. A confirmed `Pong` reports `EngineAlive`.
- **Health surface.** `EngineDescriptor` / the MCP `EngineInfo` gain `last_heartbeat_age_millis` — the cap stamps `last_alive` from each confirmed `Pong`, so a caller sees staleness short of eviction, not just present/absent.
- **Config via the ADR-0090 API, not raw env.** `EngineConfig` (`#[derive(aether_substrate::Config)]`) resolves `AETHER_HUB_HEARTBEAT_INTERVAL_SECS` / `_MISS_LIMIT` (default 5 s × 3 → ~15 s detection) argv-then-env through a `--hub-heartbeat-*` overlay flattened into `HubCli`, and shows in the hub `--config` dump. `0` interval/limit disables the heartbeat.

## Tests

- proxy: heartbeat ping→pong reports alive; missed pongs evict (the wedge case); connection-close `Bye` reports died. The timing-flaky trio carry `flaky_` soak wrappers.
- cap: `EngineDied` / `EngineAlive` for an unknown engine are idempotent no-ops (the terminate-race the issue calls out).
- existing real-substrate spawn/list/terminate integration test still green.

Full preflight green (fmt + clippy + doc + 1477 nextest + wasm32 cross-build).

## Notes

- End-to-end eviction (real substrate killed → cap drops it from `list_engines`) is covered compositionally — the proxy reporting path and the cap's idempotent removal are each tested in isolation; a live-process eviction test is a reasonable follow-up.
- Folding the cap's inline `AETHER_ENGINE_STORE_ROOT` reader into `EngineConfig`, and the ADR-0090 §4 strict (erroring) parsers, are noted follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
