### PR TITLE
refactor(substrate): settlement obligations safe by construction, not by guard

### DIFF
--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -43,7 +43,8 @@ use aether_substrate::chassis::settlement::{
 };
 use aether_substrate::runtime::lifecycle;
 use aether_substrate::{
-    HubOutbound, Mailer, SharedActorSlots, Source, SourceAddr, SubstrateBoot,
+    ClaimedInbox, HubOutbound, InboundMail, Mailer, SharedActorSlots, Source, SourceAddr,
+    SubstrateBoot,
     chassis::frame_loop,
     mail::{Mail, MailId, MailboxId},
 };
@@ -58,7 +59,6 @@ use super::chassis::UserEvent;
 use super::render::Gpu;
 use aether_substrate::capture::{CaptureQueue, PendingCapture};
 use std::io;
-use std::sync::mpsc::Receiver;
 use std::time::Duration;
 use winit::dpi::PhysicalSize;
 
@@ -93,7 +93,7 @@ pub struct App {
     /// — keeps the back-to-back advances from racing the cap's overlap
     /// guard (the same reply-gate the test-bench frame loop uses,
     /// iamacoffeepot/aether#999).
-    lifecycle_reply_inbox: Receiver<Envelope>,
+    lifecycle_reply_inbox: ClaimedInbox,
     /// Mailbox id of [`Self::lifecycle_reply_inbox`], used as the
     /// `Component` reply target stamped onto each `LifecycleAdvance`.
     lifecycle_reply_mailbox: MailboxId,
@@ -157,7 +157,7 @@ pub struct App {
     /// runs and drains even under `ControlFlow::Wait` (set when the
     /// window occludes) — the case `aether.window.focus` most needs,
     /// since the loop is otherwise parked until a winit event arrives.
-    window_inbox: Receiver<Envelope>,
+    window_inbox: ClaimedInbox,
     /// Per-actor [`local::ActorSlots`] carried out of the
     /// [`aether_substrate::MailboxClaim`] this driver produced at boot.
     /// Stamped into TLS via [`local::with_stamped`] around
@@ -384,42 +384,6 @@ fn try_framework_dispatch(mailer: &Arc<Mailer>, self_mailbox: MailboxId, env: &E
         || dispatch_cost_tail_if_matching_free(m, env.sender, self_mailbox, env)
 }
 
-/// Discharge the ADR-0080 §2 settlement bracket for one inbound
-/// `aether.window` envelope. `aether.window` is an `Inbox`
-/// (actor-enqueue) mailbox: the mailer records *no* settlement bracket
-/// on the producer side (`mail/mailer.rs` `Inbox` arm), so the
-/// `InboxHandler` contract (`mail/registry.rs`, ADR-0080 §2) puts the
-/// obligation on the downstream consumer — this hand-rolled window
-/// drain. Without it the inbound Call's root `in_flight` never reaches
-/// zero, no `Settled` fires, no wire `ReplyEnd` is emitted, and a
-/// blocking `send_mail` to `set_mode` / `set_title` / `focus` hangs
-/// (iamacoffeepot/aether#1325, a recurrence of the #846 dropped-bracket
-/// class).
-///
-/// Mirrors the bracket template in
-/// [`DispatcherSlot::dispatch_one`](aether_substrate::actor::native)
-/// (`actor/native/dispatcher_slot.rs:289`): `record_finished` after the
-/// reply, so the reply child's `Sent` is accounted before the inbound
-/// parent's `Finished` (the #1150 flush-before-Finished ordering).
-///
-/// Deliberately **settlement-only**: it discharges `in_flight` via
-/// `record_finished` but does not additionally push `Received` /
-/// `Finished` `TraceEvent`s into the driver's per-actor ring the way
-/// `dispatch_one` does. The bug is a settlement leak, not a
-/// trace-visibility gap; full trace-event emission is a separable
-/// trace-fidelity change the minimal fix does not need.
-///
-/// Early-returns on `mail_id == MailId::NONE` for legible intent —
-/// `record_finished` also no-ops on `NONE`, so this is belt-and-braces
-/// for the chassis-internal window-size / frame-stats pushes minted with
-/// `MailId::NONE` roots via `push_chassis_root`.
-fn discharge_settlement(mailer: &Mailer, mail_id: MailId, root: MailId) {
-    if mail_id == MailId::NONE {
-        return;
-    }
-    mailer.record_finished(mail_id, root);
-}
-
 /// The disposition of one consumed `aether.lifecycle.advance_reply`
 /// envelope, returned by [`consume_lifecycle_reply`] to
 /// [`App::recv_lifecycle_advance_next`].
@@ -434,59 +398,33 @@ enum LifecycleReplyOutcome {
     Unexpected,
 }
 
-/// Consume one envelope off the lifecycle reply inbox, discharging its
-/// ADR-0094 obligation guard + ADR-0080 §2 settlement bracket exactly
-/// once — the same per-envelope bracket [`App::dispatch_window_envelope`]
-/// runs for the sibling `aether.window` inbox
-/// (iamacoffeepot/aether#1325), applied here at the lifecycle-reply
-/// consume site (iamacoffeepot/aether#1704).
+/// Consume one [`InboundMail`] off the lifecycle reply inbox. The mail's
+/// ADR-0094 obligation guard + ADR-0080 §2 settlement bracket discharge
+/// when the guard falls out of scope (ADR-0106) — the same scope-exit
+/// settle [`App::dispatch_window_envelope`] relies on for the sibling
+/// `aether.window` inbox. The hand-rolled per-arm `record_finished` +
+/// `discharge()` pairs that #1325 / #1704 added retired with the
+/// framework drain: dropping `mail` on either arm settles.
 ///
-/// Both inboxes are hand-rolled `claim_mailbox` consumers that never run
-/// through [`DispatcherSlot::dispatch_one`](aether_substrate::actor::native),
-/// so neither inherits `dispatch_one`'s unconditional discharge tail —
-/// each must run the bracket itself. Post-#1701 the reply envelope
-/// carries a real `mail_id` (the disjoint reply-lineage id), which
-/// **arms** the debug-only obligation guard; dropping it without
-/// [`Envelope::discharge`] panics inside winit's `draw_rect` — a frame
-/// that cannot unwind, so the panic escalates to `abort()` and every
-/// debug desktop run dies on its first painted frame.
-///
-/// On the per-frame path the reply is sent from the lifecycle cap's
-/// `on_settled` in response to a bare, lineage-less `Settled` notice
-/// (`chassis::settlement::push_settlement_notice`), so its `root` is
-/// `MailId::NONE`: the producer's `record_sent_inflight` already no-ops,
-/// and [`discharge_settlement`] here is correspondingly a no-op on the
-/// settlement counter — the live obligation is purely the debug guard.
-/// The `discharge_settlement` call is kept for symmetry with the window
-/// arm and to balance any future non-`NONE`-root reply this inbox might
-/// receive (the degraded `on_advance` inline-reply paths). Since this is
-/// the sole consumer of these reply envelopes — nothing else records
-/// their `Finished` — the bracket can never double-discharge.
+/// On the per-frame path the reply rides a bare, lineage-less `Settled`
+/// notice, so its `root` is `MailId::NONE` and the drop's `record_finished`
+/// is a counter no-op; the live obligation it discharges is the debug
+/// guard the real `route_mail` Inbox arm armed.
 //
-// `env` is taken by value (not `&Envelope`): this consume site owns the
-// envelope it drained off the inbox, so it owns the drop — `env.discharge()`
-// disarms the guard and the envelope drops here, mirroring
-// `dispatch_window_envelope`'s owning-handoff shape.
+// `mail` is taken by value so its guard's `Drop` (the settlement) binds
+// to this scope; the body only calls `&self` accessors, which clippy
+// reads as a needless by-value.
 #[allow(clippy::needless_pass_by_value)]
-fn consume_lifecycle_reply(mailer: &Mailer, env: Envelope) -> LifecycleReplyOutcome {
-    // Capture the settlement identity before the discharge below; mirrors
-    // `dispatch_window_envelope`'s pre-arm capture (driver.rs#1325).
-    let mail_id = env.mail_id;
-    let root = env.root;
-    let outcome = if env.kind == <LifecycleAdvanceComplete as Kind>::ID {
+fn consume_lifecycle_reply(mail: InboundMail) -> LifecycleReplyOutcome {
+    if mail.kind() == <LifecycleAdvanceComplete as Kind>::ID {
         LifecycleReplyOutcome::Complete(
-            LifecycleAdvanceComplete::decode_from_bytes(env.payload.bytes())
+            LifecycleAdvanceComplete::decode_from_bytes(mail.payload())
                 .map(|complete| complete.next),
         )
     } else {
         LifecycleReplyOutcome::Unexpected
-    };
-    // ADR-0080 §2 settlement discharge + ADR-0094 guard disarm, once per
-    // envelope on both arms — the matched advance-complete return and the
-    // skip-unexpected continue — mirroring `dispatch_window_envelope`.
-    discharge_settlement(mailer, mail_id, root);
-    env.discharge();
-    outcome
+    }
+    // `mail` drops here — both arms settle (ADR-0106).
 }
 
 /// The disposition of a `capture_frame` wake against the current window
@@ -725,19 +663,18 @@ impl App {
     /// the caller can fail-fast.
     fn recv_lifecycle_advance_next(&self) -> Option<u64> {
         loop {
-            let env = self
+            let mail = self
                 .lifecycle_reply_inbox
-                .recv_timeout(FRAME_SETTLEMENT_CAP)
-                .ok()?;
-            // iamacoffeepot/aether#1704: every consumed reply envelope must
-            // discharge its ADR-0094 obligation guard + ADR-0080 §2
-            // settlement bracket (see `consume_lifecycle_reply`), or the
-            // armed guard aborts the process on drop in debug builds.
-            match consume_lifecycle_reply(&self.queue, env) {
+                .recv_timeout(FRAME_SETTLEMENT_CAP)?;
+            // ADR-0106: the consumed reply settles when its `InboundMail`
+            // guard drops inside `consume_lifecycle_reply` — no hand-rolled
+            // bracket. Pre-#1704 a dropped armed guard aborted the process
+            // on every painted frame.
+            match consume_lifecycle_reply(mail) {
                 LifecycleReplyOutcome::Complete(next) => return next,
                 // Unexpected kind on this dedicated reply inbox (nothing
-                // else targets it); already discharged — keep waiting for
-                // the advance reply rather than mis-gating the cycle.
+                // else targets it); already settled — keep waiting for the
+                // advance reply rather than mis-gating the cycle.
                 LifecycleReplyOutcome::Unexpected => {}
             }
         }
@@ -816,7 +753,6 @@ impl App {
     /// per-actor `ActorLogRing` / `ActorTraceRing` (the same property
     /// `DispatcherSlot::run_cycle` opens for every standard actor).
     fn drain_window_inbox(&mut self) {
-        use std::sync::mpsc::TryRecvError;
         // Stamp once around the whole drain rather than per-envelope —
         // the stamp is cheap (single TLS write + RAII guard) but keeping
         // it open across the full burst means a handler that fires
@@ -824,103 +760,79 @@ impl App {
         // in the driver's ring.
         let slots = self.actor_slots.clone();
         local::with_stamped(slots.slots(), || {
-            loop {
-                match self.window_inbox.try_recv() {
-                    Ok(env) => self.dispatch_window_envelope(env),
-                    Err(TryRecvError::Empty | TryRecvError::Disconnected) => return,
-                }
+            // ADR-0106: `try_next` yields each mail as an owned
+            // `InboundMail` guard, so dispatch can still take `&mut self`
+            // (the guard borrows nothing from `self.window_inbox`). Each
+            // guard settles its inbound when `dispatch_window_envelope`
+            // returns — no hand-rolled per-arm bracket.
+            while let Some(mail) = self.window_inbox.try_next() {
+                self.dispatch_window_envelope(mail);
             }
         });
     }
 
-    // `env` is owned because the dispatch borrows `env.sender`,
-    // `env.payload`, and `env.kind` separately as it walks the
-    // window-control kind set; taking `&Envelope` works but loses the
-    // owning-handoff symmetry with the rest of the dispatch surface.
+    // ADR-0106: `mail` is an owned `InboundMail` guard. It settles its
+    // ADR-0080 §2 bracket + ADR-0094 obligation when it falls out of
+    // scope at the end of this function — on every arm, including the
+    // decode-error early returns — so there is no hand-rolled
+    // `record_finished` / `discharge` pair. Replies go through
+    // `mail.reply`, which joins the inbound's causal chain (ADR-0080
+    // §5/§6) instead of minting the bare lineage-less NONE triple.
+    //
+    // `mail` is taken by value so its guard's `Drop` (the settlement)
+    // binds to this scope; the body only calls `&self` methods on it,
+    // which clippy reads as a needless by-value.
     #[allow(clippy::needless_pass_by_value)]
-    fn dispatch_window_envelope(&mut self, env: Envelope) {
-        // iamacoffeepot/aether#1325: capture the inbound settlement
-        // identity before any arm moves fields out of the owned `env`,
-        // so the ADR-0080 §2 bracket is discharged for every
-        // driver-specific arm below (see `discharge_settlement`).
-        let mail_id = env.mail_id;
-        let root = env.root;
+    fn dispatch_window_envelope(&mut self, mail: InboundMail) {
         // iamacoffeepot/aether#1272: framework-built-in dispatch arms
         // run BEFORE the driver-specific kinds, matching
         // `DispatcherSlot::run_cycle`'s ordering. Factored into a free
-        // fn so the desktop-driver unit test exercises the routing
-        // shape directly without standing up a winit `App`. The
-        // matching `DispatcherSlot::run_cycle`'s ordering. The framework
-        // arms reply but (unlike `dispatch_one`, which records `Finished`
-        // unconditionally at its tail for every arm) do NOT record their
-        // own settlement bracket — so we discharge here on the
-        // early-return path too, mirroring `dispatch_one`'s unconditional
-        // tail. ADR-0094: `env.discharge()` disarms the obligation guard
-        // beside that settlement discharge.
-        if try_framework_dispatch(&self.queue, self.window_mailbox, &env) {
-            discharge_settlement(&self.queue, mail_id, root);
-            env.discharge();
+        // fn so the desktop-driver unit test exercises the routing shape
+        // directly without standing up a winit `App`. On a match the
+        // free fn has already replied; the guard settles on return.
+        if try_framework_dispatch(&self.queue, self.window_mailbox, mail.envelope()) {
             return;
         }
-        if env.kind == self.kind_set_window_mode {
-            let payload: SetWindowMode = match postcard::from_bytes(env.payload.bytes()) {
+        if mail.kind() == self.kind_set_window_mode {
+            let payload: SetWindowMode = match postcard::from_bytes(mail.payload()) {
                 Ok(p) => p,
                 Err(e) => {
-                    self.queue.send_reply(
-                        env.sender,
-                        &SetWindowModeResult::Err {
-                            error: format!("postcard decode failed: {e}"),
-                        },
-                    );
-                    discharge_settlement(&self.queue, mail_id, root);
-                    env.discharge();
+                    mail.reply(&SetWindowModeResult::Err {
+                        error: format!("postcard decode failed: {e}"),
+                    });
                     return;
                 }
             };
             let result = self.apply_window_mode(payload.mode, payload.width, payload.height);
-            self.queue.send_reply(env.sender, &result);
-        } else if env.kind == self.kind_set_window_title {
-            let payload: SetWindowTitle = match postcard::from_bytes(env.payload.bytes()) {
+            mail.reply(&result);
+        } else if mail.kind() == self.kind_set_window_title {
+            let payload: SetWindowTitle = match postcard::from_bytes(mail.payload()) {
                 Ok(p) => p,
                 Err(e) => {
-                    self.queue.send_reply(
-                        env.sender,
-                        &SetWindowTitleResult::Err {
-                            error: format!("postcard decode failed: {e}"),
-                        },
-                    );
-                    discharge_settlement(&self.queue, mail_id, root);
-                    env.discharge();
+                    mail.reply(&SetWindowTitleResult::Err {
+                        error: format!("postcard decode failed: {e}"),
+                    });
                     return;
                 }
             };
             let result = self.apply_window_title(payload.title);
-            self.queue.send_reply(env.sender, &result);
-        } else if env.kind == self.kind_focus_window {
+            mail.reply(&result);
+        } else if mail.kind() == self.kind_focus_window {
             // `FocusWindow` is a unit payload — nothing to decode.
-            // Reply through `self.queue.send_reply` (the `Mailer`),
-            // never `self.outbound` (`HubOutbound` drops
+            // Reply through `mail.reply` (the chain-joined `Mailer`
+            // path), never `self.outbound` (`HubOutbound` drops
             // `SourceAddr::Component`, iamacoffeepot/aether#1316).
             let result = self.apply_window_focus();
-            self.queue.send_reply(env.sender, &result);
+            mail.reply(&result);
         } else {
             tracing::warn!(
                 target: "aether_substrate::driver",
-                kind = %env.kind_name,
+                kind = %mail.kind_name(),
                 "desktop driver dropped unrecognised aether.window kind",
             );
         }
-        // iamacoffeepot/aether#1325 / §Side finding #2: discharge the
-        // ADR-0080 §2 settlement bracket once per envelope at the
-        // drain-loop level (after `send_reply`), covering the two
-        // success arms AND the unrecognised-kind warn-drop arm — a
-        // blocking send of an unhandled window kind carrying a non-NONE
-        // root would otherwise leak settlement the same way. Mirrors
-        // `dispatch_one` (`dispatcher_slot.rs:289`).
-        discharge_settlement(&self.queue, mail_id, root);
-        // ADR-0094: disarm the obligation guard beside the settlement
-        // discharge for the success + unrecognised-kind arms.
-        env.discharge();
+        // `mail` drops here — the success arms AND the unrecognised-kind
+        // warn-drop arm settle (ADR-0106).
     }
 
     fn publish_window_size(&self, width: u32, height: u32) {
@@ -1450,7 +1362,7 @@ impl DriverCapability for DesktopDriverCapability {
             input_mailbox: mailbox_id_from_name(InputCapability::NAMESPACE),
             lifecycle_mailbox,
             kind_lifecycle_advance,
-            lifecycle_reply_inbox: lifecycle_reply_claim.receiver,
+            lifecycle_reply_inbox: lifecycle_reply_claim.inbox,
             lifecycle_reply_mailbox: lifecycle_reply_claim.id,
             kind_key,
             kind_key_release,
@@ -1469,7 +1381,7 @@ impl DriverCapability for DesktopDriverCapability {
             boot_size,
             boot_title,
             current_mode: boot_mode,
-            window_inbox: window_claim.receiver,
+            window_inbox: window_claim.inbox,
             actor_slots: window_claim.actor_slots,
             window_mailbox: window_claim.id,
             kind_set_window_mode,
@@ -1723,60 +1635,102 @@ mod tests {
         assert!(rx.try_recv().is_err(), "no reply emitted on skip path");
     }
 
-    /// iamacoffeepot/aether#1325: the window inbox drain owns the
-    /// ADR-0080 §2 settlement bracket for every inbound envelope (the
-    /// `Inbox` mailbox records none on the producer side). Drive the
-    /// extracted `discharge_settlement` free fn — the same call the
-    /// driver makes per envelope — against a seeded in-flight root and
-    /// assert it settles. This is the CI-runnable regression guard for
-    /// every window-kind arm without standing up winit/wgpu; the
-    /// windowed end-to-end blocking-send path stays MCP-manual.
+    /// iamacoffeepot/aether#1325, re-homed on ADR-0106: the window inbox
+    /// drain owns the ADR-0080 §2 settlement bracket for every inbound
+    /// envelope (the `Inbox` mailbox records none on the producer side),
+    /// now by construction — draining a real armed Call through a
+    /// `ClaimedInbox` and letting the `InboundMail` guard fall out of
+    /// scope settles the root and disarms the ADR-0094 guard (no #1704
+    /// abort). The CI-runnable regression guard for the window drain
+    /// without standing up winit/wgpu; the windowed end-to-end
+    /// blocking-send path stays MCP-manual.
     #[test]
-    fn discharge_settlement_settles_window_root() {
-        use aether_data::MailId;
+    fn window_inbox_drain_settles_root_on_guard_drop() {
+        use std::sync::mpsc;
+
+        use aether_data::{Kind, MailId};
+        use aether_kinds::descriptors;
+        use aether_substrate::ClaimedInbox;
         use aether_substrate::chassis::settlement::SettlementRegistry;
         use aether_substrate::handle_store::HandleStore;
-        use aether_substrate::mail::registry::Registry;
+        use aether_substrate::mail::Mail;
+        use aether_substrate::mail::registry::{InboxHandler, Registry};
+
+        fn title_payload() -> Vec<u8> {
+            postcard::to_allocvec(&SetWindowTitle {
+                title: "ignored".to_owned(),
+            })
+            .expect("encode SetWindowTitle")
+        }
 
         let registry = Arc::new(Registry::new());
+        for d in descriptors::all() {
+            let _ = registry.register_kind_with_descriptor(d);
+        }
         let store = Arc::new(HandleStore::new(1024 * 1024));
-        let mailer = Mailer::new(registry, store);
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
 
-        // Wire a settlement registry into the trace handle (the chassis
-        // builder does both installs at boot, builder.rs:1119-1122) so
-        // the emit-time counter's zero-transition can `fire_settled`.
+        // Wire a settlement registry into both seams (the chassis builder
+        // does both installs at boot, builder.rs:1119-1122) so the
+        // emit-time counter's zero-transition can `fire_settled`.
         let settlement = Arc::new(SettlementRegistry::new());
         mailer.install_settlement_registry(Arc::clone(&settlement));
         mailer
             .trace_handle()
             .install_settlement_registry(Arc::clone(&settlement));
 
-        // Mint a root, seed its emit-time `in_flight`, and subscribe its
-        // settlement the way the driver does at driver.rs:606. A second
-        // root stays seeded but is only ever poked by the NONE discharge
-        // below — its receiver proves that arm is a no-op.
+        // Register the window mailbox forwarding armed envelopes onto the
+        // `ClaimedInbox`'s channel, exactly as `claim_mailbox` does.
         let window_mailbox = mailbox_id_from_name("aether.window");
+        let (tx, rx) = mpsc::channel::<Envelope>();
+        let handler: Arc<dyn InboxHandler> = Arc::new(move |d: Envelope| {
+            let _ = tx.send(d);
+        });
+        registry
+            .try_register_inbox_with_id(window_mailbox, "aether.window", handler)
+            .expect("register the window inbox");
+        let inbox = ClaimedInbox::new(window_mailbox, rx, Arc::clone(&mailer));
+
+        // A real armed Call: seed the root, push through the mailer so the
+        // `route_mail` Inbox arm arms the obligation guard with `mail_id`,
+        // drain via `try_next`, then drop — the guard's `Drop` records
+        // `Finished` and disarms, settling the root.
         let root = MailId::new(window_mailbox, 1);
         let mail_id = MailId::new(window_mailbox, 2);
-        let guard_root = MailId::new(window_mailbox, 3);
         mailer.record_sent_inflight(root);
+        let settle = settlement.subscribe_settlement(root);
+        mailer.push(
+            Mail::new(
+                window_mailbox,
+                <SetWindowTitle as Kind>::ID,
+                title_payload(),
+                1,
+            )
+            .with_lineage(mail_id, root, None),
+        );
+        drop(inbox.try_next().expect("the armed Call is queued"));
+        settle
+            .recv()
+            .expect("window root settles when the drained mail's guard drops");
+
+        // A `MailId::NONE` push (window-size / frame-stats) settles
+        // nothing — the guard mints disarmed and `record_finished` no-ops.
+        let guard_root = MailId::new(window_mailbox, 3);
         mailer.record_sent_inflight(guard_root);
-        let rx = settlement.subscribe_settlement(root);
         let guard_rx = settlement.subscribe_settlement(guard_root);
-
-        // The per-envelope discharge the drain loop performs after
-        // `send_reply`. With it, the inbound root's `in_flight` reaches
-        // zero and `Settled` fires.
-        discharge_settlement(&mailer, mail_id, root);
-        rx.recv().expect("window root settles after discharge");
-
-        // The chassis-internal-push guard: a `MailId::NONE` envelope
-        // (window-size / frame-stats pushes) is a no-op — `guard_root`
-        // stays in-flight and its receiver never wakes.
-        discharge_settlement(&mailer, MailId::NONE, guard_root);
+        mailer.push(
+            Mail::new(
+                window_mailbox,
+                <SetWindowTitle as Kind>::ID,
+                title_payload(),
+                1,
+            )
+            .with_lineage(MailId::NONE, guard_root, None),
+        );
+        drop(inbox.try_next().expect("the NONE push is queued"));
         assert!(
             guard_rx.try_recv().is_err(),
-            "NONE discharge must not settle any root",
+            "a NONE inbound discharges no root",
         );
     }
 
@@ -1798,13 +1752,14 @@ mod tests {
         use std::sync::mpsc;
 
         use aether_data::MailId;
+        use aether_substrate::ClaimedInbox;
         use aether_substrate::chassis::settlement::SettlementRegistry;
         use aether_substrate::handle_store::HandleStore;
         use aether_substrate::mail::registry::{InboxHandler, Registry};
 
         let registry = Arc::new(Registry::new());
         let store = Arc::new(HandleStore::new(1024 * 1024));
-        let mailer = Mailer::new(Arc::clone(&registry), store);
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
 
         // Wire one settlement registry into both seams (the chassis builder
         // does both installs at boot) so the counter's zero-transition can
@@ -1816,8 +1771,9 @@ mod tests {
             .install_settlement_registry(Arc::clone(&settlement));
 
         // Register the reply inbox exactly as `claim_mailbox` does: forward
-        // the obligation-armed envelope onto an mpsc, carrying its guard
-        // with it so the consumer side owns the discharge.
+        // the obligation-armed envelope onto the `ClaimedInbox`'s channel,
+        // carrying its guard with it so the framework drain owns the
+        // discharge.
         let (tx, rx) = mpsc::channel::<Envelope>();
         let handler: Arc<dyn InboxHandler> = Arc::new(move |dispatch: Envelope| {
             let _ = tx.send(dispatch);
@@ -1825,13 +1781,15 @@ mod tests {
         let reply_mailbox = registry
             .try_register_inbox("aether.lifecycle.advance_reply", handler)
             .expect("register the reply inbox");
+        let inbox = ClaimedInbox::new(reply_mailbox, rx, Arc::clone(&mailer));
 
         let cap_mailbox = mailbox_id_from_name("aether.lifecycle");
 
         // (1) Non-`NONE`-root reply (the degraded `on_advance` inline-reply
         // shape): the producer hook records the reply's `Sent` against
-        // `root`, and the consume-site discharge is the sole `Finished`, so
-        // the root settles.
+        // `root`, and the `InboundMail` guard's `Drop` inside
+        // `consume_lifecycle_reply` is the sole `Finished`, so the root
+        // settles.
         let root = MailId::new(cap_mailbox, 1);
         // 1<<63 is the disjoint reply-lineage base (#1701) — a non-`NONE`
         // mail_id, so the real Inbox arm arms the obligation guard.
@@ -1848,8 +1806,8 @@ mod tests {
             root,
             None,
         );
-        let env = rx.recv().expect("armed reply routed to the inbox");
-        match consume_lifecycle_reply(&mailer, env) {
+        let mail = inbox.try_next().expect("armed reply routed to the inbox");
+        match consume_lifecycle_reply(mail) {
             LifecycleReplyOutcome::Complete(next) => {
                 assert_eq!(next, Some(42), "decodes the advance-complete `next`");
             }
@@ -1857,14 +1815,14 @@ mod tests {
         }
         settle_rx
             .recv()
-            .expect("the consume-site discharge balances the reply's Sent and settles the root");
+            .expect("the guard's Finished balances the reply's Sent and settles the root");
 
         // (2) `NONE`-root reply (the real per-frame deferred path, replying
         // to a bare lineage-less `Settled` notice): the producer's
-        // `record_sent_inflight` no-ops, the discharge is a counter no-op,
-        // and the armed guard is still disarmed so the envelope drops
-        // without the ADR-0094 abort. Reaching the assert at all proves the
-        // guard was disarmed.
+        // `record_sent_inflight` no-ops, the drop's `record_finished` is a
+        // counter no-op, and the armed guard is still disarmed so the
+        // envelope drops without the ADR-0094 abort. Reaching the assert at
+        // all proves the guard was disarmed.
         let armed_reply_id_2 = MailId::new(cap_mailbox, (1 << 63) + 1);
         let sender_2 = Source::with_correlation(SourceAddr::Component(reply_mailbox), 8);
         mailer.send_reply_with_lineage(
@@ -1877,8 +1835,10 @@ mod tests {
             MailId::NONE,
             None,
         );
-        let env_2 = rx.recv().expect("second armed reply routed to the inbox");
-        match consume_lifecycle_reply(&mailer, env_2) {
+        let mail_2 = inbox
+            .try_next()
+            .expect("second armed reply routed to the inbox");
+        match consume_lifecycle_reply(mail_2) {
             LifecycleReplyOutcome::Complete(next) => {
                 assert_eq!(next, Some(0), "the terminal reply decodes `next == 0`");
             }

--- a/crates/aether-substrate/src/chassis/ctx.rs
+++ b/crates/aether-substrate/src/chassis/ctx.rs
@@ -13,6 +13,7 @@ use aether_actor::local::ActorSlots;
 
 use crate::actor::native::envelope::Envelope;
 use crate::chassis::error::BootError;
+use crate::chassis::inbox::ClaimedInbox;
 use crate::mail::MailboxId;
 use crate::mail::mailer::Mailer;
 use crate::mail::registry::OwnedDispatch;
@@ -48,7 +49,13 @@ use std::sync::OnceLock;
 /// expected ring (iamacoffeepot/aether#1272).
 pub struct MailboxClaim {
     pub id: MailboxId,
-    pub receiver: mpsc::Receiver<Envelope>,
+    /// ADR-0106: the sealed inbound surface. Replaces the raw
+    /// `mpsc::Receiver<Envelope>` the claim used to expose — a capability
+    /// reaches inbound envelopes only through the [`ClaimedInbox`]'s drain
+    /// methods, each of which settles the ADR-0080 §2 bracket on scope
+    /// exit. Outside `aether-substrate` it is no longer possible to obtain
+    /// an armed [`Envelope`] from a claim.
+    pub inbox: ClaimedInbox,
     pub actor_slots: SharedActorSlots,
     /// Optional wake hook fired by the registry sink after each
     /// accepted send (iamacoffeepot/aether#1318). The plain claim path
@@ -69,7 +76,7 @@ impl fmt::Debug for MailboxClaim {
         // and finish non-exhaustively rather than deriving.
         f.debug_struct("MailboxClaim")
             .field("id", &self.id)
-            .field("receiver", &self.receiver)
+            .field("inbox", &self.inbox)
             .finish_non_exhaustive()
     }
 }
@@ -142,7 +149,12 @@ impl Default for SharedActorSlots {
 #[derive(Debug)]
 pub struct DropOnShutdownClaim {
     pub id: MailboxId,
-    pub receiver: mpsc::Receiver<Envelope>,
+    /// ADR-0106: the standard-dispatcher feed. Narrowed to `pub(crate)` —
+    /// the raw-receiver shape survives only inside `aether-substrate` (the
+    /// builder hands it straight to the pooled dispatcher), so no
+    /// out-of-crate consumer can obtain an armed [`Envelope`] from a
+    /// drop-on-shutdown claim either.
+    pub(crate) receiver: mpsc::Receiver<Envelope>,
     pub mailbox_sender: MailboxSender,
     /// Issue 635 PR C: the pool wake hook. The mailbox closure invokes
     /// it after a successful inbox push so the chassis worker pool
@@ -427,7 +439,7 @@ impl<'a> ChassisCtx<'a> {
         // arms reach the actor's per-actor `Local<T>` rings.
         Ok(MailboxClaim {
             id,
-            receiver: rx,
+            inbox: ClaimedInbox::new(id, rx, Arc::clone(self.mailer)),
             actor_slots: SharedActorSlots::new(),
             wake_slot,
         })

--- a/crates/aether-substrate/src/chassis/inbox.rs
+++ b/crates/aether-substrate/src/chassis/inbox.rs
@@ -1,0 +1,500 @@
+//! ADR-0106: the framework drain that seals the claimed-mailbox surface.
+//!
+//! A mailbox claimed via [`ChassisCtx::claim_mailbox`](crate::chassis::ctx::ChassisCtx::claim_mailbox)
+//! no longer hands the capability a raw `mpsc::Receiver<Envelope>`. It
+//! carries a [`ClaimedInbox`] — the receiver plus the `Arc<Mailer>` and
+//! the claim's [`MailboxId`] — and the only way to reach an inbound
+//! envelope is one of its drain methods, each of which yields an
+//! [`InboundMail`] guard. The guard's `Drop` records `Finished` and
+//! disarms the ADR-0094 obligation in one motion, so every consumer arm
+//! — match, decode error, unrecognised kind, early return, panic-unwind,
+//! teardown of the drain itself — settles, because settlement is what
+//! falling out of scope *does*. This mirrors `DispatcherSlot::dispatch_one`'s
+//! unconditional discharge tail (the standard actor path), so a leak at
+//! this seam is unrepresentable in consumer code rather than detected
+//! after the fact (the recurring #846 / #1325 / #1704 class).
+//!
+//! Settling on scope exit rather than on payload access is load-bearing:
+//! ADR-0080 §6 requires a reply's `Sent` to be recorded before the
+//! inbound's `Finished`, so a consume-time discharge would close the
+//! caller's chain before the reply joins it. [`InboundMail::reply`]
+//! routes through [`Mailer::send_reply_with_lineage`] with the inbound's
+//! chain and a drain-owned reply-id counter, so a claimed-mailbox
+//! consumer never reaches the bare, lineage-less `send_reply`.
+
+use std::fmt;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc;
+use std::time::Duration;
+
+use aether_data::{Kind, KindId, MailId, MailboxId, Source};
+
+use crate::actor::native::envelope::Envelope;
+use crate::mail::mailer::Mailer;
+
+/// Base of the drain's reply-lineage id space (ADR-0080 §5 / #1701).
+/// Sits in the top half of the `u64` space, disjoint from the `send`
+/// correlation counters that start at `0`, so a reply id minted here
+/// never collides with a `send` id. Mirrors
+/// [`NativeBinding`](crate::actor::native::NativeBinding)'s and the wasm
+/// trampoline's reply-lineage base, so the claimed-mailbox reply path
+/// derives reply ids the same way every other reply site does.
+const REPLY_LINEAGE_BASE: u64 = 1 << 63;
+
+/// The sealed inbound surface of a claimed mailbox (ADR-0106).
+///
+/// Owns the inbox receiver, an `Arc<Mailer>` (for settlement discharge
+/// and lineage-joined replies), the claim's [`MailboxId`], and a
+/// drain-owned reply-id counter. The raw receiver never escapes — every
+/// inbound envelope is reached through [`Self::try_next`],
+/// [`Self::recv_timeout`], or [`Self::drain`], each of which wraps the
+/// envelope in an [`InboundMail`] guard that settles on `Drop`.
+///
+/// Dropping a `ClaimedInbox` drains whatever is still queued and lets
+/// each guard settle, so a teardown that abandons mail (the #1704 shape:
+/// a queued reply envelope dropped on driver teardown) becomes a settled
+/// drain instead of an armed drop.
+pub struct ClaimedInbox {
+    id: MailboxId,
+    receiver: mpsc::Receiver<Envelope>,
+    mailer: Arc<Mailer>,
+    reply_counter: Arc<AtomicU64>,
+}
+
+impl fmt::Debug for ClaimedInbox {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ClaimedInbox")
+            .field("id", &self.id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ClaimedInbox {
+    /// Build a `ClaimedInbox` over `receiver`. Production callers receive
+    /// one already built on the [`MailboxClaim`](crate::chassis::ctx::MailboxClaim)
+    /// returned by `claim_mailbox`; the explicit constructor is `pub` so
+    /// out-of-crate tests can pair a channel with a registered inbox
+    /// handler and drive the guard directly.
+    #[must_use]
+    pub fn new(id: MailboxId, receiver: mpsc::Receiver<Envelope>, mailer: Arc<Mailer>) -> Self {
+        Self {
+            id,
+            receiver,
+            mailer,
+            reply_counter: Arc::new(AtomicU64::new(REPLY_LINEAGE_BASE)),
+        }
+    }
+
+    /// The claimed mailbox's id.
+    #[must_use]
+    pub fn id(&self) -> MailboxId {
+        self.id
+    }
+
+    fn wrap(&self, env: Envelope) -> InboundMail {
+        InboundMail {
+            env,
+            mailer: Arc::clone(&self.mailer),
+            self_mailbox: self.id,
+            reply_counter: Arc::clone(&self.reply_counter),
+        }
+    }
+
+    /// Take the next queued envelope without blocking, wrapped in an
+    /// [`InboundMail`] guard. `None` when the inbox is empty (or the
+    /// senders have all disconnected). The returned guard settles its
+    /// inbound on `Drop` — fall out of scope on any arm and the bracket
+    /// is discharged.
+    #[must_use]
+    pub fn try_next(&self) -> Option<InboundMail> {
+        self.receiver.try_recv().ok().map(|env| self.wrap(env))
+    }
+
+    /// Block up to `timeout` for the next envelope, wrapped in an
+    /// [`InboundMail`] guard. `None` on timeout or disconnect. Used by
+    /// the desktop driver's synchronous lifecycle-reply gate.
+    #[must_use]
+    pub fn recv_timeout(&self, timeout: Duration) -> Option<InboundMail> {
+        self.receiver
+            .recv_timeout(timeout)
+            .ok()
+            .map(|env| self.wrap(env))
+    }
+
+    /// Drain every currently-queued envelope, invoking `on_mail` for each
+    /// as an [`InboundMail`] guard that settles when `on_mail` returns
+    /// (the closure may move it onward, but on the common path it just
+    /// reads the fields it needs and drops). Returns when the inbox is
+    /// empty. Use [`Self::try_next`] when the per-mail body needs the
+    /// surrounding `&mut self` (the closure here cannot also borrow it).
+    pub fn drain(&self, mut on_mail: impl FnMut(InboundMail)) {
+        while let Ok(env) = self.receiver.try_recv() {
+            on_mail(self.wrap(env));
+        }
+    }
+}
+
+impl Drop for ClaimedInbox {
+    fn drop(&mut self) {
+        // Settle anything still queued: each wrapped envelope's guard
+        // records `Finished` + disarms on drop, so teardown is a settled
+        // drain rather than an armed drop (#1704).
+        while let Ok(env) = self.receiver.try_recv() {
+            drop(self.wrap(env));
+        }
+    }
+}
+
+/// A single inbound envelope drained from a [`ClaimedInbox`], with its
+/// ADR-0080 §2 settlement bracket fused to the value's lifetime.
+///
+/// Exposes the envelope's fields by borrow and replies through
+/// [`Self::reply`] (lineage-joined). On `Drop` it records
+/// `Finished(mail_id, root)` and disarms the ADR-0094 obligation guard,
+/// in that order — so a reply sent earlier in the same scope records its
+/// `Sent` before this inbound's `Finished` (ADR-0080 §6).
+///
+/// Owns its envelope and an `Arc` clone of the drain's mailer + reply
+/// counter rather than borrowing the [`ClaimedInbox`], so a consumer can
+/// hold the guard while still reaching the surrounding `&mut self` (the
+/// desktop window driver dispatches each mail against `&mut App`).
+pub struct InboundMail {
+    env: Envelope,
+    mailer: Arc<Mailer>,
+    self_mailbox: MailboxId,
+    reply_counter: Arc<AtomicU64>,
+}
+
+impl InboundMail {
+    /// The mail's kind id.
+    #[must_use]
+    pub fn kind(&self) -> KindId {
+        self.env.kind
+    }
+
+    /// The mail's registered kind name.
+    #[must_use]
+    pub fn kind_name(&self) -> &str {
+        &self.env.kind_name
+    }
+
+    /// The mail's immediate sender (reply target + correlation).
+    #[must_use]
+    pub fn sender(&self) -> Source {
+        self.env.sender
+    }
+
+    /// The mail's encoded payload bytes.
+    #[must_use]
+    pub fn payload(&self) -> &[u8] {
+        self.env.payload.bytes()
+    }
+
+    /// The mail's producer-minted identity (ADR-0080 §1).
+    #[must_use]
+    pub fn mail_id(&self) -> MailId {
+        self.env.mail_id
+    }
+
+    /// The root of the mail's causal chain (ADR-0080 §5).
+    #[must_use]
+    pub fn root(&self) -> MailId {
+        self.env.root
+    }
+
+    /// Borrow the underlying envelope — for the framework-built-in
+    /// dispatch arms (`aether.log.tail` / `aether.trace.tail` /
+    /// `aether.cost.tail`) that take `&Envelope`.
+    #[must_use]
+    pub fn envelope(&self) -> &Envelope {
+        &self.env
+    }
+
+    /// Reply to the mail's sender, joining the inbound's causal chain
+    /// (ADR-0080 §5/§6). Mints the reply id from the drain-owned
+    /// counter in the disjoint reply-lineage id space and stamps the
+    /// inbound's `root` / parent, routing through
+    /// [`Mailer::send_reply_with_lineage`]. Returns whether the reply
+    /// was routed (`false` for a `SourceAddr::None` sender — nobody
+    /// asked for a reply). The reply's `Sent` is recorded here, before
+    /// this guard's `Drop` records the inbound's `Finished`, so the §6
+    /// hold ordering holds by construction.
+    pub fn reply<K: Kind>(&self, result: &K) -> bool {
+        let correlation = self.reply_counter.fetch_add(1, Ordering::AcqRel);
+        let reply_id = MailId::new(self.self_mailbox, correlation);
+        // ADR-0080 §5: collapse a NONE parent to `None` (chassis-root /
+        // lineage-less inbound), mirroring `NativeCtx::outbound_parent`.
+        let parent = if self.env.mail_id == MailId::NONE {
+            None
+        } else {
+            Some(self.env.mail_id)
+        };
+        self.mailer.send_reply_with_lineage(
+            self.env.sender,
+            result,
+            reply_id,
+            self.env.root,
+            parent,
+        )
+    }
+}
+
+impl Drop for InboundMail {
+    fn drop(&mut self) {
+        // ADR-0080 §2 settlement discharge, then ADR-0094 guard disarm —
+        // the same two-step the standard `dispatch_one` tail runs.
+        // `record_finished` no-ops on `MailId::NONE`, so a lineage-less
+        // inbound settles nothing (parity with the chassis-internal push
+        // sentinel); the guard was minted disarmed for that case too.
+        self.mailer.record_finished(self.env.mail_id, self.env.root);
+        self.env.discharge();
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture construction panic on failure is the assertion"
+)]
+mod tests {
+    use super::*;
+
+    use crate::chassis::settlement::SettlementRegistry;
+    use crate::handle_store::HandleStore;
+    use crate::mail::MailRef;
+    use crate::mail::SourceAddr;
+    use crate::mail::registry::{InboxHandler, OwnedDispatch, Registry};
+    use aether_kinds::descriptors;
+    use aether_kinds::{LifecycleAdvanceComplete, trace::Nanos};
+
+    /// A mailer wired to a settlement registry on both seams (the chassis
+    /// builder does both installs at boot), plus the registry handle so a
+    /// test can register a reply-target inbox.
+    fn test_env() -> (Arc<Registry>, Arc<Mailer>, Arc<SettlementRegistry>) {
+        let registry = Arc::new(Registry::new());
+        for d in descriptors::all() {
+            let _ = registry.register_kind_with_descriptor(d);
+        }
+        let store = Arc::new(HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
+        let settlement = Arc::new(SettlementRegistry::new());
+        mailer.install_settlement_registry(Arc::clone(&settlement));
+        mailer
+            .trace_handle()
+            .install_settlement_registry(Arc::clone(&settlement));
+        (registry, mailer, settlement)
+    }
+
+    /// An obligation-armed envelope addressed at `id` (armed iff
+    /// `mail_id != NONE`, matching the production `route_mail` Inbox arm).
+    fn armed_env(id: MailboxId, mail_id: MailId, root: MailId, sender: Source) -> Envelope {
+        OwnedDispatch::armed(
+            KindId(7),
+            "test.inbox.kind".to_owned(),
+            None,
+            sender,
+            MailRef::from(Vec::new()),
+            1,
+            mail_id,
+            root,
+            None,
+            Nanos(0),
+            0,
+            id,
+        )
+    }
+
+    /// Every consumer arm settles the inbound: a payload-reading consume,
+    /// an unmatched drop (fields never touched), a closure `drain`, and
+    /// teardown of the `ClaimedInbox` itself with mail still queued.
+    #[test]
+    fn every_arm_settles() {
+        let (_registry, mailer, settlement) = test_env();
+        let id = MailboxId(0x106);
+
+        // (1) consume — read the payload, then drop.
+        {
+            let (tx, rx) = mpsc::channel();
+            let inbox = ClaimedInbox::new(id, rx, Arc::clone(&mailer));
+            let root = MailId::new(id, 1);
+            mailer.record_sent_inflight(root);
+            let settle = settlement.subscribe_settlement(root);
+            tx.send(armed_env(id, MailId::new(id, 11), root, Source::NONE))
+                .unwrap();
+            let mail = inbox.try_next().expect("one queued");
+            let _ = mail.payload();
+            drop(mail);
+            settle.recv().expect("consume arm settles the root");
+        }
+
+        // (2) unmatched drop — never touch the fields, just drop.
+        {
+            let (tx, rx) = mpsc::channel();
+            let inbox = ClaimedInbox::new(id, rx, Arc::clone(&mailer));
+            let root = MailId::new(id, 2);
+            mailer.record_sent_inflight(root);
+            let settle = settlement.subscribe_settlement(root);
+            tx.send(armed_env(id, MailId::new(id, 12), root, Source::NONE))
+                .unwrap();
+            drop(inbox.try_next().expect("one queued"));
+            settle.recv().expect("unmatched-drop arm settles the root");
+        }
+
+        // (3) closure drain.
+        {
+            let (tx, rx) = mpsc::channel();
+            let inbox = ClaimedInbox::new(id, rx, Arc::clone(&mailer));
+            let root = MailId::new(id, 3);
+            mailer.record_sent_inflight(root);
+            let settle = settlement.subscribe_settlement(root);
+            tx.send(armed_env(id, MailId::new(id, 13), root, Source::NONE))
+                .unwrap();
+            inbox.drain(|_mail| {});
+            settle.recv().expect("drain arm settles the root");
+        }
+
+        // (4) teardown — mail queued, ClaimedInbox dropped.
+        {
+            let (tx, rx) = mpsc::channel();
+            let inbox = ClaimedInbox::new(id, rx, Arc::clone(&mailer));
+            let root = MailId::new(id, 4);
+            mailer.record_sent_inflight(root);
+            let settle = settlement.subscribe_settlement(root);
+            tx.send(armed_env(id, MailId::new(id, 14), root, Source::NONE))
+                .unwrap();
+            drop(inbox);
+            settle
+                .recv()
+                .expect("teardown drain settles the queued root");
+        }
+    }
+
+    /// A `MailId::NONE` inbound carries no settlement obligation: dropping
+    /// its guard records no `Finished` (parity with `record_finished`'s
+    /// NONE no-op) and the disarmed guard never panics.
+    #[test]
+    fn none_mail_id_is_a_noop() {
+        let (_registry, mailer, settlement) = test_env();
+        let id = MailboxId(0x107);
+        let guard_root = MailId::new(id, 9);
+        mailer.record_sent_inflight(guard_root);
+        let guard_rx = settlement.subscribe_settlement(guard_root);
+
+        let (tx, rx) = mpsc::channel();
+        let inbox = ClaimedInbox::new(id, rx, Arc::clone(&mailer));
+        tx.send(armed_env(id, MailId::NONE, guard_root, Source::NONE))
+            .unwrap();
+        // Drop without reading — a NONE inbound must not settle anything.
+        drop(inbox.try_next().expect("one queued"));
+        assert!(
+            guard_rx.try_recv().is_err(),
+            "a NONE inbound discharges no root",
+        );
+    }
+
+    /// ADR-0080 §6: a reply's `Sent` is recorded before the inbound's
+    /// `Finished`, so the caller's chain stays open until the reply's own
+    /// `Finished` lands. Reply, then drop the guard, then settle the
+    /// reply — only the last step closes the root.
+    #[test]
+    fn reply_sent_recorded_before_inbound_finished() {
+        let (registry, mailer, settlement) = test_env();
+        let id = MailboxId(0x108);
+        let reply_target = MailboxId(0x109);
+
+        // Register the reply target so the reply routes somewhere we can
+        // pick it back up and finish it.
+        let (rtx, rrx) = mpsc::channel::<Envelope>();
+        let handler: Arc<dyn InboxHandler> = Arc::new(move |d: Envelope| {
+            let _ = rtx.send(d);
+        });
+        let reply_target = registry
+            .try_register_inbox_with_id(reply_target, "test.inbox.reply_target", handler)
+            .expect("register reply target");
+
+        let root = MailId::new(id, 1);
+        mailer.record_sent_inflight(root);
+        let settle = settlement.subscribe_settlement(root);
+
+        let (tx, rx) = mpsc::channel();
+        let inbox = ClaimedInbox::new(id, rx, Arc::clone(&mailer));
+        let sender = Source::with_correlation(SourceAddr::Component(reply_target), 7);
+        tx.send(armed_env(id, MailId::new(id, 21), root, sender))
+            .unwrap();
+
+        let mail = inbox.try_next().expect("one queued");
+        assert!(
+            mail.reply(&LifecycleAdvanceComplete {
+                completed: 1,
+                next: 42,
+            }),
+            "reply routed to the Component target",
+        );
+        // The reply's `Sent` is now on the root; it is not yet settled.
+        assert!(
+            settle.try_recv().is_err(),
+            "reply Sent holds the chain open",
+        );
+        drop(mail);
+        // The inbound's `Finished` landed, but the reply is still in flight.
+        assert!(
+            settle.try_recv().is_err(),
+            "inbound Finished alone does not settle — the reply is still open",
+        );
+
+        // Finish the reply the way its eventual recipient's dispatcher
+        // would; only now does the root settle.
+        let reply_env = rrx.recv().expect("reply routed to the target inbox");
+        let reply_id = reply_env.mail_id;
+        reply_env.discharge();
+        mailer.record_finished(reply_id, root);
+        settle
+            .recv()
+            .expect("root settles after the reply finishes");
+    }
+
+    /// `InboundMail::reply` mints its reply id in the disjoint
+    /// reply-lineage id space (`1 << 63` base), stamped with the claimed
+    /// mailbox as the sender.
+    #[test]
+    fn reply_id_minted_in_reply_lineage_space() {
+        let (registry, mailer, _settlement) = test_env();
+        let id = MailboxId(0x10a);
+        let reply_target = MailboxId(0x10b);
+
+        let (rtx, rrx) = mpsc::channel::<Envelope>();
+        let handler: Arc<dyn InboxHandler> = Arc::new(move |d: Envelope| {
+            let _ = rtx.send(d);
+        });
+        let reply_target = registry
+            .try_register_inbox_with_id(reply_target, "test.inbox.reply_id_target", handler)
+            .expect("register reply target");
+
+        let (tx, rx) = mpsc::channel();
+        let inbox = ClaimedInbox::new(id, rx, Arc::clone(&mailer));
+        let sender = Source::with_correlation(SourceAddr::Component(reply_target), 1);
+        // A lineage-less inbound (root NONE) still mints a high-space
+        // reply id — the id space is the drain's, not the inbound's.
+        tx.send(armed_env(id, MailId::NONE, MailId::NONE, sender))
+            .unwrap();
+
+        let mail = inbox.try_next().expect("one queued");
+        mail.reply(&LifecycleAdvanceComplete {
+            completed: 0,
+            next: 0,
+        });
+        drop(mail);
+
+        let reply_env = rrx.recv().expect("reply routed");
+        assert!(
+            reply_env.mail_id.correlation_id >= REPLY_LINEAGE_BASE,
+            "reply id sits in the reply-lineage space",
+        );
+        assert_eq!(
+            reply_env.mail_id.sender, id,
+            "reply id is stamped with the claimed mailbox",
+        );
+        reply_env.discharge();
+    }
+}

--- a/crates/aether-substrate/src/chassis/mod.rs
+++ b/crates/aether-substrate/src/chassis/mod.rs
@@ -23,6 +23,7 @@ pub mod ctx;
 pub mod error;
 pub mod frame_loop;
 pub mod helpers;
+pub mod inbox;
 pub mod settlement;
 pub mod settlement_counter;
 pub mod settlement_table;

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -80,6 +80,7 @@ pub use chassis::ctx::{
     ChassisCtx, DropOnShutdownClaim, FallbackRouter, MailboxClaim, MailboxSender, SharedActorSlots,
 };
 pub use chassis::error::BootError;
+pub use chassis::inbox::{ClaimedInbox, InboundMail};
 pub use config::{
     ConfigError, FromArgvThenEnv, KnobKind, KnobRecord, KnownKeys, dump_config, known_keys,
     validate_env,

--- a/crates/aether-substrate/src/mail/registry.rs
+++ b/crates/aether-substrate/src/mail/registry.rs
@@ -582,6 +582,20 @@ pub trait InlineHandler: Send + Sync + 'static {
 /// Release builds compile the guard out entirely (no field, no `Drop`),
 /// so it is zero-cost. Test/helper mints use the disarmed constructor.
 ///
+/// **ADR-0106: prefer the framework drain.** A capability that claims a
+/// mailbox via
+/// [`ChassisCtx::claim_mailbox`](crate::chassis::ctx::ChassisCtx::claim_mailbox)
+/// no longer hand-rolls this bracket: the claim carries a
+/// [`ClaimedInbox`](crate::chassis::inbox::ClaimedInbox) whose drain
+/// methods yield each mail as an
+/// [`InboundMail`](crate::chassis::inbox::InboundMail) guard that records
+/// `Finished` + disarms on scope exit, so every arm settles by
+/// construction. Hand-rolling an `impl InboxHandler` and pairing
+/// `record_finished` with `discharge` per arm is the move-onward relay
+/// shape (the three production closures route through `relay_or_transfer`)
+/// — reach for it only when forwarding the dispatch onward, not when
+/// consuming it.
+///
 /// The owned dispatch type is the structural hint: payload arrives
 /// as `Vec<u8>`, so moving it into an mpsc `Sender` is a single
 /// move, not a clone. A handler that does immediate synchronous

--- a/docs/adr/0094-settlement-obligation-guard.md
+++ b/docs/adr/0094-settlement-obligation-guard.md
@@ -2,6 +2,7 @@
 
 - **Status:** Accepted
 - **Date:** 2026-06-04
+- **Amended by:** [ADR-0106](0106-settlement-safe-by-construction.md) — seals the claimed-mailbox consumer seam behind one framework drain (`ClaimedInbox` / `InboundMail`) so the bracket this guard only *detects* a leak in is now discharged *by construction* at that seam. The guard stays — it still covers the in-crate relay / park / fan-out seams the drain does not subsume.
 
 Amends **ADR-0080 §2 / §12** (and the post-ADR-0086 settlement model). It does not change the settlement *semantics* — `(in_flight == 0 && held_open == 0)` is still the exact settled signal, the producer-site `Sent`/`Finished` brackets are unchanged — it adds a **debug-build runtime check** that enforces the §2 "every `OwnedDispatch` must have `Finished` recorded" obligation at its weakest seam, and names the **transfer-vs-discharge** vocabulary every hand-rolled drain must now follow.
 

--- a/docs/guide/recipes/debugging-a-hung-settlement.md
+++ b/docs/guide/recipes/debugging-a-hung-settlement.md
@@ -80,17 +80,20 @@ see. The hold table on [Concurrency & blocking](../systems/concurrency.md)
 matches each primitive to the shape of work it covers. `acquire_settlement_hold`
 is the explicit handle for the rare hand-rolled buffer-and-drain case.
 
-**B. Owned drain that dropped its finish obligation.** The frontier is a
-mailbox drained by hand off the pool — a capability that took an *owned*
-dispatch and was supposed to record it `Finished` or transfer the obligation
-downstream, and did neither. In debug builds the obligation guard
+**B. Owned dispatch that dropped its finish obligation.** The frontier is a
+mailbox where a capability took an *owned* dispatch and was supposed to record it
+`Finished` or transfer the obligation downstream, and did neither. The
+claimed-mailbox drain handles this by construction now — a `ClaimedInbox` yields
+each mail as a guard that settles on scope exit ([ADR-0106](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0106-settlement-safe-by-construction.md)), so the live
+suspects are the in-crate relay / park / fan-out seams that move a dispatch onward
+by hand. In debug builds the obligation guard
 ([ADR-0094](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0094-settlement-obligation-guard.md))
-turns this into an immediate panic at the leaking seam, naming the `mail_id`,
-kind, and mailbox — so check engine stderr for that panic before anything else;
-it points straight at the drain. In a release build the guard is absent and the
-chain just hangs, leaving the frontier-plus-logs walk as the way in. The rule
-for any hand-rolled drain: discharge what ends with you, transfer what you pass
-on.
+turns a dropped obligation into an immediate panic at the leaking seam, naming the
+`mail_id`, kind, and mailbox — so check engine stderr for that panic before
+anything else; it points straight at the seam. In a release build the guard is
+absent and the chain just hangs, leaving the frontier-plus-logs walk as the way
+in. The rule for any relay you write: discharge what ends with you, transfer what
+you pass on.
 
 **C. The chain is merely slow.** No handler is stuck — the frontier keeps
 advancing across re-reads and the timing spans show a real, long hop (a
@@ -106,10 +109,11 @@ To stage a hung chain deliberately — to confirm a fix or to study the frontier
 shape — inject the offending mail under `send_mail_traced` against a fresh
 engine from `spawn_substrate`, with a short `settlement_timeout_ms` so the
 `"timeout"` lands fast. A handler that defers a reply without taking a hold, or
-a hand-rolled drain that skips its `Finished`, reproduces fault A or B
-respectively; the desktop chassis's `aether.window` driver is the one owned
-drain in the tree today, so window ops are the live example of the obligation
-shape.
+a relay closure that skips its `transfer`, reproduces fault A or B respectively.
+The desktop chassis's `aether.window` driver is the lead claimed-mailbox drain in
+the tree, so window ops are the live example of the settle-by-construction
+shape — its guards close the chain whether the op applies, the payload fails to
+decode, or the window is torn down mid-drain.
 
 ## Gotcha — read the trace promptly
 

--- a/docs/guide/systems/tracing-and-settlement.md
+++ b/docs/guide/systems/tracing-and-settlement.md
@@ -96,31 +96,41 @@ opts work *out* of settlement — lives on
 
 ## The obligation guard
 
-There is a second way to break a chain, on the receiving side. A capability that
-owns an **inbox** mailbox — one that takes an *owned* dispatch and is expected to
-move it onward to a downstream channel — carries the finish obligation itself: it
-must record the inbound mail as `Finished`, or its chain never closes. The
+There is a second way a chain closes, on the receiving side. A capability that
+owns an **inbox** mailbox — one that takes an *owned* dispatch off a downstream
+channel — owes that inbound mail its `Finished`, or the chain never closes. The
 substrate brackets the two synchronous mailbox shapes automatically — an inline
 handler, and the standard actor dispatcher at handler exit — so an ordinary actor
-never has to think about this. What's on its own is a mailbox drained *by hand*,
-off the pool, and the engine has exactly one such case today: the **desktop
-chassis's window driver**. Window operations have to run on the OS event-loop
-thread rather than a pool worker, so `aether.window` is registered as an inbox the
-event loop drains itself, recording each inbound mail's `Finished` as it applies
-the op and sends the reply ([Window](window.md) covers that mailbox's surface).
-That's the lone precedent — but the same obligation lands on any future driver
-that owns and drains its own mailbox off-thread.
+never has to think about this. The third shape is a mailbox drained *by hand*,
+off the pool: a capability that claims a mailbox and drives the drain itself,
+the way the **desktop chassis's window driver** does. Window operations have to
+run on the OS event-loop thread rather than a pool worker, so `aether.window` is
+claimed as an inbox the event loop drains between frames ([Window](window.md)
+covers that mailbox's surface).
 
-Forget it and you get the worst diagnostic the runtime offers: a silent
-multi-second hang with no actor and no mail named, ending only when the
-settlement or MCP timeout fires. [ADR-0094](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0094-settlement-obligation-guard.md) converts that into an immediate, located
-failure in debug builds. Every owned dispatch must end one of two ways —
+A claimed mailbox is settle-safe by construction ([ADR-0106](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0106-settlement-safe-by-construction.md)). The claim hands the
+capability a `ClaimedInbox`, not a raw receiver, and its drain methods yield each
+mail as an `InboundMail` guard that records `Finished` and replies along the
+inbound's causal chain. The guard settles when it falls out of scope — on every
+arm, including a decode error, an unrecognised kind, an early return, or teardown
+of the drain with mail still queued — so a leak at this seam is unrepresentable in
+the consumer's code, the same way the standard dispatcher's unconditional discharge
+tail keeps an actor author from leaking. Settling on scope exit rather than on
+payload access is deliberate: a reply's `Sent` must be recorded before the
+inbound's `Finished`, and `InboundMail::reply` sends inside the guard's scope, so
+the reply joins the chain before the drop closes it.
+
+Underneath, every owned dispatch still ends one of two ways —
 **discharged** (*the obligation ends here; I am recording `Finished`*) or
-**transferred** (*the obligation moves with the work onto a downstream
-envelope*) — and an owned dispatch dropped while still armed panics at the leaking
-seam, naming the `mail_id`, kind, and mailbox. Release builds carry no field and
-no check, so the guard costs nothing where it isn't wanted. The rule for any drain
-you write: discharge what ends with you, transfer what you pass on.
+**transferred** (*the obligation moves with the work onto a downstream envelope*).
+The framework drain does the discharge; the relay closures that move a dispatch
+onward to a pool actor do the transfer. An owned dispatch dropped while still armed
+panics at the leaking seam in debug builds, naming the `mail_id`, kind, and mailbox
+([ADR-0094](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0094-settlement-obligation-guard.md)); release builds carry no field and no check, so the guard
+costs nothing. The guard now backs the in-crate relay and park seams rather than
+the claimed-mailbox drain, which no longer needs it — forget it on a relay you
+write and you still get an immediate, located failure instead of the silent
+multi-second hang the chain would otherwise wedge into.
 
 ## The trace tree
 

--- a/docs/guide/systems/window.md
+++ b/docs/guide/systems/window.md
@@ -84,11 +84,13 @@ desktop-only surface.
 **The window mailbox is drained by hand, on the event-loop thread.** Window
 operations have to run on the OS event-loop thread rather than a pool worker, so
 the desktop chassis claims `aether.window` as an inbox the event loop drains
-itself. That makes it the engine's one mailbox drained off the scheduler pool,
-and it carries the finish obligation a pooled actor gets for free: the driver
-records each inbound mail as `Finished` as it applies the op and sends the reply,
-or the mail's chain never settles. It's the lone in-tree precedent for the
-obligation guard, covered in detail on
+itself between frames. The claim hands the driver a `ClaimedInbox`, so the finish
+obligation a pooled actor gets for free is carried by construction here too: each
+inbound mail arrives as a guard that records `Finished` and replies along the
+caller's chain when it falls out of scope, whether the op applied cleanly, the
+payload failed to decode, or the kind was unrecognised. The driver applies the op
+and replies; the settle rides the guard. It's the lead example of the
+claimed-mailbox drain, covered in detail on
 [Tracing & settlement](tracing-and-settlement.md#the-obligation-guard).
 
 ## How to use it
@@ -150,8 +152,8 @@ when the platform layer underneath moves.
 
 - The substrate/chassis split that makes window an opt-in desktop capability —
   [ADR-0035](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0035-substrate-chassis-split.md).
-- Why the hand-drained window mailbox must discharge its finish obligation, and
-  the guard that catches a leak —
+- How the claimed window mailbox settles its finish obligation by construction,
+  and the guard that backs the relay seams —
   [Tracing & settlement](tracing-and-settlement.md#the-obligation-guard).
 - Why a single `send_mail` returns the applied value, and the `capture_frame`
   that pairs with `focus` — [The MCP harness](../mcp-harness.md).


### PR DESCRIPTION
Closes #1705.

## Summary

Makes settlement obligations safe by construction rather than by guard (ADR-0106). Introduces `ClaimedInbox` + an `InboundMail` drop-guard in `aether-substrate` (`chassis/inbox.rs`): consuming a mail hands back an `InboundMail` whose `Drop` records the inbound's `Finished` and disarms the ADR-0094 obligation in one motion, so every consumer arm — consume, early-return, unmatched-drop, teardown-drain — settles by scope exit instead of relying on a hand-written discharge tail. Replies route through `send_reply_with_lineage` with a drain-owned reply-id counter in the `1 << 63` space, so a reply joins the inbound's causal chain and its `Sent` is recorded before the guard's `Drop` records `Finished` (ADR-0080 §6 ordering, by construction). The desktop window driver's two drains migrate onto the guard; its six per-arm `record_finished`/`discharge` pairs and the `discharge_settlement` helper are deleted.

## Implementation note (deviation from the ADR notation)

ADR-0106 notates the guard as `InboundMail<'_>` (borrowing). The implementation makes it an **owned** guard (it holds `Arc` clones of the mailer + reply counter, no lifetime). This is load-bearing: the window driver dispatches each mail against `&mut App` while the inbox is a field of `App`, so a borrowing guard would hold a shared borrow of `self` that conflicts with the `&mut self` dispatch. The owned form preserves every property the ADR requires — settle-on-scope-exit on all arms, §6 ordering, chain-joined replies, teardown drain — and the `drain(impl FnMut(InboundMail))` closure form is still provided and tested. A one-line ADR-0106 reconciliation may follow.

## Test plan

- `chassis/inbox.rs` unit tests: every-arm-settles (consume / early-return / unmatched-drop / teardown drain), `MailId::NONE` no-op parity with `record_finished`, §6 reply-`Sent`-before-inbound-`Finished` ordering, reply id minted in the `1 << 63` space.
- #1325 / #1704 regression tests ported onto the new drain.
- Full `scripts/preflight.sh --qodana` green (qodana 0 findings); `nextest --workspace --all-features` 1749 passed.

## Generated by

`/implement` — agent execution of scoped issue #1705 (owned-guard adaptation reviewed and validated in-session).
