### PR TITLE
fix(workflow): phase-label reconcile drops the label when swapping an existing one

### DIFF
--- a/.claude/skills/approve/SKILL.md
+++ b/.claude/skills/approve/SKILL.md
@@ -103,12 +103,11 @@ When `--skip-adr` is used, the audit comment is verbose:
 The board `Phase` field is only visible on the project board — not on the issue itself or in `gh issue list`. This skill mirrors every Phase write as a `phase:*` label on the issue so the lifecycle is legible at a glance, and the label never disagrees with the board. **In the same step you set the `Phase` field, reconcile the label:**
 
 ```bash
-gh issue edit <n> \
-  --remove-label "phase:define,phase:design,phase:plan,phase:ready,phase:executing,phase:refine,phase:bounced,phase:stalled" \
-  --add-label "phase:<new>"
+gh issue edit <n> --remove-label "phase:define,phase:design,phase:plan,phase:ready,phase:executing,phase:refine,phase:bounced,phase:stalled"
+gh issue edit <n> --add-label "phase:<new>"
 ```
 
-`--remove-label` ignores labels the issue doesn't carry, so this single line is safe on any transition — it strips whatever phase label was present and applies the new one (lowercased: `Phase=Ready` → `phase:ready`). The only write this skill makes is `Phase=Ready` → `phase:ready`. On idempotent re-run (already Ready) the reconcile is a harmless no-op; run it anyway so a hand-stripped label self-heals.
+The remove and add are **two separate invocations** on purpose: a single `gh issue edit` with the target listed in both `--remove-label` and `--add-label` strips it and never re-adds it (the remove wins), so the issue ends up with no phase label on every real transition. Splitting the calls makes the add unconditional. `--remove-label` ignores labels the issue doesn't carry, so the first line is safe on any transition. The only write this skill makes is `Phase=Ready` → `phase:ready`. On idempotent re-run (already Ready) the reconcile is a harmless no-op; run it anyway so a hand-stripped label self-heals.
 
 ## Failure modes
 

--- a/.claude/skills/bounce/SKILL.md
+++ b/.claude/skills/bounce/SKILL.md
@@ -90,19 +90,18 @@ Same skill mechanism, different invocation site. `/bounce` is the user-driven va
 
 `Phase=Stalled` is a different signal — env/tooling failure, not a phase regression. Examples: qodana CI service down, GitHub API rate-limited mid-batch, `gh` token expired. The issue's scoping is fine; the *environment* is the problem.
 
-v1 has no `/stall` skill — set Stalled manually in the UI or via `gh project item-edit` with the BounceTo field left null. When you do, also set the `phase:stalled` label on the issue (`gh issue edit <n> --remove-label "phase:define,…,phase:bounced,phase:stalled" --add-label phase:stalled`) so the halt is visible in `gh issue list`. Future `/stall <issue> --reason "<env-issue>"` would post the same kind of audit comment.
+v1 has no `/stall` skill — set Stalled manually in the UI or via `gh project item-edit` with the BounceTo field left null. When you do, also set the `phase:stalled` label on the issue (`gh issue edit <n> --remove-label "phase:define,…,phase:bounced,phase:stalled"` then `gh issue edit <n> --add-label phase:stalled` — two calls, see [Phase label reconcile](#phase-label-reconcile)) so the halt is visible in `gh issue list`. Future `/stall <issue> --reason "<env-issue>"` would post the same kind of audit comment.
 
 ## Phase label reconcile
 
 The board `Phase` field is only visible on the project board — not on the issue itself or in `gh issue list`. This skill mirrors every Phase write as a `phase:*` label on the issue so the lifecycle is legible at a glance, and the label never disagrees with the board. **In the same step you set the `Phase` field, reconcile the label:**
 
 ```bash
-gh issue edit <n> \
-  --remove-label "phase:define,phase:design,phase:plan,phase:ready,phase:executing,phase:refine,phase:bounced,phase:stalled" \
-  --add-label "phase:<new>"
+gh issue edit <n> --remove-label "phase:define,phase:design,phase:plan,phase:ready,phase:executing,phase:refine,phase:bounced,phase:stalled"
+gh issue edit <n> --add-label "phase:<new>"
 ```
 
-`--remove-label` ignores labels the issue doesn't carry, so this single line is safe on any transition — it strips whatever phase label was present and applies the new one (lowercased: `Phase=Ready` → `phase:ready`). This skill writes `Phase=Bounced` (`phase:bounced`), and on the `/scope` resume contract `Phase=<BounceTo>` (`phase:<BounceTo>`).
+The remove and add are **two separate invocations** on purpose: a single `gh issue edit` with the target listed in both `--remove-label` and `--add-label` strips it and never re-adds it (the remove wins), so the issue ends up with no phase label on every real transition. Splitting the calls makes the add unconditional. `--remove-label` ignores labels the issue doesn't carry, so the first line is safe on any transition. This skill writes `Phase=Bounced` (`phase:bounced`), and on the `/scope` resume contract `Phase=<BounceTo>` (`phase:<BounceTo>`).
 
 ## Failure modes
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -194,12 +194,11 @@ Both caps trigger self-bounce to Plan with the budget breach noted. The `AuthBud
 The board `Phase` field is only visible on the project board — not on the issue itself or in `gh issue list`. This skill mirrors every Phase write as a `phase:*` label on the issue so the lifecycle is legible at a glance, and the label never disagrees with the board. **In the same step you set the `Phase` field, reconcile the label:**
 
 ```bash
-gh issue edit <n> \
-  --remove-label "phase:define,phase:design,phase:plan,phase:ready,phase:executing,phase:refine,phase:bounced,phase:stalled" \
-  --add-label "phase:<new>"
+gh issue edit <n> --remove-label "phase:define,phase:design,phase:plan,phase:ready,phase:executing,phase:refine,phase:bounced,phase:stalled"
+gh issue edit <n> --add-label "phase:<new>"
 ```
 
-`--remove-label` ignores labels the issue doesn't carry, so this single line is safe on any transition — it strips whatever phase label was present and applies the new one (lowercased: `Phase=Ready` → `phase:ready`). This skill writes `Phase` in four places, each of which must reconcile the label: `Executing` (Execute step 1 + Refine-loop fix-push), `Refine` (Refine-loop fix-and-wait + done condition), `Bounced` (self-bounce on retry-cap / wall-clock / design discovery), and `Stalled` (build-env failure). `Done` carries no label — the merge that closes the issue retires the lifecycle.
+The remove and add are **two separate invocations** on purpose: a single `gh issue edit` with the target listed in both `--remove-label` and `--add-label` strips it and never re-adds it (the remove wins), so the issue ends up with no phase label on every real transition. Splitting the calls makes the add unconditional. `--remove-label` ignores labels the issue doesn't carry, so the first line is safe on any transition. This skill writes `Phase` in four places, each of which must reconcile the label: `Executing` (Execute step 1 + Refine-loop fix-push), `Refine` (Refine-loop fix-and-wait + done condition), `Bounced` (self-bounce on retry-cap / wall-clock / design discovery), and `Stalled` (build-env failure). `Done` carries no label — the merge that closes the issue retires the lifecycle.
 
 ## Failure modes
 

--- a/.claude/skills/scope/SKILL.md
+++ b/.claude/skills/scope/SKILL.md
@@ -168,12 +168,11 @@ Cache item IDs per-issue per-run to avoid repeated lookups.
 The board `Phase` field is only visible on the project board — not on the issue itself or in `gh issue list`. This skill mirrors every Phase write as a `phase:*` label on the issue so the lifecycle is legible at a glance, and the label never disagrees with the board. **In the same step you set the `Phase` field, reconcile the label:**
 
 ```bash
-gh issue edit <n> \
-  --remove-label "phase:define,phase:design,phase:plan,phase:ready,phase:executing,phase:refine,phase:bounced,phase:stalled" \
-  --add-label "phase:<new>"
+gh issue edit <n> --remove-label "phase:define,phase:design,phase:plan,phase:ready,phase:executing,phase:refine,phase:bounced,phase:stalled"
+gh issue edit <n> --add-label "phase:<new>"
 ```
 
-`--remove-label` ignores labels the issue doesn't carry, so this single line is safe on any transition — it strips whatever phase label was present and applies the new one (lowercased: `Phase=Ready` → `phase:ready`). Two phases carry no label: `Backlog` (the resting/default state) and `Done` (the issue is closed). When moving to either, run only the `--remove-label` half. For this skill the writes are `Phase=Design`, `Phase=Plan`, and (on self-bounce) `Phase=Bounced`.
+The remove and add are **two separate invocations** on purpose: a single `gh issue edit` with the target listed in both `--remove-label` and `--add-label` strips it and never re-adds it (the remove wins), so the issue ends up with no phase label on every real transition. Splitting the calls makes the add unconditional. `--remove-label` ignores labels the issue doesn't carry, so the first line is safe on any transition. Two phases carry no label: `Backlog` (the resting/default state) and `Done` (the issue is closed). When moving to either, run only the remove line and skip the add. For this skill the writes are `Phase=Design`, `Phase=Plan`, and (on self-bounce) `Phase=Bounced`.
 
 ## Restart and resume semantics
 


### PR DESCRIPTION
Closes #1382

Generated by Bandolier.