### PR TITLE
feat(substrate-bundle): standalone loco-motion game executable via xtask bundle

### DIFF
--- a/crates/aether-substrate-bundle/Cargo.toml
+++ b/crates/aether-substrate-bundle/Cargo.toml
@@ -32,6 +32,14 @@ path = "src/bin/hub.rs"
 name = "aether-substrate-test-bench"
 path = "src/bin/test-bench.rs"
 
+# Standalone game build (#1518): a desktop chassis that auto-loads a game
+# component embedded at build time, so the binary runs hub-less and
+# double-click-to-play. `build.rs` stages the wasm `aether-game` embeds;
+# `cargo xtask bundle` builds the component wasm and drives this.
+[[bin]]
+name = "aether-game"
+path = "src/bin/aether-game.rs"
+
 # Perf-comparison tooling (iamacoffeepot/aether#1077). `perf-trial` runs
 # one latency sweep and emits a TrialReport JSON; `perf-compare`
 # interleaves K base/candidate trials and renders the noise-aware paired

--- a/crates/aether-substrate-bundle/build.rs
+++ b/crates/aether-substrate-bundle/build.rs
@@ -1,0 +1,26 @@
+//! Stage the wasm that the `aether-game` bin embeds (#1518).
+//!
+//! `aether-game` does `include_bytes!(concat!(env!("OUT_DIR"), "/game.wasm"))`,
+//! so a `game.wasm` must exist in `OUT_DIR` at compile time. `cargo xtask
+//! bundle` builds the game component for `wasm32-unknown-unknown` and points
+//! `AETHER_GAME_WASM` at the artifact; this copies it into place. A normal
+//! workspace build (no env set) writes an empty placeholder so the bin still
+//! compiles — it just boots an empty component if run, which only the bundle
+//! flow ever does for real.
+
+use std::{env, fs, path::PathBuf};
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=AETHER_GAME_WASM");
+    let out =
+        PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR set by cargo")).join("game.wasm");
+    match env::var_os("AETHER_GAME_WASM") {
+        Some(src) => {
+            let src = PathBuf::from(src);
+            println!("cargo:rerun-if-changed={}", src.display());
+            fs::copy(&src, &out)
+                .unwrap_or_else(|e| panic!("copy game wasm from {}: {e}", src.display()));
+        }
+        None => fs::write(&out, []).expect("write empty game.wasm placeholder"),
+    }
+}

--- a/crates/aether-substrate-bundle/src/bin/aether-game.rs
+++ b/crates/aether-substrate-bundle/src/bin/aether-game.rs
@@ -1,0 +1,31 @@
+//! `loco-motion` — the standalone game build (#1518).
+//!
+//! A desktop substrate that auto-loads the game component embedded at build
+//! time, so the binary runs hub-less and double-click-to-play. No MCP, no hub,
+//! no netcode. `cargo xtask bundle` builds the component wasm and embeds it
+//! (see the crate `build.rs`); a plain build embeds an empty placeholder.
+
+use aether_substrate::Chassis;
+use aether_substrate_bundle::desktop::{AutoloadComponent, DesktopChassis, DesktopEnv};
+
+/// The game component wasm, embedded at build time. `build.rs` stages it into
+/// `OUT_DIR/game.wasm` from `AETHER_GAME_WASM` (the bundle flow) or an empty
+/// placeholder (a normal build).
+const GAME_WASM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/game.wasm"));
+
+fn main() -> anyhow::Result<()> {
+    // Resolve the chassis env as the desktop bin does — so an injected
+    // `AETHER_RPC_PORT` (e.g. when the hub spawns this for a capture) still
+    // wires up — then override the title and queue the embedded component.
+    let mut env = DesktopEnv::from_env()?;
+    "loco-motion".clone_into(&mut env.boot_title);
+    env.autoload = vec![AutoloadComponent {
+        wasm: GAME_WASM.to_vec(),
+        config: Vec::new(),
+        name: None,
+        export: None,
+    }];
+    let chassis = DesktopChassis::build(env)?;
+    chassis.run()?;
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -43,6 +43,9 @@ struct Cli {
 enum Commands {
     /// Build component wasm + chassis bins into `dist/` with a manifest.
     Dist(DistArgs),
+    /// Build a standalone, hub-less game executable with the game component
+    /// embedded at build time (#1518).
+    Bundle(BundleArgs),
 }
 
 #[derive(Args)]
@@ -54,6 +57,17 @@ struct DistArgs {
     /// fast path uses this to stay wasm-only.
     #[arg(long)]
     no_bins: bool,
+}
+
+#[derive(Args)]
+struct BundleArgs {
+    /// Cargo profile for the game binary and its component.
+    #[arg(long, value_enum, default_value_t = Profile::Release)]
+    profile: Profile,
+    /// Cross-compile the game binary for this target triple (e.g.
+    /// `x86_64-pc-windows-msvc`). Defaults to the host target.
+    #[arg(long)]
+    target: Option<String>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -97,6 +111,7 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Commands::Dist(args) => run_dist(&args),
+        Commands::Bundle(args) => run_bundle(&args),
     }
 }
 
@@ -170,6 +185,66 @@ fn run_dist(args: &DistArgs) -> Result<()> {
         manifest.chassis.len(),
         manifest_path.display(),
     );
+    Ok(())
+}
+
+/// The game's component package, its wasm stem, and the standalone bin name.
+const GAME_COMPONENT: &str = "aether-kit";
+const GAME_COMPONENT_STEM: &str = "aether_kit";
+const GAME_BIN: &str = "aether-game";
+
+/// Build a standalone game executable: build the game component for wasm, embed
+/// it into [`GAME_BIN`] via the bundle crate's `build.rs` (which reads
+/// `AETHER_GAME_WASM`), and report the resulting binary.
+fn run_bundle(args: &BundleArgs) -> Result<()> {
+    let metadata = MetadataCommand::new()
+        .no_deps()
+        .exec()
+        .context("run cargo metadata")?;
+    let target_dir = metadata.target_directory.as_std_path();
+
+    // 1. Build the game component for wasm.
+    let mut wasm_cmd = Command::new(cargo());
+    wasm_cmd.args(["build", "--target", WASM_TARGET, "-p", GAME_COMPONENT]);
+    if let Some(flag) = args.profile.cargo_flag() {
+        wasm_cmd.arg(flag);
+    }
+    run(wasm_cmd, "build game component wasm")?;
+    let wasm = target_dir
+        .join(WASM_TARGET)
+        .join(args.profile.as_str())
+        .join(format!("{GAME_COMPONENT_STEM}.wasm"));
+    if !wasm.exists() {
+        bail!("game component wasm not found at {}", wasm.display());
+    }
+
+    // 2. Build the game binary with the wasm staged for `include_bytes!`.
+    let mut bin_cmd = Command::new(cargo());
+    bin_cmd.args(["build", "-p", CHASSIS_PACKAGE, "--bin", GAME_BIN]);
+    if let Some(flag) = args.profile.cargo_flag() {
+        bin_cmd.arg(flag);
+    }
+    if let Some(triple) = &args.target {
+        bin_cmd.args(["--target", triple]);
+    }
+    bin_cmd.env("AETHER_GAME_WASM", &wasm);
+    run(bin_cmd, "build game binary")?;
+
+    // 3. Report the output path.
+    let profile_dir = args.target.as_ref().map_or_else(
+        || target_dir.join(args.profile.as_str()),
+        |triple| target_dir.join(triple).join(args.profile.as_str()),
+    );
+    let windows = args
+        .target
+        .as_deref()
+        .is_some_and(|t| t.contains("windows"));
+    let exe = profile_dir.join(if windows {
+        format!("{GAME_BIN}.exe")
+    } else {
+        GAME_BIN.to_string()
+    });
+    println!("game bundle -> {}", exe.display());
     Ok(())
 }
 


### PR DESCRIPTION
A self-contained, double-click-to-play **loco-motion** build (#1518) — no hub, no MCP, no netcode.

Building on the autoload hook (#1520):

- **`aether-game` bin** — embeds the game component wasm at build time, feeds it to the desktop autoload hook, and sets the `loco-motion` window title. Boots straight into the game with no load step.
- **`build.rs`** — stages the wasm into `OUT_DIR`: the real artifact when `AETHER_GAME_WASM` is set (the bundle flow), an empty placeholder otherwise, so a normal `cargo build --workspace` still compiles.
- **`cargo xtask bundle [--profile] [--target <triple>]`** — builds the component for `wasm32`, then builds the bin with the wasm staged, optionally cross-targeting (e.g. a Windows triple). This is the "bundle CLI", as a subcommand of the tool that already owns the two-target build.

## Verified end-to-end

Spawned the built binary through the hub and captured a frame **with no `load_component` call** — loco-motion renders (floor, capsule, a ring hazard mid-telegraph, the health bar). The embed + autoload works standalone.

## Notes

- Binary size: the debug build is large (~116 MB) because it's unoptimized with full debug symbols and a statically-linked engine stack (wasmtime + wgpu + winit + cpal). The release build (the default for `xtask bundle`) is a fraction of that; further trimming (strip/LTO, dropping HTTP/RPC/AI caps the game doesn't use) is a possible follow-up.

## Next

A `windows-latest` release CI job runs `cargo xtask bundle --profile release --target x86_64-pc-windows-msvc` and uploads the `.exe` — the final PR for #1518.

Part of #1518.
