### PR TITLE
docs(guide): add the configuration page

### DIFF
--- a/docs/guide/SUMMARY.md
+++ b/docs/guide/SUMMARY.md
@@ -27,7 +27,7 @@
   - [Mesh authoring & the DSL]()
   - [Input, file I/O & audio]()
   - [Tracing & settlement](systems/tracing-and-settlement.md)
-  - [Configuration]()
+  - [Configuration](systems/configuration.md)
   - [The computation DAG & handles]()
 
 # Building with aether

--- a/docs/guide/systems/configuration.md
+++ b/docs/guide/systems/configuration.md
@@ -1,14 +1,12 @@
 # Configuration
 
 Configuration is how a knob's value gets decided before the engine runs — the
-worker-pool size, an HTTP allowlist, a provider's API key, the tick rate. Two
-things make it worth a page of its own rather than a footnote. The values come
-from a **layered stack** of sources (defaults, environment, command-line
+worker-pool size, an HTTP allowlist, a provider's API key, the tick rate. Values
+come from a **layered stack** of sources (defaults, environment, command-line
 arguments) with a defined precedence, declared once per knob and resolved the
-same way everywhere. And configuration is **per-spawn**: two substrates launched
-from one shell can be told apart — one with a capability enabled under key A,
-another with it off — which is the axis the "substrate as a general application
-host" direction needs.
+same way everywhere. And it's **per-spawn**: two substrates launched from one
+shell can be told apart — one with a capability enabled under key A, another with
+it off — the axis the "substrate as a general application host" direction needs.
 
 If you drive the engine over MCP, the part that matters most is that
 configuration is no longer one frozen, fleet-wide environment: you can hand

--- a/docs/guide/systems/configuration.md
+++ b/docs/guide/systems/configuration.md
@@ -1,20 +1,5 @@
 # Configuration
 
-Configuration is how a knob's value gets decided before the engine runs — the
-worker-pool size, an HTTP allowlist, a provider's API key, the tick rate. Values
-come from a **layered stack** of sources (defaults, environment, command-line
-arguments) with a defined precedence, declared once per knob and resolved the
-same way everywhere. And it's **per-spawn**: two substrates launched from one
-shell can be told apart — one with a capability enabled under key A, another with
-it off — the axis the "substrate as a general application host" direction needs.
-
-If you drive the engine over MCP, the part that matters most is that
-configuration is no longer one frozen, fleet-wide environment: you can hand
-`spawn_substrate` per-engine arguments and a loaded component its own typed
-config. If you author a capability or component, the part that matters is that a
-knob is *declared* — one annotation gives you parsing, a default, validation, and
-discovery — so you never hand-roll an `env::var(...).parse()` chain again.
-
 > **Governing ADR:** [ADR-0090](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0090-application-configuration.md)
 > (application configuration). The **model** — the layered source-stack, one
 > typed struct per subsystem, validation, and discovery — is **stable** and
@@ -23,26 +8,40 @@ discovery — so you never hand-roll an `env::var(...).parse()` chain again.
 > read inline). This page documents the contract and defers the rollout's
 > internals to the ADR.
 
+Configuration is how a knob's value gets decided before the engine runs — the
+worker-pool size, an HTTP allowlist, a provider's API key, the tick rate. Values
+come from a **layered stack** of sources (defaults, environment, command-line
+arguments) with a defined precedence, declared once per knob and resolved the
+same way everywhere. And it's **per-spawn**: two substrates launched from one
+shell can be told apart — one with a capability enabled under key A, another with
+it off — the axis the "substrate as a general application host" direction needs.
+
+If you drive the engine over MCP, configuration is per engine: you hand
+`spawn_substrate` the arguments for one substrate and give a loaded component its
+own typed config, independent of any other engine. If you author a capability or
+component, you declare each knob once on its config struct — that single
+declaration parses the value, supplies its default, validates it, and lists it
+for discovery.
+
 ## Why it exists
 
-The engine used to read some fifty `AETHER_*` environment variables, each parsed
-where it was used — `env::var("AETHER_HTTP_MAX_BODY_BYTES").ok().and_then(|s|
-s.parse().ok()).unwrap_or(DEFAULT)`, repeated in slightly different forms across
-the codebase. That shape has three costs. Nothing **validates**: a typo'd key
-silently no-ops and falls through to the default, and a known key set to garbage
-does the same. Nothing **discovers**: there's no list of what knobs exist, what
-they default to, or what they do. And the parsers get **copy-pasted**, which is
-how `parse_env_u64` ended up living in three places.
+Aether is assembled from many subsystems — capabilities, the runtime, the chassis
+— each with its own knobs, and all of them are configured together at startup. A
+single configuration standard gives them one way to declare a knob and one way to
+resolve it, and three properties follow from that: **validation** (a typo'd key,
+or a known key set to garbage, is caught at boot rather than swallowed by a
+default), **discovery** (one listing of every knob, its default, and what it
+does), and no **duplicated** parsing across subsystems.
 
-There's a deeper, structural reason too. A process's environment is frozen at
-`exec` and inherited down the whole tree — the tunnel's shell into the hub, the
-hub into every substrate it forks. So configuration was **global to the entire
-fleet**: there was no way to spawn one substrate with a capability enabled and
-another with it disabled, because they all inherited the same environment from
-the root. Correcting a single key meant relaunching the whole tunnel and dropping
-the MCP session. The fix isn't new plumbing — `spawn_substrate` already forwarded
-per-spawn `args` end to end; they were simply never parsed. Configuration becomes
-per-application by adding an argument layer above the environment.
+The second reason is per-spawn configuration. Configuration enters a process
+once, at startup, and a substrate inherits its environment from the hub that
+forked it — the hub from the tunnel, the tunnel from the launching shell.
+Environment values are therefore **fleet-global**: every engine the hub forks
+sees the same ones, with no way to enable a capability on one substrate and
+disable it on another. Per-spawn arguments are what let one engine differ from
+the rest — they ride the spawn call to a single substrate and layer above the
+shared environment — which is what the "substrate as a general application host"
+direction needs.
 
 ## The model: layered sources, one struct per subsystem
 
@@ -69,8 +68,8 @@ declaration.
 
 ## Resolution, validation, and discovery
 
-Resolution is strict where the old chain was silent. At boot the chassis **warns**
-on any `AETHER_*` variable that no registered knob claims — catching a typo
+Resolution is strict. At boot the chassis **warns** on any `AETHER_*` variable
+that no registered knob claims — catching a typo
 without breaking on a stray CI variable — and **hard-errors** on a *known* key
 that's set but fails to parse, rather than falling through to the default. A bad
 value stops the boot with the key named, instead of a subsystem quietly running
@@ -87,7 +86,7 @@ when you're unsure what a build will do with a given variable.
 
 Over MCP there are three ways to set configuration, from coarsest to finest:
 
-- **The environment** is still the workhorse, and it's what `CLAUDE.md` documents
+- **The environment** is the workhorse, and it's what `CLAUDE.md` documents
   knob by knob (`AETHER_TICK_HZ`, `AETHER_SAVE_DIR`, `AETHER_AUDIO_DISABLE`, and
   the rest). It's fleet-wide and fixed at launch: set it before bringing the
   tunnel up, and every engine the hub forks inherits it.

--- a/docs/guide/systems/configuration.md
+++ b/docs/guide/systems/configuration.md
@@ -16,9 +16,9 @@ same way everywhere. And it's **per-spawn**: two substrates launched from one
 shell can be told apart — one with a capability enabled under key A, another with
 it off — the axis the "substrate as a general application host" direction needs.
 
-If you drive the engine over MCP, configuration is per engine: you hand
+When you drive the engine over MCP, configuration is per engine: you hand
 `spawn_substrate` the arguments for one substrate and give a loaded component its
-own typed config, independent of any other engine. If you author a capability or
+own typed config, independent of any other engine. When you author a capability or
 component, you declare each knob once on its config struct — that single
 declaration parses the value, supplies its default, validates it, and lists it
 for discovery.

--- a/docs/guide/systems/configuration.md
+++ b/docs/guide/systems/configuration.md
@@ -1,0 +1,158 @@
+# Configuration
+
+Configuration is how a knob's value gets decided before the engine runs — the
+worker-pool size, an HTTP allowlist, a provider's API key, the tick rate. Two
+things make it worth a page of its own rather than a footnote. The values come
+from a **layered stack** of sources (defaults, environment, command-line
+arguments) with a defined precedence, declared once per knob and resolved the
+same way everywhere. And configuration is **per-spawn**: two substrates launched
+from one shell can be told apart — one with a capability enabled under key A,
+another with it off — which is the axis the "substrate as a general application
+host" direction needs.
+
+If you drive the engine over MCP, the part that matters most is that
+configuration is no longer one frozen, fleet-wide environment: you can hand
+`spawn_substrate` per-engine arguments and a loaded component its own typed
+config. If you author a capability or component, the part that matters is that a
+knob is *declared* — one annotation gives you parsing, a default, validation, and
+discovery — so you never hand-roll an `env::var(...).parse()` chain again.
+
+> **Governing ADR:** [ADR-0090](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0090-application-configuration.md)
+> (application configuration). The **model** — the layered source-stack, one
+> typed struct per subsystem, validation, and discovery — is **stable** and
+> mostly shipped; the rollout is still **settling** at the edges (a config-*file*
+> layer is planned but not yet in, and a handful of chassis-wide knobs are still
+> read inline). This page documents the contract and defers the rollout's
+> internals to the ADR.
+
+## Why it exists
+
+The engine used to read some fifty `AETHER_*` environment variables, each parsed
+where it was used — `env::var("AETHER_HTTP_MAX_BODY_BYTES").ok().and_then(|s|
+s.parse().ok()).unwrap_or(DEFAULT)`, repeated in slightly different forms across
+the codebase. That shape has three costs. Nothing **validates**: a typo'd key
+silently no-ops and falls through to the default, and a known key set to garbage
+does the same. Nothing **discovers**: there's no list of what knobs exist, what
+they default to, or what they do. And the parsers get **copy-pasted**, which is
+how `parse_env_u64` ended up living in three places.
+
+There's a deeper, structural reason too. A process's environment is frozen at
+`exec` and inherited down the whole tree — the tunnel's shell into the hub, the
+hub into every substrate it forks. So configuration was **global to the entire
+fleet**: there was no way to spawn one substrate with a capability enabled and
+another with it disabled, because they all inherited the same environment from
+the root. Correcting a single key meant relaunching the whole tunnel and dropping
+the MCP session. The fix isn't new plumbing — `spawn_substrate` already forwarded
+per-spawn `args` end to end; they were simply never parsed. Configuration becomes
+per-application by adding an argument layer above the environment.
+
+## The model: layered sources, one struct per subsystem
+
+A resolved value comes from a stack of sources, lowest precedence to highest:
+
+```text
+typed defaults   <   config file   <   environment   <   argv
+```
+
+Argv overrides the environment, the environment overrides a file, a file
+overrides the declared default. (The file layer is the one piece still to land —
+today the live stack is `defaults < environment < argv`, and a missing argument
+simply falls through to env-then-default, so an engine launched with no arguments
+boots exactly as the environment alone dictates.)
+
+Each subsystem owns its own config struct, in its own crate, declaring its own
+knobs — there is no central registry that every subsystem has to register into.
+A `#[derive(aether_substrate::Config)]` on that struct is what unifies them: from
+the field annotations it generates the environment parsing, the argument
+(`clap`) layer, and the layered resolution, *and* a machine-readable description
+of every knob that the discovery dump walks. So the declaration stays next to the
+field that owns it, and parse, validate, and discover all come from that one
+declaration.
+
+## Resolution, validation, and discovery
+
+Resolution is strict where the old chain was silent. At boot the chassis **warns**
+on any `AETHER_*` variable that no registered knob claims — catching a typo
+without breaking on a stray CI variable — and **hard-errors** on a *known* key
+that's set but fails to parse, rather than falling through to the default. A bad
+value stops the boot with the key named, instead of a subsystem quietly running
+on a default you didn't ask for.
+
+Discovery is the `--config` flag on any chassis binary: it walks the same
+declarations and prints every knob — its environment key, the value it resolves
+to and which source that value came from, its default, and its doc — then exits
+without booting. That listing is generated from the field annotations, so it
+can't drift from what the engine actually reads. It's the first place to look
+when you're unsure what a build will do with a given variable.
+
+## Configuring a running engine
+
+Over MCP there are three ways to set configuration, from coarsest to finest:
+
+- **The environment** is still the workhorse, and it's what `CLAUDE.md` documents
+  knob by knob (`AETHER_TICK_HZ`, `AETHER_SAVE_DIR`, `AETHER_AUDIO_DISABLE`, and
+  the rest). It's fleet-wide and fixed at launch: set it before bringing the
+  tunnel up, and every engine the hub forks inherits it.
+- **Per-spawn arguments** are the per-engine override. `spawn_substrate` forwards
+  its `args` to the substrate as command-line arguments, layered *above* the
+  inherited environment — so you can spawn one engine with `--gemini-api-key …`
+  or `--http-disable` and leave the next one alone. This is what makes two
+  differently-configured substrates from one environment possible. Flag names are
+  mechanical: take the environment key, drop the `AETHER_` prefix, lowercase, and
+  hyphenate (`AETHER_HTTP_TIMEOUT_MS` → `--http-timeout-ms`).
+- **Component config** is finer still: a component declares a typed `Config` and
+  receives it at `init`. Because a guest's config crosses the wasm boundary as
+  bytes, that type is a **kind** (schema-bearing), so `describe_component`
+  surfaces the config shape the way it surfaces a handler kind. You deliver the
+  bytes through `load_component`'s `config_path` — the chassis decodes them and
+  hands the value to the guest's `init`. This mirrors a native actor exactly:
+  both declare `type Config` and receive it at construction
+  ([ADR-0090](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0090-application-configuration.md)
+  §5). Boot config arrives at `init`; *runtime* reconfiguration, if a component
+  wants it, is ordinary mail — the same kind can serve both.
+
+## Adding a knob
+
+Author-side, a new knob is a field on the subsystem's resolved-config struct, not
+a fresh `env::var` read. Derive `Config` on the struct and annotate the field:
+
+```rust
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "native", derive(aether_substrate::Config))]
+#[cfg_attr(feature = "native", config(env_prefix = "AETHER_HTTP", cli_prefix = "http"))]
+pub struct HttpConfig {
+    #[cfg_attr(feature = "native", config(default = false, parse = parse_flag))]
+    pub disabled: bool,
+    #[cfg_attr(feature = "native", config(default = [], parse = parse_allowlist, csv_set))]
+    pub allowlist: HashSet<String>,
+}
+```
+
+The derive emits the environment-shaped layer, the `clap` argument overlay, and
+the `from_env` / `from_argv_then_env` resolvers; the field hints (`default`,
+`parse`, `env`, `cli_long`, `ms_duration`, `csv_set`) carry the per-knob shape.
+Two things to know going in:
+
+- **Gate it on the `native` feature**, as above. The capabilities crate also
+  cross-compiles to wasm, where the config machinery isn't available; the
+  `#[cfg_attr(feature = "native", …)]` keeps the wasm build carrying only the
+  plain struct. Clippy runs host-native and won't catch a missing gate — the
+  wasm32 step in `scripts/preflight.sh` will.
+- **Wire the argument overlay into the chassis CLI** so the per-spawn layer
+  reaches your knob, and add a `*_defaults_match` test (the derive's literal
+  default and your struct's `Default` are declared separately and a test keeps
+  them honest).
+
+The full walkthrough is the *Adding a config knob* recipe; the rule to carry is
+that a knob is declared once and resolved by the layer, never read ad-hoc.
+
+## Where to read more
+
+- The rollout's design, the source-stack rationale, and the crate choice —
+  [ADR-0090](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0090-application-configuration.md).
+- The `spawn_substrate` arguments and `load_component` config path in their tool
+  context — [The MCP harness](../mcp-harness.md).
+- How a component declares and receives `type Config` —
+  [Components & lifecycle](components.md).
+- The operational knob-by-knob reference for the `AETHER_*` environment surface —
+  `CLAUDE.md`.


### PR DESCRIPTION
Adds the **Configuration** page to the agent guide (umbrella #1355).

## What it covers
- **Why** — the `AETHER_*` env sprawl (no validation, no discovery, copy-pasted parsers) and the structural problem: config frozen at `exec` and inherited down the process tree was fleet-global, so you couldn't spawn two differently-configured substrates. Per-spawn argv is the fix.
- **The model** — the layered source-stack (`defaults < file < env < argv`), one typed struct per subsystem, the `#[derive(aether_substrate::Config)]` that unifies parse / validate / discover from one declaration.
- **Resolution** — warn on unknown `AETHER_*`, hard-error on known-but-unparseable, `--config` discovery dump.
- **Configuring a running engine** — environment (fleet-wide), per-spawn `spawn_substrate` args (per-engine override), and component config at `init` via `load_component`'s `config_path` (a `Kind`, surfaced by `describe_component`).
- **Adding a knob** — derive on the resolved struct, native-gate it, wire the overlay into the chassis CLI; never a fresh `env::var().parse()`.

## Accuracy
Verified against current code, not just ADR-0090's prose — and the rollout is much further along than the ADR's "Proposed" status suggests: confique + the derive + argv/CLI + validation + `--config` + component config are all shipped; **only the config-file layer (f) is still pending**, plus a few chassis-wide knobs read inline. Page is marked **settling** and says so honestly. (Updated my own stale memory on the rollout state in the process.)

Maturity: **settling**. Docs-only; `mdbook build` clean. Part of #1355 (umbrella stays open until the page set is complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
