### PR TITLE
docs(adr): accept ADR-0101, note the ADR-0016 revision

### DIFF
--- a/docs/adr/0016-persistent-state-across-hot-reload.md
+++ b/docs/adr/0016-persistent-state-across-hot-reload.md
@@ -3,6 +3,7 @@
 - **Status:** Accepted
 - **Date:** 2026-04-14
 - **Accepted:** 2026-04-17
+- **Revised by:** ADR-0101 (2026-06-09) — the opt-in is retired. `on_dehydrate` (the former `on_replace`) and `on_rehydrate` are now default-no-op `FfiActor` lifecycle hooks, not a `Replaceable` subtrait reached through an `export!` flag. The state-bundle protocol described below is unchanged.
 
 ## Context
 

--- a/docs/adr/0101-replace-hooks-on-ffiactor.md
+++ b/docs/adr/0101-replace-hooks-on-ffiactor.md
@@ -1,7 +1,8 @@
 # ADR-0101: Replace hooks on FfiActor
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-06-08
+- **Accepted:** 2026-06-09 (implemented by iamacoffeepot/aether#1480)
 
 ## Context
 


### PR DESCRIPTION
Post-implementation bookkeeping for the ADR-0101 arc, landed in #1480.

- **ADR-0101** — Status: Proposed → Accepted (the implementation merged in #1480).
- **ADR-0016** — adds a revision pointer to ADR-0101: its opt-in decision is retired; its state-bundle protocol is unchanged.

Docs only.
