### PR TITLE
feat(actor): export multiple actors per wasm module

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -1933,6 +1933,31 @@ fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
             #(#helper_methods_tokens)*
         }
 
+        // ADR-0096: object-safe erasure so a multi-actor module's
+        // `export!(A, B, …)` arm can hold whichever exported type an
+        // instance became in one `Slot<Box<dyn ErasedFfiActor>>` and
+        // route the FFI shims through it. Forwards to the inherent
+        // dispatch table and the `FfiActor` lifecycle hooks; `init`
+        // stays concrete (the `export!` arm tag-matches and boxes).
+        impl #impl_generics ::aether_actor::ErasedFfiActor for #self_ty #where_clause {
+            fn erased_namespace(&self) -> &'static str {
+                <#self_ty as ::aether_actor::Actor>::NAMESPACE
+            }
+            fn erased_dispatch(
+                &mut self,
+                __aether_ctx: &mut ::aether_actor::FfiCtx<'_>,
+                __aether_mail: ::aether_actor::Mail<'_>,
+            ) -> u32 {
+                self.__aether_dispatch(__aether_ctx, __aether_mail)
+            }
+            fn erased_wire(&mut self, __aether_ctx: &mut ::aether_actor::FfiCtx<'_>) {
+                <#self_ty as ::aether_actor::FfiActor>::wire(self, __aether_ctx);
+            }
+            fn erased_unwire(&mut self, __aether_ctx: &mut ::aether_actor::FfiCtx<'_>) {
+                <#self_ty as ::aether_actor::FfiActor>::unwire(self, __aether_ctx);
+            }
+        }
+
         #kind_retention_statics
     })
 }

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -253,6 +253,39 @@ pub trait Replaceable: FfiActor {
     }
 }
 
+/// Object-safe erasure over a guest [`FfiActor`]'s post-construction
+/// surface (ADR-0096). A multi-actor module — `export!(A, B, …)` —
+/// holds whichever exported type a given instance became in one
+/// `Slot<Box<dyn ErasedFfiActor>>`, and the FFI shims route mail and
+/// lifecycle calls through this trait. `#[actor]` emits the impl per
+/// type, forwarding to the inherent `__aether_dispatch` and the
+/// `FfiActor` lifecycle hooks.
+///
+/// `init` is deliberately not erased: it is generic over the ctx and
+/// returns `Self`, so it cannot be a trait-object method. The
+/// `export!` multi-actor arm matches the inbound actor-type tag against
+/// each exported type and calls the concrete `T::init` before boxing
+/// the result as a `dyn ErasedFfiActor`.
+///
+/// Single-actor modules keep their concrete `Slot<T>` path and never
+/// box, so hot-swap (`Replaceable`) stays available there; the
+/// multi-actor arm is `no_replaceable` in v1 (replaceability per
+/// exported type is a follow-on).
+pub trait ErasedFfiActor {
+    /// The actor type's [`crate::Actor::NAMESPACE`], so the `receive`
+    /// shim can derive the instance's own mailbox id for self-addressing.
+    fn erased_namespace(&self) -> &'static str;
+
+    /// Forwards to the `#[actor]`-synthesized `__aether_dispatch`.
+    fn erased_dispatch(&mut self, ctx: &mut FfiCtx<'_>, mail: crate::Mail<'_>) -> u32;
+
+    /// Forwards to [`FfiActor::wire`].
+    fn erased_wire(&mut self, ctx: &mut FfiCtx<'_>);
+
+    /// Forwards to [`FfiActor::unwire`].
+    fn erased_unwire(&mut self, ctx: &mut FfiCtx<'_>);
+}
+
 /// Generic guest allocator backing host→guest payload delivery (ADR-0095).
 ///
 /// The substrate writes every inbound payload — mail, init config, rehydrate

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -286,6 +286,22 @@ pub trait ErasedFfiActor {
     fn erased_unwire(&mut self, ctx: &mut FfiCtx<'_>);
 }
 
+/// Stage a guest init-failure message into the substrate via
+/// `init_failed_p32` (ADR-0096). Shared by the multi-actor `export!`
+/// init shims so the byte-staging boilerplate isn't repeated at each
+/// construction site. wasm32-only — the host build carries no FFI
+/// surface.
+#[cfg(target_arch = "wasm32")]
+#[doc(hidden)]
+pub fn stage_init_failure(message: &str) {
+    let bytes = message.as_bytes();
+    // SAFETY: `init_failed` copies `len` bytes from `ptr` into the
+    // substrate synchronously; the borrowed slice outlives the call.
+    unsafe {
+        raw::init_failed(bytes.as_ptr().addr() as u32, bytes.len() as u32);
+    }
+}
+
 /// Generic guest allocator backing host→guest payload delivery (ADR-0095).
 ///
 /// The substrate writes every inbound payload — mail, init config, rehydrate
@@ -795,11 +811,9 @@ macro_rules! __export_multi_internal {
                     return $crate::__export_multi_internal!(@construct $component, mailbox_id, config_bytes);
                 }
             )+
-            let msg = "guest init: unknown actor-type tag for multi-actor module";
-            let bytes = msg.as_bytes();
-            unsafe {
-                $crate::ffi::raw::init_failed(bytes.as_ptr().addr() as u32, bytes.len() as u32);
-            }
+            $crate::ffi::stage_init_failure(
+                "guest init: unknown actor-type tag for multi-actor module",
+            );
             1
         }
 
@@ -901,15 +915,11 @@ macro_rules! __export_multi_internal {
         >::decode_from_bytes($config_bytes) {
             ::core::option::Option::Some(c) => c,
             ::core::option::Option::None => {
-                let msg = ::core::concat!(
+                $crate::ffi::stage_init_failure(::core::concat!(
                     "guest init: ",
                     ::core::stringify!($ty),
                     " could not decode Config from bytes",
-                );
-                let bytes = msg.as_bytes();
-                unsafe {
-                    $crate::ffi::raw::init_failed(bytes.as_ptr().addr() as u32, bytes.len() as u32);
-                }
+                ));
                 return 1;
             }
         };
@@ -925,11 +935,7 @@ macro_rules! __export_multi_internal {
                 0
             }
             ::core::result::Result::Err(err) => {
-                let msg = err.message();
-                let bytes = msg.as_bytes();
-                unsafe {
-                    $crate::ffi::raw::init_failed(bytes.as_ptr().addr() as u32, bytes.len() as u32);
-                }
+                $crate::ffi::stage_init_failure(err.message());
                 1
             }
         }

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -375,11 +375,21 @@ pub mod guest_alloc {
 /// `replaceable` flag — `aether_actor::export!(Hello, replaceable);`.
 #[macro_export]
 macro_rules! export {
+    // Order matters: the `, replaceable` arm is tried before the
+    // variadic multi-actor arm so `export!(Foo, replaceable)` matches
+    // the literal `replaceable` token rather than parsing it as a
+    // second exported type.
+    ($component:ty, replaceable) => {
+        $crate::__export_internal!($component, replaceable);
+    };
     ($component:ty) => {
         $crate::__export_internal!($component, no_replaceable);
     };
-    ($component:ty, replaceable) => {
-        $crate::__export_internal!($component, replaceable);
+    // ADR-0096: multi-actor module — two or more `FfiActor` types in one
+    // crate. Requires at least a first + one more so it never shadows
+    // the single-actor arms above. `no_replaceable` in v1.
+    ($first:ty $(, $rest:ty)+ $(,)?) => {
+        $crate::__export_multi_internal!(@entry $first ; @all $first $(, $rest)+);
     };
 }
 
@@ -675,4 +685,253 @@ macro_rules! __export_internal {
     (@on_rehydrate replaceable, $component:ty, $instance:ident, $ctx:ident, $prior:ident) => {
         <$component as $crate::Replaceable>::on_rehydrate($instance, &mut $ctx, $prior);
     };
+}
+
+/// ADR-0096: FFI shims for a multi-actor module — `export!(A, B, …)`.
+///
+/// One module-level `Slot<Box<dyn ErasedFfiActor>>` holds whichever
+/// exported type the instance became. Two construction entry points:
+///
+/// - `init_with_config_p32` (the existing 3-arg ABI) constructs the
+///   **entry** type (the first in the `export!` list). A host that
+///   knows nothing about multi-actor modules loads the entry type with
+///   no changes.
+/// - `init_typed_p32` (4-arg, carries an actor-type tag) matches the
+///   tag against each exported type's `mailbox_id_from_name(NAMESPACE)`
+///   and constructs the selected one. The host calls this once it can
+///   resolve an export selector to a tag (the follow-on PR).
+///
+/// `receive` / `wire` / `unwire` route through the boxed
+/// `ErasedFfiActor`. The `aether.kinds.inputs` / `aether.namespace`
+/// sections carry the **entry** type today; per-type framing arrives
+/// with the selector work. Multi-actor modules are `no_replaceable` in
+/// v1 — `on_replace` / `on_rehydrate` are emitted as no-ops.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __export_multi_internal {
+    (@entry $entry:ty ; @all $($component:ty),+) => {
+        static __AETHER_MULTI: $crate::Slot<
+            $crate::__macro_internals::Box<dyn $crate::ErasedFfiActor>
+        > = $crate::Slot::new();
+
+        // Entry type's manifest + namespace (single-actor section
+        // format) so an unmodified host reads the loadable surface.
+        #[cfg(target_arch = "wasm32")]
+        #[used]
+        #[unsafe(link_section = "aether.kinds.inputs")]
+        static __AETHER_INPUTS_SECTION: [u8; <$entry>::__AETHER_INPUTS_MANIFEST_LEN] =
+            <$entry>::__AETHER_INPUTS_MANIFEST;
+
+        #[cfg(target_arch = "wasm32")]
+        #[used]
+        #[unsafe(link_section = "aether.namespace")]
+        static __AETHER_NAMESPACE_SECTION: [u8; <$entry as $crate::Actor>::NAMESPACE.len()] = {
+            let bytes = <$entry as $crate::Actor>::NAMESPACE.as_bytes();
+            let mut out = [0u8; <$entry as $crate::Actor>::NAMESPACE.len()];
+            let mut i = 0;
+            while i < bytes.len() {
+                out[i] = bytes[i];
+                i += 1;
+            }
+            out
+        };
+
+        /// # Safety
+        /// Existing 3-arg init ABI; constructs the entry (first) export.
+        #[cfg(target_arch = "wasm32")]
+        #[unsafe(export_name = "init_with_config_p32")]
+        pub unsafe extern "C" fn init_with_config(
+            mailbox_id: u64,
+            config_ptr: u32,
+            config_len: u32,
+        ) -> u32 {
+            $crate::log::install_wasm_subscriber();
+            let config_bytes: &[u8] = if config_len == 0 {
+                &[]
+            } else {
+                // SAFETY: substrate wrote `config_len` bytes at `config_ptr` (ADR-0090).
+                unsafe {
+                    ::core::slice::from_raw_parts(config_ptr as usize as *const u8, config_len as usize)
+                }
+            };
+            $crate::__export_multi_internal!(@construct $entry, mailbox_id, config_bytes)
+        }
+
+        /// # Safety
+        /// ADR-0090 legacy zero-config init; forwards to the entry type.
+        #[cfg(target_arch = "wasm32")]
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn init(mailbox_id: u64) -> u32 {
+            unsafe { init_with_config(mailbox_id, 0, 0) }
+        }
+
+        /// # Safety
+        /// ADR-0096 typed init: `type_tag` selects which exported type
+        /// to construct (its `mailbox_id_from_name(NAMESPACE)`).
+        #[cfg(target_arch = "wasm32")]
+        #[unsafe(export_name = "init_typed_p32")]
+        pub unsafe extern "C" fn init_typed(
+            mailbox_id: u64,
+            type_tag: u64,
+            config_ptr: u32,
+            config_len: u32,
+        ) -> u32 {
+            $crate::log::install_wasm_subscriber();
+            let config_bytes: &[u8] = if config_len == 0 {
+                &[]
+            } else {
+                // SAFETY: substrate wrote `config_len` bytes at `config_ptr` (ADR-0090).
+                unsafe {
+                    ::core::slice::from_raw_parts(config_ptr as usize as *const u8, config_len as usize)
+                }
+            };
+            $(
+                if type_tag
+                    == $crate::__macro_internals::mailbox_id_from_name(
+                        <$component as $crate::Actor>::NAMESPACE,
+                    )
+                    .0
+                {
+                    return $crate::__export_multi_internal!(@construct $component, mailbox_id, config_bytes);
+                }
+            )+
+            let msg = "guest init: unknown actor-type tag for multi-actor module";
+            let bytes = msg.as_bytes();
+            unsafe {
+                $crate::ffi::raw::init_failed(bytes.as_ptr().addr() as u32, bytes.len() as u32);
+            }
+            1
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn wire(mailbox_id: u64) -> u32 {
+            let Some(instance) = (unsafe { __AETHER_MULTI.get_mut() }) else {
+                return 1;
+            };
+            let mut ctx: $crate::FfiCtx<'_> = $crate::FfiCtx::__new(mailbox_id);
+            instance.erased_wire(&mut ctx);
+            0
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn unwire(mailbox_id: u64) -> u32 {
+            let Some(instance) = (unsafe { __AETHER_MULTI.get_mut() }) else {
+                return 1;
+            };
+            let mut ctx: $crate::FfiCtx<'_> = $crate::FfiCtx::__new(mailbox_id);
+            instance.erased_unwire(&mut ctx);
+            0
+        }
+
+        /// # Safety
+        /// FFI receive contract (ADR-0024); routes through the boxed
+        /// `ErasedFfiActor`. Self-mailbox id derived from the live
+        /// instance's namespace.
+        #[cfg(target_arch = "wasm32")]
+        #[unsafe(export_name = "receive_p32")]
+        pub unsafe extern "C" fn receive(
+            kind: u64,
+            ptr: u32,
+            byte_len: u32,
+            count: u32,
+            sender: u32,
+        ) -> u32 {
+            let Some(instance) = (unsafe { __AETHER_MULTI.get_mut() }) else {
+                return 1;
+            };
+            let mailbox_id = $crate::__macro_internals::mailbox_id_from_name(
+                instance.erased_namespace(),
+            )
+            .0;
+            let mut ctx: $crate::FfiCtx<'_> = $crate::FfiCtx::__new(mailbox_id);
+            let mail = unsafe { $crate::Mail::__from_raw(kind, ptr, byte_len, count, sender) };
+            instance.erased_dispatch(&mut ctx, mail)
+        }
+
+        /// ADR-0095 guest allocator — identical to the single-actor arm.
+        ///
+        /// # Safety
+        /// Called by the substrate per the layout contract.
+        #[cfg(target_arch = "wasm32")]
+        #[unsafe(export_name = "realloc_p32")]
+        pub unsafe extern "C" fn realloc_p32(
+            old_ptr: u32,
+            old_size: u32,
+            align: u32,
+            new_size: u32,
+        ) -> u32 {
+            unsafe {
+                $crate::ffi::guest_alloc::realloc_bytes(
+                    old_ptr as *mut u8,
+                    old_size as usize,
+                    align as usize,
+                    new_size as usize,
+                )
+                .addr() as u32
+            }
+        }
+
+        /// # Safety
+        /// Multi-actor modules are `no_replaceable` in v1 — no-op.
+        #[cfg(target_arch = "wasm32")]
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn on_replace() -> u32 {
+            let _ = unsafe { __AETHER_MULTI.get_mut() };
+            0
+        }
+
+        /// # Safety
+        /// Multi-actor modules are `no_replaceable` in v1 — prior state
+        /// is ignored.
+        #[cfg(target_arch = "wasm32")]
+        #[unsafe(export_name = "on_rehydrate_p32")]
+        pub unsafe extern "C" fn on_rehydrate(_version: u32, _ptr: u32, _len: u32) -> u32 {
+            0
+        }
+    };
+
+    // Decode `$ty`'s Config from `$config_bytes`, run its `init`, and box
+    // the result into `__AETHER_MULTI`. Expands inline in an init shim;
+    // a decode/init failure stages the message and `return 1`.
+    (@construct $ty:ty, $mailbox_id:ident, $config_bytes:ident) => {{
+        let config = match <
+            <$ty as $crate::FfiActor>::Config as $crate::__macro_internals::Kind
+        >::decode_from_bytes($config_bytes) {
+            ::core::option::Option::Some(c) => c,
+            ::core::option::Option::None => {
+                let msg = ::core::concat!(
+                    "guest init: ",
+                    ::core::stringify!($ty),
+                    " could not decode Config from bytes",
+                );
+                let bytes = msg.as_bytes();
+                unsafe {
+                    $crate::ffi::raw::init_failed(bytes.as_ptr().addr() as u32, bytes.len() as u32);
+                }
+                return 1;
+            }
+        };
+        let mut ctx: $crate::FfiInitCtx<'_> = $crate::FfiInitCtx::__new($mailbox_id);
+        match <$ty as $crate::FfiActor>::init(config, &mut ctx) {
+            ::core::result::Result::Ok(instance) => {
+                unsafe {
+                    __AETHER_MULTI.set(
+                        $crate::__macro_internals::Box::new(instance)
+                            as $crate::__macro_internals::Box<dyn $crate::ErasedFfiActor>,
+                    );
+                }
+                0
+            }
+            ::core::result::Result::Err(err) => {
+                let msg = err.message();
+                let bytes = msg.as_bytes();
+                unsafe {
+                    $crate::ffi::raw::init_failed(bytes.as_ptr().addr() as u32, bytes.len() as u32);
+                }
+                1
+            }
+        }
+    }};
 }

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -82,7 +82,10 @@ pub use mail::{Mail, NO_REPLY_HANDLE, PriorState, ReplyTo};
 // FFI surface promoted to the crate root so consumers see
 // `aether_actor::FfiCtx<'_>` / `aether_actor::FfiActor` / etc. without
 // an extra `ffi::` segment.
-pub use ffi::{BootError, FfiActor, FfiActorMailbox, FfiCtx, FfiDropCtx, FfiInitCtx, Replaceable};
+pub use ffi::{
+    BootError, ErasedFfiActor, FfiActor, FfiActorMailbox, FfiCtx, FfiDropCtx, FfiInitCtx,
+    Replaceable,
+};
 
 // Issue 665 retired `MailTransport` and its `MailTransportTrait`
 // alias. Per-stage capability traits in `actor::ctx` are the

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -118,6 +118,10 @@ pub const DISPATCH_UNKNOWN_KIND: u32 = 1;
 pub mod __macro_internals {
     pub use aether_data::__derive_runtime::{Cow, KindLabels, SchemaType, canonical};
     pub use aether_data::{Kind, Schema, mailbox_id_from_name};
+    // ADR-0096: the multi-actor `export!` arm stores the instance as
+    // `Box<dyn ErasedFfiActor>`; re-export `Box` so the emitted code
+    // doesn't depend on the guest crate's prelude exposing `alloc`.
+    pub use alloc::boxed::Box;
 }
 
 /// ADR-0033 attribute macros and `Kind` / `Schema` derives, behind

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -137,6 +137,56 @@ fn input_subscription_yields_one_tick_observed_per_advance() {
     );
 }
 
+/// ADR-0096: a multi-actor module (`export!(RootManager, Panel)`) loads
+/// through the unmodified host, instantiating its entry export — the
+/// first type in the list, `RootManager` — via the boxed
+/// `ErasedFfiActor` path. Omitting `name` exercises the `aether.namespace`
+/// section, which carries the entry type's `NAMESPACE` (`ui.root`), and
+/// the `LoadResult` capabilities come from the entry type's
+/// `aether.kinds.inputs` manifest. Proves init-through-the-box and the
+/// multi-actor section emission end-to-end; selecting the `Panel` export
+/// is the follow-on.
+#[test]
+fn multi_actor_module_loads_entry_export() {
+    let Some(wasm_path) = require_runtime("multi_actor") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let wasm = fs::read(&wasm_path).expect("read fixture wasm");
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm,
+                    // No name: resolve from the entry type's aether.namespace section.
+                    name: None,
+                    config: Vec::new(),
+                },
+            ),
+        )])
+        .expect("load sequence");
+    match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Ok {
+            name, capabilities, ..
+        } => {
+            assert!(
+                name.ends_with(":ui.root"),
+                "entry export should resolve to the first type's NAMESPACE (ui.root); got {name}",
+            );
+            assert!(
+                !capabilities.handlers.is_empty(),
+                "entry export RootManager declares a Ping handler; capabilities.handlers was empty",
+            );
+        }
+        LoadResult::Err { error } => panic!("multi-actor load failed: {error}"),
+    }
+}
+
 /// Dropping the probe stops further `tick_observed` broadcasts.
 /// Validates that `aether.component.drop` removes the
 /// mailbox from the input subscriber set so subsequent ticks don't

--- a/crates/aether-test-fixtures/Cargo.toml
+++ b/crates/aether-test-fixtures/Cargo.toml
@@ -49,5 +49,12 @@ crate-type = ["cdylib"]
 name = "probe_with_config"
 crate-type = ["cdylib"]
 
+# ADR-0096 multi-actor module fixture: two FfiActor types exported from
+# one crate via `export!(RootManager, Panel)`. Cross-builds to one wasm
+# module carrying both; an unmodified host loads the entry type.
+[[example]]
+name = "multi_actor"
+crate-type = ["cdylib"]
+
 [lints]
 workspace = true

--- a/crates/aether-test-fixtures/examples/multi_actor.rs
+++ b/crates/aether-test-fixtures/examples/multi_actor.rs
@@ -1,0 +1,54 @@
+//! ADR-0096 fixture: a multi-actor module. Two `FfiActor` types in one
+//! crate, exported together via `export!(RootManager, Panel)`. Proves
+//! multi-type coexistence in a single wasm module (no duplicate-symbol
+//! collision, which ADR-0014 §4 previously forbade) and that the entry
+//! type (the first export, `RootManager`) loads through an unmodified
+//! host. Selecting the non-entry export (`Panel`) is the follow-on PR.
+
+// `#[handler]` methods take `&mut self` to match the dispatch ABI even
+// when stateless.
+#![allow(clippy::unused_self)]
+
+use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
+use aether_kinds::Ping;
+
+/// Entry export — the first type in the `export!` list. An unmodified
+/// host instantiates this one.
+pub struct RootManager;
+
+#[actor]
+impl FfiActor for RootManager {
+    const NAMESPACE: &'static str = "ui.root";
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
+    where
+        C: Resolver,
+    {
+        Ok(RootManager)
+    }
+
+    #[handler]
+    fn on_ping(&mut self, _ctx: &mut FfiCtx<'_>, _ping: Ping) {}
+}
+
+/// Sibling export — reachable once the host can resolve an export
+/// selector to its actor-type tag (follow-on PR). Present here to prove
+/// two `#[actor]` types coexist in one module.
+pub struct Panel;
+
+#[actor]
+impl FfiActor for Panel {
+    const NAMESPACE: &'static str = "ui.panel";
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
+    where
+        C: Resolver,
+    {
+        Ok(Panel)
+    }
+
+    #[handler]
+    fn on_ping(&mut self, _ctx: &mut FfiCtx<'_>, _ping: Ping) {}
+}
+
+aether_actor::export!(RootManager, Panel);


### PR DESCRIPTION
Part of #1363 (ADR-0096). Foundation half — the guest-side multi-actor module. The host-side export selector (`init_typed_p32` + `LoadComponent.export` + per-type manifest) is the follow-on PR, which closes the issue.

## Summary

A wasm crate can now export multiple `FfiActor` types from one module: `export!(RootManager, Panel, ...)`. The keystone is an object-safe `ErasedFfiActor` trait, emitted per type by `#[actor]`, so one `Slot<Box<dyn ErasedFfiActor>>` holds whichever exported type an instance became and the FFI shims route mail + lifecycle through it. This lifts ADR-0014 §4 ("one actor per guest crate", previously a duplicate-symbol compile error).

Two construction entry points:

- `init_with_config_p32` (the existing 3-arg ABI) constructs the **entry** export — the first type in the list — so a host that knows nothing about multi-actor modules loads it with zero change.
- `init_typed_p32` (4-arg, carries an actor-type tag = `mailbox_id_from_name(NAMESPACE)`) selects any export. Wired here; consumed by the host in the follow-on.

The `aether.kinds.inputs` / `aether.namespace` sections carry the entry type today; per-type framing arrives with the selector work. Multi-actor modules are `no_replaceable` in v1. The single-actor `export!` path is untouched (zero regression surface).

## Test plan

- `multi_actor` fixture (`RootManager` + `Panel`) in `aether-test-fixtures` cross-builds to one wasm module — proves two `#[actor]` types coexist with no symbol collision. CI's wasm32 component cross-build covers it.
- `multi_actor_module_loads_entry_export` (test-bench): loads the fixture through the unmodified host, asserts the entry export resolves `ui.root` and instantiates through the boxed `ErasedFfiActor` path with its handler manifest read back.
- Single-actor regression: existing component scenarios (`probe`, `typed_config`, input subscriptions, replace) are unchanged and green.

## Generated by

`/implement` — agent execution of the scoped foundation half of issue #1363.

Local preflight: fmt + clippy + doc + wasm32 cross-build green; nextest 1476/1477, where the single failure each run was a documented `::heavy::` / handle-store-contention flake (both pass in isolation, neither touches this change). CI is the authoritative gate.
