### PR TITLE
refactor(substrate-bundle): migrate capture replies to the retained inbound guard

### DIFF
--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -510,47 +510,47 @@ mod native {
                 }
             }
 
-            // ADR-0086 §12 / iamacoffeepot/aether#1273: capture is a
-            // deferred reply — the render thread sends the reply after
-            // the cap handler has returned. Acquire the settlement hold
-            // *before* the queue handoff so `HoldOpen` is visible to
-            // the settlement counter ahead of this handler's
-            // `Finished`; the hold rides on `PendingCapture` and drops
-            // with `req` after `outbound.send_reply` on the render
-            // thread (`desktop/driver.rs` line ~568, `test_bench/
-            // bench.rs` line ~1019). Mirrors the ADR-0093
-            // hold-until-resolve dispatch's eager-acquire. The
-            // early-return branches above reply
-            // synchronously inside this handler's own dispatch window,
-            // so they're naturally covered by the handler's in-flight
-            // `Finished` bracket and don't need the hold.
-            let hold = ctx.mailer().acquire_settlement_hold(ctx.in_flight_root());
+            // ADR-0106 / iamacoffeepot/aether#1758: capture is a deferred
+            // reply — the render thread sends the reply a frame later, off
+            // this handler's dispatch window. Retain the dispatched
+            // `CaptureFrame` envelope as an `InboundMail` guard via
+            // `take_inbound`: the dispatcher's settlement tail then sees
+            // `None` and does not discharge, so the guard's un-fired
+            // `record_finished` keeps the inbound's chain open until the
+            // render thread replies through `reply.reply(&result)` and
+            // drops it (recording the reply's `Sent` before the inbound's
+            // `Finished`, ADR-0080 §6). This retires the hand-rolled
+            // `SettlementHold` + reply-id mint (#1273 / #1719). The
+            // early-return branches above reply synchronously inside this
+            // handler's own dispatch window, so they leave the inbound for
+            // the dispatcher's tail to settle and don't take the guard.
+            let inbound = ctx.take_inbound();
             let pending = PendingCapture {
-                reply_to: sender,
+                reply: inbound,
                 after_mails: after,
                 pre_settlements,
-                hold,
             };
-            if !backend.queue.request(pending) {
-                backend.outbound.send_reply(
-                    sender,
-                    &CaptureFrameResult::Err {
-                        error: "capture already pending; try again once the in-flight \
-                            request completes"
-                            .to_owned(),
-                    },
-                );
+            // A rejected request (`Err`) is handed back so its retained
+            // guard can carry the synchronous `Err` reply before it drops
+            // — settling after the reply, ADR-0080 §6.
+            if let Err(rejected) = backend.queue.request(pending) {
+                rejected.reply.reply(&CaptureFrameResult::Err {
+                    error: "capture already pending; try again once the in-flight \
+                        request completes"
+                        .to_owned(),
+                });
                 return;
             }
 
-            if let Err(reason) = (backend.wake)() {
-                let _ = backend.queue.take();
-                backend.outbound.send_reply(
-                    sender,
-                    &CaptureFrameResult::Err {
-                        error: reason.to_owned(),
-                    },
-                );
+            if let Err(reason) = (backend.wake)()
+                && let Some(rejected) = backend.queue.take()
+            {
+                // The wake never reached the render thread, so the request
+                // is still parked: take it back and reply `Err` through its
+                // retained guard, which then drops and settles the chain.
+                rejected.reply.reply(&CaptureFrameResult::Err {
+                    error: reason.to_owned(),
+                });
             }
         }
 

--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -258,7 +258,11 @@ fn run_frame(
             for mail in req.after_mails {
                 queue.push(mail);
             }
-            outbound.send_reply(req.reply_to, &result);
+            // Reply through the retained inbound guard (ADR-0106 / #1758),
+            // then let `req` drop at end of this arm — *after* `reply`
+            // returns — so the inbound's `Finished` records after the
+            // reply's `Sent` (ADR-0080 §6).
+            req.reply.reply(&result);
         }
         None => {
             gpu.render();

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -112,10 +112,10 @@ pub struct App {
     render_handles: RenderHandles,
     /// Shared single-slot queue with the control plane. On each
     /// redraw we `take()` any pending capture and, if present, use
-    /// `render_and_capture`, then reply to the sender via
-    /// `queue.send_reply_unchained` (the `Mailer`, which routes every
-    /// `SourceAddr` — see `outbound`; the capture reply is wire-terminal,
-    /// so lineage is moot, #1710).
+    /// `render_and_capture`, then reply to the sender through the
+    /// request's retained inbound guard (`req.reply.reply`, ADR-0106 /
+    /// #1758) — the reply joins the inbound's ADR-0080 causal chain and
+    /// settles it when the guard drops post-reply.
     capture_queue: CaptureQueue,
     /// Hub outbound — held for log egress to the hub and
     /// `lifecycle::fatal_abort`. NOT used for chassis replies:
@@ -125,9 +125,10 @@ pub struct App {
     /// hub/MCP call lands via the proxy → local RPC server) carries a
     /// `Component(rpc_server)` reply target. Replies go through the
     /// `Mailer` instead (`mail.reply` for the chain-joined window arms,
-    /// `self.queue.send_reply_unchained` for the wire-terminal capture
-    /// replies), which pushes the reply as local mail so the RPC server's
-    /// `on_any` lifts it into a `ReplyEvent` (iamacoffeepot/aether#1316).
+    /// `req.reply.reply` through the retained inbound guard for the
+    /// deferred capture replies, #1758), which pushes the reply as local
+    /// mail so the RPC server's `on_any` lifts it into a `ReplyEvent`
+    /// (iamacoffeepot/aether#1316).
     outbound: Arc<HubOutbound>,
     window: Option<Arc<Window>>,
     gpu: Option<Gpu>,
@@ -465,10 +466,13 @@ enum OccludedCaptureDisposition {
     Empty,
     /// Window is occluded and a capture is parked — fail it fast. Carries
     /// the taken [`PendingCapture`] (so the caller drains `after_mails`,
-    /// replies, then drops it to release the settlement hold) and the
-    /// `Err` reply to send.
+    /// replies through its retained inbound guard, then drops it to settle
+    /// the inbound chain) and the `Err` reply to send.
     FailFast {
-        request: PendingCapture,
+        // Boxed: `PendingCapture` carries a retained `InboundMail` guard, so
+        // it dwarfs the zero-size `Redraw` / `Empty` variants
+        // (clippy::large_enum_variant).
+        request: Box<PendingCapture>,
         result: CaptureFrameResult,
     },
 }
@@ -486,8 +490,9 @@ const OCCLUDED_CAPTURE_ERROR: &str = "capture_frame: window is occluded (hidden/
 /// so a visible-window wake never steals the entry that `RedrawRequested`
 /// is about to service — the `Redraw` arm carries no `PendingCapture`. The
 /// occluded arms move the taken request through so the caller can drain
-/// `after_mails`, reply via the `Mailer`, and drop the request *after* the
-/// reply (releasing the ADR-0086 §12 settlement hold, iamacoffeepot/aether#1273).
+/// `after_mails`, reply through the retained inbound guard, and drop the
+/// request *after* the reply (settling the inbound chain post-reply,
+/// ADR-0080 §6 / iamacoffeepot/aether#1273).
 fn occluded_capture_disposition(
     occluded: bool,
     pending: Option<PendingCapture>,
@@ -497,7 +502,7 @@ fn occluded_capture_disposition(
     }
     pending.map_or(OccludedCaptureDisposition::Empty, |request| {
         OccludedCaptureDisposition::FailFast {
-            request,
+            request: Box::new(request),
             result: CaptureFrameResult::Err {
                 error: OCCLUDED_CAPTURE_ERROR.to_owned(),
             },
@@ -873,17 +878,17 @@ impl App {
     ///
     /// macOS does not deliver `RedrawRequested` to a hidden window, so a
     /// capture parked while occluded would otherwise never be serviced and
-    /// the wire `Call` would hang on its settlement hold until timeout.
+    /// the wire `Call` would hang on its open inbound chain until timeout.
     /// Here we take the parked entry, drain its `after_mails` (parity with
-    /// the `RedrawRequested` service arm), reply `Err` via the `Mailer`
-    /// (`self.queue.send_reply_unchained`, never `self.outbound` —
-    /// `HubOutbound` drops `SourceAddr::Component`,
-    /// iamacoffeepot/aether#1316), then let the request drop *after* the
-    /// reply so the ADR-0086 §12 settlement hold's `Release` fires
-    /// post-reply (iamacoffeepot/aether#1273). The capture reply is
-    /// wire-terminal — its settlement is the ADR-0086 hold above, not an
-    /// ADR-0080 inbound chain — so the lineage-less unchained form is the
-    /// right one (#1710).
+    /// the `RedrawRequested` service arm), reply `Err` through the parked
+    /// request's retained inbound guard (`request.reply.reply`, ADR-0106 /
+    /// #1758), then let the request drop *after* the reply so the inbound's
+    /// `Finished` records after the reply's `Sent` (ADR-0080 §6 /
+    /// iamacoffeepot/aether#1273). The reply joins the inbound's causal
+    /// chain through the same guard primitive every claimed-inbox consumer
+    /// uses, so it lifts into a `ReplyEvent` even for the `Component`
+    /// reply target an engine-local RPC Call carries
+    /// (iamacoffeepot/aether#1316).
     ///
     /// The slot is taken only when occluded, so a visible-window wake never
     /// steals the entry `RedrawRequested` is about to service.
@@ -897,16 +902,20 @@ impl App {
             OccludedCaptureDisposition::Redraw => false,
             OccludedCaptureDisposition::Empty => true,
             OccludedCaptureDisposition::FailFast { request, result } => {
+                // Move the request out of its box onto the stack so the
+                // partial-move drain + retained-guard reply read cleanly.
+                let request = *request;
                 for mail in request.after_mails {
                     self.queue.push(mail);
                 }
-                // `reply_to` is `Copy`, so this read leaves `request` whole;
-                // it (and its `PendingCapture._hold`) drops at end of this
-                // scope — *after* `send_reply_unchained` returns — firing
-                // `Release` on the trace root so `Settled{root}` is exact
-                // post-reply. Don't restructure to move the reply below
-                // other work (iamacoffeepot/aether#1273 drop-order discipline).
-                self.queue.send_reply_unchained(request.reply_to, &result);
+                // Reply through the retained inbound guard, then let
+                // `request` (which still owns `request.reply` after the
+                // partial move above) drop at end of this scope — *after*
+                // `reply` returns — so the inbound's `Finished` records
+                // after the reply's `Sent` (ADR-0080 §6 / #1758). Don't
+                // restructure to move the reply below other work
+                // (iamacoffeepot/aether#1273 drop-order discipline).
+                request.reply.reply(&result);
                 true
             }
         }
@@ -1146,31 +1155,27 @@ impl ApplicationHandler<UserEvent> for App {
                                 //noinspection DuplicatedCode
                                 self.queue.push(mail);
                             }
-                            // Wire-terminal capture reply: its settlement is
-                            // the ADR-0086 §12 hold `req` owns, not an
-                            // ADR-0080 inbound chain, so the lineage-less
-                            // unchained form is correct (#1710).
-                            self.queue.send_reply_unchained(req.reply_to, &result);
-                            // iamacoffeepot/aether#1273: `req` still owns
-                            // `PendingCapture._hold` after the partial moves
-                            // above; the field drops at end of this scope —
-                            // *after* `send_reply_unchained` returns — firing
-                            // `Release` on the trace root so `Settled{root}`
-                            // is exact at post-reply. Don't restructure to
-                            // move the reply below other work in this arm.
+                            // Reply through the retained inbound guard
+                            // (ADR-0106 / #1758): the reply joins the
+                            // inbound's ADR-0080 causal chain, and `req`
+                            // (which still owns `req.reply` after the partial
+                            // moves above) drops at end of this scope —
+                            // *after* `reply` returns — so the inbound's
+                            // `Finished` records after the reply's `Sent`
+                            // (§6). Don't restructure to move the reply below
+                            // other work in this arm (iamacoffeepot/aether#1273).
+                            req.reply.reply(&result);
                         }
                         None => {
                             gpu.render();
                         }
                     }
                 } else if let Some(req) = pending_capture {
-                    // Wire-terminal capture reply (#1710): lineage is moot.
-                    self.queue.send_reply_unchained(
-                        req.reply_to,
-                        &CaptureFrameResult::Err {
-                            error: "capture requested before GPU initialized".to_owned(),
-                        },
-                    );
+                    // No GPU yet: reply `Err` through the retained guard,
+                    // which then drops and settles the inbound chain (#1758).
+                    req.reply.reply(&CaptureFrameResult::Err {
+                        error: "capture requested before GPU initialized".to_owned(),
+                    });
                 }
                 self.frame += 1;
                 // iamacoffeepot/aether#1489: the lifecycle reached its
@@ -1938,28 +1943,55 @@ mod tests {
 
     /// iamacoffeepot/aether#1317: the occluded-capture branch selection.
     /// This is the CI-runnable core of the fail-fast — the winit wiring
-    /// (`fail_capture_if_occluded` → `take` → `send_reply_unchained` → drop) stays
+    /// (`fail_capture_if_occluded` → `take` → `reply.reply` → drop) stays
     /// MCP-manual because `ControlFlow::Wait` + `RedrawRequested`
     /// suppression has no CI display surface. Here we pin only the pure
     /// branch logic: occluded-with-parked-capture selects an `Err` reply,
     /// occluded-with-empty-slot and visible-window are no-ops/redraw.
     #[test]
     fn occluded_capture_disposition_selects_failfast_only_when_occluded_and_parked() {
-        use aether_data::MailId;
-        use aether_substrate::SourceAddr;
+        use std::sync::mpsc;
+
+        use aether_data::{KindId, MailId};
+        use aether_kinds::trace::Nanos;
         use aether_substrate::capture::PendingCapture;
+        use aether_substrate::handle_store::HandleStore;
+        use aether_substrate::mail::MailRef;
         use aether_substrate::mail::Source;
-        use aether_substrate::runtime::trace::TraceHandle;
+        use aether_substrate::mail::registry::{OwnedDispatch, Registry};
 
         fn parked() -> PendingCapture {
-            // `MailId::NONE` keeps the hold's acquire/release a counter
-            // no-op; the test exercises branch selection, not settlement.
-            let hold = TraceHandle::new().acquire_settlement_hold(MailId::NONE);
+            // A NONE-lineage disarmed inbound: its retained guard carries no
+            // settlement obligation, so dropping it is a clean no-op and
+            // this branch-selection test needs no settlement registry. Sent
+            // straight onto the `SettlingInbox`'s channel, then drained to
+            // the guard.
+            let registry = Arc::new(Registry::new());
+            let store = Arc::new(HandleStore::new(1024 * 1024));
+            let mailer = Arc::new(Mailer::new(registry, store));
+            let mailbox = MailboxId(0x0CAB);
+            let (tx, rx) = mpsc::channel::<Envelope>();
+            tx.send(OwnedDispatch::disarmed(
+                KindId(0),
+                "test.capture.parked".to_owned(),
+                None,
+                Source::NONE,
+                MailRef::from(Vec::new()),
+                1,
+                MailId::NONE,
+                MailId::NONE,
+                None,
+                Nanos(0),
+                0,
+                mailbox,
+            ))
+            .expect("queue the parked inbound");
+            let inbox = SettlingInbox::new(mailbox, rx, mailer);
+            let reply = inbox.try_next().expect("one queued");
             PendingCapture {
-                reply_to: Source::to(SourceAddr::Session(aether_data::SessionToken::NIL)),
+                reply,
                 after_mails: Vec::new(),
                 pre_settlements: Vec::new(),
-                hold,
             }
         }
 
@@ -2002,5 +2034,126 @@ mod tests {
             ),
             "visible window must fall through to redraw",
         );
+    }
+
+    /// iamacoffeepot/aether#1758: the deferred capture reply joins the
+    /// inbound's ADR-0080 causal chain through the `InboundMail` guard the
+    /// render cap parked on `PendingCapture` (via `take_inbound`). Replying
+    /// through `req.reply.reply` records the reply's `Sent`; dropping `req`
+    /// records the inbound's `Finished` *after* it (ADR-0080 §6), so the
+    /// caller's root stays open until the reply itself finishes — settling
+    /// exactly once. This pins the capture-migration's reply-before-drop
+    /// order without standing up wgpu/winit, mirroring the claimed-inbox
+    /// `reply_sent_recorded_before_inbound_finished` shape through the
+    /// capture queue's parked request.
+    #[test]
+    fn capture_reply_joins_held_chain() {
+        use std::sync::mpsc;
+
+        use aether_data::{Kind, MailId};
+        use aether_kinds::{CaptureFrame, CaptureFrameResult, descriptors};
+
+        use aether_substrate::capture::PendingCapture;
+        use aether_substrate::chassis::settlement::SettlementRegistry;
+        use aether_substrate::handle_store::HandleStore;
+        use aether_substrate::mail::registry::{InboxHandler, Registry};
+        use aether_substrate::mail::{Mail, Source, SourceAddr};
+
+        let registry = Arc::new(Registry::new());
+        for d in descriptors::all() {
+            let _ = registry.register_kind_with_descriptor(d);
+        }
+        let store = Arc::new(HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
+
+        // One settlement registry wired into both seams (the chassis builder
+        // does both installs at boot) so the inbound + reply settle cleanly.
+        let settlement = Arc::new(SettlementRegistry::new());
+        mailer.install_settlement_registry(Arc::clone(&settlement));
+        mailer
+            .trace_handle()
+            .install_settlement_registry(Arc::clone(&settlement));
+
+        // A `Component` reply target captures the deferred reply so the test
+        // reads its delivered `root` and finishes it — the desktop MCP
+        // capture reply target is a `Component(rpc_server)`.
+        let (reply_tx, reply_rx) = mpsc::channel::<Envelope>();
+        let target = registry.register_inbox(
+            "test.capture.reply_target",
+            Arc::new(move |d: Envelope| {
+                let _ = reply_tx.send(d);
+            }) as Arc<dyn InboxHandler>,
+        );
+
+        // Push a real armed `CaptureFrame` Call whose reply target is the
+        // captured inbox, then drain it to the `PendingCapture`'s retained
+        // guard (the render cap's `take_inbound`, mirrored out-of-crate).
+        let render_mailbox = MailboxId(0x0CA6);
+        let (tx, rx) = mpsc::channel::<Envelope>();
+        let handler: Arc<dyn InboxHandler> = Arc::new(move |d: Envelope| {
+            let _ = tx.send(d);
+        });
+        registry
+            .try_register_inbox_with_id(render_mailbox, "test.capture.render", handler)
+            .expect("register the render inbox");
+        let inbox = SettlingInbox::new(render_mailbox, rx, Arc::clone(&mailer));
+
+        let root = MailId::new(render_mailbox, 1);
+        let mail_id = MailId::new(render_mailbox, 2);
+        mailer.record_sent_inflight(root);
+        let settle = settlement.subscribe_settlement(root);
+        let caller = Source::with_correlation(SourceAddr::Component(target), 0x42);
+        mailer.push(
+            Mail::new(render_mailbox, <CaptureFrame as Kind>::ID, Vec::new(), 1)
+                .with_reply_to(caller)
+                .with_lineage(mail_id, root, None),
+        );
+        let reply = inbox
+            .try_next()
+            .expect("the armed CaptureFrame Call is queued");
+        let req = PendingCapture {
+            reply,
+            after_mails: Vec::new(),
+            pre_settlements: Vec::new(),
+        };
+
+        // The driver's reply path: reply through the retained guard, then
+        // let `req` (the parked request) drop.
+        assert!(
+            req.reply.reply(&CaptureFrameResult::Err {
+                error: "deferred".to_owned(),
+            }),
+            "the deferred capture reply routed to the Component target",
+        );
+        assert!(
+            settle.try_recv().is_err(),
+            "the reply's Sent holds the chain open",
+        );
+        drop(req);
+        assert!(
+            settle.try_recv().is_err(),
+            "inbound Finished alone does not settle — the deferred reply is still in flight",
+        );
+
+        // Finish the reply the way the RPC server's dispatcher would; only
+        // now does the root settle — exactly once.
+        let reply_env = reply_rx
+            .recv()
+            .expect("deferred reply routed to the target");
+        assert_eq!(
+            reply_env.kind_name,
+            <CaptureFrameResult as Kind>::NAME,
+            "the deferred reply is a CaptureFrameResult",
+        );
+        assert_eq!(
+            reply_env.root, root,
+            "the deferred capture reply joins the inbound's causal chain (#1758)",
+        );
+        let reply_id = reply_env.mail_id;
+        reply_env.discharge();
+        mailer.record_finished(reply_id, root);
+        settle
+            .recv()
+            .expect("root settles once the deferred capture reply finishes");
     }
 }

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -1074,14 +1074,18 @@ impl TestBench {
                 for mail in req.after_mails {
                     self.queue.push(mail);
                 }
-                self.outbound.send_reply(req.reply_to, &result);
-                // iamacoffeepot/aether#1273: `req` still owns
-                // `PendingCapture._hold` after the partial moves above; the
-                // field drops at end of this match arm — *after*
-                // `send_reply` returns — firing `Release` on the trace
-                // root so `Settled{root}` is exact at post-reply. Don't
-                // restructure to move the reply below other work in this
-                // arm.
+                // Reply through the retained inbound guard (ADR-0106 /
+                // #1758). The bench's capture reply target is a `Session`,
+                // so the guard's `reply` routes through the same `outbound`
+                // egress `send_reply` did (the `RecordingBackend` loopback
+                // picks it up by correlation).
+                req.reply.reply(&result);
+                // iamacoffeepot/aether#1273 / #1758: `req` still owns
+                // `req.reply` after the partial moves above; the retained
+                // inbound guard drops at end of this match arm — *after*
+                // `reply` returns — so the inbound's `Finished` records
+                // after the reply's `Sent` (ADR-0080 §6). Don't restructure
+                // to move the reply below other work in this arm.
             }
             None => {
                 self.gpu.render();

--- a/crates/aether-substrate/src/capture.rs
+++ b/crates/aether-substrate/src/capture.rs
@@ -29,11 +29,11 @@ use std::sync::{Arc, Mutex};
 
 use crossbeam_channel::Receiver;
 
-use crate::mail::{Mail, Source};
-use crate::runtime::trace::SettlementHold;
+use crate::chassis::inbox::InboundMail;
+use crate::mail::Mail;
 
-/// One pending capture request. Carries the reply handle so the
-/// render thread can reply once it has bytes, plus a resolved list
+/// One pending capture request. Carries the retained inbound guard so
+/// the render thread can reply once it has bytes, plus a resolved list
 /// of `after_mails` the control plane already validated; the
 /// render thread pushes them onto the queue after readback, before
 /// replying.
@@ -48,26 +48,21 @@ use crate::runtime::trace::SettlementHold;
 /// a settlement registry (in which case the driver renders
 /// immediately, preserving pre-fix behaviour on test fixtures).
 pub struct PendingCapture {
-    pub reply_to: Source,
+    /// The retained inbound guard (ADR-0106 / iamacoffeepot/aether#1758).
+    /// `RenderCapability::on_capture_frame` takes the dispatched
+    /// `CaptureFrame` envelope out of its ctx via
+    /// [`NativeCtx::take_inbound`](crate::actor::native::ctx::NativeCtx::take_inbound)
+    /// and parks it here, so the render thread can reply a frame later
+    /// through `reply.reply(&result)`. The guard's un-fired
+    /// `record_finished` *is* the settlement hold: it keeps the inbound's
+    /// chain open until the render thread replies and drops it, recording
+    /// the reply's `Sent` before the inbound's `Finished` (ADR-0080 §6).
+    /// This retires the hand-rolled `SettlementHold` + reply-id mint the
+    /// deferred capture reply used to carry (iamacoffeepot/aether#1273 /
+    /// #1719).
+    pub reply: InboundMail,
     pub after_mails: Vec<Mail>,
     pub pre_settlements: Vec<Receiver<()>>,
-    /// ADR-0086 §12 settlement hold: held from `on_capture_frame` accept
-    /// until the render thread's `send_reply` returns; drops with
-    /// `PendingCapture` at end of the reply scope, firing `Release` so
-    /// `Settled{root}` becomes exact post-reply. Without this guard the
-    /// cap handler's `Finished` lands before the readback reply, the
-    /// trace observer settles the chain, and the wire `Call` ends with
-    /// zero reply events (iamacoffeepot/aether#1273). The pattern
-    /// mirrors the ADR-0093 hold-until-resolve dispatch (acquired before
-    /// the queue handoff so `HoldOpen` is visible to the settlement
-    /// counter ahead of `Finished`).
-    ///
-    /// The field is never read — its sole job is to keep the
-    /// [`SettlementHold`]'s `Drop` impl tied to the lifetime of this
-    /// `PendingCapture`. `SettlementHold` carries `#[must_use]`, so
-    /// stashing it on a named field (rather than `_`) is the only way
-    /// to keep it alive across the queue handoff.
-    pub hold: SettlementHold,
 }
 
 /// Single-slot queue. Cheaply cloneable (wraps an `Arc`), shared
@@ -83,25 +78,33 @@ impl CaptureQueue {
         Self::default()
     }
 
-    /// Try to install `pending` as the pending capture. Returns `true`
-    /// if the slot was empty and the request is now pending; `false`
-    /// if a capture is already in flight. The caller wakes the event
-    /// loop on success — `CaptureQueue` itself stays chassis-agnostic.
+    /// Try to install `pending` as the pending capture. Returns `Ok(())`
+    /// if the slot was empty and the request is now pending; `Err(pending)`
+    /// hands the request back (boxed — it owns a large retained guard) when
+    /// a capture is already in flight, so the caller can reply `Err`
+    /// through the rejected request's retained `reply` guard before it
+    /// drops (keeping the reply-before-`Finished` order, ADR-0080 §6). The
+    /// caller wakes the event loop on success — `CaptureQueue` itself stays
+    /// chassis-agnostic.
     ///
     /// # Panics
     /// Panics if the slot `Mutex` is poisoned — fail-fast per ADR-0063:
     /// a poisoned mutex means a prior holder panicked under the guard.
-    #[must_use]
-    pub fn request(&self, pending: PendingCapture) -> bool {
+    #[must_use = "a rejected request still owns its inbound guard; reply through it before it drops"]
+    pub fn request(&self, pending: PendingCapture) -> Result<(), Box<PendingCapture>> {
         let mut slot = self
             .slot
             .lock()
             .expect("capture slot mutex poisoned; fail-fast per ADR-0063");
         if slot.is_some() {
-            return false;
+            return Err(Box::new(pending));
         }
         *slot = Some(pending);
-        true
+        // Release the slot lock before returning — the retained guard in
+        // `pending` has a significant `Drop`, so tighten the critical
+        // section to just the check-and-set (clippy::significant_drop_tightening).
+        drop(slot);
+        Ok(())
     }
 
     /// Take the pending capture if one is set. Called by the render
@@ -123,44 +126,69 @@ impl CaptureQueue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::SourceAddr;
-    use crate::runtime::trace::TraceHandle;
-    use aether_data::{MailId, SessionToken, Uuid};
+    use crate::actor::native::envelope::Envelope;
+    use crate::chassis::inbox::SettlingInbox;
+    use crate::handle_store::HandleStore;
+    use crate::mail::mailer::Mailer;
+    use crate::mail::registry::{OwnedDispatch, Registry};
+    use crate::mail::{MailRef, Source};
+    use aether_data::{KindId, MailId, MailboxId};
+    use aether_kinds::trace::Nanos;
+    use std::sync::mpsc;
 
-    fn reply_to(u: u128) -> Source {
-        Source::to(SourceAddr::Session(SessionToken(Uuid::from_u128(u))))
-    }
-
-    fn pending(u: u128) -> PendingCapture {
-        // Sentinel `MailId::NONE` keeps the acquire/release pair a no-op
-        // in the settlement counter — the test exercises queue mechanics,
-        // not the trace pipeline. `TraceHandle::new()` builds a stand-
-        // alone handle with no installed registry.
-        let hold = TraceHandle::new().acquire_settlement_hold(MailId::NONE);
+    /// A `PendingCapture` whose retained `reply` guard wraps a NONE-lineage
+    /// disarmed inbound — dropping it records nothing and never panics, so
+    /// these slot-mechanics tests need no settlement registry. The inbound
+    /// is sent straight onto the `SettlingInbox`'s channel (no `Mailer`
+    /// route), then drained to the guard.
+    fn pending() -> PendingCapture {
+        let registry = Arc::new(Registry::new());
+        let store = Arc::new(HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(registry, store));
+        let id = MailboxId(0x0CA8);
+        let (tx, rx) = mpsc::channel::<Envelope>();
+        tx.send(OwnedDispatch::disarmed(
+            KindId(0),
+            "test.capture.pending".to_owned(),
+            None,
+            Source::NONE,
+            MailRef::from(Vec::new()),
+            1,
+            MailId::NONE,
+            MailId::NONE,
+            None,
+            Nanos(0),
+            0,
+            id,
+        ))
+        .expect("queue the inbound");
+        let inbox = SettlingInbox::new(id, rx, mailer);
+        let reply = inbox.try_next().expect("one queued");
         PendingCapture {
-            reply_to: reply_to(u),
+            reply,
             after_mails: Vec::new(),
             pre_settlements: Vec::new(),
-            hold,
         }
     }
 
     #[test]
     fn second_request_rejected_while_pending() {
         let q = CaptureQueue::new();
-        assert!(q.request(pending(1)));
-        assert!(!q.request(pending(2)));
+        assert!(q.request(pending()).is_ok());
+        assert!(
+            q.request(pending()).is_err(),
+            "a second request is rejected (and handed back) while one is pending",
+        );
     }
 
     #[test]
     fn take_clears_slot_for_next_request() {
         let q = CaptureQueue::new();
-        assert!(q.request(pending(1)));
-        let got = q.take().expect("pending");
-        assert_eq!(got.reply_to, reply_to(1));
+        assert!(q.request(pending()).is_ok());
+        assert!(q.take().is_some(), "the pending capture is taken");
         // Slot is empty again.
         assert!(q.take().is_none());
         // Next request lands.
-        assert!(q.request(pending(2)));
+        assert!(q.request(pending()).is_ok());
     }
 }


### PR DESCRIPTION
Closes #1758.

## Summary

Migrates the desktop `capture_frame` reply onto the retained `InboundMail` guard landed by #1757, the last consumer in the #1754 settling-inbox arc. `PendingCapture` collapses its separate `{reply_to: Source, hold: SettlementHold}` into one retained `reply: InboundMail`; `CaptureQueue::request` hands a rejected request back so its guard carries the synchronous `Err`; the three desktop deferred-reply sites (plus the test-bench bin's reply site) become `req.reply.reply(&result)`. The capture reply now joins the inbound's settlement chain rather than sending lineage-less, which tightens the #1273 settlement ordering — the intended outcome of this migration.

## Test plan

- `capture_reply_joins_held_chain` asserts the deferred reply records on the held inbound's chain; the queue-full / wake-failure paths reply through the rejected request's guard.
- The four capture / disposition slot-mechanics tests confirmed passing by name.
- `scripts/preflight.sh` green: fmt, clippy `--workspace --all-targets -D warnings`, `cargo nextest run --workspace`, doc.

## Generated by

`/implement` — agent execution of scoped issue #1758.
