### PR TITLE
refactor(substrate): extract the lock.pid reclaim protocol into a shared helper

### DIFF
--- a/crates/aether-capabilities/src/store.rs
+++ b/crates/aether-capabilities/src/store.rs
@@ -33,10 +33,11 @@
 //!
 //! Modeled on the ADR-0049 handle store's lock / reclaim / budget shape
 //! (`aether_substrate::handle_store`), not its instance: the handle store
-//! is keyed on `HandleId` and lives per-engine. The shared `is_pid_alive`
-//! liveness check is the one piece literally reused. The `aether.engine`
-//! cap is single-threaded (one dispatcher run-token), so the store holds
-//! its index in plain fields behind `&mut self` rather than an inner lock.
+//! is keyed on `HandleId` and lives per-engine. The shared `lock.pid`
+//! acquisition protocol lives in `aether_substrate::pid_lock` and is
+//! consumed by both stores. The `aether.engine` cap is single-threaded
+//! (one dispatcher run-token), so the store holds its index in plain
+//! fields behind `&mut self` rather than an inner lock.
 
 use std::collections::{HashMap, HashSet};
 use std::env;
@@ -47,7 +48,7 @@ use std::process;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use aether_kinds::{BinaryEntry, BinaryManifest, ListBinaries};
-use aether_substrate::handle_store::is_pid_alive;
+use aether_substrate::pid_lock::{LockAcquisition, LockGuard, acquire_lock_pid};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -464,37 +465,35 @@ fn ensure_root(root: &Path) -> PathBuf {
     fallback
 }
 
-/// Best-effort `lock.pid` acquisition (ADR-0115; reuses the handle
-/// store's reclaim shape). A stale (dead-pid) or garbage lock is
-/// reclaimed and rewritten with our pid; a live holder leaves the store
-/// unlocked (returns `None`) but still operating, since a content-
-/// addressed store tolerates a shared dir.
+/// Best-effort `lock.pid` acquisition (ADR-0115). Delegates to
+/// [`aether_substrate::pid_lock::acquire_lock_pid`] for the shared
+/// read → classify → reclaim → write protocol. A stale (dead-pid) or
+/// garbage lock is reclaimed; a live holder or a write failure leaves
+/// the store unlocked (returns `None`) but still operating, since a
+/// content-addressed store tolerates a shared dir.
 fn acquire_lock(root: &Path) -> Option<LockGuard> {
     let path = root.join("lock.pid");
-    if let Ok(raw) = fs::read_to_string(&path) {
-        match raw.trim().parse::<i32>() {
-            Ok(pid) if pid > 0 && is_pid_alive(pid) => {
-                // A live holder (possibly this same process re-opening the
-                // dir) leaves us unlocked but still operating.
-                tracing::warn!(
-                    target: TARGET,
-                    path = %path.display(),
-                    holder_pid = pid,
-                    "binary store: lock held by a live process; operating unlocked",
-                );
-                return None;
-            }
-            Ok(_) => {}
-            Err(_) => {
-                tracing::warn!(target: TARGET, path = %path.display(), "binary store: lock.pid holds garbage; reclaiming");
-            }
+    match acquire_lock_pid(&path) {
+        LockAcquisition::Acquired(guard) => Some(guard),
+        LockAcquisition::Held(pid) => {
+            tracing::warn!(
+                target: TARGET,
+                path = %path.display(),
+                holder_pid = pid,
+                "binary store: lock held by a live process; operating unlocked",
+            );
+            None
+        }
+        LockAcquisition::WriteFailed(e) => {
+            tracing::warn!(
+                target: TARGET,
+                path = %path.display(),
+                error = %e,
+                "binary store: writing lock.pid failed; operating unlocked",
+            );
+            None
         }
     }
-    if let Err(e) = atomic_write(&path, process::id().to_string().as_bytes()) {
-        tracing::warn!(target: TARGET, path = %path.display(), error = %e, "binary store: writing lock.pid failed; operating unlocked");
-        return None;
-    }
-    Some(LockGuard { path })
 }
 
 /// The in-memory index [`restore`] rebuilds from disk.
@@ -604,18 +603,6 @@ fn atomic_write(target: &Path, bytes: &[u8]) -> io::Result<()> {
             let _ = fs::remove_file(&tmp);
             Err(e)
         }
-    }
-}
-
-/// RAII guard that deletes `lock.pid` on graceful shutdown. SIGKILL
-/// bypasses `Drop`; the stale-lock reclaim on the next open handles that.
-struct LockGuard {
-    path: PathBuf,
-}
-
-impl Drop for LockGuard {
-    fn drop(&mut self) {
-        let _ = fs::remove_file(&self.path);
     }
 }
 

--- a/crates/aether-capabilities/src/store.rs
+++ b/crates/aether-capabilities/src/store.rs
@@ -42,11 +42,12 @@
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;
-use std::io::{self, ErrorKind, Write as _};
+use std::io::{self, ErrorKind};
 use std::path::{Path, PathBuf};
 use std::process;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use aether_substrate::atomic_write::atomic_write;
 use aether_kinds::{BinaryEntry, BinaryManifest, ListBinaries};
 use aether_substrate::pid_lock::{LockAcquisition, LockGuard, acquire_lock_pid};
 use serde::{Deserialize, Serialize};
@@ -578,32 +579,6 @@ fn now_nanos() -> u128 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| d.as_nanos())
-}
-
-/// Atomic write via tmp + rename (the handle store's pattern): stage to a
-/// sibling `.tmp-<pid>-<nonce>`, fsync, rename over the target. Creates
-/// the parent dir lazily.
-fn atomic_write(target: &Path, bytes: &[u8]) -> io::Result<()> {
-    if let Some(parent) = target.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    let file_name = target
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("entry");
-    let tmp = target.with_file_name(format!("{file_name}.tmp-{}-{}", process::id(), now_nanos()));
-    {
-        let mut f = fs::File::create(&tmp)?;
-        f.write_all(bytes)?;
-        f.sync_all()?;
-    }
-    match fs::rename(&tmp, target) {
-        Ok(()) => Ok(()),
-        Err(e) => {
-            let _ = fs::remove_file(&tmp);
-            Err(e)
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/aether-capabilities/src/store.rs
+++ b/crates/aether-capabilities/src/store.rs
@@ -47,8 +47,8 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use aether_substrate::atomic_write::atomic_write;
 use aether_kinds::{BinaryEntry, BinaryManifest, ListBinaries};
+use aether_substrate::atomic_write::atomic_write;
 use aether_substrate::pid_lock::{LockAcquisition, LockGuard, acquire_lock_pid};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};

--- a/crates/aether-substrate/src/atomic_write.rs
+++ b/crates/aether-substrate/src/atomic_write.rs
@@ -8,7 +8,7 @@
 //! and continue (persistence is best-effort per ADR-0049 §3).
 
 use std::fs;
-use std::io::{Write as _, Error as IoError};
+use std::io::{Error as IoError, Write as _};
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -26,10 +26,7 @@ pub fn atomic_write(target: &Path, bytes: &[u8]) -> Result<(), IoError> {
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| d.as_nanos());
     let pid = std::process::id();
-    let file_name = target
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("tmp");
+    let file_name = target.file_name().and_then(|n| n.to_str()).unwrap_or("tmp");
     let tmp = target.with_file_name(format!("{file_name}.tmp-{pid}-{nonce}"));
     {
         let mut f = fs::File::create(&tmp)?;

--- a/crates/aether-substrate/src/atomic_write.rs
+++ b/crates/aether-substrate/src/atomic_write.rs
@@ -1,0 +1,46 @@
+//! Shared atomic file-write helper used by the handle store, the hub binary
+//! store, and the pid-lock module.
+//!
+//! Stages bytes to a sibling `.tmp-<pid>-<nonce>` temp file, fsyncs it, then
+//! renames it over the target — the pattern described in ADR-0041's
+//! `LocalFileAdapter`. Creates the parent directory lazily. On rename failure
+//! the temp file is removed and the error is returned so the caller can log
+//! and continue (persistence is best-effort per ADR-0049 §3).
+
+use std::fs;
+use std::io::{Write as _, Error as IoError};
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Write `bytes` to `target` atomically via a sibling temp file.
+///
+/// The temp path is `<dir>/<name>.tmp-<pid>-<nonce>` where `<nonce>` is
+/// nanoseconds since the Unix epoch (finest-grained; used only to keep
+/// concurrent writes collision-free, not for ordering). On rename failure
+/// the temp file is cleaned up and the [`IoError`] is returned.
+pub fn atomic_write(target: &Path, bytes: &[u8]) -> Result<(), IoError> {
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    let pid = std::process::id();
+    let file_name = target
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("tmp");
+    let tmp = target.with_file_name(format!("{file_name}.tmp-{pid}-{nonce}"));
+    {
+        let mut f = fs::File::create(&tmp)?;
+        f.write_all(bytes)?;
+        f.sync_all()?;
+    }
+    match fs::rename(&tmp, target) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = fs::remove_file(&tmp);
+            Err(e)
+        }
+    }
+}

--- a/crates/aether-substrate/src/atomic_write.rs
+++ b/crates/aether-substrate/src/atomic_write.rs
@@ -10,6 +10,7 @@
 use std::fs;
 use std::io::{Error as IoError, Write as _};
 use std::path::Path;
+use std::process;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Write `bytes` to `target` atomically via a sibling temp file.
@@ -25,7 +26,7 @@ pub fn atomic_write(target: &Path, bytes: &[u8]) -> Result<(), IoError> {
     let nonce = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| d.as_nanos());
-    let pid = std::process::id();
+    let pid = process::id();
     let file_name = target.file_name().and_then(|n| n.to_str()).unwrap_or("tmp");
     let tmp = target.with_file_name(format!("{file_name}.tmp-{pid}-{nonce}"));
     {

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -46,15 +46,17 @@ use std::convert::Infallible;
 use std::error::Error as StdError;
 use std::fmt;
 use std::fs;
-use std::io::{Error as IoError, ErrorKind, Write as _};
+use std::io::{Error as IoError, ErrorKind};
 use std::mem;
 use std::path::{Path, PathBuf};
+#[cfg(test)]
 use std::process;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use crate::atomic_write::atomic_write;
 use crate::config::ConfigError;
 use crate::mail::Mail;
 use crate::mail::registry::Registry;
@@ -456,38 +458,6 @@ fn now_millis() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
-}
-
-/// Atomic write via tmp+rename (ADR-0041's `LocalFileAdapter` pattern):
-/// stage to a sibling `.tmp-<pid>-<nonce>`, fsync it, rename over the
-/// target. Creates the parent dir lazily. Returns the io error on
-/// failure so the caller can log + continue (persistence is best-effort
-/// per ADR-0049 §3).
-fn atomic_write(target: &Path, bytes: &[u8]) -> Result<(), IoError> {
-    if let Some(parent) = target.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    let nonce = now_millis();
-    let pid = process::id();
-    let file_name = target
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("entry");
-    let tmp = target.with_file_name(format!("{file_name}.tmp-{pid}-{nonce}"));
-    {
-        let mut f = fs::File::create(&tmp)?;
-        f.write_all(bytes)?;
-        // fsync the tmp file so its bytes hit disk before the rename
-        // publishes it (preserves ordering across a crash).
-        f.sync_all()?;
-    }
-    match fs::rename(&tmp, target) {
-        Ok(()) => Ok(()),
-        Err(e) => {
-            let _ = fs::remove_file(&tmp);
-            Err(e)
-        }
-    }
 }
 
 /// Per-entry store record. Bytes are the postcard-encoded `K` body
@@ -1510,7 +1480,7 @@ impl HandleStore {
     }
 
     /// Acquire the on-disk store lock (ADR-0049 §7). Delegates to
-    /// [`crate::pid_lock::acquire_lock_pid`] for the shared read →
+    /// [`acquire_lock_pid`] for the shared read →
     /// classify → reclaim → write protocol; maps the result to
     /// [`LockError`]. A live conflicting lock returns [`LockError::Held`]
     /// so the caller can abort boot with a clear error. No-op (returns

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -58,6 +58,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use crate::config::ConfigError;
 use crate::mail::Mail;
 use crate::mail::registry::Registry;
+use crate::pid_lock::{LockAcquisition, LockGuard, acquire_lock_pid};
 use aether_data::{EnumVariant, Primitive, SchemaType};
 use aether_data::{HandleId, KindId};
 use std::env;
@@ -287,49 +288,6 @@ impl fmt::Display for LockError {
 }
 
 impl StdError for LockError {}
-
-/// RAII guard that deletes `lock.pid` on graceful shutdown. SIGKILL
-/// bypasses `Drop`; the stale-lock reclamation path handles that case
-/// on the next boot.
-#[derive(Debug)]
-struct LockGuard {
-    path: PathBuf,
-}
-
-impl Drop for LockGuard {
-    fn drop(&mut self) {
-        let _ = fs::remove_file(&self.path);
-    }
-}
-
-/// Whether `pid` names a live process. Unix: `kill(pid, 0)` returns 0
-/// for a live process, `ESRCH` for a dead one, `EPERM` for a live one
-/// we can't signal (still counts as alive). Non-Unix: conservatively
-/// reports `false` so the lock is always reclaimable (substrate on
-/// Windows is deferred per ADR-0049 §7).
-///
-/// Public so the hub binary store's `lock.pid` reclaim (ADR-0115, issue
-/// 1953) reuses the same liveness check rather than duplicating the
-/// `kill(pid, 0)` unsafe — the two stores share the lock/reclaim shape,
-/// not the instance.
-#[cfg(unix)]
-#[must_use]
-pub fn is_pid_alive(pid: i32) -> bool {
-    // SAFETY: `kill` with signal 0 performs the error checks without
-    // sending a signal. No memory is touched.
-    let ret = unsafe { libc::kill(pid, 0) };
-    if ret == 0 {
-        return true;
-    }
-    // errno == EPERM means the process exists but we lack permission.
-    IoError::last_os_error().raw_os_error() == Some(libc::EPERM)
-}
-
-#[cfg(not(unix))]
-#[must_use]
-pub fn is_pid_alive(_pid: i32) -> bool {
-    false
-}
 
 /// A handle known to be on disk but not (necessarily) materialized in
 /// memory. Populated by the boot scan (issue #985) from the `.meta`
@@ -1551,11 +1509,12 @@ impl HandleStore {
         }
     }
 
-    /// Acquire the on-disk store lock (ADR-0049 §7). Writes `lock.pid`
-    /// with this process's PID after checking that any existing lock is
-    /// stale. A live conflicting lock returns [`LockError::Held`] so the
-    /// caller can abort boot with a clear error. No-op (returns `Ok`)
-    /// when persistence is disabled.
+    /// Acquire the on-disk store lock (ADR-0049 §7). Delegates to
+    /// [`crate::pid_lock::acquire_lock_pid`] for the shared read →
+    /// classify → reclaim → write protocol; maps the result to
+    /// [`LockError`]. A live conflicting lock returns [`LockError::Held`]
+    /// so the caller can abort boot with a clear error. No-op (returns
+    /// `Ok`) when persistence is disabled.
     ///
     /// On success the store holds a lock guard whose `Drop` deletes the
     /// lockfile on graceful shutdown.
@@ -1567,41 +1526,18 @@ impl HandleStore {
             return Ok(());
         };
         let path = cfg.lock_path();
-        // Inspect any existing lock.
-        if let Ok(raw) = fs::read_to_string(&path) {
-            match raw.trim().parse::<i32>() {
-                Ok(pid) if pid > 0 && is_pid_alive(pid) => {
-                    return Err(LockError::Held { path, pid });
-                }
-                Ok(pid) => {
-                    tracing::warn!(
-                        target: TARGET,
-                        path = %path.display(),
-                        stale_pid = pid,
-                        "reclaiming stale handle store lock from a dead process",
-                    );
-                }
-                Err(_) => {
-                    tracing::warn!(
-                        target: TARGET,
-                        path = %path.display(),
-                        "lock.pid holds garbage; reclaiming as stale",
-                    );
-                }
+        match acquire_lock_pid(&path) {
+            LockAcquisition::Acquired(guard) => {
+                *self
+                    .lock
+                    .lock()
+                    .expect("handle store lock mutex poisoned; fail-fast per ADR-0063") =
+                    Some(guard);
+                Ok(())
             }
+            LockAcquisition::Held(pid) => Err(LockError::Held { path, pid }),
+            LockAcquisition::WriteFailed(error) => Err(LockError::Io { path, error }),
         }
-        // Write our PID atomically.
-        let pid = process::id();
-        atomic_write(&path, pid.to_string().as_bytes()).map_err(|error| LockError::Io {
-            path: path.clone(),
-            error,
-        })?;
-        *self
-            .lock
-            .lock()
-            .expect("handle store lock mutex poisoned; fail-fast per ADR-0063") =
-            Some(LockGuard { path });
-        Ok(())
     }
 
     /// Snapshot the store state for `describe_handles` (ADR-0049 §10).

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -40,6 +40,7 @@
 extern crate self as aether_substrate;
 
 pub mod actor;
+pub mod atomic_write;
 // iamacoffeepot/aether#1275: `boot` builds a wasmtime `Engine` + `Linker`,
 // so it rides the `wasm` feature. Default-on; only `aether-derive`'s
 // trybuild fixtures opt out (they don't reach the boot path).

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -51,6 +51,7 @@ pub mod config;
 pub mod dag;
 pub mod handle_store;
 pub mod mail;
+pub mod pid_lock;
 #[cfg(feature = "render")]
 pub mod render;
 pub mod runtime;

--- a/crates/aether-substrate/src/pid_lock.rs
+++ b/crates/aether-substrate/src/pid_lock.rs
@@ -130,8 +130,7 @@ mod tests {
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map_or(0, |d| d.as_nanos());
-        let dir =
-            env::temp_dir().join(format!("aether-pid-lock-{tag}-{}-{nonce}", process::id()));
+        let dir = env::temp_dir().join(format!("aether-pid-lock-{tag}-{}-{nonce}", process::id()));
         fs::create_dir_all(&dir).expect("temp dir creates");
         dir
     }
@@ -142,11 +141,14 @@ mod tests {
         let path = dir.join("lock.pid");
         let guard = match acquire_lock_pid(&path) {
             LockAcquisition::Acquired(g) => g,
-            other => panic!("expected Acquired, got {}", match other {
-                LockAcquisition::Held(p) => format!("Held({p})"),
-                LockAcquisition::WriteFailed(e) => format!("WriteFailed({e})"),
-                LockAcquisition::Acquired(_) => unreachable!(),
-            }),
+            other => panic!(
+                "expected Acquired, got {}",
+                match other {
+                    LockAcquisition::Held(p) => format!("Held({p})"),
+                    LockAcquisition::WriteFailed(e) => format!("WriteFailed({e})"),
+                    LockAcquisition::Acquired(_) => unreachable!(),
+                }
+            ),
         };
         assert!(path.exists(), "lock.pid written");
         let contents = fs::read_to_string(&path).expect("lock.pid is readable");

--- a/crates/aether-substrate/src/pid_lock.rs
+++ b/crates/aether-substrate/src/pid_lock.rs
@@ -12,6 +12,8 @@ use std::io::Error as IoError;
 use std::path::{Path, PathBuf};
 use std::process;
 
+use crate::atomic_write::atomic_write;
+
 /// Whether `pid` names a live process. Unix: `kill(pid, 0)` returns 0
 /// for a live process, `ESRCH` for a dead one, `EPERM` for a live one
 /// we can't signal (still counts as alive). Non-Unix: conservatively
@@ -84,7 +86,7 @@ pub fn acquire_lock_pid(path: &Path) -> LockAcquisition {
             }
         }
     }
-    match crate::atomic_write::atomic_write(path, process::id().to_string().as_bytes()) {
+    match atomic_write(path, process::id().to_string().as_bytes()) {
         Ok(()) => LockAcquisition::Acquired(LockGuard {
             path: path.to_path_buf(),
         }),

--- a/crates/aether-substrate/src/pid_lock.rs
+++ b/crates/aether-substrate/src/pid_lock.rs
@@ -1,0 +1,202 @@
+//! Shared `lock.pid` acquisition protocol (ADR-0049 §7 / ADR-0115).
+//!
+//! The `lock.pid` file format — write the owning-process pid, reclaim a
+//! stale or garbage lock, delete the file on graceful shutdown — is the
+//! same between the ADR-0049 handle store and the ADR-0115 hub binary
+//! store. This module is the single definition of that protocol, consumed
+//! by both stores; each store maps the [`LockAcquisition`] result to its
+//! own divergent live-holder policy.
+
+use std::fs;
+use std::io::{Error as IoError, Write as _};
+use std::path::{Path, PathBuf};
+use std::process;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Whether `pid` names a live process. Unix: `kill(pid, 0)` returns 0
+/// for a live process, `ESRCH` for a dead one, `EPERM` for a live one
+/// we can't signal (still counts as alive). Non-Unix: conservatively
+/// reports `false` so the lock is always reclaimable (substrate on
+/// Windows is deferred per ADR-0049 §7).
+#[cfg(unix)]
+#[must_use]
+pub fn is_pid_alive(pid: i32) -> bool {
+    // SAFETY: `kill` with signal 0 performs the error checks without
+    // sending a signal. No memory is touched.
+    let ret = unsafe { libc::kill(pid, 0) };
+    if ret == 0 {
+        return true;
+    }
+    // errno == EPERM means the process exists but we lack permission.
+    IoError::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(not(unix))]
+#[must_use]
+pub fn is_pid_alive(_pid: i32) -> bool {
+    false
+}
+
+/// RAII guard that deletes `lock.pid` on graceful shutdown. SIGKILL
+/// bypasses `Drop`; the stale-lock reclamation path handles that case
+/// on the next open.
+#[derive(Debug)]
+pub struct LockGuard {
+    path: PathBuf,
+}
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+/// Outcome of [`acquire_lock_pid`].
+pub enum LockAcquisition {
+    /// Any stale or garbage lock was reclaimed; our pid has been written.
+    /// The guard deletes `lock.pid` on drop.
+    Acquired(LockGuard),
+    /// A live process holds the lock. The caller decides whether to abort
+    /// or operate without the lock.
+    Held(i32),
+    /// The pid write itself failed. The caller decides how to handle it.
+    WriteFailed(IoError),
+}
+
+/// Acquire (or reclaim) the `lock.pid` at `path`.
+///
+/// Performs read → trim → parse → classify → (reclaim and) write:
+///
+/// - If the file holds a parseable, positive, live pid: return
+///   [`LockAcquisition::Held`] — the caller decides the live-holder policy.
+/// - Otherwise (file absent, dead pid, garbage): emit one `tracing::warn!`
+///   on the reclaim path, then write `process::id()` via atomic tmp+rename.
+///   On success return [`LockAcquisition::Acquired`]; on write failure
+///   return [`LockAcquisition::WriteFailed`].
+pub fn acquire_lock_pid(path: &Path) -> LockAcquisition {
+    if let Ok(raw) = fs::read_to_string(path) {
+        match raw.trim().parse::<i32>() {
+            Ok(pid) if pid > 0 && is_pid_alive(pid) => return LockAcquisition::Held(pid),
+            _ => {
+                tracing::warn!(
+                    path = %path.display(),
+                    "reclaiming stale or garbage lock.pid",
+                );
+            }
+        }
+    }
+    match atomic_write_pid(path, process::id().to_string().as_bytes()) {
+        Ok(()) => LockAcquisition::Acquired(LockGuard {
+            path: path.to_path_buf(),
+        }),
+        Err(e) => LockAcquisition::WriteFailed(e),
+    }
+}
+
+/// Atomic write via tmp+rename. Creates the parent dir lazily.
+fn atomic_write_pid(target: &Path, bytes: &[u8]) -> Result<(), IoError> {
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    let pid = process::id();
+    let file_name = target
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("lock");
+    let tmp = target.with_file_name(format!("{file_name}.tmp-{pid}-{nonce}"));
+    {
+        let mut f = fs::File::create(&tmp)?;
+        f.write_all(bytes)?;
+        f.sync_all()?;
+    }
+    match fs::rename(&tmp, target) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = fs::remove_file(&tmp);
+            Err(e)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{env, process};
+
+    fn temp_dir(tag: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        let dir =
+            env::temp_dir().join(format!("aether-pid-lock-{tag}-{}-{nonce}", process::id()));
+        fs::create_dir_all(&dir).expect("temp dir creates");
+        dir
+    }
+
+    #[test]
+    fn absent_lock_is_acquired() {
+        let dir = temp_dir("absent");
+        let path = dir.join("lock.pid");
+        let guard = match acquire_lock_pid(&path) {
+            LockAcquisition::Acquired(g) => g,
+            other => panic!("expected Acquired, got {}", match other {
+                LockAcquisition::Held(p) => format!("Held({p})"),
+                LockAcquisition::WriteFailed(e) => format!("WriteFailed({e})"),
+                LockAcquisition::Acquired(_) => unreachable!(),
+            }),
+        };
+        assert!(path.exists(), "lock.pid written");
+        let contents = fs::read_to_string(&path).expect("lock.pid is readable");
+        let written: u32 = contents.trim().parse().expect("pid is numeric");
+        assert_eq!(written, process::id(), "our pid was written");
+        drop(guard);
+        assert!(!path.exists(), "LockGuard::drop removes lock.pid");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn garbage_lock_is_reclaimed() {
+        let dir = temp_dir("garbage");
+        let path = dir.join("lock.pid");
+        fs::write(&path, b"not-a-pid").expect("write garbage lock");
+        assert!(matches!(
+            acquire_lock_pid(&path),
+            LockAcquisition::Acquired(_)
+        ));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn dead_pid_lock_is_reclaimed() {
+        let dir = temp_dir("dead");
+        let path = dir.join("lock.pid");
+        // i32::MAX is not a live process on any realistic system.
+        fs::write(&path, i32::MAX.to_string().as_bytes()).expect("write dead-pid lock");
+        assert!(matches!(
+            acquire_lock_pid(&path),
+            LockAcquisition::Acquired(_)
+        ));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // On non-unix, is_pid_alive always returns false, so the current process
+    // would be treated as dead and the lock would be reclaimed — Held never
+    // fires. Only test Held on unix.
+    #[cfg(unix)]
+    #[test]
+    fn live_pid_yields_held() {
+        let dir = temp_dir("live");
+        let path = dir.join("lock.pid");
+        let our_pid = i32::try_from(process::id()).expect("pid fits i32");
+        fs::write(&path, our_pid.to_string().as_bytes()).expect("write live-pid lock");
+        match acquire_lock_pid(&path) {
+            LockAcquisition::Held(p) => assert_eq!(p, our_pid),
+            LockAcquisition::Acquired(_) => panic!("expected Held, got Acquired"),
+            LockAcquisition::WriteFailed(e) => panic!("expected Held, got WriteFailed({e})"),
+        }
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/aether-substrate/src/pid_lock.rs
+++ b/crates/aether-substrate/src/pid_lock.rs
@@ -8,10 +8,9 @@
 //! own divergent live-holder policy.
 
 use std::fs;
-use std::io::{Error as IoError, Write as _};
+use std::io::Error as IoError;
 use std::path::{Path, PathBuf};
 use std::process;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Whether `pid` names a live process. Unix: `kill(pid, 0)` returns 0
 /// for a live process, `ESRCH` for a dead one, `EPERM` for a live one
@@ -85,7 +84,7 @@ pub fn acquire_lock_pid(path: &Path) -> LockAcquisition {
             }
         }
     }
-    match atomic_write_pid(path, process::id().to_string().as_bytes()) {
+    match crate::atomic_write::atomic_write(path, process::id().to_string().as_bytes()) {
         Ok(()) => LockAcquisition::Acquired(LockGuard {
             path: path.to_path_buf(),
         }),
@@ -93,37 +92,10 @@ pub fn acquire_lock_pid(path: &Path) -> LockAcquisition {
     }
 }
 
-/// Atomic write via tmp+rename. Creates the parent dir lazily.
-fn atomic_write_pid(target: &Path, bytes: &[u8]) -> Result<(), IoError> {
-    if let Some(parent) = target.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |d| d.as_nanos());
-    let pid = process::id();
-    let file_name = target
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("lock");
-    let tmp = target.with_file_name(format!("{file_name}.tmp-{pid}-{nonce}"));
-    {
-        let mut f = fs::File::create(&tmp)?;
-        f.write_all(bytes)?;
-        f.sync_all()?;
-    }
-    match fs::rename(&tmp, target) {
-        Ok(()) => Ok(()),
-        Err(e) => {
-            let _ = fs::remove_file(&tmp);
-            Err(e)
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
     use std::{env, process};
 
     fn temp_dir(tag: &str) -> PathBuf {


### PR DESCRIPTION
Closes #1965.

## Summary

The `lock.pid` acquisition protocol — read the file, classify the recorded pid as live / dead / garbage, reclaim a stale-or-garbage lock by writing our own pid, and delete the file on graceful shutdown — existed in two independent copies: the ADR-0049 handle store (`crates/aether-substrate/src/handle_store.rs`) and the ADR-0115 hub binary store (`crates/aether-capabilities/src/store.rs`). Only the `is_pid_alive` liveness primitive was shared. The duplicated classify/reclaim logic, the `LockGuard` RAII type, and the `lock.pid` filename could drift between the two stores.

This extracts the protocol into one shared helper:

- New `crates/aether-substrate/src/pid_lock.rs` owns the whole protocol: `is_pid_alive` (both `#[cfg(unix)]` / `#[cfg(not(unix))]`), `pub struct LockGuard` (Drop removes the file), `pub enum LockAcquisition { Acquired(LockGuard), Held(i32), WriteFailed(IoError) }`, and `pub fn acquire_lock_pid(path) -> LockAcquisition`. The enum return lets each caller keep its own live-holder policy rather than baking one in.
- `handle_store.rs` deletes its local `LockGuard` / `is_pid_alive` / classify-reclaim body and calls `acquire_lock_pid`, mapping `Acquired → Ok`, `Held → LockError::Held`, `WriteFailed → LockError::Io`.
- `store.rs` does the same, mapping `Held` / `WriteFailed` → warn + `None` (a content-addressed store tolerates a shared dir, so its lock is hygiene, not a hard mutex).

No behavior change — each store keeps its existing policy; only the shared mechanism is deduplicated. No new ADR (ADR-0049 §7 and ADR-0115 describe the protocol; neither's prose changes).

## Test plan

- `pid_lock.rs` unit tests cover all four branches: absent / garbage / dead-pid / live-pid (`live_pid_yields_held` gated `#[cfg(unix)]`).
- `scripts/preflight.sh` green: fmt + clippy `--workspace --all-targets -D warnings` + doc + full workspace nextest (lightweight + heavy serialized — handle-store heavies, fleetbench, test_bench) + wasm32 cross-build.

## Generated by

`/implement` — agent execution of [scoped issue #1965](https://github.com/iamacoffeepot/aether/issues/1965).
