### PR TITLE
chore(capabilities): spell out _ms in gemini/anthropic default-timeout constants

### DIFF
--- a/crates/aether-capabilities/src/anthropic/cli.rs
+++ b/crates/aether-capabilities/src/anthropic/cli.rs
@@ -14,7 +14,7 @@ use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use super::DEFAULT_TIMEOUT_MS;
+use super::DEFAULT_TIMEOUT_MILLIS;
 use crate::contentgen::adapter::{AdapterUsage, AnthropicRequest, AnthropicResponse};
 
 /// Sentinel returned when the `claude` binary isn't on PATH so the cap
@@ -45,7 +45,7 @@ impl Default for ClaudeCliAdapter {
     fn default() -> Self {
         Self {
             binary: String::from("claude"),
-            timeout: Duration::from_millis(u64::from(DEFAULT_TIMEOUT_MS)),
+            timeout: Duration::from_millis(u64::from(DEFAULT_TIMEOUT_MILLIS)),
         }
     }
 }

--- a/crates/aether-capabilities/src/anthropic/mod.rs
+++ b/crates/aether-capabilities/src/anthropic/mod.rs
@@ -44,7 +44,7 @@ pub const DEFAULT_MAX_IN_FLIGHT: usize = DEFAULT_PROVIDER_MAX_IN_FLIGHT;
 
 /// Default per-request timeout when `AETHER_ANTHROPIC_TIMEOUT_MS` is
 /// unset. A long completion can run tens of seconds.
-pub const DEFAULT_TIMEOUT_MS: u32 = 120_000;
+pub const DEFAULT_TIMEOUT_MILLIS: u32 = 120_000;
 
 /// Models the Messages-API backend accepts. The cap validates a
 /// request's `model` against this before any dispatch; the CLI backend
@@ -70,7 +70,7 @@ pub struct DisabledAnthropicAdapter {
 impl DisabledAnthropicAdapter {
     /// Build the disabled adapter with the CLI backend wired to the
     /// cap's per-request `timeout`. The default impl uses
-    /// `DEFAULT_TIMEOUT_MS`; production threads `config.timeout`.
+    /// `DEFAULT_TIMEOUT_MILLIS`; production threads `config.timeout`.
     #[must_use]
     pub fn new(timeout: Duration) -> Self {
         Self {
@@ -128,7 +128,7 @@ impl AnthropicAdapter for CombinedAnthropicAdapter {
 }
 
 mod config {
-    use super::{DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MS};
+    use super::{DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MILLIS};
     // confique consumes these through `#[config(parse_env = …)]`; IntelliJ-Rust
     // doesn't trace macro-attr path args (Qodana FP), but rustc + clippy do.
     #[allow(unused_imports)]
@@ -187,7 +187,7 @@ mod config {
             feature = "native",
             config(
                 default = 120_000,
-                parse = parse_millis_strict::<DEFAULT_TIMEOUT_MS>,
+                parse = parse_millis_strict::<DEFAULT_TIMEOUT_MILLIS>,
                 ms_duration,
                 layer_field = "timeout_ms"
             )
@@ -201,7 +201,7 @@ mod config {
                 api_key: None,
                 disabled: false,
                 max_in_flight: DEFAULT_MAX_IN_FLIGHT,
-                timeout: Duration::from_millis(u64::from(DEFAULT_TIMEOUT_MS)),
+                timeout: Duration::from_millis(u64::from(DEFAULT_TIMEOUT_MILLIS)),
             }
         }
     }
@@ -209,7 +209,7 @@ mod config {
     #[cfg(all(test, feature = "native"))]
     mod tests {
         use super::{
-            AnthropicConfig, AnthropicConfigLayer, DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MS,
+            AnthropicConfig, AnthropicConfigLayer, DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MILLIS,
         };
         use confique::Config as _;
         use std::time::Duration;
@@ -228,7 +228,7 @@ mod config {
             assert_eq!(layer.api_key, None);
             assert!(!layer.disabled);
             assert_eq!(layer.max_in_flight, DEFAULT_MAX_IN_FLIGHT);
-            assert_eq!(layer.timeout_ms, DEFAULT_TIMEOUT_MS);
+            assert_eq!(layer.timeout_ms, DEFAULT_TIMEOUT_MILLIS);
             assert_eq!(
                 Duration::from_millis(u64::from(layer.timeout_ms)),
                 default.timeout

--- a/crates/aether-capabilities/src/gemini/mod.rs
+++ b/crates/aether-capabilities/src/gemini/mod.rs
@@ -42,7 +42,7 @@ pub const DEFAULT_MAX_IN_FLIGHT: usize = DEFAULT_PROVIDER_MAX_IN_FLIGHT;
 
 /// Default per-request timeout when `AETHER_GEMINI_TIMEOUT_MS` is unset.
 /// Media generation can run a couple minutes.
-pub const DEFAULT_TIMEOUT_MS: u32 = 180_000;
+pub const DEFAULT_TIMEOUT_MILLIS: u32 = 180_000;
 
 /// Adapter returned when `GEMINI_API_KEY` is unset (or
 /// `AETHER_GEMINI_DISABLE=1`). Every request replies
@@ -61,7 +61,7 @@ impl GeminiAdapter for DisabledGeminiAdapter {
 }
 
 mod config {
-    use super::{DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MS};
+    use super::{DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MILLIS};
     // confique consumes these through `#[config(parse_env = …)]`; IntelliJ-Rust
     // doesn't trace macro-attr path args (Qodana FP), but rustc + clippy do.
     #[allow(unused_imports)]
@@ -119,7 +119,7 @@ mod config {
             feature = "native",
             config(
                 default = 180_000,
-                parse = parse_millis_strict::<DEFAULT_TIMEOUT_MS>,
+                parse = parse_millis_strict::<DEFAULT_TIMEOUT_MILLIS>,
                 ms_duration,
                 layer_field = "timeout_ms"
             )
@@ -133,7 +133,7 @@ mod config {
                 api_key: None,
                 disabled: false,
                 max_in_flight: DEFAULT_MAX_IN_FLIGHT,
-                timeout: Duration::from_millis(u64::from(DEFAULT_TIMEOUT_MS)),
+                timeout: Duration::from_millis(u64::from(DEFAULT_TIMEOUT_MILLIS)),
             }
         }
     }
@@ -145,7 +145,9 @@ mod config {
 
     #[cfg(all(test, feature = "native"))]
     mod tests {
-        use super::{DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MS, GeminiConfig, GeminiConfigLayer};
+        use super::{
+            DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MILLIS, GeminiConfig, GeminiConfigLayer,
+        };
         use confique::Config as _;
         use std::time::Duration;
 
@@ -163,7 +165,7 @@ mod config {
             assert_eq!(layer.api_key, None);
             assert!(!layer.disabled);
             assert_eq!(layer.max_in_flight, DEFAULT_MAX_IN_FLIGHT);
-            assert_eq!(layer.timeout_ms, DEFAULT_TIMEOUT_MS);
+            assert_eq!(layer.timeout_ms, DEFAULT_TIMEOUT_MILLIS);
             assert_eq!(
                 Duration::from_millis(u64::from(layer.timeout_ms)),
                 default.timeout


### PR DESCRIPTION
Closes iamacoffeepot/aether#1558.

## Summary

The repo spells time units out in identifiers (`millis`, never `ms`), but the gemini and anthropic capabilities each still exported a `DEFAULT_TIMEOUT_MS` constant — the last `_MS` identifiers in the crate, left out of #1523's touched-file list.

Renames both to `DEFAULT_TIMEOUT_MILLIS` and carries every in-crate use site (including the `parse_millis_strict` turbofish, test-module imports, and the `anthropic/mod.rs` doc-comment prose). The wire-contract surfaces — the `layer_field = "timeout_ms"` pins and the `*ConfigLayer.timeout_ms` field declarations — are untouched (config-file / env contract).

## Test plan

- Existing config-default tests in `gemini/mod.rs` and `anthropic/mod.rs` cover the constants.
- `git diff` confirms no `layer_field = "timeout_ms"` line or `*ConfigLayer.timeout_ms` field declaration changed — the wire surfaces stay byte-identical.
- Full `scripts/preflight.sh` green.

## Generated by

Agent execution of scoped issue #1558.
