### PR TITLE
flake(actor-derive): widen ci trybuild slow-timeout to cover actor-derive

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -32,9 +32,10 @@ slow-timeout = { period = "60s", terminate-after = 1 }
 # iamacoffeepot/aether#1275 feature-gated wasmtime out of the
 # `aether-derive` fixture dep graph (local wall-clock 240s → 18s on
 # our dev boxes); CI's 2-core runners still push it past 60s under
-# parallel contention with `aether-data-derive`'s ui binary, so both
-# crates keep the wider cap. The bigger speedup for both is its own
-# follow-up.
+# parallel contention with `aether-data-derive`'s ui binary, so all
+# three derive crates (`aether-data-derive`, `aether-derive`,
+# `aether-actor-derive`) keep the wider cap. The bigger speedup for
+# all three is its own follow-up.
 [[profile.ci.overrides]]
-filter = "package(=aether-data-derive) | package(=aether-derive)"
+filter = "package(=aether-data-derive) | package(=aether-derive) | package(=aether-actor-derive)"
 slow-timeout = { period = "300s", terminate-after = 1 }


### PR DESCRIPTION
Closes iamacoffeepot/aether#1587.

## Summary

The `aether-actor-derive::ui` trybuild test — one nextest unit that batch-compiles its UI fixtures through a nested `cargo` invocation — intermittently exceeded the CI profile's 60s `slow-timeout` on the 2-core Linux runners and got terminated, failing runs whose changes were unrelated. The repo already widens this timeout to 300s for the sibling derive crates (`aether-data-derive`, `aether-derive`); `aether-actor-derive`'s ui test was added later and never joined the filter.

This extends the existing trybuild `slow-timeout` override in `.config/nextest.toml` to include `package(=aether-actor-derive)` and updates the adjacent comment to name all three derive crates. The override is CI-profile-only, so local runs keep the tight default.

## Test plan

- `cargo nextest show-config test-groups --profile ci` confirms the new filter term is in effect.
- Repo-config-only change (`.config/nextest.toml`); no code, no public surface.

## Generated by

`/implement` — agent execution of scoped issue #1587.
