### PR TITLE
ci(issue-labels): allow guide as a title meta-scope

### DIFF
--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -23,7 +23,7 @@ jobs:
 
             // Meta-scopes: cross-cutting work that isn't a single crate.
             // No `crate:*` label is applied for these.
-            const META_SCOPES = ['ci', 'docs', 'adr', 'qodana', 'repo', 'release', 'workflow'];
+            const META_SCOPES = ['ci', 'docs', 'adr', 'qodana', 'repo', 'release', 'workflow', 'guide'];
 
             // {type}({scope}): <subject>  OR  {type}({scope}/{subfeat}): <subject>
             const titleRegex = new RegExp(


### PR DESCRIPTION
The title-lint workflow recognized `ci` / `docs` / `adr` / `qodana` / `repo` / `release` / `workflow` as meta-scopes but not `guide`, so `docs(guide):` titles for the `docs/guide/` tree (e.g. #1551) were flagged `invalid-title`. `docs/guide/` is an established docs tree (`foundations/`, `systems/`, `SUMMARY.md`), so `guide` is a legitimate cross-cutting scope.

Adds `guide` to `META_SCOPES`. Per the bot's design, meta-scopes apply no `crate:*` label; this just makes the scope valid and lets the `invalid-title` flag auto-clear on matching issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
