### PR TITLE
fix(actor): resolve outbound sends through R::resolve instead of flat namespace hash

### DIFF
--- a/crates/aether-actor/src/actor/ctx/mail_sender.rs
+++ b/crates/aether-actor/src/actor/ctx/mail_sender.rs
@@ -21,27 +21,32 @@
 
 use aether_data::Kind;
 
-use crate::actor::{Actor, HandlesKind};
+use crate::actor::{HandlesKind, Singleton};
 
 /// Outbound-mail surface every actor ctx exposes.
 ///
-/// `R: Actor + HandlesKind<K>` is the compile-time gate: trying to
+/// `R: Singleton + HandlesKind<K>` is the compile-time gate: trying to
 /// send a kind the receiver doesn't handle is rejected at the call
-/// site, not silently warn-dropped at runtime. Wire shape (cast or
-/// postcard) follows `Kind::encode_into_bytes` (issue #240).
+/// site, not silently warn-dropped at runtime. The receiver's mailbox
+/// is resolved through `R::resolve(caller_carry)` (ADR-0099 §5) — the
+/// same lineage-aware path `ctx.actor::<R>()` walks — so a non-root
+/// receiver routes to the lineage-folded id, not the flat
+/// `hash(R::NAMESPACE)`. Wire shape (cast or postcard) follows
+/// `Kind::encode_into_bytes` (issue #240).
 pub trait MailSender {
     /// Send a single payload of kind `K` to the singleton instance of
-    /// receiver actor `R`.
+    /// receiver actor `R`, resolved via `R::resolve` against the
+    /// caller's lineage carry (ADR-0099 §5).
     fn send<R, K>(&mut self, payload: &K)
     where
-        R: Actor + HandlesKind<K>,
+        R: Singleton + HandlesKind<K>,
         K: Kind;
 
     /// Send a slice of cast-shape payloads as a contiguous batch.
     /// Cast-only — postcard has no efficient batched wire shape.
     fn send_many<R, K>(&mut self, payloads: &[K])
     where
-        R: Actor + HandlesKind<K>,
+        R: Singleton + HandlesKind<K>,
         K: Kind + bytemuck::NoUninit;
 
     /// String-keyed escape hatch for callers that genuinely don't
@@ -75,7 +80,7 @@ pub trait MailSender {
     /// trace.
     fn send_detached<R, K>(&mut self, payload: &K)
     where
-        R: Actor + HandlesKind<K>,
+        R: Singleton + HandlesKind<K>,
         K: Kind,
     {
         self.send::<R, K>(payload);

--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -259,22 +259,22 @@ impl MailSender for FfiCtx<'_> {
     //noinspection DuplicatedCode
     fn send<R, K>(&mut self, payload: &K)
     where
-        R: Actor + HandlesKind<K>,
+        R: Singleton + HandlesKind<K>,
         K: Kind,
     {
         let bytes = payload.encode_into_bytes();
-        MAIL_BRIDGE.send_mail(mailbox_id_from_name(R::NAMESPACE).0, K::ID.0, &bytes, 1);
+        MAIL_BRIDGE.send_mail(R::resolve(self.mailbox).0, K::ID.0, &bytes, 1);
     }
 
     //noinspection DuplicatedCode
     fn send_many<R, K>(&mut self, payloads: &[K])
     where
-        R: Actor + HandlesKind<K>,
+        R: Singleton + HandlesKind<K>,
         K: Kind + bytemuck::NoUninit,
     {
         let bytes: &[u8] = bytemuck::cast_slice(payloads);
         MAIL_BRIDGE.send_mail(
-            mailbox_id_from_name(R::NAMESPACE).0,
+            R::resolve(self.mailbox).0,
             K::ID.0,
             bytes,
             payloads.len() as u32,
@@ -321,6 +321,10 @@ impl OutboundReply for FfiCtx<'_> {
 /// Outbound mail still works through [`MailSender`]; the reply / resolve
 /// surfaces are intentionally absent.
 pub struct FfiDropCtx<'a> {
+    /// The actor's own mailbox id (its lineage carry), so a buffered
+    /// `send` resolves the receiver through `R::resolve(self.mailbox)`
+    /// like every other ctx (ADR-0099 §5).
+    mailbox: u64,
     _borrow: PhantomData<&'a ()>,
 }
 
@@ -328,8 +332,9 @@ impl FfiDropCtx<'_> {
     /// Not part of the public API; called only by [`crate::export!`].
     #[doc(hidden)]
     #[must_use]
-    pub fn __new() -> Self {
+    pub fn __new(mailbox: u64) -> Self {
         Self {
+            mailbox,
             _borrow: PhantomData,
         }
     }
@@ -363,22 +368,22 @@ impl MailSender for FfiDropCtx<'_> {
     //noinspection DuplicatedCode
     fn send<R, K>(&mut self, payload: &K)
     where
-        R: Actor + HandlesKind<K>,
+        R: Singleton + HandlesKind<K>,
         K: Kind,
     {
         let bytes = payload.encode_into_bytes();
-        MAIL_BRIDGE.send_mail(mailbox_id_from_name(R::NAMESPACE).0, K::ID.0, &bytes, 1);
+        MAIL_BRIDGE.send_mail(R::resolve(self.mailbox).0, K::ID.0, &bytes, 1);
     }
 
     //noinspection DuplicatedCode
     fn send_many<R, K>(&mut self, payloads: &[K])
     where
-        R: Actor + HandlesKind<K>,
+        R: Singleton + HandlesKind<K>,
         K: Kind + bytemuck::NoUninit,
     {
         let bytes: &[u8] = bytemuck::cast_slice(payloads);
         MAIL_BRIDGE.send_mail(
-            mailbox_id_from_name(R::NAMESPACE).0,
+            R::resolve(self.mailbox).0,
             K::ID.0,
             bytes,
             payloads.len() as u32,

--- a/crates/aether-actor/src/ffi/mailbox.rs
+++ b/crates/aether-actor/src/ffi/mailbox.rs
@@ -59,7 +59,10 @@ impl<R> FfiActorMailbox<R> {
 
     /// Resolve a sibling mailbox on the same transport, addressed by
     /// `name`. Same FNV-hash name resolution as
-    /// [`crate::ffi::FfiCtx::resolve_actor`] — kept as an inherent
+    /// [`crate::ffi::FfiCtx::resolve_actor`] — `name` must be the peer's
+    /// **full registered name** (flat ADR-0029 hash). A caller that needs
+    /// a lineage-folded child id (ADR-0099 §3) uses
+    /// [`Self::resolve_peer_scoped`] instead. Kept as an inherent
     /// method so cap-owned ext traits (which only have a mailbox in
     /// hand, not a ctx) can hand back peer handles without rethreading
     /// the ctx.

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -800,7 +800,14 @@ macro_rules! __export_internal {
             let Some(instance) = (unsafe { __AETHER_COMPONENT.get_mut() }) else {
                 return 1;
             };
-            let mut ctx: $crate::FfiDropCtx<'_> = $crate::FfiDropCtx::__new();
+            // Derive the actor's own mailbox id (its lineage carry) so a
+            // `send::<R>` from the save hook resolves the receiver through
+            // `R::resolve` — the same id `receive` derives for `FfiCtx`.
+            let mailbox_id = $crate::__macro_internals::mailbox_id_from_name(
+                <$component as $crate::Actor>::NAMESPACE,
+            )
+            .0;
+            let mut ctx: $crate::FfiDropCtx<'_> = $crate::FfiDropCtx::__new(mailbox_id);
             <$component as $crate::FfiActor>::on_dehydrate(instance, &mut ctx);
             0
         }
@@ -1081,7 +1088,14 @@ macro_rules! __export_multi_internal {
             let Some(instance) = (unsafe { __AETHER_MULTI.get_mut() }) else {
                 return 1;
             };
-            let mut ctx: $crate::FfiDropCtx<'_> = $crate::FfiDropCtx::__new();
+            // Derive the live actor's own mailbox id (its lineage carry) so a
+            // `send::<R>` from the save hook resolves the receiver through
+            // `R::resolve` — the same id `receive` derives for `FfiCtx`.
+            let mailbox_id = $crate::__macro_internals::mailbox_id_from_name(
+                instance.erased_namespace(),
+            )
+            .0;
+            let mut ctx: $crate::FfiDropCtx<'_> = $crate::FfiDropCtx::__new(mailbox_id);
             instance.erased_on_dehydrate(&mut ctx);
             0
         }

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -1030,6 +1030,84 @@ mod tests {
         );
     }
 
+    /// ADR-0099 §5 own-child path through the generic `MailSender::send`
+    /// surface: `send::<R>` resolves the receiver through
+    /// `R::resolve(caller_carry)` — the same lineage-aware path
+    /// `ctx.actor::<R>()` walks — so a parent at carry `C` sending by
+    /// bare type lands on `fold(C, ActorId::singleton(NAMESPACE))`, not
+    /// the flat `hash(NAMESPACE)`. The send-path analogue of
+    /// `ctx_actor_folds_own_child_singleton_onto_caller_carry`, closing
+    /// the divergence between the two send forms (#1550).
+    #[test]
+    fn mailsender_send_routes_through_resolve_not_flat_hash() {
+        use crate::actor::native::ctx::NativeCtx;
+        use aether_actor::actor::HandlesKind;
+        use aether_actor::{Actor, MailSender, Singleton};
+        use aether_data::mailbox_id_from_name;
+        use aether_kinds::Tick;
+
+        struct Child;
+        impl Actor for Child {
+            const NAMESPACE: &'static str = "test.send_fold.child";
+        }
+        impl Singleton for Child {
+            // A carry-dependent target distinct from the flat hash: a different
+            // caller carry resolves to a different mailbox, so a send that lands
+            // here proves the carry was threaded through `resolve` rather than
+            // dropped for `mailbox_id_from_name(NAMESPACE)`. The exact ADR-0099
+            // fold is exercised by aether-actor's own resolve unit tests.
+            fn resolve(caller_carry: u64) -> MailboxId {
+                mailbox_id_from_name(&format!("test.send_fold.child.{caller_carry:x}"))
+            }
+        }
+        impl HandlesKind<Tick> for Child {}
+
+        let (registry, mailer) = fresh_substrate();
+        let parent_carry = 0x0BAD_F00D_u64;
+
+        let resolved = Child::resolve(parent_carry);
+        let flat = mailbox_id_from_name("test.send_fold.child");
+        assert_ne!(
+            resolved, flat,
+            "fixture: the carry-derived id must differ from the flat hash"
+        );
+
+        // Capture at both candidate recipients: the carry-derived id the
+        // send must target, and the flat depth-1 hash the pre-fix path used.
+        let (resolved_tx, resolved_rx) = mpsc::channel::<Envelope>();
+        let (flat_tx, flat_rx) = mpsc::channel::<Envelope>();
+        registry
+            .try_register_inbox_with_id(
+                resolved,
+                "test.send_fold.resolved",
+                forward_to_envelope_sender(resolved_tx),
+            )
+            .expect("register resolved sink");
+        registry
+            .try_register_inbox_with_id(
+                flat,
+                "test.send_fold.flat",
+                forward_to_envelope_sender(flat_tx),
+            )
+            .expect("register flat sink");
+
+        let transport = Arc::new(NativeBinding::new_for_test(mailer, MailboxId(parent_carry)));
+        {
+            let mut ctx = NativeCtx::new(&transport, Source::NONE, MailId::NONE, MailId::NONE);
+            <NativeCtx as MailSender>::send::<Child, Tick>(&mut ctx, &Tick);
+            // ctx drops here → `flush_outbound` routes the buffered send.
+        }
+
+        assert!(
+            resolved_rx.try_recv().is_ok(),
+            "send must route to Child::resolve(carry), the carry-derived id"
+        );
+        assert!(
+            flat_rx.try_recv().is_err(),
+            "send must NOT route to the flat hash(NAMESPACE)"
+        );
+    }
+
     /// `install_inbox` is single-claim — a second install panics.
     #[test]
     #[should_panic(expected = "install_inbox called twice")]

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -567,7 +567,7 @@ impl NativeCtx<'_> {
     /// Recipients aren't known to share a receiver type at compile site
     /// (subscribers register at runtime by mailbox id), so this takes
     /// mailbox ids directly rather than the typed
-    /// `R: Actor + HandlesKind<K>` shape of [`MailSender::send`]. The empty
+    /// `R: Singleton + HandlesKind<K>` shape of [`MailSender::send`]. The empty
     /// recipient set is a fast no-op — encoding only runs when there's at
     /// least one consumer.
     ///
@@ -822,12 +822,12 @@ impl MailSender for NativeCtx<'_> {
     //noinspection DuplicatedCode
     fn send<R, K>(&mut self, payload: &K)
     where
-        R: Actor + HandlesKind<K>,
+        R: Singleton + HandlesKind<K>,
         K: Kind,
     {
         let bytes = payload.encode_into_bytes();
         self.binding.push_envelope_buffered(
-            mailbox_id_from_name(R::NAMESPACE).0,
+            R::resolve(self.binding.carry()).0,
             K::ID.0,
             &bytes,
             1,
@@ -839,7 +839,7 @@ impl MailSender for NativeCtx<'_> {
     //noinspection DuplicatedCode
     fn send_many<R, K>(&mut self, payloads: &[K])
     where
-        R: Actor + HandlesKind<K>,
+        R: Singleton + HandlesKind<K>,
         K: Kind + bytemuck::NoUninit,
     {
         let bytes: &[u8] = bytemuck::cast_slice(payloads);
@@ -848,7 +848,7 @@ impl MailSender for NativeCtx<'_> {
         #[allow(clippy::cast_possible_truncation)]
         let count = payloads.len() as u32;
         self.binding.push_envelope_buffered(
-            mailbox_id_from_name(R::NAMESPACE).0,
+            R::resolve(self.binding.carry()).0,
             K::ID.0,
             bytes,
             count,

--- a/crates/aether-substrate/src/actor/native/mailbox.rs
+++ b/crates/aether-substrate/src/actor/native/mailbox.rs
@@ -74,8 +74,11 @@ impl<'a, R> NativeActorMailbox<'a, R> {
 
     /// Resolve a sibling mailbox on the same binding, addressed by
     /// `name`. Same FNV-hash name resolution as
-    /// [`NativeCtx::resolve_actor`] — kept as an inherent method so
-    /// cap-owned ext traits (which only have a mailbox in hand, not a
+    /// [`NativeCtx::resolve_actor`] — `name` must be the peer's **full
+    /// registered name** (flat ADR-0029 hash). A caller that needs a
+    /// lineage-folded child id (ADR-0099 §3) uses
+    /// [`Self::resolve_peer_scoped`] instead. Kept as an inherent method
+    /// so cap-owned ext traits (which only have a mailbox in hand, not a
     /// ctx) can hand back peer handles without rethreading the ctx.
     /// Threads the existing `'a` binding ref, so the returned handle
     /// inherits the parent mailbox's borrow lifetime.

--- a/crates/aether-substrate/src/actor/native/spawn_thread.rs
+++ b/crates/aether-substrate/src/actor/native/spawn_thread.rs
@@ -125,12 +125,12 @@ impl<A: Actor> MailSender for InheritCtx<A> {
     //noinspection DuplicatedCode
     fn send<R, K>(&mut self, payload: &K)
     where
-        R: Actor + HandlesKind<K>,
+        R: Singleton + HandlesKind<K>,
         K: Kind,
     {
         let bytes = payload.encode_into_bytes();
         self.binding.send_mail_with_lineage(
-            mailbox_id_from_name(R::NAMESPACE).0,
+            R::resolve(self.binding.carry()).0,
             K::ID.0,
             &bytes,
             1,
@@ -142,7 +142,7 @@ impl<A: Actor> MailSender for InheritCtx<A> {
     //noinspection DuplicatedCode
     fn send_many<R, K>(&mut self, payloads: &[K])
     where
-        R: Actor + HandlesKind<K>,
+        R: Singleton + HandlesKind<K>,
         K: Kind + bytemuck::NoUninit,
     {
         let bytes: &[u8] = bytemuck::cast_slice(payloads);
@@ -151,7 +151,7 @@ impl<A: Actor> MailSender for InheritCtx<A> {
         #[allow(clippy::cast_possible_truncation)]
         let count = payloads.len() as u32;
         self.binding.send_mail_with_lineage(
-            mailbox_id_from_name(R::NAMESPACE).0,
+            R::resolve(self.binding.carry()).0,
             K::ID.0,
             bytes,
             count,
@@ -203,14 +203,14 @@ impl<A> RootCtx<A> {
 impl<A: Actor> MailSender for RootCtx<A> {
     fn send<R, K>(&mut self, payload: &K)
     where
-        R: Actor + HandlesKind<K>,
+        R: Singleton + HandlesKind<K>,
         K: Kind,
     {
         let bytes = payload.encode_into_bytes();
         // No inherited parent / root — each send mints its own chain
         // rooted at the freshly minted `MailId` (sender = A.mailbox).
         self.binding.send_mail_with_lineage(
-            mailbox_id_from_name(R::NAMESPACE).0,
+            R::resolve(self.binding.carry()).0,
             K::ID.0,
             &bytes,
             1,
@@ -221,7 +221,7 @@ impl<A: Actor> MailSender for RootCtx<A> {
 
     fn send_many<R, K>(&mut self, payloads: &[K])
     where
-        R: Actor + HandlesKind<K>,
+        R: Singleton + HandlesKind<K>,
         K: Kind + bytemuck::NoUninit,
     {
         let bytes: &[u8] = bytemuck::cast_slice(payloads);
@@ -230,7 +230,7 @@ impl<A: Actor> MailSender for RootCtx<A> {
         #[allow(clippy::cast_possible_truncation)]
         let count = payloads.len() as u32;
         self.binding.send_mail_with_lineage(
-            mailbox_id_from_name(R::NAMESPACE).0,
+            R::resolve(self.binding.carry()).0,
             K::ID.0,
             bytes,
             count,


### PR DESCRIPTION
Closes iamacoffeepot/aether#1550.

## Summary

ctx.send::<R>(&payload) and ctx.actor::<R>().send(&payload) were documented as interchangeable but resolved the receiver differently: actor() builds the mailbox from R::resolve(carry) (lineage-aware, ADR-0099) while the generic send flat-hashed mailbox_id_from_name(R::NAMESPACE), ignoring R::resolve and the caller's lineage carry. For any non-root receiver the two forms routed to different mailboxes — latent today only because every receiver addressed this way is currently a root cap whose resolve default equals the flat hash.

This unifies all outbound resolution onto the lineage-aware R::resolve(carry) path. The generic send / send_many / send_detached bound tightens from R: Actor to R: Singleton, and only the recipient expression changes (mailbox_id_from_name(R::NAMESPACE).0 -> R::resolve(carry).0); each impl's dispatch call and ADR-0080 trace plumbing are untouched. Covers the FFI ctx, FfiDropCtx (which gains a mailbox field so its drop-stage sends can resolve lineage), and the native NativeCtx/InheritCtx/RootCtx for wasm/native symmetry. resolve_actor / resolve_peer docs now point lineage-folding callers at resolve_peer_scoped.

A send-path guard test asserts MailSender::send routes to R::resolve(carry), not the flat hash — the analogue of the existing actor()-path guard.

## Test plan

Full preflight green (fmt, clippy -D warnings, nextest --workspace incl. the new guard test, doc, wasm32 component cross-build, qodana). cargo check confirms every existing caller is already Singleton (no caller changes).

## Merge order

Part of the actor send/reply cluster. Land after #1552 (which deletes the legacy Sender trait this PR also tightens) and rebase onto post-#1552 main; #1554 follows.

## Generated by

/implement — agent execution of scoped issue #1550.
