### PR TITLE
docs(guide): link ADR references to their sources across the guide

### DIFF
--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -35,7 +35,7 @@ establish where everything sits.
 
 Everything inside the substrate is an **actor**, and actors only ever talk by
 **mail**. The native capabilities and the wasm components are the *same actor
-model* (ADR-0074) — the renderer is an actor, your component is an actor, and
+model* ([ADR-0074](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0074-unified-actor-model-for-substrate-and-guests.md)) — the renderer is an actor, your component is an actor, and
 they address each other identically.
 
 ## The crates
@@ -48,11 +48,11 @@ Two layers: infrastructure (describes and moves typed bytes) and runtime
 | Crate | Role |
 |---|---|
 | `aether-data` | The universal data layer (`no_std`). Typed-id newtypes (`MailboxId`, `KindId`, `HandleId`), wire identity, the schema vocabulary (`SchemaType`, `KindShape`), the `Kind` / `Schema` traits, `Ref<K>`, encode/decode, and the native descriptor/transform inventories. Everything that describes typed bytes depends on it. |
-| `aether-codec` | Schema-driven JSON ↔ wire bytes (`encode_schema` / `decode_schema`) plus postcard stream framing (ADR-0072). |
+| `aether-codec` | Schema-driven JSON ↔ wire bytes (`encode_schema` / `decode_schema`) plus postcard stream framing ([ADR-0072](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0072-fold-hub-protocol-into-codec-and-hub.md)). |
 | `aether-kinds` | The substrate kind vocabulary — `Tick`, `Key`, `WindowSize`, `DrawTriangle`, and the `aether.{audio,fs,render,window,input,component,camera,log,handle,dag}.*` families. |
 | `aether-math` | `Vec2/3/4`, `Mat4`, `Quat`, `Aabb` — column-major, right-handed Y-up, `f32`, `no_std`. Reach here before hand-rolling vector math. |
 
-**Runtime + chassis (ADR-0073):**
+**Runtime + chassis ([ADR-0073](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0073-substrate-cluster-consolidation.md)):**
 
 | Crate | Role |
 |---|---|
@@ -61,7 +61,7 @@ Two layers: infrastructure (describes and moves typed bytes) and runtime
 | `aether-substrate-bundle` | The four chassis as submodules (`desktop` / `headless` / `hub` / `test_bench`) with one binary each, plus the hub library and its wire vocabulary. |
 | `aether-actor` | The guest/actor SDK: the `Actor` / `FfiActor` traits, `Mailbox<K>`, `FfiCtx`, the `#[actor]` macro, and `export!`. |
 
-**The harness (out-of-process, ADR-0089):** `aether-tunnel` (the stable MCP
+**The harness (out-of-process, [ADR-0089](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0089-mcp-hub-lifecycle-tunnel.md)):** `aether-tunnel` (the stable MCP
 front that supervises and re-forks the volatile backends), `aether-mcp` (the
 RPC client that relays each tool call as a wire `Call`), and the hub inside
 `aether-substrate-bundle`.
@@ -78,16 +78,16 @@ Trace one `send_mail` from the agent:
 1. **Tool call.** The agent calls `send_mail` with
    `{engine_id, recipient_name, kind_name, params}`. `aether-mcp` looks up the
    kind's schema and **encodes `params` (JSON) into wire bytes** against the
-   substrate vocabulary (ADR-0007), producing a wire `Call`.
+   substrate vocabulary ([ADR-0007](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0007-schema-driven-mail-at-hub.md)), producing a wire `Call`.
 2. **Route to the engine.** The hub forwards the `Call` to the right substrate
-   over the channel (ADR-0034/0037). The ids on the wire are type-tagged
-   strings (`mbx-…`, `knd-…`), so nothing is guessed (ADR-0064/0065).
+   over the channel ([ADR-0034](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0034-hub-as-substrate.md)/[ADR-0037](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0037-mail-bubbles-up-to-hub-substrate.md)). The ids on the wire are type-tagged
+   strings (`mbx-…`, `knd-…`), so nothing is guessed ([ADR-0064](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0064-type-tagged-opaque-ids-on-the-mcp-wire.md)/[ADR-0065](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0065-typed-id-newtypes-and-first-class-type-ids-in-the-schema.md)).
 3. **Schedule.** The substrate's scheduler hands the mail to the addressed
-   actor as part of a *blob* of work (ADR-0087). Each actor is single-threaded
+   actor as part of a *blob* of work ([ADR-0087](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0087-blob-unit-of-dispatch.md)). Each actor is single-threaded
    from its own perspective — no locks in actor state.
 4. **Decode + dispatch.** The actor decodes the bytes back into the kind and
    the `#[actor]`-generated dispatch table routes it to the handler whose
-   third parameter is that kind (ADR-0033). No typelist, no `is::<K>()`.
+   third parameter is that kind ([ADR-0033](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0033-handler-driven-inputs-manifest.md)). No typelist, no `is::<K>()`.
 5. **Effects and replies.** The handler does its work — maybe sending more
    mail (`ctx.actor::<RenderCapability>().send(&kind)`), maybe replying. Mail
    is **fire-and-forget unless a reply kind is part of the contract**; a
@@ -95,10 +95,10 @@ Trace one `send_mail` from the agent:
 
 Two cross-cutting systems watch this flow without it opting in:
 
-- **Tracing & settlement** (ADR-0080/0086): a traced batch shares a trace root
+- **Tracing & settlement** ([ADR-0080](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0080-substrate-mail-tracing-and-settlement.md)/[ADR-0086](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0086-decouple-settlement-from-trace.md)): a traced batch shares a trace root
   and the agent gets the full subtree once the chain *settles* — no polling, no
-  window-guessing. Settlement is exact via a hold contract (ADR-0093/0094).
-- **Per-actor logging** (ADR-0081): each actor has its own log ring, queryable
+  window-guessing. Settlement is exact via a hold contract ([ADR-0093](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0093-hold-until-resolve-dispatch-primitive.md)/[ADR-0094](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0094-settlement-obligation-guard.md)).
+- **Per-actor logging** ([ADR-0081](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0081-decentralized-per-actor-log-storage.md)): each actor has its own log ring, queryable
   by mailbox name through `actor_logs`.
 
 ## How an agent reaches all this

--- a/docs/guide/foundations/actor-model.md
+++ b/docs/guide/foundations/actor-model.md
@@ -1,8 +1,8 @@
 # The actor model
 
-> Governing ADR: **ADR-0074** (the unified actor model — capabilities and
-> components are one model, not two) with **ADR-0079** (the lifecycle stages)
-> and **ADR-0033** (the `#[actor]` macro). This model is **stable**; it's the
+> **Governing ADR:** [ADR-0074](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0074-unified-actor-model-for-substrate-and-guests.md) (the unified actor model — capabilities and
+> components are one model, not two) with [ADR-0079](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0079-instanced-actors-as-a-first-class-category.md) (the lifecycle stages)
+> and [ADR-0033](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0033-handler-driven-inputs-manifest.md) (the `#[actor]` macro). This model is **stable**; it's the
 > spine everything else hangs off. Signatures here were read from the current SDK
 > (`aether-actor`) and runtime (`aether-substrate`).
 
@@ -47,7 +47,7 @@ this page stays with the actor on the receiving end: how it's built and how it r
 ## The lifecycle
 
 Every actor — regardless of host — moves through the same three authored stages
-(ADR-0079). Each stage gets a different context, and the context *is* the
+([ADR-0079](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0079-instanced-actors-as-a-first-class-category.md)). Each stage gets a different context, and the context *is* the
 contract: it's exactly what you're permitted to do at that point.
 
 | stage | when | ctx allows | use it for |
@@ -238,7 +238,7 @@ An **instanced** actor is one of many sharing a prefix. Its `NAMESPACE` is that
 prefix, and each live instance has a full name `NAMESPACE:subname` — for example
 `aether.net.session:42`. The case that drives this is sockets: a singleton listener
 accepts connections and spawns a session actor per connection with `ctx.spawn_child`
-(ADR-0079), then reaches a specific one by subname,
+([ADR-0079](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0079-instanced-actors-as-a-first-class-category.md)), then reaches a specific one by subname,
 `ctx.resolve_actor::<SessionActor>("42")`.
 
 Spawning children on demand like that is a **native** facility — `spawn_child` is
@@ -253,7 +253,7 @@ single loaded component is, underneath, one instance of an instanced host.
 
 Here's the part that ties the engine together. There aren't two actor systems —
 there's **one model with two hosts**, differing in where the actor's code lives and
-how it reaches the outside world (ADR-0074):
+how it reaches the outside world ([ADR-0074](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0074-unified-actor-model-for-substrate-and-guests.md)):
 
 - A **native capability** is an actor compiled *into* the substrate, implementing
   `NativeActor` and linked at build time. It's the host an actor takes when what it
@@ -290,7 +290,7 @@ impl NativeActor for AudioCapability {
 Because the only coupling is mail, an actor can't tell whether the mailbox it
 sends to is backed by native Rust or sandboxed wasm — and doesn't need to. A
 component sends `aether.render` a `DrawTriangle` exactly as one capability sends
-another. This symmetry is the point of ADR-0074: one mental model, one macro, one
+another. This symmetry is the point of [ADR-0074](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0074-unified-actor-model-for-substrate-and-guests.md): one mental model, one macro, one
 lifecycle, and components get to reuse every pattern capabilities use.
 
 So **start here, with the actor**, and the two host pages are just specializations:

--- a/docs/guide/foundations/invariants.md
+++ b/docs/guide/foundations/invariants.md
@@ -23,14 +23,14 @@ It splits in two:
 > Maturity: the addressing, typing, and identity invariants are **stable** —
 > they've held since the model's early ADRs and the wire format depends on them.
 > Settlement is **stable as a contract** while its transport is still settling
-> (ADR-0086). Scheduler internals are **settling** (ADR-0087) — but the
+> ([ADR-0086](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0086-decouple-settlement-from-trace.md)). Scheduler internals are **settling** ([ADR-0087](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0087-blob-unit-of-dispatch.md)) — but the
 > concurrency *contracts* below are stable regardless of how dispatch is tuned.
 
 ## What the engine guarantees you
 
 **Mail is the only channel between actors.** No actor holds a reference into
 another actor's memory — no shared mutable state crosses the boundary, so a
-peer's data can't be read or mutated directly (ADR-0002). An actor's entire
+peer's data can't be read or mutated directly ([ADR-0002](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0002-mail-first-architecture.md)). An actor's entire
 interaction with the rest of the engine is the mail it sends and the mail it
 receives. The *enforcement* differs by actor kind: a loaded component can't even
 form such a reference (the sandbox gives it its own linear memory), while a
@@ -47,53 +47,53 @@ independently.** The mailbox decides *where* mail goes; the kind only describes
 kind. Hold these apart and most "my mail vanished" confusion disappears.
 
 **Identity is name-derived and stable.** A `MailboxId` is a deterministic hash
-of the mailbox name (FNV-1a 64, ADR-0029); a `KindId` is a hash of the kind name
-*plus its schema* (ADR-0030). Two consequences you can lean on:
+of the mailbox name (FNV-1a 64, [ADR-0029](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0029-name-derived-mailbox-ids.md)); a `KindId` is a hash of the kind name
+*plus its schema* ([ADR-0030](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0030-hashed-kind-ids.md)). Two consequences you can lean on:
 
 - **Stable across processes.** Two substrates that hash the same name produce
   the same id, so addressing works across a fleet without a resolution
   round-trip — `Kind::ID` and `mailbox_id_from_name` are compile-time constants.
 - **Stable across hot-swap.** Because the id is derived from the name, replacing
   a component in place keeps its mailbox id valid — senders and route caches
-  survive the swap (ADR-0029; the `replace_component_preserves_mailbox_identity`
+  survive the swap ([ADR-0029](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0029-name-derived-mailbox-ids.md); the `replace_component_preserves_mailbox_identity`
   scenario guards it).
 
 **A kind id encodes its shape — drift fails loud, not silently.** The `KindId`
 hashes `name + schema`, where `name` is the kind's *declared* name
 (`#[kind(name = "…")]`) and `schema` is its *structural shape* — field types and
 positions only. The Rust type name and the field names are deliberately erased
-from the hash (ADR-0031/0032), so they're not what's being compared. What that
+from the hash ([ADR-0031](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0031-const-constructible-schema-representation.md)/[ADR-0032](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0032-canonical-schema-bytes-and-labels-sidecar.md)), so they're not what's being compared. What that
 buys: a producer emitting `Thing { a }` and a consumer expecting
 `Thing { a, b }` compute *different* ids, so the stale mail lands on "kind not
-found" and can never silently garbage-decode into the wrong shape (ADR-0030).
+found" and can never silently garbage-decode into the wrong shape ([ADR-0030](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0030-hashed-kind-ids.md)).
 The fix for a mismatch is always "recompile both sides," and the failure points
 straight at it. (Exactly which edits move the id — and which, like a field
 rename, leave it untouched — is the type system's story: [The type system]().)
 
 **A kind is self-describing.** Every kind carries a schema describing its bytes
-(ADR-0005/0031), so the wire layer can encode it from JSON and a recipient can
+([ADR-0005](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0005-mail-typing-system.md)/[ADR-0031](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0031-const-constructible-schema-representation.md)), so the wire layer can encode it from JSON and a recipient can
 decode it without a shared header — and a live engine can be asked what kinds
 exist (`describe_kinds`). Payload bytes stay opaque in transit: nothing between
-sender and the addressed handler needs to understand them (ADR-0019).
+sender and the addressed handler needs to understand them ([ADR-0019](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0019-unified-mail-encoding.md)).
 
 **An actor is single-threaded from its own perspective.** An actor's handlers
 never run concurrently with each other, so its state is plain fields — no
 `Mutex`, no `RefCell`, no atomics for actor-local state. This holds even though
 actors do *not* each own a thread: they're multiplexed onto a shared
 work-stealing scheduler, and a run-token guarantees only one worker runs a given
-actor at a time (ADR-0087). The property is achieved by scheduling, not by a
+actor at a time ([ADR-0087](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0087-blob-unit-of-dispatch.md)). The property is achieved by scheduling, not by a
 dedicated thread.
 
 **Per-recipient FIFO; cross-recipient unordered.** Mail from the same sender to
 the same recipient arrives in send order. Mail to *different* recipients carries
-no ordering guarantee — each send is an independent async call (ADR-0087). This
+no ordering guarantee — each send is an independent async call ([ADR-0087](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0087-blob-unit-of-dispatch.md)). This
 is the single contract most likely to bite under load; the *what you must
 uphold* section restates it as a rule.
 
 **Settlement is exact.** A traced chain of mail is reported `Settled` exactly
 when `in_flight == 0 && held_open == 0` — the counter does not transiently reach
 zero with work still coming, so `Settled` fires once and is a fact, not a hint
-(ADR-0080 §6, as amended; ADR-0086). This is what lets `send_mail_traced` know a
+([ADR-0080](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0080-substrate-mail-tracing-and-settlement.md) §6, as amended; [ADR-0086](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0086-decouple-settlement-from-trace.md)). This is what lets `send_mail_traced` know a
 request is *fully* done rather than guessing with a timeout. It depends on the
 hold contract below being honoured.
 
@@ -102,7 +102,7 @@ actor can *do* is exactly what it can *mail*; there is no back door, not even fo
 the agent driving the engine. Gating a build is just choosing which mailboxes
 are registered. The payoff is the point: because every function is reachable as
 mail, you can interpose anywhere — address any mailbox, watch any exchange,
-inject a message mid-flow to reproduce a state (ADR-0002). Universal
+inject a message mid-flow to reproduce a state ([ADR-0002](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0002-mail-first-architecture.md)). Universal
 reachability is what makes the running engine inspectable.
 
 ## What you must uphold
@@ -142,16 +142,16 @@ never agreed to send.
 that will reply in a *later* turn (a slow provider call whose result lands after
 the handler returns), it must keep a settlement hold on the root until that last
 send — otherwise the chain settles early and any waiter is told "done" before
-the real reply arrives (ADR-0080 §12; ADR-0093). Synchronous in-handler replies
+the real reply arrives ([ADR-0080](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0080-substrate-mail-tracing-and-settlement.md) §12; [ADR-0093](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0093-hold-until-resolve-dispatch-primitive.md)). Synchronous in-handler replies
 need nothing (their `Sent` precedes their `Finished`); the sanctioned offload
 primitives hold automatically. A hand-rolled drain that consumes an owned
 dispatch must record `Finished` for the inbound mail id, or settlement never
-fires (ADR-0094). *Tell:* a multi-second hang to the settlement/MCP timeout with
+fires ([ADR-0094](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0094-settlement-obligation-guard.md)). *Tell:* a multi-second hang to the settlement/MCP timeout with
 no actor named.
 
 **On a kind's schema change, recompile both sides.** A schema edit changes the
 `KindId`. Until the peer is rebuilt, its `Kind::ID` no longer matches what you
-registered and its mail lands on "kind not found" (ADR-0030) — and prebuilt
+registered and its mail lands on "kind not found" ([ADR-0030](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0030-hashed-kind-ids.md)) — and prebuilt
 component wasm carries the *old* id, so rebuild it after any chassis-side kind or
 mailbox-name change. *Tell:* "observed kinds: []", or mail that used to route
 now missing after one side changed.

--- a/docs/guide/foundations/type-system.md
+++ b/docs/guide/foundations/type-system.md
@@ -1,9 +1,9 @@
 # The type system
 
-> Governing ADRs: **ADR-0005** (mail typing), **ADR-0019** (unified encoding),
-> **ADR-0029/0030** (name- and schema-derived ids), **ADR-0031/0032** (const
-> schema + canonical bytes / labels sidecar), **ADR-0045/0048/0049** (handles,
-> transforms, the handle store), **ADR-0064/0065** (type-tagged wire ids +
+> **Governing ADRs:** [ADR-0005](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0005-mail-typing-system.md) (mail typing), [ADR-0019](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0019-unified-mail-encoding.md) (unified encoding),
+> [ADR-0029](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0029-name-derived-mailbox-ids.md)/[ADR-0030](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0030-hashed-kind-ids.md) (name- and schema-derived ids), [ADR-0031](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0031-const-constructible-schema-representation.md)/[ADR-0032](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0032-canonical-schema-bytes-and-labels-sidecar.md) (const
+> schema + canonical bytes / labels sidecar), [ADR-0045](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0045-computation-dag-and-typed-handles.md)/[ADR-0048](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0048-transforms-and-content-addressed-handles.md)/[ADR-0049](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0049-persistent-handle-store.md) (handles,
+> transforms, the handle store), [ADR-0064](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0064-type-tagged-opaque-ids-on-the-mcp-wire.md)/[ADR-0065](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0065-typed-id-newtypes-and-first-class-type-ids-in-the-schema.md) (type-tagged wire ids +
 > first-class id types). The type vocabulary is **stable** — the wire format
 > depends on it. The DAG composition surface that handles and transforms feed is
 > **shipped and settling** (its 0.4 stack merged).
@@ -35,7 +35,7 @@ struct NoteOn { instrument: u8, pitch: u8, velocity: f32 }
 **Two derives, because they describe two different things.**
 
 - **`Schema`** gives `const SCHEMA: SchemaType` — a description of the type's
-  byte *layout* (ADR-0031). It's compositional: every type that can sit inside a
+  byte *layout* ([ADR-0031](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0031-const-constructible-schema-representation.md)). It's compositional: every type that can sit inside a
   payload implements it — the primitives, `String`, `Vec<T>`, `Option<T>`,
   arrays, and your own structs — so a struct's schema is assembled from its
   fields'. A type that only ever appears as a *field* of a kind derives `Schema`
@@ -59,14 +59,14 @@ derive emits `<Self as Schema>::SCHEMA`, which recurses into
 type — including nested structs that are never mailed — has to implement `Schema`
 on its own, so `Schema` must be a standalone derive regardless. Given that,
 `Kind` *reads* the schema rather than recomputing it; merging the two would
-duplicate the schema walk that ADR-0031/0032 deliberately collapsed into one
+duplicate the schema walk that [ADR-0031](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0031-const-constructible-schema-representation.md)/[ADR-0032](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0032-canonical-schema-bytes-and-labels-sidecar.md) deliberately collapsed into one
 trait-dispatched path. (It's the `Serialize` / `Deserialize` split: one trait,
 one derive.)
 
 Because `ID` and `SCHEMA` are `const`, there is no host round-trip to learn a
 kind's identity or shape — `Kind::ID` is a compile-time value. And because the
 schema travels with the type, the wire layer can encode a kind from JSON and a
-recipient can decode it without a shared header (ADR-0019). On the wire a
+recipient can decode it without a shared header ([ADR-0019](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0019-unified-mail-encoding.md)). On the wire a
 `#[repr(C)]` plain-data kind rides as a raw byte cast; everything else as
 postcard — the derive autodetects from the type's layout, so a single
 `send` / `reply` call site handles both.
@@ -75,7 +75,7 @@ postcard — the derive autodetects from the type's layout, so a single
 schema`, where `name` is the declared kind name and `schema` is the *structural*
 shape — field types and positions. All nominal information (the Rust type name,
 field names, variant names) is erased from the hashed bytes and carried in a
-parallel labels sidecar instead (ADR-0031/0032). So:
+parallel labels sidecar instead ([ADR-0031](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0031-const-constructible-schema-representation.md)/[ADR-0032](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0032-canonical-schema-bytes-and-labels-sidecar.md)). So:
 
 | edit | id changes? | why |
 |---|---|---|
@@ -119,14 +119,14 @@ worth knowing beyond "it's a type tree":
   hashing and for the `aether.kinds` manifest, field and variant names are
   dropped; a separate labels sidecar (`aether.kinds.labels`) carries them for
   consumers that want human-readable reconstruction, like `describe_kinds`
-  (ADR-0032). The wire never carries names — postcard fields are positional.
+  ([ADR-0032](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0032-canonical-schema-bytes-and-labels-sidecar.md)). The wire never carries names — postcard fields are positional.
 - **`Ref` is a schema arm.** A field whose type is `Ref<K>` is a *handle-or-
   inline* slot — see *Handles* below. The
   schema wraps the inner kind's shape, so a recipient decodes the resolved value
   the same way whether it arrived inline or via the store.
 - **`TypeId` is a schema arm.** A kind can have a field that *is* an id — a
   `MailboxId`, `KindId`, or `HandleId` as a first-class typed reference, not just
-  a bare `u64` (ADR-0065). These encode as a tagged string on JSON and a varint
+  a bare `u64` ([ADR-0065](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0065-typed-id-newtypes-and-first-class-type-ids-in-the-schema.md)). These encode as a tagged string on JSON and a varint
   on the wire.
 
 ### What counts as the same kind
@@ -164,7 +164,7 @@ cases that surprise people live at the schema-arm level. Holding the
 ## Mailboxes — typed addresses
 
 A **mailbox** is an address: where mail goes. Its `MailboxId` is a 64-bit hash
-of the mailbox *name* alone (no schema — a mailbox is a pure address, ADR-0029),
+of the mailbox *name* alone (no schema — a mailbox is a pure address, [ADR-0029](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0029-name-derived-mailbox-ids.md)),
 so it's the same id in every process that hashes the same name, and it survives
 a component hot-swap. In a component you rarely touch the id directly: you
 address a peer by type (`ctx.actor::<RenderCapability>()`) or hold a `Mailbox<K>`
@@ -196,7 +196,7 @@ has to know which form arrived.
 
 Handle ids are **content-addressed** (the id is derived from the bytes, so two
 producers of the same value get the same handle and the store deduplicates,
-ADR-0048), and the store is **persistent** with a disk budget (ADR-0049 —
+[ADR-0048](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0048-transforms-and-content-addressed-handles.md)), and the store is **persistent** with a disk budget ([ADR-0049](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0049-persistent-handle-store.md) —
 inspect it with `describe_handles`). Handles are how the computation DAG passes
 values between steps without round-tripping them through an actor's memory; see
 [The computation DAG & handles]().
@@ -205,7 +205,7 @@ values between steps without round-tripping them through an actor's memory; see
 
 A **transform** is a pure function the DAG runs between steps — `#[transform] fn
 foo(input: A) -> B`, registered at build time with a `TransformId` and typed by
-its input and output kinds (ADR-0048). Where a kind is a value and a mailbox is
+its input and output kinds ([ADR-0048](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0048-transforms-and-content-addressed-handles.md)). Where a kind is a value and a mailbox is
 an address, a transform is a typed *edge*: it takes a resolved handle of one kind
 and writes a new handle of another. Inspect the linked set with
 `describe_transforms`. The DAG that wires sources, transforms, and outputs into a
@@ -217,10 +217,10 @@ Every typed thing is named by a newtype over a hash, not a bare integer:
 
 | id | wraps | derived from |
 |---|---|---|
-| `KindId` | `u64` | `name + schema` (ADR-0030) |
-| `MailboxId` | `u64` | mailbox name (ADR-0029) |
-| `HandleId` | `u64` | the stored bytes (content-addressed, ADR-0048) |
-| `TransformId` | `u64` | the transform's identity (ADR-0048) |
+| `KindId` | `u64` | `name + schema` ([ADR-0030](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0030-hashed-kind-ids.md)) |
+| `MailboxId` | `u64` | mailbox name ([ADR-0029](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0029-name-derived-mailbox-ids.md)) |
+| `HandleId` | `u64` | the stored bytes (content-addressed, [ADR-0048](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0048-transforms-and-content-addressed-handles.md)) |
+| `TransformId` | `u64` | the transform's identity ([ADR-0048](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0048-transforms-and-content-addressed-handles.md)) |
 | `DagId` | `u64` | an in-flight DAG job |
 | `EngineId`, `SessionToken` | `Uuid` | wire identity of an engine / session |
 
@@ -228,12 +228,12 @@ Two properties keep these from being foot-guns:
 
 - **Disjoint hash domains.** A kind id and a mailbox id are hashed with
   different domain prefixes, so the *same* name produces *different* ids in the
-  two spaces — the id spaces don't collide even when names are shared (ADR-0030).
+  two spaces — the id spaces don't collide even when names are shared ([ADR-0030](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0030-hashed-kind-ids.md)).
   This is the mechanical reason a kind name and a mailbox name can look alike yet
   address different things.
 - **Tagged strings on the MCP wire.** Across the agent boundary, ids encode as
   `<tag>-XXXX-XXXX-XXXX` — `mbx-…` for a mailbox, `knd-…` for a kind, `hdl-…` for
-  a handle (ADR-0064). The tag makes an id self-identifying, so a mailbox id and
+  a handle ([ADR-0064](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0064-type-tagged-opaque-ids-on-the-mcp-wire.md)). The tag makes an id self-identifying, so a mailbox id and
   a kind id can't be silently swapped in a tool call. **Hand these back
   verbatim** — they're opaque tokens, not numbers to parse.
 

--- a/docs/guide/mcp-harness.md
+++ b/docs/guide/mcp-harness.md
@@ -1,6 +1,6 @@
 # The MCP harness
 
-> Governing ADR: **ADR-0089** (the tunnel), over the per-subsystem ADRs the tools
+> **Governing ADR:** [ADR-0089](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0089-mcp-hub-lifecycle-tunnel.md) (the tunnel), over the per-subsystem ADRs the tools
 > front. The harness is **stable in shape** but its tools evolve — so treat this
 > page as the map and the mental model, not a parameter reference. Each tool's
 > exact arguments live in its own schema, which your MCP client shows you live;

--- a/docs/guide/philosophy.md
+++ b/docs/guide/philosophy.md
@@ -18,7 +18,7 @@ things happen.
 Consequences that follow from taking this seriously:
 
 - The control surface is **out-of-process and restartable** without dropping
-  the agent's session (ADR-0089). The agent must be able to rebuild and
+  the agent's session ([ADR-0089](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0089-mcp-hub-lifecycle-tunnel.md)). The agent must be able to rebuild and
   relaunch the volatile backends mid-task and keep its connection.
 - Observation is first-class. The agent can capture a frame, read an actor's
   logs, trace a mail chain, and inspect handles — because an operator that
@@ -26,7 +26,7 @@ Consequences that follow from taking this seriously:
 
 ## 2. Everything is mail
 
-Actors do not call each other. They **send mail** (ADR-0002). A piece of mail
+Actors do not call each other. They **send mail** ([ADR-0002](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0002-mail-first-architecture.md)). A piece of mail
 is a typed payload (a *kind*) addressed to a *mailbox*. This is the single
 most pervasive decision in the system, and it buys:
 
@@ -36,9 +36,9 @@ most pervasive decision in the system, and it buys:
 - **Location independence.** A mailbox might be a native capability, a wasm
   component, or a peer on another process reached through the hub — the
   sender addresses it the same way. Mail bubbles up to the hub when it isn't
-  local (ADR-0037).
+  local ([ADR-0037](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0037-mail-bubbles-up-to-hub-substrate.md)).
 - **Observability for free.** Because all interaction is mail, the tracing and
-  settlement machinery (ADR-0080/0086) can watch *all* of it without each
+  settlement machinery ([ADR-0080](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0080-substrate-mail-tracing-and-settlement.md)/[ADR-0086](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0086-decouple-settlement-from-trace.md)) can watch *all* of it without each
   subsystem opting in.
 
 Mail is **fire-and-forget by default.** A handler promises nothing about a
@@ -49,8 +49,8 @@ implicit "every kind has a response."
 
 The native base layer is deliberately small. It owns I/O, GPU, audio, the
 mail scheduler, and the wasm host — and little else. Game and tool behavior
-lives **above** it, as actors (ADR-0034/0035/0073). Two kinds of actor, one
-model (ADR-0074):
+lives **above** it, as actors ([ADR-0034](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0034-hub-as-substrate.md)/[ADR-0035](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0035-substrate-chassis-split.md)/[ADR-0073](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0073-substrate-cluster-consolidation.md)). Two kinds of actor, one
+model ([ADR-0074](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0074-unified-actor-model-for-substrate-and-guests.md)):
 
 - **Native chassis capabilities** — render, audio, file I/O, input, the
   component loader, the handle store. Compiled into the substrate.
@@ -62,7 +62,7 @@ is intentional and defended: prefer a design that treats wasm and native
 uniformly over one that special-cases the target.
 
 The chassis is **composed**, not monolithic — a builder assembles the
-capabilities a given deployment needs (ADR-0070/0071), which is why there are
+capabilities a given deployment needs ([ADR-0070](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0070-native-capabilities-and-chassis-as-builder.md)/[ADR-0071](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0071-driver-capabilities-and-chassis-composition.md)), which is why there are
 several chassis (desktop, headless, hub, test-bench) sharing one runtime.
 
 ## 4. Design for machine consumers
@@ -72,8 +72,8 @@ being legible to a human. Where human API design prizes terseness and DRY,
 aether's surfaces prize being **regular, explicit, self-describing, and
 repetition-tolerant**:
 
-- Kinds carry their own schema (ADR-0031/0032) and ids are type-tagged on the
-  wire (ADR-0064/0065), so a tool result can be handed back verbatim and a
+- Kinds carry their own schema ([ADR-0031](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0031-const-constructible-schema-representation.md)/[ADR-0032](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0032-canonical-schema-bytes-and-labels-sidecar.md)) and ids are type-tagged on the
+  wire ([ADR-0064](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0064-type-tagged-opaque-ids-on-the-mcp-wire.md)/[ADR-0065](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0065-typed-id-newtypes-and-first-class-type-ids-in-the-schema.md)), so a tool result can be handed back verbatim and a
   kind can describe itself.
 - Prefer **explicit nulls over absent-field semantics** — every option
   addressed in a payload, because verbosity is nearly free for a machine
@@ -86,7 +86,7 @@ repetition-tolerant**:
 
 Two habits keep the system honest as it grows:
 
-- **Load-bearing decisions are recorded as ADRs** (ADR-0001) — numbered,
+- **Load-bearing decisions are recorded as ADRs** ([ADR-0001](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0001-record-architecture-decisions.md)) — numbered,
   reviewed like code, and cited from the code and from this guide. The ADR is
   the durable "why." When in doubt, the ADR wins over prose that has drifted.
 - **Every callable surface ships a tutorial, and the tutorial is the sanity

--- a/docs/guide/recipes.md
+++ b/docs/guide/recipes.md
@@ -13,7 +13,7 @@ This section is the home for the agent-recipe corpus
 
 The motivating failure: an agent reached for a raw `env::var(...).parse()` to
 add a tuning knob, when the blessed path was the layered config API
-(ADR-0090). The "why" was in an ADR and the "that it exists" was in `CLAUDE.md`,
+([ADR-0090](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0090-application-configuration.md)). The "why" was in an ADR and the "that it exists" was in `CLAUDE.md`,
 but **nobody showed the steps**. A recipe titled *Adding a config knob* — the
 `derive(Config)` → emitted overlay → `from_argv_then_env` → wire into the
 chassis CLI → add to the `--config` dump — would have made the right path the
@@ -55,7 +55,7 @@ These are drafted in the nav and land in subsequent PRs. The first is *Adding a
 config knob* — the pattern is shipped and proven, and it's the freshest worked
 example.
 
-- **Adding a config knob** (recompile) — the ADR-0090 layered-config dance.
+- **Adding a config knob** (recompile) — the [ADR-0090](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0090-application-configuration.md) layered-config dance.
 - **Adding a substrate kind** (recompile) — `aether-kinds` → inventory
   descriptor → MCP surface → tests, end to end.
 - **Adding a chassis capability** (recompile) — a native actor, its mailbox,

--- a/docs/guide/systems/components.md
+++ b/docs/guide/systems/components.md
@@ -1,8 +1,8 @@
 # Components & lifecycle
 
-> Governing ADRs: **ADR-0074** (one actor model, two hosts), **ADR-0024** (the
-> dual-target FFI convention), **ADR-0028 / ADR-0033** (the kind + handler
-> manifests in the wasm), **ADR-0090** (boot config), **ADR-0022 / ADR-0038**
+> **Governing ADRs:** [ADR-0074](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0074-unified-actor-model-for-substrate-and-guests.md) (one actor model, two hosts), [ADR-0024](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0024-dual-target-host-fn-ffi.md) (the
+> dual-target FFI convention), [ADR-0028](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0028-component-embedded-kind-manifest.md) / [ADR-0033](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0033-handler-driven-inputs-manifest.md) (the kind + handler
+> manifests in the wasm), [ADR-0090](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0090-application-configuration.md) (boot config), [ADR-0022](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0022-drain-on-swap.md) / [ADR-0038](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0038-actor-per-component-dispatch.md)
 > (in-place hot-swap). The authoring and loading surface here is **stable** — it's
 > what every reference component (`aether-camera`, `aether-mesh-viewer`) is built
 > on, and the signatures were read from the current SDK.
@@ -42,7 +42,7 @@ custom sections**:
 
 You never write `extern "C"` by hand. The `_p32` suffix on the pointer-taking
 exports (`receive_p32`, `on_rehydrate_p32`) is the dual-target FFI convention
-(ADR-0024): wasm32 addresses are 32-bit, so those shims take `u32` pointers and
+([ADR-0024](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0024-dual-target-host-fn-ffi.md)): wasm32 addresses are 32-bit, so those shims take `u32` pointers and
 lengths. The exports are **wasm32-only** — a native (host) build of the same crate
 carries no FFI symbols, which is why a host-side test of a component drives it
 through the in-process transport rather than the FFI path.
@@ -69,13 +69,13 @@ In practice you drive this through the MCP harness — `load_component(engine_id
 binary_path, name?)`, `replace_component(...)`, `terminate_substrate(...)` — which
 takes a **path** and reads the bytes for you (tool JSON never carries the wasm
 buffer; the wire kind does). The component's kind vocabulary travels inside the
-wasm's `aether.kinds` custom section (ADR-0028), so the loader declares nothing —
+wasm's `aether.kinds` custom section ([ADR-0028](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0028-component-embedded-kind-manifest.md)), so the loader declares nothing —
 the substrate reads the types directly off the binary.
 
 ## Boot configuration across the boundary
 
 A component takes typed boot config the same way a capability does — declare a
-`type Config` and the chassis threads it into `init` (ADR-0090). What's
+`type Config` and the chassis threads it into `init` ([ADR-0090](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0090-application-configuration.md)). What's
 wasm-specific is the *carrier*: the config rides as raw bytes on
 `LoadComponent.config`, encoded at the hub / MCP edge (SDK-typed, not wire-typed),
 so the substrate stays byte-transparent and never needs the config's Rust type.
@@ -105,7 +105,7 @@ impl Replaceable for MyComponent {
 aether_actor::export!(MyComponent, replaceable);
 ```
 
-`aether.component.replace` (ADR-0022) freezes the target mailbox, **drains
+`aether.component.replace` ([ADR-0022](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0022-drain-on-swap.md)) freezes the target mailbox, **drains
 in-flight mail through the old instance**, calls `on_replace` on it (its chance to
 serialize state via the `Persistence` ctx), instantiates the new wasm module
 **behind the same binding**, and calls `on_rehydrate` on the new instance with the
@@ -114,7 +114,7 @@ fails and the **old instance stays bound** — a failed swap is a no-op, not a
 half-swapped actor. `ReplaceResult::Ok` carries the new component's capabilities so
 the hub's cached view reflects the swapped binary.
 
-The load-bearing property is **binding stability** (ADR-0038): the swap replaces
+The load-bearing property is **binding stability** ([ADR-0038](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0038-actor-per-component-dispatch.md)): the swap replaces
 the wasm Module *in place* behind a stable mailbox handle, so the mailbox id, any
 route cache, and existing input subscriptions all stay valid across the swap. Peers
 mailing the component never learn it changed. Prefer `save_state_kind` (which

--- a/docs/guide/systems/concurrency.md
+++ b/docs/guide/systems/concurrency.md
@@ -1,13 +1,13 @@
 # Concurrency & blocking
 
-> Governing ADRs: **ADR-0087** (the blob dispatch model + scheduler), **ADR-0093**
-> (the hold-until-resolve offload primitive), **ADR-0080** (settlement). The
+> **Governing ADRs:** [ADR-0087](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0087-blob-unit-of-dispatch.md) (the blob dispatch model + scheduler), [ADR-0093](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0093-hold-until-resolve-dispatch-primitive.md)
+> (the hold-until-resolve offload primitive), [ADR-0080](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0080-substrate-mail-tracing-and-settlement.md) (settlement). The
 > *contracts* on this page — single-threaded actors, per-recipient FIFO, no
 > blocking — are **stable**. The scheduler *internals* that enforce them (the
 > per-actor mail ring, blob formation, the cursor-shared cooperative drain) are
 > **live and still being tuned** — a run of perf PRs through mid-2026 reshaped
 > them — so treat this section as the *shape*, not a spec, and read
-> `aether-substrate` (and ADR-0087) for the current mechanism. Build on the
+> `aether-substrate` (and [ADR-0087](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0087-blob-unit-of-dispatch.md)) for the current mechanism. Build on the
 > contracts, not the internals.
 
 The invariants page states three contracts as rules: an actor is single-threaded
@@ -19,7 +19,7 @@ blocking when a handler needs to wait.
 ## The model: cooperative scheduling
 
 Actors don't each own a thread. There are far more actors than worker threads,
-and the pool multiplexes them on demand (ADR-0087) — no actor is pinned to a
+and the pool multiplexes them on demand ([ADR-0087](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0087-blob-unit-of-dispatch.md)) — no actor is pinned to a
 core. And the thing the pool actually hands around is not a message, nor "an
 actor," but a **blob**.
 
@@ -76,7 +76,7 @@ to reply, and B's mail is sitting in a queue behind the very worker you're
 holding, neither of you ever makes progress.
 
 This is history, not hypothetical. The engine once had a synchronous `wait_reply`
-primitive (ADR-0042). Once dispatch became pool-only — the `Dedicated`
+primitive ([ADR-0042](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0042-synchronous-mail-wait.md)). Once dispatch became pool-only — the `Dedicated`
 per-actor-thread opt-in was removed (#1187) — an in-handler `wait_reply` could
 park a shared worker and deadlock if the awaited reply needed that worker. It was
 a latent footgun with no users, so it was retired (#1190). There is deliberately
@@ -93,14 +93,14 @@ send the request, *return* from the handler (freeing the worker), and handle the
 reply when it arrives as a *separate* mail in a later handler call. Correlation
 survives across turns — a handler can stash the correlation id of its send
 (`prev_correlation`) and match it against the inbound reply's id, so multiple
-in-flight requests don't get confused (the surviving half of ADR-0042). Every
+in-flight requests don't get confused (the surviving half of [ADR-0042](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0042-synchronous-mail-wait.md)). Every
 request/reply in the engine works this way: `aether.fs.read` →
 `…read_result`, reply-to-sender, and the rest.
 
 **2. Blocking I/O or slow off-thread work → `dispatch_blocking` + `#[handler(task)]`.**
 When a (native) capability must make a genuinely blocking call — a multi-second
 provider request, a subprocess — it hands the work *off* the scheduler thread
-(ADR-0093):
+([ADR-0093](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0093-hold-until-resolve-dispatch-primitive.md)):
 
 ```rust
 #[handler]
@@ -145,7 +145,7 @@ causal chain open*:
 
 The hold is what stops a deferred reply from settling early: if a handler kicks
 off work that replies later, the chain must stay open until that last send, or a
-waiter is told "done" before the reply arrives (ADR-0080 §12).
+waiter is told "done" before the reply arrives ([ADR-0080](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0080-substrate-mail-tracing-and-settlement.md) §12).
 `dispatch_blocking` acquires the hold *eagerly* — before the handler returns —
 and `resolve` releases it *after* the reply, so "reply before release" is
 structural rather than something you remember to order. (A hand-rolled drain that
@@ -161,7 +161,7 @@ real OS thread, deliberately: it's blocking I/O that *should* live off the
 scheduler, isolated so it can't pin a pool worker. That's the **exception** — a
 handful of infrastructure capabilities — not how actors run, and not something to
 reach for from ordinary actor logic (use one of the three shapes above). It's a
-cap-local spawn, scoped tightly to the blocking call (ADR-0050).
+cap-local spawn, scoped tightly to the blocking call ([ADR-0050](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0050-llm-completion-sink.md)).
 
 ## Where to read more
 

--- a/docs/guide/systems/mail-and-kinds.md
+++ b/docs/guide/systems/mail-and-kinds.md
@@ -1,10 +1,10 @@
 # Mail, kinds & scheduling
 
-> Governing ADRs: **ADR-0002** (mail-first actor model), **ADR-0005** (mail
-> typing), **ADR-0019** (unified encoding), **ADR-0087** (blob dispatch + the
+> **Governing ADRs:** [ADR-0002](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0002-mail-first-architecture.md) (mail-first actor model), [ADR-0005](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0005-mail-typing-system.md) (mail
+> typing), [ADR-0019](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0019-unified-mail-encoding.md) (unified encoding), [ADR-0087](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0087-blob-unit-of-dispatch.md) (blob dispatch + the
 > ordering spine). The mail/kind model is **stable**; the *scheduler internals*
 > (how work is batched and balanced across threads) are **settling** — this
-> page documents the stable contract and defers the guts to ADR-0087.
+> page documents the stable contract and defers the guts to [ADR-0087](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0087-blob-unit-of-dispatch.md).
 
 This is the spine the rest of the engine hangs on. Actors don't call each
 other — they send **mail**. A piece of mail is a typed payload (a *kind*)
@@ -27,7 +27,7 @@ one actor model and address each other identically. When this page says
 ## Why it exists
 
 Aether could have let subsystems share memory and coordinate through a
-scheduler. It deliberately doesn't (ADR-0002). One uniform message boundary
+scheduler. It deliberately doesn't ([ADR-0002](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0002-mail-first-architecture.md)). One uniform message boundary
 buys four things the project treats as non-negotiable:
 
 - **Hot-swap.** A component can be unloaded and reloaded mid-run without the
@@ -50,9 +50,9 @@ buys four things the project treats as non-negotiable:
 - **Location independence.** Transport is a choice the recipient doesn't have
   to reason about: mail from a sibling actor in the same process and mail from
   Claude over the MCP wire run the same handler path, so the "in-process SDK vs
-  out-of-process server" question dissolves (ADR-0002/0006). A handler isn't
+  out-of-process server" question dissolves ([ADR-0002](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0002-mail-first-architecture.md)/[ADR-0006](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0006-external-mail-transport.md)). A handler isn't
   fully blind to provenance — it can see a reply target and sender lineage
-  (ADR-0083) — but the guarantee is that correctness and capability never
+  ([ADR-0083](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0083-mail-sender-lineage.md)) — but the guarantee is that correctness and capability never
   *depend* on where mail came from. (Pinning down the exact origin, e.g. for a
   security policy, isn't first-class today; it's a plausible future.)
 
@@ -60,9 +60,9 @@ buys four things the project treats as non-negotiable:
 can own a whole subsystem — the entire physics world, state as plain data and a
 tight inner loop. A fine one can be a single instance: **instanced** actors are
 a first-class category (cardinality — `Singleton` vs `Instanced` — is its own
-axis, ADR-0079), and the blob dispatcher (ADR-0087) is built to rip through
+axis, [ADR-0079](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0079-instanced-actors-as-a-first-class-category.md)), and the blob dispatcher ([ADR-0087](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0087-blob-unit-of-dispatch.md)) is built to rip through
 large sets of mail, so fan-out across many small actors is cheap, not the
-performance trap an earlier design assumed. ADR-0002's "subsystem-sized, never
+performance trap an earlier design assumed. [ADR-0002](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0002-mail-first-architecture.md)'s "subsystem-sized, never
 per-entity" rule predates both and is superseded on this point.
 
 When do you split into instances versus manage multiplicity inside one actor?
@@ -75,7 +75,7 @@ camera component drives many cameras from one actor, no per-camera mailbox
 needed.
 
 Fine granularity is cheap because actors **don't each own a thread** — they're
-multiplexed onto a shared work-stealing scheduler (ADR-0087), and the run-token
+multiplexed onto a shared work-stealing scheduler ([ADR-0087](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0087-blob-unit-of-dispatch.md)), and the run-token
 that lets only one worker run a given actor at a time is what gives you the
 single-threaded-per-actor property. So thousands of instanced actors cost mail
 and state, not threads. The rare exception is blocking I/O: an actor that must
@@ -99,12 +99,12 @@ vanish, this is the first thing to check.
 
 **A kind is a typed, self-describing payload.** It's a Rust type deriving
 `Kind` + `Schema` with a `#[kind(name = "…")]`, carrying a stable hashed
-`KindId` and a schema that describes its bytes (ADR-0005/0031). Because a kind
+`KindId` and a schema that describes its bytes ([ADR-0005](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0005-mail-typing-system.md)/[ADR-0031](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0031-const-constructible-schema-representation.md)). Because a kind
 carries its own schema, the wire layer can encode it from JSON and a recipient
 can decode it without a shared header — and an agent can ask a live engine what
 kinds exist (`describe_kinds`).
 
-**Encoding is schema-driven** (ADR-0019). On the way in, params are encoded to
+**Encoding is schema-driven** ([ADR-0019](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0019-unified-mail-encoding.md)). On the way in, params are encoded to
 wire bytes against the kind's schema; the recipient decodes those bytes back
 into the kind per-kind. The bytes stay opaque until the addressed handler
 decodes them — nothing in the middle needs to understand the payload.
@@ -114,7 +114,7 @@ reply. If a reply matters, that's a separate, explicit contract between the two
 kinds — never an implicit "every kind has a response." Don't write a caller
 that blocks waiting for a reply a handler never agreed to send.
 
-**The ordering spine** (ADR-0087) — **the single contract to hold in your head
+**The ordering spine** ([ADR-0087](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0087-blob-unit-of-dispatch.md)) — **the single contract to hold in your head
 when writing handlers.** Get it wrong and you write code that passes in dev and
 breaks under load:
 
@@ -150,7 +150,7 @@ carry now: **don't block in a handler.**
 
 *How* mail is batched and balanced across workers (the per-producer rings, the
 work-stealing pool, the blob-as-unit-of-dispatch) is still settling — read
-ADR-0087 for the current design, but build on the contracts above, not its
+[ADR-0087](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0087-blob-unit-of-dispatch.md) for the current design, but build on the contracts above, not its
 internals.
 
 ## How to use it


### PR DESCRIPTION
Backfills ADR links across the guide (issue #1368): every `ADR-NNNN` reference becomes a `blob/main` link to its source, and each `Governing ADRs:` box gets the label bolded with the links left unbolded — matching the convention set on the tracing & configuration pages.

## Scope
Ten pages swept: architecture, foundations/{actor-model, invariants, type-system}, mcp-harness, philosophy, recipes, systems/{components, concurrency, mail-and-kinds}. (configuration and tracing-and-settlement were already done.) 147 ADR links across the guide now; ~117 added here.

## How it was done + verified
Fanned out one agent per page for the mechanical edits, then verified centrally:
- **Every link URL checked against the canonical map** (`ls docs/adr/` → number→filename) — zero mismatches, no guessed slugs.
- No remaining bare references except inside the architecture ASCII-diagram code fence, where a markdown link can't render — correctly left bare.
- No leftover bolded links; all six reformatted boxes are `> **Governing ADRs:** [ADR-…](…)`.
- `mdbook build` clean.

Docs-only. Closes #1368. Part of #1355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
