### PR TITLE
feat(actor): handler reply classes via mode-typed ctx

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -1512,6 +1512,10 @@ struct HandlerFn {
     /// return type. Drives the auto-emitted `ctx.reply` and the reply
     /// kind id on the inputs manifest record.
     reply: HandlerReply,
+    /// ADR-0112: the declared reply class (single / manual). Selects the
+    /// ctx view the macro passes (`as_single()` for single, the full
+    /// `Manual` ctx for manual) and the manifest `ReplyContract` tag.
+    class: HandlerClass,
 }
 
 struct FallbackFn {
@@ -1567,15 +1571,28 @@ fn expand_handlers(item: ItemImpl, opts: ActorOpts) -> syn::Result<TokenStream2>
     }
 }
 
-/// Match `#[handler]`, `#[crate::handler]`, or `#[aether_data::handler]` —
-/// any path whose last segment is `handler`. Bare `is_ident("handler")`
-/// only matches the unqualified form, so qualified-path tests like
-/// `#[aether_data::handler]` would skip the macro silently.
+/// Match a handler attribute — bare `#[handler]` (any path whose last
+/// segment is `handler`, so `#[crate::handler]` / `#[aether_data::handler]`
+/// resolve too) or a class-marked `#[handler::single|manual|stream]`
+/// (ADR-0112), whose last segment is the class and whose preceding
+/// segment is `handler`. The class path never reaches attribute
+/// resolution — `#[actor]` parses and strips it.
 fn attr_is_handler(attr: &Attribute) -> bool {
-    attr.path()
-        .segments
-        .last()
-        .is_some_and(|s| s.ident == "handler")
+    let segments = &attr.path().segments;
+    let Some(last) = segments.last() else {
+        return false;
+    };
+    if last.ident == "handler" {
+        return true;
+    }
+    if matches!(
+        last.ident.to_string().as_str(),
+        "single" | "manual" | "stream"
+    ) {
+        let len = segments.len();
+        return len >= 2 && segments[len - 2].ident == "handler";
+    }
+    false
 }
 
 /// Same logic for `#[fallback]`.
@@ -1634,6 +1651,56 @@ fn parse_handler_variant(attr: &Attribute) -> syn::Result<HandlerVariant> {
              or `#[handler(task)]`",
         )),
     }
+}
+
+/// The reply class of a handler (ADR-0112), read off the attribute path:
+/// `#[handler]` / `#[handler::single]` are [`Single`](HandlerClass::Single),
+/// `#[handler::manual]` is [`Manual`](HandlerClass::Manual), and
+/// `#[handler::stream]` is [`Stream`](HandlerClass::Stream) — reserved,
+/// rejected by [`parse_handler_class`]. Orthogonal to [`HandlerVariant`]
+/// (the `mail` / `task` trigger), which is read from the parens.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum HandlerClass {
+    Single,
+    Manual,
+    Stream,
+}
+
+/// Read a handler's [`HandlerClass`] off its attribute path (ADR-0112).
+/// The last path segment is the class (`single` / `manual` / `stream`),
+/// or `handler` itself for the bare `#[handler]` (= single). `stream` is
+/// a hard error — the class is reserved and its emit surface isn't built.
+/// `attr_is_handler` is the gate, so the path is known to end in one of
+/// these segments.
+fn parse_handler_class(attr: &Attribute) -> syn::Result<HandlerClass> {
+    let last = attr
+        .path()
+        .segments
+        .last()
+        .expect("attr_is_handler guarantees a non-empty path");
+    let class = match last.ident.to_string().as_str() {
+        // Bare `#[handler]` / `#[handler(mail|task)]` and the explicit
+        // `#[handler::single]` are both the single class.
+        "handler" | "single" => HandlerClass::Single,
+        "manual" => HandlerClass::Manual,
+        "stream" => HandlerClass::Stream,
+        other => {
+            return Err(syn::Error::new_spanned(
+                attr,
+                format!(
+                    "unknown #[handler::<class>] — accepts `single`, `manual`, or `stream` \
+                     (ADR-0112); got `{other}`"
+                ),
+            ));
+        }
+    };
+    if class == HandlerClass::Stream {
+        return Err(syn::Error::new_spanned(
+            attr,
+            "#[handler::stream] is reserved and not yet implemented (ADR-0112)",
+        ));
+    }
+    Ok(class)
 }
 
 /// Extract `(O, C, is_borrow)` from a `#[handler(task)]` method's third
@@ -1859,12 +1926,16 @@ fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
                     let kind_ty = extract_handler_kind_type(&f.sig)?;
                     let agent_doc = extract_agent_doc(&f.attrs);
                     let reply = classify_handler_reply(&f.sig.output);
+                    // ADR-0112: read the reply class off the marker path
+                    // (rejects `#[handler::stream]`).
+                    let class = parse_handler_class(&f.attrs[idx])?;
                     f.attrs.remove(idx);
                     handlers.push(HandlerFn {
                         method: f,
                         kind_ty,
                         agent_doc,
                         reply,
+                        class,
                     });
                 } else if let Some(idx) = fallback_attr_idx {
                     if fallback.is_some() {
@@ -2098,7 +2169,7 @@ fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
             #[doc(hidden)]
             pub fn __aether_dispatch(
                 &mut self,
-                __aether_ctx: &mut ::aether_actor::FfiCtx<'_>,
+                __aether_ctx: &mut ::aether_actor::FfiCtx<'_, ::aether_actor::Manual>,
                 __aether_mail: ::aether_actor::Mail<'_>,
             ) -> u32 {
                 #dispatch_body
@@ -2123,16 +2194,18 @@ fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
             }
             fn erased_dispatch(
                 &mut self,
-                __aether_ctx: &mut ::aether_actor::FfiCtx<'_>,
+                __aether_ctx: &mut ::aether_actor::FfiCtx<'_, ::aether_actor::Manual>,
                 __aether_mail: ::aether_actor::Mail<'_>,
             ) -> u32 {
                 self.__aether_dispatch(__aether_ctx, __aether_mail)
             }
-            fn erased_wire(&mut self, __aether_ctx: &mut ::aether_actor::FfiCtx<'_>) {
-                <#self_ty as ::aether_actor::FfiActor>::wire(self, __aether_ctx);
+            // ADR-0112: the lifecycle hooks keep their `FfiCtx<'_>` (= Single)
+            // default signatures; downgrade the carried `Manual` ctx here.
+            fn erased_wire(&mut self, __aether_ctx: &mut ::aether_actor::FfiCtx<'_, ::aether_actor::Manual>) {
+                <#self_ty as ::aether_actor::FfiActor>::wire(self, __aether_ctx.as_single());
             }
-            fn erased_unwire(&mut self, __aether_ctx: &mut ::aether_actor::FfiCtx<'_>) {
-                <#self_ty as ::aether_actor::FfiActor>::unwire(self, __aether_ctx);
+            fn erased_unwire(&mut self, __aether_ctx: &mut ::aether_actor::FfiCtx<'_, ::aether_actor::Manual>) {
+                <#self_ty as ::aether_actor::FfiActor>::unwire(self, __aether_ctx.as_single());
             }
             fn erased_on_dehydrate(
                 &mut self,
@@ -2142,10 +2215,10 @@ fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
             }
             fn erased_on_rehydrate(
                 &mut self,
-                __aether_ctx: &mut ::aether_actor::FfiCtx<'_>,
+                __aether_ctx: &mut ::aether_actor::FfiCtx<'_, ::aether_actor::Manual>,
                 __aether_prior: ::aether_actor::PriorState<'_>,
             ) {
-                <#self_ty as ::aether_actor::FfiActor>::on_rehydrate(self, __aether_ctx, __aether_prior);
+                <#self_ty as ::aether_actor::FfiActor>::on_rehydrate(self, __aether_ctx.as_single(), __aether_prior);
             }
         }
 
@@ -2239,6 +2312,11 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
                 }
                 if let Some(idx) = handler_attr_idx {
                     let variant = parse_handler_variant(&f.attrs[idx])?;
+                    // ADR-0112: read the reply class off the marker path
+                    // (rejects `#[handler::stream]` on both the mail and task
+                    // variants). A task handler always receives the
+                    // downgraded `Single` ctx, so it carries no class field.
+                    let class = parse_handler_class(&f.attrs[idx])?;
                     f.attrs.remove(idx);
                     match variant {
                         HandlerVariant::Mail => {
@@ -2249,6 +2327,7 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
                                 kind_ty,
                                 is_slice,
                                 reply,
+                                class,
                             });
                         }
                         HandlerVariant::Task => {
@@ -2480,19 +2559,27 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
     let dispatch_arms = handlers.iter().map(|h| {
         let kind_ty = &h.kind_ty;
         let method_ident = &h.method.sig.ident;
-        // ADR-0109: a `-> R` handler auto-replies its return value
-        // through `OutboundReply::reply` (UFCS so the trait need not be
-        // imported at the emission site). `-> ()` and `-> Pending<R>`
-        // discard the return value — the deferred `Pending` send is the
-        // follow-on (#1805).
-        let call = match &h.reply {
-            HandlerReply::Sync(_) => quote! {
-                let __aether_reply = self.#method_ident(__aether_ctx, __aether_decoded);
+        // ADR-0112: the dispatch ctx is the full `Manual` view. A single
+        // handler is called with the downgraded `as_single()` view and the
+        // macro auto-replies a `-> R` return through `OutboundReply::reply`
+        // on the `Manual` ctx (`-> ()` / `-> Pending<R>` discard it — the
+        // deferred `Pending` send is #1805). A manual handler is called with
+        // the `Manual` ctx directly and issues its own replies — no
+        // auto-reply, regardless of return type.
+        let call = match (h.class, &h.reply) {
+            (HandlerClass::Single, HandlerReply::Sync(_)) => quote! {
+                let __aether_reply = self.#method_ident(__aether_ctx.as_single(), __aether_decoded);
                 ::aether_actor::OutboundReply::reply(__aether_ctx, &__aether_reply);
             },
-            HandlerReply::None | HandlerReply::Deferred(_) => quote! {
+            (HandlerClass::Single, HandlerReply::None | HandlerReply::Deferred(_)) => quote! {
+                self.#method_ident(__aether_ctx.as_single(), __aether_decoded);
+            },
+            (HandlerClass::Manual, _) => quote! {
                 self.#method_ident(__aether_ctx, __aether_decoded);
             },
+            (HandlerClass::Stream, _) => {
+                unreachable!("parse_handler_class rejects #[handler::stream]")
+            }
         };
         if h.is_slice {
             // Slice handler — payload is `count * size_of::<K>()`
@@ -2545,16 +2632,20 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
             // `&TaskDone -> R` calls the handler for the reply value then
             // `resolve_value`s it; `&TaskDone -> ()` releases the hold via
             // `release_no_reply` with no reply.
+            //
+            // ADR-0112: the dispatch ctx is the full `Manual` view; a task
+            // handler (and `TaskDone::resolve_value`) take the single-mode
+            // ctx, so downgrade with `as_single()`.
             let dispatch = match t.mode {
                 TaskReplyMode::ByValue => quote! {
-                    self.#method_ident(__aether_ctx, __aether_done);
+                    self.#method_ident(__aether_ctx.as_single(), __aether_done);
                 },
                 TaskReplyMode::BorrowReply => quote! {
-                    let __aether_reply = self.#method_ident(__aether_ctx, &__aether_done);
-                    __aether_done.resolve_value(__aether_ctx, &__aether_reply);
+                    let __aether_reply = self.#method_ident(__aether_ctx.as_single(), &__aether_done);
+                    __aether_done.resolve_value(__aether_ctx.as_single(), &__aether_reply);
                 },
                 TaskReplyMode::BorrowNoReply => quote! {
-                    self.#method_ident(__aether_ctx, &__aether_done);
+                    self.#method_ident(__aether_ctx.as_single(), &__aether_done);
                     __aether_done.release_no_reply();
                 },
             };
@@ -2601,13 +2692,15 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
     // override on every envelope.
     let fallback_dispatch_override = fallback.as_ref().map(|f| {
         let method_ident = &f.method.sig.ident;
+        // ADR-0112: the trait seam carries the `Manual` ctx; a `#[fallback]`
+        // keeps its `NativeCtx<'_>` (= Single) signature, so downgrade.
         quote! {
             fn __aether_dispatch_fallback(
                 &mut self,
-                __aether_ctx: &mut ::aether_substrate::NativeCtx<'_>,
+                __aether_ctx: &mut ::aether_substrate::NativeCtx<'_, ::aether_actor::Manual>,
                 __aether_env: &::aether_substrate::actor::native::envelope::Envelope,
             ) -> bool {
-                self.#method_ident(__aether_ctx, __aether_env);
+                self.#method_ident(__aether_ctx.as_single(), __aether_env);
                 true
             }
         }
@@ -2624,16 +2717,16 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
     // so this is independent of rustdoc extraction.
     let capability_handler_entries = handlers.iter().map(|h| {
         let kind_ty = &h.kind_ty;
-        // ADR-0109 §5: native chassis caps don't yet surface a
+        // ADR-0109 §5 / ADR-0112: native chassis caps don't yet surface a
         // per-handler reply contract — that needs a native handler
-        // manifest (a follow-on). Leave `reply: None` until then; the
-        // wasm `describe_component` path carries the contract today.
+        // manifest (a follow-on). Report `ReplyContract::None` until then;
+        // the wasm `describe_component` path carries the real class today.
         quote! {
             ::aether_substrate::actor::native::HandlerCapability {
                 id: <#kind_ty as ::aether_data::Kind>::ID,
                 name: <#kind_ty as ::aether_data::Kind>::NAME.to_owned(),
                 doc: ::core::option::Option::None,
-                reply: ::core::option::Option::None,
+                reply: ::aether_data::ReplyContract::None,
             }
         }
     });
@@ -2728,9 +2821,11 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
 
         #[cfg(not(target_arch = "wasm32"))]
         impl #impl_generics ::aether_substrate::NativeDispatch for #self_ty #where_clause {
+            // ADR-0112: the dispatch seam carries the most-permissive
+            // `Manual` ctx; the arms downgrade per handler class.
             fn __aether_dispatch_envelope(
                 &mut self,
-                __aether_ctx: &mut ::aether_substrate::NativeCtx<'_>,
+                __aether_ctx: &mut ::aether_substrate::NativeCtx<'_, ::aether_actor::Manual>,
                 __aether_kind: ::aether_substrate::mail::KindId,
                 __aether_payload: &[u8],
             ) -> ::core::option::Option<()> {
@@ -2765,6 +2860,9 @@ struct NativeActorHandlerFn {
     /// return type. A `-> R` native handler auto-replies `R` through
     /// `OutboundReply::reply`, the same path a manual `ctx.reply` takes.
     reply: HandlerReply,
+    /// ADR-0112: the declared reply class (single / manual). Selects the
+    /// ctx view the dispatch arm passes and the manifest reply tag.
+    class: HandlerClass,
 }
 
 /// A `#[handler(task)]` completion handler (ADR-0093 §3). Its third
@@ -3021,19 +3119,27 @@ fn build_dispatch_body(handlers: &[HandlerFn], fallback: Option<&FallbackFn>) ->
     let arms = handlers.iter().map(|h| {
         let k = &h.kind_ty;
         let method = &h.method.sig.ident;
-        // ADR-0109: a `-> R` handler replies its return value through
-        // `OutboundReply::reply` (UFCS so the trait need not be in scope
-        // at the emission site) — the same discharge path a manual
-        // `ctx.reply` takes. `-> ()` and `-> Pending<R>` discard the
-        // return value (the deferred `Pending` send is #1805).
-        let call = match &h.reply {
-            HandlerReply::Sync(_) => quote! {
-                let __aether_reply = self.#method(__aether_ctx, __aether_decoded);
+        // ADR-0112: the dispatch ctx is the full `Manual` view. A single
+        // handler is called with the downgraded `as_single()` view and the
+        // macro auto-replies a `-> R` return through `OutboundReply::reply`
+        // on the `Manual` ctx (`-> ()` / `-> Pending<R>` discard it — the
+        // deferred `Pending` send is #1805). A manual handler is called with
+        // the `Manual` ctx directly and issues its own replies — no
+        // auto-reply, regardless of return type.
+        let call = match (h.class, &h.reply) {
+            (HandlerClass::Single, HandlerReply::Sync(_)) => quote! {
+                let __aether_reply = self.#method(__aether_ctx.as_single(), __aether_decoded);
                 ::aether_actor::OutboundReply::reply(__aether_ctx, &__aether_reply);
             },
-            HandlerReply::None | HandlerReply::Deferred(_) => quote! {
+            (HandlerClass::Single, HandlerReply::None | HandlerReply::Deferred(_)) => quote! {
+                self.#method(__aether_ctx.as_single(), __aether_decoded);
+            },
+            (HandlerClass::Manual, _) => quote! {
                 self.#method(__aether_ctx, __aether_decoded);
             },
+            (HandlerClass::Stream, _) => {
+                unreachable!("parse_handler_class rejects #[handler::stream]")
+            }
         };
         // `Mail::kind()` returns the raw `u64` the FFI carried; `Kind::ID`
         // is typed `KindId` post-issue 466, so we drop into `.0` for the
@@ -3052,8 +3158,10 @@ fn build_dispatch_body(handlers: &[HandlerFn], fallback: Option<&FallbackFn>) ->
 
     let tail = if let Some(f) = fallback {
         let method = &f.method.sig.ident;
+        // ADR-0112: a `#[fallback]` keeps its `FfiCtx<'_>` (= Single)
+        // signature; the dispatch ctx is `Manual`, so downgrade.
         quote! {
-            self.#method(__aether_ctx, __aether_mail);
+            self.#method(__aether_ctx.as_single(), __aether_mail);
             ::aether_actor::DISPATCH_HANDLED
         }
     } else {
@@ -3101,17 +3209,21 @@ fn build_inputs_manifest_consts(
     for h in handlers {
         let k = &h.kind_ty;
         let doc_expr = option_str_token(h.agent_doc.as_ref());
-        // ADR-0109: the reply kind id rides the handler record as an
-        // `Option<u64>` — `Some(<R as Kind>::ID.0)` for a `-> R` or
-        // `-> Pending<R>` handler (the inner `R`), `None` for `-> ()`.
-        let reply_expr = if let Some(r) = h.reply.manifest_kind() {
-            quote! {
-                ::core::option::Option::Some(
-                    <#r as ::aether_actor::__macro_internals::Kind>::ID.0
-                )
+        // ADR-0112: the reply class rides the handler record as a
+        // `ReplyContract` `(tag, id)` pair — `(0, 0)` for a single `-> ()`,
+        // `(1, R::ID)` for a single `-> R` / `-> Pending<R>`, `(3, 0)` for a
+        // manual handler (no single static reply kind). `Stream` is
+        // unreachable — `parse_handler_class` rejects `#[handler::stream]`.
+        let (reply_tag_expr, reply_id_expr) = match (h.class, h.reply.manifest_kind()) {
+            (HandlerClass::Manual, _) => (quote! { 3u8 }, quote! { 0u64 }),
+            (HandlerClass::Single, Some(r)) => (
+                quote! { 1u8 },
+                quote! { <#r as ::aether_actor::__macro_internals::Kind>::ID.0 },
+            ),
+            (HandlerClass::Single, None) => (quote! { 0u8 }, quote! { 0u64 }),
+            (HandlerClass::Stream, _) => {
+                unreachable!("parse_handler_class rejects #[handler::stream]")
             }
-        } else {
-            quote! { ::core::option::Option::None }
         };
         // `inputs_handler_len` / `write_inputs_handler` take a raw `u64`
         // for the wire bytes; `Kind::ID` is `KindId` post-issue 466 so
@@ -3121,7 +3233,8 @@ fn build_inputs_manifest_consts(
                 <#k as ::aether_actor::__macro_internals::Kind>::ID.0,
                 <#k as ::aether_actor::__macro_internals::Kind>::NAME,
                 #doc_expr,
-                #reply_expr,
+                #reply_tag_expr,
+                #reply_id_expr,
             ))
         });
         copy_blocks.push(quote! {
@@ -3131,20 +3244,22 @@ fn build_inputs_manifest_consts(
                         <#k as ::aether_actor::__macro_internals::Kind>::ID.0,
                         <#k as ::aether_actor::__macro_internals::Kind>::NAME,
                         #doc_expr,
-                        #reply_expr,
+                        #reply_tag_expr,
+                        #reply_id_expr,
                     );
                 const REC_BYTES: [u8; REC_LEN] =
                     ::aether_actor::__macro_internals::canonical::write_inputs_handler::<REC_LEN>(
                         <#k as ::aether_actor::__macro_internals::Kind>::ID.0,
                         <#k as ::aether_actor::__macro_internals::Kind>::NAME,
                         #doc_expr,
-                        #reply_expr,
+                        #reply_tag_expr,
+                        #reply_id_expr,
                     );
-                // Per-record section version byte, bumped to 0x03 by
-                // ADR-0109 (issue 1803) — the `Handler` variant gained
-                // the `reply` kind id. Keep in lockstep with
-                // `INPUTS_SECTION_VERSION`.
-                out[pos] = 0x03;
+                // Per-record section version byte, bumped to 0x04 by
+                // ADR-0112 (issue 1850) — the `Handler` variant's reply
+                // field widened from `Option<KindId>` to `ReplyContract`.
+                // Keep in lockstep with `INPUTS_SECTION_VERSION`.
+                out[pos] = 0x04;
                 pos += 1;
                 let mut i = 0;
                 while i < REC_LEN {
@@ -3167,11 +3282,9 @@ fn build_inputs_manifest_consts(
                     ::aether_actor::__macro_internals::canonical::inputs_fallback_len(#doc_expr);
                 const REC_BYTES: [u8; REC_LEN] =
                     ::aether_actor::__macro_internals::canonical::write_inputs_fallback::<REC_LEN>(#doc_expr);
-                // Per-record section version byte, bumped to 0x03 by
-                // ADR-0109 (issue 1803) — the `Handler` variant gained
-                // the `reply` kind id. Keep in lockstep with
-                // `INPUTS_SECTION_VERSION`.
-                out[pos] = 0x03;
+                // Per-record section version byte, in lockstep with
+                // `INPUTS_SECTION_VERSION` (0x04, ADR-0112 / issue 1850).
+                out[pos] = 0x04;
                 pos += 1;
                 let mut i = 0;
                 while i < REC_LEN {
@@ -3194,11 +3307,9 @@ fn build_inputs_manifest_consts(
                     ::aether_actor::__macro_internals::canonical::inputs_component_len(#doc_lit);
                 const REC_BYTES: [u8; REC_LEN] =
                     ::aether_actor::__macro_internals::canonical::write_inputs_component::<REC_LEN>(#doc_lit);
-                // Per-record section version byte, bumped to 0x03 by
-                // ADR-0109 (issue 1803) — the `Handler` variant gained
-                // the `reply` kind id. Keep in lockstep with
-                // `INPUTS_SECTION_VERSION`.
-                out[pos] = 0x03;
+                // Per-record section version byte, in lockstep with
+                // `INPUTS_SECTION_VERSION` (0x04, ADR-0112 / issue 1850).
+                out[pos] = 0x04;
                 pos += 1;
                 let mut i = 0;
                 while i < REC_LEN {
@@ -3234,9 +3345,9 @@ fn build_inputs_manifest_consts(
                         <#cfg as ::aether_actor::__macro_internals::Kind>::ID.0,
                         <#cfg as ::aether_actor::__macro_internals::Kind>::NAME,
                     );
-                // Per-record section version byte (0x03), in lockstep
-                // with `INPUTS_SECTION_VERSION` (ADR-0109 / issue 1803).
-                out[pos] = 0x03;
+                // Per-record section version byte (0x04), in lockstep
+                // with `INPUTS_SECTION_VERSION` (ADR-0112 / issue 1850).
+                out[pos] = 0x04;
                 pos += 1;
                 let mut i = 0;
                 while i < REC_LEN {

--- a/crates/aether-actor-derive/tests/ui.rs
+++ b/crates/aether-actor-derive/tests/ui.rs
@@ -19,10 +19,23 @@
 fn ui() {
     let t = trybuild::TestCases::new();
     t.pass("tests/ui/accepts_minimal_actor.rs");
+    // ADR-0112: the manual reply class compiles. The native manual-class
+    // behavior is covered by the `manual_handler_replies_through_ctx`
+    // integration test in `aether-substrate` (this proc-macro crate has no
+    // `aether-substrate` dev-dep, so a native *pass* / type-error fixture
+    // can't link the substrate types — the existing native fixtures here
+    // are all macro-level diagnostics that fire before path resolution).
+    t.pass("tests/ui/accepts_manual_handler_ffi.rs");
     t.compile_fail("tests/ui/rejects_duplicate_handler_kind_ffi.rs");
     t.compile_fail("tests/ui/rejects_duplicate_handler_kind_native.rs");
     t.compile_fail("tests/ui/rejects_missing_namespace_ffi.rs");
     t.compile_fail("tests/ui/rejects_missing_namespace_native.rs");
     t.compile_fail("tests/ui/rejects_stray_const_ffi.rs");
     t.compile_fail("tests/ui/rejects_stray_const_native.rs");
+    // ADR-0112: `#[handler::stream]` is reserved (a macro error, so the
+    // native fixture works too); an FFI marker / class disagreement fails
+    // to unify.
+    t.compile_fail("tests/ui/rejects_stream_reserved_ffi.rs");
+    t.compile_fail("tests/ui/rejects_stream_reserved_native.rs");
+    t.compile_fail("tests/ui/rejects_manual_marker_mismatch_ffi.rs");
 }

--- a/crates/aether-actor-derive/tests/ui/accepts_manual_handler_ffi.rs
+++ b/crates/aether-actor-derive/tests/ui/accepts_manual_handler_ffi.rs
@@ -1,0 +1,54 @@
+//! ADR-0112: a `#[handler::manual]` FFI handler receives the `Manual`
+//! ctx and issues its own reply via `OutboundReply::reply` — the
+//! manual-class path compiles cleanly on the wasm expansion.
+
+use aether_actor::{FfiCtx, Manual, OutboundReply, actor};
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.ping")]
+struct Ping {
+    seq: u32,
+}
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.ack")]
+struct Ack {
+    seq: u32,
+}
+
+struct ManualProbe;
+
+#[actor]
+impl aether_actor::FfiActor for ManualProbe {
+    const NAMESPACE: &'static str = "manual_probe";
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, aether_actor::BootError>
+    where
+        C: aether_actor::Resolver,
+    {
+        Ok(ManualProbe)
+    }
+
+    #[handler::manual]
+    fn on_ping(&mut self, ctx: &mut FfiCtx<'_, Manual>, ping: Ping) {
+        ctx.reply(&Ack { seq: ping.seq });
+    }
+}
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/rejects_manual_marker_mismatch_ffi.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_manual_marker_mismatch_ffi.rs
@@ -1,0 +1,62 @@
+//! ADR-0112: the class marker and the ctx marker must agree — the macro
+//! passes the manual view to a `#[handler::manual]` and the single view
+//! to a `#[handler]`, so a signature whose ctx marker disagrees fails to
+//! unify. Two mismatches on the wasm path:
+//!   - manual class + `FfiCtx<'_>` (= Single) ctx,
+//!   - single class + `FfiCtx<'_, Manual>` ctx.
+
+use aether_actor::{FfiCtx, Manual, actor};
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.ping")]
+struct Ping {
+    seq: u32,
+}
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.pong")]
+struct Pong {
+    seq: u32,
+}
+
+struct MismatchProbe;
+
+#[actor]
+impl aether_actor::FfiActor for MismatchProbe {
+    const NAMESPACE: &'static str = "mismatch_probe";
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, aether_actor::BootError>
+    where
+        C: aether_actor::Resolver,
+    {
+        Ok(MismatchProbe)
+    }
+
+    // manual class but a single-mode ctx — the macro passes the `Manual`
+    // ctx, which doesn't unify with `FfiCtx<'_>`.
+    #[handler::manual]
+    fn on_ping(&mut self, _ctx: &mut FfiCtx<'_>, _ping: Ping) {}
+
+    // single class but a manual-mode ctx — the macro passes `as_single()`,
+    // which doesn't unify with `FfiCtx<'_, Manual>`.
+    #[handler]
+    fn on_pong(&mut self, _ctx: &mut FfiCtx<'_, Manual>, _pong: Pong) {}
+}
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/rejects_manual_marker_mismatch_ffi.stderr
+++ b/crates/aether-actor-derive/tests/ui/rejects_manual_marker_mismatch_ffi.stderr
@@ -1,0 +1,35 @@
+error[E0308]: mismatched types
+  --> tests/ui/rejects_manual_marker_mismatch_ffi.rs:40:1
+   |
+40 | #[actor]
+   | ^^^^^^^^ expected `&mut FfiCtx<'_>`, found `&mut FfiCtx<'_, Manual>`
+...
+54 |     fn on_ping(&mut self, _ctx: &mut FfiCtx<'_>, _ping: Ping) {}
+   |        ------- arguments to this method are incorrect
+   |
+   = note: expected mutable reference `&mut FfiCtx<'_, Single>`
+              found mutable reference `&mut FfiCtx<'_, aether_actor::Manual>`
+note: method defined here
+  --> tests/ui/rejects_manual_marker_mismatch_ffi.rs:54:8
+   |
+54 |     fn on_ping(&mut self, _ctx: &mut FfiCtx<'_>, _ping: Ping) {}
+   |        ^^^^^^^            ---------------------
+   = note: this error originates in the attribute macro `actor` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui/rejects_manual_marker_mismatch_ffi.rs:40:1
+   |
+40 | #[actor]
+   | ^^^^^^^^ expected `&mut FfiCtx<'_, Manual>`, found `&mut FfiCtx<'_>`
+...
+59 |     fn on_pong(&mut self, _ctx: &mut FfiCtx<'_, Manual>, _pong: Pong) {}
+   |        ------- arguments to this method are incorrect
+   |
+   = note: expected mutable reference `&mut FfiCtx<'_, aether_actor::Manual>`
+              found mutable reference `&mut FfiCtx<'_, Single>`
+note: method defined here
+  --> tests/ui/rejects_manual_marker_mismatch_ffi.rs:59:8
+   |
+59 |     fn on_pong(&mut self, _ctx: &mut FfiCtx<'_, Manual>, _pong: Pong) {}
+   |        ^^^^^^^            -----------------------------
+   = note: this error originates in the attribute macro `actor` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/aether-actor-derive/tests/ui/rejects_stream_reserved_ffi.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_stream_reserved_ffi.rs
@@ -1,0 +1,38 @@
+//! ADR-0112: `#[handler::stream]` is a reserved class with no emit
+//! surface yet — the macro rejects it with a pointed "not yet
+//! implemented" error on the wasm expansion path.
+
+use aether_actor::{FfiCtx, Stream, actor};
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.ping")]
+struct Ping {
+    seq: u32,
+}
+
+struct StreamProbe;
+
+#[actor]
+impl aether_actor::FfiActor for StreamProbe {
+    const NAMESPACE: &'static str = "stream_probe";
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, aether_actor::BootError>
+    where
+        C: aether_actor::Resolver,
+    {
+        Ok(StreamProbe)
+    }
+
+    #[handler::stream]
+    fn on_ping(&mut self, _ctx: &mut FfiCtx<'_, Stream>, _ping: Ping) {}
+}
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/rejects_stream_reserved_ffi.stderr
+++ b/crates/aether-actor-derive/tests/ui/rejects_stream_reserved_ffi.stderr
@@ -1,0 +1,13 @@
+error: #[handler::stream] is reserved and not yet implemented (ADR-0112)
+  --> tests/ui/rejects_stream_reserved_ffi.rs:34:5
+   |
+34 |     #[handler::stream]
+   |     ^^^^^^^^^^^^^^^^^^
+
+warning: unused imports: `FfiCtx` and `Stream`
+ --> tests/ui/rejects_stream_reserved_ffi.rs:5:20
+  |
+5 | use aether_actor::{FfiCtx, Stream, actor};
+  |                    ^^^^^^  ^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/crates/aether-actor-derive/tests/ui/rejects_stream_reserved_native.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_stream_reserved_native.rs
@@ -1,0 +1,44 @@
+//! ADR-0112: `#[handler::stream]` is reserved on the native expansion
+//! path too — the macro rejects it before any dispatch table is emitted,
+//! mirroring the wasm fixture.
+
+use aether_actor::actor;
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.ping")]
+struct Ping {
+    seq: u32,
+}
+
+struct StreamProbe;
+
+#[actor]
+impl aether_substrate::actor::native::NativeActor for StreamProbe {
+    const NAMESPACE: &'static str = "stream_probe";
+    type Config = ();
+
+    fn init(
+        _config: (),
+        _ctx: &mut aether_substrate::actor::native::NativeInitCtx<'_>,
+    ) -> Result<Self, aether_actor::BootError> {
+        Ok(StreamProbe)
+    }
+
+    #[handler::stream]
+    fn on_ping(
+        &mut self,
+        _ctx: &mut aether_substrate::actor::native::NativeCtx<'_, aether_substrate::Stream>,
+        _ping: Ping,
+    ) {
+    }
+}
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/rejects_stream_reserved_native.stderr
+++ b/crates/aether-actor-derive/tests/ui/rejects_stream_reserved_native.stderr
@@ -1,0 +1,5 @@
+error: #[handler::stream] is reserved and not yet implemented (ADR-0112)
+  --> tests/ui/rejects_stream_reserved_native.rs:35:5
+   |
+35 |     #[handler::stream]
+   |     ^^^^^^^^^^^^^^^^^^

--- a/crates/aether-actor/src/actor/ctx/mod.rs
+++ b/crates/aether-actor/src/actor/ctx/mod.rs
@@ -23,10 +23,12 @@ pub mod lifecycle;
 pub mod mail_sender;
 pub mod outbound_reply;
 pub mod persistence;
+pub mod reply_mode;
 pub mod resolver;
 
 pub use lifecycle::LifecycleControl;
 pub use mail_sender::MailSender;
 pub use outbound_reply::OutboundReply;
 pub use persistence::Persistence;
+pub use reply_mode::{Manual, ReplyMode, Single, Stream};
 pub use resolver::Resolver;

--- a/crates/aether-actor/src/actor/ctx/reply_mode.rs
+++ b/crates/aether-actor/src/actor/ctx/reply_mode.rs
@@ -1,0 +1,71 @@
+//! [`ReplyMode`] — the phantom marker a per-handler ctx carries to
+//! select which reply surface its handler class permits (ADR-0112).
+//!
+//! One ctx type per target (`FfiCtx` / `NativeCtx`) is parameterized by
+//! a [`ReplyMode`] marker that defaults to [`Single`], so the common
+//! signature stays `FfiCtx<'_>` / `NativeCtx<'_>`. The reply surface is
+//! selected by which traits the per-mode ctx implements:
+//!
+//! - [`Single`] — 0-or-1 reply via the return value (ADR-0109). No
+//!   `reply` / `reply_to` (a transitional exception holds while the
+//!   migration runs; ADR-0112 §Consequences).
+//! - [`Manual`] — the handler issues its own replies; `OutboundReply`
+//!   (`reply` / `reply_to`) is implemented for this mode.
+//! - [`Stream`] — a stream of replies; reserved (ADR-0112), the macro
+//!   rejects `#[handler::stream]` until the stream surface is built.
+//!
+//! The trait is sealed through a private supertrait so a guest crate
+//! cannot add a fourth mode — the closed set of three is what the
+//! `#[actor]` macro's downgrade-only coercions (`as_single` /
+//! `as_stream`) rely on.
+
+mod sealed {
+    /// Private supertrait sealing [`super::ReplyMode`] — only the three
+    /// marker types in this module can implement it, so the mode set is
+    /// closed.
+    pub trait Sealed {}
+}
+
+/// Marker selecting a per-handler ctx's reply surface (ADR-0112).
+/// Sealed: the only implementors are [`Single`], [`Manual`], and
+/// [`Stream`].
+pub trait ReplyMode: sealed::Sealed {}
+
+/// single-class marker (ADR-0112): the handler replies 0-or-1 through
+/// its return value (ADR-0109). The default `M` on both ctx types, so
+/// an unmarked `FfiCtx<'_>` / `NativeCtx<'_>` is the single-mode view.
+pub struct Single;
+
+/// manual-class marker (ADR-0112): the handler issues its own replies
+/// via `OutboundReply` (`reply` / `reply_to`), which is implemented
+/// only for this mode.
+pub struct Manual;
+
+/// stream-class marker (ADR-0112): a stream of replies over time.
+/// Reserved — no emit surface is built yet, and the `#[actor]` macro
+/// rejects `#[handler::stream]` until it is.
+pub struct Stream;
+
+impl sealed::Sealed for Single {}
+impl sealed::Sealed for Manual {}
+impl sealed::Sealed for Stream {}
+
+impl ReplyMode for Single {}
+impl ReplyMode for Manual {}
+impl ReplyMode for Stream {}
+
+#[cfg(test)]
+mod tests {
+    use super::{Manual, Single, Stream};
+    use core::mem::size_of;
+
+    /// The mode markers are zero-sized — the invariant the layout-
+    /// identity reborrow in `FfiCtx::as_single` / `NativeCtx::as_single`
+    /// rests on (a `PhantomData<M>` field stays a ZST for every `M`).
+    #[test]
+    fn reply_mode_types_are_zsts() {
+        assert_eq!(size_of::<Single>(), 0);
+        assert_eq!(size_of::<Manual>(), 0);
+        assert_eq!(size_of::<Stream>(), 0);
+    }
+}

--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -17,12 +17,14 @@
 //! and dispatch goes through the bridge statics directly.
 
 use core::marker::PhantomData;
+use core::ptr;
 
 use aether_data::{Kind, MailboxId, mailbox_id_from_name};
 
 use crate::actor::ctx::mail_sender::MailSender;
 use crate::actor::ctx::outbound_reply::OutboundReply;
 use crate::actor::ctx::persistence::Persistence;
+use crate::actor::ctx::reply_mode::{Manual, ReplyMode, Single, Stream};
 use crate::actor::ctx::resolver::Resolver;
 use crate::actor::{
     Actor, HandlesKind, Instanced, NamespaceError, Singleton, Subname, validate_namespace_segment,
@@ -121,14 +123,21 @@ pub enum SpawnError {
 /// `mailbox_id` field so `wire`-stage explicit subscribes
 /// (sending [`SubscribeInput`](aether_kinds::SubscribeInput) to the
 /// `InputCapability`) can self-address.
-pub struct FfiCtx<'a> {
+pub struct FfiCtx<'a, M: ReplyMode = Single> {
     mailbox: u64,
     sender: Option<u32>,
     _borrow: PhantomData<&'a ()>,
+    /// ADR-0112: phantom reply-mode marker (a ZST, layout-neutral) that
+    /// selects which reply surface this ctx exposes. Defaults to
+    /// [`Single`], so the common `FfiCtx<'_>` signature is unchanged.
+    _mode: PhantomData<M>,
 }
 
-impl FfiCtx<'_> {
+impl<'a> FfiCtx<'a, Manual> {
     /// Not part of the public API; called only by [`crate::export!`].
+    /// The runtime builds the most-permissive [`Manual`] view; the
+    /// `#[actor]` dispatcher / lifecycle shims downgrade it per handler
+    /// class with [`Self::as_single`].
     #[doc(hidden)]
     #[must_use]
     pub fn __new(mailbox: u64) -> Self {
@@ -136,9 +145,42 @@ impl FfiCtx<'_> {
             mailbox,
             sender: None,
             _borrow: PhantomData,
+            _mode: PhantomData,
         }
     }
 
+    /// ADR-0112 downgrade-only coercion: view this [`Manual`] ctx as a
+    /// [`Single`] ctx, dropping the `OutboundReply` surface. The
+    /// `#[actor]` macro hands a single-class handler this view, so a
+    /// handler whose marker disagrees with its class fails to unify.
+    /// There is deliberately no `as_manual` — the runtime only ever
+    /// downgrades.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn as_single(&mut self) -> &mut FfiCtx<'a, Single> {
+        // SAFETY: `M` is `PhantomData`-only, so `FfiCtx<'a, Manual>` and
+        // `FfiCtx<'a, Single>` are layout-identical (the marker field is a
+        // ZST for every `M` — see `reply_mode_types_are_zsts` and
+        // `ffi_ctx_layout_identical_across_modes`). The reborrow swaps the
+        // marker without touching any real field and only removes
+        // capability, never adds it.
+        unsafe { &mut *ptr::from_mut(self).cast::<FfiCtx<'a, Single>>() }
+    }
+
+    /// ADR-0112 forward-only coercion to the reserved [`Stream`] view.
+    /// `#[handler::stream]` is rejected by the macro today, so this has
+    /// no in-tree caller yet; it exists so the stream class has its
+    /// downgrade path the day the emit surface lands.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn as_stream(&mut self) -> &mut FfiCtx<'a, Stream> {
+        // SAFETY: same as `as_single` — `M` is `PhantomData`-only, so the
+        // marker swap is a layout-identity reborrow.
+        unsafe { &mut *ptr::from_mut(self).cast::<FfiCtx<'a, Stream>>() }
+    }
+}
+
+impl<M: ReplyMode> FfiCtx<'_, M> {
     /// Not part of the public API; called only by the `#[actor]`
     /// dispatcher. Accepts `None` or `Some(ReplyHandle)` — the dispatcher
     /// passes `mail.reply_handle()` verbatim so component-origin and
@@ -251,7 +293,7 @@ impl FfiCtx<'_> {
     }
 }
 
-impl Resolver for FfiCtx<'_> {
+impl<M: ReplyMode> Resolver for FfiCtx<'_, M> {
     fn mailbox_id(&self) -> u64 {
         self.mailbox
     }
@@ -265,7 +307,7 @@ impl Resolver for FfiCtx<'_> {
     }
 }
 
-impl MailSender for FfiCtx<'_> {
+impl<M: ReplyMode> MailSender for FfiCtx<'_, M> {
     //noinspection DuplicatedCode
     fn send<R, K>(&mut self, payload: &K)
     where
@@ -324,7 +366,38 @@ impl MailSender for FfiCtx<'_> {
     }
 }
 
-impl OutboundReply for FfiCtx<'_> {
+// ADR-0112: the reply surface is per-mode. `Manual` carries it
+// permanently (a manual-class handler issues its own replies); `Single`
+// carries the identical body **transitionally** so the ~350 existing
+// `#[handler]` bodies that hand-call `ctx.reply` keep compiling — that
+// impl is dropped when `single` is locked (a separate follow-on issue).
+impl OutboundReply for FfiCtx<'_, Manual> {
+    type ReplyHandle = ReplyHandle;
+
+    fn reply_target(&self) -> Option<ReplyHandle> {
+        self.sender.map(ReplyHandle::__from_raw)
+    }
+
+    fn source_mailbox(&self) -> Option<MailboxId> {
+        None
+    }
+
+    //noinspection DuplicatedCode
+    fn reply<K: Kind>(&mut self, payload: &K) {
+        if let Some(raw) = self.sender {
+            let bytes = payload.encode_into_bytes();
+            MAIL_BRIDGE.reply_mail(raw, K::ID.0, &bytes, 1);
+        }
+    }
+
+    fn reply_to<K: Kind>(&mut self, sender: ReplyHandle, payload: &K) {
+        let bytes = payload.encode_into_bytes();
+        MAIL_BRIDGE.reply_mail(sender.raw(), K::ID.0, &bytes, 1);
+    }
+}
+
+// TRANSITIONAL (ADR-0112): dropped when single is locked.
+impl OutboundReply for FfiCtx<'_, Single> {
     type ReplyHandle = ReplyHandle;
 
     fn reply_target(&self) -> Option<ReplyHandle> {
@@ -462,5 +535,37 @@ impl Persistence for FfiDropCtx<'_> {
             status, 0,
             "aether-actor: save_state failed (status {status})"
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FfiCtx, Manual, Single};
+    use crate::actor::ctx::OutboundReply;
+    use core::mem::{align_of, size_of};
+
+    /// ADR-0112: the mode marker is layout-neutral — the `Single` and
+    /// `Manual` views have identical size + alignment. This is the
+    /// invariant the `as_single` / `as_stream` pointer reborrows rest on.
+    #[test]
+    fn ffi_ctx_layout_identical_across_modes() {
+        assert_eq!(
+            size_of::<FfiCtx<'static, Single>>(),
+            size_of::<FfiCtx<'static, Manual>>(),
+        );
+        assert_eq!(
+            align_of::<FfiCtx<'static, Single>>(),
+            align_of::<FfiCtx<'static, Manual>>(),
+        );
+    }
+
+    /// ADR-0112 step 3: `OutboundReply` is reachable from both the
+    /// permanent `Manual` ctx and the transitional `Single` ctx (the
+    /// latter keeps the existing hand-`ctx.reply` handlers compiling).
+    #[test]
+    fn outbound_reply_present_on_single_and_manual() {
+        fn assert_impls<C: OutboundReply>() {}
+        assert_impls::<FfiCtx<'static, Single>>();
+        assert_impls::<FfiCtx<'static, Manual>>();
     }
 }

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -268,19 +268,31 @@ pub trait ErasedFfiActor {
     fn erased_namespace(&self) -> &'static str;
 
     /// Forwards to the `#[actor]`-synthesized `__aether_dispatch`.
-    fn erased_dispatch(&mut self, ctx: &mut FfiCtx<'_>, mail: crate::Mail<'_>) -> u32;
+    /// ADR-0112: the object-safe seam carries the most-permissive
+    /// [`Manual`](crate::Manual) view; the synthesized dispatcher
+    /// downgrades per handler class.
+    fn erased_dispatch(
+        &mut self,
+        ctx: &mut FfiCtx<'_, crate::Manual>,
+        mail: crate::Mail<'_>,
+    ) -> u32;
 
-    /// Forwards to [`FfiActor::wire`].
-    fn erased_wire(&mut self, ctx: &mut FfiCtx<'_>);
+    /// Forwards to [`FfiActor::wire`] (the synthesized impl downgrades
+    /// the carried [`Manual`](crate::Manual) ctx to `Single`).
+    fn erased_wire(&mut self, ctx: &mut FfiCtx<'_, crate::Manual>);
 
     /// Forwards to [`FfiActor::unwire`].
-    fn erased_unwire(&mut self, ctx: &mut FfiCtx<'_>);
+    fn erased_unwire(&mut self, ctx: &mut FfiCtx<'_, crate::Manual>);
 
     /// Forwards to [`FfiActor::on_dehydrate`].
     fn erased_on_dehydrate(&mut self, ctx: &mut FfiDropCtx<'_>);
 
     /// Forwards to [`FfiActor::on_rehydrate`].
-    fn erased_on_rehydrate(&mut self, ctx: &mut FfiCtx<'_>, prior: crate::PriorState<'_>);
+    fn erased_on_rehydrate(
+        &mut self,
+        ctx: &mut FfiCtx<'_, crate::Manual>,
+        prior: crate::PriorState<'_>,
+    );
 }
 
 /// Stage a guest init-failure message into the substrate via
@@ -709,8 +721,10 @@ macro_rules! __export_internal {
             let Some(instance) = (unsafe { __AETHER_COMPONENT.get_mut() }) else {
                 return 1;
             };
-            let mut ctx: $crate::FfiCtx<'_> = $crate::FfiCtx::__new(mailbox_id);
-            <$component as $crate::FfiActor>::wire(instance, &mut ctx);
+            // ADR-0112: the runtime builds the `Manual` view; `wire`'s
+            // default signature is `FfiCtx<'_>` (= Single), so downgrade.
+            let mut ctx = $crate::FfiCtx::__new(mailbox_id);
+            <$component as $crate::FfiActor>::wire(instance, ctx.as_single());
             0
         }
 
@@ -725,8 +739,8 @@ macro_rules! __export_internal {
             let Some(instance) = (unsafe { __AETHER_COMPONENT.get_mut() }) else {
                 return 1;
             };
-            let mut ctx: $crate::FfiCtx<'_> = $crate::FfiCtx::__new(mailbox_id);
-            <$component as $crate::FfiActor>::unwire(instance, &mut ctx);
+            let mut ctx = $crate::FfiCtx::__new(mailbox_id);
+            <$component as $crate::FfiActor>::unwire(instance, ctx.as_single());
             0
         }
 
@@ -753,7 +767,9 @@ macro_rules! __export_internal {
                 <$component as $crate::Actor>::NAMESPACE,
             )
             .0;
-            let mut ctx: $crate::FfiCtx<'_> = $crate::FfiCtx::__new(mailbox_id);
+            // ADR-0112: dispatch receives the full `Manual` ctx; the
+            // synthesized `__aether_dispatch` downgrades per handler class.
+            let mut ctx = $crate::FfiCtx::__new(mailbox_id);
             let mail = unsafe { $crate::Mail::__from_raw(kind, ptr, byte_len, count, sender) };
             instance.__aether_dispatch(&mut ctx, mail)
         }
@@ -830,9 +846,9 @@ macro_rules! __export_internal {
                 <$component as $crate::Actor>::NAMESPACE,
             )
             .0;
-            let mut ctx: $crate::FfiCtx<'_> = $crate::FfiCtx::__new(mailbox_id);
+            let mut ctx = $crate::FfiCtx::__new(mailbox_id);
             let prior = unsafe { $crate::PriorState::__from_raw(version, ptr, len) };
-            <$component as $crate::FfiActor>::on_rehydrate(instance, &mut ctx, prior);
+            <$component as $crate::FfiActor>::on_rehydrate(instance, ctx.as_single(), prior);
             0
         }
     };
@@ -904,9 +920,12 @@ macro_rules! __export_multi_internal {
                         $crate::__macro_internals::canonical::write_inputs_actor_boundary::<BOUNDARY_LEN>(
                             <$component as $crate::Actor>::NAMESPACE,
                         );
-                    // Per-record section version byte (0x03), in lockstep
-                    // with `INPUTS_SECTION_VERSION` (ADR-0109 / issue 1803).
-                    out[pos] = 0x03;
+                    // Per-record section version byte, in lockstep with
+                    // `INPUTS_SECTION_VERSION` (0x04, bumped by ADR-0112 /
+                    // issue 1850; the multi-actor boundary record is a
+                    // per-record frame and tracks the same version as the
+                    // single-actor records emitted by the derive macro).
+                    out[pos] = 0x04;
                     pos += 1;
                     let mut i = 0;
                     while i < BOUNDARY_LEN {
@@ -1014,7 +1033,9 @@ macro_rules! __export_multi_internal {
             let Some(instance) = (unsafe { __AETHER_MULTI.get_mut() }) else {
                 return 1;
             };
-            let mut ctx: $crate::FfiCtx<'_> = $crate::FfiCtx::__new(mailbox_id);
+            // ADR-0112: the boxed `ErasedFfiActor` seam carries the `Manual`
+            // view; the synthesized impl downgrades to `Single` per hook.
+            let mut ctx = $crate::FfiCtx::__new(mailbox_id);
             instance.erased_wire(&mut ctx);
             0
         }
@@ -1025,7 +1046,9 @@ macro_rules! __export_multi_internal {
             let Some(instance) = (unsafe { __AETHER_MULTI.get_mut() }) else {
                 return 1;
             };
-            let mut ctx: $crate::FfiCtx<'_> = $crate::FfiCtx::__new(mailbox_id);
+            // ADR-0112: the boxed `ErasedFfiActor` seam carries the `Manual`
+            // view; the synthesized impl downgrades to `Single` per hook.
+            let mut ctx = $crate::FfiCtx::__new(mailbox_id);
             instance.erased_unwire(&mut ctx);
             0
         }
@@ -1050,7 +1073,9 @@ macro_rules! __export_multi_internal {
                 instance.erased_namespace(),
             )
             .0;
-            let mut ctx: $crate::FfiCtx<'_> = $crate::FfiCtx::__new(mailbox_id);
+            // ADR-0112: the boxed `ErasedFfiActor` seam carries the `Manual`
+            // view; the synthesized impl downgrades to `Single` per hook.
+            let mut ctx = $crate::FfiCtx::__new(mailbox_id);
             let mail = unsafe { $crate::Mail::__from_raw(kind, ptr, byte_len, count, sender) };
             instance.erased_dispatch(&mut ctx, mail)
         }
@@ -1118,7 +1143,9 @@ macro_rules! __export_multi_internal {
                 instance.erased_namespace(),
             )
             .0;
-            let mut ctx: $crate::FfiCtx<'_> = $crate::FfiCtx::__new(mailbox_id);
+            // ADR-0112: the boxed `ErasedFfiActor` seam carries the `Manual`
+            // view; the synthesized impl downgrades to `Single` per hook.
+            let mut ctx = $crate::FfiCtx::__new(mailbox_id);
             let prior = unsafe { $crate::PriorState::__from_raw(version, ptr, len) };
             instance.erased_on_rehydrate(&mut ctx, prior);
             0

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -63,7 +63,10 @@ pub mod log;
 pub mod mail;
 pub mod trace_ring;
 
-pub use actor::ctx::{LifecycleControl, MailSender, OutboundReply, Persistence, Resolver};
+pub use actor::ctx::{
+    LifecycleControl, MailSender, Manual, OutboundReply, Persistence, ReplyMode, Resolver, Single,
+    Stream,
+};
 pub use actor::slot::Slot;
 pub use actor::{
     Actor, EmbeddedHost, HandlesKind, Instanced, NAMESPACE_SEGMENT_MAX_LEN, NamespaceError,

--- a/crates/aether-actor/tests/handlers_manifest.rs
+++ b/crates/aether-actor/tests/handlers_manifest.rs
@@ -21,9 +21,9 @@
 // `&mut self` to match the dispatch ABI but don't read state.
 #![allow(clippy::unused_self)]
 
-use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
+use aether_actor::{BootError, FfiActor, FfiCtx, Manual, Resolver, actor};
 use aether_data::Kind;
-use aether_data::{INPUTS_SECTION_VERSION, InputsRecord};
+use aether_data::{INPUTS_SECTION_VERSION, InputsRecord, ReplyContract};
 use bytemuck::{Pod, Zeroable};
 
 #[repr(C)]
@@ -42,6 +42,13 @@ struct Ping {
 #[derive(Copy, Clone, Pod, Zeroable, aether_data::Kind, aether_data::Schema)]
 #[kind(name = "test.pong")]
 struct Pong {
+    seq: u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable, aether_data::Kind, aether_data::Schema)]
+#[kind(name = "test.poke")]
+struct Poke {
     seq: u32,
 }
 
@@ -78,6 +85,12 @@ impl FfiActor for ManifestProbe {
         Pong { seq: ping.seq }
     }
 
+    // ADR-0112: a manual-class handler — it receives the `Manual` ctx and
+    // issues its own replies, so the manifest reports `ReplyContract::Manual`
+    // (no single static reply kind).
+    #[handler::manual]
+    fn on_poke(&mut self, _ctx: &mut FfiCtx<'_, Manual>, _poke: Poke) {}
+
     /// # Agent
     /// Catch-all for anything else.
     #[fallback]
@@ -106,7 +119,7 @@ fn parse_section(bytes: &[u8]) -> Vec<InputsRecord> {
 #[test]
 fn manifest_const_round_trips_to_expected_records() {
     const LEN: usize = ManifestProbe::__AETHER_INPUTS_MANIFEST_LEN;
-    const { assert!(LEN > 0, "ManifestProbe declares two handlers + fallback") };
+    const { assert!(LEN > 0, "ManifestProbe declares three handlers + fallback") };
     let bytes: &[u8] = &ManifestProbe::__AETHER_INPUTS_MANIFEST;
     assert_eq!(bytes.len(), LEN);
 
@@ -129,17 +142,29 @@ fn manifest_const_round_trips_to_expected_records() {
                     "test.tick" => {
                         assert_eq!(*id, <Tick as Kind>::ID);
                         tick_doc = doc.as_ref().map(ToString::to_string);
-                        // ADR-0109: a `-> ()` handler declares no reply.
-                        assert_eq!(*reply, None, "on_tick returns () — no reply kind");
+                        // ADR-0112: a single `-> ()` handler is `None`.
+                        assert_eq!(
+                            *reply,
+                            ReplyContract::None,
+                            "on_tick returns () — no reply kind"
+                        );
                     }
                     "test.ping" => {
                         assert_eq!(*id, <Ping as Kind>::ID);
-                        // ADR-0109: a `-> Pong` handler publishes Pong's
-                        // kind id as its reply contract.
+                        // ADR-0112: a single `-> Pong` handler is `One(Pong)`.
                         assert_eq!(
                             *reply,
-                            Some(<Pong as Kind>::ID),
+                            ReplyContract::One(<Pong as Kind>::ID),
                             "on_ping returns Pong — its reply kind rides the manifest"
+                        );
+                    }
+                    "test.poke" => {
+                        assert_eq!(*id, <Poke as Kind>::ID);
+                        // ADR-0112: a `#[handler::manual]` handler is `Manual`.
+                        assert_eq!(
+                            *reply,
+                            ReplyContract::Manual,
+                            "on_poke is manual-class — the manifest reports Manual"
                         );
                     }
                     other => panic!("unexpected handler name: {other}"),
@@ -159,7 +184,7 @@ fn manifest_const_round_trips_to_expected_records() {
         }
     }
 
-    assert_eq!(handler_count, 2, "expected two #[handler] records");
+    assert_eq!(handler_count, 3, "expected three #[handler] records");
     assert_eq!(fallback_count, 1, "expected one #[fallback] record");
     assert_eq!(
         tick_doc.as_deref(),

--- a/crates/aether-capabilities/src/test_chassis.rs
+++ b/crates/aether-capabilities/src/test_chassis.rs
@@ -145,7 +145,9 @@ pub fn drive_task_completion<A>(
             break payload;
         }
     };
-    let mut ctx = NativeCtx::new(
+    // ADR-0112: route through the macro dispatch seam, which carries the
+    // `Manual` ctx — build it via `new_dispatching`, not `new`.
+    let mut ctx = NativeCtx::new_dispatching(
         binding,
         Source::NONE,
         aether_data::MailId::NONE,

--- a/crates/aether-data/src/canonical/inputs.rs
+++ b/crates/aether-data/src/canonical/inputs.rs
@@ -9,25 +9,61 @@
 //! `postcard::take_from_bytes` symmetrically.
 
 use super::primitives::{
-    option_borrowed_str_len, option_varint_u64_len, str_len, varint_u64_len,
-    write_option_borrowed_str, write_option_varint_u64, write_str, write_varint_u64,
+    option_borrowed_str_len, str_len, varint_u64_len, write_option_borrowed_str, write_str,
+    write_varint_u64,
 };
+
+/// Byte length of a [`ReplyContract`](crate::ReplyContract)'s postcard
+/// encoding from its `(tag, id)` pair. The discriminant varint is one
+/// byte for these four variants; the `One` / `Stream` arms carry a
+/// trailing `varint(id)`, the `None` / `Manual` arms carry nothing.
+/// Variant order (`None` = 0, `One` = 1, `Stream` = 2, `Manual` = 3) is
+/// the discriminant, matching the enum's declared order.
+#[must_use]
+pub const fn reply_contract_len(reply_tag: u8, reply_id: u64) -> usize {
+    match reply_tag {
+        // One / Stream carry a trailing varint(id).
+        1 | 2 => 1 + varint_u64_len(reply_id),
+        // None / Manual (and any other) carry just the discriminant.
+        _ => 1,
+    }
+}
+
+/// Serialize a [`ReplyContract`](crate::ReplyContract) into `out` at
+/// `pos` from its `(tag, id)` pair, returning the new cursor. Exact
+/// `postcard(ReplyContract)` wire shape: `varint(tag)` then, for
+/// `One` / `Stream`, `varint(id)`.
+#[must_use]
+pub const fn write_reply_contract(
+    reply_tag: u8,
+    reply_id: u64,
+    out: &mut [u8],
+    mut pos: usize,
+) -> usize {
+    out[pos] = reply_tag;
+    pos += 1;
+    if reply_tag == 1 || reply_tag == 2 {
+        pos = write_varint_u64(reply_id, out, pos);
+    }
+    pos
+}
 
 /// Byte length of a `Handler` record's postcard encoding. One-byte
 /// enum-variant tag (`0x00`) + `varint(id)` + `postcard(name)` +
-/// `option_str(doc)` + `option_varint(reply)` — the ADR-0109 reply
-/// kind id (`None` for a `-> ()` handler).
+/// `option_str(doc)` + `reply_contract(reply_tag, reply_id)` — the
+/// ADR-0112 reply class.
 #[must_use]
 pub const fn inputs_handler_len(
     id: u64,
     name: &str,
     doc: Option<&str>,
-    reply: Option<u64>,
+    reply_tag: u8,
+    reply_id: u64,
 ) -> usize {
     1 + varint_u64_len(id)
         + str_len(name)
         + option_borrowed_str_len(doc)
-        + option_varint_u64_len(reply)
+        + reply_contract_len(reply_tag, reply_id)
 }
 
 /// Serialize an `InputsRecord::Handler` into a fixed-size array sized
@@ -38,7 +74,8 @@ pub const fn write_inputs_handler<const N: usize>(
     id: u64,
     name: &str,
     doc: Option<&str>,
-    reply: Option<u64>,
+    reply_tag: u8,
+    reply_id: u64,
 ) -> [u8; N] {
     let mut out = [0u8; N];
     let mut pos = 0usize;
@@ -47,7 +84,7 @@ pub const fn write_inputs_handler<const N: usize>(
     pos = write_varint_u64(id, &mut out, pos);
     pos = write_str(name, &mut out, pos);
     pos = write_option_borrowed_str(doc, &mut out, pos);
-    pos = write_option_varint_u64(reply, &mut out, pos);
+    pos = write_reply_contract(reply_tag, reply_id, &mut out, pos);
     // Silence "assigned but never read" warning on the final write.
     let _ = pos;
     out

--- a/crates/aether-data/src/canonical/mod.rs
+++ b/crates/aether-data/src/canonical/mod.rs
@@ -43,8 +43,8 @@ mod schema;
 
 pub use inputs::{
     inputs_actor_boundary_len, inputs_component_len, inputs_config_len, inputs_fallback_len,
-    inputs_handler_len, write_inputs_actor_boundary, write_inputs_component, write_inputs_config,
-    write_inputs_fallback, write_inputs_handler,
+    inputs_handler_len, reply_contract_len, write_inputs_actor_boundary, write_inputs_component,
+    write_inputs_config, write_inputs_fallback, write_inputs_handler, write_reply_contract,
 };
 pub use labels::{canonical_len_labels, canonical_serialize_labels};
 pub use primitives::{varint_u32_len, varint_u64_len, varint_usize_len};
@@ -404,13 +404,16 @@ mod tests {
 
     #[test]
     fn inputs_handler_const_round_trips() {
+        use crate::schema::ReplyContract;
         const ID: u64 = 0xdead_beef_cafe_f00d;
         const NAME: &str = "aether.tick";
         const DOC: Option<&str> = Some("Not useful to send manually.");
-        // ADR-0109: a synchronous `-> R` handler carries its reply kind id.
-        const REPLY: Option<u64> = Some(0x00c0_ffee_0bad_f00d);
-        const N: usize = inputs_handler_len(ID, NAME, DOC, REPLY);
-        const BYTES: [u8; N] = write_inputs_handler::<N>(ID, NAME, DOC, REPLY);
+        // ADR-0112: a single `-> R` handler carries `ReplyContract::One`
+        // — `(tag = 1, id)`.
+        const REPLY_TAG: u8 = 1;
+        const REPLY_ID: u64 = 0x00c0_ffee_0bad_f00d;
+        const N: usize = inputs_handler_len(ID, NAME, DOC, REPLY_TAG, REPLY_ID);
+        const BYTES: [u8; N] = write_inputs_handler::<N>(ID, NAME, DOC, REPLY_TAG, REPLY_ID);
         let decoded: InputsRecord = postcard::from_bytes(&BYTES).expect("decode");
         match decoded {
             InputsRecord::Handler {
@@ -422,7 +425,7 @@ mod tests {
                 assert_eq!(id, KindId(ID));
                 assert_eq!(name, NAME);
                 assert_eq!(doc.as_deref(), DOC);
-                assert_eq!(reply, Some(KindId(0x00c0_ffee_0bad_f00d)));
+                assert_eq!(reply, ReplyContract::One(KindId(REPLY_ID)));
             }
             other => panic!("wrong variant: {other:?}"),
         }
@@ -430,13 +433,16 @@ mod tests {
 
     #[test]
     fn inputs_handler_without_doc_const_round_trips() {
+        use crate::schema::ReplyContract;
         const ID: u64 = 1;
         const NAME: &str = "test.ping";
         const DOC: Option<&str> = None;
-        // ADR-0109: a `-> ()` fire-and-forget handler carries no reply id.
-        const REPLY: Option<u64> = None;
-        const N: usize = inputs_handler_len(ID, NAME, DOC, REPLY);
-        const BYTES: [u8; N] = write_inputs_handler::<N>(ID, NAME, DOC, REPLY);
+        // ADR-0112: a `-> ()` fire-and-forget handler is `ReplyContract::None`
+        // — `(tag = 0, id = 0)`.
+        const REPLY_TAG: u8 = 0;
+        const REPLY_ID: u64 = 0;
+        const N: usize = inputs_handler_len(ID, NAME, DOC, REPLY_TAG, REPLY_ID);
+        const BYTES: [u8; N] = write_inputs_handler::<N>(ID, NAME, DOC, REPLY_TAG, REPLY_ID);
         let decoded: InputsRecord = postcard::from_bytes(&BYTES).expect("decode");
         assert_eq!(
             decoded,
@@ -444,9 +450,34 @@ mod tests {
                 id: KindId(ID),
                 name: NAME.into(),
                 doc: None,
-                reply: None,
+                reply: ReplyContract::None,
             }
         );
+    }
+
+    #[test]
+    fn reply_contract_postcard_roundtrip() {
+        use crate::schema::ReplyContract;
+        // ADR-0112: the const-fn `(tag, id)` encoder matches
+        // `postcard(ReplyContract)` byte-for-byte, and the leading byte is
+        // the variant discriminant — `None` = 0, `One` = 1, `Stream` = 2,
+        // `Manual` = 3.
+        fn check(tag: u8, id: u64, expect: ReplyContract, expect_disc: u8) {
+            // Reuse a fixed-cap scratch buffer; `reply_contract_len` <= 11.
+            let len = reply_contract_len(tag, id);
+            let mut buf = [0u8; 16];
+            let written = write_reply_contract(tag, id, &mut buf, 0);
+            assert_eq!(written, len, "cursor advance matches reported length");
+            assert_eq!(buf[0], expect_disc, "leading byte is the discriminant");
+            let from_postcard = postcard::to_allocvec(&expect).expect("encode");
+            assert_eq!(&buf[..len], from_postcard.as_slice(), "matches postcard");
+            let decoded: ReplyContract = postcard::from_bytes(&buf[..len]).expect("decode");
+            assert_eq!(decoded, expect);
+        }
+        check(0, 0, ReplyContract::None, 0);
+        check(1, 0xabcd, ReplyContract::One(KindId(0xabcd)), 1);
+        check(2, 0x1234, ReplyContract::Stream(KindId(0x1234)), 2);
+        check(3, 0, ReplyContract::Manual, 3);
     }
 
     #[test]

--- a/crates/aether-data/src/canonical/primitives.rs
+++ b/crates/aether-data/src/canonical/primitives.rs
@@ -210,35 +210,6 @@ pub(super) const fn write_option_str(
     pos
 }
 
-/// `Option<u64>` length/write — used by the `InputsRecord::Handler`
-/// encoder for the ADR-0109 reply kind id (`None` for a `-> ()`
-/// handler, `Some(KindId.0)` otherwise). Postcard encodes an `Option`
-/// as a one-byte discriminant (`0` None / `1` Some) followed by the
-/// varint payload when present.
-pub(super) const fn option_varint_u64_len(val: Option<u64>) -> usize {
-    match val {
-        None => 1,
-        Some(v) => 1 + varint_u64_len(v),
-    }
-}
-
-pub(super) const fn write_option_varint_u64(
-    val: Option<u64>,
-    out: &mut [u8],
-    cursor: usize,
-) -> usize {
-    match val {
-        None => {
-            out[cursor] = 0;
-            cursor + 1
-        }
-        Some(v) => {
-            out[cursor] = 1;
-            write_varint_u64(v, out, cursor + 1)
-        }
-    }
-}
-
 /// `Option<&'static str>` length/write — used by the `InputsRecord`
 /// encoders where the macro captures doc strings as plain `&str`
 /// without a `Cow` wrapper.

--- a/crates/aether-data/src/schema.rs
+++ b/crates/aether-data/src/schema.rs
@@ -799,6 +799,91 @@ pub struct KindLabels {
     pub root: LabelNode,
 }
 
+/// A handler's reply class as reported by the manifest (ADR-0112). The
+/// successor to ADR-0109's `Option<KindId>` reply field: a single-class
+/// handler reports `None` (`-> ()`) or `One(R)` (`-> R` / `-> Pending<R>`);
+/// a manual-class handler reports `Manual` (it issues its own replies, so
+/// no single static reply kind); a stream-class handler reports
+/// `Stream(R)` (reserved — the class isn't built yet). `describe_*`
+/// surfaces this so a caller reads the real reply shape, not a `None`
+/// that lies for a handler that replies by hand.
+///
+/// **Variant order is the postcard discriminant** — `None` = 0,
+/// `One` = 1, `Stream` = 2, `Manual` = 3. The const-fn encoders in
+/// [`crate::canonical`] and the macro emission depend on it; do not
+/// reorder.
+///
+/// The `Schema` impl is hand-written (aether-data has no
+/// `extern crate self` alias and never self-derives `Schema`, which is
+/// behind the optional `derive` feature). The shape mirrors what the
+/// derive would emit for this enum so `describe_kinds` renders it the
+/// same as any derived enum.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReplyContract {
+    /// `-> ()` — a single-class handler that replies nothing.
+    None,
+    /// `-> R` / `-> Pending<R>` — a single-class handler whose reply kind
+    /// is `R`.
+    One(KindId),
+    /// Reserved (ADR-0112): a stream-class handler emitting `R` replies
+    /// over time. Not yet reachable — the macro rejects `#[handler::stream]`.
+    Stream(KindId),
+    /// A manual-class handler that issues its own replies — no single
+    /// static reply kind to report.
+    Manual,
+}
+
+impl crate::Schema for ReplyContract {
+    const SCHEMA: SchemaType = SchemaType::Enum {
+        variants: Cow::Borrowed(&[
+            EnumVariant::Unit {
+                name: Cow::Borrowed("None"),
+                discriminant: 0,
+            },
+            EnumVariant::Tuple {
+                name: Cow::Borrowed("One"),
+                discriminant: 1,
+                fields: Cow::Borrowed(&[SchemaType::TypeId(KindId::TYPE_ID)]),
+            },
+            EnumVariant::Tuple {
+                name: Cow::Borrowed("Stream"),
+                discriminant: 2,
+                fields: Cow::Borrowed(&[SchemaType::TypeId(KindId::TYPE_ID)]),
+            },
+            EnumVariant::Unit {
+                name: Cow::Borrowed("Manual"),
+                discriminant: 3,
+            },
+        ]),
+    };
+
+    const LABEL: Option<&'static str> = Some("ReplyContract");
+
+    // Parallel-shape label tree mirroring `SCHEMA`. The `One` / `Stream`
+    // fields carry `LabelNode::Anonymous` — identical to
+    // `<KindId as Schema>::LABEL_NODE`, since a typed-id field has no
+    // nominal sub-shape.
+    const LABEL_NODE: LabelNode = LabelNode::Enum {
+        type_label: Some(Cow::Borrowed("ReplyContract")),
+        variants: Cow::Borrowed(&[
+            VariantLabel::Unit {
+                name: Cow::Borrowed("None"),
+            },
+            VariantLabel::Tuple {
+                name: Cow::Borrowed("One"),
+                fields: Cow::Borrowed(&[LabelNode::Anonymous]),
+            },
+            VariantLabel::Tuple {
+                name: Cow::Borrowed("Stream"),
+                fields: Cow::Borrowed(&[LabelNode::Anonymous]),
+            },
+            VariantLabel::Unit {
+                name: Cow::Borrowed("Manual"),
+            },
+        ]),
+    };
+}
+
 /// One record in the `aether.kinds.inputs` section (ADR-0033). The
 /// enum tag discriminates handler vs fallback vs component-level doc
 /// so the reader can classify before decoding further. `id` on a
@@ -814,12 +899,13 @@ pub enum InputsRecord {
         id: KindId,
         name: Cow<'static, str>,
         doc: Option<Cow<'static, str>>,
-        /// ADR-0109: the handler's reply kind id, read off its return
-        /// type — `Some(<R as Kind>::ID)` for a `-> R` (synchronous) or
-        /// `-> Pending<R>` (deferred) handler, `None` for a `-> ()`
-        /// fire-and-forget handler. Lets a caller read `In -> Out` before
-        /// issuing the call.
-        reply: Option<KindId>,
+        /// ADR-0112: the handler's reply class — `None` / `One(R)` for a
+        /// single-class handler (the ADR-0109 return-type contract),
+        /// `Manual` for a manual-class handler that replies by hand,
+        /// `Stream(R)` reserved. Lets a caller read the real `In -> Out`
+        /// before issuing the call. Successor to ADR-0109's
+        /// `Option<KindId>` reply field.
+        reply: ReplyContract,
     },
     /// A `#[fallback]` method's presence and optional description.
     Fallback { doc: Option<Cow<'static, str>> },
@@ -854,7 +940,14 @@ pub const INPUTS_SECTION: &str = "aether.kinds.inputs";
 /// unknown versions abort the read rather than silently skip. v0x02
 /// (ADR-0090 / issue 1257) added the `InputsRecord::Config` variant;
 /// v0x03 (ADR-0109 / issue 1803) added the `reply` kind id to the
-/// `Handler` variant. A component built before either and a substrate
+/// `Handler` variant; v0x04 (ADR-0112 / issue 1850) widened that field
+/// from `Option<KindId>` to [`ReplyContract`] so a handler's reply
+/// *class* (single / manual / stream) is reported, not just a single
+/// reply kind. A component built before any of these and a substrate
 /// after would otherwise disagree on the record shape, so the reader
 /// rejects an older version byte loudly — a hard rebuild boundary.
-pub const INPUTS_SECTION_VERSION: u8 = 0x03;
+///
+/// Distinct from the `aether.kinds` section's own version (also `0x04`,
+/// `kind_manifest::KINDS_VERSION`): the two sections version
+/// independently and happen to share a number at this revision.
+pub const INPUTS_SECTION_VERSION: u8 = 0x04;

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1284,14 +1284,14 @@ mod control_plane {
         pub id: aether_data::KindId,
         pub name: String,
         pub doc: Option<String>,
-        /// ADR-0109: the handler's reply kind, read off its return type —
-        /// `Some` of the reply `KindId` for a `-> R` (synchronous) or
-        /// `-> Pending<R>` (deferred) handler, `None` for a `-> ()`
-        /// fire-and-forget handler. Lets `describe_component` report
-        /// `In -> Out` so a caller reads what a call returns before
-        /// issuing it. Native chassis caps leave this `None` until the
-        /// native handler manifest lands (ADR-0109 §5, a follow-on).
-        pub reply: Option<aether_data::KindId>,
+        /// ADR-0112: the handler's reply class — `None` / `One(R)` for a
+        /// single-class handler (the ADR-0109 return-type contract),
+        /// `Manual` for a manual-class handler that replies by hand,
+        /// `Stream(R)` reserved. Lets `describe_component` report the real
+        /// `In -> Out` so a caller reads what a call returns before issuing
+        /// it. Native chassis caps report `None` until the native handler
+        /// manifest lands (ADR-0109 §5, a follow-on).
+        pub reply: aether_data::ReplyContract,
     }
 
     /// A `#[fallback]` method's advertised presence + optional doc.

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -319,7 +319,13 @@ impl Mcp {
                         caps.handlers
                             .iter()
                             .find(|h| h.name == spec.kind_name)
-                            .and_then(|h| h.reply)
+                            // ADR-0112: only a single-class handler names one
+                            // static reply kind to search the cache for; a
+                            // manual / silent handler yields no declared kind.
+                            .and_then(|h| match h.reply {
+                                aether_data::ReplyContract::One(id) => Some(id),
+                                _ => None,
+                            })
                     })
                 });
                 match self.deliver_one(spec).await {
@@ -2487,7 +2493,7 @@ mod tests {
                 id: KindId(0x11),
                 name: "test.request".to_owned(),
                 doc: None,
-                reply: Some(KindId(0x22)),
+                reply: aether_data::ReplyContract::One(KindId(0x22)),
             }],
             ..ComponentCapabilities::default()
         };

--- a/crates/aether-substrate-bundle/src/perf/harness.rs
+++ b/crates/aether-substrate-bundle/src/perf/harness.rs
@@ -172,7 +172,7 @@ impl NativeActor for Relay {
 impl NativeDispatch for Relay {
     fn __aether_dispatch_envelope(
         &mut self,
-        ctx: &mut NativeCtx<'_>,
+        ctx: &mut NativeCtx<'_, aether_substrate::Manual>,
         kind: KindId,
         payload: &[u8],
     ) -> Option<()> {
@@ -264,7 +264,7 @@ impl NativeActor for TickSource {
 impl NativeDispatch for TickSource {
     fn __aether_dispatch_envelope(
         &mut self,
-        ctx: &mut NativeCtx<'_>,
+        ctx: &mut NativeCtx<'_, aether_substrate::Manual>,
         kind: KindId,
         _payload: &[u8],
     ) -> Option<()> {

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -1465,7 +1465,7 @@ mod tests {
             impl NativeDispatch for Child {
                 fn __aether_dispatch_envelope(
                     &mut self,
-                    _ctx: &mut NativeCtx<'_>,
+                    _ctx: &mut NativeCtx<'_, aether_substrate::Manual>,
                     kind: KindId,
                     payload: &[u8],
                 ) -> Option<()> {

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -65,7 +65,7 @@ impl NativeActor for RingRelay {
 impl NativeDispatch for RingRelay {
     fn __aether_dispatch_envelope(
         &mut self,
-        ctx: &mut NativeCtx<'_>,
+        ctx: &mut NativeCtx<'_, aether_substrate::Manual>,
         kind: KindId,
         payload: &[u8],
     ) -> Option<()> {
@@ -118,7 +118,7 @@ impl NativeActor for HoldRelay {
 impl NativeDispatch for HoldRelay {
     fn __aether_dispatch_envelope(
         &mut self,
-        ctx: &mut NativeCtx<'_>,
+        ctx: &mut NativeCtx<'_, aether_substrate::Manual>,
         kind: KindId,
         _payload: &[u8],
     ) -> Option<()> {

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -22,7 +22,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use aether_actor::actor::ctx::{LifecycleControl, MailSender, OutboundReply};
-use aether_actor::{Actor, HandlesKind, Singleton};
+use aether_actor::{Actor, HandlesKind, Manual, ReplyMode, Single, Singleton, Stream};
+use core::marker::PhantomData;
+use core::ptr;
 
 use crate::actor::native::mailbox::NativeActorMailbox;
 use aether_data::{Kind, KindId, MailId, MailboxId, mailbox_id_from_name};
@@ -54,7 +56,7 @@ use std::thread::{Builder as ThreadBuilder, JoinHandle};
 /// the stage-2 migration's responsibility (today's caps reply via
 /// `mailer.send_reply(...)` directly; stage 2 routes those onto
 /// `ctx.reply(...)`).
-pub struct NativeCtx<'a> {
+pub struct NativeCtx<'a, M: ReplyMode = Single> {
     binding: &'a Arc<NativeBinding>,
     source: Source,
     /// ADR-0080 §5: identity of the mail this handler is dispatching.
@@ -81,6 +83,10 @@ pub struct NativeCtx<'a> {
     /// ctxs that dispatch nothing (init / close-hook / chassis-root /
     /// cap-test fixtures built through [`Self::new`]).
     inbound: Option<Envelope>,
+    /// ADR-0112: phantom reply-mode marker (a ZST, layout-neutral) that
+    /// selects which reply surface this ctx exposes. Defaults to
+    /// [`Single`], so the common `NativeCtx<'_>` signature is unchanged.
+    _mode: PhantomData<M>,
 }
 
 /// The receiver-addressing methods shared verbatim by [`NativeCtx`] and
@@ -137,12 +143,18 @@ macro_rules! native_sender_methods {
     };
 }
 
-impl<'a> NativeCtx<'a> {
+impl<'a> NativeCtx<'a, Single> {
     /// Internal constructor — the chassis dispatcher trampoline (in
-    /// `chassis::builder`) builds these. Cap-side test fixtures in
-    /// `aether-capabilities` also reach for it directly so they can
-    /// drive a handler without spinning up a full chassis; that's why
-    /// it's `pub` rather than `pub(crate)`.
+    /// `chassis::builder`) builds these for `wire` / `unwire` / close
+    /// hooks. Cap-side test fixtures in `aether-capabilities` also reach
+    /// for it directly so they can drive a handler method without
+    /// spinning up a full chassis; that's why it's `pub` rather than
+    /// `pub(crate)`.
+    ///
+    /// ADR-0112: stays `<Single>` so those ~hundred fixtures that call
+    /// handler methods directly keep their single-mode ctx unchanged.
+    /// Build a `<Manual>` ctx for driving the macro dispatch trampoline
+    /// with [`Self::new_dispatching`].
     pub fn new(
         binding: &'a Arc<NativeBinding>,
         sender: Source,
@@ -155,7 +167,61 @@ impl<'a> NativeCtx<'a> {
             in_flight_mail_id,
             in_flight_root,
             inbound: None,
+            _mode: PhantomData,
         }
+    }
+}
+
+impl<'a> NativeCtx<'a, Manual> {
+    /// ADR-0112: an inbound-less `<Manual>` ctx for driving the
+    /// macro-emitted `NativeDispatch::__aether_dispatch_envelope` (which
+    /// carries the most-permissive view) from a cross-crate trampoline
+    /// test. The `<Single>` [`Self::new`] backs fixtures that call handler
+    /// methods directly; this one backs fixtures that route through the
+    /// dispatch seam.
+    pub fn new_dispatching(
+        binding: &'a Arc<NativeBinding>,
+        sender: Source,
+        in_flight_mail_id: MailId,
+        in_flight_root: MailId,
+    ) -> Self {
+        Self {
+            binding,
+            source: sender,
+            in_flight_mail_id,
+            in_flight_root,
+            inbound: None,
+            _mode: PhantomData,
+        }
+    }
+
+    /// ADR-0112 downgrade-only coercion: view this [`Manual`] ctx as a
+    /// [`Single`] ctx, dropping the `OutboundReply` surface. The
+    /// `#[actor]` macro hands a single-class handler this view, so a
+    /// handler whose marker disagrees with its class fails to unify.
+    /// There is deliberately no `as_manual` — the runtime only ever
+    /// downgrades.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn as_single(&mut self) -> &mut NativeCtx<'a, Single> {
+        // SAFETY: `M` is `PhantomData`-only, so `NativeCtx<'a, Manual>` and
+        // `NativeCtx<'a, Single>` are layout-identical (the marker field is
+        // a ZST for every `M` — see `native_ctx_layout_identical_across_modes`).
+        // The reborrow swaps the marker without touching any real field and
+        // only removes capability, never adds it.
+        unsafe { &mut *ptr::from_mut(self).cast::<NativeCtx<'a, Single>>() }
+    }
+
+    /// ADR-0112 forward-only coercion to the reserved [`Stream`] view.
+    /// `#[handler::stream]` is rejected by the macro today, so this has
+    /// no in-tree caller yet; it exists so the stream class has its
+    /// downgrade path the day the emit surface lands.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn as_stream(&mut self) -> &mut NativeCtx<'a, Stream> {
+        // SAFETY: same as `as_single` — `M` is `PhantomData`-only, so the
+        // marker swap is a layout-identity reborrow.
+        unsafe { &mut *ptr::from_mut(self).cast::<NativeCtx<'a, Stream>>() }
     }
 
     /// #1757: the per-dispatch constructor — moves the single dispatched
@@ -178,9 +244,12 @@ impl<'a> NativeCtx<'a> {
             in_flight_mail_id,
             in_flight_root,
             inbound: Some(inbound),
+            _mode: PhantomData,
         }
     }
+}
 
+impl<M: ReplyMode> NativeCtx<'_, M> {
     /// #1757 / ADR-0106: retain this handler's inbound mail as an
     /// [`InboundMail`] guard to defer its reply past the handler's return
     /// — the by-construction replacement for a hand-rolled
@@ -658,7 +727,7 @@ impl<'a> NativeCtx<'a> {
     }
 }
 
-impl NativeCtx<'_> {
+impl<M: ReplyMode> NativeCtx<'_, M> {
     /// ADR-0080 §5: derive the `parent_mail` to stamp on outbound
     /// mail from this ctx's in-flight context. `MailId::NONE` collapses
     /// to `None` (chassis-root or close/init ctx).
@@ -692,7 +761,7 @@ impl NativeCtx<'_> {
     }
 }
 
-impl NativeCtx<'_> {
+impl<M: ReplyMode> NativeCtx<'_, M> {
     /// Lineage-aware multicast: encode `payload` once, then push one copy
     /// to every `recipient`. The inbound `(mail_id, root)` from this ctx
     /// propagate as `parent_mail` + `inherited_root`, so each fanned-out
@@ -837,7 +906,7 @@ impl NativeCtx<'_> {
     }
 }
 
-impl Drop for NativeCtx<'_> {
+impl<M: ReplyMode> Drop for NativeCtx<'_, M> {
     /// ADR-0087 / 2b (iamacoffeepot/aether#1105): handler-end flush. One
     /// `NativeCtx` is built per dispatched envelope (and one for
     /// `unwire`), so its scope *is* the handler's lifetime — dropping it
@@ -964,7 +1033,7 @@ impl<'a> NativeInitCtx<'a> {
 // FFI-side wiring (issue 607 phase 4 / ADR-0079) will program against
 // the trait the same way native callers do.
 
-impl MailSender for NativeCtx<'_> {
+impl<M: ReplyMode> MailSender for NativeCtx<'_, M> {
     //noinspection DuplicatedCode
     fn send<R, K>(&mut self, payload: &K)
     where
@@ -1058,7 +1127,12 @@ impl MailSender for NativeCtx<'_> {
     }
 }
 
-impl OutboundReply for NativeCtx<'_> {
+// ADR-0112: the reply surface is per-mode. `Manual` carries it
+// permanently (a manual-class handler issues its own replies); `Single`
+// carries the identical body **transitionally** so the existing native
+// handler / fallback bodies that hand-call `ctx.reply` keep compiling —
+// that impl is dropped when `single` is locked (a separate follow-on).
+impl OutboundReply for NativeCtx<'_, Manual> {
     type ReplyHandle = Source;
 
     /// Always `Some` on native — the substrate's per-handler dispatcher
@@ -1101,7 +1175,41 @@ impl OutboundReply for NativeCtx<'_> {
     }
 }
 
-impl LifecycleControl for NativeCtx<'_> {
+// TRANSITIONAL (ADR-0112): dropped when single is locked.
+impl OutboundReply for NativeCtx<'_, Single> {
+    type ReplyHandle = Source;
+
+    fn reply_target(&self) -> Option<Source> {
+        Some(self.source)
+    }
+
+    fn source_mailbox(&self) -> Option<MailboxId> {
+        match self.source.addr {
+            SourceAddr::Component(id) => Some(id),
+            _ => None,
+        }
+    }
+
+    fn reply<K: Kind>(&mut self, payload: &K) {
+        self.binding.send_reply_for_handler(
+            self.source,
+            payload,
+            self.in_flight_root,
+            self.outbound_parent(),
+        );
+    }
+
+    fn reply_to<K: Kind>(&mut self, sender: Source, payload: &K) {
+        self.binding.send_reply_for_handler(
+            sender,
+            payload,
+            self.in_flight_root,
+            self.outbound_parent(),
+        );
+    }
+}
+
+impl<M: ReplyMode> LifecycleControl for NativeCtx<'_, M> {
     type MonitorHandle = MonitorHandle;
     type MonitorError = MonitorError;
 
@@ -1236,6 +1344,32 @@ mod tests {
     fn handles_get_returns_none_for_unpublished_type() {
         let handles = ExportedHandles::new();
         assert!(handles.get::<StubHandles>().is_none());
+    }
+
+    /// ADR-0112: the mode marker is layout-neutral — the `Single` and
+    /// `Manual` views have identical size + alignment. This is the
+    /// invariant the `as_single` / `as_stream` pointer reborrows rest on.
+    #[test]
+    fn native_ctx_layout_identical_across_modes() {
+        use std::mem::{align_of, size_of};
+        assert_eq!(
+            size_of::<NativeCtx<'static, Single>>(),
+            size_of::<NativeCtx<'static, Manual>>(),
+        );
+        assert_eq!(
+            align_of::<NativeCtx<'static, Single>>(),
+            align_of::<NativeCtx<'static, Manual>>(),
+        );
+    }
+
+    /// ADR-0112 step 3: `OutboundReply` is reachable from both the
+    /// permanent `Manual` ctx and the transitional `Single` ctx (the
+    /// latter keeps the existing hand-`ctx.reply` native bodies compiling).
+    #[test]
+    fn outbound_reply_present_on_single_and_manual() {
+        fn assert_impls<C: OutboundReply>() {}
+        assert_impls::<NativeCtx<'static, Single>>();
+        assert_impls::<NativeCtx<'static, Manual>>();
     }
 
     /// Compile-time signal that `NativeActor` is `Send + 'static` (no

--- a/crates/aether-substrate/src/actor/native/dispatch.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch.rs
@@ -52,7 +52,7 @@ use crate::mail::{KindId, MailboxId};
 /// call borrows `&mut ctx`), so no borrow conflict.
 pub fn typed_then_fallback_or_warn<A>(
     actor: &mut Box<A>,
-    ctx: &mut NativeCtx<'_>,
+    ctx: &mut NativeCtx<'_, crate::Manual>,
     kind: KindId,
     payload: &[u8],
 ) where
@@ -99,7 +99,7 @@ pub fn typed_then_fallback_or_warn<A>(
 /// #1774: takes `(kind, payload)` instead of `&Envelope` — the
 /// only fields this arm reads.
 pub fn dispatch_log_tail_if_matching(
-    ctx: &mut NativeCtx<'_>,
+    ctx: &mut NativeCtx<'_, crate::Manual>,
     kind: KindId,
     payload: &[u8],
 ) -> bool {
@@ -131,7 +131,7 @@ pub fn dispatch_log_tail_if_matching(
 /// #1774: takes `(kind, payload)` instead of `&Envelope` — the
 /// only fields this arm reads.
 pub fn dispatch_trace_tail_if_matching(
-    ctx: &mut NativeCtx<'_>,
+    ctx: &mut NativeCtx<'_, crate::Manual>,
     kind: KindId,
     payload: &[u8],
 ) -> bool {
@@ -167,7 +167,7 @@ pub fn dispatch_trace_tail_if_matching(
 /// only fields this arm reads.
 pub fn dispatch_cost_tail_if_matching(
     binding: &NativeBinding,
-    ctx: &mut NativeCtx<'_>,
+    ctx: &mut NativeCtx<'_, crate::Manual>,
     kind: KindId,
     payload: &[u8],
 ) -> bool {

--- a/crates/aether-substrate/src/actor/native/mod.rs
+++ b/crates/aether-substrate/src/actor/native/mod.rs
@@ -181,9 +181,13 @@ pub trait NativeActor: Actor {
 /// caller wants a typed `dispatch_kind::<K>` entry, but Phase A
 /// doesn't need it.
 pub trait NativeDispatch: Send + 'static {
+    // ADR-0112: the dispatch seam carries the most-permissive `Manual`
+    // ctx so a `#[handler::manual]` arm reaches the reply surface; the
+    // macro downgrades to `Single` per single-class handler. Every impl
+    // (macro-emitted and hand-written test fixtures) spells `Manual` here.
     fn __aether_dispatch_envelope(
         &mut self,
-        ctx: &mut NativeCtx<'_>,
+        ctx: &mut NativeCtx<'_, crate::Manual>,
         kind: KindId,
         payload: &[u8],
     ) -> Option<()>;
@@ -197,7 +201,7 @@ pub trait NativeDispatch: Send + 'static {
     /// log.
     fn __aether_dispatch_fallback(
         &mut self,
-        _ctx: &mut NativeCtx<'_>,
+        _ctx: &mut NativeCtx<'_, crate::Manual>,
         _envelope: &Envelope,
     ) -> bool {
         false

--- a/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
+++ b/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
@@ -86,6 +86,12 @@ pub const NAMESPACE_SECTION: &str = "aether.namespace";
 /// `Kind::ID` is stable; only the framing shrunk by one byte. v0x02 /
 /// v0x03 are no longer accepted — a loud rebuild-required boundary,
 /// same as the v0x02→v0x03 bump on `aether.kinds.labels`.
+///
+/// Note: this is the `aether.kinds` section version, distinct from the
+/// `aether.kinds.inputs` section version (`INPUTS_SECTION_VERSION`, also
+/// `0x04` since ADR-0112 / issue 1850). The two sections version
+/// independently and happen to coincide at this revision — a shared
+/// number, not a shared format.
 const KINDS_VERSION: u8 = 0x04;
 
 /// Wire versions accepted in `aether.kinds.labels`. v0x03 added
@@ -1009,14 +1015,14 @@ mod tests {
                 id: aether_data::KindId(42),
                 name: "aether.tick".into(),
                 doc: Some("substrate drives this".into()),
-                // ADR-0109: a `-> R` handler's reply kind reads back.
-                reply: Some(aether_data::KindId(0xbeef)),
+                // ADR-0112: a `-> R` handler's reply class reads back.
+                reply: aether_data::ReplyContract::One(aether_data::KindId(0xbeef)),
             },
             InputsRecord::Handler {
                 id: aether_data::KindId(0xff),
                 name: "aether.ping".into(),
                 doc: None,
-                reply: None,
+                reply: aether_data::ReplyContract::None,
             },
         ]);
         let wasm = wasm_with_section(INPUTS_SECTION, &section);
@@ -1029,12 +1035,64 @@ mod tests {
             caps.handlers[0].doc.as_deref(),
             Some("substrate drives this")
         );
-        assert_eq!(caps.handlers[0].reply, Some(aether_data::KindId(0xbeef)));
+        assert_eq!(
+            caps.handlers[0].reply,
+            aether_data::ReplyContract::One(aether_data::KindId(0xbeef))
+        );
         assert_eq!(caps.handlers[1].id, aether_data::KindId(0xff));
         assert_eq!(caps.handlers[1].name, "aether.ping");
         assert!(caps.handlers[1].doc.is_none());
-        assert!(caps.handlers[1].reply.is_none());
+        assert_eq!(caps.handlers[1].reply, aether_data::ReplyContract::None);
         assert!(caps.fallback.is_none());
+    }
+
+    #[test]
+    fn reads_handler_reply_contract_variants() {
+        // ADR-0112: each `ReplyContract` variant round-trips through the
+        // `aether.kinds.inputs` v0x04 reader onto `HandlerCapability.reply`.
+        let section = inputs_section(&[
+            InputsRecord::Handler {
+                id: aether_data::KindId(1),
+                name: "silent".into(),
+                doc: None,
+                reply: aether_data::ReplyContract::None,
+            },
+            InputsRecord::Handler {
+                id: aether_data::KindId(2),
+                name: "single".into(),
+                doc: None,
+                reply: aether_data::ReplyContract::One(aether_data::KindId(0xabcd)),
+            },
+            InputsRecord::Handler {
+                id: aether_data::KindId(3),
+                name: "manual".into(),
+                doc: None,
+                reply: aether_data::ReplyContract::Manual,
+            },
+        ]);
+        let wasm = wasm_with_section(INPUTS_SECTION, &section);
+        let caps = read_inputs_from_bytes(&wasm).unwrap();
+        assert_eq!(caps.handlers.len(), 3);
+        assert_eq!(caps.handlers[0].reply, aether_data::ReplyContract::None);
+        assert_eq!(
+            caps.handlers[1].reply,
+            aether_data::ReplyContract::One(aether_data::KindId(0xabcd))
+        );
+        assert_eq!(caps.handlers[2].reply, aether_data::ReplyContract::Manual);
+    }
+
+    #[test]
+    fn rejects_v0x03_inputs_loudly() {
+        // ADR-0112: a pre-widening `aether.kinds.inputs` record (v0x03,
+        // `reply: Option<KindId>`) is rejected loudly rather than decoded
+        // against the v0x04 `ReplyContract` shape — mirrors
+        // `labels_v0x02_rejected_loudly`. A `0x03` version byte followed
+        // by arbitrary bytes must fail the version check before any decode.
+        let old_inputs_payload = [0x03u8, 0x00];
+        let wasm = wasm_with_section(INPUTS_SECTION, &old_inputs_payload);
+        let err = read_actor_inputs_from_bytes(&wasm).unwrap_err();
+        assert!(err.contains("0x3"), "err was: {err}");
+        assert!(err.contains(INPUTS_SECTION), "err was: {err}");
     }
 
     #[test]
@@ -1046,7 +1104,7 @@ mod tests {
                 id: aether_data::KindId(7),
                 name: "aether.config_query".into(),
                 doc: None,
-                reply: None,
+                reply: aether_data::ReplyContract::None,
             },
             InputsRecord::Config {
                 id: aether_data::KindId(0x00c0_ffee),
@@ -1084,7 +1142,7 @@ mod tests {
             id: aether_data::KindId(7),
             name: "aether.tick".into(),
             doc: None,
-            reply: None,
+            reply: aether_data::ReplyContract::None,
         }]);
         let wasm = wasm_with_section(INPUTS_SECTION, &section);
         let caps = read_inputs_from_bytes(&wasm).unwrap();
@@ -1122,7 +1180,7 @@ mod tests {
                 id: aether_data::KindId(1),
                 name: "ui.click".into(),
                 doc: None,
-                reply: None,
+                reply: aether_data::ReplyContract::None,
             },
             InputsRecord::ActorBoundary {
                 namespace: "ui.panel".into(),
@@ -1131,7 +1189,7 @@ mod tests {
                 id: aether_data::KindId(2),
                 name: "ui.draw".into(),
                 doc: None,
-                reply: None,
+                reply: aether_data::ReplyContract::None,
             },
             InputsRecord::Fallback {
                 doc: Some("catchall".into()),
@@ -1164,7 +1222,7 @@ mod tests {
             id: aether_data::KindId(7),
             name: "aether.tick".into(),
             doc: None,
-            reply: None,
+            reply: aether_data::ReplyContract::None,
         }]);
         let wasm = wasm_with_section(INPUTS_SECTION, &section);
         let actors = read_actor_inputs_from_bytes(&wasm).unwrap();

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -1615,7 +1615,7 @@ mod tests {
     impl NativeDispatch for StubLog {
         fn __aether_dispatch_envelope(
             &mut self,
-            _ctx: &mut NativeCtx<'_>,
+            _ctx: &mut NativeCtx<'_, crate::Manual>,
             _kind: KindId,
             _payload: &[u8],
         ) -> Option<()> {
@@ -1734,7 +1734,7 @@ mod tests {
         impl NativeDispatch for FailingCap {
             fn __aether_dispatch_envelope(
                 &mut self,
-                _ctx: &mut NativeCtx<'_>,
+                _ctx: &mut NativeCtx<'_, crate::Manual>,
                 _kind: KindId,
                 _payload: &[u8],
             ) -> Option<()> {
@@ -1833,7 +1833,7 @@ mod tests {
             impl NativeDispatch for ProbeCap {
                 fn __aether_dispatch_envelope(
                     &mut self,
-                    _ctx: &mut NativeCtx<'_>,
+                    _ctx: &mut NativeCtx<'_, crate::Manual>,
                     kind: KindId,
                     payload: &[u8],
                 ) -> Option<()> {
@@ -1964,7 +1964,7 @@ mod tests {
             impl NativeDispatch for LocalProbe {
                 fn __aether_dispatch_envelope(
                     &mut self,
-                    _ctx: &mut NativeCtx<'_>,
+                    _ctx: &mut NativeCtx<'_, crate::Manual>,
                     kind: KindId,
                     payload: &[u8],
                 ) -> Option<()> {
@@ -2095,7 +2095,7 @@ mod tests {
             impl NativeDispatch for ChildCap {
                 fn __aether_dispatch_envelope(
                     &mut self,
-                    _ctx: &mut NativeCtx<'_>,
+                    _ctx: &mut NativeCtx<'_, crate::Manual>,
                     kind: KindId,
                     payload: &[u8],
                 ) -> Option<()> {
@@ -2132,7 +2132,7 @@ mod tests {
             impl NativeDispatch for ParentCap {
                 fn __aether_dispatch_envelope(
                     &mut self,
-                    ctx: &mut NativeCtx<'_>,
+                    ctx: &mut NativeCtx<'_, crate::Manual>,
                     kind: KindId,
                     payload: &[u8],
                 ) -> Option<()> {
@@ -2271,7 +2271,7 @@ mod tests {
             impl NativeDispatch for Closer {
                 fn __aether_dispatch_envelope(
                     &mut self,
-                    ctx: &mut NativeCtx<'_>,
+                    ctx: &mut NativeCtx<'_, crate::Manual>,
                     kind: KindId,
                     payload: &[u8],
                 ) -> Option<()> {
@@ -2392,7 +2392,7 @@ mod tests {
             impl NativeDispatch for Quiet {
                 fn __aether_dispatch_envelope(
                     &mut self,
-                    _ctx: &mut NativeCtx<'_>,
+                    _ctx: &mut NativeCtx<'_, crate::Manual>,
                     _kind: KindId,
                     _payload: &[u8],
                 ) -> Option<()> {
@@ -2466,7 +2466,7 @@ mod tests {
             impl NativeDispatch for Quiet {
                 fn __aether_dispatch_envelope(
                     &mut self,
-                    _ctx: &mut NativeCtx<'_>,
+                    _ctx: &mut NativeCtx<'_, crate::Manual>,
                     _kind: KindId,
                     _payload: &[u8],
                 ) -> Option<()> {
@@ -2530,7 +2530,7 @@ mod tests {
             impl NativeDispatch for Foo {
                 fn __aether_dispatch_envelope(
                     &mut self,
-                    _ctx: &mut NativeCtx<'_>,
+                    _ctx: &mut NativeCtx<'_, crate::Manual>,
                     _kind: KindId,
                     _payload: &[u8],
                 ) -> Option<()> {
@@ -2552,7 +2552,7 @@ mod tests {
             impl NativeDispatch for Bar {
                 fn __aether_dispatch_envelope(
                     &mut self,
-                    _ctx: &mut NativeCtx<'_>,
+                    _ctx: &mut NativeCtx<'_, crate::Manual>,
                     _kind: KindId,
                     _payload: &[u8],
                 ) -> Option<()> {
@@ -2658,7 +2658,7 @@ mod tests {
             impl NativeDispatch for Target {
                 fn __aether_dispatch_envelope(
                     &mut self,
-                    ctx: &mut NativeCtx<'_>,
+                    ctx: &mut NativeCtx<'_, crate::Manual>,
                     kind: KindId,
                     payload: &[u8],
                 ) -> Option<()> {
@@ -2701,7 +2701,7 @@ mod tests {
             impl NativeDispatch for Watcher {
                 fn __aether_dispatch_envelope(
                     &mut self,
-                    ctx: &mut NativeCtx<'_>,
+                    ctx: &mut NativeCtx<'_, crate::Manual>,
                     kind: KindId,
                     payload: &[u8],
                 ) -> Option<()> {
@@ -2908,7 +2908,7 @@ mod tests {
             impl NativeDispatch for Target {
                 fn __aether_dispatch_envelope(
                     &mut self,
-                    _ctx: &mut NativeCtx<'_>,
+                    _ctx: &mut NativeCtx<'_, crate::Manual>,
                     _kind: KindId,
                     _payload: &[u8],
                 ) -> Option<()> {
@@ -2944,7 +2944,7 @@ mod tests {
             impl NativeDispatch for Watcher {
                 fn __aether_dispatch_envelope(
                     &mut self,
-                    ctx: &mut NativeCtx<'_>,
+                    ctx: &mut NativeCtx<'_, crate::Manual>,
                     kind: KindId,
                     payload: &[u8],
                 ) -> Option<()> {
@@ -3106,7 +3106,7 @@ mod tests {
             impl NativeDispatch for Member {
                 fn __aether_dispatch_envelope(
                     &mut self,
-                    ctx: &mut NativeCtx<'_>,
+                    ctx: &mut NativeCtx<'_, crate::Manual>,
                     kind: KindId,
                     payload: &[u8],
                 ) -> Option<()> {
@@ -3315,7 +3315,7 @@ mod tests {
             impl NativeDispatch for Grandchild {
                 fn __aether_dispatch_envelope(
                     &mut self,
-                    _ctx: &mut NativeCtx<'_>,
+                    _ctx: &mut NativeCtx<'_, crate::Manual>,
                     kind: KindId,
                     payload: &[u8],
                 ) -> Option<()> {
@@ -3351,7 +3351,7 @@ mod tests {
             impl NativeDispatch for Parent {
                 fn __aether_dispatch_envelope(
                     &mut self,
-                    ctx: &mut NativeCtx<'_>,
+                    ctx: &mut NativeCtx<'_, crate::Manual>,
                     kind: KindId,
                     payload: &[u8],
                 ) -> Option<()> {
@@ -3537,7 +3537,7 @@ mod tests {
             impl NativeDispatch for WireSpawnProbe {
                 fn __aether_dispatch_envelope(
                     &mut self,
-                    _ctx: &mut NativeCtx<'_>,
+                    _ctx: &mut NativeCtx<'_, crate::Manual>,
                     _kind: KindId,
                     _payload: &[u8],
                 ) -> Option<()> {
@@ -3593,7 +3593,7 @@ mod tests {
         impl NativeDispatch for WireProbe {
             fn __aether_dispatch_envelope(
                 &mut self,
-                _ctx: &mut NativeCtx<'_>,
+                _ctx: &mut NativeCtx<'_, crate::Manual>,
                 _kind: KindId,
                 _payload: &[u8],
             ) -> Option<()> {
@@ -3664,7 +3664,7 @@ mod tests {
         impl NativeDispatch for Pinger {
             fn __aether_dispatch_envelope(
                 &mut self,
-                _ctx: &mut NativeCtx<'_>,
+                _ctx: &mut NativeCtx<'_, crate::Manual>,
                 _kind: KindId,
                 _payload: &[u8],
             ) -> Option<()> {
@@ -3689,7 +3689,7 @@ mod tests {
         impl NativeDispatch for Ponger {
             fn __aether_dispatch_envelope(
                 &mut self,
-                _ctx: &mut NativeCtx<'_>,
+                _ctx: &mut NativeCtx<'_, crate::Manual>,
                 kind: KindId,
                 payload: &[u8],
             ) -> Option<()> {

--- a/crates/aether-substrate/src/chassis/inbox.rs
+++ b/crates/aether-substrate/src/chassis/inbox.rs
@@ -678,7 +678,10 @@ mod tests {
 
         let mut cap = ReplyProbe;
         {
-            let mut ctx = NativeCtx::new(&binding, caller_reply_to, MailId::NONE, MailId::NONE);
+            // ADR-0112: drive the macro dispatch seam, which carries the
+            // `Manual` ctx — build it via `new_dispatching`, not `new`.
+            let mut ctx =
+                NativeCtx::new_dispatching(&binding, caller_reply_to, MailId::NONE, MailId::NONE);
             let handled = cap.__aether_dispatch_envelope(
                 &mut ctx,
                 ReplyRequest::ID,

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -61,6 +61,9 @@ mod test_util;
 pub use actor::monitor::MonitorHandle;
 pub use actor::native::binding::NativeBinding;
 pub use actor::native::ctx::{ExportedHandles, NativeCtx, NativeInitCtx};
+// ADR-0112: the per-handler ctx reply-mode markers, re-exported next to
+// `NativeCtx` so chassis / harness code naming `NativeCtx<'_, Manual>`
+// reaches them without an `aether_actor` import.
 pub use actor::native::envelope::Envelope;
 pub use actor::native::spawn::{SpawnBuilder, SpawnError, Spawner, Subname};
 pub use actor::native::{NativeActor, NativeDispatch};
@@ -68,6 +71,7 @@ pub use actor::registry::{ActorEntry, ActorRegistry, MonitorEntry, MonitorError}
 #[cfg(feature = "wasm")]
 pub use actor::wasm::component::{Component, ComponentCtx};
 pub use aether_actor::Actor;
+pub use aether_actor::{Manual, ReplyMode, Single, Stream};
 pub use aether_derive::Config;
 #[cfg(feature = "wasm")]
 pub use boot::{SubstrateBoot, SubstrateBootBuilder};

--- a/crates/aether-substrate/src/mail/capability.rs
+++ b/crates/aether-substrate/src/mail/capability.rs
@@ -150,7 +150,7 @@ mod tests {
                     id: KindId(id),
                     name: format!("test.kind.{id}"),
                     doc: None,
-                    reply: None,
+                    reply: aether_data::ReplyContract::None,
                 })
                 .collect(),
             fallback: fallback.then_some(FallbackCapability { doc: None }),

--- a/crates/aether-substrate/tests/dag_validator.rs
+++ b/crates/aether-substrate/tests/dag_validator.rs
@@ -98,7 +98,7 @@ fn register_caps_with_fallback(
                 id,
                 name: format!("test.kind.{}", id.0),
                 doc: None,
-                reply: None,
+                reply: aether_data::ReplyContract::None,
             })
             .collect(),
         fallback: fallback.then_some(aether_kinds::FallbackCapability { doc: None }),

--- a/crates/aether-substrate/tests/native_actor_macro.rs
+++ b/crates/aether-substrate/tests/native_actor_macro.rs
@@ -24,6 +24,7 @@ use std::sync::atomic::{AtomicU32, AtomicU64, Ordering as AtomicOrdering};
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
+use aether_actor::OutboundReply;
 use aether_data::{Kind, Source, SourceAddr};
 use aether_kinds::trace::Nanos;
 use aether_substrate::actor::native::{Pending, TaskDone};
@@ -31,8 +32,9 @@ use aether_substrate::handle_store::HandleStore;
 use aether_substrate::mail::registry::{InboxHandler, OwnedDispatch};
 use aether_substrate::mail::{MailId, MailRef};
 use aether_substrate::{
-    Actor, BootError, Builder, BuiltChassis, Chassis, Mailer, NativeActor, NativeCtx,
-    NativeInitCtx, NeverDriver, PassiveChassis, Registry, mail::MailboxId,
+    Actor, BootError, Builder, BuiltChassis, Chassis, Mailer, Manual, NativeActor, NativeBinding,
+    NativeCtx, NativeDispatch, NativeInitCtx, NeverDriver, PassiveChassis, Registry,
+    mail::MailboxId,
 };
 use std::thread;
 
@@ -974,4 +976,116 @@ impl NativeActor for DeferredReplyCap {
             .store(done.output().value, AtomicOrdering::SeqCst);
         self.obs.silent_calls.fetch_add(1, AtomicOrdering::SeqCst);
     }
+}
+
+/// ADR-0112 manual reply class: input kind for the manual handler.
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.macro_native_actor.manual_ping")]
+struct ManualPing {
+    seq: u32,
+}
+
+/// ADR-0112 manual reply class: the kind the manual handler replies with.
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.macro_native_actor.manual_ack")]
+struct ManualAck {
+    seq: u32,
+}
+
+/// ADR-0112: a manual-class cap — it receives the `Manual` ctx and issues
+/// its own reply by hand via `OutboundReply::reply`, rather than via a
+/// `-> R` return value.
+struct ManualReplyCap;
+
+#[aether_data::actor]
+impl NativeActor for ManualReplyCap {
+    const NAMESPACE: &'static str = "test.macro_native_actor.manual_reply";
+    type Config = ();
+
+    fn init(_config: (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        Ok(Self)
+    }
+
+    #[aether_data::handler::manual]
+    #[allow(clippy::unused_self)]
+    fn on_ping(&mut self, ctx: &mut NativeCtx<'_, Manual>, ping: ManualPing) {
+        ctx.reply(&ManualAck { seq: ping.seq });
+    }
+}
+
+/// ADR-0112: a `#[handler::manual]` handler receives the `Manual` ctx and
+/// replies through `ctx.reply` — drive it through the macro dispatch seam
+/// (`new_dispatching` + `__aether_dispatch_envelope`) and assert the ack
+/// lands at the caller carrying the declared correlation.
+#[test]
+fn manual_handler_replies_through_ctx() {
+    let (registry, mailer) = fresh_substrate();
+
+    let (reply_tx, reply_rx) = mpsc::channel::<OwnedDispatch>();
+    let caller = registry.register_inbox(
+        "test.macro_native_actor.manual_caller",
+        forward_to(reply_tx),
+    );
+
+    let binding = Arc::new(NativeBinding::new_for_test(
+        Arc::clone(&mailer),
+        MailboxId(0x1850_0001),
+    ));
+    let caller_reply_to = Source::with_correlation(SourceAddr::Component(caller), 91);
+
+    let mut cap = ManualReplyCap;
+    {
+        // ADR-0112: the dispatch seam carries the `Manual` ctx — build it
+        // via `new_dispatching`.
+        let mut ctx =
+            NativeCtx::new_dispatching(&binding, caller_reply_to, MailId::NONE, MailId::NONE);
+        let handled = cap.__aether_dispatch_envelope(
+            &mut ctx,
+            ManualPing::ID,
+            &ManualPing { seq: 9 }.encode_into_bytes(),
+        );
+        assert_eq!(handled, Some(()), "the manual handler ran for its kind");
+        // Drop the ctx (flushing buffered outbound) before reading the reply.
+    }
+
+    let reply = reply_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("the manual handler replied to the inbound sender via ctx.reply");
+    assert_eq!(
+        reply.kind,
+        ManualAck::ID,
+        "the reply carries the manual handler's ack kind",
+    );
+    assert_eq!(
+        reply.sender.correlation_id, 91,
+        "the caller's correlation is echoed onto the manual reply",
+    );
+    let ack = ManualAck::decode_from_bytes(reply.payload.bytes()).expect("the reply decodes");
+    assert_eq!(
+        ack,
+        ManualAck { seq: 9 },
+        "the manual reply carries the ping seq"
+    );
 }


### PR DESCRIPTION
Closes #1850.

## Summary

Implements the ADR-0112 reply-class mechanism: a handler's reply surface becomes a compiler-enforced property of its declared class rather than an ambient capability on one shared ctx.

- One ctx type per target carries a phantom `ReplyMode` marker — `FfiCtx<'a, M = Single>` / `NativeCtx<'a, M = Single>`. The shared inherent surface (`ctx.actor::<Cap>()`, resolve, logging) lives on `impl<M: ReplyMode>`; `OutboundReply` (reply/reply_to) is implemented only for `Manual`, plus a **transitional `Single` impl** so the ~350 existing `#[handler]` bodies compile unchanged.
- The runtime holds the full `Manual` ctx and only ever **downgrades** (`as_single`/`as_stream`, layout-identity reborrows over the ZST marker; there is deliberately no `as_manual`). A size+align layout-equality test guards the reborrow soundness.
- The `#[actor]` macro reads `#[handler::single|manual|stream]` (with `#[handler]` aliasing `single`), classifies each handler, and emits the class-driven ctx view. `#[handler::stream]` parses but the macro rejects it as reserved.
- The manifest `InputsRecord::Handler.reply` / `HandlerCapability.reply` widen from `Option<KindId>` to `ReplyContract { None | One(KindId) | Stream(KindId) | Manual }`; the `aether.kinds.inputs` custom-section version bumps `0x03 → 0x04`.

Mechanism only — the per-crate migration of existing reply sites onto the taxonomy and the final lock that drops the transitional `Single` impl are separate follow-ons. Since `HandlerCapability` rides inside `LoadResult` / `ReplaceResult` / `Hello`, this is a coordinated substrate+hub wire change (both build from this tree).

## Reviewer notes

- **Plan undercounted the version-byte sites — fixed.** The plan enumerated four `out[pos] = 0x03` literals in `aether-actor-derive`; there was a **fifth** in the multi-actor `export!` boundary record at `aether-actor/src/ffi/mod.rs` (ADR-0096). Single-actor fixtures emitted `0x04` but multi-actor ones (`multi_actor`, `stateful_replace`) still emitted `0x03` and were rejected by the substrate. Caught in validation; the boundary record now tracks `INPUTS_SECTION_VERSION`.
- **`ReplyContract` has a hand-written `Schema` impl** (not `#[derive(Schema)]`): `aether-data` has no `extern crate self` alias and never self-derives `Schema`. The manual impl mirrors the derive's enum shape (variant order is the postcard discriminant: None=0, One=1, Stream=2, Manual=3).
- **`NativeDispatch` signature moved to `Manual`**, so ~29 hand-written `impl NativeDispatch` test/harness fixtures took a mechanical `NativeCtx<'_>` → `NativeCtx<'_, Manual>` update (broader than the plan's "~4 trampoline sites", which were the `NativeCtx::new` → `new_dispatching` call sites). No `#[handler]` body changed — the non-breaking constraint holds.
- **`name_inventory::HandlerEntry.reply` deliberately stays `Option<KindId>`** — the parallel ADR-0109 §5 native-handler-manifest surface, not "fixed" to `ReplyContract`.
- **Two sections now share version `0x04`** (`aether.kinds` `KINDS_VERSION` and `aether.kinds.inputs` `INPUTS_SECTION_VERSION`) — they version independently; clarifying comments added at both (the issue's §Side finding).
- The one qodana finding ("Duplicated code fragment", below `failThreshold`) is the intentional transitional `Single`==`Manual` `OutboundReply` body, removed when `single` is locked.

## Test plan

- `reply_mode_types_are_zsts`; `{ffi,native}_ctx_layout_identical_across_modes` (the invariant `as_single` rests on); `outbound_reply_present_on_single_and_manual`.
- Macro trybuild (`aether-actor-derive/tests/ui.rs`): accepts a manual handler; compile-fail for reserved `#[handler::stream]` and for a class↔ctx marker mismatch; native integration `manual_handler_replies_through_ctx`.
- `reply_contract_postcard_roundtrip` (each variant's discriminant byte); `kind_manifest::{reads_handler_reply_contract_variants, rejects_v0x03_inputs_loudly}`; `handlers_manifest` asserts `-> R` → One, `-> ()` → None, `#[handler::manual]` → Manual.
- Multi-actor scenario tests (`multi_actor_*`, `replace_preserves_multi_actor_state_via_dehydrate_rehydrate`) load real `0x04` fixtures and pass — the regression guard for the boundary-record fix.
- Full `scripts/preflight.sh --qodana` green (fmt, clippy, doc, nextest workspace incl. heavy, wasm32, qodana under threshold).

## Generated by

`/implement` — agent execution of scoped issue #1850, with the multi-actor version-byte fix applied during validation.
