### PR TITLE
feat(workflow): /land pr landing skill

### DIFF
--- a/.claude/skills/land/SKILL.md
+++ b/.claude/skills/land/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: land
+description: Land a CI-green draft PR — un-draft, squash-merge, flip Phase to Done, sweep the worktree. `--sweep` discovers this shard's held green draft PRs and lands them in sequence, predicting and recomputing conflict state after every merge, auto-rebasing behind branches, and routing dirty content conflicts to the user rather than touching their contents.
+---
+
+# /land — PR landing skill
+
+The orchestrator's post-review action: take a draft PR that the user has approved, un-draft it, let native auto-merge squash it onto `main`, flip the closing issue's board `Phase` to `Done`, and sweep the merged worktree. This is the step ADR-0110 names as the `land` skill in the orchestrator role's loop — deliberately separate from `/implement`, which holds at draft and never merges.
+
+Two entry shapes, one skill:
+
+- **Single mode** — `/land <pr>` — land one named PR through the full linear sequence.
+- **Sweep mode** — `/land --sweep` — discover this shard's held green draft PRs, predict conflict state for each, print a land plan, confirm, then land in sequence with a recompute after every merge.
+
+## Invocation
+
+```
+/land <pr>                  land one draft PR through the full sequence
+/land --sweep               discover held green draft PRs, plan, confirm, land in sequence
+/land <pr> --no-sweep       single mode only; suppress the post-land worktree sweep
+```
+
+## Preconditions
+
+| Check | Refusal |
+|-------|---------|
+| `.claude/release-state.json` exists | "Run `/release-init <version>` first." |
+| PR exists and is a draft | "PR #N is not a draft — it may have already been un-drafted or merged." |
+| CI green (all required checks pass, none pending) | "PR #N is not CI-green. Wait for checks or use `/implement <issue>` to fix." |
+| PR has a closing issue linked on the board | "PR #N has no closing issue in the active project. Link it or update Phase manually." |
+| Closing issue is in the active project | "Closing issue #M is not in project <project-number>. Add it or update Phase manually." |
+
+Read PR draft state and `mergeable_state` over REST (`gh api repos/iamacoffeepot/aether/pulls/<n> --jq '.draft, .mergeable_state'`); read CI state from the REST check-runs endpoint (`gh api repos/iamacoffeepot/aether/commits/<sha>/check-runs`). Both are REST forms per the §REST-vs-GraphQL routing table in `/scope`.
+
+## Sweep land
+
+`/land --sweep` is the batched orchestrator entry point: it discovers the shard's held green draft PRs, validates each against the same gates single mode runs, prints a land plan with per-PR conflict prediction, and waits for one confirmation before landing anything.
+
+1. **Enumerate held green draft PRs over REST.** `/implement` leaves every implemented PR as a draft held at `Phase=Refine`, so `phase:refine` on an open issue is the eligibility signal — no GraphQL board read:
+
+   ```bash
+   gh api 'repos/iamacoffeepot/aether/issues?labels=phase:refine&state=open' --jq '.[].number'
+   ```
+
+   For each closing issue found, look up its open draft PR over REST:
+
+   ```bash
+   gh api 'repos/iamacoffeepot/aether/pulls?state=open' \
+     --jq '[.[] | select(.draft == true)] | .[].number'
+   ```
+
+   Cross-reference to find draft PRs whose closing issue is in the `phase:refine` set. Drop any PR whose closing issue is not in the set; list it in the dropped section with reason "no phase:refine closing issue".
+
+2. **Gate-check each candidate.** Run the full [Preconditions](#preconditions) per PR. Drop any that fail and record the reason. The sweep never silently skips — every dropped PR is listed in the plan with its drop reason.
+
+3. **Predict conflict state.** For each passing candidate, predict its merge state via the local oracle (see [Conflict prediction and routing](#conflict-prediction-and-routing)). Attach the prediction — `clean`, `behind`, or `dirty` — to each entry in the plan.
+
+4. **Print the land plan and wait for confirmation.** Landing serializes on `main` and each merge advances HEAD, so the plan is a preview that the recompute loop will keep fresh as it executes. Print the ordered PR list, per-PR predicted state, and the dropped-with-reason list, then stop and wait:
+
+   ```
+   Sweep: 5 held green draft PRs, 1 dropped, 4 to land.
+
+   Land sequence (in order):
+     #1801  feat(aether-data): kind-id newtype helpers     clean
+     #1803  fix(aether-codec): frame decoder edge case     clean
+     #1805  feat(substrate-bundle): boot manifest          behind  → will rebase
+     #1807  chore(workflow): /land skill                   clean
+
+   Dropped:
+     #1799  PR not CI-green (fmt check failing)
+
+   Confirm land sequence? (no merge happens until your go-ahead)
+   ```
+
+5. **On confirmation, land in sequence.** Land each PR through the [Landing sequence](#landing-sequence) in the printed order. After every merge, **recompute the remaining predictions** — the HEAD of `main` has advanced and a previously-clean branch may now be `behind`. A recomputed `dirty` halts the sequence and surfaces the conflict to the user before proceeding to the next PR.
+
+The sweep never auto-confirms and never auto-resolves a `dirty` conflict.
+
+## Landing sequence
+
+Single-mode steps, executed once per PR (sweep mode iterates this per PR in order):
+
+1. **Gate-check.** Verify draft state, CI green, and closing-issue presence per [Preconditions](#preconditions). Abort on any failure.
+
+2. **Predict conflict state.** Run [Conflict prediction and routing](#conflict-prediction-and-routing) for this PR's branch. If `dirty`, surface and abort — do not un-draft a dirty branch.
+
+3. **Auto-rebase a `behind` branch.** If the branch is `behind`:
+   ```bash
+   git fetch origin
+   git rebase origin/main <branch>
+   git push --force-with-lease origin <branch>
+   ```
+   Then re-predict. If the rebase produces conflicts, the branch becomes `dirty` — surface and abort.
+
+4. **Un-draft via GraphQL.** The REST `pulls` PATCH cannot clear `draft`, so this is a GraphQL-only op (per `/scope` §REST-vs-GraphQL routing):
+   ```bash
+   gh api graphql -f query='
+   mutation {
+     markPullRequestReadyForReview(input: { pullRequestId: "<pr-node-id>" }) {
+       pullRequest { isDraft }
+     }
+   }'
+   ```
+   Verify `isDraft` is `false` in the response before proceeding.
+
+5. **Squash-merge.** With auto-merge enabled on this repo, un-drafting a green PR typically lets GitHub's native auto-merge land it. When that is not relied on (e.g. auto-merge disabled, or a race window), issue the REST squash merge directly:
+   ```bash
+   gh api -X PUT repos/iamacoffeepot/aether/pulls/<n>/merge \
+     -f merge_method=squash \
+     -f commit_title="<pr-title>"
+   ```
+   Poll the PR state (`gh api repos/iamacoffeepot/aether/pulls/<n> --jq '.merged'`) until `true` before proceeding to avoid writing `Phase=Done` to an un-landed issue.
+
+6. **Flip Phase to Done and delete the phase label.** `Done` carries no `phase:*` label (per the phase-label-reconcile rules in `/scope` and `/implement`) — so the label delete is the label action, not a swap:
+   ```bash
+   gh api "repos/iamacoffeepot/aether/issues/<m>/labels" \
+     --jq '.[].name | select(startswith("phase:"))' \
+     | while read -r l; do
+         gh api -X DELETE "repos/iamacoffeepot/aether/issues/<m>/labels/$l"
+       done
+   ```
+   Then write the board field via GraphQL (field and option IDs from `field_cache`, item ID from `item_cache` with the targeted-lookup fallback per `/scope` §Project board mechanics):
+   ```bash
+   gh api graphql -f query='
+   mutation {
+     updateProjectV2ItemFieldValue(input: {
+       projectId: "<project-node-id>", itemId: "<item-id>",
+       fieldId: "<phase-field-id>", value: { singleSelectOptionId: "<done-option-id>" }
+     }) { projectV2Item { id } }
+   }'
+   ```
+
+7. **Sweep the merged worktree.** Run the worktree removal for this PR's branch, equivalent to `/sweep worktrees` §Target: worktrees step 4 for the merged entry:
+   ```bash
+   git worktree remove .claude/worktrees/issue-<m>
+   git branch -D <branch>
+   ```
+   If the worktree has uncommitted files (rare — the implement agent should have committed everything), use `--force`. Skip this step when `--no-sweep` was passed.
+
+8. **Print summary.**
+   ```
+   ✓ #<n> landed.
+   Merged: <pr-url>
+   Issue #<m>: Phase → Done
+   Worktree: .claude/worktrees/issue-<m> swept
+   ```
+
+## Conflict prediction and routing
+
+The local oracle for merge state is `git merge-tree --write-tree`. GitHub's `mergeable_state` field is the cross-check, not the primary signal — GitHub computes it asynchronously and can return `unknown` transiently.
+
+```bash
+git fetch origin
+git merge-tree --write-tree origin/main origin/<branch>
+```
+
+Classify the result into one of three states:
+
+| State | Condition | Action |
+|-------|-----------|--------|
+| **clean** | `merge-tree` exits 0 with a valid tree hash and no conflict markers | Proceed with the landing sequence. |
+| **behind** | branch's `merge-base` with `origin/main` is not `origin/main` itself (the branch needs rebase), but `merge-tree` would produce a clean tree | Auto-rebase onto fresh `main`, re-push, re-predict. |
+| **dirty** | `merge-tree` exits non-zero or produces output containing conflict markers (`<<<<<<<`) | Surface to the user. Never touch the branch contents. |
+
+Cross-check: after the local oracle classifies a branch, compare against `mergeable_state` from `gh api repos/iamacoffeepot/aether/pulls/<n> --jq '.mergeable_state'`:
+
+- `clean` / `has_hooks` → agrees with the oracle's `clean` classification.
+- `behind` → agrees with the oracle's `behind` classification.
+- `dirty` → agrees with the oracle's `dirty` classification.
+- `unknown` → transient; trust the local oracle and note the `unknown` in the plan.
+- A disagreement between the oracle and `mergeable_state` (e.g. oracle says `clean`, GitHub says `dirty`) → treat as `dirty` and surface the disagreement before proceeding. The local oracle can be wrong when the remote diverges from a local fetch; a fresh `git fetch origin` and re-run resolves most cases.
+
+**Dirty conflict handling.** When a branch is `dirty`, `/land` surfaces the specific conflicting files from `merge-tree`'s output and stops:
+
+```
+✗ PR #<n> has a content conflict — landing aborted.
+Conflicting files:
+  crates/aether-data/src/id.rs
+  crates/aether-kinds/src/lib.rs
+
+Branch contents untouched. Options:
+  1. Resolve manually: rebase <branch> onto main, fix the conflicts, re-push, then re-run /land <n>.
+  2. Delegate: /implement <issue> --resume to have an agent resolve the rebase.
+```
+
+In `--sweep` mode, a `dirty` PR halts the remaining sequence — a conflict requires a human (or a delegated agent) decision, and landing subsequent PRs can change the conflict shape. Print the halt reason, list the remaining PRs that were not landed, and wait for the user to resolve before re-running.
+
+**Recompute after every merge (`--sweep` only).** After each successful merge, `origin/main` has advanced. Recompute the conflict prediction for every remaining PR in the sequence using the same local oracle before proceeding to the next land. A branch that was `clean` against the prior `main` can be `behind` (or even `dirty`, in the degenerate case) after a sibling lands.
+
+## Phase label reconcile
+
+`Done` carries no `phase:*` label. The landing sequence deletes the current `phase:*` label instead of swapping it, per the rule in `/scope` §Phase label reconcile:
+
+```bash
+gh api "repos/iamacoffeepot/aether/issues/<m>/labels" \
+  --jq '.[].name | select(startswith("phase:"))' \
+  | while read -r l; do
+      gh api -X DELETE "repos/iamacoffeepot/aether/issues/<m>/labels/$l"
+    done
+```
+
+This is the same form `/scope` documents for the `Backlog` and `Done` phases. The Phase board field write (`Done` option) uses the GraphQL `updateProjectV2ItemFieldValue` mutation per §Field writes — REST has no ProjectV2 field write.
+
+## What /land does NOT do
+
+- Auto-resolve content conflicts. A `dirty` branch always surfaces to the user (or an optional delegated agent).
+- Un-draft a PR that is not CI-green. The gate check enforces green before un-draft.
+- Land PRs in parallel. Protected `main` enforces linear history; parallel landing races to discover the serialization. The sequence lands one at a time with recompute.
+- Write `Phase=Done` before verifying the merge completed (`merged` field confirmed `true`).
+- Remove a worktree whose PR has not merged. The sweep tail runs only after a confirmed merge.
+- Edit the issue body. `/scope` owns the body; `/land` only touches the Phase field and label.
+- Dispatch implementation. `/implement` handles that; `/land` acts on PRs that implement has already produced and the user has reviewed.
+- Operate without `.claude/release-state.json`. The board field writes need the cached IDs.

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ spikes/*/target/
 !.claude/skills/sketch/
 !.claude/skills/secretary/
 !.claude/skills/sweep/
+!.claude/skills/land/
 # Wish-pass reports — themed use-case ideation runs of `/wish`. Per-run
 # markdown, not part of the source tree. Read locally, file the wishes you
 # like as issues, discard the file.


### PR DESCRIPTION
Closes #1817.

## Summary

Adds `.claude/skills/land/SKILL.md`, the PR-landing skill ADR-0110's orchestrator role needs: single mode `/land <pr>` (gate draft + CI-green → un-draft via `markPullRequestReadyForReview` → squash auto-merge → flip the closing issue's `Phase=Done` → sweep the merged worktree), and `--sweep` mode that lands a shard's held green draft PRs **in sequence** with conflict prediction — the clean/behind/dirty trichotomy via `git merge-tree --write-tree` cross-checked against `mergeable_state`, recompute after every land, rebase `behind`, never auto-resolve `dirty`. Mirrors the structure of `/implement` and `/approve` and reuses the exact REST/GraphQL ops from `/scope`'s board-mechanics section (no invented endpoints).

## Test plan

New skill file plus a `.gitignore` allowlist entry (`!.claude/skills/land/`) so the new skill dir is tracked. No Rust; preflight short-circuits. Verified by reading the skill against the sibling skills' five-section shape.

## Generated by

`/implement` — agent execution of [scoped issue #1817](https://github.com/iamacoffeepot/aether/issues/1817).
