### PR TITLE
refactor(data): route Ref inline values through the Kind codec so cast kinds need no serde

### DIFF
--- a/crates/aether-actor/src/actor/ctx/outbound_reply.rs
+++ b/crates/aether-actor/src/actor/ctx/outbound_reply.rs
@@ -50,15 +50,10 @@ pub trait OutboundReply: MailSender {
 
     /// Reply to the originator of the mail currently being dispatched.
     /// No-op when there's no reply target. Wire shape (cast or postcard)
-    /// follows `Kind::encode_into_bytes`.
-    ///
-    /// The `serde::Serialize` bound matches the substrate-side
-    /// `Mailer::send_reply` requirement: reply kinds route through
-    /// postcard when the target is a Claude session or remote engine
-    /// mailbox. Every reply kind in the workspace already derives
-    /// `Serialize` so the bound is documentation, not a breaking
-    /// change.
-    fn reply<K: Kind + serde::Serialize>(&mut self, payload: &K);
+    /// follows `Kind::encode_into_bytes` (ADR-0100), so a reply needs
+    /// only `K: Kind` — a `Pod`-without-`Serialize` cast kind is
+    /// repliable.
+    fn reply<K: Kind>(&mut self, payload: &K);
 
     /// Reply to an explicit `sender` rather than the dispatcher-stamped
     /// reply target. Used by the parked-sender pattern: caps that stash
@@ -70,5 +65,5 @@ pub trait OutboundReply: MailSender {
     /// Same wire-shape contract as [`Self::reply`]. Native impls route
     /// through `NativeBinding::send_reply_for_handler`; FFI impls route
     /// through [`crate::ffi::bridge::MailBridge::reply_mail`].
-    fn reply_to<K: Kind + serde::Serialize>(&mut self, sender: Self::ReplyHandle, payload: &K);
+    fn reply_to<K: Kind>(&mut self, sender: Self::ReplyHandle, payload: &K);
 }

--- a/crates/aether-actor/src/actor/sender.rs
+++ b/crates/aether-actor/src/actor/sender.rs
@@ -132,22 +132,13 @@ pub trait MailCtx: Sender {
     /// Reply to the originator of the mail currently being dispatched.
     /// No-op when there's no reply target (broadcast / peer-component
     /// mail). The wire shape (cast or postcard) follows
-    /// `Kind::encode_into_bytes`.
-    ///
-    /// The `serde::Serialize` bound matches the substrate-side
-    /// `Mailer::send_reply` /`HubOutbound::send_reply` requirement —
-    /// reply kinds route through postcard when the target is a Claude
-    /// session or remote engine mailbox, so they must serialize. In
-    /// practice every reply kind in the workspace already derives
-    /// `Serialize` (they all derive `aether_data::Kind` +
-    /// `aether_data::Schema` + `serde::{Serialize, Deserialize}`
-    /// together), so the bound is a documentation move rather than a
-    /// breaking change. The wasm `Ctx::reply` body still encodes via
-    /// `Kind::encode_into_bytes` (cast-or-postcard); the bound is
-    /// satisfied transparently.
+    /// `Kind::encode_into_bytes` (ADR-0100), so a reply needs only
+    /// `K: Kind` — a `Pod`-without-`Serialize` cast kind is repliable.
+    /// Both substrate reply encoders (`Mailer::send_reply`,
+    /// `HubOutbound::send_reply`) route through that same codec.
     ///
     /// Stage 1 shipped the trait method; stage 2 wires native
     /// dispatch onto it (`NativeCtx` routes through the substrate
     /// `Mailer::send_reply` / outbound bridge).
-    fn reply<K: Kind + serde::Serialize>(&mut self, payload: &K);
+    fn reply<K: Kind>(&mut self, payload: &K);
 }

--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -303,14 +303,14 @@ impl OutboundReply for FfiCtx<'_> {
     }
 
     //noinspection DuplicatedCode
-    fn reply<K: Kind + serde::Serialize>(&mut self, payload: &K) {
+    fn reply<K: Kind>(&mut self, payload: &K) {
         if let Some(raw) = self.sender {
             let bytes = payload.encode_into_bytes();
             MAIL_BRIDGE.reply_mail(raw, K::ID.0, &bytes, 1);
         }
     }
 
-    fn reply_to<K: Kind + serde::Serialize>(&mut self, sender: ReplyTo, payload: &K) {
+    fn reply_to<K: Kind>(&mut self, sender: ReplyTo, payload: &K) {
         let bytes = payload.encode_into_bytes();
         MAIL_BRIDGE.reply_mail(sender.raw(), K::ID.0, &bytes, 1);
     }
@@ -342,7 +342,7 @@ impl Sender for FfiCtx<'_> {
 
 impl MailCtx for FfiCtx<'_> {
     //noinspection DuplicatedCode
-    fn reply<K: Kind + serde::Serialize>(&mut self, payload: &K) {
+    fn reply<K: Kind>(&mut self, payload: &K) {
         if let Some(raw) = self.sender {
             let bytes = payload.encode_into_bytes();
             MAIL_BRIDGE.reply_mail(raw, K::ID.0, &bytes, 1);

--- a/crates/aether-codec/src/decode.rs
+++ b/crates/aether-codec/src/decode.rs
@@ -379,15 +379,20 @@ fn decode_postcard(
             Ok(Value::Object(obj))
         }
         SchemaType::Ref(inner) => {
-            // ADR-0045 typed handle. Wire matches the postcard
-            // enum encoding: discriminant varint, then either the
-            // inner-kind body (Inline = 0) or two varints id +
-            // kind_id (Handle = 1). Render as externally-tagged
-            // JSON to match the encoder's input shape.
+            // ADR-0045 typed handle, inline arm revised by ADR-0100.
+            // Wire matches the postcard enum encoding: discriminant
+            // varint, then either the inline body (Inline = 0) or two
+            // varints id + kind_id (Handle = 1). The inline body is the
+            // inner kind's own codec image, length-prefixed — read the
+            // length, slice it off, and decode it with the same
+            // cast-or-postcard dispatch as a top-level kind. Render as
+            // externally-tagged JSON to match the encoder's input shape.
             let disc = read_varint_u64(cur, path)? as u32;
             match disc {
                 0 => {
-                    let inner_value = decode_postcard(cur, inner, path)?;
+                    let len = read_varint_u64(cur, path)? as usize;
+                    let body = cur.take_slice(len, path)?;
+                    let inner_value = decode_schema(body, inner)?;
                     let mut obj = Map::with_capacity(1);
                     obj.insert("Inline".into(), inner_value);
                     Ok(Value::Object(obj))
@@ -1115,5 +1120,44 @@ mod tests {
             ty: SchemaType::TypeId(aether_data::MailboxId::TYPE_ID),
         }]);
         roundtrip(json!({ "mailbox": 0u64 }), &schema);
+    }
+
+    #[test]
+    fn ref_inline_cast_inner_wire_is_length_prefixed_cast_image() {
+        // ADR-0100: the inline body of a cast inner kind is the raw
+        // cast image, length-prefixed — not a postcard varint image.
+        let inner = cast_struct(vec![scalar("code", Primitive::U32)]);
+        let schema = SchemaType::Ref(SchemaCell::owned(inner.clone()));
+        let value = json!({ "Inline": { "code": 0x0102_0304u32 } });
+
+        let bytes = encode_schema(&value, &schema).expect("encode Inline Ref");
+        // The inner image is exactly what `encode_schema` emits for the
+        // inner kind standalone (the cast image).
+        let body = encode_schema(&json!({ "code": 0x0102_0304u32 }), &inner).expect("encode inner");
+        assert_eq!(body.len(), 4, "u32 cast image is 4 raw bytes");
+        let mut expected = vec![0u8, 4u8];
+        expected.extend_from_slice(&body);
+        assert_eq!(
+            bytes, expected,
+            "inline wire is disc 0 + varint(len) + cast image"
+        );
+
+        // JSON descriptor round-trips through wire and back.
+        let back = decode_schema(&bytes, &schema).expect("decode Inline Ref");
+        assert_eq!(back, value);
+    }
+
+    #[test]
+    fn ref_handle_wire_is_byte_unchanged() {
+        let inner = cast_struct(vec![scalar("code", Primitive::U32)]);
+        let schema = SchemaType::Ref(SchemaCell::owned(inner));
+        let value = json!({ "Handle": { "id": 7u64, "kind_id": 42u64 } });
+
+        let bytes = encode_schema(&value, &schema).expect("encode Handle Ref");
+        // disc 1 + varint(7) + varint(42) — unchanged from ADR-0045.
+        assert_eq!(bytes, vec![1u8, 7u8, 42u8]);
+
+        let back = decode_schema(&bytes, &schema).expect("decode Handle Ref");
+        assert_eq!(back, value);
     }
 }

--- a/crates/aether-codec/src/encode.rs
+++ b/crates/aether-codec/src/encode.rs
@@ -307,18 +307,26 @@ fn encode_postcard(
             Ok(())
         }
         SchemaType::Ref(inner) => {
-            // ADR-0045 typed handle. Externally-tagged JSON matches
-            // the Rust enum: `{"Inline": <inner-K>}` chooses the
-            // inline arm; `{"Handle": {"id": u64, "kind_id": u64}}`
-            // chooses the handle arm. Wire is the postcard enum
-            // encoding — discriminant varint + body, where body is
-            // either the inner kind's postcard bytes (Inline = 0)
-            // or two varints (Handle = 1).
+            // ADR-0045 typed handle, inline arm revised by ADR-0100.
+            // Externally-tagged JSON matches the Rust enum:
+            // `{"Inline": <inner-K>}` chooses the inline arm;
+            // `{"Handle": {"id": u64, "kind_id": u64}}` chooses the
+            // handle arm. Wire is the postcard enum encoding —
+            // discriminant varint + body. The inline body is the inner
+            // kind's own codec image (cast or postcard, dispatched on
+            // `inner`) length-prefixed (`varint(len)` + bytes); the
+            // handle body is two varints.
             let (tag, body) = decode_enum_tag(value, path)?;
             match tag {
                 "Inline" => {
                     write_varint_u64(out, 0);
-                    encode_postcard(body, inner, path, out)
+                    // The inner image is the same bytes `Kind::encode_into_bytes`
+                    // produces for the inner kind — `encode_schema` picks
+                    // cast for a `repr_c: true` struct, postcard otherwise.
+                    let body_bytes = encode_schema(body, inner)?;
+                    write_varint_u64(out, body_bytes.len() as u64);
+                    out.extend_from_slice(&body_bytes);
+                    Ok(())
                 }
                 "Handle" => {
                     write_varint_u64(out, 1);

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -280,7 +280,7 @@ impl<K, V> CastEligible for BTreeMap<K, V> {
 /// error, not a recoverable one. Use [`Ref::handle`] instead of
 /// constructing `Handle` directly to pull the id from the kind
 /// system rather than passing it by hand.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Ref<K> {
     /// Inline value — the whole `K` payload is on the wire.
     Inline(K),
@@ -332,6 +332,259 @@ impl<K> Ref<K> {
         match self {
             Self::Handle { id, .. } => Some(*id),
             Self::Inline(_) => None,
+        }
+    }
+}
+
+/// Hand-written `serde` for `Ref<K>` (ADR-0100). The inline arm carries
+/// the kind's own codec image — `K::encode_into_bytes`, length-prefixed
+/// — instead of serde-encoding the typed `K`. A cast kind's inline value
+/// stays a cast image, and `Ref<K>` needs only `K: Kind`: no
+/// `Serialize`/`Deserialize` bound on the wrapped kind.
+///
+/// The externally-tagged enum representation is preserved — variant
+/// index 0 = `Inline`, 1 = `Handle` — so a `Ref::Handle` value's wire
+/// bytes are byte-identical to the prior derive and the splice walker's
+/// discriminant semantics are unchanged. Inline wire is
+/// `disc 0 + varint(len) + K::encode_into_bytes` (`len` bytes); handle
+/// wire is `disc 1 + varint(id) + varint(kind_id)`. The handle-store
+/// splice walker and the schema-driven JSON codec share this framing.
+mod ref_serde {
+    use core::fmt;
+    use core::marker::PhantomData;
+
+    use alloc::vec::Vec;
+    use serde::de::{self, EnumAccess, MapAccess, SeqAccess, VariantAccess, Visitor};
+    use serde::ser::SerializeStructVariant;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    use crate::{Kind, Ref};
+
+    const VARIANTS: &[&str] = &["Inline", "Handle"];
+    const HANDLE_FIELDS: &[&str] = &["id", "kind_id"];
+
+    impl<K: Kind> Serialize for Ref<K> {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            match self {
+                Self::Inline(value) => {
+                    let encoded = value.encode_into_bytes();
+                    serializer.serialize_newtype_variant("Ref", 0, "Inline", &InlineBody(&encoded))
+                }
+                Self::Handle { id, kind_id } => {
+                    let mut sv = serializer.serialize_struct_variant("Ref", 1, "Handle", 2)?;
+                    sv.serialize_field("id", id)?;
+                    sv.serialize_field("kind_id", kind_id)?;
+                    sv.end()
+                }
+            }
+        }
+    }
+
+    /// Forces `serialize_bytes` for the inline body so the wire is
+    /// `varint(len) + raw bytes` — the raw `K::encode_into_bytes` image.
+    /// A plain `Vec<u8>` would serialize as a sequence and two-byte any
+    /// `>= 0x80` element, corrupting a cast image.
+    struct InlineBody<'a>(&'a [u8]);
+
+    impl Serialize for InlineBody<'_> {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer.serialize_bytes(self.0)
+        }
+    }
+
+    impl<'de, K: Kind> Deserialize<'de> for Ref<K> {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            deserializer.deserialize_enum("Ref", VARIANTS, RefVisitor(PhantomData))
+        }
+    }
+
+    /// Externally-tagged variant discriminant. Binary serializers (the
+    /// postcard wire) read it as `varint` → `visit_u64`; self-describing
+    /// ones read the variant name → `visit_str`.
+    enum VariantTag {
+        Inline,
+        Handle,
+    }
+
+    impl<'de> Deserialize<'de> for VariantTag {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            deserializer.deserialize_identifier(VariantTagVisitor)
+        }
+    }
+
+    struct VariantTagVisitor;
+
+    impl Visitor<'_> for VariantTagVisitor {
+        type Value = VariantTag;
+
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("`Inline` or `Handle` variant")
+        }
+
+        fn visit_u64<E: de::Error>(self, value: u64) -> Result<VariantTag, E> {
+            match value {
+                0 => Ok(VariantTag::Inline),
+                1 => Ok(VariantTag::Handle),
+                _ => Err(de::Error::invalid_value(
+                    de::Unexpected::Unsigned(value),
+                    &self,
+                )),
+            }
+        }
+
+        fn visit_str<E: de::Error>(self, value: &str) -> Result<VariantTag, E> {
+            match value {
+                "Inline" => Ok(VariantTag::Inline),
+                "Handle" => Ok(VariantTag::Handle),
+                _ => Err(de::Error::unknown_variant(value, VARIANTS)),
+            }
+        }
+    }
+
+    struct RefVisitor<K>(PhantomData<K>);
+
+    impl<'de, K: Kind> Visitor<'de> for RefVisitor<K> {
+        type Value = Ref<K>;
+
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("a Ref enum (`Inline` or `Handle`)")
+        }
+
+        fn visit_enum<A: EnumAccess<'de>>(self, data: A) -> Result<Ref<K>, A::Error> {
+            match data.variant()? {
+                (VariantTag::Inline, variant) => {
+                    let body: InlineBuf = variant.newtype_variant()?;
+                    K::decode_from_bytes(&body.0)
+                        .map(Ref::Inline)
+                        .ok_or_else(|| {
+                            de::Error::custom("Ref::Inline payload failed Kind::decode_from_bytes")
+                        })
+                }
+                (VariantTag::Handle, variant) => {
+                    variant.struct_variant(HANDLE_FIELDS, HandleVisitor(PhantomData))
+                }
+            }
+        }
+    }
+
+    /// Reads the inline body `InlineBody` wrote — a raw byte buffer.
+    struct InlineBuf(Vec<u8>);
+
+    impl<'de> Deserialize<'de> for InlineBuf {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            deserializer
+                .deserialize_byte_buf(InlineBufVisitor)
+                .map(InlineBuf)
+        }
+    }
+
+    struct InlineBufVisitor;
+
+    impl<'de> Visitor<'de> for InlineBufVisitor {
+        type Value = Vec<u8>;
+
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("the inline Ref byte buffer")
+        }
+
+        fn visit_bytes<E: de::Error>(self, value: &[u8]) -> Result<Vec<u8>, E> {
+            Ok(value.to_vec())
+        }
+
+        fn visit_byte_buf<E: de::Error>(self, value: Vec<u8>) -> Result<Vec<u8>, E> {
+            Ok(value)
+        }
+
+        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Vec<u8>, A::Error> {
+            let mut out = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+            while let Some(byte) = seq.next_element::<u8>()? {
+                out.push(byte);
+            }
+            Ok(out)
+        }
+    }
+
+    struct HandleVisitor<K>(PhantomData<K>);
+
+    impl<'de, K> Visitor<'de> for HandleVisitor<K> {
+        type Value = Ref<K>;
+
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("a Ref::Handle with `id` and `kind_id`")
+        }
+
+        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Ref<K>, A::Error> {
+            let id = seq
+                .next_element::<u64>()?
+                .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+            let kind_id = seq
+                .next_element::<u64>()?
+                .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+            Ok(Ref::Handle { id, kind_id })
+        }
+
+        fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Ref<K>, A::Error> {
+            let mut id: Option<u64> = None;
+            let mut kind_id: Option<u64> = None;
+            while let Some(key) = map.next_key::<HandleField>()? {
+                match key {
+                    HandleField::Id => {
+                        if id.is_some() {
+                            return Err(de::Error::duplicate_field("id"));
+                        }
+                        id = Some(map.next_value()?);
+                    }
+                    HandleField::KindId => {
+                        if kind_id.is_some() {
+                            return Err(de::Error::duplicate_field("kind_id"));
+                        }
+                        kind_id = Some(map.next_value()?);
+                    }
+                }
+            }
+            let id = id.ok_or_else(|| de::Error::missing_field("id"))?;
+            let kind_id = kind_id.ok_or_else(|| de::Error::missing_field("kind_id"))?;
+            Ok(Ref::Handle { id, kind_id })
+        }
+    }
+
+    enum HandleField {
+        Id,
+        KindId,
+    }
+
+    impl<'de> Deserialize<'de> for HandleField {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            deserializer.deserialize_identifier(HandleFieldVisitor)
+        }
+    }
+
+    struct HandleFieldVisitor;
+
+    impl Visitor<'_> for HandleFieldVisitor {
+        type Value = HandleField;
+
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("`id` or `kind_id`")
+        }
+
+        fn visit_u64<E: de::Error>(self, value: u64) -> Result<HandleField, E> {
+            match value {
+                0 => Ok(HandleField::Id),
+                1 => Ok(HandleField::KindId),
+                _ => Err(de::Error::invalid_value(
+                    de::Unexpected::Unsigned(value),
+                    &self,
+                )),
+            }
+        }
+
+        fn visit_str<E: de::Error>(self, value: &str) -> Result<HandleField, E> {
+            match value {
+                "id" => Ok(HandleField::Id),
+                "kind_id" => Ok(HandleField::KindId),
+                _ => Err(de::Error::unknown_field(value, HANDLE_FIELDS)),
+            }
         }
     }
 }
@@ -756,6 +1009,14 @@ mod tests {
     impl Kind for TestPod {
         const NAME: &'static str = "test.pod";
         const ID: KindId = KindId(0xDEAD_BEEF_0000_0001);
+
+        fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+            __derive_runtime::decode_cast::<Self>(bytes)
+        }
+
+        fn encode_into_bytes(&self) -> Vec<u8> {
+            __derive_runtime::encode_cast::<Self>(self)
+        }
     }
 
     #[repr(C)]
@@ -777,6 +1038,14 @@ mod tests {
     impl Kind for TestStruct {
         const NAME: &'static str = "test.struct";
         const ID: KindId = KindId(0xDEAD_BEEF_0000_0003);
+
+        fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+            __derive_runtime::decode_postcard::<Self>(bytes)
+        }
+
+        fn encode_into_bytes(&self) -> Vec<u8> {
+            __derive_runtime::encode_postcard::<Self>(self)
+        }
     }
 
     #[test]
@@ -932,6 +1201,44 @@ mod tests {
     #[test]
     fn ref_is_cast_ineligible() {
         const { assert!(!<Ref<TestStruct> as CastEligible>::ELIGIBLE) };
+    }
+
+    #[test]
+    fn ref_inline_cast_kind_body_is_cast_image() {
+        // ADR-0100: a cast kind's inline body is the raw cast image,
+        // not a varint-postcard image. `TestPod` carries a `u32` field
+        // (`a`), whose cast bytes differ from postcard's varint.
+        let v = TestPod {
+            a: 0x1234_5678,
+            b: 1.5,
+        };
+        let r: Ref<TestPod> = Ref::Inline(v);
+        let bytes =
+            postcard::to_allocvec(&r).expect("test setup: postcard encodes Inline Ref<TestPod>");
+        assert_eq!(bytes[0], 0, "Inline discriminant");
+        assert_eq!(bytes[1], 8, "varint length prefix of the 8-byte cast image");
+        assert_eq!(
+            &bytes[2..],
+            bytemuck::bytes_of(&v),
+            "inline body is the cast image, not a postcard varint image"
+        );
+        let back: Ref<TestPod> =
+            postcard::from_bytes(&bytes).expect("test setup: postcard decodes Inline Ref<TestPod>");
+        assert_eq!(back, r);
+    }
+
+    #[test]
+    fn ref_handle_cast_kind_roundtrip() {
+        let r: Ref<TestPod> = Ref::Handle {
+            id: 7,
+            kind_id: TestPod::ID.0,
+        };
+        let bytes =
+            postcard::to_allocvec(&r).expect("test setup: postcard encodes Handle Ref<TestPod>");
+        assert_eq!(bytes[0], 1, "Handle discriminant");
+        let back: Ref<TestPod> =
+            postcard::from_bytes(&bytes).expect("test setup: postcard decodes Handle Ref<TestPod>");
+        assert_eq!(back, r);
     }
 
     #[test]

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -55,7 +55,6 @@ use aether_substrate::{
 use super::chassis::{TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS};
 use super::events::{ChassisEvent, EventReceiver, channel as event_channel};
 use super::render::Gpu;
-use serde::de::DeserializeOwned;
 use std::error;
 use std::thread;
 
@@ -750,7 +749,7 @@ impl TestBench {
     /// `WriteResult`) can't beat the bail-out check.
     fn pump_until_reply<R>(&mut self, cid: u64, expected: &'static str) -> Result<R, TestBenchError>
     where
-        R: DeserializeOwned,
+        R: Kind,
     {
         let event = self.pump_until_event(cid, expected)?;
         Self::decode_reply::<R>(event, expected)
@@ -865,14 +864,20 @@ impl TestBench {
 
     fn decode_reply<R>(event: EgressEvent, expected: &'static str) -> Result<R, TestBenchError>
     where
-        R: DeserializeOwned,
+        R: Kind,
     {
         match event {
             EgressEvent::ToSession {
                 kind_name, payload, ..
-            } => postcard::from_bytes::<R>(&payload).map_err(|e| {
-                TestBenchError::Decode(format!("{expected} decode: {e} (kind={kind_name})"))
-            }),
+            } => {
+                // ADR-0100: decode through the kind's declared codec
+                // (cast or postcard), not a hardcoded postcard path.
+                R::decode_from_bytes(&payload).ok_or_else(|| {
+                    TestBenchError::Decode(format!(
+                        "{expected} decode failed via Kind::decode_from_bytes (kind={kind_name})"
+                    ))
+                })
+            }
             other => Err(TestBenchError::Decode(format!(
                 "expected {expected} reply event, got {other:?}"
             ))),

--- a/crates/aether-substrate-bundle/src/test_bench/execute.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/execute.rs
@@ -25,7 +25,6 @@ use std::fmt;
 
 use aether_data::{Kind, KindId};
 use aether_kinds::MailEnvelope;
-use serde::de::DeserializeOwned;
 
 use super::bench::{TestBench, TestBenchError};
 
@@ -168,21 +167,22 @@ impl ExecutionResult {
     }
 
     /// Decode the reply from a [`BenchOp::SendAndAwait`] step as `R`.
-    /// `R` is any postcard-decodable reply kind (`LoadResult`,
-    /// `ReplaceResult`, `WriteResult`, …). Errors with
-    /// [`ExecutionError::NoSuchReply`] if `label` didn't run a
-    /// `SendAndAwait` (or didn't run at all), or
+    /// `R` is any reply kind (`LoadResult`, `ReplaceResult`,
+    /// `WriteResult`, …); the bytes decode through the kind's declared
+    /// codec (cast or postcard) via `Kind::decode_from_bytes`
+    /// (ADR-0100). Errors with [`ExecutionError::NoSuchReply`] if
+    /// `label` didn't run a `SendAndAwait` (or didn't run at all), or
     /// [`ExecutionError::ReplyDecode`] if the bytes don't decode as
     /// `R`.
     pub fn reply<R>(&self, label: &str) -> Result<R, ExecutionError>
     where
-        R: DeserializeOwned,
+        R: Kind,
     {
         match self.inner.get(label) {
             Some(BenchOutput::Replied(bytes)) => {
-                postcard::from_bytes::<R>(bytes).map_err(|e| ExecutionError::ReplyDecode {
+                R::decode_from_bytes(bytes).ok_or_else(|| ExecutionError::ReplyDecode {
                     label: label.to_owned(),
-                    error: e.to_string(),
+                    error: "Kind::decode_from_bytes returned None".to_owned(),
                 })
             }
             _ => Err(ExecutionError::NoSuchReply(label.to_owned())),
@@ -289,5 +289,55 @@ impl TestBench {
             }
         }
         Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Cast reply kind with a non-`f32` field — its wire image is the
+    /// raw cast bytes, which a postcard reader would misdecode.
+    #[repr(C)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq, bytemuck::Pod, bytemuck::Zeroable)]
+    struct CastReply {
+        code: u32,
+        flag: u16,
+        _pad: u16,
+    }
+
+    impl Kind for CastReply {
+        const NAME: &'static str = "test.execute_cast_reply";
+        const ID: KindId = KindId(0xDEAD_BEEF_000A_0001);
+
+        fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+            (bytes.len() == size_of::<Self>()).then(|| bytemuck::pod_read_unaligned(bytes))
+        }
+
+        fn encode_into_bytes(&self) -> Vec<u8> {
+            bytemuck::bytes_of(self).to_vec()
+        }
+    }
+
+    /// ADR-0100: the `SendAndAwait` reply accessor decodes the recorded
+    /// bytes through `Kind::decode_from_bytes`, so a cast reply kind
+    /// round-trips uncorrupted (its `u32` / `u16` fields survive). A
+    /// postcard decode would have misread the raw cast image.
+    #[test]
+    fn execution_result_reply_decodes_cast_kind() {
+        let reply = CastReply {
+            code: 0x0A0B_0C0D,
+            flag: 0x1234,
+            _pad: 0,
+        };
+        // The substrate reply path encodes via `Kind::encode_into_bytes`
+        // (ADR-0100), so the recorded bytes are the cast image.
+        let bytes = reply.encode_into_bytes();
+        let result = ExecutionResult {
+            inner: HashMap::from([("reply".to_owned(), BenchOutput::Replied(bytes))]),
+        };
+
+        let decoded: CastReply = result.reply("reply").expect("cast reply decodes");
+        assert_eq!(decoded, reply);
     }
 }

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -441,7 +441,7 @@ impl NativeBinding {
     /// entry is the only reply API native actors reach for.
     pub fn send_reply_for_handler<K>(&self, sender: ReplyTo, payload: &K)
     where
-        K: aether_data::Kind + serde::Serialize,
+        K: aether_data::Kind,
     {
         self.mailer.send_reply(sender, payload);
     }

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -415,7 +415,7 @@ impl<'a> NativeCtx<'a> {
     /// has no caller behind it). Routes through the same
     /// [`NativeBinding::send_reply_for_handler`] path as
     /// [`MailCtx::reply`].
-    pub fn reply_to_target<K: Kind + serde::Serialize>(&mut self, sender: ReplyTo, payload: &K) {
+    pub fn reply_to_target<K: Kind>(&mut self, sender: ReplyTo, payload: &K) {
         self.binding.send_reply_for_handler(sender, payload);
     }
 
@@ -775,7 +775,7 @@ impl MailCtx for NativeCtx<'_> {
     /// — caps now reach for `ctx.reply(&result)` and the per-mail
     /// ctx already holds both the mailer reference (via the transport)
     /// and the inbound's reply target.
-    fn reply<K: Kind + serde::Serialize>(&mut self, payload: &K) {
+    fn reply<K: Kind>(&mut self, payload: &K) {
         self.binding.send_reply_for_handler(self.sender, payload);
     }
 }
@@ -960,11 +960,11 @@ impl OutboundReply for NativeCtx<'_> {
         }
     }
 
-    fn reply<K: Kind + serde::Serialize>(&mut self, payload: &K) {
+    fn reply<K: Kind>(&mut self, payload: &K) {
         self.binding.send_reply_for_handler(self.sender, payload);
     }
 
-    fn reply_to<K: Kind + serde::Serialize>(&mut self, sender: ReplyTo, payload: &K) {
+    fn reply_to<K: Kind>(&mut self, sender: ReplyTo, payload: &K) {
         self.binding.send_reply_for_handler(sender, payload);
     }
 }
@@ -1119,5 +1119,35 @@ mod tests {
         // Avoid an unused-import diagnostic when the compiler
         // dead-code-eliminates the helper.
         let _ = DataKindId(0);
+    }
+
+    /// A cast kind that is `Pod` but derives neither `Serialize` nor
+    /// `Deserialize` — the kind ADR-0100's reply path must accept.
+    #[repr(C)]
+    #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+    struct CastOnly {
+        code: u32,
+    }
+
+    impl Kind for CastOnly {
+        const NAME: &'static str = "test.cast_only_reply";
+        const ID: KindId = KindId(0xDEAD_BEEF_0009_0001);
+
+        fn encode_into_bytes(&self) -> Vec<u8> {
+            bytemuck::bytes_of(self).to_vec()
+        }
+    }
+
+    /// Type-level proof (ADR-0100): a `Pod`-without-`Serialize` cast kind
+    /// is repliable through every native reply entry point — the bounds
+    /// relaxed from `K: Kind + serde::Serialize` to `K: Kind`. Never
+    /// called; the compile is the assertion. If a reply bound regains a
+    /// `serde::Serialize` half, this stops compiling.
+    #[allow(dead_code)]
+    fn _assert_cast_kind_repliable(ctx: &mut NativeCtx<'_>, sender: ReplyTo) {
+        MailCtx::reply(ctx, &CastOnly { code: 1 });
+        OutboundReply::reply(ctx, &CastOnly { code: 2 });
+        OutboundReply::reply_to(ctx, sender, &CastOnly { code: 3 });
+        ctx.reply_to_target(sender, &CastOnly { code: 4 });
     }
 }

--- a/crates/aether-substrate/src/dag/executor.rs
+++ b/crates/aether-substrate/src/dag/executor.rs
@@ -1342,11 +1342,13 @@ fn assemble_request(
         let slot = u32::try_from(slot_index).unwrap_or(u32::MAX);
         let from = slot_source.get(&slot)?;
         let handle = *state.handles.get(from)?;
-        // The Handle variant carries no `K`, so any marker type works —
-        // emit the wire `Ref::Handle { id, kind_id }`. The walk-and-
-        // resolve path validates against the *field's* expected type at
-        // dispatch, splicing the stored bytes inline (or parking).
-        let r: Ref<u8> = Ref::Handle {
+        // The Handle variant carries no `K`, so any `Kind` marker works
+        // (`Ref<K>`'s serde needs `K: Kind` post-ADR-0100, and the unit
+        // kind is the zero-cost marker) — emit the wire
+        // `Ref::Handle { id, kind_id }`. The walk-and-resolve path
+        // validates against the *field's* expected type at dispatch,
+        // splicing the stored bytes inline (or parking).
+        let r: Ref<()> = Ref::Handle {
             id: handle.0,
             kind_id: expected_kind.0,
         };

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -18,8 +18,10 @@
 //! of the inline value; the substrate resolves the handle on dispatch
 //! and substitutes the inline bytes before delivering the mail.
 //!
-//! Wire format (postcard, ADR-0045 §1):
-//! - Inline arm: discriminant 0 + K postcard bytes.
+//! Wire format (ADR-0045 §1, inline arm revised by ADR-0100):
+//! - Inline arm: discriminant 0 + `varint(len)` + `K::encode_into_bytes`
+//!   (`len` bytes) — the kind's own codec image (cast or postcard),
+//!   an opaque length-delimited blob the walker skips by length.
 //! - Handle arm: discriminant 1 + `varint(id)` + `varint(kind_id)`.
 //!
 //! Resolution is structural: the walker reads the schema and skips
@@ -2316,7 +2318,18 @@ fn walk(
             let ref_disc_start = state.pos;
             let disc = state.read_varint()? as u32;
             match disc {
-                0 => walk(inner, state, store),
+                0 => {
+                    // ADR-0100: the inline body is an opaque
+                    // length-prefixed blob (`varint(len)` +
+                    // `K::encode_into_bytes`) — the kind's own codec
+                    // image, cast or postcard. Skip it by length rather
+                    // than re-deriving `K`'s byte layout from `inner`;
+                    // a cast image is not a schema-walkable postcard
+                    // structure.
+                    let len = state.read_varint()? as usize;
+                    state.skip_n(len)?;
+                    Ok(None)
+                }
                 1 => {
                     let id = HandleId(state.read_varint()?);
                     let kind = KindId(state.read_varint()?);
@@ -2338,10 +2351,15 @@ fn walk(
                     match resolved_inner {
                         WalkOutcome::Parked { handle, kind } => Ok(Some((handle, kind))),
                         WalkOutcome::Resolved { payload } => {
-                            // Splice: flush prefix, write Inline arm,
-                            // skip past the Handle wire bytes.
+                            // Splice: flush prefix, write the Inline arm
+                            // (disc 0 + varint(len) + payload, ADR-0100),
+                            // skip past the Handle wire bytes. The
+                            // payload is the resolved inline blob — the
+                            // byte image is identical whether it arrived
+                            // inline or was spliced from a handle here.
                             state.flush_up_to(ref_disc_start);
                             state.out.push(0u8);
+                            push_varint(&mut state.out, payload.len() as u64);
                             state.out.extend_from_slice(&payload);
                             state.prefix_end = after_handle;
                             Ok(None)
@@ -2358,6 +2376,21 @@ fn walk(
             state.skip_varint()?;
             Ok(None)
         }
+    }
+}
+
+/// Append `value` as an unsigned LEB128 varint — the same encoding
+/// postcard uses for the inline arm's `varint(len)` length prefix
+/// (ADR-0100). Mirror of [`State::read_varint`].
+fn push_varint(out: &mut Vec<u8>, mut value: u64) {
+    loop {
+        let byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value == 0 {
+            out.push(byte);
+            return;
+        }
+        out.push(byte | 0x80);
     }
 }
 
@@ -2607,6 +2640,14 @@ mod tests {
         const NAME: &'static str = "test.note";
         // Stable test sentinel — distinct from real schema-hashed kind ids.
         const ID: KindId = KindId(0xDEAD_BEEF_0002_0001);
+
+        fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+            postcard::from_bytes(bytes).ok()
+        }
+
+        fn encode_into_bytes(&self) -> Vec<u8> {
+            postcard::to_allocvec(self).expect("postcard encode to Vec is infallible")
+        }
     }
 
     /// Postcard-shape `Struct { repr_c: false, fields }` builder
@@ -2647,11 +2688,58 @@ mod tests {
         seq: u32,
     }
 
+    impl Kind for HeldNote {
+        const NAME: &'static str = "test.held_note";
+        const ID: KindId = KindId(0xDEAD_BEEF_0002_0002);
+
+        fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+            postcard::from_bytes(bytes).ok()
+        }
+
+        fn encode_into_bytes(&self) -> Vec<u8> {
+            postcard::to_allocvec(self).expect("postcard encode to Vec is infallible")
+        }
+    }
+
     fn held_note_schema() -> SchemaType {
         postcard_struct(vec![
             named("held", SchemaType::Ref(SchemaCell::owned(note_schema()))),
             seq_field(),
         ])
+    }
+
+    /// Cast-shaped walker fixture with non-`f32` fields (`u16`). ADR-0100
+    /// makes its inline body a raw cast image, whose `u16` bytes a
+    /// postcard reader would misread — the walker must treat the inline
+    /// body as an opaque length-prefixed blob, not walk it as postcard.
+    #[repr(C)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq, bytemuck::Pod, bytemuck::Zeroable)]
+    struct Coord {
+        x: u16,
+        y: u16,
+    }
+
+    impl Kind for Coord {
+        const NAME: &'static str = "test.coord";
+        const ID: KindId = KindId(0xDEAD_BEEF_0002_0003);
+
+        fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+            (bytes.len() == size_of::<Self>()).then(|| bytemuck::pod_read_unaligned(bytes))
+        }
+
+        fn encode_into_bytes(&self) -> Vec<u8> {
+            bytemuck::bytes_of(self).to_vec()
+        }
+    }
+
+    fn coord_schema() -> SchemaType {
+        SchemaType::Struct {
+            fields: Cow::Owned(vec![
+                named("x", SchemaType::Scalar(Primitive::U16)),
+                named("y", SchemaType::Scalar(Primitive::U16)),
+            ]),
+            repr_c: true,
+        }
     }
 
     #[test]
@@ -2946,6 +3034,43 @@ mod tests {
                 Ref::Handle { .. } => panic!("nested ref must also be resolved"),
             },
             Ref::Handle { .. } => panic!("outer ref must be resolved"),
+        }
+    }
+
+    /// ADR-0100: a handle to a non-`f32` cast kind resolves to an inline
+    /// arm whose body is the raw cast image, and the spliced wire decodes
+    /// on the guest path (`Ref<Coord>::decode → Kind::decode_from_bytes`)
+    /// uncorrupted — the `u16` fields survive because the walker never
+    /// re-interprets the cast image as postcard.
+    #[test]
+    fn walk_handle_ref_resolves_cast_kind_non_f32() {
+        let schema = SchemaType::Ref(SchemaCell::owned(coord_schema()));
+        let store = HandleStore::new(1024);
+
+        let pt = Coord {
+            x: 0x0102,
+            y: 0xF0E1,
+        };
+        let cast_bytes = bytemuck::bytes_of(&pt).to_vec();
+        store.put(HandleId(3), Coord::ID, cast_bytes).unwrap();
+
+        let wire = postcard::to_allocvec(&Ref::<Coord>::handle(3)).unwrap();
+        let outcome = walk_and_resolve(&schema, &wire, &store).unwrap();
+        let resolved = match outcome {
+            WalkOutcome::Resolved { payload } => payload.into_owned(),
+            WalkOutcome::Parked { .. } => panic!("expected resolved"),
+        };
+
+        // The spliced inline arm carries the 4-byte cast image,
+        // length-prefixed: disc 0 + varint(4) + 4 raw bytes.
+        assert_eq!(resolved[0], 0, "spliced Inline discriminant");
+        assert_eq!(resolved[1], 4, "varint length of the 4-byte cast image");
+        assert_eq!(&resolved[2..], bytemuck::bytes_of(&pt));
+
+        let back: Ref<Coord> = postcard::from_bytes(&resolved).unwrap();
+        match back {
+            Ref::Inline(got) => assert_eq!(got, pt, "u16 cast fields survive resolution"),
+            Ref::Handle { .. } => panic!("walker must replace Handle with Inline"),
         }
     }
 

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -428,7 +428,7 @@ impl Mailer {
     /// receive mail.
     pub fn send_reply<K>(&self, sender: ReplyTo, result: &K) -> bool
     where
-        K: Kind + serde::Serialize,
+        K: Kind,
     {
         match sender.target {
             ReplyTarget::None => false,
@@ -437,18 +437,9 @@ impl Mailer {
                 .as_ref()
                 .is_some_and(|outbound| outbound.send_reply(sender, result)),
             ReplyTarget::Component(mailbox) => {
-                let payload = match postcard::to_allocvec(result) {
-                    Ok(p) => p,
-                    Err(e) => {
-                        tracing::error!(
-                            target: "aether_substrate::mailer",
-                            kind = K::NAME,
-                            error = %e,
-                            "reply encode failed",
-                        );
-                        return false;
-                    }
-                };
+                // ADR-0100: encode the reply through the kind's declared
+                // codec (cast or postcard), not a hardcoded postcard path.
+                let payload = result.encode_into_bytes();
                 // ADR-0042: echo the caller's correlation_id onto the
                 // reply envelope so the originating handler can pick
                 // the right reply out of the mpsc by correlation.
@@ -528,21 +519,18 @@ fn route_mail(
                     // The MCP Call path replies via Component (mirrors
                     // the `LogTail`-to-unknown arm below): re-route a
                     // fresh, un-lineaged reply into the target's inbox.
-                    if let Ok(payload) = postcard::to_allocvec(&result) {
-                        let reply_to = ReplyTo::with_correlation(
-                            ReplyTarget::None,
-                            mail.reply_to.correlation_id,
-                        );
-                        route_mail(
-                            Mail::new(target, TraceTailResult::ID, payload, 1)
-                                .with_reply_to(reply_to),
-                            registry,
-                            outbound,
-                            store,
-                            chassis_router,
-                            trace_handle,
-                        );
-                    }
+                    // ADR-0100: encode through the kind's declared codec.
+                    let payload = result.encode_into_bytes();
+                    let reply_to =
+                        ReplyTo::with_correlation(ReplyTarget::None, mail.reply_to.correlation_id);
+                    route_mail(
+                        Mail::new(target, TraceTailResult::ID, payload, 1).with_reply_to(reply_to),
+                        registry,
+                        outbound,
+                        store,
+                        chassis_router,
+                        trace_handle,
+                    );
                 }
                 ReplyTarget::None => {}
             }
@@ -768,9 +756,9 @@ fn route_mail(
                 let err = aether_kinds::LogTailResult::Err {
                     error: format!("mailbox {recipient} not registered on engine"),
                 };
-                if let Ok(payload) = postcard::to_allocvec(&err)
-                    && let ReplyTarget::Component(target) = mail.reply_to.target
-                {
+                // ADR-0100: encode through the kind's declared codec.
+                let payload = err.encode_into_bytes();
+                if let ReplyTarget::Component(target) = mail.reply_to.target {
                     let reply_to =
                         ReplyTo::with_correlation(ReplyTarget::None, mail.reply_to.correlation_id);
                     route_mail(
@@ -1048,6 +1036,14 @@ mod tests {
         const NAME: &'static str = "test.mailer_note";
         // Stable test sentinel — distinct from real schema-hashed kind ids.
         const ID: KindId = KindId(0xDEAD_BEEF_0003_0001);
+
+        fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+            postcard::from_bytes(bytes).ok()
+        }
+
+        fn encode_into_bytes(&self) -> Vec<u8> {
+            postcard::to_allocvec(self).expect("postcard encode to Vec is infallible")
+        }
     }
 
     #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug, Clone)]
@@ -1144,6 +1140,53 @@ mod tests {
         let store = Arc::new(HandleStore::new(64 * 1024));
         let mailer = Arc::new(Mailer::new(Arc::clone(&registry), Arc::clone(&store)));
         (registry, mailer, store)
+    }
+
+    /// Cast-shaped reply kind with a non-`f32` field — its
+    /// `encode_into_bytes` is the raw cast image.
+    #[repr(C)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq, bytemuck::Pod, bytemuck::Zeroable)]
+    struct CastReply {
+        code: u32,
+        flag: u16,
+        _pad: u16,
+    }
+    impl Kind for CastReply {
+        const NAME: &'static str = "test.mailer_cast_reply";
+        const ID: KindId = KindId(0xDEAD_BEEF_0003_0003);
+
+        fn encode_into_bytes(&self) -> Vec<u8> {
+            bytemuck::bytes_of(self).to_vec()
+        }
+    }
+
+    /// ADR-0100: `Mailer::send_reply` to a `Component` target encodes the
+    /// reply through `Kind::encode_into_bytes`. A cast reply kind reaches
+    /// the sink as its raw cast image, not a postcard varint image — and
+    /// a `Pod`-without-`Serialize` kind is repliable at all.
+    #[test]
+    fn send_reply_cast_kind_delivers_cast_image() {
+        let (registry, mailer, _store) = make_mailer();
+        let sink = CapturingSink::new();
+        let sink_id = registry.register_inbox("test.sink", sink.inbox_handler());
+
+        let reply = CastReply {
+            code: 0x1122_3344,
+            flag: 0xABCD,
+            _pad: 0,
+        };
+        let sent = mailer.send_reply(
+            ReplyTo::with_correlation(ReplyTarget::Component(sink_id), 1),
+            &reply,
+        );
+        assert!(sent, "Component reply target routes");
+
+        let captured = sink.captured.read().unwrap().clone();
+        assert_eq!(
+            captured,
+            vec![bytemuck::bytes_of(&reply).to_vec()],
+            "reply payload is the cast image"
+        );
     }
 
     /// Mail to a sink whose kind has no `Ref` fields takes the

--- a/crates/aether-substrate/src/mail/outbound.rs
+++ b/crates/aether-substrate/src/mail/outbound.rs
@@ -404,31 +404,19 @@ impl HubOutbound {
         (outbound, rx)
     }
 
-    /// Encode `result` with postcard and route as a reply addressed at
-    /// `sender`. Forks on the sender variant: `Session` routes through
-    /// `egress_to_session`; `EngineMailbox` routes through
-    /// `egress_to_engine_mailbox`; `None` and `Component` are silent
-    /// no-ops (the latter is handled by `Mailer::send_reply` rather
-    /// than the hub). Returns `true` when the encode succeeded and a
-    /// backend method was called; `false` on encode failure or
-    /// non-hub-routed targets. Encode errors log at `error` since
-    /// they signal a postcard contract violation.
+    /// Encode `result` through the kind's declared codec
+    /// (`Kind::encode_into_bytes`, cast or postcard, ADR-0100) and route
+    /// as a reply addressed at `sender`. Forks on the sender variant:
+    /// `Session` routes through `egress_to_session`; `EngineMailbox`
+    /// routes through `egress_to_engine_mailbox`; `None` and `Component`
+    /// are silent no-ops (the latter is handled by `Mailer::send_reply`
+    /// rather than the hub). Returns `true` when a backend method was
+    /// called; `false` on a non-hub-routed target.
     pub fn send_reply<K>(&self, sender: ReplyTo, result: &K) -> bool
     where
-        K: aether_data::Kind + serde::Serialize,
+        K: aether_data::Kind,
     {
-        let payload = match postcard::to_allocvec(result) {
-            Ok(b) => b,
-            Err(e) => {
-                tracing::error!(
-                    target: "aether_substrate::outbound",
-                    kind = K::NAME,
-                    error = %e,
-                    "reply encode failed",
-                );
-                return false;
-            }
-        };
+        let payload = result.encode_into_bytes();
         match sender.target {
             ReplyTarget::Session(token) => {
                 self.egress_to_session(token, K::NAME, payload, None, sender.correlation_id);


### PR DESCRIPTION
Closes iamacoffeepot/aether#1475.

## Summary

One principle over two coupled wire surfaces (ADR-0100): a substrate wire encoder for a typed K honors the kind's declared wire shape via Kind::encode_into_bytes / decode_from_bytes, never a hardcoded postcard path.

- **Ref&lt;K&gt; inline arm.** Replaced the serde derive on Ref with hand-written Serialize / Deserialize bounded K: Kind. The inline arm now carries disc 0 + varint(len) + K::encode_into_bytes, so a cast kind rides as its cast image rather than a coincidence-correct postcard image, and the spliced-from-handle bytes match the natively-inline bytes. The Handle arm is byte-identical to the prior derive. The splice walker (handle_store) and the codec (encode/decode) move to the same framing; the externally-tagged JSON descriptor form is unchanged.
- **Reply path (R1).** Routed the reply encoders (Mailer::send_reply, HubOutbound::send_reply) through encode_into_bytes and relaxed the shared OutboundReply / MailCtx reply bounds from K: Kind + serde::Serialize to K: Kind, so a cast reply kind encodes against its declared descriptor. Byte-identical for every existing (postcard) reply kind.

Cast (Pod) kinds are now first-class on both the handle and reply wire paths with no serde derive; the store-as-cast / decode-as-postcard coincidence is removed.

## Test plan

- aether-data: Ref::Inline / Ref::Handle postcard round-trip for a cast kind with a non-f32 field, asserting the inline body is the cast image; ref_is_cast_ineligible unchanged.
- handle_store: existing walker tests re-pass against the new framing; a non-f32 cast-kind handle-resolution case proves the spliced inline value decodes on the guest path.
- aether-codec: a JSON Inline descriptor for a cast inner kind round-trips JSON to wire to JSON; the Handle path is byte-unchanged.
- reply path: existing reply tests stay green; a cast reply-kind encode asserts the cast image; a Pod-without-Serialize cast kind compiles through the reply surfaces; the test-bench reply decode round-trips a cast reply kind.
- Full scripts/preflight.sh green (fmt + clippy + doc + nextest 1548 passed + wasm32 component cross-build).

## Generated by

/implement — agent execution of scoped issue #1475.
