### PR TITLE
docs(guide): move the Governing ADR box below each page header

### DIFF
--- a/docs/guide/foundations/actor-model.md
+++ b/docs/guide/foundations/actor-model.md
@@ -1,5 +1,11 @@
 # The actor model
 
+> Governing ADR: **ADR-0074** (the unified actor model — capabilities and
+> components are one model, not two) with **ADR-0079** (the lifecycle stages)
+> and **ADR-0033** (the `#[actor]` macro). This model is **stable**; it's the
+> spine everything else hangs off. Signatures here were read from the current SDK
+> (`aether-actor`) and runtime (`aether-substrate`).
+
 The engine is built from one kind of thing: the **actor**. The renderer, the audio
 mixer, the filesystem, a component you load — all of them are actors, with no
 privileged class of "system object" sitting above them. Everything in the substrate
@@ -9,12 +15,6 @@ If you understand actors, most of the engine follows: every subsystem in this gu
 is some actor (or a handful) doing a job. This page covers the actor itself — what
 it is, the lifecycle it moves through, how you write one — and the two *hosts* it
 runs under, native **capabilities** and wasm **components**.
-
-> Governing ADR: **ADR-0074** (the unified actor model — capabilities and
-> components are one model, not two) with **ADR-0079** (the lifecycle stages)
-> and **ADR-0033** (the `#[actor]` macro). This model is **stable**; it's the
-> spine everything else hangs off. Signatures here were read from the current SDK
-> (`aether-actor`) and runtime (`aether-substrate`).
 
 ## What an actor is
 

--- a/docs/guide/foundations/type-system.md
+++ b/docs/guide/foundations/type-system.md
@@ -1,5 +1,13 @@
 # The type system
 
+> Governing ADRs: **ADR-0005** (mail typing), **ADR-0019** (unified encoding),
+> **ADR-0029/0030** (name- and schema-derived ids), **ADR-0031/0032** (const
+> schema + canonical bytes / labels sidecar), **ADR-0045/0048/0049** (handles,
+> transforms, the handle store), **ADR-0064/0065** (type-tagged wire ids +
+> first-class id types). The type vocabulary is **stable** — the wire format
+> depends on it. The DAG composition surface that handles and transforms feed is
+> **shipped and settling** (its 0.4 stack merged).
+
 Everything the engine moves is typed, and the vocabulary is small. Four kinds of
 thing carry types — **kinds** (payloads), **mailboxes** (addresses), **handles**
 (references to stored values), and **transforms** (pure functions) — and each is
@@ -12,14 +20,6 @@ without a shared header, and answer "what are you?" to a live engine. That's
 what lets the agent driving the engine introspect it — `describe_kinds`,
 `describe_component`, `describe_handles`, `describe_transforms` are all just
 "read the types." Typing is the substrate of observability, not paperwork.
-
-> Governing ADRs: **ADR-0005** (mail typing), **ADR-0019** (unified encoding),
-> **ADR-0029/0030** (name- and schema-derived ids), **ADR-0031/0032** (const
-> schema + canonical bytes / labels sidecar), **ADR-0045/0048/0049** (handles,
-> transforms, the handle store), **ADR-0064/0065** (type-tagged wire ids +
-> first-class id types). The type vocabulary is **stable** — the wire format
-> depends on it. The DAG composition surface that handles and transforms feed is
-> **shipped and settling** (its 0.4 stack merged).
 
 ## Kinds — typed payloads
 

--- a/docs/guide/mcp-harness.md
+++ b/docs/guide/mcp-harness.md
@@ -1,5 +1,12 @@
 # The MCP harness
 
+> Governing ADR: **ADR-0089** (the tunnel), over the per-subsystem ADRs the tools
+> front. The harness is **stable in shape** but its tools evolve — so treat this
+> page as the map and the mental model, not a parameter reference. Each tool's
+> exact arguments live in its own schema, which your MCP client shows you live;
+> that schema is the source of truth and is more current than any prose (this page
+> included). When the two disagree, believe the tool.
+
 An agent doesn't link against the engine or call it in-process. It drives a
 *running* engine from the outside, over **MCP** (Model Context Protocol): each
 tool call becomes mail against a live substrate, or a query about one. This is the
@@ -7,13 +14,6 @@ concrete form of the "agent in a harness" idea — the engine runs, the agent po
 it, watches what happens, and adjusts. If you're an agent reading this guide, this
 is the page that turns everything else into something you can actually *do*: the
 other pages tell you what to send; this one is how you send it.
-
-> Governing ADR: **ADR-0089** (the tunnel), over the per-subsystem ADRs the tools
-> front. The harness is **stable in shape** but its tools evolve — so treat this
-> page as the map and the mental model, not a parameter reference. Each tool's
-> exact arguments live in its own schema, which your MCP client shows you live;
-> that schema is the source of truth and is more current than any prose (this page
-> included). When the two disagree, believe the tool.
 
 ## The shape: three processes and a fleet
 

--- a/docs/guide/systems/components.md
+++ b/docs/guide/systems/components.md
@@ -1,5 +1,12 @@
 # Components & lifecycle
 
+> Governing ADRs: **ADR-0074** (one actor model, two hosts), **ADR-0024** (the
+> dual-target FFI convention), **ADR-0028 / ADR-0033** (the kind + handler
+> manifests in the wasm), **ADR-0090** (boot config), **ADR-0022 / ADR-0038**
+> (in-place hot-swap). The authoring and loading surface here is **stable** — it's
+> what every reference component (`aether-camera`, `aether-mesh-viewer`) is built
+> on, and the signatures were read from the current SDK.
+
 A **component** is the wasm host of an actor. The shared model — the `#[actor]`
 block, the `init` / `wire` / `unwire` lifecycle, handlers, addressing by type — is
 the [actor model](../foundations/actor-model.md), and a component is one of its two hosts: an actor
@@ -11,13 +18,6 @@ against `NativeActor`.
 This page is the wasm-specific machinery — read the [actor model](../foundations/actor-model.md)
 page first for how you actually *write* one; everything below is what's different
 because the actor lives across an FFI boundary and is loaded into a running engine.
-
-> Governing ADRs: **ADR-0074** (one actor model, two hosts), **ADR-0024** (the
-> dual-target FFI convention), **ADR-0028 / ADR-0033** (the kind + handler
-> manifests in the wasm), **ADR-0090** (boot config), **ADR-0022 / ADR-0038**
-> (in-place hot-swap). The authoring and loading surface here is **stable** — it's
-> what every reference component (`aether-camera`, `aether-mesh-viewer`) is built
-> on, and the signatures were read from the current SDK.
 
 ## `export!` and the FFI boundary
 

--- a/docs/guide/systems/concurrency.md
+++ b/docs/guide/systems/concurrency.md
@@ -1,11 +1,5 @@
 # Concurrency & blocking
 
-The invariants page states three contracts as rules: an actor is single-threaded
-from its own perspective, mail is per-recipient FIFO, and a handler must never
-block. This page is the machinery behind them — how the scheduler makes the
-first two hold, why the third is non-negotiable, and what you do *instead* of
-blocking when a handler needs to wait.
-
 > Governing ADRs: **ADR-0087** (the blob dispatch model + scheduler), **ADR-0093**
 > (the hold-until-resolve offload primitive), **ADR-0080** (settlement). The
 > *contracts* on this page — single-threaded actors, per-recipient FIFO, no
@@ -15,6 +9,12 @@ blocking when a handler needs to wait.
 > them — so treat this section as the *shape*, not a spec, and read
 > `aether-substrate` (and ADR-0087) for the current mechanism. Build on the
 > contracts, not the internals.
+
+The invariants page states three contracts as rules: an actor is single-threaded
+from its own perspective, mail is per-recipient FIFO, and a handler must never
+block. This page is the machinery behind them — how the scheduler makes the
+first two hold, why the third is non-negotiable, and what you do *instead* of
+blocking when a handler needs to wait.
 
 ## The model: cooperative scheduling
 

--- a/docs/guide/systems/mail-and-kinds.md
+++ b/docs/guide/systems/mail-and-kinds.md
@@ -1,5 +1,11 @@
 # Mail, kinds & scheduling
 
+> Governing ADRs: **ADR-0002** (mail-first actor model), **ADR-0005** (mail
+> typing), **ADR-0019** (unified encoding), **ADR-0087** (blob dispatch + the
+> ordering spine). The mail/kind model is **stable**; the *scheduler internals*
+> (how work is batched and balanced across threads) are **settling** — this
+> page documents the stable contract and defers the guts to ADR-0087.
+
 This is the spine the rest of the engine hangs on. Actors don't call each
 other — they send **mail**. A piece of mail is a typed payload (a *kind*)
 addressed to a *mailbox*, and the scheduler runs the handlers. Understand this
@@ -17,12 +23,6 @@ C / C++ / other guest that speaks the ABI is the same category. All of them are
 one actor model and address each other identically. When this page says
 "component" it means a loaded FFI actor; "actor" means either kind. Deep dive:
 [Components & lifecycle]().
-
-> Governing ADRs: **ADR-0002** (mail-first actor model), **ADR-0005** (mail
-> typing), **ADR-0019** (unified encoding), **ADR-0087** (blob dispatch + the
-> ordering spine). The mail/kind model is **stable**; the *scheduler internals*
-> (how work is batched and balanced across threads) are **settling** — this
-> page documents the stable contract and defers the guts to ADR-0087.
 
 ## Why it exists
 

--- a/docs/guide/systems/tracing-and-settlement.md
+++ b/docs/guide/systems/tracing-and-settlement.md
@@ -1,5 +1,14 @@
 # Tracing & settlement
 
+> **Governing ADRs:** [ADR-0080](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0080-substrate-mail-tracing-and-settlement.md) (mail lineage + settlement detection),
+> [ADR-0086](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0086-decouple-settlement-from-trace.md) (settlement decoupled from the trace stream),
+> [ADR-0093](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0093-hold-until-resolve-dispatch-primitive.md) (hold-until-resolve dispatch),
+> [ADR-0094](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0094-settlement-obligation-guard.md) (the owned-dispatch obligation guard). The **contract**
+> — what "settled" means and what you must uphold for it — is **stable**. The
+> **mechanism** that delivers it (the emit-time per-root counter, the per-actor
+> trace rings, the guided walk that rebuilds a tree) is **settling**, so this page
+> documents the contract and defers the internals to those ADRs.
+
 Send one mail and the handler that receives it may send more, and those handlers
 more again — a single message fans out into a cascade of downstream work.
 **Settlement** is the engine's answer to the question that cascade raises: *has
@@ -13,15 +22,6 @@ before it reads a frame or sends the next thing, and on the trace tree to see
 *why* an exchange was slow or *where* a chain stalled. An author writing a
 capability or component needs the model because a handler that replies late owes
 its chain an obligation — miss it and a caller hangs with nothing named.
-
-> **Governing ADRs:** [ADR-0080](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0080-substrate-mail-tracing-and-settlement.md) (mail lineage + settlement detection),
-> [ADR-0086](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0086-decouple-settlement-from-trace.md) (settlement decoupled from the trace stream),
-> [ADR-0093](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0093-hold-until-resolve-dispatch-primitive.md) (hold-until-resolve dispatch),
-> [ADR-0094](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0094-settlement-obligation-guard.md) (the owned-dispatch obligation guard). The **contract**
-> — what "settled" means and what you must uphold for it — is **stable**. The
-> **mechanism** that delivers it (the emit-time per-root counter, the per-actor
-> trace rings, the guided walk that rebuilds a tree) is **settling**, so this page
-> documents the contract and defers the internals to those ADRs.
 
 ## Why it exists
 


### PR DESCRIPTION
Moves the **Governing ADR** blockquote to sit directly below the page header on every guide page that has one, ahead of the intro prose — so the ADR/maturity metadata reads as a header box rather than appearing after the opening paragraphs.

Position-only sweep across the seven pages whose box sat after the intro:

- foundations/actor-model.md
- foundations/type-system.md
- mcp-harness.md
- systems/components.md
- systems/concurrency.md
- systems/mail-and-kinds.md
- systems/tracing-and-settlement.md

(configuration.md already has the box on top, in its own PR #1369; invariants.md is left as-is — its first blockquote is a concurrency-disambiguation + maturity note, not a Governing-ADR box, and reads better after the "what is an invariant" opener.)

No prose changed beyond block order; the link + bold-label standardization of those boxes stays tracked in #1368. Docs-only; `mdbook build` clean. Part of #1355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
