### PR TITLE
refactor(actor): rename the init_v2 FFI export to init_with_config

### DIFF
--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -389,8 +389,8 @@ macro_rules! __export_internal {
         /// returned `Err(BootError)` or its `Config::decode_from_bytes`
         /// produced `None`.
         #[cfg(target_arch = "wasm32")]
-        #[unsafe(export_name = "init_v2_p32")]
-        pub unsafe extern "C" fn init_v2(
+        #[unsafe(export_name = "init_with_config_p32")]
+        pub unsafe extern "C" fn init_with_config(
             mailbox_id: u64,
             config_ptr: u32,
             config_len: u32,
@@ -458,8 +458,8 @@ macro_rules! __export_internal {
 
         /// # Safety
         /// ADR-0090: legacy zero-config `init` shim. Called by older
-        /// substrate builds that don't know about `init_v2_p32`. Reaches
-        /// into `init_v2` with empty config bytes — works as long as
+        /// substrate builds that don't know about `init_with_config_p32`. Reaches
+        /// into `init_with_config` with empty config bytes — works as long as
         /// `<Self as FfiActor>::Config` decodes from `&[]` (i.e.
         /// `Config = ()`); a typed-config actor returns an
         /// `init_failed` here, which is the right behavior for a host
@@ -467,11 +467,11 @@ macro_rules! __export_internal {
         #[cfg(target_arch = "wasm32")]
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn init(mailbox_id: u64) -> u32 {
-            // SAFETY: forwarding to `init_v2` with `config_len = 0`
+            // SAFETY: forwarding to `init_with_config` with `config_len = 0`
             // makes `config_ptr` unread (the function's empty-len
             // branch returns `&[]`), so the dummy `0` pointer is
             // never dereferenced.
-            unsafe { init_v2(mailbox_id, 0, 0) }
+            unsafe { init_with_config(mailbox_id, 0, 0) }
         }
 
         /// # Safety

--- a/crates/aether-substrate-bundle/tests/typed_config.rs
+++ b/crates/aether-substrate-bundle/tests/typed_config.rs
@@ -1,7 +1,7 @@
 //! ADR-0090 c1 (issue 1256) integration coverage for the typed
 //! `FfiActor::Config` path. Loads the `probe_with_config` example
 //! cdylib through a [`TestBench`] and asserts the wasm guest's
-//! `init_v2_p32` decode-error surfaces in `LoadResult::Err` when the
+//! `init_with_config_p32` decode-error surfaces in `LoadResult::Err` when the
 //! load mail carries no config bytes — c1 wires the host probe and
 //! the guest shim but does not yet thread real config bytes through
 //! the load mail (that is c2). The negative path is the load-bearing
@@ -80,7 +80,7 @@ fn typed_config_guest_without_config_bytes_surfaces_decode_error() {
 /// it — the `ConfigEcho` reply must echo the exact `(seed, label)` the
 /// guest decoded at `init`. This proves the full c2 delivery seam: the
 /// load mail's `config` bytes reach `Component::instantiate`, the c1
-/// ABI writes them into the guest's linear memory, and `init_v2_p32`
+/// ABI writes them into the guest's linear memory, and `init_with_config_p32`
 /// decodes them into `Probe::init(config, ctx)`.
 ///
 /// c1 parked this behind `AETHER_CONFIG_C2` because the delivery seam

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -394,7 +394,7 @@ pub const DISPATCH_DROPPED_OVERSIZE: u32 = 2;
 const STATE_OFFSET: u32 = 8192;
 
 /// Offset the substrate writes config bytes to before calling
-/// `init_v2_p32` (ADR-0090). Sits after `STATE_OFFSET` so the three
+/// `init_with_config_p32` (ADR-0090). Sits after `STATE_OFFSET` so the three
 /// scratch regions (mail / state / config) never overlap. Config is
 /// written once at instantiate time, before any other host fn runs.
 const CONFIG_OFFSET: u32 = 16384;
@@ -457,11 +457,11 @@ impl Component {
     ///
     /// ADR-0090 (issue 1256): `config_bytes` is the wire-encoded
     /// `<FfiActor::Config as Kind>` payload threaded through to the
-    /// guest's `init_v2_p32` shim. Pass `&[]` for actors whose
+    /// guest's `init_with_config_p32` shim. Pass `&[]` for actors whose
     /// `Config = ()` or for the back-compat path (legacy `init` does
     /// not consume the bytes). The substrate writes the bytes at
     /// `CONFIG_OFFSET` in the guest's linear memory and calls
-    /// `init_v2_p32(mailbox_id, CONFIG_OFFSET, config_bytes.len())`.
+    /// `init_with_config_p32(mailbox_id, CONFIG_OFFSET, config_bytes.len())`.
     pub fn instantiate(
         engine: &Engine,
         linker: &Linker<ComponentCtx>,
@@ -484,11 +484,11 @@ impl Component {
         // so raw-FFI components predating the Phase 2 ABI still load —
         // they just don't get auto-subscribe, which they never did.
         //
-        // ADR-0090 (issue 1256): the substrate probes `init_v2_p32`
+        // ADR-0090 (issue 1256): the substrate probes `init_with_config_p32`
         // first (the post-#1256 ABI that carries config bytes), then
         // the `(u64) -> u32` shape (Phase 2), then the legacy `()` shape.
         // The order is deliberate — a `#[actor]`-built guest exports
-        // both `init_v2_p32` and the legacy `init(u64)`, so a substrate
+        // both `init_with_config_p32` and the legacy `init(u64)`, so a substrate
         // that probes `init` first would silently skip the config path.
         //
         // Issue 525 Phase 4b / issue 531: a non-zero return value
@@ -503,8 +503,8 @@ impl Component {
         // bounded by guest memory size (well below `u32::MAX`).
         #[allow(clippy::cast_possible_truncation)]
         let config_len = config_bytes.len() as u32;
-        let init_rc = if let Ok(init_v2) =
-            instance.get_typed_func::<(u64, u32, u32), u32>(&mut store, "init_v2_p32")
+        let init_rc = if let Ok(init_with_config) =
+            instance.get_typed_func::<(u64, u32, u32), u32>(&mut store, "init_with_config_p32")
         {
             // Write config bytes (even an empty slice — the guest's
             // shim still receives the `(ptr, 0)` pair and handles the
@@ -512,7 +512,7 @@ impl Component {
             if !config_bytes.is_empty() {
                 memory.write(&mut store, CONFIG_OFFSET as usize, config_bytes)?;
             }
-            Some(init_v2.call(&mut store, (mailbox_id, CONFIG_OFFSET, config_len))?)
+            Some(init_with_config.call(&mut store, (mailbox_id, CONFIG_OFFSET, config_len))?)
         } else if let Ok(init) = instance.get_typed_func::<u64, u32>(&mut store, "init") {
             // Legacy Phase 2 fallback. Discards config bytes — only
             // safe for `Config = ()`. A typed-config guest that lands
@@ -913,7 +913,7 @@ mod tests {
     }
 
     /// ADR-0090 helper: instantiate with explicit config bytes so a
-    /// WAT-level `init_v2_p32` can inspect what the host wrote at
+    /// WAT-level `init_with_config_p32` can inspect what the host wrote at
     /// `CONFIG_OFFSET`.
     fn instantiate_with_config(wat: &str, config_bytes: &[u8]) -> Component {
         let engine = Engine::default();
@@ -977,7 +977,7 @@ mod tests {
                 i32.const 0))
     "#;
 
-    /// ADR-0090 (issue 1256): `init_v2_p32` shim that stamps the host-
+    /// ADR-0090 (issue 1256): `init_with_config_p32` shim that stamps the host-
     /// provided `(config_ptr, config_len)` triple at known offsets so
     /// tests can assert the substrate wrote bytes at `CONFIG_OFFSET`
     /// and threaded the length through. Layout written by the shim:
@@ -987,12 +987,12 @@ mod tests {
     ///   offset 208  : `config_len`
     ///   offset 212  : first byte of config (when `config_len` >= 1)
     ///   offset 213  : second byte of config (when `config_len` >= 2)
-    const WAT_INIT_V2: &str = r#"
+    const WAT_INIT_WITH_CONFIG: &str = r#"
         (module
             (memory (export "memory") 1)
             (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                 i32.const 0)
-            (func (export "init_v2_p32") (param i64 i32 i32) (result i32)
+            (func (export "init_with_config_p32") (param i64 i32 i32) (result i32)
                 ;; *(u32*)200 = low32(mailbox_id)
                 i32.const 200
                 local.get 0
@@ -1194,14 +1194,14 @@ mod tests {
     }
 
     /// ADR-0090 (issue 1256): `Component::instantiate` writes
-    /// `config_bytes` at `CONFIG_OFFSET` and calls `init_v2_p32` with
+    /// `config_bytes` at `CONFIG_OFFSET` and calls `init_with_config_p32` with
     /// `(mailbox_id, CONFIG_OFFSET, len)`. The WAT shim stamps the
     /// triple at known offsets so this test can assert each leg
     /// without a real Kind decoder in scope.
     #[test]
-    fn init_v2_p32_threads_config_ptr_len_through() {
+    fn init_with_config_p32_threads_config_ptr_len_through() {
         let payload: &[u8] = &[0xAB, 0xCD, 0xEF, 0x12, 0x34];
-        let mut component = instantiate_with_config(WAT_INIT_V2, payload);
+        let mut component = instantiate_with_config(WAT_INIT_WITH_CONFIG, payload);
         // Mailbox id stamped: test ctx uses MailboxId(0), so low 32 bits are 0.
         assert_eq!(component.read_u32(200), 0);
         // config_ptr == CONFIG_OFFSET.
@@ -1221,12 +1221,12 @@ mod tests {
     }
 
     /// Companion: empty config (the trait-default `Config = ()` path)
-    /// still calls `init_v2_p32` with `(mailbox_id, CONFIG_OFFSET, 0)`.
+    /// still calls `init_with_config_p32` with `(mailbox_id, CONFIG_OFFSET, 0)`.
     /// No bytes are written to the scratch region but the shim still
     /// runs and stamps the triple.
     #[test]
-    fn init_v2_p32_empty_config_passes_zero_length() {
-        let mut component = instantiate_with_config(WAT_INIT_V2, &[]);
+    fn init_with_config_p32_empty_config_passes_zero_length() {
+        let mut component = instantiate_with_config(WAT_INIT_WITH_CONFIG, &[]);
         // Triple stamped, len == 0.
         assert_eq!(component.read_u32(200), 0);
         assert_eq!(component.read_u32(204), CONFIG_OFFSET);

--- a/crates/aether-test-fixtures/examples/probe_with_config.rs
+++ b/crates/aether-test-fixtures/examples/probe_with_config.rs
@@ -1,7 +1,7 @@
 //! ADR-0090 c1 typed-config fixture. Exercises the
 //! `FfiActor::Config = ProbeConfig` path end-to-end: the host writes
 //! postcard-encoded `ProbeConfig` bytes at `CONFIG_OFFSET` during
-//! `Component::instantiate`; the guest's `init_v2_p32` shim decodes
+//! `Component::instantiate`; the guest's `init_with_config_p32` shim decodes
 //! them via `<ProbeConfig as Kind>::decode_from_bytes` and threads
 //! the typed struct into `Probe::init(config, ctx)`.
 //!


### PR DESCRIPTION
Closes iamacoffeepot/aether#1370.

## Summary

The guest FFI export `init_v2_p32` carried a meaningless version suffix — it exists because `init` gained a boot-config argument (ADR-0090), not because of a second ABI generation. This renames it to `init_with_config_p32` (inner fn `init_v2` → `init_with_config`), keeping the `_p32` pointer-width suffix (ADR-0024). The host probe string in the substrate moves in lockstep with the macro emit. The legacy zero-config `init(mailbox_id)` shim keeps its name — only its internal call updates.

Pre-1.0, components rebuild from source, so the ABI-string rename is safe; the legacy `init` fallback keeps older zero-config wasm loading.

## Test plan

Full preflight green (fmt, clippy `-D warnings`, doc, nextest, wasm32 component cross-build). The renamed `init_with_config_p32_threads_config_ptr_len_through` and `init_with_config_p32_empty_config_passes_zero_length` tests pass; the wasm cross-build confirms the emitted component exports `init_with_config_p32` plus the legacy `init`, and no `init_v2_p32`. `grep -rn init_v2 crates/` returns zero.

## Generated by

`/implement` — agent execution of scoped issue #1370.
