### PR TITLE
feat(capabilities): glyph atlas eviction for long-lived text sessions

### DIFF
--- a/crates/aether-capabilities/src/text.rs
+++ b/crates/aether-capabilities/src/text.rs
@@ -778,7 +778,10 @@ mod native {
                         glyph_index,
                         size_pixels: 64,
                     };
-                    match cap.atlas.get_or_insert(key, ATLAS_SIZE, band_height, &coverage) {
+                    match cap
+                        .atlas
+                        .get_or_insert(key, ATLAS_SIZE, band_height, &coverage)
+                    {
                         GlyphSlot::Placed { .. } => {}
                         GlyphSlot::Full => break,
                         GlyphSlot::Empty => panic!("band coverage is not empty"),

--- a/crates/aether-capabilities/src/text.rs
+++ b/crates/aether-capabilities/src/text.rs
@@ -434,12 +434,11 @@ mod native {
                         }
                         quads.push(glyph_quad(&metrics, pen_x, baseline, &entry, mail.color));
                     }
-                    GlyphSlot::Empty => {}
-                    GlyphSlot::Full => {
-                        // The atlas saturated during this frame's layout pass.
-                        // The reset fires at the top of the next draw so this
-                        // glyph will re-pack and render then.
-                    }
+                    // Empty: no pixels, just advance the pen.
+                    // Full: the atlas saturated during this frame's layout pass;
+                    // the reset fires at the top of the next draw so this
+                    // glyph will re-pack and render then.
+                    GlyphSlot::Empty | GlyphSlot::Full => {}
                 }
                 pen_x += metrics.advance_width;
             }

--- a/crates/aether-capabilities/src/text.rs
+++ b/crates/aether-capabilities/src/text.rs
@@ -20,6 +20,13 @@
 //! `create_texture_result` reply onto the cap's own mailbox. Until the id
 //! lands the cap draws nothing; immediate mode resends every frame, so the
 //! string appears the moment the texture exists.
+//!
+//! When the atlas fills, the cap resets it at the top of the next `draw`:
+//! zeros the pixel buffer, clears the glyph cache, resets the shelf
+//! cursor, and emits one full-rect `update_texture` to re-sync the GPU
+//! side. Every glyph for that frame is then a cache miss and re-uploads
+//! normally. The cost is at most one frame of missing overflow glyphs on
+//! the saturating frame; the next frame fully recovers.
 
 // `#[handler]` methods take their decoded payload by value per the
 // ADR-0033 dispatch ABI; the macro-generated trampoline owns the decoded
@@ -160,6 +167,22 @@ mod native {
                 width: entry.width,
                 height: entry.height,
                 pixels: self.atlas.rect_rgba(entry),
+            };
+            let _ = ctx.actor::<RenderCapability>().send_traced(ctx, &update);
+        }
+
+        /// Re-sync the GPU side after an atlas reset by uploading the full
+        /// zeroed buffer. This ensures the render cap's staged pixels are a
+        /// clean mirror of the reset CPU atlas before per-glyph uploads layer
+        /// on top. Uses the same `update_texture` path as `upload_glyph`.
+        fn resync_atlas(&self, ctx: &mut NativeCtx<'_>, texture_id: u32) {
+            let update = UpdateTexture {
+                texture_id,
+                x: 0,
+                y: 0,
+                width: ATLAS_SIZE,
+                height: ATLAS_SIZE,
+                pixels: self.atlas.pixels().to_vec(),
             };
             let _ = ctx.actor::<RenderCapability>().send_traced(ctx, &update);
         }
@@ -332,9 +355,13 @@ mod native {
         /// Fire-and-forget. Rasterizes any unseen glyph into the atlas
         /// (one `update_texture` each) and sends the `draw_textured_quads`
         /// batch to `aether.render` the same tick. An unknown `font_id`
-        /// warn-drops; a full atlas drops the overflow glyphs. The first
-        /// `draw` lazily creates the atlas texture and draws nothing until
-        /// the reply lands — resend every frame (immediate-mode contract).
+        /// warn-drops. When the atlas is full it is reset at the top of this
+        /// call: the GPU side is re-synced with one full-rect `update_texture`
+        /// and all glyphs for this frame are re-rasterized as cache misses.
+        /// The cost is at most one frame of partial text on the saturating
+        /// frame; the next frame recovers fully. The first `draw` lazily
+        /// creates the atlas texture and draws nothing until the reply lands —
+        /// resend every frame (immediate-mode contract).
         #[handler]
         fn on_draw_text(&mut self, ctx: &mut NativeCtx<'_>, mail: DrawText) {
             let Some(font) = self.fonts.get(&mail.font_id).cloned() else {
@@ -354,6 +381,20 @@ mod native {
                 self.ensure_atlas_texture(ctx);
                 return;
             };
+
+            // Reset the atlas when full so the frame's glyphs can re-pack
+            // from a clean slate. The render cap's staged buffer is re-synced
+            // with one full-rect upload; per-glyph uploads follow as cache
+            // misses. This costs one frame of partial text (the overflow
+            // glyphs missing on the saturating frame) and then fully recovers.
+            if self.atlas.is_full() {
+                tracing::info!(
+                    target: "aether_substrate::text",
+                    "glyph atlas full; resetting for next frame",
+                );
+                self.atlas.reset();
+                self.resync_atlas(ctx, texture_id);
+            }
 
             let size = mail.size_pixels;
             // Quantize the size for the glyph cache key — two draws at the
@@ -395,10 +436,9 @@ mod native {
                     }
                     GlyphSlot::Empty => {}
                     GlyphSlot::Full => {
-                        tracing::warn!(
-                            target: "aether_substrate::text",
-                            "glyph atlas full; dropping glyph for the session",
-                        );
+                        // The atlas saturated during this frame's layout pass.
+                        // The reset fires at the top of the next draw so this
+                        // glyph will re-pack and render then.
                     }
                 }
                 pen_x += metrics.advance_width;
@@ -708,6 +748,69 @@ mod native {
             );
             // A printable glyph rasterizes once: first an update_texture for
             // the new glyph, then the draw_textured_quads batch.
+            assert_next_send_kind::<UpdateTexture>(&binding, &rx);
+            assert_next_send_kind::<DrawTexturedQuads>(&binding, &rx);
+        }
+
+        #[test]
+        fn draw_after_atlas_full_resets_and_renders_glyph() {
+            let mut cap = TextCapability::new();
+            cap.fonts.insert(0, Arc::new(test_font()));
+            cap.atlas_create_inflight = true;
+            let (binding, rx) = ctx_binding();
+            {
+                let mut ctx =
+                    NativeCtx::new(&binding, session_sender(), MailId::NONE, MailId::NONE);
+                cap.on_create_texture_result(&mut ctx, CreateTextureResult::Ok { texture_id: 3 });
+            }
+            assert_eq!(cap.atlas_texture_id, Some(3));
+
+            // Fill the atlas by directly calling get_or_insert with wide bands
+            // until the atlas reports full. `ATLAS_SIZE`, `GlyphKey`, and
+            // `GlyphSlot` are in scope via `use super::*` (imported from
+            // `mod native`'s own `use super::atlas::{…}` line).
+            {
+                let band_height = 64u32;
+                let coverage = vec![255u8; (ATLAS_SIZE * band_height) as usize];
+                for glyph_index in 0..32u16 {
+                    let key = GlyphKey {
+                        font_id: 99,
+                        glyph_index,
+                        size_pixels: 64,
+                    };
+                    match cap.atlas.get_or_insert(key, ATLAS_SIZE, band_height, &coverage) {
+                        GlyphSlot::Placed { .. } => {}
+                        GlyphSlot::Full => break,
+                        GlyphSlot::Empty => panic!("band coverage is not empty"),
+                    }
+                }
+            }
+            assert!(cap.atlas.is_full(), "atlas must be full before draw");
+
+            // A draw now: the cap should reset the atlas (emitting a full-rect
+            // update_texture for the resync), rasterize the glyph (another
+            // update_texture), then send draw_textured_quads. The glyph renders
+            // rather than drops — proving the reset freed space.
+            let mut ctx = NativeCtx::new(&binding, session_sender(), MailId::NONE, MailId::NONE);
+            cap.on_draw_text(
+                &mut ctx,
+                DrawText {
+                    font_id: 0,
+                    text: "A".to_owned(),
+                    size_pixels: 48.0,
+                    color: [1.0, 1.0, 1.0, 1.0],
+                    space: QuadSpace::Screen,
+                },
+            );
+
+            assert!(
+                !cap.atlas.is_full(),
+                "atlas must be clear after reset-triggered draw"
+            );
+
+            // The full-rect resync and the per-glyph upload both arrive as
+            // UpdateTexture; the quad batch follows as DrawTexturedQuads.
+            assert_next_send_kind::<UpdateTexture>(&binding, &rx);
             assert_next_send_kind::<UpdateTexture>(&binding, &rx);
             assert_next_send_kind::<DrawTexturedQuads>(&binding, &rx);
         }

--- a/crates/aether-capabilities/src/text/atlas.rs
+++ b/crates/aether-capabilities/src/text/atlas.rs
@@ -8,8 +8,14 @@
 //! sub-rect per newly-placed glyph via `update_texture` — so a glyph
 //! costs an upload the first frame it appears and is a cache hit after.
 //!
-//! When the atlas fills, further new glyphs log-and-drop for the session
-//! (eviction is an ADR-0105 non-goal).
+//! When the atlas fills, `is_full()` returns `true`. The text cap calls
+//! `reset()` at the top of the next `draw` to zero the buffer, clear the
+//! glyph cache, and reset the shelf cursor — then re-rasterizes the
+//! requested glyphs into the fresh atlas. One full-rect `update_texture`
+//! re-syncs the GPU side; every glyph is a cache miss that frame and each
+//! emits its per-glyph upload, exactly as on first draw. The result is at
+//! most one frame of missing overflow glyphs (on the saturating frame),
+//! then full rendering resumes.
 
 use std::collections::HashMap;
 
@@ -55,8 +61,9 @@ pub enum GlyphSlot {
     /// The glyph has no coverage (a space, or a zero-area raster) —
     /// nothing to draw, advance the pen and move on.
     Empty,
-    /// The atlas is full and could not place this glyph — dropped for the
-    /// session.
+    /// The atlas is full and could not place this glyph. The text cap
+    /// resets the atlas at the top of the next draw so the glyph can be
+    /// re-placed then.
     Full,
 }
 
@@ -103,6 +110,27 @@ impl Atlas {
     /// The full RGBA8 buffer — uploaded once via `create_texture`.
     pub fn pixels(&self) -> &[u8] {
         &self.pixels
+    }
+
+    /// `true` once any glyph failed to pack into the atlas. The text cap
+    /// checks this before each draw and calls [`Self::reset`] to free
+    /// space for the next frame's glyphs.
+    pub fn is_full(&self) -> bool {
+        self.full
+    }
+
+    /// Zero the pixel buffer, clear the glyph cache, and reset the shelf
+    /// cursor so the atlas can accept new glyphs again. The text cap
+    /// re-syncs the GPU side by emitting one full-rect `update_texture`
+    /// immediately after, then re-rasterizes the frame's glyphs into the
+    /// fresh atlas as cache misses.
+    pub fn reset(&mut self) {
+        self.pixels.fill(0);
+        self.cache.clear();
+        self.shelf_x = 0;
+        self.shelf_y = 0;
+        self.shelf_height = 0;
+        self.full = false;
     }
 
     /// Cheap cache probe: the cached slot for `key`, or `None` if the
@@ -313,5 +341,36 @@ mod tests {
             }
         }
         assert!(saw_full, "the atlas should report Full once it cannot grow");
+    }
+
+    #[test]
+    fn reset_clears_full_flag_and_accepts_new_glyphs() {
+        let mut atlas = Atlas::new();
+        // Fill the atlas until it signals full.
+        let band_height = 64u32;
+        let coverage = vec![255u8; (ATLAS_SIZE * band_height) as usize];
+        for glyph_index in 0..32u16 {
+            match atlas.get_or_insert(key(glyph_index), ATLAS_SIZE, band_height, &coverage) {
+                GlyphSlot::Placed { .. } => {}
+                GlyphSlot::Full => break,
+                GlyphSlot::Empty => panic!("a full band is not empty"),
+            }
+        }
+        assert!(atlas.is_full(), "atlas must be full before reset");
+
+        atlas.reset();
+
+        assert!(!atlas.is_full(), "is_full must be false after reset");
+        // A fresh insert that previously could not place must now land at the
+        // origin — the shelf cursor reset to (0, 0).
+        let small_coverage = vec![255u8; (4 * 4) as usize];
+        match atlas.get_or_insert(key(200), 4, 4, &small_coverage) {
+            GlyphSlot::Placed { entry, uploaded } => {
+                assert!(uploaded, "post-reset glyph must report an upload");
+                assert_eq!((entry.x, entry.y), (0, 0), "shelf cursor reset to origin");
+            }
+            GlyphSlot::Full => panic!("reset atlas must accept new glyphs"),
+            GlyphSlot::Empty => panic!("4×4 glyph is not empty"),
+        }
     }
 }

--- a/docs/adr/0105-text-rendering.md
+++ b/docs/adr/0105-text-rendering.md
@@ -35,11 +35,11 @@ A native capability with no GPU access — it only sends mail.
 - `aether.text.load_font { namespace, path }` → `aether.text.load_font_result` (`Ok { font_id, name, resident_bytes }` / `Err { namespace, path, error }`). Mirrors `aether.audio.load_instrument`: park the request, fetch bytes via `aether.fs.read`, correlate on `aether.fs.read_result`, parse and rasterize off the hot path in a task handler, register under a session-scoped `font_id`.
 - `aether.text.draw { font_id, text, size_pixels, color, space }` — fire-and-forget, immediate-mode per frame. The capability lays out glyphs, rasterizes any unseen `(font_id, glyph, size)` into its atlas (emitting one `update_texture`), and sends the quad batch to `aether.render` the same tick. `color` is RGBA; `space` is the render-surface discriminant above, passed through.
 
-Rasterization uses `fontdue` (pure-Rust TTF parse + rasterize + horizontal layout). The atlas is a single shelf-packed RGBA8 texture with glyph coverage in alpha; when it fills, further new glyphs log and drop for the session.
+Rasterization uses `fontdue` (pure-Rust TTF parse + rasterize + horizontal layout). The atlas is a single shelf-packed RGBA8 texture with glyph coverage in alpha. When the atlas fills, the cap resets it at the top of the next `draw` (zero pixels, clear cache, reset shelf cursor) and re-syncs the GPU side with one full-rect `update_texture`. Every glyph that frame is a cache miss and re-uploads exactly as on first draw. The cost is at most one frame of missing overflow glyphs on the saturating frame; rendering fully recovers the next frame. Atlas eviction was a v1 non-goal when the ADR was written; the whole-atlas reset replaced it without a kind-surface change.
 
 ### Non-goals for v1
 
-Shaping, BiDi, and emoji; SDF/MSDF atlases; atlas eviction; retained text objects; in-plane world text that skews with the camera (a `world_size` variant can extend `scale` later). All sit behind the kind surface, so any of them can replace the internals without a vocabulary change.
+Shaping, BiDi, and emoji; SDF/MSDF atlases; retained text objects; in-plane world text that skews with the camera (a `world_size` variant can extend `scale` later). All sit behind the kind surface, so any of them can replace the internals without a vocabulary change.
 
 ## Consequences
 


### PR DESCRIPTION
## Summary

- Adds `Atlas::is_full() -> bool` and `Atlas::reset()` to the shelf-packed glyph atlas in `text/atlas.rs`
- Adds a `resync_atlas` helper to `TextCapability` that re-uploads the full zeroed buffer via `update_texture` after a reset, keeping the render cap's GPU-side pixels clean
- Triggers the reset at the top of `on_draw_text` when `is_full()` is true: one full-rect `update_texture` for the resync, then every glyph for that frame re-rasterizes as a cache miss, each emitting its per-glyph `update_texture` exactly as on first draw

## Design

Whole-atlas reset-and-regrow, lazy at the top of the next `draw`. The cost is at most one frame of missing overflow glyphs on the saturating frame; the next frame fully recovers. No new mail kinds — the resync reuses `aether.render.update_texture`; `texture_id` is unchanged. Headless is unaffected: `create_texture` replies `Err` there so `atlas_texture_id` stays `None` and the reset path never runs.

ADR-0105 is updated to drop "atlas eviction" from the v1 non-goals list, noting the internal replacement landed without a kind-surface change.

## Test plan

- `aether-capabilities text::native::tests::reset_clears_full_flag_and_accepts_new_glyphs` — fills the atlas, resets, asserts `is_full()` clears and a subsequent insert places at origin
- `aether-capabilities text::native::tests::draw_after_atlas_full_resets_and_renders_glyph` — fills the atlas, calls `on_draw_text`, asserts the sequence: full-rect `UpdateTexture` (resync) → per-glyph `UpdateTexture` → `DrawTexturedQuads`; confirms the glyph renders rather than drops

Closes #1720