### PR TITLE
docs(adr): mark adr-0111 accepted

### DIFF
--- a/docs/adr/0111-soft-ask-boundaries.md
+++ b/docs/adr/0111-soft-ask-boundaries.md
@@ -1,6 +1,6 @@
 # ADR-0111: Soft, ask-to-confirm role and worktree boundaries
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-06-14
 
 ## Context


### PR DESCRIPTION
Flip ADR-0111 from Proposed to Accepted now that its realization has landed in #1844 (the PreToolUse role and worktree gates ask to confirm instead of hard-denying). Follows the convention that an ADR stays Proposed until its implementation arc lands.