### PR TITLE
feat(capabilities): minimum-cost reachability solver over a discretized space-time scalar field

### DIFF
--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -102,6 +102,12 @@ pub mod trampoline;
 // runs transforms, so gate the whole module rather than carry it dead.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod transforms;
+// Pure minimum-cost reachability solver core (ADR-0047/0048/0049, issue
+// 1857). Gated to non-wasm like `transforms`: its only callers are the
+// native `#[transform]`s above (and the follow-on field passes that reuse
+// `solve_cost_to_reach`), so on a wasm-header-only build it would be dead.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) mod reachability;
 pub mod window;
 
 #[cfg(feature = "audio")]

--- a/crates/aether-capabilities/src/reachability.rs
+++ b/crates/aether-capabilities/src/reachability.rs
@@ -1,0 +1,216 @@
+//! Minimum-cost reachability over a time-varying scalar field (issue
+//! 1857). The pure dynamic-programming core the `solve` /
+//! `reachability_margin` transforms (ADR-0048) wrap, kept in its own
+//! module so the follow-on field passes (corridor extraction, windowed
+//! re-solve, agent populations, counterfactual queries) call
+//! [`solve_cost_to_reach`] directly without going through the transform
+//! encode/decode boundary.
+//!
+//! The graph is a time-layered DAG — ticks only advance — so the
+//! cost-to-reach field `V` is a single forward sweep:
+//! `V(c, t) = C(c, t) + min over stencil-predecessors c' of V(c', t-1)`,
+//! seeded at `t = 0` from the start slice. Accumulated cost is the
+//! objective the sweep minimizes, so it never enters the node coordinate
+//! — nodes stay `(cell, tick)`, with no accumulator dimension. The pass
+//! is dense and iterative (no recursion, per the load-bearing-code rule),
+//! deterministic, and integer-exact, so a given field replays
+//! identically.
+
+use aether_kinds::StencilOffset;
+
+/// The reserved sentinel shared by cost fields and the solved
+/// cost-to-reach field. In a cost field it marks a blocked / impassable
+/// cell; in `V` it marks a cell no stencil-feasible path reaches. Costs
+/// are non-negative, so a `u32` field with this sentinel folds "blocked"
+/// in with no second mask, and saturating arithmetic keeps the `min`
+/// recurrence well-defined (a blocked cell or a missing predecessor
+/// absorbs to the sentinel).
+pub const UNREACHABLE: u32 = u32::MAX;
+
+/// Shift `coord` by `-delta` (the reachable-from direction) and keep it
+/// in `0..bound`. Returns `None` when the predecessor falls off the grid.
+/// Stays in `usize` arithmetic (no `i64` round-trip) so the bound check
+/// is a single `checked_add` / `checked_sub` per axis.
+fn predecessor_coord(coord: usize, delta: i32, bound: usize) -> Option<usize> {
+    let magnitude = delta.unsigned_abs() as usize;
+    let pred = if delta >= 0 {
+        coord.checked_sub(magnitude)?
+    } else {
+        coord.checked_add(magnitude)?
+    };
+    (pred < bound).then_some(pred)
+}
+
+/// Solve the cost-to-reach field `V` over a `width × height` grid across
+/// `ticks` integer time layers (issue 1857).
+///
+/// `costs` is the row-major `(tick, y, x)` cost field — the scalar at
+/// cell `(x, y)` on tick `t` is `costs[t * height * width + y * width + x]`
+/// — with [`UNREACHABLE`] marking a blocked cell. `stencil` is the
+/// one-tick movement offset set (include the zero offset for the "stay
+/// put" move); cell `c` on tick `t` draws from `c - offset` on tick
+/// `t - 1` for each offset, so a non-symmetric stencil is read in the
+/// reachable-from direction. `start` is the cost-valued seed slice of
+/// length `width * height` — the per-cell initial accumulated cost at
+/// `t = 0`, with [`UNREACHABLE`] marking a non-start cell. The cost
+/// field's `t = 0` layer is never charged; the seed *is* the accumulated
+/// value at `t = 0`, which is what lets a windowed re-solve carry its
+/// frontier without double-counting the boundary tick.
+///
+/// Returns the row-major `V` field of the same shape (`width * height *
+/// ticks` values). Malformed lengths never panic: a too-short `costs` or
+/// `start` reads as [`UNREACHABLE`] past its end, and a `width × height ×
+/// ticks` product that overflows `usize` yields an empty field.
+pub fn solve_cost_to_reach(
+    width: usize,
+    height: usize,
+    ticks: usize,
+    costs: &[u32],
+    stencil: &[StencilOffset],
+    start: &[u32],
+) -> Vec<u32> {
+    let plane = width.saturating_mul(height);
+    let Some(total) = plane.checked_mul(ticks) else {
+        return Vec::new();
+    };
+    let mut v = vec![UNREACHABLE; total];
+    if total == 0 {
+        return v;
+    }
+
+    // Seed t = 0 from the cost-valued start slice (UNREACHABLE = not
+    // seeded). A short slice leaves the tail at the sentinel default.
+    let seed_len = plane.min(start.len());
+    v[..seed_len].copy_from_slice(&start[..seed_len]);
+
+    // Forward sweep. Each layer reads only the immediately preceding one,
+    // so a split borrow gives a shared previous layer and a mutable
+    // current layer with no overlap.
+    for t in 1..ticks {
+        let (head, tail) = v.split_at_mut(t * plane);
+        let prev = &head[(t - 1) * plane..];
+        let curr = &mut tail[..plane];
+        let cost_base = t * plane;
+        for y in 0..height {
+            for x in 0..width {
+                let idx = y * width + x;
+                let mut best = UNREACHABLE;
+                for offset in stencil {
+                    let Some(px) = predecessor_coord(x, offset.dx, width) else {
+                        continue;
+                    };
+                    let Some(py) = predecessor_coord(y, offset.dy, height) else {
+                        continue;
+                    };
+                    best = best.min(prev[py * width + px]);
+                }
+                let cost = costs.get(cost_base + idx).copied().unwrap_or(UNREACHABLE);
+                curr[idx] = cost.saturating_add(best);
+            }
+        }
+    }
+
+    v
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{UNREACHABLE, solve_cost_to_reach};
+    use aether_kinds::StencilOffset;
+
+    /// Stay + the four orthogonal one-cell moves.
+    fn stencil_4way() -> Vec<StencilOffset> {
+        vec![
+            StencilOffset { dx: 0, dy: 0 },
+            StencilOffset { dx: 1, dy: 0 },
+            StencilOffset { dx: -1, dy: 0 },
+            StencilOffset { dx: 0, dy: 1 },
+            StencilOffset { dx: 0, dy: -1 },
+        ]
+    }
+
+    #[test]
+    fn single_start_cell_seeds_t0_others_unreachable() {
+        // One tick: only the seeded cell carries a value, and the tick-0
+        // cost layer is never charged (the seed is the value).
+        let costs = vec![5, 5, 5];
+        let start = vec![0, UNREACHABLE, UNREACHABLE];
+        let v = solve_cost_to_reach(3, 1, 1, &costs, &stencil_4way(), &start);
+        assert_eq!(v, vec![0, UNREACHABLE, UNREACHABLE]);
+    }
+
+    #[test]
+    fn accumulated_cost_spreads_with_uniform_field() {
+        // 3×1 grid, uniform cost 1, start at cell 0. Hand-checked layers:
+        //   t0: [0,   MAX, MAX]
+        //   t1: [1,   1,   MAX]  (cell 2 has no reachable predecessor yet)
+        //   t2: [2,   2,   2]
+        let plane = 3;
+        let ticks = 3;
+        let costs = vec![1u32; plane * ticks];
+        let start = vec![0, UNREACHABLE, UNREACHABLE];
+        let v = solve_cost_to_reach(3, 1, ticks, &costs, &stencil_4way(), &start);
+        assert_eq!(&v[0..3], &[0, UNREACHABLE, UNREACHABLE]);
+        assert_eq!(&v[3..6], &[1, 1, UNREACHABLE]);
+        assert_eq!(&v[6..9], &[2, 2, 2]);
+    }
+
+    #[test]
+    fn nonzero_seed_offsets_the_whole_field() {
+        // Seeding cell 0 at accumulated cost 10 shifts every reachable
+        // value up by 10 — the seed is the initial accumulated cost.
+        let plane = 3;
+        let ticks = 3;
+        let costs = vec![1u32; plane * ticks];
+        let start = vec![10, UNREACHABLE, UNREACHABLE];
+        let v = solve_cost_to_reach(3, 1, ticks, &costs, &stencil_4way(), &start);
+        assert_eq!(&v[0..3], &[10, UNREACHABLE, UNREACHABLE]);
+        assert_eq!(&v[3..6], &[11, 11, UNREACHABLE]);
+        assert_eq!(&v[6..9], &[12, 12, 12]);
+    }
+
+    #[test]
+    fn blocked_cell_blocks_propagation_through_it() {
+        // Cell 1 blocked (cost MAX) every tick. It never carries a finite
+        // value, and cell 2 — only reachable through cell 1 — stays
+        // unreachable, while cell 0 keeps accumulating via the stay move.
+        let plane = 3;
+        let ticks = 3;
+        let mut costs = vec![1u32; plane * ticks];
+        for t in 0..ticks {
+            costs[t * plane + 1] = UNREACHABLE;
+        }
+        let start = vec![0, UNREACHABLE, UNREACHABLE];
+        let v = solve_cost_to_reach(3, 1, ticks, &costs, &stencil_4way(), &start);
+        for t in 0..ticks {
+            assert_eq!(v[t * plane + 1], UNREACHABLE, "blocked cell stays MAX");
+            assert_eq!(
+                v[t * plane + 2],
+                UNREACHABLE,
+                "cell behind the block is unreachable"
+            );
+        }
+        assert_eq!(v[0], 0);
+        assert_eq!(v[plane], 1);
+        assert_eq!(v[2 * plane], 2);
+    }
+
+    #[test]
+    fn unreachable_without_a_path_stays_max() {
+        // Stay-only stencil on a 2×2 grid: a non-start cell can never be
+        // reached, so it holds the sentinel for the whole horizon.
+        let stay = vec![StencilOffset { dx: 0, dy: 0 }];
+        let plane = 4;
+        let ticks = 5;
+        let costs = vec![1u32; plane * ticks];
+        let start = vec![0, UNREACHABLE, UNREACHABLE, UNREACHABLE];
+        let v = solve_cost_to_reach(2, 2, ticks, &costs, &stay, &start);
+        for t in 0..ticks {
+            let expected = u32::try_from(t).expect("tick index fits u32");
+            assert_eq!(v[t * plane], expected, "stay cell accumulates each tick");
+            for cell in 1..plane {
+                assert_eq!(v[t * plane + cell], UNREACHABLE, "no path -> stays MAX");
+            }
+        }
+    }
+}

--- a/crates/aether-capabilities/src/transforms.rs
+++ b/crates/aether-capabilities/src/transforms.rs
@@ -8,8 +8,10 @@
 //! like the DAG executor's `double` / `seed` fixtures.
 
 use aether_data::transform;
-use aether_kinds::Mat4Apply;
+use aether_kinds::{BudgetQuery, Mat4Apply, ReachabilityMargin, ReachabilityProblem, ScalarField};
 use aether_math::Vec4;
+
+use crate::reachability::{UNREACHABLE, solve_cost_to_reach};
 
 /// Apply a 4×4 matrix to a 4-vector, `M · v` (ADR-0048's first
 /// first-party transform). `Mat4Apply` bundles both operands so the
@@ -26,6 +28,78 @@ use aether_math::Vec4;
 #[transform]
 fn mat4_apply(input: Mat4Apply) -> Vec4 {
     input.matrix * input.vector
+}
+
+/// Solve minimum-cost reachability over a time-varying scalar cost field
+/// (ADR-0047/0048/0049, issue 1857). `ReachabilityProblem` bundles the
+/// cost field, the movement stencil, and the start seed so the transform
+/// stays a unary `Kind → Kind` node, the same shape `Mat4Apply` gives
+/// `mat4_apply`. The output is the cost-to-reach field `V` — a
+/// `ScalarField` of the same shape — so it is the single currency every
+/// follow-on field pass consumes.
+///
+/// The body delegates to the pure [`solve_cost_to_reach`] core (the
+/// reusable internal API the corridor-graph / windowed-replan / agent-
+/// population passes call directly); the transform fn itself only
+/// unbundles the operands and rewraps the result, so it clears the
+/// `#[transform]` purity deny-list.
+#[transform]
+fn solve(problem: ReachabilityProblem) -> ScalarField {
+    let ScalarField {
+        width,
+        height,
+        ticks,
+        values: costs,
+    } = problem.cost;
+    let values = solve_cost_to_reach(
+        width as usize,
+        height as usize,
+        ticks as usize,
+        &costs,
+        &problem.stencil.offsets,
+        &problem.start,
+    );
+    ScalarField {
+        width,
+        height,
+        ticks,
+        values,
+    }
+}
+
+/// Threshold a solved cost-to-reach field against a budget (issue 1857).
+/// Reads the minimum cost-to-reach over the field's final tick: the
+/// cheapest cell reachable under the full horizon. `reachable` is that
+/// minimum `< budget`; `margin` is `budget - minimum` as a signed value
+/// (positive slack under budget, negative when even the cheapest reachable
+/// cell exceeds it, or when no cell is reachable). Kept off `ScalarField`
+/// itself so every downstream consumer is free of a readout it does not
+/// use — a separate cached query transform composes better.
+#[transform]
+fn reachability_margin(field: ScalarField, query: BudgetQuery) -> ReachabilityMargin {
+    let ScalarField {
+        width,
+        height,
+        ticks,
+        values,
+    } = field;
+    let plane = (width as usize).saturating_mul(height as usize);
+    let min_cost = if ticks == 0 || plane == 0 {
+        UNREACHABLE
+    } else {
+        let final_base = (ticks as usize - 1).saturating_mul(plane);
+        values
+            .get(final_base..final_base.saturating_add(plane))
+            .and_then(|layer| layer.iter().copied().min())
+            .unwrap_or(UNREACHABLE)
+    };
+    let reachable = min_cost < query.budget;
+    let margin = i64::from(query.budget) - i64::from(min_cost);
+    ReachabilityMargin {
+        reachable,
+        min_cost,
+        margin,
+    }
 }
 
 #[cfg(test)]
@@ -89,5 +163,198 @@ mod tests {
         let names: Vec<String> = descriptors::all().into_iter().map(|d| d.name).collect();
         assert!(names.iter().any(|n| n == Mat4Apply::NAME));
         assert!(names.iter().any(|n| n == Vec4::NAME));
+    }
+}
+
+#[cfg(test)]
+mod reachability_transform_tests {
+    use super::{reachability_margin, solve};
+    use aether_data::{Kind, transforms};
+    use aether_kinds::{
+        BudgetQuery, MovementStencil, ReachabilityMargin, ReachabilityProblem, ScalarField,
+        StencilOffset,
+    };
+
+    const UNREACHABLE: u32 = u32::MAX;
+
+    fn stencil_4way() -> MovementStencil {
+        MovementStencil {
+            offsets: vec![
+                StencilOffset { dx: 0, dy: 0 },
+                StencilOffset { dx: 1, dy: 0 },
+                StencilOffset { dx: -1, dy: 0 },
+                StencilOffset { dx: 0, dy: 1 },
+                StencilOffset { dx: 0, dy: -1 },
+            ],
+        }
+    }
+
+    /// 3×1 uniform-cost field, start at cell 0 — the same hand-checked
+    /// field the solver-core tests pin, here driven through the transform.
+    fn small_problem() -> ReachabilityProblem {
+        ReachabilityProblem {
+            cost: ScalarField {
+                width: 3,
+                height: 1,
+                ticks: 3,
+                values: vec![1u32; 9],
+            },
+            stencil: stencil_4way(),
+            start: vec![0, UNREACHABLE, UNREACHABLE],
+        }
+    }
+
+    #[test]
+    fn solve_transform_produces_the_cost_to_reach_field() {
+        let v = solve(small_problem());
+        assert_eq!(v.width, 3);
+        assert_eq!(v.height, 1);
+        assert_eq!(v.ticks, 3);
+        assert_eq!(
+            v.values,
+            vec![0, UNREACHABLE, UNREACHABLE, 1, 1, UNREACHABLE, 2, 2, 2]
+        );
+    }
+
+    #[test]
+    fn solve_registered_in_link_time_inventory() {
+        // Same contract as `mat4_apply`: registered, one `ReachabilityProblem`
+        // input slot, `ScalarField` output.
+        let entry = transforms()
+            .find(|t| t.name.ends_with("::solve"))
+            .expect("solve not registered in link-time inventory");
+        assert_eq!(entry.input_kind_ids, [ReachabilityProblem::ID]);
+        assert_eq!(entry.output_kind_id, ScalarField::ID);
+    }
+
+    #[test]
+    fn reachability_margin_registered_in_link_time_inventory() {
+        // A two-input transform: `(ScalarField, BudgetQuery)` in slot order,
+        // `ReachabilityMargin` out.
+        let entry = transforms()
+            .find(|t| t.name.ends_with("::reachability_margin"))
+            .expect("reachability_margin not registered in link-time inventory");
+        assert_eq!(entry.input_kind_ids, [ScalarField::ID, BudgetQuery::ID]);
+        assert_eq!(entry.output_kind_id, ReachabilityMargin::ID);
+    }
+
+    #[test]
+    fn reachability_kinds_resolve_distinctly() {
+        let ids = [
+            ReachabilityProblem::ID,
+            ScalarField::ID,
+            BudgetQuery::ID,
+            ReachabilityMargin::ID,
+            MovementStencil::ID,
+        ];
+        for (i, a) in ids.iter().enumerate() {
+            for b in &ids[i + 1..] {
+                assert_ne!(a, b);
+            }
+        }
+    }
+
+    #[test]
+    fn margin_threshold_is_reachable_under_budget() {
+        // Final-tick minimum is 2 (every cell reaches cost 2 at t = 2).
+        let field = solve(small_problem());
+        let under = reachability_margin(field.clone(), BudgetQuery { budget: 5 });
+        assert_eq!(
+            under,
+            ReachabilityMargin {
+                reachable: true,
+                min_cost: 2,
+                margin: 3,
+            }
+        );
+        let exact = reachability_margin(field.clone(), BudgetQuery { budget: 2 });
+        // `< budget` is strict: a budget equal to the minimum is not under.
+        assert_eq!(
+            exact,
+            ReachabilityMargin {
+                reachable: false,
+                min_cost: 2,
+                margin: 0,
+            }
+        );
+        let over = reachability_margin(field, BudgetQuery { budget: 1 });
+        assert_eq!(
+            over,
+            ReachabilityMargin {
+                reachable: false,
+                min_cost: 2,
+                margin: -1,
+            }
+        );
+    }
+
+    #[test]
+    fn margin_on_all_unreachable_final_tick_is_not_reachable() {
+        // A stay-only stencil leaves every non-start cell unreachable; with
+        // no start cell at all, the whole final tick is the sentinel.
+        let field = solve(ReachabilityProblem {
+            cost: ScalarField {
+                width: 2,
+                height: 1,
+                ticks: 2,
+                values: vec![1u32; 4],
+            },
+            stencil: MovementStencil {
+                offsets: vec![StencilOffset { dx: 0, dy: 0 }],
+            },
+            start: vec![UNREACHABLE, UNREACHABLE],
+        });
+        let margin = reachability_margin(field, BudgetQuery { budget: 100 });
+        assert!(!margin.reachable);
+        assert_eq!(margin.min_cost, UNREACHABLE);
+    }
+
+    #[test]
+    fn solve_is_deterministic_and_content_addressable() {
+        // Same input -> identical output, and the content-addressing path
+        // (the encoded output bytes the executor keys on) replays
+        // byte-for-byte.
+        let a = solve(small_problem());
+        let b = solve(small_problem());
+        assert_eq!(a, b);
+        assert_eq!(a.encode_into_bytes(), b.encode_into_bytes());
+    }
+
+    #[test]
+    fn canonical_field_encodes_under_output_cap_and_round_trips() {
+        // The canonical 64×64 grid over 1800 ticks (~7.4M cells): the
+        // solved `ScalarField` must fit the 64MB transform output cap
+        // (ADR-0048 §6) and round-trip byte-stable through the kind codec.
+        const CAP: usize = 64 * 1024 * 1024;
+        let width = 64u32;
+        let height = 64u32;
+        let ticks = 1800u32;
+        let plane = (width * height) as usize;
+        let problem = ReachabilityProblem {
+            cost: ScalarField {
+                width,
+                height,
+                ticks,
+                values: vec![1u32; plane * ticks as usize],
+            },
+            stencil: stencil_4way(),
+            start: {
+                let mut s = vec![UNREACHABLE; plane];
+                s[0] = 0;
+                s
+            },
+        };
+        let field = solve(problem);
+        assert_eq!(field.values.len(), plane * ticks as usize);
+
+        let bytes = field.encode_into_bytes();
+        assert!(
+            bytes.len() < CAP,
+            "encoded canonical field is {} bytes, over the {CAP}-byte cap",
+            bytes.len()
+        );
+
+        let back = ScalarField::decode_from_bytes(&bytes).expect("canonical field round-trips");
+        assert_eq!(field, back);
     }
 }

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -3717,6 +3717,132 @@ mod control_plane {
             error: GeminiError,
         },
     }
+
+    // ADR-0047/0048/0049 space-time reachability vocabulary (issue
+    // 1857). The shared kind contract a minimum-cost reachability solver
+    // over a time-varying scalar cost field reads and writes; the solver
+    // itself is a pair of native `#[transform]`s in `aether-capabilities`.
+    // A family of follow-on field passes (corridor extraction, windowed
+    // re-solve, agent populations) all consume `ScalarField`, so the
+    // representation lands here once. Postcard-shaped, `Vec`-bearing like
+    // `CreateTexture`.
+
+    /// A dense scalar field over a 2D grid and an integer tick axis — the
+    /// shared currency of the reachability solver (issue 1857). `values`
+    /// is row-major over `(tick, y, x)`: the scalar at cell `(x, y)` on
+    /// tick `t` is `values[t * height * width + y * width + x]`, so a
+    /// well-formed field has `values.len() == width * height * ticks`.
+    /// `u32::MAX` is the reserved sentinel — in a cost field it marks a
+    /// blocked / impassable cell, and in the solved cost-to-reach field it
+    /// marks a cell no stencil-feasible path reaches. Costs are
+    /// non-negative, so a `u32` field with the reserved sentinel folds
+    /// "blocked" in with no second mask and keeps the recurrence's `min`
+    /// well-defined. This is both the cost-field input (inside
+    /// [`ReachabilityProblem`]) and the solved cost-to-reach output of the
+    /// `solve` transform.
+    #[derive(
+        aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq,
+    )]
+    #[kind(name = "aether.reach.scalar_field")]
+    pub struct ScalarField {
+        pub width: u32,
+        pub height: u32,
+        pub ticks: u32,
+        pub values: Vec<u32>,
+    }
+
+    /// One signed cell offset in a [`MovementStencil`] — a single-tick
+    /// step `(dx, dy)` measured in grid cells. The zero offset `(0, 0)` is
+    /// the "stay put" move. Not a kind on its own — only addressable
+    /// inside `MovementStencil.offsets`.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct StencilOffset {
+        pub dx: i32,
+        pub dy: i32,
+    }
+
+    /// The one-tick movement stencil — the set of cells reachable from any
+    /// cell in a single tick (issue 1857). A standalone kind so the
+    /// corridor-graph and windowed-replan passes share one stencil
+    /// representation. Each [`StencilOffset`] is a step applied to a
+    /// cell's position; include the zero `(0, 0)` offset for the "stay
+    /// put" move. The solver reads it as the predecessor set: cell `c` on
+    /// tick `t` is reachable from `c - offset` on tick `t - 1` for each
+    /// offset, so a non-symmetric stencil is interpreted in the forward
+    /// (reachable-from) direction.
+    #[derive(
+        aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq,
+    )]
+    #[kind(name = "aether.reach.movement_stencil")]
+    pub struct MovementStencil {
+        pub offsets: Vec<StencilOffset>,
+    }
+
+    /// The bundled input to the `solve` transform (issue 1857): a cost
+    /// field, the movement stencil, and the start seed. Bundling the
+    /// operands into one kind keeps `solve` a unary `Kind -> Kind` node,
+    /// the same shape [`crate::Mat4Apply`] gives `mat4_apply`. `start` is
+    /// a cost-valued seed slice of length `cost.width * cost.height` — the
+    /// per-cell initial accumulated cost at `t = 0`, with `u32::MAX`
+    /// marking a cell that is not a start. A plain start sets its cells to
+    /// `0`; the seed-slice form (rather than a bare 0-cost cell set) is
+    /// what lets a windowed re-solve carry its frontier and a
+    /// counterfactual query seed from an actual `(cell, accumulated-cost)`
+    /// state.
+    #[derive(
+        aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq,
+    )]
+    #[kind(name = "aether.reach.problem")]
+    pub struct ReachabilityProblem {
+        pub cost: ScalarField,
+        pub stencil: MovementStencil,
+        pub start: Vec<u32>,
+    }
+
+    /// A budget threshold to query a solved cost-to-reach field against
+    /// (issue 1857). Paired with the `V` field by the `reachability_margin`
+    /// transform, which compares `budget` to the minimum cost-to-reach
+    /// over the field's final tick.
+    #[derive(
+        aether_data::Kind,
+        aether_data::Schema,
+        Serialize,
+        Deserialize,
+        Debug,
+        Clone,
+        Copy,
+        PartialEq,
+        Eq,
+    )]
+    #[kind(name = "aether.reach.budget_query")]
+    pub struct BudgetQuery {
+        pub budget: u32,
+    }
+
+    /// The result of a `reachability_margin` query (issue 1857).
+    /// `min_cost` is the minimum cost-to-reach over the field's final-tick
+    /// cells (`u32::MAX` if no final-tick cell is reachable). `reachable`
+    /// is `min_cost < budget`. `margin` is `budget - min_cost` as a signed
+    /// value — positive slack when reachable under budget, negative when
+    /// the cheapest reachable cell still exceeds the budget (or when no
+    /// cell is reachable at all).
+    #[derive(
+        aether_data::Kind,
+        aether_data::Schema,
+        Serialize,
+        Deserialize,
+        Debug,
+        Clone,
+        Copy,
+        PartialEq,
+        Eq,
+    )]
+    #[kind(name = "aether.reach.margin")]
+    pub struct ReachabilityMargin {
+        pub reachable: bool,
+        pub min_cost: u32,
+        pub margin: i64,
+    }
 }
 
 #[cfg(test)]
@@ -3922,6 +4048,11 @@ mod tests {
         assert_eq!(ListKindsResult::NAME, "aether.inventory.kinds_result");
         assert_eq!(ListHandlers::NAME, "aether.inventory.handlers");
         assert_eq!(HandlersResult::NAME, "aether.inventory.handlers_result");
+        assert_eq!(ScalarField::NAME, "aether.reach.scalar_field");
+        assert_eq!(MovementStencil::NAME, "aether.reach.movement_stencil");
+        assert_eq!(ReachabilityProblem::NAME, "aether.reach.problem");
+        assert_eq!(BudgetQuery::NAME, "aether.reach.budget_query");
+        assert_eq!(ReachabilityMargin::NAME, "aether.reach.margin");
     }
 
     // ADR-0019 PR 3 — every kind below now has a derived `Schema` impl
@@ -3984,6 +4115,69 @@ mod tests {
             assert_eq!(nested_fields[0].name, "x");
             assert_eq!(nested_fields[2].name, "z");
             assert_eq!(nested_fields[5].name, "b");
+        }
+
+        #[test]
+        fn reachability_kinds_resolve_distinctly() {
+            use aether_data::Kind;
+            // The five reachability kinds carry distinct ids — a shared id
+            // would collide in the transform Ref-slot resolver (the same
+            // contract `mat4_apply`'s input/output split rests on).
+            let ids = [
+                ScalarField::ID,
+                MovementStencil::ID,
+                ReachabilityProblem::ID,
+                BudgetQuery::ID,
+                ReachabilityMargin::ID,
+            ];
+            for (i, a) in ids.iter().enumerate() {
+                for b in &ids[i + 1..] {
+                    assert_ne!(a, b, "reachability kind ids must be distinct");
+                }
+            }
+        }
+
+        #[test]
+        fn scalar_field_schema_is_struct() {
+            let SchemaType::Struct { fields, .. } = &<ScalarField as Schema>::SCHEMA else {
+                panic!("expected Struct");
+            };
+            assert_eq!(fields.len(), 4);
+            assert_eq!(fields[0].name, "width");
+            assert_eq!(fields[0].ty, SchemaType::Scalar(Primitive::U32));
+            assert_eq!(fields[3].name, "values");
+            let SchemaType::Vec(element) = &fields[3].ty else {
+                panic!("expected Vec");
+            };
+            assert_eq!(**element, SchemaType::Scalar(Primitive::U32));
+        }
+
+        #[test]
+        fn reachability_problem_schema_nests_field_and_stencil() {
+            let SchemaType::Struct { fields, .. } = &<ReachabilityProblem as Schema>::SCHEMA else {
+                panic!("expected Struct");
+            };
+            assert_eq!(fields.len(), 3);
+            assert_eq!(fields[0].name, "cost");
+            assert!(matches!(fields[0].ty, SchemaType::Struct { .. }));
+            assert_eq!(fields[1].name, "stencil");
+            assert!(matches!(fields[1].ty, SchemaType::Struct { .. }));
+            assert_eq!(fields[2].name, "start");
+            assert!(matches!(fields[2].ty, SchemaType::Vec(_)));
+        }
+
+        #[test]
+        fn margin_schema_is_struct() {
+            let SchemaType::Struct { fields, .. } = &<ReachabilityMargin as Schema>::SCHEMA else {
+                panic!("expected Struct");
+            };
+            assert_eq!(fields.len(), 3);
+            assert_eq!(fields[0].name, "reachable");
+            assert_eq!(fields[0].ty, SchemaType::Bool);
+            assert_eq!(fields[1].name, "min_cost");
+            assert_eq!(fields[1].ty, SchemaType::Scalar(Primitive::U32));
+            assert_eq!(fields[2].name, "margin");
+            assert_eq!(fields[2].ty, SchemaType::Scalar(Primitive::I64));
         }
     }
 


### PR DESCRIPTION
Closes #1857.

## Summary

The foundation of the reachability epic: a minimum-cost reachability solver over a discretized space-time scalar field. Given a `ScalarField` cost volume and a `MovementStencil`, `solve_cost_to_reach` computes the cost-to-reach field iteratively (dense, saturating over a `u32::MAX` unreachable sentinel), and a `reachability_margin` transform answers budget queries against it. The result is a typed `ScalarField` the downstream passes (corridor graph #1858, receding-horizon re-solve #1859, etc.) consume.

New `aether.reach.*` kinds in `aether-kinds` (`ScalarField`, `MovementStencil`/`StencilOffset`, `ReachabilityProblem`, `BudgetQuery`, `ReachabilityMargin`), a pure solver core in `aether-capabilities::reachability`, and two `#[transform]`s (`solve`, `reachability_margin`) registered in the native inventory (gated off wasm).

## Test plan

- `reachability.rs` — 5 hand-checked unit tests of `solve_cost_to_reach`.
- `transforms.rs` — determinism / content-addressing, threshold-query, and a canonical 64×64×1800 size + round-trip test (solve ~2.2s, encoded field well under the 64 MB output cap).
- `aether-kinds` — kind-name stability asserts + schema/resolution tests for the new kinds.
- Full workspace: `cargo nextest run --workspace` 1851 passed / 9 skipped; clippy `-D warnings` clean; `aether-kinds` wasm32 cross-build clean.

## Generated by

`/implement` — agent execution of [scoped issue #1857](https://github.com/iamacoffeepot/aether/issues/1857).
