### PR TITLE
docs(actor): fix stale api references in rustdoc and examples

### DIFF
--- a/crates/aether-actor/examples/input_logger.rs
+++ b/crates/aether-actor/examples/input_logger.rs
@@ -13,8 +13,9 @@
 //!
 //! Each input kind has its own `#[handler]` method. Issue 640 retired
 //! the cap-side manifest auto-subscribe walker (and the macro-side
-//! walker retired earlier in #403); components subscribe explicitly
-//! via `ctx.subscribe_input::<K>()` in `init`.
+//! walker retired earlier in #403); components subscribe from the
+//! `wire` hook by sending a `SubscribeInput { kind, mailbox }` to the
+//! `InputCapability`.
 
 // Stateless logger: each `#[handler]` keeps `&mut self` for the
 // ADR-0033 / ADR-0038 dispatch ABI but doesn't need any field access.

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -521,10 +521,11 @@ pub mod guest_alloc {
 /// - `#[link_section = "aether.namespace"]` static that pins the
 ///   actor's `Actor::NAMESPACE` bytes (issue 525 Phase 1B).
 ///
-/// Only one actor per guest crate. A second [`crate::export!`] call in
-/// the same crate is a duplicate-symbol compile error on the shared
-/// `init` / `receive` names — ADR-0014 §4 parks multi-actor crates as
-/// out of scope.
+/// A single-type `export!(C)` binds the shared `init` / `receive`
+/// exports to one actor. ADR-0096 multi-actor modules pass two or more
+/// types — `export!(First, Second, …)` — which routes through
+/// `__export_multi_internal!`; the arity is what keeps the multi-actor
+/// arm from shadowing this single-actor form.
 ///
 /// ```ignore
 /// pub struct Hello { /* fields */ }

--- a/crates/aether-actor/src/mail/mod.rs
+++ b/crates/aether-actor/src/mail/mod.rs
@@ -70,7 +70,9 @@ impl ReplyHandle {
     }
 }
 
-/// Inbound mail, as received by `Component::receive`. Wraps the raw
+/// Inbound mail, as received by the `#[actor]`-synthesized
+/// `__aether_dispatch` (driven by the guest's `receive` FFI export).
+/// Wraps the raw
 /// `(kind, ptr, count, sender)` FFI parameters with typed decode helpers.
 ///
 /// The lifetime `'a` ties the returned references back to the receive


### PR DESCRIPTION
Closes iamacoffeepot/aether#1555.

## Summary

Three rustdoc/example references named retired or contradicted APIs — the stale-name inconsistencies a keyword-scanning reader trips on:

- `export!` doc (`ffi/mod.rs`) claimed single-actor-only, contradicting the multi-actor arm (ADR-0096) ~20 lines below — now describes both the single-type and multi-actor arms.
- `Mail` doc (`mail/mod.rs`) cited the retired `Component::receive` — now points at the `#[actor]`-synthesized `__aether_dispatch` (driven by the `receive` FFI export).
- `input_logger` example comment referenced the nonexistent `ctx.subscribe_input::<K>()` — now describes the real `SubscribeInput`-to-`InputCapability` send from the `wire` hook.

Comment-only edits; no code change.

## Test plan

Comment-only `.rs` edits, but the docs-only preflight skip does not apply (these are `.rs` files) — full `scripts/preflight.sh` ran green. The §Side finding about the `byte_len` FFI-tuple doc was left out of scope.

## Generated by

Agent execution of scoped issue #1555.
