### PR TITLE
feat(actor): handler return type as a synchronous reply contract

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -49,8 +49,8 @@ use syn::parse::Parser;
 use syn::spanned::Spanned;
 use syn::{
     Attribute, Data, DataEnum, DataStruct, DeriveInput, Expr, ExprLit, Fields, FnArg,
-    GenericArgument, ImplItem, Item, ItemImpl, ItemMod, Lit, Meta, PathArguments, Signature, Type,
-    parse_macro_input,
+    GenericArgument, ImplItem, Item, ItemImpl, ItemMod, Lit, Meta, PathArguments, ReturnType,
+    Signature, Type, parse_macro_input,
 };
 
 #[proc_macro_derive(Kind, attributes(kind))]
@@ -1508,6 +1508,10 @@ struct HandlerFn {
     method: syn::ImplItemFn,
     kind_ty: Type,
     agent_doc: Option<String>,
+    /// ADR-0109: the handler's reply contract, classified from its
+    /// return type. Drives the auto-emitted `ctx.reply` and the reply
+    /// kind id on the inputs manifest record.
+    reply: HandlerReply,
 }
 
 struct FallbackFn {
@@ -1793,11 +1797,13 @@ fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
                     }
                     let kind_ty = extract_handler_kind_type(&f.sig)?;
                     let agent_doc = extract_agent_doc(&f.attrs);
+                    let reply = classify_handler_reply(&f.sig.output);
                     f.attrs.remove(idx);
                     handlers.push(HandlerFn {
                         method: f,
                         kind_ty,
                         agent_doc,
+                        reply,
                     });
                 } else if let Some(idx) = fallback_attr_idx {
                     if fallback.is_some() {
@@ -2176,10 +2182,12 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
                     match variant {
                         HandlerVariant::Mail => {
                             let (kind_ty, is_slice) = extract_native_actor_handler_kind(&f.sig)?;
+                            let reply = classify_handler_reply(&f.sig.output);
                             handlers.push(NativeActorHandlerFn {
                                 method: f,
                                 kind_ty,
                                 is_slice,
+                                reply,
                             });
                         }
                         HandlerVariant::Task => {
@@ -2408,6 +2416,20 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
     let dispatch_arms = handlers.iter().map(|h| {
         let kind_ty = &h.kind_ty;
         let method_ident = &h.method.sig.ident;
+        // ADR-0109: a `-> R` handler auto-replies its return value
+        // through `OutboundReply::reply` (UFCS so the trait need not be
+        // imported at the emission site). `-> ()` and `-> Pending<R>`
+        // discard the return value — the deferred `Pending` send is the
+        // follow-on (#1805).
+        let call = match &h.reply {
+            HandlerReply::Sync(_) => quote! {
+                let __aether_reply = self.#method_ident(__aether_ctx, __aether_decoded);
+                ::aether_actor::OutboundReply::reply(__aether_ctx, &__aether_reply);
+            },
+            HandlerReply::None | HandlerReply::Deferred(_) => quote! {
+                self.#method_ident(__aether_ctx, __aether_decoded);
+            },
+        };
         if h.is_slice {
             // Slice handler — payload is `count * size_of::<K>()`
             // contiguous bytes (ADR-0019 batch wire). Cast to `&[K]`
@@ -2418,7 +2440,7 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
                     if let Some(__aether_decoded) =
                         ::aether_data::__derive_runtime::decode_cast_slice::<#kind_ty>(__aether_payload)
                     {
-                        self.#method_ident(__aether_ctx, __aether_decoded);
+                        #call
                         return ::core::option::Option::Some(());
                     }
                     return ::core::option::Option::None;
@@ -2430,7 +2452,7 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
                     if let Some(__aether_decoded) =
                         <#kind_ty as ::aether_data::Kind>::decode_from_bytes(__aether_payload)
                     {
-                        self.#method_ident(__aether_ctx, __aether_decoded);
+                        #call
                         return ::core::option::Option::Some(());
                     }
                     return ::core::option::Option::None;
@@ -2520,11 +2542,16 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
     // so this is independent of rustdoc extraction.
     let capability_handler_entries = handlers.iter().map(|h| {
         let kind_ty = &h.kind_ty;
+        // ADR-0109 §5: native chassis caps don't yet surface a
+        // per-handler reply contract — that needs a native handler
+        // manifest (a follow-on). Leave `reply: None` until then; the
+        // wasm `describe_component` path carries the contract today.
         quote! {
             ::aether_substrate::actor::native::HandlerCapability {
                 id: <#kind_ty as ::aether_data::Kind>::ID,
                 name: <#kind_ty as ::aether_data::Kind>::NAME.to_owned(),
                 doc: ::core::option::Option::None,
+                reply: ::core::option::Option::None,
             }
         }
     });
@@ -2613,6 +2640,10 @@ struct NativeActorHandlerFn {
     /// than `K`. The dispatcher decodes via `decode_cast_slice` so a
     /// single envelope with `count > 1` reaches the handler intact.
     is_slice: bool,
+    /// ADR-0109: the handler's reply contract, classified from its
+    /// return type. A `-> R` native handler auto-replies `R` through
+    /// `OutboundReply::reply`, the same path a manual `ctx.reply` takes.
+    reply: HandlerReply,
 }
 
 /// A `#[handler(task)]` completion handler (ADR-0093 §3). Its third
@@ -2764,6 +2795,65 @@ fn extract_handler_kind_type(sig: &Signature) -> syn::Result<Type> {
     Ok((*pt.ty).clone())
 }
 
+/// ADR-0109: a `#[handler]`'s reply contract, read off its return type.
+/// The return type is the single source of truth for what a handler
+/// replies — there is no separate `#[handler(reply = X)]` annotation.
+enum HandlerReply {
+    /// `-> ()` or no return type — fire-and-forget, replies nothing.
+    None,
+    /// `-> R: Kind` — reply `R` to the inbound sender synchronously on
+    /// handler return, routed through the inbound guard's reply path.
+    Sync(Type),
+    /// `-> Pending<R>` — `R` is the deferred reply kind, discharged
+    /// later via ADR-0093's hold ledger. The classifier recognizes the
+    /// shape and publishes `R` to the manifest; the deferred send
+    /// itself is wired in a follow-on (iamacoffeepot/aether#1805), so no
+    /// synchronous reply is emitted for this arm here.
+    Deferred(Type),
+}
+
+impl HandlerReply {
+    /// The reply kind published to the `aether.kinds.inputs` manifest:
+    /// `R` for both the synchronous and deferred arms (ADR-0109 §4 reads
+    /// the inner `R` off `-> Pending<R>`), `None` for `-> ()`.
+    fn manifest_kind(&self) -> Option<&Type> {
+        match self {
+            Self::None => None,
+            Self::Sync(ty) | Self::Deferred(ty) => Some(ty),
+        }
+    }
+}
+
+/// Classify a handler's return type into a [`HandlerReply`] (ADR-0109).
+/// `-> ()` (or an omitted return) is fire-and-forget; `-> Pending<R>`
+/// — a path whose last segment is `Pending<R>` — is the deferred arm;
+/// anything else is a synchronous `-> R` reply. The classifier is
+/// purely syntactic (the macro has no type resolution): `R`'s `Kind`
+/// bound is checked at the generated `ctx.reply(&r)` call site / the
+/// `<R as Kind>::ID` manifest term.
+fn classify_handler_reply(output: &ReturnType) -> HandlerReply {
+    let ty = match output {
+        ReturnType::Default => return HandlerReply::None,
+        ReturnType::Type(_, ty) => ty.as_ref(),
+    };
+    // `-> ()` — the empty tuple — replies nothing, same as no return.
+    if let Type::Tuple(tuple) = ty
+        && tuple.elems.is_empty()
+    {
+        return HandlerReply::None;
+    }
+    // `-> Pending<R>` — last path segment `Pending` with one type arg.
+    if let Type::Path(type_path) = ty
+        && let Some(seg) = type_path.path.segments.last()
+        && seg.ident == "Pending"
+        && let PathArguments::AngleBracketed(args) = &seg.arguments
+        && let Some(GenericArgument::Type(inner)) = args.args.first()
+    {
+        return HandlerReply::Deferred(inner.clone());
+    }
+    HandlerReply::Sync(ty.clone())
+}
+
 /// Soft validation that a `#[fallback]` method's signature is shaped
 /// for `Mail<'_>`. We don't do deep type equality against
 /// `::aether_actor::Mail<'_>` — the synthesized dispatcher's call
@@ -2806,6 +2896,20 @@ fn build_dispatch_body(handlers: &[HandlerFn], fallback: Option<&FallbackFn>) ->
     let arms = handlers.iter().map(|h| {
         let k = &h.kind_ty;
         let method = &h.method.sig.ident;
+        // ADR-0109: a `-> R` handler replies its return value through
+        // `OutboundReply::reply` (UFCS so the trait need not be in scope
+        // at the emission site) — the same discharge path a manual
+        // `ctx.reply` takes. `-> ()` and `-> Pending<R>` discard the
+        // return value (the deferred `Pending` send is #1805).
+        let call = match &h.reply {
+            HandlerReply::Sync(_) => quote! {
+                let __aether_reply = self.#method(__aether_ctx, __aether_decoded);
+                ::aether_actor::OutboundReply::reply(__aether_ctx, &__aether_reply);
+            },
+            HandlerReply::None | HandlerReply::Deferred(_) => quote! {
+                self.#method(__aether_ctx, __aether_decoded);
+            },
+        };
         // `Mail::kind()` returns the raw `u64` the FFI carried; `Kind::ID`
         // is typed `KindId` post-issue 466, so we drop into `.0` for the
         // comparison.
@@ -2814,7 +2918,7 @@ fn build_dispatch_body(handlers: &[HandlerFn], fallback: Option<&FallbackFn>) ->
                 if let ::core::option::Option::Some(__aether_decoded) =
                     __aether_mail.decode_kind::<#k>()
                 {
-                    self.#method(__aether_ctx, __aether_decoded);
+                    #call
                 }
                 return ::aether_actor::DISPATCH_HANDLED;
             }
@@ -2848,7 +2952,7 @@ fn build_dispatch_body(handlers: &[HandlerFn], fallback: Option<&FallbackFn>) ->
 /// `__AETHER_INPUTS_MANIFEST_LEN: usize` and
 /// `__AETHER_INPUTS_MANIFEST: [u8; …LEN]` — carrying the
 /// concatenated `aether.kinds.inputs` record bytes. Each record is
-/// `[INPUTS_SECTION_VERSION (0x02), ..postcard(InputsRecord)..]`,
+/// `[INPUTS_SECTION_VERSION (0x03), ..postcard(InputsRecord)..]`,
 /// assembled at const-eval via the hub-protocol const-fn encoders.
 /// `aether_actor::export!()` reads these consts and emits the
 /// `#[unsafe(link_section = "aether.kinds.inputs")]` static in the
@@ -2872,6 +2976,18 @@ fn build_inputs_manifest_consts(
     for h in handlers {
         let k = &h.kind_ty;
         let doc_expr = option_str_token(h.agent_doc.as_ref());
+        // ADR-0109: the reply kind id rides the handler record as an
+        // `Option<u64>` — `Some(<R as Kind>::ID.0)` for a `-> R` or
+        // `-> Pending<R>` handler (the inner `R`), `None` for `-> ()`.
+        let reply_expr = if let Some(r) = h.reply.manifest_kind() {
+            quote! {
+                ::core::option::Option::Some(
+                    <#r as ::aether_actor::__macro_internals::Kind>::ID.0
+                )
+            }
+        } else {
+            quote! { ::core::option::Option::None }
+        };
         // `inputs_handler_len` / `write_inputs_handler` take a raw `u64`
         // for the wire bytes; `Kind::ID` is `KindId` post-issue 466 so
         // we drop into `.0` here.
@@ -2880,6 +2996,7 @@ fn build_inputs_manifest_consts(
                 <#k as ::aether_actor::__macro_internals::Kind>::ID.0,
                 <#k as ::aether_actor::__macro_internals::Kind>::NAME,
                 #doc_expr,
+                #reply_expr,
             ))
         });
         copy_blocks.push(quote! {
@@ -2889,17 +3006,20 @@ fn build_inputs_manifest_consts(
                         <#k as ::aether_actor::__macro_internals::Kind>::ID.0,
                         <#k as ::aether_actor::__macro_internals::Kind>::NAME,
                         #doc_expr,
+                        #reply_expr,
                     );
                 const REC_BYTES: [u8; REC_LEN] =
                     ::aether_actor::__macro_internals::canonical::write_inputs_handler::<REC_LEN>(
                         <#k as ::aether_actor::__macro_internals::Kind>::ID.0,
                         <#k as ::aether_actor::__macro_internals::Kind>::NAME,
                         #doc_expr,
+                        #reply_expr,
                     );
-                // ADR-0090 (issue 1257): per-record section version byte
-                // bumped 0x01 -> 0x02 alongside the new `Config` variant.
-                // Keep this in lockstep with `INPUTS_SECTION_VERSION`.
-                out[pos] = 0x02;
+                // Per-record section version byte, bumped to 0x03 by
+                // ADR-0109 (issue 1803) — the `Handler` variant gained
+                // the `reply` kind id. Keep in lockstep with
+                // `INPUTS_SECTION_VERSION`.
+                out[pos] = 0x03;
                 pos += 1;
                 let mut i = 0;
                 while i < REC_LEN {
@@ -2922,10 +3042,11 @@ fn build_inputs_manifest_consts(
                     ::aether_actor::__macro_internals::canonical::inputs_fallback_len(#doc_expr);
                 const REC_BYTES: [u8; REC_LEN] =
                     ::aether_actor::__macro_internals::canonical::write_inputs_fallback::<REC_LEN>(#doc_expr);
-                // ADR-0090 (issue 1257): per-record section version byte
-                // bumped 0x01 -> 0x02 alongside the new `Config` variant.
-                // Keep this in lockstep with `INPUTS_SECTION_VERSION`.
-                out[pos] = 0x02;
+                // Per-record section version byte, bumped to 0x03 by
+                // ADR-0109 (issue 1803) — the `Handler` variant gained
+                // the `reply` kind id. Keep in lockstep with
+                // `INPUTS_SECTION_VERSION`.
+                out[pos] = 0x03;
                 pos += 1;
                 let mut i = 0;
                 while i < REC_LEN {
@@ -2948,10 +3069,11 @@ fn build_inputs_manifest_consts(
                     ::aether_actor::__macro_internals::canonical::inputs_component_len(#doc_lit);
                 const REC_BYTES: [u8; REC_LEN] =
                     ::aether_actor::__macro_internals::canonical::write_inputs_component::<REC_LEN>(#doc_lit);
-                // ADR-0090 (issue 1257): per-record section version byte
-                // bumped 0x01 -> 0x02 alongside the new `Config` variant.
-                // Keep this in lockstep with `INPUTS_SECTION_VERSION`.
-                out[pos] = 0x02;
+                // Per-record section version byte, bumped to 0x03 by
+                // ADR-0109 (issue 1803) — the `Handler` variant gained
+                // the `reply` kind id. Keep in lockstep with
+                // `INPUTS_SECTION_VERSION`.
+                out[pos] = 0x03;
                 pos += 1;
                 let mut i = 0;
                 while i < REC_LEN {
@@ -2987,7 +3109,9 @@ fn build_inputs_manifest_consts(
                         <#cfg as ::aether_actor::__macro_internals::Kind>::ID.0,
                         <#cfg as ::aether_actor::__macro_internals::Kind>::NAME,
                     );
-                out[pos] = 0x02;
+                // Per-record section version byte (0x03), in lockstep
+                // with `INPUTS_SECTION_VERSION` (ADR-0109 / issue 1803).
+                out[pos] = 0x03;
                 pos += 1;
                 let mut i = 0;
                 while i < REC_LEN {

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -904,9 +904,9 @@ macro_rules! __export_multi_internal {
                         $crate::__macro_internals::canonical::write_inputs_actor_boundary::<BOUNDARY_LEN>(
                             <$component as $crate::Actor>::NAMESPACE,
                         );
-                    // Per-record section version byte (0x02), in lockstep
-                    // with `INPUTS_SECTION_VERSION`.
-                    out[pos] = 0x02;
+                    // Per-record section version byte (0x03), in lockstep
+                    // with `INPUTS_SECTION_VERSION` (ADR-0109 / issue 1803).
+                    out[pos] = 0x03;
                     pos += 1;
                     let mut i = 0;
                     while i < BOUNDARY_LEN {

--- a/crates/aether-actor/tests/handlers_manifest.rs
+++ b/crates/aether-actor/tests/handlers_manifest.rs
@@ -38,6 +38,13 @@ struct Ping {
     seq: u32,
 }
 
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable, aether_data::Kind, aether_data::Schema)]
+#[kind(name = "test.pong")]
+struct Pong {
+    seq: u32,
+}
+
 // Minimal fixture, mirrored from `examples/hello.rs`. Lives here as a
 // duplicate (rather than reused) because `examples/*.rs` declare
 // `crate-type = ["cdylib"]` and only build for `wasm32-unknown-unknown`
@@ -63,8 +70,13 @@ impl FfiActor for ManifestProbe {
     #[handler]
     fn on_tick(&mut self, _ctx: &mut FfiCtx<'_>, _tick: Tick) {}
 
+    // ADR-0109: a `-> R` handler — the return type is the reply
+    // contract, so the macro auto-replies `Pong` and threads its kind id
+    // onto this handler's inputs-manifest record.
     #[handler]
-    fn on_ping(&mut self, _ctx: &mut FfiCtx<'_>, _ping: Ping) {}
+    fn on_ping(&mut self, _ctx: &mut FfiCtx<'_>, ping: Ping) -> Pong {
+        Pong { seq: ping.seq }
+    }
 
     /// # Agent
     /// Catch-all for anything else.
@@ -106,15 +118,29 @@ fn manifest_const_round_trips_to_expected_records() {
 
     for rec in &records {
         match rec {
-            InputsRecord::Handler { id, name, doc } => {
+            InputsRecord::Handler {
+                id,
+                name,
+                doc,
+                reply,
+            } => {
                 handler_count += 1;
                 match name.as_ref() {
                     "test.tick" => {
                         assert_eq!(*id, <Tick as Kind>::ID);
                         tick_doc = doc.as_ref().map(ToString::to_string);
+                        // ADR-0109: a `-> ()` handler declares no reply.
+                        assert_eq!(*reply, None, "on_tick returns () — no reply kind");
                     }
                     "test.ping" => {
                         assert_eq!(*id, <Ping as Kind>::ID);
+                        // ADR-0109: a `-> Pong` handler publishes Pong's
+                        // kind id as its reply contract.
+                        assert_eq!(
+                            *reply,
+                            Some(<Pong as Kind>::ID),
+                            "on_ping returns Pong — its reply kind rides the manifest"
+                        );
                     }
                     other => panic!("unexpected handler name: {other}"),
                 }

--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -125,7 +125,6 @@ mod native {
 
     use aether_actor::Actor;
     use aether_actor::actor;
-    use aether_actor::actor::ctx::OutboundReply;
     use aether_data::Kind;
     use aether_kinds::{ComponentCapabilities, LoadResult};
     use wasmtime::{Engine, Linker, Module};
@@ -220,9 +219,15 @@ mod native {
         /// invalid wasm, instantiation trap) come back as
         /// `LoadResult::Err`.
         #[handler]
-        fn on_load_component(&mut self, ctx: &mut NativeCtx<'_>, payload: LoadComponent) {
-            let result = self.handle_load(ctx, payload);
-            ctx.reply(&result);
+        fn on_load_component(
+            &mut self,
+            ctx: &mut NativeCtx<'_>,
+            payload: LoadComponent,
+        ) -> LoadResult {
+            // ADR-0109: the return type is the reply contract — the
+            // `#[actor]` macro routes this `LoadResult` back to the sender
+            // through `OutboundReply::reply`, so no manual `ctx.reply`.
+            self.handle_load(ctx, payload)
         }
 
         /// Drop a component by its mailbox id. Forwards

--- a/crates/aether-data/src/canonical/inputs.rs
+++ b/crates/aether-data/src/canonical/inputs.rs
@@ -9,26 +9,36 @@
 //! `postcard::take_from_bytes` symmetrically.
 
 use super::primitives::{
-    option_borrowed_str_len, str_len, varint_u64_len, write_option_borrowed_str, write_str,
-    write_varint_u64,
+    option_borrowed_str_len, option_varint_u64_len, str_len, varint_u64_len,
+    write_option_borrowed_str, write_option_varint_u64, write_str, write_varint_u64,
 };
 
 /// Byte length of a `Handler` record's postcard encoding. One-byte
 /// enum-variant tag (`0x00`) + `varint(id)` + `postcard(name)` +
-/// `option_str(doc)`.
+/// `option_str(doc)` + `option_varint(reply)` — the ADR-0109 reply
+/// kind id (`None` for a `-> ()` handler).
 #[must_use]
-pub const fn inputs_handler_len(id: u64, name: &str, doc: Option<&str>) -> usize {
-    1 + varint_u64_len(id) + str_len(name) + option_borrowed_str_len(doc)
+pub const fn inputs_handler_len(
+    id: u64,
+    name: &str,
+    doc: Option<&str>,
+    reply: Option<u64>,
+) -> usize {
+    1 + varint_u64_len(id)
+        + str_len(name)
+        + option_borrowed_str_len(doc)
+        + option_varint_u64_len(reply)
 }
 
 /// Serialize an `InputsRecord::Handler` into a fixed-size array sized
 /// by `inputs_handler_len`. Exact postcard wire shape for
-/// `InputsRecord::Handler { id, name, doc }`.
+/// `InputsRecord::Handler { id, name, doc, reply }`.
 #[must_use]
 pub const fn write_inputs_handler<const N: usize>(
     id: u64,
     name: &str,
     doc: Option<&str>,
+    reply: Option<u64>,
 ) -> [u8; N] {
     let mut out = [0u8; N];
     let mut pos = 0usize;
@@ -37,6 +47,7 @@ pub const fn write_inputs_handler<const N: usize>(
     pos = write_varint_u64(id, &mut out, pos);
     pos = write_str(name, &mut out, pos);
     pos = write_option_borrowed_str(doc, &mut out, pos);
+    pos = write_option_varint_u64(reply, &mut out, pos);
     // Silence "assigned but never read" warning on the final write.
     let _ = pos;
     out

--- a/crates/aether-data/src/canonical/mod.rs
+++ b/crates/aether-data/src/canonical/mod.rs
@@ -407,14 +407,22 @@ mod tests {
         const ID: u64 = 0xdead_beef_cafe_f00d;
         const NAME: &str = "aether.tick";
         const DOC: Option<&str> = Some("Not useful to send manually.");
-        const N: usize = inputs_handler_len(ID, NAME, DOC);
-        const BYTES: [u8; N] = write_inputs_handler::<N>(ID, NAME, DOC);
+        // ADR-0109: a synchronous `-> R` handler carries its reply kind id.
+        const REPLY: Option<u64> = Some(0x00c0_ffee_0bad_f00d);
+        const N: usize = inputs_handler_len(ID, NAME, DOC, REPLY);
+        const BYTES: [u8; N] = write_inputs_handler::<N>(ID, NAME, DOC, REPLY);
         let decoded: InputsRecord = postcard::from_bytes(&BYTES).expect("decode");
         match decoded {
-            InputsRecord::Handler { id, name, doc } => {
+            InputsRecord::Handler {
+                id,
+                name,
+                doc,
+                reply,
+            } => {
                 assert_eq!(id, KindId(ID));
                 assert_eq!(name, NAME);
                 assert_eq!(doc.as_deref(), DOC);
+                assert_eq!(reply, Some(KindId(0x00c0_ffee_0bad_f00d)));
             }
             other => panic!("wrong variant: {other:?}"),
         }
@@ -425,8 +433,10 @@ mod tests {
         const ID: u64 = 1;
         const NAME: &str = "test.ping";
         const DOC: Option<&str> = None;
-        const N: usize = inputs_handler_len(ID, NAME, DOC);
-        const BYTES: [u8; N] = write_inputs_handler::<N>(ID, NAME, DOC);
+        // ADR-0109: a `-> ()` fire-and-forget handler carries no reply id.
+        const REPLY: Option<u64> = None;
+        const N: usize = inputs_handler_len(ID, NAME, DOC, REPLY);
+        const BYTES: [u8; N] = write_inputs_handler::<N>(ID, NAME, DOC, REPLY);
         let decoded: InputsRecord = postcard::from_bytes(&BYTES).expect("decode");
         assert_eq!(
             decoded,
@@ -434,6 +444,7 @@ mod tests {
                 id: KindId(ID),
                 name: NAME.into(),
                 doc: None,
+                reply: None,
             }
         );
     }

--- a/crates/aether-data/src/canonical/primitives.rs
+++ b/crates/aether-data/src/canonical/primitives.rs
@@ -210,6 +210,35 @@ pub(super) const fn write_option_str(
     pos
 }
 
+/// `Option<u64>` length/write — used by the `InputsRecord::Handler`
+/// encoder for the ADR-0109 reply kind id (`None` for a `-> ()`
+/// handler, `Some(KindId.0)` otherwise). Postcard encodes an `Option`
+/// as a one-byte discriminant (`0` None / `1` Some) followed by the
+/// varint payload when present.
+pub(super) const fn option_varint_u64_len(val: Option<u64>) -> usize {
+    match val {
+        None => 1,
+        Some(v) => 1 + varint_u64_len(v),
+    }
+}
+
+pub(super) const fn write_option_varint_u64(
+    val: Option<u64>,
+    out: &mut [u8],
+    cursor: usize,
+) -> usize {
+    match val {
+        None => {
+            out[cursor] = 0;
+            cursor + 1
+        }
+        Some(v) => {
+            out[cursor] = 1;
+            write_varint_u64(v, out, cursor + 1)
+        }
+    }
+}
+
 /// `Option<&'static str>` length/write — used by the `InputsRecord`
 /// encoders where the macro captures doc strings as plain `&str`
 /// without a `Cow` wrapper.

--- a/crates/aether-data/src/schema.rs
+++ b/crates/aether-data/src/schema.rs
@@ -814,6 +814,12 @@ pub enum InputsRecord {
         id: KindId,
         name: Cow<'static, str>,
         doc: Option<Cow<'static, str>>,
+        /// ADR-0109: the handler's reply kind id, read off its return
+        /// type — `Some(<R as Kind>::ID)` for a `-> R` (synchronous) or
+        /// `-> Pending<R>` (deferred) handler, `None` for a `-> ()`
+        /// fire-and-forget handler. Lets a caller read `In -> Out` before
+        /// issuing the call.
+        reply: Option<KindId>,
     },
     /// A `#[fallback]` method's presence and optional description.
     Fallback { doc: Option<Cow<'static, str>> },
@@ -846,8 +852,9 @@ pub const INPUTS_SECTION: &str = "aether.kinds.inputs";
 /// Version byte prefixing every record in the `aether.kinds.inputs`
 /// section. Follows ADR-0028's per-record versioning convention —
 /// unknown versions abort the read rather than silently skip. v0x02
-/// (ADR-0090 / issue 1257) added the `InputsRecord::Config` variant; a
-/// substrate that understands config delivery and a component built
-/// before it would otherwise silently disagree on the config seam, so
-/// the reader rejects v0x01 loudly — a hard rebuild boundary.
-pub const INPUTS_SECTION_VERSION: u8 = 0x02;
+/// (ADR-0090 / issue 1257) added the `InputsRecord::Config` variant;
+/// v0x03 (ADR-0109 / issue 1803) added the `reply` kind id to the
+/// `Handler` variant. A component built before either and a substrate
+/// after would otherwise disagree on the record shape, so the reader
+/// rejects an older version byte loudly — a hard rebuild boundary.
+pub const INPUTS_SECTION_VERSION: u8 = 0x03;

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1284,6 +1284,14 @@ mod control_plane {
         pub id: aether_data::KindId,
         pub name: String,
         pub doc: Option<String>,
+        /// ADR-0109: the handler's reply kind, read off its return type —
+        /// `Some` of the reply `KindId` for a `-> R` (synchronous) or
+        /// `-> Pending<R>` (deferred) handler, `None` for a `-> ()`
+        /// fire-and-forget handler. Lets `describe_component` report
+        /// `In -> Out` so a caller reads what a call returns before
+        /// issuing it. Native chassis caps leave this `None` until the
+        /// native handler manifest lands (ADR-0109 §5, a follow-on).
+        pub reply: Option<aether_data::KindId>,
     }
 
     /// A `#[fallback]` method's advertised presence + optional doc.

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -2344,13 +2344,25 @@ mod tests {
             "an uncached component should be a tool error"
         );
 
-        // Seed the cache, then it round-trips.
+        // Seed the cache with a handler that declares a `-> R` reply
+        // contract (ADR-0109). `describe_component` surfaces the `reply`
+        // kind id verbatim through serde, so a caller reads `In -> Out`
+        // before issuing the call.
         let engine =
             EngineId(Uuid::parse_str(engine_id).expect("test setup: engine_id is a valid uuid"));
+        let seeded = ComponentCapabilities {
+            handlers: vec![aether_kinds::HandlerCapability {
+                id: KindId(0x11),
+                name: "test.request".to_owned(),
+                doc: None,
+                reply: Some(KindId(0x22)),
+            }],
+            ..ComponentCapabilities::default()
+        };
         mcp.components
             .lock()
             .expect("test setup: component cache mutex is never poisoned")
-            .insert((engine, mailbox), ComponentCapabilities::default());
+            .insert((engine, mailbox), seeded);
         let hit = mcp
             .describe_component(Parameters(DescribeComponentArgs {
                 engine_id: engine_id.to_owned(),
@@ -2360,6 +2372,10 @@ mod tests {
             .expect("cached component describes");
         let caps: serde_json::Value = serde_json::from_str(&hit).expect("json");
         assert!(caps.get("handlers").is_some(), "capabilities shape: {hit}");
+        assert!(
+            !caps["handlers"][0]["reply"].is_null(),
+            "the handler's ADR-0109 reply contract is surfaced: {hit}"
+        );
     }
 
     /// `parse_level` round-trips every documented spelling and rejects

--- a/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
+++ b/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
@@ -209,7 +209,7 @@ pub struct ActorInputs {
 
 /// Decode the component's `aether.kinds.inputs` section (ADR-0033 /
 /// ADR-0096) into one [`ActorInputs`] per exported actor type. The
-/// record stream is `[0x02][postcard(InputsRecord)]` back-to-back; an
+/// record stream is `[0x03][postcard(InputsRecord)]` back-to-back; an
 /// `ActorBoundary { namespace }` record opens a new group and the
 /// Handler / Fallback / Component / Config records that follow belong
 /// to it, in declaration order. A single-actor module emits no
@@ -245,13 +245,19 @@ pub fn read_actor_inputs_from_bytes(wasm: &[u8]) -> Result<Vec<ActorInputs>, Str
                     capabilities: ComponentCapabilities::default(),
                 });
             }
-            InputsRecord::Handler { id, name, doc } => {
+            InputsRecord::Handler {
+                id,
+                name,
+                doc,
+                reply,
+            } => {
                 current_capabilities(&mut groups)
                     .handlers
                     .push(HandlerCapability {
                         id,
                         name: name.into_owned(),
                         doc: doc.map(Cow::into_owned),
+                        reply,
                     });
             }
             InputsRecord::Fallback { doc } => {
@@ -1003,11 +1009,14 @@ mod tests {
                 id: aether_data::KindId(42),
                 name: "aether.tick".into(),
                 doc: Some("substrate drives this".into()),
+                // ADR-0109: a `-> R` handler's reply kind reads back.
+                reply: Some(aether_data::KindId(0xbeef)),
             },
             InputsRecord::Handler {
                 id: aether_data::KindId(0xff),
                 name: "aether.ping".into(),
                 doc: None,
+                reply: None,
             },
         ]);
         let wasm = wasm_with_section(INPUTS_SECTION, &section);
@@ -1020,9 +1029,11 @@ mod tests {
             caps.handlers[0].doc.as_deref(),
             Some("substrate drives this")
         );
+        assert_eq!(caps.handlers[0].reply, Some(aether_data::KindId(0xbeef)));
         assert_eq!(caps.handlers[1].id, aether_data::KindId(0xff));
         assert_eq!(caps.handlers[1].name, "aether.ping");
         assert!(caps.handlers[1].doc.is_none());
+        assert!(caps.handlers[1].reply.is_none());
         assert!(caps.fallback.is_none());
     }
 
@@ -1035,6 +1046,7 @@ mod tests {
                 id: aether_data::KindId(7),
                 name: "aether.config_query".into(),
                 doc: None,
+                reply: None,
             },
             InputsRecord::Config {
                 id: aether_data::KindId(0x00c0_ffee),
@@ -1072,6 +1084,7 @@ mod tests {
             id: aether_data::KindId(7),
             name: "aether.tick".into(),
             doc: None,
+            reply: None,
         }]);
         let wasm = wasm_with_section(INPUTS_SECTION, &section);
         let caps = read_inputs_from_bytes(&wasm).unwrap();
@@ -1109,6 +1122,7 @@ mod tests {
                 id: aether_data::KindId(1),
                 name: "ui.click".into(),
                 doc: None,
+                reply: None,
             },
             InputsRecord::ActorBoundary {
                 namespace: "ui.panel".into(),
@@ -1117,6 +1131,7 @@ mod tests {
                 id: aether_data::KindId(2),
                 name: "ui.draw".into(),
                 doc: None,
+                reply: None,
             },
             InputsRecord::Fallback {
                 doc: Some("catchall".into()),
@@ -1149,6 +1164,7 @@ mod tests {
             id: aether_data::KindId(7),
             name: "aether.tick".into(),
             doc: None,
+            reply: None,
         }]);
         let wasm = wasm_with_section(INPUTS_SECTION, &section);
         let actors = read_actor_inputs_from_bytes(&wasm).unwrap();

--- a/crates/aether-substrate/src/chassis/inbox.rs
+++ b/crates/aether-substrate/src/chassis/inbox.rs
@@ -615,6 +615,98 @@ mod tests {
         reply_env.discharge();
     }
 
+    use crate::{BootError, NativeActor, NativeDispatch, NativeInitCtx};
+    use aether_data::Schema;
+
+    #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize, Kind, Schema)]
+    #[kind(name = "test.adr0109.request")]
+    struct ReplyRequest {
+        seq: u32,
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize, Kind, Schema)]
+    #[kind(name = "test.adr0109.ack")]
+    struct ReplyAck {
+        seq: u32,
+    }
+
+    /// A native actor whose handler declares its reply via the return
+    /// type (ADR-0109) — the `#[actor]` macro emits the `ReplyAck` reply,
+    /// so the body carries no `ctx.reply`.
+    struct ReplyProbe;
+
+    #[aether_actor::actor]
+    impl NativeActor for ReplyProbe {
+        const NAMESPACE: &'static str = "test.adr0109.probe";
+        type Config = ();
+
+        fn init(_config: (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            Ok(Self)
+        }
+
+        #[handler]
+        #[allow(clippy::unused_self)]
+        fn on_request(&mut self, _ctx: &mut NativeCtx<'_>, req: ReplyRequest) -> ReplyAck {
+            ReplyAck { seq: req.seq }
+        }
+    }
+
+    /// ADR-0109: a `-> R` `#[actor]` handler replies its return value by
+    /// construction. The macro routes the returned `ReplyAck` back to the
+    /// inbound sender through `OutboundReply::reply` — the same discharge
+    /// path a manual `ctx.reply` took, emitted from the return type. Drive
+    /// the macro-generated native dispatch and assert the reply lands at
+    /// the caller carrying the declared reply kind + value.
+    #[test]
+    fn return_type_handler_replies_through_the_macro() {
+        let (registry, mailer, _settlement) = test_env();
+
+        // The caller: a registered inbox we observe the reply landing on.
+        let (reply_tx, reply_rx) = mpsc::channel::<Envelope>();
+        let sink: Arc<dyn InboxHandler> = Arc::new(move |d: Envelope| {
+            // ADR-0094 terminal test consumer: discharge before forwarding.
+            d.discharge();
+            let _ = reply_tx.send(d);
+        });
+        let caller = registry.register_inbox("test.adr0109.caller", sink);
+
+        let binding = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            MailboxId(0x1803_0001),
+        ));
+        let caller_reply_to = Source::with_correlation(SourceAddr::Component(caller), 5);
+
+        let mut cap = ReplyProbe;
+        {
+            let mut ctx = NativeCtx::new(&binding, caller_reply_to, MailId::NONE, MailId::NONE);
+            let handled = cap.__aether_dispatch_envelope(
+                &mut ctx,
+                ReplyRequest::ID,
+                &ReplyRequest { seq: 9 }.encode_into_bytes(),
+            );
+            assert_eq!(handled, Some(()), "the -> R handler ran for its kind");
+        }
+
+        let reply = reply_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("the -> R handler replied to the inbound sender");
+        assert_eq!(
+            reply.kind,
+            ReplyAck::ID,
+            "the reply carries the handler's declared return kind",
+        );
+        assert_eq!(
+            reply.sender.correlation_id, 5,
+            "the caller's correlation is echoed onto the reply",
+        );
+        let ack = ReplyAck::decode_from_bytes(reply.payload.bytes()).expect("reply decodes");
+        assert_eq!(
+            ack,
+            ReplyAck { seq: 9 },
+            "the value the handler returned is what was replied",
+        );
+    }
+
     /// #1757: `NativeCtx::take_inbound` moves the *single* dispatched
     /// envelope out of the ctx, so the dispatcher's settlement tail
     /// (`take_raw_inbound`) sees `None` and does not also discharge it.

--- a/crates/aether-substrate/src/mail/capability.rs
+++ b/crates/aether-substrate/src/mail/capability.rs
@@ -150,6 +150,7 @@ mod tests {
                     id: KindId(id),
                     name: format!("test.kind.{id}"),
                     doc: None,
+                    reply: None,
                 })
                 .collect(),
             fallback: fallback.then_some(FallbackCapability { doc: None }),

--- a/crates/aether-substrate/tests/dag_validator.rs
+++ b/crates/aether-substrate/tests/dag_validator.rs
@@ -98,6 +98,7 @@ fn register_caps_with_fallback(
                 id,
                 name: format!("test.kind.{}", id.0),
                 doc: None,
+                reply: None,
             })
             .collect(),
         fallback: fallback.then_some(aether_kinds::FallbackCapability { doc: None }),


### PR DESCRIPTION
Closes #1803.

## Summary

Implements the synchronous slice of ADR-0109: a `#[handler]`'s return type is now its reply contract. The `#[actor]` macro classifies each handler's return as `()` (fire-and-forget), `R: Kind` (synchronous reply), or `Pending<R>` (deferred — recognized here, wired in #1805). A `-> R` handler emits the reply through the existing `OutboundReply::reply` path by construction, so a converted `on_load_component` returns `-> LoadResult` with no manual `ctx.reply`.

The reply kind rides the handler manifest: `InputsRecord::Handler` and `HandlerCapability` gain a `reply: Option<KindId>` field, so `describe_component` reports `In -> Out` for synchronous handlers. `INPUTS_SECTION_VERSION` is bumped 0x02 → 0x03 because the change alters an existing manifest variant's wire shape — a stale 0x02 wasm is now rejected loudly at the version check rather than misparsed (matching the ADR-0090 0x01 → 0x02 precedent).

This is the keystone of the ADR-0109 cluster; #1804 (decode replies against the declared kind), #1805 (deferred `Pending<R>`), and #1806 (native handler manifest) build on the `reply` field and the classifier landed here.

## Test plan

- Handler-manifest round-trip carries the reply kind id (`handlers_manifest.rs`, a `-> Pong` handler).
- Canonical encode/decode round-trips for the extended `Handler` record (`canonical/mod.rs`), including the new `Option<u64>` varint primitives.
- Wasm manifest reader threads `reply` (`kind_manifest.rs`); `describe_component_reads_the_cache` surfaces it (`aether-mcp`).
- End-to-end `-> R` reply-behavior test drives the macro-generated native dispatch and asserts the reply lands at the sender carrying the declared kind and value (`inbox.rs`).
- Full workspace: fmt, clippy `-D warnings`, `nextest --workspace` (1810 passed), doc, wasm32 component cross-build.

## Generated by

`/implement` — agent execution of [scoped issue #1803](https://github.com/iamacoffeepot/aether/issues/1803).
