### PR TITLE
chore(substrate-bundle): add a test-bench reader for guest-emitted logs

### DIFF
--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -33,10 +33,10 @@ use std::time::{Duration, Instant};
 #[cfg(test)]
 use aether_capabilities::trace_walk::TreeWalk;
 use aether_data::{Kind, KindId, SessionToken, Uuid, encode_empty};
-use aether_kinds::Tick;
 #[cfg(test)]
 use aether_kinds::trace::{DescribeTreeResult, TraceTail, TraceTailResult};
 use aether_kinds::{Advance, AdvanceResult, CaptureFrame, CaptureFrameResult};
+use aether_kinds::{LogTail, LogTailResult, Tick};
 // `push_to_mailbox` encodes any sent kind through the descriptor-aware
 // `Kind::encode_into_bytes` (cast or postcard per the kind's shape);
 // `encode_empty` builds the zero-byte payload for unit lifecycle kinds.
@@ -412,6 +412,36 @@ impl TestBench {
             .lock()
             .expect("observed_kinds mutex is never poisoned (ADR-0063 fail-fast)")
             .clone()
+    }
+
+    /// Tail `mailbox_name`'s per-actor log ring (ADR-0081). Mirrors
+    /// `FleetBench::log_tail` over the existing `send_bytes_and_await`,
+    /// so in-process scenario tests can assert guest-emitted
+    /// `tracing::warn!` / `tracing::info!` entries without an RPC session.
+    ///
+    /// `since: None` reads from the oldest retained entry; `Some(n)` returns
+    /// only entries with `sequence > n`. `max: 0` resolves to the
+    /// substrate-default cap (currently 100). The framework dispatch loop
+    /// answers [`LogTail`] for every native actor and wasm trampoline, so
+    /// `mailbox_name` is any live mailbox path (e.g.
+    /// `"aether.component/aether.embedded:test_fixture_probe"`).
+    ///
+    /// # Panics
+    /// Panics on a decode failure — implies a kind shape mismatch,
+    /// matching the fail-fast disposition of [`Self::count_observed`] /
+    /// [`Self::observed_kinds`].
+    pub fn log_tail(&mut self, mailbox_name: &str, since: Option<u64>) -> LogTailResult {
+        let request = LogTail {
+            max: 0,
+            min_level: None,
+            since,
+        };
+        let payload = self
+            .send_bytes_and_await(mailbox_name, LogTail::ID, request.encode_into_bytes())
+            .unwrap_or_else(|e| panic!("log_tail send to {mailbox_name:?} failed: {e}"));
+        LogTailResult::decode_from_bytes(&payload).unwrap_or_else(|| {
+            panic!("log_tail reply from {mailbox_name:?} did not decode as LogTailResult")
+        })
     }
 
     /// Borrow the substrate's queryable [`CapabilityRegistry`]

--- a/crates/aether-substrate-bundle/tests/test_bench_logs.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_logs.rs
@@ -1,0 +1,145 @@
+//! `TestBench` actor-log reader proof (issue 1856): load the `probe` fixture,
+//! advance one tick to fire its first-tick `tracing::info!`, tail its per-actor
+//! `ActorLogRing` (ADR-0081) for the `typed_send_alive` info entry, then walk
+//! the `since` cursor to confirm it does not re-yield the seen entry.
+//!
+//! Heavy by construction (full `TestBench` chassis + wasm compile) — lives in
+//! `mod tests::heavy` so nextest's `test(/::heavy::/)` selector serializes it
+//! in the `serial-heavy` group.
+
+// Skip diagnostics emit `eprintln!` so `cargo test` runners surface a visible
+// "skipping: ..." line alongside `test ... ok` (issue 891).
+#![allow(clippy::print_stderr)]
+
+// Pin the fixture rlib so its `inventory::submit!` `KindDescriptor` entries are
+// present in this test binary (same rationale as test_bench_scenario.rs).
+#[allow(unused_imports)]
+use aether_test_fixtures as _;
+
+mod tests {
+    mod heavy {
+        use std::fs;
+        use std::thread;
+        use std::time::Duration;
+
+        use aether_actor::Actor;
+        use aether_kinds::{LoadComponent, LoadResult, LogTailResult};
+        use aether_substrate_bundle::test_bench::{
+            BenchOp, TestBench, test_helpers::require_runtime,
+        };
+
+        const PROBE_NAME: &str = "probe";
+
+        fn probe_address() -> String {
+            format!(
+                "aether.component/{}:{}",
+                aether_capabilities::WasmTrampoline::NAMESPACE,
+                PROBE_NAME,
+            )
+        }
+
+        /// `info` in the `0 = trace .. 4 = error` level mapping shared across
+        /// `aether.log.*`.
+        const LEVEL_INFO: u8 = 2;
+
+        /// Polling budget: after `advance(1)` the entry should already be in the
+        /// ring (the tick settled before `advance` returned), but a few retries
+        /// absorb any edge-case timing without lengthening the happy path.
+        const POLL_ATTEMPTS: usize = 10;
+        const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+        /// Load `probe`, advance one tick, poll its lineage address with
+        /// `TestBench::log_tail` until the `typed_send_alive` info entry appears,
+        /// then re-query past the returned cursor and assert it is not
+        /// re-yielded — the in-process counterpart to
+        /// `fleetbench_actor_logs_surface_the_probe_first_tick_entry`.
+        #[test]
+        fn test_bench_actor_logs_surface_the_probe_first_tick_entry() {
+            let Some(wasm_path) = require_runtime("probe") else {
+                return;
+            };
+            let mut bench = match TestBench::start_with_size(64, 48) {
+                Ok(b) => b,
+                Err(e) => {
+                    eprintln!("skipping: TestBench boot failed (likely no wgpu adapter): {e}");
+                    return;
+                }
+            };
+
+            let wasm = fs::read(&wasm_path).expect("read probe wasm");
+            let loaded = bench
+                .execute(vec![(
+                    "load",
+                    BenchOp::send_and_await(
+                        "aether.component",
+                        &LoadComponent {
+                            wasm,
+                            name: Some(PROBE_NAME.to_owned()),
+                            config: Vec::new(),
+                            export: None,
+                        },
+                    ),
+                )])
+                .expect("load probe");
+            match loaded
+                .reply::<LoadResult>("load")
+                .expect("decode LoadResult")
+            {
+                LoadResult::Ok { .. } => {}
+                LoadResult::Err { error } => panic!("load_component: {error}"),
+            }
+
+            bench
+                .execute(vec![("tick", BenchOp::advance(1))])
+                .expect("advance one tick");
+
+            let addr = probe_address();
+            let mut last_reply = None;
+            let mut found = None;
+            for _ in 0..POLL_ATTEMPTS {
+                let reply = bench.log_tail(&addr, None);
+                if let LogTailResult::Ok {
+                    ref entries,
+                    next_since,
+                    ..
+                } = reply
+                    && let Some(entry) = entries
+                        .iter()
+                        .find(|e| e.message == "typed_send_alive" && e.level == LEVEL_INFO)
+                {
+                    found = Some((entry.clone(), next_since));
+                    break;
+                }
+                last_reply = Some(reply);
+                thread::sleep(POLL_INTERVAL);
+            }
+
+            let (entry, next_since) = found.unwrap_or_else(|| {
+                panic!(
+                    "probe's `typed_send_alive` info entry never appeared after {POLL_ATTEMPTS} \
+                     polls; last reply: {last_reply:?}",
+                )
+            });
+
+            assert!(
+                entry.sequence >= 1,
+                "a buffered entry should carry a 1-based ring sequence, got {}",
+                entry.sequence,
+            );
+
+            // Walk the cursor: a re-query past `next_since` must not re-yield
+            // the entry we already consumed.
+            match bench.log_tail(&addr, Some(next_since)) {
+                LogTailResult::Ok { entries, .. } => assert!(
+                    entries.iter().all(|e| e.sequence != entry.sequence),
+                    "the `since` cursor should not re-yield the already-seen entry \
+                     (seq {}): {entries:?}",
+                    entry.sequence,
+                ),
+                LogTailResult::Err { error } => {
+                    panic!("cursor re-query LogTail failed: {error}")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #1856.

## Summary

Adds a test-bench reader for guest-emitted logs: `TestBench::log_tail(mailbox_name, since)` beside `count_observed` / `observed_kinds`, mirroring the FleetBench log surface. Lets `cargo test` scenarios assert on per-actor log ring entries (level, sequence, `next_since` pagination) without a live MCP session.

## Test plan

New `test_bench_logs` scenario: loads the probe, advances a tick, polls `log_tail` until the `typed_send_alive` info entry appears, then re-queries past `next_since` and asserts no re-yield. Full workspace green: clippy `-D warnings`, nextest `--workspace` (1835 passed), doc.

## Generated by

`/implement` — agent execution of [scoped issue #1856](https://github.com/iamacoffeepot/aether/issues/1856).
