### PR TITLE
chore: serialize contention-sensitive tests via a nextest serial-heavy group

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,29 @@
 [profile.default]
 final-status-level = "slow"
 
+# Contention/backoff-sensitive tests (iamacoffeepot/aether#1341) live in a
+# `mod heavy` submodule and exercise the scheduler's spin-then-park backoff
+# (`scheduler::spin_park` park/wake, settlement deadlines, hub restart).
+# Under a saturated `--workspace` run they oversubscribe cores, and a
+# settlement that needs timely cross-thread progress can miss its ~30s
+# deadline — passing in isolation but wedging the full suite. This group
+# runs them single-file (at most one at a time) so they never contend with
+# one another, while the thousands of lightweight tests keep saturating the
+# rest. `test(/::heavy::/)` matches the `mod heavy` path segment. The same
+# `mod heavy` set is the soak selector in `scripts/flake-soak.sh`.
+[test-groups]
+serial-heavy = { max-threads = 1 }
+
+# Profiles don't inherit overrides, so the assignment is repeated for the
+# `default` and `ci` profiles (the soak profile intentionally omits it).
+[[profile.default.overrides]]
+filter = "test(/::heavy::/)"
+test-group = "serial-heavy"
+
+[[profile.ci.overrides]]
+filter = "test(/::heavy::/)"
+test-group = "serial-heavy"
+
 [profile.ci]
 # Don't fail fast in CI to run the full test suite.
 fail-fast = false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,8 +154,11 @@ For a quick single-file check without spinning up the container, RustRover's ins
 
 Re-baselining (`qodana.sarif.json`) is done by downloading the `qodana-report` workflow artifact from a CI run.
 
-## Flake soak (pre-release)
+## Heavy (contention-sensitive) tests
 
-Concurrent / scheduler / mail-dispatch tests are timing-flaky — they pass on a lucky run and fail intermittently, so a single green CI pass does not clear one. Mark such a test by adding a thin **duplicate wrapper** next to it — keep the original, add `#[test] fn flaky_<name>() { <name>(); }`. `nextest` selects tests by name/path, so a `flaky_`-named duplicate is the simplest marker — no macro, no rename of the original.
+Concurrent / scheduler / mail-dispatch tests are timing-flaky — they pass on a lucky run and fail intermittently, and under a saturated `--workspace` run they oversubscribe cores so a settlement that needs timely cross-thread progress can miss its ~30s deadline (passing in isolation but wedging the full suite). A single green CI pass does not clear one.
 
-Before a release, soak the marked set with `scripts/flake-soak.sh [count]` (default 200): it runs `cargo nextest run --profile flake-soak --stress-count <count> -E 'test(/flaky/)'`, so each `flaky_` duplicate runs `count` times, **each in a fresh process** (the isolation that reproduces timing flakes), failing if any iteration fails. Override the selector with `AETHER_FLAKE_FILTER`.
+Mark such a test by declaring it inside a **`mod heavy`** submodule of its test module — e.g. `mod heavy { #[test] fn lost_wakeup_stress() { … } }` (shared helpers stay in the parent `mod tests`, reached via `use super::*`; or keep a body fn at module scope and delegate with `super::body()`). `nextest` selects by name/path, so the `::heavy::` path segment is the marker — no macro, no `flaky_` duplicate (iamacoffeepot/aether#1341 retired the old duplicate-wrapper convention). The one marker drives two things:
+
+- **Serialize in every run.** `.config/nextest.toml` puts `test(/::heavy::/)` in the `serial-heavy` test-group (`max-threads = 1`), so the heavy set runs single-file — never contending with one another — while the thousands of lightweight tests keep saturating cores. The override is repeated on the `default` and `ci` profiles (profiles don't inherit). Verify membership with `cargo nextest show-config test-groups --profile ci`.
+- **Soak before a release.** `scripts/flake-soak.sh [count]` (default 200) runs `cargo nextest run --profile flake-soak --stress-count <count> -E 'test(/::heavy::/)'`, so each heavy test runs `count` times, **each in a fresh process** (the isolation that reproduces timing flakes), failing if any iteration fails. Override the selector with `AETHER_FLAKE_FILTER`.

--- a/crates/aether-capabilities/src/dag/tests.rs
+++ b/crates/aether-capabilities/src/dag/tests.rs
@@ -947,7 +947,6 @@ fn transform_invoke_resolves_handle() {
 
 /// A panicking transform maps to `Failed` with the panic message in the
 /// diagnostic; the executor + sibling branches survive (ADR-0048 §6).
-#[test]
 fn transform_panic_fails_node() {
     let (registry, mailer, rx) = fresh_substrate_with_rx();
     let recorder: Recorder<TestNumberObserved> = Arc::new(Mutex::new(Vec::new()));
@@ -1090,7 +1089,6 @@ fn transform_output_overflow_fails_node() {
 /// identical across DAGs) skips the invoke entirely — the cache hit
 /// resolves the node. The pool's invoke count reports 1, not 2
 /// (ADR-0048 §4, iamacoffeepot/aether#982).
-#[test]
 fn transform_skips_invoke_on_cache_hit() {
     super::test_support::SEED_INVOKE_COUNT.store(0, Ordering::Release);
     let (registry, mailer, rx) = fresh_substrate_with_rx();
@@ -1162,16 +1160,22 @@ fn transform_skips_invoke_on_cache_hit() {
     drop(chassis);
 }
 
-/// Flake-soak wrapper (iamacoffeepot/aether#1060). Re-runs
-/// [`transform_skips_invoke_on_cache_hit`] under a `flaky_` name so the
-/// `scripts/flake-soak.sh` filterset (`test(/flaky/)`) repeat-runs it
-/// before a release — it asserts on async observer recording, the race
-/// the trace ring-buffer change (iamacoffeepot/aether#1056) exposed
-/// here. The original still runs once in normal CI; this duplicate is
-/// the soak target.
-#[test]
-fn flaky_transform_skips_invoke_on_cache_hit() {
-    transform_skips_invoke_on_cache_hit();
+/// Contention/backoff-sensitive tests live in `mod heavy`: they drive the
+/// live actor dispatch / parking / settlement path through a multi-worker
+/// pool, so they are serialized into the `serial-heavy` nextest group
+/// (`.config/nextest.toml`) and selected by `scripts/flake-soak.sh` for
+/// fresh-process soak repetition. Each delegates to the scenario body
+/// declared at module scope.
+mod heavy {
+    #[test]
+    fn transform_panic_fails_node() {
+        super::transform_panic_fails_node();
+    }
+
+    #[test]
+    fn transform_skips_invoke_on_cache_hit() {
+        super::transform_skips_invoke_on_cache_hit();
+    }
 }
 
 /// A transform that blocks briefly does not stall the executor's

--- a/crates/aether-capabilities/src/engine/proxy.rs
+++ b/crates/aether-capabilities/src/engine/proxy.rs
@@ -982,83 +982,74 @@ mod tests {
         }
     }
 
-    /// A wedged engine (handshakes, then never answers a heartbeat
-    /// `Ping`) is evicted: after `miss_limit` missed pongs the proxy
-    /// reports `EngineDied` to the engines cap. This is the wedge case
-    /// the lazy connection-drop path misses.
-    #[test]
-    fn heartbeat_evicts_engine_after_missed_pongs() {
-        let (port, _server) = fake_server(Behavior::Ignore);
-        let (_chassis, cells, engine_id) = spawn_proxy_with_heartbeat(
-            42,
-            port,
-            Some(HeartbeatParams {
-                interval: Duration::from_millis(40),
-                miss_limit: 3,
-            }),
-        );
-        let died = await_first(&cells.died, "wedged engine not evicted");
-        assert_eq!(died, engine_id, "the wedged engine's id is reported dead");
-    }
+    /// Contention/backoff-sensitive tests live in `mod heavy`: heartbeat
+    /// eviction / alive reporting ride timer + dispatcher threads and are
+    /// timing-sensitive under load, so they are serialized into the
+    /// `serial-heavy` nextest group (`.config/nextest.toml`) and selected by
+    /// `scripts/flake-soak.sh` for fresh-process soak repetition.
+    mod heavy {
+        use super::*;
 
-    /// A healthy engine (pongs every heartbeat) is reported alive and
-    /// never evicted.
-    #[test]
-    fn heartbeat_reports_alive_on_pong() {
-        let (port, _server) = fake_server(Behavior::Pong);
-        let (_chassis, cells, engine_id) = spawn_proxy_with_heartbeat(
-            7,
-            port,
-            Some(HeartbeatParams {
-                interval: Duration::from_millis(40),
-                miss_limit: 3,
-            }),
-        );
-        let alive = await_first(&cells.alive, "healthy engine never reported alive");
-        assert_eq!(
-            alive, engine_id,
-            "the healthy engine's id is reported alive"
-        );
-        // Give the miss-limit window a chance to (wrongly) fire, then
-        // confirm a ponging engine is never declared dead.
-        thread::sleep(Duration::from_millis(200));
-        assert!(
-            cells
-                .died
-                .lock()
-                .expect("test setup: died cell mutex poisoned")
-                .is_empty(),
-            "a ponging engine must not be evicted",
-        );
-    }
+        /// A wedged engine (handshakes, then never answers a heartbeat
+        /// `Ping`) is evicted: after `miss_limit` missed pongs the proxy
+        /// reports `EngineDied` to the engines cap. This is the wedge case
+        /// the lazy connection-drop path misses.
+        #[test]
+        fn heartbeat_evicts_engine_after_missed_pongs() {
+            let (port, _server) = fake_server(Behavior::Ignore);
+            let (_chassis, cells, engine_id) = spawn_proxy_with_heartbeat(
+                42,
+                port,
+                Some(HeartbeatParams {
+                    interval: Duration::from_millis(40),
+                    miss_limit: 3,
+                }),
+            );
+            let died = await_first(&cells.died, "wedged engine not evicted");
+            assert_eq!(died, engine_id, "the wedged engine's id is reported dead");
+        }
 
-    /// A proxy whose substrate closes the connection reports
-    /// `EngineDied` so the cap drops the registry entry — the reactive
-    /// path that, before issue 1339, left `list_engines` reporting a
-    /// corpse. No heartbeat needed; the `Bye` drives it.
-    #[test]
-    fn proxy_reports_died_when_connection_closes() {
-        let (port, _server) = fake_server(Behavior::Close);
-        let (_chassis, cells, engine_id) = spawn_proxy_with_heartbeat(99, port, None);
-        let died = await_first(&cells.died, "closed engine not reported dead");
-        assert_eq!(died, engine_id, "the closed engine's id is reported dead");
-    }
+        /// A healthy engine (pongs every heartbeat) is reported alive and
+        /// never evicted.
+        #[test]
+        fn heartbeat_reports_alive_on_pong() {
+            let (port, _server) = fake_server(Behavior::Pong);
+            let (_chassis, cells, engine_id) = spawn_proxy_with_heartbeat(
+                7,
+                port,
+                Some(HeartbeatParams {
+                    interval: Duration::from_millis(40),
+                    miss_limit: 3,
+                }),
+            );
+            let alive = await_first(&cells.alive, "healthy engine never reported alive");
+            assert_eq!(
+                alive, engine_id,
+                "the healthy engine's id is reported alive"
+            );
+            // Give the miss-limit window a chance to (wrongly) fire, then
+            // confirm a ponging engine is never declared dead.
+            thread::sleep(Duration::from_millis(200));
+            assert!(
+                cells
+                    .died
+                    .lock()
+                    .expect("test setup: died cell mutex poisoned")
+                    .is_empty(),
+                "a ponging engine must not be evicted",
+            );
+        }
 
-    // Heartbeat eviction / alive reporting ride timer + dispatcher
-    // threads (timing-flaky); duplicate-wrap them for the pre-release
-    // flake soak (CLAUDE.md "Flake soak").
-    #[test]
-    fn flaky_heartbeat_evicts_engine_after_missed_pongs() {
-        heartbeat_evicts_engine_after_missed_pongs();
-    }
-
-    #[test]
-    fn flaky_heartbeat_reports_alive_on_pong() {
-        heartbeat_reports_alive_on_pong();
-    }
-
-    #[test]
-    fn flaky_proxy_reports_died_when_connection_closes() {
-        proxy_reports_died_when_connection_closes();
+        /// A proxy whose substrate closes the connection reports
+        /// `EngineDied` so the cap drops the registry entry — the reactive
+        /// path that, before issue 1339, left `list_engines` reporting a
+        /// corpse. No heartbeat needed; the `Bye` drives it.
+        #[test]
+        fn proxy_reports_died_when_connection_closes() {
+            let (port, _server) = fake_server(Behavior::Close);
+            let (_chassis, cells, engine_id) = spawn_proxy_with_heartbeat(99, port, None);
+            let died = await_first(&cells.died, "closed engine not reported dead");
+            assert_eq!(died, engine_id, "the closed engine's id is reported dead");
+        }
     }
 }

--- a/crates/aether-mcp/src/bin/aether-tunnel.rs
+++ b/crates/aether-mcp/src/bin/aether-tunnel.rs
@@ -741,11 +741,7 @@ mod tests {
     /// last one could (the stub spaces them 300ms apart). If the proxy
     /// buffered the body to EOF, the first read would block until the
     /// whole stream finished — this guards against that regression.
-    #[tokio::test]
-    async fn sse_get_streams_incrementally_without_buffering() {
-        run_sse_streams_incrementally().await;
-    }
-
+    /// Driven by `mod heavy::sse_get_streams_incrementally_without_buffering`.
     async fn run_sse_streams_incrementally() {
         let upstream = start_stub_upstream().await;
         let (tunnel_port, _t) = start_tunnel_with_upstream(upstream, sleep_hub_spec()).await;
@@ -803,11 +799,6 @@ mod tests {
             }
         }
         None
-    }
-
-    #[tokio::test]
-    async fn restart_hub_cycles_the_child() {
-        run_restart_hub_cycles_the_child().await;
     }
 
     async fn run_restart_hub_cycles_the_child() {
@@ -874,16 +865,20 @@ mod tests {
         serde_json::from_str(&text).expect("json body")
     }
 
-    // Flake-soak duplicates (CLAUDE.md): the SSE timing assertion and the
-    // restart-pid race are timing-sensitive. A `flaky_`-prefixed wrapper
-    // lets `scripts/flake-soak.sh` run each in a fresh process N times.
-    #[tokio::test]
-    async fn flaky_sse_get_streams_incrementally_without_buffering() {
-        run_sse_streams_incrementally().await;
-    }
+    /// Contention/backoff-sensitive tests live in `mod heavy`: the SSE timing
+    /// assertion and the restart-pid race are timing-sensitive under load, so
+    /// they are serialized into the `serial-heavy` nextest group
+    /// (`.config/nextest.toml`) and selected by `scripts/flake-soak.sh` for
+    /// fresh-process soak repetition. Each delegates to its `run_*` body.
+    mod heavy {
+        #[tokio::test]
+        async fn sse_get_streams_incrementally_without_buffering() {
+            super::run_sse_streams_incrementally().await;
+        }
 
-    #[tokio::test]
-    async fn flaky_restart_hub_cycles_the_child() {
-        run_restart_hub_cycles_the_child().await;
+        #[tokio::test]
+        async fn restart_hub_cycles_the_child() {
+            super::run_restart_hub_cycles_the_child().await;
+        }
     }
 }

--- a/crates/aether-mcp/src/rpc.rs
+++ b/crates/aether-mcp/src/rpc.rs
@@ -810,24 +810,22 @@ mod tests {
         }
     }
 
-    /// The load-bearing fix (iamacoffeepot/aether#1212): a hub restart
-    /// under a live `RpcSession` is healed in place. A first call
-    /// round-trips; the hub then dies (the reader sidecar surfaces the
-    /// synthetic `Bye`, draining `pending` so the in-flight call fails
-    /// on the dead socket); the hub comes back on the same port; and
-    /// the next call re-dials and succeeds rather than erroring forever.
-    #[tokio::test]
-    async fn call_redials_after_hub_restart() {
-        run_redial_after_hub_restart().await;
-    }
-
-    /// Flake-soak duplicate (CLAUDE.md "Flake soak"): the restart path
-    /// races a socket close + same-port re-bind, so it is timing
-    /// sensitive. Thin `flaky_`-named wrapper so `scripts/flake-soak.sh`
-    /// selects it; the original above stays.
-    #[tokio::test]
-    async fn flaky_call_redials_after_hub_restart() {
-        run_redial_after_hub_restart().await;
+    /// Contention/backoff-sensitive tests live in `mod heavy`: the restart
+    /// path races a socket close + same-port re-bind, so it is timing
+    /// sensitive — serialized into the `serial-heavy` nextest group
+    /// (`.config/nextest.toml`) and selected by `scripts/flake-soak.sh` for
+    /// fresh-process soak repetition.
+    mod heavy {
+        /// The load-bearing fix (iamacoffeepot/aether#1212): a hub restart
+        /// under a live `RpcSession` is healed in place. A first call
+        /// round-trips; the hub then dies (the reader sidecar surfaces the
+        /// synthetic `Bye`, draining `pending` so the in-flight call fails
+        /// on the dead socket); the hub comes back on the same port; and
+        /// the next call re-dials and succeeds rather than erroring forever.
+        #[tokio::test]
+        async fn call_redials_after_hub_restart() {
+            super::run_redial_after_hub_restart().await;
+        }
     }
 
     async fn run_redial_after_hub_restart() {

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -259,7 +259,6 @@ fn mail_saturation_profile() {
 /// guarding the observer fold against settling on a truncated chain;
 /// that failure mode retired with the fold — the counter never settles
 /// on a partial chain.)
-#[test]
 #[allow(clippy::print_stderr)]
 fn depth_chain_settles_every_root() {
     let workers = available_parallelism().map_or(2, |n| n.get().saturating_sub(1).max(1));
@@ -288,12 +287,32 @@ fn depth_chain_settles_every_root() {
     }
 }
 
-/// Flake-soak duplicate of [`depth_chain_settles_every_root`] (the
-/// `flaky_` prefix is the soak selector; see CLAUDE.md "Flake soak").
-#[test]
-#[allow(clippy::print_stderr)]
-fn flaky_depth_chain_settles_every_root() {
-    depth_chain_settles_every_root();
+/// Contention/backoff-sensitive tests live in `mod heavy`: these settlement
+/// scenarios drive a multi-worker pool whose park/wake backoff path
+/// oversubscribes cores under the full suite, so they are serialized into the
+/// `serial-heavy` nextest group (`.config/nextest.toml`) and selected by
+/// `scripts/flake-soak.sh` for fresh-process soak repetition. Each delegates
+/// to the scenario body declared at module scope.
+mod heavy {
+    #[test]
+    fn depth_chain_settles_every_root() {
+        super::depth_chain_settles_every_root();
+    }
+
+    #[test]
+    fn emit_settlement_settles_two_level_tree() {
+        super::emit_settlement_settles_two_level_tree();
+    }
+
+    #[test]
+    fn emit_settlement_settles_wide_fanout() {
+        super::emit_settlement_settles_wide_fanout();
+    }
+
+    #[test]
+    fn emit_settlement_settles_under_chunked_demux() {
+        super::emit_settlement_settles_under_chunked_demux();
+    }
 }
 
 /// ADR-0086 Phase 2 emit-authority guard: the emit-time
@@ -335,15 +354,8 @@ fn emit_settlement_settles_every_root(topo: &Topology) {
 }
 
 /// Rich topology: fan-out + a shared (two-parent) node + depth.
-#[test]
 fn emit_settlement_settles_two_level_tree() {
     emit_settlement_settles_every_root(&two_level_tree());
-}
-
-/// Flake-soak duplicate (concurrent multi-worker dispatch; see CLAUDE.md).
-#[test]
-fn flaky_emit_settlement_settles_two_level_tree() {
-    emit_settlement_settles_two_level_tree();
 }
 
 /// ADR-0087 Phase 3b focused guard: a wide single-source fan-out — one
@@ -353,17 +365,8 @@ fn flaky_emit_settlement_settles_two_level_tree() {
 /// inline-demux path balances `Sent`/`Finished` for every fanned mail —
 /// a dropped or double-counted demux mail would wedge `in_flight` and
 /// the root would never settle.
-#[test]
 fn emit_settlement_settles_wide_fanout() {
     emit_settlement_settles_every_root(&fanout(8));
-}
-
-/// Flake-soak duplicate of the 3b wide-fan-out demux — the
-/// inline-vs-deposit (free-vs-busy) claim race across workers is
-/// timing-sensitive (see CLAUDE.md "Flake soak").
-#[test]
-fn flaky_emit_settlement_settles_wide_fanout() {
-    emit_settlement_settles_wide_fanout();
 }
 
 /// ADR-0087 Phase 3c: with the inline-demux chunk cap forced small
@@ -375,7 +378,6 @@ fn flaky_emit_settlement_settles_wide_fanout() {
 /// `in_flight` and a root would never settle. Also drives the
 /// steal-mid-demux race (a sibling steals a remainder sub-blob while the
 /// producer runs its own chunk).
-#[test]
 #[allow(clippy::print_stderr)]
 fn emit_settlement_settles_under_chunked_demux() {
     // Force chunking on for this process. SAFETY: set before any actor is
@@ -387,15 +389,6 @@ fn emit_settlement_settles_under_chunked_demux() {
         env::set_var("AETHER_BLOB_DEMUX_CHUNK", "2");
     }
     emit_settlement_settles_every_root(&fanout(8));
-}
-
-/// Flake-soak duplicate (iamacoffeepot/aether#1116) of the 3c chunked
-/// demux — the steal-mid-demux / inline-vs-deposit race across workers is
-/// timing-sensitive (see CLAUDE.md "Flake soak").
-#[test]
-#[allow(clippy::print_stderr)]
-fn flaky_emit_settlement_settles_under_chunked_demux() {
-    emit_settlement_settles_under_chunked_demux();
 }
 
 /// Hold path: a `spawn_inherit` worker keeps the root open past the

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -1030,89 +1030,90 @@ mod tests {
         transport.flush_outbound();
     }
 
-    /// 2b load-bearing race: the producer flushes tagged blobs into its
-    /// ring while consumer threads read each `InRing` payload in place
-    /// and drop the envelope (RAII-releasing the blob lock). A reused
-    /// region — the producer overwriting bytes a consumer is mid-read on
-    /// — would surface as a tag mismatch. This lifts the 2a ring stress
-    /// test onto the full 2b path: buffer → flush → route → mpsc →
-    /// consumer drop. Soaked via the `flaky_` duplicate below.
-    #[test]
-    fn buffered_concurrent_flush_and_consumer_release() {
-        use std::thread;
+    /// Contention/backoff-sensitive tests live in `mod heavy`: this exercises
+    /// the concurrent flush / consumer-release race, so it is serialized into
+    /// the `serial-heavy` nextest group (`.config/nextest.toml`) to avoid
+    /// oversubscribing cores, and selected by `scripts/flake-soak.sh` for
+    /// fresh-process soak repetition.
+    mod heavy {
+        use super::*;
 
-        let (registry, mailer) = fresh_substrate();
-        let (tx, rx) = mpsc::channel::<Envelope>();
-        registry.register_inbox("test.sink", forward_to_envelope_sender(tx));
-        let recipient = registry.lookup("test.sink").unwrap();
-        let transport = NativeBinding::new_for_test(mailer, MailboxId(0x9191));
+        /// 2b load-bearing race: the producer flushes tagged blobs into its
+        /// ring while consumer threads read each `InRing` payload in place
+        /// and drop the envelope (RAII-releasing the blob lock). A reused
+        /// region — the producer overwriting bytes a consumer is mid-read on
+        /// — would surface as a tag mismatch. This lifts the 2a ring stress
+        /// test onto the full 2b path: buffer → flush → route → mpsc →
+        /// consumer drop.
+        #[test]
+        fn buffered_concurrent_flush_and_consumer_release() {
+            use std::thread;
 
-        let rx = Arc::new(Mutex::new(rx));
-        let done = Arc::new(AtomicBool::new(false));
-        let consumed = Arc::new(AtomicU64::new(0));
-        let n_consumers = 4;
+            let (registry, mailer) = fresh_substrate();
+            let (tx, rx) = mpsc::channel::<Envelope>();
+            registry.register_inbox("test.sink", forward_to_envelope_sender(tx));
+            let recipient = registry.lookup("test.sink").unwrap();
+            let transport = NativeBinding::new_for_test(mailer, MailboxId(0x9191));
 
-        let consumers: Vec<_> = (0..n_consumers)
-            .map(|_| {
-                let rx = Arc::clone(&rx);
-                let done = Arc::clone(&done);
-                let consumed = Arc::clone(&consumed);
-                thread::spawn(move || {
-                    loop {
-                        let got = {
-                            let guard = rx.lock().expect("rx mutex poisoned");
-                            guard.recv_timeout(Duration::from_millis(20))
-                        };
-                        match got {
-                            Ok(env) => {
-                                let bytes = env.payload.bytes();
-                                let tag = bytes[0];
-                                assert!(
-                                    bytes.iter().all(|&b| b == tag),
-                                    "decode-in-place saw a reused region: expected tag {tag}"
-                                );
-                                drop(env); // RAII release of the blob lock
-                                consumed.fetch_add(1, Ordering::AcqRel);
+            let rx = Arc::new(Mutex::new(rx));
+            let done = Arc::new(AtomicBool::new(false));
+            let consumed = Arc::new(AtomicU64::new(0));
+            let n_consumers = 4;
+
+            let consumers: Vec<_> = (0..n_consumers)
+                .map(|_| {
+                    let rx = Arc::clone(&rx);
+                    let done = Arc::clone(&done);
+                    let consumed = Arc::clone(&consumed);
+                    thread::spawn(move || {
+                        loop {
+                            let got = {
+                                let guard = rx.lock().expect("rx mutex poisoned");
+                                guard.recv_timeout(Duration::from_millis(20))
+                            };
+                            match got {
+                                Ok(env) => {
+                                    let bytes = env.payload.bytes();
+                                    let tag = bytes[0];
+                                    assert!(
+                                        bytes.iter().all(|&b| b == tag),
+                                        "decode-in-place saw a reused region: expected tag {tag}"
+                                    );
+                                    drop(env); // RAII release of the blob lock
+                                    consumed.fetch_add(1, Ordering::AcqRel);
+                                }
+                                // Empty for the timeout: exit only once the
+                                // producer is done (channel fully drained).
+                                Err(_) if done.load(Ordering::Acquire) => break,
+                                Err(_) => {}
                             }
-                            // Empty for the timeout: exit only once the
-                            // producer is done (channel fully drained).
-                            Err(_) if done.load(Ordering::Acquire) => break,
-                            Err(_) => {}
                         }
-                    }
+                    })
                 })
-            })
-            .collect();
+                .collect();
 
-        let mut sent = 0u64;
-        for i in 0..4_000u32 {
-            let tag = (i & 0xff) as u8;
-            let n = (i % 4 + 1) as usize;
-            let payload = vec![tag; 8 + (i as usize % 24)];
-            for _ in 0..n {
-                transport.push_envelope_buffered(recipient.0, 7, &payload, 1, None, None);
-                sent += 1;
+            let mut sent = 0u64;
+            for i in 0..4_000u32 {
+                let tag = (i & 0xff) as u8;
+                let n = (i % 4 + 1) as usize;
+                let payload = vec![tag; 8 + (i as usize % 24)];
+                for _ in 0..n {
+                    transport.push_envelope_buffered(recipient.0, 7, &payload, 1, None, None);
+                    sent += 1;
+                }
+                transport.flush_outbound();
             }
-            transport.flush_outbound();
+            // All flushes returned synchronously, so every envelope is in the
+            // channel before we signal done.
+            done.store(true, Ordering::Release);
+            for h in consumers {
+                h.join().expect("consumer thread joins");
+            }
+            assert_eq!(
+                consumed.load(Ordering::Acquire),
+                sent,
+                "every flushed mail must be consumed"
+            );
         }
-        // All flushes returned synchronously, so every envelope is in the
-        // channel before we signal done.
-        done.store(true, Ordering::Release);
-        for h in consumers {
-            h.join().expect("consumer thread joins");
-        }
-        assert_eq!(
-            consumed.load(Ordering::Acquire),
-            sent,
-            "every flushed mail must be consumed"
-        );
-    }
-
-    /// Flake-soak duplicate (per `scripts/flake-soak.sh`) of the 2b
-    /// producer-flush / consumer-release race — run many times in fresh
-    /// processes to surface timing-dependent reclaim bugs.
-    #[test]
-    fn flaky_buffered_concurrent_flush_and_consumer_release() {
-        buffered_concurrent_flush_and_consumer_release();
     }
 }

--- a/crates/aether-substrate/src/actor/native/blob_work.rs
+++ b/crates/aether-substrate/src/actor/native/blob_work.rs
@@ -1241,77 +1241,78 @@ mod tests {
         );
     }
 
-    /// End-to-end under a live multi-worker pool: a wide fan-out recruits
-    /// siblings, and every recipient is dispatched **exactly once** while
-    /// many workers race the shared cursor. The exactly-once gate is the
-    /// cursor CAS (each group to one worker) + the per-recipient seize.
-    #[test]
-    fn concurrent_pool_drain_delivers_each_recipient_once() {
-        use crate::runtime::lifecycle::PanicAborter;
-        use crate::scheduler::{Pool, PoolConfig};
-        use std::thread;
-        use std::time::{Duration, Instant};
+    /// Contention/backoff-sensitive tests live in `mod heavy`: this exercises
+    /// the concurrent multi-worker drain, so it is serialized into the
+    /// `serial-heavy` nextest group (`.config/nextest.toml`) to avoid
+    /// oversubscribing cores, and selected by `scripts/flake-soak.sh` for
+    /// fresh-process soak repetition.
+    mod heavy {
+        use super::*;
 
-        // A wide fan-out (> recruit_min) so the flush broadcast-recruits.
-        // N < 256 keeps the per-recipient marker byte unique.
-        const N: usize = 60;
+        /// End-to-end under a live multi-worker pool: a wide fan-out recruits
+        /// siblings, and every recipient is dispatched **exactly once** while
+        /// many workers race the shared cursor. The exactly-once gate is the
+        /// cursor CAS (each group to one worker) + the per-recipient seize.
+        #[test]
+        fn concurrent_pool_drain_delivers_each_recipient_once() {
+            use crate::runtime::lifecycle::PanicAborter;
+            use crate::scheduler::{Pool, PoolConfig};
+            use std::thread;
+            use std::time::{Duration, Instant};
 
-        let pool = Pool::start(
-            PoolConfig {
-                workers: 8,
-                ..PoolConfig::default()
-            },
-            Arc::new(PanicAborter),
-        );
-        let (registry, mailer) = fresh_substrate();
-        let mut producer = BlobProducer::new(Arc::clone(&mailer), pool.wake_sink());
+            // A wide fan-out (> recruit_min) so the flush broadcast-recruits.
+            // N < 256 keeps the per-recipient marker byte unique.
+            const N: usize = 60;
 
-        let mut fixtures = Vec::new();
-        let mut rxs = Vec::new();
-        let mut routed = Vec::new();
-        for i in 0..N {
-            let (id, fix, direct_rx, deposit_rx) = seizable_recipient(&registry, &format!("c{i}"));
-            #[allow(clippy::cast_possible_truncation)]
-            let byte = i as u8;
-            routed.push(Mail::new(id, KindId(7), MailRef::from(vec![byte]), 1));
-            fixtures.push((fix, deposit_rx));
-            rxs.push(direct_rx);
-        }
-        producer.flush(routed);
+            let pool = Pool::start(
+                PoolConfig {
+                    workers: 8,
+                    ..PoolConfig::default()
+                },
+                Arc::new(PanicAborter),
+            );
+            let (registry, mailer) = fresh_substrate();
+            let mut producer = BlobProducer::new(Arc::clone(&mailer), pool.wake_sink());
 
-        let deadline = Instant::now() + Duration::from_secs(5);
-        let mut got: Vec<u8> = Vec::new();
-        while got.len() < N && Instant::now() < deadline {
-            for rx in &rxs {
-                while let Ok(b) = rx.try_recv() {
-                    got.push(b);
+            let mut fixtures = Vec::new();
+            let mut rxs = Vec::new();
+            let mut routed = Vec::new();
+            for i in 0..N {
+                let (id, fix, direct_rx, deposit_rx) =
+                    seizable_recipient(&registry, &format!("c{i}"));
+                #[allow(clippy::cast_possible_truncation)]
+                let byte = i as u8;
+                routed.push(Mail::new(id, KindId(7), MailRef::from(vec![byte]), 1));
+                fixtures.push((fix, deposit_rx));
+                rxs.push(direct_rx);
+            }
+            producer.flush(routed);
+
+            let deadline = Instant::now() + Duration::from_secs(5);
+            let mut got: Vec<u8> = Vec::new();
+            while got.len() < N && Instant::now() < deadline {
+                for rx in &rxs {
+                    while let Ok(b) = rx.try_recv() {
+                        got.push(b);
+                    }
+                }
+                if got.len() < N {
+                    thread::yield_now();
                 }
             }
-            if got.len() < N {
-                thread::yield_now();
-            }
+
+            let results = pool.shutdown_with_results();
+            assert!(
+                results.iter().all(thread::Result::is_ok),
+                "no worker thread panicked during concurrent drain"
+            );
+            got.sort_unstable();
+            let want: Vec<u8> = (0..N as u8).collect();
+            assert_eq!(
+                got, want,
+                "each recipient dispatched exactly once under concurrent drain"
+            );
         }
-
-        let results = pool.shutdown_with_results();
-        assert!(
-            results.iter().all(thread::Result::is_ok),
-            "no worker thread panicked during concurrent drain"
-        );
-        got.sort_unstable();
-        let want: Vec<u8> = (0..N as u8).collect();
-        assert_eq!(
-            got, want,
-            "each recipient dispatched exactly once under concurrent drain"
-        );
-    }
-
-    /// Flake-soak duplicate (iamacoffeepot/aether#1137): the concurrent
-    /// drain is timing-sensitive (cursor race + seize CAS across 8
-    /// workers), so it gets a `flaky_` wrapper for `scripts/flake-soak.sh`.
-    /// The original runs once in normal CI.
-    #[test]
-    fn flaky_concurrent_pool_drain_delivers_each_recipient_once() {
-        concurrent_pool_drain_delivers_each_recipient_once();
     }
 
     // iamacoffeepot/aether#1178: the cost-aware recruiter. `recruit_k` is a

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -2308,148 +2308,165 @@ mod tests {
         drop(chassis);
     }
 
-    /// Issue 685: chassis teardown drives `unwire` on every spawned
-    /// instanced actor, even those that never received a self-shutdown
-    /// trigger. Pre-685 the Pooled spawn path's slot was reachable
-    /// from the chassis only through the wake's `Weak`, and nothing
-    /// signaled shutdown at chassis exit — so spawned actors silently
-    /// skipped their close path. The Spawner's `shutdown_instanced`
-    /// step now signals + wakes every spawned slot before the pool
-    /// drops, and the chassis waits for each `Drainable::is_closed`.
-    #[test]
-    fn chassis_teardown_runs_unwire_for_pooled_spawned_actors() {
-        use crate::actor::native::spawn::Subname;
-        use aether_actor::Instanced;
-        use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+    /// Contention/backoff-sensitive tests live in `mod heavy`: chassis
+    /// teardown drives `unwire` across pooled spawned actors through the
+    /// worker park/wake path, which loses wakes under oversubscription, so
+    /// they are serialized into the `serial-heavy` nextest group
+    /// (`.config/nextest.toml`) and selected by `scripts/flake-soak.sh` for
+    /// fresh-process soak repetition.
+    mod heavy {
+        use super::*;
 
-        struct Quiet {
-            close_observed: Arc<AtomicU32>,
-        }
-        impl Actor for Quiet {
-            const NAMESPACE: &'static str = "test.teardown.quiet";
-        }
-        impl Instanced for Quiet {}
-        impl NativeActor for Quiet {
-            type Config = Arc<AtomicU32>;
-            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-                Ok(Self {
-                    close_observed: config,
-                })
+        /// Issue 685: chassis teardown drives `unwire` on every spawned
+        /// instanced actor, even those that never received a self-shutdown
+        /// trigger. Pre-685 the Pooled spawn path's slot was reachable
+        /// from the chassis only through the wake's `Weak`, and nothing
+        /// signaled shutdown at chassis exit — so spawned actors silently
+        /// skipped their close path. The Spawner's `shutdown_instanced`
+        /// step now signals + wakes every spawned slot before the pool
+        /// drops, and the chassis waits for each `Drainable::is_closed`.
+        #[test]
+        fn chassis_teardown_runs_unwire_for_pooled_spawned_actors() {
+            use crate::actor::native::spawn::Subname;
+            use aether_actor::Instanced;
+            use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+
+            struct Quiet {
+                close_observed: Arc<AtomicU32>,
             }
-            fn unwire(&mut self, _ctx: &mut NativeCtx<'_>) {
-                self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
+            impl Actor for Quiet {
+                const NAMESPACE: &'static str = "test.teardown.quiet";
             }
-        }
-        impl NativeDispatch for Quiet {
-            fn __aether_dispatch_envelope(
-                &mut self,
-                _ctx: &mut NativeCtx<'_>,
-                _kind: KindId,
-                _payload: &[u8],
-            ) -> Option<()> {
-                None
+            impl Instanced for Quiet {}
+            impl NativeActor for Quiet {
+                type Config = Arc<AtomicU32>;
+                fn init(
+                    config: Self::Config,
+                    _ctx: &mut NativeInitCtx<'_>,
+                ) -> Result<Self, BootError> {
+                    Ok(Self {
+                        close_observed: config,
+                    })
+                }
+                fn unwire(&mut self, _ctx: &mut NativeCtx<'_>) {
+                    self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
+                }
             }
-        }
-
-        let (registry, mailer) = fresh_substrate();
-        let close_observed = Arc::new(AtomicU32::new(0));
-        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .build_passive()
-            .expect("empty chassis boots");
-
-        let id = chassis
-            .spawn_actor::<Quiet>(Subname::Counter, Arc::clone(&close_observed))
-            .finish()
-            .expect("spawn instanced actor");
-
-        // No mail at all — the actor sits idle from the moment it
-        // spawns. Pre-685 chassis teardown skipped its close path
-        // entirely; post-685 the teardown step signals + wakes it and
-        // the worker runs the close cycle before the pool drops.
-        assert_eq!(close_observed.load(AtomicOrdering::SeqCst), 0);
-
-        drop(chassis);
-
-        assert_eq!(
-            close_observed.load(AtomicOrdering::SeqCst),
-            1,
-            "chassis teardown must drive unwire exactly once for a quiet spawned actor",
-        );
-        // Drop the unused id binding so clippy stays quiet — its
-        // referent (the actor_registry's Live entry) drops with the
-        // chassis above.
-        let _ = id;
-    }
-
-    /// Issue 714: stress version of the chassis-teardown contract.
-    /// Spawn N=64 instanced actors and assert all N `close_observed`
-    /// counters tick to exactly 1 after `drop(chassis)`. Pre-714 the
-    /// polling-based `shutdown_instanced` could lose individual wakes
-    /// under contention; the channel-signal rewrite is deterministic
-    /// — even one missed `unwire` here fails the test.
-    #[test]
-    fn chassis_teardown_runs_unwire_for_many_pooled_actors() {
-        use crate::actor::native::spawn::Subname;
-        use aether_actor::Instanced;
-        use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
-
-        struct Quiet {
-            close_observed: Arc<AtomicU32>,
-        }
-        impl Actor for Quiet {
-            const NAMESPACE: &'static str = "test.teardown.quiet_many";
-        }
-        impl Instanced for Quiet {}
-        impl NativeActor for Quiet {
-            type Config = Arc<AtomicU32>;
-            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-                Ok(Self {
-                    close_observed: config,
-                })
+            impl NativeDispatch for Quiet {
+                fn __aether_dispatch_envelope(
+                    &mut self,
+                    _ctx: &mut NativeCtx<'_>,
+                    _kind: KindId,
+                    _payload: &[u8],
+                ) -> Option<()> {
+                    None
+                }
             }
-            fn unwire(&mut self, _ctx: &mut NativeCtx<'_>) {
-                self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
-            }
-        }
-        impl NativeDispatch for Quiet {
-            fn __aether_dispatch_envelope(
-                &mut self,
-                _ctx: &mut NativeCtx<'_>,
-                _kind: KindId,
-                _payload: &[u8],
-            ) -> Option<()> {
-                None
-            }
-        }
 
-        const N: usize = 64;
+            let (registry, mailer) = fresh_substrate();
+            let close_observed = Arc::new(AtomicU32::new(0));
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .build_passive()
+                .expect("empty chassis boots");
 
-        let (registry, mailer) = fresh_substrate();
-        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .build_passive()
-            .expect("empty chassis boots");
-
-        let counters: Vec<Arc<AtomicU32>> = (0..N).map(|_| Arc::new(AtomicU32::new(0))).collect();
-        for (i, counter) in counters.iter().enumerate() {
-            let name = format!("inst-{i}");
-            chassis
-                .spawn_actor::<Quiet>(Subname::Named(&name), Arc::clone(counter))
+            let id = chassis
+                .spawn_actor::<Quiet>(Subname::Counter, Arc::clone(&close_observed))
                 .finish()
                 .expect("spawn instanced actor");
-        }
 
-        for counter in &counters {
-            assert_eq!(counter.load(AtomicOrdering::SeqCst), 0);
-        }
+            // No mail at all — the actor sits idle from the moment it
+            // spawns. Pre-685 chassis teardown skipped its close path
+            // entirely; post-685 the teardown step signals + wakes it and
+            // the worker runs the close cycle before the pool drops.
+            assert_eq!(close_observed.load(AtomicOrdering::SeqCst), 0);
 
-        drop(chassis);
+            drop(chassis);
 
-        for (i, counter) in counters.iter().enumerate() {
             assert_eq!(
-                counter.load(AtomicOrdering::SeqCst),
+                close_observed.load(AtomicOrdering::SeqCst),
                 1,
-                "actor {i} must have run unwire exactly once",
+                "chassis teardown must drive unwire exactly once for a quiet spawned actor",
             );
+            // Drop the unused id binding so clippy stays quiet — its
+            // referent (the actor_registry's Live entry) drops with the
+            // chassis above.
+            let _ = id;
+        }
+
+        /// Issue 714: stress version of the chassis-teardown contract.
+        /// Spawn N=64 instanced actors and assert all N `close_observed`
+        /// counters tick to exactly 1 after `drop(chassis)`. Pre-714 the
+        /// polling-based `shutdown_instanced` could lose individual wakes
+        /// under contention; the channel-signal rewrite is deterministic
+        /// — even one missed `unwire` here fails the test.
+        #[test]
+        fn chassis_teardown_runs_unwire_for_many_pooled_actors() {
+            use crate::actor::native::spawn::Subname;
+            use aether_actor::Instanced;
+            use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+
+            struct Quiet {
+                close_observed: Arc<AtomicU32>,
+            }
+            impl Actor for Quiet {
+                const NAMESPACE: &'static str = "test.teardown.quiet_many";
+            }
+            impl Instanced for Quiet {}
+            impl NativeActor for Quiet {
+                type Config = Arc<AtomicU32>;
+                fn init(
+                    config: Self::Config,
+                    _ctx: &mut NativeInitCtx<'_>,
+                ) -> Result<Self, BootError> {
+                    Ok(Self {
+                        close_observed: config,
+                    })
+                }
+                fn unwire(&mut self, _ctx: &mut NativeCtx<'_>) {
+                    self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
+                }
+            }
+            impl NativeDispatch for Quiet {
+                fn __aether_dispatch_envelope(
+                    &mut self,
+                    _ctx: &mut NativeCtx<'_>,
+                    _kind: KindId,
+                    _payload: &[u8],
+                ) -> Option<()> {
+                    None
+                }
+            }
+
+            const N: usize = 64;
+
+            let (registry, mailer) = fresh_substrate();
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .build_passive()
+                .expect("empty chassis boots");
+
+            let counters: Vec<Arc<AtomicU32>> =
+                (0..N).map(|_| Arc::new(AtomicU32::new(0))).collect();
+            for (i, counter) in counters.iter().enumerate() {
+                let name = format!("inst-{i}");
+                chassis
+                    .spawn_actor::<Quiet>(Subname::Named(&name), Arc::clone(counter))
+                    .finish()
+                    .expect("spawn instanced actor");
+            }
+
+            for counter in &counters {
+                assert_eq!(counter.load(AtomicOrdering::SeqCst), 0);
+            }
+
+            drop(chassis);
+
+            for (i, counter) in counters.iter().enumerate() {
+                assert_eq!(
+                    counter.load(AtomicOrdering::SeqCst),
+                    1,
+                    "actor {i} must have run unwire exactly once",
+                );
+            }
         }
     }
 

--- a/crates/aether-substrate/src/chassis/settlement_table.rs
+++ b/crates/aether-substrate/src/chassis/settlement_table.rs
@@ -614,136 +614,132 @@ mod tests {
         assert_eq!(t.live_roots(), 0);
     }
 
-    /// The kernel's riskiest property through the full table path: seed
-    /// exactly `racers` `in_flight` on one root, then race `racers` threads
-    /// each doing one `record_finished`. Exactly one must observe the
-    /// zero-arrival, and the slot must reclaim. Repeated to shake out
-    /// interleavings.
-    #[test]
-    fn final_decrement_race_fires_once() {
-        for _ in 0..2_000 {
+    /// Contention/backoff-sensitive tests live in `mod heavy`: these lock-free
+    /// settlement-table races are timing-sensitive under load, so they are
+    /// serialized into the `serial-heavy` nextest group
+    /// (`.config/nextest.toml`) to avoid oversubscribing cores against one
+    /// another, and selected by `scripts/flake-soak.sh` for fresh-process
+    /// soak repetition.
+    mod heavy {
+        use super::*;
+
+        /// The kernel's riskiest property through the full table path: seed
+        /// exactly `racers` `in_flight` on one root, then race `racers` threads
+        /// each doing one `record_finished`. Exactly one must observe the
+        /// zero-arrival, and the slot must reclaim. Repeated to shake out
+        /// interleavings.
+        #[test]
+        fn final_decrement_race_fires_once() {
+            for _ in 0..2_000 {
+                let t = Arc::new(SettlementTable::new());
+                let racers = 4u32;
+                let r = root(11, 3);
+                for _ in 0..racers {
+                    t.record_sent(r);
+                }
+                let fires = Arc::new(AtomicU32::new(0));
+                let start = Arc::new(Barrier::new(racers as usize));
+                let mut handles = Vec::new();
+                for _ in 0..racers {
+                    let t = Arc::clone(&t);
+                    let fires = Arc::clone(&fires);
+                    let start = Arc::clone(&start);
+                    handles.push(thread::spawn(move || {
+                        start.wait();
+                        if t.record_finished(r) {
+                            fires.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }));
+                }
+                for h in handles {
+                    h.join().unwrap();
+                }
+                assert_eq!(fires.load(Ordering::Relaxed), 1);
+                assert_eq!(t.live_roots(), 0);
+            }
+        }
+
+        /// Concurrent inc/dec on a *shared* set of roots, modelling fan-out
+        /// under live chains: a keepalive unit per root is pre-loaded so
+        /// `in_flight` stays at least 1 throughout the concurrent phase (the real
+        /// workload never lets a root settle while a send under it can still
+        /// race — see the module Contract). No settle/tombstone fires during
+        /// the churn; the final drain settles each root exactly once. Tests
+        /// concurrent `find` + atomic mutation against the same `OCCUPIED`
+        /// slots from many threads.
+        #[test]
+        fn concurrent_shared_roots_inc_dec_then_drain() {
             let t = Arc::new(SettlementTable::new());
-            let racers = 4u32;
-            let r = root(11, 3);
-            for _ in 0..racers {
-                t.record_sent(r);
+            let roots = 256u64;
+            let threads = 8u64;
+            let per_root_per_thread = 64u32;
+
+            // Keepalive floor: in_flight >= 1 for every root during the phase.
+            for i in 0..roots {
+                t.record_sent(root(1, i));
             }
-            let fires = Arc::new(AtomicU32::new(0));
-            let start = Arc::new(Barrier::new(racers as usize));
-            let mut handles = Vec::new();
-            for _ in 0..racers {
+
+            run_threads(threads, {
                 let t = Arc::clone(&t);
-                let fires = Arc::clone(&fires);
-                let start = Arc::clone(&start);
-                handles.push(thread::spawn(move || {
-                    start.wait();
-                    if t.record_finished(r) {
-                        fires.fetch_add(1, Ordering::Relaxed);
+                move |tid| {
+                    for i in 0..roots {
+                        let r = root(1, (i + tid) % roots);
+                        for _ in 0..per_root_per_thread {
+                            t.record_sent(r);
+                            // Never settles: the keepalive holds the floor.
+                            assert!(!t.record_finished(r));
+                        }
                     }
-                }));
+                }
+            });
+
+            // Drain the keepalive: each root settles exactly once.
+            let mut fires = 0u64;
+            for i in 0..roots {
+                if t.record_finished(root(1, i)) {
+                    fires += 1;
+                }
             }
-            for h in handles {
-                h.join().unwrap();
-            }
-            assert_eq!(fires.load(Ordering::Relaxed), 1);
+            assert_eq!(fires, roots, "each root settles exactly once on drain");
             assert_eq!(t.live_roots(), 0);
         }
-    }
 
-    /// Concurrent inc/dec on a *shared* set of roots, modelling fan-out
-    /// under live chains: a keepalive unit per root is pre-loaded so
-    /// `in_flight` stays at least 1 throughout the concurrent phase (the real
-    /// workload never lets a root settle while a send under it can still
-    /// race — see the module Contract). No settle/tombstone fires during
-    /// the churn; the final drain settles each root exactly once. Tests
-    /// concurrent `find` + atomic mutation against the same `OCCUPIED`
-    /// slots from many threads.
-    #[test]
-    fn concurrent_shared_roots_inc_dec_then_drain() {
-        let t = Arc::new(SettlementTable::new());
-        let roots = 256u64;
-        let threads = 8u64;
-        let per_root_per_thread = 64u32;
+        /// Concurrent chain births *and* settles across threads, each thread
+        /// owning a private stream of distinct roots (so no same-root re-open
+        /// — the contract). Thousands of depth-2 chains per thread drive
+        /// concurrent claim + tombstone (and probe-chain collisions) on the
+        /// shared table. Every chain must settle exactly once and the table
+        /// must fully reclaim.
+        #[test]
+        fn concurrent_distinct_chains_claim_and_reclaim() {
+            let t = Arc::new(SettlementTable::new());
+            let threads = 8u64;
+            let chains_per_thread = 4_000u64;
+            let total_fires = Arc::new(AtomicU32::new(0));
 
-        // Keepalive floor: in_flight >= 1 for every root during the phase.
-        for i in 0..roots {
-            t.record_sent(root(1, i));
-        }
-
-        run_threads(threads, {
-            let t = Arc::clone(&t);
-            move |tid| {
-                for i in 0..roots {
-                    let r = root(1, (i + tid) % roots);
-                    for _ in 0..per_root_per_thread {
-                        t.record_sent(r);
-                        // Never settles: the keepalive holds the floor.
-                        assert!(!t.record_finished(r));
+            run_threads(threads, {
+                let t = Arc::clone(&t);
+                let total_fires = Arc::clone(&total_fires);
+                move |tid| {
+                    for c in 0..chains_per_thread {
+                        let r = root(tid + 1, c); // private to this thread
+                        t.record_sent(r); // born (1)
+                        t.record_sent(r); // child (2)
+                        assert!(!t.record_finished(r)); // (1)
+                        if t.record_finished(r) {
+                            // (0) → settle
+                            total_fires.fetch_add(1, Ordering::Relaxed);
+                        }
                     }
                 }
-            }
-        });
+            });
 
-        // Drain the keepalive: each root settles exactly once.
-        let mut fires = 0u64;
-        for i in 0..roots {
-            if t.record_finished(root(1, i)) {
-                fires += 1;
-            }
+            assert_eq!(
+                u64::from(total_fires.load(Ordering::Relaxed)),
+                threads * chains_per_thread,
+                "every chain settles exactly once"
+            );
+            assert_eq!(t.live_roots(), 0, "table fully reclaimed");
         }
-        assert_eq!(fires, roots, "each root settles exactly once on drain");
-        assert_eq!(t.live_roots(), 0);
-    }
-
-    /// Concurrent chain births *and* settles across threads, each thread
-    /// owning a private stream of distinct roots (so no same-root re-open
-    /// — the contract). Thousands of depth-2 chains per thread drive
-    /// concurrent claim + tombstone (and probe-chain collisions) on the
-    /// shared table. Every chain must settle exactly once and the table
-    /// must fully reclaim.
-    #[test]
-    fn concurrent_distinct_chains_claim_and_reclaim() {
-        let t = Arc::new(SettlementTable::new());
-        let threads = 8u64;
-        let chains_per_thread = 4_000u64;
-        let total_fires = Arc::new(AtomicU32::new(0));
-
-        run_threads(threads, {
-            let t = Arc::clone(&t);
-            let total_fires = Arc::clone(&total_fires);
-            move |tid| {
-                for c in 0..chains_per_thread {
-                    let r = root(tid + 1, c); // private to this thread
-                    t.record_sent(r); // born (1)
-                    t.record_sent(r); // child (2)
-                    assert!(!t.record_finished(r)); // (1)
-                    if t.record_finished(r) {
-                        // (0) → settle
-                        total_fires.fetch_add(1, Ordering::Relaxed);
-                    }
-                }
-            }
-        });
-
-        assert_eq!(
-            u64::from(total_fires.load(Ordering::Relaxed)),
-            threads * chains_per_thread,
-            "every chain settles exactly once"
-        );
-        assert_eq!(t.live_roots(), 0, "table fully reclaimed");
-    }
-
-    /// Flake-soak duplicates (CLAUDE.md §Flake soak): the lock-free
-    /// claim/tombstone races are timing-sensitive, so `scripts/flake-soak.sh`
-    /// stress-runs these `flaky_`-named wrappers in fresh processes before a
-    /// release. The originals run once in normal CI.
-    #[test]
-    fn flaky_final_decrement_race_fires_once() {
-        final_decrement_race_fires_once();
-    }
-
-    #[test]
-    fn flaky_concurrent_distinct_chains_claim_and_reclaim() {
-        concurrent_distinct_chains_claim_and_reclaim();
     }
 }

--- a/crates/aether-substrate/src/scheduler/calibrate.rs
+++ b/crates/aether-substrate/src/scheduler/calibrate.rs
@@ -429,54 +429,50 @@ mod tests {
         assert_eq!(cell.samples(), 201, "every live fold counted");
     }
 
-    /// Many workers fold the same cell concurrently (the real wake
-    /// pattern): the CAS fold + `fetch_add` count must lose no update.
-    /// Folding the seed value keeps the mean fixed, so the final mean and
-    /// the exact sample count are both deterministic regardless of
-    /// interleaving — a lost CAS or a lost increment would show up.
-    fn handoff_ewma_concurrent_folds_lose_nothing() {
-        const THREADS: usize = 8;
-        const PER_THREAD: u64 = 2_000;
-        let cell = Arc::new(HandoffEwma::new());
-        cell.seed(1_000);
+    /// Contention/backoff-sensitive tests live in `mod heavy`: they exercise
+    /// the concurrent handoff-EWMA fold path, so they are serialized into the
+    /// `serial-heavy` nextest group (`.config/nextest.toml`) to avoid
+    /// oversubscribing cores against one another, and selected by
+    /// `scripts/flake-soak.sh` for fresh-process soak repetition.
+    mod heavy {
+        use super::*;
 
-        let workers: Vec<_> = (0..THREADS)
-            .map(|_| {
-                let cell = Arc::clone(&cell);
-                thread::spawn(move || {
-                    for _ in 0..PER_THREAD {
-                        cell.fold(1_000);
-                    }
+        /// Many workers fold the same cell concurrently (the real wake
+        /// pattern): the CAS fold + `fetch_add` count must lose no update.
+        /// Folding the seed value keeps the mean fixed, so the final mean and
+        /// the exact sample count are both deterministic regardless of
+        /// interleaving — a lost CAS or a lost increment would show up.
+        #[test]
+        fn handoff_ewma_concurrent_folds_lose_nothing() {
+            const THREADS: usize = 8;
+            const PER_THREAD: u64 = 2_000;
+            let cell = Arc::new(HandoffEwma::new());
+            cell.seed(1_000);
+
+            let workers: Vec<_> = (0..THREADS)
+                .map(|_| {
+                    let cell = Arc::clone(&cell);
+                    thread::spawn(move || {
+                        for _ in 0..PER_THREAD {
+                            cell.fold(1_000);
+                        }
+                    })
                 })
-            })
-            .collect();
-        for w in workers {
-            w.join().expect("fold worker panicked");
+                .collect();
+            for w in workers {
+                w.join().expect("fold worker panicked");
+            }
+
+            assert_eq!(
+                cell.mean(),
+                1_000,
+                "folding the seed value leaves the mean fixed under any interleaving",
+            );
+            assert_eq!(
+                cell.samples(),
+                1 + THREADS as u64 * PER_THREAD,
+                "every concurrent fold's count survives (no lost fetch_add)",
+            );
         }
-
-        assert_eq!(
-            cell.mean(),
-            1_000,
-            "folding the seed value leaves the mean fixed under any interleaving",
-        );
-        assert_eq!(
-            cell.samples(),
-            1 + THREADS as u64 * PER_THREAD,
-            "every concurrent fold's count survives (no lost fetch_add)",
-        );
-    }
-
-    #[test]
-    fn handoff_ewma_concurrent_folds_lose_nothing_once() {
-        handoff_ewma_concurrent_folds_lose_nothing();
-    }
-
-    /// Flake-soak wrapper (iamacoffeepot/aether#1182 Part 2): the
-    /// multi-writer fold is concurrency-sensitive, so `scripts/flake-soak.sh`
-    /// re-runs it in fresh processes to catch a lost-update race a single
-    /// green run can mask.
-    #[test]
-    fn flaky_handoff_ewma_concurrent_folds_lose_nothing() {
-        handoff_ewma_concurrent_folds_lose_nothing();
     }
 }

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -584,103 +584,103 @@ mod tests {
         );
     }
 
-    /// Stress: 4 slots × 1000 envelopes each across 2 workers. Confirm
-    /// every envelope dispatches and no slot is left orphaned.
-    #[test]
-    fn stress_many_slots_across_workers() {
-        let handle = standard_handle(2);
-        let slots: Vec<_> = (0..4)
-            .map(|i| CounterSlot::new(Box::leak(format!("s{i}").into_boxed_str())))
-            .collect();
-        let wakes: Vec<_> = slots
-            .iter()
-            .map(|slot| {
-                let slot_dyn: Arc<dyn Drainable> = slot.clone();
-                let weak: Weak<dyn Drainable> = Arc::downgrade(&slot_dyn);
-                drop(slot_dyn);
-                WakeHandle::new(slot.state.clone(), weak, handle.wake_sink())
-            })
-            .collect();
+    /// Contention/backoff-sensitive tests live in `mod heavy`: they exercise
+    /// the worker dispatch / wake path, so they are serialized into the
+    /// `serial-heavy` nextest group (`.config/nextest.toml`) to avoid
+    /// oversubscribing cores against one another, and selected by
+    /// `scripts/flake-soak.sh` for fresh-process soak repetition.
+    mod heavy {
+        use super::*;
 
-        for (i, slot) in slots.iter().enumerate() {
-            for n in 0..1000 {
-                // Test fixture uses tiny indices that fit in u32.
-                #[allow(clippy::cast_possible_truncation)]
-                let value = (i * 1000 + n) as u32;
-                slot.push(value);
-            }
-            // Stress seeding — bool ignored; test asserts via total().
-            let _ = wakes[i].wake();
-        }
-
-        let total_expected: u32 = 4 * 1000;
-        let total = || -> u32 { slots.iter().map(|s| s.dispatched()).sum() };
-        assert!(wait_until(Duration::from_secs(5), || total() == total_expected));
-        for slot in &slots {
-            assert_eq!(slot.dispatched(), 1000);
-            assert_eq!(slot.state.current(), SlotStateLabel::Idle);
-        }
-
-        drop(wakes);
-        let _ = handle.shutdown_with_results();
-    }
-
-    /// Flake-soak wrapper (iamacoffeepot/aether#1059). Re-runs the
-    /// multi-worker stress under a `flaky_` name so `scripts/flake-soak.sh`
-    /// repeat-runs the rewritten `acquire_slot` dispatch path. The original
-    /// still runs once in normal CI; this duplicate is the soak target.
-    #[test]
-    fn flaky_stress_many_slots_across_workers() {
-        stress_many_slots_across_workers();
-    }
-
-    /// Build a depth-`d` relay chain of `CounterSlot`s: slot[i] forwards
-    /// each dispatched env to slot[i+1] and wakes it. The forwarding wake
-    /// runs on a pool worker, so the chain drives the worker-local stash
-    /// path that `acquire_slot` reads first (iamacoffeepot/aether#1059).
-    fn relay_chain(handle: &PoolHandle, depth: usize) -> Vec<Arc<CounterSlot>> {
-        let slots: Vec<Arc<CounterSlot>> = (0..depth).map(|_| CounterSlot::new("relay")).collect();
-        for i in 0..depth.saturating_sub(1) {
-            let target = slots[i + 1].clone();
-            let target_dyn: Arc<dyn Drainable> = target.clone();
-            let weak: Weak<dyn Drainable> = Arc::downgrade(&target_dyn);
-            drop(target_dyn);
-            let wake = WakeHandle::new(target.state.clone(), weak, handle.wake_sink());
-            *slots[i].forward.lock().unwrap() = Some((target, wake));
-        }
-        slots
-    }
-
-    /// Flake-soak (iamacoffeepot/aether#1059): a relay chain on a
-    /// multi-worker pool. Each hop's wake stashes the downstream in the
-    /// running worker's local cell, so the chain stays on one warm worker
-    /// instead of bouncing across parked siblings. Soaked because the
-    /// stash path is concurrency-sensitive (worker thread-local + the
-    /// `Idle → Ready` CAS) and fires only on real worker threads — which
-    /// the other slot tests, driven from the test thread, never hit.
-    #[test]
-    fn flaky_relay_chain_stays_on_worker() {
-        let handle = standard_handle(4);
-        let slots = relay_chain(&handle, 8);
-
-        let entry = slots[0].clone();
-        let entry_dyn: Arc<dyn Drainable> = entry.clone();
-        let weak: Weak<dyn Drainable> = Arc::downgrade(&entry_dyn);
-        drop(entry_dyn);
-        let entry_wake = WakeHandle::new(entry.state.clone(), weak, handle.wake_sink());
-
-        entry.push(1);
-        assert!(entry_wake.wake());
-
-        assert!(
-            wait_until(Duration::from_secs(5), || slots
+        /// Stress: 4 slots × 1000 envelopes each across 2 workers. Confirm
+        /// every envelope dispatches and no slot is left orphaned.
+        #[test]
+        fn stress_many_slots_across_workers() {
+            let handle = standard_handle(2);
+            let slots: Vec<_> = (0..4)
+                .map(|i| CounterSlot::new(Box::leak(format!("s{i}").into_boxed_str())))
+                .collect();
+            let wakes: Vec<_> = slots
                 .iter()
-                .all(|s| s.dispatched() >= 1)),
-            "every slot in the relay chain should dispatch its forwarded env"
-        );
+                .map(|slot| {
+                    let slot_dyn: Arc<dyn Drainable> = slot.clone();
+                    let weak: Weak<dyn Drainable> = Arc::downgrade(&slot_dyn);
+                    drop(slot_dyn);
+                    WakeHandle::new(slot.state.clone(), weak, handle.wake_sink())
+                })
+                .collect();
 
-        drop(entry_wake);
-        let _ = handle.shutdown_with_results();
+            for (i, slot) in slots.iter().enumerate() {
+                for n in 0..1000 {
+                    // Test fixture uses tiny indices that fit in u32.
+                    #[allow(clippy::cast_possible_truncation)]
+                    let value = (i * 1000 + n) as u32;
+                    slot.push(value);
+                }
+                // Stress seeding — bool ignored; test asserts via total().
+                let _ = wakes[i].wake();
+            }
+
+            let total_expected: u32 = 4 * 1000;
+            let total = || -> u32 { slots.iter().map(|s| s.dispatched()).sum() };
+            assert!(wait_until(Duration::from_secs(5), || total() == total_expected));
+            for slot in &slots {
+                assert_eq!(slot.dispatched(), 1000);
+                assert_eq!(slot.state.current(), SlotStateLabel::Idle);
+            }
+
+            drop(wakes);
+            let _ = handle.shutdown_with_results();
+        }
+
+        /// Build a depth-`d` relay chain of `CounterSlot`s: slot[i] forwards
+        /// each dispatched env to slot[i+1] and wakes it. The forwarding wake
+        /// runs on a pool worker, so the chain drives the worker-local stash
+        /// path that `acquire_slot` reads first (iamacoffeepot/aether#1059).
+        fn relay_chain(handle: &PoolHandle, depth: usize) -> Vec<Arc<CounterSlot>> {
+            let slots: Vec<Arc<CounterSlot>> =
+                (0..depth).map(|_| CounterSlot::new("relay")).collect();
+            for i in 0..depth.saturating_sub(1) {
+                let target = slots[i + 1].clone();
+                let target_dyn: Arc<dyn Drainable> = target.clone();
+                let weak: Weak<dyn Drainable> = Arc::downgrade(&target_dyn);
+                drop(target_dyn);
+                let wake = WakeHandle::new(target.state.clone(), weak, handle.wake_sink());
+                *slots[i].forward.lock().unwrap() = Some((target, wake));
+            }
+            slots
+        }
+
+        /// A relay chain on a multi-worker pool: each hop's wake stashes the
+        /// downstream in the running worker's local cell, so the chain stays on
+        /// one warm worker instead of bouncing across parked siblings. The stash
+        /// path is concurrency-sensitive (worker thread-local + the `Idle → Ready`
+        /// CAS) and fires only on real worker threads — which the other slot
+        /// tests, driven from the test thread, never hit.
+        #[test]
+        fn relay_chain_stays_on_worker() {
+            let handle = standard_handle(4);
+            let slots = relay_chain(&handle, 8);
+
+            let entry = slots[0].clone();
+            let entry_dyn: Arc<dyn Drainable> = entry.clone();
+            let weak: Weak<dyn Drainable> = Arc::downgrade(&entry_dyn);
+            drop(entry_dyn);
+            let entry_wake = WakeHandle::new(entry.state.clone(), weak, handle.wake_sink());
+
+            entry.push(1);
+            assert!(entry_wake.wake());
+
+            assert!(
+                wait_until(Duration::from_secs(5), || slots
+                    .iter()
+                    .all(|s| s.dispatched() >= 1)),
+                "every slot in the relay chain should dispatch its forwarded env"
+            );
+
+            drop(entry_wake);
+            let _ = handle.shutdown_with_results();
+        }
     }
 
     // Reuse the standard wallclock budget for fairness tests — 200µs

--- a/crates/aether-substrate/src/scheduler/spin_park.rs
+++ b/crates/aether-substrate/src/scheduler/spin_park.rs
@@ -467,139 +467,123 @@ mod tests {
         assert!(worker.join().unwrap(), "acquire should resolve Shutdown");
     }
 
-    /// Part 2 (iamacoffeepot/aether#1182): a genuine parked-worker wake
-    /// folds one live `notify → wake` sample into the handoff estimate. A
-    /// worker parks (scan always empty), the main thread waits for it to
-    /// register idle, then `notify`s — which stamps the worker and unparks
-    /// it, so on resume it folds the measured latency. The folded-sample
-    /// count must rise by at least one.
-    fn parked_worker_folds_a_handoff_sample() {
-        let before = super::super::calibrate::handoff_samples();
-        let coord = Arc::new(SpinPark::with_spin_window(Duration::from_micros(20)));
-        let c2 = Arc::clone(&coord);
-        // The worker parks (scan never yields), folds on the notify wake,
-        // re-spins, and exits on shutdown.
-        let worker =
-            thread::spawn(move || matches!(c2.acquire(|| None::<u32>), Acquired::Shutdown));
+    /// Contention/backoff-sensitive tests live in `mod heavy`: they exercise
+    /// the spin-then-park backoff path, so they are serialized into the
+    /// `serial-heavy` nextest group (`.config/nextest.toml`) to avoid
+    /// oversubscribing cores against one another, and selected by
+    /// `scripts/flake-soak.sh` for fresh-process soak repetition.
+    mod heavy {
+        use super::*;
+        use crate::scheduler::calibrate;
 
-        // Wait until the worker has committed to the idle list — so the
-        // `notify` below hits the park path (stamp + unpark), not the
-        // route-to-spinner fast path (which folds nothing).
-        assert!(
-            wait_until(Duration::from_secs(2), || !coord.idle().is_empty()),
-            "worker should register as parked",
-        );
-        coord.notify(); // stamp + unpark → the worker folds notify→wake
-        // Give the woken worker time to fold before tearing down.
-        assert!(
-            wait_until(Duration::from_secs(2), || {
-                super::super::calibrate::handoff_samples() > before
-            }),
-            "a live parked-worker wake must fold a handoff sample",
-        );
+        /// Part 2 (iamacoffeepot/aether#1182): a genuine parked-worker wake
+        /// folds one live `notify → wake` sample into the handoff estimate. A
+        /// worker parks (scan always empty), the main thread waits for it to
+        /// register idle, then `notify`s — which stamps the worker and unparks
+        /// it, so on resume it folds the measured latency. The folded-sample
+        /// count must rise by at least one.
+        #[test]
+        fn parked_worker_folds_a_handoff_sample() {
+            let before = calibrate::handoff_samples();
+            let coord = Arc::new(SpinPark::with_spin_window(Duration::from_micros(20)));
+            let c2 = Arc::clone(&coord);
+            // The worker parks (scan never yields), folds on the notify wake,
+            // re-spins, and exits on shutdown.
+            let worker =
+                thread::spawn(move || matches!(c2.acquire(|| None::<u32>), Acquired::Shutdown));
 
-        coord.set_shutdown();
-        worker.thread().unpark();
-        assert!(worker.join().unwrap(), "acquire should resolve Shutdown");
-    }
-
-    #[test]
-    fn parked_worker_folds_a_handoff_sample_once() {
-        parked_worker_folds_a_handoff_sample();
-    }
-
-    /// Flake-soak wrapper (iamacoffeepot/aether#1182 Part 2): the
-    /// park → notify → fold path is timing-sensitive (the worker must be
-    /// parked when `notify` fires), so `scripts/flake-soak.sh` re-runs it
-    /// in fresh processes.
-    #[test]
-    fn flaky_parked_worker_folds_a_handoff_sample() {
-        parked_worker_folds_a_handoff_sample();
-    }
-
-    /// Lost-wakeup stress: many producers push tokens onto a shared
-    /// queue + `notify`; many workers `acquire`-drain. Every pushed
-    /// token must be consumed exactly once — a stranded token (work in
-    /// the queue, all workers parked, no pending unpark) hangs the
-    /// drain and trips the timeout. This is the highest-risk surface;
-    /// the `flaky_` wrapper below is the soak target.
-    fn lost_wakeup_stress() {
-        const WORKERS: usize = 6;
-        const PRODUCERS: usize = 4;
-        const PER_PRODUCER: u64 = 5_000;
-
-        let coord = Arc::new(SpinPark::with_spin_window(Duration::from_micros(30)));
-        let (tx, rx): (Sender<u64>, Receiver<u64>) = unbounded();
-        let consumed = Arc::new(AtomicU64::new(0));
-        let total = PRODUCERS as u64 * PER_PRODUCER;
-
-        let workers: Vec<_> = (0..WORKERS)
-            .map(|_| {
-                let coord = Arc::clone(&coord);
-                let rx = rx.clone();
-                let consumed = Arc::clone(&consumed);
-                thread::spawn(move || {
-                    loop {
-                        match coord.acquire(|| rx.try_recv().ok()) {
-                            Acquired::Slot(_) => {
-                                consumed.fetch_add(1, Ordering::Relaxed);
-                            }
-                            Acquired::Shutdown => return,
-                        }
-                    }
-                })
-            })
-            .collect();
-
-        let producers: Vec<_> = (0..PRODUCERS)
-            .map(|p| {
-                let coord = Arc::clone(&coord);
-                let tx = tx.clone();
-                thread::spawn(move || {
-                    for n in 0..PER_PRODUCER {
-                        tx.send(p as u64 * PER_PRODUCER + n).unwrap();
-                        coord.notify();
-                    }
-                })
-            })
-            .collect();
-        for p in producers {
-            p.join().unwrap();
-        }
-
-        // Wait for full drain — a lost wakeup strands the tail and this
-        // times out.
-        let start = Instant::now();
-        while consumed.load(Ordering::Relaxed) < total {
+            // Wait until the worker has committed to the idle list — so the
+            // `notify` below hits the park path (stamp + unpark), not the
+            // route-to-spinner fast path (which folds nothing).
             assert!(
-                start.elapsed() < Duration::from_secs(10),
-                "drain stalled at {}/{} — likely a lost wakeup",
-                consumed.load(Ordering::Relaxed),
-                total,
+                wait_until(Duration::from_secs(2), || !coord.idle().is_empty()),
+                "worker should register as parked",
             );
-            thread::sleep(Duration::from_millis(5));
+            coord.notify(); // stamp + unpark → the worker folds notify→wake
+            // Give the woken worker time to fold before tearing down.
+            assert!(
+                wait_until(Duration::from_secs(2), || {
+                    calibrate::handoff_samples() > before
+                }),
+                "a live parked-worker wake must fold a handoff sample",
+            );
+
+            coord.set_shutdown();
+            worker.thread().unpark();
+            assert!(worker.join().unwrap(), "acquire should resolve Shutdown");
         }
 
-        coord.set_shutdown();
-        for w in &workers {
-            w.thread().unpark();
-        }
-        for w in workers {
-            w.join().unwrap();
-        }
-        assert_eq!(consumed.load(Ordering::Relaxed), total);
-    }
+        /// Lost-wakeup stress: many producers push tokens onto a shared
+        /// queue + `notify`; many workers `acquire`-drain. Every pushed
+        /// token must be consumed exactly once — a stranded token (work in
+        /// the queue, all workers parked, no pending unpark) hangs the
+        /// drain and trips the timeout. This is the highest-risk surface.
+        #[test]
+        fn lost_wakeup_stress() {
+            const WORKERS: usize = 6;
+            const PRODUCERS: usize = 4;
+            const PER_PRODUCER: u64 = 5_000;
 
-    #[test]
-    fn lost_wakeup_stress_once() {
-        lost_wakeup_stress();
-    }
+            let coord = Arc::new(SpinPark::with_spin_window(Duration::from_micros(30)));
+            let (tx, rx): (Sender<u64>, Receiver<u64>) = unbounded();
+            let consumed = Arc::new(AtomicU64::new(0));
+            let total = PRODUCERS as u64 * PER_PRODUCER;
 
-    /// Flake-soak wrapper (iamacoffeepot/aether#1064). `scripts/flake-soak.sh`
-    /// re-runs the lost-wakeup stress in fresh processes to catch the
-    /// `StoreLoad` race that a single green run can mask.
-    #[test]
-    fn flaky_lost_wakeup_stress() {
-        lost_wakeup_stress();
+            let workers: Vec<_> = (0..WORKERS)
+                .map(|_| {
+                    let coord = Arc::clone(&coord);
+                    let rx = rx.clone();
+                    let consumed = Arc::clone(&consumed);
+                    thread::spawn(move || {
+                        loop {
+                            match coord.acquire(|| rx.try_recv().ok()) {
+                                Acquired::Slot(_) => {
+                                    consumed.fetch_add(1, Ordering::Relaxed);
+                                }
+                                Acquired::Shutdown => return,
+                            }
+                        }
+                    })
+                })
+                .collect();
+
+            let producers: Vec<_> = (0..PRODUCERS)
+                .map(|p| {
+                    let coord = Arc::clone(&coord);
+                    let tx = tx.clone();
+                    thread::spawn(move || {
+                        for n in 0..PER_PRODUCER {
+                            tx.send(p as u64 * PER_PRODUCER + n).unwrap();
+                            coord.notify();
+                        }
+                    })
+                })
+                .collect();
+            for p in producers {
+                p.join().unwrap();
+            }
+
+            // Wait for full drain — a lost wakeup strands the tail and this
+            // times out.
+            let start = Instant::now();
+            while consumed.load(Ordering::Relaxed) < total {
+                assert!(
+                    start.elapsed() < Duration::from_secs(10),
+                    "drain stalled at {}/{} — likely a lost wakeup",
+                    consumed.load(Ordering::Relaxed),
+                    total,
+                );
+                thread::sleep(Duration::from_millis(5));
+            }
+
+            coord.set_shutdown();
+            for w in &workers {
+                w.thread().unpark();
+            }
+            for w in workers {
+                w.join().unwrap();
+            }
+            assert_eq!(consumed.load(Ordering::Relaxed), total);
+        }
     }
 }

--- a/scripts/flake-soak.sh
+++ b/scripts/flake-soak.sh
@@ -5,20 +5,23 @@
 # test (iamacoffeepot/aether#1060).
 #
 # Marking is by name, because nextest selects on test name/path, not on a
-# Rust attribute: a flake-prone test carries a `flaky_` name prefix (or lives
-# in a `mod flaky`, whose path shows in the test name). nextest's
-# `--stress-count` then runs each selected test N times, each in a fresh
-# process — the process isolation that matters for timing flakes.
+# Rust attribute: a flake-prone test lives in a `mod heavy` submodule, whose
+# `::heavy::` path segment shows in the test name (iamacoffeepot/aether#1341).
+# That same marker drives the `serial-heavy` test-group in
+# `.config/nextest.toml` (which serializes the set during normal CI runs), so
+# one convention covers both serialize-in-CI and soak-before-release.
+# nextest's `--stress-count` then runs each selected test N times, each in a
+# fresh process — the process isolation that matters for timing flakes.
 #
 # Usage:
 #   scripts/flake-soak.sh [count]     # default 200
-#   AETHER_FLAKE_FILTER='test(/flaky/)' scripts/flake-soak.sh 1000
+#   AETHER_FLAKE_FILTER='test(/::heavy::/)' scripts/flake-soak.sh 1000
 #
 # Exits non-zero if any iteration of any marked test fails.
 set -euo pipefail
 
 count="${1:-200}"
-filter="${AETHER_FLAKE_FILTER:-test(/flaky/)}"
+filter="${AETHER_FLAKE_FILTER:-test(/::heavy::/)}"
 
 cd "$(git rev-parse --show-toplevel)"
 


### PR DESCRIPTION
## Summary

Concurrent / scheduler / mail-dispatch tests are timing-flaky, and under a saturated `--workspace` run they oversubscribe cores so a settlement that needs timely cross-thread progress can miss its ~30s deadline — passing in isolation but wedging the full suite. This was a recurring source of red preflight/CI runs that weren't real failures.

Mark such a test by declaring it inside a **`mod heavy`** submodule; the `::heavy::` path segment is a single nextest selector that drives two things:

- **Serialize in every run.** A `serial-heavy` test-group (`max-threads = 1`) in `.config/nextest.toml` runs the set single-file, so they never contend with one another while the thousands of lightweight tests keep saturating cores. The override is repeated on the `default` and `ci` profiles (profiles don't inherit).
- **Soak before a release.** `scripts/flake-soak.sh` selects the same `test(/::heavy::/)` set for fresh-process `--stress-count` repetition.

This **retires the parallel `flaky_` duplicate-wrapper convention** — one marker instead of two, and the redundant double-run of each test in a normal CI run goes away (the old `flaky_<name>` wrapper ran alongside its original every time). The two conventions always marked the same set; unifying them removes the drift that left offenders untracked.

## Membership (21 tests)

- The **17** previously `flaky_`-tracked tests move into `mod heavy`.
- The **2 untracked offenders** that flaked preflight join them: `transform_panic_fails_node`, `chassis_teardown_runs_unwire_for_pooled_spawned_actors`.
- **2 adjacent same-class tests** folded in (behaviour-neutral relocation; they sit in the same contention cluster and serializing them is free): `concurrent_shared_roots_inc_dec_then_drain`, `chassis_teardown_runs_unwire_for_many_pooled_actors`.

Verify membership with `cargo nextest show-config test-groups --profile ci`.

## Shape

Two move styles, both leaving the test body untouched:

- **In-place wrap** where the contention tests are contiguous (scheduler, settlement-table, binding, blob_work, builder): wrap the span in `mod heavy { use super::*; … }`. `cargo fmt` reindents — hence the large line counts on those files.
- **Delegating wrappers** where they're scattered among helpers (mail_latency, dag, tunnel, rpc): the body stays at module scope, `mod heavy` holds a thin `#[test]` that calls `super::body()`. Avoids moving bodies across module depth (keeps relative `super::` paths valid).

Two `super::super::`-relative paths in moved bodies were absolutized to `crate::` paths (`spin_park`, and a `super::test_support` in `dag`).

## Out of scope

Backoff tuning itself (spin/park thresholds, settlement deadline) — this is a test-harness fix, not a scheduler change.

Closes iamacoffeepot/aether#1341

🤖 Generated with [Claude Code](https://claude.com/claude-code)
