### PR TITLE
feat(substrate-bundle): add a render stage to the chassis lifecycle (submit after tick settles)

### DIFF
--- a/crates/aether-camera/src/runtime.rs
+++ b/crates/aether-camera/src/runtime.rs
@@ -45,9 +45,10 @@ use std::collections::HashMap;
 
 use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
 use aether_capabilities::input::InputMailboxExt;
-use aether_capabilities::{InputCapability, RenderCapability};
+use aether_capabilities::lifecycle::LifecycleMailboxExt;
+use aether_capabilities::{InputCapability, LifecycleCapability, RenderCapability};
 use aether_data::{Kind, MailboxId};
-use aether_kinds::{Camera, Tick, WindowSize};
+use aether_kinds::{Camera, Render, Tick, WindowSize};
 use aether_math::{Mat4, PI, Quat, TAU, Vec2, Vec3};
 
 use crate::{
@@ -272,28 +273,48 @@ impl FfiActor for CameraComponent {
         })
     }
 
-    /// Issue 640: subscribe to the input streams the camera advances
-    /// against. `wire` (post-init, mail-allowed) is the placement —
-    /// `init`'s ctx is `Resolver`-only and can't mail.
+    /// Issue 640 / 1378: subscribe to the input streams the camera
+    /// advances against (`Tick`, `WindowSize`) plus the `Render`
+    /// lifecycle stage it submits on. `wire` (post-init, mail-allowed)
+    /// is the placement — `init`'s ctx is `Resolver`-only and can't mail.
+    ///
+    /// On a chassis whose lifecycle graph omits `Render` (headless), the
+    /// cap replies `Err(UnsupportedStage)` to this fire-and-forget
+    /// subscribe; the reply warn-drops and the camera simply never
+    /// receives `Render` and never submits — a no-op there, where the
+    /// render cap discards anyway (ADR-0082 §7 / §11).
     fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
         let me = MailboxId(ctx.mailbox_id());
         let input = ctx.actor::<InputCapability>();
         input.subscribe(Tick::ID, me);
         input.subscribe(WindowSize::ID, me);
+        ctx.actor::<LifecycleCapability>().subscribe(Render::ID, me);
     }
 
-    /// Advance every camera's per-mode state, then publish the active
-    /// camera's `view_proj` to `"aether.render"`. Inactive cameras
-    /// still tick (so orbit yaw keeps accumulating); only the active
-    /// one writes to the sink.
+    /// Advance every camera's per-mode state each tick. Inactive cameras
+    /// still tick (so orbit yaw keeps accumulating); the active camera's
+    /// `view_proj` is submitted later, on the `Render` stage, once every
+    /// actor's per-frame Tick compute has settled (ADR-0082 §11).
     ///
     /// # Agent
     /// Tick-driven; not useful to send manually.
     #[handler]
-    fn on_tick(&mut self, ctx: &mut FfiCtx<'_>, _tick: Tick) {
+    fn on_tick(&mut self, _ctx: &mut FfiCtx<'_>, _tick: Tick) {
         for cam in self.cameras.values_mut() {
             cam.mode.tick();
         }
+    }
+
+    /// Publish the active camera's `view_proj` to `"aether.render"`. Runs
+    /// on the `Render` lifecycle stage — after the whole `Tick` chain has
+    /// settled — so the submitted view matches the fully-integrated
+    /// per-frame state (issue 1378). Publishing pauses while no camera is
+    /// active.
+    ///
+    /// # Agent
+    /// Lifecycle-driven; not useful to send manually.
+    #[handler]
+    fn on_render(&mut self, ctx: &mut FfiCtx<'_>, _render: Render) {
         if let Some(name) = &self.active
             && let Some(cam) = self.cameras.get(name)
         {

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -105,12 +105,15 @@ pub struct InitCaps;
 pub struct InitComponents;
 
 /// Lifecycle stage broadcast — render stage (ADR-0082 §1). Fires every
-/// frame between [`Tick`] and [`Present`] on chassis that declare a
-/// render state in their lifecycle graph (today: desktop). Render
-/// capabilities subscribe to integrate frame state submitted during
-/// the preceding Tick stage. Headless / hub chassis omit this state
-/// from their graph; subscribing on a chassis that doesn't declare it
-/// rejects fail-fast at wire time per ADR-0082 §7.
+/// frame after the whole [`Tick`] chain has settled (ADR-0080 §6) on
+/// chassis that declare a render state in their lifecycle graph (today:
+/// desktop and `test_bench`). Render-producing actors compute their
+/// per-frame state on [`Tick`] and submit it to `aether.render` here, on
+/// `Render` — so a submission integrates the fully-settled cross-actor
+/// state of the frame rather than racing other actors' Tick handlers.
+/// Headless / hub chassis omit this state from their graph; subscribing
+/// on a chassis that doesn't declare it rejects fail-fast at wire time
+/// per ADR-0082 §7.
 #[repr(C)]
 #[derive(
     Copy,

--- a/crates/aether-mesh-viewer/src/runtime.rs
+++ b/crates/aether-mesh-viewer/src/runtime.rs
@@ -1,6 +1,7 @@
 //! Mesh viewer runtime. Loads a mesh file from the substrate's I/O
 //! surface (ADR-0041), parses it into `DrawTriangle`s, and replays the
-//! cached list to the `"aether.render"` sink every tick.
+//! cached list to the `"aether.render"` sink each frame on the `Render`
+//! lifecycle stage.
 //!
 //! Dispatches on the file extension echoed back on `aether.fs.read_result`:
 //!
@@ -28,15 +29,15 @@
 //! 3. On reply, the cached triangle list is replaced atomically. Any
 //!    parse or mesh failure leaves the prior cache intact (silent
 //!    drop; errors surface via `engine_logs`).
-//! 4. Every `aether.lifecycle.tick` re-emits the cached triangles to
-//!    `"aether.render"`.
+//! 4. Every `aether.lifecycle.render` stage re-emits the cached
+//!    triangles to `"aether.render"`.
 
 use aether_actor::{BootError, FfiActor, FfiCtx, OutboundReply, ReplyTo, Resolver, actor};
 use aether_capabilities::fs::FsMailboxExt;
-use aether_capabilities::input::InputMailboxExt;
-use aether_capabilities::{FsCapability, InputCapability, RenderCapability};
+use aether_capabilities::lifecycle::LifecycleMailboxExt;
+use aether_capabilities::{FsCapability, LifecycleCapability, RenderCapability};
 use aether_data::{Kind, MailboxId};
-use aether_kinds::{DrawTriangle, MeshLoadResult, ReadResult, Tick, Vertex};
+use aether_kinds::{DrawTriangle, MeshLoadResult, ReadResult, Render, Vertex};
 use aether_math::Vec3;
 use aether_mesh::{Point3, Polygon, tessellate_polygon};
 
@@ -101,22 +102,32 @@ impl FfiActor for MeshViewer {
     }
 
     //noinspection DuplicatedCode
-    /// Issue 640: subscribe to `Tick` so the cached triangles re-emit
-    /// per frame. Lives in `wire` (post-init, mail-allowed); `init`
-    /// itself is `Resolver`-only.
+    /// Issue 640 / 1378: subscribe to the `Render` lifecycle stage so the
+    /// cached triangles re-emit once per frame, after the `Tick` chain
+    /// has settled (ADR-0082 §11). The viewer has no per-tick compute —
+    /// it only re-emits — so it subscribes `Render` alone, not `Tick`.
+    /// Lives in `wire` (post-init, mail-allowed); `init` is
+    /// `Resolver`-only.
+    ///
+    /// On a chassis whose lifecycle graph omits `Render` (headless), the
+    /// cap replies `Err(UnsupportedStage)` to this fire-and-forget
+    /// subscribe; the reply warn-drops and the viewer simply never
+    /// receives `Render` and never submits — a no-op there, where the
+    /// render cap discards anyway (ADR-0082 §7 / §11).
     fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
-        ctx.actor::<InputCapability>()
-            .subscribe(Tick::ID, MailboxId(ctx.mailbox_id()));
+        ctx.actor::<LifecycleCapability>()
+            .subscribe(Render::ID, MailboxId(ctx.mailbox_id()));
     }
 
-    /// Re-emits every cached triangle to the render sink.
+    /// Re-emits every cached triangle to the render sink on the `Render`
+    /// stage.
     ///
     /// # Agent
     /// Substrate-driven; do not send manually. If no triangles render
     /// after a `load`, the file failed to read / parse / mesh — check
     /// `engine_logs`.
     #[handler]
-    fn on_tick(&mut self, ctx: &mut FfiCtx<'_>, _tick: Tick) {
+    fn on_render(&mut self, ctx: &mut FfiCtx<'_>, _render: Render) {
         if !self.triangles.is_empty() {
             ctx.actor::<RenderCapability>().send_many(&self.triangles);
         }

--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -29,7 +29,7 @@ use aether_capabilities::{
     fs::NamespaceRoots, http::HttpConfig, trace::TraceDispatchCapability,
 };
 use aether_data::{Kind, MailboxId as DataMailboxId, mailbox_id_from_name};
-use aether_kinds::{Shutdown, Tick};
+use aether_kinds::{Render, Shutdown, Tick};
 use aether_substrate::chassis::Chassis;
 use aether_substrate::chassis::builder::Builder;
 use aether_substrate::config::{KnobKind, KnobRecord, KnownKeys, dump_config, known_keys};
@@ -181,6 +181,48 @@ pub fn tick_only_lifecycle_config() -> LifecycleConfig {
     }
 }
 
+/// Build the two-stage frame lifecycle config the display-driving
+/// chassis share (ADR-0082 §11, issue 1378): `Tick → Render → Tick`
+/// (looping), with the `Quit` escape to a `Shutdown` terminal on the
+/// `Tick` stage. The chassis drives a full `Tick → Render` cycle per
+/// frame; `Render` broadcasts only after the entire `Tick` chain has
+/// settled (ADR-0080 §6), so a render producer's `on_render` runs once
+/// every actor's per-frame `Tick` compute is done — no submitting
+/// against half-updated cross-actor state.
+///
+/// Same `initial_subscribers` relay as [`tick_only_lifecycle_config`]
+/// (`Tick → aether.input`), so the existing `InputCapability::on_tick`
+/// fan-out keeps routing `Tick` to component subscribers. Desktop and
+/// `test_bench` adopt this graph; headless stays
+/// [`tick_only_lifecycle_config`] (its render cap is a no-op, so a
+/// `Render` stage would settle to no GPU work). `Present` is deferred —
+/// it would be an empty-subscriber broadcast whose only role is a
+/// `Quit → Shutdown` drain edge, and no chassis routes OS-close through
+/// `Quit` mail yet.
+///
+/// # Panics
+/// Panics if the (compile-time-fixed) graph fails to build — it can't,
+/// the shape is structurally valid; the `expect` documents the
+/// invariant.
+#[must_use]
+pub fn frame_lifecycle_config() -> LifecycleConfig {
+    let graph = LifecycleGraphData::builder()
+        .state::<Tick>()
+        .next::<Render>()
+        .quit::<Shutdown>()
+        .state::<Render>()
+        .next::<Tick>()
+        .terminal::<Shutdown>()
+        .start::<Tick>()
+        .build()
+        .expect("frame lifecycle graph is structurally valid");
+    let input_mailbox = DataMailboxId(mailbox_id_from_name(InputCapability::NAMESPACE).0);
+    LifecycleConfig {
+        graph,
+        initial_subscribers: vec![(<Tick as Kind>::ID, input_mailbox)],
+    }
+}
+
 /// Args every full-stack chassis hands to [`with_common_caps`]. Kept
 /// as a flat struct (no defaults) so an added cap forces the chassis
 /// builders to acknowledge it.
@@ -244,6 +286,47 @@ pub fn maybe_with_rpc_server<C: Chassis>(
 #[cfg(test)]
 mod tests {
     use super::chassis_known_keys;
+
+    #[test]
+    fn frame_lifecycle_graph_is_tick_render_with_shutdown_terminal() {
+        // ADR-0082 §11 / issue 1378: the display-driving chassis graph is
+        // `Tick → Render → Tick` (looping) with the `Quit` escape to a
+        // `Shutdown` terminal on the `Tick` stage. The graph's edge
+        // accessors are `pub(crate)` to `aether-capabilities`, so this
+        // crate-boundary check reads the public `Debug` (start + the
+        // non-terminal state kinds + terminals) plus the preserved
+        // `initial_subscribers` relay.
+        use aether_data::Kind;
+        use aether_kinds::{Render, Shutdown, Tick};
+
+        let cfg = super::frame_lifecycle_config();
+        let graph_dbg = format!("{:?}", cfg.graph);
+        let tick = format!("{:?}", <Tick as Kind>::ID);
+        let render = format!("{:?}", <Render as Kind>::ID);
+        let shutdown = format!("{:?}", <Shutdown as Kind>::ID);
+
+        // Start state is Tick.
+        assert!(
+            graph_dbg.contains(&format!("start: {tick}")),
+            "expected start Tick in {graph_dbg}",
+        );
+        // Both Tick and Render are non-terminal states.
+        assert!(
+            graph_dbg.contains(&render),
+            "expected a Render state in {graph_dbg}",
+        );
+        // Shutdown is the sole terminal.
+        assert!(
+            graph_dbg.contains(&format!("terminals: [{shutdown}]")),
+            "expected Shutdown terminal in {graph_dbg}",
+        );
+
+        // The `Tick → aether.input` relay is preserved, identical to the
+        // tick-only config, so the InputCapability fan-out keeps routing
+        // Tick to component subscribers.
+        assert_eq!(cfg.initial_subscribers.len(), 1);
+        assert_eq!(cfg.initial_subscribers[0].0, <Tick as Kind>::ID);
+    }
 
     #[test]
     fn chassis_known_keys_includes_scheduler_hot_path_knobs() {

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -33,8 +33,8 @@ use winit::event_loop::EventLoop;
 
 use super::driver::{DesktopDriverCapability, parse_window_mode_env};
 use crate::chassis_common::{
-    CommonBoot, PersistOverride, chassis_known_keys, maybe_with_rpc_server,
-    tick_only_lifecycle_config, with_common_caps,
+    CommonBoot, PersistOverride, chassis_known_keys, frame_lifecycle_config, maybe_with_rpc_server,
+    with_common_caps,
 };
 use crate::cli::{CommonOverlay, DesktopCli};
 use crate::hub;
@@ -454,7 +454,7 @@ impl DesktopChassis {
             .with_actor::<AudioCapability>(audio)
             .with_actor::<RenderCapability>(render_config)
             .with_actor::<UnsupportedTestBenchCapability>(())
-            .with_actor::<LifecycleCapability>(tick_only_lifecycle_config());
+            .with_actor::<LifecycleCapability>(frame_lifecycle_config());
         let builder = maybe_with_rpc_server(builder, rpc_addr, "aether-desktop");
         builder.driver(driver).build()
     }

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -27,9 +27,9 @@ use aether_capabilities::RenderHandles;
 use aether_data::Kind;
 use aether_data::{encode, encode_empty, mailbox_id_from_name};
 use aether_kinds::{
-    CaptureFrameResult, FocusWindow, FocusWindowResult, Key, KeyRelease, MouseButton, MouseMove,
-    SetWindowMode, SetWindowModeResult, SetWindowTitle, SetWindowTitleResult, Tick, WindowMode,
-    WindowSize, keycode,
+    CaptureFrameResult, FocusWindow, FocusWindowResult, Key, KeyRelease, LifecycleAdvanceComplete,
+    MouseButton, MouseMove, SetWindowMode, SetWindowModeResult, SetWindowTitle,
+    SetWindowTitleResult, Tick, WindowMode, WindowSize, keycode,
 };
 use aether_substrate::actor::native::envelope::Envelope;
 use aether_substrate::actor::native::{
@@ -43,9 +43,9 @@ use aether_substrate::chassis::settlement::{
 };
 use aether_substrate::runtime::lifecycle;
 use aether_substrate::{
-    HubOutbound, Mailer, SharedActorSlots, SubstrateBoot,
+    HubOutbound, Mailer, ReplyTarget, ReplyTo, SharedActorSlots, SubstrateBoot,
     chassis::frame_loop,
-    mail::{MailId, MailboxId},
+    mail::{Mail, MailId, MailboxId},
 };
 use winit::application::ApplicationHandler;
 use winit::event::{ElementState, WindowEvent};
@@ -81,6 +81,20 @@ pub struct App {
     /// relay, then waits for settlement before submitting the frame.
     lifecycle_mailbox: MailboxId,
     kind_lifecycle_advance: aether_data::KindId,
+    /// `aether.lifecycle.advance_reply` inbox claimed at boot (issue
+    /// 1378). The per-frame `Tick → Render` cycle pushes each
+    /// `LifecycleAdvance` with this mailbox as its `Component` reply
+    /// target, then synchronously drains the receiver for the cap's
+    /// `LifecycleAdvanceComplete` reply. The reply is emitted only after
+    /// the cap clears its pending-advance guard (ADR-0082 §6), so gating
+    /// the next advance on it — rather than on the raw settlement channel
+    /// — keeps the back-to-back advances from racing the cap's overlap
+    /// guard (the same reply-gate the test-bench frame loop uses,
+    /// iamacoffeepot/aether#999).
+    lifecycle_reply_inbox: Receiver<Envelope>,
+    /// Mailbox id of [`Self::lifecycle_reply_inbox`], used as the
+    /// `Component` reply target stamped onto each `LifecycleAdvance`.
+    lifecycle_reply_mailbox: MailboxId,
     kind_key: aether_data::KindId,
     kind_key_release: aether_data::KindId,
     kind_mouse_button: aether_data::KindId,
@@ -464,6 +478,69 @@ impl App {
             .push_chassis_root_mail(correlation, recipient, kind, payload, count)
     }
 
+    /// Mint a chassis-root `LifecycleAdvance` and push it to the
+    /// `aether.lifecycle` cap with [`Self::lifecycle_reply_mailbox`] as
+    /// its `Component` reply target (issue 1378). Open-codes the
+    /// chassis-root push (`push_chassis_root_mail` doesn't carry a reply
+    /// target): mint id → record `Sent` for the trace subtree → push with
+    /// both the chassis-root lineage and the reply-to. Returns the minted
+    /// chain root so the caller can subscribe its settlement.
+    fn push_lifecycle_advance(&self) -> MailId {
+        let mut correlation = self.chassis_correlation.fetch_add(1, Ordering::Relaxed);
+        if correlation == 0 {
+            correlation = self.chassis_correlation.fetch_add(1, Ordering::Relaxed);
+        }
+        let advance_root = MailId::new(MailboxId::CHASSIS_MAILBOX_ID, correlation);
+        self.queue.record_sent(
+            advance_root,
+            advance_root,
+            None,
+            MailboxId::CHASSIS_MAILBOX_ID,
+            self.lifecycle_mailbox,
+            self.kind_lifecycle_advance,
+        );
+        let reply_to = ReplyTo::with_correlation(
+            ReplyTarget::Component(self.lifecycle_reply_mailbox),
+            correlation,
+        );
+        self.queue.push(
+            Mail::new(
+                self.lifecycle_mailbox,
+                self.kind_lifecycle_advance,
+                encode_empty::<aether_kinds::LifecycleAdvance>(),
+                1,
+            )
+            .with_lineage(advance_root, advance_root, None)
+            .with_reply_to(reply_to),
+        );
+        advance_root
+    }
+
+    /// Block (bounded) for the `LifecycleAdvanceComplete` reply to the
+    /// just-issued `LifecycleAdvance`, returning its `next` stage kind id
+    /// (issue 1378). The reply lands on [`Self::lifecycle_reply_inbox`]
+    /// and is emitted by the cap *after* it clears its pending-advance
+    /// guard, so the caller can safely issue the next advance once this
+    /// returns. The settlement wait the caller runs first guarantees the
+    /// reply is imminent; the generous timeout is a wedge backstop, not
+    /// the normal path. `None` on timeout (no reply after settlement) so
+    /// the caller can fail-fast.
+    fn recv_lifecycle_advance_next(&self) -> Option<u64> {
+        loop {
+            let env = self
+                .lifecycle_reply_inbox
+                .recv_timeout(FRAME_SETTLEMENT_CAP)
+                .ok()?;
+            if env.kind == <LifecycleAdvanceComplete as Kind>::ID {
+                return LifecycleAdvanceComplete::decode_from_bytes(env.payload.bytes())
+                    .map(|complete| complete.next);
+            }
+            // Any other kind on this dedicated reply inbox is unexpected
+            // (nothing else targets it); drop and keep waiting for the
+            // advance reply rather than mis-gating the cycle.
+        }
+    }
+
     fn apply_window_mode(
         &mut self,
         mode: WindowMode,
@@ -800,44 +877,67 @@ impl ApplicationHandler<UserEvent> for App {
                 if self.occluded && pending_capture.is_none() {
                     return;
                 }
-                // ADR-0082 §6 / PR 3c: redraw fires `LifecycleAdvance`
-                // to the lifecycle driver, which broadcasts Tick to
-                // `aether.input` (via the chassis's `initial_subscribers`
-                // relay) plus any other subscribers. Components emit
-                // their `DrawTriangle` / `aether.camera` mail into render
-                // as descendants of this advance's chain root. Waiting
-                // for that root to settle before submit guarantees the
-                // frame's geometry is integrated — the causal-completion
-                // replacement for the retired `drain_frame_bound_or_abort`
-                // pending-counter poll.
-                let advance_root = self.push_chassis_root(
-                    self.lifecycle_mailbox,
-                    self.kind_lifecycle_advance,
-                    encode_empty::<aether_kinds::LifecycleAdvance>(),
-                    1,
-                );
+                // Publish the live window size once per frame so
+                // `WindowSize` subscribers (the camera's aspect tracking)
+                // read it during the Tick stage.
                 if let Some(window) = &self.window {
                     let size = window.inner_size();
                     if size.width != 0 && size.height != 0 {
                         self.publish_window_size(size.width, size.height);
                     }
                 }
-                if let Some(registry) = self.queue.settlement_registry() {
-                    let rx = registry.subscribe_settlement(advance_root);
-                    // A frame chain that doesn't settle is a wedged
-                    // dispatcher — same fail-fast disposition the old
-                    // drain barrier had (ADR-0063). Escalating-patience
-                    // wait (issue #1305) replaces the bare wall-clock:
-                    // a starved-but-healthy chain resolves before the
-                    // cumulative cap, a genuine wedge exhausts it.
-                    if let WaitOutcome::Wedged(wedge) = await_internal_signal(
-                        &rx,
-                        "desktop.frame_advance",
-                        frame_loop::DRAIN_BUDGET,
-                        FRAME_SETTLEMENT_CAP,
-                        TerminalDisposition::Abort,
-                    ) {
-                        lifecycle::fatal_abort(&self.outbound, wedge.reason());
+                // ADR-0082 §11 / issue 1378: drive one full `Tick → Render`
+                // cycle. Each `LifecycleAdvance` broadcasts the cap's
+                // current stage; components emit their `DrawTriangle` /
+                // `aether.camera` mail into render as descendants of that
+                // advance's chain root. We wait for the broadcast root to
+                // settle (ADR-0080 §6 — the causal-completion replacement
+                // for the retired `drain_frame_bound_or_abort` poll), then
+                // read `LifecycleAdvanceComplete.next` to learn the cap's
+                // resolved next stage and loop until it returns to `Tick`
+                // (one full cycle) or reaches a terminal. Reading the reply
+                // — not the raw settlement channel — gates the next advance
+                // on the cap having cleared its pending-advance guard, so
+                // the back-to-back advances never race it
+                // (iamacoffeepot/aether#999). GPU submit + present below
+                // runs after the `Render` chain settles, so every actor's
+                // per-frame Tick compute and Render submission is
+                // integrated before readback.
+                loop {
+                    let advance_root = self.push_lifecycle_advance();
+                    if let Some(registry) = self.queue.settlement_registry() {
+                        let rx = registry.subscribe_settlement(advance_root);
+                        // A frame chain that doesn't settle is a wedged
+                        // dispatcher — same fail-fast disposition the old
+                        // drain barrier had (ADR-0063). Escalating-patience
+                        // wait (issue #1305) replaces the bare wall-clock:
+                        // a starved-but-healthy chain resolves before the
+                        // cumulative cap, a genuine wedge exhausts it.
+                        if let WaitOutcome::Wedged(wedge) = await_internal_signal(
+                            &rx,
+                            "desktop.frame_advance",
+                            frame_loop::DRAIN_BUDGET,
+                            FRAME_SETTLEMENT_CAP,
+                            TerminalDisposition::Abort,
+                        ) {
+                            lifecycle::fatal_abort(&self.outbound, wedge.reason());
+                        }
+                    }
+                    match self.recv_lifecycle_advance_next() {
+                        // Back at Tick (cycle complete) or a terminal
+                        // (`next == 0`) — stop and present.
+                        Some(next) if next == <Tick as Kind>::ID.0 || next == 0 => break,
+                        // Mid-cycle (Tick → Render) — keep advancing.
+                        Some(_) => {}
+                        // Settlement fired but the reply never arrived —
+                        // a wedge in the reply path; fail-fast like the
+                        // settlement wait above.
+                        None => lifecycle::fatal_abort(
+                            &self.outbound,
+                            "desktop.frame_advance: LifecycleAdvanceComplete reply did not \
+                             arrive after settlement"
+                                .to_owned(),
+                        ),
                     }
                 }
                 if let Some(gpu) = self.gpu.as_mut() {
@@ -1072,6 +1172,13 @@ impl DriverCapability for DesktopDriverCapability {
         let lifecycle_mailbox =
             mailbox_id_from_name(<aether_capabilities::LifecycleCapability as Actor>::NAMESPACE);
         let kind_lifecycle_advance = <aether_kinds::LifecycleAdvance as Kind>::ID;
+
+        // Issue 1378: claim a dedicated inbox for the cap's
+        // `LifecycleAdvanceComplete` replies. The per-frame `Tick →
+        // Render` cycle stamps this as the `Component` reply target on
+        // each `LifecycleAdvance` and drains the receiver synchronously
+        // to gate the next advance (see `recv_lifecycle_advance_next`).
+        let lifecycle_reply_claim = ctx.claim_mailbox("aether.lifecycle.advance_reply")?;
         let _ = kind_tick; // PR 3b retired direct Tick push; the
         // chassis still resolves the kind id via `boot.registry` for
         // compatibility but the redraw handler no longer reads it.
@@ -1081,6 +1188,8 @@ impl DriverCapability for DesktopDriverCapability {
             input_mailbox: mailbox_id_from_name(InputCapability::NAMESPACE),
             lifecycle_mailbox,
             kind_lifecycle_advance,
+            lifecycle_reply_inbox: lifecycle_reply_claim.receiver,
+            lifecycle_reply_mailbox: lifecycle_reply_claim.id,
             kind_key,
             kind_key_release,
             kind_mouse_button,

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -33,7 +33,6 @@ use std::time::{Duration, Instant};
 #[cfg(test)]
 use aether_capabilities::trace_walk::TreeWalk;
 use aether_data::{Kind, KindId, SessionToken, Uuid, encode_empty};
-#[cfg(test)]
 use aether_kinds::Tick;
 #[cfg(test)]
 use aether_kinds::trace::{DescribeTreeResult, TraceTail, TraceTailResult};
@@ -967,45 +966,60 @@ impl TestBench {
             // settlement). Reuses the same reply-correlated loopback wait
             // (`pump_until_reply`) the `advance()` / `capture()` API
             // methods already use, rather than a bespoke channel.
-            let cid = self.fresh_correlation_id();
-            // Mint a chassis-root `LifecycleAdvance` (so the trace
-            // pipeline tracks the broadcast subtree and `on_settled`
-            // fires) that *also* carries this bench's session as the
-            // reply target — the driver routes `LifecycleAdvanceComplete`
-            // there via `on_settled`'s `ctx.reply_to`. `push_chassis_root_mail`
-            // doesn't take a reply target, so the chassis-root push is
-            // open-coded here (mint id → record `Sent` → push with both
-            // lineage and reply-to), mirroring its three steps.
-            let advance_root =
-                MailId::new(MailboxId::CHASSIS_MAILBOX_ID, self.fresh_correlation_id());
-            self.queue.record_sent(
-                advance_root,
-                advance_root,
-                None,
-                MailboxId::CHASSIS_MAILBOX_ID,
-                self.lifecycle_mailbox,
-                self.kind_lifecycle_advance,
-            );
-            let reply_to = ReplyTo::with_correlation(ReplyTarget::Session(self.session), cid);
-            self.queue.push(
-                Mail::new(
+            // ADR-0082 §11 / issue 1378: the frame graph is `Tick →
+            // Render → Tick`, so one requested tick drives a full
+            // two-stage cycle. Each iteration pushes one `LifecycleAdvance`
+            // (broadcasting the cap's current stage) and blocks on its
+            // `LifecycleAdvanceComplete` reply, reading `next` to learn the
+            // cap's resolved next stage; the loop exits once it returns to
+            // `Tick` (cycle complete) or reaches a terminal (`next == 0`).
+            // The reply gate is exactly the #999 fix below — emitted only
+            // after the cap clears `pending`, so the next iteration's
+            // advance never races the overlap guard.
+            loop {
+                let cid = self.fresh_correlation_id();
+                // Mint a chassis-root `LifecycleAdvance` (so the trace
+                // pipeline tracks the broadcast subtree and `on_settled`
+                // fires) that *also* carries this bench's session as the
+                // reply target — the driver routes `LifecycleAdvanceComplete`
+                // there via `on_settled`'s `ctx.reply_to`. `push_chassis_root_mail`
+                // doesn't take a reply target, so the chassis-root push is
+                // open-coded here (mint id → record `Sent` → push with both
+                // lineage and reply-to), mirroring its three steps.
+                let advance_root =
+                    MailId::new(MailboxId::CHASSIS_MAILBOX_ID, self.fresh_correlation_id());
+                self.queue.record_sent(
+                    advance_root,
+                    advance_root,
+                    None,
+                    MailboxId::CHASSIS_MAILBOX_ID,
                     self.lifecycle_mailbox,
                     self.kind_lifecycle_advance,
-                    encode_empty::<aether_kinds::LifecycleAdvance>(),
-                    1,
-                )
-                .with_lineage(advance_root, advance_root, None)
-                .with_reply_to(reply_to),
-            );
-            // Block until the driver replies `LifecycleAdvanceComplete`
-            // for this advance. A `Timeout` here means the chain never
-            // settled (a genuine in_flight leak in some downstream cap)
-            // or the driver never replied — same fail-loud disposition
-            // the prior `SettlementTimeout` had.
-            self.pump_until_reply::<aether_kinds::LifecycleAdvanceComplete>(
-                cid,
-                "LifecycleAdvanceComplete",
-            )?;
+                );
+                let reply_to = ReplyTo::with_correlation(ReplyTarget::Session(self.session), cid);
+                self.queue.push(
+                    Mail::new(
+                        self.lifecycle_mailbox,
+                        self.kind_lifecycle_advance,
+                        encode_empty::<aether_kinds::LifecycleAdvance>(),
+                        1,
+                    )
+                    .with_lineage(advance_root, advance_root, None)
+                    .with_reply_to(reply_to),
+                );
+                // Block until the driver replies `LifecycleAdvanceComplete`
+                // for this advance. A `Timeout` here means the chain never
+                // settled (a genuine in_flight leak in some downstream cap)
+                // or the driver never replied — same fail-loud disposition
+                // the prior `SettlementTimeout` had.
+                let complete = self.pump_until_reply::<aether_kinds::LifecycleAdvanceComplete>(
+                    cid,
+                    "LifecycleAdvanceComplete",
+                )?;
+                if complete.next == <Tick as Kind>::ID.0 || complete.next == 0 {
+                    break;
+                }
+            }
         }
         // ADR-0082 §6 / PR 3c: the advance settlement above already
         // waited for the whole frame chain (Tick → component →

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -28,7 +28,7 @@ use aether_substrate::{
 
 use super::cap::{TestBenchCapConfig, TestBenchCapability};
 use super::events::{ChassisEvent, EventSender};
-use crate::chassis_common::tick_only_lifecycle_config;
+use crate::chassis_common::frame_lifecycle_config;
 use aether_substrate::mail::registry::MailDispatch;
 use std::io;
 
@@ -311,7 +311,7 @@ impl TestBenchChassis {
             .with_actor::<RenderCapability>(render_config)
             .with_actor::<HeadlessWindowCapability>(())
             .with_actor::<TestBenchCapability>(test_bench_cap_config)
-            .with_actor::<LifecycleCapability>(tick_only_lifecycle_config());
+            .with_actor::<LifecycleCapability>(frame_lifecycle_config());
         if let Some(roots) = io_roots {
             builder = builder.with_actor::<FsCapability>(roots);
         }

--- a/docs/adr/0082-application-declared-lifecycle-sequence.md
+++ b/docs/adr/0082-application-declared-lifecycle-sequence.md
@@ -187,6 +187,15 @@ The actor framework's per-actor boot sequence (`claim → init → wire → spaw
 
 Initialisation has the symmetric split: actor-framework `init` is the per-actor "construct your state" callback before mail can arrive; `InitCaps` / `InitComponents` stage broadcasts (§5) are mail that arrives once the actor is fully wired and the driver enters its loop. Use `init` for "load-bearing state that must exist before any handler runs"; use an `InitCaps` / `InitComponents` handler for cross-actor wiring that depends on peers being ready (e.g. a cap that needs to send the hub its kind manifest after the hub cap has wired its receive side).
 
+### 13. Realization — per-chassis frame graphs (issue 1378)
+
+The concrete per-chassis graphs shipped after the lifecycle cap landed (#1380 / #1383). This section records what each chassis declares, versus the `Tick → Render → Present` shape sketched in §1.
+
+- **Desktop + test_bench** declare a two-stage `Tick → Render → Tick` graph (looping), with the `Quit` escape to a `Shutdown` terminal on the `Tick` stage (`frame_lifecycle_config` in `aether-substrate-bundle::chassis_common`). The chassis drives a full `Tick → Render` cycle per frame: it issues `LifecycleAdvance` repeatedly, gating each on the cap's `LifecycleAdvanceComplete` reply (emitted only after the cap clears its pending-advance guard, so the back-to-back advances never race it — the same reply-gate the test-bench loop uses for iamacoffeepot/aether#999), until `next` returns to `Tick`. GPU submit + present runs after the `Render` chain settles. The render-producing actors (`aether-camera`, `aether-mesh-viewer`) compute on `Tick` and submit to `aether.render` on `Render`, so a submission integrates the fully-settled cross-actor state of the frame.
+- **Headless** stays tick-only (`tick_only_lifecycle_config`). Its render cap is a no-op (it discards `DrawTriangle` / `aether.camera`), so a `Render` stage would settle to no GPU work. The camera / mesh-viewer subscribe `Render` unconditionally in `wire`; on headless that subscribe gets `Err(UnsupportedStage)` (§7), which warn-drops on the fire-and-forget path — the component simply never receives `Render` and never submits, a no-op there.
+- **`Present` is deferred.** It would be an empty-subscriber broadcast whose only role is a home for a `Quit → Shutdown` drain edge, but no chassis routes OS-close through `Quit` mail today (desktop's `WindowEvent::CloseRequested` calls `event_loop.exit()` directly), so the edge has no consumer. `Present` re-enters alongside graceful `Quit → Shutdown` shutdown (see Follow-up work).
+- **No new ADR / no kind rename.** The stage reuses the already-shipped `aether.lifecycle.render` kind; the `Render` rustdoc in `aether-kinds` is tightened to the producer-submits-on-`Render` model.
+
 ## Consequences
 
 ### Positive


### PR DESCRIPTION
Closes iamacoffeepot/aether#1378.

## Summary

Adds a `Render` lifecycle stage (ADR-0082) so render-producing actors submit *after* the whole `Tick` chain has settled, instead of computing and submitting on the same `Tick` handler against half-updated cross-actor state.

- **`frame_lifecycle_config()`** (`chassis_common.rs`) — a two-stage `Tick → Render → Tick` graph (looping), `Quit → Shutdown` on `Tick`. Desktop + test_bench adopt it; headless stays tick-only (its render cap is a no-op).
- **Desktop + test_bench** drive a full `Tick → Render` cycle per frame and submit/present the GPU frame after the `Render` chain settles.
- **`aether-camera`** advances per-mode state on `Tick`, publishes the active camera's `view_proj` on a new `on_render`. **`aether-mesh-viewer`** drops its `Tick` subscribe for `Render` (it only re-emits) and submits triangles on `on_render`.
- `Present` is deferred — it would be an empty-subscriber broadcast whose only role is a `Quit → Shutdown` drain edge, and no chassis routes OS-close through `Quit` mail yet. Re-enters with graceful shutdown (a §Side follow-up).
- Docs: tightened the `Render` kind rustdoc to the producer-submits-on-`Render` model; ADR-0082 gains a §13 realization note recording the per-chassis verdict.

This resolves the publish-ordering requirement that #1479 (the fly controller) depends on — the camera's `view_proj` is now emitted after the tick's control mail is applied, by construction.

### Reviewer note — desktop driver deviation

The desktop driver needed plumbing the plan did not spell out, to avoid the iamacoffeepot/aether#999 race. Driving two back-to-back advances per frame gated only on the raw settlement channel can hit the cap's pending-advance overlap guard while the `Settled` mail is still enqueued, dropping the `Render` broadcast. So the driver now claims a dedicated `aether.lifecycle.advance_reply` inbox, stamps each `LifecycleAdvance` with it as the `Component` reply target, and gates the next advance on the cap's `LifecycleAdvanceComplete` reply (emitted only after the cap clears its guard) — the same reply-gate the test-bench loop uses. The cap replies via `Mailer::send_reply`, which honors `ReplyTarget::Component`, so the reply lands in the claimed inbox. This is the one path CI cannot cover (desktop needs a display); the test-bench path uses the same reply-gating logic and is tested. Worth a careful read of `desktop/driver.rs` (`push_lifecycle_advance` / `recv_lifecycle_advance_next` / the `RedrawRequested` loop).

## Test plan

- Full local pre-flight green: fmt, clippy `--workspace --all-targets -D warnings`, doc, wasm32 component cross-build, `cargo nextest run --workspace --all-features` (1559 passed, 6 skipped).
- Camera + mesh-viewer scenario tests load the rebuilt wasm and exercise the new `on_render` path through the test-bench frame graph — rendered pixels unchanged.
- FleetBench tests spawn a real headless substrate and load/replace the camera wasm (which subscribes `Render` unconditionally), confirming the headless `Err(UnsupportedStage)` reply warn-drops without panicking.
- `input_subscription_yields_one_tick_observed_per_advance` confirms the cycle still yields exactly one tick per requested advance.

## Generated by

Agent execution of scoped issue #1378 via the release implement flow.
