### PR TITLE
fix(substrate): settle parked mail when the handle store tears down

### DIFF
--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -47,6 +47,7 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::fs;
 use std::io::{Error as IoError, ErrorKind, Write as _};
+use std::mem;
 use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -1894,7 +1895,7 @@ impl HandleStore {
             .inner
             .write()
             .expect("handle store lock poisoned; fail-fast per ADR-0063");
-        std::mem::take(&mut inner.parked)
+        mem::take(&mut inner.parked)
             .into_values()
             .flatten()
             .collect()

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -1875,6 +1875,31 @@ impl HandleStore {
         inner.parked.remove(&id).map_or_else(Vec::new, Into::into)
     }
 
+    /// Drain every parked queue and return all held mails, flattened in
+    /// FIFO order within each handle's queue (cross-handle order is
+    /// unspecified). The `parked` map is replaced with an empty one so
+    /// every subsequent [`Self::parked_count`] call returns 0.
+    ///
+    /// This is the teardown-only counterpart to [`Self::take_parked`],
+    /// which drains a single handle's queue for live replay. Call it
+    /// from the terminal owner of parked mail (the `Mailer`'s `Drop`)
+    /// once routing can no longer replay any parked entry.
+    ///
+    /// # Panics
+    /// Panics if the inner `RwLock` is poisoned — fail-fast per
+    /// ADR-0063: a poisoned lock means a prior holder panicked under
+    /// the guard.
+    pub fn drain_all_parked(&self) -> Vec<Mail> {
+        let mut inner = self
+            .inner
+            .write()
+            .expect("handle store lock poisoned; fail-fast per ADR-0063");
+        std::mem::take(&mut inner.parked)
+            .into_values()
+            .flatten()
+            .collect()
+    }
+
     /// Sum of `bytes.len()` across every entry in the store.
     ///
     /// # Panics
@@ -2624,6 +2649,26 @@ mod tests {
         assert_eq!(drained[0].kind, KindId(1));
         assert_eq!(drained[1].kind, KindId(2));
         assert_eq!(store.parked_count(HandleId(42)), 0);
+    }
+
+    #[test]
+    fn drain_all_parked_returns_all_queues_and_clears() {
+        let store = HandleStore::new(64);
+        // Park two mails under one handle and one under another.
+        let m1 = Mail::new(MailboxId(0x01), KindId(10), vec![10], 0);
+        let m2 = Mail::new(MailboxId(0x02), KindId(11), vec![11], 0);
+        let m3 = Mail::new(MailboxId(0x03), KindId(12), vec![12], 0);
+        store.park(HandleId(1), m1);
+        store.park(HandleId(1), m2);
+        store.park(HandleId(2), m3);
+        assert_eq!(store.parked_count(HandleId(1)), 2);
+        assert_eq!(store.parked_count(HandleId(2)), 1);
+
+        let drained = store.drain_all_parked();
+        assert_eq!(drained.len(), 3, "all three mails must be returned");
+        // Every queue is cleared after the drain.
+        assert_eq!(store.parked_count(HandleId(1)), 0);
+        assert_eq!(store.parked_count(HandleId(2)), 0);
     }
 
     #[test]

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -521,6 +521,25 @@ impl Mailer {
     }
 }
 
+impl Drop for Mailer {
+    fn drop(&mut self) {
+        // The `Mailer` is the terminal owner of parked mail: once the last
+        // `Arc<Mailer>` drops, no routing call can reach `resolve_handle`
+        // and replay a parked entry. Every mail still parked at this point
+        // will never be delivered, so its `Sent` must be balanced with a
+        // `Finished` to settle the caller's chain (ADR-0080 §12 / ADR-0094).
+        //
+        // Parked mail is unarmed — it carries no `OwnedDispatch` obligation
+        // guard — so the settle is the single `record_finished` call, with
+        // no `discharge` half (contrast `InboundMail::drop`, where both
+        // fire). `record_finished` no-ops on `MailId::NONE`, so
+        // lineage-less parked mail is skipped with no double-count.
+        for mail in self.handle_store.drain_all_parked() {
+            self.trace_handle.record_finished(mail.mail_id, mail.root);
+        }
+    }
+}
+
 /// Resolve `mail.recipient` against the registry and dispatch
 /// inline. `Inbox`-bound mailboxes forward to an actor's mpsc on the caller
 /// thread (or fan out via the cap's mpsc, depending on the closure).
@@ -1565,6 +1584,81 @@ mod tests {
         assert!(
             rx.try_recv().is_ok(),
             "after publish, the resumed inline dispatch records Finished and the chain settles (issue 838)"
+        );
+    }
+
+    /// Counterpart to `ref_walk_parked_defers_finished_until_handle_publish`:
+    /// when a handle never resolves and the `Mailer` tears down, every
+    /// still-parked mail must settle rather than hanging the chain to the
+    /// 600-second MCP timeout. `Mailer::drop` drains the park table and
+    /// records `Finished` for each entry — the same `record_finished` the
+    /// ref-walk `Err` arm calls, and the same balance `InboundMail::drop`
+    /// records for armed inbox mail (parked mail is unarmed, so there is no
+    /// `discharge` half). No threads, no timing: the `try_recv` after the
+    /// explicit `Mailer` drop is deterministic.
+    #[test]
+    fn parked_mail_settles_at_mailer_teardown() {
+        let sender = MailboxId(0x8380_0007_0000_0000);
+        let root = MailId::new(sender, 1);
+
+        let (registry, mailer, store) = make_mailer();
+        let rx = settle_probe(&mailer, root);
+
+        let outer_kind_id = registry
+            .register_kind_with_descriptor(KindDescriptor {
+                name: HeldNote::NAME.into(),
+                schema: held_note_schema(),
+            })
+            .unwrap();
+        let inner_kind_id = registry
+            .register_kind_with_descriptor(KindDescriptor {
+                name: Note::NAME.into(),
+                schema: note_schema(),
+            })
+            .unwrap();
+        let sink = CapturingSink::new();
+        let sink_id = registry.register_inline("test.teardown.park_settle", sink.inline_handler());
+
+        // Build a payload that references a handle that will never be put
+        // into the store — the walker returns `Parked`, mail held.
+        let never_handle = HandleId(0xDEAD_0000_CAFE_BABE);
+        let held: HeldNote = HeldNote {
+            held: Ref::Handle {
+                id: never_handle.0,
+                kind_id: inner_kind_id.0,
+            },
+            seq: 42,
+        };
+        let payload = postcard::to_allocvec(&held).unwrap();
+
+        let mail = Mail::new(sink_id, outer_kind_id, payload, 1).with_lineage(root, root, None);
+        mailer.push(mail);
+
+        // Mail is parked. Chain must NOT have settled yet.
+        assert_eq!(
+            store.parked_count(never_handle),
+            1,
+            "mail should be parked under the never-resolving handle"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "chain must stay elevated while the Mailer is live"
+        );
+
+        // Drop the store Arc first (the Mailer holds the other ref); this
+        // proves settlement fires from the Mailer's drop, not the store's.
+        drop(store);
+        assert!(
+            rx.try_recv().is_err(),
+            "dropping the store Arc alone must not settle the chain"
+        );
+
+        // Drop the Mailer — triggers `impl Drop for Mailer`, which drains
+        // the park table and records `Finished` for the held mail.
+        drop(mailer);
+        assert!(
+            rx.try_recv().is_ok(),
+            "parked mail must settle when the Mailer tears down (issue 1718)"
         );
     }
 

--- a/docs/adr/0045-computation-dag-and-typed-handles.md
+++ b/docs/adr/0045-computation-dag-and-typed-handles.md
@@ -189,6 +189,8 @@ This is why §1 commits to handles being typed over reply kinds (`Handle<ReadRes
 
 DAG-level failures (validation rejection, cancellation, transform panic) surface through the `aether.dag.status_result::Failed` reply kind on the originating session. A panicking transform is an unrecoverable DAG failure — the DAG aborts, downstream handles never resolve, parked mail is dropped with a `CapabilityDenied`-shaped diagnostic on the affected sinks. Per-DAG state recovery is a Phase 4+ concern.
 
+Park lifecycle note (issue 1718): a mail parked on a handle that never resolves — DAG abort, actor death, engine teardown — is settled by `Mailer::drop`. The `Mailer` is the terminal owner of parked mail (once the last `Arc<Mailer>` drops, no routing call can replay a parked entry), so its drop drains the park table and records `Finished` for each held mail, balancing the upstream `Sent` so traced wait chains settle instead of hanging.
+
 ### 9. Handle lifecycle and refcounts
 
 - **Component-held handles.** A `Handle<K>` value in a guest is just an `(id, PhantomData<K>)`. The SDK acquires the slot by mailing the substrate-owned `"handle"` sink (`aether.handle.publish` request → `aether.handle.publish_result { id }` reply, sync via `send_postcard` + `wait_reply` like the io / net sinks). Refcount adjustments and pin / unpin are paired sink kinds (`aether.handle.{release,pin,unpin}`). Auto-`Drop` mails `aether.handle.release` fire-and-forget so a panicking wait can't poison teardown. Mail rather than host-fn shims keeps the privileged FFI surface small (ADR-0002), gives Claude observability into handle traffic for free, and folds capability gating (ADR-0044) into the existing per-sink permission model.

--- a/docs/guide/systems/tracing-and-settlement.md
+++ b/docs/guide/systems/tracing-and-settlement.md
@@ -130,7 +130,10 @@ panics at the leaking seam in debug builds, naming the `mail_id`, kind, and mail
 costs nothing. The guard now backs the in-crate relay and park seams rather than
 the claimed-mailbox drain, which no longer needs it — forget it on a relay you
 write and you still get an immediate, located failure instead of the silent
-multi-second hang the chain would otherwise wedge into.
+multi-second hang the chain would otherwise wedge into. Parked mail is unarmed
+(the obligation guard does not apply), but it is still settled: when the `Mailer`
+tears down, every mail still parked on a never-resolving handle receives its
+`Finished`, so the upstream chain closes rather than hanging.
 
 ## The trace tree
 


### PR DESCRIPTION
## Summary

- Add `HandleStore::drain_all_parked` — takes the write lock, `mem::take`s the `parked` map, and flattens all queues into a single `Vec<Mail>` (FIFO within each handle; cross-handle order unspecified). This is the teardown-only counterpart to `take_parked`.
- Add `impl Drop for Mailer` — drains the park table at drop and records `record_finished(mail.mail_id, mail.root)` for each held mail, balancing the upstream `Sent` so traced settlement chains close rather than hanging to the 600-second MCP timeout.
- Deterministic regression test `parked_mail_settles_at_mailer_teardown` — parks a mail on a never-resolving handle, asserts the chain stays elevated while the `Mailer` lives, drops the store `Arc` (proving the store's drop is not the settle site), drops the `Mailer`, and asserts the probe fires. Pairs with the existing `ref_walk_parked_defers_finished_until_handle_publish` to fence the contract from both sides.

## Why the `Mailer` is the terminal owner

Once the last `Arc<Mailer>` drops, no call to `resolve_handle` can replay a parked entry — the `Mailer` owns both the park-and-route path and the `TraceHandle` where `record_finished` lives. The store's `Arc` can outlive the `Mailer` (the DAG executor and handle capability hold strong refs); settling in the store's `Drop` would leave chains hung for that extra window and would couple the pure byte-cache to the settlement subsystem. `Mailer::drop` is the earliest correct settle point — the same drop-settles mechanism #1716 applied to the inbox seam, applied here to the park table's terminal owner.

## Test plan

- `cargo nextest run -p aether-substrate -E 'test(parked_mail_settles_at_mailer_teardown)'` — new teardown-settle test (deterministic, no threads)
- `cargo nextest run -p aether-substrate -E 'test(ref_walk_parked)'` — existing contract pin unchanged
- `cargo nextest run -p aether-substrate -E 'test(drain_all_parked)'` — new `drain_all_parked` unit test
- `scripts/preflight.sh` — full workspace preflight green (89/89 heavy tests pass)

Closes #1718


Closes #1718
