### PR TITLE
chore(rpc): add license.workspace = true to aether-rpc

### DIFF
--- a/crates/aether-rpc/Cargo.toml
+++ b/crates/aether-rpc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aether-rpc"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 # ADR-0102: the RPC wire vocabulary + the `Call` client primitive,
 # extracted out of `aether-capabilities` so they live in a crate with no


### PR DESCRIPTION
Closes #1652.

## Summary

`crates/aether-rpc` was the only workspace member whose `Cargo.toml` carried no license metadata — it landed just before `license = "MIT OR Apache-2.0"` reached `[workspace.package]`, so there was no workspace key to inherit at the time. This adds `license.workspace = true` under `[package]`, the same inheritance idiom every other member uses.

## Test plan

`cargo metadata` reports `MIT OR Apache-2.0` for `aether-rpc`, matching every other member. Full preflight (fmt/clippy/nextest/doc) green.

## Generated by

`/implement` — agent execution of scoped issue #1652.
