### PR TITLE
refactor(capabilities): migrate fs, handle, inventory, dag to reply classes

### DIFF
--- a/crates/aether-capabilities/src/dag.rs
+++ b/crates/aether-capabilities/src/dag.rs
@@ -42,9 +42,9 @@ mod native {
     use std::time::Duration;
 
     use super::{Cancel, DagReapTick, DagTransformDone, Settled, Status, Submit};
-    use aether_actor::{OutboundReply, actor};
+    use aether_actor::actor;
     use aether_data::{Kind, KindId, MailId, MailboxId};
-    use aether_kinds::{StatusResult, SubmitResult};
+    use aether_kinds::{CancelResult, StatusResult, SubmitResult};
     use aether_substrate::Mail;
     use aether_substrate::actor::native::envelope::Envelope;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
@@ -131,8 +131,8 @@ mod native {
         /// # Agent
         /// Reply: `SubmitResult`.
         #[handler]
-        fn on_submit(&mut self, ctx: &mut NativeCtx<'_>, mail: Submit) {
-            let reply = match self.executor.submit(ctx, mail.descriptor) {
+        fn on_submit(&mut self, ctx: &mut NativeCtx<'_>, mail: Submit) -> SubmitResult {
+            match self.executor.submit(ctx, mail.descriptor) {
                 SubmitOutcome::Ok {
                     dag_id,
                     output_handles,
@@ -141,8 +141,7 @@ mod native {
                     output_handles,
                 },
                 SubmitOutcome::Err { error } => SubmitResult::Err { error },
-            };
-            ctx.reply(&reply);
+            }
         }
 
         /// Cancel an in-flight DAG by its `DagId` (ADR-0047 §5).
@@ -150,9 +149,8 @@ mod native {
         /// # Agent
         /// Reply: `CancelResult`.
         #[handler]
-        fn on_cancel(&mut self, ctx: &mut NativeCtx<'_>, mail: Cancel) {
-            let reply = self.executor.cancel(mail.dag_id);
-            ctx.reply(&reply);
+        fn on_cancel(&mut self, _ctx: &mut NativeCtx<'_>, mail: Cancel) -> CancelResult {
+            self.executor.cancel(mail.dag_id)
         }
 
         /// Query a DAG's execution status (ADR-0047 §1/§6). An unknown
@@ -163,15 +161,13 @@ mod native {
         /// # Agent
         /// Reply: `StatusResult`.
         #[handler]
-        fn on_status(&mut self, ctx: &mut NativeCtx<'_>, mail: Status) {
-            let reply = self
-                .executor
+        fn on_status(&mut self, _ctx: &mut NativeCtx<'_>, mail: Status) -> StatusResult {
+            self.executor
                 .status(mail.dag_id)
                 .unwrap_or_else(|| StatusResult::Failed {
                     node_id: aether_kinds::NodeId(0),
                     error: format!("unknown dag {}", mail.dag_id),
-                });
-            ctx.reply(&reply);
+                })
         }
 
         /// Settlement notice for a `Call` dispatch (ADR-0047 §4 step 4).

--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -430,7 +430,7 @@ mod native {
         AdapterRegistry, Delete, FsError, List, NamespaceRoots, NamespaceRootsLayer, Read, Write,
         build_registry,
     };
-    use aether_actor::{OutboundReply, actor};
+    use aether_actor::actor;
     use aether_kinds::{DeleteResult, ListResult, ReadResult, WriteResult};
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
@@ -517,8 +517,8 @@ mod native {
     /// `aether.fs` mailbox cap. Owns the resolved adapter registry +
     /// namespace roots. The dispatcher thread holds an `Arc<Self>` and
     /// routes envelopes through the macro-emitted `NativeDispatch` impl;
-    /// replies route via `ctx.reply(&result)` through the substrate's
-    /// `Mailer::send_reply`.
+    /// replies are returned directly from `#[handler]` methods (ADR-0112)
+    /// and dispatched through the substrate's `Mailer::send_reply`.
     pub struct FsCapability {
         registry: Arc<AdapterRegistry>,
     }
@@ -555,16 +555,15 @@ mod native {
         /// # Agent
         /// Reply: `ReadResult`. Echoes namespace + path on both arms.
         #[handler]
-        fn on_read(&self, ctx: &mut NativeCtx<'_>, mail: Read) {
+        fn on_read(&self, _ctx: &mut NativeCtx<'_>, mail: Read) -> ReadResult {
             let Some(adapter) = self.registry.get(&mail.namespace) else {
-                ctx.reply(&ReadResult::Err {
+                return ReadResult::Err {
                     namespace: mail.namespace,
                     path: mail.path,
                     error: FsError::UnknownNamespace,
-                });
-                return;
+                };
             };
-            let reply = match adapter.read(&mail.path) {
+            match adapter.read(&mail.path) {
                 Ok(bytes) => ReadResult::Ok {
                     namespace: mail.namespace,
                     path: mail.path,
@@ -575,8 +574,7 @@ mod native {
                     path: mail.path,
                     error,
                 },
-            };
-            ctx.reply(&reply);
+            }
         }
 
         /// Write bytes to a logical namespace path. Atomic via tmp+rename
@@ -586,16 +584,15 @@ mod native {
         /// # Agent
         /// Reply: `WriteResult`. Echoes namespace + path (NOT bytes).
         #[handler]
-        fn on_write(&self, ctx: &mut NativeCtx<'_>, mail: Write) {
+        fn on_write(&self, _ctx: &mut NativeCtx<'_>, mail: Write) -> WriteResult {
             let Some(adapter) = self.registry.get(&mail.namespace) else {
-                ctx.reply(&WriteResult::Err {
+                return WriteResult::Err {
                     namespace: mail.namespace,
                     path: mail.path,
                     error: FsError::UnknownNamespace,
-                });
-                return;
+                };
             };
-            let reply = match adapter.write(&mail.path, &mail.bytes) {
+            match adapter.write(&mail.path, &mail.bytes) {
                 Ok(()) => WriteResult::Ok {
                     namespace: mail.namespace,
                     path: mail.path,
@@ -605,8 +602,7 @@ mod native {
                     path: mail.path,
                     error,
                 },
-            };
-            ctx.reply(&reply);
+            }
         }
 
         /// Delete a path under a namespace.
@@ -614,16 +610,15 @@ mod native {
         /// # Agent
         /// Reply: `DeleteResult`. Echoes namespace + path.
         #[handler]
-        fn on_delete(&self, ctx: &mut NativeCtx<'_>, mail: Delete) {
+        fn on_delete(&self, _ctx: &mut NativeCtx<'_>, mail: Delete) -> DeleteResult {
             let Some(adapter) = self.registry.get(&mail.namespace) else {
-                ctx.reply(&DeleteResult::Err {
+                return DeleteResult::Err {
                     namespace: mail.namespace,
                     path: mail.path,
                     error: FsError::UnknownNamespace,
-                });
-                return;
+                };
             };
-            let reply = match adapter.delete(&mail.path) {
+            match adapter.delete(&mail.path) {
                 Ok(()) => DeleteResult::Ok {
                     namespace: mail.namespace,
                     path: mail.path,
@@ -633,8 +628,7 @@ mod native {
                     path: mail.path,
                     error,
                 },
-            };
-            ctx.reply(&reply);
+            }
         }
 
         /// List entries under a namespace prefix.
@@ -642,16 +636,15 @@ mod native {
         /// # Agent
         /// Reply: `ListResult`. Echoes namespace + prefix.
         #[handler]
-        fn on_list(&self, ctx: &mut NativeCtx<'_>, mail: List) {
+        fn on_list(&self, _ctx: &mut NativeCtx<'_>, mail: List) -> ListResult {
             let Some(adapter) = self.registry.get(&mail.namespace) else {
-                ctx.reply(&ListResult::Err {
+                return ListResult::Err {
                     namespace: mail.namespace,
                     prefix: mail.prefix,
                     error: FsError::UnknownNamespace,
-                });
-                return;
+                };
             };
-            let reply = match adapter.list(&mail.prefix) {
+            match adapter.list(&mail.prefix) {
                 Ok(entries) => ListResult::Ok {
                     namespace: mail.namespace,
                     prefix: mail.prefix,
@@ -662,8 +655,7 @@ mod native {
                     prefix: mail.prefix,
                     error,
                 },
-            };
-            ctx.reply(&reply);
+            }
         }
     }
 
@@ -694,13 +686,10 @@ mod native {
         use aether_substrate::chassis::error::BootError;
         use aether_substrate::mail::Source;
 
-        use crate::test_chassis::{
-            TestChassis, cleanup, decode_reply, fresh_substrate, scratch_dir,
-        };
+        use crate::test_chassis::{TestChassis, cleanup, fresh_substrate, scratch_dir};
         use aether_substrate::mail::SourceAddr;
         use aether_substrate::mail::registry;
         use std::fs;
-        use std::sync::mpsc::Receiver;
 
         // ADR-0090: the confique migration is byte-identical to the prior
         // `env_or_default` reader. These exercise resolution without
@@ -736,17 +725,15 @@ mod native {
         /// and a `NativeBinding` long enough for handlers to borrow.
         struct TestFixture {
             cap: FsCapability,
-            rx: Receiver<EgressEvent>,
             transport: Arc<NativeBinding>,
         }
 
         impl TestFixture {
             fn new(reg: Arc<AdapterRegistry>) -> Self {
-                let (mailer, rx) = test_mailer_and_rx();
+                let (mailer, _rx) = test_mailer_and_rx();
                 let transport = Arc::new(NativeBinding::new_for_test(mailer, MailboxId(0)));
                 Self {
                     cap: FsCapability::from_registry(reg),
-                    rx,
                     transport,
                 }
             }
@@ -985,7 +972,6 @@ mod native {
         }
 
         use aether_data::{SessionToken, Uuid};
-        use aether_substrate::mail::outbound::EgressEvent;
 
         fn build_save_only_registry(root: &Path, writable: bool) -> Arc<AdapterRegistry> {
             let adapter: Arc<dyn FileAdapter> = Arc::new(
@@ -1077,14 +1063,14 @@ mod native {
                 .expect("test setup: adapter accepts write");
             let fix = TestFixture::new(reg);
             let mut ctx = fix.ctx(session_sender());
-            fix.cap.on_read(
+            let result = fix.cap.on_read(
                 &mut ctx,
                 Read {
                     namespace: "save".to_string(),
                     path: "slot.bin".to_string(),
                 },
             );
-            match decode_reply::<ReadResult>(&fix.rx) {
+            match result {
                 ReadResult::Ok {
                     namespace,
                     path,
@@ -1105,14 +1091,14 @@ mod native {
             let reg = build_save_only_registry(&root, true);
             let fix = TestFixture::new(reg);
             let mut ctx = fix.ctx(session_sender());
-            fix.cap.on_read(
+            let result = fix.cap.on_read(
                 &mut ctx,
                 Read {
                     namespace: "nope".to_string(),
                     path: "x.bin".to_string(),
                 },
             );
-            match decode_reply::<ReadResult>(&fix.rx) {
+            match result {
                 ReadResult::Err {
                     namespace,
                     path,
@@ -1132,7 +1118,7 @@ mod native {
             let reg = build_save_only_registry(&root, true);
             let fix = TestFixture::new(reg);
             let mut ctx = fix.ctx(session_sender());
-            fix.cap.on_read(
+            let result = fix.cap.on_read(
                 &mut ctx,
                 Read {
                     namespace: "save".to_string(),
@@ -1140,7 +1126,7 @@ mod native {
                 },
             );
             assert!(matches!(
-                decode_reply::<ReadResult>(&fix.rx),
+                result,
                 ReadResult::Err {
                     error: FsError::NotFound,
                     ..
@@ -1156,7 +1142,7 @@ mod native {
             let reg_clone = Arc::clone(&reg);
             let fix = TestFixture::new(reg);
             let mut ctx = fix.ctx(session_sender());
-            fix.cap.on_write(
+            let result = fix.cap.on_write(
                 &mut ctx,
                 Write {
                     namespace: "save".to_string(),
@@ -1164,7 +1150,7 @@ mod native {
                     bytes: vec![1, 2, 3],
                 },
             );
-            match decode_reply::<WriteResult>(&fix.rx) {
+            match result {
                 WriteResult::Ok { namespace, path } => {
                     assert_eq!(namespace, "save");
                     assert_eq!(path, "slot.bin");
@@ -1188,7 +1174,7 @@ mod native {
             let reg = build_save_only_registry(&root, false);
             let fix = TestFixture::new(reg);
             let mut ctx = fix.ctx(session_sender());
-            fix.cap.on_write(
+            let result = fix.cap.on_write(
                 &mut ctx,
                 Write {
                     namespace: "save".to_string(),
@@ -1197,7 +1183,7 @@ mod native {
                 },
             );
             assert!(matches!(
-                decode_reply::<WriteResult>(&fix.rx),
+                result,
                 WriteResult::Err {
                     error: FsError::Forbidden,
                     ..
@@ -1217,14 +1203,14 @@ mod native {
                 .expect("test setup: adapter accepts write");
             let fix = TestFixture::new(reg);
             let mut ctx = fix.ctx(session_sender());
-            fix.cap.on_delete(
+            let result = fix.cap.on_delete(
                 &mut ctx,
                 Delete {
                     namespace: "save".to_string(),
                     path: "x.bin".to_string(),
                 },
             );
-            match decode_reply::<DeleteResult>(&fix.rx) {
+            match result {
                 DeleteResult::Ok { namespace, path } => {
                     assert_eq!(namespace, "save");
                     assert_eq!(path, "x.bin");
@@ -1255,14 +1241,14 @@ mod native {
                 .expect("test setup: adapter accepts a.bin write");
             let fix = TestFixture::new(reg);
             let mut ctx = fix.ctx(session_sender());
-            fix.cap.on_list(
+            let result = fix.cap.on_list(
                 &mut ctx,
                 List {
                     namespace: "save".to_string(),
                     prefix: String::new(),
                 },
             );
-            match decode_reply::<ListResult>(&fix.rx) {
+            match result {
                 ListResult::Ok {
                     namespace,
                     prefix,

--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -1,5 +1,5 @@
 //! `aether.handle` cap. Owns the substrate's `HandleStore` and routes
-//! ADR-0045 publish/release/pin/unpin requests via `ctx.reply(&result)`.
+//! ADR-0045 publish/release/pin/unpin requests via ADR-0112 `-> R` handlers.
 //! Decode failure on a malformed payload goes through the macro miss
 //! path (warn-log, no reply, so the sender's correlated reply handler
 //! never fires) — substrate-level invariant violation, not
@@ -24,7 +24,7 @@ mod native {
     use std::sync::Arc;
 
     use super::{HandleDescribe, HandlePin, HandlePublish, HandleRelease, HandleUnpin};
-    use aether_actor::{OutboundReply, actor};
+    use aether_actor::actor;
     use aether_kinds::{
         HandleDescribeResult, HandleError, HandlePinResult, HandlePublishResult,
         HandleReleaseResult, HandleSummary, HandleUnpinResult,
@@ -63,7 +63,7 @@ mod native {
         /// # Agent
         /// Reply: `HandlePublishResult`.
         #[handler]
-        fn on_publish(&self, ctx: &mut NativeCtx<'_>, mail: HandlePublish) {
+        fn on_publish(&self, _ctx: &mut NativeCtx<'_>, mail: HandlePublish) -> HandlePublishResult {
             let id = self.store.next_ephemeral();
             match self.store.put(id, mail.kind_id, mail.bytes) {
                 Ok(()) => {
@@ -72,17 +72,15 @@ mod native {
                     // on zero the entry stays in the store (subject
                     // to LRU eviction under pressure).
                     self.store.inc_ref(id);
-                    ctx.reply(&HandlePublishResult::Ok {
+                    HandlePublishResult::Ok {
                         kind_id: mail.kind_id,
                         id,
-                    });
+                    }
                 }
-                Err(e) => {
-                    ctx.reply(&HandlePublishResult::Err {
-                        kind_id: mail.kind_id,
-                        error: put_error_to_handle_error(e),
-                    });
-                }
+                Err(e) => HandlePublishResult::Err {
+                    kind_id: mail.kind_id,
+                    error: put_error_to_handle_error(e),
+                },
             }
         }
 
@@ -92,14 +90,14 @@ mod native {
         /// # Agent
         /// Reply: `HandleReleaseResult`.
         #[handler]
-        fn on_release(&self, ctx: &mut NativeCtx<'_>, mail: HandleRelease) {
+        fn on_release(&self, _ctx: &mut NativeCtx<'_>, mail: HandleRelease) -> HandleReleaseResult {
             if self.store.dec_ref(mail.id) {
-                ctx.reply(&HandleReleaseResult::Ok { id: mail.id });
+                HandleReleaseResult::Ok { id: mail.id }
             } else {
-                ctx.reply(&HandleReleaseResult::Err {
+                HandleReleaseResult::Err {
                     id: mail.id,
                     error: HandleError::UnknownHandle,
-                });
+                }
             }
         }
 
@@ -108,14 +106,14 @@ mod native {
         /// # Agent
         /// Reply: `HandlePinResult`.
         #[handler]
-        fn on_pin(&self, ctx: &mut NativeCtx<'_>, mail: HandlePin) {
+        fn on_pin(&self, _ctx: &mut NativeCtx<'_>, mail: HandlePin) -> HandlePinResult {
             if self.store.pin(mail.id) {
-                ctx.reply(&HandlePinResult::Ok { id: mail.id });
+                HandlePinResult::Ok { id: mail.id }
             } else {
-                ctx.reply(&HandlePinResult::Err {
+                HandlePinResult::Err {
                     id: mail.id,
                     error: HandleError::UnknownHandle,
-                });
+                }
             }
         }
 
@@ -124,14 +122,14 @@ mod native {
         /// # Agent
         /// Reply: `HandleUnpinResult`.
         #[handler]
-        fn on_unpin(&self, ctx: &mut NativeCtx<'_>, mail: HandleUnpin) {
+        fn on_unpin(&self, _ctx: &mut NativeCtx<'_>, mail: HandleUnpin) -> HandleUnpinResult {
             if self.store.unpin(mail.id) {
-                ctx.reply(&HandleUnpinResult::Ok { id: mail.id });
+                HandleUnpinResult::Ok { id: mail.id }
             } else {
-                ctx.reply(&HandleUnpinResult::Err {
+                HandleUnpinResult::Err {
                     id: mail.id,
                     error: HandleError::UnknownHandle,
-                });
+                }
             }
         }
 
@@ -142,10 +140,14 @@ mod native {
         /// # Agent
         /// Reply: `HandleDescribeResult`.
         #[handler]
-        fn on_describe(&self, ctx: &mut NativeCtx<'_>, mail: HandleDescribe) {
+        fn on_describe(
+            &self,
+            _ctx: &mut NativeCtx<'_>,
+            mail: HandleDescribe,
+        ) -> HandleDescribeResult {
             let max = clamp_describe_max(mail.max);
             let snap = self.store.inspect(max);
-            ctx.reply(&snapshot_to_result(&snap));
+            snapshot_to_result(&snap)
         }
     }
 
@@ -260,7 +262,7 @@ mod native {
             /// `HandlePublish` mail at the registered mailbox, the dispatcher
             /// thread runs the macro-emitted `NativeDispatch::__aether_dispatch_envelope`
             /// which calls `on_publish`, the reply lands on the hub-outbound
-            /// channel via `ctx.reply(&HandlePublishResult::Ok)` →
+            /// channel via the ADR-0112 `-> R` reply path →
             /// `Mailer::send_reply` → `outbound.send_reply`.
             #[test]
             fn capability_routes_publish_through_dispatcher_thread() {

--- a/crates/aether-capabilities/src/inventory.rs
+++ b/crates/aether-capabilities/src/inventory.rs
@@ -4,7 +4,7 @@
 //! (the MCP harness) reads the running substrate's **own, per-build**
 //! state instead of a drift-prone compiled-in copy.
 //!
-//! Four request kinds, each replying synchronously via `ctx.reply`:
+//! Four request kinds, each replying synchronously (ADR-0112 `-> R`):
 //!
 //! - [`Manifest`] → [`ManifestResult`]: the compile-time manifest —
 //!   every link-time [`NameEntry`](aether_data::name_inventory::NameEntry)
@@ -61,7 +61,7 @@ mod native {
         Resolve, ResolveResult,
     };
 
-    use aether_actor::{OutboundReply, actor};
+    use aether_actor::actor;
     use aether_data::KindId;
     use aether_data::canonical::kind_id_from_parts;
     use aether_data::name_inventory::{
@@ -152,7 +152,7 @@ mod native {
         // signature, not a state read here.
         #[allow(clippy::unused_self)]
         #[handler]
-        fn on_manifest(&mut self, ctx: &mut NativeCtx<'_>, _mail: Manifest) {
+        fn on_manifest(&mut self, _ctx: &mut NativeCtx<'_>, _mail: Manifest) -> ManifestResult {
             let names = name_entries()
                 .map(|entry| NameEntryWire {
                     domain: entry.domain.to_vec(),
@@ -170,7 +170,7 @@ mod native {
                     cardinality: cardinality_wire(&entry.cardinality),
                 })
                 .collect();
-            ctx.reply(&ManifestResult { names, templates });
+            ManifestResult { names, templates }
         }
 
         /// Reply with the substrate's live kind vocabulary: every
@@ -191,7 +191,7 @@ mod native {
         /// no `Schema` impl of its own; decode it with
         /// `postcard::from_bytes::<SchemaType>(&desc.schema_postcard)`.
         #[handler]
-        fn on_list_kinds(&mut self, ctx: &mut NativeCtx<'_>, _mail: ListKinds) {
+        fn on_list_kinds(&mut self, _ctx: &mut NativeCtx<'_>, _mail: ListKinds) -> ListKindsResult {
             let kinds = self
                 .registry
                 .list_kind_descriptors()
@@ -211,7 +211,7 @@ mod native {
                     }
                 })
                 .collect();
-            ctx.reply(&ListKindsResult { kinds });
+            ListKindsResult { kinds }
         }
 
         /// Resolve each requested tagged-id string to its origin name via
@@ -230,7 +230,7 @@ mod native {
         // signature, not a state read.
         #[allow(clippy::unused_self)]
         #[handler]
-        fn on_resolve(&mut self, ctx: &mut NativeCtx<'_>, mail: Resolve) {
+        fn on_resolve(&mut self, _ctx: &mut NativeCtx<'_>, mail: Resolve) -> ResolveResult {
             let resolved = mail
                 .ids
                 .into_iter()
@@ -242,7 +242,7 @@ mod native {
                     ResolvedName { id, name }
                 })
                 .collect();
-            ctx.reply(&ResolveResult { resolved });
+            ResolveResult { resolved }
         }
 
         /// Reply with the native handler manifest (ADR-0109 §5): every
@@ -266,7 +266,7 @@ mod native {
         // not a state read.
         #[allow(clippy::unused_self)]
         #[handler]
-        fn on_handlers(&mut self, ctx: &mut NativeCtx<'_>, _mail: ListHandlers) {
+        fn on_handlers(&mut self, _ctx: &mut NativeCtx<'_>, _mail: ListHandlers) -> HandlersResult {
             let handlers = handler_entries()
                 .map(|entry| HandlerEntryWire {
                     namespace: entry.namespace.into(),
@@ -275,7 +275,7 @@ mod native {
                     reply: entry.reply,
                 })
                 .collect();
-            ctx.reply(&HandlersResult { handlers });
+            HandlersResult { handlers }
         }
     }
 
@@ -288,20 +288,16 @@ mod native {
         use aether_substrate::actor::native::binding::NativeBinding;
         use aether_substrate::handle_store::HandleStore;
         use aether_substrate::mail::mailer::Mailer;
-        use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
+        use aether_substrate::mail::outbound::HubOutbound;
         use aether_substrate::mail::registry::Registry;
         use aether_substrate::mail::{Source, SourceAddr};
         use aether_substrate::runtime::thread_name::register;
         use std::sync::Arc;
-        use std::sync::mpsc::Receiver;
 
-        use crate::test_chassis::decode_reply;
-
-        /// Cap + loopback mailer + transport wired so `ctx.reply`
-        /// egresses as a `ToSession` event the test can decode. Mirrors
-        /// the `trace.rs` `DispatchTracedFixture` shape.
+        /// Cap + fully-wired test mailer + `NativeBinding` transport.
+        /// Handlers are called directly and return their result; no egress
+        /// channel decode needed (ADR-0112 `-> R` migration).
         struct Fixture {
-            rx: Receiver<EgressEvent>,
             transport: Arc<NativeBinding>,
             cap: InventoryCapability,
         }
@@ -309,7 +305,7 @@ mod native {
         fn fixture() -> Fixture {
             let registry = Arc::new(Registry::new());
             let store = Arc::new(HandleStore::new(1024 * 1024));
-            let (outbound, rx) = HubOutbound::attached_loopback();
+            let (outbound, _rx) = HubOutbound::attached_loopback();
             let mailer = Arc::new(
                 Mailer::new(Arc::clone(&registry), Arc::clone(&store)).with_outbound(outbound),
             );
@@ -318,7 +314,6 @@ mod native {
                 MailboxId(0x1117),
             ));
             Fixture {
-                rx,
                 transport,
                 cap: InventoryCapability {
                     registry: Arc::clone(&registry),
@@ -354,10 +349,9 @@ mod native {
 
             let mut fix = fixture();
             let mut ctx = session_ctx(&fix.transport);
-            fix.cap.on_manifest(&mut ctx, Manifest {});
+            let result = fix.cap.on_manifest(&mut ctx, Manifest {});
             drop(ctx);
 
-            let result = decode_reply::<ManifestResult>(&fix.rx);
             assert!(
                 result.names.iter().any(|n| n.name == "aether.fs"),
                 "manifest should carry the aether.fs chassis mailbox NameEntry; names: {:?}",
@@ -396,10 +390,9 @@ mod native {
 
             let mut fix = fixture();
             let mut ctx = session_ctx(&fix.transport);
-            fix.cap.on_manifest(&mut ctx, Manifest {});
+            let result = fix.cap.on_manifest(&mut ctx, Manifest {});
             drop(ctx);
 
-            let result = decode_reply::<ManifestResult>(&fix.rx);
             let trampoline = result
                 .templates
                 .iter()
@@ -448,10 +441,9 @@ mod native {
                 .expect("register fresh kind");
 
             let mut ctx = session_ctx(&fix.transport);
-            fix.cap.on_list_kinds(&mut ctx, ListKinds {});
+            let result = fix.cap.on_list_kinds(&mut ctx, ListKinds {});
             drop(ctx);
 
-            let result = decode_reply::<ListKindsResult>(&fix.rx);
             let entry = result
                 .kinds
                 .iter()
@@ -499,7 +491,7 @@ mod native {
 
             let mut fix = fixture();
             let mut ctx = session_ctx(&fix.transport);
-            fix.cap.on_resolve(
+            let result = fix.cap.on_resolve(
                 &mut ctx,
                 Resolve {
                     ids: vec![
@@ -511,8 +503,6 @@ mod native {
                 },
             );
             drop(ctx);
-
-            let result = decode_reply::<ResolveResult>(&fix.rx);
             assert_eq!(result.resolved.len(), 4, "one entry per requested id");
 
             assert_eq!(result.resolved[0].id, registered_tag);
@@ -607,10 +597,9 @@ mod native {
 
             let mut fix = fixture();
             let mut ctx = session_ctx(&fix.transport);
-            fix.cap.on_handlers(&mut ctx, ListHandlers {});
+            let result = fix.cap.on_handlers(&mut ctx, ListHandlers {});
             drop(ctx);
 
-            let result = decode_reply::<HandlersResult>(&fix.rx);
             let entry = result
                 .handlers
                 .iter()

--- a/crates/aether-capabilities/src/test_chassis.rs
+++ b/crates/aether-capabilities/src/test_chassis.rs
@@ -187,7 +187,11 @@ where
 /// Decode the *next* egress as a `ToSession` reply of kind `K`. Strict
 /// sibling of [`decode_session_reply`]: it asserts the immediately
 /// following egress is a `ToSession` carrying `K`, rather than reading
-/// past bubble-ups. For cap tests whose handler re-replies exactly once.
+/// past bubble-ups. For cap tests that drive via the full dispatcher and
+/// egress channel (e.g. `render-native`) rather than direct `-> R` calls.
+// Used by render.rs tests (feature = "render-native"); dead_code fires in
+// the default build without that feature.
+#[allow(dead_code)]
 pub fn decode_reply<K>(rx: &Receiver<EgressEvent>) -> K
 where
     K: Kind + DeserializeOwned,


### PR DESCRIPTION
Closes #1874.

## Summary

Migrates 16 reply-bearing handlers across `fs.rs`, `handle.rs`, `inventory.rs`, and `dag.rs` from `ctx.reply(&result)` to the ADR-0112 single reply class (`#[handler] -> R`). Early-return branches become `return FooResult::Err { .. }`; the macro emits the reply from the return type, so a `-> R` handler's manifest reply contract is true by construction. `OutboundReply` is dropped from all four imports.

## Test plan

Direct-call unit tests adapted to capture the returned result instead of decoding from the egress channel; the `mod heavy` dispatcher-thread tests are unchanged. Full workspace green: clippy `-D warnings`, nextest `--workspace` (1834 passed), doc.

## Generated by

`/implement` — agent execution of [scoped issue #1874](https://github.com/iamacoffeepot/aether/issues/1874).
