### PR TITLE
docs(adr): clean up threading-model drift; flip ADR-0087 to accepted

### DIFF
--- a/docs/adr/0038-actor-per-component-dispatch.md
+++ b/docs/adr/0038-actor-per-component-dispatch.md
@@ -2,6 +2,7 @@
 
 - **Status:** Accepted
 - **Date:** 2026-04-21
+- **Superseded in part (2026-06-04):** the **§2 Threading model** below — one OS thread per actor (thread-per-component) — was retired. Actors are now multiplexed onto a shared work-stealing scheduler (the worker pool reintroduced by issue #635, refined into blob dispatch by ADR-0087); the single-threaded-per-actor property is preserved by the run-token, not a dedicated thread. A dedicated OS thread is now the exception, spawned only for blocking I/O. See ADR-0087 for the current dispatch model. The original decision is preserved below.
 
 ## Context
 
@@ -45,6 +46,12 @@ pub struct ComponentEntry {
 The `Component` (and its wasmtime `Store`) lives on the dispatch thread's stack for the component's lifetime. It never escapes to the host side. `on_drop` runs on the dispatch thread as the last act before the thread returns and the `Component` drops.
 
 ### 2. Threading model
+
+> **Superseded by ADR-0087 (2026-06-04).** Thread-per-component was retired for
+> a shared work-stealing scheduler — actors are multiplexed onto worker threads,
+> with the run-token preserving single-threaded-per-actor. A dedicated OS thread
+> is now spawned only for blocking I/O. The decision as originally made is
+> preserved below.
 
 wasmtime calls are synchronous and can block the calling thread for arbitrary guest time. Two viable shapes:
 

--- a/docs/adr/0079-instanced-actors-as-a-first-class-category.md
+++ b/docs/adr/0079-instanced-actors-as-a-first-class-category.md
@@ -24,7 +24,7 @@ The forces we're balancing:
 - Singular actors stay singular — most caps and components are conceptually one-of-a-kind.
 - Instanced actors must be first-class enough that the framework participates in their lifecycle (registration, monitoring, cleanup) rather than each cap reinventing it.
 - The wire format and existing actor SDK should accommodate the new category additively, without re-shaping `MailboxId` or breaking existing types.
-- The threading model under ADR-0038 (one thread per actor) extends to instances naturally for game-engine workloads (10s–100s of actors) but pushes against operational ceilings at hub-server scale (1000s+). That's a separable concern — a future scheduler ADR may revise threading without invalidating this one.
+- The threading model under ADR-0038 (one thread per actor) extends to instances naturally for game-engine workloads (10s–100s of actors) but pushes against operational ceilings at hub-server scale (1000s+). That's a separable concern — a future scheduler ADR may revise threading without invalidating this one. **(Resolved 2026-06-04: ADR-0087 did exactly this — actors are now multiplexed onto a shared work-stealing pool, so per-instance actors no longer cost an OS thread each; the run-token preserves single-threaded-per-actor.)**
 
 ## Decision
 

--- a/docs/adr/0087-blob-unit-of-dispatch.md
+++ b/docs/adr/0087-blob-unit-of-dispatch.md
@@ -1,6 +1,6 @@
 # ADR-0087: The mail blob is the unit of dispatch — per-producer rings + work-stealing pool
 
-- **Status:** Proposed
+- **Status:** Accepted — the base model (blob dispatch, per-producer rings, work-stealing pool, single-worker in-place demux) has shipped and is how all actors are dispatched; the phase-2+ items flagged as deferred below (cooperative multi-worker demux, affinity-biased stealing) remain future work.
 - **Date:** 2026-05-23
 
 ## Context


### PR DESCRIPTION
Companion to the ADR-0002 granularity note (merged in PR 1350-era cleanup): the same drift, on the *threading* model. Surfaced while writing the agent guide — ADR-0038's thread-per-component was retired for the work-stealing scheduler, but no ADR said so, so the stale "one OS thread per actor" claim reads as current.

- **ADR-0038** — forward-note (status block + inline at the §2 Threading model section): one-OS-thread-per-actor is superseded by ADR-0087. Actors are now multiplexed onto the shared work-stealing scheduler; single-threaded-per-actor is preserved by the run-token, not a dedicated thread. A dedicated thread is now the exception, spawned only for blocking I/O. Original decision preserved.
- **ADR-0079** — resolve its "a future scheduler ADR may revise threading" caveat: ADR-0087 did exactly that, so per-instance actors no longer cost a thread each.
- **ADR-0087** — flip Status from Proposed to Accepted (the base model shipped and is how all actors dispatch; phase-2+ items remain deferred as the ADR notes).

Remaining one-thread mentions (ADR-0050 / 0074 / 0080) are historical context citing ADR-0038 and left as-is. CLAUDE.md carried no thread-per-actor claim.