### PR TITLE
chore(substrate-bundle): fill FleetBench Tier-A mail + reply rows (resolves ping-pong)

### DIFF
--- a/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
@@ -40,8 +40,10 @@ use aether_capabilities::rpc::{
 use aether_capabilities::trace::TraceDispatchCapability;
 use aether_capabilities::{EngineConfig, EngineServer};
 use aether_codec::frame::{FrameError, read_frame, write_frame};
-use aether_data::{EngineId, Kind, KindId, MailboxId, Uuid, mailbox_id_from_path};
+use aether_data::{EngineId, Kind, KindId, MailId, MailboxId, Uuid, mailbox_id_from_path};
+use aether_kinds::MailEnvelope as TracedEnvelope;
 use aether_kinds::descriptors;
+use aether_kinds::trace::{DispatchTraced, DispatchTracedAck, TRACE_MAILBOX_NAME};
 use aether_kinds::{
     ComponentCapabilities, EngineDescriptor, ListEngines, ListEnginesResult, LoadComponent,
     LoadResult, LogTail, LogTailResult, ReplaceComponent, ReplaceResult, SpawnEngine,
@@ -459,6 +461,82 @@ impl FleetBench {
                 Err(_) => return,
             }
         }
+    }
+
+    /// Like [`load`](Self::load) but threads a typed init-config into the
+    /// component: `config` is encoded into the `LoadComponent.config`
+    /// carrier the guest decodes as its `FfiActor::Config` (ADR-0090).
+    /// Returns the registered ADR-0099 lineage address. Used by
+    /// components whose typed `Config` cannot decode from the empty
+    /// carrier the empty-config [`load`](Self::load) sends.
+    pub fn load_with_config<C>(&mut self, engine: EngineId, stem: &str, config: &C) -> String
+    where
+        C: Kind + Serialize,
+    {
+        let wasm = read_component_wasm(stem);
+        let replies = self.call(
+            Some(engine),
+            "aether.component",
+            &LoadComponent {
+                wasm,
+                name: None,
+                config: config.encode_into_bytes(),
+                export: None,
+            },
+        );
+        let payload = single_reply(&replies, "LoadComponent");
+        match LoadResult::decode_from_bytes(&payload) {
+            Some(LoadResult::Ok { name, .. }) => name,
+            Some(LoadResult::Err { error }) => panic!("load of {stem:?} failed: {error}"),
+            None => panic!("undecodable LoadResult"),
+        }
+    }
+
+    /// Route a one-entry traced batch (`DispatchTraced`) to a forked
+    /// engine's `aether.trace` mailbox and return the chassis-root
+    /// [`MailId`] every dispatched envelope inherited plus the reply
+    /// envelopes collected across the settlement window. Mirrors
+    /// `aether-mcp`'s `send_mail_traced`, minus the round-2 trace-tree
+    /// stitch: Tier-A asserts settlement (the [`call`](Self::call) read
+    /// already spans it — the server holds the wire `Call` open until
+    /// chain settlement) and the collected replies, not the
+    /// reconstructed tree.
+    ///
+    /// The leading `ReplyEvent` is the trace cap's synchronous
+    /// `DispatchTracedAck::Ok` — its ordering is well-defined (the trace
+    /// handler replies before the dispatched children run), so it is
+    /// split off and decoded for the `root`, and the trailing events are
+    /// the dispatched mail's correlated replies. Panics on an
+    /// `Err`/undecodable ack, mirroring [`single_reply`].
+    pub fn send_traced<K>(
+        &mut self,
+        engine: EngineId,
+        recipient: &str,
+        mail: &K,
+    ) -> (MailId, Vec<MailEnvelope>)
+    where
+        K: Kind + Serialize,
+    {
+        let batch = DispatchTraced {
+            mails: vec![TracedEnvelope {
+                recipient_name: recipient.to_owned(),
+                kind_name: K::NAME.to_owned(),
+                payload: mail.encode_into_bytes(),
+                count: 1,
+            }],
+        };
+        let mut events = self.call(Some(engine), TRACE_MAILBOX_NAME, &batch);
+        assert!(
+            !events.is_empty(),
+            "send_traced expected a DispatchTracedAck reply event, got none"
+        );
+        let ack = events.remove(0);
+        let root = match DispatchTracedAck::decode_from_bytes(&ack.payload) {
+            Some(DispatchTracedAck::Ok { root }) => root,
+            Some(DispatchTracedAck::Err { error }) => panic!("send_traced batch rejected: {error}"),
+            None => panic!("undecodable DispatchTracedAck"),
+        };
+        (root, events)
     }
 }
 

--- a/crates/aether-substrate-bundle/tests/fleetbench_mail.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_mail.rs
@@ -1,0 +1,211 @@
+//! `FleetBench` mail + reply proofs (issue 1460, Tier-A): the rows that
+//! share the settlement-aware reply-collection machinery over the real
+//! hub → RPC → forked-headless stack. Three rows land as a unit —
+//!
+//! - **ping-pong** (the load-bearing one, deferred from #1451): a wasm
+//!   component reply correlates home over the routed RPC path, plus the
+//!   ADR-0090 typed-config round-trip;
+//! - **`send_mail`**: a native-cap reply decodes + correlates;
+//! - **`send_mail_traced`**: an atomic traced batch settles, yields its
+//!   non-error ack root, and rides its correlated reply home.
+//!
+//! Heavy by construction (fork+exec + cross-process settle) — the tests
+//! live in `mod tests::heavy` so nextest's `test(/::heavy::/)` selector
+//! serializes them in the `serial-heavy` group (and soaks them).
+
+mod fleetbench;
+
+mod tests {
+    mod heavy {
+        use aether_data::{Kind, MailId};
+        use aether_kinds::trace::DispatchTraced;
+        use aether_kinds::{List, ListResult};
+        use aether_test_fixtures::{ConfigEcho, ConfigQuery, ProbeConfig};
+
+        use crate::fleetbench::FleetBench;
+
+        /// Ping-pong (verify-first, the #1451 deferral): load
+        /// `probe_with_config` with a seeded `ProbeConfig`, send it a
+        /// `ConfigQuery`, and assert the single `ConfigEcho` decodes back
+        /// to the same `{ seed, label }`. This is the first end-to-end
+        /// proof that a wasm guest reply correlates home over the real
+        /// RPC stack (the server tags the injected Call with
+        /// `reply_to = Component(rpc_server)`, so the guest's
+        /// `ctx.reply_target()` is `Some` and the echo fires; the
+        /// server's reply interception forwards it home as a
+        /// `ReplyEvent`), and it round-trips the ADR-0090 typed-config
+        /// path. Also asserts the recorded `CallRecord` captured the
+        /// round-trip, keeping the benchmark-ready trace exercised by the
+        /// mail rows.
+        #[test]
+        fn fleetbench_pingpong_echoes_typed_config() {
+            let mut bench = FleetBench::start();
+            let engine = bench.spawn_headless();
+            let config = ProbeConfig {
+                seed: 0x00C0_FFEE,
+                label: "fleetbench".to_owned(),
+            };
+            let addr = bench.load_with_config(engine, "probe_with_config", &config);
+
+            let replies = bench.send(engine, &addr, &ConfigQuery);
+            let reply = match replies.as_slice() {
+                [one] => one,
+                other => panic!(
+                    "ping-pong expected exactly one reply event, got {}",
+                    other.len(),
+                ),
+            };
+            assert_eq!(
+                reply.kind,
+                ConfigEcho::ID,
+                "the component reply should be a ConfigEcho",
+            );
+            let echo = ConfigEcho::decode_from_bytes(&reply.payload)
+                .expect("the reply payload decodes as ConfigEcho");
+            assert_eq!(
+                echo,
+                ConfigEcho {
+                    seed: config.seed,
+                    label: config.label.clone(),
+                },
+                "the echoed config should match the seeded ProbeConfig",
+            );
+
+            let query_record = bench
+                .calls()
+                .iter()
+                .find(|record| record.request_kind == ConfigQuery::ID)
+                .expect("the ConfigQuery round-trip is recorded as a CallRecord");
+            assert_eq!(
+                query_record.engine,
+                Some(engine),
+                "the ConfigQuery is routed to the forked engine",
+            );
+            assert_eq!(
+                query_record.reply_kinds,
+                vec![ConfigEcho::ID],
+                "the ConfigQuery drew exactly one ConfigEcho reply",
+            );
+        }
+
+        /// `send_mail` row: route an `fs::List` to the forked engine's
+        /// `aether.fs` cap and assert the single reply decodes as a
+        /// `ListResult` echoing the requested namespace. Both arms echo
+        /// `namespace`, so the assertion is deterministic regardless of
+        /// the save dir's contents — it proves schema-encode → route to a
+        /// forked-engine native cap → reply decode + correlate (the
+        /// non-component reply case; the component case is ping-pong).
+        #[test]
+        fn fleetbench_send_mail_decodes_fs_reply() {
+            let mut bench = FleetBench::start();
+            let engine = bench.spawn_headless();
+
+            let replies = bench.send(
+                engine,
+                "aether.fs",
+                &List {
+                    namespace: "save".to_owned(),
+                    prefix: String::new(),
+                },
+            );
+            let reply = match replies.as_slice() {
+                [one] => one,
+                other => panic!(
+                    "send_mail expected exactly one reply event, got {}",
+                    other.len(),
+                ),
+            };
+            assert_eq!(
+                reply.kind,
+                ListResult::ID,
+                "the fs reply should be a ListResult",
+            );
+            assert_eq!(
+                fs_reply_namespace(&reply.payload),
+                "save",
+                "the ListResult should echo the requested namespace",
+            );
+
+            let list_record = bench
+                .calls()
+                .iter()
+                .find(|record| record.request_kind == List::ID)
+                .expect("the fs List round-trip is recorded as a CallRecord");
+            assert_eq!(
+                list_record.engine,
+                Some(engine),
+                "the List call is routed to the forked engine",
+            );
+            assert_eq!(
+                list_record.reply_kinds,
+                vec![ListResult::ID],
+                "the List call drew exactly one ListResult reply",
+            );
+        }
+
+        /// `send_mail_traced` row: dispatch a one-entry traced batch
+        /// (`fs::List`) and assert the path settles, returns a non-error
+        /// ack root, and collects the `ListResult` reply. The single
+        /// settlement-bracketed wire `Call` yields all three — `call`'s
+        /// read-until-`ReplyEnd` spans the settlement window (the server
+        /// holds the `Call` open via its `SettlementHold`), so no new
+        /// wire read loop is needed.
+        #[test]
+        fn fleetbench_send_traced_settles_and_collects_reply() {
+            let mut bench = FleetBench::start();
+            let engine = bench.spawn_headless();
+
+            let (root, replies) = bench.send_traced(
+                engine,
+                "aether.fs",
+                &List {
+                    namespace: "save".to_owned(),
+                    prefix: String::new(),
+                },
+            );
+            assert_ne!(
+                root,
+                MailId::NONE,
+                "the traced batch ack carries a non-sentinel chassis root",
+            );
+
+            let echoed = replies
+                .iter()
+                .find(|envelope| envelope.kind == ListResult::ID)
+                .expect("the traced fs List drew a ListResult reply");
+            assert_eq!(
+                fs_reply_namespace(&echoed.payload),
+                "save",
+                "the traced ListResult should echo the requested namespace",
+            );
+
+            let traced_record = bench
+                .calls()
+                .iter()
+                .find(|record| record.request_kind == DispatchTraced::ID)
+                .expect("the traced dispatch is recorded as a CallRecord");
+            assert_eq!(
+                traced_record.engine,
+                Some(engine),
+                "the traced batch is routed to the forked engine",
+            );
+            assert!(
+                traced_record.reply_kinds.contains(&ListResult::ID),
+                "the traced call's reply stream includes the ListResult",
+            );
+        }
+
+        /// Decode an `fs::List` reply and return the echoed namespace,
+        /// matching either arm — both `Ok` and `Err` echo `namespace`,
+        /// so the row's assertion is deterministic regardless of the save
+        /// dir's contents.
+        fn fs_reply_namespace(payload: &[u8]) -> String {
+            match ListResult::decode_from_bytes(payload) {
+                Some(ListResult::Ok { namespace, .. } | ListResult::Err { namespace, .. }) => {
+                    namespace
+                }
+                None => panic!("undecodable ListResult"),
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes iamacoffeepot/aether#1460.

## Summary

Fills the mail + reply rows of the FleetBench Tier-A matrix (#1453). The harness gains `load_with_config()` and a settlement-aware `send_traced()` (reuses `call()`'s settlement-spanning read — the RPC server holds the call open until settlement). Rows:

- `fleetbench_send_mail` — `fs::List` → `ListResult`, asserting the reply decodes/correlates.
- `fleetbench_send_traced` — `send_traced` returns a non-error ack root + the collected `ListResult`.
- `fleetbench_pingpong` — `load_with_config(probe_with_config)` + `ConfigQuery` → `ConfigEcho` round-trips over the real wire.

The ping-pong row is the proof **deferred from #1451** — the first end-to-end confirmation that a wasm component's reply correlates home over the routed RPC path. It surfaced substrate bug **#1465** (the Component reply arm dropping the inbound correlation); with that fix on `main`, the row passes. So the #1451 "wrong-fixture artifact" hypothesis was wrong — it was a real substrate bug, caught by FleetBench's verify-first gate.

## Test plan

- Full `scripts/preflight.sh` green: fmt + clippy (`-D warnings`) + doc + nextest (1526 passed, 6 skipped) + wasm cross-build. All rows `mod heavy`.

## Generated by

`/implement` — agent execution of [scoped issue #1460](https://github.com/iamacoffeepot/aether/issues/1460); rebased onto the merged Bug A fix.
