### PR TITLE
feat(substrate-bundle): runtime boot manifest so spawn launches with components preloaded

### DIFF
--- a/crates/aether-capabilities/src/engine/server.rs
+++ b/crates/aether-capabilities/src/engine/server.rs
@@ -236,7 +236,7 @@ mod server_native {
         /// Fork+exec a substrate binary and connect a proxy to it.
         ///
         /// # Agent
-        /// Send `SpawnEngine { binary_path, args }`. The cap assigns a
+        /// Send `SpawnEngine { binary_path, args, boot_manifest }`. The cap assigns a
         /// free localhost port for the substrate's RPC server, injects
         /// it as `AETHER_RPC_PORT`, forks the binary, then boots an
         /// `aether.engine.proxy:<id>` actor that dials it. Reply:
@@ -265,13 +265,20 @@ mod server_native {
             self.next_engine_seq += 1;
             let engine_store_dir = engine_store_root().join(engine_id.0.simple().to_string());
 
-            let child = match Command::new(&mail.binary_path)
+            let mut command = Command::new(&mail.binary_path);
+            command
                 .args(&mail.args)
                 .env("AETHER_RPC_PORT", rpc_port.to_string())
                 .env("AETHER_HANDLE_STORE_DIR", &engine_store_dir)
-                .stdin(Stdio::null())
-                .spawn()
-            {
+                .stdin(Stdio::null());
+            // A spawn carrying a component list rides in as a boot-manifest
+            // path; inject it the same way as the RPC port so the spawned
+            // chassis reads the listed wasm itself and comes up with those
+            // components already loading (issue 1776).
+            if let Some(boot_manifest) = &mail.boot_manifest {
+                command.env("AETHER_BOOT_MANIFEST", boot_manifest);
+            }
+            let child = match command.spawn() {
                 Ok(child) => child,
                 Err(e) => {
                     ctx.reply(&SpawnEngineResult::Err {
@@ -725,6 +732,7 @@ mod tests {
                 &SpawnEngine {
                     binary_path: "/nonexistent/aether-substrate-does-not-exist".to_owned(),
                     args: vec![],
+                    boot_manifest: None,
                 },
                 || {
                     cells

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1054,11 +1054,20 @@ mod engine {
     /// `binary_path` with `args` forwarded verbatim, then boots an
     /// `aether.engine.proxy:<id>` actor that dials it. Reply:
     /// [`SpawnEngineResult`].
+    ///
+    /// `boot_manifest` (when `Some`) is the absolute path to a
+    /// `BundleManifest` JSON of components to auto-load at boot; the cap
+    /// injects it as `AETHER_BOOT_MANIFEST` alongside `AETHER_RPC_PORT`,
+    /// and the spawned chassis reads the listed wasm itself (spawn is
+    /// single-host) so the engine comes up with those components already
+    /// loading — no follow-up `load_component` round-trips. `None` boots
+    /// a bare engine, the pre-existing behaviour.
     #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.engine.spawn")]
     pub struct SpawnEngine {
         pub binary_path: String,
         pub args: Vec<String>,
+        pub boot_manifest: Option<String>,
     }
 
     /// Reply to [`SpawnEngine`]. Issue 763 P4.
@@ -3543,6 +3552,39 @@ mod tests {
         let back: MouseMove =
             decode(&bytes).expect("test setup: MouseMove cast round-trip decodes");
         assert_eq!(back, m);
+    }
+
+    #[test]
+    fn spawn_engine_roundtrip_carries_boot_manifest() {
+        // `boot_manifest` rides the wire (postcard path — non-`repr(C)`
+        // struct with `Vec<String>` + `Option<String>`); both `Some`
+        // (a spawn carrying a component list) and `None` (a bare spawn)
+        // must survive the engines-cap encode/decode.
+        use alloc::string::ToString;
+        use alloc::vec;
+
+        let spawn = SpawnEngine {
+            binary_path: "/abs/aether-substrate-headless".to_string(),
+            args: vec!["--tick-hz".to_string(), "30".to_string()],
+            boot_manifest: Some("/tmp/aether-boot-manifest.json".to_string()),
+        };
+        let back = SpawnEngine::decode_from_bytes(&spawn.encode_into_bytes())
+            .expect("test setup: SpawnEngine decodes");
+        assert_eq!(back.binary_path, spawn.binary_path);
+        assert_eq!(back.args, spawn.args);
+        assert_eq!(
+            back.boot_manifest.as_deref(),
+            Some("/tmp/aether-boot-manifest.json"),
+        );
+
+        let bare = SpawnEngine {
+            binary_path: "/abs/aether-substrate".to_string(),
+            args: vec![],
+            boot_manifest: None,
+        };
+        let back = SpawnEngine::decode_from_bytes(&bare.encode_into_bytes())
+            .expect("test setup: bare SpawnEngine decodes");
+        assert_eq!(back.boot_manifest, None);
     }
 
     #[test]

--- a/crates/aether-mcp/src/args.rs
+++ b/crates/aether-mcp/src/args.rs
@@ -17,6 +17,41 @@ pub struct SpawnSubstrateArgs {
     /// verbatim. `AETHER_RPC_PORT` is injected by the hub regardless.
     #[serde(default)]
     pub args: Vec<String>,
+    /// Components to auto-load at boot, in order. When non-empty,
+    /// `aether-mcp` stages a temporary boot-manifest JSON of these specs
+    /// and hands its path to the hub, which injects it as
+    /// `AETHER_BOOT_MANIFEST` at the fork — so the spawned engine comes
+    /// up with these components already loading, in one call, with no
+    /// follow-up `load_component`. Spawn is single-host, so the substrate
+    /// reads each `binary_path` (and `config_path`) itself — pass paths
+    /// that exist on the host running the fleet. Empty (default) boots a
+    /// bare engine.
+    #[serde(default)]
+    pub components: Vec<ComponentSpec>,
+}
+
+/// One component in a `spawn_substrate` boot list. Mirrors the
+/// `load_component` arguments (path-addressed, ADR-0096 export
+/// selector), but the substrate reads the files itself at boot rather
+/// than `aether-mcp` forwarding the bytes.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ComponentSpec {
+    /// Absolute path to the component's `.wasm` on the fleet host.
+    pub binary_path: String,
+    /// Optional human-readable load name. The substrate defaults one
+    /// from the wasm if omitted.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Optional absolute path to a file holding the component's
+    /// init-config bytes (ADR-0090), already encoded to the component's
+    /// `Config` kind wire shape. Omit for a no-config component.
+    #[serde(default)]
+    pub config_path: Option<String>,
+    /// ADR-0096: which exported actor type to instantiate from a
+    /// multi-actor module, named by its `Actor::NAMESPACE`. Omit to load
+    /// the module's entry type.
+    #[serde(default)]
+    pub export: Option<String>,
 }
 
 /// `terminate_substrate` arguments.

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -13,6 +13,7 @@
 //! cache populated by `load_component` / `replace_component`.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 // `tokio::sync::Mutex` (the async one used by the per-engine refresh-
@@ -52,11 +53,12 @@ use crate::args::ActorLogsArgs;
 use crate::args::ActorLogsResponse;
 use crate::args::{ActorCostArgs, ActorCostResponse, ActorCostRow};
 use crate::args::{
-    CaptureCheckSpec, CaptureFrameArgs, CaptureMailSpec, DagCancelArgs, DagDescriptorArg,
-    DagStatusArgs, DescribeComponentArgs, DescribeHandlesArgs, DescribeHandlesResponse, EngineInfo,
-    HandleSummaryJson, LoadComponentArgs, MailIdJson, MailNodeJson, MailSpec, MailStatus, NodeArg,
-    ReplaceComponentArgs, ReplyEventJson, SendMailArgs, SendMailTracedArgs, SendMailTracedResponse,
-    SpawnSubstrateArgs, SubmitDagArgs, TerminateSubstrateArgs, TracedMailSpec, TransformListing,
+    CaptureCheckSpec, CaptureFrameArgs, CaptureMailSpec, ComponentSpec, DagCancelArgs,
+    DagDescriptorArg, DagStatusArgs, DescribeComponentArgs, DescribeHandlesArgs,
+    DescribeHandlesResponse, EngineInfo, HandleSummaryJson, LoadComponentArgs, MailIdJson,
+    MailNodeJson, MailSpec, MailStatus, NodeArg, ReplaceComponentArgs, ReplyEventJson,
+    SendMailArgs, SendMailTracedArgs, SendMailTracedResponse, SpawnSubstrateArgs, SubmitDagArgs,
+    TerminateSubstrateArgs, TracedMailSpec, TransformListing,
 };
 use crate::reverse::EngineNames;
 use crate::rpc::RpcSession;
@@ -206,12 +208,26 @@ impl Mcp {
     }
 
     #[tool(
-        description = "Fork+exec a substrate binary as a child of the hub. The hub assigns the substrate a free localhost RPC port, injects it as AETHER_RPC_PORT, forks the binary, and connects a proxy. Returns the engine_id and rpc_port on success."
+        description = "Fork+exec a substrate binary as a child of the hub. The hub assigns the substrate a free localhost RPC port, injects it as AETHER_RPC_PORT, forks the binary, and connects a proxy. Returns the engine_id and rpc_port on success. Pass `components` (each {binary_path, name?, config_path?, export?}) to bring the engine up with those components already loaded in one call — aether-mcp stages a temp boot-manifest the hub injects as AETHER_BOOT_MANIFEST, and the spawned substrate reads the listed wasm itself (single-host), so no follow-up load_component is needed."
     )]
     pub async fn spawn_substrate(
         &self,
         Parameters(args): Parameters<SpawnSubstrateArgs>,
     ) -> Result<String, McpError> {
+        // A boot list rides in as a temp boot-manifest JSON of file
+        // paths; the hub injects its path as AETHER_BOOT_MANIFEST and the
+        // single-host substrate reads the wasm itself (issue 1776). Hold
+        // the temp file across the spawn call — the substrate reads it at
+        // boot, before the spawn reply returns — then clean it up.
+        let manifest = if args.components.is_empty() {
+            None
+        } else {
+            Some(
+                stage_boot_manifest(&args.components)
+                    .await
+                    .map_err(internal)?,
+            )
+        };
         let reply = self
             .session
             .call_one(local_envelope(
@@ -219,10 +235,15 @@ impl Mcp {
                 &SpawnEngine {
                     binary_path: args.binary_path,
                     args: args.args,
+                    boot_manifest: manifest.as_ref().map(|p| p.to_string_lossy().into_owned()),
                 },
             ))
-            .await
-            .map_err(internal)?;
+            .await;
+        if let Some(path) = &manifest {
+            // Best-effort cleanup; the substrate has already read it.
+            let _ = fs::remove_file(path).await;
+        }
+        let reply = reply.map_err(internal)?;
         match SpawnEngineResult::decode_from_bytes(&reply.payload) {
             Some(SpawnEngineResult::Ok {
                 engine_id,
@@ -1364,6 +1385,50 @@ fn validate_recipient_scope(recipient_name: &str) -> anyhow::Result<()> {
     })
 }
 
+/// Build the boot-manifest JSON for a `spawn_substrate` component list
+/// (issue 1776). Mirrors the bundle crate's `BundleManifest` schema,
+/// serialized with `serde_json::json!` so `aether-mcp` needn't depend on
+/// the bundle crate — the same approach `cargo xtask bundle` takes on the
+/// write side. Factored from [`stage_boot_manifest`] so the shape is
+/// unit-testable without staging a file. Optional spec fields are only
+/// emitted when set, matching the manifest's `#[serde(default)]` fields.
+fn component_manifest_json(components: &[ComponentSpec]) -> serde_json::Value {
+    let entries: Vec<serde_json::Value> = components
+        .iter()
+        .map(|spec| {
+            let mut entry = serde_json::json!({ "wasm": spec.binary_path });
+            if let Some(name) = &spec.name {
+                entry["name"] = serde_json::json!(name);
+            }
+            if let Some(config) = &spec.config_path {
+                entry["config"] = serde_json::json!(config);
+            }
+            if let Some(export) = &spec.export {
+                entry["export"] = serde_json::json!(export);
+            }
+            entry
+        })
+        .collect();
+    serde_json::json!({ "components": entries })
+}
+
+/// Stage the `spawn_substrate` boot list as a temporary boot-manifest
+/// JSON file and return its path (issue 1776). The hub injects the path
+/// as `AETHER_BOOT_MANIFEST` at the fork; the caller removes the file
+/// once the spawn settles. The filename is per-process-unique so
+/// concurrent spawns never collide.
+async fn stage_boot_manifest(components: &[ComponentSpec]) -> anyhow::Result<PathBuf> {
+    use std::env;
+    use std::process;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    let path = env::temp_dir().join(format!("aether-boot-manifest-{}-{seq}.json", process::id()));
+    let bytes = serde_json::to_vec(&component_manifest_json(components))?;
+    fs::write(&path, bytes).await?;
+    Ok(path)
+}
+
 /// Build a `MailEnvelope` addressed at a hub-local mailbox
 /// (`engine = None`) carrying a typed kind.
 fn local_envelope<K: Kind>(mailbox: &str, kind: &K) -> MailEnvelope {
@@ -1852,8 +1917,8 @@ fn level_to_str(level: u8) -> &'static str {
 mod tests {
     use super::*;
     use crate::args::{
-        CaptureFrameArgs, CaptureMailSpec, DescribeComponentArgs, LoadComponentArgs, MailSpec,
-        ReplaceComponentArgs, SendMailArgs, SendMailTracedArgs, SpawnSubstrateArgs,
+        CaptureFrameArgs, CaptureMailSpec, ComponentSpec, DescribeComponentArgs, LoadComponentArgs,
+        MailSpec, ReplaceComponentArgs, SendMailArgs, SendMailTracedArgs, SpawnSubstrateArgs,
         TerminateSubstrateArgs, TracedMailSpec,
     };
     use aether_capabilities::rpc::{
@@ -2013,9 +2078,54 @@ mod tests {
             .spawn_substrate(Parameters(SpawnSubstrateArgs {
                 binary_path: "/nonexistent/aether-substrate-does-not-exist".to_owned(),
                 args: vec![],
+                components: vec![],
             }))
             .await;
         assert!(result.is_err(), "a missing binary should be a tool error");
+    }
+
+    /// The temp boot-manifest `spawn_substrate` stages from its
+    /// `components` list is a well-formed `BundleManifest` JSON: list
+    /// order is preserved, `binary_path` maps to `wasm`, and the optional
+    /// `config_path` / `name` / `export` ride only when set (issue 1776).
+    #[test]
+    fn component_manifest_json_is_well_formed() {
+        let specs = vec![
+            ComponentSpec {
+                binary_path: "/abs/camera.wasm".to_owned(),
+                name: Some("camera".to_owned()),
+                config_path: Some("/abs/camera.cfg".to_owned()),
+                export: None,
+            },
+            ComponentSpec {
+                binary_path: "/abs/ui.wasm".to_owned(),
+                name: None,
+                config_path: None,
+                export: Some("ui.panel".to_owned()),
+            },
+        ];
+        let manifest = component_manifest_json(&specs);
+        let components = manifest["components"]
+            .as_array()
+            .expect("components is an array");
+        assert_eq!(components.len(), 2);
+
+        assert_eq!(components[0]["wasm"], "/abs/camera.wasm");
+        assert_eq!(components[0]["name"], "camera");
+        assert_eq!(components[0]["config"], "/abs/camera.cfg");
+        assert!(components[0].get("export").is_none());
+
+        assert_eq!(components[1]["wasm"], "/abs/ui.wasm");
+        assert_eq!(components[1]["export"], "ui.panel");
+        assert!(components[1].get("name").is_none());
+        assert!(components[1].get("config").is_none());
+
+        // The staged JSON parses back through the chassis manifest schema
+        // shape (components array of {wasm, ...}).
+        let serialized = serde_json::to_string(&manifest).expect("serialize manifest");
+        let reparsed: serde_json::Value =
+            serde_json::from_str(&serialized).expect("reparse manifest");
+        assert_eq!(reparsed["components"].as_array().unwrap().len(), 2);
     }
 
     /// `terminate_substrate` with a malformed `engine_id` surfaces the

--- a/crates/aether-substrate-bundle/build.rs
+++ b/crates/aether-substrate-bundle/build.rs
@@ -16,15 +16,16 @@
 
 use std::{env, fs, path::Path, path::PathBuf};
 
-// The pack encoder + manifest schema, shared with the lib (where the
-// bundle bins decode). Self-contained std+serde, so the same file
-// compiles in both contexts; `dead_code` because the build script only
-// uses the encode half.
+// The pack encoder + manifest schema + reader, shared with the lib
+// (where the bundle bins decode and the chassis runtime reads
+// `AETHER_BOOT_MANIFEST`). Self-contained std+serde, so the same file
+// compiles in both contexts; `dead_code` because the build script
+// only exercises the encode + read-manifest half.
 #[allow(dead_code)]
 #[path = "src/bundle_pack.rs"]
 mod bundle_pack;
 
-use bundle_pack::{BundleManifest, ChassisSettings, Pack, PackedComponent, encode_pack};
+use bundle_pack::{Pack, encode_pack, pack_from_manifest, read_manifest};
 
 fn main() {
     println!("cargo:rerun-if-env-changed=AETHER_BUNDLE_MANIFEST");
@@ -32,42 +33,23 @@ fn main() {
     let out = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR set by cargo"))
         .join("bundle_pack.bin");
     let pack = env::var_os("AETHER_BUNDLE_MANIFEST").map_or_else(Pack::default, |manifest_path| {
-        pack_from_manifest(Path::new(&manifest_path))
+        pack_for(Path::new(&manifest_path))
     });
     fs::write(&out, encode_pack(&pack)).expect("write bundle pack blob");
 }
 
-/// Read the manifest plus every wasm / config file it names into a
-/// [`Pack`], registering each input for rerun-if-changed.
-fn pack_from_manifest(manifest_path: &Path) -> Pack {
+/// Register the manifest plus every wasm / config it names for
+/// rerun-if-changed, then read them into a [`Pack`] via the shared
+/// [`pack_from_manifest`] reader (the runtime boot path reuses the same
+/// reader, so the encode and read logic live in one place).
+fn pack_for(manifest_path: &Path) -> Pack {
     println!("cargo:rerun-if-changed={}", manifest_path.display());
-    let manifest_json = fs::read_to_string(manifest_path)
-        .unwrap_or_else(|e| panic!("read bundle manifest from {}: {e}", manifest_path.display()));
-    let manifest: BundleManifest = serde_json::from_str(&manifest_json)
-        .unwrap_or_else(|e| panic!("parse bundle manifest at {}: {e}", manifest_path.display()));
-    let mut components = Vec::new();
-    for entry in manifest.components {
+    let manifest = read_manifest(manifest_path).unwrap_or_else(|e| panic!("{e}"));
+    for entry in &manifest.components {
         println!("cargo:rerun-if-changed={}", entry.wasm.display());
-        let wasm = fs::read(&entry.wasm)
-            .unwrap_or_else(|e| panic!("read component wasm from {}: {e}", entry.wasm.display()));
-        let config = entry.config.as_ref().map_or_else(Vec::new, |path| {
-            println!("cargo:rerun-if-changed={}", path.display());
-            fs::read(path)
-                .unwrap_or_else(|e| panic!("read component config from {}: {e}", path.display()))
-        });
-        components.push(PackedComponent {
-            wasm,
-            config,
-            name: entry.name,
-            export: entry.export,
-        });
+        if let Some(config) = &entry.config {
+            println!("cargo:rerun-if-changed={}", config.display());
+        }
     }
-    Pack {
-        chassis: ChassisSettings {
-            title: manifest.title,
-            window_mode: manifest.window_mode,
-            tick_hz: manifest.tick_hz,
-        },
-        components,
-    }
+    pack_from_manifest(manifest_path).unwrap_or_else(|e| panic!("{e}"))
 }

--- a/crates/aether-substrate-bundle/src/autoload.rs
+++ b/crates/aether-substrate-bundle/src/autoload.rs
@@ -9,13 +9,16 @@
 //! address the hub's `load_component` and the test bench load through
 //! — which is what makes the mechanism chassis-agnostic.
 
+use std::path::Path;
+
 use aether_actor::Actor;
 use aether_capabilities::ComponentHostCapability;
 use aether_data::{Kind as _, mailbox_id_from_name};
 use aether_kinds::LoadComponent;
 use aether_substrate::Mail;
+use aether_substrate::config::ConfigError;
 
-use crate::bundle_pack::PackedComponent;
+use crate::bundle_pack::{self, PackedComponent};
 
 /// A component to auto-load on boot — its wasm bytes, optional init-config
 /// bytes (ADR-0090; empty for none), and the optional load name / export
@@ -37,6 +40,34 @@ impl From<PackedComponent> for AutoloadComponent {
             export: packed.export,
         }
     }
+}
+
+/// Read the boot manifest at `path` into the [`AutoloadComponent`] list
+/// the chassis env's `autoload` field carries — the runtime twin of the
+/// compile-time pack the standalone bundle bins embed. Both paths feed
+/// the same `env.autoload` (one from a runtime manifest of file paths,
+/// one from a compile-time pack of bytes), which `build_inner` drains
+/// into `aether.component.load`.
+///
+/// Reached from `DesktopEnv::from_env_with_argv` / its headless twin
+/// when `AETHER_BOOT_MANIFEST` (or `--boot-manifest`) is set; the engines
+/// cap injects that env var at the fork so a `spawn_substrate` carrying a
+/// component list comes up with those components already loading.
+///
+/// # Errors
+///
+/// Returns a hard [`ConfigError`] (the ADR-0090 §4 "known knob, bad
+/// value" path — boot aborts loudly) when the manifest or any wasm /
+/// config file it names can't be read or parsed.
+pub fn boot_manifest_autoload(path: &Path) -> Result<Vec<AutoloadComponent>, ConfigError> {
+    let pack = bundle_pack::pack_from_manifest(path).map_err(|e| {
+        ConfigError::unparseable("AETHER_BOOT_MANIFEST", path.display().to_string(), e)
+    })?;
+    Ok(pack
+        .components
+        .into_iter()
+        .map(AutoloadComponent::from)
+        .collect())
 }
 
 /// Build the `aether.component.load` mail that auto-loads `component`,

--- a/crates/aether-substrate-bundle/src/bundle_pack.rs
+++ b/crates/aether-substrate-bundle/src/bundle_pack.rs
@@ -29,6 +29,9 @@
 
 use std::error::Error;
 use std::fmt;
+use std::fs;
+use std::io;
+use std::path::Path;
 use std::path::PathBuf;
 use std::str;
 
@@ -132,6 +135,120 @@ pub struct ManifestComponent {
     pub name: Option<String>,
     #[serde(default)]
     pub export: Option<String>,
+}
+
+/// A failure reading a [`BundleManifest`] (or a file it names) into a
+/// [`Pack`]. Shared by `build.rs` (compile-time embed — it `panic!`s
+/// on this) and the chassis runtime boot-manifest reader (which maps
+/// it to a hard config fault, ADR-0090 §4). Each variant carries the
+/// offending path so the message names the file, not just the fault.
+#[derive(Debug)]
+pub enum ManifestError {
+    /// The manifest JSON file could not be read off disk.
+    ReadManifest { path: PathBuf, source: io::Error },
+    /// The manifest JSON did not parse into a [`BundleManifest`].
+    ParseManifest {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+    /// A component's wasm artifact could not be read.
+    ReadWasm { path: PathBuf, source: io::Error },
+    /// A component's init-config file could not be read.
+    ReadConfig { path: PathBuf, source: io::Error },
+}
+
+impl fmt::Display for ManifestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ReadManifest { path, source } => {
+                write!(f, "read bundle manifest from {}: {source}", path.display())
+            }
+            Self::ParseManifest { path, source } => {
+                write!(f, "parse bundle manifest at {}: {source}", path.display())
+            }
+            Self::ReadWasm { path, source } => {
+                write!(f, "read component wasm from {}: {source}", path.display())
+            }
+            Self::ReadConfig { path, source } => {
+                write!(f, "read component config from {}: {source}", path.display())
+            }
+        }
+    }
+}
+
+impl Error for ManifestError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::ReadManifest { source, .. }
+            | Self::ReadWasm { source, .. }
+            | Self::ReadConfig { source, .. } => Some(source),
+            Self::ParseManifest { source, .. } => Some(source),
+        }
+    }
+}
+
+/// Read and parse the JSON [`BundleManifest`] at `manifest_path`. Split
+/// out from [`pack_from_manifest`] so `build.rs` can walk the parsed
+/// component list to register each input for `cargo:rerun-if-changed`
+/// before the bytes are read.
+///
+/// # Errors
+///
+/// Returns [`ManifestError::ReadManifest`] / [`ManifestError::ParseManifest`]
+/// when the file is unreadable or its JSON doesn't match the schema.
+pub fn read_manifest(manifest_path: &Path) -> Result<BundleManifest, ManifestError> {
+    let json = fs::read_to_string(manifest_path).map_err(|source| ManifestError::ReadManifest {
+        path: manifest_path.to_path_buf(),
+        source,
+    })?;
+    serde_json::from_str(&json).map_err(|source| ManifestError::ParseManifest {
+        path: manifest_path.to_path_buf(),
+        source,
+    })
+}
+
+/// Read the manifest at `manifest_path` plus every wasm / config file it
+/// names into a [`Pack`]. Pure file I/O — emits no cargo directives, so
+/// the same reader serves the compile-time embed (`build.rs`, which
+/// registers `rerun-if-changed` itself) and the runtime boot-manifest
+/// path (`AETHER_BOOT_MANIFEST`, read in the chassis `from_env_with_argv`).
+/// Paths in the manifest are resolved as-is (absolute, per the writer
+/// contract).
+///
+/// # Errors
+///
+/// Returns a [`ManifestError`] when the manifest, a component wasm, or a
+/// component config file can't be read or parsed.
+pub fn pack_from_manifest(manifest_path: &Path) -> Result<Pack, ManifestError> {
+    let manifest = read_manifest(manifest_path)?;
+    let mut components = Vec::with_capacity(manifest.components.len());
+    for entry in manifest.components {
+        let wasm = fs::read(&entry.wasm).map_err(|source| ManifestError::ReadWasm {
+            path: entry.wasm.clone(),
+            source,
+        })?;
+        let config = match entry.config.as_ref() {
+            Some(path) => fs::read(path).map_err(|source| ManifestError::ReadConfig {
+                path: path.clone(),
+                source,
+            })?,
+            None => Vec::new(),
+        };
+        components.push(PackedComponent {
+            wasm,
+            config,
+            name: entry.name,
+            export: entry.export,
+        });
+    }
+    Ok(Pack {
+        chassis: ChassisSettings {
+            title: manifest.title,
+            window_mode: manifest.window_mode,
+            tick_hz: manifest.tick_hz,
+        },
+        components,
+    })
 }
 
 fn put_bytes_long(out: &mut Vec<u8>, bytes: &[u8]) {
@@ -360,5 +477,89 @@ mod tests {
         assert_eq!(manifest.components.len(), 2);
         assert_eq!(manifest.components[0].name.as_deref(), Some("a"));
         assert_eq!(manifest.components[1].config, None);
+    }
+
+    /// A per-test scratch directory under the system temp dir, unique
+    /// per call so concurrent test threads never collide.
+    fn scratch_dir(tag: &str) -> PathBuf {
+        use std::env;
+        use std::process;
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+        let dir = env::temp_dir().join(format!("aether-bundle-pack-{tag}-{}-{seq}", process::id()));
+        fs::create_dir_all(&dir).expect("create scratch dir");
+        dir
+    }
+
+    #[test]
+    fn pack_from_manifest_reads_wasm_and_config_in_order() {
+        // The runtime boot-manifest path (and `build.rs`) read the
+        // listed files into a `Pack`; this proves the reader resolves
+        // each manifest entry's wasm + optional config and preserves
+        // list order, name, and export.
+        let dir = scratch_dir("read");
+        let wasm_a = dir.join("a.wasm");
+        let cfg_a = dir.join("a.cfg");
+        let wasm_b = dir.join("b.wasm");
+        fs::write(&wasm_a, [0x00, 0x61, 0x73, 0x6d]).expect("write a.wasm");
+        fs::write(&cfg_a, [1, 2, 3]).expect("write a.cfg");
+        fs::write(&wasm_b, [0xfe, 0xff]).expect("write b.wasm");
+        let manifest_path = dir.join("manifest.json");
+        let manifest_json = serde_json::json!({
+            "tick_hz": 30,
+            "components": [
+                {"wasm": wasm_a, "config": cfg_a, "name": "first"},
+                {"wasm": wasm_b, "export": "alt"},
+            ],
+        });
+        fs::write(
+            &manifest_path,
+            serde_json::to_vec(&manifest_json).expect("serialize manifest"),
+        )
+        .expect("write manifest");
+
+        let pack = pack_from_manifest(&manifest_path).expect("read pack");
+        assert_eq!(pack.chassis.tick_hz, Some(30));
+        assert_eq!(
+            pack.components,
+            vec![
+                PackedComponent {
+                    wasm: vec![0x00, 0x61, 0x73, 0x6d],
+                    config: vec![1, 2, 3],
+                    name: Some("first".to_owned()),
+                    export: None,
+                },
+                PackedComponent {
+                    wasm: vec![0xfe, 0xff],
+                    config: Vec::new(),
+                    name: None,
+                    export: Some("alt".to_owned()),
+                },
+            ],
+        );
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn pack_from_manifest_errors_on_missing_wasm() {
+        // A manifest naming a wasm that isn't on disk is a hard read
+        // error — the chassis maps this to an aborting config fault.
+        let dir = scratch_dir("missing");
+        let manifest_path = dir.join("manifest.json");
+        let manifest_json = serde_json::json!({
+            "components": [{"wasm": dir.join("nope.wasm")}],
+        });
+        fs::write(
+            &manifest_path,
+            serde_json::to_vec(&manifest_json).expect("serialize manifest"),
+        )
+        .expect("write manifest");
+
+        let err = pack_from_manifest(&manifest_path).expect_err("missing wasm errors");
+        assert!(matches!(err, ManifestError::ReadWasm { .. }), "{err:?}");
+
+        fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -71,6 +71,14 @@ pub const CHASSIS_KNOBS: &[KnobRecord] = &[
         kind: KnobKind::HandRegistered,
     },
     KnobRecord {
+        env_key: "AETHER_BOOT_MANIFEST",
+        doc: "Path to a BundleManifest JSON of components to auto-load at boot \
+              (the runtime twin of the standalone-bundle compile-time pack; \
+              injected by the engines cap on a spawn_substrate carrying components).",
+        default: None,
+        kind: KnobKind::HandRegistered,
+    },
+    KnobRecord {
         env_key: "AETHER_WINDOW_MODE",
         doc: "Desktop window mode: windowed[:WxH] / fullscreen-borderless / exclusive:WxH@HZ.",
         default: None,
@@ -318,8 +326,8 @@ pub fn maybe_with_rpc_server<C: Chassis>(
 }
 
 /// Issue 1761: boot the HTTP server only when `config` is `Some` (i.e.
-/// `AETHER_HTTP_SERVER_BIND_ADDR` or `--http-server-bind-addr` was set).
-/// Mirrors [`maybe_with_rpc_server`]: an unconfigured chassis binds nothing.
+/// the cap's `enabled` flag is set). Mirrors [`maybe_with_rpc_server`]:
+/// an unconfigured chassis binds nothing.
 pub fn maybe_with_http_server<C: Chassis>(
     builder: Builder<C>,
     config: Option<HttpServerConfig>,
@@ -328,6 +336,19 @@ pub fn maybe_with_http_server<C: Chassis>(
         return builder;
     };
     builder.with_actor::<HttpServerCapability>(config)
+}
+
+/// Read `AETHER_BOOT_MANIFEST` into the optional boot-manifest path —
+/// a `BundleManifest` JSON of components to auto-load at boot. `None`
+/// when unset; the chassis then boots componentless (the bare-spawn /
+/// hub-load path). Mirrors [`crate::hub::rpc_port_from_env`]: the env
+/// read is the fallback for an absent `--boot-manifest` CLI flag.
+/// Shared by the desktop + headless chassis.
+#[must_use]
+pub fn boot_manifest_from_env() -> Option<String> {
+    env::var("AETHER_BOOT_MANIFEST")
+        .ok()
+        .filter(|p| !p.is_empty())
 }
 
 /// Parse `AETHER_WORKERS`. Unset → `None` (chassis falls back to

--- a/crates/aether-substrate-bundle/src/cli.rs
+++ b/crates/aether-substrate-bundle/src/cli.rs
@@ -138,6 +138,12 @@ pub struct CommonOverlay {
     /// server entirely; hub falls back to `DEFAULT_RPC_PORT`).
     #[arg(long = "rpc-port")]
     pub rpc_port: Option<u16>,
+
+    /// `AETHER_BOOT_MANIFEST` — path to a `BundleManifest` JSON of
+    /// components to auto-load at boot (the runtime twin of the
+    /// standalone-bundle compile-time pack). Absent → boot componentless.
+    #[arg(long = "boot-manifest")]
+    pub boot_manifest: Option<String>,
 }
 
 /// Desktop chassis CLI root.

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -32,11 +32,11 @@ use winit::error::EventLoopError;
 use winit::event_loop::EventLoop;
 
 use super::driver::{DesktopDriverCapability, parse_window_mode_env};
-use crate::autoload::{AutoloadComponent, autoload_mail};
+use crate::autoload::{AutoloadComponent, autoload_mail, boot_manifest_autoload};
 use crate::chassis_common::{
-    CommonBoot, PersistOverride, chassis_known_keys, frame_lifecycle_config,
-    maybe_with_http_server, maybe_with_rpc_server, parse_workers_env, resolve_persist_state,
-    with_common_caps,
+    CommonBoot, PersistOverride, boot_manifest_from_env, chassis_known_keys,
+    frame_lifecycle_config, maybe_with_http_server, maybe_with_rpc_server, parse_workers_env,
+    resolve_persist_state, with_common_caps,
 };
 use crate::cli::{CommonOverlay, DesktopCli};
 use crate::hub;
@@ -44,6 +44,7 @@ use aether_substrate::config::{ConfigError, validate_env};
 use aether_substrate::runtime::lifecycle::FatalAborter;
 use aether_substrate::runtime::lifecycle::OutboundFatalAborter;
 use std::env;
+use std::path::Path;
 use winit::event_loop::ControlFlow;
 
 /// Desktop chassis env-resolution failure (ADR-0090 §4 / issue #571).
@@ -235,7 +236,17 @@ impl DesktopEnv {
             persist,
             workers: cli_workers,
             rpc_port: cli_rpc_port,
+            boot_manifest: cli_boot_manifest,
         } = common;
+
+        // Boot manifest: argv wins over `AETHER_BOOT_MANIFEST`. When set,
+        // the listed components' wasm + config are read into the autoload
+        // list `build_inner` drains into `aether.component.load`; an
+        // unreadable manifest aborts boot (ADR-0090 §4) via `ConfigError`.
+        let autoload = match cli_boot_manifest.or_else(boot_manifest_from_env) {
+            Some(path) => boot_manifest_autoload(Path::new(&path))?,
+            None => Vec::new(),
+        };
 
         let event_loop = EventLoop::<UserEvent>::with_user_event().build()?;
         event_loop.set_control_flow(ControlFlow::Poll);
@@ -321,7 +332,7 @@ impl DesktopEnv {
             workers,
             persist: persist_state,
             handle_store_max_bytes,
-            autoload: Vec::new(),
+            autoload,
         })
     }
 }

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -30,10 +30,11 @@ use aether_substrate::chassis::error::BootError;
 use aether_substrate::{Chassis, SubstrateBoot};
 
 use super::driver::{HeadlessTimerDriverCapability, parse_tick_hz_env};
-use crate::autoload::{AutoloadComponent, autoload_mail};
+use crate::autoload::{AutoloadComponent, autoload_mail, boot_manifest_autoload};
 use crate::chassis_common::{
-    CommonBoot, PersistOverride, chassis_known_keys, maybe_with_http_server, maybe_with_rpc_server,
-    parse_workers_env, resolve_persist_state, tick_only_lifecycle_config, with_common_caps,
+    CommonBoot, PersistOverride, boot_manifest_from_env, chassis_known_keys,
+    maybe_with_http_server, maybe_with_rpc_server, parse_workers_env, resolve_persist_state,
+    tick_only_lifecycle_config, with_common_caps,
 };
 use crate::cli::{CommonOverlay, HeadlessCli};
 use crate::hub;
@@ -41,6 +42,7 @@ use aether_substrate::config::{ConfigError, validate_env};
 use aether_substrate::mail::registry::MailDispatch;
 use aether_substrate::runtime::lifecycle::FatalAborter;
 use aether_substrate::runtime::lifecycle::OutboundFatalAborter;
+use std::path::Path;
 
 /// Marker type for the headless chassis. Carries no fields — the
 /// chassis instance is the [`BuiltChassis<HeadlessChassis>`] returned
@@ -146,7 +148,16 @@ impl HeadlessEnv {
             persist,
             workers: cli_workers,
             rpc_port: cli_rpc_port,
+            boot_manifest: cli_boot_manifest,
         } = common;
+        // Boot manifest: argv wins over `AETHER_BOOT_MANIFEST`. When set,
+        // the listed components' wasm + config are read into the autoload
+        // list `build_inner` drains into `aether.component.load`; an
+        // unreadable manifest aborts boot (ADR-0090 §4) via `ConfigError`.
+        let autoload = match cli_boot_manifest.or_else(boot_manifest_from_env) {
+            Some(path) => boot_manifest_autoload(Path::new(&path))?,
+            None => Vec::new(),
+        };
         let http = HttpConf::try_from_argv_then_env(http.into_layer())?;
         let anthropic = AnthropicConfig::try_from_argv_then_env(anthropic.into_layer())?;
         let gemini = GeminiConfig::try_from_argv_then_env(gemini.into_layer())?;
@@ -183,7 +194,7 @@ impl HeadlessEnv {
             workers,
             persist: persist_state,
             handle_store_max_bytes,
-            autoload: Vec::new(),
+            autoload,
         })
     }
 }

--- a/crates/aether-substrate-bundle/tests/engines_cap.rs
+++ b/crates/aether-substrate-bundle/tests/engines_cap.rs
@@ -169,6 +169,7 @@ mod heavy {
             &SpawnEngine {
                 binary_path: headless.to_owned(),
                 args: vec![],
+                boot_manifest: None,
             },
             Duration::from_secs(30),
             || {
@@ -278,6 +279,7 @@ mod heavy {
             &SpawnEngine {
                 binary_path: headless.to_owned(),
                 args: vec![],
+                boot_manifest: None,
             },
             Duration::from_secs(30),
             || {
@@ -303,6 +305,7 @@ mod heavy {
             &SpawnEngine {
                 binary_path: headless.to_owned(),
                 args: vec![],
+                boot_manifest: None,
             },
             Duration::from_secs(30),
             || {

--- a/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
@@ -182,6 +182,7 @@ impl FleetBench {
             &SpawnEngine {
                 binary_path: headless.to_owned(),
                 args: vec![],
+                boot_manifest: None,
             },
         );
         let payload = single_reply(&replies, "SpawnEngine");

--- a/crates/aether-substrate-bundle/tests/headless_autoload.rs
+++ b/crates/aether-substrate-bundle/tests/headless_autoload.rs
@@ -24,6 +24,7 @@ use std::time::Duration;
 
 use aether_substrate_bundle::Chassis as _;
 use aether_substrate_bundle::PersistOverride;
+use aether_substrate_bundle::autoload::boot_manifest_autoload;
 use aether_substrate_bundle::bundle_pack::{
     ChassisSettings, Pack, PackedComponent, decode_pack, encode_pack,
 };
@@ -110,6 +111,73 @@ mod tests {
                 thread::sleep(Duration::from_millis(25));
             }
             // Dropping `built` shuts the passives down in reverse boot order.
+        }
+
+        #[test]
+        fn autoloaded_component_from_runtime_manifest_comes_up() {
+            // The runtime-manifest twin of the embed test above: a real
+            // `BundleManifest` JSON of *paths* is read by
+            // `boot_manifest_autoload` — the same reader the chassis runs
+            // for `AETHER_BOOT_MANIFEST`, the path a `spawn_substrate`
+            // carrying a component list drives — and the resolved autoload
+            // brings the probe up with no hub.
+            let strict = env::var("AETHER_REQUIRE_RUNTIME").is_ok();
+            let Some(wasm_path) = locate_component_wasm("probe") else {
+                assert!(
+                    !strict,
+                    "AETHER_REQUIRE_RUNTIME set but probe.wasm not pre-built; \
+                 CI's `Pre-build component wasm for scenario tests` step is missing it",
+                );
+                eprintln!(
+                    "skipping: probe.wasm not built; \
+                 run `cargo build --target wasm32-unknown-unknown -p aether-test-fixtures --examples`",
+                );
+                return;
+            };
+
+            // Write a boot manifest of paths next to the test sandbox; the
+            // reader resolves the wasm bytes itself.
+            let sandbox = init_save_sandbox("headless-runtime-manifest");
+            let manifest_path = sandbox.join("boot-manifest.json");
+            let manifest_json = serde_json::json!({
+                "components": [{ "wasm": wasm_path, "name": "probe" }],
+            });
+            fs::write(
+                &manifest_path,
+                serde_json::to_vec(&manifest_json).expect("serialize boot manifest"),
+            )
+            .expect("write boot manifest");
+
+            let autoload = boot_manifest_autoload(&manifest_path).expect("read boot manifest");
+            assert_eq!(autoload.len(), 1, "one component listed in the manifest");
+
+            let env = HeadlessEnv {
+                namespace_roots: test_namespace_roots(sandbox),
+                http: HttpConfig::default(),
+                http_server: None,
+                anthropic: AnthropicConfig::default(),
+                gemini: GeminiConfig::default(),
+                tick_period: Duration::from_millis(16),
+                rpc_addr: None,
+                workers: None,
+                persist: PersistOverride::Argv(None),
+                handle_store_max_bytes: None,
+                autoload,
+            };
+
+            let built = HeadlessChassis::build(env).expect("build headless chassis");
+            let deadline = Instant::now() + Duration::from_secs(30);
+            loop {
+                if built.resolve_actor::<WasmTrampoline>("probe").is_some() {
+                    break;
+                }
+                assert!(
+                    Instant::now() < deadline,
+                    "runtime-manifest probe trampoline did not come up within 30s; live instances: {:?}",
+                    built.resolve_actors::<WasmTrampoline>(),
+                );
+                thread::sleep(Duration::from_millis(25));
+            }
         }
     }
 }

--- a/crates/aether-substrate-bundle/tests/rpc_engine_routing.rs
+++ b/crates/aether-substrate-bundle/tests/rpc_engine_routing.rs
@@ -186,6 +186,7 @@ mod heavy {
             &SpawnEngine {
                 binary_path: headless.to_owned(),
                 args: vec![],
+                boot_manifest: None,
             },
         );
         assert_eq!(spawn_kind, <SpawnEngineResult as Kind>::ID);


### PR DESCRIPTION
Closes #1776.

## Summary

`spawn_substrate` forked a bare engine — any components had to be loaded one `load_component` round-trip at a time after boot. This lets a spawn launch with components preloaded, by threading a boot manifest from the MCP tool down to the forked chassis.

`SpawnEngine` gains a `boot_manifest: Option<String>` wire field; the engines cap injects `AETHER_BOOT_MANIFEST` into the child's environment at the fork. The chassis (desktop + headless `from_env_with_argv`, plus a `--boot-manifest` flag and the `AETHER_BOOT_MANIFEST` knob) reads the manifest at boot and fills `env.autoload` — reusing `bundle_pack`'s manifest reader, lifted to a shared `read_manifest` / `pack_from_manifest` so `build.rs` and the runtime share one parser. The `aether-mcp` `spawn_substrate` tool gains a `components` list, which it stages as a temp manifest JSON, threads by path, and cleans up post-spawn. Builds additively on the autoload mechanism and ADR-0090 config validation.

## Test plan

- `aether-kinds`: `spawn_engine_roundtrip_carries_boot_manifest`.
- `aether-substrate-bundle`: `bundle_pack` reader unit tests (`pack_from_manifest_reads_wasm_and_config_in_order`, `_errors_on_missing_wasm`) + a headless runtime-manifest boot test.
- `aether-mcp`: `component_manifest_json_is_well_formed`.
- `scripts/preflight.sh` green: fmt, clippy `--workspace --all-targets -D warnings`, `cargo nextest run --workspace`, doc, `aether-camera` wasm32 cross-build.

## Generated by

`/implement` — agent execution of scoped issue #1776.
