### PR TITLE
feat(workflow): enforce role and worktree boundaries via hooks

### DIFF
--- a/.claude/hooks/check-role-boundary.sh
+++ b/.claude/hooks/check-role-boundary.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# PreToolUse hook — enforce the role boundary and the edit half of the
+# don't-dirty-main worktree boundary (ADR-0110 § "Hook-enforced guardrails").
+#
+# Two gates run before a tool executes, both reading the session-keyed role
+# marker the binding hook (#1818) writes at .claude/roles/<session-id>:
+#
+#   (a) Role gate (all tools) — the active role's deny table matches the
+#       invoked skill (its slash-command form) or the git/gh verb that stands
+#       in for it (merge / push / issue-creation must be prevented, not
+#       detected after the fact) against the Bash command, and blocks a hit.
+#         dreamer / scoper -> approve, implement, merge, code-push
+#         orchestrator     -> wish, sketch, issue-creation
+#         everything       -> nothing
+#   (b) Edit-path gate (Edit/Write/MultiEdit/NotebookEdit) — resolves the
+#       target file_path to absolute and blocks a write that lands in the main
+#       worktree, allowing /tmp scratch and the session's own worktree
+#       (.claude/worktrees/<session-id>). Reads dirty nothing, so they are
+#       never gated; the open-ended ways a Bash command can dirty main are
+#       caught after the fact by check-worktree-clean.sh.
+#
+# Reads the PreToolUse tool-call JSON from stdin (Claude Code hook protocol).
+# Exits 0 to allow, 2 to block (stderr body returns to Claude). Fails open
+# (exit 0) when the role marker is absent, so an unbound session is never
+# bricked and enforcement degrades to the pre-ADR no-op.
+#
+# Stays bash 3.2 compatible (the macOS system bash): no associative arrays,
+# the deny table is expressed as case-statement data functions.
+
+set -u
+
+input=$(cat)
+session_id=$(printf '%s' "$input" | jq -r '.session_id // ""')
+tool_name=$(printf '%s' "$input" | jq -r '.tool_name // ""')
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // ""')
+
+# Project root: CLAUDE_PROJECT_DIR is exported for hooks; fall back to the hook
+# script's own location (two levels up from .claude/hooks/) when it is unset.
+project_dir="${CLAUDE_PROJECT_DIR:-}"
+if [[ -z "$project_dir" ]]; then
+    script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+    project_dir=$(cd "$script_dir/../.." && pwd)
+fi
+
+# Without a session id there is nothing to key the binding on — fail open.
+[[ -z "$session_id" ]] && exit 0
+
+marker_file="$project_dir/.claude/roles/$session_id"
+[[ -r "$marker_file" ]] || exit 0
+role=$(tr -d '[:space:]' < "$marker_file")
+[[ -n "$role" ]] || exit 0
+
+# Command position: start of line or right after a separator (`;`, `&`, `|`, and
+# thus `&&` / `||`), mirroring check-pre-push.sh so a heredoc/quoted body that
+# merely mentions a verb does not false-positive.
+pos='(^|[;&|])[[:space:]]*'
+
+# Deny table (data). action_regex maps an action to the command-position
+# pattern that stands in for it; a skill appears as its slash-command form,
+# while merge / push / issue-creation appear as the git/gh verb (they must be
+# blocked before they run). issue-creation requires POST so a plain
+# `gh api .../issues` read is not mistaken for a create.
+action_regex() {
+    case "$1" in
+        approve) printf '%s' "${pos}/approve" ;;
+        implement) printf '%s' "${pos}/implement" ;;
+        merge) printf '%s' "${pos}(gh[[:space:]]+pr[[:space:]]+merge|git[[:space:]]+merge[[:space:]]|gh[[:space:]]+api[[:space:]][^|;&]*merge)" ;;
+        push) printf '%s' "${pos}git[[:space:]]+push" ;;
+        wish) printf '%s' "${pos}/wish" ;;
+        sketch) printf '%s' "${pos}/sketch" ;;
+        # issue-creation only: `issues` must be the final path segment (preceded
+        # by `/` or space, followed by space), so POST to .../issues/<n>/comments
+        # or .../issues/<n>/labels (commenting, labelling) is not mistaken for it.
+        issue_create) printf '%s' "${pos}(gh[[:space:]]+issue[[:space:]]+create|gh[[:space:]]+api[[:space:]][^|;&]*POST[^|;&]*[/[:space:]]issues[[:space:]]|gh[[:space:]]+api[[:space:]][^|;&]*[/[:space:]]issues[[:space:]][^|;&]*POST)" ;;
+    esac
+}
+action_label() {
+    case "$1" in
+        approve) printf 'run /approve' ;;
+        implement) printf 'run /implement' ;;
+        merge) printf 'merge a pull request (gh pr merge / git merge / gh api .../merge)' ;;
+        push) printf 'push code (git push)' ;;
+        wish) printf 'run /wish' ;;
+        sketch) printf 'run /sketch' ;;
+        issue_create) printf 'create issues (gh issue create / gh api POST .../issues)' ;;
+    esac
+}
+# role -> denied actions. everything (and any unknown role) denies nothing.
+role_actions() {
+    case "$1" in
+        dreamer | scoper) printf 'approve implement merge push' ;;
+        orchestrator) printf 'wish sketch issue_create' ;;
+        *) printf '' ;;
+    esac
+}
+role_remedy() {
+    case "$1" in
+        dreamer) printf 'A dreamer files and scopes issues. Hand the work to an orchestrator session, or re-declare this session'\''s role.' ;;
+        scoper) printf 'A scoper walks an issue Define -> Design -> Plan and stops. Hand the work to an orchestrator session, or re-declare this session'\''s role.' ;;
+        orchestrator) printf 'An orchestrator turns scoped issues into merged PRs; a design gap bounces back to a dreamer/scoper rather than being scoped in place. Re-declare this session'\''s role to ideate or scope.' ;;
+        *) printf 'Re-declare this session'\''s role to proceed.' ;;
+    esac
+}
+
+# Role gate — match the command against each action the active role denies.
+if [[ -n "$command" ]]; then
+    for action in $(role_actions "$role"); do
+        if printf '%s' "$command" | grep -qE "$(action_regex "$action")"; then
+            {
+                printf '[role boundary] the %s role may not %s.\n\n' "$role" "$(action_label "$action")"
+                printf 'ADR-0110 binds this session to the %s role; that boundary is enforced,\n' "$role"
+                printf 'not advisory.\n\n'
+                printf '%s\n' "$(role_remedy "$role")"
+            } >&2
+            exit 2
+        fi
+    done
+fi
+
+# Edit-path gate — only the edit tools, which declare their target up front.
+case "$tool_name" in
+    Edit | Write | MultiEdit | NotebookEdit) ;;
+    *) exit 0 ;;
+esac
+[[ -n "$file_path" ]] || exit 0
+
+# Resolve the target to an absolute, lexically-normalized path (the file may
+# not exist yet for a Write, so canonicalize . / .. segments without touching
+# the filesystem). A relative path resolves against the main project root.
+normalize_path() {
+    local path="$1"
+    [[ "$path" == /* ]] || path="$project_dir/$path"
+    local parts=()
+    local seg
+    local IFS='/'
+    for seg in $path; do
+        case "$seg" in
+            '' | '.') ;;
+            '..') ((${#parts[@]})) && unset 'parts[${#parts[@]}-1]' ;;
+            *) parts+=("$seg") ;;
+        esac
+    done
+    ((${#parts[@]})) && printf '/%s' "${parts[@]}" || printf '/'
+}
+
+target=$(normalize_path "$file_path")
+session_worktree=$(normalize_path "$project_dir/.claude/worktrees/$session_id")
+main_root=$(normalize_path "$project_dir")
+
+# Allow temp scratch (/tmp and the macOS temp roots).
+case "$target" in
+    /tmp/* | /tmp | /private/tmp/* | /var/tmp/* | /var/folders/*) exit 0 ;;
+esac
+# Allow the session's own worktree. A session reaches the worktrees of agents it
+# spawns through dispatch, not by editing them — those agents run outside this
+# guardrail (no role marker of their own, so the hook fails open for them) and
+# work in their own worktrees, so the bound session itself stays own-worktree.
+case "$target" in
+    "$session_worktree"/* | "$session_worktree") exit 0 ;;
+esac
+# Block anything else under the main worktree — that is what would dirty main.
+case "$target" in
+    "$main_root"/* | "$main_root")
+        {
+            printf '[worktree boundary] blocked an edit to a path in the main worktree:\n\n'
+            printf '    %s\n\n' "$target"
+            printf 'ADR-0110 holds every role to the don'\''t-dirty-main rule: edits land in\n'
+            printf 'this session'\''s own worktree (reads anywhere and /tmp scratch are fine).\n\n'
+            printf 'Redo the edit under:\n\n'
+            printf '    %s\n' "$session_worktree"
+        } >&2
+        exit 2
+        ;;
+esac
+
+# Outside the main worktree entirely (home, another mount) — cannot dirty main.
+exit 0

--- a/.claude/hooks/check-worktree-clean.sh
+++ b/.claude/hooks/check-worktree-clean.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# PostToolUse hook — the don't-dirty-main tripwire for Bash commands
+# (ADR-0110 § "Hook-enforced guardrails").
+#
+# A Bash command can dirty the main checkout in too many open-ended ways
+# (`> file`, `sed -i`, `git checkout`, applying a patch) to gate statically
+# before it runs, so this is the detect half of the don't-dirty-main rule:
+# after the command runs it checks `git status --porcelain` on the main
+# worktree. A non-empty result means the command left a tracked file changed
+# (or dropped non-ignored scratch) in the main checkout, so the hook returns
+# exit 2 naming the dirtied paths and the revert corrective. It cannot un-run
+# the command, but it reliably detects the violation and drives the fix —
+# false positives are near-zero because a role-bound session is expected to
+# keep main clean and gitignored scratch (.claude/roles, .claude/worktrees)
+# never shows here.
+#
+# Reads the PostToolUse tool-call JSON from stdin (Claude Code hook protocol).
+# Exits 0 when main is clean, 2 (with a stderr reason) when it is dirty. Fails
+# open (exit 0) when the role marker is absent, so an unbound session is never
+# flagged and enforcement degrades to the pre-ADR no-op.
+
+set -u
+
+input=$(cat)
+session_id=$(printf '%s' "$input" | jq -r '.session_id // ""')
+
+# Project root: CLAUDE_PROJECT_DIR is exported for hooks; fall back to the hook
+# script's own location (two levels up from .claude/hooks/) when it is unset.
+project_dir="${CLAUDE_PROJECT_DIR:-}"
+if [[ -z "$project_dir" ]]; then
+    script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+    project_dir=$(cd "$script_dir/../.." && pwd)
+fi
+
+# Without a session id there is nothing to key the binding on — fail open.
+[[ -z "$session_id" ]] && exit 0
+
+marker_file="$project_dir/.claude/roles/$session_id"
+[[ -r "$marker_file" ]] || exit 0
+role=$(tr -d '[:space:]' < "$marker_file")
+[[ -n "$role" ]] || exit 0
+
+command -v git >/dev/null 2>&1 || exit 0
+git -C "$project_dir" rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+dirty=$(git -C "$project_dir" status --porcelain 2>/dev/null)
+[[ -z "$dirty" ]] && exit 0
+
+{
+    printf '[worktree boundary] the main worktree is now dirty:\n\n'
+    printf '%s\n' "$dirty" | sed 's/^/    /'
+    printf '\n'
+    printf 'ADR-0110 holds every role to the don'\''t-dirty-main rule. The last Bash\n'
+    printf 'command changed a tracked file in the main checkout (%s).\n\n' "$project_dir"
+    printf 'Revert it now, then redo the work in this session'\''s worktree:\n\n'
+    printf '    git -C %s checkout -- <path>      # tracked changes\n' "$project_dir"
+    printf '    git -C %s clean -f <path>         # untracked scratch\n\n' "$project_dir"
+    printf 'The session worktree is .claude/worktrees/%s; /tmp is fine for scratch.\n' "$session_id"
+} >&2
+
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,6 +28,15 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "Bash|Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/check-role-boundary.sh"
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {
@@ -55,6 +64,17 @@
           {
             "type": "command",
             "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/check-no-divider-comments.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/check-worktree-clean.sh"
           }
         ]
       }

--- a/docs/adr/0110-claude-role-model.md
+++ b/docs/adr/0110-claude-role-model.md
@@ -41,7 +41,7 @@ The hook cannot change the running session's cwd (fixed at launch), so the sessi
 
 A `PreToolUse` hook reads the role marker and worktree path and blocks, with a reason:
 
-- **Worktree boundary (all roles)** — any file or git operation outside the session's worktree.
+- **Worktree boundary (all roles)** — a change that dirties a tracked file in the **main** worktree. Reads of any file, and writes under `/tmp` or the session's own worktree (`.claude/worktrees/<session-id>`), are allowed; only a change that would leave the main checkout dirty is held back. The edit tools (Edit/Write/MultiEdit/NotebookEdit) declare their target up front, so an edit landing in the main worktree is blocked before it runs (`PreToolUse`); a Bash command's effect is open-ended, so a dirtied main checkout is caught and reverted after it runs (a `PostToolUse` `git status` tripwire). Agents a session spawns run outside this guardrail (no role marker of their own, so the hook fails open) and work in their own worktrees, so a session stays bound to its own worktree and reaches its agents by dispatch rather than by editing theirs.
 - **Role boundary** — dreamer and scoper are blocked from `approve`, `implement`, merge, and code push; orchestrator is blocked from `wish`, `sketch`, and issue creation (a design gap bounces back rather than being scoped in place); everything carries no role boundary.
 
 Enforcement is the payoff. Advisory boundaries are the drifting status quo; a hard block is what removes the shared-clone collisions and bounds each session's blast radius.


### PR DESCRIPTION
Closes #1819.

## Summary

The enforcement half of ADR-0110's role model: two hooks that hold a role-bound session to its role and to the don't-dirty-main worktree boundary. Both read the session-keyed marker `.claude/roles/<session-id>` that the binding hook (#1818) writes, and both **fail open** when it's absent — an unbound session is never bricked.

- **`check-role-boundary.sh`** (PreToolUse, `Bash|Edit|Write|MultiEdit|NotebookEdit`) — a **role gate** (per-role deny table: dreamer/scoper deny approve/implement/merge/code-push; orchestrator denies wish/sketch/issue-creation; everything denies nothing) and an **edit-path gate** (blocks an Edit/Write target that lands in the main worktree; allows `/tmp` and the session's own worktree). Command verbs are command-position-anchored like `check-pre-push.sh`.
- **`check-worktree-clean.sh`** (PostToolUse, `Bash`) — the catch-all tripwire for the open-ended ways a Bash command can dirty main: `git -C <main> status --porcelain` after the command, exit 2 with the dirtied paths + revert corrective if non-empty.
- **`settings.json`** — wires both, preserving every existing hook entry.
- **ADR-0110 § "Hook-enforced guardrails"** — the worktree-boundary bullet refined to the don't-dirty-main rule, plus a note that spawned agents run outside the guardrail.

## Design decisions (from review)

- **Worktree gate is own-worktree-only for every role.** An orchestrator-only relaxation (edit any sibling worktree) was considered and dropped: the orchestrator operates from its own worktree, and the agents it spawns — which are what work across `issue-<N>` worktrees — run *outside* this guardrail (no role marker of their own → the hook fails open for them). So a session stays own-worktree and reaches its agents by dispatch.
- **issue-creation matches only the collection endpoint.** The deny regex anchors `issues` as the final path segment, so an orchestrator's `POST .../issues/<n>/comments` or `.../labels` (commenting, labelling) is not mistaken for creating an issue.
- **`git merge` is subcommand-anchored**, so read-only `git merge-base` / `merge-tree` (the conflict oracle `/land` uses) is not blocked.

## Known limitation

The role gate's *skill* patterns (`/approve`, `/implement`, `/wish`, `/sketch`) only fire if the slash form appears in a Bash command; skills invoked via the Skill tool aren't in the matcher, so those soft restrictions aren't enforced. The load-bearing ones — the dangerous *effects* (code push, merge, issue creation) — are caught via the git/`gh` stand-ins regardless. Extending enforcement to the Skill tool can be a follow-up.

## Test plan

Config + docs only — no Rust, preflight short-circuits. Both scripts pass `bash -n` and are `100755`; `settings.json` parses with both new entries and all prior ones preserved. The role/edit-path matrix was exercised with synthetic stdin fixtures (root under `$HOME` so the `/tmp` allowlist doesn't mask): issue-create blocked vs comment/label allowed; `git merge` blocked vs `merge-base`/`merge-tree` allowed; own-worktree allowed vs sibling-worktree / main / `../`-escape blocked; `/tmp` + outside-repo allowed; fail-open on absent marker; dreamer push still blocked.

## Generated by

`/implement` — agent execution of [scoped issue #1819](https://github.com/iamacoffeepot/aether/issues/1819), with review fixes applied by the orchestrator (own-worktree decision, issue-create / git-merge regex anchors, ADR agent-scope note).
