### PR TITLE
feat(actor): pending reply contract for deferred handlers

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -1636,12 +1636,15 @@ fn parse_handler_variant(attr: &Attribute) -> syn::Result<HandlerVariant> {
     }
 }
 
-/// Extract `(O, C)` from a `#[handler(task)]` method's third parameter,
-/// which must be `done: TaskDone<O>` (where `C` defaults to `()`) or
-/// `done: TaskDone<O, C>`. Unlike a mail handler's third parameter (a
-/// `Kind`), a task completion's parameter is the framework's
-/// `TaskDone<...>` — `O` / `C` are its generic arguments, not a kind.
-fn extract_task_handler_types(sig: &Signature) -> syn::Result<(Type, Type)> {
+/// Extract `(O, C, is_borrow)` from a `#[handler(task)]` method's third
+/// parameter, which must be `done: TaskDone<O>` (where `C` defaults to
+/// `()`) or `done: TaskDone<O, C>`, optionally behind a shared `&`.
+/// Unlike a mail handler's third parameter (a `Kind`), a task
+/// completion's parameter is the framework's `TaskDone<...>` — `O` / `C`
+/// are its generic arguments, not a kind. `is_borrow` is `true` when the
+/// parameter is `&TaskDone<…>` (the ADR-0109 opt-in for a macro-driven
+/// reply) versus the by-value `TaskDone<…>` self-resolve form.
+fn extract_task_handler_types(sig: &Signature) -> syn::Result<(Type, Type, bool)> {
     if sig.inputs.len() != 3 {
         return Err(syn::Error::new_spanned(
             sig,
@@ -1664,10 +1667,18 @@ fn extract_task_handler_types(sig: &Signature) -> syn::Result<(Type, Type)> {
             "#[handler(task)] third parameter must be `done: TaskDone<O>` or `TaskDone<O, C>`",
         ));
     };
-    let Type::Path(type_path) = &*pt.ty else {
+    // ADR-0109: `&TaskDone<…>` (the macro-driven reply opt-in) vs the
+    // by-value `TaskDone<…>` self-resolve form. Peel a leading shared
+    // reference and remember which shape it was.
+    let (is_borrow, inner_ty): (bool, &Type) = match &*pt.ty {
+        Type::Reference(r) => (true, &*r.elem),
+        other => (false, other),
+    };
+    let Type::Path(type_path) = inner_ty else {
         return Err(syn::Error::new_spanned(
             &pt.ty,
-            "#[handler(task)] third parameter must be a `TaskDone<O>` / `TaskDone<O, C>` path type",
+            "#[handler(task)] third parameter must be a `TaskDone<O>` / `TaskDone<O, C>` path type \
+             (optionally behind `&`)",
         ));
     };
     let last = type_path.path.segments.last().ok_or_else(|| {
@@ -1717,7 +1728,57 @@ fn extract_task_handler_types(sig: &Signature) -> syn::Result<(Type, Type)> {
             "#[handler(task)] `TaskDone` takes at most two type arguments: `TaskDone<O, C>`",
         ));
     }
-    Ok((output, context))
+    Ok((output, context, is_borrow))
+}
+
+/// How a `#[handler(task)]` completion discharges its reply (ADR-0109),
+/// classified from its third-parameter borrow-ness plus its return type.
+/// The `&TaskDone` borrow is the opt-in signal for a macro-driven reply.
+enum TaskReplyMode {
+    /// `TaskDone<O, C>` by value, `-> ()`: the handler owns the
+    /// completion and calls `done.resolve*` itself (the ADR-0093 path,
+    /// untouched).
+    ByValue,
+    /// `&TaskDone<O, C>` returning `-> R`: the handler borrows the
+    /// completion and returns the reply; the macro calls
+    /// `done.resolve_value(ctx, &r)` and releases the hold.
+    BorrowReply,
+    /// `&TaskDone<O, C>` returning `-> ()`: the handler borrows the
+    /// completion and replies nothing; the macro calls
+    /// `done.release_no_reply()` (the sanctioned no-reply discharge).
+    BorrowNoReply,
+}
+
+/// Classify a `#[handler(task)]` completion's reply discharge from its
+/// third-parameter borrow-ness (`is_borrow`) and return type (ADR-0109).
+/// A by-value `TaskDone` keeps the self-resolve path and must return
+/// `()`; `&TaskDone -> R` sends `R` via `resolve_value`, `&TaskDone -> ()`
+/// releases via `release_no_reply`. A task completion can't itself defer
+/// (`-> Pending<R>`).
+fn classify_task_reply_mode(sig: &Signature, is_borrow: bool) -> syn::Result<TaskReplyMode> {
+    let reply = classify_handler_reply(&sig.output);
+    if is_borrow {
+        match reply {
+            HandlerReply::Sync(_) => Ok(TaskReplyMode::BorrowReply),
+            HandlerReply::None => Ok(TaskReplyMode::BorrowNoReply),
+            HandlerReply::Deferred(_) => Err(syn::Error::new_spanned(
+                &sig.output,
+                "#[handler(task)] cannot return `Pending<R>` — a dispatch completion \
+                 is the terminal reply. Return `R` (the macro sends it via \
+                 `resolve_value`) or `()` (release without replying)",
+            )),
+        }
+    } else {
+        match reply {
+            HandlerReply::None => Ok(TaskReplyMode::ByValue),
+            HandlerReply::Sync(_) | HandlerReply::Deferred(_) => Err(syn::Error::new_spanned(
+                &sig.output,
+                "a by-value `TaskDone<…>` #[handler(task)] must return `()` and call \
+                 `done.resolve*` itself; to have the macro send the reply, borrow it: \
+                 `done: &TaskDone<…>` returning `-> R`",
+            )),
+        }
+    }
 }
 
 /// Wasm-actor expansion — `#[actor] impl FfiActor for X` (or
@@ -2191,11 +2252,14 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
                             });
                         }
                         HandlerVariant::Task => {
-                            let (output_ty, context_ty) = extract_task_handler_types(&f.sig)?;
+                            let (output_ty, context_ty, is_borrow) =
+                                extract_task_handler_types(&f.sig)?;
+                            let mode = classify_task_reply_mode(&f.sig, is_borrow)?;
                             task_handlers.push(NativeActorTaskHandlerFn {
                                 method: f,
                                 output_ty,
                                 context_ty,
+                                mode,
                             });
                         }
                     }
@@ -2476,11 +2540,29 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
             let output_ty = &t.output_ty;
             let context_ty = &t.context_ty;
             let method_ident = &t.method.sig.ident;
+            // ADR-0109: how the completion discharges. By-value hands the
+            // owned `TaskDone` to the handler (it self-resolves);
+            // `&TaskDone -> R` calls the handler for the reply value then
+            // `resolve_value`s it; `&TaskDone -> ()` releases the hold via
+            // `release_no_reply` with no reply.
+            let dispatch = match t.mode {
+                TaskReplyMode::ByValue => quote! {
+                    self.#method_ident(__aether_ctx, __aether_done);
+                },
+                TaskReplyMode::BorrowReply => quote! {
+                    let __aether_reply = self.#method_ident(__aether_ctx, &__aether_done);
+                    __aether_done.resolve_value(__aether_ctx, &__aether_reply);
+                },
+                TaskReplyMode::BorrowNoReply => quote! {
+                    self.#method_ident(__aether_ctx, &__aether_done);
+                    __aether_done.release_no_reply();
+                },
+            };
             quote! {
                 if let ::core::option::Option::Some(__aether_done) =
                     __aether_ctx.try_take_task_done::<#output_ty, #context_ty>(__aether_dispatch_id)
                 {
-                    self.#method_ident(__aether_ctx, __aether_done);
+                    #dispatch
                     return ::core::option::Option::Some(());
                 }
             }
@@ -2694,6 +2776,10 @@ struct NativeActorTaskHandlerFn {
     method: syn::ImplItemFn,
     output_ty: Type,
     context_ty: Type,
+    /// ADR-0109: how the completion discharges its reply — self-resolve
+    /// (by-value), macro-driven `resolve_value` (`&TaskDone -> R`), or
+    /// `release_no_reply` (`&TaskDone -> ()`).
+    mode: TaskReplyMode,
 }
 
 /// Token-level type equality, used to reject duplicate `TaskDone<O>`

--- a/crates/aether-capabilities/src/contentgen/task_queue.rs
+++ b/crates/aether-capabilities/src/contentgen/task_queue.rs
@@ -83,7 +83,7 @@ impl TaskQueue {
     }
 
     /// Accept a unit of blocking work. Under the bound, dispatch it now
-    /// via [`NativeCtx::dispatch_blocking`] (which acquires the hold +
+    /// via [`NativeCtx::dispatch_blocking_with`] (which acquires the hold +
     /// reply target from `ctx`). Over the bound, capture the chain
     /// context *now* — a [`SettlementHold`](aether_substrate::runtime::trace::SettlementHold)
     /// on the current root plus this handler's reply target — and buffer
@@ -97,7 +97,12 @@ impl TaskQueue {
         F: FnOnce() -> O + Send + 'static,
     {
         if self.in_flight < self.max {
-            ctx.dispatch_blocking(work);
+            // `dispatch_blocking_with` (not the bare `dispatch_blocking`,
+            // which now returns a `Pending<R>` and so needs the reply kind
+            // `R` declared, ADR-0109): `TaskQueue` is reply-kind-agnostic
+            // plumbing — its completion handler re-replies the carried
+            // output via `done.resolve`, so there is no `R` to thread here.
+            ctx.dispatch_blocking_with((), work);
             self.in_flight += 1;
         } else {
             // Capture the hold + reply target at accept time so the

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -37,7 +37,7 @@ use crate::runtime::trace::SettlementHold;
 use super::{NativeActor, NativeDispatch};
 use crate::actor::native::InheritCtx;
 use crate::actor::native::RootCtx;
-use crate::actor::native::dispatch_blocking::{DispatchId, TaskCompletionWake, TaskDone};
+use crate::actor::native::dispatch_blocking::{DispatchId, Pending, TaskCompletionWake, TaskDone};
 use crate::actor::native::envelope::Envelope;
 use crate::actor::native::spawn_thread;
 use crate::chassis::inbox::InboundMail;
@@ -312,14 +312,21 @@ impl<'a> NativeCtx<'a> {
     /// [`Self::take_task_done`] to rebuild the [`TaskDone`], then
     /// `resolve`s it.
     ///
-    /// Returns the [`DispatchId`] for *optional* cancellation; the happy
-    /// path ignores it.
-    pub fn dispatch_blocking<O, F>(&mut self, f: F) -> DispatchId
+    /// Returns a [`Pending<R>`] (ADR-0109) — the type-level receipt a
+    /// request handler returns to declare `-> Pending<R>`, naming `R` as
+    /// the reply kind the matching `#[handler(task)]` completion sends.
+    /// The inner [`DispatchId`] is reachable via [`Pending::dispatch_id`]
+    /// for *optional* cancellation; the happy path ignores it. `R` is
+    /// independent of the worker output `O` — the completion handler maps
+    /// `O` to the reply `R` it returns.
+    pub fn dispatch_blocking<O, R, F>(&mut self, f: F) -> Pending<R>
     where
         O: Send + 'static,
+        R: Kind,
         F: FnOnce() -> O + Send + 'static,
     {
-        self.dispatch_blocking_with::<O, (), F>((), f)
+        let id = self.dispatch_blocking_with::<O, (), F>((), f);
+        Pending::new(id)
     }
 
     /// Context-carrying variant of [`Self::dispatch_blocking`]

--- a/crates/aether-substrate/src/actor/native/dispatch_blocking.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch_blocking.rs
@@ -43,6 +43,7 @@
 
 use std::any::Any;
 use std::collections::HashMap;
+use std::marker::PhantomData;
 use std::sync::Mutex;
 
 use aether_data::{Kind, KindId, MailId};
@@ -60,6 +61,48 @@ use super::ctx::NativeCtx;
 /// cancellation — the happy path ignores it.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct DispatchId(pub u64);
+
+/// A type-level "receipt" for a deferred reply (ADR-0109). Returned by
+/// [`dispatch_blocking`](NativeCtx::dispatch_blocking) in place of a bare
+/// [`DispatchId`] so a request handler can declare `-> Pending<R>`: the
+/// reply is an `R`, sent later from the matching `#[handler(task)]`
+/// completion rather than synchronously on this handler's return.
+///
+/// Phantom over `R` only — the actual hold and reply target live in the
+/// in-flight ledger, not here, so a `Pending<R>` carries just the
+/// [`DispatchId`] (reachable via [`Pending::dispatch_id`] for *optional*
+/// cancellation) plus the reply-kind marker. Framework-constructed: only
+/// `dispatch_blocking` mints one, so a signature that declares
+/// `Pending<R>` implies an obligation for `R` was actually armed
+/// (ADR-0109 §3) — it is not user-fabricable.
+pub struct Pending<R: Kind> {
+    dispatch_id: DispatchId,
+    /// `fn() -> R` so `Pending<R>` is covariant in `R` and stays
+    /// `Send`/`Sync` regardless of `R` — it owns no `R`, it only names
+    /// the reply kind.
+    _reply: PhantomData<fn() -> R>,
+}
+
+impl<R: Kind> Pending<R> {
+    /// Wrap the armed dispatch's [`DispatchId`]. Crate-internal — only
+    /// [`dispatch_blocking`](NativeCtx::dispatch_blocking) constructs a
+    /// `Pending`, which is what makes the `-> Pending<R>` contract
+    /// non-forgeable (ADR-0109 §3).
+    pub(crate) fn new(dispatch_id: DispatchId) -> Self {
+        Self {
+            dispatch_id,
+            _reply: PhantomData,
+        }
+    }
+
+    /// The [`DispatchId`] of the armed dispatch, for *optional*
+    /// cancellation. The happy path ignores it — the completion routes
+    /// back through the in-flight ledger without it.
+    #[must_use]
+    pub fn dispatch_id(&self) -> DispatchId {
+        self.dispatch_id
+    }
+}
 
 /// Substrate-internal framework kind the dispatch worker pushes to the
 /// actor's own mailbox when its blocking closure finishes. Carries only
@@ -238,6 +281,32 @@ impl<O, C> TaskDone<O, C> {
     {
         let reply = f(&self.output, &self.context);
         ctx.reply_to_target(self.reply_to, &reply, self.hold_root(), None);
+        self.release();
+    }
+
+    /// Send a precomputed `reply` value through the carried `reply_to`,
+    /// then release the hold (ADR-0109). The deferred-contract form: the
+    /// `#[handler(task)]` completion handler *borrows* the `TaskDone` and
+    /// **returns** the reply, and the `#[actor]` macro hands that value
+    /// here — [`resolve_with`](Self::resolve_with) with the value already
+    /// computed by the handler rather than built in a ctx-less closure.
+    /// Re-replies **first**, then releases the hold (`Sent` before
+    /// `Release`, ADR-0080 §12), like the rest of the `resolve*` family.
+    pub fn resolve_value<R>(mut self, ctx: &mut NativeCtx<'_>, reply: &R)
+    where
+        R: Kind + serde::Serialize,
+    {
+        ctx.reply_to_target(self.reply_to, reply, self.hold_root(), None);
+        self.release();
+    }
+
+    /// Release the hold **without** sending any reply — the sanctioned
+    /// no-reply completion (ADR-0109): a `#[handler(task)]` that borrows
+    /// the `TaskDone` and returns `()` discharges the chain without
+    /// replying. Unlike dropping an un-resolved `TaskDone` (a silent lost
+    /// reply), this is a deliberate signature choice, so it releases
+    /// cleanly and skips the lost-reply `debug_assert`.
+    pub fn release_no_reply(mut self) {
         self.release();
     }
 
@@ -522,7 +591,9 @@ mod tests {
         // worker, return.
         {
             let mut ctx = NativeCtx::new(&binding, caller_reply_to, MailId::NONE, root);
-            let _id = ctx.dispatch_blocking(move || Answer { value: 42 });
+            // The bare `dispatch_blocking` now returns a `Pending<R>`
+            // (ADR-0109); `R` is the declared reply kind (here `Answer`).
+            let _pending = ctx.dispatch_blocking::<Answer, Answer, _>(move || Answer { value: 42 });
         }
 
         // The handler returned but the chain is held: settlement is

--- a/crates/aether-substrate/src/actor/native/mod.rs
+++ b/crates/aether-substrate/src/actor/native/mod.rs
@@ -76,7 +76,7 @@ pub mod spawn_thread;
 
 pub use binding::NativeBinding;
 pub use ctx::{ExportedHandles, NativeCtx, NativeInitCtx};
-pub use dispatch_blocking::{DispatchId, TaskCompletionWake, TaskDone};
+pub use dispatch_blocking::{DispatchId, Pending, TaskCompletionWake, TaskDone};
 // iamacoffeepot/aether#1272: driver-as-actor capabilities that own
 // their inbox drain inline (today only the desktop window driver)
 // reach for the `NativeCtx`-free variants of the framework dispatch

--- a/crates/aether-substrate/tests/native_actor_macro.rs
+++ b/crates/aether-substrate/tests/native_actor_macro.rs
@@ -21,13 +21,14 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering as AtomicOrdering};
+use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
-use aether_data::{Kind, Source};
+use aether_data::{Kind, Source, SourceAddr};
 use aether_kinds::trace::Nanos;
-use aether_substrate::actor::native::TaskDone;
+use aether_substrate::actor::native::{Pending, TaskDone};
 use aether_substrate::handle_store::HandleStore;
-use aether_substrate::mail::registry::OwnedDispatch;
+use aether_substrate::mail::registry::{InboxHandler, OwnedDispatch};
 use aether_substrate::mail::{MailId, MailRef};
 use aether_substrate::{
     Actor, BootError, Builder, BuiltChassis, Chassis, Mailer, NativeActor, NativeCtx,
@@ -375,6 +376,120 @@ mod heavy {
 
         drop(chassis);
     }
+
+    /// ADR-0109: a `-> Pending<R>` request handler plus a borrow-form
+    /// `&TaskDone -> R` completion settles with exactly one reply of `R`.
+    /// The macro arms no immediate reply on the request, and on completion
+    /// calls `resolve_value` with the handler's returned value, routing it
+    /// back to the original caller.
+    #[test]
+    fn macro_pending_request_borrow_completion_replies_once() {
+        let (registry, mailer) = fresh_substrate();
+        let obs = DeferredObs::new();
+
+        let (reply_tx, reply_rx) = mpsc::channel::<OwnedDispatch>();
+        let caller = registry.register_inbox(
+            "test.macro_native_actor.deferred_caller",
+            forward_to(reply_tx),
+        );
+
+        let chassis: PassiveChassis<TestChassis> =
+            Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<DeferredReplyCap>(obs.clone())
+                .build_passive()
+                .expect("deferred-reply cap boots");
+
+        // The inbound names the caller as its reply target, so the deferred
+        // reply routes back there.
+        let caller_reply_to = Source::with_correlation(SourceAddr::Component(caller), 55);
+        push_envelope_replying_to(
+            &registry,
+            DeferredReplyCap::NAMESPACE,
+            &KickP { seed: 21 },
+            caller_reply_to,
+        );
+
+        let reply = reply_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("the deferred reply lands on the caller");
+        assert_eq!(
+            reply.kind,
+            <EchoReply as Kind>::ID,
+            "the completion's `-> EchoReply` return routed back as the reply"
+        );
+        let echoed =
+            EchoReply::decode_from_bytes(reply.payload.bytes()).expect("the reply decodes");
+        assert_eq!(
+            echoed.value, 21,
+            "resolve_value sent the value the completion handler returned"
+        );
+        assert_eq!(
+            reply.sender.correlation_id, 55,
+            "the caller's correlation is echoed onto the reply"
+        );
+        assert_eq!(
+            obs.echo_calls.load(AtomicOrdering::SeqCst),
+            1,
+            "the borrow-form completion handler fired once"
+        );
+
+        // Exactly one reply settles — the macro must not also drop the
+        // TaskDone (which would re-release) or double-send.
+        assert!(
+            reply_rx.recv_timeout(Duration::from_millis(200)).is_err(),
+            "exactly one reply settles for the deferred request"
+        );
+
+        drop(chassis);
+    }
+
+    /// ADR-0109: a borrow-form `&TaskDone -> ()` completion releases the
+    /// hold without sending any reply. The macro emits `release_no_reply`,
+    /// so the completion runs cleanly (no lost-reply `debug_assert`) and
+    /// nothing routes back to the caller.
+    #[test]
+    fn macro_borrow_task_no_reply_releases_without_replying() {
+        let (registry, mailer) = fresh_substrate();
+        let obs = DeferredObs::new();
+
+        let (reply_tx, reply_rx) = mpsc::channel::<OwnedDispatch>();
+        let caller = registry.register_inbox(
+            "test.macro_native_actor.deferred_silent_caller",
+            forward_to(reply_tx),
+        );
+
+        let chassis: PassiveChassis<TestChassis> =
+            Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+                .with_actor::<DeferredReplyCap>(obs.clone())
+                .build_passive()
+                .expect("deferred-reply cap boots");
+
+        let caller_reply_to = Source::with_correlation(SourceAddr::Component(caller), 9);
+        push_envelope_replying_to(
+            &registry,
+            DeferredReplyCap::NAMESPACE,
+            &KickS { seed: 88 },
+            caller_reply_to,
+        );
+
+        assert!(
+            wait_for(1, &obs.silent_calls, Duration::from_secs(2)),
+            "the no-reply completion ran (release_no_reply, no lost-reply panic)"
+        );
+        assert_eq!(
+            obs.silent_value.load(AtomicOrdering::SeqCst),
+            88,
+            "the no-reply completion saw its own worker output"
+        );
+
+        // No reply was sent — release_no_reply discharges without replying.
+        assert!(
+            reply_rx.recv_timeout(Duration::from_millis(200)).is_err(),
+            "a `&TaskDone -> ()` completion sends nothing back to the caller"
+        );
+
+        drop(chassis);
+    }
 }
 
 /// Type-level assertion that the macro emits the universal
@@ -551,7 +666,11 @@ impl NativeActor for TaskRouteCap {
     fn on_kick_a(&self, ctx: &mut NativeCtx<'_>, mail: KickA) {
         self.obs.dispatched.fetch_add(1, AtomicOrdering::SeqCst);
         let seed = mail.seed;
-        ctx.dispatch_blocking(move || ResultA { value: seed });
+        // This cap's completions self-resolve (by-value `TaskDone`), so
+        // the request handler returns `()` and dispatches via
+        // `dispatch_blocking_with` rather than the `Pending<R>`-returning
+        // `dispatch_blocking` (ADR-0109).
+        ctx.dispatch_blocking_with((), move || ResultA { value: seed });
     }
 
     /// Dispatch a worker that produces a `ResultB`.
@@ -559,7 +678,7 @@ impl NativeActor for TaskRouteCap {
     fn on_kick_b(&self, ctx: &mut NativeCtx<'_>, mail: KickB) {
         self.obs.dispatched.fetch_add(1, AtomicOrdering::SeqCst);
         let seed = mail.seed;
-        ctx.dispatch_blocking(move || ResultB { tag: seed });
+        ctx.dispatch_blocking_with((), move || ResultB { tag: seed });
     }
 
     /// `ResultA` completion handler. Records the value + a call so the
@@ -658,4 +777,201 @@ fn macro_emits_native_handler_reply_manifest() {
         Some(<Pong as Kind>::ID),
         "the `-> Pong` return type is captured as the reply contract (In -> Out)",
     );
+}
+
+// ADR-0109 deferred reply contract (#1805): a `-> Pending<R>` request
+// handler plus a borrow-form `#[handler(task)]` completion. `&TaskDone ->
+// R` has the macro send `R` via `resolve_value`; `&TaskDone -> ()` has it
+// release the hold via `release_no_reply` with no reply. The fixtures
+// below drive both through a real chassis and observe what routes back to
+// a registered caller inbox.
+
+/// Forward every dispatched envelope onto `tx` so a test can observe the
+/// reply (or its absence) on a registered caller mailbox.
+fn forward_to(tx: mpsc::Sender<OwnedDispatch>) -> Arc<dyn InboxHandler> {
+    Arc::new(move |dispatch: OwnedDispatch| {
+        // ADR-0094: terminal test consumer — discharge before the value is
+        // forwarded for the test to observe.
+        dispatch.discharge();
+        let _ = tx.send(dispatch);
+    })
+}
+
+/// Like [`push_envelope`] but stamps an explicit `reply_to` [`Source`] so
+/// the handler's deferred reply has somewhere to route — a registered
+/// caller inbox the test reads back.
+fn push_envelope_replying_to<K: Kind>(
+    registry: &Registry,
+    recipient: &str,
+    payload: &K,
+    reply_to: Source,
+) {
+    use aether_substrate::mail::registry::MailboxEntry;
+    let id: MailboxId = registry.lookup(recipient).expect("mailbox registered");
+    let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("entry exists") else {
+        panic!("expected mailbox entry under {recipient}");
+    };
+    let bytes = payload.encode_into_bytes();
+    handler.enqueue(OwnedDispatch::disarmed(
+        <K as Kind>::ID,
+        K::NAME.to_owned(),
+        None,
+        reply_to,
+        MailRef::from(bytes),
+        1,
+        MailId::NONE,
+        MailId::NONE,
+        None,
+        Nanos(0),
+        0,
+        MailboxId(0),
+    ));
+}
+
+/// Trigger for the reply path: makes the cap dispatch an `EchoReply`
+/// worker behind a `-> Pending<EchoReply>` request handler.
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    ::aether_data::Kind,
+    ::aether_data::Schema,
+)]
+#[kind(name = "test.macro_native_actor.kick_p")]
+struct KickP {
+    seed: u64,
+}
+
+/// Trigger for the no-reply path: makes the cap dispatch a `Silent`
+/// worker whose completion releases the hold without replying.
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    ::aether_data::Kind,
+    ::aether_data::Schema,
+)]
+#[kind(name = "test.macro_native_actor.kick_s")]
+struct KickS {
+    seed: u64,
+}
+
+/// The deferred reply kind — what the `&TaskDone -> EchoReply` completion
+/// returns and the macro sends via `resolve_value`. Postcard-shape so the
+/// reply (postcard-encoded by `Mailer::send_reply`) round-trips through
+/// `EchoReply::decode_from_bytes`.
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    ::aether_data::Kind,
+    ::aether_data::Schema,
+)]
+#[kind(name = "test.macro_native_actor.echo_reply")]
+struct EchoReply {
+    value: u64,
+}
+
+/// The no-reply path's worker output — a distinct output type from
+/// `EchoReply` so the two task handlers route by output type. Never
+/// replied; the completion records it and releases.
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    ::aether_data::Kind,
+    ::aether_data::Schema,
+)]
+#[kind(name = "test.macro_native_actor.silent")]
+struct Silent {
+    value: u64,
+}
+
+/// Where the deferred-reply cap records what its completion handlers
+/// observed, so a test can assert each fired with the right value.
+#[derive(Clone)]
+struct DeferredObs {
+    /// How many times the `&TaskDone -> EchoReply` completion fired.
+    echo_calls: Arc<AtomicU32>,
+    /// How many times the `&TaskDone -> ()` completion fired.
+    silent_calls: Arc<AtomicU32>,
+    /// The `value` the no-reply completion saw on its worker output.
+    silent_value: Arc<AtomicU64>,
+}
+
+impl DeferredObs {
+    fn new() -> Self {
+        Self {
+            echo_calls: Arc::new(AtomicU32::new(0)),
+            silent_calls: Arc::new(AtomicU32::new(0)),
+            silent_value: Arc::new(AtomicU64::new(0)),
+        }
+    }
+}
+
+struct DeferredReplyCap {
+    obs: DeferredObs,
+}
+
+impl aether_actor::Singleton for DeferredReplyCap {}
+
+#[aether_data::actor]
+impl NativeActor for DeferredReplyCap {
+    type Config = DeferredObs;
+    const NAMESPACE: &'static str = "test.macro_native_actor.deferred";
+
+    fn init(config: Self::Config, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        Ok(Self { obs: config })
+    }
+
+    /// Reply path: `-> Pending<EchoReply>` declares the deferred reply
+    /// kind on the request signature and arms an `EchoReply` worker; the
+    /// macro sends nothing now.
+    #[allow(clippy::unused_self)]
+    #[aether_data::handler]
+    fn on_kick_p(&self, ctx: &mut NativeCtx<'_>, mail: KickP) -> Pending<EchoReply> {
+        let seed = mail.seed;
+        ctx.dispatch_blocking(move || EchoReply { value: seed })
+    }
+
+    /// Borrow-form completion: returns the reply; the macro calls
+    /// `resolve_value` with it and releases the hold.
+    #[aether_data::handler(task)]
+    fn on_echo_done(&self, _ctx: &mut NativeCtx<'_>, done: &TaskDone<EchoReply>) -> EchoReply {
+        self.obs.echo_calls.fetch_add(1, AtomicOrdering::SeqCst);
+        EchoReply {
+            value: done.output().value,
+        }
+    }
+
+    /// No-reply path: returns `()`, so it dispatches via
+    /// `dispatch_blocking_with` (no `Pending<R>` contract to declare).
+    #[allow(clippy::unused_self)]
+    #[aether_data::handler]
+    fn on_kick_s(&self, ctx: &mut NativeCtx<'_>, mail: KickS) {
+        let seed = mail.seed;
+        ctx.dispatch_blocking_with((), move || Silent { value: seed });
+    }
+
+    /// Borrow-form no-reply completion: returns `()`, so the macro calls
+    /// `release_no_reply` — the hold releases with no reply sent.
+    #[aether_data::handler(task)]
+    fn on_silent_done(&self, _ctx: &mut NativeCtx<'_>, done: &TaskDone<Silent>) {
+        self.obs
+            .silent_value
+            .store(done.output().value, AtomicOrdering::SeqCst);
+        self.obs.silent_calls.fetch_add(1, AtomicOrdering::SeqCst);
+    }
 }


### PR DESCRIPTION
Closes #1805.

## Summary

Implements the deferred slice of ADR-0109 (builds on #1803/#1807): a request handler returns `Pending<R>` to declare "the reply is `R`, sent later," and the completion handler returns `-> R` (the macro sends it and releases the hold), with the ADR-0093 `dispatch_blocking` → `#[handler(task)]` mechanic otherwise unchanged.

- `Pending<R>` is a phantom receipt (`PhantomData<fn() -> R>`) over `R: Kind`, returned by `dispatch_blocking` in place of the bare `DispatchId` (the id stays accessible for cancellation).
- `TaskDone::resolve_value(self, ctx, &R)` sends the precomputed reply and releases; `TaskDone::release_no_reply(self)` releases without the lost-reply assert.
- The `#[actor]` macro classifies a `#[handler(task)]` by its `TaskDone` param: `&TaskDone -> R` → `resolve_value`, `&TaskDone -> ()` → `release_no_reply`, by-value `TaskDone -> ()` → the existing self-resolve (untouched). By-value `-> R` and `&TaskDone -> Pending<R>` are rejected with pointed errors. The `-> Pending<R>` request classification and manifest reply-publishing already landed in #1803.

`Pending` is exposed at `aether_substrate::actor::native::Pending` — dispatch is native-only (ADR-0093 §7), and `aether-actor` can't depend on `aether-substrate` without inverting the crate layering, so a re-export from the guest SDK isn't feasible (and a wasm guest has no `Pending` producer regardless).

## Test plan

- `macro_pending_request_borrow_completion_replies_once`: a `-> Pending<R>` request + `&TaskDone -> R` completion settles once with one `R` reply (value + correlation verified).
- `macro_borrow_task_no_reply_releases_without_replying`: `&TaskDone -> ()` runs the completion and routes nothing back.
- The existing by-value `resolve`-calling task handler still compiles (signatures updated to `dispatch_blocking_with`).
- Full workspace: fmt, clippy `-D warnings`, `nextest --workspace`, doc, wasm32 component cross-build.

## Generated by

`/implement` — agent execution of [scoped issue #1805](https://github.com/iamacoffeepot/aether/issues/1805).
