### PR TITLE
feat(capabilities): native ui hit-testing and interaction mail

### DIFF
--- a/crates/aether-capabilities/src/ui.rs
+++ b/crates/aether-capabilities/src/ui.rs
@@ -20,23 +20,58 @@
 // Handler-signature kinds must be importable at file root because
 // `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings of
 // the mod (always-on, outside the cfg gate).
-use aether_kinds::{UiBar, UiLabel, UiPanel};
+use aether_kinds::{MouseButton, MouseMove, Tick, UiBar, UiButton, UiLabel, UiPanel};
 
 #[aether_actor::bridge(singleton, feature = "ui-native")]
 mod native {
+    use core::iter::once;
+    use core::mem::swap;
+
     use aether_actor::actor;
-    use aether_kinds::{DrawSolidQuads, DrawText, QuadSpace, SolidQuad};
+    use aether_data::MailboxId;
+    use aether_kinds::{DrawSolidQuads, DrawText, QuadSpace, SolidQuad, UiClicked};
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
 
+    use crate::input::{InputCapability, InputMailboxExt};
+    use crate::lifecycle::{LifecycleCapability, LifecycleMailboxExt};
     use crate::render::RenderCapability;
     use crate::text::TextCapability;
 
-    use super::{UiBar, UiLabel, UiPanel};
+    use super::{MouseButton, MouseMove, Tick, UiBar, UiButton, UiLabel, UiPanel};
 
-    /// `aether.ui` mailbox cap. CPU-only — no GPU handles, just a
-    /// stateless translator from widget mail to render + text mail.
-    pub struct UiCapability;
+    /// A button's hit-test record for one frame: where it was drawn, the
+    /// caller's widget `id`, and the component that drew it (the
+    /// `UiClicked` recipient on a hit).
+    struct ButtonRect {
+        /// `[x, y, width, height]` in window pixels.
+        rect: [f32; 4],
+        /// Caller-stable widget id echoed back in `UiClicked`.
+        id: u32,
+        /// Mailbox of the component that sent the `UiButton`.
+        owner: MailboxId,
+    }
+
+    /// `aether.ui` mailbox cap. CPU-only — no GPU handles. Translates
+    /// widget mail to render + text mail, and (ADR-0107 §3) hit-tests
+    /// left-clicks against the button rects drawn each frame, replying
+    /// `UiClicked` to the owning component.
+    ///
+    /// Plain-field shape (ADR-0078) — single-threaded, every handler
+    /// runs on the cap's dispatcher thread. The button-rect map is
+    /// double-buffered: `current` accumulates this frame's buttons,
+    /// `Tick` swaps it into `last`, and a click hit-tests against `last`
+    /// — the one-frame latency ADR-0107 §3 specifies, deterministic
+    /// regardless of button-mail vs click ordering within a tick.
+    #[derive(Default)]
+    pub struct UiCapability {
+        /// Latest cursor position from `MouseMove`, window pixels.
+        cursor: [f32; 2],
+        /// Buttons recorded during the in-progress frame.
+        current: Vec<ButtonRect>,
+        /// Buttons from the last completed frame — the hit-test set.
+        last: Vec<ButtonRect>,
+    }
 
     #[actor]
     impl NativeActor for UiCapability {
@@ -45,9 +80,22 @@ mod native {
         /// ADR-0107 chassis-owned mailbox.
         const NAMESPACE: &'static str = "aether.ui";
 
-        /// No substrate resources to claim — the cap holds no state.
+        /// No substrate resources to claim — the cap holds only its own
+        /// per-frame hit-test state.
         fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            Ok(Self)
+            Ok(Self::default())
+        }
+
+        /// Subscribe the cursor + click streams and the frame edge.
+        ///
+        /// Mirrors the kit's input-subscription pattern: `MouseMove` /
+        /// `MouseButton` through `aether.input`, `Tick` through
+        /// `aether.lifecycle`. The subscriptions survive `replace` (the
+        /// mailbox id is stable) and clear on drop.
+        fn wire(&mut self, ctx: &mut NativeCtx<'_>) {
+            ctx.actor::<InputCapability>().subscribe::<MouseMove>();
+            ctx.actor::<InputCapability>().subscribe::<MouseButton>();
+            ctx.actor::<LifecycleCapability>().subscribe::<Tick>();
         }
 
         /// Draw a flat-colored panel.
@@ -131,6 +179,100 @@ mod native {
             };
             let _ = ctx.actor::<TextCapability>().send_traced(ctx, &draw);
         }
+
+        /// Draw a clickable button and record it for hit-testing.
+        ///
+        /// # Agent
+        /// Fire-and-forget. Forwards the fill (`color`) as a screen-space
+        /// `DrawSolidQuads` to `aether.render` and the `text` label as a
+        /// `DrawText` to `aether.text`, the same tick. Records `(rect, id,
+        /// owner)` for the in-progress frame; `owner` is the sending
+        /// component, read from the inbound's host-stamped source. A left-
+        /// click inside `rect` replies `UiClicked { id }` to `owner`
+        /// within one frame (see `on_mouse_button`). Resend every frame.
+        #[handler]
+        fn on_button(&mut self, ctx: &mut NativeCtx<'_>, mail: UiButton) {
+            let [x, y, width, height] = mail.rect;
+            // Record for the next click's hit-test. A button mailed with
+            // no component source (broadcast / session) has nowhere to
+            // reply, so it draws but never activates.
+            if let Some(owner) = ctx.source_mailbox() {
+                self.current.push(ButtonRect {
+                    rect: mail.rect,
+                    id: mail.id,
+                    owner,
+                });
+            }
+            let fill = DrawSolidQuads {
+                space: QuadSpace::Screen,
+                quads: vec![SolidQuad {
+                    x,
+                    y,
+                    width,
+                    height,
+                    color: mail.color,
+                }],
+            };
+            let _ = ctx.actor::<RenderCapability>().send_traced(ctx, &fill);
+            let label = DrawText {
+                font_id: mail.font_id,
+                text: mail.text,
+                size_pixels: mail.size_pixels,
+                color: mail.text_color,
+                origin: [x, y],
+                space: QuadSpace::Screen,
+            };
+            let _ = ctx.actor::<TextCapability>().send_traced(ctx, &label);
+        }
+
+        /// Cache the cursor position.
+        ///
+        /// # Agent
+        /// Fire-and-forget. Updates the latest cursor used by the next
+        /// `on_mouse_button` hit-test. No forwarded mail.
+        #[handler]
+        fn on_mouse_move(&mut self, _ctx: &mut NativeCtx<'_>, mail: MouseMove) {
+            self.cursor = [mail.x, mail.y];
+        }
+
+        /// Hit-test a left-click against the last frame's buttons.
+        ///
+        /// # Agent
+        /// Fire-and-forget. Tests the cached cursor against the last
+        /// completed frame's button rects, topmost-wins (later-drawn
+        /// buttons paint on top, so it scans in reverse draw order), and
+        /// on a hit sends `UiClicked { id }` to that button's recorded
+        /// owner by id. A click outside every rect does nothing. v1: the
+        /// mouse-button stream has no button discriminant or release, so
+        /// this fires on left-press only.
+        #[handler]
+        fn on_mouse_button(&mut self, ctx: &mut NativeCtx<'_>, _mail: MouseButton) {
+            let [cursor_x, cursor_y] = self.cursor;
+            let target = self
+                .last
+                .iter()
+                .rev()
+                .find(|button| {
+                    let [x, y, width, height] = button.rect;
+                    cursor_x >= x && cursor_x < x + width && cursor_y >= y && cursor_y < y + height
+                })
+                .map(|button| (button.id, button.owner));
+            if let Some((id, owner)) = target {
+                ctx.fanout(once(owner), &UiClicked { id });
+            }
+        }
+
+        /// Frame edge: rotate the button-rect buffers.
+        ///
+        /// # Agent
+        /// Fire-and-forget. The buttons drawn this frame become the hit-
+        /// test set (`last`), and the new frame starts with an empty
+        /// accumulator (`current`). No forwarded mail.
+        #[handler]
+        fn on_tick(&mut self, _ctx: &mut NativeCtx<'_>, _tick: Tick) {
+            swap(&mut self.current, &mut self.last);
+            self.current.clear();
+        }
     }
 
     #[cfg(test)]
@@ -153,10 +295,59 @@ mod native {
             Source::to(SourceAddr::Session(SessionToken(Uuid::nil())))
         }
 
+        /// A sender stamped as the component mailbox `id` — the shape the
+        /// host stamps on a fire-and-forget `UiButton`, so `on_button`
+        /// records `id` as the button's owner.
+        fn component_sender(id: u64) -> Source {
+            Source::to(SourceAddr::Component(MailboxId(id)))
+        }
+
         fn ctx_binding() -> (Arc<NativeBinding>, Receiver<EgressEvent>) {
             let (mailer, rx) = test_mailer_and_rx();
             let binding = Arc::new(NativeBinding::new_for_test(mailer, MailboxId(0)));
             (binding, rx)
+        }
+
+        /// Flush and drain egress until a `UiClicked` arrives; return its
+        /// recipient mailbox + decoded payload. Skips the button's
+        /// forwarded fill / label sends.
+        fn recv_clicked(
+            binding: &NativeBinding,
+            rx: &Receiver<EgressEvent>,
+        ) -> (MailboxId, UiClicked) {
+            binding.flush_outbound();
+            loop {
+                let event = rx
+                    .recv_timeout(Duration::from_secs(2))
+                    .expect("test: UiClicked egress arrives within deadline");
+                if let EgressEvent::UnresolvedMail {
+                    recipient_mailbox_id,
+                    kind_id,
+                    payload,
+                    ..
+                } = event
+                    && kind_id == UiClicked::ID
+                {
+                    let decoded: UiClicked =
+                        postcard::from_bytes(&payload).expect("test: decodes UiClicked");
+                    return (recipient_mailbox_id, decoded);
+                }
+            }
+        }
+
+        /// Flush and drain the whole channel, asserting no `UiClicked` was
+        /// delivered (the button's fill / label sends are allowed).
+        fn assert_no_clicked(binding: &NativeBinding, rx: &Receiver<EgressEvent>) {
+            binding.flush_outbound();
+            while let Ok(event) = rx.try_recv() {
+                if let EgressEvent::UnresolvedMail { kind_id, .. } = event {
+                    assert_ne!(
+                        kind_id,
+                        UiClicked::ID,
+                        "a click outside every rect must not deliver UiClicked"
+                    );
+                }
+            }
         }
 
         /// Flush buffered sends and drain egress until a `UnresolvedMail` of
@@ -176,7 +367,7 @@ mod native {
 
         #[test]
         fn panel_produces_draw_solid_quads() {
-            let mut cap = UiCapability;
+            let mut cap = UiCapability::default();
             let (binding, rx) = ctx_binding();
             let mut ctx = NativeCtx::new(&binding, session_sender(), MailId::NONE, MailId::NONE);
             cap.on_panel(
@@ -191,7 +382,7 @@ mod native {
 
         #[test]
         fn bar_produces_draw_solid_quads_with_two_quads() {
-            let mut cap = UiCapability;
+            let mut cap = UiCapability::default();
             let (binding, rx) = ctx_binding();
             let mut ctx = NativeCtx::new(&binding, session_sender(), MailId::NONE, MailId::NONE);
             cap.on_bar(
@@ -222,7 +413,7 @@ mod native {
 
         #[test]
         fn bar_clamps_frac_above_one() {
-            let mut cap = UiCapability;
+            let mut cap = UiCapability::default();
             let (binding, rx) = ctx_binding();
             let mut ctx = NativeCtx::new(&binding, session_sender(), MailId::NONE, MailId::NONE);
             cap.on_bar(
@@ -255,7 +446,7 @@ mod native {
 
         #[test]
         fn bar_clamps_frac_below_zero() {
-            let mut cap = UiCapability;
+            let mut cap = UiCapability::default();
             let (binding, rx) = ctx_binding();
             let mut ctx = NativeCtx::new(&binding, session_sender(), MailId::NONE, MailId::NONE);
             cap.on_bar(
@@ -285,7 +476,7 @@ mod native {
 
         #[test]
         fn label_produces_draw_text_screen_space() {
-            let mut cap = UiCapability;
+            let mut cap = UiCapability::default();
             let (binding, rx) = ctx_binding();
             let mut ctx = NativeCtx::new(&binding, session_sender(), MailId::NONE, MailId::NONE);
             cap.on_label(
@@ -313,6 +504,90 @@ mod native {
             let decoded: DrawText = postcard::from_bytes(&payload).expect("test: decodes DrawText");
             assert_eq!(decoded.space, QuadSpace::Screen, "label uses Screen space");
             assert_eq!(decoded.origin, [50.0, 100.0], "label origin is (x, y)");
+        }
+
+        fn button(id: u32, rect: [f32; 4]) -> UiButton {
+            UiButton {
+                id,
+                rect,
+                color: [0.1, 0.1, 0.1, 1.0],
+                font_id: 0,
+                text: "Go".to_owned(),
+                size_pixels: 16.0,
+                text_color: [1.0, 1.0, 1.0, 1.0],
+            }
+        }
+
+        #[test]
+        fn button_records_rect_with_owner_and_tick_swaps() {
+            let mut cap = UiCapability::default();
+            let (binding, _rx) = ctx_binding();
+            let mut ctx =
+                NativeCtx::new(&binding, component_sender(42), MailId::NONE, MailId::NONE);
+            cap.on_button(&mut ctx, button(7, [10.0, 10.0, 100.0, 40.0]));
+            assert_eq!(cap.current.len(), 1, "one button recorded this frame");
+            assert_eq!(cap.current[0].id, 7);
+            assert_eq!(cap.current[0].rect, [10.0, 10.0, 100.0, 40.0]);
+            assert_eq!(cap.current[0].owner, MailboxId(42), "owner is the sender");
+            // Frame edge: this frame's buttons become the hit-test set,
+            // and the next frame starts empty.
+            cap.on_tick(&mut ctx, Tick);
+            assert_eq!(cap.last.len(), 1, "tick swaps current into last");
+            assert!(cap.current.is_empty(), "tick clears current");
+        }
+
+        #[test]
+        fn click_inside_button_delivers_clicked_to_owner() {
+            let mut cap = UiCapability::default();
+            let (binding, rx) = ctx_binding();
+            let mut ctx =
+                NativeCtx::new(&binding, component_sender(42), MailId::NONE, MailId::NONE);
+            cap.on_button(&mut ctx, button(7, [10.0, 10.0, 100.0, 40.0]));
+            cap.on_tick(&mut ctx, Tick);
+            cap.on_mouse_move(&mut ctx, MouseMove { x: 50.0, y: 25.0 });
+            cap.on_mouse_button(&mut ctx, MouseButton);
+            let (recipient, clicked) = recv_clicked(&binding, &rx);
+            assert_eq!(recipient, MailboxId(42), "clicked routes to the owner");
+            assert_eq!(clicked.id, 7, "clicked carries the button id");
+        }
+
+        #[test]
+        fn click_outside_button_delivers_nothing() {
+            let mut cap = UiCapability::default();
+            let (binding, rx) = ctx_binding();
+            let mut ctx =
+                NativeCtx::new(&binding, component_sender(42), MailId::NONE, MailId::NONE);
+            cap.on_button(&mut ctx, button(7, [10.0, 10.0, 100.0, 40.0]));
+            cap.on_tick(&mut ctx, Tick);
+            // Cursor outside the rect (right of x + width).
+            cap.on_mouse_move(&mut ctx, MouseMove { x: 200.0, y: 25.0 });
+            cap.on_mouse_button(&mut ctx, MouseButton);
+            assert_no_clicked(&binding, &rx);
+        }
+
+        #[test]
+        fn overlapping_buttons_activate_topmost() {
+            let mut cap = UiCapability::default();
+            let (binding, rx) = ctx_binding();
+            // Button A (id 1, owner 42) drawn first; button B (id 2,
+            // owner 43) drawn second, so B paints on top.
+            let mut ctx_a =
+                NativeCtx::new(&binding, component_sender(42), MailId::NONE, MailId::NONE);
+            cap.on_button(&mut ctx_a, button(1, [0.0, 0.0, 100.0, 100.0]));
+            let mut ctx_b =
+                NativeCtx::new(&binding, component_sender(43), MailId::NONE, MailId::NONE);
+            cap.on_button(&mut ctx_b, button(2, [50.0, 50.0, 100.0, 100.0]));
+            cap.on_tick(&mut ctx_b, Tick);
+            // Cursor inside both rects.
+            cap.on_mouse_move(&mut ctx_b, MouseMove { x: 60.0, y: 60.0 });
+            cap.on_mouse_button(&mut ctx_b, MouseButton);
+            let (recipient, clicked) = recv_clicked(&binding, &rx);
+            assert_eq!(
+                recipient,
+                MailboxId(43),
+                "topmost (last-drawn) button's owner"
+            );
+            assert_eq!(clicked.id, 2, "topmost button id wins on overlap");
         }
     }
 }

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1934,6 +1934,45 @@ mod control_plane {
         pub color: [f32; 4],
     }
 
+    /// `aether.ui.button` — draw a clickable button at `rect` in
+    /// screen-pixel space (ADR-0107 §3). The cap forwards the fill
+    /// (`color`) as a panel quad and the `text` label, and records the
+    /// rect + `id` + the sending component for hit-testing. A left-click
+    /// inside the rect replies `aether.ui.clicked { id }` to the sender
+    /// within one frame (topmost button wins on overlap). v1: the mouse-
+    /// button stream carries no button discriminant or release, so the
+    /// button activates on left-press only. Fire-and-forget; resend every
+    /// frame — `id` is the caller's stable handle for the widget.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.ui.button")]
+    pub struct UiButton {
+        /// Caller-stable widget id echoed back in `UiClicked` on a hit.
+        pub id: u32,
+        /// `[x, y, width, height]` in window pixels.
+        pub rect: [f32; 4],
+        /// Background fill, linear RGBA.
+        pub color: [f32; 4],
+        /// Font for the label, registered via `aether.text.load_font`.
+        pub font_id: u32,
+        /// Label drawn at the button's top-left corner.
+        pub text: String,
+        pub size_pixels: f32,
+        /// Label color, linear RGBA.
+        pub text_color: [f32; 4],
+    }
+
+    /// `aether.ui.clicked` — the cap's interaction reply (ADR-0107 §3).
+    /// Sent to the component that drew the `UiButton` carrying the same
+    /// `id` when a left-click lands inside that button's rect. Delivered
+    /// by id to the recorded owner — the button mail's sender — within one
+    /// frame of the click.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.ui.clicked")]
+    pub struct UiClicked {
+        /// The `id` of the `UiButton` that was clicked.
+        pub id: u32,
+    }
+
     /// The three window presentation modes. `Windowed` has no fields —
     /// the current size lives on `SetWindowModeResult`.
     /// `FullscreenExclusive` carries the specific video mode; the
@@ -3776,6 +3815,8 @@ mod tests {
         assert_eq!(UiPanel::NAME, "aether.ui.panel");
         assert_eq!(UiBar::NAME, "aether.ui.bar");
         assert_eq!(UiLabel::NAME, "aether.ui.label");
+        assert_eq!(UiButton::NAME, "aether.ui.button");
+        assert_eq!(UiClicked::NAME, "aether.ui.clicked");
         assert_eq!(SetWindowMode::NAME, "aether.window.set_mode");
         assert_eq!(SetWindowModeResult::NAME, "aether.window.set_mode_result");
         assert_eq!(SetWindowTitle::NAME, "aether.window.set_title");
@@ -4373,6 +4414,38 @@ mod tests {
             assert_eq!(back.text, "HP: 100");
             assert_eq!(back.size_pixels, 16.0);
             assert_eq!(back.color, [1.0, 1.0, 1.0, 1.0]);
+        }
+
+        #[test]
+        fn ui_button_roundtrip() {
+            let b = UiButton {
+                id: 7,
+                rect: [4.0, 8.0, 120.0, 32.0],
+                color: [0.15, 0.15, 0.2, 1.0],
+                font_id: 1,
+                text: "Play".to_string(),
+                size_pixels: 18.0,
+                text_color: [0.9, 0.9, 0.9, 1.0],
+            };
+            let bytes = postcard::to_allocvec(&b).expect("test setup: postcard encodes UiButton");
+            let back: UiButton =
+                postcard::from_bytes(&bytes).expect("test setup: postcard decodes UiButton");
+            assert_eq!(back.id, 7);
+            assert_eq!(back.rect, [4.0, 8.0, 120.0, 32.0]);
+            assert_eq!(back.color, [0.15, 0.15, 0.2, 1.0]);
+            assert_eq!(back.font_id, 1);
+            assert_eq!(back.text, "Play");
+            assert_eq!(back.size_pixels, 18.0);
+            assert_eq!(back.text_color, [0.9, 0.9, 0.9, 1.0]);
+        }
+
+        #[test]
+        fn ui_clicked_roundtrip() {
+            let c = UiClicked { id: 7 };
+            let bytes = postcard::to_allocvec(&c).expect("test setup: postcard encodes UiClicked");
+            let back: UiClicked =
+                postcard::from_bytes(&bytes).expect("test setup: postcard decodes UiClicked");
+            assert_eq!(back.id, 7);
         }
     }
 


### PR DESCRIPTION
Closes #1739.

## Summary

Adds hit-testing and the `clicked` interaction reply to the `aether.ui` capability (ADR-0107 §3), building on the cap skeleton from #1738. A component mails `aether.ui.button { id, rect, ... }` each frame; a left-click inside the rect (topmost wins on overlap) delivers `aether.ui.clicked { id }` back to the component that drew the button, within one frame. A click outside every rect does nothing.

The cap keeps a double-buffered button-rect map: `on_button` accumulates this frame's rects into `current`, `Tick` swaps `current` into `last` and clears the accumulator, and `on_mouse_button` hit-tests the cached cursor against `last` in reverse draw order (later-drawn buttons paint on top). The one-frame latency is deterministic regardless of button-mail vs click ordering within a tick. The `clicked` reply routes to the recorded owner — read from the inbound's host-stamped source (`ctx.source_mailbox()`) and sent by id via `ctx.fanout`, the type-erased by-id path the input cap already uses, so it carries no bare-string addressing.

v1 limitation, inherited from #1735's side finding: `aether.mouse_button` is a unit kind (no button discriminant, no release), so buttons are left-click-activate only.

## Test plan

- Click inside a button delivers `UiClicked` to the recorded owner (`click_inside_button_delivers_clicked_to_owner`).
- Click outside every rect delivers nothing.
- Topmost-wins on overlapping buttons.
- A button mailed with no component source draws but never activates.
- `UiButton` / `UiClicked` postcard round-trips and `NAME` asserts.
- Full workspace: fmt, clippy `-D warnings`, `nextest --workspace` (1815 passed), doc, wasm32 component cross-build.

## Generated by

`/implement` — agent execution of [scoped issue #1739](https://github.com/iamacoffeepot/aether/issues/1739).
