### PR TITLE
fix(substrate): settle the obligation when a drop-on-shutdown inbox discards mail

### DIFF
--- a/crates/aether-substrate-bundle/tests/headless_autoload.rs
+++ b/crates/aether-substrate-bundle/tests/headless_autoload.rs
@@ -34,75 +34,81 @@ use aether_substrate_bundle::test_bench::test_helpers::{
     init_save_sandbox, locate_component_wasm, test_namespace_roots,
 };
 
-mod heavy {
-    use super::*;
-    use std::time::Instant;
+// Nested under `mod tests` so the nextest test name is
+// `tests::heavy::…` and the `test(/::heavy::/)` serial-heavy filter
+// matches it — a top-level `mod heavy` yields `heavy::…` (no leading
+// `::`) and silently leaks into the parallel pool (#1564).
+mod tests {
+    mod heavy {
+        use super::super::*;
+        use std::time::Instant;
 
-    #[test]
-    fn autoloaded_component_comes_up_with_no_hub() {
-        let strict = env::var("AETHER_REQUIRE_RUNTIME").is_ok();
-        let Some(wasm_path) = locate_component_wasm("probe") else {
-            assert!(
-                !strict,
-                "AETHER_REQUIRE_RUNTIME set but probe.wasm not pre-built; \
+        #[test]
+        fn autoloaded_component_comes_up_with_no_hub() {
+            let strict = env::var("AETHER_REQUIRE_RUNTIME").is_ok();
+            let Some(wasm_path) = locate_component_wasm("probe") else {
+                assert!(
+                    !strict,
+                    "AETHER_REQUIRE_RUNTIME set but probe.wasm not pre-built; \
                  CI's `Pre-build component wasm for scenario tests` step is missing it",
-            );
-            eprintln!(
-                "skipping: probe.wasm not built; \
+                );
+                eprintln!(
+                    "skipping: probe.wasm not built; \
                  run `cargo build --target wasm32-unknown-unknown -p aether-test-fixtures --examples`",
-            );
-            return;
-        };
-        let wasm = fs::read(&wasm_path).expect("read probe wasm");
+                );
+                return;
+            };
+            let wasm = fs::read(&wasm_path).expect("read probe wasm");
 
-        // Round-trip the component through the pack format — the same
-        // bytes the bundle bin would embed and decode at boot.
-        let pack = Pack {
-            chassis: ChassisSettings::default(),
-            components: vec![PackedComponent {
-                wasm,
-                config: Vec::new(),
-                name: Some("probe".to_owned()),
-                export: None,
-            }],
-        };
-        let decoded = decode_pack(&encode_pack(&pack)).expect("pack round trip");
+            // Round-trip the component through the pack format — the same
+            // bytes the bundle bin would embed and decode at boot.
+            let pack = Pack {
+                chassis: ChassisSettings::default(),
+                components: vec![PackedComponent {
+                    wasm,
+                    config: Vec::new(),
+                    name: Some("probe".to_owned()),
+                    export: None,
+                }],
+            };
+            let decoded = decode_pack(&encode_pack(&pack)).expect("pack round trip");
 
-        // A hub-less headless env: no `rpc_addr`, no hub connection, and
-        // persistence off so the boot touches no shared on-disk state.
-        let env = HeadlessEnv {
-            namespace_roots: test_namespace_roots(init_save_sandbox("headless-autoload")),
-            http: HttpConfig::default(),
-            anthropic: AnthropicConfig::default(),
-            gemini: GeminiConfig::default(),
-            tick_period: Duration::from_millis(16),
-            rpc_addr: None,
-            workers: None,
-            persist: PersistOverride::Argv(None),
-            handle_store_max_bytes: None,
-            autoload: decoded
-                .components
-                .into_iter()
-                .map(AutoloadComponent::from)
-                .collect(),
-        };
+            // A hub-less headless env: no `rpc_addr`, no hub connection, and
+            // persistence off so the boot touches no shared on-disk state.
+            let env = HeadlessEnv {
+                namespace_roots: test_namespace_roots(init_save_sandbox("headless-autoload")),
+                http: HttpConfig::default(),
+                anthropic: AnthropicConfig::default(),
+                gemini: GeminiConfig::default(),
+                tick_period: Duration::from_millis(16),
+                rpc_addr: None,
+                workers: None,
+                persist: PersistOverride::Argv(None),
+                handle_store_max_bytes: None,
+                autoload: decoded
+                    .components
+                    .into_iter()
+                    .map(AutoloadComponent::from)
+                    .collect(),
+            };
 
-        // `build` queues the autoload mail; the worker pool (up after
-        // build) dispatches the load without the driver loop running,
-        // so the trampoline appears without ever calling `run()`.
-        let built = HeadlessChassis::build(env).expect("build headless chassis");
-        let deadline = Instant::now() + Duration::from_secs(30);
-        loop {
-            if built.resolve_actor::<WasmTrampoline>("probe").is_some() {
-                break;
+            // `build` queues the autoload mail; the worker pool (up after
+            // build) dispatches the load without the driver loop running,
+            // so the trampoline appears without ever calling `run()`.
+            let built = HeadlessChassis::build(env).expect("build headless chassis");
+            let deadline = Instant::now() + Duration::from_secs(30);
+            loop {
+                if built.resolve_actor::<WasmTrampoline>("probe").is_some() {
+                    break;
+                }
+                assert!(
+                    Instant::now() < deadline,
+                    "autoloaded probe trampoline did not come up within 30s; live instances: {:?}",
+                    built.resolve_actors::<WasmTrampoline>(),
+                );
+                thread::sleep(Duration::from_millis(25));
             }
-            assert!(
-                Instant::now() < deadline,
-                "autoloaded probe trampoline did not come up within 30s; live instances: {:?}",
-                built.resolve_actors::<WasmTrampoline>(),
-            );
-            thread::sleep(Duration::from_millis(25));
+            // Dropping `built` shuts the passives down in reverse boot order.
         }
-        // Dropping `built` shuts the passives down in reverse boot order.
     }
 }

--- a/crates/aether-substrate/src/chassis/ctx.rs
+++ b/crates/aether-substrate/src/chassis/ctx.rs
@@ -418,6 +418,14 @@ impl<'a> ChassisCtx<'a> {
             // `env.kind_name` out of the `SendError` payload.
             Arc::new(move |dispatch: OwnedDispatch| {
                 let Some(tx) = weak.upgrade() else {
+                    // ADR-0094: the cap dropped its `MailboxSender` during
+                    // shutdown — the mail is discarded at this relay seam,
+                    // not held here, so mark the obligation transferred.
+                    // Without this a send racing teardown (e.g. a loaded
+                    // component's `subscribe_self` arriving as the lifecycle
+                    // cap shuts down) drops an armed `OwnedDispatch` and
+                    // trips the debug guard (#1564).
+                    dispatch.mark_transferred();
                     tracing::warn!(
                         target: "aether_substrate::capability",
                         kind = %dispatch.kind_name,
@@ -427,6 +435,8 @@ impl<'a> ChassisCtx<'a> {
                 };
                 let env: Envelope = dispatch;
                 if let Err(mpsc::SendError(env)) = tx.send(env) {
+                    // ADR-0094: discarded at the relay seam — transfer.
+                    env.mark_transferred();
                     tracing::warn!(
                         target: "aether_substrate::capability",
                         kind = %env.kind_name,
@@ -552,10 +562,14 @@ mod tests {
     use aether_actor::local::with_stamped;
     use aether_kinds::descriptors;
 
+    use aether_kinds::trace::Nanos;
+
     use crate::actor::registry::ActorRegistry;
     use crate::handle_store::HandleStore;
+    use crate::mail::registry::MailboxEntry;
+    use crate::mail::{KindId, MailId, MailRef, Source};
     use crate::runtime::lifecycle::PanicAborter;
-    use crate::scheduler::{Pool, PoolConfig};
+    use crate::scheduler::{Pool, PoolConfig, PoolHandle};
 
     /// Per-actor scratch type for the iamacoffeepot/aether#1272 round-trip
     /// test. Mirrors the `ActorLogRing` shape (`Default + Local`) at the
@@ -625,5 +639,130 @@ mod tests {
             Probe::try_with(|p| p.0).expect("any stamped slots carry Probe")
         });
         assert_eq!(other_read, 0, "fresh slots see the Local at its default");
+    }
+
+    /// The long-lived owned infra a `ChassisCtx` borrows from. Held by
+    /// the test for the duration of the claim so the registered handler
+    /// outlives the `ctx` that registered it.
+    type TestInfra = (
+        Arc<Registry>,
+        Arc<Mailer>,
+        Arc<crate::Spawner>,
+        Arc<dyn FatalAborter>,
+        PoolHandle,
+    );
+
+    fn test_infra() -> TestInfra {
+        let registry = Arc::new(Registry::new());
+        for d in descriptors::all() {
+            let _ = registry.register_kind_with_descriptor(d);
+        }
+        let store = Arc::new(HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
+        let aborter: Arc<dyn FatalAborter> = Arc::new(PanicAborter);
+        let actor_registry = Arc::new(ActorRegistry::new());
+        let pool = Pool::start(PoolConfig::default(), Arc::clone(&aborter));
+        let spawner = Arc::new(crate::Spawner::new(
+            Arc::clone(&registry),
+            actor_registry,
+            Arc::clone(&mailer),
+            Arc::clone(&aborter),
+            pool.wake_sink(),
+        ));
+        (registry, mailer, spawner, aborter, pool)
+    }
+
+    /// An armed `OwnedDispatch` addressed at `id`, shaped like the
+    /// `subscribe_self` mail a loaded component sends from its `wire`
+    /// hook. Armed, so dropping it without `discharge`/`mark_transferred`
+    /// trips the ADR-0094 guard in a debug build.
+    fn armed_subscribe_self(id: MailboxId) -> OwnedDispatch {
+        OwnedDispatch::armed(
+            KindId(7),
+            "aether.lifecycle.subscribe_self".to_owned(),
+            None,
+            Source::NONE,
+            MailRef::from(Vec::new()),
+            1,
+            MailId::new(id, 1),
+            MailId::new(id, 1),
+            None,
+            Nanos(0),
+            0,
+            id,
+        )
+    }
+
+    /// ADR-0094 / #1564: the `claim_mailbox_drop_on_shutdown` inbox
+    /// closure registers under a `Weak` sender, so once the cap sheds its
+    /// `MailboxSender` at shutdown the `weak.upgrade()` returns `None`. A
+    /// mail arriving in that window (e.g. a loaded component's
+    /// `subscribe_self` racing the lifecycle cap's teardown) must be
+    /// `mark_transferred` at the seam, not dropped armed — which would
+    /// trip the obligation guard and fatally abort the substrate.
+    #[test]
+    fn drop_on_shutdown_inbox_transfers_obligation_when_sender_gone() {
+        let (registry, mailer, spawner, aborter, _pool) = test_infra();
+        let claim_id;
+        {
+            let mut fallback: Option<FallbackRouter> = None;
+            let mut claimed_actor_mailboxes: Vec<MailboxId> = Vec::new();
+            let mut ctx = ChassisCtx::new(
+                &registry,
+                &mailer,
+                &mut fallback,
+                &aborter,
+                &mut claimed_actor_mailboxes,
+                &spawner,
+            );
+            let claim = ctx
+                .claim_mailbox_drop_on_shutdown_with_override("test.1564.sender_gone")
+                .expect("claim succeeds");
+            claim_id = claim.id;
+            // Drop the only strong `Sender` — the registry's `Weak` now
+            // fails to upgrade, exactly as it does once a cap shuts down.
+            drop(claim.mailbox_sender);
+            drop(claim.receiver);
+        }
+        let Some(MailboxEntry::Inbox { handler, .. }) = registry.entry(claim_id) else {
+            panic!("claimed mailbox should be an Inbox entry");
+        };
+        // Pre-fix this dropped the armed dispatch and panicked the guard.
+        handler.enqueue(armed_subscribe_self(claim_id));
+    }
+
+    /// ADR-0094 / #1564: the receiver-gone branch (`tx.send` returns
+    /// `SendError` because the dispatcher's receiver dropped) must also
+    /// `mark_transferred`, not drop the armed dispatch.
+    #[test]
+    fn drop_on_shutdown_inbox_transfers_obligation_when_receiver_gone() {
+        let (registry, mailer, spawner, aborter, _pool) = test_infra();
+        let claim_id;
+        // Hold the `MailboxSender` so `weak.upgrade()` still succeeds; the
+        // dropped receiver is what forces the `SendError` branch.
+        let _keep_sender;
+        {
+            let mut fallback: Option<FallbackRouter> = None;
+            let mut claimed_actor_mailboxes: Vec<MailboxId> = Vec::new();
+            let mut ctx = ChassisCtx::new(
+                &registry,
+                &mailer,
+                &mut fallback,
+                &aborter,
+                &mut claimed_actor_mailboxes,
+                &spawner,
+            );
+            let claim = ctx
+                .claim_mailbox_drop_on_shutdown_with_override("test.1564.receiver_gone")
+                .expect("claim succeeds");
+            claim_id = claim.id;
+            drop(claim.receiver);
+            _keep_sender = claim.mailbox_sender;
+        }
+        let Some(MailboxEntry::Inbox { handler, .. }) = registry.entry(claim_id) else {
+            panic!("claimed mailbox should be an Inbox entry");
+        };
+        // Pre-fix this dropped the armed dispatch and panicked the guard.
+        handler.enqueue(armed_subscribe_self(claim_id));
     }
 }


### PR DESCRIPTION
Closes iamacoffeepot/aether#1564.

## Summary

An ADR-0094 settlement-obligation leak fatally aborted the substrate when a component's `aether.lifecycle.subscribe_self` (sent from its `wire` hook) raced the lifecycle cap's teardown. The `claim_mailbox_drop_on_shutdown_with_override` inbox closure registers under a `Weak` sender and discards mail on two abandonment branches — `weak.upgrade()` returning `None` (the cap shed its `MailboxSender` at shutdown) and `tx.send` returning `SendError` (the dispatcher receiver dropped). Both dropped the armed `OwnedDispatch` without `mark_transferred()`, so the obligation guard tripped. The closure runs synchronously on the sender's worker, so the abort surfaced on whichever test was loading a component under contention (flaked `headless_autoload` on #1559, `cap_registry` on #1563).

The three sibling relay closures (`claim_mailbox_with_override`, the spawned-instanced-actor closure) already `mark_transferred` on these seams; this one was missed when ADR-0094 landed. The fix mirrors them on both branches.

Also nests the `headless_autoload` heavy test under `mod tests` so its nextest name gains the `::heavy::` segment the `serial-heavy` filter matches — a top-level `mod heavy` yielded `heavy::…` (no leading `::`) and silently leaked into the parallel pool, which is how the leak surfaced there. (The marker miss is incidental, not the cause — #1563's victim was an ordinary non-heavy test.)

Follow-up #1565 tracks unifying the three relay closures behind one obligation-settling helper so this class of miss can't recur.

## Test plan

- Two deterministic regression tests in `chassis/ctx.rs` drive an armed dispatch through each abandonment branch (sender-gone and receiver-gone) and assert no obligation-guard panic.
- `headless_autoload` heavy test confirmed re-categorized: `cargo nextest list -E 'test(/::heavy::/)'` now lists `tests::heavy::autoloaded_component_comes_up_with_no_hub`.
- Full `scripts/preflight.sh --qodana` green (fmt, clippy, doc, workspace nextest, wasm32 cross-build, qodana).

## Generated by

`/implement` — agent execution of [scoped issue #1564](https://github.com/iamacoffeepot/aether/issues/1564).
