### PR TITLE
docs(repo): align /sketch type-inference table with issue-labels lint

### DIFF
--- a/.claude/skills/scope-spinoff/SKILL.md
+++ b/.claude/skills/scope-spinoff/SKILL.md
@@ -71,7 +71,7 @@ If §Side findings becomes empty after removal, delete the section header too.
 ```
 Would file:
   - "chore(substrate): drop unreferenced drop_handler" (from finding 1)
-  - "test(actor): add coverage for ReplaceResult error path" (from finding 3)
+  - "chore(actor): add coverage for ReplaceResult error path" (from finding 3)
 
 Would remove findings 1, 3 from #<parent> §Side findings.
 

--- a/.claude/skills/sketch/SKILL.md
+++ b/.claude/skills/sketch/SKILL.md
@@ -25,15 +25,17 @@ With no idea text, ask what the idea is — don't guess from conversation contex
 
 `{type}({crate}): subject` — lowercase subject, conventional-commit form. The repo's issue lint auto-applies `invalid-title` to anything else, and `/scope` derives the board `Type` field from the prefix, so the title is load-bearing.
 
-Type inference from the idea text (same table `/scope-spinoff` uses):
+Type inference from the idea text (same table `/scope-spinoff` uses). The authoritative type set is the `TYPES` array in `.github/workflows/issue-labels.yml` — check it when this table and the lint diverge.
 
 - "dead code", "unused", "drift", workflow/tooling → `chore`
-- "missing test", "test gap", "flaky" → `test`
+- "flaky", "contention", "intermittent" → `flake`
+- "missing test", "test gap", "harness tooling" → `chore` (or `fix` when the gap is a defect in existing tooling)
 - "doc gap", "missing rustdoc", guide/ADR work → `docs`
 - "bug", "regression", "broken", "panics" → `fix`
 - new capability, "add", "support" → `feat`
+- "slow", "perf regression", throughput/latency → `perf`
 - restructure with no behavior change → `refactor`
-- pipelines, runners, release automation → `ci`
+- CI pipelines, runners, release automation → `chore(ci):` or `fix(ci):`
 - Default if genuinely ambiguous → `chore`, and say so in the output
 
 The crate scope comes from whatever the idea names or points at (a file path resolves to its crate; skill/workflow/process work uses `workflow`; repo-wide chores use `repo`). If the scope is ambiguous, ask inline — a wrong scope is worse than one question.
@@ -42,7 +44,7 @@ The crate scope comes from whatever the idea names or points at (a file path res
 
 Apply the labels on the issue-create call itself — the REST `POST …/issues` form (see [Filing](#filing)) takes them inline via repeated `-f 'labels[]=…'`, so they land in the one create request rather than as follow-up edits.
 
-- `type:<t>` mirrors the title prefix (note: not every type has a label — check `gh label list` output cached in this repo: `type:feat`, `type:fix`, `type:docs`, `type:chore`, `type:perf`, `type:refactor`, `type:flake` exist; `ci`/`test` have no label — skip, the title carries it).
+- `type:<t>` mirrors the title prefix. All seven allowed types have a matching label: `type:feat`, `type:fix`, `type:chore`, `type:docs`, `type:perf`, `type:refactor`, `type:flake`.
 - `crate:<short>` for the crate scope. **If the crate is new and has no label, create it first** (`gh label create "crate:<short>" --color bfdadc --description "<full crate name>"`) — PRs against a crate with no label trip the title lint (Pattern E).
 - `papercut` / `design` when the idea is a gotcha/rough-edge or a work-in-progress design, respectively — pass via `--label` or infer when the idea text says so.
 - No `phase:*` label — Backlog carries none by convention.


### PR DESCRIPTION
Closes #1655.

## Summary

The `/sketch` type-inference table mapped ideas to title types the enforced lint rejects: `test` and `ci` are not in the allowed set (feat, fix, chore, docs, perf, refactor, flake), and `ci` is a meta-scope rather than a type. Following the table produced two invalid-title filings this session (#1653, #1654). This corrects the table to track the lint — flaky/contention tests map to flake, missing-test/harness work to chore or fix, CI pipelines to chore(ci): / fix(ci): — adds the missing perf row, and adds a pointer to the TYPES array in issue-labels.yml as the source of truth. Also fixes the invalid test(actor): example in /scope-spinoff.

## Test plan

Docs-only (.claude/skills/**). Every example title in the rewritten table was checked against the lint regex in .github/workflows/issue-labels.yml; a grep of .claude/skills/*/SKILL.md confirms no remaining test( or ci( example titles.

## Generated by

`/implement` — agent execution of scoped issue #1655.
