### PR TITLE
refactor(actor): replace the FFI bridge singletons with pub(crate) functions

### DIFF
--- a/crates/aether-actor/src/actor/ctx/mail_sender.rs
+++ b/crates/aether-actor/src/actor/ctx/mail_sender.rs
@@ -7,7 +7,7 @@
 //! its own bodies — there are no default-impl bodies because the
 //! cross-target dispatch trait that backed them (`MailTransport`)
 //! retired in 665. Each side calls its dispatch surface inline:
-//! FFI bodies hit [`crate::ffi::bridge::MAIL_BRIDGE`], native bodies hit
+//! FFI bodies call `crate::ffi::bridge::mail::send_mail`, native bodies hit
 //! `NativeBinding`'s inherent `send_mail`.
 //!
 //! `actor::<R>()` / `resolve_actor::<R>(name)` retired from this trait

--- a/crates/aether-actor/src/actor/ctx/outbound_reply.rs
+++ b/crates/aether-actor/src/actor/ctx/outbound_reply.rs
@@ -61,6 +61,6 @@ pub trait OutboundReply: MailSender {
     ///
     /// Same wire-shape contract as [`Self::reply`]. Native impls route
     /// through `NativeBinding::send_reply_for_handler`; FFI impls route
-    /// through [`crate::ffi::bridge::MailBridge::reply_mail`].
+    /// through `crate::ffi::bridge::mail::reply_mail`.
     fn reply_to<K: Kind>(&mut self, sender: Self::ReplyHandle, payload: &K);
 }

--- a/crates/aether-actor/src/ffi/bridge/mail.rs
+++ b/crates/aether-actor/src/ffi/bridge/mail.rs
@@ -3,227 +3,219 @@
 // `_p32`-suffixed FFI per ADR-0024 documents the convention.
 #![allow(clippy::cast_possible_truncation)]
 
-//! [`MailBridge`] — outbound-mail FFI bridge.
+//! Outbound-mail FFI bridge — `pub(crate)` free functions.
 //!
-//! ZST whose inherent methods forward to the matching `extern "C"`
-//! host fns in [`raw`]. `send_mail` pushes a typed payload
-//! at a recipient mailbox; `reply_mail` routes to the originator of
-//! the mail currently being dispatched; `prev_correlation` reads the
-//! correlation id the host minted for the most-recent `send_mail`.
+//! Each function forwards to the matching `extern "C"` host fn in [`raw`]
+//! and localizes `unsafe` to one audited site per FFI op. `send_mail`
+//! pushes a typed payload at a recipient mailbox; `reply_mail` routes to
+//! the originator of the mail currently being dispatched; `prev_correlation`
+//! reads the correlation id the host minted for the most-recent `send_mail`.
 //!
 //! Correlation is universal — every send mints a correlation id so a
 //! handler can match the reply to the request it sent. It's a property
-//! of the outbound mail, so it lives on the mail bridge.
+//! of the outbound mail, so it lives in this module.
 
 use crate::ffi::raw;
 
-/// ZST FFI bridge for outbound mail. Callers borrow [`MAIL_BRIDGE`] rather
-/// than constructing instances — the type carries no per-instance
-/// state because the FFI imports are global to the loaded module.
-pub struct MailBridge;
-
-/// Process-wide [`MailBridge`] instance. Borrow `&MAIL_BRIDGE` from any ctx impl
-/// that needs to send / reply / read the correlation id.
-pub static MAIL_BRIDGE: MailBridge = MailBridge;
-
-impl MailBridge {
-    /// Push a typed payload at `recipient`. `bytes` is the wire
-    /// encoding of the payload (cast for `#[repr(C)]` kinds, postcard
-    /// for schema-shaped kinds — `Kind::encode_into_bytes` already
-    /// resolves which). `count` is `1` for a single send and N for a
-    /// batch (cast-only — postcard has no efficient batched wire
-    /// shape, see `MailBridgebox::send_many`).
-    ///
-    /// `detached` carries the ADR-0080 §7 lineage signal. `false` (the
-    /// default `send` path) lets the host stamp the in-flight
-    /// dispatch's `parent`/`root` onto this send, so the recipient's
-    /// work stays in the caller's causal chain. `true` (`send_detached`)
-    /// suppresses inheritance — the host mints a fresh root chain. The
-    /// guest holds no trace ids, so the flag is all it can contribute;
-    /// the host owns the stamping.
-    ///
-    /// Returns `0` on success; `1` on substrate-side recipient
-    /// lookup miss. Other non-zero values are reserved for future
-    /// host-side failure surfaces.
-    ///
-    /// Not `#[must_use]`: the public ctx surfaces (`MailSender::send`,
-    /// `MailSender::send_to_named`, `OutboundReply::reply`, etc.) are
-    /// trait-defined as fire-and-forget and have no return channel for
-    /// a lookup-miss status. The substrate warn-drops unknown
-    /// recipients on its side, which is the diagnostic path; the guest
-    /// can't surface the status anywhere meaningful.
-    #[allow(
-        clippy::must_use_candidate,
-        reason = "fire-and-forget by contract — see doc-comment above; #[must_use] retired in issue 892"
-    )]
-    pub fn send_mail(
-        &self,
-        recipient: u64,
-        kind: u64,
-        bytes: &[u8],
-        count: u32,
-        detached: bool,
-    ) -> u32 {
-        // SAFETY: forwards to `raw::send_mail`, whose ABI is documented
-        // at the import site in `ffi/raw.rs`. The `(ptr, len)` pair is
-        // derived from the `&[u8]` slice we just received, which the
-        // borrow checker proves is valid for `bytes.len()` bytes for
-        // the duration of the call; the host copies before returning.
-        unsafe {
-            raw::send_mail(
-                recipient,
-                kind,
-                bytes.as_ptr().addr() as u32,
-                bytes.len() as u32,
-                count,
-                u32::from(detached),
-            )
-        }
+/// Push a typed payload at `recipient`. `bytes` is the wire
+/// encoding of the payload (cast for `#[repr(C)]` kinds, postcard
+/// for schema-shaped kinds — `Kind::encode_into_bytes` already
+/// resolves which). `count` is `1` for a single send and N for a
+/// batch (cast-only — postcard has no efficient batched wire
+/// shape, see `FfiActorMailbox::send_many`).
+///
+/// `detached` carries the ADR-0080 §7 lineage signal. `false` (the
+/// default `send` path) lets the host stamp the in-flight
+/// dispatch's `parent`/`root` onto this send, so the recipient's
+/// work stays in the caller's causal chain. `true` (`send_detached`)
+/// suppresses inheritance — the host mints a fresh root chain. The
+/// guest holds no trace ids, so the flag is all it can contribute;
+/// the host owns the stamping.
+///
+/// Returns `0` on success; `1` on substrate-side recipient
+/// lookup miss. Other non-zero values are reserved for future
+/// host-side failure surfaces.
+///
+/// Not `#[must_use]`: the public ctx surfaces (`MailSender::send`,
+/// `MailSender::send_to_named`, `OutboundReply::reply`, etc.) are
+/// trait-defined as fire-and-forget and have no return channel for
+/// a lookup-miss status. The substrate warn-drops unknown
+/// recipients on its side, which is the diagnostic path; the guest
+/// can't surface the status anywhere meaningful.
+#[allow(
+    clippy::must_use_candidate,
+    reason = "fire-and-forget by contract — see doc-comment above; #[must_use] retired in issue 892"
+)]
+pub(crate) fn send_mail(
+    recipient: u64,
+    kind: u64,
+    bytes: &[u8],
+    count: u32,
+    detached: bool,
+) -> u32 {
+    // SAFETY: forwards to `raw::send_mail`, whose ABI is documented
+    // at the import site in `ffi/raw.rs`. The `(ptr, len)` pair is
+    // derived from the `&[u8]` slice we just received, which the
+    // borrow checker proves is valid for `bytes.len()` bytes for
+    // the duration of the call; the host copies before returning.
+    unsafe {
+        raw::send_mail(
+            recipient,
+            kind,
+            bytes.as_ptr().addr() as u32,
+            bytes.len() as u32,
+            count,
+            u32::from(detached),
+        )
     }
+}
 
-    /// Reply to the originator of the mail currently being dispatched
-    /// (ADR-0013). `sender` is the per-instance handle the dispatcher
-    /// threaded onto the ctx at receive time; the substrate routes it
-    /// to the right Claude session, sibling component, or remote
-    /// engine mailbox.
-    ///
-    /// Not `#[must_use]`: the trait surface (`OutboundReply::reply`)
-    /// is fire-and-forget by contract — see the
-    /// matching rationale on `send_mail`.
-    #[allow(
-        clippy::must_use_candidate,
-        reason = "fire-and-forget by contract — see doc-comment above; #[must_use] retired in issue 892"
-    )]
-    pub fn reply_mail(&self, sender: u32, kind: u64, bytes: &[u8], count: u32) -> u32 {
-        // SAFETY: forwards to `raw::reply_mail`, whose ABI is documented
-        // at the import site in `ffi/raw.rs`. The `(ptr, len)` pair is
-        // derived from the `&[u8]` slice we just received, which the
-        // borrow checker proves is valid for `bytes.len()` bytes for
-        // the duration of the call; the host copies before returning.
-        unsafe {
-            raw::reply_mail(
-                sender,
-                kind,
-                bytes.as_ptr().addr() as u32,
-                bytes.len() as u32,
-                count,
-            )
-        }
+/// Reply to the originator of the mail currently being dispatched
+/// (ADR-0013). `sender` is the per-instance handle the dispatcher
+/// threaded onto the ctx at receive time; the substrate routes it
+/// to the right Claude session, sibling component, or remote
+/// engine mailbox.
+///
+/// Not `#[must_use]`: the trait surface (`OutboundReply::reply`)
+/// is fire-and-forget by contract — see the
+/// matching rationale on `send_mail`.
+#[allow(
+    clippy::must_use_candidate,
+    reason = "fire-and-forget by contract — see doc-comment above; #[must_use] retired in issue 892"
+)]
+pub(crate) fn reply_mail(sender: u32, kind: u64, bytes: &[u8], count: u32) -> u32 {
+    // SAFETY: forwards to `raw::reply_mail`, whose ABI is documented
+    // at the import site in `ffi/raw.rs`. The `(ptr, len)` pair is
+    // derived from the `&[u8]` slice we just received, which the
+    // borrow checker proves is valid for `bytes.len()` bytes for
+    // the duration of the call; the host copies before returning.
+    unsafe {
+        raw::reply_mail(
+            sender,
+            kind,
+            bytes.as_ptr().addr() as u32,
+            bytes.len() as u32,
+            count,
+        )
     }
+}
 
-    /// Correlation id the host minted for this actor's most recent
-    /// `send_mail` call (ADR-0042). `0` before any send. Universal —
-    /// every send mints a correlation; a handler stashes it and
-    /// matches it against the inbound reply's correlation to pair a
-    /// reply with the request it sent.
-    #[must_use]
-    pub fn prev_correlation(&self) -> u64 {
-        // SAFETY: `raw::prev_correlation` takes no arguments and reads
-        // a host-side scalar set on the most recent `send_mail`; no
-        // ABI invariants to uphold beyond "we are the FFI guest", which
-        // the `#[cfg(target_arch = "wasm32")]` import gate enforces
-        // (the host-target stub panics rather than returning garbage).
-        unsafe { raw::prev_correlation() }
+/// Correlation id the host minted for this actor's most recent
+/// `send_mail` call (ADR-0042). `0` before any send. Universal —
+/// every send mints a correlation; a handler stashes it and
+/// matches it against the inbound reply's correlation to pair a
+/// reply with the request it sent.
+#[must_use]
+pub(crate) fn prev_correlation() -> u64 {
+    // SAFETY: `raw::prev_correlation` takes no arguments and reads
+    // a host-side scalar set on the most recent `send_mail`; no
+    // ABI invariants to uphold beyond "we are the FFI guest", which
+    // the `#[cfg(target_arch = "wasm32")]` import gate enforces
+    // (the host-target stub panics rather than returning garbage).
+    unsafe { raw::prev_correlation() }
+}
+
+/// Resolve the source mailbox of the mail bound to `handle` (issue 1958).
+/// Returns the sender's raw `MailboxId` value when the inbound mail
+/// originated from a peer component; returns `MailboxId::NONE.0` (0)
+/// for every other source kind, for `NO_REPLY_HANDLE`, and for unknown
+/// handles. Callers map `0 → None` to mirror `NativeCtx::source_mailbox`.
+#[must_use]
+pub(crate) fn source_of(handle: u32) -> u64 {
+    // SAFETY: `raw::source_of` takes a scalar handle and reads a
+    // host-side ReplyTable entry — no guest memory access, no ABI
+    // invariants beyond "we are the FFI guest", enforced by the
+    // `#[cfg(target_arch = "wasm32")]` import gate.
+    unsafe { raw::source_of(handle) }
+}
+
+/// ADR-0081 §7: re-emit one `tracing::*` event on the host side.
+/// Called by the wasm subscriber per event so the host's
+/// `ActorAwareLayer` lands the entry in the trampoline's
+/// `ActorLogRing`. `level` is the `0 = trace .. 4 = error`
+/// mapping the rest of `aether.log.*` uses; `target` and
+/// `message` are the pre-rendered tracing field text.
+///
+/// Fire-and-forget: no return code. The host copies before
+/// returning; the guest's borrows are released as soon as the
+/// FFI call completes.
+///
+/// Only callable from wasm32 — the only caller ([`crate::log::WasmSubscriber`])
+/// is gated behind `#[cfg(target_arch = "wasm32")]`.
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn emit_log_event(level: u8, target: &str, message: &str) {
+    let target_bytes = target.as_bytes();
+    let message_bytes = message.as_bytes();
+    // SAFETY: forwards to `raw::log_event`, whose ABI is documented
+    // at the import site in `ffi/raw.rs`. The `(ptr, len)` pairs are
+    // derived from `&str` references valid for `len` bytes for the
+    // call's duration; the host copies before returning.
+    unsafe {
+        raw::log_event(
+            u32::from(level),
+            target_bytes.as_ptr().addr() as u32,
+            target_bytes.len() as u32,
+            message_bytes.as_ptr().addr() as u32,
+            message_bytes.len() as u32,
+        );
     }
+}
 
-    /// Resolve the source mailbox of the mail bound to `handle` (issue 1958).
-    /// Returns the sender's raw `MailboxId` value when the inbound mail
-    /// originated from a peer component; returns `MailboxId::NONE.0` (0)
-    /// for every other source kind, for `NO_REPLY_HANDLE`, and for unknown
-    /// handles. Callers map `0 → None` to mirror `NativeCtx::source_mailbox`.
-    #[must_use]
-    pub fn source_of(&self, handle: u32) -> u64 {
-        // SAFETY: `raw::source_of` takes a scalar handle and reads a
-        // host-side ReplyTable entry — no guest memory access, no ABI
-        // invariants beyond "we are the FFI guest", enforced by the
-        // `#[cfg(target_arch = "wasm32")]` import gate.
-        unsafe { raw::source_of(handle) }
+/// ADR-0097: stage a sibling-spawn request and return the new
+/// instance's `MailboxId`. `tag` is the sibling type's actor-type
+/// tag (`mailbox_id_from_name(NAMESPACE)`); `is_counter` selects
+/// `Subname::Counter` (the host appends a monotonic discriminator)
+/// vs a caller-supplied name; `subname` is the full prefixed subname
+/// for `Named` or the type-namespace prefix for `Counter`; `config`
+/// is the encoded `Config` kind. The returned id is the spawned
+/// sibling's ADR-0099 §3 lineage fold (the trampoline's carry folded
+/// with the sibling's node), known synchronously — one fold step on a
+/// carry the host already holds; the spawn itself completes just
+/// after this call (ADR-0097 §4), so a spawn-time failure surfaces
+/// asynchronously rather than here.
+#[must_use]
+pub(crate) fn spawn_sibling(tag: u64, is_counter: bool, subname: &str, config: &[u8]) -> u64 {
+    let subname_bytes = subname.as_bytes();
+    // SAFETY: forwards to `raw::spawn_sibling`, whose ABI is
+    // documented at the import site in `ffi/raw.rs`. Both `(ptr,
+    // len)` pairs are derived from references valid for `len` bytes
+    // for the call's duration; the host copies before returning.
+    unsafe {
+        raw::spawn_sibling(
+            tag,
+            u32::from(is_counter),
+            subname_bytes.as_ptr().addr() as u32,
+            subname_bytes.len() as u32,
+            config.as_ptr().addr() as u32,
+            config.len() as u32,
+        )
     }
+}
 
-    /// ADR-0081 §7: re-emit one `tracing::*` event on the host side.
-    /// Called by the wasm subscriber per event so the host's
-    /// `ActorAwareLayer` lands the entry in the trampoline's
-    /// `ActorLogRing`. `level` is the `0 = trace .. 4 = error`
-    /// mapping the rest of `aether.log.*` uses; `target` and
-    /// `message` are the pre-rendered tracing field text.
-    ///
-    /// Fire-and-forget: no return code. The host copies before
-    /// returning; the guest's borrows are released as soon as the
-    /// FFI call completes.
-    pub fn emit_log_event(&self, level: u8, target: &str, message: &str) {
-        let target_bytes = target.as_bytes();
-        let message_bytes = message.as_bytes();
-        // SAFETY: forwards to `raw::log_event`, whose ABI is documented
-        // at the import site in `ffi/raw.rs`. The `(ptr, len)` pairs are
-        // derived from `&str` references valid for `len` bytes for the
-        // call's duration; the host copies before returning.
-        unsafe {
-            raw::log_event(
-                u32::from(level),
-                target_bytes.as_ptr().addr() as u32,
-                target_bytes.len() as u32,
-                message_bytes.as_ptr().addr() as u32,
-                message_bytes.len() as u32,
-            );
-        }
-    }
-
-    /// ADR-0097: stage a sibling-spawn request and return the new
-    /// instance's `MailboxId`. `tag` is the sibling type's actor-type
-    /// tag (`mailbox_id_from_name(NAMESPACE)`); `is_counter` selects
-    /// `Subname::Counter` (the host appends a monotonic discriminator)
-    /// vs a caller-supplied name; `subname` is the full prefixed subname
-    /// for `Named` or the type-namespace prefix for `Counter`; `config`
-    /// is the encoded `Config` kind. The returned id is the spawned
-    /// sibling's ADR-0099 §3 lineage fold (the trampoline's carry folded
-    /// with the sibling's node), known synchronously — one fold step on a
-    /// carry the host already holds; the spawn itself completes just
-    /// after this call (ADR-0097 §4), so a spawn-time failure surfaces
-    /// asynchronously rather than here.
-    #[must_use]
-    pub fn spawn_sibling(&self, tag: u64, is_counter: bool, subname: &str, config: &[u8]) -> u64 {
-        let subname_bytes = subname.as_bytes();
-        // SAFETY: forwards to `raw::spawn_sibling`, whose ABI is
-        // documented at the import site in `ffi/raw.rs`. Both `(ptr,
-        // len)` pairs are derived from references valid for `len` bytes
-        // for the call's duration; the host copies before returning.
-        unsafe {
-            raw::spawn_sibling(
-                tag,
-                u32::from(is_counter),
-                subname_bytes.as_ptr().addr() as u32,
-                subname_bytes.len() as u32,
-                config.as_ptr().addr() as u32,
-                config.len() as u32,
-            )
-        }
-    }
-
-    /// ADR-0114: register an inline child's alias route and return its
-    /// `MailboxId`. The inline analogue of [`Self::spawn_sibling`]: the
-    /// host folds the alias id onto the parent's lineage carry and
-    /// registers a route to the parent trampoline's own slot, so the
-    /// co-located child is addressable like any actor with no new
-    /// trampoline. `is_counter` selects `Subname::Counter` (the host
-    /// appends a monotonic discriminator) vs a caller-supplied name;
-    /// `subname` is the bare `Named` segment (empty for `Counter`). No
-    /// config crosses here — the guest runs the child's `init` in-process
-    /// (see [`crate::FfiCtx::spawn_inline_child`]). The returned id is the
-    /// ADR-0099 §3 lineage fold, known synchronously; `0` on a host-side
-    /// error.
-    #[must_use]
-    pub fn spawn_inline_child(&self, is_counter: bool, subname: &str) -> u64 {
-        let subname_bytes = subname.as_bytes();
-        // SAFETY: forwards to `raw::spawn_inline_child`, whose ABI is
-        // documented at the import site in `ffi/raw.rs`. The `(ptr, len)`
-        // pair is derived from a reference valid for `len` bytes for the
-        // call's duration; the host copies before returning.
-        unsafe {
-            raw::spawn_inline_child(
-                u32::from(is_counter),
-                subname_bytes.as_ptr().addr() as u32,
-                subname_bytes.len() as u32,
-            )
-        }
+/// ADR-0114: register an inline child's alias route and return its
+/// `MailboxId`. The inline analogue of `spawn_sibling`: the
+/// host folds the alias id onto the parent's lineage carry and
+/// registers a route to the parent trampoline's own slot, so the
+/// co-located child is addressable like any actor with no new
+/// trampoline. `is_counter` selects `Subname::Counter` (the host
+/// appends a monotonic discriminator) vs a caller-supplied name;
+/// `subname` is the bare `Named` segment (empty for `Counter`). No
+/// config crosses here — the guest runs the child's `init` in-process
+/// (see [`crate::FfiCtx::spawn_inline_child`]). The returned id is the
+/// ADR-0099 §3 lineage fold, known synchronously; `0` on a host-side
+/// error.
+#[must_use]
+pub(crate) fn spawn_inline_child(is_counter: bool, subname: &str) -> u64 {
+    let subname_bytes = subname.as_bytes();
+    // SAFETY: forwards to `raw::spawn_inline_child`, whose ABI is
+    // documented at the import site in `ffi/raw.rs`. The `(ptr, len)`
+    // pair is derived from a reference valid for `len` bytes for the
+    // call's duration; the host copies before returning.
+    unsafe {
+        raw::spawn_inline_child(
+            u32::from(is_counter),
+            subname_bytes.as_ptr().addr() as u32,
+            subname_bytes.len() as u32,
+        )
     }
 }

--- a/crates/aether-actor/src/ffi/bridge/mail.rs
+++ b/crates/aether-actor/src/ffi/bridge/mail.rs
@@ -46,13 +46,7 @@ use crate::ffi::raw;
     clippy::must_use_candidate,
     reason = "fire-and-forget by contract — see doc-comment above; #[must_use] retired in issue 892"
 )]
-pub fn send_mail(
-    recipient: u64,
-    kind: u64,
-    bytes: &[u8],
-    count: u32,
-    detached: bool,
-) -> u32 {
+pub fn send_mail(recipient: u64, kind: u64, bytes: &[u8], count: u32, detached: bool) -> u32 {
     // SAFETY: forwards to `raw::send_mail`, whose ABI is documented
     // at the import site in `ffi/raw.rs`. The `(ptr, len)` pair is
     // derived from the `&[u8]` slice we just received, which the
@@ -140,7 +134,7 @@ pub fn source_of(handle: u32) -> u64 {
 /// returning; the guest's borrows are released as soon as the
 /// FFI call completes.
 ///
-/// Only callable from wasm32 — the only caller ([`crate::log::WasmSubscriber`])
+/// Only callable from wasm32 — the only caller (`crate::log::WasmSubscriber`)
 /// is gated behind `#[cfg(target_arch = "wasm32")]`.
 #[cfg(target_arch = "wasm32")]
 pub fn emit_log_event(level: u8, target: &str, message: &str) {

--- a/crates/aether-actor/src/ffi/bridge/mail.rs
+++ b/crates/aether-actor/src/ffi/bridge/mail.rs
@@ -3,7 +3,7 @@
 // `_p32`-suffixed FFI per ADR-0024 documents the convention.
 #![allow(clippy::cast_possible_truncation)]
 
-//! Outbound-mail FFI bridge — `pub(crate)` free functions.
+//! Outbound-mail FFI bridge — free functions in a `pub(crate)` module.
 //!
 //! Each function forwards to the matching `extern "C"` host fn in [`raw`]
 //! and localizes `unsafe` to one audited site per FFI op. `send_mail`
@@ -46,7 +46,7 @@ use crate::ffi::raw;
     clippy::must_use_candidate,
     reason = "fire-and-forget by contract — see doc-comment above; #[must_use] retired in issue 892"
 )]
-pub(crate) fn send_mail(
+pub fn send_mail(
     recipient: u64,
     kind: u64,
     bytes: &[u8],
@@ -83,7 +83,7 @@ pub(crate) fn send_mail(
     clippy::must_use_candidate,
     reason = "fire-and-forget by contract — see doc-comment above; #[must_use] retired in issue 892"
 )]
-pub(crate) fn reply_mail(sender: u32, kind: u64, bytes: &[u8], count: u32) -> u32 {
+pub fn reply_mail(sender: u32, kind: u64, bytes: &[u8], count: u32) -> u32 {
     // SAFETY: forwards to `raw::reply_mail`, whose ABI is documented
     // at the import site in `ffi/raw.rs`. The `(ptr, len)` pair is
     // derived from the `&[u8]` slice we just received, which the
@@ -106,7 +106,7 @@ pub(crate) fn reply_mail(sender: u32, kind: u64, bytes: &[u8], count: u32) -> u3
 /// matches it against the inbound reply's correlation to pair a
 /// reply with the request it sent.
 #[must_use]
-pub(crate) fn prev_correlation() -> u64 {
+pub fn prev_correlation() -> u64 {
     // SAFETY: `raw::prev_correlation` takes no arguments and reads
     // a host-side scalar set on the most recent `send_mail`; no
     // ABI invariants to uphold beyond "we are the FFI guest", which
@@ -121,7 +121,7 @@ pub(crate) fn prev_correlation() -> u64 {
 /// for every other source kind, for `NO_REPLY_HANDLE`, and for unknown
 /// handles. Callers map `0 → None` to mirror `NativeCtx::source_mailbox`.
 #[must_use]
-pub(crate) fn source_of(handle: u32) -> u64 {
+pub fn source_of(handle: u32) -> u64 {
     // SAFETY: `raw::source_of` takes a scalar handle and reads a
     // host-side ReplyTable entry — no guest memory access, no ABI
     // invariants beyond "we are the FFI guest", enforced by the
@@ -143,7 +143,7 @@ pub(crate) fn source_of(handle: u32) -> u64 {
 /// Only callable from wasm32 — the only caller ([`crate::log::WasmSubscriber`])
 /// is gated behind `#[cfg(target_arch = "wasm32")]`.
 #[cfg(target_arch = "wasm32")]
-pub(crate) fn emit_log_event(level: u8, target: &str, message: &str) {
+pub fn emit_log_event(level: u8, target: &str, message: &str) {
     let target_bytes = target.as_bytes();
     let message_bytes = message.as_bytes();
     // SAFETY: forwards to `raw::log_event`, whose ABI is documented
@@ -174,7 +174,7 @@ pub(crate) fn emit_log_event(level: u8, target: &str, message: &str) {
 /// after this call (ADR-0097 §4), so a spawn-time failure surfaces
 /// asynchronously rather than here.
 #[must_use]
-pub(crate) fn spawn_sibling(tag: u64, is_counter: bool, subname: &str, config: &[u8]) -> u64 {
+pub fn spawn_sibling(tag: u64, is_counter: bool, subname: &str, config: &[u8]) -> u64 {
     let subname_bytes = subname.as_bytes();
     // SAFETY: forwards to `raw::spawn_sibling`, whose ABI is
     // documented at the import site in `ffi/raw.rs`. Both `(ptr,
@@ -205,7 +205,7 @@ pub(crate) fn spawn_sibling(tag: u64, is_counter: bool, subname: &str, config: &
 /// ADR-0099 §3 lineage fold, known synchronously; `0` on a host-side
 /// error.
 #[must_use]
-pub(crate) fn spawn_inline_child(is_counter: bool, subname: &str) -> u64 {
+pub fn spawn_inline_child(is_counter: bool, subname: &str) -> u64 {
     let subname_bytes = subname.as_bytes();
     // SAFETY: forwards to `raw::spawn_inline_child`, whose ABI is
     // documented at the import site in `ffi/raw.rs`. The `(ptr, len)`

--- a/crates/aether-actor/src/ffi/bridge/mod.rs
+++ b/crates/aether-actor/src/ffi/bridge/mod.rs
@@ -3,10 +3,10 @@
 //!
 //! Issue 665 split the prior monolithic `MailTransport` trait + its
 //! `FfiTransport` ZST impl into one module per FFI op family. Issue 1967
-//! then collapsed the per-module ZST + static packaging into `pub(crate)`
-//! free functions, keeping the safe-wrapper boundary (one `unsafe` block
-//! per FFI op, one audited ptr/len marshalling) while closing the
-//! over-exposure the `pub static` forms created.
+//! then collapsed the per-module ZST + static packaging into free functions,
+//! keeping the safe-wrapper boundary (one `unsafe` block per FFI op, one
+//! audited ptr/len marshalling) while closing the over-exposure the
+//! `pub static` forms created.
 //!
 //! - [`mail`] — outbound mail (`send_mail`, `reply_mail`,
 //!   `prev_correlation`, `source_of`, `emit_log_event`, `spawn_sibling`,

--- a/crates/aether-actor/src/ffi/bridge/mod.rs
+++ b/crates/aether-actor/src/ffi/bridge/mod.rs
@@ -1,32 +1,25 @@
-//! Per-concern FFI bridge ZSTs — the host-fn-facing layer underneath
+//! Per-concern FFI bridge modules — the host-fn-facing layer underneath
 //! the per-stage capability traits.
 //!
 //! Issue 665 split the prior monolithic `MailTransport` trait + its
-//! `FfiTransport` ZST impl into one ZST per FFI op family:
+//! `FfiTransport` ZST impl into one module per FFI op family. Issue 1967
+//! then collapsed the per-module ZST + static packaging into `pub(crate)`
+//! free functions, keeping the safe-wrapper boundary (one `unsafe` block
+//! per FFI op, one audited ptr/len marshalling) while closing the
+//! over-exposure the `pub static` forms created.
 //!
-//! - [`MailBridge`] — outbound mail (`send_mail`, `reply_mail`,
-//!   `prev_correlation`). Correlation lives here because every send
+//! - [`mail`] — outbound mail (`send_mail`, `reply_mail`,
+//!   `prev_correlation`, `source_of`, `emit_log_event`, `spawn_sibling`,
+//!   `spawn_inline_child`). Correlation lives here because every send
 //!   mints one so a handler can match a reply to the request it sent —
 //!   it's mail-level metadata.
-//! - [`PersistBridge`] — migration-bundle deposit
+//! - [`persist`] — migration-bundle deposit
 //!   (`save_state`), used during `on_dehydrate` only.
 //!
-//! Each ZST has a process-wide `static` instance (`MAIL_BRIDGE`,
-//! `PERSIST_BRIDGE`) so callers borrow
-//! `&MAIL_BRIDGE` etc. without instantiating per-call. The `_BRIDGE`
-//! suffix is intentional — `aether_actor::Mail<'_>` (the inbound
-//! envelope decoder) is a different type at a different path, and
-//! the suffix keeps the unqualified names disambiguated. The methods
-//! are inherent — there is no shared trait across the two because
-//! their op families don't overlap.
-//!
-//! Per-stage capability ctx impls in [`crate::ffi::ctx`] route through
-//! these statics directly; the cross-target abstraction layer is the
+//! Per-stage capability ctx impls in [`crate::ffi::ctx`] call these
+//! functions directly; the cross-target abstraction layer is the
 //! per-stage capability traits in [`crate::actor::ctx`], not a single
 //! transport trait.
 
-pub mod mail;
-pub mod persist;
-
-pub use mail::{MAIL_BRIDGE, MailBridge};
-pub use persist::{PERSIST_BRIDGE, PersistBridge};
+pub(crate) mod mail;
+pub(crate) mod persist;

--- a/crates/aether-actor/src/ffi/bridge/mod.rs
+++ b/crates/aether-actor/src/ffi/bridge/mod.rs
@@ -8,12 +8,12 @@
 //! audited ptr/len marshalling) while closing the over-exposure the
 //! `pub static` forms created.
 //!
-//! - [`mail`] — outbound mail (`send_mail`, `reply_mail`,
+//! - `mail` — outbound mail (`send_mail`, `reply_mail`,
 //!   `prev_correlation`, `source_of`, `emit_log_event`, `spawn_sibling`,
 //!   `spawn_inline_child`). Correlation lives here because every send
 //!   mints one so a handler can match a reply to the request it sent —
 //!   it's mail-level metadata.
-//! - [`persist`] — migration-bundle deposit
+//! - `persist` — migration-bundle deposit
 //!   (`save_state`), used during `on_dehydrate` only.
 //!
 //! Per-stage capability ctx impls in [`crate::ffi::ctx`] call these

--- a/crates/aether-actor/src/ffi/bridge/persist.rs
+++ b/crates/aether-actor/src/ffi/bridge/persist.rs
@@ -2,13 +2,13 @@
 // to the wasm32 host-fn ABI (`_p32` convention, ADR-0024).
 #![allow(clippy::cast_possible_truncation)]
 
-//! [`PersistBridge`] — migration-bundle FFI bridge.
+//! Migration-bundle FFI bridge — `pub(crate)` free function.
 //!
-//! ZST whose only inherent method is `save_state`, the ADR-0016
-//! deposit hook called inside `on_dehydrate` to hand a typed bundle to
-//! the replacement instance. `Persistence` is conceptually distinct
-//! from mail (it's a one-shot byte deposit, not a routed envelope),
-//! so it lives in its own bridge rather than on [`super::mail::MailBridge`].
+//! `save_state` is the ADR-0016 deposit hook called inside `on_dehydrate`
+//! to hand a typed bundle to the replacement instance. Persistence is
+//! conceptually distinct from mail (it's a one-shot byte deposit, not a
+//! routed envelope), so it lives in its own module rather than alongside
+//! [`super::mail`].
 //!
 //! Native actors do not have a `replace_component`-style hot reload
 //! path — only wasm components do. The native ctx structs deliberately
@@ -16,32 +16,22 @@
 
 use crate::ffi::raw;
 
-/// ZST FFI bridge for `save_state`. Borrow [`PERSIST_BRIDGE`] from any ctx
-/// that impls [`crate::actor::ctx::Persistence`] to forward the
-/// typed-bundle bytes through the host fn.
-pub struct PersistBridge;
-
-/// Process-wide [`PersistBridge`] instance.
-pub static PERSIST_BRIDGE: PersistBridge = PersistBridge;
-
-impl PersistBridge {
-    /// Deposit a migration bundle for the substrate to hand to the
-    /// replacement instance via `on_rehydrate` (ADR-0016). Bytes are
-    /// copied into a substrate-owned buffer immediately, so the
-    /// caller is free to drop the slice on return.
-    ///
-    /// Returns `0` on success; non-zero on substrate rejection
-    /// (today: 1 MiB cap exceeded or internal OOB — both component
-    /// bugs). Meaningful inside `on_dehydrate`, where the substrate
-    /// hands the bundle to the replacement instance via `on_rehydrate`.
-    #[must_use]
-    pub fn save_state(&self, version: u32, bytes: &[u8]) -> u32 {
-        // SAFETY: forwards to `raw::save_state`, whose ABI is documented
-        // at the import site in `ffi/raw.rs`. The `(ptr, len)` pair is
-        // derived from the `&[u8]` slice we just received, which the
-        // borrow checker proves is valid for `bytes.len()` bytes for
-        // the duration of the call; the substrate copies the bundle
-        // out of guest memory before returning.
-        unsafe { raw::save_state(version, bytes.as_ptr().addr() as u32, bytes.len() as u32) }
-    }
+/// Deposit a migration bundle for the substrate to hand to the
+/// replacement instance via `on_rehydrate` (ADR-0016). Bytes are
+/// copied into a substrate-owned buffer immediately, so the
+/// caller is free to drop the slice on return.
+///
+/// Returns `0` on success; non-zero on substrate rejection
+/// (today: 1 MiB cap exceeded or internal OOB — both component
+/// bugs). Meaningful inside `on_dehydrate`, where the substrate
+/// hands the bundle to the replacement instance via `on_rehydrate`.
+#[must_use]
+pub(crate) fn save_state(version: u32, bytes: &[u8]) -> u32 {
+    // SAFETY: forwards to `raw::save_state`, whose ABI is documented
+    // at the import site in `ffi/raw.rs`. The `(ptr, len)` pair is
+    // derived from the `&[u8]` slice we just received, which the
+    // borrow checker proves is valid for `bytes.len()` bytes for
+    // the duration of the call; the substrate copies the bundle
+    // out of guest memory before returning.
+    unsafe { raw::save_state(version, bytes.as_ptr().addr() as u32, bytes.len() as u32) }
 }

--- a/crates/aether-actor/src/ffi/bridge/persist.rs
+++ b/crates/aether-actor/src/ffi/bridge/persist.rs
@@ -2,7 +2,7 @@
 // to the wasm32 host-fn ABI (`_p32` convention, ADR-0024).
 #![allow(clippy::cast_possible_truncation)]
 
-//! Migration-bundle FFI bridge — `pub(crate)` free function.
+//! Migration-bundle FFI bridge — free function in a `pub(crate)` module.
 //!
 //! `save_state` is the ADR-0016 deposit hook called inside `on_dehydrate`
 //! to hand a typed bundle to the replacement instance. Persistence is
@@ -26,7 +26,7 @@ use crate::ffi::raw;
 /// bugs). Meaningful inside `on_dehydrate`, where the substrate
 /// hands the bundle to the replacement instance via `on_rehydrate`.
 #[must_use]
-pub(crate) fn save_state(version: u32, bytes: &[u8]) -> u32 {
+pub fn save_state(version: u32, bytes: &[u8]) -> u32 {
     // SAFETY: forwards to `raw::save_state`, whose ABI is documented
     // at the import site in `ffi/raw.rs`. The `(ptr, len)` pair is
     // derived from the `&[u8]` slice we just received, which the

--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -8,8 +8,8 @@
 //! `DropCtx<'a, T>` aliases. The ctx interface is now spelled by the
 //! per-stage capability traits in [`crate::actor::ctx`]; these structs
 //! are concrete impls that route outbound calls through the
-//! per-concern bridge functions in [`crate::ffi::bridge::mail`] and
-//! [`crate::ffi::bridge::persist`].
+//! per-concern bridge functions in `crate::ffi::bridge::mail` and
+//! `crate::ffi::bridge::persist`.
 //!
 //! Issue 665 retired the `transport: &'a FfiTransport` field along
 //! with the `FfiTransport` ZST and `MailTransport` trait — ctxs hold

--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -8,13 +8,13 @@
 //! `DropCtx<'a, T>` aliases. The ctx interface is now spelled by the
 //! per-stage capability traits in [`crate::actor::ctx`]; these structs
 //! are concrete impls that route outbound calls through the
-//! per-concern bridge ZSTs in [`crate::ffi::bridge`] ([`MAIL_BRIDGE`] /
-//! [`PERSIST_BRIDGE`]).
+//! per-concern bridge functions in [`crate::ffi::bridge::mail`] and
+//! [`crate::ffi::bridge::persist`].
 //!
 //! Issue 665 retired the `transport: &'a FfiTransport` field along
 //! with the `FfiTransport` ZST and `MailTransport` trait — ctxs hold
 //! per-mail state only (mailbox id at init; reply target at receive),
-//! and dispatch goes through the bridge statics directly.
+//! and dispatch goes through the bridge functions directly.
 
 use core::marker::PhantomData;
 use core::ptr;
@@ -29,7 +29,7 @@ use crate::actor::ctx::resolver::Resolver;
 use crate::actor::{
     Actor, HandlesKind, Instanced, NamespaceError, Singleton, Subname, validate_namespace_segment,
 };
-use crate::ffi::bridge::{MAIL_BRIDGE, PERSIST_BRIDGE};
+use crate::ffi::bridge::{mail, persist};
 use crate::ffi::inline::InlineRegistry;
 use crate::ffi::mailbox::FfiActorMailbox;
 use crate::ffi::{BootError, ErasedFfiActor, FfiActor};
@@ -226,7 +226,7 @@ impl<M: ReplyMode> FfiCtx<'_, M> {
     )]
     pub fn reply_kind<K: Kind>(&self, sender: ReplyHandle, kind: KindId<K>, payload: &K) {
         let bytes = payload.encode_into_bytes();
-        MAIL_BRIDGE.reply_mail(sender.raw(), kind.raw(), &bytes, 1);
+        mail::reply_mail(sender.raw(), kind.raw(), &bytes, 1);
     }
 
     /// Reply target for the mail currently being dispatched. Mirrors
@@ -299,7 +299,7 @@ impl<M: ReplyMode> FfiCtx<'_, M> {
         let tag = mailbox_id_from_name(<A as Actor>::NAMESPACE).0;
         let (is_counter, full_subname) = resolve_subname(subname)?;
         let config_bytes = config.encode_into_bytes();
-        let id = MAIL_BRIDGE.spawn_sibling(tag, is_counter, &full_subname, &config_bytes);
+        let id = mail::spawn_sibling(tag, is_counter, &full_subname, &config_bytes);
         Ok(MailboxId(id))
     }
 
@@ -335,7 +335,7 @@ impl<M: ReplyMode> FfiCtx<'_, M> {
         A: Instanced + FfiActor + ErasedFfiActor,
     {
         let (is_counter, full_subname) = resolve_subname(subname)?;
-        let alias = MailboxId(MAIL_BRIDGE.spawn_inline_child(is_counter, &full_subname));
+        let alias = MailboxId(mail::spawn_inline_child(is_counter, &full_subname));
         // Re-decode an owned `A::Config` for the in-guest `init` from the
         // same bytes the detached path would have shipped — symmetric with
         // `spawn_child`'s encode-in-guest / decode-in-host round-trip, and
@@ -473,7 +473,7 @@ impl<M: ReplyMode> MailSender for FfiCtx<'_, M> {
         K: Kind,
     {
         let bytes = payload.encode_into_bytes();
-        MAIL_BRIDGE.send_mail(R::resolve(self.mailbox).0, K::ID.0, &bytes, 1, false);
+        mail::send_mail(R::resolve(self.mailbox).0, K::ID.0, &bytes, 1, false);
     }
 
     //noinspection DuplicatedCode
@@ -483,7 +483,7 @@ impl<M: ReplyMode> MailSender for FfiCtx<'_, M> {
         K: Kind + bytemuck::NoUninit,
     {
         let bytes: &[u8] = bytemuck::cast_slice(payloads);
-        MAIL_BRIDGE.send_mail(
+        mail::send_mail(
             R::resolve(self.mailbox).0,
             K::ID.0,
             bytes,
@@ -498,11 +498,11 @@ impl<M: ReplyMode> MailSender for FfiCtx<'_, M> {
     #[allow(clippy::disallowed_methods)]
     fn send_to_named<K: Kind>(&mut self, name: &str, payload: &K) {
         let bytes = payload.encode_into_bytes();
-        MAIL_BRIDGE.send_mail(mailbox_id_from_name(name).0, K::ID.0, &bytes, 1, false);
+        mail::send_mail(mailbox_id_from_name(name).0, K::ID.0, &bytes, 1, false);
     }
 
     fn prev_correlation(&self) -> u64 {
-        MAIL_BRIDGE.prev_correlation()
+        mail::prev_correlation()
     }
 
     //noinspection DuplicatedCode
@@ -512,7 +512,7 @@ impl<M: ReplyMode> MailSender for FfiCtx<'_, M> {
         K: Kind,
     {
         let bytes = payload.encode_into_bytes();
-        MAIL_BRIDGE.send_mail(R::resolve(self.mailbox).0, K::ID.0, &bytes, 1, true);
+        mail::send_mail(R::resolve(self.mailbox).0, K::ID.0, &bytes, 1, true);
     }
 
     //noinspection DuplicatedCode
@@ -520,7 +520,7 @@ impl<M: ReplyMode> MailSender for FfiCtx<'_, M> {
     #[allow(clippy::disallowed_methods)]
     fn send_detached_to_named<K: Kind>(&mut self, name: &str, payload: &K) {
         let bytes = payload.encode_into_bytes();
-        MAIL_BRIDGE.send_mail(mailbox_id_from_name(name).0, K::ID.0, &bytes, 1, true);
+        mail::send_mail(mailbox_id_from_name(name).0, K::ID.0, &bytes, 1, true);
     }
 }
 
@@ -537,20 +537,20 @@ impl OutboundReply for FfiCtx<'_, Manual> {
 
     fn source_mailbox(&self) -> Option<MailboxId> {
         let handle = self.sender?;
-        let id = MAIL_BRIDGE.source_of(handle);
+        let id = mail::source_of(handle);
         (id != MailboxId::NONE.0).then_some(MailboxId(id))
     }
 
     fn reply<K: Kind>(&mut self, payload: &K) {
         if let Some(raw) = self.sender {
             let bytes = payload.encode_into_bytes();
-            MAIL_BRIDGE.reply_mail(raw, K::ID.0, &bytes, 1);
+            mail::reply_mail(raw, K::ID.0, &bytes, 1);
         }
     }
 
     fn reply_to<K: Kind>(&mut self, sender: ReplyHandle, payload: &K) {
         let bytes = payload.encode_into_bytes();
-        MAIL_BRIDGE.reply_mail(sender.raw(), K::ID.0, &bytes, 1);
+        mail::reply_mail(sender.raw(), K::ID.0, &bytes, 1);
     }
 }
 
@@ -632,7 +632,7 @@ impl<'a> FfiDropCtx<'a> {
             capture.saved = Some((version, bytes.to_vec()));
             return;
         }
-        let status = PERSIST_BRIDGE.save_state(version, bytes);
+        let status = persist::save_state(version, bytes);
         assert_eq!(
             status, 0,
             "aether-actor: save_state failed (status {status})"
@@ -657,7 +657,7 @@ impl MailSender for FfiDropCtx<'_> {
         K: Kind,
     {
         let bytes = payload.encode_into_bytes();
-        MAIL_BRIDGE.send_mail(R::resolve(self.mailbox).0, K::ID.0, &bytes, 1, false);
+        mail::send_mail(R::resolve(self.mailbox).0, K::ID.0, &bytes, 1, false);
     }
 
     //noinspection DuplicatedCode
@@ -667,7 +667,7 @@ impl MailSender for FfiDropCtx<'_> {
         K: Kind + bytemuck::NoUninit,
     {
         let bytes: &[u8] = bytemuck::cast_slice(payloads);
-        MAIL_BRIDGE.send_mail(
+        mail::send_mail(
             R::resolve(self.mailbox).0,
             K::ID.0,
             bytes,
@@ -682,11 +682,11 @@ impl MailSender for FfiDropCtx<'_> {
     #[allow(clippy::disallowed_methods)]
     fn send_to_named<K: Kind>(&mut self, name: &str, payload: &K) {
         let bytes = payload.encode_into_bytes();
-        MAIL_BRIDGE.send_mail(mailbox_id_from_name(name).0, K::ID.0, &bytes, 1, false);
+        mail::send_mail(mailbox_id_from_name(name).0, K::ID.0, &bytes, 1, false);
     }
 
     fn prev_correlation(&self) -> u64 {
-        MAIL_BRIDGE.prev_correlation()
+        mail::prev_correlation()
     }
 
     //noinspection DuplicatedCode
@@ -696,7 +696,7 @@ impl MailSender for FfiDropCtx<'_> {
         K: Kind,
     {
         let bytes = payload.encode_into_bytes();
-        MAIL_BRIDGE.send_mail(R::resolve(self.mailbox).0, K::ID.0, &bytes, 1, true);
+        mail::send_mail(R::resolve(self.mailbox).0, K::ID.0, &bytes, 1, true);
     }
 
     //noinspection DuplicatedCode
@@ -704,7 +704,7 @@ impl MailSender for FfiDropCtx<'_> {
     #[allow(clippy::disallowed_methods)]
     fn send_detached_to_named<K: Kind>(&mut self, name: &str, payload: &K) {
         let bytes = payload.encode_into_bytes();
-        MAIL_BRIDGE.send_mail(mailbox_id_from_name(name).0, K::ID.0, &bytes, 1, true);
+        mail::send_mail(mailbox_id_from_name(name).0, K::ID.0, &bytes, 1, true);
     }
 }
 

--- a/crates/aether-actor/src/ffi/mailbox.rs
+++ b/crates/aether-actor/src/ffi/mailbox.rs
@@ -8,7 +8,7 @@
 //! per-side types so the `MailTransport` trait can retire. The FFI
 //! variant is lifetime-free — it carries no transport reference
 //! because the FFI imports are global to the loaded module
-//! ([`MAIL_BRIDGE`] is the dispatch surface).
+//! (`crate::ffi::bridge::mail` functions are the dispatch surface).
 //!
 //! Built via [`crate::ffi::ctx::FfiCtx::actor`] /
 //! [`crate::ffi::ctx::FfiCtx::resolve_actor`] and their init/drop
@@ -21,11 +21,11 @@ use core::marker::PhantomData;
 use aether_data::{ActorId, Kind, Tag, fold_lineage, mailbox_id_from_name, with_tag};
 
 use crate::actor::{Actor, HandlesKind};
-use crate::ffi::bridge::MAIL_BRIDGE;
+use crate::ffi::bridge::mail;
 
 /// Phantom-typed receiver-actor handle for FFI guests. ZST modulo the
 /// stored mailbox id; cheap to construct, cheap to copy, no borrow
-/// bookkeeping (the global [`MAIL_BRIDGE`] static covers dispatch).
+/// bookkeeping (the `crate::ffi::bridge::mail` free functions cover dispatch).
 pub struct FfiActorMailbox<R> {
     mailbox: u64,
     _r: PhantomData<fn() -> R>,
@@ -117,7 +117,7 @@ impl<R: Actor> FfiActorMailbox<R> {
         K: Kind,
     {
         let bytes = payload.encode_into_bytes();
-        MAIL_BRIDGE.send_mail(self.mailbox, K::ID.0, &bytes, 1, false);
+        mail::send_mail(self.mailbox, K::ID.0, &bytes, 1, false);
     }
 
     /// Send a slice of payloads as a contiguous batch. Cast-only —
@@ -130,7 +130,7 @@ impl<R: Actor> FfiActorMailbox<R> {
         K: Kind + bytemuck::NoUninit,
     {
         let bytes: &[u8] = bytemuck::cast_slice(payloads);
-        MAIL_BRIDGE.send_mail(self.mailbox, K::ID.0, bytes, payloads.len() as u32, false);
+        mail::send_mail(self.mailbox, K::ID.0, bytes, payloads.len() as u32, false);
     }
 
     /// ADR-0080 §7 fire-and-forget escape hatch: send `payload` to `R`
@@ -148,6 +148,6 @@ impl<R: Actor> FfiActorMailbox<R> {
         K: Kind,
     {
         let bytes = payload.encode_into_bytes();
-        MAIL_BRIDGE.send_mail(self.mailbox, K::ID.0, &bytes, 1, true);
+        mail::send_mail(self.mailbox, K::ID.0, &bytes, 1, true);
     }
 }

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -7,13 +7,12 @@
 //!
 //!   - [`raw`] — `extern "C"` host-fn imports + host-target panic
 //!     stubs (the only place the `_p32` symbols are named).
-//!   - [`bridge`] — per-concern `pub(crate)` free-function modules
-//!     ([`bridge::mail`], [`bridge::persist`]). Each module owns one
-//!     FFI op family and forwards calls to the matching `raw::*`
-//!     host fn. Issue 665 split the prior monolithic
-//!     `MailTransport`-impl ZST into these per-concern modules so
-//!     persistence isn't mixed with mail; issue 1967 collapsed the
-//!     per-module ZST + static packaging into free functions.
+//!   - [`bridge`] — per-concern free-function modules ([`bridge::mail`],
+//!     [`bridge::persist`]). Each module owns one FFI op family and
+//!     forwards calls to the matching `raw::*` host fn. Issue 665 split
+//!     the prior monolithic `MailTransport`-impl ZST into these per-concern
+//!     modules so persistence isn't mixed with mail; issue 1967 collapsed
+//!     the per-module ZST + static packaging into free functions.
 //!   - [`FfiInitCtx`] / [`FfiCtx`] / [`FfiDropCtx`] — concrete per-stage
 //!     ctx structs, each impling the relevant subset of the per-stage
 //!     capability traits in [`crate::actor::ctx`].

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -7,18 +7,19 @@
 //!
 //!   - [`raw`] — `extern "C"` host-fn imports + host-target panic
 //!     stubs (the only place the `_p32` symbols are named).
-//!   - [`bridge`] — per-concern ZST dispatch surfaces ([`MAIL_BRIDGE`],
-//!     [`PERSIST_BRIDGE`]). Each ZST owns one FFI op family
-//!     and forwards inherent methods to the matching `raw::*`
+//!   - [`bridge`] — per-concern `pub(crate)` free-function modules
+//!     ([`bridge::mail`], [`bridge::persist`]). Each module owns one
+//!     FFI op family and forwards calls to the matching `raw::*`
 //!     host fn. Issue 665 split the prior monolithic
-//!     `MailTransport`-impl ZST into these per-concern bridges so
-//!     persistence isn't mixed with mail.
+//!     `MailTransport`-impl ZST into these per-concern modules so
+//!     persistence isn't mixed with mail; issue 1967 collapsed the
+//!     per-module ZST + static packaging into free functions.
 //!   - [`FfiInitCtx`] / [`FfiCtx`] / [`FfiDropCtx`] — concrete per-stage
 //!     ctx structs, each impling the relevant subset of the per-stage
 //!     capability traits in [`crate::actor::ctx`].
 //!   - [`FfiActorMailbox<R>`] — actor-typed sender returned by
 //!     `ctx.actor::<R>()` / `ctx.resolve_actor::<R>(name)`. Lifetime-
-//!     free — the global [`MAIL_BRIDGE`] static covers dispatch.
+//!     free — the bridge free functions cover dispatch.
 //!   - [`FfiActor`] trait — entry point with the `init` constructor and
 //!     the `wire` / `unwire` / `on_dehydrate` / `on_rehydrate` lifecycle
 //!     hooks (ADR-0101). `init` returns `Result<Self, BootError>` so a
@@ -64,7 +65,6 @@ pub mod inline;
 pub mod mailbox;
 pub mod raw;
 
-pub use bridge::{MAIL_BRIDGE, MailBridge, PERSIST_BRIDGE, PersistBridge};
 pub use ctx::{FfiCtx, FfiDropCtx, FfiInitCtx, SpawnError};
 pub use mailbox::FfiActorMailbox;
 

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -7,8 +7,8 @@
 //!
 //!   - [`raw`] — `extern "C"` host-fn imports + host-target panic
 //!     stubs (the only place the `_p32` symbols are named).
-//!   - [`bridge`] — per-concern free-function modules ([`bridge::mail`],
-//!     [`bridge::persist`]). Each module owns one FFI op family and
+//!   - [`bridge`] — per-concern free-function modules (`bridge::mail`,
+//!     `bridge::persist`). Each module owns one FFI op family and
 //!     forwards calls to the matching `raw::*` host fn. Issue 665 split
 //!     the prior monolithic `MailTransport`-impl ZST into these per-concern
 //!     modules so persistence isn't mixed with mail; issue 1967 collapsed

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -13,8 +13,8 @@
 //! `MailTransport` trait that originally tied the FFI and native
 //! halves together — the cross-target abstraction is now the
 //! per-stage capability traits in [`actor::ctx`]; the per-target
-//! dispatch surfaces are [`ffi::bridge`] (FFI: [`ffi::MAIL_BRIDGE`],
-//! [`ffi::PERSIST_BRIDGE`]) and the inherent methods on
+//! dispatch surfaces are [`ffi::bridge`] (FFI: `ffi::bridge::mail`,
+//! `ffi::bridge::persist`) and the inherent methods on
 //! `aether_substrate::actor::native::binding::NativeBinding`.
 //!
 //! Public surface:

--- a/crates/aether-actor/src/local.rs
+++ b/crates/aether-actor/src/local.rs
@@ -54,7 +54,7 @@ mod wasm {
     /// thread of the wasm linear memory: every component runs on
     /// one logical thread inside its own linear memory, so the
     /// static can never be racily aliased across threads. Same
-    /// loophole the [`crate::ffi::bridge::MAIL_BRIDGE`] static uses.
+    /// loophole `crate::ffi::bridge::mail`'s wasm linear-memory scope uses.
     ///
     /// `BTreeMap` instead of `HashMap` because `BTreeMap::new()`
     /// is `const fn` and `aether-actor` is `no_std + alloc` — we

--- a/crates/aether-actor/src/log.rs
+++ b/crates/aether-actor/src/log.rs
@@ -15,7 +15,7 @@
 //! ADR-0081 retires the pre-ADR flush-hop machinery alongside this
 //! rewrite: `LogBuffer`, `drain_buffer`, the `IN_LOG_PIPELINE`
 //! re-entry guard, the chassis-pushed `ConfigureLogDrain` mail, the
-//! `set_native_log_shipper` hook, the wasm `MAIL_BRIDGE` route for
+//! `set_native_log_shipper` hook, the wasm mail-bridge route for
 //! `LogBatch`, and `LogCapability` itself. The new query path
 //! ([`LogTail`] / [`LogTailResult`]) is served by a framework-built-
 //! in dispatch arm every actor inherits — no `#[handler]` for it on
@@ -367,7 +367,7 @@ impl Subscriber for WasmSubscriber {
 
     fn event(&self, event: &Event<'_>) {
         let (level, target, message) = render_event(event);
-        crate::ffi::bridge::MAIL_BRIDGE.emit_log_event(level, &target, &message);
+        crate::ffi::bridge::mail::emit_log_event(level, &target, &message);
     }
 }
 

--- a/crates/aether-actor/src/mail/mailbox.rs
+++ b/crates/aether-actor/src/mail/mailbox.rs
@@ -6,8 +6,8 @@
 //! T was bound by retired. [`Mailbox<K>`] is now a pure addressing
 //! token: a (mailbox id, kind id) pair that callers thread around but
 //! that doesn't carry its own dispatch path. Sends go through each
-//! ctx's inherent / trait-provided `send` methods (FFI: bodies hit
-//! [`crate::ffi::bridge::MAIL_BRIDGE`]; native: bodies hit
+//! ctx's inherent / trait-provided `send` methods (FFI: bodies call
+//! `crate::ffi::bridge::mail::send_mail`; native: bodies hit
 //! `NativeBinding`'s inherent `send_mail`).
 //!
 //! Per-side actor-typed mailboxes ([`crate::ffi::FfiActorMailbox<R>`],

--- a/crates/aether-test-fixtures/examples/source_observer.rs
+++ b/crates/aether-test-fixtures/examples/source_observer.rs
@@ -26,11 +26,10 @@
 // the dispatch ABI even when the actor carries no state.
 #![allow(clippy::unused_self)]
 
-use aether_actor::ffi::MAIL_BRIDGE;
+use aether_actor::ffi::FfiActorMailbox;
 use aether_actor::{
     BootError, FfiActor, FfiCtx, MailSender, Manual, OutboundReply, Resolver, actor,
 };
-use aether_data::Kind;
 use aether_test_fixtures::{
     SendSourceQuery, SourceQuery, SourceReport, TEST_BENCH_OBSERVER_MAILBOX_NAME,
 };
@@ -51,15 +50,12 @@ impl FfiActor for SourceObserver {
     /// Forward `SourceQuery` to the `MailboxId` named in `msg.to`, making
     /// *this* actor the component origin so the reader can recover our id
     /// via `ctx.source_mailbox()`. The target is a runtime-supplied `u64`
-    /// (not a compile-time type), so we dispatch through the raw bridge
-    /// rather than the typed `ctx.send::<R, K>` path.
+    /// (not a compile-time type), so we address it via `FfiActorMailbox::__new`
+    /// (doc-hidden but pub) with the `Self: HandlesKind<SourceQuery>` bound
+    /// that `#[actor]` generates for the `on_source_query` handler.
     #[handler]
     fn on_send_source_query(&mut self, _ctx: &mut FfiCtx<'_>, msg: SendSourceQuery) {
-        let bytes = SourceQuery.encode_into_bytes();
-        // SAFETY: forwards to `raw::send_mail`. The `(ptr, len)` pair comes
-        // from a valid `Vec<u8>` alive for the duration of this call; the
-        // host copies before returning.
-        MAIL_BRIDGE.send_mail(msg.to, SourceQuery::ID.0, &bytes, 1, false);
+        FfiActorMailbox::<Self>::__new(msg.to).send(&SourceQuery);
     }
 
     /// Read `source_mailbox()` from the inbound `SourceQuery`, log the value


### PR DESCRIPTION
Closes #1967.

## Summary

The FFI bridge singletons `MAIL_BRIDGE` / `PERSIST_BRIDGE` (`crates/aether-actor/src/ffi/bridge/{mail,persist}.rs`) were zero-sized `pub static`s with `&self` forwarder methods — a vestige of the `MailTransport` trait that issue 665 removed. The packaging (ZST + static + `&self`) carried no per-instance state and was over-exposed: re-exported from `ffi/mod.rs`, any downstream crate could reach `aether_actor::ffi::MAIL_BRIDGE` and call `send_mail` / `reply_mail` / `spawn_sibling` directly, bypassing the typed ctx that resolves addresses and carries the ADR-0080 lineage (#1959's transferable over-exposure defect).

This collapses the packaging into `pub(crate)` free functions while keeping the safe-wrapper boundary intact:

- `ffi/bridge/{mail,persist}.rs`: the `MailBridge` / `PersistBridge` types and `MAIL_BRIDGE` / `PERSIST_BRIDGE` statics are deleted; every method becomes a free function (no `&self`). Each still localizes `unsafe` to one audited site per FFI op and marshals `&[u8]`/`&str` → `(ptr, len)` — the wrapper's four real wins (unsafe localized, marshalling written once, the type→ABI-scalar contract enforced once, the ABI-evolution docs in one place) are untouched.
- `ffi/bridge/mod.rs` seals `mail` / `persist` as `pub(crate) mod`, and `ffi/mod.rs` drops the `pub use bridge::{MAIL_BRIDGE, …}` re-export — so the functions are no longer reachable from outside the crate. The only callers are the in-crate ctx surfaces (`ffi/ctx.rs`, `ffi/mailbox.rs`, `log.rs`), rewritten to `mail::send_mail(...)` / `persist::save_state(...)`.

No public API kept (the point), no wire format change, no behavior change, no change to the `raw.rs` unsafe boundary. No new ADR.

## Reviewer notes

- `emit_log_event` is now `#[cfg(target_arch = "wasm32")]`-gated — as a free `pub(crate)` fn (rather than a method reachable via the old pub static) its only caller is the wasm-gated log-shipping route, so the gate avoids a native dead-code error under `-D warnings`.
- `aether-test-fixtures/examples/source_observer.rs` (a call site the issue's surface list missed) imported the deleted `MAIL_BRIDGE`; migrated to `FfiActorMailbox::<Self>::__new(msg.to).send(&SourceQuery)` — wire-equivalent (same address, same kind, non-detached).

## Test plan

- `scripts/preflight.sh` green: fmt + clippy `--workspace --all-targets -D warnings` (incl. the `redundant_pub_crate` / `private_intra_doc_links` cleanups) + doc + full workspace nextest + the wasm32 component cross-build (load-bearing — the FFI surface only fully exercises on wasm32).

## Generated by

`/implement` — agent execution of [scoped issue #1967](https://github.com/iamacoffeepot/aether/issues/1967).
