### PR TITLE
feat(actor): thread the inbound recipient through to guest mail

### DIFF
--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -544,8 +544,8 @@ pub mod guest_alloc {
 /// - A `static` [`crate::Slot<T>`] that backs the actor instance.
 /// - `extern "C" fn init(mailbox_id: u64) -> u32` — builds an
 ///   [`FfiInitCtx`], calls `T::init`, stashes the result in the slot.
-/// - `extern "C" fn receive(kind, ptr, byte_len, count, sender) -> u32`
-///   — builds [`FfiCtx`] and [`crate::Mail`], calls the
+/// - `extern "C" fn receive(kind, ptr, byte_len, count, sender, recipient)
+///   -> u32` — builds [`FfiCtx`] and [`crate::Mail`], calls the
 ///   `#[actor]`-synthesized `__aether_dispatch` on the stashed
 ///   instance.
 /// - `#[link_section = "aether.kinds.inputs"]` static that pins the
@@ -767,8 +767,10 @@ macro_rules! __export_internal {
 
         /// # Safety
         /// Called by the substrate with `(kind, ptr, byte_len, count,
-        /// sender)` matching the FFI contract. Exported under the
-        /// `_p32` suffix per ADR-0024 Phase 1.
+        /// sender, recipient)` matching the FFI contract. Exported under
+        /// the `_p32` suffix per ADR-0024 Phase 1; the trailing
+        /// `recipient: u64` (ADR-0114 decision #1) widens like the other
+        /// frame slots on the wasm path.
         #[cfg(target_arch = "wasm32")]
         #[unsafe(export_name = "receive_p32")]
         pub unsafe extern "C" fn receive(
@@ -777,6 +779,7 @@ macro_rules! __export_internal {
             byte_len: u32,
             count: u32,
             sender: u32,
+            recipient: u64,
         ) -> u32 {
             let Some(instance) = (unsafe { __AETHER_COMPONENT.get_mut() }) else {
                 return 1;
@@ -791,7 +794,8 @@ macro_rules! __export_internal {
             // ADR-0112: dispatch receives the full `Manual` ctx; the
             // synthesized `__aether_dispatch` downgrades per handler class.
             let mut ctx = $crate::FfiCtx::__new(mailbox_id);
-            let mail = unsafe { $crate::Mail::__from_raw(kind, ptr, byte_len, count, sender) };
+            let mail =
+                unsafe { $crate::Mail::__from_raw(kind, ptr, byte_len, count, sender, recipient) };
             instance.__aether_dispatch(&mut ctx, mail)
         }
 
@@ -1077,7 +1081,8 @@ macro_rules! __export_multi_internal {
         /// # Safety
         /// FFI receive contract (ADR-0024); routes through the boxed
         /// `ErasedFfiActor`. Self-mailbox id derived from the live
-        /// instance's namespace.
+        /// instance's namespace. The trailing `recipient: u64` (ADR-0114
+        /// decision #1) carries the routed mailbox through to `Mail`.
         #[cfg(target_arch = "wasm32")]
         #[unsafe(export_name = "receive_p32")]
         pub unsafe extern "C" fn receive(
@@ -1086,6 +1091,7 @@ macro_rules! __export_multi_internal {
             byte_len: u32,
             count: u32,
             sender: u32,
+            recipient: u64,
         ) -> u32 {
             let Some(instance) = (unsafe { __AETHER_MULTI.get_mut() }) else {
                 return 1;
@@ -1097,7 +1103,8 @@ macro_rules! __export_multi_internal {
             // ADR-0112: the boxed `ErasedFfiActor` seam carries the `Manual`
             // view; the synthesized impl downgrades to `Single` per hook.
             let mut ctx = $crate::FfiCtx::__new(mailbox_id);
-            let mail = unsafe { $crate::Mail::__from_raw(kind, ptr, byte_len, count, sender) };
+            let mail =
+                unsafe { $crate::Mail::__from_raw(kind, ptr, byte_len, count, sender, recipient) };
             instance.erased_dispatch(&mut ctx, mail)
         }
 

--- a/crates/aether-actor/src/mail/mod.rs
+++ b/crates/aether-actor/src/mail/mod.rs
@@ -22,7 +22,7 @@ pub mod mailbox;
 
 use core::marker::PhantomData;
 
-use aether_data::{Kind, Schema};
+use aether_data::{Kind, MailboxId, Schema};
 
 use crate::mail::mailbox::KindId;
 
@@ -73,7 +73,8 @@ impl ReplyHandle {
 /// Inbound mail, as received by the `#[actor]`-synthesized
 /// `__aether_dispatch` (driven by the guest's `receive` FFI export).
 /// Wraps the raw
-/// `(kind, ptr, count, sender)` FFI parameters with typed decode helpers.
+/// `(kind, ptr, count, sender, recipient)` FFI parameters with typed
+/// decode helpers.
 ///
 /// The lifetime `'a` ties the returned references back to the receive
 /// call; holding a decoded `&K` past the return of `receive` is a
@@ -97,6 +98,14 @@ pub struct Mail<'a> {
     byte_len: u32,
     count: u32,
     sender: u32,
+    // ADR-0114 decision #1: the mailbox the substrate routed this mail
+    // to, carried as the raw `u64` the substrate stamped on its
+    // `OwnedDispatch.recipient` and widened by the receive ABI. For a
+    // normally-addressed actor this equals the actor's own mailbox id;
+    // an inline-child membrane (ADR-0114) reads it to demux mail to the
+    // co-located child the producer addressed. Surfaced via
+    // [`Mail::recipient`].
+    recipient: u64,
     _borrow: PhantomData<&'a [u8]>,
 }
 
@@ -105,13 +114,21 @@ impl<'a> Mail<'a> {
     /// delivers `ptr` as a wasm32 offset (`u32`); this widens it.
     #[doc(hidden)]
     #[must_use]
-    pub unsafe fn __from_raw(kind: u64, ptr: u32, byte_len: u32, count: u32, sender: u32) -> Self {
+    pub unsafe fn __from_raw(
+        kind: u64,
+        ptr: u32,
+        byte_len: u32,
+        count: u32,
+        sender: u32,
+        recipient: u64,
+    ) -> Self {
         Mail {
             kind,
             ptr: ptr as usize,
             byte_len,
             count,
             sender,
+            recipient,
             _borrow: PhantomData,
         }
     }
@@ -128,6 +145,7 @@ impl<'a> Mail<'a> {
         byte_len: u32,
         count: u32,
         sender: u32,
+        recipient: u64,
     ) -> Self {
         Mail {
             kind,
@@ -135,6 +153,7 @@ impl<'a> Mail<'a> {
             byte_len,
             count,
             sender,
+            recipient,
             _borrow: PhantomData,
         }
     }
@@ -178,6 +197,18 @@ impl<'a> Mail<'a> {
         } else {
             Some(ReplyHandle { raw: self.sender })
         }
+    }
+
+    /// Mailbox this mail was routed to (ADR-0114 decision #1). The
+    /// substrate stamps it on the dispatch envelope and threads it
+    /// through the receive ABI, so a guest can tell apart mail addressed
+    /// to different lineage addresses that land in the same instance.
+    /// For a normally-addressed actor this equals the actor's own
+    /// mailbox id; an inline-child membrane reads it to demux inbound
+    /// mail to the co-located child the producer addressed.
+    #[must_use]
+    pub fn recipient(&self) -> MailboxId {
+        MailboxId(self.recipient)
     }
 
     /// Decode as a single owned `K`. Returns `None` if the kind does
@@ -461,8 +492,8 @@ mod tests {
     // is derived from a local stack value or buffer whose lifetime
     // straddles the resulting `Mail`/`PriorState`, satisfying the
     // ABI's `(ptr, byte_len)` validity contract for the duration of
-    // the test body. The `count` / `sender` / `version` scalars are
-    // plain values with no aliasing implications. The `0,0,0` no-deref
+    // the test body. The `count` / `sender` / `recipient` / `version`
+    // scalars are plain values with no aliasing implications. The `0,0,0` no-deref
     // variants rely on the `bytes()` / `decode*` accessors honouring
     // the `len == 0` early-return rather than forming a slice over the
     // null pointer.
@@ -473,7 +504,7 @@ mod tests {
         let ptr_raw = (&raw const value).addr();
         let byte_len = size_of::<FakePod>() as u32;
         // SAFETY: see module-level test fixture justification above.
-        let mail = unsafe { Mail::__from_ptr(7, ptr_raw, byte_len, 1, NO_REPLY_HANDLE) };
+        let mail = unsafe { Mail::__from_ptr(7, ptr_raw, byte_len, 1, NO_REPLY_HANDLE, 0) };
         let kind: KindId<FakePod> = KindId::__new(7);
         let out = mail
             .decode(kind)
@@ -487,7 +518,7 @@ mod tests {
         let ptr_raw = (&raw const value).addr();
         let byte_len = size_of::<FakePod>() as u32;
         // SAFETY: see module-level test fixture justification above.
-        let mail = unsafe { Mail::__from_ptr(7, ptr_raw, byte_len, 1, NO_REPLY_HANDLE) };
+        let mail = unsafe { Mail::__from_ptr(7, ptr_raw, byte_len, 1, NO_REPLY_HANDLE, 0) };
         let wrong: KindId<FakePod> = KindId::__new(8);
         assert!(mail.decode(wrong).is_none());
     }
@@ -498,7 +529,7 @@ mod tests {
         let ptr_raw = values.as_ptr().addr();
         let byte_len = (size_of::<FakePod>() * 2) as u32;
         // SAFETY: see module-level test fixture justification above.
-        let mail = unsafe { Mail::__from_ptr(7, ptr_raw, byte_len, 2, NO_REPLY_HANDLE) };
+        let mail = unsafe { Mail::__from_ptr(7, ptr_raw, byte_len, 2, NO_REPLY_HANDLE, 0) };
         let kind: KindId<FakePod> = KindId::__new(7);
         // `decode` requires count == 1; use `decode_slice` for batches.
         assert!(mail.decode(kind).is_none());
@@ -510,7 +541,7 @@ mod tests {
         let ptr_raw = values.as_ptr().addr();
         let byte_len = (size_of::<FakePod>() * 2) as u32;
         // SAFETY: see module-level test fixture justification above.
-        let mail = unsafe { Mail::__from_ptr(7, ptr_raw, byte_len, 2, NO_REPLY_HANDLE) };
+        let mail = unsafe { Mail::__from_ptr(7, ptr_raw, byte_len, 2, NO_REPLY_HANDLE, 0) };
         let kind: KindId<FakePod> = KindId::__new(7);
         let out = mail
             .decode_slice(kind)
@@ -522,18 +553,37 @@ mod tests {
     fn mail_sender_none_for_sentinel_handle() {
         // SAFETY: no pointer is dereferenced (`bytes()` and friends
         // are not called); we only inspect the sentinel `sender`.
-        let mail = unsafe { Mail::__from_ptr(0, 0, 0, 0, NO_REPLY_HANDLE) };
+        let mail = unsafe { Mail::__from_ptr(0, 0, 0, 0, NO_REPLY_HANDLE, 0) };
         assert!(mail.reply_handle().is_none());
     }
 
     #[test]
     fn mail_sender_some_for_real_handle() {
         // SAFETY: no pointer is dereferenced; we only inspect `sender`.
-        let mail = unsafe { Mail::__from_ptr(0, 0, 0, 0, 42) };
+        let mail = unsafe { Mail::__from_ptr(0, 0, 0, 0, 42, 0) };
         let s = mail
             .reply_handle()
             .expect("non-sentinel handle yields Some");
         assert_eq!(s.raw(), 42);
+    }
+
+    #[test]
+    fn mail_recipient_roundtrips_from_raw_address() {
+        // ADR-0114 decision #1: the receive ABI threads the routed
+        // mailbox through as the trailing `recipient` frame slot; the
+        // accessor wraps it back into a `MailboxId`. Independent of the
+        // reply-handle `sender` slot — distinct values must not bleed.
+        // SAFETY: no pointer is dereferenced; only the scalar slots are
+        // inspected.
+        let mail = unsafe { Mail::__from_ptr(0, 0, 0, 0, 42, 0x1234_5678_9ABC_DEF0) };
+        assert_eq!(mail.recipient(), MailboxId(0x1234_5678_9ABC_DEF0));
+        // `__from_raw` (the wasm32 path) carries the same recipient
+        // unchanged — only the address widens, never the recipient.
+        // SAFETY: no pointer is dereferenced; only the scalar slots are
+        // inspected.
+        let raw_mail = unsafe { Mail::__from_raw(0, 0, 0, 0, NO_REPLY_HANDLE, 0xDEAD_BEEF) };
+        assert_eq!(raw_mail.recipient(), MailboxId(0xDEAD_BEEF));
+        assert!(raw_mail.reply_handle().is_none());
     }
 
     #[test]
@@ -562,7 +612,7 @@ mod tests {
     #[test]
     fn mail_is_typed_matches_kind_id() {
         // SAFETY: no pointer is dereferenced (`is::<K>` reads `kind`).
-        let mail = unsafe { Mail::__from_ptr(FakeKind::ID.0, 0, 0, 0, NO_REPLY_HANDLE) };
+        let mail = unsafe { Mail::__from_ptr(FakeKind::ID.0, 0, 0, 0, NO_REPLY_HANDLE, 0) };
         assert!(mail.is::<FakeKind>());
         assert!(!mail.is::<FakePod>());
     }
@@ -574,7 +624,7 @@ mod tests {
         let byte_len = size_of::<FakePod>() as u32;
         // SAFETY: see module-level test fixture justification above.
         let mail =
-            unsafe { Mail::__from_ptr(FakePod::ID.0, ptr_raw, byte_len, 1, NO_REPLY_HANDLE) };
+            unsafe { Mail::__from_ptr(FakePod::ID.0, ptr_raw, byte_len, 1, NO_REPLY_HANDLE, 0) };
         let out = mail
             .decode_typed::<FakePod>()
             .expect("test setup: matching kind id decodes typed");
@@ -589,7 +639,7 @@ mod tests {
         // Kind id deliberately mismatched (FakeKind instead of FakePod).
         // SAFETY: see module-level test fixture justification above.
         let mail =
-            unsafe { Mail::__from_ptr(FakeKind::ID.0, ptr_raw, byte_len, 1, NO_REPLY_HANDLE) };
+            unsafe { Mail::__from_ptr(FakeKind::ID.0, ptr_raw, byte_len, 1, NO_REPLY_HANDLE, 0) };
         assert!(mail.decode_typed::<FakePod>().is_none());
     }
 
@@ -600,7 +650,7 @@ mod tests {
         let byte_len = (size_of::<FakePod>() * 2) as u32;
         // SAFETY: see module-level test fixture justification above.
         let mail =
-            unsafe { Mail::__from_ptr(FakePod::ID.0, ptr_raw, byte_len, 2, NO_REPLY_HANDLE) };
+            unsafe { Mail::__from_ptr(FakePod::ID.0, ptr_raw, byte_len, 2, NO_REPLY_HANDLE, 0) };
         assert!(mail.decode_typed::<FakePod>().is_none());
     }
 
@@ -611,7 +661,7 @@ mod tests {
         let byte_len = (size_of::<FakePod>() * 2) as u32;
         // SAFETY: see module-level test fixture justification above.
         let mail =
-            unsafe { Mail::__from_ptr(FakePod::ID.0, ptr_raw, byte_len, 2, NO_REPLY_HANDLE) };
+            unsafe { Mail::__from_ptr(FakePod::ID.0, ptr_raw, byte_len, 2, NO_REPLY_HANDLE, 0) };
         let out = mail
             .decode_slice_typed::<FakePod>()
             .expect("test setup: matching kind id decodes typed slice");
@@ -635,6 +685,7 @@ mod tests {
                 bytes.len() as u32,
                 1,
                 NO_REPLY_HANDLE,
+                0,
             )
         };
         let out = mail.decode_kind::<FakePostcard>().expect("decode");
@@ -667,8 +718,9 @@ mod tests {
         let ptr_raw = (&raw const value).addr();
         let byte_len = size_of::<FakeCastKind>() as u32;
         // SAFETY: see module-level test fixture justification above.
-        let mail =
-            unsafe { Mail::__from_ptr(FakeCastKind::ID.0, ptr_raw, byte_len, 1, NO_REPLY_HANDLE) };
+        let mail = unsafe {
+            Mail::__from_ptr(FakeCastKind::ID.0, ptr_raw, byte_len, 1, NO_REPLY_HANDLE, 0)
+        };
         let out = mail.decode_kind::<FakeCastKind>().expect("decode");
         assert_eq!(out, value);
     }
@@ -690,6 +742,7 @@ mod tests {
                 bytes.len() as u32,
                 1,
                 NO_REPLY_HANDLE,
+                0,
             )
         };
         assert!(mail.decode_kind::<FakePostcard>().is_none());
@@ -712,6 +765,7 @@ mod tests {
                 bytes.len() as u32,
                 2,
                 NO_REPLY_HANDLE,
+                0,
             )
         };
         assert!(mail.decode_kind::<FakePostcard>().is_none());
@@ -738,6 +792,7 @@ mod tests {
                 2,
                 1,
                 NO_REPLY_HANDLE,
+                0,
             )
         };
         assert!(mail.decode_kind::<FakePostcard>().is_none());
@@ -754,8 +809,16 @@ mod tests {
         // SAFETY: `buf` outlives `mail`; the `(addr, 0)` pair points
         // into the live `buf` allocation, satisfying the validity
         // contract trivially for the zero-byte read.
-        let mail =
-            unsafe { Mail::__from_ptr(FakeKind::ID.0, buf.as_ptr().addr(), 0, 1, NO_REPLY_HANDLE) };
+        let mail = unsafe {
+            Mail::__from_ptr(
+                FakeKind::ID.0,
+                buf.as_ptr().addr(),
+                0,
+                1,
+                NO_REPLY_HANDLE,
+                0,
+            )
+        };
         assert!(mail.decode_kind::<FakeKind>().is_none());
     }
 
@@ -773,8 +836,16 @@ mod tests {
         // The pointer is still valid for `size_of::<FakePod>()` bytes
         // (the `value` allocation), so even if decode did read it
         // would touch only valid memory.
-        let mail =
-            unsafe { Mail::__from_ptr(FakePod::ID.0, ptr_raw, bogus_byte_len, 1, NO_REPLY_HANDLE) };
+        let mail = unsafe {
+            Mail::__from_ptr(
+                FakePod::ID.0,
+                ptr_raw,
+                bogus_byte_len,
+                1,
+                NO_REPLY_HANDLE,
+                0,
+            )
+        };
         assert!(mail.decode_typed::<FakePod>().is_none());
     }
 

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -541,11 +541,14 @@ pub const DISPATCH_UNKNOWN_KIND: u32 = 1;
 pub const DISPATCH_DROPPED_OVERSIZE: u32 = 2;
 
 /// Contract with the guest: it exports a
-/// `receive(kind, ptr, byte_len, count, sender) -> u32` entrypoint
-/// and a `memory` named `memory`. ADR-0013 widened the receive ABI
-/// with a `sender: u32` parameter — a per-instance handle the guest
-/// can pass back to `reply_mail`, or `NO_REPLY_HANDLE` for
-/// component-originated mail. The `byte_len: u32` parameter (added
+/// `receive(kind, ptr, byte_len, count, sender, recipient) -> u32`
+/// entrypoint and a `memory` named `memory`. ADR-0013 widened the
+/// receive ABI with a `sender: u32` parameter — a per-instance handle
+/// the guest can pass back to `reply_mail`, or `NO_REPLY_HANDLE` for
+/// component-originated mail. ADR-0114 decision #1 added the trailing
+/// `recipient: u64` — the mailbox id the substrate routed this mail to
+/// (the actor's own id for a normal actor; an inline-child alias for
+/// the membrane). The `byte_len: u32` parameter (added
 /// to support postcard-shaped receivers per ADR-0033's "any declared
 /// kind" intent) is the total payload size the substrate wrote at
 /// `ptr`, sourced from `mail.payload.len()`. Cast decoders sanity-
@@ -565,7 +568,7 @@ type ReallocFunc = TypedFunc<(u32, u32, u32, u32), u32>;
 pub struct Component {
     store: Store<ComponentCtx>,
     memory: Memory,
-    receive: TypedFunc<(u64, u32, u32, u32, u32), u32>,
+    receive: TypedFunc<(u64, u32, u32, u32, u32, u64), u32>,
     /// Issue 584 Phase 2b: post-init mail-allowed hook. Stored (rather
     /// than called inside [`Self::instantiate`]) so the trampoline
     /// can fire it AFTER its mailbox is registered — issue 640
@@ -762,8 +765,8 @@ impl Component {
         let memory = instance
             .get_memory(&mut store, "memory")
             .ok_or_else(|| wasmtime::Error::msg("guest exports no `memory`"))?;
-        let receive =
-            instance.get_typed_func::<(u64, u32, u32, u32, u32), u32>(&mut store, "receive_p32")?;
+        let receive = instance
+            .get_typed_func::<(u64, u32, u32, u32, u32, u64), u32>(&mut store, "receive_p32")?;
 
         // Optional `init(mailbox_id) -> u32` export: called once before
         // the first `receive`, handed the component's own mailbox id so
@@ -1054,9 +1057,21 @@ impl Component {
         // call site that bypasses `deliver` (today: only test
         // fixtures) doesn't accidentally pick up stale lineage.
         self.store.data().set_in_flight(mail.mail_id, mail.root);
+        // ADR-0114 decision #1: thread the routed recipient through to
+        // the guest as the trailing `receive_p32` frame slot so a guest
+        // handler (and a future inline-child membrane) can read which
+        // address the mail was sent to. For a normally-addressed actor
+        // this equals the actor's own mailbox id.
         let result = self.receive.call(
             &mut self.store,
-            (mail.kind.0, mail_ptr, byte_len, mail.count, handle),
+            (
+                mail.kind.0,
+                mail_ptr,
+                byte_len,
+                mail.count,
+                handle,
+                mail.recipient.0,
+            ),
         );
         self.store.data().clear_in_flight();
         result
@@ -1342,7 +1357,7 @@ mod tests {
     const WAT_HOOKS: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32 i64) (result i32)
                 i32.const 0)
             (func (export "on_dehydrate") (result i32)
                 i32.const 200
@@ -1354,7 +1369,7 @@ mod tests {
     const WAT_NO_HOOKS: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32 i64) (result i32)
                 i32.const 0))
     "#;
 
@@ -1399,7 +1414,7 @@ mod tests {
         (module
             (memory (export "memory") 1)
             {WAT_REALLOC}
-            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32 i64) (result i32)
                 i32.const 16
                 local.get 1
                 i32.store
@@ -1425,7 +1440,7 @@ mod tests {
         (module
             (memory (export "memory") 1)
             {WAT_REALLOC}
-            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32 i64) (result i32)
                 i32.const 0)
             (func (export "init_with_config_p32") (param i64 i32 i32) (result i32)
                 ;; *(u32*)200 = low32(mailbox_id)
@@ -1475,7 +1490,7 @@ mod tests {
     const WAT_INIT_CONFIG_NO_ALLOC: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32 i64) (result i32)
                 i32.const 0)
             (func (export "init_with_config_p32") (param i64 i32 i32) (result i32)
                 i32.const 204
@@ -1495,7 +1510,7 @@ mod tests {
     const WAT_WIRE_UNWIRE: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32 i64) (result i32)
                 i32.const 0)
             (func (export "wire") (param i64) (result i32)
                 i32.const 100
@@ -1522,7 +1537,7 @@ mod tests {
     const WAT_WIRE_TRAPS: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32 i64) (result i32)
                 i32.const 0)
             (func (export "wire") (param i64) (result i32)
                 unreachable))
@@ -1534,7 +1549,7 @@ mod tests {
     const WAT_UNWIRE_TRAPS: &str = r#"
         (module
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32 i64) (result i32)
                 i32.const 0)
             (func (export "unwire") (param i64) (result i32)
                 unreachable))
@@ -1548,7 +1563,7 @@ mod tests {
                 (func $save_state (param i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
             (data (i32.const 300) "\de\ad\be\ef")
-            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32 i64) (result i32)
                 i32.const 0)
             (func (export "on_dehydrate") (result i32)
                 (drop (call $save_state
@@ -1566,7 +1581,7 @@ mod tests {
             (import "aether" "save_state_p32"
                 (func $save_state (param i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
-            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32 i64) (result i32)
                 i32.const 0)
             (func (export "on_dehydrate") (result i32)
                 (drop (call $save_state
@@ -1587,7 +1602,7 @@ mod tests {
         (module
             (memory (export "memory") 1)
             {WAT_REALLOC}
-            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32 i64) (result i32)
                 i32.const 0)
             (func (export "on_rehydrate_p32") (param i32 i32 i32) (result i32)
                 ;; *(u32*)396 = version
@@ -1613,9 +1628,30 @@ mod tests {
         (module
             (memory (export "memory") 1)
             {WAT_REALLOC}
-            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32 i64) (result i32)
                 i32.const 500
                 local.get 4
+                i32.store
+                i32.const 0))
+    "#
+        )
+    }
+
+    /// ADR-0114 decision #1: `receive` stores the low 32 bits of the
+    /// `recipient` param (the 6th, an `i64`) at offset 500 so the test
+    /// can observe the routed mailbox the substrate threaded through.
+    /// Exports `realloc_p32` so even an empty mail has a (non-null)
+    /// region to be placed in.
+    fn wat_stores_recipient() -> String {
+        format!(
+            r#"
+        (module
+            (memory (export "memory") 1)
+            {WAT_REALLOC}
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32 i64) (result i32)
+                i32.const 500
+                local.get 5
+                i32.wrap_i64
                 i32.store
                 i32.const 0))
     "#
@@ -1636,7 +1672,7 @@ mod tests {
                 (func $reply_mail (param i32 i64 i32 i32 i32) (result i32)))
             (memory (export "memory") 1)
             {WAT_REALLOC}
-            (func (export "receive_p32") (param i64 i32 i32 i32 i32) (result i32)
+            (func (export "receive_p32") (param i64 i32 i32 i32 i32 i64) (result i32)
                 (drop (call $reply_mail
                     (local.get 4) ;; sender handle from receive param
                     (i64.const {kind_id}) ;; hashed kind id of "test.pong"
@@ -1989,6 +2025,33 @@ mod tests {
         let mail = SubstrateMail::new(M(0), aether_data::KindId(0), vec![], 1);
         component.deliver(&mail).expect("deliver");
         assert_eq!(component.read_u32(500), NO_REPLY_HANDLE);
+    }
+
+    /// ADR-0114 decision #1 end-to-end through the dispatch unit path:
+    /// `Component::deliver` reads the routed `mail.recipient` and threads
+    /// it as the trailing `receive_p32` frame slot, so the guest reads
+    /// the address its mail was sent to. The production trampoline routes
+    /// a normally-addressed actor's mail with `recipient == self.mailbox`
+    /// (the actor's own id), so the guest sees its own mailbox id; this
+    /// unit fixture sends a distinct recipient to prove the value the
+    /// substrate routes is exactly what the guest receives.
+    #[test]
+    fn deliver_threads_recipient_to_guest() {
+        use crate::mail::{Mail as SubstrateMail, MailboxId as M};
+
+        let mut component = instantiate(&wat_stores_recipient());
+        // A recipient whose low 32 bits are observable through the WAT
+        // fixture's `i32.wrap_i64` store. The high bits (tag nibble +
+        // hash) are dropped by the wrap — the low word is enough to
+        // prove the routed id, not the reply handle, reached the guest.
+        let recipient = M(0x9999_0000_1234_5678);
+        let mail = SubstrateMail::new(recipient, aether_data::KindId(0), vec![], 1);
+        component.deliver(&mail).expect("deliver");
+        assert_eq!(
+            component.read_u32(500),
+            0x1234_5678,
+            "guest must receive the routed recipient's low word as the 6th receive param",
+        );
     }
 
     #[test]

--- a/crates/aether-substrate/src/mail/registry.rs
+++ b/crates/aether-substrate/src/mail/registry.rs
@@ -349,6 +349,14 @@ pub struct OwnedDispatch {
     ///
     /// [`TraceEvent::Received`]: aether_kinds::trace::TraceEvent
     pub enqueue_depth: u32,
+    /// The mailbox this dispatch was routed to (ADR-0114 decision #1).
+    /// For a normally-addressed actor this is the actor's own mailbox
+    /// id; once inline-child aliases exist (ADR-0114) it is the alias
+    /// the producer addressed, which the guest membrane demuxes on.
+    /// Set from the `recipient` parameter the two production mint sites
+    /// already pass; survives release builds (where the debug-only
+    /// `ObligationGuard` that previously held it is compiled out).
+    pub recipient: MailboxId,
     /// ADR-0094 debug-only settlement-obligation guard. Present only
     /// under `#[cfg(debug_assertions)]`; release builds carry no field
     /// (byte-identical to the pre-ADR-0094 layout). Disarmed via
@@ -383,8 +391,6 @@ impl OwnedDispatch {
     ) -> Self {
         #[cfg(debug_assertions)]
         let obligation = ObligationGuard::armed(mail_id, kind_name.clone(), recipient);
-        #[cfg(not(debug_assertions))]
-        let _ = recipient;
         Self {
             kind,
             kind_name,
@@ -397,6 +403,7 @@ impl OwnedDispatch {
             parent_mail,
             t_enqueue,
             enqueue_depth,
+            recipient,
             #[cfg(debug_assertions)]
             obligation,
         }
@@ -405,9 +412,9 @@ impl OwnedDispatch {
     /// Construct an `OwnedDispatch` whose ADR-0094 obligation is
     /// **disarmed** — dropping it without discharge/transfer does not
     /// panic. For test/helper mints, the `noop` handler, and seeds that
-    /// carry no real settlement lineage. `recipient` is recorded only so
-    /// the (never-firing) guard names a mailbox if it is later armed by
-    /// other means; pass `MailboxId(0)` when none is meaningful.
+    /// carry no real settlement lineage. `recipient` is stored on the
+    /// dispatch (and names the never-firing guard's mailbox in debug);
+    /// pass `MailboxId(0)` when none is meaningful.
     ///
     /// `pub` (not `pub(crate)`) because integration tests and sibling
     /// crates' (`aether-capabilities`) tests mint dispatches directly to
@@ -432,8 +439,6 @@ impl OwnedDispatch {
     ) -> Self {
         #[cfg(debug_assertions)]
         let obligation = ObligationGuard::disarmed(mail_id, kind_name.clone(), recipient);
-        #[cfg(not(debug_assertions))]
-        let _ = recipient;
         Self {
             kind,
             kind_name,
@@ -446,6 +451,7 @@ impl OwnedDispatch {
             parent_mail,
             t_enqueue,
             enqueue_depth,
+            recipient,
             #[cfg(debug_assertions)]
             obligation,
         }
@@ -491,6 +497,7 @@ impl Clone for OwnedDispatch {
             parent_mail: self.parent_mail,
             t_enqueue: self.t_enqueue,
             enqueue_depth: self.enqueue_depth,
+            recipient: self.recipient,
             // ADR-0094: a clone is for inspection, never a second live
             // obligation — `ObligationGuard::clone` is disarmed.
             #[cfg(debug_assertions)]
@@ -515,6 +522,7 @@ impl fmt::Debug for OwnedDispatch {
             .field("parent_mail", &self.parent_mail)
             .field("t_enqueue", &self.t_enqueue)
             .field("enqueue_depth", &self.enqueue_depth)
+            .field("recipient", &self.recipient)
             // ADR-0094: the debug-only `obligation` guard is deliberately
             // omitted so `Debug` output is identical across debug/release.
             .finish_non_exhaustive()
@@ -1682,6 +1690,36 @@ mod tests {
         );
         env.discharge();
         drop(env);
+    }
+
+    /// ADR-0114 decision #1: the routed recipient promoted to a real
+    /// `OwnedDispatch` field survives in every build (not just the
+    /// debug-only `ObligationGuard`). Both mint sites stamp it from
+    /// their `recipient` parameter; a clone (for inspection) carries it
+    /// through too.
+    #[test]
+    fn dispatch_carries_routed_recipient() {
+        let recipient = MailboxId(0xABCD);
+        let env = OwnedDispatch::disarmed(
+            KindId(7),
+            "aether.fs.read".to_owned(),
+            None,
+            Source::NONE,
+            MailRef::from(Vec::new()),
+            1,
+            MailId::new(MailboxId(3), 3),
+            MailId::new(MailboxId(3), 3),
+            None,
+            Nanos(0),
+            0,
+            recipient,
+        );
+        assert_eq!(env.recipient, recipient);
+        // The hand-rolled `Clone` must propagate the new field — a clone
+        // is for inspection, but still carries the recipient.
+        let cloned = env.clone();
+        drop(env);
+        assert_eq!(cloned.recipient, recipient);
     }
 
     /// ADR-0094: an armed dispatch that is `mark_transferred()` before


### PR DESCRIPTION
Closes #1911.

## Summary

The substrate routes every mail to a recipient `MailboxId`, but that recipient was dropped before it reached a WASM guest handler — surviving nowhere in release builds, and only inside the ADR-0094 `ObligationGuard` in debug. This threads it through as a first-class value, so a guest handler can read the address its mail was actually sent to. It is the inbound half of ADR-0114 (#1909) — the foundation the inline-child membrane needs to demux mail to the right co-located child.

- `aether-substrate` — `OwnedDispatch` gains a real `recipient: MailboxId` field (set from the existing `armed(...)`/`disarmed(...)` parameter); the wasm host receive call-site passes it into the guest export.
- `aether-actor` — the `export!`-generated `receive_p32` shims gain a trailing `recipient: u64` (widened like the other pointer-path params, ADR-0024); `Mail` gains a `recipient` field and a `recipient() -> MailboxId` accessor, threaded through `__from_raw` / `__from_ptr`.

Purely additive: a normally-addressed actor reads its own mailbox id as the recipient, and existing actors are unaffected. The outbound recipient-as-identity use (ADR-0114 decision #4) is the deferred sibling, not this change.

## Test plan

- `aether-actor` — `mail_recipient_roundtrips_from_raw_address` covers both `Mail` constructors + the accessor across the wasm (`__from_raw`) and host (`__from_ptr`) paths.
- `aether-substrate` — `dispatch_carries_routed_recipient` (the `OwnedDispatch` field) and `deliver_threads_recipient_to_guest` (the host→guest dispatch threads a distinct recipient through to the guest, via a WAT fixture).
- The new 6-param `receive_p32` ABI is exercised end-to-end by the existing component-loading suite (probe / camera / multi-actor / http_handler all dispatch through it) — full `scripts/preflight.sh` green including the wasm32 component cross-build (prebuilt component wasm rebuilt against the new signature).

## Generated by

`/implement` — agent execution of [scoped issue #1911](https://github.com/iamacoffeepot/aether/issues/1911).
