### PR TITLE
docs(adr): note ADR-0002 granularity rule superseded by ADR-0079/0087

### DIFF
--- a/docs/adr/0002-mail-first-architecture.md
+++ b/docs/adr/0002-mail-first-architecture.md
@@ -2,6 +2,7 @@
 
 - **Status:** Accepted (elevated from Proposed by ADR-0003)
 - **Date:** 2026-04-13
+- **Superseded in part (2026-06-04):** the *Component granularity* decision below — the "subsystem-sized, not entity-sized" rule — was lifted by ADR-0079 (instanced actors as a first-class category) and ADR-0087 (the mail blob as the unit of dispatch). Fine-grained / per-instance actors (e.g. one actor per TCP session) are now first-class and cheap. The original text is preserved below as the decision as made; see the inline note in that section.
 
 ## Context
 
@@ -38,6 +39,16 @@ Every component is addressable by **mailbox**. Mail envelopes are typed and **ba
 There is no shared memory between components. Anything one component needs to know about another component's state arrives as mail. This is deliberately strict: it keeps the abstraction uniform, keeps capability reasoning simple (you can reach who you can mail), and lets us observe where — and whether — the strictness actually hurts us.
 
 ### Component granularity
+
+> **Superseded by ADR-0079 + ADR-0087 (2026-06-04).** The prohibition on
+> fine-grained / per-entity actors below was a performance hedge from the early
+> engine. Instanced actors are now a first-class category (ADR-0079), and the
+> blob dispatcher (ADR-0087) makes large volumes of mail across many small
+> actors cheap — so an actor per TCP session, per monster, or per document is an
+> expected pattern, not an anti-pattern. (One open caveat, not a granularity
+> limit: each actor currently gets its own OS thread, which pushes against
+> ceilings at hub-server scale — a future scheduler ADR may revise that.) The
+> text below is preserved as the decision as originally made.
 
 **Components are subsystem-sized, not entity-sized.** A physics component owns its entire physics world. A scene component owns its entire scene graph. An AI component owns its entire AI state. Inside a component, state is plain data and iteration is a tight loop in native (WASM) code.
 

--- a/docs/adr/0002-mail-first-architecture.md
+++ b/docs/adr/0002-mail-first-architecture.md
@@ -45,10 +45,10 @@ There is no shared memory between components. Anything one component needs to kn
 > engine. Instanced actors are now a first-class category (ADR-0079), and the
 > blob dispatcher (ADR-0087) makes large volumes of mail across many small
 > actors cheap — so an actor per TCP session, per monster, or per document is an
-> expected pattern, not an anti-pattern. (One open caveat, not a granularity
-> limit: each actor currently gets its own OS thread, which pushes against
-> ceilings at hub-server scale — a future scheduler ADR may revise that.) The
-> text below is preserved as the decision as originally made.
+> expected pattern, not an anti-pattern. (They're cheap because actors are
+> multiplexed onto the shared work-stealing scheduler, ADR-0087 — not one OS
+> thread each, which is what ADR-0038 originally shipped.) The text below is
+> preserved as the decision as originally made.
 
 **Components are subsystem-sized, not entity-sized.** A physics component owns its entire physics world. A scene component owns its entire scene graph. An AI component owns its entire AI state. Inside a component, state is plain data and iteration is a tight loop in native (WASM) code.
 


### PR DESCRIPTION
Surfaced while writing the mail/kinds explainer for the agent guide: ADR-0002's *Component granularity* decision ("subsystem-sized, not entity-sized") reads as current truth but was lifted long ago — instanced actors are first-class (ADR-0079) and the blob dispatcher (ADR-0087) makes many small actors cheap, so an actor per TCP session / monster / document is now an expected pattern.

ADRs are immutable decision records, so this doesn't rewrite the decision — it adds a forward-pointer:
- a **"superseded in part"** line in the status block, and
- an inline note at the *Component granularity* section,

both pointing to ADR-0079/0087 and preserving the original text as the decision as made. Includes the one genuinely-open caveat (one-thread-per-actor pushes ceilings at hub-server scale).

`CLAUDE.md` and `README` carried no stale granularity claim, so ADR-0002 was the only source-of-truth drift. The guide page states the corrected model directly.