### PR TITLE
feat(capabilities): hub binary store with upload and list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,7 @@ dependencies = [
  "postcard",
  "serde",
  "serde_json",
+ "sha2",
  "tracing",
  "ureq",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,11 @@ proc-macro2 = "1"
 quote = "1"
 serde = { version = "1", default-features = false }
 serde_json = "1"
+# Content-addressed hashing for the hub binary store (ADR-0115, issue
+# 1953): sha256 over a binary's raw bytes keys each entry. Native-only
+# consumer (`aether-capabilities` under `native`); pinned here so any
+# future hashing surface shares the major.
+sha2 = "0.10"
 syn = { version = "2", features = ["full"] }
 tracing = { version = "0.1", default-features = false }
 wasmtime = "44"

--- a/crates/aether-capabilities/Cargo.toml
+++ b/crates/aether-capabilities/Cargo.toml
@@ -43,6 +43,7 @@ native = [
     "dep:httparse",
     "dep:postcard",
     "dep:serde_json",
+    "dep:sha2",
     "dep:tracing",
     "dep:ureq",
     "dep:url",
@@ -130,6 +131,10 @@ postcard = { workspace = true, optional = true, features = ["alloc", "heapless-c
 # JSON request/response bodies for the content-gen provider APIs
 # (ADR-0050) — the Anthropic Messages API and the Gemini media APIs.
 serde_json = { workspace = true, optional = true }
+# ADR-0115 (issue 1953): sha256 content addressing for the hub binary
+# store. Rides the `native` feature — the store is native-only (it forks
+# `--describe` and reads staged paths), so wasm / marker builds skip it.
+sha2 = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true, features = ["std", "attributes"] }
 ureq = { version = "3", optional = true, features = ["rustls"] }
 url = { version = "2", optional = true }

--- a/crates/aether-capabilities/src/engine/server.rs
+++ b/crates/aether-capabilities/src/engine/server.rs
@@ -38,7 +38,8 @@
 // `#[bridge]` macro emits `impl HandlesKind<K>` markers as siblings of
 // the mod.
 use aether_kinds::{
-    EngineAlive, EngineDied, ListEngines, RouteEnvelope, SpawnEngine, TerminateEngine,
+    EngineAlive, EngineDied, ListBinaries, ListEngines, RouteEnvelope, SpawnEngine,
+    TerminateEngine, UploadBinary,
 };
 #[cfg(test)]
 use std::sync::{Arc, Mutex};
@@ -54,14 +55,17 @@ pub use server_native::{EngineConfig, EngineOverlay};
 #[aether_actor::bridge(singleton)]
 mod server_native {
     use super::{
-        EngineAlive, EngineDied, ListEngines, RouteEnvelope, SpawnEngine, TerminateEngine,
+        EngineAlive, EngineDied, ListBinaries, ListEngines, RouteEnvelope, SpawnEngine,
+        TerminateEngine, UploadBinary,
     };
     use crate::engine::proxy::{EngineProxy, EngineProxyConfig, HeartbeatParams};
+    use crate::store::{ArtifactKind, ArtifactStore};
     use aether_actor::actor;
     use aether_data::{EngineId, Kind, MailboxId, Uuid};
     use aether_kinds::{
-        CallSettled, DeadEngineDescriptor, DeathReason, EngineDescriptor, ForwardEnvelope,
-        ListEnginesResult, SpawnEngineResult, TerminateEngineResult,
+        BinaryManifest, CallSettled, DeadEngineDescriptor, DeathReason, EngineDescriptor,
+        ForwardEnvelope, ListBinariesResult, ListEnginesResult, SpawnEngineResult,
+        TerminateEngineResult, UploadBinaryResult,
     };
     use aether_substrate::Mail;
     use aether_substrate::Subname;
@@ -73,6 +77,7 @@ mod server_native {
     use std::collections::VecDeque;
     use std::convert::Infallible;
     use std::env;
+    use std::fs;
     use std::io;
     use std::net::TcpListener;
     use std::path::PathBuf;
@@ -219,6 +224,14 @@ mod server_native {
         /// so an observer can tell a clean terminate from a crash or a
         /// heartbeat eviction.
         recently_died: VecDeque<DeadRecord>,
+        /// Hub-scoped content-addressed binary store (ADR-0115, issue
+        /// 1953) — the storage half of the artifact registry.
+        /// `on_upload_binary` ingests a staged binary content-addressed;
+        /// `on_list_binaries` enumerates the stored entries. Built
+        /// `from_env` at init so it persists across a `restart-hub` (the
+        /// layout root outlives the hub child); the spawn cutover (#1954)
+        /// reads it back through the store's `get` seam.
+        store: ArtifactStore,
     }
 
     #[actor]
@@ -233,6 +246,7 @@ mod server_native {
                 mailer: ctx.mailer(),
                 heartbeat: config.heartbeat_params(),
                 recently_died: VecDeque::new(),
+                store: ArtifactStore::from_env(),
             })
         }
 
@@ -562,6 +576,84 @@ mod server_native {
                 entry.last_alive = Instant::now();
             }
         }
+
+        /// Ingest a binary into the hub's content-addressed store.
+        ///
+        /// # Agent
+        /// Send `UploadBinary { staged_path, name }`. The hub reads the
+        /// staged path itself (aether-mcp never reads the bytes — too
+        /// large for the tool channel), sha256-hashes it, dedups against
+        /// the store, forks `staged_path --describe` to capture its
+        /// `BinaryManifest`, stores both, and points `name` (when set) at
+        /// the hash. Reply: `UploadBinaryResult::Ok { hash, name }`, or
+        /// `Err { error }` for an unreadable path or a `--describe` that
+        /// failed or didn't yield a parseable manifest.
+        #[handler]
+        fn on_upload_binary(
+            &mut self,
+            _ctx: &mut NativeCtx<'_>,
+            mail: UploadBinary,
+        ) -> UploadBinaryResult {
+            let bytes = match fs::read(&mail.staged_path) {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    return UploadBinaryResult::Err {
+                        error: format!("reading staged path {:?}: {e}", mail.staged_path),
+                    };
+                }
+            };
+            let manifest = match describe_binary(&mail.staged_path) {
+                Ok(manifest) => manifest,
+                Err(error) => return UploadBinaryResult::Err { error },
+            };
+            let hash = self
+                .store
+                .upload(&bytes, ArtifactKind::Binary, manifest, mail.name.clone());
+            UploadBinaryResult::Ok {
+                hash,
+                name: mail.name,
+            }
+        }
+
+        /// Enumerate the hub's stored binaries.
+        ///
+        /// # Agent
+        /// Send `ListBinaries { chassis?, caps, target? }` (each filter
+        /// field AND-combined; an absent / empty field is no constraint).
+        /// Reply: `ListBinariesResult { binaries: [{ hash, name,
+        /// manifest: { chassis, caps, git_sha, profile, target } }] }`.
+        #[handler]
+        fn on_list_binaries(
+            &mut self,
+            _ctx: &mut NativeCtx<'_>,
+            mail: ListBinaries,
+        ) -> ListBinariesResult {
+            ListBinariesResult {
+                binaries: self.store.list(&mail),
+            }
+        }
+    }
+
+    /// Fork `binary_path --describe` and parse the JSON manifest it prints
+    /// (ADR-0115, issue 1953). The one-time capture of what a binary *is* —
+    /// its chassis kind, linked caps, and build provenance — without the
+    /// hub linking the chassis crate. `stdin` is nulled so a describe can't
+    /// block on input.
+    fn describe_binary(binary_path: &str) -> Result<BinaryManifest, String> {
+        let output = Command::new(binary_path)
+            .arg("--describe")
+            .stdin(Stdio::null())
+            .output()
+            .map_err(|e| format!("forking {binary_path:?} --describe: {e}"))?;
+        if !output.status.success() {
+            return Err(format!(
+                "{binary_path:?} --describe exited {}: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim(),
+            ));
+        }
+        serde_json::from_slice(&output.stdout)
+            .map_err(|e| format!("parsing {binary_path:?} --describe manifest JSON: {e}"))
     }
 
     /// Push a `CallSettled::Err` back to `target` (correlation
@@ -692,6 +784,7 @@ mod tests {
     // for fixture wiring — reference id derivation, not sibling-cap addressing.
     #![allow(clippy::disallowed_methods)]
     use super::{EngineConfig, EngineServer, ReplyCells, ReplySink};
+    use crate::store::ENV_BINARY_STORE_DIR;
     use crate::test_chassis::TestChassis;
     use aether_actor::Actor;
     use aether_data::{Kind, mailbox_id_from_name};
@@ -707,13 +800,14 @@ mod tests {
     use aether_substrate::mail::registry::Registry;
     use aether_substrate::mail::{Mail, Source, SourceAddr};
     use std::sync::Arc;
-    use std::thread;
-    use std::time::{Duration, Instant};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+    use std::{env, process, thread};
 
     /// Boot a passive chassis hosting `EngineServer` + the reply sink.
     /// Returns the chassis (kept alive for its dispatcher threads), the
     /// mailer to push requests through, and the sink's cells.
     fn boot() -> (PassiveChassis<TestChassis>, Arc<Mailer>, ReplyCells) {
+        isolate_binary_store();
         let registry = Arc::new(Registry::new());
         for d in descriptors::all() {
             let _ = registry.register_kind_with_descriptor(d);
@@ -728,6 +822,23 @@ mod tests {
             .build_passive()
             .expect("caps boot");
         (chassis, mailer, cells)
+    }
+
+    /// Point `EngineServer::init`'s `ArtifactStore::from_env` (ADR-0115) at
+    /// a per-call temp dir so the engines-cap unit tests never touch the
+    /// real `dirs::data_dir()` binary store. These tests live in
+    /// `mod heavy`, which nextest serializes (`serial-heavy`), so the
+    /// process-global env set can't race a sibling.
+    fn isolate_binary_store() {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        let dir = env::temp_dir().join(format!("aether-binstore-engcap-{}-{nanos}", process::id()));
+        // SAFETY: serialized as a heavy test; no sibling reads this var
+        // concurrently, and only `EngineServer` consumes it.
+        unsafe {
+            env::set_var(ENV_BINARY_STORE_DIR, &dir);
+        }
     }
 
     /// Drive one request kind at `aether.engine`, reply-to the sink,

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -72,6 +72,12 @@ pub mod lifecycle;
 #[cfg(feature = "render")]
 pub mod render;
 pub mod rpc;
+// Content-addressed hub artifact store (ADR-0115, issue 1953). Native-only
+// — it forks `--describe`, reads staged host paths, and hashes bytes with
+// `sha2`, none of which the wasm-marker build links. The `EngineServer`
+// (`aether.engine`) owns one.
+#[cfg(feature = "native")]
+pub mod store;
 pub mod tcp;
 pub mod test_bench;
 // Shared `TestChassis` / `fresh_substrate` / reply-decode fixtures for the
@@ -169,6 +175,8 @@ pub use render::HeadlessRenderCapability;
 pub use render::RenderCapability;
 #[cfg(feature = "render-native")]
 pub use render::{CaptureBackend, RenderConfig, RenderGpu, RenderHandles};
+#[cfg(feature = "native")]
+pub use store::{ArtifactKind, ArtifactStore, Selector, StoredArtifact};
 pub use tcp::{TcpCapability, TcpListenerActor};
 pub use test_bench::UnsupportedTestBenchCapability;
 #[cfg(feature = "text")]

--- a/crates/aether-capabilities/src/store.rs
+++ b/crates/aether-capabilities/src/store.rs
@@ -1,0 +1,799 @@
+//! Content-addressed artifact store for the hub (ADR-0115, issue 1953).
+//!
+//! The storage half of the hub artifact registry: somewhere above the
+//! engine layer to keep uploaded binaries content-addressed, ingest one
+//! from a staged host path, and read what each binary *is*. The per-engine
+//! ADR-0049 handle store sits *below* an engine and is keyed on an assigned
+//! `HandleId`; this store is hub-scoped and keyed on a sha256 over the raw
+//! bytes, so an identical re-upload dedups to the same entry.
+//!
+//! Artifact-generic from the start — an entry is a content blob plus a
+//! type-tagged ([`ArtifactKind`]) manifest — so the registry extraction
+//! (#1955) lifts it whole. Today the only artifact is a chassis binary and
+//! the manifest is a [`BinaryManifest`].
+//!
+//! ## Layout
+//!
+//! Under a hub-scoped, layout-versioned root
+//! (`AETHER_BINARY_STORE_DIR`, default `data_dir/aether/binaries/v1`):
+//!
+//! ```text
+//! <root>/
+//!   entries/
+//!     <hash>            the raw bytes (content-addressed)
+//!     <hash>.manifest   the type tag + manifest, JSON
+//!   names.json          name -> hash map
+//!   lock.pid            owning-process pid (best-effort reclaim)
+//! ```
+//!
+//! The store survives a `restart-hub` because the root persists across the
+//! hub child's restart. The disk budget is enforced by LRU eviction over
+//! entries that are neither pinned nor named — a named or pinned entry is
+//! kept regardless of recency.
+//!
+//! Modeled on the ADR-0049 handle store's lock / reclaim / budget shape
+//! (`aether_substrate::handle_store`), not its instance: the handle store
+//! is keyed on `HandleId` and lives per-engine. The shared `is_pid_alive`
+//! liveness check is the one piece literally reused. The `aether.engine`
+//! cap is single-threaded (one dispatcher run-token), so the store holds
+//! its index in plain fields behind `&mut self` rather than an inner lock.
+
+use std::collections::{HashMap, HashSet};
+use std::env;
+use std::fs;
+use std::io::{self, ErrorKind, Write as _};
+use std::path::{Path, PathBuf};
+use std::process;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use aether_kinds::{BinaryEntry, BinaryManifest, ListBinaries};
+use aether_substrate::handle_store::is_pid_alive;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Env override for the store's layout root (the ops escape hatch and the
+/// per-process isolation knob the fleet tests set). Absent → the platform
+/// data dir, then a temp fallback.
+pub const ENV_BINARY_STORE_DIR: &str = "AETHER_BINARY_STORE_DIR";
+
+/// Layout-version subdirectory under the resolved root, so a future
+/// on-disk format change can land beside `v1` without a migration.
+pub const LAYOUT_VERSION_DIR: &str = "v1";
+
+/// Default on-disk byte budget. 16 GiB — matches the handle store's disk
+/// budget; binaries are tens of megabytes, so this holds a deep history
+/// before LRU eviction kicks in.
+pub const DEFAULT_DISK_BUDGET_BYTES: u64 = 16 * 1024 * 1024 * 1024;
+
+const TARGET: &str = "aether_capabilities::store";
+
+/// The type tag on a stored artifact (ADR-0115). One variant today — the
+/// store is artifact-generic so #1955 can add more (component packs, asset
+/// bundles) without reshaping the entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ArtifactKind {
+    /// A chassis substrate binary, described by a [`BinaryManifest`].
+    Binary,
+}
+
+/// How a caller addresses a stored artifact in [`ArtifactStore::get`] —
+/// by its content hash or by a human-readable name. The seam #1954's
+/// spawn cutover consumes to resolve a registry reference to bytes.
+#[derive(Debug, Clone)]
+pub enum Selector {
+    /// The sha256 hex content address.
+    Hash(String),
+    /// A name an upload pointed at a hash.
+    Name(String),
+}
+
+/// One resolved artifact returned by [`ArtifactStore::get`]: its content
+/// hash, the on-disk path of its raw bytes (the fork target for #1954),
+/// the type tag, the manifest, and the name pointing at it (if any).
+#[derive(Debug, Clone)]
+pub struct StoredArtifact {
+    pub hash: String,
+    pub path: PathBuf,
+    pub kind: ArtifactKind,
+    pub manifest: BinaryManifest,
+    pub name: Option<String>,
+}
+
+/// The JSON sidecar written next to each entry's bytes — the type tag
+/// plus the manifest, so a fresh store rebuilds its index from disk.
+#[derive(Serialize, Deserialize, Clone)]
+struct StoredEntry {
+    kind: ArtifactKind,
+    manifest: BinaryManifest,
+}
+
+/// In-memory record of one entry. The bytes live on disk at
+/// `entries/<hash>`; only the metadata is held in memory (binaries are
+/// large), read back lazily on [`ArtifactStore::get`].
+struct Entry {
+    kind: ArtifactKind,
+    manifest: BinaryManifest,
+    bytes_len: u64,
+    /// Eviction protection independent of naming (an explicit
+    /// [`ArtifactStore::pin`]). A named entry is also eviction-protected.
+    pinned: bool,
+    /// Monotonic access stamp; lower = older, the LRU eviction key.
+    last_access: u64,
+}
+
+/// Content-addressed, disk-backed, budget-bounded artifact store
+/// (ADR-0115). Owned by the single-threaded `aether.engine` cap, so its
+/// index lives in plain fields behind `&mut self`; #1955 can wrap it
+/// behind a lock when a multi-owner registry needs one.
+pub struct ArtifactStore {
+    /// The layout-versioned root holding `entries/`, `names.json`,
+    /// `lock.pid`.
+    root: PathBuf,
+    disk_budget_bytes: u64,
+    /// hash -> entry metadata.
+    entries: HashMap<String, Entry>,
+    /// name -> hash. Repointing a name to a new hash is a plain overwrite;
+    /// the old hash keeps its bytes but loses its name (and so its
+    /// eviction protection).
+    names: HashMap<String, String>,
+    /// Approximate on-disk byte ledger, the LRU eviction trigger.
+    total_bytes: u64,
+    /// Monotonic source for `Entry::last_access`.
+    clock: u64,
+    /// `lock.pid` guard. Held for the store's lifetime when the lock was
+    /// freshly written; `None` when another live process holds it (the
+    /// store still operates — a content-addressed store tolerates a shared
+    /// dir, so the lock is hygiene, not a hard mutex).
+    _lock: Option<LockGuard>,
+}
+
+impl ArtifactStore {
+    /// Resolve the layout root from the environment, then [`open`] it.
+    ///
+    /// Priority: `AETHER_BINARY_STORE_DIR` env override, then
+    /// `data_dir/aether/binaries`, then `temp_dir/aether-binaries`. The
+    /// [`LAYOUT_VERSION_DIR`] is always appended.
+    ///
+    /// [`open`]: Self::open
+    #[must_use]
+    pub fn from_env() -> Self {
+        Self::open(&root_from_env(), DEFAULT_DISK_BUDGET_BYTES)
+    }
+
+    /// Open (or create) the store at `root` with the given disk budget.
+    /// Infallible: a root that can't be created falls back to a unique
+    /// temp dir so the hub always comes up with a working store. The
+    /// `lock.pid` reclaim is best-effort — a stale (dead-pid) or garbage
+    /// lock is reclaimed; a live holder leaves the store unlocked but
+    /// still operating.
+    #[must_use]
+    pub fn open(root: &Path, disk_budget_bytes: u64) -> Self {
+        let root = ensure_root(root);
+        let lock = acquire_lock(&root);
+        let RestoredIndex {
+            entries,
+            names,
+            total_bytes,
+            clock,
+        } = restore(&root);
+        Self {
+            root,
+            disk_budget_bytes,
+            entries,
+            names,
+            total_bytes,
+            clock,
+            _lock: lock,
+        }
+    }
+
+    /// The layout root this store resolved to (after any temp fallback).
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Ingest `bytes` content-addressed, recording `manifest` and
+    /// (optionally) pointing `name` at the resulting hash. A re-upload of
+    /// identical bytes dedups: the bytes aren't rewritten and the same
+    /// hash comes back, but a fresh `name` still repoints. Returns the
+    /// sha256 hex the bytes stored under. Runs LRU eviction afterward to
+    /// hold the disk budget.
+    pub fn upload(
+        &mut self,
+        bytes: &[u8],
+        kind: ArtifactKind,
+        manifest: BinaryManifest,
+        name: Option<String>,
+    ) -> String {
+        let hash = hash_hex(bytes);
+        let clock = self.next_clock();
+
+        if let Some(entry) = self.entries.get_mut(&hash) {
+            // Dedup: bump recency so a re-uploaded entry isn't the first
+            // eviction target.
+            entry.last_access = clock;
+        } else {
+            // New content: write the bytes + the sidecar, then index it. A
+            // write failure leaves the entry out of the index, so the store
+            // stays consistent — the next upload of the same bytes retries.
+            let (bytes_path, manifest_path) = self.entry_paths(&hash);
+            let sidecar = StoredEntry {
+                kind,
+                manifest: manifest.clone(),
+            };
+            if let Err(e) = atomic_write(&bytes_path, bytes) {
+                tracing::warn!(target: TARGET, hash = %hash, error = %e, "binary store: writing entry bytes failed");
+            } else if let Err(e) = write_sidecar(&manifest_path, &sidecar) {
+                tracing::warn!(target: TARGET, hash = %hash, error = %e, "binary store: writing entry manifest failed");
+                let _ = fs::remove_file(&bytes_path);
+            } else {
+                let bytes_len = bytes.len() as u64;
+                self.entries.insert(
+                    hash.clone(),
+                    Entry {
+                        kind,
+                        manifest,
+                        bytes_len,
+                        pinned: false,
+                        last_access: clock,
+                    },
+                );
+                self.total_bytes = self.total_bytes.saturating_add(bytes_len);
+            }
+        }
+
+        if let Some(name) = name {
+            self.names.insert(name, hash.clone());
+            self.persist_names();
+        }
+
+        self.evict_if_needed();
+        hash
+    }
+
+    /// Pin (or unpin) an entry by hash, protecting it from eviction
+    /// independent of whether a name points at it. Returns `false` if no
+    /// entry has that hash. Persistence of the pin flag is a fast-follow —
+    /// today a pin holds for the store's lifetime (the hub process).
+    pub fn set_pinned(&mut self, hash: &str, pinned: bool) -> bool {
+        if let Some(entry) = self.entries.get_mut(hash) {
+            entry.pinned = pinned;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Pin an entry by hash. Convenience for `set_pinned(hash, true)`.
+    pub fn pin(&mut self, hash: &str) -> bool {
+        self.set_pinned(hash, true)
+    }
+
+    /// Enumerate the stored binaries matching `filter` as
+    /// [`BinaryEntry`]s. The filter fields are AND-combined: `chassis` /
+    /// `target` are exact matches, `caps` requires the entry's caps to be
+    /// a superset of every listed cap. Each absent field is "no
+    /// constraint".
+    #[must_use]
+    pub fn list(&self, filter: &ListBinaries) -> Vec<BinaryEntry> {
+        self.entries
+            .iter()
+            .filter(|(_, entry)| matches_filter(&entry.manifest, filter))
+            .map(|(hash, entry)| BinaryEntry {
+                hash: hash.clone(),
+                name: self.name_for(hash),
+                manifest: entry.manifest.clone(),
+            })
+            .collect()
+    }
+
+    /// Resolve an artifact by hash or name to its on-disk path + manifest
+    /// (ADR-0115; the seam #1954 consumes). `None` if the hash / name
+    /// isn't stored. Bumps the entry's recency.
+    pub fn get(&mut self, selector: &Selector) -> Option<StoredArtifact> {
+        let hash = match selector {
+            Selector::Hash(h) => h.clone(),
+            Selector::Name(n) => self.names.get(n)?.clone(),
+        };
+        let clock = self.next_clock();
+        let entry = self.entries.get_mut(&hash)?;
+        entry.last_access = clock;
+        let kind = entry.kind;
+        let manifest = entry.manifest.clone();
+        let name = self.name_for(&hash);
+        let (path, _) = self.entry_paths(&hash);
+        Some(StoredArtifact {
+            hash,
+            path,
+            kind,
+            manifest,
+            name,
+        })
+    }
+
+    /// Number of stored entries.
+    #[must_use]
+    pub fn entry_count(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Approximate on-disk byte total.
+    #[must_use]
+    pub fn total_bytes(&self) -> u64 {
+        self.total_bytes
+    }
+
+    /// Whether an entry with `hash` is stored.
+    #[must_use]
+    pub fn contains(&self, hash: &str) -> bool {
+        self.entries.contains_key(hash)
+    }
+
+    /// The first name pointing at `hash`, for a [`BinaryEntry`] / a
+    /// [`StoredArtifact`]. At most one name per hash in practice.
+    fn name_for(&self, hash: &str) -> Option<String> {
+        self.names
+            .iter()
+            .find(|(_, h)| h.as_str() == hash)
+            .map(|(n, _)| n.clone())
+    }
+
+    fn next_clock(&mut self) -> u64 {
+        self.clock += 1;
+        self.clock
+    }
+
+    /// The `(bytes, manifest-sidecar)` paths for `hash` under `entries/`.
+    fn entry_paths(&self, hash: &str) -> (PathBuf, PathBuf) {
+        let dir = self.root.join("entries");
+        (dir.join(hash), dir.join(format!("{hash}.manifest")))
+    }
+
+    fn names_path(&self) -> PathBuf {
+        self.root.join("names.json")
+    }
+
+    /// Rewrite `names.json` from the in-memory map (best-effort).
+    fn persist_names(&self) {
+        match serde_json::to_vec(&self.names) {
+            Ok(bytes) => {
+                if let Err(e) = atomic_write(&self.names_path(), &bytes) {
+                    tracing::warn!(target: TARGET, error = %e, "binary store: persisting names failed");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(target: TARGET, error = %e, "binary store: encoding names failed");
+            }
+        }
+    }
+
+    /// Evict LRU entries that are neither pinned nor named until the disk
+    /// ledger is back under budget (or no eligible candidate remains).
+    fn evict_if_needed(&mut self) {
+        while self.total_bytes > self.disk_budget_bytes {
+            // Snapshot the named set once (a name protects its target), then
+            // pick the oldest eligible entry. Both reads borrow disjoint
+            // fields; `victim` is owned, so the removal below is clear.
+            let named: HashSet<&str> = self.names.values().map(String::as_str).collect();
+            let victim = self
+                .entries
+                .iter()
+                .filter(|(hash, entry)| !entry.pinned && !named.contains(hash.as_str()))
+                .min_by_key(|(_, entry)| entry.last_access)
+                .map(|(hash, _)| hash.clone());
+            drop(named);
+            let Some(hash) = victim else {
+                // Everything left is protected; can't shrink further.
+                break;
+            };
+            if let Some(entry) = self.entries.remove(&hash) {
+                self.total_bytes = self.total_bytes.saturating_sub(entry.bytes_len);
+                let (bytes_path, manifest_path) = self.entry_paths(&hash);
+                let _ = fs::remove_file(&bytes_path);
+                let _ = fs::remove_file(&manifest_path);
+                tracing::info!(target: TARGET, hash = %hash, "binary store: evicted to hold disk budget");
+            }
+        }
+    }
+}
+
+/// Whether a manifest passes a [`ListBinaries`] filter.
+fn matches_filter(manifest: &BinaryManifest, filter: &ListBinaries) -> bool {
+    if let Some(chassis) = &filter.chassis
+        && &manifest.chassis != chassis
+    {
+        return false;
+    }
+    if let Some(target) = &filter.target
+        && &manifest.target != target
+    {
+        return false;
+    }
+    filter.caps.iter().all(|c| manifest.caps.contains(c))
+}
+
+/// sha256 hex over `bytes` — the content address.
+fn hash_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+/// Resolve the layout root from the environment (see
+/// [`ArtifactStore::from_env`]).
+fn root_from_env() -> PathBuf {
+    if let Ok(raw) = env::var(ENV_BINARY_STORE_DIR)
+        && !raw.is_empty()
+    {
+        return PathBuf::from(raw).join(LAYOUT_VERSION_DIR);
+    }
+    if let Some(data) = dirs::data_dir() {
+        return data
+            .join("aether")
+            .join("binaries")
+            .join(LAYOUT_VERSION_DIR);
+    }
+    env::temp_dir()
+        .join("aether-binaries")
+        .join(LAYOUT_VERSION_DIR)
+}
+
+/// Ensure `root/entries` exists, falling back to a unique temp dir when
+/// the configured root can't be created — so the store always opens.
+fn ensure_root(root: &Path) -> PathBuf {
+    if fs::create_dir_all(root.join("entries")).is_ok() {
+        return root.to_path_buf();
+    }
+    let fallback =
+        env::temp_dir().join(format!("aether-binaries-{}-{}", process::id(), now_nanos()));
+    if let Err(e) = fs::create_dir_all(fallback.join("entries")) {
+        tracing::warn!(target: TARGET, error = %e, "binary store: temp fallback dir creation failed");
+    } else {
+        tracing::warn!(
+            target: TARGET,
+            requested = %root.display(),
+            fallback = %fallback.display(),
+            "binary store: configured root unusable; using a temp fallback",
+        );
+    }
+    fallback
+}
+
+/// Best-effort `lock.pid` acquisition (ADR-0115; reuses the handle
+/// store's reclaim shape). A stale (dead-pid) or garbage lock is
+/// reclaimed and rewritten with our pid; a live holder leaves the store
+/// unlocked (returns `None`) but still operating, since a content-
+/// addressed store tolerates a shared dir.
+fn acquire_lock(root: &Path) -> Option<LockGuard> {
+    let path = root.join("lock.pid");
+    if let Ok(raw) = fs::read_to_string(&path) {
+        match raw.trim().parse::<i32>() {
+            Ok(pid) if pid > 0 && is_pid_alive(pid) => {
+                // A live holder (possibly this same process re-opening the
+                // dir) leaves us unlocked but still operating.
+                tracing::warn!(
+                    target: TARGET,
+                    path = %path.display(),
+                    holder_pid = pid,
+                    "binary store: lock held by a live process; operating unlocked",
+                );
+                return None;
+            }
+            Ok(_) => {}
+            Err(_) => {
+                tracing::warn!(target: TARGET, path = %path.display(), "binary store: lock.pid holds garbage; reclaiming");
+            }
+        }
+    }
+    if let Err(e) = atomic_write(&path, process::id().to_string().as_bytes()) {
+        tracing::warn!(target: TARGET, path = %path.display(), error = %e, "binary store: writing lock.pid failed; operating unlocked");
+        return None;
+    }
+    Some(LockGuard { path })
+}
+
+/// The in-memory index [`restore`] rebuilds from disk.
+struct RestoredIndex {
+    entries: HashMap<String, Entry>,
+    names: HashMap<String, String>,
+    total_bytes: u64,
+    clock: u64,
+}
+
+/// Rebuild the in-memory index from disk: every `entries/<hash>.manifest`
+/// sidecar paired with its `<hash>` bytes, plus the `names.json` map.
+fn restore(root: &Path) -> RestoredIndex {
+    let mut entries: HashMap<String, Entry> = HashMap::new();
+    let mut total_bytes: u64 = 0;
+    let mut clock: u64 = 0;
+    let entries_dir = root.join("entries");
+    if let Ok(read_dir) = fs::read_dir(&entries_dir) {
+        for dirent in read_dir.flatten() {
+            let path = dirent.path();
+            // Only sidecars drive restoration; the bytes file is keyed off it.
+            if path.extension().and_then(|e| e.to_str()) != Some("manifest") {
+                continue;
+            }
+            let Some(hash) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            let Some(sidecar) = read_sidecar(&path) else {
+                continue;
+            };
+            let Ok(meta) = fs::metadata(entries_dir.join(hash)) else {
+                // Sidecar without bytes — a torn write; skip it.
+                continue;
+            };
+            let bytes_len = meta.len();
+            clock += 1;
+            entries.insert(
+                hash.to_owned(),
+                Entry {
+                    kind: sidecar.kind,
+                    manifest: sidecar.manifest,
+                    bytes_len,
+                    pinned: false,
+                    last_access: clock,
+                },
+            );
+            total_bytes = total_bytes.saturating_add(bytes_len);
+        }
+    }
+    // Names: keep only entries that still resolve to a stored hash.
+    let mut names: HashMap<String, String> = HashMap::new();
+    if let Ok(bytes) = fs::read(root.join("names.json"))
+        && let Ok(stored) = serde_json::from_slice::<HashMap<String, String>>(&bytes)
+    {
+        for (name, hash) in stored {
+            if entries.contains_key(&hash) {
+                names.insert(name, hash);
+            }
+        }
+    }
+    RestoredIndex {
+        entries,
+        names,
+        total_bytes,
+        clock,
+    }
+}
+
+fn read_sidecar(path: &Path) -> Option<StoredEntry> {
+    let bytes = fs::read(path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn write_sidecar(path: &Path, sidecar: &StoredEntry) -> io::Result<()> {
+    let bytes =
+        serde_json::to_vec(sidecar).map_err(|e| io::Error::new(ErrorKind::InvalidData, e))?;
+    atomic_write(path, &bytes)
+}
+
+/// Nanoseconds since the Unix epoch, for temp-dir and tmp-file nonces.
+fn now_nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos())
+}
+
+/// Atomic write via tmp + rename (the handle store's pattern): stage to a
+/// sibling `.tmp-<pid>-<nonce>`, fsync, rename over the target. Creates
+/// the parent dir lazily.
+fn atomic_write(target: &Path, bytes: &[u8]) -> io::Result<()> {
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let file_name = target
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("entry");
+    let tmp = target.with_file_name(format!("{file_name}.tmp-{}-{}", process::id(), now_nanos()));
+    {
+        let mut f = fs::File::create(&tmp)?;
+        f.write_all(bytes)?;
+        f.sync_all()?;
+    }
+    match fs::rename(&tmp, target) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = fs::remove_file(&tmp);
+            Err(e)
+        }
+    }
+}
+
+/// RAII guard that deletes `lock.pid` on graceful shutdown. SIGKILL
+/// bypasses `Drop`; the stale-lock reclaim on the next open handles that.
+struct LockGuard {
+    path: PathBuf,
+}
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ArtifactKind, ArtifactStore, DEFAULT_DISK_BUDGET_BYTES, ListBinaries, Selector};
+    use std::path::PathBuf;
+    use std::{env, fs, process};
+
+    fn temp_root(label: &str) -> PathBuf {
+        env::temp_dir().join(format!(
+            "aether-binstore-test-{label}-{}-{}",
+            process::id(),
+            super::now_nanos()
+        ))
+    }
+
+    fn manifest(chassis: &str) -> aether_kinds::BinaryManifest {
+        aether_kinds::BinaryManifest {
+            chassis: chassis.to_owned(),
+            caps: vec!["aether.fs".to_owned()],
+            git_sha: "deadbee".to_owned(),
+            profile: "debug".to_owned(),
+            target: "x86_64-unknown-linux-gnu".to_owned(),
+        }
+    }
+
+    #[test]
+    fn upload_dedups_identical_bytes_to_one_hash() {
+        let root = temp_root("dedup");
+        let mut store = ArtifactStore::open(&root, DEFAULT_DISK_BUDGET_BYTES);
+        let h1 = store.upload(
+            b"the-binary-bytes",
+            ArtifactKind::Binary,
+            manifest("headless"),
+            None,
+        );
+        let h2 = store.upload(
+            b"the-binary-bytes",
+            ArtifactKind::Binary,
+            manifest("headless"),
+            None,
+        );
+        assert_eq!(h1, h2, "identical bytes dedup to the same content hash");
+        assert_eq!(store.entry_count(), 1, "dedup stores one entry");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn name_repoints_to_the_latest_uploaded_hash() {
+        let root = temp_root("repoint");
+        let mut store = ArtifactStore::open(&root, DEFAULT_DISK_BUDGET_BYTES);
+        let h_old = store.upload(
+            b"v1",
+            ArtifactKind::Binary,
+            manifest("headless"),
+            Some("engine".to_owned()),
+        );
+        let h_new = store.upload(
+            b"v2",
+            ArtifactKind::Binary,
+            manifest("headless"),
+            Some("engine".to_owned()),
+        );
+        assert_ne!(h_old, h_new);
+        let resolved = store
+            .get(&Selector::Name("engine".to_owned()))
+            .expect("the name resolves");
+        assert_eq!(resolved.hash, h_new, "the name points at the latest upload");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn entries_persist_across_a_reopen() {
+        let root = temp_root("persist");
+        let hash = {
+            let mut store = ArtifactStore::open(&root, DEFAULT_DISK_BUDGET_BYTES);
+            store.upload(
+                b"persisted-bytes",
+                ArtifactKind::Binary,
+                manifest("headless"),
+                Some("svc".to_owned()),
+            )
+            // store drops here — LockGuard releases lock.pid
+        };
+        let mut reopened = ArtifactStore::open(&root, DEFAULT_DISK_BUDGET_BYTES);
+        assert!(reopened.contains(&hash), "the entry survives a reopen");
+        let resolved = reopened
+            .get(&Selector::Name("svc".to_owned()))
+            .expect("the name survives a reopen");
+        assert_eq!(resolved.hash, hash);
+        let bytes = fs::read(&resolved.path).expect("the stored bytes are readable");
+        assert_eq!(bytes, b"persisted-bytes");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn eviction_skips_pinned_and_named_entries() {
+        let root = temp_root("evict");
+        // Budget holds the three ~10-byte initial entries (≈31 bytes) but
+        // not a fourth, so the trigger upload forces exactly one eviction —
+        // of the only unnamed, unpinned candidate.
+        let mut store = ArtifactStore::open(&root, 40);
+        // Unnamed, unpinned — the eviction candidate.
+        let h_plain = store.upload(
+            b"plain-aaaa",
+            ArtifactKind::Binary,
+            manifest("headless"),
+            None,
+        );
+        // Named — protected.
+        let h_named = store.upload(
+            b"named-bbbb",
+            ArtifactKind::Binary,
+            manifest("headless"),
+            Some("keep".to_owned()),
+        );
+        // Pinned — protected.
+        let h_pinned = store.upload(
+            b"pinned-cccc",
+            ArtifactKind::Binary,
+            manifest("headless"),
+            None,
+        );
+        assert!(store.pin(&h_pinned), "pin targets a stored entry");
+        // Force eviction by re-running it through another over-budget upload.
+        let _ = store.upload(
+            b"trigger-dddd",
+            ArtifactKind::Binary,
+            manifest("headless"),
+            None,
+        );
+
+        assert!(store.contains(&h_named), "a named entry is never evicted");
+        assert!(store.contains(&h_pinned), "a pinned entry is never evicted");
+        assert!(
+            !store.contains(&h_plain),
+            "the oldest unnamed, unpinned entry is evicted first",
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn list_applies_chassis_and_caps_filters() {
+        let root = temp_root("filter");
+        let mut store = ArtifactStore::open(&root, DEFAULT_DISK_BUDGET_BYTES);
+        store.upload(
+            b"headless-bin",
+            ArtifactKind::Binary,
+            manifest("headless"),
+            None,
+        );
+        let mut desktop = manifest("desktop");
+        desktop.caps = vec!["aether.fs".to_owned(), "aether.render".to_owned()];
+        store.upload(b"desktop-bin", ArtifactKind::Binary, desktop, None);
+
+        let headless_only = store.list(&ListBinaries {
+            chassis: Some("headless".to_owned()),
+            caps: vec![],
+            target: None,
+        });
+        assert_eq!(headless_only.len(), 1);
+        assert_eq!(headless_only[0].manifest.chassis, "headless");
+
+        let render_capable = store.list(&ListBinaries {
+            chassis: None,
+            caps: vec!["aether.render".to_owned()],
+            target: None,
+        });
+        assert_eq!(
+            render_capable.len(),
+            1,
+            "only the desktop binary links render",
+        );
+        assert_eq!(render_capable[0].manifest.chassis, "desktop");
+
+        let all = store.list(&ListBinaries::default());
+        assert_eq!(all.len(), 2);
+        let _ = fs::remove_dir_all(&root);
+    }
+}

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1242,6 +1242,97 @@ mod engine {
     pub struct EngineAlive {
         pub engine_id: String,
     }
+
+    /// What a stored binary *is*, captured once at upload time by forking
+    /// the binary with `--describe` (ADR-0115, issue 1953). The
+    /// content-addressed store sidecars one of these next to each entry's
+    /// bytes, and [`ListBinariesResult`] returns it per entry so an
+    /// observer (and the spawn cutover, #1954) can tell a `headless` from
+    /// a `desktop` binary, see which capabilities it links, and read its
+    /// build provenance — all without re-running the binary.
+    ///
+    /// - `chassis` — the chassis profile (`Chassis::PROFILE`):
+    ///   `"headless"` / `"desktop"` / `"hub"`.
+    /// - `caps` — the mailbox namespaces the chassis registers (its
+    ///   linked capabilities, e.g. `aether.fs`, `aether.render`).
+    /// - `git_sha` / `profile` / `target` — build provenance from the
+    ///   bundle's `build.rs` (`git rev-parse --short HEAD`, the cargo
+    ///   build profile, the target triple); `git_sha` is `"unknown"` when
+    ///   the binary was built outside a git checkout.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+    pub struct BinaryManifest {
+        pub chassis: String,
+        pub caps: Vec<String>,
+        pub git_sha: String,
+        pub profile: String,
+        pub target: String,
+    }
+
+    /// One stored binary in a [`ListBinariesResult`] (ADR-0115, issue
+    /// 1953). `hash` is the sha256 hex over the binary's raw bytes — the
+    /// content-address key. `name` is the optional human-readable name an
+    /// upload pointed at this hash (the latest upload that named it wins).
+    /// `manifest` is what the binary reported via `--describe`.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+    pub struct BinaryEntry {
+        pub hash: String,
+        pub name: Option<String>,
+        pub manifest: BinaryManifest,
+    }
+
+    /// `aether.engine.upload_binary` — ingest a binary into the hub's
+    /// content-addressed store (ADR-0115, issue 1953). `staged_path` is an
+    /// absolute host path the hub reads itself (aether-mcp never reads the
+    /// bytes — a binary is too large to ride the tool channel); the cap
+    /// sha256-hashes the bytes, dedups against the existing store, forks
+    /// `staged_path --describe` to capture its [`BinaryManifest`], and
+    /// stores both. `name`, when set, points that human-readable name at
+    /// the resulting hash. Reply: [`UploadBinaryResult`].
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.engine.upload_binary")]
+    pub struct UploadBinary {
+        pub staged_path: String,
+        pub name: Option<String>,
+    }
+
+    /// Reply to [`UploadBinary`] (ADR-0115, issue 1953). `Ok` carries the
+    /// content-address `hash` the bytes stored under (a re-upload of
+    /// identical bytes returns the same hash) and the `name` now pointing
+    /// at it, if any. `Err` carries a free-form reason — an unreadable
+    /// `staged_path`, or a `--describe` that failed or didn't yield a
+    /// parseable manifest.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.engine.upload_binary_result")]
+    pub enum UploadBinaryResult {
+        Ok { hash: String, name: Option<String> },
+        Err { error: String },
+    }
+
+    /// `aether.engine.list_binaries` — enumerate the hub's stored binaries
+    /// (ADR-0115, issue 1953). The filter fields are AND-combined and each
+    /// defaults to "no constraint": `chassis` keeps only entries whose
+    /// `manifest.chassis` matches, `caps` keeps only entries whose
+    /// `manifest.caps` is a superset of every listed cap, `target` keeps
+    /// only entries whose `manifest.target` matches. Reply:
+    /// [`ListBinariesResult`].
+    #[derive(
+        aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default,
+    )]
+    #[kind(name = "aether.engine.list_binaries")]
+    pub struct ListBinaries {
+        pub chassis: Option<String>,
+        pub caps: Vec<String>,
+        pub target: Option<String>,
+    }
+
+    /// Reply to [`ListBinaries`] (ADR-0115, issue 1953): every stored
+    /// binary matching the filter, each as a [`BinaryEntry`] carrying its
+    /// hash, optional name, and `--describe` manifest.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.engine.list_binaries_result")]
+    pub struct ListBinariesResult {
+        pub binaries: Vec<BinaryEntry>,
+    }
 }
 
 mod control_plane {
@@ -4070,6 +4161,72 @@ mod tests {
         let back = SpawnEngine::decode_from_bytes(&bare.encode_into_bytes())
             .expect("test setup: bare SpawnEngine decodes");
         assert_eq!(back.boot_manifest, None);
+    }
+
+    #[test]
+    fn binary_store_kinds_roundtrip() {
+        // The hub binary-store registry kinds (ADR-0115, issue 1953) ride
+        // the postcard path — `Option<String>` + `Vec<String>` + a nested
+        // `Schema` manifest struct. The request, the tagged result, and the
+        // list reply with its embedded `BinaryEntry`/`BinaryManifest` must
+        // all survive the engines-cap encode/decode.
+        use alloc::string::ToString;
+        use alloc::vec;
+
+        let upload = UploadBinary {
+            staged_path: "/tmp/staged/aether-substrate-headless".to_string(),
+            name: Some("headless".to_string()),
+        };
+        let back = UploadBinary::decode_from_bytes(&upload.encode_into_bytes())
+            .expect("test setup: UploadBinary decodes");
+        assert_eq!(back.staged_path, upload.staged_path);
+        assert_eq!(back.name.as_deref(), Some("headless"));
+
+        let ok = UploadBinaryResult::Ok {
+            hash: "abc123".to_string(),
+            name: Some("headless".to_string()),
+        };
+        match UploadBinaryResult::decode_from_bytes(&ok.encode_into_bytes())
+            .expect("test setup: UploadBinaryResult decodes")
+        {
+            UploadBinaryResult::Ok { hash, name } => {
+                assert_eq!(hash, "abc123");
+                assert_eq!(name.as_deref(), Some("headless"));
+            }
+            UploadBinaryResult::Err { error } => panic!("expected Ok, got Err {error}"),
+        }
+
+        let manifest = BinaryManifest {
+            chassis: "headless".to_string(),
+            caps: vec!["aether.fs".to_string(), "aether.render".to_string()],
+            git_sha: "deadbee".to_string(),
+            profile: "debug".to_string(),
+            target: "aarch64-apple-darwin".to_string(),
+        };
+        let listed = ListBinariesResult {
+            binaries: vec![BinaryEntry {
+                hash: "abc123".to_string(),
+                name: Some("headless".to_string()),
+                manifest: manifest.clone(),
+            }],
+        };
+        let back = ListBinariesResult::decode_from_bytes(&listed.encode_into_bytes())
+            .expect("test setup: ListBinariesResult decodes");
+        assert_eq!(back.binaries.len(), 1);
+        assert_eq!(back.binaries[0].hash, "abc123");
+        assert_eq!(back.binaries[0].name.as_deref(), Some("headless"));
+        assert_eq!(back.binaries[0].manifest, manifest);
+
+        let filter = ListBinaries {
+            chassis: Some("headless".to_string()),
+            caps: vec!["aether.fs".to_string()],
+            target: None,
+        };
+        let back = ListBinaries::decode_from_bytes(&filter.encode_into_bytes())
+            .expect("test setup: ListBinaries decodes");
+        assert_eq!(back.chassis.as_deref(), Some("headless"));
+        assert_eq!(back.caps, vec!["aether.fs".to_string()]);
+        assert_eq!(back.target, None);
     }
 
     #[test]

--- a/crates/aether-mcp/src/args.rs
+++ b/crates/aether-mcp/src/args.rs
@@ -61,6 +61,39 @@ pub struct TerminateSubstrateArgs {
     pub engine_id: String,
 }
 
+/// `upload_binary` arguments (ADR-0115, issue 1953).
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UploadBinaryArgs {
+    /// Absolute path to the binary on the fleet host. The hub reads this
+    /// path itself, content-addresses it (sha256), and forks
+    /// `<path> --describe` to capture its manifest — aether-mcp never
+    /// reads the bytes (unlike `load_component`, a binary is too large
+    /// for the tool channel).
+    pub staged_path: String,
+    /// Optional human-readable name to point at the resulting hash. A
+    /// later upload with the same name repoints it; the named entry is
+    /// protected from LRU eviction.
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+/// `list_binaries` arguments (ADR-0115, issue 1953). Every field is an
+/// optional AND-combined filter; omit all to list the whole store.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListBinariesArgs {
+    /// Keep only binaries whose manifest chassis matches (`"headless"` /
+    /// `"desktop"` / `"hub"`).
+    #[serde(default)]
+    pub chassis: Option<String>,
+    /// Keep only binaries whose linked caps are a superset of every cap
+    /// listed here (e.g. `["aether.render"]`).
+    #[serde(default)]
+    pub caps: Vec<String>,
+    /// Keep only binaries whose manifest target triple matches.
+    #[serde(default)]
+    pub target: Option<String>,
+}
+
 /// `send_mail` arguments — a best-effort batch.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SendMailArgs {

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -31,10 +31,11 @@ use aether_data::{EnumVariant, Primitive, SchemaType};
 use aether_kinds::dag::{DagDescriptor, Edge, Node, NodeId};
 use aether_kinds::{
     Cancel, CancelResult, CaptureFrame, CaptureFrameResult, ComponentCapabilities, CostTail,
-    CostTailResult, DeathReason, FrameCheck, FrameReduction, ListEngines, ListEnginesResult,
-    ListKinds, ListKindsResult, LoadComponent, LoadResult, MailEnvelope as KindMailEnvelope,
-    ReplaceComponent, ReplaceResult, SimilarityCheck, SpawnEngine, SpawnEngineResult, Status,
-    StatusResult, Submit, SubmitResult, TerminateEngine, TerminateEngineResult,
+    CostTailResult, DeathReason, FrameCheck, FrameReduction, ListBinaries, ListBinariesResult,
+    ListEngines, ListEnginesResult, ListKinds, ListKindsResult, LoadComponent, LoadResult,
+    MailEnvelope as KindMailEnvelope, ReplaceComponent, ReplaceResult, SimilarityCheck,
+    SpawnEngine, SpawnEngineResult, Status, StatusResult, Submit, SubmitResult, TerminateEngine,
+    TerminateEngineResult, UploadBinary, UploadBinaryResult,
     trace::{
         DescribeTreeResult, DispatchTraced, DispatchTracedAck, MailNodeWire, TRACE_MAILBOX_NAME,
         TraceTail, TraceTailResult,
@@ -56,10 +57,11 @@ use crate::args::{
     CaptureCheckSpec, CaptureFrameArgs, CaptureMailSpec, ComponentSpec, DagCancelArgs,
     DagDescriptorArg, DagStatusArgs, DeadEngineInfo, DescribeComponentArgs, DescribeHandlersArgs,
     DescribeHandlersResponse, DescribeHandlesArgs, DescribeHandlesResponse, DescribeKindsArgs,
-    EngineInfo, HandleSummaryJson, KindSummary, ListEnginesResponse, LoadComponentArgs, MailIdJson,
-    MailNodeJson, MailSpec, MailStatus, NativeCapHandlers, NativeHandlerJson, NodeArg,
-    ReplaceComponentArgs, ReplyEventJson, SendMailArgs, SendMailTracedArgs, SendMailTracedResponse,
-    SpawnSubstrateArgs, SubmitDagArgs, TerminateSubstrateArgs, TracedMailSpec, TransformListing,
+    EngineInfo, HandleSummaryJson, KindSummary, ListBinariesArgs, ListEnginesResponse,
+    LoadComponentArgs, MailIdJson, MailNodeJson, MailSpec, MailStatus, NativeCapHandlers,
+    NativeHandlerJson, NodeArg, ReplaceComponentArgs, ReplyEventJson, SendMailArgs,
+    SendMailTracedArgs, SendMailTracedResponse, SpawnSubstrateArgs, SubmitDagArgs,
+    TerminateSubstrateArgs, TracedMailSpec, TransformListing, UploadBinaryArgs,
 };
 use crate::reverse::EngineNames;
 use crate::rpc::RpcSession;
@@ -300,6 +302,60 @@ impl Mcp {
             Some(TerminateEngineResult::Ok) => json(&serde_json::json!({ "status": "terminated" })),
             Some(TerminateEngineResult::Err { error }) => Err(internal_msg(&error)),
             None => Err(internal_msg("undecodable TerminateEngineResult")),
+        }
+    }
+
+    #[tool(
+        description = "Upload a binary into the hub's content-addressed store (ADR-0115). Pass `staged_path` — an absolute path to the binary on the fleet host — and an optional `name`. The hub reads the path itself (aether-mcp never reads the bytes — a binary is too large for the tool channel), sha256-hashes it, dedups against the store (a re-upload of identical bytes returns the same hash), forks `<binary> --describe` to capture its manifest (chassis kind, linked caps, build provenance), stores both, and points `name` (when given) at the hash. The store persists across a restart-hub. Returns {hash, name}."
+    )]
+    pub async fn upload_binary(
+        &self,
+        Parameters(args): Parameters<UploadBinaryArgs>,
+    ) -> Result<String, McpError> {
+        // The hub reads the staged path; aether-mcp forwards it, never
+        // reading the bytes (unlike load_component).
+        let reply = self
+            .session
+            .call_one(local_envelope(
+                ENGINE_CAP,
+                &UploadBinary {
+                    staged_path: args.staged_path,
+                    name: args.name,
+                },
+            ))
+            .await
+            .map_err(internal)?;
+        match UploadBinaryResult::decode_from_bytes(&reply.payload) {
+            Some(UploadBinaryResult::Ok { hash, name }) => {
+                json(&serde_json::json!({ "hash": hash, "name": name }))
+            }
+            Some(UploadBinaryResult::Err { error }) => Err(internal_msg(&error)),
+            None => Err(internal_msg("undecodable UploadBinaryResult")),
+        }
+    }
+
+    #[tool(
+        description = "Enumerate the hub's stored binaries (ADR-0115). Optional AND-combined filters: `chassis` (\"headless\"/\"desktop\"/\"hub\"), `caps` (keep only binaries whose linked caps are a superset of every listed cap), `target` (the build target triple). Omit all to list the whole store. Returns an array of {hash, name, manifest: {chassis, caps, git_sha, profile, target}} — the manifest each binary reported via a one-time --describe at upload time."
+    )]
+    pub async fn list_binaries(
+        &self,
+        Parameters(args): Parameters<ListBinariesArgs>,
+    ) -> Result<String, McpError> {
+        let reply = self
+            .session
+            .call_one(local_envelope(
+                ENGINE_CAP,
+                &ListBinaries {
+                    chassis: args.chassis,
+                    caps: args.caps,
+                    target: args.target,
+                },
+            ))
+            .await
+            .map_err(internal)?;
+        match ListBinariesResult::decode_from_bytes(&reply.payload) {
+            Some(result) => json(&result.binaries),
+            None => Err(internal_msg("undecodable ListBinariesResult")),
         }
     }
 

--- a/crates/aether-substrate-bundle/build.rs
+++ b/crates/aether-substrate-bundle/build.rs
@@ -14,6 +14,7 @@
 //! so the bins still compile — they just boot componentless if run,
 //! which only the bundle flow ever does for real.
 
+use std::process::Command;
 use std::{env, fs, path::Path, path::PathBuf};
 
 // The pack encoder + manifest schema + reader, shared with the lib
@@ -28,6 +29,7 @@ mod bundle_pack;
 use bundle_pack::{Pack, encode_pack, pack_from_manifest, read_manifest};
 
 fn main() {
+    emit_provenance();
     println!("cargo:rerun-if-env-changed=AETHER_BUNDLE_MANIFEST");
     println!("cargo:rerun-if-changed=src/bundle_pack.rs");
     let out = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR set by cargo"))
@@ -36,6 +38,39 @@ fn main() {
         pack_for(Path::new(&manifest_path))
     });
     fs::write(&out, encode_pack(&pack)).expect("write bundle pack blob");
+}
+
+/// Bake build provenance into the chassis bins so their `--describe`
+/// manifest (ADR-0115, issue 1953) can report the source revision, build
+/// profile, and target triple without a runtime git / cargo probe. The
+/// bins read these back via `env!`:
+///
+/// - `AETHER_GIT_SHA` — `git rev-parse --short HEAD`, or `"unknown"` when
+///   the binary is built outside a git checkout (a published crate, a
+///   tarball). The `rerun-if-changed` on `.git/HEAD` re-runs the script
+///   when the checkout moves to a new commit.
+/// - `AETHER_BUILD_PROFILE` — cargo's `PROFILE` (`debug` / `release`).
+/// - `AETHER_TARGET_TRIPLE` — cargo's `TARGET` (e.g.
+///   `aarch64-apple-darwin`).
+fn emit_provenance() {
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    let git_sha = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .and_then(|out| String::from_utf8(out.stdout).ok())
+        .map_or_else(|| "unknown".to_owned(), |s| s.trim().to_owned());
+    let git_sha = if git_sha.is_empty() {
+        "unknown".to_owned()
+    } else {
+        git_sha
+    };
+    println!("cargo:rustc-env=AETHER_GIT_SHA={git_sha}");
+    let profile = env::var("PROFILE").unwrap_or_else(|_| "unknown".to_owned());
+    println!("cargo:rustc-env=AETHER_BUILD_PROFILE={profile}");
+    let target = env::var("TARGET").unwrap_or_else(|_| "unknown".to_owned());
+    println!("cargo:rustc-env=AETHER_TARGET_TRIPLE={target}");
 }
 
 /// Register the manifest plus every wasm / config it names for

--- a/crates/aether-substrate-bundle/src/bin/desktop.rs
+++ b/crates/aether-substrate-bundle/src/bin/desktop.rs
@@ -32,6 +32,16 @@ fn main() -> anyhow::Result<()> {
         print!("{}", chassis_config_dump());
         return Ok(());
     }
+    // `--describe` (ADR-0115, issue 1953): print this binary's manifest —
+    // chassis kind, linked caps, build provenance — as JSON, then exit
+    // before boot (no winit event loop opened).
+    if cli.describe {
+        println!(
+            "{}",
+            serde_json::to_string(&DesktopChassis::describe_manifest())?
+        );
+        return Ok(());
+    }
     let env = DesktopEnv::from_env_with_argv(cli)?;
     let chassis = DesktopChassis::build(env)?;
     tracing::info!(

--- a/crates/aether-substrate-bundle/src/bin/headless.rs
+++ b/crates/aether-substrate-bundle/src/bin/headless.rs
@@ -31,6 +31,17 @@ fn main() -> anyhow::Result<()> {
         print!("{}", chassis_config_dump());
         return Ok(());
     }
+    // `--describe` (ADR-0115, issue 1953): print this binary's manifest —
+    // chassis kind, linked caps, build provenance — as JSON, then exit
+    // before boot. The hub's binary store forks `<binary> --describe`
+    // once at upload time to capture exactly this.
+    if cli.describe {
+        println!(
+            "{}",
+            serde_json::to_string(&HeadlessChassis::describe_manifest())?
+        );
+        return Ok(());
+    }
     let env = HeadlessEnv::from_env_with_argv(cli)?;
     let chassis = HeadlessChassis::build(env)?;
     tracing::info!(

--- a/crates/aether-substrate-bundle/src/bin/hub.rs
+++ b/crates/aether-substrate-bundle/src/bin/hub.rs
@@ -46,6 +46,16 @@ fn main() -> anyhow::Result<()> {
         print!("{}", dump_config(&[], HUB_KNOBS));
         return Ok(());
     }
+    // `--describe` (ADR-0115, issue 1953): print this binary's manifest —
+    // chassis kind, linked caps, build provenance — as JSON, then exit
+    // before boot.
+    if cli.describe {
+        println!(
+            "{}",
+            serde_json::to_string(&HubChassis::describe_manifest())?
+        );
+        return Ok(());
+    }
     let chassis = HubChassis::build(HubEnv::from_env_with_argv(&cli))?;
     eprintln!(
         "aether-substrate-bundle: hub chassis initialised (profile={})",

--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -15,6 +15,7 @@ use std::env;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use aether_actor::Actor;
 use aether_capabilities::anthropic::AnthropicConfigLayer;
 use aether_capabilities::audio::AudioConfigLayer;
 use aether_capabilities::fs::NamespaceRootsLayer;
@@ -30,7 +31,7 @@ use aether_capabilities::{
     LifecycleConfig, TcpCapability, TextCapability, UiCapability, fs::NamespaceRoots,
     http::HttpConfig, trace::TraceDispatchCapability,
 };
-use aether_kinds::{Present, Render, Shutdown, Tick};
+use aether_kinds::{BinaryManifest, Present, Render, Shutdown, Tick};
 // The `aether.trajectory` recorder cap moved to `aether-labyrinth` (issue
 // 1908); the mailbox NAMESPACE (and so its hash-derived id) is unchanged.
 use aether_labyrinth::TrajectoryRecorderCapability;
@@ -306,6 +307,54 @@ pub fn with_common_caps<C: Chassis>(builder: Builder<C>, boot: CommonBoot) -> Bu
         .with_actor::<TcpCapability>(())
         .with_actor::<AnthropicCapability>(boot.anthropic)
         .with_actor::<GeminiCapability>(boot.gemini)
+}
+
+/// The mailbox namespaces `with_common_caps` registers — the linked
+/// capabilities every full-stack chassis carries, for the `--describe`
+/// manifest (ADR-0115, issue 1953). Read straight off each cap type's
+/// `Actor::NAMESPACE` const, so the values can't drift from what
+/// `with_common_caps` actually claims; the *membership* of this list must
+/// be kept in lockstep with the `.with_actor::<_>()` chain above (a cap
+/// added there must be added here). The renderer / window / lifecycle
+/// extras each chassis layers on top are appended by its own
+/// `cap_namespaces` helper.
+#[must_use]
+pub fn common_cap_namespaces() -> Vec<&'static str> {
+    vec![
+        <HandleCapability as Actor>::NAMESPACE,
+        <TraceDispatchCapability as Actor>::NAMESPACE,
+        <DagCapability as Actor>::NAMESPACE,
+        <TrajectoryRecorderCapability as Actor>::NAMESPACE,
+        <InputCapability as Actor>::NAMESPACE,
+        <ComponentHostCapability as Actor>::NAMESPACE,
+        <FsCapability as Actor>::NAMESPACE,
+        <TextCapability as Actor>::NAMESPACE,
+        <UiCapability as Actor>::NAMESPACE,
+        <InventoryCapability as Actor>::NAMESPACE,
+        <HttpCapability as Actor>::NAMESPACE,
+        <TcpCapability as Actor>::NAMESPACE,
+        <AnthropicCapability as Actor>::NAMESPACE,
+        <GeminiCapability as Actor>::NAMESPACE,
+    ]
+}
+
+/// Assemble a chassis bin's `--describe` [`BinaryManifest`] (ADR-0115,
+/// issue 1953): the chassis profile, the mailbox namespaces it links, and
+/// the build provenance `build.rs` baked into the bundle crate
+/// (`AETHER_GIT_SHA` / `AETHER_BUILD_PROFILE` / `AETHER_TARGET_TRIPLE`).
+/// The `env!`s resolve in this crate, where `build.rs` set them. Each
+/// chassis bin calls this on `--describe`, prints the JSON, and exits
+/// before boot — the hub's binary store forks `<binary> --describe` once
+/// at upload time to capture exactly this.
+#[must_use]
+pub fn binary_manifest(chassis: &str, caps: Vec<&'static str>) -> BinaryManifest {
+    BinaryManifest {
+        chassis: chassis.to_owned(),
+        caps: caps.into_iter().map(str::to_owned).collect(),
+        git_sha: env!("AETHER_GIT_SHA").to_owned(),
+        profile: env!("AETHER_BUILD_PROFILE").to_owned(),
+        target: env!("AETHER_TARGET_TRIPLE").to_owned(),
+    }
 }
 
 /// Issue 763 P2: boot the RPC server only when `rpc_addr` is set,

--- a/crates/aether-substrate-bundle/src/cli.rs
+++ b/crates/aether-substrate-bundle/src/cli.rs
@@ -170,6 +170,13 @@ pub struct DesktopCli {
     /// and exit before boot (ADR-0090 §4 discovery dump).
     #[arg(long = "config")]
     pub config: bool,
+
+    /// Print this binary's `BinaryManifest` (chassis kind, linked caps,
+    /// build provenance) as JSON and exit before boot (ADR-0115, issue
+    /// 1953). The hub's binary store forks `<binary> --describe` once at
+    /// upload time to capture what a stored binary is.
+    #[arg(long = "describe")]
+    pub describe: bool,
 }
 
 /// Headless chassis CLI root.
@@ -190,6 +197,13 @@ pub struct HeadlessCli {
     /// and exit before boot (ADR-0090 §4 discovery dump).
     #[arg(long = "config")]
     pub config: bool,
+
+    /// Print this binary's `BinaryManifest` (chassis kind, linked caps,
+    /// build provenance) as JSON and exit before boot (ADR-0115, issue
+    /// 1953). The hub's binary store forks `<binary> --describe` once at
+    /// upload time to capture what a stored binary is.
+    #[arg(long = "describe")]
+    pub describe: bool,
 }
 
 /// Hub chassis CLI root — coordinator-only, no full-stack caps.
@@ -214,4 +228,11 @@ pub struct HubCli {
     /// and exit before boot (ADR-0090 §4 discovery dump).
     #[arg(long = "config")]
     pub config: bool,
+
+    /// Print this binary's `BinaryManifest` (chassis kind, linked caps,
+    /// build provenance) as JSON and exit before boot (ADR-0115, issue
+    /// 1953). The hub's binary store forks `<binary> --describe` once at
+    /// upload time to capture what a stored binary is.
+    #[arg(long = "describe")]
+    pub describe: bool,
 }

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -18,12 +18,15 @@ use std::fmt;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use aether_actor::Actor;
 use aether_capabilities::LifecycleCapability;
+use aether_capabilities::rpc::RpcServerCapability;
 use aether_capabilities::{
     AnthropicConfig, AudioCapability, CaptureBackend, ComponentHostConfig, GeminiConfig,
     HttpServerConfig, InputConfig, RenderCapability, RenderConfig, UnsupportedTestBenchCapability,
     audio::AudioConfig as AudioConf, fs::NamespaceRoots, http::HttpConfig as HttpConf,
 };
+use aether_kinds::BinaryManifest;
 use aether_kinds::WindowMode;
 use aether_substrate::chassis::builder::{Builder, BuiltChassis};
 use aether_substrate::chassis::error::BootError;
@@ -135,6 +138,28 @@ impl Chassis for DesktopChassis {
     }
 }
 
+impl DesktopChassis {
+    /// The `--describe` manifest (ADR-0115, issue 1953): the chassis
+    /// profile, the mailbox namespaces this binary links, and the
+    /// `build.rs` provenance. The desktop chassis layers the audio /
+    /// render / test-bench / lifecycle caps plus the RPC server onto the
+    /// shared [`common_cap_namespaces`](crate::common_cap_namespaces)
+    /// base. `--describe` prints this without opening a winit event loop —
+    /// the hub can capture a desktop binary's manifest on a headless host.
+    #[must_use]
+    pub fn describe_manifest() -> BinaryManifest {
+        let mut caps = crate::common_cap_namespaces();
+        caps.extend([
+            <AudioCapability as Actor>::NAMESPACE,
+            <RenderCapability as Actor>::NAMESPACE,
+            <UnsupportedTestBenchCapability as Actor>::NAMESPACE,
+            <LifecycleCapability as Actor>::NAMESPACE,
+            <RpcServerCapability as Actor>::NAMESPACE,
+        ]);
+        crate::binary_manifest(Self::PROFILE, caps)
+    }
+}
+
 /// Bag of resolved configs the desktop chassis takes at build time.
 /// `main()` populates it from env vars (per ADR-0070's "substrate-core
 /// never reads env" invariant); tests construct one directly.
@@ -223,9 +248,10 @@ impl DesktopEnv {
             audio: audio_overlay,
             window_mode: cli_window_mode,
             window_title: cli_window_title,
-            // The bin handles `--config` (print + exit) before this
-            // resolver runs; ignore it here.
+            // The bin handles `--config` / `--describe` (print + exit)
+            // before this resolver runs; ignore them here.
             config: _,
+            describe: _,
         } = cli;
         let CommonOverlay {
             http,

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -17,13 +17,16 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use aether_actor::Actor;
 use aether_capabilities::LifecycleCapability;
+use aether_capabilities::rpc::RpcServerCapability;
 use aether_capabilities::{
     AnthropicConfig, ComponentHostConfig, GeminiConfig, HeadlessRenderCapability,
     HeadlessWindowCapability, HttpServerConfig, InputConfig, UnsupportedTestBenchCapability,
     fs::NamespaceRoots, http::HttpConfig as HttpConf,
 };
 use aether_data::Kind;
+use aether_kinds::BinaryManifest;
 use aether_kinds::{SetMasterGain, SetMasterGainResult, Tick};
 use aether_substrate::chassis::builder::{Builder, BuiltChassis};
 use aether_substrate::chassis::error::BootError;
@@ -57,6 +60,28 @@ impl Chassis for HeadlessChassis {
 
     fn build(env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
         Self::build_inner(env)
+    }
+}
+
+impl HeadlessChassis {
+    /// The `--describe` manifest (ADR-0115, issue 1953): the chassis
+    /// profile, the mailbox namespaces this binary links, and the
+    /// `build.rs` provenance. The headless chassis layers the renderer /
+    /// window / test-bench / lifecycle caps plus the RPC server onto the
+    /// shared [`common_cap_namespaces`](crate::common_cap_namespaces)
+    /// base — a hub-forked fleet engine always boots its RPC server, so it
+    /// is part of the headless capability surface.
+    #[must_use]
+    pub fn describe_manifest() -> BinaryManifest {
+        let mut caps = crate::common_cap_namespaces();
+        caps.extend([
+            <HeadlessRenderCapability as Actor>::NAMESPACE,
+            <HeadlessWindowCapability as Actor>::NAMESPACE,
+            <UnsupportedTestBenchCapability as Actor>::NAMESPACE,
+            <LifecycleCapability as Actor>::NAMESPACE,
+            <RpcServerCapability as Actor>::NAMESPACE,
+        ]);
+        crate::binary_manifest(Self::PROFILE, caps)
     }
 }
 
@@ -135,9 +160,10 @@ impl HeadlessEnv {
         let HeadlessCli {
             common,
             tick_hz: cli_tick_hz,
-            // The bin handles `--config` (print + exit) before this
-            // resolver runs; ignore it here.
+            // The bin handles `--config` / `--describe` (print + exit)
+            // before this resolver runs; ignore them here.
             config: _,
+            describe: _,
         } = cli;
         let CommonOverlay {
             http,

--- a/crates/aether-substrate-bundle/src/hub/chassis.rs
+++ b/crates/aether-substrate-bundle/src/hub/chassis.rs
@@ -14,8 +14,10 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use aether_actor::Actor;
 use aether_capabilities::rpc::{PeerKind, RpcServerCapability, RpcServerConfig};
 use aether_capabilities::{EngineConfig, EngineServer, trace::TraceDispatchCapability};
+use aether_kinds::BinaryManifest;
 use aether_substrate::chassis::builder::{
     Builder, BuiltChassis, DriverCapability, DriverCtx, DriverRunning, RunError,
 };
@@ -38,6 +40,25 @@ impl Chassis for HubChassis {
 
     fn build(env: Self::Env) -> Result<BuiltChassis<Self>, BootError> {
         Self::build_inner(env)
+    }
+}
+
+impl HubChassis {
+    /// The `--describe` manifest (ADR-0115, issue 1953): the chassis
+    /// profile, the mailbox namespaces this binary links, and the
+    /// `build.rs` provenance. The hub is the minimal coordinator chassis —
+    /// it links the trace dispatcher, the engines cap, and the RPC server,
+    /// not the full-stack cap set — so it lists those three directly
+    /// rather than through the full-stack
+    /// [`common_cap_namespaces`](crate::common_cap_namespaces) base.
+    #[must_use]
+    pub fn describe_manifest() -> BinaryManifest {
+        let caps = vec![
+            <TraceDispatchCapability as Actor>::NAMESPACE,
+            <EngineServer as Actor>::NAMESPACE,
+            <RpcServerCapability as Actor>::NAMESPACE,
+        ];
+        crate::binary_manifest(Self::PROFILE, caps)
     }
 }
 

--- a/crates/aether-substrate-bundle/src/lib.rs
+++ b/crates/aether-substrate-bundle/src/lib.rs
@@ -27,7 +27,9 @@
 pub mod autoload;
 pub mod bundle_pack;
 mod chassis_common;
-pub use chassis_common::{PersistOverride, chassis_config_dump};
+pub use chassis_common::{
+    PersistOverride, binary_manifest, chassis_config_dump, common_cap_namespaces,
+};
 pub mod chassis_root;
 pub mod cli;
 pub mod desktop;

--- a/crates/aether-substrate-bundle/tests/describe_manifest.rs
+++ b/crates/aether-substrate-bundle/tests/describe_manifest.rs
@@ -1,0 +1,46 @@
+//! `--describe` manifest smoke test (ADR-0115, issue 1953): run the real
+//! `aether-substrate-headless` binary with `--describe`, parse the JSON it
+//! prints, and assert the chassis kind plus a non-empty linked-cap list.
+//! This is the same `--describe` mode the hub's binary store forks once at
+//! upload time to capture what a stored binary is — the cap test (the
+//! `FleetBench` scenario) exercises that fork path end to end; this one
+//! pins the binary's own contract.
+
+use std::process::Command;
+
+use aether_kinds::BinaryManifest;
+
+/// `aether-substrate-headless --describe` prints a `BinaryManifest` JSON
+/// reporting `chassis == "headless"`, a non-empty cap list including the
+/// fs cap, and non-empty build provenance, then exits 0.
+#[test]
+fn headless_describe_emits_manifest() {
+    let bin = env!("CARGO_BIN_EXE_aether-substrate-headless");
+    let output = Command::new(bin)
+        .arg("--describe")
+        .output()
+        .expect("test setup: running the headless binary with --describe");
+    assert!(
+        output.status.success(),
+        "--describe should exit 0; stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let manifest: BinaryManifest = serde_json::from_slice(&output.stdout)
+        .expect("test setup: --describe stdout is a BinaryManifest JSON");
+    assert_eq!(manifest.chassis, "headless", "reports the headless profile");
+    assert!(
+        !manifest.caps.is_empty(),
+        "the headless chassis links a non-empty cap set",
+    );
+    assert!(
+        manifest.caps.iter().any(|c| c == "aether.fs"),
+        "the headless chassis links the fs cap, got {:?}",
+        manifest.caps,
+    );
+    // Build provenance is always baked (`unknown` fallbacks outside a git
+    // checkout), so the fields are never empty.
+    assert!(!manifest.git_sha.is_empty(), "git_sha is baked");
+    assert!(!manifest.profile.is_empty(), "build profile is baked");
+    assert!(!manifest.target.is_empty(), "target triple is baked");
+}

--- a/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
@@ -50,11 +50,11 @@ use aether_kinds::MailEnvelope as TracedEnvelope;
 use aether_kinds::descriptors;
 use aether_kinds::trace::{DispatchTraced, DispatchTracedAck, TRACE_MAILBOX_NAME};
 use aether_kinds::{
-    Cancel, CancelResult, ComponentCapabilities, DagDescriptor, DeadEngineDescriptor,
-    EngineDescriptor, HandleDescribe, HandleDescribeResult, ListEngines, ListEnginesResult,
-    LoadComponent, LoadResult, LogTail, LogTailResult, ReplaceComponent, ReplaceResult,
-    SpawnEngine, SpawnEngineResult, Status, StatusResult, Submit, SubmitResult, TerminateEngine,
-    TerminateEngineResult,
+    BinaryEntry, Cancel, CancelResult, ComponentCapabilities, DagDescriptor, DeadEngineDescriptor,
+    EngineDescriptor, HandleDescribe, HandleDescribeResult, ListBinaries, ListBinariesResult,
+    ListEngines, ListEnginesResult, LoadComponent, LoadResult, LogTail, LogTailResult,
+    ReplaceComponent, ReplaceResult, SpawnEngine, SpawnEngineResult, Status, StatusResult, Submit,
+    SubmitResult, TerminateEngine, TerminateEngineResult, UploadBinary, UploadBinaryResult,
 };
 use aether_substrate::chassis::Chassis;
 use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver, PassiveChassis};
@@ -219,6 +219,36 @@ impl FleetBench {
         match ListEnginesResult::decode_from_bytes(&payload) {
             Some(result) => result.recently_died,
             None => panic!("undecodable ListEnginesResult"),
+        }
+    }
+
+    /// Upload a binary into the hub's content-addressed store (ADR-0115,
+    /// issue 1953) by absolute host path, optionally naming it. Hub-local —
+    /// addressed at `aether.engine` with no engine route. The hub reads the
+    /// path, sha256s it, forks `<path> --describe`, and stores both; this
+    /// returns the decoded [`UploadBinaryResult`].
+    pub fn upload_binary(&mut self, staged_path: &str, name: Option<&str>) -> UploadBinaryResult {
+        let replies = self.call(
+            None,
+            "aether.engine",
+            &UploadBinary {
+                staged_path: staged_path.to_owned(),
+                name: name.map(str::to_owned),
+            },
+        );
+        let payload = single_reply(&replies, "UploadBinary");
+        UploadBinaryResult::decode_from_bytes(&payload).expect("undecodable UploadBinaryResult")
+    }
+
+    /// Enumerate the hub's stored binaries (ADR-0115, issue 1953) under the
+    /// given filter. Hub-local — addressed at `aether.engine` with no
+    /// engine route.
+    pub fn list_binaries(&mut self, filter: &ListBinaries) -> Vec<BinaryEntry> {
+        let replies = self.call(None, "aether.engine", filter);
+        let payload = single_reply(&replies, "ListBinaries");
+        match ListBinariesResult::decode_from_bytes(&payload) {
+            Some(result) => result.binaries,
+            None => panic!("undecodable ListBinariesResult"),
         }
     }
 
@@ -668,6 +698,11 @@ fn isolate_store_root() -> PathBuf {
     unsafe {
         env::set_var("AETHER_ENGINE_STORE_ROOT", &root);
         env::remove_var("AETHER_HANDLE_STORE_DIR");
+        // Isolate the hub's binary store (ADR-0115) under the same per-bench
+        // root so the EngineServer's `ArtifactStore::from_env` doesn't touch
+        // the real data dir and a binary-store scenario can't see another
+        // bench's entries. Removed on `Drop` with the rest of the root.
+        env::set_var("AETHER_BINARY_STORE_DIR", root.join("binaries"));
     }
     root
 }

--- a/crates/aether-substrate-bundle/tests/fleetbench_binary_store.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_binary_store.rs
@@ -1,0 +1,95 @@
+//! `FleetBench` hub binary-store proof (ADR-0115, issue 1953): drive the
+//! real hub → RPC → engines-cap stack to upload a binary
+//! content-addressed, capture its `--describe` manifest, list it back,
+//! dedup an identical re-upload, and resolve its name.
+//!
+//! Heavy by construction — it boots a hub chassis and the engines cap
+//! forks `<binary> --describe` to capture the manifest — so the test lives
+//! in `mod tests::heavy`, which nextest serializes (`serial-heavy`).
+
+mod fleetbench;
+
+mod tests {
+    mod heavy {
+        use aether_kinds::{ListBinaries, UploadBinaryResult};
+
+        use crate::fleetbench::FleetBench;
+
+        /// Upload the real `aether-substrate-headless` binary, then assert
+        /// the store ingested it content-addressed with the right
+        /// `--describe` manifest, dedups an identical re-upload to the same
+        /// hash, and resolves the name back.
+        #[test]
+        fn fleetbench_uploads_lists_and_dedups_a_real_binary() {
+            let headless = env!("CARGO_BIN_EXE_aether-substrate-headless");
+            let mut bench = FleetBench::start();
+
+            // Upload + capture the manifest via the hub's one-time fork of
+            // `<binary> --describe`.
+            let hash = match bench.upload_binary(headless, Some("headless")) {
+                UploadBinaryResult::Ok { hash, name } => {
+                    assert_eq!(
+                        name.as_deref(),
+                        Some("headless"),
+                        "the upload's name is echoed"
+                    );
+                    assert!(!hash.is_empty(), "the content hash is non-empty");
+                    hash
+                }
+                UploadBinaryResult::Err { error } => panic!("upload_binary failed: {error}"),
+            };
+
+            // List with no filter — the entry is present with the headless
+            // manifest the `--describe` fork captured.
+            let all = bench.list_binaries(&ListBinaries::default());
+            let entry = all
+                .iter()
+                .find(|e| e.hash == hash)
+                .unwrap_or_else(|| panic!("uploaded binary {hash} should be listed: {all:?}"));
+            assert_eq!(
+                entry.manifest.chassis, "headless",
+                "the stored manifest reports the headless chassis",
+            );
+            assert!(
+                !entry.manifest.caps.is_empty(),
+                "the stored manifest carries a non-empty cap list, got {:?}",
+                entry.manifest.caps,
+            );
+            assert_eq!(
+                entry.name.as_deref(),
+                Some("headless"),
+                "the name points at the entry"
+            );
+
+            // A chassis filter that matches keeps it; one that doesn't drops it.
+            let headless_filtered = bench.list_binaries(&ListBinaries {
+                chassis: Some("headless".to_owned()),
+                caps: vec![],
+                target: None,
+            });
+            assert!(
+                headless_filtered.iter().any(|e| e.hash == hash),
+                "a matching chassis filter keeps the entry",
+            );
+            let desktop_filtered = bench.list_binaries(&ListBinaries {
+                chassis: Some("desktop".to_owned()),
+                caps: vec![],
+                target: None,
+            });
+            assert!(
+                !desktop_filtered.iter().any(|e| e.hash == hash),
+                "a non-matching chassis filter drops the entry",
+            );
+
+            // A second identical upload dedups to the same content hash.
+            let again = match bench.upload_binary(headless, None) {
+                UploadBinaryResult::Ok { hash, .. } => hash,
+                UploadBinaryResult::Err { error } => panic!("re-upload failed: {error}"),
+            };
+            assert_eq!(
+                again, hash,
+                "an identical re-upload dedups to the same hash"
+            );
+        }
+    }
+}

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -307,8 +307,14 @@ impl Drop for LockGuard {
 /// we can't signal (still counts as alive). Non-Unix: conservatively
 /// reports `false` so the lock is always reclaimable (substrate on
 /// Windows is deferred per ADR-0049 §7).
+///
+/// Public so the hub binary store's `lock.pid` reclaim (ADR-0115, issue
+/// 1953) reuses the same liveness check rather than duplicating the
+/// `kill(pid, 0)` unsafe — the two stores share the lock/reclaim shape,
+/// not the instance.
 #[cfg(unix)]
-fn is_pid_alive(pid: i32) -> bool {
+#[must_use]
+pub fn is_pid_alive(pid: i32) -> bool {
     // SAFETY: `kill` with signal 0 performs the error checks without
     // sending a signal. No memory is touched.
     let ret = unsafe { libc::kill(pid, 0) };
@@ -320,7 +326,8 @@ fn is_pid_alive(pid: i32) -> bool {
 }
 
 #[cfg(not(unix))]
-fn is_pid_alive(_pid: i32) -> bool {
+#[must_use]
+pub fn is_pid_alive(_pid: i32) -> bool {
     false
 }
 


### PR DESCRIPTION
Closes #1953.

## Summary

Lands the storage half of the hub artifact registry (ADR-0115): a content-addressed, artifact-generic store owned by the `aether.engine` cap, so a binary can be uploaded once and later referenced by content rather than by a host filesystem path. The spawn cutover (#1954) builds directly on this.

- A new `crates/aether-capabilities/src/store.rs` — `ArtifactStore`, keyed by sha256 over the raw bytes, with a disk budget + LRU eviction over unpinned/unnamed entries, pin / name protection, a `lock.pid` + live-pid reclaim, and persistence reload across `restart-hub`. Artifact-generic from the start (a content blob plus a type-tagged manifest) so #1955 can extract it whole.
- `upload_binary` ingests a binary from a staged path (the hub reads + hashes + describes + stores; aether-mcp never reads the bytes), re-upload of identical bytes dedups to the same hash, an optional name points at that hash, and `list_binaries` enumerates entries each with a manifest.
- The manifest is captured by forking the staged binary once with a new `--describe` mode that prints JSON: chassis kind from the chassis `PROFILE`, linked caps from each registered cap's `Actor::NAMESPACE`, and provenance (git sha / profile / target) from the extended `build.rs`.

## Test plan

`store.rs` unit tests cover content-addressing, dedup, the disk-budget LRU, pin/name eviction protection, and `lock.pid` reclaim. A `--describe` binary smoke test asserts the manifest JSON shape. A FleetBench scenario (`fleetbench_binary_store`) proves upload + manifest capture + list + filter + dedup + name lookup over the real hub / RPC / fork-describe stack. Full local preflight green (fmt, clippy `-D warnings`, `nextest --workspace`, doc, wasm32 cross-build); the store compiles `no_std`-clean (cfg-elided) for the component target.

## Notes

`is_pid_alive` in `aether-substrate::handle_store` is made `pub` to reuse the existing live-pid reclaim rather than duplicate the unsafe `kill(pid, 0)`. The store uses plain `&mut self` fields (the `aether.engine` cap is single-threaded); #1955 can wrap it in a lock when a multi-owner registry needs one, with no API change.

## Generated by

`/implement` — agent execution of scoped issue #1953.
