### PR TITLE
feat(capabilities): aether.fs.copy, host-path-or-namespace source into a namespace destination

### DIFF
--- a/crates/aether-capabilities/src/fs.rs
+++ b/crates/aether-capabilities/src/fs.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 // `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
 // of the mod (always-on, outside the cfg gate).
 use aether_actor::FfiActorMailbox;
-use aether_kinds::{Delete, FsError, List, Read, Write};
+use aether_kinds::{Copy, CopyResult, Delete, FsError, List, NamespaceAddr, Read, Write};
 #[cfg(not(target_arch = "wasm32"))]
 use aether_substrate::actor::native::NativeActorMailbox;
 use std::fs;
@@ -355,6 +355,13 @@ pub trait FsMailboxExt {
     /// Mail `aether.fs.list { namespace, prefix }` to the cap. The
     /// reply enumerates entries under the prefix.
     fn list(&self, namespace: &str, prefix: &str);
+
+    /// Mail `aether.fs.copy { from, to }` to the cap. `from` is a raw
+    /// host filesystem path; `to` is a namespace-address destination. The
+    /// bytes flow host → namespace inside the substrate — they never ride
+    /// the wire. The reply echoes `from` + `to` without bytes, so a
+    /// large-file copy produces a small ack.
+    fn copy(&self, from: &str, to_namespace: &str, to_path: &str);
 }
 
 impl FsMailboxExt for FfiActorMailbox<FsCapability> {
@@ -382,6 +389,16 @@ impl FsMailboxExt for FfiActorMailbox<FsCapability> {
         self.send(&List {
             namespace: namespace.into(),
             prefix: prefix.into(),
+        });
+    }
+    //noinspection DuplicatedCode
+    fn copy(&self, from: &str, to_namespace: &str, to_path: &str) {
+        self.send(&Copy {
+            from: from.into(),
+            to: NamespaceAddr {
+                namespace: to_namespace.into(),
+                path: to_path.into(),
+            },
         });
     }
 }
@@ -414,6 +431,16 @@ impl FsMailboxExt for NativeActorMailbox<'_, FsCapability> {
             prefix: prefix.into(),
         });
     }
+    //noinspection DuplicatedCode
+    fn copy(&self, from: &str, to_namespace: &str, to_path: &str) {
+        self.send(&Copy {
+            from: from.into(),
+            to: NamespaceAddr {
+                namespace: to_namespace.into(),
+                path: to_path.into(),
+            },
+        });
+    }
 }
 
 // The derive emits the Layer + Overlay + `from_env` shims at this scope
@@ -423,12 +450,13 @@ impl FsMailboxExt for NativeActorMailbox<'_, FsCapability> {
 
 #[aether_actor::bridge(singleton)]
 mod native {
+    use std::fs;
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
 
     use super::{
-        AdapterRegistry, Delete, FsError, List, NamespaceRoots, NamespaceRootsLayer, Read, Write,
-        build_registry,
+        AdapterRegistry, Copy, CopyResult, Delete, FsError, List, NamespaceRoots,
+        NamespaceRootsLayer, Read, Write, build_registry, fs_error_from_std,
     };
     use aether_actor::actor;
     use aether_kinds::{DeleteResult, ListResult, ReadResult, WriteResult};
@@ -605,6 +633,48 @@ mod native {
             }
         }
 
+        /// Copy a file from a raw host path into a writable namespace.
+        /// `mail.from` is read via `std::fs::read` directly — not through
+        /// the `FileAdapter` trait — because `from` is an absolute host path
+        /// with no namespace root (the same trust model as `config_path` /
+        /// `binary_path`). The write sandbox applies entirely on the `to`
+        /// side: an unknown namespace → `UnknownNamespace`; a read-only
+        /// namespace or a `to.path` with `..` / leading `/` → `Forbidden`.
+        ///
+        /// # Agent
+        /// Reply: `CopyResult`. Echoes `from` + `to` (no bytes).
+        #[handler]
+        fn on_copy(&self, _ctx: &mut NativeCtx<'_>, mail: Copy) -> CopyResult {
+            let Some(adapter) = self.registry.get(&mail.to.namespace) else {
+                return CopyResult::Err {
+                    from: mail.from,
+                    to: mail.to,
+                    error: FsError::UnknownNamespace,
+                };
+            };
+            let bytes = match fs::read(&mail.from) {
+                Ok(b) => b,
+                Err(e) => {
+                    return CopyResult::Err {
+                        from: mail.from,
+                        to: mail.to,
+                        error: fs_error_from_std(e),
+                    };
+                }
+            };
+            match adapter.write(&mail.to.path, &bytes) {
+                Ok(()) => CopyResult::Ok {
+                    from: mail.from,
+                    to: mail.to,
+                },
+                Err(error) => CopyResult::Err {
+                    from: mail.from,
+                    to: mail.to,
+                    error,
+                },
+            }
+        }
+
         /// Delete a path under a namespace.
         ///
         /// # Agent
@@ -673,13 +743,13 @@ mod native {
     #[cfg(test)]
     mod tests {
         use super::super::{
-            AdapterRegistry, Delete, FileAdapter, FsError, List, LocalFileAdapter, NamespaceRoots,
-            Read, Write,
+            AdapterRegistry, Copy, Delete, FileAdapter, FsError, List, LocalFileAdapter,
+            NamespaceAddr, NamespaceRoots, Read, Write,
         };
         use super::{Arc, FsCapability, Path, PathBuf};
         use aether_actor::Actor;
         use aether_data::MailboxId;
-        use aether_kinds::{DeleteResult, ListResult, ReadResult, WriteResult};
+        use aether_kinds::{CopyResult, DeleteResult, ListResult, ReadResult, WriteResult};
         use aether_substrate::actor::native::binding::NativeBinding;
         use aether_substrate::actor::native::ctx::NativeCtx;
         use aether_substrate::chassis::builder::Builder;
@@ -1276,5 +1346,193 @@ mod native {
         //     `Mailer::send_reply` → component delivery.
         // Reach for the in-bundle integration suite if a future change
         // wants the full WAT roundtrip back as targeted coverage.
+
+        fn build_two_namespace_registry(root: &Path, save_writable: bool) -> Arc<AdapterRegistry> {
+            let save_adapter: Arc<dyn FileAdapter> = Arc::new(
+                LocalFileAdapter::new(root.join("save"), save_writable)
+                    .expect("test setup: save LocalFileAdapter constructs"),
+            );
+            let assets_adapter: Arc<dyn FileAdapter> = Arc::new(
+                LocalFileAdapter::new(root.join("assets"), false)
+                    .expect("test setup: assets LocalFileAdapter constructs"),
+            );
+            let mut r = AdapterRegistry::new();
+            r.register("save", save_adapter);
+            r.register("assets", assets_adapter);
+            Arc::new(r)
+        }
+
+        fn ensure_ns_dirs(root: &Path) {
+            fs::create_dir_all(root.join("save")).expect("test setup: save dir creates");
+            fs::create_dir_all(root.join("assets")).expect("test setup: assets dir creates");
+        }
+
+        #[test]
+        fn cap_copy_host_to_save_roundtrip() {
+            let root = scratch_root("cap-copy-ok");
+            ensure_ns_dirs(&root);
+            let src = root.join("source.bin");
+            fs::write(&src, b"\x0a\x14\x1e").expect("test setup: write source file");
+            let reg = build_save_only_registry(&root.join("save"), true);
+            let reg_clone = Arc::clone(&reg);
+            let fix = TestFixture::new(reg);
+            let mut ctx = fix.ctx(session_sender());
+            let result = fix.cap.on_copy(
+                &mut ctx,
+                Copy {
+                    from: src.to_string_lossy().into_owned(),
+                    to: NamespaceAddr {
+                        namespace: "save".to_string(),
+                        path: "copied.bin".to_string(),
+                    },
+                },
+            );
+            match result {
+                CopyResult::Ok { from, to } => {
+                    assert_eq!(from, src.to_string_lossy().as_ref());
+                    assert_eq!(to.namespace, "save");
+                    assert_eq!(to.path, "copied.bin");
+                }
+                CopyResult::Err { error, .. } => panic!("expected Ok, got Err({error:?})"),
+            }
+            assert_eq!(
+                reg_clone
+                    .get("save")
+                    .expect("test setup: save adapter is registered")
+                    .read("copied.bin")
+                    .expect("test setup: adapter reads copied bytes"),
+                vec![0x0a_u8, 0x14, 0x1e]
+            );
+            cleanup(&root);
+        }
+
+        #[test]
+        fn cap_copy_into_read_only_namespace_replies_forbidden() {
+            let root = scratch_root("cap-copy-ro");
+            ensure_ns_dirs(&root);
+            let src = root.join("source.bin");
+            fs::write(&src, b"x").expect("test setup: write source file");
+            let reg = build_two_namespace_registry(&root, true);
+            let fix = TestFixture::new(reg);
+            let mut ctx = fix.ctx(session_sender());
+            let result = fix.cap.on_copy(
+                &mut ctx,
+                Copy {
+                    from: src.to_string_lossy().into_owned(),
+                    to: NamespaceAddr {
+                        namespace: "assets".to_string(),
+                        path: "data.bin".to_string(),
+                    },
+                },
+            );
+            assert!(
+                matches!(
+                    result,
+                    CopyResult::Err {
+                        error: FsError::Forbidden,
+                        ..
+                    }
+                ),
+                "expected Forbidden, got {result:?}",
+            );
+            cleanup(&root);
+        }
+
+        #[test]
+        fn cap_copy_unknown_destination_namespace_replies_unknown_namespace() {
+            let root = scratch_root("cap-copy-unknown-ns");
+            ensure_ns_dirs(&root);
+            let src = root.join("source.bin");
+            fs::write(&src, b"y").expect("test setup: write source file");
+            let reg = build_save_only_registry(&root.join("save"), true);
+            let fix = TestFixture::new(reg);
+            let mut ctx = fix.ctx(session_sender());
+            let result = fix.cap.on_copy(
+                &mut ctx,
+                Copy {
+                    from: src.to_string_lossy().into_owned(),
+                    to: NamespaceAddr {
+                        namespace: "nope".to_string(),
+                        path: "data.bin".to_string(),
+                    },
+                },
+            );
+            assert!(
+                matches!(
+                    result,
+                    CopyResult::Err {
+                        error: FsError::UnknownNamespace,
+                        ..
+                    }
+                ),
+                "expected UnknownNamespace, got {result:?}",
+            );
+            cleanup(&root);
+        }
+
+        #[test]
+        fn cap_copy_missing_host_from_replies_not_found() {
+            let root = scratch_root("cap-copy-missing-src");
+            ensure_ns_dirs(&root);
+            let reg = build_save_only_registry(&root.join("save"), true);
+            let fix = TestFixture::new(reg);
+            let mut ctx = fix.ctx(session_sender());
+            let result = fix.cap.on_copy(
+                &mut ctx,
+                Copy {
+                    from: root
+                        .join("does_not_exist.bin")
+                        .to_string_lossy()
+                        .into_owned(),
+                    to: NamespaceAddr {
+                        namespace: "save".to_string(),
+                        path: "dst.bin".to_string(),
+                    },
+                },
+            );
+            assert!(
+                matches!(
+                    result,
+                    CopyResult::Err {
+                        error: FsError::NotFound,
+                        ..
+                    }
+                ),
+                "expected NotFound, got {result:?}",
+            );
+            cleanup(&root);
+        }
+
+        #[test]
+        fn cap_copy_to_path_traversal_replies_forbidden() {
+            let root = scratch_root("cap-copy-traversal");
+            ensure_ns_dirs(&root);
+            let src = root.join("source.bin");
+            fs::write(&src, b"z").expect("test setup: write source file");
+            let reg = build_save_only_registry(&root.join("save"), true);
+            let fix = TestFixture::new(reg);
+            let mut ctx = fix.ctx(session_sender());
+            let result = fix.cap.on_copy(
+                &mut ctx,
+                Copy {
+                    from: src.to_string_lossy().into_owned(),
+                    to: NamespaceAddr {
+                        namespace: "save".to_string(),
+                        path: "../escape".to_string(),
+                    },
+                },
+            );
+            assert!(
+                matches!(
+                    result,
+                    CopyResult::Err {
+                        error: FsError::Forbidden,
+                        ..
+                    }
+                ),
+                "expected Forbidden for traversal path, got {result:?}",
+            );
+            cleanup(&root);
+        }
     }
 }

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -2514,6 +2514,54 @@ mod control_plane {
         },
     }
 
+    /// Destination address for `aether.fs.copy`: a logical namespace
+    /// path the substrate resolves through the write adapter registry.
+    /// Only writable namespaces (`save`, `config`) accept a copy; a
+    /// read-only namespace (`assets`) replies `Forbidden` and an unknown
+    /// namespace replies `UnknownNamespace`. `path` is relative to the
+    /// namespace root — `..` and leading `/` are rejected at the adapter
+    /// boundary as `Forbidden`, the same rule that governs `aether.fs.write`.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    pub struct NamespaceAddr {
+        pub namespace: String,
+        pub path: String,
+    }
+
+    /// `aether.fs.copy` — copy a file from a raw host filesystem path
+    /// (`from`) into a writable namespace address (`to`). `from` is an
+    /// absolute host path the substrate reads directly — it is not
+    /// namespace-scoped and carries the same trust level as `config_path`
+    /// / `binary_path` used elsewhere on the substrate. `to` is a
+    /// namespace-address struct; the write sandbox applies on the `to`
+    /// side: a read-only or unknown namespace replies with `Forbidden` /
+    /// `UnknownNamespace`. Reply: `CopyResult`.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.fs.copy")]
+    pub struct Copy {
+        pub from: String,
+        pub to: NamespaceAddr,
+    }
+
+    /// Reply to `Copy`. Both arms echo `from` + `to` for correlation;
+    /// no bytes are echoed so the reply stays small regardless of file
+    /// size. `Err` carries an `FsError` — `NotFound` if `from` is absent
+    /// on the host, `Forbidden` for a read-only destination namespace or
+    /// a `to.path` that contains `..` / a leading `/`, `UnknownNamespace`
+    /// if `to.namespace` was not registered.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.fs.copy_result")]
+    pub enum CopyResult {
+        Ok {
+            from: String,
+            to: NamespaceAddr,
+        },
+        Err {
+            from: String,
+            to: NamespaceAddr,
+            error: FsError,
+        },
+    }
+
     /// `aether.fs.delete` — request the substrate remove a file.
     /// Missing files surface as `NotFound` (not silent success) so
     /// callers that care about the distinction can tell; callers
@@ -4239,6 +4287,8 @@ mod tests {
         assert_eq!(DeleteResult::NAME, "aether.fs.delete_result");
         assert_eq!(List::NAME, "aether.fs.list");
         assert_eq!(ListResult::NAME, "aether.fs.list_result");
+        assert_eq!(Copy::NAME, "aether.fs.copy");
+        assert_eq!(CopyResult::NAME, "aether.fs.copy_result");
         assert_eq!(Manifest::NAME, "aether.inventory.manifest");
         assert_eq!(ManifestResult::NAME, "aether.inventory.manifest_result");
         assert_eq!(Resolve::NAME, "aether.inventory.resolve");

--- a/docs/guide/systems/file-io.md
+++ b/docs/guide/systems/file-io.md
@@ -47,6 +47,7 @@ Each request kind pairs with a reply kind that names the same operation:
 | `aether.fs.write` | `namespace`, `path`, `bytes` | `aether.fs.write_result` | — (ack) |
 | `aether.fs.delete` | `namespace`, `path` | `aether.fs.delete_result` | — (ack) |
 | `aether.fs.list` | `namespace`, `prefix` | `aether.fs.list_result` | `entries` |
+| `aether.fs.copy` | `from`, `to` | `aether.fs.copy_result` | — (ack) |
 
 Each reply is an `Ok` / `Err` enum. Every arm — including the bare `write` /
 `delete` acks — echoes the request's `namespace` + `path` (or `prefix`); the


### PR DESCRIPTION
Closes #1928.

## Summary

`aether.fs.write { namespace, path, bytes }` was the only way to land bytes into a namespace, and it carries the bytes inline — for anything file-sized that inlines the whole payload into the `send_mail` call and the settlement trace, exactly what the path-staging convention (`config_path` / `payload_path` / `binary_path`) exists to avoid elsewhere.

This adds `aether.fs.copy { from, to }` as its own fs op so bytes flow reference-to-reference: `from` is a raw host filesystem path the substrate reads single-host, `to` is a writable-namespace address `{ namespace, path }`, and the bytes move host → namespace inside the substrate without ever appearing in the call or the trace. An agent can Bash-write generated content to a temp host file, then copy it into `save://…` in one call.

The write sandbox stays honest, and the boundary lives entirely on the write side:

- The host read is a direct `std::fs::read(&from)` that deliberately does not go through the namespace-scoped `FileAdapter` (there is no root for an absolute host path), and there is no `..` rejection on `from` — it is an explicit trusted single-host path, the same trust model as `config_path` / `binary_path`.
- The destination resolves through `registry.get(&to.namespace)`, so an unknown namespace replies `UnknownNamespace`, a read-only namespace (`assets`) replies `Forbidden`, and `LocalFileAdapter::resolve` rejects `..` / absolute / leading-`/` in `to.path`.

`write` stays the inline primitive; `copy` is the reference op. No `aether-mcp`, `FileAdapter`-trait, or wire/RPC change — `from` rides the wire kind as a plain string the substrate reads, so `aether.fs.copy` is sendable through `send_mail` and self-describes via `describe_kinds`. Additive, consistent with ADR-0041's namespace permission model — no ADR.

## Test plan

`crates/aether-capabilities/src/fs.rs` `mod native::tests`, mirroring the `cap_write_*` tests:
- host-temp-file → `save` round-trip (bytes resident, `Ok` echoes `from` + `to`)
- copy into a read-only namespace → `Forbidden`
- unknown destination namespace → `UnknownNamespace`
- missing host `from` → `NotFound`
- `to.path` traversal (`../escape`) → `Forbidden`

`scripts/preflight.sh` green: fmt, clippy `--workspace --all-targets -D warnings`, doc, `nextest run --workspace` (101 run / 101 passed in the changed scope), and the wasm32 component cross-build.

## Generated by

`/implement` — agent execution of [scoped issue #1928](https://github.com/iamacoffeepot/aether/issues/1928).
