### PR TITLE
chore(capabilities): fix stale NativeTransport reference in lifecycle.rs doc-comment

### DIFF
--- a/crates/aether-capabilities/src/lifecycle.rs
+++ b/crates/aether-capabilities/src/lifecycle.rs
@@ -1446,8 +1446,8 @@ mod native {
         /// `Source` the transport host-stamps to the calling actor, and
         /// delivering that mail to the cap lands the calling actor in the
         /// `Tick` stage set. The wasm FFI shims `export!` emits are
-        /// wasm32-only, so the host test drives the cap through
-        /// `NativeTransport`.
+        /// wasm32-only, so the host test drives the cap through a
+        /// `NativeBinding`.
         #[test]
         fn subscribe_via_native_mailbox_lands_calling_actor_in_stage_set() {
             use std::sync::mpsc;


### PR DESCRIPTION
Closes #1632.

## Summary

A test doc-comment in `crates/aether-capabilities/src/lifecycle.rs` referenced `NativeTransport`, a name that no longer exists. Updated it to `NativeBinding` (the current type), adjusting the sentence to read naturally.

## Test plan

`.rs` doc-comment change. Gate: `grep -rn NativeTransport crates/` returns empty. Full workspace fmt/clippy/nextest/doc green.

## Generated by

`/implement` — agent execution of [scoped issue #1632](https://github.com/iamacoffeepot/aether/issues/1632).
