### PR TITLE
feat(capabilities): sustain-loop support for sampled instrument banks

### DIFF
--- a/crates/aether-capabilities/src/audio.rs
+++ b/crates/aether-capabilities/src/audio.rs
@@ -88,6 +88,7 @@ mod native {
     use std::collections::HashMap;
     use std::collections::VecDeque;
     use std::f32::consts::TAU;
+    use std::io::Cursor;
     use std::str::from_utf8;
     use std::sync::Arc;
     use std::sync::mpsc;
@@ -107,7 +108,7 @@ mod native {
     use aether_substrate::chassis::error::BootError;
 
     use super::decode::{DecodeError, decode_wav_to_mono};
-    use super::sfz::{SfzRegion, parse_sfz};
+    use super::sfz::{SfzLoop, SfzRegion, parse_sfz};
     use super::{NoteOff, NoteOn, SetMasterGain};
 
     /// Linear fade-out duration (seconds) applied when a track is stopped,
@@ -1010,13 +1011,25 @@ mod native {
     /// dense chord doesn't clip past the soft-clip.
     const SAMPLE_BASE_AMP: f32 = 0.6;
 
+    /// A region's sustain loop in device-rate coordinates (ADR-0103 §6).
+    /// The SFZ frame offsets are scaled at bank assembly by the load-time
+    /// resample ratio into these fractional positions, so the kernel wrap
+    /// interpolates sub-sample and rounding never lands a click. `start`
+    /// and `end` index the region's device-rate PCM; the voice cycles the
+    /// half-open `[start, end)` interval while it sounds.
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    struct SampleLoop {
+        start: f32,
+        end: f32,
+    }
+
     /// One region of a sampled instrument bank (ADR-0103 §5/§6): a
     /// device-rate mono recording plus the inclusive MIDI key range it
-    /// covers, the inclusive velocity range it answers to, and the root
-    /// pitch it was recorded at (so a voice repitches by
-    /// `2^((pitch − pitch_keycenter) / 12)`). The PCM is `Arc`'d so every
-    /// region naming the same sample shares one buffer and a spawned voice
-    /// holds a cheap reference, not a copy.
+    /// covers, the inclusive velocity range it answers to, the root pitch
+    /// it was recorded at (so a voice repitches by
+    /// `2^((pitch − pitch_keycenter) / 12)`), and an optional sustain loop.
+    /// The PCM is `Arc`'d so every region naming the same sample shares one
+    /// buffer and a spawned voice holds a cheap reference, not a copy.
     #[derive(Clone, Debug)]
     struct SampleRegion {
         lokey: u8,
@@ -1025,6 +1038,9 @@ mod native {
         hivel: u8,
         pitch_keycenter: u8,
         pcm: Arc<[f32]>,
+        /// The sustain loop, or `None` for a full-decay region that plays
+        /// once and ends when its sample runs out.
+        loop_region: Option<SampleLoop>,
     }
 
     /// A loaded sampled-instrument bank (ADR-0103 §4/§5): the regions to
@@ -1049,11 +1065,15 @@ mod native {
         }
     }
 
-    /// The sample voice kernel (ADR-0103 §6, unlooped): walk the region's
-    /// device-rate PCM at a repitched rate with linear interpolation,
-    /// wrapped in the same short attack / `note_off`-release ramp the
-    /// partial bank uses. A held note ends when its sample runs out
-    /// (full-decay, piano-class sets) — sustain loops are #1682.
+    /// The sample voice kernel (ADR-0103 §6): walk the region's device-rate
+    /// PCM at a repitched rate with linear interpolation, wrapped in the
+    /// same short attack / `note_off`-release ramp the partial bank uses.
+    /// An unlooped region ends when its sample runs out (full-decay,
+    /// piano-class sets). A looped region cycles `[loop_start, loop_end)`
+    /// while it sounds — interpolating across the seam back to
+    /// `loop_start` — and holds the note indefinitely, ending only once the
+    /// `note_off` release ramp completes (the loop keeps cycling beneath
+    /// the fade).
     #[derive(Clone, Debug)]
     struct SampleVoice {
         /// Device-rate mono PCM of the selected region, shared with the
@@ -1069,12 +1089,16 @@ mod native {
         /// Velocity-scaled amplitude the interpolated sample is multiplied
         /// by.
         amplitude: f32,
+        /// The sustain loop bounds (device-rate fractional positions), or
+        /// `None` for an unlooped region.
+        loop_region: Option<SampleLoop>,
         /// Attack / release ramp, the partial bank's shape.
         stage: BankStage,
         attack_s: f32,
         release_s: f32,
-        /// Set once the read position walks off the end of the PCM (the
-        /// note's sample exhausted) or the release ramp completes.
+        /// Set once an unlooped region's read position walks off the end of
+        /// the PCM, or the release ramp completes. A looped voice never sets
+        /// it from exhaustion — it ends through the release ramp.
         finished: bool,
     }
 
@@ -1083,11 +1107,17 @@ mod native {
             let semitones = f32::from(pitch) - f32::from(region.pitch_keycenter);
             let rate = (semitones / 12.0).exp2();
             let v = f32::from(velocity) / 127.0;
+            // Drop a loop whose bounds collapsed (defensive — assembly only
+            // emits `start < end`): a non-positive span has no cycle.
+            let loop_region = region
+                .loop_region
+                .filter(|lp| lp.end > lp.start && lp.start >= 0.0);
             Self {
                 pcm: Arc::clone(&region.pcm),
                 pos: 0.0,
                 rate,
                 amplitude: SAMPLE_BASE_AMP * v,
+                loop_region,
                 stage: BankStage::Attack { t: 0.0 },
                 attack_s: SAMPLE_ATTACK_SECS,
                 release_s: SAMPLE_RELEASE_SECS,
@@ -1143,13 +1173,9 @@ mod native {
         }
 
         // Read position and PCM lengths are bounded well below 2^24 for any
-        // sane sample, so the index-to-float and float-to-index casts are
-        // exact and non-negative on the hot path.
-        #[allow(
-            clippy::cast_precision_loss,
-            clippy::cast_possible_truncation,
-            clippy::cast_sign_loss
-        )]
+        // sane sample, so the index-to-float and float-to-index casts in the
+        // looped / unlooped readers are exact and non-negative on the hot
+        // path.
         fn next_sample(&mut self, dt: f32) -> f32 {
             let ramp = self.advance_ramp(dt);
             if self.finished {
@@ -1160,6 +1186,20 @@ mod native {
                 self.finished = true;
                 return 0.0;
             }
+            match self.loop_region {
+                Some(lp) => self.next_looped(lp, len, ramp),
+                None => self.next_unlooped(len, ramp),
+            }
+        }
+
+        /// The unlooped read: linear interpolation over the PCM, ending the
+        /// voice once the read position walks off the end (ADR-0103 §6).
+        #[allow(
+            clippy::cast_precision_loss,
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss
+        )]
+        fn next_unlooped(&mut self, len: usize, ramp: f32) -> f32 {
             let i = self.pos.floor() as usize;
             if i >= len {
                 self.finished = true;
@@ -1171,9 +1211,48 @@ mod native {
             let s = (b - a).mul_add(frac, a) * self.amplitude * ramp;
             self.pos += self.rate;
             if self.pos >= len as f32 {
-                // The held note's sample ran out — the voice ends (no loop
-                // machinery in v1, ADR-0103 §6).
+                // The held note's sample ran out — an unlooped voice ends.
                 self.finished = true;
+            }
+            s
+        }
+
+        /// The looped read (ADR-0103 §6): interpolate within `[loop_start,
+        /// loop_end)`, wrapping back to `loop_start` at the seam so the
+        /// interpolation reads `loop_start` as the post-seam neighbour and
+        /// produces no discontinuity beyond interpolation error. The voice
+        /// never ends from exhaustion here — only the release ramp retires
+        /// it (the loop keeps cycling beneath the fade).
+        #[allow(
+            clippy::cast_precision_loss,
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss
+        )]
+        fn next_looped(&mut self, lp: SampleLoop, len: usize, ramp: f32) -> f32 {
+            // `pos < loop_end <= len` holds going in, so `i` is in range.
+            let i = (self.pos.floor() as usize).min(len - 1);
+            let a = self.pcm[i];
+            // The interpolation neighbour is the next frame — but if that
+            // frame reaches or crosses `loop_end`, the loop wraps, so read
+            // `loop_start` instead (the seam neighbour).
+            let next_index = if (i + 1) as f32 >= lp.end {
+                (lp.start.floor() as usize).min(len - 1)
+            } else {
+                i + 1
+            };
+            let b = self.pcm[next_index];
+            let frac = self.pos - i as f32;
+            let s = (b - a).mul_add(frac, a) * self.amplitude * ramp;
+
+            self.pos += self.rate;
+            if self.pos >= lp.end {
+                // Wrap the overshoot back into the loop region. Modulo the
+                // loop length so a rate larger than the span still lands in
+                // `[loop_start, loop_end)` in O(1).
+                let loop_len = lp.end - lp.start;
+                let over = self.pos - lp.end;
+                let wrapped = (over / loop_len).floor().mul_add(-loop_len, over);
+                self.pos = lp.start + wrapped;
             }
             s
         }
@@ -2259,22 +2338,29 @@ mod native {
         sample_bytes: &[(String, Vec<u8>)],
         target_rate: u32,
     ) -> BankAssemblyOutput {
-        let mut decoded: Vec<(String, Arc<[f32]>)> = Vec::with_capacity(sample_bytes.len());
+        // Decode each unique sample, carrying its source rate so loop frame
+        // offsets can be scaled by the same resample ratio applied to the
+        // PCM (ADR-0103 §6).
+        let mut decoded: Vec<(String, Arc<[f32]>, u32)> = Vec::with_capacity(sample_bytes.len());
         let mut resident_bytes = 0usize;
         for (rel, bytes) in sample_bytes {
             let pcm =
                 decode_wav_to_mono(bytes, target_rate).map_err(|e| format!("sample {rel}: {e}"))?;
+            let source_rate = wav_source_rate(bytes).map_err(|e| format!("sample {rel}: {e}"))?;
             resident_bytes += pcm.len() * size_of::<f32>();
-            decoded.push((rel.clone(), Arc::from(pcm.as_slice())));
+            decoded.push((rel.clone(), Arc::from(pcm.as_slice()), source_rate));
         }
 
         let mut bank_regions = Vec::with_capacity(regions.len());
         for region in regions {
-            let pcm = decoded
+            let (pcm, source_rate) = decoded
                 .iter()
-                .find(|(rel, _)| rel == &region.sample)
-                .map(|(_, pcm)| Arc::clone(pcm))
+                .find(|(rel, _, _)| rel == &region.sample)
+                .map(|(_, pcm, source_rate)| (Arc::clone(pcm), *source_rate))
                 .ok_or_else(|| format!("region references unfetched sample {}", region.sample))?;
+            let loop_region = region
+                .loop_spec
+                .and_then(|lp| scale_loop(lp, source_rate, target_rate, pcm.len()));
             bank_regions.push(SampleRegion {
                 lokey: region.lokey,
                 hikey: region.hikey,
@@ -2282,6 +2368,7 @@ mod native {
                 hivel: region.hivel,
                 pitch_keycenter: region.pitch_keycenter,
                 pcm,
+                loop_region,
             });
         }
 
@@ -2290,6 +2377,48 @@ mod native {
             regions: bank_regions,
             resident_bytes,
         }))
+    }
+
+    /// Read a WAV asset's source sample rate from its header (ADR-0103 §6).
+    /// Bank assembly needs it to scale a region's loop frame offsets by the
+    /// load-time resample ratio; `decode_wav_to_mono` consumes the same
+    /// header but only returns the resampled PCM. Parses the header chunk
+    /// only — the sample data is not read.
+    fn wav_source_rate(bytes: &[u8]) -> Result<u32, String> {
+        let reader = hound::WavReader::new(Cursor::new(bytes)).map_err(|e| e.to_string())?;
+        let rate = reader.spec().sample_rate;
+        if rate == 0 {
+            return Err("zero sample rate".to_owned());
+        }
+        Ok(rate)
+    }
+
+    /// Scale a region's source-frame loop bounds into device-rate fractional
+    /// positions (ADR-0103 §6): multiply by the resample ratio
+    /// `target_rate / source_rate` — the same ratio the PCM was resampled
+    /// by at load — and clamp `loop_end` to the resampled length. Returns
+    /// `None` when the resampled region is too short to loop or the bounds
+    /// collapse after clamping, degrading the region to unlooped.
+    #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+    fn scale_loop(
+        lp: SfzLoop,
+        source_rate: u32,
+        target_rate: u32,
+        resampled_len: usize,
+    ) -> Option<SampleLoop> {
+        if resampled_len < 2 || source_rate == 0 {
+            return None;
+        }
+        let ratio = f64::from(target_rate) / f64::from(source_rate);
+        let start = f64::from(lp.start) * ratio;
+        let end = (f64::from(lp.end) * ratio).min(resampled_len as f64);
+        if start + 1.0 >= end {
+            return None;
+        }
+        Some(SampleLoop {
+            start: start as f32,
+            end: end as f32,
+        })
     }
 
     /// The directory portion of an fs path (everything before the last
@@ -3907,6 +4036,21 @@ mod native {
                 hivel,
                 pitch_keycenter,
                 pcm: Arc::from(pcm),
+                loop_region: None,
+            }
+        }
+
+        /// A full-range region carrying a device-rate sustain loop over
+        /// `[start, end)`, for the sample-voice loop tests.
+        fn looped_region(pcm: Vec<f32>, start: f32, end: f32) -> SampleRegion {
+            SampleRegion {
+                lokey: 0,
+                hikey: 127,
+                lovel: 0,
+                hivel: 127,
+                pitch_keycenter: 60,
+                pcm: Arc::from(pcm),
+                loop_region: Some(SampleLoop { start, end }),
             }
         }
 
@@ -4086,6 +4230,189 @@ mod native {
                 n < 10_000,
                 "release ({n}) should end well before the sample exhausts",
             );
+        }
+
+        #[test]
+        fn looped_sample_voice_sustains_past_sample_length() {
+            // A 480-sample recording with a sustain loop holds the note far
+            // past its own length: the voice cycles the loop region rather
+            // than exhausting (ADR-0103 §6).
+            let region = looped_region(ramp(480), 100.0, 400.0);
+            let mut voice = SampleVoice::new(60, 100, &region);
+            let dt = 1.0 / TEST_RATE;
+            // Render past 2x the sample length while the key is held.
+            let mut sounded = false;
+            for _ in 0..1200 {
+                if voice.next_sample(dt).abs() > 0.0 {
+                    sounded = true;
+                }
+            }
+            assert!(
+                !voice.done(),
+                "held looped voice ended at sample exhaustion"
+            );
+            assert!(sounded, "held looped voice produced silence");
+        }
+
+        #[test]
+        fn looped_sample_voice_ends_on_note_off_release() {
+            // The loop holds the note open; note_off arms the release ramp,
+            // which retires the voice while the loop keeps cycling beneath
+            // it (ADR-0103 §6).
+            let region = looped_region(ramp(480), 100.0, 400.0);
+            let mut voice = SampleVoice::new(60, 100, &region);
+            let dt = 1.0 / TEST_RATE;
+            for _ in 0..2000 {
+                voice.next_sample(dt);
+            }
+            assert!(!voice.done(), "voice should still be held before note_off");
+            voice.note_off();
+            let mut n = 0;
+            while !voice.done() && n < 48_000 {
+                voice.next_sample(dt);
+                n += 1;
+            }
+            assert!(voice.done(), "released looped voice never ended");
+            assert!(
+                n < 10_000,
+                "release ({n}) should retire the voice within the ramp",
+            );
+        }
+
+        #[test]
+        fn loop_seam_produces_no_discontinuity() {
+            // A sine whose loop span is an exact multiple of its period
+            // wraps phase-continuously: the per-sample output delta across
+            // the seam stays in the band of an ordinary sine step, never the
+            // near-full-amplitude jump a naive (non-interpolating) wrap would
+            // inject (ADR-0103 §6).
+            const PERIOD: usize = 64;
+            #[allow(clippy::cast_precision_loss)]
+            let pcm: Vec<f32> = (0..512)
+                .map(|i| 0.5 * (TAU * i as f32 / PERIOD as f32).sin())
+                .collect();
+            // Loop span 256 == 4 * PERIOD, aligned to the period grid.
+            let region = looped_region(pcm, 128.0, 384.0);
+            let mut voice = SampleVoice::new(60, 100, &region);
+            let dt = 1.0 / TEST_RATE;
+            let mut prev = voice.next_sample(dt);
+            let mut max_delta = 0.0f32;
+            // Skip the attack ramp; sample well into the looped region across
+            // several wraps.
+            for n in 0..3000 {
+                let s = voice.next_sample(dt);
+                if n > 300 {
+                    max_delta = max_delta.max((s - prev).abs());
+                }
+                prev = s;
+            }
+            // An ordinary sine step at this amplitude is ~0.024; a discarded
+            // seam would jump by up to ~0.47. 0.05 cleanly separates them.
+            assert!(
+                max_delta < 0.05,
+                "loop seam introduced a discontinuity (max delta {max_delta})",
+            );
+        }
+
+        #[test]
+        fn assemble_bank_scales_loop_points_by_resample_ratio() {
+            // A source WAV at half the device rate resamples 2x at load, so
+            // the source-frame loop offsets scale 2x into device-rate
+            // positions (ADR-0103 §6).
+            let region = SfzRegion {
+                sample: "a.wav".to_owned(),
+                lokey: 0,
+                hikey: 127,
+                lovel: 0,
+                hivel: 127,
+                pitch_keycenter: 60,
+                loop_spec: Some(SfzLoop {
+                    start: 100,
+                    end: 400,
+                    mode: super::super::sfz::LoopMode::Continuous,
+                }),
+            };
+            let wav = super::super::decode::wav_int16_mono(&ramp(1000), 24_000);
+            let bank = assemble_bank(
+                "test".to_owned(),
+                &[region],
+                &[("a.wav".to_owned(), wav)],
+                48_000,
+            )
+            .expect("bank assembles");
+            let lp = bank.regions[0]
+                .loop_region
+                .expect("loop scaled through to the region");
+            assert!(
+                (lp.start - 200.0).abs() < 2.0,
+                "loop_start should scale ~2x to 200, got {}",
+                lp.start,
+            );
+            assert!(
+                (lp.end - 800.0).abs() < 2.0,
+                "loop_end should scale ~2x to 800, got {}",
+                lp.end,
+            );
+        }
+
+        #[test]
+        fn assemble_bank_clamps_loop_end_to_resampled_length() {
+            // A loop_end past the sample clamps to the resampled length
+            // rather than reading out of bounds (ADR-0103 §6).
+            let region = SfzRegion {
+                sample: "a.wav".to_owned(),
+                lokey: 0,
+                hikey: 127,
+                lovel: 0,
+                hivel: 127,
+                pitch_keycenter: 60,
+                loop_spec: Some(SfzLoop {
+                    start: 10,
+                    end: 100_000,
+                    mode: super::super::sfz::LoopMode::Continuous,
+                }),
+            };
+            let wav = super::super::decode::wav_int16_mono(&ramp(1000), 24_000);
+            let bank = assemble_bank(
+                "test".to_owned(),
+                &[region],
+                &[("a.wav".to_owned(), wav)],
+                48_000,
+            )
+            .expect("bank assembles");
+            let region = &bank.regions[0];
+            let lp = region.loop_region.expect("loop scaled through");
+            #[allow(clippy::cast_precision_loss)]
+            let len = region.pcm.len() as f32;
+            assert!(
+                lp.end <= len,
+                "loop_end {} must clamp to the resampled length {len}",
+                lp.end,
+            );
+        }
+
+        #[test]
+        fn unlooped_region_assembles_without_a_loop() {
+            // A region with no loop_spec stays unlooped through assembly
+            // (the piano-class regression path).
+            let region = SfzRegion {
+                sample: "a.wav".to_owned(),
+                lokey: 0,
+                hikey: 127,
+                lovel: 0,
+                hivel: 127,
+                pitch_keycenter: 60,
+                loop_spec: None,
+            };
+            let wav = super::super::decode::wav_int16_mono(&ramp(256), 24_000);
+            let bank = assemble_bank(
+                "test".to_owned(),
+                &[region],
+                &[("a.wav".to_owned(), wav)],
+                48_000,
+            )
+            .expect("bank assembles");
+            assert_eq!(bank.regions[0].loop_region, None);
         }
 
         #[test]

--- a/crates/aether-capabilities/src/audio/sfz.rs
+++ b/crates/aether-capabilities/src/audio/sfz.rs
@@ -15,25 +15,57 @@
 //!   Group opcodes are inherited by every following region until the next
 //!   `<group>`.
 //! - Opcodes: `sample`, `lokey` / `hikey`, `pitch_keycenter`,
-//!   `lovel` / `hivel`. The `sample` value runs to the end of the line so
-//!   filenames may carry spaces; the rest are single whitespace-delimited
-//!   tokens.
+//!   `lovel` / `hivel`, and the sustain-loop opcodes `loop_start` /
+//!   `loop_end` / `loop_mode` (ADR-0103 §5/§6, #1682). The `sample` value
+//!   runs to the end of the line so filenames may carry spaces; the rest
+//!   are single whitespace-delimited tokens.
 //! - `//` line comments are stripped.
 //!
-//! Everything outside that set — the loop opcodes (`loop_start` /
-//! `loop_end` / `loop_mode`, parked for #1682), envelope opcodes, unknown
-//! headers — warns and is ignored, so a real-world sample set loads rather
-//! than failing on the first opcode past the subset.
+//! A region carries a loop (`loop_spec`) when `loop_mode` is
+//! `loop_continuous` or `loop_sustain` and the source-frame offsets satisfy
+//! `loop_start < loop_end`; `loop_mode=no_loop`, a malformed mode value, or
+//! a degenerate offset pair warns and degrades to unlooped. Everything else
+//! outside the subset — envelope opcodes, unknown headers — warns and is
+//! ignored, so a real-world sample set loads rather than failing on the
+//! first opcode past the subset.
 
 use std::error::Error;
 use std::fmt;
 
+/// How a region's recorded sustain loops while a key is held (ADR-0103
+/// §6). The substrate approximates `Sustain` as `Continuous` (it keeps
+/// cycling through the release ramp rather than playing a post-loop tail),
+/// but the parser carries the distinction the file declared.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoopMode {
+    /// `loop_continuous`: cycle the loop region for as long as the voice
+    /// sounds, including under the release ramp.
+    Continuous,
+    /// `loop_sustain`: cycle only while the key is down. Approximated as
+    /// `Continuous` in the kernel — see ADR-0103 §6.
+    Sustain,
+}
+
+/// A region's sustain loop (ADR-0103 §6): the half-open frame interval
+/// `start..end` to cycle while the note sounds, plus the declared mode.
+/// The offsets are in the *source* sample's frames as written in the
+/// `.sfz`; bank assembly scales them by the load-time resample ratio into
+/// fractional device-rate positions (ADR-0103 §6). A loop is only emitted
+/// when `start < end`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SfzLoop {
+    pub start: u32,
+    pub end: u32,
+    pub mode: LoopMode,
+}
+
 /// One playable region of a bank: a sample, the inclusive MIDI key range
-/// it covers, the inclusive velocity range it answers to, and the root
-/// pitch the sample was recorded at (so the voice repitches by
-/// `2^((pitch − pitch_keycenter) / 12)`). `sample` is already resolved
-/// against the bank's `default_path`; the cap joins it with the `.sfz`
-/// file's own directory to address the WAV through `aether.fs`.
+/// it covers, the inclusive velocity range it answers to, the root pitch
+/// the sample was recorded at (so the voice repitches by
+/// `2^((pitch − pitch_keycenter) / 12)`), and an optional sustain loop.
+/// `sample` is already resolved against the bank's `default_path`; the cap
+/// joins it with the `.sfz` file's own directory to address the WAV
+/// through `aether.fs`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SfzRegion {
     pub sample: String,
@@ -42,6 +74,9 @@ pub struct SfzRegion {
     pub lovel: u8,
     pub hivel: u8,
     pub pitch_keycenter: u8,
+    /// The sustain loop, or `None` for a full-decay (piano-class) region
+    /// that plays once and ends when its sample runs out.
+    pub loop_spec: Option<SfzLoop>,
 }
 
 /// A parsed bank: the resolved region list. The referenced sample paths
@@ -112,6 +147,25 @@ enum Section {
     Region,
 }
 
+/// The parsed `loop_mode` opcode value as accumulated on an [`OpcodeSet`].
+/// Distinguishes "never set" from an explicit `no_loop` and from a
+/// malformed value, so inheritance and the warn-and-degrade rule both work
+/// off one field.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum LoopModeOpcode {
+    /// No `loop_mode` opcode seen on this region or its group.
+    Unset,
+    /// `loop_mode=no_loop` — explicitly unlooped.
+    NoLoop,
+    /// `loop_mode=loop_continuous`.
+    Continuous,
+    /// `loop_mode=loop_sustain`.
+    Sustain,
+    /// An unrecognised `loop_mode=…` value — already warned, degrades to
+    /// unlooped.
+    Malformed,
+}
+
 /// The mutable opcode set a region inherits from its group and then
 /// overrides. `sample` is `Option` because a region without one is not
 /// playable (skipped with a warn).
@@ -123,6 +177,9 @@ struct OpcodeSet {
     lovel: u8,
     hivel: u8,
     pitch_keycenter: u8,
+    loop_start: Option<u32>,
+    loop_end: Option<u32>,
+    loop_mode: LoopModeOpcode,
 }
 
 impl OpcodeSet {
@@ -134,6 +191,38 @@ impl OpcodeSet {
             lovel: DEFAULT_LOVEL,
             hivel: DEFAULT_HIVEL,
             pitch_keycenter: DEFAULT_PITCH_KEYCENTER,
+            loop_start: None,
+            loop_end: None,
+            loop_mode: LoopModeOpcode::Unset,
+        }
+    }
+
+    /// Resolve the accumulated loop opcodes into a [`SfzLoop`], or `None`
+    /// when the region is unlooped or the loop is malformed. A looping
+    /// `loop_mode` with absent or degenerate (`start >= end`) offsets warns
+    /// and degrades to unlooped (ADR-0103 §5).
+    fn resolve_loop(&self) -> Option<SfzLoop> {
+        let mode = match self.loop_mode {
+            LoopModeOpcode::Continuous => LoopMode::Continuous,
+            LoopModeOpcode::Sustain => LoopMode::Sustain,
+            // Unset / NoLoop / Malformed all mean no loop; Malformed
+            // already warned at parse time.
+            LoopModeOpcode::Unset | LoopModeOpcode::NoLoop | LoopModeOpcode::Malformed => {
+                return None;
+            }
+        };
+        match (self.loop_start, self.loop_end) {
+            (Some(start), Some(end)) if start < end => Some(SfzLoop { start, end, mode }),
+            _ => {
+                tracing::warn!(
+                    target: "aether_substrate::audio",
+                    loop_start = ?self.loop_start,
+                    loop_end = ?self.loop_end,
+                    "sfz: looping loop_mode with missing or degenerate loop points; \
+                     degrading region to unlooped",
+                );
+                None
+            }
         }
     }
 }
@@ -259,7 +348,7 @@ fn next_token(rest: &str) -> (&str, &str) {
 }
 
 /// Apply one `key=value` opcode to the current section's state. Unknown
-/// opcodes (including the parked loop points) warn and are ignored.
+/// opcodes warn and are ignored.
 fn apply_opcode(
     section: Section,
     default_path: &mut String,
@@ -298,7 +387,32 @@ fn apply_opcode(
         "pitch_keycenter" => {
             set.pitch_keycenter = parse_key(value).unwrap_or(set.pitch_keycenter);
         }
+        // Loop opcodes are frame offsets (`u32`) and a mode enum; a
+        // non-numeric offset keeps the inherited value, an unrecognised
+        // mode warns and forces the region unlooped (ADR-0103 §5).
+        "loop_start" => set.loop_start = value.parse::<u32>().ok().or(set.loop_start),
+        "loop_end" => set.loop_end = value.parse::<u32>().ok().or(set.loop_end),
+        "loop_mode" => set.loop_mode = parse_loop_mode(value),
         _ => warn_unknown_opcode(key),
+    }
+}
+
+/// Parse a `loop_mode` opcode value into the accumulator's tri-state. An
+/// unrecognised value warns and resolves to [`LoopModeOpcode::Malformed`]
+/// so the region degrades to unlooped (ADR-0103 §5).
+fn parse_loop_mode(value: &str) -> LoopModeOpcode {
+    match value {
+        "no_loop" => LoopModeOpcode::NoLoop,
+        "loop_continuous" => LoopModeOpcode::Continuous,
+        "loop_sustain" => LoopModeOpcode::Sustain,
+        other => {
+            tracing::warn!(
+                target: "aether_substrate::audio",
+                loop_mode = other,
+                "sfz: unrecognised loop_mode value; treating region as unlooped",
+            );
+            LoopModeOpcode::Malformed
+        }
     }
 }
 
@@ -324,6 +438,8 @@ fn flush_region(current: &mut Option<OpcodeSet>, regions: &mut Vec<SfzRegion>) {
     let Some(set) = current.take() else {
         return;
     };
+    // Resolve the loop before moving `sample` out of `set`.
+    let loop_spec = set.resolve_loop();
     let Some(sample) = set.sample else {
         tracing::warn!(
             target: "aether_substrate::audio",
@@ -338,6 +454,7 @@ fn flush_region(current: &mut Option<OpcodeSet>, regions: &mut Vec<SfzRegion>) {
         lovel: set.lovel,
         hivel: set.hivel,
         pitch_keycenter: set.pitch_keycenter,
+        loop_spec,
     });
 }
 
@@ -449,10 +566,10 @@ sample=c4.wav
     }
 
     #[test]
-    fn unknown_opcodes_including_loop_points_are_ignored() {
-        // The loop opcodes are deliberately outside this subset (#1682);
-        // they must warn-and-ignore like any other unknown opcode rather
-        // than fail the parse.
+    fn loop_opcodes_parse_and_unknown_opcodes_still_ignored() {
+        // The loop opcodes are in the subset (#1682) and carry through to
+        // the region; envelope / offset opcodes outside the subset still
+        // warn-and-ignore rather than failing the parse.
         let sfz = "\
 <region>
 sample=organ.wav
@@ -465,6 +582,114 @@ offset=0
         let spec = parse_sfz(sfz).expect("parses past unknown opcodes");
         assert_eq!(spec.regions.len(), 1);
         assert_eq!(spec.regions[0].sample, "organ.wav");
+        assert_eq!(
+            spec.regions[0].loop_spec,
+            Some(SfzLoop {
+                start: 128,
+                end: 4096,
+                mode: LoopMode::Continuous,
+            }),
+        );
+    }
+
+    #[test]
+    fn region_without_loop_opcodes_is_unlooped() {
+        let spec = parse_sfz("<region>\nsample=piano.wav\n").expect("parses");
+        assert_eq!(spec.regions[0].loop_spec, None);
+    }
+
+    #[test]
+    fn loop_sustain_mode_carries_through() {
+        let sfz = "<region>\nsample=strings.wav loop_mode=loop_sustain loop_start=0 loop_end=512\n";
+        let spec = parse_sfz(sfz).expect("parses");
+        assert_eq!(
+            spec.regions[0].loop_spec,
+            Some(SfzLoop {
+                start: 0,
+                end: 512,
+                mode: LoopMode::Sustain,
+            }),
+        );
+    }
+
+    #[test]
+    fn no_loop_mode_emits_no_loop_even_with_points() {
+        // An explicit `no_loop` keeps the region unlooped regardless of any
+        // loop_start / loop_end present.
+        let sfz = "<region>\nsample=a.wav loop_mode=no_loop loop_start=10 loop_end=20\n";
+        let spec = parse_sfz(sfz).expect("parses");
+        assert_eq!(spec.regions[0].loop_spec, None);
+    }
+
+    #[test]
+    fn loop_points_without_a_looping_mode_emit_no_loop() {
+        // The subset only loops when the mode says so (ADR-0103 §5/§6);
+        // bare loop points with no loop_mode stay unlooped.
+        let sfz = "<region>\nsample=a.wav loop_start=10 loop_end=20\n";
+        let spec = parse_sfz(sfz).expect("parses");
+        assert_eq!(spec.regions[0].loop_spec, None);
+    }
+
+    #[test]
+    fn loop_opcodes_at_group_level_are_inherited() {
+        let sfz = "\
+<group>
+loop_mode=loop_continuous loop_start=64 loop_end=1024
+<region>
+sample=a.wav lokey=60 hikey=60
+<region>
+sample=b.wav lokey=62 hikey=62
+";
+        let spec = parse_sfz(sfz).expect("parses");
+        assert_eq!(spec.regions.len(), 2);
+        for r in &spec.regions {
+            assert_eq!(
+                r.loop_spec,
+                Some(SfzLoop {
+                    start: 64,
+                    end: 1024,
+                    mode: LoopMode::Continuous,
+                }),
+                "group loop not inherited by {}",
+                r.sample,
+            );
+        }
+    }
+
+    #[test]
+    fn region_loop_opcodes_override_the_group() {
+        let sfz = "\
+<group>
+loop_mode=loop_continuous loop_start=64 loop_end=1024
+<region>
+sample=a.wav loop_end=2048
+";
+        let spec = parse_sfz(sfz).expect("parses");
+        assert_eq!(
+            spec.regions[0].loop_spec,
+            Some(SfzLoop {
+                start: 64,
+                end: 2048,
+                mode: LoopMode::Continuous,
+            }),
+            "region loop_end should override the inherited group value",
+        );
+    }
+
+    #[test]
+    fn degenerate_loop_points_degrade_to_unlooped() {
+        // start >= end is malformed: warn and emit no loop.
+        let sfz =
+            "<region>\nsample=a.wav loop_mode=loop_continuous loop_start=2048 loop_end=1024\n";
+        let spec = parse_sfz(sfz).expect("parses");
+        assert_eq!(spec.regions[0].loop_spec, None);
+    }
+
+    #[test]
+    fn unknown_loop_mode_value_degrades_to_unlooped() {
+        let sfz = "<region>\nsample=a.wav loop_mode=bounce loop_start=0 loop_end=512\n";
+        let spec = parse_sfz(sfz).expect("parses");
+        assert_eq!(spec.regions[0].loop_spec, None);
     }
 
     #[test]


### PR DESCRIPTION
Closes #1682.

## Summary

The sampled instrument banks #1679 landed play full-decay samples only — a held note ends when its sample runs out, which is correct for piano-class sets but wrong for organ/bowed strings that need to sustain. This adds SFZ sustain loops on top of that decode/voice machinery:

- **Parser** (`audio/sfz.rs`): `LoopMode` + `SfzLoop` types and a `loop_spec` field on `SfzRegion`; the `loop_start` / `loop_end` / `loop_mode` opcodes join the subset with group→region inheritance; `no_loop`, an unknown mode value, or `start >= end` warn-and-degrade to unlooped.
- **Bank assembly** (`audio.rs`): loop points arrive in source-sample frames, so they're scaled by the same resample ratio applied to the PCM at load time and stored as fractional device-rate bounds on the region; `loop_end` is clamped to the resampled length.
- **Kernel** (`audio.rs`): while a region's loop is active, `SampleVoice` wraps `loop_end → loop_start` with seam interpolation back to `loop_start`, holding the note until `note_off` starts the release ramp.

No new kinds, no wire change — entirely within `aether-capabilities`, building on the #1679 decode/voice core.

## Test plan

13 new loop unit tests (parser inheritance + degradation; loop-point resample scaling; kernel wrap, seam interpolation, release-after-loop). Full-workspace fmt / clippy / nextest (1700 passed) / doc and the qodana scope-diff scan (0 findings) pass locally.

## Generated by

`/implement` — agent execution of [scoped issue #1682](https://github.com/iamacoffeepot/aether/issues/1682).
