### PR TITLE
feat(capabilities): add a name-addressed lifecycle stage subscribe helper

### DIFF
--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -60,6 +60,12 @@ pub mod input;
 // 1122). Serves the per-build name/template manifest + dynamic-instance
 // resolve over mail.
 pub mod inventory;
+// `aether.lifecycle` driver sender-side facade (ADR-0082 §7/§12). The
+// receive-side driver lives in `aether-substrate` (native-only, generic
+// over the chassis context `C`); this module is target-agnostic so the
+// stage-subscribe helper compiles on wasm32 — it addresses the driver
+// by name, not by the un-nameable generic type.
+pub mod lifecycle;
 #[cfg(feature = "render")]
 pub mod render;
 pub mod rpc;
@@ -112,6 +118,7 @@ pub use input::InputCapability;
 #[cfg(not(target_arch = "wasm32"))]
 pub use input::InputConfig;
 pub use inventory::InventoryCapability;
+pub use lifecycle::{LifecycleMailbox, LifecycleMailboxExt};
 
 pub use fs::FsCapability;
 // ADR-0050 `aether.gemini` cap (issue 1015).

--- a/crates/aether-capabilities/src/lifecycle.rs
+++ b/crates/aether-capabilities/src/lifecycle.rs
@@ -1,0 +1,179 @@
+//! Sender-side facade for the `aether.lifecycle` driver (ADR-0082 §7,
+//! §12). The lifecycle analogue of [`crate::input::InputMailboxExt`]:
+//! lets an actor subscribe a mailbox to a lifecycle *stage* broadcast
+//! (e.g. `Render`) so that stage's per-advance payload fans out to it.
+//!
+//! **Why this is name-addressed, not type-addressed.** The receive-side
+//! driver is `LifecycleDriverCapability<C>` — generic over the chassis
+//! context `C` (`LifecycleDriverCapability<DesktopCtx>`,
+//! `LifecycleDriverCapability<HeadlessCtx>`, ...). A wasm guest doesn't
+//! know `C`, so it can't name the driver through
+//! `ctx.actor::<LifecycleDriverCapability<C>>()` the way the input path
+//! names [`InputCapability`](crate::input::InputCapability). Instead this
+//! module declares a tiny non-generic marker, [`LifecycleMailbox`], whose
+//! `NAMESPACE` is the driver's fixed mailbox name `"aether.lifecycle"`.
+//! `ctx.actor::<LifecycleMailbox>()` resolves that name to a mailbox id
+//! the same way every other `ctx.actor::<R>()` does — so the subscribe is
+//! chassis-context-agnostic and works from an FFI guest that has no
+//! handle on the driver's `C`.
+//!
+//! The marker carries `HandlesKind<LifecycleSubscribe>` /
+//! `HandlesKind<LifecycleUnsubscribe>` so the typed-send gate still
+//! rejects wrong-kind sends at the call site, exactly like a
+//! macro-emitted cap. It is a pure addressing token — it is never
+//! registered or booted as an actor (the generic
+//! [`LifecycleDriverCapability`] is the real receiver); it only names
+//! the mailbox.
+//!
+//! Call site, mirroring the input subscribe in a component's `wire`:
+//!
+//! ```ignore
+//! let me = MailboxId(ctx.mailbox_id());
+//! ctx.actor::<LifecycleMailbox>().subscribe(Render::ID, me);
+//! ```
+//!
+//! The driver's `on_subscribe` validates the stage against the chassis
+//! graph and replies [`LifecycleSubscribeResult`] — `Err` fail-fast on a
+//! chassis that doesn't declare that stage (ADR-0082 §7). Reply handling
+//! stays on the caller.
+//!
+//! [`LifecycleDriverCapability`]: aether_substrate::LifecycleDriverCapability
+//! [`LifecycleSubscribeResult`]: aether_kinds::LifecycleSubscribeResult
+
+use aether_actor::{Actor, FfiActorMailbox, HandlesKind, Singleton};
+use aether_data::{KindId, MailboxId};
+use aether_kinds::{LifecycleSubscribe, LifecycleUnsubscribe};
+#[cfg(not(target_arch = "wasm32"))]
+use aether_substrate::actor::native::NativeActorMailbox;
+
+/// Non-generic addressing marker for the `aether.lifecycle` driver.
+///
+/// The real receiver is the generic
+/// [`LifecycleDriverCapability<C>`](aether_substrate::LifecycleDriverCapability),
+/// which a wasm guest can't name (it doesn't know `C`). This ZST stands
+/// in purely so callers can address the lifecycle mailbox *by name*
+/// through the ordinary `ctx.actor::<R>()` path: its [`Actor::NAMESPACE`]
+/// is the driver's fixed mailbox name and its [`Singleton`] /
+/// [`HandlesKind`] markers let `ctx.actor::<LifecycleMailbox>()` return a
+/// typed sender with the wrong-kind compile gate intact.
+///
+/// It is never instantiated, registered, or booted — there is no `init`,
+/// no handler dispatch. The substrate registers the generic driver at the
+/// same `NAMESPACE`; this marker only resolves the name.
+pub struct LifecycleMailbox;
+
+impl Actor for LifecycleMailbox {
+    /// The driver's fixed mailbox name. Hardcoded rather than aliased
+    /// from `LifecycleDriverCapability::NAMESPACE` because that type lives
+    /// in the native-only `aether-substrate` crate, while this marker
+    /// must resolve on `wasm32` too. A native-gated test pins this literal
+    /// to the driver's constant so the two can't drift.
+    const NAMESPACE: &'static str = "aether.lifecycle";
+}
+
+impl Singleton for LifecycleMailbox {}
+impl HandlesKind<LifecycleSubscribe> for LifecycleMailbox {}
+impl HandlesKind<LifecycleUnsubscribe> for LifecycleMailbox {}
+
+/// Sender-side facade for callers addressing the lifecycle driver via
+/// `ctx.actor::<LifecycleMailbox>()`.
+///
+/// Lifts the stage-subscribe operations one indirection above the raw
+/// `.send(&LifecycleSubscribe { .. })` so component code stops
+/// reconstructing the kind struct (and the `.0` field unwraps) at every
+/// call site — same shape and rationale as
+/// [`InputMailboxExt`](crate::input::InputMailboxExt).
+///
+/// Impl'd for both transports `ctx.actor::<LifecycleMailbox>()` can
+/// return:
+///
+/// - [`FfiActorMailbox<LifecycleMailbox>`] — always-on, for wasm-component
+///   callers (the §12 stage-subscribe site).
+/// - [`NativeActorMailbox<'_, LifecycleMailbox>`] — native cap-to-cap
+///   sends, gated on `#[cfg(not(target_arch = "wasm32"))]`.
+///
+/// All methods are fire-and-forget. `subscribe` / `unsubscribe` reply
+/// via `aether.lifecycle.subscribe_result`; reply handling stays on the
+/// caller. The driver fail-fasts (`Err`) on a stage its chassis graph
+/// doesn't declare (ADR-0082 §7).
+///
+/// The generic escape hatch is unaffected: `mailbox.send(&LifecycleSubscribe { .. })`
+/// still works, since `send` is an inherent method on the underlying
+/// mailbox type.
+pub trait LifecycleMailboxExt {
+    /// Mail `aether.lifecycle.subscribe { stage, mailbox }` to the driver.
+    /// Add `mailbox` to the subscriber set for the lifecycle stage `stage`
+    /// (a stage kind's [`KindId`], e.g. `Render::ID`). Idempotent.
+    fn subscribe(&self, stage: KindId, mailbox: MailboxId);
+
+    /// Mail `aether.lifecycle.unsubscribe { stage, mailbox }` to the
+    /// driver. Remove `mailbox` from the subscriber set for `stage`.
+    /// Idempotent on "not currently subscribed."
+    fn unsubscribe(&self, stage: KindId, mailbox: MailboxId);
+}
+
+impl LifecycleMailboxExt for FfiActorMailbox<LifecycleMailbox> {
+    fn subscribe(&self, stage: KindId, mailbox: MailboxId) {
+        self.send(&LifecycleSubscribe {
+            stage: stage.0,
+            mailbox: mailbox.0,
+        });
+    }
+    fn unsubscribe(&self, stage: KindId, mailbox: MailboxId) {
+        self.send(&LifecycleUnsubscribe {
+            stage: stage.0,
+            mailbox: mailbox.0,
+        });
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl LifecycleMailboxExt for NativeActorMailbox<'_, LifecycleMailbox> {
+    fn subscribe(&self, stage: KindId, mailbox: MailboxId) {
+        self.send(&LifecycleSubscribe {
+            stage: stage.0,
+            mailbox: mailbox.0,
+        });
+    }
+    fn unsubscribe(&self, stage: KindId, mailbox: MailboxId) {
+        self.send(&LifecycleUnsubscribe {
+            stage: stage.0,
+            mailbox: mailbox.0,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Name-addressing pins to the real driver. The marker hardcodes
+    /// `"aether.lifecycle"` so it resolves on `wasm32` (where
+    /// `aether-substrate` is absent); this native-gated check asserts that
+    /// literal still matches `LifecycleDriverCapability`'s `NAMESPACE`, so
+    /// the two can't silently drift and leave guest subscribes routing to
+    /// a dead mailbox id.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn marker_namespace_matches_the_driver() {
+        use aether_substrate::LifecycleDriverCapability;
+        assert_eq!(
+            <LifecycleMailbox as Actor>::NAMESPACE,
+            <LifecycleDriverCapability<()> as Actor>::NAMESPACE,
+        );
+        assert_eq!(<LifecycleMailbox as Actor>::NAMESPACE, "aether.lifecycle");
+    }
+
+    /// The typed-send gate the ext relies on: `ctx.actor::<LifecycleMailbox>()`
+    /// can only `.send()` the two lifecycle subscribe kinds. A compile-time
+    /// assertion — if a future edit drops a `HandlesKind` impl, this stops
+    /// building.
+    #[test]
+    fn marker_handles_the_subscribe_kinds() {
+        fn assert_handles<R: HandlesKind<K>, K: aether_data::Kind>() {}
+        fn assert_singleton<R: Singleton>() {}
+        assert_handles::<LifecycleMailbox, LifecycleSubscribe>();
+        assert_handles::<LifecycleMailbox, LifecycleUnsubscribe>();
+        assert_singleton::<LifecycleMailbox>();
+    }
+}


### PR DESCRIPTION
PR1 of #1378. Adds the sender-side helper an actor uses to subscribe a mailbox to a lifecycle **stage** broadcast (e.g. `Render`) — the lifecycle analogue of `InputMailboxExt`. Behavior-preserving: nothing subscribes to a new stage yet; this only adds the helper the later PRs need.

## What's here

- `crates/aether-capabilities/src/lifecycle.rs` (new) — `LifecycleMailboxExt` (`subscribe(stage, mailbox)` / `unsubscribe`), impl'd on `FfiActorMailbox<LifecycleMailbox>` (wasm guests) and the native-gated `NativeActorMailbox<'_, LifecycleMailbox>`, mirroring the input/fs split.
- `crates/aether-capabilities/src/lib.rs` — `pub mod lifecycle` + re-export.

## Design decision to bless

The receive-side driver is `LifecycleDriverCapability<C>`, generic over the chassis context `C`. A wasm guest doesn't know `C`, so it can't name the driver via `ctx.actor::<LifecycleDriverCapability<C>>()` the way the input path names `InputCapability`. To address `aether.lifecycle` by name instead, this adds a non-generic marker ZST `LifecycleMailbox` whose `NAMESPACE` is the driver's fixed mailbox name:

- `ctx.actor::<LifecycleMailbox>().subscribe(Render::ID, me)` resolves the name through the ordinary `ctx.actor::<R>()` path, chassis-context-agnostic.
- Its `HandlesKind<LifecycleSubscribe>` / `HandlesKind<LifecycleUnsubscribe>` markers keep the wrong-kind compile gate.
- It is never instantiated, registered, or booted — the generic driver is the real receiver at the same namespace; the marker only resolves the name.

This introduces a new idiom: a type that implements `Actor` purely as an addressing token. The alternative was a new method on the `aether-actor` ctx surface; the marker keeps the change inside `aether-capabilities`. The namespace literal is hardcoded (the marker must compile on wasm32, where `aether-substrate` is absent), pinned to `LifecycleDriverCapability::NAMESPACE` by a native-gated drift test.

## Validation

Full `scripts/preflight.sh` green — fmt, clippy `-D warnings`, doc, nextest (1473 passed / 6 skipped, including the chassis-boot suites that would surface a name-inventory collision from the shared namespace), and the wasm32 cross-build. Two focused unit tests added: the namespace drift guard and a compile-time `HandlesKind` assertion.

Part of #1378.
