### PR TITLE
refactor(substrate): single-ownership dispatched envelope via take_inbound deferral

### DIFF
--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -360,6 +360,17 @@ impl NativeBinding {
         &self.mailer
     }
 
+    /// #1757: the actor's reply-lineage allocator (a shared-counter
+    /// clone). Surfaced so a handler that retains its inbound via
+    /// [`NativeCtx::take_inbound`](super::ctx::NativeCtx::take_inbound)
+    /// mints the deferred reply's id from the same disjoint
+    /// [`ReplyLineage`] space as the binding's own
+    /// [`Self::send_reply_for_handler`] path, rather than a fresh
+    /// counter that could collide.
+    pub(crate) fn reply_lineage(&self) -> ReplyLineage {
+        self.reply_lineage.clone()
+    }
+
     /// The chassis's [`crate::Spawner`], if one was wired in at
     /// construction. `Some` for production transports built through
     /// [`Self::from_ctx`] (the chassis builds + threads its `Spawner`

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -38,7 +38,9 @@ use super::{NativeActor, NativeDispatch};
 use crate::actor::native::InheritCtx;
 use crate::actor::native::RootCtx;
 use crate::actor::native::dispatch_blocking::{DispatchId, TaskCompletionWake, TaskDone};
+use crate::actor::native::envelope::Envelope;
 use crate::actor::native::spawn_thread;
+use crate::chassis::inbox::InboundMail;
 use crate::mail::{Mail, SourceAddr};
 use std::thread::{Builder as ThreadBuilder, JoinHandle};
 
@@ -67,6 +69,18 @@ pub struct NativeCtx<'a> {
     /// an inbound — those sends mint a fresh root from their own
     /// `mail_id` in `NativeBinding::send_mail`.
     in_flight_root: MailId,
+    /// #1757 / ADR-0094: the single dispatched [`Envelope`], owned here
+    /// for the duration of the handler. The dispatcher moves it in at
+    /// construction ([`Self::with_inbound`]) and takes it back at its
+    /// settlement tail ([`Self::take_raw_inbound`]) to record `Finished` +
+    /// `discharge` exactly once — unless a handler first retained it via
+    /// [`Self::take_inbound`], moving the obligation into an
+    /// [`InboundMail`] guard for a deferred reply. One envelope in one
+    /// place: the detector for a missed settlement is `Option::is_some`,
+    /// so a double-settle is structurally unrepresentable. `None` for the
+    /// ctxs that dispatch nothing (init / close-hook / chassis-root /
+    /// cap-test fixtures built through [`Self::new`]).
+    inbound: Option<Envelope>,
 }
 
 /// The receiver-addressing methods shared verbatim by [`NativeCtx`] and
@@ -123,7 +137,73 @@ impl<'a> NativeCtx<'a> {
             source: sender,
             in_flight_mail_id,
             in_flight_root,
+            inbound: None,
         }
+    }
+
+    /// #1757: the per-dispatch constructor — moves the single dispatched
+    /// [`Envelope`] into the ctx so a handler can retain it via
+    /// [`Self::take_inbound`] (and so the dispatcher's settlement tail
+    /// settles exactly one owner). Only the native dispatcher
+    /// ([`DispatcherSlot::dispatch_one`](crate::actor::native::dispatcher_slot))
+    /// builds these; the inbound-less [`Self::new`] backs the
+    /// close-hook / chassis-root / cap-test ctxs that dispatch nothing.
+    pub(crate) fn with_inbound(
+        binding: &'a Arc<NativeBinding>,
+        sender: Source,
+        in_flight_mail_id: MailId,
+        in_flight_root: MailId,
+        inbound: Envelope,
+    ) -> Self {
+        Self {
+            binding,
+            source: sender,
+            in_flight_mail_id,
+            in_flight_root,
+            inbound: Some(inbound),
+        }
+    }
+
+    /// #1757 / ADR-0106: retain this handler's inbound mail as an
+    /// [`InboundMail`] guard to defer its reply past the handler's return
+    /// — the by-construction replacement for a hand-rolled
+    /// [`SettlementHold`]. Moving the single dispatched envelope out of
+    /// the ctx means the dispatcher's settlement tail sees `None` and does
+    /// not discharge: the returned guard now owns the obligation, and its
+    /// `Drop` records the inbound's `Finished` after any `reply` it sent
+    /// (ADR-0080 §6), settling the chain exactly once. The guard is
+    /// `Send`, so the deferred reply may be sent from a worker thread (the
+    /// desktop capture readback is the motivating consumer).
+    ///
+    /// # Panics
+    /// Panics if there is no dispatched envelope to take — a call from an
+    /// init / close-hook / chassis-root ctx (those carry none), or a
+    /// second `take_inbound` after the first already moved it out.
+    /// Fail-fast per ADR-0063: a correct handler takes its inbound at most
+    /// once.
+    #[must_use]
+    pub fn take_inbound(&mut self) -> InboundMail {
+        let env = self
+            .inbound
+            .take()
+            .expect("take_inbound: no dispatched envelope (init/close-hook ctx, or already taken)");
+        InboundMail::from_dispatched(
+            env,
+            Arc::clone(self.binding.mailer()),
+            self.binding.self_mailbox(),
+            self.binding.reply_lineage(),
+        )
+    }
+
+    /// #1757: hand the dispatched envelope back to the dispatcher's
+    /// settlement tail. `Some` on the normal path (the dispatcher records
+    /// `Finished` + `discharge`s the single owner); `None` when a handler
+    /// retained the guard via [`Self::take_inbound`], whose own un-fired
+    /// `record_finished` then closes the chain when it drops. Called once,
+    /// just before the ctx's handler-end flush, so an armed inbound is
+    /// never dropped inside the ctx (which would trip the ADR-0094 guard).
+    pub(crate) fn take_raw_inbound(&mut self) -> Option<Envelope> {
+        self.inbound.take()
     }
 
     /// Borrow the wired `Mailer`. Issue 953: surfaced so cap handlers

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -214,10 +214,6 @@ where
     /// the ADR-0081 `ActorLogRing`) resolve to this actor's slots.
     /// ADR-0081 retired the prior `log_install::with_actor_dispatch`
     /// wrap + per-handler flush hop.
-    // `env` is taken by value because dispatch may move fields out
-    // (reply_to, payload) into the actor; the helper here doesn't
-    // happen to, but the surface mirrors the owning dispatch loop.
-    #[allow(clippy::needless_pass_by_value)]
     fn dispatch_one(&self, actor: &mut Box<A>, env: Envelope) {
         // iamacoffeepot/aether#1160: note this envelope against the
         // worker's local-drain burst *before* running the handler, so a
@@ -226,7 +222,16 @@ where
         // With the time valve on, the burst's first mail anchors the start
         // (one clock read per burst); with it off, this is a no-op.
         burst_note_mail(time_budget());
-        let inbound_mail_id = env.mail_id;
+        // #1757: the single dispatched envelope moves into `ctx.inbound`
+        // below, so read its `Copy` trace/settlement fields out first —
+        // the `Received` / `Finished` / cost brackets and the settlement
+        // tail run off these locals and never re-borrow the moved value.
+        let mail_id = env.mail_id;
+        let root = env.root;
+        let kind = env.kind;
+        let t_enqueue = env.t_enqueue;
+        let enqueue_depth = env.enqueue_depth;
+        let sender = env.sender;
         // Issue 734 / ADR-0088 §7: stamp the dispatching thread's
         // name-hashed `ThreadId` (a `Copy` u64) onto the `Received`
         // event. Resolved once per worker thread via a thread-local
@@ -236,7 +241,7 @@ where
         // the pool (issue 635 / issue 1187), so this is always the
         // worker's `aether-worker-N`.
         let thread_id = thread_name::current_thread_id();
-        local::with_stamped(&self.slots, || {
+        let inbound = local::with_stamped(&self.slots, || {
             // ADR-0086 Phase 3: `Received` / `Finished` land in this
             // (recipient) actor's trace ring — only inside this
             // `with_stamped` is its `ActorSlots` stamped.
@@ -246,39 +251,55 @@ where
             // no new timestamp on the hot path.
             let t_received = th.now_nanos();
             th.push_trace_ring(
-                env.root,
+                root,
                 TraceEvent::Received {
-                    mail_id: inbound_mail_id,
+                    mail_id,
                     t: t_received,
                     // iamacoffeepot/aether#1134: surface the deposit
                     // instant + scheduler backlog the producer stamped at
                     // `route_mail`, so the hop splits into send→enqueue +
                     // queue residence.
-                    t_enqueue: env.t_enqueue,
-                    enqueue_depth: env.enqueue_depth,
+                    t_enqueue,
+                    enqueue_depth,
                     thread_id,
                 },
             );
-            let mut ctx = NativeCtx::new(&self.binding, env.sender, env.mail_id, env.root);
+            // #1757 / ADR-0094: the dispatched envelope lives in exactly
+            // one place — `ctx.inbound`. The dispatch arms read a disarmed
+            // *view* (a clone whose obligation never fires), so the single
+            // armed envelope settles exactly once: either the settlement
+            // tail below discharges it, or a handler retained it via
+            // `take_inbound`. A copied-metadata `take_inbound` against a
+            // separately-held original would silently double-settle (both
+            // disarm cleanly, the chain settles before the deferred reply,
+            // the caller times out); single ownership makes that
+            // unrepresentable.
+            let view = env.clone();
+            let mut ctx = NativeCtx::with_inbound(&self.binding, sender, mail_id, root, env);
             // ADR-0081 / ADR-0086 / iamacoffeepot/aether#1128
             // framework-built-in dispatch arms for `aether.log.tail` +
             // `aether.trace.tail` + `aether.cost.tail`. See the helper
             // docs in `dispatch`.
-            if !super::dispatch::dispatch_log_tail_if_matching(&mut ctx, &env)
-                && !super::dispatch::dispatch_trace_tail_if_matching(&mut ctx, &env)
-                && !super::dispatch::dispatch_cost_tail_if_matching(&self.binding, &mut ctx, &env)
+            if !super::dispatch::dispatch_log_tail_if_matching(&mut ctx, &view)
+                && !super::dispatch::dispatch_trace_tail_if_matching(&mut ctx, &view)
+                && !super::dispatch::dispatch_cost_tail_if_matching(&self.binding, &mut ctx, &view)
             {
-                super::dispatch::typed_then_fallback_or_warn::<A>(actor, &mut ctx, &env);
+                super::dispatch::typed_then_fallback_or_warn::<A>(actor, &mut ctx, &view);
             }
+            // #1757: reclaim the single envelope before the ctx (and its
+            // handler-end flush) drops, so an armed inbound is never
+            // dropped *inside* the ctx — that would trip the ADR-0094
+            // guard. `None` means a handler retained it via `take_inbound`.
+            let inbound = ctx.take_raw_inbound();
             // iamacoffeepot/aether#1150: flush before `Finished` so a
             // child `Sent` (stamped at flush-begin on `ctx` drop) precedes
             // its parent's `Finished`.
             drop(ctx);
             let t_finished = th.now_nanos();
             th.push_trace_ring(
-                env.root,
+                root,
                 TraceEvent::Finished {
-                    mail_id: inbound_mail_id,
+                    mail_id,
                     t: t_finished,
                 },
             );
@@ -287,16 +308,20 @@ where
             // per-actor cache; framework / fallback kinds skipped).
             // Measure-only — no scheduling change. See
             // `dispatch::fold_handler_cost`.
-            super::dispatch::fold_handler_cost(env.kind, t_received, t_finished);
+            super::dispatch::fold_handler_cost(kind, t_received, t_finished);
+            inbound
         });
-        self.binding
-            .mailer()
-            .record_finished(inbound_mail_id, env.root);
-        // ADR-0094: discharge the obligation guard beside the
-        // `record_finished` that consumes this envelope. The canonical
-        // discharge site — every wasm component and native actor (issue
-        // 634 Phase 4) drains through here.
-        env.discharge();
+        // #1757 / ADR-0080 §2 / ADR-0094: settle the single envelope
+        // exactly once. `Some` is the normal path — `record_finished`
+        // beside `discharge`, the canonical settle site every wasm
+        // component and native actor drains through. `None` means a
+        // handler retained the guard via `take_inbound`; its own un-fired
+        // `record_finished` rides the retained `InboundMail` and closes
+        // the chain when that guard drops, after its deferred reply.
+        if let Some(env) = inbound {
+            self.binding.mailer().record_finished(mail_id, root);
+            env.discharge();
+        }
     }
 
     /// The close hook in the slot teardown sequence. Wraps `actor.unwire`

--- a/crates/aether-substrate/src/chassis/inbox.rs
+++ b/crates/aether-substrate/src/chassis/inbox.rs
@@ -247,6 +247,30 @@ pub struct InboundMail {
 }
 
 impl InboundMail {
+    /// #1757: build a guard for a native dispatcher's *retained* inbound
+    /// (via [`NativeCtx::take_inbound`](crate::actor::native::ctx::NativeCtx::take_inbound)).
+    /// Mirrors [`SettlingInbox::wrap`], but the mailer / claimed mailbox /
+    /// reply-lineage are passed explicitly because the native dispatcher
+    /// owns those on its
+    /// [`NativeBinding`](crate::actor::native::NativeBinding) rather than
+    /// on a `SettlingInbox`. The returned guard settles the inbound's
+    /// chain on `Drop` exactly as a sink-face guard does, so a deferred
+    /// reply joins the same chain the dispatcher would otherwise have
+    /// closed at its tail.
+    pub(crate) fn from_dispatched(
+        env: Envelope,
+        mailer: Arc<Mailer>,
+        self_mailbox: MailboxId,
+        reply_counter: ReplyLineage,
+    ) -> Self {
+        Self {
+            env,
+            mailer,
+            self_mailbox,
+            reply_counter,
+        }
+    }
+
     /// The mail's kind id.
     #[must_use]
     pub fn kind(&self) -> KindId {
@@ -332,6 +356,17 @@ impl Drop for InboundMail {
     }
 }
 
+/// #1757: a retained [`InboundMail`] crosses to a worker thread for a
+/// deferred reply (the desktop capture readback path retains the guard in
+/// one handler turn and `reply`s + drops it from the render thread), so it
+/// must be `Send`. The compile is the assertion — if a future field makes
+/// `InboundMail` `!Send`, this stops compiling rather than failing at the
+/// `take_inbound` move site.
+const _: fn() = || {
+    fn assert_send<T: Send>() {}
+    assert_send::<InboundMail>();
+};
+
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,
@@ -340,6 +375,8 @@ impl Drop for InboundMail {
 mod tests {
     use super::*;
 
+    use crate::actor::native::binding::NativeBinding;
+    use crate::actor::native::ctx::NativeCtx;
     use crate::chassis::settlement::SettlementRegistry;
     use crate::handle_store::HandleStore;
     use crate::mail::MailRef;
@@ -576,5 +613,142 @@ mod tests {
             "reply id is stamped with the claimed mailbox",
         );
         reply_env.discharge();
+    }
+
+    /// #1757: `NativeCtx::take_inbound` moves the *single* dispatched
+    /// envelope out of the ctx, so the dispatcher's settlement tail
+    /// (`take_raw_inbound`) sees `None` and does not also discharge it.
+    /// One envelope in one place — the detector is `Option::is_some`, so a
+    /// double-settle is structurally unrepresentable. A `MailId::NONE`
+    /// inbound carries no obligation, so the guard's drop is a clean
+    /// no-op; this asserts the ownership mechanics, not settlement.
+    #[test]
+    fn take_inbound_moves_the_single_envelope_out_of_the_ctx() {
+        let (_registry, mailer, _settlement) = test_env();
+        let id = MailboxId(0x1757_0001);
+        let binding = Arc::new(NativeBinding::new_for_test(Arc::clone(&mailer), id));
+        let env = armed_env(id, MailId::NONE, MailId::NONE, Source::NONE);
+        let mut ctx =
+            NativeCtx::with_inbound(&binding, Source::NONE, MailId::NONE, MailId::NONE, env);
+
+        let guard = ctx.take_inbound();
+        assert!(
+            ctx.take_raw_inbound().is_none(),
+            "take_inbound moved the single envelope out — the tail sees None and never re-settles",
+        );
+        // NONE obligation: dropping the retained guard records nothing and
+        // never panics (parity with `record_finished`'s NONE no-op).
+        drop(guard);
+    }
+
+    /// #1757 / ADR-0094: single ownership must not weaken the leak
+    /// detector. An armed inbound left in the ctx and dropped without
+    /// being taken (the dispatcher forgot to settle it, or no handler
+    /// retained it) still trips the obligation guard — settlement is not a
+    /// silent self-disarming no-op. Debug-only (the guard is compiled out
+    /// in release).
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "settlement-obligation leak")]
+    fn undispatched_armed_inbound_panics_on_ctx_drop() {
+        let (_registry, mailer, _settlement) = test_env();
+        let id = MailboxId(0x1757_0002);
+        let binding = Arc::new(NativeBinding::new_for_test(Arc::clone(&mailer), id));
+        let mail_id = MailId::new(id, 7);
+        let env = armed_env(id, mail_id, mail_id, Source::NONE);
+        let ctx = NativeCtx::with_inbound(&binding, Source::NONE, mail_id, mail_id, env);
+        // Drop the ctx without taking the inbound — the single armed
+        // envelope is dropped *inside* the ctx, so its ADR-0094 guard
+        // panics rather than leaking.
+        drop(ctx);
+    }
+
+    mod heavy {
+        use super::*;
+        use std::thread;
+
+        /// #1757: the headline gate. A handler defers its reply by
+        /// retaining the inbound guard (`take_inbound`), the dispatcher's
+        /// tail sees `None` and does not settle, and the reply is sent
+        /// across a worker thread. The chain settles **exactly once** —
+        /// not prematurely (the retained guard holds the inbound's
+        /// `Finished` until after the reply's `Sent`, ADR-0080 §6) and not
+        /// twice (single ownership: only the retained guard ever settles
+        /// this inbound). `mod heavy` because the cross-thread settlement
+        /// needs timely progress.
+        #[test]
+        fn deferred_reply_across_thread_settles_exactly_once() {
+            let (registry, mailer, settlement) = test_env();
+            let id = MailboxId(0x1757_0010);
+            let reply_target = MailboxId(0x1757_0011);
+
+            // Register a reply target so the deferred reply routes
+            // somewhere we can pick it up and finish it.
+            let (rtx, rrx) = mpsc::channel::<Envelope>();
+            let handler: Arc<dyn InboxHandler> = Arc::new(move |d: Envelope| {
+                let _ = rtx.send(d);
+            });
+            let reply_target = registry
+                .try_register_inbox_with_id(reply_target, "test.inbox.deferred_target", handler)
+                .expect("register reply target");
+
+            let root = MailId::new(id, 1);
+            mailer.record_sent_inflight(root);
+            let settle = settlement.subscribe_settlement(root);
+
+            let binding = Arc::new(NativeBinding::new_for_test(Arc::clone(&mailer), id));
+            let sender = Source::with_correlation(SourceAddr::Component(reply_target), 7);
+            let env = armed_env(id, MailId::new(id, 21), root, sender);
+            let mut ctx = NativeCtx::with_inbound(&binding, sender, MailId::new(id, 21), root, env);
+
+            // Handler defers: retain the guard, then the dispatcher tail
+            // observes the inbound was taken (single ownership).
+            let guard = ctx.take_inbound();
+            assert!(
+                ctx.take_raw_inbound().is_none(),
+                "the handler retained the single envelope — the tail must not also settle it",
+            );
+            drop(ctx);
+
+            // Reply + settle the inbound from a worker thread (the capture
+            // readback shape). `InboundMail: Send`, so the guard crosses.
+            #[allow(
+                clippy::disallowed_methods,
+                reason = "test infra thread below the actor/mail layer — models the off-thread deferred reply"
+            )]
+            let worker = thread::spawn(move || {
+                assert!(
+                    guard.reply(&LifecycleAdvanceComplete {
+                        completed: 1,
+                        next: 42,
+                    }),
+                    "deferred reply routed to the component target",
+                );
+                // Dropping the guard records the inbound's `Finished`
+                // (after the reply's `Sent`) — the chain stays open until
+                // the reply itself finishes.
+                drop(guard);
+            });
+            worker.join().expect("worker thread");
+
+            assert!(
+                settle.try_recv().is_err(),
+                "the reply's Sent holds the chain open — no premature settle",
+            );
+
+            // Finish the reply the way its eventual recipient's dispatcher
+            // would; only now does the root settle — exactly once.
+            let reply_env = rrx.recv().expect("reply routed to the target inbox");
+            let reply_id = reply_env.mail_id;
+            reply_env.discharge();
+            mailer.record_finished(reply_id, root);
+            settle
+                .recv()
+                .expect("root settles once the deferred reply finishes");
+            assert!(
+                settle.try_recv().is_err(),
+                "the chain settles exactly once — no double-settle",
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Makes the dispatched envelope single-owned during native dispatch (ADR-0094 / ADR-0080). The single envelope moves into `ctx.inbound`; the dispatch arms read a disarmed clone view, so the armed envelope settles exactly once — either the dispatcher's settlement tail discharges it, or a handler retains it via `take_inbound` for a deferred reply.

- `dispatch_one` reads the `Copy` trace/settlement fields out first, moves the armed envelope into the ctx, and reclaims it via `take_raw_inbound` before the ctx drops, so an armed inbound is never dropped inside the ctx (which would trip the ADR-0094 guard).
- `take_inbound` hands the single envelope to an `InboundMail` guard whose `Drop` records `Finished` after any deferred reply, closing the chain exactly once. The desktop capture readback is the motivating consumer.
- A copied-metadata `take_inbound` against a separately-held original would silently double-settle; single ownership makes that unrepresentable.

Behavior is covered by the existing settlement / single-settle suite; the ADR-0094 debug obligation guard panics if single-ownership regresses.

Closes #1757
