### PR TITLE
refactor(capabilities): ergonomic subscribe — generic stage, implicit-sender default, gated override

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,8 +112,7 @@ impl FfiActor for CameraComponent {
     fn init<C: Resolver>(ctx: &mut C) -> Result<Self, BootError> { /* build state */ }
 
     fn wire(&mut self, ctx: &mut FfiCtx<'_>) {              // post-init, mail allowed
-        let me = MailboxId(ctx.mailbox_id());
-        ctx.actor::<InputCapability>().subscribe(Tick::ID, me);
+        ctx.actor::<LifecycleCapability>().subscribe::<Tick>(); // subscribe the calling actor
     }
 
     #[handler]

--- a/crates/aether-actor/examples/caller.rs
+++ b/crates/aether-actor/examples/caller.rs
@@ -24,7 +24,7 @@
 use aether_actor::{BootError, FfiActor, FfiCtx, MailSender, Resolver, actor};
 use aether_capabilities::LifecycleCapability;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
-use aether_data::{Kind, MailboxId, Schema};
+use aether_data::{Kind, Schema};
 use aether_kinds::Tick;
 use bytemuck::{Pod, Zeroable};
 
@@ -59,8 +59,7 @@ impl FfiActor for Caller {
 
     //noinspection DuplicatedCode
     fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
-        ctx.actor::<LifecycleCapability>()
-            .subscribe(Tick::ID, MailboxId(ctx.mailbox_id()));
+        ctx.actor::<LifecycleCapability>().subscribe::<Tick>();
     }
 
     #[handler]

--- a/crates/aether-actor/examples/hello.rs
+++ b/crates/aether-actor/examples/hello.rs
@@ -24,7 +24,6 @@
 use aether_actor::{BootError, FfiActor, FfiCtx, KindId, Resolver, actor};
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::{LifecycleCapability, RenderCapability};
-use aether_data::{Kind, MailboxId};
 use aether_kinds::{DrawTriangle, Ping, Pong, Tick, Vertex};
 
 static TRIANGLE: DrawTriangle = DrawTriangle {
@@ -84,8 +83,7 @@ impl FfiActor for Hello {
 
     //noinspection DuplicatedCode
     fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
-        ctx.actor::<LifecycleCapability>()
-            .subscribe(Tick::ID, MailboxId(ctx.mailbox_id()));
+        ctx.actor::<LifecycleCapability>().subscribe::<Tick>();
     }
 
     /// Emits the configured triangle to the render sink every tick.

--- a/crates/aether-camera/src/runtime.rs
+++ b/crates/aether-camera/src/runtime.rs
@@ -47,7 +47,6 @@ use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
 use aether_capabilities::input::InputMailboxExt;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::{InputCapability, LifecycleCapability, RenderCapability};
-use aether_data::{Kind, MailboxId};
 use aether_kinds::{Camera, Render, Tick, WindowSize};
 use aether_math::{Mat4, PI, Quat, TAU, Vec2, Vec3};
 
@@ -289,11 +288,10 @@ impl FfiActor for CameraComponent {
     /// receives `Render` and never submits — a no-op there, where the
     /// render cap discards anyway (ADR-0082 §7 / §11).
     fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
-        let me = MailboxId(ctx.mailbox_id());
-        ctx.actor::<InputCapability>().subscribe(WindowSize::ID, me);
+        ctx.actor::<InputCapability>().subscribe::<WindowSize>();
         let lifecycle = ctx.actor::<LifecycleCapability>();
-        lifecycle.subscribe(Tick::ID, me);
-        lifecycle.subscribe(Render::ID, me);
+        lifecycle.subscribe::<Tick>();
+        lifecycle.subscribe::<Render>();
     }
 
     /// Advance every camera's per-mode state each tick. Inactive cameras

--- a/crates/aether-capabilities/src/input.rs
+++ b/crates/aether-capabilities/src/input.rs
@@ -28,12 +28,12 @@
 #![allow(clippy::needless_pass_by_value)]
 
 use aether_actor::FfiActorMailbox;
-use aether_data::{KindId, MailboxId};
+use aether_data::{Kind, MailboxId};
 #[cfg(not(target_arch = "wasm32"))]
 use aether_kinds::SubscribeInputResult;
 use aether_kinds::{
-    Key, KeyRelease, MouseButton, MouseMove, SubscribeInput, UnsubscribeAll, UnsubscribeInput,
-    WindowSize,
+    Key, KeyRelease, MouseButton, MouseMove, SubscribeInput, SubscribeInputSelf, UnsubscribeAll,
+    UnsubscribeInput, UnsubscribeInputSelf, WindowSize,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use aether_substrate::actor::native::NativeActorMailbox;
@@ -44,11 +44,12 @@ pub use native::InputConfig;
 /// Sender-side facade for callers addressing [`InputCapability`] via
 /// `ctx.actor::<InputCapability>()`.
 ///
-/// Lifts the cap-shaped operations (`subscribe(kind, mailbox)`,
-/// `unsubscribe(kind, mailbox)`, `unsubscribe_all(mailbox)`) one
-/// indirection above the raw `.send(&SubscribeInput { .. })` so
-/// component code stops reconstructing the kind struct at every call
-/// site. Same shape and rationale as [`crate::fs::FsMailboxExt`]
+/// Lifts the cap-shaped operations (`subscribe::<K>()`,
+/// `subscribe_for::<K>(mailbox)`, the `unsubscribe` twins,
+/// `unsubscribe_all(mailbox)`) one indirection above the raw
+/// `.send(&SubscribeInput { .. })` so component code stops
+/// reconstructing the kind struct at every call site. Same shape and
+/// rationale as [`crate::fs::FsMailboxExt`]
 /// (issue 580) and [`crate::component::ComponentHostFfiExt`] (issue
 /// 654) — the cap module owns receive-side ([`InputCapability`]) AND
 /// send-side ([`InputMailboxExt`]) so future kind additions land both
@@ -71,13 +72,29 @@ pub use native::InputConfig;
 /// still works for any `K` the cap declares via `HandlesKind<K>`,
 /// since `send` is an inherent method on the underlying mailbox type.
 pub trait InputMailboxExt {
-    /// Mail `aether.input.subscribe { kind, mailbox }` to the cap.
-    /// Add `mailbox` to the subscriber set for `kind`. Idempotent.
-    fn subscribe(&self, kind: KindId, mailbox: MailboxId);
+    /// Mail `aether.input.subscribe_self { kind }` to the cap —
+    /// subscribe the *calling* actor to the input stream for `K` (e.g.
+    /// `Key` / `MouseMove` / `WindowSize`). The cap resolves the
+    /// subscriber from the inbound's host-stamped `Source` (ADR-0083),
+    /// so the call site spells out neither the kind id nor its own
+    /// mailbox. This is the common form. Idempotent.
+    fn subscribe<K: Kind>(&self);
+
+    /// Mail `aether.input.subscribe { kind, mailbox }` to the cap. Add
+    /// an *explicit* `mailbox` to the subscriber set for `K`. The rare
+    /// cross-mailbox form; [`subscribe`](Self::subscribe) covers the
+    /// self case. Idempotent.
+    fn subscribe_for<K: Kind>(&self, mailbox: MailboxId);
+
+    /// Mail `aether.input.unsubscribe_self { kind }` to the cap —
+    /// unsubscribe the *calling* actor from the input stream for `K`.
+    /// Reflexive twin of [`subscribe`](Self::subscribe). Idempotent.
+    fn unsubscribe<K: Kind>(&self);
 
     /// Mail `aether.input.unsubscribe { kind, mailbox }` to the cap.
-    /// Remove `mailbox` from the subscriber set for `kind`. Idempotent.
-    fn unsubscribe(&self, kind: KindId, mailbox: MailboxId);
+    /// Remove an *explicit* `mailbox` from the subscriber set for `K`.
+    /// Idempotent.
+    fn unsubscribe_for<K: Kind>(&self, mailbox: MailboxId);
 
     /// Mail `aether.input.unsubscribe_all { mailbox }` to the cap.
     /// Remove `mailbox` from every input stream's subscriber set;
@@ -86,11 +103,23 @@ pub trait InputMailboxExt {
 }
 
 impl InputMailboxExt for FfiActorMailbox<InputCapability> {
-    fn subscribe(&self, kind: KindId, mailbox: MailboxId) {
-        self.send(&SubscribeInput { kind, mailbox });
+    fn subscribe<K: Kind>(&self) {
+        self.send(&SubscribeInputSelf { kind: K::ID });
     }
-    fn unsubscribe(&self, kind: KindId, mailbox: MailboxId) {
-        self.send(&UnsubscribeInput { kind, mailbox });
+    fn subscribe_for<K: Kind>(&self, mailbox: MailboxId) {
+        self.send(&SubscribeInput {
+            kind: K::ID,
+            mailbox,
+        });
+    }
+    fn unsubscribe<K: Kind>(&self) {
+        self.send(&UnsubscribeInputSelf { kind: K::ID });
+    }
+    fn unsubscribe_for<K: Kind>(&self, mailbox: MailboxId) {
+        self.send(&UnsubscribeInput {
+            kind: K::ID,
+            mailbox,
+        });
     }
     fn unsubscribe_all(&self, mailbox: MailboxId) {
         self.send(&UnsubscribeAll { mailbox });
@@ -99,11 +128,23 @@ impl InputMailboxExt for FfiActorMailbox<InputCapability> {
 
 #[cfg(not(target_arch = "wasm32"))]
 impl InputMailboxExt for NativeActorMailbox<'_, InputCapability> {
-    fn subscribe(&self, kind: KindId, mailbox: MailboxId) {
-        self.send(&SubscribeInput { kind, mailbox });
+    fn subscribe<K: Kind>(&self) {
+        self.send(&SubscribeInputSelf { kind: K::ID });
     }
-    fn unsubscribe(&self, kind: KindId, mailbox: MailboxId) {
-        self.send(&UnsubscribeInput { kind, mailbox });
+    fn subscribe_for<K: Kind>(&self, mailbox: MailboxId) {
+        self.send(&SubscribeInput {
+            kind: K::ID,
+            mailbox,
+        });
+    }
+    fn unsubscribe<K: Kind>(&self) {
+        self.send(&UnsubscribeInputSelf { kind: K::ID });
+    }
+    fn unsubscribe_for<K: Kind>(&self, mailbox: MailboxId) {
+        self.send(&UnsubscribeInput {
+            kind: K::ID,
+            mailbox,
+        });
     }
     fn unsubscribe_all(&self, mailbox: MailboxId) {
         self.send(&UnsubscribeAll { mailbox });
@@ -114,7 +155,7 @@ impl InputMailboxExt for NativeActorMailbox<'_, InputCapability> {
 mod native {
     use super::{
         Key, KeyRelease, MouseButton, MouseMove, SubscribeInput, SubscribeInputResult,
-        UnsubscribeAll, UnsubscribeInput, WindowSize,
+        SubscribeInputSelf, UnsubscribeAll, UnsubscribeInput, UnsubscribeInputSelf, WindowSize,
     };
     use aether_actor::actor;
     use aether_actor::actor::ctx::OutboundReply;
@@ -187,6 +228,40 @@ mod native {
             ctx.reply(&result);
         }
 
+        /// Subscribe the *sending* actor to an input stream (ADR-0021,
+        /// ADR-0083). Resolves the subscriber from the inbound
+        /// envelope's host-stamped `Source` via
+        /// [`source_mailbox`](NativeCtx::source_mailbox) rather than a
+        /// caller-supplied mailbox, so the subscriber cannot be forged
+        /// and the reflexive op is gated to in-process actors by
+        /// construction — a sender with no local mailbox (an external
+        /// session or another engine) gets an `Err` reply and is
+        /// subscribed to nothing. The host stamp already names a live
+        /// component mailbox, so no [`validate_subscriber_mailbox`]
+        /// pass is needed on this path.
+        ///
+        /// # Agent
+        /// `SubscribeInputSelf { kind }`.
+        #[handler]
+        fn on_subscribe_self(&mut self, ctx: &mut NativeCtx<'_>, payload: SubscribeInputSelf) {
+            let result = match ctx.source_mailbox() {
+                Some(mailbox) => {
+                    self.subscribers
+                        .entry(payload.kind)
+                        .or_default()
+                        .insert(mailbox);
+                    SubscribeInputResult::Ok
+                }
+                None => SubscribeInputResult::Err {
+                    error: "aether.input.subscribe_self requires a local component sender; an \
+                            external session or remote engine must use aether.input.subscribe \
+                            with an explicit mailbox"
+                        .to_string(),
+                },
+            };
+            ctx.reply(&result);
+        }
+
         /// Unsubscribe a mailbox from an input stream (ADR-0021).
         ///
         /// # Agent
@@ -202,6 +277,33 @@ mod native {
                     SubscribeInputResult::Ok
                 }
                 Err(error) => SubscribeInputResult::Err { error },
+            };
+            ctx.reply(&result);
+        }
+
+        /// Unsubscribe the *sending* actor from an input stream
+        /// (ADR-0021, ADR-0083). Resolves the subscriber from the
+        /// inbound's host-stamped `Source`, mirroring
+        /// [`Self::on_subscribe_self`]. `None` (no local sender) replies
+        /// `Err`. Idempotent on "not currently subscribed."
+        ///
+        /// # Agent
+        /// `UnsubscribeInputSelf { kind }`.
+        #[handler]
+        fn on_unsubscribe_self(&mut self, ctx: &mut NativeCtx<'_>, payload: UnsubscribeInputSelf) {
+            let result = match ctx.source_mailbox() {
+                Some(mailbox) => {
+                    if let Some(set) = self.subscribers.get_mut(&payload.kind) {
+                        set.remove(&mailbox);
+                    }
+                    SubscribeInputResult::Ok
+                }
+                None => SubscribeInputResult::Err {
+                    error: "aether.input.unsubscribe_self requires a local component sender; an \
+                            external session or remote engine must use aether.input.unsubscribe \
+                            with an explicit mailbox"
+                        .to_string(),
+                },
             };
             ctx.reply(&result);
         }
@@ -283,6 +385,72 @@ mod native {
             Some(MailboxEntry::Inbox { .. } | MailboxEntry::Inline(_)) => Ok(()),
             Some(MailboxEntry::Dropped) => Err(format!("mailbox {id:?} already dropped")),
             None => Err(format!("unknown mailbox id {id:?}")),
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use aether_substrate::actor::native::binding::NativeBinding;
+        use aether_substrate::handle_store::HandleStore;
+        use aether_substrate::mail::mailer::Mailer;
+        use aether_substrate::mail::{MailId, Source, SourceAddr};
+
+        fn test_cap() -> InputCapability {
+            InputCapability {
+                registry: Arc::new(Registry::new()),
+                subscribers: HashMap::new(),
+            }
+        }
+
+        fn test_mailer() -> Arc<Mailer> {
+            Arc::new(Mailer::new(
+                Arc::new(Registry::new()),
+                Arc::new(HandleStore::new(1024)),
+            ))
+        }
+
+        /// A `subscribe_self` carrying a `Component` source lands *that*
+        /// mailbox in the stream set (ADR-0083: the cap reads the
+        /// subscriber off the host-stamped envelope, not a payload field).
+        #[test]
+        fn subscribe_self_subscribes_the_component_source() {
+            let mut cap = test_cap();
+            let key = <Key as Kind>::ID;
+            let sender = MailboxId(0x00C0_FFEE);
+
+            let transport = Arc::new(NativeBinding::new_for_test(test_mailer(), MailboxId(0)));
+            let source = Source::to(SourceAddr::Component(sender));
+            let mut ctx = NativeCtx::new(&transport, source, MailId::NONE, MailId::NONE);
+            cap.on_subscribe_self(&mut ctx, SubscribeInputSelf { kind: key });
+
+            assert!(
+                cap.subscribers
+                    .get(&key)
+                    .is_some_and(|s| s.contains(&sender)),
+                "a Component-source subscribe_self lands that mailbox in the stream set"
+            );
+        }
+
+        /// A `subscribe_self` from a non-`Component` source (an external
+        /// session) replies `Err` and subscribes nothing — the reflexive
+        /// form is gated to in-process actors by construction.
+        #[test]
+        fn subscribe_self_rejects_non_component_source() {
+            use aether_data::{SessionToken, Uuid};
+
+            let mut cap = test_cap();
+            let key = <Key as Kind>::ID;
+
+            let transport = Arc::new(NativeBinding::new_for_test(test_mailer(), MailboxId(0)));
+            let source = Source::to(SourceAddr::Session(SessionToken(Uuid::from_u128(0xFEED))));
+            let mut ctx = NativeCtx::new(&transport, source, MailId::NONE, MailId::NONE);
+            cap.on_subscribe_self(&mut ctx, SubscribeInputSelf { kind: key });
+
+            assert!(
+                cap.subscribers.get(&key).is_none_or(BTreeSet::is_empty),
+                "a non-Component source subscribes nothing"
+            );
         }
     }
 }

--- a/crates/aether-capabilities/src/lifecycle.rs
+++ b/crates/aether-capabilities/src/lifecycle.rs
@@ -9,7 +9,7 @@
 //! [`InputCapability`](crate::input::InputCapability) and
 //! `RenderCapability`, its
 //! `NAMESPACE` is wasm-reachable: a component subscribes a stage via
-//! `ctx.actor::<LifecycleCapability>().subscribe(Render::ID, me)`.
+//! `ctx.actor::<LifecycleCapability>().subscribe::<Render>()`.
 //!
 //! On each [`LifecycleAdvance`] the cap:
 //!
@@ -41,7 +41,8 @@ use aether_actor::FfiActorMailbox;
 use aether_data::{Kind, KindId, MailboxId};
 use aether_kinds::trace::Settled;
 use aether_kinds::{
-    LifecycleAdvance, LifecycleSubscribe, LifecycleUnsubscribe, LifecycleUnsubscribeAll, Quit,
+    LifecycleAdvance, LifecycleSubscribe, LifecycleSubscribeSelf, LifecycleUnsubscribe,
+    LifecycleUnsubscribeAll, LifecycleUnsubscribeSelf, Quit,
 };
 // Reply types ride only the native handler bodies (via `super::`), so they
 // elide on wasm where `mod native` is compiled out.
@@ -79,28 +80,48 @@ pub use native::LifecycleConfig;
 /// still works, since `send` is an inherent method on the underlying
 /// mailbox type.
 pub trait LifecycleMailboxExt {
+    /// Mail `aether.lifecycle.subscribe_self { stage }` to the cap —
+    /// subscribe the *calling* actor to the lifecycle stage `K` (a
+    /// stage kind, e.g. `Tick` / `Render`). The cap resolves the
+    /// subscriber from the inbound's host-stamped `Source` (ADR-0083),
+    /// so the call site spells out neither the stage id nor its own
+    /// mailbox. This is the common form. Idempotent.
+    fn subscribe<K: Kind>(&self);
+
     /// Mail `aether.lifecycle.subscribe { stage, mailbox }` to the cap.
-    /// Add `mailbox` to the subscriber set for the lifecycle stage
-    /// `stage` (a stage kind's [`KindId`], e.g. `Render::ID`).
-    /// Idempotent.
-    fn subscribe(&self, stage: KindId, mailbox: MailboxId);
+    /// Add an *explicit* `mailbox` to the subscriber set for stage `K`.
+    /// The rare cross-mailbox form; [`subscribe`](Self::subscribe)
+    /// covers the self case. Idempotent.
+    fn subscribe_for<K: Kind>(&self, mailbox: MailboxId);
+
+    /// Mail `aether.lifecycle.unsubscribe_self { stage }` to the cap —
+    /// unsubscribe the *calling* actor from stage `K`. Reflexive twin
+    /// of [`subscribe`](Self::subscribe). Idempotent on "not currently
+    /// subscribed."
+    fn unsubscribe<K: Kind>(&self);
 
     /// Mail `aether.lifecycle.unsubscribe { stage, mailbox }` to the
-    /// cap. Remove `mailbox` from the subscriber set for `stage`.
-    /// Idempotent on "not currently subscribed."
-    fn unsubscribe(&self, stage: KindId, mailbox: MailboxId);
+    /// cap. Remove an *explicit* `mailbox` from the subscriber set for
+    /// stage `K`. Idempotent on "not currently subscribed."
+    fn unsubscribe_for<K: Kind>(&self, mailbox: MailboxId);
 }
 
 impl LifecycleMailboxExt for FfiActorMailbox<LifecycleCapability> {
-    fn subscribe(&self, stage: KindId, mailbox: MailboxId) {
+    fn subscribe<K: Kind>(&self) {
+        self.send(&LifecycleSubscribeSelf { stage: K::ID.0 });
+    }
+    fn subscribe_for<K: Kind>(&self, mailbox: MailboxId) {
         self.send(&LifecycleSubscribe {
-            stage: stage.0,
+            stage: K::ID.0,
             mailbox: mailbox.0,
         });
     }
-    fn unsubscribe(&self, stage: KindId, mailbox: MailboxId) {
+    fn unsubscribe<K: Kind>(&self) {
+        self.send(&LifecycleUnsubscribeSelf { stage: K::ID.0 });
+    }
+    fn unsubscribe_for<K: Kind>(&self, mailbox: MailboxId) {
         self.send(&LifecycleUnsubscribe {
-            stage: stage.0,
+            stage: K::ID.0,
             mailbox: mailbox.0,
         });
     }
@@ -108,15 +129,21 @@ impl LifecycleMailboxExt for FfiActorMailbox<LifecycleCapability> {
 
 #[cfg(not(target_arch = "wasm32"))]
 impl LifecycleMailboxExt for NativeActorMailbox<'_, LifecycleCapability> {
-    fn subscribe(&self, stage: KindId, mailbox: MailboxId) {
+    fn subscribe<K: Kind>(&self) {
+        self.send(&LifecycleSubscribeSelf { stage: K::ID.0 });
+    }
+    fn subscribe_for<K: Kind>(&self, mailbox: MailboxId) {
         self.send(&LifecycleSubscribe {
-            stage: stage.0,
+            stage: K::ID.0,
             mailbox: mailbox.0,
         });
     }
-    fn unsubscribe(&self, stage: KindId, mailbox: MailboxId) {
+    fn unsubscribe<K: Kind>(&self) {
+        self.send(&LifecycleUnsubscribeSelf { stage: K::ID.0 });
+    }
+    fn unsubscribe_for<K: Kind>(&self, mailbox: MailboxId) {
         self.send(&LifecycleUnsubscribe {
-            stage: stage.0,
+            stage: K::ID.0,
             mailbox: mailbox.0,
         });
     }
@@ -486,8 +513,8 @@ mod native {
 
     use super::{
         LifecycleAdvance, LifecycleAdvanceComplete, LifecycleGraphData, LifecycleStateData,
-        LifecycleSubscribe, LifecycleSubscribeResult, LifecycleUnsubscribe,
-        LifecycleUnsubscribeAll, Quit, Settled,
+        LifecycleSubscribe, LifecycleSubscribeResult, LifecycleSubscribeSelf, LifecycleUnsubscribe,
+        LifecycleUnsubscribeAll, LifecycleUnsubscribeSelf, Quit, Settled,
     };
 
     /// Internal state-advance decision produced by `on_advance` before
@@ -680,6 +707,54 @@ mod native {
             ctx.reply(&result);
         }
 
+        /// Subscribe the *sending* actor to a lifecycle stage broadcast
+        /// (ADR-0082 §7, ADR-0083). Resolves the subscriber from the
+        /// inbound envelope's host-stamped `Source` via
+        /// [`source_mailbox`](NativeCtx::source_mailbox) rather than a
+        /// caller-supplied mailbox, so the subscriber cannot be forged.
+        /// `None` means the sender has no local mailbox (an external
+        /// session or another engine) — reply `Err` and subscribe
+        /// nothing, which gates the reflexive form to in-process actors
+        /// by construction. Reuses [`Self::on_subscribe`]'s insert path
+        /// once the mailbox is resolved.
+        ///
+        /// # Agent
+        /// `LifecycleSubscribeSelf { stage }`. Stage must be a kind id
+        /// registered as a state or terminal in the lifecycle graph.
+        #[handler]
+        fn on_subscribe_self(&mut self, ctx: &mut NativeCtx<'_>, payload: LifecycleSubscribeSelf) {
+            let stage_kind = KindId(payload.stage);
+            let result = match ctx.source_mailbox() {
+                None => LifecycleSubscribeResult::Err {
+                    stage: payload.stage,
+                    error: "aether.lifecycle.subscribe_self requires a local component sender; \
+                            an external session or remote engine must use \
+                            aether.lifecycle.subscribe with an explicit mailbox"
+                        .to_string(),
+                },
+                Some(sender) => {
+                    let known = self.graph.state(stage_kind).is_some()
+                        || self.graph.is_terminal(stage_kind);
+                    if known {
+                        self.subscribers
+                            .entry(stage_kind)
+                            .or_default()
+                            .insert(DataMailboxId(sender.0));
+                        LifecycleSubscribeResult::Ok
+                    } else {
+                        LifecycleSubscribeResult::Err {
+                            stage: payload.stage,
+                            error: format!(
+                                "stage {stage_kind:?} is not declared by this chassis's \
+                                 lifecycle graph"
+                            ),
+                        }
+                    }
+                }
+            };
+            ctx.reply(&result);
+        }
+
         /// Unsubscribe a mailbox from a lifecycle stage broadcast.
         /// Idempotent on "not currently subscribed."
         ///
@@ -702,6 +777,52 @@ mod native {
                     error: format!(
                         "stage {stage_kind:?} is not declared by this chassis's lifecycle graph"
                     ),
+                }
+            };
+            ctx.reply(&result);
+        }
+
+        /// Unsubscribe the *sending* actor from a lifecycle stage
+        /// broadcast (ADR-0082 §7, ADR-0083). Resolves the subscriber
+        /// from the inbound envelope's host-stamped `Source` via
+        /// [`source_mailbox`](NativeCtx::source_mailbox), mirroring
+        /// [`Self::on_subscribe_self`]. `None` (no local sender) replies
+        /// `Err`. Idempotent on "not currently subscribed."
+        ///
+        /// # Agent
+        /// `LifecycleUnsubscribeSelf { stage }`.
+        #[handler]
+        fn on_unsubscribe_self(
+            &mut self,
+            ctx: &mut NativeCtx<'_>,
+            payload: LifecycleUnsubscribeSelf,
+        ) {
+            let stage_kind = KindId(payload.stage);
+            let result = match ctx.source_mailbox() {
+                None => LifecycleSubscribeResult::Err {
+                    stage: payload.stage,
+                    error: "aether.lifecycle.unsubscribe_self requires a local component sender; \
+                            an external session or remote engine must use \
+                            aether.lifecycle.unsubscribe with an explicit mailbox"
+                        .to_string(),
+                },
+                Some(sender) => {
+                    let known = self.graph.state(stage_kind).is_some()
+                        || self.graph.is_terminal(stage_kind);
+                    if known {
+                        if let Some(set) = self.subscribers.get_mut(&stage_kind) {
+                            set.remove(&DataMailboxId(sender.0));
+                        }
+                        LifecycleSubscribeResult::Ok
+                    } else {
+                        LifecycleSubscribeResult::Err {
+                            stage: payload.stage,
+                            error: format!(
+                                "stage {stage_kind:?} is not declared by this chassis's \
+                                 lifecycle graph"
+                            ),
+                        }
+                    }
                 }
             };
             ctx.reply(&result);
@@ -1070,7 +1191,7 @@ mod native {
         //! ADR-0082 §3 quit-flag semantics and the #1048/#1052
         //! settlement-latency gate, pinned at the unit layer.
         use super::*;
-        use aether_kinds::{Present, Render, Shutdown};
+        use aether_kinds::{Present, Render, Shutdown, Tick};
         use aether_substrate::handle_store::HandleStore;
         use aether_substrate::mail::registry::Registry;
 
@@ -1235,6 +1356,177 @@ mod native {
                 "co-subscribers on a shared stage must survive the purge"
             );
         }
+
+        /// A `Tick`→`Shutdown` graph fixture (the round-trip test wants
+        /// `Tick` as a declared stage, which `test_cap`'s Render-rooted
+        /// graph doesn't carry).
+        fn tick_start_graph_cap() -> LifecycleCapability {
+            let graph = LifecycleGraphData::builder()
+                .state::<Tick>()
+                .next::<Shutdown>()
+                .terminal::<Shutdown>()
+                .start::<Tick>()
+                .build()
+                .expect("test setup: tick graph builds");
+            let mailer = Arc::new(Mailer::new(
+                Arc::new(Registry::default()),
+                Arc::new(HandleStore::new(1024)),
+            ));
+            LifecycleCapability {
+                current_state: graph.start(),
+                graph,
+                subscribers: BTreeMap::new(),
+                terminal_reached: false,
+                quit_pending: false,
+                pending: None,
+                advance_timeout: Duration::from_millis(ADVANCE_TIMEOUT_MS_DEFAULT),
+                settlement_latency_ewma: None,
+                last_slow_warn: None,
+                mailer,
+            }
+        }
+
+        /// A `subscribe_self` carrying a `Component` source lands *that*
+        /// mailbox in the stage set (ADR-0083: the cap reads the
+        /// subscriber off the host-stamped envelope, not a payload field).
+        #[test]
+        fn subscribe_self_subscribes_the_component_source() {
+            use aether_substrate::actor::native::binding::NativeBinding;
+            use aether_substrate::mail::SourceAddr;
+
+            let mut cap = test_cap(Duration::from_millis(ADVANCE_TIMEOUT_MS_DEFAULT));
+            let render = <Render as Kind>::ID;
+            let sender = DataMailboxId(0x00C0_FFEE);
+
+            let transport = Arc::new(NativeBinding::new_for_test(
+                Arc::clone(&cap.mailer),
+                MailboxId(0),
+            ));
+            let source = Source::to(SourceAddr::Component(MailboxId(sender.0)));
+            let mut ctx = NativeCtx::new(&transport, source, MailId::NONE, MailId::NONE);
+            cap.on_subscribe_self(&mut ctx, LifecycleSubscribeSelf { stage: render.0 });
+
+            assert!(
+                cap.subscribers
+                    .get(&render)
+                    .is_some_and(|s| s.contains(&sender)),
+                "a Component-source subscribe_self lands that mailbox in the stage set"
+            );
+        }
+
+        /// A `subscribe_self` from a non-`Component` source (an external
+        /// session) replies `Err` and subscribes nothing — the reflexive
+        /// form is gated to in-process actors by construction.
+        #[test]
+        fn subscribe_self_rejects_non_component_source() {
+            use aether_data::{SessionToken, Uuid};
+            use aether_substrate::actor::native::binding::NativeBinding;
+            use aether_substrate::mail::SourceAddr;
+
+            let mut cap = test_cap(Duration::from_millis(ADVANCE_TIMEOUT_MS_DEFAULT));
+            let render = <Render as Kind>::ID;
+
+            let transport = Arc::new(NativeBinding::new_for_test(
+                Arc::clone(&cap.mailer),
+                MailboxId(0),
+            ));
+            let source = Source::to(SourceAddr::Session(SessionToken(Uuid::from_u128(0xFEED))));
+            let mut ctx = NativeCtx::new(&transport, source, MailId::NONE, MailId::NONE);
+            cap.on_subscribe_self(&mut ctx, LifecycleSubscribeSelf { stage: render.0 });
+
+            assert!(
+                cap.subscribers.get(&render).is_none_or(BTreeSet::is_empty),
+                "a non-Component source subscribes nothing"
+            );
+        }
+
+        /// Round trip through the host SDK path: calling
+        /// `subscribe::<Tick>()` on a `NativeActorMailbox<LifecycleCapability>`
+        /// emits `LifecycleSubscribeSelf { stage = Tick::ID }` whose
+        /// `Source` the transport host-stamps to the calling actor, and
+        /// delivering that mail to the cap lands the calling actor in the
+        /// `Tick` stage set. The wasm FFI shims `export!` emits are
+        /// wasm32-only, so the host test drives the cap through
+        /// `NativeTransport`.
+        #[test]
+        fn subscribe_via_native_mailbox_lands_calling_actor_in_stage_set() {
+            use std::sync::mpsc;
+
+            use aether_substrate::actor::native::NativeActorMailbox;
+            use aether_substrate::actor::native::binding::NativeBinding;
+            use aether_substrate::mail::SourceAddr;
+            use aether_substrate::mail::registry::{InboxHandler, OwnedDispatch};
+
+            use crate::lifecycle::LifecycleMailboxExt;
+            use crate::test_chassis::fresh_substrate;
+
+            let (registry, mailer) = fresh_substrate();
+
+            // Capturing sink at the lifecycle mailbox: records the single
+            // mail the SDK `subscribe::<Tick>()` emits so the test can read
+            // back the kind, the host-stamped `Source`, and the payload.
+            let (tx, rx) = mpsc::channel::<(KindId, Source, Vec<u8>)>();
+            let handler: Arc<dyn InboxHandler> = Arc::new(move |dispatch: OwnedDispatch| {
+                let captured = (
+                    dispatch.kind,
+                    dispatch.sender,
+                    dispatch.payload.bytes().to_vec(),
+                );
+                dispatch.discharge();
+                let _ = tx.send(captured);
+            });
+            let lifecycle_id = registry.register_inbox(
+                <LifecycleCapability as aether_actor::Actor>::NAMESPACE,
+                handler,
+            );
+
+            // The calling actor: a transport stamped with SENDER as its
+            // self-mailbox, so its sends carry `Source::Component(SENDER)`.
+            let sender = DataMailboxId(0x00C0_FFEE);
+            let tx_binding = NativeBinding::new_for_test(Arc::clone(&mailer), MailboxId(sender.0));
+            let lifecycle =
+                NativeActorMailbox::<LifecycleCapability>::__new(lifecycle_id.0, &tx_binding);
+            lifecycle.subscribe::<Tick>();
+            tx_binding.flush_outbound();
+
+            let (kind, source, bytes) =
+                rx.try_recv().expect("subscribe::<Tick>() emitted one mail");
+            assert_eq!(
+                kind,
+                <LifecycleSubscribeSelf as Kind>::ID,
+                "the SDK self-subscribe sends LifecycleSubscribeSelf"
+            );
+            assert_eq!(
+                source.addr,
+                SourceAddr::Component(MailboxId(sender.0)),
+                "the host stamps the calling actor as the Source"
+            );
+            let decoded = LifecycleSubscribeSelf::decode_from_bytes(&bytes)
+                .expect("payload decodes as LifecycleSubscribeSelf");
+            assert_eq!(
+                decoded.stage,
+                <Tick as Kind>::ID.0,
+                "the payload carries the Tick stage id"
+            );
+
+            // Deliver the captured mail to the cap exactly as the
+            // dispatcher would, and confirm the calling actor is now in the
+            // Tick stage set.
+            let mut cap = tick_start_graph_cap();
+            let cap_transport = Arc::new(NativeBinding::new_for_test(
+                Arc::clone(&cap.mailer),
+                MailboxId(0),
+            ));
+            let mut ctx = NativeCtx::new(&cap_transport, source, MailId::NONE, MailId::NONE);
+            cap.on_subscribe_self(&mut ctx, decoded);
+
+            assert!(
+                cap.subscribers
+                    .get(&<Tick as Kind>::ID)
+                    .is_some_and(|s| s.contains(&sender)),
+                "the calling actor lands in the Tick stage set"
+            );
+        }
     }
 }
 
@@ -1374,7 +1666,9 @@ mod tests {
         fn assert_handles<R: HandlesKind<K>, K: Kind>() {}
         fn assert_singleton<R: Singleton>() {}
         assert_handles::<LifecycleCapability, LifecycleSubscribe>();
+        assert_handles::<LifecycleCapability, LifecycleSubscribeSelf>();
         assert_handles::<LifecycleCapability, LifecycleUnsubscribe>();
+        assert_handles::<LifecycleCapability, LifecycleUnsubscribeSelf>();
         assert_handles::<LifecycleCapability, LifecycleUnsubscribeAll>();
         assert_singleton::<LifecycleCapability>();
     }

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -270,6 +270,35 @@ pub struct LifecycleSubscribe {
     pub mailbox: u64,
 }
 
+/// Reflexive counterpart of [`LifecycleSubscribe`]: subscribe the
+/// *sending* actor to a lifecycle stage broadcast, with no explicit
+/// `mailbox` field. The cap resolves the subscriber from the inbound
+/// envelope's host-stamped `Source` (ADR-0083) via
+/// `ctx.source_mailbox()`, so the subscriber cannot be forged and the
+/// op is gated to in-process actors by construction — an external
+/// session or another engine has no local mailbox and gets an `Err`
+/// reply, pushing it onto the named [`LifecycleSubscribe`] form. This
+/// is the common "subscribe me" case; `stage` carries the same
+/// [`KindId`](aether_data::KindId) as [`LifecycleSubscribe`]. Substrate
+/// replies with [`LifecycleSubscribeResult`].
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Pod,
+    Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "aether.lifecycle.subscribe_self")]
+pub struct LifecycleSubscribeSelf {
+    pub stage: u64,
+}
+
 /// Unsubscribe counterpart of [`LifecycleSubscribe`]. Idempotent on
 /// "not currently subscribed."
 #[repr(C)]
@@ -289,6 +318,30 @@ pub struct LifecycleSubscribe {
 pub struct LifecycleUnsubscribe {
     pub stage: u64,
     pub mailbox: u64,
+}
+
+/// Reflexive counterpart of [`LifecycleUnsubscribe`]: unsubscribe the
+/// *sending* actor from a lifecycle stage, with no explicit `mailbox`
+/// field. The cap resolves the subscriber from the inbound envelope's
+/// host-stamped `Source` (ADR-0083), the same gating as
+/// [`LifecycleSubscribeSelf`]. Idempotent on "not currently
+/// subscribed." Substrate replies with [`LifecycleSubscribeResult`].
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Pod,
+    Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "aether.lifecycle.unsubscribe_self")]
+pub struct LifecycleUnsubscribeSelf {
+    pub stage: u64,
 }
 
 /// `aether.lifecycle.unsubscribe_all` — remove `mailbox` from every
@@ -1313,6 +1366,22 @@ mod control_plane {
         pub mailbox: aether_data::MailboxId,
     }
 
+    /// `aether.input.subscribe_self` — reflexive counterpart of
+    /// [`SubscribeInput`]: subscribe the *sending* actor to the input
+    /// stream for `kind`, with no explicit `mailbox` field. The cap
+    /// resolves the subscriber from the inbound envelope's host-stamped
+    /// `Source` (ADR-0083) via `ctx.source_mailbox()`, so the
+    /// subscriber cannot be forged and the op is gated to in-process
+    /// actors by construction — an external session or another engine
+    /// has no local mailbox and gets an `Err` reply, pushing it onto
+    /// the named [`SubscribeInput`] form. This is the common
+    /// "subscribe me" case. Reply: `SubscribeInputResult`.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.input.subscribe_self")]
+    pub struct SubscribeInputSelf {
+        pub kind: aether_data::KindId,
+    }
+
     /// `aether.input.unsubscribe` — remove `mailbox` from the
     /// subscriber set for `kind`. Idempotent: unsubscribing a mailbox
     /// that isn't subscribed is still `Ok`. Reply:
@@ -1322,6 +1391,19 @@ mod control_plane {
     pub struct UnsubscribeInput {
         pub kind: aether_data::KindId,
         pub mailbox: aether_data::MailboxId,
+    }
+
+    /// `aether.input.unsubscribe_self` — reflexive counterpart of
+    /// [`UnsubscribeInput`]: unsubscribe the *sending* actor from the
+    /// input stream for `kind`, with no explicit `mailbox` field. The
+    /// cap resolves the subscriber from the inbound envelope's
+    /// host-stamped `Source` (ADR-0083), the same gating as
+    /// [`SubscribeInputSelf`]. Idempotent on "not currently
+    /// subscribed." Reply: `SubscribeInputResult`.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.input.unsubscribe_self")]
+    pub struct UnsubscribeInputSelf {
+        pub kind: aether_data::KindId,
     }
 
     /// Reply to subscribe / unsubscribe / `unsubscribe_all` (ADR-0021 §2).
@@ -2940,7 +3022,15 @@ mod tests {
             "aether.lifecycle.advance_complete"
         );
         assert_eq!(LifecycleSubscribe::NAME, "aether.lifecycle.subscribe");
+        assert_eq!(
+            LifecycleSubscribeSelf::NAME,
+            "aether.lifecycle.subscribe_self"
+        );
         assert_eq!(LifecycleUnsubscribe::NAME, "aether.lifecycle.unsubscribe");
+        assert_eq!(
+            LifecycleUnsubscribeSelf::NAME,
+            "aether.lifecycle.unsubscribe_self"
+        );
         assert_eq!(
             LifecycleUnsubscribeAll::NAME,
             "aether.lifecycle.unsubscribe_all"
@@ -2963,7 +3053,9 @@ mod tests {
         assert_eq!(DropResult::NAME, "aether.component.drop_result");
         assert_eq!(ReplaceResult::NAME, "aether.component.replace_result");
         assert_eq!(SubscribeInput::NAME, "aether.input.subscribe");
+        assert_eq!(SubscribeInputSelf::NAME, "aether.input.subscribe_self");
         assert_eq!(UnsubscribeInput::NAME, "aether.input.unsubscribe");
+        assert_eq!(UnsubscribeInputSelf::NAME, "aether.input.unsubscribe_self");
         assert_eq!(SubscribeInputResult::NAME, "aether.input.subscribe_result");
         assert_eq!(CaptureFrame::NAME, "aether.render.capture_frame");
         assert_eq!(

--- a/crates/aether-kit/src/runtime.rs
+++ b/crates/aether-kit/src/runtime.rs
@@ -51,7 +51,6 @@ use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
 use aether_capabilities::input::InputMailboxExt;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::{InputCapability, LifecycleCapability, RenderCapability};
-use aether_data::{Kind, MailboxId};
 use aether_kinds::{DrawTriangle, Key, KeyRelease, Render, Tick, Vertex, keycode};
 
 use crate::{OCTIMETERS_PER_TILE, SetGranularity, SetWalkable, TILE_BITS, Teleport};
@@ -205,13 +204,12 @@ impl FfiActor for Locomotion {
     }
 
     fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
-        let me = MailboxId(ctx.mailbox_id());
         let input = ctx.actor::<InputCapability>();
-        input.subscribe(Key::ID, me);
-        input.subscribe(KeyRelease::ID, me);
+        input.subscribe::<Key>();
+        input.subscribe::<KeyRelease>();
         let lifecycle = ctx.actor::<LifecycleCapability>();
-        lifecycle.subscribe(Tick::ID, me);
-        lifecycle.subscribe(Render::ID, me);
+        lifecycle.subscribe::<Tick>();
+        lifecycle.subscribe::<Render>();
     }
 
     #[handler]

--- a/crates/aether-mesh-viewer/src/runtime.rs
+++ b/crates/aether-mesh-viewer/src/runtime.rs
@@ -36,7 +36,6 @@ use aether_actor::{BootError, FfiActor, FfiCtx, OutboundReply, ReplyHandle, Reso
 use aether_capabilities::fs::FsMailboxExt;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::{FsCapability, LifecycleCapability, RenderCapability};
-use aether_data::{Kind, MailboxId};
 use aether_kinds::{DrawTriangle, MeshLoadResult, ReadResult, Render, Vertex};
 use aether_math::Vec3;
 use aether_mesh::{Point3, Polygon, tessellate_polygon};
@@ -115,8 +114,7 @@ impl FfiActor for MeshViewer {
     /// receives `Render` and never submits — a no-op there, where the
     /// render cap discards anyway (ADR-0082 §7 / §11).
     fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
-        ctx.actor::<LifecycleCapability>()
-            .subscribe(Render::ID, MailboxId(ctx.mailbox_id()));
+        ctx.actor::<LifecycleCapability>().subscribe::<Render>();
     }
 
     /// Re-emits every cached triangle to the render sink on the `Render`

--- a/crates/aether-test-fixtures/examples/probe.rs
+++ b/crates/aether-test-fixtures/examples/probe.rs
@@ -38,7 +38,6 @@ use aether_actor::{BootError, FfiActor, FfiCtx, MailSender, Resolver, actor};
 use aether_capabilities::input::InputMailboxExt;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::{InputCapability, LifecycleCapability, RenderCapability};
-use aether_data::{Kind, MailboxId};
 use aether_kinds::{DrawTriangle, Key, Tick, Vertex};
 use aether_test_fixtures::{
     KeyObserved, SetRender, TEST_BENCH_OBSERVER_MAILBOX_NAME, TickObserved,
@@ -72,9 +71,8 @@ impl FfiActor for Probe {
     /// so it subscribes on `aether.input` (ADR-0021) — the input-stream
     /// path the round-trip scenarios exercise (issue 1490).
     fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
-        let me = MailboxId(ctx.mailbox_id());
-        ctx.actor::<LifecycleCapability>().subscribe(Tick::ID, me);
-        ctx.actor::<InputCapability>().subscribe(Key::ID, me);
+        ctx.actor::<LifecycleCapability>().subscribe::<Tick>();
+        ctx.actor::<InputCapability>().subscribe::<Key>();
     }
 
     /// Counts ticks delivered to this mailbox; broadcasts the running

--- a/demos/sokoban/src/lib.rs
+++ b/demos/sokoban/src/lib.rs
@@ -27,10 +27,11 @@
 
 use aether_actor::{BootError, FfiActor, FfiCtx, KindId, MailSender, Resolver, actor};
 use aether_camera::{CameraTopdownSet, TopdownParams};
+use aether_capabilities::input::InputMailboxExt;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::{InputCapability, LifecycleCapability, RenderCapability};
-use aether_data::{Kind, MailboxId, Schema};
-use aether_kinds::{DrawTriangle, Key, SubscribeInput, Tick, Vertex, keycode};
+use aether_data::{Kind, Schema};
+use aether_kinds::{DrawTriangle, Key, Tick, Vertex, keycode};
 use bytemuck::{Pod, Zeroable};
 
 const PLAYER_HALF: f32 = 0.25;
@@ -178,15 +179,11 @@ impl FfiActor for Sokoban {
     /// (post-init, mail-allowed) is the placement — `init`'s ctx is
     /// `Resolver`-only.
     fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
-        let me = MailboxId(ctx.mailbox_id());
         // `Tick` is a frame-lifecycle stage (`aether.lifecycle`,
         // ADR-0082); `Key` is a genuine input interrupt (`aether.input`,
         // ADR-0021).
-        ctx.actor::<LifecycleCapability>().subscribe(Tick::ID, me);
-        ctx.actor::<InputCapability>().send(&SubscribeInput {
-            kind: Key::ID,
-            mailbox: me,
-        });
+        ctx.actor::<LifecycleCapability>().subscribe::<Tick>();
+        ctx.actor::<InputCapability>().subscribe::<Key>();
     }
 
     #[handler]

--- a/docs/guide/foundations/actor-model.md
+++ b/docs/guide/foundations/actor-model.md
@@ -133,7 +133,7 @@ impl FfiActor for Hello {
     }
 
     fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
-        ctx.actor::<InputCapability>().subscribe(Tick::ID, MailboxId(ctx.mailbox_id()));
+        ctx.actor::<LifecycleCapability>().subscribe::<Tick>();
     }
 
     #[handler]
@@ -222,7 +222,7 @@ to `resolve_actor`, or use the `loaded` helper below.
 
 A capability can also dress up its mail surface with **extension-trait helpers** —
 typed methods on the mailbox handle that stand in for raw kind sends.
-`ctx.actor::<InputCapability>().subscribe(Tick::ID, me)` is one (from
+`ctx.actor::<InputCapability>().subscribe::<Key>()` is one (from
 `InputMailboxExt`), and `ctx.actor::<ComponentHostCapability>().loaded::<Camera>("camera")`
 is the loaded-component lookup just mentioned (from `ComponentHostExt`). Each such
 trait is implemented for *both* the component and the capability handle, so the same

--- a/docs/guide/systems/input.md
+++ b/docs/guide/systems/input.md
@@ -55,22 +55,30 @@ the `InputCapability` actor — the sole owner of the subscriber table
 **`Tick` lives on the lifecycle, not here.** The per-frame advance is the
 substrate's frame-lifecycle state machine (`aether.lifecycle.tick`), so a
 component subscribes the `Tick` stage directly on `aether.lifecycle` —
-`ctx.actor::<LifecycleCapability>().subscribe(Tick::ID, me)` (ADR-0082), the same
+`ctx.actor::<LifecycleCapability>().subscribe::<Tick>()` (ADR-0082), the same
 subscribe shape as the input streams below. `Key`, `MouseMove`, and the rest are
 genuine input interrupts and stay on `aether.input`.
 
-**Subscribe and unsubscribe are mail.** Three control kinds on `aether.input`:
+**Subscribe and unsubscribe are mail.** Control kinds on `aether.input`:
 
-- `aether.input.subscribe { kind, mailbox }` — add `mailbox` to the set for
-  `kind`. Idempotent (it's a set). Replies `aether.input.subscribe_result`
-  (`Ok` / `Err { error }`).
+- `aether.input.subscribe_self { kind }` — subscribe the *sending* actor to
+  `kind`. The cap reads the subscriber off the inbound's host-stamped `Source`
+  (ADR-0083), so the caller names neither the kind id nor its own mailbox. This
+  is the common form. Idempotent. Replies `aether.input.subscribe_result`
+  (`Ok` / `Err { error }`); a sender with no local mailbox (an external session
+  or another engine) gets `Err`.
+- `aether.input.unsubscribe_self { kind }` — the reflexive unsubscribe twin.
+- `aether.input.subscribe { kind, mailbox }` — add an *explicit* `mailbox` to
+  the set for `kind`. The rare cross-mailbox form. Idempotent; same reply.
 - `aether.input.unsubscribe { kind, mailbox }` — remove it. Idempotent; same
   reply.
 - `aether.input.unsubscribe_all { mailbox }` — drop `mailbox` from every stream.
   No reply; this is what the component host fires on drop.
 
-A subscribe is validated: the mailbox must name a live, dispatchable actor — a
-dropped or unknown id is rejected with `Err`.
+A named (`subscribe` / `unsubscribe`) subscribe is validated: the mailbox must
+name a live, dispatchable actor — a dropped or unknown id is rejected with
+`Err`. The reflexive (`*_self`) forms need no such check: the host-stamped
+`Source` already names the live sending actor.
 
 **Fan-out, and the empty case.** A driver pushes each platform event as a single
 mail to `aether.input`; the cap then sends one copy per subscriber, carrying the
@@ -88,16 +96,19 @@ keep receiving fan-out.
 
 **From a component — subscribe in `wire`.** `init` can't send mail (its context
 is resolver-only), so subscriptions go in the `wire` hook, which runs post-init
-with mail allowed. Address the cap by type and name the kind:
+with mail allowed. Address the cap by type and name the stream as a type
+parameter — the cap subscribes the calling actor:
 
 ```rust
 fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
-    let me = MailboxId(ctx.mailbox_id());
     let input = ctx.actor::<InputCapability>();
-    input.subscribe(Key::ID, me);
-    input.subscribe(WindowSize::ID, me);
+    input.subscribe::<Key>();
+    input.subscribe::<WindowSize>();
 }
 ```
+
+To subscribe a *different* mailbox (the rare cross-mailbox case) use the named
+form: `input.subscribe_for::<Key>(other_mailbox)`.
 
 Then handle each stream as its kind, like any other mail:
 


### PR DESCRIPTION
<!-- pr-body-ok: e — release-flow PR body, scope is the implement skill -->

Closes iamacoffeepot/aether#1497.

## Summary

Collapses the stage-subscribe surface so a component writes `ctx.actor::<LifecycleCapability>().subscribe::<Tick>()` instead of `subscribe(Tick::ID, MailboxId(ctx.mailbox_id()))`. The generic carries the stage id; the common self-subscribe reads the caller off the inbound's host-stamped `Source` (ADR-0083) via `ctx.source_mailbox()`, gated to in-process actors by construction — a sender with no local mailbox (an external session or remote engine) gets an `Err` and must use the named form. The rare cross-mailbox case moves to `subscribe_for::<K>(mailbox)`. Same treatment for the input cap, so there is one `subscribe::<K>()` idiom across the `*MailboxExt` family.

- New reflexive wire kinds: `LifecycleSubscribeSelf` / `LifecycleUnsubscribeSelf` (Pod cast-shape) and `SubscribeInputSelf` / `UnsubscribeInputSelf` (serde). The two-kind split (over a `mailbox: 0` sentinel) falls out of the Pod constraint on `LifecycleSubscribe`.
- `LifecycleMailboxExt` / `InputMailboxExt` swap the old non-generic `subscribe(stage, mailbox)` for `subscribe::<K>()` + `subscribe_for::<K>(mailbox)` and the `unsubscribe` twins, across both the FFI and native impls.
- `on_subscribe_self` / `on_unsubscribe_self` resolve the subscriber from `source_mailbox()` and reply `Err` on a non-local sender. The named path keeps its `validate_subscriber_mailbox` check; the self path needs none (the host stamp already names a live actor).
- Call sites migrate to the generic form: `aether-camera`, `aether-mesh-viewer`, the `caller` / `hello` / `probe` examples, and the `sokoban` demo. Guide docs and the CLAUDE.md snippet migrate too (fixing a latent `Tick`-on-`InputCapability` slip — `Tick` is a lifecycle stage).

Builds on ADR-0082 (lifecycle stages) and ADR-0083 (`Source`); no new ADR.

## Test plan

- New unit tests on both caps: a `Component`-source `subscribe_self` lands that mailbox in the stage/stream set; a non-`Component` source (`SourceAddr::Session`) replies `Err` and subscribes nothing.
- A `NativeTransport` round-trip test: `subscribe::<Tick>()` emits `LifecycleSubscribeSelf { stage = Tick::ID }` whose `Source` the host stamps to the calling actor, and delivering it to the cap lands that actor in the `Tick` stage set.
- `assert_handles` compile-time coverage extended for the new kinds; `NAME` assertions for the four `*_self` kinds.
- Full local preflight green (fmt + clippy `--all-targets -D warnings` + doc + nextest 1566 passed + wasm32 component cross-build).

## Generated by

`/implement` — agent execution of scoped issue #1497.
