### PR TITLE
chore(ci): reduce runner resource pressure and auto-retry transient CI failures

### DIFF
--- a/.github/workflows/ci-retry.yml
+++ b/.github/workflows/ci-retry.yml
@@ -1,0 +1,32 @@
+name: CI auto-retry
+
+# Triggered once per CI run completion. Retries failed jobs exactly
+# once on a fresh runner — the mechanism that actually clears runner
+# resource-exhaustion failures (mold + free-disk-space are prevention;
+# this is the backstop for anything that slips through).
+#
+# The run_attempt guard is load-bearing: without it a genuinely broken
+# PR would loop forever. At attempt >= 2 the job is skipped and the
+# failure stands for human triage.
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  actions: write
+
+jobs:
+  rerun:
+    name: Rerun failed jobs (attempt 1 only)
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt < 2
+    steps:
+      - name: Rerun failed jobs on a fresh runner
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X POST \
+            "repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/rerun-failed-jobs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,10 @@ jobs:
       # build — keeps the linker OOM (collect2: ld terminated with
       # signal 7) off the ubuntu runner. CI-scoped so dev machines
       # are unaffected. Companion to the free-disk-space step below.
-      RUSTFLAGS: -Clink-arg=-fuse-ld=mold
+      # Target-scoped to the native host triple: the wasm32 component
+      # cross-build links with rust-lld, which rejects -fuse-ld=mold,
+      # so a job-wide RUSTFLAGS would break it.
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -Clink-arg=-fuse-ld=mold
       # line-tables-only (instead of full DWARF) shrinks test
       # binaries and the linked artifacts on disk, reducing the
       # chance of hitting "no space left on device" even after

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
       # most headroom. Swap is kept (swap-storage: false) to avoid
       # degrading the linker under memory pressure.
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           android: 'true'
           dotnet: 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,17 @@ jobs:
     # default 6h quota before anyone notices. If this tripping
     # becomes routine, lower it — routine failure is a signal.
     timeout-minutes: 15
+    env:
+      # Use mold to reduce peak link memory and speed up the test
+      # build — keeps the linker OOM (collect2: ld terminated with
+      # signal 7) off the ubuntu runner. CI-scoped so dev machines
+      # are unaffected. Companion to the free-disk-space step below.
+      RUSTFLAGS: -Clink-arg=-fuse-ld=mold
+      # line-tables-only (instead of full DWARF) shrinks test
+      # binaries and the linked artifacts on disk, reducing the
+      # chance of hitting "no space left on device" even after
+      # the free-disk-space reclaim.
+      CARGO_PROFILE_TEST_DEBUG: line-tables-only
     steps:
       # Issue #612: fetch-depth 2 (PR) / 0 (push) so the changed-crate
       # filter in `Run tests` can `git diff HEAD^1 HEAD` (or against
@@ -124,12 +135,24 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+      # Reclaim ~20–30 GB by removing preinstalled Android / .NET /
+      # Haskell tooling that the build never uses. Runs before the
+      # rust-toolchain step so cargo's own build artifacts have the
+      # most headroom. Swap is kept (swap-storage: false) to avoid
+      # degrading the linker under memory pressure.
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1
+        with:
+          android: 'true'
+          dotnet: 'true'
+          haskell: 'true'
+          swap-storage: 'false'
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-      - name: Install Linux deps (ALSA for cpal, Mesa lavapipe for wgpu)
+      - name: Install Linux deps (ALSA for cpal, Mesa lavapipe for wgpu, mold linker)
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev
-          mesa-vulkan-drivers
+          mesa-vulkan-drivers mold
       - uses: Swatinem/rust-cache@v2
       # Pre-build the packaged artifact tree the scenario runner loads
       # at test time. Without this, ADR-0067 per-component scenarios


### PR DESCRIPTION
Closes #1792.

## Summary

The `Test (workspace, linux)` CI job hits two infra-class failures under the desktop test stack (winit/wayland/x11) — linker OOM (`collect2: ld terminated with signal 7`) and `No space left on device` — that are transient resource exhaustion, not code defects. This adds both prevention and a backstop:

- **`ci.yml`** — reclaim ~20–30 GB via `jlumbroso/free-disk-space@v1` (drops Android/.NET/Haskell tooling, keeps swap); link with `mold` (`RUSTFLAGS=-Clink-arg=-fuse-ld=mold`, installed via apt) to cut peak link memory; `CARGO_PROFILE_TEST_DEBUG=line-tables-only` to shrink test binaries. All CI-scoped — dev machines unaffected.
- **`ci-retry.yml`** (new) — a `workflow_run` companion that calls `rerun-failed-jobs` once when CI fails on the first attempt, getting a fresh runner for anything that still slips through. The `run_attempt < 2` guard is load-bearing: a genuinely broken PR fails and stands for triage rather than looping.

## Test plan

- Both workflow files validate as well-formed YAML (`yaml.safe_load`).
- The retry workflow runs from the default-branch definition, so it activates after merge to `main` (it cannot retry this PR's own CI, by design).
- The prevention measures take effect on this PR's `Test (workspace, linux)` run.

## Generated by

`/implement` — agent execution of [scoped issue #1792](https://github.com/iamacoffeepot/aether/issues/1792).
