### PR TITLE
docs(adr): mark adr-0096 accepted

### DIFF
--- a/docs/adr/0096-multi-actor-wasm-modules.md
+++ b/docs/adr/0096-multi-actor-wasm-modules.md
@@ -1,6 +1,6 @@
 # ADR-0096: Multi-actor wasm modules
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-06-06
 
 ## Context


### PR DESCRIPTION
ADR-0096 (multi-actor wasm modules) is fully implemented and merged: the guest side in #1406 (PR-A) and the host-side export selector in #1407 (PR-B, which closed #1363). Flip its status from Proposed to Accepted.

One-line status change, docs-only.