### PR TITLE
feat(capabilities): self-realizing field simulator where motion spawns the contributions it must avoid

### DIFF
--- a/crates/aether-capabilities/src/reachability.rs
+++ b/crates/aether-capabilities/src/reachability.rs
@@ -708,6 +708,123 @@ fn forward_coord(coord: usize, delta: i32, bound: usize) -> Option<usize> {
     (next < bound).then_some(next)
 }
 
+/// The mutable state one self-realizing run carries across ticks: the agent's
+/// current cell, the cost accumulated so far, and the active snapshot
+/// contributions. Shared by both run drivers — [`simulate_run`] (the closure /
+/// finish verdict) and [`realize_single`] (the per-tick stacked field) — so the
+/// one closed-loop step lives in exactly one place ([`step_realized_run`]).
+struct RunState {
+    current: usize,
+    acc: u32,
+    contributions: Vec<Contribution>,
+}
+
+/// The outcome of one [`step_realized_run`] call.
+enum StepOutcome {
+    /// The realized field closed around the agent before it could step — no
+    /// stencil neighbor is both un-blocked and keeps `acc < budget`.
+    Closed,
+    /// The agent reached a goal cell with `acc < budget`.
+    Reached,
+    /// The agent stepped and the run continues.
+    Continued,
+}
+
+/// One tick of the closed self-realizing loop, mutating `state` in place: realize
+/// the field at `now`, check closure, spawn a snapshot contribution on the
+/// placement cadence, plan one step via [`plan_step_realized`], then step and
+/// accumulate the true realized cost (the `now + 1` realization at the landed
+/// cell). Returns the realized field *at `now`* (the field the agent planned
+/// against this tick, which the stacked-field driver records) and the
+/// [`StepOutcome`]. This is the single per-step body both run drivers share, so
+/// the closed loop is defined once. Iterative — the per-tick window solve and
+/// the contribution scan are bounded; no recursion.
+#[allow(clippy::too_many_arguments)]
+fn step_realized_run(
+    width: usize,
+    height: usize,
+    base: &[u32],
+    base_ticks: usize,
+    stencil: &[StencilOffset],
+    goal: &[usize],
+    budget: u32,
+    placement_period: usize,
+    model: &ContributionModel,
+    window: usize,
+    now: usize,
+    rng: &mut Xorshift64,
+    state: &mut RunState,
+) -> (Vec<u32>, StepOutcome) {
+    let is_goal = |cell: usize| goal.contains(&cell);
+    let realized = realize_field(
+        width,
+        height,
+        base,
+        base_ticks,
+        now,
+        &state.contributions,
+        model,
+    );
+
+    // Closure check before stepping: has the trail covered every feasible
+    // next cell from the agent's current position this tick?
+    if field_closed(
+        width,
+        height,
+        &realized,
+        stencil,
+        state.current,
+        state.acc,
+        budget,
+    ) {
+        return (realized, StepOutcome::Closed);
+    }
+
+    // Spawn a snapshot contribution on the current cell at the placement
+    // cadence (snapshot placement + lead, #1866's model), holding at most
+    // `max_concurrent` active — the oldest expires.
+    if placement_period > 0 && now.is_multiple_of(placement_period) {
+        state.contributions.push(Contribution {
+            center: state.current,
+            trigger_tick: now,
+        });
+        if model.max_concurrent > 0 && state.contributions.len() > model.max_concurrent {
+            state.contributions.remove(0);
+        }
+    }
+
+    let next = plan_step_realized(
+        width,
+        height,
+        &realized,
+        stencil,
+        goal,
+        state.current,
+        window,
+        rng,
+    );
+    // The realized cost actually paid is the next-tick realization at the
+    // landed cell (the contribution set the agent stepped into).
+    let landed_realized = realize_field(
+        width,
+        height,
+        base,
+        base_ticks,
+        now + 1,
+        &state.contributions,
+        model,
+    );
+    let true_cost = landed_realized.get(next).copied().unwrap_or(UNREACHABLE);
+    state.acc = state.acc.saturating_add(true_cost);
+    state.current = next;
+    let outcome = if state.acc < budget && is_goal(state.current) {
+        StepOutcome::Reached
+    } else {
+        StepOutcome::Continued
+    };
+    (realized, outcome)
+}
+
 /// Simulate one self-realizing run from `start` (issue 1867). Per tick the
 /// closed loop is: realize the field (base plus active contributions) →
 /// plan one step via [`plan_step_realized`] → step and accumulate the true
@@ -734,58 +851,38 @@ fn simulate_run(
     window: usize,
     rng: &mut Xorshift64,
 ) -> (bool, u32) {
-    let is_goal = |cell: usize| goal.contains(&cell);
-    let mut current = start;
-    let mut acc = start_cost;
-    let mut contributions: Vec<Contribution> = Vec::new();
+    let mut state = RunState {
+        current: start,
+        acc: start_cost,
+        contributions: Vec::new(),
+    };
 
-    if acc < budget && is_goal(current) {
+    if state.acc < budget && goal.contains(&state.current) {
         return (true, u32::MAX);
     }
 
     for now in 0..ticks.saturating_sub(1) {
-        let realized = realize_field(width, height, base, base_ticks, now, &contributions, model);
-
-        // Closure check before stepping: has the trail covered every feasible
-        // next cell from the agent's current position this tick?
-        if field_closed(width, height, &realized, stencil, current, acc, budget) {
-            // `now < ticks`, and `ticks` came from a `u32` field, so the
-            // cast is exact; saturate defensively.
-            return (false, u32::try_from(now).unwrap_or(u32::MAX));
-        }
-
-        // Spawn a snapshot contribution on the current cell at the placement
-        // cadence (snapshot placement + lead, #1866's model), holding at most
-        // `max_concurrent` active — the oldest expires.
-        if placement_period > 0 && now % placement_period == 0 {
-            contributions.push(Contribution {
-                center: current,
-                trigger_tick: now,
-            });
-            if model.max_concurrent > 0 && contributions.len() > model.max_concurrent {
-                contributions.remove(0);
-            }
-        }
-
-        let next = plan_step_realized(
-            width, height, &realized, stencil, goal, current, window, rng,
-        );
-        // The realized cost actually paid is the next-tick realization at the
-        // landed cell (the contribution set the agent stepped into).
-        let landed_realized = realize_field(
+        let (_realized, outcome) = step_realized_run(
             width,
             height,
             base,
             base_ticks,
-            now + 1,
-            &contributions,
+            stencil,
+            goal,
+            budget,
+            placement_period,
             model,
+            window,
+            now,
+            rng,
+            &mut state,
         );
-        let true_cost = landed_realized.get(next).copied().unwrap_or(UNREACHABLE);
-        acc = acc.saturating_add(true_cost);
-        current = next;
-        if acc < budget && is_goal(current) {
-            return (true, u32::MAX);
+        match outcome {
+            // `now < ticks`, and `ticks` came from a `u32` field, so the cast
+            // is exact; saturate defensively.
+            StepOutcome::Closed => return (false, u32::try_from(now).unwrap_or(u32::MAX)),
+            StepOutcome::Reached => return (true, u32::MAX),
+            StepOutcome::Continued => {}
         }
     }
     (false, u32::MAX)
@@ -920,71 +1017,59 @@ pub fn realize_single(input: RealizationProblem) -> ScalarField {
     } else {
         start_cells[run_rng.next_bounded(start_cells.len())]
     };
-    let mut current = start;
-    let mut acc = start_seed.get(start).copied().unwrap_or(0);
-    let mut contributions: Vec<Contribution> = Vec::new();
+    let mut state = RunState {
+        current: start,
+        acc: start_seed.get(start).copied().unwrap_or(0),
+        contributions: Vec::new(),
+    };
 
     let out_ticks = ticks.max(1);
     let mut values = vec![UNREACHABLE; plane.saturating_mul(out_ticks)];
 
-    let goal_hit = |cell: usize, a: u32| a < budget && goal.contains(&cell);
-    let mut done = goal_hit(current, acc) || start_cells.is_empty();
+    // Once the run stops stepping (goal reached, field closed, or no start
+    // region) the contributions freeze, but the stacked field keeps recording
+    // the still-aging realized field — so the loop continues to the horizon,
+    // calling the shared step body only while the run is still live.
+    let mut done = (state.acc < budget && goal.contains(&state.current)) || start_cells.is_empty();
 
     for now in 0..out_ticks {
-        let realized = realize_field(
-            width,
-            height,
-            &base,
-            base_ticks,
-            now,
-            &contributions,
-            &model,
-        );
+        let active = !done && now + 1 < out_ticks;
+        let realized = if active {
+            let (realized, outcome) = step_realized_run(
+                width,
+                height,
+                &base,
+                base_ticks,
+                &stencil,
+                &goal,
+                budget,
+                placement_period,
+                &model,
+                window,
+                now,
+                &mut run_rng,
+                &mut state,
+            );
+            if matches!(outcome, StepOutcome::Closed | StepOutcome::Reached) {
+                done = true;
+            }
+            realized
+        } else {
+            // Frozen / final tick: just record the realization at `now`; the
+            // contribution set no longer changes.
+            realize_field(
+                width,
+                height,
+                &base,
+                base_ticks,
+                now,
+                &state.contributions,
+                &model,
+            )
+        };
         let dst = now.saturating_mul(plane);
         if let Some(slot) = values.get_mut(dst..dst + plane) {
             slot.copy_from_slice(&realized[..plane]);
-        }
-
-        if done || now + 1 >= out_ticks {
-            continue;
-        }
-        if field_closed(width, height, &realized, &stencil, current, acc, budget) {
-            done = true;
-            continue;
-        }
-        if placement_period > 0 && now % placement_period == 0 {
-            contributions.push(Contribution {
-                center: current,
-                trigger_tick: now,
-            });
-            if model.max_concurrent > 0 && contributions.len() > model.max_concurrent {
-                contributions.remove(0);
-            }
-        }
-        let next = plan_step_realized(
-            width,
-            height,
-            &realized,
-            &stencil,
-            &goal,
-            current,
-            window,
-            &mut run_rng,
-        );
-        let landed_realized = realize_field(
-            width,
-            height,
-            &base,
-            base_ticks,
-            now + 1,
-            &contributions,
-            &model,
-        );
-        let true_cost = landed_realized.get(next).copied().unwrap_or(UNREACHABLE);
-        acc = acc.saturating_add(true_cost);
-        current = next;
-        if goal_hit(current, acc) {
-            done = true;
         }
     }
 

--- a/crates/aether-capabilities/src/reachability.rs
+++ b/crates/aether-capabilities/src/reachability.rs
@@ -17,8 +17,8 @@
 //! identically.
 
 use aether_kinds::{
-    MovementStencil, PopulationSweepProblem, ReachabilityProblem, ScalarField, StencilOffset,
-    SurvivalCurve, SurvivalSample,
+    ClosureDistribution, MovementStencil, PopulationSweepProblem, ReachabilityProblem,
+    RealizationProblem, RunOutcome, ScalarField, StencilOffset, SurvivalCurve, SurvivalSample,
 };
 
 /// The reserved sentinel shared by cost fields and the solved
@@ -447,6 +447,637 @@ pub fn solve_population_sweep(problem: PopulationSweepProblem) -> SurvivalCurve 
     }
 }
 
+/// A snapshot-placed field contribution committed at a trigger tick (issue
+/// 1867, #1866's contribution model). `center` is the flat row-major cell
+/// the agent occupied when it was snapshotted; `trigger_tick` is when it was
+/// committed. The contribution is *active* (covers cells) only once
+/// `t - trigger_tick >= lead`, and at age `a = t - trigger_tick` it covers
+/// every cell within radius `cover(a) = r0 + g*a` of `center`.
+#[derive(Clone, Copy)]
+struct Contribution {
+    center: usize,
+    trigger_tick: usize,
+}
+
+/// The fixed contribution shape shared by every contribution in one run —
+/// #1866's `(L, r0, g)` plus the per-cell cost and concurrency ceiling.
+#[derive(Clone, Copy)]
+struct ContributionModel {
+    lead: usize,
+    extent_initial: f32,
+    growth_per_tick: f32,
+    cost: u32,
+    max_concurrent: usize,
+}
+
+/// Realize the cost field at tick `now`: the base field's `now` layer (the
+/// last available layer for a `now` past the field's horizon) plus, summed
+/// over every *active* contribution, `model.cost` on each covered cell. A
+/// contribution committed at `c.trigger_tick` is active iff
+/// `now - c.trigger_tick >= model.lead`; at age `a = now - c.trigger_tick` it
+/// covers every cell whose Euclidean grid distance from `c.center` is
+/// `<= cover(a) = r0 + g*a`. Costs saturate at the [`UNREACHABLE`] sentinel
+/// (a covered blocked cell stays blocked). The scan is bounded (the covered
+/// radius is clamped to the grid) and iterative — no recursion.
+fn realize_field(
+    width: usize,
+    height: usize,
+    base: &[u32],
+    base_ticks: usize,
+    now: usize,
+    contributions: &[Contribution],
+    model: &ContributionModel,
+) -> Vec<u32> {
+    let plane = width.saturating_mul(height);
+    // Past the base horizon the field holds at its final layer (the base is
+    // the static backdrop; the realized motion comes from contributions).
+    let base_tick = now.min(base_ticks.saturating_sub(1));
+    let base_off = base_tick.saturating_mul(plane);
+    let mut field = vec![UNREACHABLE; plane];
+    for (idx, cell) in field.iter_mut().enumerate() {
+        *cell = base.get(base_off + idx).copied().unwrap_or(UNREACHABLE);
+    }
+
+    for c in contributions {
+        let age = now.saturating_sub(c.trigger_tick);
+        if age < model.lead {
+            continue;
+        }
+        // cover(age) = r0 + g*age, in grid-cell radii. Clamp to a sane
+        // non-negative radius and to the grid extent so the box scan stays
+        // bounded. age -> f32 / grid-extent -> f32 precision loss is
+        // intentional: covered extents and tick counts are small in practice
+        // (the same convention `escapability.rs`'s bound uses).
+        #[allow(clippy::cast_precision_loss)]
+        let age_f = age as f32;
+        let radius = model
+            .growth_per_tick
+            .mul_add(age_f, model.extent_initial)
+            .max(0.0);
+        if !radius.is_finite() {
+            continue;
+        }
+        let radius_sq = radius * radius;
+        // Integer bounding box of the disc around the center.
+        #[allow(clippy::cast_precision_loss)]
+        let grid_extent = width.max(height) as f32;
+        let r_cells = {
+            // ceil >= 0 and finite; the cap keeps the cast in range.
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let v = radius.ceil().min(grid_extent) as usize;
+            v
+        };
+        let cx = c.center % width;
+        let cy = c.center / width;
+        let x_lo = cx.saturating_sub(r_cells);
+        let x_hi = (cx + r_cells).min(width.saturating_sub(1));
+        let y_lo = cy.saturating_sub(r_cells);
+        let y_hi = (cy + r_cells).min(height.saturating_sub(1));
+        for y in y_lo..=y_hi {
+            for x in x_lo..=x_hi {
+                // Cell-offset -> f32 precision loss is intentional (grid
+                // coordinates are small); `dx*dx + dy*dy` via `mul_add` keeps
+                // the distance check accurate.
+                #[allow(clippy::cast_precision_loss)]
+                let dx = x as f32 - cx as f32;
+                #[allow(clippy::cast_precision_loss)]
+                let dy = y as f32 - cy as f32;
+                if dx.mul_add(dx, dy * dy) <= radius_sq {
+                    let idx = y * width + x;
+                    field[idx] = field[idx].saturating_add(model.cost);
+                }
+            }
+        }
+    }
+
+    field
+}
+
+/// Plan one step over the *realized* field. The realized field is only
+/// known at the current tick (future contributions depend on future steps),
+/// so the planner projects the tick-`now` realization constant across its
+/// `window` look-ahead and runs #1857's exact [`solve_cost_to_reach`] over
+/// that — the same machinery #1863's `plan_next_cell` uses, here over a
+/// realized rather than a fixed field. Returns the first cell of the optimal
+/// path to the cheapest perceived goal, or `current` (stay put) when no goal
+/// is visible. The closed feedback loop is what makes the field
+/// path-dependent; the planner stays the exact solver so closure is
+/// structural rather than a heuristic artifact.
+#[allow(clippy::too_many_arguments)]
+fn plan_step_realized(
+    width: usize,
+    height: usize,
+    realized: &[u32],
+    stencil: &[StencilOffset],
+    goal: &[usize],
+    current: usize,
+    window: usize,
+    rng: &mut Xorshift64,
+) -> usize {
+    let plane = width.saturating_mul(height);
+    if plane == 0 {
+        return current;
+    }
+    // The look-ahead is the realized field repeated across `layers` layers
+    // (window depth, at least 2 so there is a step to take).
+    let layers = window.max(1) + 1;
+    let mut perceived = vec![UNREACHABLE; plane * layers];
+    for k in 0..layers {
+        let dst = k * plane;
+        perceived[dst..dst + plane].copy_from_slice(&realized[..plane]);
+    }
+
+    let mut seed = vec![UNREACHABLE; plane];
+    seed[current] = 0;
+    let v = solve_cost_to_reach(width, height, layers, &perceived, stencil, &seed);
+
+    let mut best_cost = UNREACHABLE;
+    let mut best_targets: Vec<(usize, usize)> = Vec::new();
+    for k in 1..layers {
+        let layer_base = k * plane;
+        for &g in goal {
+            if g >= plane {
+                continue;
+            }
+            let cost = v[layer_base + g];
+            if cost == UNREACHABLE {
+                continue;
+            }
+            if cost < best_cost {
+                best_cost = cost;
+                best_targets.clear();
+                best_targets.push((g, k));
+            } else if cost == best_cost {
+                best_targets.push((g, k));
+            }
+        }
+    }
+    if best_targets.is_empty() {
+        return current;
+    }
+    let pick = if best_targets.len() == 1 {
+        0
+    } else {
+        rng.next_bounded(best_targets.len())
+    };
+    let (mut cur, mut layer) = best_targets[pick];
+
+    while layer > 1 {
+        let x = cur % width;
+        let y = cur / width;
+        let target = v[layer * plane + cur];
+        let landed = perceived[layer * plane + cur];
+        let mut preds: Vec<usize> = Vec::new();
+        for offset in stencil {
+            let Some(px) = predecessor_coord(x, offset.dx, width) else {
+                continue;
+            };
+            let Some(py) = predecessor_coord(y, offset.dy, height) else {
+                continue;
+            };
+            let p = py * width + px;
+            let pv = v[(layer - 1) * plane + p];
+            if pv != UNREACHABLE && landed.saturating_add(pv) == target {
+                preds.push(p);
+            }
+        }
+        if preds.is_empty() {
+            return current;
+        }
+        cur = pick_tie(rng, &preds);
+        layer -= 1;
+    }
+    cur
+}
+
+/// Whether the realized field has **closed around** the agent at `current`:
+/// no stencil neighbor (the moves out of `current`, the zero "stay" offset
+/// excluded) is both un-blocked and keeps the accumulated cost `< budget`.
+/// This is the window-independent closure signal — the agent's own trail has
+/// covered every feasible next cell. `acc` is the cost already paid; a
+/// neighbor is feasible iff its realized cost is finite and
+/// `acc + cost < budget`.
+fn field_closed(
+    width: usize,
+    height: usize,
+    realized: &[u32],
+    stencil: &[StencilOffset],
+    current: usize,
+    acc: u32,
+    budget: u32,
+) -> bool {
+    let plane = width.saturating_mul(height);
+    let x = current % width;
+    let y = current / width;
+    for offset in stencil {
+        if offset.dx == 0 && offset.dy == 0 {
+            continue;
+        }
+        // The stencil reads predecessors as `c - offset`; a *successor* is
+        // `c + offset`, so step the coordinate forward by the offset.
+        let Some(nx) = forward_coord(x, offset.dx, width) else {
+            continue;
+        };
+        let Some(ny) = forward_coord(y, offset.dy, height) else {
+            continue;
+        };
+        let neighbor = ny * width + nx;
+        if neighbor >= plane {
+            continue;
+        }
+        let cost = realized.get(neighbor).copied().unwrap_or(UNREACHABLE);
+        if cost == UNREACHABLE {
+            continue;
+        }
+        if acc.saturating_add(cost) < budget {
+            return false;
+        }
+    }
+    true
+}
+
+/// Shift `coord` by `+delta` (the successor direction) and keep it in
+/// `0..bound`; the forward complement of [`predecessor_coord`].
+fn forward_coord(coord: usize, delta: i32, bound: usize) -> Option<usize> {
+    let magnitude = delta.unsigned_abs() as usize;
+    let next = if delta >= 0 {
+        coord.checked_add(magnitude)?
+    } else {
+        coord.checked_sub(magnitude)?
+    };
+    (next < bound).then_some(next)
+}
+
+/// Simulate one self-realizing run from `start` (issue 1867). Per tick the
+/// closed loop is: realize the field (base plus active contributions) →
+/// plan one step via [`plan_step_realized`] → step and accumulate the true
+/// realized cost → spawn a snapshot contribution every `placement_period`
+/// ticks → advance. Returns `(finished, closure_tick)`: `finished` iff the
+/// agent reaches a goal cell under budget before the final tick;
+/// `closure_tick` is the first tick the realized field closed around it
+/// (`u32::MAX` if it never closed). Iterative throughout — the tick loop,
+/// the per-tick window solve, and the contribution scan are all bounded.
+#[allow(clippy::too_many_arguments)]
+fn simulate_run(
+    width: usize,
+    height: usize,
+    ticks: usize,
+    base: &[u32],
+    base_ticks: usize,
+    stencil: &[StencilOffset],
+    goal: &[usize],
+    start: usize,
+    start_cost: u32,
+    budget: u32,
+    placement_period: usize,
+    model: &ContributionModel,
+    window: usize,
+    rng: &mut Xorshift64,
+) -> (bool, u32) {
+    let is_goal = |cell: usize| goal.contains(&cell);
+    let mut current = start;
+    let mut acc = start_cost;
+    let mut contributions: Vec<Contribution> = Vec::new();
+
+    if acc < budget && is_goal(current) {
+        return (true, u32::MAX);
+    }
+
+    for now in 0..ticks.saturating_sub(1) {
+        let realized = realize_field(width, height, base, base_ticks, now, &contributions, model);
+
+        // Closure check before stepping: has the trail covered every feasible
+        // next cell from the agent's current position this tick?
+        if field_closed(width, height, &realized, stencil, current, acc, budget) {
+            // `now < ticks`, and `ticks` came from a `u32` field, so the
+            // cast is exact; saturate defensively.
+            return (false, u32::try_from(now).unwrap_or(u32::MAX));
+        }
+
+        // Spawn a snapshot contribution on the current cell at the placement
+        // cadence (snapshot placement + lead, #1866's model), holding at most
+        // `max_concurrent` active — the oldest expires.
+        if placement_period > 0 && now % placement_period == 0 {
+            contributions.push(Contribution {
+                center: current,
+                trigger_tick: now,
+            });
+            if model.max_concurrent > 0 && contributions.len() > model.max_concurrent {
+                contributions.remove(0);
+            }
+        }
+
+        let next = plan_step_realized(
+            width, height, &realized, stencil, goal, current, window, rng,
+        );
+        // The realized cost actually paid is the next-tick realization at the
+        // landed cell (the contribution set the agent stepped into).
+        let landed_realized = realize_field(
+            width,
+            height,
+            base,
+            base_ticks,
+            now + 1,
+            &contributions,
+            model,
+        );
+        let true_cost = landed_realized.get(next).copied().unwrap_or(UNREACHABLE);
+        acc = acc.saturating_add(true_cost);
+        current = next;
+        if acc < budget && is_goal(current) {
+            return (true, u32::MAX);
+        }
+    }
+    (false, u32::MAX)
+}
+
+/// Run a seeded distribution of self-realizing field simulations and emit
+/// the closure-outcome distribution (issue 1867). Each run is the closed
+/// feedback loop where the agent's own motion spawns the contributions it
+/// then plans against, so the realized field is path-dependent and distinct
+/// per seed. The whole sweep is a pure function of `input` (seed + field in,
+/// distribution out): the PRNG samples each run's start cell from the start
+/// region and breaks the planner's equal-cost ties, so a given input replays
+/// byte-identically (ADR-0048 §4/§130). Iterative throughout (the per-run
+/// tick loop, the per-tick window solve, and the contribution-realization
+/// scan are all bounded; no recursion, per the load-bearing-code rule).
+pub fn simulate_realization(input: RealizationProblem) -> ClosureDistribution {
+    let (
+        width,
+        height,
+        base_ticks,
+        base,
+        stencil,
+        start_seed,
+        goal,
+        budget,
+        placement_period,
+        model,
+        window,
+        runs,
+        seed,
+    ) = unpack_realization(input);
+    let plane = width.saturating_mul(height);
+
+    let start_cells: Vec<usize> = (0..plane)
+        .filter(|&c| start_seed.get(c).copied().unwrap_or(UNREACHABLE) != UNREACHABLE)
+        .collect();
+
+    // The simulated horizon: run for the base field's full tick span (or at
+    // least a couple of ticks so the loop has room when the base is a single
+    // static layer).
+    let ticks = base_ticks.max(2);
+
+    let mut samples: Vec<RunOutcome> = Vec::with_capacity(runs as usize);
+    let mut closed: u32 = 0;
+    for run in 0..runs {
+        // Per-run start cell, drawn from a per-run mixed seed so each run is
+        // an independent sample of the start region (a no-op start region
+        // yields no run).
+        let mut run_rng = Xorshift64::seeded(agent_seed(seed, u64::from(run) + 1));
+        let start = if start_cells.is_empty() {
+            0
+        } else {
+            start_cells[run_rng.next_bounded(start_cells.len())]
+        };
+        let start_cost = start_seed.get(start).copied().unwrap_or(0);
+
+        let (finished, closure_tick) = if start_cells.is_empty() {
+            (false, u32::MAX)
+        } else {
+            simulate_run(
+                width,
+                height,
+                ticks,
+                &base,
+                base_ticks,
+                &stencil,
+                &goal,
+                start,
+                start_cost,
+                budget,
+                placement_period,
+                &model,
+                window,
+                &mut run_rng,
+            )
+        };
+        if closure_tick != u32::MAX {
+            closed += 1;
+        }
+        samples.push(RunOutcome {
+            run,
+            finished,
+            closure_tick,
+        });
+    }
+
+    ClosureDistribution {
+        runs,
+        closed,
+        samples,
+    }
+}
+
+/// Replay a single run of the self-realizing simulation (the `input`'s seed,
+/// run index `0`) and emit its **realized field** as a [`ScalarField`] — the
+/// inspection path for the headline counts-only [`ClosureDistribution`]
+/// (issue 1867). Leaning on the determinism contract (same seed → same
+/// realized field), the realized field of any run is recoverable by
+/// replaying that seed here, so the distribution output stays tiny. The
+/// emitted field stacks every tick's realization into one `(tick, y, x)`
+/// `ScalarField`: layer `t` is the realized cost field the run planned
+/// against at tick `t`, so a consumer reads the path-dependent trail
+/// accumulating over time. Iterative throughout.
+pub fn realize_single(input: RealizationProblem) -> ScalarField {
+    let (
+        width,
+        height,
+        base_ticks,
+        base,
+        stencil,
+        start_seed,
+        goal,
+        budget,
+        placement_period,
+        model,
+        window,
+        _runs,
+        seed,
+    ) = unpack_realization(input);
+    let plane = width.saturating_mul(height);
+    let ticks = base_ticks.max(2);
+
+    let start_cells: Vec<usize> = (0..plane)
+        .filter(|&c| start_seed.get(c).copied().unwrap_or(UNREACHABLE) != UNREACHABLE)
+        .collect();
+
+    // Replay run 0 exactly as `simulate_realization` does, recording the
+    // realized field at every tick into the stacked output.
+    let mut run_rng = Xorshift64::seeded(agent_seed(seed, 1));
+    let start = if start_cells.is_empty() {
+        0
+    } else {
+        start_cells[run_rng.next_bounded(start_cells.len())]
+    };
+    let mut current = start;
+    let mut acc = start_seed.get(start).copied().unwrap_or(0);
+    let mut contributions: Vec<Contribution> = Vec::new();
+
+    let out_ticks = ticks.max(1);
+    let mut values = vec![UNREACHABLE; plane.saturating_mul(out_ticks)];
+
+    let goal_hit = |cell: usize, a: u32| a < budget && goal.contains(&cell);
+    let mut done = goal_hit(current, acc) || start_cells.is_empty();
+
+    for now in 0..out_ticks {
+        let realized = realize_field(
+            width,
+            height,
+            &base,
+            base_ticks,
+            now,
+            &contributions,
+            &model,
+        );
+        let dst = now.saturating_mul(plane);
+        if let Some(slot) = values.get_mut(dst..dst + plane) {
+            slot.copy_from_slice(&realized[..plane]);
+        }
+
+        if done || now + 1 >= out_ticks {
+            continue;
+        }
+        if field_closed(width, height, &realized, &stencil, current, acc, budget) {
+            done = true;
+            continue;
+        }
+        if placement_period > 0 && now % placement_period == 0 {
+            contributions.push(Contribution {
+                center: current,
+                trigger_tick: now,
+            });
+            if model.max_concurrent > 0 && contributions.len() > model.max_concurrent {
+                contributions.remove(0);
+            }
+        }
+        let next = plan_step_realized(
+            width,
+            height,
+            &realized,
+            &stencil,
+            &goal,
+            current,
+            window,
+            &mut run_rng,
+        );
+        let landed_realized = realize_field(
+            width,
+            height,
+            &base,
+            base_ticks,
+            now + 1,
+            &contributions,
+            &model,
+        );
+        let true_cost = landed_realized.get(next).copied().unwrap_or(UNREACHABLE);
+        acc = acc.saturating_add(true_cost);
+        current = next;
+        if goal_hit(current, acc) {
+            done = true;
+        }
+    }
+
+    // `width` / `height` round-trip from the input `u32` field dimensions;
+    // `out_ticks` is the simulated horizon. All fit `u32`; saturate
+    // defensively rather than truncate.
+    ScalarField {
+        width: u32::try_from(width).unwrap_or(u32::MAX),
+        height: u32::try_from(height).unwrap_or(u32::MAX),
+        ticks: u32::try_from(out_ticks).unwrap_or(u32::MAX),
+        values,
+    }
+}
+
+/// Unpack a [`RealizationProblem`] into the `usize`-typed simulation
+/// parameters both [`simulate_realization`] and [`realize_single`] consume,
+/// so the two replay-equivalent loops decode the input identically.
+#[allow(clippy::type_complexity)]
+fn unpack_realization(
+    input: RealizationProblem,
+) -> (
+    usize,
+    usize,
+    usize,
+    Vec<u32>,
+    Vec<StencilOffset>,
+    Vec<u32>,
+    Vec<usize>,
+    u32,
+    usize,
+    ContributionModel,
+    usize,
+    u32,
+    u64,
+) {
+    let RealizationProblem {
+        problem:
+            ReachabilityProblem {
+                cost:
+                    ScalarField {
+                        width,
+                        height,
+                        ticks,
+                        values: base,
+                    },
+                stencil: MovementStencil { offsets: stencil },
+                start: start_seed,
+            },
+        goal: goal_indices,
+        budget,
+        placement_period,
+        lead_ticks,
+        covered_extent_initial,
+        covered_growth_per_tick,
+        contribution_cost,
+        max_concurrent,
+        window,
+        runs,
+        seed,
+    } = input;
+    let width = width as usize;
+    let height = height as usize;
+    let base_ticks = ticks as usize;
+    let plane = width.saturating_mul(height);
+    let goal: Vec<usize> = goal_indices
+        .iter()
+        .map(|&g| g as usize)
+        .filter(|&g| g < plane)
+        .collect();
+    let model = ContributionModel {
+        lead: lead_ticks as usize,
+        extent_initial: covered_extent_initial,
+        growth_per_tick: covered_growth_per_tick,
+        cost: contribution_cost,
+        max_concurrent: max_concurrent as usize,
+    };
+    (
+        width,
+        height,
+        base_ticks,
+        base,
+        stencil,
+        start_seed,
+        goal,
+        budget,
+        placement_period as usize,
+        model,
+        window as usize,
+        runs,
+        seed,
+    )
+}
+
 /// Shared cost-field fixtures for this crate's `#[cfg(test)]` modules: the
 /// `stencil_4way` movement set lives here once (returned both as raw
 /// [`StencilOffset`]s for the solver-core tests and wrapped in a
@@ -852,5 +1483,285 @@ mod population_tests {
         for sample in &curve.samples {
             assert_eq!(sample.finished, 0);
         }
+    }
+}
+
+#[cfg(test)]
+mod realization_tests {
+    use super::test_fields::stencil_4way;
+    use super::{UNREACHABLE, realize_single, simulate_realization};
+    use aether_kinds::{MovementStencil, ReachabilityProblem, RealizationProblem, ScalarField};
+
+    /// A `RealizationProblem` over a `width × height` base field with the
+    /// 4-way stencil, the start region the finite cells of `start`, and the
+    /// contribution model / sweep parameters passed in. The base field is a
+    /// single static layer repeated implicitly past its horizon, so `ticks`
+    /// here is the simulated tick span.
+    #[allow(clippy::too_many_arguments)]
+    fn problem(
+        width: u32,
+        height: u32,
+        ticks: u32,
+        values: Vec<u32>,
+        start: Vec<u32>,
+        goal: Vec<u32>,
+        budget: u32,
+        placement_period: u32,
+        lead_ticks: u32,
+        covered_extent_initial: f32,
+        covered_growth_per_tick: f32,
+        contribution_cost: u32,
+        max_concurrent: u32,
+        window: u32,
+        runs: u32,
+        seed: u64,
+    ) -> RealizationProblem {
+        RealizationProblem {
+            problem: ReachabilityProblem {
+                cost: ScalarField {
+                    width,
+                    height,
+                    ticks,
+                    values,
+                },
+                stencil: stencil_4way(),
+                start,
+            },
+            goal,
+            budget,
+            placement_period,
+            lead_ticks,
+            covered_extent_initial,
+            covered_growth_per_tick,
+            contribution_cost,
+            max_concurrent,
+            window,
+            runs,
+            seed,
+        }
+    }
+
+    #[test]
+    fn no_contributions_reduces_to_plain_receding_horizon() {
+        // With placement disabled (period 0) the realized field is just the
+        // base field, so the loop degenerates to #1863's fixed-field
+        // receding-horizon agent: a 5×1 uniform-cost corridor, start cell 0,
+        // goal cell 4, ample budget — every run finishes, none closes.
+        let p = problem(
+            5,
+            1,
+            6,
+            vec![1u32; 5 * 6],
+            vec![0, UNREACHABLE, UNREACHABLE, UNREACHABLE, UNREACHABLE],
+            vec![4],
+            100,
+            0, // placement_period 0 → no contributions
+            0,
+            0.0,
+            0.0,
+            0,
+            0,
+            8,
+            8,
+            0xC0FF_EE00,
+        );
+        let dist = simulate_realization(p);
+        assert_eq!(dist.runs, 8);
+        assert_eq!(dist.closed, 0);
+        assert_eq!(dist.samples.len(), 8);
+        assert!(dist.samples.iter().all(|s| s.finished));
+        assert!(dist.samples.iter().all(|s| s.closure_tick == u32::MAX));
+    }
+
+    #[test]
+    fn trail_closes_around_the_agent() {
+        // A 3×1 corridor whose forward cell (2) is base-blocked: the agent
+        // can only step 0 → 1, and its own snapshot contribution on cell 0
+        // (cost far over budget, active immediately) covers the one feasible
+        // way back — the realized field closes around it.
+        //
+        // Trace: tick 0 at cell 0, neighbor cell 1 is free → step + spawn a
+        // contribution on cell 0. Tick 1 at cell 1: cell 2 is blocked, and
+        // realized cell 0 = base 1 + 100 = 101, so acc(1) + 101 >= budget 10
+        // — every feasible neighbor is over budget → closed at tick 1.
+        let p = problem(
+            3,
+            1,
+            4,
+            vec![
+                1,
+                1,
+                UNREACHABLE,
+                1,
+                1,
+                UNREACHABLE,
+                1,
+                1,
+                UNREACHABLE,
+                1,
+                1,
+                UNREACHABLE,
+            ],
+            vec![0, UNREACHABLE, UNREACHABLE],
+            vec![2],
+            10,
+            1, // spawn every tick
+            0, // active immediately
+            0.0,
+            0.0,
+            100, // contribution cost far over budget
+            4,
+            8,
+            5,
+            0x1111_2222,
+        );
+        let dist = simulate_realization(p);
+        assert_eq!(dist.runs, 5);
+        // Single start cell → every run is identical and closes.
+        assert_eq!(dist.closed, 5);
+        assert!(dist.samples.iter().all(|s| !s.finished));
+        assert!(dist.samples.iter().all(|s| s.closure_tick == 1));
+    }
+
+    #[test]
+    fn agent_always_escapes_when_lead_outpaces_cover() {
+        // A 5×1 corridor with a long lead and zero-growth, zero-extent
+        // contributions: each contribution only ever covers its own center
+        // cell and not until well after the agent has left it, so the trail
+        // never closes around a moving agent — no run closes, every run
+        // reaches the goal under budget.
+        let p = problem(
+            5,
+            1,
+            8,
+            vec![1u32; 5 * 8],
+            vec![0, UNREACHABLE, UNREACHABLE, UNREACHABLE, UNREACHABLE],
+            vec![4],
+            100,
+            1,
+            6,   // lead far longer than the walk
+            0.0, // zero extent
+            0.0, // zero growth — covers only the center cell
+            50,
+            8,
+            8,
+            6,
+            0x9999_8888,
+        );
+        let dist = simulate_realization(p);
+        assert_eq!(dist.closed, 0);
+        assert!(dist.samples.iter().all(|s| s.finished));
+    }
+
+    #[test]
+    fn closure_fraction_is_stable_under_doubled_runs() {
+        // Doubling the run count over a multi-cell start region leaves the
+        // closure fraction stable (here exactly 0 — the field is escapable):
+        // the per-run sampling is independent and the headline rate is a
+        // property of the field, not the run count.
+        let start = {
+            let mut s = vec![UNREACHABLE; 5];
+            s[0] = 0;
+            s[1] = 0;
+            s
+        };
+        let base = problem(
+            5,
+            1,
+            8,
+            vec![1u32; 5 * 8],
+            start,
+            vec![4],
+            100,
+            2,
+            6,
+            0.0,
+            0.0,
+            50,
+            8,
+            8,
+            16,
+            0x4242_4242,
+        );
+        let small = simulate_realization(base.clone());
+        let mut doubled = base;
+        doubled.runs = 32;
+        let large = simulate_realization(doubled);
+        assert_eq!(small.closed, 0);
+        assert_eq!(large.closed, 0);
+        assert_eq!(small.runs, 16);
+        assert_eq!(large.runs, 32);
+    }
+
+    #[test]
+    fn realize_single_emits_a_stacked_realized_field() {
+        // The companion readout stacks each tick's realized field into a
+        // `(tick, y, x)` `ScalarField` over the simulated horizon, so a
+        // consumer reads the path-dependent trail accumulating over time.
+        let p = problem(
+            3,
+            1,
+            4,
+            vec![1u32; 3 * 4],
+            vec![0, UNREACHABLE, UNREACHABLE],
+            vec![2],
+            100,
+            1,
+            0,
+            0.0,
+            0.0,
+            7,
+            4,
+            8,
+            1,
+            0x7777_0000,
+        );
+        let field = realize_single(p);
+        assert_eq!(field.width, 3);
+        assert_eq!(field.height, 1);
+        assert_eq!(field.ticks, 4);
+        assert_eq!(field.values.len(), 3 * 4);
+        // Tick 0 is the pristine base field (no contribution active yet).
+        assert_eq!(&field.values[0..3], &[1, 1, 1]);
+        // By a later tick the agent's own trail has raised at least one cell
+        // above the base cost — the path-dependent realization is visible.
+        assert!(field.values.iter().any(|&v| v > 1 && v != UNREACHABLE));
+    }
+
+    #[test]
+    fn empty_start_region_yields_no_closures() {
+        // No finite start cell → no run can spawn; every run is a non-finish,
+        // non-closure outcome (a degenerate but well-defined distribution).
+        let p = problem(
+            3,
+            1,
+            4,
+            vec![1u32; 3 * 4],
+            vec![UNREACHABLE, UNREACHABLE, UNREACHABLE],
+            vec![2],
+            10,
+            1,
+            0,
+            0.0,
+            0.0,
+            100,
+            4,
+            8,
+            4,
+            0xDEAD_BEEF,
+        );
+        let dist = simulate_realization(p);
+        assert_eq!(dist.closed, 0);
+        assert!(dist.samples.iter().all(|s| !s.finished));
+        assert!(dist.samples.iter().all(|s| s.closure_tick == u32::MAX));
+    }
+
+    #[test]
+    fn stencil_unused_warning_guard() {
+        // Touch the wrapped-stencil constructor so the import path matches the
+        // sibling test modules (the realized-field tests bundle the 4-way set
+        // through `problem`).
+        let s: MovementStencil = stencil_4way();
+        assert_eq!(s.offsets.len(), 5);
     }
 }

--- a/crates/aether-capabilities/src/transforms.rs
+++ b/crates/aether-capabilities/src/transforms.rs
@@ -9,15 +9,17 @@
 
 use aether_data::transform;
 use aether_kinds::{
-    BudgetQuery, CorridorGraph, CrossingClassification, CrossingQueryParams, Mat4Apply,
-    MovementStencil, PopulationSweepProblem, ReachabilityMargin, ReachabilityProblem, ScalarField,
-    SurvivalCurve, TrajectoryLog,
+    BudgetQuery, ClosureDistribution, CorridorGraph, CrossingClassification, CrossingQueryParams,
+    Mat4Apply, MovementStencil, PopulationSweepProblem, ReachabilityMargin, ReachabilityProblem,
+    RealizationProblem, ScalarField, SurvivalCurve, TrajectoryLog,
 };
 use aether_math::Vec4;
 
 use crate::corridor::build_corridor_graph_core;
 use crate::counterfactual::solve_counterfactual_core;
-use crate::reachability::{UNREACHABLE, solve_cost_to_reach, solve_population_sweep};
+use crate::reachability::{
+    UNREACHABLE, realize_single, simulate_realization, solve_cost_to_reach, solve_population_sweep,
+};
 
 /// Apply a 4×4 matrix to a 4-vector, `M · v` (ADR-0048's first
 /// first-party transform). `Mat4Apply` bundles both operands so the
@@ -190,6 +192,44 @@ fn solve_counterfactual(
         params.window,
         params.budget,
     )
+}
+
+/// Simulate a seeded distribution of self-realizing field runs and emit the
+/// closure-outcome distribution (issue 1867). `RealizationProblem` bundles
+/// the shared reachability operands (base field, stencil, start region), the
+/// goal region, the contribution model (`placement_period`, `lead_ticks`,
+/// `covered_extent_initial`, `covered_growth_per_tick`, `contribution_cost`,
+/// `max_concurrent`), the planning `window`, the run count, and the seed, so
+/// the transform stays a unary `Kind → Kind` node — the same shape
+/// `Mat4Apply` gives `mat4_apply`.
+///
+/// The body delegates to the pure [`simulate_realization`] core: per run a
+/// closed feedback loop where the agent's own motion spawns the snapshot
+/// contributions it then plans against via #1857's exact
+/// [`solve_cost_to_reach`], so the realized field is path-dependent and the
+/// closure is structural. This is the empirical complement to #1866's local
+/// escapability bound — it realizes the aggregate trail along the real path
+/// and detects the multi-window closure the single-instant `cover(L)` measure
+/// cannot rule out. The seed is an explicit input and the PRNG
+/// deterministic, so the sweep is a pure function of its inputs and
+/// content-addresses correctly: it clears the `#[transform]` purity deny-list
+/// (no host fn, no `Ctx`, no `std::time` / `std::env`; seeded PRNG only).
+#[transform]
+fn simulate_realization_sweep(input: RealizationProblem) -> ClosureDistribution {
+    simulate_realization(input)
+}
+
+/// Replay a single self-realizing run (the input's seed, run index `0`) and
+/// emit its realized field as a stacked `(tick, y, x)` [`ScalarField`] (issue
+/// 1867). The inspection path for the counts-only [`ClosureDistribution`]:
+/// leaning on the determinism contract (same seed → same realized field), any
+/// run's path-dependent realized field is recoverable by replaying that seed
+/// here, so the headline distribution stays tiny. The body delegates to the
+/// pure [`realize_single`] core and clears the same purity deny-list as
+/// `simulate_realization_sweep`.
+#[transform]
+fn realize_single_run(input: RealizationProblem) -> ScalarField {
+    realize_single(input)
 }
 
 #[cfg(test)]
@@ -824,5 +864,267 @@ mod counterfactual_transform_tests {
         let back =
             CrossingClassification::decode_from_bytes(&bytes).expect("classification round-trips");
         assert_eq!(out, back);
+    }
+}
+
+#[cfg(test)]
+mod realization_transform_tests {
+    use super::{realize_single_run, simulate_realization_sweep};
+    use crate::escapability::{EscapeParams, evaluate};
+    use crate::reachability::test_fields::{UNREACHABLE, stencil_4way};
+    use aether_data::{Kind, transforms};
+    use aether_kinds::{ClosureDistribution, ReachabilityProblem, RealizationProblem, ScalarField};
+
+    /// A 3×1 corridor whose forward cell is base-blocked: the agent steps
+    /// 0 → 1, and its own immediate over-budget contribution on cell 0 closes
+    /// the realized field around it (the hand-traced closure regime from the
+    /// core tests, driven through the transform).
+    fn closing_problem() -> RealizationProblem {
+        RealizationProblem {
+            problem: ReachabilityProblem {
+                cost: ScalarField {
+                    width: 3,
+                    height: 1,
+                    ticks: 4,
+                    values: vec![
+                        1,
+                        1,
+                        UNREACHABLE,
+                        1,
+                        1,
+                        UNREACHABLE,
+                        1,
+                        1,
+                        UNREACHABLE,
+                        1,
+                        1,
+                        UNREACHABLE,
+                    ],
+                },
+                stencil: stencil_4way(),
+                start: vec![0, UNREACHABLE, UNREACHABLE],
+            },
+            goal: vec![2],
+            budget: 10,
+            placement_period: 1,
+            lead_ticks: 0,
+            covered_extent_initial: 0.0,
+            covered_growth_per_tick: 0.0,
+            contribution_cost: 100,
+            max_concurrent: 4,
+            window: 8,
+            runs: 4,
+            seed: 0xABCD_4321,
+        }
+    }
+
+    #[test]
+    fn simulate_realization_registered_in_link_time_inventory() {
+        // Same contract as `solve` / `solve_population`: registered, one
+        // `RealizationProblem` input slot, `ClosureDistribution` output.
+        let entry = transforms()
+            .find(|t| t.name.ends_with("::simulate_realization_sweep"))
+            .expect("simulate_realization_sweep not registered in link-time inventory");
+        assert_eq!(entry.input_kind_ids, [RealizationProblem::ID]);
+        assert_eq!(entry.output_kind_id, ClosureDistribution::ID);
+    }
+
+    #[test]
+    fn realize_single_registered_in_link_time_inventory() {
+        // The companion readout: one `RealizationProblem` input slot, a
+        // `ScalarField` (the replayed run's realized field) output.
+        let entry = transforms()
+            .find(|t| t.name.ends_with("::realize_single_run"))
+            .expect("realize_single_run not registered in link-time inventory");
+        assert_eq!(entry.input_kind_ids, [RealizationProblem::ID]);
+        assert_eq!(entry.output_kind_id, ScalarField::ID);
+    }
+
+    #[test]
+    fn realization_kinds_resolve_distinctly() {
+        assert_ne!(RealizationProblem::ID, ClosureDistribution::ID);
+        assert_ne!(RealizationProblem::ID, ScalarField::ID);
+        assert_ne!(ClosureDistribution::ID, ScalarField::ID);
+    }
+
+    #[test]
+    fn simulate_and_single_are_deterministic_and_content_addressable() {
+        // Same seed + field bytes -> byte-identical `ClosureDistribution` AND
+        // byte-identical `realize_single` `ScalarField`: the content-
+        // addressing contract and the proof that "same seed → same realized
+        // field."
+        let dist_a = simulate_realization_sweep(closing_problem());
+        let dist_b = simulate_realization_sweep(closing_problem());
+        assert_eq!(dist_a, dist_b);
+        assert_eq!(dist_a.encode_into_bytes(), dist_b.encode_into_bytes());
+
+        let field_a = realize_single_run(closing_problem());
+        let field_b = realize_single_run(closing_problem());
+        assert_eq!(field_a, field_b);
+        assert_eq!(field_a.encode_into_bytes(), field_b.encode_into_bytes());
+    }
+
+    #[test]
+    fn multi_window_closure_each_contribution_locally_certified() {
+        // The headline: a regime where **every spawned contribution passes
+        // #1866's local `escapable_within_lead`** (each is individually
+        // escapable within its lead) yet the concurrent count along the path
+        // exceeds #1866's conservative `max_concurrent` (so the local bound
+        // explicitly does *not* certify the configuration) — and the
+        // simulator empirically exhibits closure the O(1) local bound cannot
+        // rule out.
+        //
+        // The certified contribution shape #1866 evaluates: r0 = 0, g = 1,
+        // stencil speed s = 2 (the analytic per-tick displacement bound), lead
+        // L = 4 → cover(L) = 4, reach(L) = 8. The per-contribution verdict is
+        // `escapable` (4 < 8, g < s) with a *finite* conservative concurrency
+        // cap `max_concurrent` — ratio = 2, ratio² = 4, N_max = 3. So #1866
+        // certifies any configuration of at most 3 simultaneously-active
+        // contributions of this shape, and leaves a count above 3 uncertified.
+        let shape = EscapeParams {
+            covered_extent_initial: 0.0,
+            covered_growth_per_tick: 1.0,
+            stencil_speed: 2.0,
+            lead_ticks: 4,
+        };
+        let verdict = evaluate(&shape);
+        assert!(
+            verdict.escapable,
+            "each contribution must be locally certified escapable"
+        );
+        assert_eq!(verdict.max_concurrent, 3);
+
+        // A 1×1-wide pocket the agent walks into and seals with its own
+        // trail: a long thin corridor (1×9) where the agent paces back and
+        // forth dropping over-budget contributions every tick, and `lead`
+        // and `cover` are tuned to the certified shape above, yet the
+        // *aggregate* trail — many concurrent contributions of different
+        // ages stacked along the real path — closes the field around it.
+        let width = 1u32;
+        let height = 9u32;
+        let plane = (width * height) as usize;
+        let blocked_ends = {
+            // A static base field that is finite only in a short reachable
+            // stub, so the agent cannot run away from its own trail; the goal
+            // sits past a base-blocked cell it can never afford.
+            let mut layer = vec![1u32; plane];
+            // Block the far half so the agent is confined to a short segment.
+            for cell in layer.iter_mut().skip(3) {
+                *cell = UNREACHABLE;
+            }
+            let ticks = 8u32;
+            let mut values = Vec::with_capacity(plane * ticks as usize);
+            for _ in 0..ticks {
+                values.extend_from_slice(&layer);
+            }
+            (values, ticks)
+        };
+        let (values, ticks) = blocked_ends;
+        let p = RealizationProblem {
+            problem: ReachabilityProblem {
+                cost: ScalarField {
+                    width,
+                    height,
+                    ticks,
+                    values,
+                },
+                stencil: stencil_4way(),
+                start: {
+                    let mut s = vec![UNREACHABLE; plane];
+                    s[0] = 0;
+                    s
+                },
+            },
+            // Goal in the blocked far region: unreachable, so the run never
+            // finishes and the only terminal outcome is self-closure.
+            goal: vec![8],
+            budget: 10,
+            placement_period: 1, // dense placement → many concurrent contributions
+            lead_ticks: 4,       // the certified shape's lead
+            covered_extent_initial: 0.0,
+            covered_growth_per_tick: 1.0, // the certified shape's growth
+            contribution_cost: 100,       // each covered cell goes over budget
+            max_concurrent: 6,            // hold more concurrently than #1866's cap certifies
+            window: 8,
+            runs: 4,
+            seed: 0x0BAD_F00D,
+        };
+        // The path holds up to `max_concurrent = 6` simultaneously-active
+        // contributions — above #1866's conservative cap of 3 for this shape,
+        // the multi-window regime the O(1) local check leaves uncertified.
+        assert!(p.max_concurrent > verdict.max_concurrent);
+        let dist = simulate_realization_sweep(p);
+        assert!(
+            dist.closed > 0,
+            "expected the aggregate trail to close the realized field around the agent"
+        );
+    }
+
+    #[test]
+    fn closure_distribution_encodes_under_output_cap_and_replays() {
+        // A multi-run sweep over a multi-cell start region: the
+        // `ClosureDistribution` is counts plus one `(u32, bool, u32)`
+        // `RunOutcome` per run, so it sits far under the 64MB transform output
+        // cap (ADR-0048 §6), and two runs of the same input replay
+        // byte-identically.
+        const CAP: usize = 64 * 1024 * 1024;
+        let width = 8u32;
+        let height = 8u32;
+        let ticks = 12u32;
+        let plane = (width * height) as usize;
+        let sweep = || RealizationProblem {
+            problem: ReachabilityProblem {
+                cost: ScalarField {
+                    width,
+                    height,
+                    ticks,
+                    values: vec![1u32; plane * ticks as usize],
+                },
+                stencil: stencil_4way(),
+                start: {
+                    let mut s = vec![UNREACHABLE; plane];
+                    s[0] = 0;
+                    s[1] = 0;
+                    s[2] = 0;
+                    s
+                },
+            },
+            goal: vec![63],
+            budget: 1000,
+            placement_period: 2,
+            lead_ticks: 3,
+            covered_extent_initial: 0.0,
+            covered_growth_per_tick: 0.5,
+            contribution_cost: 50,
+            max_concurrent: 6,
+            window: 8,
+            runs: 64,
+            seed: 0x2468_ACE0,
+        };
+
+        let dist = simulate_realization_sweep(sweep());
+        assert_eq!(dist.runs, 64);
+        assert_eq!(dist.samples.len(), 64);
+
+        let bytes = dist.encode_into_bytes();
+        assert!(
+            bytes.len() < CAP,
+            "encoded closure distribution is {} bytes, over the {CAP}-byte cap",
+            bytes.len()
+        );
+        let back = ClosureDistribution::decode_from_bytes(&bytes)
+            .expect("closure distribution round-trips");
+        assert_eq!(dist, back);
+
+        let replay = simulate_realization_sweep(sweep());
+        assert_eq!(dist.encode_into_bytes(), replay.encode_into_bytes());
+
+        // The companion realized field also fits the cap and round-trips.
+        let field = realize_single_run(sweep());
+        let field_bytes = field.encode_into_bytes();
+        assert!(field_bytes.len() < CAP);
+        let field_back =
+            ScalarField::decode_from_bytes(&field_bytes).expect("realized field round-trips");
+        assert_eq!(field, field_back);
     }
 }

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -4180,6 +4180,110 @@ mod control_plane {
     pub struct CrossingClassification {
         pub crossings: Vec<CrossingVerdict>,
     }
+
+    /// A self-realizing field simulation (issue 1867): an agent whose own
+    /// motion through a field *spawns* the contributions it must then avoid.
+    /// Per run, a closed feedback loop — realize the field, plan against it,
+    /// step, snapshot a contribution onto the recent position, advance —
+    /// produces a path-dependent realized field that is distinct per seed,
+    /// deterministic given (seed + policy + field). Studied as a
+    /// distribution over many seeded runs (see [`ClosureDistribution`]), not
+    /// a single solve. The whole simulation is a pure function of its inputs
+    /// (seed + field in), so it content-addresses as a `#[transform]` with no
+    /// executor change (ADR-0048 §4/§130).
+    ///
+    /// `problem` carries the shared reachability bundle (the base space-time
+    /// cost field, the one-tick [`MovementStencil`], and the start seed) —
+    /// embedding [`ReachabilityProblem`] keeps the per-tick planner
+    /// *literally* #1857's `solve_cost_to_reach` over the realized field, so
+    /// the path-dependence is structural rather than a bespoke trap
+    /// heuristic. `problem.start` doubles as the **start region**: the cells
+    /// with a finite seed value are the spawn cells, and each run inherits
+    /// its sampled cell's seed as its initial accumulated cost. `goal` is the
+    /// goal region as flat row-major cell indices (`y * width + x`); a run
+    /// **finishes** the moment it lands on a goal cell with accumulated cost
+    /// `< budget` before the final tick.
+    ///
+    /// The **contribution model** is #1866's snapshot-placement-plus-lead.
+    /// Every `placement_period` ticks the run snapshots its current cell and
+    /// enqueues a contribution that takes effect `lead_ticks` (`L`) later. An
+    /// *active* contribution committed at trigger tick `t_c` (with
+    /// `t - t_c >= L`) adds `contribution_cost` to every base-field cell
+    /// within radius `cover(age) = covered_extent_initial +
+    /// covered_growth_per_tick * (t - t_c)` of its snapshot center
+    /// (saturating at the `u32::MAX` sentinel). At most `max_concurrent`
+    /// contributions are held active at once (oldest expires). The realized
+    /// field at tick `t` is the base field plus the sum of every active
+    /// contribution at its current age — the load-bearing path-dependent
+    /// quantity, since which cells are covered is a function of where the run
+    /// stepped at every earlier placement tick.
+    ///
+    /// `window` is the planning-window depth `W` (how far forward the planner
+    /// sees each tick); `runs` is the number of seeded runs in the
+    /// distribution; `seed` keys the deterministic PRNG that samples each
+    /// run's start cell and breaks equal-cost stencil ties. Where the per-
+    /// contribution escapability bound (#1866) certifies a single snapshot in
+    /// O(1) but leaves `N > max_concurrent` *uncertified*, this simulator is
+    /// the empirical complement: it realizes the aggregate trail along the
+    /// real path and detects the multi-window closure the single-instant
+    /// `cover(L)` measure cannot see.
+    #[derive(
+        aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq,
+    )]
+    #[kind(name = "aether.reach.realization_problem")]
+    pub struct RealizationProblem {
+        pub problem: ReachabilityProblem,
+        pub goal: Vec<u32>,
+        pub budget: u32,
+        pub placement_period: u32,
+        pub lead_ticks: u32,
+        pub covered_extent_initial: f32,
+        pub covered_growth_per_tick: f32,
+        pub contribution_cost: u32,
+        pub max_concurrent: u32,
+        pub window: u32,
+        pub runs: u32,
+        pub seed: u64,
+    }
+
+    /// One run's outcome in a [`ClosureDistribution`] (issue 1867). Not a
+    /// kind on its own — only addressable inside
+    /// `ClosureDistribution.samples`. `run` is the run index. `finished` is
+    /// `true` iff the agent reached a goal cell under budget before the final
+    /// tick. `closure_tick` is the first tick at which the realized field
+    /// **closed around the agent** — no stencil neighbor of the current cell
+    /// is both un-blocked and keeps accumulated cost `< budget`, the
+    /// window-independent signal that the run's own trail has covered every
+    /// feasible next cell. `closure_tick` is `u32::MAX` when the run never
+    /// closed (it exhausted ticks without the field closing), separating
+    /// self-accumulated closure — the headline failure — from plain
+    /// budget/time exhaustion. Integer-exact, so a run replays byte-stable.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct RunOutcome {
+        pub run: u32,
+        pub finished: bool,
+        pub closure_tick: u32,
+    }
+
+    /// The output of the self-realizing field simulation (issue 1867): the
+    /// distribution of closure outcomes over a seeded set of runs. `runs` is
+    /// the shared run count; `closed` is how many runs the realized field
+    /// closed around (the headline failure rate is `closed / runs`);
+    /// `samples` carries one [`RunOutcome`] per run, in run-index order. The
+    /// distribution of `closure_tick` over the samples shows *when* the
+    /// multi-window closure happens. Counts-only and integer-exact — every
+    /// run's realized field is recoverable by replaying its seed through the
+    /// companion `realize_single` transform, so the headline output stays
+    /// tiny and byte-stable for content-addressing replay.
+    #[derive(
+        aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq,
+    )]
+    #[kind(name = "aether.reach.closure_distribution")]
+    pub struct ClosureDistribution {
+        pub runs: u32,
+        pub closed: u32,
+        pub samples: Vec<RunOutcome>,
+    }
 }
 
 mod trajectory {
@@ -4521,6 +4625,11 @@ mod tests {
             CrossingClassification::NAME,
             "aether.reach.crossing_classification"
         );
+        assert_eq!(RealizationProblem::NAME, "aether.reach.realization_problem");
+        assert_eq!(
+            ClosureDistribution::NAME,
+            "aether.reach.closure_distribution"
+        );
     }
 
     // ADR-0019 PR 3 — every kind below now has a derived `Schema` impl
@@ -4849,6 +4958,70 @@ mod tests {
             let back: CrossingClassification = postcard::from_bytes(&bytes)
                 .expect("test setup: postcard decodes CrossingClassification");
             assert_eq!(back, cls);
+        }
+
+        #[test]
+        fn realization_kinds_resolve_distinctly_from_reach_kinds() {
+            use aether_data::Kind;
+            // The two realization kinds carry ids distinct from each other
+            // and from the #1857 / #1863 reachability kinds they build on — a
+            // shared id would collide in the transform Ref-slot resolver.
+            let ids = [
+                RealizationProblem::ID,
+                ClosureDistribution::ID,
+                ScalarField::ID,
+                ReachabilityProblem::ID,
+                PopulationSweepProblem::ID,
+            ];
+            for (i, a) in ids.iter().enumerate() {
+                for b in &ids[i + 1..] {
+                    assert_ne!(a, b, "realization kind ids must be distinct");
+                }
+            }
+        }
+
+        #[test]
+        fn realization_problem_schema_embeds_reachability_problem() {
+            let SchemaType::Struct { fields, .. } = &<RealizationProblem as Schema>::SCHEMA else {
+                panic!("expected Struct");
+            };
+            assert_eq!(fields.len(), 12);
+            assert_eq!(fields[0].name, "problem");
+            assert!(matches!(fields[0].ty, SchemaType::Struct { .. }));
+            assert_eq!(fields[1].name, "goal");
+            assert!(matches!(fields[1].ty, SchemaType::Vec(_)));
+            assert_eq!(fields[2].name, "budget");
+            assert_eq!(fields[2].ty, SchemaType::Scalar(Primitive::U32));
+            assert_eq!(fields[5].name, "covered_extent_initial");
+            assert_eq!(fields[5].ty, SchemaType::Scalar(Primitive::F32));
+            assert_eq!(fields[6].name, "covered_growth_per_tick");
+            assert_eq!(fields[6].ty, SchemaType::Scalar(Primitive::F32));
+            assert_eq!(fields[11].name, "seed");
+            assert_eq!(fields[11].ty, SchemaType::Scalar(Primitive::U64));
+        }
+
+        #[test]
+        fn closure_distribution_schema_is_struct_of_samples() {
+            let SchemaType::Struct { fields, .. } = &<ClosureDistribution as Schema>::SCHEMA else {
+                panic!("expected Struct");
+            };
+            assert_eq!(fields.len(), 3);
+            assert_eq!(fields[0].name, "runs");
+            assert_eq!(fields[0].ty, SchemaType::Scalar(Primitive::U32));
+            assert_eq!(fields[1].name, "closed");
+            assert_eq!(fields[1].ty, SchemaType::Scalar(Primitive::U32));
+            assert_eq!(fields[2].name, "samples");
+            let SchemaType::Vec(element) = &fields[2].ty else {
+                panic!("expected Vec");
+            };
+            let SchemaType::Struct { fields: sample, .. } = &**element else {
+                panic!("expected nested RunOutcome struct");
+            };
+            assert_eq!(sample.len(), 3);
+            assert_eq!(sample[0].name, "run");
+            assert_eq!(sample[1].name, "finished");
+            assert_eq!(sample[1].ty, SchemaType::Bool);
+            assert_eq!(sample[2].name, "closure_tick");
         }
     }
 


### PR DESCRIPTION
Closes #1867.

## Summary

A self-realizing field simulator (`aether-capabilities::reachability`) where motion spawns the contributions it must avoid. A closed loop (`simulate_realization` / `realize_single`) re-plans each step over the *realized* field (via #1857's `solve_cost_to_reach`), spawning the per-step contributions, until closure or completion — producing a `ClosureDistribution`. New `RealizationProblem` / `ClosureDistribution` / `RunOutcome` kinds and two `#[transform]`s (`simulate_realization_sweep`, `realize_single_run`). Iterative throughout. The headline test exhibits multi-window closure: each contribution passes #1866's per-snapshot escapability bound, yet the path holds more concurrent than its cap certifies.

## Test plan

16 new tests: kind name / schema / id-distinctness; core closed-loop cases (a)–(d); transform inventory-registration + determinism; the multi-window-closure headline; replay + 64 MB-cap sanity. Reuses the shared `reachability::test_fields` fixtures. `clippy --workspace --all-targets -- -D warnings` clean; `aether-kinds` + `aether-capabilities` tests pass (381); doc + wasm32 cross-build clean. CI runs the full-workspace suite.

## Generated by

`/implement` — agent execution of scoped issue #1867.
