### PR TITLE
chore(repo): remove section-divider comments and repeated long inline paths

### DIFF
--- a/crates/aether-mesh/tests/mesh_v1_remaining.rs
+++ b/crates/aether-mesh/tests/mesh_v1_remaining.rs
@@ -25,7 +25,7 @@ fn tri_centroid(tri: &aether_mesh::Triangle) -> Vec3 {
     (tri.vertices[0] + tri.vertices[1] + tri.vertices[2]) * (1.0 / 3.0)
 }
 
-// ---------- cylinder ----------
+// cylinder
 
 #[test]
 fn cylinder_has_28_triangles_after_cap_merge() {
@@ -68,7 +68,7 @@ fn cylinder_outward_normals() {
     }
 }
 
-// ---------- cone ----------
+// cone
 
 #[test]
 fn cone_has_10_triangles_after_cap_merge() {
@@ -102,7 +102,7 @@ fn cone_outward_normals() {
     }
 }
 
-// ---------- wedge ----------
+// wedge
 
 #[test]
 fn wedge_has_eight_triangles() {
@@ -145,7 +145,7 @@ fn wedge_uses_six_unique_vertices() {
     assert_eq!(seen.len(), 6, "expected 6 unique corners, got {seen:?}");
 }
 
-// ---------- sphere ----------
+// sphere
 
 #[test]
 fn sphere_triangle_count_matches_lathe_pole_collapse() {
@@ -192,7 +192,7 @@ fn sphere_outward_normals() {
     }
 }
 
-// ---------- extrude ----------
+// extrude
 
 #[test]
 fn extrude_square_produces_walls_and_caps() {
@@ -247,7 +247,7 @@ fn extrude_with_under_three_profile_points_emits_nothing() {
     assert_eq!(mesh(&ast).expect("test setup: extrude meshes").len(), 0);
 }
 
-// ---------- mirror ----------
+// mirror
 
 #[test]
 fn mirror_x_reflects_box_across_yz_plane() {
@@ -288,7 +288,7 @@ fn mirror_preserves_outward_winding() {
     }
 }
 
-// ---------- array ----------
+// array
 
 #[test]
 fn array_produces_count_copies() {
@@ -322,7 +322,7 @@ fn array_zero_count_emits_nothing() {
     assert_eq!(mesh(&ast).expect("test setup: array meshes").len(), 0);
 }
 
-// ---------- round-trip across the full v1 vocabulary ----------
+// round-trip across the full v1 vocabulary
 
 #[test]
 fn round_trip_full_v1_vocab() {

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -29,7 +29,9 @@ use aether_kinds::trace::Nanos;
 use crate::actor::native::binding::NativeBinding;
 use crate::actor::native::dispatcher_slot::DispatcherSlot;
 use crate::actor::native::envelope::Envelope;
-use crate::actor::native::{NativeActor, NativeDispatch, NativeInitCtx};
+use crate::actor::native::{
+    ExportedHandles, NativeActor, NativeCtx, NativeDispatch, NativeInitCtx,
+};
 use crate::actor::registry::ActorRegistry;
 use crate::chassis::ctx::MailboxWakeSlot;
 use crate::chassis::error::BootError;
@@ -387,7 +389,7 @@ impl Spawner {
             // today — Phase 4+ may revisit. Pass a throwaway
             // ExportedHandles to keep the init-ctx shape uniform with
             // the singleton path.
-            let mut throwaway_handles = crate::ExportedHandles::new();
+            let mut throwaway_handles = ExportedHandles::new();
             let mut init_ctx =
                 NativeInitCtx::new(&transport, &mut throwaway_handles, Arc::clone(&self.mailer));
             // ADR-0081: wrap `init` in `with_stamped` so any
@@ -540,12 +542,7 @@ impl Spawner {
         // child wire→dispatcher transition is sequential within this
         // ctx, peers are running, all mailboxes claimed.
         local::with_stamped(&slots, || {
-            let mut wire_ctx = crate::actor::native::NativeCtx::new(
-                &transport,
-                Source::NONE,
-                MailId::NONE,
-                MailId::NONE,
-            );
+            let mut wire_ctx = NativeCtx::new(&transport, Source::NONE, MailId::NONE, MailId::NONE);
             actor.wire(&mut wire_ctx);
         });
 

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -26,7 +26,9 @@ use std::sync::atomic::AtomicU64;
 
 use crate::actor::native::binding::NativeBinding;
 use crate::actor::native::dispatcher_slot::DispatcherSlot;
-use crate::actor::native::{ExportedHandles, NativeActor, NativeDispatch, NativeInitCtx};
+use crate::actor::native::{
+    ExportedHandles, NativeActor, NativeCtx, NativeDispatch, NativeInitCtx,
+};
 use crate::chassis::Chassis;
 use crate::chassis::ctx::MailboxSender;
 use crate::chassis::ctx::MailboxWakeSlot;
@@ -593,7 +595,7 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
         // so `Local<T>` and `tracing::*` route into this actor's
         // `ActorLogRing` identically.
         local::with_stamped(&resources.slots, || {
-            let mut wire_ctx = crate::actor::native::NativeCtx::new(
+            let mut wire_ctx = NativeCtx::new(
                 &resources.transport,
                 aether_data::Source::NONE,
                 aether_data::MailId::NONE,

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -2455,9 +2455,7 @@ mod tests {
         assert_eq!(layer.eviction_tick_secs, DEFAULT_DISK_EVICTION_TICK_SECS);
     }
 
-    // ------------------------------------------------------------
     // HandleStore unit tests
-    // ------------------------------------------------------------
 
     #[test]
     fn put_then_get_round_trips_bytes_and_kind() {
@@ -2621,9 +2619,7 @@ mod tests {
         assert_eq!(bytes, vec![1, 2, 3]);
     }
 
-    // ------------------------------------------------------------
     // Walker tests — schema-driven over real Ref<K> wire
-    // ------------------------------------------------------------
 
     /// Tiny postcard kind for walker tests. Kept here rather than
     /// pulling the derive macro into substrate-core's dev-deps:

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -1023,9 +1023,7 @@ mod tests {
         }
     }
 
-    // ------------------------------------------------------------
     // ADR-0045 Ref-resolution integration
-    // ------------------------------------------------------------
 
     #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug, Clone)]
     struct Note {


### PR DESCRIPTION
Closes iamacoffeepot/aether#1524.

## Summary

Style cleanup against two repo conventions (no banner-divider comments; pull repeated multi-segment inline paths in via `use`). Textual only, no behavior change.

- Delete the 14 banner-divider comments, keeping each section's label as a single plain comment: `mesh_v1_remaining.rs` x8, `handle_store.rs` x4 (two pairs), `mailer.rs` x2 (one pair). `mesh_v1_remaining.rs` stays one file — no per-primitive module split (that would churn every nextest path / CI history for zero functional gain; plain comments carry the structure).
- Convert the genuine in-body inline paths to `use` imports: `builder.rs` (`NativeCtx`) and `spawn.rs` (`ExportedHandles`, `NativeCtx`).

Per the issue's design-note corrections: `aether-actor/src/ffi/mod.rs`'s fully-qualified FFI-shim paths are intentional and left as-is. The audited `actor/native/ctx.rs:1052` instance had drifted by HEAD into an existing `use` statement, so no in-body conversion remained there.

## Test plan

- Full `scripts/preflight.sh --qodana` green (fmt + clippy + doc + nextest + wasm32 cross-build + qodana).
- Banner-divider greps come back empty across the three touched files.
- `aether-mesh` (325) and the touched `aether-substrate` test modules green.

## Generated by

`/implement` — agent execution of [scoped issue #1524](https://github.com/iamacoffeepot/aether/issues/1524).