### PR TITLE
feat(capabilities): spawn substrates by registry selector

### DIFF
--- a/crates/aether-capabilities/src/engine/server.rs
+++ b/crates/aether-capabilities/src/engine/server.rs
@@ -59,13 +59,13 @@ mod server_native {
         TerminateEngine, UploadBinary,
     };
     use crate::engine::proxy::{EngineProxy, EngineProxyConfig, HeartbeatParams};
-    use crate::store::{ArtifactKind, ArtifactStore};
+    use crate::store::{ArtifactKind, ArtifactStore, Selector, StoredArtifact};
     use aether_actor::actor;
     use aether_data::{EngineId, Kind, MailboxId, Uuid};
     use aether_kinds::{
-        BinaryManifest, CallSettled, DeadEngineDescriptor, DeathReason, EngineDescriptor,
-        ForwardEnvelope, ListBinariesResult, ListEnginesResult, SpawnEngineResult,
-        TerminateEngineResult, UploadBinaryResult,
+        BinaryManifest, BinarySelector, CallSettled, DeadEngineDescriptor, DeathReason,
+        EngineDescriptor, ForwardEnvelope, ListBinariesResult, ListEnginesResult,
+        SpawnEngineResult, TerminateEngineResult, UploadBinaryResult,
     };
     use aether_substrate::Mail;
     use aether_substrate::Subname;
@@ -80,7 +80,7 @@ mod server_native {
     use std::fs;
     use std::io;
     use std::net::TcpListener;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::process::{Command, Stdio};
     use std::sync::Arc;
     use std::time::{Duration, Instant};
@@ -91,6 +91,21 @@ mod server_native {
     /// to `std::env::temp_dir().join("aether-engines")` if no data dir
     /// is resolvable.
     const ENV_ENGINE_STORE_ROOT: &str = "AETHER_ENGINE_STORE_ROOT";
+
+    /// Env var the hub reads at [`EngineServer::init`] to bootstrap its
+    /// content-addressed binary store (ADR-0115, issue 1954): an
+    /// OS-path-list (`std::env::split_paths`) of chassis binaries to ingest
+    /// at boot, so a `default` / `name` selector resolves in a fresh or
+    /// `restart-hub`'d hub without a manual `upload_binary`.
+    /// `ensure-tunnel.sh` exports it to the freshly-built chassis bins.
+    /// Idempotent — content dedup means a re-ingest of identical bytes is a
+    /// no-op.
+    const ENV_BINARY_BOOTSTRAP: &str = "AETHER_BINARY_BOOTSTRAP";
+
+    /// The chassis a `default` selector (an empty [`BinarySelector::query`]
+    /// with no attribute filters) resolves to (ADR-0115): `headless` has no
+    /// window and runs on any host, so a bare spawn is self-sufficient.
+    const DEFAULT_CHASSIS: &str = "headless";
 
     /// Default heartbeat ping cadence (issue 1339). 5 s × the miss
     /// limit is the detection-latency vs. flap-tolerance tradeoff.
@@ -240,13 +255,18 @@ mod server_native {
         const NAMESPACE: &'static str = "aether.engine";
 
         fn init(config: EngineConfig, ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            // Build the hub-scoped store, then bootstrap-ingest the chassis
+            // bins named in `AETHER_BINARY_BOOTSTRAP` so `default` / `name`
+            // resolve in a fresh or `restart-hub`'d hub (ADR-0115, #1954).
+            let mut store = ArtifactStore::from_env();
+            bootstrap_ingest(&mut store);
             Ok(Self {
                 engines: HashMap::new(),
                 next_engine_seq: 1,
                 mailer: ctx.mailer(),
                 heartbeat: config.heartbeat_params(),
                 recently_died: VecDeque::new(),
-                store: ArtifactStore::from_env(),
+                store,
             })
         }
 
@@ -307,15 +327,29 @@ mod server_native {
         /// Fork+exec a substrate binary and connect a proxy to it.
         ///
         /// # Agent
-        /// Send `SpawnEngine { binary_path, args, boot_manifest }`. The cap assigns a
-        /// free localhost port for the substrate's RPC server, injects
-        /// it as `AETHER_RPC_PORT`, forks the binary, then boots an
-        /// `aether.engine.proxy:<id>` actor that dials it. Reply:
-        /// `SpawnEngineResult::Ok { engine_id, rpc_port }` on success,
-        /// or `Err { error }` if the fork fails or the substrate never
-        /// comes up.
+        /// Send `SpawnEngine { selector, args, boot_manifest }`. The cap
+        /// resolves `selector` against its content-addressed binary store
+        /// (ADR-0115), materializes the resolved bytes to an executable
+        /// temp file, assigns a free localhost port for the substrate's
+        /// RPC server, injects it as `AETHER_RPC_PORT`, forks the realized
+        /// binary, then boots an `aether.engine.proxy:<id>` actor that
+        /// dials it. Reply: `SpawnEngineResult::Ok { engine_id, rpc_port }`
+        /// on success, or `Err { error }` if the selector resolves to no
+        /// stored binary, the fork fails, or the substrate never comes up.
         #[handler]
         fn on_spawn(&mut self, ctx: &mut NativeCtx<'_>, mail: SpawnEngine) -> SpawnEngineResult {
+            // Resolve the registry selector to stored content bytes before
+            // any side effect, so a miss returns without reserving a port
+            // or burning an engine id (ADR-0115, #1954).
+            let Some(artifact) = resolve_selector(&mut self.store, &mail.selector) else {
+                return SpawnEngineResult::Err {
+                    error: format!(
+                        "no binary in the registry matched selector {:?}",
+                        mail.selector
+                    ),
+                };
+            };
+
             let rpc_port = match free_local_port() {
                 Ok(port) => port,
                 Err(e) => {
@@ -335,7 +369,22 @@ mod server_native {
             self.next_engine_seq += 1;
             let engine_store_dir = engine_store_root().join(engine_id.0.simple().to_string());
 
-            let mut command = Command::new(&mail.binary_path);
+            // Stored bytes are content-addressed and not directly
+            // fork-exec'able, so materialize the resolved entry to an
+            // executable temp file under this engine's store dir and fork
+            // that (ADR-0115 §Execution); the caller never sees the path.
+            let exec_path = engine_store_dir.join("substrate");
+            if let Err(e) = realize_executable(&artifact.path, &exec_path) {
+                return SpawnEngineResult::Err {
+                    error: format!(
+                        "materializing binary {} to {}: {e}",
+                        artifact.hash,
+                        exec_path.display()
+                    ),
+                };
+            }
+
+            let mut command = Command::new(&exec_path);
             command
                 .args(&mail.args)
                 .env("AETHER_RPC_PORT", rpc_port.to_string())
@@ -352,7 +401,7 @@ mod server_native {
                 Ok(child) => child,
                 Err(e) => {
                     return SpawnEngineResult::Err {
-                        error: format!("failed to spawn {}: {e}", mail.binary_path),
+                        error: format!("failed to spawn {}: {e}", exec_path.display()),
                     };
                 }
             };
@@ -594,24 +643,12 @@ mod server_native {
             _ctx: &mut NativeCtx<'_>,
             mail: UploadBinary,
         ) -> UploadBinaryResult {
-            let bytes = match fs::read(&mail.staged_path) {
-                Ok(bytes) => bytes,
-                Err(e) => {
-                    return UploadBinaryResult::Err {
-                        error: format!("reading staged path {:?}: {e}", mail.staged_path),
-                    };
-                }
-            };
-            let manifest = match describe_binary(&mail.staged_path) {
-                Ok(manifest) => manifest,
-                Err(error) => return UploadBinaryResult::Err { error },
-            };
-            let hash = self
-                .store
-                .upload(&bytes, ArtifactKind::Binary, manifest, mail.name.clone());
-            UploadBinaryResult::Ok {
-                hash,
-                name: mail.name,
+            match ingest_binary(&mut self.store, &mail.staged_path, mail.name.clone()) {
+                Ok(hash) => UploadBinaryResult::Ok {
+                    hash,
+                    name: mail.name,
+                },
+                Err(error) => UploadBinaryResult::Err { error },
             }
         }
 
@@ -654,6 +691,145 @@ mod server_native {
         }
         serde_json::from_slice(&output.stdout)
             .map_err(|e| format!("parsing {binary_path:?} --describe manifest JSON: {e}"))
+    }
+
+    /// Ingest the binary at `path` into `store` content-addressed,
+    /// capturing its manifest via a one-time `<path> --describe` fork
+    /// (ADR-0115, issue 1953). Shared by the `on_upload_binary` handler and
+    /// the [`bootstrap_ingest`] boot path. Returns the stored content hash,
+    /// or a human-readable error for an unreadable path or a `--describe`
+    /// that failed / yielded no parseable manifest. Idempotent — identical
+    /// bytes dedup to the same hash.
+    fn ingest_binary(
+        store: &mut ArtifactStore,
+        path: &str,
+        name: Option<String>,
+    ) -> Result<String, String> {
+        let bytes = fs::read(path).map_err(|e| format!("reading binary path {path:?}: {e}"))?;
+        let manifest = describe_binary(path)?;
+        Ok(store.upload(&bytes, ArtifactKind::Binary, manifest, name))
+    }
+
+    /// Bootstrap-ingest the chassis bins named in `AETHER_BINARY_BOOTSTRAP`
+    /// (an OS path list) into `store`, naming each by its file stem so a
+    /// `default` / `name` selector resolves in a fresh or `restart-hub`'d
+    /// hub (ADR-0115, issue 1954). A path that can't be read or
+    /// `--describe`d is logged and skipped — a bad bootstrap entry must not
+    /// fail hub boot. Idempotent via content dedup.
+    pub(super) fn bootstrap_ingest(store: &mut ArtifactStore) {
+        let Ok(raw) = env::var(ENV_BINARY_BOOTSTRAP) else {
+            return;
+        };
+        for path in env::split_paths(&raw) {
+            let Some(path_str) = path.to_str() else {
+                continue;
+            };
+            let name = path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .map(str::to_owned);
+            match ingest_binary(store, path_str, name) {
+                Ok(hash) => tracing::info!(
+                    target: "aether_substrate::engine_server",
+                    path = path_str,
+                    hash = %hash,
+                    "binary bootstrap: ingested a chassis bin",
+                ),
+                Err(error) => tracing::warn!(
+                    target: "aether_substrate::engine_server",
+                    path = path_str,
+                    error = %error,
+                    "binary bootstrap: skipping a bin that failed to ingest",
+                ),
+            }
+        }
+    }
+
+    /// Resolve a [`BinarySelector`] against `store` to the stored content
+    /// bytes the spawn forks (ADR-0115). Resolution order: an exact `query`
+    /// token wins first (`hash` > `name@version` > `name`); absent a token,
+    /// the `chassis` / `caps` / `target` attribute query resolves, and with
+    /// no attribute filters either, `default` = the [`DEFAULT_CHASSIS`]
+    /// binary. `None` when nothing matched.
+    pub(super) fn resolve_selector(
+        store: &mut ArtifactStore,
+        selector: &BinarySelector,
+    ) -> Option<StoredArtifact> {
+        if let Some(token) = selector
+            .query
+            .as_deref()
+            .map(str::trim)
+            .filter(|t| !t.is_empty())
+        {
+            // Exact hash wins outright.
+            if let Some(found) = store.get(&Selector::Hash(token.to_owned())) {
+                return Some(found);
+            }
+            // `name@version`: the binary's self-reported build id (the
+            // manifest `git_sha`) pins a specific entry of a name.
+            if let Some((name, version)) = token.split_once('@') {
+                let hash = pick_versioned(store, name, version)?;
+                return store.get(&Selector::Hash(hash));
+            }
+            // A bare name points at the latest hash uploaded under it.
+            return store.get(&Selector::Name(token.to_owned()));
+        }
+        // No exact token: an attribute query, else `default` = headless.
+        let hash = store
+            .list(&attribute_filter(selector))
+            .into_iter()
+            .map(|entry| entry.hash)
+            .min()?;
+        store.get(&Selector::Hash(hash))
+    }
+
+    /// The store filter for a tokenless [`BinarySelector`]: the explicit
+    /// `chassis` / `caps` / `target` attribute query, or — when none is
+    /// set — the `default` filter selecting the [`DEFAULT_CHASSIS`]
+    /// chassis.
+    fn attribute_filter(selector: &BinarySelector) -> ListBinaries {
+        if selector.chassis.is_none() && selector.caps.is_empty() && selector.target.is_none() {
+            ListBinaries {
+                chassis: Some(DEFAULT_CHASSIS.to_owned()),
+                caps: Vec::new(),
+                target: None,
+            }
+        } else {
+            ListBinaries {
+                chassis: selector.chassis.clone(),
+                caps: selector.caps.clone(),
+                target: selector.target.clone(),
+            }
+        }
+    }
+
+    /// The content hash of the entry named `name` whose manifest build id
+    /// (`git_sha`) is `version` — the `name@version` selector (ADR-0115).
+    /// `None` when no current entry matches both.
+    fn pick_versioned(store: &ArtifactStore, name: &str, version: &str) -> Option<String> {
+        store
+            .list(&ListBinaries::default())
+            .into_iter()
+            .find(|entry| entry.name.as_deref() == Some(name) && entry.manifest.git_sha == version)
+            .map(|entry| entry.hash)
+    }
+
+    /// Copy the content bytes at `src` to `dest` and mark `dest`
+    /// executable (`0o755` on Unix; the `from_mode` precedent in
+    /// `anthropic/cli.rs`), creating `dest`'s parent dir. The
+    /// realize-to-exec step for spawn: stored bytes aren't directly
+    /// fork-exec'able (ADR-0115 §Execution).
+    fn realize_executable(src: &Path, dest: &Path) -> io::Result<()> {
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::copy(src, dest)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(dest, fs::Permissions::from_mode(0o755))?;
+        }
+        Ok(())
     }
 
     /// Push a `CallSettled::Err` back to `target` (correlation
@@ -790,8 +966,8 @@ mod tests {
     use aether_data::{Kind, mailbox_id_from_name};
     use aether_kinds::descriptors;
     use aether_kinds::{
-        DeathReason, EngineAlive, EngineDied, ListEngines, SpawnEngine, SpawnEngineResult,
-        TerminateEngine, TerminateEngineResult,
+        BinarySelector, DeathReason, EngineAlive, EngineDied, ListEngines, SpawnEngine,
+        SpawnEngineResult, TerminateEngine, TerminateEngineResult,
     };
     use aether_substrate::chassis::builder::{Builder, PassiveChassis};
     use aether_substrate::handle_store::HandleStore;
@@ -903,15 +1079,22 @@ mod tests {
             assert!(result.engines.is_empty(), "fresh cap supervises no engines");
         }
 
-        /// `on_spawn` with a binary path that doesn't exist fails fast at
-        /// the fork — no proxy is spawned, no retry window is entered.
+        /// `on_spawn` with a selector that resolves to no stored binary
+        /// fails fast at resolution — the store is empty (each cap test
+        /// isolates a fresh binary store), so no proxy is spawned and no
+        /// fork is attempted (ADR-0115, #1954).
         #[test]
         fn spawn_with_missing_binary_replies_err() {
             let (_chassis, mailer, cells) = boot();
             let result = drive(
                 &mailer,
                 &SpawnEngine {
-                    binary_path: "/nonexistent/aether-substrate-does-not-exist".to_owned(),
+                    selector: BinarySelector {
+                        query: Some("nonexistent-hash-or-name".to_owned()),
+                        chassis: None,
+                        caps: vec![],
+                        target: None,
+                    },
                     args: vec![],
                     boot_manifest: None,
                 },
@@ -926,12 +1109,82 @@ mod tests {
             match result {
                 SpawnEngineResult::Err { error } => {
                     assert!(
-                        error.contains("failed to spawn"),
+                        error.contains("no binary in the registry matched selector"),
                         "unexpected error: {error}"
                     );
                 }
-                SpawnEngineResult::Ok { .. } => panic!("a missing binary must not spawn"),
+                SpawnEngineResult::Ok { .. } => {
+                    panic!("an unresolvable selector must not spawn")
+                }
             }
+        }
+
+        /// Bootstrap-ingest a stand-in headless binary through
+        /// `AETHER_BINARY_BOOTSTRAP`, then resolve the `default` selector
+        /// (empty `query`, no attribute filters) to it — the bare-spawn
+        /// path a fresh hub serves (ADR-0115, #1954). Heavy: it sets a
+        /// process-global env var and forks `<stand-in> --describe`.
+        #[cfg(unix)]
+        #[test]
+        fn bootstrap_populates_and_default_resolves_to_headless() {
+            use super::super::server_native::{bootstrap_ingest, resolve_selector};
+            use crate::store::{ArtifactStore, DEFAULT_DISK_BUDGET_BYTES};
+            use std::fs;
+            use std::os::unix::fs::PermissionsExt;
+
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_or(0, |d| d.as_nanos());
+            let dir = env::temp_dir().join(format!(
+                "aether-binstore-bootstrap-{}-{nanos}",
+                process::id()
+            ));
+            fs::create_dir_all(&dir).expect("test setup: bootstrap temp dir");
+
+            // A stand-in chassis bin: on `--describe` it prints a headless
+            // manifest; its own bytes are what the store content-addresses.
+            let stand_in = dir.join("aether-substrate-headless");
+            fs::write(
+                &stand_in,
+                "#!/bin/sh\nif [ \"$1\" = \"--describe\" ]; then printf \
+                 '{\"chassis\":\"headless\",\"caps\":[\"aether.fs\"],\"git_sha\":\"deadbee\",\
+                 \"profile\":\"debug\",\"target\":\"x86_64-unknown-linux-gnu\"}'; fi\n",
+            )
+            .expect("test setup: write stand-in");
+            fs::set_permissions(&stand_in, fs::Permissions::from_mode(0o755))
+                .expect("test setup: chmod stand-in");
+
+            // SAFETY: serialized as a heavy test; no sibling reads
+            // AETHER_BINARY_BOOTSTRAP concurrently, and only the bootstrap
+            // path consumes it. Key mirrors `ENV_BINARY_BOOTSTRAP`.
+            unsafe {
+                env::set_var("AETHER_BINARY_BOOTSTRAP", &stand_in);
+            }
+
+            let mut store = ArtifactStore::open(&dir.join("store"), DEFAULT_DISK_BUDGET_BYTES);
+            bootstrap_ingest(&mut store);
+
+            let resolved = resolve_selector(
+                &mut store,
+                &BinarySelector {
+                    query: None,
+                    chassis: None,
+                    caps: vec![],
+                    target: None,
+                },
+            )
+            .expect("the default selector resolves to the bootstrapped headless bin");
+            assert_eq!(
+                resolved.manifest.chassis, "headless",
+                "default resolves to the headless chassis",
+            );
+
+            // SAFETY: same heavy-test serialization; restore the global so
+            // a sibling heavy test's `boot()` bootstrap sees it unset.
+            unsafe {
+                env::remove_var("AETHER_BINARY_BOOTSTRAP");
+            }
+            let _ = fs::remove_dir_all(&dir);
         }
 
         /// `on_terminate` with an `engine_id` that isn't a UUID, and one

--- a/crates/aether-capabilities/src/engine/server.rs
+++ b/crates/aether-capabilities/src/engine/server.rs
@@ -59,7 +59,10 @@ mod server_native {
         TerminateEngine, UploadBinary,
     };
     use crate::engine::proxy::{EngineProxy, EngineProxyConfig, HeartbeatParams};
-    use crate::store::{ArtifactKind, ArtifactStore, Selector, StoredArtifact};
+    use crate::store::{
+        ArtifactKind, ArtifactStore, DEFAULT_DISK_BUDGET_BYTES, LAYOUT_VERSION_DIR, Selector,
+        StoredArtifact,
+    };
     use aether_actor::actor;
     use aether_data::{EngineId, Kind, MailboxId, Uuid};
     use aether_kinds::{
@@ -74,6 +77,7 @@ mod server_native {
     use aether_substrate::mail::mailer::Mailer;
     use aether_substrate::mail::{Source, SourceAddr};
     use std::collections::HashMap;
+    use std::collections::HashSet;
     use std::collections::VecDeque;
     use std::convert::Infallible;
     use std::env;
@@ -92,16 +96,6 @@ mod server_native {
     /// is resolvable.
     const ENV_ENGINE_STORE_ROOT: &str = "AETHER_ENGINE_STORE_ROOT";
 
-    /// Env var the hub reads at [`EngineServer::init`] to bootstrap its
-    /// content-addressed binary store (ADR-0115, issue 1954): an
-    /// OS-path-list (`std::env::split_paths`) of chassis binaries to ingest
-    /// at boot, so a `default` / `name` selector resolves in a fresh or
-    /// `restart-hub`'d hub without a manual `upload_binary`.
-    /// `ensure-tunnel.sh` exports it to the freshly-built chassis bins.
-    /// Idempotent — content dedup means a re-ingest of identical bytes is a
-    /// no-op.
-    const ENV_BINARY_BOOTSTRAP: &str = "AETHER_BINARY_BOOTSTRAP";
-
     /// The chassis a `default` selector (an empty [`BinarySelector::query`]
     /// with no attribute filters) resolves to (ADR-0115): `headless` has no
     /// window and runs on any host, so a bare spawn is self-sufficient.
@@ -114,10 +108,12 @@ mod server_native {
     /// dead. Small N tolerates a transient hiccup / GC pause.
     const DEFAULT_HEARTBEAT_MISS_LIMIT: u32 = 3;
 
-    /// Resolved engines-cap configuration (ADR-0090, issue 1339).
-    /// Today this is just the liveness-heartbeat tuning; the inline
-    /// `AETHER_ENGINE_STORE_ROOT` reader (`engine_store_root`) is a
-    /// pre-ADR-0090 holdover left to a separate migration.
+    /// Resolved engines-cap configuration (ADR-0090, issue 1339): the
+    /// liveness-heartbeat tuning plus the hub binary store's layout dir,
+    /// disk budget, and bootstrap list (ADR-0115, #1954 — these last three
+    /// moved onto the config off their pre-ADR-0090 naked `env::var`
+    /// readers). The inline `AETHER_ENGINE_STORE_ROOT` reader
+    /// (`engine_store_root`) is a separate, still-inline knob.
     ///
     /// `#[derive(aether_substrate::Config)]` emits the env-shaped
     /// `EngineConfigLayer`, the clap-shaped `EngineOverlay`, and the
@@ -125,12 +121,16 @@ mod server_native {
     /// beats the literal default). The hub chassis resolves it with
     /// `EngineConfig::from_argv_then_env(cli.engine.into_layer())` and
     /// hands it to `with_actor::<EngineServer>(cfg)`; tests build it
-    /// directly. `env_prefix = "AETHER_HUB"` + the `heartbeat_*` field
-    /// names compose the `AETHER_HUB_HEARTBEAT_*` env keys and
-    /// `--hub-heartbeat-*` flags. `Default` (the test constructor)
-    /// resolves to `0/0` = heartbeat-disabled; production picks up the
-    /// `default = 5/3` literals through the layer.
-    #[derive(Clone, Debug, Default, aether_substrate::Config)]
+    /// directly. `env_prefix = "AETHER_HUB"` + the `heartbeat_*` /
+    /// `binary_disk_budget_bytes` field names compose the
+    /// `AETHER_HUB_HEARTBEAT_*` / `AETHER_HUB_BINARY_DISK_BUDGET_BYTES`
+    /// env keys and `--hub-*` flags; `binary_store_dir` / `binary_bootstrap`
+    /// pin the unprefixed `AETHER_BINARY_STORE_DIR` / `AETHER_BINARY_BOOTSTRAP`
+    /// keys via per-field `env` overrides. `Default` (the test constructor)
+    /// resolves the heartbeat to `0/0` (disabled) and the store fields to
+    /// unset / `16 GiB`; production picks up the `default = 5/3` / `16 GiB`
+    /// literals and the env layers through `from_argv_then_env`.
+    #[derive(Clone, Debug, aether_substrate::Config)]
     #[config(env_prefix = "AETHER_HUB", cli_prefix = "hub")]
     pub struct EngineConfig {
         /// Heartbeat ping cadence in seconds
@@ -147,6 +147,56 @@ mod server_native {
         /// `miss_limit × interval_secs`.
         #[config(default = 3, parse = parse_heartbeat_miss_limit)]
         pub heartbeat_miss_limit: u32,
+        /// Layout-root override for the hub's content-addressed binary
+        /// store (`AETHER_BINARY_STORE_DIR`, unprefixed — the ops escape
+        /// hatch and the fleet tests' per-process isolation knob). Unset
+        /// (`None`) → the computed default `data_dir/aether/binaries/v1`
+        /// (`ArtifactStore::default_root`). A bare `Option<String>` (not a
+        /// `PathBuf`) keeps that runtime-computed default in `init`, so
+        /// `EngineConfig` needs no `skip_from_layer`; `EngineServer::init`
+        /// joins the store's layout-version dir to a set override.
+        #[config(env = "AETHER_BINARY_STORE_DIR")]
+        pub binary_store_dir: Option<String>,
+        /// On-disk byte budget for the binary store
+        /// (`AETHER_HUB_BINARY_DISK_BUDGET_BYTES`, derived from the
+        /// `AETHER_HUB` prefix / `--hub-binary-disk-budget-bytes`). Default
+        /// 16 GiB (`DEFAULT_DISK_BUDGET_BYTES`); LRU eviction over unpinned,
+        /// unnamed entries holds it.
+        #[config(default = 17_179_869_184u64, parse = parse_binary_disk_budget)]
+        pub binary_disk_budget_bytes: u64,
+        /// Chassis bins to bootstrap-ingest at init so a `default` / `name`
+        /// selector resolves in a fresh or `restart-hub`'d hub
+        /// (`AETHER_BINARY_BOOTSTRAP`, unprefixed, comma-separated). Each is
+        /// ingested content-addressed and named by its file stem;
+        /// idempotent via content dedup. `ensure-tunnel.sh` exports the
+        /// freshly-built chassis bins here.
+        #[config(
+            env = "AETHER_BINARY_BOOTSTRAP",
+            default = [],
+            parse = parse_binary_bootstrap,
+            csv_set
+        )]
+        pub binary_bootstrap: HashSet<String>,
+    }
+
+    impl Default for EngineConfig {
+        /// The test constructor: heartbeat disabled (`0/0`) but a real
+        /// `DEFAULT_DISK_BUDGET_BYTES` budget — `0` is inert for the
+        /// heartbeat (no pinging) yet destructive for the store (it would
+        /// evict every unnamed upload), so the budget can't share the
+        /// heartbeat's zero. Store dir unset (the computed default) and an
+        /// empty bootstrap. Production resolves all five through the layer
+        /// (`from_argv_then_env`); this matches the prior `from_env()`
+        /// store budget every `EngineConfig::default()` consumer saw.
+        fn default() -> Self {
+            Self {
+                heartbeat_interval_secs: 0,
+                heartbeat_miss_limit: 0,
+                binary_store_dir: None,
+                binary_disk_budget_bytes: DEFAULT_DISK_BUDGET_BYTES,
+                binary_bootstrap: HashSet::new(),
+            }
+        }
     }
 
     impl EngineConfig {
@@ -180,6 +230,25 @@ mod server_native {
     #[allow(clippy::unnecessary_wraps)]
     fn parse_heartbeat_miss_limit(s: &str) -> Result<u32, Infallible> {
         Ok(s.trim().parse().unwrap_or(DEFAULT_HEARTBEAT_MISS_LIMIT))
+    }
+
+    /// Parse the binary-store disk budget; unparseable → the default
+    /// `DEFAULT_DISK_BUDGET_BYTES` (mirrors the heartbeat parsers).
+    #[allow(clippy::unnecessary_wraps)]
+    fn parse_binary_disk_budget(s: &str) -> Result<u64, Infallible> {
+        Ok(s.trim().parse().unwrap_or(DEFAULT_DISK_BUDGET_BYTES))
+    }
+
+    /// Split a comma-separated bootstrap path list, trimming and dropping
+    /// empties (mirrors the http allowlist's `parse_allowlist`). Total —
+    /// never errors.
+    #[allow(clippy::unnecessary_wraps)]
+    fn parse_binary_bootstrap(s: &str) -> Result<HashSet<String>, Infallible> {
+        Ok(s.split(',')
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+            .map(str::to_string)
+            .collect())
     }
 
     /// How many recently-died engines [`EngineServer`] retains for
@@ -242,10 +311,11 @@ mod server_native {
         /// Hub-scoped content-addressed binary store (ADR-0115, issue
         /// 1953) — the storage half of the artifact registry.
         /// `on_upload_binary` ingests a staged binary content-addressed;
-        /// `on_list_binaries` enumerates the stored entries. Built
-        /// `from_env` at init so it persists across a `restart-hub` (the
-        /// layout root outlives the hub child); the spawn cutover (#1954)
-        /// reads it back through the store's `get` seam.
+        /// `on_list_binaries` enumerates the stored entries. Built from
+        /// `EngineConfig` (the layout dir + disk budget) at init so it
+        /// persists across a `restart-hub` (the layout root outlives the
+        /// hub child); the spawn cutover (#1954) reads it back through the
+        /// store's `get` seam.
         store: ArtifactStore,
     }
 
@@ -255,11 +325,23 @@ mod server_native {
         const NAMESPACE: &'static str = "aether.engine";
 
         fn init(config: EngineConfig, ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            // Build the hub-scoped store, then bootstrap-ingest the chassis
-            // bins named in `AETHER_BINARY_BOOTSTRAP` so `default` / `name`
-            // resolve in a fresh or `restart-hub`'d hub (ADR-0115, #1954).
-            let mut store = ArtifactStore::from_env();
-            bootstrap_ingest(&mut store);
+            // Build the hub-scoped store from `EngineConfig` (ADR-0090): the
+            // layout-dir override + disk budget ride config fields (their
+            // `AETHER_BINARY_*` env keys are the config env layer), then
+            // bootstrap-ingest the chassis bins in `binary_bootstrap` so
+            // `default` / `name` resolve in a fresh or `restart-hub`'d hub
+            // (ADR-0115, #1954). An unset store dir falls back to the
+            // computed default; a set one gets the layout-version dir joined
+            // (matching the prior `AETHER_BINARY_STORE_DIR` reader).
+            let store_dir = config
+                .binary_store_dir
+                .as_deref()
+                .filter(|d| !d.is_empty())
+                .map_or_else(ArtifactStore::default_root, |dir| {
+                    PathBuf::from(dir).join(LAYOUT_VERSION_DIR)
+                });
+            let mut store = ArtifactStore::open(&store_dir, config.binary_disk_budget_bytes);
+            bootstrap_ingest(&mut store, &config.binary_bootstrap);
             Ok(Self {
                 engines: HashMap::new(),
                 next_engine_seq: 1,
@@ -710,34 +792,29 @@ mod server_native {
         Ok(store.upload(&bytes, ArtifactKind::Binary, manifest, name))
     }
 
-    /// Bootstrap-ingest the chassis bins named in `AETHER_BINARY_BOOTSTRAP`
-    /// (an OS path list) into `store`, naming each by its file stem so a
-    /// `default` / `name` selector resolves in a fresh or `restart-hub`'d
-    /// hub (ADR-0115, issue 1954). A path that can't be read or
-    /// `--describe`d is logged and skipped — a bad bootstrap entry must not
-    /// fail hub boot. Idempotent via content dedup.
-    pub(super) fn bootstrap_ingest(store: &mut ArtifactStore) {
-        let Ok(raw) = env::var(ENV_BINARY_BOOTSTRAP) else {
-            return;
-        };
-        for path in env::split_paths(&raw) {
-            let Some(path_str) = path.to_str() else {
-                continue;
-            };
-            let name = path
+    /// Bootstrap-ingest each chassis bin in `paths` into `store`, naming
+    /// each by its file stem so a `default` / `name` selector resolves in a
+    /// fresh or `restart-hub`'d hub (ADR-0115, issue 1954). The list rides
+    /// `EngineConfig`'s `binary_bootstrap` field (its `AETHER_BINARY_BOOTSTRAP`
+    /// env layer, ADR-0090). A path that can't be read or `--describe`d is
+    /// logged and skipped — a bad bootstrap entry must not fail hub boot.
+    /// Idempotent via content dedup.
+    pub(super) fn bootstrap_ingest(store: &mut ArtifactStore, paths: &HashSet<String>) {
+        for path_str in paths {
+            let name = Path::new(path_str)
                 .file_stem()
                 .and_then(|stem| stem.to_str())
                 .map(str::to_owned);
             match ingest_binary(store, path_str, name) {
                 Ok(hash) => tracing::info!(
                     target: "aether_substrate::engine_server",
-                    path = path_str,
+                    path = path_str.as_str(),
                     hash = %hash,
                     "binary bootstrap: ingested a chassis bin",
                 ),
                 Err(error) => tracing::warn!(
                     target: "aether_substrate::engine_server",
-                    path = path_str,
+                    path = path_str.as_str(),
                     error = %error,
                     "binary bootstrap: skipping a bin that failed to ingest",
                 ),
@@ -960,7 +1037,6 @@ mod tests {
     // for fixture wiring — reference id derivation, not sibling-cap addressing.
     #![allow(clippy::disallowed_methods)]
     use super::{EngineConfig, EngineServer, ReplyCells, ReplySink};
-    use crate::store::ENV_BINARY_STORE_DIR;
     use crate::test_chassis::TestChassis;
     use aether_actor::Actor;
     use aether_data::{Kind, mailbox_id_from_name};
@@ -983,7 +1059,6 @@ mod tests {
     /// Returns the chassis (kept alive for its dispatcher threads), the
     /// mailer to push requests through, and the sink's cells.
     fn boot() -> (PassiveChassis<TestChassis>, Arc<Mailer>, ReplyCells) {
-        isolate_binary_store();
         let registry = Arc::new(Registry::new());
         for d in descriptors::all() {
             let _ = registry.register_kind_with_descriptor(d);
@@ -992,29 +1067,34 @@ mod tests {
         let store = Arc::new(HandleStore::new(1024 * 1024));
         let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
         let cells = ReplyCells::default();
+        // Point the cap's binary store (ADR-0115) at a per-call temp dir via
+        // the ADR-0090 config field so these unit tests never touch the real
+        // `dirs::data_dir()` store. Heartbeat stays disabled (the `Default`);
+        // only the store dir is overridden.
+        let config = EngineConfig {
+            binary_store_dir: Some(isolated_store_dir()),
+            ..EngineConfig::default()
+        };
         let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-            .with_actor::<EngineServer>(EngineConfig::default())
+            .with_actor::<EngineServer>(config)
             .with_actor::<ReplySink>(cells.clone())
             .build_passive()
             .expect("caps boot");
         (chassis, mailer, cells)
     }
 
-    /// Point `EngineServer::init`'s `ArtifactStore::from_env` (ADR-0115) at
-    /// a per-call temp dir so the engines-cap unit tests never touch the
-    /// real `dirs::data_dir()` binary store. These tests live in
-    /// `mod heavy`, which nextest serializes (`serial-heavy`), so the
-    /// process-global env set can't race a sibling.
-    fn isolate_binary_store() {
+    /// A unique per-call temp dir for the engines-cap unit tests' binary
+    /// store (ADR-0115), threaded onto `EngineConfig`'s `binary_store_dir`
+    /// by [`boot`] so they never touch the real `dirs::data_dir()` store. No
+    /// env side-channel — the store dir now rides the config (ADR-0090).
+    fn isolated_store_dir() -> String {
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map_or(0, |d| d.as_nanos());
-        let dir = env::temp_dir().join(format!("aether-binstore-engcap-{}-{nanos}", process::id()));
-        // SAFETY: serialized as a heavy test; no sibling reads this var
-        // concurrently, and only `EngineServer` consumes it.
-        unsafe {
-            env::set_var(ENV_BINARY_STORE_DIR, &dir);
-        }
+        env::temp_dir()
+            .join(format!("aether-binstore-engcap-{}-{nanos}", process::id()))
+            .to_string_lossy()
+            .into_owned()
     }
 
     /// Drive one request kind at `aether.engine`, reply-to the sink,
@@ -1119,16 +1199,17 @@ mod tests {
             }
         }
 
-        /// Bootstrap-ingest a stand-in headless binary through
-        /// `AETHER_BINARY_BOOTSTRAP`, then resolve the `default` selector
-        /// (empty `query`, no attribute filters) to it — the bare-spawn
-        /// path a fresh hub serves (ADR-0115, #1954). Heavy: it sets a
-        /// process-global env var and forks `<stand-in> --describe`.
+        /// Bootstrap-ingest a stand-in headless binary (passed directly as
+        /// the bootstrap list), then resolve the `default` selector (empty
+        /// `query`, no attribute filters) to it — the bare-spawn path a
+        /// fresh hub serves (ADR-0115, #1954). Heavy: it forks
+        /// `<stand-in> --describe`.
         #[cfg(unix)]
         #[test]
         fn bootstrap_populates_and_default_resolves_to_headless() {
             use super::super::server_native::{bootstrap_ingest, resolve_selector};
             use crate::store::{ArtifactStore, DEFAULT_DISK_BUDGET_BYTES};
+            use std::collections::HashSet;
             use std::fs;
             use std::os::unix::fs::PermissionsExt;
 
@@ -1154,15 +1235,9 @@ mod tests {
             fs::set_permissions(&stand_in, fs::Permissions::from_mode(0o755))
                 .expect("test setup: chmod stand-in");
 
-            // SAFETY: serialized as a heavy test; no sibling reads
-            // AETHER_BINARY_BOOTSTRAP concurrently, and only the bootstrap
-            // path consumes it. Key mirrors `ENV_BINARY_BOOTSTRAP`.
-            unsafe {
-                env::set_var("AETHER_BINARY_BOOTSTRAP", &stand_in);
-            }
-
             let mut store = ArtifactStore::open(&dir.join("store"), DEFAULT_DISK_BUDGET_BYTES);
-            bootstrap_ingest(&mut store);
+            let bootstrap = HashSet::from([stand_in.to_string_lossy().into_owned()]);
+            bootstrap_ingest(&mut store, &bootstrap);
 
             let resolved = resolve_selector(
                 &mut store,
@@ -1179,11 +1254,6 @@ mod tests {
                 "default resolves to the headless chassis",
             );
 
-            // SAFETY: same heavy-test serialization; restore the global so
-            // a sibling heavy test's `boot()` bootstrap sees it unset.
-            unsafe {
-                env::remove_var("AETHER_BINARY_BOOTSTRAP");
-            }
             let _ = fs::remove_dir_all(&dir);
         }
 

--- a/crates/aether-capabilities/src/store.rs
+++ b/crates/aether-capabilities/src/store.rs
@@ -14,8 +14,9 @@
 //!
 //! ## Layout
 //!
-//! Under a hub-scoped, layout-versioned root
-//! (`AETHER_BINARY_STORE_DIR`, default `data_dir/aether/binaries/v1`):
+//! Under a hub-scoped, layout-versioned root — the dir resolved from
+//! `EngineConfig`'s `binary_store_dir` field (the `AETHER_BINARY_STORE_DIR`
+//! env layer, ADR-0090) or the computed default `data_dir/aether/binaries/v1`:
 //!
 //! ```text
 //! <root>/
@@ -51,18 +52,15 @@ use aether_substrate::handle_store::is_pid_alive;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-/// Env override for the store's layout root (the ops escape hatch and the
-/// per-process isolation knob the fleet tests set). Absent → the platform
-/// data dir, then a temp fallback.
-pub const ENV_BINARY_STORE_DIR: &str = "AETHER_BINARY_STORE_DIR";
-
 /// Layout-version subdirectory under the resolved root, so a future
 /// on-disk format change can land beside `v1` without a migration.
 pub const LAYOUT_VERSION_DIR: &str = "v1";
 
 /// Default on-disk byte budget. 16 GiB — matches the handle store's disk
 /// budget; binaries are tens of megabytes, so this holds a deep history
-/// before LRU eviction kicks in.
+/// before LRU eviction kicks in. `EngineConfig`'s `binary_disk_budget_bytes`
+/// carries this as its literal default (`17_179_869_184`) and folds an
+/// unparseable env value back to it.
 pub const DEFAULT_DISK_BUDGET_BYTES: u64 = 16 * 1024 * 1024 * 1024;
 
 const TARGET: &str = "aether_capabilities::store";
@@ -148,16 +146,24 @@ pub struct ArtifactStore {
 }
 
 impl ArtifactStore {
-    /// Resolve the layout root from the environment, then [`open`] it.
-    ///
-    /// Priority: `AETHER_BINARY_STORE_DIR` env override, then
-    /// `data_dir/aether/binaries`, then `temp_dir/aether-binaries`. The
-    /// [`LAYOUT_VERSION_DIR`] is always appended.
-    ///
-    /// [`open`]: Self::open
+    /// The computed default layout root for the store — `data_dir`'s
+    /// `aether/binaries/<LAYOUT_VERSION_DIR>`, or a `temp_dir` fallback
+    /// when no platform data dir resolves. No env read: the
+    /// `AETHER_BINARY_STORE_DIR` override now rides `EngineConfig`'s
+    /// `binary_store_dir` field (ADR-0090), and `EngineServer::init` joins
+    /// [`LAYOUT_VERSION_DIR`] to a configured override or falls back here
+    /// when it's unset.
     #[must_use]
-    pub fn from_env() -> Self {
-        Self::open(&root_from_env(), DEFAULT_DISK_BUDGET_BYTES)
+    pub fn default_root() -> PathBuf {
+        if let Some(data) = dirs::data_dir() {
+            return data
+                .join("aether")
+                .join("binaries")
+                .join(LAYOUT_VERSION_DIR);
+        }
+        env::temp_dir()
+            .join("aether-binaries")
+            .join(LAYOUT_VERSION_DIR)
     }
 
     /// Open (or create) the store at `root` with the given disk budget.
@@ -422,25 +428,6 @@ fn hash_hex(bytes: &[u8]) -> String {
         let _ = write!(out, "{byte:02x}");
     }
     out
-}
-
-/// Resolve the layout root from the environment (see
-/// [`ArtifactStore::from_env`]).
-fn root_from_env() -> PathBuf {
-    if let Ok(raw) = env::var(ENV_BINARY_STORE_DIR)
-        && !raw.is_empty()
-    {
-        return PathBuf::from(raw).join(LAYOUT_VERSION_DIR);
-    }
-    if let Some(data) = dirs::data_dir() {
-        return data
-            .join("aether")
-            .join("binaries")
-            .join(LAYOUT_VERSION_DIR);
-    }
-    env::temp_dir()
-        .join("aether-binaries")
-        .join(LAYOUT_VERSION_DIR)
 }
 
 /// Ensure `root/entries` exists, falling back to a unique temp dir when

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1090,15 +1090,47 @@ mod engine {
         pub recently_died: Vec<DeadEngineDescriptor>,
     }
 
+    /// How a [`SpawnEngine`] names the binary to fork — a registry
+    /// selector resolved against the hub's content-addressed binary store
+    /// (ADR-0115), not a host filesystem path. The engines cap resolves it
+    /// in this order:
+    ///
+    /// - `query` is the exact selector token: a sha256 content `hash`, a
+    ///   `name@version` (where `version` is the binary's self-reported
+    ///   build id — its manifest `git_sha`), or a `name` an upload pointed
+    ///   at a hash. `None` means `default` — the configured fallback, the
+    ///   `headless` chassis (no window, runs on any host), so a bare
+    ///   `SpawnEngine` with an empty selector returns a working engine.
+    /// - `chassis` / `caps` / `target` are an attribute query over the
+    ///   stored manifests, consulted when `query` is `None`: keep only
+    ///   binaries whose `chassis` matches, whose linked `caps` are a
+    ///   superset of every listed cap, and whose `target` triple matches.
+    ///   They mirror [`ListBinaries`]' filter shape.
+    ///
+    /// An exact `query` wins first; absent one, the attribute query
+    /// resolves, then `default`. A selector that resolves to no stored
+    /// binary fails the spawn.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    pub struct BinarySelector {
+        pub query: Option<String>,
+        pub chassis: Option<String>,
+        pub caps: Vec<String>,
+        pub target: Option<String>,
+    }
+
     /// `aether.engine.spawn` — ask the engines cap to fork+exec a
     /// substrate binary and connect a per-engine proxy to it. Issue
     /// 763 P4.
     ///
-    /// The cap picks a free localhost port for the substrate's
-    /// `RpcServerCapability`, injects it as `AETHER_RPC_PORT`, forks
-    /// `binary_path` with `args` forwarded verbatim, then boots an
-    /// `aether.engine.proxy:<id>` actor that dials it. Reply:
-    /// [`SpawnEngineResult`].
+    /// The cap resolves `selector` against its content-addressed binary
+    /// store (ADR-0115) to the stored content bytes, materializes them to
+    /// an executable temp file, picks a free localhost port for the
+    /// substrate's `RpcServerCapability`, injects it as `AETHER_RPC_PORT`,
+    /// forks the realized binary with `args` forwarded verbatim, then
+    /// boots an `aether.engine.proxy:<id>` actor that dials it. Reply:
+    /// [`SpawnEngineResult`] — `Err` if the selector resolves to no stored
+    /// binary. The host filesystem path is gone from the spawn surface;
+    /// the only path input is the one-time [`UploadBinary`].
     ///
     /// `boot_manifest` (when `Some`) is the absolute path to a
     /// `BundleManifest` JSON of components to auto-load at boot; the cap
@@ -1110,7 +1142,7 @@ mod engine {
     #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.engine.spawn")]
     pub struct SpawnEngine {
-        pub binary_path: String,
+        pub selector: BinarySelector,
         pub args: Vec<String>,
         pub boot_manifest: Option<String>,
     }
@@ -4132,34 +4164,52 @@ mod tests {
 
     #[test]
     fn spawn_engine_roundtrip_carries_boot_manifest() {
-        // `boot_manifest` rides the wire (postcard path — non-`repr(C)`
-        // struct with `Vec<String>` + `Option<String>`); both `Some`
-        // (a spawn carrying a component list) and `None` (a bare spawn)
-        // must survive the engines-cap encode/decode.
+        // The spawn kind rides the wire (postcard path — non-`repr(C)`
+        // struct with a nested `BinarySelector`, `Vec<String>`, and
+        // `Option<String>`). Both `Some` (a spawn carrying a component
+        // list) and `None` (a bare spawn) must survive the engines-cap
+        // encode/decode, and the registry selector must round-trip in both
+        // its exact-hash and `default` forms (ADR-0115, #1954).
         use alloc::string::ToString;
         use alloc::vec;
 
         let spawn = SpawnEngine {
-            binary_path: "/abs/aether-substrate-headless".to_string(),
+            selector: BinarySelector {
+                query: Some("abc123def456".to_string()),
+                chassis: Some("headless".to_string()),
+                caps: vec!["aether.fs".to_string()],
+                target: None,
+            },
             args: vec!["--tick-hz".to_string(), "30".to_string()],
             boot_manifest: Some("/tmp/aether-boot-manifest.json".to_string()),
         };
         let back = SpawnEngine::decode_from_bytes(&spawn.encode_into_bytes())
             .expect("test setup: SpawnEngine decodes");
-        assert_eq!(back.binary_path, spawn.binary_path);
+        assert_eq!(back.selector.query.as_deref(), Some("abc123def456"));
+        assert_eq!(back.selector.chassis.as_deref(), Some("headless"));
+        assert_eq!(back.selector.caps, vec!["aether.fs".to_string()]);
+        assert_eq!(back.selector.target, None);
         assert_eq!(back.args, spawn.args);
         assert_eq!(
             back.boot_manifest.as_deref(),
             Some("/tmp/aether-boot-manifest.json"),
         );
 
+        // The `default` selector — empty query, no attribute filters, the
+        // bare-spawn form — round-trips too.
         let bare = SpawnEngine {
-            binary_path: "/abs/aether-substrate".to_string(),
+            selector: BinarySelector {
+                query: None,
+                chassis: None,
+                caps: vec![],
+                target: None,
+            },
             args: vec![],
             boot_manifest: None,
         };
         let back = SpawnEngine::decode_from_bytes(&bare.encode_into_bytes())
             .expect("test setup: bare SpawnEngine decodes");
+        assert_eq!(back.selector.query, None);
         assert_eq!(back.boot_manifest, None);
     }
 

--- a/crates/aether-mcp/src/args.rs
+++ b/crates/aether-mcp/src/args.rs
@@ -9,10 +9,26 @@ use serde::{Deserialize, Serialize};
 /// `spawn_substrate` arguments.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SpawnSubstrateArgs {
-    /// Absolute path to the substrate binary the hub should fork+exec.
-    /// The hub doesn't resolve or locate binaries — pass a path that
-    /// exists.
-    pub binary_path: String,
+    /// Registry selector for the binary to fork, resolved against the
+    /// hub's content-addressed store (ADR-0115) — `upload_binary` first if
+    /// it isn't stored yet. An exact token: a `hash`, a `name@version`
+    /// (version = the binary's self-reported build id), or a `name`. Omit
+    /// (or `null`) for `default` — the headless chassis, so a bare
+    /// `spawn_substrate` with no arguments returns a working engine.
+    #[serde(default)]
+    pub selector: Option<String>,
+    /// Attribute query over the stored manifests, used when `selector` is
+    /// omitted: the binary's chassis (`"headless"` / `"desktop"` /
+    /// `"hub"`).
+    #[serde(default)]
+    pub chassis: Option<String>,
+    /// Attribute query: keep only binaries whose linked caps are a
+    /// superset of every cap listed here (e.g. `["aether.render"]`).
+    #[serde(default)]
+    pub caps: Vec<String>,
+    /// Attribute query: the build target triple to match.
+    #[serde(default)]
+    pub target: Option<String>,
     /// Extra command-line arguments forwarded to the substrate
     /// verbatim. `AETHER_RPC_PORT` is injected by the hub regardless.
     #[serde(default)]

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -34,10 +34,10 @@ use aether_data::{
 use aether_data::{EnumVariant, Primitive, SchemaType};
 use aether_kinds::dag::{DagDescriptor, Edge, Node, NodeId};
 use aether_kinds::{
-    Cancel, CancelResult, CaptureFrame, CaptureFrameResult, ComponentCapabilities, CostTail,
-    CostTailResult, DeathReason, FrameCheck, FrameReduction, ListBinaries, ListBinariesResult,
-    ListEngines, ListEnginesResult, ListKinds, ListKindsResult, LoadComponent, LoadResult,
-    MailEnvelope as KindMailEnvelope, ReplaceComponent, ReplaceResult, SimilarityCheck,
+    BinarySelector, Cancel, CancelResult, CaptureFrame, CaptureFrameResult, ComponentCapabilities,
+    CostTail, CostTailResult, DeathReason, FrameCheck, FrameReduction, ListBinaries,
+    ListBinariesResult, ListEngines, ListEnginesResult, ListKinds, ListKindsResult, LoadComponent,
+    LoadResult, MailEnvelope as KindMailEnvelope, ReplaceComponent, ReplaceResult, SimilarityCheck,
     SpawnEngine, SpawnEngineResult, Status, StatusResult, Submit, SubmitResult, TerminateEngine,
     TerminateEngineResult, UploadBinary, UploadBinaryResult,
     trace::{
@@ -234,7 +234,7 @@ impl Mcp {
     }
 
     #[tool(
-        description = "Fork+exec a substrate binary as a child of the hub. The hub assigns the substrate a free localhost RPC port, injects it as AETHER_RPC_PORT, forks the binary, and connects a proxy. Returns the engine_id and rpc_port on success. Pass `components` (each {binary_path, name?, config_path?, export?}) to bring the engine up with those components already loaded in one call — aether-mcp stages a temp boot-manifest the hub injects as AETHER_BOOT_MANIFEST, and the spawned substrate reads the listed wasm itself (single-host), so no follow-up load_component is needed."
+        description = "Fork+exec a substrate binary as a child of the hub, resolved from the hub's content-addressed binary store (ADR-0115) — not a host path. Pass `selector` to pick the binary: a content `hash`, a `name@version`, or a `name` (upload_binary first if it isn't stored). Omit `selector` for `default` — the headless chassis — so a bare spawn_substrate with no arguments returns a working engine. When `selector` is omitted you may instead attribute-query with `chassis` (\"headless\"/\"desktop\"/\"hub\"), `caps` (linked-cap superset), and `target` (build triple). The hub resolves the selector to the stored bytes, materializes them to an executable temp file, assigns a free localhost RPC port (injected as AETHER_RPC_PORT), forks it, and connects a proxy. Returns the engine_id and rpc_port on success; errors if the selector resolves to no stored binary. Pass `components` (each {binary_path, name?, config_path?, export?}) to bring the engine up with those components already loaded in one call — aether-mcp stages a temp boot-manifest the hub injects as AETHER_BOOT_MANIFEST, and the spawned substrate reads the listed wasm itself (single-host), so no follow-up load_component is needed."
     )]
     pub async fn spawn_substrate(
         &self,
@@ -259,7 +259,12 @@ impl Mcp {
             .call_one(local_envelope(
                 ENGINE_CAP,
                 &SpawnEngine {
-                    binary_path: args.binary_path,
+                    selector: BinarySelector {
+                        query: args.selector,
+                        chassis: args.chassis,
+                        caps: args.caps,
+                        target: args.target,
+                    },
                     args: args.args,
                     boot_manifest: manifest.as_ref().map(|p| p.to_string_lossy().into_owned()),
                 },
@@ -2868,20 +2873,27 @@ mod tests {
         );
     }
 
-    /// `spawn_substrate` with a binary path that doesn't exist surfaces
-    /// the hub's `SpawnEngineResult::Err` as a tool error.
+    /// `spawn_substrate` with a selector that resolves to no stored binary
+    /// surfaces the hub's `SpawnEngineResult::Err` as a tool error (the
+    /// store is empty on a fresh hub).
     #[tokio::test]
     async fn spawn_substrate_missing_binary_is_tool_error() {
         let (_chassis, port) = boot_hub();
         let mcp = connect_mcp(port);
         let result = mcp
             .spawn_substrate(Parameters(SpawnSubstrateArgs {
-                binary_path: "/nonexistent/aether-substrate-does-not-exist".to_owned(),
+                selector: Some("nonexistent-hash-or-name".to_owned()),
+                chassis: None,
+                caps: vec![],
+                target: None,
                 args: vec![],
                 components: vec![],
             }))
             .await;
-        assert!(result.is_err(), "a missing binary should be a tool error");
+        assert!(
+            result.is_err(),
+            "an unresolvable selector should be a tool error"
+        );
     }
 
     /// The temp boot-manifest `spawn_substrate` stages from its

--- a/crates/aether-substrate-bundle/tests/engines_cap.rs
+++ b/crates/aether-substrate-bundle/tests/engines_cap.rs
@@ -29,6 +29,7 @@ use aether_substrate::mail::mailer::Mailer;
 use aether_substrate::mail::outbound::HubOutbound;
 use aether_substrate::mail::registry::Registry;
 use aether_substrate::mail::{Mail, Source, SourceAddr};
+use std::collections::HashSet;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -109,7 +110,7 @@ mod sink {
 // `ReplySink` is re-exported to this module root by the `#[bridge]`
 // macro — no explicit `use sink::ReplySink` needed.
 
-fn boot() -> (PassiveChassis<TestChassis>, Arc<Mailer>, ReplyCells) {
+fn boot(engine_config: EngineConfig) -> (PassiveChassis<TestChassis>, Arc<Mailer>, ReplyCells) {
     let registry = Arc::new(Registry::new());
     for d in descriptors::all() {
         let _ = registry.register_kind_with_descriptor(d);
@@ -119,23 +120,24 @@ fn boot() -> (PassiveChassis<TestChassis>, Arc<Mailer>, ReplyCells) {
     let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
     let cells = ReplyCells::default();
     let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-        .with_actor::<EngineServer>(EngineConfig::default())
+        .with_actor::<EngineServer>(engine_config)
         .with_actor::<ReplySink>(cells.clone())
         .build_passive()
         .expect("caps boot");
     (chassis, mailer, cells)
 }
 
-/// Isolate the hub binary store (ADR-0115) under `store_dir` and bootstrap
-/// it with the `headless` bin, so the cap resolves a `default` selector to
-/// that binary (issue 1954). Must run before [`boot`] — `EngineServer::init`
-/// reads `AETHER_BINARY_BOOTSTRAP` and forks `<headless> --describe`. nextest
-/// runs each test in its own process, so the env set can't race a sibling.
-fn isolate_and_bootstrap_store(store_dir: &Path, headless: &str) {
-    // SAFETY: per-test process; no sibling reads these vars concurrently.
-    unsafe {
-        env::set_var("AETHER_BINARY_STORE_DIR", store_dir);
-        env::set_var("AETHER_BINARY_BOOTSTRAP", headless);
+/// Build the engines-cap config that isolates the hub binary store
+/// (ADR-0115) under `store_dir` and bootstraps it with the `headless` bin,
+/// so the cap resolves a `default` selector to that binary (issue 1954).
+/// The store dir / bootstrap list ride `EngineConfig` (ADR-0090) instead of
+/// the env side-channel; the heartbeat stays disabled (the `Default`).
+/// `EngineServer::init` forks `<headless> --describe` to ingest it.
+fn bootstrap_store_config(store_dir: &Path, headless: &str) -> EngineConfig {
+    EngineConfig {
+        binary_store_dir: Some(store_dir.to_string_lossy().into_owned()),
+        binary_bootstrap: HashSet::from([headless.to_owned()]),
+        ..EngineConfig::default()
     }
 }
 
@@ -198,9 +200,8 @@ mod tests {
                 .map_or(0, |d| d.as_nanos());
             let store_dir =
                 env::temp_dir().join(format!("aether-engcap-binstore-{}-{nanos}", process::id()));
-            isolate_and_bootstrap_store(&store_dir, headless);
 
-            let (_chassis, mailer, cells) = boot();
+            let (_chassis, mailer, cells) = boot(bootstrap_store_config(&store_dir, headless));
 
             // Spawn: the cap assigns a port, forks the substrate, and the
             // proxy retries the dial until the fresh process binds. Generous
@@ -313,19 +314,18 @@ mod tests {
             // `engine_store_root()` to resolve to `root` (read in the test
             // process when `on_spawn` runs), (b) the spawned substrates to
             // NOT inherit a parent `AETHER_HANDLE_STORE_DIR` (which would win
-            // over the cap's per-engine injection), (c) persistence not
+            // over the cap's per-engine injection), and (c) persistence not
             // to be globally disabled — the lock-collision case the issue
-            // pins only fires when each substrate writes a `lock.pid` — and
-            // (d) the cap to resolve a `default` selector to the bootstrapped
-            // headless bin (ADR-0115, #1954).
+            // pins only fires when each substrate writes a `lock.pid`. The
+            // `default`-selector resolution to the bootstrapped headless bin
+            // (ADR-0115, #1954) now rides `bootstrap_store_config`, not env.
             unsafe {
                 env::set_var("AETHER_ENGINE_STORE_ROOT", &root);
                 env::remove_var("AETHER_HANDLE_STORE_DIR");
                 env::remove_var("AETHER_HANDLE_STORE_PERSIST_DISABLE");
             }
-            isolate_and_bootstrap_store(&bin_store, headless);
 
-            let (_chassis, mailer, cells) = boot();
+            let (_chassis, mailer, cells) = boot(bootstrap_store_config(&bin_store, headless));
 
             // Spawn engine A.
             let a = drive(

--- a/crates/aether-substrate-bundle/tests/engines_cap.rs
+++ b/crates/aether-substrate-bundle/tests/engines_cap.rs
@@ -18,8 +18,8 @@ use aether_capabilities::{EngineConfig, EngineServer};
 use aether_data::{Kind, mailbox_id_from_name};
 use aether_kinds::descriptors;
 use aether_kinds::{
-    ListEngines, ListEnginesResult, SpawnEngine, SpawnEngineResult, TerminateEngine,
-    TerminateEngineResult,
+    BinarySelector, ListEngines, ListEnginesResult, SpawnEngine, SpawnEngineResult,
+    TerminateEngine, TerminateEngineResult,
 };
 use aether_substrate::chassis::Chassis;
 use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver, PassiveChassis};
@@ -31,7 +31,7 @@ use aether_substrate::mail::registry::Registry;
 use aether_substrate::mail::{Mail, Source, SourceAddr};
 use std::env;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -126,6 +126,30 @@ fn boot() -> (PassiveChassis<TestChassis>, Arc<Mailer>, ReplyCells) {
     (chassis, mailer, cells)
 }
 
+/// Isolate the hub binary store (ADR-0115) under `store_dir` and bootstrap
+/// it with the `headless` bin, so the cap resolves a `default` selector to
+/// that binary (issue 1954). Must run before [`boot`] — `EngineServer::init`
+/// reads `AETHER_BINARY_BOOTSTRAP` and forks `<headless> --describe`. nextest
+/// runs each test in its own process, so the env set can't race a sibling.
+fn isolate_and_bootstrap_store(store_dir: &Path, headless: &str) {
+    // SAFETY: per-test process; no sibling reads these vars concurrently.
+    unsafe {
+        env::set_var("AETHER_BINARY_STORE_DIR", store_dir);
+        env::set_var("AETHER_BINARY_BOOTSTRAP", headless);
+    }
+}
+
+/// The `default` registry selector — empty `query`, no attribute filters —
+/// the bare-spawn form that resolves to the bootstrapped headless bin.
+fn default_selector() -> BinarySelector {
+    BinarySelector {
+        query: None,
+        chassis: None,
+        caps: vec![],
+        target: None,
+    }
+}
+
 /// Drive one request kind at `aether.engine`, reply-to the sink, and
 /// block until `probe` returns a recorded reply (or `deadline` passes).
 fn drive<K: Kind, T>(
@@ -151,201 +175,83 @@ fn drive<K: Kind, T>(
 }
 
 /// Contention-sensitive: both tests fork a real headless substrate and
-/// sleep-poll under a ~30s settle deadline, so they go in `mod heavy`
-/// for the `serial-heavy` nextest group (issue 1522).
-mod heavy {
+/// sleep-poll under a ~30s settle deadline, so they go in `mod tests::heavy`
+/// for the `serial-heavy` nextest group (issue 1522). The `tests` parent is
+/// load-bearing: the `serial-heavy` filter keys on the `::heavy::` path
+/// segment, and a bare top-level `mod heavy` renders as `heavy::…` (no
+/// leading `::`), which the filter misses — leaking the real-substrate fork
+/// into the saturated parallel run.
+mod tests {
     use super::*;
 
-    #[test]
-    fn engines_cap_spawns_lists_and_terminates_a_real_headless_substrate() {
-        let (_chassis, mailer, cells) = boot();
-        let headless = env!("CARGO_BIN_EXE_aether-substrate-headless");
+    mod heavy {
+        use super::*;
 
-        // Spawn: the cap assigns a port, forks the substrate, and the
-        // proxy retries the dial until the fresh process binds. Generous
-        // deadline — this covers a debug-build chassis cold start.
-        let spawn = drive(
-            &mailer,
-            &SpawnEngine {
-                binary_path: headless.to_owned(),
-                args: vec![],
-                boot_manifest: None,
-            },
-            Duration::from_secs(30),
-            || {
-                cells
-                    .spawn
-                    .lock()
-                    .expect("test setup: spawn cell mutex is never poisoned")
-                    .take()
-            },
-        );
-        let engine_id = match spawn {
-            SpawnEngineResult::Ok {
-                engine_id,
-                rpc_port,
-            } => {
-                assert_ne!(rpc_port, 0, "cap should report the assigned RPC port");
-                engine_id
-            }
-            SpawnEngineResult::Err { error } => panic!("spawn failed: {error}"),
-        };
+        #[test]
+        fn engines_cap_spawns_lists_and_terminates_a_real_headless_substrate() {
+            let headless = env!("CARGO_BIN_EXE_aether-substrate-headless");
+            // Bootstrap the binary store with the headless bin so the cap
+            // resolves a `default` selector to it (ADR-0115, #1954). Before
+            // `boot()` — init reads the bootstrap env. Cleaned on success.
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_or(0, |d| d.as_nanos());
+            let store_dir =
+                env::temp_dir().join(format!("aether-engcap-binstore-{}-{nanos}", process::id()));
+            isolate_and_bootstrap_store(&store_dir, headless);
 
-        // List: the freshly-spawned engine shows up in the cap's table.
-        let list = drive(&mailer, &ListEngines {}, Duration::from_secs(5), || {
-            cells
-                .list
-                .lock()
-                .expect("test setup: list cell mutex is never poisoned")
-                .take()
-        });
-        assert!(
-            list.engines.iter().any(|e| e.engine_id == engine_id),
-            "spawned engine {engine_id} should appear in ListEngines: {list:?}",
-        );
+            let (_chassis, mailer, cells) = boot();
 
-        // Terminate: the cap forwards to the proxy, which SIGKILLs the
-        // substrate and self-shuts-down; the table entry is dropped.
-        let terminate = drive(
-            &mailer,
-            &TerminateEngine {
-                engine_id: engine_id.clone(),
-            },
-            Duration::from_secs(5),
-            || {
-                cells
-                    .terminate
-                    .lock()
-                    .expect("test setup: terminate cell mutex is never poisoned")
-                    .take()
-            },
-        );
-        assert!(
-            matches!(terminate, TerminateEngineResult::Ok),
-            "terminate of a live engine should succeed: {terminate:?}",
-        );
-
-        // After terminate, the engine is gone from the table.
-        let list_after = drive(&mailer, &ListEngines {}, Duration::from_secs(5), || {
-            cells
-                .list
-                .lock()
-                .expect("test setup: list cell mutex is never poisoned")
-                .take()
-        });
-        assert!(
-            !list_after.engines.iter().any(|e| e.engine_id == engine_id),
-            "terminated engine {engine_id} should be gone from ListEngines: {list_after:?}",
-        );
-    }
-
-    /// Two engines spawned via the cap coexist with persistence on: each
-    /// gets its own `${AETHER_ENGINE_STORE_ROOT}/<engine_id>` handle-store
-    /// dir, so the ADR-0049 §7 `lock.pid` doesn't collide
-    /// (iamacoffeepot/aether#1274). Before the fix, both substrates
-    /// resolved to the same default `dirs::data_dir()/aether/handles` and
-    /// one failed with `LockError::Held`.
-    #[test]
-    fn two_engines_get_distinct_handle_store_dirs() {
-        let headless = env!("CARGO_BIN_EXE_aether-substrate-headless");
-
-        // Per-test scratch dir under the system temp root. Process pid +
-        // nanos disambiguate against any leftover from a prior run that
-        // didn't clean up (the test below cleans on the success path).
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_or(0, |d| d.as_nanos());
-        let root = env::temp_dir().join(format!("aether-engines-cap-{}-{}", process::id(), nanos));
-
-        // SAFETY: nextest runs each test in its own process, so the env
-        // mutations here don't race sibling tests. We need (a) the cap's
-        // `engine_store_root()` to resolve to `root` (read in the test
-        // process when `on_spawn` runs), (b) the spawned substrates to
-        // NOT inherit a parent `AETHER_HANDLE_STORE_DIR` (which would win
-        // over the cap's per-engine injection), and (c) persistence not
-        // to be globally disabled — the lock-collision case the issue
-        // pins only fires when each substrate writes a `lock.pid`.
-        unsafe {
-            env::set_var("AETHER_ENGINE_STORE_ROOT", &root);
-            env::remove_var("AETHER_HANDLE_STORE_DIR");
-            env::remove_var("AETHER_HANDLE_STORE_PERSIST_DISABLE");
-        }
-
-        let (_chassis, mailer, cells) = boot();
-
-        // Spawn engine A.
-        let a = drive(
-            &mailer,
-            &SpawnEngine {
-                binary_path: headless.to_owned(),
-                args: vec![],
-                boot_manifest: None,
-            },
-            Duration::from_secs(30),
-            || {
-                cells
-                    .spawn
-                    .lock()
-                    .expect("test setup: spawn cell mutex is never poisoned")
-                    .take()
-            },
-        );
-        let a_id = match a {
-            SpawnEngineResult::Ok { engine_id, .. } => engine_id,
-            SpawnEngineResult::Err { error } => panic!("spawn A failed: {error}"),
-        };
-
-        // Spawn engine B. Pre-fix this would race the same handle-store
-        // dir and either A or B would die with `LockError::Held`; the
-        // cap's reply to `on_spawn` would be `Err` because the proxy
-        // never connected to a substrate that aborted boot. The assertion
-        // below is structural — both spawn replies are Ok.
-        let b = drive(
-            &mailer,
-            &SpawnEngine {
-                binary_path: headless.to_owned(),
-                args: vec![],
-                boot_manifest: None,
-            },
-            Duration::from_secs(30),
-            || {
-                cells
-                    .spawn
-                    .lock()
-                    .expect("test setup: spawn cell mutex is never poisoned")
-                    .take()
-            },
-        );
-        let b_id = match b {
-            SpawnEngineResult::Ok { engine_id, .. } => engine_id,
-            SpawnEngineResult::Err { error } => panic!("spawn B failed: {error}"),
-        };
-        assert_ne!(a_id, b_id, "the cap must mint distinct engine ids");
-
-        // Walk `root/` for the per-engine subdirs the cap allocated.
-        // Each child substrate creates `lock.pid` + `v1/` lazily under
-        // its assigned `AETHER_HANDLE_STORE_DIR`, so we only assert on the
-        // top-level subdir count — the lock collision (the actual bug)
-        // would surface as a missing dir or a failed spawn earlier.
-        let subdirs: Vec<PathBuf> = fs::read_dir(&root)
-            .unwrap_or_else(|e| panic!("read_dir({}): {e}", root.display()))
-            .filter_map(Result::ok)
-            .map(|entry| entry.path())
-            .filter(|p| p.is_dir())
-            .collect();
-        assert_eq!(
-            subdirs.len(),
-            2,
-            "expected two per-engine handle-store dirs under {}; saw: {subdirs:?}",
-            root.display(),
-        );
-
-        // Terminate both engines so their proxies SIGKILL the substrates;
-        // best-effort cleanup of the scratch root follows.
-        for id in [a_id, b_id] {
-            let _ = drive(
+            // Spawn: the cap assigns a port, forks the substrate, and the
+            // proxy retries the dial until the fresh process binds. Generous
+            // deadline — this covers a debug-build chassis cold start.
+            let spawn = drive(
                 &mailer,
-                &TerminateEngine { engine_id: id },
+                &SpawnEngine {
+                    selector: default_selector(),
+                    args: vec![],
+                    boot_manifest: None,
+                },
+                Duration::from_secs(30),
+                || {
+                    cells
+                        .spawn
+                        .lock()
+                        .expect("test setup: spawn cell mutex is never poisoned")
+                        .take()
+                },
+            );
+            let engine_id = match spawn {
+                SpawnEngineResult::Ok {
+                    engine_id,
+                    rpc_port,
+                } => {
+                    assert_ne!(rpc_port, 0, "cap should report the assigned RPC port");
+                    engine_id
+                }
+                SpawnEngineResult::Err { error } => panic!("spawn failed: {error}"),
+            };
+
+            // List: the freshly-spawned engine shows up in the cap's table.
+            let list = drive(&mailer, &ListEngines {}, Duration::from_secs(5), || {
+                cells
+                    .list
+                    .lock()
+                    .expect("test setup: list cell mutex is never poisoned")
+                    .take()
+            });
+            assert!(
+                list.engines.iter().any(|e| e.engine_id == engine_id),
+                "spawned engine {engine_id} should appear in ListEngines: {list:?}",
+            );
+
+            // Terminate: the cap forwards to the proxy, which SIGKILLs the
+            // substrate and self-shuts-down; the table entry is dropped.
+            let terminate = drive(
+                &mailer,
+                &TerminateEngine {
+                    engine_id: engine_id.clone(),
+                },
                 Duration::from_secs(5),
                 || {
                     cells
@@ -355,7 +261,157 @@ mod heavy {
                         .take()
                 },
             );
+            assert!(
+                matches!(terminate, TerminateEngineResult::Ok),
+                "terminate of a live engine should succeed: {terminate:?}",
+            );
+
+            // After terminate, the engine is gone from the table.
+            let list_after = drive(&mailer, &ListEngines {}, Duration::from_secs(5), || {
+                cells
+                    .list
+                    .lock()
+                    .expect("test setup: list cell mutex is never poisoned")
+                    .take()
+            });
+            assert!(
+                !list_after.engines.iter().any(|e| e.engine_id == engine_id),
+                "terminated engine {engine_id} should be gone from ListEngines: {list_after:?}",
+            );
+
+            let _ = fs::remove_dir_all(&store_dir);
         }
-        let _ = fs::remove_dir_all(&root);
+
+        /// Two engines spawned via the cap coexist with persistence on: each
+        /// gets its own `${AETHER_ENGINE_STORE_ROOT}/<engine_id>` handle-store
+        /// dir, so the ADR-0049 §7 `lock.pid` doesn't collide
+        /// (iamacoffeepot/aether#1274). Before the fix, both substrates
+        /// resolved to the same default `dirs::data_dir()/aether/handles` and
+        /// one failed with `LockError::Held`.
+        #[test]
+        fn two_engines_get_distinct_handle_store_dirs() {
+            let headless = env!("CARGO_BIN_EXE_aether-substrate-headless");
+
+            // Per-test scratch dir under the system temp root. Process pid +
+            // nanos disambiguate against any leftover from a prior run that
+            // didn't clean up (the test below cleans on the success path).
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_or(0, |d| d.as_nanos());
+            let root =
+                env::temp_dir().join(format!("aether-engines-cap-{}-{}", process::id(), nanos));
+            // The binary store lives outside `root` so it doesn't add a
+            // top-level subdir the per-engine-dir count below asserts on.
+            let bin_store = env::temp_dir().join(format!(
+                "aether-engcap-binstore-{}-{}",
+                process::id(),
+                nanos
+            ));
+
+            // SAFETY: nextest runs each test in its own process, so the env
+            // mutations here don't race sibling tests. We need (a) the cap's
+            // `engine_store_root()` to resolve to `root` (read in the test
+            // process when `on_spawn` runs), (b) the spawned substrates to
+            // NOT inherit a parent `AETHER_HANDLE_STORE_DIR` (which would win
+            // over the cap's per-engine injection), (c) persistence not
+            // to be globally disabled — the lock-collision case the issue
+            // pins only fires when each substrate writes a `lock.pid` — and
+            // (d) the cap to resolve a `default` selector to the bootstrapped
+            // headless bin (ADR-0115, #1954).
+            unsafe {
+                env::set_var("AETHER_ENGINE_STORE_ROOT", &root);
+                env::remove_var("AETHER_HANDLE_STORE_DIR");
+                env::remove_var("AETHER_HANDLE_STORE_PERSIST_DISABLE");
+            }
+            isolate_and_bootstrap_store(&bin_store, headless);
+
+            let (_chassis, mailer, cells) = boot();
+
+            // Spawn engine A.
+            let a = drive(
+                &mailer,
+                &SpawnEngine {
+                    selector: default_selector(),
+                    args: vec![],
+                    boot_manifest: None,
+                },
+                Duration::from_secs(30),
+                || {
+                    cells
+                        .spawn
+                        .lock()
+                        .expect("test setup: spawn cell mutex is never poisoned")
+                        .take()
+                },
+            );
+            let a_id = match a {
+                SpawnEngineResult::Ok { engine_id, .. } => engine_id,
+                SpawnEngineResult::Err { error } => panic!("spawn A failed: {error}"),
+            };
+
+            // Spawn engine B. Pre-fix this would race the same handle-store
+            // dir and either A or B would die with `LockError::Held`; the
+            // cap's reply to `on_spawn` would be `Err` because the proxy
+            // never connected to a substrate that aborted boot. The assertion
+            // below is structural — both spawn replies are Ok.
+            let b = drive(
+                &mailer,
+                &SpawnEngine {
+                    selector: default_selector(),
+                    args: vec![],
+                    boot_manifest: None,
+                },
+                Duration::from_secs(30),
+                || {
+                    cells
+                        .spawn
+                        .lock()
+                        .expect("test setup: spawn cell mutex is never poisoned")
+                        .take()
+                },
+            );
+            let b_id = match b {
+                SpawnEngineResult::Ok { engine_id, .. } => engine_id,
+                SpawnEngineResult::Err { error } => panic!("spawn B failed: {error}"),
+            };
+            assert_ne!(a_id, b_id, "the cap must mint distinct engine ids");
+
+            // Walk `root/` for the per-engine subdirs the cap allocated.
+            // Each child substrate creates `lock.pid` + `v1/` lazily under
+            // its assigned `AETHER_HANDLE_STORE_DIR`, so we only assert on the
+            // top-level subdir count — the lock collision (the actual bug)
+            // would surface as a missing dir or a failed spawn earlier.
+            let subdirs: Vec<PathBuf> = fs::read_dir(&root)
+                .unwrap_or_else(|e| panic!("read_dir({}): {e}", root.display()))
+                .filter_map(Result::ok)
+                .map(|entry| entry.path())
+                .filter(|p| p.is_dir())
+                .collect();
+            assert_eq!(
+                subdirs.len(),
+                2,
+                "expected two per-engine handle-store dirs under {}; saw: {subdirs:?}",
+                root.display(),
+            );
+
+            // Terminate both engines so their proxies SIGKILL the substrates;
+            // best-effort cleanup of the scratch root follows.
+            for id in [a_id, b_id] {
+                let _ = drive(
+                    &mailer,
+                    &TerminateEngine { engine_id: id },
+                    Duration::from_secs(5),
+                    || {
+                        cells
+                            .terminate
+                            .lock()
+                            .expect("test setup: terminate cell mutex is never poisoned")
+                            .take()
+                    },
+                );
+            }
+            let _ = fs::remove_dir_all(&root);
+            let _ = fs::remove_dir_all(&bin_store);
+        }
     }
 }

--- a/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
@@ -149,7 +149,7 @@ impl FleetBench {
     /// `TcpStream`, and complete the `Hello`/`HelloAck` handshake.
     pub fn start() -> Self {
         let store_root = isolate_store_root();
-        let (chassis, port) = boot_hub();
+        let (chassis, port) = boot_hub(&store_root.join("binaries"));
         let stream = TcpStream::connect(format!("127.0.0.1:{port}"))
             .expect("test setup: connecting to the hub's bound RPC port succeeds");
         stream
@@ -710,14 +710,13 @@ fn isolate_store_root() -> PathBuf {
     // SAFETY: nextest runs each integration test in its own process, so
     // this env mutation can't race a sibling test; each `FleetBench` in a
     // process gets a fresh `nanos`-tagged root.
+    //
+    // The hub's binary store (ADR-0115) is isolated under `root/binaries`
+    // too, but that dir rides `EngineConfig::binary_store_dir` (ADR-0090)
+    // now, threaded into `boot_hub` from the returned root — not an env var.
     unsafe {
         env::set_var("AETHER_ENGINE_STORE_ROOT", &root);
         env::remove_var("AETHER_HANDLE_STORE_DIR");
-        // Isolate the hub's binary store (ADR-0115) under the same per-bench
-        // root so the EngineServer's `ArtifactStore::from_env` doesn't touch
-        // the real data dir and a binary-store scenario can't see another
-        // bench's entries. Removed on `Drop` with the rest of the root.
-        env::set_var("AETHER_BINARY_STORE_DIR", root.join("binaries"));
     }
     root
 }
@@ -726,8 +725,10 @@ fn isolate_store_root() -> PathBuf {
 /// (engine-addressed Calls route through `aether.engine`), the engines
 /// cap, and `TraceDispatchCapability` so the `RpcServer`'s local Calls
 /// settle and close. Returns the chassis and the port the RPC server
-/// bound. Mirrors the seed's `boot_hub`.
-fn boot_hub() -> (PassiveChassis<TestChassis>, u16) {
+/// bound. Mirrors the seed's `boot_hub`. `binary_store_dir` isolates the
+/// hub's content-addressed store (ADR-0115) per-bench via `EngineConfig`
+/// (ADR-0090); the heartbeat stays disabled (the `Default`).
+fn boot_hub(binary_store_dir: &Path) -> (PassiveChassis<TestChassis>, u16) {
     let registry = Arc::new(Registry::new());
     for d in descriptors::all() {
         let _ = registry.register_kind_with_descriptor(d);
@@ -737,7 +738,10 @@ fn boot_hub() -> (PassiveChassis<TestChassis>, u16) {
     let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
     let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
         .with_actor::<TraceDispatchCapability>(())
-        .with_actor::<EngineServer>(EngineConfig::default())
+        .with_actor::<EngineServer>(EngineConfig {
+            binary_store_dir: Some(binary_store_dir.to_string_lossy().into_owned()),
+            ..EngineConfig::default()
+        })
         .with_actor::<RpcServerCapability>(RpcServerConfig {
             bind_addr: "127.0.0.1:0".into(),
             peer_kind: PeerKind::Substrate {

--- a/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
@@ -50,11 +50,12 @@ use aether_kinds::MailEnvelope as TracedEnvelope;
 use aether_kinds::descriptors;
 use aether_kinds::trace::{DispatchTraced, DispatchTracedAck, TRACE_MAILBOX_NAME};
 use aether_kinds::{
-    BinaryEntry, Cancel, CancelResult, ComponentCapabilities, DagDescriptor, DeadEngineDescriptor,
-    EngineDescriptor, HandleDescribe, HandleDescribeResult, ListBinaries, ListBinariesResult,
-    ListEngines, ListEnginesResult, LoadComponent, LoadResult, LogTail, LogTailResult,
-    ReplaceComponent, ReplaceResult, SpawnEngine, SpawnEngineResult, Status, StatusResult, Submit,
-    SubmitResult, TerminateEngine, TerminateEngineResult, UploadBinary, UploadBinaryResult,
+    BinaryEntry, BinarySelector, Cancel, CancelResult, ComponentCapabilities, DagDescriptor,
+    DeadEngineDescriptor, EngineDescriptor, HandleDescribe, HandleDescribeResult, ListBinaries,
+    ListBinariesResult, ListEngines, ListEnginesResult, LoadComponent, LoadResult, LogTail,
+    LogTailResult, ReplaceComponent, ReplaceResult, SpawnEngine, SpawnEngineResult, Status,
+    StatusResult, Submit, SubmitResult, TerminateEngine, TerminateEngineResult, UploadBinary,
+    UploadBinaryResult,
 };
 use aether_substrate::chassis::Chassis;
 use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver, PassiveChassis};
@@ -175,13 +176,27 @@ impl FleetBench {
 
     /// Fork a real `aether-substrate-headless` through the hub's engines
     /// cap and return its `EngineId`. Records the engine for teardown.
+    ///
+    /// Pins the binary by content hash (ADR-0115, #1954): upload the
+    /// headless bin into the hub's content-addressed store, then spawn
+    /// exactly that hash — so every run forks the same binary regardless of
+    /// local build state, instead of handing the cap a host path.
     pub fn spawn_headless(&mut self) -> EngineId {
         let headless = env!("CARGO_BIN_EXE_aether-substrate-headless");
+        let hash = match self.upload_binary(headless, Some("headless")) {
+            UploadBinaryResult::Ok { hash, .. } => hash,
+            UploadBinaryResult::Err { error } => panic!("spawn_headless upload failed: {error}"),
+        };
         let replies = self.call(
             None,
             "aether.engine",
             &SpawnEngine {
-                binary_path: headless.to_owned(),
+                selector: BinarySelector {
+                    query: Some(hash),
+                    chassis: None,
+                    caps: vec![],
+                    target: None,
+                },
                 args: vec![],
                 boot_manifest: None,
             },

--- a/crates/aether-substrate-bundle/tests/rpc_engine_routing.rs
+++ b/crates/aether-substrate-bundle/tests/rpc_engine_routing.rs
@@ -40,6 +40,7 @@ use aether_substrate::handle_store::HandleStore;
 use aether_substrate::mail::mailer::Mailer;
 use aether_substrate::mail::outbound::HubOutbound;
 use aether_substrate::mail::registry::Registry;
+use std::collections::HashSet;
 use std::net::TcpStream;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -59,7 +60,7 @@ impl Chassis for TestChassis {
 /// (engine-addressed Calls route through `aether.engine`), the engines
 /// cap, and `TraceDispatchCapability` so the `RpcServer`'s local Calls
 /// (`spawn`, `terminate`) settle and close.
-fn boot_hub() -> (PassiveChassis<TestChassis>, u16) {
+fn boot_hub(engine_config: EngineConfig) -> (PassiveChassis<TestChassis>, u16) {
     let registry = Arc::new(Registry::new());
     for d in descriptors::all() {
         let _ = registry.register_kind_with_descriptor(d);
@@ -69,7 +70,7 @@ fn boot_hub() -> (PassiveChassis<TestChassis>, u16) {
     let mailer = Arc::new(Mailer::new(Arc::clone(&registry), store).with_outbound(outbound));
     let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
         .with_actor::<TraceDispatchCapability>(())
-        .with_actor::<EngineServer>(EngineConfig::default())
+        .with_actor::<EngineServer>(engine_config)
         .with_actor::<RpcServerCapability>(RpcServerConfig {
             bind_addr: "127.0.0.1:0".into(),
             peer_kind: PeerKind::Substrate {
@@ -157,8 +158,8 @@ mod tests {
         fn hub_routes_engine_addressed_calls_to_a_real_substrate() {
             let headless = env!("CARGO_BIN_EXE_aether-substrate-headless");
             // Bootstrap an isolated binary store so the hub resolves a
-            // `default` selector to the headless bin (ADR-0115, #1954). Set
-            // before boot_hub() — `EngineServer::init` reads the bootstrap env.
+            // `default` selector to the headless bin (ADR-0115, #1954) —
+            // threaded onto the engines-cap config below.
             let nanos = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .map_or(0, |d| d.as_nanos());
@@ -166,14 +167,16 @@ mod tests {
                 "aether-rpcroute-binstore-{}-{nanos}",
                 process::id()
             ));
-            // SAFETY: nextest runs each test in its own process, so this env
-            // set can't race a sibling.
-            unsafe {
-                env::set_var("AETHER_BINARY_STORE_DIR", &bin_store);
-                env::set_var("AETHER_BINARY_BOOTSTRAP", headless);
-            }
+            // The store dir / bootstrap list ride `EngineConfig` (ADR-0090)
+            // instead of the env side-channel; the heartbeat stays disabled
+            // (the `Default`).
+            let engine_config = EngineConfig {
+                binary_store_dir: Some(bin_store.to_string_lossy().into_owned()),
+                binary_bootstrap: HashSet::from([headless.to_owned()]),
+                ..EngineConfig::default()
+            };
 
-            let (_chassis, hub_port) = boot_hub();
+            let (_chassis, hub_port) = boot_hub(engine_config);
 
             let mut stream =
                 TcpStream::connect(format!("127.0.0.1:{hub_port}")).expect("connect to hub");

--- a/crates/aether-substrate-bundle/tests/rpc_engine_routing.rs
+++ b/crates/aether-substrate-bundle/tests/rpc_engine_routing.rs
@@ -30,7 +30,9 @@ use aether_capabilities::{EngineConfig, EngineServer};
 use aether_codec::frame::{read_frame, write_frame};
 use aether_data::{EngineId, Kind, Uuid, mailbox_id_from_name};
 use aether_kinds::descriptors;
-use aether_kinds::{List, ListResult, SpawnEngine, SpawnEngineResult, TerminateEngine};
+use aether_kinds::{
+    BinarySelector, List, ListResult, SpawnEngine, SpawnEngineResult, TerminateEngine,
+};
 use aether_substrate::chassis::Chassis;
 use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver, PassiveChassis};
 use aether_substrate::chassis::error::BootError;
@@ -40,7 +42,8 @@ use aether_substrate::mail::outbound::HubOutbound;
 use aether_substrate::mail::registry::Registry;
 use std::net::TcpStream;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::{env, fs, process};
 
 struct TestChassis;
 impl Chassis for TestChassis {
@@ -138,95 +141,126 @@ fn call_round_trip<K: Kind>(
 
 /// Contention-sensitive: boots a real `PassiveChassis` substrate + hub
 /// routing and round-trips an engine-addressed call across threads.
-/// Wrapped in `mod heavy` so nextest's `serial-heavy` test-group
-/// (`max-threads = 1`, `.config/nextest.toml`) serializes it against the
-/// rest of the heavy set under a saturated `--workspace` run (issue 1772).
-mod heavy {
+/// Wrapped in `mod tests::heavy` so its nextest path carries the
+/// `::heavy::` marker segment that the `serial-heavy` test-group filter
+/// (`test(/::heavy::/)`, `max-threads = 1`, `.config/nextest.toml`) keys
+/// on — a bare top-level `mod heavy` renders as `heavy::…`, which the
+/// leading-`::` filter misses, leaking the real-substrate fork into the
+/// saturated parallel run (issue 1772).
+mod tests {
     use super::*;
 
-    #[test]
-    fn hub_routes_engine_addressed_calls_to_a_real_substrate() {
-        let (_chassis, hub_port) = boot_hub();
-        let headless = env!("CARGO_BIN_EXE_aether-substrate-headless");
+    mod heavy {
+        use super::*;
 
-        let mut stream =
-            TcpStream::connect(format!("127.0.0.1:{hub_port}")).expect("connect to hub");
-        // Generous: a forwarded call's first step is forking a real
-        // substrate and waiting for it to bind its RPC port.
-        stream
-            .set_read_timeout(Some(Duration::from_secs(30)))
-            .expect("test setup: setting socket read timeout on a connected stream succeeds");
-
-        // Handshake.
-        write_frame(
-            &mut stream,
-            &WireFrame::Hello(Hello {
-                wire_version: WIRE_VERSION,
-                peer: PeerKind::Client {
-                    client_name: "rpc-engine-routing-test".into(),
-                    client_version: "0.0.1".into(),
-                },
-            }),
-        )
-        .expect("write Hello");
-        match read_frame(&mut stream).expect("read HelloAck") {
-            WireFrame::HelloAck(HelloAck { wire_version, .. }) => {
-                assert_eq!(wire_version, WIRE_VERSION);
+        #[test]
+        fn hub_routes_engine_addressed_calls_to_a_real_substrate() {
+            let headless = env!("CARGO_BIN_EXE_aether-substrate-headless");
+            // Bootstrap an isolated binary store so the hub resolves a
+            // `default` selector to the headless bin (ADR-0115, #1954). Set
+            // before boot_hub() — `EngineServer::init` reads the bootstrap env.
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_or(0, |d| d.as_nanos());
+            let bin_store = env::temp_dir().join(format!(
+                "aether-rpcroute-binstore-{}-{nanos}",
+                process::id()
+            ));
+            // SAFETY: nextest runs each test in its own process, so this env
+            // set can't race a sibling.
+            unsafe {
+                env::set_var("AETHER_BINARY_STORE_DIR", &bin_store);
+                env::set_var("AETHER_BINARY_BOOTSTRAP", headless);
             }
-            other => panic!("expected HelloAck, got {other:?}"),
+
+            let (_chassis, hub_port) = boot_hub();
+
+            let mut stream =
+                TcpStream::connect(format!("127.0.0.1:{hub_port}")).expect("connect to hub");
+            // Generous: a forwarded call's first step is forking a real
+            // substrate and waiting for it to bind its RPC port.
+            stream
+                .set_read_timeout(Some(Duration::from_secs(30)))
+                .expect("test setup: setting socket read timeout on a connected stream succeeds");
+
+            // Handshake.
+            write_frame(
+                &mut stream,
+                &WireFrame::Hello(Hello {
+                    wire_version: WIRE_VERSION,
+                    peer: PeerKind::Client {
+                        client_name: "rpc-engine-routing-test".into(),
+                        client_version: "0.0.1".into(),
+                    },
+                }),
+            )
+            .expect("write Hello");
+            match read_frame(&mut stream).expect("read HelloAck") {
+                WireFrame::HelloAck(HelloAck { wire_version, .. }) => {
+                    assert_eq!(wire_version, WIRE_VERSION);
+                }
+                other => panic!("expected HelloAck, got {other:?}"),
+            }
+
+            // 1. engine = None: spawn a real headless substrate via the
+            //    hub-local engines cap. Dispatches locally on the hub.
+            let (spawn_kind, spawn_payload) = call_round_trip(
+                &mut stream,
+                1,
+                None,
+                "aether.engine",
+                &SpawnEngine {
+                    selector: BinarySelector {
+                        query: None,
+                        chassis: None,
+                        caps: vec![],
+                        target: None,
+                    },
+                    args: vec![],
+                    boot_manifest: None,
+                },
+            );
+            assert_eq!(spawn_kind, <SpawnEngineResult as Kind>::ID);
+            let engine_id = match SpawnEngineResult::decode_from_bytes(&spawn_payload) {
+                Some(SpawnEngineResult::Ok { engine_id, .. }) => engine_id,
+                Some(SpawnEngineResult::Err { error }) => panic!("spawn failed: {error}"),
+                None => panic!("undecodable SpawnEngineResult"),
+            };
+            let engine_id = EngineId(Uuid::parse_str(&engine_id).expect("engine_id parses"));
+
+            // 2. engine = Some(_): a ROUTED call. The hub forwards it through
+            //    aether.engine -> proxy -> (RPC) -> the substrate's aether.fs
+            //    -> back. This is the P5a proof.
+            let (routed_kind, _routed_payload) = call_round_trip(
+                &mut stream,
+                2,
+                Some(engine_id),
+                "aether.fs",
+                &List {
+                    namespace: "save".to_owned(),
+                    prefix: String::new(),
+                },
+            );
+            assert_eq!(
+                routed_kind,
+                <ListResult as Kind>::ID,
+                "routed call should return the substrate's aether.fs ListResult",
+            );
+
+            // 3. engine = None: terminate the engine — proxy SIGKILLs + reaps
+            //    the child, so the test leaves no orphaned substrate.
+            let (term_kind, _term_payload) = call_round_trip(
+                &mut stream,
+                3,
+                None,
+                "aether.engine",
+                &TerminateEngine {
+                    engine_id: engine_id.0.to_string(),
+                },
+            );
+            assert_eq!(term_kind, <aether_kinds::TerminateEngineResult as Kind>::ID);
+
+            let _ = fs::remove_dir_all(&bin_store);
         }
-
-        // 1. engine = None: spawn a real headless substrate via the
-        //    hub-local engines cap. Dispatches locally on the hub.
-        let (spawn_kind, spawn_payload) = call_round_trip(
-            &mut stream,
-            1,
-            None,
-            "aether.engine",
-            &SpawnEngine {
-                binary_path: headless.to_owned(),
-                args: vec![],
-                boot_manifest: None,
-            },
-        );
-        assert_eq!(spawn_kind, <SpawnEngineResult as Kind>::ID);
-        let engine_id = match SpawnEngineResult::decode_from_bytes(&spawn_payload) {
-            Some(SpawnEngineResult::Ok { engine_id, .. }) => engine_id,
-            Some(SpawnEngineResult::Err { error }) => panic!("spawn failed: {error}"),
-            None => panic!("undecodable SpawnEngineResult"),
-        };
-        let engine_id = EngineId(Uuid::parse_str(&engine_id).expect("engine_id parses"));
-
-        // 2. engine = Some(_): a ROUTED call. The hub forwards it through
-        //    aether.engine -> proxy -> (RPC) -> the substrate's aether.fs
-        //    -> back. This is the P5a proof.
-        let (routed_kind, _routed_payload) = call_round_trip(
-            &mut stream,
-            2,
-            Some(engine_id),
-            "aether.fs",
-            &List {
-                namespace: "save".to_owned(),
-                prefix: String::new(),
-            },
-        );
-        assert_eq!(
-            routed_kind,
-            <ListResult as Kind>::ID,
-            "routed call should return the substrate's aether.fs ListResult",
-        );
-
-        // 3. engine = None: terminate the engine — proxy SIGKILLs + reaps
-        //    the child, so the test leaves no orphaned substrate.
-        let (term_kind, _term_payload) = call_round_trip(
-            &mut stream,
-            3,
-            None,
-            "aether.engine",
-            &TerminateEngine {
-                engine_id: engine_id.0.to_string(),
-            },
-        );
-        assert_eq!(term_kind, <aether_kinds::TerminateEngineResult as Kind>::ID);
     }
 }

--- a/scripts/ensure-tunnel.sh
+++ b/scripts/ensure-tunnel.sh
@@ -90,6 +90,25 @@ echo "[ensure-tunnel] pre-building tunnel + forked binaries (no-op when warm)...
         -p aether-substrate-bundle --bin aether-substrate-headless
 ) || true
 
+# Bootstrap the hub's content-addressed binary store (ADR-0115) with the
+# chassis bins just built, so a bare `spawn_substrate` (selector `default`)
+# resolves to the headless binary even in a fresh or `restart-hub`'d hub —
+# the spawn surface no longer takes a host path, so the host-path knowledge
+# lives here in the build flow. The forked hub's `EngineServer::init` reads
+# this OS-path-list and ingests each (idempotent via content dedup). Exported
+# so the detached tunnel — and the hub it forks — inherit it; only bins that
+# actually built are listed.
+BOOTSTRAP_BINS=()
+for bin in aether-substrate-headless aether-substrate; do
+    candidate="${PROJECT_DIR}/target/release/${bin}"
+    [[ -x "$candidate" ]] && BOOTSTRAP_BINS+=("$candidate")
+done
+if (( ${#BOOTSTRAP_BINS[@]} > 0 )); then
+    AETHER_BINARY_BOOTSTRAP="$(IFS=:; printf '%s' "${BOOTSTRAP_BINS[*]}")"
+    export AETHER_BINARY_BOOTSTRAP
+    echo "[ensure-tunnel] binary-store bootstrap: ${AETHER_BINARY_BOOTSTRAP}"
+fi
+
 # Pick a launch command: prefer a pre-built binary (fast, clean reap), else
 # fall back to `cargo run` (rebuild-friendly).
 RELEASE_BIN="${PROJECT_DIR}/target/release/aether-tunnel"

--- a/scripts/ensure-tunnel.sh
+++ b/scripts/ensure-tunnel.sh
@@ -94,17 +94,18 @@ echo "[ensure-tunnel] pre-building tunnel + forked binaries (no-op when warm)...
 # chassis bins just built, so a bare `spawn_substrate` (selector `default`)
 # resolves to the headless binary even in a fresh or `restart-hub`'d hub —
 # the spawn surface no longer takes a host path, so the host-path knowledge
-# lives here in the build flow. The forked hub's `EngineServer::init` reads
-# this OS-path-list and ingests each (idempotent via content dedup). Exported
-# so the detached tunnel — and the hub it forks — inherit it; only bins that
-# actually built are listed.
+# lives here in the build flow. The forked hub resolves this comma-separated
+# list through `EngineConfig`'s `binary_bootstrap` field (its
+# `AETHER_BINARY_BOOTSTRAP` env layer, ADR-0090) and ingests each (idempotent
+# via content dedup). Exported so the detached tunnel — and the hub it forks —
+# inherit it; only bins that actually built are listed.
 BOOTSTRAP_BINS=()
 for bin in aether-substrate-headless aether-substrate; do
     candidate="${PROJECT_DIR}/target/release/${bin}"
     [[ -x "$candidate" ]] && BOOTSTRAP_BINS+=("$candidate")
 done
 if (( ${#BOOTSTRAP_BINS[@]} > 0 )); then
-    AETHER_BINARY_BOOTSTRAP="$(IFS=:; printf '%s' "${BOOTSTRAP_BINS[*]}")"
+    AETHER_BINARY_BOOTSTRAP="$(IFS=,; printf '%s' "${BOOTSTRAP_BINS[*]}")"
     export AETHER_BINARY_BOOTSTRAP
     echo "[ensure-tunnel] binary-store bootstrap: ${AETHER_BINARY_BOOTSTRAP}"
 fi


### PR DESCRIPTION
Closes #1954.

## Summary

The spawn half of ADR-0115. `spawn_substrate` and the `SpawnEngine` kind no longer carry a host `binary_path` — they carry a **selector** resolved against the #1953 content-addressed store, and the host path leaves the surface entirely (no escape hatch).

- `aether-kinds` — `SpawnEngine.binary_path` → `selector: BinarySelector { query, chassis, caps, target }` (a `Schema` field type; `query` `None` = `default`).
- `aether-capabilities` — `resolve_selector` maps the wire selector onto #1953's store in the ADR order: exact `query` resolves `hash` > `name@version` (the entry whose self-reported `manifest.git_sha` matches, per ADR-0115) > `name`; a tokenless selector runs an attribute query, falling back to `default` = the headless chassis. `on_spawn` realizes the resolved bytes to a temp exec (`0o755`, unix) and forks that.
- `aether-mcp` — `SpawnSubstrateArgs` drops `binary_path` for `selector` + `chassis`/`caps`/`target`; the tool builds the `BinarySelector`. Component-spec boot-manifest fields stay path-based (that's #1956).
- `aether-substrate-bundle` — FleetBench `spawn_headless` uploads the headless bin then spawns by the returned hash.

**Store configuration rides `EngineConfig` (ADR-0090), not an env side-channel.** The `aether.engine` cap's store dir, disk budget, and bootstrap list are now `#[config]` fields on `EngineConfig` — the same derive-`Config` struct that already carries the heartbeat tuning — instead of a naked `ArtifactStore::from_env()` + `env::var(AETHER_BINARY_BOOTSTRAP)` read inside `init`:

- `binary_store_dir: Option<String>` (`env = AETHER_BINARY_STORE_DIR`; `None` → the computed `data_dir/aether/binaries/v1` default in `init`).
- `binary_disk_budget_bytes: u64` (`default = 16 GiB`, env `AETHER_HUB_BINARY_DISK_BUDGET_BYTES`).
- `binary_bootstrap: HashSet<String>` (`env = AETHER_BINARY_BOOTSTRAP`, `csv_set`).

The env keys keep working as the env *layer* of those fields (argv > env > default), so `restart-hub` and `ensure-tunnel.sh` resolve them exactly as before — the change is that they no longer bypass the config struct. `EngineConfig::Default` is hand-written so `binary_disk_budget_bytes` defaults to 16 GiB rather than the derive's `0` (a `0` budget would evict every unpinned upload). `ArtifactStore::from_env()` is gone, replaced by a no-env `default_root()`; `ensure-tunnel.sh` exports the bootstrap list comma-separated to match `csv_set`.

## Reviewer notes

- **`BinarySelector` derives `Schema`, not `Kind`** — it's a nested field type, not a standalone mail kind; the `Kind` derive requires `#[kind(name=…)]`. Matches the `BinaryManifest` / `EngineDescriptor` precedent.
- **A pre-existing heavy-test grouping bug is fixed (bundled).** `engines_cap.rs` / `rpc_engine_routing.rs` declared `mod heavy` at the integration-test top level, so their nextest path rendered as `heavy::…` — which the `serial-heavy` filter `test(/::heavy::/)` does not match (no leading `::`), leaking real-substrate forks into the saturated parallel step. The new heavier spawn path exposed the resulting flake under load; nesting them under `mod tests` makes the filter match so they serialize, per CLAUDE.md.

## Test plan

- `aether-kinds` selector roundtrip (exact-hash + `default`).
- `aether-capabilities` cap-level: unresolvable selector replies `Err`; bootstrap populate → `default` resolves to headless.
- FleetBench `spawn_headless` upload → spawn-by-hash → `list_engines`.
- `scripts/preflight.sh` green: fmt + clippy `--workspace --all-targets -D warnings` + doc + full workspace nextest (lightweight + heavy, 107/107) + wasm32 cross-build.

## Generated by

`/implement` — agent execution of [scoped issue #1954](https://github.com/iamacoffeepot/aether/issues/1954), with the store-config-via-`EngineConfig` rework applied on review.
