### PR TITLE
docs(guide): add the actor model foundation; narrow components to the FFI host

### DIFF
--- a/docs/guide/SUMMARY.md
+++ b/docs/guide/SUMMARY.md
@@ -10,6 +10,7 @@
 # Foundations
 
 - [The type system](foundations/type-system.md)
+- [The actor model](foundations/actor-model.md)
 - [Invariants & guarantees](foundations/invariants.md)
 
 # The systems

--- a/docs/guide/SUMMARY.md
+++ b/docs/guide/SUMMARY.md
@@ -17,7 +17,7 @@
 - [Subsystem map](systems.md)
   - [Mail, kinds & scheduling](systems/mail-and-kinds.md)
   - [Concurrency & blocking](systems/concurrency.md)
-  - [Components & lifecycle]()
+  - [Components & lifecycle](systems/components.md)
   - [Rendering & camera]()
   - [Mesh authoring & the DSL]()
   - [Input, file I/O & audio]()

--- a/docs/guide/foundations/actor-model.md
+++ b/docs/guide/foundations/actor-model.md
@@ -87,12 +87,13 @@ mail-driven setup or teardown to do.
 ## The context
 
 Every lifecycle method and handler is handed a **context** (`ctx`) — the actor's
-only handle to the world outside its own state. It's how the actor resolves an
-address, sends mail, replies to a sender, persists state across a swap, or asks to
-shut down; anything that reaches past its own fields goes through it. You never
-construct one — the runtime passes it in for the duration of the call and takes it
-back when the call returns, so an actor interacts with the world only while a
-handler is actually running, never through a saved-away handle.
+only handle to the world outside its own state. Through it the actor resolves
+addresses, sends mail, and replies to whoever sent the current message; depending on
+where it's running it can also spawn a child actor, persist state for a successor, or
+ask to shut down. Anything that reaches past the actor's own fields goes through the
+context, and you never construct one — the runtime passes it in for the duration of a
+call and takes it back when the call returns, so an actor touches the world only
+while a handler is running, never through a stashed handle.
 
 There's more than one context *type* because what an actor is allowed to do changes
 from stage to stage, and the type is how that's enforced. The context handed to
@@ -103,9 +104,13 @@ persist state. That's what "the context is the contract" means literally: the me
 you're in determines which context type you hold, and that type determines what
 compiles.
 
-The concrete types differ by host — `FfiCtx` in a wasm component, `NativeCtx` in a
-native capability — but you write handlers against a shared set of capability traits
-(`Resolver`, `MailSender`, and friends), so the same body works on either.
+Host matters as well as stage. Resolving, sending, and replying are common to both,
+but a few operations live on one side only: a native capability can spawn child
+actors and shut itself down, while a wasm component currently can't — its lifetime is
+driven from outside, by load, drop, and replace. The concrete context types differ by
+host too — `FfiCtx` in a component, `NativeCtx` in a capability — but you write
+handlers against a shared set of capability traits (`Resolver`, `MailSender`, and
+friends), so the same body works on either.
 
 ## Authoring an actor
 
@@ -154,6 +159,41 @@ compiles only if that actor actually handles the payload's kind, and both the
 mailbox id and kind id resolve at compile time. The handler takes the decoded mail
 **by value** and gets `&mut self` because nothing else can touch the state
 concurrently.
+
+## Names and addressing
+
+The `NAMESPACE` const on the `Actor` trait is the name an actor claims — the
+`"hello"`, `"camera"`, `"aether.audio"` in the examples above. Names are how actors
+get reached: a mailbox id is just a compile-time hash of the name
+(`mailbox_id_from_name`), so `ctx.actor::<RenderCapability>()` resolves to an address
+with no runtime lookup — the type carries its `NAMESPACE`, the hash is a const, and
+the send lands at the right mailbox.
+
+What the name maps to depends on the host. For a **capability** the `NAMESPACE` *is*
+the mailbox — `aether.audio`, `aether.render`, `aether.input` — claimed by the
+chassis at boot, so addressing one by type reaches it directly. For a **component**
+the `NAMESPACE` is only the *default load name*: once loaded, the actor is registered
+at `aether.component.trampoline:<name>` (the name `LoadResult` hands back, which is
+the `NAMESPACE` unless the load overrode it). You reach a loaded component through
+that resolved name — `ctx.loaded::<Camera>("camera")`, or the `LoadResult.name`
+string — not by hashing its bare `NAMESPACE`.
+
+## One or many: cardinality
+
+An actor type is either **singleton** or **instanced**, marked by the `Singleton` or
+`Instanced` trait, and that choice decides how its name and addressing work.
+
+A **singleton** is one of a kind: at most one instance per `NAMESPACE`, and the
+`NAMESPACE` is its whole name. Capabilities are always singletons, and a component
+loaded at its default name is one too. You address it by type, `ctx.actor::<R>()`.
+
+An **instanced** actor is one of many sharing a prefix. Its `NAMESPACE` is that
+prefix, and each live instance has a full name `NAMESPACE:subname` — for example
+`aether.net.session:42`. The case that drives this is sockets: a singleton listener
+accepts connections and, for each one, spawns a session actor with `ctx.spawn_child`
+(ADR-0079); you then reach a specific instance by its subname,
+`ctx.resolve_actor::<SessionActor>("42")`. Spawning children this way is a native
+capability's job — a wasm component is itself a singleton, loaded rather than spawned.
 
 ## One model, two hosts
 

--- a/docs/guide/foundations/actor-model.md
+++ b/docs/guide/foundations/actor-model.md
@@ -165,11 +165,11 @@ lives and what it's trusted with (ADR-0074):
   `NativeActor`, it's linked at build time, and it's trusted with raw I/O — the
   renderer, the audio mixer, the filesystem, the input streams, the
   component-loader itself are all capabilities. This is the chassis.
-- A **component** is an actor *loaded at runtime* — wasm today — that runs
-  sandboxed behind the wasm wall and reaches the outside world only by mailing
-  capabilities. It implements `FfiActor`, and the substrate drives it through an
-  FFI **trampoline**. This is the agent-facing extension path: new behavior with
-  no substrate rebuild.
+- A **component** is an actor *loaded at runtime* as a wasm module, run sandboxed
+  behind the wasm wall and reaching the outside world only by mailing capabilities.
+  It implements `FfiActor`, and the substrate drives it through an FFI
+  **trampoline**. This is the agent-facing extension path: new behavior with no
+  substrate rebuild.
 
 The two traits are deliberately mirror images. Both sit on the shared `Actor`
 super-trait (which owns only `NAMESPACE`). Both have a `type Config`, the same

--- a/docs/guide/foundations/actor-model.md
+++ b/docs/guide/foundations/actor-model.md
@@ -1,0 +1,178 @@
+# The actor model
+
+The engine is built from one primitive: the **actor**. The renderer is an actor.
+The audio mixer is an actor. A component you load is an actor. There is no second
+kind of thing — no privileged "system objects" that actors orbit. Everything in
+the substrate is an actor, and actors interact in exactly one way: by **mail**.
+
+Understand the actor and most of the engine follows, because every subsystem in
+this guide is "an actor (or a few) that does X." This page is the primitive
+itself: what an actor is, the lifecycle every actor moves through, how you author
+one, and the two *hosts* the same primitive runs under — native **capabilities**
+and wasm **components**.
+
+> Governing ADR: **ADR-0074** (the unified actor model — capabilities and
+> components are one primitive, not two) with **ADR-0079** (the lifecycle stages)
+> and **ADR-0033** (the `#[actor]` macro). This model is **stable**; it's the
+> spine everything else hangs off. Signatures here were read from the current SDK
+> (`aether-actor`) and runtime (`aether-substrate`).
+
+## What an actor is
+
+An actor is a bundle of **private state** and a set of **typed handlers**. It does
+nothing until mail arrives; when an envelope lands, the handler registered for
+that kind runs, with exclusive `&mut` access to the state. That's the whole shape:
+state in, mail drives handlers, handlers mutate state and send more mail.
+
+Two properties make it tractable to reason about:
+
+- **Actors communicate *only* by mail.** No actor holds a reference into another
+  actor's memory, calls another's methods, or shares a lock with it. The only way
+  to affect another actor is to send it a kind it handles. This is what lets the
+  same model span a trusted in-process capability and a sandboxed wasm component
+  without either knowing which it's talking to — mail is the only coupling, so the
+  *host* is an implementation detail. (See [capability = reachability](invariants.md)
+  for the security consequence.)
+- **An actor is single-threaded from its own perspective.** The scheduler
+  guarantees that no two threads ever run one actor's handlers at once, so actor
+  state is **plain fields** — no `Mutex`, no `RefCell`, no atomics. You write
+  ordinary sequential Rust and the runtime makes it safe. (How the scheduler
+  enforces this — the run-token — is the [concurrency](../systems/concurrency.md)
+  page; here, just take it as the contract.)
+
+What flows between actors — the kinds, their ids, the wire encoding — is the
+[type system](type-system.md). How it routes and in what order — mailboxes, FIFO,
+fire-and-forget — is [mail & scheduling](../systems/mail-and-kinds.md). This page
+is the actor on the receiving end of all that.
+
+## The lifecycle
+
+Every actor — regardless of host — moves through the same three authored stages
+(ADR-0079). Each stage gets a different context, and the context *is* the
+contract: it's exactly what you're permitted to do at that point.
+
+| stage | when | ctx allows | use it for |
+|---|---|---|---|
+| **`init`** | once, at boot | resolve only — **no mail** | build and return the initial state |
+| **`wire`** | after `init`, mailbox now published | full send + resolve | subscribe to input, announce yourself, kick off a self-poll |
+| handlers | steady state, one call per inbound kind | full send + resolve + reply | the actor's actual behavior |
+| **`unwire`** | after the inbox drains, before drop | full send + resolve | final broadcast, signal monitors, flush state |
+
+`init` is a **pure synchronous constructor**: its ctx can resolve kind ids and
+mailbox addresses but *cannot send mail*, because the actor's own mailbox isn't
+published yet and peers may not exist. Anything mail-driven — above all,
+subscribing to the tick or input streams — belongs in `wire`, which runs once
+`init` returns `Ok` and the mailbox is live. If startup can fail (a missing
+handle, an unparseable config), `init` returns `Err(BootError)` and the failure
+surfaces cleanly rather than producing a half-built actor.
+
+`wire` and `unwire` default to no-ops; override them only when you have setup or
+teardown to do. (Both are mail-allowed; the older single `on_drop` hook was
+folded into `unwire`.)
+
+## Authoring an actor
+
+You declare the receive side with the **`#[actor]`** attribute on one `impl`
+block, and each **`#[handler]`** method *is* a handler — the macro infers the kind
+it handles from the method's **third parameter**:
+
+```rust
+#[actor]
+impl FfiActor for Hello {
+    const NAMESPACE: &'static str = "hello";
+
+    fn init<C>(ctx: &mut C) -> Result<Self, BootError>
+    where C: Resolver {
+        Ok(Hello { pong: ctx.resolve::<Pong>() })
+    }
+
+    fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
+        ctx.actor::<InputCapability>().subscribe(Tick::ID, MailboxId(ctx.mailbox_id()));
+    }
+
+    #[handler]
+    fn on_tick(&mut self, ctx: &mut FfiCtx<'_>, _tick: Tick) {
+        ctx.actor::<RenderCapability>().send(&TRIANGLE);   // draw every tick
+    }
+
+    #[handler]
+    fn on_ping(&mut self, ctx: &mut FfiCtx<'_>, ping: Ping) {
+        if let Some(sender) = ctx.reply_target() {
+            ctx.reply_kind(sender, self.pong, &Pong { seq: ping.seq });
+        }
+    }
+}
+```
+
+`Ping` is the kind `on_ping` handles; `Tick` is the kind `on_tick` handles. The
+macro reads those parameter types and generates the dispatch table that routes an
+inbound envelope to the right handler by matching its kind id — a **compile-time
+const** (`K::ID`), so there's no runtime registration and no host round-trip to
+resolve an address. A handler with no match falls through to an optional
+**`#[fallback]`** (taking the raw `Mail<'_>`); omit the fallback and the actor is
+a *strict receiver* — unhandled kinds are reported, not silently dropped.
+
+You address peers **by type** — `ctx.actor::<RenderCapability>().send(&payload)`
+compiles only if that actor actually handles the payload's kind, and both the
+mailbox id and kind id resolve at compile time. The handler takes the decoded mail
+**by value** and gets `&mut self` because nothing else can touch the state
+concurrently.
+
+## One primitive, two hosts
+
+Here's the part that ties the engine together. There aren't two actor systems —
+there's **one primitive with two hosts**, differing only in where the actor's code
+lives and what it's trusted with (ADR-0074):
+
+- A **native capability** is an actor compiled *into* the substrate. It implements
+  `NativeActor`, it's linked at build time, and it's trusted with raw I/O — the
+  renderer, the audio mixer, the filesystem, the input streams, the
+  component-loader itself are all capabilities. This is the chassis.
+- A **component** is an actor *loaded at runtime* — wasm today — that runs
+  sandboxed behind the wasm wall and reaches the outside world only by mailing
+  capabilities. It implements `FfiActor`, and the substrate drives it through an
+  FFI **trampoline**. This is the agent-facing extension path: new behavior with
+  no substrate rebuild.
+
+The two traits are deliberately mirror images. Both sit on the shared `Actor`
+super-trait (which owns only `NAMESPACE`). Both have a `type Config`, the same
+`init` / `wire` / `unwire` lifecycle with identical semantics, and the same
+`#[actor]` / `#[handler]` authoring shape. The *only* differences are the context
+type — `NativeCtx<'_>` instead of `FfiCtx<'_>` — and the host machinery underneath.
+A native capability's `wire` looks like a component's `wire`:
+
+```rust
+#[actor]
+impl NativeActor for AudioCapability {
+    type Config = AudioConfig;
+    const NAMESPACE: &'static str = "aether.audio";
+
+    fn init(config: AudioConfig, ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> { … }
+
+    #[handler]
+    fn on_note_on(&mut self, ctx: &mut NativeCtx<'_>, note: NoteOn) { … }
+}
+```
+
+Because the only coupling is mail, an actor can't tell whether the mailbox it
+sends to is backed by native Rust or sandboxed wasm — and doesn't need to. A
+component sends `aether.render` a `DrawTriangle` exactly as one capability sends
+another. This symmetry is the point of ADR-0074: one mental model, one macro, one
+lifecycle, and components get to reuse every pattern capabilities use.
+
+So **start here, with the actor**, and the two host pages are just specializations:
+
+- The wasm/FFI host — the trampoline, `export!`, loading, hot-swap — is
+  [Components & lifecycle](../systems/components.md).
+- Adding a native capability is a recipe ([Recipes](../recipes.md)); it's the same
+  `#[actor]` shape against `NativeActor`.
+
+## Where to read more
+
+- What flows between actors — [The type system](type-system.md).
+- The rules the model guarantees (ordering, fire-and-forget, capability =
+  reachability, single-threaded) — [Invariants & guarantees](invariants.md).
+- How mail routes and in what order — [Mail, kinds & scheduling](../systems/mail-and-kinds.md).
+- How the scheduler keeps an actor single-threaded, and what to do instead of
+  blocking — [Concurrency & blocking](../systems/concurrency.md).
+- The wasm host in depth — [Components & lifecycle](../systems/components.md).

--- a/docs/guide/foundations/actor-model.md
+++ b/docs/guide/foundations/actor-model.md
@@ -28,7 +28,7 @@ Two properties make it tractable to reason about:
 - **Actors communicate *only* by mail.** No actor holds a reference into another
   actor's memory, calls another's methods, or shares a lock with it. The only way
   to affect another actor is to send it a kind it handles. This is what lets the
-  same model span a trusted in-process capability and a sandboxed wasm component
+  same model span an in-process capability and a sandboxed wasm component
   without either knowing which it's talking to — mail is the only coupling, so the
   *host* is an implementation detail. (See [capability = reachability](invariants.md)
   for the security consequence.)
@@ -198,42 +198,69 @@ get reached: a mailbox id is just a compile-time hash of the name
 with no runtime lookup — the type carries its `NAMESPACE`, the hash is a const, and
 the send lands at the right mailbox.
 
+Because the name *is* the address, it has to be unique — two actors claiming the same
+name hash to the same mailbox. The substrate enforces one claimant per name **at
+registration**: a second capability claiming a taken name fails to boot, and a
+component loaded under a name already in use comes back as a load error. This is not
+a compile-time check — two types can declare the same `NAMESPACE` string and compile
+cleanly; the collision only surfaces when the second one tries to register. For an
+instanced actor (below) the uniqueness is on the full `NAMESPACE:subname`, not the
+shared prefix.
+
 What the name maps to depends on the host. For a **capability** the `NAMESPACE` *is*
 the mailbox — `aether.audio`, `aether.render`, `aether.input` — claimed by the
-chassis at boot, so addressing one by type reaches it directly. For a **component**
-the `NAMESPACE` is only the *default load name*: once loaded, the actor is registered
-at `aether.component.trampoline:<name>` (the name `LoadResult` hands back, which is
-the `NAMESPACE` unless the load overrode it). You reach a loaded component through
-that resolved name — `ctx.loaded::<Camera>("camera")`, or the `LoadResult.name`
-string — not by hashing its bare `NAMESPACE`.
+chassis at boot, so `ctx.actor::<AudioCapability>()` reaches it directly. For a
+**component** the `NAMESPACE` is only the *default load name*: once loaded, the actor
+is registered at `aether.component.trampoline:<name>` (the name `LoadResult` hands
+back, which is the `NAMESPACE` unless the load overrode it). You reach it by that
+registered name, not by hashing the bare `NAMESPACE` — either pass `LoadResult.name`
+to `resolve_actor`, or use the `loaded` helper below.
+
+A capability can also dress up its mail surface with **extension-trait helpers** —
+typed methods on the mailbox handle that stand in for raw kind sends.
+`ctx.actor::<InputCapability>().subscribe(Tick::ID, me)` is one (from
+`InputMailboxExt`), and `ctx.actor::<ComponentHostCapability>().loaded::<Camera>("camera")`
+is the loaded-component lookup just mentioned (from `ComponentHostExt`). Each such
+trait is implemented for *both* the component and the capability handle, so the same
+helper reads the same whichever host you write from.
 
 ## One or many: cardinality
 
 An actor type is either **singleton** or **instanced**, marked by the `Singleton` or
-`Instanced` trait, and that choice decides how its name and addressing work.
+`Instanced` trait, and the choice sets whether its `NAMESPACE` is a whole name or a
+prefix.
 
-A **singleton** is one of a kind: at most one instance per `NAMESPACE`, and the
-`NAMESPACE` is its whole name. Capabilities are always singletons, and a component
-loaded at its default name is one too. You address it by type, `ctx.actor::<R>()`.
+A **singleton** is one of a kind: at most one instance, and the `NAMESPACE` is its
+whole name. Every capability is a singleton — and because a capability's name is its
+mailbox, you address it straight by type, `ctx.actor::<R>()`.
 
 An **instanced** actor is one of many sharing a prefix. Its `NAMESPACE` is that
 prefix, and each live instance has a full name `NAMESPACE:subname` — for example
 `aether.net.session:42`. The case that drives this is sockets: a singleton listener
-accepts connections and, for each one, spawns a session actor with `ctx.spawn_child`
-(ADR-0079); you then reach a specific instance by its subname,
-`ctx.resolve_actor::<SessionActor>("42")`. Spawning children this way is a native
-capability's job — a wasm component is itself a singleton, loaded rather than spawned.
+accepts connections and spawns a session actor per connection with `ctx.spawn_child`
+(ADR-0079), then reaches a specific one by subname,
+`ctx.resolve_actor::<SessionActor>("42")`.
+
+Spawning children on demand like that is a **native** facility — `spawn_child` is
+bounded to `Instanced` native actors. A wasm component can't spawn children of its
+own (a current gap, not a principle). It *can* still run as several instances,
+though: load the same wasm under different names and each is an independent actor at
+its own `aether.component.trampoline:<name>`. The loader in fact hosts every
+component behind an instanced trampoline actor, spawned once per load — so even a
+single loaded component is, underneath, one instance of an instanced host.
 
 ## One model, two hosts
 
 Here's the part that ties the engine together. There aren't two actor systems —
-there's **one model with two hosts**, differing only in where the actor's code
-lives and what it's trusted with (ADR-0074):
+there's **one model with two hosts**, differing in where the actor's code lives and
+how it reaches the outside world (ADR-0074):
 
-- A **native capability** is an actor compiled *into* the substrate. It implements
-  `NativeActor`, it's linked at build time, and it's trusted with raw I/O — the
-  renderer, the audio mixer, the filesystem, the input streams, the
-  component-loader itself are all capabilities. This is the chassis.
+- A **native capability** is an actor compiled *into* the substrate, implementing
+  `NativeActor` and linked at build time. It's the host an actor takes when what it
+  does needs native Rust APIs or raw performance — the GPU through wgpu, the audio
+  device through cpal, the filesystem, the OS input loop. The renderer, the audio
+  mixer, the filesystem, the input streams, and the component-loader itself are all
+  capabilities; together they're the chassis.
 - A **component** is an actor *loaded at runtime* as a wasm module, run sandboxed
   behind the wasm wall and reaching the outside world only by mailing capabilities.
   It implements `FfiActor`, and the substrate drives it through an FFI

--- a/docs/guide/foundations/actor-model.md
+++ b/docs/guide/foundations/actor-model.md
@@ -1,28 +1,27 @@
 # The actor model
 
-The engine is built from one primitive: the **actor**. The renderer is an actor.
-The audio mixer is an actor. A component you load is an actor. There is no second
-kind of thing — no privileged "system objects" that actors orbit. Everything in
-the substrate is an actor, and actors interact in exactly one way: by **mail**.
+The engine is built from one kind of thing: the **actor**. The renderer, the audio
+mixer, the filesystem, a component you load — all of them are actors, with no
+privileged class of "system object" sitting above them. Everything in the substrate
+is an actor, and the only way actors ever interact is by **mail**.
 
-Understand the actor and most of the engine follows, because every subsystem in
-this guide is "an actor (or a few) that does X." This page is the primitive
-itself: what an actor is, the lifecycle every actor moves through, how you author
-one, and the two *hosts* the same primitive runs under — native **capabilities**
-and wasm **components**.
+If you understand actors, most of the engine follows: every subsystem in this guide
+is some actor (or a handful) doing a job. This page covers the actor itself — what
+it is, the lifecycle it moves through, how you write one — and the two *hosts* it
+runs under, native **capabilities** and wasm **components**.
 
 > Governing ADR: **ADR-0074** (the unified actor model — capabilities and
-> components are one primitive, not two) with **ADR-0079** (the lifecycle stages)
+> components are one model, not two) with **ADR-0079** (the lifecycle stages)
 > and **ADR-0033** (the `#[actor]` macro). This model is **stable**; it's the
 > spine everything else hangs off. Signatures here were read from the current SDK
 > (`aether-actor`) and runtime (`aether-substrate`).
 
 ## What an actor is
 
-An actor is a bundle of **private state** and a set of **typed handlers**. It does
-nothing until mail arrives; when an envelope lands, the handler registered for
-that kind runs, with exclusive `&mut` access to the state. That's the whole shape:
-state in, mail drives handlers, handlers mutate state and send more mail.
+An actor is some **private state** paired with a set of **typed handlers**. It sits
+idle until mail arrives; when an envelope lands, the handler registered for that
+kind runs with exclusive `&mut` access to the state, updating it and sending mail
+of its own. Nothing happens except in response to a message.
 
 Two properties make it tractable to reason about:
 
@@ -33,17 +32,17 @@ Two properties make it tractable to reason about:
   without either knowing which it's talking to — mail is the only coupling, so the
   *host* is an implementation detail. (See [capability = reachability](invariants.md)
   for the security consequence.)
-- **An actor is single-threaded from its own perspective.** The scheduler
-  guarantees that no two threads ever run one actor's handlers at once, so actor
-  state is **plain fields** — no `Mutex`, no `RefCell`, no atomics. You write
-  ordinary sequential Rust and the runtime makes it safe. (How the scheduler
-  enforces this — the run-token — is the [concurrency](../systems/concurrency.md)
-  page; here, just take it as the contract.)
+- **An actor only ever runs on one thread at a time.** The scheduler guarantees no
+  two threads run an actor's handlers at once, so an actor can freely mutate the
+  data on its own struct — its state is **plain fields**, no `Mutex`, no `RefCell`,
+  no atomics, just ordinary sequential Rust. (How the scheduler enforces this — the
+  run-token — is the [concurrency](../systems/concurrency.md) page; here, take it as
+  a guarantee you can build on.)
 
 What flows between actors — the kinds, their ids, the wire encoding — is the
 [type system](type-system.md). How it routes and in what order — mailboxes, FIFO,
-fire-and-forget — is [mail & scheduling](../systems/mail-and-kinds.md). This page
-is the actor on the receiving end of all that.
+fire-and-forget — is [mail & scheduling](../systems/mail-and-kinds.md). The rest of
+this page stays with the actor on the receiving end: how it's built and how it runs.
 
 ## The lifecycle
 
@@ -58,17 +57,55 @@ contract: it's exactly what you're permitted to do at that point.
 | handlers | steady state, one call per inbound kind | full send + resolve + reply | the actor's actual behavior |
 | **`unwire`** | after the inbox drains, before drop | full send + resolve | final broadcast, signal monitors, flush state |
 
-`init` is a **pure synchronous constructor**: its ctx can resolve kind ids and
-mailbox addresses but *cannot send mail*, because the actor's own mailbox isn't
-published yet and peers may not exist. Anything mail-driven — above all,
-subscribing to the tick or input streams — belongs in `wire`, which runs once
-`init` returns `Ok` and the mailbox is live. If startup can fail (a missing
-handle, an unparseable config), `init` returns `Err(BootError)` and the failure
-surfaces cleanly rather than producing a half-built actor.
+The three stages exist because constructing an actor and letting it participate in
+the mail system are different moments, and only the second is safe to send from.
+`init` runs while the actor is still being built: its mailbox isn't published yet,
+peers may not have booted, and it returns `Result<Self, BootError>` so a failure
+aborts the load cleanly. Sending mail from there would mean announcing yourself
+before you're addressable, or mailing a peer that doesn't exist yet. So `init` stays
+a pure synchronous constructor — resolve kind ids and mailbox addresses, assemble
+state, return it (or fail with a `BootError` that surfaces instead of leaving a
+half-built actor behind).
 
-`wire` and `unwire` default to no-ops; override them only when you have setup or
-teardown to do. (Both are mail-allowed; the older single `on_drop` hook was
-folded into `unwire`.)
+`wire` is the first point where sending is safe. It runs once `init` has succeeded,
+the mailbox is live, and the chassis is past its boot barrier, so peers are
+addressable and replies can route back. That's why mail-driven setup lives here:
+subscribing to the tick or input streams, announcing yourself to a peer, starting a
+poll loop by mailing yourself. An actor that needs to subscribe at startup would have
+nowhere safe to do it if `init` were the only hook.
+
+`unwire` is the mirror at the other end, and it exists for the same reason in
+reverse — teardown often needs to send, whether that's a closing broadcast, a signal
+to monitors, or a final flush to a peer, and Rust's `Drop` can't reach cleanly into
+the mail system. It runs after the inbox has drained but before the actor drops, so
+its sends still land in live peers (mail to one that's already gone warn-drops). It
+absorbs what used to be a separate `on_drop` hook.
+
+Both `wire` and `unwire` default to no-ops; override them only when you have
+mail-driven setup or teardown to do.
+
+## The context
+
+Every lifecycle method and handler is handed a **context** (`ctx`) — the actor's
+only handle to the world outside its own state. It's how the actor resolves an
+address, sends mail, replies to a sender, persists state across a swap, or asks to
+shut down; anything that reaches past its own fields goes through it. You never
+construct one — the runtime passes it in for the duration of the call and takes it
+back when the call returns, so an actor interacts with the world only while a
+handler is actually running, never through a saved-away handle.
+
+There's more than one context *type* because what an actor is allowed to do changes
+from stage to stage, and the type is how that's enforced. The context handed to
+`init` can resolve addresses but has no `send` method at all — so "init can't mail"
+isn't a rule you have to remember, it simply won't compile. `wire`, handlers, and
+`unwire` get a context that can send and reply; the hot-swap hooks get one that can
+persist state. That's what "the context is the contract" means literally: the method
+you're in determines which context type you hold, and that type determines what
+compiles.
+
+The concrete types differ by host — `FfiCtx` in a wasm component, `NativeCtx` in a
+native capability — but you write handlers against a shared set of capability traits
+(`Resolver`, `MailSender`, and friends), so the same body works on either.
 
 ## Authoring an actor
 
@@ -118,10 +155,10 @@ mailbox id and kind id resolve at compile time. The handler takes the decoded ma
 **by value** and gets `&mut self` because nothing else can touch the state
 concurrently.
 
-## One primitive, two hosts
+## One model, two hosts
 
 Here's the part that ties the engine together. There aren't two actor systems —
-there's **one primitive with two hosts**, differing only in where the actor's code
+there's **one model with two hosts**, differing only in where the actor's code
 lives and what it's trusted with (ADR-0074):
 
 - A **native capability** is an actor compiled *into* the substrate. It implements

--- a/docs/guide/foundations/actor-model.md
+++ b/docs/guide/foundations/actor-model.md
@@ -160,6 +160,35 @@ mailbox id and kind id resolve at compile time. The handler takes the decoded ma
 **by value** and gets `&mut self` because nothing else can touch the state
 concurrently.
 
+## Configuring an actor
+
+An actor can take typed **boot configuration**. Declare a `Config` associated type
+and the chassis threads a decoded value into `init` as its leading argument:
+
+```rust
+#[actor]
+impl FfiActor for ProbeWithConfig {
+    type Config = ProbeConfig;
+    const NAMESPACE: &'static str = "probe_with_config";
+
+    fn init<C>(config: ProbeConfig, ctx: &mut C) -> Result<Self, BootError>
+    where C: Resolver { … }
+}
+```
+
+Most actors need none. Omit `Config` and the `#[actor]` macro synthesizes `()` and
+injects the unused argument, so a no-config `init` stays the terse
+`fn init<C>(ctx: &mut C)` from the examples above — there's no `type Config = ()` to
+write by hand.
+
+The two hosts differ in one way, and it follows from how the config reaches them. A
+capability's config is built in-process by the chassis, so it can be any
+`Send + 'static` type. A component's config has to cross the wasm boundary as bytes,
+so it must be a `Kind` — encoded at the load edge, decoded on the way in. That seam
+aside, the authoring shape is identical. (How a component's config rides the load
+call, and how a chassis assembles its own layered config, are the
+[components](../systems/components.md) and configuration pages.)
+
 ## Names and addressing
 
 The `NAMESPACE` const on the `Actor` trait is the name an actor claims — the

--- a/docs/guide/systems/components.md
+++ b/docs/guide/systems/components.md
@@ -1,8 +1,8 @@
 # Components & lifecycle
 
-A **component** is the wasm host of an actor. The [actor model](../foundations/actor-model.md)
-is the primitive — the `#[actor]` block, the `init` / `wire` / `unwire` lifecycle,
-handlers, addressing by type — and a component is one of its two hosts: an actor
+A **component** is the wasm host of an actor. The shared model — the `#[actor]`
+block, the `init` / `wire` / `unwire` lifecycle, handlers, addressing by type — is
+the [actor model](../foundations/actor-model.md), and a component is one of its two hosts: an actor
 that arrives as **wasm bytes**, runs **sandboxed** behind the wasm wall, is reached
 by the substrate through an **FFI trampoline**, and can be **loaded, dropped, and
 hot-swapped at runtime**. The other host, a native capability, is the same shape
@@ -123,8 +123,8 @@ bundle unless you're persisting a non-kind blob or driving an explicit migration
 
 ## Where to read more
 
-- The actor primitive this specializes — its lifecycle, `#[actor]`, handlers,
-  addressing — [The actor model](../foundations/actor-model.md).
+- The actor this specializes — its lifecycle, `#[actor]`, handlers, addressing —
+  [The actor model](../foundations/actor-model.md).
 - Kinds, ids, and how the vocabulary crosses the wasm boundary — [The type system](../foundations/type-system.md).
 - How mail routes and what a kind is — [Mail, kinds & scheduling](mail-and-kinds.md).
 - Why a handler must never block, and how to wait instead — [Concurrency & blocking](concurrency.md).

--- a/docs/guide/systems/components.md
+++ b/docs/guide/systems/components.md
@@ -1,172 +1,28 @@
 # Components & lifecycle
 
-A **component** is an actor you load into a running engine. It's the unit an
-agent writes and ships: a small Rust crate, compiled to wasm, dropped into a live
-substrate with `load_component` and addressable by mail the moment it boots. This
-page is how to author one — the trait you implement, the lifecycle stages it
-moves through, how to send and subscribe from inside it, and how it gets loaded,
-dropped, and hot-swapped.
+A **component** is the wasm host of an actor. The [actor model](../foundations/actor-model.md)
+is the primitive — the `#[actor]` block, the `init` / `wire` / `unwire` lifecycle,
+handlers, addressing by type — and a component is one of its two hosts: an actor
+that arrives as **wasm bytes**, runs **sandboxed** behind the wasm wall, is reached
+by the substrate through an **FFI trampoline**, and can be **loaded, dropped, and
+hot-swapped at runtime**. The other host, a native capability, is the same shape
+against `NativeActor`.
 
-> Governing ADRs: **ADR-0074** (the unified actor model — components and native
-> capabilities are *one* primitive with two hosts), **ADR-0033** (the `#[actor]`
-> macro and handler-driven inputs manifest), **ADR-0079** (the lifecycle stages),
-> **ADR-0090** (typed boot config), **ADR-0022 / ADR-0038** (in-place hot-swap).
-> The authoring surface here — the `#[actor]` block, `init`/`wire`/`unwire`,
-> `export!` — is **stable**: it's the contract every reference component
-> (`aether-camera`, `aether-mesh-viewer`) and example is built on. Where this
-> page shows an exact signature it was read from the current SDK, not an ADR.
+This page is the wasm-specific machinery — read the [actor model](../foundations/actor-model.md)
+page first for how you actually *write* one; everything below is what's different
+because the actor lives across an FFI boundary and is loaded into a running engine.
 
-## What a component is (and isn't)
+> Governing ADRs: **ADR-0074** (one actor model, two hosts), **ADR-0024** (the
+> dual-target FFI convention), **ADR-0028 / ADR-0033** (the kind + handler
+> manifests in the wasm), **ADR-0090** (boot config), **ADR-0022 / ADR-0038**
+> (in-place hot-swap). The authoring and loading surface here is **stable** — it's
+> what every reference component (`aether-camera`, `aether-mesh-viewer`) is built
+> on, and the signatures were read from the current SDK.
 
-There's one actor model in the engine, not two (ADR-0074). A **capability** is a
-native actor — Rust compiled into the substrate, hosting I/O and GPU and audio.
-A **component** is a *loaded* actor — wasm today, instantiated at runtime behind
-an FFI boundary. They share the same `Actor` super-trait, the same lifecycle
-shape, the same mail surface, and address each other identically. The difference
-is the host: a capability is linked at build time and trusted with raw I/O; a
-component arrives as bytes, runs sandboxed in the wasm wall, and reaches the
-outside world only by mailing capabilities. (See the [invariants
-page](../foundations/invariants.md) on capability = reachability.)
+## `export!` and the FFI boundary
 
-So "writing a component" is the agent-facing path for extending the engine: you
-add behavior without touching or rebuilding the substrate. The substrate stays a
-thin host; the engine grows in wasm.
-
-A component implements **`FfiActor`** (FFI = the loaded, foreign host). A native
-capability implements `NativeActor`. Both sit on `Actor`, which owns only the
-shared `NAMESPACE` const. You author the receive side with the `#[actor]` macro
-on one `impl FfiActor for C` block, and emit the FFI shims with `export!`.
-
-## The lifecycle: `init` → `wire` → handlers → `unwire`
-
-A component moves through three authored stages (ADR-0079). Each gets a different
-context, and the context is the contract — it's exactly what you're allowed to do
-at that stage.
-
-**`init` — the constructor. No mail.**
-
-```rust
-fn init<C>(ctx: &mut C) -> Result<Self, BootError>
-where
-    C: Resolver,
-```
-
-Runs once. Build and return the actor's initial state. The ctx is **`Resolver`
-only**: you can resolve kind ids and mailbox addresses (`ctx.resolve::<K>()`,
-`ctx.mailbox_id()`), but you *cannot send mail* — the actor's mailbox isn't
-published yet, and peers may not exist. This is deliberate (ADR-0079): `init` is
-a pure synchronous constructor. If startup can fail — a missing handle, an
-unparseable config — return `Err(BootError::new("…"))` and the failure surfaces
-to the loader as `LoadResult::Err { error }` instead of a half-built actor.
-
-**`wire` — post-init, mail allowed.**
-
-```rust
-fn wire(&mut self, ctx: &mut FfiCtx<'_>) { … }
-```
-
-Runs after `init` returns `Ok` and the mailbox is published, before the first
-inbound envelope is dispatched. Now the ctx is a full `FfiCtx`: you can send. This
-is where mail-driven setup goes — **subscribe to input streams**, announce
-yourself to peers, kick off a self-mail poll loop. The reference camera subscribes
-here:
-
-```rust
-fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
-    let me = MailboxId(ctx.mailbox_id());
-    let input = ctx.actor::<InputCapability>();
-    input.subscribe(Tick::ID, me);
-    input.subscribe(WindowSize::ID, me);
-}
-```
-
-Subscriptions belong in `wire`, not `init`, precisely because `init` can't mail.
-Default is a no-op; override only if you have setup to do.
-
-**handlers — steady state.** Between `wire` and shutdown the actor just receives
-mail, one handler call per kind. Covered below.
-
-**`unwire` — pre-shutdown, mail allowed.**
-
-```rust
-fn unwire(&mut self, ctx: &mut FfiCtx<'_>) { … }
-```
-
-Runs after the dispatcher drains the inbox, before the actor value drops. Full
-`FfiCtx` again — final broadcasts, monitor signals, a flush all land. Mail to a
-live peer is delivered; mail to a peer that's already gone warn-drops. (The older
-`on_drop` hook was retired in favor of this single mail-allowed teardown stage.)
-Default no-op.
-
-## Writing the receive side: `#[actor]` and `#[handler]`
-
-The `#[actor]` attribute goes on the one `impl FfiActor` block. Each `#[handler]`
-method *is* a mail handler, and the macro infers the kind it handles **from the
-method's third parameter** — no typelist, no `is::<K>()` dispatch:
-
-```rust
-#[actor]
-impl FfiActor for Hello {
-    const NAMESPACE: &'static str = "hello";
-
-    fn init<C>(ctx: &mut C) -> Result<Self, BootError>
-    where C: Resolver {
-        Ok(Hello { pong: ctx.resolve::<Pong>() })
-    }
-
-    fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
-        ctx.actor::<InputCapability>().send(&SubscribeInput {
-            kind: Tick::ID,
-            mailbox: MailboxId(ctx.mailbox_id()),
-        });
-    }
-
-    #[handler]
-    fn on_tick(&mut self, ctx: &mut FfiCtx<'_>, _tick: Tick) {
-        ctx.actor::<RenderCapability>().send(&TRIANGLE);   // draw every tick
-    }
-
-    #[handler]
-    fn on_ping(&mut self, ctx: &mut FfiCtx<'_>, ping: Ping) {
-        if let Some(sender) = ctx.reply_target() {
-            ctx.reply_kind(sender, self.pong, &Pong { seq: ping.seq });
-        }
-    }
-}
-
-aether_actor::export!(Hello);
-```
-
-The third parameter `Ping` is the kind `on_ping` handles; `Tick` is the kind
-`on_tick` handles. The macro reads those types and codegens the dispatch table
-that matches an inbound envelope's kind id against each handler's `K::ID` (a
-compile-time const — no runtime registration, no host round-trip to resolve the
-address). It also emits the **`aether.kinds.inputs` custom section** in the wasm:
-a manifest of every handler kind plus its doc, which is exactly what
-`describe_component` reads back to tell a live engine what this component accepts.
-Your doc comments — filtered through a `# Agent` section if you write one — ride
-along into that manifest.
-
-A handler takes the decoded mail **by value** (`ping: Ping`), not by reference;
-the macro-generated trampoline owns the decoded payload. `&mut self` gives the
-handler the actor's state, which is plain fields — no locks, because an actor is
-single-threaded from its own view (see [concurrency](concurrency.md)).
-
-**Strict by default; `#[fallback]` to catch the rest.** A component with no
-fallback is a *strict receiver*: mail of a kind it doesn't handle is reported as
-`DISPATCH_UNKNOWN_KIND` rather than silently swallowed. Add one catch-all if you
-want to absorb everything else:
-
-```rust
-#[fallback]
-fn on_other(&mut self, ctx: &mut FfiCtx<'_>, mail: Mail<'_>) { … }
-```
-
-The fallback takes the raw `Mail<'_>` (it doesn't know the kind statically) and
-its presence is recorded in the manifest too, so introspection can tell a strict
-receiver from a permissive one.
-
-## `export!` — the FFI shims
+Authoring a component is authoring an actor (`#[actor] impl FfiActor for C`), plus
+one line that doesn't exist on the native side:
 
 ```rust
 aether_actor::export!(Hello);
@@ -174,76 +30,27 @@ aether_actor::export!(Hello);
 
 This is **required** — without it the wasm has no FFI exports and the substrate
 can't drive the actor. It emits the `#[no_mangle]` entry points the host calls
-across the boundary (`init`, `wire`, `receive_p32`, `unwire`) plus the two custom
-sections (`aether.kinds.inputs` and `aether.namespace`). You never write
-`extern "C"` by hand.
+across the boundary (`init`, `wire`, `receive_p32`, `unwire`) and two **wasm
+custom sections**:
 
-The `_p32` suffix on the pointer-taking exports (`receive_p32`,
-`on_rehydrate_p32`) is the dual-target FFI convention (ADR-0024): wasm32 addresses
-are 32-bit, so those shims take `u32` pointers/lengths. The exports are
-**wasm32-only** — a native (host) build of the same crate carries no FFI symbols,
-which is why host-side tests of a component drive it through the in-process
-transport rather than the FFI path. (See the [type system
-page](../foundations/type-system.md) for how the kind vocabulary itself crosses
-the boundary.)
+- **`aether.kinds.inputs`** — the manifest of every `#[handler]` kind (plus its
+  doc, and whether a `#[fallback]` is present), generated by `#[actor]`. This is
+  exactly what `describe_component` reads back to tell a live engine what the
+  component accepts — your doc comments, filtered through a `# Agent` section if
+  you write one, ride along.
+- **`aether.namespace`** — the component's default load name from `NAMESPACE`.
 
-## Addressing and sending from inside
-
-You address another actor **by type**, and it resolves at compile time:
-
-```rust
-ctx.actor::<RenderCapability>().send(&Camera { view_proj });   // singleton, by type
-```
-
-`ctx.actor::<R>()` returns a typed mailbox handle for capability `R`, and
-`.send::<K>(&payload)` compiles only if `R` actually handles `K` (`R:
-HandlesKind<K>` — the macro emits one such impl per `#[handler]`). Both the
-mailbox id and the kind id are compile-time consts, so there's no host round-trip
-to resolve an address.
-
-Other shapes:
-
-- **Self-address:** `ctx.mailbox_id()` — your own mailbox, e.g. to hand to a
-  subscription so the stream routes back to you.
-- **Subscribe to an input stream:** `ctx.actor::<InputCapability>().subscribe(Tick::ID, me)`
-  (the convenience on `InputMailboxExt`), or send `SubscribeInput { kind, mailbox }`
-  directly. Subscriptions clear on drop and survive a hot-swap (the mailbox id is
-  stable).
-- **Reply to a request:** `ctx.reply_target()` returns the sender if the inbound
-  mail had one; reply to it. A handler promises *nothing* about replies — replying
-  is the handler's own business, not part of the kind contract (see the [mail
-  page](mail-and-kinds.md)).
-- **Name-keyed escape hatch:** when you only know a mailbox by string, resolve a
-  `Mailbox<K>` token and send through it — used for peer addresses you learn at
-  runtime (e.g. a `LoadResult.name`).
-
-## Boot configuration
-
-A component can take typed boot config (ADR-0090). Declare a `type Config` and
-the chassis threads decoded bytes into `init`:
-
-```rust
-#[actor]
-impl FfiActor for ProbeWithConfig {
-    type Config = ProbeConfig;
-    const NAMESPACE: &'static str = "probe_with_config";
-
-    fn init<C>(config: ProbeConfig, ctx: &mut C) -> Result<Self, BootError>
-    where C: Resolver { … }
-}
-```
-
-Omit `type Config` and the macro synthesizes `type Config = ()` *and* injects the
-unused `_config` argument, so a no-config component's `init` stays terse —
-`fn init<C>(ctx: &mut C)`, exactly as `Hello` writes it above. The config rides
-as raw bytes on `LoadComponent.config`: the hub / MCP edge encodes the config
-struct to bytes (SDK-typed, not wire-typed), so the substrate stays
-byte-transparent. A declared config kind shows up in the component's advertised
-capabilities, so `describe_kinds` can resolve its schema.
+You never write `extern "C"` by hand. The `_p32` suffix on the pointer-taking
+exports (`receive_p32`, `on_rehydrate_p32`) is the dual-target FFI convention
+(ADR-0024): wasm32 addresses are 32-bit, so those shims take `u32` pointers and
+lengths. The exports are **wasm32-only** — a native (host) build of the same crate
+carries no FFI symbols, which is why a host-side test of a component drives it
+through the in-process transport rather than the FFI path.
 
 ## Loading, dropping, and the trampoline address
 
-Lifecycle control is mail to the `aether.component` mailbox:
+A component enters and leaves a running engine by mail to the `aether.component`
+mailbox:
 
 | kind | does | reply |
 |---|---|---|
@@ -260,15 +67,26 @@ string is the address you send subsequent mail to. Bare names (`"player"`) are
 
 In practice you drive this through the MCP harness — `load_component(engine_id,
 binary_path, name?)`, `replace_component(...)`, `terminate_substrate(...)` — which
-takes a *path* and reads the bytes for you (tool JSON never carries the wasm
+takes a **path** and reads the bytes for you (tool JSON never carries the wasm
 buffer; the wire kind does). The component's kind vocabulary travels inside the
 wasm's `aether.kinds` custom section (ADR-0028), so the loader declares nothing —
 the substrate reads the types directly off the binary.
 
+## Boot configuration across the boundary
+
+A component takes typed boot config the same way a capability does — declare a
+`type Config` and the chassis threads it into `init` (ADR-0090). What's
+wasm-specific is the *carrier*: the config rides as raw bytes on
+`LoadComponent.config`, encoded at the hub / MCP edge (SDK-typed, not wire-typed),
+so the substrate stays byte-transparent and never needs the config's Rust type.
+Omit `type Config` and the macro synthesizes `()` and injects the unused argument,
+so a no-config `init` stays terse. A declared config kind shows up in the
+component's advertised capabilities, so `describe_kinds` can resolve its schema.
+
 ## Hot reload
 
-Replacing a component's wasm *without* dropping its mailbox is opt-in. By default
-a component isn't replaceable; to participate, impl the `Replaceable` subtrait and
+Replacing a component's wasm *without* dropping its mailbox is opt-in. By default a
+component isn't replaceable; to participate, impl the `Replaceable` subtrait and
 emit with the `replaceable` flag:
 
 ```rust
@@ -293,31 +111,21 @@ serialize state via the `Persistence` ctx), instantiates the new wasm module
 **behind the same binding**, and calls `on_rehydrate` on the new instance with the
 prior state bundle if one was saved. If the drain exceeds its timeout the replace
 fails and the **old instance stays bound** — a failed swap is a no-op, not a
-half-swapped actor. `ReplaceResult::Ok` carries the new component's capabilities
-so the hub's cached view reflects the swapped binary.
+half-swapped actor. `ReplaceResult::Ok` carries the new component's capabilities so
+the hub's cached view reflects the swapped binary.
 
 The load-bearing property is **binding stability** (ADR-0038): the swap replaces
 the wasm Module *in place* behind a stable mailbox handle, so the mailbox id, any
-route cache, and existing input subscriptions all stay valid across the swap.
-Peers mailing the component never learn it changed. Prefer
-`save_state_kind` (which carries schema identity through the kind system) over the
-raw `save_state` byte bundle unless you're persisting a non-kind blob or driving
-an explicit migration.
-
-## Where this fits
-
-Writing a component is the standard way to extend the engine in wasm — new
-behavior, no substrate rebuild. When the thing you need is genuinely native (it
-must own a socket, a GPU resource, an audio device), that's a *capability*
-instead, authored against `NativeActor` with the same `#[actor]` shape; the
-[recipes](../recipes.md) cover adding one. The reference components to read are
-`aether-camera` (multi-instance state, input subscriptions, a rich mail family)
-and `aether-mesh-viewer` (fetch-and-cache, replay-every-tick).
+route cache, and existing input subscriptions all stay valid across the swap. Peers
+mailing the component never learn it changed. Prefer `save_state_kind` (which
+carries schema identity through the kind system) over the raw `save_state` byte
+bundle unless you're persisting a non-kind blob or driving an explicit migration.
 
 ## Where to read more
 
-- The lifecycle and single-threaded-actor contract this builds on — [Invariants & guarantees](../foundations/invariants.md).
+- The actor primitive this specializes — its lifecycle, `#[actor]`, handlers,
+  addressing — [The actor model](../foundations/actor-model.md).
+- Kinds, ids, and how the vocabulary crosses the wasm boundary — [The type system](../foundations/type-system.md).
 - How mail routes and what a kind is — [Mail, kinds & scheduling](mail-and-kinds.md).
 - Why a handler must never block, and how to wait instead — [Concurrency & blocking](concurrency.md).
-- Kinds, ids, and how the vocabulary crosses the wasm boundary — [The type system](../foundations/type-system.md).
 - Loading and inspecting a live component — the `load_component` / `describe_component` MCP tools (`CLAUDE.md`).

--- a/docs/guide/systems/components.md
+++ b/docs/guide/systems/components.md
@@ -1,0 +1,323 @@
+# Components & lifecycle
+
+A **component** is an actor you load into a running engine. It's the unit an
+agent writes and ships: a small Rust crate, compiled to wasm, dropped into a live
+substrate with `load_component` and addressable by mail the moment it boots. This
+page is how to author one — the trait you implement, the lifecycle stages it
+moves through, how to send and subscribe from inside it, and how it gets loaded,
+dropped, and hot-swapped.
+
+> Governing ADRs: **ADR-0074** (the unified actor model — components and native
+> capabilities are *one* primitive with two hosts), **ADR-0033** (the `#[actor]`
+> macro and handler-driven inputs manifest), **ADR-0079** (the lifecycle stages),
+> **ADR-0090** (typed boot config), **ADR-0022 / ADR-0038** (in-place hot-swap).
+> The authoring surface here — the `#[actor]` block, `init`/`wire`/`unwire`,
+> `export!` — is **stable**: it's the contract every reference component
+> (`aether-camera`, `aether-mesh-viewer`) and example is built on. Where this
+> page shows an exact signature it was read from the current SDK, not an ADR.
+
+## What a component is (and isn't)
+
+There's one actor model in the engine, not two (ADR-0074). A **capability** is a
+native actor — Rust compiled into the substrate, hosting I/O and GPU and audio.
+A **component** is a *loaded* actor — wasm today, instantiated at runtime behind
+an FFI boundary. They share the same `Actor` super-trait, the same lifecycle
+shape, the same mail surface, and address each other identically. The difference
+is the host: a capability is linked at build time and trusted with raw I/O; a
+component arrives as bytes, runs sandboxed in the wasm wall, and reaches the
+outside world only by mailing capabilities. (See the [invariants
+page](../foundations/invariants.md) on capability = reachability.)
+
+So "writing a component" is the agent-facing path for extending the engine: you
+add behavior without touching or rebuilding the substrate. The substrate stays a
+thin host; the engine grows in wasm.
+
+A component implements **`FfiActor`** (FFI = the loaded, foreign host). A native
+capability implements `NativeActor`. Both sit on `Actor`, which owns only the
+shared `NAMESPACE` const. You author the receive side with the `#[actor]` macro
+on one `impl FfiActor for C` block, and emit the FFI shims with `export!`.
+
+## The lifecycle: `init` → `wire` → handlers → `unwire`
+
+A component moves through three authored stages (ADR-0079). Each gets a different
+context, and the context is the contract — it's exactly what you're allowed to do
+at that stage.
+
+**`init` — the constructor. No mail.**
+
+```rust
+fn init<C>(ctx: &mut C) -> Result<Self, BootError>
+where
+    C: Resolver,
+```
+
+Runs once. Build and return the actor's initial state. The ctx is **`Resolver`
+only**: you can resolve kind ids and mailbox addresses (`ctx.resolve::<K>()`,
+`ctx.mailbox_id()`), but you *cannot send mail* — the actor's mailbox isn't
+published yet, and peers may not exist. This is deliberate (ADR-0079): `init` is
+a pure synchronous constructor. If startup can fail — a missing handle, an
+unparseable config — return `Err(BootError::new("…"))` and the failure surfaces
+to the loader as `LoadResult::Err { error }` instead of a half-built actor.
+
+**`wire` — post-init, mail allowed.**
+
+```rust
+fn wire(&mut self, ctx: &mut FfiCtx<'_>) { … }
+```
+
+Runs after `init` returns `Ok` and the mailbox is published, before the first
+inbound envelope is dispatched. Now the ctx is a full `FfiCtx`: you can send. This
+is where mail-driven setup goes — **subscribe to input streams**, announce
+yourself to peers, kick off a self-mail poll loop. The reference camera subscribes
+here:
+
+```rust
+fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
+    let me = MailboxId(ctx.mailbox_id());
+    let input = ctx.actor::<InputCapability>();
+    input.subscribe(Tick::ID, me);
+    input.subscribe(WindowSize::ID, me);
+}
+```
+
+Subscriptions belong in `wire`, not `init`, precisely because `init` can't mail.
+Default is a no-op; override only if you have setup to do.
+
+**handlers — steady state.** Between `wire` and shutdown the actor just receives
+mail, one handler call per kind. Covered below.
+
+**`unwire` — pre-shutdown, mail allowed.**
+
+```rust
+fn unwire(&mut self, ctx: &mut FfiCtx<'_>) { … }
+```
+
+Runs after the dispatcher drains the inbox, before the actor value drops. Full
+`FfiCtx` again — final broadcasts, monitor signals, a flush all land. Mail to a
+live peer is delivered; mail to a peer that's already gone warn-drops. (The older
+`on_drop` hook was retired in favor of this single mail-allowed teardown stage.)
+Default no-op.
+
+## Writing the receive side: `#[actor]` and `#[handler]`
+
+The `#[actor]` attribute goes on the one `impl FfiActor` block. Each `#[handler]`
+method *is* a mail handler, and the macro infers the kind it handles **from the
+method's third parameter** — no typelist, no `is::<K>()` dispatch:
+
+```rust
+#[actor]
+impl FfiActor for Hello {
+    const NAMESPACE: &'static str = "hello";
+
+    fn init<C>(ctx: &mut C) -> Result<Self, BootError>
+    where C: Resolver {
+        Ok(Hello { pong: ctx.resolve::<Pong>() })
+    }
+
+    fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
+        ctx.actor::<InputCapability>().send(&SubscribeInput {
+            kind: Tick::ID,
+            mailbox: MailboxId(ctx.mailbox_id()),
+        });
+    }
+
+    #[handler]
+    fn on_tick(&mut self, ctx: &mut FfiCtx<'_>, _tick: Tick) {
+        ctx.actor::<RenderCapability>().send(&TRIANGLE);   // draw every tick
+    }
+
+    #[handler]
+    fn on_ping(&mut self, ctx: &mut FfiCtx<'_>, ping: Ping) {
+        if let Some(sender) = ctx.reply_target() {
+            ctx.reply_kind(sender, self.pong, &Pong { seq: ping.seq });
+        }
+    }
+}
+
+aether_actor::export!(Hello);
+```
+
+The third parameter `Ping` is the kind `on_ping` handles; `Tick` is the kind
+`on_tick` handles. The macro reads those types and codegens the dispatch table
+that matches an inbound envelope's kind id against each handler's `K::ID` (a
+compile-time const — no runtime registration, no host round-trip to resolve the
+address). It also emits the **`aether.kinds.inputs` custom section** in the wasm:
+a manifest of every handler kind plus its doc, which is exactly what
+`describe_component` reads back to tell a live engine what this component accepts.
+Your doc comments — filtered through a `# Agent` section if you write one — ride
+along into that manifest.
+
+A handler takes the decoded mail **by value** (`ping: Ping`), not by reference;
+the macro-generated trampoline owns the decoded payload. `&mut self` gives the
+handler the actor's state, which is plain fields — no locks, because an actor is
+single-threaded from its own view (see [concurrency](concurrency.md)).
+
+**Strict by default; `#[fallback]` to catch the rest.** A component with no
+fallback is a *strict receiver*: mail of a kind it doesn't handle is reported as
+`DISPATCH_UNKNOWN_KIND` rather than silently swallowed. Add one catch-all if you
+want to absorb everything else:
+
+```rust
+#[fallback]
+fn on_other(&mut self, ctx: &mut FfiCtx<'_>, mail: Mail<'_>) { … }
+```
+
+The fallback takes the raw `Mail<'_>` (it doesn't know the kind statically) and
+its presence is recorded in the manifest too, so introspection can tell a strict
+receiver from a permissive one.
+
+## `export!` — the FFI shims
+
+```rust
+aether_actor::export!(Hello);
+```
+
+This is **required** — without it the wasm has no FFI exports and the substrate
+can't drive the actor. It emits the `#[no_mangle]` entry points the host calls
+across the boundary (`init`, `wire`, `receive_p32`, `unwire`) plus the two custom
+sections (`aether.kinds.inputs` and `aether.namespace`). You never write
+`extern "C"` by hand.
+
+The `_p32` suffix on the pointer-taking exports (`receive_p32`,
+`on_rehydrate_p32`) is the dual-target FFI convention (ADR-0024): wasm32 addresses
+are 32-bit, so those shims take `u32` pointers/lengths. The exports are
+**wasm32-only** — a native (host) build of the same crate carries no FFI symbols,
+which is why host-side tests of a component drive it through the in-process
+transport rather than the FFI path. (See the [type system
+page](../foundations/type-system.md) for how the kind vocabulary itself crosses
+the boundary.)
+
+## Addressing and sending from inside
+
+You address another actor **by type**, and it resolves at compile time:
+
+```rust
+ctx.actor::<RenderCapability>().send(&Camera { view_proj });   // singleton, by type
+```
+
+`ctx.actor::<R>()` returns a typed mailbox handle for capability `R`, and
+`.send::<K>(&payload)` compiles only if `R` actually handles `K` (`R:
+HandlesKind<K>` — the macro emits one such impl per `#[handler]`). Both the
+mailbox id and the kind id are compile-time consts, so there's no host round-trip
+to resolve an address.
+
+Other shapes:
+
+- **Self-address:** `ctx.mailbox_id()` — your own mailbox, e.g. to hand to a
+  subscription so the stream routes back to you.
+- **Subscribe to an input stream:** `ctx.actor::<InputCapability>().subscribe(Tick::ID, me)`
+  (the convenience on `InputMailboxExt`), or send `SubscribeInput { kind, mailbox }`
+  directly. Subscriptions clear on drop and survive a hot-swap (the mailbox id is
+  stable).
+- **Reply to a request:** `ctx.reply_target()` returns the sender if the inbound
+  mail had one; reply to it. A handler promises *nothing* about replies — replying
+  is the handler's own business, not part of the kind contract (see the [mail
+  page](mail-and-kinds.md)).
+- **Name-keyed escape hatch:** when you only know a mailbox by string, resolve a
+  `Mailbox<K>` token and send through it — used for peer addresses you learn at
+  runtime (e.g. a `LoadResult.name`).
+
+## Boot configuration
+
+A component can take typed boot config (ADR-0090). Declare a `type Config` and
+the chassis threads decoded bytes into `init`:
+
+```rust
+#[actor]
+impl FfiActor for ProbeWithConfig {
+    type Config = ProbeConfig;
+    const NAMESPACE: &'static str = "probe_with_config";
+
+    fn init<C>(config: ProbeConfig, ctx: &mut C) -> Result<Self, BootError>
+    where C: Resolver { … }
+}
+```
+
+Omit `type Config` and the macro synthesizes `type Config = ()` *and* injects the
+unused `_config` argument, so a no-config component's `init` stays terse —
+`fn init<C>(ctx: &mut C)`, exactly as `Hello` writes it above. The config rides
+as raw bytes on `LoadComponent.config`: the hub / MCP edge encodes the config
+struct to bytes (SDK-typed, not wire-typed), so the substrate stays
+byte-transparent. A declared config kind shows up in the component's advertised
+capabilities, so `describe_kinds` can resolve its schema.
+
+## Loading, dropping, and the trampoline address
+
+Lifecycle control is mail to the `aether.component` mailbox:
+
+| kind | does | reply |
+|---|---|---|
+| `aether.component.load` | compile + instantiate the wasm, register its kinds, publish a mailbox | `LoadResult` |
+| `aether.component.drop` | tear down a component, invalidate its mailbox id | `DropResult` |
+| `aether.component.replace` | hot-swap the wasm behind a stable mailbox id | `ReplaceResult` |
+
+`LoadResult::Ok` carries the assigned `mailbox_id`, the **resolved name** (so a
+caller that omitted `name` learns the substrate-defaulted one), and the parsed
+`ComponentCapabilities` (handlers, fallback, doc, config) read from the manifest.
+A loaded component registers at **`aether.component.trampoline:NAME`** — that full
+string is the address you send subsequent mail to. Bare names (`"player"`) are
+*not* registered and warn-drop; always use the name from `LoadResult`.
+
+In practice you drive this through the MCP harness — `load_component(engine_id,
+binary_path, name?)`, `replace_component(...)`, `terminate_substrate(...)` — which
+takes a *path* and reads the bytes for you (tool JSON never carries the wasm
+buffer; the wire kind does). The component's kind vocabulary travels inside the
+wasm's `aether.kinds` custom section (ADR-0028), so the loader declares nothing —
+the substrate reads the types directly off the binary.
+
+## Hot reload
+
+Replacing a component's wasm *without* dropping its mailbox is opt-in. By default
+a component isn't replaceable; to participate, impl the `Replaceable` subtrait and
+emit with the `replaceable` flag:
+
+```rust
+impl Replaceable for MyComponent {
+    fn on_replace<C>(&mut self, ctx: &mut C)
+    where C: MailSender + Persistence {
+        ctx.save_state_kind(1, &self.snapshot());   // hand state to the successor
+    }
+
+    fn on_rehydrate<C>(&mut self, ctx: &mut C, prior: PriorState<'_>)
+    where C: OutboundReply {
+        if let Some(snap) = prior.as_kind::<Snapshot>(Snapshot::ID) { … }
+    }
+}
+
+aether_actor::export!(MyComponent, replaceable);
+```
+
+`aether.component.replace` (ADR-0022) freezes the target mailbox, **drains
+in-flight mail through the old instance**, calls `on_replace` on it (its chance to
+serialize state via the `Persistence` ctx), instantiates the new wasm module
+**behind the same binding**, and calls `on_rehydrate` on the new instance with the
+prior state bundle if one was saved. If the drain exceeds its timeout the replace
+fails and the **old instance stays bound** — a failed swap is a no-op, not a
+half-swapped actor. `ReplaceResult::Ok` carries the new component's capabilities
+so the hub's cached view reflects the swapped binary.
+
+The load-bearing property is **binding stability** (ADR-0038): the swap replaces
+the wasm Module *in place* behind a stable mailbox handle, so the mailbox id, any
+route cache, and existing input subscriptions all stay valid across the swap.
+Peers mailing the component never learn it changed. Prefer
+`save_state_kind` (which carries schema identity through the kind system) over the
+raw `save_state` byte bundle unless you're persisting a non-kind blob or driving
+an explicit migration.
+
+## Where this fits
+
+Writing a component is the standard way to extend the engine in wasm — new
+behavior, no substrate rebuild. When the thing you need is genuinely native (it
+must own a socket, a GPU resource, an audio device), that's a *capability*
+instead, authored against `NativeActor` with the same `#[actor]` shape; the
+[recipes](../recipes.md) cover adding one. The reference components to read are
+`aether-camera` (multi-instance state, input subscriptions, a rich mail family)
+and `aether-mesh-viewer` (fetch-and-cache, replay-every-tick).
+
+## Where to read more
+
+- The lifecycle and single-threaded-actor contract this builds on — [Invariants & guarantees](../foundations/invariants.md).
+- How mail routes and what a kind is — [Mail, kinds & scheduling](mail-and-kinds.md).
+- Why a handler must never block, and how to wait instead — [Concurrency & blocking](concurrency.md).
+- Kinds, ids, and how the vocabulary crosses the wasm boundary — [The type system](../foundations/type-system.md).
+- Loading and inspecting a live component — the `load_component` / `describe_component` MCP tools (`CLAUDE.md`).


### PR DESCRIPTION
Restructures the actors/components material to lead with the primitive, per review: a component isn't the starting point — it's the **wasm host of an actor**. Going component-first drew the owl.

**New Foundations page — The actor model.** Teaches the primitive itself:
- An actor = private state + typed handlers, communicating *only* by mail; single-threaded from its own view (so state is plain fields, no locks).
- The shared `init` / `wire` / `unwire` lifecycle and what each ctx allows (init can't mail; wire is where subscriptions go).
- The `#[actor]` / `#[handler]` authoring shape and addressing peers by type.
- The load-bearing framing (ADR-0074): **one primitive, two hosts** — a native **capability** (`NativeActor`, linked, trusted with I/O) and a wasm **component** (`FfiActor`, loaded, sandboxed, reached via an FFI trampoline) are mirror-image traits over a shared `Actor` super-trait. The only deltas are the ctx type and the host; mail is the only coupling, so neither side knows which it's talking to.

**Components page, narrowed to the wasm host.** Now builds on the actor page instead of re-teaching the lifecycle. Keeps only what's wasm-specific: `export!` and the FFI boundary (`_p32`, the `aether.kinds.inputs` / `aether.namespace` custom-section manifests), the `aether.component.{load,drop,replace}` mail surface + `trampoline:NAME` address, the boot-config byte carrier, and hot reload via `Replaceable` + ADR-0038 binding stability.

**Nav:** `Foundations → The type system → The actor model → Invariants`, then `The systems → … → Components & lifecycle`.

`NativeActor`/`FfiActor` symmetry and all signatures verified against `aether-substrate` / `aether-actor` and the reference components, not ADR prose. `mdbook build` clean. Part of the agent-guide umbrella #1355.