### PR TITLE
docs(repo): scaffold the agent guide site (mdbook + pages)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,60 @@
+name: docs
+
+# Builds the mdBook guide (docs/) and, on main, publishes it to GitHub Pages.
+# On pull requests the build runs as a check only — a broken book fails the PR
+# without touching the live site. Pages source must be set to "GitHub Actions"
+# in the repo settings for the deploy job to publish.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/guide/**'
+      - 'docs/book.toml'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'docs/guide/**'
+      - 'docs/book.toml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Allow one concurrent deploy; don't cancel an in-progress publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install mdBook
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: '0.4.40'
+      - name: Build the guide
+        run: mdbook build docs
+      - name: Upload Pages artifact
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/book
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 # Spike crates under spikes/ are standalone Cargo workspaces with
 # their own target dirs (per ADR-0003 §Consequences).
 spikes/*/target/
+# mdBook render output for the guide (docs/book.toml). CI rebuilds it
+# fresh and publishes to Pages; the built site is never committed.
+/docs/book/
 # Research projects under research/ are independent nested git repos
 # (own .git, own remote, possibly private). Unlike spikes/ they are
 # never tracked here — their content, including any locally decoded

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,23 @@
+[book]
+title = "Aether Guide"
+description = "How aether works and how to build with it — written for agents."
+authors = ["aether"]
+language = "en"
+# The guide source lives under docs/guide/ so it sits next to the ADRs
+# (docs/adr/) without entangling with them. The rendered site builds to
+# docs/book/ (gitignored); CI rebuilds it fresh and deploys to Pages.
+src = "guide"
+
+[output.html]
+default-theme = "navy"
+preferred-dark-theme = "navy"
+git-repository-url = "https://github.com/iamacoffeepot/aether"
+edit-url-template = "https://github.com/iamacoffeepot/aether/edit/main/docs/{path}"
+no-section-label = false
+
+[output.html.fold]
+enable = true
+level = 1
+
+[output.html.search]
+enable = true

--- a/docs/guide/SUMMARY.md
+++ b/docs/guide/SUMMARY.md
@@ -1,0 +1,34 @@
+# Summary
+
+[Introduction](introduction.md)
+
+# Design & philosophy
+
+- [Why aether is shaped this way](philosophy.md)
+- [Architecture overview](architecture.md)
+
+# The systems
+
+- [Subsystem map](systems.md)
+  - [Mail, kinds & scheduling]()
+  - [Components & lifecycle]()
+  - [Rendering & camera]()
+  - [Mesh authoring & the DSL]()
+  - [Input, file I/O & audio]()
+  - [Tracing & settlement]()
+  - [Configuration]()
+  - [The computation DAG & handles]()
+
+# Building with aether
+
+- [Recipes](recipes.md)
+  - [Adding a config knob]()
+  - [Adding a substrate kind]()
+  - [Adding a chassis capability]()
+  - [Wiring an MCP tool]()
+  - [Writing a component]()
+  - [Debugging a hung settlement]()
+
+# Reference
+
+- [Pointers & where to read more](reference.md)

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -8,29 +8,29 @@ establish where everything sits.
 ## The stack
 
 ```
-        ┌──────────────────────────────────────────────┐
- agent  │  Claude in a harness                          │
-        └───────────────┬──────────────────────────────┘
-                        │ MCP (tool calls)
-        ┌───────────────▼──────────────────────────────┐
-        │  aether-tunnel        stable MCP front (:8890) │  ADR-0089
-        │    ├─ aether-mcp      dials the hub  (:8891)   │
-        │    └─ aether-substrate-hub  RPC server (:8901) │  ADR-0034
-        └───────────────┬──────────────────────────────┘
-                        │ wire Call / MailFrame
-        ┌───────────────▼──────────────────────────────┐
-        │  substrate (a chassis)                         │  ADR-0035/0073
-        │   ┌──────────────────────────────────────┐    │
-        │   │ mail scheduler  (blob dispatch)        │    │  ADR-0087
-        │   ├──────────────────────────────────────┤    │
-        │   │ native capabilities (actors)           │    │  ADR-0070/0071
-        │   │  render · audio · fs · input · window  │    │
-        │   │  component-loader · handle-store · dag │    │
-        │   ├──────────────────────────────────────┤    │
-        │   │ wasm runtime → components (actors)     │    │  ADR-0010/0074
-        │   │  aether.component.trampoline:NAME      │    │
-        │   └──────────────────────────────────────┘    │
-        └────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────┐
+│  agent: Claude in a harness                      │
+└────────────────────────┬─────────────────────────┘
+                         │ MCP (tool calls)
+┌────────────────────────v─────────────────────────┐
+│  aether-tunnel        stable MCP front (:8890)   │   ADR-0089
+│   |- aether-mcp       dials the hub   (:8891)    │
+│   `- aether-substrate-hub  RPC server (:8901)    │   ADR-0034
+└────────────────────────┬─────────────────────────┘
+                         │ wire Call / MailFrame
+┌────────────────────────v─────────────────────────┐
+│  substrate (a chassis)                           │   ADR-0035/0073
+│  ┌────────────────────────────────────────────┐  │
+│  │ mail scheduler  (blob dispatch)            │  │   ADR-0087
+│  ├────────────────────────────────────────────┤  │
+│  │ native capabilities (actors)               │  │   ADR-0070/0071
+│  │  render, audio, fs, input, window          │  │
+│  │  component-loader, handle-store, dag       │  │
+│  ├────────────────────────────────────────────┤  │
+│  │ wasm runtime -> components (actors)        │  │   ADR-0010/0074
+│  │  aether.component.trampoline:NAME          │  │
+│  └────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────┘
 ```
 
 Everything inside the substrate is an **actor**, and actors only ever talk by

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -1,0 +1,115 @@
+# Architecture overview
+
+This page is the map. It names the pieces, shows how they stack, and traces a
+single piece of mail from an agent's tool call to a handler and back. Each
+subsystem has its own explainer in [The systems](systems.md); here we only
+establish where everything sits.
+
+## The stack
+
+```
+        ┌──────────────────────────────────────────────┐
+ agent  │  Claude in a harness                          │
+        └───────────────┬──────────────────────────────┘
+                        │ MCP (tool calls)
+        ┌───────────────▼──────────────────────────────┐
+        │  aether-tunnel        stable MCP front (:8890) │  ADR-0089
+        │    ├─ aether-mcp      dials the hub  (:8891)   │
+        │    └─ aether-substrate-hub  RPC server (:8901) │  ADR-0034
+        └───────────────┬──────────────────────────────┘
+                        │ wire Call / MailFrame
+        ┌───────────────▼──────────────────────────────┐
+        │  substrate (a chassis)                         │  ADR-0035/0073
+        │   ┌──────────────────────────────────────┐    │
+        │   │ mail scheduler  (blob dispatch)        │    │  ADR-0087
+        │   ├──────────────────────────────────────┤    │
+        │   │ native capabilities (actors)           │    │  ADR-0070/0071
+        │   │  render · audio · fs · input · window  │    │
+        │   │  component-loader · handle-store · dag │    │
+        │   ├──────────────────────────────────────┤    │
+        │   │ wasm runtime → components (actors)     │    │  ADR-0010/0074
+        │   │  aether.component.trampoline:NAME      │    │
+        │   └──────────────────────────────────────┘    │
+        └────────────────────────────────────────────────┘
+```
+
+Everything inside the substrate is an **actor**, and actors only ever talk by
+**mail**. The native capabilities and the wasm components are the *same actor
+model* (ADR-0074) — the renderer is an actor, your component is an actor, and
+they address each other identically.
+
+## The crates
+
+Two layers: infrastructure (describes and moves typed bytes) and runtime
+(hosts and runs actors).
+
+**Infrastructure — non-actor:**
+
+| Crate | Role |
+|---|---|
+| `aether-data` | The universal data layer (`no_std`). Typed-id newtypes (`MailboxId`, `KindId`, `HandleId`), wire identity, the schema vocabulary (`SchemaType`, `KindShape`), the `Kind` / `Schema` traits, `Ref<K>`, encode/decode, and the native descriptor/transform inventories. Everything that describes typed bytes depends on it. |
+| `aether-codec` | Schema-driven JSON ↔ wire bytes (`encode_schema` / `decode_schema`) plus postcard stream framing (ADR-0072). |
+| `aether-kinds` | The substrate kind vocabulary — `Tick`, `Key`, `WindowSize`, `DrawTriangle`, and the `aether.{audio,fs,render,window,input,component,camera,log,handle,dag}.*` families. |
+| `aether-math` | `Vec2/3/4`, `Mat4`, `Quat`, `Aabb` — column-major, right-handed Y-up, `f32`, `no_std`. Reach here before hand-rolling vector math. |
+
+**Runtime + chassis (ADR-0073):**
+
+| Crate | Role |
+|---|---|
+| `aether-substrate` | The shared runtime: mail scheduler, wasm host, the actor machinery. |
+| `aether-capabilities` | Native capabilities (the chassis actors): render, audio, fs, input, component-loader, handle store, etc. |
+| `aether-substrate-bundle` | The four chassis as submodules (`desktop` / `headless` / `hub` / `test_bench`) with one binary each, plus the hub library and its wire vocabulary. |
+| `aether-actor` | The guest/actor SDK: the `Actor` / `FfiActor` traits, `Mailbox<K>`, `FfiCtx`, the `#[actor]` macro, and `export!`. |
+
+**The harness (out-of-process, ADR-0089):** `aether-tunnel` (the stable MCP
+front that supervises and re-forks the volatile backends), `aether-mcp` (the
+RPC client that relays each tool call as a wire `Call`), and the hub inside
+`aether-substrate-bundle`.
+
+## Anatomy of a piece of mail
+
+A *kind* is a typed payload shape; a *mailbox* is an address. They are
+**independent**: you send the kind `aether.audio.note_on` to the mailbox
+`aether.audio`. They often share a prefix but route separately — this trips up
+everyone once, so internalize it early.
+
+Trace one `send_mail` from the agent:
+
+1. **Tool call.** The agent calls `send_mail` with
+   `{engine_id, recipient_name, kind_name, params}`. `aether-mcp` looks up the
+   kind's schema and **encodes `params` (JSON) into wire bytes** against the
+   substrate vocabulary (ADR-0007), producing a wire `Call`.
+2. **Route to the engine.** The hub forwards the `Call` to the right substrate
+   over the channel (ADR-0034/0037). The ids on the wire are type-tagged
+   strings (`mbx-…`, `knd-…`), so nothing is guessed (ADR-0064/0065).
+3. **Schedule.** The substrate's scheduler hands the mail to the addressed
+   actor as part of a *blob* of work (ADR-0087). Each actor is single-threaded
+   from its own perspective — no locks in actor state.
+4. **Decode + dispatch.** The actor decodes the bytes back into the kind and
+   the `#[actor]`-generated dispatch table routes it to the handler whose
+   third parameter is that kind (ADR-0033). No typelist, no `is::<K>()`.
+5. **Effects and replies.** The handler does its work — maybe sending more
+   mail (`ctx.actor::<RenderCapability>().send(&kind)`), maybe replying. Mail
+   is **fire-and-forget unless a reply kind is part of the contract**; a
+   handler promises nothing about a reply on its own.
+
+Two cross-cutting systems watch this flow without it opting in:
+
+- **Tracing & settlement** (ADR-0080/0086): a traced batch shares a trace root
+  and the agent gets the full subtree once the chain *settles* — no polling, no
+  window-guessing. Settlement is exact via a hold contract (ADR-0093/0094).
+- **Per-actor logging** (ADR-0081): each actor has its own log ring, queryable
+  by mailbox name through `actor_logs`.
+
+## How an agent reaches all this
+
+The agent never touches the substrate directly. It calls MCP tools
+(`mcp__aether-hub__*`) — `spawn_substrate`, `load_component`, `send_mail`,
+`capture_frame`, `submit_dag`, and the introspection trio (`describe_kinds`,
+`describe_component`, `describe_transforms`). The tunnel keeps the MCP session
+alive across hub restarts, so the agent can rebuild and relaunch the engine
+mid-task without re-initialising. The full tool list and the operational
+details live in `CLAUDE.md`; the [reference](reference.md) page points there.
+
+From here, the [subsystem map](systems.md) takes each box in the stack and
+explains what it's for, what you mail it, and how to extend it.

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -1,0 +1,67 @@
+# Introduction
+
+Aether is a game engine being built to be **driven by an agent**. The
+working assumption everywhere in the design is that the primary operator —
+the one who spawns engines, loads components, sends mail, authors content,
+and extends the codebase — is Claude, sitting in a harness. Humans are
+welcome, but the surfaces are shaped for a machine consumer first.
+
+This guide is the narrative companion to that codebase. It is written for
+the agent that has to *do something* with aether and wants to understand
+the system well enough to extend or reuse it, not just call it.
+
+## What this guide is (and isn't)
+
+Aether already has two kinds of agent-facing documentation:
+
+- **`CLAUDE.md`** — reference: the facts, conventions, commands, and the
+  operational surface (what to mail where). Loaded into context every
+  session. Terse by design.
+- **ADRs** (`docs/adr/NNNN-*.md`) — the decision record: *why* each
+  load-bearing choice was made, in the order it was made. Authoritative,
+  but raw and chronological.
+
+This guide is the missing middle: a **digested, navigable explanation** of
+how the system works and how to build with it. It synthesizes the ADRs into
+per-subsystem explainers, states the design philosophy out loud, and
+collects the worked "how to do X here" recipes. Where a section makes a
+claim about a subsystem, it cites the ADR that governs it — read the ADR
+for the authoritative detail; read the guide to understand the shape.
+
+## How it's organized
+
+- **[Design & philosophy](philosophy.md)** — the load-bearing principles.
+  Why aether is mail-first, why the substrate is thin, why every surface is
+  built for a machine reader. Read this first; the rest of the system makes
+  sense in its light.
+- **[Architecture overview](architecture.md)** — the system map. The crates,
+  the substrate/chassis/capabilities split, the actor model, how mail flows
+  end to end, and how an agent reaches the engine through MCP.
+- **[The systems](systems.md)** — per-subsystem explainers: what each one is
+  for, what you mail it, and how to extend or reuse it.
+- **[Building with aether](recipes.md)** — recipes: worked, copy-able
+  walkthroughs for the recurring multi-file dances (adding a kind, a config
+  knob, a capability, a component).
+- **[Reference](reference.md)** — where to go for the authoritative detail.
+
+## A note on staleness
+
+This guide carries file paths and symbol names, so it can drift as the code
+moves. Two defenses: every page cites the ADR it is digesting (the ADR is
+the durable source of truth), and recipes point at a **real in-tree example**
+rather than freezing a code snippet that rots. If a page names a file,
+function, or kind that no longer exists, trust the code and the ADR over the
+prose — and fix the page.
+
+## Why a guide at all: the dogfood premise
+
+There's a second reason this guide exists, beyond helping an agent navigate.
+Aether's policy is that **every feature with a callable surface ships a short
+tutorial, and the tutorial _is_ the API sanity check** — a dual pass: a human
+reads it and the API looks sane, and an agent reads it and can build on the
+API from the tutorial alone. If either fails, the API is mis-shaped — and the
+fix is the design, not the prose.
+
+So this guide is also a forcing function. An API you can't write a clean,
+followable explanation for is telling you something. Writing these pages is
+how we find out whether the surfaces we've built are actually coherent.

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -1,9 +1,12 @@
 # Introduction
 
-Aether is a game engine being built to be **driven by an agent**. The
-working assumption everywhere in the design is that the primary operator —
-the one who spawns engines, loads components, sends mail, authors content,
-and extends the codebase — is Claude, sitting in a harness. Humans are
+Aether is an application engine — built for games, and **driven by an
+agent**. The substrate underneath is general: it hosts whatever real-time,
+interactive software runs on it (a game, a tool, a server), and games are the
+motivating target rather than a baked-in assumption — so don't expect a fixed
+game loop to be load-bearing. What *is* baked in everywhere is **who operates
+it**: the one who spawns engines, loads components, sends mail, authors
+content, and extends the codebase is Claude, sitting in a harness. Humans are
 welcome, but the surfaces are shaped for a machine consumer first.
 
 This guide is the narrative companion to that codebase. It is written for

--- a/docs/guide/philosophy.md
+++ b/docs/guide/philosophy.md
@@ -1,0 +1,106 @@
+# Why aether is shaped this way
+
+Aether is not a conventional engine that happens to have an agent bolted on.
+The agent-in-a-harness premise is upstream of almost every structural
+decision. This page states the principles out loud, because once you hold
+them the rest of the system stops looking arbitrary.
+
+## 1. The agent is the operator
+
+The motivating image is Claude sitting in a harness as assistant, engineer,
+and designer — driving a running engine, observing it, and modifying it. That
+is not a feature; it is the **load-bearing constraint**. A native **substrate**
+owns the things only native code can own — I/O, the GPU, audio — and hosts a
+WebAssembly runtime. Everything above the substrate is an **actor**, and the
+agent reaches in from outside through a stable tool surface (MCP) to make
+things happen.
+
+Consequences that follow from taking this seriously:
+
+- The control surface is **out-of-process and restartable** without dropping
+  the agent's session (ADR-0089). The agent must be able to rebuild and
+  relaunch the volatile backends mid-task and keep its connection.
+- Observation is first-class. The agent can capture a frame, read an actor's
+  logs, trace a mail chain, and inspect handles — because an operator that
+  can't see can't act.
+
+## 2. Everything is mail
+
+Actors do not call each other. They **send mail** (ADR-0002). A piece of mail
+is a typed payload (a *kind*) addressed to a *mailbox*. This is the single
+most pervasive decision in the system, and it buys:
+
+- **A uniform boundary.** The same mechanism carries a tick event, a draw
+  command, an audio note, a file write, and a request to load a component.
+  There is one thing to learn, not twelve.
+- **Location independence.** A mailbox might be a native capability, a wasm
+  component, or a peer on another process reached through the hub — the
+  sender addresses it the same way. Mail bubbles up to the hub when it isn't
+  local (ADR-0037).
+- **Observability for free.** Because all interaction is mail, the tracing and
+  settlement machinery (ADR-0080/0086) can watch *all* of it without each
+  subsystem opting in.
+
+Mail is **fire-and-forget by default.** A handler promises nothing about a
+reply; if a reply matters, that's a separate, explicit contract — never an
+implicit "every kind has a response."
+
+## 3. The substrate is thin; the engine is actors
+
+The native base layer is deliberately small. It owns I/O, GPU, audio, the
+mail scheduler, and the wasm host — and little else. Game and tool behavior
+lives **above** it, as actors (ADR-0034/0035/0073). Two kinds of actor, one
+model (ADR-0074):
+
+- **Native chassis capabilities** — render, audio, file I/O, input, the
+  component loader, the handle store. Compiled into the substrate.
+- **Wasm components** — your logic, loaded at runtime and hot-swappable.
+
+They are the *same actor model*, addressed the same way. A component talks to
+the renderer exactly as one native capability talks to another. The symmetry
+is intentional and defended: prefer a design that treats wasm and native
+uniformly over one that special-cases the target.
+
+The chassis is **composed**, not monolithic — a builder assembles the
+capabilities a given deployment needs (ADR-0070/0071), which is why there are
+several chassis (desktop, headless, hub, test-bench) sharing one runtime.
+
+## 4. Design for machine consumers
+
+The surfaces are built to be legible to an LLM, which is not the same as
+being legible to a human. Where human API design prizes terseness and DRY,
+aether's surfaces prize being **regular, explicit, self-describing, and
+repetition-tolerant**:
+
+- Kinds carry their own schema (ADR-0031/0032) and ids are type-tagged on the
+  wire (ADR-0064/0065), so a tool result can be handed back verbatim and a
+  kind can describe itself.
+- Prefer **explicit nulls over absent-field semantics** — every option
+  addressed in a payload, because verbosity is nearly free for a machine
+  caller and ambiguity is not.
+- The vocabulary is introspectable live: an agent can ask the engine what
+  kinds exist, what a component handles, what transforms are linked, what
+  handles are stored.
+
+## 5. ADRs are the memory; tutorials are the proof
+
+Two habits keep the system honest as it grows:
+
+- **Load-bearing decisions are recorded as ADRs** (ADR-0001) — numbered,
+  reviewed like code, and cited from the code and from this guide. The ADR is
+  the durable "why." When in doubt, the ADR wins over prose that has drifted.
+- **Every callable surface ships a tutorial, and the tutorial is the sanity
+  check.** If you cannot write a clean walkthrough that a fresh agent can
+  build from, the surface is mis-shaped — fix the design, not the words. This
+  guide is where those tutorials live, and writing them is how the API shapes
+  get tested. (See the [recipes](recipes.md) section.)
+
+---
+
+These five hang together. Because the agent is the operator (1), interaction
+has to be uniform, addressable, and observable — so everything is mail (2).
+Because the agent both *uses* and *extends* the engine, the line between
+native and wasm has to be thin and symmetric (3). Because the consumer is a
+model, the surfaces are explicit and self-describing (4). And because all of
+this drifts without discipline, decisions are recorded and tutorials prove the
+surfaces stay sane (5).

--- a/docs/guide/recipes.md
+++ b/docs/guide/recipes.md
@@ -1,0 +1,78 @@
+# Recipes
+
+A recipe is a worked, copy-able walkthrough for one of the recurring
+multi-file dances in aether — "how do I add X here, the blessed way, with the
+gotchas inline." Recipes are the middle ground between reference (facts) and a
+skill (a deterministic workflow an agent runs): they carry **judgment** plus a
+walkthrough you can follow end to end.
+
+This section is the home for the agent-recipe corpus
+([iamacoffeepot/aether#1344](https://github.com/iamacoffeepot/aether/issues/1344)).
+
+## Why recipes earn their own section
+
+The motivating failure: an agent reached for a raw `env::var(...).parse()` to
+add a tuning knob, when the blessed path was the layered config API
+(ADR-0090). The "why" was in an ADR and the "that it exists" was in `CLAUDE.md`,
+but **nobody showed the steps**. A recipe titled *Adding a config knob* — the
+`derive(Config)` → emitted overlay → `from_argv_then_env` → wire into the
+chassis CLI → add to the `--config` dump — would have made the right path the
+obvious one. Recipes exist to make the blessed multi-file dance the path of
+least resistance.
+
+## The dual-pass test (what makes a recipe done)
+
+Every recipe is also an **API sanity check**, per aether's tutorial policy. A
+recipe is only finished when it passes both directions:
+
+- **A human reads it** → the steps make sense and the API looks sane.
+- **An agent reads it** → can build the feature *on* that API from the recipe
+  alone, without spelunking the source.
+
+If either side fails, the recipe isn't the problem — **the API is mis-shaped.**
+Fix the design, then the recipe follows. This is the whole reason to write
+recipes during design rather than after: the writing is the test.
+
+## The one structural seam: does it recompile?
+
+Recipes split on a single practical axis — not "using vs extending" (that line
+is blurry; writing a component is both at once), but **whether the task touches
+aether's Rust and rebuilds**:
+
+- **Drive-only** — MCP tool calls against a running engine (author a mesh, move
+  the camera, capture a frame). Prereq: the harness is up. No build.
+- **Recompile** — editing aether's Rust (a kind, a config knob, a capability).
+  Prereq: `cargo` + the pre-flight loop.
+- **The middle** — writing a wasm component with the actor SDK. You compile
+  *your* crate to extend the running engine without touching aether's
+  internals. Both at once.
+
+Each recipe states its prereqs up front so you know which loop you're in.
+
+## Planned recipes
+
+These are drafted in the nav and land in subsequent PRs. The first is *Adding a
+config knob* — the pattern is shipped and proven, and it's the freshest worked
+example.
+
+- **Adding a config knob** (recompile) — the ADR-0090 layered-config dance.
+- **Adding a substrate kind** (recompile) — `aether-kinds` → inventory
+  descriptor → MCP surface → tests, end to end.
+- **Adding a chassis capability** (recompile) — a native actor, its mailbox,
+  its handlers, and the builder wiring.
+- **Wiring an MCP tool** (recompile) — args → tool → wire-kind round-trip.
+- **Writing a component** (the middle) — `#[actor]`, handlers, `export!`,
+  loading it, and talking to it.
+- **Debugging a hung settlement** (drive-only) — reading a stuck mail chain
+  with the trace tools.
+
+## The staleness rule for recipes
+
+Recipes carry file paths and symbol names, so they rot faster than the
+explainers. Two rules keep them honest:
+
+1. **Point at a real in-tree example**, don't freeze a snippet. Reference the
+   actual file/PR that did the thing; a copy drifts, a pointer doesn't.
+2. **Carry a "verify against current code" note.** Before following a recipe,
+   confirm the named symbols still exist — and if they don't, fix the recipe as
+   part of the work.

--- a/docs/guide/reference.md
+++ b/docs/guide/reference.md
@@ -1,0 +1,58 @@
+# Pointers & where to read more
+
+This guide is the *digested* view. When you need the authoritative,
+always-current detail, these are the sources — and the guide defers to them
+whenever they disagree with it.
+
+## The durable sources of truth
+
+- **`CLAUDE.md`** (repo root) — the operational reference. Commands, the full
+  MCP tool list with signatures, the recipient-name convention, the chassis
+  surface (what to mail where), the pre-flight and CI workflow. Loaded into
+  every agent session. If the guide and `CLAUDE.md` disagree about a command
+  or a tool signature, `CLAUDE.md` wins.
+- **The ADR log** (`docs/adr/NNNN-*.md`) — the decision record, in the order
+  decisions were made. Every claim in this guide about *why* a subsystem is
+  shaped a certain way is digesting one or more ADRs; the citation is in the
+  text. Read the ADR for the authoritative reasoning and the alternatives that
+  were rejected. Start a new one from `docs/adr/TEMPLATE.md`.
+- **The code** — the final authority. If a page names a file, function, or
+  kind that no longer exists, the code is right and the page is stale. Fix the
+  page.
+
+## Live introspection (ask the running engine)
+
+Much of what you'd want from "reference" is better asked of a live engine than
+read from a doc, because the engine can't drift from itself:
+
+- `describe_kinds` — the static substrate kind vocabulary with full schemas.
+- `describe_component(engine_id, mailbox_id)` — a loaded component's handler
+  kinds and per-handler docs.
+- `describe_transforms` — the native `#[transform]` functions linked at build
+  time.
+- `describe_handles(engine_id)` — the persistent handle store's contents.
+- `actor_logs(engine_id, mailbox_name)` — recent entries from one actor's log
+  ring.
+
+Reach for these before assuming a doc is current.
+
+## How the docs divide up
+
+| Source | Question it answers | Form |
+|---|---|---|
+| This guide | "How does the system work, and how do I build with it?" | Digested narrative |
+| `CLAUDE.md` | "What's the command / tool / convention right now?" | Terse reference |
+| ADRs | "Why was this decided, and what was rejected?" | Decision record |
+| Live introspection | "What does *this* engine actually have right now?" | Queried from the engine |
+| The code | "What is true?" | The authority |
+
+## Contributing to this guide
+
+The guide builds with [mdBook](https://rust-lang.github.io/mdBook/). Source is
+under `docs/guide/`; `docs/book.toml` is the config. Build locally with
+`mdbook build docs` (output in `docs/book/`, gitignored) or `mdbook serve docs`
+to preview. On merge to `main`, CI rebuilds and publishes to GitHub Pages.
+
+When you add or change a callable surface, add or update the matching recipe in
+the same change — the tutorial is the API sanity check, and writing it during
+design is how a mis-shaped API gets caught before it freezes.

--- a/docs/guide/systems.md
+++ b/docs/guide/systems.md
@@ -1,0 +1,60 @@
+# Subsystem map
+
+This page is the index to the per-subsystem explainers. Each subsystem gets a
+dedicated page (under construction — see the nav) covering *why it exists*,
+*what it does*, and *how to extend or reuse it*. Until a page lands, the row
+below is the orientation: what it's for, what you mail it, and the ADRs that
+govern it.
+
+A note on the **maturity** column, because it changes how you should read a
+page: *Stable* surfaces are safe to build on and document in full. *Settling*
+surfaces have a stable outward face (what to mail, what it does) but internals
+still in motion — the explainer documents the face and defers the guts to the
+ADR until it lands. When in doubt, the ADR is authoritative.
+
+## Mailbox addressing, first
+
+Before the table: the rule that everything else assumes. `recipient_name`
+names the **mailbox**; `kind_name` names the **payload shape**. They route
+independently even when they share a prefix. Chassis-owned mailboxes live under
+`aether.<name>` (`aether.render`, `aether.audio`, `aether.fs`, `aether.input`,
+`aether.window`, `aether.component`, `aether.handle`). A loaded wasm component
+registers at `aether.component.trampoline:NAME` — use the full address that
+`LoadResult.name` hands back. **Bare names** (`"camera"`, `"player"`) are not
+registered and warn-drop.
+
+## The subsystems
+
+| Subsystem | What it's for | Mail it | ADRs | Maturity |
+|---|---|---|---|---|
+| **Mail & scheduling** | The universal interaction mechanism + the blob dispatcher that runs actors. | (the substrate itself; not a mailbox) | 0002, 0005, 0019, 0087 | Settling (scheduler internals) |
+| **Kinds, schema & encoding** | Typed payloads that describe themselves on the wire. | — | 0005, 0031, 0032, 0064, 0065, 0091 | Stable |
+| **Components & lifecycle** | Loading, replacing, and hot-reloading wasm actors. | `aether.component` — `load` / `drop` / `replace` | 0010, 0015, 0022, 0038, 0063, 0074 | Stable |
+| **Input streams** | Tick / key / mouse / window-size as publish-subscribe, keyed by `KindId`. | subscribe via `aether.input` from a component's `wire` hook | 0021, 0068 | Stable |
+| **Rendering & camera** | World-space geometry + a `view_proj` uniform; a camera publishes the matrix. | `aether.render` (`DrawTriangle`, `aether.camera`) | 0025, 0066, 0074 §7 | Stable |
+| **Mesh authoring & the DSL** | Author meshes as DSL text, hot-load them, replay to the renderer. | `aether.mesh.load` to the mesh-viewer component | 0026, 0051, 0052, 0057 | Stable |
+| **File I/O** | Namespaced read/write/delete/list — `save` / `assets` / `config`. | `aether.fs` — `read` / `write` / `delete` / `list` | 0041 | Stable |
+| **Audio** | Fire-and-forget note on/off + master gain; built-in instruments. | `aether.audio` — `note_on` / `note_off` / `set_master_gain` | 0039 | Stable |
+| **Window** (desktop) | Mode / title / focus; replies with the value actually applied. | `aether.window` — `set_mode` / `set_title` / `focus` | 0035 | Stable |
+| **Tracing & settlement** | Watch a mail chain to exact completion; trace subtree returned to the agent. | via `send_mail_traced` | 0080, 0086, 0093, 0094 | Settling (eviction, #1048) |
+| **Logging** | Per-actor log rings, queryable by mailbox name. | — (read via `actor_logs`) | 0077, 0081 | Stable |
+| **Configuration** | Layered app config — derive + overlay + argv/env, dumped via `--config`. | — (boot-time + CLI) | 0090 | Settling (rollout across knobs) |
+| **Computation DAG & handles** | Large/async work as a graph of `Kind → Kind` transforms producing typed handles. | via `submit_dag` / `dag_status` / `dag_cancel` | 0045, 0047, 0048, 0049, 0084 | Stable (pattern); growing |
+| **HTTP egress** | Outbound network as a capability. | `aether.http` | 0043 | Stable |
+
+## How to read an explainer (the shape each page follows)
+
+When the per-subsystem pages land they'll each answer the same four questions,
+in this order — so you can jump straight to the one you need:
+
+1. **Why it exists.** The problem it solves and the alternative it rejected
+   (this is the ADR's "context," digested).
+2. **What it does.** The model — the mailboxes, the kinds, the reply contracts
+   if any, the invariants.
+3. **How to use it.** The operational surface from a caller's seat: what to
+   mail, what comes back, the gotchas inline.
+4. **How to extend or reuse it.** The seams — what you'd add a kind for, where
+   a new capability plugs in, what a component can reuse.
+
+That last question is the one this guide exists to answer, and it's where the
+[recipes](recipes.md) take over with the worked, step-by-step version.


### PR DESCRIPTION
Stands up the in-repo documentation site agents (and humans) read to understand how aether works and how to build with it. mdBook source under `docs/guide/`, rendered to GitHub Pages by `.github/workflows/docs.yml`.

## What's in this PR (the durable layers + plumbing)

- **Introduction** — what the guide is, how it sits between `CLAUDE.md` (terse reference) and the ADRs (raw decision record), and the dogfood premise: a tutorial *is* the API sanity check.
- **Why aether is shaped this way** — the five load-bearing principles (agent-as-operator, everything-is-mail, thin-substrate/uniform-actors, design-for-machine-consumers, ADRs-as-memory + tutorials-as-proof).
- **Architecture overview** — crate map, a stack diagram, and a walkthrough of one piece of mail from an agent tool call to a handler.
- **Subsystem map** — every subsystem with its purpose, what to mail it, its ADRs, and a **maturity** marker. The in-flux internals (scheduler, trace eviction, config rollout) are documented at the stable-face level; the guts stay in their ADRs until they land.
- **Recipes intro** — folds the agent-recipe corpus (iamacoffeepot/aether#1344) in as one section, with the dual-pass test and the recompile-vs-drive-only seam.
- **Plumbing** — `docs/book.toml`, the Pages-deploy workflow (build-only on PRs, publish on `main`), and a `.gitignore` rule for the build output.

## What's deliberately *not* here

The per-subsystem explainer pages and the worked recipes show in the nav as **drafts** (greyed, visible roadmap) and land in follow-up PRs as the work that settles each subsystem merges. Leading with durable content keeps the first PR from freezing a moving internal.

## One manual step before it's live

Publishing needs the repo's **Pages source set to "GitHub Actions"** (Settings → Pages). That's a one-time change, not done here — the workflow's `build` job runs on this PR as a check regardless, so the book is verified to build even before Pages is enabled.

Refs iamacoffeepot/aether#1344