### PR TITLE
perf(substrate): add index.bin boot fast-path for handle-store restore

### DIFF
--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -1129,12 +1129,23 @@ impl DriverRunning for DesktopDriverRunning {
             mut app,
             event_loop,
             triangles_rendered,
-            _boot,
+            // Bound (not `_boot`) so the teardown snapshot below can reach
+            // the handle store; still held to the end of `run()` so the
+            // scheduler joins workers on drop.
+            _boot: boot,
         } = *self;
 
         event_loop
             .run_app(&mut app)
             .map_err(|e| RunError::Other(format!("event loop: {e}").into()))?;
+
+        // ADR-0049 §3 boot fast-path (issue #1446): the event loop has
+        // exited cleanly (window closed), so write the `index.bin`
+        // snapshot of the live disk index. The next boot loads it in one
+        // read + decode instead of one `open()` per `.meta` sidecar; a
+        // crash that skips this teardown leaves the directory scan as the
+        // fallback. Best-effort + a no-op when persistence is disabled.
+        boot.handle_store.snapshot_index();
 
         let total = triangles_rendered.load(Ordering::Relaxed);
         let elapsed = app.started.map(|s| s.elapsed()).unwrap_or_default();

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -61,7 +61,9 @@ use std::env;
 
 pub mod meta;
 
-use meta::{HandleMeta, SCHEMA_VERSION, TransformOrigin};
+use meta::{
+    HandleMeta, INDEX_FORMAT_VERSION, IndexEntry, IndexSnapshot, SCHEMA_VERSION, TransformOrigin,
+};
 
 /// Default byte cap for the handle store.
 pub const DEFAULT_MAX_BYTES: usize = 256 * 1024 * 1024;
@@ -241,6 +243,14 @@ impl PersistConfig {
     #[must_use]
     pub fn lock_path(&self) -> PathBuf {
         self.root.join("lock.pid")
+    }
+
+    /// The `index.bin` boot fast-path snapshot under the layout root
+    /// (ADR-0049 §3). Written on graceful shutdown; loaded then deleted
+    /// at boot.
+    #[must_use]
+    pub fn index_path(&self) -> PathBuf {
+        self.root.join("index.bin")
     }
 }
 
@@ -696,7 +706,17 @@ impl HandleStore {
             lock: Mutex::new(None),
             kind_resolver,
         };
-        store.restore_from_disk();
+        // ADR-0049 §3 boot fast-path (issue #1446): try to load the
+        // `index.bin` snapshot a clean shutdown left behind, collapsing
+        // the per-`.meta` directory scan into one read + decode. On any
+        // failure — missing, unreadable, version skew, decode error —
+        // fall through to the directory walk, which stays the
+        // correctness primitive (it scrubs orphans + runs the §6
+        // schema-evolution check). The fast path defers that validation
+        // to lazy materialization (see `lookup_from_disk`).
+        if !store.load_index_bin() {
+            store.restore_from_disk();
+        }
         store
     }
 
@@ -1014,6 +1034,172 @@ impl HandleStore {
         }
     }
 
+    /// Write the `index.bin` boot fast-path snapshot from the live disk
+    /// index (ADR-0049 §3). Called from the chassis driver teardown on
+    /// graceful shutdown — the same graceful point at which `LockGuard`
+    /// removes `lock.pid`. Best-effort: an encode or write failure
+    /// warn-logs and returns, leaving the next boot to fall back to the
+    /// directory scan. No-op when persistence is disabled.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063.
+    pub fn snapshot_index(&self) {
+        let Some(cfg) = self.persist.as_ref() else {
+            return;
+        };
+        let entries: HashMap<u64, IndexEntry> = {
+            let inner = self
+                .inner
+                .read()
+                .expect("handle store lock poisoned; fail-fast per ADR-0063");
+            inner
+                .disk_index
+                .iter()
+                .map(|(id, e)| {
+                    (
+                        id.0,
+                        IndexEntry {
+                            kind_id: e.kind_id.0,
+                            bytes_len: e.bytes_len,
+                            pinned: e.pinned,
+                            created_at: e.created_at,
+                        },
+                    )
+                })
+                .collect()
+        };
+        let count = entries.len();
+        let snapshot = IndexSnapshot {
+            schema_version: INDEX_FORMAT_VERSION,
+            entries,
+        };
+        let bytes = match postcard::to_allocvec(&snapshot) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!(
+                    target: TARGET,
+                    error = %e,
+                    "failed to encode index.bin snapshot; next boot falls back to the directory scan",
+                );
+                return;
+            }
+        };
+        let path = cfg.index_path();
+        if let Err(e) = atomic_write(&path, &bytes) {
+            tracing::warn!(
+                target: TARGET,
+                path = %path.display(),
+                error = %e,
+                "index.bin snapshot write failed; next boot falls back to the directory scan",
+            );
+            return;
+        }
+        tracing::debug!(
+            target: TARGET,
+            indexed = count,
+            "handle store index.bin snapshot written on shutdown",
+        );
+    }
+
+    /// Boot fast-path (ADR-0049 §3): try to populate `disk_index` from a
+    /// previously-written `index.bin` snapshot. Returns `true` when the
+    /// fast path took (the index is populated and `index.bin` deleted so
+    /// a later crash can't replay a stale snapshot); `false` on any
+    /// failure — no persistence, missing / unreadable file, version skew,
+    /// or decode error — so the caller falls back to
+    /// [`Self::restore_from_disk`].
+    ///
+    /// On success this recomputes `total_disk_bytes` from the loaded
+    /// entries' `bytes_len` sum (the same recompute the directory scan
+    /// does), reconciling the approximate ledger across the restart. The
+    /// §6 schema-evolution check is skipped here and deferred to
+    /// [`Self::lookup_from_disk`]: the snapshot exists only after a
+    /// graceful shutdown, so the tree is consistent and the index already
+    /// reflects the live set.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063.
+    fn load_index_bin(&self) -> bool {
+        let Some(cfg) = self.persist.as_ref() else {
+            return false;
+        };
+        let path = cfg.index_path();
+        let Ok(raw) = fs::read(&path) else {
+            // Missing or unreadable — the common cold/crashed-boot case.
+            // Fall back to the scan silently (a fresh store has no
+            // snapshot; a crash left none).
+            return false;
+        };
+        let snapshot = match postcard::from_bytes::<IndexSnapshot>(&raw) {
+            Ok(s) if s.schema_version == INDEX_FORMAT_VERSION => s,
+            Ok(s) => {
+                tracing::warn!(
+                    target: TARGET,
+                    path = %path.display(),
+                    found = s.schema_version,
+                    expected = INDEX_FORMAT_VERSION,
+                    "index.bin version skew; falling back to the directory scan",
+                );
+                return false;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: TARGET,
+                    path = %path.display(),
+                    error = %e,
+                    "index.bin decode failed; falling back to the directory scan",
+                );
+                return false;
+            }
+        };
+        let index: HashMap<HandleId, DiskEntry> = snapshot
+            .entries
+            .into_iter()
+            .map(|(id, e)| {
+                (
+                    HandleId(id),
+                    DiskEntry {
+                        kind_id: KindId(e.kind_id),
+                        bytes_len: e.bytes_len,
+                        pinned: e.pinned,
+                        created_at: e.created_at,
+                    },
+                )
+            })
+            .collect();
+        let count = index.len();
+        let disk_bytes: u64 = index.values().map(|e| u64::from(e.bytes_len)).sum();
+        {
+            let mut inner = self
+                .inner
+                .write()
+                .expect("handle store lock poisoned; fail-fast per ADR-0063");
+            inner.disk_index = index;
+            inner.total_disk_bytes = disk_bytes;
+        }
+        // Delete the snapshot so a crash before the next clean shutdown
+        // can't replay a now-stale view (it is rewritten on the next
+        // graceful shutdown).
+        if let Err(e) = fs::remove_file(&path)
+            && e.kind() != ErrorKind::NotFound
+        {
+            tracing::warn!(
+                target: TARGET,
+                path = %path.display(),
+                error = %e,
+                "failed to delete index.bin after load; a crash before the next clean shutdown could replay a stale snapshot",
+            );
+        }
+        tracing::debug!(
+            target: TARGET,
+            indexed = count,
+            "handle store boot fast-path loaded index.bin",
+        );
+        true
+    }
+
     /// Boot scan (ADR-0049 §3): read `pinned.set`, walk `entries/` for
     /// `.meta` sidecars, and populate the sparse `disk_index`. Bytes are
     /// NOT eagerly loaded — disk-resident entries materialize on first
@@ -1163,6 +1349,18 @@ impl HandleStore {
     /// missing is treated as corruption: the index entry is dropped and
     /// the id lands in the negative cache. Returns `None` when there's
     /// no persistence, no index hit, or the id is negatively cached.
+    ///
+    /// The §6 schema-evolution check (ADR-0049) the boot scan runs
+    /// eagerly is deferred to this cold materialization for entries that
+    /// arrived via the `index.bin` fast path (issue #1446, which skips
+    /// the scan): the sibling `.meta` is read and validated against the
+    /// current kind registry, and a stale entry (kind id changed /
+    /// retired since the snapshot, or a version skew) is dropped at
+    /// access time — both files deleted, the ledger decremented, the id
+    /// negative-cached. An unreadable `.meta` skips the check and
+    /// materializes from the index entry (scan-path entries were already
+    /// validated at boot, so re-reading the `.meta` there only confirms a
+    /// match).
     fn lookup_from_disk(&self, id: HandleId) -> Option<(KindId, Vec<u8>)> {
         let cfg = self.persist.as_ref()?;
         // Read the index entry + negative-cache state under a read lock.
@@ -1176,7 +1374,33 @@ impl HandleStore {
             }
             inner.disk_index.get(&id).cloned()?
         };
-        let (bin_path, _) = entry_paths(&cfg.root, id);
+        let (bin_path, meta_path) = entry_paths(&cfg.root, id);
+        // ADR-0049 §6 deferred schema-evolution check (issue #1446 fast
+        // path). A readable `.meta` is validated against the current
+        // registry; a `Drop` verdict invalidates the entry here rather
+        // than at boot.
+        if let Some(meta) = read_meta_file(&meta_path)
+            && let Validation::Drop(reason) = validate_meta(&meta, self.kind_resolver.as_deref())
+        {
+            let _ = fs::remove_file(&bin_path);
+            let _ = fs::remove_file(&meta_path);
+            let mut inner = self
+                .inner
+                .write()
+                .expect("handle store lock poisoned; fail-fast per ADR-0063");
+            inner.total_disk_bytes = inner
+                .total_disk_bytes
+                .saturating_sub(u64::from(disk_entry.bytes_len));
+            inner.disk_index.remove(&id);
+            inner.note_negative(id);
+            tracing::info!(
+                target: TARGET,
+                handle = %id,
+                reason = %reason,
+                "handle store entry invalidated by schema evolution on materialization; dropped",
+            );
+            return None;
+        }
         let Ok(bytes) = fs::read(&bin_path) else {
             // `.bin` missing but the index said it was there —
             // corruption. Treat as a miss + remember it.
@@ -2808,5 +3032,281 @@ mod tests {
             assert_eq!(kind, KindId(100));
             assert_eq!(&bytes, b"payload");
         }
+    }
+
+    // index.bin boot fast-path tests (issue #1446 / ADR-0049 §3).
+    use std::sync::atomic::Ordering as AtomicOrdering;
+
+    static FAST_PATH_NONCE: AtomicU64 = AtomicU64::new(0);
+
+    fn fast_path_scratch(tag: &str) -> PathBuf {
+        let pid = process::id();
+        let millis = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(0));
+        let n = FAST_PATH_NONCE.fetch_add(1, AtomicOrdering::Relaxed);
+        let path = env::temp_dir().join(format!("aether-index-fastpath-{tag}-{pid}-{millis}-{n}"));
+        fs::create_dir_all(&path).expect("scratch dir creates");
+        path
+    }
+
+    fn fast_path_cleanup(path: &Path) {
+        let _ = fs::remove_dir_all(path);
+    }
+
+    fn fast_path_cfg(root: &Path) -> PersistConfig {
+        PersistConfig {
+            root: root.join("v1"),
+            disk_budget_bytes: u64::MAX,
+            eviction_tick_secs: 60,
+        }
+    }
+
+    /// Synthetic bidirectional kind registry for the deferred
+    /// schema-evolution check, mirroring the integration-test fixture.
+    struct FakeKindRegistry {
+        by_name: HashMap<String, KindId>,
+        by_id: HashMap<KindId, String>,
+    }
+
+    impl FakeKindRegistry {
+        fn new(entries: &[(&str, u64)]) -> Self {
+            let mut by_name = HashMap::new();
+            let mut by_id = HashMap::new();
+            for (name, id) in entries {
+                by_name.insert((*name).to_owned(), KindId(*id));
+                by_id.insert(KindId(*id), (*name).to_owned());
+            }
+            Self { by_name, by_id }
+        }
+    }
+
+    impl KindResolver for FakeKindRegistry {
+        fn id_for_name(&self, name: &str) -> Option<KindId> {
+            self.by_name.get(name).copied()
+        }
+        fn name_for_id(&self, id: KindId) -> Option<String> {
+            self.by_id.get(&id).cloned()
+        }
+    }
+
+    /// Step 3: a snapshot of a populated store writes a decodable
+    /// `index.bin` whose entry set matches the live disk index.
+    #[test]
+    fn snapshot_index_writes_decodable_index_bin() {
+        let root = fast_path_scratch("snapshot");
+        let cfg = fast_path_cfg(&root);
+        let store = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg.clone()));
+        store
+            .put_persistent(HandleId(1), KindId(7), vec![0u8; 16], None)
+            .unwrap();
+        store
+            .put_persistent(HandleId(2), KindId(7), vec![0u8; 32], None)
+            .unwrap();
+        store.pin(HandleId(2));
+        store.snapshot_index();
+
+        let path = cfg.index_path();
+        assert!(path.exists(), "index.bin written");
+        let raw = fs::read(&path).unwrap();
+        let snapshot: IndexSnapshot = postcard::from_bytes(&raw).unwrap();
+        assert_eq!(snapshot.schema_version, INDEX_FORMAT_VERSION);
+        assert_eq!(snapshot.entries.len(), 2);
+        let e1 = snapshot.entries.get(&1).expect("id 1 in snapshot");
+        assert_eq!(e1.kind_id, 7);
+        assert_eq!(e1.bytes_len, 16);
+        assert!(!e1.pinned);
+        let e2 = snapshot.entries.get(&2).expect("id 2 in snapshot");
+        assert_eq!(e2.bytes_len, 32);
+        assert!(e2.pinned, "pinned flag carried into the snapshot");
+        fast_path_cleanup(&root);
+    }
+
+    /// Step 4a: a fresh store loads the snapshot via the fast path —
+    /// disk index populated, `index.bin` deleted post-load.
+    #[test]
+    fn fast_path_loads_index_bin_and_deletes_it() {
+        let root = fast_path_scratch("load");
+        let cfg = fast_path_cfg(&root);
+        {
+            let store = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg.clone()));
+            for i in 0..50u64 {
+                store
+                    .put_persistent(HandleId(i + 1), KindId(7), vec![0u8; 8], None)
+                    .unwrap();
+            }
+            store.snapshot_index();
+        }
+        assert!(cfg.index_path().exists(), "snapshot present before reboot");
+        let restored = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg.clone()));
+        assert_eq!(restored.disk_index_len(), 50);
+        assert!(
+            !cfg.index_path().exists(),
+            "index.bin deleted after a successful fast-path load",
+        );
+        fast_path_cleanup(&root);
+    }
+
+    /// Step 4b: a corrupt (truncated) `index.bin` falls back to the
+    /// directory scan, which still indexes from the `.meta` sidecars.
+    #[test]
+    fn fast_path_corrupt_index_falls_back_to_scan() {
+        let root = fast_path_scratch("corrupt");
+        let cfg = fast_path_cfg(&root);
+        {
+            let store = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg.clone()));
+            for i in 0..10u64 {
+                store
+                    .put_persistent(HandleId(i + 1), KindId(7), vec![0u8; 8], None)
+                    .unwrap();
+            }
+            store.snapshot_index();
+        }
+        // Truncate the snapshot to just its version byte — the entry map
+        // is gone, so the decode fails.
+        let path = cfg.index_path();
+        let raw = fs::read(&path).unwrap();
+        fs::write(&path, &raw[..1]).unwrap();
+
+        let restored = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg));
+        assert_eq!(
+            restored.disk_index_len(),
+            10,
+            "scan fallback indexed from the .meta sidecars",
+        );
+        fast_path_cleanup(&root);
+    }
+
+    /// Step 4b: a version-skewed `index.bin` (decodes cleanly but the
+    /// header doesn't match) falls back to the directory scan.
+    #[test]
+    fn fast_path_version_skew_falls_back_to_scan() {
+        let root = fast_path_scratch("skew");
+        let cfg = fast_path_cfg(&root);
+        {
+            let store = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg.clone()));
+            for i in 0..10u64 {
+                store
+                    .put_persistent(HandleId(i + 1), KindId(7), vec![0u8; 8], None)
+                    .unwrap();
+            }
+            store.snapshot_index();
+        }
+        // Flip the leading version byte; the rest of the postcard struct
+        // stays valid, so it decodes but trips the version gate.
+        let path = cfg.index_path();
+        let mut raw = fs::read(&path).unwrap();
+        raw[0] = INDEX_FORMAT_VERSION.wrapping_add(1);
+        fs::write(&path, &raw).unwrap();
+
+        let restored = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg));
+        assert_eq!(
+            restored.disk_index_len(),
+            10,
+            "scan fallback indexed despite the version skew",
+        );
+        fast_path_cleanup(&root);
+    }
+
+    /// Step 4c: an absent `index.bin` (no clean shutdown) falls through
+    /// to the directory scan.
+    #[test]
+    fn fast_path_absent_index_uses_scan() {
+        let root = fast_path_scratch("absent");
+        let cfg = fast_path_cfg(&root);
+        {
+            let store = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg.clone()));
+            for i in 0..10u64 {
+                store
+                    .put_persistent(HandleId(i + 1), KindId(7), vec![0u8; 8], None)
+                    .unwrap();
+            }
+            // No snapshot_index() — emulates a crash before clean shutdown.
+        }
+        assert!(!cfg.index_path().exists(), "no snapshot was written");
+        let restored = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg));
+        assert_eq!(restored.disk_index_len(), 10);
+        fast_path_cleanup(&root);
+    }
+
+    /// Step 5: the fast path skips the boot schema-evolution check
+    /// (the entry survives the load), and the deferred check drops a
+    /// schema-stale entry at cold materialization.
+    #[test]
+    fn fast_path_defers_schema_validation_to_materialization() {
+        let root = fast_path_scratch("defer-validate");
+        let cfg = fast_path_cfg(&root);
+        let id = HandleId(0xABCD);
+        {
+            let resolver: Arc<dyn KindResolver> =
+                Arc::new(FakeKindRegistry::new(&[("demo.kind", 0xAAAA)]));
+            let store = HandleStore::with_persist_validated(
+                64 * 1024 * 1024,
+                Some(cfg.clone()),
+                Some(resolver),
+            );
+            store
+                .put_persistent(id, KindId(0xAAAA), b"bytes".to_vec(), None)
+                .unwrap();
+            store.snapshot_index();
+        }
+        // Reboot with the kind's id changed to 0xBBBB for the same name.
+        let resolver: Arc<dyn KindResolver> =
+            Arc::new(FakeKindRegistry::new(&[("demo.kind", 0xBBBB)]));
+        let restored = HandleStore::with_persist_validated(
+            64 * 1024 * 1024,
+            Some(cfg.clone()),
+            Some(resolver),
+        );
+        // Fast path loaded the entry WITHOUT validating it at boot.
+        assert_eq!(
+            restored.disk_index_len(),
+            1,
+            "fast path defers the schema check (entry present after load)",
+        );
+        // Cold materialization runs the deferred §6 check and drops it.
+        assert!(restored.get(id).is_none(), "stale entry dropped on access");
+        assert_eq!(restored.disk_index_len(), 0, "index entry removed");
+        let (bin, meta) = entry_paths(&cfg.root, id);
+        assert!(!bin.exists() && !meta.exists(), "both files deleted");
+        fast_path_cleanup(&root);
+    }
+
+    /// Step 7: end-to-end — write N entries, snapshot, reboot on the
+    /// same dir, and a subsequent `get` materializes from disk.
+    #[test]
+    fn end_to_end_snapshot_reboot_materializes() {
+        let root = fast_path_scratch("e2e");
+        let cfg = fast_path_cfg(&root);
+        let mut expected: HashMap<HandleId, Vec<u8>> = HashMap::new();
+        {
+            let store = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg.clone()));
+            for i in 0..32u64 {
+                let id = HandleId(i + 1);
+                let bytes = format!("payload-{i}").into_bytes();
+                store
+                    .put_persistent(id, KindId(7), bytes.clone(), None)
+                    .unwrap();
+                expected.insert(id, bytes);
+            }
+            store.snapshot_index();
+        }
+        let restored = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg.clone()));
+        assert_eq!(restored.disk_index_len(), expected.len());
+        for (id, bytes) in &expected {
+            assert!(
+                !restored.contains_in_memory(*id),
+                "not eagerly materialized"
+            );
+            let (kind, got) = restored.get(*id).expect("materializes from disk");
+            assert_eq!(kind, KindId(7));
+            assert_eq!(&got, bytes);
+            assert!(restored.contains_in_memory(*id), "now in memory");
+        }
+        assert!(
+            !cfg.index_path().exists(),
+            "index.bin consumed by the fast-path load",
+        );
+        fast_path_cleanup(&root);
     }
 }

--- a/crates/aether-substrate/src/handle_store/meta.rs
+++ b/crates/aether-substrate/src/handle_store/meta.rs
@@ -9,6 +9,8 @@
 //! cheap consistency check against the sibling `.bin`; restore asserts
 //! the lengths agree.
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 /// On-disk `HandleMeta` schema version. Bumping this invalidates all
@@ -72,4 +74,87 @@ pub struct TransformOrigin {
     pub transform_index: u32,
     /// The input handle ids that produced this output, slot-ordered.
     pub input_handle_ids: Vec<u64>,
+}
+
+/// On-disk format version for the `index.bin` boot fast-path snapshot
+/// (ADR-0049 §3). A mismatch on read makes the boot fall through to the
+/// directory scan rather than trusting a stale-format snapshot. Tracked
+/// independently of [`SCHEMA_VERSION`] (the per-entry `.meta` version):
+/// `index.bin` is a derived summary, so its layout can evolve without
+/// touching the authoritative sidecars.
+pub const INDEX_FORMAT_VERSION: u8 = 1;
+
+/// One entry in the [`IndexSnapshot`] boot fast-path summary — a flat
+/// mirror of the in-memory `DiskEntry`, keyed by raw `u64` handle id in
+/// the snapshot map. Ids are raw `u64` (not the typed
+/// [`aether_data::KindId`] newtype) so the on-disk format is a flat
+/// postcard struct independent of the tagged-id serde branch, matching
+/// [`HandleMeta`]'s convention.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexEntry {
+    /// Schema-hash of the kind type (ADR-0030), raw `u64`. Mirrors the
+    /// `.meta` sidecar's `kind_id`.
+    pub kind_id: u64,
+    /// Length of the sibling `.bin` payload.
+    pub bytes_len: u32,
+    /// Whether the handle was pinned at snapshot time (ADR-0045 §9).
+    pub pinned: bool,
+    /// Millis since the unix epoch at the handle's write time.
+    pub created_at: u64,
+}
+
+/// The whole `index.bin` file: a leading `schema_version` byte followed
+/// by the disk-index summary (ADR-0049 §3). Written atomically on
+/// graceful shutdown by snapshotting the live disk index, and loaded at
+/// boot to populate the index in one read + decode instead of one
+/// `open()` per `.meta` sidecar.
+///
+/// This is a plain postcard struct — deliberately not an aether `Kind`
+/// (no derive, no registry entry, no schema-driven codec): persistence
+/// is substrate-internal (ADR-0049) and the snapshot never crosses the
+/// wire.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexSnapshot {
+    /// Set to [`INDEX_FORMAT_VERSION`] on write; a mismatch on read
+    /// drops the fast path back to the directory scan.
+    pub schema_version: u8,
+    /// The disk-index summary, keyed by raw `u64` handle id.
+    pub entries: HashMap<u64, IndexEntry>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn index_snapshot_postcard_round_trips() {
+        let mut entries = HashMap::new();
+        entries.insert(
+            0x1111_2222_3333_4444,
+            IndexEntry {
+                kind_id: 0xAAAA,
+                bytes_len: 1024,
+                pinned: true,
+                created_at: 42,
+            },
+        );
+        entries.insert(
+            0x5555_6666_7777_8888,
+            IndexEntry {
+                kind_id: 0xBBBB,
+                bytes_len: 7,
+                pinned: false,
+                created_at: 99,
+            },
+        );
+        let snapshot = IndexSnapshot {
+            schema_version: INDEX_FORMAT_VERSION,
+            entries,
+        };
+        let bytes = postcard::to_allocvec(&snapshot).expect("snapshot encodes");
+        // The leading byte is the version header.
+        assert_eq!(bytes[0], INDEX_FORMAT_VERSION);
+        let decoded: IndexSnapshot = postcard::from_bytes(&bytes).expect("snapshot decodes");
+        assert_eq!(decoded, snapshot);
+    }
 }


### PR DESCRIPTION
Closes iamacoffeepot/aether#1446.

## Summary

Boot restore did one `open()` per `.meta` sidecar to rebuild the sparse disk index, so boot cost scaled with on-disk entry count. This adds the ADR-0049 §3 `index.bin` boot fast-path:

- **Snapshot on graceful shutdown** — the desktop driver calls `handle_store.snapshot_index()` after the event loop returns (clean window-close teardown), writing a flat postcard `IndexSnapshot { schema_version, entries }` of the live disk index via the existing `atomic_write`. It is a plain postcard struct with raw-`u64` ids, deliberately **not** an aether `Kind` (no registry, no schema-driven codec) — persistence is substrate-internal and never crosses the wire.
- **Fast-path load at boot** — the store constructor tries `load_index_bin()` first and falls back to the directory scan on any failure (missing, unreadable, version skew, decode error). The scan stays the correctness primitive (orphan scrub + eager §6 schema-evolution check); `index.bin` is only the latency optimization.
- **Delete `index.bin` after load** so a crash before the next clean shutdown can't replay a now-stale snapshot (it is rewritten on the next graceful shutdown).
- **Ledger reconciliation** — `load_index_bin` recomputes `total_disk_bytes` from the loaded entries, the same recompute the scan does (repairs the approximate ledger's same-id-rewrite over-count across restart).
- **Deferred schema-validation** — the fast path skips the boot-time §6 check (the index carries no `kind_name`); `lookup_from_disk` validates the sibling `.meta` against the registry on cold materialization and drops a stale entry then.

## Scope: desktop-only graceful snapshot

The snapshot fires on the **desktop** chassis only. Headless has no graceful-shutdown point — its run loop only ends via SIGTERM/SIGINT/process-exit, which kills the process without unwinding, so neither this snapshot nor the pre-existing `Drop`/`unwire`/`lock.pid` teardown runs there. Correctness is unaffected: headless boots via the directory scan, which is exact. Adding the headless signal handler (which also fixes the pre-existing `lock.pid` leak) is tracked in **#1455**.

## Test plan

- Full workspace preflight green (fmt, clippy `-D warnings`, `cargo doc`, `cargo nextest run --workspace` — 1515 passed).
- 8 new tests: snapshot postcard round-trip; snapshot writes a decodable `index.bin`; fast path loads + deletes it; corrupt / version-skew / absent index all fall back to the scan; fast path defers schema validation to materialization; end-to-end snapshot → reboot → materialize. Existing `handle_store_restore` / `handle_store_schema_evolution` integration tests still pass (now exercising the scan fallback).

## Generated by

`/implement` (hybrid background-agent mode) — execution of [scoped issue #1446](https://github.com/iamacoffeepot/aether/issues/1446).
