### PR TITLE
docs(adr): accept the claude role model

### DIFF
--- a/docs/adr/0110-claude-role-model.md
+++ b/docs/adr/0110-claude-role-model.md
@@ -1,6 +1,6 @@
 # ADR-0110: Claude Role Model
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-06-13
 
 ## Context


### PR DESCRIPTION
## Summary

Flips ADR-0110 (Claude Role Model) from **Proposed** to **Accepted**. The convention is that an ADR stays Proposed until its implementation arc lands; that arc is now on main:

- session role binding hook (#1818)
- hook-enforced role + don't-dirty-main worktree guardrails (#1819)
- status line role indicator (#1820)
- supporting pipeline skills: `/sweep fat` (#1816), `/land` (#1817), `/wish --deep` weighting (#1821)

One-line status change, no design changes.

## Test plan

Docs-only — preflight short-circuits. No code touched.
