### PR TITLE
feat(actor): wasm sibling spawn via ctx.spawn_child

### DIFF
--- a/crates/aether-actor/src/actor/mod.rs
+++ b/crates/aether-actor/src/actor/mod.rs
@@ -80,6 +80,26 @@ pub trait Singleton: Actor {}
 /// Mutually exclusive with [`Singleton`] at the type level. ADR-0079.
 pub trait Instanced: Actor {}
 
+/// How a spawned child's mailbox subname is derived (ADR-0079). The
+/// full mailbox name is `"{A::NAMESPACE}:{subname}"`; the substrate
+/// hashes that string deterministically (ADR-0029) to the returned
+/// `MailboxId`. Shared spawn-addressing vocabulary: native
+/// `spawn_child` and the FFI guest's `FfiCtx::spawn_child` (ADR-0097)
+/// both name children through it, so the two transports name children
+/// the same way.
+#[derive(Debug, Clone, Copy)]
+pub enum Subname<'a> {
+    /// Spawner-allocated monotonic discriminator — "spawn me one of
+    /// these, I'll track the returned `MailboxId`." The fit for
+    /// per-connection / per-entity churn where no human-readable name
+    /// is needed.
+    Counter,
+    /// Caller-supplied subname. Must pass [`validate_namespace_segment`]
+    /// and be unique within the owning prefix (no `:` separator); names
+    /// retire on drop (ADR-0079).
+    Named(&'a str),
+}
+
 /// Validation outcome for namespace segments — both the `NAMESPACE`
 /// const on an [`Instanced`] type (the listener prefix) and the
 /// runtime subname passed to `spawn_child`. Same rules apply at both

--- a/crates/aether-actor/src/ffi/bridge/mail.rs
+++ b/crates/aether-actor/src/ffi/bridge/mail.rs
@@ -137,4 +137,34 @@ impl MailBridge {
             );
         }
     }
+
+    /// ADR-0097: stage a sibling-spawn request and return the new
+    /// instance's `MailboxId`. `tag` is the sibling type's actor-type
+    /// tag (`mailbox_id_from_name(NAMESPACE)`); `is_counter` selects
+    /// `Subname::Counter` (the host appends a monotonic discriminator)
+    /// vs a caller-supplied name; `subname` is the full prefixed subname
+    /// for `Named` or the type-namespace prefix for `Counter`; `config`
+    /// is the encoded `Config` kind. The returned id is
+    /// `hash("aether.component.trampoline:<subname>")`, known
+    /// synchronously; the spawn itself completes just after this call
+    /// (ADR-0097 §4), so a spawn-time failure surfaces asynchronously
+    /// rather than here.
+    #[must_use]
+    pub fn spawn_sibling(&self, tag: u64, is_counter: bool, subname: &str, config: &[u8]) -> u64 {
+        let subname_bytes = subname.as_bytes();
+        // SAFETY: forwards to `raw::spawn_sibling`, whose ABI is
+        // documented at the import site in `ffi/raw.rs`. Both `(ptr,
+        // len)` pairs are derived from references valid for `len` bytes
+        // for the call's duration; the host copies before returning.
+        unsafe {
+            raw::spawn_sibling(
+                tag,
+                u32::from(is_counter),
+                subname_bytes.as_ptr().addr() as u32,
+                subname_bytes.len() as u32,
+                config.as_ptr().addr() as u32,
+                config.len() as u32,
+            )
+        }
+    }
 }

--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -18,14 +18,17 @@
 
 use core::marker::PhantomData;
 
-use aether_data::{Kind, mailbox_id_from_name};
+use aether_data::{Kind, MailboxId, mailbox_id_from_name};
 
 use crate::actor::ctx::mail_sender::MailSender;
 use crate::actor::ctx::outbound_reply::OutboundReply;
 use crate::actor::ctx::persistence::Persistence;
 use crate::actor::ctx::resolver::Resolver;
 use crate::actor::sender::{MailCtx, Sender};
-use crate::actor::{Actor, HandlesKind, Singleton};
+use crate::actor::{
+    Actor, HandlesKind, Instanced, NamespaceError, Singleton, validate_namespace_segment,
+};
+use crate::ffi::FfiActor;
 use crate::ffi::bridge::{MAIL_BRIDGE, PERSIST_BRIDGE};
 use crate::ffi::mailbox::FfiActorMailbox;
 use crate::mail::ReplyTo;
@@ -97,6 +100,34 @@ impl Resolver for FfiInitCtx<'_> {
     fn resolve_mailbox<K: Kind>(&self, name: &str) -> Mailbox<K> {
         resolve_mailbox::<K>(name)
     }
+}
+
+/// How a spawned sibling's mailbox name is derived (ADR-0097) — the
+/// guest-side mirror of the substrate's `Subname`. The full mailbox
+/// name is `aether.component.trampoline:<A::NAMESPACE>` for `Counter`
+/// (the host appends its monotonic discriminator) or
+/// `aether.component.trampoline:<A::NAMESPACE>.<name>` for `Named`.
+#[derive(Debug, Clone, Copy)]
+pub enum Subname<'a> {
+    /// Host-allocated monotonic discriminator — "spawn me one of these,
+    /// I'll track the returned `MailboxId`." The fit for per-entity /
+    /// per-connection churn where no human-readable name is needed.
+    Counter,
+    /// Caller-supplied discriminator, appended to the sibling type's
+    /// namespace. Must pass [`validate_namespace_segment`] and be unique
+    /// within the trampoline prefix; retired on drop (ADR-0079).
+    Named(&'a str),
+}
+
+/// Why a synchronous [`FfiCtx::spawn_child`] call failed before the host
+/// staged the request (ADR-0097). Spawn-time failures — a retired or
+/// in-use subname, or the sibling's `init` returning `Err` — surface
+/// asynchronously on the trampoline, not through this `Result`.
+#[derive(Debug, Clone)]
+pub enum SpawnError {
+    /// A [`Subname::Named`] discriminator failed
+    /// [`validate_namespace_segment`].
+    SubnameInvalid(NamespaceError),
 }
 
 /// Per-receive (and post-init `wire` / pre-shutdown `unwire`)
@@ -182,6 +213,48 @@ impl FfiCtx<'_> {
     pub fn fatal_abort(&self, reason: String) -> ! {
         panic!("aether-actor: fatal_abort: {reason}")
     }
+
+    /// ADR-0097: spawn a sibling actor type from the same resident
+    /// module — the wasm analogue of native `ctx.spawn_child::<A>`. `A`
+    /// is one of this module's exported `Instanced` types; the SDK
+    /// resolves its actor-type tag (`mailbox_id_from_name(A::NAMESPACE)`)
+    /// and encodes `A::Config`, both at compile time. Returns the new
+    /// instance's [`MailboxId`] synchronously — it is `hash(name)`
+    /// (ADR-0029) — and the instance becomes addressable at
+    /// `aether.component.trampoline:<name>`.
+    ///
+    /// Only synchronous subname validation can `Err` here; a spawn-time
+    /// failure (a retired / in-use subname, or the sibling's `init`
+    /// returning `Err`) is logged on the trampoline and does not come
+    /// back through this `Result` (ADR-0097 §4). The spawned sibling's
+    /// `ReplyTo` is this actor's mailbox, so its replies route here.
+    pub fn spawn_child<A>(
+        &self,
+        subname: Subname<'_>,
+        config: &A::Config,
+    ) -> Result<MailboxId, SpawnError>
+    where
+        A: Instanced + FfiActor,
+    {
+        let tag = mailbox_id_from_name(<A as Actor>::NAMESPACE).0;
+        let (is_counter, full_subname) = match subname {
+            // `Counter`: pass the type-namespace prefix; the host appends
+            // its monotonic discriminator so the name is globally unique.
+            Subname::Counter => (true, String::from(<A as Actor>::NAMESPACE)),
+            // `Named`: form the full prefixed subname here; validate the
+            // caller-supplied segment before it crosses the FFI.
+            Subname::Named(name) => {
+                validate_namespace_segment(name).map_err(SpawnError::SubnameInvalid)?;
+                (
+                    false,
+                    alloc::format!("{}.{}", <A as Actor>::NAMESPACE, name),
+                )
+            }
+        };
+        let config_bytes = config.encode_into_bytes();
+        let id = MAIL_BRIDGE.spawn_sibling(tag, is_counter, &full_subname, &config_bytes);
+        Ok(MailboxId(id))
+    }
 }
 
 impl Resolver for FfiCtx<'_> {
@@ -242,7 +315,7 @@ impl OutboundReply for FfiCtx<'_> {
         self.sender.map(ReplyTo::__from_raw)
     }
 
-    fn origin(&self) -> Option<aether_data::MailboxId> {
+    fn origin(&self) -> Option<MailboxId> {
         None
     }
 

--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -26,7 +26,7 @@ use crate::actor::ctx::persistence::Persistence;
 use crate::actor::ctx::resolver::Resolver;
 use crate::actor::sender::{MailCtx, Sender};
 use crate::actor::{
-    Actor, HandlesKind, Instanced, NamespaceError, Singleton, validate_namespace_segment,
+    Actor, HandlesKind, Instanced, NamespaceError, Singleton, Subname, validate_namespace_segment,
 };
 use crate::ffi::FfiActor;
 use crate::ffi::bridge::{MAIL_BRIDGE, PERSIST_BRIDGE};
@@ -100,23 +100,6 @@ impl Resolver for FfiInitCtx<'_> {
     fn resolve_mailbox<K: Kind>(&self, name: &str) -> Mailbox<K> {
         resolve_mailbox::<K>(name)
     }
-}
-
-/// How a spawned sibling's mailbox name is derived (ADR-0097) — the
-/// guest-side mirror of the substrate's `Subname`. The full mailbox
-/// name is `aether.component.trampoline:<A::NAMESPACE>` for `Counter`
-/// (the host appends its monotonic discriminator) or
-/// `aether.component.trampoline:<A::NAMESPACE>.<name>` for `Named`.
-#[derive(Debug, Clone, Copy)]
-pub enum Subname<'a> {
-    /// Host-allocated monotonic discriminator — "spawn me one of these,
-    /// I'll track the returned `MailboxId`." The fit for per-entity /
-    /// per-connection churn where no human-readable name is needed.
-    Counter,
-    /// Caller-supplied discriminator, appended to the sibling type's
-    /// namespace. Must pass [`validate_namespace_segment`] and be unique
-    /// within the trampoline prefix; retired on drop (ADR-0079).
-    Named(&'a str),
 }
 
 /// Why a synchronous [`FfiCtx::spawn_child`] call failed before the host

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -65,7 +65,7 @@ pub mod mailbox;
 pub mod raw;
 
 pub use bridge::{MAIL_BRIDGE, MailBridge, PERSIST_BRIDGE, PersistBridge};
-pub use ctx::{FfiCtx, FfiDropCtx, FfiInitCtx, SpawnError, Subname};
+pub use ctx::{FfiCtx, FfiDropCtx, FfiInitCtx, SpawnError};
 pub use mailbox::FfiActorMailbox;
 
 // Issue 665 retired the `ffi::Mailbox<K>` 1-arg alias and the

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -65,7 +65,7 @@ pub mod mailbox;
 pub mod raw;
 
 pub use bridge::{MAIL_BRIDGE, MailBridge, PERSIST_BRIDGE, PersistBridge};
-pub use ctx::{FfiCtx, FfiDropCtx, FfiInitCtx};
+pub use ctx::{FfiCtx, FfiDropCtx, FfiInitCtx, SpawnError, Subname};
 pub use mailbox::FfiActorMailbox;
 
 // Issue 665 retired the `ffi::Mailbox<K>` 1-arg alias and the

--- a/crates/aether-actor/src/ffi/raw.rs
+++ b/crates/aether-actor/src/ffi/raw.rs
@@ -62,6 +62,28 @@ unsafe extern "C" {
         message_ptr: u32,
         message_len: u32,
     );
+    /// ADR-0097: spawn a sibling actor type from the same resident
+    /// module. `tag` is the sibling's actor-type tag
+    /// (`mailbox_id_from_name(NAMESPACE)`), used to pick the export at
+    /// `init_typed_p32`. `is_counter` is `1` for `Subname::Counter`
+    /// (the host appends a monotonic discriminator) or `0` for a
+    /// caller-supplied name. `subname_ptr/len` is the full subname for
+    /// `Named` or the type-namespace prefix for `Counter`;
+    /// `config_ptr/len` is the encoded `Config` kind. The host stages
+    /// the request and returns the new instance's `MailboxId`
+    /// (= `hash("aether.component.trampoline:<subname>")`); the spawn
+    /// itself completes just after this returns (ADR-0097 §4). Bytes at
+    /// `(subname_ptr, subname_len)` / `(config_ptr, config_len)` are
+    /// copied out of guest memory before the call returns.
+    #[link_name = "spawn_sibling_p32"]
+    pub fn spawn_sibling(
+        tag: u64,
+        is_counter: u32,
+        subname_ptr: u32,
+        subname_len: u32,
+        config_ptr: u32,
+        config_len: u32,
+    ) -> u64;
 }
 
 /// Host-side stub for the FFI `aether::send_mail` import. Always
@@ -156,4 +178,26 @@ pub unsafe fn log_event(
     _message_len: u32,
 ) {
     panic!("aether-actor: log_event called outside the FFI guest");
+}
+
+/// Host-side stub for the FFI `aether::spawn_sibling` import (ADR-0097).
+/// Always panics — callers outside the FFI guest are misusing the SDK.
+///
+/// # Safety
+/// FFI-import stub; the wasm32 variant is `unsafe extern "C"`.
+///
+/// # Panics
+/// Always panics — fail-fast per ADR-0063: the host build of the SDK
+/// has no FFI host to call, so any invocation is a bug.
+#[cfg(not(target_arch = "wasm32"))]
+#[must_use]
+pub unsafe fn spawn_sibling(
+    _tag: u64,
+    _is_counter: u32,
+    _subname_ptr: u32,
+    _subname_len: u32,
+    _config_ptr: u32,
+    _config_len: u32,
+) -> u64 {
+    panic!("aether-actor: spawn_sibling called outside the FFI guest");
 }

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -84,7 +84,7 @@ pub use mail::{Mail, NO_REPLY_HANDLE, PriorState, ReplyTo};
 // an extra `ffi::` segment.
 pub use ffi::{
     BootError, ErasedFfiActor, FfiActor, FfiActorMailbox, FfiCtx, FfiDropCtx, FfiInitCtx,
-    Replaceable,
+    Replaceable, SpawnError, Subname,
 };
 
 // Issue 665 retired `MailTransport` and its `MailTransportTrait`

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -66,7 +66,7 @@ pub use actor::ctx::{LifecycleControl, MailSender, OutboundReply, Persistence, R
 pub use actor::sender::{MailCtx, Sender};
 pub use actor::slot::Slot;
 pub use actor::{
-    Actor, HandlesKind, Instanced, NAMESPACE_SEGMENT_MAX_LEN, NamespaceError, Singleton,
+    Actor, HandlesKind, Instanced, NAMESPACE_SEGMENT_MAX_LEN, NamespaceError, Singleton, Subname,
     validate_namespace_segment,
 };
 pub use local::Local;
@@ -84,7 +84,7 @@ pub use mail::{Mail, NO_REPLY_HANDLE, PriorState, ReplyTo};
 // an extra `ffi::` segment.
 pub use ffi::{
     BootError, ErasedFfiActor, FfiActor, FfiActorMailbox, FfiCtx, FfiDropCtx, FfiInitCtx,
-    Replaceable, SpawnError, Subname,
+    Replaceable, SpawnError,
 };
 
 // Issue 665 retired `MailTransport` and its `MailTransportTrait`

--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -237,6 +237,13 @@ mod native {
     }
 
     impl ComponentHostCapability {
+        #[allow(
+            clippy::too_many_lines,
+            reason = "one cohesive load sequence: parse + register kinds, resolve the export, \
+                      compile, name, spawn the trampoline, register caps, announce. Splitting it \
+                      would thread the load payload + registry/engine handles through a helper \
+                      for no clarity gain."
+        )]
         fn handle_load(&mut self, ctx: &mut NativeCtx<'_>, payload: LoadComponent) -> LoadResult {
             // 1. Parse + register kind descriptors (ADR-0028).
             let descriptors = match kind_manifest::read_from_bytes(&payload.wasm) {
@@ -264,32 +271,33 @@ mod native {
                 ComponentCapabilities,
                 Option<u64>,
                 Option<String>,
-            ) = match &payload.export {
-                Some(requested) => {
-                    let Some(group) = actors
+            ) = if let Some(requested) = &payload.export {
+                let Some(group) = actors
+                    .iter()
+                    .find(|a| a.namespace.as_deref() == Some(requested.as_str()))
+                else {
+                    let available: Vec<&str> = actors
                         .iter()
-                        .find(|a| a.namespace.as_deref() == Some(requested.as_str()))
-                    else {
-                        let available: Vec<&str> = actors
-                            .iter()
-                            .filter_map(|a| a.namespace.as_deref())
-                            .collect();
-                        return LoadResult::Err {
-                            error: format!(
-                                "export {requested:?} not found in module; exported types: {available:?}"
-                            ),
-                        };
+                        .filter_map(|a| a.namespace.as_deref())
+                        .collect();
+                    return LoadResult::Err {
+                        error: format!(
+                            "export {requested:?} not found in module; exported types: {available:?}"
+                        ),
                     };
-                    (
-                        group.capabilities.clone(),
-                        Some(aether_data::mailbox_id_from_name(requested).0),
-                        Some(requested.clone()),
-                    )
-                }
-                None => match actors.into_iter().next() {
-                    Some(entry) => (entry.capabilities, None, entry.namespace),
-                    None => (ComponentCapabilities::default(), None, None),
-                },
+                };
+                (
+                    group.capabilities.clone(),
+                    Some(aether_data::mailbox_id_from_name(requested).0),
+                    Some(requested.clone()),
+                )
+            } else {
+                let entry = actors.first();
+                (
+                    entry.map(|a| a.capabilities.clone()).unwrap_or_default(),
+                    None,
+                    entry.and_then(|a| a.namespace.clone()),
+                )
             };
 
             // 3. Compile module.
@@ -345,6 +353,10 @@ mod native {
                 // `init_typed_p32`. `None` = entry type (single-actor
                 // modules and unselected loads keep the legacy init path).
                 type_tag,
+                // ADR-0097: the full per-type capability map, so a guest
+                // `spawn_child::<Sibling>` can register the spawned
+                // sibling's own handler set (looked up by actor-type tag).
+                actor_caps: actors,
             };
             let mailbox_id = match ctx
                 .spawn_child::<WasmTrampoline>(Subname::Named(&name), trampoline_config)

--- a/crates/aether-capabilities/src/trampoline.rs
+++ b/crates/aether-capabilities/src/trampoline.rs
@@ -84,9 +84,11 @@ mod native {
     use wasmtime::{Engine, Linker, Module};
 
     use aether_substrate::actor::native::envelope::Envelope;
+    use aether_substrate::actor::native::spawn::Subname;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::actor::wasm::component::{Component, ComponentCtx};
+    use aether_substrate::actor::wasm::component::{Component, ComponentCtx, PendingSpawn};
     use aether_substrate::actor::wasm::kind_manifest;
+    use aether_substrate::actor::wasm::kind_manifest::ActorInputs;
     use aether_substrate::chassis::error::BootError;
     use aether_substrate::mail::capability::MailboxCaps;
     use aether_substrate::mail::mailer::Mailer;
@@ -126,6 +128,12 @@ mod native {
         /// module has. Stored on the trampoline so a later
         /// `ReplaceComponent` rebuilds the same export.
         pub type_tag: Option<u64>,
+        /// ADR-0097: every exported type's capability group, parsed once
+        /// at load. The trampoline keeps it so a `spawn_child::<Sibling>`
+        /// host-fn request can register the spawned sibling's *own*
+        /// handler set (looked up by actor-type tag), and so each
+        /// spawned sibling carries the same map for its own spawns.
+        pub actor_caps: Vec<ActorInputs>,
     }
 
     /// Per-component trampoline. Holds the wasm `Component`
@@ -162,6 +170,14 @@ mod native {
         /// re-instantiates the same exported type from the new wasm
         /// and re-reads that type's capability group.
         type_tag: Option<u64>,
+        /// ADR-0097: the resident `Module`, retained so a sibling spawn
+        /// re-instantiates it (a cheap `Arc` clone — wasmtime shares the
+        /// compiled code) without a re-compile, and refreshed on replace.
+        module: Module,
+        /// ADR-0097: every exported type's capability group (see
+        /// [`WasmTrampolineConfig::actor_caps`]). A spawned sibling looks
+        /// up its own handler set here by actor-type tag.
+        actor_caps: Vec<ActorInputs>,
     }
 
     #[actor]
@@ -171,7 +187,12 @@ mod native {
         /// Wasm-component senders read this via
         /// `WasmTrampoline::NAMESPACE` (reachable on every target
         /// because the bridge stub emits the always-on `Actor` impl
-        /// at file root).
+        /// at file root). Must stay a string literal — the `#[actor]`
+        /// macro feeds it to `concat!`. ADR-0097: the substrate's
+        /// `TRAMPOLINE_NAMESPACE` mirrors this literal (its `spawn_sibling`
+        /// host fn predicts the spawned mailbox id and can't name this
+        /// capabilities-layer type); the
+        /// `trampoline_namespace_matches_substrate` test guards the match.
         const NAMESPACE: &'static str = "aether.component.trampoline";
 
         fn init(
@@ -234,6 +255,8 @@ mod native {
                 outbound: config.outbound,
                 mailbox,
                 type_tag: config.type_tag,
+                module: config.module,
+                actor_caps: config.actor_caps,
             })
         }
 
@@ -316,49 +339,102 @@ mod native {
         /// dispatch shim do the rest.
         #[fallback]
         fn forward_to_wasm(&mut self, ctx: &mut NativeCtx<'_>, env: &Envelope) -> bool {
-            let Some(component) = self.component.as_mut() else {
-                tracing::warn!(
-                    target: "aether_capabilities::trampoline",
-                    mailbox = %self.mailbox,
-                    kind = %env.kind_name,
-                    "mail to trampoline with no wasm loaded (post-drop); discarded — re-load via aether.component.replace",
-                );
-                return true;
+            // ADR-0097: deliver the inbound, then drain any sibling spawn
+            // the guest staged during `deliver`. The block scopes the
+            // `&mut component` borrow so `spawn_sibling` can read the
+            // trampoline's other fields afterward.
+            let pending = {
+                let Some(component) = self.component.as_mut() else {
+                    tracing::warn!(
+                        target: "aether_capabilities::trampoline",
+                        mailbox = %self.mailbox,
+                        kind = %env.kind_name,
+                        "mail to trampoline with no wasm loaded (post-drop); discarded — re-load via aether.component.replace",
+                    );
+                    return true;
+                };
+                // Issue iamacoffeepot/aether#722: carry the inbound's
+                // lineage through to the synthetic `Mail`.
+                // `Component::deliver` reads `mail.mail_id` and `mail.root`
+                // to populate `ComponentCtx`'s in-flight cells, so any
+                // guest-triggered `send_mail_p32` / `reply_mail_p32` stamps
+                // `parent_mail = Some(env.mail_id)` and inherits the chain
+                // `root`. Without this, the trampoline's wrapped Mail
+                // defaults to `MailId::NONE` and the guest's outbound looks
+                // like a fresh root.
+                let mail = Mail::new(
+                    self.mailbox,
+                    env.kind,
+                    env.payload.bytes().to_vec(),
+                    env.count,
+                )
+                .with_reply_to(env.sender)
+                .with_lineage(env.mail_id, env.root, env.parent_mail);
+                if let Err(e) = component.deliver(&mail) {
+                    // ADR-0063 fail-fast: a wasm trap (or host-fn error
+                    // returned through `Component::deliver`) kills the
+                    // substrate. Wedge detection (CPU-loop guests) waits
+                    // on a future epoch-deadline ADR — symmetric with
+                    // native actors, which have no wedge guard either
+                    // today.
+                    ctx.fatal_abort(format!(
+                        "component {} (kind {}) trapped: {e}",
+                        self.mailbox, env.kind_name,
+                    ));
+                }
+                component.take_pending_spawn()
             };
-            // Issue iamacoffeepot/aether#722: carry the inbound's
-            // lineage through to the synthetic `Mail`.
-            // `Component::deliver` reads `mail.mail_id` and `mail.root`
-            // to populate `ComponentCtx`'s in-flight cells, so any
-            // guest-triggered `send_mail_p32` / `reply_mail_p32` stamps
-            // `parent_mail = Some(env.mail_id)` and inherits the chain
-            // `root`. Without this, the trampoline's wrapped Mail
-            // defaults to `MailId::NONE` and the guest's outbound looks
-            // like a fresh root.
-            let mail = Mail::new(
-                self.mailbox,
-                env.kind,
-                env.payload.bytes().to_vec(),
-                env.count,
-            )
-            .with_reply_to(env.sender)
-            .with_lineage(env.mail_id, env.root, env.parent_mail);
-            if let Err(e) = component.deliver(&mail) {
-                // ADR-0063 fail-fast: a wasm trap (or host-fn error
-                // returned through `Component::deliver`) kills the
-                // substrate. Wedge detection (CPU-loop guests) waits
-                // on a future epoch-deadline ADR — symmetric with
-                // native actors, which have no wedge guard either
-                // today.
-                ctx.fatal_abort(format!(
-                    "component {} (kind {}) trapped: {e}",
-                    self.mailbox, env.kind_name,
-                ));
+            if let Some(pending) = pending {
+                self.spawn_sibling(ctx, pending);
             }
             true
         }
     }
 
     impl WasmTrampoline {
+        /// ADR-0097: perform the sibling spawn the guest staged via the
+        /// `spawn_sibling` host fn during `Component::deliver`. The
+        /// trampoline runs the typed `spawn_child::<WasmTrampoline>` the
+        /// substrate host fn couldn't (it can't name this type), reusing
+        /// the resident `Module` and registering the spawned sibling's
+        /// own capability group (looked up by actor-type tag). A
+        /// spawn-time failure surfaces here, asynchronously to the guest
+        /// (which already received the `MailboxId`): logged, not fatal.
+        fn spawn_sibling(&self, ctx: &mut NativeCtx<'_>, pending: PendingSpawn) {
+            let capabilities =
+                self.actor_caps
+                    .iter()
+                    .find(|actor| {
+                        actor.namespace.as_deref().is_some_and(|ns| {
+                            aether_data::mailbox_id_from_name(ns).0 == pending.tag
+                        })
+                    })
+                    .map(|actor| actor.capabilities.clone())
+                    .unwrap_or_default();
+            let config = WasmTrampolineConfig {
+                engine: Arc::clone(&self.engine),
+                linker: Arc::clone(&self.linker),
+                module: self.module.clone(),
+                registry: Arc::clone(&self.registry),
+                outbound: Arc::clone(&self.outbound),
+                capabilities,
+                config: pending.config,
+                type_tag: Some(pending.tag),
+                actor_caps: self.actor_caps.clone(),
+            };
+            if let Err(e) = ctx
+                .spawn_child::<Self>(Subname::Named(&pending.subname), config)
+                .finish()
+            {
+                tracing::warn!(
+                    target: "aether_capabilities::trampoline",
+                    parent = %self.mailbox,
+                    subname = %pending.subname,
+                    "sibling spawn failed: {e:?}",
+                );
+            }
+        }
+
         fn handle_replace(&mut self, payload: ReplaceComponent) -> ReplaceResult {
             // `payload.wasm` is the new module bytes; `mailbox_id` is
             // the trampoline's own id (the agent already addressed
@@ -374,37 +450,37 @@ mod native {
                 }
             };
 
-            // ADR-0033 / ADR-0096: parse capabilities from the new wasm
-            // for the SAME exported type this trampoline loaded, so the
-            // reply carries the post-replace handler vocabulary.
-            // `self.type_tag == None` reads the entry type (single-actor
-            // and entry loads). A tag absent from the new module is an
-            // `Err` — the replacement doesn't export the loaded type.
+            // ADR-0033 / ADR-0096 / ADR-0097: parse every exported type's
+            // capability group from the new wasm. `capabilities` is the
+            // group for the type THIS trampoline hosts (entry when
+            // `type_tag` is None), so the reply carries the post-replace
+            // handler vocabulary; the full `actors` set refreshes
+            // `self.actor_caps` below so post-replace sibling spawns see
+            // the new module's types. A tag absent from the new module is
+            // an `Err` — the replacement doesn't export the loaded type.
+            let actors = match kind_manifest::read_actor_inputs_from_bytes(&payload.wasm) {
+                Ok(a) => a,
+                Err(error) => return ReplaceResult::Err { error },
+            };
             let capabilities = match self.type_tag {
-                None => match kind_manifest::read_inputs_from_bytes(&payload.wasm) {
-                    Ok(c) => c,
-                    Err(error) => return ReplaceResult::Err { error },
-                },
-                Some(tag) => {
-                    let actors = match kind_manifest::read_actor_inputs_from_bytes(&payload.wasm) {
-                        Ok(a) => a,
-                        Err(error) => return ReplaceResult::Err { error },
-                    };
-                    match actors.into_iter().find(|a| {
-                        a.namespace
-                            .as_deref()
-                            .is_some_and(|ns| aether_data::mailbox_id_from_name(ns).0 == tag)
-                    }) {
-                        Some(group) => group.capabilities,
-                        None => {
-                            return ReplaceResult::Err {
-                                error: format!(
-                                    "replace: new module does not export the actor type (tag {tag:#x}) this trampoline loaded"
-                                ),
-                            };
-                        }
+                None => actors
+                    .first()
+                    .map(|a| a.capabilities.clone())
+                    .unwrap_or_default(),
+                Some(tag) => match actors.iter().find(|a| {
+                    a.namespace
+                        .as_deref()
+                        .is_some_and(|ns| aether_data::mailbox_id_from_name(ns).0 == tag)
+                }) {
+                    Some(group) => group.capabilities.clone(),
+                    None => {
+                        return ReplaceResult::Err {
+                            error: format!(
+                                "replace: new module does not export the actor type (tag {tag:#x}) this trampoline loaded"
+                            ),
+                        };
                     }
-                }
+                },
             };
 
             // Run unwire then on_replace on the old instance and lift
@@ -463,6 +539,12 @@ mod native {
                 }
             };
 
+            // ADR-0097: the new module is now resident — retain it (and
+            // the refreshed per-type cap map) so sibling spawns after this
+            // replace re-instantiate the new code, not the old.
+            self.module = module;
+            self.actor_caps = actors;
+
             // ADR-0016 §4: rehydrate the new instance if the old one
             // produced a bundle. A failed rehydrate still installs the
             // new component (the old one is already gone) and surfaces
@@ -504,6 +586,25 @@ mod native {
             CostCells::try_with_mut(|cells| cells.seed(seeded));
 
             ReplaceResult::Ok { capabilities }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use aether_actor::Actor;
+        use aether_substrate::actor::wasm::component::TRAMPOLINE_NAMESPACE;
+
+        /// ADR-0097: the substrate's `TRAMPOLINE_NAMESPACE` — used by the
+        /// `spawn_sibling` host fn to predict a spawned sibling's mailbox
+        /// id — must equal the literal `WasmTrampoline::NAMESPACE` (issue
+        /// 654). The `#[actor]` macro forces the latter to be a literal,
+        /// so they can't share one const; this guards the mirror.
+        #[test]
+        fn trampoline_namespace_matches_substrate() {
+            assert_eq!(
+                <super::WasmTrampoline as Actor>::NAMESPACE,
+                TRAMPOLINE_NAMESPACE,
+            );
         }
     }
 }

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -32,7 +32,7 @@ use std::path::Path;
 use aether_data::{Kind, MailboxId};
 use aether_kinds::{
     Delete, DeleteResult, DropComponent, DropResult, FsError, List, ListResult, LoadComponent,
-    LoadResult, MailEnvelope, Read, ReadResult, ReplaceComponent, ReplaceResult, Write,
+    LoadResult, MailEnvelope, Ping, Read, ReadResult, ReplaceComponent, ReplaceResult, Write,
     WriteResult,
 };
 use aether_substrate_bundle::test_bench::{
@@ -279,6 +279,75 @@ fn multi_actor_unknown_export_errors() {
             panic!("unknown export should fail the load, not fall through; loaded {name}")
         }
     }
+}
+
+/// ADR-0097: a loaded `RootManager` spawns a `Panel` sibling at runtime
+/// via `ctx.spawn_child::<Panel>`. Pinging `RootManager` triggers the
+/// spawn; the spawned `Panel` registers at
+/// `aether.component.trampoline:ui.panel.0` (Counter discriminator), and
+/// pinging *it* makes it broadcast a `TickObserved` to the bench
+/// observer — proving the spawned sibling is addressable and dispatches.
+/// The fire-and-settle send blocks until the whole tree (including the
+/// spawned trampoline's init) drains, so the panel is registered before
+/// the second send routes.
+#[test]
+fn multi_actor_sibling_spawn() {
+    let Some(wasm_path) = require_runtime("multi_actor") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let wasm = fs::read(&wasm_path).expect("read fixture wasm");
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm,
+                    name: None,
+                    config: Vec::new(),
+                    export: None,
+                },
+            ),
+        )])
+        .expect("load sequence");
+    let root_name = match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Ok { name, .. } => name,
+        LoadResult::Err { error } => panic!("multi-actor load failed: {error}"),
+    };
+    assert!(
+        root_name.ends_with(":ui.root"),
+        "entry load should resolve to ui.root; got {root_name}",
+    );
+
+    bench
+        .execute(vec![
+            // RootManager spawns a Panel sibling (Counter → ui.panel.0).
+            (
+                "spawn",
+                BenchOp::send_mail::<Ping>(root_name.as_str(), &Ping { seq: 0 }),
+            ),
+            // The spawned Panel broadcasts TickObserved when pinged.
+            (
+                "ping_panel",
+                BenchOp::send_mail::<Ping>(
+                    "aether.component.trampoline:ui.panel.0",
+                    &Ping { seq: 1 },
+                ),
+            ),
+        ])
+        .expect("spawn + ping sequence");
+
+    assert_eq!(
+        bench.count_observed(TICK_OBSERVED),
+        1,
+        "the spawned Panel (ui.panel.0) should have dispatched its ping and broadcast once; \
+         observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
 }
 
 /// Dropping the probe stops further `tick_observed` broadcasts.

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -48,23 +48,13 @@ use aether_actor::local::ActorSlots;
 use std::sync::Weak;
 use std::time::Duration;
 
-/// How to derive the subname for a [`SpawnBuilder::finish`] call. The
-/// full mailbox name is `"{A::NAMESPACE}:{subname}"`; the substrate
-/// hashes that string deterministically (ADR-0029) to produce the
-/// returned [`MailboxId`].
-#[derive(Debug, Clone, Copy)]
-pub enum Subname<'a> {
-    /// Listener-allocated monotonic counter. Caller doesn't care which
-    /// id the instance gets — useful for "spawn me one of these per
-    /// connection" patterns where the listener tracks the resulting
-    /// `MailboxId` directly.
-    Counter,
-    /// Caller-supplied subname. Must validate per
-    /// [`validate_namespace_segment`] and must be unique within the
-    /// owning prefix (no `:` separator, no control chars / whitespace,
-    /// ≤ [`aether_actor::NAMESPACE_SEGMENT_MAX_LEN`] bytes).
-    Named(&'a str),
-}
+/// The spawn-subname vocabulary, re-exported from `aether-actor`
+/// (ADR-0097). It's shared between native `spawn_child` and the FFI
+/// guest's `FfiCtx::spawn_child`, so it lives in the actor SDK both
+/// transports depend on; native call sites import it from this path
+/// unchanged. The full mailbox name is `"{A::NAMESPACE}:{subname}"`,
+/// hashed deterministically (ADR-0029) to the returned `MailboxId`.
+pub use aether_actor::Subname;
 
 /// Failure modes for the [`SpawnBuilder::finish`] spawn pipeline.
 /// Returned in the order the lifecycle checks them: validate → owner

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -162,6 +162,17 @@ impl Spawner {
         &self.wake_sink
     }
 
+    /// ADR-0097: allocate the next monotonic discriminator from the same
+    /// per-chassis sequence [`Subname::Counter`] draws on. The
+    /// `spawn_sibling` host fn calls this to resolve a wasm
+    /// `Subname::Counter` synchronously — it bakes the value into a
+    /// `Named` subname so the spawned trampoline's `MailboxId` is known
+    /// before the spawn completes (ADR-0097 §4), without double-drawing
+    /// the counter at spawn time.
+    pub fn next_counter(&self) -> u64 {
+        self.counter.fetch_add(1, Ordering::Relaxed)
+    }
+
     /// Issue 685: walk every spawned instanced slot, signal shutdown
     /// on its binding, fire one wake so a pool worker picks it up and
     /// runs the close path (drain residual → `unwire` → registry

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -154,6 +154,38 @@ pub struct ComponentCtx {
     in_flight_mail_id: Cell<MailId>,
     /// ADR-0080 §5 in-flight inbound `root`. See `in_flight_mail_id`.
     in_flight_root: Cell<MailId>,
+    /// ADR-0097: a sibling-spawn request staged by the `spawn_sibling`
+    /// host fn and drained by the trampoline after `receive_p32`
+    /// returns — the same host-fn-stages / host-drains pattern as
+    /// `saved_state`. `None` outside an in-flight spawn. The trampoline
+    /// performs the actual `spawn_child::<WasmTrampoline>`; substrate
+    /// can't name that capabilities-layer type (ADR-0097 §4).
+    pub pending_spawn: Option<PendingSpawn>,
+}
+
+/// The mailbox-name prefix every wasm component (loaded or spawned)
+/// registers under: `aether.component.trampoline:<name>`. The
+/// `spawn_sibling` host fn (ADR-0097) needs this string to predict a
+/// spawned sibling's `MailboxId = hash("{prefix}:{subname}")`
+/// synchronously, and substrate can't name the capabilities-layer
+/// `WasmTrampoline` that owns the canonical declaration
+/// (`WasmTrampoline::NAMESPACE`, issue 654). The `#[actor]` macro
+/// requires that declaration to be a literal, so the two can't share a
+/// const; capabilities' `trampoline_namespace_matches_substrate` test
+/// asserts this mirror stays in lockstep.
+pub const TRAMPOLINE_NAMESPACE: &str = "aether.component.trampoline";
+
+/// ADR-0097: a sibling-spawn request the `spawn_sibling` host fn stages
+/// onto [`ComponentCtx`] for the trampoline to drain and execute.
+/// `tag` selects the exported type at `init_typed_p32`; `subname` is the
+/// full trampoline subname (the spawned instance addresses as
+/// `aether.component.trampoline:<subname>`); `config` is the encoded
+/// `Config` kind handed to the new instance.
+#[derive(Debug, Clone)]
+pub struct PendingSpawn {
+    pub tag: u64,
+    pub subname: String,
+    pub config: Vec<u8>,
 }
 
 impl ComponentCtx {
@@ -181,6 +213,7 @@ impl ComponentCtx {
             correlation_counter: Cell::new(1),
             in_flight_mail_id: Cell::new(MailId::NONE),
             in_flight_root: Cell::new(MailId::NONE),
+            pending_spawn: None,
         }
     }
 
@@ -976,6 +1009,15 @@ impl Component {
     /// store.
     pub fn take_saved_state(&mut self) -> Option<StateBundle> {
         self.store.data_mut().saved_state.take()
+    }
+
+    /// ADR-0097: drain the sibling-spawn request the guest staged via
+    /// the `spawn_sibling` host fn during the just-returned `receive`.
+    /// The trampoline calls this after `deliver` and performs the
+    /// actual `spawn_child::<WasmTrampoline>`. Destructive — returns
+    /// `None` once drained, and `None` when the guest didn't spawn.
+    pub fn take_pending_spawn(&mut self) -> Option<PendingSpawn> {
+        self.store.data_mut().pending_spawn.take()
     }
 
     /// Extract a failure recorded by `save_state` (size cap, OOB).

--- a/crates/aether-substrate/src/actor/wasm/host_fns.rs
+++ b/crates/aether-substrate/src/actor/wasm/host_fns.rs
@@ -4,9 +4,13 @@
 // surface. Growth of this surface should be reviewed as deliberately
 // as any other architectural change.
 
+use core::str::from_utf8;
+
 use wasmtime::{Caller, Linker};
 
-use crate::actor::wasm::component::{ComponentCtx, StateBundle};
+use crate::actor::wasm::component::{
+    ComponentCtx, PendingSpawn, StateBundle, TRAMPOLINE_NAMESPACE,
+};
 use crate::mail::{KindId, MailboxId, ReplyTarget};
 use crate::runtime::log_install;
 
@@ -77,6 +81,96 @@ pub fn register(linker: &mut Linker<ComponentCtx>) -> wasmtime::Result<()> {
             let ctx = caller.data();
             ctx.send(MailboxId(recipient), KindId(kind), payload, count);
             0
+        },
+    )?;
+
+    // HOST_FN_OK: ADR-0097 — sibling spawn is a synchronous host fn by
+    // design. The mail-sink alternative (spawn-via-mail to
+    // aether.component) was considered and rejected there: it makes the
+    // call site async and loses the native `spawn_child` symmetry. The
+    // host fn only *stages* the request (it can't name the
+    // capabilities-layer WasmTrampoline); the trampoline performs the
+    // spawn after `receive` returns.
+    //
+    // ADR-0097: stage a sibling-spawn request. The guest passes the
+    // sibling's actor-type `tag`, an `is_counter` flag, the subname
+    // (the full prefixed name for `Named`, the type-namespace prefix
+    // for `Counter`), and the encoded `Config` bytes. This host fn
+    // can't perform the spawn itself — `spawn_child::<WasmTrampoline>`
+    // names a capabilities-layer type substrate can't see — so it
+    // stages the request onto the ctx and returns the new instance's
+    // `MailboxId` synchronously (`hash("{TRAMPOLINE_NAMESPACE}:{subname}")`,
+    // ADR-0029). The trampoline drains the request after `receive`
+    // returns and runs the real spawn (ADR-0097 §4). On any host-side
+    // error (no memory, OOB, bad UTF-8, no spawner) it warn-logs and
+    // returns 0 without staging — the sibling simply never appears.
+    linker.func_wrap(
+        "aether",
+        "spawn_sibling_p32",
+        |mut caller: Caller<'_, ComponentCtx>,
+         tag: u64,
+         is_counter: u32,
+         subname_ptr: u32,
+         subname_len: u32,
+         config_ptr: u32,
+         config_len: u32|
+         -> u64 {
+            // Copy subname + config out of guest memory, ending the
+            // immutable borrow before the `data_mut` stage below.
+            let copied = {
+                let Some(memory) = caller
+                    .get_export("memory")
+                    .and_then(wasmtime::Extern::into_memory)
+                else {
+                    tracing::warn!(target: "aether_substrate::component", "spawn_sibling: guest exports no memory");
+                    return 0;
+                };
+                let data = memory.data(&caller);
+                let read = |ptr: u32, len: u32| -> Option<&[u8]> {
+                    let start = ptr as usize;
+                    let end = start.checked_add(len as usize)?;
+                    (end <= data.len()).then(|| &data[start..end])
+                };
+                let (Some(subname_bytes), Some(config_bytes)) =
+                    (read(subname_ptr, subname_len), read(config_ptr, config_len))
+                else {
+                    tracing::warn!(target: "aether_substrate::component", "spawn_sibling: subname/config pointer out of bounds");
+                    return 0;
+                };
+                let Ok(subname) = from_utf8(subname_bytes) else {
+                    tracing::warn!(target: "aether_substrate::component", "spawn_sibling: subname is not valid UTF-8");
+                    return 0;
+                };
+                (subname.to_owned(), config_bytes.to_vec())
+            };
+            let (subname_prefix, config) = copied;
+
+            // `Counter`: append a discriminator from the live Spawner so
+            // the name is globally unique and known synchronously.
+            let full_subname = if is_counter == 0 {
+                subname_prefix
+            } else {
+                let Some(n) = caller
+                    .data()
+                    .binding
+                    .as_ref()
+                    .and_then(|binding| binding.spawner())
+                    .map(|spawner| spawner.next_counter())
+                else {
+                    tracing::warn!(target: "aether_substrate::component", "spawn_sibling: no spawner on the binding (counter subname unresolvable)");
+                    return 0;
+                };
+                format!("{subname_prefix}.{n}")
+            };
+
+            let full_name = format!("{TRAMPOLINE_NAMESPACE}:{full_subname}");
+            let mailbox_id = aether_data::mailbox_id_from_name(&full_name).0;
+            caller.data_mut().pending_spawn = Some(PendingSpawn {
+                tag,
+                subname: full_subname,
+                config,
+            });
+            mailbox_id
         },
     )?;
 

--- a/crates/aether-test-fixtures/examples/multi_actor.rs
+++ b/crates/aether-test-fixtures/examples/multi_actor.rs
@@ -1,23 +1,29 @@
-//! ADR-0096 fixture: a multi-actor module. Two `FfiActor` types in one
-//! crate, exported together via `export!(RootManager, Panel)`. Proves
-//! multi-type coexistence in a single wasm module (no duplicate-symbol
-//! collision, which ADR-0014 §4 previously forbade), that the entry
-//! type (the first export, `RootManager`) loads through an unmodified
-//! host, and that the host can select the non-entry export (`Panel`)
-//! by its `Actor::NAMESPACE`.
+//! ADR-0096 / ADR-0097 fixture: a multi-actor module. Two `FfiActor`
+//! types in one crate, exported together via `export!(RootManager,
+//! Panel)`. Proves multi-type coexistence in a single wasm module (no
+//! duplicate-symbol collision, which ADR-0014 §4 previously forbade),
+//! that the entry type (the first export, `RootManager`) loads through
+//! an unmodified host, that the host can select the non-entry export
+//! (`Panel`) by its `Actor::NAMESPACE` (ADR-0096), and that `RootManager`
+//! can spawn a `Panel` sibling at runtime via `ctx.spawn_child::<Panel>`
+//! (ADR-0097).
 //!
-//! The two types carry deliberately distinct receive surfaces so a load
-//! test can prove which one was instantiated: `RootManager` is a strict
-//! receiver (one `Ping` handler, no fallback) while `Panel` adds a
-//! `#[fallback]`. The resolved `aether.kinds.inputs` group for a
-//! selected export must match the type that load picked.
+//! Receive surfaces are deliberately distinct so a load test can prove
+//! which type was instantiated: `RootManager` is a strict receiver (one
+//! `Ping` handler, no fallback); `Panel` adds a `#[fallback]`. On `Ping`,
+//! `RootManager` spawns a `Panel` sibling and `Panel` broadcasts a
+//! `TickObserved` to the test-bench observer — so a scenario can confirm
+//! the spawned sibling is addressable and live.
 
 // `#[handler]` / `#[fallback]` methods take `&mut self` to match the
 // dispatch ABI even when stateless.
 #![allow(clippy::unused_self)]
 
-use aether_actor::{BootError, FfiActor, FfiCtx, Mail, Resolver, actor};
+use aether_actor::{
+    BootError, FfiActor, FfiCtx, Instanced, Mail, MailSender, Resolver, Subname, actor,
+};
 use aether_kinds::Ping;
+use aether_test_fixtures::{TEST_BENCH_OBSERVER_MAILBOX_NAME, TickObserved};
 
 /// Entry export — the first type in the `export!` list. An unmodified
 /// host instantiates this one. Strict receiver: no `#[fallback]`.
@@ -34,14 +40,23 @@ impl FfiActor for RootManager {
         Ok(RootManager)
     }
 
+    /// ADR-0097: on `Ping`, spawn a `Panel` sibling from the same
+    /// resident module. `Subname::Counter` lets the host name it
+    /// `ui.panel.<n>`; the returned `MailboxId` is fire-and-forget here.
     #[handler]
-    fn on_ping(&mut self, _ctx: &mut FfiCtx<'_>, _ping: Ping) {}
+    fn on_ping(&mut self, ctx: &mut FfiCtx<'_>, _ping: Ping) {
+        let _ = ctx.spawn_child::<Panel>(Subname::Counter, &());
+    }
 }
 
-/// Sibling export — selected by passing `export: "ui.panel"` to the
-/// load. Carries a `#[fallback]` so its capability group is observably
-/// distinct from the entry type's strict receiver.
+/// Sibling export — selectable at load via `export: "ui.panel"`
+/// (ADR-0096) and spawnable at runtime by `RootManager` (ADR-0097).
+/// `Instanced` so it satisfies the `spawn_child` bound. Carries a
+/// `#[fallback]` so its capability group is observably distinct from the
+/// entry type's strict receiver.
 pub struct Panel;
+
+impl Instanced for Panel {}
 
 #[actor]
 impl FfiActor for Panel {
@@ -54,8 +69,16 @@ impl FfiActor for Panel {
         Ok(Panel)
     }
 
+    /// On `Ping`, broadcast a `TickObserved` to the test-bench observer
+    /// so a scenario can confirm a spawned `Panel` is addressable and
+    /// dispatches mail.
     #[handler]
-    fn on_ping(&mut self, _ctx: &mut FfiCtx<'_>, _ping: Ping) {}
+    fn on_ping(&mut self, ctx: &mut FfiCtx<'_>, _ping: Ping) {
+        ctx.send_to_named::<TickObserved>(
+            TEST_BENCH_OBSERVER_MAILBOX_NAME,
+            &TickObserved { count: 1 },
+        );
+    }
 
     #[fallback]
     fn on_other(&mut self, _ctx: &mut FfiCtx<'_>, _mail: Mail<'_>) {}

--- a/docs/adr/0097-wasm-sibling-spawn.md
+++ b/docs/adr/0097-wasm-sibling-spawn.md
@@ -1,6 +1,6 @@
 # ADR-0097: Wasm sibling spawn
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-06-06
 
 ## Context


### PR DESCRIPTION
Closes iamacoffeepot/aether#1409.

Implements ADR-0097: a running wasm actor spawns one of its sibling types from the same resident module — the wasm analogue of native `ctx.spawn_child::<A>`, with the same `Subname` / `Instanced` / drop semantics.

## Summary

- **Guest SDK (`aether-actor`)** — a `spawn_sibling` `_p32` import + `MailBridge` method, and `FfiCtx::spawn_child::<A: Instanced + FfiActor>(Subname, &A::Config) -> Result<MailboxId, SpawnError>`. The SDK resolves `A`'s actor-type tag (`mailbox_id_from_name(A::NAMESPACE)`) and encodes `A::Config` at compile time, and returns the new `MailboxId` synchronously — it is `hash(name)` (ADR-0029).
- **Stage-and-drain (`aether-substrate`)** — the host fn can't name the capabilities-layer `WasmTrampoline` that `spawn_child::<WasmTrampoline>` requires, so it stages `(tag, subname, config)` onto `ComponentCtx` (mirroring `save_state`) and returns the predicted id. `Counter` resolves a discriminator off the live `Spawner` (`Spawner::next_counter`) so the id is synchronous and globally unique. `TRAMPOLINE_NAMESPACE` owns the prefix the host fn predicts against.
- **Trampoline (`aether-capabilities`)** — retains its compiled `Module` (a cheap `Arc` clone) and the per-type capability map; after `Component::deliver` it drains the staged spawn and runs the typed `spawn_child::<WasmTrampoline>`, registering the spawned sibling's own handler set. A spawn-time failure is logged, not fatal (the guest already has the id).
- ADR-0097 flipped Proposed → Accepted.

Sibling-only by design: foreign instantiation stays `load_component` (ADR-0097 §3). The macro forces `WasmTrampoline::NAMESPACE` to be a literal, so substrate keeps a mirrored `TRAMPOLINE_NAMESPACE` guarded by a test.

## Test plan

- `multi_actor` fixture: `RootManager` spawns a `Panel` on `Ping`; `Panel` (`Instanced`) broadcasts `TickObserved` on `Ping`.
- `multi_actor_sibling_spawn` (test bench): ping `RootManager` → it spawns `Panel` (`Counter` → `ui.panel.0`); ping that mailbox → it dispatches and broadcasts once. Proves the spawned sibling is addressable and live.
- Existing multi-actor load tests (entry / selected-export / unknown-export) still pass; guard test pins `TRAMPOLINE_NAMESPACE` against `WasmTrampoline::NAMESPACE`.
- Full `scripts/preflight.sh` green: fmt, clippy, doc, 1485 nextest, wasm32 cross-build.

## Generated by

`/implement` — agent execution of scoped issue #1409.
