### PR TITLE
feat(substrate): graceful headless shutdown on SIGTERM/SIGINT

### DIFF
--- a/crates/aether-substrate-bundle/src/headless/driver.rs
+++ b/crates/aether-substrate-bundle/src/headless/driver.rs
@@ -13,10 +13,16 @@
 //! headless tick loop runs on the chassis main thread end-to-end (no
 //! winit, but the `chassis_builder`'s single-threaded
 //! Builder→BuiltChassis→run path applies all the same).
+//!
+//! A SIGINT/SIGTERM shutdown flag (`signal_hook::flag::register` on
+//! Unix, `ctrlc` on Windows) lets the loop break so `run()` returns and
+//! the chassis teardown unwinds — per-actor `unwire`, `lock.pid` removal
+//! (ADR-0049 §7), and the `index.bin` boot-snapshot — the headless
+//! analogue of desktop returning from winit's `event_loop.run_app`.
 
 use std::env;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -89,6 +95,13 @@ pub struct HeadlessTimerRunning {
     /// loop body stays alloc-free per tick.
     kind_lifecycle_advance: KindId,
     tick_period: Duration,
+    /// SIGINT/SIGTERM shutdown flag, flipped from the signal handler
+    /// installed in [`HeadlessTimerCapability::boot`]. The run loop
+    /// checks it at the top of each iteration and `break`s, so `run()`
+    /// returns and the chassis teardown unwinds. A struct field (not a
+    /// loop-local) so tests can inject a pre-set flag and drive `run()`
+    /// to a clean return without sending a real signal.
+    shutdown: Arc<AtomicBool>,
     /// `SubstrateBoot` drops at the end of `run()` so its scheduler
     /// joins workers before the chassis exits.
     _boot: SubstrateBoot,
@@ -104,13 +117,62 @@ impl DriverCapability for HeadlessTimerCapability {
             tick_period,
         } = self;
 
+        let shutdown = Arc::new(AtomicBool::new(false));
+        install_shutdown_handler(&shutdown);
+
         Ok(HeadlessTimerRunning {
             queue: Arc::clone(&boot.queue),
             lifecycle_mailbox: mailbox_id_from_name(<LifecycleCapability as Actor>::NAMESPACE),
             kind_lifecycle_advance: <LifecycleAdvance as Kind>::ID,
             tick_period,
+            shutdown,
             _boot: boot,
         })
+    }
+}
+
+/// Install a SIGINT/SIGTERM → `shutdown` flag handler so the tick loop
+/// can break and `run()` return, letting the chassis teardown unwind
+/// (per-actor `unwire`, `lock.pid` removal, the `index.bin` snapshot).
+/// `signal_hook::flag::register` flips the `AtomicBool` directly from the
+/// async-signal-safe handler — no watcher thread, since the loop already
+/// polls the flag every tick (rejected the hub's blocking
+/// `signals.forever()`, which would freeze ticks).
+///
+/// Both signals on Unix: interactive shells deliver SIGINT, but process
+/// supervisors (systemd), `pkill` / `kill` (no `-9`), and CI cancellation
+/// send SIGTERM; ignoring it would skip teardown the way `SIGKILL` does.
+/// Best-effort per ADR-0049 §7 — a failed install warn-logs and leaves
+/// the loop running until the process is killed.
+#[cfg(unix)]
+fn install_shutdown_handler(shutdown: &Arc<AtomicBool>) {
+    use signal_hook::consts::{SIGINT, SIGTERM};
+    use signal_hook::flag;
+    for sig in [SIGINT, SIGTERM] {
+        if let Err(e) = flag::register(sig, Arc::clone(shutdown)) {
+            tracing::error!(
+                target: "aether_substrate::boot",
+                signal = sig,
+                error = %e,
+                "headless: shutdown signal handler install failed; \
+                 teardown will be skipped when this signal arrives",
+            );
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn install_shutdown_handler(shutdown: &Arc<AtomicBool>) {
+    let flag = Arc::clone(shutdown);
+    if let Err(e) = ctrlc::set_handler(move || {
+        flag.store(true, Ordering::SeqCst);
+    }) {
+        tracing::error!(
+            target: "aether_substrate::boot",
+            error = %e,
+            "headless: ctrl-c handler install failed; \
+             teardown will be skipped on Ctrl-C",
+        );
     }
 }
 
@@ -121,7 +183,11 @@ impl DriverRunning for HeadlessTimerRunning {
             lifecycle_mailbox,
             kind_lifecycle_advance,
             tick_period,
-            _boot,
+            shutdown,
+            // Bound (not `_boot`) so the teardown snapshot below can reach
+            // the handle store; still held to the end of `run()` so the
+            // scheduler joins workers on drop.
+            _boot: boot,
         } = *self;
 
         // ADR-0080 §6 chassis-root correlation counter (issue
@@ -131,7 +197,10 @@ impl DriverRunning for HeadlessTimerRunning {
         let chassis_correlation = AtomicU64::new(1);
 
         let mut next_deadline = Instant::now() + tick_period;
-        loop {
+        // Checked at the top of each iteration so a SIGINT/SIGTERM
+        // observed during the prior tick's sleep breaks within one tick
+        // period (~16 ms at 60 Hz) — fine for shutdown.
+        while !shutdown.load(Ordering::Relaxed) {
             let now = Instant::now();
             if now < next_deadline {
                 thread::sleep(next_deadline - now);
@@ -155,7 +224,96 @@ impl DriverRunning for HeadlessTimerRunning {
                 1,
             );
         }
-        // The `loop` above never breaks — process exit is the only
-        // termination path (SIGTERM/SIGINT or `fatal_abort`).
+
+        // SIGINT/SIGTERM flipped `shutdown` (or a test pre-set it): the
+        // loop broke, so `run()` returns. ADR-0049 §3 boot fast-path
+        // (issue #1446): write the `index.bin` snapshot so the next boot
+        // loads it in one read + decode instead of one `open()` per
+        // `.meta` sidecar; best-effort + a no-op when persistence is
+        // disabled. Symmetric to the desktop seam after `run_app`. Then
+        // the destructured locals drop — `boot` joins the scheduler
+        // workers and `Drop for HandleStore` removes `lock.pid`
+        // (ADR-0049 §7) — the teardown a bare SIGKILL would skip.
+        boot.handle_store.snapshot_index();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::process;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use aether_substrate::handle_store::PersistConfig;
+
+    /// Unique scratch dir under the system temp dir, mirroring the
+    /// handle-store fast-path tests. PID + millis + a per-call nonce keep
+    /// concurrent test processes from colliding.
+    fn scratch_dir(tag: &str) -> PathBuf {
+        static NONCE: AtomicU64 = AtomicU64::new(0);
+        let pid = process::id();
+        let millis = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(0));
+        let n = NONCE.fetch_add(1, Ordering::Relaxed);
+        let path =
+            env::temp_dir().join(format!("aether-headless-shutdown-{tag}-{pid}-{millis}-{n}"));
+        fs::create_dir_all(&path).expect("scratch dir creates");
+        path
+    }
+
+    /// A pre-set shutdown flag breaks the run loop immediately, so
+    /// `run()` returns and the teardown unwinds: `lock.pid` is removed
+    /// (ADR-0049 §7 `LockGuard::drop`) and the `index.bin` boot snapshot
+    /// is written (issue #1446). The flag is injected directly rather
+    /// than via a real signal, so the test never hangs on the tick loop.
+    #[test]
+    fn shutdown_flag_breaks_loop_and_runs_teardown() {
+        let root = scratch_dir("teardown");
+        let cfg = PersistConfig {
+            root: root.clone(),
+            disk_budget_bytes: u64::MAX,
+            eviction_tick_secs: 3600,
+        };
+
+        let boot = SubstrateBoot::builder("aether-headless-test", env!("CARGO_PKG_VERSION"))
+            .persist_config(Some(cfg.clone()))
+            .handle_store_max_bytes(Some(64 * 1024 * 1024))
+            .build()
+            .expect("substrate boot");
+
+        // Boot acquired the on-disk lock (ADR-0049 §7).
+        assert!(
+            cfg.lock_path().exists(),
+            "lock.pid written at boot before teardown"
+        );
+
+        let running = Box::new(HeadlessTimerRunning {
+            queue: Arc::clone(&boot.queue),
+            lifecycle_mailbox: mailbox_id_from_name(<LifecycleCapability as Actor>::NAMESPACE),
+            kind_lifecycle_advance: <LifecycleAdvance as Kind>::ID,
+            // Irrelevant — the pre-set flag breaks before the first sleep.
+            tick_period: Duration::from_millis(16),
+            // Pre-set: the `while !shutdown.load(..)` guard is false on the
+            // first check, so the loop body never runs.
+            shutdown: Arc::new(AtomicBool::new(true)),
+            _boot: boot,
+        });
+
+        running.run().expect("run returns on the shutdown flag");
+
+        assert!(
+            !cfg.lock_path().exists(),
+            "lock.pid removed by LockGuard::drop after run() returns"
+        );
+        assert!(
+            cfg.index_path().exists(),
+            "index.bin snapshot written at teardown"
+        );
+
+        let _ = fs::remove_dir_all(&root);
     }
 }


### PR DESCRIPTION
Closes iamacoffeepot/aether#1455.

## Summary

The headless chassis had no graceful-shutdown path — its driver `run()` was an infinite `loop { sleep; push LifecycleAdvance }` whose only exit was SIGTERM/SIGINT/process-exit, which kills the process without unwinding. So none of the orderly teardown ran on headless: per-actor `unwire`, `LockGuard::drop` (removing `lock.pid`, ADR-0049 §7), and #1446's `index.bin` snapshot.

This adds a SIGINT/SIGTERM shutdown flag so the loop can break, `run()` returns, and the existing drop chain unwinds — the headless analogue of desktop returning from winit's `event_loop.run_app`:

- `shutdown: Arc<AtomicBool>` field on `HeadlessTimerRunning`, flipped by a handler installed at boot. `install_shutdown_handler` is cfg-split: `#[cfg(unix)]` registers SIGINT+SIGTERM via `signal_hook::flag::register` (flips the flag directly from the async-signal-safe handler — no watcher thread, since the loop polls each tick); `#[cfg(not(unix))]` uses `ctrlc::set_handler`. This mirrors the hub's existing split but rejects its blocking `signals.forever()` (which would freeze the tick loop). Both already bundle dependencies — no new deps.
- The loop becomes `while !shutdown.load(Relaxed)`, so a signal observed during a tick's sleep breaks within one tick period (~16 ms at 60 Hz).
- After the loop, `boot.handle_store.snapshot_index()` runs (symmetric to the desktop seam), then the locals drop — the scheduler joins workers and `lock.pid` is removed.

This delivers two things: #1446's `index.bin` snapshot now reaches headless, and the pre-existing `lock.pid`-never-removed-on-headless leak is fixed.

## Test plan

- Full workspace preflight green (fmt, clippy `-D warnings`, `cargo doc`, `cargo nextest run --workspace` — 1519 passed).
- New `shutdown_flag_breaks_loop_and_runs_teardown`: boots a substrate with a tempdir `PersistConfig`, asserts `lock.pid` exists post-boot, constructs the driver with the flag **pre-set to true**, drives `run()`, then asserts `lock.pid` removed + `index.bin` written. The pre-set flag means the loop body never runs, so the test is deterministic and never sends a real signal (no hang). Plain `#[test]` — not `mod heavy` — for that reason.
- The Windows `ctrlc` arm mirrors the hub's existing `#[cfg(not(unix))]` fallback verbatim; exercised only by a Windows CI job (the dev host is unix).

## Generated by

`/implement` (hybrid background-agent mode) — execution of [scoped issue #1455](https://github.com/iamacoffeepot/aether/issues/1455).
