### PR TITLE
docs(guide): document multi-actor modules + sibling spawn

### DIFF
--- a/docs/guide/foundations/actor-model.md
+++ b/docs/guide/foundations/actor-model.md
@@ -2,7 +2,8 @@
 
 > **Governing ADR:** [ADR-0074](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0074-unified-actor-model-for-substrate-and-guests.md) (the unified actor model — capabilities and
 > components are one model, not two) with [ADR-0079](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0079-instanced-actors-as-a-first-class-category.md) (the lifecycle stages)
-> and [ADR-0033](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0033-handler-driven-inputs-manifest.md) (the `#[actor]` macro). This model is **stable**; it's the
+> and [ADR-0033](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0033-handler-driven-inputs-manifest.md) (the `#[actor]` macro), extended by [ADR-0096](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0096-multi-actor-wasm-modules.md) (a wasm module exports several
+> actor types) and [ADR-0097](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0097-wasm-sibling-spawn.md) (a component spawns its siblings). This model is **stable**; it's the
 > spine everything else hangs off. Signatures here were read from the current SDK
 > (`aether-actor`) and runtime (`aether-substrate`).
 
@@ -104,13 +105,16 @@ persist state. That's what "the context is the contract" means literally: the me
 you're in determines which context type you hold, and that type determines what
 compiles.
 
-Host matters as well as stage. Resolving, sending, and replying are common to both,
-but a few operations live on one side only: a native capability can spawn child
-actors and shut itself down, while a wasm component currently can't — its lifetime is
-driven from outside, by load, drop, and replace. The concrete context types differ by
-host too — `FfiCtx` in a component, `NativeCtx` in a capability — but you write
-handlers against a shared set of capability traits (`Resolver`, `MailSender`, and
-friends), so the same body works on either.
+Host matters as well as stage. Resolving, sending, and replying are common to both;
+a few operations are host-specific. A native capability can spawn any instanced child
+actor and ask to shut itself down. A component can spawn its **sibling** types — the
+other actors its own module exports
+([ADR-0097](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0097-wasm-sibling-spawn.md), and the
+[cardinality](#one-or-many-cardinality) section below) — while its own load, drop, and
+replace are driven from outside. The concrete context types differ by host too —
+`FfiCtx` in a component, `NativeCtx` in a capability — but you write handlers against a
+shared set of capability traits (`Resolver`, `MailSender`, and friends), so the same
+body works on either.
 
 ## Authoring an actor
 
@@ -241,13 +245,21 @@ accepts connections and spawns a session actor per connection with `ctx.spawn_ch
 ([ADR-0079](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0079-instanced-actors-as-a-first-class-category.md)), then reaches a specific one by subname,
 `ctx.resolve_actor::<SessionActor>("42")`.
 
-Spawning children on demand like that is a **native** facility — `spawn_child` is
-bounded to `Instanced` native actors. A wasm component can't spawn children of its
-own (a current gap, not a principle). It *can* still run as several instances,
-though: load the same wasm under different names and each is an independent actor at
-its own `aether.component.trampoline:<name>`. The loader in fact hosts every
-component behind an instanced trampoline actor, spawned once per load — so even a
-single loaded component is, underneath, one instance of an instanced host.
+`ctx.spawn_child` works on both hosts. A native capability spawns any `Instanced`
+native actor; a wasm component spawns its own **sibling** types — `Instanced` actors
+its module also exports ([ADR-0097](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0097-wasm-sibling-spawn.md)). One wasm crate can export several
+actor types (`export!(RootManager, Panel, …)`), and a running instance stands up a
+sibling just as the listener stands up a session:
+`ctx.spawn_child::<Panel>(Subname::Counter, &config)`. A component spawns within the
+module it was built from; a foreign module comes in through `load_component`, which
+carries its own code and kinds — the boundary is covered in
+[Components & lifecycle](../systems/components.md).
+
+A component can also run as several instances of one type: load the same wasm under
+different names and each is an independent actor at its own
+`aether.component.trampoline:<name>`. The loader in fact hosts every component behind
+an instanced trampoline actor, spawned once per load — so even a single loaded
+component is, underneath, one instance of an instanced host.
 
 ## One model, two hosts
 

--- a/docs/guide/systems/components.md
+++ b/docs/guide/systems/components.md
@@ -3,7 +3,9 @@
 > **Governing ADRs:** [ADR-0074](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0074-unified-actor-model-for-substrate-and-guests.md) (one actor model, two hosts), [ADR-0024](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0024-dual-target-host-fn-ffi.md) (the
 > dual-target FFI convention), [ADR-0028](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0028-component-embedded-kind-manifest.md) / [ADR-0033](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0033-handler-driven-inputs-manifest.md) (the kind + handler
 > manifests in the wasm), [ADR-0090](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0090-application-configuration.md) (boot config), [ADR-0022](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0022-drain-on-swap.md) / [ADR-0038](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0038-actor-per-component-dispatch.md)
-> (in-place hot-swap). The authoring and loading surface here is **stable** — it's
+> (in-place hot-swap), [ADR-0096](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0096-multi-actor-wasm-modules.md) (several actor types per module,
+> selected at load) and [ADR-0097](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0097-wasm-sibling-spawn.md) (a component spawns its
+> siblings). The authoring and loading surface here is **stable** — it's
 > what every reference component (`aether-camera`, `aether-mesh-viewer`) is built
 > on, and the signatures were read from the current SDK.
 
@@ -47,6 +49,24 @@ lengths. The exports are **wasm32-only** — a native (host) build of the same c
 carries no FFI symbols, which is why a host-side test of a component drives it
 through the in-process transport rather than the FFI path.
 
+### Several actors in one module
+
+A crate can export more than one actor type ([ADR-0096](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0096-multi-actor-wasm-modules.md)):
+
+```rust
+aether_actor::export!(RootManager, Panel, Toolbar);
+```
+
+The module then carries every listed type's code behind one FFI surface, and the
+load path picks which type an instance becomes (below). The first in the list is the
+**entry** type — the one a load instantiates when it says nothing else, and the one
+whose `NAMESPACE` fills the `aether.namespace` section. The `aether.kinds.inputs`
+manifest grows to one handler group per exported type, each tagged with its
+namespace, so the loader and `describe_component` read each type's surface
+separately. Grouping actors that belong together — a subsystem's coordinator and the
+panels it manages, say — into one module is the intended use: it ships and versions
+them as a unit, and lets a running instance spawn its siblings ([below](#spawning-siblings)).
+
 ## Loading, dropping, and the trampoline address
 
 A component enters and leaves a running engine by mail to the `aether.component`
@@ -65,8 +85,18 @@ A loaded component registers at **`aether.component.trampoline:NAME`** — that 
 string is the address you send subsequent mail to. Bare names (`"player"`) are
 *not* registered and warn-drop; always use the name from `LoadResult`.
 
+For a multi-actor module, the load also chooses **which exported type** to
+instantiate: `aether.component.load` takes an optional **export selector** — the
+target type's `NAMESPACE` — and stands up that type, defaulting to the entry type
+when omitted. The selected type's namespace also becomes the default trampoline
+name, so loading the `Panel` export with `export: "ui.panel"` registers it at
+`aether.component.trampoline:ui.panel` and the `LoadResult` reports that type's
+capabilities. A selector naming a type the module doesn't export is a clean load
+error. A single-actor module has only the entry type, so an omitted selector is the
+whole story there.
+
 In practice you drive this through the MCP harness — `load_component(engine_id,
-binary_path, name?)`, `replace_component(...)`, `terminate_substrate(...)` — which
+binary_path, name?, export?)`, `replace_component(...)`, `terminate_substrate(...)` — which
 takes a **path** and reads the bytes for you (tool JSON never carries the wasm
 buffer; the wire kind does). The component's kind vocabulary travels inside the
 wasm's `aether.kinds` custom section ([ADR-0028](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0028-component-embedded-kind-manifest.md)), so the loader declares nothing —
@@ -82,6 +112,32 @@ so the substrate stays byte-transparent and never needs the config's Rust type.
 Omit `type Config` and the macro synthesizes `()` and injects the unused argument,
 so a no-config `init` stays terse. A declared config kind shows up in the
 component's advertised capabilities, so `describe_kinds` can resolve its schema.
+
+## Spawning siblings
+
+A running instance can stand up another actor from its **own module** — a *sibling*
+type — without a fresh load ([ADR-0097](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0097-wasm-sibling-spawn.md)). Where a native capability spawns
+any `Instanced` actor with `ctx.spawn_child`, a component spawns one of the
+`Instanced` types its `export!` listed:
+
+```rust
+#[handler]
+fn on_open_panel(&mut self, ctx: &mut FfiCtx<'_>, _: OpenPanel) {
+    // -> Result<MailboxId, SpawnError>: the new instance's address
+    let panel = ctx.spawn_child::<Panel>(Subname::Counter, &PanelConfig { /* … */ });
+}
+```
+
+`Subname::Counter` has the host number the instance — `ui.panel.0`, `.1`, … — for
+when you'll track it by the returned `MailboxId`; `Subname::Named("inventory")` gives
+it a stable name you address by. Either way the new instance lives at
+`aether.component.trampoline:<name>` like any loaded component, and its replies route
+back to the spawner. Spawn stays within the module the instance runs from; a
+different binary comes in through `load_component`, which carries its own code and
+kind vocabulary. This is what lets a wasm crate be a *library* of actors: a UI root
+spawns its panels, a zone manager spawns a per-entity actor for each thing in range —
+all from one resident module, its compiled code shared across the instances while
+each keeps its own state.
 
 ## Hot reload
 


### PR DESCRIPTION
Catches the GitBook up with ADR-0096 (multi-actor modules + load selector) and ADR-0097 (sibling spawn), and fixes two now-incorrect passages.

## Drift fixed
`foundations/actor-model.md` asserted twice that a wasm component can't spawn children — closed by ADR-0097. Both rewritten: a component spawns its **sibling** types via `ctx.spawn_child::<Sibling>` (sibling-only; a foreign module comes in through `load_component`). Banner now cites ADR-0096 / ADR-0097.

## Added
`systems/components.md`:
- **Several actors in one module** — `export!(RootManager, Panel, …)`, the entry type, and the per-type `aether.kinds.inputs` grouping.
- **Export selector** on load — `aether.component.load` / `load_component(… export?)` picks which exported type to instantiate (defaults to entry; selected type's namespace becomes the trampoline name).
- **Spawning siblings** — `ctx.spawn_child::<Sibling>(Subname::Counter | Named, &config)`, addressing, and the within-module boundary.

Reader-level throughout — the stage-and-drain host-fn mechanics stay in the ADR, not the guide. `mdbook build` clean (anchors resolve). Docs-only.

Not addressed (separate, pre-existing backlog): the empty `SUMMARY.md` stubs — Rendering, Mesh/DSL, Audio, the DAG, and the six recipes including "Writing a component" (the natural home for a full `export!` + spawn walkthrough).
