### PR TITLE
chore(substrate-bundle): in-process TestBench cube render scenario with silhouette assertions

### DIFF
--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -38,7 +38,7 @@ use aether_kinds::{
 use aether_substrate_bundle::test_bench::{
     BenchOp, TestBench,
     test_helpers::{has_wgpu_adapter, init_save_sandbox, require_runtime, test_namespace_roots},
-    visual::{background_top_left, centroid, coverage, decode_png},
+    visual::{background_top_left, bounding_box, centroid, coverage, decode_png},
 };
 use aether_test_fixtures::{Bump, CountQuery, CountReport, SetRender};
 
@@ -113,6 +113,36 @@ fn load_probe(bench: &mut TestBench, wasm_path: &Path) -> MailboxId {
     {
         LoadResult::Ok { mailbox_id, .. } => mailbox_id,
         LoadResult::Err { error } => panic!("load_component: {error}"),
+    }
+}
+
+/// Load the `cube` fixture into the bench, blocking on `LoadResult`
+/// so the subsequent advance sees a tick-subscribed component. Mirrors
+/// `load_probe`; the cube scenario only needs the load to succeed (it
+/// captures rather than mailing the component), so the returned
+/// `MailboxId` is discarded.
+fn load_cube(bench: &mut TestBench, wasm_path: &Path) {
+    let wasm = fs::read(wasm_path).expect("read fixture wasm");
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm,
+                    name: Some("cube".to_owned()),
+                    config: Vec::new(),
+                    export: None,
+                },
+            ),
+        )])
+        .expect("load sequence");
+    match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Ok { .. } => {}
+        LoadResult::Err { error } => panic!("load_component(cube): {error}"),
     }
 }
 
@@ -518,6 +548,90 @@ fn capture_frame_round_trip_runs_pre_and_after_mails() {
         cleaned_coverage < 0.01,
         "after after-mail cleanup the captured frame should be uniform clear color, \
          but coverage was {cleaned_coverage} (cleanup did not run)",
+    );
+}
+
+/// Render-pipeline proof: load the `cube` fixture, drive one tick, and
+/// capture. The fixture publishes a fixed `Camera { view_proj }` and a
+/// twelve-triangle world-space unit cube, so the captured frame puts
+/// every stage on the line at once — camera, `view_proj`, world-space
+/// geometry, the depth test that orders the cube's faces, and GPU
+/// readback. The existing `capture_frame_round_trip` scenario only
+/// draws a flat NDC triangle at identity `view_proj`, so this is the
+/// first capture that actually projects geometry through a camera.
+///
+/// The assertions use the #1513 silhouette reductions against the
+/// known framing matrix: the cube's lit bounding box must sit centered
+/// and inset from the frame edges (not a corner speck, not full-bleed),
+/// and coverage must land in the cube's band. The bounds below were
+/// tuned against the real captured frame at this size and `view_proj`.
+#[test]
+#[allow(clippy::cast_precision_loss)]
+fn cube_render_projects_centered_silhouette() {
+    let Some(wasm_path) = require_runtime("cube") else {
+        return;
+    };
+    // 128×96 matches the fixture's `view_proj` aspect (4:3), so the
+    // silhouette projects undistorted.
+    let (width, height) = (128u32, 96u32);
+    let mut bench = TestBench::start_with_size(width, height).expect("boot");
+    load_cube(&mut bench, &wasm_path);
+
+    // Priming advance subscribes the cube to ticks; the next tick (run
+    // inside `capture`) drives the cube's camera + geometry emission so
+    // the readback sees a fully-formed frame.
+    let captured = bench
+        .execute(vec![
+            ("prime", BenchOp::advance(1)),
+            ("snap", BenchOp::capture()),
+        ])
+        .expect("prime + capture");
+    let png = captured.captured("snap").expect("snap step ran");
+    let img = decode_png(png).expect("decode capture png");
+    let bg = background_top_left(&img);
+    let tolerance = 5;
+
+    // Coverage band: the cube fills a healthy fraction of the frame but
+    // leaves the clear color showing in the corners. The fixed
+    // `view_proj` makes this deterministic; the observed fraction is
+    // ~0.18, so the band brackets it with margin while still ruling out
+    // an empty frame (drew nothing) and a full-bleed frame (clear-color
+    // mismatch or runaway geometry).
+    let drawn = coverage(&img, bg, tolerance);
+    assert!(
+        (0.10..0.30).contains(&drawn),
+        "cube coverage {drawn} fell outside the expected band (0.10, 0.30); \
+         the captured frame is effectively empty or entirely filled",
+    );
+
+    // The silhouette must be centered and inset from every edge —
+    // proving the cube projected to the middle of the frame, not into a
+    // corner and not bleeding past the borders.
+    let silhouette = bounding_box(&img, bg, tolerance).expect("a lit frame has a bounding box");
+    let (frame_width, frame_height) = (img.width as f32, img.height as f32);
+    let min_x = silhouette.min_x as f32;
+    let min_y = silhouette.min_y as f32;
+    let max_x = silhouette.max_x as f32;
+    let max_y = silhouette.max_y as f32;
+    assert!(
+        min_x > 0.05 * frame_width
+            && max_x < 0.95 * frame_width
+            && min_y > 0.05 * frame_height
+            && max_y < 0.95 * frame_height,
+        "cube silhouette {silhouette:?} should be inset from the edges of the \
+         {}x{} frame (not full-bleed)",
+        img.width,
+        img.height,
+    );
+    assert!(
+        min_x < 0.45 * frame_width
+            && max_x > 0.55 * frame_width
+            && min_y < 0.45 * frame_height
+            && max_y > 0.55 * frame_height,
+        "cube silhouette {silhouette:?} should straddle the center of the \
+         {}x{} frame (not a corner speck)",
+        img.width,
+        img.height,
     );
 }
 

--- a/crates/aether-test-fixtures/Cargo.toml
+++ b/crates/aether-test-fixtures/Cargo.toml
@@ -69,6 +69,14 @@ crate-type = ["cdylib"]
 name = "stateful_replace"
 crate-type = ["cdylib"]
 
+# Issue 1454: cube render fixture. Emits a twelve-triangle world-space
+# unit cube under a fixed `view_proj` so the TestBench cube scenario can
+# assert the camera + depth + readback pipeline.
+# Wasm artifact: target/wasm32-unknown-unknown/{profile}/examples/cube.wasm
+[[example]]
+name = "cube"
+crate-type = ["cdylib"]
+
 # Issue 1472: DAG `Source` fixture. Replies a fixed `Mat4Apply` operand
 # on `Mat4SourceTrigger`, feeding the `mat4_apply` transform downstream.
 # Wasm artifact: target/wasm32-unknown-unknown/{profile}/examples/mat4_source.wasm

--- a/crates/aether-test-fixtures/examples/cube.rs
+++ b/crates/aether-test-fixtures/examples/cube.rs
@@ -1,0 +1,168 @@
+//! Test-fixture component that renders a solid unit cube through a
+//! fixed camera, so a `TestBench` capture scenario can assert the
+//! full render pipeline end-to-end: camera + `view_proj` + world-space
+//! geometry + depth test + GPU readback (issue 1454).
+//!
+//! The existing offscreen capture fixture (`probe`) paints a single
+//! flat NDC triangle at identity `view_proj`, which touches none of
+//! the camera path. This fixture instead emits a twelve-triangle
+//! world-space cube centered at the origin (corners at ±0.5) and
+//! publishes a hand-computed `Camera { view_proj }` that frames the
+//! cube as a centered silhouette. The camera sits in the all-positive
+//! octant looking back at the origin, so three faces are visible and
+//! the view is non-axis-aligned — the depth test actually orders the
+//! faces rather than collapsing to a flat quad.
+//!
+//! Behaviour:
+//!
+//! - `init` computes the `view_proj` once (perspective × look-at,
+//!   built from `aether-math`) and stores it. The matrix is fixed, so
+//!   every captured frame is deterministic.
+//! - `wire` subscribes `Tick` on `aether.lifecycle` (ADR-0082),
+//!   mirroring the reference camera and the probe.
+//! - On each tick the fixture publishes the stored `Camera` to the
+//!   chassis render mailbox, then emits the cube's twelve
+//!   `DrawTriangle`s — six faces, each a distinct flat color so the
+//!   silhouette reads as one solid blob. Vertices carry world `z`, so
+//!   the `Depth32Float` / `LessEqual` test draws nearer faces over
+//!   farther ones.
+
+use core::f32::consts::FRAC_PI_4;
+
+use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
+use aether_capabilities::lifecycle::LifecycleMailboxExt;
+use aether_capabilities::{LifecycleCapability, RenderCapability};
+use aether_kinds::{Camera, DrawTriangle, Tick, Vertex};
+use aether_math::{Mat4, Vec3};
+
+/// Half-extent of the unit cube: corners sit at ±`HALF` on every axis,
+/// so the cube spans one world unit and is centered at the origin.
+const HALF: f32 = 0.5;
+
+/// Aspect ratio the `view_proj` is built for. The cube scenario boots
+/// the bench at 128×96, so a 4:3 aspect keeps the projected silhouette
+/// undistorted. A small mismatch with the real frame only scales the
+/// silhouette slightly; the capture asserts leave margin for it.
+const ASPECT: f32 = 128.0 / 96.0;
+
+/// Vertical field of view in radians (45°). Combined with the eye
+/// distance below it sizes the cube to a healthy fraction of the frame
+/// without bleeding to the edges.
+const FIELD_OF_VIEW_Y_RADIANS: f32 = FRAC_PI_4;
+
+/// Near / far planes bracketing the cube comfortably; the cube's world
+/// `z` lives in roughly [-0.87, 0.87] after projection, well inside.
+const Z_NEAR: f32 = 0.1;
+const Z_FAR: f32 = 100.0;
+
+pub struct Cube {
+    view_proj: [f32; 16],
+}
+
+impl Cube {
+    /// World-to-clip matrix that frames the cube. The eye sits in the
+    /// all-positive octant and looks back at the origin, so the +X,
+    /// +Y, and +Z faces are all visible and no cube edge is parallel
+    /// to a frame axis. `proj * view` is the column-major product the
+    /// chassis uploads verbatim as the `view_proj` uniform.
+    fn framing_view_proj() -> [f32; 16] {
+        let eye = Vec3::new(1.8, 1.5, 2.2);
+        let view = Mat4::look_at_rh(eye, Vec3::ZERO, Vec3::Y);
+        let proj = Mat4::perspective_rh(FIELD_OF_VIEW_Y_RADIANS, ASPECT, Z_NEAR, Z_FAR);
+        (proj * view).to_cols_array()
+    }
+
+    /// The cube's twelve world-space triangles. Each of the six faces
+    /// is two triangles sharing a flat color, wound so the solid
+    /// silhouette is gap-free regardless of cull state. Colors are
+    /// distinct per face purely so the faces are visually separable in
+    /// a captured frame; the silhouette asserts only care that the
+    /// union is a solid centered blob.
+    fn triangles() -> [DrawTriangle; 12] {
+        // Eight corners of the cube, named by their sign on each axis.
+        let corner = |sx: f32, sy: f32, sz: f32| (sx * HALF, sy * HALF, sz * HALF);
+        let nnn = corner(-1.0, -1.0, -1.0);
+        let pnn = corner(1.0, -1.0, -1.0);
+        let npn = corner(-1.0, 1.0, -1.0);
+        let ppn = corner(1.0, 1.0, -1.0);
+        let nnp = corner(-1.0, -1.0, 1.0);
+        let pnp = corner(1.0, -1.0, 1.0);
+        let npp = corner(-1.0, 1.0, 1.0);
+        let ppp = corner(1.0, 1.0, 1.0);
+
+        // One vertex with a face color baked in.
+        let vert = |position: (f32, f32, f32), color: [f32; 3]| Vertex {
+            x: position.0,
+            y: position.1,
+            z: position.2,
+            r: color[0],
+            g: color[1],
+            b: color[2],
+        };
+        // A quad as two triangles, all six vertices sharing `color`.
+        let quad = |a, b, c, d, color: [f32; 3]| {
+            [
+                DrawTriangle {
+                    verts: [vert(a, color), vert(b, color), vert(c, color)],
+                },
+                DrawTriangle {
+                    verts: [vert(a, color), vert(c, color), vert(d, color)],
+                },
+            ]
+        };
+
+        let [front_0, front_1] = quad(nnp, pnp, ppp, npp, [0.85, 0.20, 0.20]); // +Z
+        let [back_0, back_1] = quad(pnn, nnn, npn, ppn, [0.20, 0.30, 0.85]); // -Z
+        let [right_0, right_1] = quad(pnp, pnn, ppn, ppp, [0.20, 0.75, 0.30]); // +X
+        let [left_0, left_1] = quad(nnn, nnp, npp, npn, [0.85, 0.75, 0.20]); // -X
+        let [top_0, top_1] = quad(npp, ppp, ppn, npn, [0.80, 0.45, 0.85]); // +Y
+        let [bottom_0, bottom_1] = quad(nnn, pnn, pnp, nnp, [0.30, 0.80, 0.80]); // -Y
+
+        [
+            front_0, front_1, back_0, back_1, right_0, right_1, left_0, left_1, top_0, top_1,
+            bottom_0, bottom_1,
+        ]
+    }
+}
+
+#[actor]
+impl FfiActor for Cube {
+    const NAMESPACE: &'static str = "cube";
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
+    where
+        C: Resolver,
+    {
+        Ok(Cube {
+            view_proj: Cube::framing_view_proj(),
+        })
+    }
+
+    /// Subscribe `Tick` so the chassis tick fanout drives `on_tick`.
+    /// `init` is `Resolver`-only and can't mail, so the subscribe lands
+    /// here in `wire` (mirrors the probe and the reference camera).
+    fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
+        ctx.actor::<LifecycleCapability>().subscribe::<Tick>();
+    }
+
+    /// Publish the fixed camera, then emit the cube. The camera goes
+    /// first so the chassis's `view_proj` uniform holds the framing
+    /// matrix before the triangles are rasterized in the same frame.
+    ///
+    /// # Agent
+    /// Not sent manually; the substrate's tick fanout fires it once per
+    /// advance for every `aether.lifecycle`-subscribed mailbox. A
+    /// `capture_frame` taken after one tick shows the centered cube
+    /// silhouette.
+    #[handler]
+    fn on_tick(&mut self, ctx: &mut FfiCtx<'_>, _: Tick) {
+        ctx.actor::<RenderCapability>().send(&Camera {
+            view_proj: self.view_proj,
+        });
+        for triangle in Cube::triangles() {
+            ctx.actor::<RenderCapability>().send(&triangle);
+        }
+    }
+}
+
+aether_actor::export!(Cube);


### PR DESCRIPTION
Closes iamacoffeepot/aether#1454.

## Summary

There was no cube-render correctness test anywhere — the only offscreen capture scenario drew a single flat NDC triangle at identity `view_proj`, exercising none of camera + `view_proj` + depth. This adds real render-pipeline coverage in-process (no new chassis, no RPC), the shape the issue was re-scoped to after the consolidation discussion: capture/cube correctness belongs in TestBench, and RPC byte-reply robustness is already FleetBench's.

- New cube fixture `aether-test-fixtures/examples/cube.rs` — an `#[actor]` that computes a fixed `view_proj` once via aether-math (a perspective `look_at` from the positive octant so three faces show and the view is non-axis-aligned), and on each tick publishes the `Camera` to `RenderCapability` then emits a 12-triangle world-space unit cube (corners at ±0.5, distinct flat face colors, world-z so the depth test orders faces).
- New TestBench scenario `cube_render_projects_centered_silhouette` — loads the fixture, drives one frame, captures, and asserts via the #1513 reductions that the projected silhouette is centered and sanely sized.

## Test plan

- Plain in-process `#[test]` gated on `require_runtime("cube")` — runs on a wgpu box, skips cleanly on driverless ones.
- Assertions tuned against the real captured frame (128×96): observed coverage 0.183 with bbox `Rect { min_x: 36, min_y: 23, max_x: 90, max_y: 78 }` (x-center ≈ frame center). Asserts a coverage band (0.10..0.30), a silhouette inset from all four edges (rules out full-bleed), and a straddle-center check (rules out a corner speck).
- `cargo xtask dist` places `cube.wasm` in the manifest; wasm32 cross-build of the fixture passes.
- Full workspace pre-flight green (`fmt`, `clippy --workspace --all-targets -D warnings`, `nextest run --workspace` incl. the cube scenario, `doc`, qodana).

## Generated by

`/implement` — agent execution of scoped issue #1454.
