### PR TITLE
fix(substrate): bound depth-0 keep-local chains with an every-K injector backstop

### DIFF
--- a/crates/aether-substrate/src/scheduler/mod.rs
+++ b/crates/aether-substrate/src/scheduler/mod.rs
@@ -69,7 +69,7 @@ pub const LIFECYCLE_KNOBS: &[KnobRecord] = &[KnobRecord {
 
 /// The scheduler + lifecycle hot-path tuning knobs registered for
 /// config discovery (ADR-0090 unit b2, iamacoffeepot/aether#1255).
-/// Concatenates the four deque / keep-local-valve knobs
+/// Concatenates the five deque / keep-local-valve knobs
 /// (`worker_deque::DEQUE_KNOBS`), the handoff-cost calibration knob
 /// (`calibrate::CALIBRATE_KNOBS`), and the lifecycle advance-timeout
 /// knob ([`LIFECYCLE_KNOBS`]) into the single
@@ -85,6 +85,7 @@ pub const SCHEDULER_KNOBS: &[KnobRecord] = &[
     worker_deque::DEQUE_KNOBS[1],
     worker_deque::DEQUE_KNOBS[2],
     worker_deque::DEQUE_KNOBS[3],
+    worker_deque::DEQUE_KNOBS[4],
     calibrate::CALIBRATE_KNOBS[0],
     LIFECYCLE_KNOBS[0],
 ];
@@ -95,13 +96,14 @@ mod knob_tests {
     use crate::config::KnobKind;
 
     #[test]
-    fn scheduler_knobs_cover_all_six_hot_path_env_keys() {
+    fn scheduler_knobs_cover_all_seven_hot_path_env_keys() {
         let keys: Vec<&str> = SCHEDULER_KNOBS.iter().map(|r| r.env_key).collect();
         for expected in [
             "AETHER_LOCAL_STICKY_MAX",
             "AETHER_LOCAL_MAIL_BUDGET",
             "AETHER_LOCAL_TIME_BUDGET_US",
             "AETHER_PEER_STEAL",
+            "AETHER_LOCAL_CHAIN_BACKSTOP",
             "AETHER_HANDOFF_COST_NS",
             "AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS",
         ] {
@@ -110,7 +112,7 @@ mod knob_tests {
                 "SCHEDULER_KNOBS missing {expected}; has {keys:?}",
             );
         }
-        assert_eq!(SCHEDULER_KNOBS.len(), 6);
+        assert_eq!(SCHEDULER_KNOBS.len(), 7);
     }
 
     #[test]

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -348,6 +348,14 @@ fn worker_loop(
 /// work still exits — iamacoffeepot/aether#1531), and inside the
 /// coordinator (a flag + an explicit unpark of every worker on
 /// teardown, covering spinning and parked workers).
+///
+/// The own-deque fast path carries the **every-K chain backstop**
+/// (`worker_deque::chain_pop_due`, iamacoffeepot/aether#1535): every
+/// `chain_backstop()` consecutive own-deque pops, one
+/// `steal_into_local` pass runs before the chain continues, so a
+/// self-sustaining relay loop (which never drains its deque and so
+/// never reaches the steal arm) cannot starve the injector for longer
+/// than ~K cycles.
 fn acquire_slot(
     idx: usize,
     stealers: &[Stealer<Arc<dyn Drainable>>],
@@ -366,6 +374,29 @@ fn acquire_slot(
         return None;
     }
     if let Some(slot) = worker_deque::pop_local() {
+        // Every-K chain backstop (iamacoffeepot/aether#1535): the depth-0
+        // keep-local exemption means a serial chain oscillates the own
+        // deque 0→1→0 and never reaches the steal below, so a
+        // *self-sustaining* chain would monopolise this worker and starve
+        // the injector indefinitely. Every `chain_backstop()`-th
+        // consecutive pop, take one look at the injector before
+        // continuing the chain: a hit runs the stolen slot now — the
+        // chain slot goes back on the own deque (LIFO top: it is the next
+        // pop, so the chain resumes right after) — and a miss costs one
+        // empty probe. Injector starvation is thereby bounded at ~K ×
+        // cycle-time per worker; the chain stays warm K−1 of K cycles.
+        if worker_deque::chain_pop_due()
+            && let Some(stolen) =
+                worker_deque::steal_into_local(idx, stealers, injector, peer_steal)
+        {
+            if let Err(slot) = worker_deque::push_local(slot) {
+                // Unreachable on a worker (`pop_local` just succeeded, so
+                // the own deque is installed); spill rather than lose the
+                // slot if it ever isn't.
+                injector.push(slot);
+            }
+            return Some(stolen);
+        }
         return Some(slot);
     }
     // Own deque drained empty — the local cascade is over. Close its
@@ -605,6 +636,121 @@ mod tests {
     /// oversubscribing cores against one another.
     mod heavy {
         use super::*;
+        use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+        /// A self-sustaining slot (iamacoffeepot/aether#1535): each
+        /// `run_cycle` immediately re-schedules itself through
+        /// `WakeSink::schedule` — the handler-wake keep-local path
+        /// (`worker_deque::try_push_local_budgeted`) — so the running
+        /// worker's own deque oscillates 0→1→0 forever. The depth-0
+        /// exemption keeps every re-push local with no clock read, so
+        /// without the every-K backstop the worker would never visit the
+        /// injector again. `stop` ends the loop so shutdown can drain.
+        struct LoopSlot {
+            cycles: AtomicU32,
+            stop: Arc<AtomicBool>,
+            sink: WakeSink,
+            this: Weak<Self>,
+        }
+
+        impl LoopSlot {
+            fn new(stop: Arc<AtomicBool>, sink: WakeSink) -> Arc<Self> {
+                Arc::new_cyclic(|this| Self {
+                    cycles: AtomicU32::new(0),
+                    stop,
+                    sink,
+                    this: this.clone(),
+                })
+            }
+
+            fn cycles(&self) -> u32 {
+                self.cycles.load(Ordering::Acquire)
+            }
+        }
+
+        impl Drainable for LoopSlot {
+            fn run_cycle(&self, _budget: BatchBudget) -> CycleResult {
+                self.cycles.fetch_add(1, Ordering::AcqRel);
+                if !self.stop.load(Ordering::Acquire)
+                    && let Some(me) = self.this.upgrade()
+                {
+                    self.sink.schedule(me);
+                }
+                CycleResult::Idle
+            }
+
+            fn label(&self) -> &'static str {
+                "loop-slot"
+            }
+
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        /// Regression for the every-K chain backstop
+        /// (iamacoffeepot/aether#1535): W self-sustaining loops capture all
+        /// W workers, then an independent slot arrives through the
+        /// injector. Without the backstop no captured worker ever consults
+        /// the injector again (the depth-0 keep-local chain never drains
+        /// its deque), so the slot starves past any deadline; with it,
+        /// every worker probes the injector each `chain_backstop()`-th pop
+        /// and the slot dispatches almost immediately.
+        #[test]
+        fn injector_fed_slot_dispatches_under_full_worker_capture() {
+            const WORKERS: usize = 2;
+            let handle = standard_handle(WORKERS);
+            let stop = Arc::new(AtomicBool::new(false));
+
+            // Seed the loops one at a time, waiting for each to start
+            // cycling before seeding the next: an already-captured worker
+            // takes injector work at most once per backstop window, so
+            // each fresh loop lands on a still-idle worker (and if a
+            // captured worker's probe does take it, the displaced idle
+            // worker only makes the final assertion easier — the test
+            // discriminates either way: with no backstop, captured
+            // workers never steal at all).
+            let loops: Vec<Arc<LoopSlot>> = (0..WORKERS)
+                .map(|_| LoopSlot::new(Arc::clone(&stop), handle.wake_sink()))
+                .collect();
+            for slot in &loops {
+                let seed: Arc<dyn Drainable> = slot.clone();
+                handle.wake_sink().schedule(seed);
+                assert!(
+                    wait_until(Duration::from_secs(2), || slot.cycles() > 0),
+                    "loop slot should start cycling once a worker picks it up"
+                );
+            }
+
+            // Every worker is captured. An independent slot now arrives
+            // through the injector (a wake off any pool worker spills
+            // there) — the path the backstop exists to keep live.
+            let probe = CounterSlot::new("injector-fed");
+            let probe_dyn: Arc<dyn Drainable> = probe.clone();
+            let weak: Weak<dyn Drainable> = Arc::downgrade(&probe_dyn);
+            drop(probe_dyn);
+            let wake = WakeHandle::new(probe.state.clone(), weak, handle.wake_sink());
+            probe.push(1);
+            assert!(wake.wake());
+
+            let dispatched = wait_until(Duration::from_secs(5), || probe.dispatched() == 1);
+
+            // End the loops *before* asserting so the deques drain — a
+            // perpetually-cycling worker only reaches the shutdown
+            // observation point (the spin/park coordinator) once its own
+            // deque runs empty. Asserting first would leave the loops
+            // spinning through the panic unwind and wedge the suite on a
+            // regression instead of failing at the deadline.
+            stop.store(true, Ordering::Release);
+            drop(wake);
+            let _ = handle.shutdown_with_results();
+
+            assert!(
+                dispatched,
+                "every-K backstop must dispatch injector work under full \
+                 worker capture (iamacoffeepot/aether#1535)"
+            );
+        }
 
         /// Stress: 4 slots × 1000 envelopes each across 2 workers. Confirm
         /// every envelope dispatches and no slot is left orphaned.

--- a/crates/aether-substrate/src/scheduler/worker_deque.rs
+++ b/crates/aether-substrate/src/scheduler/worker_deque.rs
@@ -36,6 +36,20 @@
 //! the shared injector, never a sibling's cascade. Set `AETHER_PEER_STEAL=1`
 //! to opt the sibling-tail raid back in.
 //!
+//! The depth-0 keep-local exemption (the `len > 0` term in
+//! [`try_push_local_budgeted`]'s spill condition) means a serial relay
+//! chain — own deque oscillating 0→1→0 — never reads the clock, never
+//! trips the time valve, and never visits the injector. A
+//! *self-sustaining* chain (A mails B, B mails A, no external pacing)
+//! would therefore monopolise its worker indefinitely and, with one such
+//! loop per worker, starve the injector completely. The **every-K chain
+//! backstop** (iamacoffeepot/aether#1535) bounds that monopoly: every
+//! [`chain_backstop`] consecutive own-deque pops ([`chain_pop_due`],
+//! `AETHER_LOCAL_CHAIN_BACKSTOP`, default 64) `acquire_slot` takes one
+//! look at the injector before continuing the chain, so injector
+//! starvation is bounded at ~K × cycle-time per worker while the chain
+//! stays warm K−1 of K cycles — no clock read added.
+//!
 //! Only pool-worker threads call [`install`]; on any other thread
 //! (chassis main, the hub, the trace drainer) [`try_push_local_budgeted`]
 //! is a no-op spill and [`pop_local`] / [`steal_into_local`] yield nothing.
@@ -52,10 +66,11 @@ use crate::config::{KnobKind, KnobRecord};
 use crate::scheduler::calibrate::handoff_cost;
 use crate::scheduler::slot::Drainable;
 
-/// Discovery records for the four deque / keep-local-valve hot-path
+/// Discovery records for the five deque / keep-local-valve hot-path
 /// tuning knobs (ADR-0090 unit b2, iamacoffeepot/aether#1255). These
 /// describe the `OnceLock` getters below ([`hard_cap`], [`mail_budget`],
-/// [`time_budget`], [`peer_steal_enabled`]) so e1's unknown-`AETHER_*`
+/// [`time_budget`], [`peer_steal_enabled`], [`chain_backstop`]) so e1's
+/// unknown-`AETHER_*`
 /// sweep doesn't flag them and e2's `--config` dump lists them. The
 /// hot-path read stays exactly as-is — these are pure `&'static`
 /// metadata assembled once at boot, never on the dispatch path. Docs +
@@ -91,6 +106,15 @@ pub const DEQUE_KNOBS: &[KnobRecord] = &[
         doc: "Whether idle workers may raid siblings' deques (peer-deque stealing). \
               Default off (owner-only); set 1/true to opt the sibling raid back in.",
         default: Some("off"),
+        kind: KnobKind::HandRegistered,
+    },
+    KnobRecord {
+        env_key: "AETHER_LOCAL_CHAIN_BACKSTOP",
+        doc: "Every-K injector backstop for keep-local chains: after K consecutive \
+              own-deque pops a worker probes the injector once before continuing \
+              its chain, bounding injector starvation at ~K cycles per worker \
+              (values < 1 / unparseable fall back).",
+        default: Some("64"),
         kind: KnobKind::HandRegistered,
     },
 ];
@@ -131,6 +155,16 @@ thread_local! {
     /// or before the burst's first mail. [`burst_over_budget`] reads
     /// `elapsed()` against it at decision time.
     static BURST_START: Cell<Option<Instant>> = const { Cell::new(None) };
+
+    /// Consecutive own-deque `pop_local` hits since the last injector
+    /// probe or burst reset — the every-K chain-backstop counter
+    /// (iamacoffeepot/aether#1535). [`chain_pop_due`] bumps it per pop hit
+    /// and reports `true` (resetting) every [`chain_backstop`]-th hit;
+    /// [`burst_reset`] zeroes it when the own deque drains empty (the
+    /// chain is over — the next cascade starts fresh). Single-writer
+    /// (only the running worker touches it, never across a `run_cycle`),
+    /// so a plain `Cell` — same pattern as `BURST_MAIL`.
+    static CHAIN_POPS: Cell<u32> = const { Cell::new(0) };
 }
 
 /// Move this worker's deque into its thread-local. Called once at the top
@@ -305,6 +339,46 @@ pub fn peer_steal_enabled() -> bool {
     })
 }
 
+/// Every-K chain backstop (iamacoffeepot/aether#1535) — how many
+/// consecutive own-deque pops a worker takes before [`chain_pop_due`]
+/// directs `acquire_slot` to probe the injector once. The depth-0
+/// keep-local exemption deliberately keeps a serial chain warm with no
+/// clock read (iamacoffeepot/aether#1174), so a *self-sustaining* chain
+/// would otherwise monopolise its worker forever; this bounds injector
+/// starvation at ~K × cycle-time per worker while the chain stays warm
+/// K−1 of K cycles. Read once from `AETHER_LOCAL_CHAIN_BACKSTOP`; values
+/// `< 1` and unparseable input fall back to `64`.
+#[must_use]
+pub fn chain_backstop() -> u32 {
+    static K: OnceLock<u32> = OnceLock::new();
+    *K.get_or_init(|| {
+        env::var("AETHER_LOCAL_CHAIN_BACKSTOP")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .filter(|&k| k >= 1)
+            .unwrap_or(64)
+    })
+}
+
+/// Note one own-deque `pop_local` hit against the every-K chain backstop
+/// (iamacoffeepot/aether#1535): bump the consecutive-pop counter and
+/// report `true` — resetting it — on every [`chain_backstop`]-th hit.
+/// `acquire_slot` calls this on its pop-hit path and, when due, runs one
+/// `steal_into_local` pass before continuing the chain. The counter also
+/// resets in [`burst_reset`] (own deque drained empty — the chain is
+/// over). A `Cell` bump and an integer compare per pop; no clock read.
+#[must_use]
+pub fn chain_pop_due() -> bool {
+    let n = CHAIN_POPS.get().saturating_add(1);
+    if n >= chain_backstop() {
+        CHAIN_POPS.set(0);
+        true
+    } else {
+        CHAIN_POPS.set(n);
+        false
+    }
+}
+
 /// Note one dispatched envelope against the current local-drain burst
 /// (iamacoffeepot/aether#1160). Increments the burst mail counter and, when
 /// time budgeting is on (`time_budget > 0`), anchors the burst start on the
@@ -357,13 +431,16 @@ pub fn burst_over_budget(mail_budget: Option<u32>, time_budget: Duration) -> boo
         .is_some_and(|start| start.elapsed() >= time_budget)
 }
 
-/// Reset the local-drain burst counters (iamacoffeepot/aether#1160). Called
-/// by `acquire_slot` the moment `pop_local` reports the own deque drained
+/// Reset the local-drain burst counters (iamacoffeepot/aether#1160) and the
+/// chain-backstop pop counter (iamacoffeepot/aether#1535). Called by
+/// `acquire_slot` the moment `pop_local` reports the own deque drained
 /// empty, so each local cascade is one burst and any subsequently stolen
-/// work starts a fresh budget.
+/// work starts a fresh budget — and the next chain starts a fresh
+/// every-K count.
 pub fn burst_reset() {
     BURST_MAIL.set(0);
     BURST_START.set(None);
+    CHAIN_POPS.set(0);
 }
 
 /// Push of a just-produced blob onto this worker's own deque
@@ -422,6 +499,25 @@ pub fn try_push_local_budgeted(
 /// and before the park, so an own slot is never stranded.
 pub fn pop_local() -> Option<Slot> {
     LOCAL.with(|w| w.borrow().as_ref().and_then(Worker::pop))
+}
+
+/// Unconditional push back onto this worker's own deque — the re-queue
+/// arm of the every-K chain backstop (iamacoffeepot/aether#1535).
+/// `acquire_slot` gives a just-popped chain slot back when the backstop
+/// probe found injector work to run first: the stolen slot runs now and
+/// the chain slot waits at the LIFO top (it is the next pop, so the
+/// chain resumes right after). No budget terms — the keep-local decision
+/// was already made when the slot was pushed; this only restores it. Off
+/// a pool worker there is no own deque, so the slot is handed back
+/// (`Err`) for the caller to spill.
+pub fn push_local(slot: Slot) -> Result<(), Slot> {
+    LOCAL.with(|w| match w.borrow().as_ref() {
+        Some(worker) => {
+            worker.push(slot);
+            Ok(())
+        }
+        None => Err(slot),
+    })
 }
 
 /// Steal work into this worker's own deque and return one slot to run.
@@ -766,6 +862,68 @@ mod tests {
             !burst_over_budget(Some(u32::MAX), tiny),
             "reset clears the burst start"
         );
+    }
+
+    #[test]
+    fn chain_pop_due_fires_every_k_and_resets() {
+        // The every-K backstop counter (iamacoffeepot/aether#1535): quiet
+        // for K−1 consecutive pop hits, due on the K-th, then the reset
+        // makes the next window identical.
+        burst_reset();
+        let k = chain_backstop();
+        for i in 1..k {
+            assert!(!chain_pop_due(), "pop {i} of {k} must not be due");
+        }
+        assert!(chain_pop_due(), "the K-th consecutive pop is due");
+        for i in 1..k {
+            assert!(!chain_pop_due(), "post-reset pop {i} must not be due");
+        }
+        assert!(chain_pop_due(), "the window repeats after the due-reset");
+    }
+
+    #[test]
+    fn burst_reset_clears_chain_pops() {
+        // A drained deque ends the chain: `burst_reset` zeroes the
+        // counter, so the next chain gets a full fresh window rather
+        // than inheriting the old chain's progress toward K.
+        burst_reset();
+        let k = chain_backstop();
+        for _ in 1..k {
+            assert!(!chain_pop_due());
+        }
+        burst_reset(); // own deque drained — chain over
+        for i in 1..k {
+            assert!(
+                !chain_pop_due(),
+                "pop {i} after reset must restart the count, not inherit it"
+            );
+        }
+        assert!(chain_pop_due());
+    }
+
+    #[test]
+    fn push_local_off_worker_hands_back() {
+        // No `install` on this thread — not a pool worker, so there is
+        // no own deque to restore the slot to.
+        assert!(push_local(noop()).is_err());
+    }
+
+    #[test]
+    fn push_local_on_worker_requeues_unconditionally() {
+        // The re-queue arm ignores every budget term: deque depth and
+        // burst state don't matter, the slot was already keep-local.
+        install(Worker::new_lifo());
+        drain_local();
+        burst_reset();
+        for _ in 0..100 {
+            burst_note_mail(Duration::ZERO); // far past any budget
+        }
+        assert!(push_local(noop()).is_ok());
+        assert!(push_local(noop()).is_ok(), "no budget term applies");
+        assert!(pop_local().is_some());
+        assert!(pop_local().is_some());
+        assert!(pop_local().is_none());
+        burst_reset();
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The depth-0 keep-local exemption (the `len > 0` term in `try_push_local_budgeted`'s spill condition) lets a serial relay chain oscillate a worker's own deque 0→1→0 with no clock read, no time valve, and no injector visit — `acquire_slot` only consults the injector when `pop_local()` misses. A self-sustaining mail loop (A mails B, B mails A, no external pacing) therefore pins one worker indefinitely; W such loops capture every worker and starve the injector completely — requeued slots, fresh ticks, and MCP mail included. The exemption itself is the deliberate, measured #1174 stance and stays; the corner closed here is the unbounded monopoly.

## Fix (every-K backstop)

- `worker_deque`: a per-worker thread-local `Cell` counter of consecutive `pop_local()` hits (`CHAIN_POPS`, beside its `BURST_MAIL` siblings). `chain_pop_due()` bumps it per pop hit and reports true — resetting — every `chain_backstop()`-th hit; `burst_reset` also zeroes it (deque drained — the chain is over, the next cascade starts fresh).
- `acquire_slot` (pool.rs): on the pop-hit path, when due, run one `steal_into_local` pass before continuing the chain. A hit runs the stolen slot now and the chain slot goes back to the LIFO top via the new `push_local` (it is the next pop, so the chain resumes right after); a miss costs one empty injector probe.
- K reads once per process from `AETHER_LOCAL_CHAIN_BACKSTOP` (default 64; values < 1 or unparseable fall back — the `hard_cap()` pattern), registered in `DEQUE_KNOBS` / `SCHEDULER_KNOBS` for config discovery (ADR-0090 unit b2).

Injector starvation is bounded at ~K × cycle-time per worker; the chain stays warm K−1 of K cycles, with one counter bump per pop and no clock read added. A runaway loop still consumes its one worker — valid work as far as the scheduler knows; this backstop keeps the rest of the system live, and detecting or killing runaway actors stays supervision-layer policy.

## Verification

- Heavy-marked regression (`pool::tests::heavy::injector_fed_slot_dispatches_under_full_worker_capture`): W self-sustaining loop slots capture a W-worker pool, then an injector-fed probe slot must dispatch within the deadline. Discrimination-checked both ways: with the probe disabled the slot starves past the 5s deadline; with it active it dispatches in ~0.03s. The test stops the loops before asserting so a future regression fails at the deadline instead of wedging the suite.
- Unit tests cover the every-K window + reset (`chain_pop_due_fires_every_k_and_resets`, `burst_reset_clears_chain_pops`) and the unconditional re-queue arm (`push_local_*`); the knob-registry sweep covers the new `AETHER_LOCAL_CHAIN_BACKSTOP` record.
- Full preflight with qodana green on this commit.

Closes #1535

🤖 Generated with [Claude Code](https://claude.com/claude-code)