### PR TITLE
perf(substrate): drop per-dispatch envelope clone on the hot dispatch path

### DIFF
--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -206,6 +206,16 @@ impl<'a> NativeCtx<'a> {
         self.inbound.take()
     }
 
+    /// #1774: read-only borrow of the dispatched envelope. The cold
+    /// fallback/warn miss path in `typed_then_fallback_or_warn` clones
+    /// from here so the full envelope is available to `#[fallback]` and
+    /// the warn without paying the per-dispatch allocation the hot path
+    /// never needs. `None` for ctxs that carry no inbound (init /
+    /// close-hook / chassis-root / cap-test fixtures).
+    pub(crate) fn inbound(&self) -> Option<&Envelope> {
+        self.inbound.as_ref()
+    }
+
     /// Borrow the wired `Mailer`. Issue 953: surfaced so cap handlers
     /// (`TraceDispatchCapability` is the motivating consumer) can
     /// reach the per-chassis trace handle for `now_nanos` without

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -42,15 +42,37 @@ use crate::mail::{KindId, MailboxId};
 /// Issue 576 framing: catch-all caps that own a `#[fallback]` return
 /// `true` after their fallback runs, which suppresses the warn.
 /// Strict receivers keep the default (`false`) so the miss surfaces.
-pub fn typed_then_fallback_or_warn<A>(actor: &mut Box<A>, ctx: &mut NativeCtx<'_>, env: &Envelope)
-where
+///
+/// #1774: takes `(kind, payload)` instead of `&Envelope` so the hot
+/// typed-match path pays no `kind_name`/`origin` allocation. On a miss
+/// (typed arm returns `None`) the full envelope is cloned from
+/// `ctx.inbound()` — the cold path, where the old per-dispatch cost
+/// now fires only when actually needed. The clone-then-`&mut`-ctx
+/// borrows are sequential (clone borrows `&ctx`, drops; the fallback
+/// call borrows `&mut ctx`), so no borrow conflict.
+pub fn typed_then_fallback_or_warn<A>(
+    actor: &mut Box<A>,
+    ctx: &mut NativeCtx<'_>,
+    kind: KindId,
+    payload: &[u8],
+) where
     A: NativeActor + NativeDispatch,
 {
     if actor
-        .__aether_dispatch_envelope(ctx, env.kind, env.payload.bytes())
-        .is_none()
-        && !actor.__aether_dispatch_fallback(ctx, env)
+        .__aether_dispatch_envelope(ctx, kind, payload)
+        .is_some()
     {
+        return;
+    }
+    let Some(env) = ctx.inbound().cloned() else {
+        tracing::warn!(
+            target: "aether_substrate::dispatch",
+            actor = A::NAMESPACE,
+            "actor dispatch missed: no inbound envelope in ctx",
+        );
+        return;
+    };
+    if !actor.__aether_dispatch_fallback(ctx, &env) {
         tracing::warn!(
             target: "aether_substrate::dispatch",
             actor = A::NAMESPACE,
@@ -73,11 +95,18 @@ where
 /// failure mode; today the per-actor ring is initialised in the
 /// dispatcher's `local::with_stamped` setup unconditionally, so a
 /// missing ring would be a substrate-level invariant violation.
-pub fn dispatch_log_tail_if_matching(ctx: &mut NativeCtx<'_>, env: &Envelope) -> bool {
-    if env.kind.0 != <LogTail as Kind>::ID.0 {
+///
+/// #1774: takes `(kind, payload)` instead of `&Envelope` — the
+/// only fields this arm reads.
+pub fn dispatch_log_tail_if_matching(
+    ctx: &mut NativeCtx<'_>,
+    kind: KindId,
+    payload: &[u8],
+) -> bool {
+    if kind.0 != <LogTail as Kind>::ID.0 {
         return false;
     }
-    let Some(request) = <LogTail as Kind>::decode_from_bytes(env.payload.bytes()) else {
+    let Some(request) = <LogTail as Kind>::decode_from_bytes(payload) else {
         ctx.reply(&LogTailResult::Err {
             error: "aether.log.tail: payload failed to decode".to_owned(),
         });
@@ -98,11 +127,18 @@ pub fn dispatch_log_tail_if_matching(ctx: &mut NativeCtx<'_>, env: &Envelope) ->
 /// replies inline; the dispatcher then skips the user's typed/fallback
 /// dispatch for this envelope. The trace-tree coordinator fans this out
 /// across live actors and stitches the per-ring slices.
-pub fn dispatch_trace_tail_if_matching(ctx: &mut NativeCtx<'_>, env: &Envelope) -> bool {
-    if env.kind.0 != <TraceTail as Kind>::ID.0 {
+///
+/// #1774: takes `(kind, payload)` instead of `&Envelope` — the
+/// only fields this arm reads.
+pub fn dispatch_trace_tail_if_matching(
+    ctx: &mut NativeCtx<'_>,
+    kind: KindId,
+    payload: &[u8],
+) -> bool {
+    if kind.0 != <TraceTail as Kind>::ID.0 {
         return false;
     }
-    let Some(request) = <TraceTail as Kind>::decode_from_bytes(env.payload.bytes()) else {
+    let Some(request) = <TraceTail as Kind>::decode_from_bytes(payload) else {
         ctx.reply(&TraceTailResult::Err {
             error: "aether.trace.tail: payload failed to decode".to_owned(),
         });
@@ -126,15 +162,19 @@ pub fn dispatch_trace_tail_if_matching(ctx: &mut NativeCtx<'_>, env: &Envelope) 
 /// user's typed/fallback dispatch for this envelope. Cold path — read
 /// lock fine (the per-dispatch fold runs lock-free through the per-actor
 /// `CostCells` cache, never here).
+///
+/// #1774: takes `(kind, payload)` instead of `&Envelope` — the
+/// only fields this arm reads.
 pub fn dispatch_cost_tail_if_matching(
     binding: &NativeBinding,
     ctx: &mut NativeCtx<'_>,
-    env: &Envelope,
+    kind: KindId,
+    payload: &[u8],
 ) -> bool {
-    if env.kind.0 != <CostTail as Kind>::ID.0 {
+    if kind.0 != <CostTail as Kind>::ID.0 {
         return false;
     }
-    let Some(request) = <CostTail as Kind>::decode_from_bytes(env.payload.bytes()) else {
+    let Some(request) = <CostTail as Kind>::decode_from_bytes(payload) else {
         ctx.reply(&CostTailResult::Err {
             error: "aether.cost.tail: payload failed to decode".to_owned(),
         });

--- a/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
+++ b/crates/aether-substrate/src/actor/native/dispatcher_slot.rs
@@ -274,17 +274,29 @@ where
             // disarm cleanly, the chain settles before the deferred reply,
             // the caller times out); single ownership makes that
             // unrepresentable.
-            let view = env.clone();
+            //
+            // #1774: replace the full envelope clone with a `MailRef`-only
+            // clone (an Arc-bump for `InRing`, bytes-copy only for the rare
+            // `Owned`). The dispatch arms take `(kind, payload)` — the only
+            // fields they read on the hot path. The cold fallback/warn path
+            // clones the full envelope from `ctx.inbound()` on a miss.
+            let payload_view = env.payload.clone();
             let mut ctx = NativeCtx::with_inbound(&self.binding, sender, mail_id, root, env);
+            let payload = payload_view.bytes();
             // ADR-0081 / ADR-0086 / iamacoffeepot/aether#1128
             // framework-built-in dispatch arms for `aether.log.tail` +
             // `aether.trace.tail` + `aether.cost.tail`. See the helper
             // docs in `dispatch`.
-            if !super::dispatch::dispatch_log_tail_if_matching(&mut ctx, &view)
-                && !super::dispatch::dispatch_trace_tail_if_matching(&mut ctx, &view)
-                && !super::dispatch::dispatch_cost_tail_if_matching(&self.binding, &mut ctx, &view)
+            if !super::dispatch::dispatch_log_tail_if_matching(&mut ctx, kind, payload)
+                && !super::dispatch::dispatch_trace_tail_if_matching(&mut ctx, kind, payload)
+                && !super::dispatch::dispatch_cost_tail_if_matching(
+                    &self.binding,
+                    &mut ctx,
+                    kind,
+                    payload,
+                )
             {
-                super::dispatch::typed_then_fallback_or_warn::<A>(actor, &mut ctx, &view);
+                super::dispatch::typed_then_fallback_or_warn::<A>(actor, &mut ctx, kind, payload);
             }
             // #1757: reclaim the single envelope before the ctx (and its
             // handler-end flush) drops, so an armed inbound is never


### PR DESCRIPTION
Closes #1774.

## Summary

The hot dispatch path took a full `let view = env.clone()` so the framework/typed/fallback arms could read the dispatched envelope while the armed original moved into `ctx.inbound` for single-ownership settlement (#1757 / ADR-0094). That clone copied `kind_name: String` + `origin: Option<String>` + `payload: MailRef` on every dispatch, even though the common arms read only `kind` (a `Copy` `KindId`) and `payload.bytes()`.

This passes `(kind: KindId, payload: &[u8])` to the four dispatch arms instead of `&Envelope`, replaces the per-dispatch `env.clone()` with a `MailRef`-only `env.payload.clone()` (an Arc-bump on the common `InRing` path, a byte-copy only on the rare `Owned` fallback), and clones the full envelope out of `ctx.inbound()` only on the cold fallback/warn miss. Both `String` allocations are gone from every dispatch and the common `InRing` path is byte-copy-free. Behavior-preserving — `take_inbound` is untouched and the ADR-0094 single-ownership invariant holds.

## Test plan

Behavior-preserving refactor; the gate is the existing dispatch / settlement / fallback / framework-arm suite staying green (the ADR-0094 debug obligation guard panics on a single-ownership regression). `scripts/preflight.sh` green: fmt, clippy `--workspace --all-targets -D warnings`, `cargo nextest run --workspace`, doc.

## Generated by

`/implement` — agent execution of scoped issue #1774.
