### PR TITLE
chore(repo): clear qodana findings and disable the package-upgrade inspection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,6 @@ dependencies = [
  "cpal",
  "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-queue",
  "dirs",
  "libc",
  "png",

--- a/crates/aether-actor/src/cost.rs
+++ b/crates/aether-actor/src/cost.rs
@@ -103,12 +103,13 @@ impl CostCell {
             let mean = self.mean.load(Ordering::Relaxed);
             // Signed delta folded with a symmetric shift so the EWMA
             // tracks both rising and falling costs without float.
-            let next_mean = ewma_step(mean, sample);
+            let next_mean = ewma_step(mean, sample, EWMA_SHIFT);
             self.mean.store(next_mean, Ordering::Relaxed);
 
             let dev = sample.abs_diff(next_mean);
             let mad = self.mad.load(Ordering::Relaxed);
-            self.mad.store(ewma_step(mad, dev), Ordering::Relaxed);
+            self.mad
+                .store(ewma_step(mad, dev, EWMA_SHIFT), Ordering::Relaxed);
         }
         self.samples
             .store(prior.saturating_add(1), Ordering::Relaxed);
@@ -135,14 +136,16 @@ impl CostCell {
 }
 
 /// One constant-α EWMA step toward `sample`: `current + (sample −
-/// current) >> k`, computed on the signed difference so a falling cost
-/// converges as fast as a rising one. Integer-only — the `>> k` is the
-/// power-of-two α.
-fn ewma_step(current: u64, sample: u64) -> u64 {
+/// current) >> shift`, computed on the signed difference so a falling
+/// cost converges as fast as a rising one. Integer-only — the
+/// `>> shift` is the power-of-two α. Shared with the substrate
+/// scheduler's handoff calibration, which folds with its own shift.
+#[must_use]
+pub fn ewma_step(current: u64, sample: u64, shift: u32) -> u64 {
     if sample >= current {
-        current + ((sample - current) >> EWMA_SHIFT)
+        current + ((sample - current) >> shift)
     } else {
-        current - ((current - sample) >> EWMA_SHIFT)
+        current - ((current - sample) >> shift)
     }
 }
 

--- a/crates/aether-actor/src/trace_ring.rs
+++ b/crates/aether-actor/src/trace_ring.rs
@@ -5,7 +5,7 @@
 //! (`record_sent` / `record_received` / `record_finished`) push the
 //! mail-graph events for the current actor into its ring; a coordinator
 //! reconstructs a trace tree on demand by fanning out
-//! [`aether_kinds::trace::TraceTail`] across live actors and stitching
+//! [`TraceTail`] across live actors and stitching
 //! the per-ring slices by lineage keys.
 //!
 //! The ring stores only the mail-graph events — `Sent` lands in the

--- a/crates/aether-capabilities/src/contentgen/staging.rs
+++ b/crates/aether-capabilities/src/contentgen/staging.rs
@@ -78,26 +78,11 @@ pub fn stage_gen_output_under(root: &Path, bytes: &[u8], ext: &str) -> Result<St
 mod tests {
     use super::{GEN_PREFIX, stage_gen_output_under};
     use crate::fs::{FileAdapter, LocalFileAdapter};
-    use std::env::temp_dir;
-    use std::fs;
-    use std::path::{Path, PathBuf};
-    use std::process;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use crate::test_chassis::{cleanup, scratch_dir};
+    use std::path::PathBuf;
 
     fn scratch_root(tag: &str) -> PathBuf {
-        let pid = process::id();
-        let nonce: u64 = SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| {
-            #[allow(clippy::cast_possible_truncation)]
-            let nanos = d.as_nanos() as u64;
-            nanos
-        });
-        let path = temp_dir().join(format!("aether-gen-stage-{tag}-{pid}-{nonce}"));
-        fs::create_dir_all(&path).expect("test setup: scratch dir creates");
-        path
-    }
-
-    fn cleanup(path: &Path) {
-        let _ = fs::remove_dir_all(path);
+        scratch_dir("aether-gen-stage", tag)
     }
 
     #[test]

--- a/crates/aether-capabilities/src/contentgen/task_queue.rs
+++ b/crates/aether-capabilities/src/contentgen/task_queue.rs
@@ -157,15 +157,7 @@ mod tests {
     impl Kind for Answer {
         const NAME: &'static str = "test.task_queue.answer";
         const ID: KindId = KindId(0xD15B_0CC2_0000_0001);
-        fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-            if bytes.len() != size_of::<Self>() {
-                return None;
-            }
-            Some(bytemuck::pod_read_unaligned(bytes))
-        }
-        fn encode_into_bytes(&self) -> Vec<u8> {
-            bytemuck::bytes_of(self).to_vec()
-        }
+        aether_data::pod_kind_codec!();
     }
 
     /// A synthetic chain root for a request — the value the cap handler

--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -249,7 +249,7 @@ pub struct NamespaceRoots {
         config(
             env = "AETHER_SAVE_DIR",
             cli_long = "save-dir",
-            parse = parse_dir
+            parse = native::parse_dir
         )
     )]
     pub save: PathBuf,
@@ -258,7 +258,7 @@ pub struct NamespaceRoots {
         config(
             env = "AETHER_ASSETS_DIR",
             cli_long = "assets-dir",
-            parse = parse_dir
+            parse = native::parse_dir
         )
     )]
     pub assets: PathBuf,
@@ -267,7 +267,7 @@ pub struct NamespaceRoots {
         config(
             env = "AETHER_CONFIG_DIR",
             cli_long = "config-dir",
-            parse = parse_dir
+            parse = native::parse_dir
         )
     )]
     pub config: PathBuf,
@@ -416,20 +416,10 @@ impl FsMailboxExt for NativeActorMailbox<'_, FsCapability> {
     }
 }
 
-// The derive's emitted Layer + Overlay + `from_env` shims live at the
-// file root (same scope as the `NamespaceRoots` struct itself). The
-// `parse_dir` helper they reference must therefore also live at file
-// root; the legacy bridge-mod-local helper is re-exported via the
-// re-export below.
-//
-// The Layer type re-export is no longer needed — the derive emits
-// `NamespaceRootsLayer` at this very scope.
-
-// `parse_dir` is reachable from the derive-emitted Layer fields via
-// the file-root scope. The bridge mod re-exports its definitions
-// (`parse_dir`, `EmptyDir`) so the prior layout doesn't need to move.
-#[cfg(all(not(target_arch = "wasm32"), feature = "native"))]
-use native::parse_dir;
+// The derive emits the Layer + Overlay + `from_env` shims at this scope
+// (`NamespaceRootsLayer` alongside the `NamespaceRoots` struct). Their
+// field parsers name `native::parse_dir` by its full path, so the bridge
+// mod's helper stays put — no file-root re-export needed.
 
 #[aether_actor::bridge(singleton)]
 mod native {
@@ -690,8 +680,6 @@ mod native {
 
     #[cfg(test)]
     mod tests {
-        use std::env::temp_dir;
-
         use super::super::{
             AdapterRegistry, Delete, FileAdapter, FsError, List, LocalFileAdapter, NamespaceRoots,
             Read, Write,
@@ -706,16 +694,13 @@ mod native {
         use aether_substrate::chassis::error::BootError;
         use aether_substrate::mail::Source;
 
-        use crate::test_chassis::{TestChassis, fresh_substrate};
+        use crate::test_chassis::{
+            TestChassis, cleanup, decode_reply, fresh_substrate, scratch_dir,
+        };
         use aether_substrate::mail::SourceAddr;
         use aether_substrate::mail::registry;
-        use serde::de::DeserializeOwned;
         use std::fs;
-        use std::process;
         use std::sync::mpsc::Receiver;
-        use std::time::Duration;
-        use std::time::SystemTime;
-        use std::time::UNIX_EPOCH;
 
         // ADR-0090: the confique migration is byte-identical to the prior
         // `env_or_default` reader. These exercise resolution without
@@ -776,25 +761,8 @@ mod native {
             }
         }
 
-        /// Manual tempdir helper to avoid pulling in the `tempfile`
-        /// crate. Caller cleans up via [`cleanup`] after the test asserts.
         fn scratch_root(tag: &str) -> PathBuf {
-            let pid = process::id();
-            let nonce: u64 = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                // Nanosecond clock fits comfortably in u64 for the next ~584 years.
-                .map_or(0, |d| {
-                    #[allow(clippy::cast_possible_truncation)]
-                    let nanos = d.as_nanos() as u64;
-                    nanos
-                });
-            let path = temp_dir().join(format!("aether-io-cap-{tag}-{pid}-{nonce}"));
-            fs::create_dir_all(&path).expect("test setup: scratch dir creates");
-            path
-        }
-
-        fn cleanup(path: &Path) {
-            let _ = fs::remove_dir_all(path);
+            scratch_dir("aether-io-cap", tag)
         }
 
         fn roots_under(root: &Path) -> NamespaceRoots {
@@ -1034,20 +1002,6 @@ mod native {
         }
 
         use crate::test_chassis::test_mailer_and_rx;
-
-        fn decode_reply<K: aether_data::Kind + DeserializeOwned>(rx: &Receiver<EgressEvent>) -> K {
-            let event = rx
-                .recv_timeout(Duration::from_secs(1))
-                .expect("test: egress event arrives within 1s deadline");
-            let EgressEvent::ToSession {
-                kind_name, payload, ..
-            } = event
-            else {
-                panic!("expected ToSession egress, got {event:?}");
-            };
-            assert_eq!(kind_name, K::NAME);
-            postcard::from_bytes(&payload).expect("test: reply payload decodes via postcard")
-        }
 
         /// Boot the cap against a fresh tempdir; assert the mailbox
         /// is registered.

--- a/crates/aether-capabilities/src/inventory.rs
+++ b/crates/aether-capabilities/src/inventory.rs
@@ -241,10 +241,10 @@ mod native {
         use aether_substrate::mail::registry::Registry;
         use aether_substrate::mail::{Source, SourceAddr};
         use aether_substrate::runtime::thread_name::register;
-        use serde::de::DeserializeOwned;
         use std::sync::Arc;
         use std::sync::mpsc::Receiver;
-        use std::time::Duration;
+
+        use crate::test_chassis::decode_reply;
 
         /// Cap + loopback mailer + transport wired so `ctx.reply`
         /// egresses as a `ToSession` event the test can decode. Mirrors
@@ -283,20 +283,6 @@ mod native {
                 aether_data::MailId::NONE,
                 aether_data::MailId::NONE,
             )
-        }
-
-        fn decode_reply<K: aether_data::Kind + DeserializeOwned>(rx: &Receiver<EgressEvent>) -> K {
-            let event = rx
-                .recv_timeout(Duration::from_secs(1))
-                .expect("test: egress event arrives within 1s deadline");
-            let EgressEvent::ToSession {
-                kind_name, payload, ..
-            } = event
-            else {
-                panic!("expected ToSession egress, got {event:?}");
-            };
-            assert_eq!(kind_name, K::NAME);
-            postcard::from_bytes(&payload).expect("test: reply payload decodes via postcard")
         }
 
         /// The served manifest carries a known chassis mailbox name

--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -935,6 +935,29 @@ mod tests {
         (chassis, stream)
     }
 
+    /// Boot a chassis with the deferred-echo actor + trace dispatch
+    /// behind the RPC server, connect a client, and complete the
+    /// handshake. Shared by the deferred-reply settlement tests. Returns
+    /// `(chassis, stream)`; both must stay alive for the listener.
+    fn boot_with_deferred_echo(timeout: Duration) -> (PassiveChassis<TestChassis>, TcpStream) {
+        use crate::rpc::test_echo::DeferredEchoActor;
+        use crate::trace::TraceDispatchCapability;
+
+        let (registry, mailer) = fresh_substrate();
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<TraceDispatchCapability>(())
+            .with_actor::<DeferredEchoActor>(())
+            .with_actor::<RpcServerCapability>(RpcServerConfig {
+                bind_addr: "127.0.0.1:0".into(),
+                peer_kind: test_peer_kind(),
+            })
+            .build_passive()
+            .expect("caps boot");
+        let mut stream = connect_to_rpc_server(&chassis, timeout);
+        complete_handshake(&mut stream);
+        (chassis, stream)
+    }
+
     /// Lift the published `RpcServerHandle`'s `local_port`, open a
     /// `TcpStream`, set `read_timeout`. Shared by every test whose
     /// boot path is more elaborate than `boot_with_rpc_server_only`.
@@ -1202,23 +1225,10 @@ mod tests {
     fn call_deferred_echo_settles_after_reply() {
         use crate::rpc::test_echo::{DeferredEchoActor, DeferredEchoReply, DeferredEchoRequest};
         use crate::rpc::wire::{MailEnvelope, MailboxAddress};
-        use crate::trace::TraceDispatchCapability;
         use aether_actor::Actor;
         use aether_data::{Kind, mailbox_id_from_name};
 
-        let (registry, mailer) = fresh_substrate();
-        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<TraceDispatchCapability>(())
-            .with_actor::<DeferredEchoActor>(())
-            .with_actor::<RpcServerCapability>(RpcServerConfig {
-                bind_addr: "127.0.0.1:0".into(),
-                peer_kind: test_peer_kind(),
-            })
-            .build_passive()
-            .expect("caps boot");
-
-        let mut stream = connect_to_rpc_server(&chassis, Duration::from_secs(5));
-        complete_handshake(&mut stream);
+        let (_chassis, mut stream) = boot_with_deferred_echo(Duration::from_secs(5));
 
         let payload = postcard::to_allocvec(&DeferredEchoRequest { value: 99 })
             .expect("test setup: DeferredEchoRequest serializes via postcard");
@@ -1297,19 +1307,7 @@ mod tests {
         use aether_kinds::MailEnvelope as TracedEnvelope;
         use aether_kinds::trace::DispatchTraced;
 
-        let (registry, mailer) = fresh_substrate();
-        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<TraceDispatchCapability>(())
-            .with_actor::<DeferredEchoActor>(())
-            .with_actor::<RpcServerCapability>(RpcServerConfig {
-                bind_addr: "127.0.0.1:0".into(),
-                peer_kind: test_peer_kind(),
-            })
-            .build_passive()
-            .expect("caps boot");
-
-        let mut stream = connect_to_rpc_server(&chassis, Duration::from_secs(10));
-        complete_handshake(&mut stream);
+        let (_chassis, mut stream) = boot_with_deferred_echo(Duration::from_secs(10));
 
         // Build a batched DispatchTraced with two DeferredEchoRequest
         // envelopes, addressed at the deferred-echo actor by name (the

--- a/crates/aether-capabilities/src/test_chassis.rs
+++ b/crates/aether-capabilities/src/test_chassis.rs
@@ -11,9 +11,13 @@
 //! 786 lives here too — same six sites all wanted the same
 //! `(Arc<Registry>, Arc<Mailer>)` seed for `Builder::new`.
 
+use std::env::temp_dir;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process;
 use std::sync::Arc;
 use std::sync::mpsc::Receiver;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use aether_data::{Kind, Source};
 use aether_kinds::descriptors;
@@ -176,4 +180,47 @@ where
                 .expect("test: reply payload decodes via postcard");
         }
     }
+}
+
+/// Decode the *next* egress as a `ToSession` reply of kind `K`. Strict
+/// sibling of [`decode_session_reply`]: it asserts the immediately
+/// following egress is a `ToSession` carrying `K`, rather than reading
+/// past bubble-ups. For cap tests whose handler re-replies exactly once.
+pub fn decode_reply<K>(rx: &Receiver<EgressEvent>) -> K
+where
+    K: Kind + DeserializeOwned,
+{
+    let event = rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("test: egress event arrives within 1s deadline");
+    let EgressEvent::ToSession {
+        kind_name, payload, ..
+    } = event
+    else {
+        panic!("expected ToSession egress, got {event:?}");
+    };
+    assert_eq!(kind_name, K::NAME);
+    postcard::from_bytes(&payload).expect("test: reply payload decodes via postcard")
+}
+
+/// Manual tempdir under the system temp root, namespaced by `prefix` and
+/// `tag` plus the pid and a nanosecond nonce so concurrent tests never
+/// collide. Avoids pulling in the `tempfile` crate; the caller cleans up
+/// via [`cleanup`] after asserting.
+pub fn scratch_dir(prefix: &str, tag: &str) -> PathBuf {
+    let pid = process::id();
+    let nonce: u64 = SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| {
+        // Nanosecond clock fits comfortably in u64 for the next ~584 years.
+        #[allow(clippy::cast_possible_truncation)]
+        let nanos = d.as_nanos() as u64;
+        nanos
+    });
+    let path = temp_dir().join(format!("{prefix}-{tag}-{pid}-{nonce}"));
+    fs::create_dir_all(&path).expect("test setup: scratch dir creates");
+    path
+}
+
+/// Remove a [`scratch_dir`] tree, ignoring errors (best-effort teardown).
+pub fn cleanup(path: &Path) {
+    let _ = fs::remove_dir_all(path);
 }

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -159,6 +159,29 @@ pub trait Kind {
     }
 }
 
+/// Emit the `Kind::decode_from_bytes` / `encode_into_bytes` pair for a
+/// hand-rolled `Kind` impl over a `#[repr(C)]` + `bytemuck::Pod` type.
+///
+/// Use inside an `impl Kind for T` block whose `NAME` / `ID` are set by
+/// hand — a fixed const id for a test fixture, or an internal kind kept
+/// out of the `#[derive(Kind)]` inventory submission. The emitted bodies
+/// route through the same cast-shape codec
+/// ([`__derive_runtime::decode_cast`] / [`__derive_runtime::encode_cast`])
+/// that `#[derive(Kind)]` generates, so the wire shape matches a derived
+/// kind byte-for-byte.
+#[macro_export]
+macro_rules! pod_kind_codec {
+    () => {
+        fn decode_from_bytes(bytes: &[u8]) -> ::core::option::Option<Self> {
+            $crate::__derive_runtime::decode_cast::<Self>(bytes)
+        }
+
+        fn encode_into_bytes(&self) -> $crate::__derive_runtime::Vec<u8> {
+            $crate::__derive_runtime::encode_cast::<Self>(self)
+        }
+    };
+}
+
 /// `Kind` impl for the unit type. Lets `()` ride the same
 /// `Kind::decode_from_bytes` / `Kind::encode_into_bytes` shim path as
 /// real kinds, which is what makes the `FfiActor::Config = ()` default

--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -37,6 +37,8 @@ use aether_substrate::scheduler::SCHEDULER_KNOBS;
 use confique::Config as _;
 use confique::meta::Meta;
 
+use crate::cli::PersistOverlay;
+
 /// Chassis-direct env knobs that aren't `#[derive(Config)]` fields —
 /// the bare-shadowed knobs the chassis bins read inline
 /// (`AETHER_WORKERS`, `AETHER_TICK_HZ`, `AETHER_RPC_PORT`, the desktop
@@ -147,6 +149,29 @@ pub enum PersistOverride {
     EnvOnly,
     /// Argv overlay resolved: use this verbatim.
     Argv(Option<PersistConfig>),
+}
+
+/// Resolve the handle-store persistence overlay the desktop and headless
+/// chassis share (issue 1258). When argv sets any persistence field, the
+/// chassis-bin vote `persist_enabled = true` rides into an argv-then-env
+/// resolved [`PersistConfig`]; otherwise persistence falls through to
+/// env-only resolution at build time (ADR-0049 §9).
+#[must_use]
+pub fn resolve_persist_state(persist: &PersistOverlay) -> PersistOverride {
+    let persist_argv_set = persist.dir.is_some()
+        || persist.persist_disable.is_some()
+        || persist.disk_budget_bytes.is_some()
+        || persist.eviction_tick_secs.is_some();
+    if persist_argv_set {
+        PersistOverride::Argv(PersistConfig::from_argv_then_env(
+            true,
+            persist.dir.clone(),
+            persist.persist_disable,
+            persist.numeric_layer(),
+        ))
+    } else {
+        PersistOverride::EnvOnly
+    }
 }
 
 /// Build the standard single-stage lifecycle config every Tick-driven

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -34,12 +34,11 @@ use winit::event_loop::EventLoop;
 use super::driver::{DesktopDriverCapability, parse_window_mode_env};
 use crate::chassis_common::{
     CommonBoot, PersistOverride, chassis_known_keys, frame_lifecycle_config, maybe_with_rpc_server,
-    with_common_caps,
+    resolve_persist_state, with_common_caps,
 };
 use crate::cli::{CommonOverlay, DesktopCli};
 use crate::hub;
 use aether_substrate::config::{ConfigError, validate_env};
-use aether_substrate::handle_store::PersistConfig;
 use aether_substrate::runtime::lifecycle::FatalAborter;
 use aether_substrate::runtime::lifecycle::OutboundFatalAborter;
 use std::env;
@@ -283,23 +282,9 @@ impl DesktopEnv {
 
         let workers = cli_workers.or_else(parse_workers_env);
 
-        // Persistence overlay: parallel to headless (issue 1258). The
-        // chassis-bin vote is `persist_enabled=true` (desktop opts into
-        // on-disk persistence per ADR-0049 §9).
-        let persist_argv_set = persist.dir.is_some()
-            || persist.persist_disable.is_some()
-            || persist.disk_budget_bytes.is_some()
-            || persist.eviction_tick_secs.is_some();
-        let persist_state = if persist_argv_set {
-            PersistOverride::Argv(PersistConfig::from_argv_then_env(
-                true,
-                persist.dir.clone(),
-                persist.persist_disable,
-                persist.numeric_layer(),
-            ))
-        } else {
-            PersistOverride::EnvOnly
-        };
+        // Persistence overlay shared with headless (issue 1258); desktop
+        // opts into on-disk persistence per ADR-0049 §9.
+        let persist_state = resolve_persist_state(&persist);
         let handle_store_max_bytes = persist.max_bytes;
 
         Ok(Self {

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -158,9 +158,9 @@ pub struct App {
     /// window occludes) — the case `aether.window.focus` most needs,
     /// since the loop is otherwise parked until a winit event arrives.
     window_inbox: Receiver<Envelope>,
-    /// Per-actor [`aether_actor::local::ActorSlots`] carried out of the
+    /// Per-actor [`local::ActorSlots`] carried out of the
     /// [`aether_substrate::MailboxClaim`] this driver produced at boot.
-    /// Stamped into TLS via [`aether_actor::local::with_stamped`] around
+    /// Stamped into TLS via [`local::with_stamped`] around
     /// the bespoke `aether.window` inbox drain so framework-built-in
     /// dispatch arms (`aether.log.tail` / `aether.trace.tail` /
     /// `aether.cost.tail`) reach the driver's per-actor `Local<T>`
@@ -373,7 +373,7 @@ fn resolve_fullscreen(
 /// serves these kinds — see the issue body for the contract.
 ///
 /// Caller invariant: must run inside a `local::with_stamped` block
-/// against the driver's [`aether_actor::local::ActorSlots`] so the
+/// against the driver's [`local::ActorSlots`] so the
 /// log / trace arms reach the driver's per-actor ring. Factored out of
 /// [`App::dispatch_window_envelope`] so the unit test directly drives
 /// the routing shape without standing up a winit `App`.
@@ -738,7 +738,7 @@ impl App {
     /// else warns and drops.
     ///
     /// The whole drain is wrapped in
-    /// [`aether_actor::local::with_stamped`] against
+    /// [`local::with_stamped`] against
     /// [`Self::actor_slots`] so the framework arms reach this driver's
     /// per-actor `ActorLogRing` / `ActorTraceRing` (the same property
     /// `DispatcherSlot::run_cycle` opens for every standard actor).

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -27,12 +27,11 @@ use aether_data::Kind;
 use aether_kinds::{SetMasterGain, SetMasterGainResult, Tick};
 use aether_substrate::chassis::builder::{Builder, BuiltChassis};
 use aether_substrate::chassis::error::BootError;
-use aether_substrate::handle_store::PersistConfig;
 use aether_substrate::{Chassis, SubstrateBoot};
 
 use super::driver::{HeadlessTimerCapability, parse_tick_hz_env};
 use crate::chassis_common::{
-    CommonBoot, PersistOverride, chassis_known_keys, maybe_with_rpc_server,
+    CommonBoot, PersistOverride, chassis_known_keys, maybe_with_rpc_server, resolve_persist_state,
     tick_only_lifecycle_config, with_common_caps,
 };
 use crate::cli::{CommonOverlay, HeadlessCli};
@@ -142,25 +141,9 @@ impl HeadlessEnv {
         let anthropic = AnthropicConfig::try_from_argv_then_env(anthropic.into_layer())?;
         let gemini = GeminiConfig::try_from_argv_then_env(gemini.into_layer())?;
         let namespace_roots = NamespaceRoots::from_argv_then_env(fs.into_layer());
-        // Persistence overlay: the cap accepts the full argv-then-env
-        // overlay shape (dir + persist_disable + numeric layer). The
-        // chassis-bin verdict is `persist_enabled=true` (headless opts
-        // into on-disk persistence per ADR-0049 §9); the cap layer
-        // applies the argv → env → default precedence.
-        let persist_argv_set = persist.dir.is_some()
-            || persist.persist_disable.is_some()
-            || persist.disk_budget_bytes.is_some()
-            || persist.eviction_tick_secs.is_some();
-        let persist_state = if persist_argv_set {
-            PersistOverride::Argv(PersistConfig::from_argv_then_env(
-                true,
-                persist.dir.clone(),
-                persist.persist_disable,
-                persist.numeric_layer(),
-            ))
-        } else {
-            PersistOverride::EnvOnly
-        };
+        // Persistence overlay shared with desktop (issue 1258); headless
+        // opts into on-disk persistence per ADR-0049 §9.
+        let persist_state = resolve_persist_state(&persist);
         let handle_store_max_bytes = persist.max_bytes;
         // Chassis-wide knobs: argv-then-env shadow (ad-hoc, lifted to
         // confique in unit e1). `cli.tick_hz` wins when `Some`, falls

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -1397,15 +1397,7 @@ mod tests {
         impl DataKind for Bump {
             const NAME: &'static str = "test.spawn.bump";
             const ID: DataKindId = DataKindId(0xB0B1_B2B3_B4B5_B6B7);
-            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != size_of::<Self>() {
-                    return None;
-                }
-                Some(bytemuck::pod_read_unaligned(bytes))
-            }
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
+            aether_data::pod_kind_codec!();
         }
 
         struct Child {

--- a/crates/aether-substrate/Cargo.toml
+++ b/crates/aether-substrate/Cargo.toml
@@ -73,8 +73,6 @@ png = { version = "0.18", optional = true }
 # Audio-only deps; gated by the `audio` feature. Desktop enables it,
 # headless and hub do not.
 cpal = { version = "0.17", optional = true }
-# ADR-0080 trace queue (always on — substrate-wide tracing).
-crossbeam-queue = "0.3"
 # Issue 635 PR B worker-pool ready queue. MPMC channel — std mpsc is
 # single-consumer so it can't load-balance across pool workers. Still
 # used for settlement/capture one-shots + the close-done signal; the

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -411,7 +411,7 @@ impl<'a> NativeCtx<'a> {
 
     /// Reply to an explicit [`Source`] rather than the inbound's own
     /// sender. The ADR-0093 hold-until-resolve path reaches for this:
-    /// [`TaskDone::resolve`](super::dispatch_blocking::TaskDone::resolve)
+    /// [`TaskDone::resolve`]
     /// re-replies through the *originating* caller's reply target
     /// (captured at dispatch, parked in the in-flight ledger), not the
     /// completion-wake's sender (the worker thread's loopback mail, which
@@ -637,7 +637,7 @@ impl NativeCtx<'_> {
     /// stamping the default `(Component(self_mailbox), auto_correlation)`.
     /// The minted [`MailId`] and the chain's `in_flight` accounting are
     /// unchanged — only the recipient's
-    /// [`aether_actor::actor::ctx::OutboundReply::reply_target`]
+    /// [`OutboundReply::reply_target`]
     /// view changes.
     ///
     /// Use this when a cap is **forwarding** another actor's call rather

--- a/crates/aether-substrate/src/actor/native/dispatch_blocking.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch_blocking.rs
@@ -89,16 +89,7 @@ impl Kind for TaskCompletionWake {
         aether_data::fnv1a_64_prefixed(aether_data::KIND_DOMAIN, Self::NAME.as_bytes()),
     ));
 
-    fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-        if bytes.len() != size_of::<Self>() {
-            return None;
-        }
-        Some(bytemuck::pod_read_unaligned(bytes))
-    }
-
-    fn encode_into_bytes(&self) -> Vec<u8> {
-        bytemuck::bytes_of(self).to_vec()
-    }
+    aether_data::pod_kind_codec!();
 }
 
 /// One in-flight dispatch's held state, parked in the [`InflightTable`]
@@ -439,15 +430,7 @@ mod tests {
     impl Kind for Answer {
         const NAME: &'static str = "test.dispatch_blocking.answer";
         const ID: KindId = KindId(0xD15B_0CC1_0000_0001);
-        fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-            if bytes.len() != size_of::<Self>() {
-                return None;
-            }
-            Some(bytemuck::pod_read_unaligned(bytes))
-        }
-        fn encode_into_bytes(&self) -> Vec<u8> {
-            bytemuck::bytes_of(self).to_vec()
-        }
+        aether_data::pod_kind_codec!();
     }
 
     /// Forward every dispatched envelope onto `tx` so a test can observe

--- a/crates/aether-substrate/src/boot.rs
+++ b/crates/aether-substrate/src/boot.rs
@@ -150,7 +150,7 @@ impl SubstrateBootBuilder<'_> {
     /// issue 1258). When chassis bins have parsed argv overlays, they
     /// resolve `PersistConfig::from_argv_then_env(...)` themselves and
     /// hand the result in here, bypassing the env-only resolution baked
-    /// into [`crate::handle_store::HandleStore::from_env_persistent`].
+    /// into [`HandleStore::from_env_persistent`].
     /// `None` means "argv said persistence is off". When not called,
     /// env-only resolution runs.
     #[must_use]

--- a/crates/aether-substrate/src/dag/executor.rs
+++ b/crates/aether-substrate/src/dag/executor.rs
@@ -41,7 +41,6 @@
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
-use aether_data::canonical::canonical_kind_bytes;
 use aether_data::{
     DagId, HandleId, KindId, MailId, MailboxId, Ref, SchemaType, Tag, TransformId,
     content_addressed_handle_id, with_tag,
@@ -52,6 +51,7 @@ use aether_kinds::{
 };
 
 use crate::actor::native::NativeCtx;
+use crate::dag::kind_id_for_schema;
 use crate::dag::state::{CallBuffer, DagState, DagStatus};
 use crate::dag::transform_pool::{TransformOutcome, TransformPool};
 use crate::dag::transform_registry::TransformRegistry;
@@ -1367,14 +1367,7 @@ fn assemble_request(
 /// stored kind equals the slot type.
 fn slot_inner_kind_id(registry: &Registry, cell: &aether_data::SchemaCell) -> KindId {
     let inner: &SchemaType = cell;
-    let target = canonical_kind_bytes("", inner);
-    registry
-        .list_kind_descriptors()
-        .into_iter()
-        .find(|d| canonical_kind_bytes("", &d.schema) == target)
-        .map_or(KindId(0), |d| {
-            registry.kind_id(&d.name).unwrap_or(KindId(0))
-        })
+    kind_id_for_schema(registry, inner)
 }
 
 #[cfg(test)]

--- a/crates/aether-substrate/src/dag/mod.rs
+++ b/crates/aether-substrate/src/dag/mod.rs
@@ -21,3 +21,24 @@ pub mod state;
 pub mod transform_pool;
 pub mod transform_registry;
 pub mod validator;
+
+use aether_data::SchemaType;
+use aether_data::canonical::canonical_kind_bytes;
+
+use crate::mail::{KindId, Registry};
+
+/// Best-effort registered kind id for a schema: searches the registered
+/// kind vocabulary for a descriptor whose schema canonically matches
+/// `schema` and returns its id, falling back to `KindId(0)` when no
+/// registered kind matches (the schema names a kind this substrate
+/// doesn't know — still a usable answer, just without a precise id).
+pub(crate) fn kind_id_for_schema(registry: &Registry, schema: &SchemaType) -> KindId {
+    let target = canonical_kind_bytes("", schema);
+    registry
+        .list_kind_descriptors()
+        .into_iter()
+        .find(|d| canonical_kind_bytes("", &d.schema) == target)
+        .map_or(KindId(0), |d| {
+            registry.kind_id(&d.name).unwrap_or(KindId(0))
+        })
+}

--- a/crates/aether-substrate/src/dag/validator.rs
+++ b/crates/aether-substrate/src/dag/validator.rs
@@ -28,6 +28,7 @@ use aether_data::canonical::canonical_kind_bytes;
 use aether_data::{Kind, Schema, SchemaType};
 use aether_kinds::{Bundle, DagDescriptor, DagError, Edge, Node, NodeId};
 
+use crate::dag::kind_id_for_schema;
 use crate::dag::transform_registry::TransformRegistry;
 use crate::mail::{CapabilityRegistry, KindId, MailboxEntry, MailboxId, Registry};
 
@@ -494,14 +495,7 @@ fn consumer_slot_kind(
 /// registered kind matches (the schema names a kind this substrate
 /// doesn't know — still a mismatch, just without a precise id to name).
 fn declared_kind_id(mailboxes: &Registry, schema: &SchemaType) -> KindId {
-    let target = canonical_kind_bytes("", schema);
-    mailboxes
-        .list_kind_descriptors()
-        .into_iter()
-        .find(|d| canonical_kind_bytes("", &d.schema) == target)
-        .map_or(KindId(0), |d| {
-            mailboxes.kind_id(&d.name).unwrap_or(KindId(0))
-        })
+    kind_id_for_schema(mailboxes, schema)
 }
 
 /// Does `id` resolve to a live (non-dropped) mailbox in the routing

--- a/crates/aether-substrate/src/scheduler/calibrate.rs
+++ b/crates/aether-substrate/src/scheduler/calibrate.rs
@@ -53,6 +53,8 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use aether_actor::cost::ewma_step;
+
 use crate::config::{KnobKind, KnobRecord};
 
 /// Discovery records for the handoff-cost calibration knob (ADR-0090
@@ -127,7 +129,7 @@ impl HandoffEwma {
     fn fold(&self, sample: u64) {
         let mut mean = self.mean.load(Ordering::Relaxed);
         loop {
-            let next = ewma_step(mean, sample);
+            let next = ewma_step(mean, sample, EWMA_SHIFT);
             match self
                 .mean
                 .compare_exchange_weak(mean, next, Ordering::Relaxed, Ordering::Relaxed)
@@ -146,18 +148,6 @@ impl HandoffEwma {
     #[cfg(test)]
     fn samples(&self) -> u64 {
         self.samples.load(Ordering::Relaxed)
-    }
-}
-
-/// One constant-α EWMA step toward `sample`: `current + ((sample − current) >> k)`,
-/// computed on the signed difference so a falling cost converges as fast as
-/// a rising one. Integer-only — the `>> k` is the power-of-two α. Mirrors
-/// `aether_actor::cost`'s step.
-fn ewma_step(current: u64, sample: u64) -> u64 {
-    if sample >= current {
-        current + ((sample - current) >> EWMA_SHIFT)
-    } else {
-        current - ((current - sample) >> EWMA_SHIFT)
     }
 }
 

--- a/crates/aether-substrate/src/scheduler/worker_deque.rs
+++ b/crates/aether-substrate/src/scheduler/worker_deque.rs
@@ -18,7 +18,7 @@
 //! ([`time_budget`]) trips — then the backlog spills so a *heavy* cascade
 //! parallelises across idle workers. The budget is **adaptive**
 //! (iamacoffeepot/aether#1182): a small multiple of the measured
-//! cross-worker handoff cost ([`super::calibrate::handoff_cost`]) — the
+//! cross-worker handoff cost ([`handoff_cost`]) — the
 //! thing the valve out-amortises — so it tracks the hardware instead of a
 //! one-box constant (the prior fixed 12µs sat at `≈ 6 ×` this box's ~2µs
 //! handoff). `AETHER_LOCAL_TIME_BUDGET_US` still overrides. Duration is the
@@ -214,7 +214,7 @@ pub fn mail_budget() -> Option<u32> {
 ///
 /// `6` reproduces the #1174-tuned default on the box it was tuned on: that
 /// 12µs sits at `≈ 6 ×` this box's measured ~2µs handoff
-/// ([`super::calibrate::handoff_cost`]). On a slower box (a more expensive
+/// ([`handoff_cost`]). On a slower box (a more expensive
 /// handoff) the budget scales up — more inlining is worth it before paying
 /// the steeper handoff — and on a faster box it scales down, so the
 /// trivial-vs-heavy discrimination tracks the hardware instead of a
@@ -243,7 +243,7 @@ const MAX_ADAPTIVE_BUDGET: Duration = Duration::from_micros(60);
 /// value pins the budget and `0` disables the valve (pure inline-cascade,
 /// bounded only by `hard_cap`). Unset (the default), the budget is
 /// **derived from the measured handoff cost**: `derive_budget` of
-/// [`super::calibrate::handoff_cost`] — `BUDGET_HANDOFF_MULTIPLIER ×` the
+/// [`handoff_cost`] — `BUDGET_HANDOFF_MULTIPLIER ×` the
 /// boot-probed, live-refined cross-worker handoff on this box, clamped to
 /// the safety rails. Reading the live estimate (rather than a boot
 /// snapshot) keeps the budget tracking the *operating* handoff cost the

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -11,6 +11,10 @@ profile:
 
 # Paths Qodana shouldn't analyse.
 exclude:
+  # Crate-version-upgrade nags are off project-wide: bumping a dependency
+  # on a linter's say-so is a supply-chain risk, so version bumps stay a
+  # deliberate human decision rather than a quality-gate finding.
+  - name: NewCrateVersionAvailable
   - name: All
     paths:
       - target


### PR DESCRIPTION
<!-- pr-body-ok: e — release-flow PR body, scope is the cleanup issue -->

Closes iamacoffeepot/aether#1505.

## Summary

Clears the 20 findings `scripts/qodana-local.sh` reports on `main` so #1496 can wire the scan into `preflight --qodana` against a clean tree, and disables the package-upgrade inspection.

- **`RsUnnecessaryQualifications` (11)** — shorten redundant intra-doc-link path prefixes to the in-scope name (`trace_ring.rs`, `driver.rs`, `ctx.rs`, `boot.rs`, `worker_deque.rs`).
- **`RsUnusedImport` (1)** — `fs.rs`: qualify the `Config` derive's `parse = native::parse_dir` by full path so the file-root re-export is genuinely unneeded, then drop it.
- **`CargoUnusedDependency` (1)** — remove the genuinely-unused `crossbeam-queue` from `aether-substrate` (zero `crossbeam_queue` uses, incl. under any `cfg`).
- **`DuplicatedCode` (7 groups)** — extracted into shared helpers, none suppressed: `pod_kind_codec!` (aether-data, routes through the same cast codec `#[derive(Kind)]` uses so the wire shape is byte-identical), `resolve_persist_state` (chassis_common, the desktop↔headless persist overlay), `kind_id_for_schema` (dag, the executor↔validator schema→KindId lookup), a parameterised `aether_actor::cost::ewma_step`, and `decode_reply` / `scratch_dir` / `cleanup` + a `boot_with_deferred_echo` rpc helper in `test_chassis`.

Disables `NewCrateVersionAvailable` project-wide in `qodana.yaml` — bumping a dependency on a linter's say-so is a supply-chain risk, so crate-version bumps stay a deliberate human decision rather than a quality-gate nag.

## Test plan

- `scripts/preflight.sh` green: fmt + clippy (`-D warnings`) + doc + 1570 nextest passed + wasm32 cross-build.
- `scripts/qodana-local.sh` exits 0 — **0 problems detected** (clean against the threshold).

## Note for review

`ewma_step` now lives in `aether-actor::cost` and is shared by the substrate scheduler's `calibrate.rs` (reuses the existing dep). Per the `aether-math` "domain-agnostic primitives" convention it could arguably live there instead — happy to relocate if preferred.

## Generated by

`/implement` — agent execution of issue #1505 (unblocks #1496).
