### PR TITLE
docs(guide): update foundations pages to the adr-0099 two-identity model

### DIFF
--- a/docs/guide/foundations/actor-model.md
+++ b/docs/guide/foundations/actor-model.md
@@ -3,7 +3,8 @@
 > **Governing ADR:** [ADR-0074](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0074-unified-actor-model-for-substrate-and-guests.md) (the unified actor model — capabilities and
 > components are one model, not two) with [ADR-0079](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0079-instanced-actors-as-a-first-class-category.md) (the lifecycle stages)
 > and [ADR-0033](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0033-handler-driven-inputs-manifest.md) (the `#[actor]` macro), extended by [ADR-0096](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0096-multi-actor-wasm-modules.md) (a wasm module exports several
-> actor types) and [ADR-0097](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0097-wasm-sibling-spawn.md) (a component spawns its siblings). This model is **stable**; it's the
+> actor types), [ADR-0097](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0097-wasm-sibling-spawn.md) (a component spawns its siblings), and [ADR-0099](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0099-actor-identity-and-addressing.md) (actor
+> identity and addressing). This model is **stable**; it's the
 > spine everything else hangs off. Signatures here were read from the current SDK
 > (`aether-actor`) and runtime (`aether-substrate`).
 
@@ -196,37 +197,57 @@ call, and how a chassis assembles its own layered config, are the
 ## Names and addressing
 
 The `NAMESPACE` const on the `Actor` trait is the name an actor claims — the
-`"hello"`, `"camera"`, `"aether.audio"` in the examples above. Names are how actors
-get reached: a mailbox id is just a compile-time hash of the name
-(`mailbox_id_from_name`), so `ctx.actor::<RenderCapability>()` resolves to an address
-with no runtime lookup — the type carries its `NAMESPACE`, the hash is a const, and
-the send lands at the right mailbox.
+`"hello"`, `"camera"`, `"aether.audio"` in the examples above. From the name and
+the actor's place in the runtime tree come two ids, two distinct moments
+([ADR-0099](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0099-actor-identity-and-addressing.md)):
 
-Because the name *is* the address, it has to be unique — two actors claiming the same
-name hash to the same mailbox. The substrate enforces one claimant per name **at
-registration**: a second capability claiming a taken name fails to boot, and a
-component loaded under a name already in use comes back as a load error. This is not
-a compile-time check — two types can declare the same `NAMESPACE` string and compile
-cleanly; the collision only surfaces when the second one tries to register. For an
-instanced actor (below) the uniqueness is on the full `NAMESPACE:subname`, not the
+- **`NAMESPACE` → `ActorId`, at compile time.** The hash of the `NAMESPACE`
+  names *which actor* this is — binary-unique, the same wherever the actor is
+  hosted. An instanced actor (below) folds its runtime discriminator in:
+  `hash(NAMESPACE:subname)`.
+- **Lineage → `MailboxId`, at creation.** *Where* the actor sits is its
+  **lineage** — the ordered ActorIds from the substrate root down to it, fixed
+  when the actor is created. Its `MailboxId` is a hash chain over the lineage,
+  one fold step per node, and mail routes to that.
+
+For a **capability** the two coincide. It sits at the root, so its lineage is
+one node and the fold of one node is that node: `MailboxId == ActorId`, the
+`NAMESPACE` is the whole address (`aether.audio`, `aether.render`,
+`aether.input`), and `ctx.actor::<AudioCapability>()` resolves to it as a
+compile-time const with no runtime lookup.
+
+For a **component** the `NAMESPACE` is the *default load name*, and the loaded
+actor runs under the component host: its lineage is the `aether.component` host,
+then itself as an instance under the embedding-host class (`aether.embedded`),
+rendered with one `/` per node as
+`aether.component/aether.embedded:<name>` — the name `LoadResult` hands back
+(the `NAMESPACE` unless the load overrode it). The string is a display rendering
+of the lineage; the `MailboxId` is the fold over the nodes
+(`mailbox_id_from_path` on the string side), never a hash of the joined string.
+You reach a loaded component through its lineage: pass `LoadResult.name` to
+`resolve_actor`, use the `loaded` helper below, or address it by bare type —
+`ctx.actor::<Camera>()` on an embeddable component type resolves by folding the
+component's own name under the embedding-host class, landing on the same hosted
+mailbox.
+
+Because the lineage is the address, two actors collide exactly when they would
+occupy the same position — same parent, same name. The substrate enforces one
+claimant per position **at registration**: a second capability claiming a taken
+root name fails to boot, and a component loaded under a name already in use
+comes back as a load error. This is not a compile-time check — two types can
+declare the same `NAMESPACE` string and compile cleanly; the collision only
+surfaces when the second one tries to register. For an instanced actor (below)
+the colliding unit is the full `NAMESPACE:subname` under one parent, not the
 shared prefix.
-
-What the name maps to depends on the host. For a **capability** the `NAMESPACE` *is*
-the mailbox — `aether.audio`, `aether.render`, `aether.input` — claimed by the
-chassis at boot, so `ctx.actor::<AudioCapability>()` reaches it directly. For a
-**component** the `NAMESPACE` is only the *default load name*: once loaded, the actor
-is registered at `aether.component/aether.embedded:<name>` (the name `LoadResult` hands
-back, which is the `NAMESPACE` unless the load overrode it). You reach it by that
-registered name, not by hashing the bare `NAMESPACE` — either pass `LoadResult.name`
-to `resolve_actor`, or use the `loaded` helper below.
 
 A capability can also dress up its mail surface with **extension-trait helpers** —
 typed methods on the mailbox handle that stand in for raw kind sends.
 `ctx.actor::<InputCapability>().subscribe::<Key>()` is one (from
 `InputMailboxExt`), and `ctx.actor::<ComponentHostCapability>().loaded::<Camera>("camera")`
-is the loaded-component lookup just mentioned (from `ComponentHostExt`). Each such
-trait is implemented for *both* the component and the capability handle, so the same
-helper reads the same whichever host you write from.
+is the loaded-component lookup just mentioned (from `ComponentHostFfiExt` in a
+component, `ComponentHostNativeExt` in a capability). Each helper is available on
+both the component and the capability handle, so the same call reads the same
+whichever host you write from.
 
 ## One or many: cardinality
 
@@ -234,14 +255,18 @@ An actor type is either **singleton** or **instanced**, marked by the `Singleton
 `Instanced` trait, and the choice sets whether its `NAMESPACE` is a whole name or a
 prefix.
 
-A **singleton** is one of a kind: at most one instance, and the `NAMESPACE` is its
-whole name. Every capability is a singleton — and because a capability's name is its
-mailbox, you address it straight by type, `ctx.actor::<R>()`.
+A **singleton** is one of a kind: at most one instance under a given parent, and
+its `ActorId` is the plain `hash(NAMESPACE)`. Every capability is a root
+singleton — its one-node lineage makes its `NAMESPACE` the whole address, so you
+address it straight by type, `ctx.actor::<R>()`.
 
 An **instanced** actor is one of many sharing a prefix. Its `NAMESPACE` is that
-prefix, and each live instance has a full name `NAMESPACE:subname` — for example
-`aether.net.session:42`. The case that drives this is sockets: a singleton listener
-accepts connections and spawns a session actor per connection with `ctx.spawn_child`
+prefix, and each live instance gets its own `ActorId` by folding a runtime
+discriminator in — `hash(NAMESPACE:subname)`, rendered `aether.net.session:42` —
+with its `MailboxId` folding that ActorId under the parent's lineage, so two
+instances under one parent differ by subname. The case that drives this is
+sockets: a singleton listener accepts connections and spawns a session actor per
+connection with `ctx.spawn_child`
 ([ADR-0079](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0079-instanced-actors-as-a-first-class-category.md)), then reaches a specific one by subname,
 `ctx.resolve_actor::<SessionActor>("42")`.
 

--- a/docs/guide/foundations/invariants.md
+++ b/docs/guide/foundations/invariants.md
@@ -46,17 +46,33 @@ independently.** The mailbox decides *where* mail goes; the kind only describes
 `.note_on` verb → `aether.audio.note_on` kind), but routing never consults the
 kind. Hold these apart and most "my mail vanished" confusion disappears.
 
-**Identity is name-derived and stable.** A `MailboxId` is a deterministic hash
-of the mailbox name (FNV-1a 64, [ADR-0029](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0029-name-derived-mailbox-ids.md)); a `KindId` is a hash of the kind name
-*plus its schema* ([ADR-0030](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0030-hashed-kind-ids.md)). Two consequences you can lean on:
+**Identity is name-derived and stable.** An actor carries two ids, each
+deterministic ([ADR-0099](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0099-actor-identity-and-addressing.md)): its `ActorId` — *which actor* — is the FNV-1a 64
+hash of its `NAMESPACE` (`hash(NAMESPACE:subname)` for an instanced actor), and
+its `MailboxId` — *where it sits* — is a hash chain over its **lineage**, the
+ordered ActorIds from the substrate root down to the actor. A root actor's
+lineage is one node, so its `MailboxId` equals its `ActorId` — the name hash of
+[ADR-0029](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0029-name-derived-mailbox-ids.md) is the depth-1 case of the fold. A `KindId` is a hash of the kind
+name *plus its schema* ([ADR-0030](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0030-hashed-kind-ids.md)). Two consequences you can lean on:
 
-- **Stable across processes.** Two substrates that hash the same name produce
-  the same id, so addressing works across a fleet without a resolution
-  round-trip — `Kind::ID` and `mailbox_id_from_name` are compile-time constants.
-- **Stable across hot-swap.** Because the id is derived from the name, replacing
-  a component in place keeps its mailbox id valid — senders and route caches
-  survive the swap ([ADR-0029](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0029-name-derived-mailbox-ids.md); the `replace_component_preserves_mailbox_identity`
+- **Stable across processes.** Every id is computed from names and lineage,
+  never assigned — `Kind::ID` and `mailbox_id_from_name` are compile-time
+  constants, and the lineage fold (`fold_lineage`) is the same pure function on
+  every substrate and guest — so two processes that hold the same names and the
+  same lineage produce the same ids, and addressing works across a fleet
+  without a resolution round-trip.
+- **Stable across hot-swap.** Replacing a component in place changes neither
+  its name nor its position under its host, so its lineage — and the
+  `MailboxId` folded from it — is unchanged: senders and route caches survive
+  the swap ([ADR-0029](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0029-name-derived-mailbox-ids.md); the `replace_component_preserves_mailbox_identity`
   scenario guards it).
+
+One sharp edge follows from the lineage fold: a `/`-rendered address
+(`aether.component/aether.embedded:camera`) resolves by parsing it into
+segments and folding their ActorIds (`mailbox_id_from_path`). Hashing the
+joined string as a flat name yields an id the registry never registered, and
+mail to it warn-drops — the string is a rendering of the lineage, never the
+hash input.
 
 **A kind id encodes its shape — drift fails loud, not silently.** The `KindId`
 hashes `name + schema`, where `name` is the kind's *declared* name

--- a/docs/guide/foundations/type-system.md
+++ b/docs/guide/foundations/type-system.md
@@ -1,7 +1,7 @@
 # The type system
 
 > **Governing ADRs:** [ADR-0005](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0005-mail-typing-system.md) (mail typing), [ADR-0019](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0019-unified-mail-encoding.md) (unified encoding),
-> [ADR-0029](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0029-name-derived-mailbox-ids.md)/[ADR-0030](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0030-hashed-kind-ids.md) (name- and schema-derived ids), [ADR-0031](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0031-const-constructible-schema-representation.md)/[ADR-0032](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0032-canonical-schema-bytes-and-labels-sidecar.md) (const
+> [ADR-0029](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0029-name-derived-mailbox-ids.md)/[ADR-0030](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0030-hashed-kind-ids.md) (name- and schema-derived ids), [ADR-0099](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0099-actor-identity-and-addressing.md) (actor identity and addressing), [ADR-0031](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0031-const-constructible-schema-representation.md)/[ADR-0032](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0032-canonical-schema-bytes-and-labels-sidecar.md) (const
 > schema + canonical bytes / labels sidecar), [ADR-0045](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0045-computation-dag-and-typed-handles.md)/[ADR-0048](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0048-transforms-and-content-addressed-handles.md)/[ADR-0049](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0049-persistent-handle-store.md) (handles,
 > transforms, the handle store), [ADR-0064](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0064-type-tagged-opaque-ids-on-the-mcp-wire.md)/[ADR-0065](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0065-typed-id-newtypes-and-first-class-type-ids-in-the-schema.md) (type-tagged wire ids +
 > first-class id types). The type vocabulary is **stable** — the wire format
@@ -163,13 +163,38 @@ cases that surprise people live at the schema-arm level. Holding the
 
 ## Mailboxes — typed addresses
 
-A **mailbox** is an address: where mail goes. Its `MailboxId` is a 64-bit hash
-of the mailbox *name* alone (no schema — a mailbox is a pure address, [ADR-0029](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0029-name-derived-mailbox-ids.md)),
-so it's the same id in every process that hashes the same name, and it survives
-a component hot-swap. In a component you rarely touch the id directly: you
-address a peer by type (`ctx.actor::<RenderCapability>()`) or hold a `Mailbox<K>`
-token. The mailbox-vs-kind distinction — why an address and a payload shape are
-different things even when they share a name prefix — is the
+A **mailbox** is an address: where mail goes. Addressing rests on two ids, one
+per question ([ADR-0099](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0099-actor-identity-and-addressing.md)):
+
+- An **`ActorId`** answers *which actor*. It is a 64-bit hash of the actor's
+  `NAMESPACE` alone — `hash(NAMESPACE)` for a singleton actor,
+  `hash(NAMESPACE:subname)` for an instanced one — with no schema in the hash,
+  because an actor's identity is its name ([ADR-0029](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0029-name-derived-mailbox-ids.md)). It names the actor
+  wherever it is hosted, and it reverse-maps to that name for introspection.
+- A **`MailboxId`** answers *where in the tree*. An actor sits somewhere — at
+  the substrate root, or hosted under a parent — and its **lineage** is the
+  ordered list of ActorIds from the root down to it. The `MailboxId` is a hash
+  chain over that lineage (`fold_lineage`, one fold step per node), and mail
+  routes to it.
+
+For a root actor — every chassis capability — the lineage is a single node,
+and the fold of one node is that node: `MailboxId == ActorId == hash(name)`,
+so the name hash of [ADR-0029](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0029-name-derived-mailbox-ids.md) is the depth-1 case of the fold. A hosted
+actor — a loaded component, a spawned child — folds its ActorId onto its
+parent's, so the same code under two different parents is two different
+mailboxes. The `/`-rendered addresses you see
+(`aether.component/aether.embedded:camera`) are a display rendering of the
+lineage, one segment per ActorId; a written path resolves by parsing it into
+segments and re-folding (`mailbox_id_from_path`), never by hashing the joined
+string.
+
+Both ids are computed from compile-time constants with no registry lookup, so
+every process that holds the same names and the same lineage computes the same
+ids — and a component hot-swap, which changes neither, keeps the address
+valid. In a component you rarely touch either id directly: you address a peer
+by type (`ctx.actor::<RenderCapability>()`) or hold a `Mailbox<K>` token. The
+mailbox-vs-kind distinction — why an address and a payload shape are different
+things even when they share a name prefix — is the
 [Mail, kinds & scheduling](../systems/mail-and-kinds.md) page's subject.
 
 ## Handles — references to stored values
@@ -219,7 +244,8 @@ Every typed thing is named by a newtype over a hash, not a bare integer:
 | id | wraps | derived from |
 |---|---|---|
 | `KindId` | `u64` | `name + schema` ([ADR-0030](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0030-hashed-kind-ids.md)) |
-| `MailboxId` | `u64` | mailbox name ([ADR-0029](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0029-name-derived-mailbox-ids.md)) |
+| `ActorId` | `u64` | the actor's `NAMESPACE` (plus `:subname` when instanced) ([ADR-0099](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0099-actor-identity-and-addressing.md)) |
+| `MailboxId` | `u64` | the actor's lineage — a hash chain of `ActorId`s, root → leaf; a root actor's equals its name hash ([ADR-0029](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0029-name-derived-mailbox-ids.md)/[ADR-0099](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0099-actor-identity-and-addressing.md)) |
 | `HandleId` | `u64` | the stored bytes (content-addressed, [ADR-0048](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0048-transforms-and-content-addressed-handles.md)) |
 | `TransformId` | `u64` | the transform's identity ([ADR-0048](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0048-transforms-and-content-addressed-handles.md)) |
 | `DagId` | `u64` | an in-flight DAG job |
@@ -231,7 +257,9 @@ Two properties keep these from being foot-guns:
   different domain prefixes, so the *same* name produces *different* ids in the
   two spaces — the id spaces don't collide even when names are shared ([ADR-0030](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0030-hashed-kind-ids.md)).
   This is the mechanical reason a kind name and a mailbox name can look alike yet
-  address different things.
+  address different things. (`ActorId` deliberately shares the mailbox domain —
+  a root actor's `MailboxId` *is* its `ActorId`, which is what keeps every
+  chassis capability's id equal to its name hash.)
 - **Tagged strings on the MCP wire.** Across the agent boundary, ids encode as
   `<tag>-XXXX-XXXX-XXXX` — `mbx-…` for a mailbox, `knd-…` for a kind, `hdl-…` for
   a handle ([ADR-0064](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0064-type-tagged-opaque-ids-on-the-mcp-wire.md)). The tag makes an id self-identifying, so a mailbox id and


### PR DESCRIPTION
Closes iamacoffeepot/aether#1592.

## Summary

The three foundations pages state the engine's identity model as a guarantee readers can build on — and the stated model is the superseded one. ADR-0099 split identity into **ActorId** (which actor: `hash(NAMESPACE)`, or `hash(NAMESPACE:subname)` for an instanced actor) and **MailboxId** (where it sits: a fold over its runtime lineage, rendered with `/`). The guide's "a MailboxId is a deterministic hash of the mailbox name" holds only for top-level actors; for anything hosted under another actor it is wrong, and the typed-id table in type-system.md has no ActorId row at all.

## Test plan

Documentation / process change. Where guide pages changed, `mdbook build docs` is clean (no broken-link warnings); `scripts/preflight.sh` classifies the change under a pre-flight exception class (docs-only or repo-config-only) and short-circuits the Rust pre-flight.

## Generated by

`/implement` hybrid background-agent dispatch for scoped issue #1592.
