### PR TITLE
docs(adr): accept adr-0113 kind-typed actor state

### DIFF
--- a/docs/adr/0113-kind-typed-actor-state.md
+++ b/docs/adr/0113-kind-typed-actor-state.md
@@ -1,7 +1,8 @@
 # ADR-0113: Kind-typed actor state for hot-reload
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-06-14
+- **Accepted:** 2026-06-15 (implemented by #1884)
 
 ## Context
 


### PR DESCRIPTION
## What

Flips ADR-0113 (kind-typed actor state for hot-reload) from Proposed to Accepted.

The implementation landed in #1884 — the `type State` associated type on `FfiActor` plus the macro-generated `dehydrate` / `rehydrate` hooks; `type State` is now on main in `crates/aether-actor/src/ffi/mod.rs`. Per the project rule that an ADR is accepted only once its implementation arc lands, this is the closing step. Adds an `Accepted: 2026-06-15 (implemented by #1884)` line mirroring ADR-0101's convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
