### PR TITLE
refactor(actor): denote instanced actors with a colon, not a dotted discriminator

### DIFF
--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -274,17 +274,16 @@ impl<M: ReplyMode> FfiCtx<'_, M> {
         #[allow(clippy::disallowed_methods)]
         let tag = mailbox_id_from_name(<A as Actor>::NAMESPACE).0;
         let (is_counter, full_subname) = match subname {
-            // `Counter`: pass the type-namespace prefix; the host appends
-            // its monotonic discriminator so the name is globally unique.
-            Subname::Counter => (true, String::from(<A as Actor>::NAMESPACE)),
-            // `Named`: form the full prefixed subname here; validate the
-            // caller-supplied segment before it crosses the FFI.
+            // `Counter`: the host assigns a bare monotonic counter as the
+            // discriminator. No prefix is passed — the host ignores it for
+            // Counter and produces just `n.to_string()`.
+            Subname::Counter => (true, String::new()),
+            // `Named`: validate the caller-supplied segment (no `:`,
+            // no control/whitespace, not empty) then pass it bare as the
+            // flat discriminator — convention: no `.` in a discriminator.
             Subname::Named(name) => {
                 validate_namespace_segment(name).map_err(SpawnError::SubnameInvalid)?;
-                (
-                    false,
-                    alloc::format!("{}.{}", <A as Actor>::NAMESPACE, name),
-                )
+                (false, String::from(name))
             }
         };
         let config_bytes = config.encode_into_bytes();

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -321,12 +321,12 @@ fn multi_actor_unknown_export_errors() {
 /// ADR-0097: a loaded `RootManager` spawns a `Panel` sibling at runtime
 /// via `ctx.spawn_child::<Panel>`. Pinging `RootManager` triggers the
 /// spawn; the spawned `Panel` registers at
-/// `aether.embedded:ui.panel.0` (Counter discriminator), and
-/// pinging *it* makes it broadcast a `TickObserved` to the bench
-/// observer — proving the spawned sibling is addressable and dispatches.
-/// The fire-and-settle send blocks until the whole tree (including the
-/// spawned trampoline's init) drains, so the panel is registered before
-/// the second send routes.
+/// `aether.embedded:0` (Counter discriminator — a flat segment, no type
+/// prefix), and pinging *it* makes it broadcast a `TickObserved` to the
+/// bench observer — proving the spawned sibling is addressable and
+/// dispatches. The fire-and-settle send blocks until the whole tree
+/// (including the spawned trampoline's init) drains, so the panel is
+/// registered before the second send routes.
 #[test]
 fn multi_actor_sibling_spawn() {
     let Some(wasm_path) = require_runtime("multi_actor") else {
@@ -363,11 +363,12 @@ fn multi_actor_sibling_spawn() {
     // ADR-0099 §3/§4: a spawned sibling nests under its spawner, so the
     // Panel registers at the `/`-rendered lineage path — the RootManager's
     // name with the sibling's trampoline segment appended — and its id is
-    // the lineage fold of that path, not `hash("…trampoline:ui.panel.0")`.
-    let panel_name = format!("{root_name}/aether.embedded:ui.panel.0");
+    // the lineage fold of that path, not `hash("…trampoline:0")`.
+    // The Counter discriminator is a flat segment ("0") — no type prefix.
+    let panel_name = format!("{root_name}/aether.embedded:0");
     bench
         .execute(vec![
-            // RootManager spawns a Panel sibling (Counter → ui.panel.0).
+            // RootManager spawns a Panel sibling (Counter → 0).
             (
                 "spawn",
                 BenchOp::send_mail::<Ping>(root_name.as_str(), &Ping { seq: 0 }),
@@ -383,7 +384,7 @@ fn multi_actor_sibling_spawn() {
     assert_eq!(
         bench.count_observed(TICK_OBSERVED),
         1,
-        "the spawned Panel (ui.panel.0) should have dispatched its ping and broadcast once; \
+        "the spawned Panel (0) should have dispatched its ping and broadcast once; \
          observed kinds: {:?}",
         bench.observed_kinds(),
     );

--- a/crates/aether-substrate/src/actor/wasm/host_fns.rs
+++ b/crates/aether-substrate/src/actor/wasm/host_fns.rs
@@ -156,8 +156,9 @@ pub fn register(linker: &mut Linker<ComponentCtx>) -> wasmtime::Result<()> {
             };
             let (subname_prefix, config) = copied;
 
-            // `Counter`: append a discriminator from the live Spawner so
-            // the name is globally unique and known synchronously.
+            // `Counter`: the discriminator is the bare counter value — a
+            // flat segment with no prefix, per the convention that `.`
+            // appears only inside namespace atoms (ADR-0099 §4).
             let full_subname = if is_counter == 0 {
                 subname_prefix
             } else {
@@ -171,7 +172,7 @@ pub fn register(linker: &mut Linker<ComponentCtx>) -> wasmtime::Result<()> {
                     tracing::warn!(target: "aether_substrate::component", "spawn_sibling: no spawner on the binding (counter subname unresolvable)");
                     return 0;
                 };
-                format!("{subname_prefix}.{n}")
+                n.to_string()
             };
 
             // ADR-0099 §3: a spawned sibling nests under this trampoline,

--- a/crates/aether-test-fixtures/examples/multi_actor.rs
+++ b/crates/aether-test-fixtures/examples/multi_actor.rs
@@ -41,8 +41,9 @@ impl FfiActor for RootManager {
     }
 
     /// ADR-0097: on `Ping`, spawn a `Panel` sibling from the same
-    /// resident module. `Subname::Counter` lets the host name it
-    /// `ui.panel.<n>`; the returned `MailboxId` is fire-and-forget here.
+    /// resident module. `Subname::Counter` gives it a bare counter
+    /// discriminator (`0`, `1`, …); the returned `MailboxId` is
+    /// fire-and-forget here.
     #[handler]
     fn on_ping(&mut self, ctx: &mut FfiCtx<'_>, _ping: Ping) {
         let _ = ctx.spawn_child::<Panel>(Subname::Counter, &());

--- a/docs/adr/0099-actor-identity-and-addressing.md
+++ b/docs/adr/0099-actor-identity-and-addressing.md
@@ -82,8 +82,8 @@ atom     := ident ( "." ident )*
 ```
 
 - **`/`** separates nodes — one segment per ActorId in the lineage, root → leaf.
-- **`:`** carries an instanced node's discriminator; the segment around it names that node's ActorId, `hash(NAMESPACE:subname)`.
-- **`.`** is cosmetic, within a single namespace ident — `aether.component` is one segment.
+- **`:`** carries an instanced node's discriminator; the segment around it names that node's ActorId, `hash(NAMESPACE:subname)`. A discriminator is a flat segment — no `.` inside it; an instanced node is `hash(namespace:subname)` where the subname carries no internal `.`.
+- **`.`** is cosmetic, within a single namespace atom — `aether.embedded` is one atom. It does not appear inside a discriminator.
 
 The loaded camera renders as `aether.component/aether.embedded:camera`: root host, child embedding-host class, instance. Because the string is a rendering, a MailboxId is never computed by hashing it — a written path is resolved by parsing it into segments, mapping each segment to its ActorId, and chain-folding (§3). Type addressing never touches the string at all: `ctx.actor::<R>()` resolves R to its id by R's resolution mode (§5), not by the rendered path. The parse is the cold path, paid only by string-addressed callers — MCP, the CLI, `actor_logs`.
 

--- a/docs/guide/systems/components.md
+++ b/docs/guide/systems/components.md
@@ -128,11 +128,11 @@ fn on_open_panel(&mut self, ctx: &mut FfiCtx<'_>, _: OpenPanel) {
 }
 ```
 
-`Subname::Counter` has the host number the instance — `ui.panel.0`, `.1`, … — for
-when you'll track it by the returned `MailboxId`; `Subname::Named("inventory")` gives
-it a stable name you address by. Either way the new instance lives at
+`Subname::Counter` has the host number the instance with a bare counter — `0`, `1`,
+… — for when you'll track it by the returned `MailboxId`; `Subname::Named("inventory")`
+gives it a stable name you address by. Either way the new instance lives at
 `aether.component/aether.embedded:<name>` like any loaded component, and its replies route
-back to the spawner. Spawn stays within the module the instance runs from; a
+back to the spawner. The name after `:` is always a flat segment (no `.`). Spawn stays within the module the instance runs from; a
 different binary comes in through `load_component`, which carries its own code and
 kind vocabulary. This is what lets a wasm crate be a *library* of actors: a UI root
 spawns its panels, a zone manager spawns a per-entity actor for each thing in range —


### PR DESCRIPTION
Closes #1920.

## Summary

ADR-0099 §4 owns the address-rendering grammar but left a gap: it didn't say a discriminator is flat. The wasm `spawn_child` path filled that gap inconsistently — it prefixed a spawned sibling's discriminator with the actor's namespace (`aether.embedded:ui.panel.0`), so the discriminator carried a `.`, while the native spawn path already used a bare counter (`aether.embedded:0`).

This makes the convention uniform: an instanced node is `hash(namespace:subname)` with a **flat** subname — `.` appears only inside a namespace atom like `aether.embedded`, never in a discriminator.

- `aether-actor` (`ffi/ctx.rs`) — `spawn_child` Counter passes no prefix; Named validates the caller's segment and passes it bare (no `.` formed here).
- `aether-substrate` (`actor/wasm/host_fns.rs`) — the host Counter branch produces `n.to_string()` instead of `{prefix}.{n}`.
- `docs/adr/0099-*.md` §4 — a clarifying sentence (a discriminator is a flat segment); `docs/guide/systems/components.md` — the counter example.

## Test plan

- **Addressing stability**: the native `spawn_child` path was already flat, and the loaded-component path (`aether.embedded:NAMESPACE`) is unchanged — only the wasm guest→host spawn path changed, and only the rendering of a *newly* spawned sibling. Addresses are computed fresh each run (no persistence), so no migration. The `multi_actor_sibling_spawn` scenario test passes with the new `aether.embedded:0`.
- Full `scripts/preflight.sh` green (fmt / clippy / nextest 1947 + 101 heavy / wasm cross-build).

## Generated by

`/implement` — agent execution of [scoped issue #1920](https://github.com/iamacoffeepot/aether/issues/1920).
