### PR TITLE
ci(board): make reconcile-board auth robust and its failures legible

### DIFF
--- a/.github/workflows/reconcile-board.yml
+++ b/.github/workflows/reconcile-board.yml
@@ -41,9 +41,12 @@ jobs:
 
       - name: Reconcile board
         env:
-          # Projects v2 (user-level) needs a project-scoped token; GITHUB_TOKEN
-          # cannot write it. PROJECTS_TOKEN is the fine-grained PAT (see header).
-          GH_TOKEN: ${{ secrets.PROJECTS_TOKEN || github.token }}
+          # Projects v2 (user-level) needs a project-scoped token; the default
+          # GITHUB_TOKEN cannot read or write it (it yields "unknown owner type"
+          # on a user owner). No fallback on purpose: if PROJECTS_TOKEN is unset
+          # the run fails loudly with an auth error instead of limping along on
+          # the useless default token. See header for how to set it.
+          GH_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
           # .claude/release-state.json is gitignored, so it is absent in CI; the
           # script falls back to these. Owner is the built-in repo owner (never
           # stale). The project number rolls every release, so it lives in the

--- a/scripts/reconcile-board.sh
+++ b/scripts/reconcile-board.sh
@@ -73,15 +73,21 @@ if [[ -z "$OWNER" || -z "$PROJECT" ]]; then
     exit 1
 fi
 
-# Phase field + options, resolved live (never stale). Surface gh's own error
-# rather than dying mutely under set -e when the token can't read the project.
-if ! proj_json=$(gh project view "$PROJECT" --owner "$OWNER" --format json 2>&1); then
-    echo "cannot read project $PROJECT for owner $OWNER — the token likely lacks project read scope (classic 'project', or fine-grained Projects: Read)." >&2
+# Phase field + options, resolved live (never stale). Address the project as
+# "@me" (the authenticated user) rather than by owner login: `gh project
+# --owner <login>` resolves the owner by querying both user(login) and
+# organization(login), and on some gh versions the org half's error for a User
+# login poisons the response into "unknown owner type". "@me" routes through
+# `viewer`, skipping that lookup. (Assumes the board is owned by the token's
+# user — true for this release board; an org-owned board would use its login.)
+# Surface gh's own error rather than dying mutely under set -e on failure.
+if ! proj_json=$(gh project view "$PROJECT" --owner "@me" --format json 2>&1); then
+    echo "cannot read project $PROJECT as @me — token lacks project scope, or @me is not the board owner ($OWNER)." >&2
     echo "  gh: $proj_json" >&2
     exit 1
 fi
 PROJECT_NODE=$(echo "$proj_json" | jq -r '.id // empty')
-if ! FIELDS_JSON=$(gh project field-list "$PROJECT" --owner "$OWNER" --format json 2>&1); then
+if ! FIELDS_JSON=$(gh project field-list "$PROJECT" --owner "@me" --format json 2>&1); then
     echo "cannot list project $PROJECT fields — token scope? gh: $FIELDS_JSON" >&2
     exit 1
 fi
@@ -109,7 +115,7 @@ label_to_phase() {
 BOARD_TSV="$(mktemp)"
 trap 'rm -f "$BOARD_TSV"' EXIT
 load_board() {
-    gh project item-list "$PROJECT" --owner "$OWNER" --format json --limit 500 2>/dev/null \
+    gh project item-list "$PROJECT" --owner "@me" --format json --limit 500 2>/dev/null \
         | jq -r '.items[] | select(.content.number != null)
                  | [.content.number, .id, (.phase // "")] | @tsv' > "$BOARD_TSV" || {
         echo "warning: could not list project $PROJECT items — is GH_TOKEN scoped for projects?" >&2

--- a/scripts/reconcile-board.sh
+++ b/scripts/reconcile-board.sh
@@ -73,12 +73,21 @@ if [[ -z "$OWNER" || -z "$PROJECT" ]]; then
     exit 1
 fi
 
-# Phase field + options, resolved live (never stale).
-PROJECT_NODE=$(gh project view "$PROJECT" --owner "$OWNER" --format json 2>/dev/null | jq -r '.id // empty')
-FIELDS_JSON=$(gh project field-list "$PROJECT" --owner "$OWNER" --format json 2>/dev/null || echo '{}')
+# Phase field + options, resolved live (never stale). Surface gh's own error
+# rather than dying mutely under set -e when the token can't read the project.
+if ! proj_json=$(gh project view "$PROJECT" --owner "$OWNER" --format json 2>&1); then
+    echo "cannot read project $PROJECT for owner $OWNER — the token likely lacks project read scope (classic 'project', or fine-grained Projects: Read)." >&2
+    echo "  gh: $proj_json" >&2
+    exit 1
+fi
+PROJECT_NODE=$(echo "$proj_json" | jq -r '.id // empty')
+if ! FIELDS_JSON=$(gh project field-list "$PROJECT" --owner "$OWNER" --format json 2>&1); then
+    echo "cannot list project $PROJECT fields — token scope? gh: $FIELDS_JSON" >&2
+    exit 1
+fi
 PHASE_FIELD=$(echo "$FIELDS_JSON" | jq -r '.fields[]? | select(.name=="Phase") | .id' | head -1)
 if [[ -z "$PROJECT_NODE" || -z "$PHASE_FIELD" ]]; then
-    echo "could not resolve project $PROJECT / Phase field for owner $OWNER (token scope? project number?)" >&2
+    echo "resolved no project node / Phase field on project $PROJECT (owner $OWNER)" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Follow-up to the board-sync automation. As merged, the workflow failed in CI with an opaque `unknown owner type` that turned out to mask a plain `401 Bad credentials` — the diagnosis took a while precisely because the script hid the real error. These three commits fix the auth path and make any future failure self-explaining.

## Changes

1. **Surface gh's error instead of dying mute.** The project-id / Phase-field resolution used unguarded `$(gh ... | jq)` substitutions, so under `set -euo pipefail` any gh failure killed the script with a bare exit 1 — the run log showed only "Process completed with exit code 1". Now it captures gh's stderr and prints it.

2. **Require PROJECTS_TOKEN; drop the github.token fallback.** `secrets.PROJECTS_TOKEN || github.token` silently downgraded to the default Actions token when the secret was empty, and the default token cannot resolve a user-level project owner — so a token problem presented as "unknown owner type" with the PAT never even attempted. The secret is now referenced directly, so a bad/missing token fails loudly with the real auth error.

3. **Address the board as `@me`.** `gh project --owner <login>` resolves the owner by querying both `user(login)` and `organization(login)`; on the runner's gh version the org half's error for a User login poisoned the response into "unknown owner type". `@me` routes through `viewer` and skips the user-vs-org lookup, which surfaced the underlying 401 and (once the token was fixed) resolves the board cleanly.

## Verified

`workflow_dispatch` on this branch now completes green: "board-sync: nothing drifted — every card matches its issue's phase label." The owner/project values were correct throughout; the root cause was an invalid token value in the secret, which fix 1 + 3 made diagnosable.

`.github/**` plus `scripts/**` only; no Rust changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)