### PR TITLE
fix(ci): force nightly for the fuzz build over the repo toolchain pin

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -28,6 +28,14 @@ jobs:
       # Per-run time box. 300s warm accretes coverage on top of the
       # persisted corpus rather than restarting cold each night.
       MAX_TOTAL_TIME: "300"
+      # The repo pins a stable toolchain in `rust-toolchain.toml`, which
+      # takes precedence over the nightly the step below installs as the
+      # default. cargo-fuzz builds with `-Zsanitizer=address`, a
+      # nightly-only flag, so the inner `cargo build` would resolve to
+      # stable and fail. `RUSTUP_TOOLCHAIN` sits above the toolchain file
+      # in rustup's override order and propagates to that nested build,
+      # forcing the whole fuzz build onto nightly without touching the pin.
+      RUSTUP_TOOLCHAIN: nightly
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## What

The nightly fuzz job has failed since 2026-06-12. The root rust-toolchain.toml added in #1681 pins stable 1.96.0, and a toolchain file takes precedence over the nightly that dtolnay/rust-toolchain installs as the default. cargo-fuzz builds with -Zsanitizer=address (nightly-only), so the inner cargo build resolved to stable and the job died before fuzzing:

```
error: the option `Z` is only accepted on the nightly compiler
Error: failed to build fuzz script: ... -Zsanitizer=address ...
```

## Fix

Set RUSTUP_TOOLCHAIN=nightly in the job env. It sits above rust-toolchain.toml in rustup's override order and propagates to the nested cargo build cargo-fuzz spawns, forcing the whole fuzz build onto nightly without touching the repo-wide pin.

## Notes

The earlier 2026-06-11 failure was a separate, genuine fuzzer find (allocation-size-too-big in decode_schema, issue #1638) already fixed by #1643's allocation clamp. This PR only addresses the toolchain-pin regression.

## Validation

CI-config-only; can't be unit-tested. Validate by dispatching the workflow on this branch once the PR is up.