### PR TITLE
docs(guide): type-system noteon example drifts from the real kind

### DIFF
--- a/docs/guide/foundations/type-system.md
+++ b/docs/guide/foundations/type-system.md
@@ -29,7 +29,7 @@ stable id, and a wire encoding. You declare one with two derives and a name:
 ```rust
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize)]
 #[kind(name = "aether.audio.note_on")]
-struct NoteOn { instrument: u8, pitch: u8, velocity: f32 }
+struct NoteOn { pitch: u8, velocity: u8, instrument_id: u8 }
 ```
 
 **Two derives, because they describe two different things.**


### PR DESCRIPTION
Closes #1671.

## Summary

The guide's kinds introduction declared `aether.audio.note_on` with fields the real kind doesn't have (`instrument: u8`, `velocity: f32`). Since the same page teaches that a kind's id is `hash(name + canonical(SCHEMA))`, the example described a kind whose id would differ from the real one — a trap for the agents who copy guide examples into components. The declaration now mirrors `aether-kinds`' `NoteOn` verbatim, in declaration order (order is part of the canonical schema the id hashes).

## Test plan

Docs-only — no code or tests. Verified the new field list matches `crates/aether-kinds/src/lib.rs` (`pitch: u8, velocity: u8, instrument_id: u8`) in declaration order.

## Generated by

`/implement` — agent execution of [scoped issue #1671](https://github.com/iamacoffeepot/aether/issues/1671).
