### PR TITLE
chore(repo): add MIT OR Apache-2.0 license metadata to workspace and member crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ exclude = [
 [workspace.package]
 version = "0.3.0-alpha"
 edition = "2024"
+license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 # Chassis-binary argv parsing (ADR-0090 unit d, issue 1258). One

--- a/crates/aether-actor-derive/Cargo.toml
+++ b/crates/aether-actor-derive/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aether-actor-derive"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/aether-actor/Cargo.toml
+++ b/crates/aether-actor/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aether-actor"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 # Actor SDK shared by WASM components (via `wasm::WasmTransport` —
 # folded in from the prior `aether-component` crate by issue 552 stage

--- a/crates/aether-camera/Cargo.toml
+++ b/crates/aether-camera/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aether-camera"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 # Issue 552 stage 1.5: consolidated dual-output crate. Trunk types
 # (kind structs, parameter shapes) live at the crate root for

--- a/crates/aether-capabilities/Cargo.toml
+++ b/crates/aether-capabilities/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aether-capabilities"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 # Issue 552 stage 2e: the chassis-cap layer extracted out of
 # `aether-substrate`. Hosts the six native chassis capabilities

--- a/crates/aether-codec/Cargo.toml
+++ b/crates/aether-codec/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aether-codec"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 # Schema-driven encode + decode of agent-supplied JSON params against
 # `aether_data::SchemaType` descriptors. ADR-0019 made every

--- a/crates/aether-data-derive/Cargo.toml
+++ b/crates/aether-data-derive/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aether-data-derive"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/aether-data/Cargo.toml
+++ b/crates/aether-data/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aether-data"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [features]
 # Re-export `#[derive(Kind)]` and `#[derive(Schema)]` from

--- a/crates/aether-derive/Cargo.toml
+++ b/crates/aether-derive/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aether-derive"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 # Engine-wide derive macros that don't fit the actor or data
 # categories. The `Config` derive (ADR-0090 unit g, issue 1264)

--- a/crates/aether-kinds/Cargo.toml
+++ b/crates/aether-kinds/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aether-kinds"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 # ADR-0069: the data layer (typed ids, schema vocab, Kind/Schema

--- a/crates/aether-kit/Cargo.toml
+++ b/crates/aether-kit/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aether-kit"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 # The gameplay-systems layer: reusable actors built on the engine that
 # any tile game on the substrate can load. Each system is its own

--- a/crates/aether-math/Cargo.toml
+++ b/crates/aether-math/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aether-math"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 # ADR-0048 / issue 1464: `Vec4` is the `aether.math.vec4` wire kind

--- a/crates/aether-mcp/Cargo.toml
+++ b/crates/aether-mcp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aether-mcp"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 # The out-of-process MCP coordinator (issue 763 P5). Claude Code points
 # `.mcp.json` at this binary; it owns the `rmcp` HTTP server and the

--- a/crates/aether-mesh-viewer/Cargo.toml
+++ b/crates/aether-mesh-viewer/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aether-mesh-viewer"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 # Issue 552 stage 1.5: consolidated dual-output crate. Trunk types
 # (kind structs, parameter shapes) live at the crate root for

--- a/crates/aether-mesh/Cargo.toml
+++ b/crates/aether-mesh/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aether-mesh"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 aether-math = { path = "../aether-math" }

--- a/crates/aether-substrate-bundle/Cargo.toml
+++ b/crates/aether-substrate-bundle/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aether-substrate-bundle"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 # Multi-binary chassis crate. Holds the desktop, headless, hub, and
 # test-bench chassis source as submodules (`src/<chassis>/`). Each

--- a/crates/aether-substrate/Cargo.toml
+++ b/crates/aether-substrate/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aether-substrate"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 # ADR-0035 Phase 1: runtime (wasmtime host, mail scheduler, kind
 # manifest, registry, control-plane dispatch, hub client) for the

--- a/crates/aether-test-fixtures/Cargo.toml
+++ b/crates/aether-test-fixtures/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aether-test-fixtures"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 # Shared test-fixture crate. The `lib` rlib holds Kind definitions and
 # helpers shared with the integration tests (and visible as

--- a/demos/sokoban/Cargo.toml
+++ b/demos/sokoban/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aether-demo-sokoban"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [lib]
 # `cdylib` is the production artifact (wasm32 build → component). `rlib`

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xtask"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]


### PR DESCRIPTION
Closes #1399

## Summary

Phase 2 of the licensing work (#1398 landed the license texts, `CONTRIBUTING.md`, and the README section). Declares the outbound license as manifest metadata so `cargo publish`, license scanners, SBOM generators, and GitHub's dependency graph can read it.

- `license = "MIT OR Apache-2.0"` added once to `[workspace.package]` in the root `Cargo.toml`.
- `license.workspace = true` added to every member's `[package]` (19 members: all `crates/*`, `demos/sokoban`, `xtask`), so the SPDX expression is declared in one place and inherited everywhere.

The SPDX `license` field carries the dual grant directly; `license-file` is not used (it permits only a single file).

## Test plan

`cargo metadata --no-deps` reports `"license": "MIT OR Apache-2.0"` on all 19 workspace members. Full local pre-flight (fmt, clippy `--all-targets`, nextest `--workspace`, doc, wasm32 component cross-build) green. Metadata-only — no code, no wire formats.

## Generated by

`/implement --sweep` — agent execution of scoped issue #1399.
