### PR TITLE
docs(adr): mark shipped ADRs accepted

### DIFF
--- a/docs/adr/0102-extract-rpc-wire-crate.md
+++ b/docs/adr/0102-extract-rpc-wire-crate.md
@@ -1,6 +1,6 @@
 # ADR-0102: Extract the RPC wire vocabulary into its own crate
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — the aether-rpc crate)
 - **Date:** 2026-06-10
 
 ## Context

--- a/docs/adr/0103-sampled-audio-track-playback-and-instrument-banks.md
+++ b/docs/adr/0103-sampled-audio-track-playback-and-instrument-banks.md
@@ -1,6 +1,6 @@
 # ADR-0103: Sampled Audio: Track Playback and Instrument Banks
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — sampled audio in the aether.audio capability)
 - **Date:** 2026-06-11
 
 ## Context

--- a/docs/adr/0104-scheduled-note-events.md
+++ b/docs/adr/0104-scheduled-note-events.md
@@ -1,6 +1,6 @@
 # ADR-0104: Scheduled note events for the audio capability
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — the aether.audio.schedule handler)
 - **Date:** 2026-06-12
 
 ## Context

--- a/docs/adr/0105-text-rendering.md
+++ b/docs/adr/0105-text-rendering.md
@@ -1,6 +1,6 @@
 # ADR-0105: Text Rendering
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — the aether.text capability)
 - **Date:** 2026-06-12
 
 ## Context

--- a/docs/adr/0106-settlement-safe-by-construction.md
+++ b/docs/adr/0106-settlement-safe-by-construction.md
@@ -1,6 +1,6 @@
 # ADR-0106: Settlement safe by construction
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — substrate settlement)
 - **Date:** 2026-06-12
 
 Amends **ADR-0094** (settlement-obligation guard) and the consumer side of **ADR-0080 §2**. The settlement semantics are unchanged — `(in_flight == 0 && held_open == 0)` is still the settled signal, and the producer-site brackets stay where they are. What changes is who implements the consumer side of the bracket for claimed mailboxes: the framework, once, instead of every hand-rolled drain.

--- a/docs/adr/0108-substrate-http-server-capability.md
+++ b/docs/adr/0108-substrate-http-server-capability.md
@@ -1,6 +1,6 @@
 # ADR-0108: Substrate HTTP server capability
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — the aether.http server capability)
 - **Date:** 2026-06-12
 
 Mirrors **ADR-0043** (the substrate HTTP egress sink) on the inbound side: where ADR-0043 turns a component's outbound `Fetch` mail into an HTTP request, this turns an inbound HTTP request into mail to a handler component. It reuses ADR-0043's `HttpMethod` / `HttpHeader` shapes and its buffered-body decision, joins the socket-binding capability family of **ADR-0079** (the `aether.tcp` listener / session actors), drives its response close through the settlement machinery of **ADR-0080** and **ADR-0106**, follows the I/O-cap-as-mail-sink and config-layering template of **ADR-0041** and **ADR-0090**, and takes the `RpcServerCapability` (issue 750) as its literal code template.

--- a/docs/adr/0109-handler-reply-contracts.md
+++ b/docs/adr/0109-handler-reply-contracts.md
@@ -1,6 +1,6 @@
 # ADR-0109: Handler reply contracts via return types
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — return-type reply contracts in aether-actor)
 - **Date:** 2026-06-13
 
 ## Context

--- a/docs/adr/0112-handler-reply-classes.md
+++ b/docs/adr/0112-handler-reply-classes.md
@@ -1,6 +1,6 @@
 # ADR-0112: Handler reply classes
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — the reply-class migration + lock, #1850 / #1874–#1879)
 - **Date:** 2026-06-14
 
 ## Context


### PR DESCRIPTION
Flip the status of eight ADRs whose implementations have shipped but whose `Status` line still read `Proposed` — the post-implementation "flip to Accepted" step (`/sweep adrs`, run against current `main`).

| ADR | → Status |
| --- | --- |
| 0102 Extract RPC wire vocabulary | Accepted (aether-rpc crate) |
| 0103 Sampled audio | Accepted (aether.audio sampled instruments) |
| 0104 Scheduled note events | Accepted (aether.audio.schedule) |
| 0105 Text rendering | Accepted (aether.text capability) |
| 0106 Settlement safe by construction | Accepted (substrate settlement) |
| 0108 Substrate HTTP server capability | Accepted (aether.http server cap) |
| 0109 Handler reply contracts | Accepted (return-type reply contracts) |
| 0112 Handler reply classes | Accepted (reply-class migration + lock, #1850 / #1874–#1879) |

Each carries a brief shipped-evidence note (the citing crate / the landing PRs). ADR-0113 was already `Accepted`. The lower-confidence drifts (0107 immediate-mode UI, 0046 content-gen pipeline) and the intentional/pending ADRs (0044 parked, 0059 draft, 0025/0084/0092 no-code-yet) were left untouched.

Docs-only — takes the docs pre-flight exception.
