### PR TITLE
chore(substrate): scheduler hardening sweep from the concurrency audit

### DIFF
--- a/crates/aether-substrate/src/actor/native/blob_lifecycle.rs
+++ b/crates/aether-substrate/src/actor/native/blob_lifecycle.rs
@@ -176,6 +176,17 @@ impl Lifecycle {
     pub fn complete(&self) -> bool {
         let mut w = self.word.load(Ordering::Acquire);
         loop {
+            // Invariant: each `complete` pairs with a claimed group, so
+            // `done` can never reach `len` before this call bumps it. An
+            // unpaired `complete` would push `done` past `len`, so the
+            // `done == len` seal test below never fires and the blob wedges
+            // (never retires). Guard the pairing in debug builds.
+            debug_assert!(
+                done_of(w) < len_of(w),
+                "Lifecycle::complete called with done ({}) >= len ({}) — unpaired complete",
+                done_of(w),
+                len_of(w),
+            );
             let new_done = done_of(w) + 1;
             let retire = new_done == len_of(w);
             let next = pack(cursor_of(w), len_of(w), new_done, sealed_of(w) || retire);
@@ -263,6 +274,22 @@ mod tests {
         assert!(lc.complete(), "completion bringing done==len retires");
         assert!(lc.is_retired());
         assert_eq!(lc.snapshot(), (2, 2, 2, true));
+    }
+
+    /// An unpaired `complete` (more completions than claimed groups) trips
+    /// the `done < len` debug guard rather than silently pushing `done`
+    /// past `len` and wedging the blob (it would never seal). Debug-only:
+    /// `debug_assert!` is compiled out in release, so the panic only fires
+    /// under `debug_assertions`.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "unpaired complete")]
+    fn complete_past_len_trips_debug_guard() {
+        let lc = Lifecycle::new(1);
+        assert_eq!(lc.claim(), Some(0));
+        assert!(lc.complete(), "the one claimed group retires the blob");
+        // Second, unpaired completion: done (1) >= len (1) — guard fires.
+        lc.complete();
     }
 
     #[test]

--- a/crates/aether-substrate/src/actor/native/blob_work.rs
+++ b/crates/aether-substrate/src/actor/native/blob_work.rs
@@ -137,12 +137,46 @@ use rustc_hash::FxHashMap;
 
 use crate::actor::native::Envelope;
 use crate::actor::native::blob_lifecycle::{Lifecycle, MAX_GROUPS, Published};
+use crate::config::{KnobKind, KnobRecord};
 use crate::mail::cost::CostLookup;
 use crate::mail::mailer::Mailer;
 use crate::mail::{KindId, Mail, MailboxId};
 use crate::scheduler::{
     BatchBudget, CycleResult, Drainable, SeizeHandle, WakeSink, handoff_cost_nanos,
 };
+
+/// Config-discovery records (ADR-0090 unit b2) for the blob recruiter's
+/// three `OnceLock`-cached env knobs — [`recruit_min`], [`recruit_cap`],
+/// and [`wake_cost_nanos`]. Referenced by
+/// [`crate::scheduler::SCHEDULER_KNOBS`] so the e1 unknown-key sweep and
+/// the e2 `--config` dump cover them; the getters' hot-path reads stay
+/// untouched. Pure `&'static` metadata, docs/defaults lifted from the
+/// getter doc-comments.
+pub const RECRUIT_KNOBS: &[KnobRecord] = &[
+    KnobRecord {
+        env_key: "AETHER_BLOB_RECRUIT_MIN",
+        doc: "Minimum fresh-group count for a flush to broadcast-recruit siblings \
+              (the width gate). Values < 1 / unparseable fall back to 9.",
+        default: Some("9"),
+        kind: KnobKind::HandRegistered,
+    },
+    KnobRecord {
+        env_key: "AETHER_BLOB_RECRUIT_MAX",
+        doc: "Cap on the number of sibling copies a single flush injects when \
+              recruiting, bounding injector churn for a very wide fan-out. Values \
+              < 1 / unparseable fall back to 32.",
+        default: Some("32"),
+        kind: KnobKind::HandRegistered,
+    },
+    KnobRecord {
+        env_key: "AETHER_WAKE_COST_NANOS",
+        doc: "Pins the recruit wake break-even (nanoseconds) and freezes live \
+              refinement. Values < 1 / unparseable fall back to the box-measured \
+              handoff cost. Unset → measured and live-refined.",
+        default: None,
+        kind: KnobKind::HandRegistered,
+    },
+];
 
 /// Floor for a fresh blob's group-array capacity — a little headroom so a
 /// couple of subsequent flushes to *new* recipients can accumulate before
@@ -214,6 +248,11 @@ fn wake_cost_nanos() -> u64 {
         env::var("AETHER_WAKE_COST_NANOS")
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
+            // `>= 1`: a 0 override would disable the recruit wake gate
+            // entirely (every blob clears the break-even). Filter it out for
+            // consistency with `AETHER_HANDOFF_COST_NS` / `recruit_min` /
+            // `recruit_cap`; a rejected 0 falls through to the measured cost.
+            .filter(|&ns| ns >= 1)
     }) {
         return ns;
     }

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -59,17 +59,28 @@ use std::sync::PoisonError;
 /// `ActorSlots` uses `RefCell` internally because the dedicated-thread
 /// dispatcher path only ever reaches it from one OS thread. Worker-pool
 /// dispatch can have *different* worker threads hit the same slot
-/// across cycles — but the [`SlotState`] machine guarantees only one
-/// worker is in `Running` at a time. That serialization makes the
-/// `RefCell` accesses sound; this wrapper is the safety story.
+/// across cycles, so the wrapper has to make those accesses sound.
+///
+/// The root guarantor is the actor [`Mutex`](DispatcherSlot::actor):
+/// every read of the inner `ActorSlots` happens inside
+/// [`DispatcherSlot::drain_after_seed`], which holds that lock for the
+/// whole drain. The lock provides both the mutual exclusion (one
+/// dispatcher body at a time) and the happens-before edge that
+/// publishes one body's `RefCell` mutations to the next. The
+/// [`SlotState`] machine is the *scheduling filter* layered above it —
+/// it keeps the common case to a single un-contended worker — but it is
+/// not the exclusion on its own: in the post-`mark_idle` recheck window
+/// a worker can dispatch an envelope without holding `Running` while a
+/// second worker legitimately enters `drain_after_seed`, so only the
+/// actor `Mutex` actually serializes the `ActorSlots` access there.
 #[repr(transparent)]
 struct PooledSlots(Box<ActorSlots>);
 
-// SAFETY: see the doc-comment on `PooledSlots`. The SlotState
-// machine's `Idle → Ready → Running → Idle` invariant ensures at most
-// one worker thread holds an active reference to the inner
-// `ActorSlots` at any time, so the inner `RefCell` is effectively
-// single-threaded across the Pooled dispatch path.
+// SAFETY: see the doc-comment on `PooledSlots`. Every access to the
+// inner `ActorSlots` is made under the actor `Mutex` held across
+// `DispatcherSlot::drain_after_seed`, which serializes the `RefCell`
+// accesses and establishes the happens-before edge between successive
+// dispatch bodies regardless of which worker thread runs them.
 unsafe impl Sync for PooledSlots {}
 
 impl Deref for PooledSlots {
@@ -101,11 +112,14 @@ where
 {
     /// The slot's atomic state machine. Shared with the `WakeHandle`.
     pub(crate) state: Arc<SlotState>,
-    /// The actor itself. The state machine guarantees only one worker
-    /// is in `Running` at a time, so the `Mutex` is uncontested in
-    /// production — used here over `UnsafeCell` only for the simpler
-    /// safety story. `Option` so the `Closed` finalize path can take
-    /// the box and run `unwire` on the consumed actor.
+    /// The actor itself. This `Mutex` is the root mutual-exclusion +
+    /// happens-before guarantor for a slot's dispatch: every drain runs
+    /// under it (see [`Self::drain_after_seed`]), so two workers that
+    /// reach the slot — e.g. a recheck-window dispatch racing a fresh
+    /// `seize_and_run` — serialize here rather than relying on
+    /// [`SlotState`] alone, which is the scheduling filter above it.
+    /// `Option` so the `Closed` finalize path can take the box and run
+    /// `unwire` on the consumed actor.
     actor: Mutex<Option<Box<A>>>,
     /// Per-actor binding (inbox + shutdown flag + reply machinery).
     binding: Arc<NativeBinding>,

--- a/crates/aether-substrate/src/mail/ring.rs
+++ b/crates/aether-substrate/src/mail/ring.rs
@@ -759,22 +759,6 @@ impl MailRing {
         hdr.lock.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Batch-decrement a blob's lock by `n` (the inline-drain path, where
-    /// the worker ran `n` of the blob's recipients itself). **Producer or
-    /// consumer-safe** — it is the same atomic as [`Self::release`].
-    ///
-    /// # Safety
-    /// Same as [`Self::release`], and `n` must not exceed the lock the
-    /// caller holds.
-    pub unsafe fn release_n(&self, header_off: u32, n: u32) {
-        if n == 0 {
-            return;
-        }
-        // SAFETY: header_off addresses a live blob's header.
-        let hdr = unsafe { &*self.header_ptr(header_off as usize) };
-        hdr.lock.fetch_sub(n, Ordering::Release);
-    }
-
     /// Advance `front` past every fully-released (`lock == 0`) blob at the
     /// head, freeing their bytes for reuse. Lazy: the producer calls this
     /// before a write (or opportunistically). **Producer-only.** Returns
@@ -813,6 +797,28 @@ impl MailRing {
             reclaimed += total;
         }
         reclaimed
+    }
+}
+
+#[cfg(test)]
+impl MailRing {
+    /// Batch-decrement a blob's lock by `n`. **Producer or consumer-safe**
+    /// — it is the same atomic as [`Self::release`]. Test-only: the
+    /// production inline-drain path releases one count at a time via
+    /// [`Self::release`]; this batched form has no production callers and
+    /// only exists to exercise the reclaim arithmetic in
+    /// [`tests::batch_release_reclaims`].
+    ///
+    /// # Safety
+    /// Same as [`Self::release`], and `n` must not exceed the lock the
+    /// caller holds.
+    pub unsafe fn release_n(&self, header_off: u32, n: u32) {
+        if n == 0 {
+            return;
+        }
+        // SAFETY: header_off addresses a live blob's header.
+        let hdr = unsafe { &*self.header_ptr(header_off as usize) };
+        hdr.lock.fetch_sub(n, Ordering::Release);
     }
 }
 

--- a/crates/aether-substrate/src/scheduler/mod.rs
+++ b/crates/aether-substrate/src/scheduler/mod.rs
@@ -49,6 +49,7 @@ pub use slot::{
 pub use spin_park::{Acquired, SpinPark};
 pub use worker_deque::{burst_note_mail, pending_depth, time_budget};
 
+use crate::actor::native::blob_work::RECRUIT_KNOBS;
 use crate::config::{KnobKind, KnobRecord};
 
 /// The lifecycle advance-timeout knob (ADR-0090 unit b2,
@@ -71,11 +72,13 @@ pub const LIFECYCLE_KNOBS: &[KnobRecord] = &[KnobRecord {
 /// config discovery (ADR-0090 unit b2, iamacoffeepot/aether#1255).
 /// Concatenates the five deque / keep-local-valve knobs
 /// (`worker_deque::DEQUE_KNOBS`), the handoff-cost calibration knob
-/// (`calibrate::CALIBRATE_KNOBS`), and the lifecycle advance-timeout
-/// knob ([`LIFECYCLE_KNOBS`]) into the single
-/// slice e1's `chassis_known_keys()` folds into the known-key set and
-/// e2's `--config` dump renders. Pure `&'static` metadata — there is
-/// no change to any hot-path `OnceLock` read.
+/// (`calibrate::CALIBRATE_KNOBS`), the lifecycle advance-timeout knob
+/// ([`LIFECYCLE_KNOBS`]), the three blob-recruiter knobs
+/// (`blob_work::RECRUIT_KNOBS`), and the spin-window knob
+/// (`pool::SPIN_KNOBS`) into the single slice e1's `chassis_known_keys()`
+/// folds into the known-key set and e2's `--config` dump renders. Pure
+/// `&'static` metadata — there is no change to any hot-path `OnceLock`
+/// read.
 ///
 /// The element-by-element array (rather than a runtime concat) keeps
 /// `SCHEDULER_KNOBS` a `const`: each record is still *defined* once in
@@ -88,6 +91,10 @@ pub const SCHEDULER_KNOBS: &[KnobRecord] = &[
     worker_deque::DEQUE_KNOBS[4],
     calibrate::CALIBRATE_KNOBS[0],
     LIFECYCLE_KNOBS[0],
+    RECRUIT_KNOBS[0],
+    RECRUIT_KNOBS[1],
+    RECRUIT_KNOBS[2],
+    pool::SPIN_KNOBS[0],
 ];
 
 #[cfg(test)]
@@ -96,7 +103,7 @@ mod knob_tests {
     use crate::config::KnobKind;
 
     #[test]
-    fn scheduler_knobs_cover_all_seven_hot_path_env_keys() {
+    fn scheduler_knobs_cover_all_hot_path_env_keys() {
         let keys: Vec<&str> = SCHEDULER_KNOBS.iter().map(|r| r.env_key).collect();
         for expected in [
             "AETHER_LOCAL_STICKY_MAX",
@@ -106,13 +113,17 @@ mod knob_tests {
             "AETHER_LOCAL_CHAIN_BACKSTOP",
             "AETHER_HANDOFF_COST_NS",
             "AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS",
+            "AETHER_BLOB_RECRUIT_MIN",
+            "AETHER_BLOB_RECRUIT_MAX",
+            "AETHER_WAKE_COST_NANOS",
+            "AETHER_SPIN_WINDOW_USEC",
         ] {
             assert!(
                 keys.contains(&expected),
                 "SCHEDULER_KNOBS missing {expected}; has {keys:?}",
             );
         }
-        assert_eq!(SCHEDULER_KNOBS.len(), 7);
+        assert_eq!(SCHEDULER_KNOBS.len(), 11);
     }
 
     #[test]

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -36,6 +36,7 @@ use std::thread::{self, JoinHandle};
 
 use crossbeam_deque::{Injector, Stealer, Worker};
 
+use crate::config::{KnobKind, KnobRecord};
 use crate::scheduler::spin_park::{Acquired, DEFAULT_SPIN_WINDOW_USEC, SpinPark};
 use crate::scheduler::worker_deque;
 
@@ -231,6 +232,20 @@ impl Pool {
         }
     }
 }
+
+/// Config-discovery record (ADR-0090 unit b2) for the spin-window knob
+/// [`spin_window_from_env`] reads. Referenced by
+/// [`crate::scheduler::SCHEDULER_KNOBS`] so the e1 unknown-key sweep and
+/// the e2 `--config` dump cover it; the read path stays untouched. Pure
+/// `&'static` metadata.
+pub const SPIN_KNOBS: &[KnobRecord] = &[KnobRecord {
+    env_key: "AETHER_SPIN_WINDOW_USEC",
+    doc: "Route-to-spinner spin-window (microseconds) before a worker parks. The \
+          latency sweep retunes this without a recompile; malformed values fall \
+          back to 50.",
+    default: Some("50"),
+    kind: KnobKind::HandRegistered,
+}];
 
 /// Read the spin-window override (`AETHER_SPIN_WINDOW_USEC`) for the
 /// route-to-spinner coordinator, falling back to the default. The

--- a/crates/aether-substrate/src/scheduler/slot.rs
+++ b/crates/aether-substrate/src/scheduler/slot.rs
@@ -102,8 +102,14 @@ impl SlotState {
     /// (`Ready` or `Running`); the existing scheduling will pick up
     /// the newly-pushed envelope.
     pub fn try_wake(&self) -> bool {
+        // SeqCst: producer side of the send-vs-drain store-buffer pattern
+        // (inbox push then this CAS, vs the worker's `mark_idle` store then
+        // recheck). A single total order across `try_wake` / `mark_idle` /
+        // `seize` / `try_self_requeue` is what guarantees that the sender and
+        // the draining worker cannot both observe stale state and strand the
+        // envelope in an Idle, unqueued slot.
         self.state
-            .compare_exchange(STATE_IDLE, STATE_READY, Ordering::AcqRel, Ordering::Acquire)
+            .compare_exchange(STATE_IDLE, STATE_READY, Ordering::SeqCst, Ordering::SeqCst)
             .is_ok()
     }
 
@@ -135,12 +141,17 @@ impl SlotState {
     /// `route_mail`, and the holder/woken cycle drains it (per-recipient
     /// FIFO preserved by the inbox's own ordering).
     pub fn seize(&self) -> bool {
+        // SeqCst: a demuxer's `Idle → Running` seize competes with a sender's
+        // `try_wake` (`Idle → Ready`) for the same Idle slot. Both must agree,
+        // in the single total order shared with `try_wake` / `mark_idle` /
+        // `try_self_requeue`, on which transition won — otherwise the loser's
+        // mail can strand in an Idle, unqueued slot.
         self.state
             .compare_exchange(
                 STATE_IDLE,
                 STATE_RUNNING,
-                Ordering::AcqRel,
-                Ordering::Acquire,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
             )
             .is_ok()
     }
@@ -149,7 +160,13 @@ impl SlotState {
     /// `Running → Idle` is unconditional (we hold the slot exclusively
     /// while `Running`).
     pub fn mark_idle(&self) {
-        self.state.store(STATE_IDLE, Ordering::Release);
+        // SeqCst: consumer side of the send-vs-drain store-buffer pattern —
+        // this `Running → Idle` store precedes the worker's inbox recheck.
+        // Placing it in the single total order shared with `try_wake` /
+        // `seize` / `try_self_requeue` forbids the worker's recheck and a
+        // concurrent sender's `try_wake` from both reading stale state and
+        // leaving freshly-pushed mail stranded in an Idle, unqueued slot.
+        self.state.store(STATE_IDLE, Ordering::SeqCst);
     }
 
     /// Worker-side: budget hit — leave the slot in `Ready` so the
@@ -165,8 +182,13 @@ impl SlotState {
     /// re-pushes the slot; `false` means a concurrent sender beat us
     /// to it (and they re-pushed).
     pub fn try_self_requeue(&self) -> bool {
+        // SeqCst: the post-`mark_idle` recheck CAS races a concurrent sender's
+        // `try_wake` for the requeue. Sequencing it in the single total order
+        // shared with `try_wake` / `seize` / `mark_idle` guarantees exactly
+        // one of the two wins the `Idle → Ready` transition and re-pushes the
+        // slot, so the rechecked envelope is never lost.
         self.state
-            .compare_exchange(STATE_IDLE, STATE_READY, Ordering::AcqRel, Ordering::Acquire)
+            .compare_exchange(STATE_IDLE, STATE_READY, Ordering::SeqCst, Ordering::SeqCst)
             .is_ok()
     }
 


### PR DESCRIPTION
Closes iamacoffeepot/aether#1534.

## Summary

The 2026-06-09 scheduler concurrency audit found no observed bug but left five hardening gaps in aether-substrate. This applies the audit prescriptions as one substrate-only PR (no public API, no wire format, no ADR):

1. SeqCst on exactly the four send-vs-drain store-buffer transitions in `scheduler/slot.rs` (`try_wake`, `seize`, `mark_idle`, `try_self_requeue`), each with a per-site ordering rationale. The pattern is formally unsound under the C++ memory model with AcqRel (safe today only by x86-64 / AArch64 + LLVM behavior); a single total order across the four closes the gap. `enter_running` and the lifecycle word / spinlock / spin-park fences / pending counter were audited correct and stay untouched.
2. Rewrite the `PooledSlots` Sync safety comment and the actor-field doc to name the actor `Mutex` as the root mutual-exclusion + happens-before guarantor, with `SlotState` as the scheduling filter — dropping the false "uncontested in production" claim (a second worker can legitimately enter `drain_after_seed` in the post-`mark_idle` recheck window).
3. `debug_assert!(done < len)` in `Lifecycle::complete`, guarding the claim/complete pairing so an unpaired complete trips rather than silently wedging the blob.
4. Filter `AETHER_WAKE_COST_NANOS` to `>= 1` (a 0 disabled the recruit wake gate, inconsistent with the sibling knobs), and register the four knobs absent from ADR-0090 config discovery (`AETHER_WAKE_COST_NANOS`, `AETHER_BLOB_RECRUIT_MIN`, `AETHER_BLOB_RECRUIT_MAX`, `AETHER_SPIN_WINDOW_USEC`) as `KnobRecord`s folded into `SCHEDULER_KNOBS`.
5. Move `MailRing::release_n` (no production callers) into a `#[cfg(test)]` impl block, keeping the `batch_release_reclaims` coverage.

## Test plan

- Full `scripts/preflight.sh --qodana` green (fmt + clippy + doc + nextest + wasm32 cross-build + qodana scan under failThreshold).
- Heavy scheduler nextest set (`serial-heavy` group) green.
- New `complete_past_len_trips_debug_guard` (debug-only `#[should_panic]`) exercises the lifecycle guard; `scheduler_knobs_cover_all_hot_path_env_keys` updated to assert the four new keys + len 10.

## Generated by

`/implement` — agent execution of [scoped issue #1534](https://github.com/iamacoffeepot/aether/issues/1534).