### PR TITLE
feat(workflow): enter the session worktree on bind and restyle the role badge

### DIFF
--- a/.claude/hooks/bind-session-role.sh
+++ b/.claude/hooks/bind-session-role.sh
@@ -66,7 +66,7 @@ if [[ -f "$marker_file" ]]; then
     directive_file="$directives_dir/$role.md"
     if [[ -n "$role" && -f "$directive_file" ]]; then
         directive=$(cat "$directive_file")
-        emit_context "$(printf 'This session is bound to the %s role (ADR-0110). Its directive follows.\n\n%s' "$role" "$directive")"
+        emit_context "$(printf 'This session is bound to the %s role (ADR-0110).\n\nFirst action: switch into the session worktree by calling the EnterWorktree tool with path "%s" (it already exists — the SessionStart hook created it), so your edits and commands land in the worktree, never the main checkout.\n\nIts directive follows.\n\n%s' "$role" "$worktree_dir" "$directive")"
         exit 0
     fi
     # Marker present but empty or naming an unknown role — fall through to the
@@ -89,6 +89,11 @@ Roles:
 
 Once the marker is written, the matching role directive is injected at the next
 session start.
+
+After writing the marker, switch into the session worktree by calling the
+EnterWorktree tool with path "$worktree_dir" (it already exists — this hook
+created it), so your edits and commands land in the worktree, not the main
+checkout.
 EOF
 )
 

--- a/.claude/statusline-role.sh
+++ b/.claude/statusline-role.sh
@@ -1,16 +1,26 @@
 #!/usr/bin/env bash
-# Status line command — render the session's bound role as a colored label.
+# Status line command — render the session's bound role as a pastel pill badge.
 #
 # Claude Code pipes a JSON object to stdin on each status refresh; this script
 # extracts the session_id field, reads the session-keyed role marker the
-# SessionStart hook writes, and prints a single ANSI-colored line naming the
-# role (ADR-0110 § "Status line").
+# SessionStart hook writes, and prints a single ANSI badge naming the role
+# (ADR-0110 § "Status line").
 #
-# Four roles, four fixed colors:
-#   dreamer      — blue
-#   scoper        — yellow
-#   orchestrator  — green
-#   everything    — magenta
+# Four roles, four pastel fills (truecolor, Catppuccin Mocha) with dark ink:
+#   dreamer       — blue   (137,180,250)
+#   scoper        — yellow (249,226,175)
+#   orchestrator  — green  (166,227,161)
+#   everything    — mauve  (203,166,247)
+#
+# The badge is a rounded pill: a pastel left half-circle, the role name in dark
+# text on the pastel fill, a pastel right half-circle. The end-caps are the
+# powerline glyphs U+E0B6 / U+E0B4 — they need a Nerd Font to render. Set
+# AETHER_STATUSLINE_BADGE=block to drop the caps for a rectangular fill that
+# renders in any font.
+#
+# Stays bash 3.2 compatible (the macOS system bash): printf octal escapes only,
+# no \u unicode escapes (unsupported there), so the cap glyphs are spelled as
+# their UTF-8 bytes.
 #
 # An absent or empty marker prints a dim neutral placeholder rather than
 # failing, so a session that has not yet written its marker still renders
@@ -31,42 +41,58 @@ session_id=$(printf '%s' "$input" | jq -r '.session_id // ""')
 RESET='\033[0m'
 DIM='\033[2m'
 
-if [[ -z "$session_id" ]]; then
+print_none() {
     printf "${DIM}no role${RESET}\n"
+}
+
+if [[ -z "$session_id" ]]; then
+    print_none
     exit 0
 fi
 
 marker_file="$project_dir/.claude/roles/$session_id"
 
 if [[ ! -f "$marker_file" ]]; then
-    printf "${DIM}no role${RESET}\n"
+    print_none
     exit 0
 fi
 
 role=$(tr -d '[:space:]' < "$marker_file")
 
 if [[ -z "$role" ]]; then
-    printf "${DIM}no role${RESET}\n"
+    print_none
     exit 0
 fi
 
+# Pastel fill per role, as a truecolor "R;G;B" triple.
 case "$role" in
     dreamer)
-        COLOR='\033[34m'
+        pastel='137;180;250'
         ;;
     scoper)
-        COLOR='\033[33m'
+        pastel='249;226;175'
         ;;
     orchestrator)
-        COLOR='\033[32m'
+        pastel='166;227;161'
         ;;
     everything)
-        COLOR='\033[35m'
+        pastel='203;166;247'
         ;;
     *)
-        printf "${DIM}no role${RESET}\n"
+        print_none
         exit 0
         ;;
 esac
 
-printf "${COLOR}${role}${RESET}\n"
+ink='30;30;46'  # dark text on the pastel fill (Catppuccin base)
+
+fg="\033[38;2;${pastel}m"
+bg="\033[48;2;${pastel}m"
+ink_fg="\033[38;2;${ink}m"
+
+# \356\202\266 = U+E0B6 (left half-circle), \356\202\264 = U+E0B4 (right).
+if [[ "${AETHER_STATUSLINE_BADGE:-rounded}" == "block" ]]; then
+    printf "${bg}${ink_fg} %s ${RESET}\n" "$role"
+else
+    printf "${fg}\356\202\266${bg}${ink_fg} %s ${RESET}${fg}\356\202\264${RESET}\n" "$role"
+fi

--- a/docs/adr/0110-claude-role-model.md
+++ b/docs/adr/0110-claude-role-model.md
@@ -35,7 +35,7 @@ Weight reuses the existing Size field, extended with a fourth option, **XL**, me
 
 Each session is bound to its own worktree under `.claude/worktrees/<session-id>`, created at start and never swapped out. The role marker is a gitignored, session-keyed file (`.claude/roles/<session-id>`) in the main clone, written once the role is known and read by session id from each consumer's input — the binding hook, the guardrail hook, and the status line. A `SessionStart` hook creates the worktree, reads the marker, and injects that role's directive — the skill set, the loop, the gate. With no marker, the hook injects an instruction to ask the user the role and write the marker. The directive ends with the `loop` invocation over the role's skill sequence, pausing at the role's gate for the user's go/no-go. The role is durable and session-bound, so it survives a restart. A per-session status line renders the role as a colored label, read from the same marker, so the kind of session is legible at a glance.
 
-The hook cannot change the running session's cwd (fixed at launch), so the session stays rooted at the repo while operating inside its worktree path; the enforcement below keeps it there.
+The hook cannot change the running session's cwd itself (a hook's cwd is fixed at launch), so ahead of the directive it injects an instruction making the session's first action a call to the `EnterWorktree` tool with the session-worktree path — a model tool, unlike a hook, that does move the session's cwd into the worktree. Edits and commands then land in the worktree by default, and the `PreToolUse`/`PostToolUse` enforcement below is the backstop for anything that slips past rather than the primary mechanism.
 
 ### Hook-enforced guardrails
 


### PR DESCRIPTION
## What

Two pieces of ADR-0110 session-binding polish, born from using the freshly-landed role model.

### Session enters its worktree on bind

The SessionStart binding hook already created each session's worktree, but the session stayed cwd-rooted at the main checkout — only the reactive PreToolUse / PostToolUse guardrails kept edits out of main. A hook cannot change a running session's cwd; the EnterWorktree model tool can. The hook now injects, ahead of the role directive, an instruction making the session's first action a call to EnterWorktree with the session-worktree path. Edits and commands then land in the worktree by default, and the guardrails become a backstop rather than the primary mechanism. ADR-0110 section "Session binding" is amended to record this.

### Pastel pill role badge

The role status line moves from the eight basic ANSI colors to a truecolor pastel pill: a rounded end-cap each side, dark ink on a pastel fill per role — dreamer blue, scoper yellow, orchestrator green, everything mauve. `AETHER_STATUSLINE_BADGE=block` drops the caps for a plain rectangular badge in fonts without the powerline glyphs. Stays bash-3.2 compatible (octal UTF-8 for the cap glyphs, no unicode escapes).

## Verification

- Rendered the status line for all four roles (rounded + block) and the no-role placeholder; hexdump confirms the U+E0B6 / U+E0B4 cap bytes and the pastel triples.
- Both edited scripts pass `bash -n`.
- All changed paths are in the docs/config pre-flight skip class, so no Rust checks apply.
