### PR TITLE
fix(mcp): actionable error when a capture returns no frame

### DIFF
--- a/crates/aether-mcp/src/rpc.rs
+++ b/crates/aether-mcp/src/rpc.rs
@@ -365,10 +365,19 @@ impl RpcSession {
     /// [`Self::call`], expecting exactly one `ReplyEvent` — the shape
     /// of the engines-cap result kinds (`ListEnginesResult`, etc.).
     pub async fn call_one(&self, envelope: MailEnvelope) -> anyhow::Result<MailEnvelope> {
+        let kind = envelope.kind;
+        let mailbox = envelope.to.mailbox;
         let mut events = self.call(envelope).await?;
         match events.len() {
             1 => Ok(events.pop().expect("len checked")),
-            n => Err(anyhow::anyhow!("expected exactly one reply event, got {n}")),
+            0 => Err(anyhow::anyhow!(
+                "recipient settled without a reply event (kind {kind}, mailbox {mailbox}); \
+                 this usually means the capability is unavailable on that engine \
+                 (e.g. frame capture on a windowless/headless substrate emits no frame)"
+            )),
+            n => Err(anyhow::anyhow!(
+                "expected exactly one reply event, got {n} (kind {kind}, mailbox {mailbox})"
+            )),
         }
     }
 
@@ -1032,6 +1041,74 @@ mod tests {
             pending_count(&session),
             0,
             "fire registers nothing in pending",
+        );
+
+        hub.stop();
+    }
+
+    /// `call_one` against a hub that settles with zero reply events
+    /// returns an actionable zero-reply error (issue 1934), naming the
+    /// kind and mailbox so the caller can correlate the diagnostic.
+    #[tokio::test]
+    async fn call_one_zero_replies_is_actionable_error() {
+        let (hub, port) = FakeHub::serve_with(
+            0,
+            ServeMode {
+                reply_events: 0,
+                send_end: true,
+            },
+        );
+        let session =
+            task::spawn_blocking(move || RpcSession::connect(&format!("127.0.0.1:{port}")))
+                .await
+                .expect("connect task")
+                .expect("connect");
+
+        let err = session
+            .call_one(probe_envelope())
+            .await
+            .expect_err("zero-reply settle must be an error");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("settled without a reply event"),
+            "zero-reply error should mention the settled-without-reply condition, got: {msg:?}",
+        );
+        assert!(
+            msg.contains("unavailable") || msg.contains("windowless") || msg.contains("headless"),
+            "zero-reply error should hint at capability unavailability, got: {msg:?}",
+        );
+
+        hub.stop();
+    }
+
+    /// `call_one` against a hub that emits two reply events returns
+    /// an error that distinguishes the multi-reply condition from the
+    /// zero-reply case (issue 1934) and names the kind and mailbox.
+    #[tokio::test]
+    async fn call_one_multi_reply_is_protocol_error() {
+        let (hub, port) = FakeHub::serve_with(
+            0,
+            ServeMode {
+                reply_events: 2,
+                send_end: true,
+            },
+        );
+        let session =
+            task::spawn_blocking(move || RpcSession::connect(&format!("127.0.0.1:{port}")))
+                .await
+                .expect("connect task")
+                .expect("connect");
+
+        let err = session
+            .call_one(probe_envelope())
+            .await
+            .expect_err("multi-reply settle must be an error");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("exactly one reply event") && msg.contains("got 2"),
+            "multi-reply error should mention the expected-one / got-N condition, got: {msg:?}",
         );
 
         hub.stop();


### PR DESCRIPTION
Closes #1934.

## Summary

A `capture_frame` (or any single-reply MCP tool call) that settled without producing a reply event surfaced as `MCP error -32603: expected exactly one reply event, got 0` — the internal reply-count assertion leaking verbatim, naming neither the call nor the recipient and reading like an engine bug.

The fix lands in the one shared helper, `RpcSession::call_one`, rather than special-casing capture. The single `n =>` arm collapsed two distinct conditions; it is now split into a `0 =>` branch (the recipient settled without a reply event — names the kind and mailbox, and notes that a zero-reply settle usually means the capability is unavailable on that engine, e.g. frame capture on a windowless substrate) and an `n =>` branch (keeps the count for a genuine multi-reply protocol surprise, now also naming kind and mailbox). The `kind` and `mailbox` ids are captured off the envelope before it moves into the call. This fixes capture and all single-reply callers at the exact site the bug lives, with no new dependency in the transport layer and no public-signature change.

## Test plan

- Two unit tests in `rpc.rs` driving the existing `FakeHub` scaffold: settle with zero reply events (asserts the actionable zero-reply message) and with two reply events (asserts the multi-reply message). Plain `#[tokio::test]`, matching the existing reply-count tests — no FleetBench, no live engine.
- Full `scripts/preflight.sh` green.

## Generated by

`/implement` — agent execution of [scoped issue #1934](https://github.com/iamacoffeepot/aether/issues/1934).
