### PR TITLE
refactor(capabilities): migrate render, window, input, text to reply classes

### DIFF
--- a/crates/aether-capabilities/src/input.rs
+++ b/crates/aether-capabilities/src/input.rs
@@ -158,7 +158,6 @@ mod native {
         SubscribeInputSelf, UnsubscribeAll, UnsubscribeInput, UnsubscribeInputSelf, WindowSize,
     };
     use aether_actor::actor;
-    use aether_actor::actor::ctx::OutboundReply;
     use aether_data::{Kind, KindId};
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
@@ -214,8 +213,12 @@ mod native {
         /// `SubscribeInput { kind, mailbox }`. Component mailboxes only —
         /// sinks and dropped mailboxes are rejected.
         #[handler]
-        fn on_subscribe(&mut self, ctx: &mut NativeCtx<'_>, payload: SubscribeInput) {
-            let result = match validate_subscriber_mailbox(&self.registry, payload.mailbox) {
+        fn on_subscribe(
+            &mut self,
+            _ctx: &mut NativeCtx<'_>,
+            payload: SubscribeInput,
+        ) -> SubscribeInputResult {
+            match validate_subscriber_mailbox(&self.registry, payload.mailbox) {
                 Ok(()) => {
                     self.subscribers
                         .entry(payload.kind)
@@ -224,8 +227,7 @@ mod native {
                     SubscribeInputResult::Ok
                 }
                 Err(error) => SubscribeInputResult::Err { error },
-            };
-            ctx.reply(&result);
+            }
         }
 
         /// Subscribe the *sending* actor to an input stream (ADR-0021,
@@ -243,8 +245,12 @@ mod native {
         /// # Agent
         /// `SubscribeInputSelf { kind }`.
         #[handler]
-        fn on_subscribe_self(&mut self, ctx: &mut NativeCtx<'_>, payload: SubscribeInputSelf) {
-            let result = match ctx.source_mailbox() {
+        fn on_subscribe_self(
+            &mut self,
+            ctx: &mut NativeCtx<'_>,
+            payload: SubscribeInputSelf,
+        ) -> SubscribeInputResult {
+            match ctx.source_mailbox() {
                 Some(mailbox) => {
                     self.subscribers
                         .entry(payload.kind)
@@ -258,8 +264,7 @@ mod native {
                             with an explicit mailbox"
                         .to_string(),
                 },
-            };
-            ctx.reply(&result);
+            }
         }
 
         /// Unsubscribe a mailbox from an input stream (ADR-0021).
@@ -268,8 +273,12 @@ mod native {
         /// `UnsubscribeInput { kind, mailbox }`. Idempotent on
         /// "not currently subscribed"; rejects unknown / sink mailboxes.
         #[handler]
-        fn on_unsubscribe(&mut self, ctx: &mut NativeCtx<'_>, payload: UnsubscribeInput) {
-            let result = match validate_subscriber_mailbox(&self.registry, payload.mailbox) {
+        fn on_unsubscribe(
+            &mut self,
+            _ctx: &mut NativeCtx<'_>,
+            payload: UnsubscribeInput,
+        ) -> SubscribeInputResult {
+            match validate_subscriber_mailbox(&self.registry, payload.mailbox) {
                 Ok(()) => {
                     if let Some(set) = self.subscribers.get_mut(&payload.kind) {
                         set.remove(&payload.mailbox);
@@ -277,8 +286,7 @@ mod native {
                     SubscribeInputResult::Ok
                 }
                 Err(error) => SubscribeInputResult::Err { error },
-            };
-            ctx.reply(&result);
+            }
         }
 
         /// Unsubscribe the *sending* actor from an input stream
@@ -290,8 +298,12 @@ mod native {
         /// # Agent
         /// `UnsubscribeInputSelf { kind }`.
         #[handler]
-        fn on_unsubscribe_self(&mut self, ctx: &mut NativeCtx<'_>, payload: UnsubscribeInputSelf) {
-            let result = match ctx.source_mailbox() {
+        fn on_unsubscribe_self(
+            &mut self,
+            ctx: &mut NativeCtx<'_>,
+            payload: UnsubscribeInputSelf,
+        ) -> SubscribeInputResult {
+            match ctx.source_mailbox() {
                 Some(mailbox) => {
                     if let Some(set) = self.subscribers.get_mut(&payload.kind) {
                         set.remove(&mailbox);
@@ -304,8 +316,7 @@ mod native {
                             with an explicit mailbox"
                         .to_string(),
                 },
-            };
-            ctx.reply(&result);
+            }
         }
 
         /// Remove `mailbox` from every input stream's subscriber set.

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -62,12 +62,13 @@ mod native {
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::{Mutex, OnceLock};
 
-    use aether_actor::{OutboundReply, actor};
+    use aether_actor::actor;
     use aether_data::Kind;
     use aether_kinds::{
         CaptureFrameResult, CreateTextureResult, DRAW_TRIANGLE_BYTES, QuadScale, QuadSpace,
         SimilarityCheck, SolidQuad, TexturedQuad,
     };
+    use aether_substrate::Manual;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::capture::{CaptureQueue, PendingCapture, ReferenceCapture};
     use aether_substrate::chassis::error::BootError;
@@ -453,8 +454,8 @@ mod native {
         /// for an atomic "set X, capture, restore X" call. Reply is
         /// `aether.render.capture_frame_result` carrying the PNG on
         /// success or a free-form reason on failure.
-        #[handler]
-        fn on_capture_frame(&self, ctx: &mut NativeCtx<'_>, mail: CaptureFrame) {
+        #[handler::manual]
+        fn on_capture_frame(&self, ctx: &mut NativeCtx<'_, Manual>, mail: CaptureFrame) {
             if let Some(obs) = &self.config.observed_kinds {
                 obs.lock()
                     .expect("mutex poisoned; fail-fast per ADR-0063")
@@ -599,7 +600,11 @@ mod native {
         /// the reply `aether.render.create_texture_result` carries the
         /// `texture_id` to thread into `draw_textured_quads`.
         #[handler]
-        fn on_create_texture(&self, ctx: &mut NativeCtx<'_>, mail: CreateTexture) {
+        fn on_create_texture(
+            &self,
+            _ctx: &mut NativeCtx<'_>,
+            mail: CreateTexture,
+        ) -> CreateTextureResult {
             if let Some(obs) = &self.config.observed_kinds {
                 obs.lock()
                     .expect("mutex poisoned; fail-fast per ADR-0063")
@@ -607,22 +612,20 @@ mod native {
             }
             let expected = expected_pixel_bytes(mail.width, mail.height);
             let Some(expected) = expected else {
-                ctx.reply(&CreateTextureResult::Err {
+                return CreateTextureResult::Err {
                     error: format!(
                         "texture dimensions {}x{} overflow or are zero",
                         mail.width, mail.height
                     ),
-                });
-                return;
+                };
             };
             if mail.pixels.len() != expected {
-                ctx.reply(&CreateTextureResult::Err {
+                return CreateTextureResult::Err {
                     error: format!(
                         "pixels length {} does not match width*height*4 = {expected}",
                         mail.pixels.len()
                     ),
-                });
-                return;
+                };
             }
             let mut registry = self
                 .handles
@@ -642,7 +645,7 @@ mod native {
                 },
             );
             drop(registry);
-            ctx.reply(&CreateTextureResult::Ok { texture_id });
+            CreateTextureResult::Ok { texture_id }
         }
 
         /// `UpdateTexture` handler (ADR-0105). Overwrites a sub-rectangle
@@ -1646,6 +1649,7 @@ mod native_headless {
 
     use aether_actor::actor;
     use aether_kinds::{CaptureFrameResult, CreateTextureResult};
+    use aether_substrate::Manual;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
     use aether_substrate::mail::outbound::HubOutbound;
@@ -1709,8 +1713,8 @@ mod native_headless {
         /// fails fast on headless instead of hanging on a reply that
         /// never comes. Mirrors ADR-0035 §Consequences fail-fast shape
         /// for `set_window_mode`.
-        #[handler]
-        fn on_capture_frame(&self, ctx: &mut NativeCtx<'_>, _mail: CaptureFrame) {
+        #[handler::manual]
+        fn on_capture_frame(&self, ctx: &mut NativeCtx<'_, Manual>, _mail: CaptureFrame) {
             self.outbound.send_reply(
                 ctx.reply_target(),
                 &CaptureFrameResult::Err {
@@ -1723,8 +1727,8 @@ mod native_headless {
         /// texture against a headless chassis fails fast instead of
         /// waiting on a reply that never comes — same fail-fast shape as
         /// `on_capture_frame` (ADR-0105).
-        #[handler]
-        fn on_create_texture(&self, ctx: &mut NativeCtx<'_>, _mail: CreateTexture) {
+        #[handler::manual]
+        fn on_create_texture(&self, ctx: &mut NativeCtx<'_, Manual>, _mail: CreateTexture) {
             self.outbound.send_reply(
                 ctx.reply_target(),
                 &CreateTextureResult::Err {
@@ -1778,7 +1782,7 @@ mod native_headless {
                 Arc::clone(&mailer),
                 MailboxId(0),
             ));
-            let mut ctx = NativeCtx::new(
+            let mut ctx = NativeCtx::new_dispatching(
                 &transport,
                 Source::to(SourceAddr::Session(SessionToken(Uuid::nil()))),
                 aether_data::MailId::NONE,

--- a/crates/aether-capabilities/src/text.rs
+++ b/crates/aether-capabilities/src/text.rs
@@ -57,6 +57,7 @@ mod native {
         CreateTexture, DrawTexturedQuads, LoadFontResult, QuadSpace, Read, TexturedQuad,
         UpdateTexture,
     };
+    use aether_substrate::Manual;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
     use aether_substrate::chassis::error::BootError;
 
@@ -208,8 +209,8 @@ mod native {
         /// replies `Ok { font_id, name, resident_bytes }` once registered
         /// or `Err` with the failure reason (bad path, or an unparseable
         /// file). The `font_id` is session-scoped — thread it into `draw`.
-        #[handler]
-        fn on_load_font(&mut self, ctx: &mut NativeCtx<'_>, mail: LoadFont) {
+        #[handler::manual]
+        fn on_load_font(&mut self, ctx: &mut NativeCtx<'_, Manual>, mail: LoadFont) {
             let source = ctx.reply_target();
             let key = (mail.namespace.clone(), mail.path.clone());
             self.pending_fonts
@@ -230,8 +231,8 @@ mod native {
         /// font parse off the hot path, pinning its deferred reply to the
         /// original `load_font` caller; `Err` relays the fs error to that
         /// caller as `LoadFontResult::Err`.
-        #[handler]
-        fn on_read_result(&mut self, ctx: &mut NativeCtx<'_>, mail: ReadResult) {
+        #[handler::manual]
+        fn on_read_result(&mut self, ctx: &mut NativeCtx<'_, Manual>, mail: ReadResult) {
             match mail {
                 ReadResult::Ok {
                     namespace,
@@ -597,7 +598,8 @@ mod native {
         fn load_font_parks_request_and_forwards_read() {
             let mut cap = TextCapability::new();
             let (binding, rx) = ctx_binding();
-            let mut ctx = NativeCtx::new(&binding, session_sender(), MailId::NONE, MailId::NONE);
+            let mut ctx =
+                NativeCtx::new_dispatching(&binding, session_sender(), MailId::NONE, MailId::NONE);
             cap.on_load_font(
                 &mut ctx,
                 LoadFont {
@@ -613,7 +615,8 @@ mod native {
         fn read_err_replies_load_font_err_and_clears_pending() {
             let mut cap = TextCapability::new();
             let (binding, rx) = ctx_binding();
-            let mut ctx = NativeCtx::new(&binding, session_sender(), MailId::NONE, MailId::NONE);
+            let mut ctx =
+                NativeCtx::new_dispatching(&binding, session_sender(), MailId::NONE, MailId::NONE);
             cap.on_load_font(
                 &mut ctx,
                 LoadFont {
@@ -625,7 +628,7 @@ mod native {
             assert_next_send_kind::<Read>(&binding, &rx);
 
             let mut read_ctx =
-                NativeCtx::new(&binding, session_sender(), MailId::NONE, MailId::NONE);
+                NativeCtx::new_dispatching(&binding, session_sender(), MailId::NONE, MailId::NONE);
             cap.on_read_result(
                 &mut read_ctx,
                 ReadResult::Err {
@@ -645,7 +648,8 @@ mod native {
         fn malformed_font_bytes_reply_err() {
             let mut cap = TextCapability::new();
             let (binding, rx) = ctx_binding();
-            let mut ctx = NativeCtx::new(&binding, session_sender(), MailId::NONE, MailId::NONE);
+            let mut ctx =
+                NativeCtx::new_dispatching(&binding, session_sender(), MailId::NONE, MailId::NONE);
             cap.on_load_font(
                 &mut ctx,
                 LoadFont {
@@ -656,7 +660,7 @@ mod native {
             assert_next_send_kind::<Read>(&binding, &rx);
 
             let mut read_ctx =
-                NativeCtx::new(&binding, session_sender(), MailId::NONE, MailId::NONE);
+                NativeCtx::new_dispatching(&binding, session_sender(), MailId::NONE, MailId::NONE);
             cap.on_read_result(
                 &mut read_ctx,
                 ReadResult::Ok {

--- a/crates/aether-capabilities/src/window.rs
+++ b/crates/aether-capabilities/src/window.rs
@@ -15,7 +15,7 @@ use aether_kinds::{FocusWindow, SetWindowMode, SetWindowTitle};
 
 #[aether_actor::bridge(singleton)]
 mod native {
-    use aether_actor::{OutboundReply, actor};
+    use aether_actor::actor;
     use aether_kinds::{FocusWindowResult, SetWindowModeResult, SetWindowTitleResult};
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
@@ -58,19 +58,27 @@ mod native {
         // capability is stateless, so the reply routes purely off `ctx`.
         #[allow(clippy::unused_self)]
         #[handler]
-        fn on_set_mode(&self, ctx: &mut NativeCtx<'_>, _mail: SetWindowMode) {
-            ctx.reply(&SetWindowModeResult::Err {
+        fn on_set_mode(
+            &self,
+            _ctx: &mut NativeCtx<'_>,
+            _mail: SetWindowMode,
+        ) -> SetWindowModeResult {
+            SetWindowModeResult::Err {
                 error: "unsupported on this chassis — no window peripheral".to_owned(),
-            });
+            }
         }
 
         /// Reply `Err` for the same reason as `on_set_mode`.
         #[allow(clippy::unused_self)]
         #[handler]
-        fn on_set_title(&self, ctx: &mut NativeCtx<'_>, _mail: SetWindowTitle) {
-            ctx.reply(&SetWindowTitleResult::Err {
+        fn on_set_title(
+            &self,
+            _ctx: &mut NativeCtx<'_>,
+            _mail: SetWindowTitle,
+        ) -> SetWindowTitleResult {
+            SetWindowTitleResult::Err {
                 error: "unsupported on this chassis — no window peripheral".to_owned(),
-            });
+            }
         }
 
         /// Reply `Err` for the same reason as `on_set_mode`
@@ -78,10 +86,10 @@ mod native {
         /// peripheral can't foreground one.
         #[allow(clippy::unused_self)]
         #[handler]
-        fn on_focus(&self, ctx: &mut NativeCtx<'_>, _mail: FocusWindow) {
-            ctx.reply(&FocusWindowResult::Err {
+        fn on_focus(&self, _ctx: &mut NativeCtx<'_>, _mail: FocusWindow) -> FocusWindowResult {
+            FocusWindowResult::Err {
                 error: "unsupported on this chassis — no window peripheral".to_owned(),
-            });
+            }
         }
     }
 
@@ -92,12 +100,14 @@ mod native {
     )]
     mod tests {
         use super::*;
-        use aether_data::{MailId, Source, SourceAddr};
+        use aether_data::{Kind, MailId, Source, SourceAddr};
         use aether_kinds::{FocusWindow, SetWindowMode, SetWindowTitle, WindowMode};
         use aether_substrate::actor::native::binding::NativeBinding;
         use aether_substrate::handle_store::HandleStore;
         use aether_substrate::mail::mailer::Mailer;
-        use aether_substrate::{HubOutbound, InboxHandler, MailboxId, OwnedDispatch, Registry};
+        use aether_substrate::{
+            HubOutbound, InboxHandler, MailboxId, NativeDispatch, OwnedDispatch, Registry,
+        };
         use std::sync::Arc;
         use std::sync::mpsc;
         use std::time::Duration;
@@ -128,8 +138,9 @@ mod native {
         /// `focus` reply from the headless window cap joins the caller's
         /// causal chain — the reply's `Sent` holds the root open until its
         /// `Finished` fires, instead of detaching through the lineage-less
-        /// unchained path. Each handler routes through the typed
-        /// `ctx.reply()`, so they all share the proof.
+        /// unchained path. Each handler is a single-class `-> R` handler;
+        /// the macro-emitted dispatch issues the reply so they all share the
+        /// proof via the dispatch trampoline (ADR-0112).
         #[test]
         fn err_reply_joins_caller_chain() {
             let (mailer, caller_mailbox, reply_rx) = settlement_substrate();
@@ -138,12 +149,13 @@ mod native {
                 Arc::clone(&mailer),
                 MailboxId(0),
             ));
-            let cap = HeadlessWindowCapability;
+            let mut cap = HeadlessWindowCapability;
 
-            // Run each handler under its own root and assert the reply
-            // holds, then settles, that root.
+            // Run each handler under its own root through the dispatch
+            // trampoline (ADR-0112: `NativeCtx::new_dispatching` + `__aether_dispatch_envelope`)
+            // and assert the reply holds, then settles, that root.
             let mut next_correlation = 0_u64;
-            let mut drive = |handler: &dyn Fn(&HeadlessWindowCapability, &mut NativeCtx<'_>)| {
+            let mut drive = |kind_id: aether_data::KindId, payload: &[u8]| {
                 next_correlation += 1;
                 let root = MailId::new(MailboxId(0x1710), next_correlation);
                 let caller_source = Source::with_correlation(
@@ -152,14 +164,14 @@ mod native {
                 );
 
                 {
-                    let mut ctx = NativeCtx::new(&transport, caller_source, root, root);
-                    handler(&cap, &mut ctx);
+                    let mut ctx = NativeCtx::new_dispatching(&transport, caller_source, root, root);
+                    cap.__aether_dispatch_envelope(&mut ctx, kind_id, payload);
                 }
 
                 assert_eq!(
                     counter.live_roots(),
                     1,
-                    "the in-handler reply holds the caller chain open",
+                    "the macro-emitted reply holds the caller chain open",
                 );
                 let dispatch = reply_rx
                     .recv_timeout(Duration::from_secs(2))
@@ -173,27 +185,23 @@ mod native {
                 );
             };
 
-            drive(&|cap, ctx| {
-                cap.on_set_mode(
-                    ctx,
-                    SetWindowMode {
-                        mode: WindowMode::Windowed,
-                        width: None,
-                        height: None,
-                    },
-                );
-            });
-            drive(&|cap, ctx| {
-                cap.on_set_title(
-                    ctx,
-                    SetWindowTitle {
-                        title: "test".to_owned(),
-                    },
-                );
-            });
-            drive(&|cap, ctx| {
-                cap.on_focus(ctx, FocusWindow {});
-            });
+            drive(
+                SetWindowMode::ID,
+                &SetWindowMode {
+                    mode: WindowMode::Windowed,
+                    width: None,
+                    height: None,
+                }
+                .encode_into_bytes(),
+            );
+            drive(
+                SetWindowTitle::ID,
+                &SetWindowTitle {
+                    title: "test".to_owned(),
+                }
+                .encode_into_bytes(),
+            );
+            drive(FocusWindow::ID, &FocusWindow {}.encode_into_bytes());
         }
     }
 }


### PR DESCRIPTION
Closes #1876.

## Summary

Migrates 13 handlers across `render.rs`, `window.rs`, `input.rs`, and `text.rs` onto the ADR-0112 reply classes — unconditional repliers become `#[handler] -> R`, the redirecting / conditional ones (`on_capture_frame`, headless render, `on_load_font`, `on_read_result`) become `#[handler::manual]` with `NativeCtx<'_, Manual>`. Behavior-preserving; `OutboundReply` dropped where no longer used.

## Test plan

Test call sites that drive migrated handlers directly updated to `NativeCtx::new_dispatching` so the macro-emitted reply still exercises the settlement chain. Full workspace green: clippy `-D warnings`, nextest `--workspace` (1834 passed), doc, wasm32 cross-build.

## Generated by

`/implement` — agent execution of [scoped issue #1876](https://github.com/iamacoffeepot/aether/issues/1876).
