### PR TITLE
feat(workflow): bind session role via SessionStart hook

### DIFF
--- a/.claude/hooks/bind-session-role.sh
+++ b/.claude/hooks/bind-session-role.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# SessionStart hook — bind each Claude session to a role and its own worktree
+# (ADR-0110 § "Session binding").
+#
+# On every session start this hook:
+#   1. ensures the session's worktree exists at .claude/worktrees/<session-id>
+#      (idempotent: `git worktree add` when absent, no-op when already present);
+#   2. reads the session-keyed role marker at .claude/roles/<session-id>:
+#        - hit  -> injects the matching role directive
+#                  (.claude/roles/directives/<role>.md) as session context;
+#        - miss -> injects an instruction to ask the user which role applies
+#                  and write the marker.
+#
+# Reads the SessionStart hook payload JSON from stdin (Claude Code hook
+# protocol) and emits added context via the hookSpecificOutput.additionalContext
+# form. It never blocks — it primes the conversation, it does not gate it. The
+# hook cannot change the running session's cwd (fixed at launch), so the session
+# stays repo-rooted; the worktree boundary is enforced by a separate PreToolUse
+# hook (ADR-0110 § "Hook-enforced guardrails").
+
+set -u
+
+input=$(cat)
+
+# Project root: CLAUDE_PROJECT_DIR is exported for hooks; fall back to the hook
+# script's own location (two levels up from .claude/hooks/) when it is unset.
+project_dir="${CLAUDE_PROJECT_DIR:-}"
+if [[ -z "$project_dir" ]]; then
+    script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+    project_dir=$(cd "$script_dir/../.." && pwd)
+fi
+
+session_id=$(printf '%s' "$input" | jq -r '.session_id // ""')
+
+# Without a session id there is nothing to key the binding on — stay silent.
+if [[ -z "$session_id" ]]; then
+    exit 0
+fi
+
+roles_dir="$project_dir/.claude/roles"
+directives_dir="$roles_dir/directives"
+marker_file="$roles_dir/$session_id"
+worktree_dir="$project_dir/.claude/worktrees/$session_id"
+
+# (1) Ensure the per-session worktree exists. Idempotent: skip when the path is
+# already present, otherwise add it. Never fatal — a failure here must not stop
+# the session from starting.
+if command -v git >/dev/null 2>&1 \
+    && git -C "$project_dir" rev-parse --git-dir >/dev/null 2>&1; then
+    if [[ ! -e "$worktree_dir" ]]; then
+        git -C "$project_dir" worktree add "$worktree_dir" >/dev/null 2>&1 || true
+    fi
+fi
+
+# Emit the SessionStart added-context JSON for the text in $1, built safely with
+# jq so the directive body is escaped correctly.
+emit_context() {
+    jq -n --arg ctx "$1" \
+        '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'
+}
+
+# (2) Read the role marker. On a hit inject the matching directive; on a miss
+# inject the ask-the-user-and-write-the-marker instruction.
+if [[ -f "$marker_file" ]]; then
+    role=$(tr -d '[:space:]' < "$marker_file")
+    directive_file="$directives_dir/$role.md"
+    if [[ -n "$role" && -f "$directive_file" ]]; then
+        directive=$(cat "$directive_file")
+        emit_context "$(printf 'This session is bound to the %s role (ADR-0110). Its directive follows.\n\n%s' "$role" "$directive")"
+        exit 0
+    fi
+    # Marker present but empty or naming an unknown role — fall through to the
+    # prompt so the user can re-declare it.
+fi
+
+prompt=$(cat <<EOF
+This session has no role marker yet (ADR-0110 § "Session binding").
+
+Ask the user which of the four roles this session is for, then write the choice
+to the session-keyed marker so the binding is durable across restarts:
+
+    printf '%s\n' <role> > "$marker_file"
+
+Roles:
+  - dreamer       turn a felt absence into scoped issues
+  - scoper        scope-only: walk a Backlog issue Define -> Design -> Plan
+  - orchestrator  scoped issues -> merged PRs end-to-end (shardable)
+  - everything    no directive, every skill, the ad-hoc escape hatch
+
+Once the marker is written, the matching role directive is injected at the next
+session start.
+EOF
+)
+
+emit_context "$prompt"
+exit 0

--- a/.claude/roles/directives/dreamer.md
+++ b/.claude/roles/directives/dreamer.md
@@ -1,0 +1,31 @@
+# Role: dreamer
+
+You are bound to the **dreamer** role for this session (ADR-0110 § "Roles").
+A dreamer turns a felt absence into scoped issues.
+
+## Skills
+
+- `/wish` — adversity-grounded design ideation
+- `/wish-deep` — best-first fan-out drilling of a wish theme
+- `/sketch` — capture an idea as a well-formed GitHub issue
+- `/scope` — walk an issue Define → Design → Plan
+- `/scope-spinoff` — triage §Side findings into child issues
+- `/sweep fat` — enumerate fat (Size XL) issues and drive each through decomposition
+
+## Loop
+
+Wish a theme → drill → weigh each candidate → file the skinny ones and decompose
+the fat ones → scope to Plan. Run this sequence self-paced (a `/loop` over the
+skills above), pausing at the gate for the user's go/no-go.
+
+## Gate
+
+Pause for the user per decomposition plan, and at "scoped to Plan, awaiting
+approve."
+
+## Boundary
+
+You cannot `approve`, `implement`, merge, or push code (ADR-0110 §
+"Hook-enforced guardrails"). A design gap is scoped here; it is not implemented.
+You may read any file and use `/tmp` for scratch; every change you make lands in
+this session's worktree, never dirtying the main worktree.

--- a/.claude/roles/directives/everything.md
+++ b/.claude/roles/directives/everything.md
@@ -1,0 +1,8 @@
+# Role: everything
+
+You are bound to the **everything** role for this session (ADR-0110 § "Roles").
+
+There is no role directive. Every skill is available — this is the ad-hoc escape
+hatch. The one constraint is the worktree boundary (ADR-0110 § "Hook-enforced
+guardrails"): you may read any file and use `/tmp` for scratch, but every change
+you make lands in this session's worktree, never dirtying the main worktree.

--- a/.claude/roles/directives/orchestrator.md
+++ b/.claude/roles/directives/orchestrator.md
@@ -1,0 +1,40 @@
+# Role: orchestrator
+
+You are bound to the **orchestrator** role for this session (ADR-0110 § "Roles").
+An orchestrator turns scoped issues into merged PRs end-to-end, landing included.
+It is the one shardable role: several orchestrator sessions run concurrently,
+each in its own session-worktree, each owning a disjoint slice of issues
+end-to-end including its own merges.
+
+## Skills
+
+- `/approve` — Plan → Ready gate
+- `/implement` — issue → open PR (dispatches background agents)
+- `/bounce` — move an issue back to an earlier phase with a recorded reason
+- `/land` — land a CI-green draft PR
+- `/sweep` — reclaim stale local state
+
+## Loop
+
+Approve a batch → dispatch `implement` (background agents) → run CI to green →
+hold draft → (user go) land → board → Done → sweep. Run this sequence self-paced
+(a `/loop` over the skills above), pausing at the gate.
+
+## Gate
+
+Pause at the un-draft/land review gate.
+
+## Boundary
+
+You cannot `wish`, `sketch`, or create issues (ADR-0110 § "Hook-enforced
+guardrails"); a design gap bounces back rather than being scoped in place. You
+may read any file and use `/tmp` for scratch; every change you make lands in this
+session's worktree, never dirtying the main worktree.
+
+## Sharding
+
+When the user hands this shard a batch as its go, claim it via the GitHub issue
+assignee (a REST write, so the claim costs no GraphQL). The shared per-user
+GraphQL pool is the practical cap on concurrent shards, so batch board ops,
+stagger dispatch, and prefer REST forms (merges, labels, assignees, issue
+creation) over GraphQL.

--- a/.claude/roles/directives/scoper.md
+++ b/.claude/roles/directives/scoper.md
@@ -1,0 +1,26 @@
+# Role: scoper
+
+You are bound to the **scoper** role for this session (ADR-0110 § "Roles").
+A scoper is a narrow dreamer for the occasions a session does scope-only work.
+
+## Skills
+
+- `/scope` — walk an issue Define → Design → Plan
+- `/bounce` — move an issue back to an earlier phase with a recorded reason
+- `/scope-spinoff` — triage §Side findings into child issues
+
+## Loop
+
+Take a Backlog issue → walk Define → Design → Plan → stop. Run this sequence
+self-paced (a `/loop` over the skills above), pausing at the gate.
+
+## Gate
+
+Pause at Plan (awaiting approve).
+
+## Boundary
+
+You cannot `approve`, `implement`, merge, or push code (ADR-0110 §
+"Hook-enforced guardrails"). You may read any file and use `/tmp` for scratch;
+every change you make lands in this session's worktree, never dirtying the main
+worktree.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,16 @@
     ]
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/bind-session-role.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,13 @@ spikes/*/target/
 !.claude/skills/secretary/
 !.claude/skills/sweep/
 !.claude/skills/land/
+# Per-session role markers (ADR-0110 § "Session binding") — session-keyed,
+# per-clone state like `.claude/worktrees/`. The `*` glob ignores the marker
+# files (`.claude/roles/<session-id>`) while the negation keeps the committed
+# role-directive files under `directives/` tracked (same shape as the
+# `.claude/skills/*` + negation above).
+.claude/roles/*
+!.claude/roles/directives/
 # Wish-pass reports — themed use-case ideation runs of `/wish`. Per-run
 # markdown, not part of the source tree. Read locally, file the wishes you
 # like as issues, discard the file.


### PR DESCRIPTION
Closes #1818.

## Summary

First build step of ADR-0110's role model: bind each Claude session to a role and its own worktree at session start.

- **Four role directives** under the committed `.claude/roles/directives/` (`dreamer`, `scoper`, `orchestrator`, `everything`) — each carries that role's skill set, loop, gate, and boundary straight from ADR-0110 § "Roles".
- **`bind-session-role.sh`** — a `SessionStart` hook that idempotently ensures the session's worktree (`.claude/worktrees/<session-id>`), reads the session-keyed marker `.claude/roles/<session-id>`, and injects the matching directive (hit) or an ask-the-user-and-write-the-marker prompt (miss) via `hookSpecificOutput.additionalContext`. It never blocks — it primes the conversation, it does not gate it.
- **`settings.json`** — wires the `SessionStart` hook alongside the existing `PreToolUse` hooks (untouched).
- **`.gitignore`** — ignores the session-keyed markers (`.claude/roles/*`) while keeping the committed directives tracked (`!.claude/roles/directives/`), mirroring the existing `.claude/skills/*` pattern.

The hooked guardrails that *enforce* a bound role's boundary land separately (#1819); the status-line role indicator lands in #1820. Both read the marker this hook writes.

## Test plan

Config/docs-only (`.claude/**` + `.gitignore`) — no Rust, preflight short-circuits. Verified: `jq empty .claude/settings.json` (parses), `bash -n` on the hook, `git check-ignore` (directive tracked, marker ignored), and the hook exercised across hit / miss / unknown-role / missing-session-id / idempotent-rerun cases with valid JSON output each time.

## Generated by

`/implement` — agent execution of [scoped issue #1818](https://github.com/iamacoffeepot/aether/issues/1818).
