### PR TITLE
refactor(actor): lock the single reply class by dropping the transitional impl

### DIFF
--- a/crates/aether-actor-derive/tests/ui.rs
+++ b/crates/aether-actor-derive/tests/ui.rs
@@ -38,6 +38,11 @@ fn ui() {
     t.compile_fail("tests/ui/rejects_stream_reserved_ffi.rs");
     t.compile_fail("tests/ui/rejects_stream_reserved_native.rs");
     t.compile_fail("tests/ui/rejects_manual_marker_mismatch_ffi.rs");
+    // ADR-0112 (single-locked): a single-class `#[handler]` body has no
+    // reply surface (`OutboundReply` is not impl'd for the `Single` ctx),
+    // so a hand-call to `ctx.reply` is a compile error — `-> ()` is
+    // provably silent.
+    t.compile_fail("tests/ui/single_handler_cannot_reply.rs");
     // ADR-0113: declarative `type State` + `dehydrate` / `rehydrate`
     // accessors generate the hot-swap hooks; the macro enforces the XOR
     // (no manual hook), the pairing (both accessors), and the dependency

--- a/crates/aether-actor-derive/tests/ui/single_handler_cannot_reply.rs
+++ b/crates/aether-actor-derive/tests/ui/single_handler_cannot_reply.rs
@@ -1,0 +1,59 @@
+//! ADR-0112 (single-locked): a plain `#[handler]` (single-class) body has
+//! no reply surface — the `Single` ctx does not implement `OutboundReply`,
+//! so a hand-call to `ctx.reply` is a compile error. This locks `-> ()`
+//! as provably silent (the manifest's `ReplyContract::None` is true by
+//! construction). A handler that needs to reply by hand declares
+//! `#[handler::manual]` and takes the `Manual` ctx.
+
+use aether_actor::{FfiCtx, OutboundReply, actor};
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.ping")]
+struct Ping {
+    seq: u32,
+}
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.ack")]
+struct Ack {
+    seq: u32,
+}
+
+struct SilentProbe;
+
+#[actor]
+impl aether_actor::FfiActor for SilentProbe {
+    const NAMESPACE: &'static str = "silent_probe";
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, aether_actor::BootError>
+    where
+        C: aether_actor::Resolver,
+    {
+        Ok(SilentProbe)
+    }
+
+    #[handler]
+    fn on_ping(&mut self, ctx: &mut FfiCtx<'_>, ping: Ping) {
+        // A single-class handler has no reply surface: `OutboundReply` is
+        // not implemented for `FfiCtx<'_, Single>`, so this fails to compile.
+        ctx.reply(&Ack { seq: ping.seq });
+    }
+}
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/single_handler_cannot_reply.stderr
+++ b/crates/aether-actor-derive/tests/ui/single_handler_cannot_reply.stderr
@@ -1,0 +1,11 @@
+error[E0599]: no method named `reply` found for mutable reference `&mut FfiCtx<'_>` in the current scope
+  --> tests/ui/single_handler_cannot_reply.rs:55:13
+   |
+55 |         ctx.reply(&Ack { seq: ping.seq });
+   |             ^^^^^
+   |
+help: there is a method `reply_kind` with a similar name, but with different arguments
+  --> $WORKSPACE/crates/aether-actor/src/ffi/ctx.rs
+   |
+   |     pub fn reply_kind<K: Kind>(&self, sender: ReplyHandle, kind: KindId<K>, payload: &K) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/aether-actor/examples/echoer.rs
+++ b/crates/aether-actor/examples/echoer.rs
@@ -12,7 +12,7 @@
 // fine but must keep the signature.
 #![allow(clippy::unused_self)]
 
-use aether_actor::{BootError, FfiActor, FfiCtx, OutboundReply, Resolver, actor};
+use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
 use aether_data::{Kind, Schema};
 use bytemuck::{Pod, Zeroable};
 
@@ -44,8 +44,8 @@ impl FfiActor for Echoer {
     }
 
     #[handler]
-    fn on_request(&mut self, ctx: &mut FfiCtx<'_>, req: Request) {
-        ctx.reply(&Response { seq: req.seq });
+    fn on_request(&mut self, _ctx: &mut FfiCtx<'_>, req: Request) -> Response {
+        Response { seq: req.seq }
     }
 }
 

--- a/crates/aether-actor/examples/hello.rs
+++ b/crates/aether-actor/examples/hello.rs
@@ -21,7 +21,7 @@
 // fine but must keep the signature.
 #![allow(clippy::unused_self)]
 
-use aether_actor::{BootError, FfiActor, FfiCtx, OutboundReply, Resolver, actor};
+use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::{LifecycleCapability, RenderCapability};
 use aether_kinds::{DrawTriangle, Ping, Pong, Tick, Vertex};
@@ -102,8 +102,8 @@ impl FfiActor for Hello {
     /// The seq echo lets you pair requests and replies when multiple
     /// are in flight.
     #[handler]
-    fn on_ping(&mut self, ctx: &mut FfiCtx<'_>, ping: Ping) {
-        ctx.reply(&Pong { seq: ping.seq });
+    fn on_ping(&mut self, _ctx: &mut FfiCtx<'_>, ping: Ping) -> Pong {
+        Pong { seq: ping.seq }
     }
 }
 

--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -366,11 +366,10 @@ impl<M: ReplyMode> MailSender for FfiCtx<'_, M> {
     }
 }
 
-// ADR-0112: the reply surface is per-mode. `Manual` carries it
-// permanently (a manual-class handler issues its own replies); `Single`
-// carries the identical body **transitionally** so the ~350 existing
-// `#[handler]` bodies that hand-call `ctx.reply` keep compiling — that
-// impl is dropped when `single` is locked (a separate follow-on issue).
+// ADR-0112: the reply surface is per-mode. `Manual` carries it (a
+// manual-class handler issues its own replies); `Single` deliberately
+// does not, so a `-> ()` single handler is provably silent and a stray
+// single-ctx `ctx.reply` is a compile error rather than a manifest lie.
 impl OutboundReply for FfiCtx<'_, Manual> {
     type ReplyHandle = ReplyHandle;
 
@@ -382,33 +381,6 @@ impl OutboundReply for FfiCtx<'_, Manual> {
         None
     }
 
-    //noinspection DuplicatedCode
-    fn reply<K: Kind>(&mut self, payload: &K) {
-        if let Some(raw) = self.sender {
-            let bytes = payload.encode_into_bytes();
-            MAIL_BRIDGE.reply_mail(raw, K::ID.0, &bytes, 1);
-        }
-    }
-
-    fn reply_to<K: Kind>(&mut self, sender: ReplyHandle, payload: &K) {
-        let bytes = payload.encode_into_bytes();
-        MAIL_BRIDGE.reply_mail(sender.raw(), K::ID.0, &bytes, 1);
-    }
-}
-
-// TRANSITIONAL (ADR-0112): dropped when single is locked.
-impl OutboundReply for FfiCtx<'_, Single> {
-    type ReplyHandle = ReplyHandle;
-
-    fn reply_target(&self) -> Option<ReplyHandle> {
-        self.sender.map(ReplyHandle::__from_raw)
-    }
-
-    fn source_mailbox(&self) -> Option<MailboxId> {
-        None
-    }
-
-    //noinspection DuplicatedCode
     fn reply<K: Kind>(&mut self, payload: &K) {
         if let Some(raw) = self.sender {
             let bytes = payload.encode_into_bytes();
@@ -559,13 +531,13 @@ mod tests {
         );
     }
 
-    /// ADR-0112 step 3: `OutboundReply` is reachable from both the
-    /// permanent `Manual` ctx and the transitional `Single` ctx (the
-    /// latter keeps the existing hand-`ctx.reply` handlers compiling).
+    /// ADR-0112: `OutboundReply` is reachable from the `Manual` ctx
+    /// only. The single-locked ctx carries no reply surface, so a `-> ()`
+    /// single handler is provably silent (a stray single-ctx `ctx.reply`
+    /// is a compile error, not a manifest lie).
     #[test]
-    fn outbound_reply_present_on_single_and_manual() {
+    fn outbound_reply_present_on_manual() {
         fn assert_impls<C: OutboundReply>() {}
-        assert_impls::<FfiCtx<'static, Single>>();
         assert_impls::<FfiCtx<'static, Manual>>();
     }
 }

--- a/crates/aether-capabilities/src/anthropic/mod.rs
+++ b/crates/aether-capabilities/src/anthropic/mod.rs
@@ -259,7 +259,7 @@ mod native {
     };
     use crate::contentgen::adapter::{AdapterUsage, AnthropicResponse};
     use crate::contentgen::task_queue::TaskQueue;
-    use aether_actor::{OutboundReply, actor};
+    use aether_actor::{Manual, OutboundReply, actor};
     use aether_kinds::{AnthropicError, Message, Role, Usage};
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
     use aether_substrate::chassis::error::BootError;
@@ -353,7 +353,7 @@ mod native {
         /// path always passes through.
         fn gate_model(
             &self,
-            ctx: &mut NativeCtx<'_>,
+            ctx: &mut NativeCtx<'_, Manual>,
             path: SendPath,
             request_id: u64,
             model: &str,
@@ -374,7 +374,7 @@ mod native {
         /// Reply an `Err` synchronously (model validation failure)
         /// before any dispatch.
         fn reply_err(
-            ctx: &mut NativeCtx<'_>,
+            ctx: &mut NativeCtx<'_, Manual>,
             path: SendPath,
             request_id: u64,
             error: AnthropicError,
@@ -458,8 +458,8 @@ mod native {
         /// supported table synchronously (`UnknownModel` on a miss),
         /// then dispatches the blocking HTTPS call on an ephemeral
         /// thread; the reply lands when the call returns.
-        #[handler]
-        fn on_messages_send(&mut self, ctx: &mut NativeCtx<'_>, mail: MessagesSend) {
+        #[handler::manual]
+        fn on_messages_send(&mut self, ctx: &mut NativeCtx<'_, Manual>, mail: MessagesSend) {
             let request_id = mail.request_id;
             if !self.gate_model(ctx, SendPath::Messages, request_id, &mail.model) {
                 return;
@@ -489,8 +489,8 @@ mod native {
         /// flag, so setting either replies `Err { ParamNotSupported }`
         /// synchronously (no dispatch) rather than silently dropping it —
         /// route sampling knobs through `aether.anthropic.messages.send`.
-        #[handler]
-        fn on_cli_send(&mut self, ctx: &mut NativeCtx<'_>, mail: CliSend) {
+        #[handler::manual]
+        fn on_cli_send(&mut self, ctx: &mut NativeCtx<'_, Manual>, mail: CliSend) {
             // The `claude` CLI has no flag for either knob; reject when
             // set instead of silently dropping (the outcome to avoid —
             // `feedback_explicit_nulls_over_absent_fields`).
@@ -645,7 +645,7 @@ mod native {
                 Arc::clone(&mailer),
                 cap_mailbox,
             ));
-            let mut ctx = NativeCtx::new(
+            let mut ctx = NativeCtx::new_dispatching(
                 &transport,
                 session_sender(),
                 aether_data::MailId::NONE,
@@ -691,7 +691,7 @@ mod native {
                 Arc::clone(&mailer),
                 cap_mailbox,
             ));
-            let mut ctx = NativeCtx::new(
+            let mut ctx = NativeCtx::new_dispatching(
                 &transport,
                 session_sender(),
                 aether_data::MailId::NONE,
@@ -741,7 +741,7 @@ mod native {
                 4,
             );
             let transport = Arc::new(NativeBinding::new_for_test(Arc::clone(mailer), cap_mailbox));
-            let mut ctx = NativeCtx::new(
+            let mut ctx = NativeCtx::new_dispatching(
                 &transport,
                 session_sender(),
                 aether_data::MailId::NONE,
@@ -852,7 +852,7 @@ mod native {
                 Arc::clone(&mailer),
                 cap_mailbox,
             ));
-            let mut ctx = NativeCtx::new(
+            let mut ctx = NativeCtx::new_dispatching(
                 &transport,
                 session_sender(),
                 aether_data::MailId::NONE,
@@ -895,7 +895,7 @@ mod native {
                 Arc::clone(&mailer),
                 cap_mailbox,
             ));
-            let mut ctx = NativeCtx::new(
+            let mut ctx = NativeCtx::new_dispatching(
                 &transport,
                 session_sender(),
                 aether_data::MailId::NONE,

--- a/crates/aether-capabilities/src/contentgen/task_queue.rs
+++ b/crates/aether-capabilities/src/contentgen/task_queue.rs
@@ -91,10 +91,11 @@ impl TaskQueue {
     /// [`NativeCtx::dispatch_blocking_resumed`] when a slot later frees,
     /// so the deferred dispatch keeps *this* chain held and replies to
     /// *this* caller (iamacoffeepot/aether#1031).
-    pub fn submit<O, F>(&mut self, ctx: &mut NativeCtx<'_>, work: F)
+    pub fn submit<O, F, M>(&mut self, ctx: &mut NativeCtx<'_, M>, work: F)
     where
         O: Kind + serde::Serialize + Send + 'static,
         F: FnOnce() -> O + Send + 'static,
+        M: aether_actor::ReplyMode,
     {
         if self.in_flight < self.max {
             // `dispatch_blocking_with` (not the bare `dispatch_blocking`,

--- a/crates/aether-capabilities/src/dag/test_support.rs
+++ b/crates/aether-capabilities/src/dag/test_support.rs
@@ -147,7 +147,7 @@ pub struct TestCallConfig {
 #[aether_actor::bridge(singleton)]
 mod test_source {
     use super::{TestReadResult, TestSourceRequest};
-    use aether_actor::{OutboundReply, actor};
+    use aether_actor::actor;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
 
@@ -164,15 +164,18 @@ mod test_source {
 
         #[allow(clippy::unused_self, clippy::needless_pass_by_value)]
         #[handler]
-        fn on_source(&mut self, ctx: &mut NativeCtx<'_>, mail: TestSourceRequest) {
-            let reply = if mail.fail {
+        fn on_source(
+            &mut self,
+            _ctx: &mut NativeCtx<'_>,
+            mail: TestSourceRequest,
+        ) -> TestReadResult {
+            if mail.fail {
                 TestReadResult::Err {
                     message: format!("source {} failed", mail.value),
                 }
             } else {
                 TestReadResult::Ok { value: mail.value }
-            };
-            ctx.reply(&reply);
+            }
         }
     }
 }
@@ -282,7 +285,7 @@ mod test_bundle_observer {
 #[aether_actor::bridge(singleton)]
 mod test_call {
     use super::{TestCallConfig, TestCallReply, TestCallRequest};
-    use aether_actor::{OutboundReply, actor};
+    use aether_actor::{Manual, OutboundReply, actor};
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
     use aether_substrate::runtime::trace::SettlementHold;
@@ -317,8 +320,8 @@ mod test_call {
         }
 
         #[allow(clippy::needless_pass_by_value)]
-        #[handler]
-        fn on_call(&mut self, ctx: &mut NativeCtx<'_>, mail: TestCallRequest) {
+        #[handler::manual]
+        fn on_call(&mut self, ctx: &mut NativeCtx<'_, Manual>, mail: TestCallRequest) {
             let _ = &mail.input;
             if self.config.never {
                 // Acquire a hold on the call's chain root and never
@@ -522,7 +525,7 @@ fn big_output(x: TestNumber) -> TestBytes {
 #[aether_actor::bridge(singleton)]
 mod test_number_source {
     use super::{TestNumber, TestNumberRequest};
-    use aether_actor::{OutboundReply, actor};
+    use aether_actor::actor;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
 
@@ -541,11 +544,11 @@ mod test_number_source {
 
         #[allow(clippy::unused_self, clippy::needless_pass_by_value)]
         #[handler]
-        fn on_request(&mut self, ctx: &mut NativeCtx<'_>, mail: TestNumberRequest) {
-            ctx.reply(&TestNumber {
+        fn on_request(&mut self, _ctx: &mut NativeCtx<'_>, mail: TestNumberRequest) -> TestNumber {
+            TestNumber {
                 value: mail.value,
                 tag: 0,
-            });
+            }
         }
     }
 }

--- a/crates/aether-capabilities/src/gemini/mod.rs
+++ b/crates/aether-capabilities/src/gemini/mod.rs
@@ -425,7 +425,7 @@ mod native {
     use crate::contentgen::staging::{gen_root, stage_gen_output};
     use crate::contentgen::task_queue::TaskQueue;
     use crate::fs::{FileAdapter, LocalFileAdapter};
-    use aether_actor::{OutboundReply, actor};
+    use aether_actor::{Manual, OutboundReply, actor};
     use aether_kinds::{GeminiError, GroundingMetadata, Usage};
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
     use aether_substrate::chassis::error::BootError;
@@ -613,8 +613,12 @@ mod native {
         /// per-model `aspect_ratio` / `image_size` / reference-count
         /// rules synchronously (the matching `…NotSupportedByModel` /
         /// `UnknownModel` error on a miss) before any dispatch.
-        #[handler]
-        fn on_nanobanana_generate(&mut self, ctx: &mut NativeCtx<'_>, mail: NanobananaGenerate) {
+        #[handler::manual]
+        fn on_nanobanana_generate(
+            &mut self,
+            ctx: &mut NativeCtx<'_, Manual>,
+            mail: NanobananaGenerate,
+        ) {
             let request_id = mail.request_id;
             // Opt-in / default-off; cross-model, so never validated.
             let include_sig = mail.include_thought_signature.unwrap_or(false);
@@ -686,8 +690,8 @@ mod native {
         /// `save://gen/<uuid>.wav` path per clip. Rejects an unknown
         /// model and a both-set `seed` + `sample_count` synchronously
         /// before any dispatch.
-        #[handler]
-        fn on_lyria_generate(&mut self, ctx: &mut NativeCtx<'_>, mail: LyriaGenerate) {
+        #[handler::manual]
+        fn on_lyria_generate(&mut self, ctx: &mut NativeCtx<'_, Manual>, mail: LyriaGenerate) {
             let request_id = mail.request_id;
             if !lyria::is_supported(&mail.model) {
                 OutboundReply::reply(
@@ -842,7 +846,7 @@ mod native {
                 Arc::clone(&mailer),
                 cap_mailbox,
             ));
-            let mut ctx = NativeCtx::new(
+            let mut ctx = NativeCtx::new_dispatching(
                 &transport,
                 session_sender(),
                 aether_data::MailId::NONE,
@@ -893,7 +897,7 @@ mod native {
                 Arc::clone(&mailer),
                 cap_mailbox,
             ));
-            let mut ctx = NativeCtx::new(
+            let mut ctx = NativeCtx::new_dispatching(
                 &transport,
                 session_sender(),
                 aether_data::MailId::NONE,
@@ -937,7 +941,7 @@ mod native {
                 Arc::clone(&mailer),
                 cap_mailbox,
             ));
-            let mut ctx = NativeCtx::new(
+            let mut ctx = NativeCtx::new_dispatching(
                 &transport,
                 session_sender(),
                 aether_data::MailId::NONE,
@@ -986,7 +990,7 @@ mod native {
                 Arc::clone(&mailer),
                 cap_mailbox,
             ));
-            let mut ctx = NativeCtx::new(
+            let mut ctx = NativeCtx::new_dispatching(
                 &transport,
                 session_sender(),
                 aether_data::MailId::NONE,
@@ -1034,7 +1038,7 @@ mod native {
                 Arc::clone(&mailer),
                 cap_mailbox,
             ));
-            let mut ctx = NativeCtx::new(
+            let mut ctx = NativeCtx::new_dispatching(
                 &transport,
                 session_sender(),
                 aether_data::MailId::NONE,
@@ -1262,7 +1266,7 @@ mod native {
                 Arc::clone(&mailer),
                 cap_mailbox,
             ));
-            let mut ctx = NativeCtx::new(
+            let mut ctx = NativeCtx::new_dispatching(
                 &transport,
                 session_sender(),
                 aether_data::MailId::NONE,

--- a/crates/aether-capabilities/src/rpc/test_echo.rs
+++ b/crates/aether-capabilities/src/rpc/test_echo.rs
@@ -56,7 +56,7 @@ pub struct TestEchoReply {
 #[aether_actor::bridge(singleton)]
 mod test_echo_actor {
     use super::{TestEchoReply, TestEchoRequest};
-    use aether_actor::{actor, actor::ctx::OutboundReply};
+    use aether_actor::actor;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
 
@@ -76,8 +76,8 @@ mod test_echo_actor {
         // doesn't touch component state.
         #[allow(clippy::unused_self)]
         #[handler]
-        fn on_echo(&mut self, ctx: &mut NativeCtx<'_>, mail: TestEchoRequest) {
-            ctx.reply(&TestEchoReply { value: mail.value });
+        fn on_echo(&mut self, _ctx: &mut NativeCtx<'_>, mail: TestEchoRequest) -> TestEchoReply {
+            TestEchoReply { value: mail.value }
         }
     }
 }

--- a/crates/aether-mesh-viewer/src/runtime.rs
+++ b/crates/aether-mesh-viewer/src/runtime.rs
@@ -32,7 +32,9 @@
 //! 4. Every `aether.lifecycle.render` stage re-emits the cached
 //!    triangles to `"aether.render"`.
 
-use aether_actor::{BootError, FfiActor, FfiCtx, OutboundReply, ReplyHandle, Resolver, actor};
+use aether_actor::{
+    BootError, FfiActor, FfiCtx, Manual, OutboundReply, ReplyHandle, Resolver, actor,
+};
 use aether_capabilities::fs::FsMailboxExt;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::{FsCapability, LifecycleCapability, RenderCapability};
@@ -177,8 +179,8 @@ impl FfiActor for MeshViewer {
     ///
     /// # Agent
     /// Substrate-driven; do not send manually.
-    #[handler]
-    fn on_read_result(&mut self, ctx: &mut FfiCtx<'_>, r: ReadResult) {
+    #[handler::manual]
+    fn on_read_result(&mut self, ctx: &mut FfiCtx<'_, Manual>, r: ReadResult) {
         let (namespace, path, outcome) = match r {
             ReadResult::Ok {
                 namespace,
@@ -270,7 +272,7 @@ impl MeshViewer {
     /// so a stale target can't leak into a later load's reply.
     fn reply_load_result(
         &mut self,
-        ctx: &mut FfiCtx<'_>,
+        ctx: &mut FfiCtx<'_, Manual>,
         namespace: String,
         path: String,
         outcome: LoadOutcome,

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -1061,7 +1061,7 @@ mod tests {
         let caller_source = Source::with_correlation(SourceAddr::Component(caller), 55);
 
         {
-            let mut ctx = NativeCtx::new(&binding, caller_source, request, root);
+            let mut ctx = NativeCtx::new_dispatching(&binding, caller_source, request, root);
             OutboundReply::reply(&mut ctx, &Tick);
             // ctx drops here; the reply already routed eagerly via the
             // Mailer (replies are not buffered), so the flush is a no-op.
@@ -1118,7 +1118,7 @@ mod tests {
         let root = MailId::new(MailboxId(0xC0), 1);
         let caller_source = Source::with_correlation(SourceAddr::Component(caller), 7);
         {
-            let mut ctx = NativeCtx::new(&binding, caller_source, root, root);
+            let mut ctx = NativeCtx::new_dispatching(&binding, caller_source, root, root);
             OutboundReply::reply(&mut ctx, &Tick);
             OutboundReply::reply(&mut ctx, &Tick);
         }
@@ -1338,7 +1338,7 @@ mod tests {
         let root = MailId::new(MailboxId(0xC0), 1);
         let caller_source = Source::with_correlation(SourceAddr::Component(caller), 7);
         {
-            let mut ctx = NativeCtx::new(&binding, caller_source, root, root);
+            let mut ctx = NativeCtx::new_dispatching(&binding, caller_source, root, root);
             OutboundReply::reply(&mut ctx, &Tick);
         }
 

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -1127,11 +1127,10 @@ impl<M: ReplyMode> MailSender for NativeCtx<'_, M> {
     }
 }
 
-// ADR-0112: the reply surface is per-mode. `Manual` carries it
-// permanently (a manual-class handler issues its own replies); `Single`
-// carries the identical body **transitionally** so the existing native
-// handler / fallback bodies that hand-call `ctx.reply` keep compiling —
-// that impl is dropped when `single` is locked (a separate follow-on).
+// ADR-0112: the reply surface is per-mode. `Manual` carries it (a
+// manual-class handler issues its own replies); `Single` deliberately
+// does not, so a `-> ()` single handler is provably silent and a stray
+// single-ctx `ctx.reply` is a compile error rather than a manifest lie.
 impl OutboundReply for NativeCtx<'_, Manual> {
     type ReplyHandle = Source;
 
@@ -1157,40 +1156,6 @@ impl OutboundReply for NativeCtx<'_, Manual> {
         // ADR-0080 §5/§6 (#1695): a synchronous reply joins the handler's
         // causal chain — inherit this ctx's `root` + `parent` so the
         // reply's `Sent` lands in the caller's chain.
-        self.binding.send_reply_for_handler(
-            self.source,
-            payload,
-            self.in_flight_root,
-            self.outbound_parent(),
-        );
-    }
-
-    fn reply_to<K: Kind>(&mut self, sender: Source, payload: &K) {
-        self.binding.send_reply_for_handler(
-            sender,
-            payload,
-            self.in_flight_root,
-            self.outbound_parent(),
-        );
-    }
-}
-
-// TRANSITIONAL (ADR-0112): dropped when single is locked.
-impl OutboundReply for NativeCtx<'_, Single> {
-    type ReplyHandle = Source;
-
-    fn reply_target(&self) -> Option<Source> {
-        Some(self.source)
-    }
-
-    fn source_mailbox(&self) -> Option<MailboxId> {
-        match self.source.addr {
-            SourceAddr::Component(id) => Some(id),
-            _ => None,
-        }
-    }
-
-    fn reply<K: Kind>(&mut self, payload: &K) {
         self.binding.send_reply_for_handler(
             self.source,
             payload,
@@ -1362,13 +1327,13 @@ mod tests {
         );
     }
 
-    /// ADR-0112 step 3: `OutboundReply` is reachable from both the
-    /// permanent `Manual` ctx and the transitional `Single` ctx (the
-    /// latter keeps the existing hand-`ctx.reply` native bodies compiling).
+    /// ADR-0112: `OutboundReply` is reachable from the `Manual` ctx
+    /// only. The single-locked ctx carries no reply surface, so a `-> ()`
+    /// single handler is provably silent (a stray single-ctx `ctx.reply`
+    /// is a compile error, not a manifest lie).
     #[test]
-    fn outbound_reply_present_on_single_and_manual() {
+    fn outbound_reply_present_on_manual() {
         fn assert_impls<C: OutboundReply>() {}
-        assert_impls::<NativeCtx<'static, Single>>();
         assert_impls::<NativeCtx<'static, Manual>>();
     }
 
@@ -1486,7 +1451,7 @@ mod tests {
     /// called; the compile is the assertion. If a reply bound regains a
     /// `serde::Serialize` half, this stops compiling.
     #[allow(dead_code)]
-    fn _assert_cast_kind_repliable(ctx: &mut NativeCtx<'_>, sender: Source) {
+    fn _assert_cast_kind_repliable(ctx: &mut NativeCtx<'_, Manual>, sender: Source) {
         OutboundReply::reply(ctx, &CastOnly { code: 2 });
         OutboundReply::reply_to(ctx, sender, &CastOnly { code: 3 });
         ctx.reply_to_target(sender, &CastOnly { code: 4 }, MailId::NONE, None);

--- a/crates/aether-test-fixtures/examples/http_handler.rs
+++ b/crates/aether-test-fixtures/examples/http_handler.rs
@@ -20,7 +20,7 @@
 // ignores `self` is correct but triggers `unused_self`.
 #![allow(clippy::needless_pass_by_value, clippy::unused_self)]
 
-use aether_actor::{BootError, FfiActor, FfiCtx, OutboundReply, Resolver, actor};
+use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
 use aether_kinds::{HttpServerRequest, HttpServerResponse};
 
 pub struct HttpHandler;
@@ -45,16 +45,16 @@ impl FfiActor for HttpHandler {
     /// on every inbound request. Configure `HttpServerConfig.handler_mailbox`
     /// to `"aether.component/aether.embedded:web"` to route here.
     #[handler]
-    fn on_request(&mut self, ctx: &mut FfiCtx<'_>, req: HttpServerRequest) {
+    fn on_request(&mut self, _ctx: &mut FfiCtx<'_>, req: HttpServerRequest) -> HttpServerResponse {
         let (status, body): (u16, &[u8]) = match req.path.as_str() {
             "/" => (200, b"hello from aether"),
             _ => (404, b"not found"),
         };
-        ctx.reply(&HttpServerResponse {
+        HttpServerResponse {
             status,
             headers: Vec::new(),
             body: body.to_vec(),
-        });
+        }
     }
 }
 

--- a/crates/aether-test-fixtures/examples/mat4_source.rs
+++ b/crates/aether-test-fixtures/examples/mat4_source.rs
@@ -20,7 +20,7 @@
 // even though this source is stateless.
 #![allow(clippy::unused_self)]
 
-use aether_actor::{BootError, FfiActor, FfiCtx, OutboundReply, Resolver, actor};
+use aether_actor::{BootError, FfiActor, FfiCtx, Resolver, actor};
 use aether_kinds::Mat4Apply;
 use aether_math::{Mat4, Vec4};
 use aether_test_fixtures::Mat4SourceTrigger;
@@ -48,8 +48,8 @@ impl FfiActor for MatSource {
     /// dispatches `aether.test_fixtures.mat4_source_trigger` and the
     /// reply (`aether.math.mat4_apply`) is the transform input.
     #[handler]
-    fn on_trigger(&mut self, ctx: &mut FfiCtx<'_>, _trigger: Mat4SourceTrigger) {
-        ctx.reply(&Mat4Apply {
+    fn on_trigger(&mut self, _ctx: &mut FfiCtx<'_>, _trigger: Mat4SourceTrigger) -> Mat4Apply {
+        Mat4Apply {
             matrix: Mat4::from_cols_array([
                 2.0, 0.0, 0.0, 0.0, //
                 0.0, 3.0, 0.0, 0.0, //
@@ -57,7 +57,7 @@ impl FfiActor for MatSource {
                 5.0, 6.0, 7.0, 1.0, //
             ]),
             vector: Vec4::new(1.0, 1.0, 1.0, 1.0),
-        });
+        }
     }
 }
 

--- a/crates/aether-test-fixtures/examples/probe_with_config.rs
+++ b/crates/aether-test-fixtures/examples/probe_with_config.rs
@@ -10,7 +10,7 @@
 //! config round-tripped intact. No tick / render behaviour — the
 //! sibling `probe` covers that.
 
-use aether_actor::{BootError, FfiActor, FfiCtx, OutboundReply, Resolver, actor};
+use aether_actor::{BootError, FfiActor, FfiCtx, Manual, OutboundReply, Resolver, actor};
 use aether_test_fixtures::{ConfigEcho, ConfigQuery, ProbeConfig};
 
 pub struct ProbeWithConfig {
@@ -36,8 +36,8 @@ impl FfiActor for ProbeWithConfig {
     /// Reply with a `ConfigEcho` describing the cached config. Lets
     /// the integration test observe what the typed `init` actually
     /// received without scraping logs or readback.
-    #[handler]
-    fn on_config_query(&mut self, ctx: &mut FfiCtx<'_>, _query: ConfigQuery) {
+    #[handler::manual]
+    fn on_config_query(&mut self, ctx: &mut FfiCtx<'_, Manual>, _query: ConfigQuery) {
         if ctx.reply_target().is_some() {
             ctx.reply(&ConfigEcho {
                 seed: self.seed,

--- a/crates/aether-test-fixtures/examples/stateful_replace.rs
+++ b/crates/aether-test-fixtures/examples/stateful_replace.rs
@@ -21,8 +21,8 @@
 #![allow(clippy::unused_self)]
 
 use aether_actor::{
-    BootError, FfiActor, FfiCtx, FfiDropCtx, Instanced, Mail, OutboundReply, PriorState, Resolver,
-    actor,
+    BootError, FfiActor, FfiCtx, FfiDropCtx, Instanced, Mail, Manual, OutboundReply, PriorState,
+    Resolver, actor,
 };
 use aether_test_fixtures::{Bump, CountQuery, CountReport};
 
@@ -50,8 +50,8 @@ impl FfiActor for Counter {
     }
 
     /// Reply with the live counter so a test can read it across a swap.
-    #[handler]
-    fn on_count_query(&mut self, ctx: &mut FfiCtx<'_>, _query: CountQuery) {
+    #[handler::manual]
+    fn on_count_query(&mut self, ctx: &mut FfiCtx<'_, Manual>, _query: CountQuery) {
         if ctx.reply_target().is_some() {
             ctx.reply(&CountReport { count: self.count });
         }

--- a/crates/aether-test-fixtures/examples/stateful_replace_reshaped.rs
+++ b/crates/aether-test-fixtures/examples/stateful_replace_reshaped.rs
@@ -11,7 +11,7 @@
 // owned for an all-`Copy` state, so silence the false positive.
 #![allow(clippy::needless_pass_by_value)]
 
-use aether_actor::{BootError, FfiActor, FfiCtx, OutboundReply, Resolver, actor};
+use aether_actor::{BootError, FfiActor, FfiCtx, Manual, OutboundReply, Resolver, actor};
 use aether_test_fixtures::{Bump, CountQuery, CountReport};
 
 /// Reshaped durable state — the added `generation` field changes the
@@ -68,8 +68,8 @@ impl FfiActor for Counter {
         self.count += 1;
     }
 
-    #[handler]
-    fn on_count_query(&mut self, ctx: &mut FfiCtx<'_>, _query: CountQuery) {
+    #[handler::manual]
+    fn on_count_query(&mut self, ctx: &mut FfiCtx<'_, Manual>, _query: CountQuery) {
         if ctx.reply_target().is_some() {
             ctx.reply(&CountReport { count: self.count });
         }

--- a/crates/aether-test-fixtures/examples/stateful_replace_typed.rs
+++ b/crates/aether-test-fixtures/examples/stateful_replace_typed.rs
@@ -17,7 +17,7 @@
 // contract is the point, so silence the false positive here.
 #![allow(clippy::needless_pass_by_value)]
 
-use aether_actor::{BootError, FfiActor, FfiCtx, OutboundReply, Resolver, actor};
+use aether_actor::{BootError, FfiActor, FfiCtx, Manual, OutboundReply, Resolver, actor};
 use aether_test_fixtures::{Bump, CountQuery, CountReport};
 
 /// Durable state the `Counter` carries across `replace_component`. The
@@ -73,8 +73,8 @@ impl FfiActor for Counter {
     }
 
     /// Reply with the live counter so a test can read it across a swap.
-    #[handler]
-    fn on_count_query(&mut self, ctx: &mut FfiCtx<'_>, _query: CountQuery) {
+    #[handler::manual]
+    fn on_count_query(&mut self, ctx: &mut FfiCtx<'_, Manual>, _query: CountQuery) {
         if ctx.reply_target().is_some() {
             ctx.reply(&CountReport { count: self.count });
         }

--- a/demos/sokoban/src/lib.rs
+++ b/demos/sokoban/src/lib.rs
@@ -25,7 +25,9 @@
 //!
 //! Grid is still capped at 16×16 (pre-ADR-0028 carryover).
 
-use aether_actor::{BootError, FfiActor, FfiCtx, MailSender, OutboundReply, Resolver, actor};
+use aether_actor::{
+    BootError, FfiActor, FfiCtx, MailSender, Manual, OutboundReply, Resolver, actor,
+};
 use aether_camera::{CameraTopdownSet, TopdownParams};
 use aether_capabilities::input::InputMailboxExt;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
@@ -210,14 +212,14 @@ impl FfiActor for Sokoban {
         }
     }
 
-    #[handler]
-    fn on_reset(&mut self, ctx: &mut FfiCtx<'_>, _rst: SokobanReset) {
+    #[handler::manual]
+    fn on_reset(&mut self, ctx: &mut FfiCtx<'_, Manual>, _rst: SokobanReset) {
         self.load_level(self.state.level_id);
         self.reply_state(ctx);
     }
 
-    #[handler]
-    fn on_load_level(&mut self, ctx: &mut FfiCtx<'_>, load: SokobanLoadLevel) {
+    #[handler::manual]
+    fn on_load_level(&mut self, ctx: &mut FfiCtx<'_, Manual>, load: SokobanLoadLevel) {
         self.load_level(load.id);
         self.reply_state(ctx);
     }
@@ -384,7 +386,7 @@ impl Sokoban {
         ctx.actor::<RenderCapability>().send(&body);
     }
 
-    fn reply_state(&self, ctx: &mut FfiCtx<'_>) {
+    fn reply_state(&self, ctx: &mut FfiCtx<'_, Manual>) {
         ctx.reply(&self.state);
     }
 


### PR DESCRIPTION
Closes #1879.

## Summary

The terminal step of the ADR-0112 reply-class arc. Drops the transitional `OutboundReply for <Single>` impls (`aether-actor/src/ffi/ctx.rs` + `aether-substrate/src/actor/native/ctx.rs`), so a single-mode `-> ()` handler is provably silent and the manifest's `None` is true by construction. Sweeps the remaining `ctx.reply` stragglers onto their reply classes — the issue-named mesh-viewer + fixtures, plus compiler-found content-gen caps (anthropic / gemini / rpc-echo / dag, the contentgen task queue, the sokoban demo, and test fixtures) that the issue's list didn't enumerate. Adds a `single_handler_cannot_reply` trybuild compile-fail fixture as a standing lock guard, and drops the now-obsolete `//noinspection DuplicatedCode` annotations (#1871's duplicated transitional body is gone).

## Test plan

The two `outbound_reply_present_*` tests + the cast-repliable helper updated; the new compile-fail fixture pins the lock. Full workspace green: clippy `-D warnings` (also `--all-features`), nextest `--workspace` (1906 passed), loader tests with `AETHER_REQUIRE_RUNTIME=1` against freshly-rebuilt component wasm (189 passed), doc, wasm32 cross-build of the touched components.

## Generated by

`/implement` — agent execution of scoped issue #1879.
