### PR TITLE
flake(repo): triage timing-sensitive tests missing a mod heavy marker

### DIFF
--- a/crates/aether-capabilities/src/anthropic/cli.rs
+++ b/crates/aether-capabilities/src/anthropic/cli.rs
@@ -205,46 +205,52 @@ mod tests {
         assert_eq!(err, CLI_NOT_FOUND);
     }
 
-    /// A subprocess that outlives the deadline is killed + reaped and
-    /// surfaces as `TIMEOUT_SENTINEL` carrying the elapsed ms — well
-    /// under the child's nominal 5s sleep. The adapter always invokes
-    /// `<binary> --print --model <model> ...`, so the stand-in must be a
-    /// script that ignores its args and sleeps. We write a tiny shell
-    /// script to a temp file and point the adapter at it.
-    #[cfg(unix)]
-    #[test]
-    fn slow_binary_times_out_and_is_reaped() {
-        use std::os::unix::fs::PermissionsExt;
-        use std::{env, fs, process};
+    /// Real subprocess spawn + reap under a 50ms deadline, so it lives in
+    /// `mod heavy` for the `serial-heavy` nextest group (issue 1522).
+    mod heavy {
+        use super::*;
 
-        let mut script = env::temp_dir();
-        script.push(format!("aether-cli-timeout-{}.sh", process::id()));
-        // Ignore every arg, sleep 5s. A ~50ms deadline must fire first.
-        fs::write(&script, "#!/bin/sh\nsleep 5\n").expect("write stand-in script");
-        fs::set_permissions(&script, fs::Permissions::from_mode(0o755))
-            .expect("chmod stand-in script");
+        /// A subprocess that outlives the deadline is killed + reaped and
+        /// surfaces as `TIMEOUT_SENTINEL` carrying the elapsed ms — well
+        /// under the child's nominal 5s sleep. The adapter always invokes
+        /// `<binary> --print --model <model> ...`, so the stand-in must be a
+        /// script that ignores its args and sleeps. We write a tiny shell
+        /// script to a temp file and point the adapter at it.
+        #[cfg(unix)]
+        #[test]
+        fn slow_binary_times_out_and_is_reaped() {
+            use std::os::unix::fs::PermissionsExt;
+            use std::{env, fs, process};
 
-        let adapter = ClaudeCliAdapter::new(
-            script.to_string_lossy().into_owned(),
-            Duration::from_millis(50),
-        );
-        let started = Instant::now();
-        let err = adapter
-            .cli_send(&req())
-            .expect_err("a slow binary must time out");
+            let mut script = env::temp_dir();
+            script.push(format!("aether-cli-timeout-{}.sh", process::id()));
+            // Ignore every arg, sleep 5s. A ~50ms deadline must fire first.
+            fs::write(&script, "#!/bin/sh\nsleep 5\n").expect("write stand-in script");
+            fs::set_permissions(&script, fs::Permissions::from_mode(0o755))
+                .expect("chmod stand-in script");
 
-        let _ = fs::remove_file(&script);
+            let adapter = ClaudeCliAdapter::new(
+                script.to_string_lossy().into_owned(),
+                Duration::from_millis(50),
+            );
+            let started = Instant::now();
+            let err = adapter
+                .cli_send(&req())
+                .expect_err("a slow binary must time out");
 
-        assert!(
-            err.starts_with(TIMEOUT_SENTINEL),
-            "expected timeout sentinel, got {err:?}",
-        );
-        // The deadline fired well under the child's 5s lifetime, which
-        // also implies the kill returned (the child was reaped).
-        assert!(
-            started.elapsed() < Duration::from_secs(2),
-            "timeout took too long: {:?}",
-            started.elapsed(),
-        );
+            let _ = fs::remove_file(&script);
+
+            assert!(
+                err.starts_with(TIMEOUT_SENTINEL),
+                "expected timeout sentinel, got {err:?}",
+            );
+            // The deadline fired well under the child's 5s lifetime, which
+            // also implies the kill returned (the child was reaped).
+            assert!(
+                started.elapsed() < Duration::from_secs(2),
+                "timeout took too long: {:?}",
+                started.elapsed(),
+            );
+        }
     }
 }

--- a/crates/aether-capabilities/src/dag/tests.rs
+++ b/crates/aether-capabilities/src/dag/tests.rs
@@ -572,7 +572,6 @@ fn dag_executor_status_reports_running() {
 /// With tiny retention windows, a completed DAG is observable as
 /// `Complete`, then reaped — after which `status` reports the unknown-dag
 /// shape (`Failed { error: "unknown dag .." }`).
-#[test]
 fn dag_executor_status_reports_complete_then_reaps() {
     // SAFETY: nextest runs each test in its own process, so the env set
     // here doesn't race sibling tests.
@@ -714,7 +713,6 @@ fn dag_executor_call_inherited_worker_counts_toward_settlement() {
 /// Call to a cap that never settles (holds the chain open forever): with
 /// a tiny per-`Call` timeout the node fails rather than buffering forever
 /// or truncating to a partial bundle.
-#[test]
 fn dag_executor_call_times_out_nonsettling_cap() {
     // SAFETY: nextest runs each test in its own process.
     unsafe {
@@ -908,7 +906,6 @@ fn number_transform_dag(tx: aether_data::TransformId, value: u64) -> DagDescript
 /// source → `double` transform → observer. The observer receives the
 /// doubled value resolved inline; the DAG reaches `Complete` (ADR-0048
 /// §3 invocation path).
-#[test]
 fn transform_invoke_resolves_handle() {
     let (registry, mailer, rx) = fresh_substrate_with_rx();
     let recorder: Recorder<TestNumberObserved> = Arc::new(Mutex::new(Vec::new()));
@@ -988,7 +985,6 @@ fn transform_panic_fails_node() {
 /// { error: "timeout: ..." }`; the thread orphans (the executor
 /// continues). The fixture releases the gate afterward so the pool
 /// joins cleanly (ADR-0048 §6).
-#[test]
 fn transform_timeout_fails_node() {
     SLOW_TRANSFORM_GATE.store(false, Ordering::Release);
     // SAFETY: nextest runs each test in its own process.
@@ -1169,6 +1165,26 @@ mod heavy {
     #[test]
     fn transform_skips_invoke_on_cache_hit() {
         super::transform_skips_invoke_on_cache_hit();
+    }
+
+    #[test]
+    fn dag_executor_status_reports_complete_then_reaps() {
+        super::dag_executor_status_reports_complete_then_reaps();
+    }
+
+    #[test]
+    fn dag_executor_call_times_out_nonsettling_cap() {
+        super::dag_executor_call_times_out_nonsettling_cap();
+    }
+
+    #[test]
+    fn transform_invoke_resolves_handle() {
+        super::transform_invoke_resolves_handle();
+    }
+
+    #[test]
+    fn transform_timeout_fails_node() {
+        super::transform_timeout_fails_node();
     }
 }
 

--- a/crates/aether-capabilities/src/engine/proxy.rs
+++ b/crates/aether-capabilities/src/engine/proxy.rs
@@ -758,7 +758,9 @@ mod tests {
     /// reply-to, and observe the echoed value land on the sink — proof
     /// the proxy forwards as a `Call` and routes the `ReplyEvent` back
     /// to the original sender.
-    #[test]
+    /// Body lives here to share the parent fixtures; the `#[test]` wrapper
+    /// is in `mod heavy` (issue 1522 — boots a TCP RPC server + proxy
+    /// threads and polls a 5s cross-thread round-trip).
     fn forward_round_trips_reply_back_to_sender() {
         let (registry, mailer) = fresh_substrate();
         let recorded: Arc<Mutex<Option<u64>>> = Arc::new(Mutex::new(None));
@@ -988,6 +990,14 @@ mod tests {
     /// `serial-heavy` nextest group (`.config/nextest.toml`).
     mod heavy {
         use super::*;
+
+        /// `#[test]` wrapper for the parent forward-round-trip body, which
+        /// boots a TCP RPC server + proxy threads and polls a 5s
+        /// cross-thread deadline (issue 1522).
+        #[test]
+        fn forward_round_trips_reply_back_to_sender() {
+            super::forward_round_trips_reply_back_to_sender();
+        }
 
         /// A wedged engine (handshakes, then never answers a heartbeat
         /// `Ping`) is evicted: after `miss_limit` missed pongs the proxy

--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -249,170 +249,179 @@ mod native {
             Source::to(SourceAddr::Session(SessionToken(Uuid::from_u128(0xfeed))))
         }
 
-        /// End-to-end through the cap: boot it via `with_actor`, push a
-        /// `HandlePublish` mail at the registered mailbox, the dispatcher
-        /// thread runs the macro-emitted `NativeDispatch::__aether_dispatch_envelope`
-        /// which calls `on_publish`, the reply lands on the hub-outbound
-        /// channel via `ctx.reply(&HandlePublishResult::Ok)` →
-        /// `Mailer::send_reply` → `outbound.send_reply`.
-        #[test]
-        fn capability_routes_publish_through_dispatcher_thread() {
-            let (store, mailer, registry, rx) = fresh_substrate();
+        /// These boot the cap on its dispatcher thread and sleep-poll the
+        /// hub-outbound channel under a multi-second deadline (one joins the
+        /// dispatcher thread), so they live in `mod heavy` for the
+        /// `serial-heavy` nextest group (issue 1522).
+        mod heavy {
+            use super::*;
 
-            let chassis = boot_test_chassis_with::<HandleCapability>(&registry, &mailer, ());
+            /// End-to-end through the cap: boot it via `with_actor`, push a
+            /// `HandlePublish` mail at the registered mailbox, the dispatcher
+            /// thread runs the macro-emitted `NativeDispatch::__aether_dispatch_envelope`
+            /// which calls `on_publish`, the reply lands on the hub-outbound
+            /// channel via `ctx.reply(&HandlePublishResult::Ok)` →
+            /// `Mailer::send_reply` → `outbound.send_reply`.
+            #[test]
+            fn capability_routes_publish_through_dispatcher_thread() {
+                let (store, mailer, registry, rx) = fresh_substrate();
 
-            let id = registry
-                .lookup(HandleCapability::NAMESPACE)
-                .expect("mailbox registered");
-            let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("entry") else {
-                panic!("expected mailbox entry");
-            };
+                let chassis = boot_test_chassis_with::<HandleCapability>(&registry, &mailer, ());
 
-            let req = HandlePublish {
-                kind_id: KindId(0xCAFE),
-                bytes: vec![1, 2, 3, 4, 5],
-            };
-            let bytes = postcard::to_allocvec(&req)
-                .expect("test setup: HandlePublish serializes via postcard");
-            handler.enqueue(OwnedDispatch::disarmed(
-                <HandlePublish as Kind>::ID,
-                "aether.handle.publish".to_owned(),
-                None,
-                session_reply_to(),
-                MailRef::from(bytes),
-                1,
-                MailId::NONE,
-                MailId::NONE,
-                None,
-                Nanos(0),
-                0,
-                aether_data::MailboxId(0),
-            ));
+                let id = registry
+                    .lookup(HandleCapability::NAMESPACE)
+                    .expect("mailbox registered");
+                let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("entry") else {
+                    panic!("expected mailbox entry");
+                };
 
-            let deadline = Instant::now() + Duration::from_secs(2);
-            let frame = loop {
-                if let Ok(f) = rx.try_recv() {
-                    break f;
-                }
+                let req = HandlePublish {
+                    kind_id: KindId(0xCAFE),
+                    bytes: vec![1, 2, 3, 4, 5],
+                };
+                let bytes = postcard::to_allocvec(&req)
+                    .expect("test setup: HandlePublish serializes via postcard");
+                handler.enqueue(OwnedDispatch::disarmed(
+                    <HandlePublish as Kind>::ID,
+                    "aether.handle.publish".to_owned(),
+                    None,
+                    session_reply_to(),
+                    MailRef::from(bytes),
+                    1,
+                    MailId::NONE,
+                    MailId::NONE,
+                    None,
+                    Nanos(0),
+                    0,
+                    aether_data::MailboxId(0),
+                ));
+
+                let deadline = Instant::now() + Duration::from_secs(2);
+                let frame = loop {
+                    if let Ok(f) = rx.try_recv() {
+                        break f;
+                    }
+                    assert!(
+                        Instant::now() < deadline,
+                        "publish reply did not arrive within deadline"
+                    );
+                    thread::sleep(Duration::from_millis(5));
+                };
+                let payload = match frame {
+                    EgressEvent::ToSession { payload, .. } => payload,
+                    other => panic!("expected ToSession egress, got {other:?}"),
+                };
+                let result: HandlePublishResult = postcard::from_bytes(&payload)
+                    .expect("test setup: HandlePublishResult decodes via postcard");
+                let HandlePublishResult::Ok {
+                    kind_id,
+                    id: handle_id,
+                } = result
+                else {
+                    panic!("expected Ok, got {result:?}");
+                };
+                assert_eq!(kind_id, KindId(0xCAFE));
+                assert_ne!(handle_id, HandleId(0));
+                let (stored_kind, stored_bytes) = store
+                    .get(handle_id)
+                    .expect("test setup: stored handle should be retrievable");
+                assert_eq!(stored_kind, KindId(0xCAFE));
+                assert_eq!(stored_bytes, vec![1, 2, 3, 4, 5]);
+
+                drop(chassis);
+            }
+
+            /// `aether.handle.describe` flows through the cap and returns a
+            /// `HandleDescribeResult` whose counts match the store contents
+            /// (ADR-0049 §10).
+            #[test]
+            fn capability_describe_summarizes_store() {
+                use aether_kinds::{HandleDescribe, HandleDescribeResult};
+
+                let (store, mailer, registry, rx) = fresh_substrate();
+                // Pre-populate the store: 3 entries, 1 pinned.
+                store
+                    .put(HandleId(1), KindId(0xA), vec![0u8; 100])
+                    .expect("put 1");
+                store
+                    .put(HandleId(2), KindId(0xB), vec![0u8; 200])
+                    .expect("put 2");
+                store
+                    .put(HandleId(3), KindId(0xC), vec![0u8; 50])
+                    .expect("put 3");
+                store.pin(HandleId(2));
+
+                let chassis = boot_test_chassis_with::<HandleCapability>(&registry, &mailer, ());
+
+                let id = registry
+                    .lookup(HandleCapability::NAMESPACE)
+                    .expect("mailbox registered");
+                let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("entry") else {
+                    panic!("expected mailbox entry");
+                };
+
+                let req = HandleDescribe { max: 16 };
+                let bytes = postcard::to_allocvec(&req).expect("HandleDescribe serializes");
+                handler.enqueue(OwnedDispatch::disarmed(
+                    <HandleDescribe as Kind>::ID,
+                    "aether.handle.describe".to_owned(),
+                    None,
+                    session_reply_to(),
+                    MailRef::from(bytes),
+                    1,
+                    MailId::NONE,
+                    MailId::NONE,
+                    None,
+                    Nanos(0),
+                    0,
+                    aether_data::MailboxId(0),
+                ));
+
+                let deadline = Instant::now() + Duration::from_secs(2);
+                let frame = loop {
+                    if let Ok(f) = rx.try_recv() {
+                        break f;
+                    }
+                    assert!(Instant::now() < deadline, "describe reply did not arrive");
+                    thread::sleep(Duration::from_millis(5));
+                };
+                let payload = match frame {
+                    EgressEvent::ToSession { payload, .. } => payload,
+                    other => panic!("expected ToSession egress, got {other:?}"),
+                };
+                let result: HandleDescribeResult =
+                    postcard::from_bytes(&payload).expect("HandleDescribeResult decodes");
+                assert_eq!(result.total_entries, 3);
+                assert_eq!(result.in_memory_entries, 3);
+                assert_eq!(result.pinned_entries, 1);
+                assert_eq!(result.in_memory_bytes, 350);
+                // top_by_size descending: the 200-byte entry leads.
+                assert_eq!(result.top_by_size.first().map(|s| s.bytes_len), Some(200));
+
+                drop(chassis);
+            }
+
+            /// Channel-drop shutdown: drop the chassis, the cap's dispatcher
+            /// thread exits within a generous deadline.
+            #[test]
+            fn shutdown_joins_dispatcher_thread() {
+                let (_store, mailer, registry, _rx) = fresh_substrate();
+
+                //noinspection DuplicatedCode
+                let chassis =
+                    Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+                        .with_actor::<HandleCapability>(())
+                        .build_passive()
+                        .expect("capability boots");
+
+                let start = Instant::now();
+                drop(chassis);
+                let elapsed = start.elapsed();
                 assert!(
-                    Instant::now() < deadline,
-                    "publish reply did not arrive within deadline"
+                    elapsed < Duration::from_millis(500),
+                    "shutdown should complete promptly via channel-drop (took {elapsed:?})"
                 );
-                thread::sleep(Duration::from_millis(5));
-            };
-            let payload = match frame {
-                EgressEvent::ToSession { payload, .. } => payload,
-                other => panic!("expected ToSession egress, got {other:?}"),
-            };
-            let result: HandlePublishResult = postcard::from_bytes(&payload)
-                .expect("test setup: HandlePublishResult decodes via postcard");
-            let HandlePublishResult::Ok {
-                kind_id,
-                id: handle_id,
-            } = result
-            else {
-                panic!("expected Ok, got {result:?}");
-            };
-            assert_eq!(kind_id, KindId(0xCAFE));
-            assert_ne!(handle_id, HandleId(0));
-            let (stored_kind, stored_bytes) = store
-                .get(handle_id)
-                .expect("test setup: stored handle should be retrievable");
-            assert_eq!(stored_kind, KindId(0xCAFE));
-            assert_eq!(stored_bytes, vec![1, 2, 3, 4, 5]);
-
-            drop(chassis);
-        }
-
-        /// `aether.handle.describe` flows through the cap and returns a
-        /// `HandleDescribeResult` whose counts match the store contents
-        /// (ADR-0049 §10).
-        #[test]
-        fn capability_describe_summarizes_store() {
-            use aether_kinds::{HandleDescribe, HandleDescribeResult};
-
-            let (store, mailer, registry, rx) = fresh_substrate();
-            // Pre-populate the store: 3 entries, 1 pinned.
-            store
-                .put(HandleId(1), KindId(0xA), vec![0u8; 100])
-                .expect("put 1");
-            store
-                .put(HandleId(2), KindId(0xB), vec![0u8; 200])
-                .expect("put 2");
-            store
-                .put(HandleId(3), KindId(0xC), vec![0u8; 50])
-                .expect("put 3");
-            store.pin(HandleId(2));
-
-            let chassis = boot_test_chassis_with::<HandleCapability>(&registry, &mailer, ());
-
-            let id = registry
-                .lookup(HandleCapability::NAMESPACE)
-                .expect("mailbox registered");
-            let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("entry") else {
-                panic!("expected mailbox entry");
-            };
-
-            let req = HandleDescribe { max: 16 };
-            let bytes = postcard::to_allocvec(&req).expect("HandleDescribe serializes");
-            handler.enqueue(OwnedDispatch::disarmed(
-                <HandleDescribe as Kind>::ID,
-                "aether.handle.describe".to_owned(),
-                None,
-                session_reply_to(),
-                MailRef::from(bytes),
-                1,
-                MailId::NONE,
-                MailId::NONE,
-                None,
-                Nanos(0),
-                0,
-                aether_data::MailboxId(0),
-            ));
-
-            let deadline = Instant::now() + Duration::from_secs(2);
-            let frame = loop {
-                if let Ok(f) = rx.try_recv() {
-                    break f;
-                }
-                assert!(Instant::now() < deadline, "describe reply did not arrive");
-                thread::sleep(Duration::from_millis(5));
-            };
-            let payload = match frame {
-                EgressEvent::ToSession { payload, .. } => payload,
-                other => panic!("expected ToSession egress, got {other:?}"),
-            };
-            let result: HandleDescribeResult =
-                postcard::from_bytes(&payload).expect("HandleDescribeResult decodes");
-            assert_eq!(result.total_entries, 3);
-            assert_eq!(result.in_memory_entries, 3);
-            assert_eq!(result.pinned_entries, 1);
-            assert_eq!(result.in_memory_bytes, 350);
-            // top_by_size descending: the 200-byte entry leads.
-            assert_eq!(result.top_by_size.first().map(|s| s.bytes_len), Some(200));
-
-            drop(chassis);
-        }
-
-        /// Channel-drop shutdown: drop the chassis, the cap's dispatcher
-        /// thread exits within a generous deadline.
-        #[test]
-        fn shutdown_joins_dispatcher_thread() {
-            let (_store, mailer, registry, _rx) = fresh_substrate();
-
-            //noinspection DuplicatedCode
-            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-                .with_actor::<HandleCapability>(())
-                .build_passive()
-                .expect("capability boots");
-
-            let start = Instant::now();
-            drop(chassis);
-            let elapsed = start.elapsed();
-            assert!(
-                elapsed < Duration::from_millis(500),
-                "shutdown should complete promptly via channel-drop (took {elapsed:?})"
-            );
+            }
         }
 
         /// Builder rejects a duplicate claim if the well-known mailbox

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -1096,403 +1096,414 @@ fn correlation_of(event: &EgressEvent) -> Option<u64> {
 #[allow(clippy::too_many_lines, clippy::significant_drop_tightening)]
 mod tests {
     use super::*;
-    use crate::test_bench::BenchOp;
-    use std::thread;
-    use std::time::Instant;
 
-    /// Boot, advance one tick, capture, sanity-check the PNG.
-    /// The default scene is empty so the captured frame is the
-    /// background-clear color uniformly. The test asserts the PNG
-    /// is well-formed; deeper visual assertions land in the scenario
-    /// library.
-    ///
-    /// The unit test lets `TestBench::start_with_size` fail naturally
-    /// on driverless runners and skips on any boot error, rather than
-    /// pulling in the `test_helpers` wgpu probe — keeping the lib
-    /// unit test self-contained (the same skip semantics, keyed off
-    /// the boot result rather than a separate adapter probe).
-    #[test]
-    fn boot_advance_capture_round_trip() {
-        let mut tb = match TestBench::start_with_size(64, 48) {
-            Ok(tb) => tb,
-            Err(e) => {
-                eprintln!("skipping: TestBench boot failed (likely no wgpu adapter): {e}");
-                return;
-            }
-        };
-        let result = tb
-            .execute(vec![
-                ("tick", BenchOp::advance(1)),
-                ("snap", BenchOp::capture()),
-            ])
-            .expect("advance + capture");
-        let png = result.captured("snap").expect("snap step ran");
-        assert!(
-            png.starts_with(&[0x89, 0x50, 0x4E, 0x47]),
-            "captured bytes are not a PNG: first 8 bytes={:?}",
-            &png.iter().take(8).copied().collect::<Vec<u8>>(),
-        );
-    }
+    /// Every `TestBench` test boots a full multi-worker chassis (offscreen
+    /// wgpu), so they live in `mod heavy` for the `serial-heavy` nextest
+    /// group (issue 1522). Driverless boxes still skip on boot error.
+    mod heavy {
+        use super::*;
+        use crate::test_bench::BenchOp;
+        use std::thread;
+        use std::time::Instant;
 
-    /// iamacoffeepot/aether#1273: `on_capture_frame` parks the request
-    /// on the capture queue and returns immediately — the reply happens
-    /// later on the chassis main thread. ADR-0086 §12 says deferred
-    /// replies MUST hold-open against the trace root; without that hold
-    /// `Settled{root}` fires before the reply lands and the wire `Call`
-    /// driving the MCP tool ends with zero collected reply events.
-    ///
-    /// This test sends `CaptureFrame` via `BenchOp::send_and_await` (the
-    /// shape the issue's regression test calls for) and asserts the
-    /// reply decodes to `CaptureFrameResult::Ok { png: <non-empty> }`.
-    /// The PNG comes back through the loopback's `EgressEvent::ToSession`
-    /// — same correlation-id round-trip the MCP harness uses, but
-    /// in-process.
-    #[test]
-    fn capture_frame_send_and_await_returns_png() {
-        let mut tb = match TestBench::start_with_size(64, 48) {
-            Ok(tb) => tb,
-            Err(e) => {
-                eprintln!("skipping: TestBench boot failed (likely no wgpu adapter): {e}");
-                return;
+        /// Boot, advance one tick, capture, sanity-check the PNG.
+        /// The default scene is empty so the captured frame is the
+        /// background-clear color uniformly. The test asserts the PNG
+        /// is well-formed; deeper visual assertions land in the scenario
+        /// library.
+        ///
+        /// The unit test lets `TestBench::start_with_size` fail naturally
+        /// on driverless runners and skips on any boot error, rather than
+        /// pulling in the `test_helpers` wgpu probe — keeping the lib
+        /// unit test self-contained (the same skip semantics, keyed off
+        /// the boot result rather than a separate adapter probe).
+        #[test]
+        fn boot_advance_capture_round_trip() {
+            let mut tb = match TestBench::start_with_size(64, 48) {
+                Ok(tb) => tb,
+                Err(e) => {
+                    eprintln!("skipping: TestBench boot failed (likely no wgpu adapter): {e}");
+                    return;
+                }
+            };
+            let result = tb
+                .execute(vec![
+                    ("tick", BenchOp::advance(1)),
+                    ("snap", BenchOp::capture()),
+                ])
+                .expect("advance + capture");
+            let png = result.captured("snap").expect("snap step ran");
+            assert!(
+                png.starts_with(&[0x89, 0x50, 0x4E, 0x47]),
+                "captured bytes are not a PNG: first 8 bytes={:?}",
+                &png.iter().take(8).copied().collect::<Vec<u8>>(),
+            );
+        }
+
+        /// iamacoffeepot/aether#1273: `on_capture_frame` parks the request
+        /// on the capture queue and returns immediately — the reply happens
+        /// later on the chassis main thread. ADR-0086 §12 says deferred
+        /// replies MUST hold-open against the trace root; without that hold
+        /// `Settled{root}` fires before the reply lands and the wire `Call`
+        /// driving the MCP tool ends with zero collected reply events.
+        ///
+        /// This test sends `CaptureFrame` via `BenchOp::send_and_await` (the
+        /// shape the issue's regression test calls for) and asserts the
+        /// reply decodes to `CaptureFrameResult::Ok { png: <non-empty> }`.
+        /// The PNG comes back through the loopback's `EgressEvent::ToSession`
+        /// — same correlation-id round-trip the MCP harness uses, but
+        /// in-process.
+        #[test]
+        fn capture_frame_send_and_await_returns_png() {
+            let mut tb = match TestBench::start_with_size(64, 48) {
+                Ok(tb) => tb,
+                Err(e) => {
+                    eprintln!("skipping: TestBench boot failed (likely no wgpu adapter): {e}");
+                    return;
+                }
+            };
+            let result = tb
+                .execute(vec![
+                    ("tick", BenchOp::advance(1)),
+                    (
+                        "capture",
+                        BenchOp::send_and_await(
+                            RenderCapability::NAMESPACE,
+                            &CaptureFrame {
+                                mails: Vec::new(),
+                                after_mails: Vec::new(),
+                            },
+                        ),
+                    ),
+                ])
+                .expect("advance + send_and_await(CaptureFrame)");
+            let reply: CaptureFrameResult = result
+                .reply("capture")
+                .expect("capture step replied with CaptureFrameResult");
+            match reply {
+                CaptureFrameResult::Ok { png } => {
+                    assert!(
+                        png.starts_with(&[0x89, 0x50, 0x4E, 0x47]),
+                        "captured bytes are not a PNG: first 8 bytes={:?}",
+                        &png.iter().take(8).copied().collect::<Vec<u8>>(),
+                    );
+                }
+                CaptureFrameResult::Err { error } => {
+                    panic!("capture_frame replied Err: {error}");
+                }
             }
-        };
-        let result = tb
-            .execute(vec![
-                ("tick", BenchOp::advance(1)),
+        }
+
+        /// Issue iamacoffeepot/aether#723: chassis-source ticks are minted
+        /// via `push_chassis_root_mail`, and the input cap fanout
+        /// propagates `(root, parent_mail)` from the inbound through
+        /// `NativeCtx::fanout` so each subscriber-bound copy lands in the
+        /// same causal chain. Verified by registering a closure-bound
+        /// mailbox, subscribing it to ticks, advancing one tick, and
+        /// asserting the captured `MailDispatch` carries non-default root +
+        /// parent.
+        #[test]
+        fn tick_fanout_propagates_chassis_root_lineage() {
+            use aether_data::{Kind as DataKind, MailId};
+            use aether_kinds::LifecycleSubscribe;
+            use aether_substrate::mail::registry::MailDispatch;
+            use std::sync::Mutex;
+
+            type CapturedRow = (MailId, MailId, Option<MailId>);
+
+            let mut tb = match TestBench::start_with_size(64, 48) {
+                Ok(tb) => tb,
+                Err(e) => {
+                    eprintln!("skipping: TestBench boot failed (likely no wgpu adapter): {e}");
+                    return;
+                }
+            };
+
+            // Register a synchronous closure mailbox that captures the
+            // lineage of every mail it receives. `register_inline` is the
+            // correct variant: the handler does immediate work (push into
+            // a captured Vec) rather than enqueueing onto a downstream
+            // inbox, so the producer-side `Received`/`Finished` bracket
+            // belongs on the call site. `validate_subscriber_mailbox`
+            // accepts both `Inbox` and `Inline` so the input cap's
+            // subscribe path still admits this mailbox. Pre-#845 this
+            // used `register_inbox` and the substrate's `run_frame`
+            // silently swallowed the resulting in_flight leak; strict
+            // propagation surfaces the variant mismatch as a
+            // `SettlementTimeout`, which is the right shape — the
+            // handler that owns the bracket gets to advertise its
+            // contract via the variant choice.
+            let captured: Arc<Mutex<Vec<CapturedRow>>> = Arc::new(Mutex::new(Vec::new()));
+            let captured_for_handler = Arc::clone(&captured);
+            let subscriber_mbox = tb.registry.register_inline(
+                "issue_723_test_subscriber",
+                Arc::new(move |dispatch: MailDispatch<'_>| {
+                    captured_for_handler
+                        .lock()
+                        .expect("test setup: captured mutex is never poisoned")
+                        .push((dispatch.mail_id, dispatch.root, dispatch.parent_mail));
+                }),
+            );
+
+            // Subscribe the closure mailbox to the `Tick` lifecycle stage
+            // (goes through the lifecycle cap's on_subscribe handler), then
+            // advance one tick. The advance issues a `LifecycleAdvance` whose
+            // chain root the lifecycle cap threads through
+            // `broadcast_to_subscribers` (`send_envelope_traced`) to every
+            // stage subscriber (issue 723 lineage, ADR-0082 §6). Sequencing
+            // both through `execute` settles the subscribe before the tick
+            // fires.
+            tb.execute(vec![
                 (
-                    "capture",
-                    BenchOp::send_and_await(
-                        RenderCapability::NAMESPACE,
-                        &CaptureFrame {
-                            mails: Vec::new(),
-                            after_mails: Vec::new(),
+                    "subscribe",
+                    BenchOp::send_mail(
+                        "aether.lifecycle",
+                        &LifecycleSubscribe {
+                            stage: Tick::ID.0,
+                            mailbox: subscriber_mbox.0,
                         },
                     ),
                 ),
+                ("advance", BenchOp::advance(1)),
             ])
-            .expect("advance + send_and_await(CaptureFrame)");
-        let reply: CaptureFrameResult = result
-            .reply("capture")
-            .expect("capture step replied with CaptureFrameResult");
-        match reply {
-            CaptureFrameResult::Ok { png } => {
-                assert!(
-                    png.starts_with(&[0x89, 0x50, 0x4E, 0x47]),
-                    "captured bytes are not a PNG: first 8 bytes={:?}",
-                    &png.iter().take(8).copied().collect::<Vec<u8>>(),
-                );
-            }
-            CaptureFrameResult::Err { error } => {
-                panic!("capture_frame replied Err: {error}");
-            }
-        }
-    }
+            .expect("subscribe + advance");
 
-    /// Issue iamacoffeepot/aether#723: chassis-source ticks are minted
-    /// via `push_chassis_root_mail`, and the input cap fanout
-    /// propagates `(root, parent_mail)` from the inbound through
-    /// `NativeCtx::fanout` so each subscriber-bound copy lands in the
-    /// same causal chain. Verified by registering a closure-bound
-    /// mailbox, subscribing it to ticks, advancing one tick, and
-    /// asserting the captured `MailDispatch` carries non-default root +
-    /// parent.
-    #[test]
-    fn tick_fanout_propagates_chassis_root_lineage() {
-        use aether_data::{Kind as DataKind, MailId};
-        use aether_kinds::LifecycleSubscribe;
-        use aether_substrate::mail::registry::MailDispatch;
-        use std::sync::Mutex;
-
-        type CapturedRow = (MailId, MailId, Option<MailId>);
-
-        let mut tb = match TestBench::start_with_size(64, 48) {
-            Ok(tb) => tb,
-            Err(e) => {
-                eprintln!("skipping: TestBench boot failed (likely no wgpu adapter): {e}");
-                return;
-            }
-        };
-
-        // Register a synchronous closure mailbox that captures the
-        // lineage of every mail it receives. `register_inline` is the
-        // correct variant: the handler does immediate work (push into
-        // a captured Vec) rather than enqueueing onto a downstream
-        // inbox, so the producer-side `Received`/`Finished` bracket
-        // belongs on the call site. `validate_subscriber_mailbox`
-        // accepts both `Inbox` and `Inline` so the input cap's
-        // subscribe path still admits this mailbox. Pre-#845 this
-        // used `register_inbox` and the substrate's `run_frame`
-        // silently swallowed the resulting in_flight leak; strict
-        // propagation surfaces the variant mismatch as a
-        // `SettlementTimeout`, which is the right shape — the
-        // handler that owns the bracket gets to advertise its
-        // contract via the variant choice.
-        let captured: Arc<Mutex<Vec<CapturedRow>>> = Arc::new(Mutex::new(Vec::new()));
-        let captured_for_handler = Arc::clone(&captured);
-        let subscriber_mbox = tb.registry.register_inline(
-            "issue_723_test_subscriber",
-            Arc::new(move |dispatch: MailDispatch<'_>| {
-                captured_for_handler
-                    .lock()
-                    .expect("test setup: captured mutex is never poisoned")
-                    .push((dispatch.mail_id, dispatch.root, dispatch.parent_mail));
-            }),
-        );
-
-        // Subscribe the closure mailbox to the `Tick` lifecycle stage
-        // (goes through the lifecycle cap's on_subscribe handler), then
-        // advance one tick. The advance issues a `LifecycleAdvance` whose
-        // chain root the lifecycle cap threads through
-        // `broadcast_to_subscribers` (`send_envelope_traced`) to every
-        // stage subscriber (issue 723 lineage, ADR-0082 §6). Sequencing
-        // both through `execute` settles the subscribe before the tick
-        // fires.
-        tb.execute(vec![
-            (
-                "subscribe",
-                BenchOp::send_mail(
-                    "aether.lifecycle",
-                    &LifecycleSubscribe {
-                        stage: Tick::ID.0,
-                        mailbox: subscriber_mbox.0,
-                    },
-                ),
-            ),
-            ("advance", BenchOp::advance(1)),
-        ])
-        .expect("subscribe + advance");
-
-        let captured = captured
-            .lock()
-            .expect("test setup: captured mutex is never poisoned");
-        assert!(
-            !captured.is_empty(),
-            "subscriber received no mail — fanout never reached it",
-        );
-        let (mail_id, root, parent) = captured[0];
-        // Issue 723 fix: each fanned-out copy gets its own MailId, but
-        // the root is inherited from the chassis-root tick and the
-        // parent_mail points at it. Pre-fix both would be MailId::NONE
-        // (orphaned: ctx.in_flight was NONE because the tick used
-        // bare push, AND the fanout used bare push too).
-        assert_ne!(
-            root,
-            MailId::NONE,
-            "fanned-out copy should inherit a non-default root"
-        );
-        assert!(
-            parent.is_some_and(|p| p != MailId::NONE),
-            "fanned-out copy should carry a non-default parent_mail (got {parent:?})",
-        );
-        // The fanned-out copy's own mail_id must be distinct from its
-        // parent — it's a child node in the trace tree.
-        assert_ne!(
-            mail_id,
-            parent.expect("test setup: parent was asserted non-None above"),
-            "fanned-out mail_id should differ from parent (each fanout copy gets a fresh id)"
-        );
-    }
-
-    /// iamacoffeepot/aether#1489: a `Quit` mail drives the frame
-    /// lifecycle to its `Shutdown` terminal, finishing the in-flight
-    /// `Tick → Render → Present` frame first because the quit edge lives
-    /// on `Present` (ADR-0082 §3). This is the CI-runnable coverage for
-    /// the drain — the desktop winit `CloseRequested` / ctrlc bridges
-    /// that push the `Quit` are MCP-smoke territory, but the `Quit →
-    /// Present → Shutdown` graph behaviour they depend on is exercised
-    /// here without a live window (the bench shares the same
-    /// `frame_lifecycle_config` graph desktop uses).
-    ///
-    /// Registers an inline mailbox subscribed to the `Shutdown` stage,
-    /// sends `Quit` to `aether.lifecycle`, then advances one frame. The
-    /// run-frame loop drives the whole `Tick → Render → Present →
-    /// Shutdown` chain in that single advance once `quit_pending` is set
-    /// (each stage breaks the loop only at `Tick` cycle-complete or the
-    /// `next == 0` terminal), so observing the `Shutdown` broadcast at the
-    /// subscriber proves the quit was consumed at `Present` and that
-    /// `Shutdown` fired + settled.
-    #[test]
-    fn quit_drains_frame_then_broadcasts_shutdown() {
-        use aether_data::Kind as DataKind;
-        use aether_kinds::{LifecycleSubscribe, Quit, Shutdown};
-        use aether_substrate::mail::registry::MailDispatch;
-        use std::sync::Mutex;
-
-        let mut tb = match TestBench::start_with_size(64, 48) {
-            Ok(tb) => tb,
-            Err(e) => {
-                eprintln!("skipping: TestBench boot failed (likely no wgpu adapter): {e}");
-                return;
-            }
-        };
-
-        // Record the kind id of every mail the observer receives. The
-        // lifecycle cap broadcasts the `Shutdown` stage to its
-        // subscribers when it reaches the terminal; `register_inline` is
-        // the right variant (immediate work, no downstream enqueue) so
-        // the producer-side settlement bracket stays on the broadcast
-        // call site — the same shape the Tick-fanout test above relies on.
-        let observed: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
-        let observed_for_handler = Arc::clone(&observed);
-        let observer_mailbox = tb.registry.register_inline(
-            "issue_1489_shutdown_observer",
-            Arc::new(move |dispatch: MailDispatch<'_>| {
-                observed_for_handler
-                    .lock()
-                    .expect("test setup: observed mutex is never poisoned")
-                    .push(dispatch.kind.0);
-            }),
-        );
-
-        // Subscribe to Shutdown, set the quit flag, then advance one
-        // frame — `execute` settles each step before the next, so the
-        // subscription and `quit_pending` are both in place when the
-        // advance fires.
-        tb.execute(vec![
-            (
-                "subscribe_shutdown",
-                BenchOp::send_mail(
-                    "aether.lifecycle",
-                    &LifecycleSubscribe {
-                        stage: <Shutdown as DataKind>::ID.0,
-                        mailbox: observer_mailbox.0,
-                    },
-                ),
-            ),
-            ("quit", BenchOp::send_mail("aether.lifecycle", &Quit {})),
-            ("advance", BenchOp::advance(1)),
-        ])
-        .expect("subscribe + quit + advance");
-
-        let observed = observed
-            .lock()
-            .expect("test setup: observed mutex is never poisoned");
-        assert!(
-            observed.contains(&<Shutdown as DataKind>::ID.0),
-            "Shutdown broadcast never reached the subscriber — quit was not drained to the \
-             terminal; observed kind ids: {observed:?}",
-        );
-    }
-
-    /// Issue 607 Phase 3 verify: spawn an instanced actor through
-    /// `TestBench::spawn_actor`, exercise `Subname::Counter` +
-    /// `Subname::Named`, assert returned `MailboxId` matches the
-    /// deterministic full-name hash, confirm reused subnames fail,
-    /// and confirm `after_init` mail lands as the actor's first
-    /// dispatch.
-    #[test]
-    fn spawn_instanced_actor_smoke() {
-        use aether_actor::{Actor as ActorTrait, HandlesKind, Instanced};
-        use aether_data::{Kind as DataKind, KindId as DataKindId, mailbox_id_from_name};
-        use aether_substrate::{
-            BootError, NativeActor, NativeCtx, NativeDispatch, NativeInitCtx, SpawnError, Subname,
-        };
-        use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
-
-        #[repr(C)]
-        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-        struct Bump {
-            tag: u32,
-        }
-        impl DataKind for Bump {
-            const NAME: &'static str = "test.spawn.bump";
-            const ID: DataKindId = DataKindId(0xB0B1_B2B3_B4B5_B6B7);
-            aether_data::pod_kind_codec!();
+            let captured = captured
+                .lock()
+                .expect("test setup: captured mutex is never poisoned");
+            assert!(
+                !captured.is_empty(),
+                "subscriber received no mail — fanout never reached it",
+            );
+            let (mail_id, root, parent) = captured[0];
+            // Issue 723 fix: each fanned-out copy gets its own MailId, but
+            // the root is inherited from the chassis-root tick and the
+            // parent_mail points at it. Pre-fix both would be MailId::NONE
+            // (orphaned: ctx.in_flight was NONE because the tick used
+            // bare push, AND the fanout used bare push too).
+            assert_ne!(
+                root,
+                MailId::NONE,
+                "fanned-out copy should inherit a non-default root"
+            );
+            assert!(
+                parent.is_some_and(|p| p != MailId::NONE),
+                "fanned-out copy should carry a non-default parent_mail (got {parent:?})",
+            );
+            // The fanned-out copy's own mail_id must be distinct from its
+            // parent — it's a child node in the trace tree.
+            assert_ne!(
+                mail_id,
+                parent.expect("test setup: parent was asserted non-None above"),
+                "fanned-out mail_id should differ from parent (each fanout copy gets a fresh id)"
+            );
         }
 
-        struct Child {
-            received: Arc<AtomicU32>,
-        }
-        impl ActorTrait for Child {
-            const NAMESPACE: &'static str = "test.spawn.child";
-        }
-        impl Instanced for Child {}
-        impl HandlesKind<Bump> for Child {}
-        impl NativeActor for Child {
-            type Config = Arc<AtomicU32>;
-            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-                Ok(Self { received: config })
-            }
-        }
-        impl NativeDispatch for Child {
-            fn __aether_dispatch_envelope(
-                &mut self,
-                _ctx: &mut NativeCtx<'_>,
-                kind: KindId,
-                payload: &[u8],
-            ) -> Option<()> {
-                if kind.0 == Bump::ID.0 {
-                    let _ = Bump::decode_from_bytes(payload)?;
-                    self.received.fetch_add(1, AtomicOrdering::SeqCst);
-                    return Some(());
+        /// iamacoffeepot/aether#1489: a `Quit` mail drives the frame
+        /// lifecycle to its `Shutdown` terminal, finishing the in-flight
+        /// `Tick → Render → Present` frame first because the quit edge lives
+        /// on `Present` (ADR-0082 §3). This is the CI-runnable coverage for
+        /// the drain — the desktop winit `CloseRequested` / ctrlc bridges
+        /// that push the `Quit` are MCP-smoke territory, but the `Quit →
+        /// Present → Shutdown` graph behaviour they depend on is exercised
+        /// here without a live window (the bench shares the same
+        /// `frame_lifecycle_config` graph desktop uses).
+        ///
+        /// Registers an inline mailbox subscribed to the `Shutdown` stage,
+        /// sends `Quit` to `aether.lifecycle`, then advances one frame. The
+        /// run-frame loop drives the whole `Tick → Render → Present →
+        /// Shutdown` chain in that single advance once `quit_pending` is set
+        /// (each stage breaks the loop only at `Tick` cycle-complete or the
+        /// `next == 0` terminal), so observing the `Shutdown` broadcast at the
+        /// subscriber proves the quit was consumed at `Present` and that
+        /// `Shutdown` fired + settled.
+        #[test]
+        fn quit_drains_frame_then_broadcasts_shutdown() {
+            use aether_data::Kind as DataKind;
+            use aether_kinds::{LifecycleSubscribe, Quit, Shutdown};
+            use aether_substrate::mail::registry::MailDispatch;
+            use std::sync::Mutex;
+
+            let mut tb = match TestBench::start_with_size(64, 48) {
+                Ok(tb) => tb,
+                Err(e) => {
+                    eprintln!("skipping: TestBench boot failed (likely no wgpu adapter): {e}");
+                    return;
                 }
-                None
-            }
+            };
+
+            // Record the kind id of every mail the observer receives. The
+            // lifecycle cap broadcasts the `Shutdown` stage to its
+            // subscribers when it reaches the terminal; `register_inline` is
+            // the right variant (immediate work, no downstream enqueue) so
+            // the producer-side settlement bracket stays on the broadcast
+            // call site — the same shape the Tick-fanout test above relies on.
+            let observed: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
+            let observed_for_handler = Arc::clone(&observed);
+            let observer_mailbox = tb.registry.register_inline(
+                "issue_1489_shutdown_observer",
+                Arc::new(move |dispatch: MailDispatch<'_>| {
+                    observed_for_handler
+                        .lock()
+                        .expect("test setup: observed mutex is never poisoned")
+                        .push(dispatch.kind.0);
+                }),
+            );
+
+            // Subscribe to Shutdown, set the quit flag, then advance one
+            // frame — `execute` settles each step before the next, so the
+            // subscription and `quit_pending` are both in place when the
+            // advance fires.
+            tb.execute(vec![
+                (
+                    "subscribe_shutdown",
+                    BenchOp::send_mail(
+                        "aether.lifecycle",
+                        &LifecycleSubscribe {
+                            stage: <Shutdown as DataKind>::ID.0,
+                            mailbox: observer_mailbox.0,
+                        },
+                    ),
+                ),
+                ("quit", BenchOp::send_mail("aether.lifecycle", &Quit {})),
+                ("advance", BenchOp::advance(1)),
+            ])
+            .expect("subscribe + quit + advance");
+
+            let observed = observed
+                .lock()
+                .expect("test setup: observed mutex is never poisoned");
+            assert!(
+                observed.contains(&<Shutdown as DataKind>::ID.0),
+                "Shutdown broadcast never reached the subscriber — quit was not drained to the \
+             terminal; observed kind ids: {observed:?}",
+            );
         }
 
-        let tb = match TestBench::start_with_size(64, 48) {
-            Ok(tb) => tb,
-            Err(e) => {
-                eprintln!("skipping: TestBench boot failed (likely no wgpu adapter): {e}");
-                return;
+        /// Issue 607 Phase 3 verify: spawn an instanced actor through
+        /// `TestBench::spawn_actor`, exercise `Subname::Counter` +
+        /// `Subname::Named`, assert returned `MailboxId` matches the
+        /// deterministic full-name hash, confirm reused subnames fail,
+        /// and confirm `after_init` mail lands as the actor's first
+        /// dispatch.
+        #[test]
+        fn spawn_instanced_actor_smoke() {
+            use aether_actor::{Actor as ActorTrait, HandlesKind, Instanced};
+            use aether_data::{Kind as DataKind, KindId as DataKindId, mailbox_id_from_name};
+            use aether_substrate::{
+                BootError, NativeActor, NativeCtx, NativeDispatch, NativeInitCtx, SpawnError,
+                Subname,
+            };
+            use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+
+            #[repr(C)]
+            #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+            struct Bump {
+                tag: u32,
             }
-        };
+            impl DataKind for Bump {
+                const NAME: &'static str = "test.spawn.bump";
+                const ID: DataKindId = DataKindId(0xB0B1_B2B3_B4B5_B6B7);
+                aether_data::pod_kind_codec!();
+            }
 
-        let received = Arc::new(AtomicU32::new(0));
+            struct Child {
+                received: Arc<AtomicU32>,
+            }
+            impl ActorTrait for Child {
+                const NAMESPACE: &'static str = "test.spawn.child";
+            }
+            impl Instanced for Child {}
+            impl HandlesKind<Bump> for Child {}
+            impl NativeActor for Child {
+                type Config = Arc<AtomicU32>;
+                fn init(
+                    config: Self::Config,
+                    _ctx: &mut NativeInitCtx<'_>,
+                ) -> Result<Self, BootError> {
+                    Ok(Self { received: config })
+                }
+            }
+            impl NativeDispatch for Child {
+                fn __aether_dispatch_envelope(
+                    &mut self,
+                    _ctx: &mut NativeCtx<'_>,
+                    kind: KindId,
+                    payload: &[u8],
+                ) -> Option<()> {
+                    if kind.0 == Bump::ID.0 {
+                        let _ = Bump::decode_from_bytes(payload)?;
+                        self.received.fetch_add(1, AtomicOrdering::SeqCst);
+                        return Some(());
+                    }
+                    None
+                }
+            }
 
-        // Subname::Counter — first instance, full name "test.spawn.child:0".
-        let id_a = tb
-            .spawn_actor::<Child>(Subname::Counter, Arc::clone(&received))
-            .after_init(Bump { tag: 1 })
-            .after_init(Bump { tag: 2 })
-            .finish()
-            .expect("first counter spawn");
-        assert_eq!(
-            id_a,
-            MailboxId(mailbox_id_from_name("test.spawn.child:0").0),
-            "Counter subname allocates from a per-Spawner counter starting at 0"
-        );
+            let tb = match TestBench::start_with_size(64, 48) {
+                Ok(tb) => tb,
+                Err(e) => {
+                    eprintln!("skipping: TestBench boot failed (likely no wgpu adapter): {e}");
+                    return;
+                }
+            };
 
-        // Subname::Named — second instance, full name "test.spawn.child:alpha".
-        let id_b = tb
-            .spawn_actor::<Child>(Subname::Named("alpha"), Arc::clone(&received))
-            .finish()
-            .expect("named spawn");
-        assert_eq!(
-            id_b,
-            MailboxId(mailbox_id_from_name("test.spawn.child:alpha").0),
-        );
+            let received = Arc::new(AtomicU32::new(0));
 
-        // Reused subname → SubnameInUse.
-        let err = tb
-            .spawn_actor::<Child>(Subname::Named("alpha"), Arc::clone(&received))
-            .finish()
-            .expect_err("reused subname must fail");
-        assert!(
-            matches!(err, SpawnError::SubnameInUse { .. }),
-            "expected SubnameInUse, got {err:?}"
-        );
+            // Subname::Counter — first instance, full name "test.spawn.child:0".
+            let id_a = tb
+                .spawn_actor::<Child>(Subname::Counter, Arc::clone(&received))
+                .after_init(Bump { tag: 1 })
+                .after_init(Bump { tag: 2 })
+                .finish()
+                .expect("first counter spawn");
+            assert_eq!(
+                id_a,
+                MailboxId(mailbox_id_from_name("test.spawn.child:0").0),
+                "Counter subname allocates from a per-Spawner counter starting at 0"
+            );
 
-        // Wait briefly for the two pre-loaded `Bump` mails to land in
-        // the first instance's dispatcher.
-        let deadline = Instant::now() + Duration::from_millis(500);
-        while received.load(AtomicOrdering::SeqCst) < 2 && Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(5));
+            // Subname::Named — second instance, full name "test.spawn.child:alpha".
+            let id_b = tb
+                .spawn_actor::<Child>(Subname::Named("alpha"), Arc::clone(&received))
+                .finish()
+                .expect("named spawn");
+            assert_eq!(
+                id_b,
+                MailboxId(mailbox_id_from_name("test.spawn.child:alpha").0),
+            );
+
+            // Reused subname → SubnameInUse.
+            let err = tb
+                .spawn_actor::<Child>(Subname::Named("alpha"), Arc::clone(&received))
+                .finish()
+                .expect_err("reused subname must fail");
+            assert!(
+                matches!(err, SpawnError::SubnameInUse { .. }),
+                "expected SubnameInUse, got {err:?}"
+            );
+
+            // Wait briefly for the two pre-loaded `Bump` mails to land in
+            // the first instance's dispatcher.
+            let deadline = Instant::now() + Duration::from_millis(500);
+            while received.load(AtomicOrdering::SeqCst) < 2 && Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(5));
+            }
+            assert_eq!(
+                received.load(AtomicOrdering::SeqCst),
+                2,
+                "both pre-loaded after_init mails should dispatch to the first instance"
+            );
+
+            // Live registry slots are populated by id.
+            assert!(
+                tb.actor_registry().is_live(id_a),
+                "first instance should be Live in the actor registry"
+            );
+            assert!(
+                tb.actor_registry().is_live(id_b),
+                "second instance should be Live in the actor registry"
+            );
         }
-        assert_eq!(
-            received.load(AtomicOrdering::SeqCst),
-            2,
-            "both pre-loaded after_init mails should dispatch to the first instance"
-        );
-
-        // Live registry slots are populated by id.
-        assert!(
-            tb.actor_registry().is_live(id_a),
-            "first instance should be Live in the actor registry"
-        );
-        assert!(
-            tb.actor_registry().is_live(id_b),
-            "second instance should be Live in the actor registry"
-        );
     }
 }

--- a/crates/aether-substrate-bundle/tests/engines_cap.rs
+++ b/crates/aether-substrate-bundle/tests/engines_cap.rs
@@ -146,193 +146,66 @@ fn drive<K: Kind, T>(
     }
 }
 
-#[test]
-fn engines_cap_spawns_lists_and_terminates_a_real_headless_substrate() {
-    let (_chassis, mailer, cells) = boot();
-    let headless = env!("CARGO_BIN_EXE_aether-substrate-headless");
+/// Contention-sensitive: both tests fork a real headless substrate and
+/// sleep-poll under a ~30s settle deadline, so they go in `mod heavy`
+/// for the `serial-heavy` nextest group (issue 1522).
+mod heavy {
+    use super::*;
 
-    // Spawn: the cap assigns a port, forks the substrate, and the
-    // proxy retries the dial until the fresh process binds. Generous
-    // deadline — this covers a debug-build chassis cold start.
-    let spawn = drive(
-        &mailer,
-        &SpawnEngine {
-            binary_path: headless.to_owned(),
-            args: vec![],
-        },
-        Duration::from_secs(30),
-        || {
-            cells
-                .spawn
-                .lock()
-                .expect("test setup: spawn cell mutex is never poisoned")
-                .take()
-        },
-    );
-    let engine_id = match spawn {
-        SpawnEngineResult::Ok {
-            engine_id,
-            rpc_port,
-        } => {
-            assert_ne!(rpc_port, 0, "cap should report the assigned RPC port");
-            engine_id
-        }
-        SpawnEngineResult::Err { error } => panic!("spawn failed: {error}"),
-    };
+    #[test]
+    fn engines_cap_spawns_lists_and_terminates_a_real_headless_substrate() {
+        let (_chassis, mailer, cells) = boot();
+        let headless = env!("CARGO_BIN_EXE_aether-substrate-headless");
 
-    // List: the freshly-spawned engine shows up in the cap's table.
-    let list = drive(&mailer, &ListEngines {}, Duration::from_secs(5), || {
-        cells
-            .list
-            .lock()
-            .expect("test setup: list cell mutex is never poisoned")
-            .take()
-    });
-    assert!(
-        list.engines.iter().any(|e| e.engine_id == engine_id),
-        "spawned engine {engine_id} should appear in ListEngines: {list:?}",
-    );
-
-    // Terminate: the cap forwards to the proxy, which SIGKILLs the
-    // substrate and self-shuts-down; the table entry is dropped.
-    let terminate = drive(
-        &mailer,
-        &TerminateEngine {
-            engine_id: engine_id.clone(),
-        },
-        Duration::from_secs(5),
-        || {
-            cells
-                .terminate
-                .lock()
-                .expect("test setup: terminate cell mutex is never poisoned")
-                .take()
-        },
-    );
-    assert!(
-        matches!(terminate, TerminateEngineResult::Ok),
-        "terminate of a live engine should succeed: {terminate:?}",
-    );
-
-    // After terminate, the engine is gone from the table.
-    let list_after = drive(&mailer, &ListEngines {}, Duration::from_secs(5), || {
-        cells
-            .list
-            .lock()
-            .expect("test setup: list cell mutex is never poisoned")
-            .take()
-    });
-    assert!(
-        !list_after.engines.iter().any(|e| e.engine_id == engine_id),
-        "terminated engine {engine_id} should be gone from ListEngines: {list_after:?}",
-    );
-}
-
-/// Two engines spawned via the cap coexist with persistence on: each
-/// gets its own `${AETHER_ENGINE_STORE_ROOT}/<engine_id>` handle-store
-/// dir, so the ADR-0049 §7 `lock.pid` doesn't collide
-/// (iamacoffeepot/aether#1274). Before the fix, both substrates
-/// resolved to the same default `dirs::data_dir()/aether/handles` and
-/// one failed with `LockError::Held`.
-#[test]
-fn two_engines_get_distinct_handle_store_dirs() {
-    let headless = env!("CARGO_BIN_EXE_aether-substrate-headless");
-
-    // Per-test scratch dir under the system temp root. Process pid +
-    // nanos disambiguate against any leftover from a prior run that
-    // didn't clean up (the test below cleans on the success path).
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |d| d.as_nanos());
-    let root = env::temp_dir().join(format!("aether-engines-cap-{}-{}", process::id(), nanos));
-
-    // SAFETY: nextest runs each test in its own process, so the env
-    // mutations here don't race sibling tests. We need (a) the cap's
-    // `engine_store_root()` to resolve to `root` (read in the test
-    // process when `on_spawn` runs), (b) the spawned substrates to
-    // NOT inherit a parent `AETHER_HANDLE_STORE_DIR` (which would win
-    // over the cap's per-engine injection), and (c) persistence not
-    // to be globally disabled — the lock-collision case the issue
-    // pins only fires when each substrate writes a `lock.pid`.
-    unsafe {
-        env::set_var("AETHER_ENGINE_STORE_ROOT", &root);
-        env::remove_var("AETHER_HANDLE_STORE_DIR");
-        env::remove_var("AETHER_HANDLE_STORE_PERSIST_DISABLE");
-    }
-
-    let (_chassis, mailer, cells) = boot();
-
-    // Spawn engine A.
-    let a = drive(
-        &mailer,
-        &SpawnEngine {
-            binary_path: headless.to_owned(),
-            args: vec![],
-        },
-        Duration::from_secs(30),
-        || {
-            cells
-                .spawn
-                .lock()
-                .expect("test setup: spawn cell mutex is never poisoned")
-                .take()
-        },
-    );
-    let a_id = match a {
-        SpawnEngineResult::Ok { engine_id, .. } => engine_id,
-        SpawnEngineResult::Err { error } => panic!("spawn A failed: {error}"),
-    };
-
-    // Spawn engine B. Pre-fix this would race the same handle-store
-    // dir and either A or B would die with `LockError::Held`; the
-    // cap's reply to `on_spawn` would be `Err` because the proxy
-    // never connected to a substrate that aborted boot. The assertion
-    // below is structural — both spawn replies are Ok.
-    let b = drive(
-        &mailer,
-        &SpawnEngine {
-            binary_path: headless.to_owned(),
-            args: vec![],
-        },
-        Duration::from_secs(30),
-        || {
-            cells
-                .spawn
-                .lock()
-                .expect("test setup: spawn cell mutex is never poisoned")
-                .take()
-        },
-    );
-    let b_id = match b {
-        SpawnEngineResult::Ok { engine_id, .. } => engine_id,
-        SpawnEngineResult::Err { error } => panic!("spawn B failed: {error}"),
-    };
-    assert_ne!(a_id, b_id, "the cap must mint distinct engine ids");
-
-    // Walk `root/` for the per-engine subdirs the cap allocated.
-    // Each child substrate creates `lock.pid` + `v1/` lazily under
-    // its assigned `AETHER_HANDLE_STORE_DIR`, so we only assert on the
-    // top-level subdir count — the lock collision (the actual bug)
-    // would surface as a missing dir or a failed spawn earlier.
-    let subdirs: Vec<PathBuf> = fs::read_dir(&root)
-        .unwrap_or_else(|e| panic!("read_dir({}): {e}", root.display()))
-        .filter_map(Result::ok)
-        .map(|entry| entry.path())
-        .filter(|p| p.is_dir())
-        .collect();
-    assert_eq!(
-        subdirs.len(),
-        2,
-        "expected two per-engine handle-store dirs under {}; saw: {subdirs:?}",
-        root.display(),
-    );
-
-    // Terminate both engines so their proxies SIGKILL the substrates;
-    // best-effort cleanup of the scratch root follows.
-    for id in [a_id, b_id] {
-        let _ = drive(
+        // Spawn: the cap assigns a port, forks the substrate, and the
+        // proxy retries the dial until the fresh process binds. Generous
+        // deadline — this covers a debug-build chassis cold start.
+        let spawn = drive(
             &mailer,
-            &TerminateEngine { engine_id: id },
+            &SpawnEngine {
+                binary_path: headless.to_owned(),
+                args: vec![],
+            },
+            Duration::from_secs(30),
+            || {
+                cells
+                    .spawn
+                    .lock()
+                    .expect("test setup: spawn cell mutex is never poisoned")
+                    .take()
+            },
+        );
+        let engine_id = match spawn {
+            SpawnEngineResult::Ok {
+                engine_id,
+                rpc_port,
+            } => {
+                assert_ne!(rpc_port, 0, "cap should report the assigned RPC port");
+                engine_id
+            }
+            SpawnEngineResult::Err { error } => panic!("spawn failed: {error}"),
+        };
+
+        // List: the freshly-spawned engine shows up in the cap's table.
+        let list = drive(&mailer, &ListEngines {}, Duration::from_secs(5), || {
+            cells
+                .list
+                .lock()
+                .expect("test setup: list cell mutex is never poisoned")
+                .take()
+        });
+        assert!(
+            list.engines.iter().any(|e| e.engine_id == engine_id),
+            "spawned engine {engine_id} should appear in ListEngines: {list:?}",
+        );
+
+        // Terminate: the cap forwards to the proxy, which SIGKILLs the
+        // substrate and self-shuts-down; the table entry is dropped.
+        let terminate = drive(
+            &mailer,
+            &TerminateEngine {
+                engine_id: engine_id.clone(),
+            },
             Duration::from_secs(5),
             || {
                 cells
@@ -342,6 +215,140 @@ fn two_engines_get_distinct_handle_store_dirs() {
                     .take()
             },
         );
+        assert!(
+            matches!(terminate, TerminateEngineResult::Ok),
+            "terminate of a live engine should succeed: {terminate:?}",
+        );
+
+        // After terminate, the engine is gone from the table.
+        let list_after = drive(&mailer, &ListEngines {}, Duration::from_secs(5), || {
+            cells
+                .list
+                .lock()
+                .expect("test setup: list cell mutex is never poisoned")
+                .take()
+        });
+        assert!(
+            !list_after.engines.iter().any(|e| e.engine_id == engine_id),
+            "terminated engine {engine_id} should be gone from ListEngines: {list_after:?}",
+        );
     }
-    let _ = fs::remove_dir_all(&root);
+
+    /// Two engines spawned via the cap coexist with persistence on: each
+    /// gets its own `${AETHER_ENGINE_STORE_ROOT}/<engine_id>` handle-store
+    /// dir, so the ADR-0049 §7 `lock.pid` doesn't collide
+    /// (iamacoffeepot/aether#1274). Before the fix, both substrates
+    /// resolved to the same default `dirs::data_dir()/aether/handles` and
+    /// one failed with `LockError::Held`.
+    #[test]
+    fn two_engines_get_distinct_handle_store_dirs() {
+        let headless = env!("CARGO_BIN_EXE_aether-substrate-headless");
+
+        // Per-test scratch dir under the system temp root. Process pid +
+        // nanos disambiguate against any leftover from a prior run that
+        // didn't clean up (the test below cleans on the success path).
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        let root = env::temp_dir().join(format!("aether-engines-cap-{}-{}", process::id(), nanos));
+
+        // SAFETY: nextest runs each test in its own process, so the env
+        // mutations here don't race sibling tests. We need (a) the cap's
+        // `engine_store_root()` to resolve to `root` (read in the test
+        // process when `on_spawn` runs), (b) the spawned substrates to
+        // NOT inherit a parent `AETHER_HANDLE_STORE_DIR` (which would win
+        // over the cap's per-engine injection), and (c) persistence not
+        // to be globally disabled — the lock-collision case the issue
+        // pins only fires when each substrate writes a `lock.pid`.
+        unsafe {
+            env::set_var("AETHER_ENGINE_STORE_ROOT", &root);
+            env::remove_var("AETHER_HANDLE_STORE_DIR");
+            env::remove_var("AETHER_HANDLE_STORE_PERSIST_DISABLE");
+        }
+
+        let (_chassis, mailer, cells) = boot();
+
+        // Spawn engine A.
+        let a = drive(
+            &mailer,
+            &SpawnEngine {
+                binary_path: headless.to_owned(),
+                args: vec![],
+            },
+            Duration::from_secs(30),
+            || {
+                cells
+                    .spawn
+                    .lock()
+                    .expect("test setup: spawn cell mutex is never poisoned")
+                    .take()
+            },
+        );
+        let a_id = match a {
+            SpawnEngineResult::Ok { engine_id, .. } => engine_id,
+            SpawnEngineResult::Err { error } => panic!("spawn A failed: {error}"),
+        };
+
+        // Spawn engine B. Pre-fix this would race the same handle-store
+        // dir and either A or B would die with `LockError::Held`; the
+        // cap's reply to `on_spawn` would be `Err` because the proxy
+        // never connected to a substrate that aborted boot. The assertion
+        // below is structural — both spawn replies are Ok.
+        let b = drive(
+            &mailer,
+            &SpawnEngine {
+                binary_path: headless.to_owned(),
+                args: vec![],
+            },
+            Duration::from_secs(30),
+            || {
+                cells
+                    .spawn
+                    .lock()
+                    .expect("test setup: spawn cell mutex is never poisoned")
+                    .take()
+            },
+        );
+        let b_id = match b {
+            SpawnEngineResult::Ok { engine_id, .. } => engine_id,
+            SpawnEngineResult::Err { error } => panic!("spawn B failed: {error}"),
+        };
+        assert_ne!(a_id, b_id, "the cap must mint distinct engine ids");
+
+        // Walk `root/` for the per-engine subdirs the cap allocated.
+        // Each child substrate creates `lock.pid` + `v1/` lazily under
+        // its assigned `AETHER_HANDLE_STORE_DIR`, so we only assert on the
+        // top-level subdir count — the lock collision (the actual bug)
+        // would surface as a missing dir or a failed spawn earlier.
+        let subdirs: Vec<PathBuf> = fs::read_dir(&root)
+            .unwrap_or_else(|e| panic!("read_dir({}): {e}", root.display()))
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|p| p.is_dir())
+            .collect();
+        assert_eq!(
+            subdirs.len(),
+            2,
+            "expected two per-engine handle-store dirs under {}; saw: {subdirs:?}",
+            root.display(),
+        );
+
+        // Terminate both engines so their proxies SIGKILL the substrates;
+        // best-effort cleanup of the scratch root follows.
+        for id in [a_id, b_id] {
+            let _ = drive(
+                &mailer,
+                &TerminateEngine { engine_id: id },
+                Duration::from_secs(5),
+                || {
+                    cells
+                        .terminate
+                        .lock()
+                        .expect("test setup: terminate cell mutex is never poisoned")
+                        .take()
+                },
+            );
+        }
+        let _ = fs::remove_dir_all(&root);
+    }
 }

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -1761,580 +1761,597 @@ mod tests {
         );
     }
 
-    /// Issue 552 stage 1: end-to-end smoke for the new
-    /// [`Builder::with_actor`] boot path. Boots a hand-rolled
-    /// `NativeActor + NativeDispatch` fixture, looks it up via
-    /// [`PassiveChassis::actor`], pushes one envelope at the cap's
-    /// mailbox, and asserts the dispatcher routed it to the right
-    /// handler. Stage 1 lands the infrastructure; stage 2 migrates
-    /// real caps onto it. This test is the load-bearing acceptance
-    /// gate.
-    #[test]
-    fn with_actor_boots_dispatches_and_tears_down() {
-        use crate::mail::registry::MailboxEntry;
-        use aether_data::Kind;
-        use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
-
-        // Fixture kind: a 4-byte cast-shape payload so encode_into_bytes
-        // lands on the bytemuck path.
-        #[repr(C)]
-        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-        struct Ping {
-            tag: u32,
-        }
-        impl Kind for Ping {
-            const NAME: &'static str = "test.with_actor.ping";
-            const ID: KindId = KindId(0xA1B2_C3D4_E5F6_0001);
-            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != size_of::<Self>() {
-                    return None;
-                }
-                Some(bytemuck::pod_read_unaligned(bytes))
-            }
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
-        }
-
-        // Fixture cap. State behind interior mutability so `&self`
-        // dispatch can mutate it (the post-552 norm).
-        struct ProbeCap {
-            received: Arc<AtomicU32>,
-        }
-        impl Actor for ProbeCap {
-            const NAMESPACE: &'static str = "test.with_actor.probe";
-        }
-        impl aether_actor::Singleton for ProbeCap {}
-        impl HandlesKind<Ping> for ProbeCap {}
-
-        impl NativeActor for ProbeCap {
-            type Config = Arc<AtomicU32>;
-            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-                Ok(Self { received: config })
-            }
-        }
-
-        // Hand-rolled NativeDispatch — what the macro arm emits in
-        // task #731. The if-arm decodes Ping bytes, calls the
-        // handler, returns Some(()) on success.
-        impl NativeDispatch for ProbeCap {
-            fn __aether_dispatch_envelope(
-                &mut self,
-                _ctx: &mut NativeCtx<'_>,
-                kind: KindId,
-                payload: &[u8],
-            ) -> Option<()> {
-                if kind.0 == Ping::ID.0 {
-                    let _decoded = Ping::decode_from_bytes(payload)?;
-                    self.received.fetch_add(1, AtomicOrdering::SeqCst);
-                    return Some(());
-                }
-                None
-            }
-        }
-
-        let (registry, mailer) = fresh_substrate();
-        let received = Arc::new(AtomicU32::new(0));
-
-        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<ProbeCap>(Arc::clone(&received))
-            .build_passive()
-            .expect("with_actor boot succeeds");
-
-        // Issue 629 / Phase A: chassis-level `actor::<X>()` retired.
-        // The cap is owned by its dispatcher thread; the test verifies
-        // the cap is alive via the mail dispatch round-trip below.
-
-        // Push one envelope at the cap's mailbox via the registry's
-        // sink handler. The dispatcher thread pulls from its inbox
-        // and routes through __aether_dispatch_envelope → on_ping.
-        let mailbox_id = registry
-            .lookup(<ProbeCap as Actor>::NAMESPACE)
-            .expect("with_actor claimed the mailbox");
-        let MailboxEntry::Inbox { handler, .. } =
-            registry.entry(mailbox_id).expect("sink registered")
-        else {
-            panic!("ProbeCap claim must be a sink entry");
-        };
-
-        let payload = Ping { tag: 0xDEAD_BEEF };
-        let bytes = payload.encode_into_bytes();
-        handler.enqueue(registry::test_owned_dispatch(
-            <Ping as Kind>::ID,
-            Ping::NAME,
-            &bytes,
-            1,
-        ));
-
-        // Wait briefly for the dispatcher thread to dispatch.
-        let deadline = Instant::now() + Duration::from_millis(500);
-        while received.load(AtomicOrdering::SeqCst) == 0 && Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(5));
-        }
-        assert_eq!(
-            received.load(AtomicOrdering::SeqCst),
-            1,
-            "dispatcher should have routed Ping → on_ping within the wait budget"
-        );
-
-        drop(chassis);
-    }
-
-    /// Issue 582: the chassis dispatcher trampoline stamps the
-    /// per-actor [`ActorSlots`] into TLS
-    /// for the duration of `init` and each handler call. A cap that
-    /// reaches for `Local::with_mut` from inside both lifecycle
-    /// stages must see its own state — verified end-to-end here so
-    /// the stamping wiring can't silently regress.
-    #[test]
-    fn with_actor_stamps_local_for_init_and_handler() {
-        use crate::mail::registry::MailboxEntry;
-        use aether_actor::Local;
-        use aether_data::Kind;
-        use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
-
-        #[repr(C)]
-        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-        struct Tick {
-            seq: u32,
-        }
-        impl Kind for Tick {
-            const NAME: &'static str = "test.local.tick";
-            const ID: KindId = KindId(0xA1B2_C3D4_E5F6_0002);
-            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != size_of::<Self>() {
-                    return None;
-                }
-                Some(bytemuck::pod_read_unaligned(bytes))
-            }
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
-        }
-
-        // The cap holds an Arc<AtomicU32> the test reads after each
-        // dispatch. The actor-local counter is keyed by `TypeId<Counter>`
-        // — the chassis stamp is what makes `with_mut` resolve at
-        // all (outside a stamp it would `debug_assert!` panic).
-        struct LocalProbe {
-            observed: Arc<AtomicU32>,
-        }
-        impl Actor for LocalProbe {
-            const NAMESPACE: &'static str = "test.local.probe";
-        }
-        impl aether_actor::Singleton for LocalProbe {}
-        impl HandlesKind<Tick> for LocalProbe {}
-
-        // Newtype-per-slot is the Local convention: each
-        // logical storage gets its own type, so two probes that
-        // both want a u32 don't alias under TypeId. The
-        // `#[local]` attribute is the shorthand for the
-        // marker impl.
-        #[derive(Default)]
-        #[aether_actor::local]
-        struct Counter(u32);
-
-        impl NativeActor for LocalProbe {
-            type Config = Arc<AtomicU32>;
-            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-                // Init runs inside the chassis builder's stamp guard
-                // — write a sentinel so the handler test below proves
-                // the same slots are reused across init→dispatch.
-                Counter::with_mut(|c| c.0 = 100);
-                Ok(Self { observed: config })
-            }
-        }
-
-        impl NativeDispatch for LocalProbe {
-            fn __aether_dispatch_envelope(
-                &mut self,
-                _ctx: &mut NativeCtx<'_>,
-                kind: KindId,
-                payload: &[u8],
-            ) -> Option<()> {
-                if kind.0 == Tick::ID.0 {
-                    let _decoded = Tick::decode_from_bytes(payload)?;
-                    Counter::with_mut(|c| c.0 += 1);
-                    let snapshot = Counter::with(|c| c.0);
-                    self.observed.store(snapshot, AtomicOrdering::SeqCst);
-                    return Some(());
-                }
-                None
-            }
-        }
-
-        let (registry, mailer) = fresh_substrate();
-        let observed = Arc::new(AtomicU32::new(0));
-        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<LocalProbe>(Arc::clone(&observed))
-            .build_passive()
-            .expect("LocalProbe boots");
-
-        let mailbox_id = registry
-            .lookup(<LocalProbe as Actor>::NAMESPACE)
-            .expect("with_actor claimed the mailbox");
-        let MailboxEntry::Inbox { handler, .. } =
-            registry.entry(mailbox_id).expect("sink registered")
-        else {
-            panic!("LocalProbe claim must be a sink entry");
-        };
-
-        // Three dispatches. Init seeded 100; the handler bumps once
-        // per dispatch and snapshots — so observed should walk
-        // 101, 102, 103 in order. We assert the final 103 with a
-        // wait budget to cover dispatcher-thread scheduling.
-        for seq in 0..3 {
-            let payload = Tick { seq };
-            let bytes = payload.encode_into_bytes();
-            handler.enqueue(registry::test_owned_dispatch(
-                <Tick as Kind>::ID,
-                Tick::NAME,
-                &bytes,
-                1,
-            ));
-        }
-
-        let deadline = Instant::now() + Duration::from_millis(500);
-        while observed.load(AtomicOrdering::SeqCst) != 103 && Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(5));
-        }
-        assert_eq!(
-            observed.load(AtomicOrdering::SeqCst),
-            103,
-            "init seeded 100 + 3 handler bumps ⇒ Local at 103 (proves the same \
-             ActorSlots is stamped across init and dispatch)"
-        );
-
-        drop(chassis);
-    }
-
-    /// Issue 607 Phase 3b verify: a singleton parent's handler calls
-    /// `ctx.spawn_child::<Child>(...)` to launch an instanced actor.
-    /// Asserts the child's `MailboxId` lands in the chassis's
-    /// `ActorRegistry` as a Live entry, and that the parent-pre-loaded
-    /// `after_init` mail dispatches as the child's first envelope.
-    #[test]
-    fn ctx_spawn_child_routes_through_handler() {
-        use crate::actor::native::spawn::Subname;
-        use crate::mail::registry::MailboxEntry;
-        use aether_actor::{HandlesKind, Instanced};
-        use aether_data::{Kind, KindId as DataKindId};
-        use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
-
-        #[repr(C)]
-        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-        struct Hatch {
-            tag: u32,
-        }
-        impl Kind for Hatch {
-            const NAME: &'static str = "test.spawn_child.hatch";
-            const ID: DataKindId = DataKindId(0xC0C1_C2C3_C4C5_C6C7);
-            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != size_of::<Self>() {
-                    return None;
-                }
-                Some(bytemuck::pod_read_unaligned(bytes))
-            }
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
-        }
-
-        #[repr(C)]
-        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-        struct Ping {
-            tag: u32,
-        }
-        impl Kind for Ping {
-            const NAME: &'static str = "test.spawn_child.ping";
-            const ID: DataKindId = DataKindId(0xD0D1_D2D3_D4D5_D6D7);
-            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != size_of::<Self>() {
-                    return None;
-                }
-                Some(bytemuck::pod_read_unaligned(bytes))
-            }
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
-        }
-
-        struct ChildCap {
-            received: Arc<AtomicU32>,
-        }
-        impl Actor for ChildCap {
-            const NAMESPACE: &'static str = "test.spawn_child.child";
-        }
-        impl Instanced for ChildCap {}
-        impl HandlesKind<Ping> for ChildCap {}
-        impl NativeActor for ChildCap {
-            type Config = Arc<AtomicU32>;
-            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-                Ok(Self { received: config })
-            }
-        }
-        impl NativeDispatch for ChildCap {
-            fn __aether_dispatch_envelope(
-                &mut self,
-                _ctx: &mut NativeCtx<'_>,
-                kind: KindId,
-                payload: &[u8],
-            ) -> Option<()> {
-                if kind.0 == Ping::ID.0 {
-                    let _ = Ping::decode_from_bytes(payload)?;
-                    self.received.fetch_add(1, AtomicOrdering::SeqCst);
-                    return Some(());
-                }
-                None
-            }
-        }
-
-        struct ParentCap {
-            spawn_count: Arc<AtomicU32>,
-            child_received: Arc<AtomicU32>,
-        }
-        impl Actor for ParentCap {
-            const NAMESPACE: &'static str = "test.spawn_child.parent";
-        }
-        impl aether_actor::Singleton for ParentCap {}
-        impl HandlesKind<Hatch> for ParentCap {}
-        impl NativeActor for ParentCap {
-            type Config = (Arc<AtomicU32>, Arc<AtomicU32>);
-            fn init(
-                (spawn_count, child_received): Self::Config,
-                _ctx: &mut NativeInitCtx<'_>,
-            ) -> Result<Self, BootError> {
-                Ok(Self {
-                    spawn_count,
-                    child_received,
-                })
-            }
-        }
-        impl NativeDispatch for ParentCap {
-            fn __aether_dispatch_envelope(
-                &mut self,
-                ctx: &mut NativeCtx<'_>,
-                kind: KindId,
-                payload: &[u8],
-            ) -> Option<()> {
-                if kind.0 == Hatch::ID.0 {
-                    let _ = Hatch::decode_from_bytes(payload)?;
-                    let _id = ctx
-                        .spawn_child::<ChildCap>(Subname::Counter, Arc::clone(&self.child_received))
-                        .after_init(Ping { tag: 42 })
-                        .finish()
-                        .expect("spawn_child must succeed");
-                    self.spawn_count.fetch_add(1, AtomicOrdering::SeqCst);
-                    return Some(());
-                }
-                None
-            }
-        }
-
-        let (registry, mailer) = fresh_substrate();
-        let spawn_count = Arc::new(AtomicU32::new(0));
-        let child_received = Arc::new(AtomicU32::new(0));
-
-        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<ParentCap>((Arc::clone(&spawn_count), Arc::clone(&child_received)))
-            .build_passive()
-            .expect("ParentCap boots");
-
-        // Push Hatch at the parent's mailbox; the parent's handler
-        // calls `ctx.spawn_child::<ChildCap>` which in turn pushes a
-        // Ping at the new child via the after_init bootstrap.
-        let parent_id = registry
-            .lookup(<ParentCap as Actor>::NAMESPACE)
-            .expect("ParentCap claimed");
-        let MailboxEntry::Inbox { handler, .. } = registry.entry(parent_id).expect("sink") else {
-            panic!("expected mailbox entry");
-        };
-        let bytes = (Hatch { tag: 1 }).encode_into_bytes();
-        handler.enqueue(registry::test_owned_dispatch(
-            <Hatch as Kind>::ID,
-            Hatch::NAME,
-            &bytes,
-            1,
-        ));
-
-        let deadline = Instant::now() + Duration::from_millis(500);
-        while child_received.load(AtomicOrdering::SeqCst) < 1 && Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(5));
-        }
-        assert_eq!(
-            spawn_count.load(AtomicOrdering::SeqCst),
-            1,
-            "parent's handler ran spawn_child exactly once"
-        );
-        assert_eq!(
-            child_received.load(AtomicOrdering::SeqCst),
-            1,
-            "spawn_child's after_init mail dispatched as the child's first envelope"
-        );
-
-        // Child is Live in the chassis's actor registry under the
-        // ADR-0099 §3 lineage fold: the parent is a root cap (depth-1,
-        // carry == id), so the child's id folds the child node's ActorId
-        // onto the parent's id — not the flat `hash(NAMESPACE:subname)`.
-        let child_id = MailboxId(aether_data::with_tag(
-            aether_data::Tag::Mailbox,
-            aether_data::fold_lineage(
-                parent_id.0,
-                aether_data::ActorId::instanced("test.spawn_child.child", "0"),
-            ),
-        ));
-        assert!(
-            chassis.actor_registry().is_live(child_id),
-            "spawned child should be Live in the actor registry under the lineage-folded id"
-        );
-
-        drop(chassis);
-    }
-
-    /// Issue 607 Phase 4a verify: `ctx.shutdown()` from inside an
-    /// instanced actor's handler triggers the drain → unwire → exit
-    /// path, flips the `actor_registry` slot to `Dead`, and inserts the
-    /// id into `tombstones`. A reused subname after retirement returns
-    /// `SpawnError::SubnameRetired`.
-    #[test]
-    fn ctx_shutdown_marks_dead_runs_unwire_tombstones_id() {
-        use crate::actor::native::spawn::{SpawnError, Subname};
-        use crate::mail::registry::MailboxEntry;
-        use aether_actor::{HandlesKind, Instanced};
-        use aether_data::{Kind, KindId as DataKindId};
-        use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
-
-        #[repr(C)]
-        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-        struct Quit {
-            tag: u32,
-        }
-        impl Kind for Quit {
-            const NAME: &'static str = "test.shutdown.quit";
-            const ID: DataKindId = DataKindId(0xE0E1_E2E3_E4E5_E6E7);
-            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != size_of::<Self>() {
-                    return None;
-                }
-                Some(bytemuck::pod_read_unaligned(bytes))
-            }
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
-        }
-
-        struct Closer {
-            close_observed: Arc<AtomicU32>,
-        }
-        impl Actor for Closer {
-            const NAMESPACE: &'static str = "test.shutdown.closer";
-        }
-        impl Instanced for Closer {}
-        impl HandlesKind<Quit> for Closer {}
-        impl NativeActor for Closer {
-            type Config = Arc<AtomicU32>;
-            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-                Ok(Self {
-                    close_observed: config,
-                })
-            }
-            fn unwire(&mut self, _ctx: &mut NativeCtx<'_>) {
-                self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
-            }
-        }
-        impl NativeDispatch for Closer {
-            fn __aether_dispatch_envelope(
-                &mut self,
-                ctx: &mut NativeCtx<'_>,
-                kind: KindId,
-                payload: &[u8],
-            ) -> Option<()> {
-                if kind.0 == Quit::ID.0 {
-                    let _ = Quit::decode_from_bytes(payload)?;
-                    ctx.shutdown();
-                    return Some(());
-                }
-                None
-            }
-        }
-
-        let (registry, mailer) = fresh_substrate();
-        let close_observed = Arc::new(AtomicU32::new(0));
-        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .build_passive()
-            .expect("empty chassis boots");
-
-        let id = chassis
-            .spawn_actor::<Closer>(Subname::Counter, Arc::clone(&close_observed))
-            .finish()
-            .expect("spawn instanced actor");
-
-        // Push a Quit envelope at the spawned mailbox via the
-        // registered sink handler. The handler's `ctx.shutdown()`
-        // flips the dispatcher's flag; after the handler returns the
-        // trampoline drains, runs `unwire`, marks Dead, tombstones.
-        let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("sink registered")
-        else {
-            panic!("expected mailbox entry for instanced actor");
-        };
-        let bytes = (Quit { tag: 1 }).encode_into_bytes();
-        handler.enqueue(registry::test_owned_dispatch(
-            <Quit as Kind>::ID,
-            Quit::NAME,
-            &bytes,
-            1,
-        ));
-
-        // Wait for unwire to run + the registry slot to flip Dead.
-        let deadline = Instant::now() + Duration::from_millis(500);
-        while close_observed.load(AtomicOrdering::SeqCst) == 0 && Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(5));
-        }
-        assert_eq!(
-            close_observed.load(AtomicOrdering::SeqCst),
-            1,
-            "unwire fired exactly once after the dispatcher drained"
-        );
-        // Spin until the slot transitions Dead — the dispatcher
-        // thread runs `mark_dead` after `unwire`, so there's a
-        // small window between the close-observed bump above and the
-        // registry update.
-        let deadline = Instant::now() + Duration::from_millis(500);
-        while chassis.actor_registry().is_live(id) && Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(5));
-        }
-        assert!(
-            !chassis.actor_registry().is_live(id),
-            "registry slot should transition Live → Dead after unwire runs"
-        );
-        assert!(
-            chassis.actor_registry().is_tombstoned(id),
-            "tombstone insertion forbids reuse of the retired full name"
-        );
-
-        // Spawning again under the same `Subname::Counter` would
-        // increment the per-Spawner counter (so it'd target a fresh
-        // id, not collide); reuse the same `Named` subname to land
-        // back at the tombstoned id.
-        let err = chassis
-            .spawn_actor::<Closer>(Subname::Named("0"), Arc::clone(&close_observed))
-            .finish()
-            .expect_err("retired subname must reject");
-        assert!(
-            matches!(err, SpawnError::SubnameRetired { .. }),
-            "expected SubnameRetired, got {err:?}"
-        );
-
-        drop(chassis);
-    }
-
-    /// Contention/backoff-sensitive tests live in `mod heavy`: chassis
-    /// teardown drives `unwire` across pooled spawned actors through the
-    /// worker park/wake path, which loses wakes under oversubscription, so
-    /// they are serialized into the `serial-heavy` nextest group
+    /// Contention/backoff-sensitive tests live in `mod heavy`: these boot a
+    /// chassis and sleep-poll a 500ms dispatcher-scheduling deadline (some
+    /// drive teardown across pooled spawned actors through the worker
+    /// park/wake path, which loses wakes under oversubscription), so they
+    /// are serialized into the `serial-heavy` nextest group
     /// (`.config/nextest.toml`).
     mod heavy {
         use super::*;
+
+        /// Issue 552 stage 1: end-to-end smoke for the new
+        /// [`Builder::with_actor`] boot path. Boots a hand-rolled
+        /// `NativeActor + NativeDispatch` fixture, looks it up via
+        /// [`PassiveChassis::actor`], pushes one envelope at the cap's
+        /// mailbox, and asserts the dispatcher routed it to the right
+        /// handler. Stage 1 lands the infrastructure; stage 2 migrates
+        /// real caps onto it. This test is the load-bearing acceptance
+        /// gate.
+        #[test]
+        fn with_actor_boots_dispatches_and_tears_down() {
+            use crate::mail::registry::MailboxEntry;
+            use aether_data::Kind;
+            use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+
+            // Fixture kind: a 4-byte cast-shape payload so encode_into_bytes
+            // lands on the bytemuck path.
+            #[repr(C)]
+            #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+            struct Ping {
+                tag: u32,
+            }
+            impl Kind for Ping {
+                const NAME: &'static str = "test.with_actor.ping";
+                const ID: KindId = KindId(0xA1B2_C3D4_E5F6_0001);
+                fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+                    if bytes.len() != size_of::<Self>() {
+                        return None;
+                    }
+                    Some(bytemuck::pod_read_unaligned(bytes))
+                }
+                fn encode_into_bytes(&self) -> Vec<u8> {
+                    bytemuck::bytes_of(self).to_vec()
+                }
+            }
+
+            // Fixture cap. State behind interior mutability so `&self`
+            // dispatch can mutate it (the post-552 norm).
+            struct ProbeCap {
+                received: Arc<AtomicU32>,
+            }
+            impl Actor for ProbeCap {
+                const NAMESPACE: &'static str = "test.with_actor.probe";
+            }
+            impl aether_actor::Singleton for ProbeCap {}
+            impl HandlesKind<Ping> for ProbeCap {}
+
+            impl NativeActor for ProbeCap {
+                type Config = Arc<AtomicU32>;
+                fn init(
+                    config: Self::Config,
+                    _ctx: &mut NativeInitCtx<'_>,
+                ) -> Result<Self, BootError> {
+                    Ok(Self { received: config })
+                }
+            }
+
+            // Hand-rolled NativeDispatch — what the macro arm emits in
+            // task #731. The if-arm decodes Ping bytes, calls the
+            // handler, returns Some(()) on success.
+            impl NativeDispatch for ProbeCap {
+                fn __aether_dispatch_envelope(
+                    &mut self,
+                    _ctx: &mut NativeCtx<'_>,
+                    kind: KindId,
+                    payload: &[u8],
+                ) -> Option<()> {
+                    if kind.0 == Ping::ID.0 {
+                        let _decoded = Ping::decode_from_bytes(payload)?;
+                        self.received.fetch_add(1, AtomicOrdering::SeqCst);
+                        return Some(());
+                    }
+                    None
+                }
+            }
+
+            let (registry, mailer) = fresh_substrate();
+            let received = Arc::new(AtomicU32::new(0));
+
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<ProbeCap>(Arc::clone(&received))
+                .build_passive()
+                .expect("with_actor boot succeeds");
+
+            // Issue 629 / Phase A: chassis-level `actor::<X>()` retired.
+            // The cap is owned by its dispatcher thread; the test verifies
+            // the cap is alive via the mail dispatch round-trip below.
+
+            // Push one envelope at the cap's mailbox via the registry's
+            // sink handler. The dispatcher thread pulls from its inbox
+            // and routes through __aether_dispatch_envelope → on_ping.
+            let mailbox_id = registry
+                .lookup(<ProbeCap as Actor>::NAMESPACE)
+                .expect("with_actor claimed the mailbox");
+            let MailboxEntry::Inbox { handler, .. } =
+                registry.entry(mailbox_id).expect("sink registered")
+            else {
+                panic!("ProbeCap claim must be a sink entry");
+            };
+
+            let payload = Ping { tag: 0xDEAD_BEEF };
+            let bytes = payload.encode_into_bytes();
+            handler.enqueue(registry::test_owned_dispatch(
+                <Ping as Kind>::ID,
+                Ping::NAME,
+                &bytes,
+                1,
+            ));
+
+            // Wait briefly for the dispatcher thread to dispatch.
+            let deadline = Instant::now() + Duration::from_millis(500);
+            while received.load(AtomicOrdering::SeqCst) == 0 && Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(5));
+            }
+            assert_eq!(
+                received.load(AtomicOrdering::SeqCst),
+                1,
+                "dispatcher should have routed Ping → on_ping within the wait budget"
+            );
+
+            drop(chassis);
+        }
+
+        /// Issue 582: the chassis dispatcher trampoline stamps the
+        /// per-actor [`ActorSlots`] into TLS
+        /// for the duration of `init` and each handler call. A cap that
+        /// reaches for `Local::with_mut` from inside both lifecycle
+        /// stages must see its own state — verified end-to-end here so
+        /// the stamping wiring can't silently regress.
+        #[test]
+        fn with_actor_stamps_local_for_init_and_handler() {
+            use crate::mail::registry::MailboxEntry;
+            use aether_actor::Local;
+            use aether_data::Kind;
+            use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+
+            #[repr(C)]
+            #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+            struct Tick {
+                seq: u32,
+            }
+            impl Kind for Tick {
+                const NAME: &'static str = "test.local.tick";
+                const ID: KindId = KindId(0xA1B2_C3D4_E5F6_0002);
+                fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+                    if bytes.len() != size_of::<Self>() {
+                        return None;
+                    }
+                    Some(bytemuck::pod_read_unaligned(bytes))
+                }
+                fn encode_into_bytes(&self) -> Vec<u8> {
+                    bytemuck::bytes_of(self).to_vec()
+                }
+            }
+
+            // The cap holds an Arc<AtomicU32> the test reads after each
+            // dispatch. The actor-local counter is keyed by `TypeId<Counter>`
+            // — the chassis stamp is what makes `with_mut` resolve at
+            // all (outside a stamp it would `debug_assert!` panic).
+            struct LocalProbe {
+                observed: Arc<AtomicU32>,
+            }
+            impl Actor for LocalProbe {
+                const NAMESPACE: &'static str = "test.local.probe";
+            }
+            impl aether_actor::Singleton for LocalProbe {}
+            impl HandlesKind<Tick> for LocalProbe {}
+
+            // Newtype-per-slot is the Local convention: each
+            // logical storage gets its own type, so two probes that
+            // both want a u32 don't alias under TypeId. The
+            // `#[local]` attribute is the shorthand for the
+            // marker impl.
+            #[derive(Default)]
+            #[aether_actor::local]
+            struct Counter(u32);
+
+            impl NativeActor for LocalProbe {
+                type Config = Arc<AtomicU32>;
+                fn init(
+                    config: Self::Config,
+                    _ctx: &mut NativeInitCtx<'_>,
+                ) -> Result<Self, BootError> {
+                    // Init runs inside the chassis builder's stamp guard
+                    // — write a sentinel so the handler test below proves
+                    // the same slots are reused across init→dispatch.
+                    Counter::with_mut(|c| c.0 = 100);
+                    Ok(Self { observed: config })
+                }
+            }
+
+            impl NativeDispatch for LocalProbe {
+                fn __aether_dispatch_envelope(
+                    &mut self,
+                    _ctx: &mut NativeCtx<'_>,
+                    kind: KindId,
+                    payload: &[u8],
+                ) -> Option<()> {
+                    if kind.0 == Tick::ID.0 {
+                        let _decoded = Tick::decode_from_bytes(payload)?;
+                        Counter::with_mut(|c| c.0 += 1);
+                        let snapshot = Counter::with(|c| c.0);
+                        self.observed.store(snapshot, AtomicOrdering::SeqCst);
+                        return Some(());
+                    }
+                    None
+                }
+            }
+
+            let (registry, mailer) = fresh_substrate();
+            let observed = Arc::new(AtomicU32::new(0));
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<LocalProbe>(Arc::clone(&observed))
+                .build_passive()
+                .expect("LocalProbe boots");
+
+            let mailbox_id = registry
+                .lookup(<LocalProbe as Actor>::NAMESPACE)
+                .expect("with_actor claimed the mailbox");
+            let MailboxEntry::Inbox { handler, .. } =
+                registry.entry(mailbox_id).expect("sink registered")
+            else {
+                panic!("LocalProbe claim must be a sink entry");
+            };
+
+            // Three dispatches. Init seeded 100; the handler bumps once
+            // per dispatch and snapshots — so observed should walk
+            // 101, 102, 103 in order. We assert the final 103 with a
+            // wait budget to cover dispatcher-thread scheduling.
+            for seq in 0..3 {
+                let payload = Tick { seq };
+                let bytes = payload.encode_into_bytes();
+                handler.enqueue(registry::test_owned_dispatch(
+                    <Tick as Kind>::ID,
+                    Tick::NAME,
+                    &bytes,
+                    1,
+                ));
+            }
+
+            let deadline = Instant::now() + Duration::from_millis(500);
+            while observed.load(AtomicOrdering::SeqCst) != 103 && Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(5));
+            }
+            assert_eq!(
+                observed.load(AtomicOrdering::SeqCst),
+                103,
+                "init seeded 100 + 3 handler bumps ⇒ Local at 103 (proves the same \
+             ActorSlots is stamped across init and dispatch)"
+            );
+
+            drop(chassis);
+        }
+
+        /// Issue 607 Phase 3b verify: a singleton parent's handler calls
+        /// `ctx.spawn_child::<Child>(...)` to launch an instanced actor.
+        /// Asserts the child's `MailboxId` lands in the chassis's
+        /// `ActorRegistry` as a Live entry, and that the parent-pre-loaded
+        /// `after_init` mail dispatches as the child's first envelope.
+        #[test]
+        fn ctx_spawn_child_routes_through_handler() {
+            use crate::actor::native::spawn::Subname;
+            use crate::mail::registry::MailboxEntry;
+            use aether_actor::{HandlesKind, Instanced};
+            use aether_data::{Kind, KindId as DataKindId};
+            use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+
+            #[repr(C)]
+            #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+            struct Hatch {
+                tag: u32,
+            }
+            impl Kind for Hatch {
+                const NAME: &'static str = "test.spawn_child.hatch";
+                const ID: DataKindId = DataKindId(0xC0C1_C2C3_C4C5_C6C7);
+                fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+                    if bytes.len() != size_of::<Self>() {
+                        return None;
+                    }
+                    Some(bytemuck::pod_read_unaligned(bytes))
+                }
+                fn encode_into_bytes(&self) -> Vec<u8> {
+                    bytemuck::bytes_of(self).to_vec()
+                }
+            }
+
+            #[repr(C)]
+            #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+            struct Ping {
+                tag: u32,
+            }
+            impl Kind for Ping {
+                const NAME: &'static str = "test.spawn_child.ping";
+                const ID: DataKindId = DataKindId(0xD0D1_D2D3_D4D5_D6D7);
+                fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+                    if bytes.len() != size_of::<Self>() {
+                        return None;
+                    }
+                    Some(bytemuck::pod_read_unaligned(bytes))
+                }
+                fn encode_into_bytes(&self) -> Vec<u8> {
+                    bytemuck::bytes_of(self).to_vec()
+                }
+            }
+
+            struct ChildCap {
+                received: Arc<AtomicU32>,
+            }
+            impl Actor for ChildCap {
+                const NAMESPACE: &'static str = "test.spawn_child.child";
+            }
+            impl Instanced for ChildCap {}
+            impl HandlesKind<Ping> for ChildCap {}
+            impl NativeActor for ChildCap {
+                type Config = Arc<AtomicU32>;
+                fn init(
+                    config: Self::Config,
+                    _ctx: &mut NativeInitCtx<'_>,
+                ) -> Result<Self, BootError> {
+                    Ok(Self { received: config })
+                }
+            }
+            impl NativeDispatch for ChildCap {
+                fn __aether_dispatch_envelope(
+                    &mut self,
+                    _ctx: &mut NativeCtx<'_>,
+                    kind: KindId,
+                    payload: &[u8],
+                ) -> Option<()> {
+                    if kind.0 == Ping::ID.0 {
+                        let _ = Ping::decode_from_bytes(payload)?;
+                        self.received.fetch_add(1, AtomicOrdering::SeqCst);
+                        return Some(());
+                    }
+                    None
+                }
+            }
+
+            struct ParentCap {
+                spawn_count: Arc<AtomicU32>,
+                child_received: Arc<AtomicU32>,
+            }
+            impl Actor for ParentCap {
+                const NAMESPACE: &'static str = "test.spawn_child.parent";
+            }
+            impl aether_actor::Singleton for ParentCap {}
+            impl HandlesKind<Hatch> for ParentCap {}
+            impl NativeActor for ParentCap {
+                type Config = (Arc<AtomicU32>, Arc<AtomicU32>);
+                fn init(
+                    (spawn_count, child_received): Self::Config,
+                    _ctx: &mut NativeInitCtx<'_>,
+                ) -> Result<Self, BootError> {
+                    Ok(Self {
+                        spawn_count,
+                        child_received,
+                    })
+                }
+            }
+            impl NativeDispatch for ParentCap {
+                fn __aether_dispatch_envelope(
+                    &mut self,
+                    ctx: &mut NativeCtx<'_>,
+                    kind: KindId,
+                    payload: &[u8],
+                ) -> Option<()> {
+                    if kind.0 == Hatch::ID.0 {
+                        let _ = Hatch::decode_from_bytes(payload)?;
+                        let _id = ctx
+                            .spawn_child::<ChildCap>(
+                                Subname::Counter,
+                                Arc::clone(&self.child_received),
+                            )
+                            .after_init(Ping { tag: 42 })
+                            .finish()
+                            .expect("spawn_child must succeed");
+                        self.spawn_count.fetch_add(1, AtomicOrdering::SeqCst);
+                        return Some(());
+                    }
+                    None
+                }
+            }
+
+            let (registry, mailer) = fresh_substrate();
+            let spawn_count = Arc::new(AtomicU32::new(0));
+            let child_received = Arc::new(AtomicU32::new(0));
+
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<ParentCap>((Arc::clone(&spawn_count), Arc::clone(&child_received)))
+                .build_passive()
+                .expect("ParentCap boots");
+
+            // Push Hatch at the parent's mailbox; the parent's handler
+            // calls `ctx.spawn_child::<ChildCap>` which in turn pushes a
+            // Ping at the new child via the after_init bootstrap.
+            let parent_id = registry
+                .lookup(<ParentCap as Actor>::NAMESPACE)
+                .expect("ParentCap claimed");
+            let MailboxEntry::Inbox { handler, .. } = registry.entry(parent_id).expect("sink")
+            else {
+                panic!("expected mailbox entry");
+            };
+            let bytes = (Hatch { tag: 1 }).encode_into_bytes();
+            handler.enqueue(registry::test_owned_dispatch(
+                <Hatch as Kind>::ID,
+                Hatch::NAME,
+                &bytes,
+                1,
+            ));
+
+            let deadline = Instant::now() + Duration::from_millis(500);
+            while child_received.load(AtomicOrdering::SeqCst) < 1 && Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(5));
+            }
+            assert_eq!(
+                spawn_count.load(AtomicOrdering::SeqCst),
+                1,
+                "parent's handler ran spawn_child exactly once"
+            );
+            assert_eq!(
+                child_received.load(AtomicOrdering::SeqCst),
+                1,
+                "spawn_child's after_init mail dispatched as the child's first envelope"
+            );
+
+            // Child is Live in the chassis's actor registry under the
+            // ADR-0099 §3 lineage fold: the parent is a root cap (depth-1,
+            // carry == id), so the child's id folds the child node's ActorId
+            // onto the parent's id — not the flat `hash(NAMESPACE:subname)`.
+            let child_id = MailboxId(aether_data::with_tag(
+                aether_data::Tag::Mailbox,
+                aether_data::fold_lineage(
+                    parent_id.0,
+                    aether_data::ActorId::instanced("test.spawn_child.child", "0"),
+                ),
+            ));
+            assert!(
+                chassis.actor_registry().is_live(child_id),
+                "spawned child should be Live in the actor registry under the lineage-folded id"
+            );
+
+            drop(chassis);
+        }
+
+        /// Issue 607 Phase 4a verify: `ctx.shutdown()` from inside an
+        /// instanced actor's handler triggers the drain → unwire → exit
+        /// path, flips the `actor_registry` slot to `Dead`, and inserts the
+        /// id into `tombstones`. A reused subname after retirement returns
+        /// `SpawnError::SubnameRetired`.
+        #[test]
+        fn ctx_shutdown_marks_dead_runs_unwire_tombstones_id() {
+            use crate::actor::native::spawn::{SpawnError, Subname};
+            use crate::mail::registry::MailboxEntry;
+            use aether_actor::{HandlesKind, Instanced};
+            use aether_data::{Kind, KindId as DataKindId};
+            use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+
+            #[repr(C)]
+            #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+            struct Quit {
+                tag: u32,
+            }
+            impl Kind for Quit {
+                const NAME: &'static str = "test.shutdown.quit";
+                const ID: DataKindId = DataKindId(0xE0E1_E2E3_E4E5_E6E7);
+                fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+                    if bytes.len() != size_of::<Self>() {
+                        return None;
+                    }
+                    Some(bytemuck::pod_read_unaligned(bytes))
+                }
+                fn encode_into_bytes(&self) -> Vec<u8> {
+                    bytemuck::bytes_of(self).to_vec()
+                }
+            }
+
+            struct Closer {
+                close_observed: Arc<AtomicU32>,
+            }
+            impl Actor for Closer {
+                const NAMESPACE: &'static str = "test.shutdown.closer";
+            }
+            impl Instanced for Closer {}
+            impl HandlesKind<Quit> for Closer {}
+            impl NativeActor for Closer {
+                type Config = Arc<AtomicU32>;
+                fn init(
+                    config: Self::Config,
+                    _ctx: &mut NativeInitCtx<'_>,
+                ) -> Result<Self, BootError> {
+                    Ok(Self {
+                        close_observed: config,
+                    })
+                }
+                fn unwire(&mut self, _ctx: &mut NativeCtx<'_>) {
+                    self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
+                }
+            }
+            impl NativeDispatch for Closer {
+                fn __aether_dispatch_envelope(
+                    &mut self,
+                    ctx: &mut NativeCtx<'_>,
+                    kind: KindId,
+                    payload: &[u8],
+                ) -> Option<()> {
+                    if kind.0 == Quit::ID.0 {
+                        let _ = Quit::decode_from_bytes(payload)?;
+                        ctx.shutdown();
+                        return Some(());
+                    }
+                    None
+                }
+            }
+
+            let (registry, mailer) = fresh_substrate();
+            let close_observed = Arc::new(AtomicU32::new(0));
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .build_passive()
+                .expect("empty chassis boots");
+
+            let id = chassis
+                .spawn_actor::<Closer>(Subname::Counter, Arc::clone(&close_observed))
+                .finish()
+                .expect("spawn instanced actor");
+
+            // Push a Quit envelope at the spawned mailbox via the
+            // registered sink handler. The handler's `ctx.shutdown()`
+            // flips the dispatcher's flag; after the handler returns the
+            // trampoline drains, runs `unwire`, marks Dead, tombstones.
+            let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("sink registered")
+            else {
+                panic!("expected mailbox entry for instanced actor");
+            };
+            let bytes = (Quit { tag: 1 }).encode_into_bytes();
+            handler.enqueue(registry::test_owned_dispatch(
+                <Quit as Kind>::ID,
+                Quit::NAME,
+                &bytes,
+                1,
+            ));
+
+            // Wait for unwire to run + the registry slot to flip Dead.
+            let deadline = Instant::now() + Duration::from_millis(500);
+            while close_observed.load(AtomicOrdering::SeqCst) == 0 && Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(5));
+            }
+            assert_eq!(
+                close_observed.load(AtomicOrdering::SeqCst),
+                1,
+                "unwire fired exactly once after the dispatcher drained"
+            );
+            // Spin until the slot transitions Dead — the dispatcher
+            // thread runs `mark_dead` after `unwire`, so there's a
+            // small window between the close-observed bump above and the
+            // registry update.
+            let deadline = Instant::now() + Duration::from_millis(500);
+            while chassis.actor_registry().is_live(id) && Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(5));
+            }
+            assert!(
+                !chassis.actor_registry().is_live(id),
+                "registry slot should transition Live → Dead after unwire runs"
+            );
+            assert!(
+                chassis.actor_registry().is_tombstoned(id),
+                "tombstone insertion forbids reuse of the retired full name"
+            );
+
+            // Spawning again under the same `Subname::Counter` would
+            // increment the per-Spawner counter (so it'd target a fresh
+            // id, not collide); reuse the same `Named` subname to land
+            // back at the tombstoned id.
+            let err = chassis
+                .spawn_actor::<Closer>(Subname::Named("0"), Arc::clone(&close_observed))
+                .finish()
+                .expect_err("retired subname must reject");
+            assert!(
+                matches!(err, SpawnError::SubnameRetired { .. }),
+                "expected SubnameRetired, got {err:?}"
+            );
+
+            drop(chassis);
+        }
 
         /// Issue 685: chassis teardown drives `unwire` on every spawned
         /// instanced actor, even those that never received a self-shutdown

--- a/crates/aether-substrate/src/chassis/settlement.rs
+++ b/crates/aether-substrate/src/chassis/settlement.rs
@@ -724,90 +724,98 @@ mod tests {
         assert_eq!(decoded, r2);
     }
 
-    /// Resolves-within-cap: the signal fires after one round elapses
-    /// (exercising the re-arm path), and the helper returns `Settled`.
-    #[test]
-    fn await_internal_signal_resolves_after_rearm() {
-        let (tx, rx) = bounded::<()>(1);
-        // Fire from a sibling thread after roughly one round budget so
-        // the first `recv_timeout` times out (logging + re-arm) and the
-        // second resolves.
-        let handle = thread::spawn(move || {
-            thread::sleep(Duration::from_millis(30));
-            let _ = tx.try_send(());
-        });
-        let outcome = await_internal_signal(
-            &rx,
-            "test.rearm",
-            Duration::from_millis(10),
-            Duration::from_secs(5),
-            TerminalDisposition::Proceed,
-        );
-        handle.join().expect("firing thread joins");
-        assert!(matches!(outcome, WaitOutcome::Settled));
-    }
+    /// The `await_internal_signal` family drives the real `recv_timeout`
+    /// settlement loop (one spawns a firing thread) under sub-100ms round
+    /// budgets, so they live in `mod heavy` for the `serial-heavy` nextest
+    /// group (issue 1522).
+    mod heavy {
+        use super::*;
 
-    /// Cap-exhaustion: the signal never fires, so the helper exhausts
-    /// the cumulative cap and returns `Wedged` (not disconnected) for a
-    /// non-`Panic` disposition.
-    #[test]
-    fn await_internal_signal_cap_exhaustion_wedges() {
-        // Hold the sender alive so the channel doesn't disconnect —
-        // this is the silent-to-cap path, distinct from `Disconnected`.
-        let (_tx, rx) = bounded::<()>(1);
-        let outcome = await_internal_signal(
-            &rx,
-            "test.cap",
-            Duration::from_millis(5),
-            Duration::from_millis(20),
-            TerminalDisposition::ReplyErr,
-        );
-        match outcome {
-            WaitOutcome::Wedged(w) => {
-                assert!(!w.disconnected);
-                assert_eq!(w.gate, "test.cap");
-                assert!(w.waited >= Duration::from_millis(20));
-            }
-            WaitOutcome::Settled => panic!("expected a wedge, got Settled"),
+        /// Resolves-within-cap: the signal fires after one round elapses
+        /// (exercising the re-arm path), and the helper returns `Settled`.
+        #[test]
+        fn await_internal_signal_resolves_after_rearm() {
+            let (tx, rx) = bounded::<()>(1);
+            // Fire from a sibling thread after roughly one round budget so
+            // the first `recv_timeout` times out (logging + re-arm) and the
+            // second resolves.
+            let handle = thread::spawn(move || {
+                thread::sleep(Duration::from_millis(30));
+                let _ = tx.try_send(());
+            });
+            let outcome = await_internal_signal(
+                &rx,
+                "test.rearm",
+                Duration::from_millis(10),
+                Duration::from_secs(5),
+                TerminalDisposition::Proceed,
+            );
+            handle.join().expect("firing thread joins");
+            assert!(matches!(outcome, WaitOutcome::Settled));
         }
-    }
 
-    /// `Disconnected`: dropping the sender takes the same terminal path
-    /// as cap-exhaustion, with `disconnected` set.
-    #[test]
-    fn await_internal_signal_disconnect_wedges() {
-        let (tx, rx) = bounded::<()>(1);
-        drop(tx);
-        let outcome = await_internal_signal(
-            &rx,
-            "test.disconnect",
-            Duration::from_millis(50),
-            Duration::from_secs(5),
-            TerminalDisposition::Proceed,
-        );
-        match outcome {
-            WaitOutcome::Wedged(w) => {
-                assert!(w.disconnected);
-                assert_eq!(w.gate, "test.disconnect");
+        /// Cap-exhaustion: the signal never fires, so the helper exhausts
+        /// the cumulative cap and returns `Wedged` (not disconnected) for a
+        /// non-`Panic` disposition.
+        #[test]
+        fn await_internal_signal_cap_exhaustion_wedges() {
+            // Hold the sender alive so the channel doesn't disconnect —
+            // this is the silent-to-cap path, distinct from `Disconnected`.
+            let (_tx, rx) = bounded::<()>(1);
+            let outcome = await_internal_signal(
+                &rx,
+                "test.cap",
+                Duration::from_millis(5),
+                Duration::from_millis(20),
+                TerminalDisposition::ReplyErr,
+            );
+            match outcome {
+                WaitOutcome::Wedged(w) => {
+                    assert!(!w.disconnected);
+                    assert_eq!(w.gate, "test.cap");
+                    assert!(w.waited >= Duration::from_millis(20));
+                }
+                WaitOutcome::Settled => panic!("expected a wedge, got Settled"),
             }
-            WaitOutcome::Settled => panic!("expected a wedge, got Settled"),
         }
-    }
 
-    /// `Panic` disposition diverges inside the helper on a wedge —
-    /// asserts the gate fails attributably at the gate site.
-    #[test]
-    #[should_panic(expected = "gate test.panic wedged")]
-    fn await_internal_signal_panic_disposition_diverges() {
-        let (tx, rx) = bounded::<()>(1);
-        drop(tx);
-        let _ = await_internal_signal(
-            &rx,
-            "test.panic",
-            Duration::from_millis(5),
-            Duration::from_millis(20),
-            TerminalDisposition::Panic,
-        );
+        /// `Disconnected`: dropping the sender takes the same terminal path
+        /// as cap-exhaustion, with `disconnected` set.
+        #[test]
+        fn await_internal_signal_disconnect_wedges() {
+            let (tx, rx) = bounded::<()>(1);
+            drop(tx);
+            let outcome = await_internal_signal(
+                &rx,
+                "test.disconnect",
+                Duration::from_millis(50),
+                Duration::from_secs(5),
+                TerminalDisposition::Proceed,
+            );
+            match outcome {
+                WaitOutcome::Wedged(w) => {
+                    assert!(w.disconnected);
+                    assert_eq!(w.gate, "test.disconnect");
+                }
+                WaitOutcome::Settled => panic!("expected a wedge, got Settled"),
+            }
+        }
+
+        /// `Panic` disposition diverges inside the helper on a wedge —
+        /// asserts the gate fails attributably at the gate site.
+        #[test]
+        #[should_panic(expected = "gate test.panic wedged")]
+        fn await_internal_signal_panic_disposition_diverges() {
+            let (tx, rx) = bounded::<()>(1);
+            drop(tx);
+            let _ = await_internal_signal(
+                &rx,
+                "test.panic",
+                Duration::from_millis(5),
+                Duration::from_millis(20),
+                TerminalDisposition::Panic,
+            );
+        }
     }
 
     /// The settlement-notice payload postcard-decodes back to the

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -434,8 +434,9 @@ mod tests {
 
     /// End-to-end happy path: register a slot, push N envelopes,
     /// observe the worker drain them all and park the slot Idle.
-    #[test]
-    fn pool_drains_pushed_envelopes() {
+    /// Body lives here to share the parent helpers; the `#[test]` wrapper
+    /// is in `mod heavy` (issue 1522 — spawns a worker pool + `wait_until`).
+    fn pool_drains_pushed_envelopes_body() {
         let handle = standard_handle(1);
         let slot = CounterSlot::new("happy");
         let slot_dyn: Arc<dyn Drainable> = slot.clone();
@@ -462,9 +463,9 @@ mod tests {
 
     /// Two slots, both perpetually ready: a worker fairly round-robins
     /// (the budget yield is what enables this — without it one slot
-    /// would monopolise the worker until empty).
-    #[test]
-    fn two_slots_round_robin_under_budget() {
+    /// would monopolise the worker until empty). Body here, `#[test]`
+    /// wrapper in `mod heavy` (issue 1522 — worker pool + `wait_until`).
+    fn two_slots_round_robin_under_budget_body() {
         // One worker so the round-robin is observable. Custom budget
         // — a tiny mail cap means each slot hits Yielded quickly and
         // the worker drains the other.
@@ -519,9 +520,9 @@ mod tests {
     /// A handler panic escalates via the [`FatalAborter`]. The test
     /// uses [`PanicAborter`] (the test-only aborter) which `panic!`s
     /// instead of `process::exit`; the worker thread propagates the
-    /// panic, and `shutdown` returns it via `JoinHandle::join`.
-    #[test]
-    fn handler_panic_escalates_via_aborter() {
+    /// panic, and `shutdown` returns it via `JoinHandle::join`. Body here,
+    /// `#[test]` wrapper in `mod heavy` (issue 1522 — pool + `wait_until`).
+    fn handler_panic_escalates_via_aborter_body() {
         let aborter: Arc<dyn FatalAborter> = Arc::new(PanicAborter);
         let handle = Pool::start(
             PoolConfig {
@@ -605,6 +606,24 @@ mod tests {
     /// oversubscribing cores against one another.
     mod heavy {
         use super::*;
+
+        /// `#[test]` wrappers for the parent dispatch tests that spawn a
+        /// worker pool and `wait_until`-poll under a multi-second deadline
+        /// (issue 1522). Bodies stay in the parent to share its helpers.
+        #[test]
+        fn pool_drains_pushed_envelopes() {
+            pool_drains_pushed_envelopes_body();
+        }
+
+        #[test]
+        fn two_slots_round_robin_under_budget() {
+            two_slots_round_robin_under_budget_body();
+        }
+
+        #[test]
+        fn handler_panic_escalates_via_aborter() {
+            handler_panic_escalates_via_aborter_body();
+        }
 
         /// Stress: 4 slots × 1000 envelopes each across 2 workers. Confirm
         /// every envelope dispatches and no slot is left orphaned.

--- a/crates/aether-substrate/src/scheduler/spin_park.rs
+++ b/crates/aether-substrate/src/scheduler/spin_park.rs
@@ -463,21 +463,6 @@ mod tests {
         thread::park_timeout(Duration::from_millis(0));
     }
 
-    /// Shutdown signalled while a worker is in `acquire` resolves to
-    /// `Shutdown` rather than hanging.
-    #[test]
-    fn acquire_resolves_shutdown() {
-        let coord = Arc::new(SpinPark::with_spin_window(Duration::from_micros(50)));
-        let c2 = Arc::clone(&coord);
-        let worker =
-            thread::spawn(move || matches!(c2.acquire(|| None::<u32>), Acquired::Shutdown));
-        // Let it cycle into the park, then signal + unpark.
-        thread::sleep(Duration::from_millis(20));
-        coord.set_shutdown();
-        worker.thread().unpark();
-        assert!(worker.join().unwrap(), "acquire should resolve Shutdown");
-    }
-
     /// Contention/backoff-sensitive tests live in `mod heavy`: they exercise
     /// the spin-then-park backoff path, so they are serialized into the
     /// `serial-heavy` nextest group (`.config/nextest.toml`) to avoid
@@ -485,6 +470,21 @@ mod tests {
     mod heavy {
         use super::*;
         use crate::scheduler::calibrate;
+
+        /// Shutdown signalled while a worker is in `acquire` resolves to
+        /// `Shutdown` rather than hanging.
+        #[test]
+        fn acquire_resolves_shutdown() {
+            let coord = Arc::new(SpinPark::with_spin_window(Duration::from_micros(50)));
+            let c2 = Arc::clone(&coord);
+            let worker =
+                thread::spawn(move || matches!(c2.acquire(|| None::<u32>), Acquired::Shutdown));
+            // Let it cycle into the park, then signal + unpark.
+            thread::sleep(Duration::from_millis(20));
+            coord.set_shutdown();
+            worker.thread().unpark();
+            assert!(worker.join().unwrap(), "acquire should resolve Shutdown");
+        }
 
         /// Part 2 (iamacoffeepot/aether#1182): a genuine parked-worker wake
         /// folds one live `notify → wake` sample into the handoff estimate. A

--- a/crates/aether-substrate/tests/handle_store_disk_eviction.rs
+++ b/crates/aether-substrate/tests/handle_store_disk_eviction.rs
@@ -200,40 +200,46 @@ fn eviction_recovers_from_orphan_bin() {
     cleanup(&root);
 }
 
-#[test]
-fn eviction_ledger_stays_consistent_under_concurrent_writes() {
-    let root = scratch_root("ledger");
-    let cfg = cfg_with_budget(&root, u64::MAX);
-    let store = Arc::new(HandleStore::with_persist(
-        256 * 1024 * 1024,
-        Some(cfg.clone()),
-    ));
-    // 10 threads × 100 distinct entries × 256 bytes.
-    let handles: Vec<_> = (0..10u64)
-        .map(|t| {
-            let store = Arc::clone(&store);
-            thread::spawn(move || {
-                for i in 0..100u64 {
-                    let id = HandleId(t * 1000 + i + 1);
-                    let origin = TransformOrigin {
-                        component_mailbox: t,
-                        transform_index: 0,
-                        input_handle_ids: vec![],
-                    };
-                    store
-                        .put_persistent(id, KindId(7), vec![0u8; 256], Some(origin))
-                        .unwrap();
-                }
+/// Spawns 10 writer threads racing `put_persistent` and joins them, so it
+/// lives in `mod heavy` for the `serial-heavy` nextest group (issue 1522).
+mod heavy {
+    use super::*;
+
+    #[test]
+    fn eviction_ledger_stays_consistent_under_concurrent_writes() {
+        let root = scratch_root("ledger");
+        let cfg = cfg_with_budget(&root, u64::MAX);
+        let store = Arc::new(HandleStore::with_persist(
+            256 * 1024 * 1024,
+            Some(cfg.clone()),
+        ));
+        // 10 threads × 100 distinct entries × 256 bytes.
+        let handles: Vec<_> = (0..10u64)
+            .map(|t| {
+                let store = Arc::clone(&store);
+                thread::spawn(move || {
+                    for i in 0..100u64 {
+                        let id = HandleId(t * 1000 + i + 1);
+                        let origin = TransformOrigin {
+                            component_mailbox: t,
+                            transform_index: 0,
+                            input_handle_ids: vec![],
+                        };
+                        store
+                            .put_persistent(id, KindId(7), vec![0u8; 256], Some(origin))
+                            .unwrap();
+                    }
+                })
             })
-        })
-        .collect();
-    for h in handles {
-        h.join().unwrap();
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+        // Distinct ids → ledger equals actual on-disk bin bytes.
+        assert_eq!(store.disk_bytes(), actual_bin_bytes(&cfg));
+        assert_eq!(store.disk_bytes(), 1000 * 256);
+        cleanup(&root);
     }
-    // Distinct ids → ledger equals actual on-disk bin bytes.
-    assert_eq!(store.disk_bytes(), actual_bin_bytes(&cfg));
-    assert_eq!(store.disk_bytes(), 1000 * 256);
-    cleanup(&root);
 }
 
 #[test]

--- a/crates/aether-substrate/tests/native_actor_macro.rs
+++ b/crates/aether-substrate/tests/native_actor_macro.rs
@@ -163,139 +163,218 @@ fn wait_for(target: u32, counter: &AtomicU32, budget: Duration) -> bool {
     counter.load(AtomicOrdering::SeqCst) >= target
 }
 
-#[test]
-fn macro_emitted_cap_routes_postcard_kind_through_dispatch() {
-    let (registry, mailer) = fresh_substrate();
-    let greet_total = Arc::new(AtomicU32::new(0));
-    let ping_total = Arc::new(AtomicU32::new(0));
+/// Dispatcher-thread tests: each boots a cap and `wait_for`/sleep-polls an
+/// atomic up to a target under a 500ms–2s deadline (some spawn pool
+/// workers), so they live in `mod heavy` for the `serial-heavy` nextest
+/// group (issue 1522).
+mod heavy {
+    use super::*;
 
-    let chassis: PassiveChassis<TestChassis> =
-        Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<MacroProbeCap>(ProbeConfig {
-                greet_total: Arc::clone(&greet_total),
-                ping_total: Arc::clone(&ping_total),
-            })
-            .build_passive()
-            .expect("macro-emitted cap boots");
+    #[test]
+    fn macro_emitted_cap_routes_postcard_kind_through_dispatch() {
+        let (registry, mailer) = fresh_substrate();
+        let greet_total = Arc::new(AtomicU32::new(0));
+        let ping_total = Arc::new(AtomicU32::new(0));
 
-    push_envelope(&registry, MacroProbeCap::NAMESPACE, &Greet { tag: 7 });
-    assert!(
-        wait_for(7, &greet_total, Duration::from_millis(500)),
-        "macro dispatcher should route Greet → on_greet within budget"
-    );
-    assert_eq!(ping_total.load(AtomicOrdering::SeqCst), 0);
+        let chassis: PassiveChassis<TestChassis> =
+            Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<MacroProbeCap>(ProbeConfig {
+                    greet_total: Arc::clone(&greet_total),
+                    ping_total: Arc::clone(&ping_total),
+                })
+                .build_passive()
+                .expect("macro-emitted cap boots");
 
-    drop(chassis);
-}
-
-/// iamacoffeepot/aether#1135: a blob demuxer seeds a free `Pooled` actor
-/// via `seize_and_run` — the seed dispatches in place (no inbox deposit /
-/// `try_recv` repop) and the slot returns to `Idle`. Boots a real Pooled
-/// actor through the chassis, lets it quiesce, then resolves the seize
-/// handle off its registry `Inbox` entry, wins the `Idle → Running` seize,
-/// and runs one seed envelope.
-#[test]
-fn seize_and_run_dispatches_seed_in_place() {
-    use aether_substrate::mail::registry::MailboxEntry;
-    use aether_substrate::scheduler::{BatchBudget, SlotStateLabel};
-
-    let (registry, mailer) = fresh_substrate();
-    let greet_total = Arc::new(AtomicU32::new(0));
-    let ping_total = Arc::new(AtomicU32::new(0));
-
-    let chassis: PassiveChassis<TestChassis> =
-        Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<MacroProbeCap>(ProbeConfig {
-                greet_total: Arc::clone(&greet_total),
-                ping_total: Arc::clone(&ping_total),
-            })
-            .build_passive()
-            .expect("macro-emitted cap boots");
-
-    let id = registry
-        .lookup(MacroProbeCap::NAMESPACE)
-        .expect("cap mailbox registered");
-
-    // The cap boots with no pre-load mail, so its slot quiesces to `Idle`.
-    // Resolve the seize handle off the `Inbox` entry's deferred cell (the
-    // #1135 surfacing) and wait for the slot to be seizable.
-    let MailboxEntry::Inbox { seize, .. } = registry.entry(id).expect("entry exists") else {
-        panic!("expected an Inbox entry for the Pooled cap");
-    };
-    let seize = seize.get().expect("a Pooled actor exposes a seize handle");
-
-    let deadline = Instant::now() + Duration::from_millis(500);
-    let slot = loop {
-        if let Some(slot) = seize.try_seize() {
-            break slot;
-        }
+        push_envelope(&registry, MacroProbeCap::NAMESPACE, &Greet { tag: 7 });
         assert!(
-            Instant::now() < deadline,
-            "Pooled slot should quiesce to Idle and become seizable"
+            wait_for(7, &greet_total, Duration::from_millis(500)),
+            "macro dispatcher should route Greet → on_greet within budget"
         );
-        thread::sleep(Duration::from_millis(5));
-    };
-    // The seize put the slot in `Running`.
-    assert_eq!(seize.state().current(), SlotStateLabel::Running);
+        assert_eq!(ping_total.load(AtomicOrdering::SeqCst), 0);
 
-    // Build one seed envelope and dispatch it in place — no inbox bounce.
-    let payload = Greet { tag: 11 }.encode_into_bytes();
-    let seed = OwnedDispatch::disarmed(
-        <Greet as Kind>::ID,
-        Greet::NAME.to_owned(),
-        None,
-        Source::NONE,
-        MailRef::from(payload),
-        1,
-        MailId::NONE,
-        MailId::NONE,
-        None,
-        // The #1135 contract: a direct-dispatched seed has residence ≈ 0.
-        Nanos(0),
-        0,
-        MailboxId(0),
-    );
-    slot.seize_and_run(seed, BatchBudget::standard());
+        drop(chassis);
+    }
 
-    // Handler ran exactly once; the slot drained empty back to `Idle`.
-    assert_eq!(
-        greet_total.load(AtomicOrdering::SeqCst),
-        11,
-        "the seed dispatched through on_greet in place"
-    );
-    assert_eq!(ping_total.load(AtomicOrdering::SeqCst), 0);
-    assert_eq!(
-        seize.state().current(),
-        SlotStateLabel::Idle,
-        "the slot drained empty and returned to Idle"
-    );
+    /// iamacoffeepot/aether#1135: a blob demuxer seeds a free `Pooled` actor
+    /// via `seize_and_run` — the seed dispatches in place (no inbox deposit /
+    /// `try_recv` repop) and the slot returns to `Idle`. Boots a real Pooled
+    /// actor through the chassis, lets it quiesce, then resolves the seize
+    /// handle off its registry `Inbox` entry, wins the `Idle → Running` seize,
+    /// and runs one seed envelope.
+    #[test]
+    fn seize_and_run_dispatches_seed_in_place() {
+        use aether_substrate::mail::registry::MailboxEntry;
+        use aether_substrate::scheduler::{BatchBudget, SlotStateLabel};
 
-    drop(chassis);
-}
+        let (registry, mailer) = fresh_substrate();
+        let greet_total = Arc::new(AtomicU32::new(0));
+        let ping_total = Arc::new(AtomicU32::new(0));
 
-#[test]
-fn macro_emitted_cap_routes_cast_kind_through_dispatch() {
-    let (registry, mailer) = fresh_substrate();
-    let greet_total = Arc::new(AtomicU32::new(0));
-    let ping_total = Arc::new(AtomicU32::new(0));
+        let chassis: PassiveChassis<TestChassis> =
+            Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<MacroProbeCap>(ProbeConfig {
+                    greet_total: Arc::clone(&greet_total),
+                    ping_total: Arc::clone(&ping_total),
+                })
+                .build_passive()
+                .expect("macro-emitted cap boots");
 
-    let chassis: PassiveChassis<TestChassis> =
-        Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<MacroProbeCap>(ProbeConfig {
-                greet_total: Arc::clone(&greet_total),
-                ping_total: Arc::clone(&ping_total),
-            })
-            .build_passive()
-            .expect("macro-emitted cap boots");
+        let id = registry
+            .lookup(MacroProbeCap::NAMESPACE)
+            .expect("cap mailbox registered");
 
-    push_envelope(&registry, MacroProbeCap::NAMESPACE, &Ping { seq: 42 });
-    assert!(
-        wait_for(42, &ping_total, Duration::from_millis(500)),
-        "macro dispatcher should route Ping → on_ping within budget"
-    );
-    assert_eq!(greet_total.load(AtomicOrdering::SeqCst), 0);
+        // The cap boots with no pre-load mail, so its slot quiesces to `Idle`.
+        // Resolve the seize handle off the `Inbox` entry's deferred cell (the
+        // #1135 surfacing) and wait for the slot to be seizable.
+        let MailboxEntry::Inbox { seize, .. } = registry.entry(id).expect("entry exists") else {
+            panic!("expected an Inbox entry for the Pooled cap");
+        };
+        let seize = seize.get().expect("a Pooled actor exposes a seize handle");
 
-    drop(chassis);
+        let deadline = Instant::now() + Duration::from_millis(500);
+        let slot = loop {
+            if let Some(slot) = seize.try_seize() {
+                break slot;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "Pooled slot should quiesce to Idle and become seizable"
+            );
+            thread::sleep(Duration::from_millis(5));
+        };
+        // The seize put the slot in `Running`.
+        assert_eq!(seize.state().current(), SlotStateLabel::Running);
+
+        // Build one seed envelope and dispatch it in place — no inbox bounce.
+        let payload = Greet { tag: 11 }.encode_into_bytes();
+        let seed = OwnedDispatch::disarmed(
+            <Greet as Kind>::ID,
+            Greet::NAME.to_owned(),
+            None,
+            Source::NONE,
+            MailRef::from(payload),
+            1,
+            MailId::NONE,
+            MailId::NONE,
+            None,
+            // The #1135 contract: a direct-dispatched seed has residence ≈ 0.
+            Nanos(0),
+            0,
+            MailboxId(0),
+        );
+        slot.seize_and_run(seed, BatchBudget::standard());
+
+        // Handler ran exactly once; the slot drained empty back to `Idle`.
+        assert_eq!(
+            greet_total.load(AtomicOrdering::SeqCst),
+            11,
+            "the seed dispatched through on_greet in place"
+        );
+        assert_eq!(ping_total.load(AtomicOrdering::SeqCst), 0);
+        assert_eq!(
+            seize.state().current(),
+            SlotStateLabel::Idle,
+            "the slot drained empty and returned to Idle"
+        );
+
+        drop(chassis);
+    }
+
+    #[test]
+    fn macro_emitted_cap_routes_cast_kind_through_dispatch() {
+        let (registry, mailer) = fresh_substrate();
+        let greet_total = Arc::new(AtomicU32::new(0));
+        let ping_total = Arc::new(AtomicU32::new(0));
+
+        let chassis: PassiveChassis<TestChassis> =
+            Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<MacroProbeCap>(ProbeConfig {
+                    greet_total: Arc::clone(&greet_total),
+                    ping_total: Arc::clone(&ping_total),
+                })
+                .build_passive()
+                .expect("macro-emitted cap boots");
+
+        push_envelope(&registry, MacroProbeCap::NAMESPACE, &Ping { seq: 42 });
+        assert!(
+            wait_for(42, &ping_total, Duration::from_millis(500)),
+            "macro dispatcher should route Ping → on_ping within budget"
+        );
+        assert_eq!(greet_total.load(AtomicOrdering::SeqCst), 0);
+
+        drop(chassis);
+    }
+
+    #[test]
+    fn macro_routes_task_completions_by_output_type() {
+        let (registry, mailer) = fresh_substrate();
+        let obs = TaskObservations {
+            dispatched: Arc::new(AtomicU32::new(0)),
+            a_value: Arc::new(AtomicU64::new(0)),
+            a_calls: Arc::new(AtomicU32::new(0)),
+            b_tag: Arc::new(AtomicU32::new(0)),
+            b_calls: Arc::new(AtomicU32::new(0)),
+        };
+
+        let chassis: PassiveChassis<TestChassis> =
+            Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<TaskRouteCap>(obs.clone())
+                .build_passive()
+                .expect("task-routing cap boots");
+
+        // Kick off both dispatches. Each handler spawns a worker that fills
+        // the ledger and pushes a `TaskCompletionWake` back to this actor's
+        // own mailbox; the chassis redelivers those wakes through the macro's
+        // single completion arm, which routes each to its output-typed
+        // handler.
+        push_envelope(&registry, TaskRouteCap::NAMESPACE, &KickA { seed: 7 });
+        push_envelope(&registry, TaskRouteCap::NAMESPACE, &KickB { seed: 9 });
+
+        assert!(
+            wait_for(1, &obs.a_calls, Duration::from_secs(2)),
+            "the ResultA completion routed to on_result_a"
+        );
+        assert!(
+            wait_for(1, &obs.b_calls, Duration::from_secs(2)),
+            "the ResultB completion routed to on_result_b"
+        );
+
+        // Each completion landed on the correct handler with the correct
+        // payload — output-type routing, not a kind id.
+        assert_eq!(
+            obs.a_value.load(AtomicOrdering::SeqCst),
+            7,
+            "on_result_a saw its own dispatch's value"
+        );
+        assert_eq!(
+            obs.b_tag.load(AtomicOrdering::SeqCst),
+            9,
+            "on_result_b saw its own dispatch's tag"
+        );
+
+        // Neither completion was mis-delivered to the other-typed handler:
+        // each task handler fired exactly once. A wrong-type probe in the
+        // completion arm must leave the ledger entry intact (non-consuming
+        // `try_take_task_done`) — if it consumed, one handler would swallow
+        // the other's completion and its call count would be 0.
+        assert_eq!(
+            obs.a_calls.load(AtomicOrdering::SeqCst),
+            1,
+            "on_result_a fired exactly once (no mis-routed extra completion)"
+        );
+        assert_eq!(
+            obs.b_calls.load(AtomicOrdering::SeqCst),
+            1,
+            "on_result_b fired exactly once"
+        );
+        assert_eq!(
+            obs.dispatched.load(AtomicOrdering::SeqCst),
+            2,
+            "both kick handlers dispatched a worker"
+        );
+
+        drop(chassis);
+    }
 }
 
 /// Type-level assertion that the macro emits the universal
@@ -506,75 +585,4 @@ impl NativeActor for TaskRouteCap {
         self.obs.b_calls.fetch_add(1, AtomicOrdering::SeqCst);
         done.resolve(ctx);
     }
-}
-
-#[test]
-fn macro_routes_task_completions_by_output_type() {
-    let (registry, mailer) = fresh_substrate();
-    let obs = TaskObservations {
-        dispatched: Arc::new(AtomicU32::new(0)),
-        a_value: Arc::new(AtomicU64::new(0)),
-        a_calls: Arc::new(AtomicU32::new(0)),
-        b_tag: Arc::new(AtomicU32::new(0)),
-        b_calls: Arc::new(AtomicU32::new(0)),
-    };
-
-    let chassis: PassiveChassis<TestChassis> =
-        Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<TaskRouteCap>(obs.clone())
-            .build_passive()
-            .expect("task-routing cap boots");
-
-    // Kick off both dispatches. Each handler spawns a worker that fills
-    // the ledger and pushes a `TaskCompletionWake` back to this actor's
-    // own mailbox; the chassis redelivers those wakes through the macro's
-    // single completion arm, which routes each to its output-typed
-    // handler.
-    push_envelope(&registry, TaskRouteCap::NAMESPACE, &KickA { seed: 7 });
-    push_envelope(&registry, TaskRouteCap::NAMESPACE, &KickB { seed: 9 });
-
-    assert!(
-        wait_for(1, &obs.a_calls, Duration::from_secs(2)),
-        "the ResultA completion routed to on_result_a"
-    );
-    assert!(
-        wait_for(1, &obs.b_calls, Duration::from_secs(2)),
-        "the ResultB completion routed to on_result_b"
-    );
-
-    // Each completion landed on the correct handler with the correct
-    // payload — output-type routing, not a kind id.
-    assert_eq!(
-        obs.a_value.load(AtomicOrdering::SeqCst),
-        7,
-        "on_result_a saw its own dispatch's value"
-    );
-    assert_eq!(
-        obs.b_tag.load(AtomicOrdering::SeqCst),
-        9,
-        "on_result_b saw its own dispatch's tag"
-    );
-
-    // Neither completion was mis-delivered to the other-typed handler:
-    // each task handler fired exactly once. A wrong-type probe in the
-    // completion arm must leave the ledger entry intact (non-consuming
-    // `try_take_task_done`) — if it consumed, one handler would swallow
-    // the other's completion and its call count would be 0.
-    assert_eq!(
-        obs.a_calls.load(AtomicOrdering::SeqCst),
-        1,
-        "on_result_a fired exactly once (no mis-routed extra completion)"
-    );
-    assert_eq!(
-        obs.b_calls.load(AtomicOrdering::SeqCst),
-        1,
-        "on_result_b fired exactly once"
-    );
-    assert_eq!(
-        obs.dispatched.load(AtomicOrdering::SeqCst),
-        2,
-        "both kick handlers dispatched a worker"
-    );
-
-    drop(chassis);
 }


### PR DESCRIPTION
A judgment pass, not a mechanical sweep. Moves genuinely contention-sensitive tests into a `mod heavy` submodule so the `serial-heavy` nextest group serializes them and they stop wedging a saturated `--workspace` run. Test modules only; no production code.

Bar for moving: spawns threads/processes, awaits across a cross-thread deadline, or sleep-then-assert-presence. Left in place: cheap synchronous state-machine / budget-math unit tests, and starvation-safe assert-absence tests.

Newly gaining `mod heavy`:
- `engines_cap` (both tests fork a real headless substrate), `handle` (3 dispatcher-thread tests), `chassis/settlement` (4 `await_internal_signal_*` recv_timeout tests), `native_actor_macro` (4 wait_for/seize dispatch tests), `anthropic/cli` (the subprocess-reap timeout test), `handle_store_disk_eviction` (the 10-writer-thread test), `test_bench/bench` (all 5 boot a multi-worker chassis).

Relocated into an existing `mod heavy`:
- `dag/tests` (4 retention/timeout tests), `scheduler/spin_park` (acquire-shutdown thread test), `scheduler/pool` (3 worker-pool wait_until tests, via body+wrapper delegation to share helpers), `engine/proxy` (the TCP round-trip test), `chassis/builder` (4 dispatcher-scheduling wait tests).

Deliberately left out (noted for review):
- `scheduler/slot` and `scheduler/worker_deque`: all tests drive slots/deques synchronously on the test thread (pure state-machine / budget-math) — no spawn, no cross-thread deadline. (slot.rs untouched, so no overlap with the in-flight scheduler-hardening PR.)
- `engine/server` and `tcp/mod`: a `drive` helper polls a single mail round-trip under a very generous 2s/10s deadline — cheap single-dispatch awaits, not contention-flaky.
- `render`: its lone sleep asserts an absence (decode-drop), which starvation cannot flip.

Verified the moved tests appear under `serial-heavy` via cargo nextest show-config test-groups --profile ci.

Closes #1522