### PR TITLE
fix(skills): &&-guard the phase-label reconcile against a stalled gh call

### DIFF
--- a/.claude/skills/approve/SKILL.md
+++ b/.claude/skills/approve/SKILL.md
@@ -103,11 +103,11 @@ When `--skip-adr` is used, the audit comment is verbose:
 The board `Phase` field is only visible on the project board — not on the issue itself or in `gh issue list`. This skill mirrors every Phase write as a `phase:*` label on the issue so the lifecycle is legible at a glance, and the label never disagrees with the board. **In the same step you set the `Phase` field, reconcile the label:**
 
 ```bash
-gh issue edit <n> --remove-label "phase:define,phase:design,phase:plan,phase:ready,phase:executing,phase:refine,phase:bounced,phase:stalled"
-gh issue edit <n> --add-label "phase:<new>"
+gh issue edit <n> --remove-label "phase:define,phase:design,phase:plan,phase:ready,phase:executing,phase:refine,phase:bounced,phase:stalled" \
+  && gh issue edit <n> --add-label "phase:<new>"
 ```
 
-The remove and add are **two separate invocations** on purpose: a single `gh issue edit` with the target listed in both `--remove-label` and `--add-label` strips it and never re-adds it (the remove wins), so the issue ends up with no phase label on every real transition. Splitting the calls makes the add unconditional. `--remove-label` ignores labels the issue doesn't carry, so the first line is safe on any transition. The only write this skill makes is `Phase=Ready` → `phase:ready`. On idempotent re-run (already Ready) the reconcile is a harmless no-op; run it anyway so a hand-stripped label self-heals.
+`--remove-label` ignores labels the issue doesn't carry, so the remove is safe on any transition and idempotent on re-run (lowercased: `Phase=Ready` → `phase:ready`). The two calls are chained with `&&` so the add fires only after the remove succeeds — if the first `gh` call stalls or errors (a transient CLI or API outage), the chain stops there instead of stamping the new label onto an issue whose old phase label is still present, which would leave two phase labels on the board at once. A reconcile that fails partway leaves the prior label untouched and heals on the next run. The only write this skill makes is `Phase=Ready` → `phase:ready`. On idempotent re-run (already Ready) the reconcile is a harmless no-op; run it anyway so a hand-stripped label self-heals.
 
 ## Failure modes
 

--- a/.claude/skills/bounce/SKILL.md
+++ b/.claude/skills/bounce/SKILL.md
@@ -90,18 +90,18 @@ Same skill mechanism, different invocation site. `/bounce` is the user-driven va
 
 `Phase=Stalled` is a different signal — env/tooling failure, not a phase regression. Examples: qodana CI service down, GitHub API rate-limited mid-batch, `gh` token expired. The issue's scoping is fine; the *environment* is the problem.
 
-v1 has no `/stall` skill — set Stalled manually in the UI or via `gh project item-edit` with the BounceTo field left null. When you do, also set the `phase:stalled` label on the issue (`gh issue edit <n> --remove-label "phase:define,…,phase:bounced,phase:stalled"` then `gh issue edit <n> --add-label phase:stalled` — two calls, see [Phase label reconcile](#phase-label-reconcile)) so the halt is visible in `gh issue list`. Future `/stall <issue> --reason "<env-issue>"` would post the same kind of audit comment.
+v1 has no `/stall` skill — set Stalled manually in the UI or via `gh project item-edit` with the BounceTo field left null. When you do, also set the `phase:stalled` label on the issue (`gh issue edit <n> --remove-label "phase:define,…,phase:bounced,phase:stalled" && gh issue edit <n> --add-label phase:stalled` — `&&`-chained per [Phase label reconcile](#phase-label-reconcile)) so the halt is visible in `gh issue list`. Future `/stall <issue> --reason "<env-issue>"` would post the same kind of audit comment.
 
 ## Phase label reconcile
 
 The board `Phase` field is only visible on the project board — not on the issue itself or in `gh issue list`. This skill mirrors every Phase write as a `phase:*` label on the issue so the lifecycle is legible at a glance, and the label never disagrees with the board. **In the same step you set the `Phase` field, reconcile the label:**
 
 ```bash
-gh issue edit <n> --remove-label "phase:define,phase:design,phase:plan,phase:ready,phase:executing,phase:refine,phase:bounced,phase:stalled"
-gh issue edit <n> --add-label "phase:<new>"
+gh issue edit <n> --remove-label "phase:define,phase:design,phase:plan,phase:ready,phase:executing,phase:refine,phase:bounced,phase:stalled" \
+  && gh issue edit <n> --add-label "phase:<new>"
 ```
 
-The remove and add are **two separate invocations** on purpose: a single `gh issue edit` with the target listed in both `--remove-label` and `--add-label` strips it and never re-adds it (the remove wins), so the issue ends up with no phase label on every real transition. Splitting the calls makes the add unconditional. `--remove-label` ignores labels the issue doesn't carry, so the first line is safe on any transition. This skill writes `Phase=Bounced` (`phase:bounced`), and on the `/scope` resume contract `Phase=<BounceTo>` (`phase:<BounceTo>`).
+`--remove-label` ignores labels the issue doesn't carry, so the remove is safe on any transition and idempotent on re-run (lowercased: `Phase=Ready` → `phase:ready`). The two calls are chained with `&&` so the add fires only after the remove succeeds — if the first `gh` call stalls or errors (a transient CLI or API outage), the chain stops there instead of stamping the new label onto an issue whose old phase label is still present, which would leave two phase labels on the board at once. A reconcile that fails partway leaves the prior label untouched and heals on the next run. This skill writes `Phase=Bounced` (`phase:bounced`), and on the `/scope` resume contract `Phase=<BounceTo>` (`phase:<BounceTo>`).
 
 ## Failure modes
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -194,11 +194,11 @@ Both caps trigger self-bounce to Plan with the budget breach noted. The `AuthBud
 The board `Phase` field is only visible on the project board — not on the issue itself or in `gh issue list`. This skill mirrors every Phase write as a `phase:*` label on the issue so the lifecycle is legible at a glance, and the label never disagrees with the board. **In the same step you set the `Phase` field, reconcile the label:**
 
 ```bash
-gh issue edit <n> --remove-label "phase:define,phase:design,phase:plan,phase:ready,phase:executing,phase:refine,phase:bounced,phase:stalled"
-gh issue edit <n> --add-label "phase:<new>"
+gh issue edit <n> --remove-label "phase:define,phase:design,phase:plan,phase:ready,phase:executing,phase:refine,phase:bounced,phase:stalled" \
+  && gh issue edit <n> --add-label "phase:<new>"
 ```
 
-The remove and add are **two separate invocations** on purpose: a single `gh issue edit` with the target listed in both `--remove-label` and `--add-label` strips it and never re-adds it (the remove wins), so the issue ends up with no phase label on every real transition. Splitting the calls makes the add unconditional. `--remove-label` ignores labels the issue doesn't carry, so the first line is safe on any transition. This skill writes `Phase` in four places, each of which must reconcile the label: `Executing` (Execute step 1 + Refine-loop fix-push), `Refine` (Refine-loop fix-and-wait + done condition), `Bounced` (self-bounce on retry-cap / wall-clock / design discovery), and `Stalled` (build-env failure). `Done` carries no label — the merge that closes the issue retires the lifecycle.
+`--remove-label` ignores labels the issue doesn't carry, so the remove is safe on any transition and idempotent on re-run (lowercased: `Phase=Ready` → `phase:ready`). The two calls are chained with `&&` so the add fires only after the remove succeeds — if the first `gh` call stalls or errors (a transient CLI or API outage), the chain stops there instead of stamping the new label onto an issue whose old phase label is still present, which would leave two phase labels on the board at once. A reconcile that fails partway leaves the prior label untouched and heals on the next run. This skill writes `Phase` in four places, each of which must reconcile the label: `Executing` (Execute step 1 + Refine-loop fix-push), `Refine` (Refine-loop fix-and-wait + done condition), `Bounced` (self-bounce on retry-cap / wall-clock / design discovery), and `Stalled` (build-env failure). `Done` carries no label — the merge that closes the issue retires the lifecycle.
 
 ## Failure modes
 

--- a/.claude/skills/scope/SKILL.md
+++ b/.claude/skills/scope/SKILL.md
@@ -168,11 +168,11 @@ Cache item IDs per-issue per-run to avoid repeated lookups.
 The board `Phase` field is only visible on the project board — not on the issue itself or in `gh issue list`. This skill mirrors every Phase write as a `phase:*` label on the issue so the lifecycle is legible at a glance, and the label never disagrees with the board. **In the same step you set the `Phase` field, reconcile the label:**
 
 ```bash
-gh issue edit <n> --remove-label "phase:define,phase:design,phase:plan,phase:ready,phase:executing,phase:refine,phase:bounced,phase:stalled"
-gh issue edit <n> --add-label "phase:<new>"
+gh issue edit <n> --remove-label "phase:define,phase:design,phase:plan,phase:ready,phase:executing,phase:refine,phase:bounced,phase:stalled" \
+  && gh issue edit <n> --add-label "phase:<new>"
 ```
 
-The remove and add are **two separate invocations** on purpose: a single `gh issue edit` with the target listed in both `--remove-label` and `--add-label` strips it and never re-adds it (the remove wins), so the issue ends up with no phase label on every real transition. Splitting the calls makes the add unconditional. `--remove-label` ignores labels the issue doesn't carry, so the first line is safe on any transition. Two phases carry no label: `Backlog` (the resting/default state) and `Done` (the issue is closed). When moving to either, run only the remove line and skip the add. For this skill the writes are `Phase=Design`, `Phase=Plan`, and (on self-bounce) `Phase=Bounced`.
+`--remove-label` ignores labels the issue doesn't carry, so the remove is safe on any transition and idempotent on re-run (lowercased: `Phase=Ready` → `phase:ready`). The two calls are chained with `&&` so the add fires only after the remove succeeds — if the first `gh` call stalls or errors (a transient CLI or API outage), the chain stops there instead of stamping the new label onto an issue whose old phase label is still present, which would leave two phase labels on the board at once. A reconcile that fails partway leaves the prior label untouched and heals on the next run. Two phases carry no label — `Backlog` (the resting/default state) and `Done` (the issue is closed); when moving to either, drop the `&&` add and run the remove alone. For this skill the writes are `Phase=Design`, `Phase=Plan`, and (on self-bounce) `Phase=Bounced`.
 
 ## Restart and resume semantics
 


### PR DESCRIPTION
## Summary

Chain the phase-label reconcile's remove and add with `&&` so the add fires only after the remove succeeds. A transient `gh` or API outage can no longer stamp the new phase label onto an issue whose old one is still present — which would otherwise leave two phase labels on the board at once. A reconcile that fails partway leaves the prior label intact and heals on the next run.

Applied across the `scope`, `approve`, `implement`, and `bounce` reconcile sections, plus `bounce`'s inline `/stall` note, so all four stay consistent.

## Test plan

Skill-doc / repo-config only — no code paths change. Confirmed the four files carry the `&&`-chained command and render cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
