### PR TITLE
refactor(capabilities): migrate lifecycle, component, trace to reply classes

### DIFF
--- a/crates/aether-capabilities/src/lifecycle.rs
+++ b/crates/aether-capabilities/src/lifecycle.rs
@@ -503,8 +503,8 @@ mod native {
     use std::sync::Arc;
     use std::time::{Duration, Instant};
 
-    use aether_actor::actor;
     use aether_actor::actor::ctx::OutboundReply;
+    use aether_actor::{Manual, ReplyMode, actor};
     use aether_data::{Kind, KindId, MailboxId as DataMailboxId, mailbox_id_from_name};
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
@@ -685,12 +685,16 @@ mod native {
         /// `LifecycleSubscribe { stage, mailbox }`. Stage must be a kind
         /// id registered as a state or terminal in the lifecycle graph.
         #[handler]
-        fn on_subscribe(&mut self, ctx: &mut NativeCtx<'_>, payload: LifecycleSubscribe) {
+        fn on_subscribe(
+            &mut self,
+            _ctx: &mut NativeCtx<'_>,
+            payload: LifecycleSubscribe,
+        ) -> LifecycleSubscribeResult {
             let stage_kind = KindId(payload.stage);
             let mailbox = DataMailboxId(payload.mailbox);
             let known =
                 self.graph.state(stage_kind).is_some() || self.graph.is_terminal(stage_kind);
-            let result = if known {
+            if known {
                 self.subscribers
                     .entry(stage_kind)
                     .or_default()
@@ -703,8 +707,7 @@ mod native {
                         "stage {stage_kind:?} is not declared by this chassis's lifecycle graph"
                     ),
                 }
-            };
-            ctx.reply(&result);
+            }
         }
 
         /// Subscribe the *sending* actor to a lifecycle stage broadcast
@@ -722,9 +725,13 @@ mod native {
         /// `LifecycleSubscribeSelf { stage }`. Stage must be a kind id
         /// registered as a state or terminal in the lifecycle graph.
         #[handler]
-        fn on_subscribe_self(&mut self, ctx: &mut NativeCtx<'_>, payload: LifecycleSubscribeSelf) {
+        fn on_subscribe_self(
+            &mut self,
+            ctx: &mut NativeCtx<'_>,
+            payload: LifecycleSubscribeSelf,
+        ) -> LifecycleSubscribeResult {
             let stage_kind = KindId(payload.stage);
-            let result = match ctx.source_mailbox() {
+            match ctx.source_mailbox() {
                 None => LifecycleSubscribeResult::Err {
                     stage: payload.stage,
                     error: "aether.lifecycle.subscribe_self requires a local component sender; \
@@ -751,8 +758,7 @@ mod native {
                         }
                     }
                 }
-            };
-            ctx.reply(&result);
+            }
         }
 
         /// Unsubscribe a mailbox from a lifecycle stage broadcast.
@@ -761,12 +767,16 @@ mod native {
         /// # Agent
         /// `LifecycleUnsubscribe { stage, mailbox }`.
         #[handler]
-        fn on_unsubscribe(&mut self, ctx: &mut NativeCtx<'_>, payload: LifecycleUnsubscribe) {
+        fn on_unsubscribe(
+            &mut self,
+            _ctx: &mut NativeCtx<'_>,
+            payload: LifecycleUnsubscribe,
+        ) -> LifecycleSubscribeResult {
             let stage_kind = KindId(payload.stage);
             let mailbox = DataMailboxId(payload.mailbox);
             let known =
                 self.graph.state(stage_kind).is_some() || self.graph.is_terminal(stage_kind);
-            let result = if known {
+            if known {
                 if let Some(set) = self.subscribers.get_mut(&stage_kind) {
                     set.remove(&mailbox);
                 }
@@ -778,8 +788,7 @@ mod native {
                         "stage {stage_kind:?} is not declared by this chassis's lifecycle graph"
                     ),
                 }
-            };
-            ctx.reply(&result);
+            }
         }
 
         /// Unsubscribe the *sending* actor from a lifecycle stage
@@ -796,9 +805,9 @@ mod native {
             &mut self,
             ctx: &mut NativeCtx<'_>,
             payload: LifecycleUnsubscribeSelf,
-        ) {
+        ) -> LifecycleSubscribeResult {
             let stage_kind = KindId(payload.stage);
-            let result = match ctx.source_mailbox() {
+            match ctx.source_mailbox() {
                 None => LifecycleSubscribeResult::Err {
                     stage: payload.stage,
                     error: "aether.lifecycle.unsubscribe_self requires a local component sender; \
@@ -824,8 +833,7 @@ mod native {
                         }
                     }
                 }
-            };
-            ctx.reply(&result);
+            }
         }
 
         /// Remove `mailbox` from every lifecycle stage's subscriber set.
@@ -876,8 +884,8 @@ mod native {
         /// `LifecycleAdvance {}`. Sent by the chassis main loop each
         /// frame. Reply: [`LifecycleAdvanceComplete`] once the broadcast
         /// root settles.
-        #[handler]
-        fn on_advance(&mut self, ctx: &mut NativeCtx<'_>, _payload: LifecycleAdvance) {
+        #[handler::manual]
+        fn on_advance(&mut self, ctx: &mut NativeCtx<'_, Manual>, _payload: LifecycleAdvance) {
             if self.terminal_reached {
                 // Already done — reply immediately with zeros so the
                 // chassis main loop unblocks and can break on `next == 0`.
@@ -1012,8 +1020,8 @@ mod native {
         /// `Settled { root }`. Synthesised by the settlement registry
         /// when the in-flight count for `root` reaches zero; not a public
         /// API for user code.
-        #[handler]
-        fn on_settled(&mut self, ctx: &mut NativeCtx<'_>, payload: Settled) {
+        #[handler::manual]
+        fn on_settled(&mut self, ctx: &mut NativeCtx<'_, Manual>, payload: Settled) {
             let Some(pending) = self.pending.as_ref() else {
                 return;
             };
@@ -1108,7 +1116,7 @@ mod native {
         /// [`Self::on_settled`]'s state mutation + reply but logs at
         /// `error`: reaching here means the settlement pipeline stalled
         /// past `advance_timeout`. No-op when nothing is pending.
-        fn force_complete_pending(&mut self, ctx: &mut NativeCtx<'_>) {
+        fn force_complete_pending(&mut self, ctx: &mut NativeCtx<'_, Manual>) {
             let Some(pending) = self.pending.take() else {
                 return;
             };
@@ -1162,8 +1170,8 @@ mod native {
     /// state's), not a compile-site `K`; the path preserves the inbound
     /// `(parent, root)` lineage so settlement counts each child against
     /// the root (ADR-0080 §6).
-    fn broadcast_to_subscribers(
-        ctx: &mut NativeCtx<'_>,
+    fn broadcast_to_subscribers<M: ReplyMode>(
+        ctx: &mut NativeCtx<'_, M>,
         subscribers: &BTreeMap<KindId, BTreeSet<DataMailboxId>>,
         stage: KindId,
     ) {

--- a/crates/aether-capabilities/src/trace.rs
+++ b/crates/aether-capabilities/src/trace.rs
@@ -29,7 +29,7 @@ mod native {
     use super::{DispatchTraced, DispatchTracedAck};
     use std::sync::Arc;
 
-    use aether_actor::{OutboundReply, actor};
+    use aether_actor::actor;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
     use aether_substrate::mail::helpers::resolve_bundle;
@@ -92,7 +92,11 @@ mod native {
         /// `correlation_id`, so the RPC server's `on_any` fallback wraps
         /// each into a `ReplyEvent` on the wire.
         #[handler]
-        fn on_dispatch_traced(&mut self, ctx: &mut NativeCtx<'_>, batch: DispatchTraced) {
+        fn on_dispatch_traced(
+            &mut self,
+            ctx: &mut NativeCtx<'_>,
+            batch: DispatchTraced,
+        ) -> DispatchTracedAck {
             let root = ctx.in_flight_mail_id();
             let forward_reply_to = ctx.reply_target();
             let DispatchTraced { mails } = batch;
@@ -104,8 +108,7 @@ mod native {
             let resolved = match resolve_bundle(&self.registry, &mails, "dispatch_traced batch") {
                 Ok(v) => v,
                 Err(error) => {
-                    ctx.reply(&DispatchTracedAck::Err { error });
-                    return;
+                    return DispatchTracedAck::Err { error };
                 }
             };
             for mail in resolved {
@@ -116,7 +119,7 @@ mod native {
                     forward_reply_to,
                 );
             }
-            ctx.reply(&DispatchTracedAck::Ok { root });
+            DispatchTracedAck::Ok { root }
         }
     }
 
@@ -130,21 +133,17 @@ mod native {
         use aether_substrate::actor::native::binding::NativeBinding;
         use aether_substrate::handle_store::HandleStore;
         use aether_substrate::mail::mailer::Mailer;
-        use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
+        use aether_substrate::mail::outbound::HubOutbound;
         use aether_substrate::mail::registry::MailDispatch;
         use aether_substrate::mail::{Source, SourceAddr};
-        use std::sync::mpsc::Receiver;
-        use std::time::Duration;
 
         /// Shared scaffolding for the `on_dispatch_traced` tests:
         /// fresh registry + mailer + outbound + transport + cap wired
-        /// together with the `mailer.outbound -> rx` egress recorder.
-        /// The cap doesn't go through `init` (which reads ctx state);
-        /// construct it directly with the registry handle the resolve
-        /// path needs.
+        /// together. The cap doesn't go through `init` (which reads ctx
+        /// state); construct it directly with the registry handle the
+        /// resolve path needs.
         struct DispatchTracedFixture {
             registry: Arc<Registry>,
-            rx: Receiver<EgressEvent>,
             transport: Arc<NativeBinding>,
             cap: TraceDispatchCapability,
         }
@@ -152,7 +151,7 @@ mod native {
         fn dispatch_traced_fixture() -> DispatchTracedFixture {
             let registry = Arc::new(Registry::new());
             let store = Arc::new(HandleStore::new(1024 * 1024));
-            let (outbound, rx) = HubOutbound::attached_loopback();
+            let (outbound, _rx) = HubOutbound::attached_loopback();
             let mailer = Arc::new(
                 Mailer::new(Arc::clone(&registry), Arc::clone(&store)).with_outbound(outbound),
             );
@@ -163,7 +162,6 @@ mod native {
             let cap = TraceDispatchCapability::with_registry(Arc::clone(&registry));
             DispatchTracedFixture {
                 registry,
-                rx,
                 transport,
                 cap,
             }
@@ -175,23 +173,6 @@ mod native {
         fn chassis_root_ctx(transport: &Arc<NativeBinding>, inbound: MailId) -> NativeCtx<'_> {
             let sender = Source::to(SourceAddr::Session(SessionToken(Uuid::nil())));
             NativeCtx::new(transport, sender, inbound, inbound)
-        }
-
-        /// Drain `rx` until it goes quiet, decoding every
-        /// `DispatchTracedAck` `ToSession` egress it sees. Exactly one
-        /// ack is the success shape; the test asserts on `len()`.
-        fn drain_ack_replies(rx: &Receiver<EgressEvent>) -> Vec<DispatchTracedAck> {
-            let mut acks = Vec::new();
-            while let Ok(event) = rx.recv_timeout(Duration::from_millis(250)) {
-                if let EgressEvent::ToSession {
-                    kind_name, payload, ..
-                } = event
-                    && kind_name == <DispatchTracedAck as aether_data::Kind>::NAME
-                {
-                    acks.push(postcard::from_bytes(&payload).expect("ack payload decodes"));
-                }
-            }
-            acks
         }
 
         /// Issue 749: `on_dispatch_traced` resolves each envelope's
@@ -233,7 +214,7 @@ mod native {
 
             let inbound = MailId::new(MailboxId(0xC0DE), 7);
             let mut ctx = chassis_root_ctx(&fix.transport, inbound);
-            fix.cap.on_dispatch_traced(
+            let ack = fix.cap.on_dispatch_traced(
                 &mut ctx,
                 DispatchTraced {
                     mails: vec![
@@ -280,11 +261,9 @@ mod native {
                 "envelope B missing or chain not inherited; captured: {snapshot:?}"
             );
 
-            let acks = drain_ack_replies(&fix.rx);
-            assert_eq!(acks.len(), 1, "expected exactly one ack reply");
-            match &acks[0] {
+            match ack {
                 DispatchTracedAck::Ok { root } => assert_eq!(
-                    *root, inbound,
+                    root, inbound,
                     "Ok ack must echo the in-flight inbound mail id as the chassis root"
                 ),
                 DispatchTracedAck::Err { error } => {
@@ -302,7 +281,7 @@ mod native {
             let mut fix = dispatch_traced_fixture();
             let inbound = MailId::new(MailboxId(0xC0DE), 99);
             let mut ctx = chassis_root_ctx(&fix.transport, inbound);
-            fix.cap.on_dispatch_traced(
+            let ack = fix.cap.on_dispatch_traced(
                 &mut ctx,
                 DispatchTraced {
                     mails: vec![MailEnvelope {
@@ -314,12 +293,9 @@ mod native {
                 },
             );
 
-            let acks = drain_ack_replies(&fix.rx);
-            assert_eq!(acks.len(), 1);
             assert!(
-                matches!(&acks[0], DispatchTracedAck::Err { error } if error.contains("unknown recipient")),
-                "expected Err with 'unknown recipient' message, got: {:?}",
-                acks[0]
+                matches!(&ack, DispatchTracedAck::Err { error } if error.contains("unknown recipient")),
+                "expected Err with 'unknown recipient' message, got: {ack:?}"
             );
         }
     }

--- a/crates/aether-capabilities/src/trampoline.rs
+++ b/crates/aether-capabilities/src/trampoline.rs
@@ -77,7 +77,6 @@ mod native {
     use std::sync::Arc;
 
     use aether_actor::actor;
-    use aether_actor::actor::ctx::OutboundReply;
     use aether_kinds::{
         ComponentCapabilities, DropComponent, DropResult, ReplaceComponent, ReplaceResult,
     };
@@ -295,7 +294,11 @@ mod native {
         /// [`Self::forward_to_wasm`], which warn-drops because
         /// `self.component` is `None`.
         #[handler]
-        fn on_drop_component(&mut self, ctx: &mut NativeCtx<'_>, _payload: DropComponent) {
+        fn on_drop_component(
+            &mut self,
+            _ctx: &mut NativeCtx<'_>,
+            _payload: DropComponent,
+        ) -> DropResult {
             if let Some(mut component) = self.component.take() {
                 // Issue 584 Phase 3 (ADR-0079 amended): unwire is the
                 // single pre-shutdown hook — the legacy `on_drop`
@@ -315,7 +318,7 @@ mod native {
             // inside `with_stamped`, so both indexes clear together.
             self.mailer.cost_table().drop_mailbox(self.mailbox);
             CostCells::try_with_mut(|cells| cells.seed(Vec::new()));
-            ctx.reply(&DropResult::Ok);
+            DropResult::Ok
         }
 
         /// Replace the wasm component with a fresh module. ADR-0022 +
@@ -326,9 +329,12 @@ mod native {
         /// module instantiates against the same binding, and
         /// `on_rehydrate` runs on the fresh side.
         #[handler]
-        fn on_replace_component(&mut self, ctx: &mut NativeCtx<'_>, payload: ReplaceComponent) {
-            let result = self.handle_replace(payload);
-            ctx.reply(&result);
+        fn on_replace_component(
+            &mut self,
+            _ctx: &mut NativeCtx<'_>,
+            payload: ReplaceComponent,
+        ) -> ReplaceResult {
+            self.handle_replace(payload)
         }
 
         /// Forward un-handled mail to the wasm guest.


### PR DESCRIPTION
Closes #1877.

## Summary

Migrates the lifecycle / runtime capability handlers (`aether.lifecycle`, `aether.trace`, and the capability trampoline) onto the ADR-0112 reply classes — single replies become `#[handler] -> R`, redirect / conditional become `#[handler::manual]`. Behavior-preserving: the reply still happens, but the manifest stops reporting `None` for a handler that replies. `component.rs` is intentionally untouched (`on_load_component` was already migrated in #1871; its other handlers use inherent ctx methods, not `OutboundReply`).

## Test plan

Existing `mod tests` call sites adapted to the new return shapes; the dispatcher-thread `mod heavy` tests are unchanged (macro still replies at the dispatch layer). Full workspace green: clippy `-D warnings`, nextest `--workspace`, doc.

## Generated by

`/implement` — agent execution of [scoped issue #1877](https://github.com/iamacoffeepot/aether/issues/1877).
