### PR TITLE
chore(substrate): drop the vestigial instanced pending counter

### DIFF
--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -44,7 +44,6 @@
 //! the same drain tail ([`Self::drain_after_seed`]).
 
 use std::any::Any;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -127,12 +126,6 @@ where
     /// envelope dispatch. Wrapped in [`PooledSlots`] for the `Sync`
     /// safety story — see that type's doc-comment.
     slots: PooledSlots,
-    /// Per-actor inbox-pending counter, decremented after every
-    /// successful dispatch. `None` for singleton caps (ADR-0082 retired
-    /// the frame-bound drain that was the singleton consumer); `Some`
-    /// for instanced actors, where `Spawner::shutdown_instanced` reads
-    /// it to coordinate teardown (issue 685).
-    pending: Option<Arc<AtomicU64>>,
     /// Chassis-level actor registry. Used by [`Self::finalize_registry`]
     /// to drain `monitors_of[id]` and prune `monitoring[id]` from each
     /// target on shutdown.
@@ -179,7 +172,6 @@ where
         actor: Box<A>,
         binding: Arc<NativeBinding>,
         slots: Box<ActorSlots>,
-        pending: Option<Arc<AtomicU64>>,
         actor_registry: Arc<ActorRegistry>,
         mailer: Arc<Mailer>,
         self_id: MailboxId,
@@ -189,7 +181,6 @@ where
             actor: Mutex::new(Some(actor)),
             binding,
             slots: PooledSlots(slots),
-            pending,
             actor_registry,
             mailer,
             self_id,
@@ -306,9 +297,6 @@ where
         // discharge site — every wasm component and native actor (issue
         // 634 Phase 4) drains through here.
         env.discharge();
-        if let Some(p) = &self.pending {
-            p.fetch_sub(1, Ordering::AcqRel);
-        }
     }
 
     /// The close hook in the slot teardown sequence. Wraps `actor.unwire`

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -420,16 +420,6 @@ impl Spawner {
         // and external mail addressed to the dead mailbox warn-drops.
         let strong_sender: Arc<mpsc::Sender<Envelope>> = Arc::new(tx.clone());
         let weak_for_handler = Arc::downgrade(&strong_sender);
-        // Per-actor inbox-pending counter. Sink handler ++ on push;
-        // dispatcher slot -- after handling. Pre-PR-4 the test bench's
-        // `wait_instanced_quiesce` queried this through
-        // `Spawner::instanced_pending`; ADR-0080 settlement gating
-        // retires that polling path. The counter survives because the
-        // `DispatcherSlot` still threads it as the optional `pending`
-        // arg, but nothing queries the value today — a future cleanup
-        // PR can drop it entirely.
-        let pending = Arc::new(AtomicU64::new(0));
-        let pending_for_handler = Arc::clone(&pending);
         // Issue 635 PR C: pool wake hook. Populated post-init below
         // (every actor is pool-dispatched since issue 1187); empty until
         // then so the closure's `get()` is a single relaxed atomic load.
@@ -438,12 +428,6 @@ impl Spawner {
         // iamacoffeepot/aether#848 PR 3: closure takes `OwnedDispatch`
         // and routes it through [`relay_or_transfer`] — the shared
         // upgrade → send → wake core with both ADR-0094 transfer seams.
-        // The instanced-only `pending` bracket stays here at the call
-        // site: `fetch_add` before the relay, `fetch_sub` on either
-        // abandonment arm, so the at-rest value is identical to the
-        // pre-helper code (a delivered envelope's `-1` happens in the
-        // dispatcher after drain). The counter is provably unread today
-        // (`wait_instanced_quiesce` retired); #1567 removes it entirely.
         // ADR-0099 §3: register under the lineage-folded `id`, not
         // `hash(full_name)` — the rendered name is display / reverse-map
         // only and no longer derives the id.
@@ -451,11 +435,9 @@ impl Spawner {
             id,
             full_name.clone(),
             Arc::new(move |dispatch: OwnedDispatch| {
-                pending_for_handler.fetch_add(1, Ordering::AcqRel);
                 match relay_or_transfer(dispatch, &weak_for_handler, &wake_for_handler) {
                     RelayOutcome::Delivered => {}
                     RelayOutcome::SenderGone { kind_name } => {
-                        pending_for_handler.fetch_sub(1, Ordering::AcqRel);
                         tracing::warn!(
                             target: "aether_substrate::spawn",
                             kind = %kind_name,
@@ -463,7 +445,6 @@ impl Spawner {
                         );
                     }
                     RelayOutcome::ReceiverGone { kind_name } => {
-                        pending_for_handler.fetch_sub(1, Ordering::AcqRel);
                         tracing::warn!(
                             target: "aether_substrate::spawn",
                             kind = %kind_name,
@@ -532,11 +513,8 @@ impl Spawner {
 
         // Pre-load bootstrap mail. tx is alive (rx is held by the
         // transport; nobody's polling yet), so these sends always
-        // succeed. The per-actor `pending` counter increments here
-        // for symmetry with the sink-handler path; the value is no
-        // longer queried (PR 4 retired `wait_instanced_quiesce`).
+        // succeed.
         for env in after_init_mail {
-            pending.fetch_add(1, Ordering::AcqRel);
             // mpsc::Sender::send only fails when the receiver
             // disconnects; rx is alive here. Discard on the
             // theoretical impossibility.
@@ -557,7 +535,6 @@ impl Spawner {
             actor,
             Arc::clone(&transport),
             slots,
-            Some(Arc::clone(&pending)),
             Arc::clone(&self.actor_registry),
             Arc::clone(&self.mailer),
             id,

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -22,7 +22,6 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::marker::PhantomData;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
 
 use crate::actor::native::binding::NativeBinding;
 use crate::actor::native::dispatcher_slot::DispatcherSlot;
@@ -344,7 +343,6 @@ struct ClaimResources {
     mailbox_id: MailboxId,
     transport: Arc<NativeBinding>,
     mailbox_sender: MailboxSender,
-    pending: Option<Arc<AtomicU64>>,
     wake_slot: Arc<MailboxWakeSlot>,
     slots: Box<ActorSlots>,
 }
@@ -437,27 +435,20 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
             )))));
         }
 
-        // Frame-bound caps (today: render) claim through the
-        // frame-bound path so the `pending` counter feeds the chassis
-        // frame loop. Free-running caps take the regular drop-on-
-        // shutdown claim. Both share the same dispatcher trampoline
-        // shape apart from the post-dispatch decrement.
-        //
         // ADR-0082: every cap takes the drop-on-shutdown claim. The
         // FRAME_BARRIER frame-bound claim variant retired with the
         // per-frame drain barrier — settlement gating on the
         // LifecycleAdvance chain root is the frame-integration gate
-        // now, so no cap needs a pending-counter registration.
+        // now.
         let claim_result = ctx.claim_mailbox_drop_on_shutdown::<A>().map(|claim| {
             (
                 claim.id,
                 claim.receiver,
                 claim.mailbox_sender,
-                None,
                 claim.wake_slot,
             )
         });
-        let (mailbox_id, receiver, mailbox_sender, pending, wake_slot) = match claim_result {
+        let (mailbox_id, receiver, mailbox_sender, wake_slot) = match claim_result {
             Ok(c) => c,
             Err(e) => {
                 // Release the namespace claim we just made — otherwise
@@ -489,7 +480,6 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
                 mailbox_id,
                 transport,
                 mailbox_sender,
-                pending,
                 wake_slot,
                 slots,
             },
@@ -616,7 +606,6 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
             mailbox_id,
             transport,
             mailbox_sender,
-            pending,
             wake_slot,
             slots,
         } = resources;
@@ -632,7 +621,6 @@ impl<A: NativeActor + NativeDispatch> PassiveBoot for NativeActorBoot<A> {
             actor,
             Arc::clone(&transport),
             slots,
-            pending,
             actor_registry,
             mailer_clone,
             mailbox_id,


### PR DESCRIPTION
Closes iamacoffeepot/aether#1567.

## Summary

The per-actor inbox pending AtomicU64 was write-only. It was incremented in the instanced relay closure and the after_init pre-load bracket, decremented after every dispatch in DispatcherSlot, and threaded through DispatcherSlot::new and the chassis builder's ClaimResources — but nothing read the value. Its only reader, wait_instanced_quiesce, retired when ADR-0080 settlement gating landed.

This deletes the AtomicU64, its fetch_add/fetch_sub brackets, and the pending arg from DispatcherSlot::new and ClaimResources, across spawn.rs, dispatcher_slot.rs, and builder.rs. Behavior is byte-identical — nothing read the value.

Follow-up to #1565: with the counter gone, the instanced relay closure loses its only divergence from the drop-on-shutdown closure and now routes through the relay_or_transfer helper with no per-site bookkeeping at all.

No public API, wire-format, or behavior change. DispatcherSlot::new is pub(crate), so its signature change is crate-internal.

## Test plan

- Full scripts/preflight.sh --qodana green (fmt, clippy -D warnings, doc, nextest including the heavy instanced-spawn / teardown set, wasm32 cross-build, qodana at threshold).
- The dispatch-path / instanced-teardown tests cover the removed decrement: it is a no-op since nothing read the counter.

## Generated by

/implement — agent execution of scoped issue #1567.
