### PR TITLE
docs(adr): revise adr-0097 spawn mechanism to stage-and-drain

### DIFF
--- a/docs/adr/0097-wasm-sibling-spawn.md
+++ b/docs/adr/0097-wasm-sibling-spawn.md
@@ -17,6 +17,7 @@ Constraints carried in:
 - **ADR-0079.** `Instanced` / `Singleton` cardinality, `spawn_child` semantics, and the drop / name-retirement rules.
 - **ADR-0024.** The `_p32` FFI shim surface — the contract this extends with a spawn import.
 - **ADR-0090.** Init-config crosses from the host into the guest's typed `init` as wire bytes.
+- **Crate layering.** The wasmtime `Linker<ComponentCtx>` and the host-fn surface are built in `aether-substrate` (`boot.rs` → `host_fns::register`); `WasmTrampoline` lives in `aether-capabilities`, which depends on substrate, not the reverse. A substrate-registered host-fn therefore cannot name `WasmTrampoline`, so `spawn_child::<WasmTrampoline>` cannot be monomorphized at the host-fn site. The actual spawn must execute in the capabilities layer, which shapes the mechanism below.
 
 ## Decision
 
@@ -28,7 +29,7 @@ Five sub-decisions.
 let panel = ctx.spawn_child::<Panel>(Subname::Counter, &PanelConfig { /* … */ })?;
 ```
 
-Guest-side, typed, mirroring native. The SDK lowers `::<Panel>` to the sibling's compile-time tag (`mailbox_id_from_name(Panel::NAMESPACE)`) and encodes the config to wire bytes. A new host-fn import on the `_p32` surface carries `(tag, subname, config_bytes)` across the boundary and returns the new `MailboxId`. The typed call site is available because the guest crate compiled `Panel`: resolving `Panel::TAG` and encoding `Panel::Config` happen entirely at compile time, with no cross-boundary monomorphization.
+Guest-side, typed, mirroring native. The SDK lowers `::<Panel>` to the sibling's compile-time tag (`mailbox_id_from_name(Panel::NAMESPACE)`) and encodes the config to wire bytes. A new host-fn import on the `_p32` surface carries `(tag, subname, config_bytes)` across the boundary and returns the new `MailboxId` synchronously — the id is `hash(name)` (ADR-0029), so it is known before the instance finishes spawning (§4). The typed call site is available because the guest crate compiled `Panel`: resolving `Panel::TAG` and encoding `Panel::Config` happen entirely at compile time, with no cross-boundary monomorphization.
 
 ### 2. Spawnable siblings are `Instanced`; spawn reuses ADR-0079 wholesale
 
@@ -38,9 +39,11 @@ A spawnable sibling is an `Instanced` exported type. `Subname::Counter | Named`,
 
 `spawn_child` instantiates only types compiled into the calling module. Instantiating a foreign module — another binary, by path, embedded bytes, or name — is a load, served by `load_component` (a guest mails `aether.component.load`; ADR-0096 gave that path an export selector). The line falls out of the typed primitive: there is no `::<ForeignType>` to write for a type the crate did not compile against, so anything foreign arrives as a name plus opaque bytes, which is the load shape. The cost model reinforces it — `spawn_child` re-instantiates an already-compiled, already-registered resident module with no disk read, compile, or kind registration, whereas a foreign child pays a full module load. And the authority differs: spawning own siblings stays inside the authority granted at load, while pulling arbitrary other binaries into the host is a larger grant that belongs to a governed load. The partition: spawn is one more instance of code the actor already is; load brings in code it is not.
 
-### 4. The host reuses the load path's instantiation
+### 4. The host-fn stages the request; the trampoline performs the spawn
 
-The host-fn closure already holds the trampoline's `NativeCtx` (with its `Spawner`) and the resident `Module`. It runs `spawn_child::<WasmTrampoline>(subname, WasmTrampolineConfig { module: <the caller's resident module>, type_tag, config, .. })` — the same call `handle_load` makes, fired from a running guest instead of a load mail. `init_typed_p32` constructs the sibling; the config bytes ride the ADR-0090 path. The spawn is synchronous and returns the new `MailboxId`, matching native; the spawner (the trampoline) is the new instance's `ReplyTo`, and since the guest's mailbox is the trampoline's mailbox, replies land at the guest.
+Because a substrate-registered host-fn cannot name `WasmTrampoline` (see §Context — crate layering), the host-fn does not spawn directly. It stages `(tag, subname, config_bytes)` onto `ComponentCtx` — the same host-fn-stages / host-drains pattern `save_state` and `init_failed` already use — and returns the new `MailboxId`, computed synchronously as `hash("aether.component.trampoline:<subname>")` (ADR-0029). After `Component::deliver` returns, the `WasmTrampoline` — in `aether-capabilities`, holding its `NativeCtx`, engine, linker, and a retained handle to its resident `Module` — drains the staged request and runs `ctx.spawn_child::<WasmTrampoline>(subname, WasmTrampolineConfig { module, type_tag, config, .. })`, the same call `handle_load` makes. `init_typed_p32` constructs the sibling; the config bytes ride the ADR-0090 path; the spawner stamps the trampoline's mailbox as the sibling's `ReplyTo`, and since the guest's mailbox is the trampoline's mailbox, replies land at the guest.
+
+Because the id is the name's hash, the guest receives it synchronously even though the spawn completes just after the host-fn returns — the call site stays `let panel = ctx.spawn_child::<Panel>(…)?` as in §1. The trade is that **success and failure split**: synchronously-checkable errors (subname invalid / too long) come back as the host-fn's `Err`, but a spawn-time failure (subname retired or in use, guest `init` error) surfaces asynchronously — logged on the trampoline and, where it matters, mailed back to the parent — rather than as the `spawn_child` return value.
 
 ### 5. No automatic lifecycle cascade
 
@@ -52,12 +55,13 @@ A spawned sibling has independent lifecycle, mirroring native. Children self-clo
 
 - **A wasm subsystem composes at runtime, not just at load.** A coordinator type stands up its worker types on demand from one resident module — the UI-root-spawns-panels shape, and per-connection / per-entity patterns generally.
 - **The wasm and native spawn surfaces are symmetric** — same `spawn_child` shape, same `Subname` / cardinality / drop semantics — so an author moving between targets carries one model.
-- **It reuses the #1363 machinery end to end** — resident module, type-tag, `init_typed_p32`, config-as-bytes, trampoline spawn. The new surface is one host-fn import plus the SDK method and its tag-lowering.
+- **It reuses the #1363 machinery end to end** — resident module, type-tag, `init_typed_p32`, config-as-bytes, trampoline spawn. The new surface is one host-fn import, the SDK method + tag-lowering, a staging field on `ComponentCtx`, and the trampoline's drain step.
 
 ### Negative
 
-- **The `_p32` contract grows a spawn import**, and the SDK grows a guest-side `spawn_child` + `Subname`. Contained to `aether-actor` / `aether-actor-derive` plus the trampoline's host-fn registration.
-- **Spawn failure now has a guest-visible error path** (bad tag, subname invalid / retired / in use, init failure) that must cross the boundary as a result rather than a trap.
+- **The `_p32` contract grows a spawn import**, the SDK grows a guest-side `spawn_child` + `Subname`, `ComponentCtx` grows a staged-spawn field, and the trampoline grows a post-`deliver` drain. The host-fn body stays in `aether-substrate` (it only stages); the typed `spawn_child::<WasmTrampoline>` stays in `aether-capabilities`.
+- **The trampoline retains its compiled `Module`** to re-instantiate siblings — a cheap `Arc` clone (wasmtime `Module` is `Arc`-backed), not a second copy of the code.
+- **Spawn success and failure split.** The `MailboxId` returns synchronously (it is the name hash) and synchronous subname validation errors come back as the host-fn's `Err`, but a spawn-time failure (retired / in-use subname, guest `init` error) surfaces asynchronously rather than at the call site.
 
 ### Neutral
 
@@ -73,7 +77,8 @@ A spawned sibling has independent lifecycle, mirroring native. Children self-clo
 - **Spawn foreign types by path or embedded bytes.** Rejected (also rejected in #1363): a foreign type can't be named by a typed `::<T>`, it pays a full load, and it's a larger authority grant — all of which make it a load, which already exists.
 - **Every exported type implicitly spawnable.** Rejected: drops the `Instanced` / `Singleton` distinction on the wasm side and invents a parallel cardinality model instead of reusing ADR-0079.
 - **Framework parent→child cascade-close.** Rejected: an asymmetry the native path doesn't carry, and the UI use case it targets is expressible in guest code via `unwire` plus tracked `MailboxId`s.
-- **Spawn via mail to `aether.component`.** Rejected: a guest mailing a spawn request and awaiting a reply is async and clunkier at the call site than the synchronous host-fn, which the trampoline's live `Spawner` already makes feasible.
+- **Spawn via mail to `aether.component`.** Rejected: a guest mailing a spawn request and awaiting a reply is fully async at the call site, losing the synchronous `spawn_child` symmetry with native. The crate-layering wall (the host-fn can't name `WasmTrampoline`) is a real argument for it, but stage-and-drain (§4) keeps the synchronous id while still performing the typed spawn in the capabilities layer, so the layering doesn't force the async surface. Kept as the fallback if the sync-id / async-failure split (§4) proves unworkable in practice.
+- **Type-erased spawn hook injected at boot.** A `dyn` trampoline-spawn hook installed onto the substrate `Spawner` by the bundle, called by the host-fn. Rejected: it's a cross-boundary indirection invented to dodge the layering, where stage-and-drain instead reuses the existing `ComponentCtx` staging pattern (`save_state` / `init_failed`) and lets the trampoline — which already owns the spawn context — do the typed call.
 
 ## Related
 


### PR DESCRIPTION
Revises ADR-0097 §4 after a crate-layering wall surfaced while implementing #1409.

**Why.** The merged §4 said the spawn host-fn runs `spawn_child::<WasmTrampoline>` directly. It can't: the wasmtime `Linker` and host-fns are built in `aether-substrate`, which cannot name the `aether-capabilities` `WasmTrampoline` the generic requires (capabilities depends on substrate, not the reverse).

**Fix — stage-and-drain.** The host-fn stages `(tag, subname, config_bytes)` onto `ComponentCtx` (the same pattern `save_state` / `init_failed` use) and returns the new `MailboxId` synchronously, since it is `hash(name)` (ADR-0029). After `Component::deliver` returns, the trampoline — which is in capabilities and owns the spawn context — drains the request and runs the typed `spawn_child::<WasmTrampoline>`. The synchronous, native-symmetric call site is preserved; the only new semantic is that success returns the id sync while a spawn-time failure surfaces async.

Also records: the crate-layering constraint (Context), the trampoline retaining its `Module`, and the rejected type-erased-hook alternative.

Part of #1409 (the implementation re-scopes off this revision).
