### PR TITLE
refactor(actor): deprecate reply_kind in favor of reply and reply_to

### DIFF
--- a/crates/aether-actor/examples/echoer.rs
+++ b/crates/aether-actor/examples/echoer.rs
@@ -7,7 +7,12 @@
 //! inbound mail by `#[actor]`) so the handler body never touches
 //! `Mail<'_>` directly.
 
-use aether_actor::{BootError, FfiActor, FfiCtx, KindId, Resolver, actor};
+// `#[handler]` methods take `&mut self` to match the dispatch ABI
+// (ADR-0033 / ADR-0038); a stateless handler that ignores `self` is
+// fine but must keep the signature.
+#![allow(clippy::unused_self)]
+
+use aether_actor::{BootError, FfiActor, FfiCtx, OutboundReply, Resolver, actor};
 use aether_data::{Kind, Schema};
 use bytemuck::{Pod, Zeroable};
 
@@ -25,28 +30,22 @@ pub struct Response {
     pub seq: u32,
 }
 
-pub struct Echoer {
-    response: KindId<Response>,
-}
+pub struct Echoer {}
 
 #[actor]
 impl FfiActor for Echoer {
     const NAMESPACE: &'static str = "echoer";
 
-    fn init<C>(ctx: &mut C) -> Result<Self, BootError>
+    fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
     where
         C: Resolver,
     {
-        Ok(Echoer {
-            response: ctx.resolve::<Response>(),
-        })
+        Ok(Echoer {})
     }
 
     #[handler]
     fn on_request(&mut self, ctx: &mut FfiCtx<'_>, req: Request) {
-        if let Some(sender) = ctx.reply_target() {
-            ctx.reply_kind(sender, self.response, &Response { seq: req.seq });
-        }
+        ctx.reply(&Response { seq: req.seq });
     }
 }
 

--- a/crates/aether-actor/examples/hello.rs
+++ b/crates/aether-actor/examples/hello.rs
@@ -21,7 +21,7 @@
 // fine but must keep the signature.
 #![allow(clippy::unused_self)]
 
-use aether_actor::{BootError, FfiActor, FfiCtx, KindId, Resolver, actor};
+use aether_actor::{BootError, FfiActor, FfiCtx, OutboundReply, Resolver, actor};
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::{LifecycleCapability, RenderCapability};
 use aether_kinds::{DrawTriangle, Ping, Pong, Tick, Vertex};
@@ -56,9 +56,7 @@ static TRIANGLE: DrawTriangle = DrawTriangle {
 };
 
 /// Per-instance state for the hello component.
-pub struct Hello {
-    pong: KindId<Pong>,
-}
+pub struct Hello {}
 
 /// Minimal end-to-end smoke component: draws a static triangle every
 /// tick and echoes pings back to the sender.
@@ -72,13 +70,11 @@ pub struct Hello {
 impl FfiActor for Hello {
     const NAMESPACE: &'static str = "hello";
 
-    fn init<C>(ctx: &mut C) -> Result<Self, BootError>
+    fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
     where
         C: Resolver,
     {
-        Ok(Hello {
-            pong: ctx.resolve::<Pong>(),
-        })
+        Ok(Hello {})
     }
 
     //noinspection DuplicatedCode
@@ -107,9 +103,7 @@ impl FfiActor for Hello {
     /// are in flight.
     #[handler]
     fn on_ping(&mut self, ctx: &mut FfiCtx<'_>, ping: Ping) {
-        if let Some(sender) = ctx.reply_target() {
-            ctx.reply_kind(sender, self.pong, &Pong { seq: ping.seq });
-        }
+        ctx.reply(&Pong { seq: ping.seq });
     }
 }
 

--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -146,14 +146,16 @@ impl FfiCtx<'_> {
         self.sender = sender.map(ReplyHandle::raw);
     }
 
-    /// Reply with an explicit `sender` + cached `KindId<K>`. Sits
-    /// alongside the trait-driven [`OutboundReply::reply`] which uses
-    /// the dispatcher-stamped sender plus `K::ID`. Useful for FFI
-    /// guests sending cast-shaped types that don't impl
-    /// `serde::Serialize` (the trait method's bound covers native's
-    /// postcard reply path; FFI's `reply_mail` only ships bytes via
-    /// [`Kind::encode_into_bytes`], so the bound is over-strict for
-    /// guest-side cast kinds).
+    /// Reply with an explicit `sender` + cached `KindId<K>`.
+    ///
+    /// Prefer the trait surface: [`OutboundReply::reply`] replies to the
+    /// dispatcher-stamped sender (a no-op when there's none), and
+    /// [`OutboundReply::reply_to`] takes an explicit [`ReplyHandle`]. Both
+    /// derive the kind from `K::ID`, so the cached `KindId<K>` argument
+    /// here is redundant.
+    #[deprecated(
+        note = "use OutboundReply::reply / reply_to; ADR-0100 dropped the Serialize bound"
+    )]
     pub fn reply_kind<K: Kind>(&self, sender: ReplyHandle, kind: KindId<K>, payload: &K) {
         let bytes = payload.encode_into_bytes();
         MAIL_BRIDGE.reply_mail(sender.raw(), kind.raw(), &bytes, 1);

--- a/demos/sokoban/src/lib.rs
+++ b/demos/sokoban/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! Grid is still capped at 16×16 (pre-ADR-0028 carryover).
 
-use aether_actor::{BootError, FfiActor, FfiCtx, KindId, MailSender, Resolver, actor};
+use aether_actor::{BootError, FfiActor, FfiCtx, MailSender, OutboundReply, Resolver, actor};
 use aether_camera::{CameraTopdownSet, TopdownParams};
 use aether_capabilities::input::InputMailboxExt;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
@@ -133,7 +133,6 @@ const LEVELS: &[&[&str]] = &[
 
 pub struct Sokoban {
     state: SokobanState,
-    state_kind: KindId<SokobanState>,
     /// Cached camera-follow envelope. The `name` field is set once at
     /// init and reused every tick to avoid re-allocating the String;
     /// only `params.center` is mutated per frame.
@@ -156,13 +155,12 @@ pub struct Sokoban {
 impl FfiActor for Sokoban {
     const NAMESPACE: &'static str = "sokoban";
 
-    fn init<C>(ctx: &mut C) -> Result<Self, BootError>
+    fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
     where
         C: Resolver,
     {
         let mut me = Sokoban {
             state: SokobanState::default(),
-            state_kind: ctx.resolve::<SokobanState>(),
             follow_msg: CameraTopdownSet {
                 name: "main".to_owned(),
                 params: TopdownParams {
@@ -387,10 +385,7 @@ impl Sokoban {
     }
 
     fn reply_state(&self, ctx: &mut FfiCtx<'_>) {
-        let Some(sender) = ctx.reply_target() else {
-            return;
-        };
-        ctx.reply_kind(sender, self.state_kind, &self.state);
+        ctx.reply(&self.state);
     }
 
     fn render_grid(&self, ctx: &mut FfiCtx<'_>) {


### PR DESCRIPTION
Closes iamacoffeepot/aether#1554.

## Summary

FfiCtx::reply_kind existed only to work around a Serialize bound it claimed the trait reply method needed for cast-shaped kinds. ADR-0100 obsoleted that: OutboundReply::reply needs only K: Kind, and a Pod-without-Serialize cast kind is repliable. Because reply_kind takes a pre-resolved KindId<K>, the canonical examples resolve-and-store a KindId in init purely to feed it, teaching the most verbose of three reply idioms.

This converts the three in-tree callers (echoer, hello, sokoban) to ctx.reply(&payload): each drops the stored KindId field, its init-time resolve, and the KindId import, adds use aether_actor::OutboundReply, and collapses the reply_target() guard (reply is a built-in no-op when there's no sender). reply_kind stays as a thin #[deprecated] wrapper for one release (it's a pub guest-SDK method, so out-of-tree guests get a deprecation window) with its doc-comment rewritten to drop the obsolete Serialize rationale.

## Test plan

Full preflight green (fmt, clippy -D warnings — proving no in-tree caller trips the deprecation lint, nextest --workspace, doc, wasm32 component cross-build incl. the sokoban demo, qodana).

## Merge order

Part of the actor send/reply cluster. Land after #1552 (retire MailCtx, which removes the dual-reply E0034 overlap noted in this issue's side findings) and #1550; rebase onto post-cluster main.

## Generated by

/implement — agent execution of scoped issue #1554.
