### PR TITLE
docs(adr): reconcile 0096-0099 records after the ADR-0099 arc landed

### DIFF
--- a/docs/adr/0096-multi-actor-wasm-modules.md
+++ b/docs/adr/0096-multi-actor-wasm-modules.md
@@ -1,6 +1,6 @@
 # ADR-0096: Multi-actor wasm modules
 
-- **Status:** Accepted
+- **Status:** Accepted (hosted-actor addressing later revised by [ADR-0099](0099-actor-identity-and-addressing.md); the actor-type tag here is reused as the ActorId)
 - **Date:** 2026-06-06
 
 ## Context
@@ -55,7 +55,7 @@ Loading a multi-actor module names which exported type the instance becomes. `Lo
 
 ### Neutral
 
-- **Addressing and wire format unchanged.** Loaded actors live under `aether.component.trampoline` as today; `MailboxId = hash(name)` holds.
+- **Addressing and wire format unchanged.** Loaded actors live under `aether.component.trampoline` as today; `MailboxId = hash(name)` holds. *(Revised by [ADR-0099](0099-actor-identity-and-addressing.md): a hosted actor's `MailboxId` is now the lineage fold, not `hash(name)`, and the embedding-host node is renamed `aether.embedded`. The multi-actor-module foundation above is unchanged, and its actor-type tag is reused as the ActorId.)*
 - **The load path gains a type selector.** Single-actor modules keep their current behavior.
 
 ### Follow-on
@@ -71,6 +71,7 @@ Loading a multi-actor module names which exported type the instance becomes. `Lo
 ## Related
 
 - ADR-0079 — Instanced actors as a first-class category; its deferred wasm-side spawn unparks on the sibling-spawn follow-on, which builds on this.
+- ADR-0099 — Actor identity and addressing. Reuses this ADR's **actor-type tag** as the ActorId, and revises the hosted-actor **addressing**: a loaded actor's `MailboxId` is the lineage fold (not `hash(name)`) and the embedding-host node is `aether.embedded`. The multi-actor-module foundation here stands.
 - ADR-0024 — Dual-target `_p32` shims; the contract this extends with an actor-type tag.
 - ADR-0033 — Handler-driven inputs manifest; grows to one handler set per exported type.
 - ADR-0066 — Component and peers share the kind crate; the `runtime` feature emits the cdylib.

--- a/docs/adr/0097-wasm-sibling-spawn.md
+++ b/docs/adr/0097-wasm-sibling-spawn.md
@@ -1,6 +1,6 @@
 # ADR-0097: Wasm sibling spawn
 
-- **Status:** Accepted
+- **Status:** Accepted (hosted-actor addressing later revised by [ADR-0099](0099-actor-identity-and-addressing.md) — the spawn *mechanism* stands)
 - **Date:** 2026-06-06
 
 ## Context
@@ -65,7 +65,7 @@ A spawned sibling has independent lifecycle, mirroring native. Children self-clo
 
 ### Neutral
 
-- **Addressing and wire format unchanged.** Spawned siblings live under `aether.component.trampoline:<name>` like every other loaded actor; `MailboxId = hash(name)` holds.
+- **Addressing and wire format unchanged.** Spawned siblings live under `aether.component.trampoline:<name>` like every other loaded actor; `MailboxId = hash(name)` holds. *(Revised by [ADR-0099](0099-actor-identity-and-addressing.md): a spawned sibling now nests under the spawner's lineage — its `MailboxId` is the lineage fold, not `hash(name)` — and the embedding-host node is renamed `aether.embedded`. The spawn mechanism above is unchanged.)*
 - **Foreign instantiation is unchanged** — still `load_component`, still capability-governed.
 
 ### Follow-on
@@ -83,6 +83,7 @@ A spawned sibling has independent lifecycle, mirroring native. Children self-clo
 ## Related
 
 - ADR-0096 — multi-actor wasm modules; this is its deferred runtime follow-on and resolves its open granularity question.
+- ADR-0099 — Actor identity and addressing. Revises this ADR's sibling **addressing**: a spawned sibling nests under the spawner's lineage (its `MailboxId` is the lineage fold, not `hash(name)`) and the embedding-host node is `aether.embedded`. The spawn **mechanism** (stage-and-drain, typed `spawn_child`, sync-id / async-failure, sibling-only, no cascade) stands unchanged.
 - ADR-0079 — instanced actors, cardinality, and the `spawn_child` semantics reused here.
 - ADR-0024 — dual-target `_p32` shims; the contract this extends with a spawn import.
 - ADR-0090 — init-config byte carrier; a spawned sibling's config rides the same path.

--- a/docs/adr/0099-actor-identity-and-addressing.md
+++ b/docs/adr/0099-actor-identity-and-addressing.md
@@ -1,7 +1,8 @@
 # ADR-0099: Actor identity and addressing
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-06-07
+- **Accepted:** 2026-06-08 (implementation arc iamacoffeepot/aether#1429 landed)
 
 ## Context
 
@@ -25,7 +26,7 @@ This ADR **supersedes ADR-0098** (scoped singletons), which framed the same #136
 
 ## Decision
 
-Five sub-decisions.
+Six sub-decisions.
 
 ### 1. Two identities: ActorId (which actor) and MailboxId (where in the tree)
 
@@ -82,9 +83,9 @@ atom     := ident ( "." ident )*
 
 - **`/`** separates nodes — one segment per ActorId in the lineage, root → leaf.
 - **`:`** carries an instanced node's discriminator; the segment around it names that node's ActorId, `hash(NAMESPACE:subname)`.
-- **`.`** is cosmetic, within a single namespace ident — `aether.component.trampoline` is one segment.
+- **`.`** is cosmetic, within a single namespace ident — `aether.component` is one segment.
 
-The loaded camera renders as `aether.component/aether.component.trampoline:camera`: root host, child trampoline scope, instance. Because the string is a rendering, a MailboxId is never computed by hashing it — a written path is resolved by parsing it into segments, mapping each segment to its ActorId, and chain-folding (§3). Type addressing never touches the string at all: `ctx.actor::<R>()` resolves R to its id by R's resolution mode (§5), not by the rendered path. The parse is the cold path, paid only by string-addressed callers — MCP, the CLI, `actor_logs`.
+The loaded camera renders as `aether.component/aether.embedded:camera`: root host, child embedding-host class, instance. Because the string is a rendering, a MailboxId is never computed by hashing it — a written path is resolved by parsing it into segments, mapping each segment to its ActorId, and chain-folding (§3). Type addressing never touches the string at all: `ctx.actor::<R>()` resolves R to its id by R's resolution mode (§5), not by the rendered path. The parse is the cold path, paid only by string-addressed callers — MCP, the CLI, `actor_logs`.
 
 Display spellings can therefore vary — collapsing a repeated root, abbreviating a namespace — without touching the hash, because the lineage array is the single source of truth and the string never feeds resolution. There is no second authoritative form to disagree with the first.
 
@@ -144,7 +145,7 @@ This is a second kind of namespace sharing. The chassis render caps share `aethe
 
 ### Follow-on
 
-- **Implementation** is scoped on iamacoffeepot/aether#1420 and split into PRs: the lineage fold + carry in `aether-data` and the actor binding, with the trampoline re-spell; static resolution, with an embeddable component delegating to its host class (§5) under the reserved `aether.embedded` namespace; and the migration of name-carrying surfaces.
+- **Implementation** landed via the iamacoffeepot/aether#1429 arc: the lineage fold + carry in `aether-data` and the actor binding with the trampoline re-spell (#1430), static resolution with an embeddable component delegating to its host class (§5) under the reserved `aether.embedded` namespace (#1431, #1432), and the tcp consumer through the shared resolver (#1433). (Supersedes the earlier #1420 scoping, which was drafted against a prior draft of this ADR.)
 - **Display-layer ergonomics** — collapsing a repeated namespace root in the rendered path — are free to land later, since the string never feeds the hash.
 
 ## Alternatives considered
@@ -166,4 +167,4 @@ This is a second kind of namespace sharing. The chassis render caps share `aethe
 - ADR-0079 — Instanced actors and cardinality. An instanced node's discriminator is folded into its ActorId by the `:` separator.
 - ADR-0064 — Type-tagged opaque ids. The depth-1 fixed point relies on `with_tag` being idempotent for a repeated tag.
 - ADR-0080 — Mail tracing and settlement. The causal mail lineage (`ReplyTo`) is a separate lineage, unaffected.
-- iamacoffeepot/aether#1364 — the gap this closes; #1420 — the implementation; #1423 — static resolution (an embeddable actor delegates to its host class; no registry, no round-trip).
+- iamacoffeepot/aether#1364 — the gap this closes; #1429 — the implementation arc (#1430 lineage fold + carry, #1431 static resolution, #1432 embeddable resolution through the host class, #1433 tcp consumer).


### PR DESCRIPTION
Reconciles the records of ADRs 0096–0099 now that ADR-0099's resolution arc (#1429: #1430–#1433) has merged. No design change — only record correctness.

## Per ADR

- **0099** (the current design) — `Proposed` → **`Accepted`** (the arc landed); "Five" → "Six sub-decisions" (the #1437 revision added §6); the §4 render example and the `.`-is-cosmetic grammar example use the current `aether.embedded` node; the Follow-on and Related point at the #1429 arc instead of the superseded #1420 scoping. The Context and Alternatives keep the historical before/rejected framing (they describe the problem and the rejected approaches as they stood).
- **0096 / 0097** (accepted, partially revised) — bodies preserved; each gains a Status note, a Related entry, and an inline note on the now-revised **"Addressing and wire format unchanged"** Neutral claim, pointing to ADR-0099: a hosted actor's `MailboxId` is the lineage fold (not `hash(name)`) and the embedding-host node is `aether.embedded`. 0096's actor-type tag is reused as the ActorId; 0097's spawn mechanism stands. This follows the same forward-cross-link convention 0098 already uses for "Superseded by".
- **0098** — already `Superseded by ADR-0099`; unchanged.

## One judgment call — flagged for your nod (why this is a draft)

Flipping **0099 to Accepted** is the `feedback_adr_accepted_after_implementation` "last step" — the impl arc is fully merged, so `Proposed` is now incorrect. You'd earlier said not to *auto-offer* the flip, so I've made it but held this as a draft rather than letting it auto-merge. Un-draft (or tell me) to land it; or say the word and I'll drop the Accepted flip and keep 0099 at Proposed.

Also intentionally **not** touched (out of scope for a record-reconcile, surfaced for your call):
- 0099's Context still says the loaded component is "registered at `aether.component.trampoline:camera` (ADR-0096 §3)" — left as the pre-implementation problem framing, consistent with 0096 §3's own (unchanged) text.
- The rejected-alternative and "constraints carried in" mentions of the old trampoline name — left as historical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
