### PR TITLE
feat(capabilities): aether.ui native capability with panel label and bar widgets

### DIFF
--- a/crates/aether-capabilities/Cargo.toml
+++ b/crates/aether-capabilities/Cargo.toml
@@ -65,6 +65,11 @@ audio = []
 # `ctx.actor::<TextCapability>()` without dragging `fontdue` into the wasm
 # graph.
 text = []
+# ADR-0107 `aether.ui` cap marker. CPU-only — it composes the render
+# solid-quad and text surfaces entirely by mail — gated the same two-
+# layer way so a wasm component can address it via
+# `ctx.actor::<UiCapability>()` without pulling native deps.
+ui = []
 
 # Native impl layers — adds the substrate-side runtime + heavy deps
 # atop the marker layer. Chassis bins activate these. Each implies its
@@ -75,6 +80,10 @@ audio-native = ["audio", "native", "dep:cpal", "dep:crossbeam-queue", "dep:hound
 # the pure-Rust TTF parse + rasterize + horizontal layout the cap runs
 # off the hot path. Implies the marker layer + `native`.
 text-native = ["text", "native", "dep:fontdue"]
+# `ui-native` has no heavy deps — the cap only sends mail to the render
+# and text caps. Implies the marker layer + `native` + the two surface
+# marker layers the native impl addresses.
+ui-native = ["ui", "native", "render", "text"]
 
 [dependencies]
 # Always-on: target-agnostic SDK + data layer + kind types. These

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -83,6 +83,8 @@ pub(crate) mod test_chassis;
 #[cfg(feature = "text")]
 pub mod text;
 pub mod trace;
+#[cfg(feature = "ui")]
+pub mod ui;
 // ADR-0086 Phase 3b decentralized trace-tree reconstruction. Pure,
 // transport-agnostic guided walk + stitch over the per-actor trace
 // rings; the MCP and the in-process harness each supply their own
@@ -169,6 +171,8 @@ pub use text::TextCapability;
 pub use trampoline::WasmTrampoline;
 #[cfg(not(target_arch = "wasm32"))]
 pub use trampoline::WasmTrampolineConfig;
+#[cfg(feature = "ui")]
+pub use ui::UiCapability;
 pub use window::HeadlessWindowCapability;
 
 #[cfg(all(test, feature = "native"))]

--- a/crates/aether-capabilities/src/ui.rs
+++ b/crates/aether-capabilities/src/ui.rs
@@ -1,0 +1,318 @@
+//! `aether.ui` cap (ADR-0107). Translates immediate-mode widget mail into
+//! `draw_solid_quads` and `draw_text` sends the same tick — a CPU-only
+//! translator with no retained widget state across frames. Components lay
+//! out and resend every frame; the cap forwards.
+//!
+//! Three handlers, each fire-and-forget:
+//!
+//! - **`on_panel`** → one `DrawSolidQuads` (screen-space) to `aether.render`.
+//! - **`on_bar`** → two `SolidQuad`s in one `DrawSolidQuads` (track + frac-
+//!   sized fill, screen-space) to `aether.render`.
+//! - **`on_label`** → one `DrawText` (screen-space) to `aether.text`. The
+//!   string flows from the screen-pixel `(x, y)` along the baseline, where
+//!   `(0, 0)` is the window's top-left corner.
+
+// `#[handler]` methods take their decoded payload by value per the
+// ADR-0033 dispatch ABI; the macro-generated trampoline owns the decoded
+// bytes so callers can't see references.
+#![allow(clippy::needless_pass_by_value)]
+
+// Handler-signature kinds must be importable at file root because
+// `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings of
+// the mod (always-on, outside the cfg gate).
+use aether_kinds::{UiBar, UiLabel, UiPanel};
+
+#[aether_actor::bridge(singleton, feature = "ui-native")]
+mod native {
+    use aether_actor::actor;
+    use aether_kinds::{DrawSolidQuads, DrawText, QuadSpace, SolidQuad};
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+
+    use crate::render::RenderCapability;
+    use crate::text::TextCapability;
+
+    use super::{UiBar, UiLabel, UiPanel};
+
+    /// `aether.ui` mailbox cap. CPU-only — no GPU handles, just a
+    /// stateless translator from widget mail to render + text mail.
+    pub struct UiCapability;
+
+    #[actor]
+    impl NativeActor for UiCapability {
+        type Config = ();
+
+        /// ADR-0107 chassis-owned mailbox.
+        const NAMESPACE: &'static str = "aether.ui";
+
+        /// No substrate resources to claim — the cap holds no state.
+        fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            Ok(Self)
+        }
+
+        /// Draw a flat-colored panel.
+        ///
+        /// # Agent
+        /// Fire-and-forget. Forwards one `DrawSolidQuads` (screen-space) to
+        /// `aether.render` the same tick. Resend every frame.
+        // Cap holds no state; `&mut self` is the required handler ABI.
+        #[allow(clippy::unused_self)]
+        #[handler]
+        fn on_panel(&mut self, ctx: &mut NativeCtx<'_>, mail: UiPanel) {
+            let [x, y, width, height] = mail.rect;
+            let draw = DrawSolidQuads {
+                space: QuadSpace::Screen,
+                quads: vec![SolidQuad {
+                    x,
+                    y,
+                    width,
+                    height,
+                    color: mail.color,
+                }],
+            };
+            let _ = ctx.actor::<RenderCapability>().send_traced(ctx, &draw);
+        }
+
+        /// Draw a two-layer progress bar.
+        ///
+        /// # Agent
+        /// Fire-and-forget. Forwards a two-quad `DrawSolidQuads` (screen-
+        /// space, track then frac-sized fill) to `aether.render` the same
+        /// tick. `frac` is clamped to [0, 1]. Resend every frame.
+        // Cap holds no state; `&mut self` is the required handler ABI.
+        #[allow(clippy::unused_self)]
+        #[handler]
+        fn on_bar(&mut self, ctx: &mut NativeCtx<'_>, mail: UiBar) {
+            let [x, y, width, height] = mail.rect;
+            let frac = mail.frac.clamp(0.0, 1.0);
+            let draw = DrawSolidQuads {
+                space: QuadSpace::Screen,
+                quads: vec![
+                    // Track: full rect.
+                    SolidQuad {
+                        x,
+                        y,
+                        width,
+                        height,
+                        color: mail.track_color,
+                    },
+                    // Fill: frac-fraction of the width.
+                    SolidQuad {
+                        x,
+                        y,
+                        width: width * frac,
+                        height,
+                        color: mail.fill_color,
+                    },
+                ],
+            };
+            let _ = ctx.actor::<RenderCapability>().send_traced(ctx, &draw);
+        }
+
+        /// Draw a text label.
+        ///
+        /// # Agent
+        /// Fire-and-forget. Forwards one `DrawText` (screen-space) to
+        /// `aether.text` the same tick. The string flows from the screen-pixel
+        /// `(x, y)` along the baseline, where `(0, 0)` is the window's
+        /// top-left corner. An unknown `font_id` warn-drops in the text cap.
+        /// Resend every frame.
+        // Cap holds no state; `&mut self` is the required handler ABI.
+        #[allow(clippy::unused_self)]
+        #[handler]
+        fn on_label(&mut self, ctx: &mut NativeCtx<'_>, mail: UiLabel) {
+            let draw = DrawText {
+                font_id: mail.font_id,
+                text: mail.text,
+                size_pixels: mail.size_pixels,
+                color: mail.color,
+                origin: [mail.x, mail.y],
+                space: QuadSpace::Screen,
+            };
+            let _ = ctx.actor::<TextCapability>().send_traced(ctx, &draw);
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        #![allow(clippy::unwrap_used)]
+
+        use std::sync::Arc;
+        use std::sync::mpsc::Receiver;
+        use std::time::Duration;
+
+        use aether_data::{Kind, MailId, MailboxId, SessionToken, Source, SourceAddr, Uuid};
+        use aether_kinds::{DrawSolidQuads, DrawText};
+        use aether_substrate::actor::native::binding::NativeBinding;
+        use aether_substrate::mail::outbound::EgressEvent;
+
+        use super::*;
+        use crate::test_chassis::test_mailer_and_rx;
+
+        fn session_sender() -> Source {
+            Source::to(SourceAddr::Session(SessionToken(Uuid::nil())))
+        }
+
+        fn ctx_binding() -> (Arc<NativeBinding>, Receiver<EgressEvent>) {
+            let (mailer, rx) = test_mailer_and_rx();
+            let binding = Arc::new(NativeBinding::new_for_test(mailer, MailboxId(0)));
+            (binding, rx)
+        }
+
+        /// Flush buffered sends and drain egress until a `UnresolvedMail` of
+        /// kind `K` arrives. Skips non-mail events.
+        fn assert_next_send_kind<K: Kind>(binding: &NativeBinding, rx: &Receiver<EgressEvent>) {
+            binding.flush_outbound();
+            loop {
+                let event = rx
+                    .recv_timeout(Duration::from_secs(2))
+                    .expect("test: egress event arrives within deadline");
+                if let EgressEvent::UnresolvedMail { kind_id, .. } = event {
+                    assert_eq!(kind_id, K::ID, "unexpected bubbled kind");
+                    return;
+                }
+            }
+        }
+
+        #[test]
+        fn panel_produces_draw_solid_quads() {
+            let mut cap = UiCapability;
+            let (binding, rx) = ctx_binding();
+            let mut ctx = NativeCtx::new(&binding, session_sender(), MailId::NONE, MailId::NONE);
+            cap.on_panel(
+                &mut ctx,
+                UiPanel {
+                    rect: [10.0, 20.0, 100.0, 50.0],
+                    color: [0.2, 0.4, 0.6, 1.0],
+                },
+            );
+            assert_next_send_kind::<DrawSolidQuads>(&binding, &rx);
+        }
+
+        #[test]
+        fn bar_produces_draw_solid_quads_with_two_quads() {
+            let mut cap = UiCapability;
+            let (binding, rx) = ctx_binding();
+            let mut ctx = NativeCtx::new(&binding, session_sender(), MailId::NONE, MailId::NONE);
+            cap.on_bar(
+                &mut ctx,
+                UiBar {
+                    rect: [0.0, 0.0, 200.0, 20.0],
+                    frac: 0.5,
+                    track_color: [0.3, 0.3, 0.3, 1.0],
+                    fill_color: [0.0, 0.8, 0.0, 1.0],
+                },
+            );
+            binding.flush_outbound();
+            let event = rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("test: egress event");
+            let EgressEvent::UnresolvedMail {
+                kind_id, payload, ..
+            } = event
+            else {
+                panic!("expected UnresolvedMail for DrawSolidQuads");
+            };
+            assert_eq!(kind_id, DrawSolidQuads::ID, "expected DrawSolidQuads");
+            let decoded: DrawSolidQuads =
+                postcard::from_bytes(&payload).expect("test: decodes DrawSolidQuads");
+            assert_eq!(decoded.quads.len(), 2, "bar emits track + fill quad");
+            assert_eq!(decoded.quads[1].width, 100.0, "fill is frac * full width");
+        }
+
+        #[test]
+        fn bar_clamps_frac_above_one() {
+            let mut cap = UiCapability;
+            let (binding, rx) = ctx_binding();
+            let mut ctx = NativeCtx::new(&binding, session_sender(), MailId::NONE, MailId::NONE);
+            cap.on_bar(
+                &mut ctx,
+                UiBar {
+                    rect: [0.0, 0.0, 200.0, 20.0],
+                    frac: 2.0,
+                    track_color: [0.3, 0.3, 0.3, 1.0],
+                    fill_color: [0.8, 0.0, 0.0, 1.0],
+                },
+            );
+            binding.flush_outbound();
+            let event = rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("test: egress event");
+            let EgressEvent::UnresolvedMail {
+                kind_id, payload, ..
+            } = event
+            else {
+                panic!("expected UnresolvedMail");
+            };
+            assert_eq!(kind_id, DrawSolidQuads::ID);
+            let decoded: DrawSolidQuads =
+                postcard::from_bytes(&payload).expect("test: decodes DrawSolidQuads");
+            assert_eq!(
+                decoded.quads[1].width, 200.0,
+                "frac > 1 clamps to full width"
+            );
+        }
+
+        #[test]
+        fn bar_clamps_frac_below_zero() {
+            let mut cap = UiCapability;
+            let (binding, rx) = ctx_binding();
+            let mut ctx = NativeCtx::new(&binding, session_sender(), MailId::NONE, MailId::NONE);
+            cap.on_bar(
+                &mut ctx,
+                UiBar {
+                    rect: [0.0, 0.0, 200.0, 20.0],
+                    frac: -0.5,
+                    track_color: [0.3, 0.3, 0.3, 1.0],
+                    fill_color: [0.8, 0.0, 0.0, 1.0],
+                },
+            );
+            binding.flush_outbound();
+            let event = rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("test: egress event");
+            let EgressEvent::UnresolvedMail {
+                kind_id, payload, ..
+            } = event
+            else {
+                panic!("expected UnresolvedMail");
+            };
+            assert_eq!(kind_id, DrawSolidQuads::ID);
+            let decoded: DrawSolidQuads =
+                postcard::from_bytes(&payload).expect("test: decodes DrawSolidQuads");
+            assert_eq!(decoded.quads[1].width, 0.0, "frac < 0 clamps to zero width");
+        }
+
+        #[test]
+        fn label_produces_draw_text_screen_space() {
+            let mut cap = UiCapability;
+            let (binding, rx) = ctx_binding();
+            let mut ctx = NativeCtx::new(&binding, session_sender(), MailId::NONE, MailId::NONE);
+            cap.on_label(
+                &mut ctx,
+                UiLabel {
+                    x: 50.0,
+                    y: 100.0,
+                    font_id: 3,
+                    text: "Score: 42".to_owned(),
+                    size_pixels: 24.0,
+                    color: [1.0, 1.0, 1.0, 1.0],
+                },
+            );
+            binding.flush_outbound();
+            let event = rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("test: egress event arrives within deadline");
+            let EgressEvent::UnresolvedMail {
+                kind_id, payload, ..
+            } = event
+            else {
+                panic!("expected UnresolvedMail for DrawText");
+            };
+            assert_eq!(kind_id, DrawText::ID, "expected DrawText");
+            let decoded: DrawText = postcard::from_bytes(&payload).expect("test: decodes DrawText");
+            assert_eq!(decoded.space, QuadSpace::Screen, "label uses Screen space");
+            assert_eq!(decoded.origin, [50.0, 100.0], "label origin is (x, y)");
+        }
+    }
+}

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1836,6 +1836,52 @@ mod control_plane {
         pub space: QuadSpace,
     }
 
+    // ADR-0107 `aether.ui` widget kinds. Immediate-mode: the component
+    // lays out and sends these each frame; the `aether.ui` cap translates
+    // them to `draw_solid_quads` and `draw_text` calls the same tick.
+    // Screen-space; `rect` is `[x, y, width, height]` in window pixels.
+
+    /// `aether.ui.panel` — draw a flat-colored panel at `rect` in
+    /// screen-pixel space. `color` is a linear RGBA value; the alpha
+    /// channel scales the blend. Fire-and-forget; resend every frame.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.ui.panel")]
+    pub struct UiPanel {
+        /// `[x, y, width, height]` in window pixels.
+        pub rect: [f32; 4],
+        pub color: [f32; 4],
+    }
+
+    /// `aether.ui.bar` — draw a two-layer progress bar at `rect` in
+    /// screen-pixel space. The track (`track_color`) fills the full rect;
+    /// the fill (`fill_color`) covers `frac` × width, clamped to [0, 1].
+    /// Fire-and-forget; resend every frame.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.ui.bar")]
+    pub struct UiBar {
+        /// `[x, y, width, height]` in window pixels.
+        pub rect: [f32; 4],
+        /// Filled fraction, clamped to [0, 1] by the cap.
+        pub frac: f32,
+        pub track_color: [f32; 4],
+        pub fill_color: [f32; 4],
+    }
+
+    /// `aether.ui.label` — draw a string at `(x, y)` in screen-pixel
+    /// space using the font registered under `font_id` (via
+    /// `aether.text.load_font`). Fire-and-forget; resend every frame.
+    /// An unknown `font_id` warn-drops in the `aether.text` cap.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.ui.label")]
+    pub struct UiLabel {
+        pub x: f32,
+        pub y: f32,
+        pub font_id: u32,
+        pub text: String,
+        pub size_pixels: f32,
+        pub color: [f32; 4],
+    }
+
     /// The three window presentation modes. `Windowed` has no fields —
     /// the current size lives on `SetWindowModeResult`.
     /// `FullscreenExclusive` carries the specific video mode; the
@@ -3675,6 +3721,9 @@ mod tests {
         assert_eq!(LoadFont::NAME, "aether.text.load_font");
         assert_eq!(LoadFontResult::NAME, "aether.text.load_font_result");
         assert_eq!(DrawText::NAME, "aether.text.draw");
+        assert_eq!(UiPanel::NAME, "aether.ui.panel");
+        assert_eq!(UiBar::NAME, "aether.ui.bar");
+        assert_eq!(UiLabel::NAME, "aether.ui.label");
         assert_eq!(SetWindowMode::NAME, "aether.window.set_mode");
         assert_eq!(SetWindowModeResult::NAME, "aether.window.set_mode_result");
         assert_eq!(SetWindowTitle::NAME, "aether.window.set_title");
@@ -4147,6 +4196,65 @@ mod tests {
             assert_eq!(back.color, [1.0, 0.5, 0.25, 1.0]);
             assert_eq!(back.origin, [24.0, 48.0]);
             assert_eq!(back.space, QuadSpace::Screen);
+        }
+    }
+
+    // ADR-0107 `aether.ui` widget kind round-trips. Each kind is
+    // postcard-encoded and decoded, proving the derived
+    // Serialize/Deserialize agree on the wire for each shape.
+    mod ui_roundtrips {
+        use super::*;
+        use alloc::string::ToString;
+
+        #[test]
+        fn ui_panel_roundtrip() {
+            let p = UiPanel {
+                rect: [10.0, 20.0, 100.0, 50.0],
+                color: [0.1, 0.2, 0.3, 0.8],
+            };
+            let bytes = postcard::to_allocvec(&p).expect("test setup: postcard encodes UiPanel");
+            let back: UiPanel =
+                postcard::from_bytes(&bytes).expect("test setup: postcard decodes UiPanel");
+            assert_eq!(back.rect, [10.0, 20.0, 100.0, 50.0]);
+            assert_eq!(back.color, [0.1, 0.2, 0.3, 0.8]);
+        }
+
+        #[test]
+        fn ui_bar_roundtrip() {
+            let b = UiBar {
+                rect: [0.0, 0.0, 200.0, 24.0],
+                frac: 0.75,
+                track_color: [0.2, 0.2, 0.2, 1.0],
+                fill_color: [0.1, 0.8, 0.2, 1.0],
+            };
+            let bytes = postcard::to_allocvec(&b).expect("test setup: postcard encodes UiBar");
+            let back: UiBar =
+                postcard::from_bytes(&bytes).expect("test setup: postcard decodes UiBar");
+            assert_eq!(back.rect, [0.0, 0.0, 200.0, 24.0]);
+            assert_eq!(back.frac, 0.75);
+            assert_eq!(back.track_color, [0.2, 0.2, 0.2, 1.0]);
+            assert_eq!(back.fill_color, [0.1, 0.8, 0.2, 1.0]);
+        }
+
+        #[test]
+        fn ui_label_roundtrip() {
+            let l = UiLabel {
+                x: 10.0,
+                y: 20.0,
+                font_id: 2,
+                text: "HP: 100".to_string(),
+                size_pixels: 16.0,
+                color: [1.0, 1.0, 1.0, 1.0],
+            };
+            let bytes = postcard::to_allocvec(&l).expect("test setup: postcard encodes UiLabel");
+            let back: UiLabel =
+                postcard::from_bytes(&bytes).expect("test setup: postcard decodes UiLabel");
+            assert_eq!(back.x, 10.0);
+            assert_eq!(back.y, 20.0);
+            assert_eq!(back.font_id, 2);
+            assert_eq!(back.text, "HP: 100");
+            assert_eq!(back.size_pixels, 16.0);
+            assert_eq!(back.color, [1.0, 1.0, 1.0, 1.0]);
         }
     }
 

--- a/crates/aether-substrate-bundle/Cargo.toml
+++ b/crates/aether-substrate-bundle/Cargo.toml
@@ -66,7 +66,7 @@ path = "src/bin/perf-plot.rs"
 
 [dependencies]
 aether-substrate = { path = "../aether-substrate", features = ["render"] }
-aether-capabilities = { path = "../aether-capabilities", features = ["render-native", "audio-native", "text-native"] }
+aether-capabilities = { path = "../aether-capabilities", features = ["render-native", "audio-native", "text-native", "ui-native"] }
 aether-actor = { path = "../aether-actor" }
 aether-data = { path = "../aether-data" }
 aether-kinds = { path = "../aether-kinds" }

--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -27,8 +27,8 @@ use aether_capabilities::{
     AnthropicCapability, AnthropicConfig, ComponentHostCapability, ComponentHostConfig,
     DagCapability, FsCapability, GeminiCapability, GeminiConfig, HandleCapability, HttpCapability,
     HttpServerCapability, HttpServerConfig, InputCapability, InputConfig, InventoryCapability,
-    LifecycleConfig, TcpCapability, TextCapability, fs::NamespaceRoots, http::HttpConfig,
-    trace::TraceDispatchCapability,
+    LifecycleConfig, TcpCapability, TextCapability, UiCapability, fs::NamespaceRoots,
+    http::HttpConfig, trace::TraceDispatchCapability,
 };
 use aether_kinds::{Present, Render, Shutdown, Tick};
 use aether_substrate::chassis::Chassis;
@@ -296,6 +296,7 @@ pub fn with_common_caps<C: Chassis>(builder: Builder<C>, boot: CommonBoot) -> Bu
         .with_actor::<ComponentHostCapability>(boot.component_host_config)
         .with_actor::<FsCapability>(boot.namespace_roots)
         .with_actor::<TextCapability>(())
+        .with_actor::<UiCapability>(())
         .with_actor::<InventoryCapability>(())
         .with_actor::<HttpCapability>(boot.http)
         .with_actor::<TcpCapability>(())


### PR DESCRIPTION
Closes #1738.

## Summary

Stands up `aether.ui`, a CPU-only native capability symmetric with `aether.text`: a component mails the cap its widget set each frame (immediate-mode) and the cap translates each widget to `aether.render` (`draw_solid_quads`) and `aether.text` (`draw`) the same tick, holding no UI state across frames. Widget kinds live in `aether-kinds` under `aether.ui.{panel,bar,label}` (explicit screen-pixel geometry); the cap is a translator, not a layout engine. Registered in `with_common_caps` beside `TextCapability`, so it boots on desktop, headless, and test-bench, and a wasm guest reaches it via `ctx.actor::<UiCapability>()` exactly as it reaches `RenderCapability`.

Labels render screen-anchored: `on_label` maps the `UiLabel`'s `(x, y)` straight to `DrawText.origin` in `QuadSpace::Screen` — the screen-pixel offset that #1773 added to `aether.text.draw`, which this issue was bounced waiting on.

## Test plan

- Cap unit tests: a panel / bar / label each produces the expected forwarded `DrawSolidQuads` / `DrawText` mail; the label test decodes the payload and asserts `space == QuadSpace::Screen` and `origin == [x, y]`.
- Full `cargo nextest run --workspace` (1802 passed), clippy `--all-targets -D warnings` clean, doc clean, and `aether-camera` wasm32 cross-build clean.
- Guest-addressability (`ctx.actor::<UiCapability>()` from a wasm guest) is proven end-to-end by #1740's HUD port; this PR's coverage is native.

## Generated by

`/implement` — agent execution of [scoped issue #1738](https://github.com/iamacoffeepot/aether/issues/1738).
