### PR TITLE
chore(substrate-bundle): real coverage/centroid/bbox frame reductions to de-placebo capture asserts

### DIFF
--- a/crates/aether-substrate-bundle/src/test_bench/visual.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/visual.rs
@@ -77,6 +77,17 @@ pub fn not_all_black(image: &Image) -> Result<(), String> {
     ))
 }
 
+/// A pixel is "lit" when at least one of its RGB channels diverges
+/// from the reference background `bg` by more than `tol`. This is the
+/// per-pixel predicate shared by `differs_from_background` and the
+/// silhouette reductions (`coverage` / `centroid` / `bounding_box`):
+/// they all partition the frame into the same lit/unlit mask, so the
+/// "what counts as drawn" rule lives in exactly one place. `rgb` is
+/// the leading three bytes of an RGBA chunk; alpha is ignored.
+fn is_lit(rgb: &[u8], bg: [u8; 3], tol: u8) -> bool {
+    rgb[0].abs_diff(bg[0]) > tol || rgb[1].abs_diff(bg[1]) > tol || rgb[2].abs_diff(bg[2]) > tol
+}
+
 /// Asserts at least one pixel differs from the top-left pixel by
 /// more than `tolerance` per RGB channel. The top-left pixel is the
 /// "background reference" — for chassis-rendered scenes it's almost
@@ -91,21 +102,128 @@ pub fn differs_from_background(image: &Image, tolerance: u8) -> Result<(), Strin
             image.width, image.height
         ));
     }
-    let bg_r = image.rgba[0];
-    let bg_g = image.rgba[1];
-    let bg_b = image.rgba[2];
+    let bg = [image.rgba[0], image.rgba[1], image.rgba[2]];
     for chunk in image.rgba.chunks_exact(4) {
-        let dr = chunk[0].abs_diff(bg_r);
-        let dg = chunk[1].abs_diff(bg_g);
-        let db = chunk[2].abs_diff(bg_b);
-        if dr > tolerance || dg > tolerance || db > tolerance {
+        if is_lit(chunk, bg, tolerance) {
             return Ok(());
         }
     }
     Err(format!(
         "all {}x{} pixels within tolerance ±{} of top-left ({},{},{})",
-        image.width, image.height, tolerance, bg_r, bg_g, bg_b
+        image.width, image.height, tolerance, bg[0], bg[1], bg[2]
     ))
+}
+
+/// Axis-aligned pixel extent of a lit region, inclusive on both
+/// corners: `min`/`max` are the smallest and largest lit column (`x`)
+/// and row (`y`). A single lit pixel yields `min == max`. Returned by
+/// `bounding_box`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Rect {
+    pub min_x: u32,
+    pub min_y: u32,
+    pub max_x: u32,
+    pub max_y: u32,
+}
+
+/// Fraction of the frame that is lit relative to background `bg` at
+/// per-channel tolerance `tol`, in `[0.0, 1.0]` (lit pixels divided by
+/// `width * height`). Unlike `differs_from_background`, which only
+/// answers "did *anything* draw," coverage constrains *how much* of
+/// the frame the geometry occupies — a tight band rules out both an
+/// all-background miss and an all-filled clear-color mismatch. The
+/// background is passed explicitly so a caller that knows the boot
+/// clear color can pin it rather than inferring from the top-left
+/// pixel; pass `background_top_left(image)` to keep that convention.
+#[must_use]
+#[allow(clippy::cast_precision_loss)]
+pub fn coverage(image: &Image, bg: [u8; 3], tol: u8) -> f32 {
+    let total = image.width as usize * image.height as usize;
+    if total == 0 {
+        return 0.0;
+    }
+    let lit = image
+        .rgba
+        .chunks_exact(4)
+        .filter(|chunk| is_lit(chunk, bg, tol))
+        .count();
+    lit as f32 / total as f32
+}
+
+/// Mean `(x, y)` pixel coordinate of the lit region relative to
+/// background `bg` at tolerance `tol`, where `x` is the column and `y`
+/// the row (top-down). This pins *where* the geometry landed — a
+/// centroid near the frame center says the blob sits in the interior,
+/// not hugging an edge. Returns `None` when no pixel is lit (an empty
+/// mask has no centroid). The `bg`/`tol` convention matches
+/// `coverage`.
+#[must_use]
+#[allow(clippy::cast_precision_loss)]
+pub fn centroid(image: &Image, bg: [u8; 3], tol: u8) -> Option<(f32, f32)> {
+    let width = image.width as usize;
+    let mut sum_x = 0u64;
+    let mut sum_y = 0u64;
+    let mut lit = 0u64;
+    for (index, chunk) in image.rgba.chunks_exact(4).enumerate() {
+        if is_lit(chunk, bg, tol) {
+            sum_x += (index % width) as u64;
+            sum_y += (index / width) as u64;
+            lit += 1;
+        }
+    }
+    if lit == 0 {
+        return None;
+    }
+    Some((sum_x as f32 / lit as f32, sum_y as f32 / lit as f32))
+}
+
+/// Inclusive axis-aligned bounding box of the lit region relative to
+/// background `bg` at tolerance `tol`. Together with `coverage` this
+/// distinguishes "a large blob centered here" from "a thin streak
+/// along one edge" that share a coverage fraction. Returns `None` when
+/// no pixel is lit (an empty mask has no extent). The `bg`/`tol`
+/// convention matches `coverage`.
+#[must_use]
+#[allow(clippy::cast_possible_truncation)]
+pub fn bounding_box(image: &Image, bg: [u8; 3], tol: u8) -> Option<Rect> {
+    let width = image.width as usize;
+    let mut min_x = u32::MAX;
+    let mut min_y = u32::MAX;
+    let mut max_x = 0u32;
+    let mut max_y = 0u32;
+    let mut any_lit = false;
+    for (index, chunk) in image.rgba.chunks_exact(4).enumerate() {
+        if !is_lit(chunk, bg, tol) {
+            continue;
+        }
+        any_lit = true;
+        let x = (index % width) as u32;
+        let y = (index / width) as u32;
+        min_x = min_x.min(x);
+        min_y = min_y.min(y);
+        max_x = max_x.max(x);
+        max_y = max_y.max(y);
+    }
+    any_lit.then_some(Rect {
+        min_x,
+        min_y,
+        max_x,
+        max_y,
+    })
+}
+
+/// RGB of the top-left pixel — the conventional background reference
+/// for a chassis-rendered scene, where the clear color fills the
+/// corners and geometry sits in the middle. Pass the result as `bg` to
+/// `coverage` / `centroid` / `bounding_box` to keep the
+/// `differs_from_background` convention. An image with fewer than four
+/// bytes (no first pixel) yields `[0, 0, 0]`.
+#[must_use]
+pub fn background_top_left(image: &Image) -> [u8; 3] {
+    if image.rgba.len() < 4 {
+        return [0, 0, 0];
+    }
+    [image.rgba[0], image.rgba[1], image.rgba[2]]
 }
 
 #[cfg(test)]
@@ -125,6 +243,102 @@ mod tests {
             height,
             rgba: buf,
         }
+    }
+
+    /// Paint a single filled rectangle in `fill` over a solid `bg`
+    /// frame, so the silhouette reductions can be checked against
+    /// geometry with known corners, area, and center. The rect spans
+    /// `[min_x, max_x] × [min_y, max_y]` inclusive, in pixel
+    /// coordinates — the same inclusive convention `Rect` and
+    /// `bounding_box` use, so a round-trip through `bounding_box`
+    /// recovers the exact `rect` passed in.
+    fn solid_with_rect(width: u32, height: u32, bg: [u8; 4], fill: [u8; 4], rect: Rect) -> Image {
+        let mut image = solid(width, height, bg);
+        for y in rect.min_y..=rect.max_y {
+            for x in rect.min_x..=rect.max_x {
+                let start = ((y * width + x) * 4) as usize;
+                image.rgba[start..start + 4].copy_from_slice(&fill);
+            }
+        }
+        image
+    }
+
+    #[test]
+    fn coverage_matches_rect_area_fraction() {
+        let bg = [69, 79, 105];
+        // 4×4 lit rect (4..=7 × 6..=9) on a 16×16 frame: 16 of 256 px.
+        let rect = Rect {
+            min_x: 4,
+            min_y: 6,
+            max_x: 7,
+            max_y: 9,
+        };
+        let img = solid_with_rect(16, 16, [bg[0], bg[1], bg[2], 255], [200, 32, 32, 255], rect);
+        let fraction = coverage(&img, bg, 5);
+        assert!(
+            (fraction - 16.0 / 256.0).abs() < 1e-6,
+            "coverage was {fraction}, expected 16/256",
+        );
+    }
+
+    #[test]
+    fn centroid_lands_at_rect_center() {
+        let bg = [69, 79, 105];
+        let rect = Rect {
+            min_x: 4,
+            min_y: 6,
+            max_x: 7,
+            max_y: 9,
+        };
+        let img = solid_with_rect(16, 16, [bg[0], bg[1], bg[2], 255], [200, 32, 32, 255], rect);
+        let (center_x, center_y) = centroid(&img, bg, 5).expect("a lit mask has a centroid");
+        // Mean of the inclusive spans 4..=7 and 6..=9.
+        assert!(
+            (center_x - 5.5).abs() < 1e-6,
+            "centroid x was {center_x}, expected 5.5",
+        );
+        assert!(
+            (center_y - 7.5).abs() < 1e-6,
+            "centroid y was {center_y}, expected 7.5",
+        );
+    }
+
+    #[test]
+    fn bounding_box_recovers_rect_corners() {
+        let bg = [69, 79, 105];
+        let rect = Rect {
+            min_x: 4,
+            min_y: 6,
+            max_x: 7,
+            max_y: 9,
+        };
+        let img = solid_with_rect(16, 16, [bg[0], bg[1], bg[2], 255], [200, 32, 32, 255], rect);
+        assert_eq!(bounding_box(&img, bg, 5), Some(rect));
+    }
+
+    #[test]
+    fn reductions_report_empty_on_all_background() {
+        let bg = [69, 79, 105];
+        let img = solid(8, 8, [bg[0], bg[1], bg[2], 255]);
+        // No pixel diverges from bg, so the mask is empty: zero
+        // coverage and no centroid / bounding box to report.
+        assert_eq!(coverage(&img, bg, 5), 0.0);
+        assert!(centroid(&img, bg, 5).is_none());
+        assert!(bounding_box(&img, bg, 5).is_none());
+    }
+
+    #[test]
+    fn background_top_left_reads_first_pixel() {
+        let img = solid(4, 4, [69, 79, 105, 255]);
+        assert_eq!(background_top_left(&img), [69, 79, 105]);
+        // An image with no first pixel falls back to black rather than
+        // indexing out of bounds.
+        let empty = Image {
+            width: 0,
+            height: 0,
+            rgba: Vec::new(),
+        };
+        assert_eq!(background_top_left(&empty), [0, 0, 0]);
     }
 
     #[test]

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -38,7 +38,7 @@ use aether_kinds::{
 use aether_substrate_bundle::test_bench::{
     BenchOp, TestBench,
     test_helpers::{has_wgpu_adapter, init_save_sandbox, require_runtime, test_namespace_roots},
-    visual::{decode_png, differs_from_background},
+    visual::{background_top_left, centroid, coverage, decode_png},
 };
 use aether_test_fixtures::{Bump, CountQuery, CountReport, SetRender};
 
@@ -412,13 +412,15 @@ fn drop_component_silences_tick_echoes() {
 }
 
 /// `capture_frame` round-trip with non-empty mail bundles. The
-/// pre-mail bundle flips the fixture's render state to "visible
-/// red"; the captured PNG must contain at least one pixel that
-/// diverges from the chassis clear color. The after-mail bundle
-/// flips render back to invisible; a follow-up advance + plain
-/// capture must produce a frame back at the clear color, proving
-/// the after-mail cleanup ran.
+/// pre-mail bundle flips the fixture's render state to "visible red";
+/// the probe then paints one large triangle, so the captured PNG must
+/// show a coverage fraction inside a sane band (neither all-background
+/// nor all-filled) with a centroid sitting in the frame interior. The
+/// after-mail bundle flips render back to invisible; a follow-up
+/// advance + plain capture must produce a frame back at the clear
+/// color — near-zero coverage — proving the after-mail cleanup ran.
 #[test]
+#[allow(clippy::cast_precision_loss)]
 fn capture_frame_round_trip_runs_pre_and_after_mails() {
     let Some(wasm_path) = require_runtime("probe") else {
         return;
@@ -471,7 +473,34 @@ fn capture_frame_round_trip_runs_pre_and_after_mails() {
         .expect("prime + capture-with-mails");
     let png = captured.captured("snap").expect("snap step ran");
     let img = decode_png(png).expect("decode capture png");
-    differs_from_background(&img, 5).expect("captured frame should contain a non-background pixel");
+    let bg = background_top_left(&img);
+    let tolerance = 5;
+    // The probe draws one large triangle (NDC verts spanning ±0.9),
+    // covering roughly 40% of the frame. A coverage band rules out the
+    // two ways the old single-pixel `differs_from_background` check went
+    // placebo: an all-background miss (drew nothing) and an all-filled
+    // frame (clear color itself diverging from the sampled corner).
+    let drawn = coverage(&img, bg, tolerance);
+    assert!(
+        (0.05..0.95).contains(&drawn),
+        "probe triangle coverage {drawn} fell outside the expected band (0.05, 0.95); \
+         the captured frame is effectively empty or entirely filled",
+    );
+    // The triangle is centered on the middle column and weighted toward
+    // the lower half, so its centroid lands well inside the frame rather
+    // than hugging an edge.
+    let (center_x, center_y) = centroid(&img, bg, tolerance).expect("a lit frame has a centroid");
+    let (width, height) = (img.width as f32, img.height as f32);
+    assert!(
+        center_x > 0.1 * width
+            && center_x < 0.9 * width
+            && center_y > 0.1 * height
+            && center_y < 0.9 * height,
+        "triangle centroid ({center_x}, {center_y}) should sit in the frame interior \
+         of the {}x{} capture",
+        img.width,
+        img.height,
+    );
 
     // Cleanup ran: probe.render is now { visible: 0 }. Advance once
     // and capture again — the next tick won't emit DrawTriangle, so
@@ -484,10 +513,11 @@ fn capture_frame_round_trip_runs_pre_and_after_mails() {
         .expect("post-cleanup advance + capture");
     let png2 = cleaned.captured("snap2").expect("snap2 step ran");
     let img2 = decode_png(png2).expect("decode cleanup png");
+    let cleaned_coverage = coverage(&img2, background_top_left(&img2), 5);
     assert!(
-        differs_from_background(&img2, 5).is_err(),
+        cleaned_coverage < 0.01,
         "after after-mail cleanup the captured frame should be uniform clear color, \
-         but at least one pixel still diverges (cleanup did not run)",
+         but coverage was {cleaned_coverage} (cleanup did not run)",
     );
 }
 


### PR DESCRIPTION
Closes iamacoffeepot/aether#1513.

## Summary

The substrate's only frame-analysis primitives were `not_all_black` and `differs_from_background`, both satisfied by a single non-background pixel — so the offscreen `capture_frame_round_trip` test asserted only "a pixel diverges from the top-left," saying nothing about where geometry landed or how much it covered. That placebo blocked any real capture assertion downstream.

This adds three pure reductions over the decoded RGBA lit-mask in `test_bench/visual.rs` (a pixel is lit when it differs from an explicit reference background beyond a per-channel tolerance):

- `coverage(&Image, bg, tol) -> f32` — lit-pixel fraction.
- `centroid(&Image, bg, tol) -> Option<(f32, f32)>` — center-of-mass of the lit mask.
- `bounding_box(&Image, bg, tol) -> Option<Rect>` — silhouette extent.

The lit predicate is factored into a private `is_lit` that `differs_from_background` now calls (no behavior change there), and `background_top_left` preserves the existing top-left-reference convention. The offscreen `capture_frame_round_trip_runs_pre_and_after_mails` test is tightened to assert the probe triangle's coverage band plus a centroid-in-interior check, and the cleanup frame to assert coverage near zero.

## Test plan

- Unit tests on synthesized images: a lit rectangle at a known position asserts coverage matches the area fraction, centroid lands at the rect center, and `bounding_box` recovers the exact corners; an all-background image returns empty (0.0 / None / None). `background_top_left` covers the empty-image fallback.
- The offscreen capture scenario runs on a wgpu box (verified locally — the probe triangle lands at ~40% coverage with a centered-lower centroid, inside the asserted band) and skips cleanly on driverless boxes.
- Full workspace pre-flight green (`fmt`, `clippy --workspace --all-targets -D warnings`, `nextest run --workspace`, `doc`, qodana).

## Generated by

`/implement` — agent execution of scoped issue #1513.
