### PR TITLE
docs(workflow): add /sketch skill as the single issue-creation path

### DIFF
--- a/.claude/skills/scope-spinoff/SKILL.md
+++ b/.claude/skills/scope-spinoff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scope-spinoff
-description: Triage §Side findings into child GitHub issues. Reads the parent issue's §Side findings section, lets the user pick which entries to spin off, files each as a new Backlog-Phase issue with a conventional-commit title and a link back to the parent, then removes the spun-off entries from the parent body. Audit-comment trail on the parent records what was spun.
+description: Triage §Side findings into child GitHub issues. Reads the parent issue's §Side findings section, lets the user pick which entries to spin off, files each via /sketch's mechanics as a new Backlog-Phase issue with a link back to the parent, then removes the spun-off entries from the parent body. The children's timeline cross-references on the parent record what was spun.
 ---
 
 # /scope-spinoff — side findings → child issues
@@ -58,13 +58,7 @@ For each selected finding:
 
    For a spun-off finding the verbatim blockquote in `## Description` is the finding line as it appeared in the parent body; the expansion is any context the agent already has from reading the code. Don't set Type/Size/AgentReady — `/scope` handles those when the child gets scoped.
 
-3. **Audit comment on parent:**
-
-   ```
-   [scope-spinoff] Filed #<child> from finding "<one-line finding text>".
-   ```
-
-   One comment per spin-off, not a batched list — makes the timeline legible per-finding.
+No comment is posted on the parent: the child's `Spun off from #<parent>` line creates a cross-reference event in the parent's timeline automatically, one per filing, which is the per-finding record.
 
 After all selected findings are filed, **rewrite the parent's body** to remove the spun-off entries from §Side findings. Remaining findings keep their original numbering shifted to fill gaps (1, 2, 3 after removing original 2 means new 1, 2 — the user re-runs `/scope-spinoff` with fresh indices).
 
@@ -80,7 +74,6 @@ Would file:
   - "test(actor): add coverage for ReplaceResult error path" (from finding 3)
 
 Would remove findings 1, 3 from #<parent> §Side findings.
-Would add 2 audit comments to #<parent>.
 
 (no changes made — re-run without --dry-run to file)
 ```
@@ -97,12 +90,12 @@ Would add 2 audit comments to #<parent>.
   Use which scope? (e.g. substrate, actor, mesh, or "skip" to omit this finding)
   ```
 
-- **Parent issue closed**: still allowed — informational findings can be filed against a closed parent. Add a note in the audit comment that the parent is closed.
+- **Parent issue closed**: still allowed — informational findings can be filed against a closed parent. Note it in the run's output.
 
 ## What `/scope-spinoff` does NOT do
 
 - Scope the child issues. They're filed at `Phase=Backlog` with a title + description; running `/scope <child>` is a separate operation.
-- Auto-link as dependencies. The §Found during line in the body and the `[scope-spinoff]` audit comment on the parent are the connection. GitHub's native `--add-dependency` feature could be added in v2 if the dependency graph view becomes load-bearing.
+- Auto-link as dependencies. The §Found during line in the body (and the timeline cross-reference it creates on the parent) is the connection. GitHub's native `--add-dependency` feature could be added in v2 if the dependency graph view becomes load-bearing.
 - Modify §Problem statement, §Design notes, or §Implementation plan on the parent. Only §Side findings is touched.
 - Reorder remaining findings. Index reuse means re-run = different number for the same item; user is expected to re-read after a partial spin-off.
 
@@ -111,6 +104,6 @@ Would add 2 audit comments to #<parent>.
 Two alternatives considered for handling spun-off entries:
 
 - **Strikethrough**: visually clear what was spun, preserves history in-body. But clutters the section over time and competes with future spin-off runs.
-- **Move to a §Spun off subsection**: keeps the body as the canonical record. But duplicates the audit-comment trail and bloats the body.
+- **Move to a §Spun off subsection**: keeps the body as the canonical record. But duplicates the timeline's cross-reference trail and bloats the body.
 
-**Removal** is cleanest: the §Side findings section stays a live to-triage list; the audit comments are the historical record; the child issue itself carries the long-form context. The body shouldn't be a log.
+**Removal** is cleanest: the §Side findings section stays a live to-triage list; the timeline cross-references are the historical record; the child issue itself carries the long-form context. The body shouldn't be a log.

--- a/.claude/skills/scope-spinoff/SKILL.md
+++ b/.claude/skills/scope-spinoff/SKILL.md
@@ -44,45 +44,21 @@ Wait for the user's response. Parse "1,3,4" into a set of indices.
 
 For each selected finding:
 
-1. **Generate a conventional-commit title** from the finding text. The agent applies its judgment for the type prefix:
-   - "dead code", "unused", "drift" → `chore(<crate>)`
-   - "missing test", "test gap" → `test(<crate>)`
-   - "doc gap", "missing rustdoc" → `docs(<crate>)`
-   - "bug", "regression" → `fix(<crate>)`
-   - "missing feature", "extension" → `feat(<crate>)`
-   - Default if ambiguous → `chore(<crate>)`
+1. **File the child via `/sketch`'s mechanics** (read `.claude/skills/sketch/SKILL.md` — it is the single definition of issue filing). The finding text is the sketch input: `/sketch` owns title inference (type prefix from its inference table, crate scope from the finding's file pointer — e.g. `aether-substrate/dispatch.rs:142` → `substrate`; ask the user inline if the pointer is missing or ambiguous), label selection, board placement at `Phase=Backlog`, and the item-ID cache write.
 
-   The `<crate>` comes from the file pointer in the finding (e.g. `aether-substrate/dispatch.rs:142` → `substrate`). If the pointer is missing or ambiguous, ask the user inline.
-
-2. **File the child issue:**
-
-   ```bash
-   gh issue create --title "<conventional-title>" --body "<body>"
-   ```
-
-   Body template:
+2. **Append the spinoff context** to the body `/sketch` produces — the lead comment plus a `## Found during` section after `## Description`:
 
    ```markdown
    <!-- pr-body-ok: e — auto-filed from scope-spinoff, scope is parent-issue context -->
-
-   ## Description
-
-   <expanded finding text — keep the original line, add any context the agent already has from reading the code>
 
    ## Found during
 
    Spun off from #<parent> §Side findings during `/scope-spinoff` on <date>.
    ```
 
-3. **Add the child to the active project** at `Phase=Backlog`:
+   For a spun-off finding the verbatim blockquote in `## Description` is the finding line as it appeared in the parent body; the expansion is any context the agent already has from reading the code. Don't set Type/Size/AgentReady — `/scope` handles those when the child gets scoped.
 
-   ```bash
-   gh project item-add <active-project> --owner <owner> --url <child-url>
-   ```
-
-   Don't set Type/Size/AgentReady — `/scope` handles those when the child gets scoped.
-
-4. **Audit comment on parent:**
+3. **Audit comment on parent:**
 
    ```
    [scope-spinoff] Filed #<child> from finding "<one-line finding text>".

--- a/.claude/skills/sketch/SKILL.md
+++ b/.claude/skills/sketch/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: sketch
+description: Capture an idea as a well-formed GitHub issue — lint-clean conventional-commit title, type/crate labels, added to the active release board at Phase=Backlog. Light expansion only — preserves the user's words verbatim and adds brief context, no design or architecture reasoning (that's /scope). The single definition of "file an issue correctly"; /scope-spinoff delegates here.
+---
+
+# /sketch — idea → issue
+
+The entry point of the pipeline: turn a rough idea into a filed, board-tracked issue that `/scope` can pick up later. `/sketch` is capture, not scoping — it preserves the user's intent and adds just enough context for a future reader, then stops.
+
+This skill is the single definition of issue-filing mechanics (title, labels, board placement). Other skills that file issues (`/scope-spinoff`, `/scope`'s multi-PR split) follow this skill's mechanics rather than defining their own.
+
+## Invocation
+
+```
+/sketch <idea text>                  file an issue from the idea
+/sketch <idea text> --type <t>       override the inferred type prefix
+/sketch <idea text> --crate <c>      override the inferred crate scope
+/sketch <idea text> --label <l,...>  extra labels (e.g. papercut, design)
+/sketch <idea text> --no-board       file the issue, skip board placement
+```
+
+With no idea text, ask what the idea is — don't guess from conversation context unless the user just described it.
+
+## Title
+
+`{type}({crate}): subject` — lowercase subject, conventional-commit form. The repo's issue lint auto-applies `invalid-title` to anything else, and `/scope` derives the board `Type` field from the prefix, so the title is load-bearing.
+
+Type inference from the idea text (same table `/scope-spinoff` uses):
+
+- "dead code", "unused", "drift", workflow/tooling → `chore`
+- "missing test", "test gap", "flaky" → `test`
+- "doc gap", "missing rustdoc", guide/ADR work → `docs`
+- "bug", "regression", "broken", "panics" → `fix`
+- new capability, "add", "support" → `feat`
+- restructure with no behavior change → `refactor`
+- pipelines, runners, release automation → `ci`
+- Default if genuinely ambiguous → `chore`, and say so in the output
+
+The crate scope comes from whatever the idea names or points at (a file path resolves to its crate; skill/workflow/process work uses `workflow`; repo-wide chores use `repo`). If the scope is ambiguous, ask inline — a wrong scope is worse than one question.
+
+## Labels
+
+Apply on the `gh issue create` call itself (`--label "type:<t>,crate:<c>"`) — labels at creation are part of the one REST call, not follow-up edits.
+
+- `type:<t>` mirrors the title prefix (note: not every type has a label — check `gh label list` output cached in this repo: `type:feat`, `type:fix`, `type:docs`, `type:chore`, `type:perf`, `type:refactor`, `type:flake` exist; `ci`/`test` have no label — skip, the title carries it).
+- `crate:<short>` for the crate scope. **If the crate is new and has no label, create it first** (`gh label create "crate:<short>" --color bfdadc --description "<full crate name>"`) — PRs against a crate with no label trip the title lint (Pattern E).
+- `papercut` / `design` when the idea is a gotcha/rough-edge or a work-in-progress design, respectively — pass via `--label` or infer when the idea text says so.
+- No `phase:*` label — Backlog carries none by convention.
+
+## Body — light expansion
+
+The body preserves the user's words and adds brief grounding. It does **not** design, does not scope out what needs wiring where, and never pre-creates the `/scope`-managed sections (`## Problem statement`, `## Design notes`, `## Implementation plan`, `## Sub-issues`, `## Side findings`).
+
+```markdown
+## Description
+
+> <the user's sketch, verbatim>
+
+<2–3 sentences of context: what part of the system this touches, file pointers
+(`crate/src/file.rs`) if already known from the conversation, and any constraint
+the user stated. Nothing speculative — if you'd have to open files to say it,
+leave it for /scope.>
+```
+
+The blockquote/expansion split is deliberate: `/scope`'s Define phase needs to know what is user intent versus added context.
+
+Callers delegating to this skill (e.g. `/scope-spinoff`) may append their own sections after `## Description` (such as `## Found during`); `/sketch` itself adds nothing more.
+
+## Board placement
+
+Requires `.claude/release-state.json` (the active-release marker). Two GraphQL calls:
+
+1. `addProjectV2ItemById` with the new issue's node ID (returned by `gh issue create` via `--json` or one `gh issue view --json id`).
+2. `updateProjectV2ItemFieldValue` setting `Phase=Backlog` using the cached field/option IDs.
+
+Record the returned project item ID in `release-state.json` under `item_cache` so later skills skip the lookup entirely:
+
+```json
+"item_cache": { "<issue-number>": "PVTI_..." }
+```
+
+(Create the key if absent; item IDs are stable for the life of the project.)
+
+Don't set `Type` / `Size` / `AgentReady` — `/scope` owns those. No audit comment — the issue's own creation event is the record.
+
+Once the release board carries the server-side "item added → Backlog" workflow (issue #1577's template path), step 2 disappears; detect this by the project's workflows rather than guessing — until then, write the field explicitly.
+
+## Output
+
+```
+✓ Filed #<N>: <title>
+  Labels: <labels>
+  Board: <project> @ Backlog   (or "skipped — <reason>")
+  Next: /scope <N> when it's ready to be worked.
+```
+
+## Failure modes
+
+- **`.claude/release-state.json` missing**: file the issue anyway, skip board placement, and say so — an idea is worth capturing even between releases. (`--no-board` makes this explicit.)
+- **`gh` lacks `project` scope**: same — file, skip the board, print the `gh auth refresh -s project` pointer.
+- **Crate scope ambiguous**: ask inline before filing. Don't file with a guessed scope.
+- **Board add succeeds but the Phase write fails**: the item lands wherever the project's default puts it (column-less or Backlog). Report it; re-running the field write is safe.
+- **Idea is really several ideas**: file one issue per separable idea, confirming the split with the user first.
+
+## What `/sketch` does NOT do
+
+- Scope, design, or plan — no architecture reasoning, no reading code beyond pointers already in hand. `/scope` does the thinking.
+- Pre-create scope-managed body sections.
+- Set board fields other than `Phase=Backlog`.
+- Post comments.
+- Write production code or open PRs.

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ spikes/*/target/
 !.claude/skills/release-init/
 !.claude/skills/scope/
 !.claude/skills/scope-spinoff/
+!.claude/skills/sketch/
 !.claude/skills/secretary/
 !.claude/skills/sweep/
 # Wish-pass reports — themed use-case ideation runs of `/wish`. Per-run


### PR DESCRIPTION
Closes #1575.

## Summary

- New `.claude/skills/sketch/SKILL.md`: capture an idea as a filed, board-tracked issue. Lint-clean `{type}({crate}):` title with the type-inference table (moved here from /scope-spinoff), `type:*`/`crate:*` labels applied on the create call itself, board placement at `Phase=Backlog` (no phase label, per convention), and it seeds the persistent `item_cache` in `release-state.json` that #1576 makes the other skills read.
- Body shape is verbatim-sketch-as-blockquote + 2-3 sentences of expansion — deliberately no design reasoning and no pre-created scope-managed sections; /scope owns the thinking.
- `/scope-spinoff` now delegates its per-finding filing mechanics to /sketch (appending its `## Found during` section), so "file an issue correctly" is defined exactly once.
- `/scope-spinoff`'s per-filing audit comments are retired here rather than in #1576's sweep, since both would rewrite the same section: the child's "Spun off from #parent" line already creates a per-filing cross-reference event in the parent's timeline.
- `.gitignore`: allowlist entry for the new skill directory.

## Test plan

Docs/skill-only change (repo-config preflight class). Verified the skill encodes the live repo conventions: label set against the current label list, Backlog-carries-no-label, scope-managed section names.

## Generated by

Agent execution of #1575 (design settled in chat 2026-06-10).