### PR TITLE
refactor(mcp): route send-path wire builders through the Kind codec

### DIFF
--- a/crates/aether-capabilities/src/dag/tests.rs
+++ b/crates/aether-capabilities/src/dag/tests.rs
@@ -110,17 +110,12 @@ fn session(corr: u64) -> ReplyTo {
 /// Enqueue an already-encoded request kind at `mailbox_name` with a
 /// session reply target. Drives the request through the cap's live
 /// dispatcher thread.
-fn enqueue<K: Kind + serde::Serialize>(
-    registry: &Registry,
-    mailbox_name: &str,
-    payload: &K,
-    sender: ReplyTo,
-) {
+fn enqueue<K: Kind>(registry: &Registry, mailbox_name: &str, payload: &K, sender: ReplyTo) {
     let id = registry.lookup(mailbox_name).expect("mailbox registered");
     let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("entry") else {
         panic!("expected inbox mailbox for {mailbox_name}");
     };
-    let bytes = postcard::to_allocvec(payload).expect("encode request");
+    let bytes = payload.encode_into_bytes();
     handler.enqueue(OwnedDispatch::disarmed(
         K::ID,
         K::NAME.to_owned(),

--- a/crates/aether-capabilities/src/engine/server.rs
+++ b/crates/aether-capabilities/src/engine/server.rs
@@ -653,11 +653,7 @@ mod tests {
     /// Drive one request kind at `aether.engine`, reply-to the sink,
     /// and block until `probe` sees a recorded reply (or the deadline
     /// passes).
-    fn drive<K: Kind + serde::Serialize, T>(
-        mailer: &Arc<Mailer>,
-        request: &K,
-        probe: impl Fn() -> Option<T>,
-    ) -> T {
+    fn drive<K: Kind, T>(mailer: &Arc<Mailer>, request: &K, probe: impl Fn() -> Option<T>) -> T {
         let server = mailbox_id_from_name(<EngineServer as Actor>::NAMESPACE);
         let sink = mailbox_id_from_name(<ReplySink as Actor>::NAMESPACE);
         mailer.push(
@@ -766,7 +762,7 @@ mod tests {
     /// so the assertion runs only after the cap has processed the
     /// earlier mail (single-threaded actor, in-order mailbox). Returns
     /// the engine list the cap reports afterward.
-    fn push_then_list<K: Kind + serde::Serialize>(
+    fn push_then_list<K: Kind>(
         mailer: &Arc<Mailer>,
         cells: &ReplyCells,
         fire: &K,

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -641,9 +641,9 @@ mod cap_native {
             ReplyTo::to(ReplyTarget::Session(SessionToken(Uuid::from_u128(0xfeed))))
         }
 
-        /// Push a postcard-encoded mail at the cap's mailbox via the
-        /// registered sink handler, then wait for the next outbound
-        /// reply on `rx` and decode as `R`.
+        /// Push an encoded mail (via the kind's `encode_into_bytes`) at
+        /// the cap's mailbox via the registered sink handler, then wait
+        /// for the next outbound reply on `rx` and decode as `R`.
         fn drive_and_decode<K, R>(
             registry: &Arc<Registry>,
             rx: &mpsc::Receiver<EgressEvent>,
@@ -651,7 +651,7 @@ mod cap_native {
             mail: &K,
         ) -> R
         where
-            K: Kind + serde::Serialize,
+            K: Kind,
             R: DeserializeOwned,
         {
             let id = registry
@@ -660,7 +660,7 @@ mod cap_native {
             let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("cap entry") else {
                 panic!("expected mailbox entry");
             };
-            let bytes = postcard::to_allocvec(mail).expect("encode");
+            let bytes = mail.encode_into_bytes();
             handler.enqueue(OwnedDispatch::disarmed(
                 K::ID,
                 K::NAME.to_owned(),

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -1321,7 +1321,7 @@ impl ServerHandler for Mcp {
 
 /// Build a `MailEnvelope` addressed at a hub-local mailbox
 /// (`engine = None`) carrying a typed kind.
-fn local_envelope<K: Kind + serde::Serialize>(mailbox: &str, kind: &K) -> MailEnvelope {
+fn local_envelope<K: Kind>(mailbox: &str, kind: &K) -> MailEnvelope {
     MailEnvelope {
         to: MailboxAddress::local(mailbox_id_from_path(mailbox)),
         from: None,
@@ -1334,11 +1334,7 @@ fn local_envelope<K: Kind + serde::Serialize>(mailbox: &str, kind: &K) -> MailEn
 /// Build a `MailEnvelope` addressed at a mailbox on a specific
 /// substrate (`engine = Some`) carrying a typed kind — the hub routes
 /// it through to that engine's proxy.
-fn engine_envelope<K: Kind + serde::Serialize>(
-    engine: EngineId,
-    mailbox: &str,
-    kind: &K,
-) -> MailEnvelope {
+fn engine_envelope<K: Kind>(engine: EngineId, mailbox: &str, kind: &K) -> MailEnvelope {
     engine_envelope_by_id(engine, mailbox_id_from_path(mailbox), kind)
 }
 
@@ -1347,11 +1343,7 @@ fn engine_envelope<K: Kind + serde::Serialize>(
 /// 3b) discovers recipients as ids embedded in `Sent` events, never as
 /// names — a `MailboxId` is a one-way name hash, so there's no name to
 /// reconstruct.
-fn engine_envelope_by_id<K: Kind + serde::Serialize>(
-    engine: EngineId,
-    mailbox: MailboxId,
-    kind: &K,
-) -> MailEnvelope {
+fn engine_envelope_by_id<K: Kind>(engine: EngineId, mailbox: MailboxId, kind: &K) -> MailEnvelope {
     MailEnvelope {
         to: MailboxAddress {
             engine: Some(engine),
@@ -2437,6 +2429,45 @@ mod tests {
         }
         .encode_into_bytes();
         assert_eq!(actual, expected);
+    }
+
+    /// A cast-only kind — `#[repr(C)]` + `bytemuck::Pod`, no
+    /// `serde::Serialize` impl (`LifecycleSubscribe`) — rides the send
+    /// builders, which bound `K: Kind` (not `K: Kind + Serialize`) and
+    /// encode via the descriptor-aware `encode_into_bytes`. The payload
+    /// is the kind's cast image (length == `size_of`, distinct from a
+    /// postcard varint encode of these `u64`s) and round-trips through
+    /// `Kind::decode_from_bytes`. Compiling at all is the bound check:
+    /// the old `serde::Serialize` bound would reject this kind.
+    #[test]
+    fn send_builders_encode_a_cast_only_kind() {
+        let mail = aether_kinds::LifecycleSubscribe {
+            stage: u64::MAX,
+            mailbox: 0x0102_0304_0506_0708,
+        };
+        let cast_bytes = mail.encode_into_bytes();
+        assert_eq!(
+            cast_bytes.len(),
+            size_of::<aether_kinds::LifecycleSubscribe>(),
+            "cast image is the fixed struct size, not a postcard varint encode",
+        );
+
+        let local = local_envelope("aether.lifecycle", &mail);
+        assert_eq!(local.kind, aether_kinds::LifecycleSubscribe::ID);
+        assert_eq!(local.payload, cast_bytes);
+        assert_eq!(
+            aether_kinds::LifecycleSubscribe::decode_from_bytes(&local.payload),
+            Some(mail),
+        );
+
+        let engine = EngineId(Uuid::from_u128(0x1232_dead_beef));
+        let by_id = engine_envelope_by_id(engine, mailbox_id_from_name("aether.lifecycle"), &mail);
+        assert_eq!(by_id.kind, aether_kinds::LifecycleSubscribe::ID);
+        assert_eq!(by_id.payload, cast_bytes);
+        assert_eq!(
+            aether_kinds::LifecycleSubscribe::decode_from_bytes(&by_id.payload),
+            Some(mail),
+        );
     }
 
     /// `submit_dag` with a `payload_path` that doesn't exist returns a

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -32,14 +32,15 @@ use std::time::{Duration, Instant};
 
 #[cfg(test)]
 use aether_capabilities::trace_walk::TreeWalk;
-use aether_data::{Kind, KindId, SessionToken, Uuid, encode_empty, encode_struct};
+use aether_data::{Kind, KindId, SessionToken, Uuid, encode_empty};
 #[cfg(test)]
 use aether_kinds::Tick;
 #[cfg(test)]
 use aether_kinds::trace::{DescribeTreeResult, TraceTail, TraceTailResult};
 use aether_kinds::{Advance, AdvanceResult, CaptureFrame, CaptureFrameResult};
-// `encode_struct` is used for control kinds (postcard-shape); cast-
-// shape kinds (e.g. FrameStats) flow through `frame_loop` helpers.
+// `push_to_mailbox` encodes any sent kind through the descriptor-aware
+// `Kind::encode_into_bytes` (cast or postcard per the kind's shape);
+// `encode_empty` builds the zero-byte payload for unit lifecycle kinds.
 use aether_actor::Actor;
 use aether_capabilities::{RenderCapability, fs::NamespaceRoots};
 use aether_substrate::chassis::settlement::{
@@ -720,10 +721,10 @@ impl TestBench {
     /// `aether.window.set_mode`, etc.).
     fn push_to_mailbox<K>(&self, mailbox: MailboxId, mail: &K, cid: u64)
     where
-        K: Kind + serde::Serialize,
+        K: Kind,
     {
         let reply_to = ReplyTo::with_correlation(ReplyTarget::Session(self.session), cid);
-        let payload = encode_struct(mail);
+        let payload = mail.encode_into_bytes();
         self.queue
             .push(Mail::new(mailbox, K::ID, payload, 1).with_reply_to(reply_to));
     }

--- a/crates/aether-substrate-bundle/tests/engines_cap.rs
+++ b/crates/aether-substrate-bundle/tests/engines_cap.rs
@@ -124,7 +124,7 @@ fn boot() -> (PassiveChassis<TestChassis>, Arc<Mailer>, ReplyCells) {
 
 /// Drive one request kind at `aether.engine`, reply-to the sink, and
 /// block until `probe` returns a recorded reply (or `deadline` passes).
-fn drive<K: Kind + serde::Serialize, T>(
+fn drive<K: Kind, T>(
     mailer: &Arc<Mailer>,
     request: &K,
     deadline: Duration,

--- a/crates/aether-substrate-bundle/tests/rpc_engine_routing.rs
+++ b/crates/aether-substrate-bundle/tests/rpc_engine_routing.rs
@@ -84,7 +84,7 @@ fn boot_hub() -> (PassiveChassis<TestChassis>, u16) {
 /// returning the `(kind, payload)` of the single `ReplyEvent` seen in
 /// between (these calls each yield exactly one event then end). Panics
 /// on a `ReplyEnd::Err` or a missing event.
-fn call_round_trip<K: Kind + serde::Serialize>(
+fn call_round_trip<K: Kind>(
     stream: &mut TcpStream,
     cid: u64,
     engine: Option<EngineId>,

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -417,8 +417,8 @@ mod free_dispatch_tests {
         (mailer, rx)
     }
 
-    fn build_envelope<K: Kind + serde::Serialize>(payload: &K, reply_to: ReplyTo) -> Envelope {
-        let bytes = postcard::to_allocvec(payload).expect("postcard encode");
+    fn build_envelope<K: Kind>(payload: &K, reply_to: ReplyTo) -> Envelope {
+        let bytes = payload.encode_into_bytes();
         Envelope::disarmed(
             KindId(<K as Kind>::ID.0),
             <K as Kind>::NAME.to_owned(),


### PR DESCRIPTION
Closes iamacoffeepot/aether#1478.

## Summary

One principle (ADR-0100, #1476) extended to the send surface: a substrate wire encoder for a typed `K` honors the kind's declared shape via `Kind::encode_into_bytes`, bounding `K: Kind` only — never `K: Kind + serde::Serialize`. #1477 applied this to the `Ref` inline arm and the reply path; this completes it on the send-path wire builders so a pure-cast (`Pod`, no serde) kind is first-class on every send surface.

Mechanical and byte-identical for every existing (postcard) kind — no wire-format change, no new ADR:

- **MCP send builders** (`local_envelope` / `engine_envelope` / `engine_envelope_by_id`) — drop the `serde::Serialize` half of the bound; bodies already encode via `encode_into_bytes`.
- **Test / harness send helpers** — `push_to_mailbox` (TestBench), `build_envelope` (substrate test), the capabilities `drive` / `drive_and_decode` / `enqueue` helpers, and the bundle integration `drive` / `call_round_trip` helpers — drop the bound, and where they still hardcoded `postcard::to_allocvec`, route through `encode_into_bytes`.

The production native and FFI `ctx.send` paths were audited and already bound `K: Kind` + encode via `encode_into_bytes`, so this is a cleanup of the few remaining builders, not a change to how actors send.

## Test plan

- New unit test `send_builders_encode_a_cast_only_kind` (aether-mcp): sends a cast-only kind (`#[repr(C)]` + `Pod`, no `Serialize`) through `local_envelope` and `engine_envelope_by_id`, asserts the payload equals the kind's cast bytes, that `len == size_of` (proving cast-shape over postcard), and that `decode_from_bytes` round-trips. The kind compiling through the builders at all is the bound check — the old `serde::Serialize` bound would reject it.
- Existing MCP / TestBench / capabilities / bundle tests stay green — byte-identical for the postcard kinds they exercise.
- Full `scripts/preflight.sh` green: fmt-check + clippy `--workspace --all-targets -D warnings` + doc + nextest `--workspace` (1549 passed, 6 skipped) + wasm32 component cross-build.

## Generated by

`/implement` — agent execution of scoped issue #1478.
