### PR TITLE
docs(docs): remove the DCO sign-off requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,31 +10,6 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
-## Developer Certificate of Origin (DCO)
-
-Every commit must be signed off. The sign-off is your certification, under the
-[Developer Certificate of Origin](https://developercertificate.org/) (v1.1),
-that you wrote the contribution or otherwise have the right to submit it under
-the project's license. It is a lightweight attestation, not a copyright
-assignment — you keep the copyright in your work.
-
-Add the sign-off with `-s`:
-
-```
-git commit -s -m "your message"
-```
-
-That appends a trailer to the commit message:
-
-```
-Signed-off-by: Your Name <your@email.example>
-```
-
-If you wrote the contribution on an employer's time or equipment, confirm you
-actually have the right to contribute it before you sign off — and when in
-doubt, get your employer's sign-off too. The DCO is only as good as the
-representation behind it.
-
 ## Before you push
 
 The repository's pre-flight mirrors CI:

--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ at your option.
 
 ### Contribution
 
-Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions. See [CONTRIBUTING.md](CONTRIBUTING.md) for the sign-off (DCO) convention.
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions. See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.


### PR DESCRIPTION
Removes the Developer Certificate of Origin sign-off requirement. The probot DCO App is being uninstalled from the account, so the per-commit Signed-off-by ceremony no longer applies. Contributions remain inbound-dual-licensed under the existing Apache-2.0 / MIT terms stated in the licensing sections.

- Drop the DCO section from CONTRIBUTING.md
- Trim the README contribution pointer to drop the (DCO) convention reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)