### PR TITLE
ci(board): label-driven board sync workflow + script

### DIFF
--- a/.github/workflows/reconcile-board.yml
+++ b/.github/workflows/reconcile-board.yml
@@ -1,0 +1,63 @@
+name: reconcile-board
+
+# Keep the release board in sync with each issue's phase:* label. The label is
+# the source of truth; this moves the card to match (closed -> Done, no label
+# -> Backlog). See scripts/reconcile-board.sh for the rules.
+#
+# Setup (one-time):
+#   - Board writes hit a user-level Projects v2 board, which the default
+#     GITHUB_TOKEN cannot write. Create a fine-grained PAT with read/write on
+#     "Projects" for the owner and add it as the repo secret PROJECTS_TOKEN.
+#     Without it the project step warns and no card moves.
+#   - Set the active board number: `gh variable set BOARD_PROJECT --body <N>`
+#     (currently 2). Bump it when a new release board opens — that is the only
+#     per-release touch; nothing is hard-coded in this file.
+
+on:
+  issues:
+    types: [labeled, unlabeled, opened, reopened, closed]
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: "Apply changes (false = dry-run plan only)"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  issues: read
+
+concurrency:
+  # One issue can fire labeled+unlabeled in quick succession; collapse to the
+  # latest per issue. The dispatch backlog pass gets its own group.
+  group: reconcile-board-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Reconcile board
+        env:
+          # Projects v2 (user-level) needs a project-scoped token; GITHUB_TOKEN
+          # cannot write it. PROJECTS_TOKEN is the fine-grained PAT (see header).
+          GH_TOKEN: ${{ secrets.PROJECTS_TOKEN || github.token }}
+          # .claude/release-state.json is gitignored, so it is absent in CI; the
+          # script falls back to these. Owner is the built-in repo owner (never
+          # stale). The project number rolls every release, so it lives in the
+          # repo variable BOARD_PROJECT (gh variable set BOARD_PROJECT --body N),
+          # not a literal here — bump it once when a new release board opens.
+          BOARD_OWNER: ${{ github.repository_owner }}
+          BOARD_PROJECT: ${{ vars.BOARD_PROJECT }}
+        run: |
+          if [ "${{ github.event_name }}" = "issues" ]; then
+            scripts/reconcile-board.sh --issue "${{ github.event.issue.number }}" --apply --verbose
+          else
+            if [ "${{ inputs.apply }}" = "true" ]; then
+              scripts/reconcile-board.sh --all --apply --verbose
+            else
+              scripts/reconcile-board.sh --all --verbose
+            fi
+          fi

--- a/scripts/reconcile-board.sh
+++ b/scripts/reconcile-board.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Move issues to the right column on the release board, driven by the issue's
+# phase:* label. The label is the source of truth; the board card follows it.
+#
+# An issue carries a phase:<name> label (set by humans in the UI, or by the
+# scope/approve/implement/bounce skills). The board Phase field should always
+# show that same column. It drifts because the field is only writable through
+# the project API, so a label slapped on in the UI never moves the card. This
+# syncs the card to the label.
+#
+# Rules, in order:
+#   issue CLOSED                -> Phase = Done   (Done carries no label)
+#   issue OPEN, phase:<x> label -> Phase = <X>    (matched to the board option)
+#   issue OPEN, no phase label  -> Phase = Backlog (the resting/default column)
+#
+# Runs from `.github/workflows/reconcile-board.yml` on issue label/state events
+# (one issue) and is runnable by hand for a whole-board backlog pass:
+#
+#   scripts/reconcile-board.sh --all                # dry-run: print the plan
+#   scripts/reconcile-board.sh --all --apply        # actually move the cards
+#   scripts/reconcile-board.sh --issue 984 --apply  # one issue
+#
+# Default is DRY-RUN — nothing moves without --apply. The workflow passes
+# --apply (an unattended run has no human to confirm a printed plan).
+#
+# Owner + project number come from .claude/release-state.json when present
+# (local runs), else from $BOARD_OWNER / $BOARD_PROJECT (the workflow sets
+# these — they are public, not secret). The project node id and the Phase
+# field/option ids are always resolved live from the API, so nothing here goes
+# stale and the gitignored release-state.json is not required in CI.
+#
+# Projects v2 (user-level) writes need a token with project scope; the default
+# Actions GITHUB_TOKEN cannot write a user project, so the workflow sets GH_TOKEN
+# to a PROJECTS_TOKEN secret. If a write fails for lack of scope the script
+# warns once and keeps going rather than aborting.
+
+set -euo pipefail
+
+MODE=""
+TARGET=""
+APPLY=0
+VERBOSE=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --all) MODE="all"; shift ;;
+        --issue) MODE="issue"; TARGET="$2"; shift 2 ;;
+        --apply) APPLY=1; shift ;;
+        --verbose|-v) VERBOSE=1; shift ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ -z "$MODE" ]]; then
+    echo "usage: reconcile-board.sh (--all | --issue N) [--apply] [--verbose]" >&2
+    exit 2
+fi
+
+log() { [[ $VERBOSE -eq 1 ]] && echo "  · $*" >&2 || true; }
+
+# Owner + project number: local cache first, env fallback for CI.
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+STATE="$ROOT/.claude/release-state.json"
+if [[ -f "$STATE" ]]; then
+    OWNER=$(jq -r '.owner' "$STATE")
+    PROJECT=$(jq -r '.active_project' "$STATE")
+else
+    OWNER="${BOARD_OWNER:-}"
+    PROJECT="${BOARD_PROJECT:-}"
+fi
+if [[ -z "$OWNER" || -z "$PROJECT" ]]; then
+    echo "no owner/project — need .claude/release-state.json or \$BOARD_OWNER + \$BOARD_PROJECT" >&2
+    exit 1
+fi
+
+# Phase field + options, resolved live (never stale).
+PROJECT_NODE=$(gh project view "$PROJECT" --owner "$OWNER" --format json 2>/dev/null | jq -r '.id // empty')
+FIELDS_JSON=$(gh project field-list "$PROJECT" --owner "$OWNER" --format json 2>/dev/null || echo '{}')
+PHASE_FIELD=$(echo "$FIELDS_JSON" | jq -r '.fields[]? | select(.name=="Phase") | .id' | head -1)
+if [[ -z "$PROJECT_NODE" || -z "$PHASE_FIELD" ]]; then
+    echo "could not resolve project $PROJECT / Phase field for owner $OWNER (token scope? project number?)" >&2
+    exit 1
+fi
+
+phase_option_id() {
+    echo "$FIELDS_JSON" | jq -r --arg n "$1" \
+        '.fields[]? | select(.name=="Phase") | .options[]? | select(.name==$n) | .id' | head -1
+}
+
+# Map a phase:<x> label suffix to the canonical board option name, matched
+# case-insensitively (phase:ready -> "Ready"). Empty if not a real option.
+label_to_phase() {
+    echo "$FIELDS_JSON" | jq -r --arg x "$1" \
+        '.fields[]? | select(.name=="Phase") | .options[]? | .name
+         | select(ascii_downcase == ($x | ascii_downcase))' | head -1
+}
+
+# Board item cache as a num<TAB>id<TAB>phase file (bash 3.2 has no associative
+# arrays, and the default macOS bash is 3.2).
+BOARD_TSV="$(mktemp)"
+trap 'rm -f "$BOARD_TSV"' EXIT
+load_board() {
+    gh project item-list "$PROJECT" --owner "$OWNER" --format json --limit 500 2>/dev/null \
+        | jq -r '.items[] | select(.content.number != null)
+                 | [.content.number, .id, (.phase // "")] | @tsv' > "$BOARD_TSV" || {
+        echo "warning: could not list project $PROJECT items — is GH_TOKEN scoped for projects?" >&2
+    }
+}
+board_item_id() { awk -F'\t' -v n="$1" '$1==n{print $2; exit}' "$BOARD_TSV"; }
+board_phase()   { awk -F'\t' -v n="$1" '$1==n{print $3; exit}' "$BOARD_TSV"; }
+
+plan_lines=()
+applied=0
+warned=0
+
+# Target column for one issue, from its state + phase:* label.
+target_phase_for() {
+    local num="$1" data st label_suffix
+    data=$(gh issue view "$num" --json state,labels 2>/dev/null) || { echo ""; return 0; }
+    st=$(echo "$data" | jq -r '.state')
+    if [[ "$st" == "CLOSED" ]]; then
+        echo "Done"; return 0
+    fi
+    label_suffix=$(echo "$data" | jq -r '.labels[].name | select(startswith("phase:")) | sub("^phase:"; "")' | head -1)
+    if [[ -z "$label_suffix" ]]; then
+        echo "Backlog"; return 0
+    fi
+    label_to_phase "$label_suffix"
+}
+
+reconcile_issue() {
+    local num="$1" target cur item
+    # Only move cards that exist. An issue not on the board is a "should it be
+    # tracked" question, not a "move the card" one — out of scope here.
+    item="$(board_item_id "$num")"
+    if [[ -z "$item" ]]; then
+        log "#$num not on board — skipping"
+        return 0
+    fi
+    target=$(target_phase_for "$num")
+    cur="$(board_phase "$num")"; cur="${cur:-<none>}"
+    if [[ -z "$target" ]]; then
+        log "#$num — unrecognized phase label, leaving at $cur"
+        return 0
+    fi
+    log "#$num board=$cur target=$target"
+    [[ "$target" == "$cur" ]] && return 0
+
+    plan_lines+=("  #$num  Phase $cur → $target")
+
+    if [[ $APPLY -eq 1 ]]; then
+        local opt
+        opt=$(phase_option_id "$target")
+        if [[ -z "$opt" ]]; then
+            echo "warning: no option id for phase '$target'" >&2
+            return 0
+        fi
+        if gh project item-edit --id "$item" --project-id "$PROJECT_NODE" \
+             --field-id "$PHASE_FIELD" --single-select-option-id "$opt" >/dev/null 2>&1; then
+            applied=$((applied+1))
+        elif [[ $warned -eq 0 ]]; then
+            echo "warning: project field write failed (token missing 'project' scope?) — cards left unmoved" >&2
+            warned=1
+        fi
+    fi
+}
+
+load_board
+
+case "$MODE" in
+    issue) reconcile_issue "$TARGET" ;;
+    all)
+        # Every card on the board, synced to its issue's label/state.
+        for n in $(cut -f1 "$BOARD_TSV" | sort -un); do
+            [[ -n "$n" ]] && reconcile_issue "$n"
+        done
+        ;;
+esac
+
+echo
+if [[ ${#plan_lines[@]} -eq 0 ]]; then
+    echo "board-sync: nothing drifted — every card matches its issue's phase label."
+elif [[ $APPLY -eq 1 ]]; then
+    echo "board-sync: moved ${applied} card(s):"
+    printf '%s\n' "${plan_lines[@]}"
+else
+    echo "board-sync (DRY-RUN — re-run with --apply): ${#plan_lines[@]} card(s) to move:"
+    printf '%s\n' "${plan_lines[@]}"
+fi


### PR DESCRIPTION
## Summary

Automates the release board so cards stop drifting from reality. The issue's `phase:*` label is the source of truth; the board card follows it. No PR-linkage derivation — just the label (and closed-state).

`scripts/reconcile-board.sh` moves a card to match its issue:

| issue state | label | board Phase |
|---|---|---|
| CLOSED | (any) | **Done** |
| OPEN | `phase:<x>` | **`<X>`** (matched to the board option) |
| OPEN | none | **Backlog** (resting/default column) |

Only cards already on the board are moved — adding untracked issues is a separate concern. Default is **dry-run** (prints the plan); `--apply` mutates. Runnable by hand for a whole-board backlog pass (`--all`) or one issue (`--issue N`), and bash 3.2-safe so it works on a stock macOS shell.

`.github/workflows/reconcile-board.yml` fires it:
- on `issues` events (`labeled`/`unlabeled`/`opened`/`reopened`/`closed`) then reconcile that one issue with `--apply`;
- via `workflow_dispatch` then whole-board backlog pass (use this once to clean up the current drift).

Phase field/option ids resolve live from the API (`gh project view` / `field-list`), so nothing goes stale. Owner is the built-in repo owner; the project number is a repo variable (it rolls every release, so it is not hard-coded). Locally the script reads both from `.claude/release-state.json`.

## One-time setup

1. **`PROJECTS_TOKEN` secret** — user-level Projects v2 boards can't be written by the default `GITHUB_TOKEN`. Create a fine-grained PAT with **read/write on Projects** for the owner and add it as the repo secret `PROJECTS_TOKEN`. Without it the workflow runs, warns, and moves nothing.
2. **`BOARD_PROJECT` variable** — `gh variable set BOARD_PROJECT --body 2` (the current release board). Bump it once whenever a new release board opens; that is the only per-release touch.

## Current drift

A dry-run over the live board found **40 closed issues** stranded at `Plan`/`Ready`/`Executing` that should be `Done` (e.g. the whole DAG/handle-store umbrella set, issues 973 through 989, merged back in May). Running the `workflow_dispatch` backlog pass once setup is done will clear them in one go.

`.github/**` plus `scripts/**` only; no Rust changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)