### PR TITLE
feat(actor): persist and reconstruct inline children across replace_component

### DIFF
--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -37,6 +37,7 @@ use crate::mail::ReplyHandle;
 use crate::mail::mailbox::{KindId, Mailbox, resolve, resolve_mailbox};
 use alloc::boxed::Box;
 use alloc::string::String;
+use alloc::vec::Vec;
 
 /// Init-only capability handle for FFI guests. Resolved during
 /// `FfiActor::init`; not available at runtime (the type split fences
@@ -336,7 +337,13 @@ impl<M: ReplyMode> FfiCtx<'_, M> {
                 "spawn_inline_child: Config round-trip failed",
             )));
         };
-        install_inline_child::<A>(alias, owned)
+        // The actor-type tag the rehydrate reconstruct matches against the
+        // module's exported types (ADR-0114 §5) — the same `hash(NAMESPACE)`
+        // tag `init_typed_p32` selects on. This is the id definition for the
+        // child type, so the disallowed-method allow mirrors `spawn_child`.
+        #[allow(clippy::disallowed_methods)]
+        let type_tag = mailbox_id_from_name(<A as Actor>::NAMESPACE).0;
+        install_inline_child::<A>(alias, type_tag, full_subname, is_counter, owned)
     }
 }
 
@@ -362,14 +369,30 @@ fn resolve_subname(subname: Subname<'_>) -> Result<(bool, String), SpawnError> {
 /// `init` + registry insert is exercisable on the host build (where the
 /// `spawn_inline_child` host fn is a panicking stub): the unit test calls
 /// this with a synthetic alias and an owned config.
-fn install_inline_child<A>(alias: MailboxId, config: A::Config) -> Result<MailboxId, SpawnError>
+///
+/// ADR-0114 §5: `type_tag` / `full_subname` / `is_counter` are recorded in
+/// the slot so a `replace_component` swap can reconstruct the child by
+/// type and re-fold its metadata.
+fn install_inline_child<A>(
+    alias: MailboxId,
+    type_tag: u64,
+    full_subname: String,
+    is_counter: bool,
+    config: A::Config,
+) -> Result<MailboxId, SpawnError>
 where
     A: FfiActor + ErasedFfiActor,
 {
     let mut ctx = FfiInitCtx::__new(alias.0);
     match A::init(config, &mut ctx) {
         Ok(child) => {
-            INLINE_CHILDREN.insert(alias, Box::new(child));
+            INLINE_CHILDREN.insert_child(
+                alias,
+                type_tag,
+                full_subname,
+                is_counter,
+                Box::new(child),
+            );
             Ok(alias)
         }
         Err(err) => Err(SpawnError::InitFailed(err)),
@@ -477,6 +500,27 @@ impl OutboundReply for FfiCtx<'_, Manual> {
     }
 }
 
+/// A `save_state` deposit captured in memory instead of forwarded to the
+/// host `save_state` import (ADR-0114 §5). The dehydrate compose hands the
+/// parent and each inline child a [`FfiDropCtx`] bound to one of these so
+/// it can collect every saved blob and pack them into a single composite,
+/// then call the real host `save_state` once.
+#[derive(Default)]
+pub struct CapturedState {
+    /// The most recent `(version, bytes)` the hook saved. `None` until the
+    /// hook calls `save_state`; the last call wins (mirroring the host's
+    /// single-`Option<StateBundle>` overwrite contract).
+    saved: Option<(u32, Vec<u8>)>,
+}
+
+impl CapturedState {
+    /// Take the captured `(version, bytes)`, leaving the slot empty.
+    #[must_use]
+    pub fn take(&mut self) -> Option<(u32, Vec<u8>)> {
+        self.saved.take()
+    }
+}
+
 /// Narrowed capability handle for the `on_dehydrate` save hook.
 /// Outbound mail still works through [`MailSender`]; the reply / resolve
 /// surfaces are intentionally absent.
@@ -485,28 +529,55 @@ pub struct FfiDropCtx<'a> {
     /// `send` resolves the receiver through `R::resolve(self.mailbox)`
     /// like every other ctx (ADR-0099 §5).
     mailbox: u64,
+    /// ADR-0114 §5: when `Some`, `save_state` records into this buffer
+    /// instead of the host import, so the dehydrate compose can collect
+    /// the parent's and each child's bundle and pack one composite. `None`
+    /// is the ordinary path — `save_state` forwards to the host.
+    capture: Option<&'a mut CapturedState>,
     _borrow: PhantomData<&'a ()>,
 }
 
-impl FfiDropCtx<'_> {
+impl<'a> FfiDropCtx<'a> {
     /// Not part of the public API; called only by [`crate::export!`].
+    /// Forwards `save_state` to the host import.
     #[doc(hidden)]
     #[must_use]
     pub fn __new(mailbox: u64) -> Self {
         Self {
             mailbox,
+            capture: None,
+            _borrow: PhantomData,
+        }
+    }
+
+    /// Not part of the public API; called only by the dehydrate compose
+    /// (`crate::ffi::inline_compose`). `save_state` records into `capture`
+    /// rather than the host import, so the composite can be assembled
+    /// before a single real host `save_state`.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn __new_capturing(mailbox: u64, capture: &'a mut CapturedState) -> Self {
+        Self {
+            mailbox,
+            capture: Some(capture),
             _borrow: PhantomData,
         }
     }
 
     /// Deposit a migration bundle. Mirrors [`Persistence::save_state`].
+    /// When this ctx was built capturing (ADR-0114 §5), the deposit is
+    /// recorded in the capture buffer; otherwise it forwards to the host.
     ///
     /// # Panics
     /// Panics if the host `save_state` import returns non-zero — fail-fast
     /// per ADR-0063: the persistence bridge is part of the substrate
     /// contract and a failure here means the runtime is in an
-    /// unrecoverable state.
+    /// unrecoverable state. (The capturing path cannot fail.)
     pub fn save_state(&mut self, version: u32, bytes: &[u8]) {
+        if let Some(capture) = self.capture.as_mut() {
+            capture.saved = Some((version, bytes.to_vec()));
+            return;
+        }
         let status = PERSIST_BRIDGE.save_state(version, bytes);
         assert_eq!(
             status, 0,
@@ -585,11 +656,11 @@ impl MailSender for FfiDropCtx<'_> {
 
 impl Persistence for FfiDropCtx<'_> {
     fn save_state(&mut self, version: u32, bytes: &[u8]) {
-        let status = PERSIST_BRIDGE.save_state(version, bytes);
-        assert_eq!(
-            status, 0,
-            "aether-actor: save_state failed (status {status})"
-        );
+        // Route through the inherent `save_state` so the ADR-0114 §5
+        // capture path applies — the generated `on_dehydrate` hooks reach
+        // the bundle through `Persistence::save_state_kind`, which calls
+        // this trait method, so a capturing ctx must intercept here too.
+        FfiDropCtx::save_state(self, version, bytes);
     }
 }
 
@@ -602,6 +673,7 @@ mod tests {
     use crate::ffi::{BootError, ErasedFfiActor, FfiActor, FfiDropCtx};
     use crate::mail::{Mail, PriorState};
     use aether_data::MailboxId;
+    use alloc::string::String;
     use core::mem::{align_of, size_of};
 
     /// Test inline child whose `init` always fails — drives the
@@ -656,7 +728,13 @@ mod tests {
     /// it without the panicking `spawn_inline_child` host-fn stub.
     #[test]
     fn install_inline_child_reports_init_failure() {
-        let result = install_inline_child::<FailingChild>(MailboxId(0x5555), ());
+        let result = install_inline_child::<FailingChild>(
+            MailboxId(0x5555),
+            0,
+            String::from("child"),
+            false,
+            (),
+        );
         assert!(
             matches!(result, Err(SpawnError::InitFailed(_))),
             "a failing init must return SpawnError::InitFailed, got {result:?}",

--- a/crates/aether-actor/src/ffi/inline.rs
+++ b/crates/aether-actor/src/ffi/inline.rs
@@ -18,6 +18,7 @@
 //! [`crate::Slot`].
 
 use alloc::boxed::Box;
+use alloc::string::String;
 use alloc::vec::Vec;
 use core::cell::UnsafeCell;
 
@@ -29,9 +30,45 @@ use crate::mail::Mail;
 
 /// One inline child's slot. `actor` is `None` while the child is taken
 /// out for dispatch (the slot-shaped take / reinsert) and `Some` at rest.
+///
+/// ADR-0114 §5: the slot also records the metadata a `replace_component`
+/// swap needs to reconstruct the child in the fresh instance — the
+/// actor-type tag (`mailbox_id_from_name(NAMESPACE)`, the same tag
+/// `init_typed_p32` matches a reconstruct on) plus the resolved
+/// `full_subname` / `is_counter` the alias id was folded from, so the
+/// rehydrate path re-folds the identical alias and re-`init`s the child
+/// by type.
 struct InlineSlot {
     id: MailboxId,
+    /// `mailbox_id_from_name(A::NAMESPACE)` — the actor-type tag the
+    /// rehydrate reconstruct matches against the module's exported types.
+    type_tag: u64,
+    /// The resolved discriminator the alias id was folded from (a counter
+    /// child's monotonic value is already resolved here, not the
+    /// unresolved `Counter` marker), so re-folding on rehydrate is
+    /// deterministic.
+    full_subname: String,
+    /// Whether the host should treat `full_subname` as a counter prefix on
+    /// re-fold; always `false` after resolution, but carried so the
+    /// rehydrate call mirrors the original `spawn_inline_child` shape.
+    is_counter: bool,
     actor: Option<Box<dyn ErasedFfiActor>>,
+}
+
+/// A cloneable snapshot of one resident inline child's reconstruct
+/// metadata (no actor box), produced by [`InlineRegistry::child_metas`]
+/// for the dehydrate walk. The compose path reads each child's state
+/// through [`InlineRegistry::with_child_mut`] keyed by `id`.
+#[derive(Clone)]
+pub struct InlineChildMeta {
+    /// The child's alias [`MailboxId`] (the registry key).
+    pub id: MailboxId,
+    /// The actor-type tag — `mailbox_id_from_name(NAMESPACE)`.
+    pub type_tag: u64,
+    /// The resolved subname the alias id was folded from.
+    pub full_subname: String,
+    /// Whether the original spawn used a counter discriminator.
+    pub is_counter: bool,
 }
 
 /// The process-global inline-child registry (ADR-0114 decision #3), keyed
@@ -57,28 +94,45 @@ impl InlineRegistry {
         }
     }
 
-    /// Install (or replace) the child registered under `id`.
-    pub fn insert(&self, id: MailboxId, actor: Box<dyn ErasedFfiActor>) {
+    /// Register a freshly-spawned (or reconstructed) inline child under
+    /// `id`, recording the reconstruct metadata alongside the actor box.
+    /// Replaces the actor + metadata if `id` is already present (a
+    /// re-spawn / rehydrate re-register of the same alias).
+    pub fn insert_child(
+        &self,
+        id: MailboxId,
+        type_tag: u64,
+        full_subname: String,
+        is_counter: bool,
+        actor: Box<dyn ErasedFfiActor>,
+    ) {
         // SAFETY: single-threaded guest + serialized delivery — no other
         // live borrow of the cell (the `Sync` argument). The borrow is
         // released before this returns, so it never spans a dispatch.
         let slots = unsafe { &mut *self.inner.get() };
         if let Some(slot) = slots.iter_mut().find(|s| s.id == id) {
+            slot.type_tag = type_tag;
+            slot.full_subname = full_subname;
+            slot.is_counter = is_counter;
             slot.actor = Some(actor);
         } else {
             slots.push(InlineSlot {
                 id,
+                type_tag,
+                full_subname,
+                is_counter,
                 actor: Some(actor),
             });
         }
     }
 
-    /// Take the child out for dispatch, leaving its slot empty. Returns
+    /// Take the child out for dispatch, leaving its slot (and its
+    /// reconstruct metadata) intact but the actor box empty. Returns
     /// `None` if `id` names no resident inline child (already taken out,
     /// or never registered). The borrow drops before the returned box is
     /// dispatched, so a child may re-enter the registry mid-dispatch.
     pub fn take(&self, id: MailboxId) -> Option<Box<dyn ErasedFfiActor>> {
-        // SAFETY: see [`Self::insert`].
+        // SAFETY: see [`Self::insert_child`].
         let slots = unsafe { &mut *self.inner.get() };
         slots
             .iter_mut()
@@ -86,9 +140,53 @@ impl InlineRegistry {
             .and_then(|s| s.actor.take())
     }
 
-    /// Put a child back after dispatch. Pairs with [`Self::take`].
+    /// Put a child back after dispatch, into its existing slot (metadata
+    /// preserved). Pairs with [`Self::take`]; the slot is guaranteed to
+    /// exist because `take` left it in place with an empty actor box.
     pub fn reinsert(&self, id: MailboxId, actor: Box<dyn ErasedFfiActor>) {
-        self.insert(id, actor);
+        // SAFETY: see [`Self::insert_child`].
+        let slots = unsafe { &mut *self.inner.get() };
+        if let Some(slot) = slots.iter_mut().find(|s| s.id == id) {
+            slot.actor = Some(actor);
+        }
+    }
+
+    /// Snapshot the reconstruct metadata of every resident inline child
+    /// (ADR-0114 §5 dehydrate walk). The actor boxes stay in the
+    /// registry; the compose path reads each child's state through
+    /// [`Self::with_child_mut`] keyed by the returned `id`.
+    #[must_use]
+    pub fn child_metas(&self) -> Vec<InlineChildMeta> {
+        // SAFETY: see [`Self::insert_child`].
+        let slots = unsafe { &*self.inner.get() };
+        slots
+            .iter()
+            .map(|slot| InlineChildMeta {
+                id: slot.id,
+                type_tag: slot.type_tag,
+                full_subname: slot.full_subname.clone(),
+                is_counter: slot.is_counter,
+            })
+            .collect()
+    }
+
+    /// Run `f` against the child registered under `id` with a unique
+    /// mutable borrow held only for the call, returning its result (or
+    /// `None` if `id` names no resident child). Used by the dehydrate
+    /// compose to drive each child's `erased_on_dehydrate` in place. The
+    /// borrow drops before this returns, so it never spans a dispatch.
+    pub fn with_child_mut<R>(
+        &self,
+        id: MailboxId,
+        f: impl FnOnce(&mut dyn ErasedFfiActor) -> R,
+    ) -> Option<R> {
+        // SAFETY: see [`Self::insert_child`].
+        let slots = unsafe { &mut *self.inner.get() };
+        slots
+            .iter_mut()
+            .find(|s| s.id == id)
+            .and_then(|s| s.actor.as_deref_mut())
+            .map(f)
     }
 }
 
@@ -147,6 +245,7 @@ mod tests {
     use crate::mail::{Mail, PriorState};
     use aether_data::MailboxId;
     use alloc::boxed::Box;
+    use alloc::string::String;
     use core::sync::atomic::{AtomicU32, Ordering};
 
     /// Distinct return codes so an assertion can tell which dispatch path
@@ -205,7 +304,13 @@ mod tests {
         let id = MailboxId(0x1111);
 
         assert!(registry.take(id).is_none(), "empty registry has no child");
-        registry.insert(id, Box::new(RecordingChild));
+        registry.insert_child(
+            id,
+            0,
+            String::from("widget"),
+            false,
+            Box::new(RecordingChild),
+        );
         let taken = registry
             .take(id)
             .expect("insert then take returns the child");
@@ -218,6 +323,33 @@ mod tests {
             registry.take(id).is_some(),
             "reinsert refills the slot for the next dispatch",
         );
+    }
+
+    /// Step 1 coverage: a spawned child's slot carries its actor-type tag
+    /// and resolved subname, surfaced through `child_metas` for the
+    /// dehydrate walk.
+    #[test]
+    fn child_metas_carry_type_tag_and_subname() {
+        let registry = InlineRegistry::new();
+        let id = MailboxId(0x7777);
+        let tag = 0xABCD_u64;
+        registry.insert_child(
+            id,
+            tag,
+            String::from("widget"),
+            false,
+            Box::new(RecordingChild),
+        );
+
+        let metas = registry.child_metas();
+        let meta = match metas.as_slice() {
+            [one] => one,
+            other => panic!("expected exactly one child meta, got {}", other.len()),
+        };
+        assert_eq!(meta.id, id, "the meta carries the alias id");
+        assert_eq!(meta.type_tag, tag, "the meta carries the actor-type tag");
+        assert_eq!(meta.full_subname, "widget", "the meta carries the subname");
+        assert!(!meta.is_counter, "a Named subname is not a counter");
     }
 
     /// Step 4 coverage: recipient == own id dispatches the parent, never
@@ -237,7 +369,13 @@ mod tests {
         let own = 0x3000_u64;
         let child = 0x3001_u64;
         let before = CHILD_DISPATCHES.load(Ordering::Relaxed);
-        INLINE_CHILDREN.insert(MailboxId(child), Box::new(RecordingChild));
+        INLINE_CHILDREN.insert_child(
+            MailboxId(child),
+            0,
+            String::from("widget"),
+            false,
+            Box::new(RecordingChild),
+        );
 
         let rc = membrane_dispatch(own, mail_to(child), |_mail| {
             panic!("own dispatch must not run for a child recipient")

--- a/crates/aether-actor/src/ffi/inline_bundle.rs
+++ b/crates/aether-actor/src/ffi/inline_bundle.rs
@@ -1,0 +1,335 @@
+//! Composite migration bundle for inline children (ADR-0114 §5).
+//!
+//! A `replace_component` swap carries one `StateBundle`
+//! (`aether_substrate::actor::wasm::component::StateBundle`) across the
+//! splice — a single `Option<StateBundle>` the host overwrites on a second
+//! `save_state`, so the parent and its co-located inline children
+//! **cannot** save separately; they pack into one composite. This module
+//! is the encode / decode for that composite.
+//!
+//! The no-regression guard is byte-identity: a component with **zero**
+//! inline children must compose to exactly the bytes (and version) its
+//! own `on_dehydrate` produced today, so a childless component
+//! hot-reloads unchanged. [`compose`] enforces that by passing the
+//! parent's `(version, bytes)` through verbatim when the child list is
+//! empty; the framed layout is used only when at least one child is
+//! present, gated by a reserved `version` discriminator plus a magic
+//! header so [`decompose`] can never mistake a raw parent blob for a
+//! composite.
+//!
+//! Framed layout (children present):
+//!
+//! ```text
+//! magic:          4 bytes  = COMPOSITE_MAGIC ("AEIC" = Aether Inline Composite)
+//! parent_version: u32 LE
+//! parent_len:     u32 LE
+//! parent_bytes:   parent_len bytes
+//! child_count:    u32 LE
+//! per child:
+//!   alias_id:     u64 LE
+//!   type_tag:     u64 LE
+//!   is_counter:   u8 (0 / 1)
+//!   subname_len:  u32 LE
+//!   subname:      subname_len bytes (UTF-8)
+//!   version:      u32 LE
+//!   state_len:    u32 LE
+//!   state_bytes:  state_len bytes
+//! ```
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+/// Reserved `StateBundle::version` value the composite frame is tagged
+/// with. Distinct from the macro-generated hooks' `version = 0` and from
+/// any plausible hand-written component version, so a raw parent blob is
+/// never decoded as a composite (the magic header is the second guard).
+pub const COMPOSITE_VERSION: u32 = 0xAE11_B0D1;
+
+/// Magic header bytes opening a framed composite — AEIC, for "Aether
+/// Inline Composite" — so a raw parent blob that happens to carry
+/// `version == COMPOSITE_VERSION` still can't be mistaken for one.
+const COMPOSITE_MAGIC: [u8; 4] = *b"AEIC";
+
+/// One inline child's saved entry in a composite bundle.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChildEntry {
+    /// The child's alias [`aether_data::MailboxId`] raw value — the key
+    /// the rehydrate path re-registers the reconstructed child under in
+    /// the guest `INLINE_CHILDREN` registry.
+    pub alias_id: u64,
+    /// The actor-type tag (`mailbox_id_from_name(NAMESPACE)`) the
+    /// rehydrate reconstruct matches against the module's exported types.
+    pub type_tag: u64,
+    /// Whether the original spawn used a counter discriminator.
+    pub is_counter: bool,
+    /// The resolved subname the slot carried (informational on
+    /// reconstruct; the alias route is re-keyed by `alias_id`).
+    pub full_subname: String,
+    /// The child's `on_dehydrate` bundle version.
+    pub version: u32,
+    /// The child's `on_dehydrate` bundle bytes.
+    pub state_bytes: Vec<u8>,
+}
+
+/// The parent half of a decomposed bundle — exactly the `(version,
+/// bytes)` the parent's `on_dehydrate` produced.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ParentState {
+    pub version: u32,
+    pub bytes: Vec<u8>,
+}
+
+/// The result of [`decompose`]: the parent's saved `(version, bytes)`
+/// plus the per-child entries (empty for a childless bundle).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Decomposed {
+    pub parent: ParentState,
+    pub children: Vec<ChildEntry>,
+}
+
+/// Compose the migration bundle the parent saves once via `save_state`.
+///
+/// With **zero** children the parent's `(version, bytes)` pass through
+/// verbatim — byte-identical to a childless component's save today (the
+/// no-regression guard). With at least one child the framed layout is
+/// emitted under [`COMPOSITE_VERSION`].
+#[must_use]
+pub fn compose(
+    parent_version: u32,
+    parent_bytes: &[u8],
+    children: &[ChildEntry],
+) -> (u32, Vec<u8>) {
+    if children.is_empty() {
+        return (parent_version, parent_bytes.to_vec());
+    }
+
+    let mut out = Vec::new();
+    out.extend_from_slice(&COMPOSITE_MAGIC);
+    out.extend_from_slice(&parent_version.to_le_bytes());
+    out.extend_from_slice(&len_u32(parent_bytes.len()).to_le_bytes());
+    out.extend_from_slice(parent_bytes);
+    out.extend_from_slice(&len_u32(children.len()).to_le_bytes());
+    for child in children {
+        out.extend_from_slice(&child.alias_id.to_le_bytes());
+        out.extend_from_slice(&child.type_tag.to_le_bytes());
+        out.push(u8::from(child.is_counter));
+        let subname = child.full_subname.as_bytes();
+        out.extend_from_slice(&len_u32(subname.len()).to_le_bytes());
+        out.extend_from_slice(subname);
+        out.extend_from_slice(&child.version.to_le_bytes());
+        out.extend_from_slice(&len_u32(child.state_bytes.len()).to_le_bytes());
+        out.extend_from_slice(&child.state_bytes);
+    }
+    (COMPOSITE_VERSION, out)
+}
+
+/// Decompose a migration bundle handed to `on_rehydrate`.
+///
+/// A `version` other than [`COMPOSITE_VERSION`], or any framed-layout
+/// parse miss (short buffer, wrong magic), is treated as a raw childless
+/// parent blob: the parent's `(version, bytes)` pass through verbatim and
+/// the child list is empty. This is the byte-identity counterpart of
+/// [`compose`] and the forward-compat fallback for a bundle written by an
+/// older or newer SDK.
+#[must_use]
+pub fn decompose(version: u32, bytes: &[u8]) -> Decomposed {
+    if version != COMPOSITE_VERSION {
+        return raw_passthrough(version, bytes);
+    }
+    parse_framed(bytes).unwrap_or_else(|| raw_passthrough(version, bytes))
+}
+
+/// A bundle that is not a framed composite — the parent's bytes verbatim,
+/// no children.
+fn raw_passthrough(version: u32, bytes: &[u8]) -> Decomposed {
+    Decomposed {
+        parent: ParentState {
+            version,
+            bytes: bytes.to_vec(),
+        },
+        children: Vec::new(),
+    }
+}
+
+/// Parse the framed-composite layout. Returns `None` on any malformed
+/// frame (bad magic, truncated field) so the caller falls back to the
+/// raw passthrough rather than trapping on a partial read.
+fn parse_framed(bytes: &[u8]) -> Option<Decomposed> {
+    let mut cursor = Cursor::new(bytes);
+    if cursor.take(COMPOSITE_MAGIC.len())? != COMPOSITE_MAGIC {
+        return None;
+    }
+    let parent_version = cursor.read_u32()?;
+    let parent_len = cursor.read_u32()? as usize;
+    let parent_bytes = cursor.take(parent_len)?.to_vec();
+    let child_count = cursor.read_u32()? as usize;
+    let mut children = Vec::with_capacity(child_count);
+    for _ in 0..child_count {
+        let alias_id = cursor.read_u64()?;
+        let type_tag = cursor.read_u64()?;
+        let is_counter = cursor.read_u8()? != 0;
+        let subname_len = cursor.read_u32()? as usize;
+        let subname = String::from_utf8(cursor.take(subname_len)?.to_vec()).ok()?;
+        let version = cursor.read_u32()?;
+        let state_len = cursor.read_u32()? as usize;
+        let state_bytes = cursor.take(state_len)?.to_vec();
+        children.push(ChildEntry {
+            alias_id,
+            type_tag,
+            is_counter,
+            full_subname: subname,
+            version,
+            state_bytes,
+        });
+    }
+    Some(Decomposed {
+        parent: ParentState {
+            version: parent_version,
+            bytes: parent_bytes,
+        },
+        children,
+    })
+}
+
+/// Narrow a `usize` length to the `u32` the frame stores. A bundle that
+/// large is already past the substrate's 1 MiB `save_state` cap, so the
+/// saturating clamp is a defensive floor that never fires in practice.
+fn len_u32(value: usize) -> u32 {
+    u32::try_from(value).unwrap_or(u32::MAX)
+}
+
+/// Bounds-checked forward reader over the framed bytes.
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
+    }
+
+    /// Borrow the next `len` bytes, advancing the cursor. `None` if fewer
+    /// than `len` bytes remain.
+    fn take(&mut self, len: usize) -> Option<&'a [u8]> {
+        let end = self.pos.checked_add(len)?;
+        let slice = self.bytes.get(self.pos..end)?;
+        self.pos = end;
+        Some(slice)
+    }
+
+    fn read_u8(&mut self) -> Option<u8> {
+        Some(self.take(1)?[0])
+    }
+
+    fn read_u32(&mut self) -> Option<u32> {
+        let mut buf = [0u8; 4];
+        buf.copy_from_slice(self.take(4)?);
+        Some(u32::from_le_bytes(buf))
+    }
+
+    fn read_u64(&mut self) -> Option<u64> {
+        let mut buf = [0u8; 8];
+        buf.copy_from_slice(self.take(8)?);
+        Some(u64::from_le_bytes(buf))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{COMPOSITE_VERSION, ChildEntry, Decomposed, ParentState, compose, decompose};
+    use alloc::string::String;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    fn child(alias: u64, tag: u64, name: &str, state: &[u8]) -> ChildEntry {
+        ChildEntry {
+            alias_id: alias,
+            type_tag: tag,
+            is_counter: false,
+            full_subname: String::from(name),
+            version: 0,
+            state_bytes: state.to_vec(),
+        }
+    }
+
+    /// Step 2 no-regression guard: zero children composes BYTE-IDENTICALLY
+    /// to today's single-actor blob (the raw parent `(version, bytes)`),
+    /// and round-trips back to the same parent with no children.
+    #[test]
+    fn zero_children_compose_is_byte_identical_to_raw_parent() {
+        let parent_bytes: &[u8] = &[0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02];
+        let parent_version = 7;
+
+        let (version, bytes) = compose(parent_version, parent_bytes, &[]);
+        assert_eq!(
+            version, parent_version,
+            "zero-child compose passes the parent version through unchanged",
+        );
+        assert_eq!(
+            bytes,
+            parent_bytes.to_vec(),
+            "zero-child compose is byte-identical to the raw parent blob",
+        );
+
+        let decomposed = decompose(version, &bytes);
+        assert_eq!(
+            decomposed,
+            Decomposed {
+                parent: ParentState {
+                    version: parent_version,
+                    bytes: parent_bytes.to_vec(),
+                },
+                children: Vec::new(),
+            },
+            "the raw parent blob round-trips with no children",
+        );
+    }
+
+    /// Step 2: a multi-child bundle round-trips both the parent state and
+    /// every child entry, under the reserved composite version.
+    #[test]
+    fn multi_child_bundle_round_trips() {
+        let parent_bytes: &[u8] = &[1, 2, 3];
+        let children = vec![
+            child(0x1111, 0xAAAA, "widget", &[9, 8, 7]),
+            ChildEntry {
+                is_counter: true,
+                ..child(0x2222, 0xBBBB, "0", &[])
+            },
+        ];
+
+        let (version, bytes) = compose(5, parent_bytes, &children);
+        assert_eq!(
+            version, COMPOSITE_VERSION,
+            "a children-present bundle is tagged with the composite version",
+        );
+
+        let decomposed = decompose(version, &bytes);
+        assert_eq!(
+            decomposed.parent,
+            ParentState {
+                version: 5,
+                bytes: parent_bytes.to_vec(),
+            },
+            "the parent state survives the composite round-trip",
+        );
+        assert_eq!(
+            decomposed.children, children,
+            "every child entry survives the composite round-trip",
+        );
+    }
+
+    /// A truncated composite frame degrades to the raw passthrough rather
+    /// than trapping — forward-compat / robustness.
+    #[test]
+    fn truncated_composite_falls_back_to_raw() {
+        let (version, mut bytes) = compose(0, &[1, 2], &[child(0x33, 0x44, "c", &[5])]);
+        bytes.truncate(6);
+        let decomposed = decompose(version, &bytes);
+        assert!(
+            decomposed.children.is_empty(),
+            "a truncated frame yields no children (raw fallback)",
+        );
+    }
+}

--- a/crates/aether-actor/src/ffi/inline_compose.rs
+++ b/crates/aether-actor/src/ffi/inline_compose.rs
@@ -1,0 +1,386 @@
+//! Dehydrate-compose / rehydrate-reconstruct for inline children
+//! (ADR-0114 §5), shared by both `export!` arms (single-actor and
+//! multi-actor) so the symmetric walk lives in one place rather than
+//! being copy-pasted per arm.
+//!
+//! On dehydrate ([`compose_dehydrate`]): run the parent's `on_dehydrate`
+//! into a capture buffer, walk every resident inline child running its
+//! `erased_on_dehydrate` into its own capture buffer, and pack the
+//! parent's blob plus each child's into one composite (`inline_bundle`).
+//! The shim then calls the host `save_state` **once** with the result.
+//!
+//! On rehydrate ([`reconstruct_inline_children`]): decompose the
+//! composite, run the parent's `on_rehydrate` with its slice, then per
+//! child entry call the codegen-supplied reconstruct callback (which
+//! resolves the type tag against the module's `export!` set and re-`init`s
+//! the child) before restoring its `type State` and re-registering it.
+//!
+//! Both halves are plain `alloc`-crate code with no FFI imports, so the
+//! logic is exercised on the host unit-test build; the wasm32-only
+//! `save_state` call lives in the `export!` shim, not here.
+
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use aether_data::{Kind, MailboxId};
+
+use crate::ffi::ctx::{CapturedState, FfiDropCtx, FfiInitCtx};
+use crate::ffi::inline::INLINE_CHILDREN;
+use crate::ffi::inline_bundle::{self, ChildEntry};
+use crate::ffi::{ErasedFfiActor, FfiActor, FfiCtx};
+use crate::mail::PriorState;
+
+/// Run the parent's `on_dehydrate` and every inline child's, packing one
+/// composite migration bundle (ADR-0114 §5).
+///
+/// `run_parent_dehydrate` runs the live parent instance's `on_dehydrate`
+/// against the supplied capturing [`FfiDropCtx`] (so the parent's own
+/// `save_state` is captured, not forwarded to the host).
+///
+/// Returns `None` when the parent's `on_dehydrate` saved nothing **and**
+/// no inline children are resident — the no-bundle case, so the shim
+/// skips the host `save_state` exactly as a no-saving component does
+/// today (the substrate then skips `on_rehydrate`, ADR-0016 §3). Otherwise
+/// returns `Some((version, bytes))` for the single host `save_state`;
+/// with no inline children that is byte-identical to the parent's own
+/// blob.
+#[must_use]
+pub fn compose_dehydrate(
+    mailbox_id: u64,
+    run_parent_dehydrate: impl FnOnce(&mut FfiDropCtx<'_>),
+) -> Option<(u32, Vec<u8>)> {
+    // Parent half: capture whatever the parent's `on_dehydrate` saves.
+    let mut parent_capture = CapturedState::default();
+    {
+        let mut ctx = FfiDropCtx::__new_capturing(mailbox_id, &mut parent_capture);
+        run_parent_dehydrate(&mut ctx);
+    }
+    let parent_saved = parent_capture.take();
+
+    // Child half: walk the registry, driving each child's `on_dehydrate`
+    // into its own capture buffer. The metadata snapshot is taken first so
+    // the per-child borrow in `with_child_mut` never overlaps the walk.
+    let metas = INLINE_CHILDREN.child_metas();
+    let mut children = Vec::with_capacity(metas.len());
+    for meta in metas {
+        let mut child_capture = CapturedState::default();
+        INLINE_CHILDREN.with_child_mut(meta.id, |child| {
+            let mut ctx = FfiDropCtx::__new_capturing(meta.id.0, &mut child_capture);
+            child.erased_on_dehydrate(&mut ctx);
+        });
+        let (version, state_bytes) = child_capture.take().unwrap_or((0, Vec::new()));
+        children.push(ChildEntry {
+            alias_id: meta.id.0,
+            type_tag: meta.type_tag,
+            is_counter: meta.is_counter,
+            full_subname: meta.full_subname,
+            version,
+            state_bytes,
+        });
+    }
+
+    // No parent save and no children: there is no bundle to migrate, so
+    // skip the host save entirely (the unchanged no-state path).
+    if parent_saved.is_none() && children.is_empty() {
+        return None;
+    }
+
+    let (parent_version, parent_bytes) = parent_saved.unwrap_or((0, Vec::new()));
+    Some(inline_bundle::compose(
+        parent_version,
+        &parent_bytes,
+        &children,
+    ))
+}
+
+/// One inline child to reconstruct, handed to the codegen-supplied
+/// reconstruct callback. The callback resolves [`Self::type_tag`] against
+/// the module's `export!` types, re-`init`s that type, restores its
+/// `type State` from `(state_version, state_bytes)` via `on_rehydrate`,
+/// and re-registers it in `INLINE_CHILDREN` under `alias` — all of which
+/// it can do because it expands inside the `export!` arm that knows the
+/// type set. An unknown tag is logged and skipped (the callback returns
+/// `false`).
+pub struct InlineChildToReconstruct<'a> {
+    /// The alias [`MailboxId`] to re-register the reconstructed child
+    /// under — the substrate route under this id survived the swap
+    /// (ADR-0022; the parent mailbox / slot is stable across replace), so
+    /// re-keying the guest registry by it restores addressing without a
+    /// host round-trip.
+    pub alias: MailboxId,
+    /// The actor-type tag to resolve against the exported type set.
+    pub type_tag: u64,
+    /// Whether the original spawn used a counter discriminator (carried
+    /// into the rebuilt slot metadata).
+    pub is_counter: bool,
+    /// The resolved subname (carried into the rebuilt slot metadata).
+    pub full_subname: &'a str,
+    /// The child's saved `on_dehydrate` bundle version.
+    pub state_version: u32,
+    /// The child's saved `on_dehydrate` bundle bytes.
+    pub state_bytes: &'a [u8],
+}
+
+/// Decompose a migration bundle, run the parent's `on_rehydrate` with its
+/// slice, then reconstruct every inline child (ADR-0114 §5).
+///
+/// `run_parent_rehydrate` runs the freshly-`init`ed parent instance's
+/// `on_rehydrate` with the parent's saved `(version, bytes)` rebuilt as a
+/// [`crate::PriorState`]. `reconstruct_child` is the codegen callback that
+/// re-`init`s one child by type tag, restores its state, and re-registers
+/// it; it returns `false` for an unknown tag (logged + skipped by the
+/// callback).
+///
+/// For a childless bundle the decompose yields the raw parent
+/// `(version, bytes)` and no children, so the parent's `on_rehydrate`
+/// sees the identical slice it would have today.
+pub fn reconstruct_inline_children(
+    version: u32,
+    bytes: &[u8],
+    run_parent_rehydrate: impl FnOnce(u32, &[u8]),
+    mut reconstruct_child: impl FnMut(&InlineChildToReconstruct<'_>) -> bool,
+) {
+    let decomposed = inline_bundle::decompose(version, bytes);
+
+    run_parent_rehydrate(decomposed.parent.version, &decomposed.parent.bytes);
+
+    for entry in &decomposed.children {
+        let to_reconstruct = InlineChildToReconstruct {
+            alias: MailboxId(entry.alias_id),
+            type_tag: entry.type_tag,
+            is_counter: entry.is_counter,
+            full_subname: &entry.full_subname,
+            state_version: entry.version,
+            state_bytes: &entry.state_bytes,
+        };
+        if !reconstruct_child(&to_reconstruct) {
+            // An unknown type tag (a replace that dropped a child type) or
+            // a failed re-`init`: skip it. The codegen callback has already
+            // logged; nothing else to do for this entry.
+            crate::__macro_internals::tracing::warn!(
+                target = "aether_actor::inline",
+                alias = to_reconstruct.alias.0,
+                type_tag = to_reconstruct.type_tag,
+                "inline child not reconstructed across replace_component (unknown type tag \
+                 or re-init failure); skipping",
+            );
+        }
+    }
+}
+
+/// Re-`init` one inline child of concrete type `A`, restore its
+/// `type State`, and re-register it under `alias` (ADR-0114 §5). Called
+/// by the `export!`-generated reconstruct callback once it has matched the
+/// child's type tag to one of the module's exported types.
+///
+/// Returns `false` (and does not register) when `A::Config` cannot decode
+/// from empty bytes (a typed-config inline child — its config isn't
+/// persisted across replace) or `A::init` returns `Err`; the caller logs
+/// and skips. The substrate alias route under `alias` survived the swap
+/// (ADR-0022; the parent slot is stable), so re-keying the guest registry
+/// by `alias` restores addressing with no host round-trip.
+#[must_use]
+pub fn reconstruct_one_child<A>(to_reconstruct: &InlineChildToReconstruct<'_>) -> bool
+where
+    A: FfiActor + ErasedFfiActor,
+{
+    // The child's config isn't part of the migration bundle; re-`init`
+    // from empty config bytes, the same shape the legacy zero-config
+    // `init` shim uses. A typed-config child decodes `None` here and is
+    // skipped.
+    let Some(config) = <A::Config as Kind>::decode_from_bytes(&[]) else {
+        return false;
+    };
+    let mut init_ctx = FfiInitCtx::__new(to_reconstruct.alias.0);
+    let Ok(mut child) = A::init(config, &mut init_ctx) else {
+        return false;
+    };
+
+    // Restore the child's `type State` from its saved bundle before it is
+    // registered, so the first inbound mail sees the rehydrated state.
+    {
+        let mut ctx = FfiCtx::__new(to_reconstruct.alias.0);
+        // SAFETY: `state_bytes` lives for this call; `PriorState::__from_ptr`
+        // forms a slice over it bounded by the borrow, never escaping.
+        let prior = unsafe {
+            PriorState::__from_ptr(
+                to_reconstruct.state_version,
+                to_reconstruct.state_bytes.as_ptr() as usize,
+                to_reconstruct.state_bytes.len(),
+            )
+        };
+        child.erased_on_rehydrate(&mut ctx, prior);
+    }
+
+    INLINE_CHILDREN.insert_child(
+        to_reconstruct.alias,
+        to_reconstruct.type_tag,
+        String::from(to_reconstruct.full_subname),
+        to_reconstruct.is_counter,
+        Box::new(child),
+    );
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{compose_dehydrate, reconstruct_inline_children};
+    use crate::ffi::ctx::FfiDropCtx;
+    use crate::ffi::inline::INLINE_CHILDREN;
+    use crate::ffi::inline_bundle;
+    use crate::ffi::{ErasedFfiActor, FfiCtx};
+    use crate::mail::{Mail, PriorState};
+    use aether_data::MailboxId;
+    use alloc::boxed::Box;
+    use alloc::string::String;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    /// A child whose `on_dehydrate` saves a fixed 4-byte tag, so the
+    /// compose can be asserted to carry the child's bytes. The reconstruct
+    /// tests don't drive this type's dispatch.
+    struct SavingChild {
+        tag: u32,
+    }
+
+    impl ErasedFfiActor for SavingChild {
+        fn erased_namespace(&self) -> &'static str {
+            "test.inline.saving_child"
+        }
+        fn erased_dispatch(
+            &mut self,
+            _ctx: &mut FfiCtx<'_, crate::Manual>,
+            _mail: Mail<'_>,
+        ) -> u32 {
+            0
+        }
+        fn erased_wire(&mut self, _ctx: &mut FfiCtx<'_, crate::Manual>) {}
+        fn erased_unwire(&mut self, _ctx: &mut FfiCtx<'_, crate::Manual>) {}
+        fn erased_on_dehydrate(&mut self, ctx: &mut FfiDropCtx<'_>) {
+            ctx.save_state(9, &self.tag.to_le_bytes());
+        }
+        fn erased_on_rehydrate(
+            &mut self,
+            _ctx: &mut FfiCtx<'_, crate::Manual>,
+            _prior: PriorState<'_>,
+        ) {
+        }
+    }
+
+    /// Step 3 coverage: a parent with two inline children yields a
+    /// composite carrying both child entries plus the parent's own state,
+    /// composed through one logical `save_state`.
+    #[test]
+    fn compose_dehydrate_packs_parent_and_children() {
+        // Two children with distinct tags + type tags + aliases.
+        let id_a = MailboxId(0xA1);
+        let id_b = MailboxId(0xB2);
+        INLINE_CHILDREN.insert_child(
+            id_a,
+            0xAAAA,
+            String::from("a"),
+            false,
+            Box::new(SavingChild { tag: 0x1111_2222 }),
+        );
+        INLINE_CHILDREN.insert_child(
+            id_b,
+            0xBBBB,
+            String::from("b"),
+            true,
+            Box::new(SavingChild { tag: 0x3333_4444 }),
+        );
+
+        // Parent saves a marker blob of its own.
+        let (version, bytes) = compose_dehydrate(0x7000, |ctx| {
+            ctx.save_state(3, &[0xDE, 0xAD]);
+        })
+        .expect("a parent that saves plus two children yields a bundle");
+
+        // Decompose and assert both children + the parent survived. The
+        // registry is process-global across unit tests, so assert by
+        // looking up our own aliases rather than the total child count.
+        let decomposed = inline_bundle::decompose(version, &bytes);
+        assert_eq!(decomposed.parent.version, 3, "parent version is carried");
+        assert_eq!(decomposed.parent.bytes, vec![0xDE, 0xAD]);
+        let a = decomposed
+            .children
+            .iter()
+            .find(|c| c.alias_id == id_a.0)
+            .expect("child a present");
+        assert_eq!(a.type_tag, 0xAAAA);
+        assert_eq!(a.state_bytes, 0x1111_2222u32.to_le_bytes().to_vec());
+        let b = decomposed
+            .children
+            .iter()
+            .find(|c| c.alias_id == id_b.0)
+            .expect("child b present");
+        assert!(b.is_counter, "child b's counter flag is carried");
+        assert_eq!(b.state_bytes, 0x3333_4444u32.to_le_bytes().to_vec());
+
+        // Empty the slots so the children's actor boxes don't linger in the
+        // process-global registry for sibling tests.
+        let _ = INLINE_CHILDREN.take(id_a);
+        let _ = INLINE_CHILDREN.take(id_b);
+    }
+
+    /// Step 4 coverage: each child entry is offered to the reconstruct
+    /// callback with its type tag + alias + state, and an unknown tag is
+    /// still offered (the callback decides to skip). The parent rehydrate
+    /// runs once with the parent slice.
+    #[test]
+    fn reconstruct_offers_each_child_and_parent_slice() {
+        // Build a composite with a parent blob + two children directly
+        // through the bundle helpers (no live registry needed).
+        use crate::ffi::inline_bundle::{ChildEntry, compose};
+
+        const TAG_KNOWN: u64 = 0xBEEF;
+        const TAG_UNKNOWN: u64 = 0xDEAD;
+
+        let children = vec![
+            ChildEntry {
+                alias_id: 0xC1,
+                type_tag: TAG_KNOWN,
+                is_counter: false,
+                full_subname: String::from("a"),
+                version: 1,
+                state_bytes: vec![1, 2, 3],
+            },
+            ChildEntry {
+                alias_id: 0xC2,
+                type_tag: TAG_UNKNOWN,
+                is_counter: false,
+                full_subname: String::from("b"),
+                version: 2,
+                state_bytes: vec![4, 5],
+            },
+        ];
+        let (version, bytes) = compose(5, &[7, 7], &children);
+
+        let mut parent_runs = 0u32;
+        let mut offered: Vec<(u64, Vec<u8>)> = Vec::new();
+        reconstruct_inline_children(
+            version,
+            &bytes,
+            |pv, pb| {
+                assert_eq!(pv, 5, "parent version slice is carried");
+                assert_eq!(pb, &[7, 7], "parent bytes slice is carried");
+                parent_runs += 1;
+            },
+            |child| {
+                offered.push((child.type_tag, child.state_bytes.to_vec()));
+                // An unknown tag is offered but the callback skips it.
+                child.type_tag != TAG_UNKNOWN
+            },
+        );
+
+        assert_eq!(parent_runs, 1, "the parent rehydrate runs exactly once");
+        assert_eq!(
+            offered.len(),
+            2,
+            "both children are offered to the callback"
+        );
+        assert_eq!(offered[0].1, vec![1, 2, 3], "child a state is carried");
+        assert_eq!(offered[1].1, vec![4, 5], "child b state is carried");
+    }
+}

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -61,6 +61,8 @@ use core::fmt;
 pub mod bridge;
 pub mod ctx;
 pub mod inline;
+pub mod inline_bundle;
+pub mod inline_compose;
 pub mod mailbox;
 pub mod raw;
 
@@ -857,8 +859,19 @@ macro_rules! __export_internal {
                 <$component as $crate::Actor>::NAMESPACE,
             )
             .0;
-            let mut ctx: $crate::FfiDropCtx<'_> = $crate::FfiDropCtx::__new(mailbox_id);
-            <$component as $crate::FfiActor>::on_dehydrate(instance, &mut ctx);
+            // ADR-0114 §5: run the parent's `on_dehydrate` and every
+            // resident inline child's into a single composite, then call
+            // the host `save_state` once. With no inline children the
+            // composite is byte-identical to the parent's own blob, so a
+            // childless component dehydrates exactly as before; a parent
+            // that saves nothing and has no children skips the host save.
+            if let Some((version, bytes)) = $crate::ffi::inline_compose::compose_dehydrate(
+                mailbox_id,
+                |ctx| <$component as $crate::FfiActor>::on_dehydrate(instance, ctx),
+            ) {
+                let mut ctx: $crate::FfiDropCtx<'_> = $crate::FfiDropCtx::__new(mailbox_id);
+                ctx.save_state(version, &bytes);
+            }
             0
         }
 
@@ -879,12 +892,66 @@ macro_rules! __export_internal {
                 <$component as $crate::Actor>::NAMESPACE,
             )
             .0;
-            let mut ctx = $crate::FfiCtx::__new(mailbox_id);
-            let prior = unsafe { $crate::PriorState::__from_raw(version, ptr, len) };
-            <$component as $crate::FfiActor>::on_rehydrate(instance, ctx.as_single(), prior);
+            // ADR-0114 §5: decompose the migration bundle, restore the
+            // parent, then reconstruct each inline child by type. For a
+            // childless component the bundle decomposes to the raw parent
+            // blob, so the parent sees the identical `PriorState` it would
+            // have before. A single-actor module's reconstructable type set
+            // is just `$component` (an inline child of any other type is
+            // not in the `export!` set; its tag is logged + skipped).
+            let prior_bytes: &[u8] = if len == 0 {
+                &[]
+            } else {
+                // SAFETY: substrate wrote `len` bytes at `ptr` (the rehydrate
+                // ABI); the slice is bounded by this call.
+                unsafe { ::core::slice::from_raw_parts(ptr as usize as *const u8, len as usize) }
+            };
+            $crate::ffi::inline_compose::reconstruct_inline_children(
+                version,
+                prior_bytes,
+                |parent_version, parent_bytes| {
+                    let mut ctx = $crate::FfiCtx::__new(mailbox_id);
+                    // SAFETY: `parent_bytes` lives for this closure call;
+                    // `PriorState::__from_ptr` bounds the slice to it.
+                    let parent_prior = unsafe {
+                        $crate::PriorState::__from_ptr(
+                            parent_version,
+                            parent_bytes.as_ptr() as usize,
+                            parent_bytes.len(),
+                        )
+                    };
+                    <$component as $crate::FfiActor>::on_rehydrate(
+                        instance,
+                        ctx.as_single(),
+                        parent_prior,
+                    );
+                },
+                |child| $crate::__export_internal!(@reconstruct_child child ; $component),
+            );
             0
         }
     };
+
+    // Reconstruct one inline child by matching its persisted type tag
+    // against the module's exported type set (ADR-0114 §5). For each
+    // candidate type whose `hash(NAMESPACE)` matches, re-`init` it and
+    // restore its state via `inline_compose::reconstruct_one_child`. An
+    // unmatched tag returns `false` so the caller logs + skips it.
+    (@reconstruct_child $child:ident ; $($candidate:ty),+) => {{
+        let mut __aether_reconstructed = false;
+        $(
+            if $child.type_tag
+                == $crate::__macro_internals::mailbox_id_from_name(
+                    <$candidate as $crate::Actor>::NAMESPACE,
+                )
+                .0
+            {
+                __aether_reconstructed =
+                    $crate::ffi::inline_compose::reconstruct_one_child::<$candidate>($child);
+            }
+        )+
+        __aether_reconstructed
+    }};
 }
 
 /// ADR-0096: FFI shims for a multi-actor module — `export!(A, B, …)`.
@@ -1162,8 +1229,17 @@ macro_rules! __export_multi_internal {
                 instance.erased_namespace(),
             )
             .0;
-            let mut ctx: $crate::FfiDropCtx<'_> = $crate::FfiDropCtx::__new(mailbox_id);
-            instance.erased_on_dehydrate(&mut ctx);
+            // ADR-0114 §5: compose the parent + every inline child into one
+            // composite, then `save_state` once (the boxed instance's
+            // dehydrate routes through `erased_on_dehydrate`). Childless ⇒
+            // byte-identical to the boxed parent's own blob.
+            if let Some((version, bytes)) = $crate::ffi::inline_compose::compose_dehydrate(
+                mailbox_id,
+                |ctx| instance.erased_on_dehydrate(ctx),
+            ) {
+                let mut ctx: $crate::FfiDropCtx<'_> = $crate::FfiDropCtx::__new(mailbox_id);
+                ctx.save_state(version, &bytes);
+            }
             0
         }
 
@@ -1184,11 +1260,36 @@ macro_rules! __export_multi_internal {
                 instance.erased_namespace(),
             )
             .0;
-            // ADR-0112: the boxed `ErasedFfiActor` seam carries the `Manual`
-            // view; the synthesized impl downgrades to `Single` per hook.
-            let mut ctx = $crate::FfiCtx::__new(mailbox_id);
-            let prior = unsafe { $crate::PriorState::__from_raw(version, ptr, len) };
-            instance.erased_on_rehydrate(&mut ctx, prior);
+            // ADR-0114 §5: decompose, restore the boxed parent, then
+            // reconstruct each inline child by matching its type tag against
+            // every exported type. Childless ⇒ the boxed parent sees the
+            // identical `PriorState`.
+            let prior_bytes: &[u8] = if len == 0 {
+                &[]
+            } else {
+                // SAFETY: substrate wrote `len` bytes at `ptr` (the rehydrate
+                // ABI); the slice is bounded by this call.
+                unsafe { ::core::slice::from_raw_parts(ptr as usize as *const u8, len as usize) }
+            };
+            $crate::ffi::inline_compose::reconstruct_inline_children(
+                version,
+                prior_bytes,
+                |parent_version, parent_bytes| {
+                    // ADR-0112: the boxed `ErasedFfiActor` seam carries the
+                    // `Manual` view; the synthesized impl downgrades per hook.
+                    let mut ctx = $crate::FfiCtx::__new(mailbox_id);
+                    // SAFETY: `parent_bytes` lives for this closure call.
+                    let parent_prior = unsafe {
+                        $crate::PriorState::__from_ptr(
+                            parent_version,
+                            parent_bytes.as_ptr() as usize,
+                            parent_bytes.len(),
+                        )
+                    };
+                    instance.erased_on_rehydrate(&mut ctx, parent_prior);
+                },
+                |child| $crate::__export_internal!(@reconstruct_child child ; $($component),+),
+            );
             0
         }
     };

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -2260,6 +2260,233 @@ fn text_draws_world_space_label() {
     );
 }
 
+/// ADR-0114 §5: an inline child carries its `type State` across a
+/// `replace_component` swap. Loads `inline_child_stateful` (the entry
+/// `InlineStatefulParent` spawns a stateful `InlineStatefulChild` in
+/// `wire`), bumps the **child's** counter to 2 through the child's
+/// first-class lineage address, replaces the wasm at the same mailbox id
+/// with the same binary, then re-queries the child's alias. The old
+/// instance's `on_dehydrate` packs the child's state into the composite
+/// migration bundle; the new instance's `on_rehydrate` reconstructs the
+/// child by type and restores its count — so the post-replace query reads
+/// 2, not the fresh-`init` 0. Reload is engine-internal correctness
+/// (dehydrate → composite → rehydrate reconstruct), which is `TestBench`'s
+/// lane; #1916's `FleetBench` already proved the over-the-wire child
+/// addressing, so this doesn't re-prove it.
+#[test]
+fn replace_preserves_inline_child_state_via_reconstruct() {
+    use aether_actor::Actor;
+
+    const FIXTURE_NAME: &str = "inline_child_stateful";
+
+    let Some(wasm_path) = require_runtime(FIXTURE_NAME) else {
+        return;
+    };
+    let parent_addr = format!(
+        "aether.component/{}:{FIXTURE_NAME}",
+        aether_capabilities::WasmTrampoline::NAMESPACE,
+    );
+    // The child's first-class lineage address: the parent's rendered name
+    // plus the inline-child node (ADR-0114). The parent spawns it under
+    // the `Named("widget")` subname in `wire`.
+    let child_addr = format!("{parent_addr}/aether.embedded:widget");
+
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let wasm = fs::read(&wasm_path).expect("read fixture wasm");
+
+    // Load the entry export (InlineStatefulParent), capturing its mailbox
+    // id for the replace.
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm,
+                    name: Some(FIXTURE_NAME.to_owned()),
+                    config: Vec::new(),
+                    export: None,
+                },
+            ),
+        )])
+        .expect("load sequence");
+    let mailbox_id = match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Ok { mailbox_id, .. } => mailbox_id,
+        LoadResult::Err { error } => panic!("inline_child_stateful load failed: {error}"),
+    };
+
+    // Bump the *child's* counter to 2 (mail demuxed to the child's alias),
+    // then read it back. `send_mail` is fire-and-settle, so the bumps land
+    // before the query.
+    let pre = bench
+        .execute(vec![
+            (
+                "bump_a",
+                BenchOp::send_mail::<Bump>(child_addr.as_str(), &Bump),
+            ),
+            (
+                "bump_b",
+                BenchOp::send_mail::<Bump>(child_addr.as_str(), &Bump),
+            ),
+            (
+                "query",
+                BenchOp::send_and_await(child_addr.as_str(), &CountQuery),
+            ),
+        ])
+        .expect("bump + query sequence");
+    assert_eq!(
+        pre.reply::<CountReport>("query")
+            .expect("decode pre-replace CountReport"),
+        CountReport { count: 2 },
+        "two bumps should leave the inline child's counter at 2 before the replace",
+    );
+
+    // Replace the wasm at the parent's mailbox id with the same binary.
+    // The old instance's `on_dehydrate` composites the child's state; the
+    // new instance's `on_rehydrate` reconstructs the child and restores it.
+    let wasm = fs::read(&wasm_path).expect("re-read fixture wasm");
+    let swapped = bench
+        .execute(vec![(
+            "swap",
+            BenchOp::send_and_await(
+                "aether.component",
+                &ReplaceComponent {
+                    mailbox_id,
+                    wasm,
+                    drain_timeout_ms: None,
+                    config: Vec::new(),
+                },
+            ),
+        )])
+        .expect("replace sequence");
+    match swapped
+        .reply::<ReplaceResult>("swap")
+        .expect("decode ReplaceResult")
+    {
+        ReplaceResult::Ok { .. } => {}
+        ReplaceResult::Err { error } => panic!("replace_component: {error}"),
+    }
+
+    // Query the reconstructed child's alias: the count must still be 2.
+    // A 0 here means the child vanished across the reload (its state lost,
+    // or it booted fresh) — the regression ADR-0114 §5 closes.
+    let post = bench
+        .execute(vec![(
+            "query",
+            BenchOp::send_and_await(child_addr.as_str(), &CountQuery),
+        )])
+        .expect("post-replace query sequence");
+    let post_count = post
+        .reply::<CountReport>("query")
+        .expect("decode post-replace CountReport");
+    assert_eq!(
+        post_count,
+        CountReport { count: 2 },
+        "the inline child's state must survive replace_component via the composite bundle + \
+         rehydrate reconstruct; got {post_count:?} (0 means the child was not reconstructed)",
+    );
+}
+
+/// ADR-0114 §5 no-regression: a childless component still hot-reloads
+/// unchanged. The `stateful_replace` fixture spawns no inline children, so
+/// its composite is byte-identical to its own `on_dehydrate` blob and the
+/// reload behaves exactly as before the inline-child compose landed. This
+/// guards the byte-identity invariant from the integration side; the
+/// `aether-actor` unit `zero_children_compose_is_byte_identical_to_raw_parent`
+/// guards it at the bundle layer.
+#[test]
+fn childless_component_hot_reloads_unchanged() {
+    use aether_actor::Actor;
+
+    const FIXTURE_NAME: &str = "stateful_replace";
+
+    let Some(wasm_path) = require_runtime(FIXTURE_NAME) else {
+        return;
+    };
+    let addr = format!(
+        "aether.component/{}:{FIXTURE_NAME}",
+        aether_capabilities::WasmTrampoline::NAMESPACE,
+    );
+
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let wasm = fs::read(&wasm_path).expect("read fixture wasm");
+
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm,
+                    name: Some(FIXTURE_NAME.to_owned()),
+                    config: Vec::new(),
+                    export: None,
+                },
+            ),
+        )])
+        .expect("load sequence");
+    let mailbox_id = match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Ok { mailbox_id, .. } => mailbox_id,
+        LoadResult::Err { error } => panic!("stateful_replace load failed: {error}"),
+    };
+
+    let pre = bench
+        .execute(vec![
+            ("bump_a", BenchOp::send_mail::<Bump>(addr.as_str(), &Bump)),
+            ("bump_b", BenchOp::send_mail::<Bump>(addr.as_str(), &Bump)),
+            ("query", BenchOp::send_and_await(addr.as_str(), &CountQuery)),
+        ])
+        .expect("bump + query sequence");
+    assert_eq!(
+        pre.reply::<CountReport>("query")
+            .expect("decode pre-replace CountReport"),
+        CountReport { count: 2 },
+        "two bumps leave the childless counter at 2 before the replace",
+    );
+
+    let wasm = fs::read(&wasm_path).expect("re-read fixture wasm");
+    let swapped = bench
+        .execute(vec![(
+            "swap",
+            BenchOp::send_and_await(
+                "aether.component",
+                &ReplaceComponent {
+                    mailbox_id,
+                    wasm,
+                    drain_timeout_ms: None,
+                    config: Vec::new(),
+                },
+            ),
+        )])
+        .expect("replace sequence");
+    match swapped
+        .reply::<ReplaceResult>("swap")
+        .expect("decode ReplaceResult")
+    {
+        ReplaceResult::Ok { .. } => {}
+        ReplaceResult::Err { error } => panic!("replace_component: {error}"),
+    }
+
+    let post = bench
+        .execute(vec![(
+            "query",
+            BenchOp::send_and_await(addr.as_str(), &CountQuery),
+        )])
+        .expect("post-replace query sequence");
+    assert_eq!(
+        post.reply::<CountReport>("query")
+            .expect("decode post-replace CountReport"),
+        CountReport { count: 2 },
+        "a childless component's state survives the reload unchanged (byte-identical composite)",
+    );
+}
+
 // Pre-#775 the bench emitted `aether.observation.frame_stats` every
 // 120 frames and a test verified one broadcast arrived after
 // `advance(120)`. Issue 775 retired the broadcast cap, the frame_stats

--- a/crates/aether-test-fixtures/Cargo.toml
+++ b/crates/aether-test-fixtures/Cargo.toml
@@ -136,5 +136,16 @@ crate-type = ["cdylib"]
 name = "inline_child"
 crate-type = ["cdylib"]
 
+# ADR-0114 §5 inline-child-reload fixture (#1930): a multi-actor module
+# `export!(InlineStatefulParent, InlineStatefulChild)` whose entry spawns
+# a stateful inline child in `wire`. The child declares `type State` and
+# answers `Bump` / `CountQuery`, so a TestBench scenario can mutate its
+# state, `replace_component` the same wasm, and assert the prior count
+# survived the dehydrate → composite bundle → rehydrate reconstruct.
+# Wasm artifact: target/wasm32-unknown-unknown/{profile}/examples/inline_child_stateful.wasm
+[[example]]
+name = "inline_child_stateful"
+crate-type = ["cdylib"]
+
 [lints]
 workspace = true

--- a/crates/aether-test-fixtures/examples/inline_child_stateful.rs
+++ b/crates/aether-test-fixtures/examples/inline_child_stateful.rs
@@ -1,0 +1,130 @@
+//! ADR-0114 §5 fixture: a multi-actor module whose entry
+//! `InlineStatefulParent` spawns a co-located, **stateful**
+//! `InlineStatefulChild` in `wire` via `ctx.spawn_inline_child`. The
+//! child declares `type State = CounterState` (ADR-0113), so the
+//! `#[actor]` macro generates its hot-swap hooks; the parent + child are
+//! both in the `export!` list so the rehydrate path can reconstruct the
+//! child **by type** after a `replace_component` swap.
+//!
+//! The child answers `Bump` by incrementing its counter and `CountQuery`
+//! by replying the live count, so a `TestBench` scenario can mutate the
+//! child's state, hot-reload the same wasm, then re-query the child's
+//! alias and assert the prior count survived the swap — the round-trip
+//! ADR-0114 §5 (dehydrate → composite bundle → rehydrate reconstruct)
+//! delivers.
+//!
+//! `InlineStatefulChild` rides the `export!` list (unlike the stateless
+//! `inline_child` fixture's child) because the rehydrate reconstruct
+//! resolves the child's type tag against the module's exported type set
+//! (ADR-0096) — a co-located child type must be exported to be
+//! reconstructable.
+
+// The parent's `#[fallback]` and the child's `#[handler::manual]` take
+// `&mut self` to match the dispatch ABI even when an arm is stateless.
+#![allow(clippy::unused_self)]
+// `rehydrate` takes its `State` by value (the macro moves the decoded
+// state into the actor); `CounterState` is all-`Copy`, so clippy reads the
+// by-value parameter as needlessly owned — the contract is the point.
+#![allow(clippy::needless_pass_by_value)]
+
+use aether_actor::{
+    BootError, FfiActor, FfiCtx, Instanced, Mail, Manual, OutboundReply, Resolver, Subname, actor,
+};
+use aether_test_fixtures::{Bump, CountQuery, CountReport};
+
+/// Durable state the inline child carries across `replace_component`.
+/// Reuses the `aether.test_fixtures.counter_state` shape so the macro
+/// frames it via `save_state_kind` on dehydrate and recovers it via
+/// `as_kind` on rehydrate.
+#[derive(
+    aether_data::Kind, aether_data::Schema, serde::Serialize, serde::Deserialize, Debug, Clone,
+)]
+#[kind(name = "aether.test_fixtures.inline_counter_state")]
+pub struct InlineCounterState {
+    pub count: u32,
+}
+
+/// Entry export — the loaded component. Spawns its stateful inline child
+/// in `wire` and otherwise ignores mail.
+pub struct InlineStatefulParent;
+
+#[actor]
+impl FfiActor for InlineStatefulParent {
+    const NAMESPACE: &'static str = "test.inline.stateful_parent";
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
+    where
+        C: Resolver,
+    {
+        Ok(InlineStatefulParent)
+    }
+
+    /// ADR-0114: co-locate an `InlineStatefulChild` under the `Named`
+    /// subname `widget`. The child is addressed by its rendered lineage
+    /// name (`{parent}/aether.embedded:widget`); the membrane demuxes the
+    /// `Bump` / `CountQuery` mail to it.
+    fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
+        let _ = ctx.spawn_inline_child::<InlineStatefulChild>(Subname::Named("widget"), &());
+    }
+
+    /// The parent ignores mail addressed to its own id — only the child
+    /// carries state. A `#[fallback]` keeps the parent a valid receiver.
+    #[fallback]
+    fn on_other(&mut self, _ctx: &mut FfiCtx<'_>, _mail: Mail<'_>) {}
+}
+
+/// Inline child — co-located in the parent's wasm instance, carrying a
+/// counter that must survive a `replace_component` swap. `Instanced`
+/// satisfies the `spawn_inline_child` bound; it is in the `export!` list
+/// so the rehydrate reconstruct can re-`init` it by type.
+pub struct InlineStatefulChild {
+    count: u32,
+}
+
+impl Instanced for InlineStatefulChild {}
+
+#[actor]
+impl FfiActor for InlineStatefulChild {
+    const NAMESPACE: &'static str = "test.inline.stateful_child";
+
+    /// ADR-0113: the durable shape. The `#[actor]` macro generates the
+    /// child's `on_dehydrate` / `on_rehydrate` from this plus the
+    /// accessors below, and ADR-0114 §5 packs / restores them through the
+    /// composite migration bundle.
+    type State = InlineCounterState;
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
+    where
+        C: Resolver,
+    {
+        Ok(InlineStatefulChild { count: 0 })
+    }
+
+    /// Save-side accessor: snapshot the live counter for the composite.
+    fn dehydrate(&self) -> InlineCounterState {
+        InlineCounterState { count: self.count }
+    }
+
+    /// Restore-side accessor: adopt the recovered snapshot after the swap.
+    fn rehydrate(&mut self, state: InlineCounterState) {
+        self.count = state.count;
+    }
+
+    /// Increment the child's in-memory counter (mail demuxed to the
+    /// child's alias).
+    #[handler]
+    fn on_bump(&mut self, _ctx: &mut FfiCtx<'_>, _bump: Bump) {
+        self.count += 1;
+    }
+
+    /// Reply with the live counter so a test can read the child's state
+    /// across a swap.
+    #[handler::manual]
+    fn on_count_query(&mut self, ctx: &mut FfiCtx<'_, Manual>, _query: CountQuery) {
+        if ctx.reply_target().is_some() {
+            ctx.reply(&CountReport { count: self.count });
+        }
+    }
+}
+
+aether_actor::export!(InlineStatefulParent, InlineStatefulChild);


### PR DESCRIPTION
Closes #1930.

## Summary

Step 4 of the ADR-0114 inline-child arc: inline children now survive `replace_component` (hot reload). #1916 landed the inline-child primitive, but a `replace_component` builds a fresh WASM instance whose process-global `INLINE_CHILDREN` registry starts empty — so after a reload a component's inline children vanished (their `type State` lost, mail to a child alias falling through the membrane to the parent's unmatched path). ADR-0114 §5 specified the fix; this implements it.

The mechanism, per ADR-0114 §5 / ADR-0016 / ADR-0113:

- **Registry** — `InlineSlot` now records each child's actor-type tag and `Subname` at `spawn_inline_child` time, with a snapshot path for dehydrate and a reconstruct/insert path for rehydrate.
- **Composite bundle** (`ffi/inline_bundle.rs`) — the migration `StateBundle` is a single `Option<StateBundle>` the host overwrites on a second `save_state`, so the parent and its inline children pack into one composite. The no-regression guard is byte-identity: a childless component composes to exactly the bytes (and version) its own `on_dehydrate` produces today; the framed layout is used only when a child is present, gated by a reserved version discriminator plus a magic header so a raw parent blob can never be misread as a composite.
- **Dehydrate** — the `export!`-generated `on_dehydrate_p32` shim runs the parent's `on_dehydrate`, walks `INLINE_CHILDREN` calling each child's `erased_on_dehydrate`, packs the composite, and calls `save_state` once.
- **Rehydrate** — `on_rehydrate_p32` unpacks the composite, restores the parent, then per child entry reconstructs the child by type from the module's `export!` actor-type set (reusing the `init_typed_p32` mapping — no new author declaration), restores its `type State` via `erased_on_rehydrate`, re-inserts under the persisted alias id, and re-keys the guest registry. An unknown type tag is logged and skipped (forward-compat).

No `aether-substrate` change was needed: the substrate alias route survives the swap (the registry is a shared `Arc` reused across replace, behind the stable parent mailbox), so reconstruct re-keys by the persisted alias id with no host round-trip — which also correctly handles `Counter` children whose host-resolved discriminator the guest never learns. No new ADR (covered by ADR-0114 §5, ADR-0016, ADR-0113).

## Test plan

- Guest units (`ffi/inline*.rs`): slot carries type tag + subname; composite round-trip including the zero-children byte-identity guard and a truncated-frame raw fallback; dehydrate packs parent + both children; rehydrate reconstructs each child to the right type and skips an unknown tag.
- End-to-end reload (`test_bench_scenario.rs` + a new `inline_child_stateful` fixture): spawn an inline child, mutate its `type State`, `replace_component` the same wasm, then mail the child's alias and assert it reaches the reconstructed child with its prior state intact; a childless component still hot-reloads unchanged. TestBench (engine-internal correctness), since #1916's FleetBench already proves the over-the-wire addressing.
- `scripts/preflight.sh` green: fmt, clippy `--workspace --all-targets -D warnings`, doc, `nextest run --workspace` (102 run / 102 passed in the changed scope, full suite 2064 passed), and the wasm32 component cross-build (`xtask dist`, 16 components incl. the new fixture).

## Generated by

`/implement` — agent execution of [scoped issue #1930](https://github.com/iamacoffeepot/aether/issues/1930).
