### PR TITLE
refactor(substrate): retire bare Mailer::send_reply for the lineage-joined guard path

### DIFF
--- a/crates/aether-capabilities/src/window.rs
+++ b/crates/aether-capabilities/src/window.rs
@@ -15,7 +15,7 @@ use aether_kinds::{FocusWindow, SetWindowMode, SetWindowTitle};
 
 #[aether_actor::bridge(singleton)]
 mod native {
-    use aether_actor::actor;
+    use aether_actor::{OutboundReply, actor};
     use aether_kinds::{FocusWindowResult, SetWindowModeResult, SetWindowTitleResult};
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
@@ -46,34 +46,31 @@ mod native {
         /// Reply `Err` so MCP `set_window_mode` fails fast instead of
         /// hanging on a reply that never comes.
         ///
-        /// Reply through `ctx.mailer().send_reply` (the `Mailer`, the
-        /// complete router) rather than `HubOutbound::send_reply`, which
-        /// silently drops `SourceAddr::Component` — the local-RPC-server
-        /// reply target an MCP-spawned engine tags (iamacoffeepot/aether#1321,
-        /// matching the desktop driver fix in #1319).
+        /// Reply through the typed `ctx.reply()` (the
+        /// `NativeBinding::send_reply_for_handler` path), which mints the
+        /// reply id and joins the caller's ADR-0080 causal chain so the
+        /// blocking `set_window_mode` settles on the reply's `Finished`.
+        /// It routes every `SourceAddr` — including the `Component`
+        /// local-RPC-server reply target an MCP-spawned engine tags
+        /// (iamacoffeepot/aether#1321) that `HubOutbound::send_reply`
+        /// silently drops.
         // `&self` keeps the dispatch ABI (ADR-0033 / ADR-0038); the
         // capability is stateless, so the reply routes purely off `ctx`.
         #[allow(clippy::unused_self)]
         #[handler]
         fn on_set_mode(&self, ctx: &mut NativeCtx<'_>, _mail: SetWindowMode) {
-            ctx.mailer().send_reply(
-                ctx.reply_target(),
-                &SetWindowModeResult::Err {
-                    error: "unsupported on this chassis — no window peripheral".to_owned(),
-                },
-            );
+            ctx.reply(&SetWindowModeResult::Err {
+                error: "unsupported on this chassis — no window peripheral".to_owned(),
+            });
         }
 
         /// Reply `Err` for the same reason as `on_set_mode`.
         #[allow(clippy::unused_self)]
         #[handler]
         fn on_set_title(&self, ctx: &mut NativeCtx<'_>, _mail: SetWindowTitle) {
-            ctx.mailer().send_reply(
-                ctx.reply_target(),
-                &SetWindowTitleResult::Err {
-                    error: "unsupported on this chassis — no window peripheral".to_owned(),
-                },
-            );
+            ctx.reply(&SetWindowTitleResult::Err {
+                error: "unsupported on this chassis — no window peripheral".to_owned(),
+            });
         }
 
         /// Reply `Err` for the same reason as `on_set_mode`
@@ -82,12 +79,121 @@ mod native {
         #[allow(clippy::unused_self)]
         #[handler]
         fn on_focus(&self, ctx: &mut NativeCtx<'_>, _mail: FocusWindow) {
-            ctx.mailer().send_reply(
-                ctx.reply_target(),
-                &FocusWindowResult::Err {
-                    error: "unsupported on this chassis — no window peripheral".to_owned(),
-                },
+            ctx.reply(&FocusWindowResult::Err {
+                error: "unsupported on this chassis — no window peripheral".to_owned(),
+            });
+        }
+    }
+
+    #[cfg(test)]
+    #[allow(
+        clippy::unwrap_used,
+        reason = "test-setup unwraps: fixture construction panic on failure is the assertion"
+    )]
+    mod tests {
+        use super::*;
+        use aether_data::{MailId, Source, SourceAddr};
+        use aether_kinds::{FocusWindow, SetWindowMode, SetWindowTitle, WindowMode};
+        use aether_substrate::actor::native::binding::NativeBinding;
+        use aether_substrate::handle_store::HandleStore;
+        use aether_substrate::mail::mailer::Mailer;
+        use aether_substrate::{HubOutbound, InboxHandler, MailboxId, OwnedDispatch, Registry};
+        use std::sync::Arc;
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        /// `(mailer, caller_mailbox, reply_rx)` — a mailer with a
+        /// `Component`-target caller inbox that discharges each delivered
+        /// reply and forwards the dispatch so the test can read its
+        /// lineage. Mirrors the audio cap's `settlement_substrate`.
+        fn settlement_substrate() -> (Arc<Mailer>, MailboxId, mpsc::Receiver<OwnedDispatch>) {
+            let registry = Arc::new(Registry::new());
+            let (outbound, _egress_rx) = HubOutbound::attached_loopback();
+            let store = Arc::new(HandleStore::new(1024 * 1024));
+            let mailer =
+                Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
+            let (reply_tx, reply_rx) = mpsc::channel::<OwnedDispatch>();
+            let caller_mailbox = registry.register_inbox(
+                "test.window.settlement.caller",
+                Arc::new(move |dispatch: OwnedDispatch| {
+                    // ADR-0094: terminal consumer — discharge before forwarding.
+                    dispatch.discharge();
+                    let _ = reply_tx.send(dispatch);
+                }) as Arc<dyn InboxHandler>,
             );
+            (mailer, caller_mailbox, reply_rx)
+        }
+
+        /// #1701 / #1710 conformance: a blocking `set_mode` / `set_title` /
+        /// `focus` reply from the headless window cap joins the caller's
+        /// causal chain — the reply's `Sent` holds the root open until its
+        /// `Finished` fires, instead of detaching through the lineage-less
+        /// unchained path. Each handler routes through the typed
+        /// `ctx.reply()`, so they all share the proof.
+        #[test]
+        fn err_reply_joins_caller_chain() {
+            let (mailer, caller_mailbox, reply_rx) = settlement_substrate();
+            let counter = Arc::clone(mailer.trace_handle().settlement_counter());
+            let transport = Arc::new(NativeBinding::new_for_test(
+                Arc::clone(&mailer),
+                MailboxId(0),
+            ));
+            let cap = HeadlessWindowCapability;
+
+            // Run each handler under its own root and assert the reply
+            // holds, then settles, that root.
+            let mut next_correlation = 0_u64;
+            let mut drive = |handler: &dyn Fn(&HeadlessWindowCapability, &mut NativeCtx<'_>)| {
+                next_correlation += 1;
+                let root = MailId::new(MailboxId(0x1710), next_correlation);
+                let caller_source = Source::with_correlation(
+                    SourceAddr::Component(caller_mailbox),
+                    next_correlation,
+                );
+
+                {
+                    let mut ctx = NativeCtx::new(&transport, caller_source, root, root);
+                    handler(&cap, &mut ctx);
+                }
+
+                assert_eq!(
+                    counter.live_roots(),
+                    1,
+                    "the in-handler reply holds the caller chain open",
+                );
+                let dispatch = reply_rx
+                    .recv_timeout(Duration::from_secs(2))
+                    .expect("Err reply reached the caller inbox");
+                assert_eq!(dispatch.root, root, "reply inherits the caller's root");
+                mailer.record_finished(dispatch.mail_id, dispatch.root);
+                assert_eq!(
+                    counter.live_roots(),
+                    0,
+                    "chain settles after the reply's Finished fires",
+                );
+            };
+
+            drive(&|cap, ctx| {
+                cap.on_set_mode(
+                    ctx,
+                    SetWindowMode {
+                        mode: WindowMode::Windowed,
+                        width: None,
+                        height: None,
+                    },
+                );
+            });
+            drive(&|cap, ctx| {
+                cap.on_set_title(
+                    ctx,
+                    SetWindowTitle {
+                        title: "test".to_owned(),
+                    },
+                );
+            });
+            drive(&|cap, ctx| {
+                cap.on_focus(ctx, FocusWindow {});
+            });
         }
     }
 }

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -31,6 +31,9 @@ use aether_kinds::{
     MouseButton, MouseMove, Quit, SetWindowMode, SetWindowModeResult, SetWindowTitle,
     SetWindowTitleResult, Tick, WindowMode, WindowSize, keycode,
 };
+// Only the unit tests name the `Envelope` (aka `OwnedDispatch`) type now —
+// `try_framework_dispatch` reaches it through `InboundMail::envelope()`.
+#[cfg(test)]
 use aether_substrate::actor::native::envelope::Envelope;
 use aether_substrate::actor::native::{
     dispatch_cost_tail_if_matching_free, dispatch_log_tail_if_matching_free,
@@ -110,8 +113,9 @@ pub struct App {
     /// Shared single-slot queue with the control plane. On each
     /// redraw we `take()` any pending capture and, if present, use
     /// `render_and_capture`, then reply to the sender via
-    /// `queue.send_reply` (the `Mailer`, which routes every
-    /// `SourceAddr` — see `outbound`).
+    /// `queue.send_reply_unchained` (the `Mailer`, which routes every
+    /// `SourceAddr` — see `outbound`; the capture reply is wire-terminal,
+    /// so lineage is moot, #1710).
     capture_queue: CaptureQueue,
     /// Hub outbound — held for log egress to the hub and
     /// `lifecycle::fatal_abort`. NOT used for chassis replies:
@@ -119,10 +123,11 @@ pub struct App {
     /// targets and silently drops `SourceAddr::Component`, but mail
     /// dispatched by this engine's own `RpcServerCapability` (every
     /// hub/MCP call lands via the proxy → local RPC server) carries a
-    /// `Component(rpc_server)` reply target. Replies go through
-    /// `self.queue.send_reply` (the `Mailer`) instead, which pushes the
-    /// reply as local mail so the RPC server's `on_any` lifts it into a
-    /// `ReplyEvent` (iamacoffeepot/aether#1316).
+    /// `Component(rpc_server)` reply target. Replies go through the
+    /// `Mailer` instead (`mail.reply` for the chain-joined window arms,
+    /// `self.queue.send_reply_unchained` for the wire-terminal capture
+    /// replies), which pushes the reply as local mail so the RPC server's
+    /// `on_any` lifts it into a `ReplyEvent` (iamacoffeepot/aether#1316).
     outbound: Arc<HubOutbound>,
     window: Option<Arc<Window>>,
     gpu: Option<Gpu>,
@@ -364,11 +369,16 @@ fn resolve_fullscreen(
     }
 }
 
-/// iamacoffeepot/aether#1272: route an inbound `aether.window` envelope
-/// through the framework-built-in dispatch arms (`aether.log.tail` /
-/// `aether.trace.tail` / `aether.cost.tail`) before the driver-specific
-/// `SetWindowMode` / `SetWindowTitle` arms get their turn. Returns
-/// `true` when one of the framework arms matched (a reply has already
+/// iamacoffeepot/aether#1272 / #1710: route an inbound `aether.window`
+/// envelope through the framework-built-in dispatch arms
+/// (`aether.log.tail` / `aether.trace.tail` / `aether.cost.tail`) before
+/// the driver-specific `SetWindowMode` / `SetWindowTitle` arms get their
+/// turn. Each helper computes-and-returns its `*TailResult`; on a match
+/// the reply rides the inbound's drain guard — [`InboundMail::reply`]
+/// mints the reply id on the drain-owned counter and stamps the
+/// inbound's `root` / parent, so the framework-arm reply joins the
+/// caller's ADR-0080 chain exactly like the window-mode / title arms.
+/// Returns `true` when one of the framework arms matched (the reply has
 /// been routed); `false` otherwise. ADR-0081 §1 promises every mailbox
 /// serves these kinds — see the issue body for the contract.
 ///
@@ -377,11 +387,25 @@ fn resolve_fullscreen(
 /// log / trace arms reach the driver's per-actor ring. Factored out of
 /// [`App::dispatch_window_envelope`] so the unit test directly drives
 /// the routing shape without standing up a winit `App`.
-fn try_framework_dispatch(mailer: &Arc<Mailer>, self_mailbox: MailboxId, env: &Envelope) -> bool {
-    let m = mailer.as_ref();
-    dispatch_log_tail_if_matching_free(m, env.sender, env)
-        || dispatch_trace_tail_if_matching_free(m, env.sender, env)
-        || dispatch_cost_tail_if_matching_free(m, env.sender, self_mailbox, env)
+fn try_framework_dispatch(
+    mailer: &Arc<Mailer>,
+    self_mailbox: MailboxId,
+    mail: &InboundMail,
+) -> bool {
+    let env = mail.envelope();
+    if let Some(result) = dispatch_log_tail_if_matching_free(env) {
+        mail.reply(&result);
+        return true;
+    }
+    if let Some(result) = dispatch_trace_tail_if_matching_free(env) {
+        mail.reply(&result);
+        return true;
+    }
+    if let Some(result) = dispatch_cost_tail_if_matching_free(mailer.as_ref(), self_mailbox, env) {
+        mail.reply(&result);
+        return true;
+    }
+    false
 }
 
 /// The disposition of one consumed `aether.lifecycle.advance_reply`
@@ -789,8 +813,9 @@ impl App {
         // `DispatcherSlot::run_cycle`'s ordering. Factored into a free
         // fn so the desktop-driver unit test exercises the routing shape
         // directly without standing up a winit `App`. On a match the
-        // free fn has already replied; the guard settles on return.
-        if try_framework_dispatch(&self.queue, self.window_mailbox, mail.envelope()) {
+        // helper has already replied through `mail`'s drain guard (the
+        // chain-joined path, #1710); the guard settles on return.
+        if try_framework_dispatch(&self.queue, self.window_mailbox, &mail) {
             return;
         }
         if mail.kind() == self.kind_set_window_mode {
@@ -851,10 +876,14 @@ impl App {
     /// the wire `Call` would hang on its settlement hold until timeout.
     /// Here we take the parked entry, drain its `after_mails` (parity with
     /// the `RedrawRequested` service arm), reply `Err` via the `Mailer`
-    /// (`self.queue.send_reply`, never `self.outbound` — `HubOutbound`
-    /// drops `SourceAddr::Component`, iamacoffeepot/aether#1316), then let
-    /// the request drop *after* the reply so the ADR-0086 §12 settlement
-    /// hold's `Release` fires post-reply (iamacoffeepot/aether#1273).
+    /// (`self.queue.send_reply_unchained`, never `self.outbound` —
+    /// `HubOutbound` drops `SourceAddr::Component`,
+    /// iamacoffeepot/aether#1316), then let the request drop *after* the
+    /// reply so the ADR-0086 §12 settlement hold's `Release` fires
+    /// post-reply (iamacoffeepot/aether#1273). The capture reply is
+    /// wire-terminal — its settlement is the ADR-0086 hold above, not an
+    /// ADR-0080 inbound chain — so the lineage-less unchained form is the
+    /// right one (#1710).
     ///
     /// The slot is taken only when occluded, so a visible-window wake never
     /// steals the entry `RedrawRequested` is about to service.
@@ -873,11 +902,11 @@ impl App {
                 }
                 // `reply_to` is `Copy`, so this read leaves `request` whole;
                 // it (and its `PendingCapture._hold`) drops at end of this
-                // scope — *after* `send_reply` returns — firing `Release` on
-                // the trace root so `Settled{root}` is exact post-reply.
-                // Don't restructure to move the reply below other work
-                // (iamacoffeepot/aether#1273 drop-order discipline).
-                self.queue.send_reply(request.reply_to, &result);
+                // scope — *after* `send_reply_unchained` returns — firing
+                // `Release` on the trace root so `Settled{root}` is exact
+                // post-reply. Don't restructure to move the reply below
+                // other work (iamacoffeepot/aether#1273 drop-order discipline).
+                self.queue.send_reply_unchained(request.reply_to, &result);
                 true
             }
         }
@@ -1117,11 +1146,15 @@ impl ApplicationHandler<UserEvent> for App {
                                 //noinspection DuplicatedCode
                                 self.queue.push(mail);
                             }
-                            self.queue.send_reply(req.reply_to, &result);
+                            // Wire-terminal capture reply: its settlement is
+                            // the ADR-0086 §12 hold `req` owns, not an
+                            // ADR-0080 inbound chain, so the lineage-less
+                            // unchained form is correct (#1710).
+                            self.queue.send_reply_unchained(req.reply_to, &result);
                             // iamacoffeepot/aether#1273: `req` still owns
                             // `PendingCapture._hold` after the partial moves
                             // above; the field drops at end of this scope —
-                            // *after* `send_reply` returns — firing
+                            // *after* `send_reply_unchained` returns — firing
                             // `Release` on the trace root so `Settled{root}`
                             // is exact at post-reply. Don't restructure to
                             // move the reply below other work in this arm.
@@ -1131,7 +1164,8 @@ impl ApplicationHandler<UserEvent> for App {
                         }
                     }
                 } else if let Some(req) = pending_capture {
-                    self.queue.send_reply(
+                    // Wire-terminal capture reply (#1710): lineage is moot.
+                    self.queue.send_reply_unchained(
                         req.reply_to,
                         &CaptureFrameResult::Err {
                             error: "capture requested before GPU initialized".to_owned(),
@@ -1518,131 +1552,170 @@ mod tests {
         assert!(matches!(m, WindowMode::Windowed));
     }
 
-    /// iamacoffeepot/aether#1272: a `LogTail` envelope routed at the
-    /// driver's `aether.window` mailbox produces a `LogTailResult`
-    /// reply via the framework-built-in dispatch arm. Pre-fix the
-    /// driver's bespoke "unrecognised kind → warn-drop" tail ate the
-    /// envelope and `actor_logs aether.window` hung waiting for a
-    /// reply that never came; this test pins the fix at the
-    /// driver-dispatch layer without standing up wgpu/winit.
+    /// iamacoffeepot/aether#1272 / #1710: a `LogTail` Call drained at the
+    /// driver's `aether.window` mailbox produces a `LogTailResult` reply
+    /// through the inbound's drain guard — and that reply joins the
+    /// inbound's ADR-0080 causal chain (it carries the inbound's `root`)
+    /// rather than minting the lineage-less `MailId::NONE` triple the
+    /// pre-#1710 bare `Mailer::send_reply` form did. Drives a real armed
+    /// Call through a `ClaimedInbox` (mirroring
+    /// `window_inbox_drain_settles_root_on_guard_drop`), routes the reply
+    /// at a captured `Component` inbox, and reads the delivered reply's
+    /// `root` — without standing up wgpu/winit.
     #[test]
     fn try_framework_dispatch_replies_to_log_tail() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
         use aether_actor::local::{ActorSlots, with_stamped};
-        use aether_data::KindId;
-        use aether_data::{MailId, SessionToken};
+        use aether_data::MailId;
         use aether_kinds::descriptors;
-        use aether_kinds::trace::Nanos;
         use aether_kinds::{LogTail, LogTailResult};
+        use aether_substrate::ClaimedInbox;
+        use aether_substrate::chassis::settlement::SettlementRegistry;
         use aether_substrate::handle_store::HandleStore;
-        use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
-        use aether_substrate::mail::registry::Registry;
-        use aether_substrate::mail::{MailRef, Source, SourceAddr};
+        use aether_substrate::mail::Mail;
+        use aether_substrate::mail::registry::{InboxHandler, OwnedDispatch, Registry};
+        use aether_substrate::mail::{Source, SourceAddr};
 
         let registry = Arc::new(Registry::new());
         for d in descriptors::all() {
             let _ = registry.register_kind_with_descriptor(d);
         }
-        let (outbound, rx) = HubOutbound::attached_loopback();
         let store = Arc::new(HandleStore::new(1024 * 1024));
-        let mailer = Arc::new(Mailer::new(registry, store).with_outbound(outbound));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
 
-        let request = LogTail {
+        // Wire one settlement registry into both seams (the chassis builder
+        // does both installs at boot) so an armed Call drains cleanly.
+        let settlement = Arc::new(SettlementRegistry::new());
+        mailer.install_settlement_registry(Arc::clone(&settlement));
+        mailer
+            .trace_handle()
+            .install_settlement_registry(Arc::clone(&settlement));
+
+        // A `Component` caller inbox captures the reply so the test reads
+        // its delivered `root`.
+        let (reply_tx, reply_rx) = mpsc::channel::<OwnedDispatch>();
+        let caller_mailbox = registry.register_inbox(
+            "test.window.log_tail.caller",
+            Arc::new(move |dispatch: OwnedDispatch| {
+                dispatch.discharge();
+                let _ = reply_tx.send(dispatch);
+            }) as Arc<dyn InboxHandler>,
+        );
+
+        // The window inbox forwards armed envelopes onto the
+        // `ClaimedInbox`'s channel, exactly as `claim_mailbox` does.
+        let window_mailbox = mailbox_id_from_name("aether.window");
+        let (tx, rx) = mpsc::channel::<Envelope>();
+        let handler: Arc<dyn InboxHandler> = Arc::new(move |d: Envelope| {
+            let _ = tx.send(d);
+        });
+        registry
+            .try_register_inbox_with_id(window_mailbox, "aether.window", handler)
+            .expect("register the window inbox");
+        let inbox = ClaimedInbox::new(window_mailbox, rx, Arc::clone(&mailer));
+
+        // Push a real armed `LogTail` Call whose reply target is the
+        // caller inbox, then drain it to an `InboundMail` guard.
+        let root = MailId::new(window_mailbox, 1);
+        let mail_id = MailId::new(window_mailbox, 2);
+        mailer.record_sent_inflight(root);
+        let caller_source = Source::with_correlation(SourceAddr::Component(caller_mailbox), 0x99);
+        let bytes = postcard::to_allocvec(&LogTail {
             max: 8,
             min_level: None,
             since: None,
-        };
-        let bytes = postcard::to_allocvec(&request).expect("encode LogTail");
-        let session = SessionToken::NIL;
-        let reply_to = Source::with_correlation(SourceAddr::Session(session), 0x99);
-        let env = Envelope::disarmed(
-            KindId(<LogTail as Kind>::ID.0),
-            <LogTail as Kind>::NAME.to_owned(),
-            None,
-            reply_to,
-            MailRef::from(bytes),
-            1,
-            MailId::NONE,
-            MailId::NONE,
-            None,
-            Nanos(0),
-            0,
-            MailboxId(0),
+        })
+        .expect("encode LogTail");
+        mailer.push(
+            Mail::new(window_mailbox, <LogTail as Kind>::ID, bytes, 1)
+                .with_reply_to(caller_source)
+                .with_lineage(mail_id, root, None),
         );
+        let mail = inbox.try_next().expect("the armed LogTail Call is queued");
 
-        let window_mailbox = mailbox_id_from_name("aether.window");
         let slots = ActorSlots::new();
         let matched = with_stamped(&slots, || {
-            try_framework_dispatch(&mailer, window_mailbox, &env)
+            try_framework_dispatch(&mailer, window_mailbox, &mail)
         });
         assert!(
             matched,
-            "framework dispatch arm must match a LogTail envelope at aether.window",
+            "framework dispatch arm must match a LogTail Call at aether.window",
         );
 
-        let event = rx.try_recv().expect("framework arm routed a reply");
-        match event {
-            EgressEvent::ToSession {
-                kind_name,
-                correlation_id,
-                ..
-            } => {
-                assert_eq!(kind_name, <LogTailResult as Kind>::NAME);
-                assert_eq!(correlation_id, 0x99);
-            }
-            other => panic!("expected ToSession reply, got {other:?}"),
-        }
+        let dispatch = reply_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("framework arm routed a reply to the caller inbox");
+        assert_eq!(
+            dispatch.kind_name,
+            <LogTailResult as Kind>::NAME,
+            "the reply is a LogTailResult",
+        );
+        assert_eq!(
+            dispatch.root, root,
+            "the framework-arm reply joins the inbound's causal chain (#1710)",
+        );
+
+        // Drop the guard last so its `Finished` records after the reply's
+        // `Sent` (ADR-0080 §6) — settlement bookkeeping stays balanced.
+        drop(mail);
     }
 
     /// A non-framework kind (here `SetWindowTitle`) does NOT trip the
     /// framework arms — the driver-specific path keeps its turn so
     /// `actor_logs`-style queries don't shadow the existing window
-    /// controls.
+    /// controls. The helpers return `None` and the driver dispatch
+    /// continues; nothing is replied here.
     #[test]
     fn try_framework_dispatch_skips_window_kinds() {
+        use std::sync::mpsc;
+
         use aether_actor::local::{ActorSlots, with_stamped};
-        use aether_data::KindId;
         use aether_data::MailId;
         use aether_kinds::descriptors;
-        use aether_kinds::trace::Nanos;
+        use aether_substrate::ClaimedInbox;
         use aether_substrate::handle_store::HandleStore;
-        use aether_substrate::mail::outbound::HubOutbound;
-        use aether_substrate::mail::registry::Registry;
-        use aether_substrate::mail::{MailRef, Source};
+        use aether_substrate::mail::Mail;
+        use aether_substrate::mail::registry::{InboxHandler, Registry};
 
         let registry = Arc::new(Registry::new());
         for d in descriptors::all() {
             let _ = registry.register_kind_with_descriptor(d);
         }
-        let (outbound, rx) = HubOutbound::attached_loopback();
         let store = Arc::new(HandleStore::new(1024 * 1024));
-        let mailer = Arc::new(Mailer::new(registry, store).with_outbound(outbound));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
 
+        let window_mailbox = mailbox_id_from_name("aether.window");
+        let (tx, rx) = mpsc::channel::<Envelope>();
+        let handler: Arc<dyn InboxHandler> = Arc::new(move |d: Envelope| {
+            let _ = tx.send(d);
+        });
+        registry
+            .try_register_inbox_with_id(window_mailbox, "aether.window", handler)
+            .expect("register the window inbox");
+        let inbox = ClaimedInbox::new(window_mailbox, rx, Arc::clone(&mailer));
+
+        // A `MailId::NONE` push keeps the drained guard disarmed (no armed
+        // Call to settle) — the test pins only the skip verdict.
         let payload = postcard::to_allocvec(&SetWindowTitle {
             title: "ignored".to_owned(),
         })
         .expect("encode SetWindowTitle");
-        let env = Envelope::disarmed(
-            KindId(<SetWindowTitle as Kind>::ID.0),
-            <SetWindowTitle as Kind>::NAME.to_owned(),
-            None,
-            Source::NONE,
-            MailRef::from(payload),
-            1,
-            MailId::NONE,
-            MailId::NONE,
-            None,
-            Nanos(0),
-            0,
-            MailboxId(0),
+        mailer.push(
+            Mail::new(window_mailbox, <SetWindowTitle as Kind>::ID, payload, 1).with_lineage(
+                MailId::NONE,
+                MailId::NONE,
+                None,
+            ),
         );
+        let mail = inbox.try_next().expect("the SetWindowTitle push is queued");
 
-        let window_mailbox = mailbox_id_from_name("aether.window");
         let slots = ActorSlots::new();
         let matched = with_stamped(&slots, || {
-            try_framework_dispatch(&mailer, window_mailbox, &env)
+            try_framework_dispatch(&mailer, window_mailbox, &mail)
         });
         assert!(!matched, "SetWindowTitle is a driver-specific kind");
-        assert!(rx.try_recv().is_err(), "no reply emitted on skip path");
     }
 
     /// iamacoffeepot/aether#1325, re-homed on ADR-0106: the window inbox
@@ -1858,7 +1931,7 @@ mod tests {
 
     /// iamacoffeepot/aether#1317: the occluded-capture branch selection.
     /// This is the CI-runnable core of the fail-fast — the winit wiring
-    /// (`fail_capture_if_occluded` → `take` → `send_reply` → drop) stays
+    /// (`fail_capture_if_occluded` → `take` → `send_reply_unchained` → drop) stays
     /// MCP-manual because `ControlFlow::Wait` + `RedrawRequested`
     /// suppression has no CI display surface. Here we pin only the pure
     /// branch logic: occluded-with-parked-capture selects an `Err` reply,

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -33,7 +33,7 @@ use crate::actor::native::ctx::NativeCtx;
 use crate::actor::native::envelope::Envelope;
 use crate::actor::native::{NativeActor, NativeDispatch};
 use crate::mail::mailer::Mailer;
-use crate::mail::{KindId, MailboxId, Source};
+use crate::mail::{KindId, MailboxId};
 
 /// Try the typed `#[handler]` dispatch; if no typed arm matches and
 /// the actor's `#[fallback]` also returns `false`, warn that the kind
@@ -151,96 +151,83 @@ pub fn dispatch_cost_tail_if_matching(
     true
 }
 
-/// iamacoffeepot/aether#1272: `NativeCtx`-free variant of
+/// iamacoffeepot/aether#1272 / #1710: `NativeCtx`-free variant of
 /// `dispatch_log_tail_if_matching` for driver-as-actor capabilities
 /// that own their inbox drain inline (today only the desktop window
 /// driver). Reads the receiving actor's `ActorLogRing` through the
-/// currently-stamped `ActorSlots` and routes the reply via the supplied
-/// `Mailer::send_reply` — the same path `NativeCtx::reply` goes through.
+/// currently-stamped `ActorSlots` and **returns** the computed
+/// `LogTailResult` — `None` when the kind didn't match (the caller's
+/// own arms get their turn), `Some(result)` when it did (the caller
+/// replies through its lineage-joined drain guard). This helper sends
+/// nothing: the reply id is minted on the drain-owned counter the
+/// guard holds, so routing the reply here would detach it from the
+/// caller's settlement chain (#1710).
 ///
 /// Caller invariant: this must be called inside a
 /// `local::with_stamped(&actor_slots, …)` block so `ActorLogRing::try_with`
 /// resolves to the driver's per-actor ring.
-pub fn dispatch_log_tail_if_matching_free(
-    mailer: &Mailer,
-    reply_to: Source,
-    env: &Envelope,
-) -> bool {
+#[must_use]
+pub fn dispatch_log_tail_if_matching_free(env: &Envelope) -> Option<LogTailResult> {
     if env.kind.0 != <LogTail as Kind>::ID.0 {
-        return false;
+        return None;
     }
     let Some(request) = <LogTail as Kind>::decode_from_bytes(env.payload.bytes()) else {
-        mailer.send_reply(
-            reply_to,
-            &LogTailResult::Err {
-                error: "aether.log.tail: payload failed to decode".to_owned(),
-            },
-        );
-        return true;
+        return Some(LogTailResult::Err {
+            error: "aether.log.tail: payload failed to decode".to_owned(),
+        });
     };
-    let reply =
+    Some(
         ActorLogRing::try_with(|ring| ring.tail(&request)).unwrap_or_else(|| LogTailResult::Err {
             error: "aether.log.tail: actor has no stamped slots".to_owned(),
-        });
-    mailer.send_reply(reply_to, &reply);
-    true
+        }),
+    )
 }
 
-/// iamacoffeepot/aether#1272: `NativeCtx`-free counterpart of
-/// `dispatch_trace_tail_if_matching`. See
-/// [`dispatch_log_tail_if_matching_free`] for the caller invariant.
-pub fn dispatch_trace_tail_if_matching_free(
-    mailer: &Mailer,
-    reply_to: Source,
-    env: &Envelope,
-) -> bool {
+/// iamacoffeepot/aether#1272 / #1710: `NativeCtx`-free counterpart of
+/// `dispatch_trace_tail_if_matching`. Compute-and-return like
+/// [`dispatch_log_tail_if_matching_free`]; see it for the caller
+/// invariant and the reasoning the helper sends nothing.
+#[must_use]
+pub fn dispatch_trace_tail_if_matching_free(env: &Envelope) -> Option<TraceTailResult> {
     if env.kind.0 != <TraceTail as Kind>::ID.0 {
-        return false;
+        return None;
     }
     let Some(request) = <TraceTail as Kind>::decode_from_bytes(env.payload.bytes()) else {
-        mailer.send_reply(
-            reply_to,
-            &TraceTailResult::Err {
-                error: "aether.trace.tail: payload failed to decode".to_owned(),
-            },
-        );
-        return true;
+        return Some(TraceTailResult::Err {
+            error: "aether.trace.tail: payload failed to decode".to_owned(),
+        });
     };
-    let reply = ActorTraceRing::try_with(|ring| ring.tail(&request)).unwrap_or_else(|| {
-        TraceTailResult::Err {
-            error: "aether.trace.tail: actor has no stamped slots".to_owned(),
-        }
-    });
-    mailer.send_reply(reply_to, &reply);
-    true
+    Some(
+        ActorTraceRing::try_with(|ring| ring.tail(&request)).unwrap_or_else(|| {
+            TraceTailResult::Err {
+                error: "aether.trace.tail: actor has no stamped slots".to_owned(),
+            }
+        }),
+    )
 }
 
-/// iamacoffeepot/aether#1272: `NativeCtx`-free counterpart of
+/// iamacoffeepot/aether#1272 / #1710: `NativeCtx`-free counterpart of
 /// `dispatch_cost_tail_if_matching`. The cost table doesn't depend on
 /// stamped `ActorSlots` — it's read directly off the mailer — so the
 /// `self_mailbox` rides along explicitly (the standard variant pulls it
-/// from `binding.self_mailbox()`).
+/// from `binding.self_mailbox()`). Still takes `&Mailer` only to read
+/// `cost_table()`; like its siblings it computes-and-returns and sends
+/// nothing.
+#[must_use]
 pub fn dispatch_cost_tail_if_matching_free(
     mailer: &Mailer,
-    reply_to: Source,
     self_mailbox: MailboxId,
     env: &Envelope,
-) -> bool {
+) -> Option<CostTailResult> {
     if env.kind.0 != <CostTail as Kind>::ID.0 {
-        return false;
+        return None;
     }
     let Some(request) = <CostTail as Kind>::decode_from_bytes(env.payload.bytes()) else {
-        mailer.send_reply(
-            reply_to,
-            &CostTailResult::Err {
-                error: "aether.cost.tail: payload failed to decode".to_owned(),
-            },
-        );
-        return true;
+        return Some(CostTailResult::Err {
+            error: "aether.cost.tail: payload failed to decode".to_owned(),
+        });
     };
-    let reply = mailer.cost_table().tail(self_mailbox, &request);
-    mailer.send_reply(reply_to, &reply);
-    true
+    Some(mailer.cost_table().tail(self_mailbox, &request))
 }
 
 /// iamacoffeepot/aether#1128 dark-instrumentation fold. Folds one
@@ -395,30 +382,29 @@ mod free_dispatch_tests {
     use super::*;
     use crate::handle_store::HandleStore;
     use crate::mail::mailer::Mailer;
-    use crate::mail::outbound::{EgressEvent, HubOutbound};
     use crate::mail::registry::Registry;
-    use crate::mail::{MailRef, SourceAddr};
+    use crate::mail::{MailRef, Source, SourceAddr};
     use aether_actor::local::{ActorSlots, with_stamped};
-    use aether_data::{MailId, SessionToken};
+    use aether_data::MailId;
     use aether_kinds::SetWindowTitle;
     use aether_kinds::descriptors;
     use aether_kinds::trace::Nanos;
     use std::sync::Arc;
-    use std::sync::mpsc;
 
-    fn fresh_substrate_with_outbound() -> (Arc<Mailer>, mpsc::Receiver<EgressEvent>) {
+    fn fresh_substrate() -> Arc<Mailer> {
         let registry = Arc::new(Registry::new());
         for d in descriptors::all() {
             let _ = registry.register_kind_with_descriptor(d);
         }
-        let (outbound, rx) = HubOutbound::attached_loopback();
         let store = Arc::new(HandleStore::new(1024 * 1024));
-        let mailer = Arc::new(Mailer::new(registry, store).with_outbound(outbound));
-        (mailer, rx)
+        Arc::new(Mailer::new(registry, store))
     }
 
-    fn build_envelope<K: Kind>(payload: &K, reply_to: Source) -> Envelope {
+    fn build_envelope<K: Kind>(payload: &K) -> Envelope {
         let bytes = payload.encode_into_bytes();
+        // The helpers ignore the envelope's sender (they no longer reply —
+        // the caller's drain guard does), so any reply target serves.
+        let reply_to = Source::with_correlation(SourceAddr::None, 0);
         Envelope::disarmed(
             KindId(<K as Kind>::ID.0),
             <K as Kind>::NAME.to_owned(),
@@ -435,114 +421,69 @@ mod free_dispatch_tests {
         )
     }
 
-    /// The free-fn log-tail arm fires a `LogTailResult` reply to the
-    /// envelope's `sender` when the kind matches — the property the
-    /// desktop window driver (iamacoffeepot/aether#1272) relies on so
-    /// `actor_logs aether.window` resolves instead of hanging on a
-    /// never-arriving reply.
+    /// The free-fn log-tail arm returns its computed `LogTailResult` when
+    /// the kind matches — the caller (the desktop window driver) replies
+    /// it through its lineage-joined drain guard. #1710: the helper sends
+    /// nothing itself.
     #[test]
-    fn dispatch_log_tail_free_replies_on_match() {
-        let (mailer, rx) = fresh_substrate_with_outbound();
-        let session = SessionToken::NIL;
-        let reply_to = Source::with_correlation(SourceAddr::Session(session), 0x1272_4242);
-        let env = build_envelope(
-            &LogTail {
-                max: 10,
-                min_level: None,
-                since: None,
-            },
-            reply_to,
-        );
+    fn dispatch_log_tail_free_returns_some_on_match() {
+        let env = build_envelope(&LogTail {
+            max: 10,
+            min_level: None,
+            since: None,
+        });
 
         // The arm reads `ActorLogRing::try_with`, so it must run inside a
         // `with_stamped` block. Stamping with a fresh slot map makes the
-        // ring resolve to its default (empty) — the reply lands as
+        // ring resolve to its default (empty) — the result is
         // `LogTailResult::Ok { entries: [] }`.
         let slots = ActorSlots::new();
-        let matched = with_stamped(&slots, || {
-            dispatch_log_tail_if_matching_free(&mailer, reply_to, &env)
-        });
-        assert!(matched, "log.tail kind matches");
-
-        let event = rx.try_recv().expect("reply egress recorded");
-        match event {
-            EgressEvent::ToSession {
-                session: got_session,
-                kind_name,
-                correlation_id,
-                ..
-            } => {
-                assert_eq!(got_session, session);
-                assert_eq!(kind_name, <LogTailResult as Kind>::NAME);
-                assert_eq!(correlation_id, 0x1272_4242);
-            }
-            other => panic!("expected ToSession egress, got {other:?}"),
-        }
+        let result = with_stamped(&slots, || dispatch_log_tail_if_matching_free(&env));
+        assert!(
+            matches!(result, Some(LogTailResult::Ok { ref entries, .. }) if entries.is_empty()),
+            "log.tail kind matches and returns an empty Ok, got {result:?}",
+        );
     }
 
-    /// Non-matching kinds fall through without replying — the driver's
-    /// existing `kind_set_window_mode` / `kind_set_window_title` arms
-    /// still get their chance after the framework arms return `false`.
+    /// Non-matching kinds return `None` — the driver's existing
+    /// `kind_set_window_mode` / `kind_set_window_title` arms still get
+    /// their chance after the framework arms decline.
     #[test]
-    fn dispatch_log_tail_free_skips_non_match() {
-        let (mailer, rx) = fresh_substrate_with_outbound();
-        let session = SessionToken::NIL;
-        let reply_to = Source::with_correlation(SourceAddr::Session(session), 0);
+    fn dispatch_log_tail_free_returns_none_on_non_match() {
         // Build an envelope of a different kind (`SetWindowTitle`); the
-        // arm must early-return `false` and emit nothing.
-        let env = build_envelope(
-            &SetWindowTitle {
-                title: "test".to_owned(),
-            },
-            reply_to,
-        );
+        // arm must return `None`.
+        let env = build_envelope(&SetWindowTitle {
+            title: "test".to_owned(),
+        });
 
         let slots = ActorSlots::new();
-        let matched = with_stamped(&slots, || {
-            dispatch_log_tail_if_matching_free(&mailer, reply_to, &env)
-        });
-        assert!(!matched, "non-log.tail kind doesn't match");
-        assert!(rx.try_recv().is_err(), "skip path emits no reply egress");
+        let result = with_stamped(&slots, || dispatch_log_tail_if_matching_free(&env));
+        assert!(result.is_none(), "non-log.tail kind returns None");
     }
 
     /// The trace-tail and cost-tail free fns are siblings of the log-tail
-    /// arm; smoke-test both fire their reply on a matched envelope so a
+    /// arm; smoke-test both return `Some` on a matched envelope so a
     /// future contract slip on either kind doesn't silently regress
     /// `actor_logs`-style queries against the desktop driver.
     #[test]
-    fn dispatch_trace_and_cost_tail_free_reply_on_match() {
-        let (mailer, rx) = fresh_substrate_with_outbound();
+    fn dispatch_trace_and_cost_tail_free_return_some_on_match() {
+        let mailer = fresh_substrate();
         let self_mbx = MailboxId(0x1272_AAAA);
-        let session = SessionToken::NIL;
-        let reply_to = Source::with_correlation(SourceAddr::Session(session), 0xCAFE);
 
-        let trace_env = build_envelope(
-            &TraceTail {
-                max: 16,
-                since: None,
-                root: None,
-            },
-            reply_to,
-        );
-        let cost_env = build_envelope(&CostTail { kind: None }, reply_to);
+        let trace_env = build_envelope(&TraceTail {
+            max: 16,
+            since: None,
+            root: None,
+        });
+        let cost_env = build_envelope(&CostTail { kind: None });
 
         let slots = ActorSlots::new();
-        let (trace_match, cost_match) = with_stamped(&slots, || {
-            let trace = dispatch_trace_tail_if_matching_free(&mailer, reply_to, &trace_env);
-            let cost = dispatch_cost_tail_if_matching_free(&mailer, reply_to, self_mbx, &cost_env);
+        let (trace, cost) = with_stamped(&slots, || {
+            let trace = dispatch_trace_tail_if_matching_free(&trace_env);
+            let cost = dispatch_cost_tail_if_matching_free(&mailer, self_mbx, &cost_env);
             (trace, cost)
         });
-        assert!(trace_match);
-        assert!(cost_match);
-
-        // Two replies must have been routed; both `ToSession`.
-        let names: Vec<String> = (0..2)
-            .map(|_| match rx.try_recv().expect("reply egress recorded") {
-                EgressEvent::ToSession { kind_name, .. } => kind_name,
-                other => panic!("expected ToSession egress, got {other:?}"),
-            })
-            .collect();
-        assert!(names.iter().any(|n| n == <TraceTailResult as Kind>::NAME));
-        assert!(names.iter().any(|n| n == <CostTailResult as Kind>::NAME));
+        assert!(trace.is_some(), "trace.tail kind matches");
+        assert!(cost.is_some(), "cost.tail kind matches");
     }
 }

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -414,20 +414,33 @@ impl Mailer {
         Ok(())
     }
 
-    /// Route a chassis-bound mailbox's `*Result` reply to `sender` with
-    /// a single encode and no inherited lineage — the reply opens as a
-    /// fresh, lineage-less mail (the `MailId::NONE` triple). This is the
-    /// shape for substrate-internal synthesized replies and chassis caps
-    /// that manage their own settlement (the desktop window / render
-    /// drivers); handler replies that should join the caller's ADR-0080
-    /// causal chain go through [`Self::send_reply_with_lineage`] (the
-    /// `NativeBinding::send_reply_for_handler` path).
+    /// Route a `*Result` reply to `sender` with a single encode and **no
+    /// inherited lineage** — the reply opens as a fresh, lineage-less mail
+    /// (the `MailId::NONE` triple), detached from any caller settlement
+    /// chain. The name says so loudly: detachment is a deliberate choice,
+    /// not the default a short name invites.
+    ///
+    /// Reach for this only on the two arms where lineage is structurally
+    /// moot: wire-terminal replies whose `sender` is a `Session` /
+    /// `EngineMailbox` (the hub-wire boundary is terminal for engine-side
+    /// chain accounting — the lineage would not be applied anyway), and
+    /// substrate-internal synthesized replies with no caller chain to join.
+    ///
+    /// A reply that should join the caller's ADR-0080 causal chain goes
+    /// through the lineage-carrying path instead:
+    /// [`Self::send_reply_with_lineage`] (the
+    /// `NativeBinding::send_reply_for_handler` form),
+    /// [`InboundMail::reply`](crate::chassis::inbox::InboundMail::reply)
+    /// (the claimed-inbox drain guard), or the typed `ctx.reply()` on a
+    /// handler context. Routing a `Component`-addressed reply through this
+    /// unchained form silently detaches it from the caller's settlement
+    /// window — the bug class #1701 fixed for handler replies.
     ///
     /// Equivalent to [`Self::send_reply_with_lineage`] with a `NONE`
     /// triple — the bare-vs-lineage split mirrors
     /// [`NativeBinding::send_mail`](crate::actor::native::NativeBinding)'s
     /// `send_mail` / `send_mail_with_lineage` pair.
-    pub fn send_reply<K>(&self, sender: Source, result: &K) -> bool
+    pub fn send_reply_unchained<K>(&self, sender: Source, result: &K) -> bool
     where
         K: Kind,
     {
@@ -463,7 +476,7 @@ impl Mailer {
     /// `NativeBinding::send_reply_for_handler`. A `MailId::NONE`
     /// `reply_id` skips the hook and stamps the `NONE` triple,
     /// reproducing the pre-lineage reply shape for callers without a
-    /// handler chain (the bare [`Self::send_reply`]).
+    /// handler chain (the bare [`Self::send_reply_unchained`]).
     pub fn send_reply_with_lineage<K>(
         &self,
         sender: Source,
@@ -493,7 +506,7 @@ impl Mailer {
                 // ADR-0080 §2 producer hook: record the reply's `Sent`
                 // before pushing it, so the caller's `root` counts the
                 // reply in-flight until its `Finished`. Skipped for the
-                // `NONE` reply id (the bare `send_reply` lineage-less path).
+                // `NONE` reply id (the bare `send_reply_unchained` path).
                 if reply_id != aether_data::MailId::NONE {
                     self.record_sent(reply_id, root, parent, reply_id.sender, mailbox, K::ID);
                 }
@@ -1214,7 +1227,7 @@ mod tests {
         }
     }
 
-    /// ADR-0100: `Mailer::send_reply` to a `Component` target encodes the
+    /// ADR-0100: `Mailer::send_reply_unchained` to a `Component` target encodes the
     /// reply through `Kind::encode_into_bytes`. A cast reply kind reaches
     /// the sink as its raw cast image, not a postcard varint image — and
     /// a `Pod`-without-`Serialize` kind is repliable at all.
@@ -1229,7 +1242,7 @@ mod tests {
             flag: 0xABCD,
             _pad: 0,
         };
-        let sent = mailer.send_reply(
+        let sent = mailer.send_reply_unchained(
             Source::with_correlation(SourceAddr::Component(sink_id), 1),
             &reply,
         );


### PR DESCRIPTION
Closes #1710.

## Summary

`Mailer::send_reply` minted the un-lineaged `MailId::NONE` triple under the short, obvious name, with chain-joining correctness opt-in via the longer `send_reply_with_lineage` — so a reply sent through the bare form to a `Component` target silently detached from the caller's settlement window (the #1701 bug class, for the call sites the ADR-0106 drain guard doesn't reach).

This retires the bare name rather than re-defaulting it:

- `Mailer::send_reply` is renamed to `send_reply_unchained` (same body — the `NONE` triple), so detachment is a loud, greppable choice instead of the default a short name invites; chain-joiners are pointed at `send_reply_with_lineage` / `InboundMail::reply` / `ctx.reply()`. `HubOutbound::send_reply` is a distinct wire-boundary method and is untouched.
- The three `HeadlessWindowCapability` handlers move onto the typed `ctx.reply()` path (mints the reply id, inherits the handler's chain).
- The framework-arm tail helpers `dispatch_{log,trace,cost}_tail_if_matching_free` become pure compute-and-return `Option<*TailResult>` (they no longer send), and `try_framework_dispatch` takes the `&InboundMail` guard the desktop driver already holds, routing each match through `mail.reply(&result)` — the guard's counter-minted, chain-joined lineage. Reply-id minting stays in one place (the drain-owned counter).
- The surviving `send_reply_unchained` callers are audited as wire-terminal (the desktop driver's capture-frame readback replies — `Session`/`EngineMailbox` targets) with a doc note that lineage is moot on the wire arm.

No settlement semantics change; no new ADR (ADR-0106 records the rationale).

## Test plan

- A `HeadlessWindowCapability` conformance case (`err_reply_joins_caller_chain`) asserts each handler's `Err` reply holds the caller root open (`live_roots() == 1`) until its `Finished`.
- The `dispatch.rs` free-fn tests are rewritten to assert the returned `Option`; the driver's `try_framework_dispatch_replies_to_log_tail` is rewritten as a `ClaimedInbox`-driven case asserting the `LogTail` reply carries the inbound's `root`.
- `cargo nextest run --workspace --all-features` (1750 passed, 6 skipped), `cargo clippy --workspace --all-targets --all-features -D warnings`, `cargo doc`, and `scripts/preflight.sh --qodana` (0 findings) all clean.

## Generated by

`/implement` — agent execution of [scoped issue #1710](https://github.com/iamacoffeepot/aether/issues/1710).
