### PR TITLE
docs(repo): reframe the readme headline as an application engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aether
 
-A game engine being built collaboratively with Claude.
+An application engine — built for games — developed collaboratively with Claude.
 
 The vision is a harness where Claude sits as assistant, engineer, and designer — driving a running engine, observing it, modifying it. The architecture is a thin native **substrate** that owns I/O, GPU, and audio and hosts a WebAssembly runtime; engine **components** run as WASM modules and communicate with the substrate and with each other through a **mail** system.
 


### PR DESCRIPTION
One-line headline reframe: aether is an application engine built for games, not a game engine — the substrate is a general real-time host and a fixed game loop isn't load-bearing. Matches the framing the new agent guide uses (iamacoffeepot/aether#1350).