### PR TITLE
chore(repo): promote shared dependencies to workspace.dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,31 @@ edition = "2024"
 # surfaces reach for the same major.
 clap = { version = "4", features = ["derive"] }
 
+# High-fanout shared deps (iamacoffeepot/aether#1526). Promoted to the
+# workspace table so the single-version property is structural — members
+# inherit with `{ workspace = true }` and extend per-member `features` /
+# `optional` locally. The no_std/wasm members need defaults off
+# (postcard's `heapless-cas`, serde's / tracing's `std`), and edition
+# 2024 only lets a member disable defaults when the workspace entry does
+# — so these carry `default-features = false` and the native consumers
+# re-add the default features they rely on (`heapless-cas`, `std`,
+# `attributes`) on their own declaration, keeping Cargo.lock byte-stable.
+anyhow = "1"
+bytemuck = { version = "1.19", default-features = false }
+confique = { version = "0.4", default-features = false }
+cpal = "0.17"
+inventory = "0.3"
+png = "0.18"
+postcard = { version = "1.1", default-features = false }
+proc-macro2 = "1"
+quote = "1"
+serde = { version = "1", default-features = false }
+serde_json = "1"
+syn = { version = "2", features = ["full"] }
+tracing = { version = "0.1", default-features = false }
+wasmtime = "44"
+wgpu = "29.0.1"
+
 [workspace.lints.rust]
 # Phase 5 of iamacoffeepot/aether#913 swept ~244 RsUnnecessaryQualifications
 # findings across the workspace. Enabling rustc's matching lint here at

--- a/crates/aether-actor-derive/Cargo.toml
+++ b/crates/aether-actor-derive/Cargo.toml
@@ -7,15 +7,15 @@ edition.workspace = true
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1"
-quote = "1"
-syn = { version = "2", features = ["full"] }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }
 
 [dev-dependencies]
 aether-data = { path = "../aether-data", features = ["derive"] }
-bytemuck = { version = "1.19", features = ["derive"] }
-serde = { version = "1", features = ["derive"] }
-inventory = "0.3"
+bytemuck = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive", "std"] }
+inventory = { workspace = true }
 aether-actor = { path = "../aether-actor" }
 
 [lints]

--- a/crates/aether-actor/Cargo.toml
+++ b/crates/aether-actor/Cargo.toml
@@ -22,18 +22,18 @@ aether-data = { path = "../aether-data", features = ["derive"] }
 # 552 stage 0) also build `aether.fs.*` / `aether.net.*` / `aether.log.*`
 # request kinds — that whole vocabulary lives in `aether-kinds`.
 aether-kinds = { path = "../aether-kinds" }
-bytemuck = { version = "1", default-features = false }
-postcard = { version = "1.1", default-features = false, features = ["alloc"] }
+bytemuck = { workspace = true, default-features = false }
+postcard = { workspace = true, default-features = false, features = ["alloc"] }
 # Postcard-decoding typed payloads (e.g. `PriorState::as_kind`,
 # `Mail::decode_kind`) is serde-driven. The crate stays
 # `no_std`-friendly with `default-features = false`.
-serde = { version = "1", default-features = false, features = ["alloc"] }
+serde = { workspace = true, default-features = false, features = ["alloc"] }
 # ADR-0060: the wasm shim installs a `tracing::Subscriber`
 # (`MailSubscriber`) at component boot that turns `tracing::warn!` /
 # `error!` / `info!` inside the wasm sandbox into `aether.log` mail.
 # The facade itself is `no_std`-friendly with `default-features = false`;
 # we don't pull `tracing-subscriber`.
-tracing = { version = "0.1", default-features = false }
+tracing = { workspace = true, default-features = false }
 
 [dev-dependencies]
 # Examples migrate from kind-typed `Mailbox` resolutions to actor-
@@ -44,13 +44,13 @@ tracing = { version = "0.1", default-features = false }
 # feature). `aether-substrate` deps back on `aether-actor`, but cargo
 # permits dev-dep cycles for the test-target build graph.
 aether-capabilities = { path = "../aether-capabilities", features = ["render"] }
-serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
-bytemuck = { version = "1", features = ["derive"] }
-postcard = { version = "1.1", features = ["alloc"] }
+serde = { workspace = true, default-features = false, features = ["derive", "alloc"] }
+bytemuck = { workspace = true, features = ["derive"] }
+postcard = { workspace = true, features = ["alloc", "heapless-cas"] }
 # Issue #243: `#[derive(Kind)]` test fixtures emit `inventory::submit!`
 # on native targets; the macro path needs `::inventory` reachable.
 # Tests run native, so an unconditional dev-dep is fine.
-inventory = "0.3"
+inventory = { workspace = true }
 
 # ADR-0017 (component-to-component reply) smoke pair: caller sends
 # `demo.request` to "echoer" and observes the reply.

--- a/crates/aether-camera/Cargo.toml
+++ b/crates/aether-camera/Cargo.toml
@@ -40,18 +40,18 @@ aether-capabilities = { path = "../aether-capabilities", default-features = fals
 aether-data = { path = "../aether-data", features = ["derive"] }
 aether-kinds = { path = "../aether-kinds" }
 aether-math = { path = "../aether-math" }
-serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
+serde = { workspace = true, default-features = false, features = ["derive", "alloc"] }
 # Substrate-side `aether.log` (ADR-0060) for warn-log on rejected
 # mail (unknown camera, mode mismatch, etc.). Default-features-off to
 # match the rest of the SDK pattern.
-tracing = { version = "0.1", default-features = false }
+tracing = { workspace = true, default-features = false }
 
 # Issue #243: every crate that derives `Kind` needs `inventory` reachable
 # on native builds so the `aether.kinds` substrate descriptor list picks
 # up its types. Wasm guests skip the submission via the derive's
 # `cfg(not(target_arch = "wasm32"))` gate.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-inventory = "0.3"
+inventory = { workspace = true }
 
 # Integration tests boot a `TestBench`, load this crate's own wasm
 # artifact, and assert mail-flow + render properties via direct

--- a/crates/aether-capabilities/Cargo.toml
+++ b/crates/aether-capabilities/Cargo.toml
@@ -76,12 +76,12 @@ aether-kinds = { path = "../aether-kinds" }
 # / `Vec4` from the wire `[f32; N]` arrays. Always-on + target-agnostic
 # (no_std), so it rides the wasm-header-only build too.
 aether-math = { path = "../aether-math" }
-serde = { version = "1", default-features = false, features = ["derive"] }
+serde = { workspace = true, default-features = false, features = ["derive"] }
 
 # Native-only: gated behind the `native` feature so wasm builds
 # don't drag in wasmtime / cpal / wgpu transitively.
 aether-substrate = { path = "../aether-substrate", optional = true }
-bytemuck = { version = "1.19", optional = true }
+bytemuck = { workspace = true, optional = true }
 # ADR-0090 unit g (iamacoffeepot/aether#1264): the `Config` derive
 # emits per-cap `*Overlay` structs (`#[derive(clap::Args)]`) next to
 # the domain struct, retiring the hand-rolled overlays that used to
@@ -92,13 +92,13 @@ clap = { workspace = true, optional = true }
 # `*Layer` structs (e.g. `HttpConfigLayer`) that back each cap's
 # `*Config::from_env`. `default-features = false` keeps it env-only —
 # no TOML/YAML file parsers until ADR-0090's config-file step.
-confique = { version = "0.4", default-features = false, optional = true }
+confique = { workspace = true, optional = true }
 dirs = { version = "6", optional = true }
-postcard = { version = "1.1", optional = true, features = ["alloc"] }
+postcard = { workspace = true, optional = true, features = ["alloc", "heapless-cas"] }
 # JSON request/response bodies for the content-gen provider APIs
 # (ADR-0050) — the Anthropic Messages API and the Gemini media APIs.
-serde_json = { version = "1", optional = true }
-tracing = { version = "0.1", optional = true }
+serde_json = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true, features = ["std", "attributes"] }
 ureq = { version = "3", optional = true, features = ["rustls"] }
 url = { version = "2", optional = true }
 # `v4` random-name generation for `save://gen/<uuid>.{png,wav}` output
@@ -112,14 +112,14 @@ uuid = { version = "1", optional = true, features = ["v4"] }
 # the substrate previously held in its `ControlPlane` struct. Same
 # version aether-substrate uses; chassis builds get a single wasmtime
 # in the dep tree.
-wasmtime = { version = "44", optional = true }
-wgpu = { version = "29.0.1", optional = true }
-cpal = { version = "0.17", optional = true }
+wasmtime = { workspace = true, optional = true }
+wgpu = { workspace = true, optional = true }
+cpal = { workspace = true, optional = true }
 crossbeam-queue = { version = "0.3", optional = true }
 
 [dev-dependencies]
 aether-data = { path = "../aether-data", features = ["derive"] }
-bytemuck = { version = "1.19", features = ["derive"] }
+bytemuck = { workspace = true, features = ["derive"] }
 
 [lints]
 workspace = true

--- a/crates/aether-codec/Cargo.toml
+++ b/crates/aether-codec/Cargo.toml
@@ -24,9 +24,9 @@ path = "src/lib.rs"
 
 [dependencies]
 aether-data = { path = "../aether-data" }
-postcard = { version = "1.1", features = ["alloc"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+postcard = { workspace = true, features = ["alloc", "heapless-cas"] }
+serde = { workspace = true, features = ["derive", "std"] }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 # Round-trip tests in this crate encode JSON params via the schema
@@ -37,7 +37,7 @@ serde_json = "1"
 # callers don't need any of this — only pulled in for `cargo test`.
 aether-kinds = { path = "../aether-kinds" }
 aether-data = { path = "../aether-data", features = ["derive"] }
-bytemuck = { version = "1.19", features = ["derive"] }
+bytemuck = { workspace = true, features = ["derive"] }
 
 [lints]
 workspace = true

--- a/crates/aether-data-derive/Cargo.toml
+++ b/crates/aether-data-derive/Cargo.toml
@@ -7,15 +7,15 @@ edition.workspace = true
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1"
-quote = "1"
-syn = { version = "2", features = ["full", "visit"] }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true, features = ["visit"] }
 
 [dev-dependencies]
 aether-data = { path = "../aether-data", features = ["derive"] }
-bytemuck = { version = "1.19", features = ["derive"] }
-serde = { version = "1", features = ["derive"] }
-inventory = "0.3"
+bytemuck = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive", "std"] }
+inventory = { workspace = true }
 trybuild = "1"
 
 [lints]

--- a/crates/aether-data/Cargo.toml
+++ b/crates/aether-data/Cargo.toml
@@ -17,9 +17,9 @@ derive = ["dep:aether-actor-derive", "dep:aether-data-derive"]
 [dependencies]
 aether-actor-derive = { path = "../aether-actor-derive", optional = true }
 aether-data-derive = { path = "../aether-data-derive", optional = true }
-bytemuck = { version = "1.19", features = ["derive"] }
-postcard = { version = "1.1", default-features = false, features = ["alloc"] }
-serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
+bytemuck = { workspace = true, features = ["derive"] }
+postcard = { workspace = true, default-features = false, features = ["alloc"] }
+serde = { workspace = true, default-features = false, features = ["derive", "alloc"] }
 # ADR-0070 phase 4 follow-up (ADR-0071 phase 7c): identity types
 # `EngineId` / `SessionToken` are UUIDs at the wire boundary. Default
 # features off keeps `aether-data` no_std + alloc; the `serde` feature
@@ -36,7 +36,7 @@ uuid = { version = "1", default-features = false, features = ["serde"] }
 # compiled. ADR-0032's wasm `aether.kinds` custom-section path remains
 # the wasm-side collection mechanism; this is the native mirror.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-inventory = "0.3"
+inventory = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/aether-derive/Cargo.toml
+++ b/crates/aether-derive/Cargo.toml
@@ -14,9 +14,9 @@ edition.workspace = true
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1"
-quote = "1"
-syn = { version = "2", features = ["full"] }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }
 
 [dev-dependencies]
 # trybuild compile-pass / compile-fail fixtures under tests/ui/. Each
@@ -31,8 +31,8 @@ trybuild = "1"
 # wasmtime per fixture binary — the speedup this issue tracks.
 aether-substrate = { path = "../aether-substrate", default-features = false }
 aether-derive = { path = "." }
-confique = { version = "0.4", default-features = false }
-clap = { version = "4", features = ["derive"] }
+confique = { workspace = true }
+clap = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/aether-kinds/Cargo.toml
+++ b/crates/aether-kinds/Cargo.toml
@@ -12,13 +12,13 @@ aether-data = { path = "../aether-data", features = ["derive"] }
 # `aether_math::{Mat4, Vec4}` directly. `aether-math` is acyclic — it
 # depends on `aether-data` but never on `aether-kinds`.
 aether-math = { path = "../aether-math" }
-bytemuck = { version = "1.19", features = ["derive"] }
-serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
+bytemuck = { workspace = true, features = ["derive"] }
+serde = { workspace = true, default-features = false, features = ["derive", "alloc"] }
 
 [dev-dependencies]
 # ADR-0041 I/O kind roundtrip tests exercise the postcard wire
 # directly (the mail-path `encode_struct` helper wraps this).
-postcard = { version = "1.1", default-features = false, features = ["alloc"] }
+postcard = { workspace = true, default-features = false, features = ["alloc"] }
 
 # Issue #243: descriptors.rs::all() iterates the substrate-native
 # `inventory` slot to materialize the descriptor list. inventory's
@@ -27,7 +27,7 @@ postcard = { version = "1.1", default-features = false, features = ["alloc"] }
 # builds needs `inventory` reachable. Wasm-only consumers don't (the
 # derive's `cfg(not(target_arch = "wasm32"))` gate skips emission).
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-inventory = "0.3"
+inventory = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/aether-kit/Cargo.toml
+++ b/crates/aether-kit/Cargo.toml
@@ -31,16 +31,16 @@ aether-capabilities = { path = "../aether-capabilities", default-features = fals
 aether-data = { path = "../aether-data", features = ["derive"] }
 aether-kinds = { path = "../aether-kinds" }
 aether-math = { path = "../aether-math" }
-serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
+serde = { workspace = true, default-features = false, features = ["derive", "alloc"] }
 # Substrate-side `aether.log` (ADR-0060) for warn-log on rejected mail
 # (out-of-bounds teleport, etc.). Default-features-off per the SDK pattern.
-tracing = { version = "0.1", default-features = false }
+tracing = { workspace = true, default-features = false }
 
 # Every crate that derives `Kind` needs `inventory` reachable on native
 # builds so the `aether.kinds` descriptor list picks up its types. Wasm
 # guests skip the submission via the derive's cfg gate.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-inventory = "0.3"
+inventory = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/aether-math/Cargo.toml
+++ b/crates/aether-math/Cargo.toml
@@ -14,7 +14,7 @@ aether-data = { path = "../aether-data", features = ["derive"] }
 # `Vec4` is `#[repr(C)]`, so its `Kind` derive takes the cast wire
 # path, which needs `Pod` (`NoUninit` + `AnyBitPattern`). The bytemuck
 # derive supplies it. Same version aether-kinds uses for its cast kinds.
-bytemuck = { version = "1.19", features = ["derive"] }
+bytemuck = { workspace = true, features = ["derive"] }
 libm = "0.2"
 
 [lints]

--- a/crates/aether-mcp/Cargo.toml
+++ b/crates/aether-mcp/Cargo.toml
@@ -34,7 +34,7 @@ aether-codec = { path = "../aether-codec" }
 aether-data = { path = "../aether-data" }
 aether-kinds = { path = "../aether-kinds" }
 
-anyhow = "1"
+anyhow = { workspace = true }
 axum = "0.8"
 base64 = "0.22"
 futures-util = "0.3"
@@ -48,17 +48,17 @@ reqwest = { version = "0.13", default-features = false, features = ["stream"] }
 # `SchemaType` through the `KindDescriptorWire.schema_postcard` field —
 # `SchemaType` has no `Schema` impl of its own, so it rides as opaque
 # bytes within the `aether.inventory.kinds_result` wire kind.
-postcard = "1"
+postcard = { workspace = true, features = ["heapless-cas"] }
 rmcp = { version = "1.7", features = [
     "server",
     "macros",
     "transport-streamable-http-server",
 ] }
 schemars = "1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true, features = ["derive", "std"] }
+serde_json = { workspace = true }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal", "fs", "time", "io-util"] }
-tracing = "0.1"
+tracing = { workspace = true, features = ["std", "attributes"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]

--- a/crates/aether-mesh-viewer/Cargo.toml
+++ b/crates/aether-mesh-viewer/Cargo.toml
@@ -40,17 +40,17 @@ aether-capabilities = { path = "../aether-capabilities", default-features = fals
 aether-kinds = { path = "../aether-kinds" }
 aether-mesh = { path = "../aether-mesh" }
 aether-math = { path = "../aether-math" }
-serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
+serde = { workspace = true, default-features = false, features = ["derive", "alloc"] }
 # ADR-0060: tracing facade reaches the substrate's `aether.log` via
 # the SDK's `MailSubscriber` (installed by `export!`).
-tracing = { version = "0.1", default-features = false }
+tracing = { workspace = true, default-features = false }
 
 # Issue #243: every crate that derives `Kind` needs `inventory` reachable
 # on native builds so the `aether.kinds` substrate descriptor list picks
 # up its types. Wasm guests skip the submission via the derive's
 # `cfg(not(target_arch = "wasm32"))` gate.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-inventory = "0.3"
+inventory = { workspace = true }
 
 # Integration tests boot a `TestBench`, load this crate's own wasm
 # artifact, and assert mail-flow + render properties via direct

--- a/crates/aether-mesh/Cargo.toml
+++ b/crates/aether-mesh/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 aether-math = { path = "../aether-math" }
 lexpr = "0.2"
 thiserror = "2"
-tracing = "0.1"
+tracing = { workspace = true, features = ["std", "attributes"] }
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/crates/aether-substrate-bundle/Cargo.toml
+++ b/crates/aether-substrate-bundle/Cargo.toml
@@ -78,13 +78,13 @@ clap = { workspace = true }
 # the cap's `from_argv_then_env` then preloads it into the confique
 # builder ahead of `.env()`. Direct dep so cli.rs can name the
 # `confique::Layer` trait without reaching through aether-capabilities.
-confique = { version = "0.4", default-features = false }
+confique = { workspace = true }
 # Catch-all error type for chassis main()s + build_passive that
 # bridge BootError / wasmtime / io faults purely to bubble up.
 # Same crate as `wasmtime::Result` re-exports (issue #571).
-anyhow = "1"
-bytemuck = { version = "1.19", features = ["derive"] }
-png = "0.18"
+anyhow = { workspace = true }
+bytemuck = { workspace = true, features = ["derive"] }
+png = { workspace = true }
 pollster = "0.4.0"
 # iamacoffeepot/aether#1155: distribution-plot rendering for the
 # `perf-plot` bin. `ab_glyph` keeps fonts pure-Rust (no font-kit / system
@@ -98,19 +98,19 @@ plotters = { version = "0.3", default-features = false, features = [
     "ab_glyph",
     "line_series",
 ] }
-postcard = { version = "1.1", default-features = false, features = ["alloc"] }
+postcard = { workspace = true, default-features = false, features = ["alloc"] }
 # `rmcp` / `axum` / `base64` / `schemars` retired with the embedded MCP
 # server (issue 763 P5e) — the harness moved out-of-process into the
 # `aether-mcp` crate, which owns those deps now.
-serde = { version = "1", features = ["derive"] }
+serde = { workspace = true, features = ["derive", "std"] }
 # Trial reports + comparison output are JSON (perf tooling, #1077).
-serde_json = "1"
+serde_json = { workspace = true }
 # `test_bench::visual::ImageError` derives `thiserror::Error` (moved
 # from `aether-scenario` per issue 821). New runtime dep here because
 # `aether-substrate-bundle` had no prior thiserror consumer.
 thiserror = "2"
-tracing = "0.1"
-wgpu = "29.0.1"
+tracing = { workspace = true, features = ["std", "attributes"] }
+wgpu = { workspace = true }
 winit = "0.30.13"
 
 # Hub chassis blocks on a SIGINT/SIGTERM signal in
@@ -131,8 +131,8 @@ ctrlc = "3"
 # `build.rs` parses the `AETHER_BUNDLE_MANIFEST` JSON and encodes the
 # bundle pack through `src/bundle_pack.rs` (compiled in via `#[path]`,
 # #1529), so the build script needs serde + serde_json in build scope.
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true, features = ["derive", "std"] }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 # Test-bench Phase 3 substrate-feature scenarios (issue 430). Tests

--- a/crates/aether-substrate/Cargo.toml
+++ b/crates/aether-substrate/Cargo.toml
@@ -39,7 +39,7 @@ aether-data = { path = "../aether-data" }
 # re-exports `aether-data-derive`'s `#[derive(Kind, Schema)]`.
 aether-derive = { path = "../aether-derive" }
 aether-kinds = { path = "../aether-kinds" }
-bytemuck = "1.19"
+bytemuck = { workspace = true }
 # ADR-0090: typed, layered config resolution. Backs the env-shaped
 # `*Layer` structs (`PersistConfig`, the DAG `Caps` + `ExecutorConfig`)
 # that resolve each chassis-resolved config's `from_env`.
@@ -48,24 +48,24 @@ bytemuck = "1.19"
 # native-only crate (wasmtime feature-gated since iamacoffeepot/aether#1275
 # but default-on), so this is a plain dep, not feature-gated like the
 # capabilities crate's confique.
-confique = { version = "0.4", default-features = false }
+confique = { workspace = true }
 # ADR-0049 on-disk handle store: resolve the default persistence root
 # (`dirs::data_dir()/aether/handles`). Same crate the fs cap uses.
 dirs = "6"
-postcard = { version = "1.1", features = ["alloc"] }
-serde = { version = "1", features = ["derive"] }
+postcard = { workspace = true, features = ["alloc", "heapless-cas"] }
+serde = { workspace = true, features = ["derive", "std"] }
 # ADR-0081 §4 crash dump: serialize the panicking actor's ring as
 # JSONL on a panic-hook write path. Read-side consumers (operator
 # `jq` queries) match.
-serde_json = "1"
-tracing = "0.1"
+serde_json = { workspace = true }
+tracing = { workspace = true, features = ["std", "attributes"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-wasmtime = { version = "44", optional = true }
+wasmtime = { workspace = true, optional = true }
 # Render-only deps; gated by the `render` feature. Headless + hub
 # don't enable the feature, so wgpu's transitive graph stays out of
 # their builds.
-wgpu = { version = "29.0.1", optional = true }
-png = { version = "0.18", optional = true }
+wgpu = { workspace = true, optional = true }
+png = { workspace = true, optional = true }
 # Issue 635 PR B worker-pool ready queue. MPMC channel — std mpsc is
 # single-consumer so it can't load-balance across pool workers. Still
 # used for settlement/capture one-shots + the close-done signal; the
@@ -106,7 +106,7 @@ aether-data = { path = "../aether-data", features = ["derive"] }
 # needs aether-kinds in scope (integration tests see only the lib +
 # dev-deps, not the lib's regular deps).
 aether-kinds = { path = "../aether-kinds" }
-bytemuck = { version = "1.19", features = ["derive"] }
+bytemuck = { workspace = true, features = ["derive"] }
 
 [lints]
 workspace = true

--- a/crates/aether-test-fixtures/Cargo.toml
+++ b/crates/aether-test-fixtures/Cargo.toml
@@ -23,8 +23,8 @@ aether-data = { path = "../aether-data", features = ["derive"] }
 # `aether.math.vec4` kind in its `Ref` slot, so the shared lib needs
 # `Vec4`. `aether-math` is `no_std`, keeping this rlib `no_std`.
 aether-math = { path = "../aether-math" }
-bytemuck = { version = "1", default-features = false, features = ["derive"] }
-serde = { version = "1", default-features = false, features = ["derive"] }
+bytemuck = { workspace = true, default-features = false, features = ["derive"] }
+serde = { workspace = true, default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 aether-actor = { path = "../aether-actor" }
@@ -38,7 +38,7 @@ aether-capabilities = { path = "../aether-capabilities", default-features = fals
 # Issue #581: the probe emits `tracing::info!` on the first tick; the
 # actor-aware subscriber installed by `export!()` buffers + drains it
 # to LogCapability.
-tracing = { version = "0.1", default-features = false }
+tracing = { workspace = true, default-features = false }
 
 # ADR-0090 c1 reference fixture: the pre-1256 probe, now an example
 # cdylib. Wasm artifact: target/wasm32-unknown-unknown/{profile}/examples/probe.wasm

--- a/demos/sokoban/Cargo.toml
+++ b/demos/sokoban/Cargo.toml
@@ -23,7 +23,7 @@ aether-capabilities = { path = "../../crates/aether-capabilities", default-featu
 aether-camera = { path = "../../crates/aether-camera", default-features = false }
 aether-kinds = { path = "../../crates/aether-kinds" }
 aether-data = { path = "../../crates/aether-data", features = ["derive"] }
-bytemuck = { version = "1", default-features = false, features = ["derive"] }
+bytemuck = { workspace = true, default-features = false, features = ["derive"] }
 
 # Integration tests boot a `TestBench`, load the demo's own wasm
 # artifact, and assert mail-flow + render properties via direct

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,11 +5,11 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 cargo_metadata = "0.23.1"
 clap = { workspace = true }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true, features = ["derive", "std"] }
+serde_json = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Closes iamacoffeepot/aether#1526.

## Summary

Shared dependencies were redeclared per-member with drifting version specs while [workspace.dependencies] held only clap. This promotes the 15 high-fanout deps (bytemuck, postcard, serde, serde_json, tracing, inventory, anyhow, confique, wgpu, png, cpal, wasmtime, proc-macro2, quote, syn) into the workspace table and flips every member to workspace = true, making the single-version property structural rather than coincidental. Where specs drifted the stricter majority spec was adopted (bytemuck 1.19, postcard 1.1, wgpu 29.0.1, png 0.18, cpal 0.17, wasmtime 44) so resolution stays put. Per-member features/optional flags are preserved; aether-derive's verbatim clap is routed through the existing workspace entry.

Cargo.lock is byte-identical and cargo tree --workspace --duplicates is unchanged. Built on top of #1521 (dependency hygiene) so no dead deps were promoted.

## Test plan

Full preflight green (fmt, clippy -D warnings, nextest --workspace, doc, wasm32 component cross-build, qodana). Cargo.lock diff verified empty; duplicate set unchanged.

## Note

Edition 2024 forbids a member disabling default-features unless the workspace entry also sets default-features = false. The no_std/wasm members need defaults off (postcard heapless-cas, serde/tracing std), so bytemuck/postcard/serde/tracing carry default-features = false at the workspace level with the native consumers re-adding their needed default features locally — keeping heapless and tracing-attributes resolved and the lockfile byte-identical. Documented in the root Cargo.toml.

## Generated by

/implement — agent execution of scoped issue #1526.
