### PR TITLE
docs(adr): accept ADR-0082 and note the lifecycle subscribe-site divergence

### DIFF
--- a/docs/adr/0082-application-declared-lifecycle-sequence.md
+++ b/docs/adr/0082-application-declared-lifecycle-sequence.md
@@ -1,9 +1,22 @@
 # ADR-0082: Application-declared lifecycle sequence
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-19
 - **Amends:** ADR-0074 §Decision 5 (retires `FRAME_BARRIER`)
 - **Supersedes:** iamacoffeepot/aether#687 (closed)
+
+> **Amendment (2026-06-05).** Status moved Proposed → Accepted. The decision
+> shipped: `LifecycleDriverCapability`, the `LifecycleGraph` builder,
+> settlement-gated advance, and the `aether.lifecycle.*` stage kinds are wired
+> into the desktop, headless, and test_bench chassis, and §6's `FRAME_BARRIER` +
+> `drain_frame_bound_or_abort` retired as designed. One implementation point
+> departs from the body: §12 prescribes subscribing to `Tick` on the lifecycle
+> driver, but a component subscribes through `InputCapability` —
+> `ctx.actor::<InputCapability>().subscribe(Tick::ID, me)` — and the driver relays
+> its broadcast `Tick` to `aether.input` via the chassis's initial-subscriber
+> wiring. The driver's own `LifecycleSubscribe` mechanism exists and carries that
+> relay rather than direct component subscription; read §12's subscribe site
+> accordingly.
 
 ## Context
 


### PR DESCRIPTION
Flips ADR-0082 (application-declared lifecycle sequence) from **Proposed** to **Accepted**, and adds a dated amendment so the record matches the code.

The decision shipped: `LifecycleDriverCapability`, the `LifecycleGraph` builder, settlement-gated advance, and the `aether.lifecycle.*` stage kinds are wired into the desktop, headless, and test_bench chassis. §6's `FRAME_BARRIER` and `drain_frame_bound_or_abort` retired as designed (the remaining mentions in the tree are retirement comments, not live machinery).

The amendment records one implementation divergence from the body: §12 prescribes subscribing to `Tick` on the lifecycle driver, but a component actually subscribes through `InputCapability` (`ctx.actor::<InputCapability>().subscribe(Tick::ID, me)`), and the driver relays its broadcast `Tick` to `aether.input` via the chassis's initial-subscriber wiring. The driver's `LifecycleSubscribe` mechanism carries that relay rather than direct component subscription. Anyone coding off §12 as written would target the wrong mailbox, so the note points at the real subscribe site.

Verified against current code while writing the Input streams guide page (#1376) and prepping the forthcoming Frame lifecycle page (#1355).
