### PR TITLE
refactor(substrate-bundle): convert bare-string mailbox literals left by #1707 to namespace consts

### DIFF
--- a/crates/aether-capabilities/src/engine/proxy.rs
+++ b/crates/aether-capabilities/src/engine/proxy.rs
@@ -48,11 +48,12 @@ pub use proxy_native::{EngineProxyConfig, HeartbeatParams};
 #[aether_actor::bridge(instanced, one_per = "engine")]
 mod proxy_native {
     use super::{EngineHeartbeatTick, ForwardEnvelope, RpcInboundReady, TerminateEngine};
+    use crate::engine::EngineServer;
     use crate::rpc::{
         MailEnvelope, MailboxAddress, PeerKind, RpcClient, RpcClientError, RpcConnection, RpcError,
         WireFrame,
     };
-    use aether_actor::actor;
+    use aether_actor::{Actor, actor};
     use aether_data::{EngineId, Kind, KindId, MailboxId, mailbox_id_from_name};
     use aether_kinds::{CallSettled, EngineAlive, EngineDied};
     use aether_substrate::Mail;
@@ -70,15 +71,15 @@ mod proxy_native {
 
     /// Mailbox of the engines cap (`aether.engine`) — where a proxy
     /// reports its own liveness transitions (`EngineAlive` / `EngineDied`,
-    /// issue 1339). A compile-time const from the well-known name, so no
-    /// host round-trip; matches the `RpcServerCapability`'s own
-    /// `mailbox_id_from_name("aether.engine")` route lookup.
+    /// issue 1339). A compile-time const derived from
+    /// `<EngineServer as Actor>::NAMESPACE`, so no host round-trip; matches
+    /// the `RpcServerCapability`'s own route lookup.
     // Well-known engines-cap route shared with `RpcServerCapability`'s own
     // lookup; a ctx-less free helper in the proxy bridge mod, so there is no
     // sibling `ctx.actor::<_>()` to resolve through.
     #[allow(clippy::disallowed_methods)]
     fn engine_cap_mailbox() -> MailboxId {
-        mailbox_id_from_name("aether.engine")
+        mailbox_id_from_name(<EngineServer as Actor>::NAMESPACE)
     }
 
     /// Total time [`connect_proxy`] keeps retrying a refused dial when

--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -36,10 +36,11 @@ use aether_rpc::rpc::PeerKind;
 #[aether_actor::bridge(singleton)]
 mod server_native {
     use super::{PeerKind, RpcInboundReady, Settled};
+    use crate::engine::EngineServer;
     use crate::rpc::{
         Hello, HelloAck, MailEnvelope, MailboxAddress, RpcError, WIRE_VERSION, WireFrame,
     };
-    use aether_actor::actor;
+    use aether_actor::{Actor, actor};
     use aether_codec::frame::FrameError;
     use aether_codec::frame::{read_frame, write_frame};
     use aether_data::{Kind, KindId, MailId, MailboxId, mailbox_id_from_name};
@@ -633,7 +634,7 @@ mod server_native {
                 // holds opaque MailboxId/KindId/bytes, with no compile-time
                 // sibling type to resolve through.
                 #[allow(clippy::disallowed_methods)]
-                let engine_cap = mailbox_id_from_name("aether.engine");
+                let engine_cap = mailbox_id_from_name(<EngineServer as Actor>::NAMESPACE);
                 let mail_id = ctx.send_envelope_as_root(
                     engine_cap,
                     <RouteEnvelope as Kind>::ID,

--- a/crates/aether-substrate-bundle/src/autoload.rs
+++ b/crates/aether-substrate-bundle/src/autoload.rs
@@ -9,6 +9,8 @@
 //! address the hub's `load_component` and the test bench load through
 //! — which is what makes the mechanism chassis-agnostic.
 
+use aether_actor::Actor;
+use aether_capabilities::ComponentHostCapability;
 use aether_data::{Kind as _, mailbox_id_from_name};
 use aether_kinds::LoadComponent;
 use aether_substrate::Mail;
@@ -53,7 +55,7 @@ pub(crate) fn autoload_mail(component: AutoloadComponent) -> Mail {
         // ctx-less free fn, the same address the hub and test bench load
         // through, with no sibling resolver in scope.
         #[allow(clippy::disallowed_methods)]
-        mailbox_id_from_name("aether.component"),
+        mailbox_id_from_name(<ComponentHostCapability as Actor>::NAMESPACE),
         LoadComponent::ID,
         payload,
         1,
@@ -77,7 +79,10 @@ mod tests {
             name: Some("loco-motion".to_owned()),
             export: None,
         });
-        assert_eq!(mail.recipient, mailbox_id_from_name("aether.component"));
+        assert_eq!(
+            mail.recipient,
+            mailbox_id_from_name(<ComponentHostCapability as Actor>::NAMESPACE)
+        );
         assert_eq!(mail.kind, LoadComponent::ID);
     }
 }

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -1606,7 +1606,9 @@ mod tests {
 
         // The window inbox forwards armed envelopes onto the
         // `SettlingInbox`'s channel, exactly as `claim_mailbox` does.
-        let window_mailbox = mailbox_id_from_name("aether.window");
+        let window_mailbox = mailbox_id_from_name(
+            <aether_capabilities::HeadlessWindowCapability as Actor>::NAMESPACE,
+        );
         let (tx, rx) = mpsc::channel::<Envelope>();
         let handler: Arc<dyn InboxHandler> = Arc::new(move |d: Envelope| {
             let _ = tx.send(d);
@@ -1686,7 +1688,9 @@ mod tests {
         let store = Arc::new(HandleStore::new(1024 * 1024));
         let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
 
-        let window_mailbox = mailbox_id_from_name("aether.window");
+        let window_mailbox = mailbox_id_from_name(
+            <aether_capabilities::HeadlessWindowCapability as Actor>::NAMESPACE,
+        );
         let (tx, rx) = mpsc::channel::<Envelope>();
         let handler: Arc<dyn InboxHandler> = Arc::new(move |d: Envelope| {
             let _ = tx.send(d);
@@ -1764,7 +1768,9 @@ mod tests {
 
         // Register the window mailbox forwarding armed envelopes onto the
         // `SettlingInbox`'s channel, exactly as `claim_mailbox` does.
-        let window_mailbox = mailbox_id_from_name("aether.window");
+        let window_mailbox = mailbox_id_from_name(
+            <aether_capabilities::HeadlessWindowCapability as Actor>::NAMESPACE,
+        );
         let (tx, rx) = mpsc::channel::<Envelope>();
         let handler: Arc<dyn InboxHandler> = Arc::new(move |d: Envelope| {
             let _ = tx.send(d);
@@ -1866,7 +1872,8 @@ mod tests {
             .expect("register the reply inbox");
         let inbox = SettlingInbox::new(reply_mailbox, rx, Arc::clone(&mailer));
 
-        let cap_mailbox = mailbox_id_from_name("aether.lifecycle");
+        let cap_mailbox =
+            mailbox_id_from_name(<aether_capabilities::LifecycleCapability as Actor>::NAMESPACE);
 
         // (1) Non-`NONE`-root reply (the degraded `on_advance` inline-reply
         // shape): the producer hook records the reply's `Sent` against


### PR DESCRIPTION
Closes #1713.

## Summary

Convert the bare-string mailbox literals left by #1707 in the capabilities and substrate-bundle crates to their owning cap's `NAMESPACE` const. Six `mailbox_id_from_name("aether.X")` sites — the engine-cap route in the proxy and RPC server (`<EngineServer as Actor>::NAMESPACE`), `autoload_mail` (`<ComponentHostCapability as Actor>::NAMESPACE`), and the desktop driver's window / lifecycle test routes (`<HeadlessWindowCapability …>` / `<LifecycleCapability …>`) — now derive the well-known name from the cap's `NAMESPACE` const, so there's one source of truth and the string can't drift.

New cross-module `use`s only; the `#[allow(clippy::disallowed_methods)]` escape-hatch annotations and their reasons stay (these are ctx-less free helpers / wire-`Call` forwarding with no sibling type to resolve through). No `MailboxId` values change.

## Test plan

`cargo nextest run --workspace` green confirms the computed `MailboxId`s are unchanged (the `autoload` route assertion now compares against the same NAMESPACE-derived id). `scripts/preflight.sh --qodana` clean.

## Generated by

`/implement` — agent execution of [scoped issue #1713](https://github.com/iamacoffeepot/aether/issues/1713).
