### PR TITLE
chore(ci): run mod heavy tests in a quiet second nextest pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,11 +148,22 @@ jobs:
       # changed-crate filter the prior step had is gone — nextest's
       # process-per-test isolation surfaces cross-test contamination
       # that the per-crate filter could mask, and the CI profile's
-      # `slow-timeout` bounds runaway tests cleanly.
+      # `slow-timeout` bounds runaway tests cleanly. The run is split
+      # into two passes (iamacoffeepot/aether#1511): the lightweight set
+      # at full parallelism, then the `::heavy::` contention tests alone
+      # (`--test-threads 1`) on the now-idle runner, so a heavy test's
+      # teardown park/wake path isn't starved for cores by the rest of
+      # the suite. The heavy step runs only if the lightweight pass
+      # passed (default fail-fast) — a lightweight failure is the
+      # actionable signal.
       - name: Install latest nextest release
         uses: taiki-e/install-action@nextest
-      - name: Run tests
-        run: cargo nextest run --all-features --profile ci
+      - name: Run tests (lightweight, parallel)
+        run: cargo nextest run --all-features --profile ci -E 'not test(/::heavy::/)'
+        env:
+          AETHER_REQUIRE_RUNTIME: "1"
+      - name: Run tests (heavy, serial on a quiet runner)
+        run: cargo nextest run --all-features --profile ci -E 'test(/::heavy::/)' --test-threads 1
         env:
           AETHER_REQUIRE_RUNTIME: "1"
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -167,11 +167,20 @@ run_step "cargo doc --workspace --no-deps (rustdoc lints denied)" \
 run_step "cargo xtask dist --no-bins (component wasm cross-build)" \
     cargo xtask dist --no-bins
 
-# Slowest Rust step. AETHER_REQUIRE_RUNTIME=1 mirrors CI so a
-# missing wasm artifact fails loudly rather than skipping silently.
-run_step "cargo nextest run --workspace --all-features --profile ci" \
+# Slowest Rust step, split into two passes (iamacoffeepot/aether#1511).
+# Pass 1 runs everything except the `::heavy::` contention tests at full
+# parallelism; pass 2 runs the heavy set alone (`--test-threads 1`) on the
+# now-idle machine, so each heavy test's teardown park/wake path isn't
+# fighting the rest of the suite for cores. `set -e` aborts on the first
+# failing pass. AETHER_REQUIRE_RUNTIME=1 mirrors CI so a missing wasm
+# artifact fails loudly rather than skipping silently.
+run_step "cargo nextest run (lightweight, parallel)" \
     env AETHER_REQUIRE_RUNTIME=1 \
-    cargo nextest run --workspace --all-features --profile ci
+    cargo nextest run --workspace --all-features --profile ci -E 'not test(/::heavy::/)'
+
+run_step "cargo nextest run (heavy, serial on a quiet machine)" \
+    env AETHER_REQUIRE_RUNTIME=1 \
+    cargo nextest run --workspace --all-features --profile ci -E 'test(/::heavy::/)' --test-threads 1
 
 # Opt-in (--qodana / PREFLIGHT_QODANA=1), and last — it adds ~3.3min and
 # needs colima/docker up. Same scan CI runs (qodana-local.sh reads


### PR DESCRIPTION
Closes iamacoffeepot/aether#1511.

## Summary

The `serial-heavy` nextest group caps heavy-vs-heavy concurrency, but the heavy tests still run alongside the full lightweight suite, which saturates every core — so a heavy test never gets a quiet machine. Its teardown drives `unwire` across spawned slots through the worker park/wake path, and under that oversubscription a wake arrives late and the test misses the ~30s deadline, even though it passes in ~0.01s in isolation.

This splits the test run into two sequential passes in both `scripts/preflight.sh` and `.github/workflows/ci.yml`: the lightweight set at full parallelism, then the `::heavy::` set alone with `--test-threads 1` on the now-idle machine, so each heavy test's park/wake path no longer fights the rest of the suite for cores. nextest has no in-run group ordering, so two invocations is the only way to guarantee the heavy set runs last and alone. The `serial-heavy` group is kept as a zero-cost guard for ad-hoc runs that skip the wrapper.

## Test plan

- `cargo nextest list` confirms the filters partition the suite exactly: 41 heavy + 1538 lightweight = 1579 total, so no test is dropped or double-run.
- `bash -n scripts/preflight.sh` and a YAML parse of `ci.yml` both pass.
- This PR's own CI run exercises the split — both `Run tests (lightweight, parallel)` and `Run tests (heavy, serial on a quiet runner)` steps must appear, pass, and still feed `ci-pass`.
- Post-land: watch heavy-test outcomes across subsequent CI runs. If the deadline flakes vanish the fix holds; if a heavy test still times out on the quiet pass, that confirms a genuine `spin_park` lost-wake bug worth its own `fix(substrate)` issue.

## Generated by

`/implement` — agent execution of [scoped issue #1511](https://github.com/iamacoffeepot/aether/issues/1511).
