### PR TITLE
refactor(capabilities): subscribe Tick directly on aether.lifecycle and retire the input relay

### DIFF
--- a/crates/aether-actor/examples/caller.rs
+++ b/crates/aether-actor/examples/caller.rs
@@ -22,9 +22,10 @@
 #![allow(clippy::unused_self)]
 
 use aether_actor::{BootError, FfiActor, FfiCtx, MailSender, Resolver, actor};
-use aether_capabilities::InputCapability;
+use aether_capabilities::LifecycleCapability;
+use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_data::{Kind, MailboxId, Schema};
-use aether_kinds::{SubscribeInput, Tick};
+use aether_kinds::Tick;
 use bytemuck::{Pod, Zeroable};
 
 #[repr(C)]
@@ -58,10 +59,8 @@ impl FfiActor for Caller {
 
     //noinspection DuplicatedCode
     fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
-        ctx.actor::<InputCapability>().send(&SubscribeInput {
-            kind: Tick::ID,
-            mailbox: MailboxId(ctx.mailbox_id()),
-        });
+        ctx.actor::<LifecycleCapability>()
+            .subscribe(Tick::ID, MailboxId(ctx.mailbox_id()));
     }
 
     #[handler]

--- a/crates/aether-actor/examples/hello.rs
+++ b/crates/aether-actor/examples/hello.rs
@@ -22,9 +22,10 @@
 #![allow(clippy::unused_self)]
 
 use aether_actor::{BootError, FfiActor, FfiCtx, KindId, Resolver, actor};
-use aether_capabilities::{InputCapability, RenderCapability};
+use aether_capabilities::lifecycle::LifecycleMailboxExt;
+use aether_capabilities::{LifecycleCapability, RenderCapability};
 use aether_data::{Kind, MailboxId};
-use aether_kinds::{DrawTriangle, Ping, Pong, SubscribeInput, Tick, Vertex};
+use aether_kinds::{DrawTriangle, Ping, Pong, Tick, Vertex};
 
 static TRIANGLE: DrawTriangle = DrawTriangle {
     verts: [
@@ -83,10 +84,8 @@ impl FfiActor for Hello {
 
     //noinspection DuplicatedCode
     fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
-        ctx.actor::<InputCapability>().send(&SubscribeInput {
-            kind: Tick::ID,
-            mailbox: MailboxId(ctx.mailbox_id()),
-        });
+        ctx.actor::<LifecycleCapability>()
+            .subscribe(Tick::ID, MailboxId(ctx.mailbox_id()));
     }
 
     /// Emits the configured triangle to the render sink every tick.

--- a/crates/aether-actor/examples/input_logger.rs
+++ b/crates/aether-actor/examples/input_logger.rs
@@ -1,6 +1,8 @@
 //! Smoke component for ADR-0021 input subscriptions. Observes the
-//! four substrate-published input kinds (Tick / Key / `MouseMove` /
-//! `MouseButton`) and counts each dispatch.
+//! substrate-published input kinds (Key / `MouseMove` / `MouseButton`)
+//! and counts each dispatch. `Tick` is a frame-lifecycle stage
+//! (`aether.lifecycle`, ADR-0082), not an input stream, so it is not
+//! part of this input-streams demo.
 //!
 //! Pre-issue-775 the example emitted a `demo.input_observed { stream,
 //! code }` to `hub.claude.broadcast` so the driving Claude session
@@ -21,7 +23,7 @@
 use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
 use aether_capabilities::InputCapability;
 use aether_data::{Kind, MailboxId};
-use aether_kinds::{Key, MouseButton, MouseMove, SubscribeInput, Tick};
+use aether_kinds::{Key, MouseButton, MouseMove, SubscribeInput};
 
 pub struct InputLogger;
 
@@ -39,13 +41,10 @@ impl FfiActor for InputLogger {
     fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
         let me = MailboxId(ctx.mailbox_id());
         let input = ctx.actor::<InputCapability>();
-        for kind in [Tick::ID, Key::ID, MouseMove::ID, MouseButton::ID] {
+        for kind in [Key::ID, MouseMove::ID, MouseButton::ID] {
             input.send(&SubscribeInput { kind, mailbox: me });
         }
     }
-
-    #[handler]
-    fn on_tick(&mut self, _ctx: &mut FfiCtx<'_>, _tick: Tick) {}
 
     #[handler]
     fn on_key(&mut self, _ctx: &mut FfiCtx<'_>, _key: Key) {}

--- a/crates/aether-camera/src/runtime.rs
+++ b/crates/aether-camera/src/runtime.rs
@@ -273,22 +273,27 @@ impl FfiActor for CameraComponent {
         })
     }
 
-    /// Issue 640 / 1378: subscribe to the input streams the camera
-    /// advances against (`Tick`, `WindowSize`) plus the `Render`
-    /// lifecycle stage it submits on. `wire` (post-init, mail-allowed)
-    /// is the placement — `init`'s ctx is `Resolver`-only and can't mail.
+    /// Subscribe the lifecycle stages the camera advances against
+    /// (`Tick`, `Render`) on `aether.lifecycle`, plus the `WindowSize`
+    /// input interrupt on `aether.input`. `wire` (post-init,
+    /// mail-allowed) is the placement — `init`'s ctx is `Resolver`-only
+    /// and can't mail.
+    ///
+    /// `Tick` and `Render` are frame-lifecycle stages (ADR-0082), so they
+    /// ride `aether.lifecycle`; `WindowSize` is a genuine input interrupt
+    /// (ADR-0021), so it stays on `aether.input`.
     ///
     /// On a chassis whose lifecycle graph omits `Render` (headless), the
-    /// cap replies `Err(UnsupportedStage)` to this fire-and-forget
+    /// cap replies `Err(UnsupportedStage)` to that fire-and-forget
     /// subscribe; the reply warn-drops and the camera simply never
     /// receives `Render` and never submits — a no-op there, where the
     /// render cap discards anyway (ADR-0082 §7 / §11).
     fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
         let me = MailboxId(ctx.mailbox_id());
-        let input = ctx.actor::<InputCapability>();
-        input.subscribe(Tick::ID, me);
-        input.subscribe(WindowSize::ID, me);
-        ctx.actor::<LifecycleCapability>().subscribe(Render::ID, me);
+        ctx.actor::<InputCapability>().subscribe(WindowSize::ID, me);
+        let lifecycle = ctx.actor::<LifecycleCapability>();
+        lifecycle.subscribe(Tick::ID, me);
+        lifecycle.subscribe(Render::ID, me);
     }
 
     /// Advance every camera's per-mode state each tick. Inactive cameras

--- a/crates/aether-capabilities/src/input.rs
+++ b/crates/aether-capabilities/src/input.rs
@@ -1,6 +1,11 @@
 //! `aether.input` cap. Owns the ADR-0021 publish/subscribe routing
-//! table for substrate input streams (`Tick`, `Key`, `KeyRelease`,
+//! table for substrate input streams (`Key`, `KeyRelease`,
 //! `MouseMove`, `MouseButton`, `WindowSize`).
+//!
+//! `Tick` is not an input stream: it is a frame-lifecycle stage
+//! (`aether.lifecycle.tick`) a component subscribes directly on
+//! `aether.lifecycle` via `ctx.actor::<LifecycleCapability>()`
+//! (ADR-0082). The input cap carries only genuine input interrupts.
 //!
 //! Issue 640 collapsed the last `Arc<RwLock<HashMap<...>>>` cross-thread
 //! share. The cap is the sole owner of the subscriber table, held as a
@@ -27,8 +32,8 @@ use aether_data::{KindId, MailboxId};
 #[cfg(not(target_arch = "wasm32"))]
 use aether_kinds::SubscribeInputResult;
 use aether_kinds::{
-    Key, KeyRelease, MouseButton, MouseMove, SubscribeInput, Tick, UnsubscribeAll,
-    UnsubscribeInput, WindowSize,
+    Key, KeyRelease, MouseButton, MouseMove, SubscribeInput, UnsubscribeAll, UnsubscribeInput,
+    WindowSize,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use aether_substrate::actor::native::NativeActorMailbox;
@@ -108,7 +113,7 @@ impl InputMailboxExt for NativeActorMailbox<'_, InputCapability> {
 #[aether_actor::bridge(singleton)]
 mod native {
     use super::{
-        Key, KeyRelease, MouseButton, MouseMove, SubscribeInput, SubscribeInputResult, Tick,
+        Key, KeyRelease, MouseButton, MouseMove, SubscribeInput, SubscribeInputResult,
         UnsubscribeAll, UnsubscribeInput, WindowSize,
     };
     use aether_actor::actor;
@@ -137,7 +142,7 @@ mod native {
     /// 1. **Subscribe / Unsubscribe / `UnsubscribeAll`** — mutates the
     ///    table on `&mut self`. Reply target: the original sender.
     ///
-    /// 2. **Input events** (`Tick`, `Key`, `KeyRelease`, `MouseMove`,
+    /// 2. **Input events** (`Key`, `KeyRelease`, `MouseMove`,
     ///    `MouseButton`, `WindowSize`) — pushed by the chassis driver
     ///    after each platform event; the cap fans out one mail per
     ///    subscriber. Fire-and-forget; no reply.
@@ -215,12 +220,6 @@ mod native {
             for set in self.subscribers.values_mut() {
                 set.remove(&payload.mailbox);
             }
-        }
-
-        /// Per-frame tick fan-out (ADR-0021). Empty payload.
-        #[handler]
-        fn on_tick(&mut self, ctx: &mut NativeCtx<'_>, payload: Tick) {
-            self.fanout(ctx, &payload);
         }
 
         /// Key-press fan-out.

--- a/crates/aether-capabilities/src/lifecycle.rs
+++ b/crates/aether-capabilities/src/lifecycle.rs
@@ -536,9 +536,9 @@ mod native {
         /// on the chassis side.
         pub graph: LifecycleGraphData,
         /// Initial `(stage_kind, mailbox)` pairs to populate the
-        /// subscriber table at boot. Chassis builders use this to wire
-        /// the relay (e.g. `(Tick::ID, aether.input)`) without
-        /// round-tripping a `LifecycleSubscribe` mail. Each pair must
+        /// subscriber table at boot — a chassis builder can pre-subscribe
+        /// a mailbox to a stage this way without round-tripping a
+        /// `LifecycleSubscribe` mail. Each pair must
         /// reference a stage kind declared by `graph` — the boot path
         /// verifies this and returns `BootError` otherwise, so
         /// misconfiguration fails fast at chassis-build.

--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -14,7 +14,6 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use aether_actor::Actor;
 use aether_capabilities::anthropic::AnthropicConfigLayer;
 use aether_capabilities::audio::AudioConfigLayer;
 use aether_capabilities::fs::NamespaceRootsLayer;
@@ -28,7 +27,6 @@ use aether_capabilities::{
     InputCapability, InputConfig, InventoryCapability, LifecycleConfig, TcpCapability,
     fs::NamespaceRoots, http::HttpConfig, trace::TraceDispatchCapability,
 };
-use aether_data::{Kind, MailboxId as DataMailboxId, mailbox_id_from_name};
 use aether_kinds::{Present, Render, Shutdown, Tick};
 use aether_substrate::chassis::Chassis;
 use aether_substrate::chassis::builder::Builder;
@@ -153,9 +151,9 @@ pub enum PersistOverride {
 
 /// Build the standard single-stage lifecycle config every Tick-driven
 /// chassis shares today (ADR-0082 PR 3b): a `Tick` self-loop with a
-/// `Quit` escape to a `Shutdown` terminal, relaying `Tick` to
-/// `aether.input` so the existing `InputCapability::on_tick` fan-out
-/// keeps routing to component subscribers. Headless / `test_bench` /
+/// `Quit` escape to a `Shutdown` terminal. Components subscribe the
+/// `Tick` stage directly on `aether.lifecycle` (ADR-0082 §7/§11), so
+/// the config wires no initial subscribers. Headless / `test_bench` /
 /// desktop all use this identical shape; a chassis that adds
 /// `Render` / `Present` stages (ADR-0082 §11) builds its own graph
 /// instead.
@@ -174,10 +172,9 @@ pub fn tick_only_lifecycle_config() -> LifecycleConfig {
         .start::<Tick>()
         .build()
         .expect("tick-only lifecycle graph is structurally valid");
-    let input_mailbox = DataMailboxId(mailbox_id_from_name(InputCapability::NAMESPACE).0);
     LifecycleConfig {
         graph,
-        initial_subscribers: vec![(<Tick as Kind>::ID, input_mailbox)],
+        initial_subscribers: vec![],
     }
 }
 
@@ -200,9 +197,9 @@ pub fn tick_only_lifecycle_config() -> LifecycleConfig {
 /// this drain edge; per-stage component subscription lands when a
 /// producer needs a post-`Render` hook.
 ///
-/// Same `initial_subscribers` relay as [`tick_only_lifecycle_config`]
-/// (`Tick → aether.input`), so the existing `InputCapability::on_tick`
-/// fan-out keeps routing `Tick` to component subscribers. Desktop and
+/// Like [`tick_only_lifecycle_config`], components subscribe the `Tick`
+/// (and `Render`) stage directly on `aether.lifecycle` (ADR-0082
+/// §7/§11), so the config wires no initial subscribers. Desktop and
 /// `test_bench` adopt this graph; headless stays
 /// [`tick_only_lifecycle_config`] (its render cap is a no-op, so a
 /// `Render` / `Present` stage would settle to no GPU work).
@@ -225,10 +222,9 @@ pub fn frame_lifecycle_config() -> LifecycleConfig {
         .start::<Tick>()
         .build()
         .expect("frame lifecycle graph is structurally valid");
-    let input_mailbox = DataMailboxId(mailbox_id_from_name(InputCapability::NAMESPACE).0);
     LifecycleConfig {
         graph,
-        initial_subscribers: vec![(<Tick as Kind>::ID, input_mailbox)],
+        initial_subscribers: vec![],
     }
 }
 
@@ -304,8 +300,8 @@ mod tests {
         // The graph's edge accessors (`next` / `quit` per state) are
         // `pub(crate)` to `aether-capabilities`, so this crate-boundary
         // check reads the public `Debug` (start + the non-terminal state
-        // kinds + terminals) plus the preserved `initial_subscribers`
-        // relay. Quit-edge *placement* (on `Present`, not `Tick`) is
+        // kinds + terminals) plus the now-empty `initial_subscribers`
+        // set. Quit-edge *placement* (on `Present`, not `Tick`) is
         // verified at the cap-unit layer (`lifecycle.rs` `resolve_edge`
         // tests, which can read `state().quit`) and end-to-end by the
         // `test_bench` quit-drain scenario.
@@ -339,11 +335,11 @@ mod tests {
             "expected Shutdown terminal in {graph_dbg}",
         );
 
-        // The `Tick → aether.input` relay is preserved, identical to the
-        // tick-only config, so the InputCapability fan-out keeps routing
-        // Tick to component subscribers.
-        assert_eq!(cfg.initial_subscribers.len(), 1);
-        assert_eq!(cfg.initial_subscribers[0].0, <Tick as Kind>::ID);
+        // No initial subscribers: components subscribe the `Tick` stage
+        // directly on `aether.lifecycle` (ADR-0082 §7/§11); the boot-time
+        // `Tick → aether.input` relay retired with the input cap's
+        // `on_tick` fan-out.
+        assert!(cfg.initial_subscribers.is_empty());
     }
 
     #[test]

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -76,9 +76,11 @@ pub struct App {
     /// out per-subscriber on its own dispatcher (issue 640).
     input_mailbox: MailboxId,
     /// `aether.lifecycle` mailbox id, cached at boot. Each redraw
-    /// fires one `LifecycleAdvance` here; the driver broadcasts
-    /// Tick to `aether.input` via the chassis's `initial_subscribers`
-    /// relay, then waits for settlement before submitting the frame.
+    /// fires one `LifecycleAdvance` here; the cap broadcasts the `Tick`
+    /// stage directly to its stage subscribers (issue 1490 retired the
+    /// `Tick → aether.input` relay; components subscribe `Tick` on
+    /// `aether.lifecycle`), then the driver waits for settlement before
+    /// submitting the frame.
     lifecycle_mailbox: MailboxId,
     kind_lifecycle_advance: aether_data::KindId,
     /// `aether.lifecycle.advance_reply` inbox claimed at boot (issue

--- a/crates/aether-substrate-bundle/src/headless/driver.rs
+++ b/crates/aether-substrate-bundle/src/headless/driver.rs
@@ -87,9 +87,10 @@ pub struct HeadlessTimerCapability {
 pub struct HeadlessTimerRunning {
     queue: Arc<Mailer>,
     /// `aether.lifecycle` mailbox id, cached at boot. Each tick fires
-    /// one `LifecycleAdvance` here; the lifecycle driver broadcasts
-    /// the current stage (Tick) to its subscriber set, including
-    /// `aether.input` per the chassis's `initial_subscribers`.
+    /// one `LifecycleAdvance` here; the lifecycle driver broadcasts the
+    /// current stage (Tick) directly to its stage subscriber set
+    /// (issue 1490 retired the `Tick → aether.input` relay; components
+    /// subscribe `Tick` on `aether.lifecycle`).
     lifecycle_mailbox: MailboxId,
     /// Kind id of [`LifecycleAdvance`], pre-resolved so the timer
     /// loop body stays alloc-free per tick.

--- a/crates/aether-substrate-bundle/src/perf/harness.rs
+++ b/crates/aether-substrate-bundle/src/perf/harness.rs
@@ -26,7 +26,7 @@ use aether_actor::trace_ring::DEFAULT_TRACE_RING_CAP;
 use aether_capabilities::trace_walk::fold_nodes;
 use aether_data::{Kind, KindId, MailboxId, mailbox_id_from_name};
 use aether_kinds::trace::{MailNodeWire, TraceRingEntry, TraceTail, TraceTailResult};
-use aether_kinds::{SubscribeInput, SubscribeInputResult, Tick};
+use aether_kinds::{LifecycleSubscribe, LifecycleSubscribeResult, Tick};
 use aether_substrate::{BootError, NativeActor, NativeCtx, NativeDispatch, NativeInitCtx, Subname};
 
 use crate::perf::report::LatencySection;
@@ -1132,16 +1132,16 @@ pub fn run_sweep_samples(cfg: &SweepConfig) -> Vec<CellSamples> {
                 continue;
             }
 
-            // Wire the source into the platform `Tick` stream so
-            // `advance` delivers a tick to it each frame (ADR-0021).
-            let sub_req = SubscribeInput {
-                kind: Tick::ID,
-                mailbox: ticksrc_id(),
+            // Subscribe the source to the `Tick` lifecycle stage so
+            // `advance` broadcasts a tick to it each frame (ADR-0082).
+            let sub_req = LifecycleSubscribe {
+                stage: Tick::ID.0,
+                mailbox: ticksrc_id().0,
             }
             .encode_into_bytes();
-            match tb.send_bytes_and_await("aether.input", SubscribeInput::ID, sub_req) {
-                Ok(reply) => match SubscribeInputResult::decode_from_bytes(&reply) {
-                    Some(SubscribeInputResult::Ok) => {}
+            match tb.send_bytes_and_await("aether.lifecycle", LifecycleSubscribe::ID, sub_req) {
+                Ok(reply) => match LifecycleSubscribeResult::decode_from_bytes(&reply) {
+                    Some(LifecycleSubscribeResult::Ok) => {}
                     other => {
                         tracing::warn!(target: "aether_perf", topo = %topo.name, ?other, "Tick subscribe failed");
                         continue;

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -155,9 +155,9 @@ pub struct TestBench {
 
     /// `aether.lifecycle` mailbox id, cached at boot. `advance()`
     /// fires one `LifecycleAdvance` here per requested tick; the
-    /// lifecycle driver broadcasts `Tick` to `aether.input` (relayed
-    /// via the chassis's `initial_subscribers`) and the rest of the
-    /// subscriber set per ADR-0082.
+    /// lifecycle driver broadcasts the `Tick` stage directly to its
+    /// stage subscriber set per ADR-0082 (issue 1490 retired the
+    /// `Tick → aether.input` relay).
     lifecycle_mailbox: MailboxId,
     /// Kind id of [`LifecycleAdvance`], pre-resolved so the advance
     /// loop body stays alloc-free per tick.
@@ -940,10 +940,11 @@ impl TestBench {
     fn run_frame(&mut self, dispatch_tick: bool) -> Result<(), TestBenchError> {
         if dispatch_tick {
             // ADR-0082 PR 3b: TestBench pushes `LifecycleAdvance` to the
-            // lifecycle driver, which broadcasts Tick to `aether.input`
-            // (relayed via the chassis's `initial_subscribers`) plus any
-            // other subscribers. The chain rooted at this advance's
-            // `MailId` covers the whole subtree — input fanout,
+            // lifecycle driver, which broadcasts the `Tick` stage directly
+            // to its stage subscribers (issue 1490 retired the
+            // `Tick → aether.input` relay; components subscribe `Tick` on
+            // `aether.lifecycle`). The chain rooted at this advance's
+            // `MailId` covers the whole subtree — the stage fanout,
             // subscriber handlers, the tick_observed broadcasts those
             // subscribers emit, the broadcast cap's egress to outbound.
             //
@@ -1198,7 +1199,7 @@ mod tests {
     #[test]
     fn tick_fanout_propagates_chassis_root_lineage() {
         use aether_data::{Kind as DataKind, MailId};
-        use aether_kinds::SubscribeInput;
+        use aether_kinds::LifecycleSubscribe;
         use aether_substrate::mail::registry::MailDispatch;
         use std::sync::Mutex;
 
@@ -1238,22 +1239,22 @@ mod tests {
             }),
         );
 
-        // Subscribe the closure mailbox to Tick (goes through the
-        // input cap's on_subscribe handler), then advance one tick.
-        // The advance calls `push_chassis_root_mail` for the tick
-        // (issue 723), which mints a fresh chassis-root MailId and
-        // fires `Sent`. The input cap's `on_tick` reads `ctx.in_flight_*`
-        // and threads them through `ctx.fanout` to every subscriber.
-        // Sequencing both through `execute` settles the subscribe
-        // before the tick fires.
+        // Subscribe the closure mailbox to the `Tick` lifecycle stage
+        // (goes through the lifecycle cap's on_subscribe handler), then
+        // advance one tick. The advance issues a `LifecycleAdvance` whose
+        // chain root the lifecycle cap threads through
+        // `broadcast_to_subscribers` (`send_envelope_traced`) to every
+        // stage subscriber (issue 723 lineage, ADR-0082 §6). Sequencing
+        // both through `execute` settles the subscribe before the tick
+        // fires.
         tb.execute(vec![
             (
                 "subscribe",
                 BenchOp::send_mail(
-                    "aether.input",
-                    &SubscribeInput {
-                        kind: Tick::ID,
-                        mailbox: subscriber_mbox,
+                    "aether.lifecycle",
+                    &LifecycleSubscribe {
+                        stage: Tick::ID.0,
+                        mailbox: subscriber_mbox.0,
                     },
                 ),
             ),

--- a/crates/aether-substrate-bundle/tests/cap_registry.rs
+++ b/crates/aether-substrate-bundle/tests/cap_registry.rs
@@ -83,8 +83,8 @@ fn require_wgpu_only() -> bool {
 }
 
 /// A freshly-loaded probe's trampoline mailbox accepts the kinds the
-/// probe declares `#[handler]`s for (`Tick`, `SetRender`) and rejects
-/// kinds it doesn't (`Ping`).
+/// probe declares `#[handler]`s for (`Tick`, `Key`, `SetRender`) and
+/// rejects kinds it doesn't (`Ping`).
 #[test]
 fn cap_registry_reports_accepted_kinds() {
     let Some(wasm_path) = require_runtime("probe") else {

--- a/crates/aether-substrate-bundle/tests/input_subscriptions.rs
+++ b/crates/aether-substrate-bundle/tests/input_subscriptions.rs
@@ -6,6 +6,14 @@
 //! retired `InputCapability::for_test` / `subscribe_for_test` /
 //! `unsubscribe_for_test` helpers and used `mailer.drain_all` to
 //! synchronise. Tracked under issue 648.
+//!
+//! Targets the `Key` input stream, not `Tick`: issue 1490 moved `Tick`
+//! off `aether.input` onto `aether.lifecycle` (it is a frame-lifecycle
+//! stage, not an input interrupt), so the `aether.input` subscribe /
+//! unsubscribe / drop-clears contract is exercised here against a
+//! genuine input stream. The probe subscribes `Key` in `wire` and
+//! broadcasts a `key_observed` per dispatch; Tick-via-lifecycle delivery
+//! is covered by the `test_bench` frame-loop scenarios.
 
 use std::path::Path;
 
@@ -13,12 +21,15 @@ use aether_actor::Actor;
 use aether_capabilities::{ComponentHostCapability, InputCapability};
 use aether_data::{Kind, KindId, MailboxId};
 use aether_kinds::{
-    DropComponent, DropResult, LoadComponent, LoadResult, SubscribeInputResult, Tick,
+    DropComponent, DropResult, Key, LoadComponent, LoadResult, SubscribeInputResult,
     UnsubscribeInput,
 };
 use aether_substrate_bundle::test_bench::{BenchOp, TestBench, test_helpers::require_runtime};
-use aether_test_fixtures::TickObserved;
+use aether_test_fixtures::KeyObserved;
 use std::fs;
+
+/// Arbitrary key code for the synthetic `Key` events these tests inject.
+const KEY_CODE: u32 = 65;
 
 fn load_probe_named(bench: &mut TestBench, wasm_path: &Path, name: &str) -> MailboxId {
     let wasm = fs::read(wasm_path).expect("read fixture wasm");
@@ -43,6 +54,23 @@ fn load_probe_named(bench: &mut TestBench, wasm_path: &Path, name: &str) -> Mail
         LoadResult::Ok { mailbox_id, .. } => mailbox_id,
         LoadResult::Err { error } => panic!("load_component({name}): {error}"),
     }
+}
+
+/// Inject `count` synthetic `Key` presses to `aether.input`. The input
+/// cap fans each out to every `Key` subscriber; `execute` blocks on
+/// settlement, so the `key_observed` broadcasts have landed by return.
+fn send_keys(bench: &mut TestBench, count: usize) {
+    let labels: Vec<String> = (0..count).map(|i| format!("key{i}")).collect();
+    let steps: Vec<(&str, BenchOp)> = labels
+        .iter()
+        .map(|label| {
+            (
+                label.as_str(),
+                BenchOp::send_mail("aether.input", &Key { code: KEY_CODE }),
+            )
+        })
+        .collect();
+    bench.execute(steps).expect("key send sequence");
 }
 
 fn unsubscribe(bench: &mut TestBench, kind: KindId, mailbox: MailboxId) {
@@ -83,75 +111,69 @@ fn drop_component(bench: &mut TestBench, mailbox_id: MailboxId) {
     }
 }
 
-/// No probes loaded ⇒ no Tick subscribers ⇒ advance generates zero
-/// `tick_observed` broadcasts. Confirms the input fanout is gated on
-/// the subscriber set rather than firing unconditionally.
+/// No probes loaded ⇒ no `Key` subscribers ⇒ an injected key event
+/// fans out to no one. Confirms the input fanout is gated on the
+/// subscriber set rather than firing unconditionally.
 #[test]
 fn empty_subscribers_means_no_delivery() {
     if require_runtime("probe").is_none() {
         return;
     }
     let mut bench = TestBench::start_with_size(64, 48).expect("boot");
-    bench
-        .execute(vec![("advance", BenchOp::advance(2))])
-        .expect("advance 2");
+    send_keys(&mut bench, 2);
     assert_eq!(
-        bench.count_observed(TickObserved::NAME),
+        bench.count_observed(KeyObserved::NAME),
         0,
-        "no probe loaded but tick_observed was broadcast; observed kinds: {:?}",
+        "no probe loaded but key_observed was broadcast; observed kinds: {:?}",
         bench.observed_kinds(),
     );
 }
 
-/// One subscribed probe broadcasts once per tick.
+/// One subscribed probe broadcasts once per injected key.
 #[test]
-fn subscribed_component_receives_published_ticks() {
+fn subscribed_component_receives_published_keys() {
     let Some(wasm_path) = require_runtime("probe") else {
         return;
     };
     let mut bench = TestBench::start_with_size(64, 48).expect("boot");
     let _mbox = load_probe_named(&mut bench, &wasm_path, "listener");
-    let baseline = bench.count_observed(TickObserved::NAME);
+    let baseline = bench.count_observed(KeyObserved::NAME);
 
-    bench
-        .execute(vec![("advance", BenchOp::advance(3))])
-        .expect("advance 3");
-    let delta = bench.count_observed(TickObserved::NAME) - baseline;
+    send_keys(&mut bench, 3);
+    let delta = bench.count_observed(KeyObserved::NAME) - baseline;
     assert_eq!(
         delta,
         3,
-        "expected 3 tick_observed broadcasts; observed kinds: {:?}",
+        "expected 3 key_observed broadcasts; observed kinds: {:?}",
         bench.observed_kinds(),
     );
 }
 
 /// Two independently-loaded probes each subscribe their own mailbox
-/// in `wire`; tick fanout reaches both. 2 subscribers × 2 ticks ⇒
+/// in `wire`; key fanout reaches both. 2 subscribers × 2 keys ⇒
 /// 4 broadcasts.
 #[test]
-fn two_subscribers_each_receive_every_tick() {
+fn two_subscribers_each_receive_every_key() {
     let Some(wasm_path) = require_runtime("probe") else {
         return;
     };
     let mut bench = TestBench::start_with_size(64, 48).expect("boot");
     let _mbox_a = load_probe_named(&mut bench, &wasm_path, "a");
     let _mbox_b = load_probe_named(&mut bench, &wasm_path, "b");
-    let baseline = bench.count_observed(TickObserved::NAME);
+    let baseline = bench.count_observed(KeyObserved::NAME);
 
-    bench
-        .execute(vec![("advance", BenchOp::advance(2))])
-        .expect("advance 2");
-    let delta = bench.count_observed(TickObserved::NAME) - baseline;
+    send_keys(&mut bench, 2);
+    let delta = bench.count_observed(KeyObserved::NAME) - baseline;
     assert_eq!(
         delta,
         4,
-        "2 subscribers × 2 ticks should yield 4 broadcasts; observed kinds: {:?}",
+        "2 subscribers × 2 keys should yield 4 broadcasts; observed kinds: {:?}",
         bench.observed_kinds(),
     );
 }
 
-/// `aether.input.unsubscribe` removes the mailbox from the Tick
-/// subscriber set; subsequent advances stop producing broadcasts
+/// `aether.input.unsubscribe` removes the mailbox from the `Key`
+/// subscriber set; subsequent key events stop producing broadcasts
 /// from that probe.
 #[test]
 fn unsubscribe_stops_delivery() {
@@ -160,34 +182,30 @@ fn unsubscribe_stops_delivery() {
     };
     let mut bench = TestBench::start_with_size(64, 48).expect("boot");
     let mbox = load_probe_named(&mut bench, &wasm_path, "listener");
-    let baseline = bench.count_observed(TickObserved::NAME);
+    let baseline = bench.count_observed(KeyObserved::NAME);
 
-    bench
-        .execute(vec![("advance", BenchOp::advance(1))])
-        .expect("pre-unsubscribe advance");
+    send_keys(&mut bench, 1);
     assert_eq!(
-        bench.count_observed(TickObserved::NAME) - baseline,
+        bench.count_observed(KeyObserved::NAME) - baseline,
         1,
         "expected 1 broadcast in the pre-unsubscribe window; observed kinds: {:?}",
         bench.observed_kinds(),
     );
-    let pre_unsub = bench.count_observed(TickObserved::NAME);
+    let pre_unsub = bench.count_observed(KeyObserved::NAME);
 
-    unsubscribe(&mut bench, Tick::ID, mbox);
-    bench
-        .execute(vec![("advance", BenchOp::advance(2))])
-        .expect("post-unsubscribe advance");
+    unsubscribe(&mut bench, Key::ID, mbox);
+    send_keys(&mut bench, 2);
     assert_eq!(
-        bench.count_observed(TickObserved::NAME),
+        bench.count_observed(KeyObserved::NAME),
         pre_unsub,
-        "tick_observed climbed after unsubscribe; observed kinds: {:?}",
+        "key_observed climbed after unsubscribe; observed kinds: {:?}",
         bench.observed_kinds(),
     );
 }
 
 /// `aether.component.drop` clears the dropped mailbox from the input
 /// subscriber set as a side effect of lifecycle teardown
-/// (ADR-0021 + ADR-0038). Subsequent advances don't broadcast from
+/// (ADR-0021 + ADR-0038). Subsequent key events don't broadcast from
 /// the dropped probe.
 #[test]
 fn drop_clears_subscriptions() {
@@ -196,27 +214,23 @@ fn drop_clears_subscriptions() {
     };
     let mut bench = TestBench::start_with_size(64, 48).expect("boot");
     let mbox = load_probe_named(&mut bench, &wasm_path, "victim");
-    let baseline = bench.count_observed(TickObserved::NAME);
+    let baseline = bench.count_observed(KeyObserved::NAME);
 
-    bench
-        .execute(vec![("advance", BenchOp::advance(1))])
-        .expect("pre-drop advance");
+    send_keys(&mut bench, 1);
     assert_eq!(
-        bench.count_observed(TickObserved::NAME) - baseline,
+        bench.count_observed(KeyObserved::NAME) - baseline,
         1,
         "expected 1 broadcast in the pre-drop window; observed kinds: {:?}",
         bench.observed_kinds(),
     );
-    let pre_drop = bench.count_observed(TickObserved::NAME);
+    let pre_drop = bench.count_observed(KeyObserved::NAME);
 
     drop_component(&mut bench, mbox);
-    bench
-        .execute(vec![("advance", BenchOp::advance(2))])
-        .expect("post-drop advance");
+    send_keys(&mut bench, 2);
     assert_eq!(
-        bench.count_observed(TickObserved::NAME),
+        bench.count_observed(KeyObserved::NAME),
         pre_drop,
-        "tick_observed climbed after drop; observed kinds: {:?}",
+        "key_observed climbed after drop; observed kinds: {:?}",
         bench.observed_kinds(),
     );
 }

--- a/crates/aether-test-fixtures/examples/probe.rs
+++ b/crates/aether-test-fixtures/examples/probe.rs
@@ -30,12 +30,19 @@
 //! kinds moved to the sibling lib so integration tests can import
 //! them without reaching into a cdylib.
 
+// `on_key` only re-broadcasts the inbound payload, so it doesn't touch
+// `self`; it keeps `&mut self` to match the `#[handler]` dispatch ABI.
+#![allow(clippy::unused_self)]
+
 use aether_actor::{BootError, FfiActor, FfiCtx, MailSender, Resolver, actor};
 use aether_capabilities::input::InputMailboxExt;
-use aether_capabilities::{InputCapability, RenderCapability};
+use aether_capabilities::lifecycle::LifecycleMailboxExt;
+use aether_capabilities::{InputCapability, LifecycleCapability, RenderCapability};
 use aether_data::{Kind, MailboxId};
-use aether_kinds::{DrawTriangle, Tick, Vertex};
-use aether_test_fixtures::{SetRender, TEST_BENCH_OBSERVER_MAILBOX_NAME, TickObserved};
+use aether_kinds::{DrawTriangle, Key, Tick, Vertex};
+use aether_test_fixtures::{
+    KeyObserved, SetRender, TEST_BENCH_OBSERVER_MAILBOX_NAME, TickObserved,
+};
 
 pub struct Probe {
     tick_count: u64,
@@ -59,9 +66,15 @@ impl FfiActor for Probe {
     //noinspection DuplicatedCode
     /// Issue 640: explicit subscribe in `wire`; init is `Resolver`-only
     /// post-issue-703 and can't mail.
+    ///
+    /// `Tick` is a frame-lifecycle stage, so it subscribes on
+    /// `aether.lifecycle` (ADR-0082); `Key` is a genuine input interrupt,
+    /// so it subscribes on `aether.input` (ADR-0021) — the input-stream
+    /// path the round-trip scenarios exercise (issue 1490).
     fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
-        ctx.actor::<InputCapability>()
-            .subscribe(Tick::ID, MailboxId(ctx.mailbox_id()));
+        let me = MailboxId(ctx.mailbox_id());
+        ctx.actor::<LifecycleCapability>().subscribe(Tick::ID, me);
+        ctx.actor::<InputCapability>().subscribe(Key::ID, me);
     }
 
     /// Counts ticks delivered to this mailbox; broadcasts the running
@@ -103,6 +116,23 @@ impl FfiActor for Probe {
                 verts: [v(-0.9, -0.9), v(0.9, -0.9), v(0.0, 0.9)],
             });
         }
+    }
+
+    /// Broadcasts a `key_observed` for each `Key` input dispatch, so the
+    /// ADR-0021 input round-trip scenarios can count `aether.input`
+    /// fan-out deliveries (subscribe / unsubscribe / drop-clears) on a
+    /// genuine input interrupt.
+    ///
+    /// # Agent
+    /// Not sent manually; the substrate's input fan-out fires it for
+    /// every `aether.input`-subscribed mailbox when a key is pressed.
+    /// Watch `receive_mail` for `aether.test_fixture.key_observed`.
+    #[handler]
+    fn on_key(&mut self, ctx: &mut FfiCtx<'_>, key: Key) {
+        ctx.send_to_named::<KeyObserved>(
+            TEST_BENCH_OBSERVER_MAILBOX_NAME,
+            &KeyObserved { code: key.code },
+        );
     }
 
     /// Updates the stored render state. Subsequent ticks paint the

--- a/crates/aether-test-fixtures/src/lib.rs
+++ b/crates/aether-test-fixtures/src/lib.rs
@@ -36,6 +36,20 @@ pub struct TickObserved {
     pub count: u64,
 }
 
+/// Broadcast payload the probe emits on each `Key` input dispatch,
+/// carrying the pressed key `code`. Lets the ADR-0021 input round-trip
+/// scenarios count `aether.input` fan-out deliveries the same way
+/// [`TickObserved`] counts lifecycle ticks — `Key` is a genuine input
+/// interrupt, so it exercises the `aether.input` subscribe / unsubscribe
+/// / drop-clears path that `Tick` no longer does (issue 1490).
+#[derive(
+    aether_data::Kind, aether_data::Schema, serde::Serialize, serde::Deserialize, Debug, Clone,
+)]
+#[kind(name = "aether.test_fixture.key_observed")]
+pub struct KeyObserved {
+    pub code: u32,
+}
+
 /// Driver kind: scenarios send this to flip a probe fixture's render
 /// state. `visible == 0` halts the per-tick draw; any other value
 /// enables it. Cast-shape so encoding is just a memcpy of four

--- a/demos/sokoban/src/lib.rs
+++ b/demos/sokoban/src/lib.rs
@@ -27,7 +27,8 @@
 
 use aether_actor::{BootError, FfiActor, FfiCtx, KindId, MailSender, Resolver, actor};
 use aether_camera::{CameraTopdownSet, TopdownParams};
-use aether_capabilities::{InputCapability, RenderCapability};
+use aether_capabilities::lifecycle::LifecycleMailboxExt;
+use aether_capabilities::{InputCapability, LifecycleCapability, RenderCapability};
 use aether_data::{Kind, MailboxId, Schema};
 use aether_kinds::{DrawTriangle, Key, SubscribeInput, Tick, Vertex, keycode};
 use bytemuck::{Pod, Zeroable};
@@ -178,12 +179,11 @@ impl FfiActor for Sokoban {
     /// `Resolver`-only.
     fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
         let me = MailboxId(ctx.mailbox_id());
-        let input = ctx.actor::<InputCapability>();
-        input.send(&SubscribeInput {
-            kind: Tick::ID,
-            mailbox: me,
-        });
-        input.send(&SubscribeInput {
+        // `Tick` is a frame-lifecycle stage (`aether.lifecycle`,
+        // ADR-0082); `Key` is a genuine input interrupt (`aether.input`,
+        // ADR-0021).
+        ctx.actor::<LifecycleCapability>().subscribe(Tick::ID, me);
+        ctx.actor::<InputCapability>().send(&SubscribeInput {
             kind: Key::ID,
             mailbox: me,
         });

--- a/docs/adr/0021-input-stream-subscriptions.md
+++ b/docs/adr/0021-input-stream-subscriptions.md
@@ -13,6 +13,14 @@
   cap-side manifest pass both retired. Kind names also rehomed from
   `aether.control.subscribe_input` to `aether.input.subscribe` per
   issue 638 Phase 2.
+- **Updated 2026-06-09 (issue 1490):** `Tick` leaves the input-stream set.
+  It is a frame-lifecycle stage (`aether.lifecycle.tick`, ADR-0082), so a
+  component subscribes it on `aether.lifecycle` via `LifecycleCapability`, not
+  on `aether.input`. `InputCapability` now carries only genuine input
+  interrupts (`Key`, `KeyRelease`, `MouseMove`, `MouseButton`, `WindowSize`);
+  the boot-time `Tick → aether.input` relay and the cap's `on_tick` fan-out
+  retired. A third-party component subscribing `Tick` via `InputMailboxExt`
+  moves the one-line subscribe to `LifecycleCapability`.
 
 ## Context
 

--- a/docs/adr/0068-input-subscribers-keyed-by-kindid.md
+++ b/docs/adr/0068-input-subscribers-keyed-by-kindid.md
@@ -2,6 +2,12 @@
 
 - **Status:** Proposed
 - **Date:** 2026-04-30
+- **Updated 2026-06-09 (issue 1490):** `Tick` is no longer keyed as an input
+  subscriber. It is a frame-lifecycle stage (ADR-0082) subscribed on
+  `aether.lifecycle`; the `KindId`-keyed `aether.input` subscriber map now
+  covers only the genuine input interrupts (`Key`, `KeyRelease`, `MouseMove`,
+  `MouseButton`, `WindowSize`). The keying mechanism this ADR introduces is
+  unchanged — only `Tick`'s membership in the set.
 
 ## Context
 

--- a/docs/adr/0082-application-declared-lifecycle-sequence.md
+++ b/docs/adr/0082-application-declared-lifecycle-sequence.md
@@ -35,6 +35,20 @@
 >   `Tick → Render → Present` graph and per-stage component subscription land
 >   with iamacoffeepot/aether#1378.
 
+> **Amendment (2026-06-09, issue 1490).** The §12 `Tick → aether.input`
+> initial-subscriber relay retired. A component subscribes the `Tick` stage
+> directly on `aether.lifecycle` —
+> `ctx.actor::<LifecycleCapability>().subscribe(Tick::ID, me)` — the same site as
+> every other stage; both `tick_only_lifecycle_config` and
+> `frame_lifecycle_config` wire no initial subscribers, and `InputCapability` no
+> longer carries `Tick`. This separates input *interrupts* (key / mouse /
+> window-size, on `aether.input`, ADR-0021/0068) from frame *stages* (`Tick` /
+> `Render` / `Present`, on `aether.lifecycle`). A third-party component that
+> subscribes `Tick` via `InputMailboxExt` moves the one-line subscribe to
+> `LifecycleCapability`; the `aether.lifecycle.tick` kind id is unchanged, so
+> there is no load-time error — an un-migrated subscriber silently stops
+> receiving ticks.
+
 ## Context
 
 The chassis lifecycle today — `init` → repeated (`tick` → `render` → `present`) → `shutdown` — is encoded in hand-written driver code per chassis (`crates/aether-substrate-bundle/src/{desktop,headless,hub,test_bench}/`). ADR-0074 §Decision 5 layered a single `FRAME_BARRIER: bool` const on every actor to mark "drains within the per-frame barrier vs runs free," and that const is the only first-class structure naming the frame. Everything else — what stages exist, what they emit, what order they fire — is implicit.

--- a/docs/guide/systems/input.md
+++ b/docs/guide/systems/input.md
@@ -3,28 +3,29 @@
 > **Governing ADRs:** [ADR-0021](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0021-input-stream-subscriptions.md)
 > (publish/subscribe routing), [ADR-0068](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0068-input-subscribers-keyed-by-kindid.md)
 > (subscribers keyed by `KindId`). The model — subscribe by kind, fan out to
-> every subscriber — is **stable**. One stream, `Tick`, is also a frame
-> lifecycle stage; what *drives its cadence* lives in the lifecycle state
-> machine (its own page) — this page covers how you receive it and the rest.
+> every subscriber — is **stable**. This page covers the input interrupts
+> (key, mouse, window-size). The per-frame `Tick` is a frame-lifecycle stage:
+> a component subscribes it on `aether.lifecycle`, not here — the lifecycle
+> state machine (its own page) owns it.
 
-The substrate owns the window, the keyboard, the mouse, and the per-frame clock.
-The events they produce — a key down, the cursor moving, a resize, a tick —
-reach actors as ordinary mail through one mailbox, `aether.input`, on a
-publish/subscribe model. An actor that wants a stream **subscribes** to it; the
-substrate fans each event out to every subscriber. Nothing is pushed at an actor
-that didn't ask; a stream with no subscribers is dropped at the source.
+The substrate owns the window, the keyboard, and the mouse. The events they
+produce — a key down, the cursor moving, a resize — reach actors as ordinary
+mail through one mailbox, `aether.input`, on a publish/subscribe model. An actor
+that wants a stream **subscribes** to it; the substrate fans each event out to
+every subscriber. Nothing is pushed at an actor that didn't ask; a stream with
+no subscribers is dropped at the source.
 
 When you author a component, this is how it feels the world — you subscribe to
-`Tick` to advance each frame, to `Key` to react to input, to `WindowSize` to
-track the viewport. When you drive over MCP, input normally originates at the
-platform layer, but you can inject a synthetic event by mailing its kind to
-`aether.input`, which fans it out to whoever subscribed.
+`Key` to react to keystrokes, to `MouseMove` to follow the cursor, to
+`WindowSize` to track the viewport. When you drive over MCP, input normally
+originates at the platform layer, but you can inject a synthetic event by mailing
+its kind to `aether.input`, which fans it out to whoever subscribed.
 
 ## Why it exists
 
-Several actors can want the same input at once. A renderer, a physics step, and
-a telemetry collector might all advance on `Tick`; a debug overlay might watch
-keystrokes alongside the component reacting to them. Routing input to a single
+Several actors can want the same input at once. A gameplay actor and a debug
+overlay might both watch keystrokes; a HUD and a renderer might both want resize
+events. Routing input to a single
 owner would force the extra listeners to fan out through that one — the
 incidental coupling the mail-first design exists to avoid. So the substrate keeps
 a subscriber *set* per stream and broadcasts to every member, the same shape
@@ -50,15 +51,13 @@ the `InputCapability` actor — the sole owner of the subscriber table
 | `aether.mouse_move` | cursor movement |
 | `aether.mouse_button` | a mouse-button press |
 | `aether.window_size` | a resize |
-| `aether.lifecycle.tick` | each frame — see below |
 
-**`Tick` is a lifecycle stage you happen to subscribe to here.** Its kind name is
-`aether.lifecycle.tick`, not `aether.input.*`, because the per-frame advance is
-the substrate's lifecycle state machine — that's what emits a tick each frame.
-But you subscribe to it through `aether.input` exactly like the other streams,
-and it fans out the same way, so from a component's seat `Tick` is just another
-stream. The cadence behind it — when a frame advances, and what it waits on — is
-the lifecycle page's subject, not this one.
+**`Tick` lives on the lifecycle, not here.** The per-frame advance is the
+substrate's frame-lifecycle state machine (`aether.lifecycle.tick`), so a
+component subscribes the `Tick` stage directly on `aether.lifecycle` —
+`ctx.actor::<LifecycleCapability>().subscribe(Tick::ID, me)` (ADR-0082), the same
+subscribe shape as the input streams below. `Key`, `MouseMove`, and the rest are
+genuine input interrupts and stay on `aether.input`.
 
 **Subscribe and unsubscribe are mail.** Three control kinds on `aether.input`:
 
@@ -95,7 +94,7 @@ with mail allowed. Address the cap by type and name the kind:
 fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
     let me = MailboxId(ctx.mailbox_id());
     let input = ctx.actor::<InputCapability>();
-    input.subscribe(Tick::ID, me);
+    input.subscribe(Key::ID, me);
     input.subscribe(WindowSize::ID, me);
 }
 ```
@@ -104,20 +103,22 @@ Then handle each stream as its kind, like any other mail:
 
 ```rust
 #[handler]
-fn on_tick(&mut self, ctx: &mut FfiCtx<'_>, _tick: Tick) { /* advance a frame */ }
+fn on_key(&mut self, ctx: &mut FfiCtx<'_>, key: Key) { /* react to a keystroke */ }
 ```
 
-The reference `aether-camera` subscribes `Tick` and `WindowSize` this way and
-advances its cameras on each. You don't unsubscribe on the way out — the host
-clears your subscriptions when the component drops.
+The reference `aether-camera` subscribes `WindowSize` this way to track the
+viewport, and subscribes the `Tick` and `Render` lifecycle stages on
+`aether.lifecycle` to advance and submit each frame. You don't unsubscribe on the
+way out — the host clears your subscriptions when the component drops.
 
 **From an agent over MCP.** Input originates at the platform layer, so the usual
 way you see it is through a subscribed component's behavior or its logs. To drive
 a component without a real keyboard — in a test, or on the headless chassis — mail
 the event's kind straight to `aether.input` (`aether.key`, `aether.mouse_move`,
 …) and the cap fans it out to subscribers just as a platform event would. The
-per-frame `Tick` is the exception: its cadence is the lifecycle driver's job, not
-something you pump by hand.
+per-frame `Tick` is not an input stream: it is a frame-lifecycle stage on
+`aether.lifecycle`, advanced by the lifecycle driver, so you don't pump it
+through `aether.input` by hand.
 
 ## How to extend or reuse it
 


### PR DESCRIPTION
Closes iamacoffeepot/aether#1490.

## Summary

Subscribes `Tick` directly on `aether.lifecycle` and retires the `aether.input` relay, cleanly separating input-interrupts (key/mouse/window-size, on `aether.input`) from frame-stages (`Tick`/`Render`, owned by `aether.lifecycle`).

- `InputCapability` no longer handles/relays `Tick`; both lifecycle configs drop the `initial_subscribers: [(Tick::ID, aether.input)]` relay (now `vec![]`).
- Every in-tree `Tick` subscriber moves to `LifecycleCapability` (`aether-camera`, the test-fixtures probe, the `aether-actor` examples, the perf harness `TickSource`, the sokoban demo, and the bench lineage test). `WindowSize` stays on `aether.input`; `aether-mesh-viewer` already subscribes `Render` only, so it's untouched.
- No unsubscribe/cleanup logic needed here — #1491's `LifecycleUnsubscribeAll` + `on_drop_component` notification already clears a dropped component's lifecycle stage subscriptions on main.

## Reviewer note — scope widened to match the plan's goal

The plan's affected-surfaces list named three subscribers, but five more in-tree actors still subscribed `Tick` via `aether.input`. Leaving any on `aether.input` would silently dead-end them (no ticks) once the relay and `InputCapability::on_tick` were gone — so all were migrated, honoring the plan's stated goal ("every in-tree `Tick` subscriber subscribes on `aether.lifecycle`"). This is required for correctness, not gold-plating.

A one-line doc fix is folded in: the `LifecycleConfig::initial_subscribers` rustdoc cited `(Tick::ID, aether.input)` as its example — exactly the relay this change retires — so it's reworded to a generic description.

## Test plan

- Full pre-flight green: fmt, clippy `--workspace --all-targets -D warnings`, doc, wasm32 cross-build, `cargo nextest run --workspace --all-features` (1561 passed, 6 skipped).
- The ADR-0021 input round-trip tests are retargeted from `Tick` (no longer an input stream) onto the genuine `Key` stream (new `KeyObserved` fixture kind + probe `on_key`); the drop-clear test still exercises input-subscription clearing. The lineage bench test subscribes `Tick` on `aether.lifecycle`. Camera scenario tests pass unchanged (same pixels).
- Guide (`docs/guide/systems/input.md`) drops `Tick` from the input-streams table and redirects it to the lifecycle domain; ADR-0021/0068/0082 carry amendment notes (no new ADR).

## Generated by

Agent execution of scoped issue #1490 via the release implement flow.
