### PR TITLE
docs(workflow): retire stale close-form rationale in implement pr body template

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -169,7 +169,7 @@ The worktree stays on disk until the user cleans up — useful for inspecting th
 ## PR body template
 
 ```markdown
-Closes iamacoffeepot/aether#<issue>.
+Closes #<issue>.
 
 ## Summary
 
@@ -183,8 +183,6 @@ Closes iamacoffeepot/aether#<issue>.
 
 `/implement` — agent execution of [scoped issue #<issue>](<issue-url>).
 ```
-
-The cross-repo close form (`Closes iamacoffeepot/aether#N`) is required because the bare `#N` form gets stripped by the user's PR-body hook. See `feedback_close_keyword_hook_strips_hash.md`.
 
 ## Auth budget (v1, will grow in Phase C)
 


### PR DESCRIPTION
Closes #1612.

## Summary

The `/implement` skill's §PR body template mandated the cross-repo close form (`Closes iamacoffeepot/aether#<issue>`) and justified it with a PR-body hook that stripped bare `#N` references. That hook behavior was retired in #1348 — a bare `Closes #N` survives intact and is the current repo convention. This switches the template to the bare form and deletes the stale rationale paragraph (and its `feedback_close_keyword_hook_strips_hash.md` pointer).

## Test plan

Docs-only change to `.claude/skills/implement/SKILL.md` — repo-config class, skips the Rust pre-flight. No tests.

## Generated by

`/implement` — agent execution of [scoped issue #1612](https://github.com/iamacoffeepot/aether/issues/1612).