### PR TITLE
chore(repo): spell out time units and drop type-in-name identifiers

### DIFF
--- a/crates/aether-capabilities/src/anthropic/api.rs
+++ b/crates/aether-capabilities/src/anthropic/api.rs
@@ -69,7 +69,7 @@ impl UreqAnthropicAdapter {
             .body(body_bytes)
             .map_err(|e| format!("build request: {e}"))?;
 
-        let (status, retry_after_ms, text) =
+        let (status, retry_after_millis, text) =
             shared::run_request(&self.agent, http_req, self.timeout)?;
 
         if !(200..300).contains(&status) {
@@ -77,12 +77,12 @@ impl UreqAnthropicAdapter {
             // the cap's `error::status_to_error` mapping reconstructs
             // the typed variant. The cap parses the leading status.
             return Err(format!(
-                "status={status} retry_after_ms={retry_after_ms:?} body={text}"
+                "status={status} retry_after_ms={retry_after_millis:?} body={text}"
             ));
         }
 
-        let elapsed_ms = elapsed_ms(started);
-        parse_messages_response(&text, &req.model, elapsed_ms)
+        let elapsed_millis = elapsed_millis(started);
+        parse_messages_response(&text, &req.model, elapsed_millis)
     }
 }
 
@@ -159,7 +159,7 @@ fn clamp_u32(v: u64) -> u32 {
     u32::try_from(v).unwrap_or(u32::MAX)
 }
 
-fn elapsed_ms(started: Instant) -> u32 {
+fn elapsed_millis(started: Instant) -> u32 {
     clamp_u32(u64::try_from(started.elapsed().as_millis()).unwrap_or_else(|_| u64::from(u32::MAX)))
 }
 

--- a/crates/aether-capabilities/src/anthropic/cli.rs
+++ b/crates/aether-capabilities/src/anthropic/cli.rs
@@ -127,9 +127,9 @@ impl ClaudeCliAdapter {
                         // JoinHandle detaches the thread; its buffer is moot.
                         let _ = child.kill();
                         let _ = child.wait();
-                        let elapsed_ms =
+                        let elapsed_millis =
                             u32::try_from(started.elapsed().as_millis()).unwrap_or(u32::MAX);
-                        return Err(format!("{TIMEOUT_SENTINEL}{elapsed_ms}"));
+                        return Err(format!("{TIMEOUT_SENTINEL}{elapsed_millis}"));
                     }
                     thread::sleep(POLL_INTERVAL);
                 }

--- a/crates/aether-capabilities/src/contentgen/shared.rs
+++ b/crates/aether-capabilities/src/contentgen/shared.rs
@@ -42,7 +42,7 @@ pub fn run_request(
         .run()
         .map_err(|e| format!("request: {e}"))?;
     let status = response.status().as_u16();
-    let retry_after_ms = response
+    let retry_after_millis = response
         .headers()
         .get("retry-after")
         .and_then(|v| v.to_str().ok())
@@ -52,7 +52,7 @@ pub fn run_request(
         .body_mut()
         .read_to_string()
         .map_err(|e| format!("read body: {e}"))?;
-    Ok((status, retry_after_ms, text))
+    Ok((status, retry_after_millis, text))
 }
 
 /// Parse the `<status> retry_after_ms=<Debug-of-Option<u32>>` prefix a
@@ -63,7 +63,7 @@ pub fn run_request(
 pub fn parse_status_prefix(rest: &str) -> Option<(u16, Option<u32>)> {
     let mut parts = rest.split_whitespace();
     let status = parts.next()?.parse::<u16>().ok()?;
-    let retry_after_ms = parts.next().and_then(|tok| {
+    let retry_after_millis = parts.next().and_then(|tok| {
         tok.strip_prefix("retry_after_ms=").and_then(|v| {
             // The backend formats `Option<u32>` via Debug — `Some(1500)`
             // or `None`. Extract the inner integer when present.
@@ -72,7 +72,7 @@ pub fn parse_status_prefix(rest: &str) -> Option<(u16, Option<u32>)> {
                 .and_then(|n| n.parse::<u32>().ok())
         })
     });
-    Some((status, retry_after_ms))
+    Some((status, retry_after_millis))
 }
 
 /// Trim a response body to a short diagnostic snippet so an adapter

--- a/crates/aether-capabilities/src/gemini/mod.rs
+++ b/crates/aether-capabilities/src/gemini/mod.rs
@@ -212,11 +212,11 @@ impl UreqGeminiAdapter {
             .header("content-type", "application/json")
             .body(body_bytes)
             .map_err(|e| format!("build request: {e}"))?;
-        let (status, retry_after_ms, text) =
+        let (status, retry_after_millis, text) =
             shared::run_request(&self.agent, http_req, self.timeout)?;
         if !(200..300).contains(&status) {
             return Err(format!(
-                "status={status} retry_after_ms={retry_after_ms:?} body={text}"
+                "status={status} retry_after_ms={retry_after_millis:?} body={text}"
             ));
         }
         Ok(text)

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -40,7 +40,7 @@ pub const DEFAULT_MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
 /// Default per-request timeout when `AETHER_HTTP_TIMEOUT_MS` is unset
 /// and the fetch itself supplies no `timeout_ms`. 30s matches
 /// ADR-0043 §4.
-pub const DEFAULT_TIMEOUT_MS: u32 = 30_000;
+pub const DEFAULT_TIMEOUT_MILLIS: u32 = 30_000;
 
 /// Adapter-facing request shape. Converted from the wire `Fetch`
 /// kind by the cap before handing to the adapter.
@@ -136,7 +136,7 @@ pub struct HttpConfig {
     )]
     pub max_body_bytes: usize,
     /// Default per-request timeout when `Fetch.timeout_ms` is
-    /// `None`. Defaults to [`DEFAULT_TIMEOUT_MS`] (30 s). The derive's
+    /// `None`. Defaults to [`DEFAULT_TIMEOUT_MILLIS`] (30 s). The derive's
     /// `ms_duration` hint stores the Layer field as `u32`-ms and
     /// bridges via `Duration::from_millis(u64::from(...))`;
     /// `layer_field = "timeout_ms"` pins the Layer / env / CLI shape to
@@ -146,7 +146,7 @@ pub struct HttpConfig {
         feature = "native",
         config(
             default = 30_000,
-            parse = parse_timeout_ms,
+            parse = parse_timeout_millis,
             ms_duration,
             layer_field = "timeout_ms"
         )
@@ -161,7 +161,7 @@ impl Default for HttpConfig {
             allowlist: HashSet::new(),
             require_https: false,
             max_body_bytes: DEFAULT_MAX_BODY_BYTES,
-            default_timeout: Duration::from_millis(u64::from(DEFAULT_TIMEOUT_MS)),
+            default_timeout: Duration::from_millis(u64::from(DEFAULT_TIMEOUT_MILLIS)),
         }
     }
 }
@@ -202,7 +202,7 @@ fn parse_max_body_bytes(s: &str) -> Result<usize, ParseIntError> {
 }
 
 /// Parse a timeout in milliseconds (ADR-0090 §4 hard-error half):
-/// empty → [`DEFAULT_TIMEOUT_MS`]; a non-empty value that doesn't
+/// empty → [`DEFAULT_TIMEOUT_MILLIS`]; a non-empty value that doesn't
 /// parse as `u32` errors.
 ///
 /// # Errors
@@ -210,9 +210,9 @@ fn parse_max_body_bytes(s: &str) -> Result<usize, ParseIntError> {
 /// Returns a [`ParseIntError`] for a
 /// non-empty value that isn't a valid `u32`.
 #[cfg(feature = "native")]
-fn parse_timeout_ms(s: &str) -> Result<u32, ParseIntError> {
+fn parse_timeout_millis(s: &str) -> Result<u32, ParseIntError> {
     if s.trim().is_empty() {
-        return Ok(DEFAULT_TIMEOUT_MS);
+        return Ok(DEFAULT_TIMEOUT_MILLIS);
     }
     s.trim().parse()
 }
@@ -625,13 +625,15 @@ mod native {
             // empty value falls back to the default (unset), and a
             // non-empty garbage value errors rather than silently
             // defaulting.
-            use super::super::{DEFAULT_TIMEOUT_MS, parse_max_body_bytes, parse_timeout_ms};
+            use super::super::{
+                DEFAULT_TIMEOUT_MILLIS, parse_max_body_bytes, parse_timeout_millis,
+            };
             assert_eq!(parse_max_body_bytes("1024"), Ok(1024));
             assert_eq!(parse_max_body_bytes(""), Ok(DEFAULT_MAX_BODY_BYTES));
             assert!(parse_max_body_bytes("not-a-number").is_err());
-            assert_eq!(parse_timeout_ms("5000"), Ok(5000));
-            assert_eq!(parse_timeout_ms(""), Ok(DEFAULT_TIMEOUT_MS));
-            assert!(parse_timeout_ms("garbage").is_err());
+            assert_eq!(parse_timeout_millis("5000"), Ok(5000));
+            assert_eq!(parse_timeout_millis(""), Ok(DEFAULT_TIMEOUT_MILLIS));
+            assert!(parse_timeout_millis("garbage").is_err());
         }
 
         #[test]

--- a/crates/aether-capabilities/src/lifecycle.rs
+++ b/crates/aether-capabilities/src/lifecycle.rs
@@ -641,7 +641,7 @@ mod native {
                 initial_subscribers,
             } = config;
             let current_state = graph.start();
-            let advance_timeout_ms = env::var("AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS")
+            let advance_timeout_millis = env::var("AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS")
                 .ok()
                 .and_then(|s| s.parse::<u64>().ok())
                 .unwrap_or(ADVANCE_TIMEOUT_MS_DEFAULT);
@@ -669,7 +669,7 @@ mod native {
                 terminal_reached: false,
                 quit_pending: false,
                 pending: None,
-                advance_timeout: Duration::from_millis(advance_timeout_ms),
+                advance_timeout: Duration::from_millis(advance_timeout_millis),
                 settlement_latency_ewma: None,
                 last_slow_warn: None,
                 mailer,

--- a/crates/aether-mesh/src/parse.rs
+++ b/crates/aether-mesh/src/parse.rs
@@ -167,7 +167,7 @@ fn expect_arity(
 fn require_color(node: &'static str, keywords: &[(String, &Value)]) -> Result<u32, ParseError> {
     for (k, v) in keywords {
         if k == "color" {
-            return as_u32(v);
+            return as_uint(v);
         }
     }
     Err(ParseError::MissingKeyword {
@@ -196,14 +196,14 @@ fn check_no_extra_keywords(
 // the intended precision boundary (DSL author writes the literal;
 // we keep the lower-precision in-engine representation).
 #[allow(clippy::cast_possible_truncation)]
-fn as_f32(value: &Value) -> Result<f32, ParseError> {
+fn as_float(value: &Value) -> Result<f32, ParseError> {
     value
         .as_f64()
         .map(|n| n as f32)
         .ok_or_else(|| ParseError::ExpectedNumber(format!("{value}")))
 }
 
-fn as_u32(value: &Value) -> Result<u32, ParseError> {
+fn as_uint(value: &Value) -> Result<u32, ParseError> {
     let n = value
         .as_u64()
         .ok_or_else(|| ParseError::ExpectedInteger(format!("{value}")))?;
@@ -236,9 +236,9 @@ fn as_vec3(node: &'static str, value: &Value) -> Result<Vec3, ParseError> {
         });
     }
     Ok(Vec3::new(
-        as_f32(items[0])?,
-        as_f32(items[1])?,
-        as_f32(items[2])?,
+        as_float(items[0])?,
+        as_float(items[1])?,
+        as_float(items[2])?,
     ))
 }
 
@@ -250,7 +250,7 @@ fn as_profile(value: &Value) -> Result<Vec<[f32; 2]>, ParseError> {
         if coords.len() != 2 {
             return Err(ParseError::InvalidProfilePoint(coords.len()));
         }
-        out.push([as_f32(coords[0])?, as_f32(coords[1])?]);
+        out.push([as_float(coords[0])?, as_float(coords[1])?]);
     }
     Ok(out)
 }
@@ -259,9 +259,9 @@ fn parse_box(positional: &[&Value], keywords: &[(String, &Value)]) -> Result<Nod
     expect_arity("box", positional, 3)?;
     check_no_extra_keywords("box", keywords, &["color"])?;
     Ok(Node::Box {
-        x: as_f32(positional[0])?,
-        y: as_f32(positional[1])?,
-        z: as_f32(positional[2])?,
+        x: as_float(positional[0])?,
+        y: as_float(positional[1])?,
+        z: as_float(positional[2])?,
         color: require_color("box", keywords)?,
     })
 }
@@ -273,9 +273,9 @@ fn parse_cylinder(
     expect_arity("cylinder", positional, 3)?;
     check_no_extra_keywords("cylinder", keywords, &["color"])?;
     Ok(Node::Cylinder {
-        radius: as_f32(positional[0])?,
-        height: as_f32(positional[1])?,
-        segments: as_u32(positional[2])?,
+        radius: as_float(positional[0])?,
+        height: as_float(positional[1])?,
+        segments: as_uint(positional[2])?,
         color: require_color("cylinder", keywords)?,
     })
 }
@@ -284,9 +284,9 @@ fn parse_cone(positional: &[&Value], keywords: &[(String, &Value)]) -> Result<No
     expect_arity("cone", positional, 3)?;
     check_no_extra_keywords("cone", keywords, &["color"])?;
     Ok(Node::Cone {
-        radius: as_f32(positional[0])?,
-        height: as_f32(positional[1])?,
-        segments: as_u32(positional[2])?,
+        radius: as_float(positional[0])?,
+        height: as_float(positional[1])?,
+        segments: as_uint(positional[2])?,
         color: require_color("cone", keywords)?,
     })
 }
@@ -295,9 +295,9 @@ fn parse_wedge(positional: &[&Value], keywords: &[(String, &Value)]) -> Result<N
     expect_arity("wedge", positional, 3)?;
     check_no_extra_keywords("wedge", keywords, &["color"])?;
     Ok(Node::Wedge {
-        x: as_f32(positional[0])?,
-        y: as_f32(positional[1])?,
-        z: as_f32(positional[2])?,
+        x: as_float(positional[0])?,
+        y: as_float(positional[1])?,
+        z: as_float(positional[2])?,
         color: require_color("wedge", keywords)?,
     })
 }
@@ -306,8 +306,8 @@ fn parse_sphere(positional: &[&Value], keywords: &[(String, &Value)]) -> Result<
     expect_arity("sphere", positional, 2)?;
     check_no_extra_keywords("sphere", keywords, &["color"])?;
     Ok(Node::Sphere {
-        radius: as_f32(positional[0])?,
-        subdivisions: as_u32(positional[1])?,
+        radius: as_float(positional[0])?,
+        subdivisions: as_uint(positional[1])?,
         color: require_color("sphere", keywords)?,
     })
 }
@@ -317,7 +317,7 @@ fn parse_lathe(positional: &[&Value], keywords: &[(String, &Value)]) -> Result<N
     check_no_extra_keywords("lathe", keywords, &["color"])?;
     Ok(Node::Lathe {
         profile: as_profile(positional[0])?,
-        segments: as_u32(positional[1])?,
+        segments: as_uint(positional[1])?,
         color: require_color("lathe", keywords)?,
     })
 }
@@ -327,7 +327,7 @@ fn parse_extrude(positional: &[&Value], keywords: &[(String, &Value)]) -> Result
     check_no_extra_keywords("extrude", keywords, &["color"])?;
     Ok(Node::Extrude {
         profile: as_profile(positional[0])?,
-        depth: as_f32(positional[1])?,
+        depth: as_float(positional[1])?,
         color: require_color("extrude", keywords)?,
     })
 }
@@ -336,10 +336,10 @@ fn parse_torus(positional: &[&Value], keywords: &[(String, &Value)]) -> Result<N
     expect_arity("torus", positional, 4)?;
     check_no_extra_keywords("torus", keywords, &["color"])?;
     Ok(Node::Torus {
-        major_radius: as_f32(positional[0])?,
-        minor_radius: as_f32(positional[1])?,
-        major_segments: as_u32(positional[2])?,
-        minor_segments: as_u32(positional[3])?,
+        major_radius: as_float(positional[0])?,
+        minor_radius: as_float(positional[1])?,
+        major_segments: as_uint(positional[2])?,
+        minor_segments: as_uint(positional[3])?,
         color: require_color("torus", keywords)?,
     })
 }
@@ -378,7 +378,7 @@ fn parse_sweep(positional: &[&Value], keywords: &[(String, &Value)]) -> Result<N
 
 fn as_scalar_list(value: &Value) -> Result<Vec<f32>, ParseError> {
     let items = list_to_vec(value)?;
-    items.iter().map(|v| as_f32(v)).collect()
+    items.iter().map(|v| as_float(v)).collect()
 }
 
 fn as_path(value: &Value) -> Result<Vec<Vec3>, ParseError> {
@@ -419,7 +419,7 @@ fn parse_rotate(positional: &[&Value], keywords: &[(String, &Value)]) -> Result<
     check_no_extra_keywords("rotate", keywords, &[])?;
     Ok(Node::Rotate {
         axis: as_vec3("rotate", positional[0])?,
-        angle: as_f32(positional[1])?,
+        angle: as_float(positional[1])?,
         child: Box::new(parse_node(positional[2])?),
     })
 }
@@ -451,7 +451,7 @@ fn parse_array(positional: &[&Value], keywords: &[(String, &Value)]) -> Result<N
     expect_arity("array", positional, 3)?;
     check_no_extra_keywords("array", keywords, &[])?;
     Ok(Node::Array {
-        count: as_u32(positional[0])?,
+        count: as_uint(positional[0])?,
         spacing: as_vec3("array", positional[1])?,
         child: Box::new(parse_node(positional[2])?),
     })
@@ -461,11 +461,11 @@ fn parse_array(positional: &[&Value], keywords: &[(String, &Value)]) -> Result<N
 mod tests {
     use super::*;
 
-    /// `as_u32` accepts values up to `u32::MAX`. Pinned by issue #362
+    /// `as_uint` accepts values up to `u32::MAX`. Pinned by issue #362
     /// to keep the boundary case from regressing if the conversion is
     /// ever rewritten.
     #[test]
-    fn as_u32_accepts_u32_max() {
+    fn as_uint_accepts_u32_max() {
         let dsl = format!("(box 1 1 1 :color {})", u32::MAX);
         parse(&dsl).expect("u32::MAX must parse successfully");
     }
@@ -474,7 +474,7 @@ mod tests {
     /// (`n as u32` is a wrapping cast); per issue #362 they must now
     /// surface a parse error rather than producing a different mesh.
     #[test]
-    fn as_u32_rejects_values_above_u32_max() {
+    fn as_uint_rejects_values_above_u32_max() {
         let dsl = format!("(box 1 1 1 :color {})", u64::from(u32::MAX) + 1);
         let err = parse(&dsl).expect_err("values above u32::MAX must error");
         match err {

--- a/crates/aether-substrate-bundle/src/bin/perf-plot.rs
+++ b/crates/aether-substrate-bundle/src/bin/perf-plot.rs
@@ -161,10 +161,10 @@ fn render_cell(path: &Path, c: &CellSamples) -> Result<(), Box<dyn Error>> {
             .copied()
             .filter(|&v| v > 0)
     };
-    let lo_ns = positive().min().unwrap_or(1);
-    let hi_ns = positive().max().unwrap_or(1).max(lo_ns + 1);
-    let xmin = (lo_ns as f64 / 1000.0).max(0.001);
-    let xmax = (hi_ns as f64 / 1000.0).max(xmin * 1.001);
+    let lo_nanos = positive().min().unwrap_or(1);
+    let hi_nanos = positive().max().unwrap_or(1).max(lo_nanos + 1);
+    let xmin = (lo_nanos as f64 / 1000.0).max(0.001);
+    let xmax = (hi_nanos as f64 / 1000.0).max(xmin * 1.001);
 
     let (lmin, lmax) = (xmin.ln(), xmax.ln());
     let bin_of = |us: f64| -> usize {

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -29,7 +29,7 @@ use aether_substrate::chassis::builder::{Builder, BuiltChassis};
 use aether_substrate::chassis::error::BootError;
 use aether_substrate::{Chassis, SubstrateBoot};
 
-use super::driver::{HeadlessTimerCapability, parse_tick_hz_env};
+use super::driver::{HeadlessTimerDriverCapability, parse_tick_hz_env};
 use crate::autoload::{AutoloadComponent, autoload_mail};
 use crate::chassis_common::{
     CommonBoot, PersistOverride, chassis_known_keys, maybe_with_rpc_server, resolve_persist_state,
@@ -51,7 +51,7 @@ pub struct HeadlessChassis;
 
 impl Chassis for HeadlessChassis {
     const PROFILE: &'static str = "headless";
-    type Driver = HeadlessTimerCapability;
+    type Driver = HeadlessTimerDriverCapability;
     type Env = HeadlessEnv;
 
     fn build(env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
@@ -211,7 +211,7 @@ impl HeadlessChassis {
     /// the native passives (broadcast/handle/log/control/io/http plus
     /// the headless render / window / test-bench fail-fast caps)
     /// through the `chassis_builder` `.with()` chain, then wrap the
-    /// timer in a [`HeadlessTimerCapability`] and hand it to the
+    /// timer in a [`HeadlessTimerDriverCapability`] and hand it to the
     /// builder.
     fn build_inner(env: HeadlessEnv) -> Result<BuiltChassis<Self>, BootError> {
         let HeadlessEnv {
@@ -297,7 +297,7 @@ impl HeadlessChassis {
         let aborter: Arc<dyn FatalAborter> =
             Arc::new(OutboundFatalAborter::new(Arc::clone(&boot.outbound)));
 
-        let driver = HeadlessTimerCapability {
+        let driver = HeadlessTimerDriverCapability {
             boot,
             kind_tick,
             tick_period,

--- a/crates/aether-substrate-bundle/src/headless/driver.rs
+++ b/crates/aether-substrate-bundle/src/headless/driver.rs
@@ -72,7 +72,7 @@ pub fn parse_tick_hz_env() -> u32 {
 /// it now fires `LifecycleAdvance` at `aether.lifecycle`, and the
 /// `LifecycleCapability` owns the broadcast vocabulary so the substrate
 /// observes a labelled `aether.lifecycle` root for every frame chain.
-pub struct HeadlessTimerCapability {
+pub struct HeadlessTimerDriverCapability {
     pub boot: SubstrateBoot,
     /// Field kept for wire compatibility; the timer body no longer
     /// touches `Tick` directly post-ADR-0082, but chassis builders
@@ -97,7 +97,7 @@ pub struct HeadlessTimerRunning {
     kind_lifecycle_advance: KindId,
     tick_period: Duration,
     /// SIGINT/SIGTERM shutdown flag, flipped from the signal handler
-    /// installed in [`HeadlessTimerCapability::boot`]. The run loop
+    /// installed in [`HeadlessTimerDriverCapability::boot`]. The run loop
     /// checks it at the top of each iteration and `break`s, so `run()`
     /// returns and the chassis teardown unwinds. A struct field (not a
     /// loop-local) so tests can inject a pre-set flag and drive `run()`
@@ -108,7 +108,7 @@ pub struct HeadlessTimerRunning {
     _boot: SubstrateBoot,
 }
 
-impl DriverCapability for HeadlessTimerCapability {
+impl DriverCapability for HeadlessTimerDriverCapability {
     type Running = HeadlessTimerRunning;
 
     fn boot(self, _ctx: &mut DriverCtx<'_>) -> Result<Self::Running, BootError> {

--- a/crates/aether-substrate-bundle/src/perf/report.rs
+++ b/crates/aether-substrate-bundle/src/perf/report.rs
@@ -553,7 +553,7 @@ pub struct CompareConfig {
     /// differences read as noise; see the latency-sweep finding that
     /// ~100ns deltas are unresolvable). Without it, a 50ns shift on a
     /// 170ns sub-µs handler cell reads as a 30% "regression".
-    pub abs_floor_ns: f64,
+    pub abs_floor_nanos: f64,
     /// Fraction of trials whose delta must share the effect's sign.
     pub consistency: f64,
 }
@@ -563,7 +563,7 @@ impl Default for CompareConfig {
         Self {
             effect_floor_iqr: 1.5,
             rel_floor: 0.10,
-            abs_floor_ns: 300.0,
+            abs_floor_nanos: 300.0,
             consistency: 0.75,
         }
     }
@@ -942,13 +942,13 @@ fn classify(
         .count() as f64;
     let consistent = same_sign / n >= cfg.consistency;
 
-    // The absolute floor (`abs_floor_ns`) is a *nanosecond* resolution
+    // The absolute floor (`abs_floor_nanos`) is a *nanosecond* resolution
     // floor — meaningful for a latency span, meaningless for a mails/sec
     // rate (iamacoffeepot/aether#1202). For a higher-is-better rate the
     // verdict rests on the IQR + relative floors only; the ns floor is
     // neutralised to zero.
     let abs_floor = match dir {
-        Direction::LowerIsBetter => cfg.abs_floor_ns,
+        Direction::LowerIsBetter => cfg.abs_floor_nanos,
         Direction::HigherIsBetter => 0.0,
     };
     let floor = (cfg.effect_floor_iqr * delta_iqr)

--- a/crates/aether-substrate/src/dag/executor.rs
+++ b/crates/aether-substrate/src/dag/executor.rs
@@ -68,17 +68,17 @@ use std::thread;
 const TARGET: &str = "aether::dag::executor";
 
 /// Env override for the completed-DAG retention window (ADR-0047 §7).
-/// Default [`DEFAULT_RETENTION_COMPLETE_MS`].
+/// Default [`DEFAULT_RETENTION_COMPLETE_MILLIS`].
 pub const ENV_RETENTION_COMPLETE_MS: &str = "AETHER_DAG_RETENTION_COMPLETE_MS";
 /// Env override for the failed-DAG retention window (ADR-0047 §7).
-/// Default [`DEFAULT_RETENTION_FAILED_MS`].
+/// Default [`DEFAULT_RETENTION_FAILED_MILLIS`].
 pub const ENV_RETENTION_FAILED_MS: &str = "AETHER_DAG_RETENTION_FAILED_MS";
 /// Env override for the per-`Call` settlement timeout (ADR-0047 §4 —
-/// never-settling caps). Default [`DEFAULT_CALL_TIMEOUT_MS`].
+/// never-settling caps). Default [`DEFAULT_CALL_TIMEOUT_MILLIS`].
 pub const ENV_CALL_TIMEOUT_MS: &str = "AETHER_DAG_CALL_TIMEOUT_MS";
 /// Env override for the default per-`Transform` wall-clock deadline
 /// (ADR-0048 §3/§6). A `Node::Transform.timeout_ms` overrides per node.
-/// Default [`DEFAULT_TRANSFORM_TIMEOUT_MS`].
+/// Default [`DEFAULT_TRANSFORM_TIMEOUT_MILLIS`].
 pub const ENV_TRANSFORM_TIMEOUT_MS: &str = "AETHER_TRANSFORM_TIMEOUT_MS";
 /// Env override for the transform output-byte cap (ADR-0048 §6).
 /// Default [`DEFAULT_TRANSFORM_MAX_OUTPUT_BYTES`].
@@ -88,17 +88,17 @@ pub const ENV_TRANSFORM_MAX_OUTPUT_BYTES: &str = "AETHER_TRANSFORM_MAX_OUTPUT_BY
 pub const ENV_TRANSFORM_POOL_THREADS: &str = "AETHER_TRANSFORM_POOL_THREADS";
 
 /// Default completed-DAG retention before reaping (ADR-0047 §7).
-pub const DEFAULT_RETENTION_COMPLETE_MS: u64 = 60_000;
+pub const DEFAULT_RETENTION_COMPLETE_MILLIS: u64 = 60_000;
 /// Default failed-DAG retention before reaping (ADR-0047 §7).
-pub const DEFAULT_RETENTION_FAILED_MS: u64 = 300_000;
+pub const DEFAULT_RETENTION_FAILED_MILLIS: u64 = 300_000;
 /// Default per-`Call` settlement timeout — bounds a cap that never
 /// settles (never replies or streams forever). On expiry the `Call`
 /// node fails (ADR-0047 §4).
-pub const DEFAULT_CALL_TIMEOUT_MS: u64 = 30_000;
+pub const DEFAULT_CALL_TIMEOUT_MILLIS: u64 = 30_000;
 /// Default per-`Transform` wall-clock deadline (ADR-0048 §3/§6). A
 /// native thread can't be preempted, so on expiry the executor fails
 /// the node + orphans the runaway thread.
-pub const DEFAULT_TRANSFORM_TIMEOUT_MS: u64 = 30_000;
+pub const DEFAULT_TRANSFORM_TIMEOUT_MILLIS: u64 = 30_000;
 /// Default transform output-byte cap (ADR-0048 §6). Encoded output
 /// exceeding this hard-fails the node.
 pub const DEFAULT_TRANSFORM_MAX_OUTPUT_BYTES: u64 = 64 * 1024 * 1024;
@@ -111,15 +111,15 @@ pub const DEFAULT_TRANSFORM_MAX_OUTPUT_BYTES: u64 = 64 * 1024 * 1024;
 #[derive(Clone, Copy, Debug)]
 pub struct ExecutorConfig {
     /// Per-`Call` settlement timeout in ms (ADR-0047 §4).
-    pub call_timeout_ms: u64,
+    pub call_timeout_millis: u64,
     /// Default per-`Transform` wall-clock deadline in ms (ADR-0048 §3/§6).
-    pub transform_timeout_ms: u64,
+    pub transform_timeout_millis: u64,
     /// Transform output-byte cap (ADR-0048 §6).
     pub transform_max_output_bytes: u64,
     /// Completed-DAG retention window in ms (ADR-0047 §7).
-    pub retention_complete_ms: u64,
+    pub retention_complete_millis: u64,
     /// Failed/cancelled-DAG retention window in ms (ADR-0047 §7).
-    pub retention_failed_ms: u64,
+    pub retention_failed_millis: u64,
     /// Transform compute-pool thread count (ADR-0048 §3). Resolved at
     /// [`ExecutorConfig::from_env`] from available parallelism when unset.
     pub pool_threads: usize,
@@ -128,11 +128,11 @@ pub struct ExecutorConfig {
 impl Default for ExecutorConfig {
     fn default() -> Self {
         Self {
-            call_timeout_ms: DEFAULT_CALL_TIMEOUT_MS,
-            transform_timeout_ms: DEFAULT_TRANSFORM_TIMEOUT_MS,
+            call_timeout_millis: DEFAULT_CALL_TIMEOUT_MILLIS,
+            transform_timeout_millis: DEFAULT_TRANSFORM_TIMEOUT_MILLIS,
             transform_max_output_bytes: DEFAULT_TRANSFORM_MAX_OUTPUT_BYTES,
-            retention_complete_ms: DEFAULT_RETENTION_COMPLETE_MS,
-            retention_failed_ms: DEFAULT_RETENTION_FAILED_MS,
+            retention_complete_millis: DEFAULT_RETENTION_COMPLETE_MILLIS,
+            retention_failed_millis: DEFAULT_RETENTION_FAILED_MILLIS,
             pool_threads: default_pool_threads(),
         }
     }
@@ -165,11 +165,11 @@ impl ExecutorConfig {
             .load()
             .expect("ExecutorConfigLayer defaults are well-formed");
         Self {
-            call_timeout_ms: layer.call_timeout_ms,
-            transform_timeout_ms: layer.transform_timeout_ms,
+            call_timeout_millis: layer.call_timeout_millis,
+            transform_timeout_millis: layer.transform_timeout_millis,
             transform_max_output_bytes: layer.transform_max_output_bytes,
-            retention_complete_ms: layer.retention_complete_ms,
-            retention_failed_ms: layer.retention_failed_ms,
+            retention_complete_millis: layer.retention_complete_millis,
+            retention_failed_millis: layer.retention_failed_millis,
             // Runtime-computed default (not a literal confique can hold):
             // unset *or* unparseable → available parallelism (clamped ≥ 1).
             // A parseable value (incl `0`) is honoured verbatim — the prior
@@ -197,16 +197,16 @@ fn default_pool_threads() -> usize {
 struct ExecutorConfigLayer {
     #[config(
         env = "AETHER_DAG_CALL_TIMEOUT_MS",
-        parse_env = parse_call_timeout_ms,
+        parse_env = parse_call_timeout_millis,
         default = 30_000u64
     )]
-    call_timeout_ms: u64,
+    call_timeout_millis: u64,
     #[config(
         env = "AETHER_TRANSFORM_TIMEOUT_MS",
-        parse_env = parse_transform_timeout_ms,
+        parse_env = parse_transform_timeout_millis,
         default = 30_000u64
     )]
-    transform_timeout_ms: u64,
+    transform_timeout_millis: u64,
     #[config(
         env = "AETHER_TRANSFORM_MAX_OUTPUT_BYTES",
         parse_env = parse_transform_max_output_bytes,
@@ -215,16 +215,16 @@ struct ExecutorConfigLayer {
     transform_max_output_bytes: u64,
     #[config(
         env = "AETHER_DAG_RETENTION_COMPLETE_MS",
-        parse_env = parse_retention_complete_ms,
+        parse_env = parse_retention_complete_millis,
         default = 60_000u64
     )]
-    retention_complete_ms: u64,
+    retention_complete_millis: u64,
     #[config(
         env = "AETHER_DAG_RETENTION_FAILED_MS",
-        parse_env = parse_retention_failed_ms,
+        parse_env = parse_retention_failed_millis,
         default = 300_000u64
     )]
-    retention_failed_ms: u64,
+    retention_failed_millis: u64,
     /// Held as the raw string so `ExecutorConfig::from_env` can apply the
     /// soft `.parse().ok()` then fall back to available parallelism on an
     /// unset *or* unparseable value (a confique numeric field would
@@ -242,17 +242,17 @@ struct ExecutorConfigLayer {
 // variants land with the ADR-0090 §4 validation pass; hence the per-fn
 // `unnecessary_wraps` allow.
 
-/// Parse the per-`Call` timeout; unparseable → [`DEFAULT_CALL_TIMEOUT_MS`].
+/// Parse the per-`Call` timeout; unparseable → [`DEFAULT_CALL_TIMEOUT_MILLIS`].
 #[allow(clippy::unnecessary_wraps)]
-fn parse_call_timeout_ms(s: &str) -> Result<u64, Infallible> {
-    Ok(s.parse().unwrap_or(DEFAULT_CALL_TIMEOUT_MS))
+fn parse_call_timeout_millis(s: &str) -> Result<u64, Infallible> {
+    Ok(s.parse().unwrap_or(DEFAULT_CALL_TIMEOUT_MILLIS))
 }
 
 /// Parse the transform deadline; unparseable →
-/// [`DEFAULT_TRANSFORM_TIMEOUT_MS`].
+/// [`DEFAULT_TRANSFORM_TIMEOUT_MILLIS`].
 #[allow(clippy::unnecessary_wraps)]
-fn parse_transform_timeout_ms(s: &str) -> Result<u64, Infallible> {
-    Ok(s.parse().unwrap_or(DEFAULT_TRANSFORM_TIMEOUT_MS))
+fn parse_transform_timeout_millis(s: &str) -> Result<u64, Infallible> {
+    Ok(s.parse().unwrap_or(DEFAULT_TRANSFORM_TIMEOUT_MILLIS))
 }
 
 /// Parse the transform output cap; unparseable →
@@ -263,17 +263,17 @@ fn parse_transform_max_output_bytes(s: &str) -> Result<u64, Infallible> {
 }
 
 /// Parse the completed-DAG retention; unparseable →
-/// [`DEFAULT_RETENTION_COMPLETE_MS`].
+/// [`DEFAULT_RETENTION_COMPLETE_MILLIS`].
 #[allow(clippy::unnecessary_wraps)]
-fn parse_retention_complete_ms(s: &str) -> Result<u64, Infallible> {
-    Ok(s.parse().unwrap_or(DEFAULT_RETENTION_COMPLETE_MS))
+fn parse_retention_complete_millis(s: &str) -> Result<u64, Infallible> {
+    Ok(s.parse().unwrap_or(DEFAULT_RETENTION_COMPLETE_MILLIS))
 }
 
 /// Parse the failed-DAG retention; unparseable →
-/// [`DEFAULT_RETENTION_FAILED_MS`].
+/// [`DEFAULT_RETENTION_FAILED_MILLIS`].
 #[allow(clippy::unnecessary_wraps)]
-fn parse_retention_failed_ms(s: &str) -> Result<u64, Infallible> {
-    Ok(s.parse().unwrap_or(DEFAULT_RETENTION_FAILED_MS))
+fn parse_retention_failed_millis(s: &str) -> Result<u64, Infallible> {
+    Ok(s.parse().unwrap_or(DEFAULT_RETENTION_FAILED_MILLIS))
 }
 
 /// What a landed reply correlates to (ADR-0047 §4). Sources resolve a
@@ -317,7 +317,7 @@ struct InFlightTransform {
     output_kind_id: KindId,
     deadline: Instant,
     /// The deadline expressed in millis, for the timeout diagnostic.
-    timeout_ms: u64,
+    timeout_millis: u64,
 }
 
 /// The DAG executor. Holds every live + recently-terminal DAG plus the
@@ -373,12 +373,12 @@ impl Executor {
             pending: HashMap::new(),
             in_flight_calls: HashMap::new(),
             in_flight_transforms: HashMap::new(),
-            call_timeout: Duration::from_millis(config.call_timeout_ms),
-            transform_timeout: Duration::from_millis(config.transform_timeout_ms),
+            call_timeout: Duration::from_millis(config.call_timeout_millis),
+            transform_timeout: Duration::from_millis(config.transform_timeout_millis),
             transform_max_output_bytes: usize::try_from(config.transform_max_output_bytes)
                 .unwrap_or(usize::MAX),
-            retention_complete: Duration::from_millis(config.retention_complete_ms),
-            retention_failed: Duration::from_millis(config.retention_failed_ms),
+            retention_complete: Duration::from_millis(config.retention_complete_millis),
+            retention_failed: Duration::from_millis(config.retention_failed_millis),
             transform_registry: Arc::new(TransformRegistry::from_inventory()),
             transform_pool,
         }
@@ -724,7 +724,7 @@ impl Executor {
             KindId(<DagTransformDone as aether_data::Kind>::ID.0),
         );
         let timeout = node_timeout.map_or(self.transform_timeout, Duration::from_millis);
-        let timeout_ms = u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX);
+        let timeout_millis = u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX);
         self.in_flight_transforms.insert(
             job_id,
             InFlightTransform {
@@ -734,7 +734,7 @@ impl Executor {
                 content_id,
                 output_kind_id,
                 deadline: Instant::now() + timeout,
-                timeout_ms,
+                timeout_millis,
             },
         );
     }
@@ -1228,13 +1228,13 @@ impl Executor {
             .in_flight_transforms
             .iter()
             .filter(|(_, t)| now >= t.deadline)
-            .map(|(job, t)| (*job, t.dag_id, t.node_id, t.timeout_ms))
+            .map(|(job, t)| (*job, t.dag_id, t.node_id, t.timeout_millis))
             .collect();
-        for (job_id, dag_id, node_id, timeout_ms) in timed_out_transforms {
+        for (job_id, dag_id, node_id, timeout_millis) in timed_out_transforms {
             self.in_flight_transforms.remove(&job_id);
             self.transform_pool.forget(job_id);
             if let Some(state) = self.dags.get_mut(&dag_id) {
-                state.mark_failed(node_id, format!("timeout: {timeout_ms}ms"));
+                state.mark_failed(node_id, format!("timeout: {timeout_millis}ms"));
             }
         }
 
@@ -1373,11 +1373,12 @@ fn slot_inner_kind_id(registry: &Registry, cell: &aether_data::SchemaCell) -> Ki
 #[cfg(test)]
 mod config_tests {
     use super::{
-        DEFAULT_CALL_TIMEOUT_MS, DEFAULT_RETENTION_COMPLETE_MS, DEFAULT_RETENTION_FAILED_MS,
-        DEFAULT_TRANSFORM_MAX_OUTPUT_BYTES, DEFAULT_TRANSFORM_TIMEOUT_MS, ExecutorConfig,
-        ExecutorConfigLayer, default_pool_threads, parse_call_timeout_ms,
-        parse_retention_complete_ms, parse_retention_failed_ms, parse_transform_max_output_bytes,
-        parse_transform_timeout_ms,
+        DEFAULT_CALL_TIMEOUT_MILLIS, DEFAULT_RETENTION_COMPLETE_MILLIS,
+        DEFAULT_RETENTION_FAILED_MILLIS, DEFAULT_TRANSFORM_MAX_OUTPUT_BYTES,
+        DEFAULT_TRANSFORM_TIMEOUT_MILLIS, ExecutorConfig, ExecutorConfigLayer,
+        default_pool_threads, parse_call_timeout_millis, parse_retention_complete_millis,
+        parse_retention_failed_millis, parse_transform_max_output_bytes,
+        parse_transform_timeout_millis,
     };
 
     // ADR-0090: the confique migration is byte-identical to the prior
@@ -1387,30 +1388,30 @@ mod config_tests {
 
     #[test]
     fn parse_numbers_soft_fall_back_to_defaults() {
-        assert_eq!(parse_call_timeout_ms("100").unwrap(), 100);
+        assert_eq!(parse_call_timeout_millis("100").unwrap(), 100);
         assert_eq!(
-            parse_call_timeout_ms("nope").unwrap(),
-            DEFAULT_CALL_TIMEOUT_MS
+            parse_call_timeout_millis("nope").unwrap(),
+            DEFAULT_CALL_TIMEOUT_MILLIS
         );
-        assert_eq!(parse_transform_timeout_ms("200").unwrap(), 200);
+        assert_eq!(parse_transform_timeout_millis("200").unwrap(), 200);
         assert_eq!(
-            parse_transform_timeout_ms("nope").unwrap(),
-            DEFAULT_TRANSFORM_TIMEOUT_MS
+            parse_transform_timeout_millis("nope").unwrap(),
+            DEFAULT_TRANSFORM_TIMEOUT_MILLIS
         );
         assert_eq!(parse_transform_max_output_bytes("4096").unwrap(), 4096);
         assert_eq!(
             parse_transform_max_output_bytes("nope").unwrap(),
             DEFAULT_TRANSFORM_MAX_OUTPUT_BYTES
         );
-        assert_eq!(parse_retention_complete_ms("300").unwrap(), 300);
+        assert_eq!(parse_retention_complete_millis("300").unwrap(), 300);
         assert_eq!(
-            parse_retention_complete_ms("nope").unwrap(),
-            DEFAULT_RETENTION_COMPLETE_MS
+            parse_retention_complete_millis("nope").unwrap(),
+            DEFAULT_RETENTION_COMPLETE_MILLIS
         );
-        assert_eq!(parse_retention_failed_ms("400").unwrap(), 400);
+        assert_eq!(parse_retention_failed_millis("400").unwrap(), 400);
         assert_eq!(
-            parse_retention_failed_ms("nope").unwrap(),
-            DEFAULT_RETENTION_FAILED_MS
+            parse_retention_failed_millis("nope").unwrap(),
+            DEFAULT_RETENTION_FAILED_MILLIS
         );
     }
 
@@ -1423,15 +1424,24 @@ mod config_tests {
             .load()
             .expect("defaults load");
         let default = ExecutorConfig::default();
-        assert_eq!(layer.call_timeout_ms, DEFAULT_CALL_TIMEOUT_MS);
-        assert_eq!(layer.call_timeout_ms, default.call_timeout_ms);
-        assert_eq!(layer.transform_timeout_ms, DEFAULT_TRANSFORM_TIMEOUT_MS);
+        assert_eq!(layer.call_timeout_millis, DEFAULT_CALL_TIMEOUT_MILLIS);
+        assert_eq!(layer.call_timeout_millis, default.call_timeout_millis);
+        assert_eq!(
+            layer.transform_timeout_millis,
+            DEFAULT_TRANSFORM_TIMEOUT_MILLIS
+        );
         assert_eq!(
             layer.transform_max_output_bytes,
             DEFAULT_TRANSFORM_MAX_OUTPUT_BYTES
         );
-        assert_eq!(layer.retention_complete_ms, DEFAULT_RETENTION_COMPLETE_MS);
-        assert_eq!(layer.retention_failed_ms, DEFAULT_RETENTION_FAILED_MS);
+        assert_eq!(
+            layer.retention_complete_millis,
+            DEFAULT_RETENTION_COMPLETE_MILLIS
+        );
+        assert_eq!(
+            layer.retention_failed_millis,
+            DEFAULT_RETENTION_FAILED_MILLIS
+        );
         // Pool threads has no literal default — the layer field is `None`
         // when unset, resolved to available parallelism in `from_env`.
         assert_eq!(layer.pool_threads, None);

--- a/crates/aether-substrate/src/runtime/log_install.rs
+++ b/crates/aether-substrate/src/runtime/log_install.rs
@@ -18,7 +18,7 @@
 use aether_actor::Local;
 use aether_actor::log::{ActorLogRing, render_event};
 
-use super::now_unix_ms;
+use super::now_unix_millis;
 use std::io;
 use tracing::{Event, Subscriber};
 use tracing_subscriber::EnvFilter;
@@ -39,7 +39,7 @@ where
 {
     fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
         let (level, target, message) = render_event(event);
-        let timestamp = now_unix_ms();
+        let timestamp = now_unix_millis();
         // `try_with_mut` returns `Some` only when the chassis
         // dispatcher has stamped an actor's slots (in-actor branch).
         // Out-of-actor events drop here and leave `engine_logs`
@@ -64,7 +64,7 @@ pub fn emit_host_event(level: u32, target: &str, message: &str) {
     // skip the macro entirely and push directly to the actor's ring.
     // `EnvFilter` matched against the *host* target, not the guest's,
     // would otherwise drop the guest event on its way through.
-    let timestamp = now_unix_ms();
+    let timestamp = now_unix_millis();
     let target = target.to_owned();
     let message = message.to_owned();
     let level_u8 = level.min(4) as u8;

--- a/crates/aether-substrate/src/runtime/mod.rs
+++ b/crates/aether-substrate/src/runtime/mod.rs
@@ -14,7 +14,7 @@ pub use panic_hook::init_panic_hook;
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-pub(crate) fn now_unix_ms() -> u64 {
+pub(crate) fn now_unix_millis() -> u64 {
     SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| {
         #[allow(clippy::cast_possible_truncation)]
         let ms = d.as_millis() as u64;

--- a/crates/aether-substrate/src/runtime/panic_hook.rs
+++ b/crates/aether-substrate/src/runtime/panic_hook.rs
@@ -44,7 +44,7 @@ use aether_actor::Local;
 use aether_actor::log::ActorLogRing;
 use aether_kinds::LogEntry;
 
-use super::now_unix_ms;
+use super::now_unix_millis;
 
 /// Env var that forces backtrace capture without flipping
 /// `RUST_BACKTRACE` for the whole process (which would change every
@@ -96,7 +96,7 @@ fn make_hook(
         // failures — a panic during the panic hook is the worst-
         // case-scenario; we never want to obscure the original
         // payload by panicking again here.
-        let timestamp_unix_ms = now_unix_ms();
+        let timestamp_unix_ms = now_unix_millis();
         let thread = thread::current();
         let thread_name = thread.name().unwrap_or("<unnamed>").to_owned();
         let location = info.location().map_or_else(

--- a/crates/aether-substrate/src/scheduler/calibrate.rs
+++ b/crates/aether-substrate/src/scheduler/calibrate.rs
@@ -234,8 +234,8 @@ fn parse_cost_override(raw: Option<String>) -> Option<u64> {
 /// `actor_logs` on any box (especially the CI VM) to confirm the budget
 /// landed where intended. Called once at chassis boot.
 pub fn log_handoff_calibration() {
-    let cost_ns = handoff_cost_nanos();
-    let budget_ns =
+    let cost_nanos = handoff_cost_nanos();
+    let budget_nanos =
         u64::try_from(super::worker_deque::time_budget().as_nanos()).unwrap_or(u64::MAX);
     // Realized handoffs-per-budget on this box: `BUDGET_HANDOFF_MULTIPLIER`
     // in the common case, or off it when a rail / env override bound the
@@ -244,11 +244,11 @@ pub fn log_handoff_calibration() {
         clippy::cast_precision_loss,
         reason = "nanosecond counts are well within f64's exact-integer range; the ratio is a diagnostic, not load-bearing"
     )]
-    let realized_multiplier = budget_ns as f64 / cost_ns as f64;
+    let realized_multiplier = budget_nanos as f64 / cost_nanos as f64;
     tracing::info!(
         target: "aether_substrate::scheduler",
-        handoff_cost_ns = cost_ns,
-        budget_ns,
+        handoff_cost_nanos = cost_nanos,
+        budget_nanos,
         realized_multiplier,
         "keep-local time budget derived from the measured cross-worker handoff cost (iamacoffeepot/aether#1182)",
     );


### PR DESCRIPTION
Implements the 2026-06-09 naming-audit fixes:

- spells out two-letter time units (`_ms` -> `_millis`, `_ns` -> `_nanos`) across aether-substrate, aether-capabilities, and aether-substrate-bundle
- renames the type-in-name DSL parse helpers in aether-mesh (`as_f32`/`as_u32` -> `as_float`/`as_uint`)
- renames the under-named `HeadlessTimerCapability` -> `HeadlessTimerDriverCapability` (it implements the DriverCapability trait)

Pure renames, no behavior change. Wire-contract surfaces stay byte-stable — aether-kinds serde fields, confique config-layer field names, env-key constants, and error-string format keys are left untouched.

Closes #1523