### PR TITLE
feat(capabilities): native handler reply manifest

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -2579,6 +2579,43 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
         }
     };
 
+    // ADR-0109 §5: the native analogue of the wasm `aether.kinds.inputs`
+    // custom section. Submit one link-time `HandlerEntry` per
+    // `#[handler]` — the owning `NAMESPACE`, the input kind (id + name),
+    // and the reply kind id read off the return type (the same
+    // `classify_handler_reply` the auto-reply arm uses). The
+    // `aether.inventory` cap folds these into the
+    // `aether.inventory.handlers` reply, so a native cap surfaces its
+    // `In -> Out` the way `describe_component` does for a wasm component.
+    // Gated on `not(wasm32)` to match the rest of the native surface
+    // (the `inventory` crate doesn't link on wasm32). Skipped for a
+    // generic native actor — none exist, and `<Self as Actor>::NAMESPACE`
+    // wouldn't const-resolve in the non-generic inventory static.
+    let handler_inventory = if generics.params.is_empty() {
+        let submissions = handlers.iter().map(|h| {
+            let kind_ty = &h.kind_ty;
+            let reply_expr = if let Some(reply_ty) = h.reply.manifest_kind() {
+                quote! { ::core::option::Option::Some(<#reply_ty as ::aether_data::Kind>::ID) }
+            } else {
+                quote! { ::core::option::Option::None }
+            };
+            quote! {
+                #[cfg(not(target_arch = "wasm32"))]
+                ::aether_data::name_inventory::inventory::submit! {
+                    ::aether_data::name_inventory::HandlerEntry {
+                        namespace: <#self_ty as ::aether_actor::Actor>::NAMESPACE,
+                        id: <#kind_ty as ::aether_data::Kind>::ID,
+                        name: <#kind_ty as ::aether_data::Kind>::NAME,
+                        reply: #reply_expr,
+                    }
+                }
+            }
+        });
+        quote! { #(#submissions)* }
+    } else {
+        quote! {}
+    };
+
     // Issue 552 stage 4: NativeActor + NativeDispatch + the inherent
     // handler-method impl all reach for `::aether_substrate::*` paths
     // and native-only types in their bodies. They're emitted under
@@ -2597,6 +2634,8 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
         #actor_impl
 
         #(#handles_kind_impls)*
+
+        #handler_inventory
 
         #[cfg(not(target_arch = "wasm32"))]
         impl #impl_generics #trait_path for #self_ty #where_clause {

--- a/crates/aether-capabilities/src/inventory.rs
+++ b/crates/aether-capabilities/src/inventory.rs
@@ -4,7 +4,7 @@
 //! (the MCP harness) reads the running substrate's **own, per-build**
 //! state instead of a drift-prone compiled-in copy.
 //!
-//! Three request kinds, each replying synchronously via `ctx.reply`:
+//! Four request kinds, each replying synchronously via `ctx.reply`:
 //!
 //! - [`Manifest`] → [`ManifestResult`]: the compile-time manifest —
 //!   every link-time [`NameEntry`](aether_data::name_inventory::NameEntry)
@@ -28,6 +28,16 @@
 //!   component-defined kind encodes correctly the moment the
 //!   `aether.component.load` returns — no per-kind hand-promotion into
 //!   `aether-kinds`.
+//! - [`ListHandlers`] → [`HandlersResult`] (ADR-0109 §5): the native
+//!   handler manifest — every `#[handler]`'s `{ namespace, input kind,
+//!   reply kind }` across every native actor linked into the substrate,
+//!   read from the link-time
+//!   [`HandlerEntry`](aether_data::name_inventory::HandlerEntry)
+//!   inventory the `#[actor]` macro populates. The native analogue of
+//!   the wasm `aether.kinds.inputs` custom section: the harness folds
+//!   the reply per `namespace` so a native cap (`aether.fs`,
+//!   `aether.render`, …) surfaces its `In -> Out` the way
+//!   `describe_component` surfaces a wasm component's.
 //!
 //! The cap holds a clone of the substrate's `Arc<Registry>` (taken in
 //! `init` via `NativeInitCtx::mailer().registry()` — the same `Arc` the
@@ -39,20 +49,28 @@
 //! `NameEntry` for `NAMESPACE`, so `aether.inventory` reverses through
 //! the same static map it serves.
 
-use aether_kinds::{ListKinds, ListKindsResult, Manifest, ManifestResult, Resolve, ResolveResult};
+use aether_kinds::{
+    HandlersResult, ListHandlers, ListKinds, ListKindsResult, Manifest, ManifestResult, Resolve,
+    ResolveResult,
+};
 
 #[aether_actor::bridge(singleton)]
 mod native {
-    use super::{ListKinds, ListKindsResult, Manifest, ManifestResult, Resolve, ResolveResult};
+    use super::{
+        HandlersResult, ListHandlers, ListKinds, ListKindsResult, Manifest, ManifestResult,
+        Resolve, ResolveResult,
+    };
 
     use aether_actor::{OutboundReply, actor};
     use aether_data::KindId;
     use aether_data::canonical::kind_id_from_parts;
-    use aether_data::name_inventory::{Cardinality, ParamKind, name_entries, template_entries};
+    use aether_data::name_inventory::{
+        Cardinality, ParamKind, handler_entries, name_entries, template_entries,
+    };
     use aether_data::tagged_id;
     use aether_kinds::{
-        CardinalityWire, KindDescriptorWire, NameEntryWire, ParamKindWire, ResolvedName,
-        TemplateEntryWire,
+        CardinalityWire, HandlerEntryWire, KindDescriptorWire, NameEntryWire, ParamKindWire,
+        ResolvedName, TemplateEntryWire,
     };
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
@@ -225,6 +243,39 @@ mod native {
                 })
                 .collect();
             ctx.reply(&ResolveResult { resolved });
+        }
+
+        /// Reply with the native handler manifest (ADR-0109 §5): every
+        /// `#[handler]` across every native actor linked into the
+        /// substrate, each carrying its owning `namespace`, input kind
+        /// (id + name), and declared reply kind id. Read from the
+        /// process-global link-time
+        /// [`HandlerEntry`](aether_data::name_inventory::HandlerEntry)
+        /// inventory the `#[actor]` macro populates — the native
+        /// analogue of the wasm `aether.kinds.inputs` custom section.
+        ///
+        /// # Agent
+        /// Reply: `HandlersResult`. One `HandlerEntryWire` per native
+        /// handler; `reply` is the kind a `-> R` handler answers with
+        /// (`None` for a fire-and-forget `-> ()` handler). Fold per
+        /// `namespace` to read each native cap (`aether.fs`,
+        /// `aether.render`, …) as a `describe_component`-style
+        /// `In -> Out` handler list.
+        // The manifest is read from the process-global link-time
+        // inventory — `&mut self` is the `#[handler]` dispatch signature,
+        // not a state read.
+        #[allow(clippy::unused_self)]
+        #[handler]
+        fn on_handlers(&mut self, ctx: &mut NativeCtx<'_>, _mail: ListHandlers) {
+            let handlers = handler_entries()
+                .map(|entry| HandlerEntryWire {
+                    namespace: entry.namespace.into(),
+                    id: entry.id,
+                    name: entry.name.into(),
+                    reply: entry.reply,
+                })
+                .collect();
+            ctx.reply(&HandlersResult { handlers });
         }
     }
 
@@ -487,6 +538,103 @@ mod native {
             assert_eq!(
                 result.resolved[3].name, None,
                 "a malformed id reports None without aborting the batch",
+            );
+        }
+
+        /// A native test cap with a synchronous `-> R` handler — the
+        /// surface ADR-0109 §5 makes `aether.inventory.handlers` carry.
+        /// Its `#[actor]` expansion submits a link-time `HandlerEntry`
+        /// declaring `ProbeReq -> ProbeReply`.
+        #[derive(
+            serde::Serialize,
+            serde::Deserialize,
+            aether_data::Kind,
+            aether_data::Schema,
+            Debug,
+            Clone,
+        )]
+        #[kind(name = "aether.test.inventory_handlers.req")]
+        struct ProbeReq {}
+
+        #[derive(
+            serde::Serialize,
+            serde::Deserialize,
+            aether_data::Kind,
+            aether_data::Schema,
+            Debug,
+            Clone,
+        )]
+        #[kind(name = "aether.test.inventory_handlers.reply")]
+        struct ProbeReply {}
+
+        struct ReplyProbeCap;
+
+        #[actor]
+        impl NativeActor for ReplyProbeCap {
+            type Config = ();
+            const NAMESPACE: &'static str = "aether.test.inventory_handlers.probe";
+
+            fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+                Ok(Self)
+            }
+
+            /// A synchronous `-> ProbeReply` handler — the reply contract
+            /// the link-time inventory captures. Stateless: the link-time
+            /// `HandlerEntry` is what the test reads, not handler state.
+            #[allow(clippy::unused_self)]
+            #[handler]
+            fn on_probe(&mut self, _ctx: &mut NativeCtx<'_>, _mail: ProbeReq) -> ProbeReply {
+                ProbeReply {}
+            }
+        }
+
+        /// ADR-0109 §5: a native cap's `-> R` handler surfaces `In -> Out`
+        /// through `aether.inventory.handlers`. `on_handlers` projects the
+        /// process-global link-time `HandlerEntry` inventory onto
+        /// `HandlersResult`; the `ReplyProbeCap` entry round-trips its
+        /// input kind (id + name) and its `Some(ProbeReply)` reply
+        /// contract.
+        #[test]
+        fn handlers_surfaces_native_reply_contract() {
+            use aether_actor::Actor;
+            use aether_data::Kind;
+            // Force `ReplyProbeCap`'s `#[actor]` HandlerEntry submission to
+            // link into this test binary.
+            assert_eq!(
+                ReplyProbeCap::NAMESPACE,
+                "aether.test.inventory_handlers.probe"
+            );
+
+            let mut fix = fixture();
+            let mut ctx = session_ctx(&fix.transport);
+            fix.cap.on_handlers(&mut ctx, ListHandlers {});
+            drop(ctx);
+
+            let result = decode_reply::<HandlersResult>(&fix.rx);
+            let entry = result
+                .handlers
+                .iter()
+                .find(|h| h.namespace == ReplyProbeCap::NAMESPACE && h.id == <ProbeReq as Kind>::ID)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "HandlersResult should carry the ReplyProbeCap probe handler; \
+                         namespaces: {:?}",
+                        result
+                            .handlers
+                            .iter()
+                            .map(|h| &h.namespace)
+                            .collect::<Vec<_>>(),
+                    )
+                });
+            assert_eq!(
+                entry.name,
+                <ProbeReq as Kind>::NAME,
+                "input kind name round-trips"
+            );
+            assert_eq!(
+                entry.reply,
+                Some(<ProbeReply as Kind>::ID),
+                "a `-> ProbeReply` handler surfaces ProbeReply as its reply (In -> Out)",
             );
         }
     }

--- a/crates/aether-capabilities/src/ui.rs
+++ b/crates/aether-capabilities/src/ui.rs
@@ -213,7 +213,7 @@ mod native {
                     color: mail.color,
                 }],
             };
-            let _ = ctx.actor::<RenderCapability>().send_traced(ctx, &fill);
+            ctx.actor::<RenderCapability>().send(&fill);
             let label = DrawText {
                 font_id: mail.font_id,
                 text: mail.text,
@@ -222,7 +222,7 @@ mod native {
                 origin: [x, y],
                 space: QuadSpace::Screen,
             };
-            let _ = ctx.actor::<TextCapability>().send_traced(ctx, &label);
+            ctx.actor::<TextCapability>().send(&label);
         }
 
         /// Cache the cursor position.

--- a/crates/aether-data/src/name_inventory.rs
+++ b/crates/aether-data/src/name_inventory.rs
@@ -59,6 +59,7 @@ use alloc::string::{String, ToString};
 
 use crate::__inventory::DescriptorEntry;
 use crate::hash::{KIND_DOMAIN, fnv1a_64_prefixed};
+use crate::ids::KindId;
 use crate::tagged_id::{Tag, with_tag};
 use crate::transform::TransformEntry;
 
@@ -210,6 +211,39 @@ pub fn name_entries() -> impl Iterator<Item = &'static NameEntry> {
 /// Iterate every [`TemplateEntry`] collected at link time.
 pub fn template_entries() -> impl Iterator<Item = &'static TemplateEntry> {
     inventory::iter::<TemplateEntry>.into_iter()
+}
+
+/// A native actor's per-handler reply contract, collected at link time
+/// (ADR-0109 §5) — the native analogue of the wasm `aether.kinds.inputs`
+/// custom section's handler record. The `#[actor]` macro submits one
+/// entry per `#[handler]` on a native actor: the owning actor's
+/// `NAMESPACE` (the mailbox the handler is reached at), the handler's
+/// input kind (id + name), and the reply kind id read off the return
+/// type (`None` for a `-> ()` fire-and-forget handler, `Some` for a
+/// `-> R` synchronous or `-> Pending<R>` deferred reply). The
+/// `aether.inventory` cap folds these into the
+/// `aether.inventory.handlers` reply so a driver reads a native cap's
+/// `In -> Out` the way `describe_component` reads a wasm component's.
+///
+/// Owns nothing but `'static` data (`KindId` is a `Copy` `u64` newtype),
+/// so it is const-constructible from `inventory::submit!`.
+pub struct HandlerEntry {
+    /// The owning actor's `NAMESPACE` const (e.g. `"aether.fs"`).
+    pub namespace: &'static str,
+    /// The handler's input kind id (`<K as Kind>::ID`).
+    pub id: KindId,
+    /// The handler's input kind name (`<K as Kind>::NAME`).
+    pub name: &'static str,
+    /// The handler's declared reply kind id — the `R` of `-> R` /
+    /// `-> Pending<R>` — or `None` for a `-> ()` fire-and-forget handler.
+    pub reply: Option<KindId>,
+}
+
+inventory::collect!(HandlerEntry);
+
+/// Iterate every native [`HandlerEntry`] collected at link time.
+pub fn handler_entries() -> impl Iterator<Item = &'static HandlerEntry> {
+    inventory::iter::<HandlerEntry>.into_iter()
 }
 
 /// Map a byte-domain prefix to the ADR-0064 [`Tag`] a reconstructed id

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -2655,6 +2655,49 @@ mod control_plane {
         pub kinds: Vec<KindDescriptorWire>,
     }
 
+    /// One native actor's per-handler reply contract on the wire — the
+    /// mirror of `aether_data::name_inventory::HandlerEntry` (ADR-0109
+    /// §5) and the native analogue of the wasm [`HandlerCapability`].
+    /// `namespace` is the owning cap's mailbox; `id` / `name` are the
+    /// handler's input kind; `reply` is its declared reply kind id
+    /// (`None` for a `-> ()` fire-and-forget handler, `Some` for a
+    /// `-> R` synchronous or `-> Pending<R>` deferred reply). Carries no
+    /// `doc` — the native link-time inventory holds ids + names, so a
+    /// native cap's per-handler docs are out of scope here (the wasm
+    /// `HandlerCapability` carries them from the custom section instead).
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+    pub struct HandlerEntryWire {
+        pub namespace: String,
+        pub id: aether_data::KindId,
+        pub name: String,
+        pub reply: Option<aether_data::KindId>,
+    }
+
+    /// `aether.inventory.handlers` — request the running substrate's
+    /// native handler manifest (ADR-0109 §5): every native chassis cap's
+    /// per-handler `{ namespace, input kind, reply kind }`, collected at
+    /// link time. Empty payload; the request *is* the signal. Mailed to
+    /// the `"aether.inventory"` mailbox; reply: [`HandlersResult`].
+    ///
+    /// The MCP harness uses this to surface a native cap's `In -> Out`
+    /// the way `describe_component` surfaces a wasm component's — the
+    /// reply contract for the caps the driver leans on most
+    /// (`aether.fs`, `aether.render`, `aether.audio`).
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.inventory.handlers")]
+    pub struct ListHandlers {}
+
+    /// Reply to [`ListHandlers`] (ADR-0109 §5). One [`HandlerEntryWire`]
+    /// per `#[handler]` across every native actor linked into the
+    /// substrate, in link order. The harness folds these per `namespace`
+    /// so each native cap reads as a `describe_component`-style handler
+    /// list carrying its `In -> Out` reply contract.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.inventory.handlers_result")]
+    pub struct HandlersResult {
+        pub handlers: Vec<HandlerEntryWire>,
+    }
+
     // Mesh-viewer structured load replies (issue 964). The mesh-viewer
     // component's `aether.mesh.load` was fire-and-forget — failures
     // warn-logged and the prior cache stayed, with no wire signal a
@@ -3877,6 +3920,8 @@ mod tests {
         assert_eq!(ResolveResult::NAME, "aether.inventory.resolve_result");
         assert_eq!(ListKinds::NAME, "aether.inventory.kinds");
         assert_eq!(ListKindsResult::NAME, "aether.inventory.kinds_result");
+        assert_eq!(ListHandlers::NAME, "aether.inventory.handlers");
+        assert_eq!(HandlersResult::NAME, "aether.inventory.handlers_result");
     }
 
     // ADR-0019 PR 3 — every kind below now has a derived `Schema` impl

--- a/crates/aether-mcp/src/args.rs
+++ b/crates/aether-mcp/src/args.rs
@@ -399,6 +399,45 @@ pub struct DescribeHandlesResponse {
     pub top_by_recency: Vec<HandleSummaryJson>,
 }
 
+/// `describe_handlers` arguments (ADR-0109 §5) — describe a substrate's
+/// native chassis caps' reply contracts, the native analogue of
+/// `describe_component`.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DescribeHandlersArgs {
+    /// Engine UUID to query (from `list_engines`).
+    pub engine_id: String,
+}
+
+/// One native `#[handler]`'s reply contract as `describe_handlers`
+/// renders it (ADR-0109 §5). `input_id` / `reply_id` are tagged-id
+/// strings (`knd-XXXX-XXXX-XXXX`). `reply_id` / `reply_name` are `null`
+/// for a fire-and-forget `-> ()` handler; `reply_name` is `null` for a
+/// component-defined reply kind the static substrate vocabulary can't
+/// name.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct NativeHandlerJson {
+    pub input_id: String,
+    pub input_name: String,
+    pub reply_id: Option<String>,
+    pub reply_name: Option<String>,
+}
+
+/// One native cap's handlers, grouped under its mailbox `namespace`
+/// (ADR-0109 §5) — the `describe_component`-style view for a native cap.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct NativeCapHandlers {
+    pub namespace: String,
+    pub handlers: Vec<NativeHandlerJson>,
+}
+
+/// `describe_handlers` response — the native handler manifest folded per
+/// mailbox namespace (ADR-0109 §5).
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct DescribeHandlersResponse {
+    pub engine_id: String,
+    pub caps: Vec<NativeCapHandlers>,
+}
+
 /// `send_mail_traced` arguments — atomic batched dispatch with a shared
 /// trace root (issue iamacoffeepot/aether#749). Every spec lands on the
 /// same engine and inherits the same chassis root, so the response carries one

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -12,7 +12,7 @@
 //! inventory baked into `aether-kinds` and from a component-capability
 //! cache populated by `load_component` / `replace_component`.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
@@ -54,16 +54,19 @@ use crate::args::ActorLogsResponse;
 use crate::args::{ActorCostArgs, ActorCostResponse, ActorCostRow};
 use crate::args::{
     CaptureCheckSpec, CaptureFrameArgs, CaptureMailSpec, ComponentSpec, DagCancelArgs,
-    DagDescriptorArg, DagStatusArgs, DescribeComponentArgs, DescribeHandlesArgs,
-    DescribeHandlesResponse, EngineInfo, HandleSummaryJson, LoadComponentArgs, MailIdJson,
-    MailNodeJson, MailSpec, MailStatus, NodeArg, ReplaceComponentArgs, ReplyEventJson,
+    DagDescriptorArg, DagStatusArgs, DescribeComponentArgs, DescribeHandlersArgs,
+    DescribeHandlersResponse, DescribeHandlesArgs, DescribeHandlesResponse, EngineInfo,
+    HandleSummaryJson, LoadComponentArgs, MailIdJson, MailNodeJson, MailSpec, MailStatus,
+    NativeCapHandlers, NativeHandlerJson, NodeArg, ReplaceComponentArgs, ReplyEventJson,
     SendMailArgs, SendMailTracedArgs, SendMailTracedResponse, SpawnSubstrateArgs, SubmitDagArgs,
     TerminateSubstrateArgs, TracedMailSpec, TransformListing,
 };
 use crate::reverse::EngineNames;
 use crate::rpc::RpcSession;
 use aether_kinds::descriptors;
-use aether_kinds::{Manifest, ManifestResult, Resolve, ResolveResult};
+use aether_kinds::{
+    HandlersResult, ListHandlers, Manifest, ManifestResult, Resolve, ResolveResult,
+};
 use base64::engine::general_purpose::STANDARD;
 use std::time::Duration;
 use tokio::fs;
@@ -725,6 +728,60 @@ impl Mcp {
                 None,
             )),
         }
+    }
+
+    #[tool(
+        description = "Describe a substrate's NATIVE chassis caps' reply contracts (ADR-0109 §5): the native analogue of describe_component. Sends aether.inventory.handlers to the engine's aether.inventory mailbox and decodes aether.inventory.handlers_result — the link-time handler manifest the #[actor] macro populates. Returns the handlers folded per mailbox namespace; each handler carries its input kind (id + name) and its reply kind id+name, so you read a native cap's In -> Out (e.g. aether.fs.read -> aether.fs.read_result) before issuing the call. reply is null for a fire-and-forget handler. Reply kind names resolve best-effort from the static substrate vocabulary; a component-defined reply kind stays null. Use describe_component for a loaded wasm component, describe_kinds for the full schema of any kind."
+    )]
+    pub async fn describe_handlers(
+        &self,
+        Parameters(args): Parameters<DescribeHandlersArgs>,
+    ) -> Result<String, McpError> {
+        let engine = parse_engine_id(&args.engine_id)?;
+        let reply = self
+            .session
+            .call_one(engine_envelope(engine, INVENTORY_CAP, &ListHandlers {}))
+            .await
+            .map_err(internal)?;
+        let Some(HandlersResult { handlers }) = HandlersResult::decode_from_bytes(&reply.payload)
+        else {
+            return Err(internal_msg("undecodable HandlersResult"));
+        };
+        // Fold the flat per-handler manifest per owning namespace so each
+        // native cap reads as a describe_component-style handler list. A
+        // BTreeMap keeps the caps (and their handlers) in a stable order.
+        let mut folded: BTreeMap<String, Vec<NativeHandlerJson>> = BTreeMap::new();
+        for entry in handlers {
+            folded
+                .entry(entry.namespace)
+                .or_default()
+                .push(NativeHandlerJson {
+                    // Input kind id rendered as the ADR-0064 tagged string,
+                    // falling back to a hex literal on an unencodable id.
+                    input_id: tagged_id::encode(entry.id.0)
+                        .unwrap_or_else(|| format!("{:#x}", entry.id.0)),
+                    input_name: entry.name,
+                    // The reply kind id is the contract; resolve its name
+                    // best-effort from the static substrate vocabulary so
+                    // the In -> Out reads without a second lookup. A
+                    // component-defined reply kind stays `None`.
+                    reply_id: entry.reply.map(|id| {
+                        tagged_id::encode(id.0).unwrap_or_else(|| format!("{:#x}", id.0))
+                    }),
+                    reply_name: entry.reply.and_then(static_kind_name),
+                });
+        }
+        let caps = folded
+            .into_iter()
+            .map(|(namespace, handlers)| NativeCapHandlers {
+                namespace,
+                handlers,
+            })
+            .collect();
+        json(&DescribeHandlersResponse {
+            engine_id: args.engine_id,
+            caps,
+        })
     }
 
     #[tool(

--- a/crates/aether-substrate/tests/native_actor_macro.rs
+++ b/crates/aether-substrate/tests/native_actor_macro.rs
@@ -586,3 +586,76 @@ impl NativeActor for TaskRouteCap {
         done.resolve(ctx);
     }
 }
+
+// ADR-0109 §5: the `#[actor]` macro submits a process-global link-time
+// `HandlerEntry` for each native `#[handler]`, carrying the owning
+// `NAMESPACE`, the input kind (id + name), and the reply kind read off
+// the return type. This is the native analogue of the wasm
+// `aether.kinds.inputs` custom section — the `aether.inventory.handlers`
+// query projects it onto the wire.
+
+/// Reply kind for the link-time native-handler-manifest macro test.
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    ::aether_data::Kind,
+    ::aether_data::Schema,
+)]
+#[kind(name = "test.macro_native_actor.pong")]
+struct Pong {
+    echoed: u32,
+}
+
+/// A cap with a synchronous `-> R` handler. Its `#[actor]` expansion
+/// submits a link-time `HandlerEntry` declaring `Greet -> Pong`.
+struct ReplyMacroCap;
+
+#[aether_data::actor]
+impl NativeActor for ReplyMacroCap {
+    type Config = ();
+    const NAMESPACE: &'static str = "test.macro_native_actor.reply";
+
+    fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        Ok(Self)
+    }
+
+    /// A synchronous `-> Pong` handler — the reply contract ADR-0109
+    /// captures from the return type. Stateless: the link-time
+    /// `HandlerEntry` (not handler behaviour) is what this cap exists to
+    /// exercise.
+    #[allow(clippy::unused_self)]
+    #[aether_data::handler]
+    fn on_greet_reply(&self, _ctx: &mut NativeCtx<'_>, mail: Greet) -> Pong {
+        Pong { echoed: mail.tag }
+    }
+}
+
+/// ADR-0109 §5: the macro emits a link-time `HandlerEntry` for each
+/// native `#[handler]`, carrying the owning `NAMESPACE`, the input kind
+/// (id + name), and the reply kind read off the return type. A `-> Pong`
+/// handler surfaces `Greet -> Pong`; the round-trip reads the same entry
+/// back out of the process-global inventory.
+#[test]
+fn macro_emits_native_handler_reply_manifest() {
+    use aether_data::name_inventory::handler_entries;
+    // Reference the cap so its `#[actor]` HandlerEntry submission links
+    // into this test binary.
+    assert_eq!(ReplyMacroCap::NAMESPACE, "test.macro_native_actor.reply");
+
+    let entry = handler_entries()
+        .find(|e| e.namespace == ReplyMacroCap::NAMESPACE && e.id == <Greet as Kind>::ID)
+        .expect("the macro should submit a HandlerEntry for the Greet -> Pong handler");
+    assert_eq!(
+        entry.name,
+        <Greet as Kind>::NAME,
+        "input kind name round-trips"
+    );
+    assert_eq!(
+        entry.reply,
+        Some(<Pong as Kind>::ID),
+        "the `-> Pong` return type is captured as the reply contract (In -> Out)",
+    );
+}


### PR DESCRIPTION
Closes #1806.

## Summary

Adds a native analogue of the wasm `aether.kinds.inputs` custom section so native chassis caps expose their reply contracts the way `describe_component` does for wasm components (ADR-0109 §5, builds on #1803/#1807). A process-global link-time `HandlerEntry { namespace, input kind, reply kind }` inventory is populated by the `#[actor]` macro for native actors (reusing #1803's return-type classification), a new `aether.inventory.handlers` query (→ `HandlersResult`) on `InventoryCapability` serves it, and a `describe_handlers` aether-mcp tool folds it per cap so a native cap surfaces its `In -> Out`.

Wire shape: query `aether.inventory.handlers` (`ListHandlers {}`) → reply `aether.inventory.handlers_result` (`HandlersResult { handlers: Vec<HandlerEntryWire> }`), where `HandlerEntryWire { namespace, id, name, reply: Option<KindId> }` mirrors the wasm `HandlerCapability` plus `namespace`.

Note: also migrates two `aether-capabilities/src/ui.rs` calls from the removed `send_traced(ctx, &x)` to #1808's default-chain-inheriting `send(&x)`. This is a pre-existing break on `main` — #1808 renamed `send_traced` while #1739's `on_button` still called it, and `aether-substrate-bundle` enables the `ui-native` feature, so `nextest --workspace` / `clippy --all-targets` don't compile without it. Two-line in-crate fix to the documented new API.

## Test plan

- `inventory.rs`: a native cap with a `-> ProbeReply` handler surfaces `ProbeReq -> Some(ProbeReply)` through `on_handlers`.
- `native_actor_macro.rs`: round-trips the macro's link-time `HandlerEntry` (`Greet -> Pong`).
- Full workspace: fmt, clippy `-D warnings`, `nextest --workspace` (1820 passed), doc, wasm32 component cross-build.

## Generated by

`/implement` — agent execution of [scoped issue #1806](https://github.com/iamacoffeepot/aether/issues/1806).
