### PR TITLE
flake(capabilities): triage tcp/server drive-helper tests for mod heavy

### DIFF
--- a/crates/aether-capabilities/src/engine/server.rs
+++ b/crates/aether-capabilities/src/engine/server.rs
@@ -670,94 +670,6 @@ mod tests {
         }
     }
 
-    /// `on_list` on a fresh cap replies with an empty engine list.
-    #[test]
-    fn list_on_empty_cap_is_empty() {
-        let (_chassis, mailer, cells) = boot();
-        let result = drive(&mailer, &ListEngines {}, || {
-            cells
-                .list
-                .lock()
-                .expect("test setup: list cell mutex poisoned")
-                .take()
-        });
-        assert!(result.engines.is_empty(), "fresh cap supervises no engines");
-    }
-
-    /// `on_spawn` with a binary path that doesn't exist fails fast at
-    /// the fork — no proxy is spawned, no retry window is entered.
-    #[test]
-    fn spawn_with_missing_binary_replies_err() {
-        let (_chassis, mailer, cells) = boot();
-        let result = drive(
-            &mailer,
-            &SpawnEngine {
-                binary_path: "/nonexistent/aether-substrate-does-not-exist".to_owned(),
-                args: vec![],
-            },
-            || {
-                cells
-                    .spawn
-                    .lock()
-                    .expect("test setup: spawn cell mutex poisoned")
-                    .take()
-            },
-        );
-        match result {
-            SpawnEngineResult::Err { error } => {
-                assert!(
-                    error.contains("failed to spawn"),
-                    "unexpected error: {error}"
-                );
-            }
-            SpawnEngineResult::Ok { .. } => panic!("a missing binary must not spawn"),
-        }
-    }
-
-    /// `on_terminate` with an `engine_id` that isn't a UUID, and one
-    /// that is well-formed but names no supervised engine, both reply
-    /// `Err` rather than panicking.
-    #[test]
-    fn terminate_unknown_engine_replies_err() {
-        let (_chassis, mailer, cells) = boot();
-
-        let malformed = drive(
-            &mailer,
-            &TerminateEngine {
-                engine_id: "not-a-uuid".to_owned(),
-            },
-            || {
-                cells
-                    .terminate
-                    .lock()
-                    .expect("test setup: terminate cell mutex poisoned")
-                    .take()
-            },
-        );
-        assert!(
-            matches!(malformed, TerminateEngineResult::Err { .. }),
-            "a malformed engine_id should be rejected",
-        );
-
-        let unknown = drive(
-            &mailer,
-            &TerminateEngine {
-                engine_id: "00000000-0000-0000-0000-000000000000".to_owned(),
-            },
-            || {
-                cells
-                    .terminate
-                    .lock()
-                    .expect("test setup: terminate cell mutex poisoned")
-                    .take()
-            },
-        );
-        assert!(
-            matches!(unknown, TerminateEngineResult::Err { .. }),
-            "a well-formed but unknown engine_id should be rejected",
-        );
-    }
-
     /// Push a fire-and-forget kind at the cap, then drive a `ListEngines`
     /// so the assertion runs only after the cap has processed the
     /// earlier mail (single-threaded actor, in-order mailbox). Returns
@@ -779,55 +691,151 @@ mod tests {
         .engines
     }
 
-    /// `on_engine_died` for an engine the cap never supervised — the
-    /// terminate-race / double-report case — is an idempotent no-op,
-    /// not a panic, and inserts nothing. Covers both a malformed and a
-    /// well-formed-but-unknown `engine_id` (issue 1339).
-    #[test]
-    fn engine_died_for_unknown_is_noop() {
-        let (_chassis, mailer, cells) = boot();
+    /// Contention-sensitive driver tests: each boots a `PassiveChassis`
+    /// whose dispatcher thread must make timely cross-thread progress for
+    /// the poll-until deadline to pass, so they serialize under
+    /// `serial-heavy` (the `::heavy::` path is the marker).
+    mod heavy {
+        use super::*;
 
-        let after_malformed = push_then_list(
-            &mailer,
-            &cells,
-            &EngineDied {
-                engine_id: "not-a-uuid".to_owned(),
-            },
-        );
-        assert!(
-            after_malformed.is_empty(),
-            "a malformed died must not panic or insert",
-        );
+        /// `on_list` on a fresh cap replies with an empty engine list.
+        #[test]
+        fn list_on_empty_cap_is_empty() {
+            let (_chassis, mailer, cells) = boot();
+            let result = drive(&mailer, &ListEngines {}, || {
+                cells
+                    .list
+                    .lock()
+                    .expect("test setup: list cell mutex poisoned")
+                    .take()
+            });
+            assert!(result.engines.is_empty(), "fresh cap supervises no engines");
+        }
 
-        let after_unknown = push_then_list(
-            &mailer,
-            &cells,
-            &EngineDied {
-                engine_id: "00000000-0000-0000-0000-000000000000".to_owned(),
-            },
-        );
-        assert!(
-            after_unknown.is_empty(),
-            "a died for an unknown engine is a no-op",
-        );
-    }
+        /// `on_spawn` with a binary path that doesn't exist fails fast at
+        /// the fork — no proxy is spawned, no retry window is entered.
+        #[test]
+        fn spawn_with_missing_binary_replies_err() {
+            let (_chassis, mailer, cells) = boot();
+            let result = drive(
+                &mailer,
+                &SpawnEngine {
+                    binary_path: "/nonexistent/aether-substrate-does-not-exist".to_owned(),
+                    args: vec![],
+                },
+                || {
+                    cells
+                        .spawn
+                        .lock()
+                        .expect("test setup: spawn cell mutex poisoned")
+                        .take()
+                },
+            );
+            match result {
+                SpawnEngineResult::Err { error } => {
+                    assert!(
+                        error.contains("failed to spawn"),
+                        "unexpected error: {error}"
+                    );
+                }
+                SpawnEngineResult::Ok { .. } => panic!("a missing binary must not spawn"),
+            }
+        }
 
-    /// `on_engine_alive` for an unknown engine is a silent no-op (no
-    /// panic, no spurious insert) — a stale `alive` racing an eviction
-    /// must not resurrect the engine (issue 1339).
-    #[test]
-    fn engine_alive_for_unknown_is_noop() {
-        let (_chassis, mailer, cells) = boot();
-        let after = push_then_list(
-            &mailer,
-            &cells,
-            &EngineAlive {
-                engine_id: "00000000-0000-0000-0000-000000000000".to_owned(),
-            },
-        );
-        assert!(
-            after.is_empty(),
-            "an alive for an unknown engine must not insert it",
-        );
+        /// `on_terminate` with an `engine_id` that isn't a UUID, and one
+        /// that is well-formed but names no supervised engine, both reply
+        /// `Err` rather than panicking.
+        #[test]
+        fn terminate_unknown_engine_replies_err() {
+            let (_chassis, mailer, cells) = boot();
+
+            let malformed = drive(
+                &mailer,
+                &TerminateEngine {
+                    engine_id: "not-a-uuid".to_owned(),
+                },
+                || {
+                    cells
+                        .terminate
+                        .lock()
+                        .expect("test setup: terminate cell mutex poisoned")
+                        .take()
+                },
+            );
+            assert!(
+                matches!(malformed, TerminateEngineResult::Err { .. }),
+                "a malformed engine_id should be rejected",
+            );
+
+            let unknown = drive(
+                &mailer,
+                &TerminateEngine {
+                    engine_id: "00000000-0000-0000-0000-000000000000".to_owned(),
+                },
+                || {
+                    cells
+                        .terminate
+                        .lock()
+                        .expect("test setup: terminate cell mutex poisoned")
+                        .take()
+                },
+            );
+            assert!(
+                matches!(unknown, TerminateEngineResult::Err { .. }),
+                "a well-formed but unknown engine_id should be rejected",
+            );
+        }
+
+        /// `on_engine_died` for an engine the cap never supervised — the
+        /// terminate-race / double-report case — is an idempotent no-op,
+        /// not a panic, and inserts nothing. Covers both a malformed and a
+        /// well-formed-but-unknown `engine_id` (issue 1339).
+        #[test]
+        fn engine_died_for_unknown_is_noop() {
+            let (_chassis, mailer, cells) = boot();
+
+            let after_malformed = push_then_list(
+                &mailer,
+                &cells,
+                &EngineDied {
+                    engine_id: "not-a-uuid".to_owned(),
+                },
+            );
+            assert!(
+                after_malformed.is_empty(),
+                "a malformed died must not panic or insert",
+            );
+
+            let after_unknown = push_then_list(
+                &mailer,
+                &cells,
+                &EngineDied {
+                    engine_id: "00000000-0000-0000-0000-000000000000".to_owned(),
+                },
+            );
+            assert!(
+                after_unknown.is_empty(),
+                "a died for an unknown engine is a no-op",
+            );
+        }
+
+        /// `on_engine_alive` for an unknown engine is a silent no-op (no
+        /// panic, no spurious insert) — a stale `alive` racing an eviction
+        /// must not resurrect the engine (issue 1339).
+        #[test]
+        fn engine_alive_for_unknown_is_noop() {
+            let (_chassis, mailer, cells) = boot();
+            let after = push_then_list(
+                &mailer,
+                &cells,
+                &EngineAlive {
+                    engine_id: "00000000-0000-0000-0000-000000000000".to_owned(),
+                },
+            );
+            assert!(
+                after.is_empty(),
+                "an alive for an unknown engine must not insert it",
+            );
+        }
     }
 }

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -695,184 +695,194 @@ mod cap_native {
             postcard::from_bytes(&payload).expect("decode reply")
         }
 
-        /// Issue 607 Phase 6a: bind → list → unbind round-trip on a
-        /// loopback port. Asserts the cap-local supervisor map
-        /// reflects every step (bound, listed, unbound).
-        #[test]
-        fn bind_then_list_then_unbind_roundtrip() {
-            let (registry, rx, _chassis) = boot_tcp_substrate();
+        /// Contention-sensitive driver tests: each boots a
+        /// `PassiveChassis` whose dispatcher thread must make timely
+        /// cross-thread progress for the poll-until deadline to pass, so
+        /// they serialize under `serial-heavy` (the `::heavy::` path is
+        /// the marker).
+        mod heavy {
+            use super::*;
 
-            // Bind to port 0 — let the OS pick a free port.
-            let bind_reply: BindListenerResult = drive_and_decode(
-                &registry,
-                &rx,
-                TcpCapability::NAMESPACE,
-                &BindListener {
-                    addr: "127.0.0.1:0".into(),
-                    name: None,
-                },
-            );
-            let (listener_name, local_port) = match bind_reply {
-                BindListenerResult::Ok {
+            /// Issue 607 Phase 6a: bind → list → unbind round-trip on a
+            /// loopback port. Asserts the cap-local supervisor map
+            /// reflects every step (bound, listed, unbound).
+            #[test]
+            fn bind_then_list_then_unbind_roundtrip() {
+                let (registry, rx, _chassis) = boot_tcp_substrate();
+
+                // Bind to port 0 — let the OS pick a free port.
+                let bind_reply: BindListenerResult = drive_and_decode(
+                    &registry,
+                    &rx,
+                    TcpCapability::NAMESPACE,
+                    &BindListener {
+                        addr: "127.0.0.1:0".into(),
+                        name: None,
+                    },
+                );
+                let (listener_name, local_port) = match bind_reply {
+                    BindListenerResult::Ok {
+                        listener_name,
+                        local_port,
+                        ..
+                    } => (listener_name, local_port),
+                    BindListenerResult::Err { reason, .. } => panic!("bind failed: {reason}"),
+                };
+                assert_eq!(
                     listener_name,
-                    local_port,
-                    ..
-                } => (listener_name, local_port),
-                BindListenerResult::Err { reason, .. } => panic!("bind failed: {reason}"),
-            };
-            assert_eq!(
-                listener_name,
-                local_port.to_string(),
-                "default subname should be the bound port",
-            );
-            assert!(local_port > 0, "OS-picked port should be non-zero");
+                    local_port.to_string(),
+                    "default subname should be the bound port",
+                );
+                assert!(local_port > 0, "OS-picked port should be non-zero");
 
-            // List enumerates the one listener.
-            let list_reply: ListListenersResult = drive_and_decode(
-                &registry,
-                &rx,
-                TcpCapability::NAMESPACE,
-                &ListListeners::default(),
-            );
-            assert_eq!(list_reply.listeners.len(), 1, "exactly one listener");
-            let entry = &list_reply.listeners[0];
-            assert_eq!(entry.name, listener_name);
-            assert_eq!(entry.port, local_port);
-            assert_eq!(entry.addr, "127.0.0.1:0");
+                // List enumerates the one listener.
+                let list_reply: ListListenersResult = drive_and_decode(
+                    &registry,
+                    &rx,
+                    TcpCapability::NAMESPACE,
+                    &ListListeners::default(),
+                );
+                assert_eq!(list_reply.listeners.len(), 1, "exactly one listener");
+                let entry = &list_reply.listeners[0];
+                assert_eq!(entry.name, listener_name);
+                assert_eq!(entry.port, local_port);
+                assert_eq!(entry.addr, "127.0.0.1:0");
 
-            // Unbind — asynchronous reply via MonitorNotice.
-            let unbind_reply: UnbindListenerResult = drive_and_decode(
-                &registry,
-                &rx,
-                TcpCapability::NAMESPACE,
-                &UnbindListener {
-                    listener_name: listener_name.clone(),
-                },
-            );
-            match unbind_reply {
-                UnbindListenerResult::Ok { listener_name: ln } => assert_eq!(ln, listener_name),
-                UnbindListenerResult::Err { reason, .. } => panic!("unbind failed: {reason}"),
+                // Unbind — asynchronous reply via MonitorNotice.
+                let unbind_reply: UnbindListenerResult = drive_and_decode(
+                    &registry,
+                    &rx,
+                    TcpCapability::NAMESPACE,
+                    &UnbindListener {
+                        listener_name: listener_name.clone(),
+                    },
+                );
+                match unbind_reply {
+                    UnbindListenerResult::Ok { listener_name: ln } => assert_eq!(ln, listener_name),
+                    UnbindListenerResult::Err { reason, .. } => panic!("unbind failed: {reason}"),
+                }
+
+                // List should now be empty — cap-local supervisor map
+                // dropped the entry on MonitorNotice.
+                let list_reply: ListListenersResult = drive_and_decode(
+                    &registry,
+                    &rx,
+                    TcpCapability::NAMESPACE,
+                    &ListListeners::default(),
+                );
+                assert!(
+                    list_reply.listeners.is_empty(),
+                    "list should drop the unbound listener",
+                );
             }
 
-            // List should now be empty — cap-local supervisor map
-            // dropped the entry on MonitorNotice.
-            let list_reply: ListListenersResult = drive_and_decode(
-                &registry,
-                &rx,
-                TcpCapability::NAMESPACE,
-                &ListListeners::default(),
-            );
-            assert!(
-                list_reply.listeners.is_empty(),
-                "list should drop the unbound listener",
-            );
-        }
+            /// Binding the same port twice fails the second bind. Uses
+            /// the first bind's actually-bound port to drive the second.
+            #[test]
+            fn bind_port_in_use_returns_err() {
+                let (registry, rx, _chassis) = boot_tcp_substrate();
 
-        /// Binding the same port twice fails the second bind. Uses
-        /// the first bind's actually-bound port to drive the second.
-        #[test]
-        fn bind_port_in_use_returns_err() {
-            let (registry, rx, _chassis) = boot_tcp_substrate();
+                let first: BindListenerResult = drive_and_decode(
+                    &registry,
+                    &rx,
+                    TcpCapability::NAMESPACE,
+                    &BindListener {
+                        addr: "127.0.0.1:0".into(),
+                        name: Some("first".into()),
+                    },
+                );
+                let local_port = match first {
+                    BindListenerResult::Ok { local_port, .. } => local_port,
+                    BindListenerResult::Err { reason, .. } => panic!("first bind failed: {reason}"),
+                };
 
-            let first: BindListenerResult = drive_and_decode(
-                &registry,
-                &rx,
-                TcpCapability::NAMESPACE,
-                &BindListener {
-                    addr: "127.0.0.1:0".into(),
-                    name: Some("first".into()),
-                },
-            );
-            let local_port = match first {
-                BindListenerResult::Ok { local_port, .. } => local_port,
-                BindListenerResult::Err { reason, .. } => panic!("first bind failed: {reason}"),
-            };
-
-            // Second bind on the same port — must fail.
-            let second: BindListenerResult = drive_and_decode(
-                &registry,
-                &rx,
-                TcpCapability::NAMESPACE,
-                &BindListener {
-                    addr: format!("127.0.0.1:{local_port}"),
-                    name: Some("second".into()),
-                },
-            );
-            match second {
-                BindListenerResult::Ok { .. } => panic!("expected port-in-use Err"),
-                BindListenerResult::Err { reason, addr } => {
-                    assert_eq!(addr, format!("127.0.0.1:{local_port}"));
-                    assert!(
-                        reason.starts_with("bind failed:"),
-                        "expected bind-fail reason, got: {reason}",
-                    );
+                // Second bind on the same port — must fail.
+                let second: BindListenerResult = drive_and_decode(
+                    &registry,
+                    &rx,
+                    TcpCapability::NAMESPACE,
+                    &BindListener {
+                        addr: format!("127.0.0.1:{local_port}"),
+                        name: Some("second".into()),
+                    },
+                );
+                match second {
+                    BindListenerResult::Ok { .. } => panic!("expected port-in-use Err"),
+                    BindListenerResult::Err { reason, addr } => {
+                        assert_eq!(addr, format!("127.0.0.1:{local_port}"));
+                        assert!(
+                            reason.starts_with("bind failed:"),
+                            "expected bind-fail reason, got: {reason}",
+                        );
+                    }
                 }
             }
-        }
 
-        /// Unbind on an unknown name surfaces an Err with the name
-        /// echoed back.
-        #[test]
-        fn unbind_unknown_listener_errors() {
-            let (registry, rx, _chassis) = boot_tcp_substrate();
+            /// Unbind on an unknown name surfaces an Err with the name
+            /// echoed back.
+            #[test]
+            fn unbind_unknown_listener_errors() {
+                let (registry, rx, _chassis) = boot_tcp_substrate();
 
-            let reply: UnbindListenerResult = drive_and_decode(
-                &registry,
-                &rx,
-                TcpCapability::NAMESPACE,
-                &UnbindListener {
-                    listener_name: "nope".into(),
-                },
-            );
-            match reply {
-                UnbindListenerResult::Err { listener_name, .. } => {
-                    assert_eq!(listener_name, "nope");
+                let reply: UnbindListenerResult = drive_and_decode(
+                    &registry,
+                    &rx,
+                    TcpCapability::NAMESPACE,
+                    &UnbindListener {
+                        listener_name: "nope".into(),
+                    },
+                );
+                match reply {
+                    UnbindListenerResult::Err { listener_name, .. } => {
+                        assert_eq!(listener_name, "nope");
+                    }
+                    UnbindListenerResult::Ok { .. } => panic!("expected Err for unknown listener"),
                 }
-                UnbindListenerResult::Ok { .. } => panic!("expected Err for unknown listener"),
             }
-        }
 
-        // Pre-#775 the session round-trip test asserted that
-        // SessionData / SessionClosed broadcasts arrived at the egress
-        // after a real TCP client wrote then dropped. Issue 775 retired
-        // the BroadcastCapability + observation fan-out, so the
-        // session actor no longer publishes those kinds — the test was
-        // deleted with the broadcasts.
+            // Pre-#775 the session round-trip test asserted that
+            // SessionData / SessionClosed broadcasts arrived at the egress
+            // after a real TCP client wrote then dropped. Issue 775 retired
+            // the BroadcastCapability + observation fan-out, so the
+            // session actor no longer publishes those kinds — the test was
+            // deleted with the broadcasts.
 
-        /// Two concurrent binds on different ports both surface in
-        /// `ListListeners`.
-        #[test]
-        fn list_enumerates_two_concurrent_listeners() {
-            let (registry, rx, _chassis) = boot_tcp_substrate();
+            /// Two concurrent binds on different ports both surface in
+            /// `ListListeners`.
+            #[test]
+            fn list_enumerates_two_concurrent_listeners() {
+                let (registry, rx, _chassis) = boot_tcp_substrate();
 
-            let _: BindListenerResult = drive_and_decode(
-                &registry,
-                &rx,
-                TcpCapability::NAMESPACE,
-                &BindListener {
-                    addr: "127.0.0.1:0".into(),
-                    name: Some("admin".into()),
-                },
-            );
-            let _: BindListenerResult = drive_and_decode(
-                &registry,
-                &rx,
-                TcpCapability::NAMESPACE,
-                &BindListener {
-                    addr: "127.0.0.1:0".into(),
-                    name: Some("game".into()),
-                },
-            );
+                let _: BindListenerResult = drive_and_decode(
+                    &registry,
+                    &rx,
+                    TcpCapability::NAMESPACE,
+                    &BindListener {
+                        addr: "127.0.0.1:0".into(),
+                        name: Some("admin".into()),
+                    },
+                );
+                let _: BindListenerResult = drive_and_decode(
+                    &registry,
+                    &rx,
+                    TcpCapability::NAMESPACE,
+                    &BindListener {
+                        addr: "127.0.0.1:0".into(),
+                        name: Some("game".into()),
+                    },
+                );
 
-            let list: ListListenersResult = drive_and_decode(
-                &registry,
-                &rx,
-                TcpCapability::NAMESPACE,
-                &ListListeners::default(),
-            );
-            let mut names: Vec<String> = list.listeners.iter().map(|l| l.name.clone()).collect();
-            names.sort();
-            assert_eq!(names, vec!["admin".to_string(), "game".to_string()]);
+                let list: ListListenersResult = drive_and_decode(
+                    &registry,
+                    &rx,
+                    TcpCapability::NAMESPACE,
+                    &ListListeners::default(),
+                );
+                let mut names: Vec<String> =
+                    list.listeners.iter().map(|l| l.name.clone()).collect();
+                names.sort();
+                assert_eq!(names, vec!["admin".to_string(), "game".to_string()]);
+            }
         }
     }
 }


### PR DESCRIPTION
Closes iamacoffeepot/aether#1557.

## Summary

Closes the #1522 heavy-marker triage. Nine driver-helper tests boot a `PassiveChassis` whose dispatcher thread must make timely cross-thread progress for a deadline assert to pass — the same structural shape #1522 moved for `handle.rs` — yet none serialized under `serial-heavy`, so a saturated `--workspace` run can starve them past their deadlines.

Moves all nine into a `mod heavy` submodule: the four `tcp/mod.rs` driver tests and the five `engine/server.rs` driver tests. Helpers stay in the parent test module (the interleaved `push_then_list` helper was relocated above `mod heavy` so it stays in the parent).

## Test plan

- Full `scripts/preflight.sh` green (51 tests pass).
- `cargo nextest show-config test-groups --profile ci` lists all nine under `serial-heavy` (`max threads = 1`) — they resolve under `engine::server::tests::heavy::*` and `tcp::cap_native::tests::heavy::*`, both matching the `::heavy::` selector.

## Generated by

Agent execution of scoped issue #1557.
