### PR TITLE
flake(substrate): move the contention-sensitive spawn-actor wire test into mod heavy

### DIFF
--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -2572,885 +2572,988 @@ mod tests {
 
             drop(chassis);
         }
-    }
 
-    /// Issue 607 Phase 4b verify: a `ctx.monitor(target)` registration
-    /// fires exactly one `MonitorNotice` at the watcher when the
-    /// target self-shuts. Two-actor scenario: Watcher (instanced)
-    /// holds a `MonitorHandle` against Target (instanced) and counts
-    /// the notices it receives; Target self-shuts on `Quit`. After
-    /// the close fan-out we assert (1) the watcher saw the notice
-    /// once with the right target id, (2) the target's slot is Dead +
-    /// tombstoned, and (3) the registry's forward index drained.
-    #[test]
-    fn ctx_monitor_fires_notice_at_target_close() {
-        use crate::actor::native::spawn::Subname;
-        use crate::mail::registry::MailboxEntry;
-        use aether_actor::{HandlesKind, Instanced};
-        use aether_data::{Kind, KindId as DataKindId};
-        use std::sync::Mutex;
-        use std::sync::atomic::{AtomicU32, AtomicU64, Ordering as AtomicOrdering};
+        /// Issue 607 Phase 4b verify: a `ctx.monitor(target)` registration
+        /// fires exactly one `MonitorNotice` at the watcher when the
+        /// target self-shuts. Two-actor scenario: Watcher (instanced)
+        /// holds a `MonitorHandle` against Target (instanced) and counts
+        /// the notices it receives; Target self-shuts on `Quit`. After
+        /// the close fan-out we assert (1) the watcher saw the notice
+        /// once with the right target id, (2) the target's slot is Dead +
+        /// tombstoned, and (3) the registry's forward index drained.
+        #[test]
+        fn ctx_monitor_fires_notice_at_target_close() {
+            use crate::actor::native::spawn::Subname;
+            use crate::mail::registry::MailboxEntry;
+            use aether_actor::{HandlesKind, Instanced};
+            use aether_data::{Kind, KindId as DataKindId};
+            use std::sync::Mutex;
+            use std::sync::atomic::{AtomicU32, AtomicU64, Ordering as AtomicOrdering};
 
-        // Self-shutdown trigger for the target.
-        #[repr(C)]
-        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-        struct Quit {
-            tag: u32,
-        }
-        impl Kind for Quit {
-            const NAME: &'static str = "test.monitor.quit";
-            const ID: DataKindId = DataKindId(0xC0DE_C0DE_4B4B_4B4B);
-            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != size_of::<Self>() {
-                    return None;
+            // Self-shutdown trigger for the target.
+            #[repr(C)]
+            #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+            struct Quit {
+                tag: u32,
+            }
+            impl Kind for Quit {
+                const NAME: &'static str = "test.monitor.quit";
+                const ID: DataKindId = DataKindId(0xC0DE_C0DE_4B4B_4B4B);
+                fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+                    if bytes.len() != size_of::<Self>() {
+                        return None;
+                    }
+                    Some(bytemuck::pod_read_unaligned(bytes))
                 }
-                Some(bytemuck::pod_read_unaligned(bytes))
-            }
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
-        }
-
-        // Tells the watcher which target to monitor. The watcher's
-        // handler reads `target_id` and calls `ctx.monitor`.
-        #[repr(C)]
-        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-        struct WatchOrder {
-            target_id: u64,
-        }
-        impl Kind for WatchOrder {
-            const NAME: &'static str = "test.monitor.watch_order";
-            const ID: DataKindId = DataKindId(0x4B4B_C0DE_C0DE_C0DE);
-            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != size_of::<Self>() {
-                    return None;
+                fn encode_into_bytes(&self) -> Vec<u8> {
+                    bytemuck::bytes_of(self).to_vec()
                 }
-                Some(bytemuck::pod_read_unaligned(bytes))
             }
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
-        }
 
-        // Target — handles Quit by self-shutting.
-        struct Target;
-        impl Actor for Target {
-            const NAMESPACE: &'static str = "test.monitor.target";
-        }
-        impl Instanced for Target {}
-        impl HandlesKind<Quit> for Target {}
-        impl NativeActor for Target {
-            type Config = ();
-            fn init((): Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-                Ok(Self)
+            // Tells the watcher which target to monitor. The watcher's
+            // handler reads `target_id` and calls `ctx.monitor`.
+            #[repr(C)]
+            #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+            struct WatchOrder {
+                target_id: u64,
             }
-        }
-        impl NativeDispatch for Target {
-            fn __aether_dispatch_envelope(
-                &mut self,
-                ctx: &mut NativeCtx<'_>,
-                kind: KindId,
-                payload: &[u8],
-            ) -> Option<()> {
-                if kind.0 == Quit::ID.0 {
-                    let _ = Quit::decode_from_bytes(payload)?;
-                    ctx.shutdown();
-                    return Some(());
+            impl Kind for WatchOrder {
+                const NAME: &'static str = "test.monitor.watch_order";
+                const ID: DataKindId = DataKindId(0x4B4B_C0DE_C0DE_C0DE);
+                fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+                    if bytes.len() != size_of::<Self>() {
+                        return None;
+                    }
+                    Some(bytemuck::pod_read_unaligned(bytes))
                 }
-                None
-            }
-        }
-
-        // Watcher — handles WatchOrder by registering a monitor;
-        // handles MonitorNotice by recording the target id and
-        // bumping a counter.
-        struct Watcher {
-            notice_count: Arc<AtomicU32>,
-            last_target: Arc<AtomicU64>,
-            handle: Mutex<Option<MonitorHandle>>,
-        }
-        impl Actor for Watcher {
-            const NAMESPACE: &'static str = "test.monitor.watcher";
-        }
-        impl Instanced for Watcher {}
-        impl HandlesKind<WatchOrder> for Watcher {}
-        impl HandlesKind<aether_kinds::MonitorNotice> for Watcher {}
-        impl NativeActor for Watcher {
-            type Config = (Arc<AtomicU32>, Arc<AtomicU64>);
-            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-                Ok(Self {
-                    notice_count: config.0,
-                    last_target: config.1,
-                    handle: Mutex::new(None),
-                })
-            }
-        }
-        impl NativeDispatch for Watcher {
-            fn __aether_dispatch_envelope(
-                &mut self,
-                ctx: &mut NativeCtx<'_>,
-                kind: KindId,
-                payload: &[u8],
-            ) -> Option<()> {
-                if kind.0 == WatchOrder::ID.0 {
-                    let order = WatchOrder::decode_from_bytes(payload)?;
-                    let target = MailboxId(order.target_id);
-                    let h = ctx
-                        .monitor(target)
-                        .expect("target must be Live at order time");
-                    *self.handle.lock().unwrap() = Some(h);
-                    return Some(());
+                fn encode_into_bytes(&self) -> Vec<u8> {
+                    bytemuck::bytes_of(self).to_vec()
                 }
-                if kind.0 == <aether_kinds::MonitorNotice as Kind>::ID.0 {
-                    let notice = <aether_kinds::MonitorNotice as Kind>::decode_from_bytes(payload)?;
-                    self.last_target
-                        .store(notice.target.0, AtomicOrdering::SeqCst);
-                    self.notice_count.fetch_add(1, AtomicOrdering::SeqCst);
-                    return Some(());
+            }
+
+            // Target — handles Quit by self-shutting.
+            struct Target;
+            impl Actor for Target {
+                const NAMESPACE: &'static str = "test.monitor.target";
+            }
+            impl Instanced for Target {}
+            impl HandlesKind<Quit> for Target {}
+            impl NativeActor for Target {
+                type Config = ();
+                fn init((): Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+                    Ok(Self)
                 }
-                None
             }
-        }
-
-        let (registry, mailer) = fresh_substrate();
-        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .build_passive()
-            .expect("empty chassis boots");
-
-        // Spawn target first so the watcher can register against a
-        // Live id.
-        let target_id = chassis
-            .spawn_actor::<Target>(Subname::Counter, ())
-            .finish()
-            .expect("spawn target");
-
-        let notice_count = Arc::new(AtomicU32::new(0));
-        let last_target = Arc::new(AtomicU64::new(0));
-        let watcher_id = chassis
-            .spawn_actor::<Watcher>(
-                Subname::Counter,
-                (Arc::clone(&notice_count), Arc::clone(&last_target)),
-            )
-            .finish()
-            .expect("spawn watcher");
-
-        // Drive the watcher to register the monitor by pushing a
-        // WatchOrder through its sink handler. After this returns
-        // the watcher's handle is stored in `self.handle`.
-        let MailboxEntry::Inbox {
-            handler: watcher_handler,
-            ..
-        } = registry.entry(watcher_id).expect("watcher sink registered")
-        else {
-            panic!("expected mailbox entry for watcher");
-        };
-        let order = WatchOrder {
-            target_id: target_id.0,
-        };
-        watcher_handler.enqueue(registry::test_owned_dispatch(
-            <WatchOrder as Kind>::ID,
-            WatchOrder::NAME,
-            &order.encode_into_bytes(),
-            1,
-        ));
-
-        // Wait until the registry sees the monitor entry.
-        let deadline = Instant::now() + Duration::from_millis(500);
-        while chassis.actor_registry().monitor_count(target_id) == 0 && Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(5));
-        }
-        assert_eq!(
-            chassis.actor_registry().monitor_count(target_id),
-            1,
-            "watcher's monitor should be registered against target",
-        );
-        assert_eq!(
-            chassis.actor_registry().monitoring_count(watcher_id),
-            1,
-            "watcher should appear in the reverse index",
-        );
-
-        // Fire Quit at the target — its handler self-shuts; the
-        // dispatcher's close path runs `close_actor`, which fans out
-        // a MonitorNotice mail to watcher_id.
-        let MailboxEntry::Inbox {
-            handler: target_handler,
-            ..
-        } = registry.entry(target_id).expect("target sink registered")
-        else {
-            panic!("expected mailbox entry for target");
-        };
-        target_handler.enqueue(registry::test_owned_dispatch(
-            <Quit as Kind>::ID,
-            Quit::NAME,
-            &(Quit { tag: 1 }).encode_into_bytes(),
-            1,
-        ));
-
-        // Wait for the notice to land at the watcher.
-        let deadline = Instant::now() + Duration::from_millis(500);
-        while notice_count.load(AtomicOrdering::SeqCst) == 0 && Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(5));
-        }
-        assert_eq!(
-            notice_count.load(AtomicOrdering::SeqCst),
-            1,
-            "watcher should have received exactly one MonitorNotice",
-        );
-        assert_eq!(
-            last_target.load(AtomicOrdering::SeqCst),
-            target_id.0,
-            "MonitorNotice.target should match the closed actor's id",
-        );
-
-        // Wait for target slot to flip Dead (the close path runs
-        // close_actor → mark_dead after fan-out).
-        let deadline = Instant::now() + Duration::from_millis(500);
-        while chassis.actor_registry().is_live(target_id) && Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(5));
-        }
-        assert!(
-            !chassis.actor_registry().is_live(target_id),
-            "target slot should transition Live → Dead after close fan-out",
-        );
-        assert!(
-            chassis.actor_registry().is_tombstoned(target_id),
-            "target id should be tombstoned",
-        );
-        // Forward index for target was drained.
-        assert_eq!(
-            chassis.actor_registry().monitor_count(target_id),
-            0,
-            "monitors_of[target] must drain after fan-out",
-        );
-
-        drop(chassis);
-    }
-
-    /// Issue 607 Phase 4b verify: when the *watcher* dies first, the
-    /// reverse-index walk prunes the watcher's entry from each
-    /// monitored target's `monitors_of`. No `MonitorNotice` fires (the
-    /// watcher is the one closing; targets are still alive).
-    #[test]
-    fn watcher_close_prunes_targets_forward_index() {
-        use crate::actor::native::spawn::Subname;
-        use crate::mail::registry::MailboxEntry;
-        use aether_actor::{HandlesKind, Instanced};
-        use aether_data::{Kind, KindId as DataKindId};
-        use std::sync::Mutex;
-        use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
-
-        // Re-use Quit + WatchOrder shape inline (test isolation).
-        #[repr(C)]
-        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-        struct Quit {
-            tag: u32,
-        }
-        impl Kind for Quit {
-            const NAME: &'static str = "test.monitor.quit2";
-            const ID: DataKindId = DataKindId(0xCAFE_BABE_DEAD_BEEF);
-            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != size_of::<Self>() {
-                    return None;
+            impl NativeDispatch for Target {
+                fn __aether_dispatch_envelope(
+                    &mut self,
+                    ctx: &mut NativeCtx<'_>,
+                    kind: KindId,
+                    payload: &[u8],
+                ) -> Option<()> {
+                    if kind.0 == Quit::ID.0 {
+                        let _ = Quit::decode_from_bytes(payload)?;
+                        ctx.shutdown();
+                        return Some(());
+                    }
+                    None
                 }
-                Some(bytemuck::pod_read_unaligned(bytes))
             }
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
+
+            // Watcher — handles WatchOrder by registering a monitor;
+            // handles MonitorNotice by recording the target id and
+            // bumping a counter.
+            struct Watcher {
+                notice_count: Arc<AtomicU32>,
+                last_target: Arc<AtomicU64>,
+                handle: Mutex<Option<MonitorHandle>>,
             }
-        }
-        #[repr(C)]
-        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-        struct WatchOrder {
-            target_id: u64,
-        }
-        impl Kind for WatchOrder {
-            const NAME: &'static str = "test.monitor.watch_order2";
-            const ID: DataKindId = DataKindId(0xBEEF_DEAD_BABE_CAFE);
-            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != size_of::<Self>() {
-                    return None;
+            impl Actor for Watcher {
+                const NAMESPACE: &'static str = "test.monitor.watcher";
+            }
+            impl Instanced for Watcher {}
+            impl HandlesKind<WatchOrder> for Watcher {}
+            impl HandlesKind<aether_kinds::MonitorNotice> for Watcher {}
+            impl NativeActor for Watcher {
+                type Config = (Arc<AtomicU32>, Arc<AtomicU64>);
+                fn init(
+                    config: Self::Config,
+                    _ctx: &mut NativeInitCtx<'_>,
+                ) -> Result<Self, BootError> {
+                    Ok(Self {
+                        notice_count: config.0,
+                        last_target: config.1,
+                        handle: Mutex::new(None),
+                    })
                 }
-                Some(bytemuck::pod_read_unaligned(bytes))
             }
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
-        }
-
-        struct Target;
-        impl Actor for Target {
-            const NAMESPACE: &'static str = "test.monitor.target2";
-        }
-        impl Instanced for Target {}
-        impl NativeActor for Target {
-            type Config = ();
-            fn init((): Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-                Ok(Self)
-            }
-        }
-        impl NativeDispatch for Target {
-            fn __aether_dispatch_envelope(
-                &mut self,
-                _ctx: &mut NativeCtx<'_>,
-                _kind: KindId,
-                _payload: &[u8],
-            ) -> Option<()> {
-                None
-            }
-        }
-
-        struct Watcher {
-            handle: Mutex<Option<MonitorHandle>>,
-            close_observed: Arc<AtomicU32>,
-        }
-        impl Actor for Watcher {
-            const NAMESPACE: &'static str = "test.monitor.watcher2";
-        }
-        impl Instanced for Watcher {}
-        impl HandlesKind<WatchOrder> for Watcher {}
-        impl HandlesKind<Quit> for Watcher {}
-        impl NativeActor for Watcher {
-            type Config = Arc<AtomicU32>;
-            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-                Ok(Self {
-                    handle: Mutex::new(None),
-                    close_observed: config,
-                })
-            }
-            fn unwire(&mut self, _ctx: &mut NativeCtx<'_>) {
-                self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
-            }
-        }
-        impl NativeDispatch for Watcher {
-            fn __aether_dispatch_envelope(
-                &mut self,
-                ctx: &mut NativeCtx<'_>,
-                kind: KindId,
-                payload: &[u8],
-            ) -> Option<()> {
-                if kind.0 == WatchOrder::ID.0 {
-                    let order = WatchOrder::decode_from_bytes(payload)?;
-                    let target = MailboxId(order.target_id);
-                    let h = ctx.monitor(target).expect("target Live");
-                    *self.handle.lock().unwrap() = Some(h);
-                    return Some(());
+            impl NativeDispatch for Watcher {
+                fn __aether_dispatch_envelope(
+                    &mut self,
+                    ctx: &mut NativeCtx<'_>,
+                    kind: KindId,
+                    payload: &[u8],
+                ) -> Option<()> {
+                    if kind.0 == WatchOrder::ID.0 {
+                        let order = WatchOrder::decode_from_bytes(payload)?;
+                        let target = MailboxId(order.target_id);
+                        let h = ctx
+                            .monitor(target)
+                            .expect("target must be Live at order time");
+                        *self.handle.lock().unwrap() = Some(h);
+                        return Some(());
+                    }
+                    if kind.0 == <aether_kinds::MonitorNotice as Kind>::ID.0 {
+                        let notice =
+                            <aether_kinds::MonitorNotice as Kind>::decode_from_bytes(payload)?;
+                        self.last_target
+                            .store(notice.target.0, AtomicOrdering::SeqCst);
+                        self.notice_count.fetch_add(1, AtomicOrdering::SeqCst);
+                        return Some(());
+                    }
+                    None
                 }
-                if kind.0 == Quit::ID.0 {
-                    let _ = Quit::decode_from_bytes(payload)?;
-                    ctx.shutdown();
-                    return Some(());
+            }
+
+            let (registry, mailer) = fresh_substrate();
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .build_passive()
+                .expect("empty chassis boots");
+
+            // Spawn target first so the watcher can register against a
+            // Live id.
+            let target_id = chassis
+                .spawn_actor::<Target>(Subname::Counter, ())
+                .finish()
+                .expect("spawn target");
+
+            let notice_count = Arc::new(AtomicU32::new(0));
+            let last_target = Arc::new(AtomicU64::new(0));
+            let watcher_id = chassis
+                .spawn_actor::<Watcher>(
+                    Subname::Counter,
+                    (Arc::clone(&notice_count), Arc::clone(&last_target)),
+                )
+                .finish()
+                .expect("spawn watcher");
+
+            // Drive the watcher to register the monitor by pushing a
+            // WatchOrder through its sink handler. After this returns
+            // the watcher's handle is stored in `self.handle`.
+            let MailboxEntry::Inbox {
+                handler: watcher_handler,
+                ..
+            } = registry.entry(watcher_id).expect("watcher sink registered")
+            else {
+                panic!("expected mailbox entry for watcher");
+            };
+            let order = WatchOrder {
+                target_id: target_id.0,
+            };
+            watcher_handler.enqueue(registry::test_owned_dispatch(
+                <WatchOrder as Kind>::ID,
+                WatchOrder::NAME,
+                &order.encode_into_bytes(),
+                1,
+            ));
+
+            // Wait until the registry sees the monitor entry.
+            let deadline = Instant::now() + Duration::from_millis(500);
+            while chassis.actor_registry().monitor_count(target_id) == 0
+                && Instant::now() < deadline
+            {
+                thread::sleep(Duration::from_millis(5));
+            }
+            assert_eq!(
+                chassis.actor_registry().monitor_count(target_id),
+                1,
+                "watcher's monitor should be registered against target",
+            );
+            assert_eq!(
+                chassis.actor_registry().monitoring_count(watcher_id),
+                1,
+                "watcher should appear in the reverse index",
+            );
+
+            // Fire Quit at the target — its handler self-shuts; the
+            // dispatcher's close path runs `close_actor`, which fans out
+            // a MonitorNotice mail to watcher_id.
+            let MailboxEntry::Inbox {
+                handler: target_handler,
+                ..
+            } = registry.entry(target_id).expect("target sink registered")
+            else {
+                panic!("expected mailbox entry for target");
+            };
+            target_handler.enqueue(registry::test_owned_dispatch(
+                <Quit as Kind>::ID,
+                Quit::NAME,
+                &(Quit { tag: 1 }).encode_into_bytes(),
+                1,
+            ));
+
+            // Wait for the notice to land at the watcher.
+            let deadline = Instant::now() + Duration::from_millis(500);
+            while notice_count.load(AtomicOrdering::SeqCst) == 0 && Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(5));
+            }
+            assert_eq!(
+                notice_count.load(AtomicOrdering::SeqCst),
+                1,
+                "watcher should have received exactly one MonitorNotice",
+            );
+            assert_eq!(
+                last_target.load(AtomicOrdering::SeqCst),
+                target_id.0,
+                "MonitorNotice.target should match the closed actor's id",
+            );
+
+            // Wait for target slot to flip Dead (the close path runs
+            // close_actor → mark_dead after fan-out).
+            let deadline = Instant::now() + Duration::from_millis(500);
+            while chassis.actor_registry().is_live(target_id) && Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(5));
+            }
+            assert!(
+                !chassis.actor_registry().is_live(target_id),
+                "target slot should transition Live → Dead after close fan-out",
+            );
+            assert!(
+                chassis.actor_registry().is_tombstoned(target_id),
+                "target id should be tombstoned",
+            );
+            // Forward index for target was drained.
+            assert_eq!(
+                chassis.actor_registry().monitor_count(target_id),
+                0,
+                "monitors_of[target] must drain after fan-out",
+            );
+
+            drop(chassis);
+        }
+
+        /// Issue 607 Phase 4b verify: when the *watcher* dies first, the
+        /// reverse-index walk prunes the watcher's entry from each
+        /// monitored target's `monitors_of`. No `MonitorNotice` fires (the
+        /// watcher is the one closing; targets are still alive).
+        #[test]
+        fn watcher_close_prunes_targets_forward_index() {
+            use crate::actor::native::spawn::Subname;
+            use crate::mail::registry::MailboxEntry;
+            use aether_actor::{HandlesKind, Instanced};
+            use aether_data::{Kind, KindId as DataKindId};
+            use std::sync::Mutex;
+            use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+
+            // Re-use Quit + WatchOrder shape inline (test isolation).
+            #[repr(C)]
+            #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+            struct Quit {
+                tag: u32,
+            }
+            impl Kind for Quit {
+                const NAME: &'static str = "test.monitor.quit2";
+                const ID: DataKindId = DataKindId(0xCAFE_BABE_DEAD_BEEF);
+                fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+                    if bytes.len() != size_of::<Self>() {
+                        return None;
+                    }
+                    Some(bytemuck::pod_read_unaligned(bytes))
                 }
-                None
-            }
-        }
-
-        let (registry, mailer) = fresh_substrate();
-        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .build_passive()
-            .expect("empty chassis boots");
-
-        let target_id = chassis
-            .spawn_actor::<Target>(Subname::Counter, ())
-            .finish()
-            .expect("spawn target");
-        let close_observed = Arc::new(AtomicU32::new(0));
-        let watcher_id = chassis
-            .spawn_actor::<Watcher>(Subname::Counter, Arc::clone(&close_observed))
-            .finish()
-            .expect("spawn watcher");
-
-        // Watcher registers monitor against target.
-        let MailboxEntry::Inbox {
-            handler: watcher_handler,
-            ..
-        } = registry.entry(watcher_id).expect("watcher sink registered")
-        else {
-            panic!("expected mailbox entry for watcher");
-        };
-        let order = WatchOrder {
-            target_id: target_id.0,
-        };
-        watcher_handler.enqueue(registry::test_owned_dispatch(
-            <WatchOrder as Kind>::ID,
-            WatchOrder::NAME,
-            &order.encode_into_bytes(),
-            1,
-        ));
-
-        // Wait for register to land.
-        let deadline = Instant::now() + Duration::from_millis(500);
-        while chassis.actor_registry().monitor_count(target_id) == 0 && Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(5));
-        }
-        assert_eq!(chassis.actor_registry().monitor_count(target_id), 1);
-
-        // Quit watcher — its close path walks `monitoring[watcher]` and
-        // prunes watcher from `monitors_of[target]`.
-        watcher_handler.enqueue(registry::test_owned_dispatch(
-            <Quit as Kind>::ID,
-            Quit::NAME,
-            &(Quit { tag: 1 }).encode_into_bytes(),
-            1,
-        ));
-
-        let deadline = Instant::now() + Duration::from_millis(500);
-        while close_observed.load(AtomicOrdering::SeqCst) == 0 && Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(5));
-        }
-        assert_eq!(
-            close_observed.load(AtomicOrdering::SeqCst),
-            1,
-            "watcher's unwire fired exactly once",
-        );
-
-        // Watcher slot tombstones; target slot still Live; target's
-        // forward index drained of the dead watcher.
-        let deadline = Instant::now() + Duration::from_millis(500);
-        while chassis.actor_registry().is_live(watcher_id) && Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(5));
-        }
-        assert!(
-            chassis.actor_registry().is_tombstoned(watcher_id),
-            "watcher tombstoned",
-        );
-        assert!(
-            chassis.actor_registry().is_live(target_id),
-            "target should still be Live (watcher closed, not target)",
-        );
-        assert_eq!(
-            chassis.actor_registry().monitor_count(target_id),
-            0,
-            "target's monitors_of should drop the dead watcher",
-        );
-
-        drop(chassis);
-    }
-
-    /// Issue 607 Phase 5 verify: `resolve_actor` and `resolve_actors`
-    /// against a multi-instance fixture. Spawns three instanced actors
-    /// under one type, asserts:
-    ///   - `resolve_actor::<A>("a")` finds the named instance.
-    ///   - `resolve_actor::<A>("missing")` returns `None`.
-    ///   - `resolve_actors::<A>()` enumerates all three (subname-keyed).
-    ///   - After one closes, the iterator drops to two and the closed
-    ///     name returns `None` from `resolve_actor`.
-    #[test]
-    fn resolve_actor_finds_named_instance_resolve_actors_enumerates() {
-        use crate::actor::native::spawn::Subname;
-        use crate::mail::registry::MailboxEntry;
-        use aether_actor::{HandlesKind, Instanced};
-        use aether_data::{Kind, KindId as DataKindId};
-        use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
-
-        #[repr(C)]
-        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-        struct Quit {
-            tag: u32,
-        }
-        impl Kind for Quit {
-            const NAME: &'static str = "test.resolve.quit";
-            const ID: DataKindId = DataKindId(0xF00D_F00D_F00D_F00D);
-            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != size_of::<Self>() {
-                    return None;
+                fn encode_into_bytes(&self) -> Vec<u8> {
+                    bytemuck::bytes_of(self).to_vec()
                 }
-                Some(bytemuck::pod_read_unaligned(bytes))
             }
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
+            #[repr(C)]
+            #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+            struct WatchOrder {
+                target_id: u64,
             }
-        }
-
-        // The `tag` field is set at init from the per-instance config
-        // and would be read by handler code; Phase A's resolve_actor
-        // returns MailboxId rather than `Arc<Member>` so the tag is no
-        // longer externally observable. Kept as an init payload so the
-        // spawn path covers the full Config-threaded shape.
-        #[allow(dead_code)]
-        struct Member {
-            tag: u32,
-        }
-        impl Actor for Member {
-            const NAMESPACE: &'static str = "test.resolve.member";
-        }
-        impl Instanced for Member {}
-        impl HandlesKind<Quit> for Member {}
-        impl NativeActor for Member {
-            type Config = u32;
-            fn init(tag: u32, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-                Ok(Self { tag })
-            }
-        }
-        impl NativeDispatch for Member {
-            fn __aether_dispatch_envelope(
-                &mut self,
-                ctx: &mut NativeCtx<'_>,
-                kind: KindId,
-                payload: &[u8],
-            ) -> Option<()> {
-                if kind.0 == Quit::ID.0 {
-                    let _ = Quit::decode_from_bytes(payload)?;
-                    ctx.shutdown();
-                    return Some(());
+            impl Kind for WatchOrder {
+                const NAME: &'static str = "test.monitor.watch_order2";
+                const ID: DataKindId = DataKindId(0xBEEF_DEAD_BABE_CAFE);
+                fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+                    if bytes.len() != size_of::<Self>() {
+                        return None;
+                    }
+                    Some(bytemuck::pod_read_unaligned(bytes))
                 }
-                None
-            }
-        }
-
-        let (registry, mailer) = fresh_substrate();
-        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .build_passive()
-            .expect("empty chassis boots");
-
-        let id_a = chassis
-            .spawn_actor::<Member>(Subname::Named("a"), 1)
-            .finish()
-            .expect("spawn a");
-        let _id_b = chassis
-            .spawn_actor::<Member>(Subname::Named("b"), 2)
-            .finish()
-            .expect("spawn b");
-        let id_c = chassis
-            .spawn_actor::<Member>(Subname::Named("c"), 3)
-            .finish()
-            .expect("spawn c");
-
-        // Issue 629 / Phase A: resolve_actor returns the address
-        // (`MailboxId`), not `Arc<A>`. Verify the address resolves and
-        // matches the spawn-time id.
-        let a_id = chassis.resolve_actor::<Member>("a").expect("a is live");
-        assert_eq!(a_id, id_a, "resolve_actor returns the matching MailboxId");
-
-        // Missing subname → None.
-        assert!(
-            chassis.resolve_actor::<Member>("missing").is_none(),
-            "unknown subname should return None",
-        );
-
-        // resolve_actors enumerates all three. Order is registry-defined
-        // (HashMap iteration), so collect into a sorted subname vec for
-        // assertions. The Member's per-instance tag is dispatcher-thread
-        // owned (Phase A) and not externally observable here; the
-        // subname uniquely identifies the instance.
-        let mut all: Vec<String> = chassis
-            .resolve_actors::<Member>()
-            .into_iter()
-            .map(|(name, _id)| name)
-            .collect();
-        all.sort();
-        assert_eq!(
-            all,
-            vec!["a".to_owned(), "b".to_owned(), "c".to_owned()],
-            "resolve_actors should enumerate every Live instance subname",
-        );
-
-        // Close c — Quit it through the sink handler. After close,
-        // resolve_actors drops to two and resolve_actor::<Member>("c")
-        // returns None.
-        let MailboxEntry::Inbox { handler, .. } = registry.entry(id_c).expect("c sink registered")
-        else {
-            panic!("expected mailbox entry for c");
-        };
-        handler.enqueue(registry::test_owned_dispatch(
-            <Quit as Kind>::ID,
-            Quit::NAME,
-            &(Quit { tag: 1 }).encode_into_bytes(),
-            1,
-        ));
-
-        // Wait for c's slot to flip Dead.
-        let deadline = Instant::now() + Duration::from_millis(500);
-        while chassis.actor_registry().is_live(id_c) && Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(5));
-        }
-
-        assert!(
-            chassis.resolve_actor::<Member>("c").is_none(),
-            "closed instance should disappear from resolve_actor",
-        );
-        let mut after: Vec<String> = chassis
-            .resolve_actors::<Member>()
-            .into_iter()
-            .map(|(name, _id)| name)
-            .collect();
-        after.sort();
-        assert_eq!(
-            after,
-            vec!["a".to_owned(), "b".to_owned()],
-            "resolve_actors should drop the closed instance",
-        );
-
-        // Counter for unused warning. (`_id_a` / `_id_b` retain their
-        // names elsewhere; this guard keeps the compiler happy.)
-        let _ = AtomicU32::new(0).load(AtomicOrdering::SeqCst);
-
-        drop(chassis);
-    }
-
-    /// Issue 607 Phase 5.5 verify: an instanced parent's handler calls
-    /// `ctx.spawn_child::<Grandchild>(...)` to launch an instanced
-    /// grandchild. Phase 3b shipped `Arc<Spawner>` threading through
-    /// every spawned actor's transport precisely so this works; this
-    /// test is the first end-to-end coverage of the instanced→instanced
-    /// path. Phase 6b (`TcpListenerActor` → `TcpSessionActor`) structurally
-    /// depends on this — listeners spawning sessions IS the recursive
-    /// case.
-    ///
-    /// Asserts:
-    ///   1. Grandchild's `MailboxId` is `Live` in the registry.
-    ///   2. `chassis.resolve_actor::<Grandchild>(name)` resolves it.
-    ///   3. Grandchild's `after_init` mail dispatches as its first
-    ///      envelope (received counter bumps to 1).
-    ///   4. Closing the parent does NOT cascade-close the grandchild —
-    ///      no parent-child shutdown coupling is wired by default;
-    ///      that's monitor-driven, opt-in.
-    #[test]
-    fn instanced_can_spawn_grandchild() {
-        use crate::actor::native::spawn::Subname;
-        use crate::mail::registry::MailboxEntry;
-        use aether_actor::{HandlesKind, Instanced};
-        use aether_data::{Kind, KindId as DataKindId};
-        use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
-
-        // Trigger to make the parent spawn its grandchild.
-        #[repr(C)]
-        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-        struct Hatch {
-            tag: u32,
-        }
-        impl Kind for Hatch {
-            const NAME: &'static str = "test.recursive.hatch";
-            const ID: DataKindId = DataKindId(0xA00A_A00A_A00A_A00A);
-            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != size_of::<Self>() {
-                    return None;
+                fn encode_into_bytes(&self) -> Vec<u8> {
+                    bytemuck::bytes_of(self).to_vec()
                 }
-                Some(bytemuck::pod_read_unaligned(bytes))
             }
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
-        }
 
-        // Pre-loaded onto the grandchild via after_init.
-        #[repr(C)]
-        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-        struct Ping {
-            tag: u32,
-        }
-        impl Kind for Ping {
-            const NAME: &'static str = "test.recursive.ping";
-            const ID: DataKindId = DataKindId(0xB00B_B00B_B00B_B00B);
-            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != size_of::<Self>() {
-                    return None;
+            struct Target;
+            impl Actor for Target {
+                const NAMESPACE: &'static str = "test.monitor.target2";
+            }
+            impl Instanced for Target {}
+            impl NativeActor for Target {
+                type Config = ();
+                fn init((): Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+                    Ok(Self)
                 }
-                Some(bytemuck::pod_read_unaligned(bytes))
             }
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
-        }
-
-        // Self-shutdown trigger for the parent.
-        #[repr(C)]
-        #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-        struct Quit {
-            tag: u32,
-        }
-        impl Kind for Quit {
-            const NAME: &'static str = "test.recursive.quit";
-            const ID: DataKindId = DataKindId(0xC00C_C00C_C00C_C00C);
-            fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-                if bytes.len() != size_of::<Self>() {
-                    return None;
+            impl NativeDispatch for Target {
+                fn __aether_dispatch_envelope(
+                    &mut self,
+                    _ctx: &mut NativeCtx<'_>,
+                    _kind: KindId,
+                    _payload: &[u8],
+                ) -> Option<()> {
+                    None
                 }
-                Some(bytemuck::pod_read_unaligned(bytes))
             }
-            fn encode_into_bytes(&self) -> Vec<u8> {
-                bytemuck::bytes_of(self).to_vec()
-            }
-        }
 
-        struct Grandchild {
-            received: Arc<AtomicU32>,
-        }
-        impl Actor for Grandchild {
-            const NAMESPACE: &'static str = "test.recursive.grandchild";
-        }
-        impl Instanced for Grandchild {}
-        impl HandlesKind<Ping> for Grandchild {}
-        impl NativeActor for Grandchild {
-            type Config = Arc<AtomicU32>;
-            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-                Ok(Self { received: config })
+            struct Watcher {
+                handle: Mutex<Option<MonitorHandle>>,
+                close_observed: Arc<AtomicU32>,
             }
-        }
-        impl NativeDispatch for Grandchild {
-            fn __aether_dispatch_envelope(
-                &mut self,
-                _ctx: &mut NativeCtx<'_>,
-                kind: KindId,
-                payload: &[u8],
-            ) -> Option<()> {
-                if kind.0 == Ping::ID.0 {
-                    let _ = Ping::decode_from_bytes(payload)?;
-                    self.received.fetch_add(1, AtomicOrdering::SeqCst);
-                    return Some(());
+            impl Actor for Watcher {
+                const NAMESPACE: &'static str = "test.monitor.watcher2";
+            }
+            impl Instanced for Watcher {}
+            impl HandlesKind<WatchOrder> for Watcher {}
+            impl HandlesKind<Quit> for Watcher {}
+            impl NativeActor for Watcher {
+                type Config = Arc<AtomicU32>;
+                fn init(
+                    config: Self::Config,
+                    _ctx: &mut NativeInitCtx<'_>,
+                ) -> Result<Self, BootError> {
+                    Ok(Self {
+                        handle: Mutex::new(None),
+                        close_observed: config,
+                    })
                 }
-                None
-            }
-        }
-
-        struct Parent {
-            grandchild_received: Arc<AtomicU32>,
-        }
-        impl Actor for Parent {
-            const NAMESPACE: &'static str = "test.recursive.parent";
-        }
-        impl Instanced for Parent {}
-        impl HandlesKind<Hatch> for Parent {}
-        impl HandlesKind<Quit> for Parent {}
-        impl NativeActor for Parent {
-            type Config = Arc<AtomicU32>;
-            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-                Ok(Self {
-                    grandchild_received: config,
-                })
-            }
-        }
-        impl NativeDispatch for Parent {
-            fn __aether_dispatch_envelope(
-                &mut self,
-                ctx: &mut NativeCtx<'_>,
-                kind: KindId,
-                payload: &[u8],
-            ) -> Option<()> {
-                if kind.0 == Hatch::ID.0 {
-                    let _ = Hatch::decode_from_bytes(payload)?;
-                    // Recursive spawn: instanced parent → instanced
-                    // grandchild. Pre-load a Ping so the grandchild's
-                    // first envelope dispatches without an external
-                    // mail step.
-                    let _id = ctx
-                        .spawn_child::<Grandchild>(
-                            Subname::Named("only"),
-                            Arc::clone(&self.grandchild_received),
-                        )
-                        .after_init(Ping { tag: 0xCAFE })
-                        .finish()
-                        .expect("recursive spawn must succeed");
-                    return Some(());
+                fn unwire(&mut self, _ctx: &mut NativeCtx<'_>) {
+                    self.close_observed.fetch_add(1, AtomicOrdering::SeqCst);
                 }
-                if kind.0 == Quit::ID.0 {
-                    let _ = Quit::decode_from_bytes(payload)?;
-                    ctx.shutdown();
-                    return Some(());
-                }
-                None
             }
+            impl NativeDispatch for Watcher {
+                fn __aether_dispatch_envelope(
+                    &mut self,
+                    ctx: &mut NativeCtx<'_>,
+                    kind: KindId,
+                    payload: &[u8],
+                ) -> Option<()> {
+                    if kind.0 == WatchOrder::ID.0 {
+                        let order = WatchOrder::decode_from_bytes(payload)?;
+                        let target = MailboxId(order.target_id);
+                        let h = ctx.monitor(target).expect("target Live");
+                        *self.handle.lock().unwrap() = Some(h);
+                        return Some(());
+                    }
+                    if kind.0 == Quit::ID.0 {
+                        let _ = Quit::decode_from_bytes(payload)?;
+                        ctx.shutdown();
+                        return Some(());
+                    }
+                    None
+                }
+            }
+
+            let (registry, mailer) = fresh_substrate();
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .build_passive()
+                .expect("empty chassis boots");
+
+            let target_id = chassis
+                .spawn_actor::<Target>(Subname::Counter, ())
+                .finish()
+                .expect("spawn target");
+            let close_observed = Arc::new(AtomicU32::new(0));
+            let watcher_id = chassis
+                .spawn_actor::<Watcher>(Subname::Counter, Arc::clone(&close_observed))
+                .finish()
+                .expect("spawn watcher");
+
+            // Watcher registers monitor against target.
+            let MailboxEntry::Inbox {
+                handler: watcher_handler,
+                ..
+            } = registry.entry(watcher_id).expect("watcher sink registered")
+            else {
+                panic!("expected mailbox entry for watcher");
+            };
+            let order = WatchOrder {
+                target_id: target_id.0,
+            };
+            watcher_handler.enqueue(registry::test_owned_dispatch(
+                <WatchOrder as Kind>::ID,
+                WatchOrder::NAME,
+                &order.encode_into_bytes(),
+                1,
+            ));
+
+            // Wait for register to land.
+            let deadline = Instant::now() + Duration::from_millis(500);
+            while chassis.actor_registry().monitor_count(target_id) == 0
+                && Instant::now() < deadline
+            {
+                thread::sleep(Duration::from_millis(5));
+            }
+            assert_eq!(chassis.actor_registry().monitor_count(target_id), 1);
+
+            // Quit watcher — its close path walks `monitoring[watcher]` and
+            // prunes watcher from `monitors_of[target]`.
+            watcher_handler.enqueue(registry::test_owned_dispatch(
+                <Quit as Kind>::ID,
+                Quit::NAME,
+                &(Quit { tag: 1 }).encode_into_bytes(),
+                1,
+            ));
+
+            let deadline = Instant::now() + Duration::from_millis(500);
+            while close_observed.load(AtomicOrdering::SeqCst) == 0 && Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(5));
+            }
+            assert_eq!(
+                close_observed.load(AtomicOrdering::SeqCst),
+                1,
+                "watcher's unwire fired exactly once",
+            );
+
+            // Watcher slot tombstones; target slot still Live; target's
+            // forward index drained of the dead watcher.
+            let deadline = Instant::now() + Duration::from_millis(500);
+            while chassis.actor_registry().is_live(watcher_id) && Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(5));
+            }
+            assert!(
+                chassis.actor_registry().is_tombstoned(watcher_id),
+                "watcher tombstoned",
+            );
+            assert!(
+                chassis.actor_registry().is_live(target_id),
+                "target should still be Live (watcher closed, not target)",
+            );
+            assert_eq!(
+                chassis.actor_registry().monitor_count(target_id),
+                0,
+                "target's monitors_of should drop the dead watcher",
+            );
+
+            drop(chassis);
         }
 
-        let (registry, mailer) = fresh_substrate();
-        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .build_passive()
-            .expect("empty chassis boots");
+        /// Issue 607 Phase 5 verify: `resolve_actor` and `resolve_actors`
+        /// against a multi-instance fixture. Spawns three instanced actors
+        /// under one type, asserts:
+        ///   - `resolve_actor::<A>("a")` finds the named instance.
+        ///   - `resolve_actor::<A>("missing")` returns `None`.
+        ///   - `resolve_actors::<A>()` enumerates all three (subname-keyed).
+        ///   - After one closes, the iterator drops to two and the closed
+        ///     name returns `None` from `resolve_actor`.
+        #[test]
+        fn resolve_actor_finds_named_instance_resolve_actors_enumerates() {
+            use crate::actor::native::spawn::Subname;
+            use crate::mail::registry::MailboxEntry;
+            use aether_actor::{HandlesKind, Instanced};
+            use aether_data::{Kind, KindId as DataKindId};
+            use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 
-        let grandchild_received = Arc::new(AtomicU32::new(0));
-        let parent_id = chassis
-            .spawn_actor::<Parent>(Subname::Named("p1"), Arc::clone(&grandchild_received))
-            .finish()
-            .expect("spawn parent");
+            #[repr(C)]
+            #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+            struct Quit {
+                tag: u32,
+            }
+            impl Kind for Quit {
+                const NAME: &'static str = "test.resolve.quit";
+                const ID: DataKindId = DataKindId(0xF00D_F00D_F00D_F00D);
+                fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+                    if bytes.len() != size_of::<Self>() {
+                        return None;
+                    }
+                    Some(bytemuck::pod_read_unaligned(bytes))
+                }
+                fn encode_into_bytes(&self) -> Vec<u8> {
+                    bytemuck::bytes_of(self).to_vec()
+                }
+            }
 
-        // Trigger parent → grandchild spawn.
-        let MailboxEntry::Inbox {
-            handler: parent_handler,
-            ..
-        } = registry.entry(parent_id).expect("parent sink registered")
-        else {
-            panic!("expected mailbox entry for parent");
-        };
-        parent_handler.enqueue(registry::test_owned_dispatch(
-            <Hatch as Kind>::ID,
-            Hatch::NAME,
-            &(Hatch { tag: 1 }).encode_into_bytes(),
-            1,
-        ));
+            // The `tag` field is set at init from the per-instance config
+            // and would be read by handler code; Phase A's resolve_actor
+            // returns MailboxId rather than `Arc<Member>` so the tag is no
+            // longer externally observable. Kept as an init payload so the
+            // spawn path covers the full Config-threaded shape.
+            #[allow(dead_code)]
+            struct Member {
+                tag: u32,
+            }
+            impl Actor for Member {
+                const NAMESPACE: &'static str = "test.resolve.member";
+            }
+            impl Instanced for Member {}
+            impl HandlesKind<Quit> for Member {}
+            impl NativeActor for Member {
+                type Config = u32;
+                fn init(tag: u32, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+                    Ok(Self { tag })
+                }
+            }
+            impl NativeDispatch for Member {
+                fn __aether_dispatch_envelope(
+                    &mut self,
+                    ctx: &mut NativeCtx<'_>,
+                    kind: KindId,
+                    payload: &[u8],
+                ) -> Option<()> {
+                    if kind.0 == Quit::ID.0 {
+                        let _ = Quit::decode_from_bytes(payload)?;
+                        ctx.shutdown();
+                        return Some(());
+                    }
+                    None
+                }
+            }
 
-        // Wait for the grandchild's after_init Ping to dispatch (proves
-        // the recursive spawn happened AND the after_init plumbing
-        // works through it).
-        let deadline = Instant::now() + Duration::from_millis(500);
-        while grandchild_received.load(AtomicOrdering::SeqCst) == 0 && Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(5));
+            let (registry, mailer) = fresh_substrate();
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .build_passive()
+                .expect("empty chassis boots");
+
+            let id_a = chassis
+                .spawn_actor::<Member>(Subname::Named("a"), 1)
+                .finish()
+                .expect("spawn a");
+            let _id_b = chassis
+                .spawn_actor::<Member>(Subname::Named("b"), 2)
+                .finish()
+                .expect("spawn b");
+            let id_c = chassis
+                .spawn_actor::<Member>(Subname::Named("c"), 3)
+                .finish()
+                .expect("spawn c");
+
+            // Issue 629 / Phase A: resolve_actor returns the address
+            // (`MailboxId`), not `Arc<A>`. Verify the address resolves and
+            // matches the spawn-time id.
+            let a_id = chassis.resolve_actor::<Member>("a").expect("a is live");
+            assert_eq!(a_id, id_a, "resolve_actor returns the matching MailboxId");
+
+            // Missing subname → None.
+            assert!(
+                chassis.resolve_actor::<Member>("missing").is_none(),
+                "unknown subname should return None",
+            );
+
+            // resolve_actors enumerates all three. Order is registry-defined
+            // (HashMap iteration), so collect into a sorted subname vec for
+            // assertions. The Member's per-instance tag is dispatcher-thread
+            // owned (Phase A) and not externally observable here; the
+            // subname uniquely identifies the instance.
+            let mut all: Vec<String> = chassis
+                .resolve_actors::<Member>()
+                .into_iter()
+                .map(|(name, _id)| name)
+                .collect();
+            all.sort();
+            assert_eq!(
+                all,
+                vec!["a".to_owned(), "b".to_owned(), "c".to_owned()],
+                "resolve_actors should enumerate every Live instance subname",
+            );
+
+            // Close c — Quit it through the sink handler. After close,
+            // resolve_actors drops to two and resolve_actor::<Member>("c")
+            // returns None.
+            let MailboxEntry::Inbox { handler, .. } =
+                registry.entry(id_c).expect("c sink registered")
+            else {
+                panic!("expected mailbox entry for c");
+            };
+            handler.enqueue(registry::test_owned_dispatch(
+                <Quit as Kind>::ID,
+                Quit::NAME,
+                &(Quit { tag: 1 }).encode_into_bytes(),
+                1,
+            ));
+
+            // Wait for c's slot to flip Dead.
+            let deadline = Instant::now() + Duration::from_millis(500);
+            while chassis.actor_registry().is_live(id_c) && Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(5));
+            }
+
+            assert!(
+                chassis.resolve_actor::<Member>("c").is_none(),
+                "closed instance should disappear from resolve_actor",
+            );
+            let mut after: Vec<String> = chassis
+                .resolve_actors::<Member>()
+                .into_iter()
+                .map(|(name, _id)| name)
+                .collect();
+            after.sort();
+            assert_eq!(
+                after,
+                vec!["a".to_owned(), "b".to_owned()],
+                "resolve_actors should drop the closed instance",
+            );
+
+            // Counter for unused warning. (`_id_a` / `_id_b` retain their
+            // names elsewhere; this guard keeps the compiler happy.)
+            let _ = AtomicU32::new(0).load(AtomicOrdering::SeqCst);
+
+            drop(chassis);
         }
-        assert_eq!(
-            grandchild_received.load(AtomicOrdering::SeqCst),
-            1,
-            "grandchild's after_init Ping should dispatch as its first envelope",
-        );
 
-        // Grandchild is Live under the ADR-0099 §3 lineage fold. The
-        // parent was chassis-spawned (no parent → depth-1, carry == id),
-        // so the grandchild's id folds its node's ActorId onto the
-        // parent's id — not the flat `hash(NAMESPACE:subname)`.
-        let grandchild_id = MailboxId(aether_data::with_tag(
-            aether_data::Tag::Mailbox,
-            aether_data::fold_lineage(
-                parent_id.0,
-                aether_data::ActorId::instanced("test.recursive.grandchild", "only"),
-            ),
-        ));
-        assert!(
-            chassis.actor_registry().is_live(grandchild_id),
-            "grandchild should be Live in the registry under the lineage-folded id",
-        );
+        /// Issue 607 Phase 5.5 verify: an instanced parent's handler calls
+        /// `ctx.spawn_child::<Grandchild>(...)` to launch an instanced
+        /// grandchild. Phase 3b shipped `Arc<Spawner>` threading through
+        /// every spawned actor's transport precisely so this works; this
+        /// test is the first end-to-end coverage of the instanced→instanced
+        /// path. Phase 6b (`TcpListenerActor` → `TcpSessionActor`) structurally
+        /// depends on this — listeners spawning sessions IS the recursive
+        /// case.
+        ///
+        /// Asserts:
+        ///   1. Grandchild's `MailboxId` is `Live` in the registry.
+        ///   2. `chassis.resolve_actor::<Grandchild>(name)` resolves it.
+        ///   3. Grandchild's `after_init` mail dispatches as its first
+        ///      envelope (received counter bumps to 1).
+        ///   4. Closing the parent does NOT cascade-close the grandchild —
+        ///      no parent-child shutdown coupling is wired by default;
+        ///      that's monitor-driven, opt-in.
+        #[test]
+        fn instanced_can_spawn_grandchild() {
+            use crate::actor::native::spawn::Subname;
+            use crate::mail::registry::MailboxEntry;
+            use aether_actor::{HandlesKind, Instanced};
+            use aether_data::{Kind, KindId as DataKindId};
+            use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 
-        // Issue 629 / Phase A: resolve_actor returns the address.
-        // Verify it resolves and matches the registry id.
-        let resolved = chassis
-            .resolve_actor::<Grandchild>("only")
-            .expect("resolve_actor must find the grandchild");
-        assert_eq!(
-            resolved, grandchild_id,
-            "resolve_actor returns the matching MailboxId",
-        );
-        // The grandchild is alive (verifies the dispatcher's Arc<AtomicU32>
-        // is the same one passed in via config — the test's `received`
-        // counter sees handler dispatches against the live instance).
-        let _ = &grandchild_received;
+            // Trigger to make the parent spawn its grandchild.
+            #[repr(C)]
+            #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+            struct Hatch {
+                tag: u32,
+            }
+            impl Kind for Hatch {
+                const NAME: &'static str = "test.recursive.hatch";
+                const ID: DataKindId = DataKindId(0xA00A_A00A_A00A_A00A);
+                fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+                    if bytes.len() != size_of::<Self>() {
+                        return None;
+                    }
+                    Some(bytemuck::pod_read_unaligned(bytes))
+                }
+                fn encode_into_bytes(&self) -> Vec<u8> {
+                    bytemuck::bytes_of(self).to_vec()
+                }
+            }
 
-        // Closing the parent does NOT cascade-close the grandchild.
-        // Parent-child shutdown coupling is opt-in via monitor; without
-        // it, the grandchild keeps running.
-        parent_handler.enqueue(registry::test_owned_dispatch(
-            <Quit as Kind>::ID,
-            Quit::NAME,
-            &(Quit { tag: 1 }).encode_into_bytes(),
-            1,
-        ));
+            // Pre-loaded onto the grandchild via after_init.
+            #[repr(C)]
+            #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+            struct Ping {
+                tag: u32,
+            }
+            impl Kind for Ping {
+                const NAME: &'static str = "test.recursive.ping";
+                const ID: DataKindId = DataKindId(0xB00B_B00B_B00B_B00B);
+                fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+                    if bytes.len() != size_of::<Self>() {
+                        return None;
+                    }
+                    Some(bytemuck::pod_read_unaligned(bytes))
+                }
+                fn encode_into_bytes(&self) -> Vec<u8> {
+                    bytemuck::bytes_of(self).to_vec()
+                }
+            }
 
-        // Wait for parent slot to flip Dead.
-        let deadline = Instant::now() + Duration::from_millis(500);
-        while chassis.actor_registry().is_live(parent_id) && Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(5));
+            // Self-shutdown trigger for the parent.
+            #[repr(C)]
+            #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+            struct Quit {
+                tag: u32,
+            }
+            impl Kind for Quit {
+                const NAME: &'static str = "test.recursive.quit";
+                const ID: DataKindId = DataKindId(0xC00C_C00C_C00C_C00C);
+                fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+                    if bytes.len() != size_of::<Self>() {
+                        return None;
+                    }
+                    Some(bytemuck::pod_read_unaligned(bytes))
+                }
+                fn encode_into_bytes(&self) -> Vec<u8> {
+                    bytemuck::bytes_of(self).to_vec()
+                }
+            }
+
+            struct Grandchild {
+                received: Arc<AtomicU32>,
+            }
+            impl Actor for Grandchild {
+                const NAMESPACE: &'static str = "test.recursive.grandchild";
+            }
+            impl Instanced for Grandchild {}
+            impl HandlesKind<Ping> for Grandchild {}
+            impl NativeActor for Grandchild {
+                type Config = Arc<AtomicU32>;
+                fn init(
+                    config: Self::Config,
+                    _ctx: &mut NativeInitCtx<'_>,
+                ) -> Result<Self, BootError> {
+                    Ok(Self { received: config })
+                }
+            }
+            impl NativeDispatch for Grandchild {
+                fn __aether_dispatch_envelope(
+                    &mut self,
+                    _ctx: &mut NativeCtx<'_>,
+                    kind: KindId,
+                    payload: &[u8],
+                ) -> Option<()> {
+                    if kind.0 == Ping::ID.0 {
+                        let _ = Ping::decode_from_bytes(payload)?;
+                        self.received.fetch_add(1, AtomicOrdering::SeqCst);
+                        return Some(());
+                    }
+                    None
+                }
+            }
+
+            struct Parent {
+                grandchild_received: Arc<AtomicU32>,
+            }
+            impl Actor for Parent {
+                const NAMESPACE: &'static str = "test.recursive.parent";
+            }
+            impl Instanced for Parent {}
+            impl HandlesKind<Hatch> for Parent {}
+            impl HandlesKind<Quit> for Parent {}
+            impl NativeActor for Parent {
+                type Config = Arc<AtomicU32>;
+                fn init(
+                    config: Self::Config,
+                    _ctx: &mut NativeInitCtx<'_>,
+                ) -> Result<Self, BootError> {
+                    Ok(Self {
+                        grandchild_received: config,
+                    })
+                }
+            }
+            impl NativeDispatch for Parent {
+                fn __aether_dispatch_envelope(
+                    &mut self,
+                    ctx: &mut NativeCtx<'_>,
+                    kind: KindId,
+                    payload: &[u8],
+                ) -> Option<()> {
+                    if kind.0 == Hatch::ID.0 {
+                        let _ = Hatch::decode_from_bytes(payload)?;
+                        // Recursive spawn: instanced parent → instanced
+                        // grandchild. Pre-load a Ping so the grandchild's
+                        // first envelope dispatches without an external
+                        // mail step.
+                        let _id = ctx
+                            .spawn_child::<Grandchild>(
+                                Subname::Named("only"),
+                                Arc::clone(&self.grandchild_received),
+                            )
+                            .after_init(Ping { tag: 0xCAFE })
+                            .finish()
+                            .expect("recursive spawn must succeed");
+                        return Some(());
+                    }
+                    if kind.0 == Quit::ID.0 {
+                        let _ = Quit::decode_from_bytes(payload)?;
+                        ctx.shutdown();
+                        return Some(());
+                    }
+                    None
+                }
+            }
+
+            let (registry, mailer) = fresh_substrate();
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .build_passive()
+                .expect("empty chassis boots");
+
+            let grandchild_received = Arc::new(AtomicU32::new(0));
+            let parent_id = chassis
+                .spawn_actor::<Parent>(Subname::Named("p1"), Arc::clone(&grandchild_received))
+                .finish()
+                .expect("spawn parent");
+
+            // Trigger parent → grandchild spawn.
+            let MailboxEntry::Inbox {
+                handler: parent_handler,
+                ..
+            } = registry.entry(parent_id).expect("parent sink registered")
+            else {
+                panic!("expected mailbox entry for parent");
+            };
+            parent_handler.enqueue(registry::test_owned_dispatch(
+                <Hatch as Kind>::ID,
+                Hatch::NAME,
+                &(Hatch { tag: 1 }).encode_into_bytes(),
+                1,
+            ));
+
+            // Wait for the grandchild's after_init Ping to dispatch (proves
+            // the recursive spawn happened AND the after_init plumbing
+            // works through it).
+            let deadline = Instant::now() + Duration::from_millis(500);
+            while grandchild_received.load(AtomicOrdering::SeqCst) == 0 && Instant::now() < deadline
+            {
+                thread::sleep(Duration::from_millis(5));
+            }
+            assert_eq!(
+                grandchild_received.load(AtomicOrdering::SeqCst),
+                1,
+                "grandchild's after_init Ping should dispatch as its first envelope",
+            );
+
+            // Grandchild is Live under the ADR-0099 §3 lineage fold. The
+            // parent was chassis-spawned (no parent → depth-1, carry == id),
+            // so the grandchild's id folds its node's ActorId onto the
+            // parent's id — not the flat `hash(NAMESPACE:subname)`.
+            let grandchild_id = MailboxId(aether_data::with_tag(
+                aether_data::Tag::Mailbox,
+                aether_data::fold_lineage(
+                    parent_id.0,
+                    aether_data::ActorId::instanced("test.recursive.grandchild", "only"),
+                ),
+            ));
+            assert!(
+                chassis.actor_registry().is_live(grandchild_id),
+                "grandchild should be Live in the registry under the lineage-folded id",
+            );
+
+            // Issue 629 / Phase A: resolve_actor returns the address.
+            // Verify it resolves and matches the registry id.
+            let resolved = chassis
+                .resolve_actor::<Grandchild>("only")
+                .expect("resolve_actor must find the grandchild");
+            assert_eq!(
+                resolved, grandchild_id,
+                "resolve_actor returns the matching MailboxId",
+            );
+            // The grandchild is alive (verifies the dispatcher's Arc<AtomicU32>
+            // is the same one passed in via config — the test's `received`
+            // counter sees handler dispatches against the live instance).
+            let _ = &grandchild_received;
+
+            // Closing the parent does NOT cascade-close the grandchild.
+            // Parent-child shutdown coupling is opt-in via monitor; without
+            // it, the grandchild keeps running.
+            parent_handler.enqueue(registry::test_owned_dispatch(
+                <Quit as Kind>::ID,
+                Quit::NAME,
+                &(Quit { tag: 1 }).encode_into_bytes(),
+                1,
+            ));
+
+            // Wait for parent slot to flip Dead.
+            let deadline = Instant::now() + Duration::from_millis(500);
+            while chassis.actor_registry().is_live(parent_id) && Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(5));
+            }
+            assert!(
+                chassis.actor_registry().is_tombstoned(parent_id),
+                "parent should have tombstoned",
+            );
+            // Grandchild survives — no cascade.
+            assert!(
+                chassis.actor_registry().is_live(grandchild_id),
+                "grandchild should outlive parent (no automatic cascade-close)",
+            );
+            assert!(
+                chassis.resolve_actor::<Grandchild>("only").is_some(),
+                "grandchild remains resolvable after parent's death",
+            );
+
+            drop(chassis);
         }
-        assert!(
-            chassis.actor_registry().is_tombstoned(parent_id),
-            "parent should have tombstoned",
-        );
-        // Grandchild survives — no cascade.
-        assert!(
-            chassis.actor_registry().is_live(grandchild_id),
-            "grandchild should outlive parent (no automatic cascade-close)",
-        );
-        assert!(
-            chassis.resolve_actor::<Grandchild>("only").is_some(),
-            "grandchild remains resolvable after parent's death",
-        );
 
-        drop(chassis);
+        /// Issue 697 multi-pass model: wire-time mail crosses actors
+        /// regardless of declaration order. Pinger's `wire` mails Ponger;
+        /// Ponger's handler increments a counter. With Pinger declared
+        /// FIRST, a single-pass interleaved boot would have Pinger's wire
+        /// fire before Ponger's claim — the mail would warn-drop. The
+        /// multi-pass model (claim-all → init-all → wire-all → spawn-all)
+        /// claims both mailboxes before any wire runs, so the mail queues
+        /// in Ponger's inbox and processes once dispatchers come up.
+        #[test]
+        fn wire_pass_mail_crosses_actors_pinger_first() {
+            wire_pass_mail_crosses_actors(/* pinger_first */ true);
+        }
+
+        /// Mirror of [`wire_pass_mail_crosses_actors_pinger_first`] with
+        /// the registration order reversed. Multi-pass model means both
+        /// orderings are valid; this test pins the symmetry.
+        #[test]
+        fn wire_pass_mail_crosses_actors_ponger_first() {
+            wire_pass_mail_crosses_actors(/* pinger_first */ false);
+        }
+
+        /// Issue 584 Phase 2a runtime sibling: `Spawner::spawn_actor` runs
+        /// `wire` exactly once on a freshly-spawned instanced actor —
+        /// after `init` Ok and after the mailbox is published, before
+        /// pre-load mail or the dispatcher pull. Runtime spawn doesn't
+        /// need the chassis-boot multi-pass barrier (the substrate is
+        /// already steady-state).
+        #[test]
+        fn spawn_actor_runs_wire_once_after_init() {
+            use crate::actor::native::spawn::Subname;
+            use aether_actor::Instanced;
+            use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+
+            struct WireSpawnProbe {
+                wire_count: Arc<AtomicU32>,
+            }
+            impl Actor for WireSpawnProbe {
+                const NAMESPACE: &'static str = "test.spawn_wire.probe";
+            }
+            impl Instanced for WireSpawnProbe {}
+            impl NativeActor for WireSpawnProbe {
+                type Config = Arc<AtomicU32>;
+                fn init(
+                    config: Self::Config,
+                    _ctx: &mut NativeInitCtx<'_>,
+                ) -> Result<Self, BootError> {
+                    Ok(Self { wire_count: config })
+                }
+                fn wire(&mut self, _ctx: &mut NativeCtx<'_>) {
+                    self.wire_count.fetch_add(1, AtomicOrdering::SeqCst);
+                }
+            }
+            impl NativeDispatch for WireSpawnProbe {
+                fn __aether_dispatch_envelope(
+                    &mut self,
+                    _ctx: &mut NativeCtx<'_>,
+                    _kind: KindId,
+                    _payload: &[u8],
+                ) -> Option<()> {
+                    None
+                }
+            }
+
+            let (registry, mailer) = fresh_substrate();
+            let wire_count = Arc::new(AtomicU32::new(0));
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .build_passive()
+                .expect("empty chassis boots");
+
+            let id = chassis
+                .spawn_actor::<WireSpawnProbe>(Subname::Counter, Arc::clone(&wire_count))
+                .finish()
+                .expect("spawn instanced actor");
+
+            assert_eq!(
+                wire_count.load(AtomicOrdering::SeqCst),
+                1,
+                "wire must fire exactly once on Spawner::spawn_actor",
+            );
+
+            drop(chassis);
+            let _ = id;
+        }
     }
 
     /// Issue 584 Phase 2a / 697 wire pass: `wire` runs exactly once
@@ -3501,27 +3604,6 @@ mod tests {
         );
 
         drop(chassis);
-    }
-
-    /// Issue 697 multi-pass model: wire-time mail crosses actors
-    /// regardless of declaration order. Pinger's `wire` mails Ponger;
-    /// Ponger's handler increments a counter. With Pinger declared
-    /// FIRST, a single-pass interleaved boot would have Pinger's wire
-    /// fire before Ponger's claim — the mail would warn-drop. The
-    /// multi-pass model (claim-all → init-all → wire-all → spawn-all)
-    /// claims both mailboxes before any wire runs, so the mail queues
-    /// in Ponger's inbox and processes once dispatchers come up.
-    #[test]
-    fn wire_pass_mail_crosses_actors_pinger_first() {
-        wire_pass_mail_crosses_actors(/* pinger_first */ true);
-    }
-
-    /// Mirror of [`wire_pass_mail_crosses_actors_pinger_first`] with
-    /// the registration order reversed. Multi-pass model means both
-    /// orderings are valid; this test pins the symmetry.
-    #[test]
-    fn wire_pass_mail_crosses_actors_ponger_first() {
-        wire_pass_mail_crosses_actors(/* pinger_first */ false);
     }
 
     fn wire_pass_mail_crosses_actors(pinger_first: bool) {
@@ -3643,66 +3725,6 @@ mod tests {
         );
 
         drop(chassis);
-    }
-
-    /// Issue 584 Phase 2a runtime sibling: `Spawner::spawn_actor` runs
-    /// `wire` exactly once on a freshly-spawned instanced actor —
-    /// after `init` Ok and after the mailbox is published, before
-    /// pre-load mail or the dispatcher pull. Runtime spawn doesn't
-    /// need the chassis-boot multi-pass barrier (the substrate is
-    /// already steady-state).
-    #[test]
-    fn spawn_actor_runs_wire_once_after_init() {
-        use crate::actor::native::spawn::Subname;
-        use aether_actor::Instanced;
-        use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
-
-        struct WireSpawnProbe {
-            wire_count: Arc<AtomicU32>,
-        }
-        impl Actor for WireSpawnProbe {
-            const NAMESPACE: &'static str = "test.spawn_wire.probe";
-        }
-        impl Instanced for WireSpawnProbe {}
-        impl NativeActor for WireSpawnProbe {
-            type Config = Arc<AtomicU32>;
-            fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-                Ok(Self { wire_count: config })
-            }
-            fn wire(&mut self, _ctx: &mut NativeCtx<'_>) {
-                self.wire_count.fetch_add(1, AtomicOrdering::SeqCst);
-            }
-        }
-        impl NativeDispatch for WireSpawnProbe {
-            fn __aether_dispatch_envelope(
-                &mut self,
-                _ctx: &mut NativeCtx<'_>,
-                _kind: KindId,
-                _payload: &[u8],
-            ) -> Option<()> {
-                None
-            }
-        }
-
-        let (registry, mailer) = fresh_substrate();
-        let wire_count = Arc::new(AtomicU32::new(0));
-        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .build_passive()
-            .expect("empty chassis boots");
-
-        let id = chassis
-            .spawn_actor::<WireSpawnProbe>(Subname::Counter, Arc::clone(&wire_count))
-            .finish()
-            .expect("spawn instanced actor");
-
-        assert_eq!(
-            wire_count.load(AtomicOrdering::SeqCst),
-            1,
-            "wire must fire exactly once on Spawner::spawn_actor",
-        );
-
-        drop(chassis);
-        let _ = id;
     }
 
     /// Issue 745: `Some(0)` clamps to 1 since the pool requires at


### PR DESCRIPTION
Closes #1653.

## Summary

`spawn_actor_runs_wire_once_after_init` sat in the outer `mod tests` block instead of `mod heavy`, so nextest did not serialize it into the `serial-heavy` group — and it wedged the settlement gate under core oversubscription, flaking unrelated PRs' CI. This moves it (and the outer-module siblings sharing the boot-chassis + spawn-pooled-actor + sleep-poll + `drop(chassis)`-teardown profile) into `mod heavy`, where the `::heavy::` path segment routes them into the single-threaded group.

Moved: the target plus `ctx_monitor_fires_notice_at_target_close`, `watcher_close_prunes_targets_forward_index`, `resolve_actor_finds_named_instance_resolve_actors_enumerates`, `instanced_can_spawn_grandchild`, and both `wire_pass_mail_crosses_actors_*_first` wrappers. Left in the outer module: `with_actor_runs_wire_once_at_chassis_boot` (wire fires synchronously, no cross-thread wait) and the shared helper `wire_pass_mail_crosses_actors` (reached from `mod heavy` via `use super::*` per the doctrine).

## Test plan

- `cargo nextest list -E 'test(/::heavy::/)'` lists all 7 moved tests under `serial-heavy` on both the ci and default profiles.
- fmt/clippy/nextest --workspace/doc green.

## Generated by

`/implement` — agent execution of scoped issue #1653.
