### PR TITLE
refactor(actor): rename mail_scratch to kind_scratch now that it serves config too

### DIFF
--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -253,20 +253,23 @@ pub trait Replaceable: FfiActor {
     }
 }
 
-/// Reusable inbound-mail scratch buffer (iamacoffeepot/aether#1337 Phase 2).
+/// Reusable inbound Kind-payload scratch buffer (iamacoffeepot/aether#1337
+/// Phase 2).
 ///
-/// The substrate delivers small mail through a fixed low-memory scratch
-/// offset, but a larger payload (e.g. a whole file via `aether.fs.read_result`)
-/// would overrun that window. For those, the substrate calls the
-/// `mail_scratch_reserve_p32` export (emitted by [`crate::export!`]) to get a
+/// The substrate delivers a small inbound payload through a fixed low-memory
+/// scratch offset, but a larger one — a whole file via `aether.fs.read_result`
+/// at runtime, or a large init config at instantiate time (iamacoffeepot/
+/// aether#1390) — would overrun that window. For those, the substrate calls the
+/// `kind_scratch_reserve_p32` export (emitted by [`crate::export!`]) to get a
 /// pointer into this guest-*heap*-owned buffer, writes the payload there, then
-/// calls `receive`. Because the buffer lives on the heap (not the fixed stack
-/// scratch) there is no overrun, and because it is a persistent `static` reused
-/// across mails — grown to a high-water mark, never shrunk — there is no
-/// per-mail allocation churn (wasm has no GC, so a fresh alloc per mail would
-/// force a matching host-driven free).
+/// calls the entry point (`receive` for mail, `init_with_config` for config).
+/// Because the buffer lives on the heap (not the fixed stack scratch) there is
+/// no overrun, and because it is a persistent `static` reused across payloads —
+/// grown to a high-water mark, never shrunk — there is no per-payload
+/// allocation churn (wasm has no GC, so a fresh alloc each time would force a
+/// matching host-driven free).
 #[cfg(target_arch = "wasm32")]
-pub mod mail_scratch {
+pub mod kind_scratch {
     use alloc::vec::Vec;
 
     static mut BUFFER: Vec<u8> = Vec::new();
@@ -542,17 +545,17 @@ macro_rules! __export_internal {
         /// a reusable guest-heap buffer of at least `min_len` bytes for an
         /// inbound payload too large for the fixed-offset scratch window. The
         /// substrate writes the payload there and passes the pointer to
-        /// `receive`. Backed by [`$crate::ffi::mail_scratch`] — one buffer per
+        /// `receive`. Backed by [`$crate::ffi::kind_scratch`] — one buffer per
         /// wasm module, reused across mails.
         ///
         /// # Safety
         /// Called by the substrate before `receive`; see
-        /// [`$crate::ffi::mail_scratch::reserve`].
+        /// [`$crate::ffi::kind_scratch::reserve`].
         #[cfg(target_arch = "wasm32")]
-        #[unsafe(export_name = "mail_scratch_reserve_p32")]
-        pub unsafe extern "C" fn mail_scratch_reserve(min_len: u32) -> u32 {
-            // SAFETY: see `mail_scratch::reserve`. wasm32 pointers are 32-bit.
-            unsafe { $crate::ffi::mail_scratch::reserve(min_len as usize).addr() as u32 }
+        #[unsafe(export_name = "kind_scratch_reserve_p32")]
+        pub unsafe extern "C" fn kind_scratch_reserve(min_len: u32) -> u32 {
+            // SAFETY: see `kind_scratch::reserve`. wasm32 pointers are 32-bit.
+            unsafe { $crate::ffi::kind_scratch::reserve(min_len as usize).addr() as u32 }
         }
 
         /// # Safety

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -35,7 +35,7 @@ use crate::scheduler::pending_depth;
 // never need to coexist within the same wasm function activation.
 // Each fixed window is small (low shadow-stack region); a mail or config
 // payload too large for its window instead rides the reusable guest-heap
-// reserve buffer (`mail_scratch_reserve`, iamacoffeepot/aether#1337/#1390),
+// reserve buffer (`kind_scratch_reserve`, iamacoffeepot/aether#1337/#1390),
 // which is heap-backed and shared across the two temporally-disjoint paths.
 const MAIL_OFFSET: u32 = 1024;
 
@@ -47,7 +47,7 @@ const MAIL_SCRATCH_STACK_RESERVE: usize = 256 * 1024;
 /// Largest inbound payload (bytes) [`Component::deliver`] writes through the
 /// guest's fixed [`MAIL_OFFSET`] scratch window (iamacoffeepot/aether#1337). A
 /// payload at or below this takes the fast inline path; a larger one rides the
-/// reusable guest-heap buffer (`mail_scratch_reserve`, Phase 2) instead.
+/// reusable guest-heap buffer (`kind_scratch_reserve`, Phase 2) instead.
 ///
 /// `Memory::write` does not grow memory, and `MAIL_OFFSET` sits at the bottom
 /// of linear memory — inside the low stack region of the standard stack-first
@@ -74,7 +74,7 @@ const MAX_DELIVERABLE_MAIL_BYTES: usize = 64 << 20;
 /// the guest's fixed [`CONFIG_OFFSET`] scratch window (ADR-0090, iamacoffeepot/
 /// aether#1390). A config at or below this takes the fast inline path; a larger
 /// one rides the same reusable guest-heap buffer the mail path uses
-/// (`mail_scratch_reserve`) — config and mail are temporally disjoint (config at
+/// (`kind_scratch_reserve`) — config and mail are temporally disjoint (config at
 /// init, before any mail), so sharing the one buffer is safe.
 ///
 /// Sized exactly like [`MAX_MAIL_PAYLOAD_BYTES`] from `MAIL_OFFSET`: `CONFIG_OFFSET`
@@ -397,7 +397,7 @@ impl ComponentCtx {
 pub const DISPATCH_UNKNOWN_KIND: u32 = 1;
 
 /// Sentinel [`Component::deliver`] returns when it refused to deliver an
-/// inbound because its payload exceeded the guest's `mail_scratch_ceiling`
+/// inbound because its payload exceeded the guest's `kind_scratch_ceiling`
 /// (iamacoffeepot/aether#1337). The mail was dropped (logged) without
 /// touching guest memory or invoking `receive`; the caller treats it as a
 /// non-error so the native dispatcher still discharges settlement.
@@ -459,7 +459,7 @@ pub struct Component {
     on_replace: Option<TypedFunc<(), u32>>,
     on_rehydrate: Option<TypedFunc<(u32, u32, u32), u32>>,
     /// iamacoffeepot/aether#1337 Phase 2: the guest's
-    /// `mail_scratch_reserve_p32` export, used to deliver a payload larger
+    /// `kind_scratch_reserve_p32` export, used to deliver a payload larger
     /// than [`MAX_MAIL_PAYLOAD_BYTES`] into a reusable guest-heap buffer
     /// instead of the fixed [`MAIL_OFFSET`] scratch window. The same buffer
     /// carries an over-window init config (iamacoffeepot/aether#1390) —
@@ -467,7 +467,7 @@ pub struct Component {
     /// `None` for a guest too old to export it — such a guest drops oversize
     /// mail (Phase 1 disposition) and rejects an over-window config rather
     /// than risking an overrun.
-    mail_scratch_reserve: Option<TypedFunc<u32, u32>>,
+    kind_scratch_reserve: Option<TypedFunc<u32, u32>>,
     /// Mailbox id stamped at instantiate-time, replayed into `wire`
     /// and `unwire` calls. Same value the guest's `init` shim received.
     self_mailbox_id: u64,
@@ -535,12 +535,12 @@ impl Component {
         // routes a large config through it, mirroring `deliver`'s mail routing.
         // Present on macro-built guests (emitted by `export!`); absent on raw-FFI
         // guests, which then can't take an over-window config. The reserve
-        // (`mail_scratch::reserve`) is a module-level guest allocator, ready right
+        // (`kind_scratch::reserve`) is a module-level guest allocator, ready right
         // after instantiation and independent of the actor's `init`, so calling it
         // during `instantiate` before `init` is valid; config use is temporally
         // disjoint from mail use, so sharing the one buffer is safe.
-        let mail_scratch_reserve = instance
-            .get_typed_func::<u32, u32>(&mut store, "mail_scratch_reserve_p32")
+        let kind_scratch_reserve = instance
+            .get_typed_func::<u32, u32>(&mut store, "kind_scratch_reserve_p32")
             .ok();
         // Wasm32 ABI carries `u32` byte lengths; config bytes are
         // bounded by guest memory size (well below `u32::MAX`).
@@ -579,7 +579,7 @@ impl Component {
                     "guest init config of {} bytes exceeds the {MAX_DELIVERABLE_MAIL_BYTES}-byte deliverable bound",
                     config_bytes.len(),
                 )));
-            } else if let Some(reserve) = &mail_scratch_reserve {
+            } else if let Some(reserve) = &kind_scratch_reserve {
                 let ptr = reserve.call(&mut store, config_len)?;
                 memory.write(&mut store, ptr as usize, config_bytes)?;
                 ptr
@@ -587,7 +587,7 @@ impl Component {
                 Self::log_oversize_config(
                     &store,
                     config_bytes.len(),
-                    "guest exports no mail_scratch_reserve buffer (raw-FFI guest)",
+                    "guest exports no kind_scratch_reserve buffer (raw-FFI guest)",
                 );
                 return Err(wasmtime::Error::msg(format!(
                     "guest init config of {} bytes exceeds the {MAX_CONFIG_PAYLOAD_BYTES}-byte inline window and the guest exports no reserve buffer",
@@ -662,7 +662,7 @@ impl Component {
             unwire,
             on_replace,
             on_rehydrate,
-            mail_scratch_reserve,
+            kind_scratch_reserve,
             self_mailbox_id: mailbox_id,
         })
     }
@@ -739,7 +739,7 @@ impl Component {
         // substrate abort). Route by size:
         //   - small (<= MAX_MAIL_PAYLOAD_BYTES): fast inline write at MAIL_OFFSET.
         //   - larger (<= MAX_DELIVERABLE_MAIL_BYTES): a reusable guest-heap
-        //     buffer via `mail_scratch_reserve` — guest-owned, no overrun.
+        //     buffer via `kind_scratch_reserve` — guest-owned, no overrun.
         //   - beyond that, or no buffer export (raw-FFI guest): drop loudly.
         // A drop returns `Ok` without invoking `receive`, so the trampoline's
         // `forward_to_wasm` returns normally and the native dispatcher
@@ -755,13 +755,13 @@ impl Component {
         } else if payload_len > MAX_DELIVERABLE_MAIL_BYTES {
             self.log_dropped_oversize(mail, payload_len, "exceeds the absolute mail-size bound");
             return Ok(DISPATCH_DROPPED_OVERSIZE);
-        } else if let Some(reserve) = &self.mail_scratch_reserve {
+        } else if let Some(reserve) = &self.kind_scratch_reserve {
             reserve.call(&mut self.store, byte_len)?
         } else {
             self.log_dropped_oversize(
                 mail,
                 payload_len,
-                "guest exports no mail_scratch_reserve buffer (raw-FFI guest)",
+                "guest exports no kind_scratch_reserve buffer (raw-FFI guest)",
             );
             return Ok(DISPATCH_DROPPED_OVERSIZE);
         };
@@ -1062,7 +1062,7 @@ mod tests {
     "#;
 
     /// iamacoffeepot/aether#1337 Phase 2: fixture that exports
-    /// `mail_scratch_reserve_p32` (returning a fixed high offset, standing in
+    /// `kind_scratch_reserve_p32` (returning a fixed high offset, standing in
     /// for the reusable heap buffer) and a `receive_p32` that records the
     /// pointer it was handed at offset 16 — so a test can prove a large payload
     /// routes through the reserve pointer rather than `MAIL_OFFSET`. 80 pages
@@ -1070,7 +1070,7 @@ mod tests {
     const WAT_WITH_SCRATCH_BUFFER: &str = r#"
         (module
             (memory (export "memory") 80)
-            (func (export "mail_scratch_reserve_p32") (param i32) (result i32)
+            (func (export "kind_scratch_reserve_p32") (param i32) (result i32)
                 i32.const 2000000)
             (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                 i32.const 16
@@ -1134,7 +1134,7 @@ mod tests {
     "#;
 
     /// iamacoffeepot/aether#1390: a guest exporting BOTH `init_with_config_p32`
-    /// and `mail_scratch_reserve_p32`. The reserve returns a fixed high offset
+    /// and `kind_scratch_reserve_p32`. The reserve returns a fixed high offset
     /// (`2_000_000`) standing in for the reusable heap buffer; `init_with_config_p32`
     /// stamps the same `(mailbox_id, config_ptr, config_len)` triple `WAT_INIT_WITH_CONFIG`
     /// does and copies the first two config bytes — so a test can prove a large
@@ -1146,7 +1146,7 @@ mod tests {
             (memory (export "memory") 80)
             (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
                 i32.const 0)
-            (func (export "mail_scratch_reserve_p32") (param i32) (result i32)
+            (func (export "kind_scratch_reserve_p32") (param i32) (result i32)
                 i32.const 2000000)
             (func (export "init_with_config_p32") (param i64 i32 i32) (result i32)
                 ;; *(u32*)200 = low32(mailbox_id)
@@ -1188,7 +1188,7 @@ mod tests {
     "#;
 
     /// iamacoffeepot/aether#1390: a guest exporting `init_with_config_p32` but
-    /// NO `mail_scratch_reserve_p32`. 80 pages so a large config would *fit*
+    /// NO `kind_scratch_reserve_p32`. 80 pages so a large config would *fit*
     /// linear memory — the rejection must come from the missing reserve export,
     /// not a memory-bound trap. Stamps the same triple so a test could inspect
     /// it on the fast path (it is never reached for the oversize case).
@@ -1430,7 +1430,7 @@ mod tests {
     }
 
     /// iamacoffeepot/aether#1390: a config too large for the inline window but
-    /// within the deliverable bound rides the guest's `mail_scratch_reserve`
+    /// within the deliverable bound rides the guest's `kind_scratch_reserve`
     /// buffer — `init_with_config_p32` is handed the reserve pointer (not
     /// `CONFIG_OFFSET`) and the config bytes round-trip to it.
     #[test]
@@ -1473,7 +1473,7 @@ mod tests {
     }
 
     /// iamacoffeepot/aether#1390: a config too large for the inline window
-    /// delivered to a guest with NO `mail_scratch_reserve` export is a clean boot
+    /// delivered to a guest with NO `kind_scratch_reserve` export is a clean boot
     /// error, not a trap — the guard fires before the write even though the
     /// 80-page guest has room for the bytes.
     #[test]
@@ -1592,7 +1592,7 @@ mod tests {
 
     /// iamacoffeepot/aether#1337 Phase 2: a payload too large for the inline
     /// window but within the deliverable bound is carried through the guest's
-    /// `mail_scratch_reserve` buffer — `receive` runs (rc 0) and is handed the
+    /// `kind_scratch_reserve` buffer — `receive` runs (rc 0) and is handed the
     /// pointer the reserve export returned, not `MAIL_OFFSET`.
     #[test]
     fn deliver_routes_large_payload_through_reserve_buffer() {
@@ -1609,7 +1609,7 @@ mod tests {
         );
     }
 
-    /// A guest that exports no `mail_scratch_reserve` (raw-FFI, pre-Phase-2)
+    /// A guest that exports no `kind_scratch_reserve` (raw-FFI, pre-Phase-2)
     /// drops an over-inline-window payload cleanly rather than trapping on the
     /// write — the guard fires before `Memory::write`, regardless of guest
     /// memory size (single-page fixture here).

--- a/docs/adr/0090-application-configuration.md
+++ b/docs/adr/0090-application-configuration.md
@@ -251,7 +251,7 @@ The wire-encoded config bytes are written into the guest's linear memory before
 size, mirroring the mail path (#1337): a config at or below the fixed
 `CONFIG_OFFSET` window's `MAX_CONFIG_PAYLOAD_BYTES` cap lands inline at
 `CONFIG_OFFSET`; a larger config rides the same reusable guest-heap reserve buffer
-the large-mail path uses (`mail_scratch::reserve`), so a config that would overrun
+the large-mail path uses (`kind_scratch::reserve`), so a config that would overrun
 the low shadow-stack window is delivered heap-backed instead of clobbering the
 stack and trapping init. The reserve is a module-level guest allocator, ready
 right after instantiation and independent of the actor's `init`, and config use is


### PR DESCRIPTION
Closes iamacoffeepot/aether#1391.

## Summary

The guest-heap scratch buffer (#1337 Phase 2) carried only large mail until #1390 reused it to deliver a large init config. Config is itself a wire-encoded Kind (`FfiActor::Config`), the same shape as a mail payload, so the buffer fundamentally holds an inbound **Kind payload** — at init (config) or at runtime (mail). The `mail_scratch` name misled at the config call site.

Atomic ABI rename, host probe and guest export moved in lockstep (pre-1.0; components rebuild from source):

- `mail_scratch` module → `kind_scratch`
- `mail_scratch_reserve_p32` export → `kind_scratch_reserve_p32`
- `mail_scratch_reserve` host field/probe → `kind_scratch_reserve`
- doc comments reworded to "inbound Kind payload (mail or config)"
- ADR-0090's `mail_scratch::reserve` reference updated

Pure rename; no behavior change.

## Test plan

Full `scripts/preflight.sh` green (1475 passed), including the wasm32 component cross-build — the gate that proves the renamed guest export string and the host probe still agree. No new tests: mechanical rename, and the existing #1390 config-via-reserve tests exercise the probe + export end-to-end.

## Generated by

`/implement` — agent execution of scoped issue #1391.

---

Touches the same `component.rs` as #1389 but shares no lines or symbols with it (this renames identifiers; #1389 rewords the file header and offset comments generically), so the two PRs merge in any order.
