### PR TITLE
docs(readme): refresh stale README and expand for newcomers and agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,77 @@
 
 An application engine — built for games — developed collaboratively with Claude.
 
-The vision is a harness where Claude sits as assistant, engineer, and designer — driving a running engine, observing it, modifying it. The architecture is a thin native **substrate** that owns I/O, GPU, and audio and hosts a WebAssembly runtime; engine **components** run as WASM modules and communicate with the substrate and with each other through a **mail** system.
+The vision is a harness where Claude sits as assistant, engineer, and designer — driving a running engine, observing it, modifying it. A thin native **substrate** owns I/O, GPU, and audio and hosts a WebAssembly runtime; engine **actors** — WASM components and native chassis capabilities — run on the substrate and communicate with it and with each other only through **mail**.
 
-## Reading the codebase
+## Status
 
-- Architectural decisions are recorded as ADRs under `docs/adr/`. Read in order to follow the design as it evolved; the latest ADRs describe current commitments.
-- `CLAUDE.md` at the repo root is the working-directory guide for collaborating in this codebase.
+Pre-1.0 Rust project (edition 2024). The design is still moving; the ADRs under `docs/adr/` are the record of what is committed and why.
 
-## Component layout (ADR-0066, amended by issue 552 stage 1.5)
+## Repository layout
 
-A component lives in one dual-output crate (`crate-type = ["cdylib", "rlib"]`):
+Infrastructure crates (no actor of their own):
 
-- The crate's **rlib** is the public API for *talking to* the component — kind types (the mail shapes other components send to it), parameter structs, helpers. Other components import it for the wire shapes.
-- The crate's **cdylib** is the deployable wasm. The runtime (`#[actor] impl WasmActor for …`) sits next to the trunk types in the same crate; the wasm `export!()` invocation produces the FFI exports the substrate links against. The host-target rlib build leaves those exports inert so integration tests can link the same artifact.
+- **`aether-data`** — the universal data layer (`no_std` + `alloc`): typed-id newtypes, wire identity, the schema vocabulary, and the `Kind` / `Schema` traits everything else builds on. Proc macros live in `aether-data-derive`.
+- **`aether-codec`** — schema-driven JSON ↔ wire-byte conversion plus length-prefixed stream framing.
+- **`aether-kinds`** — the substrate's own kind vocabulary (ticks, input, render, audio, window, filesystem, …).
+- **`aether-math`** — `Vec*`, `Mat4`, `Quat`, `Aabb` (`no_std`, column-major, right-handed Y-up).
 
-Examples in-tree: `aether-camera`, `aether-mesh-viewer`. Third parties follow the same shape (`coffeepots-thing`); the convention is symmetric and not first-party-privileged. `aether-kinds` is reserved for chassis primitives the substrate itself emits or consumes. ADR-0066's prior `<thing>` + `<thing>-component` two-crate split was consolidated by issue 552 stage 1.5 — the cdylib + rlib pair lives in one crate now.
+Runtime and chassis:
+
+- **`aether-substrate`** — the shared native runtime (scheduler, mail queue, WASM host).
+- **`aether-capabilities`** — native chassis capabilities (render, audio, filesystem, input, …).
+- **`aether-substrate-bundle`** — the four chassis as binaries (see below), plus the hub client and the in-process test bench.
+
+Actor SDK:
+
+- **`aether-actor`** — the guest SDK: the `Actor` / `FfiActor` traits, `Mailbox<K>`, `FfiCtx`, the `#[actor]` macro, and `export!`. Macros live in `aether-actor-derive`.
+
+Reference actors and tools: **`aether-camera`** and **`aether-mesh-viewer`** (components), **`aether-mesh`** (a mesh DSL + mesher), and **`aether-mcp`** (the out-of-process MCP harness Claude drives the engine through).
+
+## Building and running
+
+```sh
+cargo build                       # debug build of the workspace (release: --release)
+cargo nextest run --workspace     # run the test suite
+cargo clippy --all-targets -- -D warnings
+cargo fmt
+```
+
+The workspace root has no default binary. The chassis binaries all live in `aether-substrate-bundle`; pick one with `--bin`:
+
+```sh
+cargo run -p aether-substrate-bundle --bin aether-substrate          # desktop (windowed, GPU)
+cargo run -p aether-substrate-bundle --bin aether-substrate-headless # headless (timer-driven ticks)
+cargo run -p aether-substrate-bundle --bin aether-substrate-hub      # hub (supervises a fleet of engines)
+```
+
+## Driving the engine (the MCP harness)
+
+Claude drives a running engine through MCP — the concrete form of the "Claude-in-harness" vision. The harness (`aether-mcp`) is an RPC client that relays each tool call to the hub as wire mail, fronted by a long-lived tunnel so the volatile backends can restart without dropping the MCP session. Bring the stack up with `scripts/ensure-tunnel.sh` (idempotent). From there an agent spawns substrates, loads components, sends mail, captures frames, runs computation DAGs, and reads per-actor logs.
+
+The tools and the process topology are documented in `CLAUDE.md` (the *MCP harness* section) and in `docs/guide/mcp-harness.md`.
+
+## Writing a component
+
+A component is an actor: an `#[actor] impl FfiActor for C` block declaring handlers, plus an `export!(C)` that emits the FFI shims the substrate links against. Address peers and chassis capabilities by type (`ctx.actor::<RenderCapability>().send(&kind)`); mail is fire-and-forget unless a reply kind is noted. See [Writing components](CLAUDE.md#writing-components) in `CLAUDE.md` for the full shape.
+
+A component lives in one crate that produces both outputs (`crate-type = ["cdylib", "rlib"]`):
+
+- The crate's **rlib** is the public API for *talking to* the component — the kind types (mail shapes), parameter structs, and helpers that other components import to build the wire shapes they send it.
+- The crate's **cdylib** is the deployable wasm. The runtime (the `FfiActor` impl) lives in the crate's `runtime` module behind a default-on `runtime` feature; under `wasm32` the `export!()` invocation produces the component's FFI exports. The host-target rlib build leaves those exports inert, so integration tests link the same artifact. A consumer that only needs the kind types opts out with `default-features = false`.
+
+Reference components in-tree: `aether-camera` and `aether-mesh-viewer`. Third-party components follow the same shape — the convention is symmetric, not first-party-privileged. `aether-kinds` is reserved for the chassis primitives the substrate itself emits or consumes.
+
+## Testing and pre-flight
+
+- **Tests** run under `cargo nextest run --workspace`. Timing-sensitive concurrency tests live in a `mod heavy` submodule so the runner serializes them; see the *Heavy tests* section of `CLAUDE.md`.
+- **Pre-flight**: `scripts/preflight.sh` runs the CI-equivalent checks locally (fmt, clippy, doc, tests, and the wasm32 component cross-build). Install the pre-push hook once per clone with `scripts/setup-githooks.sh`.
+
+## Documentation
+
+- **`CLAUDE.md`** — the working-directory guide: crate map, runtime surfaces, the MCP harness, and the repo conventions. Start here when working in the tree.
+- **`docs/adr/`** — Architecture Decision Records, numbered sequentially. Read the ADR that owns a subsystem before changing it; `docs/adr/TEMPLATE.md` starts a new one.
+- **`docs/guide/`** — the longer-form guide (an mdBook): philosophy, architecture, the type system and actor model, the MCP harness, and the engine systems.
 
 ## License
 


### PR DESCRIPTION
The README had drifted from the codebase and was thin. This refreshes it to the current design and expands it into a usable front door.

## Corrected
- Actor trait renamed in prose from the retired WasmActor to FfiActor.
- Reframed around the actor model (WASM components and native chassis capabilities communicating by mail) rather than "components run as WASM modules".
- Component layout now describes the runtime module behind the default-on runtime feature, instead of the stale "sits next to the trunk types" wording.
- Dropped the project-history framing (issue and stage references, "prior split was consolidated") — reader docs should state the present design.

## Added
- Status — pre-1.0, edition 2024.
- Repository layout — a condensed crate map grouped by role.
- Building and running — the workspace commands and the three runnable chassis binaries.
- Driving the engine — what the MCP harness is and how to bring it up, linking the deeper docs.
- Testing and pre-flight — nextest, the heavy-test note, and the pre-flight script plus hook.
- Documentation — a map of CLAUDE.md, the ADRs, and the guide.

Docs-only; verified crate names, bin names, and script paths against the tree.