### PR TITLE
feat(kit): port the locomotion hud onto the aether.ui capability

### DIFF
--- a/crates/aether-kit/Cargo.toml
+++ b/crates/aether-kit/Cargo.toml
@@ -28,7 +28,7 @@ runtime = []
 
 [dependencies]
 aether-actor = { path = "../aether-actor" }
-aether-capabilities = { path = "../aether-capabilities", default-features = false, features = ["render"] }
+aether-capabilities = { path = "../aether-capabilities", default-features = false, features = ["render", "ui"] }
 aether-data = { path = "../aether-data", features = ["derive"] }
 aether-kinds = { path = "../aether-kinds" }
 aether-math = { path = "../aether-math" }

--- a/crates/aether-kit/src/runtime.rs
+++ b/crates/aether-kit/src/runtime.rs
@@ -77,10 +77,10 @@ use std::collections::{BinaryHeap, VecDeque};
 use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
 use aether_capabilities::input::InputMailboxExt;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
-use aether_capabilities::{InputCapability, LifecycleCapability, RenderCapability};
+use aether_capabilities::{InputCapability, LifecycleCapability, RenderCapability, UiCapability};
 use aether_kinds::{
-    Camera, DrawTriangle, Key, KeyRelease, MouseButton, MouseMove, Render, Tick, Vertex,
-    WindowSize, keycode,
+    Camera, DrawTriangle, Key, KeyRelease, MouseButton, MouseMove, Render, Tick, UiBar, UiPanel,
+    Vertex, WindowSize, keycode,
 };
 use aether_math::{Mat4, Vec3};
 
@@ -436,6 +436,9 @@ impl FfiActor for Locomotion {
             view_proj: self.view_proj(),
         });
         render.send_many(&self.render_triangles());
+        // The HUD composes on the `aether.ui` cap in screen space, kept
+        // separate from the world geometry above.
+        self.send_hud(ctx);
     }
 
     #[handler]
@@ -838,87 +841,48 @@ impl Locomotion {
         let ax = self.mover.x as f32 / OCTIMETERS_PER_TILE as f32;
         let az = self.mover.z as f32 / OCTIMETERS_PER_TILE as f32;
         push_capsule(&mut out, ax, az, mover_color(self.cell));
-        // HUD: a health bar pinned to the top of the screen, drawn last so it
-        // sits over the scene. A dark backing plate, then a fill that shrinks
-        // and reddens as health drops.
-        let hud = Hud::new(self.camera_eye_target(), self.aspect());
-        hud.quad(
-            &mut out,
-            [-0.55, 0.55, 0.84, 0.92],
-            0.50,
-            (0.10, 0.10, 0.13),
-        );
-        let frac = self.health as f32 / HEALTH_MAX as f32;
-        if frac > 0.0 {
-            // A touch closer than the backing so it wins the depth test.
-            let rect = [-0.52, frac.mul_add(1.04, -0.52), 0.855, 0.905];
-            hud.quad(&mut out, rect, 0.49, health_color(frac));
-        }
         out
     }
-}
 
-/// A projector for screen-pinned HUD quads: it places a quad given in NDC at a
-/// fixed depth along the camera ray, so the quad holds its screen position as
-/// the camera orbits.
-struct Hud {
-    eye: Vec3,
-    fwd: Vec3,
-    right: Vec3,
-    up: Vec3,
-    scale_x: f32,
-    scale_y: f32,
-}
-
-impl Hud {
-    /// Build from the camera's eye/target and the viewport aspect — the same
-    /// basis `pick_world` derives, reused to project the other way.
-    fn new((eye, target): (Vec3, Vec3), aspect: f32) -> Self {
-        let fwd = (target - eye).normalize();
-        let right = fwd.cross(Vec3::Y).normalize();
-        let up = right.cross(fwd);
-        let tan = (CAMERA_FOV_Y * 0.5).tan();
-        Self {
-            eye,
-            fwd,
-            right,
-            up,
-            scale_x: tan * aspect,
-            scale_y: tan,
+    /// Mail the screen-anchored health HUD to the `aether.ui` cap: a dark
+    /// backing `panel` plate under a health `bar` whose fill shrinks and
+    /// reddens as health drops. The rects are screen-pixel rects derived from
+    /// the cached window size and resent every frame in immediate mode.
+    /// Skipped in preview (the parameter contact sheet carries no mover or
+    /// HUD) and before the first `WindowSize` establishes a real viewport.
+    fn send_hud(&self, ctx: &mut FfiCtx<'_>) {
+        if self.preview != 0 {
+            return;
         }
-    }
-
-    /// Append a flat-coloured quad covering the NDC rectangle `[x0, x1, y0, y1]`
-    /// at `depth` along the camera ray — smaller depth draws nearer, so layered
-    /// HUD pieces win the depth test in order.
-    fn quad(&self, out: &mut Vec<DrawTriangle>, rect: [f32; 4], depth: f32, rgb: (f32, f32, f32)) {
-        let [x0, x1, y0, y1] = rect;
-        let corner = |nx: f32, ny: f32| {
-            self.eye
-                + self.fwd * depth
-                + self.right * (nx * self.scale_x * depth)
-                + self.up * (ny * self.scale_y * depth)
-        };
-        let (r, g, b) = rgb;
-        let v = |p: Vec3| Vertex {
-            x: p.x,
-            y: p.y,
-            z: p.z,
-            r,
-            g,
-            b,
-        };
-        let (p00, p10, p11, p01) = (
-            corner(x0, y0),
-            corner(x1, y0),
-            corner(x1, y1),
-            corner(x0, y1),
-        );
-        out.push(DrawTriangle {
-            verts: [v(p00), v(p10), v(p11)],
+        let (width, height) = self.window;
+        if width == 0 || height == 0 {
+            return;
+        }
+        let (width, height) = (width as f32, height as f32);
+        // A centered strip near the top edge: the dark plate, then a fill
+        // track inset within it. Both are fractions of the window so the HUD
+        // holds its screen position at any size — the anchoring the
+        // camera-ray projector used to stand in for.
+        let plate = [0.225 * width, 0.040 * height, 0.550 * width, 0.040 * height];
+        let track = [
+            0.240 * width,
+            0.0475 * height,
+            0.520 * width,
+            0.025 * height,
+        ];
+        let frac = self.health as f32 / HEALTH_MAX as f32;
+        let (fill_r, fill_g, fill_b) = health_color(frac);
+        let plate_color = [0.10, 0.10, 0.13, 1.0];
+        let ui = ctx.actor::<UiCapability>();
+        ui.send(&UiPanel {
+            rect: plate,
+            color: plate_color,
         });
-        out.push(DrawTriangle {
-            verts: [v(p00), v(p11), v(p01)],
+        ui.send(&UiBar {
+            rect: track,
+            frac,
+            track_color: plate_color,
+            fill_color: [fill_r, fill_g, fill_b, 1.0],
         });
     }
 }

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -14,7 +14,7 @@ use aether_capabilities::LifecycleCapability;
 use aether_capabilities::{
     CaptureBackend, FsCapability, HandleCapability, HeadlessWindowCapability, InputCapability,
     InputConfig, RenderCapability, RenderConfig, RenderHandles, TcpCapability, TextCapability,
-    fs::NamespaceRoots, trace::TraceDispatchCapability,
+    UiCapability, fs::NamespaceRoots, trace::TraceDispatchCapability,
 };
 use aether_capabilities::{ComponentHostCapability, ComponentHostConfig};
 use aether_data::Kind;
@@ -311,6 +311,7 @@ impl TestBenchChassis {
             .with_actor::<TcpCapability>(())
             .with_actor::<RenderCapability>(render_config)
             .with_actor::<TextCapability>(())
+            .with_actor::<UiCapability>(())
             .with_actor::<HeadlessWindowCapability>(())
             .with_actor::<TestBenchCapability>(test_bench_cap_config)
             .with_actor::<LifecycleCapability>(frame_lifecycle_config());

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -35,7 +35,8 @@ use aether_kinds::{
     DeleteResult, DrawSolidQuads, DrawText, DrawTexturedQuads, DropComponent, DropResult,
     FrameCheck, FrameCheckResult, FrameReduction, FsError, List, ListResult, LoadComponent,
     LoadFont, LoadFontResult, LoadResult, MailEnvelope, Ping, QuadScale, QuadSpace, Read,
-    ReadResult, ReplaceComponent, ReplaceResult, SolidQuad, TexturedQuad, Write, WriteResult,
+    ReadResult, ReplaceComponent, ReplaceResult, SolidQuad, TexturedQuad, UiBar, UiPanel, Write,
+    WriteResult,
 };
 use aether_math::{Mat4, Vec3};
 use aether_substrate_bundle::test_bench::{
@@ -842,6 +843,95 @@ fn solid_quad_draws_screen_space_rect() {
     assert!(
         cleared_coverage < 0.01,
         "after the solid quad stopped being sent the frame should be uniform clear color, \
+         but coverage was {cleared_coverage} (immediate-mode clear did not run)",
+    );
+}
+
+/// iamacoffeepot/aether#1740: the locomotion HUD composes on the
+/// `aether.ui` cap in screen space. This drives the same widget mail the
+/// kit now sends — a dark `UiPanel` backing plate under a `UiBar` health
+/// fill in a centered strip near the top edge — and asserts the bar lands
+/// where a screen-anchored HUD should: a coverage band (a bar is drawn,
+/// the frame is neither empty nor full) with the lit centroid sitting in
+/// the top of the frame and horizontally centered. A second capture after
+/// an advance with nothing resent asserts the immediate-mode clear.
+#[test]
+#[allow(clippy::cast_precision_loss)]
+fn ui_hud_draws_screen_space_health_bar() {
+    if !require_wgpu_only() {
+        return;
+    }
+    let (frame_width, frame_height) = (128u32, 96u32);
+    let mut bench = TestBench::start_with_size(frame_width, frame_height).expect("boot");
+
+    // A centered strip near the top edge, mirroring the kit's HUD layout:
+    // the dark plate, then the health fill inset within it.
+    let plate_color = [0.10, 0.10, 0.13, 1.0];
+    let pre = vec![
+        envelope(
+            "aether.ui",
+            &UiPanel {
+                rect: [29.0, 8.0, 70.0, 12.0],
+                color: plate_color,
+            },
+        ),
+        envelope(
+            "aether.ui",
+            &UiBar {
+                rect: [31.0, 10.0, 66.0, 8.0],
+                frac: 0.7,
+                track_color: plate_color,
+                // A bright fill so the bar reads clearly against the plate.
+                fill_color: [0.25, 0.82, 0.32, 1.0],
+            },
+        ),
+    ];
+
+    let captured = bench
+        .execute(vec![("snap", BenchOp::capture_with_mails(pre, vec![]))])
+        .expect("capture-with-mails");
+    let png = captured.captured("snap").expect("snap step ran");
+    let img = decode_png(png).expect("decode capture png");
+    let bg = background_top_left(&img);
+    let tolerance = 5;
+
+    // A bar is drawn: coverage sits in a band, neither an empty frame nor a
+    // fully filled one.
+    let drawn = coverage(&img, bg, tolerance);
+    assert!(
+        (0.02..0.40).contains(&drawn),
+        "HUD bar coverage {drawn} fell outside the expected band (0.02, 0.40); \
+         the captured frame is effectively empty or entirely filled",
+    );
+
+    // Screen-anchored at the top: the lit centroid lands in the top of the
+    // frame and stays horizontally centered.
+    let (cx, cy) = centroid(&img, bg, tolerance).expect("a lit frame has a centroid");
+    assert!(
+        cy < frame_height as f32 * 0.4,
+        "HUD centroid y={cy} should sit in the top of the {frame_height}-tall frame \
+         (the bar is anchored near the top edge)",
+    );
+    assert!(
+        (frame_width as f32 * 0.2..frame_width as f32 * 0.8).contains(&cx),
+        "HUD centroid x={cx} should sit toward the horizontal center of the \
+         {frame_width}-wide frame (the bar is centered)",
+    );
+
+    // Immediate-mode clear: advance with nothing resent, next capture
+    // returns to the clear color.
+    let cleared = bench
+        .execute(vec![
+            ("clear_advance", BenchOp::advance(1)),
+            ("snap2", BenchOp::capture()),
+        ])
+        .expect("advance + capture");
+    let png2 = cleared.captured("snap2").expect("snap2 step ran");
+    let img2 = decode_png(png2).expect("decode cleared png");
+    let cleared_coverage = coverage(&img2, background_top_left(&img2), tolerance);
+    assert!(
+        cleared_coverage < 0.01,
+        "after the HUD widgets stopped being sent the frame should be uniform clear color, \
          but coverage was {cleared_coverage} (immediate-mode clear did not run)",
     );
 }

--- a/docs/guide/SUMMARY.md
+++ b/docs/guide/SUMMARY.md
@@ -44,6 +44,7 @@
   - [Adding a config knob](recipes/adding-a-config-knob.md)
   - [Adding a substrate kind](recipes/adding-a-substrate-kind.md)
   - [Drawing your first text](recipes/drawing-text.md)
+  - [Drawing your first UI](recipes/drawing-ui.md)
   - [Adding a chassis capability](recipes/adding-a-chassis-capability.md)
   - [Wiring an MCP tool](recipes/wiring-an-mcp-tool.md)
   - [Writing a component](recipes/writing-a-component.md)

--- a/docs/guide/recipes/drawing-ui.md
+++ b/docs/guide/recipes/drawing-ui.md
@@ -1,0 +1,150 @@
+# Drawing your first UI
+
+**Class:** drive. No recompile — a running engine, a TTF asset, and a few
+pieces of mail. Reach for the MCP harness (`send_mail`) or a component's
+`ctx`; the steps are identical.
+
+The `aether.ui` capability draws immediate-mode widgets in screen space. You
+mail it a panel, a bar, a label, or a button each frame, and it composes them
+onto the renderer's solid-quad and text surfaces the same tick. Every widget
+takes a `rect` of `[x, y, width, height]` in window pixels, with `(0, 0)` at
+the top-left corner. Send a widget every frame it should be on screen; stop
+sending it and it vanishes — the same contract as `aether.draw_triangle`.
+
+## 1. A backing panel
+
+A panel is a flat-colored rectangle — the plate a HUD sits on, or a dialog
+background. Mail `aether.ui.panel` to the `aether.ui` mailbox:
+
+```jsonc
+// send_mail → aether.ui  (kind: aether.ui.panel), fire-and-forget
+{
+  "rect": [24.0, 16.0, 240.0, 48.0],   // x, y, width, height in pixels
+  "color": [0.10, 0.10, 0.13, 1.0]     // RGBA, linear; alpha scales the blend
+}
+```
+
+The capability forwards it as one screen-space solid quad to `aether.render`
+the same tick. Resend it every frame the panel should hold.
+
+## 2. A progress bar
+
+A bar draws two layers in one widget: a `track` filling the whole rect, and a
+`fill` covering `frac` of the width from the left. It is the health bar, the
+load meter, the cooldown sweep. Mail `aether.ui.bar`:
+
+```jsonc
+// send_mail → aether.ui  (kind: aether.ui.bar), fire-and-forget
+{
+  "rect": [28.0, 22.0, 232.0, 16.0],
+  "frac": 0.7,                         // clamped to [0, 1] by the cap
+  "track_color": [0.10, 0.10, 0.13, 1.0],
+  "fill_color": [0.25, 0.82, 0.32, 1.0]
+}
+```
+
+`frac` is the only value you animate frame to frame — drop it toward `0.0` and
+the fill shrinks and you recolor it to taste. The locomotion kit's health HUD
+is exactly a panel plate under a bar whose `fill_color` reddens as `frac`
+falls.
+
+## 3. A text label
+
+A label needs a font. Load one through the text capability first — the same
+`aether.text.load_font` from [Drawing your first text](drawing-text.md) — and
+hold onto the `font_id` it replies with:
+
+```jsonc
+// send_mail → aether.text  (kind: aether.text.load_font)
+{ "namespace": "assets", "path": "fonts/RobotoMono.ttf" }
+// reply: { "Ok": { "font_id": 0, "name": "RobotoMono", "resident_bytes": 183700 } }
+```
+
+Then mail `aether.ui.label` with that `font_id`. The string flows from `(x, y)`
+along the baseline:
+
+```jsonc
+// send_mail → aether.ui  (kind: aether.ui.label), fire-and-forget
+{
+  "x": 28.0,
+  "y": 14.0,
+  "font_id": 0,
+  "text": "HEALTH",
+  "size_pixels": 14.0,
+  "color": [1.0, 1.0, 1.0, 1.0]
+}
+```
+
+The capability forwards it as a screen-space `aether.text.draw`, so an unknown
+`font_id` warn-drops in the text cap. Resend it every frame.
+
+## 4. A button you can click
+
+A button draws a filled rect with a centered text label and records its rect
+for hit-testing. Mail `aether.ui.button` every frame, carrying a caller-stable
+`id`:
+
+```jsonc
+// send_mail → aether.ui  (kind: aether.ui.button), fire-and-forget
+{
+  "id": 1,
+  "rect": [24.0, 80.0, 120.0, 40.0],
+  "color": [0.18, 0.20, 0.26, 1.0],
+  "font_id": 0,
+  "text": "Restart",
+  "size_pixels": 18.0,
+  "text_color": [1.0, 1.0, 1.0, 1.0]
+}
+```
+
+A left-click inside the rect replies `aether.ui.clicked { id }` to the sender
+within one frame, carrying the same `id` you drew with — your stable handle for
+the widget. When buttons overlap, the topmost (last-drawn) one wins.
+
+In a component, you receive that reply with a handler on the clicked kind:
+
+```rust
+#[handler]
+fn on_clicked(&mut self, _ctx: &mut FfiCtx<'_>, click: UiClicked) {
+    if click.id == RESTART_BUTTON {
+        self.restart();
+    }
+}
+```
+
+The cap delivers `aether.ui.clicked` by `id` to the component that drew the
+button, read from the host-stamped source of the button mail. Subscribe to
+nothing extra — the reply routes to you because you sent the button.
+
+## 5. See it
+
+From the MCP harness, `capture_frame` with the widgets in `mails` renders a
+frame with the HUD composited on top:
+
+```jsonc
+// capture_frame
+{
+  "mails": [
+    { "recipient_name": "aether.ui", "kind_name": "aether.ui.panel",
+      "params": { "rect": [24.0, 16.0, 240.0, 48.0], "color": [0.10, 0.10, 0.13, 1.0] } },
+    { "recipient_name": "aether.ui", "kind_name": "aether.ui.bar",
+      "params": { "rect": [28.0, 22.0, 232.0, 16.0], "frac": 0.7,
+                  "track_color": [0.10, 0.10, 0.13, 1.0],
+                  "fill_color": [0.25, 0.82, 0.32, 1.0] } }
+  ]
+}
+```
+
+## What it does not do yet
+
+- **Screen space only.** Widgets anchor in window pixels; there is no
+  world-anchored panel or bar in the vocabulary yet. (Text alone reaches world
+  space through `aether.text.draw`'s `World` mode.)
+- **Buttons activate on left-press.** The mouse-button stream carries no button
+  discriminant or release in v1, so a button fires on left-press, and only a
+  left one.
+- **Layout is yours.** Each widget takes an explicit rect — there is no
+  flow, stacking, or anchoring layer above these kinds.
+
+All of these sit behind the `aether.ui.*` kinds, so the internals can grow
+without changing the mail you send.


### PR DESCRIPTION
Closes #1740.

## Summary

Ports the locomotion shell's hand-rolled HUD onto the `aether.ui` capability (the proof-of-use for the #1735 umbrella, completing it). The `Hud` struct and its NDC-along-the-camera-ray world-rect projector are deleted; the shell now mails `aether.ui.panel` (backing plate) + `aether.ui.bar` (health fill, `frac` + the preserved `health_color(frac)`) each frame in screen-pixel rects derived from the cached `WindowSize`, addressed via `ctx.actor::<UiCapability>()` (no bare-string mailbox). The UI cap renders them screen-anchored, so the shell no longer owns any HUD geometry.

Two changes beyond the literal plan, both required for the port to route end-to-end:
- `aether-kit` now enables the `ui` feature on its `aether-capabilities` dependency — `UiCapability` is feature-gated, and the kit's standalone wasm cross-build fails without it (a workspace clippy masks it via feature unification, the #1365 gap).
- `UiCapability` is registered in the test-bench chassis (it was only in `chassis_common`), so `aether.ui` mail routes under the test bench instead of warn-dropping.

A new `drawing-ui` recipe lands alongside, mirroring `drawing-text.md` — load a font, mail panel/bar/label/button each frame, read `aether.ui.clicked` back. It doubles as the tutorial-sanity-check on the #1738/#1739 surface.

## Test plan

- `ui_hud_draws_screen_space_health_bar` (test bench): drives the same `UiPanel` + `UiBar` mail the kit now sends and asserts the screen-space bar via the `visual` coverage + centroid reductions (coverage band, centroid top-of-frame and horizontally centered), plus the immediate-mode clear. (No pre-existing HUD visual test existed.)
- Full workspace: fmt, clippy `-D warnings`, `nextest --workspace` (1823 passed), doc, wasm32 component cross-build (incl. the kit).

## Generated by

`/implement` — agent execution of [scoped issue #1740](https://github.com/iamacoffeepot/aether/issues/1740).
