### PR TITLE
feat(substrate-bundle): substrate-side frame verdict in capture_frame from the raw rgba

### DIFF
--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -76,9 +76,9 @@ mod native {
     use aether_substrate::render::{
         CaptureMeta, IDENTITY_VIEW_PROJ, OverlayDraw, Pipeline, QUAD_VERTEX_STRIDE,
         QUAD_VERTICES_PER_QUAD, QuadPipeline, RealizedTexture, RenderError, Targets,
-        build_main_pipeline, build_quad_pipeline, finish_capture, prepare_capture_copy,
-        push_screen_quad_vertices, push_world_quad_vertices, realize_texture, record_main_pass,
-        record_quad_overlay_pass, upload_texture_full,
+        build_main_pipeline, build_quad_pipeline, finish_capture, map_capture_rgba,
+        prepare_capture_copy, push_screen_quad_vertices, push_world_quad_vertices, realize_texture,
+        record_main_pass, record_quad_overlay_pass, upload_texture_full,
     };
 
     use super::{
@@ -529,6 +529,7 @@ mod native {
                 reply: inbound,
                 after_mails: after,
                 pre_settlements,
+                checks: mail.checks,
             };
             // A rejected request (`Err`) is handed back so its retained
             // guard can carry the synchronous `Err` reply before it drops
@@ -1135,6 +1136,26 @@ mod native {
                 .lock()
                 .expect("mutex poisoned; fail-fast per ADR-0063");
             finish_capture(&gpu.device, &targets, meta)
+        }
+
+        /// Map the readback buffer prepared by [`Self::record_capture_copy`]
+        /// and return the raw de-padded RGBA8 frame — the exact pixels
+        /// [`Self::finish_capture`] PNG-encodes. The bundle render thread
+        /// scores a verdict on these bytes and encodes the PNG from the
+        /// same buffer, so the readback is mapped just once
+        /// (iamacoffeepot/aether#1777). Call after the encoder containing
+        /// the matching `record_capture_copy` has been submitted.
+        ///
+        /// # Panics
+        /// Panics if `install_gpu` hasn't been called or if the targets
+        /// mutex is poisoned — fail-fast per ADR-0063.
+        pub fn map_capture_rgba(&self, meta: &CaptureMeta) -> Result<Vec<u8>, String> {
+            let gpu = self.expect_gpu();
+            let targets = gpu
+                .targets
+                .lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063");
+            map_capture_rgba(&gpu.device, &targets, meta)
         }
 
         /// Resize the offscreen color + depth targets. Idempotent on

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1458,12 +1458,21 @@ mod control_plane {
     /// is dispatched and the reply is `CaptureFrameResult::Err`. The
     /// whole request aborts before touching the queue.
     ///
+    /// `checks` requests a substrate-side verdict scored on the exact
+    /// RGBA the PNG is built from — the de-padded, swizzled frame the
+    /// render thread maps before the PNG encode (ADR-0105 capture path,
+    /// iamacoffeepot/aether#1777). Each entry names one
+    /// `test_bench::visual` reduction plus its lit/background partition
+    /// params; the results ride back on `CaptureFrameResult::Ok.verdict`.
+    /// Empty means "PNG only, no verdict" — the prior behaviour.
+    ///
     /// Reply: `CaptureFrameResult`.
     #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.render.capture_frame")]
     pub struct CaptureFrame {
         pub mails: Vec<MailEnvelope>,
         pub after_mails: Vec<MailEnvelope>,
+        pub checks: Vec<FrameCheck>,
     }
 
     /// One mail in a `CaptureFrame.mails` bundle. Structurally mirrors
@@ -1482,28 +1491,121 @@ mod control_plane {
     }
 
     /// Reply to `CaptureFrame`. `Ok` carries the PNG bytes for the
-    /// captured frame; `Err` carries a free-form reason — capture not
-    /// supported on this surface, map failed, encode failed, or a
-    /// bundle-resolution failure (unknown kind / mailbox) aborting
+    /// captured frame plus an optional [`FrameVerdict`] (present iff the
+    /// request carried `checks`); `Err` carries a free-form reason —
+    /// capture not supported on this surface, map failed, encode failed,
+    /// or a bundle-resolution failure (unknown kind / mailbox) aborting
     /// before any mail was dispatched.
     #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.render.capture_frame_result")]
     pub enum CaptureFrameResult {
-        Ok { png: Vec<u8> },
-        Err { error: String },
+        Ok {
+            png: Vec<u8>,
+            verdict: Option<FrameVerdict>,
+        },
+        Err {
+            error: String,
+        },
     }
 
     /// Build a [`CaptureFrameResult`] from the raw GPU `render_and_capture`
     /// result shape. Every capture handler in `aether-substrate-bundle`
     /// (test-bench inline, in-process bench, desktop driver) needs this
-    /// same `Ok(png) → Ok { png }` / `Err(error) → Err { error }` flip.
-    impl From<Result<Vec<u8>, String>> for CaptureFrameResult {
-        fn from(result: Result<Vec<u8>, String>) -> Self {
+    /// same `Ok((png, verdict)) → Ok { png, verdict }` / `Err(error) → Err
+    /// { error }` flip. `verdict` is `None` when the request carried no
+    /// `checks`.
+    impl From<Result<(Vec<u8>, Option<FrameVerdict>), String>> for CaptureFrameResult {
+        fn from(result: Result<(Vec<u8>, Option<FrameVerdict>), String>) -> Self {
             match result {
-                Ok(png) => Self::Ok { png },
+                Ok((png, verdict)) => Self::Ok { png, verdict },
                 Err(error) => Self::Err { error },
             }
         }
+    }
+
+    /// One reduction requested in a [`CaptureFrame::checks`] list. The
+    /// `reduction` names which `test_bench::visual` check to run;
+    /// `tolerance` is the per-channel threshold that partitions pixels
+    /// into the lit/background mask the silhouette reductions share; and
+    /// `background` pins the reference RGB — `None` falls back to the
+    /// frame's top-left pixel, the `differs_from_background` convention.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+    pub struct FrameCheck {
+        pub reduction: FrameReduction,
+        pub tolerance: u8,
+        pub background: Option<[u8; 3]>,
+    }
+
+    /// Which `test_bench::visual` reduction a [`FrameCheck`] runs. The
+    /// names mirror the public reduction functions one-for-one.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum FrameReduction {
+        /// `not_all_black` — at least one pixel has a non-zero RGB.
+        NotAllBlack,
+        /// `differs_from_background` — at least one pixel exceeds the
+        /// tolerance band around the background reference.
+        DiffersFromBackground,
+        /// `coverage` — lit fraction of the frame in `[0.0, 1.0]`.
+        Coverage,
+        /// `centroid` — mean lit-pixel `(x, y)`.
+        Centroid,
+        /// `bounding_box` — inclusive lit-pixel extent.
+        BoundingBox,
+    }
+
+    /// Substrate-side verdict over a captured frame: the frame
+    /// dimensions plus one [`FrameCheckResult`] per requested reduction,
+    /// scored on the exact de-padded RGBA the PNG was encoded from
+    /// (iamacoffeepot/aether#1777). Rides on `CaptureFrameResult::Ok`
+    /// when the request carried `checks`.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq)]
+    pub struct FrameVerdict {
+        pub width: u32,
+        pub height: u32,
+        pub results: Vec<FrameCheckResult>,
+    }
+
+    /// Result of one requested reduction. The variant matches the
+    /// [`FrameReduction`] requested; the assertion-style checks
+    /// (`NotAllBlack` / `DiffersFromBackground`) report `passed` plus a
+    /// `detail` failure string (`None` on pass), and the silhouette
+    /// reductions echo the `background` they partitioned against
+    /// alongside their scalar / coordinate result (`None` when the lit
+    /// mask was empty).
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq)]
+    pub enum FrameCheckResult {
+        NotAllBlack {
+            passed: bool,
+            detail: Option<String>,
+        },
+        DiffersFromBackground {
+            passed: bool,
+            detail: Option<String>,
+        },
+        Coverage {
+            background: [u8; 3],
+            fraction: f32,
+        },
+        Centroid {
+            background: [u8; 3],
+            centroid: Option<[f32; 2]>,
+        },
+        BoundingBox {
+            background: [u8; 3],
+            rect: Option<FrameRect>,
+        },
+    }
+
+    /// Inclusive axis-aligned pixel extent of a lit region — the wire
+    /// mirror of `test_bench::visual::Rect`. `min`/`max` are the smallest
+    /// and largest lit column (`x`) and row (`y`); a single lit pixel
+    /// yields `min == max`.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct FrameRect {
+        pub min_x: u32,
+        pub min_y: u32,
+        pub max_x: u32,
+        pub max_y: u32,
     }
 
     // ADR-0105 textured-quad render surface. Three kinds on the
@@ -3645,6 +3747,133 @@ mod tests {
             assert_eq!(nested_fields[0].name, "x");
             assert_eq!(nested_fields[2].name, "z");
             assert_eq!(nested_fields[5].name, "b");
+        }
+    }
+
+    // iamacoffeepot/aether#1777 capture-verdict kind roundtrips. The
+    // request gains an optional-background `checks` list and the result
+    // gains an optional `verdict` carrying scalar / coordinate reduction
+    // results; postcard roundtrip proves the derived Serialize/Deserialize
+    // agree on the wire for the new shapes.
+    mod capture_verdict_roundtrips {
+        use super::*;
+        use alloc::string::ToString;
+        use alloc::vec;
+
+        #[test]
+        fn capture_frame_checks_roundtrip() {
+            let frame = CaptureFrame {
+                mails: vec![],
+                after_mails: vec![],
+                checks: vec![
+                    FrameCheck {
+                        reduction: FrameReduction::NotAllBlack,
+                        tolerance: 0,
+                        background: None,
+                    },
+                    FrameCheck {
+                        reduction: FrameReduction::Coverage,
+                        tolerance: 5,
+                        background: Some([69, 79, 105]),
+                    },
+                ],
+            };
+            let bytes =
+                postcard::to_allocvec(&frame).expect("test setup: postcard encodes CaptureFrame");
+            let back: CaptureFrame =
+                postcard::from_bytes(&bytes).expect("test setup: postcard decodes CaptureFrame");
+            assert_eq!(back.checks.len(), 2);
+            assert_eq!(back.checks[0].reduction, FrameReduction::NotAllBlack);
+            assert_eq!(back.checks[0].background, None);
+            assert_eq!(back.checks[1].reduction, FrameReduction::Coverage);
+            assert_eq!(back.checks[1].tolerance, 5);
+            assert_eq!(back.checks[1].background, Some([69, 79, 105]));
+        }
+
+        #[test]
+        fn capture_frame_result_verdict_roundtrip() {
+            let ok = CaptureFrameResult::Ok {
+                png: vec![0x89, 0x50, 0x4E, 0x47],
+                verdict: Some(FrameVerdict {
+                    width: 64,
+                    height: 48,
+                    results: vec![
+                        FrameCheckResult::NotAllBlack {
+                            passed: true,
+                            detail: None,
+                        },
+                        FrameCheckResult::DiffersFromBackground {
+                            passed: false,
+                            detail: Some("all pixels within tolerance".to_string()),
+                        },
+                        FrameCheckResult::Coverage {
+                            background: [69, 79, 105],
+                            fraction: 0.25,
+                        },
+                        FrameCheckResult::Centroid {
+                            background: [69, 79, 105],
+                            centroid: Some([31.5, 23.5]),
+                        },
+                        FrameCheckResult::BoundingBox {
+                            background: [69, 79, 105],
+                            rect: Some(FrameRect {
+                                min_x: 16,
+                                min_y: 12,
+                                max_x: 40,
+                                max_y: 30,
+                            }),
+                        },
+                    ],
+                }),
+            };
+            let bytes = postcard::to_allocvec(&ok)
+                .expect("test setup: postcard encodes CaptureFrameResult::Ok");
+            let back: CaptureFrameResult = postcard::from_bytes(&bytes)
+                .expect("test setup: postcard decodes CaptureFrameResult::Ok");
+            match back {
+                CaptureFrameResult::Ok { png, verdict } => {
+                    assert_eq!(png, vec![0x89, 0x50, 0x4E, 0x47]);
+                    let verdict = verdict.expect("verdict survives the roundtrip");
+                    assert_eq!((verdict.width, verdict.height), (64, 48));
+                    assert_eq!(verdict.results.len(), 5);
+                    assert_eq!(
+                        verdict.results[2],
+                        FrameCheckResult::Coverage {
+                            background: [69, 79, 105],
+                            fraction: 0.25,
+                        },
+                    );
+                    assert_eq!(
+                        verdict.results[4],
+                        FrameCheckResult::BoundingBox {
+                            background: [69, 79, 105],
+                            rect: Some(FrameRect {
+                                min_x: 16,
+                                min_y: 12,
+                                max_x: 40,
+                                max_y: 30,
+                            }),
+                        },
+                    );
+                }
+                CaptureFrameResult::Err { .. } => panic!("expected Ok"),
+            }
+        }
+
+        #[test]
+        fn capture_frame_result_no_verdict_roundtrip() {
+            let ok = CaptureFrameResult::Ok {
+                png: vec![1, 2, 3],
+                verdict: None,
+            };
+            let bytes = postcard::to_allocvec(&ok)
+                .expect("test setup: postcard encodes CaptureFrameResult::Ok");
+            let back: CaptureFrameResult = postcard::from_bytes(&bytes)
+                .expect("test setup: postcard decodes CaptureFrameResult::Ok");
+            match back {
+                CaptureFrameResult::Ok { verdict, .. } => assert!(verdict.is_none()),
+                CaptureFrameResult::Err { .. } => panic!("expected Ok"),
+            }
         }
     }
 

--- a/crates/aether-mcp/src/args.rs
+++ b/crates/aether-mcp/src/args.rs
@@ -481,6 +481,27 @@ pub struct MailNodeJson {
     pub thread_name: Option<String>,
 }
 
+/// One frame check in a `capture_frame` `checks` list. Names a
+/// substrate-side reduction the render thread scores on the raw RGBA
+/// the PNG is built from, so a smoke demo asserts without decoding the
+/// returned PNG (iamacoffeepot/aether#1777).
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CaptureCheckSpec {
+    /// Which reduction to run: `"not_all_black"`,
+    /// `"differs_from_background"`, `"coverage"`, `"centroid"`, or
+    /// `"bounding_box"`.
+    pub reduction: String,
+    /// Per-channel tolerance (0-255) for the lit/background partition
+    /// the silhouette reductions share. Defaults to 0.
+    #[serde(default)]
+    pub tolerance: u8,
+    /// Explicit background RGB the reduction partitions against. Omit
+    /// or `null` to use the frame's top-left pixel (the
+    /// `differs_from_background` convention).
+    #[serde(default)]
+    pub background: Option<[u8; 3]>,
+}
+
 /// `capture_frame` arguments.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct CaptureFrameArgs {
@@ -495,6 +516,11 @@ pub struct CaptureFrameArgs {
     /// flag the caller flipped for the capture.
     #[serde(default)]
     pub after_mails: Vec<CaptureMailSpec>,
+    /// Reductions to score substrate-side on the captured frame's raw
+    /// RGBA, returned as a `verdict` alongside the PNG. Omit for a
+    /// PNG-only capture (iamacoffeepot/aether#1777).
+    #[serde(default)]
+    pub checks: Vec<CaptureCheckSpec>,
 }
 
 // `SubmitDagArgs` lives in its own module so a *scoped*

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -30,10 +30,10 @@ use aether_data::{
 use aether_kinds::dag::{DagDescriptor, Edge, Node, NodeId};
 use aether_kinds::{
     Cancel, CancelResult, CaptureFrame, CaptureFrameResult, ComponentCapabilities, CostTail,
-    CostTailResult, ListEngines, ListEnginesResult, ListKinds, ListKindsResult, LoadComponent,
-    LoadResult, MailEnvelope as KindMailEnvelope, ReplaceComponent, ReplaceResult, SpawnEngine,
-    SpawnEngineResult, Status, StatusResult, Submit, SubmitResult, TerminateEngine,
-    TerminateEngineResult,
+    CostTailResult, FrameCheck, FrameReduction, ListEngines, ListEnginesResult, ListKinds,
+    ListKindsResult, LoadComponent, LoadResult, MailEnvelope as KindMailEnvelope, ReplaceComponent,
+    ReplaceResult, SpawnEngine, SpawnEngineResult, Status, StatusResult, Submit, SubmitResult,
+    TerminateEngine, TerminateEngineResult,
     trace::{
         DescribeTreeResult, DispatchTraced, DispatchTracedAck, MailNodeWire, TRACE_MAILBOX_NAME,
         TraceTail, TraceTailResult,
@@ -52,8 +52,8 @@ use crate::args::ActorLogsArgs;
 use crate::args::ActorLogsResponse;
 use crate::args::{ActorCostArgs, ActorCostResponse, ActorCostRow};
 use crate::args::{
-    CaptureFrameArgs, CaptureMailSpec, DagCancelArgs, DagDescriptorArg, DagStatusArgs,
-    DescribeComponentArgs, DescribeHandlesArgs, DescribeHandlesResponse, EngineInfo,
+    CaptureCheckSpec, CaptureFrameArgs, CaptureMailSpec, DagCancelArgs, DagDescriptorArg,
+    DagStatusArgs, DescribeComponentArgs, DescribeHandlesArgs, DescribeHandlesResponse, EngineInfo,
     HandleSummaryJson, LoadComponentArgs, MailIdJson, MailNodeJson, MailSpec, MailStatus, NodeArg,
     ReplaceComponentArgs, ReplyEventJson, SendMailArgs, SendMailTracedArgs, SendMailTracedResponse,
     SpawnSubstrateArgs, SubmitDagArgs, TerminateSubstrateArgs, TracedMailSpec, TransformListing,
@@ -567,7 +567,7 @@ impl Mcp {
     }
 
     #[tool(
-        description = "Capture an engine's current frame as a PNG, returned inline as image content. Optionally carries two mail bundles dispatched atomically around the capture: `mails` fires before readback (state changes that should appear in the image), `after_mails` fires after (cleanup). A bad bundle entry aborts the whole capture before any mail moves."
+        description = "Capture an engine's current frame as a PNG, returned inline as image content. Optionally carries two mail bundles dispatched atomically around the capture: `mails` fires before readback (state changes that should appear in the image), `after_mails` fires after (cleanup). A bad bundle entry aborts the whole capture before any mail moves. Optionally carries `checks`: substrate-side reductions (not_all_black, differs_from_background, coverage, centroid, bounding_box) scored on the exact RGBA the PNG is built from and returned as a `verdict` text block alongside the image — a one-call spawn -> drive -> assert with no caller-side PNG decode."
     )]
     pub async fn capture_frame(
         &self,
@@ -592,22 +592,40 @@ impl Mcp {
             .map_err(|e| {
                 McpError::invalid_params(format!("capture_frame after_mails bundle: {e}"), None)
             })?;
+        // Map the verdict request: an unknown reduction name is a clean
+        // invalid-params error before the capture touches the wire.
+        let checks = args
+            .checks
+            .iter()
+            .map(capture_check)
+            .collect::<Result<Vec<FrameCheck>, McpError>>()?;
         let reply = self
             .session
             .call_one(engine_envelope(
                 engine,
                 RENDER_CAP,
-                &CaptureFrame { mails, after_mails },
+                &CaptureFrame {
+                    mails,
+                    after_mails,
+                    checks,
+                },
             ))
             .await
             .map_err(internal)?;
         match CaptureFrameResult::decode_from_bytes(&reply.payload) {
-            Some(CaptureFrameResult::Ok { png }) => {
+            Some(CaptureFrameResult::Ok { png, verdict }) => {
                 let encoded = STANDARD.encode(&png);
-                Ok(CallToolResult::success(vec![Content::image(
-                    encoded,
-                    "image/png",
-                )]))
+                let mut content = vec![Content::image(encoded, "image/png")];
+                // Surface the verdict as a JSON text block so the caller
+                // reads the reductions' results without decoding the PNG
+                // (iamacoffeepot/aether#1777). Absent when no `checks`
+                // were requested.
+                if let Some(verdict) = verdict {
+                    let json = serde_json::to_string(&verdict)
+                        .map_err(|e| internal_msg(&format!("verdict serialize: {e}")))?;
+                    content.push(Content::text(json));
+                }
+                Ok(CallToolResult::success(content))
             }
             Some(CaptureFrameResult::Err { error }) => Err(internal_msg(&error)),
             None => Err(internal_msg("undecodable CaptureFrameResult")),
@@ -1383,6 +1401,34 @@ fn engine_envelope_by_id<K: Kind>(engine: EngineId, mailbox: MailboxId, kind: &K
     }
 }
 
+/// Map a `capture_frame` check spec onto a wire [`FrameCheck`],
+/// resolving the reduction name. An unknown name is an invalid-params
+/// error so a typo aborts the capture cleanly before it reaches the
+/// wire (iamacoffeepot/aether#1777).
+fn capture_check(spec: &CaptureCheckSpec) -> Result<FrameCheck, McpError> {
+    let reduction = match spec.reduction.as_str() {
+        "not_all_black" => FrameReduction::NotAllBlack,
+        "differs_from_background" => FrameReduction::DiffersFromBackground,
+        "coverage" => FrameReduction::Coverage,
+        "centroid" => FrameReduction::Centroid,
+        "bounding_box" => FrameReduction::BoundingBox,
+        other => {
+            return Err(McpError::invalid_params(
+                format!(
+                    "capture_frame check: unknown reduction {other:?}; expected one of \
+                     not_all_black, differs_from_background, coverage, centroid, bounding_box"
+                ),
+                None,
+            ));
+        }
+    };
+    Ok(FrameCheck {
+        reduction,
+        tolerance: spec.tolerance,
+        background: spec.background,
+    })
+}
+
 /// Parse a UUID-string `engine_id` (from `list_engines` /
 /// `spawn_substrate`) into an `EngineId`.
 fn parse_engine_id(s: &str) -> Result<EngineId, McpError> {
@@ -2130,6 +2176,7 @@ mod tests {
                     params: None,
                 }],
                 after_mails: vec![],
+                checks: vec![],
             }))
             .await;
         assert!(

--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -252,7 +252,7 @@ fn run_frame(
                 }
             }
             let result = pre_failed.map_or_else(
-                || CaptureFrameResult::from(gpu.render_and_capture()),
+                || CaptureFrameResult::from(gpu.render_and_capture(&req.checks)),
                 |error| CaptureFrameResult::Err { error },
             );
             for mail in req.after_mails {

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -1148,7 +1148,7 @@ impl ApplicationHandler<UserEvent> for App {
                                 }
                             }
                             let result = pre_failed.map_or_else(
-                                || CaptureFrameResult::from(gpu.render_and_capture()),
+                                || CaptureFrameResult::from(gpu.render_and_capture(&req.checks)),
                                 |error| CaptureFrameResult::Err { error },
                             );
                             for mail in req.after_mails {
@@ -1992,6 +1992,7 @@ mod tests {
                 reply,
                 after_mails: Vec::new(),
                 pre_settlements: Vec::new(),
+                checks: Vec::new(),
             }
         }
 
@@ -2115,6 +2116,7 @@ mod tests {
             reply,
             after_mails: Vec::new(),
             pre_settlements: Vec::new(),
+            checks: Vec::new(),
         };
 
         // The driver's reply path: reply through the retained guard, then

--- a/crates/aether-substrate-bundle/src/desktop/render.rs
+++ b/crates/aether-substrate-bundle/src/desktop/render.rs
@@ -15,14 +15,22 @@
 use std::sync::Arc;
 
 use aether_capabilities::{RenderGpu, RenderHandles};
-use aether_substrate::render::{self, RenderError, vertex_buffer_layout};
+use aether_kinds::{FrameCheck, FrameVerdict};
+use aether_substrate::render::{self, RenderError, encode_png, vertex_buffer_layout};
 use winit::dpi::PhysicalSize;
 use winit::window::Window;
+
+use crate::visual;
 
 pub use render::VERTEX_BUFFER_BYTES;
 use std::env;
 use std::iter;
 use std::slice;
+
+/// PNG bytes plus the optional [`FrameVerdict`] `render_and_capture`
+/// produces — the verdict is `Some` iff the request carried `checks`
+/// (iamacoffeepot/aether#1777).
+type CaptureOutcome = Result<(Vec<u8>, Option<FrameVerdict>), String>;
 
 /// Wireframe-overlay shader: same vertex layout as the main shader so
 /// the pipeline shares the existing vertex buffer. The fragment stage
@@ -308,27 +316,29 @@ impl Gpu {
     }
 
     pub fn render(&mut self) {
-        let _ = self.render_impl(false);
+        let _ = self.render_impl(None);
     }
 
     /// Variant of `render` that also copies the offscreen texture into
-    /// a readback buffer, maps it, and returns an encoded PNG. On any
+    /// a readback buffer, maps it, and returns an encoded PNG plus an
+    /// optional [`FrameVerdict`] scored on the same raw RGBA (present
+    /// iff `checks` is non-empty; iamacoffeepot/aether#1777). On any
     /// capture-path failure, returns `Err(reason)`; the frame itself
     /// still renders and (if the surface is available) presents, since
     /// capture is a side channel.
-    pub fn render_and_capture(&mut self) -> Result<Vec<u8>, String> {
-        self.render_impl(true)
+    pub fn render_and_capture(&mut self, checks: &[FrameCheck]) -> CaptureOutcome {
+        self.render_impl(Some(checks))
             .ok_or_else(|| "capture did not produce a result".to_owned())?
     }
 
     /// Draw the current accumulator vertices into the offscreen target
     /// with the latest camera view-proj, optionally encode a capture
     /// copy, then best-effort blit to the swapchain and present.
-    /// Returns `Some(Ok(png))` / `Some(Err(reason))` when `capture` is
-    /// set; `None` when `capture` is false or the capture path
-    /// couldn't allocate. Surface unavailability does *not* prevent
-    /// capture — offscreen is the source of truth.
-    fn render_impl(&mut self, capture: bool) -> Option<Result<Vec<u8>, String>> {
+    /// Returns `Some(Ok((png, verdict)))` / `Some(Err(reason))` when
+    /// `capture` is `Some(checks)`; `None` when capture wasn't requested
+    /// or the capture path couldn't allocate. Surface unavailability
+    /// does *not* prevent capture — offscreen is the source of truth.
+    fn render_impl(&mut self, capture: Option<&[FrameCheck]>) -> Option<CaptureOutcome> {
         let device = self.render_handles.device();
         let queue = self.render_handles.queue();
 
@@ -384,7 +394,7 @@ impl Gpu {
         // Capture path: the copy runs against the offscreen texture,
         // which is unaffected by whether a swapchain image is available
         // this frame. That decouples capture from window visibility.
-        let capture_meta = if capture {
+        let capture_meta = if capture.is_some() {
             Some(self.render_handles.record_capture_copy(&mut encoder))
         } else {
             None
@@ -429,7 +439,20 @@ impl Gpu {
             tex.present();
         }
 
-        capture_meta.map(|meta| self.render_handles.finish_capture(&meta))
+        // Map the readback once; encode the PNG and (when checks were
+        // requested) score the verdict from the same de-padded RGBA so
+        // the verdict scores the exact bytes the PNG carries
+        // (iamacoffeepot/aether#1777). `capture_meta` is `Some` iff
+        // `capture` is `Some`, so `unwrap_or(&[])` only papers over an
+        // unreachable case.
+        capture_meta.map(|meta| {
+            let rgba = self.render_handles.map_capture_rgba(&meta)?;
+            let png = encode_png(&rgba, meta.width, meta.height)?;
+            let checks = capture.unwrap_or(&[]);
+            let verdict = (!checks.is_empty())
+                .then(|| visual::run_checks(rgba, meta.width, meta.height, checks));
+            Ok((png, verdict))
+        })
     }
 
     /// Try to get the current swapchain texture. Reconfigures the

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -719,11 +719,15 @@ impl TestBench {
             &CaptureFrame {
                 mails: pre,
                 after_mails: after,
+                // The `TestBench::capture` API returns the PNG only; the
+                // substrate-side verdict path (iamacoffeepot/aether#1777)
+                // is exercised through `BenchOp::send_and_await` scenarios.
+                checks: Vec::new(),
             },
             cid,
         );
         match self.pump_until_reply::<CaptureFrameResult>(cid, "CaptureFrameResult")? {
-            CaptureFrameResult::Ok { png } => Ok(png),
+            CaptureFrameResult::Ok { png, .. } => Ok(png),
             CaptureFrameResult::Err { error } => Err(TestBenchError::Capture(error)),
         }
     }
@@ -1070,7 +1074,7 @@ impl TestBench {
                         });
                     }
                 }
-                let result = CaptureFrameResult::from(self.gpu.render_and_capture());
+                let result = CaptureFrameResult::from(self.gpu.render_and_capture(&req.checks));
                 for mail in req.after_mails {
                     self.queue.push(mail);
                 }
@@ -1195,6 +1199,7 @@ mod tests {
                             &CaptureFrame {
                                 mails: Vec::new(),
                                 after_mails: Vec::new(),
+                                checks: Vec::new(),
                             },
                         ),
                     ),
@@ -1204,7 +1209,11 @@ mod tests {
                 .reply("capture")
                 .expect("capture step replied with CaptureFrameResult");
             match reply {
-                CaptureFrameResult::Ok { png } => {
+                CaptureFrameResult::Ok { png, verdict } => {
+                    assert!(
+                        verdict.is_none(),
+                        "no checks were requested, so the verdict must be absent",
+                    );
                     assert!(
                         png.starts_with(&[0x89, 0x50, 0x4E, 0x47]),
                         "captured bytes are not a PNG: first 8 bytes={:?}",

--- a/crates/aether-substrate-bundle/src/test_bench/render.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/render.rs
@@ -8,10 +8,17 @@
 use std::sync::Arc;
 
 use aether_capabilities::{RenderGpu, RenderHandles};
-use aether_substrate::render::RenderError;
+use aether_kinds::{FrameCheck, FrameVerdict};
+use aether_substrate::render::{RenderError, encode_png};
 
+use crate::visual;
 pub use aether_substrate::render::VERTEX_BUFFER_BYTES;
 use std::iter;
+
+/// PNG bytes plus the optional [`FrameVerdict`] `render_and_capture`
+/// produces — the verdict is `Some` iff the request carried `checks`
+/// (iamacoffeepot/aether#1777).
+type CaptureOutcome = Result<(Vec<u8>, Option<FrameVerdict>), String>;
 
 /// Render target format. Test-bench commits to RGBA at init since
 /// there's no surface to query, which keeps the readback path swizzle-
@@ -114,7 +121,9 @@ impl Gpu {
     }
 
     /// Variant of `render` that also copies the offscreen texture
-    /// into a readback buffer, maps it, and returns an encoded PNG.
+    /// into a readback buffer, maps it, and returns an encoded PNG
+    /// plus an optional [`FrameVerdict`] scored on the same raw RGBA
+    /// (present iff `checks` is non-empty; iamacoffeepot/aether#1777).
     /// On any capture-path failure, returns `Err(reason)`; the frame
     /// still rendered to the offscreen — capture is a side channel.
     ///
@@ -126,7 +135,7 @@ impl Gpu {
     /// iamacoffeepot/aether#847 retired the historical `nudge_tick`
     /// boilerplate that worked around the prior consume-and-discard
     /// behaviour.
-    pub fn render_and_capture(&mut self) -> Result<Vec<u8>, String> {
+    pub fn render_and_capture(&mut self, checks: &[FrameCheck]) -> CaptureOutcome {
         let device = self.render_handles.device();
         let queue = self.render_handles.queue();
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -145,6 +154,13 @@ impl Gpu {
         self.render_handles.record_overlay_pass(&mut encoder, true);
         let meta = self.render_handles.record_capture_copy(&mut encoder);
         queue.submit(iter::once(encoder.finish()));
-        self.render_handles.finish_capture(&meta)
+        // Map the readback once; encode the PNG and score the verdict
+        // from the same de-padded RGBA so a verdict scores the exact
+        // bytes the PNG carries (iamacoffeepot/aether#1777).
+        let rgba = self.render_handles.map_capture_rgba(&meta)?;
+        let png = encode_png(&rgba, meta.width, meta.height)?;
+        let verdict =
+            (!checks.is_empty()).then(|| visual::run_checks(rgba, meta.width, meta.height, checks));
+        Ok((png, verdict))
     }
 }

--- a/crates/aether-substrate-bundle/src/visual.rs
+++ b/crates/aether-substrate-bundle/src/visual.rs
@@ -6,6 +6,7 @@
 
 use std::io::Cursor;
 
+use aether_kinds::{FrameCheck, FrameCheckResult, FrameRect, FrameReduction, FrameVerdict};
 use thiserror::Error;
 
 /// Decoded frame: RGBA8 pixels in row-major top-down order, width
@@ -224,6 +225,73 @@ pub fn background_top_left(image: &Image) -> [u8; 3] {
         return [0, 0, 0];
     }
     [image.rgba[0], image.rgba[1], image.rgba[2]]
+}
+
+/// Score a `CaptureFrame.checks` request against a freshly-mapped
+/// RGBA8 frame (the exact bytes the PNG is encoded from) and return the
+/// wire [`FrameVerdict`]. This is the substrate-side verdict the MCP
+/// `capture_frame` tool surfaces alongside the PNG
+/// (iamacoffeepot/aether#1777): the render thread reaches the raw RGBA
+/// and the reductions in one place, so a smoke demo asserts on the
+/// precise pixels rendered without decoding the returned PNG.
+///
+/// Each check resolves its own background — explicit when the request
+/// pins one, otherwise the frame's top-left pixel
+/// (`differs_from_background`'s convention). `rgba` is consumed to build
+/// the working `Image` so the verdict runs without copying the buffer.
+#[must_use]
+pub fn run_checks(rgba: Vec<u8>, width: u32, height: u32, checks: &[FrameCheck]) -> FrameVerdict {
+    let image = Image {
+        width,
+        height,
+        rgba,
+    };
+    let results = checks
+        .iter()
+        .map(|check| {
+            let bg = check
+                .background
+                .unwrap_or_else(|| background_top_left(&image));
+            match check.reduction {
+                FrameReduction::NotAllBlack => {
+                    let (passed, detail) = match not_all_black(&image) {
+                        Ok(()) => (true, None),
+                        Err(detail) => (false, Some(detail)),
+                    };
+                    FrameCheckResult::NotAllBlack { passed, detail }
+                }
+                FrameReduction::DiffersFromBackground => {
+                    let (passed, detail) = match differs_from_background(&image, check.tolerance) {
+                        Ok(()) => (true, None),
+                        Err(detail) => (false, Some(detail)),
+                    };
+                    FrameCheckResult::DiffersFromBackground { passed, detail }
+                }
+                FrameReduction::Coverage => FrameCheckResult::Coverage {
+                    background: bg,
+                    fraction: coverage(&image, bg, check.tolerance),
+                },
+                FrameReduction::Centroid => FrameCheckResult::Centroid {
+                    background: bg,
+                    centroid: centroid(&image, bg, check.tolerance).map(<[f32; 2]>::from),
+                },
+                FrameReduction::BoundingBox => FrameCheckResult::BoundingBox {
+                    background: bg,
+                    rect: bounding_box(&image, bg, check.tolerance).map(|r| FrameRect {
+                        min_x: r.min_x,
+                        min_y: r.min_y,
+                        max_x: r.max_x,
+                        max_y: r.max_y,
+                    }),
+                },
+            }
+        })
+        .collect();
+    FrameVerdict {
+        width,
+        height,
+        results,
+    }
 }
 
 #[cfg(test)]

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -31,8 +31,9 @@ use std::path::Path;
 
 use aether_data::{Kind, MailboxId};
 use aether_kinds::{
-    Camera, CreateTexture, CreateTextureResult, Delete, DeleteResult, DrawSolidQuads, DrawText,
-    DrawTexturedQuads, DropComponent, DropResult, FsError, List, ListResult, LoadComponent,
+    Camera, CaptureFrame, CaptureFrameResult, CreateTexture, CreateTextureResult, Delete,
+    DeleteResult, DrawSolidQuads, DrawText, DrawTexturedQuads, DropComponent, DropResult,
+    FrameCheck, FrameCheckResult, FrameReduction, FsError, List, ListResult, LoadComponent,
     LoadFont, LoadFontResult, LoadResult, MailEnvelope, Ping, QuadScale, QuadSpace, Read,
     ReadResult, ReplaceComponent, ReplaceResult, SolidQuad, TexturedQuad, Write, WriteResult,
 };
@@ -843,6 +844,126 @@ fn solid_quad_draws_screen_space_rect() {
         "after the solid quad stopped being sent the frame should be uniform clear color, \
          but coverage was {cleared_coverage} (immediate-mode clear did not run)",
     );
+}
+
+/// iamacoffeepot/aether#1777: a `capture_frame` carrying a `checks`
+/// request returns a substrate-side verdict scored on the exact RGBA
+/// the PNG is built from — no caller-side PNG decode. Draws a known
+/// solid quad as a capture pre-mail and asserts the verdict's
+/// reductions (`not_all_black`, `coverage`, `centroid`, `bounding_box`)
+/// land the same way the decode-based `solid_quad_draws_screen_space_rect`
+/// scores them, but computed in the render thread.
+#[test]
+#[allow(clippy::cast_precision_loss)]
+fn capture_frame_checks_return_substrate_verdict() {
+    if !require_wgpu_only() {
+        return;
+    }
+    let (frame_width, frame_height) = (64u32, 48u32);
+    let mut bench = TestBench::start_with_size(frame_width, frame_height).expect("boot");
+
+    // Known screen rect: top-left (16, 12), size 24×18 — the same draw
+    // `solid_quad_draws_screen_space_rect` decodes the PNG to score.
+    let (quad_x, quad_y, quad_w, quad_h) = (16.0f32, 12.0f32, 24.0f32, 18.0f32);
+    let draw = envelope(
+        "aether.render",
+        &DrawSolidQuads {
+            space: QuadSpace::Screen,
+            quads: vec![SolidQuad {
+                x: quad_x,
+                y: quad_y,
+                width: quad_w,
+                height: quad_h,
+                color: [1.0, 1.0, 1.0, 1.0],
+            }],
+        },
+    );
+    let tolerance = 5u8;
+    let mk_check = |reduction| FrameCheck {
+        reduction,
+        tolerance,
+        // None → partition against the frame's top-left pixel (the clear
+        // color), matching the decode-based scenarios' convention.
+        background: None,
+    };
+
+    let result = bench
+        .execute(vec![(
+            "snap",
+            BenchOp::send_and_await(
+                "aether.render",
+                &CaptureFrame {
+                    mails: vec![draw],
+                    after_mails: vec![],
+                    checks: vec![
+                        mk_check(FrameReduction::NotAllBlack),
+                        mk_check(FrameReduction::Coverage),
+                        mk_check(FrameReduction::Centroid),
+                        mk_check(FrameReduction::BoundingBox),
+                    ],
+                },
+            ),
+        )])
+        .expect("send_and_await(CaptureFrame) with checks");
+    let reply: CaptureFrameResult = result.reply("snap").expect("decode CaptureFrameResult");
+    let verdict = match reply {
+        CaptureFrameResult::Ok { png, verdict } => {
+            assert!(
+                png.starts_with(&[0x89, 0x50, 0x4E, 0x47]),
+                "the PNG still rides back alongside the verdict",
+            );
+            verdict.expect("a checks request returns a verdict")
+        }
+        CaptureFrameResult::Err { error } => panic!("capture_frame replied Err: {error}"),
+    };
+    assert_eq!((verdict.width, verdict.height), (frame_width, frame_height));
+    assert_eq!(verdict.results.len(), 4);
+
+    match &verdict.results[0] {
+        FrameCheckResult::NotAllBlack { passed, detail } => {
+            assert!(passed, "the white quad lights pixels: {detail:?}");
+        }
+        other => panic!("expected NotAllBlack result, got {other:?}"),
+    }
+    match &verdict.results[1] {
+        FrameCheckResult::Coverage { fraction, .. } => {
+            // 24*18 / 64*48 ≈ 0.14 — the same band the decode test asserts.
+            assert!(
+                (0.08..0.22).contains(fraction),
+                "solid quad coverage {fraction} fell outside the expected band",
+            );
+        }
+        other => panic!("expected Coverage result, got {other:?}"),
+    }
+    match &verdict.results[2] {
+        FrameCheckResult::Centroid { centroid, .. } => {
+            let [cx, cy] = centroid.expect("a lit frame has a centroid");
+            let pad = 4.0f32;
+            assert!(
+                cx >= quad_x - pad
+                    && cx <= quad_x + quad_w + pad
+                    && cy >= quad_y - pad
+                    && cy <= quad_y + quad_h + pad,
+                "verdict centroid ({cx}, {cy}) should sit inside the screen rect",
+            );
+        }
+        other => panic!("expected Centroid result, got {other:?}"),
+    }
+    match &verdict.results[3] {
+        FrameCheckResult::BoundingBox { rect, .. } => {
+            let rect = rect.expect("a lit frame has a bounding box");
+            let pad = 4.0f32;
+            let (min_x, max_x) = (rect.min_x as f32, rect.max_x as f32);
+            assert!(
+                min_x >= quad_x - pad
+                    && min_x <= quad_x + pad
+                    && max_x <= quad_x + quad_w + pad
+                    && max_x >= quad_x + quad_w - pad,
+                "verdict bounding box {rect:?} should hug the drawn rect's x-extent",
+            );
+        }
+        other => panic!("expected BoundingBox result, got {other:?}"),
+    }
 }
 
 /// `replace_component` preserves the mailbox identity across the

--- a/crates/aether-substrate/src/capture.rs
+++ b/crates/aether-substrate/src/capture.rs
@@ -63,6 +63,11 @@ pub struct PendingCapture {
     pub reply: InboundMail,
     pub after_mails: Vec<Mail>,
     pub pre_settlements: Vec<Receiver<()>>,
+    /// The `CaptureFrame.checks` request copied through from the cap
+    /// handler. The render thread scores these reductions on the raw
+    /// RGBA after readback and lands the verdict on the reply
+    /// (iamacoffeepot/aether#1777). Empty when no verdict was requested.
+    pub checks: Vec<aether_kinds::FrameCheck>,
 }
 
 /// Single-slot queue. Cheaply cloneable (wraps an `Arc`), shared
@@ -168,6 +173,7 @@ mod tests {
             reply,
             after_mails: Vec::new(),
             pre_settlements: Vec::new(),
+            checks: Vec::new(),
         }
     }
 

--- a/crates/aether-substrate/src/render/capture.rs
+++ b/crates/aether-substrate/src/render/capture.rs
@@ -100,14 +100,45 @@ pub fn prepare_capture_copy(
 }
 
 /// Map the readback buffer (after the encoder's submit has run),
-/// strip row padding, swizzle BGRA → RGBA when the offscreen is in
-/// a BGRA format, and PNG-encode the bytes.
+/// strip row padding, swizzle BGRA → RGBA when the offscreen is in a
+/// BGRA format, and PNG-encode the bytes.
+///
+/// A thin compose of [`map_capture_rgba`] + [`encode_png`] kept
+/// byte-identical to the prior single-pass form: the same map / strip /
+/// swizzle feeds the same encoder. Callers that also want a verdict on
+/// the raw pixels (iamacoffeepot/aether#1777) reach for `map_capture_rgba`
+/// directly and encode the returned bytes with `encode_png`, so the
+/// buffer is mapped exactly once.
 ///
 /// Blocks the calling thread on `device.poll(wait_indefinitely)` —
 /// callers that can't tolerate the stall (the desktop render loop)
 /// should not call this on the hot path; capture is one frame per
 /// MCP request, not per frame.
 pub fn finish_capture(
+    device: &wgpu::Device,
+    targets: &Targets,
+    meta: &CaptureMeta,
+) -> Result<Vec<u8>, String> {
+    encode_png(
+        &map_capture_rgba(device, targets, meta)?,
+        meta.width,
+        meta.height,
+    )
+}
+
+/// Map the readback buffer (after the encoder's submit has run), strip
+/// row padding, and swizzle BGRA → RGBA when the offscreen is in a BGRA
+/// format. Returns the de-padded, top-down RGBA8 frame — the exact
+/// bytes [`encode_png`] turns into the captured PNG. Splitting the map
+/// out of [`finish_capture`] lets the render thread score a verdict on
+/// these pixels before they're consumed by the encode
+/// (iamacoffeepot/aether#1777), mapping the buffer just once.
+///
+/// Blocks the calling thread on `device.poll(wait_indefinitely)` —
+/// callers that can't tolerate the stall (the desktop render loop)
+/// should not call this on the hot path; capture is one frame per
+/// MCP request, not per frame.
+pub fn map_capture_rgba(
     device: &wgpu::Device,
     targets: &Targets,
     meta: &CaptureMeta,
@@ -150,10 +181,14 @@ pub fn finish_capture(
     drop(mapped);
     readback.buffer.unmap();
 
-    encode_png(&rgba, meta.width, meta.height)
+    Ok(rgba)
 }
 
-fn encode_png(rgba: &[u8], width: u32, height: u32) -> Result<Vec<u8>, String> {
+/// PNG-encode a de-padded RGBA8 frame (the bytes [`map_capture_rgba`]
+/// returns). Public so the bundle render thread can encode the same
+/// buffer it scored a verdict on, mapping the readback only once
+/// (iamacoffeepot/aether#1777).
+pub fn encode_png(rgba: &[u8], width: u32, height: u32) -> Result<Vec<u8>, String> {
     let mut out = Vec::new();
     {
         let mut encoder = png::Encoder::new(&mut out, width, height);

--- a/crates/aether-substrate/src/render/mod.rs
+++ b/crates/aether-substrate/src/render/mod.rs
@@ -21,7 +21,9 @@ mod pipeline;
 mod quad;
 mod targets;
 
-pub use capture::{CaptureMeta, finish_capture, prepare_capture_copy};
+pub use capture::{
+    CaptureMeta, encode_png, finish_capture, map_capture_rgba, prepare_capture_copy,
+};
 pub use pipeline::{Pipeline, RenderError, build_main_pipeline, record_main_pass};
 pub use quad::{
     OverlayDraw, QUAD_UNIFORM_BYTES, QUAD_VERTEX_BUFFER_BYTES, QUAD_VERTEX_STRIDE,


### PR DESCRIPTION
Closes #1777.

## Summary

`capture_frame` returned only the PNG, so a caller checking "did the demo render correctly" had to decode the PNG and score it client-side. This computes a verdict substrate-side, from the raw RGBA already in hand on the render thread, before encode.

`CaptureFrame` gains a `checks: Vec<FrameCheck>` list (a wire change on `aether-kinds`); `CaptureFrameResult::Ok` gains `verdict: Option<FrameVerdict>`. On the render thread, `render_and_capture` maps the readback buffer once (`map_capture_rgba`, factored out of `finish_capture` so the PNG bytes stay byte-identical), encodes the PNG, and runs the requested reductions over the same RGBA via `visual::run_checks`. The `aether-mcp` `capture_frame` tool accepts the `checks` list and returns the verdict as a JSON text block alongside the image. Headless still replies `Err` (handler unchanged). Builds additively on ADR-0105's capture path.

## Test plan

- `aether-kinds`: three `capture_verdict_roundtrips` tests over the new `FrameCheck` / `FrameVerdict` / `FrameReduction` wire shapes.
- `aether-substrate-bundle`: `capture_frame_checks_return_substrate_verdict` wgpu scenario test — a known solid quad scores as expected (ran on the Metal adapter, not skipped).
- `scripts/preflight.sh` green: fmt, clippy `--workspace --all-targets -D warnings`, `cargo nextest run --workspace`, doc, `aether-camera` wasm32 cross-build.

## Generated by

`/implement` — agent execution of scoped issue #1777.
