### PR TITLE
refactor(workflow): board tracks only phase, lift the rest to labels

### DIFF
--- a/.claude/skills/approve/SKILL.md
+++ b/.claude/skills/approve/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: approve
-description: Plan → Ready gate. Validates that an issue's scope artifacts are complete and any drafted ADR has merged, then sets AgentReady=Yes and advances Phase to Ready. Does NOT dispatch implementation — that's /implement's job. Idempotent on re-run. `--sweep` discovers and batch-approves every Plan-complete issue behind one confirmation.
+description: Plan → Ready gate. Validates that an issue's scope artifacts are complete and any drafted ADR has merged, then advances Phase to Ready. Does NOT dispatch implementation — that's /implement's job. Idempotent on re-run. `--sweep` discovers and batch-approves every Plan-complete issue behind one confirmation.
 ---
 
 # /approve — Plan → Ready gate
@@ -19,7 +19,7 @@ The primary human review point of the release flow. The user invokes `/approve <
 
    This is the REST issues endpoint (per `/scope` §REST-vs-GraphQL routing), not `gh issue list`, which is GraphQL-backed and drains the contended pool.
 
-2. **Gate-check each candidate.** Run the full [gate checks](#gate-checks) per issue — `Phase == Plan`, the three §-sections present and non-empty, every referenced ADR PR merged, exactly one `model:*` label, `AgentReady` not blocked by a label. Drop any issue that fails and record the reason; the sweep never silently skips — every dropped issue is listed in the plan with its drop reason. `--skip-adr` is **not** honored in sweep mode: a batch is the wrong place for a per-issue emergency override, so an unmerged-ADR issue is dropped and listed, to be approved singly with `/approve <n> --skip-adr` if the override is intended.
+2. **Gate-check each candidate.** Run the full [gate checks](#gate-checks) per issue — `Phase == Plan`, the three §-sections present and non-empty, every referenced ADR PR merged, exactly one `model:*` label, not blocked by a `blocked`/`wontfix`/`duplicate` label. Drop any issue that fails and record the reason; the sweep never silently skips — every dropped issue is listed in the plan with its drop reason. `--skip-adr` is **not** honored in sweep mode: a batch is the wrong place for a per-issue emergency override, so an unmerged-ADR issue is dropped and listed, to be approved singly with `/approve <n> --skip-adr` if the override is intended.
 
 3. **Print the approve plan and wait for confirmation.** A batch board write is cheap to do but annoying to unwind, so one confirmation prompt covers the set. Print the issues that will be approved (with their `size:*` / `model:*` for context), any umbrella issues flagged distinctly (an umbrella with `## Sub-issues` is approvable — approving means "the plan is approved, children split correctly" — but it is not itself `/implement`-able; see [Multi-PR umbrella issues](#multi-pr-umbrella-issues)), and the dropped-with-reason list, then stop and wait:
 
@@ -39,7 +39,7 @@ The primary human review point of the release flow. The user invokes `/approve <
    Confirm approve? (no board write happens until your go-ahead)
    ```
 
-4. **On confirmation, approve the batch.** Apply [Actions on pass](#actions-on-pass) over the passing set in one aliased `gh api graphql` request — 2N `updateProjectV2ItemFieldValue` mutations (`Phase=Ready` + `AgentReady=Yes` per issue) — then reconcile each issue's label to `phase:ready`. The sweep never auto-confirms.
+4. **On confirmation, approve the batch.** Apply [Actions on pass](#actions-on-pass) over the passing set in one aliased `gh api graphql` request — N `updateProjectV2ItemFieldValue` mutations (`Phase=Ready` per issue) — then reconcile each issue's label to `phase:ready`. The sweep never auto-confirms.
 
 `--sweep` takes no issue argument — it discovers them. It does not combine with `--note` or `--skip-adr`, both single-issue concerns.
 
@@ -47,7 +47,7 @@ The primary human review point of the release flow. The user invokes `/approve <
 
 ```
 /approve <issue>                    standard (single issue)
-/approve <issue> [<issue> …]        batch — validate each, write all board fields in one aliased request
+/approve <issue> [<issue> …]        batch — validate each, flip all to Ready in one aliased request
 /approve --sweep                    discover every Plan-complete issue, validate each, confirm, approve all
 /approve <issue> --note "<text>"    posts the text as a comment on the issue
 /approve <issue> --skip-adr         bypass the ADR-merged check (emergency override)
@@ -70,13 +70,13 @@ Run all of these. **Refuse** if any fail; list every failure in the refusal outp
 | Implementation plan | body has `## Implementation plan` and is non-empty | "Missing or empty §Implementation plan." |
 | ADR merged | if §Design notes references an ADR PR, that PR's `mergedAt` is non-null | "ADR PR #M is not merged. Merge it or pass `--skip-adr` to override." |
 | Model label | exactly one `model:*` label present (REST: `gh api repos/iamacoffeepot/aether/issues/<n>/labels`) | "Missing model:* label (or more than one). `/scope` stamps model routing at Plan — re-run its Plan step or add the label by hand." |
-| AgentReady allowed | `AgentReady` field is settable (not blocked by labels like `blocked`, `wontfix`, `duplicate`) | "Issue carries label '<label>' which blocks approval." |
+| Not blocked | no `blocked` / `wontfix` / `duplicate` label present | "Issue carries label '<label>' which blocks approval." |
 
 If **all** gates pass, proceed.
 
 ## Actions on pass
 
-1. Set every approved issue's `Phase` field to `Ready` and its `AgentReady` field to `Yes` in **one** `gh api graphql` request — two aliased `updateProjectV2ItemFieldValue` mutations per issue (2N for N issues), assembled per `/scope` §"Batch every multi-write run into one aliased request" (field/option IDs from `field_cache`, item IDs from `item_cache` with the targeted-lookup fallback). A single-issue `/approve` is the N=1 case — still the aliased form, just the two mutations. Then reconcile each approved issue's label to `phase:ready` (see [Phase label reconcile](#phase-label-reconcile)). When a batch mixes passing and failing issues, write the board fields only for the ones that cleared every gate and list the rest in the refusal.
+1. Set every approved issue's `Phase` field to `Ready` in **one** `gh api graphql` request — one aliased `updateProjectV2ItemFieldValue` mutation per issue (N for N issues), assembled per `/scope` §"Batch every multi-write run into one aliased request" (field/option IDs from `field_cache`, item IDs from `item_cache` with the targeted-lookup fallback). A single-issue `/approve` is the N=1 case — a single Phase write. Then reconcile each approved issue's label to `phase:ready` (see [Phase label reconcile](#phase-label-reconcile)) — the `phase:ready` label is the agent-eligibility signal `/implement` reads. When a batch mixes passing and failing issues, write the board field only for the ones that cleared every gate and list the rest in the refusal.
 2. No comment on a plain approve — the `phase:ready` label, the board fields, and the timeline's label event already record it. If `--note` was passed, post the note as prose markdown:
 
    ```markdown
@@ -88,16 +88,15 @@ If **all** gates pass, proceed.
    ```
    ✓ #N approved.
    Phase: Plan → Ready
-   AgentReady: No → Yes
    Next: /implement <N>   (or wait for the orchestrator)
    ```
 
 ## Idempotency
 
-If `/approve` is re-run on an issue that already has `Phase=Ready` and `AgentReady=Yes`:
+If `/approve` is re-run on an issue that already has `Phase=Ready`:
 
 - Re-validate the gates (catches drift if anyone hand-edited the body).
-- If gates still pass: no-op, print *"Already approved — Phase=Ready, AgentReady=Yes."* No new comment.
+- If gates still pass: no-op, print *"Already approved — Phase=Ready."* No new comment.
 - If gates now fail: refuse and list failures. Don't auto-bounce — let the user decide whether to fix the body or `/bounce` the issue.
 
 ## Side findings

--- a/.claude/skills/bounce/SKILL.md
+++ b/.claude/skills/bounce/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: bounce
-description: Explicit phase regression. Move an issue from its current Phase back to an earlier one (Plan / Design / Define), record the reason as a comment, and set the BounceTo field so /scope can resume from the right place. Required reason — no silent bounces. For env/tooling halts, use Phase=Stalled manually (no skill in v1).
+description: Explicit phase regression. Move an issue from its current Phase back to an earlier one (Plan / Design / Define), record the reason as a comment, and set a bounce-to:* label so /scope can resume from the right place. Required reason — no silent bounces. For env/tooling halts, use Phase=Stalled manually (no skill in v1).
 ---
 
 # /bounce — explicit phase regression
 
-The user invokes `/bounce` when reviewing scope artifacts (or watching execution) and concludes an upstream phase needs rework. The skill records the regression as a `Phase=Bounced` + `BounceTo=<phase>` state with the reason posted as a comment. `/scope` then resumes from the target phase on next invocation.
+The user invokes `/bounce` when reviewing scope artifacts (or watching execution) and concludes an upstream phase needs rework. The skill records the regression as a `Phase=Bounced` board state plus a `bounce-to:<phase>` label, with the reason posted as a comment. `/scope` then resumes from the target phase on next invocation.
 
 Self-bounces by other skills (`/scope` hitting a wall, `/implement` discovering a design flaw mid-execution) use the same mechanism — this skill is the explicit user-driven wrapper.
 
@@ -29,7 +29,7 @@ Self-bounces by other skills (`/scope` hitting a wall, `/implement` discovering 
 |-------|---------|
 | Target phase is `Define`, `Design`, or `Plan` | "Cannot bounce to <phase>. Valid: Define, Design, Plan." |
 | Target phase is earlier than current phase in the flow | "Issue is at <current>; bouncing to <target> would advance, not regress. Use `/scope` to advance." |
-| Issue is not already at `Phase=Bounced` | "Issue is already Bounced (BounceTo=<x>). Resolve that bounce first, or re-scope." |
+| Issue is not already at `Phase=Bounced` | "Issue is already Bounced (bounce-to:<x>). Resolve that bounce first, or re-scope." |
 | Issue is not at `Phase=Done` | "Issue is Done; bouncing a closed issue is a no-op. File a fresh issue if work needs to resume." |
 
 Phase ordering for "is earlier" check:
@@ -42,7 +42,7 @@ A bounce from `Ready` to `Plan` is valid (target=3 < current=4). A bounce from `
 
 ## Actions on pass
 
-1. Set the project item's `Phase` field to `Bounced` and its `BounceTo` field to the target phase in **one** `gh api graphql` request — two aliased `updateProjectV2ItemFieldValue` mutations against the same item (item ID from `item_cache`, targeted-lookup fallback per `/scope` §Project board mechanics). Then reconcile the issue label to `phase:bounced` (see [Phase label reconcile](#phase-label-reconcile)).
+1. Set the project item's `Phase` field to `Bounced` (one `updateProjectV2ItemFieldValue` mutation; item ID from `item_cache`, targeted-lookup fallback per `/scope` §Project board mechanics). Then, over REST, reconcile the issue label to `phase:bounced` and stamp `bounce-to:<target>` (replacing any prior `bounce-to:*`) — the resume phase lives on the label, not a board field (see [Phase label reconcile](#phase-label-reconcile)).
 2. Post the reason as a comment — it is the surviving comment class (information addressed to a human with no structured home), written as prose markdown with a bold lead:
 
    ```markdown
@@ -56,7 +56,7 @@ A bounce from `Ready` to `Plan` is valid (target=3 < current=4). A bounce from `
    ```
    ✓ #N bounced.
    Phase: <previous> → Bounced
-   BounceTo: <target>
+   bounce-to: <target>
    Next: address the reason in the issue body or comments, then /scope #N
          (or /scope #N --phase <target> to force redo of that section)
    ```
@@ -65,15 +65,15 @@ A bounce from `Ready` to `Plan` is valid (target=3 < current=4). A bounce from `
 
 When `/scope <issue>` runs on a Bounced issue, it must:
 
-1. Read `BounceTo` from the project item.
-2. Set `Phase=<BounceTo>` (clears the Bounced state), reconciling the label from `phase:bounced` to `phase:<BounceTo>`.
+1. Read the `bounce-to:*` label from the issue (REST).
+2. Set `Phase=<target>` (clears the Bounced state), reconciling the label from `phase:bounced` to `phase:<target>` and removing the now-consumed `bounce-to:*` label in the same REST `PUT`.
 3. Run from that phase forward — redoing the bounced phase and every downstream phase.
 
-If the user passes `/scope <issue> --phase <name>` while bounced and `<name>` matches `BounceTo`, behavior is identical (the flag is the explicit form of the same intent). If `<name>` differs from `BounceTo`, honor `<name>` (the user is overriding) and note the override in the run's output.
+If the user passes `/scope <issue> --phase <name>` while bounced and `<name>` matches the `bounce-to:*` label, behavior is identical (the flag is the explicit form of the same intent). If `<name>` differs from the label, honor `<name>` (the user is overriding) and note the override in the run's output.
 
 ## Self-bounce by other skills
 
-Skills that detect their own wall conditions (`/scope` hitting a vague issue body, `/implement` discovering a broken assumption) call into the same logic: set `Phase=Bounced`, set `BounceTo=<phase>`, post the blocker as a comment. Same prose-markdown shape, with the lead naming what's blocked and the body carrying the question or finding:
+Skills that detect their own wall conditions (`/scope` hitting a vague issue body, `/implement` discovering a broken assumption) call into the same logic: set `Phase=Bounced`, stamp the `bounce-to:<phase>` label, post the blocker as a comment. Same prose-markdown shape, with the lead naming what's blocked and the body carrying the question or finding:
 
 ```markdown
 **Bounced to Design** — the two candidate shapes are genuinely tied.
@@ -94,7 +94,7 @@ Same skill mechanism, different invocation site. `/bounce` is the user-driven va
 
 `Phase=Stalled` is a different signal — env/tooling failure, not a phase regression. Examples: qodana CI service down, GitHub API rate-limited mid-batch, `gh` token expired. The issue's scoping is fine; the *environment* is the problem.
 
-v1 has no `/stall` skill — set Stalled manually in the UI or via `gh project item-edit` with the BounceTo field left null. When you do, also set the `phase:stalled` label on the issue — the REST swap from [Phase label reconcile](#phase-label-reconcile), with `new="phase:stalled"` — so the halt is visible in `gh issue list`. Future `/stall <issue> --reason "<env-issue>"` would post the reason the same way `/bounce` does — it's the same surviving comment class.
+v1 has no `/stall` skill — set Stalled manually in the UI or via `gh project item-edit`, with no `bounce-to:*` label (a stall is not a phase regression). When you do, also set the `phase:stalled` label on the issue — the REST swap from [Phase label reconcile](#phase-label-reconcile), with `new="phase:stalled"` — so the halt is visible in `gh issue list`. Future `/stall <issue> --reason "<env-issue>"` would post the reason the same way `/bounce` does — it's the same surviving comment class.
 
 ## Phase label reconcile
 
@@ -112,7 +112,7 @@ gh api -X PUT "repos/$repo/issues/$n/labels" "${args[@]}"
 EOF
 ```
 
-The single `PUT …/labels` replaces the label set with the non-`phase:*` labels plus the one new `phase:*`, so the issue never carries two phase labels and never carries zero — a tighter guarantee than the old remove-then-add pair, which had a window between its two calls (lowercased: `Phase=Bounced` → `phase:bounced`). A failed PUT leaves the prior labels untouched and heals on the next run. This skill writes `Phase=Bounced` (`phase:bounced`), and on the `/scope` resume contract `Phase=<BounceTo>` (`phase:<BounceTo>`).
+The single `PUT …/labels` replaces the label set with the non-`phase:*` labels plus the one new `phase:*`, so the issue never carries two phase labels and never carries zero — a tighter guarantee than the old remove-then-add pair, which had a window between its two calls (lowercased: `Phase=Bounced` → `phase:bounced`). A failed PUT leaves the prior labels untouched and heals on the next run. This skill writes `Phase=Bounced` (`phase:bounced`) plus a `bounce-to:<target>` label; on the `/scope` resume contract that becomes `Phase=<target>` (`phase:<target>`) with the `bounce-to:*` label cleared. The three `bounce-to:plan|design|define` labels must exist in the repo (`gh label create` once) for the stamp to apply.
 
 ## Failure modes
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement
-description: The single path from issue to open PR. Default mode requires Phase=Ready + AgentReady=Yes (post /approve); --quick skips the board gate for ad-hoc body-carries-the-fix issues. Cuts a worktree branch, implements the plan, opens a PR, loops CI until green, then holds for review (never auto-merges). Replaces the retired /delegate skill.
+description: The single path from issue to open PR. Default mode requires the issue at phase:ready (post /approve); --quick skips the board gate for ad-hoc body-carries-the-fix issues. Cuts a worktree branch, implements the plan, opens a PR, loops CI until green, then holds for review (never auto-merges). Replaces the retired /delegate skill.
 ---
 
 # /implement — the implementation skill
@@ -9,7 +9,7 @@ The single path from an issue to an open PR. Pairs with `/scope` and `/approve`:
 
 Two entry shapes, one skill:
 
-- **Scoped** — `/implement <issue>` — the issue passed `/scope` + `/approve` (`Phase=Ready`, `AgentReady=Yes`). The default release-flow path.
+- **Scoped** — `/implement <issue>` — the issue passed `/scope` + `/approve` (`phase:ready`). The default release-flow path.
 - **Quick** — `/implement <issue> --quick` — an ad-hoc fix whose issue body already carries a complete, mechanical fix. Skips the board approval gate and goes straight to Executing. This **replaces the retired `/delegate` skill** — same niche (small, mechanical, the body carries the fix), and runs in the main session (a `--quick` fix is too small to be worth a worktree hand-off; the hybrid background-agent split below is the sanctioned way to delegate the scoped path — see `feedback_delegate_implementation_stop_after_commit`).
 
 Two ways to run it:
@@ -17,7 +17,7 @@ Two ways to run it:
 - **In-session (default).** The whole skill runs in the main session — implement, push, drive CI green, hold the draft. Use this for a single issue or when you want tight control over each step.
 - **Hybrid background-agent.** To parallelize across independent issues, the orchestrator may dispatch one background Agent per issue that does *only* the bounded, parallelizable part: cut the worktree off `main`, implement the plan, run the full-workspace validation, and commit — then **STOP**. The main session ("parent") then takes each finished worktree and runs the serial, less-reliable part itself: `scripts/preflight.sh --qodana` (which stamps the commit; `--qodana` runs the same qodana scan CI gates on, needs colima up), the push, the draft-PR open, and the CI-green Refine loop — reviewing the agent's diff as it takes over. Never hand the push, PR creation, CI loop, or board writes to the dispatched Agent: handing off the *whole* skill (the retired `/delegate`) proved flaky, so the split keeps the unreliable parts in-session (see `feedback_delegate_implementation_stop_after_commit`). **The parent owns the `Phase=Executing` flip at dispatch:** before or as it spawns the agents, the parent performs §Execute step 1 — the `Phase=Executing` board write plus the `phase:executing` label reconcile — for every issue in the batch. The dispatched agent never touches the board, so the flip cannot be deferred to it; leaving it for the parent's takeover would hold each issue at `Phase=Ready` for the whole time its agent is implementing, misreporting the in-flight fleet and inviting a double-dispatch. `Executing` here means *handed to an agent*: with batched per-agent queues every issue in a queue flips at dispatch, so a queued-but-not-yet-started issue reads `Executing` slightly early — accepted, because the parent cannot observe intra-agent queue progress and `Ready` would misreport the whole window.
 
-  **Batched dispatch.** Before spawning agents, the orchestrator reads each candidate issue's `size:*` and `model:*` labels over REST (`gh api repos/iamacoffeepot/aether/issues/<n> --jq '.labels[].name'` per issue, or one `gh api 'repos/iamacoffeepot/aether/issues?labels=size:m&state=open' --jq '.[].number'` sweep — not `gh issue view` / `gh issue list`, which are GraphQL-backed) — no GraphQL board query, since `/scope` mirrors the `Size` field and the model routing onto labels at Plan time. It then packs the approved issues into per-agent queues by an **estimated context budget** rather than a fixed count: a queue accumulates issues until the next one would push it past the ~150k-token compaction threshold an agent hits, then a new queue opens.
+  **Batched dispatch.** Before spawning agents, the orchestrator reads each candidate issue's `size:*` and `model:*` labels over REST (`gh api repos/iamacoffeepot/aether/issues/<n> --jq '.labels[].name'` per issue, or one `gh api 'repos/iamacoffeepot/aether/issues?labels=size:m&state=open' --jq '.[].number'` sweep — not `gh issue view` / `gh issue list`, which are GraphQL-backed) — no GraphQL board query, since `/scope` stamps the size and model routing onto labels at Plan time. It then packs the approved issues into per-agent queues by an **estimated context budget** rather than a fixed count: a queue accumulates issues until the next one would push it past the ~150k-token compaction threshold an agent hits, then a new queue opens.
 
   The `size:*` label is the prior context-cost estimate — heuristic anchors **S ≈ 25k, M ≈ 60k, L ≈ 120k** accumulated agent context (exploration + diff + validation churn) — and reading each candidate's body and `## Implementation plan` refines it: step count, the count of files and crates the plan touches, and how much exploration the change implies all move the estimate off its label anchor. Pack greedily against the refined estimates: smalls pack densely (several trivial S can share one agent where the old count rule capped at three), mediums co-queue when two fit under the cap, and an L stays solo because its prior alone approaches the threshold.
 
@@ -31,7 +31,7 @@ Either mode opens the PR **as a draft**, drives CI green, and holds it in draft 
 
 `/implement --sweep` is the batched hybrid background-agent entry point: it discovers the eligible set instead of taking one issue, packs it into per-agent queues, and waits for your confirmation before any agent spawns. It exists so the orchestrator stops assembling each dispatch set by hand.
 
-1. **Enumerate over REST, in one call.** `phase:ready` is set only by `/approve`, which flips `AgentReady=Yes` in the same step — so the label alone is the eligibility signal and no GraphQL board read is needed:
+1. **Enumerate over REST, in one call.** `phase:ready` is set only by `/approve` — so the label alone is the eligibility signal and no GraphQL board read is needed:
 
    ```bash
    gh api 'repos/iamacoffeepot/aether/issues?labels=phase:ready&state=open' --jq '.[].number'
@@ -39,7 +39,7 @@ Either mode opens the PR **as a draft**, drives CI green, and holds it in draft 
 
    This is the REST issues endpoint (per `/scope` §REST-vs-GraphQL routing), not `gh issue list`, which is GraphQL-backed and drains the contended pool.
 
-2. **Gate-check each candidate.** Run the same [per-issue preconditions](#preconditions) the single-issue path runs — `Phase == Ready`, `AgentReady == Yes`, no `## Sub-issues` umbrella, `## Implementation plan` present, exactly one `model:*` label. Drop any issue that fails and record the reason; the sweep does not silently skip — every dropped issue is listed in the plan with its drop reason.
+2. **Gate-check each candidate.** Run the same [per-issue preconditions](#preconditions) the single-issue path runs — `phase:ready` present, no `## Sub-issues` umbrella, `## Implementation plan` present, exactly one `model:*` label. Drop any issue that fails and record the reason; the sweep does not silently skip — every dropped issue is listed in the plan with its drop reason.
 
 3. **Pack and order.** Apply the **Batched dispatch** rules above (under the hybrid background-agent mode): budget-based packing against the `size:*`-label priors refined by each body read, crate-affinity co-queueing with the trivial-mechanical exception, broadest-exploration-first ordering within each queue.
 
@@ -57,7 +57,7 @@ Either mode opens the PR **as a draft**, drives CI green, and holds it in draft 
 4. **Print the dispatch plan and wait for confirmation.** Packing is heuristic, so a mis-packed multi-issue agent run is expensive to unwind — one confirmation prompt per sweep is cheap insurance. Print the queues, their issues in order, the routed model per queue, the stale-worktree classification per affected candidate, and the dropped-with-reason list, then stop and wait:
 
    ```
-   Sweep: 7 Ready+AgentReady issues, 3 dropped, 4 dispatched across 2 agents.
+   Sweep: 7 phase:ready issues, 3 dropped, 4 dispatched across 2 agents.
 
    Agent 1 (model: opus)     ~110k  [crate:aether-data]
      #1612  refactor kind-id newtype helpers        (broadest — read first)
@@ -88,8 +88,8 @@ The sweep never auto-confirms and never dispatches the serial tail (push / PR / 
 
 ```
 /implement <issue>                       scoped run (defaults: retry-cap=3, wall=30min)
-/implement --sweep                       enumerate every Ready+AgentReady issue, pack per-agent queues, confirm, dispatch
-/implement <issue> --quick               ad-hoc fix: skip the Ready/AgentReady gate (body must carry a complete fix)
+/implement --sweep                       enumerate every phase:ready issue, pack per-agent queues, confirm, dispatch
+/implement <issue> --quick               ad-hoc fix: skip the phase:ready gate (body must carry a complete fix)
 /implement <issue> --retry-cap <N>       override retry cap
 /implement <issue> --wall-clock <mins>   override wall-clock budget
 /implement <issue> --resume              continue an in-flight execution (rare)
@@ -103,18 +103,17 @@ The sweep never auto-confirms and never dispatches the serial tail (push / PR / 
 |-------|---------|
 | `.claude/release-state.json` exists | "Run `/release-init <version>` first." |
 | Issue in active project | "Issue #N is not in project <project-number>. Add it first." |
-| `Phase == Ready` | "Issue is at <current>, not Ready. Use `/scope` + `/approve` first." |
-| `AgentReady == Yes` | "Approval gate not met. Run `/approve <issue>` first." |
+| `phase:ready` label present | "Issue is not Ready (no `phase:ready` label). Use `/scope` + `/approve` first." |
 | Exactly one `model:*` label | "Missing model:* label (or more than one). Re-run `/scope`'s Plan step or stamp the label by hand." |
 | §Sub-issues section absent or empty | "Issue is an umbrella with sub-issues. Delegate the children, not the parent." |
 | Issue body has `## Implementation plan` | "Missing implementation plan — issue isn't fully scoped. Re-run `/scope`." |
 | `gh auth status` has `repo`+`project` scopes | "Run `gh auth refresh -s project` (repo scope is standard)." |
 
-**`--quick` mode relaxes the gate.** With `--quick`, the `Phase == Ready`, `AgentReady == Yes`, and `model:*`-label checks are skipped (a `--quick` fix runs in the main session — no agent is dispatched, so there is nothing to route), and the issue need not be on the project board at all. In exchange, the issue body MUST carry a complete, mechanical fix — either a `## Implementation plan` section or an unambiguous proposed-fix description. Before proceeding, sanity-check the body:
+**`--quick` mode relaxes the gate.** With `--quick`, the `phase:ready` and `model:*`-label checks are skipped (a `--quick` fix runs in the main session — no agent is dispatched, so there is nothing to route), and the issue need not be on the project board at all. In exchange, the issue body MUST carry a complete, mechanical fix — either a `## Implementation plan` section or an unambiguous proposed-fix description. Before proceeding, sanity-check the body:
 
 - **Body ambiguous or missing the fix** → refuse: *"`--quick` needs a complete fix in the body. Run `/scope <issue>` to design it."* Don't guess.
 - **Fix looks design-bearing** (new public API, wire-format change, ADR-worthy choice) → refuse: *"This needs design, not a quick fix. Run `/scope <issue>`."* `--quick` is for mechanical work only (the old `/delegate` bar).
-- **Issue not on the active project board** → run **label-only**: set the `phase:*` labels normally but skip every `Phase` / `AgentReady` board-field write (there's no project item to update). All other behavior is identical.
+- **Issue not on the active project board** → run **label-only**: set the `phase:*` labels normally but skip every `Phase` board-field write (there's no project item to update). All other behavior is identical.
 
 ## Worktree setup
 
@@ -128,7 +127,7 @@ Worktree path is `.claude/worktrees/issue-<N>` (gitignored per CLAUDE.md §Workf
 
 Before the `git worktree add`, run the same [stale-worktree probe](#sweep-dispatch) §Sweep dispatch uses, for this one issue: if `.claude/worktrees/issue-<N>` already exists from a prior aborted or bounced attempt, check its uncommitted-file count, whether its branch is ahead of `origin/main`, and whether an open PR is attached (the REST `pulls?head=` form). Auto-clear when safe — clean worktree, branch not ahead, no open PR — with `git worktree remove` plus `git branch -D`, then proceed with the add. Surface and stop when the worktree is dirty, ahead, or PR-attached: clearing would discard uncommitted bounce context or unpushed work, so report the state and let the user decide rather than forcing the add.
 
-Type comes from the project item's `Type` field. Slug is the issue title sanitized: lowercased, alnum + dashes, max 30 chars.
+Type comes from the issue's `type:*` label. Slug is the issue title sanitized: lowercased, alnum + dashes, max 30 chars.
 
 ## Execute phase
 
@@ -192,11 +191,11 @@ After PR open, enter the loop. On each iteration:
 
 5. Set project item's `Phase` to `Refine` during fix-and-wait, back to `Executing` when pushing the fix. (Flicker is intentional — gives the board honest visibility.) Reconcile the `phase:*` label on each flip (see [Phase label reconcile](#phase-label-reconcile)). No per-attempt comments — the PR's own commit and check history is the attempt record; track the attempt counter in-session.
 
-6. **Retry cap hit** → self-bounce. `Phase=Bounced`, `BounceTo=Plan`, comment with the full attempt history.
+6. **Retry cap hit** → self-bounce. `Phase=Bounced`, `bounce-to:plan` label, comment with the full attempt history.
 
 7. **Wall-clock hit** → self-bounce. Same as retry cap with the elapsed time noted.
 
-8. **Design-level discovery** at any attempt → self-bounce. `Phase=Bounced`, `BounceTo=Design`, comment with the specific finding. Examples:
+8. **Design-level discovery** at any attempt → self-bounce. `Phase=Bounced`, `bounce-to:design` label, comment with the specific finding. Examples:
    - "Approach X doesn't work because Y; needs alternative."
    - "Test Z passes only if we also change A, which is outside §Implementation plan."
 
@@ -210,7 +209,7 @@ Format/clippy/build are never flakes — always real, always immediate fix.
 
 CI green:
 
-1. Project item: leave `Phase = Refine` and `AgentReady = Yes` (the issue label stays `phase:refine`). The resting state is "draft PR open + green" — no comment; the green checks on the PR are the record.
+1. Project item: leave `Phase = Refine` (the issue label stays `phase:refine`). The resting state is "draft PR open + green" — no comment; the green checks on the PR are the record.
 2. Leave the PR as a **draft**. Do not un-draft, do not merge, do not close, do not auto-set Phase=Done. Un-drafting is the user's (or the approved release process's) action — once a PR is un-drafted, native auto-merge lands it on green ([[feedback_green_pr_automerges_before_review]]).
 3. Print to user:
 
@@ -272,7 +271,7 @@ Closes #<issue>.
 | Wall clock | 30 minutes total | `--wall-clock <mins>` |
 | Token cost | not enforced in v1 | future `--token-cap <N>` |
 
-Both caps trigger self-bounce to Plan with the budget breach noted. The `AuthBudget` field on the project item is the persistent record; for v1 it's a free-text note ("retry=3, wall=30m"). Phase C orchestrator will read this field to apply per-issue budgets.
+Both caps trigger self-bounce to Plan with the budget breach noted in the bounce comment. v1 does not persist the budget to the board; a future Phase C orchestrator can reintroduce a per-issue budget store (a label, or a body field) when it needs one.
 
 ## Phase label reconcile
 

--- a/.claude/skills/release-init/SKILL.md
+++ b/.claude/skills/release-init/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-init
-description: Bootstrap a new aether release. Copies the release template project (canonical schema with the phase vocabulary in the built-in Status field plus Type/Size/AgentReady/BounceTo/ADR/AuthBudget custom fields, and the server-side added→Backlog / closed→Done workflows), populates .claude/release-state.json with the project ID + field/option ID cache, optionally seeds the project with starter issues. Required before /scope works.
+description: Bootstrap a new aether release. Copies the release template project (canonical schema — the phase vocabulary in the built-in Status field, no custom fields, plus the server-side added→Backlog / closed→Done workflows), populates .claude/release-state.json with the project ID + Phase field/option ID cache, optionally seeds the project with starter issues. Required before /scope works.
 ---
 
 # /release-init — release bootstrap skill
@@ -37,7 +37,7 @@ If no project titled `aether release template` exists for the owner, `/release-i
 bash scripts/release-project-init.sh --init-template --owner <owner>
 ```
 
-The script creates the project, replaces the `Status` field's options with the phase vocabulary (one `updateProjectV2Field` mutation), and creates the other custom fields. The two workflow toggles ("Item added to project" → Backlog, "Item closed" → Done) are **UI-only** — the workflow API is read/delete-only — and the script prints the exact steps. Done once; every release copies them for free (GitHub excludes only auto-add workflows from copies, which this flow doesn't use — `/sketch` adds items itself).
+The script creates the project and replaces the `Status` field's options with the phase vocabulary (one `updateProjectV2Field` mutation). The two workflow toggles ("Item added to project" → Backlog, "Item closed" → Done) are **UI-only** — the workflow API is read/delete-only — and the script prints the exact steps. Done once; every release copies them for free (GitHub excludes only auto-add workflows from copies, which this flow doesn't use — `/sketch` adds items itself).
 
 ### 1. Create or adopt the project
 
@@ -49,7 +49,7 @@ bash scripts/release-project-init.sh <version> --owner <owner>
 
 The script locates the template by title and copies it (`gh project copy`) into `aether <version>`. Capture the project number from the script's output. If the script reports the template is missing, run step 0 first.
 
-If `--reuse <num>` was passed, skip creation and use `<num>` directly. Verify the project exists and has the expected fields by running the next step's `field-list` and checking that Status (carrying the phase options), Type, Size, AgentReady, BounceTo, ADR, AuthBudget are present. If any are missing, abort with a message naming the missing fields.
+If `--reuse <num>` was passed, skip creation and use `<num>` directly. Verify the project exists and that Status carries the phase options by running the next step's `field-list`. If Status or its options are missing, abort with a message naming what's missing.
 
 ### 2. Query the field cache
 
@@ -60,8 +60,7 @@ gh project view <project-number> --owner <owner> --format json
 
 Extract:
 - The project's GraphQL node ID (from `view`, `.id`).
-- For each of Status, Type, Size, AgentReady, BounceTo: the field ID and, for single-select fields, every option's ID. **The field named `Status` is cached under the key `"Phase"`** — the copy regenerates all field/option IDs, so never reuse IDs from the template or a prior release.
-- For ADR and AuthBudget: just the field ID (text fields, no options).
+- For Status: the field ID and every option's ID. **The field named `Status` is cached under the key `"Phase"`** — the copy regenerates the field/option IDs, so never reuse IDs from the template or a prior release.
 
 ### 3. Write `.claude/release-state.json`
 
@@ -88,13 +87,7 @@ Schema (formatted, no trailing comma):
         "Bounced": "<id>",
         "Stalled": "<id>"
       }
-    },
-    "Type":       { "id": "...", "options": { "feat": "...", "fix": "...", ... } },
-    "Size":       { "id": "...", "options": { "S": "...", "M": "...", "L": "..." } },
-    "AgentReady": { "id": "...", "options": { "No": "...", "Yes": "..." } },
-    "BounceTo":   { "id": "...", "options": { "Plan": "...", "Design": "...", "Define": "..." } },
-    "ADR":        { "id": "...", "options": null },
-    "AuthBudget": { "id": "...", "options": null }
+    }
   },
   "item_cache": {}
 }
@@ -116,7 +109,7 @@ For each issue in the comma-separated list:
 gh project item-add <project-number> --owner <owner> --url https://github.com/<owner>/aether/issues/<number>
 ```
 
-No Phase write — the copied "item added" workflow sets Backlog server-side. Spot-check the first import landed in Backlog; if it didn't (the workflow toggle was skipped on the template), set the field explicitly and remind the user to fix the template's workflows. Don't set Type/Size/AgentReady — those are `/scope`'s responsibility per-issue. Record each returned item ID in `item_cache`.
+No Phase write — the copied "item added" workflow sets Backlog server-side. Spot-check the first import landed in Backlog; if it didn't (the workflow toggle was skipped on the template), set the field explicitly and remind the user to fix the template's workflows. Issue metadata (type / size / model) rides labels, not board fields — `/sketch` stamps `type:*` at filing and `/scope` stamps `size:*` / `model:*` at Plan; this step doesn't touch them. Record each returned item ID in `item_cache`.
 
 ### 6. Print summary
 
@@ -138,14 +131,14 @@ Next:
 - **`gh` lacks `project` scope**: abort with the refresh command.
 - **Template project missing**: the script exits with a pointer; run `/release-init --init-template`, do the two printed workflow toggles, then re-run.
 - **Bootstrap script fails partway**: leave whatever was created on the GH side, report the error, do not write `release-state.json`. The user can `gh project delete` and retry.
-- **`field-list` returns fewer fields than expected** (e.g. someone hand-deleted a field, or the Status options weren't replaced on the template): abort and report the missing fields/options by name.
+- **`field-list` shows the Status field missing or its phase options not replaced**: abort and report what's missing by name.
 - **`.claude/release-state.json` already exists and `--force` not passed**: ask the user to confirm overwrite before proceeding.
 - **`--import` issue doesn't exist or is in a different repo**: skip with a warning comment; continue with the rest.
 
 ## What `/release-init` does NOT do
 
 - Configure the board view layout (group-by, sort, sub-grouping) or toggle workflows. Both are UI-only; both live on the template, configured once at `--init-template` time and carried into every copy.
-- Add Type/Size/AgentReady values to imported issues — `/scope` handles that.
+- Stamp `type:*` / `size:*` / `model:*` labels on imported issues — `/sketch` and `/scope` own those.
 - Migrate items from an older release project. If you want to move issues from `aether 0.3` to `aether 0.4`, use `gh project item-archive` on the old + `--import` on the new.
 - Rename the Status field. GitHub doesn't allow it; the tooling vocabulary "Phase" lives in `release-state.json`'s cache key and everything downstream of it.
 - Delete or close old release projects. The user does that manually when they're done with a release.

--- a/.claude/skills/scope-spinoff/SKILL.md
+++ b/.claude/skills/scope-spinoff/SKILL.md
@@ -56,7 +56,7 @@ For each selected finding:
    Spun off from #<parent> §Side findings during `/scope-spinoff` on <date>.
    ```
 
-   For a spun-off finding the verbatim blockquote in `## Description` is the finding line as it appeared in the parent body; the expansion is any context the agent already has from reading the code. Don't set Type/Size/AgentReady — `/scope` handles those when the child gets scoped.
+   For a spun-off finding the verbatim blockquote in `## Description` is the finding line as it appeared in the parent body; the expansion is any context the agent already has from reading the code. Don't stamp `size:*` / `model:*` — `/scope` handles those when the child gets scoped (`type:*` rides the issue from filing).
 
 No comment is posted on the parent: the child's `Spun off from #<parent>` line creates a cross-reference event in the parent's timeline automatically, one per filing, which is the per-finding record.
 

--- a/.claude/skills/scope/SKILL.md
+++ b/.claude/skills/scope/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: scope
-description: Walk a GitHub issue Define → Design → Plan and update the release Project board. Stops at Plan with AgentReady=No, awaiting user approval via /approve. Aggressive (agent makes design calls) and resumable (per-phase updates to the board).
+description: Walk a GitHub issue Define → Design → Plan and update the release Project board. Stops at Plan, awaiting user approval via /approve. Aggressive (agent makes design calls) and resumable (per-phase updates to the board).
 ---
 
 # /scope — release scoping skill
 
-Walk a single issue from Backlog through Define → Design → Plan, producing a problem statement, design rationale, and implementation plan as structured body sections. Updates the active release Project's `Phase` field as it advances. Stops at `Plan` with `AgentReady=No`, awaiting user review via `/approve`.
+Walk a single issue from Backlog through Define → Design → Plan, producing a problem statement, design rationale, and implementation plan as structured body sections. Updates the active release Project's `Phase` field as it advances. Stops at `Plan`, awaiting user review via `/approve`.
 
-This skill produces **scoping artifacts only**. It does not write production code (that's `/implement`), open implementation PRs, or set `AgentReady=Yes` (that's `/approve`).
+This skill produces **scoping artifacts only**. It does not write production code (that's `/implement`), open implementation PRs, or advance the issue to Ready (that's `/approve`).
 
 ## Invocation
 
@@ -23,11 +23,11 @@ This skill produces **scoping artifacts only**. It does not write production cod
 
 ## Sweep dispatch
 
-`/scope --sweep` is the batched discovery entry point: instead of one issue, it takes the Backlog set, dispatches one background scoper agent per issue, and waits for your confirmation before any agent spawns. It is the read-only twin of `/implement --sweep` — each agent runs a full single-issue `/scope` (Define → Design → Plan, writing that issue's body sections, board fields, and `size:*` / `model:*` labels) in its own context, then stops with a bounded summary. The parent assembles the batch, confirms, paces dispatch against the shared GraphQL pool, and rolls up the outcomes.
+`/scope --sweep` is the batched discovery entry point: instead of one issue, it takes the Backlog set, dispatches one background scoper agent per issue, and waits for your confirmation before any agent spawns. It is the read-only twin of `/implement --sweep` — each agent runs a full single-issue `/scope` (Define → Design → Plan, writing that issue's body sections, the Phase board field, and `size:*` / `model:*` labels) in its own context, then stops with a bounded summary. The parent assembles the batch, confirms, paces dispatch against the shared GraphQL pool, and rolls up the outcomes.
 
 Two things differ from `/implement --sweep`:
 
-- **The agent owns its issue's whole scope.** `/implement` keeps the serial tail (push, PR, CI loop, board writes) in the parent because that tail is flaky; scope has no such tail — no worktree, no push, no CI — so each scoper agent writes its issue's artifacts directly and there is nothing to hand back. Each agent still batches its own issue's field writes into one aliased request per §"Batch every multi-write run into one aliased request"; the cross-agent pacing is the concurrency cap below, not a shared batch.
+- **The agent owns its issue's whole scope.** `/implement` keeps the serial tail (push, PR, CI loop, board writes) in the parent because that tail is flaky; scope has no such tail — no worktree, no push, no CI — so each scoper agent writes its issue's artifacts directly and there is nothing to hand back. Each agent writes only its own issue's Phase transitions (the board's one field) plus its labels; the cross-agent pacing is the concurrency cap below, not a shared batch.
 - **Two models, not one.** The scoper agents run a design-capable model — `--model` (default `opus`), because scoping makes design calls. That is distinct from the per-issue `model:*` label each agent *stamps* at Plan to route the future `/implement`.
 
 1. **Enumerate the candidate set.** With no issue arguments, discover every Backlog issue. Backlog is the resting phase that carries no `phase:*` label (see [Phase label reconcile](#phase-label-reconcile)), so an open non-PR issue with no `phase:*` label is at Backlog. Over REST (per [Project board mechanics](#project-board-mechanics) — not `gh issue list`, which is GraphQL-backed):
@@ -74,11 +74,7 @@ Reads `.claude/release-state.json` at the repo root:
   "release_version": "0.4",
   "owner": "iamacoffeepot",
   "field_cache": {
-    "Phase":      { "id": "PVTSSF_...", "options": { "Backlog": "...", "Define": "...", ... } },
-    "Type":       { "id": "...", "options": { ... } },
-    "Size":       { "id": "...", "options": { ... } },
-    "AgentReady": { "id": "...", "options": { ... } },
-    "BounceTo":   { "id": "...", "options": { ... } }
+    "Phase": { "id": "PVTSSF_...", "options": { "Backlog": "...", "Define": "...", ... } }
   },
   "item_cache": { "<issue-number>": "PVTI_..." }
 }
@@ -98,7 +94,7 @@ For each sub-phase: read inputs, write the corresponding body section, advance t
 - **Output**: replaces or adds `## Problem statement` section in the body. Two short paragraphs:
   1. *What's being solved.* The concrete problem in plain language.
   2. *Why now / success criteria.* Why this release; what "done" looks like observably.
-- **Bounce**: if the body is too vague to frame a problem (e.g. one-line title, no description, no linked context), self-bounce with `Phase=Bounced`, `BounceTo=Define`, and a comment asking the specific clarifying question. Don't guess.
+- **Bounce**: if the body is too vague to frame a problem (e.g. one-line title, no description, no linked context), self-bounce with `Phase=Bounced`, a `bounce-to:define` label, and a comment asking the specific clarifying question. Don't guess.
 - **Project board**: set `Phase=Design` on success.
 
 ### Design
@@ -146,12 +142,12 @@ For each sub-phase: read inputs, write the corresponding body section, advance t
   - More than 3 logically-separable changes, *or*
   - More than 2 crates with logically-separable work
   - In that case, file each sub-issue via `/sketch`'s mechanics (Phase=Backlog initially, link parent), update §Sub-issues, and scope each child in a follow-up `/scope` run.
-- **Size estimation** — set the `Size` custom field on the project item:
+- **Size estimation** — stamp the issue's `size:*` label by this rubric:
   - **S**: single file, single concept, <100 LOC change
   - **M**: single crate, multiple files, <500 LOC change
   - **L**: cross-crate, architectural, or >500 LOC change
 
-  In the same step you set the `Size` field, mirror it to a `size:s|m|l` label over REST (the same `gh api …/labels` endpoints the [Phase label reconcile](#phase-label-reconcile) uses — never `gh issue edit`, which rides GraphQL), so the dispatcher both reads *and* writes the estimate off the contended pool:
+  Write it as a `size:s|m|l` label over REST (the same `gh api …/labels` endpoints the [Phase label reconcile](#phase-label-reconcile) uses — never `gh issue edit`, which rides GraphQL), so the estimate the dispatcher reads lives entirely off the contended pool:
 
   ```bash
   gh api "repos/iamacoffeepot/aether/issues/<n>/labels" --jq '.[].name | select(startswith("size:"))' \
@@ -165,7 +161,7 @@ For each sub-phase: read inputs, write the corresponding body section, advance t
   - `model:fable` — never stamped by `/scope`; reserved for a human pinning the top tier explicitly.
 
   The gate encodes a size-asymmetry: a downward misjudgment costs more as size grows, so an M/L `model:sonnet` demands a plan that reads as executable verbatim — when in doubt at M or L, stamp `model:opus`. Note the choice and a one-clause reason in the Plan audit comment.
-- **Project board**: leave `Phase=Plan`; set `AgentReady=No` (default, but explicit). This is the resting state awaiting `/approve`.
+- **Project board**: leave `Phase=Plan`. This is the resting state awaiting `/approve`.
 
 ## Side findings
 
@@ -210,7 +206,7 @@ This section is the canonical GitHub API-budget reference for the whole pipeline
 
 ### Field writes (GraphQL)
 
-To set a single-select field on a project item:
+To set the Phase field (the board's one single-select) on a project item:
 
 ```bash
 gh api graphql -f query='
@@ -252,32 +248,30 @@ Every op with a REST endpoint rides REST (`gh api <path>`); only the three Proje
 
 **GraphQL-only — no REST equivalent:**
 
-- ProjectV2 field writes — `updateProjectV2ItemFieldValue` (Phase / Type / Size / AgentReady / BounceTo).
+- ProjectV2 field writes — `updateProjectV2ItemFieldValue` (Phase — the board's only field).
 - ProjectV2 item add — `addProjectV2ItemById`.
 - Un-draft a PR — `markPullRequestReadyForReview` (the REST `pulls` PATCH cannot clear `draft`).
 
 ### Batch every multi-write run into one aliased request
 
-When a run writes more than one ProjectV2 field — across several issues, or several fields of one issue — send them as one `gh api graphql` request with aliased mutations instead of one request per write. An `/approve` of N issues issues one request carrying 2N aliased `updateProjectV2ItemFieldValue` mutations (Phase + AgentReady per issue); a single-issue Plan run that sets Phase, Size, and AgentReady aliases all three.
+When a run writes the Phase field for more than one issue — an `/approve --sweep` or `/implement --sweep` flipping a batch — send them as one `gh api graphql` request with aliased mutations instead of one request per issue. An `/approve` of N issues issues one request carrying N aliased `updateProjectV2ItemFieldValue` mutations (Phase per issue); a single-issue run writes Phase once and needs no aliasing.
 
 Build the aliased body under `bash` — zsh does not word-split an unquoted variable, so a body assembled in a loop must run inside a `bash <<'EOF'` block:
 
 ```bash
 bash <<'EOF'
 PID=<project-node-id>; PHASE=<phase-field-id>; READY=<ready-option-id>
-AR=<agentready-field-id>; YES=<yes-option-id>
 items=(PVTI_aaa PVTI_bbb PVTI_ccc)        # item IDs from item_cache
 body=""; i=0
 for item in "${items[@]}"; do
   body+="p$i: updateProjectV2ItemFieldValue(input:{projectId:\"$PID\",itemId:\"$item\",fieldId:\"$PHASE\",value:{singleSelectOptionId:\"$READY\"}}){projectV2Item{id}} "
-  body+="r$i: updateProjectV2ItemFieldValue(input:{projectId:\"$PID\",itemId:\"$item\",fieldId:\"$AR\",value:{singleSelectOptionId:\"$YES\"}}){projectV2Item{id}} "
   i=$((i+1))
 done
 gh api graphql -f query="mutation { $body }"
 EOF
 ```
 
-One request, 2N mutations, against the GraphQL pool once instead of N times. The item add and its Phase write cannot alias into one request (the field write needs the item ID the add returns), so a fresh `/sketch` filing stays two GraphQL calls.
+One request, N mutations, against the GraphQL pool once instead of N times. The item add and its Phase write cannot alias into one request (the field write needs the item ID the add returns), so a fresh `/sketch` filing stays two GraphQL calls.
 
 ## Phase label reconcile
 
@@ -314,8 +308,8 @@ gh api "repos/iamacoffeepot/aether/issues/<n>/labels" --jq '.[].name | select(st
 - Open implementation PRs (use `/implement`).
 - Merge anything.
 - Auto-file side findings as child issues (use `/scope-spinoff`).
-- Set `AgentReady=Yes` (use `/approve`).
-- Set `Type` — that should come from the issue title's conventional-commit prefix (`feat:` → `feat`, `fix:` → `fix`, etc.). If unset, infer from title; if title has no prefix, leave unset and surface it in the run's output.
+- Advance the issue to Ready (use `/approve`).
+- Stamp `Type` — `/sketch` sets the `type:*` label at filing from the title's conventional-commit prefix; there is no board Type field for `/scope` to set.
 
 ## Failure modes to handle gracefully
 

--- a/.claude/skills/sketch/SKILL.md
+++ b/.claude/skills/sketch/SKILL.md
@@ -23,7 +23,7 @@ With no idea text, ask what the idea is — don't guess from conversation contex
 
 ## Title
 
-`{type}({crate}): subject` — lowercase subject, conventional-commit form. The repo's issue lint auto-applies `invalid-title` to anything else, and `/scope` derives the board `Type` field from the prefix, so the title is load-bearing.
+`{type}({crate}): subject` — lowercase subject, conventional-commit form. The repo's issue lint auto-applies `invalid-title` to anything else, and the `type:*` label is stamped from the prefix, so the title is load-bearing.
 
 Type inference from the idea text (same table `/scope-spinoff` uses). The authoritative type set is the `TYPES` array in `.github/workflows/issue-labels.yml` — check it when this table and the lint diverge.
 
@@ -97,7 +97,7 @@ Record the returned project item ID in `release-state.json` under `item_cache` s
 
 (Create the key if absent; item IDs are stable for the life of the project.)
 
-Don't set `Type` / `Size` / `AgentReady` — `/scope` owns those. No audit comment — the issue's own creation event is the record.
+The board carries only `Phase=Backlog`. (`type:*` rides the issue from filing; `/scope` stamps `size:*` / `model:*` at Plan — all labels, no board fields.) No audit comment — the issue's own creation event is the record.
 
 Once the release board carries the server-side "item added → Backlog" workflow (issue #1577's template path), step 2 disappears; detect this by the project's workflows rather than guessing — until then, write the field explicitly.
 

--- a/docs/adr/0110-claude-role-model.md
+++ b/docs/adr/0110-claude-role-model.md
@@ -9,7 +9,7 @@ Multiple Claude sessions run against this repository at once — ideating, scopi
 
 Authority also drifts. A session opened to ideate ends up merging to main; one opened to implement re-scopes an issue. Nothing scopes what a session is *for*, so the blast radius of any single session is the whole pipeline.
 
-The pieces a role model can build on already exist: a skill vocabulary (`wish`, `wish-deep`, `sketch`, `scope`, `scope-spinoff`, `approve`, `implement`, `bounce`, `sweep`), a release board whose built-in Status field carries the Phase vocabulary (Backlog → Define → Design → Plan → Ready → … → Done), and custom fields including Size, AgentReady, and BounceTo. What is missing is a binding from a session to a **role** that fixes which skills it runs, where it runs them, and what it is allowed to touch.
+The pieces a role model can build on already exist: a skill vocabulary (`wish`, `wish-deep`, `sketch`, `scope`, `scope-spinoff`, `approve`, `implement`, `bounce`, `sweep`), a release board whose built-in Status field carries the Phase vocabulary (Backlog → Define → Design → Plan → Ready → … → Done), with the rest of an issue's metadata on labels (`type:*`, `size:*`, `model:*`, `phase:*`). What is missing is a binding from a session to a **role** that fixes which skills it runs, where it runs them, and what it is allowed to touch.
 
 ## Decision
 

--- a/docs/release/schema.md
+++ b/docs/release/schema.md
@@ -1,10 +1,10 @@
 # Release project schema
 
-Each aether release lives in its own GitHub Project (`aether 0.4`, `aether 0.5`, …). The schema is created by `release-project-init.sh <version>` and used by future `/release-*` skills.
+Each aether release lives in its own GitHub Project (`aether 0.4`, `aether 0.5`, …), copied from the release template by `release-project-init.sh <version>` and driven by the `/release-*` skills.
 
-## Phase (custom single-select field — board's grouping column)
+## Phase (the board's one field — its grouping column)
 
-We use a custom `Phase` field rather than the default `Status` because we need to set its options programmatically; `Status`'s options aren't editable via `gh project field-create`. Group the board view by Phase and ignore Status.
+The lifecycle vocabulary lives in the built-in **Status** field, whose options `release-project-init.sh --init-template` replaces with the phase set (GitHub's built-in workflows can only set Status, so the vocabulary has to live there). Everything else — the skills, `release-state.json`, this doc — calls it **Phase**: `release-state.json`'s `field_cache` key `"Phase"` points at the field named `Status`. Group the board view by Status to get the phase columns.
 
 | Phase     | Meaning                                                    | Advances by  |
 |-----------|------------------------------------------------------------|--------------|
@@ -12,41 +12,45 @@ We use a custom `Phase` field rather than the default `Status` because we need t
 | Define    | Problem framing in progress                                | User + Claude |
 | Design    | Tradeoffs / options / ADR drafting                         | User + Claude |
 | Plan      | Sequencing, dependencies, sub-issues                       | User + Claude |
-| Ready     | Agent-ready; awaiting dispatch                             | Gate: `AgentReady=Yes` |
+| Ready     | Agent-ready; awaiting dispatch                             | Gate: `phase:ready` label |
 | Executing | Agent has the issue; PR in flight                          | Auto         |
 | Refine    | CI-feedback loop, agent-driven                             | Auto         |
 | Done      | PR merged                                                  | Auto         |
-| Bounced   | Phase regression — see `BounceTo`                          | User triage  |
+| Bounced   | Phase regression — see the `bounce-to:*` label             | User triage  |
 | Stalled   | Env/tooling failure, blocks dispatch                       | User triage  |
 
-## Custom fields
+Phase is mirrored to a `phase:*` label on each issue (the board field isn't visible in `gh issue list`), so the skills read lifecycle state off labels over REST and never need a board query to enumerate or gate.
 
-| Field        | Type           | Values / shape                                | Notes |
-|--------------|----------------|-----------------------------------------------|-------|
-| `Phase`      | single-select  | (see above)                                   | Board column |
-| `Type`       | single-select  | feat / fix / chore / docs / refactor / ci / test | Mirrors conventional-commit type |
-| `Size`       | single-select  | S / M / L                                     | Caps parallelism in Phase C executor |
-| `AgentReady` | single-select  | No (default) / Yes                            | Gate to `Ready` |
-| `BounceTo`   | single-select  | Plan / Design / Define                        | Only meaningful when `Phase=Bounced` |
-| `ADR`        | text           | e.g. "ADR-0072"                               | Non-null in `Design` if architectural |
-| `AuthBudget` | text           | freeform                                      | Phase C placeholder (cost/time/retry caps) |
+## Issue metadata — labels, not board fields
+
+The board carries **only** Phase. Everything that used to be a custom single-select rides on issue labels instead — durable, REST-cheap, and the signal the skills actually read:
+
+| Metadata      | Lives as                                | Set by | Notes |
+|---------------|-----------------------------------------|--------|-------|
+| Type          | `type:*` label                          | `/sketch` at filing | Mirrors the conventional-commit prefix |
+| Size          | `size:s\|m\|l` label                    | `/scope` at Plan | Dispatch context-cost prior; `size:xl` marks a fat issue needing breakdown |
+| Model route   | `model:*` label                         | `/scope` at Plan | Routes the implementing agent's model |
+| Agent-ready   | `phase:ready` label                     | `/approve` | "Ready" *is* the eligibility signal — there is no separate field |
+| Bounce target | `bounce-to:plan\|design\|define` label  | `/bounce` (or a self-bouncing skill) | Present only while `Phase=Bounced`; `/scope` reads it to resume, then clears it |
+
+The ADR link lives in the issue's `## Design notes` section; per-issue auth budgets aren't persisted in v1 (a breach is noted in the self-bounce comment).
 
 ## Native fields used
 
 - `Repository`: auto-populated when issues are added.
 - Issue dependencies: GH's native feature, not a custom field. `gh issue edit <n> --add-dependency <m>` and the dependency graph view.
 
-## Phase-transition rules (enforced socially in Phase B; codified in `/release-promote` in Phase C)
+## Phase-transition rules (enforced by the `/release-*` skills)
 
 ```
 Backlog  → Define     body has a problem statement
 Define   → Design     if multi-PR, umbrella issue exists; if architectural, ADR drafted
-Design   → Plan       tradeoffs aired in comments; ADR merged if applicable
-Plan     → Ready      dependencies declared, AgentReady=Yes, one concept per issue
+Design   → Plan       tradeoffs aired; ADR merged if applicable
+Plan     → Ready      dependencies declared, one concept per issue (sets phase:ready)
 Ready    → Executing  /implement run (manually or by the fleet executor)
 Executing → Refine    PR opened, CI running
 Refine   → Done       CI green, merged
-Executing/Refine → Bounced   agent surfaced an upstream-phase issue (BounceTo set)
+Executing/Refine → Bounced   agent surfaced an upstream-phase issue (sets bounce-to:*)
 Any      → Stalled    env/tooling failure (not the issue's fault)
 ```
 
@@ -54,6 +58,6 @@ Any      → Stalled    env/tooling failure (not the issue's fault)
 
 - **Create release project:** `release-project-init.sh 0.4`
 - **Add issue to project:** `gh project item-add <project> --owner iamacoffeepot --url <issue-url>`
-- **Set a field on an issue:** `gh project item-edit --id <item-id> --field-id <field-id> --single-select-option-id <option-id>` (or `--text` / `--number` etc.)
+- **Set Phase on an issue:** the `/release-*` skills write it via `updateProjectV2ItemFieldValue` (Phase field/option IDs cached in `release-state.json`), mirroring the `phase:*` label in the same step.
 
-Field and option IDs aren't human-readable; future `/release-*` skills will cache them at project-create time so callers can use field names directly.
+Field and option IDs aren't human-readable; the `/release-*` skills cache them at project-create time so callers use field names directly.

--- a/scripts/release-project-init.sh
+++ b/scripts/release-project-init.sh
@@ -42,21 +42,6 @@ if [[ "$INIT_TEMPLATE" -eq 0 && -z "$VERSION" ]]; then
     exit 64
 fi
 
-create_select() {
-    local number="$1" name="$2" options="$3"
-    echo "  + ${name} (single-select)"
-    gh project field-create "$number" --owner "$OWNER" \
-        --name "$name" --data-type SINGLE_SELECT \
-        --single-select-options "$options" >/dev/null
-}
-
-create_text() {
-    local number="$1" name="$2"
-    echo "  + ${name} (text)"
-    gh project field-create "$number" --owner "$OWNER" \
-        --name "$name" --data-type TEXT >/dev/null
-}
-
 if [[ "$INIT_TEMPLATE" -eq 1 ]]; then
     echo "→ Creating template project: ${TEMPLATE_TITLE} (owner: ${OWNER})"
     PROJECT_JSON=$(gh project create --owner "$OWNER" --title "$TEMPLATE_TITLE" --format json)
@@ -76,22 +61,15 @@ if [[ "$INIT_TEMPLATE" -eq 1 ]]; then
               {name: "Define",    color: BLUE,   description: "problem statement in progress"},
               {name: "Design",    color: BLUE,   description: "design rationale in progress"},
               {name: "Plan",      color: BLUE,   description: "impl plan written, awaiting /approve"},
-              {name: "Ready",     color: GREEN,  description: "approved, AgentReady"},
+              {name: "Ready",     color: GREEN,  description: "approved, ready for an agent"},
               {name: "Executing", color: YELLOW, description: "PR in flight"},
               {name: "Refine",    color: ORANGE, description: "CI loop / draft PR resting state"},
               {name: "Done",      color: PURPLE, description: "merged and closed"},
-              {name: "Bounced",   color: RED,    description: "regressed; see BounceTo"},
+              {name: "Bounced",   color: RED,    description: "regressed; see the bounce-to:* label"},
               {name: "Stalled",   color: PINK,   description: "env/tooling halt"}
             ]
           }) { projectV2Field { ... on ProjectV2SingleSelectField { id } } }
         }' -f fieldId="$STATUS_FIELD_ID" >/dev/null
-
-    create_select "$PROJECT_NUMBER" "Type"       "feat,fix,chore,docs,refactor,ci,test"
-    create_select "$PROJECT_NUMBER" "Size"       "S,M,L"
-    create_select "$PROJECT_NUMBER" "AgentReady" "No,Yes"
-    create_select "$PROJECT_NUMBER" "BounceTo"   "Plan,Design,Define"
-    create_text   "$PROJECT_NUMBER" "ADR"
-    create_text   "$PROJECT_NUMBER" "AuthBudget"
 
     cat <<EOF
 


### PR DESCRIPTION
Closes #1825.

## Summary

The release board duplicated issue metadata it didn't need to: every scoped issue carried its lifecycle as both labels and ProjectV2 fields (Type, Size, AgentReady, BounceTo, ADR, AuthBudget), and the skills already read state from the **labels** — so the board fields were a write-only, GraphQL-costly, fragile mirror (editing the Size option set re-minted its ids and wiped every item's value, recovered only from the `size:*` labels).

This drops the board to **Phase only** — the stage view, the one thing the board is used for — and lifts every other field onto the labels the skills already maintain:

- `Type` → `type:*` (set by `/sketch` at filing)
- `Size` → `size:*`, model route → `model:*` (set by `/scope` at Plan)
- `AgentReady` → folded into `phase:ready` ("ready" *is* the agent-eligibility signal)
- `BounceTo` → a `bounce-to:plan|design|define` label that `/bounce` writes and `/scope` reads to auto-resume a bounced issue, clearing it once consumed
- `ADR` (the link lives in `## Design notes`) and `AuthBudget` (unused in v1) → dropped

Sweeps the seven pipeline skills (`scope`, `approve`, `implement`, `sketch`, `scope-spinoff`, `bounce`, `release-init`), the canonical board-schema doc (`docs/release/schema.md`), the ADR-0110 context mention, and the bootstrap script's field provisioning.

## Test plan

Skill / doc / script changes only — `.claude/**`, `docs/**`, `scripts/**`, no Rust, so the Rust pre-flight short-circuits. Verified: zero residual `AgentReady` / `BounceTo` / `AuthBudget` references repo-wide, `bash -n` clean on `release-project-init.sh`. The live + template board field deletions, the `bounce-to:*` label creation, and the `release-state.json` `field_cache` trim are a one-time runtime step performed after merge (so no skill writes a since-deleted field mid-flight).

## Generated by

`/implement` — in-session execution of [scoped issue #1825](https://github.com/iamacoffeepot/aether/issues/1825).
