### PR TITLE
fix(workflow): scope model-routing rationale goes in the plan body, not a comment

### DIFF
--- a/.claude/skills/scope/SKILL.md
+++ b/.claude/skills/scope/SKILL.md
@@ -160,7 +160,7 @@ For each sub-phase: read inputs, write the corresponding body section, advance t
   - `model:opus` — the implementation itself requires non-obvious judgment: cross-crate L work, design-adjacent changes, plans with open exploration.
   - `model:fable` — never stamped by `/scope`; reserved for a human pinning the top tier explicitly.
 
-  The gate encodes a size-asymmetry: a downward misjudgment costs more as size grows, so an M/L `model:sonnet` demands a plan that reads as executable verbatim — when in doubt at M or L, stamp `model:opus`. Note the choice and a one-clause reason in the Plan audit comment.
+  The gate encodes a size-asymmetry: a downward misjudgment costs more as size grows, so an M/L `model:sonnet` demands a plan that reads as executable verbatim — when in doubt at M or L, stamp `model:opus`. Note the choice and a one-clause reason inline in the `## Implementation plan` section.
 - **Project board**: leave `Phase=Plan`. This is the resting state awaiting `/approve`.
 
 ## Side findings
@@ -178,7 +178,7 @@ These are *not auto-filed* as child issues. The user reviews them at `/approve` 
 
 ## Comments
 
-No progress comments — phase transitions are already legible from the `phase:*` labels (the issue timeline records every label change), the board fields, and the body sections themselves. A comment exists only when it is addressed to a human and carries content with no structured home. For this skill that is the **self-bounce question/blocker**, written as prose markdown with a bold lead, no `[skill]` prefix:
+No progress comments — phase transitions are already legible from the `phase:*` labels (the issue timeline records every label change), the board fields, and the body sections themselves. A comment exists only when it is addressed to a human and carries content with no structured home. For this skill that is the **self-bounce question/blocker**, written as prose markdown with a bold lead, no `[skill]` prefix. (The model-routing rationale is recorded inline in `## Implementation plan` — it has a structured home in the body, so it never goes in a comment.)
 
 ```markdown
 **Bounced to Define** — the body doesn't say which chassis this applies to.


### PR DESCRIPTION
Closes #1824.

## Summary

Reconciles a contradiction in `/scope`: the Plan model-routing step said to record the rationale "in the Plan audit comment," but the Comments section bans progress comments. The rationale has a structured home — the Plan — so the step now points it inline into the `## Implementation plan` section, and the Comments section cross-references that so the two can't re-drift.

## Test plan

A two-line reconciliation in `.claude/skills/scope/SKILL.md`. No Rust; preflight short-circuits. Re-applied onto post-#1825 `/scope` after a rebase — the conflict was only adjacent-line context from #1825's `AgentReady` removal, not a semantic clash.

## Generated by

`/implement` — agent execution of [scoped issue #1824](https://github.com/iamacoffeepot/aether/issues/1824).
