### PR TITLE
chore(repo): dependency hygiene — drifted wasmparser pin, dead optional deps, misplaced dev-dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,9 +92,7 @@ dependencies = [
  "cpal",
  "crossbeam-queue",
  "dirs",
- "png",
  "postcard",
- "rustc-hash 2.1.2",
  "serde",
  "serde_json",
  "tracing",
@@ -269,7 +267,6 @@ dependencies = [
  "aether-kinds",
  "bytemuck",
  "confique",
- "cpal",
  "crossbeam-channel",
  "crossbeam-deque",
  "dirs",
@@ -281,7 +278,7 @@ dependencies = [
  "serde_json",
  "tracing",
  "tracing-subscriber",
- "wasmparser 0.249.0",
+ "wasmparser 0.246.2",
  "wasmtime",
  "wat",
  "wgpu",
@@ -1853,8 +1850,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "foldhash 0.2.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -4682,19 +4677,6 @@ checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.16.1",
- "indexmap",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.249.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30538cae9a794215f490b532df01c557e2e2bfac92569482554acd0992a102ea"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.17.0",
  "indexmap",
  "semver",
  "serde",

--- a/crates/aether-capabilities/Cargo.toml
+++ b/crates/aether-capabilities/Cargo.toml
@@ -40,7 +40,6 @@ native = [
     "dep:confique",
     "dep:dirs",
     "dep:postcard",
-    "dep:rustc-hash",
     "dep:serde_json",
     "dep:tracing",
     "dep:ureq",
@@ -62,8 +61,8 @@ audio = []
 # Native impl layers — adds the substrate-side runtime + heavy deps
 # atop the marker layer. Chassis bins activate these. Each implies its
 # marker layer + `native` so chassis builds still see the full cap.
-render-native = ["render", "native", "aether-substrate/render", "dep:wgpu", "dep:png"]
-audio-native = ["audio", "native", "aether-substrate/audio", "dep:cpal", "dep:crossbeam-queue"]
+render-native = ["render", "native", "aether-substrate/render", "dep:wgpu"]
+audio-native = ["audio", "native", "dep:cpal", "dep:crossbeam-queue"]
 
 [dependencies]
 # Always-on: target-agnostic SDK + data layer + kind types. These
@@ -96,9 +95,6 @@ clap = { workspace = true, optional = true }
 confique = { version = "0.4", default-features = false, optional = true }
 dirs = { version = "6", optional = true }
 postcard = { version = "1.1", optional = true, features = ["alloc"] }
-# Fast non-cryptographic hasher for the trace observer's hot-path maps
-# (keyed by 64-bit ids — no DoS surface). iamacoffeepot/aether#1054.
-rustc-hash = { version = "2", optional = true }
 # JSON request/response bodies for the content-gen provider APIs
 # (ADR-0050) — the Anthropic Messages API and the Gemini media APIs.
 serde_json = { version = "1", optional = true }
@@ -118,7 +114,6 @@ uuid = { version = "1", optional = true, features = ["v4"] }
 # in the dep tree.
 wasmtime = { version = "44", optional = true }
 wgpu = { version = "29.0.1", optional = true }
-png = { version = "0.18", optional = true }
 cpal = { version = "0.17", optional = true }
 crossbeam-queue = { version = "0.3", optional = true }
 

--- a/crates/aether-substrate-bundle/Cargo.toml
+++ b/crates/aether-substrate-bundle/Cargo.toml
@@ -64,11 +64,10 @@ name = "aether-perf-plot"
 path = "src/bin/perf-plot.rs"
 
 [dependencies]
-aether-substrate = { path = "../aether-substrate", features = ["render", "audio"] }
+aether-substrate = { path = "../aether-substrate", features = ["render"] }
 aether-capabilities = { path = "../aether-capabilities", features = ["render-native", "audio-native"] }
 aether-actor = { path = "../aether-actor" }
 aether-data = { path = "../aether-data" }
-aether-codec = { path = "../aether-codec" }
 aether-kinds = { path = "../aether-kinds" }
 # Chassis-binary argv parsing (ADR-0090 unit d, issue 1258). The
 # `cli` module declares per-chassis Parser roots and per-cap overlay
@@ -147,6 +146,10 @@ serde_json = "1"
 # ADR-0090 c1: renamed from `aether-test-fixture-probe` and restructured
 # so per-fixture cdylibs live as `[[example]]`s; the lib rlib carries
 # the shared `Kind` definitions.
+# Length-prefix postcard frame helpers (`aether_codec::frame::{read_frame,
+# write_frame}`) used by the RPC engine-routing + FleetBench integration
+# tests; no `src/` consumer, so it rides dev-dependencies only.
+aether-codec = { path = "../aether-codec" }
 aether-test-fixtures = { path = "../aether-test-fixtures" }
 # iamacoffeepot/aether#1472: the FleetBench Transform-DAG test builds a
 # descriptor with `output_kind_id == Vec4::ID` and casts the observer's

--- a/crates/aether-substrate/Cargo.toml
+++ b/crates/aether-substrate/Cargo.toml
@@ -23,10 +23,6 @@ wasm = ["dep:wasmtime", "dep:wasmparser"]
 # offscreen pipeline + capture path. Headless and hub leave it off
 # and never link wgpu.
 render = ["dep:wgpu", "dep:png"]
-# ADR-0070 phase 3 (part 4): chassis with an audio device enable
-# `audio` to pull in the cpal-backed synth + the `aether.sink.audio`
-# capability. Headless and hub leave it off; desktop turns it on.
-audio = ["dep:cpal"]
 
 [dependencies]
 # ADR-0074 Phase 2: target-agnostic actor SDK. Capabilities own a
@@ -70,9 +66,6 @@ wasmtime = { version = "44", optional = true }
 # their builds.
 wgpu = { version = "29.0.1", optional = true }
 png = { version = "0.18", optional = true }
-# Audio-only deps; gated by the `audio` feature. Desktop enables it,
-# headless and hub do not.
-cpal = { version = "0.17", optional = true }
 # Issue 635 PR B worker-pool ready queue. MPMC channel — std mpsc is
 # single-consumer so it can't load-balance across pool workers. Still
 # used for settlement/capture one-shots + the close-done signal; the
@@ -86,7 +79,7 @@ crossbeam-deque = "0.8"
 # wasmparser directly to walk the raw wasm bytes for the ADR-0028
 # `aether.kinds` section. Pin to the version wasmtime re-exports
 # transitively so we stay on a single compiled copy.
-wasmparser = { version = "0.249", optional = true }
+wasmparser = { version = "0.246", optional = true }
 # Registry hot-path maps (#1067): FxHashMap on the id-keyed `mailboxes`
 # and `kinds` tables. Keys are pre-hashed 64-bit ids (ADR-0029/0030), so
 # SipHash's DoS resistance buys nothing here — Fx is faster per lookup and


### PR DESCRIPTION
Closes iamacoffeepot/aether#1521.

## Summary

Four independent manifest-level drifts from a workspace dependency audit, landed as one PR (manifest-only, no source changes):

1. **Re-pin wasmparser 0.249 -> 0.246** in aether-substrate to match the version wasmtime 44 re-exports (0.246.2). The workspace now compiles a single wasmparser instead of two.
2. **Delete dead optional deps in aether-capabilities** — `rustc-hash` (zero `rustc_hash::`/`FxHash` refs; the real consumer is aether-substrate's own copy) and `png` (zero `png::` refs; the stub PNG in `contentgen/adapter.rs` is hand-rolled to avoid the encoder and stays). Removed from the `native` / `render-native` feature lists too.
3. **Remove the vestigial `audio` feature + cpal optional dep from aether-substrate** — it gated nothing (zero `cfg(feature = "audio")` guards). Fixed the two downstream references: dropped `"audio"` from the aether-substrate-bundle dep feature list and `"aether-substrate/audio"` from capabilities' `audio-native`. The real cpal consumer (capabilities `audio-native` -> `dep:cpal`) is untouched.
4. **Demote aether-codec to dev-dependencies in aether-substrate-bundle** — zero `src/` usages; only the RPC-routing and FleetBench integration tests use `aether_codec::frame::*`.

## Verification

Full preflight green (fmt + clippy `--all-targets` + doc + nextest + wasm32 cross-build + qodana). `cargo tree --workspace --duplicates` now shows a single `wasmparser 0.246.2`.

Note on `hashbrown 0.17`: the issue expected the wasmparser re-pin to also drop the second `hashbrown` major. It does remove wasmparser 0.249's edge to it, but `hashbrown 0.17.0` persists via a pre-existing, wasmparser-independent path — `wasmtime 44 -> addr2line -> gimli 0.33 -> indexmap 2.14 -> hashbrown 0.17`. That path is already in main's lockfile and is intrinsic to the wasmtime stack; forcing `indexmap` down would be out-of-scope. The wasmparser dedup goal (single compiled copy) is met.

## Generated by

`/implement` — agent execution of scoped issue #1521.
