### PR TITLE
feat(capabilities): position-stream recorder actor emitting a per-tick sample log handle

### DIFF
--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -74,8 +74,12 @@ pub mod render;
 pub mod rpc;
 pub mod tcp;
 pub mod test_bench;
+// `aether.trajectory` position-stream recorder cap (issue 1862). A
+// native-only cap that accumulates per-tick samples into a typed,
+// seed-keyed `TrajectoryLog` handle (ADR-0049) replayable offline.
 #[cfg(test)]
 pub(crate) mod test_chassis;
+pub mod trajectory;
 // `aether.text` cap (ADR-0105). CPU-only — composes the render texture
 // surface by mail — but feature-gated the two-layer way so a wasm
 // component can address it by type without pulling `fontdue` into the
@@ -168,6 +172,7 @@ pub use tcp::{TcpCapability, TcpListenerActor};
 pub use test_bench::UnsupportedTestBenchCapability;
 #[cfg(feature = "text")]
 pub use text::TextCapability;
+pub use trajectory::TrajectoryRecorderCapability;
 pub use trampoline::WasmTrampoline;
 #[cfg(not(target_arch = "wasm32"))]
 pub use trampoline::WasmTrampolineConfig;

--- a/crates/aether-capabilities/src/trajectory.rs
+++ b/crates/aether-capabilities/src/trajectory.rs
@@ -1,0 +1,586 @@
+//! `aether.trajectory` cap. Subscribes to a per-tick stream of a moving
+//! point's grid position plus a scalar accumulator value, accumulating
+//! samples into a typed, seed-keyed `TrajectoryLog` handle (ADR-0049)
+//! that an offline analysis transform can replay.
+//!
+//! State is a plain `sessions` `HashMap` plus an `Arc<HandleStore>` cloned
+//! at `init` from `ctx.mailer().handle_store()` — the same pattern as
+//! `HandleCapability`. Every handler runs on the cap's dispatcher thread
+//! (ADR-0078 plain-field, no locks). Registered as `aether.trajectory`
+//! via `with_common_caps` on desktop and headless chassis; the test-bench
+//! chassis adds it explicitly.
+//!
+//! Two handlers:
+//!
+//! - `on_sample` — fire-and-forget: append `(tick, x, y, value)` to the
+//!   buffer for `seed`, creating the buffer on first sample for that seed.
+//! - `on_end` — build a `TrajectoryLog { seed, samples, end_reason }`,
+//!   postcard-encode it via `encode_into_bytes`, publish it to the handle
+//!   store via `next_ephemeral` → `put` → `inc_ref`, drop the in-memory
+//!   buffer, and return `RecordResult` (ADR-0112 return-type reply form).
+
+// `#[handler]` methods take their decoded payload by value per the
+// ADR-0033 dispatch ABI; the macro-generated trampoline owns the
+// decoded bytes so callers can't see references.
+#![allow(clippy::needless_pass_by_value)]
+
+use aether_kinds::{TrajectoryEnd, TrajectorySample};
+
+#[aether_actor::bridge(singleton)]
+mod native {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use aether_actor::actor;
+    use aether_data::Kind;
+    use aether_kinds::{
+        RecordResult, TrajectoryEnd, TrajectoryLog, TrajectorySample, TrajectorySampleEntry,
+    };
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+    use aether_substrate::handle_store::HandleStore;
+
+    /// `aether.trajectory` mailbox cap. Accumulates per-tick samples
+    /// from a moving point into a typed `TrajectoryLog` handle (ADR-0049)
+    /// that an offline analysis transform can replay.
+    ///
+    /// State is plain fields — single-threaded, every handler on the
+    /// cap's dispatcher thread (ADR-0078). No locks needed.
+    pub struct TrajectoryRecorderCapability {
+        /// Per-seed in-flight sample buffers. Created on the first
+        /// `TrajectorySample` for a seed; flushed and removed on the
+        /// matching `TrajectoryEnd`.
+        sessions: HashMap<u64, Vec<TrajectorySampleEntry>>,
+        /// Shared handle store — cloned from the substrate's mailer at
+        /// `init`, the same as `HandleCapability`.
+        store: Arc<HandleStore>,
+    }
+
+    #[actor]
+    impl NativeActor for TrajectoryRecorderCapability {
+        type Config = ();
+
+        /// ADR-0074 §5: chassis-owned mailbox under the `aether.<name>`
+        /// namespace. Single-segment name matches the dominant chassis-cap
+        /// convention (`aether.input`, `aether.render`, `aether.handle`).
+        const NAMESPACE: &'static str = "aether.trajectory";
+
+        fn init((): (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            let store = Arc::clone(ctx.mailer().handle_store());
+            Ok(Self {
+                sessions: HashMap::new(),
+                store,
+            })
+        }
+
+        /// Append one per-tick sample to the in-flight buffer for
+        /// `s.seed`. Creates the buffer on first arrival for that seed.
+        /// Fire-and-forget — no reply.
+        ///
+        /// # Agent
+        /// No reply (fire-and-forget). Address this cap by type:
+        /// `ctx.actor::<TrajectoryRecorderCapability>().send(&sample)`.
+        #[handler]
+        fn on_sample(&mut self, _ctx: &mut NativeCtx<'_>, s: TrajectorySample) {
+            self.sessions
+                .entry(s.seed)
+                .or_default()
+                .push(TrajectorySampleEntry {
+                    tick: s.tick,
+                    x: s.x,
+                    y: s.y,
+                    value: s.value,
+                });
+        }
+
+        /// Flush the in-flight buffer for `e.seed`, build a
+        /// `TrajectoryLog`, publish it to the handle store, and return
+        /// `RecordResult`.
+        ///
+        /// # Agent
+        /// Reply: `RecordResult`. `Ok` carries the seed, the minted
+        /// `handle_id`, and `kind_id` (`TrajectoryLog::ID`). Use
+        /// `handle_id` to pass the log to a DAG transform or retrieve it
+        /// later via `describe_handles`. `Err` when `seed` names no
+        /// in-flight session (unknown seed or already terminated).
+        #[handler]
+        fn on_end(&mut self, _ctx: &mut NativeCtx<'_>, e: TrajectoryEnd) -> RecordResult {
+            let Some(samples) = self.sessions.remove(&e.seed) else {
+                return RecordResult::Err {
+                    seed: e.seed,
+                    error: format!("no in-flight session for seed {}", e.seed),
+                };
+            };
+
+            let log = TrajectoryLog {
+                seed: e.seed,
+                samples,
+                end_reason: e.reason,
+            };
+
+            let id = self.store.next_ephemeral();
+            let bytes = log.encode_into_bytes();
+            let kind_id = TrajectoryLog::ID;
+
+            match self.store.put(id, kind_id, bytes) {
+                Ok(()) => {
+                    // Hold a reference on behalf of the recorder,
+                    // mirroring `HandleCapability::on_publish`.
+                    self.store.inc_ref(id);
+                    RecordResult::Ok {
+                        seed: e.seed,
+                        handle_id: id,
+                        kind_id,
+                    }
+                }
+                Err(err) => RecordResult::Err {
+                    seed: e.seed,
+                    error: format!("handle store put failed: {err:?}"),
+                },
+            }
+        }
+    }
+
+    #[cfg(test)]
+    #[allow(
+        clippy::unwrap_used,
+        reason = "test-setup unwraps: fixture construction panic on failure is the assertion"
+    )]
+    mod tests {
+        use std::sync::mpsc;
+
+        use aether_data::{HandleId, Kind, MailId, MailboxId};
+        use aether_kinds::TrajectoryEndReason;
+        use aether_kinds::descriptors;
+        use aether_kinds::trace::Nanos;
+        use aether_substrate::actor::native::binding::NativeBinding;
+        use aether_substrate::mail::mailer::Mailer;
+        use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
+        use aether_substrate::mail::registry::{OwnedDispatch, Registry};
+        use aether_substrate::mail::{MailRef, Source, SourceAddr};
+
+        use super::*;
+        use crate::test_chassis::{TestChassis, boot_test_chassis_with};
+        use aether_actor::Actor;
+        use aether_substrate::chassis::builder::Builder;
+
+        /// Build a substrate where the `Arc<HandleStore>` is also returned
+        /// to the caller. Used by both the direct-call unit tests and the
+        /// heavy dispatcher test.
+        fn fresh_substrate() -> (
+            Arc<HandleStore>,
+            Arc<Mailer>,
+            Arc<Registry>,
+            mpsc::Receiver<EgressEvent>,
+        ) {
+            let store = Arc::new(HandleStore::new(64 * 1024));
+            let registry = Arc::new(Registry::new());
+            for d in descriptors::all() {
+                let _ = registry.register_kind_with_descriptor(d);
+            }
+            let (outbound, rx) = HubOutbound::attached_loopback();
+            let mailer = Arc::new(
+                Mailer::new(Arc::clone(&registry), Arc::clone(&store)).with_outbound(outbound),
+            );
+            (store, mailer, registry, rx)
+        }
+
+        /// Create a session-targeted `Source` for direct handler calls.
+        fn session_source() -> Source {
+            use aether_data::{SessionToken, Uuid};
+            Source::to(SourceAddr::Session(SessionToken(Uuid::from_u128(
+                0xfeed_u128,
+            ))))
+        }
+
+        /// Directly-exercised capability fixture (no dispatcher thread).
+        struct DirectFixture {
+            cap: TrajectoryRecorderCapability,
+            store: Arc<HandleStore>,
+            transport: Arc<NativeBinding>,
+        }
+
+        fn direct_fixture() -> DirectFixture {
+            let (store, mailer, _registry, _rx) = fresh_substrate();
+            let transport = Arc::new(NativeBinding::new_for_test(
+                Arc::clone(&mailer),
+                MailboxId(0x1862),
+            ));
+            let cap = TrajectoryRecorderCapability {
+                sessions: HashMap::new(),
+                store: Arc::clone(&store),
+            };
+            DirectFixture {
+                cap,
+                store,
+                transport,
+            }
+        }
+
+        fn make_ctx(transport: &Arc<NativeBinding>) -> NativeCtx<'_> {
+            NativeCtx::new(transport, session_source(), MailId::NONE, MailId::NONE)
+        }
+
+        // Unit tests — direct handler calls, no dispatcher thread.
+
+        /// A sample for a fresh seed creates a buffer and appends the
+        /// entry. A second sample for the same seed appends to the same
+        /// buffer.
+        #[test]
+        fn on_sample_appends_to_seed_buffer() {
+            let mut fix = direct_fixture();
+            let mut ctx = make_ctx(&fix.transport);
+
+            fix.cap.on_sample(
+                &mut ctx,
+                TrajectorySample {
+                    seed: 42,
+                    tick: 1,
+                    x: 3,
+                    y: 4,
+                    value: 99,
+                },
+            );
+            fix.cap.on_sample(
+                &mut ctx,
+                TrajectorySample {
+                    seed: 42,
+                    tick: 2,
+                    x: 5,
+                    y: 6,
+                    value: 100,
+                },
+            );
+
+            let buf = fix.cap.sessions.get(&42).expect("seed 42 buffer exists");
+            assert_eq!(buf.len(), 2, "two samples for seed 42");
+            assert_eq!(
+                buf[0],
+                TrajectorySampleEntry {
+                    tick: 1,
+                    x: 3,
+                    y: 4,
+                    value: 99
+                }
+            );
+            assert_eq!(
+                buf[1],
+                TrajectorySampleEntry {
+                    tick: 2,
+                    x: 5,
+                    y: 6,
+                    value: 100
+                }
+            );
+        }
+
+        /// Two interleaved seeds accumulate into separate buffers; neither
+        /// spills into the other.
+        #[test]
+        fn on_sample_keeps_seeds_separate() {
+            let mut fix = direct_fixture();
+            let mut ctx = make_ctx(&fix.transport);
+
+            fix.cap.on_sample(
+                &mut ctx,
+                TrajectorySample {
+                    seed: 1,
+                    tick: 10,
+                    x: 0,
+                    y: 0,
+                    value: 1,
+                },
+            );
+            fix.cap.on_sample(
+                &mut ctx,
+                TrajectorySample {
+                    seed: 2,
+                    tick: 11,
+                    x: 7,
+                    y: 8,
+                    value: 2,
+                },
+            );
+            fix.cap.on_sample(
+                &mut ctx,
+                TrajectorySample {
+                    seed: 1,
+                    tick: 12,
+                    x: 1,
+                    y: 0,
+                    value: 3,
+                },
+            );
+
+            let buf1 = fix.cap.sessions.get(&1).expect("seed 1 buffer exists");
+            let buf2 = fix.cap.sessions.get(&2).expect("seed 2 buffer exists");
+            assert_eq!(buf1.len(), 2, "seed 1 has two samples");
+            assert_eq!(buf2.len(), 1, "seed 2 has one sample");
+            assert_eq!(
+                buf2[0],
+                TrajectorySampleEntry {
+                    tick: 11,
+                    x: 7,
+                    y: 8,
+                    value: 2
+                }
+            );
+        }
+
+        /// `on_end` publishes a handle containing a `TrajectoryLog` that
+        /// decodes back to the samples in tick order, removes the buffer,
+        /// and returns `RecordResult::Ok`.
+        #[test]
+        fn on_end_publishes_decodable_log() {
+            let mut fix = direct_fixture();
+            let mut ctx = make_ctx(&fix.transport);
+
+            let seed = 7u64;
+            fix.cap.on_sample(
+                &mut ctx,
+                TrajectorySample {
+                    seed,
+                    tick: 1,
+                    x: 0,
+                    y: 0,
+                    value: 10,
+                },
+            );
+            fix.cap.on_sample(
+                &mut ctx,
+                TrajectorySample {
+                    seed,
+                    tick: 2,
+                    x: 1,
+                    y: 0,
+                    value: 20,
+                },
+            );
+
+            let result = fix.cap.on_end(
+                &mut ctx,
+                TrajectoryEnd {
+                    seed,
+                    reason: TrajectoryEndReason::Completed,
+                },
+            );
+
+            let RecordResult::Ok {
+                seed: out_seed,
+                handle_id,
+                kind_id,
+            } = result
+            else {
+                panic!("expected RecordResult::Ok, got {result:?}");
+            };
+
+            assert_eq!(out_seed, seed, "seed echoed");
+            assert_ne!(handle_id, HandleId(0), "handle id is non-zero");
+            assert_eq!(kind_id, TrajectoryLog::ID, "kind id matches TrajectoryLog");
+
+            // Verify the session buffer was cleared.
+            assert!(
+                !fix.cap.sessions.contains_key(&seed),
+                "session buffer removed after on_end"
+            );
+
+            // Verify the stored bytes decode back to the expected log.
+            let (stored_kind, stored_bytes) =
+                fix.store.get(handle_id).expect("handle exists in store");
+            assert_eq!(stored_kind, TrajectoryLog::ID, "stored kind id matches");
+            let log: TrajectoryLog =
+                postcard::from_bytes(&stored_bytes).expect("stored bytes decode to TrajectoryLog");
+            assert_eq!(log.seed, seed);
+            assert_eq!(log.end_reason, TrajectoryEndReason::Completed);
+            assert_eq!(log.samples.len(), 2);
+            assert_eq!(
+                log.samples[0],
+                TrajectorySampleEntry {
+                    tick: 1,
+                    x: 0,
+                    y: 0,
+                    value: 10
+                }
+            );
+            assert_eq!(
+                log.samples[1],
+                TrajectorySampleEntry {
+                    tick: 2,
+                    x: 1,
+                    y: 0,
+                    value: 20
+                }
+            );
+        }
+
+        /// `on_end` for a seed with no in-flight session returns
+        /// `RecordResult::Err`.
+        #[test]
+        fn on_end_unknown_seed_returns_err() {
+            let mut fix = direct_fixture();
+            let mut ctx = make_ctx(&fix.transport);
+
+            let result = fix.cap.on_end(
+                &mut ctx,
+                TrajectoryEnd {
+                    seed: 999,
+                    reason: TrajectoryEndReason::Aborted,
+                },
+            );
+
+            assert!(
+                matches!(result, RecordResult::Err { seed: 999, .. }),
+                "expected Err for unknown seed, got {result:?}"
+            );
+        }
+
+        /// End-to-end through the dispatcher thread: boot the cap via
+        /// `boot_test_chassis_with`, enqueue `TrajectorySample`s then a
+        /// `TrajectoryEnd`, assert `RecordResult::Ok` arrives on the
+        /// loopback channel, and verify the store holds a decodable
+        /// `TrajectoryLog`. Sleep-polls under a multi-second deadline →
+        /// `mod heavy` for the `serial-heavy` nextest group (issue 1522).
+        mod heavy {
+            use std::thread;
+            use std::time::{Duration, Instant};
+
+            use aether_data::{SessionToken, Uuid};
+            use aether_substrate::mail::registry::MailboxEntry;
+
+            use super::*;
+
+            #[test]
+            fn capability_routes_end_through_dispatcher_thread() {
+                let (store, mailer, registry, rx) = fresh_substrate();
+
+                let chassis =
+                    boot_test_chassis_with::<TrajectoryRecorderCapability>(&registry, &mailer, ());
+
+                let mbx_id = registry
+                    .lookup(TrajectoryRecorderCapability::NAMESPACE)
+                    .expect("aether.trajectory registered");
+
+                let MailboxEntry::Inbox { handler, .. } =
+                    registry.entry(mbx_id).expect("entry exists")
+                else {
+                    panic!("expected Inbox entry");
+                };
+
+                let seed = 1234u64;
+
+                // Send two samples.
+                for (tick, x, y, value) in [(1u32, 2u32, 3u32, 10u32), (2, 4, 5, 20)] {
+                    let s = TrajectorySample {
+                        seed,
+                        tick,
+                        x,
+                        y,
+                        value,
+                    };
+                    let bytes = postcard::to_allocvec(&s).expect("TrajectorySample serializes");
+                    handler.enqueue(OwnedDispatch::disarmed(
+                        <TrajectorySample as Kind>::ID,
+                        "aether.trajectory.sample".to_owned(),
+                        None,
+                        Source::NONE,
+                        MailRef::from(bytes),
+                        1,
+                        MailId::NONE,
+                        MailId::NONE,
+                        None,
+                        Nanos(0),
+                        0,
+                        MailboxId(0),
+                    ));
+                }
+
+                // Send the terminal event with a session reply target so
+                // the dispatcher can route the RecordResult reply.
+                let reply_to =
+                    Source::to(SourceAddr::Session(SessionToken(Uuid::from_u128(0x1862))));
+                let end = TrajectoryEnd {
+                    seed,
+                    reason: TrajectoryEndReason::Completed,
+                };
+                let bytes = postcard::to_allocvec(&end).expect("TrajectoryEnd serializes");
+                handler.enqueue(OwnedDispatch::disarmed(
+                    <TrajectoryEnd as Kind>::ID,
+                    "aether.trajectory.end".to_owned(),
+                    None,
+                    reply_to,
+                    MailRef::from(bytes),
+                    1,
+                    MailId::NONE,
+                    MailId::NONE,
+                    None,
+                    Nanos(0),
+                    0,
+                    MailboxId(0),
+                ));
+
+                // Poll the outbound channel for the RecordResult reply.
+                let deadline = Instant::now() + Duration::from_secs(5);
+                let payload = loop {
+                    if let Ok(EgressEvent::ToSession { payload, .. }) = rx.try_recv() {
+                        break payload;
+                    }
+                    assert!(
+                        Instant::now() < deadline,
+                        "RecordResult reply did not arrive within deadline"
+                    );
+                    thread::sleep(Duration::from_millis(5));
+                };
+
+                let result: RecordResult =
+                    postcard::from_bytes(&payload).expect("RecordResult decodes via postcard");
+                let RecordResult::Ok {
+                    seed: out_seed,
+                    handle_id,
+                    kind_id,
+                } = result
+                else {
+                    panic!("expected RecordResult::Ok, got {result:?}");
+                };
+
+                assert_eq!(out_seed, seed, "seed echoed");
+                assert_ne!(handle_id, HandleId(0), "handle id is non-zero");
+                assert_eq!(kind_id, TrajectoryLog::ID, "kind id matches TrajectoryLog");
+
+                // Verify the handle store holds a decodable log.
+                let (stored_kind, stored_bytes) =
+                    store.get(handle_id).expect("handle exists in store");
+                assert_eq!(stored_kind, TrajectoryLog::ID);
+                let log: TrajectoryLog = postcard::from_bytes(&stored_bytes)
+                    .expect("stored bytes decode to TrajectoryLog");
+                assert_eq!(log.seed, seed);
+                assert_eq!(log.end_reason, TrajectoryEndReason::Completed);
+                assert_eq!(log.samples.len(), 2);
+
+                drop(chassis);
+            }
+        }
+
+        /// Builder rejects a duplicate claim on `aether.trajectory`.
+        #[test]
+        fn duplicate_claim_rejects_with_typed_error() {
+            use aether_substrate::chassis::error::BootError;
+            use aether_substrate::mail::registry;
+
+            let (_store, mailer, registry_arc, _rx) = fresh_substrate();
+            registry_arc.register_inbox(
+                TrajectoryRecorderCapability::NAMESPACE,
+                registry::noop_handler(),
+            );
+
+            let err = Builder::<TestChassis>::new(Arc::clone(&registry_arc), Arc::clone(&mailer))
+                .with_actor::<TrajectoryRecorderCapability>(())
+                .build_passive()
+                .expect_err("collision must surface as BootError");
+            assert!(matches!(
+                err,
+                BootError::MailboxAlreadyClaimed { ref name }
+                    if name == TrajectoryRecorderCapability::NAMESPACE
+            ));
+        }
+    }
+}

--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -55,9 +55,10 @@ mod tests {
         Fetch, FetchResult, Key, LifecycleUnsubscribeAll, List, ListResult, LoadComponent,
         LoadResult, LyriaGenerate, LyriaGenerateResult, Mat4Apply, MessagesSend,
         MessagesSendResult, MouseButton, MouseMove, NanobananaGenerate, NanobananaGenerateResult,
-        NoteOff, NoteOn, Ping, Pong, ProcessExited, Read, ReadResult, ReplaceComponent,
-        ReplaceResult, SetMasterGain, Spawn, SpawnResult, SubscribeInput, SubscribeInputResult,
-        Terminate, TerminateResult, Tick, UnsubscribeAll, UnsubscribeInput, Write, WriteResult,
+        NoteOff, NoteOn, Ping, Pong, ProcessExited, Read, ReadResult, RecordResult,
+        ReplaceComponent, ReplaceResult, SetMasterGain, Spawn, SpawnResult, SubscribeInput,
+        SubscribeInputResult, Terminate, TerminateResult, Tick, TrajectoryEnd, TrajectoryLog,
+        TrajectorySample, UnsubscribeAll, UnsubscribeInput, Write, WriteResult,
     };
 
     #[test]
@@ -441,5 +442,122 @@ mod tests {
         for f in vec_fields.iter() {
             assert_eq!(f.ty, SchemaType::Scalar(Primitive::F32));
         }
+    }
+
+    /// Regression guard: all four trajectory kinds register in the
+    /// inventory-driven descriptor list so they appear in `describe_kinds`
+    /// without a manual second touch (ADR-0028, issue #243).
+    #[test]
+    fn trajectory_kinds_are_in_descriptor_list() {
+        let descs = all();
+        let names: Vec<&str> = descs.iter().map(|d| d.name.as_str()).collect();
+        assert!(
+            names.contains(&TrajectorySample::NAME),
+            "TrajectorySample missing from descriptor list"
+        );
+        assert!(
+            names.contains(&TrajectoryEnd::NAME),
+            "TrajectoryEnd missing from descriptor list"
+        );
+        assert!(
+            names.contains(&TrajectoryLog::NAME),
+            "TrajectoryLog missing from descriptor list"
+        );
+        assert!(
+            names.contains(&RecordResult::NAME),
+            "RecordResult missing from descriptor list"
+        );
+    }
+
+    /// Trajectory kinds resolve to distinct ids: no two share the same
+    /// `Kind::ID`. A collision would mean two kinds dispatched to the
+    /// same handler, silently losing one.
+    #[test]
+    fn trajectory_kind_ids_are_distinct() {
+        let ids = [
+            TrajectorySample::ID,
+            TrajectoryEnd::ID,
+            TrajectoryLog::ID,
+            RecordResult::ID,
+        ];
+        // O(n²) pairwise check — n = 4, tolerable.
+        for (i, a) in ids.iter().enumerate() {
+            for b in ids.iter().skip(i + 1) {
+                assert_ne!(a.0, b.0, "duplicate trajectory kind ids: {a:?} == {b:?}");
+            }
+        }
+    }
+
+    /// `TrajectoryLog` is a postcard-shaped `Struct` (it carries a
+    /// `Vec<TrajectorySampleEntry>` field, so `repr_c` must be false).
+    #[test]
+    fn trajectory_log_is_postcard_struct() {
+        let descs = all();
+        let d = descs
+            .iter()
+            .find(|d| d.name == TrajectoryLog::NAME)
+            .expect("TrajectoryLog in descriptor list");
+        let SchemaType::Struct { repr_c, .. } = &d.schema else {
+            panic!("expected Struct for TrajectoryLog, got {:?}", d.schema);
+        };
+        assert!(
+            !*repr_c,
+            "TrajectoryLog contains Vec — must be postcard, not cast"
+        );
+    }
+
+    /// `RecordResult` is an `Enum` schema (two variants: `Ok` and `Err`).
+    #[test]
+    fn record_result_is_enum_schema() {
+        let descs = all();
+        let d = descs
+            .iter()
+            .find(|d| d.name == RecordResult::NAME)
+            .expect("RecordResult in descriptor list");
+        assert!(
+            matches!(d.schema, SchemaType::Enum { .. }),
+            "RecordResult should be Enum, got {:?}",
+            d.schema
+        );
+    }
+
+    /// Postcard round-trip for `TrajectoryLog`: encode via `Kind::encode_into_bytes`,
+    /// decode via postcard, assert equality of all fields and samples in order.
+    #[test]
+    fn trajectory_log_postcard_roundtrip() {
+        use crate::{TrajectoryEndReason, TrajectorySampleEntry};
+
+        let original = TrajectoryLog {
+            seed: 0xDEAD_BEEF_u64,
+            samples: alloc::vec![
+                TrajectorySampleEntry {
+                    tick: 1,
+                    x: 10,
+                    y: 20,
+                    value: 100,
+                },
+                TrajectorySampleEntry {
+                    tick: 2,
+                    x: 11,
+                    y: 21,
+                    value: 200,
+                },
+            ],
+            end_reason: TrajectoryEndReason::Completed,
+        };
+
+        let bytes = original.encode_into_bytes();
+        let decoded: TrajectoryLog =
+            postcard::from_bytes(&bytes).expect("TrajectoryLog round-trips via postcard");
+
+        assert_eq!(decoded.seed, original.seed);
+        assert_eq!(decoded.samples.len(), 2);
+        assert_eq!(decoded.samples[0].tick, 1);
+        assert_eq!(decoded.samples[0].x, 10);
+        assert_eq!(decoded.samples[0].y, 20);
+        assert_eq!(decoded.samples[0].value, 100);
+        assert_eq!(decoded.samples[1].tick, 2);
+        assert_eq!(decoded.samples[1].value, 200);
+        assert_eq!(decoded.end_reason, TrajectoryEndReason::Completed);
     }
 }

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -764,6 +764,7 @@ pub use control_plane::*;
 pub use engine::*;
 pub use rpc::*;
 pub use tcp::*;
+pub use trajectory::*;
 
 mod tcp {
     use alloc::string::String;
@@ -3715,6 +3716,124 @@ mod control_plane {
         Err {
             request_id: u64,
             error: GeminiError,
+        },
+    }
+}
+
+mod trajectory {
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    use serde::{Deserialize, Serialize};
+
+    /// One per-tick sample from a moving point's grid position and a
+    /// scalar accumulator value. Sent by a producer to the
+    /// `TrajectoryRecorderCapability` (`aether.trajectory`) every tick
+    /// to record the point's current state. `seed` keys the session:
+    /// all samples sharing a seed are accumulated into the same
+    /// `TrajectoryLog` handle, emitted when `TrajectoryEnd` arrives for
+    /// that seed. Fire-and-forget; the recorder has no per-sample reply.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.trajectory.sample")]
+    pub struct TrajectorySample {
+        /// Session discriminator. All samples with the same seed are
+        /// accumulated into a single `TrajectoryLog` handle.
+        pub seed: u64,
+        /// Tick counter at which this sample was captured. Preserved
+        /// verbatim in the log so offline transforms replay in tick
+        /// order.
+        pub tick: u32,
+        /// Grid column the point occupied at this tick.
+        pub x: u32,
+        /// Grid row the point occupied at this tick.
+        pub y: u32,
+        /// Scalar accumulator value at this tick (e.g. a score,
+        /// resource count, or distance travelled — domain-agnostic).
+        pub value: u32,
+    }
+
+    /// Reason a trajectory session ended. Domain-free and self-describing
+    /// so an LLM caller can interpret the terminal event without needing
+    /// additional context (ADR memory: design for machine consumers).
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+    pub enum TrajectoryEndReason {
+        /// The session ran to its natural conclusion (e.g. the point
+        /// reached its target or exhausted a fixed step budget).
+        Completed,
+        /// The session was cut short by a soft limit (e.g. a time
+        /// budget was exceeded, or a step cap was reached before the
+        /// natural end condition).
+        Truncated,
+        /// The session was cancelled by the producer before it reached
+        /// a natural or soft-limit end condition.
+        Aborted,
+    }
+
+    /// Terminal marker for a trajectory session. Signals the
+    /// `TrajectoryRecorderCapability` to build the `TrajectoryLog`
+    /// handle for `seed` from all accumulated `TrajectorySample`s and
+    /// publish it to the handle store. Reply: `RecordResult`.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.trajectory.end")]
+    pub struct TrajectoryEnd {
+        /// The same seed used in the `TrajectorySample` stream being
+        /// terminated. Selects which buffer the recorder flushes.
+        pub seed: u64,
+        /// Why the session ended. Carried verbatim into `TrajectoryLog`
+        /// so offline analysis can filter by outcome.
+        pub reason: TrajectoryEndReason,
+    }
+
+    /// One tick's worth of position + accumulator data, as stored in a
+    /// `TrajectoryLog`. Separates the on-wire sample shape
+    /// (`TrajectorySample`, which also carries `seed`) from the stored
+    /// shape (which doesn't need `seed` since all entries share the log's
+    /// single `seed` field).
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+    pub struct TrajectorySampleEntry {
+        pub tick: u32,
+        pub x: u32,
+        pub y: u32,
+        pub value: u32,
+    }
+
+    /// A complete, tick-ordered record of one trajectory session, stored
+    /// in the handle store (ADR-0049) under `aether.trajectory.log`
+    /// (`TrajectoryLog::ID`). Published by `TrajectoryRecorderCapability`
+    /// at terminal time (on `TrajectoryEnd`) as a single immutable handle
+    /// keyed by `seed`. Offline analysis transforms decode this handle to
+    /// replay the session's path.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.trajectory.log")]
+    pub struct TrajectoryLog {
+        /// The session seed — matches the `seed` on every
+        /// `TrajectorySample` in this log.
+        pub seed: u64,
+        /// Tick-ordered list of recorded samples. The recorder appends
+        /// in the order `TrajectorySample` mails arrive; a well-behaved
+        /// producer sends them in ascending-tick order.
+        pub samples: Vec<TrajectorySampleEntry>,
+        /// Why the session ended, propagated from `TrajectoryEnd`.
+        pub end_reason: TrajectoryEndReason,
+    }
+
+    /// Reply to `TrajectoryEnd`. `Ok` carries the seed and the freshly
+    /// minted handle id + kind id of the published `TrajectoryLog` in
+    /// the handle store; `Err` is returned when `seed` has no in-flight
+    /// session (unknown or already terminated). Mirrors the shape of
+    /// `HandlePublishResult` so a caller can chain the handle id into a
+    /// DAG `Source` or store it for offline replay.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.trajectory.record_result")]
+    pub enum RecordResult {
+        Ok {
+            seed: u64,
+            handle_id: aether_data::HandleId,
+            kind_id: aether_data::KindId,
+        },
+        Err {
+            seed: u64,
+            error: String,
         },
     }
 }

--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -27,8 +27,8 @@ use aether_capabilities::{
     AnthropicCapability, AnthropicConfig, ComponentHostCapability, ComponentHostConfig,
     DagCapability, FsCapability, GeminiCapability, GeminiConfig, HandleCapability, HttpCapability,
     HttpServerCapability, HttpServerConfig, InputCapability, InputConfig, InventoryCapability,
-    LifecycleConfig, TcpCapability, TextCapability, UiCapability, fs::NamespaceRoots,
-    http::HttpConfig, trace::TraceDispatchCapability,
+    LifecycleConfig, TcpCapability, TextCapability, TrajectoryRecorderCapability, UiCapability,
+    fs::NamespaceRoots, http::HttpConfig, trace::TraceDispatchCapability,
 };
 use aether_kinds::{Present, Render, Shutdown, Tick};
 use aether_substrate::chassis::Chassis;
@@ -292,6 +292,7 @@ pub fn with_common_caps<C: Chassis>(builder: Builder<C>, boot: CommonBoot) -> Bu
         .with_actor::<HandleCapability>(())
         .with_actor::<TraceDispatchCapability>(())
         .with_actor::<DagCapability>(())
+        .with_actor::<TrajectoryRecorderCapability>(())
         .with_actor::<InputCapability>(boot.input_config)
         .with_actor::<ComponentHostCapability>(boot.component_host_config)
         .with_actor::<FsCapability>(boot.namespace_roots)

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -14,7 +14,7 @@ use aether_capabilities::LifecycleCapability;
 use aether_capabilities::{
     CaptureBackend, FsCapability, HandleCapability, HeadlessWindowCapability, InputCapability,
     InputConfig, RenderCapability, RenderConfig, RenderHandles, TcpCapability, TextCapability,
-    UiCapability, fs::NamespaceRoots, trace::TraceDispatchCapability,
+    TrajectoryRecorderCapability, UiCapability, fs::NamespaceRoots, trace::TraceDispatchCapability,
 };
 use aether_capabilities::{ComponentHostCapability, ComponentHostConfig};
 use aether_data::Kind;
@@ -306,6 +306,7 @@ impl TestBenchChassis {
             .with_workers(pool_workers)
             .with_actor::<HandleCapability>(())
             .with_actor::<TraceDispatchCapability>(())
+            .with_actor::<TrajectoryRecorderCapability>(())
             .with_actor::<InputCapability>(input_config)
             .with_actor::<ComponentHostCapability>(component_host_config)
             .with_actor::<TcpCapability>(())


### PR DESCRIPTION
Closes #1862.

## Summary

A position-stream recorder actor (`aether-capabilities`) that samples per-tick positions and accumulates them into a `TrajectoryLog` sample-log handle — the input feed downstream reachability / corridor-graph work (the gauntlet epic) replays and aggregates. New `trajectory` kinds in `aether-kinds`, the recorder actor + registration in `aether-capabilities`, and chassis wiring so the test bench can drive it.

## Test plan

6 unit tests in `trajectory.rs` covering the recorder's per-tick sampling and log-handle emission; test-bench chassis wiring exercises it under `cargo test`. Full workspace green: clippy `-D warnings`, nextest `--workspace` (99 affected tests passed, including the 6 new), doc.

## Generated by

`/implement` — agent execution of [scoped issue #1862](https://github.com/iamacoffeepot/aether/issues/1862).
