### PR TITLE
feat(actor-derive): diagnose duplicate handler kinds and missing namespace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ dependencies = [
  "quote",
  "serde",
  "syn",
+ "trybuild",
 ]
 
 [[package]]

--- a/crates/aether-actor-derive/Cargo.toml
+++ b/crates/aether-actor-derive/Cargo.toml
@@ -17,6 +17,7 @@ bytemuck = { version = "1.19", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 inventory = "0.3"
 aether-actor = { path = "../aether-actor" }
+trybuild = "1"
 
 [lints]
 workspace = true

--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -1853,6 +1853,31 @@ fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
         ));
     }
 
+    // Two `#[handler]` methods that accept the same mail kind would emit
+    // two `HandlesKind<K>` impls (a coherence error) plus a dead second
+    // dispatch arm the first arm always shadows. Reject the duplicate at
+    // compile time, spanned at the later handler. The macro has no type
+    // resolution, so dedup is by token equality (`types_token_eq`), not
+    // by resolved `KindId`.
+    for (i, later) in handlers.iter().enumerate() {
+        if let Some(earlier) = handlers[..i]
+            .iter()
+            .find(|earlier| types_token_eq(&earlier.kind_ty, &later.kind_ty))
+        {
+            let earlier_name = &earlier.method.sig.ident;
+            let kind_ty = &later.kind_ty;
+            return Err(syn::Error::new_spanned(
+                &later.method.sig.ident,
+                format!(
+                    "two #[handler] methods accept the same mail kind `{}` (also on \
+                     `{earlier_name}`) — each kind routes to exactly one handler. Give each \
+                     handler a distinct kind.",
+                    quote!(#kind_ty)
+                ),
+            ));
+        }
+    }
+
     // ADR-0090 (issue 1256): the trait now takes `init(config: Self::Config,
     // ctx: &mut C)`. If the user declared `type Config = …`, leave their
     // init alone — they're expected to spell out the `config` param. If
@@ -1919,6 +1944,41 @@ fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
     // Component for X` to a sibling `impl ::aether_actor::Actor`
     // block so satisfying `FfiActor: Actor` works without making the
     // user split the impl manually.
+    //
+    // Validate the const surface first: `NAMESPACE` is required (the
+    // marker `impl Actor` carries it) and is the only authorable const on
+    // the `Actor` super-trait. A removed `SCHEDULING` const (issue 1187)
+    // and any stray const are rejected at their own span, and a missing
+    // `NAMESPACE` at the type — each a pointed diagnostic rather than a
+    // later "no associated const NAMESPACE" error against the surfaceless
+    // `Actor` trait.
+    let mut has_namespace = false;
+    for c in &consts {
+        if c.ident == "NAMESPACE" {
+            has_namespace = true;
+        } else if c.ident == "SCHEDULING" {
+            return Err(syn::Error::new_spanned(
+                c,
+                "`SCHEDULING` was removed (issue 1187): every actor drains on the chassis \
+                 worker pool. Drop the const — never block a handler; offload blocking work \
+                 to a `ctx.spawn`'d thread that feeds results back as mail.",
+            ));
+        } else {
+            return Err(syn::Error::new_spanned(
+                c,
+                "#[actor] impl FfiActor for X accepts only \
+                 `const NAMESPACE: &'static str = …` — the `Actor` super-trait carries no \
+                 other authorable const",
+            ));
+        }
+    }
+    if !has_namespace {
+        return Err(syn::Error::new_spanned(
+            self_ty,
+            "#[actor] impl FfiActor for X must declare \
+             `const NAMESPACE: &'static str = ...` so the marker `impl Actor` can carry it",
+        ));
+    }
     let const_tokens = consts.iter();
     let actor_impl = if consts.is_empty() {
         quote! {}
@@ -2215,6 +2275,31 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
         }
     }
 
+    // Two `#[handler]` methods that accept the same mail kind would emit
+    // two `HandlesKind<K>` impls (a coherence error) plus a dead second
+    // dispatch arm the first arm always shadows. Reject the duplicate at
+    // compile time, spanned at the later handler. The macro has no type
+    // resolution, so dedup is by token equality (`types_token_eq`,
+    // matching the task-handler check above), not by resolved `KindId`.
+    for (i, later) in handlers.iter().enumerate() {
+        if let Some(earlier) = handlers[..i]
+            .iter()
+            .find(|earlier| types_token_eq(&earlier.kind_ty, &later.kind_ty))
+        {
+            let earlier_name = &earlier.method.sig.ident;
+            let kind_ty = &later.kind_ty;
+            return Err(syn::Error::new_spanned(
+                &later.method.sig.ident,
+                format!(
+                    "two #[handler] methods accept the same mail kind `{}` (also on \
+                     `{earlier_name}`) — each kind routes to exactly one handler. Give each \
+                     handler a distinct kind.",
+                    quote!(#kind_ty)
+                ),
+            ));
+        }
+    }
+
     // `NAMESPACE` is declared on the supertrait `Actor`, but the user
     // wrote it inside `impl NativeActor for X` for the symmetric
     // authoring shape. Route the const onto a sibling `impl Actor for X`
@@ -2228,18 +2313,47 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
     // expansion does not duplicate them. The native-only impls below
     // still emit unchanged.
     //
-    // Dispatch placement is no longer authorable (issue 1187): the
-    // scheduling enum + trait const were removed — every actor drains on
-    // the chassis worker pool. Reject a leftover `SCHEDULING` const with
-    // a pointed diagnostic instead of letting it pass through to a
-    // "no associated const SCHEDULING" error against the surfaceless
-    // `Actor` trait.
-    if let Some(c) = consts.iter().find(|c| c.ident == "SCHEDULING") {
+    //
+    // Validate the const surface in one pass. Dispatch placement is no
+    // longer authorable (issue 1187): the scheduling enum + trait const
+    // were removed — every actor drains on the chassis worker pool, so a
+    // leftover `SCHEDULING` const earns a pointed diagnostic. Any const
+    // other than `NAMESPACE` is stray (the `Actor` super-trait carries no
+    // other
+    // authorable const) and is rejected at its own span rather than
+    // silently routed onto the sibling `impl Actor` block; and the
+    // presence of `NAMESPACE` is tracked so a block that omits it fails
+    // here (spanned at the type, mirroring the `#[bridge]` path) instead
+    // of at a later "no associated const NAMESPACE" error against the
+    // surfaceless `Actor` trait. A `skip_markers` (bridge-wrapped) block
+    // legitimately omits `NAMESPACE` — the `#[bridge]` expansion emits
+    // the marker `impl Actor` carrying it as a sibling — so the
+    // missing-NAMESPACE check is gated on `!opts.skip_markers`.
+    let mut has_namespace = false;
+    for c in &consts {
+        if c.ident == "NAMESPACE" {
+            has_namespace = true;
+        } else if c.ident == "SCHEDULING" {
+            return Err(syn::Error::new_spanned(
+                c,
+                "`SCHEDULING` was removed (issue 1187): every actor drains on the chassis \
+                 worker pool. Drop the const — never block a handler; offload blocking work \
+                 to a `ctx.spawn`'d thread that feeds results back as mail.",
+            ));
+        } else {
+            return Err(syn::Error::new_spanned(
+                c,
+                "#[actor] impl NativeActor for X accepts only \
+                 `const NAMESPACE: &'static str = …` — the `Actor` super-trait carries no \
+                 other authorable const",
+            ));
+        }
+    }
+    if !has_namespace && !opts.skip_markers {
         return Err(syn::Error::new_spanned(
-            c,
-            "`SCHEDULING` was removed (issue 1187): every actor drains on the chassis \
-             worker pool. Drop the const — never block a handler; offload blocking work \
-             to a `ctx.spawn`'d thread that feeds results back as mail.",
+            self_ty,
+            "#[actor] impl NativeActor for X must declare \
+             `const NAMESPACE: &'static str = ...` so the marker `impl Actor` can carry it",
         ));
     }
     // NAMESPACE passes through unchanged because its RHS is a

--- a/crates/aether-actor-derive/tests/ui.rs
+++ b/crates/aether-actor-derive/tests/ui.rs
@@ -1,0 +1,28 @@
+//! `#[actor]` macro trybuild fixtures (iamacoffeepot/aether#1553).
+//!
+//! The `tests/ui/` fixtures exercise the spanned diagnostics the
+//! `#[actor]` macro emits on BOTH direct expansion paths — wasm
+//! (`impl FfiActor for X`) and native (`impl NativeActor for X`) — so a
+//! malformed actor block earns a pointed error at the author's code
+//! instead of a downstream type error against a generated impl:
+//!
+//!   - duplicate `#[handler]` mail kinds (spanned at the later handler),
+//!   - a missing `const NAMESPACE` (spanned at the type),
+//!   - a stray non-`NAMESPACE` const (spanned at the const).
+//!
+//! Each is golden-tested on both paths to keep the wasm / native
+//! diagnostic surface symmetric. `.stderr` goldens are toolchain-
+//! sensitive — regenerate with `TRYBUILD=overwrite cargo test -p
+//! aether-actor-derive --test ui`.
+
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/ui/accepts_minimal_actor.rs");
+    t.compile_fail("tests/ui/rejects_duplicate_handler_kind_ffi.rs");
+    t.compile_fail("tests/ui/rejects_duplicate_handler_kind_native.rs");
+    t.compile_fail("tests/ui/rejects_missing_namespace_ffi.rs");
+    t.compile_fail("tests/ui/rejects_missing_namespace_native.rs");
+    t.compile_fail("tests/ui/rejects_stray_const_ffi.rs");
+    t.compile_fail("tests/ui/rejects_stray_const_native.rs");
+}

--- a/crates/aether-actor-derive/tests/ui/accepts_minimal_actor.rs
+++ b/crates/aether-actor-derive/tests/ui/accepts_minimal_actor.rs
@@ -1,0 +1,39 @@
+//! Baseline: a minimal well-formed `#[actor] impl FfiActor` — one
+//! `#[handler]` plus a `const NAMESPACE` — expands cleanly. Guards the
+//! reject fixtures against false positives: the new diagnostics must
+//! fire on the malformed shapes, not on every actor.
+
+use aether_actor::actor;
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.ping")]
+struct Ping {
+    seq: u32,
+}
+
+struct Minimal;
+
+#[actor]
+impl aether_actor::FfiActor for Minimal {
+    const NAMESPACE: &'static str = "minimal";
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, aether_actor::BootError>
+    where
+        C: aether_actor::Resolver,
+    {
+        Ok(Minimal)
+    }
+
+    #[handler]
+    fn on_ping(&mut self, _ctx: &mut aether_actor::FfiCtx<'_>, _ping: Ping) {}
+}
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/rejects_duplicate_handler_kind_ffi.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_duplicate_handler_kind_ffi.rs
@@ -1,0 +1,44 @@
+//! Two `#[handler]` methods on one `#[actor] impl FfiActor` block that
+//! accept the same mail kind are rejected, spanned at the later handler.
+//! Each kind routes to exactly one handler; a duplicate would emit two
+//! `HandlesKind<K>` impls (a coherence error) and a dead second dispatch
+//! arm.
+
+use aether_actor::actor;
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.ping")]
+struct Ping {
+    seq: u32,
+}
+
+#[allow(dead_code)]
+struct Dup;
+
+#[actor]
+impl aether_actor::FfiActor for Dup {
+    const NAMESPACE: &'static str = "dup";
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, aether_actor::BootError>
+    where
+        C: aether_actor::Resolver,
+    {
+        Ok(Dup)
+    }
+
+    #[handler]
+    fn on_first(&mut self, _ctx: &mut aether_actor::FfiCtx<'_>, _ping: Ping) {}
+
+    #[handler]
+    fn on_second(&mut self, _ctx: &mut aether_actor::FfiCtx<'_>, _ping: Ping) {}
+}
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/rejects_duplicate_handler_kind_ffi.stderr
+++ b/crates/aether-actor-derive/tests/ui/rejects_duplicate_handler_kind_ffi.stderr
@@ -1,0 +1,5 @@
+error: two #[handler] methods accept the same mail kind `Ping` (also on `on_first`) — each kind routes to exactly one handler. Give each handler a distinct kind.
+  --> tests/ui/rejects_duplicate_handler_kind_ffi.rs:41:8
+   |
+41 |     fn on_second(&mut self, _ctx: &mut aether_actor::FfiCtx<'_>, _ping: Ping) {}
+   |        ^^^^^^^^^

--- a/crates/aether-actor-derive/tests/ui/rejects_duplicate_handler_kind_native.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_duplicate_handler_kind_native.rs
@@ -1,0 +1,53 @@
+//! Two `#[handler]` methods on one `#[actor] impl NativeActor` block
+//! that accept the same mail kind are rejected, spanned at the later
+//! handler — mirroring the wasm path so the diagnostic surface stays
+//! symmetric across both expansions.
+
+use aether_actor::actor;
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.ping")]
+struct Ping {
+    seq: u32,
+}
+
+#[allow(dead_code)]
+struct Dup;
+
+#[actor]
+impl aether_substrate::actor::native::NativeActor for Dup {
+    type Config = ();
+
+    fn init(
+        _config: (),
+        _ctx: &mut aether_substrate::actor::native::NativeInitCtx<'_>,
+    ) -> Result<Self, aether_actor::BootError> {
+        unimplemented!()
+    }
+
+    #[handler]
+    fn on_first(
+        &mut self,
+        _ctx: &mut aether_substrate::actor::native::NativeCtx<'_>,
+        _ping: Ping,
+    ) {
+    }
+
+    #[handler]
+    fn on_second(
+        &mut self,
+        _ctx: &mut aether_substrate::actor::native::NativeCtx<'_>,
+        _ping: Ping,
+    ) {
+    }
+}
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/rejects_duplicate_handler_kind_native.stderr
+++ b/crates/aether-actor-derive/tests/ui/rejects_duplicate_handler_kind_native.stderr
@@ -1,0 +1,5 @@
+error: two #[handler] methods accept the same mail kind `Ping` (also on `on_first`) — each kind routes to exactly one handler. Give each handler a distinct kind.
+  --> tests/ui/rejects_duplicate_handler_kind_native.rs:45:8
+   |
+45 |     fn on_second(
+   |        ^^^^^^^^^

--- a/crates/aether-actor-derive/tests/ui/rejects_missing_namespace_ffi.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_missing_namespace_ffi.rs
@@ -1,0 +1,38 @@
+//! An `#[actor] impl FfiActor` block that omits `const NAMESPACE` is
+//! rejected at the type, mirroring the `#[bridge]` path — rather than
+//! falling through to a later "no associated const NAMESPACE" error
+//! against the surfaceless `Actor` trait.
+
+use aether_actor::actor;
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.ping")]
+struct Ping {
+    seq: u32,
+}
+
+#[allow(dead_code)]
+struct NoNamespace;
+
+#[actor]
+impl aether_actor::FfiActor for NoNamespace {
+    fn init<C>(_ctx: &mut C) -> Result<Self, aether_actor::BootError>
+    where
+        C: aether_actor::Resolver,
+    {
+        Ok(NoNamespace)
+    }
+
+    #[handler]
+    fn on_ping(&mut self, _ctx: &mut aether_actor::FfiCtx<'_>, _ping: Ping) {}
+}
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/rejects_missing_namespace_ffi.stderr
+++ b/crates/aether-actor-derive/tests/ui/rejects_missing_namespace_ffi.stderr
@@ -1,0 +1,5 @@
+error: #[actor] impl FfiActor for X must declare `const NAMESPACE: &'static str = ...` so the marker `impl Actor` can carry it
+  --> tests/ui/rejects_missing_namespace_ffi.rs:26:33
+   |
+26 | impl aether_actor::FfiActor for NoNamespace {
+   |                                 ^^^^^^^^^^^

--- a/crates/aether-actor-derive/tests/ui/rejects_missing_namespace_native.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_missing_namespace_native.rs
@@ -1,0 +1,45 @@
+//! An `#[actor] impl NativeActor` block that omits `const NAMESPACE` is
+//! rejected at the type — rather than falling through to a later
+//! "no associated const NAMESPACE" error against the surfaceless `Actor`
+//! trait.
+
+use aether_actor::actor;
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.ping")]
+struct Ping {
+    seq: u32,
+}
+
+#[allow(dead_code)]
+struct NoNamespace;
+
+#[actor]
+impl aether_substrate::actor::native::NativeActor for NoNamespace {
+    type Config = ();
+
+    fn init(
+        _config: (),
+        _ctx: &mut aether_substrate::actor::native::NativeInitCtx<'_>,
+    ) -> Result<Self, aether_actor::BootError> {
+        unimplemented!()
+    }
+
+    #[handler]
+    fn on_ping(
+        &mut self,
+        _ctx: &mut aether_substrate::actor::native::NativeCtx<'_>,
+        _ping: Ping,
+    ) {
+    }
+}
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/rejects_missing_namespace_native.stderr
+++ b/crates/aether-actor-derive/tests/ui/rejects_missing_namespace_native.stderr
@@ -1,0 +1,5 @@
+error: #[actor] impl NativeActor for X must declare `const NAMESPACE: &'static str = ...` so the marker `impl Actor` can carry it
+  --> tests/ui/rejects_missing_namespace_native.rs:26:55
+   |
+26 | impl aether_substrate::actor::native::NativeActor for NoNamespace {
+   |                                                       ^^^^^^^^^^^

--- a/crates/aether-actor-derive/tests/ui/rejects_stray_const_ffi.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_stray_const_ffi.rs
@@ -1,0 +1,41 @@
+//! A const other than `NAMESPACE` inside an `#[actor] impl FfiActor`
+//! block is stray — the `Actor` super-trait carries no other authorable
+//! const — and is rejected at its own span rather than silently routed
+//! onto the sibling `impl Actor` block.
+
+use aether_actor::actor;
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.ping")]
+struct Ping {
+    seq: u32,
+}
+
+#[allow(dead_code)]
+struct StrayConst;
+
+#[actor]
+impl aether_actor::FfiActor for StrayConst {
+    const NAMESPACE: &'static str = "stray";
+    const BUFFER_CAPACITY: usize = 64;
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, aether_actor::BootError>
+    where
+        C: aether_actor::Resolver,
+    {
+        Ok(StrayConst)
+    }
+
+    #[handler]
+    fn on_ping(&mut self, _ctx: &mut aether_actor::FfiCtx<'_>, _ping: Ping) {}
+}
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/rejects_stray_const_ffi.stderr
+++ b/crates/aether-actor-derive/tests/ui/rejects_stray_const_ffi.stderr
@@ -1,0 +1,5 @@
+error: #[actor] impl FfiActor for X accepts only `const NAMESPACE: &'static str = …` — the `Actor` super-trait carries no other authorable const
+  --> tests/ui/rejects_stray_const_ffi.rs:28:5
+   |
+28 |     const BUFFER_CAPACITY: usize = 64;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/aether-actor-derive/tests/ui/rejects_stray_const_native.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_stray_const_native.rs
@@ -1,0 +1,48 @@
+//! A const other than `NAMESPACE` inside an `#[actor] impl NativeActor`
+//! block is stray — the `Actor` super-trait carries no other authorable
+//! const — and is rejected at its own span rather than silently routed
+//! onto the sibling `impl Actor` block.
+
+use aether_actor::actor;
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.ping")]
+struct Ping {
+    seq: u32,
+}
+
+#[allow(dead_code)]
+struct StrayConst;
+
+#[actor]
+impl aether_substrate::actor::native::NativeActor for StrayConst {
+    type Config = ();
+
+    const NAMESPACE: &'static str = "stray";
+    const BUFFER_CAPACITY: usize = 64;
+
+    fn init(
+        _config: (),
+        _ctx: &mut aether_substrate::actor::native::NativeInitCtx<'_>,
+    ) -> Result<Self, aether_actor::BootError> {
+        unimplemented!()
+    }
+
+    #[handler]
+    fn on_ping(
+        &mut self,
+        _ctx: &mut aether_substrate::actor::native::NativeCtx<'_>,
+        _ping: Ping,
+    ) {
+    }
+}
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/rejects_stray_const_native.stderr
+++ b/crates/aether-actor-derive/tests/ui/rejects_stray_const_native.stderr
@@ -1,0 +1,5 @@
+error: #[actor] impl NativeActor for X accepts only `const NAMESPACE: &'static str = …` — the `Actor` super-trait carries no other authorable const
+  --> tests/ui/rejects_stray_const_native.rs:30:5
+   |
+30 |     const BUFFER_CAPACITY: usize = 64;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -35,6 +35,7 @@ exclude:
       # attached to any cargo target, so Qodana's "Detached file"
       # inspection fires on every one. The detachment is the trybuild
       # contract, not a defect; exclude the fixture trees.
+      - crates/aether-actor-derive/tests/ui
       - crates/aether-data-derive/tests/ui
       - crates/aether-derive/tests/ui
 


### PR DESCRIPTION
Closes iamacoffeepot/aether#1553.

## Summary

The #[actor] macro degraded several common structural authoring mistakes into cryptic downstream errors. This adds spanned diagnostics on both direct expansion paths (wasm expand_wasm_actor and native expand_native_actor_trait, kept symmetric so neither path is left silently broken):

- Duplicate handler kinds — a types_token_eq loop spanned at the later handler ident, mirroring the existing task-handler check, before the HandlesKind impls emit.
- Missing const NAMESPACE and stray non-NAMESPACE/non-SCHEDULING consts — a const-validation loop spanned at the self type, mirroring the bridge path's pointed error; this also adds the SCHEDULING/stray-const rejection the wasm path previously lacked.

Bootstraps the crate's first trybuild harness (tests/ui.rs + a passing baseline and six compile_fail fixtures with goldens). Because trybuild fixtures are standalone .rs inputs intentionally detached from the cargo build graph, qodana.yaml gains crates/aether-actor-derive/tests/ui to its exclude list — the same exclusion the other two derive crates already carry for their trybuild trees.

Typo'd-lifecycle-hook detection and full lifecycle-set alignment are punted to side findings per the issue's "at least the first two / consider the rest".

## Test plan

Full preflight green: fmt, clippy -D warnings, nextest --workspace (incl. the 7 new trybuild ui fixtures, both expansion paths), doc, wasm32 component cross-build, qodana (2 pre-existing findings, under threshold). Each golden points at the author's code, not the generated impls.

## Generated by

/implement — agent execution of scoped issue #1553.
