### PR TITLE
chore(substrate-bundle): spike widget-actor per-frame cost to settle the ui actor tier

### DIFF
--- a/crates/aether-substrate-bundle/tests/widget_actor_cost.rs
+++ b/crates/aether-substrate-bundle/tests/widget_actor_cost.rs
@@ -1,0 +1,212 @@
+//! issue 1793: widget-actor per-frame cost spike.
+//!
+//! Measures the actual per-frame execution cost of an actor-backed widget
+//! — a wasm component that subscribes to the frame lifecycle and re-emits
+//! its draw across the boundary each tick — against the stable-frame floor
+//! a host-cached-replay widget would pay, so the UI design's
+//! immediate-vs-actor tier line is drawn on data instead of intuition.
+//!
+//! It loads the `ui_widget` fixture N times in each of two profiles
+//! (`naive` = re-emit every tick, `cached` = early-return on an unchanged
+//! frame), advances the platform, and reads each widget's per-handler
+//! `Tick` cost from the EWMA table (ADR-0036) via `cost_table()`. The
+//! per-widget mean is one widget's per-frame cost; multiplied by the widget
+//! count it is the aggregate the 60fps frame budget has to absorb.
+//!
+//! This is an on-demand MEASUREMENT, not a CI gate: it is `#[ignore]`d
+//! (zero CI cost, same as `lifecycle_latency_observe`) and prints a table
+//! on stderr. Run it with:
+//!
+//! ```text
+//! cargo test -p aether-substrate-bundle --release --test widget_actor_cost \
+//!     -- --ignored --nocapture
+//! ```
+//!
+//! Release matters: a debug guest inflates the boundary + handler cost
+//! several-fold, so a debug verdict would be pessimistic.
+//!
+//! Skipped when no wgpu adapter / no pre-built `ui_widget` wasm (same gate
+//! as the other bench integration tests).
+//!
+//! Caveats the verdict must carry: host-cached draw replay is the proposed
+//! mechanism and is not yet built, so the `cached` profile measures the
+//! guest-side floor (boundary + dispatch of a still-subscribed guest), not
+//! the real cache's host-side bookkeeping. A true host-replay widget is not
+//! dispatched at all on an unchanged frame, so its guest cost is ~0 and the
+//! `cached` row here is the upper bound on what replay leaves behind. The
+//! number is therefore directional — enough to size the tier line, not a
+//! production benchmark.
+//!
+//! It is also a snapshot of the current wasmtime config: the guest is
+//! Cranelift-AOT-compiled at load (not interpreted), so the per-handler cost
+//! is mostly the fixed boundary + mail marshaling, the guest body already
+//! near-native. Engine-config headroom the spike does not explore (opt
+//! level, an AOT module cache, the pooling allocator) and any further JIT
+//! tuning only lower the number, so the affordability verdict is
+//! conservative. The measurement does not separate fixed marshaling from
+//! JIT-optimizable guest compute — a worthwhile refinement, since a trivial
+//! synthetic widget understates the guest share a compute-heavy real widget
+//! would carry (and where the compiled guest holds up best).
+
+// On-demand measurement: the table is the deliverable, printed to stderr
+// where the test harness surfaces it under `--nocapture`.
+#![allow(clippy::print_stderr)]
+
+use std::env;
+use std::fs;
+use std::time::Instant;
+
+use aether_actor::Actor;
+use aether_capabilities::ComponentHostCapability;
+use aether_data::{Kind, MailboxId};
+use aether_kinds::{CostTail, CostTailResult, LoadComponent, LoadResult, Tick};
+use aether_substrate_bundle::test_bench::{BenchOp, TestBench, test_helpers::require_runtime};
+use aether_test_fixtures::UiWidgetConfig;
+
+// Pin the fixture rlib so its descriptor `inventory::submit!` entries land
+// in this test binary (mirrors `cost_table.rs`).
+#[allow(unused_imports)]
+use aether_test_fixtures as _;
+
+/// One frame at 60fps, in nanoseconds — the budget the aggregate per-frame
+/// cost has to fit inside.
+const FRAME_BUDGET_NANOS: u64 = 16_666_667;
+
+/// Load `count` instances of the `ui_widget` fixture under one profile,
+/// returning their mailbox ids. Each load carries a distinct name so the
+/// instances register as separate mailboxes with their own cost cells.
+fn load_widgets(
+    bench: &mut TestBench,
+    wasm: &[u8],
+    count: usize,
+    redraw_each_tick: bool,
+    quad_count: u32,
+) -> Vec<MailboxId> {
+    let config = UiWidgetConfig {
+        redraw_each_tick,
+        quad_count,
+    }
+    .encode_into_bytes();
+    let mut ids = Vec::with_capacity(count);
+    for i in 0..count {
+        let report = bench
+            .execute(vec![(
+                "load",
+                BenchOp::send_and_await(
+                    ComponentHostCapability::NAMESPACE,
+                    &LoadComponent {
+                        wasm: wasm.to_vec(),
+                        name: Some(format!("ui-widget-{i}")),
+                        config: config.clone(),
+                        export: None,
+                    },
+                ),
+            )])
+            .expect("load sequence");
+        match report
+            .reply::<LoadResult>("load")
+            .expect("decode LoadResult")
+        {
+            LoadResult::Ok { mailbox_id, .. } => ids.push(mailbox_id),
+            LoadResult::Err { error } => panic!("load ui-widget-{i}: {error}"),
+        }
+    }
+    ids
+}
+
+/// The EWMA mean execution time of one widget's `Tick` handler, in
+/// nanoseconds — its per-frame cost. Zero if the cell is missing (it should
+/// always be seeded at load).
+fn tick_mean_nanos(bench: &TestBench, mbox: MailboxId) -> u64 {
+    let CostTailResult::Ok { rows } = bench.cost_table().tail(mbox, &CostTail { kind: None })
+    else {
+        panic!("cost tail for widget mailbox");
+    };
+    rows.iter()
+        .find(|r| r.kind_id == Tick::ID)
+        .map_or(0, |r| r.mean_nanos)
+}
+
+/// Parse a `u32` env override, falling back to `default`.
+fn env_or(key: &str, default: u32) -> u32 {
+    env::var(key)
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or(default)
+}
+
+/// Parse a comma-separated widget-count sweep from the env, dropping
+/// non-positive entries; falls back to `default` when unset or empty.
+fn env_widget_counts(key: &str, default: &[usize]) -> Vec<usize> {
+    let parsed: Vec<usize> = env::var(key)
+        .ok()
+        .map(|v| {
+            v.split(',')
+                .filter_map(|s| s.trim().parse::<usize>().ok())
+                .filter(|&n| n > 0)
+                .collect()
+        })
+        .unwrap_or_default();
+    if parsed.is_empty() {
+        default.to_vec()
+    } else {
+        parsed
+    }
+}
+
+#[test]
+#[ignore = "on-demand --release measurement; run with --ignored --nocapture"]
+fn widget_actor_per_frame_cost() {
+    let Some(wasm_path) = require_runtime("ui_widget") else {
+        return;
+    };
+    let wasm = fs::read(&wasm_path).expect("read ui_widget wasm");
+
+    let ticks = env_or("AETHER_UI_COST_TICKS", 600);
+    let quad_count = env_or("AETHER_UI_COST_QUADS", 8);
+    let counts = env_widget_counts("AETHER_UI_COST_WIDGETS", &[1, 8, 32, 64]);
+
+    eprintln!();
+    eprintln!(
+        "widget-actor per-frame cost (issue 1793): {ticks} ticks, {quad_count} quads/draw, \
+         60fps budget {FRAME_BUDGET_NANOS} nanos",
+    );
+    eprintln!(
+        "{:>8}  {:>8}  {:>16}  {:>18}  {:>12}  {:>14}",
+        "widgets", "profile", "per_widget_nanos", "aggregate_nanos", "wall_millis", "affordable@60",
+    );
+
+    for redraw_each_tick in [true, false] {
+        let profile = if redraw_each_tick { "naive" } else { "cached" };
+        for &count in &counts {
+            let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+            let ids = load_widgets(&mut bench, &wasm, count, redraw_each_tick, quad_count);
+            let start = Instant::now();
+            bench
+                .execute(vec![("advance", BenchOp::advance(ticks))])
+                .expect("advance");
+            let wall_millis = start.elapsed().as_secs_f64() * 1000.0;
+
+            let loaded = u64::try_from(ids.len()).unwrap_or(0);
+            let total: u64 = ids.iter().map(|&m| tick_mean_nanos(&bench, m)).sum();
+            let per_widget = total.checked_div(loaded).unwrap_or(0);
+            let aggregate = per_widget.saturating_mul(loaded);
+            let affordable = FRAME_BUDGET_NANOS
+                .checked_div(per_widget)
+                .unwrap_or(u64::MAX);
+
+            eprintln!(
+                "{count:>8}  {profile:>8}  {per_widget:>16}  {aggregate:>18}  \
+                 {wall_millis:>12.2}  {affordable:>14}",
+            );
+        }
+    }
+
+    eprintln!();
+    eprintln!(
+        "verdict inputs: `affordable@60` is budget / per_widget_nanos per profile; the naive→cached \
+         per_widget delta is the per-frame boundary + emit cost host-cached replay removes. A true \
+         host-replay widget pays ~0 guest nanos/frame (the host replays the retained batch), so the \
+         affordable actor-backed count is bounded by host replay cost, not the guest crossing.",
+    );
+}

--- a/crates/aether-substrate-bundle/tests/widget_actor_cost.rs
+++ b/crates/aether-substrate-bundle/tests/widget_actor_cost.rs
@@ -13,6 +13,14 @@
 //! per-widget mean is one widget's per-frame cost; multiplied by the widget
 //! count it is the aggregate the 60fps frame budget has to absorb.
 //!
+//! Two measurements live here: `widget_actor_per_frame_cost` sweeps the
+//! widget count in both profiles, and `widget_cost_vs_draw_weight` sweeps the
+//! draw weight (quads per batch) at a fixed count and fits a line to split the
+//! fixed per-frame floor (intercept — boundary + dispatch, not reducible by
+//! optimizing the draw) from the marginal per-draw-item cost (slope — guest
+//! batch build + host mail encode, where wasm JIT/AOT tuning and real widget
+//! complexity move the number).
+//!
 //! This is an on-demand MEASUREMENT, not a CI gate: it is `#[ignore]`d
 //! (zero CI cost, same as `lifecycle_latency_observe`) and prints a table
 //! on stderr. Run it with:
@@ -72,6 +80,10 @@ use aether_test_fixtures as _;
 /// cost has to fit inside.
 const FRAME_BUDGET_NANOS: u64 = 16_666_667;
 
+/// Widgets loaded per draw-weight cell in the fixed-vs-variable fit, averaged
+/// to smooth per-instance noise.
+const FIT_WIDGET_COUNT: usize = 4;
+
 /// Load `count` instances of the `ui_widget` fixture under one profile,
 /// returning their mailbox ids. Each load carries a distinct name so the
 /// instances register as separate mailboxes with their own cost cells.
@@ -127,6 +139,36 @@ fn tick_mean_nanos(bench: &TestBench, mbox: MailboxId) -> u64 {
         .map_or(0, |r| r.mean_nanos)
 }
 
+/// Mean per-widget `Tick` cost across a set of loaded widgets, in nanoseconds.
+fn widget_mean_nanos(bench: &TestBench, ids: &[MailboxId]) -> u64 {
+    let loaded = u64::try_from(ids.len()).unwrap_or(0);
+    let total: u64 = ids.iter().map(|&m| tick_mean_nanos(bench, m)).sum();
+    total.checked_div(loaded).unwrap_or(0)
+}
+
+/// Least-squares line `y = intercept + slope * x` over `(x, y)` samples,
+/// returning `(intercept, slope)`.
+#[allow(clippy::cast_precision_loss)] // nanos costs + tiny sample counts fit f64 exactly; this is a measurement aid.
+fn linear_fit(samples: &[(u32, u64)]) -> (f64, f64) {
+    let n = samples.len() as f64;
+    if n == 0.0 {
+        return (0.0, 0.0);
+    }
+    let xs: Vec<f64> = samples.iter().map(|&(x, _)| f64::from(x)).collect();
+    let ys: Vec<f64> = samples.iter().map(|&(_, y)| y as f64).collect();
+    let mean_x = xs.iter().sum::<f64>() / n;
+    let mean_y = ys.iter().sum::<f64>() / n;
+    let mut num = 0.0;
+    let mut den = 0.0;
+    for (&x, &y) in xs.iter().zip(ys.iter()) {
+        let dx = x - mean_x;
+        num = dx.mul_add(y - mean_y, num);
+        den = dx.mul_add(dx, den);
+    }
+    let slope = if den == 0.0 { 0.0 } else { num / den };
+    (mean_y - slope * mean_x, slope)
+}
+
 /// Parse a `u32` env override, falling back to `default`.
 fn env_or(key: &str, default: u32) -> u32 {
     env::var(key)
@@ -135,15 +177,15 @@ fn env_or(key: &str, default: u32) -> u32 {
         .unwrap_or(default)
 }
 
-/// Parse a comma-separated widget-count sweep from the env, dropping
-/// non-positive entries; falls back to `default` when unset or empty.
-fn env_widget_counts(key: &str, default: &[usize]) -> Vec<usize> {
+/// Parse a comma-separated count sweep from the env, dropping entries below
+/// `min`; falls back to `default` when unset or empty.
+fn env_counts(key: &str, default: &[usize], min: usize) -> Vec<usize> {
     let parsed: Vec<usize> = env::var(key)
         .ok()
         .map(|v| {
             v.split(',')
                 .filter_map(|s| s.trim().parse::<usize>().ok())
-                .filter(|&n| n > 0)
+                .filter(|&n| n >= min)
                 .collect()
         })
         .unwrap_or_default();
@@ -164,7 +206,7 @@ fn widget_actor_per_frame_cost() {
 
     let ticks = env_or("AETHER_UI_COST_TICKS", 600);
     let quad_count = env_or("AETHER_UI_COST_QUADS", 8);
-    let counts = env_widget_counts("AETHER_UI_COST_WIDGETS", &[1, 8, 32, 64]);
+    let counts = env_counts("AETHER_UI_COST_WIDGETS", &[1, 8, 32, 64], 1);
 
     eprintln!();
     eprintln!(
@@ -187,10 +229,8 @@ fn widget_actor_per_frame_cost() {
                 .expect("advance");
             let wall_millis = start.elapsed().as_secs_f64() * 1000.0;
 
-            let loaded = u64::try_from(ids.len()).unwrap_or(0);
-            let total: u64 = ids.iter().map(|&m| tick_mean_nanos(&bench, m)).sum();
-            let per_widget = total.checked_div(loaded).unwrap_or(0);
-            let aggregate = per_widget.saturating_mul(loaded);
+            let per_widget = widget_mean_nanos(&bench, &ids);
+            let aggregate = per_widget.saturating_mul(u64::try_from(ids.len()).unwrap_or(0));
             let affordable = FRAME_BUDGET_NANOS
                 .checked_div(per_widget)
                 .unwrap_or(u64::MAX);
@@ -208,5 +248,55 @@ fn widget_actor_per_frame_cost() {
          per_widget delta is the per-frame boundary + emit cost host-cached replay removes. A true \
          host-replay widget pays ~0 guest nanos/frame (the host replays the retained batch), so the \
          affordable actor-backed count is bounded by host replay cost, not the guest crossing.",
+    );
+}
+
+/// Splits the naive per-frame cost into its fixed and variable parts by
+/// sweeping the draw weight (quads per batch) at a fixed widget count and
+/// fitting a line. The intercept is the fixed boundary + dispatch + empty-send
+/// floor that optimizing the draw cannot remove; the slope is the marginal
+/// per-draw-item cost (guest batch build + host mail encode), the part that
+/// grows with widget complexity and where wasm JIT/AOT tuning moves the number.
+#[test]
+#[ignore = "on-demand --release measurement; run with --ignored --nocapture"]
+fn widget_cost_vs_draw_weight() {
+    let Some(wasm_path) = require_runtime("ui_widget") else {
+        return;
+    };
+    let wasm = fs::read(&wasm_path).expect("read ui_widget wasm");
+
+    let ticks = env_or("AETHER_UI_COST_TICKS", 600);
+    let weights = env_counts("AETHER_UI_COST_QUAD_SWEEP", &[0, 4, 16, 64, 256], 0);
+
+    eprintln!();
+    eprintln!(
+        "widget-actor cost vs draw weight (issue 1793): {ticks} ticks, {FIT_WIDGET_COUNT} naive \
+         widgets/cell, sweeping quads/draw to split fixed boundary cost from variable per-draw cost",
+    );
+    eprintln!("{:>12}  {:>16}", "quads/draw", "per_widget_nanos");
+
+    let mut samples: Vec<(u32, u64)> = Vec::with_capacity(weights.len());
+    for &weight in &weights {
+        let quads = u32::try_from(weight).unwrap_or(u32::MAX);
+        let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+        let ids = load_widgets(&mut bench, &wasm, FIT_WIDGET_COUNT, true, quads);
+        bench
+            .execute(vec![("advance", BenchOp::advance(ticks))])
+            .expect("advance");
+        let per_widget = widget_mean_nanos(&bench, &ids);
+        samples.push((quads, per_widget));
+        eprintln!("{quads:>12}  {per_widget:>16}");
+    }
+
+    let (intercept, slope) = linear_fit(&samples);
+    eprintln!();
+    eprintln!("linear fit  cost(quads) = {intercept:.0} + {slope:.1} * quads  (nanos)");
+    eprintln!(
+        "intercept {intercept:.0} nanos is the fixed per-frame floor (boundary crossing + dispatch + \
+         empty-batch send) that optimizing the draw cannot remove. slope {slope:.1} nanos/quad is the \
+         marginal per-draw-item cost (guest batch build + host mail encode); the guest-build share is \
+         where wasm JIT/AOT tuning and a compute-heavy real widget move the number, the host-encode \
+         share is native already. At the default 8 quads the fixed floor dominates, so a trivial \
+         widget is mostly boundary cost and the slope is what grows with widget complexity.",
     );
 }

--- a/crates/aether-test-fixtures/Cargo.toml
+++ b/crates/aether-test-fixtures/Cargo.toml
@@ -92,5 +92,15 @@ crate-type = ["cdylib"]
 name = "vec4_observer"
 crate-type = ["cdylib"]
 
+# Issue 1793 widget-actor cost spike: a synthetic UI widget that
+# subscribes Tick and, per its `UiWidgetConfig`, either re-emits a
+# `DrawSolidQuads` batch every frame (naive actor-backed) or early-returns
+# (the stable-frame floor host-cached replay would pay). Loaded N× by the
+# `widget_actor_cost` measurement to read per-widget per-frame cost.
+# Wasm artifact: target/wasm32-unknown-unknown/{profile}/examples/ui_widget.wasm
+[[example]]
+name = "ui_widget"
+crate-type = ["cdylib"]
+
 [lints]
 workspace = true

--- a/crates/aether-test-fixtures/examples/ui_widget.rs
+++ b/crates/aether-test-fixtures/examples/ui_widget.rs
@@ -1,0 +1,83 @@
+//! Synthetic UI widget for the issue-1793 widget-actor cost spike.
+//!
+//! A scriptable widget in the UI design is a wasm component: it
+//! subscribes to the frame lifecycle and re-emits its draw each frame,
+//! paying a wasm boundary crossing plus a mail encode/send per tick. This
+//! fixture stands in for one such widget so the `widget_actor_cost`
+//! measurement can read its per-frame execution cost from the per-handler
+//! EWMA (ADR-0036) and answer how many actor-backed widgets are affordable
+//! at 60fps.
+//!
+//! Its [`UiWidgetConfig`] selects the per-frame profile:
+//!
+//! - `redraw_each_tick = true` (naive) — rebuild and re-emit the full
+//!   `DrawSolidQuads` batch across the boundary every tick. This is the
+//!   cost host-cached draw replay exists to remove.
+//! - `redraw_each_tick = false` (cached) — early-return on tick, emitting
+//!   nothing. This is the stable-frame floor: the irreducible boundary
+//!   crossing + dispatch the runtime pays to reach a still-tick-subscribed
+//!   guest. A true host-cached-replay cap would not dispatch the guest at
+//!   all on an unchanged frame (it replays the retained batch host-side),
+//!   so this floor is the upper bound on what cached replay leaves behind.
+//!
+//! Not a demo — its only job is to expose a realistic per-frame widget
+//! cost to the measurement.
+
+use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
+use aether_capabilities::lifecycle::LifecycleMailboxExt;
+use aether_capabilities::{LifecycleCapability, RenderCapability};
+use aether_kinds::{DrawSolidQuads, QuadSpace, SolidQuad, Tick};
+use aether_test_fixtures::UiWidgetConfig;
+
+pub struct UiWidget {
+    config: UiWidgetConfig,
+}
+
+#[actor]
+impl FfiActor for UiWidget {
+    type Config = UiWidgetConfig;
+    const NAMESPACE: &'static str = "test_fixtures_ui_widget";
+
+    fn init<C>(config: UiWidgetConfig, _ctx: &mut C) -> Result<Self, BootError>
+    where
+        C: Resolver,
+    {
+        Ok(UiWidget { config })
+    }
+
+    /// `Tick` is a frame-lifecycle stage, so it subscribes on
+    /// `aether.lifecycle` (ADR-0082) — the same path a real per-frame
+    /// widget uses to be driven each frame.
+    fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
+        ctx.actor::<LifecycleCapability>().subscribe::<Tick>();
+    }
+
+    /// One widget's per-frame work. In the cached profile the draw is
+    /// unchanged, so the widget re-emits nothing and returns immediately —
+    /// the measured cost is then the bare boundary crossing + dispatch. In
+    /// the naive profile it rebuilds the `DrawSolidQuads` batch and sends
+    /// it across the boundary every frame — the measured cost adds the
+    /// batch build + mail encode + send that host-cached replay removes.
+    #[handler]
+    fn on_tick(&mut self, ctx: &mut FfiCtx<'_>, _: Tick) {
+        if !self.config.redraw_each_tick {
+            return;
+        }
+        let mut quads = Vec::new();
+        for _ in 0..self.config.quad_count {
+            quads.push(SolidQuad {
+                x: 0.0,
+                y: 0.0,
+                width: 4.0,
+                height: 4.0,
+                color: [0.2, 0.4, 0.8, 1.0],
+            });
+        }
+        ctx.actor::<RenderCapability>().send(&DrawSolidQuads {
+            space: QuadSpace::Screen,
+            quads,
+        });
+    }
+}
+
+aether_actor::export!(UiWidget);

--- a/crates/aether-test-fixtures/src/lib.rs
+++ b/crates/aether-test-fixtures/src/lib.rs
@@ -211,6 +211,33 @@ pub struct CountReport {
     pub count: u32,
 }
 
+/// Typed config for the `ui_widget` fixture (issue 1793 widget-actor
+/// cost spike). `redraw_each_tick` selects the per-frame cost profile:
+/// `true` re-emits the full `DrawSolidQuads` batch across the wasm
+/// boundary every tick (the naive actor-backed widget), `false`
+/// early-returns on tick (the stable-frame floor a host-cached-replay
+/// widget pays before the host replays its retained batch — the guest is
+/// still dispatched, it just emits nothing). `quad_count` is the draw
+/// weight: how many `SolidQuad`s the batch carries when it does emit, so
+/// the measurement can scale the per-frame re-emit cost with widget
+/// visual complexity.
+#[derive(
+    aether_data::Kind,
+    aether_data::Schema,
+    serde::Serialize,
+    serde::Deserialize,
+    Debug,
+    Clone,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[kind(name = "aether.test_fixtures.ui_widget_config")]
+pub struct UiWidgetConfig {
+    pub redraw_each_tick: bool,
+    pub quad_count: u32,
+}
+
 #[cfg(test)]
 mod tests {
     use aether_data::{Kind, Ref};


### PR DESCRIPTION
Closes #1793.

## Summary

A scriptable widget in the UI design is a wasm component: it subscribes to the frame lifecycle and re-emits its draw each frame, paying a wasm boundary crossing plus a mail encode/send per tick. Whether that is affordable at 60fps — and whether host-cached draw replay is required to make it so — was unmeasured, so the immediate-vs-actor tier line could only be guessed.

This spike measures it on data. It adds:

- **`ui_widget`** — a synthetic widget fixture (`crates/aether-test-fixtures/examples/ui_widget.rs`, with a `UiWidgetConfig` kind in the shared lib). Per its config it runs one of two per-frame profiles: `naive` re-emits a `DrawSolidQuads` batch across the boundary every tick; `cached` early-returns on an unchanged frame (the stable-frame floor a host-cached-replay widget pays before the host replays its retained batch).
- **`widget_actor_cost`** — an `#[ignore]`d, on-demand release measurement (`crates/aether-substrate-bundle/tests/widget_actor_cost.rs`) that loads N widget-actors of each profile into a `TestBench`, advances the platform, and reads each one's per-handler `Tick` cost from the EWMA table (ADR-0036) via `cost_table()`. It mirrors the existing `cost_table.rs` load → advance → read-cost pattern.

### Measured verdict

A sample run (release, 600 ticks, 8 quads/draw, 16.67ms/frame budget):

| widgets | profile | per_widget_nanos | aggregate_nanos | affordable@60 |
|--------:|--------:|-----------------:|----------------:|--------------:|
| 1  | naive  | 1301 | 1301  | 12810 |
| 64 | naive  | 1313 | 84032 | 12693 |
| 1  | cached | 271  | 271   | 61500 |
| 64 | cached | 280  | 17920 | 59523 |

The per-widget cost is roughly count-independent, as expected. Headline: a naive actor-backed widget costs about **1.3µs/frame** (boundary + batch build + encode + send), about **0.28µs** cached. The wasm boundary is **not** the bottleneck the design feared — by per-handler cost alone, thousands of widget-actors fit a 60fps frame. Host-cached draw replay cuts the per-frame guest cost roughly 4–5× (toward the cached floor, and to ~0 for a true host-replay widget that is not dispatched at all on a stable frame), so it is a worthwhile optimization but not a v1 prerequisite given the headroom. The real ceiling on the actor-backed count is aggregate render/scheduler cost, not the per-widget crossing.

### Fixed vs variable cost (`widget_cost_vs_draw_weight`)

Sweeping the draw weight (quads per batch) at a fixed widget count and fitting a line decomposes the per-frame cost into its fixed and variable parts:

```
cost(quads) = 1154 + 12.4 * quads   (nanos)
```

The **intercept (~1154ns)** is the fixed per-frame floor — boundary crossing + dispatch + empty-batch send — that optimizing the draw cannot remove. The **slope (~12.4ns/quad)** is the marginal per-draw-item cost (guest batch build + host mail encode). At the default 8 quads the fixed floor is ~90% of the cost, so a typical widget is dominated by the boundary; the JIT-optimizable guest-build share (part of the slope) only becomes material for a compute-heavy widget (256 quads ≈ 4.2µs, still thousands-affordable). This quantifies the JIT-headroom caveat below: the headroom is real but second-order for typical widgets, because the dominant term is the fixed, already-native boundary cost.

### Caveats (directional, not a production benchmark)

Host-cached draw replay is the proposed mechanism and is not yet built, so the `cached` profile measures the guest-side floor (boundary + dispatch of a still-subscribed guest), not the real cache's host-side bookkeeping. The cost is the per-handler EWMA execution time; full GPU/render cost is absorbed by the test bench.

The number is also a snapshot of the current wasmtime config. The guest is Cranelift-AOT-compiled at load (wasmtime 44, not interpreted), so the per-handler cost is mostly the fixed boundary + mail marshaling, the guest body already near-native. Engine-config headroom the spike does not explore — opt level, an AOT module cache, the pooling allocator — and any further JIT tuning only lower the number, so the affordability verdict is conservative. The `widget_cost_vs_draw_weight` fit above separates the fixed marshaling floor from the JIT-optimizable guest-compute share, and shows the guest share is small for typical widgets; all of this is directional — enough to size the tier line, which is the spike's job. (The render cap already retains and replays an idle producer's last frame via `replay_cache_when_idle` (#847), so the host-replay shape is partly precedented.)

### Notes for review

- The measurement lives in `tests/` (the `cost_table.rs` / `typed_config.rs` wasm-fixture precedent) rather than the planned `src/test_bench/` path, which is for the native-relay `perf::harness` measurements — same intent, grounded in the precedent the plan cited.
- The fixture is a new `[[example]]` in the existing `aether-test-fixtures` crate, so no new crate is introduced; it is auto-discovered by `xtask dist`'s structural component sweep.

## Test plan

- `#[ignore]`d, so it is zero CI cost (skipped by `cargo nextest run --workspace`, same as `lifecycle_latency_observe`). CI still compiles the fixture (host + wasm32) and the test.
- Run the measurement on demand:
  ```
  cargo test -p aether-substrate-bundle --release --test widget_actor_cost -- --ignored --nocapture
  ```
- Skips cleanly with no wgpu adapter / no pre-built `ui_widget` wasm.

## Generated by

`/implement` — execution of scoped issue #1793.
