### PR TITLE
feat(workflow): show bound session role in the status line

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "statusLine": {
+    "type": "command",
+    "command": "${CLAUDE_PROJECT_DIR}/.claude/statusline-role.sh"
+  },
   "permissions": {
     "allow": [
       "Bash(cargo test *)",

--- a/.claude/statusline-role.sh
+++ b/.claude/statusline-role.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Status line command — render the session's bound role as a colored label.
+#
+# Claude Code pipes a JSON object to stdin on each status refresh; this script
+# extracts the session_id field, reads the session-keyed role marker the
+# SessionStart hook writes, and prints a single ANSI-colored line naming the
+# role (ADR-0110 § "Status line").
+#
+# Four roles, four fixed colors:
+#   dreamer      — blue
+#   scoper        — yellow
+#   orchestrator  — green
+#   everything    — magenta
+#
+# An absent or empty marker prints a dim neutral placeholder rather than
+# failing, so a session that has not yet written its marker still renders
+# cleanly.
+
+set -u
+
+input=$(cat)
+
+project_dir="${CLAUDE_PROJECT_DIR:-}"
+if [[ -z "$project_dir" ]]; then
+    script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+    project_dir=$(cd "$script_dir/.." && pwd)
+fi
+
+session_id=$(printf '%s' "$input" | jq -r '.session_id // ""')
+
+RESET='\033[0m'
+DIM='\033[2m'
+
+if [[ -z "$session_id" ]]; then
+    printf "${DIM}no role${RESET}\n"
+    exit 0
+fi
+
+marker_file="$project_dir/.claude/roles/$session_id"
+
+if [[ ! -f "$marker_file" ]]; then
+    printf "${DIM}no role${RESET}\n"
+    exit 0
+fi
+
+role=$(tr -d '[:space:]' < "$marker_file")
+
+if [[ -z "$role" ]]; then
+    printf "${DIM}no role${RESET}\n"
+    exit 0
+fi
+
+case "$role" in
+    dreamer)
+        COLOR='\033[34m'
+        ;;
+    scoper)
+        COLOR='\033[33m'
+        ;;
+    orchestrator)
+        COLOR='\033[32m'
+        ;;
+    everything)
+        COLOR='\033[35m'
+        ;;
+    *)
+        printf "${DIM}no role${RESET}\n"
+        exit 0
+        ;;
+esac
+
+printf "${COLOR}${role}${RESET}\n"


### PR DESCRIPTION
Closes #1820.

## Summary

Surfaces the session's bound role (ADR-0110) in the Claude Code status line, so a glance shows whether this session is a dreamer / scoper / orchestrator / everything.

- **`.claude/statusline-role.sh`** (new) — reads the status-line stdin JSON, extracts `session_id`, reads the session-keyed marker `.claude/roles/<session-id>` that the SessionStart binding hook (#1818) writes, and prints a single ANSI-colored label: dreamer=blue, scoper=yellow, orchestrator=green, everything=magenta. An absent / empty / unknown marker (or missing `session_id`) renders a dim `no role` placeholder, so a session that hasn't bound yet still draws cleanly.
- **`.claude/settings.json`** — adds the top-level `statusLine` key wiring the script.

Display-only — it reads the same marker the binding hook (#1818, merged) and the boundary guardrails (#1819) use, and changes nothing about enforcement.

## Test plan

Config-only (`.claude/**`) — no Rust, preflight short-circuits. Verified: `jq empty` (parses) and `jq '.statusLine'` (key present); `bash -n` on the script; and each of the four roles rendered its own colored label while an absent marker and a missing `session_id` both rendered the `no role` placeholder.

## Generated by

`/implement` — agent execution of [scoped issue #1820](https://github.com/iamacoffeepot/aether/issues/1820).
