### PR TITLE
feat(actor): static lineage-fold resolution for ctx.actor (ADR-0099)

### DIFF
--- a/crates/aether-actor/src/actor/mod.rs
+++ b/crates/aether-actor/src/actor/mod.rs
@@ -25,7 +25,7 @@ pub mod ctx;
 pub mod sender;
 pub mod slot;
 
-use aether_data::Kind;
+use aether_data::{ActorId, Kind, MailboxId, Tag, with_tag};
 
 /// The symmetric trait every actor implements: the recipient name it
 /// claims. Lifecycle methods (`boot` for native chassis caps, `init`
@@ -75,7 +75,32 @@ pub trait Actor: Sized + Send + 'static {
 /// Mutually exclusive with [`Instanced`] at the type level: an actor is
 /// either one-of-a-kind within a scope (singleton) or N-instances under
 /// a shared prefix (instanced, name-keyed). ADR-0079.
-pub trait Singleton: Actor {}
+pub trait Singleton: Actor {
+    /// This actor's [`MailboxId`] as seen by a caller whose lineage carry
+    /// is `caller_carry` (ADR-0099 §5). `ctx.actor::<R>()` calls
+    /// `R::resolve(self_carry)` and addresses the result.
+    ///
+    /// The default is the static, root-pinned resolution: the depth-1
+    /// fixed point (§3), this actor's own [`ActorId`] tagged as a mailbox,
+    /// **ignoring the caller's carry** because a root cap sits at the root,
+    /// not below the caller. It equals today's `mailbox_id_from_name(NAMESPACE)`
+    /// because [`with_tag`] is idempotent on an already-`Mailbox`-tagged
+    /// value — so every chassis cap keeps the exact id it has today.
+    ///
+    /// A non-root actor overrides this. A direct child folds the caller's
+    /// carry — `with_tag(Mailbox, fold_lineage(caller_carry, ActorId::singleton(NAMESPACE)))`
+    /// — and a loaded component folds its harness lineage
+    /// (iamacoffeepot/aether#1432). The override is the only carrier of the
+    /// §2 position fact: a root-pinned actor keeps the default, and nothing
+    /// else about position is held at the type level.
+    #[must_use]
+    fn resolve(_caller_carry: u64) -> MailboxId {
+        MailboxId(with_tag(
+            Tag::Mailbox,
+            ActorId::singleton(Self::NAMESPACE).0,
+        ))
+    }
+}
 
 /// Cardinality marker: many instances of this actor type can be live
 /// per substrate, each under its own subname. `R::NAMESPACE` is a
@@ -189,6 +214,7 @@ pub trait HandlesKind<K: Kind>: Actor {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aether_data::{fold_lineage, mailbox_id_from_name};
 
     /// Issue 625 (ADR-0079): `#[derive(Singleton)]` and
     /// `#[derive(Instanced)]` are the explicit author-side surface
@@ -216,5 +242,61 @@ mod tests {
         }
         fn requires_instanced<T: Instanced>() {}
         requires_instanced::<PerThing>();
+    }
+
+    /// ADR-0099 §5 static default: a root-pinned singleton's [`Singleton::resolve`]
+    /// ignores the caller's carry and returns the depth-1 fixed point —
+    /// the id `mailbox_id_from_name(NAMESPACE)` yields today, so the
+    /// chassis-cap vocabulary stays frozen (§3).
+    #[test]
+    fn singleton_resolve_default_is_frozen_depth_one() {
+        struct RootCap;
+        impl Actor for RootCap {
+            const NAMESPACE: &'static str = "test.resolve.rootcap";
+        }
+        impl Singleton for RootCap {}
+
+        let frozen = mailbox_id_from_name("test.resolve.rootcap");
+        assert_eq!(
+            RootCap::resolve(0),
+            frozen,
+            "default resolve is the depth-1 id"
+        );
+        assert_eq!(
+            RootCap::resolve(0xDEAD_BEEF),
+            frozen,
+            "a root cap ignores the caller's carry"
+        );
+    }
+
+    /// ADR-0099 §5 own-child path: a non-root singleton overrides
+    /// [`Singleton::resolve`] to fold the caller's carry, so the same type
+    /// resolves to a different mailbox under each parent.
+    #[test]
+    fn singleton_resolve_override_folds_caller_carry() {
+        struct Child;
+        impl Actor for Child {
+            const NAMESPACE: &'static str = "test.resolve.child";
+        }
+        impl Singleton for Child {
+            fn resolve(caller_carry: u64) -> MailboxId {
+                MailboxId(with_tag(
+                    Tag::Mailbox,
+                    fold_lineage(caller_carry, ActorId::singleton(<Self as Actor>::NAMESPACE)),
+                ))
+            }
+        }
+
+        let carry = 0x1234_5678_u64;
+        let expected = MailboxId(with_tag(
+            Tag::Mailbox,
+            fold_lineage(carry, ActorId::singleton("test.resolve.child")),
+        ));
+        assert_eq!(Child::resolve(carry), expected, "override folds the carry");
+        assert_ne!(
+            Child::resolve(carry),
+            mailbox_id_from_name("test.resolve.child"),
+            "a folded child id differs from the flat depth-1 hash"
+        );
     }
 }

--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -77,7 +77,7 @@ impl FfiInitCtx<'_> {
     /// addressing the unique instance of receiver actor `R`.
     #[must_use]
     pub fn actor<R: Singleton>(&self) -> FfiActorMailbox<R> {
-        FfiActorMailbox::__new(mailbox_id_from_name(R::NAMESPACE).0)
+        FfiActorMailbox::__new(R::resolve(self.mailbox).0)
     }
 
     /// Multi-instance sender. Resolve a typed [`FfiActorMailbox`]
@@ -169,7 +169,7 @@ impl FfiCtx<'_> {
     /// addressing the unique instance of receiver actor `R`.
     #[must_use]
     pub fn actor<R: Singleton>(&self) -> FfiActorMailbox<R> {
-        FfiActorMailbox::__new(mailbox_id_from_name(R::NAMESPACE).0)
+        FfiActorMailbox::__new(R::resolve(self.mailbox).0)
     }
 
     /// Multi-instance sender. Resolve a typed [`FfiActorMailbox`]

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -760,6 +760,25 @@ mod native {
 
         use crate::test_chassis::fresh_substrate;
 
+        /// ADR-0099 §3/§5: a real `#[bridge(singleton)]` chassis cap keeps
+        /// the default [`aether_actor::Singleton::resolve`], so its id is the
+        /// depth-1 fixed point — exactly the `mailbox_id_from_name(NAMESPACE)`
+        /// value it had before the lineage fold, regardless of the caller's
+        /// carry. Guards the frozen-vocabulary claim: #1431 must not move any
+        /// root-cap id.
+        #[test]
+        fn render_capability_resolves_to_frozen_depth_one_id() {
+            use aether_actor::Singleton;
+            use aether_data::mailbox_id_from_name;
+
+            let frozen = mailbox_id_from_name(<RenderCapability as Actor>::NAMESPACE);
+            assert_eq!(<RenderCapability as Singleton>::resolve(0), frozen);
+            assert_eq!(
+                <RenderCapability as Singleton>::resolve(0xFFFF_FFFF_FFFF_FFFF),
+                frozen,
+            );
+        }
+
         /// Boots a passive `TestChassis` with a default `RenderCapability`.
         /// Collapses the four-line `Builder::<TestChassis>::new(...)` chain
         /// every render test repeated (issue 795).

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -984,6 +984,52 @@ mod tests {
         assert_eq!(transport.prev_correlation(), 2);
     }
 
+    /// ADR-0099 §5 own-child path through the real `ctx.actor` call site:
+    /// a non-root singleton overrides [`Singleton::resolve`] to fold the
+    /// caller's carry, and `ctx.actor::<R>()` feeds it `self.binding.carry()`.
+    /// A parent at carry `C` addressing this child by bare type lands on
+    /// `fold(C, ActorId::singleton(NAMESPACE))`, not the flat `hash(NAMESPACE)`
+    /// — the miss the lineage fold closes (#1364).
+    #[test]
+    fn ctx_actor_folds_own_child_singleton_onto_caller_carry() {
+        use crate::actor::native::ctx::NativeCtx;
+        use aether_actor::{Actor, Singleton};
+        use aether_data::{ActorId, Tag, fold_lineage, mailbox_id_from_name, with_tag};
+
+        struct OwnChild;
+        impl Actor for OwnChild {
+            const NAMESPACE: &'static str = "test.actor_fold.child";
+        }
+        impl Singleton for OwnChild {
+            fn resolve(caller_carry: u64) -> MailboxId {
+                MailboxId(with_tag(
+                    Tag::Mailbox,
+                    fold_lineage(caller_carry, ActorId::singleton(<Self as Actor>::NAMESPACE)),
+                ))
+            }
+        }
+
+        let (_registry, mailer) = fresh_substrate();
+        let parent_carry = 0x0BAD_F00D_u64;
+        let transport = Arc::new(NativeBinding::new_for_test(mailer, MailboxId(parent_carry)));
+        let ctx = NativeCtx::new(&transport, ReplyTo::NONE, MailId::NONE, MailId::NONE);
+
+        let resolved = ctx.actor::<OwnChild>().mailbox_id();
+        let expected = MailboxId(with_tag(
+            Tag::Mailbox,
+            fold_lineage(parent_carry, ActorId::singleton("test.actor_fold.child")),
+        ));
+        assert_eq!(
+            resolved, expected,
+            "ctx.actor feeds self.carry to Singleton::resolve, folding the own-child node"
+        );
+        assert_ne!(
+            resolved,
+            mailbox_id_from_name("test.actor_fold.child"),
+            "the folded own-child id differs from the flat depth-1 hash"
+        );
+    }
+
     /// `install_inbox` is single-claim — a second install panics.
     #[test]
     #[should_panic(expected = "install_inbox called twice")]

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -69,6 +69,40 @@ pub struct NativeCtx<'a> {
     in_flight_root: MailId,
 }
 
+/// The receiver-addressing methods shared verbatim by [`NativeCtx`] and
+/// [`NativeInitCtx`]: both hold the same `binding`, so `actor` /
+/// `resolve_actor` / `actor_at` resolve identically. Emitting them from
+/// one source keeps the two ctxs from drifting and means the bodies are
+/// not a `DuplicatedCode` clone (ADR-0099 §5 / issue 1431).
+macro_rules! native_sender_methods {
+    () => {
+        /// Singleton sender shortcut: returns a typed [`NativeActorMailbox`]
+        /// addressing the unique instance of receiver actor `R`.
+        #[must_use]
+        pub fn actor<R: Singleton>(&self) -> NativeActorMailbox<'_, R> {
+            NativeActorMailbox::__new(R::resolve(self.binding.carry()).0, self.binding)
+        }
+
+        /// Multi-instance sender: resolve a typed [`NativeActorMailbox`]
+        /// from a runtime instance name.
+        #[must_use]
+        pub fn resolve_actor<R: Actor>(&self, name: &str) -> NativeActorMailbox<'_, R> {
+            NativeActorMailbox::__new(mailbox_id_from_name(name).0, self.binding)
+        }
+
+        /// Address an actor by a [`MailboxId`] already in hand — the id a
+        /// `spawn_child` returned, or one a peer handed over. ADR-0099 §3:
+        /// a hosted / nested actor's id is the lineage fold, not
+        /// `hash(name)`, so it cannot be re-derived from a name; a supervisor
+        /// that tracks its children's ids addresses them through this rather
+        /// than re-resolving by name.
+        #[must_use]
+        pub fn actor_at<R: Actor>(&self, id: MailboxId) -> NativeActorMailbox<'_, R> {
+            NativeActorMailbox::__new(id.0, self.binding)
+        }
+    };
+}
+
 impl<'a> NativeCtx<'a> {
     /// Internal constructor — the chassis dispatcher trampoline (in
     /// `chassis::builder`) builds these. Cap-side test fixtures in
@@ -370,31 +404,7 @@ impl<'a> NativeCtx<'a> {
         }
     }
 
-    /// Singleton sender shortcut: returns a typed [`NativeActorMailbox`]
-    /// addressing the unique instance of receiver actor `R`.
-    #[must_use]
-    pub fn actor<R: Singleton>(&self) -> NativeActorMailbox<'_, R> {
-        NativeActorMailbox::__new(R::resolve(self.binding.carry()).0, self.binding)
-    }
-
-    //noinspection DuplicatedCode
-    /// Multi-instance sender: resolve a typed [`NativeActorMailbox`]
-    /// from a runtime instance name.
-    #[must_use]
-    pub fn resolve_actor<R: Actor>(&self, name: &str) -> NativeActorMailbox<'_, R> {
-        NativeActorMailbox::__new(mailbox_id_from_name(name).0, self.binding)
-    }
-
-    /// Address an actor by a [`MailboxId`] already in hand — the id a
-    /// `spawn_child` returned, or one a peer handed over. ADR-0099 §3:
-    /// a hosted / nested actor's id is the lineage fold, not
-    /// `hash(name)`, so it cannot be re-derived from a name; a supervisor
-    /// that tracks its children's ids addresses them through this rather
-    /// than re-resolving by name.
-    #[must_use]
-    pub fn actor_at<R: Actor>(&self, id: MailboxId) -> NativeActorMailbox<'_, R> {
-        NativeActorMailbox::__new(id.0, self.binding)
-    }
+    native_sender_methods!();
 
     /// Reply to an explicit [`ReplyTo`] rather than the inbound's own
     /// sender. The ADR-0093 hold-until-resolve path reaches for this:
@@ -854,31 +864,7 @@ impl<'a> NativeInitCtx<'a> {
             .insert(TypeId::of::<H>(), Box::new(handle));
     }
 
-    /// Singleton sender shortcut: returns a typed [`NativeActorMailbox`]
-    /// addressing the unique instance of receiver actor `R`.
-    #[must_use]
-    pub fn actor<R: Singleton>(&self) -> NativeActorMailbox<'_, R> {
-        NativeActorMailbox::__new(R::resolve(self.binding.carry()).0, self.binding)
-    }
-
-    //noinspection DuplicatedCode
-    /// Multi-instance sender: resolve a typed [`NativeActorMailbox`]
-    /// from a runtime instance name.
-    #[must_use]
-    pub fn resolve_actor<R: Actor>(&self, name: &str) -> NativeActorMailbox<'_, R> {
-        NativeActorMailbox::__new(mailbox_id_from_name(name).0, self.binding)
-    }
-
-    /// Address an actor by a [`MailboxId`] already in hand — the id a
-    /// `spawn_child` returned, or one a peer handed over. ADR-0099 §3:
-    /// a hosted / nested actor's id is the lineage fold, not
-    /// `hash(name)`, so it cannot be re-derived from a name; a supervisor
-    /// that tracks its children's ids addresses them through this rather
-    /// than re-resolving by name.
-    #[must_use]
-    pub fn actor_at<R: Actor>(&self, id: MailboxId) -> NativeActorMailbox<'_, R> {
-        NativeActorMailbox::__new(id.0, self.binding)
-    }
+    native_sender_methods!();
 }
 
 // Issue 703: NativeInitCtx no longer impls `Sender` / `MailSender`.

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -374,7 +374,7 @@ impl<'a> NativeCtx<'a> {
     /// addressing the unique instance of receiver actor `R`.
     #[must_use]
     pub fn actor<R: Singleton>(&self) -> NativeActorMailbox<'_, R> {
-        NativeActorMailbox::__new(mailbox_id_from_name(R::NAMESPACE).0, self.binding)
+        NativeActorMailbox::__new(R::resolve(self.binding.carry()).0, self.binding)
     }
 
     //noinspection DuplicatedCode
@@ -858,7 +858,7 @@ impl<'a> NativeInitCtx<'a> {
     /// addressing the unique instance of receiver actor `R`.
     #[must_use]
     pub fn actor<R: Singleton>(&self) -> NativeActorMailbox<'_, R> {
-        NativeActorMailbox::__new(mailbox_id_from_name(R::NAMESPACE).0, self.binding)
+        NativeActorMailbox::__new(R::resolve(self.binding.carry()).0, self.binding)
     }
 
     //noinspection DuplicatedCode


### PR DESCRIPTION
Closes iamacoffeepot/aether#1431.

## Summary

`ctx.actor::<R>()` resolved the flat `mailbox_id_from_name(R::NAMESPACE)`, which is correct only for a depth-1 root cap. A hosted actor's MailboxId is the lineage fold (#1430), so the bare-type call missed it — the #1364 gap.

This adds a provided `Singleton::resolve(caller_carry) -> MailboxId` (ADR-0099 §5). The default is the depth-1 fixed point — the actor's own `ActorId` tagged as a mailbox, ignoring the carry — which equals today's flat hash, so every chassis cap keeps the exact id it has now. A non-root actor overrides `resolve` to fold the caller's carry; that override is the only carrier of the §2 position fact (no marker trait, no const). `ctx.actor` now calls `R::resolve(self_carry)` at the four FFI/native init+receive sites, with the carry read from `self.mailbox` (FFI) or `self.binding.carry()` (native).

The bound stays `R: Singleton`, so there is no macro change and no fixture migration; a hosted component falls through to today's behaviour until the delegate (dynamic) override lands (#1432).

## Test plan

- `aether-actor` unit tests: the default `resolve` ignores the carry and equals `mailbox_id_from_name(NAMESPACE)` (frozen depth-1); an overriding fixture folds the carry.
- `aether-capabilities`: a real `#[bridge(singleton)]` cap (`RenderCapability`) resolves to its unchanged depth-1 id for any carry — the frozen-vocabulary guard.
- `aether-substrate`: `ctx.actor::<Child>()` through a real `NativeCtx` folds the caller's carry onto the own-child node, differing from the flat hash.
- Full `scripts/preflight.sh` — fmt, clippy `--workspace --all-targets`, doc, nextest `--workspace`, wasm32 component cross-build.

## Generated by

`/implement` — agent execution of [scoped issue #1431](https://github.com/iamacoffeepot/aether/issues/1431).
