### PR TITLE
chore(repo): pin the rust toolchain so local preflight clippy matches ci

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.96.0"
+components = ["clippy", "rustfmt"]
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Closes #1677.

## Summary

Local clippy and CI clippy resolve different toolchains because nothing pins one. CI uses `dtolnay/rust-toolchain@stable` (1.96.0 today) while local `cargo clippy` uses whatever the developer's rustup has. The workspace sets `nursery = warn`, and nursery lints move between releases — 1.96's `clippy::suboptimal_flops` fires on multiply-add float expressions 1.95 does not flag — so `scripts/preflight.sh` can stamp a green pre-flight that the CI Clippy job then fails (hit live on PR #1675).

This adds a repo-root `rust-toolchain.toml` pinning `channel = "1.96.0"` with the `clippy` + `rustfmt` components and the `wasm32-unknown-unknown` target. No workflow change is needed: `dtolnay/rust-toolchain` selects via `rustup default` and does not export `RUSTUP_TOOLCHAIN`, so rustup's precedence puts the toolchain file above the default and every CI `cargo` invocation resolves the pin. `ci.yml`'s path filters already include `rust-toolchain.toml` in both the `code` and `qodana` change sets, so a future pin bump retriggers the full pipeline.

## Test plan

No Rust change — the local pre-flight is the gate. `rustup show active-toolchain` inside the repo reports `1.96.0` resolved from the override file; this PR's own CI Clippy job runs on the pinned toolchain (the job log prints the resolved version).

## Generated by

`/implement` — agent execution of [scoped issue #1677](https://github.com/iamacoffeepot/aether/issues/1677).
