### PR TITLE
chore(repo): add guide to the pre-flight hook meta-scope mirror

### DIFF
--- a/.claude/hooks/check-pr-body.sh
+++ b/.claude/hooks/check-pr-body.sh
@@ -166,7 +166,7 @@ if [[ ",$allowed," != *",e,"* ]] && (( is_issue_cmd == 1 )) && [[ -n "$title" ]]
     # match META_SCOPES in .github/workflows/issue-labels.yml — the
     # server accepts these, so the local hook must too or it
     # false-positives on a title the server would pass.
-    meta_scopes=" ci docs adr qodana repo release workflow "
+    meta_scopes=" ci docs adr qodana repo release workflow guide "
     if [[ "$title" =~ $title_re ]]; then
         scope="${BASH_REMATCH[2]}"
         if [[ "$meta_scopes" != *" $scope "* ]] \
@@ -189,7 +189,7 @@ if (( ${#issues[@]} )); then
         printf '  - Issue title: {type}({scope}): <subject>. Types: feat fix chore docs perf refactor flake.\n'
         printf '  - PR title: same {type}({scope}): <subject> shape; PR types additionally allow test build ci style revert.\n'
         printf '  - Subject (issue + PR) must start lowercase.\n'
-        printf '  - Scope is a crate name OR a meta-scope: ci docs adr qodana repo release workflow.\n'
+        printf '  - Scope is a crate name OR a meta-scope: ci docs adr qodana repo release workflow guide.\n'
         printf '  - Body: no backslash before a backtick/dollar (A); no dollar-delimited math span, use backticks (D).\n'
         printf '\nTo override deliberately, include `<!-- pr-body-ok: <letters> — <reason> -->` (letters: a/c/d/e, comma-separated; only listed patterns are skipped).\n'
         printf 'Context: feedback_heredoc_no_backtick_escape.md (auto-memory).\n'


### PR DESCRIPTION
Closes iamacoffeepot/aether#1609.

## Summary

The local check-pr-body.sh hook kept a hardcoded mirror of the server-side META_SCOPES list in .github/workflows/issue-labels.yml, and the mirror had drifted: the server list includes guide, the hook's did not. Every docs(guide) issue or PR title was blocked at the local gate (Pattern E) even though the server-side lint accepts it, forcing a pr-body-ok: e override.

This adds guide to the meta_scopes string and to the rules-reference line, restoring the hook as a faithful mirror of the workflow's META_SCOPES. The guide-page batch (#1592 onward) no longer needs the override.

## Test plan

Smoke-tested by piping PreToolUse JSON into the hook:

- docs(guide) issue title exits 0 with no output (and no override needed).
- a bogus scope still exits 2, and both the Pattern E message and the rules-reference line now list guide.

## Generated by

`/implement` — agent execution of scoped issue #1609.