### PR TITLE
feat(actor): tear down inline children and settle their owed obligations

### DIFF
--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -345,6 +345,40 @@ impl<M: ReplyMode> FfiCtx<'_, M> {
         let type_tag = mailbox_id_from_name(<A as Actor>::NAMESPACE).0;
         install_inline_child::<A>(alias, type_tag, full_subname, is_counter, owned)
     }
+
+    /// ADR-0114: tear down an **inline child** spawned by
+    /// [`Self::spawn_inline_child`]. Drops the child from the ctx-side
+    /// [`INLINE_CHILDREN`] registry (running the child's `Drop`), so it
+    /// stops handling mail. `child` is the alias [`MailboxId`] that
+    /// `spawn_inline_child` returned (the registry key, the natural
+    /// handle). Returns `true` if a resident child was removed, `false` if
+    /// the alias named no inline child — idempotent, so despawning an
+    /// absent or already-gone alias is a clean `false`, not an error.
+    ///
+    /// **The substrate alias route is kept** — teardown is guest-only, with
+    /// no substrate change and no alias deregistration. The alias stays a
+    /// route to this component's slot, so any in-flight or later mail to the
+    /// torn-down alias — fresh mail or an orphaned downstream reply — lands
+    /// in this inbox, the `export!` membrane finds no resident child and
+    /// falls through to the parent's standard dispatch tail, and the chain
+    /// settles (ADR-0080 / ADR-0094) rather than leaking. Discarding the
+    /// alias would short-circuit-drop that orphan mail; routing it to the
+    /// parent is the deliberate teardown discipline.
+    ///
+    /// Callable from any depth: a parent on a child, a sibling on a
+    /// sibling, or a child on itself. A self-despawn mid-dispatch drops
+    /// correctly — the child is taken out of its slot while it runs, so
+    /// `remove` clears the empty slot and the matching `reinsert` on the
+    /// inline registry finds nothing and no-ops, dropping the live box at
+    /// end of dispatch.
+    ///
+    /// No `unwire` runs on teardown in v1: inline children get only `init`
+    /// today, so an `unwire` here would be asymmetric. The inline-child
+    /// `wire` / `unwire` / subscription lifecycle lands separately, and
+    /// teardown grows its `unwire` call then.
+    pub fn despawn_inline_child(&self, child: MailboxId) -> bool {
+        INLINE_CHILDREN.remove(child)
+    }
 }
 
 /// Resolve a [`Subname`] into the `(is_counter, discriminator)` pair the
@@ -752,6 +786,63 @@ mod tests {
         assert!(
             matches!(result, Err(SpawnError::SubnameInvalid(_))),
             "a separator-bearing subname must return SubnameInvalid, got {result:?}",
+        );
+    }
+
+    /// Test inline child whose `init` succeeds, so `install_inline_child`
+    /// registers it in `INLINE_CHILDREN` for the despawn test. Its dispatch
+    /// hooks are unreachable here — the test only installs then despawns.
+    struct SucceedingChild;
+
+    impl Actor for SucceedingChild {
+        const NAMESPACE: &'static str = "test.inline.succeeding_child";
+    }
+
+    impl Instanced for SucceedingChild {}
+
+    impl FfiActor for SucceedingChild {
+        type Config = ();
+        type State = ();
+
+        fn init<C>(_config: (), _ctx: &mut C) -> Result<Self, BootError>
+        where
+            C: Resolver,
+        {
+            Ok(Self)
+        }
+    }
+
+    impl ErasedFfiActor for SucceedingChild {
+        fn erased_namespace(&self) -> &'static str {
+            Self::NAMESPACE
+        }
+        fn erased_dispatch(&mut self, _ctx: &mut FfiCtx<'_, Manual>, _mail: Mail<'_>) -> u32 {
+            unreachable!("the despawn test never dispatches this child")
+        }
+        fn erased_wire(&mut self, _ctx: &mut FfiCtx<'_, Manual>) {}
+        fn erased_unwire(&mut self, _ctx: &mut FfiCtx<'_, Manual>) {}
+        fn erased_on_dehydrate(&mut self, _ctx: &mut FfiDropCtx<'_>) {}
+        fn erased_on_rehydrate(&mut self, _ctx: &mut FfiCtx<'_, Manual>, _prior: PriorState<'_>) {}
+    }
+
+    /// Step 2: `despawn_inline_child` removes a resident inline child
+    /// (returns `true`) and is idempotent — a second despawn of the same
+    /// alias returns `false`, not an error. Installs the child directly
+    /// (the host build's `spawn_inline_child` host fn is a panicking stub).
+    #[test]
+    fn despawn_inline_child_removes_then_idempotent() {
+        let alias = MailboxId(0x6161);
+        install_inline_child::<SucceedingChild>(alias, 0, String::from("widget"), false, ())
+            .expect("a succeeding init installs the inline child");
+
+        let ctx = FfiCtx::__new(alias.0);
+        assert!(
+            ctx.despawn_inline_child(alias),
+            "despawning a resident child returns true",
+        );
+        assert!(
+            !ctx.despawn_inline_child(alias),
+            "a second despawn of the same alias returns false (idempotent)",
         );
     }
 

--- a/crates/aether-actor/src/ffi/inline.rs
+++ b/crates/aether-actor/src/ffi/inline.rs
@@ -143,12 +143,43 @@ impl InlineRegistry {
     /// Put a child back after dispatch, into its existing slot (metadata
     /// preserved). Pairs with [`Self::take`]; the slot is guaranteed to
     /// exist because `take` left it in place with an empty actor box.
+    ///
+    /// The find-then-set is deliberately a no-op when no slot matches `id`:
+    /// a child despawned mid-dispatch (its slot already
+    /// [`removed`](Self::remove) while it was taken out) has nowhere to go
+    /// back to, so the live box drops at end of scope rather than
+    /// re-entering the registry. This no-op is what makes self-despawn
+    /// fall out for free (ADR-0114) — no pending-removal flag.
     pub fn reinsert(&self, id: MailboxId, actor: Box<dyn ErasedFfiActor>) {
         // SAFETY: see [`Self::insert_child`].
         let slots = unsafe { &mut *self.inner.get() };
         if let Some(slot) = slots.iter_mut().find(|s| s.id == id) {
             slot.actor = Some(actor);
         }
+    }
+
+    /// Tear down the inline child registered under `id` (ADR-0114
+    /// teardown): remove its slot, dropping the resident
+    /// `Box<dyn ErasedFfiActor>` so the child's `Drop` runs. Returns
+    /// `true` if a slot was present, `false` if `id` named no inline child
+    /// (idempotent — a re-despawn of an already-gone alias is a clean
+    /// `false`, not an error). Backs [`FfiCtx::despawn_inline_child`].
+    ///
+    /// If the child is currently taken out for dispatch (a self-despawn:
+    /// its slot's actor box is `None`, the live box held on the stack by
+    /// [`membrane_dispatch`]), removing the empty slot makes the matching
+    /// [`Self::reinsert`] find nothing and no-op, so the box drops at end
+    /// of dispatch instead of re-entering — the reentrant case the
+    /// slot-shaped take/reinsert design handles with no extra state.
+    pub fn remove(&self, id: MailboxId) -> bool {
+        // SAFETY: see [`Self::insert_child`] — the borrow is taken fresh
+        // and released before return, never spanning a dispatch.
+        let slots = unsafe { &mut *self.inner.get() };
+        let Some(pos) = slots.iter().position(|s| s.id == id) else {
+            return false;
+        };
+        slots.remove(pos);
+        true
     }
 
     /// Snapshot the reconstruct metadata of every resident inline child
@@ -258,6 +289,11 @@ mod tests {
     /// second dispatch lands again).
     static CHILD_DISPATCHES: AtomicU32 = AtomicU32::new(0);
 
+    /// Process-global drop counter the self-despawning child bumps from its
+    /// `Drop`, so the reentrancy test can prove the box dropped (rather than
+    /// being reinserted) after it removed its own slot mid-dispatch.
+    static SELF_DESPAWN_DROPS: AtomicU32 = AtomicU32::new(0);
+
     /// Minimal `ErasedFfiActor` for the membrane tests: records each
     /// dispatch and returns [`CHILD_CODE`]. The lifecycle hooks are
     /// unreachable in these tests.
@@ -273,6 +309,47 @@ mod tests {
             _mail: Mail<'_>,
         ) -> u32 {
             CHILD_DISPATCHES.fetch_add(1, Ordering::Relaxed);
+            CHILD_CODE
+        }
+        fn erased_wire(&mut self, _ctx: &mut FfiCtx<'_, crate::Manual>) {}
+        fn erased_unwire(&mut self, _ctx: &mut FfiCtx<'_, crate::Manual>) {}
+        fn erased_on_dehydrate(&mut self, _ctx: &mut crate::FfiDropCtx<'_>) {}
+        fn erased_on_rehydrate(
+            &mut self,
+            _ctx: &mut FfiCtx<'_, crate::Manual>,
+            _prior: PriorState<'_>,
+        ) {
+        }
+    }
+
+    /// A child that despawns *itself* from [`INLINE_CHILDREN`] during its
+    /// own dispatch and bumps [`SELF_DESPAWN_DROPS`] when dropped — used to
+    /// prove the reentrant self-despawn drops the live box rather than
+    /// reinserting it. Carries its own alias id so `erased_dispatch` can
+    /// remove the matching slot.
+    struct SelfDespawningChild {
+        id: MailboxId,
+    }
+
+    impl Drop for SelfDespawningChild {
+        fn drop(&mut self) {
+            SELF_DESPAWN_DROPS.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    impl ErasedFfiActor for SelfDespawningChild {
+        fn erased_namespace(&self) -> &'static str {
+            "test.inline.self_despawning_child"
+        }
+        fn erased_dispatch(
+            &mut self,
+            _ctx: &mut FfiCtx<'_, crate::Manual>,
+            _mail: Mail<'_>,
+        ) -> u32 {
+            // Self-despawn mid-dispatch: this box is currently taken out
+            // (held on the membrane's stack), so `remove` clears the empty
+            // slot and the membrane's `reinsert` will find nothing.
+            INLINE_CHILDREN.remove(self.id);
             CHILD_CODE
         }
         fn erased_wire(&mut self, _ctx: &mut FfiCtx<'_, crate::Manual>) {}
@@ -404,6 +481,81 @@ mod tests {
         assert_eq!(
             rc, OWN_CODE,
             "an unknown recipient falls back to the parent's unmatched path",
+        );
+    }
+
+    /// Step 1 coverage: `remove` drops a resident child (the alias goes
+    /// absent) and is idempotent — a second `remove` of the same id is a
+    /// clean `false`.
+    #[test]
+    fn registry_remove_drops_child_and_is_idempotent() {
+        let registry = InlineRegistry::new();
+        let id = MailboxId(0x8888);
+
+        assert!(
+            !registry.remove(id),
+            "removing an absent id returns false (idempotent)",
+        );
+        registry.insert_child(
+            id,
+            0,
+            String::from("widget"),
+            false,
+            Box::new(RecordingChild),
+        );
+        assert!(
+            registry.remove(id),
+            "removing a resident child returns true",
+        );
+        assert!(
+            registry.take(id).is_none(),
+            "a removed child is absent from the registry",
+        );
+        assert!(
+            !registry.remove(id),
+            "a second remove of the same id is a clean false",
+        );
+    }
+
+    /// Step 3 coverage: a child that despawns itself mid-dispatch drops
+    /// correctly. `membrane_dispatch` takes it out, the dispatch removes the
+    /// now-empty slot via `INLINE_CHILDREN.remove`, the membrane's
+    /// `reinsert` finds nothing and no-ops, and the live box drops at end of
+    /// scope — proving the slot-shaped take/reinsert handles the reentrant
+    /// drop with no pending-removal flag. A subsequent send to the same
+    /// alias then falls through to the parent's unmatched path.
+    #[test]
+    fn membrane_self_despawn_drops_box_and_falls_through() {
+        let own = 0x5000_u64;
+        let child = 0x5001_u64;
+        let before_drops = SELF_DESPAWN_DROPS.load(Ordering::Relaxed);
+        INLINE_CHILDREN.insert_child(
+            MailboxId(child),
+            0,
+            String::from("widget"),
+            false,
+            Box::new(SelfDespawningChild {
+                id: MailboxId(child),
+            }),
+        );
+
+        // Dispatch the child; it removes its own slot mid-dispatch.
+        let rc = membrane_dispatch(own, mail_to(child), |_mail| {
+            panic!("own dispatch must not run while the child is resident")
+        });
+        assert_eq!(rc, CHILD_CODE, "the child handled the despawning dispatch");
+        assert_eq!(
+            SELF_DESPAWN_DROPS.load(Ordering::Relaxed) - before_drops,
+            1,
+            "the self-despawned box dropped at end of dispatch, not reinserted",
+        );
+
+        // The alias is gone: a second send falls through to the parent's
+        // unmatched path rather than re-dispatching a dropped child.
+        let rc2 = membrane_dispatch(own, mail_to(child), |_mail| OWN_CODE);
+        assert_eq!(
+            rc2, OWN_CODE,
+            "the torn-down alias falls through to the parent",
         );
     }
 }

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -46,7 +46,10 @@ use aether_substrate_bundle::test_bench::{
 use aether_substrate_bundle::visual::{
     background_top_left, bounding_box, centroid, coverage, decode_png,
 };
-use aether_test_fixtures::{Bump, CountQuery, CountReport, SetRender};
+use aether_test_fixtures::{
+    Bump, CountQuery, CountReport, DespawnChild, INLINE_WHO_CHILD, INLINE_WHO_PARENT, InlineEcho,
+    InlineProbe, SetRender,
+};
 
 // Pin the fixture rlib so its `inventory::submit!` `KindDescriptor`
 // entries are present in this test binary. Without the reference, the
@@ -2387,6 +2390,104 @@ fn replace_preserves_inline_child_state_via_reconstruct() {
         CountReport { count: 2 },
         "the inline child's state must survive replace_component via the composite bundle + \
          rehydrate reconstruct; got {post_count:?} (0 means the child was not reconstructed)",
+    );
+}
+
+/// ADR-0114 teardown (#1939): an inline child torn down mid-life still
+/// settles mail to its now-dead alias through the parent. Loads
+/// `inline_child_despawn` (the entry `InlineDespawnParent` spawns an
+/// `InlineDespawnChild` in `wire`), probes the child's first-class alias and
+/// asserts the *child* answers + the chain settles, sends a `DespawnChild`
+/// trigger to the parent (which calls `ctx.despawn_inline_child` on the
+/// stored alias), then probes the **same** alias again. The substrate alias
+/// route is kept on teardown, so the orphaned probe lands in the parent's
+/// inbox, the membrane finds no resident child and falls through to the
+/// parent's dispatch tail — the *parent* answers and the chain **settles**.
+/// A `SettlementTimeout` on the post-teardown probe would be the leak this
+/// verb exists to prevent. Teardown settlement is engine-internal (membrane
+/// fallthrough → parent dispatch tail → `record_finished`), `TestBench`'s
+/// lane; #1916's `FleetBench` already proved over-the-wire inline addressing.
+#[test]
+fn despawn_inline_child_settles_orphan_mail_via_parent() {
+    use aether_actor::Actor;
+
+    const FIXTURE_NAME: &str = "inline_child_despawn";
+
+    let Some(wasm_path) = require_runtime(FIXTURE_NAME) else {
+        return;
+    };
+    let parent_addr = format!(
+        "aether.component/{}:{FIXTURE_NAME}",
+        aether_capabilities::WasmTrampoline::NAMESPACE,
+    );
+    // The child's first-class lineage address: the parent's rendered name
+    // plus the inline-child node (ADR-0114). The parent spawns it under the
+    // `Named("widget")` subname in `wire`.
+    let child_addr = format!("{parent_addr}/aether.embedded:widget");
+
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let wasm = fs::read(&wasm_path).expect("read fixture wasm");
+
+    // Load the entry export, then probe the *live* child's alias: the
+    // membrane demuxes to the child, which answers with the child marker,
+    // and the chain settles.
+    let live = bench
+        .execute(vec![
+            (
+                "load",
+                BenchOp::send_and_await(
+                    "aether.component",
+                    &LoadComponent {
+                        wasm,
+                        name: Some(FIXTURE_NAME.to_owned()),
+                        config: Vec::new(),
+                        export: None,
+                    },
+                ),
+            ),
+            (
+                "probe",
+                BenchOp::send_and_await(child_addr.as_str(), &InlineProbe),
+            ),
+        ])
+        .expect("load + live-probe sequence");
+    match live.reply::<LoadResult>("load").expect("decode LoadResult") {
+        LoadResult::Ok { .. } => {}
+        LoadResult::Err { error } => panic!("inline_child_despawn load failed: {error}"),
+    }
+    assert_eq!(
+        live.reply::<InlineEcho>("probe")
+            .expect("decode live-probe InlineEcho"),
+        InlineEcho {
+            who: INLINE_WHO_CHILD,
+        },
+        "a probe to the live child's alias is demuxed to and answered by the child",
+    );
+
+    // Tear the child down via the parent (`ctx.despawn_inline_child(self.child)`),
+    // then probe the *same* alias again. The kept alias routes the orphaned
+    // probe to the parent's dispatch tail, so it settles (a SettlementTimeout
+    // here would be the leak this verb prevents) and the *parent* answers.
+    let post = bench
+        .execute(vec![
+            (
+                "despawn",
+                BenchOp::send_mail::<DespawnChild>(parent_addr.as_str(), &DespawnChild),
+            ),
+            (
+                "probe",
+                BenchOp::send_and_await(child_addr.as_str(), &InlineProbe),
+            ),
+        ])
+        .expect("despawn + post-teardown probe must settle, not SettlementTimeout");
+    assert_eq!(
+        post.reply::<InlineEcho>("probe")
+            .expect("decode post-teardown InlineEcho"),
+        InlineEcho {
+            who: INLINE_WHO_PARENT,
+        },
+        "after teardown, a probe to the same alias falls through to the parent \
+         (kept alias → membrane no resident child → parent dispatch tail)",
     );
 }
 

--- a/crates/aether-test-fixtures/Cargo.toml
+++ b/crates/aether-test-fixtures/Cargo.toml
@@ -147,5 +147,17 @@ crate-type = ["cdylib"]
 name = "inline_child_stateful"
 crate-type = ["cdylib"]
 
+# ADR-0114 inline-child teardown fixture (#1939): the entry
+# `InlineDespawnParent` spawns a co-located `InlineDespawnChild` in `wire`,
+# stores its alias, and tears it down on a `DespawnChild` trigger via
+# `ctx.despawn_inline_child`. A TestBench scenario probes the live child,
+# despawns it, then probes the same alias and asserts the parent answered
+# (membrane fallthrough) and the chain still settled — the post-teardown
+# settlement guarantee (the kept alias routes orphan mail to the parent).
+# Wasm artifact: target/wasm32-unknown-unknown/{profile}/examples/inline_child_despawn.wasm
+[[example]]
+name = "inline_child_despawn"
+crate-type = ["cdylib"]
+
 [lints]
 workspace = true

--- a/crates/aether-test-fixtures/examples/inline_child_despawn.rs
+++ b/crates/aether-test-fixtures/examples/inline_child_despawn.rs
@@ -1,0 +1,132 @@
+//! ADR-0114 inline-child teardown fixture (#1939). A single-actor module
+//! whose entry `InlineDespawnParent` spawns a co-located `InlineDespawnChild`
+//! in `wire` via `ctx.spawn_inline_child` and **stores the returned alias**,
+//! so a `DespawnChild` trigger to the parent tears the child down via
+//! `ctx.despawn_inline_child(self.child)`.
+//!
+//! Both actors answer the shared `InlineProbe` with a `who`-tagged
+//! `InlineEcho`, so a `TestBench` scenario can probe the child's alias (the
+//! child answers + settles), tear the child down, then probe the **same**
+//! alias again and assert the *parent* answered (the membrane fell through
+//! to the parent's dispatch tail) and the chain still settled — the
+//! post-teardown-settlement guarantee. The substrate alias route is kept on
+//! teardown, so the orphaned mail settles through the parent rather than
+//! being short-circuit-dropped.
+//!
+//! `InlineDespawnChild` also handles `DespawnChild` by despawning *itself*
+//! mid-dispatch (the reentrant self-despawn path), addressed by the child's
+//! own alias (`ctx.mailbox_id()`). It is `Instanced` (the
+//! `spawn_inline_child` bound) and not in the `export!` list — an inline
+//! child is constructed in-process by the parent, not instantiated by the
+//! host. A sibling of `inline_child.rs` so the #1916 `FleetBench` fixture
+//! stays pristine.
+
+// `#[handler::manual]` methods take `&mut self` to match the dispatch ABI
+// even though these stateless replies never read it.
+#![allow(clippy::unused_self)]
+
+use aether_actor::{
+    BootError, FfiActor, FfiCtx, Instanced, Manual, OutboundReply, Resolver, Subname, actor,
+};
+use aether_data::MailboxId;
+use aether_test_fixtures::{
+    DespawnChild, INLINE_WHO_CHILD, INLINE_WHO_PARENT, InlineEcho, InlineProbe,
+};
+
+/// Reply to an `InlineProbe` with the `who` marker of whichever actor
+/// handled it — shared by the parent's own-id (control / post-teardown
+/// fallthrough) path and the child's demux path — when the probe carries a
+/// reply target.
+fn reply_who(ctx: &mut FfiCtx<'_, Manual>, who: u32) {
+    if ctx.reply_target().is_some() {
+        ctx.reply(&InlineEcho { who });
+    }
+}
+
+/// Entry export — the loaded component. Spawns its inline child in `wire`,
+/// stores the alias, and tears the child down on a `DespawnChild` trigger.
+pub struct InlineDespawnParent {
+    /// The spawned child's alias `MailboxId` (set in `wire`), the handle the
+    /// `DespawnChild` handler tears down. `None` until `wire` runs.
+    child: Option<MailboxId>,
+}
+
+#[actor]
+impl FfiActor for InlineDespawnParent {
+    const NAMESPACE: &'static str = "test.inline.despawn_parent";
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
+    where
+        C: Resolver,
+    {
+        Ok(InlineDespawnParent { child: None })
+    }
+
+    /// ADR-0114: co-locate an `InlineDespawnChild` under the `Named` subname
+    /// `widget` and store the returned alias so the `DespawnChild` handler
+    /// can tear it down. The child is addressed by its rendered lineage name
+    /// (`{parent}/aether.embedded:widget`).
+    fn wire(&mut self, ctx: &mut FfiCtx<'_>) {
+        if let Ok(alias) =
+            ctx.spawn_inline_child::<InlineDespawnChild>(Subname::Named("widget"), &())
+        {
+            self.child = Some(alias);
+        }
+    }
+
+    /// Tear down the stored inline child (ADR-0114 teardown). The substrate
+    /// alias route is kept, so a later probe to the now-dead alias settles
+    /// back through this parent's dispatch tail rather than leaking.
+    #[handler::manual]
+    fn on_despawn(&mut self, ctx: &mut FfiCtx<'_, Manual>, _trigger: DespawnChild) {
+        if let Some(child) = self.child {
+            let _ = ctx.despawn_inline_child(child);
+        }
+    }
+
+    /// Answer an `InlineProbe` addressed to the parent's own mailbox with
+    /// the parent marker — the membrane's own-id (control) path, and the
+    /// post-teardown fallthrough target for a probe to the dead child alias.
+    #[handler::manual]
+    fn on_probe(&mut self, ctx: &mut FfiCtx<'_, Manual>, _probe: InlineProbe) {
+        reply_who(ctx, INLINE_WHO_PARENT);
+    }
+}
+
+/// Inline child — co-located in the parent's wasm instance. `Instanced`
+/// so it satisfies the `spawn_inline_child` bound; not exported (the parent
+/// constructs it in-process).
+pub struct InlineDespawnChild;
+
+impl Instanced for InlineDespawnChild {}
+
+#[actor]
+impl FfiActor for InlineDespawnChild {
+    const NAMESPACE: &'static str = "test.inline.despawn_child";
+
+    fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
+    where
+        C: Resolver,
+    {
+        Ok(InlineDespawnChild)
+    }
+
+    /// Answer an `InlineProbe` addressed to the child's alias with the child
+    /// marker — the membrane's child-demux path.
+    #[handler::manual]
+    fn on_probe(&mut self, ctx: &mut FfiCtx<'_, Manual>, _probe: InlineProbe) {
+        reply_who(ctx, INLINE_WHO_CHILD);
+    }
+
+    /// Self-despawn: tear *itself* down mid-dispatch (ADR-0114 reentrant
+    /// teardown). The membrane has this child taken out of its slot while it
+    /// runs, so `despawn_inline_child` clears the empty slot and the
+    /// membrane's `reinsert` no-ops, dropping the live box at end of
+    /// dispatch. The child's own alias is the ctx's mailbox id.
+    #[handler::manual]
+    fn on_despawn(&mut self, ctx: &mut FfiCtx<'_, Manual>, _trigger: DespawnChild) {
+        let _ = ctx.despawn_inline_child(MailboxId(ctx.mailbox_id()));
+    }
+}
+
+aether_actor::export!(InlineDespawnParent);

--- a/crates/aether-test-fixtures/src/lib.rs
+++ b/crates/aether-test-fixtures/src/lib.rs
@@ -282,6 +282,23 @@ pub const INLINE_WHO_PARENT: u32 = 1;
 /// child-alias path).
 pub const INLINE_WHO_CHILD: u32 = 2;
 
+/// ADR-0114 inline-child teardown trigger. Sent to the despawn fixture's
+/// parent (which tears down its stored child via `ctx.despawn_inline_child`)
+/// or to the child's alias (which despawns itself mid-dispatch). Carries no
+/// payload — the recipient address selects which actor tears the child
+/// down. Postcard-shaped unit struct.
+#[derive(
+    aether_data::Kind,
+    aether_data::Schema,
+    serde::Serialize,
+    serde::Deserialize,
+    Debug,
+    Clone,
+    Default,
+)]
+#[kind(name = "aether.test_fixtures.despawn_child")]
+pub struct DespawnChild;
+
 #[cfg(test)]
 mod tests {
     use aether_data::{Kind, Ref};


### PR DESCRIPTION
Closes #1939.

## Summary

`spawn_inline_child` (#1916 / #1930) landed without an inverse — a component could spawn inline children but never tear one back down, so a widget tree could only grow. This adds the teardown verb, step 5 of the ADR-0114 inline-child arc.

`FfiCtx::despawn_inline_child(child: MailboxId) -> bool` drops the child from the ctx-side registry (running its `Drop`) and stops it handling mail, callable from any depth and idempotent. It deliberately **keeps** the substrate alias route rather than deregistering it: mail in flight to a torn-down child — a fresh send or an orphaned reply — lands in the parent's inbox, the `export!` membrane finds no resident child, and falls through to `dispatch_own`, so the parent's dispatch tail records `Finished` and the chain settles (ADR-0080 / ADR-0094) rather than leaking. Self-despawn (a child removing its own slot mid-dispatch) needs no special handling — `reinsert`'s existing no-op-on-missing-slot drops the live box correctly, so there is no pending-removal flag and no membrane change. No substrate change, no new host fn, no `unwire` on despawn in v1.

## Test plan

- Guest unit tests in `ffi/inline.rs`: `InlineRegistry::remove` returns `true` then the alias is absent; `remove` on an absent id returns `false` (idempotent); self-despawn reentrancy — a child that removes its own slot mid-`membrane_dispatch` drops its box and the alias falls through to the parent.
- Guest unit test in `ffi/ctx.rs`: `despawn_inline_child` returns `true` then `false` on a second call.
- TestBench scenario `despawn_inline_child_settles_orphan_mail_via_parent`: probe the live child (answers `who == child`, settles); despawn via the parent; re-probe the same alias asserting `who == parent` and the chain settles, not `SettlementTimeout`.
- Full `scripts/preflight.sh` green (fmt, clippy `--workspace -D warnings`, doc, nextest `--workspace`, wasm32 component cross-build; the TestBench scenario ran with wgpu present).

## Generated by

`/implement` — agent execution of [scoped issue #1939](https://github.com/iamacoffeepot/aether/issues/1939).
