### PR TITLE
feat(capabilities): reaction-delayed agent population over a space-time cost field (completion-rate vs reaction-delay sweep)

### DIFF
--- a/crates/aether-capabilities/src/reachability.rs
+++ b/crates/aether-capabilities/src/reachability.rs
@@ -454,12 +454,12 @@ pub fn solve_population_sweep(problem: PopulationSweepProblem) -> SurvivalCurve 
 /// population, corridor, and population-transform test modules reuse one
 /// definition instead of redeclaring it.
 #[cfg(test)]
-pub(crate) mod test_fields {
-    pub(crate) use super::UNREACHABLE;
+pub mod test_fields {
+    pub use super::UNREACHABLE;
     use aether_kinds::{MovementStencil, StencilOffset};
 
     /// Stay + the four orthogonal one-cell moves, as raw offsets.
-    pub(crate) fn stencil_offsets() -> Vec<StencilOffset> {
+    pub fn stencil_offsets() -> Vec<StencilOffset> {
         vec![
             StencilOffset { dx: 0, dy: 0 },
             StencilOffset { dx: 1, dy: 0 },
@@ -471,7 +471,7 @@ pub(crate) mod test_fields {
 
     /// The same 4-way move set wrapped in a [`MovementStencil`] — the form
     /// the `ReachabilityProblem` / transform tests bundle.
-    pub(crate) fn stencil_4way() -> MovementStencil {
+    pub fn stencil_4way() -> MovementStencil {
         MovementStencil {
             offsets: stencil_offsets(),
         }
@@ -574,9 +574,7 @@ mod tests {
 mod population_tests {
     use super::test_fields::stencil_offsets as stencil_4way;
     use super::{UNREACHABLE, solve_cost_to_reach, solve_population_sweep};
-    use aether_kinds::{
-        MovementStencil, PopulationSweepProblem, ReachabilityProblem, ScalarField,
-    };
+    use aether_kinds::{MovementStencil, PopulationSweepProblem, ReachabilityProblem, ScalarField};
 
     /// Build a sweep problem from a single start cell (the rest of the
     /// start region is the sentinel, so the population is sampled entirely

--- a/crates/aether-capabilities/src/reachability.rs
+++ b/crates/aether-capabilities/src/reachability.rs
@@ -16,7 +16,10 @@
 //! deterministic, and integer-exact, so a given field replays
 //! identically.
 
-use aether_kinds::StencilOffset;
+use aether_kinds::{
+    MovementStencil, PopulationSweepProblem, ReachabilityProblem, ScalarField, StencilOffset,
+    SurvivalCurve, SurvivalSample,
+};
 
 /// The reserved sentinel shared by cost fields and the solved
 /// cost-to-reach field. In a cost field it marks a blocked / impassable
@@ -113,13 +116,350 @@ pub fn solve_cost_to_reach(
     v
 }
 
-#[cfg(test)]
-mod tests {
-    use super::{UNREACHABLE, solve_cost_to_reach};
-    use aether_kinds::StencilOffset;
+/// A hand-rolled xorshift64 PRNG (the established in-tree pattern —
+/// `audio.rs`'s per-voice xorshift32, `aether-kit`'s `arena.rs`
+/// xorshift64 — so the population sweep needs no `rand` dependency). The
+/// sequence is a pure function of the seed, so seeding it from the
+/// transform's `seed` *input* keeps the whole sweep content-addressable
+/// (ADR-0048 §4/§130): same seed + field → byte-identical curve.
+struct Xorshift64 {
+    state: u64,
+}
 
-    /// Stay + the four orthogonal one-cell moves.
-    fn stencil_4way() -> Vec<StencilOffset> {
+impl Xorshift64 {
+    /// Seed the generator, forcing the state non-zero (xorshift64 is
+    /// stuck at zero), the same guard `audio.rs` applies to its
+    /// voice-keyed noise PRNG.
+    fn seeded(seed: u64) -> Self {
+        Self {
+            state: if seed == 0 {
+                0x9E37_79B9_7F4A_7C15
+            } else {
+                seed
+            },
+        }
+    }
+
+    /// One xorshift64 step (the `13 / 7 / 17` triple `arena.rs` uses).
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.state;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.state = x;
+        x
+    }
+
+    /// A draw in `0..bound` (`bound >= 1`).
+    fn next_bounded(&mut self, bound: usize) -> usize {
+        let reduced = self.next_u64() % bound as u64;
+        // `reduced < bound`, so it always fits a `usize` (even where the
+        // pointer is 32-bit and `bound` was widened to `u64`).
+        usize::try_from(reduced).unwrap_or(0)
+    }
+}
+
+/// Derive a per-agent seed from the sweep seed and the agent index — the
+/// splitmix64 finalizer, so each agent gets its own well-mixed tie-break
+/// stream. Folding *only* the seed and the index (not the delay) in is
+/// deliberate: agent `i`'s PRNG starts identically at every swept delay,
+/// so the only thing that changes the agent's fate across the sweep is
+/// the reaction lag, not a reshuffled tie-break stream.
+fn agent_seed(seed: u64, index: u64) -> u64 {
+    let mut z = seed.wrapping_add(index.wrapping_mul(0x9E37_79B9_7F4A_7C15));
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+/// Pick one candidate, breaking a tie with the PRNG (a single draw only
+/// when there is an actual tie, so a tie-free field consumes no entropy
+/// and the stream stays predictable).
+fn pick_tie(rng: &mut Xorshift64, candidates: &[usize]) -> usize {
+    match candidates.len() {
+        0 => usize::MAX,
+        1 => candidates[0],
+        n => candidates[rng.next_bounded(n)],
+    }
+}
+
+/// The per-agent receding-horizon planner (issue 1863). The agent sits at
+/// flat cell `current` on real tick `now`; it solves the **exact**
+/// [`solve_cost_to_reach`] core over its perceived window — the field as
+/// it truly was `delay` ticks earlier for each window layer — and returns
+/// the first cell of the optimal path to the cheapest perceived goal.
+/// Committing that one step and re-planning next tick is #1859's `S = 1`
+/// receding horizon, per agent. Returns `current` (stay put) when no goal
+/// is visible inside the window.
+///
+/// Binding the planner to the same core the exact solver uses is the load-
+/// bearing move: at `delay = 0` and `window >= ticks` the perceived field
+/// is the true field over the full remaining horizon, so the plan *is* the
+/// exact single-source solve and the greedy traces an optimal path —
+/// reaching the cheapest goal with exactly its certified cost.
+#[allow(clippy::too_many_arguments)]
+fn plan_next_cell(
+    width: usize,
+    height: usize,
+    ticks: usize,
+    costs: &[u32],
+    stencil: &[StencilOffset],
+    goal: &[usize],
+    current: usize,
+    now: usize,
+    window: usize,
+    delay: usize,
+    rng: &mut Xorshift64,
+) -> usize {
+    let plane = width.saturating_mul(height);
+    if plane == 0 || now + 1 >= ticks {
+        return current;
+    }
+    // The window spans real ticks [now ..= horizon_end]; layer k is real
+    // tick now + k, perceived as the true field at tick max(0, real - d).
+    let horizon_end = (now + window).min(ticks - 1);
+    let layers = horizon_end - now + 1;
+    if layers < 2 {
+        return current;
+    }
+
+    let mut perceived = vec![UNREACHABLE; plane * layers];
+    for k in 0..layers {
+        let real_tick = now + k;
+        let src_tick = real_tick.saturating_sub(delay);
+        let src_base = src_tick * plane;
+        let dst_base = k * plane;
+        for idx in 0..plane {
+            perceived[dst_base + idx] = costs.get(src_base + idx).copied().unwrap_or(UNREACHABLE);
+        }
+    }
+
+    let mut seed = vec![UNREACHABLE; plane];
+    seed[current] = 0;
+    let v = solve_cost_to_reach(width, height, layers, &perceived, stencil, &seed);
+
+    // Cheapest perceived goal arrival over layers 1..layers (layer 0 is
+    // the seed). Among equal-cost arrivals, the PRNG breaks the tie.
+    let mut best_cost = UNREACHABLE;
+    let mut best_targets: Vec<(usize, usize)> = Vec::new();
+    for k in 1..layers {
+        let layer_base = k * plane;
+        for &g in goal {
+            if g >= plane {
+                continue;
+            }
+            let cost = v[layer_base + g];
+            if cost == UNREACHABLE {
+                continue;
+            }
+            if cost < best_cost {
+                best_cost = cost;
+                best_targets.clear();
+                best_targets.push((g, k));
+            } else if cost == best_cost {
+                best_targets.push((g, k));
+            }
+        }
+    }
+    if best_targets.is_empty() {
+        return current;
+    }
+    let pick = if best_targets.len() == 1 {
+        0
+    } else {
+        rng.next_bounded(best_targets.len())
+    };
+    let (mut cur, mut layer) = best_targets[pick];
+
+    // Backtrack along an optimal predecessor chain to layer 1; that cell
+    // is the agent's next step. `cur(layer)` drew from `cur - offset` on
+    // `layer - 1`, mirroring the forward sweep's predecessor read.
+    while layer > 1 {
+        let x = cur % width;
+        let y = cur / width;
+        let target = v[layer * plane + cur];
+        let landed = perceived[layer * plane + cur];
+        let mut preds: Vec<usize> = Vec::new();
+        for offset in stencil {
+            let Some(px) = predecessor_coord(x, offset.dx, width) else {
+                continue;
+            };
+            let Some(py) = predecessor_coord(y, offset.dy, height) else {
+                continue;
+            };
+            let p = py * width + px;
+            let pv = v[(layer - 1) * plane + p];
+            if pv != UNREACHABLE && landed.saturating_add(pv) == target {
+                preds.push(p);
+            }
+        }
+        if preds.is_empty() {
+            // No reconstructable predecessor (degenerate perceived field) —
+            // stay rather than step blind.
+            return current;
+        }
+        cur = pick_tie(rng, &preds);
+        layer -= 1;
+    }
+    cur
+}
+
+/// Simulate one reaction-delayed agent from `start` under reaction lag
+/// `delay`, returning whether it finishes (lands on a goal cell with
+/// accumulated cost `< budget`) before the final tick. Accumulates the
+/// **true** (un-lagged) cost of every cell it lands on — the lag only
+/// clouds the agent's *plan*, never the cost it actually pays.
+#[allow(clippy::too_many_arguments)]
+fn simulate_agent(
+    width: usize,
+    height: usize,
+    ticks: usize,
+    costs: &[u32],
+    stencil: &[StencilOffset],
+    goal: &[usize],
+    start: usize,
+    start_cost: u32,
+    budget: u32,
+    window: usize,
+    delay: usize,
+    rng: &mut Xorshift64,
+) -> bool {
+    let plane = width.saturating_mul(height);
+    let is_goal = |cell: usize| goal.contains(&cell);
+
+    let mut current = start;
+    let mut acc = start_cost;
+    if acc < budget && is_goal(current) {
+        return true;
+    }
+
+    for now in 0..ticks.saturating_sub(1) {
+        let next = plan_next_cell(
+            width, height, ticks, costs, stencil, goal, current, now, window, delay, rng,
+        );
+        let landed_tick = now + 1;
+        let true_cost = costs
+            .get(landed_tick * plane + next)
+            .copied()
+            .unwrap_or(UNREACHABLE);
+        acc = acc.saturating_add(true_cost);
+        current = next;
+        if acc < budget && is_goal(current) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Run a seeded Monte-Carlo population of reaction-delayed agents over a
+/// time-varying scalar cost field and emit the completion-rate-vs-
+/// reaction-delay curve (issue 1863). Each agent's planner is #1857's
+/// exact [`solve_cost_to_reach`] degraded by a per-tick perceived-field
+/// lag, so at `delay = 0` with a full window the survival fraction
+/// approaches the exact reachable-under-budget bound.
+///
+/// The whole sweep is a pure function of `problem` (seed + field in,
+/// curve out): the PRNG samples the population once from the start region,
+/// then every swept delay re-simulates that same population, so the only
+/// variable across the curve is the reaction lag. Iterative throughout
+/// (the per-agent window solve and the simulation loop are bounded; no
+/// recursion, per the load-bearing-code rule).
+pub fn solve_population_sweep(problem: PopulationSweepProblem) -> SurvivalCurve {
+    let PopulationSweepProblem {
+        problem:
+            ReachabilityProblem {
+                cost:
+                    ScalarField {
+                        width,
+                        height,
+                        ticks,
+                        values: costs,
+                    },
+                stencil: MovementStencil { offsets: stencil },
+                start: start_seed,
+            },
+        goal: goal_indices,
+        budget,
+        population,
+        window,
+        seed,
+        delays,
+    } = problem;
+    let width = width as usize;
+    let height = height as usize;
+    let ticks = ticks as usize;
+    let window = window as usize;
+    let plane = width.saturating_mul(height);
+
+    let goal: Vec<usize> = goal_indices
+        .iter()
+        .map(|&g| g as usize)
+        .filter(|&g| g < plane)
+        .collect();
+
+    // The start region is every cell with a finite seed value; each agent
+    // inherits its sampled cell's seed as its initial accumulated cost.
+    let start_cells: Vec<usize> = (0..plane)
+        .filter(|&c| start_seed.get(c).copied().unwrap_or(UNREACHABLE) != UNREACHABLE)
+        .collect();
+
+    // Sample the population once (so the same agents are replayed at every
+    // delay) — a no-op when the start region is empty.
+    let mut spawn_rng = Xorshift64::seeded(seed);
+    let agents: Vec<usize> = if start_cells.is_empty() {
+        Vec::new()
+    } else {
+        (0..population)
+            .map(|_| start_cells[spawn_rng.next_bounded(start_cells.len())])
+            .collect()
+    };
+
+    let mut samples = Vec::with_capacity(delays.len());
+    for &delay in &delays {
+        let delay_ticks = delay as usize;
+        let mut finished: u32 = 0;
+        for (i, &start) in agents.iter().enumerate() {
+            let start_cost = start_seed.get(start).copied().unwrap_or(UNREACHABLE);
+            let mut rng = Xorshift64::seeded(agent_seed(seed, i as u64 + 1));
+            if simulate_agent(
+                width,
+                height,
+                ticks,
+                &costs,
+                &stencil,
+                &goal,
+                start,
+                start_cost,
+                budget,
+                window,
+                delay_ticks,
+                &mut rng,
+            ) {
+                finished += 1;
+            }
+        }
+        samples.push(SurvivalSample { delay, finished });
+    }
+
+    SurvivalCurve {
+        population,
+        samples,
+    }
+}
+
+/// Shared cost-field fixtures for this crate's `#[cfg(test)]` modules: the
+/// `stencil_4way` movement set lives here once (returned both as raw
+/// [`StencilOffset`]s for the solver-core tests and wrapped in a
+/// [`MovementStencil`] for the transform tests) so the reachability,
+/// population, corridor, and population-transform test modules reuse one
+/// definition instead of redeclaring it.
+#[cfg(test)]
+pub(crate) mod test_fields {
+    pub(crate) use super::UNREACHABLE;
+    use aether_kinds::{MovementStencil, StencilOffset};
+
+    /// Stay + the four orthogonal one-cell moves, as raw offsets.
+    pub(crate) fn stencil_offsets() -> Vec<StencilOffset> {
         vec![
             StencilOffset { dx: 0, dy: 0 },
             StencilOffset { dx: 1, dy: 0 },
@@ -128,6 +468,21 @@ mod tests {
             StencilOffset { dx: 0, dy: -1 },
         ]
     }
+
+    /// The same 4-way move set wrapped in a [`MovementStencil`] — the form
+    /// the `ReachabilityProblem` / transform tests bundle.
+    pub(crate) fn stencil_4way() -> MovementStencil {
+        MovementStencil {
+            offsets: stencil_offsets(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_fields::stencil_offsets as stencil_4way;
+    use super::{UNREACHABLE, solve_cost_to_reach};
+    use aether_kinds::StencilOffset;
 
     #[test]
     fn single_start_cell_seeds_t0_others_unreachable() {
@@ -211,6 +566,293 @@ mod tests {
             for cell in 1..plane {
                 assert_eq!(v[t * plane + cell], UNREACHABLE, "no path -> stays MAX");
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod population_tests {
+    use super::test_fields::stencil_offsets as stencil_4way;
+    use super::{UNREACHABLE, solve_cost_to_reach, solve_population_sweep};
+    use aether_kinds::{
+        MovementStencil, PopulationSweepProblem, ReachabilityProblem, ScalarField,
+    };
+
+    /// Build a sweep problem from a single start cell (the rest of the
+    /// start region is the sentinel, so the population is sampled entirely
+    /// from `start_cell`).
+    #[allow(clippy::too_many_arguments)]
+    fn single_start_problem(
+        width: u32,
+        height: u32,
+        ticks: u32,
+        values: Vec<u32>,
+        start_cell: usize,
+        goal: Vec<u32>,
+        budget: u32,
+        population: u32,
+        window: u32,
+        seed: u64,
+        delays: Vec<u32>,
+    ) -> PopulationSweepProblem {
+        let plane = (width * height) as usize;
+        let mut start = vec![UNREACHABLE; plane];
+        start[start_cell] = 0;
+        PopulationSweepProblem {
+            problem: ReachabilityProblem {
+                cost: ScalarField {
+                    width,
+                    height,
+                    ticks,
+                    values,
+                },
+                stencil: MovementStencil {
+                    offsets: stencil_4way(),
+                },
+                start,
+            },
+            goal,
+            budget,
+            population,
+            window,
+            seed,
+            delays,
+        }
+    }
+
+    /// The exact certificate: the minimum cost to reach any goal cell from
+    /// `start_cell` over the full horizon (#1857's machinery — a single-
+    /// source `solve_cost_to_reach` plus a goal-region min readout).
+    fn certificate_min(
+        width: usize,
+        height: usize,
+        ticks: usize,
+        values: &[u32],
+        start_cell: usize,
+        goal: &[u32],
+    ) -> u32 {
+        let plane = width * height;
+        let mut seed = vec![UNREACHABLE; plane];
+        seed[start_cell] = 0;
+        let v = solve_cost_to_reach(width, height, ticks, values, &stencil_4way(), &seed);
+        let mut best = UNREACHABLE;
+        for t in 0..ticks {
+            for &g in goal {
+                best = best.min(v[t * plane + g as usize]);
+            }
+        }
+        best
+    }
+
+    #[test]
+    fn zero_delay_full_window_matches_exact_reachable_under_budget() {
+        // 3×1 uniform-cost field, start at cell 0, goal = {cell 2}. The
+        // exact min cost to reach the goal is 2 (cell 2 first reachable at
+        // t = 2). A full-window (W >= ticks), zero-lag population must
+        // finish iff the budget strictly clears that certificate — and a
+        // d = 0 wipe against a *reachable* certificate is exactly the
+        // planner gap this guards.
+        let values = vec![1u32; 9];
+        let goal = vec![2u32];
+        let cert = certificate_min(3, 1, 3, &values, 0, &goal);
+        assert_eq!(cert, 2, "hand-checked exact cost-to-reach the goal");
+
+        // budget 5 > cert -> reachable -> the whole population finishes.
+        let reachable = solve_population_sweep(single_start_problem(
+            3,
+            1,
+            3,
+            values.clone(),
+            0,
+            goal.clone(),
+            5,
+            8,
+            8,
+            0xA17E,
+            vec![0],
+        ));
+        assert_eq!(reachable.population, 8);
+        assert_eq!(
+            reachable.samples[0].finished, 8,
+            "d=0 must finish from a reachable-under-budget start (planner-gap guard)"
+        );
+
+        // budget == cert -> strict `< budget` fails -> nobody finishes.
+        let at_threshold = solve_population_sweep(single_start_problem(
+            3,
+            1,
+            3,
+            values,
+            0,
+            goal,
+            2,
+            8,
+            8,
+            0xA17E,
+            vec![0],
+        ));
+        assert_eq!(at_threshold.samples[0].finished, 0);
+    }
+
+    #[test]
+    fn survival_is_non_increasing_across_a_delay_sweep() {
+        // A false-corridor field on a 2×3 grid. The left column cell (0,1)
+        // (index 2) is open at t = 0 but blocks at every later tick; the
+        // right column stays open. A zero-lag agent sees the future block
+        // and routes right to the goal row; a lagged agent reacts to the
+        // stale (open) left corridor, steps onto (0,1), and dies when the
+        // true field has it blocked. So survival is 1 at d = 0 and 0 once
+        // the lag clouds the block — strictly non-increasing.
+        let width = 2u32;
+        let height = 3u32;
+        let ticks = 4u32;
+        let plane = (width * height) as usize;
+        let mut values = vec![1u32; plane * ticks as usize];
+        for t in 1..ticks as usize {
+            values[t * plane + 2] = UNREACHABLE; // (0,1) blocks from t = 1 on
+        }
+        // d = 0: the certificate says the goal row is reachable.
+        let cert = certificate_min(2, 3, 4, &values, 0, &[4, 5]);
+        assert_eq!(cert, 3, "right-column route to (1,2) costs 3");
+
+        let curve = solve_population_sweep(single_start_problem(
+            width,
+            height,
+            ticks,
+            values,
+            0,
+            vec![4, 5],
+            100,
+            1,
+            8,
+            0x00C0_FFEE,
+            vec![0, 1, 2, 3],
+        ));
+        let finished: Vec<u32> = curve.samples.iter().map(|s| s.finished).collect();
+        assert_eq!(finished, vec![1, 0, 0, 0], "lag strictly hurts past d = 0");
+        for pair in finished.windows(2) {
+            assert!(
+                pair[1] <= pair[0],
+                "survival must be non-increasing in delay"
+            );
+        }
+    }
+
+    #[test]
+    fn unreachable_certificate_yields_zero_finishers_at_every_delay() {
+        // 3×1 grid with cell 1 walled off every tick; the goal (cell 2)
+        // sits behind the wall, so no path reaches it at any delay — no
+        // false positives.
+        let mut values = vec![1u32; 9];
+        for t in 0..3 {
+            values[t * 3 + 1] = UNREACHABLE;
+        }
+        let cert = certificate_min(3, 1, 3, &values, 0, &[2]);
+        assert_eq!(cert, UNREACHABLE, "goal is walled off");
+
+        let curve = solve_population_sweep(single_start_problem(
+            3,
+            1,
+            3,
+            values,
+            0,
+            vec![2],
+            1000,
+            16,
+            8,
+            0xBEEF,
+            vec![0, 1, 2],
+        ));
+        for sample in &curve.samples {
+            assert_eq!(
+                sample.finished, 0,
+                "an unreachable certificate finishes nobody at any delay"
+            );
+        }
+    }
+
+    #[test]
+    fn population_fraction_is_stable_under_doubling() {
+        // A 5×1 grid with a wall at cell 3 and a start region {cell 0,
+        // cell 4} either side of the goal (cell 2). Agents sampled at
+        // cell 0 reach the goal; those at cell 4 are walled off — so the
+        // survival fraction tracks the sampler's split of the region, and
+        // is stable (the same fraction in expectation) when the population
+        // doubles.
+        let mut values = vec![1u32; 5 * 4];
+        for t in 0..4 {
+            values[t * 5 + 3] = UNREACHABLE; // wall at cell 3
+        }
+        let region_problem = |population: u32| {
+            let plane = 5usize;
+            let mut start = vec![UNREACHABLE; plane];
+            start[0] = 0;
+            start[4] = 0;
+            PopulationSweepProblem {
+                problem: ReachabilityProblem {
+                    cost: ScalarField {
+                        width: 5,
+                        height: 1,
+                        ticks: 4,
+                        values: values.clone(),
+                    },
+                    stencil: MovementStencil {
+                        offsets: stencil_4way(),
+                    },
+                    start,
+                },
+                goal: vec![2],
+                budget: 100,
+                population,
+                window: 8,
+                seed: 0x5EED,
+                delays: vec![0],
+            }
+        };
+
+        let small = solve_population_sweep(region_problem(128));
+        let large = solve_population_sweep(region_problem(256));
+        let frac_small = f64::from(small.samples[0].finished) / 128.0;
+        let frac_large = f64::from(large.samples[0].finished) / 256.0;
+        assert!(
+            (0.3..0.7).contains(&frac_small),
+            "half the region reaches the goal: frac_small = {frac_small}"
+        );
+        assert!(
+            (frac_small - frac_large).abs() < 0.15,
+            "doubling the population keeps the fraction stable: {frac_small} vs {frac_large}"
+        );
+    }
+
+    #[test]
+    fn empty_start_region_finishes_nobody() {
+        // No finite start seed -> no spawn cells -> every agent fails, and
+        // the curve still reports one sample per swept delay.
+        let plane = 4usize;
+        let problem = PopulationSweepProblem {
+            problem: ReachabilityProblem {
+                cost: ScalarField {
+                    width: 2,
+                    height: 2,
+                    ticks: 3,
+                    values: vec![1u32; plane * 3],
+                },
+                stencil: MovementStencil {
+                    offsets: stencil_4way(),
+                },
+                start: vec![UNREACHABLE; plane],
+            },
+            goal: vec![3],
+            budget: 100,
+            population: 8,
+            window: 4,
+            seed: 1,
+            delays: vec![0, 2],
+        };
+        let curve = solve_population_sweep(problem);
+        assert_eq!(curve.samples.len(), 2);
+        for sample in &curve.samples {
+            assert_eq!(sample.finished, 0);
         }
     }
 }

--- a/crates/aether-capabilities/src/transforms.rs
+++ b/crates/aether-capabilities/src/transforms.rs
@@ -9,13 +9,13 @@
 
 use aether_data::transform;
 use aether_kinds::{
-    BudgetQuery, CorridorGraph, Mat4Apply, MovementStencil, ReachabilityMargin,
-    ReachabilityProblem, ScalarField,
+    BudgetQuery, CorridorGraph, Mat4Apply, MovementStencil, PopulationSweepProblem,
+    ReachabilityMargin, ReachabilityProblem, ScalarField, SurvivalCurve,
 };
 use aether_math::Vec4;
 
 use crate::corridor::build_corridor_graph_core;
-use crate::reachability::{UNREACHABLE, solve_cost_to_reach};
+use crate::reachability::{UNREACHABLE, solve_cost_to_reach, solve_population_sweep};
 
 /// Apply a 4×4 matrix to a 4-vector, `M · v` (ADR-0048's first
 /// first-party transform). `Mat4Apply` bundles both operands so the
@@ -133,6 +133,27 @@ fn build_corridor_graph(
     build_corridor_graph_core(&field, &stencil.offsets, query.budget)
 }
 
+/// Sweep a seeded Monte-Carlo population of reaction-delayed agents over a
+/// time-varying scalar cost field, emitting the completion-rate-vs-
+/// reaction-delay curve (issue 1863). `PopulationSweepProblem` bundles the
+/// shared reachability operands (field, stencil, start region), the goal
+/// region, and the sweep parameters (budget, population, window, seed, the
+/// delay set) so the transform stays a unary `Kind → Kind` node, the same
+/// shape `Mat4Apply` gives `mat4_apply`.
+///
+/// The body delegates to the pure [`solve_population_sweep`] core — each
+/// agent's planner is #1857's exact [`solve_cost_to_reach`] degraded by a
+/// reaction-delay lag, so at `delay = 0` with a full window the survival
+/// fraction approaches the exact reachable-under-budget bound. The seed is
+/// an explicit input and the PRNG deterministic, so the sweep is a pure
+/// function of its inputs and content-addresses correctly: it clears the
+/// `#[transform]` purity deny-list (no host fn, no `Ctx`, no `std::time` /
+/// `std::env`; seeded PRNG only).
+#[transform]
+fn solve_population(input: PopulationSweepProblem) -> SurvivalCurve {
+    solve_population_sweep(input)
+}
+
 #[cfg(test)]
 mod tests {
     use super::mat4_apply;
@@ -200,25 +221,12 @@ mod tests {
 #[cfg(test)]
 mod reachability_transform_tests {
     use super::{reachability_margin, solve};
+    use crate::reachability::test_fields::{UNREACHABLE, stencil_4way};
     use aether_data::{Kind, transforms};
     use aether_kinds::{
         BudgetQuery, MovementStencil, ReachabilityMargin, ReachabilityProblem, ScalarField,
         StencilOffset,
     };
-
-    const UNREACHABLE: u32 = u32::MAX;
-
-    fn stencil_4way() -> MovementStencil {
-        MovementStencil {
-            offsets: vec![
-                StencilOffset { dx: 0, dy: 0 },
-                StencilOffset { dx: 1, dy: 0 },
-                StencilOffset { dx: -1, dy: 0 },
-                StencilOffset { dx: 0, dy: 1 },
-                StencilOffset { dx: 0, dy: -1 },
-            ],
-        }
-    }
 
     /// 3×1 uniform-cost field, start at cell 0 — the same hand-checked
     /// field the solver-core tests pin, here driven through the transform.
@@ -393,22 +401,9 @@ mod reachability_transform_tests {
 #[cfg(test)]
 mod corridor_transform_tests {
     use super::build_corridor_graph;
+    use crate::reachability::test_fields::stencil_4way;
     use aether_data::{Kind, transforms};
-    use aether_kinds::{
-        BudgetQuery, CorridorGraph, EdgeKind, MovementStencil, ScalarField, StencilOffset,
-    };
-
-    fn stencil_4way() -> MovementStencil {
-        MovementStencil {
-            offsets: vec![
-                StencilOffset { dx: 0, dy: 0 },
-                StencilOffset { dx: 1, dy: 0 },
-                StencilOffset { dx: -1, dy: 0 },
-                StencilOffset { dx: 0, dy: 1 },
-                StencilOffset { dx: 0, dy: -1 },
-            ],
-        }
-    }
+    use aether_kinds::{BudgetQuery, CorridorGraph, EdgeKind, MovementStencil, ScalarField};
 
     /// 5×1 field with a sub-budget ridge at cell 2, driven through the
     /// transform: two components and a punch priced at the ridge `V`.
@@ -453,5 +448,131 @@ mod corridor_transform_tests {
         let b = build_corridor_graph(ridge_field(), stencil_4way(), BudgetQuery { budget: 5 });
         assert_eq!(a, b);
         assert_eq!(a.encode_into_bytes(), b.encode_into_bytes());
+    }
+}
+
+#[cfg(test)]
+mod population_transform_tests {
+    use super::solve_population;
+    use crate::reachability::test_fields::{UNREACHABLE, stencil_4way};
+    use aether_data::{Kind, transforms};
+    use aether_kinds::{PopulationSweepProblem, ReachabilityProblem, ScalarField, SurvivalCurve};
+
+    /// A small reachable sweep: a 3×1 uniform-cost field, the population
+    /// spawned at cell 0, goal at cell 2.
+    fn small_sweep() -> PopulationSweepProblem {
+        PopulationSweepProblem {
+            problem: ReachabilityProblem {
+                cost: ScalarField {
+                    width: 3,
+                    height: 1,
+                    ticks: 3,
+                    values: vec![1u32; 9],
+                },
+                stencil: stencil_4way(),
+                start: vec![0, UNREACHABLE, UNREACHABLE],
+            },
+            goal: vec![2],
+            budget: 5,
+            population: 16,
+            window: 8,
+            seed: 0xABCD_1234,
+            delays: vec![0, 1, 2],
+        }
+    }
+
+    #[test]
+    fn solve_population_produces_one_sample_per_delay() {
+        let curve = solve_population(small_sweep());
+        assert_eq!(curve.population, 16);
+        assert_eq!(curve.samples.len(), 3);
+        assert_eq!(curve.samples[0].delay, 0);
+        // Uniform-cost, full-window, zero-lag: the whole population clears
+        // the reachable-under-budget certificate.
+        assert_eq!(curve.samples[0].finished, 16);
+    }
+
+    #[test]
+    fn solve_population_registered_in_link_time_inventory() {
+        // Same contract as `mat4_apply` / `solve`: registered, one
+        // `PopulationSweepProblem` input slot, `SurvivalCurve` output.
+        let entry = transforms()
+            .find(|t| t.name.ends_with("::solve_population"))
+            .expect("solve_population not registered in link-time inventory");
+        assert_eq!(entry.input_kind_ids, [PopulationSweepProblem::ID]);
+        assert_eq!(entry.output_kind_id, SurvivalCurve::ID);
+    }
+
+    #[test]
+    fn population_kinds_resolve_distinctly() {
+        assert_ne!(PopulationSweepProblem::ID, SurvivalCurve::ID);
+        assert_ne!(PopulationSweepProblem::ID, ScalarField::ID);
+        assert_ne!(SurvivalCurve::ID, ReachabilityProblem::ID);
+    }
+
+    #[test]
+    fn solve_population_is_deterministic_and_content_addressable() {
+        // Same seed + field -> identical curve, and the content-addressing
+        // path (the encoded output bytes the executor keys on) replays
+        // byte-for-byte — the proof the seeded Monte-Carlo is pure.
+        let a = solve_population(small_sweep());
+        let b = solve_population(small_sweep());
+        assert_eq!(a, b);
+        assert_eq!(a.encode_into_bytes(), b.encode_into_bytes());
+    }
+
+    #[test]
+    fn canonical_field_sweep_encodes_under_output_cap_and_replays() {
+        // The canonical 64×64 grid over 1800 ticks driven through a multi-
+        // delay sweep: the `SurvivalCurve` output is a handful of
+        // `(delay, finished)` samples, so it sits far under the 64MB
+        // transform output cap (ADR-0048 §6), and two runs of the same
+        // input replay byte-identically. Uniform cost with the goal a few
+        // cells inside the planning window so agents reach it in a handful
+        // of ticks — the sweep exercises the canonical field dimensions
+        // without grinding the full horizon.
+        const CAP: usize = 64 * 1024 * 1024;
+        let width = 64u32;
+        let height = 64u32;
+        let ticks = 1800u32;
+        let plane = (width * height) as usize;
+        let sweep = || PopulationSweepProblem {
+            problem: ReachabilityProblem {
+                cost: ScalarField {
+                    width,
+                    height,
+                    ticks,
+                    values: vec![1u32; plane * ticks as usize],
+                },
+                stencil: stencil_4way(),
+                start: {
+                    let mut s = vec![UNREACHABLE; plane];
+                    s[0] = 0;
+                    s
+                },
+            },
+            goal: vec![5],
+            budget: 1000,
+            population: 4,
+            window: 8,
+            seed: 0x1357_9BDF,
+            delays: vec![0, 2, 5],
+        };
+
+        let curve = solve_population(sweep());
+        assert_eq!(curve.samples.len(), 3);
+
+        let bytes = curve.encode_into_bytes();
+        assert!(
+            bytes.len() < CAP,
+            "encoded survival curve is {} bytes, over the {CAP}-byte cap",
+            bytes.len()
+        );
+
+        let back = SurvivalCurve::decode_from_bytes(&bytes).expect("survival curve round-trips");
+        assert_eq!(curve, back);
+
+        let replay = solve_population(sweep());
+        assert_eq!(curve.encode_into_bytes(), replay.encode_into_bytes());
     }
 }

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -4014,6 +4014,83 @@ mod control_plane {
         pub nodes: Vec<CorridorNode>,
         pub edges: Vec<CorridorEdge>,
     }
+
+    /// A seeded Monte-Carlo population sweep over a time-varying scalar
+    /// cost field (issue 1863): a population of reaction-delayed agents
+    /// re-planning toward the cheapest goal under a fixed per-tick lag.
+    /// The whole sweep is a pure function of its inputs (seed + field in,
+    /// curve out), so it content-addresses as a `#[transform]` with no
+    /// executor change (ADR-0048 §4/§130).
+    ///
+    /// `problem` carries the shared reachability bundle (the space-time
+    /// cost field, the one-tick [`MovementStencil`], and the start seed)
+    /// — embedding [`ReachabilityProblem`] keeps the per-agent planner
+    /// *literally* #1857's [`ReachabilityProblem`]-shaped solve, so
+    /// the headline property holds structurally rather than by
+    /// coincidence. `problem.start` doubles as the **start region**: the
+    /// cells with a finite seed value are the population's spawn cells, and
+    /// each agent inherits that cell's seed as its initial accumulated
+    /// cost.
+    ///
+    /// `goal` is the goal region as flat row-major cell indices
+    /// (`y * width + x`); an agent **finishes** the moment it lands on a
+    /// goal cell with accumulated cost `< budget` before the final tick.
+    /// `population` is the number of agents sampled from the start region;
+    /// `window` is each agent's planning-window depth `W` (how far forward
+    /// it sees); `seed` keys the deterministic PRNG that samples the
+    /// population and breaks equal-cost ties; `delays` is the swept set of
+    /// reaction lags.
+    ///
+    /// The **lag convention**: at simulation tick `t`, an agent with delay
+    /// `d` perceives the field tick `τ` (for each `τ` in its window) as it
+    /// truly was at tick `max(0, τ - d)` — it reacts to field changes `d`
+    /// ticks late. At `d = 0` and `window >= ticks` the perceived field is
+    /// the true field over the full remaining horizon, so each agent's plan
+    /// *is* the exact single-source solve and the survival fraction
+    /// approaches the exact reachable-under-budget bound. `d` (how stale the
+    /// view is) is orthogonal to `window` (how far forward the agent sees).
+    #[derive(
+        aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq,
+    )]
+    #[kind(name = "aether.reach.population_problem")]
+    pub struct PopulationSweepProblem {
+        pub problem: ReachabilityProblem,
+        pub goal: Vec<u32>,
+        pub budget: u32,
+        pub population: u32,
+        pub window: u32,
+        pub seed: u64,
+        pub delays: Vec<u32>,
+    }
+
+    /// One point on a [`SurvivalCurve`] (issue 1863): for the swept
+    /// reaction delay `delay`, the number of agents (out of the curve's
+    /// shared `population`) that finished under budget. Not a kind on its
+    /// own — only addressable inside `SurvivalCurve.samples`. Integer
+    /// counts (rather than a pre-divided `f32` fraction) keep the output
+    /// byte-exact for content-addressing replay; the survival fraction
+    /// `finished / population` is a trivial derived read.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct SurvivalSample {
+        pub delay: u32,
+        pub finished: u32,
+    }
+
+    /// The output of the population sweep (issue 1863): the
+    /// completion-rate-vs-reaction-delay curve. `population` is the shared
+    /// agent count every [`SurvivalSample`] divides; `samples` carries one
+    /// `(delay, finished)` point per swept delay, in the input `delays`
+    /// order. The fraction `finished / population` is the survival rate,
+    /// and the knee where it collapses is the field's effective reaction
+    /// demand.
+    #[derive(
+        aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq,
+    )]
+    #[kind(name = "aether.reach.survival_curve")]
+    pub struct SurvivalCurve {
+        pub population: u32,
+        pub samples: Vec<SurvivalSample>,
+    }
 }
 
 mod trajectory {
@@ -4345,6 +4422,11 @@ mod tests {
         assert_eq!(BudgetQuery::NAME, "aether.reach.budget_query");
         assert_eq!(ReachabilityMargin::NAME, "aether.reach.margin");
         assert_eq!(CorridorGraph::NAME, "aether.corridor.graph");
+        assert_eq!(
+            PopulationSweepProblem::NAME,
+            "aether.reach.population_problem"
+        );
+        assert_eq!(SurvivalCurve::NAME, "aether.reach.survival_curve");
     }
 
     // ADR-0019 PR 3 — every kind below now has a derived `Schema` impl
@@ -4512,6 +4594,64 @@ mod tests {
                     assert_ne!(a, b, "corridor / reach kind ids must be distinct");
                 }
             }
+        }
+
+        #[test]
+        fn population_kinds_resolve_distinctly_from_reach_kinds() {
+            use aether_data::Kind;
+            // The two population kinds carry ids distinct from each other
+            // and from the #1857 reachability kinds they build on — a
+            // shared id would collide in the transform Ref-slot resolver.
+            let ids = [
+                PopulationSweepProblem::ID,
+                SurvivalCurve::ID,
+                ScalarField::ID,
+                ReachabilityProblem::ID,
+            ];
+            for (i, a) in ids.iter().enumerate() {
+                for b in &ids[i + 1..] {
+                    assert_ne!(a, b, "population kind ids must be distinct");
+                }
+            }
+        }
+
+        #[test]
+        fn population_problem_schema_embeds_reachability_problem() {
+            let SchemaType::Struct { fields, .. } = &<PopulationSweepProblem as Schema>::SCHEMA
+            else {
+                panic!("expected Struct");
+            };
+            assert_eq!(fields.len(), 7);
+            assert_eq!(fields[0].name, "problem");
+            assert!(matches!(fields[0].ty, SchemaType::Struct { .. }));
+            assert_eq!(fields[1].name, "goal");
+            assert!(matches!(fields[1].ty, SchemaType::Vec(_)));
+            assert_eq!(fields[2].name, "budget");
+            assert_eq!(fields[2].ty, SchemaType::Scalar(Primitive::U32));
+            assert_eq!(fields[5].name, "seed");
+            assert_eq!(fields[5].ty, SchemaType::Scalar(Primitive::U64));
+            assert_eq!(fields[6].name, "delays");
+            assert!(matches!(fields[6].ty, SchemaType::Vec(_)));
+        }
+
+        #[test]
+        fn survival_curve_schema_is_struct_of_samples() {
+            let SchemaType::Struct { fields, .. } = &<SurvivalCurve as Schema>::SCHEMA else {
+                panic!("expected Struct");
+            };
+            assert_eq!(fields.len(), 2);
+            assert_eq!(fields[0].name, "population");
+            assert_eq!(fields[0].ty, SchemaType::Scalar(Primitive::U32));
+            assert_eq!(fields[1].name, "samples");
+            let SchemaType::Vec(element) = &fields[1].ty else {
+                panic!("expected Vec");
+            };
+            let SchemaType::Struct { fields: sample, .. } = &**element else {
+                panic!("expected nested SurvivalSample struct");
+            };
+            assert_eq!(sample.len(), 2);
+            assert_eq!(sample[0].name, "delay");
+            assert_eq!(sample[1].name, "finished");
         }
     }
 


### PR DESCRIPTION
Closes #1863.

## Summary

A reaction-delayed agent population sweep over #1857's space-time cost field (`aether-capabilities::reachability::solve_population_sweep`): each agent plans with #1857's `solve_cost_to_reach` over a reaction-delay-lagged perceived window, backtracks the optimal path to take one receding-horizon step, and accumulates true cost — producing a completion-rate-vs-reaction-delay `SurvivalCurve`. Deterministic from a seed via a hand-rolled `Xorshift64` + splitmix64 per-agent seeding (no `rand` dep). New `PopulationSweepProblem` / `SurvivalCurve` / `SurvivalSample` kinds and a `#[transform] solve_population`.

## Test plan

`d=0` matches the exact reachable-under-budget certificate (planner-gap guard); non-increasing survival on a false-corridor field; zero finishers under an unreachable certificate; fraction stability under N doubling; empty-start-region. Transform: inventory registration, byte-identical determinism, canonical 64×64×1800 replay. Full workspace green: clippy `-D warnings`, nextest `--workspace` (1880 passed), doc.

## Generated by

`/implement` — agent execution of [scoped issue #1863](https://github.com/iamacoffeepot/aether/issues/1863).
