### PR TITLE
refactor(capabilities): standardize opt-in capabilities on a config-driven enabled flag

### DIFF
--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -553,4 +553,35 @@ mod tests {
         assert!(dump.contains("AETHER_WORKERS")); // bare chassis knob
         assert!(dump.contains("AETHER_LOCAL_STICKY_MAX")); // scheduler knob
     }
+
+    /// Regression guard for the enable / disable convention (#1791): a
+    /// capability's enable/disable flag is resolved through its
+    /// derive-`Config` (`*Config::from_argv_then_env`), never a raw
+    /// `env::var` read in a chassis builder. This is the shape #1761 put
+    /// the http server on; the guard keeps a future cap from regressing to
+    /// presence-inference or a hand-rolled env read.
+    ///
+    /// Scoped to the cap *flag* keys on purpose — `AETHER_WINDOW_MODE` /
+    /// `AETHER_WINDOW_TITLE` are hand-parsed desktop boot overrides, not
+    /// derive-`Config` knobs, and are read via `env::var` by design, so a
+    /// blanket "no `env::var` of a known key" scan would false-positive.
+    #[test]
+    fn chassis_builders_resolve_cap_enable_flags_via_config() {
+        // Enable / disable env keys owned by a derive-`Config` cap. Add a
+        // cap's flag key here when a new opt-in / opt-out cap lands.
+        const CAP_FLAG_KEYS: &[&str] = &["AETHER_HTTP_SERVER_ENABLED", "AETHER_AUDIO_DISABLE"];
+        let desktop = include_str!("desktop/chassis.rs");
+        let headless = include_str!("headless/chassis.rs");
+        for key in CAP_FLAG_KEYS {
+            let raw_read = format!("env::var(\"{key}\")");
+            for (chassis, src) in [("desktop", desktop), ("headless", headless)] {
+                assert!(
+                    !src.contains(&raw_read),
+                    "{chassis} chassis reads {key} via raw env::var — route it through the \
+                     cap's config API instead (see the `config` module's \
+                     \"Enable / disable convention\")",
+                );
+            }
+        }
+    }
 }

--- a/crates/aether-substrate/src/config.rs
+++ b/crates/aether-substrate/src/config.rs
@@ -40,6 +40,31 @@
 //! derive emits an impl of it. Hand-written impls remain valid where
 //! the derive doesn't fit.
 //!
+//! # Enable / disable convention
+//!
+//! A capability that is off (or on) by default carries its on/off state
+//! as a single config-API `bool` field. It is resolved like every other
+//! knob — through the derive, with a literal `false` default — so the
+//! decision flows from one documented `AETHER_…` key (or its CLI flag),
+//! never from presence-inference (a bound address, a configured path) and
+//! never from a raw `env::var` read of a key the config layer already
+//! owns:
+//!
+//! ```ignore
+//! #[cfg_attr(feature = "native", config(default = false, parse = parse_flag))]
+//! pub enabled: bool,
+//! ```
+//!
+//! Polarity follows intent rather than a fixed keyword. An opt-in cap —
+//! off until asked for — names the field `enabled`; an opt-out cap — on
+//! until suppressed — names it `disabled`. Both default to `false`, so
+//! the literal default always reads as the unsurprising state, and the
+//! chassis maps the resolved `bool` to its structural choice at the one
+//! composition site (`cfg.enabled.then_some(cfg)`). The `parse_flag`
+//! helper accepts the usual `1` / `true` / `yes` / `on` spellings.
+//! `PersistConfig` is the documented exception below; every other cap
+//! follows this shape.
+//!
 //! # Why not `PersistConfig` too?
 //!
 //! `aether_substrate::handle_store::PersistConfig::from_argv_then_env`

--- a/docs/guide/recipes/adding-a-config-knob.md
+++ b/docs/guide/recipes/adding-a-config-knob.md
@@ -29,6 +29,31 @@ which is the common case — the struct's layer is already registered for
 discovery, so a new field joins the `--config` dump for free. Adding a
 **brand-new** config struct takes two extra steps, called out at the end.
 
+## Enable / disable flags
+
+A capability that ships off (or on) by default exposes that switch as one
+config-API `bool`, resolved through the same derive as every other knob —
+not inferred from another field (a bound address, a configured path) and
+not read out of `env::var` directly. Declare it with a `false` literal
+default and the shared `parse_flag` parser:
+
+```rust
+#[cfg_attr(feature = "native", config(default = false, parse = parse_flag))]
+pub enabled: bool,
+```
+
+Name it for the intent: an opt-in cap that stays off until asked for calls
+the field `enabled`, while an opt-out cap that runs until suppressed calls
+it `disabled`. Both default to `false`, so the literal default reads as the
+unsurprising state, and a chassis turns the behaviour on from one
+documented `AETHER_…` key (or its CLI flag). At the composition site the
+chassis maps the resolved flag to its structural choice —
+`cfg.enabled.then_some(cfg)` for an opt-in cap — keeping the flag the
+single source of the on/off decision. `parse_flag` (in
+`aether-capabilities/src/config_env.rs`) accepts `1` / `true` / `yes` /
+`on`. `PersistConfig` is the one documented exception, for the reasons its
+`config` module doc records.
+
 ## Steps
 
 ### 1. Declare the field with a `#[config(...)]` hint


### PR DESCRIPTION
Closes #1791.

## Summary

Writes down the enable/disable convention for opt-in / opt-out capabilities and adds a regression guard. The convention: a capability's on/off state is a single config-API `bool` resolved through the derive with a `false` literal default, polarity by intent (`enabled` for opt-in, `disabled` for opt-out), never presence-inference and never a raw `env::var` read of a key the config layer already owns.

- **`crates/aether-substrate/src/config.rs`** — an "Enable / disable convention" section in the module doc, beside "Preferred shape" and the `PersistConfig` exception.
- **`docs/guide/recipes/adding-a-config-knob.md`** — an "Enable / disable flags" section for cap authors.
- **`crates/aether-substrate-bundle/src/chassis_common.rs`** — a regression guard test asserting a cap's enable/disable flag is resolved through its `Config`, not a raw `env::var` read in a chassis builder.

The audit comes out clean and is the bulk of the value: the http server conforms after #1761, audio already conforms (`disabled: bool`, `default = false`, `parse_flag`), and `PersistConfig` is the one documented exception (its structural inputs don't fit confique's literal-default model). No behavior change to any capability.

## Note on the regression guard

The plan sketched a guard that scans the chassis builders for *any* `env::var` of a key in `chassis_known_keys()`. That proved brittle exactly as the plan anticipated: the desktop chassis reads `AETHER_WINDOW_MODE` / `AETHER_WINDOW_TITLE` via raw `env::var` by design — they're hand-parsed boot overrides, not derive-`Config` knobs, and both are registered keys — so a blanket scan false-positives. Rather than drop the guard, I narrowed it to the actual regression class: a cap's *enable/disable flag* read via raw `env::var` in a chassis builder. That stays robust and still catches the #1761 mistake recurring.

## Test plan

- The new `chassis_builders_resolve_cap_enable_flags_via_config` guard passes (the http server + audio flags are resolved via config, not raw env).
- Full `scripts/preflight.sh` (fmt + clippy + nextest + doc) passes; the doc build is the main gate for the convention text.

## Generated by

`/implement` — agent execution of [scoped issue #1791](https://github.com/iamacoffeepot/aether/issues/1791). (The dispatched agent reached its context limit before starting this issue; the parent session implemented it in-session.)
