### PR TITLE
chore(repo): package component wasm + chassis bins into dist/ with a manifest

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+# `cargo xtask <cmd>` runs the repo build-task crate. `dist` packages the
+# component wasm + chassis bins into `dist/` with a typed manifest; see
+# xtask/src/main.rs.
+[alias]
+xtask = "run --package xtask --"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,57 +124,26 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev
           mesa-vulkan-drivers
       - uses: Swatinem/rust-cache@v2
-      # Pre-build component wasm artifacts the scenario runner loads
+      # Pre-build the packaged artifact tree the scenario runner loads
       # at test time. Without this, ADR-0067 per-component scenarios
-      # silently skip in CI ("wasm not built"). Cheap to build —
-      # the wasm targets are tiny next to the host workspace and
-      # rust-cache picks up the wasm artifacts on subsequent runs.
-      # Component crates are discovered from `cargo metadata` by two
-      # structural signals (issue 439): the package declares a
-      # `cdylib` lib target AND depends on `aether-actor`. The dep
-      # IS the component contract — anything that imports the SDK
-      # (init, receive_p32, MailTransport, etc.) deps on it; anything
-      # that doesn't isn't a component. No filename convention to
-      # remember and no static list to keep in sync. (Pre issue-552
-      # the dep signal was `aether-component`; that crate folded into
-      # `aether-actor` in stage 0, so the marker name moves with it.)
-      # `AETHER_REQUIRE_RUNTIME=1` on the test step turns any missing
-      # wasm into a hard failure so a discovery miss is loud, not silent.
+      # silently skip in CI ("wasm not built"); `AETHER_REQUIRE_RUNTIME=1`
+      # on the test step turns any missing wasm into a hard failure so a
+      # discovery miss is loud, not silent. `cargo xtask dist` discovers
+      # component crates structurally (issue 439): a package depending on
+      # `aether-actor` that exposes a `cdylib` lib or `[[example]]` target.
+      # The dep IS the component contract — anything importing the SDK
+      # (init, receive_p32, MailTransport, etc.) deps on it. Each package
+      # cross-builds in its own cargo invocation: consolidated component
+      # crates (e.g. `aether-camera`) gate their `aether_actor::export!()`
+      # FFI emission behind a default `runtime` feature, and trunk-type
+      # consumers (sokoban) opt out via `default-features = false`. A
+      # multi-package build would feature-unify, re-enabling `runtime` for
+      # the trunk consumer → wasm-lld duplicate-symbol on `init` /
+      # `receive_p32`; xtask keeps each build's feature resolve isolated.
+      # The wasm lands under `target/wasm32-unknown-unknown/` (where the
+      # scenario tests read it) as well as `dist/`.
       - name: Pre-build component wasm for scenario tests
-        # Issue 552 stage 1.5: build each component crate in its own
-        # cargo invocation so feature unification stays per-package.
-        # Consolidated component crates (e.g. `aether-camera`) gate
-        # their `aether_actor::export!()` FFI emission behind a default
-        # `runtime` feature; trunk-type consumers (sokoban) opt out via
-        # `default-features = false`. A multi-package `-p A -p B` build
-        # would feature-unify, re-enabling `runtime` for the trunk
-        # consumer's transitive view → wasm-lld duplicate-symbol on
-        # `init` / `receive_p32`. Per-package invocations keep each
-        # build's feature resolve independent.
-        run: |
-          set -euo pipefail
-          pkgs=$(cargo metadata --format-version=1 --no-deps |
-            jq -r '.packages[]
-              | select(.targets[] | .kind | contains(["cdylib"]))
-              | select([.dependencies[] | .name] | contains(["aether-actor"]))
-              | .name')
-          if [ -z "$pkgs" ]; then
-            echo "no wasm component crates discovered"; exit 1
-          fi
-          echo "Building wasm for:"; echo "$pkgs"
-          while read -r pkg; do
-            [ -z "$pkg" ] && continue
-            cargo build --target wasm32-unknown-unknown -p "$pkg"
-          done <<< "$pkgs"
-          # ADR-0090 c1 (issue 1256): aether-test-fixtures carries its
-          # component cdylibs as `[[example]] crate-type = ["cdylib"]`,
-          # not as the package's lib output. The metadata-driven
-          # discovery above filters by `targets[].kind = "cdylib"`,
-          # which doesn't match example targets (kind = "example"
-          # even with crate-type = cdylib), so the test-fixtures crate
-          # is invisible to the structural sweep — build its examples
-          # explicitly.
-          cargo build --target wasm32-unknown-unknown -p aether-test-fixtures --examples
+        run: cargo xtask dist
       # Run the full workspace test suite under nextest. The
       # changed-crate filter the prior step had is gone — nextest's
       # process-per-test isolation surfaces cross-test contamination

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 /target
+# Packaged artifact tree written by `cargo xtask dist` (component wasm +
+# chassis bins + manifest.json). Regenerated each build, never committed.
+/dist/
 # Spike crates under spikes/ are standalone Cargo workspaces with
 # their own target dirs (per ADR-0003 §Consequences).
 spikes/*/target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5802,6 +5835,17 @@ name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xtask"
+version = "0.3.0-alpha"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "clap",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/aether-mesh-viewer",
     "crates/aether-test-fixtures",
     "demos/sokoban",
+    "xtask",
 ]
 # Reference artefacts under spikes/ are standalone Cargo workspaces
 # (see ADR-0003 §Consequences) and must be excluded so they aren't

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -149,34 +149,12 @@ run_step "cargo doc --workspace --no-deps (rustdoc lints denied)" \
     env RUSTDOCFLAGS="-D rustdoc::redundant_explicit_links -D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links" \
     cargo doc --workspace --no-deps
 
-# Wasm32 component cross-build mirrors CI's pre-test step. Component
-# crates are discovered structurally (issue #439): cdylib lib target
-# AND a dep on `aether-actor`.
-echo "  -> wasm32 component cross-build"
-comp_pkgs=$(cargo metadata --format-version=1 --no-deps |
-    jq -r '.packages[]
-        | select(.targets[]?.kind | (. // []) | contains(["cdylib"]))
-        | select([.dependencies[]?.name] | contains(["aether-actor"]))
-        | .name' || true)
-if [[ -n "${comp_pkgs:-}" ]]; then
-    while IFS= read -r pkg; do
-        [[ -z "$pkg" ]] && continue
-        echo "     . $pkg"
-        cargo build --target wasm32-unknown-unknown -p "$pkg" --quiet
-    done <<< "$comp_pkgs"
-else
-    echo "     (no component crates discovered)"
-fi
-
-# ADR-0090 c1 (issue 1256): `aether-test-fixtures` carries cdylib
-# component artifacts as `[[example]]`s rather than at the package
-# level (so a typed-config fixture can live next to the original
-# probe without a per-fixture member crate). The cdylib-discovery
-# query above looks at `targets[].kind`, which is `["example"]` for
-# example targets — even with `crate-type = ["cdylib"]` — so the
-# crate is invisible to the structural sweep. Build it explicitly.
-echo "     . aether-test-fixtures (examples)"
-cargo build --target wasm32-unknown-unknown -p aether-test-fixtures --examples --quiet
+# Wasm32 component cross-build mirrors CI's pre-test step. `xtask dist`
+# discovers component crates structurally (cdylib lib + example targets
+# gated on the `aether-actor` dep, issue #439) and cross-builds each
+# per-package. `--no-bins` keeps the preflight fast path wasm-only.
+run_step "cargo xtask dist --no-bins (component wasm cross-build)" \
+    cargo xtask dist --no-bins
 
 # Final, slowest step. AETHER_REQUIRE_RUNTIME=1 mirrors CI so a
 # missing wasm artifact fails loudly rather than skipping silently.

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "xtask"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+anyhow = "1"
+cargo_metadata = "0.23.1"
+clap = { workspace = true }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[lints]
+workspace = true

--- a/xtask/src/inventory.rs
+++ b/xtask/src/inventory.rs
@@ -1,0 +1,104 @@
+//! Structural discovery of the workspace's packaged artifacts.
+//!
+//! This is the single source of truth for "what does `dist/` contain":
+//! the component wasm set (discovered from `cargo metadata`) plus the
+//! static chassis-binary list. It is written as a standalone module so a
+//! future harness (`FleetBench`) and the hardcoded `--bin` lists in
+//! `scripts/ensure-tunnel.sh` / `scripts/perf-compare.sh` can be derived
+//! from the same inventory instead of re-deriving it per call site.
+
+use cargo_metadata::{CrateType, Metadata, TargetKind};
+
+/// The dependency that marks a package as a component (issue #439): any
+/// crate importing the actor SDK (`init`, `receive_p32`, `MailTransport`)
+/// deps on it; anything that does not is not a component.
+const ACTOR_DEP: &str = "aether-actor";
+
+/// Cargo package owning the chassis binaries. All three live here, so
+/// they build in one cargo invocation (same crate, shared feature
+/// resolve) without the per-package isolation the wasm components need.
+pub const CHASSIS_PACKAGE: &str = "aether-substrate-bundle";
+
+/// Chassis (host-target) binaries packaged into `dist/bin/`. Each name is
+/// both the `--bin` selector and the output filename.
+pub const CHASSIS_BINS: &[&str] = &[
+    "aether-substrate",
+    "aether-substrate-headless",
+    "aether-substrate-hub",
+];
+
+/// One discovered wasm component artifact.
+#[derive(Debug, Clone)]
+pub struct Component {
+    /// `cargo build -p <package>` argument.
+    pub package: String,
+    /// Build the package's `[[example]]` cdylibs (`--examples`) rather
+    /// than its lib cdylib. Example cdylibs land under
+    /// `<profile>/examples/<stem>.wasm`; lib cdylibs land directly under
+    /// `<profile>/<stem>.wasm`.
+    pub from_example: bool,
+    /// Wasm output filename stem — the lib or example target name. This
+    /// is the same string `locate_component_wasm` keys on (e.g.
+    /// `aether_camera`, `probe`, `aether_demo_sokoban`).
+    pub stem: String,
+}
+
+/// One `cargo build` invocation. Lib components build per-package
+/// (`-p <pkg>`); example components build that package's examples
+/// (`-p <pkg> --examples`).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct BuildPlan {
+    pub package: String,
+    pub examples: bool,
+}
+
+/// Discover the component set: every workspace package that depends on
+/// `aether-actor` and exposes a `cdylib` target. A lib `cdylib` target
+/// (case a) and an `[[example]]` `cdylib` target (case b) are both
+/// components — typed `crate_types` inspection covers them in one pass,
+/// so the example-fixture case needs no special-casing.
+///
+/// `aether-actor`'s own example cdylibs are excluded: the crate does not
+/// depend on itself, so it fails the `ACTOR_DEP` gate.
+pub fn discover_components(metadata: &Metadata) -> Vec<Component> {
+    let mut components = Vec::new();
+    for package in &metadata.packages {
+        let depends_on_actor = package.dependencies.iter().any(|d| d.name == ACTOR_DEP);
+        if !depends_on_actor {
+            continue;
+        }
+        for target in &package.targets {
+            if !target.crate_types.contains(&CrateType::CDyLib) {
+                continue;
+            }
+            components.push(Component {
+                package: package.name.to_string(),
+                from_example: target.kind.contains(&TargetKind::Example),
+                stem: target.name.clone(),
+            });
+        }
+    }
+    components
+}
+
+/// Collapse the component list to the unique set of `cargo build`
+/// invocations. Multiple example cdylibs in one package share a single
+/// `-p <pkg> --examples` build; a lib cdylib gets its own `-p <pkg>`.
+///
+/// Each component package builds in its own invocation — never batch
+/// multiple `-p` flags. A multi-package build feature-unifies and
+/// re-enables the `runtime` feature on opted-out trunk consumers, causing
+/// a wasm-lld duplicate-symbol on `init` / `receive_p32`.
+pub fn build_plans(components: &[Component]) -> Vec<BuildPlan> {
+    let mut plans: Vec<BuildPlan> = Vec::new();
+    for component in components {
+        let plan = BuildPlan {
+            package: component.package.clone(),
+            examples: component.from_example,
+        };
+        if !plans.contains(&plan) {
+            plans.push(plan);
+        }
+    }
+    plans
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,278 @@
+//! Aether repo build tasks (`cargo xtask …`).
+//!
+//! `dist` packages the component wasm + chassis binaries into a stable
+//! `dist/` tree with a typed `manifest.json`, so a harness running
+//! outside a cargo-test process (no `CARGO_*` anchors) can locate every
+//! artifact through the manifest. `dist/` is additive — the substrate
+//! `target/` tree is still populated identically, so in-process scenario
+//! tests (which read `target/…`) are untouched.
+
+// xtask is a developer-facing build tool: emitting build progress + a
+// summary to the terminal is its purpose. The workspace
+// `print_stdout = warn` lint targets actor / library code, where a stray
+// print is a smell; here it is the intended output channel.
+#![allow(clippy::print_stdout)]
+
+mod inventory;
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::{env, fs};
+
+use anyhow::{Context, Result, bail};
+use cargo_metadata::MetadataCommand;
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use serde::Serialize;
+
+use crate::inventory::{
+    BuildPlan, CHASSIS_BINS, CHASSIS_PACKAGE, Component, build_plans, discover_components,
+};
+
+/// Wasm triple the components cross-build to.
+const WASM_TARGET: &str = "wasm32-unknown-unknown";
+
+#[derive(Parser)]
+#[command(name = "xtask", about = "Aether repo build tasks")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Build component wasm + chassis bins into `dist/` with a manifest.
+    Dist(DistArgs),
+}
+
+#[derive(Args)]
+struct DistArgs {
+    /// Cargo profile to build and package.
+    #[arg(long, value_enum, default_value_t = Profile::Debug)]
+    profile: Profile,
+    /// Skip the chassis (host-target) binary build + copy. The preflight
+    /// fast path uses this to stay wasm-only.
+    #[arg(long)]
+    no_bins: bool,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum Profile {
+    Debug,
+    Release,
+}
+
+impl Profile {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Debug => "debug",
+            Self::Release => "release",
+        }
+    }
+
+    /// Cargo's profile flag — debug is the default (no flag).
+    fn cargo_flag(self) -> Option<&'static str> {
+        match self {
+            Self::Debug => None,
+            Self::Release => Some("--release"),
+        }
+    }
+}
+
+/// `dist/manifest.json` schema. Paths are relative to `dist/` and use
+/// forward slashes so the manifest is stable across host OSes.
+#[derive(Serialize)]
+struct Manifest {
+    /// Triple the component wasm is built for (`wasm32-unknown-unknown`).
+    target: String,
+    /// Cargo profile the tree was built under (`debug` / `release`).
+    profile: String,
+    /// Wasm stem → `components/<stem>.wasm`.
+    components: BTreeMap<String, String>,
+    /// Chassis bin name → `bin/<name>`. Empty under `--no-bins`.
+    chassis: BTreeMap<String, String>,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Dist(args) => run_dist(&args),
+    }
+}
+
+fn run_dist(args: &DistArgs) -> Result<()> {
+    let metadata = MetadataCommand::new()
+        .no_deps()
+        .exec()
+        .context("run cargo metadata")?;
+
+    let components = discover_components(&metadata);
+    if components.is_empty() {
+        bail!("no wasm component crates discovered (cdylib target + aether-actor dep)");
+    }
+
+    let workspace_root = metadata.workspace_root.as_std_path();
+    let target_dir = metadata.target_directory.as_std_path();
+    let wasm_profile_dir = target_dir.join(WASM_TARGET).join(args.profile.as_str());
+    let dist = workspace_root.join("dist");
+
+    // Build each component package in its own cargo invocation — never
+    // batch multiple `-p`. See `inventory::build_plans`.
+    for plan in build_plans(&components) {
+        build_component(&plan, args.profile)?;
+    }
+    if !args.no_bins {
+        build_chassis(args.profile)?;
+    }
+
+    // Regenerate dist/ from scratch so the manifest is authoritative
+    // (e.g. a prior `--no-bins`-then-full run can't leave stale state).
+    if dist.exists() {
+        fs::remove_dir_all(&dist).with_context(|| format!("clear {}", dist.display()))?;
+    }
+    fs::create_dir_all(dist.join("components")).context("create dist/components")?;
+
+    let mut component_paths = BTreeMap::new();
+    for component in &components {
+        let src = wasm_artifact_path(&wasm_profile_dir, component);
+        let rel = format!("components/{}.wasm", component.stem);
+        copy_artifact(&src, &dist.join(&rel))?;
+        component_paths.insert(component.stem.clone(), rel);
+    }
+
+    let mut chassis_paths = BTreeMap::new();
+    if !args.no_bins {
+        fs::create_dir_all(dist.join("bin")).context("create dist/bin")?;
+        let host_profile_dir = target_dir.join(args.profile.as_str());
+        for bin in CHASSIS_BINS {
+            let src = host_profile_dir.join(bin);
+            let rel = format!("bin/{bin}");
+            copy_artifact(&src, &dist.join(&rel))?;
+            chassis_paths.insert((*bin).to_string(), rel);
+        }
+    }
+
+    let manifest = Manifest {
+        target: WASM_TARGET.to_string(),
+        profile: args.profile.as_str().to_string(),
+        components: component_paths,
+        chassis: chassis_paths,
+    };
+    let manifest_path = dist.join("manifest.json");
+    let mut json = serde_json::to_string_pretty(&manifest).context("serialize manifest")?;
+    json.push('\n');
+    fs::write(&manifest_path, json)
+        .with_context(|| format!("write {}", manifest_path.display()))?;
+
+    println!(
+        "dist: {} component(s), {} chassis bin(s) -> {}",
+        manifest.components.len(),
+        manifest.chassis.len(),
+        manifest_path.display(),
+    );
+    Ok(())
+}
+
+/// Source path of a component's wasm under the target tree. Example
+/// cdylibs land under `examples/`; lib cdylibs directly under the profile
+/// dir.
+fn wasm_artifact_path(wasm_profile_dir: &Path, component: &Component) -> PathBuf {
+    let file = format!("{}.wasm", component.stem);
+    if component.from_example {
+        wasm_profile_dir.join("examples").join(file)
+    } else {
+        wasm_profile_dir.join(file)
+    }
+}
+
+fn copy_artifact(src: &Path, dst: &Path) -> Result<()> {
+    fs::copy(src, dst).with_context(|| format!("copy {} -> {}", src.display(), dst.display()))?;
+    Ok(())
+}
+
+fn build_component(plan: &BuildPlan, profile: Profile) -> Result<()> {
+    let mut cmd = Command::new(cargo());
+    cmd.args(["build", "--target", WASM_TARGET, "-p", &plan.package]);
+    if plan.examples {
+        cmd.arg("--examples");
+    }
+    if let Some(flag) = profile.cargo_flag() {
+        cmd.arg(flag);
+    }
+    let label = if plan.examples {
+        format!("{} (examples)", plan.package)
+    } else {
+        plan.package.clone()
+    };
+    run(cmd, &format!("build component {label}"))
+}
+
+fn build_chassis(profile: Profile) -> Result<()> {
+    let mut cmd = Command::new(cargo());
+    cmd.args(["build", "-p", CHASSIS_PACKAGE]);
+    for bin in CHASSIS_BINS {
+        cmd.args(["--bin", bin]);
+    }
+    if let Some(flag) = profile.cargo_flag() {
+        cmd.arg(flag);
+    }
+    run(cmd, "build chassis bins")
+}
+
+fn run(mut cmd: Command, what: &str) -> Result<()> {
+    let status = cmd
+        .status()
+        .with_context(|| format!("spawn cargo to {what}"))?;
+    if !status.success() {
+        bail!("cargo failed to {what} ({status})");
+    }
+    Ok(())
+}
+
+/// Cargo binary to re-invoke — honours the `CARGO` env var cargo sets for
+/// subprocesses, falling back to `cargo` on `PATH`.
+fn cargo() -> String {
+    env::var("CARGO").unwrap_or_else(|_| "cargo".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::inventory::discover_components;
+
+    #[test]
+    fn discovers_expected_component_set() {
+        let metadata = cargo_metadata::MetadataCommand::new()
+            .no_deps()
+            .exec()
+            .expect("run cargo metadata");
+        let components = discover_components(&metadata);
+        let stems: BTreeSet<&str> = components.iter().map(|c| c.stem.as_str()).collect();
+
+        // Parity with the structural sweep preflight / CI ran before this
+        // xtask: a drop here surfaces as an AETHER_REQUIRE_RUNTIME panic.
+        for expected in [
+            "probe",
+            "probe_with_config",
+            "multi_actor",
+            "aether_camera",
+            "aether_mesh_viewer",
+            "aether_demo_sokoban",
+        ] {
+            assert!(
+                stems.contains(expected),
+                "discovery dropped component {expected}; found {stems:?}",
+            );
+        }
+
+        // aether-actor's own example cdylibs are NOT components — the
+        // crate does not depend on itself, so it fails the actor-dep gate.
+        for excluded in ["hello", "echoer", "caller", "input_logger"] {
+            assert!(
+                !stems.contains(excluded),
+                "discovery wrongly included aether-actor example {excluded}",
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes iamacoffeepot/aether#1445.

## Summary

Formalize the structural wasm-build sweep — previously hand-duplicated in `scripts/preflight.sh` and `.github/workflows/ci.yml` — into a Rust **xtask**. `cargo xtask dist`:

- discovers component crates via `cargo_metadata` (cdylib-lib and example-cdylib targets gated on the `aether-actor` dep, in one pass — typed `crate_types` inspection dissolves the `aether-test-fixtures` example special-case);
- builds each per-package to wasm32 — **one `cargo build` per package**, since batching feature-unifies and re-enables `runtime` on opted-out trunk consumers, triggering a wasm-lld duplicate-symbol on `init` / `receive_p32`;
- optionally builds the chassis bins (`--no-bins` skips them);
- copies everything into `dist/` and emits a typed `dist/manifest.json` mapping component and chassis names to paths.

`preflight.sh` + CI now call it instead of the duplicated shell. `dist/` is additive — `target/` is still populated identically, so the in-process scenario tests under `AETHER_REQUIRE_RUNTIME=1` are untouched.

This is the prerequisite for the future `FleetBench` E2E harness, which will locate the substrate binary + component wasm through the manifest. The discovery is factored into a reusable `inventory` module so the hardcoded `--bin` lists in `ensure-tunnel.sh` / `perf-compare.sh` can be derived from it later (recorded as a side finding on the issue).

## Test plan

- New `xtask` unit test asserts the discovered component set (`aether_camera`, `aether_demo_sokoban`, `aether_mesh_viewer`, `multi_actor`, `probe`, `probe_with_config`) and excludes `aether-actor`'s own example cdylibs.
- Full preflight green: fmt + clippy (`-D warnings`) + doc + nextest (1508 passed) + the xtask-driven wasm cross-build. The rewired `cargo xtask dist` path is exercised end-to-end by preflight itself.

## Generated by

`/implement` — delegated execution of [scoped issue #1445](https://github.com/iamacoffeepot/aether/issues/1445).
