### PR TITLE
chore(repo): run qodana-local in preflight --qodana and retire the RustRover qodana pre-flight

### DIFF
--- a/.claude/hooks/check-pre-push.sh
+++ b/.claude/hooks/check-pre-push.sh
@@ -2,17 +2,12 @@
 # Pre-flight gate for Claude-driven `git push` / `gh pr create` Bash calls.
 #
 # The git pre-push hook (.githooks/pre-push) does the same gating for any
-# pusher (CLI, IDE, Claude). What this Claude-side hook adds:
-#
-#   1. Earlier failure. The check fires before `git push` starts uploading,
-#      so a stale tree fails in milliseconds instead of after a slow push +
-#      pre-push pre-flight cycle.
-#
-#   2. The RustRover MCP nudge. The git hook can only run shell-callable
-#      checks (fmt / clippy / doc / nextest / wasm32). The qodana-equivalent
-#      surface lives in RustRover's IDE inspector, callable as the
-#      `mcp__rustrover__get_file_problems` MCP tool from Claude. This hook
-#      reminds Claude to run that tool over the diff before pushing.
+# pusher (CLI, IDE, Claude). What this Claude-side hook adds: earlier
+# failure — the check fires before `git push` starts uploading, so a stale
+# tree fails in milliseconds instead of after a slow push + pre-push
+# pre-flight cycle. (Qodana is no longer a separate nudge: it runs inside
+# `scripts/preflight.sh --qodana`, which the implement-agent push path
+# passes; see CLAUDE.md § "Qodana pre-flight".)
 #
 # Reads the Bash tool-call JSON from stdin (Claude Code PreToolUse hook
 # protocol). Exits 0 to allow, 2 to block (stdout body returns to Claude).
@@ -72,20 +67,7 @@ if [[ -f "$stamp_file" ]]; then
     fi
 fi
 
-# No matching stamp. Compute the diff vs origin/main so the message tells
-# Claude exactly which files to inspect.
-if git rev-parse --verify origin/main >/dev/null 2>&1; then
-    base=$(git merge-base HEAD origin/main 2>/dev/null \
-        || git rev-parse origin/main)
-else
-    base=$(git rev-parse HEAD~1 2>/dev/null || echo "$head_sha")
-fi
-rust_files=()
-while IFS= read -r f; do
-    [[ -n "$f" ]] || continue
-    [[ "$f" =~ \.rs$ ]] && rust_files+=("$f")
-done < <(git diff --name-only "$base..HEAD" 2>/dev/null || true)
-
+# No matching stamp — tell Claude to run the pre-flight.
 {
     echo "[claude pre-push] no pre-flight stamp for HEAD ($head_sha)."
     echo
@@ -93,21 +75,15 @@ done < <(git diff --name-only "$base..HEAD" 2>/dev/null || true)
     echo
     echo "    scripts/preflight.sh"
     echo
-    if [[ ${#rust_files[@]} -gt 0 ]]; then
-        echo "Then run \`mcp__rustrover__get_file_problems\` over each changed .rs"
-        echo "file (the qodana-equivalent that preflight.sh can't run locally)."
-        echo "IMPORTANT: pass \`errorsOnly: false\` — the default is errors-only"
-        echo "and Qodana CI flags NOTICE-level findings (Duplicated code"
-        echo "fragment, Unnecessary path prefix) that get missed otherwise:"
-        echo
-        for f in "${rust_files[@]}"; do
-            echo "    - $f"
-        done
-        echo
-    fi
+    echo "On the implement-agent push path (about to open a CI-checked PR),"
+    echo "pass --qodana so the pre-flight also runs the same qodana scan CI"
+    echo "gates on:"
+    echo
+    echo "    scripts/preflight.sh --qodana"
+    echo
     echo "Once preflight.sh exits 0 the stamp updates and the push proceeds."
-    echo "To bypass deliberately (e.g. emergency docs push), re-run the push"
-    echo "with --no-verify."
+    echo "To bypass deliberately (e.g. emergency docs push, or a known"
+    echo "Qodana-for-Rust EAP tooling flake), re-run the push with --no-verify."
 } >&2
 
 exit 2

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -15,7 +15,7 @@ Two entry shapes, one skill:
 Two ways to run it:
 
 - **In-session (default).** The whole skill runs in the main session — implement, push, drive CI green, hold the draft. Use this for a single issue or when you want tight control over each step.
-- **Hybrid background-agent.** To parallelize across independent issues, the orchestrator may dispatch one background Agent per issue that does *only* the bounded, parallelizable part: cut the worktree off `main`, implement the plan, run the full-workspace validation, and commit — then **STOP**. The main session ("parent") then takes each finished worktree and runs the serial, less-reliable part itself: `scripts/preflight.sh` (which stamps the commit), the push, the draft-PR open, and the CI-green Refine loop — reviewing the agent's diff as it takes over. Never hand the push, PR creation, CI loop, or board writes to the dispatched Agent: handing off the *whole* skill (the retired `/delegate`) proved flaky, so the split keeps the unreliable parts in-session (see `feedback_delegate_implementation_stop_after_commit`).
+- **Hybrid background-agent.** To parallelize across independent issues, the orchestrator may dispatch one background Agent per issue that does *only* the bounded, parallelizable part: cut the worktree off `main`, implement the plan, run the full-workspace validation, and commit — then **STOP**. The main session ("parent") then takes each finished worktree and runs the serial, less-reliable part itself: `scripts/preflight.sh --qodana` (which stamps the commit; `--qodana` runs the same qodana scan CI gates on, needs colima up), the push, the draft-PR open, and the CI-green Refine loop — reviewing the agent's diff as it takes over. Never hand the push, PR creation, CI loop, or board writes to the dispatched Agent: handing off the *whole* skill (the retired `/delegate`) proved flaky, so the split keeps the unreliable parts in-session (see `feedback_delegate_implementation_stop_after_commit`).
 
 Either mode opens the PR **as a draft**, drives CI green, and holds it in draft for your review. This repo has native GitHub auto-merge on, so a *non-draft* PR that reaches green merges itself — draft is the review gate (see `feedback_green_pr_automerges_before_review`). Landing is the release *process*'s call: an approved release un-drafts the PR so native auto-merge takes it. This skill never issues a merge command and never un-drafts on its own.
 
@@ -71,7 +71,7 @@ Type comes from the project item's `Type` field. Slug is the issue title sanitiz
    - `cargo nextest run --workspace`
    - `cargo doc --workspace --no-deps`
    - wasm32 cross-build for component crates (`cargo metadata` → packages with `crate-type = cdylib` and `aether-component` dep)
-   - `scripts/preflight.sh` if present (writes the stamp file expected by the pre-push hook)
+   - `scripts/preflight.sh --qodana` if present (writes the stamp file expected by the pre-push hook). Pass `--qodana` on this push path so the pre-flight runs the same qodana scan CI gates on before the PR opens — it needs colima/docker up and adds ~3.3min; a non-clean qodana exit (findings over `failThreshold`, or the Qodana-for-Rust EAP tooling crash) classifies as a build-env failure → `Stalled` (handle as a `--no-verify` push only for a confirmed EAP flake, never to skip real findings)
 
 4. Push the branch and open the PR:
    ```bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,11 +208,14 @@ jobs:
           # the prior approach (iamacoffeepot/aether#911) is now
           # unnecessary.
           #
-          # --fail-threshold 0 pins the action to fail on any finding
-          # instead of relying on the action's default threshold,
-          # which could shift across version bumps
-          # (iamacoffeepot/aether#941).
-          args: --linter qodana-rust -u root --fail-threshold 0
+          # The fail-threshold lives in qodana.yaml (`failThreshold`),
+          # the single source of truth both this job and
+          # scripts/qodana-local.sh inherit — so the local pre-flight
+          # gate and CI can never disagree. It stays explicit there
+          # (not the action's default, which could shift across version
+          # bumps — iamacoffeepot/aether#941), so no --fail-threshold
+          # CLI override here, which would shadow the yaml value.
+          args: --linter qodana-rust -u root
           # We own restore/save (steps above + below); qodana-action's
           # built-in cache save runs root-owned and trips tar exit 2.
           use-caches: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,24 +132,23 @@ aether_actor::export!(CameraComponent);                    // required; emits wa
 
 `scripts/preflight.sh` runs the CI-equivalent local checks (fmt + clippy + doc + nextest + wasm32 component cross-build) over the workspace and, on success, stamps `.git/aether-preflight-passed` with the HEAD sha so a re-push of the same commit short-circuits. The pre-push git hook (`.githooks/pre-push`) invokes it automatically against the changed-file set. Enable once per clone: `scripts/setup-githooks.sh` (sets `core.hooksPath -> .githooks`).
 
+The qodana scan is **opt-in** via `scripts/preflight.sh --qodana` (or `PREFLIGHT_QODANA=1`) — it runs `scripts/qodana-local.sh` as the last step, needs colima/docker up, and adds ~3.3min, so the default fast loop skips it. The implement-agent push path passes `--qodana` to match the CI qodana gate before opening a PR (see § "Qodana pre-flight").
+
 Exception classes that skip the Rust pre-flight (only when *every* changed path matches the class):
 
 - **Docs-only**: `docs/**` or `*.md` at the root.
 - **CI / repo-config-only**: `.github/**`, `.claude/**`, `.githooks/**`, `scripts/**`, `qodana.{yaml,sarif.json}`, `.mcp.json`, `.gitignore`, `.gitattributes`, or `{rust-toolchain,rustfmt,clippy}.toml`.
 
-A Claude-side hook (`.claude/hooks/check-pre-push.sh`) checks the stamp ahead of `git push` / `gh pr create`. If HEAD has no matching stamp it blocks and prompts Claude to run `scripts/preflight.sh` plus `mcp__rustrover__get_file_problems` over each changed `.rs` file (the qodana-equivalent the shell-only git hook can't reach). Bypass either layer with `git push --no-verify`.
+A Claude-side hook (`.claude/hooks/check-pre-push.sh`) checks the stamp ahead of `git push` / `gh pr create`. If HEAD has no matching stamp it blocks and prompts Claude to run `scripts/preflight.sh` (with `--qodana` on the implement-agent push path). Bypass either layer with `git push --no-verify`.
 
 ## Qodana pre-flight (local)
 
-Qodana gates merges via the `ci-pass` aggregator. Run the **same scan CI submits**, locally, with `scripts/qodana-local.sh` (issue 1099). The naive `qodana scan` times out because it bind-mounts the repo over colima's virtiofs and Qodana's `cargo metadata` pass does thousands of small reads there; the script sidesteps that the way CI does — it syncs the working tree into a Docker named volume (the VM's native fs) and keeps a persistent cache volume for the bootstrapped toolchain + analysis caches. Same linter image / `qodana.recommended` profile / `--fail-threshold 0` as the CI job, reading the same `qodana.yaml`.
+Qodana gates merges via the `ci-pass` aggregator. Run the **same scan CI submits**, locally, with `scripts/qodana-local.sh` (issue 1099). The naive `qodana scan` times out because it bind-mounts the repo over colima's virtiofs and Qodana's `cargo metadata` pass does thousands of small reads there; the script sidesteps that the way CI does — it syncs the working tree into a Docker named volume (the VM's native fs) and keeps a persistent cache volume for the bootstrapped toolchain + analysis caches. Same linter image / `qodana.recommended` profile / fail-threshold as the CI job, reading the same `qodana.yaml` — `failThreshold: 2` lives there as the single source both the CI job and the local run inherit (neither passes a `--fail-threshold` CLI override). `scripts/preflight.sh --qodana` runs it as a pre-flight step; concurrent runs serialize on a lockfile (the volumes are fixed shared names).
 
 - **Run it**: `colima start` first (the script won't auto-boot a cold VM), then `scripts/qodana-local.sh`. ~3.3min warm; SARIF + HTML report land in `./.qodana-local/` (gitignored). Exit code is Qodana's gate (non-zero = findings). `--rebuild-cache` drops the cache volume.
 - **Fidelity**: validated against a main CI run — local reproduced 19/22 findings exactly (`RsUnnecessaryQualifications`, `DuplicatedCode`, `RsUnusedImport`, `CargoUnusedDependency` all matched). The one offline gap is `NewCrateVersionAvailable` (queries crates.io; needs `QODANA_TOKEN`) — export the token to close it, else it stays CI-only. Note `CargoUnusedDependency` **does** run locally.
 
-For a quick single-file check without spinning up the container, RustRover's inspector rehosts most of the same checks:
-
-- **Agent-side**: `mcp__rustrover__get_file_problems` (`errorsOnly: false`) returns the problem set for one file. Iterate it over `git diff --name-only` for a fast pre-commit pass on Qodana-touched files. RustRover MCP has no project-wide runner — use `scripts/qodana-local.sh` (or the IDE's `Code → Inspect Code…`) for whole-project.
-- **Per-file in-IDE**: the gutter + Problems tool window surface the same inspection ids (`RsUnnecessaryParentheses`, `RsApproxConstant`, `DuplicatedCode`, …).
+The authoritative local qodana gate is `scripts/preflight.sh --qodana` (or `scripts/qodana-local.sh` directly) — the same scan CI runs, working from any checkout including a `.claude/worktrees/` worktree. RustRover's IDE inspector is **not** the qodana pre-flight: it analyzes the IDE's open project (the main checkout, not the worktree diff an implement agent validates) and rehosts only a subset of the checks. Reach for RustRover MCP for rename / symbol / refactor work; for the qodana gate use qodana-local.
 
 Re-baselining (`qodana.sarif.json`) is done by downloading the `qodana-report` workflow artifact from a CI run.
 

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -9,6 +9,13 @@ linter: jetbrains/qodana-rust:2026.1-eap
 profile:
   name: qodana.recommended
 
+# Quality gate: the scan fails when the finding count exceeds this.
+# Bumped 0 -> 2 so a small number of findings get swept at end-of-release
+# rather than blocking each push. Single source of truth — both the CI
+# Qodana job and scripts/qodana-local.sh inherit it (neither passes a
+# --fail-threshold CLI override, which would shadow this value).
+failThreshold: 2
+
 # Paths Qodana shouldn't analyse.
 exclude:
   # Crate-version-upgrade nags are off project-wide: bumping a dependency

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -3,8 +3,10 @@
 #
 # Mirrors the CI gates (.github/workflows/ci.yml) that are feasible
 # to run locally: fmt + clippy + doc + nextest + wasm32 component
-# cross-build. Qodana is omitted (running `qodana scan` locally is
-# blocked by colima virtiofs; see CLAUDE.md § "Qodana pre-flight").
+# cross-build. Qodana is opt-in (--qodana / PREFLIGHT_QODANA=1): it
+# adds ~3.3min and needs colima/docker up, so the fast human loop
+# skips it; the implement-agent push path passes --qodana to match the
+# CI gate before opening a PR (see CLAUDE.md § "Qodana pre-flight").
 #
 # On success, writes `.git/aether-preflight-passed` with the current
 # HEAD sha + unix timestamp. The pre-push hook (.githooks/pre-push)
@@ -16,6 +18,8 @@
 #                                              # (used by .githooks/pre-push)
 #   scripts/preflight.sh --force               # ignore exception classes,
 #                                              # run the full check set
+#   scripts/preflight.sh --qodana              # also run the qodana-local
+#                                              # scan (or set PREFLIGHT_QODANA=1)
 
 set -euo pipefail
 
@@ -31,6 +35,9 @@ HEAD_AT_START="$(git rev-parse HEAD)"
 force=0
 explicit=0
 explicit_files=()
+# Opt-in qodana: default off (fast human loop); the implement-agent push
+# path passes --qodana, or set PREFLIGHT_QODANA=1.
+qodana=${PREFLIGHT_QODANA:-0}
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --files)
@@ -43,6 +50,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --force)
             force=1
+            shift
+            ;;
+        --qodana)
+            qodana=1
             shift
             ;;
         -h|--help)
@@ -156,11 +167,21 @@ run_step "cargo doc --workspace --no-deps (rustdoc lints denied)" \
 run_step "cargo xtask dist --no-bins (component wasm cross-build)" \
     cargo xtask dist --no-bins
 
-# Final, slowest step. AETHER_REQUIRE_RUNTIME=1 mirrors CI so a
+# Slowest Rust step. AETHER_REQUIRE_RUNTIME=1 mirrors CI so a
 # missing wasm artifact fails loudly rather than skipping silently.
 run_step "cargo nextest run --workspace --all-features --profile ci" \
     env AETHER_REQUIRE_RUNTIME=1 \
     cargo nextest run --workspace --all-features --profile ci
+
+# Opt-in (--qodana / PREFLIGHT_QODANA=1), and last — it adds ~3.3min and
+# needs colima/docker up. Same scan CI runs (qodana-local.sh reads
+# qodana.yaml, incl. failThreshold). A non-clean exit — findings over the
+# threshold, or the Qodana-for-Rust EAP internal crash — fails the
+# pre-flight; bypass a known tooling flake with `git push --no-verify`.
+if (( qodana )); then
+    run_step "scripts/qodana-local.sh (qodana scan, opt-in)" \
+        scripts/qodana-local.sh
+fi
 
 stamp_pass
 echo "[preflight] OK."

--- a/scripts/qodana-local.sh
+++ b/scripts/qodana-local.sh
@@ -17,9 +17,11 @@
 #      cargo registry + analysis caches, so only the FIRST run pays the
 #      ~minutes of bootstrap; later runs are warm.
 #
-# It runs the same linter image, profile, and `--fail-threshold 0` as
+# It runs the same linter image, profile, and fail-threshold as
 # `.github/workflows/ci.yml`'s Qodana job, reading the same
-# `qodana.yaml` (linter, profile, excludes, bootstrap). Findings match
+# `qodana.yaml` (linter, profile, excludes, bootstrap, `failThreshold`
+# — the single source of truth both this run and CI inherit). Findings
+# match
 # CI: validated against main run 26928217340, local reproduced 19 of 22
 # findings exactly (RsUnnecessaryQualifications, DuplicatedCode,
 # RsUnusedImport, CargoUnusedDependency all matched).
@@ -69,6 +71,20 @@ if ! docker info >/dev/null 2>&1; then
     echo "    colima start --cpu 6 --memory 12" >&2
     exit 1
 fi
+
+# Serialize concurrent runs. The project / cache / results volumes are
+# fixed shared names, so a second run syncing into $proj_vol mid-scan
+# would clobber the first (parallel implement-agent pre-flights, or a
+# manual run alongside one). Take an exclusive lock for the rest of the
+# script; others queue instead of corrupting the volume. An atomic
+# `mkdir` lock — not `flock`, which isn't standard on the macOS host —
+# released on any exit via the trap.
+lock_dir="${TMPDIR:-/tmp}/aether-qodana.lock.d"
+while ! mkdir "$lock_dir" 2>/dev/null; do
+    echo "qodana-local: another scan holds the lock ($lock_dir); waiting ..."
+    sleep 5
+done
+trap 'rmdir "$lock_dir" 2>/dev/null || true' EXIT
 
 docker volume create "$proj_vol"   >/dev/null
 docker volume create "$cache_vol"  >/dev/null
@@ -120,8 +136,7 @@ docker run --rm -u root \
     -v "$cache_vol":/data/cache \
     -v "$results_vol":/data/results \
     ${QODANA_TOKEN:+-e QODANA_TOKEN="$QODANA_TOKEN"} \
-    "$image" \
-    --fail-threshold 0
+    "$image"
 scan_status=$?
 set -e
 


### PR DESCRIPTION
<!-- pr-body-ok: e — release-flow PR body, scope is the implement skill -->

Closes iamacoffeepot/aether#1496.

## Summary

Wires the qodana scan into the local pre-flight as an opt-in step and centralizes the fail-threshold, so the implement-agent push path catches qodana findings before CI instead of after.

- **`scripts/preflight.sh --qodana`** (or `PREFLIGHT_QODANA=1`) — runs `scripts/qodana-local.sh` as the last step (after nextest), default off so the human loop stays ~30s; the implement-agent push path passes `--qodana` to match the CI gate. A non-clean exit hard-fails the pre-flight; bypass a known Qodana-for-Rust EAP tooling flake with `--no-verify`.
- **Centralized fail-threshold** — `failThreshold: 2` lives in `qodana.yaml` (the single source both the CI Qodana job and the local run read); dropped the duplicated `--fail-threshold 0` CLI override from `scripts/qodana-local.sh` and `.github/workflows/ci.yml` so the two gates can never drift.
- **`flock`-free serialization** — `qodana-local.sh` takes an atomic `mkdir` lock (portable to the macOS host, unlike `flock`) so concurrent runs don't clobber the fixed shared volumes.
- **Retired the RustRover qodana pre-flight** — dropped the `mcp__rustrover__get_file_problems` nudge from `.claude/hooks/check-pre-push.sh` and the "RustRover is the qodana pre-flight" framing in CLAUDE.md (it analyzes the IDE's main checkout, blind to worktree diffs, and rehosts only a subset). RustRover MCP stays documented for rename / symbol / refactor.
- The implement skill's push path now invokes `scripts/preflight.sh --qodana`.

Depends on #1505 (cleared the findings); rebased onto it, so `qodana.yaml` carries both `failThreshold: 2` and the `NewCrateVersionAvailable` exclude.

## Test plan

End-to-end on the rebased clean tree, `scripts/preflight.sh --qodana --force`:

- the `--qodana` step fired (`-> scripts/qodana-local.sh`), qodana read `failThreshold: 2` from `qodana.yaml`, reported **0 problems**, exited 0;
- full Rust suite green (fmt + clippy `-D warnings` + doc + 1579 nextest + wasm32);
- `[preflight] OK`.

This PR's own CI Qodana job exercises the `ci.yml` change (qodana inheriting `failThreshold` from the yaml with no CLI override).

## Generated by

`/implement` — issue #1496.
