### PR TITLE
feat(capabilities): flat-fill screen-space quads via draw_solid_quads

### DIFF
--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -36,7 +36,8 @@
 // `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
 // of the mod (always-on, outside the cfg gate).
 use aether_kinds::{
-    Camera, CaptureFrame, CreateTexture, DrawTexturedQuads, DrawTriangle, UpdateTexture,
+    Camera, CaptureFrame, CreateTexture, DrawSolidQuads, DrawTexturedQuads, DrawTriangle,
+    UpdateTexture,
 };
 
 // Auxiliary native-only types the chassis driver consumes alongside
@@ -63,7 +64,7 @@ mod native {
     use aether_data::Kind;
     use aether_kinds::{
         CaptureFrameResult, CreateTextureResult, DRAW_TRIANGLE_BYTES, QuadScale, QuadSpace,
-        TexturedQuad,
+        SolidQuad, TexturedQuad,
     };
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::capture::{CaptureQueue, PendingCapture};
@@ -81,7 +82,8 @@ mod native {
     };
 
     use super::{
-        Camera, CaptureFrame, CreateTexture, DrawTexturedQuads, DrawTriangle, UpdateTexture,
+        Camera, CaptureFrame, CreateTexture, DrawSolidQuads, DrawTexturedQuads, DrawTriangle,
+        UpdateTexture,
     };
     use aether_substrate::render::VERTEX_BUFFER_BYTES;
     use std::mem;
@@ -242,6 +244,13 @@ mod native {
             self.dirty = false;
         }
     }
+
+    /// Reserved sentinel `texture_id` for the internal 1×1 white texture
+    /// used by `on_draw_solid_quads`. `create_texture` starts at `0` and
+    /// increments, so `u32::MAX` is outside the range any caller-visible id
+    /// occupies — the white texture is never handed to a caller and never
+    /// collides with a user-created texture.
+    const WHITE_TEXTURE_ID: u32 = u32::MAX;
 
     /// Session-scoped texture registry. `next_id` hands out the
     /// `texture_id` a `create_texture` reply carries — assigned in
@@ -668,6 +677,74 @@ mod native {
                     texture_id: mail.texture_id,
                     space: mail.space,
                     quads: mail.quads,
+                });
+        }
+
+        /// `DrawSolidQuads` handler (ADR-0107 §4). Expands each `SolidQuad`
+        /// into a `TexturedQuad` covering the full uv of a reserved internal
+        /// 1×1 white texture, tinted by `color` — so the white texel ×
+        /// tint produces the flat fill color with no new GPU pipeline.
+        /// Lazily inserts the white texture into the registry on first call.
+        /// Accumulates into the same `quad_frame` accumulator as
+        /// `on_draw_textured_quads`; immediate-mode contract is identical.
+        ///
+        /// # Agent
+        /// Mail `aether.render.draw_solid_quads { space, quads }` every
+        /// frame the rects should appear; no reply.
+        #[handler]
+        fn on_draw_solid_quads(&self, _ctx: &mut NativeCtx<'_>, mail: DrawSolidQuads) {
+            if let Some(obs) = &self.config.observed_kinds {
+                obs.lock()
+                    .expect("mutex poisoned; fail-fast per ADR-0063")
+                    .push(<DrawSolidQuads as Kind>::NAME.into());
+            }
+            let mut registry = self
+                .handles
+                .textures
+                .lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063");
+            registry
+                .entries
+                .entry(WHITE_TEXTURE_ID)
+                .or_insert_with(|| StagedTexture {
+                    width: 1,
+                    height: 1,
+                    pixels: vec![255, 255, 255, 255],
+                    realized: None,
+                    dirty: true,
+                });
+            drop(registry);
+            let quads: Vec<TexturedQuad> = mail
+                .quads
+                .into_iter()
+                .map(
+                    |SolidQuad {
+                         x,
+                         y,
+                         width,
+                         height,
+                         color,
+                     }| TexturedQuad {
+                        x,
+                        y,
+                        width,
+                        height,
+                        u0: 0.0,
+                        v0: 0.0,
+                        u1: 1.0,
+                        v1: 1.0,
+                        tint: color,
+                    },
+                )
+                .collect();
+            self.handles
+                .quad_frame
+                .lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063")
+                .push(QuadBatch {
+                    texture_id: WHITE_TEXTURE_ID,
+                    space: mail.space,
+                    quads,
                 });
         }
     }
@@ -1347,6 +1424,95 @@ mod native {
             assert!(!texture.apply_subrect(0, 0, 0, 1, &[]));
         }
 
+        /// ADR-0107 §4: `draw_solid_quads` accumulates into `quad_frame` under
+        /// the reserved `WHITE_TEXTURE_ID` and records its kind name in
+        /// `observed_kinds`. Verifies the expand-to-TexturedQuad path and the
+        /// lazy white-texture insertion without a GPU.
+        #[test]
+        fn draw_solid_quads_accumulates_and_observed() {
+            let observed = Arc::new(Mutex::new(Vec::<String>::new()));
+            let config = RenderConfig {
+                observed_kinds: Some(Arc::clone(&observed)),
+                ..RenderConfig::default()
+            };
+            let (registry, mailer) = fresh_substrate();
+            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<RenderCapability>(config)
+                .build_passive()
+                .expect("build succeeds");
+            let handles = chassis
+                .handle::<RenderHandles>()
+                .expect("RenderCapability publishes RenderHandles");
+
+            let mail = DrawSolidQuads {
+                space: QuadSpace::Screen,
+                quads: vec![SolidQuad {
+                    x: 10.0,
+                    y: 20.0,
+                    width: 30.0,
+                    height: 40.0,
+                    color: [1.0, 0.0, 0.5, 0.8],
+                }],
+            };
+            let payload = postcard::to_allocvec(&mail).expect("encode DrawSolidQuads");
+            deliver(
+                &registry,
+                RenderCapability::NAMESPACE,
+                <DrawSolidQuads as Kind>::ID,
+                &payload,
+            );
+
+            thread::sleep(Duration::from_millis(50));
+
+            let seen = observed
+                .lock()
+                .expect("observed_kinds mutex is not poisoned")
+                .clone();
+            assert!(
+                seen.contains(&DrawSolidQuads::NAME.to_owned()),
+                "draw_solid_quads handler should push its kind name; observed: {seen:?}",
+            );
+
+            let batches = handles
+                .quad_frame
+                .lock()
+                .expect("quad_frame mutex is not poisoned")
+                .clone();
+            assert_eq!(
+                batches.len(),
+                1,
+                "one QuadBatch should be in the accumulator"
+            );
+            assert_eq!(
+                batches[0].texture_id, WHITE_TEXTURE_ID,
+                "batch must use the reserved white texture id",
+            );
+            assert_eq!(
+                batches[0].quads.len(),
+                1,
+                "batch must contain the one expanded quad"
+            );
+            assert_eq!(
+                batches[0].quads[0].tint,
+                [1.0, 0.0, 0.5, 0.8],
+                "expanded quad tint must match the SolidQuad color",
+            );
+            assert_eq!(batches[0].quads[0].width, 30.0);
+
+            let tex_present = handles
+                .textures
+                .lock()
+                .expect("textures mutex is not poisoned")
+                .entries
+                .contains_key(&WHITE_TEXTURE_ID);
+            assert!(
+                tex_present,
+                "white texture must be lazily inserted on first send"
+            );
+
+            drop(chassis);
+        }
+
         #[test]
         fn camera_kind_drops_wrong_length_payload() {
             let (registry, mailer) = fresh_substrate();
@@ -1383,7 +1549,8 @@ mod native_headless {
     use aether_substrate::mail::outbound::HubOutbound;
 
     use super::{
-        Camera, CaptureFrame, CreateTexture, DrawTexturedQuads, DrawTriangle, UpdateTexture,
+        Camera, CaptureFrame, CreateTexture, DrawSolidQuads, DrawTexturedQuads, DrawTriangle,
+        UpdateTexture,
     };
     use std::io;
 
@@ -1476,6 +1643,12 @@ mod native_headless {
         #[allow(clippy::unused_self)]
         #[handler]
         fn on_draw_textured_quads(&self, _ctx: &mut NativeCtx<'_>, _mail: DrawTexturedQuads) {}
+
+        /// `DrawSolidQuads` lands here as a no-op for the same reason
+        /// as `on_draw_textured_quads`.
+        #[allow(clippy::unused_self)]
+        #[handler]
+        fn on_draw_solid_quads(&self, _ctx: &mut NativeCtx<'_>, _mail: DrawSolidQuads) {}
     }
 
     #[cfg(test)]
@@ -1528,6 +1701,39 @@ mod native_headless {
                     panic!("headless create_texture must reply Err, not assign an id")
                 }
             }
+        }
+
+        /// ADR-0107 §4: `draw_solid_quads` on the headless chassis is a
+        /// no-op — no panic, no reply, nothing accumulated. Mirrors the
+        /// `on_draw_textured_quads` no-op contract.
+        #[test]
+        fn headless_draw_solid_quads_is_noop() {
+            use aether_kinds::{DrawSolidQuads, QuadSpace};
+
+            let (mailer, _rx) = test_mailer_and_rx();
+            let outbound = mailer
+                .outbound()
+                .cloned()
+                .expect("test_mailer_and_rx wires a loopback outbound");
+            let cap = HeadlessRenderCapability { outbound };
+            let transport = Arc::new(NativeBinding::new_for_test(
+                Arc::clone(&mailer),
+                MailboxId(0),
+            ));
+            let mut ctx = NativeCtx::new(
+                &transport,
+                Source::to(SourceAddr::Session(SessionToken(Uuid::nil()))),
+                aether_data::MailId::NONE,
+                aether_data::MailId::NONE,
+            );
+            cap.on_draw_solid_quads(
+                &mut ctx,
+                DrawSolidQuads {
+                    space: QuadSpace::Screen,
+                    quads: vec![],
+                },
+            );
+            // No panic and no reply enqueued — the no-op dropped the mail cleanly.
         }
     }
 }

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1629,6 +1629,35 @@ mod control_plane {
         pub quads: Vec<TexturedQuad>,
     }
 
+    /// One flat-colored quad in a `DrawSolidQuads` batch. `(x, y)` is the
+    /// top-left corner and `(width, height)` the size, both in the unit
+    /// the batch's `space` selects — window pixels for `Screen`, pixel
+    /// offsets from the anchor for `World`. `color` is a linear RGBA value;
+    /// the alpha channel scales the blend. Not a kind on its own — only
+    /// addressable inside `DrawSolidQuads.quads`.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq)]
+    pub struct SolidQuad {
+        pub x: f32,
+        pub y: f32,
+        pub width: f32,
+        pub height: f32,
+        pub color: [f32; 4],
+    }
+
+    /// `aether.render.draw_solid_quads` — draw a batch of flat-colored,
+    /// alpha-blended quads in the projection `space` selects. Accumulated
+    /// per frame with the same immediate-mode contract as
+    /// `aether.draw_triangle`: send it every frame the quads should appear,
+    /// or they vanish next frame. Reuses the textured-quad overlay pipeline
+    /// with a reserved internal 1×1 white texture tinted by `color` — no
+    /// new GPU pipeline. Fire-and-forget; no reply.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.render.draw_solid_quads")]
+    pub struct DrawSolidQuads {
+        pub space: QuadSpace,
+        pub quads: Vec<SolidQuad>,
+    }
+
     // ADR-0105 text surface. The `aether.text` capability composes the
     // textured-quad surface above into glyphs: load a TTF off the hot
     // path under a session-scoped `font_id`, then draw a string every
@@ -3444,6 +3473,7 @@ mod tests {
         );
         assert_eq!(UpdateTexture::NAME, "aether.render.update_texture");
         assert_eq!(DrawTexturedQuads::NAME, "aether.render.draw_textured_quads");
+        assert_eq!(DrawSolidQuads::NAME, "aether.render.draw_solid_quads");
         assert_eq!(LoadFont::NAME, "aether.text.load_font");
         assert_eq!(LoadFontResult::NAME, "aether.text.load_font_result");
         assert_eq!(DrawText::NAME, "aether.text.draw");
@@ -3689,6 +3719,28 @@ mod tests {
                 }
                 QuadSpace::Screen => panic!("expected World"),
             }
+        }
+
+        #[test]
+        fn draw_solid_quads_screen_roundtrip() {
+            let d = DrawSolidQuads {
+                space: QuadSpace::Screen,
+                quads: vec![SolidQuad {
+                    x: 10.0,
+                    y: 8.0,
+                    width: 20.0,
+                    height: 16.0,
+                    color: [1.0, 0.0, 0.5, 1.0],
+                }],
+            };
+            let bytes =
+                postcard::to_allocvec(&d).expect("test setup: postcard encodes DrawSolidQuads");
+            let back: DrawSolidQuads =
+                postcard::from_bytes(&bytes).expect("test setup: postcard decodes DrawSolidQuads");
+            assert_eq!(back.space, QuadSpace::Screen);
+            assert_eq!(back.quads.len(), 1);
+            assert_eq!(back.quads[0].width, 20.0);
+            assert_eq!(back.quads[0].color, [1.0, 0.0, 0.5, 1.0]);
         }
 
         #[test]

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -31,10 +31,10 @@ use std::path::Path;
 
 use aether_data::{Kind, MailboxId};
 use aether_kinds::{
-    Camera, CreateTexture, CreateTextureResult, Delete, DeleteResult, DrawText, DrawTexturedQuads,
-    DropComponent, DropResult, FsError, List, ListResult, LoadComponent, LoadFont, LoadFontResult,
-    LoadResult, MailEnvelope, Ping, QuadScale, QuadSpace, Read, ReadResult, ReplaceComponent,
-    ReplaceResult, TexturedQuad, Write, WriteResult,
+    Camera, CreateTexture, CreateTextureResult, Delete, DeleteResult, DrawSolidQuads, DrawText,
+    DrawTexturedQuads, DropComponent, DropResult, FsError, List, ListResult, LoadComponent,
+    LoadFont, LoadFontResult, LoadResult, MailEnvelope, Ping, QuadScale, QuadSpace, Read,
+    ReadResult, ReplaceComponent, ReplaceResult, SolidQuad, TexturedQuad, Write, WriteResult,
 };
 use aether_math::{Mat4, Vec3};
 use aether_substrate_bundle::test_bench::{
@@ -762,6 +762,83 @@ fn textured_quad_draws_screen_space_rect() {
     assert!(
         cleared_coverage < 0.01,
         "after the quad stopped being sent the frame should be uniform clear color, \
+         but coverage was {cleared_coverage} (immediate-mode clear did not run)",
+    );
+}
+
+/// ADR-0107 §4 flat-fill primitive: a `draw_solid_quads` batch draws an
+/// opaque screen-space rect in the overlay pass without a caller-created
+/// texture. The test dispatches a single `SolidQuad` covering a known
+/// pixel rect and asserts `coverage > 0` and `centroid` inside the rect.
+/// A second capture after an advance with no resent quads asserts the
+/// immediate-mode clear — exactly the same contract as
+/// `textured_quad_draws_screen_space_rect`.
+#[test]
+#[allow(clippy::cast_precision_loss)]
+fn solid_quad_draws_screen_space_rect() {
+    if !require_wgpu_only() {
+        return;
+    }
+    let (frame_width, frame_height) = (64u32, 48u32);
+    let mut bench = TestBench::start_with_size(frame_width, frame_height).expect("boot");
+
+    // Known screen rect: top-left (16, 12), size 24×18.
+    let (quad_x, quad_y, quad_w, quad_h) = (16.0f32, 12.0f32, 24.0f32, 18.0f32);
+    let pre = vec![envelope(
+        "aether.render",
+        &DrawSolidQuads {
+            space: QuadSpace::Screen,
+            quads: vec![SolidQuad {
+                x: quad_x,
+                y: quad_y,
+                width: quad_w,
+                height: quad_h,
+                color: [1.0, 1.0, 1.0, 1.0],
+            }],
+        },
+    )];
+
+    let captured = bench
+        .execute(vec![("snap", BenchOp::capture_with_mails(pre, vec![]))])
+        .expect("capture-with-mails");
+    let png = captured.captured("snap").expect("snap step ran");
+    let img = decode_png(png).expect("decode capture png");
+    let bg = background_top_left(&img);
+    let tolerance = 5;
+
+    // Coverage band around the quad's area fraction (24*18 / 64*48 ≈ 0.14).
+    let drawn = coverage(&img, bg, tolerance);
+    assert!(
+        (0.08..0.22).contains(&drawn),
+        "solid quad coverage {drawn} fell outside the expected band (0.08, 0.22); \
+         the captured frame is effectively empty or entirely filled",
+    );
+
+    // The lit centroid must land inside the requested rect — ruling out a misplaced fill.
+    let (cx, cy) = centroid(&img, bg, tolerance).expect("a lit frame has a centroid");
+    let pad = 4.0f32;
+    assert!(
+        cx >= quad_x - pad
+            && cx <= quad_x + quad_w + pad
+            && cy >= quad_y - pad
+            && cy <= quad_y + quad_h + pad,
+        "solid quad centroid ({cx}, {cy}) should sit inside the screen rect \
+         ({quad_x},{quad_y})+({quad_w}x{quad_h}) of the {frame_width}x{frame_height} frame",
+    );
+
+    // Immediate-mode clear: advance with no quad resent, next capture returns to clear color.
+    let cleared = bench
+        .execute(vec![
+            ("clear_advance", BenchOp::advance(1)),
+            ("snap2", BenchOp::capture()),
+        ])
+        .expect("advance + capture");
+    let png2 = cleared.captured("snap2").expect("snap2 step ran");
+    let img2 = decode_png(png2).expect("decode cleared png");
+    let cleared_coverage = coverage(&img2, background_top_left(&img2), tolerance);
+    assert!(
+        cleared_coverage < 0.01,
+        "after the solid quad stopped being sent the frame should be uniform clear color, \
          but coverage was {cleared_coverage} (immediate-mode clear did not run)",
     );
 }


### PR DESCRIPTION
Closes #1737.

## Summary

Add a flat-fill screen-space quad primitive (ADR-0107 §4). A new `aether.render.draw_solid_quads` kind carries a batch of `SolidQuad { x, y, width, height, color }` in a `QuadSpace`; `RenderCapability::on_draw_solid_quads` expands each quad into a full-uv `TexturedQuad` over a reserved internal 1×1 white texture tinted by `color`, accumulating into the same per-frame batch as the textured-quad surface — so the flat fill rides the existing blended overlay pipeline with no new GPU pipeline or pass. `HeadlessRenderCapability` absorbs it as a no-op. Immediate-mode: resend per frame.

## Test plan

Render-cap unit test (accumulation into `quad_frame` + observed-kind push + lazy white-texture insertion), headless no-op test, kind-name + postcard round-trip tests, and a test-bench scenario asserting a coverage band + the lit centroid inside the dispatched rect + immediate-mode clear after a no-resend advance. Full `cargo nextest run --workspace` green; `scripts/preflight.sh --qodana` clean.

## Generated by

`/implement` — agent execution of [scoped issue #1737](https://github.com/iamacoffeepot/aether/issues/1737).
