### PR TITLE
feat(capabilities): counterfactual reachability-from-state query over a windowed cost field

### DIFF
--- a/crates/aether-capabilities/src/counterfactual.rs
+++ b/crates/aether-capabilities/src/counterfactual.rs
@@ -1,0 +1,511 @@
+//! Counterfactual reachability-from-state query over a recorded path
+//! (issue 1864). The pure core the `solve_counterfactual` transform
+//! (ADR-0048) wraps, kept beside the reachability solver and the corridor
+//! graph so it reuses [`solve_cost_to_reach`] directly rather than going
+//! through the transform encode/decode boundary.
+//!
+//! Given a recorded path through a time-varying cost field (a
+//! [`TrajectoryLog`], issue 1862) and a tick where its accumulator crossed
+//! a budget `B`, the query re-runs the reachability solver from the path's
+//! actual `(position, accumulated-cost)` state `W` ticks before the
+//! crossing, restricted to the field visible in that window, and reports
+//! whether a within-budget continuation existed. Each budget-crossing is
+//! classified avoidable (a continuation existed) or unavoidable (none did).
+//!
+//! Per crossing the query: (1) detects the crossing — the first sample
+//! whose accumulator reaches `B` (`prev.value < B` → `cur.value >= B`, plus
+//! a first-sample-already-over crossing at the path start); (2) extracts
+//! the path's actual state at the decision tick `t0 = crossing_tick − W`
+//! (clamped to the first recorded tick) — the latest sample at or before
+//! `t0`; (3) slices the cost field over the visible window `[t0, tc]`
+//! inclusive, seeds the single cell `(x0, y0)` at the cost-valued seed `v0`,
+//! and runs one full-lookahead [`solve_cost_to_reach`] over the slice; and
+//! (4) reads the budget verdict — `best = min over cells of Vloc(·, tc)`,
+//! `avoidable = best < B`, `margin = budget − best`. Iterative throughout
+//! (a per-crossing loop, a per-window dense solve; no recursion, per the
+//! load-bearing-code rule), so a given field + path replays byte-identically.
+
+use aether_kinds::{
+    CrossingClassification, CrossingVerdict, ScalarField, StencilOffset, TrajectoryLog,
+};
+
+use crate::reachability::{UNREACHABLE, solve_cost_to_reach};
+
+/// The path's actual state at a decision tick — the seed of one windowed
+/// re-solve. `(x, y)` is the grid cell the path occupied; `cost` is the
+/// accumulated field cost there, in the same `u32` currency as `V` and the
+/// budget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SeedState {
+    decision_tick: u32,
+    x: u32,
+    y: u32,
+    cost: u32,
+}
+
+/// One detected budget-crossing: the tick at which the path's accumulator
+/// first reached the budget, paired with the seed state at its decision
+/// tick.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Crossing {
+    crossing_tick: u32,
+    seed: SeedState,
+}
+
+/// Detect every budget-crossing in a recorded path and, for each, extract
+/// the path's actual state at its decision tick `t0 = crossing_tick −
+/// window` (clamped to the first recorded tick).
+///
+/// A crossing is the first sample whose accumulator reaches the budget: a
+/// `prev.value < budget` → `cur.value >= budget` transition, plus a
+/// first-sample-already-`>= budget` crossing at the path start. The samples
+/// are consumed in recorded order; a well-behaved producer records them in
+/// ascending-tick order, and the state lookup tolerates gaps and a path
+/// that stops short (truncated / aborted sessions, issue 1862).
+fn detect_crossings(path: &TrajectoryLog, window: u32, budget: u32) -> Vec<Crossing> {
+    let samples = &path.samples;
+    let mut crossings = Vec::new();
+    if samples.is_empty() {
+        return crossings;
+    }
+
+    let first_tick = samples[0].tick;
+    for (i, cur) in samples.iter().enumerate() {
+        let crosses = if i == 0 {
+            // A first sample already at or over the budget is a crossing at
+            // the path start.
+            cur.value >= budget
+        } else {
+            samples[i - 1].value < budget && cur.value >= budget
+        };
+        if !crosses {
+            continue;
+        }
+        let crossing_tick = cur.tick;
+        // Decision tick = crossing tick − window, clamped to the first
+        // recorded tick so a short path (or `tc < window`) seeds from the
+        // path start rather than a tick the path never visited.
+        let decision_tick = crossing_tick.saturating_sub(window).max(first_tick);
+        let seed = seed_state_at(samples, decision_tick);
+        crossings.push(Crossing {
+            crossing_tick,
+            seed,
+        });
+    }
+    crossings
+}
+
+/// The path's state at `decision_tick`: the latest sample at or before it.
+/// Walks the recorded order and keeps the last sample whose tick does not
+/// exceed `decision_tick`, so it tolerates non-contiguous ticks and a path
+/// that ends before some computed decision tick. Falls back to the first
+/// sample when none precedes the decision tick (the caller clamps
+/// `decision_tick` to the first recorded tick, so this is a safety net for
+/// out-of-order producers).
+fn seed_state_at(samples: &[aether_kinds::TrajectorySampleEntry], decision_tick: u32) -> SeedState {
+    let mut chosen = &samples[0];
+    for sample in samples {
+        if sample.tick <= decision_tick {
+            chosen = sample;
+        }
+    }
+    SeedState {
+        decision_tick,
+        x: chosen.x,
+        y: chosen.y,
+        cost: chosen.value,
+    }
+}
+
+/// Run one windowed re-solve from a crossing's seed state and read the
+/// budget verdict. Slices `cost` over the visible window `[t0, tc]`
+/// inclusive (the `C[·, t .. t+W]` convention with `t = t0`, `t+W = tc`),
+/// seeds the single cell `(x0, y0)` at the cost-valued seed `v0`, runs a
+/// full-lookahead [`solve_cost_to_reach`] over the slice, and takes `best =
+/// min over cells of Vloc(·, tc)` (the slice's last layer).
+///
+/// `avoidable = best < budget`; `margin = budget − best`. An out-of-range
+/// seed cell, a window past the field's tick range, or an empty slice all
+/// read as unreachable (`best = u32::MAX`), so the verdict is well-defined
+/// for a truncated path or a clamped window.
+fn classify_crossing(
+    cost: &ScalarField,
+    stencil: &[StencilOffset],
+    crossing: Crossing,
+    budget: u32,
+) -> CrossingVerdict {
+    let width = cost.width as usize;
+    let height = cost.height as usize;
+    let plane = width.saturating_mul(height);
+    let field_ticks = cost.ticks as usize;
+    let t0 = crossing.seed.decision_tick as usize;
+    let tc = crossing.crossing_tick as usize;
+
+    // Window length in tick layers: `[t0, tc]` inclusive. A seed beyond the
+    // crossing (only possible if the producer recorded out of order) or a
+    // window that starts past the field collapses to an unreachable verdict.
+    let best = if plane == 0 || tc < t0 || t0 >= field_ticks {
+        UNREACHABLE
+    } else {
+        let window_ticks = tc - t0 + 1;
+        // Slice the cost field's `[t0, tc]` layers. A slice that runs past
+        // the field's recorded ticks reads as UNREACHABLE past its end (the
+        // solver tolerates a short `costs`), so clamp the copy and let the
+        // tail default.
+        let slice_start = t0.saturating_mul(plane);
+        let available_ticks = field_ticks - t0;
+        let copy_ticks = window_ticks.min(available_ticks);
+        let costs_slice = cost
+            .values
+            .get(slice_start..slice_start.saturating_add(copy_ticks.saturating_mul(plane)))
+            .unwrap_or(&[]);
+
+        // Cost-valued seed slice for the window's t = 0 layer: the single
+        // cell `(x0, y0)` at the accumulated cost `v0`, sentinel elsewhere.
+        let mut seed = vec![UNREACHABLE; plane];
+        let sx = crossing.seed.x as usize;
+        let sy = crossing.seed.y as usize;
+        if sx < width && sy < height {
+            seed[sy * width + sx] = crossing.seed.cost;
+        }
+
+        let vloc = solve_cost_to_reach(width, height, window_ticks, costs_slice, stencil, &seed);
+        // `best = min over cells of Vloc(·, tc)` — the window's last layer.
+        let last_base = (window_ticks - 1).saturating_mul(plane);
+        vloc.get(last_base..last_base.saturating_add(plane))
+            .and_then(|layer| layer.iter().copied().min())
+            .unwrap_or(UNREACHABLE)
+    };
+
+    let avoidable = best < budget;
+    let margin = i64::from(budget) - i64::from(best);
+    CrossingVerdict {
+        crossing_tick: crossing.crossing_tick,
+        decision_tick: crossing.seed.decision_tick,
+        seed_x: crossing.seed.x,
+        seed_y: crossing.seed.y,
+        seed_cost: crossing.seed.cost,
+        avoidable,
+        best_continuation_cost: best,
+        margin,
+    }
+}
+
+/// Classify every budget-crossing in a recorded path against a cost field
+/// (issue 1864) — the pure core the `solve_counterfactual` transform wraps.
+/// Detects the crossings, extracts each crossing's seed state at its
+/// decision tick, runs a windowed re-solve from that state, and emits one
+/// [`CrossingVerdict`] per crossing in tick order. A path with no crossing
+/// yields an empty classification.
+pub fn solve_counterfactual_core(
+    cost: &ScalarField,
+    stencil: &[StencilOffset],
+    path: &TrajectoryLog,
+    window: u32,
+    budget: u32,
+) -> CrossingClassification {
+    let crossings = detect_crossings(path, window, budget);
+    let mut verdicts = Vec::with_capacity(crossings.len());
+    for crossing in crossings {
+        verdicts.push(classify_crossing(cost, stencil, crossing, budget));
+    }
+    CrossingClassification {
+        crossings: verdicts,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        Crossing, SeedState, classify_crossing, detect_crossings, solve_counterfactual_core,
+    };
+    use aether_kinds::{
+        ScalarField, StencilOffset, TrajectoryEndReason, TrajectoryLog, TrajectorySampleEntry,
+    };
+
+    const UNREACHABLE: u32 = u32::MAX;
+
+    fn stencil_4way() -> Vec<StencilOffset> {
+        vec![
+            StencilOffset { dx: 0, dy: 0 },
+            StencilOffset { dx: 1, dy: 0 },
+            StencilOffset { dx: -1, dy: 0 },
+            StencilOffset { dx: 0, dy: 1 },
+            StencilOffset { dx: 0, dy: -1 },
+        ]
+    }
+
+    fn sample(tick: u32, x: u32, y: u32, value: u32) -> TrajectorySampleEntry {
+        TrajectorySampleEntry { tick, x, y, value }
+    }
+
+    fn log(samples: Vec<TrajectorySampleEntry>) -> TrajectoryLog {
+        TrajectoryLog {
+            seed: 1,
+            samples,
+            end_reason: TrajectoryEndReason::Completed,
+        }
+    }
+
+    #[test]
+    fn single_clean_crossing_detected_with_clamped_decision_tick() {
+        // Accumulator climbs 0,2,4,6,8 over ticks 0..5; budget 5 is first
+        // reached at tick 3 (value 6). Window 2 → decision tick 1.
+        let path = log(vec![
+            sample(0, 0, 0, 0),
+            sample(1, 1, 0, 2),
+            sample(2, 2, 0, 4),
+            sample(3, 3, 0, 6),
+            sample(4, 4, 0, 8),
+        ]);
+        let crossings = detect_crossings(&path, 2, 5);
+        assert_eq!(crossings.len(), 1);
+        assert_eq!(crossings[0].crossing_tick, 3);
+        assert_eq!(
+            crossings[0].seed,
+            SeedState {
+                decision_tick: 1,
+                x: 1,
+                y: 0,
+                cost: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn multiple_crossings_in_one_path() {
+        // Budget 5. value dips back under 5 then crosses again: the
+        // `< B → >= B` operator fires once per up-crossing.
+        let path = log(vec![
+            sample(0, 0, 0, 0),
+            sample(1, 1, 0, 6), // first crossing
+            sample(2, 2, 0, 3), // back under
+            sample(3, 3, 0, 4),
+            sample(4, 4, 0, 7), // second crossing
+        ]);
+        let crossings = detect_crossings(&path, 1, 5);
+        assert_eq!(crossings.len(), 2);
+        assert_eq!(crossings[0].crossing_tick, 1);
+        assert_eq!(crossings[1].crossing_tick, 4);
+    }
+
+    #[test]
+    fn no_crossing_yields_empty() {
+        // Accumulator never reaches the budget.
+        let path = log(vec![
+            sample(0, 0, 0, 0),
+            sample(1, 1, 0, 1),
+            sample(2, 2, 0, 2),
+        ]);
+        assert!(detect_crossings(&path, 1, 5).is_empty());
+    }
+
+    #[test]
+    fn first_sample_already_over_is_a_crossing_at_path_start() {
+        // First sample is already >= budget: a crossing at the path start,
+        // decision tick clamps to the first recorded tick.
+        let path = log(vec![sample(2, 5, 5, 9), sample(3, 6, 5, 11)]);
+        let crossings = detect_crossings(&path, 4, 5);
+        assert_eq!(crossings.len(), 1);
+        assert_eq!(crossings[0].crossing_tick, 2);
+        // tc(2) − window(4) saturates to 0, then clamps to first tick 2.
+        assert_eq!(crossings[0].seed.decision_tick, 2);
+        assert_eq!(crossings[0].seed.cost, 9);
+    }
+
+    #[test]
+    fn tc_less_than_window_clamps_decision_tick_to_path_start() {
+        let path = log(vec![
+            sample(0, 0, 0, 0),
+            sample(1, 1, 0, 3),
+            sample(2, 2, 0, 8), // crossing at tick 2
+        ]);
+        // window 10 ≫ tc 2 → decision tick saturates to 0, the path start.
+        let crossings = detect_crossings(&path, 10, 5);
+        assert_eq!(crossings.len(), 1);
+        assert_eq!(crossings[0].seed.decision_tick, 0);
+        assert_eq!(crossings[0].seed.cost, 0);
+    }
+
+    #[test]
+    fn state_lookup_picks_latest_sample_at_or_before_decision_tick() {
+        // Non-contiguous ticks: decision tick 5 has no exact sample, so the
+        // lookup picks the latest at or before it (tick 4).
+        let path = log(vec![
+            sample(0, 0, 0, 0),
+            sample(4, 4, 1, 3),
+            sample(8, 8, 2, 7), // crossing at tick 8
+        ]);
+        let crossings = detect_crossings(&path, 3, 5);
+        assert_eq!(crossings.len(), 1);
+        assert_eq!(crossings[0].crossing_tick, 8);
+        assert_eq!(
+            crossings[0].seed,
+            SeedState {
+                decision_tick: 5,
+                x: 4,
+                y: 1,
+                cost: 3,
+            }
+        );
+    }
+
+    /// A 3×1 uniform-cost-1 field over `ticks` layers.
+    fn uniform_field(ticks: u32) -> ScalarField {
+        ScalarField {
+            width: 3,
+            height: 1,
+            ticks,
+            values: vec![1u32; 3 * ticks as usize],
+        }
+    }
+
+    #[test]
+    fn avoidable_when_a_within_budget_continuation_exists() {
+        // Seed cell 0 at accumulated cost 2, window [0, 2] (3 layers), cost
+        // 1/tick. Vloc at tick 2 reaches cost 4 (2 + 1 + 1). Budget 5 → the
+        // continuation is under budget, so the crossing is avoidable.
+        let field = uniform_field(3);
+        let crossing = Crossing {
+            crossing_tick: 2,
+            seed: SeedState {
+                decision_tick: 0,
+                x: 0,
+                y: 0,
+                cost: 2,
+            },
+        };
+        let verdict = classify_crossing(&field, &stencil_4way(), crossing, 5);
+        assert!(verdict.avoidable);
+        assert_eq!(verdict.best_continuation_cost, 4);
+        assert_eq!(verdict.margin, 1);
+    }
+
+    #[test]
+    fn unavoidable_when_every_window_end_cell_is_over_budget() {
+        // Same window but seed cost 4: Vloc at tick 2 is 6 everywhere, over
+        // a budget of 5 — unavoidable.
+        let field = uniform_field(3);
+        let crossing = Crossing {
+            crossing_tick: 2,
+            seed: SeedState {
+                decision_tick: 0,
+                x: 0,
+                y: 0,
+                cost: 4,
+            },
+        };
+        let verdict = classify_crossing(&field, &stencil_4way(), crossing, 5);
+        assert!(!verdict.avoidable);
+        assert_eq!(verdict.best_continuation_cost, 6);
+        assert_eq!(verdict.margin, -1);
+    }
+
+    #[test]
+    fn lookahead_boundary_flips_avoidable_with_window_depth() {
+        // A field where the cheap escape lies 3 cells from the start, and a
+        // tall barrier sits in between every tick. With a short window the
+        // solve can't reach the cheap cell at the crossing tick; with a long
+        // enough window it can, flipping the verdict.
+        //
+        // 5×1 grid, cost layout per tick: [1, 1, 9, 1, 1]. Seed cell 0.
+        // Through-the-barrier (cell 2, cost 9) is the only orthogonal route
+        // to cells 3/4, so reaching them is expensive; staying at/near the
+        // start accumulates cheaply. We assert the verdict shifts as the
+        // window (and thus the crossing tick) grows.
+        let ticks = 6u32;
+        let plane = 5usize;
+        let mut values = Vec::with_capacity(plane * ticks as usize);
+        for _ in 0..ticks {
+            values.extend_from_slice(&[1, 1, 9, 1, 1]);
+        }
+        let field = ScalarField {
+            width: 5,
+            height: 1,
+            ticks,
+            values,
+        };
+
+        // Short window [0, 1]: seed cell 0 at cost 0; at tick 1 the cheapest
+        // reachable cell is cost 1 (stay or step to cell 1). Budget 2 →
+        // avoidable (cheap cells are within budget early).
+        let short = Crossing {
+            crossing_tick: 1,
+            seed: SeedState {
+                decision_tick: 0,
+                x: 0,
+                y: 0,
+                cost: 0,
+            },
+        };
+        let short_verdict = classify_crossing(&field, &stencil_4way(), short, 2);
+        assert!(short_verdict.avoidable, "short window stays under budget");
+
+        // Long window [0, 5]: seed cell 0 at cost 4 — by the crossing tick
+        // the accumulator is high, and the only sub-budget escape needs to
+        // pay the cost-9 barrier. Best continuation at tick 5 exceeds budget
+        // 5 → unavoidable. The flip is the exact lookahead/budget boundary.
+        let long = Crossing {
+            crossing_tick: 5,
+            seed: SeedState {
+                decision_tick: 0,
+                x: 0,
+                y: 0,
+                cost: 4,
+            },
+        };
+        let long_verdict = classify_crossing(&field, &stencil_4way(), long, 5);
+        assert!(
+            !long_verdict.avoidable,
+            "long window over budget is unavoidable",
+        );
+    }
+
+    #[test]
+    fn end_to_end_classifies_a_recorded_path() {
+        // Accumulator 0,2,4,6,8 over ticks 0..5. Budget 5 is first reached
+        // at tick 3 (value 6 — the `4 < 5 → 6 >= 5` transition), so the
+        // crossing tick is 3, not 4. Window 3 → decision tick 0, seed cost 0
+        // at cell 0. Vloc(·, 3) over 4 uniform-cost-1 layers from cost 0
+        // reaches 3 → under budget 5, so this crossing is avoidable.
+        let field = uniform_field(5);
+        let path = log(vec![
+            sample(0, 0, 0, 0),
+            sample(1, 1, 0, 2),
+            sample(2, 2, 0, 4),
+            sample(3, 2, 0, 6),
+            sample(4, 2, 0, 8),
+        ]);
+        let cls = solve_counterfactual_core(&field, &stencil_4way(), &path, 3, 5);
+        assert_eq!(cls.crossings.len(), 1);
+        let v = cls.crossings[0];
+        assert_eq!(v.crossing_tick, 3);
+        assert_eq!(v.decision_tick, 0);
+        assert_eq!(v.seed_x, 0);
+        assert_eq!(v.seed_cost, 0);
+        // Vloc(·, 3) from seed-cost 0 over 4 uniform-cost-1 layers = 3.
+        assert_eq!(v.best_continuation_cost, 3);
+        assert_eq!(v.margin, 2);
+        assert!(v.avoidable, "best continuation 3 < budget 5");
+    }
+
+    #[test]
+    fn truncated_path_window_past_field_stays_unreachable() {
+        // A crossing whose window runs past the field's recorded ticks: the
+        // slice reads UNREACHABLE past its end, so the verdict is a
+        // well-defined unavoidable rather than a panic.
+        let field = uniform_field(2);
+        let crossing = Crossing {
+            crossing_tick: 5, // beyond the 2-tick field
+            seed: SeedState {
+                decision_tick: 1,
+                x: 0,
+                y: 0,
+                cost: 1,
+            },
+        };
+        let verdict = classify_crossing(&field, &stencil_4way(), crossing, 100);
+        assert_eq!(verdict.best_continuation_cost, UNREACHABLE);
+        assert!(!verdict.avoidable);
+    }
+}

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -121,6 +121,14 @@ pub(crate) mod reachability;
 // be dead.
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) mod corridor;
+// Pure counterfactual reachability-from-state core (ADR-0047/0048/0049,
+// issue 1864): classifies each budget-crossing in a recorded path as
+// avoidable / unavoidable via a windowed re-solve seeded from the path's
+// actual state. Gated to non-wasm like `reachability` / `corridor` — its
+// caller is the native `solve_counterfactual` transform, so on a
+// wasm-header-only build it would be dead.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) mod counterfactual;
 pub mod window;
 
 #[cfg(feature = "audio")]

--- a/crates/aether-capabilities/src/transforms.rs
+++ b/crates/aether-capabilities/src/transforms.rs
@@ -9,12 +9,14 @@
 
 use aether_data::transform;
 use aether_kinds::{
-    BudgetQuery, CorridorGraph, Mat4Apply, MovementStencil, PopulationSweepProblem,
-    ReachabilityMargin, ReachabilityProblem, ScalarField, SurvivalCurve,
+    BudgetQuery, CorridorGraph, CrossingClassification, CrossingQueryParams, Mat4Apply,
+    MovementStencil, PopulationSweepProblem, ReachabilityMargin, ReachabilityProblem, ScalarField,
+    SurvivalCurve, TrajectoryLog,
 };
 use aether_math::Vec4;
 
 use crate::corridor::build_corridor_graph_core;
+use crate::counterfactual::solve_counterfactual_core;
 use crate::reachability::{UNREACHABLE, solve_cost_to_reach, solve_population_sweep};
 
 /// Apply a 4×4 matrix to a 4-vector, `M · v` (ADR-0048's first
@@ -152,6 +154,42 @@ fn build_corridor_graph(
 #[transform]
 fn solve_population(input: PopulationSweepProblem) -> SurvivalCurve {
     solve_population_sweep(input)
+}
+
+/// Classify every budget-crossing in a recorded path against a windowed
+/// cost field — the counterfactual reachability-from-state query
+/// (ADR-0047/0048/0049, issue 1864). A three-input transform: the
+/// `ReachabilityProblem` (its cost field + movement stencil; its `start`
+/// seed is unused — the path supplies the seed), the recorded
+/// `TrajectoryLog` (issue 1862), and the `(window, budget)` params. The
+/// output is one `CrossingVerdict` per budget-crossing, each carrying
+/// whether the crossing was avoidable — whether, `window` ticks earlier
+/// and seeing only the field visible in that window, a within-budget
+/// continuation existed from the path's actual state.
+///
+/// The body delegates to the pure [`solve_counterfactual_core`] (the
+/// reusable internal API), which reuses [`solve_cost_to_reach`] for each
+/// per-crossing windowed re-solve; the transform fn only unbundles the
+/// operands and threads the params, so it clears the `#[transform]` purity
+/// deny-list. Iterative throughout (a per-crossing loop, a per-window
+/// dense solve).
+// The `#[transform]` ABI hands the body owned kinds decoded from wire
+// bytes; the core borrows them, so the owned `problem` / `path` params are
+// intentionally passed by reference rather than consumed.
+#[allow(clippy::needless_pass_by_value)]
+#[transform]
+fn solve_counterfactual(
+    problem: ReachabilityProblem,
+    path: TrajectoryLog,
+    params: CrossingQueryParams,
+) -> CrossingClassification {
+    solve_counterfactual_core(
+        &problem.cost,
+        &problem.stencil.offsets,
+        &path,
+        params.window,
+        params.budget,
+    )
 }
 
 #[cfg(test)]
@@ -574,5 +612,217 @@ mod population_transform_tests {
 
         let replay = solve_population(sweep());
         assert_eq!(curve.encode_into_bytes(), replay.encode_into_bytes());
+    }
+}
+
+#[cfg(test)]
+mod counterfactual_transform_tests {
+    use super::solve_counterfactual;
+    use crate::reachability::test_fields::{UNREACHABLE, stencil_4way};
+    use aether_data::{Kind, transforms};
+    use aether_kinds::{
+        CrossingClassification, CrossingQueryParams, ReachabilityProblem, ScalarField,
+        TrajectoryEndReason, TrajectoryLog, TrajectorySampleEntry,
+    };
+
+    /// A 3×1 uniform-cost-1 field over `ticks` layers, wrapped in a
+    /// `ReachabilityProblem` (whose `start` seed is unused — the path
+    /// supplies the seed).
+    fn uniform_problem(ticks: u32) -> ReachabilityProblem {
+        ReachabilityProblem {
+            cost: ScalarField {
+                width: 3,
+                height: 1,
+                ticks,
+                values: vec![1u32; 3 * ticks as usize],
+            },
+            stencil: stencil_4way(),
+            // Unused by the counterfactual query; left as a non-seed.
+            start: vec![UNREACHABLE, UNREACHABLE, UNREACHABLE],
+        }
+    }
+
+    fn entry(tick: u32, x: u32, y: u32, value: u32) -> TrajectorySampleEntry {
+        TrajectorySampleEntry { tick, x, y, value }
+    }
+
+    fn log(samples: Vec<TrajectorySampleEntry>) -> TrajectoryLog {
+        TrajectoryLog {
+            seed: 7,
+            samples,
+            end_reason: TrajectoryEndReason::Completed,
+        }
+    }
+
+    /// A path over the uniform field that crosses budget 5 at tick 4.
+    fn crossing_path() -> TrajectoryLog {
+        log(vec![
+            entry(0, 0, 0, 0),
+            entry(1, 1, 0, 2),
+            entry(2, 2, 0, 4),
+            entry(3, 2, 0, 6),
+            entry(4, 2, 0, 8),
+        ])
+    }
+
+    #[test]
+    fn registered_in_link_time_inventory() {
+        // A three-input transform: `(ReachabilityProblem, TrajectoryLog,
+        // CrossingQueryParams)` in slot order, `CrossingClassification`
+        // out — the same inventory contract the other reach transforms
+        // satisfy.
+        let entry = transforms()
+            .find(|t| t.name.ends_with("::solve_counterfactual"))
+            .expect("solve_counterfactual not registered in link-time inventory");
+        assert_eq!(
+            entry.input_kind_ids,
+            [
+                ReachabilityProblem::ID,
+                TrajectoryLog::ID,
+                CrossingQueryParams::ID
+            ]
+        );
+        assert_eq!(entry.output_kind_id, CrossingClassification::ID);
+    }
+
+    #[test]
+    fn avoidable_crossing_under_a_large_window() {
+        // The path crosses budget 5 at tick 3 (value 6). Window 4 →
+        // decision tick saturates to 0, seed cost 0 at cell 0. Vloc(·, 3)
+        // over 4 uniform-cost-1 layers from cost 0 reaches 3 → under budget
+        // 5, so the crossing is avoidable (a within-budget continuation
+        // existed from the path's state 4 ticks back).
+        let out = solve_counterfactual(
+            uniform_problem(5),
+            crossing_path(),
+            CrossingQueryParams {
+                window: 4,
+                budget: 5,
+            },
+        );
+        assert_eq!(out.crossings.len(), 1);
+        let v = out.crossings[0];
+        assert_eq!(v.crossing_tick, 3);
+        assert_eq!(v.decision_tick, 0);
+        assert_eq!(v.seed_cost, 0);
+        assert!(v.avoidable, "best continuation 3 < budget 5");
+        assert_eq!(v.best_continuation_cost, 3);
+        assert_eq!(v.margin, 2);
+    }
+
+    #[test]
+    fn unavoidable_crossing_under_a_small_window() {
+        // Crossing at tick 3. Window 1 → decision tick 2, seed cost 4 at
+        // cell 2. Vloc(·, 3) over 2 uniform-cost-1 layers from cost 4
+        // reaches 5 → not under budget 5, so the crossing is unavoidable.
+        // Same field + path as the avoidable case: the shorter window seeds
+        // from a costlier, later state, flipping the verdict.
+        let out = solve_counterfactual(
+            uniform_problem(5),
+            crossing_path(),
+            CrossingQueryParams {
+                window: 1,
+                budget: 5,
+            },
+        );
+        assert_eq!(out.crossings.len(), 1);
+        let v = out.crossings[0];
+        assert_eq!(v.crossing_tick, 3);
+        assert_eq!(v.decision_tick, 2);
+        assert_eq!(v.seed_cost, 4);
+        assert!(!v.avoidable, "best continuation 5 is not < budget 5");
+        assert_eq!(v.best_continuation_cost, 5);
+        assert_eq!(v.margin, 0);
+    }
+
+    #[test]
+    fn no_crossing_yields_empty_classification() {
+        // A path that never reaches the budget produces no verdicts.
+        let path = log(vec![
+            entry(0, 0, 0, 0),
+            entry(1, 1, 0, 1),
+            entry(2, 2, 0, 2),
+        ]);
+        let out = solve_counterfactual(
+            uniform_problem(3),
+            path,
+            CrossingQueryParams {
+                window: 1,
+                budget: 5,
+            },
+        );
+        assert!(out.crossings.is_empty());
+    }
+
+    #[test]
+    fn is_deterministic_and_content_addressable() {
+        // Same input bytes -> identical output bytes: the content-addressing
+        // contract the DAG executor keys transform results on, so a query
+        // replays byte-for-byte.
+        let a = solve_counterfactual(
+            uniform_problem(5),
+            crossing_path(),
+            CrossingQueryParams {
+                window: 4,
+                budget: 5,
+            },
+        );
+        let b = solve_counterfactual(
+            uniform_problem(5),
+            crossing_path(),
+            CrossingQueryParams {
+                window: 4,
+                budget: 5,
+            },
+        );
+        assert_eq!(a, b);
+        assert_eq!(a.encode_into_bytes(), b.encode_into_bytes());
+    }
+
+    #[test]
+    fn classification_over_canonical_field_encodes_under_output_cap() {
+        // A path with many crossings over the canonical 64×64×1800 field:
+        // the `CrossingClassification` is a skeleton (one verdict per
+        // crossing), so it stays orders of magnitude under the 64MB
+        // transform output cap (ADR-0048 §6) regardless of the field size.
+        const CAP: usize = 64 * 1024 * 1024;
+        let width = 64u32;
+        let height = 64u32;
+        let ticks = 1800u32;
+        let plane = (width * height) as usize;
+        let problem = ReachabilityProblem {
+            cost: ScalarField {
+                width,
+                height,
+                ticks,
+                values: vec![1u32; plane * ticks as usize],
+            },
+            stencil: stencil_4way(),
+            start: vec![UNREACHABLE; plane],
+        };
+        // A sawtooth accumulator that crosses budget 5 repeatedly across the
+        // full horizon — exercises the per-crossing loop at scale.
+        let samples: Vec<_> = (0..ticks)
+            .map(|t| entry(t, t % width, (t / width) % height, (t % 8) + 1))
+            .collect();
+        let path = log(samples);
+        let out = solve_counterfactual(
+            problem,
+            path,
+            CrossingQueryParams {
+                window: 4,
+                budget: 5,
+            },
+        );
+        assert!(!out.crossings.is_empty(), "sawtooth crosses the budget");
+        let bytes = out.encode_into_bytes();
+        assert!(
+            bytes.len() < CAP,
+            "encoded classification is {} bytes, over the {CAP}-byte cap",
+            bytes.len()
+        );
+        let back =
+            CrossingClassification::decode_from_bytes(&bytes).expect("classification round-trips");
+        assert_eq!(out, back);
     }
 }

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -4091,6 +4091,95 @@ mod control_plane {
         pub population: u32,
         pub samples: Vec<SurvivalSample>,
     }
+
+    // ADR-0047/0048/0049 counterfactual reachability query (issue 1864).
+    // Given a recorded path through a time-varying cost field (a
+    // `TrajectoryLog`, issue 1862) and a tick where its accumulator
+    // crossed a budget `B`, the `solve_counterfactual` transform re-runs
+    // the reachability solver from the path's actual `(position,
+    // accumulated-cost)` state `W` ticks before the crossing, seeing only
+    // the field visible in that window, and classifies the crossing as
+    // avoidable (a within-budget continuation existed) or unavoidable. The
+    // query params are a cast-shaped scalar bundle (modeled on
+    // [`WindowSize`]); the classification is `Vec`-bearing (modeled on
+    // [`CorridorGraph`]).
+
+    /// The lookahead depth and budget for a [`solve_counterfactual`] query
+    /// (issue 1864). `window` is `W` — how many ticks before each
+    /// budget-crossing the re-solve seeds from the path's actual state, so
+    /// the decision tick is `crossing_tick − window`, clamped to the path's
+    /// first recorded tick. `budget` is `B`, the threshold a path's
+    /// accumulator crosses: a crossing is the first sample whose `value`
+    /// reaches `B` (the `prev.value < B` → `cur.value >= B` transition; a
+    /// first sample already `>= B` is a crossing at the path start). The
+    /// `value` carried in each `TrajectorySampleEntry` is the path's
+    /// accumulated field cost, denominated in the same `u32` currency as
+    /// the cost-to-reach field `V` and `budget`, which is what makes the
+    /// seed cost comparable to the budget.
+    ///
+    /// [`solve_counterfactual`]: https://docs.rs/aether-capabilities
+    #[repr(C)]
+    #[derive(
+        Copy,
+        Clone,
+        Debug,
+        PartialEq,
+        Eq,
+        Serialize,
+        Deserialize,
+        bytemuck::Pod,
+        bytemuck::Zeroable,
+        aether_data::Kind,
+        aether_data::Schema,
+    )]
+    #[kind(name = "aether.reach.crossing_query")]
+    pub struct CrossingQueryParams {
+        pub window: u32,
+        pub budget: u32,
+    }
+
+    /// One budget-crossing's verdict in a [`CrossingClassification`] (issue
+    /// 1864). `crossing_tick` is the tick at which the path's accumulator
+    /// first reached the budget; `decision_tick` is `crossing_tick −
+    /// window` clamped to the path's first recorded tick (the tick whose
+    /// state seeds the windowed re-solve). `seed_x` / `seed_y` /
+    /// `seed_cost` are the path's actual `(x, y, value)` state at the
+    /// decision tick (the latest sample at or before it), echoed in full so
+    /// a machine consumer correlates each verdict to its seed without
+    /// re-deriving it. `avoidable` is true exactly when the windowed
+    /// re-solve reaches some cell at `crossing_tick` under the budget;
+    /// `best_continuation_cost` is the minimum cost-to-reach over the
+    /// window's final-tick cells (`u32::MAX` if none is reachable), and
+    /// `margin` is `budget − best_continuation_cost` as a signed value
+    /// (positive slack when avoidable, negative when even the cheapest
+    /// continuation exceeds the budget). Not a kind on its own — only
+    /// addressable inside `CrossingClassification.crossings`.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct CrossingVerdict {
+        pub crossing_tick: u32,
+        pub decision_tick: u32,
+        pub seed_x: u32,
+        pub seed_y: u32,
+        pub seed_cost: u32,
+        pub avoidable: bool,
+        pub best_continuation_cost: u32,
+        pub margin: i64,
+    }
+
+    /// The per-crossing classification produced by the
+    /// `solve_counterfactual` transform (issue 1864): one
+    /// [`CrossingVerdict`] for every budget-crossing detected in the
+    /// recorded path, in tick order. A path with no crossing yields an
+    /// empty `crossings`. A skeleton keyed to the path's crossings rather
+    /// than a field, so its size scales with the number of crossings, not
+    /// `width * height * ticks`. `Vec`-bearing like [`CorridorGraph`].
+    #[derive(
+        aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq,
+    )]
+    #[kind(name = "aether.reach.crossing_classification")]
+    pub struct CrossingClassification {
+        pub crossings: Vec<CrossingVerdict>,
+    }
 }
 
 mod trajectory {
@@ -4427,6 +4516,11 @@ mod tests {
             "aether.reach.population_problem"
         );
         assert_eq!(SurvivalCurve::NAME, "aether.reach.survival_curve");
+        assert_eq!(CrossingQueryParams::NAME, "aether.reach.crossing_query");
+        assert_eq!(
+            CrossingClassification::NAME,
+            "aether.reach.crossing_classification"
+        );
     }
 
     // ADR-0019 PR 3 — every kind below now has a derived `Schema` impl
@@ -4616,6 +4710,75 @@ mod tests {
         }
 
         #[test]
+        fn crossing_query_params_is_repr_c_struct_of_two_u32() {
+            // A cast-shaped scalar bundle (modeled on `WindowSize`): two
+            // `u32` fields in a `repr(C)` struct so the cheap cast path
+            // carries it on the wire.
+            const { assert!(<CrossingQueryParams as CastEligible>::ELIGIBLE) };
+            let SchemaType::Struct { repr_c, fields } = &<CrossingQueryParams as Schema>::SCHEMA
+            else {
+                panic!("expected Struct");
+            };
+            assert!(*repr_c);
+            assert_eq!(fields.len(), 2);
+            assert_eq!(fields[0].name, "window");
+            assert_eq!(fields[0].ty, SchemaType::Scalar(Primitive::U32));
+            assert_eq!(fields[1].name, "budget");
+            assert_eq!(fields[1].ty, SchemaType::Scalar(Primitive::U32));
+        }
+
+        #[test]
+        fn crossing_classification_schema_is_struct_of_one_vec() {
+            // A flat Vec-bearing struct (modeled on `CorridorGraph`): one
+            // `Vec<CrossingVerdict>`, recursing into the verdict struct. A
+            // `Struct` schema (not a cast) is what the DAG validator and the
+            // hub codec read for the transform output.
+            let SchemaType::Struct { fields, .. } = &<CrossingClassification as Schema>::SCHEMA
+            else {
+                panic!("expected Struct");
+            };
+            assert_eq!(fields.len(), 1);
+            assert_eq!(fields[0].name, "crossings");
+            let SchemaType::Vec(verdict) = &fields[0].ty else {
+                panic!("expected Vec of verdicts");
+            };
+            let SchemaType::Struct {
+                fields: verdict_fields,
+                ..
+            } = &**verdict
+            else {
+                panic!("expected nested verdict Struct");
+            };
+            assert_eq!(verdict_fields.len(), 8);
+            assert_eq!(verdict_fields[0].name, "crossing_tick");
+            assert_eq!(verdict_fields[1].name, "decision_tick");
+            assert_eq!(verdict_fields[5].name, "avoidable");
+            assert_eq!(verdict_fields[5].ty, SchemaType::Bool);
+            assert_eq!(verdict_fields[7].name, "margin");
+            assert_eq!(verdict_fields[7].ty, SchemaType::Scalar(Primitive::I64));
+        }
+
+        #[test]
+        fn crossing_kinds_resolve_distinctly_from_reach_kinds() {
+            use aether_data::Kind;
+            // The two new crossing-query kinds share no id with the
+            // reachability / trajectory kinds they compose with in a DAG — a
+            // collision would alias the transform's Ref slots.
+            let ids = [
+                CrossingQueryParams::ID,
+                CrossingClassification::ID,
+                ReachabilityProblem::ID,
+                ScalarField::ID,
+                TrajectoryLog::ID,
+            ];
+            for (i, a) in ids.iter().enumerate() {
+                for b in &ids[i + 1..] {
+                    assert_ne!(a, b, "crossing / reach / trajectory ids must be distinct");
+                }
+            }
+        }
+
+        #[test]
         fn population_problem_schema_embeds_reachability_problem() {
             let SchemaType::Struct { fields, .. } = &<PopulationSweepProblem as Schema>::SCHEMA
             else {
@@ -4652,6 +4815,40 @@ mod tests {
             assert_eq!(sample.len(), 2);
             assert_eq!(sample[0].name, "delay");
             assert_eq!(sample[1].name, "finished");
+        }
+
+        #[test]
+        fn crossing_classification_postcard_round_trips() {
+            use alloc::vec;
+            let cls = CrossingClassification {
+                crossings: vec![
+                    CrossingVerdict {
+                        crossing_tick: 12,
+                        decision_tick: 4,
+                        seed_x: 3,
+                        seed_y: 7,
+                        seed_cost: 18,
+                        avoidable: true,
+                        best_continuation_cost: 22,
+                        margin: 3,
+                    },
+                    CrossingVerdict {
+                        crossing_tick: 30,
+                        decision_tick: 30,
+                        seed_x: 0,
+                        seed_y: 0,
+                        seed_cost: 99,
+                        avoidable: false,
+                        best_continuation_cost: u32::MAX,
+                        margin: -1,
+                    },
+                ],
+            };
+            let bytes = postcard::to_allocvec(&cls)
+                .expect("test setup: postcard encodes CrossingClassification");
+            let back: CrossingClassification = postcard::from_bytes(&bytes)
+                .expect("test setup: postcard decodes CrossingClassification");
+            assert_eq!(back, cls);
         }
     }
 


### PR DESCRIPTION
Closes #1864.

## Summary

A counterfactual reachability-from-state query over a windowed cost field (`aether-capabilities::counterfactual`): given a path through #1857's cost field, it detects budget crossings, extracts per-crossing state, and windowed-re-solves to classify each crossing avoidable / unavoidable. New `CrossingQueryParams` / `CrossingClassification` / `CrossingVerdict` kinds and a `#[transform] solve_counterfactual`. Reuses #1857's `solve_cost_to_reach` (cost-valued seed) directly. Iterative throughout.

## Test plan

21 new tests: kind name/schema/distinctness + postcard round-trip; core crossing-detection (avoidable / unavoidable / window-flip); transform inventory-registration, determinism, size-sanity. Full workspace green: clippy `-D warnings`, nextest `--workspace` (1927 passed), doc, wasm32 component cross-build (15 components).

## Generated by

`/implement` — agent execution of scoped issue #1864.
