### PR TITLE
chore(substrate-bundle): skip fleetbench tests when the dist manifest is absent

### DIFF
--- a/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
@@ -22,6 +22,10 @@
 //! exercised by another.
 
 #![allow(dead_code)]
+// The manifest-presence guard emits its skip diagnostic via stderr so
+// `cargo test` surfaces "skipping: ..." alongside `test ... ok` (issue
+// 891), matching `headless_autoload.rs`.
+#![allow(clippy::print_stderr)]
 
 use std::collections::BTreeMap;
 use std::env;
@@ -705,10 +709,45 @@ fn dist_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../dist")
 }
 
+/// Manifest-presence guard for the `FleetBench` tests that load component
+/// wasm. Returns `true` when `dist/manifest.json` is present (the test
+/// proceeds); returns `false` when it's absent so the caller can
+/// early-return as a skip — except under `AETHER_REQUIRE_RUNTIME` (which
+/// CI sets), where a missing manifest panics so a missing
+/// `cargo xtask dist` pre-build can't pass silently. Mirrors
+/// `headless_autoload.rs`'s pre-built-wasm skip/require convention (issue
+/// 891): a bare `cargo nextest run` in a worktree that hasn't run
+/// `cargo xtask dist` skips instead of reporting hard failures that read
+/// as regressions.
+///
+/// [`read_component_wasm`] itself keeps its panic: past this guard the
+/// manifest is present, and a manifest that exists but is missing a
+/// requested stem (a stale dist, not an unbuilt one) is a real test bug.
+#[must_use]
+pub fn dist_manifest_present() -> bool {
+    let manifest_path = dist_dir().join("manifest.json");
+    if manifest_path.exists() {
+        return true;
+    }
+    assert!(
+        env::var("AETHER_REQUIRE_RUNTIME").is_err(),
+        "AETHER_REQUIRE_RUNTIME set but {} is absent; \
+         run `cargo xtask dist` to build the component wasm + manifest",
+        manifest_path.display(),
+    );
+    eprintln!(
+        "skipping: {} absent; \
+         run `cargo xtask dist` first to build the component wasm + manifest",
+        manifest_path.display(),
+    );
+    false
+}
+
 /// Read a component wasm by stem through `dist/manifest.json` (the
 /// #1445 dist tree). Panics with a `cargo xtask dist` hint if the
 /// manifest is absent — the harness can't locate component wasm without
-/// it.
+/// it. Tests guard their load path with [`dist_manifest_present`] so a
+/// missing manifest skips rather than reaching this panic.
 pub fn read_component_wasm(stem: &str) -> Vec<u8> {
     let dist = dist_dir();
     let manifest_path = dist.join("manifest.json");

--- a/crates/aether-substrate-bundle/tests/fleetbench_load.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_load.rs
@@ -16,7 +16,7 @@ mod tests {
         use aether_data::Kind;
         use aether_kinds::{LoadComponent, LoadResult};
 
-        use crate::fleetbench::FleetBench;
+        use crate::fleetbench::{FleetBench, dist_manifest_present};
 
         /// Load the `probe` component and assert `LoadResult.name` is the
         /// `/`-rendered lineage
@@ -29,6 +29,9 @@ mod tests {
         /// round-trip, exercising the benchmark-ready trace object.
         #[test]
         fn fleetbench_loads_probe_at_its_lineage_address() {
+            if !dist_manifest_present() {
+                return;
+            }
             let mut bench = FleetBench::start();
             let engine = bench.spawn_headless();
             let addr = bench.load(engine, "probe");

--- a/crates/aether-substrate-bundle/tests/fleetbench_logs.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_logs.rs
@@ -17,7 +17,7 @@ mod tests {
 
         use aether_kinds::LogTailResult;
 
-        use crate::fleetbench::FleetBench;
+        use crate::fleetbench::{FleetBench, dist_manifest_present};
 
         /// Up to ~3s of bounded polling closes the wire→first-tick race:
         /// the headless chassis auto-ticks at 60Hz, so the probe's first
@@ -38,6 +38,9 @@ mod tests {
         /// walk.
         #[test]
         fn fleetbench_actor_logs_surface_the_probe_first_tick_entry() {
+            if !dist_manifest_present() {
+                return;
+            }
             let mut bench = FleetBench::start();
             let engine = bench.spawn_headless();
             let addr = bench.load(engine, "probe");

--- a/crates/aether-substrate-bundle/tests/fleetbench_mail.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_mail.rs
@@ -22,7 +22,7 @@ mod tests {
         use aether_kinds::{List, ListResult};
         use aether_test_fixtures::{ConfigEcho, ConfigQuery, ProbeConfig};
 
-        use crate::fleetbench::FleetBench;
+        use crate::fleetbench::{FleetBench, dist_manifest_present};
 
         /// Ping-pong (verify-first, the #1451 deferral): load
         /// `probe_with_config` with a seeded `ProbeConfig`, send it a
@@ -39,6 +39,9 @@ mod tests {
         /// mail rows.
         #[test]
         fn fleetbench_pingpong_echoes_typed_config() {
+            if !dist_manifest_present() {
+                return;
+            }
             let mut bench = FleetBench::start();
             let engine = bench.spawn_headless();
             let config = ProbeConfig {

--- a/crates/aether-substrate-bundle/tests/fleetbench_replace.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_replace.rs
@@ -19,7 +19,7 @@ mod tests {
         use aether_kinds::{ComponentCapabilities, LogTailResult, Tick};
         use aether_test_fixtures::SetRender;
 
-        use crate::fleetbench::FleetBench;
+        use crate::fleetbench::{FleetBench, dist_manifest_present};
 
         /// Load `probe` (handlers `SetRender` + `Tick`), then `replace`
         /// it with `aether_camera` (handlers `CameraCreate` + `Tick` +
@@ -31,6 +31,9 @@ mod tests {
         /// must still route to the live mailbox afterward.
         #[test]
         fn fleetbench_replaces_probe_with_camera_at_a_stable_address() {
+            if !dist_manifest_present() {
+                return;
+            }
             let mut bench = FleetBench::start();
             let engine = bench.spawn_headless();
             let loaded = bench.load_full(engine, "probe");

--- a/crates/aether-substrate-bundle/tests/fleetbench_transform_dag.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_transform_dag.rs
@@ -32,7 +32,7 @@ mod tests {
         use aether_math::Vec4;
         use aether_test_fixtures::{Mat4SourceTrigger, Vec4Observed};
 
-        use crate::fleetbench::FleetBench;
+        use crate::fleetbench::{FleetBench, dist_manifest_present};
 
         /// The observer's surfaced output file, under the `save`
         /// namespace. The `vec4_observer` fixture writes the resolved
@@ -47,6 +47,9 @@ mod tests {
         /// `Mat4Apply` / `Vec4` round-trip across the real wire.
         #[test]
         fn fleetbench_transform_dag_observer_sees_m_times_v() {
+            if !dist_manifest_present() {
+                return;
+            }
             let mut bench = FleetBench::start();
             let engine = bench.spawn_headless();
 

--- a/crates/aether-substrate-bundle/tests/replace_drop_reply_routing.rs
+++ b/crates/aether-substrate-bundle/tests/replace_drop_reply_routing.rs
@@ -23,7 +23,7 @@ mod tests {
             DropComponent, DropResult, LoadComponent, LoadResult, ReplaceComponent, ReplaceResult,
         };
 
-        use crate::fleetbench::{FleetBench, read_component_wasm};
+        use crate::fleetbench::{FleetBench, dist_manifest_present, read_component_wasm};
 
         /// Load the `probe` component, then drive a `ReplaceComponent`
         /// and a `DropComponent` to its cap over the real wire and assert
@@ -34,6 +34,9 @@ mod tests {
         /// reply set came back empty.
         #[test]
         fn forwarded_replace_and_drop_route_their_reply() {
+            if !dist_manifest_present() {
+                return;
+            }
             let mut bench = FleetBench::start();
             let engine = bench.spawn_headless();
             let wasm = read_component_wasm("probe");


### PR DESCRIPTION
Closes #1654.

## Summary

`read_component_wasm` panicked when `dist/manifest.json` was absent, so a bare `cargo nextest run` in a worktree that had not run `cargo xtask dist` reported hard failures across every FleetBench scenario — a missing build artifact masquerading as a regression. This adds a manifest-presence guard helper to `tests/fleetbench/mod.rs` following the issue-891 skip-with-reason convention and the `AETHER_REQUIRE_RUNTIME=1` panic flip from `headless_autoload.rs`: manifest present proceeds, absent + flag unset skips with a `skipping:` stderr line, absent + flag set panics. Every test that transitively reaches `read_component_wasm` is guarded. `read_component_wasm` keeps its panic for the present-but-stale-stem case.

## Test plan

- fmt / clippy --workspace --all-targets / cargo doc --workspace --no-deps: clean.
- nextest --workspace: green (1619 passed, 6 skipped).
- Manifest present: all fleetbench tests pass, behavior unchanged.
- Manifest renamed away: the loading tests pass with `skipping: …` stderr lines, no panic.
- Manifest absent + `AETHER_REQUIRE_RUNTIME=1`: hard panic, as designed.
- CI already exports `AETHER_REQUIRE_RUNTIME=1` for the heavy nextest step the fleetbench tests run under, so a missing pre-build stays a hard CI failure.

## Generated by

`/implement` — agent execution of scoped issue #1654.
