### PR TITLE
refactor(capabilities): migrate tcp, http, server caps to reply classes

### DIFF
--- a/crates/aether-capabilities/src/engine/server.rs
+++ b/crates/aether-capabilities/src/engine/server.rs
@@ -57,7 +57,7 @@ mod server_native {
         EngineAlive, EngineDied, ListEngines, RouteEnvelope, SpawnEngine, TerminateEngine,
     };
     use crate::engine::proxy::{EngineProxy, EngineProxyConfig, HeartbeatParams};
-    use aether_actor::{OutboundReply, actor};
+    use aether_actor::actor;
     use aether_data::{EngineId, Kind, MailboxId, Uuid};
     use aether_kinds::{
         CallSettled, EngineDescriptor, ForwardEnvelope, ListEnginesResult, SpawnEngineResult,
@@ -216,7 +216,7 @@ mod server_native {
         /// Send `ListEngines` (fieldless). Reply: `ListEnginesResult
         /// { engines: [{ engine_id, rpc_port, last_heartbeat_age_millis }] }`.
         #[handler]
-        fn on_list(&mut self, ctx: &mut NativeCtx<'_>, _mail: ListEngines) {
+        fn on_list(&mut self, _ctx: &mut NativeCtx<'_>, _mail: ListEngines) -> ListEnginesResult {
             let now = Instant::now();
             let engines = self
                 .engines
@@ -230,7 +230,7 @@ mod server_native {
                     .unwrap_or(u64::MAX),
                 })
                 .collect();
-            ctx.reply(&ListEnginesResult { engines });
+            ListEnginesResult { engines }
         }
 
         /// Fork+exec a substrate binary and connect a proxy to it.
@@ -244,14 +244,13 @@ mod server_native {
         /// or `Err { error }` if the fork fails or the substrate never
         /// comes up.
         #[handler]
-        fn on_spawn(&mut self, ctx: &mut NativeCtx<'_>, mail: SpawnEngine) {
+        fn on_spawn(&mut self, ctx: &mut NativeCtx<'_>, mail: SpawnEngine) -> SpawnEngineResult {
             let rpc_port = match free_local_port() {
                 Ok(port) => port,
                 Err(e) => {
-                    ctx.reply(&SpawnEngineResult::Err {
+                    return SpawnEngineResult::Err {
                         error: format!("could not allocate an RPC port: {e}"),
-                    });
-                    return;
+                    };
                 }
             };
 
@@ -281,10 +280,9 @@ mod server_native {
             let child = match command.spawn() {
                 Ok(child) => child,
                 Err(e) => {
-                    ctx.reply(&SpawnEngineResult::Err {
+                    return SpawnEngineResult::Err {
                         error: format!("failed to spawn {}: {e}", mail.binary_path),
-                    });
-                    return;
+                    };
                 }
             };
 
@@ -319,16 +317,14 @@ mod server_native {
                             last_alive: Instant::now(),
                         },
                     );
-                    ctx.reply(&SpawnEngineResult::Ok {
+                    SpawnEngineResult::Ok {
                         engine_id: engine_id.0.to_string(),
                         rpc_port,
-                    });
+                    }
                 }
-                Err(e) => {
-                    ctx.reply(&SpawnEngineResult::Err {
-                        error: format!("proxy failed to connect to the spawned substrate: {e:?}"),
-                    });
-                }
+                Err(e) => SpawnEngineResult::Err {
+                    error: format!("proxy failed to connect to the spawned substrate: {e:?}"),
+                },
             }
         }
 
@@ -343,22 +339,24 @@ mod server_native {
         /// for an `engine_id` that doesn't parse or names no
         /// supervised engine.
         #[handler]
-        fn on_terminate(&mut self, ctx: &mut NativeCtx<'_>, mail: TerminateEngine) {
+        fn on_terminate(
+            &mut self,
+            ctx: &mut NativeCtx<'_>,
+            mail: TerminateEngine,
+        ) -> TerminateEngineResult {
             let engine_id = match Uuid::parse_str(&mail.engine_id) {
                 Ok(uuid) => EngineId(uuid),
                 Err(e) => {
-                    ctx.reply(&TerminateEngineResult::Err {
+                    return TerminateEngineResult::Err {
                         error: format!("engine_id {:?} is not a valid UUID: {e}", mail.engine_id),
-                    });
-                    return;
+                    };
                 }
             };
 
             let Some(entry) = self.engines.remove(&engine_id) else {
-                ctx.reply(&TerminateEngineResult::Err {
+                return TerminateEngineResult::Err {
                     error: format!("no supervised engine {}", mail.engine_id),
-                });
-                return;
+                };
             };
 
             // Forward to the proxy: it SIGKILLs its substrate and
@@ -371,7 +369,7 @@ mod server_native {
                 <TerminateEngine as Kind>::ID,
                 &payload,
             );
-            ctx.reply(&TerminateEngineResult::Ok);
+            TerminateEngineResult::Ok
         }
 
         /// Relay one mail to a specific engine's substrate.

--- a/crates/aether-capabilities/src/http.rs
+++ b/crates/aether-capabilities/src/http.rs
@@ -310,7 +310,7 @@ mod native {
         DisabledHttpAdapter, Fetch, FetchRequest, FetchResponse, HttpAdapter, HttpConfig,
         HttpError, HttpHeader, HttpMethod,
     };
-    use aether_actor::{OutboundReply, actor};
+    use aether_actor::actor;
     use aether_kinds::FetchResult;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
@@ -550,7 +550,7 @@ mod native {
         /// Reply: `FetchResult`. Synchronous on the dispatcher thread —
         /// long-running fetches block other HTTP mail until they finish.
         #[handler]
-        fn on_fetch(&self, ctx: &mut NativeCtx<'_>, mail: Fetch) {
+        fn on_fetch(&self, _ctx: &mut NativeCtx<'_>, mail: Fetch) -> FetchResult {
             let timeout = mail.timeout_ms.map_or(self.default_timeout, |ms| {
                 Duration::from_millis(u64::from(ms))
             });
@@ -564,7 +564,7 @@ mod native {
                 timeout,
             };
 
-            let reply = match self.adapter.fetch(adapter_req) {
+            match self.adapter.fetch(adapter_req) {
                 Ok(r) => FetchResult::Ok {
                     url,
                     status: r.status,
@@ -572,8 +572,7 @@ mod native {
                     body: r.body,
                 },
                 Err(error) => FetchResult::Err { url, error },
-            };
-            ctx.reply(&reply);
+            }
         }
     }
 
@@ -590,7 +589,7 @@ mod native {
             build_http_adapter,
         };
         use aether_actor::Actor;
-        use aether_data::{Kind, MailboxId};
+        use aether_data::MailboxId;
         use aether_substrate::actor::native::binding::NativeBinding;
         use aether_substrate::actor::native::ctx::NativeCtx;
         use aether_substrate::chassis::builder::Builder;
@@ -599,8 +598,6 @@ mod native {
 
         use crate::test_chassis::{TestChassis, fresh_substrate};
         use aether_substrate::mail::registry;
-        use serde::de::DeserializeOwned;
-        use std::sync::mpsc::Receiver;
 
         // ADR-0090: the confique migration is byte-identical to the prior
         // hand-rolled reader. These exercise the resolution logic without
@@ -691,27 +688,11 @@ mod native {
 
         use aether_data::{SessionToken, SourceAddr, Uuid};
 
-        use aether_substrate::mail::outbound::EgressEvent;
-
         fn session_sender() -> Source {
             Source::to(SourceAddr::Session(SessionToken(Uuid::nil())))
         }
 
         use crate::test_chassis::test_mailer_and_rx;
-
-        fn decode_reply<K: Kind + DeserializeOwned>(rx: &Receiver<EgressEvent>) -> K {
-            let event = rx
-                .recv_timeout(Duration::from_secs(1))
-                .expect("test: egress event arrives within 1s deadline");
-            let EgressEvent::ToSession {
-                kind_name, payload, ..
-            } = event
-            else {
-                panic!("expected ToSession egress, got {event:?}");
-            };
-            assert_eq!(kind_name, K::NAME);
-            postcard::from_bytes(&payload).expect("test: reply payload decodes via postcard")
-        }
 
         /// Boot the cap against a default disabled `HttpConfig` and confirm
         /// the mailbox is registered.
@@ -756,7 +737,7 @@ mod native {
 
         #[test]
         fn disabled_adapter_replies_disabled() {
-            let (mailer, rx) = test_mailer_and_rx();
+            let (mailer, _) = test_mailer_and_rx();
             let cap = HttpCapability::from_adapter(
                 Arc::new(DisabledHttpAdapter),
                 HttpConfig::default().default_timeout,
@@ -768,7 +749,7 @@ mod native {
                 aether_data::MailId::NONE,
                 aether_data::MailId::NONE,
             );
-            cap.on_fetch(
+            match cap.on_fetch(
                 &mut ctx,
                 Fetch {
                     url: "https://api.example.com/".to_string(),
@@ -777,8 +758,7 @@ mod native {
                     body: vec![],
                     timeout_ms: None,
                 },
-            );
-            match decode_reply::<FetchResult>(&rx) {
+            ) {
                 FetchResult::Err {
                     url,
                     error: HttpError::Disabled,
@@ -862,7 +842,7 @@ mod native {
 
         #[test]
         fn cap_fetch_ok_replies_with_response() {
-            let (mailer, rx) = test_mailer_and_rx();
+            let (mailer, _) = test_mailer_and_rx();
             let stub = StubAdapter::with(Ok(FetchResponse {
                 status: 200,
                 headers: vec![HttpHeader {
@@ -882,7 +862,7 @@ mod native {
                 aether_data::MailId::NONE,
                 aether_data::MailId::NONE,
             );
-            cap.on_fetch(
+            match cap.on_fetch(
                 &mut ctx,
                 Fetch {
                     url: "https://api.example.com/v1".to_string(),
@@ -891,8 +871,7 @@ mod native {
                     body: vec![],
                     timeout_ms: Some(5000),
                 },
-            );
-            match decode_reply::<FetchResult>(&rx) {
+            ) {
                 FetchResult::Ok {
                     url,
                     status,
@@ -910,7 +889,7 @@ mod native {
 
         #[test]
         fn cap_fetch_err_echoes_url_and_error() {
-            let (mailer, rx) = test_mailer_and_rx();
+            let (mailer, _) = test_mailer_and_rx();
             let cap = HttpCapability::from_adapter(
                 StubAdapter::with(Err(HttpError::Timeout)) as Arc<dyn HttpAdapter>,
                 HttpConfig::default().default_timeout,
@@ -922,7 +901,7 @@ mod native {
                 aether_data::MailId::NONE,
                 aether_data::MailId::NONE,
             );
-            cap.on_fetch(
+            match cap.on_fetch(
                 &mut ctx,
                 Fetch {
                     url: "https://slow.example.com/".to_string(),
@@ -931,8 +910,7 @@ mod native {
                     body: vec![],
                     timeout_ms: None,
                 },
-            );
-            match decode_reply::<FetchResult>(&rx) {
+            ) {
                 FetchResult::Err { url, error } => {
                     assert_eq!(url, "https://slow.example.com/");
                     assert_eq!(error, HttpError::Timeout);
@@ -961,7 +939,7 @@ mod native {
                 aether_data::MailId::NONE,
                 aether_data::MailId::NONE,
             );
-            cap.on_fetch(
+            let _ = cap.on_fetch(
                 &mut ctx,
                 Fetch {
                     url: "https://api.example.com/".to_string(),
@@ -996,10 +974,5 @@ mod native {
             });
             assert!(matches!(resp, Err(HttpError::Disabled)));
         }
-
-        /// Silence `Kind` unused-import (handy for the test mod's
-        /// `decode_reply` bound).
-        #[allow(dead_code)]
-        fn _silence_kind<K: Kind>() {}
     }
 }

--- a/crates/aether-capabilities/src/http_server.rs
+++ b/crates/aether-capabilities/src/http_server.rs
@@ -1148,7 +1148,7 @@ mod test_handlers {
     #[aether_actor::bridge(singleton)]
     mod echo_handler {
         use super::{HttpHeader, HttpServerRequest, HttpServerResponse};
-        use aether_actor::{actor, actor::ctx::OutboundReply};
+        use aether_actor::actor;
         use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
         use aether_substrate::chassis::error::BootError;
 
@@ -1165,7 +1165,11 @@ mod test_handlers {
 
             #[allow(clippy::unused_self)]
             #[handler]
-            fn on_request(&mut self, ctx: &mut NativeCtx<'_>, request: HttpServerRequest) {
+            fn on_request(
+                &mut self,
+                _ctx: &mut NativeCtx<'_>,
+                request: HttpServerRequest,
+            ) -> HttpServerResponse {
                 let headers = vec![
                     HttpHeader {
                         name: "x-aether-method".to_string(),
@@ -1184,11 +1188,11 @@ mod test_handlers {
                         value: "text/plain".to_string(),
                     },
                 ];
-                ctx.reply(&HttpServerResponse {
+                HttpServerResponse {
                     status: 200,
                     headers,
                     body: request.body,
-                });
+                }
             }
         }
     }

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -329,8 +329,8 @@ mod cap_native {
         BindListenerResult, Close, ListListenersResult, ListenerInfo, TcpListenerActor,
         TcpListenerConfig, UnbindListenerResult,
     };
-    use aether_actor::actor;
     use aether_actor::actor::ctx::OutboundReply;
+    use aether_actor::{Manual, actor};
     use aether_substrate::actor::monitor::MonitorHandle;
     use aether_substrate::actor::native::spawn::Subname;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
@@ -404,25 +404,23 @@ mod cap_native {
         /// Reply: `BindListenerResult`. `Ok` on successful bind +
         /// spawn; `Err` on addr parse / bind / spawn / monitor failure.
         #[handler]
-        fn on_bind(&mut self, ctx: &mut NativeCtx<'_>, mail: BindListener) {
+        fn on_bind(&mut self, ctx: &mut NativeCtx<'_>, mail: BindListener) -> BindListenerResult {
             let listener = match TcpListener::bind(&mail.addr) {
                 Ok(l) => l,
                 Err(e) => {
-                    ctx.reply(&BindListenerResult::Err {
+                    return BindListenerResult::Err {
                         addr: mail.addr,
                         reason: format!("bind failed: {e}"),
-                    });
-                    return;
+                    };
                 }
             };
             let local_port = match listener.local_addr() {
                 Ok(addr) => addr.port(),
                 Err(e) => {
-                    ctx.reply(&BindListenerResult::Err {
+                    return BindListenerResult::Err {
                         addr: mail.addr,
                         reason: format!("local_addr failed: {e}"),
-                    });
-                    return;
+                    };
                 }
             };
             let subname_str = mail.name.clone().unwrap_or_else(|| format!("{local_port}"));
@@ -440,11 +438,10 @@ mod cap_native {
             {
                 Ok(id) => id,
                 Err(e) => {
-                    ctx.reply(&BindListenerResult::Err {
+                    return BindListenerResult::Err {
                         addr: mail.addr,
                         reason: format!("spawn failed: {e:?}"),
-                    });
-                    return;
+                    };
                 }
             };
 
@@ -458,11 +455,10 @@ mod cap_native {
                     // unlikely (listener was just inserted Live). Reply
                     // Err and let the listener live; chassis shutdown
                     // will reap it.
-                    ctx.reply(&BindListenerResult::Err {
+                    return BindListenerResult::Err {
                         addr: mail.addr,
                         reason: format!("monitor failed: {e:?}"),
-                    });
-                    return;
+                    };
                 }
             };
 
@@ -476,11 +472,11 @@ mod cap_native {
                 },
             );
 
-            ctx.reply(&BindListenerResult::Ok {
+            BindListenerResult::Ok {
                 listener_name: subname_str,
                 listener_id,
                 local_port,
-            });
+            }
         }
 
         /// Mail `Close` to the named listener and park the
@@ -491,8 +487,8 @@ mod cap_native {
         /// Reply: `UnbindListenerResult`. Asynchronous — the response
         /// fires after the listener's accept thread joins and its
         /// `MonitorNotice` arrives at this cap.
-        #[handler]
-        fn on_unbind(&mut self, ctx: &mut NativeCtx<'_>, mail: UnbindListener) {
+        #[handler::manual]
+        fn on_unbind(&mut self, ctx: &mut NativeCtx<'_, Manual>, mail: UnbindListener) {
             // Resolve listener_id from the cap-local supervisor map by
             // name. The cap is the source of truth for "what listeners
             // exist"; no registry walk needed.
@@ -533,7 +529,11 @@ mod cap_native {
         /// # Agent
         /// Reply: `ListListenersResult`.
         #[handler]
-        fn on_list(&mut self, ctx: &mut NativeCtx<'_>, _mail: ListListeners) {
+        fn on_list(
+            &mut self,
+            _ctx: &mut NativeCtx<'_>,
+            _mail: ListListeners,
+        ) -> ListListenersResult {
             let listeners: Vec<ListenerInfo> = self
                 .listeners
                 .values()
@@ -543,7 +543,7 @@ mod cap_native {
                     port: entry.port,
                 })
                 .collect();
-            ctx.reply(&ListListenersResult { listeners });
+            ListListenersResult { listeners }
         }
 
         /// Listener tombstoned — remove from the supervisor map and
@@ -554,8 +554,8 @@ mod cap_native {
         /// `on_bind`) fires this notice; if the close came from an
         /// unbind request, `pending_unbinds` has an entry with the
         /// originator to reply to.
-        #[handler]
-        fn on_monitor_notice(&mut self, ctx: &mut NativeCtx<'_>, notice: MonitorNotice) {
+        #[handler::manual]
+        fn on_monitor_notice(&mut self, ctx: &mut NativeCtx<'_, Manual>, notice: MonitorNotice) {
             // Drop the supervisor entry. The held MonitorHandle drops
             // here; deregister is idempotent with the close path's
             // forward-index drain.


### PR DESCRIPTION
Closes #1878.

## Summary

Migrates the tcp / http / server capability handlers onto the ADR-0112 reply classes across `tcp/mod.rs`, `http.rs`, `http_server.rs`, and `engine/server.rs` — unconditional repliers become `#[handler] -> R` (early exits as `return Err`, match arms as value expressions), redirecting ones (`on_unbind`, `on_monitor_notice`) become `#[handler::manual]`. Dead `decode_reply` helpers and now-unused `OutboundReply` imports removed.

## Test plan

Direct-call unit tests adapted to assert the returned result directly. Full workspace green: clippy `-D warnings`, nextest `--workspace` (1834 passed), doc.

## Generated by

`/implement` — agent execution of [scoped issue #1878](https://github.com/iamacoffeepot/aether/issues/1878).
