### PR TITLE
feat(capabilities): time-sliced corridor graph from a cost-to-reach field (components + budget filtration)

### DIFF
--- a/crates/aether-capabilities/src/corridor.rs
+++ b/crates/aether-capabilities/src/corridor.rs
@@ -1,0 +1,674 @@
+//! Time-sliced corridor graph over a cost-to-reach field (issue 1858).
+//! The pure core the `build_corridor_graph` transform (ADR-0048) wraps,
+//! kept beside the reachability solver so the follow-on passes (path-snap,
+//! the validation harness) reuse the exact per-tick component labeler for
+//! id parity.
+//!
+//! Given the solved cost-to-reach field `V` (a [`ScalarField`], issue
+//! 1857) and a budget `B`, the corridor graph is the connectivity
+//! skeleton of `V`: per tick, the connected components of the affordable
+//! set `{cell : V(cell, tick) <= B}` (the nodes); intra-tick "punch" edges
+//! between two components a sub-budget barrier separates, priced at the
+//! sublevel-filtration threshold of `V` at which raising `B` fuses them;
+//! and inter-tick "flow" edges linking a component at tick `t` to one at
+//! `t + 1` when an affordable one-tick stencil step bridges them.
+//!
+//! Each tick runs one iterative union-find sublevel filtration over the
+//! tick's `V` slice: visit cells in ascending `V`, union each with its
+//! already-visited stencil neighbors, and record the `V` threshold at the
+//! moment two distinct affordable components first connect. The partition
+//! restricted to cells with `V <= B` is the tick's components; a merge
+//! event whose threshold exceeds `B` and joins two distinct `<= B`
+//! components is a punch edge priced at that threshold. Union-find stays
+//! iterative (find is a loop with path compression, union by rank — no
+//! recursion, per the load-bearing-code rule), so a given `V` + `B`
+//! replays byte-identically.
+
+use std::collections::BTreeMap;
+
+use aether_kinds::{
+    CorridorEdge, CorridorGraph, CorridorNode, EdgeKind, ScalarField, StencilOffset,
+};
+
+use crate::reachability::UNREACHABLE;
+
+/// An iterative disjoint-set forest (union by rank, path-compressing
+/// find). No recursion: `find` walks parent links in a loop. `rank` is
+/// the usual union-by-rank height bound. Cells are `usize` grid indices.
+struct UnionFind {
+    parent: Vec<usize>,
+    rank: Vec<u8>,
+}
+
+impl UnionFind {
+    fn new(len: usize) -> Self {
+        Self {
+            parent: (0..len).collect(),
+            rank: vec![0u8; len],
+        }
+    }
+
+    /// Representative of `x`'s set, compressing the path to the root.
+    fn find(&mut self, x: usize) -> usize {
+        let mut root = x;
+        while self.parent[root] != root {
+            root = self.parent[root];
+        }
+        let mut cur = x;
+        while self.parent[cur] != root {
+            let next = self.parent[cur];
+            self.parent[cur] = root;
+            cur = next;
+        }
+        root
+    }
+
+    /// Union the sets containing `a` and `b`, returning the surviving
+    /// representative. A no-op (returns the shared root) when they already
+    /// share one.
+    fn union(&mut self, a: usize, b: usize) -> usize {
+        let root_a = self.find(a);
+        let root_b = self.find(b);
+        if root_a == root_b {
+            return root_a;
+        }
+        let (keep, drop) = if self.rank[root_a] < self.rank[root_b] {
+            (root_b, root_a)
+        } else {
+            (root_a, root_b)
+        };
+        self.parent[drop] = keep;
+        if self.rank[keep] == self.rank[drop] {
+            self.rank[keep] += 1;
+        }
+        keep
+    }
+}
+
+/// Cell indices with a finite `V`, ordered ascending by `(value, index)` —
+/// the visit order of the sublevel filtration, stable across builds.
+fn ascending_finite_cells(slice: &[u32]) -> Vec<usize> {
+    let mut order: Vec<usize> = (0..slice.len())
+        .filter(|&i| slice[i] != UNREACHABLE)
+        .collect();
+    order.sort_by_key(|&i| (slice[i], i));
+    order
+}
+
+/// In-bounds cell `(x + dx, y + dy)` of cell `index`, or `None` if it
+/// falls off the grid. The signed deltas carry both the forward stencil
+/// step (intra-tick connectivity, the forward flow landing) and the
+/// reverse step (a flow landing's predecessor).
+fn offset_neighbor(
+    index: usize,
+    dx: isize,
+    dy: isize,
+    width: usize,
+    height: usize,
+) -> Option<usize> {
+    let x = index % width;
+    let y = index / width;
+    let nx = x.checked_add_signed(dx)?;
+    let ny = y.checked_add_signed(dy)?;
+    if nx >= width || ny >= height {
+        return None;
+    }
+    Some(ny * width + nx)
+}
+
+/// Forward in-bounds stencil neighbor of `index`, or `None` for the zero
+/// offset (a cell is not its own stencil neighbor for connectivity) or an
+/// off-grid step.
+fn stencil_neighbor(
+    index: usize,
+    offset: StencilOffset,
+    width: usize,
+    height: usize,
+) -> Option<usize> {
+    if offset.dx == 0 && offset.dy == 0 {
+        return None;
+    }
+    offset_neighbor(index, offset.dx as isize, offset.dy as isize, width, height)
+}
+
+/// The per-tick component labeling of one `V` slice (issue 1858). Exposed
+/// crate-wide so the path-snap pass reuses the exact same labeling for id
+/// parity.
+pub struct TickComponents {
+    /// Per-cell component id (`Some(id)` for an affordable cell, `None`
+    /// for an above-budget or unreachable cell). Length `width * height`.
+    pub label: Vec<Option<u32>>,
+    /// The component summary nodes for this tick, ordered by `component`.
+    pub nodes: Vec<CorridorNode>,
+    /// Intra-tick punch merges `(component_a, component_b, threshold)`,
+    /// `component_a < component_b`, deduplicated to the minimum threshold.
+    pub punches: Vec<(u32, u32, u32)>,
+}
+
+/// Label one tick's affordable components and detect its punch merges.
+///
+/// `slice` is the tick's row-major `V` values (length `width * height`).
+/// Affordable cells (`V <= budget`, never the [`UNREACHABLE`] sentinel)
+/// are partitioned into connected components under the stencil adjacency;
+/// component ids are assigned in row-major first-encounter order. A
+/// sublevel filtration over every finite cell then records, for each pair
+/// of components a barrier separates, the minimum `V` threshold at which
+/// they merge — a punch edge.
+pub fn label_tick_components(
+    slice: &[u32],
+    width: usize,
+    height: usize,
+    stencil: &[StencilOffset],
+    budget: u32,
+    tick: u32,
+) -> TickComponents {
+    let plane = slice.len();
+    let affordable = |i: usize| slice[i] != UNREACHABLE && slice[i] <= budget;
+
+    // Components: union affordable cells with their affordable stencil
+    // neighbors. Connectivity is order-independent, so a single row-major
+    // sweep suffices; the filtration below reuses the same adjacency.
+    let mut comp_uf = UnionFind::new(plane);
+    for i in 0..plane {
+        if !affordable(i) {
+            continue;
+        }
+        for &offset in stencil {
+            if let Some(n) = stencil_neighbor(i, offset, width, height)
+                && affordable(n)
+            {
+                comp_uf.union(i, n);
+            }
+        }
+    }
+
+    // Assign per-tick component ids in row-major first-encounter order so
+    // the labeling is deterministic and content-addressable.
+    let mut root_to_comp: BTreeMap<usize, u32> = BTreeMap::new();
+    let mut label: Vec<Option<u32>> = vec![None; plane];
+    let mut nodes: Vec<CorridorNode> = Vec::new();
+    for i in 0..plane {
+        if !affordable(i) {
+            continue;
+        }
+        let root = comp_uf.find(i);
+        let comp = *root_to_comp.entry(root).or_insert_with(|| {
+            let id = u32::try_from(nodes.len()).expect("component count fits u32");
+            nodes.push(CorridorNode {
+                tick,
+                component: id,
+                cell_count: 0,
+                min_cost: UNREACHABLE,
+            });
+            id
+        });
+        label[i] = Some(comp);
+        let node = &mut nodes[comp as usize];
+        node.cell_count = node.cell_count.saturating_add(1);
+        node.min_cost = node.min_cost.min(slice[i]);
+    }
+
+    // Punch edges: a sublevel filtration over every finite cell. Visiting
+    // ascending, each newly-active cell unions with its already-active
+    // neighbors; the threshold of a union is the current (larger) cell's
+    // `V`. `root_comp[root]` carries the minimum component id among the
+    // affordable cells in that filtration set, so a union above the budget
+    // that joins two distinct components is the punch — priced at the
+    // threshold at which raising the budget would fuse them.
+    let mut punch_map: BTreeMap<(u32, u32), u32> = BTreeMap::new();
+    // A punch joins two distinct affordable components, so a tick with
+    // fewer than two has none — skip the filtration sweep entirely (the
+    // common single-basin case).
+    if nodes.len() >= 2 {
+        let order = ascending_finite_cells(slice);
+        let mut filt = UnionFind::new(plane);
+        let mut active = vec![false; plane];
+        let mut root_comp: Vec<Option<u32>> = vec![None; plane];
+        for &cell in &order {
+            active[cell] = true;
+            root_comp[filt.find(cell)] = label[cell];
+            let threshold = slice[cell];
+            for &offset in stencil {
+                let Some(n) = stencil_neighbor(cell, offset, width, height) else {
+                    continue;
+                };
+                if !active[n] {
+                    continue;
+                }
+                let root_cell = filt.find(cell);
+                let root_neighbor = filt.find(n);
+                if root_cell == root_neighbor {
+                    continue;
+                }
+                let comp_cell = root_comp[root_cell];
+                let comp_neighbor = root_comp[root_neighbor];
+                if threshold > budget
+                    && let (Some(left), Some(right)) = (comp_cell, comp_neighbor)
+                    && left != right
+                {
+                    let key = if left < right {
+                        (left, right)
+                    } else {
+                        (right, left)
+                    };
+                    punch_map
+                        .entry(key)
+                        .and_modify(|t| *t = (*t).min(threshold))
+                        .or_insert(threshold);
+                }
+                let root = filt.union(cell, n);
+                // Carry the minimum component id of the merged set forward.
+                let merged = match (comp_cell, comp_neighbor) {
+                    (Some(left), Some(right)) => Some(left.min(right)),
+                    (Some(only), None) | (None, Some(only)) => Some(only),
+                    (None, None) => None,
+                };
+                root_comp[root] = merged;
+            }
+        }
+    }
+
+    let punches: Vec<(u32, u32, u32)> = punch_map
+        .into_iter()
+        .map(|((a, b), threshold)| (a, b, threshold))
+        .collect();
+
+    TickComponents {
+        label,
+        nodes,
+        punches,
+    }
+}
+
+/// Inter-tick flow edges between adjacent ticks' affordable components.
+///
+/// A flow links a component at the previous tick to one at this tick when
+/// an affordable cell of the former can stencil-step onto an affordable
+/// cell of the latter. `overlap_width` is the count of distinct affordable
+/// landing cells the bridge reaches for that component pair — how wide the
+/// pinch/branch is — so each landing cell counts once per distinct source
+/// component that reaches it (#1869 reads it as the scrub datum).
+///
+/// Counted from the landing side: for each affordable cell in `curr`,
+/// gather the distinct source components among its stencil predecessors in
+/// `prev` (the reverse step `landing - offset`, plus the zero "stay put"
+/// step so a held component links to itself), and credit the cell once to
+/// each. Returns `((from_comp, to_comp), overlap_width)` sorted by pair.
+fn flow_edges(
+    prev: &[Option<u32>],
+    curr: &[Option<u32>],
+    width: usize,
+    height: usize,
+    stencil: &[StencilOffset],
+) -> Vec<((u32, u32), u32)> {
+    let mut counts: BTreeMap<(u32, u32), u32> = BTreeMap::new();
+    // Distinct source components reaching the current landing cell; the
+    // stencil is small, so a reused scratch Vec dedups faster than a set.
+    let mut sources: Vec<u32> = Vec::new();
+    for (landing, to) in curr.iter().enumerate() {
+        let Some(to_comp) = *to else { continue };
+        sources.clear();
+        for &offset in stencil {
+            let source_cell = if offset.dx == 0 && offset.dy == 0 {
+                Some(landing)
+            } else {
+                offset_neighbor(
+                    landing,
+                    -(offset.dx as isize),
+                    -(offset.dy as isize),
+                    width,
+                    height,
+                )
+            };
+            let Some(source_cell) = source_cell else {
+                continue;
+            };
+            if let Some(from_comp) = prev[source_cell]
+                && !sources.contains(&from_comp)
+            {
+                sources.push(from_comp);
+            }
+        }
+        for &from_comp in &sources {
+            *counts.entry((from_comp, to_comp)).or_insert(0) += 1;
+        }
+    }
+    counts.into_iter().collect()
+}
+
+/// Build the corridor graph of a cost-to-reach field `V` under a fixed
+/// budget (issue 1858).
+///
+/// `field` is the solved [`ScalarField`] `V` (row-major `(tick, y, x)`,
+/// [`UNREACHABLE`] marking a cell no path reaches); `stencil` is the
+/// one-tick movement offset set shared with the solver; `budget` is the
+/// affordability threshold `B`. The result is a time-layered DAG: nodes
+/// are the per-tick connected components of `{cell : V <= B}`, ordered by
+/// `(tick, component)`; edges are the inter-tick `Flow` links and the
+/// intra-tick `Punch` merges, emitted sorted by endpoints then kind so the
+/// encoded output is byte-stable. A malformed (too-short) field stops at
+/// the first truncated tick rather than panicking.
+pub fn build_corridor_graph_core(
+    field: &ScalarField,
+    stencil: &[StencilOffset],
+    budget: u32,
+) -> CorridorGraph {
+    let width = field.width as usize;
+    let height = field.height as usize;
+    let ticks = field.ticks as usize;
+    let plane = width.saturating_mul(height);
+
+    let mut nodes: Vec<CorridorNode> = Vec::new();
+    let mut edges: Vec<CorridorEdge> = Vec::new();
+    if plane == 0 || ticks == 0 {
+        return CorridorGraph { nodes, edges };
+    }
+
+    let mut prev_label: Vec<Option<u32>> = Vec::new();
+    let mut prev_node_base: u32 = 0;
+    let mut prev_has_components = false;
+
+    for t in 0..ticks {
+        let base = t.saturating_mul(plane);
+        let slice = match field.values.get(base..base.saturating_add(plane)) {
+            Some(s) if s.len() == plane => s,
+            // A truncated field can't be sliced cleanly past here; stop
+            // rather than fabricate components from a short read.
+            _ => break,
+        };
+
+        let curr_node_base = u32::try_from(nodes.len()).expect("node count fits u32");
+        let tick = u32::try_from(t).expect("tick index fits u32");
+        let TickComponents {
+            label,
+            nodes: tick_nodes,
+            punches,
+        } = label_tick_components(slice, width, height, stencil, budget, tick);
+        let curr_has_components = !tick_nodes.is_empty();
+        nodes.extend(tick_nodes);
+
+        for (a, b, threshold) in punches {
+            edges.push(CorridorEdge {
+                from: curr_node_base + a,
+                to: curr_node_base + b,
+                kind: EdgeKind::Punch,
+                price: threshold,
+                overlap_width: 0,
+            });
+        }
+
+        if t > 0 && prev_has_components && curr_has_components {
+            for ((a, b), overlap_width) in flow_edges(&prev_label, &label, width, height, stencil) {
+                edges.push(CorridorEdge {
+                    from: prev_node_base + a,
+                    to: curr_node_base + b,
+                    kind: EdgeKind::Flow,
+                    price: 0,
+                    overlap_width,
+                });
+            }
+        }
+
+        prev_label = label;
+        prev_node_base = curr_node_base;
+        prev_has_components = curr_has_components;
+    }
+
+    // Byte-stable output: sort edges by endpoints then kind (flow before
+    // punch), with price / overlap as final tiebreakers.
+    edges.sort_by(|x, y| {
+        let kind_ord = |k: &EdgeKind| match k {
+            EdgeKind::Flow => 0u8,
+            EdgeKind::Punch => 1u8,
+        };
+        (x.from, x.to, kind_ord(&x.kind), x.price, x.overlap_width).cmp(&(
+            y.from,
+            y.to,
+            kind_ord(&y.kind),
+            y.price,
+            y.overlap_width,
+        ))
+    });
+
+    CorridorGraph { nodes, edges }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_corridor_graph_core;
+    use aether_kinds::{EdgeKind, ScalarField, StencilOffset};
+
+    const UNREACHABLE: u32 = u32::MAX;
+
+    fn stencil_4way() -> Vec<StencilOffset> {
+        vec![
+            StencilOffset { dx: 0, dy: 0 },
+            StencilOffset { dx: 1, dy: 0 },
+            StencilOffset { dx: -1, dy: 0 },
+            StencilOffset { dx: 0, dy: 1 },
+            StencilOffset { dx: 0, dy: -1 },
+        ]
+    }
+
+    /// One uniform-cost affordable basin per tick → exactly one node per
+    /// tick and a flow edge per tick step.
+    #[test]
+    fn single_basin_is_one_node_per_tick() {
+        let width = 3;
+        let height = 1;
+        let ticks = 3;
+        let field = ScalarField {
+            width,
+            height,
+            ticks,
+            values: vec![1u32; (width * height * ticks) as usize],
+        };
+        let graph = build_corridor_graph_core(&field, &stencil_4way(), 10);
+        assert_eq!(graph.nodes.len(), 3, "one node per tick");
+        for (t, node) in graph.nodes.iter().enumerate() {
+            assert_eq!(node.tick, u32::try_from(t).expect("tick fits u32"));
+            assert_eq!(node.component, 0);
+            assert_eq!(node.cell_count, 3);
+            assert_eq!(node.min_cost, 1);
+        }
+        // Two tick steps → two flow edges, no punches.
+        assert_eq!(graph.edges.len(), 2);
+        assert!(graph.edges.iter().all(|e| e.kind == EdgeKind::Flow));
+        assert_eq!(graph.edges[0].from, 0);
+        assert_eq!(graph.edges[0].to, 1);
+        assert_eq!(graph.edges[1].from, 1);
+        assert_eq!(graph.edges[1].to, 2);
+    }
+
+    /// Two affordable basins split by a one-cell ridge whose `V` exceeds
+    /// the budget → two components per tick plus a punch edge priced at the
+    /// ridge `V` (the threshold at which raising the budget fuses them).
+    #[test]
+    fn two_basins_split_by_ridge_yield_a_punch_at_ridge_cost() {
+        // 5×1: cells 0,1 affordable (V=1), cell 2 the ridge (V=7), cells
+        // 3,4 affordable (V=1). Budget 5 keeps the ridge above budget.
+        let field = ScalarField {
+            width: 5,
+            height: 1,
+            ticks: 1,
+            values: vec![1, 1, 7, 1, 1],
+        };
+        let graph = build_corridor_graph_core(&field, &stencil_4way(), 5);
+        assert_eq!(
+            graph.nodes.len(),
+            2,
+            "two components either side of the ridge"
+        );
+        assert_eq!(graph.nodes[0].component, 0);
+        assert_eq!(graph.nodes[0].cell_count, 2);
+        assert_eq!(graph.nodes[1].component, 1);
+        assert_eq!(graph.nodes[1].cell_count, 2);
+        assert_eq!(graph.edges.len(), 1, "one punch edge");
+        let punch = &graph.edges[0];
+        assert_eq!(punch.kind, EdgeKind::Punch);
+        assert_eq!(punch.from, 0);
+        assert_eq!(punch.to, 1);
+        assert_eq!(punch.price, 7, "priced at the ridge V");
+        assert_eq!(punch.overlap_width, 0);
+    }
+
+    /// A tick with no affordable cell contributes no node and no edge.
+    #[test]
+    fn all_unaffordable_tick_has_no_nodes() {
+        let field = ScalarField {
+            width: 2,
+            height: 1,
+            ticks: 1,
+            values: vec![20, 20],
+        };
+        let graph = build_corridor_graph_core(&field, &stencil_4way(), 5);
+        assert!(graph.nodes.is_empty());
+        assert!(graph.edges.is_empty());
+    }
+
+    /// An `UNREACHABLE` cell never joins a component even when the budget
+    /// is the maximum value.
+    #[test]
+    fn unreachable_cell_never_enters_a_component() {
+        let field = ScalarField {
+            width: 3,
+            height: 1,
+            ticks: 1,
+            values: vec![1, UNREACHABLE, 1],
+        };
+        let graph = build_corridor_graph_core(&field, &stencil_4way(), u32::MAX);
+        // Cells 0 and 2 are affordable but separated by the unreachable
+        // cell 1, which is never affordable → two single-cell components,
+        // and no finite barrier to punch through (the sentinel is not a
+        // ridge), so no punch edge.
+        assert_eq!(graph.nodes.len(), 2);
+        assert!(graph.nodes.iter().all(|n| n.cell_count == 1));
+        assert!(graph.edges.is_empty());
+    }
+
+    /// A persisting region links tick to tick with exactly one flow edge
+    /// per step.
+    #[test]
+    fn persisting_region_links_each_tick_step() {
+        let width = 2;
+        let height = 2;
+        let ticks = 4;
+        let field = ScalarField {
+            width,
+            height,
+            ticks,
+            values: vec![1u32; (width * height * ticks) as usize],
+        };
+        let graph = build_corridor_graph_core(&field, &stencil_4way(), 10);
+        assert_eq!(graph.nodes.len(), 4);
+        let flow = graph
+            .edges
+            .iter()
+            .filter(|e| e.kind == EdgeKind::Flow)
+            .count();
+        assert_eq!(flow, 3, "one flow edge per tick step");
+        assert!(graph.edges.iter().all(|e| e.kind == EdgeKind::Flow));
+        // Each flow edge carries a positive overlap width.
+        assert!(graph.edges.iter().all(|e| e.overlap_width > 0));
+    }
+
+    /// A region that splits into two then re-merges: out-degree 2 at the
+    /// branch (a node with two forward flow edges) and a join back to one.
+    #[test]
+    fn split_then_merge_branches_then_joins() {
+        // 3×1 grid over 3 ticks.
+        //   t0: [1, 1, 1]      one component (cells 0,1,2)
+        //   t1: [1, 9, 1]      cell 1 a sub-budget barrier → two components
+        //   t2: [1, 1, 1]      one component again
+        // Budget 5: the middle cell at t1 is above budget, splitting the
+        // row into {0} and {2}; the flow from t0's single component
+        // branches to both, then both rejoin into t2's single component.
+        let field = ScalarField {
+            width: 3,
+            height: 1,
+            ticks: 3,
+            values: vec![
+                1, 1, 1, //
+                1, 9, 1, //
+                1, 1, 1, //
+            ],
+        };
+        let graph = build_corridor_graph_core(&field, &stencil_4way(), 5);
+        // t0: 1 node (index 0); t1: 2 nodes (1, 2); t2: 1 node (index 3).
+        assert_eq!(graph.nodes.len(), 4);
+        assert_eq!(graph.nodes[0].tick, 0);
+        assert_eq!(graph.nodes[1].tick, 1);
+        assert_eq!(graph.nodes[2].tick, 1);
+        assert_eq!(graph.nodes[3].tick, 2);
+
+        let flow_from = |n: u32| {
+            graph
+                .edges
+                .iter()
+                .filter(|e| e.kind == EdgeKind::Flow && e.from == n)
+                .count()
+        };
+        let flow_to = |n: u32| {
+            graph
+                .edges
+                .iter()
+                .filter(|e| e.kind == EdgeKind::Flow && e.to == n)
+                .count()
+        };
+        // The t0 component branches to both t1 components (out-degree 2).
+        assert_eq!(flow_from(0), 2, "branch: out-degree equals branch count");
+        // The two t1 components both flow into the single t2 component.
+        assert_eq!(flow_to(3), 2, "join: both branches re-merge");
+    }
+
+    /// Determinism: the same `V` + budget produces byte-identical output.
+    #[test]
+    fn build_is_deterministic() {
+        use aether_data::Kind;
+        let field = ScalarField {
+            width: 5,
+            height: 1,
+            ticks: 3,
+            values: vec![
+                1, 1, 7, 1, 1, //
+                1, 1, 7, 1, 1, //
+                1, 1, 1, 1, 1, //
+            ],
+        };
+        let a = build_corridor_graph_core(&field, &stencil_4way(), 5);
+        let b = build_corridor_graph_core(&field, &stencil_4way(), 5);
+        assert_eq!(a, b);
+        assert_eq!(a.encode_into_bytes(), b.encode_into_bytes());
+    }
+
+    /// The canonical 64×64 × 1800-tick field encodes well under the 64MB
+    /// transform output cap and round-trips byte-stable.
+    #[test]
+    fn canonical_field_encodes_under_cap_and_round_trips() {
+        use aether_data::Kind;
+        const CAP: usize = 64 * 1024 * 1024;
+        let width = 64u32;
+        let height = 64u32;
+        let ticks = 1800u32;
+        let plane = (width * height) as usize;
+        // One affordable basin everywhere → a tiny skeleton (one node per
+        // tick, one flow edge per step), far under the cap.
+        let field = ScalarField {
+            width,
+            height,
+            ticks,
+            values: vec![1u32; plane * ticks as usize],
+        };
+        let graph = build_corridor_graph_core(&field, &stencil_4way(), 10);
+        assert_eq!(graph.nodes.len(), ticks as usize);
+        let bytes = graph.encode_into_bytes();
+        assert!(
+            bytes.len() < CAP,
+            "encoded corridor graph is {} bytes, over the {CAP}-byte cap",
+            bytes.len()
+        );
+        let back = aether_kinds::CorridorGraph::decode_from_bytes(&bytes)
+            .expect("corridor graph round-trips");
+        assert_eq!(graph, back);
+    }
+}

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -112,6 +112,14 @@ pub mod transforms;
 // `solve_cost_to_reach`), so on a wasm-header-only build it would be dead.
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) mod reachability;
+// Pure corridor-graph core (ADR-0047/0048/0049, issue 1858): the
+// connectivity skeleton of a solved cost-to-reach field under a budget.
+// Gated to non-wasm like `reachability` — its caller is the native
+// `build_corridor_graph` transform (and the follow-on passes that reuse
+// the per-tick component labeler), so on a wasm-header-only build it would
+// be dead.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) mod corridor;
 pub mod window;
 
 #[cfg(feature = "audio")]

--- a/crates/aether-capabilities/src/transforms.rs
+++ b/crates/aether-capabilities/src/transforms.rs
@@ -8,9 +8,13 @@
 //! like the DAG executor's `double` / `seed` fixtures.
 
 use aether_data::transform;
-use aether_kinds::{BudgetQuery, Mat4Apply, ReachabilityMargin, ReachabilityProblem, ScalarField};
+use aether_kinds::{
+    BudgetQuery, CorridorGraph, Mat4Apply, MovementStencil, ReachabilityMargin,
+    ReachabilityProblem, ScalarField,
+};
 use aether_math::Vec4;
 
+use crate::corridor::build_corridor_graph_core;
 use crate::reachability::{UNREACHABLE, solve_cost_to_reach};
 
 /// Apply a 4×4 matrix to a 4-vector, `M · v` (ADR-0048's first
@@ -100,6 +104,33 @@ fn reachability_margin(field: ScalarField, query: BudgetQuery) -> ReachabilityMa
         min_cost,
         margin,
     }
+}
+
+/// Build the time-sliced corridor graph of a solved cost-to-reach field
+/// `V` under a budget (ADR-0047/0048/0049, issue 1858). A multi-input
+/// transform: `V` (the `solve` output), the movement stencil shared with
+/// the solver, and the budget query whose `budget` is the affordability
+/// threshold `B`. The output is the connectivity skeleton of `V` — per
+/// tick the connected components of `{cell : V <= B}`, the inter-tick flow
+/// edges, and the intra-tick punch edges priced at the sublevel-filtration
+/// threshold of `V` that fuses them — a flat DAG orders of magnitude
+/// smaller than `V`.
+///
+/// The body delegates to the pure [`build_corridor_graph_core`] (the
+/// reusable internal API the path-snap / validation passes call directly);
+/// the transform fn only unbundles the operands, so it clears the
+/// `#[transform]` purity deny-list.
+// The `#[transform]` ABI hands the body owned kinds decoded from wire
+// bytes; the core borrows them, so the owned `field` / `stencil` params
+// are intentionally passed by reference rather than consumed.
+#[allow(clippy::needless_pass_by_value)]
+#[transform]
+fn build_corridor_graph(
+    field: ScalarField,
+    stencil: MovementStencil,
+    query: BudgetQuery,
+) -> CorridorGraph {
+    build_corridor_graph_core(&field, &stencil.offsets, query.budget)
 }
 
 #[cfg(test)]
@@ -356,5 +387,71 @@ mod reachability_transform_tests {
 
         let back = ScalarField::decode_from_bytes(&bytes).expect("canonical field round-trips");
         assert_eq!(field, back);
+    }
+}
+
+#[cfg(test)]
+mod corridor_transform_tests {
+    use super::build_corridor_graph;
+    use aether_data::{Kind, transforms};
+    use aether_kinds::{
+        BudgetQuery, CorridorGraph, EdgeKind, MovementStencil, ScalarField, StencilOffset,
+    };
+
+    fn stencil_4way() -> MovementStencil {
+        MovementStencil {
+            offsets: vec![
+                StencilOffset { dx: 0, dy: 0 },
+                StencilOffset { dx: 1, dy: 0 },
+                StencilOffset { dx: -1, dy: 0 },
+                StencilOffset { dx: 0, dy: 1 },
+                StencilOffset { dx: 0, dy: -1 },
+            ],
+        }
+    }
+
+    /// 5×1 field with a sub-budget ridge at cell 2, driven through the
+    /// transform: two components and a punch priced at the ridge `V`.
+    fn ridge_field() -> ScalarField {
+        ScalarField {
+            width: 5,
+            height: 1,
+            ticks: 1,
+            values: vec![1, 1, 7, 1, 1],
+        }
+    }
+
+    #[test]
+    fn transform_produces_components_and_a_punch() {
+        let graph = build_corridor_graph(ridge_field(), stencil_4way(), BudgetQuery { budget: 5 });
+        assert_eq!(graph.nodes.len(), 2);
+        assert_eq!(graph.edges.len(), 1);
+        assert_eq!(graph.edges[0].kind, EdgeKind::Punch);
+        assert_eq!(graph.edges[0].price, 7);
+    }
+
+    #[test]
+    fn registered_in_link_time_inventory() {
+        // A three-input transform: `(ScalarField, MovementStencil,
+        // BudgetQuery)` in slot order, `CorridorGraph` out — the same
+        // inventory contract `solve` / `reachability_margin` satisfy.
+        let entry = transforms()
+            .find(|t| t.name.ends_with("::build_corridor_graph"))
+            .expect("build_corridor_graph not registered in link-time inventory");
+        assert_eq!(
+            entry.input_kind_ids,
+            [ScalarField::ID, MovementStencil::ID, BudgetQuery::ID]
+        );
+        assert_eq!(entry.output_kind_id, CorridorGraph::ID);
+    }
+
+    #[test]
+    fn build_is_deterministic_and_content_addressable() {
+        // Same input bytes -> identical output bytes: the content-addressing
+        // contract the DAG executor keys transform results on.
+        let a = build_corridor_graph(ridge_field(), stencil_4way(), BudgetQuery { budget: 5 });
+        let b = build_corridor_graph(ridge_field(), stencil_4way(), BudgetQuery { budget: 5 });
+        assert_eq!(a, b);
+        assert_eq!(a.encode_into_bytes(), b.encode_into_bytes());
     }
 }

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -3844,6 +3844,94 @@ mod control_plane {
         pub min_cost: u32,
         pub margin: i64,
     }
+
+    // ADR-0047/0048/0049 corridor-graph vocabulary (issue 1858). The
+    // time-sliced connectivity skeleton of a solved cost-to-reach field
+    // `V` (a [`ScalarField`]) under a budget `B`: per tick, the connected
+    // components of the affordable set `{cell : V(cell, tick) <= B}` (the
+    // nodes), the intra-tick "punch" edges a sub-budget barrier separates
+    // (priced at the sublevel-filtration threshold of `V` at which raising
+    // `B` would merge them), and the inter-tick "flow" edges between
+    // components an affordable one-tick stencil step links. A flat,
+    // postcard-friendly DAG built by the `build_corridor_graph` transform
+    // in `aether-capabilities`: nodes carry summaries, not cell sets, so
+    // the graph stays orders of magnitude smaller than `V`, and components
+    // are re-derivable from `V` + `B` + the [`MovementStencil`] (all
+    // content-addressed) rather than stored as per-tick label images.
+    // `Vec`-bearing like [`crate::DrawTexturedQuads`].
+
+    /// One node in a [`CorridorGraph`] — a single connected component of
+    /// the affordable set `{cell : V(cell, tick) <= budget}` at one tick.
+    /// A summary, not a cell set. `tick` is the time layer (the row-major
+    /// `(tick, y, x)` slice convention is [`ScalarField`]'s); `component`
+    /// is the component's per-tick id, assigned in row-major
+    /// first-encounter order over the tick's affordable cells, so two
+    /// builds of the same `V` + budget label identically; `cell_count` is
+    /// the number of affordable cells the component covers; `min_cost` is
+    /// the minimum cost-to-reach (`V`) over those cells. A node is
+    /// referenced from a [`CorridorEdge`] by its index into
+    /// [`CorridorGraph::nodes`], which is ordered by `(tick, component)`.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct CorridorNode {
+        pub tick: u32,
+        pub component: u32,
+        pub cell_count: u32,
+        pub min_cost: u32,
+    }
+
+    /// Whether a [`CorridorEdge`] joins two components already connected
+    /// under the budget (`Flow`) or a pair a sub-budget barrier currently
+    /// separates (`Punch`). `Flow` edges are inter-tick (a component at
+    /// tick `t` to one at `t + 1`); `Punch` edges are intra-tick (two
+    /// components at the same tick that the sublevel filtration of `V`
+    /// would merge above the budget). Kept as two distinct kinds, plus the
+    /// edge's `price`, so "connected now" never collapses into "connected
+    /// at higher budget."
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum EdgeKind {
+        Flow,
+        Punch,
+    }
+
+    /// One directed edge in a [`CorridorGraph`]. `from` and `to` index
+    /// into [`CorridorGraph::nodes`]; the graph is a time-layered DAG, so
+    /// a `Flow` edge always points forward in time (`from` at tick `t`,
+    /// `to` at tick `t + 1`) and a `Punch` edge joins two components at the
+    /// same tick. `price` is the punch's merge threshold — the budget at
+    /// which the sublevel filtration of `V` fuses the two components (the
+    /// minimum `V` along the separating barrier) — and is `0` for a `Flow`
+    /// edge. `overlap_width` is the count of distinct affordable landing
+    /// cells the stencil step bridges for a `Flow` edge (how wide the
+    /// pinch/branch is) and is `0` for a `Punch` edge. Both `price` and
+    /// `overlap_width` are public: a consumer recovers "what merges at
+    /// `B'`" by thresholding punch prices, and reads `overlap_width` to
+    /// render branch width.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct CorridorEdge {
+        pub from: u32,
+        pub to: u32,
+        pub kind: EdgeKind,
+        pub price: u32,
+        pub overlap_width: u32,
+    }
+
+    /// The time-sliced corridor graph (issue 1858): the connectivity
+    /// skeleton of a solved cost-to-reach field `V` under a fixed budget.
+    /// `nodes` are the per-tick connected components of the affordable set,
+    /// ordered by `(tick, component)`; `edges` are the inter-tick `Flow`
+    /// links and the intra-tick `Punch` merges, emitted sorted by endpoints
+    /// then kind so the output is byte-stable and content-addressable. A
+    /// skeleton, not a field: it carries no cell-to-component label image,
+    /// so its size scales with the number of components and edges rather
+    /// than `width * height * ticks`.
+    #[derive(
+        aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq,
+    )]
+    #[kind(name = "aether.corridor.graph")]
+    pub struct CorridorGraph {
+        pub nodes: Vec<CorridorNode>,
+        pub edges: Vec<CorridorEdge>,
+    }
 }
 
 mod trajectory {
@@ -4172,6 +4260,7 @@ mod tests {
         assert_eq!(ReachabilityProblem::NAME, "aether.reach.problem");
         assert_eq!(BudgetQuery::NAME, "aether.reach.budget_query");
         assert_eq!(ReachabilityMargin::NAME, "aether.reach.margin");
+        assert_eq!(CorridorGraph::NAME, "aether.corridor.graph");
     }
 
     // ADR-0019 PR 3 — every kind below now has a derived `Schema` impl
@@ -4297,6 +4386,48 @@ mod tests {
             assert_eq!(fields[1].ty, SchemaType::Scalar(Primitive::U32));
             assert_eq!(fields[2].name, "margin");
             assert_eq!(fields[2].ty, SchemaType::Scalar(Primitive::I64));
+        }
+
+        #[test]
+        fn corridor_graph_schema_is_struct_of_two_vecs() {
+            // The corridor graph is a flat DAG: a `Vec<CorridorNode>` and a
+            // `Vec<CorridorEdge>`, both recursing into their element
+            // structs. A `Struct` schema (not a cast) is what the DAG
+            // validator and the hub codec read for the transform output.
+            let SchemaType::Struct { fields, .. } = &<CorridorGraph as Schema>::SCHEMA else {
+                panic!("expected Struct");
+            };
+            assert_eq!(fields.len(), 2);
+            assert_eq!(fields[0].name, "nodes");
+            let SchemaType::Vec(node) = &fields[0].ty else {
+                panic!("expected Vec of nodes");
+            };
+            assert!(matches!(**node, SchemaType::Struct { .. }));
+            assert_eq!(fields[1].name, "edges");
+            let SchemaType::Vec(edge) = &fields[1].ty else {
+                panic!("expected Vec of edges");
+            };
+            assert!(matches!(**edge, SchemaType::Struct { .. }));
+        }
+
+        #[test]
+        fn corridor_graph_id_distinct_from_reach_kinds() {
+            use aether_data::Kind;
+            // The corridor output shares no id with the reachability kinds
+            // it composes with in a DAG — a collision would alias the
+            // transform's `Ref<CorridorGraph>` output slot.
+            let ids = [
+                CorridorGraph::ID,
+                ScalarField::ID,
+                MovementStencil::ID,
+                BudgetQuery::ID,
+                ReachabilityMargin::ID,
+            ];
+            for (i, a) in ids.iter().enumerate() {
+                for b in &ids[i + 1..] {
+                    assert_ne!(a, b, "corridor / reach kind ids must be distinct");
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Closes #1858.

## Summary

A time-sliced corridor graph over #1857's cost-to-reach field (`aether-capabilities::corridor`): one iterative union-find sublevel filtration per tick yields connected components + punch thresholds; predecessor-counted flow edges connect them across ticks with a byte-stable sort. New `CorridorGraph` kind (`aether.corridor.graph`) with inner `CorridorNode`/`CorridorEdge`/`EdgeKind`, and a `#[transform] build_corridor_graph(ScalarField, MovementStencil, BudgetQuery) -> CorridorGraph`. A crate-visible `label_tick_components` is exposed for #1865's per-edge density aggregation.

## Test plan

Kind name/schema/id-distinctness tests; core component + flow-edge tests; transform inventory-registration, determinism, and a canonical 64×64×1800 size/replay check (~4s, in line with #1857's canonical test). Iterative (no recursion). Full workspace green: clippy `-D warnings`, nextest `--workspace` (1880 passed), doc, wasm32 cross-build.

## Generated by

`/implement` — agent execution of [scoped issue #1858](https://github.com/iamacoffeepot/aether/issues/1858).
