### PR TITLE
chore(substrate-bundle): fill FleetBench Tier-A lifecycle + read-query rows

### DIFF
--- a/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
@@ -40,11 +40,12 @@ use aether_capabilities::rpc::{
 use aether_capabilities::trace::TraceDispatchCapability;
 use aether_capabilities::{EngineConfig, EngineServer};
 use aether_codec::frame::{FrameError, read_frame, write_frame};
-use aether_data::{EngineId, Kind, KindId, Uuid, mailbox_id_from_path};
+use aether_data::{EngineId, Kind, KindId, MailboxId, Uuid, mailbox_id_from_path};
 use aether_kinds::descriptors;
 use aether_kinds::{
-    EngineDescriptor, ListEngines, ListEnginesResult, LoadComponent, LoadResult, SpawnEngine,
-    SpawnEngineResult, TerminateEngine,
+    ComponentCapabilities, EngineDescriptor, ListEngines, ListEnginesResult, LoadComponent,
+    LoadResult, LogTail, LogTailResult, ReplaceComponent, ReplaceResult, SpawnEngine,
+    SpawnEngineResult, TerminateEngine, TerminateEngineResult,
 };
 use aether_substrate::chassis::Chassis;
 use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver, PassiveChassis};
@@ -101,6 +102,18 @@ pub struct CallRecord {
 #[derive(serde::Deserialize)]
 struct ManifestView {
     components: BTreeMap<String, String>,
+}
+
+/// The three `LoadResult::Ok` fields a loaded component exposes:
+/// the assigned trampoline `mailbox_id` (the [`replace`](FleetBench::replace)
+/// target), the rendered ADR-0099 lineage `addr`, and the advertised
+/// receive-side `capabilities`. Returned by
+/// [`load_full`](FleetBench::load_full) for the lifecycle rows that need
+/// the mailbox id the thin [`load`](FleetBench::load) delegate discards.
+pub struct Loaded {
+    pub mailbox_id: MailboxId,
+    pub addr: String,
+    pub capabilities: ComponentCapabilities,
 }
 
 /// A booted hub chassis plus a connected, handshaken raw-frame client.
@@ -191,8 +204,20 @@ impl FleetBench {
     /// ADR-0099 lineage address
     /// (`aether.component/aether.embedded:<NAMESPACE>`). Loads with no
     /// init-config — the `LoadComponent.config` carrier is empty, which a
-    /// `Config = ()` component decodes uniformly.
+    /// `Config = ()` component decodes uniformly. A thin delegate over
+    /// [`load_full`](Self::load_full) for callers that need only the
+    /// address.
     pub fn load(&mut self, engine: EngineId, stem: &str) -> String {
+        self.load_full(engine, stem).addr
+    }
+
+    /// Load the `<stem>` component and surface all three `LoadResult::Ok`
+    /// fields as a [`Loaded`]: the assigned trampoline `mailbox_id` (the
+    /// [`replace`](Self::replace) target), the rendered lineage `addr`,
+    /// and the advertised `capabilities`. The lifecycle rows that drive a
+    /// replace or re-address the loaded mailbox need the mailbox id the
+    /// thin [`load`](Self::load) delegate drops.
+    pub fn load_full(&mut self, engine: EngineId, stem: &str) -> Loaded {
         let wasm = read_component_wasm(stem);
         let replies = self.call(
             Some(engine),
@@ -206,10 +231,100 @@ impl FleetBench {
         );
         let payload = single_reply(&replies, "LoadComponent");
         match LoadResult::decode_from_bytes(&payload) {
-            Some(LoadResult::Ok { name, .. }) => name,
+            Some(LoadResult::Ok {
+                mailbox_id,
+                name,
+                capabilities,
+            }) => Loaded {
+                mailbox_id,
+                addr: name,
+                capabilities,
+            },
             Some(LoadResult::Err { error }) => panic!("load of {stem:?} failed: {error}"),
             None => panic!("undecodable LoadResult"),
         }
+    }
+
+    /// Terminate `engine` through the asserting [`call`](Self::call)
+    /// path — the agent-facing `terminate_substrate`, distinct from the
+    /// `Drop`-only best-effort
+    /// [`terminate_quietly`](Self::terminate_quietly). The engines cap
+    /// removes the fleet entry synchronously before it replies, so a
+    /// follow-up [`list_engines`](Self::list_engines) reflects the
+    /// eviction with no heartbeat-eviction wait. Drops `engine` from the
+    /// teardown set so `Drop` doesn't double-terminate it.
+    pub fn terminate(&mut self, engine: EngineId) {
+        let replies = self.call(
+            None,
+            "aether.engine",
+            &TerminateEngine {
+                engine_id: engine.0.to_string(),
+            },
+        );
+        let payload = single_reply(&replies, "TerminateEngine");
+        match TerminateEngineResult::decode_from_bytes(&payload) {
+            Some(TerminateEngineResult::Ok) => {}
+            Some(TerminateEngineResult::Err { error }) => {
+                panic!("terminate of {engine:?} failed: {error}")
+            }
+            None => panic!("undecodable TerminateEngineResult"),
+        }
+        self.spawned.retain(|e| *e != engine);
+    }
+
+    /// Replace the component bound to `mailbox_id` on `engine` with the
+    /// `<stem>` wasm (ADR-0022 in-place swap) and return the swapped
+    /// binary's advertised capabilities. The trampoline keeps its
+    /// load-time name across replace, so targeting the captured
+    /// `mailbox_id` rebinds the same lineage address to the new instance.
+    pub fn replace(
+        &mut self,
+        engine: EngineId,
+        mailbox_id: MailboxId,
+        stem: &str,
+    ) -> ComponentCapabilities {
+        let wasm = read_component_wasm(stem);
+        let replies = self.call(
+            Some(engine),
+            "aether.component",
+            &ReplaceComponent {
+                mailbox_id,
+                wasm,
+                drain_timeout_ms: None,
+                config: Vec::new(),
+            },
+        );
+        let payload = single_reply(&replies, "ReplaceComponent");
+        match ReplaceResult::decode_from_bytes(&payload) {
+            Some(ReplaceResult::Ok { capabilities }) => capabilities,
+            Some(ReplaceResult::Err { error }) => panic!("replace with {stem:?} failed: {error}"),
+            None => panic!("undecodable ReplaceResult"),
+        }
+    }
+
+    /// Tail `recipient`'s per-actor `ActorLogRing` (ADR-0081) on
+    /// `engine`. `since: None` reads from the oldest retained entry;
+    /// `Some(n)` returns only entries with `sequence > n` (the per-actor
+    /// cursor). `max: 0` resolves to the substrate-default cap. The
+    /// framework dispatch loop answers `LogTail` for every native actor
+    /// and wasm trampoline, so `recipient` is any live mailbox path.
+    pub fn log_tail(
+        &mut self,
+        engine: EngineId,
+        recipient: &str,
+        since: Option<u64>,
+    ) -> LogTailResult {
+        let replies = self.call(
+            Some(engine),
+            recipient,
+            &LogTail {
+                max: 0,
+                min_level: None,
+                since,
+            },
+        );
+        let payload = single_reply(&replies, "LogTail");
+        LogTailResult::decode_from_bytes(&payload).expect("undecodable LogTailResult")
     }
 
     /// Route a mail to a recipient on a forked substrate and return the

--- a/crates/aether-substrate-bundle/tests/fleetbench_logs.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_logs.rs
@@ -1,0 +1,91 @@
+//! `FleetBench` `actor_logs` proof (issue 1459, Tier-A): load the
+//! `probe` fixture into a forked substrate and tail its per-actor
+//! `ActorLogRing` (ADR-0081) for the one-shot `typed_send_alive` entry
+//! the probe emits on its first tick, then walk the `since` cursor to
+//! confirm it does not re-yield the seen entry.
+//!
+//! Heavy by construction (fork+exec + cross-process settle) — the test
+//! lives in `mod tests::heavy` so nextest's `test(/::heavy::/)` selector
+//! serializes it in the `serial-heavy` group.
+
+mod fleetbench;
+
+mod tests {
+    mod heavy {
+        use std::thread;
+        use std::time::Duration;
+
+        use aether_kinds::LogTailResult;
+
+        use crate::fleetbench::FleetBench;
+
+        /// Up to ~3s of bounded polling closes the wire→first-tick race:
+        /// the headless chassis auto-ticks at 60Hz, so the probe's first
+        /// tick (which emits the entry) fires within a few frames of
+        /// `wire`, and the lone entry is never evicted from a 100-slot
+        /// ring.
+        const POLL_ATTEMPTS: usize = 30;
+        const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+        /// `info` in the `0 = trace .. 4 = error` level mapping shared
+        /// across `aether.log.*`.
+        const LEVEL_INFO: u8 = 2;
+
+        /// Load `probe`, poll its lineage address with `LogTail` until the
+        /// `typed_send_alive` info entry appears, then re-query past the
+        /// returned cursor and assert it is not re-yielded — the
+        /// `actor_logs` row: a per-actor ring read plus a `since`-cursor
+        /// walk.
+        #[test]
+        fn fleetbench_actor_logs_surface_the_probe_first_tick_entry() {
+            let mut bench = FleetBench::start();
+            let engine = bench.spawn_headless();
+            let addr = bench.load(engine, "probe");
+
+            let mut last_reply = None;
+            let mut found = None;
+            for _ in 0..POLL_ATTEMPTS {
+                let reply = bench.log_tail(engine, &addr, None);
+                if let LogTailResult::Ok {
+                    entries,
+                    next_since,
+                    ..
+                } = &reply
+                    && let Some(entry) = entries
+                        .iter()
+                        .find(|e| e.message == "typed_send_alive" && e.level == LEVEL_INFO)
+                {
+                    found = Some((entry.clone(), *next_since));
+                    break;
+                }
+                last_reply = Some(reply);
+                thread::sleep(POLL_INTERVAL);
+            }
+
+            let (entry, next_since) = found.unwrap_or_else(|| {
+                panic!(
+                    "probe's `typed_send_alive` info entry never appeared after {POLL_ATTEMPTS} \
+                     polls; last reply: {last_reply:?}",
+                )
+            });
+
+            // The ring's per-actor sequence starts at 1 (ADR-0081).
+            assert!(
+                entry.sequence >= 1,
+                "a buffered entry should carry a 1-based ring sequence, got {}",
+                entry.sequence,
+            );
+
+            // Walk the cursor: a re-query past `next_since` must not
+            // re-yield the entry we already consumed.
+            match bench.log_tail(engine, &addr, Some(next_since)) {
+                LogTailResult::Ok { entries, .. } => assert!(
+                    entries.iter().all(|e| e.sequence != entry.sequence),
+                    "the `since` cursor should not re-yield the already-seen entry (seq {}): {entries:?}",
+                    entry.sequence,
+                ),
+                LogTailResult::Err { error } => panic!("cursor re-query LogTail failed: {error}"),
+            }
+        }
+    }
+}

--- a/crates/aether-substrate-bundle/tests/fleetbench_replace.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_replace.rs
@@ -1,0 +1,94 @@
+//! `FleetBench` `replace_component` proof (issue 1459, Tier-A): load the
+//! `probe` fixture into a forked substrate, then atomically swap it for
+//! the `aether_camera` wasm at the same trampoline mailbox id (ADR-0022)
+//! and assert the returned capability set reflects the new binary while
+//! the lineage address stays put.
+//!
+//! Heavy by construction (fork+exec + cross-process settle) — the test
+//! lives in `mod tests::heavy` so nextest's `test(/::heavy::/)` selector
+//! serializes it in the `serial-heavy` group.
+
+mod fleetbench;
+
+mod tests {
+    mod heavy {
+        use aether_actor::Actor;
+        use aether_camera::CameraCreate;
+        use aether_capabilities::WasmTrampoline;
+        use aether_data::Kind;
+        use aether_kinds::{ComponentCapabilities, LogTailResult, Tick};
+        use aether_test_fixtures::SetRender;
+
+        use crate::fleetbench::FleetBench;
+
+        /// Load `probe` (handlers `SetRender` + `Tick`), then `replace`
+        /// it with `aether_camera` (handlers `CameraCreate` + `Tick` +
+        /// the camera-driver kinds) targeting the captured trampoline
+        /// `mailbox_id`. The returned `ReplaceResult::Ok.capabilities`
+        /// must carry the camera handler set and not the probe's, with
+        /// `Tick` surviving the swap; the lineage address — unchanged by
+        /// construction, since the trampoline keeps its load-time name —
+        /// must still route to the live mailbox afterward.
+        #[test]
+        fn fleetbench_replaces_probe_with_camera_at_a_stable_address() {
+            let mut bench = FleetBench::start();
+            let engine = bench.spawn_headless();
+            let loaded = bench.load_full(engine, "probe");
+
+            let has = |caps: &ComponentCapabilities, id| caps.handlers.iter().any(|h| h.id == id);
+
+            // Pre-replace sanity: the probe declares SetRender, not the
+            // camera's create kind, and registers at its ADR-0099 lineage
+            // address.
+            assert!(
+                has(&loaded.capabilities, SetRender::ID),
+                "probe should declare a SetRender handler: {:?}",
+                loaded.capabilities.handlers,
+            );
+            assert!(
+                !has(&loaded.capabilities, CameraCreate::ID),
+                "probe should not declare a CameraCreate handler: {:?}",
+                loaded.capabilities.handlers,
+            );
+            let expected = format!(
+                "aether.component/{}:test_fixture_probe",
+                WasmTrampoline::NAMESPACE,
+            );
+            assert_eq!(
+                loaded.addr, expected,
+                "probe should load at its ADR-0099 lineage address",
+            );
+
+            let caps = bench.replace(engine, loaded.mailbox_id, "aether_camera");
+
+            // Post-replace: the camera handler set is active, the probe's
+            // is gone, and Tick (declared by both) survives the swap.
+            assert!(
+                has(&caps, CameraCreate::ID),
+                "post-replace should declare a CameraCreate handler: {:?}",
+                caps.handlers,
+            );
+            assert!(
+                !has(&caps, SetRender::ID),
+                "post-replace should not declare the probe's SetRender handler: {:?}",
+                caps.handlers,
+            );
+            assert!(
+                has(&caps, Tick::ID),
+                "Tick is declared by both components and should survive the swap: {:?}",
+                caps.handlers,
+            );
+
+            // The lineage address still resolves to the live mailbox: a
+            // LogTail routed to the rendered path is answered Ok, proving
+            // the same mailbox was swapped in place.
+            assert!(
+                matches!(
+                    bench.log_tail(engine, &loaded.addr, None),
+                    LogTailResult::Ok { .. },
+                ),
+                "the lineage address should still route to the live mailbox after replace",
+            );
+        }
+    }
+}

--- a/crates/aether-substrate-bundle/tests/fleetbench_terminate.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_terminate.rs
@@ -1,0 +1,74 @@
+//! `FleetBench` `terminate_substrate` + standalone `list_engines` proofs
+//! (issue 1459, Tier-A): fork real `aether-substrate-headless` processes
+//! through the hub's engines cap, then assert the supervised fleet tracks
+//! the spawned set and that a `terminate` evicts an engine synchronously.
+//!
+//! Heavy by construction (fork+exec + cross-process settle) — the tests
+//! live in `mod tests::heavy` so nextest's `test(/::heavy::/)` selector
+//! serializes them in the `serial-heavy` group.
+
+mod fleetbench;
+
+mod tests {
+    mod heavy {
+        use crate::fleetbench::FleetBench;
+
+        /// Spawn two headless substrates and assert both appear in
+        /// `ListEngines` with fresh heartbeats — the standalone
+        /// `list_engines` row: the hub's fleet table round-trips the
+        /// spawned set, not just a single engine.
+        #[test]
+        fn fleetbench_lists_the_spawned_engine_set() {
+            let mut bench = FleetBench::start();
+            let first = bench.spawn_headless();
+            let second = bench.spawn_headless();
+
+            let engines = bench.list_engines();
+            for engine in [first, second] {
+                let engine_id = engine.0.to_string();
+                let descriptor = engines
+                    .iter()
+                    .find(|e| e.engine_id == engine_id)
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "spawned engine {engine_id} should appear in ListEngines: {engines:?}"
+                        )
+                    });
+                // Freshly spawned ⇒ recently seen; the cap evicts only at
+                // the miss limit (default 5s × 3), far above this bound.
+                assert!(
+                    descriptor.last_heartbeat_age_millis < 10_000,
+                    "freshly spawned engine should have a near-zero heartbeat age, got {}ms",
+                    descriptor.last_heartbeat_age_millis,
+                );
+            }
+        }
+
+        /// Spawn one headless substrate, confirm it is supervised, then
+        /// `terminate` it and assert it is gone from a follow-up
+        /// `list_engines` — the `terminate_substrate` row. The engines
+        /// cap removes the fleet entry synchronously before replying, so
+        /// the eviction is visible immediately, with no heartbeat-miss
+        /// wait.
+        #[test]
+        fn fleetbench_terminate_evicts_from_the_fleet() {
+            let mut bench = FleetBench::start();
+            let engine = bench.spawn_headless();
+            let engine_id = engine.0.to_string();
+
+            let before = bench.list_engines();
+            assert!(
+                before.iter().any(|e| e.engine_id == engine_id),
+                "spawned engine {engine_id} should be supervised before terminate: {before:?}",
+            );
+
+            bench.terminate(engine);
+
+            let after = bench.list_engines();
+            assert!(
+                after.iter().all(|e| e.engine_id != engine_id),
+                "terminated engine {engine_id} should be gone from the fleet: {after:?}",
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes iamacoffeepot/aether#1459.

## Summary

Fills the lifecycle + read-query rows of the FleetBench Tier-A matrix (#1453), over the real hub → RPC → forked-headless path. The harness gains `terminate()`, `replace()`, `log_tail()`, and `load_full() -> Loaded` (with `load()` kept as a thin delegate so `fleetbench_load.rs` is untouched). Rows:

- `fleetbench_terminate` — `list_engines` reflects the spawned set; `terminate` evicts synchronously.
- `fleetbench_logs` — `LogTail` (ADR-0081) polled for the probe's `typed_send_alive` ring entry; `since` cursor exercised.
- `fleetbench_replace` — probe → aether_camera, asserting `ReplaceResult::Ok` with the swapped handler set at a stable lineage address.

The `replace` row was the row that **surfaced substrate bug #1466** (forwarded replace/drop replies settling before the trampoline replies). With that fix now on `main`, the row passes over the real wire — it's the FleetBench regression for it, complementary to #1466's own `replace_drop_reply_routing` test.

## Test plan

- Full `scripts/preflight.sh` green: fmt + clippy (`-D warnings`) + doc + nextest (1527 passed, 6 skipped) + wasm cross-build. All four rows `mod heavy` (serialized in `serial-heavy`).

## Generated by

`/implement` — agent execution of [scoped issue #1459](https://github.com/iamacoffeepot/aether/issues/1459); rebased onto the merged Bug B fix.
