### PR TITLE
feat(actor): spawn_inline_child primitive for co-located child actors

### DIFF
--- a/crates/aether-actor/src/ffi/bridge/mail.rs
+++ b/crates/aether-actor/src/ffi/bridge/mail.rs
@@ -184,4 +184,32 @@ impl MailBridge {
             )
         }
     }
+
+    /// ADR-0114: register an inline child's alias route and return its
+    /// `MailboxId`. The inline analogue of [`Self::spawn_sibling`]: the
+    /// host folds the alias id onto the parent's lineage carry and
+    /// registers a route to the parent trampoline's own slot, so the
+    /// co-located child is addressable like any actor with no new
+    /// trampoline. `is_counter` selects `Subname::Counter` (the host
+    /// appends a monotonic discriminator) vs a caller-supplied name;
+    /// `subname` is the bare `Named` segment (empty for `Counter`). No
+    /// config crosses here — the guest runs the child's `init` in-process
+    /// (see [`crate::FfiCtx::spawn_inline_child`]). The returned id is the
+    /// ADR-0099 §3 lineage fold, known synchronously; `0` on a host-side
+    /// error.
+    #[must_use]
+    pub fn spawn_inline_child(&self, is_counter: bool, subname: &str) -> u64 {
+        let subname_bytes = subname.as_bytes();
+        // SAFETY: forwards to `raw::spawn_inline_child`, whose ABI is
+        // documented at the import site in `ffi/raw.rs`. The `(ptr, len)`
+        // pair is derived from a reference valid for `len` bytes for the
+        // call's duration; the host copies before returning.
+        unsafe {
+            raw::spawn_inline_child(
+                u32::from(is_counter),
+                subname_bytes.as_ptr().addr() as u32,
+                subname_bytes.len() as u32,
+            )
+        }
+    }
 }

--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -29,11 +29,13 @@ use crate::actor::ctx::resolver::Resolver;
 use crate::actor::{
     Actor, HandlesKind, Instanced, NamespaceError, Singleton, Subname, validate_namespace_segment,
 };
-use crate::ffi::FfiActor;
 use crate::ffi::bridge::{MAIL_BRIDGE, PERSIST_BRIDGE};
+use crate::ffi::inline::INLINE_CHILDREN;
 use crate::ffi::mailbox::FfiActorMailbox;
+use crate::ffi::{BootError, ErasedFfiActor, FfiActor};
 use crate::mail::ReplyHandle;
 use crate::mail::mailbox::{KindId, Mailbox, resolve, resolve_mailbox};
+use alloc::boxed::Box;
 use alloc::string::String;
 
 /// Init-only capability handle for FFI guests. Resolved during
@@ -106,15 +108,27 @@ impl Resolver for FfiInitCtx<'_> {
     }
 }
 
-/// Why a synchronous [`FfiCtx::spawn_child`] call failed before the host
-/// staged the request (ADR-0097). Spawn-time failures — a retired or
-/// in-use subname, or the sibling's `init` returning `Err` — surface
-/// asynchronously on the trampoline, not through this `Result`.
+/// Why a synchronous spawn verb failed.
+///
+/// For the detached [`FfiCtx::spawn_child`] (ADR-0097), only subname
+/// validation can fail here — a spawn-time failure (a retired / in-use
+/// subname, or the sibling's `init` returning `Err`) surfaces
+/// asynchronously on the trampoline, not through this `Result`. For the
+/// inline [`FfiCtx::spawn_inline_child`] (ADR-0114) the child's `init`
+/// runs in-process, synchronously, so its failure is reported here as
+/// [`SpawnError::InitFailed`].
 #[derive(Debug, Clone)]
 pub enum SpawnError {
     /// A [`Subname::Named`] discriminator failed
     /// [`validate_namespace_segment`].
     SubnameInvalid(NamespaceError),
+    /// ADR-0114: an inline child's synchronous `init` returned `Err`. The
+    /// wrapped [`BootError`] carries the actor's own failure message.
+    /// Unlike the detached `spawn_child` — whose `init` runs later on the
+    /// trampoline and logs asynchronously — an inline child's `init` runs
+    /// in-guest during [`FfiCtx::spawn_inline_child`], so the boot failure
+    /// comes back through this `Result`.
+    InitFailed(BootError),
 }
 
 /// Per-receive (and post-init `wire` / pre-shutdown `unwire`)
@@ -273,22 +287,92 @@ impl<M: ReplyMode> FfiCtx<'_, M> {
         // before any lineage carry exists.
         #[allow(clippy::disallowed_methods)]
         let tag = mailbox_id_from_name(<A as Actor>::NAMESPACE).0;
-        let (is_counter, full_subname) = match subname {
-            // `Counter`: the host assigns a bare monotonic counter as the
-            // discriminator. No prefix is passed — the host ignores it for
-            // Counter and produces just `n.to_string()`.
-            Subname::Counter => (true, String::new()),
-            // `Named`: validate the caller-supplied segment (no `:`,
-            // no control/whitespace, not empty) then pass it bare as the
-            // flat discriminator — convention: no `.` in a discriminator.
-            Subname::Named(name) => {
-                validate_namespace_segment(name).map_err(SpawnError::SubnameInvalid)?;
-                (false, String::from(name))
-            }
-        };
+        let (is_counter, full_subname) = resolve_subname(subname)?;
         let config_bytes = config.encode_into_bytes();
         let id = MAIL_BRIDGE.spawn_sibling(tag, is_counter, &full_subname, &config_bytes);
         Ok(MailboxId(id))
+    }
+
+    /// ADR-0114: spawn an **inline child** — a co-located child actor that
+    /// shares this component's WASM instance, slot, and run-token, while
+    /// being addressed and mailed like any actor. The signature mirrors
+    /// [`Self::spawn_child`] (a `Subname`-discriminated `Instanced` type);
+    /// the only difference is co-residency.
+    ///
+    /// The host folds the child's alias [`MailboxId`]
+    /// (`{parent}/aether.embedded:<subname>`) and registers a route to
+    /// this trampoline's own slot; the SDK then runs `A::init`
+    /// **synchronously** (unlike the detached `spawn_child`, whose `init`
+    /// runs later on a fresh trampoline) and inserts the boxed child into
+    /// the ctx-side [`INLINE_CHILDREN`] registry keyed by the alias. Mail
+    /// addressed to the alias lands in this slot and the `export!`
+    /// membrane demuxes it to the child; the child's own sends stamp the
+    /// child's address as origin and its replies route back.
+    ///
+    /// A [`Subname::Named`] that fails validation returns
+    /// [`SpawnError::SubnameInvalid`]; a synchronous `init` `Err` returns
+    /// [`SpawnError::InitFailed`].
+    pub fn spawn_inline_child<A>(
+        &self,
+        subname: Subname<'_>,
+        config: &A::Config,
+    ) -> Result<MailboxId, SpawnError>
+    where
+        // `ErasedFfiActor` is the boxing seam every `#[actor]` type emits
+        // (ADR-0096) — the registry stores the child as `dyn
+        // ErasedFfiActor`, so the bound is the mechanical realisation of
+        // "reuse the existing erasure" (no new child-dispatch trait).
+        A: Instanced + FfiActor + ErasedFfiActor,
+    {
+        let (is_counter, full_subname) = resolve_subname(subname)?;
+        let alias = MailboxId(MAIL_BRIDGE.spawn_inline_child(is_counter, &full_subname));
+        // Re-decode an owned `A::Config` for the in-guest `init` from the
+        // same bytes the detached path would have shipped — symmetric with
+        // `spawn_child`'s encode-in-guest / decode-in-host round-trip, and
+        // it sidesteps a `Clone` bound the detached verb also lacks.
+        let bytes = config.encode_into_bytes();
+        let Some(owned) = <A::Config as Kind>::decode_from_bytes(&bytes) else {
+            return Err(SpawnError::InitFailed(BootError::new(
+                "spawn_inline_child: Config round-trip failed",
+            )));
+        };
+        install_inline_child::<A>(alias, owned)
+    }
+}
+
+/// Resolve a [`Subname`] into the `(is_counter, discriminator)` pair the
+/// spawn host fns take, shared by [`FfiCtx::spawn_child`] and
+/// [`FfiCtx::spawn_inline_child`]. `Counter` passes an empty discriminator
+/// the host ignores (it assigns a bare monotonic counter and produces just
+/// `n.to_string()`); `Named` validates the caller-supplied segment (no `:`,
+/// no control/whitespace, not empty) then passes it bare as the flat
+/// discriminator — convention: no `.` in a discriminator.
+fn resolve_subname(subname: Subname<'_>) -> Result<(bool, String), SpawnError> {
+    match subname {
+        Subname::Counter => Ok((true, String::new())),
+        Subname::Named(name) => {
+            validate_namespace_segment(name).map_err(SpawnError::SubnameInvalid)?;
+            Ok((false, String::from(name)))
+        }
+    }
+}
+
+/// Build an inline child's actor value and register it under its alias
+/// (ADR-0114). Split out of [`FfiCtx::spawn_inline_child`] so the in-guest
+/// `init` + registry insert is exercisable on the host build (where the
+/// `spawn_inline_child` host fn is a panicking stub): the unit test calls
+/// this with a synthetic alias and an owned config.
+fn install_inline_child<A>(alias: MailboxId, config: A::Config) -> Result<MailboxId, SpawnError>
+where
+    A: FfiActor + ErasedFfiActor,
+{
+    let mut ctx = FfiInitCtx::__new(alias.0);
+    match A::init(config, &mut ctx) {
+        Ok(child) => {
+            INLINE_CHILDREN.insert(alias, Box::new(child));
+            Ok(alias)
+        }
+        Err(err) => Err(SpawnError::InitFailed(err)),
     }
 }
 
@@ -511,9 +595,87 @@ impl Persistence for FfiDropCtx<'_> {
 
 #[cfg(test)]
 mod tests {
-    use super::{FfiCtx, Manual, Single};
-    use crate::actor::ctx::OutboundReply;
+    use super::{FfiCtx, Manual, Single, SpawnError, install_inline_child};
+    use crate::Actor;
+    use crate::actor::ctx::{OutboundReply, Resolver};
+    use crate::actor::{Instanced, Subname};
+    use crate::ffi::{BootError, ErasedFfiActor, FfiActor, FfiDropCtx};
+    use crate::mail::{Mail, PriorState};
+    use aether_data::MailboxId;
     use core::mem::{align_of, size_of};
+
+    /// Test inline child whose `init` always fails — drives the
+    /// [`SpawnError::InitFailed`] path. The `ErasedFfiActor` dispatch
+    /// hooks are unreachable: a failed `init` never registers or
+    /// dispatches the child.
+    struct FailingChild;
+
+    impl Actor for FailingChild {
+        const NAMESPACE: &'static str = "test.inline.failing_child";
+    }
+
+    impl Instanced for FailingChild {}
+
+    impl FfiActor for FailingChild {
+        type Config = ();
+        type State = ();
+
+        fn init<C>(_config: (), _ctx: &mut C) -> Result<Self, BootError>
+        where
+            C: Resolver,
+        {
+            Err(BootError::new("inline child init deliberately fails"))
+        }
+    }
+
+    impl ErasedFfiActor for FailingChild {
+        fn erased_namespace(&self) -> &'static str {
+            Self::NAMESPACE
+        }
+        fn erased_dispatch(&mut self, _ctx: &mut FfiCtx<'_, Manual>, _mail: Mail<'_>) -> u32 {
+            unreachable!("a failed-init child is never dispatched")
+        }
+        fn erased_wire(&mut self, _ctx: &mut FfiCtx<'_, Manual>) {
+            unreachable!()
+        }
+        fn erased_unwire(&mut self, _ctx: &mut FfiCtx<'_, Manual>) {
+            unreachable!()
+        }
+        fn erased_on_dehydrate(&mut self, _ctx: &mut FfiDropCtx<'_>) {
+            unreachable!()
+        }
+        fn erased_on_rehydrate(&mut self, _ctx: &mut FfiCtx<'_, Manual>, _prior: PriorState<'_>) {
+            unreachable!()
+        }
+    }
+
+    /// Step 3: a synchronous `init` `Err` surfaces as
+    /// [`SpawnError::InitFailed`] (the inline child runs `init` in-process,
+    /// unlike the detached `spawn_child` whose init failure logs async).
+    /// Exercises [`install_inline_child`] directly so the host build runs
+    /// it without the panicking `spawn_inline_child` host-fn stub.
+    #[test]
+    fn install_inline_child_reports_init_failure() {
+        let result = install_inline_child::<FailingChild>(MailboxId(0x5555), ());
+        assert!(
+            matches!(result, Err(SpawnError::InitFailed(_))),
+            "a failing init must return SpawnError::InitFailed, got {result:?}",
+        );
+    }
+
+    /// Step 3: subname validation parity with `spawn_child` — a
+    /// separator-bearing `Named` subname is rejected up front with
+    /// [`SpawnError::SubnameInvalid`], before any host round-trip (so the
+    /// host build's panicking host-fn stub is never reached).
+    #[test]
+    fn spawn_inline_child_rejects_invalid_subname() {
+        let ctx = FfiCtx::__new(0);
+        let result = ctx.spawn_inline_child::<FailingChild>(Subname::Named("bad:name"), &());
+        assert!(
+            matches!(result, Err(SpawnError::SubnameInvalid(_))),
+            "a separator-bearing subname must return SubnameInvalid, got {result:?}",
+        );
+    }
 
     /// ADR-0112: the mode marker is layout-neutral — the `Single` and
     /// `Manual` views have identical size + alignment. This is the

--- a/crates/aether-actor/src/ffi/inline.rs
+++ b/crates/aether-actor/src/ffi/inline.rs
@@ -1,0 +1,271 @@
+//! Inline-child registry + receive membrane (ADR-0114 decisions #2/#3).
+//!
+//! An inline child shares its parent's WASM instance, slot, and
+//! run-token (ADR-0114). [`FfiCtx::spawn_inline_child`] inserts
+//! the constructed child into the process-global [`INLINE_CHILDREN`]
+//! registry keyed by the child's alias [`MailboxId`]; the
+//! [`crate::export!`] `receive_p32` shims route every inbound mail
+//! through [`membrane_dispatch`], which dispatches the parent when the
+//! routed recipient is the parent's own id and otherwise demuxes to the
+//! co-located child the producer addressed.
+//!
+//! The registry is slot-shaped (take-out / dispatch / reinsert) so a
+//! running child can spawn or mutate siblings through `ctx` while it is
+//! itself dispatched — the registry borrow is never held across a child's
+//! `erased_dispatch`. The guest is single-threaded (ADR-0010 §5) and the
+//! substrate serializes delivery under the run token, so an `UnsafeCell`
+//! with a blanket `Sync` impl is sound — the same argument that licenses
+//! [`crate::Slot`].
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::cell::UnsafeCell;
+
+use aether_data::MailboxId;
+
+use crate::ffi::ErasedFfiActor;
+use crate::ffi::ctx::FfiCtx;
+use crate::mail::Mail;
+
+/// One inline child's slot. `actor` is `None` while the child is taken
+/// out for dispatch (the slot-shaped take / reinsert) and `Some` at rest.
+struct InlineSlot {
+    id: MailboxId,
+    actor: Option<Box<dyn ErasedFfiActor>>,
+}
+
+/// The process-global inline-child registry (ADR-0114 decision #3), keyed
+/// by each child's alias [`MailboxId`]. The membrane demuxes the inbound
+/// recipient against it.
+pub struct InlineRegistry {
+    inner: UnsafeCell<Vec<InlineSlot>>,
+}
+
+// SAFETY: identical argument to [`crate::Slot`] — the WASM guest is
+// single-threaded (ADR-0010 §5) and the substrate serializes delivery
+// under the run token, so `INLINE_CHILDREN` is only ever touched from one
+// thread at a time. On the host unit-test build the static is reached
+// from one test thread.
+unsafe impl Sync for InlineRegistry {}
+
+impl InlineRegistry {
+    /// An empty registry. `const` so it can back a `static`.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            inner: UnsafeCell::new(Vec::new()),
+        }
+    }
+
+    /// Install (or replace) the child registered under `id`.
+    pub fn insert(&self, id: MailboxId, actor: Box<dyn ErasedFfiActor>) {
+        // SAFETY: single-threaded guest + serialized delivery — no other
+        // live borrow of the cell (the `Sync` argument). The borrow is
+        // released before this returns, so it never spans a dispatch.
+        let slots = unsafe { &mut *self.inner.get() };
+        if let Some(slot) = slots.iter_mut().find(|s| s.id == id) {
+            slot.actor = Some(actor);
+        } else {
+            slots.push(InlineSlot {
+                id,
+                actor: Some(actor),
+            });
+        }
+    }
+
+    /// Take the child out for dispatch, leaving its slot empty. Returns
+    /// `None` if `id` names no resident inline child (already taken out,
+    /// or never registered). The borrow drops before the returned box is
+    /// dispatched, so a child may re-enter the registry mid-dispatch.
+    pub fn take(&self, id: MailboxId) -> Option<Box<dyn ErasedFfiActor>> {
+        // SAFETY: see [`Self::insert`].
+        let slots = unsafe { &mut *self.inner.get() };
+        slots
+            .iter_mut()
+            .find(|s| s.id == id)
+            .and_then(|s| s.actor.take())
+    }
+
+    /// Put a child back after dispatch. Pairs with [`Self::take`].
+    pub fn reinsert(&self, id: MailboxId, actor: Box<dyn ErasedFfiActor>) {
+        self.insert(id, actor);
+    }
+}
+
+impl Default for InlineRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The registry the [`crate::export!`] membrane and
+/// [`FfiCtx::spawn_inline_child`] share.
+pub static INLINE_CHILDREN: InlineRegistry = InlineRegistry::new();
+
+/// ADR-0114 decision #3: the receive membrane every `export!`
+/// `receive_p32` shim routes inbound mail through. When the routed
+/// recipient is the parent's own mailbox id, dispatch the parent
+/// (`dispatch_own`); otherwise take the inline child the producer
+/// addressed out of [`INLINE_CHILDREN`], dispatch it with a ctx
+/// self-identified as the child ([`FfiCtx::__new`]), and reinsert. An
+/// unrecognised recipient falls back to the parent's dispatch — the
+/// existing unmatched path (the parent's `#[fallback]`, or the
+/// `DISPATCH_UNKNOWN_KIND` sentinel for a strict receiver), never a
+/// short-circuit drop.
+///
+/// For a normal (non-inline) actor the routed recipient equals the
+/// parent's own id, so the membrane no-ops straight to `dispatch_own` —
+/// the regression guard the whole demux rests on.
+pub fn membrane_dispatch<F>(own_mailbox_id: u64, mail: Mail<'_>, dispatch_own: F) -> u32
+where
+    F: FnOnce(Mail<'_>) -> u32,
+{
+    let recipient = mail.recipient().0;
+    if recipient == own_mailbox_id {
+        return dispatch_own(mail);
+    }
+    let id = MailboxId(recipient);
+    match INLINE_CHILDREN.take(id) {
+        Some(mut child) => {
+            let mut ctx = FfiCtx::__new(recipient);
+            let rc = child.erased_dispatch(&mut ctx, mail);
+            INLINE_CHILDREN.reinsert(id, child);
+            rc
+        }
+        // An alias whose child isn't resident (a race against teardown, or
+        // a stray address) runs the parent's unmatched path rather than
+        // dropping the mail silently.
+        None => dispatch_own(mail),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{INLINE_CHILDREN, InlineRegistry, membrane_dispatch};
+    use crate::FfiCtx;
+    use crate::ffi::ErasedFfiActor;
+    use crate::mail::{Mail, PriorState};
+    use aether_data::MailboxId;
+    use alloc::boxed::Box;
+    use core::sync::atomic::{AtomicU32, Ordering};
+
+    /// Distinct return codes so an assertion can tell which dispatch path
+    /// the membrane took.
+    const OWN_CODE: u32 = 0xA0;
+    const CHILD_CODE: u32 = 0xC0;
+
+    /// Process-global dispatch counter the recording child bumps, so a
+    /// test can prove a child taken out for dispatch was reinserted (a
+    /// second dispatch lands again).
+    static CHILD_DISPATCHES: AtomicU32 = AtomicU32::new(0);
+
+    /// Minimal `ErasedFfiActor` for the membrane tests: records each
+    /// dispatch and returns [`CHILD_CODE`]. The lifecycle hooks are
+    /// unreachable in these tests.
+    struct RecordingChild;
+
+    impl ErasedFfiActor for RecordingChild {
+        fn erased_namespace(&self) -> &'static str {
+            "test.inline.recording_child"
+        }
+        fn erased_dispatch(
+            &mut self,
+            _ctx: &mut FfiCtx<'_, crate::Manual>,
+            _mail: Mail<'_>,
+        ) -> u32 {
+            CHILD_DISPATCHES.fetch_add(1, Ordering::Relaxed);
+            CHILD_CODE
+        }
+        fn erased_wire(&mut self, _ctx: &mut FfiCtx<'_, crate::Manual>) {}
+        fn erased_unwire(&mut self, _ctx: &mut FfiCtx<'_, crate::Manual>) {}
+        fn erased_on_dehydrate(&mut self, _ctx: &mut crate::FfiDropCtx<'_>) {}
+        fn erased_on_rehydrate(
+            &mut self,
+            _ctx: &mut FfiCtx<'_, crate::Manual>,
+            _prior: PriorState<'_>,
+        ) {
+        }
+    }
+
+    /// Build a host-side `Mail` with the given routed recipient; the
+    /// payload pointer is never dereferenced by these tests (the
+    /// recording child doesn't decode), so a dangling-but-unread `ptr`
+    /// with `byte_len = 0` is fine.
+    fn mail_to(recipient: u64) -> Mail<'static> {
+        // SAFETY: `byte_len = 0` so no bytes at `ptr` are ever read; the
+        // membrane and `RecordingChild` only inspect `recipient`.
+        unsafe { Mail::__from_ptr(0, 1, 0, 1, crate::NO_REPLY_HANDLE, recipient) }
+    }
+
+    /// Step 3 coverage: the slot-shaped registry round-trips a child
+    /// through insert → take → reinsert → take.
+    #[test]
+    fn registry_insert_take_reinsert_round_trips() {
+        let registry = InlineRegistry::new();
+        let id = MailboxId(0x1111);
+
+        assert!(registry.take(id).is_none(), "empty registry has no child");
+        registry.insert(id, Box::new(RecordingChild));
+        let taken = registry
+            .take(id)
+            .expect("insert then take returns the child");
+        assert!(
+            registry.take(id).is_none(),
+            "a taken-out slot is empty until reinsert",
+        );
+        registry.reinsert(id, taken);
+        assert!(
+            registry.take(id).is_some(),
+            "reinsert refills the slot for the next dispatch",
+        );
+    }
+
+    /// Step 4 coverage: recipient == own id dispatches the parent, never
+    /// the child registry.
+    #[test]
+    fn membrane_routes_own_recipient_to_parent() {
+        let own = 0x2000_u64;
+        let rc = membrane_dispatch(own, mail_to(own), |_mail| OWN_CODE);
+        assert_eq!(rc, OWN_CODE, "own-id recipient runs the parent dispatch");
+    }
+
+    /// Step 4 coverage: a child-addressed recipient dispatches the child
+    /// and reinserts it, so a second send to the same alias dispatches
+    /// again (the take/reinsert round-trip under the membrane).
+    #[test]
+    fn membrane_routes_child_recipient_and_reinserts() {
+        let own = 0x3000_u64;
+        let child = 0x3001_u64;
+        let before = CHILD_DISPATCHES.load(Ordering::Relaxed);
+        INLINE_CHILDREN.insert(MailboxId(child), Box::new(RecordingChild));
+
+        let rc = membrane_dispatch(own, mail_to(child), |_mail| {
+            panic!("own dispatch must not run for a child recipient")
+        });
+        assert_eq!(rc, CHILD_CODE, "child recipient runs the child dispatch");
+
+        // Reinserted: a second send to the same alias dispatches again.
+        let rc2 = membrane_dispatch(own, mail_to(child), |_mail| {
+            panic!("own dispatch must not run for a reinserted child")
+        });
+        assert_eq!(rc2, CHILD_CODE, "the child was reinserted after dispatch");
+        assert_eq!(
+            CHILD_DISPATCHES.load(Ordering::Relaxed) - before,
+            2,
+            "both sends reached the child",
+        );
+    }
+
+    /// Step 4 coverage: an unrecognised recipient (no resident child) runs
+    /// the parent's unmatched path rather than short-circuit dropping.
+    #[test]
+    fn membrane_routes_unknown_recipient_to_parent_unmatched_path() {
+        let own = 0x4000_u64;
+        let stray = 0x4999_u64;
+        let rc = membrane_dispatch(own, mail_to(stray), |_mail| OWN_CODE);
+        assert_eq!(
+            rc, OWN_CODE,
+            "an unknown recipient falls back to the parent's unmatched path",
+        );
+    }
+}

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -60,6 +60,7 @@ use core::fmt;
 
 pub mod bridge;
 pub mod ctx;
+pub mod inline;
 pub mod mailbox;
 pub mod raw;
 
@@ -791,12 +792,19 @@ macro_rules! __export_internal {
                 <$component as $crate::Actor>::NAMESPACE,
             )
             .0;
-            // ADR-0112: dispatch receives the full `Manual` ctx; the
-            // synthesized `__aether_dispatch` downgrades per handler class.
-            let mut ctx = $crate::FfiCtx::__new(mailbox_id);
             let mail =
                 unsafe { $crate::Mail::__from_raw(kind, ptr, byte_len, count, sender, recipient) };
-            instance.__aether_dispatch(&mut ctx, mail)
+            // ADR-0114: the receive membrane demuxes on the routed
+            // recipient — own id dispatches the parent's handlers, an
+            // inline-child alias dispatches the co-located child. For a
+            // normally-addressed actor the recipient equals `mailbox_id`,
+            // so the closure runs verbatim. ADR-0112: dispatch receives
+            // the full `Manual` ctx; `__aether_dispatch` downgrades per
+            // handler class.
+            $crate::ffi::inline::membrane_dispatch(mailbox_id, mail, move |__aether_mail| {
+                let mut ctx = $crate::FfiCtx::__new(mailbox_id);
+                instance.__aether_dispatch(&mut ctx, __aether_mail)
+            })
         }
 
         /// ADR-0095: the generic guest allocator the substrate delivers every
@@ -1100,12 +1108,17 @@ macro_rules! __export_multi_internal {
                 instance.erased_namespace(),
             )
             .0;
-            // ADR-0112: the boxed `ErasedFfiActor` seam carries the `Manual`
-            // view; the synthesized impl downgrades to `Single` per hook.
-            let mut ctx = $crate::FfiCtx::__new(mailbox_id);
             let mail =
                 unsafe { $crate::Mail::__from_raw(kind, ptr, byte_len, count, sender, recipient) };
-            instance.erased_dispatch(&mut ctx, mail)
+            // ADR-0114: same receive membrane as the single-actor arm —
+            // own id dispatches the entry/boxed type, an inline-child
+            // alias dispatches the co-located child. ADR-0112: the boxed
+            // `ErasedFfiActor` seam carries the `Manual` view; the
+            // synthesized impl downgrades to `Single` per hook.
+            $crate::ffi::inline::membrane_dispatch(mailbox_id, mail, move |__aether_mail| {
+                let mut ctx = $crate::FfiCtx::__new(mailbox_id);
+                instance.erased_dispatch(&mut ctx, __aether_mail)
+            })
         }
 
         /// ADR-0095 guest allocator — identical to the single-actor arm.

--- a/crates/aether-actor/src/ffi/raw.rs
+++ b/crates/aether-actor/src/ffi/raw.rs
@@ -97,6 +97,22 @@ unsafe extern "C" {
         config_ptr: u32,
         config_len: u32,
     ) -> u64;
+    /// ADR-0114: register an inline child's alias route and return its
+    /// `MailboxId`. Unlike [`spawn_sibling`] (which stages a detached
+    /// spawn), this folds the alias id `with_tag(Mailbox,
+    /// fold_lineage(parent_carry, instanced(aether.embedded, subname)))`
+    /// and synchronously registers an alias `MailboxEntry` routing to the
+    /// parent trampoline's own dispatcher slot — the child is co-located
+    /// in the parent's wasm instance, so there is no new trampoline and no
+    /// config (the guest runs `init` in-process). `is_counter` is `1` for
+    /// `Subname::Counter` (the host appends a monotonic discriminator) or
+    /// `0` for a caller-supplied name; `subname_ptr/len` is the bare
+    /// `Named` segment (empty for `Counter`), copied out of guest memory
+    /// before the call returns. The returned id is the ADR-0099 §3 lineage
+    /// fold of the trampoline's carry with the child's node; `0` on a
+    /// host-side error (no memory, OOB, bad UTF-8, no binding/spawner).
+    #[link_name = "spawn_inline_child_p32"]
+    pub fn spawn_inline_child(is_counter: u32, subname_ptr: u32, subname_len: u32) -> u64;
 }
 
 /// Host-side stub for the FFI `aether::send_mail` import. Always
@@ -220,4 +236,20 @@ pub unsafe fn spawn_sibling(
     _config_len: u32,
 ) -> u64 {
     panic!("aether-actor: spawn_sibling called outside the FFI guest");
+}
+
+/// Host-side stub for the FFI `aether::spawn_inline_child` import
+/// (ADR-0114). Always panics — callers outside the FFI guest are
+/// misusing the SDK.
+///
+/// # Safety
+/// FFI-import stub; the wasm32 variant is `unsafe extern "C"`.
+///
+/// # Panics
+/// Always panics — fail-fast per ADR-0063: the host build of the SDK
+/// has no FFI host to call, so any invocation is a bug.
+#[cfg(not(target_arch = "wasm32"))]
+#[must_use]
+pub unsafe fn spawn_inline_child(_is_counter: u32, _subname_ptr: u32, _subname_len: u32) -> u64 {
+    panic!("aether-actor: spawn_inline_child called outside the FFI guest");
 }

--- a/crates/aether-capabilities/src/trampoline.rs
+++ b/crates/aether-capabilities/src/trampoline.rs
@@ -370,8 +370,17 @@ mod native {
                 // `root`. Without this, the trampoline's wrapped Mail
                 // defaults to `MailId::NONE` and the guest's outbound looks
                 // like a fresh root.
+                // ADR-0114 §2: deliver the *routed* recipient as the guest
+                // `Mail`'s recipient, not the trampoline's own id. For a
+                // normally-addressed actor `env.recipient` equals
+                // `self.mailbox`, so this is a no-op; for an inline-child
+                // alias it carries the child's address, which
+                // `Component::deliver` threads to the guest's `receive`
+                // frame + the `ComponentCtx` dispatch identity so the
+                // membrane demuxes to the child and the child's sends stamp
+                // its address as origin.
                 let mail = Mail::new(
-                    self.mailbox,
+                    env.recipient,
                     env.kind,
                     env.payload.bytes().to_vec(),
                     env.count,

--- a/crates/aether-substrate-bundle/tests/fleetbench_inline_child.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_inline_child.rs
@@ -1,0 +1,108 @@
+//! `FleetBench` inline-child proof (issue 1916, ADR-0114 step 5): load a
+//! component that spawns a co-located `InlineChild` in `wire`, then send
+//! to the child's first-class lineage address **by name over the real
+//! `WireFrame::Call` wire** (the same path MCP `send_mail` uses) and
+//! assert the *child* — not the parent — handled the query and its reply
+//! settled back across the wire. A control send to the parent's own
+//! address asserts a normally-addressed actor is unaffected (the membrane
+//! no-ops to the parent).
+//!
+//! This is the headline contract: the inline child is a first-class
+//! address reached directly over the wire. `FleetBench` exercises that
+//! `Call` path end-to-end; the in-engine mechanism (alias routing,
+//! recipient-as-identity, the guest membrane) is covered by the unit
+//! tests in `aether-actor` / `aether-substrate`.
+//!
+//! Heavy by construction (fork+exec + cross-process settle) — the test
+//! lives in `mod tests::heavy` so nextest's `test(/::heavy::/)` selector
+//! serializes it in the `serial-heavy` group.
+
+mod fleetbench;
+
+mod tests {
+    mod heavy {
+        use aether_data::Kind;
+        use aether_test_fixtures::{INLINE_WHO_CHILD, INLINE_WHO_PARENT, InlineEcho, InlineProbe};
+
+        use crate::fleetbench::{FleetBench, dist_manifest_present};
+
+        /// Load `inline_child`, address its inline child by the rendered
+        /// lineage name over the wire, and assert the child replied
+        /// `InlineEcho { who: CHILD }`; then control-send to the parent's
+        /// own address and assert `who: PARENT`. Proves the membrane
+        /// demuxed the same `InlineProbe` kind to the child vs the parent
+        /// purely on the routed recipient, and that both replies settle
+        /// home over the real RPC stack.
+        #[test]
+        fn fleetbench_inline_child_handles_mail_to_its_lineage_address() {
+            if !dist_manifest_present() {
+                return;
+            }
+            let mut bench = FleetBench::start();
+            let engine = bench.spawn_headless();
+            let parent_addr = bench.load(engine, "inline_child");
+
+            // The child's first-class lineage address: the parent's
+            // rendered name plus the inline-child node (ADR-0114).
+            let child_addr = format!("{parent_addr}/aether.embedded:widget");
+
+            // Mail to the child's address: the membrane demuxes it to the
+            // co-located child, which replies with the CHILD marker.
+            let child_replies = bench.send(engine, &child_addr, &InlineProbe);
+            let child_reply = match child_replies.as_slice() {
+                [one] => one,
+                other => panic!(
+                    "the inline child should reply exactly once, got {}",
+                    other.len(),
+                ),
+            };
+            assert_eq!(
+                child_reply.kind,
+                InlineEcho::ID,
+                "the child reply should be an InlineEcho",
+            );
+            let echo = InlineEcho::decode_from_bytes(&child_reply.payload)
+                .expect("the child reply decodes as InlineEcho");
+            assert_eq!(
+                echo.who, INLINE_WHO_CHILD,
+                "the inline child (not the parent) handled the mail to its lineage address",
+            );
+
+            // Control: the same kind to the parent's own address is
+            // unaffected — the membrane no-ops to the parent, which
+            // replies with the PARENT marker.
+            let parent_replies = bench.send(engine, &parent_addr, &InlineProbe);
+            let parent_reply = match parent_replies.as_slice() {
+                [one] => one,
+                other => panic!("the parent should reply exactly once, got {}", other.len()),
+            };
+            assert_eq!(
+                parent_reply.kind,
+                InlineEcho::ID,
+                "the parent reply should be an InlineEcho",
+            );
+            let parent_echo = InlineEcho::decode_from_bytes(&parent_reply.payload)
+                .expect("the parent reply decodes as InlineEcho");
+            assert_eq!(
+                parent_echo.who, INLINE_WHO_PARENT,
+                "a normally-addressed actor is unaffected by the inline-child membrane",
+            );
+
+            // The child query round-trip is recorded as a CallRecord with
+            // the InlineEcho reply, routed to the forked engine.
+            let child_record = bench
+                .calls()
+                .iter()
+                .find(|record| {
+                    record.request_kind == InlineProbe::ID
+                        && record.reply_kinds == vec![InlineEcho::ID]
+                })
+                .expect("the InlineProbe round-trip is recorded as a CallRecord");
+            assert_eq!(
+                child_record.engine,
+                Some(engine),
+                "the InlineProbe is routed to the forked engine",
+            );
+        }
+    }
+}

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -154,6 +154,19 @@ pub struct ComponentCtx {
     in_flight_mail_id: Cell<MailId>,
     /// ADR-0080 §5 in-flight inbound `root`. See `in_flight_mail_id`.
     in_flight_root: Cell<MailId>,
+    /// ADR-0114 decision #4: the mailbox the in-flight inbound was routed
+    /// to — the dispatch's self-identity. Set by [`Component::deliver`]
+    /// from `mail.recipient` before the guest's `receive_p32` shim runs
+    /// (the recipient the capabilities trampoline now forwards as the
+    /// guest `Mail`'s recipient, ADR-0114 §2). Outbound origin stamping
+    /// (`send` / `reply`) reads it via [`Self::dispatch_identity`] so an
+    /// inline child's sends carry the child's address instead of the fixed
+    /// `self.sender`. For a normally-addressed actor it equals `self.sender`
+    /// (the component's own id), so the stamp is unchanged — the
+    /// no-op regression guard. [`MailboxId::NONE`] outside an in-flight
+    /// dispatch (and on substrate-internal call sites that bypass
+    /// `deliver`, e.g. test fixtures), where it falls back to `self.sender`.
+    in_flight_recipient: Cell<MailboxId>,
     /// Issue iamacoffeepot/aether#1465: lineage-`MailId` counter for
     /// [`ComponentCtx::reply`]. A reply echoes the inbound correlation
     /// on its `reply_to` (so it correlates home), but its own trace
@@ -236,6 +249,7 @@ impl ComponentCtx {
             correlation_counter: Cell::new(1),
             in_flight_mail_id: Cell::new(MailId::NONE),
             in_flight_root: Cell::new(MailId::NONE),
+            in_flight_recipient: Cell::new(MailboxId::NONE),
             reply_lineage_counter: Cell::new(REPLY_LINEAGE_BASE),
             pending_spawn: None,
         }
@@ -277,6 +291,21 @@ impl ComponentCtx {
         id
     }
 
+    /// ADR-0114 decision #4: the self-identity outbound mail is stamped
+    /// with — the in-flight dispatch's routed recipient. For an inline
+    /// child (ADR-0114) this is the child's alias, so its sends stamp the
+    /// child's address as origin and its replies route back to the child;
+    /// for a normally-addressed actor it equals `self.sender`, so the
+    /// stamp is unchanged. Falls back to `self.sender` when no recipient
+    /// is in flight (substrate-internal call sites that bypass
+    /// [`Component::deliver`], e.g. test fixtures).
+    fn dispatch_identity(&self) -> MailboxId {
+        match self.in_flight_recipient.get() {
+            id if id == MailboxId::NONE => self.sender,
+            id => id,
+        }
+    }
+
     /// Return the correlation id used by the most recent
     /// `ComponentCtx::send` call. The `prev_correlation_p32` host fn
     /// surfaces this to the guest so a handler can match an inbound
@@ -302,13 +331,18 @@ impl ComponentCtx {
         // (auto-routed by `Mailer::send_reply`) carries it back so a
         // handler can match the reply to this send.
         let correlation = self.mint_correlation();
-        let reply_to = Source::with_correlation(SourceAddr::Component(self.sender), correlation);
+        // ADR-0114 decision #4: stamp origin from the dispatch identity
+        // (the routed recipient) so an inline child's sends carry the
+        // child's address; a normally-addressed actor stamps `self.sender`
+        // unchanged.
+        let identity = self.dispatch_identity();
+        let reply_to = Source::with_correlation(SourceAddr::Component(identity), correlation);
 
         // ADR-0080 §1 (issue iamacoffeepot/aether#722): mint the
         // outbound's MailId from the same correlation that drives
         // reply routing — symmetric with `NativeBinding::send_mail_with_lineage`,
         // which uses one counter for both.
-        let mail_id = MailId::new(self.sender, correlation);
+        let mail_id = MailId::new(identity, correlation);
         self.send_routed(recipient, kind, payload, count, reply_to, mail_id, false);
     }
 
@@ -327,8 +361,9 @@ impl ComponentCtx {
         count: u32,
     ) {
         let correlation = self.mint_correlation();
-        let reply_to = Source::with_correlation(SourceAddr::Component(self.sender), correlation);
-        let mail_id = MailId::new(self.sender, correlation);
+        let identity = self.dispatch_identity();
+        let reply_to = Source::with_correlation(SourceAddr::Component(identity), correlation);
+        let mail_id = MailId::new(identity, correlation);
         self.send_routed(recipient, kind, payload, count, reply_to, mail_id, true);
     }
 
@@ -361,7 +396,10 @@ impl ComponentCtx {
         correlation: u64,
     ) {
         let reply_to = Source::with_correlation(SourceAddr::None, correlation);
-        let mail_id = MailId::new(self.sender, self.next_reply_lineage());
+        // ADR-0114 decision #4: a child's reply stamps the child's
+        // identity (the routed recipient) on its lineage `MailId`, like
+        // its sends; a normally-addressed actor stamps `self.sender`.
+        let mail_id = MailId::new(self.dispatch_identity(), self.next_reply_lineage());
         self.send_routed(recipient, kind, payload, count, reply_to, mail_id, false);
     }
 
@@ -410,8 +448,13 @@ impl ComponentCtx {
             (parent_mail, inherited_root)
         };
         let root = inherited_root.unwrap_or(mail_id);
+        // ADR-0114 decision #4: the recorded source + the `origin` name
+        // stamped below read the dispatch identity (the routed recipient),
+        // so an inline child's mail is attributed to the child's address;
+        // a normally-addressed actor reads `self.sender` unchanged.
+        let identity = self.dispatch_identity();
         self.queue
-            .record_sent(mail_id, root, parent_mail, self.sender, recipient, kind);
+            .record_sent(mail_id, root, parent_mail, identity, recipient, kind);
 
         // Closure-bound (actor-enqueue) and Sink-bound (synchronous
         // handler) recipients dispatch inline here, bypassing the
@@ -436,7 +479,7 @@ impl ComponentCtx {
                 // and move payload + kind_name into it. The bytes
                 // flow straight into the downstream cap's mpsc
                 // envelope without a `to_vec()` clone.
-                let origin = self.registry.mailbox_name(self.sender);
+                let origin = self.registry.mailbox_name(identity);
                 // ADR-0094: the second of two production mint sites
                 // (ComponentCtx's inline send bypasses `route_mail`). Armed
                 // here; the recipient actor's dispatcher discharges it.
@@ -463,7 +506,7 @@ impl ComponentCtx {
             }
             Some(MailboxEntry::Inline(handler)) => {
                 let kind_name = self.registry.kind_name(kind).unwrap_or_default();
-                let origin = self.registry.mailbox_name(self.sender);
+                let origin = self.registry.mailbox_name(identity);
                 handler.dispatch(crate::mail::registry::MailDispatch {
                     kind,
                     kind_name: &kind_name,
@@ -516,11 +559,24 @@ impl ComponentCtx {
         self.in_flight_root.set(root);
     }
 
+    /// ADR-0114 decision #4: publish the in-flight dispatch's routed
+    /// recipient (the dispatch identity) so [`Self::dispatch_identity`]
+    /// stamps a guest-triggered `send` / `reply` with it. Called by
+    /// [`Component::deliver`] alongside [`Self::set_in_flight`], from
+    /// `mail.recipient` (the recipient the capabilities trampoline now
+    /// forwards as the guest `Mail`'s recipient). For a normally-addressed
+    /// actor this equals `self.sender`, so the stamp is unchanged.
+    pub(crate) fn set_in_flight_recipient(&self, recipient: MailboxId) {
+        self.in_flight_recipient.set(recipient);
+    }
+
     /// Clear the in-flight context after the guest's `receive_p32`
-    /// shim returns. Symmetric with [`Self::set_in_flight`].
+    /// shim returns. Symmetric with [`Self::set_in_flight`] /
+    /// [`Self::set_in_flight_recipient`].
     pub(crate) fn clear_in_flight(&self) {
         self.in_flight_mail_id.set(MailId::NONE);
         self.in_flight_root.set(MailId::NONE);
+        self.in_flight_recipient.set(MailboxId::NONE);
     }
 }
 
@@ -1057,11 +1113,17 @@ impl Component {
         // call site that bypasses `deliver` (today: only test
         // fixtures) doesn't accidentally pick up stale lineage.
         self.store.data().set_in_flight(mail.mail_id, mail.root);
+        // ADR-0114 decision #4: publish the routed recipient as the
+        // dispatch identity so a guest-triggered `send` / `reply` stamps
+        // its origin with the address the mail was sent to (the inline
+        // child's alias, or the actor's own id for normal mail). Cleared
+        // alongside the lineage cells after the call.
+        self.store.data().set_in_flight_recipient(mail.recipient);
         // ADR-0114 decision #1: thread the routed recipient through to
         // the guest as the trailing `receive_p32` frame slot so a guest
-        // handler (and a future inline-child membrane) can read which
-        // address the mail was sent to. For a normally-addressed actor
-        // this equals the actor's own mailbox id.
+        // handler (and the inline-child membrane) can read which address
+        // the mail was sent to. For a normally-addressed actor this equals
+        // the actor's own mailbox id.
         let result = self.receive.call(
             &mut self.store,
             (
@@ -2427,5 +2489,164 @@ mod tests {
         );
         assert_eq!(root, mail_id, "detached send is its own root");
         assert_eq!(mail_id.sender, sender);
+    }
+
+    /// ADR-0114 step 1: the inline-child alias id the `spawn_inline_child`
+    /// host fn folds — `with_tag(Mailbox, fold_lineage(parent_carry,
+    /// instanced(aether.embedded, subname)))` — equals the parse → fold of
+    /// the rendered lineage name (`mailbox_id_from_path`), so a wire `Call`
+    /// addressing the child by name resolves to the same id the guest
+    /// keys its membrane on (the post-#1920 convention). The parent carry
+    /// mirrors a depth-2 loaded component (`aether.component/aether.embedded:NAME`).
+    #[test]
+    fn inline_alias_folded_id_matches_post_1920_convention() {
+        let parent_carry = aether_data::fold_lineage(
+            aether_data::ActorId::singleton("aether.component").0,
+            aether_data::ActorId::instanced("aether.embedded", "testparent"),
+        );
+        let folded = MailboxId(aether_data::with_tag(
+            Tag::Mailbox,
+            aether_data::fold_lineage(
+                parent_carry,
+                aether_data::ActorId::instanced(TRAMPOLINE_NAMESPACE, "widget"),
+            ),
+        ));
+        let from_path = aether_data::mailbox_id_from_path(
+            "aether.component/aether.embedded:testparent/aether.embedded:widget",
+        );
+        assert_eq!(
+            folded, from_path,
+            "the host-fn alias fold matches the rendered-name parse → fold",
+        );
+    }
+
+    /// ADR-0114 step 1: an alias `MailboxEntry` cloned from the parent's
+    /// `Inbox` routes mail addressed to the alias into the parent slot's
+    /// inbox, and the rendered alias name resolves (the engine's `Call`
+    /// recipient-name path) to the alias id. Mirrors the `spawn_inline_child`
+    /// host fn's registration against a depth-2 parent registered with its
+    /// lineage-folded id.
+    #[test]
+    fn inline_alias_routes_into_parent_slot_inbox() {
+        let registry = Arc::new(Registry::new());
+        let captured: LineageCapture = Arc::new(Mutex::new(Vec::new()));
+        let captured_for_handler = Arc::clone(&captured);
+        let parent_name = "aether.component/aether.embedded:testparent".to_owned();
+        let parent_id = aether_data::mailbox_id_from_path(&parent_name);
+        registry
+            .try_register_inbox_with_id(
+                parent_id,
+                parent_name.clone(),
+                Arc::new(move |dispatch: OwnedDispatch| {
+                    dispatch.discharge();
+                    captured_for_handler.lock().unwrap().push((
+                        dispatch.mail_id,
+                        dispatch.root,
+                        dispatch.parent_mail,
+                    ));
+                }),
+            )
+            .expect("parent registers under its lineage id");
+
+        // Mirror the host fn: fold the alias id and register an alias route
+        // to the parent's slot by cloning the parent's Inbox handler.
+        let alias_name = format!("{parent_name}/aether.embedded:widget");
+        let alias_id = aether_data::mailbox_id_from_path(&alias_name);
+        let Some(MailboxEntry::Inbox { handler, .. }) = registry.entry(parent_id) else {
+            panic!("parent is registered as a live Inbox");
+        };
+        registry
+            .try_register_inbox_with_id(alias_id, alias_name.clone(), handler)
+            .expect("alias registers under the folded id");
+
+        // Name resolution (the wire `Call` path) resolves the alias.
+        assert_eq!(
+            registry.lookup(&alias_name),
+            Some(alias_id),
+            "the rendered alias name resolves to the folded alias id",
+        );
+
+        // Mail addressed to the alias lands in the parent slot's inbox.
+        let store = Arc::new(HandleStore::new(1024 * 1024));
+        let mailer = Mailer::new(Arc::clone(&registry), store);
+        mailer.push(Mail::new(
+            alias_id,
+            aether_data::KindId(0xABCD),
+            vec![1, 2, 3],
+            1,
+        ));
+        assert_eq!(
+            captured.lock().unwrap().len(),
+            1,
+            "alias mail dispatched into the parent slot's inbox",
+        );
+    }
+
+    /// ADR-0114 step 2: a guest `send` during a dispatch whose routed
+    /// recipient equals the component's own mailbox stamps the component
+    /// as origin — the no-op regression that guards a normally-addressed
+    /// actor.
+    #[test]
+    fn send_stamps_self_when_recipient_is_own_mailbox() {
+        let registry = Arc::new(Registry::new());
+        let (captured, sink_id) =
+            register_lineage_capture_sink(&registry, "inline_self_origin_sink");
+        let store = Arc::new(HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
+        let sender = MailboxId(aether_data::with_tag(Tag::Mailbox, 0x42));
+        let ctx = ComponentCtx::new(
+            sender,
+            Arc::clone(&registry),
+            Arc::clone(&mailer),
+            HubOutbound::disconnected(),
+        );
+
+        // Recipient == own mailbox (a normally-addressed actor).
+        ctx.set_in_flight_recipient(sender);
+        ctx.send(sink_id, aether_data::KindId(0xABCD), vec![], 1);
+
+        let captured = captured.lock().unwrap();
+        let (mail_id, _root, _parent) = captured[0];
+        assert_eq!(
+            mail_id.sender, sender,
+            "origin stamps the component's own id when recipient == self",
+        );
+    }
+
+    /// ADR-0114 step 2: a guest `send` during a dispatch routed to an
+    /// inline-child alias stamps the alias as origin — the recipient
+    /// becomes the dispatch identity, so the child's sends carry the
+    /// child's address.
+    #[test]
+    fn send_stamps_alias_when_recipient_is_inline_child() {
+        let registry = Arc::new(Registry::new());
+        let (captured, sink_id) =
+            register_lineage_capture_sink(&registry, "inline_alias_origin_sink");
+        let store = Arc::new(HandleStore::new(1024 * 1024));
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store));
+        let sender = MailboxId(aether_data::with_tag(Tag::Mailbox, 0x42));
+        let alias = MailboxId(aether_data::with_tag(Tag::Mailbox, 0xA11A5));
+        let ctx = ComponentCtx::new(
+            sender,
+            Arc::clone(&registry),
+            Arc::clone(&mailer),
+            HubOutbound::disconnected(),
+        );
+
+        // Recipient == an inline-child alias distinct from the component's
+        // own id.
+        ctx.set_in_flight_recipient(alias);
+        ctx.send(sink_id, aether_data::KindId(0xABCD), vec![], 1);
+
+        let captured = captured.lock().unwrap();
+        let (mail_id, _root, _parent) = captured[0];
+        assert_eq!(
+            mail_id.sender, alias,
+            "origin stamps the alias (dispatch identity) when recipient is a child",
+        );
+        assert_ne!(
+            mail_id.sender, sender,
+            "the child's send must not stamp the parent component",
+        );
     }
 }

--- a/crates/aether-substrate/src/actor/wasm/host_fns.rs
+++ b/crates/aether-substrate/src/actor/wasm/host_fns.rs
@@ -11,6 +11,7 @@ use wasmtime::{Caller, Linker};
 use crate::actor::wasm::component::{
     ComponentCtx, PendingSpawn, StateBundle, TRAMPOLINE_NAMESPACE,
 };
+use crate::mail::registry::MailboxEntry;
 use crate::mail::{KindId, MailboxId, SourceAddr};
 use crate::runtime::log_install;
 
@@ -198,6 +199,122 @@ pub fn register(linker: &mut Linker<ComponentCtx>) -> wasmtime::Result<()> {
                 config,
             });
             mailbox_id
+        },
+    )?;
+
+    // HOST_FN_OK: ADR-0114 — inline-child spawn is a synchronous host fn,
+    // like `spawn_sibling`. Unlike `spawn_sibling` (which stages a
+    // detached spawn the trampoline drains after `receive`), this needs no
+    // staging: the inline child is co-located in the parent's wasm
+    // instance, so the host only folds the alias id and registers an
+    // *alias* `MailboxEntry` routing to the parent trampoline's own slot —
+    // both the parent's binding carry and the registry are on the
+    // `ComponentCtx`, readable here. The guest runs the child's `init`
+    // in-process and dispatches it behind a membrane keyed on the routed
+    // recipient (`aether-actor`'s `export!`). No config crosses: the guest
+    // owns construction.
+    //
+    // ADR-0114: register an inline child's alias route. The guest passes
+    // an `is_counter` flag and the bare subname (empty for `Counter`). The
+    // alias id is `with_tag(Mailbox, fold_lineage(parent_carry,
+    // instanced(aether.embedded, subname)))` — the same fold a detached
+    // sibling renders post-#1920 (so the synchronous prediction matches a
+    // `Call`-by-name resolution). On any host-side error (no memory, OOB,
+    // bad UTF-8, no binding/spawner, parent not a live Inbox) it warn-logs
+    // and returns 0 without registering — the child simply never becomes
+    // addressable.
+    linker.func_wrap(
+        "aether",
+        "spawn_inline_child_p32",
+        |mut caller: Caller<'_, ComponentCtx>,
+         is_counter: u32,
+         subname_ptr: u32,
+         subname_len: u32|
+         -> u64 {
+            // Copy the subname out of guest memory (empty for `Counter`),
+            // ending the immutable memory borrow before the reads below.
+            let subname_prefix = {
+                let Some(memory) = caller
+                    .get_export("memory")
+                    .and_then(wasmtime::Extern::into_memory)
+                else {
+                    tracing::warn!(target: "aether_substrate::component", "spawn_inline_child: guest exports no memory");
+                    return 0;
+                };
+                let data = memory.data(&caller);
+                let start = subname_ptr as usize;
+                let Some(end) = start
+                    .checked_add(subname_len as usize)
+                    .filter(|e| *e <= data.len())
+                else {
+                    tracing::warn!(target: "aether_substrate::component", "spawn_inline_child: subname pointer out of bounds");
+                    return 0;
+                };
+                let Ok(subname) = from_utf8(&data[start..end]) else {
+                    tracing::warn!(target: "aether_substrate::component", "spawn_inline_child: subname is not valid UTF-8");
+                    return 0;
+                };
+                subname.to_owned()
+            };
+
+            // `Counter`: the discriminator is the bare counter value — the
+            // same source `spawn_sibling` draws from, so inline + detached
+            // children never collide under one parent (ADR-0099 §4).
+            let full_subname = if is_counter == 0 {
+                subname_prefix
+            } else {
+                let Some(n) = caller
+                    .data()
+                    .binding
+                    .as_ref()
+                    .and_then(|binding| binding.spawner())
+                    .map(|spawner| spawner.next_counter())
+                else {
+                    tracing::warn!(target: "aether_substrate::component", "spawn_inline_child: no spawner on the binding (counter subname unresolvable)");
+                    return 0;
+                };
+                n.to_string()
+            };
+
+            let ctx = caller.data();
+            // ADR-0099 §3: fold the alias id onto the parent trampoline's
+            // lineage carry — identical to `spawn_sibling`'s fold, so the
+            // id matches a written-name `Call` resolution.
+            let Some(parent_carry) = ctx.binding.as_ref().map(|binding| binding.carry()) else {
+                tracing::warn!(target: "aether_substrate::component", "spawn_inline_child: no binding on the trampoline (cannot fold alias id)");
+                return 0;
+            };
+            let child_node = aether_data::ActorId::instanced(TRAMPOLINE_NAMESPACE, &full_subname);
+            let alias_id = MailboxId(aether_data::with_tag(
+                aether_data::Tag::Mailbox,
+                aether_data::fold_lineage(parent_carry, child_node),
+            ));
+
+            // Route the alias to the parent trampoline's own slot: clone
+            // the parent's `Inbox` handler under the alias id + the
+            // rendered lineage name, so a producer can address the child by
+            // name (the engine's `Call` recipient-name path) or by the
+            // returned id, and the mail lands in the parent's inbox for the
+            // guest membrane to demux.
+            let Some(MailboxEntry::Inbox { handler, .. }) = ctx.registry.entry(ctx.sender) else {
+                tracing::warn!(target: "aether_substrate::component", "spawn_inline_child: parent slot is not a live Inbox (cannot alias)");
+                return 0;
+            };
+            let Some(parent_name) = ctx.registry.mailbox_name(ctx.sender) else {
+                tracing::warn!(target: "aether_substrate::component", "spawn_inline_child: parent has no registered name (cannot render alias)");
+                return 0;
+            };
+            let alias_name = format!("{parent_name}/{TRAMPOLINE_NAMESPACE}:{full_subname}");
+            if let Err(e) =
+                ctx.registry
+                    .try_register_inbox_with_id(alias_id, alias_name, handler)
+            {
+                // A duplicate alias (same subname spawned twice) keeps the
+                // first route — log it and still return the id so the
+                // guest's re-register is harmless / idempotent.
+                tracing::warn!(target: "aether_substrate::component", "spawn_inline_child: alias registration: {e:?}");
+            }
+            alias_id.0
         },
     )?;
 

--- a/crates/aether-test-fixtures/Cargo.toml
+++ b/crates/aether-test-fixtures/Cargo.toml
@@ -126,5 +126,15 @@ crate-type = ["cdylib"]
 name = "http_handler"
 crate-type = ["cdylib"]
 
+# ADR-0114 inline-child fixture (#1916): the entry `InlineParent` spawns a
+# co-located `InlineChild` in `wire` via `ctx.spawn_inline_child`. Both
+# answer `InlineProbe` with a `who`-tagged `InlineEcho` so the FleetBench
+# scenario can address the child by its first-class lineage name over the
+# wire and assert the membrane demuxed to the child (not the parent).
+# Wasm artifact: target/wasm32-unknown-unknown/{profile}/examples/inline_child.wasm
+[[example]]
+name = "inline_child"
+crate-type = ["cdylib"]
+
 [lints]
 workspace = true

--- a/crates/aether-test-fixtures/examples/inline_child.rs
+++ b/crates/aether-test-fixtures/examples/inline_child.rs
@@ -1,0 +1,90 @@
+//! ADR-0114 inline-child fixture. A single-actor module whose entry
+//! `InlineParent` spawns a co-located `InlineChild` in `wire` via
+//! `ctx.spawn_inline_child::<InlineChild>` (ADR-0114). The child gets a
+//! first-class lineage address (`{parent}/aether.embedded:widget`) routed
+//! to the parent's one slot; the `export!` membrane demuxes mail
+//! addressed to that alias to the child.
+//!
+//! Both actors answer the same `InlineProbe` query with an `InlineEcho`
+//! tagged by `who` handled it, so a `FleetBench` scenario can send to the
+//! child's address over the real wire and assert the *child* (not the
+//! parent) replied — and that a control send to the parent's own address
+//! is unaffected (the membrane no-ops to the parent). `InlineChild` is
+//! `Instanced` (the `spawn_inline_child` bound); it is not in the
+//! `export!` list because an inline child is constructed in-process by
+//! the parent, not instantiated by the host.
+
+// `#[handler::manual]` methods take `&mut self` to match the dispatch ABI
+// even though these stateless replies never read it.
+#![allow(clippy::unused_self)]
+
+use aether_actor::{
+    BootError, FfiActor, FfiCtx, Instanced, Manual, OutboundReply, Resolver, Subname, actor,
+};
+use aether_test_fixtures::{INLINE_WHO_CHILD, INLINE_WHO_PARENT, InlineEcho, InlineProbe};
+
+/// Reply to an `InlineProbe` with the `who` marker of whichever actor
+/// handled it — shared by the parent's own-id (control) path and the
+/// child's demux path — when the probe carries a reply target.
+fn reply_who(ctx: &mut FfiCtx<'_, Manual>, who: u32) {
+    if ctx.reply_target().is_some() {
+        ctx.reply(&InlineEcho { who });
+    }
+}
+
+/// Entry export — the loaded component. Spawns its inline child in `wire`.
+pub struct InlineParent;
+
+#[actor]
+impl FfiActor for InlineParent {
+    const NAMESPACE: &'static str = "test.inline.parent";
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
+    where
+        C: Resolver,
+    {
+        Ok(InlineParent)
+    }
+
+    /// ADR-0114: co-locate an `InlineChild` under the `Named` subname
+    /// `widget`. The returned alias `MailboxId` is fire-and-forget here —
+    /// the `FleetBench` addresses the child by its rendered lineage name.
+    fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
+        let _ = ctx.spawn_inline_child::<InlineChild>(Subname::Named("widget"), &());
+    }
+
+    /// Answer an `InlineProbe` addressed to the parent's own mailbox with
+    /// the parent marker — the membrane's own-id (control) path.
+    #[handler::manual]
+    fn on_probe(&mut self, ctx: &mut FfiCtx<'_, Manual>, _probe: InlineProbe) {
+        reply_who(ctx, INLINE_WHO_PARENT);
+    }
+}
+
+/// Inline child — co-located in the parent's wasm instance. `Instanced`
+/// so it satisfies the `spawn_inline_child` bound; not exported (the
+/// parent constructs it in-process).
+pub struct InlineChild;
+
+impl Instanced for InlineChild {}
+
+#[actor]
+impl FfiActor for InlineChild {
+    const NAMESPACE: &'static str = "test.inline.child";
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
+    where
+        C: Resolver,
+    {
+        Ok(InlineChild)
+    }
+
+    /// Answer an `InlineProbe` addressed to the child's alias with the
+    /// child marker — the membrane's child-demux path.
+    #[handler::manual]
+    fn on_probe(&mut self, ctx: &mut FfiCtx<'_, Manual>, _probe: InlineProbe) {
+        reply_who(ctx, INLINE_WHO_CHILD);
+    }
+}
+
+aether_actor::export!(InlineParent);

--- a/crates/aether-test-fixtures/src/lib.rs
+++ b/crates/aether-test-fixtures/src/lib.rs
@@ -238,6 +238,50 @@ pub struct UiWidgetConfig {
     pub quad_count: u32,
 }
 
+/// ADR-0114 inline-child fixture driver. A unit query sent to either the
+/// parent's own address or its inline child's first-class lineage
+/// address; the recipient replies an [`InlineEcho`] tagged with `who`
+/// handled it, so the `FleetBench` scenario proves the membrane demuxed
+/// the mail to the child (not the parent) and a control to the parent's
+/// own address is unaffected. Postcard-shaped unit struct.
+#[derive(
+    aether_data::Kind,
+    aether_data::Schema,
+    serde::Serialize,
+    serde::Deserialize,
+    Debug,
+    Clone,
+    Default,
+)]
+#[kind(name = "aether.test_fixtures.inline_probe")]
+pub struct InlineProbe;
+
+/// Reply to [`InlineProbe`] — `who` names the actor that handled the
+/// query so the test can assert the demux landed on the child vs the
+/// parent. Postcard-shaped.
+#[derive(
+    aether_data::Kind,
+    aether_data::Schema,
+    serde::Serialize,
+    serde::Deserialize,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+)]
+#[kind(name = "aether.test_fixtures.inline_echo")]
+pub struct InlineEcho {
+    pub who: u32,
+}
+
+/// [`InlineEcho::who`] marker for the parent component (the membrane's
+/// own-id path).
+pub const INLINE_WHO_PARENT: u32 = 1;
+
+/// [`InlineEcho::who`] marker for the inline child (the membrane's
+/// child-alias path).
+pub const INLINE_WHO_CHILD: u32 = 2;
+
 #[cfg(test)]
 mod tests {
     use aether_data::{Kind, Ref};


### PR DESCRIPTION
Closes #1916.

## Summary

Step 3 of the ADR-0114 inline-child arc: the `spawn_inline_child` primitive. A WASM component spawns a child actor co-located in its own wasm instance, slot, and run-token, while the child is addressed and mailed like any actor — `ctx.spawn_inline_child::<Child>(subname, cfg)` returns a first-class lineage `MailboxId` (`{parent}/aether.embedded:{subname}`), mail to that address is delivered to the parent's slot and demuxed to the child, and the child's own sends stamp the child's address as origin. Builds on #1911 (PR #1915, inbound recipient reaches the guest) and #1920 (PR #1923, the `aether.embedded:{subname}` instanced addressing).

The four pieces land together because the primitive is only meaningful end-to-end:

- **Guest SDK (`aether-actor`)** — `FfiCtx::spawn_inline_child<A>` mirrors the post-#1920 `spawn_child` (bare subname, `A: Instanced`), differing only in requesting co-residency; a ctx-side slot-shaped `INLINE_CHILDREN` registry stores the child as `Box<dyn ErasedFfiActor>`; a shared `membrane_dispatch` the `export!` single- and multi-actor `receive_p32` shims route through (own id → parent dispatch, alias → child, unknown → the parent's unmatched path, never a silent drop); `SpawnError::InitFailed` for a synchronous in-guest init error.
- **Substrate (`aether-substrate`)** — the `spawn_inline_child_p32` host fn folds the alias id (`with_tag(Mailbox, fold_lineage(parent_carry, instanced(aether.embedded, subname)))`) and synchronously registers an alias entry routing to the parent trampoline's own slot; `ComponentCtx` gains an `in_flight_recipient` cell and stamps `Source` / `MailId` origin from it, so the routed recipient becomes the dispatch identity.
- **Capabilities (`aether-capabilities`)** — `WasmTrampoline::forward_to_wasm` delivers `env.recipient` as the guest `Mail`'s recipient instead of `self.mailbox`.

For a normally-addressed (non-inline) actor the routed recipient equals its own mailbox id, so both the origin stamp and the membrane no-op — the regression guard the whole design rests on. `NativeBinding` stamping, the scheduler, the run-token model, and the one-Box/one-slot model are untouched. ADR-0114 flips Proposed → Accepted when the arc lands.

## Test plan

- Substrate units (`component.rs`): folded-id-matches-convention, alias-routes-into-parent-inbox, name-resolution-resolves-alias; origin stamp own-mailbox-stamps-the-component (no-op regression) and alias-recipient-stamps-the-alias.
- Guest units (`ffi/inline.rs`): registry insert/take/reinsert round-trip, own/child/unknown membrane routing + reinsert, subname-validation parity, init-failure returns `InitFailed`.
- End-to-end (`tests/fleetbench_inline_child.rs`): a parent component that spawns an `InlineChild` in `wire`; a FleetBench scenario addresses the child by its first-class lineage name over the real `Call` wire and asserts the child (not the parent) handled it, with a control send to the parent unaffected. Marked `mod heavy` (serial-heavy group); gated on the prebuilt component manifest.
- `scripts/preflight.sh` green: fmt, clippy `--workspace --all-targets -D warnings`, doc, `nextest run --workspace` (102 run / 102 passed in the changed scope), and the wasm32 component cross-build (`inline_child` single-actor membrane + the multi-actor membrane fixtures).

## Generated by

`/implement` — agent execution of [scoped issue #1916](https://github.com/iamacoffeepot/aether/issues/1916).
