### PR TITLE
docs(workflow): replace state-echo audit comments with labels and trim api calls

### DIFF
--- a/.claude/skills/approve/SKILL.md
+++ b/.claude/skills/approve/SKILL.md
@@ -11,7 +11,7 @@ The primary human review point of the release flow. The user invokes `/approve <
 
 ```
 /approve <issue>                    standard
-/approve <issue> --note "<text>"    adds the text to the audit comment
+/approve <issue> --note "<text>"    posts the text as a comment on the issue
 /approve <issue> --skip-adr         bypass the ADR-merged check (emergency override)
 ```
 
@@ -22,7 +22,7 @@ The primary human review point of the release flow. The user invokes `/approve <
 
 ## Gate checks
 
-Run all of these. **Refuse** if any fail; list every failure in the refusal comment, don't stop at the first.
+Run all of these. **Refuse** if any fail; list every failure in the refusal output, don't stop at the first.
 
 | Gate | Check | Refusal message |
 |------|-------|-----------------|
@@ -37,16 +37,14 @@ If **all** gates pass, proceed.
 
 ## Actions on pass
 
-1. Set the project item's `AgentReady` field to `Yes`.
-2. Set the project item's `Phase` field to `Ready`, and reconcile the issue label to `phase:ready` (see [Phase label reconcile](#phase-label-reconcile)).
-3. Post an audit comment:
+1. Set the project item's `AgentReady` field to `Yes` and its `Phase` field to `Ready` in **one** `gh api graphql` request — two aliased `updateProjectV2ItemFieldValue` mutations against the same item (field/option IDs from `field_cache`, item ID from `item_cache` with the targeted-lookup fallback — see `/scope` §Project board mechanics). Then reconcile the issue label to `phase:ready` (see [Phase label reconcile](#phase-label-reconcile)).
+2. No comment on a plain approve — the `phase:ready` label, the board fields, and the timeline's label event already record it. If `--note` was passed, post the note as prose markdown:
 
-   ```
-   [approve] Plan approved by <user>. Phase → Ready, AgentReady=Yes.
-   <--note text if passed>
+   ```markdown
+   **Approved** — <note text>
    ```
 
-4. Print a summary to the user:
+3. Print a summary to the user:
 
    ```
    ✓ #N approved.
@@ -88,12 +86,12 @@ For each such reference, run `gh pr view <N> --json mergedAt,state` and require 
 - The ADR is intentionally drafted in the same release but lands separately (e.g. ADR-NNNN cluster work).
 - The change is small enough that ADR-by-the-time-Ready is overkill in retrospect.
 
-When `--skip-adr` is used, the audit comment is verbose:
+When `--skip-adr` is used, a comment is mandatory — the override rationale has no structured home, and the next reader of the issue needs it:
 
-```
-[approve] Plan approved by <user> with --skip-adr override.
-   Unmerged ADRs at approval time: #M
-   Reason: <required note text>
+```markdown
+**Approved with `--skip-adr`** — ADR PR #M was not merged at approval time.
+
+<required note text>
 ```
 
 `--skip-adr` requires `--note "<reason>"`. Don't allow silent ADR bypasses.
@@ -122,4 +120,4 @@ gh issue edit <n> --remove-label "phase:define,phase:design,phase:plan,phase:rea
 - Edit the issue body. Even if a gate fails because a section is missing, /approve doesn't write the missing section — that's `/scope`'s job.
 - Auto-resolve side findings.
 - Close umbrella issues when children complete. Future work.
-- Notify anyone. The audit comment is the notification surface.
+- Notify anyone. The printed summary (and the `phase:ready` label) is the surface; comments appear only for `--note` / `--skip-adr`.

--- a/.claude/skills/bounce/SKILL.md
+++ b/.claude/skills/bounce/SKILL.md
@@ -5,7 +5,7 @@ description: Explicit phase regression. Move an issue from its current Phase bac
 
 # /bounce — explicit phase regression
 
-The user invokes `/bounce` when reviewing scope artifacts (or watching execution) and concludes an upstream phase needs rework. The skill records the regression as a `Phase=Bounced` + `BounceTo=<phase>` state with an audit comment. `/scope` then resumes from the target phase on next invocation.
+The user invokes `/bounce` when reviewing scope artifacts (or watching execution) and concludes an upstream phase needs rework. The skill records the regression as a `Phase=Bounced` + `BounceTo=<phase>` state with the reason posted as a comment. `/scope` then resumes from the target phase on next invocation.
 
 Self-bounces by other skills (`/scope` hitting a wall, `/implement` discovering a design flaw mid-execution) use the same mechanism — this skill is the explicit user-driven wrapper.
 
@@ -42,17 +42,16 @@ A bounce from `Ready` to `Plan` is valid (target=3 < current=4). A bounce from `
 
 ## Actions on pass
 
-1. Set the project item's `Phase` field to `Bounced`, and reconcile the issue label to `phase:bounced` (see [Phase label reconcile](#phase-label-reconcile)).
-2. Set the project item's `BounceTo` field to the target phase.
-3. Post an audit comment:
+1. Set the project item's `Phase` field to `Bounced` and its `BounceTo` field to the target phase in **one** `gh api graphql` request — two aliased `updateProjectV2ItemFieldValue` mutations against the same item (item ID from `item_cache`, targeted-lookup fallback per `/scope` §Project board mechanics). Then reconcile the issue label to `phase:bounced` (see [Phase label reconcile](#phase-label-reconcile)).
+2. Post the reason as a comment — it is the surviving comment class (information addressed to a human with no structured home), written as prose markdown with a bold lead:
 
+   ```markdown
+   **Bounced to <target>** (from <previous-phase>)
+
+   <reason text, verbatim>
    ```
-   [bounce] Phase regression by <user>: <previous-phase> → Bounced (BounceTo=<target>).
 
-   Reason: <text>
-   ```
-
-4. Print summary:
+3. Print summary:
 
    ```
    ✓ #N bounced.
@@ -70,18 +69,23 @@ When `/scope <issue>` runs on a Bounced issue, it must:
 2. Set `Phase=<BounceTo>` (clears the Bounced state), reconciling the label from `phase:bounced` to `phase:<BounceTo>`.
 3. Run from that phase forward — redoing the bounced phase and every downstream phase.
 
-If the user passes `/scope <issue> --phase <name>` while bounced and `<name>` matches `BounceTo`, behavior is identical (the flag is the explicit form of the same intent). If `<name>` differs from `BounceTo`, honor `<name>` (the user is overriding) but post a comment noting the override.
+If the user passes `/scope <issue> --phase <name>` while bounced and `<name>` matches `BounceTo`, behavior is identical (the flag is the explicit form of the same intent). If `<name>` differs from `BounceTo`, honor `<name>` (the user is overriding) and note the override in the run's output.
 
 ## Self-bounce by other skills
 
-Skills that detect their own wall conditions (`/scope` hitting a vague issue body, `/implement` discovering a broken assumption) call into the same logic: set `Phase=Bounced`, set `BounceTo=<phase>`, post a comment. The audit comment prefix changes to identify the source:
+Skills that detect their own wall conditions (`/scope` hitting a vague issue body, `/implement` discovering a broken assumption) call into the same logic: set `Phase=Bounced`, set `BounceTo=<phase>`, post the blocker as a comment. Same prose-markdown shape, with the lead naming what's blocked and the body carrying the question or finding:
 
+```markdown
+**Bounced to Design** — the two candidate shapes are genuinely tied.
+
+<the specific question the user must answer>
 ```
-[scope] Self-bounce: <previous> → Bounced (BounceTo=Design).
-   Question: <the blocker>
 
-[implement] Self-bounce: Executing → Bounced (BounceTo=Plan).
-   Discovered during implementation: <the issue>
+```markdown
+**Bounced to Plan** — discovered during implementation.
+
+<the broken assumption, with the file/test that exposed it; for /implement,
+the attempt history follows here>
 ```
 
 Same skill mechanism, different invocation site. `/bounce` is the user-driven variant.
@@ -90,7 +94,7 @@ Same skill mechanism, different invocation site. `/bounce` is the user-driven va
 
 `Phase=Stalled` is a different signal — env/tooling failure, not a phase regression. Examples: qodana CI service down, GitHub API rate-limited mid-batch, `gh` token expired. The issue's scoping is fine; the *environment* is the problem.
 
-v1 has no `/stall` skill — set Stalled manually in the UI or via `gh project item-edit` with the BounceTo field left null. When you do, also set the `phase:stalled` label on the issue (`gh issue edit <n> --remove-label "phase:define,…,phase:bounced,phase:stalled" && gh issue edit <n> --add-label phase:stalled` — `&&`-chained per [Phase label reconcile](#phase-label-reconcile)) so the halt is visible in `gh issue list`. Future `/stall <issue> --reason "<env-issue>"` would post the same kind of audit comment.
+v1 has no `/stall` skill — set Stalled manually in the UI or via `gh project item-edit` with the BounceTo field left null. When you do, also set the `phase:stalled` label on the issue (`gh issue edit <n> --remove-label "phase:define,…,phase:bounced,phase:stalled" && gh issue edit <n> --add-label phase:stalled` — `&&`-chained per [Phase label reconcile](#phase-label-reconcile)) so the halt is visible in `gh issue list`. Future `/stall <issue> --reason "<env-issue>"` would post the reason the same way `/bounce` does — it's the same surviving comment class.
 
 ## Phase label reconcile
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -61,7 +61,7 @@ Type comes from the project item's `Type` field. Slug is the issue title sanitiz
 
 ## Execute phase
 
-1. Set project item's `Phase = Executing` and reconcile the issue label to `phase:executing` (see [Phase label reconcile](#phase-label-reconcile)). In `--quick` label-only mode (issue not on the board), set the label and skip the board field. Post audit comment: `[implement] Executing — branched <type>/issue-<N>-<slug> off main, worktree .claude/worktrees/issue-<N>`.
+1. Set project item's `Phase = Executing` (item ID from `release-state.json`'s `item_cache`, targeted-lookup fallback per `/scope` §Project board mechanics) and reconcile the issue label to `phase:executing` (see [Phase label reconcile](#phase-label-reconcile)). In `--quick` label-only mode (issue not on the board), set the label and skip the board field. No comment — the label event records the transition, and the branch/worktree are printed in the run's output.
 
 2. Implement per the issue body's `## Implementation plan` section. The agent follows the plan literally: same files, same sequence, same test coverage. Deviations are bounces, not freelancing.
 
@@ -79,7 +79,7 @@ Type comes from the project item's `Type` field. Slug is the issue title sanitiz
    gh pr create --draft --title "<conventional-commit title>" --body "<see PR body template below>"
    ```
 
-5. Audit comment on issue: `[implement] PR opened: #<pr-number>`.
+   No "PR opened" comment — the PR body's closing reference creates a cross-reference event in the issue's timeline.
 
 ## Refine loop (the spin-until-green part)
 
@@ -108,15 +108,13 @@ After PR open, enter the loop. On each iteration:
 
 4. If real failure, fix in the worktree, push to the same branch, increment attempt counter, goto step 1.
 
-5. Set project item's `Phase` to `Refine` during fix-and-wait, back to `Executing` when pushing the fix. (Flicker is intentional — gives the board honest visibility.) Reconcile the `phase:*` label on each flip (see [Phase label reconcile](#phase-label-reconcile)).
+5. Set project item's `Phase` to `Refine` during fix-and-wait, back to `Executing` when pushing the fix. (Flicker is intentional — gives the board honest visibility.) Reconcile the `phase:*` label on each flip (see [Phase label reconcile](#phase-label-reconcile)). No per-attempt comments — the PR's own commit and check history is the attempt record; track the attempt counter in-session.
 
-6. Audit comment per attempt: `[implement] CI failed (attempt <N>/<retry-cap>): <one-line summary>` and `[implement] Fix pushed for attempt <N>`.
+6. **Retry cap hit** → self-bounce. `Phase=Bounced`, `BounceTo=Plan`, comment with the full attempt history.
 
-7. **Retry cap hit** → self-bounce. `Phase=Bounced`, `BounceTo=Plan`, comment with the full attempt history.
+7. **Wall-clock hit** → self-bounce. Same as retry cap with the elapsed time noted.
 
-8. **Wall-clock hit** → self-bounce. Same as retry cap with the elapsed time noted.
-
-9. **Design-level discovery** at any attempt → self-bounce. `Phase=Bounced`, `BounceTo=Design`, comment with the specific finding. Examples:
+8. **Design-level discovery** at any attempt → self-bounce. `Phase=Bounced`, `BounceTo=Design`, comment with the specific finding. Examples:
    - "Approach X doesn't work because Y; needs alternative."
    - "Test Z passes only if we also change A, which is outside §Implementation plan."
 
@@ -130,10 +128,9 @@ Format/clippy/build are never flakes — always real, always immediate fix.
 
 CI green:
 
-1. Audit comment: `[implement] CI green on attempt <N>. Draft PR #<pr-number> ready for your review.`
-2. Project item: leave `Phase = Refine` and `AgentReady = Yes` (the issue label stays `phase:refine`). The resting state is "draft PR open + green".
-3. Leave the PR as a **draft**. Do not un-draft, do not merge, do not close, do not auto-set Phase=Done. Un-drafting is the user's (or the approved release process's) action — once a PR is un-drafted, native auto-merge lands it on green ([[feedback_green_pr_automerges_before_review]]).
-4. Print to user:
+1. Project item: leave `Phase = Refine` and `AgentReady = Yes` (the issue label stays `phase:refine`). The resting state is "draft PR open + green" — no comment; the green checks on the PR are the record.
+2. Leave the PR as a **draft**. Do not un-draft, do not merge, do not close, do not auto-set Phase=Done. Un-drafting is the user's (or the approved release process's) action — once a PR is un-drafted, native auto-merge lands it on green ([[feedback_green_pr_automerges_before_review]]).
+3. Print to user:
 
    ```
    ✓ #<N> implemented and CI-green.
@@ -151,15 +148,18 @@ For v1, that final transition is manual: the user merges via `gh pr merge` or th
 
 ## Self-bounce mechanics
 
-Uses the same machinery as `/bounce` — see that skill's "Self-bounce by other skills" section. Audit comment prefix is `[implement]`:
+Uses the same machinery as `/bounce` — see that skill's "Self-bounce by other skills" section. The bounce comment is prose markdown carrying the reason and the full attempt history (the one place that history lives):
 
-```
-[implement] Self-bounce after attempt <N>: Executing → Bounced (BounceTo=Plan).
-   Reason: <retry cap hit | wall clock hit | scope expansion needed | ...>
-   Attempts history:
-     1. <failure summary>
-     2. <failure summary>
-     3. <failure summary>
+```markdown
+**Bounced to Plan** — retry cap hit after attempt <N>.
+
+Attempts:
+
+1. <failure summary>
+2. <failure summary>
+3. <failure summary>
+
+<what the plan needs to address before a re-run>
 ```
 
 The worktree stays on disk until the user cleans up — useful for inspecting the failed state. Worktree cleanup is *not* part of self-bounce.
@@ -220,7 +220,7 @@ gh issue edit <n> --remove-label "phase:define,phase:design,phase:plan,phase:rea
 - Edit the issue body (only `/scope` does).
 - Re-scope the issue when CI surfaces problems — bounce instead.
 - Address reviewer feedback on the PR. Reviewers comment; `/bounce` if the feedback requires re-scoping; manual handling otherwise.
-- Notify anyone. Audit comments are the surface.
+- Notify anyone. The printed output and the `phase:*` labels are the surface; the only comment this skill posts is a self-bounce reason.
 - Merge — code PRs always hold for your review; auto-merge is the release process's call, not this skill's.
 - Run scoped (without `--quick`) on issues that aren't in the active project. For an ad-hoc fix outside the board, use `--quick` (label-only mode).
 - Clean up worktrees after success or bounce. Leaves them for inspection; `git worktree remove .claude/worktrees/issue-<N>` is the user's call.

--- a/.claude/skills/scope/SKILL.md
+++ b/.claude/skills/scope/SKILL.md
@@ -34,17 +34,18 @@ Reads `.claude/release-state.json` at the repo root:
     "Size":       { "id": "...", "options": { ... } },
     "AgentReady": { "id": "...", "options": { ... } },
     "BounceTo":   { "id": "...", "options": { ... } }
-  }
+  },
+  "item_cache": { "<issue-number>": "PVTI_..." }
 }
 ```
 
 If the file is missing, abort with: *"No active release state. Run `/release-init <version>` first or create `.claude/release-state.json`."*
 
-The cache is populated by `/release-init`; this skill never writes it.
+`field_cache` is populated by `/release-init`; no other skill writes it. `item_cache` maps issue numbers to project item IDs — `/sketch` seeds it at filing, and any skill appends on a lookup miss (see [Project board mechanics](#project-board-mechanics)). Item IDs are stable for the life of the project.
 
 ## Phase walk
 
-For each sub-phase: read inputs, write the corresponding body section, post a brief progress comment, advance the `Phase` field on the project board — and reconcile the matching `phase:*` label (see [Phase label reconcile](#phase-label-reconcile)). If a sub-phase has nothing to do (already complete on a resumed run), skip it.
+For each sub-phase: read inputs, write the corresponding body section, advance the `Phase` field on the project board — and reconcile the matching `phase:*` label (see [Phase label reconcile](#phase-label-reconcile)). If a sub-phase has nothing to do (already complete on a resumed run), skip it.
 
 ### Define
 
@@ -99,7 +100,7 @@ For each sub-phase: read inputs, write the corresponding body section, post a br
 - **Multi-PR split** triggers when:
   - More than 3 logically-separable changes, *or*
   - More than 2 crates with logically-separable work
-  - In that case, file each sub-issue (Phase=Backlog initially, link parent), update §Sub-issues, and scope each child in a follow-up `/scope` run.
+  - In that case, file each sub-issue via `/sketch`'s mechanics (Phase=Backlog initially, link parent), update §Sub-issues, and scope each child in a follow-up `/scope` run.
 - **Size estimation** — set the `Size` custom field on the project item:
   - **S**: single file, single concept, <100 LOC change
   - **M**: single crate, multiple files, <500 LOC change
@@ -119,17 +120,18 @@ During Design and Plan reads, the agent will inevitably notice unrelated issues 
 
 These are *not auto-filed* as child issues. The user reviews them at `/approve` time and chooses which to spin off via `/scope-spinoff <issue>` (separate skill).
 
-## Comments (audit trail)
+## Comments
 
-After each sub-phase completes, post a brief comment so the timeline is legible:
+No progress comments — phase transitions are already legible from the `phase:*` labels (the issue timeline records every label change), the board fields, and the body sections themselves. A comment exists only when it is addressed to a human and carries content with no structured home. For this skill that is the **self-bounce question/blocker**, written as prose markdown with a bold lead, no `[skill]` prefix:
 
+```markdown
+**Bounced to Define** — the body doesn't say which chassis this applies to.
+
+Desktop-only (window mail exists) or all four? The answer changes whether the
+headless chassis needs a nop mailbox. Re-run `/scope` once the body says.
 ```
-[scope] Define complete — see body §Problem statement
-[scope] Design complete — chose A over B because <one-line reason>
-[scope] Plan complete — Size=M, sub-issues filed: #NNN, #MMM
-```
 
-Bounces are full comments with the question/blocker. Don't pad them with summaries of the section.
+Don't pad the comment with summaries of work that completed — the body sections carry that.
 
 ## Body editing mechanics
 
@@ -154,14 +156,16 @@ gh project item-edit \
     --single-select-option-id <option-id>
 ```
 
-All four IDs come from `.claude/release-state.json`'s `field_cache`. The item ID for a given issue:
+Field and option IDs come from `.claude/release-state.json`'s `field_cache`; the item ID comes from its `item_cache` (keyed by issue number). On a cache miss, resolve it with one targeted GraphQL query — never a board-wide `gh project item-list` scan:
 
-```
-gh project item-list <active_project> --owner <owner> --format json \
-  | jq '.items[] | select(.content.number == <issue-number>) | .id'
+```bash
+gh api graphql -f query='query { repository(owner: "<owner>", name: "aether") {
+  issue(number: <n>) { projectItems(first: 10) { nodes { id project { id } } } } } }'
 ```
 
-Cache item IDs per-issue per-run to avoid repeated lookups.
+Pick the node whose `project.id` matches `project_node_id`, then append it to `item_cache` so every later run skips the query.
+
+GitHub's REST and GraphQL rate budgets are separate, and the GraphQL one is the binding constraint when many agents run — spend GraphQL only where it's mandatory (board field reads/writes); labels, comments, and body edits ride REST via plain `gh issue` commands.
 
 ## Phase label reconcile
 
@@ -187,7 +191,7 @@ gh issue edit <n> --remove-label "phase:define,phase:design,phase:plan,phase:rea
 - Merge anything.
 - Auto-file side findings as child issues (use `/scope-spinoff`).
 - Set `AgentReady=Yes` (use `/approve`).
-- Set `Type` — that should come from the issue title's conventional-commit prefix (`feat:` → `feat`, `fix:` → `fix`, etc.). If unset, infer from title; if title has no prefix, leave unset and surface in a Plan-phase comment.
+- Set `Type` — that should come from the issue title's conventional-commit prefix (`feat:` → `feat`, `fix:` → `fix`, etc.). If unset, infer from title; if title has no prefix, leave unset and surface it in the run's output.
 
 ## Failure modes to handle gracefully
 
@@ -195,5 +199,5 @@ gh issue edit <n> --remove-label "phase:define,phase:design,phase:plan,phase:rea
 - **Issue not in active project**: add it (`gh project item-add`), then proceed.
 - **`gh` lacks `project` scope**: abort with *"Run `gh auth refresh -s project`"*.
 - **Issue already at Phase=Done or Phase=Executing**: refuse with *"Issue is past Plan — use `/bounce` to regress or work in a fresh issue."*
-- **ADR drafting failure**: keep the issue at Design, post a comment explaining, don't advance to Plan.
-- **Body-edit collision (user edited body mid-run)**: re-read, re-merge, post a comment if there are conflicts in managed sections.
+- **ADR drafting failure**: keep the issue at Design, explain in the run's output, don't advance to Plan.
+- **Body-edit collision (user edited body mid-run)**: re-read, re-merge, surface any conflicts in managed sections in the run's output.

--- a/.claude/skills/secretary/SKILL.md
+++ b/.claude/skills/secretary/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: secretary
-description: Surface everything that needs your attention as a ranked queue, then prompt with `AskUserQuestion` selectors so resolution is click-driven instead of typed. Bidirectional — invoke as `/secretary` to see what's pending, or have Claude/agents post a blocker via `/secretary --post-blocker` when mid-task work needs a user decision. Scans observable state (open PRs, project board phases, failing CI, unanswered audit comments) plus a posted-blockers file. Output is a printed queue followed by selector questions (HIGH/MED) — LOW items print-only.
+description: Surface everything that needs your attention as a ranked queue, then prompt with `AskUserQuestion` selectors so resolution is click-driven instead of typed. Bidirectional — invoke as `/secretary` to see what's pending, or have Claude/agents post a blocker via `/secretary --post-blocker` when mid-task work needs a user decision. Scans observable state (open PRs, project board phases, failing CI, unresolved bounce reasons) plus a posted-blockers file. Output is a printed queue followed by selector questions (HIGH/MED) — LOW items print-only.
 ---
 
 # /secretary — pending-attention queue
@@ -36,7 +36,7 @@ Most blockers are observable; the skill doesn't need anything written ahead of t
 1. **Open PRs you authored** — `gh pr list --author @me --state open --json number,title,createdAt,reviewDecision,statusCheckRollup`. Items with no review and >24h old are MED; items with failing CI are HIGH.
 2. **Open PRs from agents on your behalf** — `gh pr list --search "is:open author:app/*"` (or filter by branch prefix if agents use a convention).
 3. **Active release project** (if `.claude/release-state.json` exists) — items at `Phase=Plan` with `AgentReady=No` (awaiting `/approve`), `Phase=Bounced` (need triage), `Phase=Stalled` (env/tooling).
-4. **Issues with unanswered `[bounce]` / `[scope]` audit comments** since the last user reply on that issue.
+4. **Issues labeled `phase:bounced` / `phase:stalled`** — `gh issue list --label phase:bounced` (one cheap REST call; repeat for `phase:stalled`). This is the label-side mirror of source 3's board scan and works even when `release-state.json` is absent. An issue is *unresolved* when the user hasn't commented since the bounce-reason comment; fetch that comment's text for the item's description so the queue entry says what's blocked, not just that something is.
 5. **Failing CI on your branches** — `gh run list --branch <branch> --status failure --limit 5` per checked-out branch with recent activity.
 6. **Wish reports awaiting triage** — `ls wishes/` directories without corresponding filed issues. Cross-reference against `gh issue list` body content (search for the wish slug).
 7. **Pending memory writes** — entries in `~/.claude/projects/.../memory/PENDING.md` if the file exists (a thin convention: Claude appends "memory I think should be saved but you haven't decided on" entries; `/secretary` surfaces them as multi-choice).
@@ -129,7 +129,7 @@ After the user picks, act on each one (run `/approve`, `/bounce`, save memory fi
 ## Priority rules
 
 - **HIGH**: posted blockers (active agents are waiting); CI red on a branch with recent commits; Bounced / Stalled project items; PRs with explicit "changes requested" review.
-- **MED**: open PRs >24h with no review; project items at `Phase=Plan + AgentReady=No`; unanswered audit comments; failing CI on branches without recent commits.
+- **MED**: open PRs >24h with no review; project items at `Phase=Plan + AgentReady=No`; failing CI on branches without recent commits.
 - **LOW**: pending memory saves; old wish reports awaiting triage; stale unmerged branches with no PR.
 
 If `--high` is passed, only HIGH items print.


### PR DESCRIPTION
Closes #1576.

## Summary

New comment policy across /scope, /approve, /bounce, /implement, /secretary: **a comment exists only when it is addressed to a human and carries content with no structured home.**

- Survivors, as prose markdown with a bold lead (no `[skill]` prefix): bounce reasons (user-driven and self-bounce, with /implement's attempt history folded into its bounce comment) and /approve `--note` / `--skip-adr` rationale. A plain approve posts nothing.
- Retired: per-sub-phase progress comments, "PR opened", per-attempt CI comments, the CI-green comment. The `phase:*` labels (whose add/remove events the issue timeline records), the board fields, and the PR's closing cross-reference already carry all of it.
- /secretary scan source 4 rekeys from `[bounce]`/`[scope]` comment markers to the `phase:bounced` / `phase:stalled` labels — cheaper, and it works without `release-state.json`.

Bundled API trim in the same files:

- `release-state.json` gains `item_cache` (issue number → project item ID, stable for the project's life; seeded by /sketch from #1578, appended on miss via one targeted GraphQL `issue → projectItems` query). The board-wide `item-list | jq` scan is gone.
- /approve (Phase+AgentReady) and /bounce (Phase+BounceTo) each write their two board fields as aliased `updateProjectV2ItemFieldValue` mutations in **one** GraphQL request.
- Budget rule stated where the mechanics live: GraphQL points only for board ops; labels/comments/body edits ride the separate REST budget. The `&&`-chained two-call label swap is untouched.

`/scope-spinoff` is deliberately absent — its comment retirement rode #1578, which rewrites the same section.

## Test plan

Docs/skill-only change (repo-config preflight class). Grepped the five files for leftover `[skill]`-prefix and audit-comment references after the sweep.

## Generated by

Agent execution of #1576 (design settled in chat 2026-06-10).