### PR TITLE
fix(capabilities): unsubscribe lifecycle stage subscriptions on component drop

### DIFF
--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -30,9 +30,9 @@
 #![allow(clippy::needless_pass_by_value)]
 
 use aether_actor::{Actor, FfiActorMailbox};
-#[cfg(not(target_arch = "wasm32"))]
-use aether_kinds::UnsubscribeAll;
 use aether_kinds::{DropComponent, LoadComponent, ReplaceComponent};
+#[cfg(not(target_arch = "wasm32"))]
+use aether_kinds::{LifecycleUnsubscribeAll, UnsubscribeAll};
 #[cfg(not(target_arch = "wasm32"))]
 use aether_substrate::actor::native::NativeActorMailbox;
 
@@ -130,7 +130,9 @@ mod native {
     use aether_kinds::{ComponentCapabilities, LoadResult};
     use wasmtime::{Engine, Linker, Module};
 
-    use super::{DropComponent, LoadComponent, ReplaceComponent, UnsubscribeAll};
+    use super::{
+        DropComponent, LifecycleUnsubscribeAll, LoadComponent, ReplaceComponent, UnsubscribeAll,
+    };
 
     use aether_substrate::actor::native::spawn::Subname;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
@@ -145,6 +147,7 @@ mod native {
     use aether_substrate::mail::{KindId, MailboxId};
 
     use crate::input::InputCapability;
+    use crate::lifecycle::LifecycleCapability;
     use crate::trampoline::{WasmTrampoline, WasmTrampolineConfig};
 
     /// Configuration for [`ComponentHostCapability`]. `engine` and
@@ -227,18 +230,28 @@ mod native {
         /// trampoline's [`WasmTrampoline::on_drop_component`] handler
         /// replies `DropResult::Ok` and shuts itself down.
         ///
+        /// Before forwarding, purges the dying trampoline's mailbox from
+        /// every fan-out subscriber table so no cap keeps firing at a
+        /// dropped mailbox: `aether.input`'s input-stream tables (via
+        /// [`UnsubscribeAll`]) and `aether.lifecycle`'s per-stage tables
+        /// (via [`LifecycleUnsubscribeAll`]).
+        ///
         /// # Agent
         /// `DropComponent { mailbox_id }`. The `mailbox_id` is the
         /// trampoline's id from the `LoadResult.mailbox_id` field.
         #[handler]
         fn on_drop_component(&mut self, ctx: &mut NativeCtx<'_>, payload: DropComponent) {
-            // Cap-side cleanup: ask the input cap to drop the dying
-            // trampoline from every fan-out set. Mail rather than
-            // direct mutation post-issue-640 — `aether.input` is the
-            // sole owner of the subscriber table.
+            // Cap-side cleanup: ask each owning cap to drop the dying
+            // trampoline from its fan-out sets. Mail rather than direct
+            // mutation post-issue-640 — each cap is the sole owner of its
+            // own subscriber table.
             ctx.actor::<InputCapability>().send(&UnsubscribeAll {
                 mailbox: payload.mailbox_id,
             });
+            ctx.actor::<LifecycleCapability>()
+                .send(&LifecycleUnsubscribeAll {
+                    mailbox: payload.mailbox_id.0,
+                });
             self.forward_to_trampoline(ctx, payload.mailbox_id, DropComponent::ID, &payload);
         }
 

--- a/crates/aether-capabilities/src/lifecycle.rs
+++ b/crates/aether-capabilities/src/lifecycle.rs
@@ -40,7 +40,9 @@ use std::marker::PhantomData;
 use aether_actor::FfiActorMailbox;
 use aether_data::{Kind, KindId, MailboxId};
 use aether_kinds::trace::Settled;
-use aether_kinds::{LifecycleAdvance, LifecycleSubscribe, LifecycleUnsubscribe, Quit};
+use aether_kinds::{
+    LifecycleAdvance, LifecycleSubscribe, LifecycleUnsubscribe, LifecycleUnsubscribeAll, Quit,
+};
 // Reply types ride only the native handler bodies (via `super::`), so they
 // elide on wasm where `mod native` is compiled out.
 #[cfg(not(target_arch = "wasm32"))]
@@ -484,7 +486,8 @@ mod native {
 
     use super::{
         LifecycleAdvance, LifecycleAdvanceComplete, LifecycleGraphData, LifecycleStateData,
-        LifecycleSubscribe, LifecycleSubscribeResult, LifecycleUnsubscribe, Quit, Settled,
+        LifecycleSubscribe, LifecycleSubscribeResult, LifecycleUnsubscribe,
+        LifecycleUnsubscribeAll, Quit, Settled,
     };
 
     /// Internal state-advance decision produced by `on_advance` before
@@ -702,6 +705,29 @@ mod native {
                 }
             };
             ctx.reply(&result);
+        }
+
+        /// Remove `mailbox` from every lifecycle stage's subscriber set.
+        /// Issued by `ComponentHostCapability` on `DropComponent` so a
+        /// dropped trampoline doesn't keep receiving stage-broadcast mail
+        /// — the lifecycle-family counterpart of
+        /// [`InputCapability::on_unsubscribe_all`](crate::input::InputCapability),
+        /// which the same drop path notifies for `aether.input`. No
+        /// mailbox-validation: the trampoline's mailbox is already torn
+        /// down by the time this fires; we accept any id and purge it from
+        /// every stage. No reply.
+        ///
+        /// # Agent
+        /// `LifecycleUnsubscribeAll { mailbox }`. Idempotent.
+        #[handler]
+        fn on_unsubscribe_all(
+            &mut self,
+            _ctx: &mut NativeCtx<'_>,
+            payload: LifecycleUnsubscribeAll,
+        ) {
+            for set in self.subscribers.values_mut() {
+                set.remove(&DataMailboxId(payload.mailbox));
+            }
         }
 
         /// Lifecycle escape signal (ADR-0082 §3). Sets `quit_pending =
@@ -1171,6 +1197,44 @@ mod native {
                 "cooldown should suppress the second warn"
             );
         }
+
+        #[test]
+        fn on_unsubscribe_all_purges_mailbox_from_every_stage() {
+            // A dropped trampoline's mailbox must leave every stage's
+            // subscriber set in one shot (the drop-cleanup contract,
+            // mirroring `InputCapability::on_unsubscribe_all`), while
+            // co-subscribers on a shared stage survive.
+            use aether_substrate::actor::native::binding::NativeBinding;
+
+            let mut cap = test_cap(Duration::from_millis(ADVANCE_TIMEOUT_MS_DEFAULT));
+            let dropped = DataMailboxId(0xDEAD);
+            let survivor = DataMailboxId(0xBEEF);
+            let render = <Render as Kind>::ID;
+            let present = <Present as Kind>::ID;
+            cap.subscribers.entry(render).or_default().insert(dropped);
+            cap.subscribers.entry(render).or_default().insert(survivor);
+            cap.subscribers.entry(present).or_default().insert(dropped);
+
+            let transport = Arc::new(NativeBinding::new_for_test(
+                Arc::clone(&cap.mailer),
+                MailboxId(0),
+            ));
+            let mut ctx = NativeCtx::new(&transport, ReplyTo::NONE, MailId::NONE, MailId::NONE);
+            cap.on_unsubscribe_all(&mut ctx, LifecycleUnsubscribeAll { mailbox: dropped.0 });
+
+            assert!(
+                !cap.subscribers[&render].contains(&dropped),
+                "dropped mailbox must leave the Render stage"
+            );
+            assert!(
+                !cap.subscribers[&present].contains(&dropped),
+                "dropped mailbox must leave the Present stage"
+            );
+            assert!(
+                cap.subscribers[&render].contains(&survivor),
+                "co-subscribers on a shared stage must survive the purge"
+            );
+        }
     }
 }
 
@@ -1311,6 +1375,7 @@ mod tests {
         fn assert_singleton<R: Singleton>() {}
         assert_handles::<LifecycleCapability, LifecycleSubscribe>();
         assert_handles::<LifecycleCapability, LifecycleUnsubscribe>();
+        assert_handles::<LifecycleCapability, LifecycleUnsubscribeAll>();
         assert_singleton::<LifecycleCapability>();
     }
 }

--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -52,12 +52,12 @@ mod tests {
 
     use crate::{
         CliSend, CliSendResult, Delete, DeleteResult, DrawTriangle, DropComponent, DropResult,
-        Fetch, FetchResult, Key, List, ListResult, LoadComponent, LoadResult, LyriaGenerate,
-        LyriaGenerateResult, Mat4Apply, MessagesSend, MessagesSendResult, MouseButton, MouseMove,
-        NanobananaGenerate, NanobananaGenerateResult, NoteOff, NoteOn, Ping, Pong, ProcessExited,
-        Read, ReadResult, ReplaceComponent, ReplaceResult, SetMasterGain, Spawn, SpawnResult,
-        SubscribeInput, SubscribeInputResult, Terminate, TerminateResult, Tick, UnsubscribeAll,
-        UnsubscribeInput, Write, WriteResult,
+        Fetch, FetchResult, Key, LifecycleUnsubscribeAll, List, ListResult, LoadComponent,
+        LoadResult, LyriaGenerate, LyriaGenerateResult, Mat4Apply, MessagesSend,
+        MessagesSendResult, MouseButton, MouseMove, NanobananaGenerate, NanobananaGenerateResult,
+        NoteOff, NoteOn, Ping, Pong, ProcessExited, Read, ReadResult, ReplaceComponent,
+        ReplaceResult, SetMasterGain, Spawn, SpawnResult, SubscribeInput, SubscribeInputResult,
+        Terminate, TerminateResult, Tick, UnsubscribeAll, UnsubscribeInput, Write, WriteResult,
     };
 
     #[test]
@@ -110,6 +110,7 @@ mod tests {
         assert!(names.contains(&SubscribeInput::NAME));
         assert!(names.contains(&UnsubscribeInput::NAME));
         assert!(names.contains(&UnsubscribeAll::NAME));
+        assert!(names.contains(&LifecycleUnsubscribeAll::NAME));
         assert!(names.contains(&SubscribeInputResult::NAME));
         assert!(names.contains(&NoteOn::NAME));
         assert!(names.contains(&NoteOff::NAME));

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -291,6 +291,33 @@ pub struct LifecycleUnsubscribe {
     pub mailbox: u64,
 }
 
+/// `aether.lifecycle.unsubscribe_all` — remove `mailbox` from every
+/// lifecycle stage's subscriber set. Issued by
+/// `ComponentHostCapability` on `DropComponent` so the lifecycle cap's
+/// per-stage broadcast doesn't keep firing at a dropped trampoline —
+/// the lifecycle-family counterpart of [`UnsubscribeAll`] for
+/// `aether.input`. Idempotent: a mailbox with no stage subscriptions
+/// is still a no-op. Fire-and-forget; no reply. Cast-shape (Pod), one
+/// `mailbox` field, matching the sibling lifecycle kinds' raw-`u64`
+/// shape.
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Pod,
+    Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "aether.lifecycle.unsubscribe_all")]
+pub struct LifecycleUnsubscribeAll {
+    pub mailbox: u64,
+}
+
 /// Reply to [`LifecycleSubscribe`] / [`LifecycleUnsubscribe`].
 /// `Err` carries the stage kind id and a human-readable reason —
 /// fail-fast subscribe per ADR-0082 §7. Same shape and rationale as
@@ -2914,6 +2941,10 @@ mod tests {
         );
         assert_eq!(LifecycleSubscribe::NAME, "aether.lifecycle.subscribe");
         assert_eq!(LifecycleUnsubscribe::NAME, "aether.lifecycle.unsubscribe");
+        assert_eq!(
+            LifecycleUnsubscribeAll::NAME,
+            "aether.lifecycle.unsubscribe_all"
+        );
         assert_eq!(
             LifecycleSubscribeResult::NAME,
             "aether.lifecycle.subscribe_result"


### PR DESCRIPTION
Closes iamacoffeepot/aether#1491.

## Summary

Fixes a lifecycle stage-subscription leak on component drop. The component host fired `UnsubscribeAll` to `aether.input` only, so a dropped component's lifecycle stage subscription (`Render`, live on main since #1378) lingered in the lifecycle cap's subscriber table and the per-frame broadcast warn-dropped to a dead mailbox every frame.

- New `aether-kinds` kind `LifecycleUnsubscribeAll` (`aether.lifecycle.unsubscribe_all`, one `mailbox: u64`) — Pod cast-shape, mirroring the sibling lifecycle kinds rather than reusing the `aether.input.unsubscribe_all` kind (an input-prefixed kind handled by the lifecycle cap would break the kind-name-prefix convention).
- `on_unsubscribe_all` handler on `LifecycleCapability` purges the mailbox from every stage's subscriber set, mirroring `InputCapability::on_unsubscribe_all`.
- The host `on_drop_component` path now sends `LifecycleUnsubscribeAll` to `aether.lifecycle` alongside the existing `UnsubscribeAll` to `aether.input`.

This is pre-existing (surfaced by #1378's camera `Render` subscriber); #1490 adds `Tick` to the previously-leaking set, so this lands first.

## Test plan

- Full pre-flight green: fmt, clippy `--workspace --all-targets -D warnings`, doc, wasm32 component cross-build, `cargo nextest run --workspace --all-features` (1560 passed, 6 skipped).
- New unit test `on_unsubscribe_all_purges_mailbox_from_every_stage` — a dropped mailbox leaves every stage set while a co-subscriber on a shared stage survives.
- `covers_every_substrate_kind` / `kind_names_are_stable` updated for the new kind; the cap's compile-time `HandlesKind` guard wires the handler.

## Note for review

The host drop-send itself (the one-line `aether.lifecycle` notification in `on_drop_component`) is covered by mirroring the already-proven `aether.input` send plus the handler unit test, not by a new egress-observing drop harness (component.rs has no such fixture today — the scoped plan marked that test optional). I can MCP-smoke a real load/drop to confirm no warn-drop before un-draft if you want belt-and-suspenders.

## Generated by

Agent execution of scoped issue #1491 via the release implement flow.
