### PR TITLE
feat(mesh-viewer): space-time iso-surface mesh of a stacked scalar field (boundary extraction)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,7 @@ dependencies = [
  "aether-mesh",
  "aether-substrate-bundle",
  "inventory",
+ "postcard",
  "serde",
  "tracing",
 ]

--- a/crates/aether-mesh-viewer/Cargo.toml
+++ b/crates/aether-mesh-viewer/Cargo.toml
@@ -42,6 +42,13 @@ aether-kinds = { path = "../aether-kinds" }
 aether-mesh = { path = "../aether-mesh" }
 aether-math = { path = "../aether-math" }
 serde = { workspace = true, default-features = false, features = ["derive", "alloc"] }
+# Issue 1868: the `.field` arm decodes a Serde-derived `ScalarField`
+# (the reachability solver's kind, issue 1857) from `.field` file bytes
+# straight off `aether.fs.read`. Postcard is the wire shape the substrate
+# already uses for kind params, so the file bytes an agent writes via
+# `aether.fs.write` are postcard. `default-features = false` keeps it
+# `no_std` for the wasm guest build.
+postcard = { workspace = true, default-features = false, features = ["alloc"] }
 # ADR-0060: tracing facade reaches the substrate's `aether.log` via
 # the SDK's `MailSubscriber` (installed by `export!`).
 tracing = { workspace = true, default-features = false }

--- a/crates/aether-mesh-viewer/src/runtime.rs
+++ b/crates/aether-mesh-viewer/src/runtime.rs
@@ -36,7 +36,7 @@ use aether_actor::{BootError, FfiActor, FfiCtx, OutboundReply, ReplyHandle, Reso
 use aether_capabilities::fs::FsMailboxExt;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::{FsCapability, LifecycleCapability, RenderCapability};
-use aether_kinds::{DrawTriangle, MeshLoadResult, ReadResult, Render, Vertex};
+use aether_kinds::{DrawTriangle, MeshLoadResult, ReadResult, Render, ScalarField, Vertex};
 use aether_math::Vec3;
 use aether_mesh::{Point3, Polygon, tessellate_polygon};
 
@@ -59,6 +59,23 @@ const PALETTE: &[(f32, f32, f32)] = &[
 ];
 
 const OBJ_DEFAULT_COLOR: (f32, f32, f32) = PALETTE[0];
+
+/// Iso threshold for the `.field` arm (issue 1868). Fixed at `1`: cost-0
+/// cells classify as outside and every positive value — the `u32::MAX`
+/// unreachable sentinel included — as inside, with no special case, so a
+/// reachability field becomes a solid whose empty regions read as
+/// tunnels through it.
+const FIELD_ISO_THRESHOLD: u32 = 1;
+
+/// World cell size for the `.field` arm: one world unit per grid step on
+/// each axis, with time → world-z (the camera's depth convention). The
+/// camera frames the result through `view_proj`; the placement is the
+/// fixed unit convention, matching the DSL/OBJ paths' world units.
+const FIELD_CELL: Vec3 = Vec3::splat(1.0);
+
+/// World origin for the `.field` arm. The field's `(0, 0, tick 0)` corner
+/// maps to the world origin (a half-cell shell extends just outside it).
+const FIELD_ORIGIN: Vec3 = Vec3::ZERO;
 
 pub struct MeshViewer {
     triangles: Vec<DrawTriangle>,
@@ -241,6 +258,13 @@ impl MeshViewer {
     /// success and leaving it intact on any failure. Returns the
     /// structured outcome for the `MeshLoadResult` reply.
     fn load_bytes(&mut self, path: &str, bytes: &[u8]) -> LoadOutcome {
+        let lower = path.rsplit('.').next().map(str::to_ascii_lowercase);
+        // `.field` carries a binary `ScalarField` (issue 1868), not UTF-8
+        // text, so it dispatches on the raw bytes before the text decode
+        // the `.dsl` / `.obj` arms need.
+        if lower.as_deref() == Some("field") {
+            return self.try_replace_field(bytes);
+        }
         let Ok(text) = str::from_utf8(bytes) else {
             tracing::warn!(
                 target: "aether_mesh_viewer",
@@ -249,7 +273,6 @@ impl MeshViewer {
             );
             return LoadOutcome::failed("mesh file is not valid UTF-8".to_string());
         };
-        let lower = path.rsplit('.').next().map(str::to_ascii_lowercase);
         if lower.as_deref() == Some("dsl") {
             self.try_replace_dsl(text)
         } else if lower.as_deref() == Some("obj") {
@@ -258,9 +281,11 @@ impl MeshViewer {
             tracing::warn!(
                 target: "aether_mesh_viewer",
                 path = %path,
-                "unsupported file extension; expected .dsl or .obj",
+                "unsupported file extension; expected .dsl, .obj, or .field",
             );
-            LoadOutcome::failed("unsupported file extension; expected .dsl or .obj".to_string())
+            LoadOutcome::failed(
+                "unsupported file extension; expected .dsl, .obj, or .field".to_string(),
+            )
         }
     }
 
@@ -352,6 +377,75 @@ impl MeshViewer {
             }
         }
     }
+
+    /// Decode a binary `ScalarField` (issue 1857) from `.field` bytes,
+    /// iso-surface it, and replace the cached triangle list (issue 1868).
+    ///
+    /// The field's dense row-major `values[t * H * W + y * W + x]` layout
+    /// *is* the stacked space-time volume, so it meshes directly with
+    /// `(x, y, tick)` mapped to `(x, y, z)` and `depth = ticks` — time
+    /// becomes world-z, matching the camera's depth convention. The
+    /// iso threshold is fixed at `1`, so cost-0 cells are outside and
+    /// every positive value (the `u32::MAX` unreachable sentinel included)
+    /// is inside, with no special case. World placement is the fixed
+    /// unit-cell convention (`FIELD_CELL` / `FIELD_ORIGIN`); the camera
+    /// frames the result through `view_proj`. A decode or mesh failure
+    /// leaves the prior cache intact, mirroring the `.dsl` / `.obj` arms.
+    fn try_replace_field(&mut self, bytes: &[u8]) -> LoadOutcome {
+        let field: ScalarField = match postcard::from_bytes(bytes) {
+            Ok(field) => field,
+            Err(error) => {
+                tracing::warn!(
+                    target: "aether_mesh_viewer",
+                    error = ?error,
+                    "ScalarField decode failed; keeping prior mesh",
+                );
+                return LoadOutcome::failed(format!("ScalarField decode failed: {error}"));
+            }
+        };
+        let expected = (field.width as usize)
+            .saturating_mul(field.height as usize)
+            .saturating_mul(field.ticks as usize);
+        if field.values.len() != expected {
+            tracing::warn!(
+                target: "aether_mesh_viewer",
+                width = field.width,
+                height = field.height,
+                ticks = field.ticks,
+                values = field.values.len(),
+                expected,
+                "ScalarField values length mismatch; keeping prior mesh",
+            );
+            return LoadOutcome::failed(format!(
+                "ScalarField values length {} != width * height * ticks = {}",
+                field.values.len(),
+                expected,
+            ));
+        }
+        let tris = aether_mesh::surface_net(
+            field.width as usize,
+            field.height as usize,
+            field.ticks as usize,
+            &field.values,
+            FIELD_ISO_THRESHOLD,
+            FIELD_CELL,
+            FIELD_ORIGIN,
+        );
+        let out: Vec<DrawTriangle> = tris
+            .iter()
+            .map(|t| to_draw_triangle_palette_vec3(t.vertices, t.color))
+            .collect();
+        tracing::info!(
+            target: "aether_mesh_viewer",
+            width = field.width,
+            height = field.height,
+            ticks = field.ticks,
+            triangles = out.len(),
+            "field load complete; cache replaced",
+        );
+        self.triangles = out;
+        LoadOutcome::ok()
+    }
 }
 
 fn polygon_outline_triangles(polygon: &Polygon) -> Vec<[Vec3; 3]> {
@@ -390,6 +484,15 @@ fn outline_loop(loop_: &[Vec3], n: Vec3, out: &mut Vec<[Vec3; 3]>) {
 fn to_draw_triangle_palette(tri: [Point3; 3], color: u32) -> DrawTriangle {
     let rgb = PALETTE[(color as usize) % PALETTE.len()];
     to_draw_triangle_rgb([tri[0].to_f32(), tri[1].to_f32(), tri[2].to_f32()], rgb)
+}
+
+/// Palette-color a world-space `Vec3` triangle (the surface-nets mesher's
+/// output, issue 1868). Mirrors [`to_draw_triangle_palette`] but takes
+/// `Vec3` vertices directly — the surface-nets pass already emits world
+/// coordinates, with no fixed-point `Point3` round-trip.
+fn to_draw_triangle_palette_vec3(tri: [Vec3; 3], color: u32) -> DrawTriangle {
+    let rgb = PALETTE[(color as usize) % PALETTE.len()];
+    to_draw_triangle_rgb(tri, rgb)
 }
 
 fn to_draw_triangle_rgb(tri: [Vec3; 3], rgb: (f32, f32, f32)) -> DrawTriangle {
@@ -583,6 +686,97 @@ mod tests {
             v 1 0 0\n\
             f 1 2 99\n";
         assert!(parse_obj(obj).is_err());
+    }
+
+    /// A bare viewer with an empty cache and no parked reply — enough to
+    /// drive `load_bytes` directly (no scheduler / ctx needed).
+    fn empty_viewer() -> MeshViewer {
+        MeshViewer {
+            triangles: Vec::new(),
+            pending_reply: None,
+        }
+    }
+
+    /// A single-inside-sample `ScalarField` postcard-encoded the way an
+    /// agent writes it via `aether.fs.write`.
+    fn single_voxel_field_bytes() -> Vec<u8> {
+        let mut values = vec![0u32; 3 * 3 * 3];
+        values[13] = 1; // center sample (x, y, z) = (1, 1, 1): 1*9 + 1*3 + 1
+        let field = ScalarField {
+            width: 3,
+            height: 3,
+            ticks: 3,
+            values,
+        };
+        postcard::to_allocvec(&field).expect("test setup: encode ScalarField")
+    }
+
+    /// Issue 1868: a `.field` load decodes a postcard `ScalarField`,
+    /// meshes it, and replaces the cache with a non-empty triangle list,
+    /// reporting `ok: true`. The single-voxel field meshes to the
+    /// 12-triangle closed cube the mesher's own test asserts.
+    #[test]
+    fn field_load_replaces_cache_and_reports_ok() {
+        let mut viewer = empty_viewer();
+        let bytes = single_voxel_field_bytes();
+        let outcome = viewer.load_bytes("reach.field", &bytes);
+        assert!(
+            outcome.error.is_none(),
+            "good field should load: {:?}",
+            outcome.error,
+        );
+        assert_eq!(
+            viewer.triangles.len(),
+            12,
+            "single-voxel field meshes to a 12-triangle closed cube",
+        );
+    }
+
+    /// Issue 1868: a malformed `.field` buffer keeps the prior cache and
+    /// reports `ok: false`. A non-postcard byte run fails to decode; the
+    /// previously-loaded triangles survive.
+    #[test]
+    fn malformed_field_keeps_prior_cache() {
+        let mut viewer = empty_viewer();
+        // Seed a prior good mesh.
+        let good = single_voxel_field_bytes();
+        viewer.load_bytes("good.field", &good);
+        let prior = viewer.triangles.len();
+        assert_eq!(prior, 12, "prior good load populated the cache");
+
+        // A truncated / garbage buffer fails to decode.
+        let outcome = viewer.load_bytes("bad.field", &[0xff, 0xff, 0xff, 0x01]);
+        assert!(outcome.error.is_some(), "malformed field reports a failure");
+        assert_eq!(
+            viewer.triangles.len(),
+            prior,
+            "malformed field leaves the prior cache intact",
+        );
+    }
+
+    /// A `.field` whose declared dimensions disagree with `values.len()`
+    /// is rejected before meshing, keeping the prior cache.
+    #[test]
+    fn field_length_mismatch_keeps_prior_cache() {
+        let mut viewer = empty_viewer();
+        let good = single_voxel_field_bytes();
+        viewer.load_bytes("good.field", &good);
+        let prior = viewer.triangles.len();
+
+        let field = ScalarField {
+            width: 4,
+            height: 4,
+            ticks: 4,
+            values: vec![1u32; 10], // not 4*4*4
+        };
+        let bytes = postcard::to_allocvec(&field).expect("encode mismatched field");
+        let outcome = viewer.load_bytes("mismatch.field", &bytes);
+        assert!(outcome.error.is_some(), "length mismatch reports a failure");
+        assert_eq!(
+            viewer.triangles.len(),
+            prior,
+            "length mismatch leaves the prior cache intact",
+        );
     }
 }
 

--- a/crates/aether-mesh-viewer/tests/scenario.rs
+++ b/crates/aether-mesh-viewer/tests/scenario.rs
@@ -20,7 +20,7 @@
 //! `TestBench::builder().namespace_roots(...)` rather than env-var
 //! mutation.
 
-use aether_kinds::{LoadComponent, LoadResult, MeshLoadResult};
+use aether_kinds::{LoadComponent, LoadResult, MeshLoadResult, ScalarField};
 use aether_mesh_viewer::LoadMesh;
 use aether_substrate_bundle::test_bench::{
     BenchOp, TestBench,
@@ -153,6 +153,59 @@ fn dsl_box_loads_and_renders() {
     let img = decode_png(png).expect("decode capture png");
     assert_draw_triangle_observed(&bench);
     differs_from_background(&img, 5).expect("captured frame should diverge from clear color");
+}
+
+/// Issue 1868 render-path smoke: a `.field` load decodes a postcard
+/// `ScalarField`, surface-nets it, and replays the triangles to
+/// `aether.render` every frame — `aether.draw_triangle` is observed.
+/// Asserts mesh structure (triangles flow), not pixels, per the GPU-test
+/// split (the test bench has no GPU-capture host for structural checks).
+#[test]
+fn field_loads_and_renders() {
+    let Some(wasm_path) = require_runtime("aether_mesh_viewer") else {
+        return;
+    };
+    let sandbox = init_save_sandbox("mesh-viewer");
+    // A small filled box with an interior empty pocket — a non-trivial
+    // boundary surface (an outer shell plus a cavity).
+    let (w, h, t) = (4u32, 4u32, 4u32);
+    let (wz, hz, tz) = (w as usize, h as usize, t as usize);
+    let mut values = vec![1u32; wz * hz * tz];
+    values[2 * hz * wz + 2 * wz + 2] = 0; // carve an interior empty cell
+    let field = ScalarField {
+        width: w,
+        height: h,
+        ticks: t,
+        values,
+    };
+    let bytes = postcard::to_allocvec(&field).expect("encode ScalarField fixture");
+    let path = write_fixture("reach.field", &bytes);
+
+    let mut bench = TestBench::builder()
+        .size(64, 48)
+        .namespace_roots(test_namespace_roots(sandbox))
+        .build()
+        .expect("boot");
+    load_viewer(&mut bench, &wasm_path);
+
+    bench
+        .execute(vec![
+            ("prime", BenchOp::advance(1)),
+            (
+                "load_mesh",
+                BenchOp::send_mail(
+                    component_address(),
+                    &LoadMesh {
+                        namespace: "save".to_owned(),
+                        path,
+                    },
+                ),
+            ),
+            ("post", BenchOp::advance(5)),
+        ])
+        .expect("prime + load + advance");
+
+    assert_draw_triangle_observed(&bench);
 }
 
 /// `.obj` parser smoke. The OBJ path doesn't go through `aether-mesh`'s

--- a/crates/aether-mesh/src/lib.rs
+++ b/crates/aether-mesh/src/lib.rs
@@ -23,6 +23,7 @@ pub mod point;
 pub mod polygon;
 pub mod serialize;
 pub mod simplify;
+pub mod surface_net;
 pub mod tessellate;
 
 #[cfg(test)]
@@ -35,3 +36,4 @@ pub use parse::{ParseError, parse};
 pub use point::Point3;
 pub use polygon::{Polygon, mesh_polygons, tessellate_polygon};
 pub use serialize::serialize;
+pub use surface_net::surface_net;

--- a/crates/aether-mesh/src/surface_net.rs
+++ b/crates/aether-mesh/src/surface_net.rs
@@ -1,0 +1,514 @@
+// Surface nets is domain math: bounded grid-index integer counts cast to
+// f32 for centroid placement, and `a`/`b`/`q`/`t0`/`t1` are the canonical
+// edge / quad / triangle vocabulary — the same convention `mesh.rs` and
+// `tessellate.rs` carry.
+#![allow(clippy::cast_precision_loss, clippy::many_single_char_names)]
+
+//! Naive surface-nets meshing of a dense scalar volume (issue 1868).
+//!
+//! The dual (one-vertex-per-cell) surface extractor: given a dense
+//! `u32` sample grid and an iso threshold, it meshes only the interface
+//! between the *inside* region (`value >= iso_threshold`) and the
+//! *outside* region, so cost is O(boundary area) rather than O(volume
+//! cells). An all-outside volume emits zero triangles; an all-inside
+//! volume emits only its outer shell (clamped against a virtual outside
+//! beyond the grid), not its interior.
+//!
+//! Library-only, per ADR-0053: this produces triangles, it does not
+//! render. It sits alongside the DSL mesher (`crate::mesh`) as a second
+//! triangle producer, reusing the crate's [`Triangle`] and
+//! `aether_math::Vec3`. The reachability solver's [`ScalarField`]
+//! (issue 1857) is the canonical input — its dense row-major
+//! `values[t * H * W + y * W + x]` layout *is* the stacked volume, so a
+//! caller meshes a field by passing `(x, y, t)` as `(x, y, z)` with
+//! `depth = ticks`.
+//!
+//! The sweep is iterative and dense (no recursion over geometry, per
+//! the load-bearing-code rule in `CLAUDE.md`): a single linear pass over
+//! the cells places one centroid vertex per straddling cube, and a
+//! second linear pass over the interior axis-aligned grid edges emits a
+//! sign-wound quad (two [`Triangle`]s) per sign-change edge.
+//!
+//! [`ScalarField`]: https://docs.rs/aether-kinds
+
+use crate::mesh::Triangle;
+use aether_math::Vec3;
+
+/// Flat color index handed to every emitted triangle. The viewer maps
+/// this through its palette; a single index keeps the surface one solid
+/// color (the boundary surface has no per-face material).
+const SURFACE_COLOR: u32 = 0;
+
+/// A sentinel for "no vertex placed in this cube". Cubes that do not
+/// straddle the surface get no vertex; the quad pass skips any edge
+/// whose four surrounding cubes are not all populated.
+const NO_VERTEX: u32 = u32::MAX;
+
+/// Extract the boundary surface of a dense scalar volume as a triangle
+/// list, via naive (centroid-placed) surface nets.
+///
+/// `values` is a dense row-major `width * height * depth` grid of
+/// samples, indexed `values[z * height * width + y * width + x]` — the
+/// same layout the reachability solver's `ScalarField` uses with
+/// `(x, y, tick)` mapped to `(x, y, z)`. A sample is *inside* iff
+/// `value >= iso_threshold`; everything else is *outside*. The grid is
+/// padded by one virtual-outside layer on every side, so an inside
+/// region touching the volume edge caps cleanly against an outer shell.
+///
+/// Cubes sit between 8 corner samples. A cube *straddles* the surface
+/// iff its 8 corners are not all the same side; only straddling cubes
+/// contribute, which is the O(boundary area) property — interior-full
+/// and interior-empty cubes are skipped. Each straddling cube gets one
+/// vertex at its centroid, mapped to world as `origin + cell * c` where
+/// `c` is the cube center in sample coordinates (the boundary shell's
+/// cubes sit a half-cell outside the `[0, dim-1]` sample extent). For
+/// each axis-aligned grid edge whose two endpoints differ in side, the
+/// four cubes sharing that edge are wound into a quad (two triangles)
+/// oriented so the front face points toward the outside region.
+///
+/// Returns an empty list when the volume has no cubes (any dimension
+/// `< 2`), when `values.len()` does not match `width * height * depth`,
+/// or when no cube straddles the surface.
+#[allow(clippy::too_many_lines)]
+#[must_use]
+pub fn surface_net(
+    width: usize,
+    height: usize,
+    depth: usize,
+    values: &[u32],
+    iso_threshold: u32,
+    cell: Vec3,
+    origin: Vec3,
+) -> Vec<Triangle> {
+    // Fewer than two samples along any axis means no cube exists, and a
+    // wrong-length `values` is a malformed field — both mesh to nothing
+    // rather than panicking (defensive against a bad decoded field).
+    if width < 2 || height < 2 || depth < 2 {
+        return Vec::new();
+    }
+    if values.len() != width * height * depth {
+        return Vec::new();
+    }
+
+    // The grid is padded by one virtual-outside layer on every side, so
+    // an inside region touching the volume edge caps cleanly against a
+    // shell: a padded sample `(px, py, pz)` maps to the real sample
+    // `(px - 1, py - 1, pz - 1)` when that lies in range, and is treated
+    // as outside (below the threshold) otherwise. The padded sample grid
+    // is `(width + 2, height + 2, depth + 2)`; its cubes are
+    // `(width + 1) * (height + 1) * (depth + 1)`. The outermost cubes
+    // straddle the original boundary, producing the outer shell that a
+    // bare-grid sweep would miss.
+    let pw = width + 2;
+    let ph = height + 2;
+    let pd = depth + 2;
+
+    let inside = |px: usize, py: usize, pz: usize| -> bool {
+        if px == 0 || py == 0 || pz == 0 || px > width || py > height || pz > depth {
+            return false; // virtual outside
+        }
+        let (x, y, z) = (px - 1, py - 1, pz - 1);
+        values[z * height * width + y * width + x] >= iso_threshold
+    };
+
+    let cells_x = pw - 1;
+    let cells_y = ph - 1;
+    let cells_z = pd - 1;
+
+    // Pass 1: place one centroid vertex per straddling cube. `vertex`
+    // holds the index into `positions` for each cube, or `NO_VERTEX`.
+    let cell_count = cells_x * cells_y * cells_z;
+    let mut vertex = vec![NO_VERTEX; cell_count];
+    let mut positions: Vec<Vec3> = Vec::new();
+
+    let cube_index = |i: usize, j: usize, k: usize| -> usize { (k * cells_y + j) * cells_x + i };
+
+    for k in 0..cells_z {
+        for j in 0..cells_y {
+            for i in 0..cells_x {
+                // The cube's 8 corners span padded samples
+                // (i..=i+1, j..=j+1, k..=k+1). Count how many are inside;
+                // a cube straddles iff the count is neither 0 nor 8.
+                let mut inside_count = 0u8;
+                for dk in 0..2 {
+                    for dj in 0..2 {
+                        for di in 0..2 {
+                            if inside(i + di, j + dj, k + dk) {
+                                inside_count += 1;
+                            }
+                        }
+                    }
+                }
+                if inside_count == 0 || inside_count == 8 {
+                    continue;
+                }
+                // The padded cube `(i, j, k)` centers between padded
+                // samples `i` and `i+1`, i.e. real coordinate
+                // `(i - 1) + 0.5 = i - 0.5`. World placement maps a real
+                // coordinate `c` to `origin + cell * c`, so the boundary
+                // shell's cubes sit a half-cell outside the sample extent.
+                let centroid = origin
+                    + Vec3::new(
+                        cell.x * (i as f32 - 0.5),
+                        cell.y * (j as f32 - 0.5),
+                        cell.z * (k as f32 - 0.5),
+                    );
+                // The vertex count is bounded by the boundary cell count;
+                // a field with more than `u32::MAX - 1` straddling cubes
+                // (4 billion) is not representable, so this never
+                // truncates and never collides with `NO_VERTEX`.
+                #[allow(clippy::cast_possible_truncation)]
+                let idx = positions.len() as u32;
+                positions.push(centroid);
+                vertex[cube_index(i, j, k)] = idx;
+            }
+        }
+    }
+
+    if positions.is_empty() {
+        return Vec::new();
+    }
+
+    // Pass 2: for each interior padded-grid axis-aligned edge whose two
+    // endpoints differ in side, the four cubes sharing that edge form a
+    // quad. "Interior" is in the *padded* grid — the padding guarantees
+    // every original boundary edge now has four surrounding cubes, so the
+    // outer shell is emitted. The four cubes are addressed by stepping
+    // back along the two axes orthogonal to the edge.
+    let mut triangles: Vec<Triangle> = Vec::new();
+
+    // X-axis edges: endpoints (x, y, z)-(x+1, y, z). The four cubes
+    // sharing this edge vary in (j, k) around (y, z).
+    for z in 1..cells_z {
+        for y in 1..cells_y {
+            for x in 0..cells_x {
+                let a = inside(x, y, z);
+                let b = inside(x + 1, y, z);
+                if a == b {
+                    continue;
+                }
+                let q = [
+                    vertex[cube_index(x, y - 1, z - 1)],
+                    vertex[cube_index(x, y, z - 1)],
+                    vertex[cube_index(x, y, z)],
+                    vertex[cube_index(x, y - 1, z)],
+                ];
+                emit_quad(&mut triangles, &positions, q, a);
+            }
+        }
+    }
+
+    // Y-axis edges: endpoints (x, y, z)-(x, y+1, z). Four cubes vary in
+    // (i, k). The (i, k) winding has the opposite handedness to the
+    // (j, k) edge above for the same sign direction, so flip the
+    // sign-driven order to keep normals outward.
+    for z in 1..cells_z {
+        for y in 0..cells_y {
+            for x in 1..cells_x {
+                let a = inside(x, y, z);
+                let b = inside(x, y + 1, z);
+                if a == b {
+                    continue;
+                }
+                let q = [
+                    vertex[cube_index(x - 1, y, z - 1)],
+                    vertex[cube_index(x, y, z - 1)],
+                    vertex[cube_index(x, y, z)],
+                    vertex[cube_index(x - 1, y, z)],
+                ];
+                emit_quad(&mut triangles, &positions, q, !a);
+            }
+        }
+    }
+
+    // Z-axis edges: endpoints (x, y, z)-(x, y, z+1). Four cubes vary in
+    // (i, j).
+    for z in 0..cells_z {
+        for y in 1..cells_y {
+            for x in 1..cells_x {
+                let a = inside(x, y, z);
+                let b = inside(x, y, z + 1);
+                if a == b {
+                    continue;
+                }
+                let q = [
+                    vertex[cube_index(x - 1, y - 1, z)],
+                    vertex[cube_index(x, y - 1, z)],
+                    vertex[cube_index(x, y, z)],
+                    vertex[cube_index(x - 1, y, z)],
+                ];
+                emit_quad(&mut triangles, &positions, q, a);
+            }
+        }
+    }
+
+    triangles
+}
+
+/// Fan a quad of four cube-vertices into two triangles, wound so the
+/// front face points toward the outside region.
+///
+/// `q` is the four surrounding cube vertex indices in CCW order around
+/// the edge as seen from the positive edge direction; `endpoint0_inside`
+/// is whether the edge's first endpoint is inside. When it is, the
+/// inside region sits "behind" the CCW order, so the quad is wound in
+/// the listed order; otherwise the order is reversed so the front face
+/// flips to face the (now opposite) outside. Any quad with an
+/// unpopulated corner (an edge on the volume's outer face) is dropped —
+/// the four cubes must all straddle for a closed quad.
+fn emit_quad(out: &mut Vec<Triangle>, positions: &[Vec3], q: [u32; 4], endpoint0_inside: bool) {
+    if q.contains(&NO_VERTEX) {
+        return;
+    }
+    let p = [
+        positions[q[0] as usize],
+        positions[q[1] as usize],
+        positions[q[2] as usize],
+        positions[q[3] as usize],
+    ];
+    // CCW fan (0,1,2)+(0,2,3) faces one way; reverse for the other sign.
+    let (t0, t1) = if endpoint0_inside {
+        ([p[0], p[1], p[2]], [p[0], p[2], p[3]])
+    } else {
+        ([p[0], p[2], p[1]], [p[0], p[3], p[2]])
+    };
+    out.push(Triangle {
+        vertices: t0,
+        color: SURFACE_COLOR,
+    });
+    out.push(Triangle {
+        vertices: t1,
+        color: SURFACE_COLOR,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_math::Aabb;
+
+    /// Build a dense `w*h*d` volume from a closure classifying each
+    /// grid point as inside (`true` → 1) or outside (`false` → 0).
+    fn volume(w: usize, h: usize, d: usize, f: impl Fn(usize, usize, usize) -> bool) -> Vec<u32> {
+        let mut v = vec![0u32; w * h * d];
+        for z in 0..d {
+            for y in 0..h {
+                for x in 0..w {
+                    if f(x, y, z) {
+                        v[z * h * w + y * w + x] = 1;
+                    }
+                }
+            }
+        }
+        v
+    }
+
+    fn unit() -> (Vec3, Vec3) {
+        (Vec3::splat(1.0), Vec3::ZERO)
+    }
+
+    /// A single inside sample at the center of a 3x3x3 volume meshes to
+    /// a closed surface of 12 triangles — exactly the box=12 precedent.
+    /// The lone inside sample is shared by 8 straddling cubes, giving 8
+    /// vertices and the 6 interior sign-change edges incident on it,
+    /// each emitting one quad (two triangles) → 12 triangles.
+    #[test]
+    fn single_inside_sample_meshes_closed_cube() {
+        let (cell, origin) = unit();
+        let v = volume(3, 3, 3, |x, y, z| (x, y, z) == (1, 1, 1));
+        let tris = surface_net(3, 3, 3, &v, 1, cell, origin);
+        assert_eq!(tris.len(), 12, "single voxel → 12-triangle closed cube");
+    }
+
+    /// An all-outside volume emits nothing — no cube straddles.
+    #[test]
+    fn all_outside_emits_no_triangles() {
+        let (cell, origin) = unit();
+        let v = volume(4, 4, 4, |_, _, _| false);
+        let tris = surface_net(4, 4, 4, &v, 1, cell, origin);
+        assert!(tris.is_empty(), "all-outside → 0 triangles");
+    }
+
+    /// An all-inside volume emits only its outer shell against the
+    /// virtual-outside padding, and the count tracks boundary area, not
+    /// interior volume (the O(area) guarantee). Growing only the z-extent
+    /// of a fully-inside box adds side-wall area but leaves every interior
+    /// cube fully inside (non-straddling, zero vertices), so the triangle
+    /// count grows by the added wall area alone.
+    #[test]
+    fn all_inside_emits_only_shell_independent_of_depth() {
+        let (cell, origin) = unit();
+        let shallow = volume(3, 3, 3, |_, _, _| true);
+        let deep = volume(3, 3, 5, |_, _, _| true);
+        let tris_shallow = surface_net(3, 3, 3, &shallow, 1, cell, origin);
+        let tris_deep = surface_net(3, 3, 5, &deep, 1, cell, origin);
+        assert!(!tris_shallow.is_empty(), "full cube has an outer shell");
+        // The deeper box has taller side walls (more boundary area), so a
+        // strictly larger shell — but nowhere near a volume-scaling pass:
+        // every fully-interior cube stays non-straddling and contributes
+        // nothing.
+        assert!(
+            tris_deep.len() > tris_shallow.len(),
+            "taller box has more side-wall area: shallow={} deep={}",
+            tris_shallow.len(),
+            tris_deep.len(),
+        );
+        // The all-inside shell is a closed box. Each of the 3x3x3 volume's
+        // 6 faces has 3x3 = 9 boundary samples, each emitting one outward
+        // sign-change edge → one quad → 9 quads per face. 6 * 9 = 54 quads
+        // → 108 triangles. The interior is never meshed (the O(area)
+        // guarantee, not O(volume)).
+        assert_eq!(
+            tris_shallow.len(),
+            6 * 3 * 3 * 2,
+            "3x3x3 full box shell = 6 faces * 9 quads * 2 tris",
+        );
+    }
+
+    /// A volume with an interior empty pocket emits more triangles than
+    /// the bare outer shell — the pocket is a tunnel/cavity boundary —
+    /// and the meshed vertices' bounding box matches the volume extent.
+    #[test]
+    fn interior_pocket_adds_surface_and_bbox_matches_extent() {
+        let (cell, origin) = unit();
+        let w = 5;
+        let h = 5;
+        let d = 5;
+        let full = volume(w, h, d, |_, _, _| true);
+        // Carve a single empty sample at the center.
+        let pocket = volume(w, h, d, |x, y, z| (x, y, z) != (2, 2, 2));
+        let tris_full = surface_net(w, h, d, &full, 1, cell, origin);
+        let tris_pocket = surface_net(w, h, d, &pocket, 1, cell, origin);
+        assert!(
+            tris_pocket.len() > tris_full.len(),
+            "an interior empty pocket adds boundary surface (a cavity)",
+        );
+        // The vertex bounding box spans the outer shell's cube centroids,
+        // which sit a half-cell outside the sample extent: real coordinate
+        // -0.5 at the low side, (dim-1)+0.5 at the high side along each
+        // axis.
+        let pts: Vec<Vec3> = tris_pocket
+            .iter()
+            .flat_map(|t| t.vertices.iter().copied())
+            .collect();
+        let bbox = Aabb::from_points(&pts);
+        let lo = -0.5_f32;
+        let hi_x = (w - 1) as f32 + 0.5;
+        let hi_y = (h - 1) as f32 + 0.5;
+        let hi_z = (d - 1) as f32 + 0.5;
+        let eps = 1e-4;
+        assert!((bbox.min.x - lo).abs() < eps, "bbox min.x = {}", bbox.min.x);
+        assert!((bbox.min.y - lo).abs() < eps, "bbox min.y = {}", bbox.min.y);
+        assert!((bbox.min.z - lo).abs() < eps, "bbox min.z = {}", bbox.min.z);
+        assert!(
+            (bbox.max.x - hi_x).abs() < eps,
+            "bbox max.x = {}",
+            bbox.max.x
+        );
+        assert!(
+            (bbox.max.y - hi_y).abs() < eps,
+            "bbox max.y = {}",
+            bbox.max.y
+        );
+        assert!(
+            (bbox.max.z - hi_z).abs() < eps,
+            "bbox max.z = {}",
+            bbox.max.z
+        );
+    }
+
+    /// The single-voxel cube's faces wind outward: every triangle's
+    /// geometric normal points away from the voxel center. The voxel
+    /// sample sits at world `(1, 1, 1)`; each surrounding centroid sits at
+    /// a corner offset of `±0.5`, so the closed surface is the cube
+    /// `[0.5, 1.5]` cubed centered at `(1, 1, 1)`, and an outward normal
+    /// has a positive dot with `face_centroid - cube_center`.
+    #[test]
+    fn single_voxel_winds_outward() {
+        let (cell, origin) = unit();
+        let v = volume(3, 3, 3, |x, y, z| (x, y, z) == (1, 1, 1));
+        let tris = surface_net(3, 3, 3, &v, 1, cell, origin);
+        let center = Vec3::new(1.0, 1.0, 1.0);
+        for t in &tris {
+            let [a, b, c] = t.vertices;
+            let normal = (b - a).cross(c - a);
+            let face_center = (a + b + c) * (1.0 / 3.0);
+            let outward = face_center - center;
+            assert!(
+                normal.dot(outward) > 0.0,
+                "triangle normal must face outward: n·out = {}",
+                normal.dot(outward),
+            );
+        }
+    }
+
+    /// `iso_threshold = 1` classifies cost-0 cells outside and every
+    /// positive value — the `u32::MAX` unreachable sentinel included —
+    /// inside, with no special case and no panic. A volume with a single
+    /// `u32::MAX` sample meshes the same closed cube as a single `1`.
+    #[test]
+    fn sentinel_classified_inside_no_panic() {
+        let (cell, origin) = unit();
+        let mut v = volume(3, 3, 3, |_, _, _| false);
+        // Center sample at (x, y, z) = (1, 1, 1) in a 3x3x3 grid:
+        // index z*H*W + y*W + x = 1*9 + 1*3 + 1 = 13.
+        v[13] = u32::MAX;
+        let tris = surface_net(3, 3, 3, &v, 1, cell, origin);
+        assert_eq!(
+            tris.len(),
+            12,
+            "a u32::MAX sample is inside under iso_threshold = 1",
+        );
+    }
+
+    /// Degenerate dimensions (a single slice along any axis) have no
+    /// cubes and mesh to nothing — boundary clamping never indexes out
+    /// of range.
+    #[test]
+    fn degenerate_dimensions_emit_nothing() {
+        let (cell, origin) = unit();
+        for (w, h, d) in [(1, 3, 3), (3, 1, 3), (3, 3, 1)] {
+            let v = volume(w, h, d, |_, _, _| true);
+            let tris = surface_net(w, h, d, &v, 1, cell, origin);
+            assert!(
+                tris.is_empty(),
+                "a {w}x{h}x{d} volume has no cells → 0 triangles",
+            );
+        }
+    }
+
+    /// A mismatched `values` length returns empty rather than panicking
+    /// — defensive against a malformed decoded field.
+    #[test]
+    fn mismatched_length_returns_empty() {
+        let (cell, origin) = unit();
+        let v = vec![1u32; 10]; // not 3*3*3 = 27
+        let tris = surface_net(3, 3, 3, &v, 1, cell, origin);
+        assert!(tris.is_empty(), "wrong-length values → 0 triangles");
+    }
+
+    /// Non-unit `cell` and a non-zero `origin` place vertices in world
+    /// space at `origin + cell * (i+0.5)`.
+    #[test]
+    fn cell_and_origin_place_vertices_in_world() {
+        let cell = Vec3::new(2.0, 3.0, 4.0);
+        let origin = Vec3::new(10.0, 20.0, 30.0);
+        let v = volume(3, 3, 3, |x, y, z| (x, y, z) == (1, 1, 1));
+        let tris = surface_net(3, 3, 3, &v, 1, cell, origin);
+        let pts: Vec<Vec3> = tris
+            .iter()
+            .flat_map(|t| t.vertices.iter().copied())
+            .collect();
+        let bbox = Aabb::from_points(&pts);
+        // Centroids at i in {0, 1}: x = 10 + 2*(0.5) = 11 and
+        // 10 + 2*(1.5) = 13; y = 20 + 3*0.5 = 21.5 .. 24.5;
+        // z = 30 + 4*0.5 = 32 .. 36.
+        let eps = 1e-4;
+        assert!((bbox.min.x - 11.0).abs() < eps);
+        assert!((bbox.max.x - 13.0).abs() < eps);
+        assert!((bbox.min.y - 21.5).abs() < eps);
+        assert!((bbox.max.y - 24.5).abs() < eps);
+        assert!((bbox.min.z - 32.0).abs() < eps);
+        assert!((bbox.max.z - 36.0).abs() < eps);
+    }
+}


### PR DESCRIPTION
Closes #1868.

## Summary

A space-time iso-surface mesh for the mesh-viewer. A pure dual surface-nets mesher (`aether-mesh::surface_net`) extracts the boundary of a stacked `ScalarField` (z = tick), and a `.field` load arm in `aether-mesh-viewer` postcard-decodes a `ScalarField`, meshes it at `iso = 1`, caches the triangles, and renders them through the existing draw path. The sample grid is padded with a virtual-outside layer so an all-inside volume emits its outer shell (per the design's acceptance criteria).

## Test plan

9 mesher unit tests (single-voxel cube, all-outside / all-inside shell, interior pocket, outward winding, `u32::MAX` sentinel, degenerate dims, world placement); 3 runtime tests (ok load → 12 tris, malformed / length-mismatch keep the prior cache); a TestBench scenario asserting `aether.draw_triangle` is observed. Full workspace green: clippy `-D warnings`, nextest `--workspace` (1919 passed), doc, wasm32 cross-build of `aether-mesh-viewer`.

## Generated by

`/implement` — agent execution of scoped issue #1868.
