### PR TITLE
feat(substrate): select a wasm actor export by namespace at load

### DIFF
--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -718,10 +718,14 @@ macro_rules! __export_internal {
 ///   resolve an export selector to a tag (the follow-on PR).
 ///
 /// `receive` / `wire` / `unwire` route through the boxed
-/// `ErasedFfiActor`. The `aether.kinds.inputs` / `aether.namespace`
-/// sections carry the **entry** type today; per-type framing arrives
-/// with the selector work. Multi-actor modules are `no_replaceable` in
-/// v1 — `on_replace` / `on_rehydrate` are emitted as no-ops.
+/// `ErasedFfiActor`. The `aether.kinds.inputs` section carries every
+/// exported type's records, each preceded by an `ActorBoundary`
+/// (ADR-0096), so the host can regroup per type and resolve an export
+/// selector to a tag. The `aether.namespace` section names the
+/// **entry** type — the default mailbox name when the load omits both
+/// an explicit name and an export selector. Multi-actor modules are
+/// `no_replaceable` in v1 — `on_replace` / `on_rehydrate` are emitted
+/// as no-ops.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __export_multi_internal {
@@ -730,13 +734,62 @@ macro_rules! __export_multi_internal {
             $crate::__macro_internals::Box<dyn $crate::ErasedFfiActor>
         > = $crate::Slot::new();
 
-        // Entry type's manifest + namespace (single-actor section
-        // format) so an unmodified host reads the loadable surface.
+        // ADR-0096: per-actor `aether.kinds.inputs` section. Each
+        // exported type's records are preceded by an
+        // `ActorBoundary { namespace }` record (version-tagged like
+        // every other record) so the host's
+        // `read_actor_inputs_from_bytes` regroups the flat record
+        // stream into one capability set per type. The entry type is
+        // first. A single-actor `export!` never reaches this arm, so
+        // the boundary-free single-actor layout stays byte-identical.
+        #[cfg(target_arch = "wasm32")]
+        const __AETHER_MULTI_INPUTS_LEN: usize = 0usize $(
+            + 1
+            + $crate::__macro_internals::canonical::inputs_actor_boundary_len(
+                <$component as $crate::Actor>::NAMESPACE,
+            )
+            + <$component>::__AETHER_INPUTS_MANIFEST_LEN
+        )+;
+
         #[cfg(target_arch = "wasm32")]
         #[used]
         #[unsafe(link_section = "aether.kinds.inputs")]
-        static __AETHER_INPUTS_SECTION: [u8; <$entry>::__AETHER_INPUTS_MANIFEST_LEN] =
-            <$entry>::__AETHER_INPUTS_MANIFEST;
+        static __AETHER_INPUTS_SECTION: [u8; __AETHER_MULTI_INPUTS_LEN] = {
+            let mut out = [0u8; __AETHER_MULTI_INPUTS_LEN];
+            let mut pos = 0usize;
+            $(
+                {
+                    const BR_LEN: usize =
+                        $crate::__macro_internals::canonical::inputs_actor_boundary_len(
+                            <$component as $crate::Actor>::NAMESPACE,
+                        );
+                    const BR_BYTES: [u8; BR_LEN] =
+                        $crate::__macro_internals::canonical::write_inputs_actor_boundary::<BR_LEN>(
+                            <$component as $crate::Actor>::NAMESPACE,
+                        );
+                    // Per-record section version byte (0x02), in lockstep
+                    // with `INPUTS_SECTION_VERSION`.
+                    out[pos] = 0x02;
+                    pos += 1;
+                    let mut i = 0;
+                    while i < BR_LEN {
+                        out[pos] = BR_BYTES[i];
+                        pos += 1;
+                        i += 1;
+                    }
+                    const MAN_LEN: usize = <$component>::__AETHER_INPUTS_MANIFEST_LEN;
+                    const MAN_BYTES: [u8; MAN_LEN] = <$component>::__AETHER_INPUTS_MANIFEST;
+                    let mut j = 0;
+                    while j < MAN_LEN {
+                        out[pos] = MAN_BYTES[j];
+                        pos += 1;
+                        j += 1;
+                    }
+                }
+            )+
+            let _ = pos;
+            out
+        };
 
         #[cfg(target_arch = "wasm32")]
         #[used]

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -759,12 +759,14 @@ macro_rules! __export_multi_internal {
             let mut pos = 0usize;
             $(
                 {
-                    const BR_LEN: usize =
+                    // The per-type `ActorBoundary` record, then that
+                    // type's own `aether.kinds.inputs` manifest bytes.
+                    const BOUNDARY_LEN: usize =
                         $crate::__macro_internals::canonical::inputs_actor_boundary_len(
                             <$component as $crate::Actor>::NAMESPACE,
                         );
-                    const BR_BYTES: [u8; BR_LEN] =
-                        $crate::__macro_internals::canonical::write_inputs_actor_boundary::<BR_LEN>(
+                    const BOUNDARY_BYTES: [u8; BOUNDARY_LEN] =
+                        $crate::__macro_internals::canonical::write_inputs_actor_boundary::<BOUNDARY_LEN>(
                             <$component as $crate::Actor>::NAMESPACE,
                         );
                     // Per-record section version byte (0x02), in lockstep
@@ -772,16 +774,17 @@ macro_rules! __export_multi_internal {
                     out[pos] = 0x02;
                     pos += 1;
                     let mut i = 0;
-                    while i < BR_LEN {
-                        out[pos] = BR_BYTES[i];
+                    while i < BOUNDARY_LEN {
+                        out[pos] = BOUNDARY_BYTES[i];
                         pos += 1;
                         i += 1;
                     }
-                    const MAN_LEN: usize = <$component>::__AETHER_INPUTS_MANIFEST_LEN;
-                    const MAN_BYTES: [u8; MAN_LEN] = <$component>::__AETHER_INPUTS_MANIFEST;
+                    const MANIFEST_LEN: usize = <$component>::__AETHER_INPUTS_MANIFEST_LEN;
+                    const MANIFEST_BYTES: [u8; MANIFEST_LEN] =
+                        <$component>::__AETHER_INPUTS_MANIFEST;
                     let mut j = 0;
-                    while j < MAN_LEN {
-                        out[pos] = MAN_BYTES[j];
+                    while j < MANIFEST_LEN {
+                        out[pos] = MANIFEST_BYTES[j];
                         pos += 1;
                         j += 1;
                     }

--- a/crates/aether-actor/tests/handlers_manifest.rs
+++ b/crates/aether-actor/tests/handlers_manifest.rs
@@ -126,6 +126,10 @@ fn manifest_const_round_trips_to_expected_records() {
             InputsRecord::Config { .. } => {
                 panic!("unexpected Config record for a no-config component")
             }
+            // ADR-0096: single-actor `export!` emits no boundary record.
+            InputsRecord::ActorBoundary { .. } => {
+                panic!("unexpected ActorBoundary record for a single-actor module")
+            }
         }
     }
 

--- a/crates/aether-camera/tests/scenario.rs
+++ b/crates/aether-camera/tests/scenario.rs
@@ -71,6 +71,7 @@ fn load_camera(bench: &mut TestBench, wasm_path: &Path) {
                     wasm,
                     name: Some(COMPONENT_NAME.to_owned()),
                     config: Vec::new(),
+                    export: None,
                 },
             ),
         )])

--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -103,7 +103,7 @@ mod native {
     use aether_actor::actor;
     use aether_actor::actor::ctx::OutboundReply;
     use aether_data::Kind;
-    use aether_kinds::LoadResult;
+    use aether_kinds::{ComponentCapabilities, LoadResult};
     use wasmtime::{Engine, Linker, Module};
 
     use super::{DropComponent, LoadComponent, ReplaceComponent, UnsubscribeAll};
@@ -247,10 +247,49 @@ mod native {
                 return LoadResult::Err { error };
             }
 
-            // 2. Parse capabilities manifest (ADR-0033).
-            let capabilities = match kind_manifest::read_inputs_from_bytes(&payload.wasm) {
-                Ok(c) => c,
+            // 2. Parse the per-actor capability manifest (ADR-0033 /
+            //    ADR-0096) and resolve which exported type to load.
+            //    `export: None` selects the entry (first) type — the
+            //    only type a single-actor module has — so the legacy
+            //    load is unchanged. A named selector must match one of
+            //    the module's `ActorBoundary` namespaces, else the load
+            //    fails cleanly. The selected type's `type_tag` drives
+            //    `init_typed_p32` at instantiate; `None` keeps the
+            //    legacy entry-init path.
+            let actors = match kind_manifest::read_actor_inputs_from_bytes(&payload.wasm) {
+                Ok(a) => a,
                 Err(error) => return LoadResult::Err { error },
+            };
+            let (capabilities, type_tag, selected_namespace): (
+                ComponentCapabilities,
+                Option<u64>,
+                Option<String>,
+            ) = match &payload.export {
+                Some(requested) => {
+                    let Some(group) = actors
+                        .iter()
+                        .find(|a| a.namespace.as_deref() == Some(requested.as_str()))
+                    else {
+                        let available: Vec<&str> = actors
+                            .iter()
+                            .filter_map(|a| a.namespace.as_deref())
+                            .collect();
+                        return LoadResult::Err {
+                            error: format!(
+                                "export {requested:?} not found in module; exported types: {available:?}"
+                            ),
+                        };
+                    };
+                    (
+                        group.capabilities.clone(),
+                        Some(aether_data::mailbox_id_from_name(requested).0),
+                        Some(requested.clone()),
+                    )
+                }
+                None => match actors.into_iter().next() {
+                    Some(entry) => (entry.capabilities, None, entry.namespace),
+                    None => (ComponentCapabilities::default(), None, None),
+                },
             };
 
             // 3. Compile module.
@@ -263,17 +302,23 @@ mod native {
                 }
             };
 
-            // 4. Resolve the component name. Caller > wasm-declared >
-            // monotonic default.
+            // 4. Resolve the component name. Caller > selected export's
+            // namespace > wasm-declared entry namespace > monotonic
+            // default. A non-entry export defaults its mailbox name to
+            // the selected type's namespace, the multi-actor analog of
+            // the single-actor `aether.namespace` fallback.
             let name = match payload.name {
                 Some(n) => n,
-                None => match kind_manifest::read_namespace_from_bytes(&payload.wasm) {
-                    Ok(Some(declared)) => declared,
-                    Ok(None) => {
-                        let n = self.default_name_counter.fetch_add(1, Ordering::Relaxed);
-                        format!("component_{n}")
-                    }
-                    Err(error) => return LoadResult::Err { error },
+                None => match selected_namespace {
+                    Some(ns) => ns,
+                    None => match kind_manifest::read_namespace_from_bytes(&payload.wasm) {
+                        Ok(Some(declared)) => declared,
+                        Ok(None) => {
+                            let n = self.default_name_counter.fetch_add(1, Ordering::Relaxed);
+                            format!("component_{n}")
+                        }
+                        Err(error) => return LoadResult::Err { error },
+                    },
                 },
             };
 
@@ -295,6 +340,11 @@ mod native {
                 // bytes into the trampoline; `WasmTrampoline::init` hands
                 // them to the guest's typed `init`.
                 config: payload.config,
+                // ADR-0096: the selected export's actor-type tag, threaded
+                // through to `Component::instantiate` so it calls
+                // `init_typed_p32`. `None` = entry type (single-actor
+                // modules and unselected loads keep the legacy init path).
+                type_tag,
             };
             let mailbox_id = match ctx
                 .spawn_child::<WasmTrampoline>(Subname::Named(&name), trampoline_config)

--- a/crates/aether-capabilities/src/trampoline.rs
+++ b/crates/aether-capabilities/src/trampoline.rs
@@ -118,6 +118,14 @@ mod native {
         /// `FfiActor::init` via `Component::instantiate`. Empty means
         /// "no config" — a `Config = ()` guest decodes `&[]` uniformly.
         pub config: Vec<u8>,
+        /// ADR-0096: the selected export's actor-type tag
+        /// (`mailbox_id_from_name(NAMESPACE)`), threaded through to
+        /// `Component::instantiate` so it calls `init_typed_p32`.
+        /// `None` instantiates the module's entry type via the legacy
+        /// `init_with_config_p32` path — the only type a single-actor
+        /// module has. Stored on the trampoline so a later
+        /// `ReplaceComponent` rebuilds the same export.
+        pub type_tag: Option<u64>,
     }
 
     /// Per-component trampoline. Holds the wasm `Component`
@@ -149,6 +157,11 @@ mod native {
         /// reaching into `ctx.binding().self_mailbox()` on every
         /// handler call.
         mailbox: MailboxId,
+        /// ADR-0096: the selected export's actor-type tag, or `None`
+        /// for the entry type. Held so [`Self::handle_replace`]
+        /// re-instantiates the same exported type from the new wasm
+        /// and re-reads that type's capability group.
+        type_tag: Option<u64>,
     }
 
     #[actor]
@@ -189,6 +202,7 @@ mod native {
                 &config.module,
                 substrate_ctx,
                 &config.config,
+                config.type_tag,
             )
             .map_err(|e| {
                 BootError::Other(io::Error::other(format!("wasm instantiation failed: {e}")).into())
@@ -219,6 +233,7 @@ mod native {
                 mailer,
                 outbound: config.outbound,
                 mailbox,
+                type_tag: config.type_tag,
             })
         }
 
@@ -359,11 +374,37 @@ mod native {
                 }
             };
 
-            // ADR-0033: parse capabilities from the new wasm so the
+            // ADR-0033 / ADR-0096: parse capabilities from the new wasm
+            // for the SAME exported type this trampoline loaded, so the
             // reply carries the post-replace handler vocabulary.
-            let capabilities = match kind_manifest::read_inputs_from_bytes(&payload.wasm) {
-                Ok(c) => c,
-                Err(error) => return ReplaceResult::Err { error },
+            // `self.type_tag == None` reads the entry type (single-actor
+            // and entry loads). A tag absent from the new module is an
+            // `Err` — the replacement doesn't export the loaded type.
+            let capabilities = match self.type_tag {
+                None => match kind_manifest::read_inputs_from_bytes(&payload.wasm) {
+                    Ok(c) => c,
+                    Err(error) => return ReplaceResult::Err { error },
+                },
+                Some(tag) => {
+                    let actors = match kind_manifest::read_actor_inputs_from_bytes(&payload.wasm) {
+                        Ok(a) => a,
+                        Err(error) => return ReplaceResult::Err { error },
+                    };
+                    match actors.into_iter().find(|a| {
+                        a.namespace
+                            .as_deref()
+                            .is_some_and(|ns| aether_data::mailbox_id_from_name(ns).0 == tag)
+                    }) {
+                        Some(group) => group.capabilities,
+                        None => {
+                            return ReplaceResult::Err {
+                                error: format!(
+                                    "replace: new module does not export the actor type (tag {tag:#x}) this trampoline loaded"
+                                ),
+                            };
+                        }
+                    }
+                }
             };
 
             // Run unwire then on_replace on the old instance and lift
@@ -412,6 +453,7 @@ mod native {
                 &module,
                 substrate_ctx,
                 &payload.config,
+                self.type_tag,
             ) {
                 Ok(c) => c,
                 Err(e) => {

--- a/crates/aether-data/src/canonical/inputs.rs
+++ b/crates/aether-data/src/canonical/inputs.rs
@@ -100,3 +100,25 @@ pub const fn write_inputs_config<const N: usize>(id: u64, name: &str) -> [u8; N]
     let _ = pos;
     out
 }
+
+/// Byte length of an `ActorBoundary` record's postcard encoding
+/// (ADR-0096). One-byte enum-variant tag (`0x04`) + `postcard(namespace)`.
+#[must_use]
+pub const fn inputs_actor_boundary_len(namespace: &str) -> usize {
+    1 + str_len(namespace)
+}
+
+/// Serialize an `InputsRecord::ActorBoundary` into a fixed-size array
+/// sized by `inputs_actor_boundary_len`. Exact postcard wire shape for
+/// `InputsRecord::ActorBoundary { namespace }` — the per-actor group
+/// marker `export!(A, B, …)` writes ahead of each type's records.
+#[must_use]
+pub const fn write_inputs_actor_boundary<const N: usize>(namespace: &str) -> [u8; N] {
+    let mut out = [0u8; N];
+    let mut pos = 0usize;
+    out[pos] = 4; // variant tag: ActorBoundary
+    pos += 1;
+    pos = write_str(namespace, &mut out, pos);
+    let _ = pos;
+    out
+}

--- a/crates/aether-data/src/canonical/mod.rs
+++ b/crates/aether-data/src/canonical/mod.rs
@@ -42,8 +42,9 @@ mod primitives;
 mod schema;
 
 pub use inputs::{
-    inputs_component_len, inputs_config_len, inputs_fallback_len, inputs_handler_len,
-    write_inputs_component, write_inputs_config, write_inputs_fallback, write_inputs_handler,
+    inputs_actor_boundary_len, inputs_component_len, inputs_config_len, inputs_fallback_len,
+    inputs_handler_len, write_inputs_actor_boundary, write_inputs_component, write_inputs_config,
+    write_inputs_fallback, write_inputs_handler,
 };
 pub use labels::{canonical_len_labels, canonical_serialize_labels};
 pub use primitives::{varint_u32_len, varint_u64_len, varint_usize_len};
@@ -475,6 +476,24 @@ mod tests {
             InputsRecord::Config {
                 id: KindId(ID),
                 name: NAME.into(),
+            }
+        );
+    }
+
+    #[test]
+    fn inputs_actor_boundary_const_round_trips() {
+        // ADR-0096: `export!(A, B, …)` writes one `ActorBoundary` record
+        // per exported type; the const-eval bytes must decode to
+        // `InputsRecord::ActorBoundary` byte-for-byte so the substrate
+        // reader groups the flat record stream back by namespace.
+        const NS: &str = "ui.panel";
+        const N: usize = inputs_actor_boundary_len(NS);
+        const BYTES: [u8; N] = write_inputs_actor_boundary::<N>(NS);
+        let decoded: InputsRecord = postcard::from_bytes(&BYTES).expect("decode");
+        assert_eq!(
+            decoded,
+            InputsRecord::ActorBoundary {
+                namespace: NS.into()
             }
         );
     }

--- a/crates/aether-data/src/schema.rs
+++ b/crates/aether-data/src/schema.rs
@@ -825,6 +825,16 @@ pub enum InputsRecord {
     /// declared a `type Config` other than the synthesized `()` — the
     /// reader lifts it into `ComponentCapabilities.config`.
     Config { id: KindId, name: Cow<'static, str> },
+    /// ADR-0096: a per-actor boundary marker in a multi-actor module.
+    /// `export!(A, B, …)` writes one `ActorBoundary { namespace }` ahead
+    /// of each exported type's own handler / fallback / component-doc /
+    /// config records, so the reader can group the flat record stream
+    /// back into per-type capability sets. `namespace` is the type's
+    /// `Actor::NAMESPACE`; the first boundary names the entry type.
+    /// Appended last so its postcard variant tag stays additive — a
+    /// single-actor module emits no boundary and decodes byte-identically
+    /// under the existing reader, so no section-version bump is needed.
+    ActorBoundary { namespace: Cow<'static, str> },
 }
 
 /// Custom-section name for the inputs manifest (ADR-0033). Paired

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1102,6 +1102,14 @@ mod control_plane {
         /// MCP encode the config struct to bytes at the edge
         /// (SDK-typed, not wire-typed), matching `wasm`'s `Vec<u8>`.
         pub config: Vec<u8>,
+        /// ADR-0096: which exported actor type to instantiate from a
+        /// multi-actor module, named by its `Actor::NAMESPACE`. `None`
+        /// loads the **entry** type (the first in the module's
+        /// `export!` list), which is also the only type a single-actor
+        /// module has — so an unset selector preserves the pre-ADR-0096
+        /// load. An export that the module doesn't declare is a clean
+        /// `LoadResult::Err`.
+        pub export: Option<String>,
     }
 
     /// Reply to `LoadComponent`. `Ok` carries the assigned mailbox id,
@@ -3438,6 +3446,7 @@ mod tests {
                 wasm: vec![0x00, 0x61, 0x73, 0x6d],
                 name: Some("probe_with_config".to_string()),
                 config: vec![0xde, 0xad, 0xbe, 0xef],
+                export: Some("ui.panel".to_string()),
             };
             let bytes = load.encode_into_bytes();
             let back =
@@ -3445,6 +3454,7 @@ mod tests {
             assert_eq!(back.config, vec![0xde, 0xad, 0xbe, 0xef]);
             assert_eq!(back.wasm, vec![0x00, 0x61, 0x73, 0x6d]);
             assert_eq!(back.name.as_deref(), Some("probe_with_config"));
+            assert_eq!(back.export.as_deref(), Some("ui.panel"));
         }
 
         #[test]

--- a/crates/aether-mcp/src/args.rs
+++ b/crates/aether-mcp/src/args.rs
@@ -146,6 +146,14 @@ pub struct LoadComponentArgs {
     /// `describe_component` reports the expected config kind.
     #[serde(default)]
     pub config_path: Option<String>,
+    /// ADR-0096: which exported actor type to instantiate from a
+    /// multi-actor module, named by its `Actor::NAMESPACE` (e.g.
+    /// `"ui.panel"`). Omit to load the module's entry type — the first
+    /// in its `export!` list, and the only type a single-actor module
+    /// has. An export the module doesn't declare comes back as a
+    /// `LoadResult::Err`.
+    #[serde(default)]
+    pub export: Option<String>,
 }
 
 /// `replace_component` arguments.

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -454,7 +454,7 @@ impl Mcp {
     }
 
     #[tool(
-        description = "Load a WASM component into a substrate by filesystem path. aether-mcp reads the binary, forwards it as aether.component.load to the engine's aether.component mailbox, and awaits the LoadResult — returning {mailbox_id, name, capabilities} or an error. The path must exist as given (no ~ expansion, no relative resolution). The component's kind vocabulary rides in the wasm's aether.kinds custom section. Pass config_path to deliver init-config bytes to a typed-config component (ADR-0090): the file must already hold the component's Config kind wire bytes — describe_component reports the expected config kind. Very large wasm payloads (typically target/wasm32-unknown-unknown/debug/*.wasm, which can run 15-25 MiB) may exceed the RPC framing cap — prefer release builds, or raise the cap via the AETHER_MAX_FRAME_SIZE env var (default 64 MiB, clamped at 1 GiB; issue 1271)."
+        description = "Load a WASM component into a substrate by filesystem path. aether-mcp reads the binary, forwards it as aether.component.load to the engine's aether.component mailbox, and awaits the LoadResult — returning {mailbox_id, name, capabilities} or an error. The path must exist as given (no ~ expansion, no relative resolution). The component's kind vocabulary rides in the wasm's aether.kinds custom section. Pass config_path to deliver init-config bytes to a typed-config component (ADR-0090): the file must already hold the component's Config kind wire bytes — describe_component reports the expected config kind. Pass export to pick which exported actor type to instantiate from a multi-actor module (ADR-0096), named by its Actor::NAMESPACE; omit it to load the module's entry type (the first in its export! list, and the only type a single-actor module has). The returned name + capabilities describe the selected type. Very large wasm payloads (typically target/wasm32-unknown-unknown/debug/*.wasm, which can run 15-25 MiB) may exceed the RPC framing cap — prefer release builds, or raise the cap via the AETHER_MAX_FRAME_SIZE env var (default 64 MiB, clamped at 1 GiB; issue 1271)."
     )]
     pub async fn load_component(
         &self,
@@ -487,6 +487,7 @@ impl Mcp {
                     wasm,
                     name: args.name,
                     config,
+                    export: args.export,
                 },
             ))
             .await
@@ -2009,6 +2010,7 @@ mod tests {
                 binary_path: "/nonexistent/does-not-exist.wasm".to_owned(),
                 name: None,
                 config_path: None,
+                export: None,
             }))
             .await;
         assert!(result.is_err(), "a missing binary should be a tool error");

--- a/crates/aether-mesh-viewer/tests/scenario.rs
+++ b/crates/aether-mesh-viewer/tests/scenario.rs
@@ -81,6 +81,7 @@ fn load_viewer(bench: &mut TestBench, wasm_path: &Path) {
                     wasm,
                     name: Some(COMPONENT_NAME.to_owned()),
                     config: Vec::new(),
+                    export: None,
                 },
             ),
         )])

--- a/crates/aether-substrate-bundle/tests/cap_registry.rs
+++ b/crates/aether-substrate-bundle/tests/cap_registry.rs
@@ -52,6 +52,7 @@ fn load_named(bench: &mut TestBench, wasm_path: &Path, name: &str) -> MailboxId 
                     wasm,
                     name: Some(name.to_owned()),
                     config: Vec::new(),
+                    export: None,
                 },
             ),
         )])

--- a/crates/aether-substrate-bundle/tests/cost_table.rs
+++ b/crates/aether-substrate-bundle/tests/cost_table.rs
@@ -41,6 +41,7 @@ fn load_probe(bench: &mut TestBench, wasm_path: &Path) -> MailboxId {
                     wasm,
                     name: Some("cost-probe".to_owned()),
                     config: Vec::new(),
+                    export: None,
                 },
             ),
         )])

--- a/crates/aether-substrate-bundle/tests/end_to_end.rs
+++ b/crates/aether-substrate-bundle/tests/end_to_end.rs
@@ -38,6 +38,7 @@ fn load_probe(bench: &mut TestBench, wasm_path: &Path) -> MailboxId {
                     wasm,
                     name: Some(PROBE_NAME.to_owned()),
                     config: Vec::new(),
+                    export: None,
                 },
             ),
         )])

--- a/crates/aether-substrate-bundle/tests/input_subscriptions.rs
+++ b/crates/aether-substrate-bundle/tests/input_subscriptions.rs
@@ -31,6 +31,7 @@ fn load_probe_named(bench: &mut TestBench, wasm_path: &Path, name: &str) -> Mail
                     wasm,
                     name: Some(name.to_owned()),
                     config: Vec::new(),
+                    export: None,
                 },
             ),
         )])

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -101,6 +101,7 @@ fn load_probe(bench: &mut TestBench, wasm_path: &Path) -> MailboxId {
                     wasm,
                     name: Some(PROBE_NAME.to_owned()),
                     config: Vec::new(),
+                    export: None,
                 },
             ),
         )])
@@ -163,6 +164,8 @@ fn multi_actor_module_loads_entry_export() {
                     // No name: resolve from the entry type's aether.namespace section.
                     name: None,
                     config: Vec::new(),
+                    // No selector: load the entry export (RootManager).
+                    export: None,
                 },
             ),
         )])
@@ -184,6 +187,97 @@ fn multi_actor_module_loads_entry_export() {
             );
         }
         LoadResult::Err { error } => panic!("multi-actor load failed: {error}"),
+    }
+}
+
+/// ADR-0096: passing `export: "ui.panel"` instantiates the non-entry
+/// type from the same multi-actor module. The host resolves the
+/// selector to the actor-type tag, `init_typed_p32` constructs `Panel`
+/// (not the entry `RootManager`), the trampoline name defaults to the
+/// selected type's namespace (`:ui.panel`), and the `LoadResult`
+/// capabilities come from `Panel`'s `aether.kinds.inputs` group — which
+/// carries a `#[fallback]` the entry type lacks, so the reply proves
+/// the right group was selected.
+#[test]
+fn multi_actor_module_loads_selected_export() {
+    let Some(wasm_path) = require_runtime("multi_actor") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let wasm = fs::read(&wasm_path).expect("read fixture wasm");
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm,
+                    // No name: defaults to the selected export's namespace.
+                    name: None,
+                    config: Vec::new(),
+                    export: Some("ui.panel".to_owned()),
+                },
+            ),
+        )])
+        .expect("load sequence");
+    match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Ok {
+            name, capabilities, ..
+        } => {
+            assert!(
+                name.ends_with(":ui.panel"),
+                "selected export should resolve to Panel's NAMESPACE (ui.panel); got {name}",
+            );
+            assert!(
+                capabilities.fallback.is_some(),
+                "Panel declares a #[fallback]; selecting it must surface that group's capabilities, \
+                 not the entry RootManager's strict-receiver group",
+            );
+        }
+        LoadResult::Err { error } => panic!("multi-actor select-export load failed: {error}"),
+    }
+}
+
+/// ADR-0096: an export selector that names no type the module exports
+/// is a clean `LoadResult::Err`, not a silent fall-through to the entry
+/// type. The error names the requested export.
+#[test]
+fn multi_actor_unknown_export_errors() {
+    let Some(wasm_path) = require_runtime("multi_actor") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let wasm = fs::read(&wasm_path).expect("read fixture wasm");
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm,
+                    name: None,
+                    config: Vec::new(),
+                    export: Some("ui.does_not_exist".to_owned()),
+                },
+            ),
+        )])
+        .expect("load sequence");
+    match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Err { error } => {
+            assert!(
+                error.contains("ui.does_not_exist"),
+                "unknown-export error should name the requested export; got {error}",
+            );
+        }
+        LoadResult::Ok { name, .. } => {
+            panic!("unknown export should fail the load, not fall through; loaded {name}")
+        }
     }
 }
 

--- a/crates/aether-substrate-bundle/tests/typed_config.rs
+++ b/crates/aether-substrate-bundle/tests/typed_config.rs
@@ -54,6 +54,7 @@ fn typed_config_guest_without_config_bytes_surfaces_decode_error() {
                     wasm,
                     name: Some("probe_with_config".to_owned()),
                     config: Vec::new(),
+                    export: None,
                 },
             ),
         )])
@@ -109,6 +110,7 @@ fn typed_config_guest_with_config_bytes_round_trips() {
                         wasm,
                         name: Some("probe_with_config".to_owned()),
                         config: config_bytes,
+                        export: None,
                     },
                 ),
             ),

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -576,12 +576,28 @@ impl Component {
     /// boot error (`LoadResult::Err`) — never a write or trap. Whichever pointer
     /// the config landed at is what `init_with_config_p32(mailbox_id, ptr, len)`
     /// receives.
+    ///
+    /// ADR-0096: `type_tag` selects which exported actor type a
+    /// multi-actor module instantiates. `Some(tag)` calls the guest's
+    /// `init_typed_p32(mailbox_id, tag, ptr, len)` — a missing export is
+    /// a clean boot error (the module isn't multi-actor, or doesn't
+    /// export the selected type). `None` is the entry-type / single-actor
+    /// path: the substrate probes `init_with_config_p32`, then the legacy
+    /// `init` shapes, exactly as before.
+    #[allow(
+        clippy::too_many_lines,
+        reason = "one cohesive instantiate sequence: build instance, probe the \
+                  delivery allocator, select + run the init shim, look up the \
+                  optional lifecycle exports. Splitting it would thread a dozen \
+                  store/region locals through a helper for no clarity gain."
+    )]
     pub fn instantiate(
         engine: &Engine,
         linker: &Linker<ComponentCtx>,
         module: &Module,
         ctx: ComponentCtx,
         config_bytes: &[u8],
+        type_tag: Option<u64>,
     ) -> wasmtime::Result<Self> {
         let mut store = Store::new(engine, ctx);
         let instance = linker.instantiate(&mut store, module)?;
@@ -646,7 +662,35 @@ impl Component {
         // bounded by guest memory size (well below `u32::MAX`).
         #[allow(clippy::cast_possible_truncation)]
         let config_len = config_bytes.len() as u32;
-        let init_rc = if let Ok(init_with_config) =
+        let init_rc = if let Some(type_tag) = type_tag {
+            // ADR-0096: a multi-actor module loaded with an export
+            // selector. The module exports `init_typed_p32`
+            // (mailbox_id, type_tag, ptr, len); the tag picks which
+            // exported type to construct. A guest without that export
+            // either isn't a multi-actor module or was built against an
+            // older SDK — a clean boot error, never a silent fall-through
+            // to the entry-only `init_with_config_p32`.
+            let init_typed = instance
+                .get_typed_func::<(u64, u64, u32, u32), u32>(&mut store, "init_typed_p32")
+                .map_err(|e| {
+                    wasmtime::Error::msg(format!(
+                        "export selector set but guest exports no `init_typed_p32` \
+                         (not a multi-actor module?): {e}"
+                    ))
+                })?;
+            // ADR-0095: same allocator-backed config write as the
+            // entry path below.
+            let config_ptr = Self::place_init_config(
+                &mut store,
+                &memory,
+                realloc.as_ref(),
+                small_ptr,
+                &mut large_ptr,
+                &mut large_cap,
+                config_bytes,
+            )?;
+            Some(init_typed.call(&mut store, (mailbox_id, type_tag, config_ptr, config_len))?)
+        } else if let Ok(init_with_config) =
             instance.get_typed_func::<(u64, u32, u32), u32>(&mut store, "init_with_config_p32")
         {
             // ADR-0095: route the config write through the allocator-backed
@@ -1099,7 +1143,7 @@ mod tests {
         host_fns::register(&mut linker).expect("register host fns");
         let wasm = wat::parse_str(wat).expect("compile WAT");
         let module = Module::new(&engine, &wasm).expect("compile module");
-        Component::instantiate(&engine, &linker, &module, ctx(), &[]).expect("instantiate")
+        Component::instantiate(&engine, &linker, &module, ctx(), &[], None).expect("instantiate")
     }
 
     /// ADR-0090 helper: instantiate with explicit config bytes so a
@@ -1119,7 +1163,7 @@ mod tests {
         host_fns::register(&mut linker).expect("register host fns");
         let wasm = wat::parse_str(wat).expect("compile WAT");
         let module = Module::new(&engine, &wasm).expect("compile module");
-        Component::instantiate(&engine, &linker, &module, ctx(), config_bytes)
+        Component::instantiate(&engine, &linker, &module, ctx(), config_bytes, None)
     }
 
     /// WAT where `on_replace` writes 0x11 to offset 200 — same pattern
@@ -1842,7 +1886,7 @@ mod tests {
         host_fns::register(&mut linker).expect("register host fns");
         let wasm = wat::parse_str(wat).unwrap();
         let module = Module::new(&engine, &wasm).unwrap();
-        Component::instantiate(&engine, &linker, &module, ctx, &[]).unwrap()
+        Component::instantiate(&engine, &linker, &module, ctx, &[], None).unwrap()
     }
 
     #[test]

--- a/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
+++ b/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
@@ -190,22 +190,39 @@ pub fn read_namespace_from_bytes(wasm: &[u8]) -> Result<Option<String>, String> 
     Ok(None)
 }
 
-/// Decode the component's `aether.kinds.inputs` section (ADR-0033)
-/// into a structured `ComponentCapabilities`. Components without the
-/// section return `ComponentCapabilities::default()` — valid only for
-/// components built against the pre-ADR-0033 SDK, which are no longer
-/// produceable after phase 3 retired the `type Kinds` / `fn receive`
-/// surface.
-///
-/// Record shape: `[0x02][postcard(InputsRecord)]` back-to-back. The
-/// classifier walks the records in declaration order: every Handler
-/// enters `handlers`, at most one Fallback populates `fallback`, at
-/// most one Component populates `doc`, and at most one Config
-/// populates `config` (ADR-0090 / issue 1257). Duplicate Fallback /
-/// Component / Config records are a substrate-rejected load error —
-/// the macro emits at most one of each so seeing two means the
-/// component binary was built against a different manifest contract.
-pub fn read_inputs_from_bytes(wasm: &[u8]) -> Result<ComponentCapabilities, String> {
+/// One exported actor's receive-side surface within a (possibly
+/// multi-actor) module, tagged by the `Actor::NAMESPACE` from its
+/// `ActorBoundary` record (ADR-0096). A single-actor module emits no
+/// boundary, so it yields one group with `namespace: None` — the
+/// loader resolves its mailbox name from the `aether.namespace`
+/// section instead. In a multi-actor module the first group is the
+/// entry type.
+#[derive(Debug, Clone)]
+pub struct ActorInputs {
+    /// `Actor::NAMESPACE` of this group's type, from its `ActorBoundary`
+    /// record; `None` for the implicit single-actor group.
+    pub namespace: Option<String>,
+    /// The handler / fallback / component-doc / config records that
+    /// belong to this actor type.
+    pub capabilities: ComponentCapabilities,
+}
+
+/// Decode the component's `aether.kinds.inputs` section (ADR-0033 /
+/// ADR-0096) into one [`ActorInputs`] per exported actor type. The
+/// record stream is `[0x02][postcard(InputsRecord)]` back-to-back; an
+/// `ActorBoundary { namespace }` record opens a new group and the
+/// Handler / Fallback / Component / Config records that follow belong
+/// to it, in declaration order. A single-actor module emits no
+/// boundary, so all its records fall into one implicit `namespace:
+/// None` group (byte-identical to the pre-ADR-0096 layout). The first
+/// group is the entry type. Within each group: every Handler enters
+/// `handlers`, at most one Fallback populates `fallback`, at most one
+/// Component populates `doc`, and at most one Config populates
+/// `config` (ADR-0090 / issue 1257) — a duplicate of any of the
+/// at-most-one records is a substrate-rejected load error, since the
+/// macro emits at most one of each per type. A module that declares no
+/// inputs section at all returns an empty vec.
+pub fn read_actor_inputs_from_bytes(wasm: &[u8]) -> Result<Vec<ActorInputs>, String> {
     let mut records: Vec<InputsRecord> = Vec::new();
 
     for payload in Parser::new(0).parse_all(wasm) {
@@ -219,20 +236,29 @@ pub fn read_inputs_from_bytes(wasm: &[u8]) -> Result<ComponentCapabilities, Stri
         decode_inputs_records(reader.data(), &mut records)?;
     }
 
-    let mut caps = ComponentCapabilities::default();
+    let mut groups: Vec<ActorInputs> = Vec::new();
     for record in records {
         match record {
-            InputsRecord::Handler { id, name, doc } => {
-                caps.handlers.push(HandlerCapability {
-                    id,
-                    name: name.into_owned(),
-                    doc: doc.map(Cow::into_owned),
+            InputsRecord::ActorBoundary { namespace } => {
+                groups.push(ActorInputs {
+                    namespace: Some(namespace.into_owned()),
+                    capabilities: ComponentCapabilities::default(),
                 });
             }
+            InputsRecord::Handler { id, name, doc } => {
+                current_capabilities(&mut groups)
+                    .handlers
+                    .push(HandlerCapability {
+                        id,
+                        name: name.into_owned(),
+                        doc: doc.map(Cow::into_owned),
+                    });
+            }
             InputsRecord::Fallback { doc } => {
+                let caps = current_capabilities(&mut groups);
                 if caps.fallback.is_some() {
                     return Err(format!(
-                        "{INPUTS_SECTION}: duplicate Fallback record — macro emits at most one"
+                        "{INPUTS_SECTION}: duplicate Fallback record — macro emits at most one per actor"
                     ));
                 }
                 caps.fallback = Some(FallbackCapability {
@@ -240,17 +266,19 @@ pub fn read_inputs_from_bytes(wasm: &[u8]) -> Result<ComponentCapabilities, Stri
                 });
             }
             InputsRecord::Component { doc } => {
+                let caps = current_capabilities(&mut groups);
                 if caps.doc.is_some() {
                     return Err(format!(
-                        "{INPUTS_SECTION}: duplicate Component record — macro emits at most one"
+                        "{INPUTS_SECTION}: duplicate Component record — macro emits at most one per actor"
                     ));
                 }
                 caps.doc = Some(doc.into_owned());
             }
             InputsRecord::Config { id, name } => {
+                let caps = current_capabilities(&mut groups);
                 if caps.config.is_some() {
                     return Err(format!(
-                        "{INPUTS_SECTION}: duplicate Config record — macro emits at most one"
+                        "{INPUTS_SECTION}: duplicate Config record — macro emits at most one per actor"
                     ));
                 }
                 caps.config = Some(ConfigCapability {
@@ -260,7 +288,34 @@ pub fn read_inputs_from_bytes(wasm: &[u8]) -> Result<ComponentCapabilities, Stri
             }
         }
     }
-    Ok(caps)
+    Ok(groups)
+}
+
+/// The capabilities of the open (last) group, creating an implicit
+/// `namespace: None` group when records arrive before any
+/// `ActorBoundary` — the single-actor layout, which emits no boundary.
+fn current_capabilities(groups: &mut Vec<ActorInputs>) -> &mut ComponentCapabilities {
+    if groups.is_empty() {
+        groups.push(ActorInputs {
+            namespace: None,
+            capabilities: ComponentCapabilities::default(),
+        });
+    }
+    let last = groups.len() - 1;
+    &mut groups[last].capabilities
+}
+
+/// Decode the component's `aether.kinds.inputs` section into the entry
+/// type's [`ComponentCapabilities`] — the first [`ActorInputs`] group,
+/// or `ComponentCapabilities::default()` when the module declares no
+/// inputs section. The back-compat view for callers that load the
+/// entry (or single) actor without an export selector.
+pub fn read_inputs_from_bytes(wasm: &[u8]) -> Result<ComponentCapabilities, String> {
+    Ok(read_actor_inputs_from_bytes(wasm)?
+        .into_iter()
+        .next()
+        .map(|actor| actor.capabilities)
+        .unwrap_or_default())
 }
 
 fn decode_inputs_records(data: &[u8], out: &mut Vec<InputsRecord>) -> Result<(), String> {
@@ -1033,6 +1088,89 @@ mod tests {
         assert!(caps.handlers.is_empty());
         let fallback = caps.fallback.expect("fallback present");
         assert_eq!(fallback.doc.as_deref(), Some("catchall"));
+    }
+
+    // ADR-0096: a multi-actor module frames each exported type's
+    // records behind an `ActorBoundary`. These pin the per-type
+    // grouping the export selector resolves against.
+
+    #[test]
+    fn groups_multi_actor_records_by_boundary() {
+        // Each `ActorBoundary` opens a group; the records that follow
+        // belong to it, in order. The first group is the entry type.
+        let section = inputs_section(&[
+            InputsRecord::ActorBoundary {
+                namespace: "ui.root".into(),
+            },
+            InputsRecord::Component {
+                doc: "Root.".into(),
+            },
+            InputsRecord::Handler {
+                id: aether_data::KindId(1),
+                name: "ui.click".into(),
+                doc: None,
+            },
+            InputsRecord::ActorBoundary {
+                namespace: "ui.panel".into(),
+            },
+            InputsRecord::Handler {
+                id: aether_data::KindId(2),
+                name: "ui.draw".into(),
+                doc: None,
+            },
+            InputsRecord::Fallback {
+                doc: Some("catchall".into()),
+            },
+        ]);
+        let wasm = wasm_with_section(INPUTS_SECTION, &section);
+        let actors = read_actor_inputs_from_bytes(&wasm).unwrap();
+        assert_eq!(actors.len(), 2);
+        assert_eq!(actors[0].namespace.as_deref(), Some("ui.root"));
+        assert_eq!(actors[0].capabilities.doc.as_deref(), Some("Root."));
+        assert_eq!(actors[0].capabilities.handlers.len(), 1);
+        assert!(actors[0].capabilities.fallback.is_none());
+        assert_eq!(actors[1].namespace.as_deref(), Some("ui.panel"));
+        assert_eq!(actors[1].capabilities.handlers.len(), 1);
+        assert!(actors[1].capabilities.fallback.is_some());
+
+        // The back-compat entry view returns the FIRST group's caps.
+        let entry = read_inputs_from_bytes(&wasm).unwrap();
+        assert_eq!(entry.doc.as_deref(), Some("Root."));
+        assert_eq!(entry.handlers.len(), 1);
+        assert!(entry.fallback.is_none());
+    }
+
+    #[test]
+    fn single_actor_section_is_one_unnamed_group() {
+        // No boundary record (the single-actor layout) → one implicit
+        // group with `namespace: None`; the loader resolves its name
+        // from the `aether.namespace` section instead.
+        let section = inputs_section(&[InputsRecord::Handler {
+            id: aether_data::KindId(7),
+            name: "aether.tick".into(),
+            doc: None,
+        }]);
+        let wasm = wasm_with_section(INPUTS_SECTION, &section);
+        let actors = read_actor_inputs_from_bytes(&wasm).unwrap();
+        assert_eq!(actors.len(), 1);
+        assert!(actors[0].namespace.is_none());
+        assert_eq!(actors[0].capabilities.handlers.len(), 1);
+    }
+
+    #[test]
+    fn per_actor_duplicate_fallback_rejected() {
+        // The at-most-one rule is per group: two fallbacks within one
+        // boundary is still a rejected load.
+        let section = inputs_section(&[
+            InputsRecord::ActorBoundary {
+                namespace: "ui.root".into(),
+            },
+            InputsRecord::Fallback { doc: None },
+            InputsRecord::Fallback { doc: None },
+        ]);
+        let wasm = wasm_with_section(INPUTS_SECTION, &section);
+        let err = read_actor_inputs_from_bytes(&wasm).unwrap_err();
+        assert!(err.contains("duplicate Fallback"), "err: {err}");
     }
 
     #[test]

--- a/crates/aether-test-fixtures/examples/multi_actor.rs
+++ b/crates/aether-test-fixtures/examples/multi_actor.rs
@@ -1,19 +1,26 @@
 //! ADR-0096 fixture: a multi-actor module. Two `FfiActor` types in one
 //! crate, exported together via `export!(RootManager, Panel)`. Proves
 //! multi-type coexistence in a single wasm module (no duplicate-symbol
-//! collision, which ADR-0014 §4 previously forbade) and that the entry
+//! collision, which ADR-0014 §4 previously forbade), that the entry
 //! type (the first export, `RootManager`) loads through an unmodified
-//! host. Selecting the non-entry export (`Panel`) is the follow-on PR.
+//! host, and that the host can select the non-entry export (`Panel`)
+//! by its `Actor::NAMESPACE`.
+//!
+//! The two types carry deliberately distinct receive surfaces so a load
+//! test can prove which one was instantiated: `RootManager` is a strict
+//! receiver (one `Ping` handler, no fallback) while `Panel` adds a
+//! `#[fallback]`. The resolved `aether.kinds.inputs` group for a
+//! selected export must match the type that load picked.
 
-// `#[handler]` methods take `&mut self` to match the dispatch ABI even
-// when stateless.
+// `#[handler]` / `#[fallback]` methods take `&mut self` to match the
+// dispatch ABI even when stateless.
 #![allow(clippy::unused_self)]
 
-use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
+use aether_actor::{BootError, FfiActor, FfiCtx, Mail, Resolver, actor};
 use aether_kinds::Ping;
 
 /// Entry export — the first type in the `export!` list. An unmodified
-/// host instantiates this one.
+/// host instantiates this one. Strict receiver: no `#[fallback]`.
 pub struct RootManager;
 
 #[actor]
@@ -31,9 +38,9 @@ impl FfiActor for RootManager {
     fn on_ping(&mut self, _ctx: &mut FfiCtx<'_>, _ping: Ping) {}
 }
 
-/// Sibling export — reachable once the host can resolve an export
-/// selector to its actor-type tag (follow-on PR). Present here to prove
-/// two `#[actor]` types coexist in one module.
+/// Sibling export — selected by passing `export: "ui.panel"` to the
+/// load. Carries a `#[fallback]` so its capability group is observably
+/// distinct from the entry type's strict receiver.
 pub struct Panel;
 
 #[actor]
@@ -49,6 +56,9 @@ impl FfiActor for Panel {
 
     #[handler]
     fn on_ping(&mut self, _ctx: &mut FfiCtx<'_>, _ping: Ping) {}
+
+    #[fallback]
+    fn on_other(&mut self, _ctx: &mut FfiCtx<'_>, _mail: Mail<'_>) {}
 }
 
 aether_actor::export!(RootManager, Panel);

--- a/demos/sokoban/tests/scenario.rs
+++ b/demos/sokoban/tests/scenario.rs
@@ -66,6 +66,7 @@ fn load_sokoban(bench: &mut TestBench, wasm_path: &Path) {
                     wasm,
                     name: Some(COMPONENT_NAME.to_owned()),
                     config: Vec::new(),
+                    export: None,
                 },
             ),
         )])


### PR DESCRIPTION
Closes iamacoffeepot/aether#1363.

PR-B of ADR-0096 (multi-actor wasm modules) — the host-side export selector. PR-A (#1406) landed the guest side (`ErasedFfiActor`, the multi-actor `export!` arm, `init_typed_p32`). This closes the loop: a load can now name which exported actor type to instantiate from a module that exports several.

## Summary

- **Wire (`aether-data`)** — `InputsRecord::ActorBoundary { namespace }`, appended last so its postcard tag is additive (no section-version bump; single-actor manifests stay byte-identical). Const-fn encoders `inputs_actor_boundary_len` / `write_inputs_actor_boundary` alongside the existing record encoders.
- **`export!` multi arm** — concatenates each exported type's `aether.kinds.inputs` records behind an `ActorBoundary` into one section, entry type first.
- **Reader (`kind_manifest`)** — `read_actor_inputs_from_bytes` groups the flat record stream into one `ComponentCapabilities` per exported type (the at-most-one fallback/component/config rule is now per group). `read_inputs_from_bytes` becomes the entry-view wrapper; a single-actor module (no boundary) is one implicit group, unchanged.
- **Load path** — `LoadComponent.export: Option<String>` and the `aether.component` loader resolve the selector (a type's `NAMESPACE`) to its actor-type tag, default the trampoline name to the selected namespace, and register the selected type's caps. An export the module doesn't declare is a clean `LoadResult::Err`. Omitting the selector loads the entry type, so single-actor modules and existing callers are unchanged.
- **`Component::instantiate`** — calls `init_typed_p32(mailbox_id, tag, ptr, len)` when a tag is set, else the legacy `init_with_config_p32` path. The trampoline stores the tag so a later replace rebuilds the same export and re-reads that type's capability group.
- **MCP `load_component`** — optional `export` arg; `describe_component` reports the loaded instance's type via the cached selected capabilities.

## Test plan

- `aether-data`: `ActorBoundary` const-encoder round-trip.
- `kind_manifest`: existing 20 reader tests unchanged; 3 new — multi-actor grouping by boundary, single-actor one-unnamed-group, per-actor duplicate-fallback rejection.
- `aether-kinds`: `LoadComponent` wire round-trip carries `export`.
- Test bench (`test_bench_scenario`): entry-export load (unchanged), select the non-entry `Panel` export (resolves to `:ui.panel`, surfaces Panel's `#[fallback]`), unknown-export error.
- The `multi_actor` fixture gains a distinguishing `#[fallback]` on `Panel`; cross-builds to wasm32.

Full `scripts/preflight.sh` green (fmt, clippy, doc, 1483 nextest, wasm32 cross-build).

## Generated by

`/implement` — agent execution of scoped issue #1363 (PR-B).
