### PR TITLE
docs(guide): serving-http recipe and reference handler component with end-to-end test

### DIFF
--- a/crates/aether-substrate-bundle/tests/http_serving.rs
+++ b/crates/aether-substrate-bundle/tests/http_serving.rs
@@ -1,0 +1,198 @@
+//! End-to-end smoke for the `aether.http.server` guest handler path
+//! (issue 1762, ADR-0108). Loads the `http_handler` fixture component
+//! into a headless chassis with `HttpServerCapability` bound, fires a
+//! real HTTP/1.1 request over a `TcpStream`, and asserts the returned
+//! status line and body. This proves the full stack:
+//!
+//! ```text
+//! TcpStream → HttpServerCapability → aether.component.load (wasm guest)
+//!           → HttpServerRequest dispatch → FfiActor::on_request
+//!           → HttpServerResponse reply → formatted HTTP/1.1 response
+//! ```
+//!
+//! Heavy: boots a full headless chassis with a real wasm guest, so it
+//! lives in `mod tests::heavy` and runs in the `serial-heavy` nextest
+//! group.  Skipped when `http_handler.wasm` hasn't been pre-built
+//! (`AETHER_REQUIRE_RUNTIME=1` flips the skip to a panic, same as the
+//! other wasm-gated integration tests).
+
+// Skip diagnostic goes to stderr so `cargo nextest` surfaces it
+// alongside `test ... ok`.
+#![allow(clippy::print_stderr)]
+
+use std::env;
+use std::fs;
+use std::io::{self, Read, Write};
+use std::net::TcpStream;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use aether_substrate_bundle::Chassis as _;
+use aether_substrate_bundle::PersistOverride;
+use aether_substrate_bundle::autoload::AutoloadComponent;
+use aether_substrate_bundle::capabilities::http::HttpConfig;
+use aether_substrate_bundle::capabilities::{
+    AnthropicConfig, GeminiConfig, HttpServerConfig, HttpServerHandle, WasmTrampoline,
+};
+use aether_substrate_bundle::headless::{HeadlessChassis, HeadlessEnv};
+use aether_substrate_bundle::test_bench::test_helpers::{
+    init_save_sandbox, locate_component_wasm, test_namespace_roots,
+};
+
+/// The `http_handler` fixture's `NAMESPACE` const — the subname under
+/// which `WasmTrampoline` registers it, and the last segment of its
+/// full lineage address (`aether.component/aether.embedded:web`).
+const HANDLER_NAMESPACE: &str = "web";
+
+/// The full handler mailbox address the http server cap resolves at
+/// dispatch time (ADR-0108 §3 late binding).
+const HANDLER_MAILBOX: &str = "aether.component/aether.embedded:web";
+
+/// Write the raw HTTP/1.1 `request` to `port` on loopback, read until
+/// EOF (the cap sends `Connection: close`), and return the raw response
+/// bytes. Mirrors the helper used in the `http_server.rs` cap unit tests.
+fn round_trip(port: u16, request: &[u8]) -> Vec<u8> {
+    let mut stream =
+        TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect to http server");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .expect("set_read_timeout");
+    stream.write_all(request).expect("write request");
+    stream.flush().expect("flush request");
+
+    let mut response = Vec::new();
+    let mut chunk = [0u8; 4096];
+    loop {
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(n) => response.extend_from_slice(&chunk[..n]),
+            Err(e)
+                if e.kind() == io::ErrorKind::WouldBlock || e.kind() == io::ErrorKind::TimedOut =>
+            {
+                break;
+            }
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(_) => break,
+        }
+    }
+    response
+}
+
+mod tests {
+    mod heavy {
+        use super::super::*;
+
+        /// Boot a headless chassis with `HttpServerCapability` bound (port 0,
+        /// OS picks) and the `http_handler` wasm fixture loaded via the autoload
+        /// path. Once the guest trampoline is live, send two real HTTP/1.1
+        /// requests over a `TcpStream` and assert:
+        ///
+        /// - `GET /` → `200 OK` with body `hello from aether`
+        /// - `GET /missing` → `404 Not Found`
+        #[test]
+        fn wasm_handler_serves_http_requests() {
+            let strict = env::var("AETHER_REQUIRE_RUNTIME").is_ok();
+            let Some(wasm_path) = locate_component_wasm("http_handler") else {
+                assert!(
+                    !strict,
+                    "AETHER_REQUIRE_RUNTIME set but http_handler.wasm not pre-built; \
+                 CI's `Pre-build component wasm for scenario tests` step is missing it",
+                );
+                eprintln!(
+                    "skipping: http_handler.wasm not built; \
+                 run `cargo build --target wasm32-unknown-unknown \
+                 -p aether-test-fixtures --examples`",
+                );
+                return;
+            };
+            let wasm = fs::read(&wasm_path).expect("read http_handler wasm");
+
+            let server_config = HttpServerConfig {
+                enabled: true,
+                bind_addr: "127.0.0.1:0".to_string(),
+                handler_mailbox: HANDLER_MAILBOX.to_string(),
+                max_request_bytes: 65_536,
+                max_header_bytes: 8_192,
+                request_timeout_millis: 10_000,
+            };
+
+            let sandbox = init_save_sandbox("http-serving");
+            let env = HeadlessEnv {
+                namespace_roots: test_namespace_roots(sandbox),
+                http: HttpConfig::default(),
+                http_server: Some(server_config),
+                anthropic: AnthropicConfig::default(),
+                gemini: GeminiConfig::default(),
+                tick_period: Duration::from_millis(100),
+                rpc_addr: None,
+                workers: None,
+                persist: PersistOverride::Argv(None),
+                handle_store_max_bytes: None,
+                autoload: vec![AutoloadComponent {
+                    wasm,
+                    config: Vec::new(),
+                    name: Some(HANDLER_NAMESPACE.to_owned()),
+                    export: None,
+                }],
+            };
+
+            let built =
+                HeadlessChassis::build(env).expect("build headless chassis with http server");
+
+            // Wait for the wasm handler trampoline to come up.
+            let deadline = Instant::now() + Duration::from_secs(30);
+            loop {
+                if built
+                    .resolve_actor::<WasmTrampoline>(HANDLER_NAMESPACE)
+                    .is_some()
+                {
+                    break;
+                }
+                assert!(
+                    Instant::now() < deadline,
+                    "http_handler trampoline did not register within 30s; \
+                 live trampolines: {:?}",
+                    built.resolve_actors::<WasmTrampoline>(),
+                );
+                thread::sleep(Duration::from_millis(25));
+            }
+
+            // Retrieve the OS-assigned port from the published handle.
+            let port = built
+                .handle::<HttpServerHandle>()
+                .expect("HttpServerHandle published by HttpServerCapability")
+                .local_port;
+            assert!(port > 0, "bound to an OS-assigned port");
+
+            // GET / → 200 with body "hello from aether"
+            let root_response = round_trip(
+                port,
+                b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+            );
+            let root_str = String::from_utf8_lossy(&root_response);
+            assert!(
+                root_str.starts_with("HTTP/1.1 200 "),
+                "GET / should reply 200, got: {root_str:?}",
+            );
+            assert!(
+                root_str.contains("hello from aether"),
+                "GET / body should contain 'hello from aether', got: {root_str:?}",
+            );
+
+            // GET /missing → 404
+            let miss_response = round_trip(
+                port,
+                b"GET /missing HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+            );
+            let miss_str = String::from_utf8_lossy(&miss_response);
+            assert!(
+                miss_str.starts_with("HTTP/1.1 404 "),
+                "GET /missing should reply 404, got: {miss_str:?}",
+            );
+            assert!(
+                miss_str.contains("not found"),
+                "GET /missing body should contain 'not found', got: {miss_str:?}",
+            );
+        }
+    }
+}

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -1409,6 +1409,17 @@ impl<C: Chassis> BuiltChassis<C> {
         &self.booted.actor_registry
     }
 
+    /// Retrieve a clone of a cap-published handle bundle of type `H`.
+    /// Mirrors [`PassiveChassis::handle`] for chassis that were built
+    /// with a driver (via [`Builder::build`]). `None` if no cap
+    /// published a handle of that type. Useful for embedder tests that
+    /// drive a full-stack chassis and need to read a cap's published
+    /// handle (e.g. `HttpServerHandle::local_port`).
+    #[must_use]
+    pub fn handle<H: Any + Send + Sync + Clone + 'static>(&self) -> Option<H> {
+        self.booted.handles.get::<H>()
+    }
+
     /// Block on the driver's run loop. On clean return, shut down
     /// every passive in reverse boot order. Driver errors propagate
     /// as [`RunError`]; passives still tear down before the error

--- a/crates/aether-test-fixtures/Cargo.toml
+++ b/crates/aether-test-fixtures/Cargo.toml
@@ -102,5 +102,13 @@ crate-type = ["cdylib"]
 name = "ui_widget"
 crate-type = ["cdylib"]
 
+# Issue 1762: reference HTTP handler fixture for the serving-http e2e
+# test and recipe. Handles `aether.http.server.request` with a path
+# match (/ → 200, else 404) and replies `aether.http.server.response`.
+# Wasm artifact: target/wasm32-unknown-unknown/{profile}/examples/http_handler.wasm
+[[example]]
+name = "http_handler"
+crate-type = ["cdylib"]
+
 [lints]
 workspace = true

--- a/crates/aether-test-fixtures/examples/http_handler.rs
+++ b/crates/aether-test-fixtures/examples/http_handler.rs
@@ -1,0 +1,61 @@
+//! Reference HTTP handler fixture for the `serving-http` e2e test and
+//! recipe (issue 1762, ADR-0108). Not a demo, not exemplary — its only
+//! job is to prove the `aether.http.server` guest load path end to end:
+//! `HttpServerCapability` dispatches an `HttpServerRequest` here; this
+//! actor path-matches and replies `HttpServerResponse`; the cap formats
+//! the HTTP/1.1 response and writes it to the client socket.
+//!
+//! Behaviour:
+//!
+//! - `GET /` → 200 `hello from aether`
+//! - Anything else → 404 `not found`
+//!
+//! Registered at `aether.component/aether.embedded:web` after load.
+//! The e2e test configures `HttpServerConfig.handler_mailbox` to that
+//! address and then fires real `TcpStream` requests at the bound port.
+
+// `#[handler]` methods take their decoded payload by value per the
+// ADR-0033 dispatch ABI; the macro-generated trampoline owns the decoded
+// bytes so callers can't see references. A stateless handler that
+// ignores `self` is correct but triggers `unused_self`.
+#![allow(clippy::needless_pass_by_value, clippy::unused_self)]
+
+use aether_actor::{BootError, FfiActor, FfiCtx, OutboundReply, Resolver, actor};
+use aether_kinds::{HttpServerRequest, HttpServerResponse};
+
+pub struct HttpHandler;
+
+#[actor]
+impl FfiActor for HttpHandler {
+    const NAMESPACE: &'static str = "web";
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
+    where
+        C: Resolver,
+    {
+        Ok(HttpHandler)
+    }
+
+    /// Route an inbound HTTP request to a status + body and reply the
+    /// formatted response. The HTTP server cap writes the reply to the
+    /// waiting client socket.
+    ///
+    /// # Agent
+    /// Not sent manually — the `aether.http.server` cap dispatches it
+    /// on every inbound request. Configure `HttpServerConfig.handler_mailbox`
+    /// to `"aether.component/aether.embedded:web"` to route here.
+    #[handler]
+    fn on_request(&mut self, ctx: &mut FfiCtx<'_>, req: HttpServerRequest) {
+        let (status, body): (u16, &[u8]) = match req.path.as_str() {
+            "/" => (200, b"hello from aether"),
+            _ => (404, b"not found"),
+        };
+        ctx.reply(&HttpServerResponse {
+            status,
+            headers: Vec::new(),
+            body: body.to_vec(),
+        });
+    }
+}
+
+aether_actor::export!(HttpHandler);

--- a/docs/guide/recipes/serving-http.md
+++ b/docs/guide/recipes/serving-http.md
@@ -1,0 +1,134 @@
+# Serving HTTP from a component
+
+**Class: recompile.** You're writing a wasm component that handles inbound
+HTTP requests — `cargo` plus the pre-flight loop. The `aether.http.server`
+capability (ADR-0108) binds the listening socket; you write the handler that
+receives `aether.http.server.request` and replies
+`aether.http.server.response`.
+
+## 1. Configure the server
+
+The HTTP server is opt-in (off by default). Set `AETHER_HTTP_SERVER_ENABLED=1`
+to turn it on, and point it at the component mailbox your handler will register
+at:
+
+```sh
+AETHER_HTTP_SERVER_ENABLED=1 \
+AETHER_HTTP_SERVER_BIND_ADDR=127.0.0.1:8080 \
+AETHER_HTTP_SERVER_HANDLER_MAILBOX=aether.component/aether.embedded:web \
+cargo run -p aether-substrate-bundle --bin aether-substrate-headless
+```
+
+`AETHER_HTTP_SERVER_BIND_ADDR` defaults to `127.0.0.1:8080`; use port `0` to
+let the OS pick a free port. `AETHER_HTTP_SERVER_HANDLER_MAILBOX` is the late-
+bound mailbox name (ADR-0108 §3): the server resolves it at dispatch time, so
+the handler component can load or reload without restarting the server.
+
+## 2. Write the handler
+
+A handler is a wasm component with one `#[handler]` for
+`aether.http.server.request`. It replies `aether.http.server.response` with a
+status code, optional headers, and a byte body. The server writes the formatted
+HTTP/1.1 response to the client socket and closes the connection.
+
+```rust
+use aether_actor::{BootError, FfiActor, FfiCtx, OutboundReply, Resolver, actor};
+use aether_kinds::{HttpServerRequest, HttpServerResponse};
+
+pub struct Web;
+
+#[actor]
+impl FfiActor for Web {
+    const NAMESPACE: &'static str = "web";
+
+    fn init<C: Resolver>(_ctx: &mut C) -> Result<Self, BootError> {
+        Ok(Web)
+    }
+
+    #[handler]
+    fn on_request(&mut self, ctx: &mut FfiCtx<'_>, req: HttpServerRequest) {
+        let (status, body): (u16, &[u8]) = match req.path.as_str() {
+            "/" => (200, b"hello"),
+            _ => (404, b"not found"),
+        };
+        ctx.reply(&HttpServerResponse {
+            status,
+            headers: Vec::new(),
+            body: body.to_vec(),
+        });
+    }
+}
+
+aether_actor::export!(Web);
+```
+
+The component registers at `aether.component/aether.embedded:web` (its
+`NAMESPACE` const rendered through the ADR-0099 lineage), which is the same
+address you put in `AETHER_HTTP_SERVER_HANDLER_MAILBOX`.
+
+## 3. Load the handler
+
+Load the handler component with `load_component` over the MCP harness once the
+substrate is up:
+
+```jsonc
+// load_component
+{
+  "engine_id": "<engine>",
+  "binary_path": "/path/to/web.wasm"
+}
+```
+
+`load_component` replies `LoadResult.Ok` with the registered mailbox name
+(`aether.component/aether.embedded:web`). After that, any inbound HTTP request
+on the bound port routes to your handler.
+
+## 4. Send a request
+
+From a shell, or from any HTTP client that speaks HTTP/1.1:
+
+```sh
+curl http://127.0.0.1:8080/
+# → hello
+```
+
+The server reads the request, dispatches `aether.http.server.request` to the
+handler mailbox, waits for the `aether.http.server.response` reply, and writes
+the formatted response to the client. The server adds `Connection: close` and
+an appropriate `Content-Length` header; your handler sets the status code,
+optional extra headers, and the body.
+
+## What happens when the handler doesn't reply
+
+If the handler receives the request but returns without calling `ctx.reply`, the
+settled chain triggers the `502 Bad Gateway` safety net. If the handler takes
+longer than `AETHER_HTTP_SERVER_REQUEST_TIMEOUT_MILLIS` (default 30 000 ms), the
+server sends `504 Gateway Timeout`. A missing handler mailbox (nothing loaded
+yet) returns `503 Service Unavailable`.
+
+## Adding response headers
+
+Pass a `Vec<HttpHeader>` in the reply:
+
+```rust
+use aether_kinds::HttpHeader;
+
+ctx.reply(&HttpServerResponse {
+    status: 200,
+    headers: vec![HttpHeader {
+        name: "content-type".to_string(),
+        value: "application/json".to_string(),
+    }],
+    body: br#"{"ok":true}"#.to_vec(),
+});
+```
+
+The server sends these after its own `Connection: close` and `Content-Length`
+headers.
+
+## Verify against current code
+
+This recipe names the env keys and kind names live in the source. Before
+following it, confirm `AETHER_HTTP_SERVER_ENABLED`, `HttpServerRequest`,
+`HttpServerResponse`, and `HttpServerConfig` still exist where named — grep the
+crates, and if a name has drifted, fix the recipe as part of your work.


### PR DESCRIPTION
Closes #1762.

## Summary

Documents how to serve HTTP requests as mail through the `aether.http.server` capability (#1760) registered on the chassis (#1761), with a runnable reference handler and an end-to-end test that proves the path:

- **`crates/aether-test-fixtures/examples/http_handler.rs`** — a reference handler component: receives the cap's request mail, replies with a response.
- **`crates/aether-substrate-bundle/tests/http_serving.rs`** — an e2e integration test that boots the chassis with the http server cap, issues a real request, and asserts the handler's response round-trips.
- **`docs/guide/recipes/serving-http.md`** — the recipe walking a reader from load to first served request.
- A small `chassis/builder.rs` touch to wire the fixture into the test boot.

## Test plan

- `cargo nextest run --workspace` (full preflight) passes, including the new `http_serving` e2e test.
- clippy `--all-targets -D warnings`, doc, and wasm32 component cross-build all clean.

## Generated by

`/implement` — agent execution of [scoped issue #1762](https://github.com/iamacoffeepot/aether/issues/1762). (Agent implemented and committed; parent ran preflight + opened the PR after the agent reached its context limit on the follow-on issue.)
