### PR TITLE
feat(kit): loco-motion survival game shell — levels, difficulty ramp, and health

### DIFF
--- a/crates/aether-kit/src/arena.rs
+++ b/crates/aether-kit/src/arena.rs
@@ -68,10 +68,13 @@ const COLUMN_THICK: i32 = 2;
 /// Gap width in the wall, in sub-cells (~3 tiles of breathing room).
 const COLUMN_GAP: i32 = 12;
 
-// Wave: a single expanding arc — one ~90° sector of an outward ring.
+// Wave: a single expanding arc — one sector of an outward ring.
 const WAVE_TICKS_PER_STEP: i32 = 5;
 const WAVE_THICK: i32 = 3;
 const WAVE_MAX: i32 = 50;
+/// Wave half-angle as a `(numerator, denominator)` slope bound on `|cross| /
+/// dot` (see [`paint_arc`]): `(1, 1)` is a ±45° wedge, a 90° sector.
+const WAVE_WEDGE: (i32, i32) = (1, 1);
 
 /// The eight compass directions a wave can face.
 const COMPASS_DIRS: [(i32, i32); 8] = [
@@ -96,9 +99,11 @@ const MAX_CONCURRENT: usize = 2;
 const SPEED_DEN: i32 = 4;
 const SPEED_MIN: i32 = 1; // 0.25×
 const SPEED_MAX: i32 = 16; // 4×
-/// Adjustable wall-thickness bounds, in sub-cells.
+/// Adjustable wall-thickness bounds, in sub-cells. The ceiling is high enough
+/// for a wall to read as a thick advancing slab (40 sub = 10 tiles, most of the
+/// 16-tile field), not just a thin line.
 const WALL_MIN: i32 = 1;
-const WALL_MAX: i32 = 8;
+const WALL_MAX: i32 = 40;
 
 /// A sub-cell's current hazard state.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -212,9 +217,15 @@ impl Pattern {
             Shape::Wave { cx, cz, ux, uz } => {
                 let wf = (age / WAVE_TICKS_PER_STEP).min(WAVE_MAX);
                 let df = (danger_age / WAVE_TICKS_PER_STEP).min(WAVE_MAX);
-                paint_arc(field, cx, cz, df, wf + WAVE_THICK, Phase::Warning, (ux, uz));
+                let arc = ArcSpec {
+                    cx,
+                    cz,
+                    dir: (ux, uz),
+                    wedge: WAVE_WEDGE,
+                };
+                paint_arc(field, df, wf + WAVE_THICK, Phase::Warning, arc);
                 if age >= LEAD_TICKS {
-                    paint_arc(field, cx, cz, df, df + WAVE_THICK, Phase::Danger, (ux, uz));
+                    paint_arc(field, df, df + WAVE_THICK, Phase::Danger, arc);
                 }
             }
         }
@@ -399,6 +410,91 @@ impl Arena {
             Phase::Safe | Phase::Warning => None,
         }
     }
+
+    /// Design aid (not gameplay): freeze the field into a static 3×3 contact
+    /// sheet of one shape's parameter variations, so the look of each parameter
+    /// reads at a glance under the top-down preview camera. Thickness varies
+    /// down the rows; the shape's spatial parameter varies across the columns.
+    /// `shape`: `1` ring, `2` wall, `3` wave; anything else clears the field.
+    /// The danger band shows red with its leading-edge orange telegraph, the
+    /// same as in play.
+    pub fn show_matrix(&mut self, shape: u32) {
+        self.phases.fill(Phase::Safe);
+        match shape {
+            1 => self.paint_ring_matrix(),
+            2 => self.paint_wall_matrix(),
+            3 => self.paint_wave_matrix(),
+            _ => {}
+        }
+    }
+
+    /// Rings: band thickness down the rows, expansion-frontier radius across the
+    /// columns. Orange leads outward — where the ring is about to reach.
+    fn paint_ring_matrix(&mut self) {
+        const RADII: [i32; 3] = [4, 6, 8];
+        const THICKS: [i32; 3] = [2, 3, 4];
+        for (row, &thick) in THICKS.iter().enumerate() {
+            for (col, &radius) in RADII.iter().enumerate() {
+                let (cx, cz) = panel_center(col, row);
+                paint_annulus(&mut self.phases, cx, cz, radius, radius + 3, Phase::Warning);
+                paint_annulus(&mut self.phases, cx, cz, radius - thick, radius, Phase::Danger);
+            }
+        }
+    }
+
+    /// Walls: a wall spans the whole arena, so it reads as a barrier rather than
+    /// a panel tile. Three full-width walls stacked down the field, thickness
+    /// growing top to bottom at a fixed gap; orange leads downward (`+z`), the
+    /// sweep direction. Each wall is anchored at the top of its band so the
+    /// thick one grows down into its own space without overlapping the next.
+    #[allow(clippy::cast_possible_wrap)] // row is a 0..3 loop index
+    fn paint_wall_matrix(&mut self) {
+        const THICKS: [i32; 3] = [4, 10, 16];
+        const GAP: i32 = 10;
+        let gap_lo = HW / 2 - GAP / 2;
+        let gap_hi = HW / 2 + GAP / 2;
+        let band = HH / 3;
+        for (row, &thick) in THICKS.iter().enumerate() {
+            let z0 = row as i32 * band + 1;
+            for k in 0..thick {
+                paint_line(&mut self.phases, true, z0 + k, gap_lo, gap_hi, Phase::Danger);
+            }
+            for k in thick..(thick + 3) {
+                paint_line(&mut self.phases, true, z0 + k, gap_lo, gap_hi, Phase::Warning);
+            }
+        }
+    }
+
+    /// Waves: band thickness down the rows, arc width across the columns. Each
+    /// arc opens downward (`+z`); orange leads outward along the radius.
+    fn paint_wave_matrix(&mut self) {
+        const WEDGES: [(i32, i32); 3] = [(1, 2), (1, 1), (2, 1)];
+        const THICKS: [i32; 3] = [2, 3, 4];
+        const RADIUS: i32 = 8;
+        for (row, &thick) in THICKS.iter().enumerate() {
+            for (col, &wedge) in WEDGES.iter().enumerate() {
+                let (cx, panel_cz) = panel_center(col, row);
+                // Centre the arc's apex in the panel's upper quarter so the
+                // sector opens down into the panel.
+                let cz = panel_cz - HH / 12;
+                let arc = ArcSpec {
+                    cx,
+                    cz,
+                    dir: (0, 1),
+                    wedge,
+                };
+                paint_arc(&mut self.phases, RADIUS, RADIUS + 3, Phase::Warning, arc);
+                paint_arc(&mut self.phases, RADIUS - thick, RADIUS, Phase::Danger, arc);
+            }
+        }
+    }
+}
+
+/// Sub-cell center of preview panel `(col, row)` in a 3×3 grid over the field.
+#[allow(clippy::cast_possible_wrap)] // col/row are 0..3 loop indices
+fn panel_center(col: usize, row: usize) -> (i32, i32) {
+    let (pw, ph) = (HW / 3, HH / 3);
+    (col as i32 * pw + pw / 2, row as i32 * ph + ph / 2)
 }
 
 /// Set a sub-cell to `phase`, with danger overriding an existing warning but a
@@ -432,22 +528,31 @@ fn paint_annulus(field: &mut [Phase], cx: i32, cz: i32, r_lo: i32, r_hi: i32, ph
     }
 }
 
-/// Paint the annulus `r_lo <= dist < r_hi` about a center, but only within the
-/// ~90° arc facing `(ux, uz)` — a single wave segment. Integer cross/dot, so
-/// it stays deterministic.
-fn paint_arc(
-    field: &mut [Phase],
+/// A wave arc: a sector of an annulus about `(cx, cz)` opening toward `dir`,
+/// `wedge`-wide. `wedge` is a `(numerator, denominator)` bound on the slope
+/// `|cross| / dot` from the facing axis — `(1, 1)` is a ±45° half-angle (a 90°
+/// sector), `(1, 2)` narrows it (~±27°), `(2, 1)` widens it (~±63°).
+#[derive(Clone, Copy)]
+struct ArcSpec {
     cx: i32,
     cz: i32,
-    r_lo: i32,
-    r_hi: i32,
-    phase: Phase,
     dir: (i32, i32),
-) {
+    wedge: (i32, i32),
+}
+
+/// Paint the annulus `r_lo <= dist < r_hi` about the arc's center, but only
+/// within the sector facing `arc.dir` and no wider than `arc.wedge`. Integer
+/// cross/dot, so it stays deterministic.
+fn paint_arc(field: &mut [Phase], r_lo: i32, r_hi: i32, phase: Phase, arc: ArcSpec) {
     if r_hi <= 0 {
         return;
     }
-    let (ux, uz) = dir;
+    let ArcSpec {
+        cx,
+        cz,
+        dir: (ux, uz),
+        wedge: (wn, wd),
+    } = arc;
     let r_lo = r_lo.max(0);
     let (lo2, hi2) = (r_lo * r_lo, r_hi * r_hi);
     for sz in (cz - r_hi).max(0)..=(cz + r_hi).min(HH - 1) {
@@ -455,11 +560,11 @@ fn paint_arc(
             let (dx, dz) = (sx - cx, sz - cz);
             let d2 = dx * dx + dz * dz;
             if d2 >= lo2 && d2 < hi2 {
-                // Within ±45° of the facing direction: |cross| ≤ dot, on its
-                // side (dot > 0).
+                // On the facing side (dot > 0) and within the wedge:
+                // |cross| / dot <= wn / wd, compared by cross-multiplication.
                 let dot = dx * ux + dz * uz;
                 let cross = dx * uz - dz * ux;
-                if dot > 0 && cross.abs() <= dot {
+                if dot > 0 && cross.abs() * wd <= dot * wn {
                     set(field, sx, sz, phase);
                 }
             }

--- a/crates/aether-kit/src/arena.rs
+++ b/crates/aether-kit/src/arena.rs
@@ -51,30 +51,14 @@ const DANGER_COLOR: (f32, f32, f32) = (0.85, 0.13, 0.11);
 /// by this, so nothing strikes a cell that wasn't telegraphed.
 const LEAD_TICKS: i32 = 84;
 
-// Ring motion: the front advances one sub-cell of radius every
-// `RING_TICKS_PER_STEP` ticks. Rings stop short of the arena so there is
-// always a safe island — outward rings stop at `RING_OUT_MAX` (safe band
-// outside), inward rings contract from `RING_IN_START` only to `RING_IN_MIN`
-// (safe center).
-const RING_TICKS_PER_STEP: i32 = 6;
-const RING_THICK: i32 = 3;
-const RING_OUT_MAX: i32 = 24;
+/// Difficulty runs `0..=INTENSITY_MAX`. A level ramps it across its duration,
+/// and every spawn snapshots its parameters from it (see [`Tuning`]) so each
+/// pattern's motion stays consistent even as the ramp moves underneath it.
+const INTENSITY_MAX: i32 = 100;
+
+/// Inward rings always collapse from this radius; the safe-island *floor* they
+/// stop at is the difficulty-driven part (see [`Tuning::in_min`]).
 const RING_IN_START: i32 = 40;
-const RING_IN_MIN: i32 = 14;
-
-// Column (swept wall) motion along one axis, with a gap to aim for.
-const COLUMN_TICKS_PER_STEP: i32 = 5;
-const COLUMN_THICK: i32 = 2;
-/// Gap width in the wall, in sub-cells (~3 tiles of breathing room).
-const COLUMN_GAP: i32 = 12;
-
-// Wave: a single expanding arc — one sector of an outward ring.
-const WAVE_TICKS_PER_STEP: i32 = 5;
-const WAVE_THICK: i32 = 3;
-const WAVE_MAX: i32 = 50;
-/// Wave half-angle as a `(numerator, denominator)` slope bound on `|cross| /
-/// dot` (see [`paint_arc`]): `(1, 1)` is a ±45° wedge, a 90° sector.
-const WAVE_WEDGE: (i32, i32) = (1, 1);
 
 /// The eight compass directions a wave can face.
 const COMPASS_DIRS: [(i32, i32); 8] = [
@@ -88,10 +72,11 @@ const COMPASS_DIRS: [(i32, i32); 8] = [
     (-1, -1),
 ];
 
-/// Ticks between pattern spawns.
-const SPAWN_INTERVAL_TICKS: u64 = 110;
-/// Most patterns running at once.
-const MAX_CONCURRENT: usize = 2;
+/// Spawn cadence (ticks between patterns) and max concurrent patterns, each an
+/// `(easy, hard)` pair interpolated by intensity — harder spawns more often and
+/// runs more at once.
+const SPAWN_INTERVAL: (i32, i32) = (150, 55);
+const CONCURRENT: (i32, i32) = (1, 3);
 
 /// Global speed is `speed_num / SPEED_DEN`: the arena clock advances that many
 /// quarter-steps per tick, scaling motion, telegraph, and spawn rate together.
@@ -99,11 +84,10 @@ const MAX_CONCURRENT: usize = 2;
 const SPEED_DEN: i32 = 4;
 const SPEED_MIN: i32 = 1; // 0.25×
 const SPEED_MAX: i32 = 16; // 4×
-/// Adjustable wall-thickness bounds, in sub-cells. The ceiling is high enough
-/// for a wall to read as a thick advancing slab (40 sub = 10 tiles, most of the
-/// 16-tile field), not just a thin line.
-const WALL_MIN: i32 = 1;
-const WALL_MAX: i32 = 40;
+
+/// Fixed non-zero RNG seed: every run faces the same pattern sequence, which is
+/// both fair across players and exactly replayable.
+const SEED: u64 = 0x2545_F491_4F6C_DD1D;
 
 /// A sub-cell's current hazard state.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -127,60 +111,134 @@ enum Shape {
         gap_lo: i32,
         reverse: bool,
     },
-    /// A single expanding arc — one ~90° sector of an outward ring, facing
+    /// A single expanding arc — one sector of an outward ring, facing
     /// `(ux, uz)`. A radial wave to dodge out of the way of.
     Wave { cx: i32, cz: i32, ux: i32, uz: i32 },
 }
 
-/// One live pattern: a shape plus the ticks since it spawned.
+/// The three hazard families a level is built from. A level confines spawns to
+/// one class; `Shape` is the concrete instance (a ring can collapse or expand, a
+/// wall sweep either axis, and so on).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ShapeClass {
+    Ring,
+    Wall,
+    Wave,
+}
+
+/// A shape's parameters at a given difficulty. Snapshotted when a pattern spawns
+/// so its motion stays consistent even as the level's intensity ramps underneath
+/// it. Fields a class doesn't use stay at their defaults.
+#[derive(Clone, Copy)]
+struct Tuning {
+    /// Band depth, sub-cells.
+    thick: i32,
+    /// Ticks per sub-cell of front travel — smaller is faster.
+    speed: i32,
+    /// Ring: outward frontier cap (safe band beyond it).
+    out_max: i32,
+    /// Ring: inward collapse floor (safe island inside it).
+    in_min: i32,
+    /// Wall: gap width, sub-cells.
+    gap: i32,
+    /// Wave: radial reach.
+    reach: i32,
+    /// Wave: arc half-angle as a `(num, den)` slope bound on `|cross| / dot`.
+    wedge: (i32, i32),
+}
+
+impl Tuning {
+    /// The parameter envelope for a class at `intensity`, interpolating each
+    /// knob from its easy value (intensity 0) to its hard value
+    /// ([`INTENSITY_MAX`]). Harder means faster, thicker, and tighter margins.
+    fn for_class(class: ShapeClass, intensity: i32) -> Self {
+        let t = intensity.clamp(0, INTENSITY_MAX);
+        let lerp = |easy, hard| lerp_i(easy, hard, t, INTENSITY_MAX);
+        let base = Self {
+            thick: 0,
+            speed: 5,
+            out_max: 0,
+            in_min: 0,
+            gap: 0,
+            reach: 0,
+            wedge: (1, 1),
+        };
+        match class {
+            ShapeClass::Ring => Self {
+                thick: lerp(2, 5),
+                speed: lerp(8, 3),
+                out_max: lerp(20, 28),
+                in_min: lerp(16, 8),
+                ..base
+            },
+            ShapeClass::Wall => Self {
+                thick: lerp(2, 20),
+                speed: lerp(7, 3),
+                gap: lerp(18, 6),
+                ..base
+            },
+            ShapeClass::Wave => Self {
+                thick: lerp(2, 4),
+                speed: lerp(7, 3),
+                reach: lerp(40, 60),
+                wedge: (lerp(1, 5), 2),
+                ..base
+            },
+        }
+    }
+}
+
+/// One live pattern: a shape, the ticks since it spawned, and the tuning it was
+/// born with.
 struct Pattern {
     shape: Shape,
     age: i32,
+    tuning: Tuning,
 }
 
 impl Pattern {
     /// Whether the pattern has finished — its danger front has run off the end
     /// of its animation — and should be retired.
-    fn done(&self, wall_thickness: i32) -> bool {
+    fn done(&self) -> bool {
+        let tn = &self.tuning;
         match self.shape {
             Shape::Ring { inward, .. } => {
                 let travel = if inward {
-                    RING_IN_START - RING_IN_MIN
+                    RING_IN_START - tn.in_min
                 } else {
-                    RING_OUT_MAX
+                    tn.out_max
                 };
-                self.age > LEAD_TICKS + (travel + RING_THICK) * RING_TICKS_PER_STEP
+                self.age > LEAD_TICKS + (travel + tn.thick) * tn.speed
             }
             Shape::Column { horizontal, .. } => {
                 let span = if horizontal { HH } else { HW };
-                self.age > LEAD_TICKS + (span + wall_thickness) * COLUMN_TICKS_PER_STEP
+                self.age > LEAD_TICKS + (span + tn.thick) * tn.speed
             }
-            Shape::Wave { .. } => {
-                self.age > LEAD_TICKS + (WAVE_MAX + WAVE_THICK) * WAVE_TICKS_PER_STEP
-            }
+            Shape::Wave { .. } => self.age > LEAD_TICKS + (tn.reach + tn.thick) * tn.speed,
         }
     }
 
     /// Paint this shape's warning band (current age) and danger front (age
     /// minus the lead) into the field.
-    fn paint(&self, field: &mut [Phase], wall_thickness: i32) {
+    fn paint(&self, field: &mut [Phase]) {
+        let tn = &self.tuning;
         let age = self.age;
         let danger_age = (age - LEAD_TICKS).max(0);
         match self.shape {
             Shape::Ring { cx, cz, inward } => {
-                let wf = ring_radius(age, inward);
-                let df = ring_radius(danger_age, inward);
+                let wf = ring_radius(age, inward, tn);
+                let df = ring_radius(danger_age, inward, tn);
                 // Warning spans the whole band from the danger front to the
                 // leading edge; danger is the thin front, painted only once the
                 // lead has elapsed.
                 let (lo, hi) = if inward {
-                    (wf, df + RING_THICK)
+                    (wf, df + tn.thick)
                 } else {
-                    (df, wf + RING_THICK)
+                    (df, wf + tn.thick)
                 };
                 paint_annulus(field, cx, cz, lo, hi, Phase::Warning);
                 if age >= LEAD_TICKS {
-                    paint_annulus(field, cx, cz, df, df + RING_THICK, Phase::Danger);
+                    paint_annulus(field, cx, cz, df, df + tn.thick, Phase::Danger);
                 }
             }
             Shape::Column {
@@ -189,10 +247,10 @@ impl Pattern {
                 reverse,
             } => {
                 let span = if horizontal { HH } else { HW };
-                let wpos = column_pos(age, span, reverse);
-                let dpos = column_pos(danger_age, span, reverse);
+                let wpos = column_pos(age, span, reverse, tn.speed);
+                let dpos = column_pos(danger_age, span, reverse, tn.speed);
                 let dir = if reverse { -1 } else { 1 };
-                let gap_hi = gap_lo + COLUMN_GAP;
+                let gap_hi = gap_lo + tn.gap;
                 let (lo, hi) = if wpos <= dpos {
                     (wpos, dpos)
                 } else {
@@ -202,7 +260,7 @@ impl Pattern {
                     paint_line(field, horizontal, pos, gap_lo, gap_hi, Phase::Warning);
                 }
                 if age >= LEAD_TICKS {
-                    for k in 0..wall_thickness {
+                    for k in 0..tn.thick {
                         paint_line(
                             field,
                             horizontal,
@@ -215,39 +273,45 @@ impl Pattern {
                 }
             }
             Shape::Wave { cx, cz, ux, uz } => {
-                let wf = (age / WAVE_TICKS_PER_STEP).min(WAVE_MAX);
-                let df = (danger_age / WAVE_TICKS_PER_STEP).min(WAVE_MAX);
+                let wf = (age / tn.speed).min(tn.reach);
+                let df = (danger_age / tn.speed).min(tn.reach);
                 let arc = ArcSpec {
                     cx,
                     cz,
                     dir: (ux, uz),
-                    wedge: WAVE_WEDGE,
+                    wedge: tn.wedge,
                 };
-                paint_arc(field, df, wf + WAVE_THICK, Phase::Warning, arc);
+                paint_arc(field, df, wf + tn.thick, Phase::Warning, arc);
                 if age >= LEAD_TICKS {
-                    paint_arc(field, df, df + WAVE_THICK, Phase::Danger, arc);
+                    paint_arc(field, df, df + tn.thick, Phase::Danger, arc);
                 }
             }
         }
     }
 }
 
-/// Ring front radius at a given age, clamped to its safe-island limit:
-/// outward grows from 0 up to `RING_OUT_MAX`, inward shrinks from
-/// `RING_IN_START` down to `RING_IN_MIN`.
-fn ring_radius(age: i32, inward: bool) -> i32 {
-    let step = age / RING_TICKS_PER_STEP;
+/// Ring front radius at a given age, clamped to its safe-island limit: outward
+/// grows from 0 up to `tn.out_max`, inward shrinks from `RING_IN_START` down to
+/// `tn.in_min`.
+fn ring_radius(age: i32, inward: bool, tn: &Tuning) -> i32 {
+    let step = age / tn.speed;
     if inward {
-        (RING_IN_START - step).max(RING_IN_MIN)
+        (RING_IN_START - step).max(tn.in_min)
     } else {
-        step.min(RING_OUT_MAX)
+        step.min(tn.out_max)
     }
 }
 
 /// Column front position at a given age along a `span`-long axis.
-fn column_pos(age: i32, span: i32, reverse: bool) -> i32 {
-    let step = age / COLUMN_TICKS_PER_STEP;
+fn column_pos(age: i32, span: i32, reverse: bool, speed: i32) -> i32 {
+    let step = age / speed;
     if reverse { span - 1 - step } else { step }
+}
+
+/// Integer linear interpolation: `a` at `t = 0`, `b` at `t = tmax`. Works for a
+/// descending range (`a > b`), and rounds toward `a`.
+fn lerp_i(a: i32, b: i32, t: i32, tmax: i32) -> i32 {
+    a + (b - a) * t / tmax
 }
 
 /// The hazard field plus its deterministic spawn clock and live patterns.
@@ -263,8 +327,12 @@ pub struct Arena {
     speed_num: i32,
     /// Fractional carry for sub-1× speeds.
     time_accum: i32,
-    /// Swept-wall thickness, in sub-cells.
-    wall_thickness: i32,
+    /// The class a level confines spawns to; `None` is free-play (a random class
+    /// each spawn).
+    director: Option<ShapeClass>,
+    /// Current difficulty, `0..=INTENSITY_MAX`. Drives each spawn's tuning and
+    /// the spawn cadence/concurrency.
+    intensity: i32,
 }
 
 impl Arena {
@@ -272,13 +340,12 @@ impl Arena {
         Self {
             phases: [Phase::Safe; HCELLS],
             patterns: Vec::new(),
-            // Fixed non-zero seed: every run faces the same sequence, which is
-            // both fair across players and exactly replayable.
-            rng: 0x2545_F491_4F6C_DD1D,
+            rng: SEED,
             elapsed: 0,
             speed_num: SPEED_DEN,
             time_accum: 0,
-            wall_thickness: COLUMN_THICK,
+            director: None,
+            intensity: INTENSITY_MAX / 2,
         }
     }
 
@@ -292,23 +359,56 @@ impl Arena {
         }
         self.phases.fill(Phase::Safe);
         for pattern in &self.patterns {
-            pattern.paint(&mut self.phases, self.wall_thickness);
+            pattern.paint(&mut self.phases);
         }
     }
 
-    /// One logical step: spawn on cadence, age the patterns, retire finished
-    /// ones.
+    /// One logical step: spawn on the intensity-scaled cadence, age the
+    /// patterns, retire finished ones.
+    #[allow(clippy::cast_sign_loss)] // interval/concurrent lerp from non-negative endpoints
     fn step(&mut self) {
-        if self.elapsed.is_multiple_of(SPAWN_INTERVAL_TICKS) && self.patterns.len() < MAX_CONCURRENT
+        let interval = lerp_i(
+            SPAWN_INTERVAL.0,
+            SPAWN_INTERVAL.1,
+            self.intensity,
+            INTENSITY_MAX,
+        );
+        let concurrent = lerp_i(CONCURRENT.0, CONCURRENT.1, self.intensity, INTENSITY_MAX);
+        if self.elapsed.is_multiple_of(interval.max(1) as u64)
+            && self.patterns.len() < concurrent.max(1) as usize
         {
             self.spawn();
         }
         for pattern in &mut self.patterns {
             pattern.age += 1;
         }
-        let wall = self.wall_thickness;
-        self.patterns.retain(|pattern| !pattern.done(wall));
+        self.patterns.retain(|pattern| !pattern.done());
         self.elapsed += 1;
+    }
+
+    /// Confine spawns to one class at a fixed difficulty — what a level drives
+    /// each tick as its clock ramps the intensity.
+    pub fn set_level(&mut self, class: ShapeClass, intensity: i32) {
+        self.director = Some(class);
+        self.intensity = intensity.clamp(0, INTENSITY_MAX);
+    }
+
+    /// Clear the field back to a fresh start (no live patterns, clock zeroed,
+    /// RNG re-seeded) — used when the game restarts after a death.
+    pub fn reset(&mut self) {
+        self.phases.fill(Phase::Safe);
+        self.patterns.clear();
+        self.rng = SEED;
+        self.elapsed = 0;
+        self.time_accum = 0;
+    }
+
+    /// Whether a sub-cell is currently lethal (red). Out-of-bounds reads safe.
+    #[allow(clippy::cast_sign_loss)] // caller passes in-bounds coords
+    pub fn is_danger(&self, sx: i32, sz: i32) -> bool {
+        (0..HW).contains(&sx)
+            && (0..HH).contains(&sz)
+            && self.phases[(sz * HW + sx) as usize] == Phase::Danger
     }
 
     /// Nudge global speed up / down a quarter-step; returns the new speed as a
@@ -323,54 +423,53 @@ impl Arena {
         self.speed_num * 100 / SPEED_DEN
     }
 
-    /// Thicken / thin the swept walls; returns the new thickness in sub-cells.
-    pub fn walls_thicker(&mut self) -> i32 {
-        self.wall_thickness = (self.wall_thickness + 1).min(WALL_MAX);
-        self.wall_thickness
-    }
-
-    pub fn walls_thinner(&mut self) -> i32 {
-        self.wall_thickness = (self.wall_thickness - 1).max(WALL_MIN);
-        self.wall_thickness
-    }
-
-    /// Pick and place a fresh pattern from the RNG.
+    /// Pick the class (the level's, or a random one in free-play), snapshot its
+    /// tuning at the current intensity, and place a fresh pattern.
     fn spawn(&mut self) {
-        let shape = match self.next_rng() % 5 {
-            // Expanding ring: dodge the band.
-            0 => Shape::Ring {
-                cx: self.rand_between(SUB * 4, HW - SUB * 4),
-                cz: self.rand_between(SUB * 4, HH - SUB * 4),
-                inward: false,
+        let class = self.director.unwrap_or_else(|| match self.next_rng() % 3 {
+            0 => ShapeClass::Ring,
+            1 => ShapeClass::Wall,
+            _ => ShapeClass::Wave,
+        });
+        let tuning = Tuning::for_class(class, self.intensity);
+        let shape = self.make_shape(class, &tuning);
+        self.patterns.push(Pattern {
+            shape,
+            age: 0,
+            tuning,
+        });
+    }
+
+    /// A concrete shape of `class` — random placement / orientation from the
+    /// RNG, with the gap sized to `tuning`.
+    fn make_shape(&mut self, class: ShapeClass, tuning: &Tuning) -> Shape {
+        let margin = SUB * 4;
+        match class {
+            ShapeClass::Ring => Shape::Ring {
+                cx: self.rand_between(margin, HW - margin),
+                cz: self.rand_between(margin, HH - margin),
+                inward: self.next_rng().is_multiple_of(2),
             },
-            // Collapsing ring: get to the center before it closes.
-            1 => Shape::Ring {
-                cx: self.rand_between(SUB * 4, HW - SUB * 4),
-                cz: self.rand_between(SUB * 4, HH - SUB * 4),
-                inward: true,
-            },
-            2 => Shape::Column {
-                horizontal: true,
-                gap_lo: self.rand_between(0, HW - COLUMN_GAP),
-                reverse: self.next_rng().is_multiple_of(2),
-            },
-            3 => Shape::Column {
-                horizontal: false,
-                gap_lo: self.rand_between(0, HH - COLUMN_GAP),
-                reverse: self.next_rng().is_multiple_of(2),
-            },
-            // Single expanding arc — a radial wave.
-            _ => {
+            ShapeClass::Wall => {
+                let horizontal = self.next_rng().is_multiple_of(2);
+                // Horizontal walls span X (gap on X); vertical span Z (gap on Z).
+                let gap_span = if horizontal { HW } else { HH };
+                Shape::Column {
+                    horizontal,
+                    gap_lo: self.rand_between(0, (gap_span - tuning.gap).max(1)),
+                    reverse: self.next_rng().is_multiple_of(2),
+                }
+            }
+            ShapeClass::Wave => {
                 let (ux, uz) = self.rand_dir();
                 Shape::Wave {
-                    cx: self.rand_between(SUB * 4, HW - SUB * 4),
-                    cz: self.rand_between(SUB * 4, HH - SUB * 4),
+                    cx: self.rand_between(margin, HW - margin),
+                    cz: self.rand_between(margin, HH - margin),
                     ux,
                     uz,
                 }
             }
-        };
-        self.patterns.push(Pattern { shape, age: 0 });
+        }
     }
 
     /// Deterministic xorshift64 step.
@@ -437,7 +536,14 @@ impl Arena {
             for (col, &radius) in RADII.iter().enumerate() {
                 let (cx, cz) = panel_center(col, row);
                 paint_annulus(&mut self.phases, cx, cz, radius, radius + 3, Phase::Warning);
-                paint_annulus(&mut self.phases, cx, cz, radius - thick, radius, Phase::Danger);
+                paint_annulus(
+                    &mut self.phases,
+                    cx,
+                    cz,
+                    radius - thick,
+                    radius,
+                    Phase::Danger,
+                );
             }
         }
     }
@@ -447,7 +553,7 @@ impl Arena {
     /// growing top to bottom at a fixed gap; orange leads downward (`+z`), the
     /// sweep direction. Each wall is anchored at the top of its band so the
     /// thick one grows down into its own space without overlapping the next.
-    #[allow(clippy::cast_possible_wrap)] // row is a 0..3 loop index
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)] // row is 0..3
     fn paint_wall_matrix(&mut self) {
         const THICKS: [i32; 3] = [4, 10, 16];
         const GAP: i32 = 10;
@@ -457,10 +563,24 @@ impl Arena {
         for (row, &thick) in THICKS.iter().enumerate() {
             let z0 = row as i32 * band + 1;
             for k in 0..thick {
-                paint_line(&mut self.phases, true, z0 + k, gap_lo, gap_hi, Phase::Danger);
+                paint_line(
+                    &mut self.phases,
+                    true,
+                    z0 + k,
+                    gap_lo,
+                    gap_hi,
+                    Phase::Danger,
+                );
             }
             for k in thick..(thick + 3) {
-                paint_line(&mut self.phases, true, z0 + k, gap_lo, gap_hi, Phase::Warning);
+                paint_line(
+                    &mut self.phases,
+                    true,
+                    z0 + k,
+                    gap_lo,
+                    gap_hi,
+                    Phase::Warning,
+                );
             }
         }
     }
@@ -491,7 +611,7 @@ impl Arena {
 }
 
 /// Sub-cell center of preview panel `(col, row)` in a 3×3 grid over the field.
-#[allow(clippy::cast_possible_wrap)] // col/row are 0..3 loop indices
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)] // col/row are 0..3
 fn panel_center(col: usize, row: usize) -> (i32, i32) {
     let (pw, ph) = (HW / 3, HH / 3);
     (col as i32 * pw + pw / 2, row as i32 * ph + ph / 2)
@@ -652,10 +772,27 @@ mod tests {
     fn patterns_retire_so_the_field_does_not_fill_up() {
         // Patterns finish and are dropped, so the live set stays bounded and
         // hazards never accumulate without end.
+        let cap = usize::try_from(CONCURRENT.1).expect("CONCURRENT.1 is a small positive constant");
         let mut arena = Arena::new();
         for _ in 0..3_000 {
             arena.tick();
-            assert!(arena.patterns.len() <= MAX_CONCURRENT);
+            assert!(arena.patterns.len() <= cap);
+        }
+    }
+
+    #[test]
+    fn a_level_spawns_only_its_class() {
+        // A level confines spawns to its one class — no mixing.
+        let mut arena = Arena::new();
+        arena.set_level(ShapeClass::Wall, 70);
+        for _ in 0..2_500 {
+            arena.tick();
+            for pattern in &arena.patterns {
+                assert!(
+                    matches!(pattern.shape, Shape::Column { .. }),
+                    "a non-wall pattern spawned in a wall level"
+                );
+            }
         }
     }
 }

--- a/crates/aether-kit/src/lib.rs
+++ b/crates/aether-kit/src/lib.rs
@@ -68,6 +68,18 @@ pub struct SetGranularity {
     pub cell_octimeters: i32,
 }
 
+/// `aether.kit.locomotion.preview` — a design aid, not part of play. Freezes
+/// the live hazard game and paints a top-down contact-sheet of one shape's
+/// parameter variations (a 3×3 matrix: thickness down the rows, the shape's
+/// spatial parameter across the columns) so the look of each parameter can be
+/// compared at a glance. `shape` selects which: `0` resumes the game, `1` ring,
+/// `2` wall, `3` wave.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.kit.locomotion.preview")]
+pub struct Preview {
+    pub shape: u32,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aether-kit/src/runtime.rs
+++ b/crates/aether-kit/src/runtime.rs
@@ -85,7 +85,7 @@ use aether_kinds::{
 use aether_math::{Mat4, Vec3};
 
 use crate::arena::{Arena, HH, HW, SUB};
-use crate::{OCTIMETERS_PER_TILE, SetGranularity, SetWalkable, TILE_BITS, Teleport};
+use crate::{OCTIMETERS_PER_TILE, Preview, SetGranularity, SetWalkable, TILE_BITS, Teleport};
 
 /// Walkable map dimensions, in tiles.
 pub(crate) const GRID_W: i32 = 16;
@@ -320,6 +320,10 @@ pub struct Locomotion {
     /// Whether to draw the orange warning telegraph. Off is a hardcore mode —
     /// only the red strikes (and the blue refuge) show. Toggled with `O`.
     show_warnings: bool,
+    /// Design-aid preview (not play): when non-zero the live game is frozen and
+    /// the field shows a static parameter matrix of one shape (see [`Preview`]),
+    /// viewed top-down. `0` is normal play.
+    preview: u32,
 }
 
 #[actor]
@@ -349,6 +353,7 @@ impl FfiActor for Locomotion {
             cam_held: CamHeld::default(),
             arena: Arena::new(),
             show_warnings: true,
+            preview: 0,
         })
     }
 
@@ -366,6 +371,11 @@ impl FfiActor for Locomotion {
 
     #[handler]
     fn on_tick(&mut self, _ctx: &mut FfiCtx<'_>, _tick: Tick) {
+        // In preview mode the game is frozen: the static matrix in the field
+        // must persist, so skip the simulation entirely.
+        if self.preview != 0 {
+            return;
+        }
         self.orbit_camera();
         self.arena.tick();
         self.advance();
@@ -456,6 +466,15 @@ impl FfiActor for Locomotion {
     #[handler]
     fn on_set_granularity(&mut self, _ctx: &mut FfiCtx<'_>, mail: SetGranularity) {
         self.set_cell(mail.cell_octimeters);
+    }
+
+    #[handler]
+    fn on_preview(&mut self, _ctx: &mut FfiCtx<'_>, mail: Preview) {
+        self.preview = mail.shape;
+        if mail.shape != 0 {
+            self.arena.show_matrix(mail.shape);
+        }
+        tracing::info!(shape = mail.shape, "locomotion preview");
     }
 }
 
@@ -577,10 +596,17 @@ impl Locomotion {
         (target + offset, target)
     }
 
-    /// Perspective `view_proj` for the follow camera.
+    /// Perspective `view_proj`: the follow camera in play, or a fixed top-down
+    /// view framing the whole grid in preview (so the parameter matrix reads
+    /// like a contact sheet).
     fn view_proj(&self) -> [f32; 16] {
-        let (eye, target) = self.camera_eye_target();
-        let view = Mat4::look_at_rh(eye, target, Vec3::Y);
+        let (eye, target, up) = if self.preview == 0 {
+            let (eye, target) = self.camera_eye_target();
+            (eye, target, Vec3::Y)
+        } else {
+            preview_camera()
+        };
+        let view = Mat4::look_at_rh(eye, target, up);
         let proj = Mat4::perspective_rh(CAMERA_FOV_Y, self.aspect(), CAMERA_Z_NEAR, CAMERA_Z_FAR);
         (proj * view).to_cols_array()
     }
@@ -697,17 +723,25 @@ impl Locomotion {
                 push_quad(&mut out, tx as f32 + 0.5, tz as f32 + 0.5, 0.48, 0.0, color);
             }
         }
-        // Hazard overlay at sub-cell resolution, laid just above the floor.
+        // Hazard overlay at sub-cell resolution, laid just above the floor. In
+        // preview the orange telegraph always shows (the matrix is about seeing
+        // both bands), independent of the hardcore toggle.
+        let show_warnings = self.show_warnings || self.preview != 0;
         let sub = SUB as f32;
         let half = 0.5 / sub;
         for sz in 0..HH {
             for sx in 0..HW {
-                if let Some(color) = self.arena.subcell_color(sx, sz, self.show_warnings) {
+                if let Some(color) = self.arena.subcell_color(sx, sz, show_warnings) {
                     let cx = (sx as f32 + 0.5) / sub;
                     let cz = (sz as f32 + 0.5) / sub;
                     push_quad(&mut out, cx, cz, half, 0.02, color);
                 }
             }
+        }
+        // The preview is a static contact sheet: no player or destination, just
+        // the parameter matrix on the floor.
+        if self.preview != 0 {
+            return out;
         }
         // Click-to-move destination: the exact cell the mover will rest in,
         // sized to the active granularity. Laid above the hazard overlay
@@ -946,6 +980,18 @@ fn step_camera(yaw: f32, pitch: f32, yaw_dir: f32, pitch_dir: f32) -> (f32, f32)
         .mul_add(CAMERA_PITCH_SPEED, pitch)
         .clamp(CAMERA_PITCH_MIN, CAMERA_PITCH_MAX);
     (yaw, pitch)
+}
+
+/// Fixed top-down camera for the preview matrix: looks straight down at the
+/// grid center from high enough that the whole 16×16 floor frames with a
+/// margin. Returns `(eye, target, up)`; `up = -Z` puts grid `+Z` toward the
+/// bottom of frame, so matrix rows read top-to-bottom.
+fn preview_camera() -> (Vec3, Vec3, Vec3) {
+    let cx = GRID_W as f32 / 2.0;
+    let cz = GRID_H as f32 / 2.0;
+    let eye = Vec3::new(cx, 20.0, cz);
+    let target = Vec3::new(cx, 0.0, cz);
+    (eye, target, Vec3::new(0.0, 0.0, -1.0))
 }
 
 /// Append a flat axis-aligned quad (two triangles) on the XZ plane.

--- a/crates/aether-kit/src/runtime.rs
+++ b/crates/aether-kit/src/runtime.rs
@@ -84,7 +84,7 @@ use aether_kinds::{
 };
 use aether_math::{Mat4, Vec3};
 
-use crate::arena::{Arena, HH, HW, SUB};
+use crate::arena::{Arena, HH, HW, SUB, ShapeClass};
 use crate::{OCTIMETERS_PER_TILE, Preview, SetGranularity, SetWalkable, TILE_BITS, Teleport};
 
 /// Walkable map dimensions, in tiles.
@@ -153,6 +153,28 @@ const DEFAULT_ASPECT: f32 = 16.0 / 9.0;
 /// Highlight tint for the click-to-move destination cell — the exact region
 /// the mover will come to rest in.
 const DEST_COLOR: (f32, f32, f32) = (0.20, 0.95, 0.65);
+
+/// Each level lasts 30 s at the 60 Hz tick.
+const LEVEL_TICKS: u32 = 1800;
+
+/// The five levels: a shape class and the intensity envelope it ramps across
+/// (start → end). The three classes are reused, each repeat starting harder, so
+/// difficulty climbs both within a level and across the run.
+const LEVELS: [(ShapeClass, i32, i32); 5] = [
+    (ShapeClass::Ring, 0, 50),
+    (ShapeClass::Wave, 10, 60),
+    (ShapeClass::Wall, 15, 65),
+    (ShapeClass::Ring, 45, 90),
+    (ShapeClass::Wall, 55, 100),
+];
+
+/// Full health. A larger pool than it needs to be so the bar drains smoothly.
+const HEALTH_MAX: i32 = 1000;
+/// Health lost per tick while standing on a striking (red) sub-cell — about two
+/// seconds of continuous contact to die from full.
+const DAMAGE_PER_TICK: i32 = 8;
+/// Pause after death before the run restarts: 10 s at the 60 Hz tick.
+const RESTART_TICKS: u32 = 600;
 
 /// Player capsule (a capped cylinder) at human dimensions: 1.8 m tall,
 /// 0.3 m radius. The bottom cap rests on the ground (`y = 0`).
@@ -324,6 +346,15 @@ pub struct Locomotion {
     /// the field shows a static parameter matrix of one shape (see [`Preview`]),
     /// viewed top-down. `0` is normal play.
     preview: u32,
+    /// Index into [`LEVELS`] of the level being played.
+    level: usize,
+    /// Ticks elapsed in the current level, `0..LEVEL_TICKS`; drives the
+    /// continuous difficulty ramp.
+    level_clock: u32,
+    /// Remaining health, `0..=HEALTH_MAX`. Drains while standing on a red cell.
+    health: i32,
+    /// When dead, ticks left before the run restarts; `None` while alive.
+    dead_clock: Option<u32>,
 }
 
 #[actor]
@@ -354,6 +385,10 @@ impl FfiActor for Locomotion {
             arena: Arena::new(),
             show_warnings: true,
             preview: 0,
+            level: 0,
+            level_clock: 0,
+            health: HEALTH_MAX,
+            dead_clock: None,
         })
     }
 
@@ -376,8 +411,19 @@ impl FfiActor for Locomotion {
         if self.preview != 0 {
             return;
         }
+        // The camera still orbits whether alive or dead.
         self.orbit_camera();
+        // Dead: the game is frozen; count down, then restart the run.
+        if let Some(remaining) = self.dead_clock {
+            match remaining.checked_sub(1).filter(|&r| r > 0) {
+                Some(r) => self.dead_clock = Some(r),
+                None => self.restart(),
+            }
+            return;
+        }
+        self.advance_level();
         self.arena.tick();
+        self.apply_damage();
         self.advance();
     }
 
@@ -420,12 +466,6 @@ impl FfiActor for Locomotion {
             }
             keycode::KEY_J => {
                 tracing::info!(speed_percent = self.arena.speed_down(), "hazard speed");
-            }
-            keycode::KEY_M => {
-                tracing::info!(wall_thickness = self.arena.walls_thicker(), "hazard walls");
-            }
-            keycode::KEY_N => {
-                tracing::info!(wall_thickness = self.arena.walls_thinner(), "hazard walls");
             }
             _ => self.set_held(key.code, true),
         }
@@ -493,6 +533,49 @@ impl Locomotion {
             keycode::KEY_DOWN => self.cam_held.down = down,
             _ => {}
         }
+    }
+
+    /// Drive the level director one tick: ramp the current level's intensity
+    /// across its clock, push it to the arena, and roll to the next level (wrap
+    /// at the end) when the clock expires.
+    fn advance_level(&mut self) {
+        let (class, lo, hi) = LEVELS[self.level];
+        self.arena
+            .set_level(class, lerp_level(lo, hi, self.level_clock, LEVEL_TICKS));
+        self.level_clock += 1;
+        if self.level_clock >= LEVEL_TICKS {
+            self.level_clock = 0;
+            self.level = (self.level + 1) % LEVELS.len();
+        }
+    }
+
+    /// Drain health while the mover's tile stands on a striking (red) sub-cell;
+    /// at zero, enter the death pause that restarts the run.
+    fn apply_damage(&mut self) {
+        let sub = OCTIMETERS_PER_TILE / SUB;
+        if self.arena.is_danger(self.mover.x / sub, self.mover.z / sub) {
+            self.health = (self.health - DAMAGE_PER_TICK).max(0);
+            if self.health == 0 {
+                self.dead_clock = Some(RESTART_TICKS);
+            }
+        }
+    }
+
+    /// Restart the run from level one: full health, fresh arena, mover recentred.
+    fn restart(&mut self) {
+        self.level = 0;
+        self.level_clock = 0;
+        self.health = HEALTH_MAX;
+        self.dead_clock = None;
+        self.arena.reset();
+        self.mover = Mover {
+            x: tile_center_octimeters(GRID_W / 2),
+            z: tile_center_octimeters(GRID_H / 2),
+        };
+        self.path.clear();
+        self.dest = None;
+        self.target_x = None;
+        self.target_z = None;
     }
 
     /// Orbit the camera one tick from the held arrow keys: sweep yaw freely,
@@ -755,8 +838,95 @@ impl Locomotion {
         let ax = self.mover.x as f32 / OCTIMETERS_PER_TILE as f32;
         let az = self.mover.z as f32 / OCTIMETERS_PER_TILE as f32;
         push_capsule(&mut out, ax, az, mover_color(self.cell));
+        // HUD: a health bar pinned to the top of the screen, drawn last so it
+        // sits over the scene. A dark backing plate, then a fill that shrinks
+        // and reddens as health drops.
+        let hud = Hud::new(self.camera_eye_target(), self.aspect());
+        hud.quad(
+            &mut out,
+            [-0.55, 0.55, 0.84, 0.92],
+            0.50,
+            (0.10, 0.10, 0.13),
+        );
+        let frac = self.health as f32 / HEALTH_MAX as f32;
+        if frac > 0.0 {
+            // A touch closer than the backing so it wins the depth test.
+            let rect = [-0.52, frac.mul_add(1.04, -0.52), 0.855, 0.905];
+            hud.quad(&mut out, rect, 0.49, health_color(frac));
+        }
         out
     }
+}
+
+/// A projector for screen-pinned HUD quads: it places a quad given in NDC at a
+/// fixed depth along the camera ray, so the quad holds its screen position as
+/// the camera orbits.
+struct Hud {
+    eye: Vec3,
+    fwd: Vec3,
+    right: Vec3,
+    up: Vec3,
+    scale_x: f32,
+    scale_y: f32,
+}
+
+impl Hud {
+    /// Build from the camera's eye/target and the viewport aspect — the same
+    /// basis `pick_world` derives, reused to project the other way.
+    fn new((eye, target): (Vec3, Vec3), aspect: f32) -> Self {
+        let fwd = (target - eye).normalize();
+        let right = fwd.cross(Vec3::Y).normalize();
+        let up = right.cross(fwd);
+        let tan = (CAMERA_FOV_Y * 0.5).tan();
+        Self {
+            eye,
+            fwd,
+            right,
+            up,
+            scale_x: tan * aspect,
+            scale_y: tan,
+        }
+    }
+
+    /// Append a flat-coloured quad covering the NDC rectangle `[x0, x1, y0, y1]`
+    /// at `depth` along the camera ray — smaller depth draws nearer, so layered
+    /// HUD pieces win the depth test in order.
+    fn quad(&self, out: &mut Vec<DrawTriangle>, rect: [f32; 4], depth: f32, rgb: (f32, f32, f32)) {
+        let [x0, x1, y0, y1] = rect;
+        let corner = |nx: f32, ny: f32| {
+            self.eye
+                + self.fwd * depth
+                + self.right * (nx * self.scale_x * depth)
+                + self.up * (ny * self.scale_y * depth)
+        };
+        let (r, g, b) = rgb;
+        let v = |p: Vec3| Vertex {
+            x: p.x,
+            y: p.y,
+            z: p.z,
+            r,
+            g,
+            b,
+        };
+        let (p00, p10, p11, p01) = (
+            corner(x0, y0),
+            corner(x1, y0),
+            corner(x1, y1),
+            corner(x0, y1),
+        );
+        out.push(DrawTriangle {
+            verts: [v(p00), v(p10), v(p11)],
+        });
+        out.push(DrawTriangle {
+            verts: [v(p00), v(p11), v(p01)],
+        });
+    }
+}
+
+/// Health-bar fill colour: red at empty through green at full.
+fn health_color(frac: f32) -> (f32, f32, f32) {
+    let lerp = |a: f32, b: f32| (b - a).mul_add(frac, a);
+    (lerp(0.85, 0.25), lerp(0.20, 0.82), lerp(0.18, 0.32))
 }
 
 /// Mover tint for the active cell size — its [`CELL_PRESETS`] color, or a
@@ -980,6 +1150,12 @@ fn step_camera(yaw: f32, pitch: f32, yaw_dir: f32, pitch_dir: f32) -> (f32, f32)
         .mul_add(CAMERA_PITCH_SPEED, pitch)
         .clamp(CAMERA_PITCH_MIN, CAMERA_PITCH_MAX);
     (yaw, pitch)
+}
+
+/// Intensity at `clock`/`span` of the way through a level's `lo`..`hi` ramp.
+#[allow(clippy::cast_possible_wrap)] // clock/span are small (<= LEVEL_TICKS)
+fn lerp_level(lo: i32, hi: i32, clock: u32, span: u32) -> i32 {
+    lo + (hi - lo) * clock as i32 / span as i32
 }
 
 /// Fixed top-down camera for the preview matrix: looks straight down at the


### PR DESCRIPTION
Codename **loco-motion** (crazy-motion). Turns the hazard sandbox from #1515 into a playable survival game, and adds the shape-tuning preview tool used to design it.

## Survival game shell

The arena gains a **director**: a level confines spawns to one shape class at a difficulty that runs `0..=100`, and each spawn snapshots its `Tuning` so a pattern's motion stays smooth even as the level ramps underneath it. Every knob — speed, thickness, ring safe-island, wall gap, wave arc and reach, spawn cadence, concurrency — interpolates from an easy value to a hard one with intensity.

The `Locomotion` actor drives the shell:

- **Five 30s levels**, reusing the three classes with each repeat starting harder: ring → wave → wall → ring+ → wall+.
- **Continuous ramp** within each level — tension builds toward a hard finish, then rolls to the next.
- **Health bar** pinned to the screen via the camera ray (the `pick_world` trick in reverse), draining while the mover stands on a striking cell. No regen — the whole run is one pool.
- **Death → restart**: at zero health the run freezes for ten seconds, then restarts from level one with a re-seeded arena.

Manual wall-thickness keys (M/N) are retired — the level's intensity now drives thickness automatically (walls ramp up to a thick advancing slab on the hard levels).

## Shape-tuning preview tool

A design aid, drivable over MCP: a `preview` mail freezes the game and paints a top-down contact sheet of one shape's parameter variations (a 3×3 matrix for ring and wave, stacked full-width walls), so the look of each parameter reads at a glance. Used to dial in the level envelopes. The wave arc is now a parameterised wedge (`paint_arc` takes an `ArcSpec`).

## Verification

- Full preflight green: fmt, clippy (`-D warnings`), doc, 1550 + 41 tests, wasm32 component cross-build.
- New arena tests cover the telegraph invariant, determinism, pattern retirement, and single-class-per-level.
- Driven live throughout via the MCP harness with hot-reload.

## Next

Distributable build (a double-click Windows artifact, no hub) is tracked in #1518 — not part of this PR.
