### PR TITLE
docs(guide): fix dead inline links and stale tick placement

### DIFF
--- a/docs/guide/foundations/invariants.md
+++ b/docs/guide/foundations/invariants.md
@@ -17,7 +17,7 @@ It splits in two:
 > Concurrency *enforces* several of these (single-threaded actors, ordering,
 > no-blocking) but is not the same topic — the contracts live here; the
 > machinery that makes them hold, and how to work with it, is
-> [Concurrency & blocking](). Invariants are the *what*; concurrency is one of
+> [Concurrency & blocking](../systems/concurrency.md). Invariants are the *what*; concurrency is one of
 > the *hows*.
 >
 > Maturity: the addressing, typing, and identity invariants are **stable** —
@@ -68,7 +68,7 @@ buys: a producer emitting `Thing { a }` and a consumer expecting
 found" and can never silently garbage-decode into the wrong shape ([ADR-0030](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0030-hashed-kind-ids.md)).
 The fix for a mismatch is always "recompile both sides," and the failure points
 straight at it. (Exactly which edits move the id — and which, like a field
-rename, leave it untouched — is the type system's story: [The type system]().)
+rename, leave it untouched — is the type system's story: [The type system](type-system.md).)
 
 **A kind is self-describing.** Every kind carries a schema describing its bytes
 ([ADR-0005](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0005-mail-typing-system.md)/[ADR-0031](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0031-const-constructible-schema-representation.md)), so the wire layer can encode it from JSON and a recipient can
@@ -117,7 +117,7 @@ have *its* next mail queued behind you). Await a reply through the framework, or
 hand blocking/async work off the actor thread (a computation DAG, or the
 sanctioned spawn primitives). *Tell:* a hang with no progress and, often, no
 actor named — the worst diagnostic shape the runtime offers. Full treatment in
-[Concurrency & blocking]().
+[Concurrency & blocking](../systems/concurrency.md).
 
 **Address exactly — bare and unknown names warn-drop.** A bare name (`"camera"`,
 `"player"`) or a kind name used as a recipient (`aether.audio.note_on` as an
@@ -166,9 +166,9 @@ is fine. *Tell:* a stack-overflow abort on adversarial or pathological input.
 ## Where to read more
 
 - The mechanics behind the concurrency invariants —
-  [Concurrency & blocking]().
+  [Concurrency & blocking](../systems/concurrency.md).
 - How kinds, mailboxes, handles, and ids fit together —
-  [The type system]().
+  [The type system](type-system.md).
 - The mail spine these all hang on —
   [Mail, kinds & scheduling](../systems/mail-and-kinds.md).
 - Settlement and tracing in depth — [Tracing & settlement](../systems/tracing-and-settlement.md).

--- a/docs/guide/systems.md
+++ b/docs/guide/systems.md
@@ -18,7 +18,7 @@ Before the table: the rule that everything else assumes. `recipient_name`
 names the **mailbox**; `kind_name` names the **payload shape**. They route
 independently even when they share a prefix. Chassis-owned mailboxes live under
 `aether.<name>` (`aether.render`, `aether.audio`, `aether.fs`, `aether.input`,
-`aether.window`, `aether.component`, `aether.handle`). A loaded wasm component
+`aether.lifecycle`, `aether.window`, `aether.component`, `aether.handle`). A loaded wasm component
 registers at `aether.component/aether.embedded:NAME` — use the full address that
 `LoadResult.name` hands back. **Bare names** (`"camera"`, `"player"`) are not
 registered and warn-drop.
@@ -30,7 +30,7 @@ registered and warn-drop.
 | **Mail & scheduling** | The universal interaction mechanism + the blob dispatcher that runs actors. | (the substrate itself; not a mailbox) | 0002, 0005, 0019, 0087 | Settling (scheduler internals) |
 | **Kinds, schema & encoding** | Typed payloads that describe themselves on the wire. | — | 0005, 0031, 0032, 0064, 0065, 0091 | Stable |
 | **Components & lifecycle** | Loading, replacing, and hot-reloading wasm actors. | `aether.component` — `load` / `drop` / `replace` | 0010, 0015, 0022, 0038, 0063, 0074 | Stable |
-| **Input streams** | Tick / key / mouse / window-size as publish-subscribe, keyed by `KindId`. | subscribe via `aether.input` from a component's `wire` hook | 0021, 0068 | Stable |
+| **Input streams** | Key / mouse / window-size input interrupts on `aether.input`; the per-frame Tick is a lifecycle stage on `aether.lifecycle`. All publish-subscribe, keyed by `KindId`. | subscribe via `aether.input`; subscribe Tick via `aether.lifecycle` | 0021, 0068, 0082 | Stable |
 | **Rendering & camera** | World-space geometry + a `view_proj` uniform; a camera publishes the matrix. | `aether.render` (`DrawTriangle`, `aether.camera`) | 0025, 0066, 0074 §7 | Stable |
 | **Mesh authoring & the DSL** | Author meshes as DSL text, hot-load them, replay to the renderer. | `aether.mesh.load` to the mesh-viewer component | 0026, 0051, 0052, 0057 | Stable |
 | **File I/O** | Namespaced read/write/delete/list — `save` / `assets` / `config`. | `aether.fs` — `read` / `write` / `delete` / `list` | 0041 | Stable |

--- a/docs/guide/systems/mail-and-kinds.md
+++ b/docs/guide/systems/mail-and-kinds.md
@@ -22,7 +22,7 @@ the only guest target wired up today. So a component is WASM *right now*, but a
 C / C++ / other guest that speaks the ABI is the same category. All of them are
 one actor model and address each other identically. When this page says
 "component" it means a loaded FFI actor; "actor" means either kind. Deep dive:
-[Components & lifecycle]().
+[Components & lifecycle](components.md).
 
 ## Why it exists
 
@@ -166,14 +166,14 @@ kind's schema. For a batch that must settle as one traced unit, use
 `Kind::ID` and `mailbox_id_from_name` are compile-time constants, so there's no
 host round-trip to resolve an address. You receive mail with a
 `#[handler] fn on_x(&mut self, ctx, mail: K)` — the kind is inferred from the
-third parameter (see [Components & lifecycle]() and the *Writing a component*
+third parameter (see [Components & lifecycle](components.md) and the *Writing a component*
 recipe).
 
 **Addressing rules that bite if ignored:**
 
 - Chassis mailboxes live under `aether.<name>` (`aether.render`, `aether.fs`,
-  `aether.audio`, `aether.input`, `aether.window`, `aether.component`,
-  `aether.handle`).
+  `aether.audio`, `aether.input`, `aether.lifecycle`, `aether.window`,
+  `aether.component`, `aether.handle`).
 - A loaded component registers at `aether.component/aether.embedded:NAME` — use the
   full address `LoadResult.name` hands back.
 - **Bare names** (`"camera"`, `"player"`) are not registered and warn-drop
@@ -193,7 +193,7 @@ the system a new kind" or "stand up a new mailbox":
   model and the same addressing.
 - **Reuse the streams** rather than polling. Tick / key / mouse / window-size
   are publish-subscribe — subscribe from a component's `wire` hook and you get
-  the events as mail. See [Input, file I/O & audio]().
+  the events as mail. See [Input](input.md) and [File I/O](file-io.md).
 
 Because everything is mail, these few moves compose: a new capability that
 handles a new kind and publishes another is the whole vocabulary of building on


### PR DESCRIPTION
Closes iamacoffeepot/aether#1593.

## Summary

Several guide pages shipped before their cross-link targets existed and carry empty `[title]()` links that now have live targets: invariants.md links Concurrency & blocking and The type system as empty in five places, and mail-and-kinds.md links Components & lifecycle as empty and points one link at "Input, file I/O & audio" — a page that was split into separate input and file-io pages before it ever existed. Separately, systems.md's input-streams row still describes Tick as an input stream, contradicting input.md and ADR-0082's amendment (Tick is a frame-lifecycle stage subscribed on `aether.lifecycle`), and neither systems.md nor mail-and-kinds.md lists `aether.lifecycle` among the chassis-owned mailboxes.

## Test plan

Documentation / process change. Where guide pages changed, `mdbook build docs` is clean (no broken-link warnings); `scripts/preflight.sh` classifies the change under a pre-flight exception class (docs-only or repo-config-only) and short-circuits the Rust pre-flight.

## Generated by

`/implement` hybrid background-agent dispatch for scoped issue #1593.
