### PR TITLE
feat(actor): auto-serialize actor state as a declared kind

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -1882,6 +1882,15 @@ fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
     // emitted `export!` shim can decode 0 config bytes via
     // `impl Kind for ()` and the user's `init` body stays 1-param.
     let mut config_type: Option<syn::ImplItemType> = None;
+    // ADR-0113 (issue 1855): optional `type State = …` declaration plus
+    // the `dehydrate` / `rehydrate` accessor pair. When `type State` is
+    // declared the macro generates the `on_dehydrate` / `on_rehydrate`
+    // hooks from these (snapshot via `dehydrate`, restore via
+    // `rehydrate`); when omitted it synthesizes `type State = ();` so a
+    // no-persistence actor is unchanged.
+    let mut state_type: Option<syn::ImplItemType> = None;
+    let mut dehydrate_accessor: Option<syn::ImplItemFn> = None;
+    let mut rehydrate_accessor: Option<syn::ImplItemFn> = None;
 
     for impl_item in item.items {
         match impl_item {
@@ -1893,6 +1902,9 @@ fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
             }
             ImplItem::Type(it) if it.ident == "Config" => {
                 config_type = Some(it);
+            }
+            ImplItem::Type(it) if it.ident == "State" => {
+                state_type = Some(it);
             }
             ImplItem::Const(c) => {
                 consts.push(c);
@@ -1963,6 +1975,18 @@ fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
                         &f,
                         "#[actor] synthesizes `fn receive`; remove this definition",
                     ));
+                } else if name == "dehydrate" {
+                    // ADR-0113: the save-side accessor — `fn dehydrate(&self)
+                    // -> Self::State`. Routed out of `helpers` so the macro
+                    // can validate the `type State` XOR and lift it into the
+                    // inherent impl where the generated `on_dehydrate` calls
+                    // `self.dehydrate()`.
+                    dehydrate_accessor = Some(f);
+                } else if name == "rehydrate" {
+                    // ADR-0113: the restore-side accessor — `fn rehydrate(&mut
+                    // self, state: Self::State)`. The generated `on_rehydrate`
+                    // calls `self.rehydrate(..)` with the decoded state.
+                    rehydrate_accessor = Some(f);
                 } else {
                     helpers.push(f);
                 }
@@ -2015,6 +2039,68 @@ fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
             ));
         }
     }
+
+    // ADR-0113 (issue 1855): declarative persistence. `type State` plus
+    // the `dehydrate` / `rehydrate` accessor pair generate the
+    // `on_dehydrate` / `on_rehydrate` hooks, so they are mutually
+    // exclusive with hand-written hooks and require each other. Validate
+    // the XOR at the offending span before synthesizing / generating.
+    let manual_state_hook = lifecycle_methods.iter().find(|m| {
+        matches!(
+            m.sig.ident.to_string().as_str(),
+            "on_dehydrate" | "on_rehydrate"
+        )
+    });
+    if let Some(state) = state_type.as_ref() {
+        // (a) `type State` + a hand-written hook is contradictory — the
+        // macro already generates the hook from the accessors.
+        if let Some(hook) = manual_state_hook {
+            return Err(syn::Error::new_spanned(
+                hook,
+                "#[actor] generates `on_dehydrate` / `on_rehydrate` from `type State` plus the \
+                 `dehydrate` / `rehydrate` accessors (ADR-0113); remove the hand-written hook, \
+                 or drop `type State` and the accessors to write the hooks by hand",
+            ));
+        }
+        // (c) `type State` needs both accessors — a half-pair would leave
+        // one generated hook with no method to call.
+        if dehydrate_accessor.is_none() {
+            return Err(syn::Error::new_spanned(
+                state,
+                "`type State` requires a `fn dehydrate(&self) -> Self::State` accessor \
+                 (ADR-0113) — the macro snapshots state through it in the generated \
+                 `on_dehydrate`",
+            ));
+        }
+        if rehydrate_accessor.is_none() {
+            return Err(syn::Error::new_spanned(
+                state,
+                "`type State` requires a `fn rehydrate(&mut self, state: Self::State)` accessor \
+                 (ADR-0113) — the macro restores state through it in the generated \
+                 `on_rehydrate`",
+            ));
+        }
+    } else if let Some(accessor) = dehydrate_accessor.as_ref().or(rehydrate_accessor.as_ref()) {
+        // (b) an accessor without `type State` has no kind to (de)serialize.
+        return Err(syn::Error::new_spanned(
+            accessor,
+            "`dehydrate` / `rehydrate` are the ADR-0113 persistence accessors and require a \
+             `type State = …` declaration; add it, or rename the method if it is an unrelated \
+             helper",
+        ));
+    }
+
+    // Mirror `synthesized_config_type`: synthesize `type State = ();`
+    // when the author omitted it (gated on `state_type.is_some()` at
+    // macro time, NOT on `State != ()` at runtime), so a no-persistence
+    // actor keeps the default no-op hooks and pays nothing.
+    let synthesized_state_type: Option<syn::ImplItemType> = if state_type.is_some() {
+        None
+    } else {
+        Some(syn::parse_quote!(
+            type State = ();
+        ))
+    };
 
     // ADR-0090 (issue 1256): the trait now takes `init(config: Self::Config,
     // ctx: &mut C)`. If the user declared `type Config = …`, leave their
@@ -2152,6 +2238,65 @@ fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
         (None, None) => unreachable!("synthesized_config_type is Some when user omitted"),
     };
 
+    // ADR-0113: emit the `type State = …` line in the trait impl — the
+    // user's declaration (passed through) or the synthesized `= ()`.
+    let state_type_tokens = match (state_type.as_ref(), synthesized_state_type.as_ref()) {
+        (Some(user), _) => quote! { #user },
+        (None, Some(synth)) => quote! { #synth },
+        (None, None) => unreachable!("synthesized_state_type is Some when user omitted"),
+    };
+
+    // ADR-0113: when the author declared `type State`, generate the
+    // `on_dehydrate` / `on_rehydrate` hooks from the lifted accessors.
+    // `Self::State` resolves directly inside `impl FfiActor for Self`.
+    // `on_dehydrate` snapshots through `self.dehydrate()` and frames the
+    // value with `save_state_kind`; `on_rehydrate` decodes via
+    // `PriorState::as_kind` and either restores through `self.rehydrate`
+    // or boots fresh, warning only when bytes were present but did not
+    // decode (a reshaped state kind — `K::ID` changed). When `type State`
+    // was omitted these are empty and the actor keeps the default no-op
+    // hooks (or its own hand-written ones, carried in `lifecycle_methods`).
+    let generated_state_hooks = if state_type.is_some() {
+        quote! {
+            fn on_dehydrate(&mut self, __aether_ctx: &mut ::aether_actor::FfiDropCtx<'_>) {
+                let __aether_state = self.dehydrate();
+                ::aether_actor::Persistence::save_state_kind::<
+                    <Self as ::aether_actor::FfiActor>::State,
+                >(__aether_ctx, 0, &__aether_state);
+            }
+
+            fn on_rehydrate(
+                &mut self,
+                __aether_ctx: &mut ::aether_actor::FfiCtx<'_>,
+                __aether_prior: ::aether_actor::PriorState<'_>,
+            ) {
+                match __aether_prior.as_kind::<<Self as ::aether_actor::FfiActor>::State>() {
+                    ::core::option::Option::Some(__aether_state) => {
+                        self.rehydrate(__aether_state);
+                    }
+                    ::core::option::Option::None => {
+                        if !__aether_prior.bytes().is_empty() {
+                            ::aether_actor::__macro_internals::tracing::warn!(
+                                "discarded prior state on rehydrate: bytes were present but did \
+                                 not decode as the declared `type State` (a reshaped state kind); \
+                                 booting fresh",
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
+
+    // ADR-0113: the lifted accessors ride as inherent methods on Self
+    // (like handlers / helpers) so the generated trait-impl hooks can
+    // call `self.dehydrate()` / `self.rehydrate(..)`. Both are `None`
+    // when the actor declares no `type State`.
+    let dehydrate_accessor_tokens = dehydrate_accessor.as_ref();
+    let rehydrate_accessor_tokens = rehydrate_accessor.as_ref();
+
     Ok(quote! {
         #actor_impl
 
@@ -2159,10 +2304,13 @@ fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
 
         impl #impl_generics #trait_path for #self_ty #where_clause {
             #config_type_tokens
+            #state_type_tokens
 
             #wrapped_init
 
             #(#lifecycle_methods)*
+
+            #generated_state_hooks
         }
 
         impl #impl_generics #self_ty #where_clause {
@@ -2180,6 +2328,8 @@ fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
             #(#handler_methods_tokens)*
             #fallback_method_tokens
             #(#helper_methods_tokens)*
+            #dehydrate_accessor_tokens
+            #rehydrate_accessor_tokens
         }
 
         // ADR-0096: object-safe erasure so a multi-actor module's

--- a/crates/aether-actor-derive/tests/ui.rs
+++ b/crates/aether-actor-derive/tests/ui.rs
@@ -38,4 +38,12 @@ fn ui() {
     t.compile_fail("tests/ui/rejects_stream_reserved_ffi.rs");
     t.compile_fail("tests/ui/rejects_stream_reserved_native.rs");
     t.compile_fail("tests/ui/rejects_manual_marker_mismatch_ffi.rs");
+    // ADR-0113: declarative `type State` + `dehydrate` / `rehydrate`
+    // accessors generate the hot-swap hooks; the macro enforces the XOR
+    // (no manual hook), the pairing (both accessors), and the dependency
+    // (an accessor needs `type State`).
+    t.pass("tests/ui/accepts_state_actor.rs");
+    t.compile_fail("tests/ui/rejects_state_with_manual_hook.rs");
+    t.compile_fail("tests/ui/rejects_accessor_without_state.rs");
+    t.compile_fail("tests/ui/rejects_missing_rehydrate.rs");
 }

--- a/crates/aether-actor-derive/tests/ui/accepts_state_actor.rs
+++ b/crates/aether-actor-derive/tests/ui/accepts_state_actor.rs
@@ -1,0 +1,62 @@
+//! ADR-0113: a well-formed `type State` plus a `dehydrate` / `rehydrate`
+//! accessor pair expands cleanly — `#[actor]` generates the
+//! `on_dehydrate` / `on_rehydrate` hooks from the declaration and the
+//! lifted accessors. Guards the reject fixtures against false positives:
+//! the new diagnostics must fire on the malformed shapes, not on every
+//! stateful actor.
+
+use aether_actor::{FfiCtx, actor};
+use serde::{Deserialize, Serialize};
+
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize)]
+#[kind(name = "test.counter_state")]
+struct CounterState {
+    count: u32,
+}
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.bump")]
+struct Bump {
+    delta: u32,
+}
+
+struct Counter {
+    count: u32,
+}
+
+#[actor]
+impl aether_actor::FfiActor for Counter {
+    const NAMESPACE: &'static str = "counter";
+
+    type State = CounterState;
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, aether_actor::BootError>
+    where
+        C: aether_actor::Resolver,
+    {
+        Ok(Counter { count: 0 })
+    }
+
+    fn dehydrate(&self) -> CounterState {
+        CounterState { count: self.count }
+    }
+
+    fn rehydrate(&mut self, state: CounterState) {
+        self.count = state.count;
+    }
+
+    #[handler]
+    fn on_bump(&mut self, _ctx: &mut FfiCtx<'_>, bump: Bump) {
+        self.count += bump.delta;
+    }
+}
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/rejects_accessor_without_state.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_accessor_without_state.rs
@@ -1,0 +1,58 @@
+//! ADR-0113: a `dehydrate` / `rehydrate` accessor with no `type State`
+//! declaration has no kind to (de)serialize — the accessor pair only
+//! means anything alongside a declared state kind. Rejected at the
+//! accessor's span.
+
+use aether_actor::actor;
+use serde::{Deserialize, Serialize};
+
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize)]
+#[kind(name = "test.counter_state")]
+struct CounterState {
+    count: u32,
+}
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.bump")]
+struct Bump {
+    delta: u32,
+}
+
+struct Counter {
+    count: u32,
+}
+
+#[actor]
+impl aether_actor::FfiActor for Counter {
+    const NAMESPACE: &'static str = "counter";
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, aether_actor::BootError>
+    where
+        C: aether_actor::Resolver,
+    {
+        Ok(Counter { count: 0 })
+    }
+
+    fn dehydrate(&self) -> CounterState {
+        CounterState { count: self.count }
+    }
+
+    fn rehydrate(&mut self, state: CounterState) {
+        self.count = state.count;
+    }
+
+    #[handler]
+    fn on_bump(&mut self, _ctx: &mut aether_actor::FfiCtx<'_>, bump: Bump) {
+        self.count += bump.delta;
+    }
+}
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/rejects_accessor_without_state.stderr
+++ b/crates/aether-actor-derive/tests/ui/rejects_accessor_without_state.stderr
@@ -1,0 +1,7 @@
+error: `dehydrate` / `rehydrate` are the ADR-0113 persistence accessors and require a `type State = …` declaration; add it, or rename the method if it is an unrelated helper
+  --> tests/ui/rejects_accessor_without_state.rs:44:5
+   |
+44 | /     fn dehydrate(&self) -> CounterState {
+45 | |         CounterState { count: self.count }
+46 | |     }
+   | |_____^

--- a/crates/aether-actor-derive/tests/ui/rejects_missing_rehydrate.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_missing_rehydrate.rs
@@ -1,0 +1,56 @@
+//! ADR-0113: `type State` requires both halves of the accessor pair —
+//! a lone `dehydrate` (no `rehydrate`) would leave the generated
+//! `on_rehydrate` with no method to call. Rejected at the `type State`
+//! span, naming the missing accessor.
+
+use aether_actor::actor;
+use serde::{Deserialize, Serialize};
+
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize)]
+#[kind(name = "test.counter_state")]
+struct CounterState {
+    count: u32,
+}
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.bump")]
+struct Bump {
+    delta: u32,
+}
+
+struct Counter {
+    count: u32,
+}
+
+#[actor]
+impl aether_actor::FfiActor for Counter {
+    const NAMESPACE: &'static str = "counter";
+
+    type State = CounterState;
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, aether_actor::BootError>
+    where
+        C: aether_actor::Resolver,
+    {
+        Ok(Counter { count: 0 })
+    }
+
+    fn dehydrate(&self) -> CounterState {
+        CounterState { count: self.count }
+    }
+
+    #[handler]
+    fn on_bump(&mut self, _ctx: &mut aether_actor::FfiCtx<'_>, bump: Bump) {
+        self.count += bump.delta;
+    }
+}
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/rejects_missing_rehydrate.stderr
+++ b/crates/aether-actor-derive/tests/ui/rejects_missing_rehydrate.stderr
@@ -1,0 +1,5 @@
+error: `type State` requires a `fn rehydrate(&mut self, state: Self::State)` accessor (ADR-0113) — the macro restores state through it in the generated `on_rehydrate`
+  --> tests/ui/rejects_missing_rehydrate.rs:37:5
+   |
+37 |     type State = CounterState;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/aether-actor-derive/tests/ui/rejects_state_with_manual_hook.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_state_with_manual_hook.rs
@@ -1,0 +1,62 @@
+//! ADR-0113: `type State` (plus accessors) and a hand-written
+//! `on_dehydrate` / `on_rehydrate` are mutually exclusive — the macro
+//! already generates the hook from the accessors, so a manual one is
+//! rejected at the hand-written hook's span.
+
+use aether_actor::actor;
+use serde::{Deserialize, Serialize};
+
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize)]
+#[kind(name = "test.counter_state")]
+struct CounterState {
+    count: u32,
+}
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.bump")]
+struct Bump {
+    delta: u32,
+}
+
+struct Counter {
+    count: u32,
+}
+
+#[actor]
+impl aether_actor::FfiActor for Counter {
+    const NAMESPACE: &'static str = "counter";
+
+    type State = CounterState;
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, aether_actor::BootError>
+    where
+        C: aether_actor::Resolver,
+    {
+        Ok(Counter { count: 0 })
+    }
+
+    fn dehydrate(&self) -> CounterState {
+        CounterState { count: self.count }
+    }
+
+    fn rehydrate(&mut self, state: CounterState) {
+        self.count = state.count;
+    }
+
+    fn on_dehydrate(&mut self, _ctx: &mut aether_actor::FfiDropCtx<'_>) {}
+
+    #[handler]
+    fn on_bump(&mut self, _ctx: &mut aether_actor::FfiCtx<'_>, bump: Bump) {
+        self.count += bump.delta;
+    }
+}
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/rejects_state_with_manual_hook.stderr
+++ b/crates/aether-actor-derive/tests/ui/rejects_state_with_manual_hook.stderr
@@ -1,0 +1,5 @@
+error: #[actor] generates `on_dehydrate` / `on_rehydrate` from `type State` plus the `dehydrate` / `rehydrate` accessors (ADR-0113); remove the hand-written hook, or drop `type State` and the accessors to write the hooks by hand
+  --> tests/ui/rejects_state_with_manual_hook.rs:54:5
+   |
+54 |     fn on_dehydrate(&mut self, _ctx: &mut aether_actor::FfiDropCtx<'_>) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -154,6 +154,27 @@ pub trait FfiActor: crate::Actor {
     /// would have to write `type Config = ();` themselves.
     type Config: aether_data::Kind;
 
+    /// ADR-0113 kind-typed persistent state: the durable shape the
+    /// actor carries across a `replace_component` swap. Declaring it
+    /// (beside a `dehydrate` / `rehydrate` accessor pair) lets the
+    /// `#[actor]` macro generate the [`Self::on_dehydrate`] /
+    /// [`Self::on_rehydrate`] hooks instead of the author hand-writing
+    /// them — the save side snapshots `State` and frames it via
+    /// `save_state_kind`, the restore side decodes it via
+    /// [`PriorState::as_kind`][crate::PriorState::as_kind] and boots
+    /// fresh (with a `tracing::warn!`) when a reshaped `State` kind no
+    /// longer decodes.
+    ///
+    /// Mirrors [`Self::Config`]: the `#[actor]` macro synthesizes
+    /// `type State = ();` when the author omits it, so a no-persistence
+    /// actor is unchanged and pays nothing (stable Rust has no
+    /// associated-type defaults — rust-lang/rust#29661 — so the
+    /// synthesis stands in). Distinct from `Self` because the durable
+    /// fields are a subset of the actor's state: the `Mailbox` tokens
+    /// and handle ids `init` rebuilds are intentionally excluded
+    /// (ADR-0113).
+    type State: aether_data::Kind;
+
     /// Runs once. Resolve kinds and mailboxes via `ctx` and return the
     /// initial actor state. ADR-0033: `#[actor]` prepends
     /// `ctx.subscribe_input::<K>()` for every `K::IS_INPUT` handler

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -125,6 +125,11 @@ pub mod __macro_internals {
     // `Box<dyn ErasedFfiActor>`; re-export `Box` so the emitted code
     // doesn't depend on the guest crate's prelude exposing `alloc`.
     pub use alloc::boxed::Box;
+    // ADR-0113: the `#[actor]`-generated `on_rehydrate` warns through
+    // `::aether_actor::__macro_internals::tracing::warn!` on a non-empty
+    // decode-miss, so the macro roots the warn here rather than forcing
+    // `tracing` into every component's dependency list.
+    pub use tracing;
 }
 
 /// ADR-0033 attribute macros and `Kind` / `Schema` derives, behind

--- a/crates/aether-actor/tests/state_framing_roundtrip.rs
+++ b/crates/aether-actor/tests/state_framing_roundtrip.rs
@@ -1,0 +1,112 @@
+//! ADR-0113 / issue 1855: host-side proof of the framing the
+//! `#[actor]`-generated `on_dehydrate` / `on_rehydrate` hooks ride.
+//!
+//! The generated `on_dehydrate` deposits the actor's `type State` via
+//! `Persistence::save_state_kind`; the generated `on_rehydrate` recovers
+//! it via `PriorState::as_kind` and boots fresh (warning) when the decode
+//! misses. Those hooks only run on the wasm load/replace path, which the
+//! test bench drives end-to-end — but the test bench cannot observe the
+//! decode-miss warn (it does not route `aether.log` mail through its
+//! observed sinks). This test stands in for that seam on the host: it
+//! exercises the deposit (`save_state_kind`) and recovery (`as_kind`)
+//! halves through a capture ctx, and asserts the exact decode-miss
+//! predicate the generated warn branches on (`as_kind() == None` while
+//! `bytes()` is non-empty).
+
+use aether_actor::{Persistence, PriorState};
+use aether_data::Kind;
+use serde::{Deserialize, Serialize};
+
+/// Captures whatever the dehydrate side deposits, standing in for the
+/// substrate-owned migration buffer the real `FfiDropCtx` writes to.
+#[derive(Default)]
+struct CaptureCtx {
+    saved: Option<(u32, Vec<u8>)>,
+}
+
+impl Persistence for CaptureCtx {
+    fn save_state(&mut self, version: u32, bytes: &[u8]) {
+        self.saved = Some((version, bytes.to_vec()));
+    }
+}
+
+/// The state kind a typed actor declares as `type State`.
+#[derive(
+    aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq,
+)]
+#[kind(name = "test.state.counter")]
+struct CounterState {
+    count: u32,
+}
+
+/// A reshaped version of the same logical state — an added field changes
+/// the schema and therefore `Kind::ID`, which is exactly how a
+/// `replace_component` against an evolved state kind manifests.
+#[derive(
+    aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq,
+)]
+#[kind(name = "test.state.counter.reshaped")]
+struct CounterStateReshaped {
+    count: u32,
+    generation: u32,
+}
+
+/// Build a `PriorState` over a captured save buffer. The returned value
+/// borrows `buf` for its lifetime.
+fn prior_from(buf: &[u8]) -> PriorState<'_> {
+    // SAFETY: `PriorState<'_>` borrows `buf` via the explicit lifetime;
+    // the `(addr, len)` pair derives from a live slice valid for the
+    // borrow. Mirrors the substrate's `on_rehydrate` ABI on the host.
+    unsafe { PriorState::__from_ptr(0, buf.as_ptr().addr(), buf.len()) }
+}
+
+/// The deposit half (`save_state_kind`) and the recovery half
+/// (`PriorState::as_kind`) round-trip the state value — the two halves
+/// the generated hooks each own, exercised back to back.
+#[test]
+fn save_state_kind_round_trips_through_as_kind() {
+    let value = CounterState { count: 7 };
+
+    let mut ctx = CaptureCtx::default();
+    ctx.save_state_kind::<CounterState>(0, &value);
+
+    let (version, buf) = ctx.saved.expect("dehydrate deposits a bundle");
+    assert_eq!(version, 0, "the generated on_dehydrate frames version 0");
+
+    let prior = prior_from(&buf);
+    let recovered = prior
+        .as_kind::<CounterState>()
+        .expect("the framed bundle decodes back to the same state kind");
+    assert_eq!(recovered, value);
+}
+
+/// A bundle framed under one state shape and recovered against a reshaped
+/// one decodes to `None` while leaving the raw bytes present — the exact
+/// condition the generated `on_rehydrate` reads to fire its warn before
+/// booting fresh.
+#[test]
+fn reshaped_state_kind_misses_decode_with_bytes_present() {
+    let value = CounterState { count: 7 };
+
+    let mut ctx = CaptureCtx::default();
+    ctx.save_state_kind::<CounterState>(0, &value);
+    let (_, buf) = ctx.saved.expect("dehydrate deposits a bundle");
+
+    // The reshaped kind has a different `Kind::ID`, so the leading-id
+    // compare in `as_kind` rejects before postcard runs.
+    assert_ne!(
+        CounterState::ID,
+        CounterStateReshaped::ID,
+        "reshaping the state kind must change Kind::ID for the decode-miss to be real",
+    );
+
+    let prior = prior_from(&buf);
+    assert!(
+        prior.as_kind::<CounterStateReshaped>().is_none(),
+        "a reshaped state kind must not decode the old bundle",
+    );
+    assert!(
+        !prior.bytes().is_empty(),
+        "the raw bytes stay present on a decode-miss — this is the warn trigger",
+    );
+}

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -1239,6 +1239,220 @@ fn replace_preserves_multi_actor_state_via_dehydrate_rehydrate() {
     );
 }
 
+/// ADR-0113: a single-actor component carries its declared `type State`
+/// across `replace_component` through the macro-generated `on_dehydrate`
+/// / `on_rehydrate` hooks — no hand-written hooks. Loads the
+/// `stateful_replace_typed` fixture, bumps the counter to 3, replaces the
+/// wasm at the same mailbox id with the same binary, then re-queries. The
+/// generated `on_dehydrate` frames the `CounterState` via
+/// `save_state_kind`; the generated `on_rehydrate` recovers it via
+/// `as_kind`, so the count survives the swap.
+#[test]
+fn replace_preserves_state_via_typed_state_kind() {
+    use aether_actor::Actor;
+
+    const FIXTURE_NAME: &str = "stateful_replace_typed";
+
+    let Some(wasm_path) = require_runtime(FIXTURE_NAME) else {
+        return;
+    };
+    let addr = format!(
+        "aether.component/{}:{FIXTURE_NAME}",
+        aether_capabilities::WasmTrampoline::NAMESPACE,
+    );
+
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let wasm = fs::read(&wasm_path).expect("read fixture wasm");
+
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm,
+                    name: Some(FIXTURE_NAME.to_owned()),
+                    config: Vec::new(),
+                    export: None,
+                },
+            ),
+        )])
+        .expect("load sequence");
+    let mailbox_id = match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Ok { mailbox_id, .. } => mailbox_id,
+        LoadResult::Err { error } => panic!("stateful_replace_typed load failed: {error}"),
+    };
+
+    // Bump the counter to 3, then read it back.
+    let pre = bench
+        .execute(vec![
+            ("bump_a", BenchOp::send_mail::<Bump>(addr.as_str(), &Bump)),
+            ("bump_b", BenchOp::send_mail::<Bump>(addr.as_str(), &Bump)),
+            ("bump_c", BenchOp::send_mail::<Bump>(addr.as_str(), &Bump)),
+            ("query", BenchOp::send_and_await(addr.as_str(), &CountQuery)),
+        ])
+        .expect("bump + query sequence");
+    assert_eq!(
+        pre.reply::<CountReport>("query")
+            .expect("decode pre-replace CountReport"),
+        CountReport { count: 3 },
+        "three bumps should leave the counter at 3 before the replace",
+    );
+
+    // Replace with the same binary; the generated hooks carry the count.
+    let wasm = fs::read(&wasm_path).expect("re-read fixture wasm");
+    let swapped = bench
+        .execute(vec![(
+            "swap",
+            BenchOp::send_and_await(
+                "aether.component",
+                &ReplaceComponent {
+                    mailbox_id,
+                    wasm,
+                    drain_timeout_ms: None,
+                    config: Vec::new(),
+                },
+            ),
+        )])
+        .expect("replace sequence");
+    match swapped
+        .reply::<ReplaceResult>("swap")
+        .expect("decode ReplaceResult")
+    {
+        ReplaceResult::Ok { .. } => {}
+        ReplaceResult::Err { error } => panic!("replace_component: {error}"),
+    }
+
+    let post = bench
+        .execute(vec![(
+            "query",
+            BenchOp::send_and_await(addr.as_str(), &CountQuery),
+        )])
+        .expect("post-replace query sequence");
+    let post_count = post
+        .reply::<CountReport>("query")
+        .expect("decode post-replace CountReport");
+    assert_eq!(
+        post_count,
+        CountReport { count: 3 },
+        "the counter must survive the replace via the macro-generated typed-state hooks; \
+         got {post_count:?} (0 means the generated hooks did not carry the state)",
+    );
+}
+
+/// ADR-0113: when a replacement is compiled against a reshaped `type
+/// State` kind (a different `Kind::ID`), the generated `on_rehydrate`
+/// sees `PriorState::as_kind` miss the decode and boots fresh. Loads the
+/// `stateful_replace_typed` fixture, bumps to 3, then replaces it with
+/// `stateful_replace_reshaped` (same `NAMESPACE`, a `CounterState` that
+/// gained a field). The recovered count is 0 — the fresh-`init` value —
+/// because the saved bundle's leading id no longer matches. The warn the
+/// generated hook emits on the decode-miss is covered host-side by
+/// `aether-actor`'s `state_framing_roundtrip` test (the bench does not
+/// route `aether.log` mail through its observed sinks).
+#[test]
+fn typed_state_decode_miss_boots_fresh() {
+    use aether_actor::Actor;
+
+    const TYPED_NAME: &str = "stateful_replace_typed";
+    const RESHAPED_NAME: &str = "stateful_replace_reshaped";
+
+    let Some(typed_path) = require_runtime(TYPED_NAME) else {
+        return;
+    };
+    let Some(reshaped_path) = require_runtime(RESHAPED_NAME) else {
+        return;
+    };
+    let addr = format!(
+        "aether.component/{}:{TYPED_NAME}",
+        aether_capabilities::WasmTrampoline::NAMESPACE,
+    );
+
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let typed_wasm = fs::read(&typed_path).expect("read typed fixture wasm");
+
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm: typed_wasm,
+                    name: Some(TYPED_NAME.to_owned()),
+                    config: Vec::new(),
+                    export: None,
+                },
+            ),
+        )])
+        .expect("load sequence");
+    let mailbox_id = match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Ok { mailbox_id, .. } => mailbox_id,
+        LoadResult::Err { error } => panic!("stateful_replace_typed load failed: {error}"),
+    };
+
+    let pre = bench
+        .execute(vec![
+            ("bump_a", BenchOp::send_mail::<Bump>(addr.as_str(), &Bump)),
+            ("bump_b", BenchOp::send_mail::<Bump>(addr.as_str(), &Bump)),
+            ("bump_c", BenchOp::send_mail::<Bump>(addr.as_str(), &Bump)),
+            ("query", BenchOp::send_and_await(addr.as_str(), &CountQuery)),
+        ])
+        .expect("bump + query sequence");
+    assert_eq!(
+        pre.reply::<CountReport>("query")
+            .expect("decode pre-replace CountReport"),
+        CountReport { count: 3 },
+        "three bumps should leave the counter at 3 before the replace",
+    );
+
+    // Replace with the reshaped wasm: the saved bundle's leading id no
+    // longer matches the new `CounterState::ID`, so rehydrate misses.
+    let reshaped_wasm = fs::read(&reshaped_path).expect("read reshaped fixture wasm");
+    let swapped = bench
+        .execute(vec![(
+            "swap",
+            BenchOp::send_and_await(
+                "aether.component",
+                &ReplaceComponent {
+                    mailbox_id,
+                    wasm: reshaped_wasm,
+                    drain_timeout_ms: None,
+                    config: Vec::new(),
+                },
+            ),
+        )])
+        .expect("replace sequence");
+    match swapped
+        .reply::<ReplaceResult>("swap")
+        .expect("decode ReplaceResult")
+    {
+        ReplaceResult::Ok { .. } => {}
+        ReplaceResult::Err { error } => panic!("replace_component: {error}"),
+    }
+
+    let post = bench
+        .execute(vec![(
+            "query",
+            BenchOp::send_and_await(addr.as_str(), &CountQuery),
+        )])
+        .expect("post-replace query sequence");
+    let post_count = post
+        .reply::<CountReport>("query")
+        .expect("decode post-replace CountReport");
+    assert_eq!(
+        post_count,
+        CountReport { count: 0 },
+        "a reshaped state kind must boot fresh on rehydrate (decode-miss); \
+         got {post_count:?} (3 would mean the stale bundle decoded against the new shape)",
+    );
+}
+
 /// fs scenarios need wgpu (the bench unconditionally builds a
 /// `Gpu` at boot) but not the fixture wasm. Skips on wgpu-less
 /// runners and panics under `AETHER_REQUIRE_RUNTIME` so a

--- a/crates/aether-test-fixtures/Cargo.toml
+++ b/crates/aether-test-fixtures/Cargo.toml
@@ -70,6 +70,22 @@ crate-type = ["cdylib"]
 name = "stateful_replace"
 crate-type = ["cdylib"]
 
+# ADR-0113 declarative-state fixture: a single-actor `Counter` that
+# declares `type State = CounterState` plus the `dehydrate` / `rehydrate`
+# accessors, so `#[actor]` generates the hooks. The counter survives a
+# same-wasm `replace_component` swap with no hand-written hooks.
+[[example]]
+name = "stateful_replace_typed"
+crate-type = ["cdylib"]
+
+# ADR-0113 decode-miss companion: same `NAMESPACE` / `CounterState` kind
+# name but a reshaped state shape (added field → different `Kind::ID`).
+# Replacing the typed fixture with this one makes the generated
+# `on_rehydrate` miss the decode and boot fresh.
+[[example]]
+name = "stateful_replace_reshaped"
+crate-type = ["cdylib"]
+
 # Issue 1454: cube render fixture. Emits a twelve-triangle world-space
 # unit cube under a fixed `view_proj` so the TestBench cube scenario can
 # assert the camera + depth + readback pipeline.

--- a/crates/aether-test-fixtures/examples/stateful_replace_reshaped.rs
+++ b/crates/aether-test-fixtures/examples/stateful_replace_reshaped.rs
@@ -1,0 +1,79 @@
+//! ADR-0113 decode-miss companion to `stateful_replace_typed.rs`: same
+//! `NAMESPACE` and the same `CounterState` kind name, but the state shape
+//! gains a `generation` field. Reshaping the schema changes `Kind::ID`,
+//! so when this wasm replaces the typed fixture the generated
+//! `on_rehydrate` sees `PriorState::as_kind::<CounterState>() == None`
+//! (the saved bundle carries the old id), warns, and boots fresh — the
+//! counter resets to its `init` zero instead of restoring.
+
+// See `stateful_replace_typed.rs`: `rehydrate` takes its `State` by value
+// (the by-value persistence contract); clippy reads that as needlessly
+// owned for an all-`Copy` state, so silence the false positive.
+#![allow(clippy::needless_pass_by_value)]
+
+use aether_actor::{BootError, FfiActor, FfiCtx, OutboundReply, Resolver, actor};
+use aether_test_fixtures::{Bump, CountQuery, CountReport};
+
+/// Reshaped durable state — the added `generation` field changes the
+/// schema and therefore `Kind::ID`, which is what drives the decode-miss
+/// when this fixture replaces `stateful_replace_typed`.
+#[derive(
+    aether_data::Kind, aether_data::Schema, serde::Serialize, serde::Deserialize, Debug, Clone,
+)]
+#[kind(name = "aether.test_fixtures.counter_state")]
+pub struct CounterState {
+    pub count: u32,
+    pub generation: u32,
+}
+
+/// The evolved counter, tracking the new `generation` field its reshaped
+/// state carries. The added field is what makes this a genuine schema
+/// evolution: when this replaces the typed fixture, the saved bundle's
+/// `Kind::ID` no longer matches and rehydrate misses.
+pub struct Counter {
+    count: u32,
+    generation: u32,
+}
+
+#[actor]
+impl FfiActor for Counter {
+    const NAMESPACE: &'static str = "stateful.typed";
+
+    type State = CounterState;
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
+    where
+        C: Resolver,
+    {
+        Ok(Counter {
+            count: 0,
+            generation: 0,
+        })
+    }
+
+    fn dehydrate(&self) -> CounterState {
+        CounterState {
+            count: self.count,
+            generation: self.generation,
+        }
+    }
+
+    fn rehydrate(&mut self, state: CounterState) {
+        self.count = state.count;
+        self.generation = state.generation;
+    }
+
+    #[handler]
+    fn on_bump(&mut self, _ctx: &mut FfiCtx<'_>, _bump: Bump) {
+        self.count += 1;
+    }
+
+    #[handler]
+    fn on_count_query(&mut self, ctx: &mut FfiCtx<'_>, _query: CountQuery) {
+        if ctx.reply_target().is_some() {
+            ctx.reply(&CountReport { count: self.count });
+        }
+    }
+}
+
+aether_actor::export!(Counter);

--- a/crates/aether-test-fixtures/examples/stateful_replace_typed.rs
+++ b/crates/aether-test-fixtures/examples/stateful_replace_typed.rs
@@ -1,0 +1,84 @@
+//! ADR-0113 fixture: a single-actor component whose persistent state is
+//! declared as `type State` plus a `dehydrate` / `rehydrate` accessor
+//! pair, so the `#[actor]` macro generates the `on_dehydrate` /
+//! `on_rehydrate` hooks. The counter survives a `replace_component` swap
+//! with the same wasm exactly as the hand-written `stateful_replace`
+//! fixture's does — but with no hand-written hooks.
+//!
+//! `stateful_replace_reshaped.rs` is the decode-miss companion: same
+//! `NAMESPACE`, a reshaped `CounterState` (an added field changes
+//! `Kind::ID`), so a replacement compiled against it sees `as_kind` =
+//! `None` and boots fresh.
+
+// `rehydrate` takes its `State` by value — the macro hands the decoded
+// state over to be moved into the actor (so a real `State` with heap
+// fields needs no clone). This fixture's `CounterState` is all-`Copy`, so
+// clippy reads the by-value parameter as needlessly owned; the by-value
+// contract is the point, so silence the false positive here.
+#![allow(clippy::needless_pass_by_value)]
+
+use aether_actor::{BootError, FfiActor, FfiCtx, OutboundReply, Resolver, actor};
+use aether_test_fixtures::{Bump, CountQuery, CountReport};
+
+/// Durable state the `Counter` carries across `replace_component`. The
+/// `count` field is the only thing worth persisting — the macro frames it
+/// via `save_state_kind` on dehydrate and recovers it via `as_kind` on
+/// rehydrate. The reshaped companion fixture adds a field, changing
+/// `Kind::ID` so the recovery misses.
+#[derive(
+    aether_data::Kind, aether_data::Schema, serde::Serialize, serde::Deserialize, Debug, Clone,
+)]
+#[kind(name = "aether.test_fixtures.counter_state")]
+pub struct CounterState {
+    pub count: u32,
+}
+
+/// Single-actor component holding a counter that must survive a swap.
+pub struct Counter {
+    count: u32,
+}
+
+#[actor]
+impl FfiActor for Counter {
+    const NAMESPACE: &'static str = "stateful.typed";
+
+    /// ADR-0113: the durable shape. Declaring it plus the accessors below
+    /// is enough — `#[actor]` generates the `on_dehydrate` /
+    /// `on_rehydrate` hooks.
+    type State = CounterState;
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
+    where
+        C: Resolver,
+    {
+        Ok(Counter { count: 0 })
+    }
+
+    /// Save-side accessor: snapshot the live counter. The generated
+    /// `on_dehydrate` calls this immediately before the swap.
+    fn dehydrate(&self) -> CounterState {
+        CounterState { count: self.count }
+    }
+
+    /// Restore-side accessor: adopt the recovered snapshot. The generated
+    /// `on_rehydrate` hands the decoded state over by value.
+    fn rehydrate(&mut self, state: CounterState) {
+        self.count = state.count;
+    }
+
+    /// Increment the in-memory counter.
+    #[handler]
+    fn on_bump(&mut self, _ctx: &mut FfiCtx<'_>, _bump: Bump) {
+        self.count += 1;
+    }
+
+    /// Reply with the live counter so a test can read it across a swap.
+    #[handler]
+    fn on_count_query(&mut self, ctx: &mut FfiCtx<'_>, _query: CountQuery) {
+        if ctx.reply_target().is_some() {
+            ctx.reply(&CountReport { count: self.count });
+        }
+    }
+}
+
+aether_actor::export!(Counter);


### PR DESCRIPTION
Closes #1855.

## Summary

Implements ADR-0113 declarative actor state: `FfiActor` gains `type State: aether_data::Kind`, and the `#[actor]` macro synthesizes `on_dehydrate` (`save_state_kind::<Self::State>`) / `on_rehydrate` (`as_kind::<Self::State>` → restore, else boot fresh with a warn only on a non-empty decode-miss) from a declared `dehydrate` / `rehydrate` pair. Omitting state synthesizes `type State = ()`, so every existing component recompiles unchanged.

## Test plan

UI tests (`accepts_state_actor` + three rejects with `.stderr` goldens); a host round-trip exercising `save_state_kind` → `PriorState::as_kind` and the decode-miss predicate; two test-bench scenarios (`replace_preserves_state_via_typed_state_kind`, `typed_state_decode_miss_boots_fresh`). Full workspace green: clippy `-D warnings`, nextest `--workspace` (1838 passed), doc, and wasm32 cross-build of every existing component under the synthesized `type State = ()`.

## Generated by

`/implement` — agent execution of [scoped issue #1855](https://github.com/iamacoffeepot/aether/issues/1855).
