### PR TITLE
docs(workflow): release-init copies the release template with status-as-phase

### DIFF
--- a/.claude/skills/release-init/SKILL.md
+++ b/.claude/skills/release-init/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: release-init
-description: Bootstrap a new aether release. Creates a GitHub Project with the canonical schema (Phase column + Type/Size/AgentReady/BounceTo/ADR/AuthBudget custom fields), populates .claude/release-state.json with the project ID + field/option ID cache, optionally seeds the project with starter issues. Required before /scope works.
+description: Bootstrap a new aether release. Copies the release template project (canonical schema with the phase vocabulary in the built-in Status field plus Type/Size/AgentReady/BounceTo/ADR/AuthBudget custom fields, and the server-side added→Backlog / closed→Done workflows), populates .claude/release-state.json with the project ID + field/option ID cache, optionally seeds the project with starter issues. Required before /scope works.
 ---
 
 # /release-init — release bootstrap skill
 
-Bootstraps the GitHub Project + local config that the other release skills depend on. Idempotent only when `--reuse` is passed; otherwise creates a fresh project each call.
+Bootstraps the GitHub Project + local config that the other release skills depend on. The per-release project is a **copy of the release template project** — the copy carries the field schema, views, and the two configured workflows (item added → Backlog, issue closed → Done), so phase placement on add and close runs on GitHub's side with no skill writes. Idempotent only when `--reuse` is passed; otherwise creates a fresh project each call.
+
+**Status-as-Phase.** The lifecycle vocabulary (Backlog … Done, Bounced, Stalled) lives in the built-in `Status` field's options, because GitHub's built-in workflows can only set `Status` — never a custom single-select. The built-in field can't be renamed or deleted, so the UI header reads "Status"; everything else (this skill, `release-state.json`, the other skills, chat) keeps calling it **Phase** — the `field_cache` key `"Phase"` simply points at the field named `Status`.
 
 ## Invocation
 
 ```
-/release-init <version>                            create new project "aether <version>"
+/release-init <version>                            copy the template into "aether <version>"
 /release-init <version> --reuse <project-number>   adopt an existing project (no creation)
-/release-init <version> --import #N,#M,#...        add listed issues to project, set Phase=Backlog
+/release-init <version> --import #N,#M,#...        add listed issues to the project
 /release-init <version> --owner <owner>            override default owner (iamacoffeepot)
+/release-init --init-template                      one-time: create the release template project
 ```
 
 Combinable: `/release-init 0.4 --reuse 2 --import #297,#694`.
@@ -26,6 +29,16 @@ Combinable: `/release-init 0.4 --reuse 2 --import #297,#694`.
 
 ## Steps
 
+### 0. (One-time) create the template
+
+If no project titled `aether release template` exists for the owner, `/release-init --init-template` runs:
+
+```bash
+bash scripts/release-project-init.sh --init-template --owner <owner>
+```
+
+The script creates the project, replaces the `Status` field's options with the phase vocabulary (one `updateProjectV2Field` mutation), and creates the other custom fields. The two workflow toggles ("Item added to project" → Backlog, "Item closed" → Done) are **UI-only** — the workflow API is read/delete-only — and the script prints the exact steps. Done once; every release copies them for free (GitHub excludes only auto-add workflows from copies, which this flow doesn't use — `/sketch` adds items itself).
+
 ### 1. Create or adopt the project
 
 If `--reuse <num>` was not passed:
@@ -34,9 +47,9 @@ If `--reuse <num>` was not passed:
 bash scripts/release-project-init.sh <version> --owner <owner>
 ```
 
-Capture the project number from the script's output (`Project N created.`).
+The script locates the template by title and copies it (`gh project copy`) into `aether <version>`. Capture the project number from the script's output. If the script reports the template is missing, run step 0 first.
 
-If `--reuse <num>` was passed, skip creation and use `<num>` directly. Verify the project exists and has the expected fields by running the next step's `field-list` and checking that Phase, Type, Size, AgentReady, BounceTo, ADR, AuthBudget are present. If any are missing, abort with a message naming the missing fields.
+If `--reuse <num>` was passed, skip creation and use `<num>` directly. Verify the project exists and has the expected fields by running the next step's `field-list` and checking that Status (carrying the phase options), Type, Size, AgentReady, BounceTo, ADR, AuthBudget are present. If any are missing, abort with a message naming the missing fields.
 
 ### 2. Query the field cache
 
@@ -47,7 +60,7 @@ gh project view <project-number> --owner <owner> --format json
 
 Extract:
 - The project's GraphQL node ID (from `view`, `.id`).
-- For each of Phase, Type, Size, AgentReady, BounceTo: the field ID and, for single-select fields, every option's ID.
+- For each of Status, Type, Size, AgentReady, BounceTo: the field ID and, for single-select fields, every option's ID. **The field named `Status` is cached under the key `"Phase"`** — the copy regenerates all field/option IDs, so never reuse IDs from the template or a prior release.
 - For ADR and AuthBudget: just the field ID (text fields, no options).
 
 ### 3. Write `.claude/release-state.json`
@@ -82,9 +95,12 @@ Schema (formatted, no trailing comma):
     "BounceTo":   { "id": "...", "options": { "Plan": "...", "Design": "...", "Define": "..." } },
     "ADR":        { "id": "...", "options": null },
     "AuthBudget": { "id": "...", "options": null }
-  }
+  },
+  "item_cache": {}
 }
 ```
+
+The `"Phase"` entry holds the field named `Status` on the board (see [Status-as-Phase](#release-init--release-bootstrap-skill) above) — the key name is the tooling vocabulary, not the UI name. `item_cache` starts empty; `/sketch` seeds it per filed issue and other skills append on lookup miss.
 
 Write atomically: temp file then rename. Set permissions to user-only (`chmod 600`) since this is operational state, not source.
 
@@ -100,7 +116,7 @@ For each issue in the comma-separated list:
 gh project item-add <project-number> --owner <owner> --url https://github.com/<owner>/aether/issues/<number>
 ```
 
-Then set `Phase=Backlog` on each (using the now-cached field/option IDs). Don't set Type/Size/AgentReady yet — those are `/scope`'s responsibility per-issue.
+No Phase write — the copied "item added" workflow sets Backlog server-side. Spot-check the first import landed in Backlog; if it didn't (the workflow toggle was skipped on the template), set the field explicitly and remind the user to fix the template's workflows. Don't set Type/Size/AgentReady — those are `/scope`'s responsibility per-issue. Record each returned item ID in `item_cache`.
 
 ### 6. Print summary
 
@@ -111,29 +127,31 @@ Then set `Phase=Backlog` on each (using the now-cached field/option IDs). Don't 
   Imported: <N> issue(s)
 
 Next:
-  1. Open the project URL above, switch board view → group by Phase.
-  2. Add more issues: gh project item-add <project-number> --owner <owner> --url <issue-url>
+  1. Open the project URL above; the board view groups by Status (the phase vocabulary).
+     Verify both workflows copied: item added → Backlog, item closed → Done.
+  2. Add more issues: /sketch (files + board-adds in one step)
   3. Scope an issue: /scope <issue-number>
 ```
 
 ## Failure modes
 
 - **`gh` lacks `project` scope**: abort with the refresh command.
+- **Template project missing**: the script exits with a pointer; run `/release-init --init-template`, do the two printed workflow toggles, then re-run.
 - **Bootstrap script fails partway**: leave whatever was created on the GH side, report the error, do not write `release-state.json`. The user can `gh project delete` and retry.
-- **`field-list` returns fewer fields than expected** (e.g. someone hand-deleted a field): abort and report the missing fields by name.
+- **`field-list` returns fewer fields than expected** (e.g. someone hand-deleted a field, or the Status options weren't replaced on the template): abort and report the missing fields/options by name.
 - **`.claude/release-state.json` already exists and `--force` not passed**: ask the user to confirm overwrite before proceeding.
 - **`--import` issue doesn't exist or is in a different repo**: skip with a warning comment; continue with the rest.
 
 ## What `/release-init` does NOT do
 
-- Configure the board view layout (group-by, sort, sub-grouping). That's a UI-only step today. The CLI prints instructions; the user does it once.
+- Configure the board view layout (group-by, sort, sub-grouping) or toggle workflows. Both are UI-only; both live on the template, configured once at `--init-template` time and carried into every copy.
 - Add Type/Size/AgentReady values to imported issues — `/scope` handles that.
 - Migrate items from an older release project. If you want to move issues from `aether 0.3` to `aether 0.4`, use `gh project item-archive` on the old + `--import` on the new.
-- Mark the project as a template. Possible future refinement: `/release-init --as-template` followed by `gh project copy` per release. Not yet.
+- Rename the Status field. GitHub doesn't allow it; the tooling vocabulary "Phase" lives in `release-state.json`'s cache key and everything downstream of it.
 - Delete or close old release projects. The user does that manually when they're done with a release.
 
 ## Notes on `release-state.json`
 
 - The file is the **active-release marker**. Only one exists at a time per repo. Switching releases means re-running `/release-init <newversion>` (after archiving the old).
-- The `field_cache` is invalidated if anyone hand-edits fields/options in the UI. If `/scope` or another skill ever fails with a "field ID not found" error, run `/release-init <version> --reuse <num>` to rebuild the cache against the same project.
+- The `field_cache` is invalidated if anyone hand-edits fields/options in the UI. If `/scope` or another skill ever fails with a "field ID not found" error, run `/release-init <version> --reuse <num>` to rebuild the cache against the same project. Rebuilding preserves `item_cache` (item IDs only die with the project itself).
 - The file is `chmod 600` because it carries operational state; not sensitive per se, but personal to the machine.

--- a/scripts/release-project-init.sh
+++ b/scripts/release-project-init.sh
@@ -1,69 +1,140 @@
 #!/usr/bin/env bash
-# release-project-init.sh — create a GitHub Project v2 for an aether release.
+# release-project-init.sh — bootstrap GitHub Projects for aether releases.
 #
-# Usage:
+# Two modes:
+#
+#   release-project-init.sh --init-template [--owner <owner>]
+#       One-time: create the release template project. Repurposes the
+#       built-in Status field to carry the phase vocabulary (built-in
+#       project workflows can only set Status, never a custom field)
+#       and creates the remaining custom fields. The two workflow
+#       toggles are UI-only (no API exists) — instructions printed.
+#
 #   release-project-init.sh <version> [--owner <owner>]
+#       Per release: copy the template into "aether <version>". The
+#       copy carries fields, views, and configured workflows (auto-add
+#       workflows are excluded by GitHub, and unused — /sketch adds
+#       items itself).
 #
-# Example:
-#   release-project-init.sh 0.4
-#   release-project-init.sh 0.4-sandbox --owner iamacoffeepot
-#
-# Idempotent? No. Creates a fresh project each call.
+# The phase vocabulary lives in the Status field's options; tooling
+# (release-state.json, the pipeline skills) keeps calling it "Phase" —
+# only the UI header reads "Status" (the built-in field cannot be
+# renamed or deleted).
 
 set -euo pipefail
 
-VERSION="${1:?usage: $0 <version> [--owner <owner>]}"
-shift || true
-
+TEMPLATE_TITLE="aether release template"
 OWNER="iamacoffeepot"
+VERSION=""
+INIT_TEMPLATE=0
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --init-template) INIT_TEMPLATE=1; shift;;
         --owner) OWNER="$2"; shift 2;;
-        *) echo "unknown arg: $1" >&2; exit 64;;
+        --*) echo "unknown arg: $1" >&2; exit 64;;
+        *) VERSION="$1"; shift;;
     esac
 done
 
-TITLE="aether ${VERSION}"
-
-echo "→ Creating project: ${TITLE} (owner: ${OWNER})"
-PROJECT_JSON=$(gh project create --owner "$OWNER" --title "$TITLE" --format json)
-PROJECT_URL=$(echo "$PROJECT_JSON" | jq -r '.url')
-PROJECT_NUMBER=$(echo "$PROJECT_JSON" | jq -r '.number')
-echo "  ${PROJECT_URL}"
+if [[ "$INIT_TEMPLATE" -eq 0 && -z "$VERSION" ]]; then
+    echo "usage: $0 <version> [--owner <owner>] | $0 --init-template [--owner <owner>]" >&2
+    exit 64
+fi
 
 create_select() {
-    local name="$1" options="$2"
+    local number="$1" name="$2" options="$3"
     echo "  + ${name} (single-select)"
-    gh project field-create "$PROJECT_NUMBER" --owner "$OWNER" \
+    gh project field-create "$number" --owner "$OWNER" \
         --name "$name" --data-type SINGLE_SELECT \
         --single-select-options "$options" >/dev/null
 }
 
 create_text() {
-    local name="$1"
+    local number="$1" name="$2"
     echo "  + ${name} (text)"
-    gh project field-create "$PROJECT_NUMBER" --owner "$OWNER" \
+    gh project field-create "$number" --owner "$OWNER" \
         --name "$name" --data-type TEXT >/dev/null
 }
 
-create_select "Phase"      "Backlog,Define,Design,Plan,Ready,Executing,Refine,Done,Bounced,Stalled"
-create_select "Type"       "feat,fix,chore,docs,refactor,ci,test"
-create_select "Size"       "S,M,L"
-create_select "AgentReady" "No,Yes"
-create_select "BounceTo"   "Plan,Design,Define"
-create_text   "ADR"
-create_text   "AuthBudget"
+if [[ "$INIT_TEMPLATE" -eq 1 ]]; then
+    echo "→ Creating template project: ${TEMPLATE_TITLE} (owner: ${OWNER})"
+    PROJECT_JSON=$(gh project create --owner "$OWNER" --title "$TEMPLATE_TITLE" --format json)
+    PROJECT_URL=$(echo "$PROJECT_JSON" | jq -r '.url')
+    PROJECT_NUMBER=$(echo "$PROJECT_JSON" | jq -r '.number')
+    echo "  ${PROJECT_URL}"
+
+    echo "  ~ Status (repurposing options to the phase vocabulary)"
+    STATUS_FIELD_ID=$(gh project field-list "$PROJECT_NUMBER" --owner "$OWNER" --format json \
+        | jq -r '.fields[] | select(.name == "Status") | .id')
+    gh api graphql -f query='
+        mutation($fieldId: ID!) {
+          updateProjectV2Field(input: {
+            fieldId: $fieldId,
+            singleSelectOptions: [
+              {name: "Backlog",   color: GRAY,   description: "resting/default state"},
+              {name: "Define",    color: BLUE,   description: "problem statement in progress"},
+              {name: "Design",    color: BLUE,   description: "design rationale in progress"},
+              {name: "Plan",      color: BLUE,   description: "impl plan written, awaiting /approve"},
+              {name: "Ready",     color: GREEN,  description: "approved, AgentReady"},
+              {name: "Executing", color: YELLOW, description: "PR in flight"},
+              {name: "Refine",    color: ORANGE, description: "CI loop / draft PR resting state"},
+              {name: "Done",      color: PURPLE, description: "merged and closed"},
+              {name: "Bounced",   color: RED,    description: "regressed; see BounceTo"},
+              {name: "Stalled",   color: PINK,   description: "env/tooling halt"}
+            ]
+          }) { projectV2Field { ... on ProjectV2SingleSelectField { id } } }
+        }' -f fieldId="$STATUS_FIELD_ID" >/dev/null
+
+    create_select "$PROJECT_NUMBER" "Type"       "feat,fix,chore,docs,refactor,ci,test"
+    create_select "$PROJECT_NUMBER" "Size"       "S,M,L"
+    create_select "$PROJECT_NUMBER" "AgentReady" "No,Yes"
+    create_select "$PROJECT_NUMBER" "BounceTo"   "Plan,Design,Define"
+    create_text   "$PROJECT_NUMBER" "ADR"
+    create_text   "$PROJECT_NUMBER" "AuthBudget"
+
+    cat <<EOF
+
+✓ Template project ${PROJECT_NUMBER} created.
+
+One-time manual steps (the workflow API is read/delete-only):
+  1. Open ${PROJECT_URL}/settings/workflows
+  2. "Item added to project" → enable, set Status: Backlog
+  3. "Item closed"           → enable, set Status: Done
+     (also disable "Pull request merged" if enabled — PRs aren't board items)
+  4. Board view → group by Status
+
+These workflows are carried into every copy made from this template.
+EOF
+    exit 0
+fi
+
+TITLE="aether ${VERSION}"
+echo "→ Looking up template: ${TEMPLATE_TITLE} (owner: ${OWNER})"
+TEMPLATE_NUMBER=$(gh project list --owner "$OWNER" --format json --limit 100 \
+    | jq -r --arg t "$TEMPLATE_TITLE" '.projects[] | select(.title == $t) | .number' | head -1)
+if [[ -z "$TEMPLATE_NUMBER" ]]; then
+    echo "No project titled '${TEMPLATE_TITLE}' found. Run: $0 --init-template" >&2
+    exit 1
+fi
+
+echo "→ Copying template ${TEMPLATE_NUMBER} → ${TITLE}"
+PROJECT_JSON=$(gh project copy "$TEMPLATE_NUMBER" \
+    --source-owner "$OWNER" --target-owner "$OWNER" --title "$TITLE" --format json)
+PROJECT_URL=$(echo "$PROJECT_JSON" | jq -r '.url')
+PROJECT_NUMBER=$(echo "$PROJECT_JSON" | jq -r '.number')
 
 cat <<EOF
 
-✓ Project ${PROJECT_NUMBER} created.
+✓ Project ${PROJECT_NUMBER} created from template.
+  ${PROJECT_URL}
 
-Next steps (manual, in the UI):
-  1. Open ${PROJECT_URL}
-  2. Board view → group by Phase (not the default Status)
-  3. Optionally hide the default Status field
+Verify (one minute, in the UI):
+  ${PROJECT_URL}/settings/workflows — both workflows should have copied:
+    "Item added to project" → Status: Backlog
+    "Item closed"           → Status: Done
 
 Programmatic next:
-  gh project item-add ${PROJECT_NUMBER} --owner ${OWNER} --url <issue-url>
-  gh project field-list ${PROJECT_NUMBER} --owner ${OWNER} --format json  # for field/option IDs
+  gh project field-list ${PROJECT_NUMBER} --owner ${OWNER} --format json  # field/option IDs
+  (cache the field named "Status" under the key "Phase" in release-state.json)
 EOF


### PR DESCRIPTION
Closes #1577.

## Summary

- **Status-as-Phase**: the lifecycle vocabulary moves into the built-in `Status` field's options, because GitHub's built-in project workflows can only set Status — never a custom single-select (verified against the live GraphQL schema and docs). `release-state.json` caches the Status field under its existing `"Phase"` key, so /scope, /approve, /bounce, /implement are untouched. The UI header reading "Status" is the accepted cosmetic cost; the field can't be renamed or deleted.
- **Template flow**: `scripts/release-project-init.sh --init-template` creates the one-time template project — replaces Status's options with the phase vocabulary via one `updateProjectV2Field` mutation, creates Type/Size/AgentReady/BounceTo/ADR/AuthBudget, and prints the two UI-only workflow toggles (the workflow API is read/delete-only). The default mode now copies the template by title into `aether <version>`, carrying fields, views, and both workflows ("item added → Backlog", "item closed → Done"). Auto-add workflows are excluded from copies by GitHub and unused — /sketch board-adds at filing.
- `/release-init` SKILL.md reworked to match: step 0 template bootstrap, copy-based step 1, `--import` drops its per-item Phase write (the added→Backlog workflow does it server-side), `item_cache: {}` in the written state, new failure modes.
- Net effect at the next release cut: Backlog placement on add and Done on close cost zero skill-side API calls. The live 0.4 board keeps its custom Phase field and is untouched by this PR.

## Test plan

Skill + script change (repo-config preflight class). `bash -n` on the script; `updateProjectV2Field.singleSelectOptions` and the copy/template workflow-carrying behavior verified against the live schema introspection and GitHub docs (2026-06-10). The script's template mode gets a real run at the next release cut.

## Generated by

Agent execution of #1577 (design settled in chat 2026-06-10).