### PR TITLE
feat(capabilities): load components by registry selector

### DIFF
--- a/crates/aether-capabilities/src/engine/server.rs
+++ b/crates/aether-capabilities/src/engine/server.rs
@@ -38,8 +38,8 @@
 // `#[bridge]` macro emits `impl HandlesKind<K>` markers as siblings of
 // the mod.
 use aether_kinds::{
-    EngineAlive, EngineDied, ListBinaries, ListEngines, RouteEnvelope, SpawnEngine,
-    TerminateEngine, UploadBinary,
+    EngineAlive, EngineDied, ListBinaries, ListComponents, ListEngines, ResolveComponent,
+    RouteEnvelope, SpawnEngine, TerminateEngine, UploadBinary, UploadComponent,
 };
 #[cfg(test)]
 use std::sync::{Arc, Mutex};
@@ -55,20 +55,21 @@ pub use server_native::{EngineConfig, EngineOverlay};
 #[aether_actor::bridge(singleton)]
 mod server_native {
     use super::{
-        EngineAlive, EngineDied, ListBinaries, ListEngines, RouteEnvelope, SpawnEngine,
-        TerminateEngine, UploadBinary,
+        EngineAlive, EngineDied, ListBinaries, ListComponents, ListEngines, ResolveComponent,
+        RouteEnvelope, SpawnEngine, TerminateEngine, UploadBinary, UploadComponent,
     };
     use crate::engine::proxy::{EngineProxy, EngineProxyConfig, HeartbeatParams};
     use crate::store::{
         ArtifactKind, ArtifactStore, DEFAULT_DISK_BUDGET_BYTES, LAYOUT_VERSION_DIR, Selector,
-        StoredArtifact,
+        StoredArtifact, StoredManifest, component_manifest,
     };
     use aether_actor::actor;
     use aether_data::{EngineId, Kind, MailboxId, Uuid};
     use aether_kinds::{
-        BinaryManifest, BinarySelector, CallSettled, DeadEngineDescriptor, DeathReason,
-        EngineDescriptor, ForwardEnvelope, ListBinariesResult, ListEnginesResult,
-        SpawnEngineResult, TerminateEngineResult, UploadBinaryResult,
+        BinaryManifest, BinarySelector, CallSettled, ComponentSelector, DeadEngineDescriptor,
+        DeathReason, EngineDescriptor, ForwardEnvelope, ListBinariesResult, ListComponentsResult,
+        ListEnginesResult, ResolveComponentResult, SpawnEngineResult, TerminateEngineResult,
+        UploadBinaryResult, UploadComponentResult,
     };
     use aether_substrate::Mail;
     use aether_substrate::Subname;
@@ -748,7 +749,70 @@ mod server_native {
             mail: ListBinaries,
         ) -> ListBinariesResult {
             ListBinariesResult {
-                binaries: self.store.list(&mail),
+                binaries: self.store.list_binaries(&mail),
+            }
+        }
+
+        /// Ingest a component wasm into the hub's content-addressed store
+        /// (ADR-0116, issue 1956).
+        ///
+        /// # Agent
+        /// Send `UploadComponent { staged_path, name }`. The hub reads the
+        /// staged path itself (aether-mcp never reads the bytes — too large
+        /// for the tool channel), sha256-hashes it, dedups against the
+        /// store, reads the manifest straight from the wasm (no execution
+        /// step), stores both, and points `name` (when set) at the hash.
+        /// Reply: `UploadComponentResult::Ok { hash, name }`, or
+        /// `Err { error }` for an unreadable path or an unparseable wasm.
+        #[handler]
+        fn on_upload_component(
+            &mut self,
+            _ctx: &mut NativeCtx<'_>,
+            mail: UploadComponent,
+        ) -> UploadComponentResult {
+            match ingest_component(&mut self.store, &mail.staged_path, mail.name.clone()) {
+                Ok(hash) => UploadComponentResult::Ok {
+                    hash,
+                    name: mail.name,
+                },
+                Err(error) => UploadComponentResult::Err { error },
+            }
+        }
+
+        /// Resolve a component selector to its wasm bytes + manifest.
+        ///
+        /// # Agent
+        /// Send `ResolveComponent { selector }`. aether-mcp calls this
+        /// hub-local before forwarding a `LoadComponent` to the target
+        /// substrate, so the load seam stays path-free. The selector is a
+        /// `hash` / `name` (latest) / `module@actor` exact token, or a
+        /// namespace / handled-kind attribute query (an attribute query
+        /// matching more than one component is a clean ambiguity error).
+        /// Reply: `ResolveComponentResult::Ok { hash, wasm, name, manifest,
+        /// export }`, or `Err { error }` for no match / ambiguity.
+        #[handler]
+        fn on_resolve_component(
+            &mut self,
+            _ctx: &mut NativeCtx<'_>,
+            mail: ResolveComponent,
+        ) -> ResolveComponentResult {
+            resolve_component(&mut self.store, &mail.selector)
+        }
+
+        /// Enumerate the hub's stored components.
+        ///
+        /// # Agent
+        /// Send `ListComponents { namespace?, handled_kind? }` (each filter
+        /// AND-combined; an absent field is no constraint). Reply:
+        /// `ListComponentsResult { components: [{ hash, name, manifest }] }`.
+        #[handler]
+        fn on_list_components(
+            &mut self,
+            _ctx: &mut NativeCtx<'_>,
+            mail: ListComponents,
+        ) -> ListComponentsResult {
+            ListComponentsResult {
+                components: self.store.list_components(&mail),
             }
         }
     }
@@ -789,7 +853,12 @@ mod server_native {
     ) -> Result<String, String> {
         let bytes = fs::read(path).map_err(|e| format!("reading binary path {path:?}: {e}"))?;
         let manifest = describe_binary(path)?;
-        Ok(store.upload(&bytes, ArtifactKind::Binary, manifest, name))
+        Ok(store.upload(
+            &bytes,
+            ArtifactKind::Binary,
+            StoredManifest::Binary(manifest),
+            name,
+        ))
     }
 
     /// Bootstrap-ingest each chassis bin in `paths` into `store`, naming
@@ -819,6 +888,148 @@ mod server_native {
                     "binary bootstrap: skipping a bin that failed to ingest",
                 ),
             }
+        }
+    }
+
+    /// Ingest the component wasm at `path` into `store` content-addressed,
+    /// reading its manifest straight from the wasm (ADR-0116, issue 1956) —
+    /// no execution step. Returns the stored content hash, or a
+    /// human-readable error for an unreadable path or an unparseable wasm.
+    /// Idempotent — identical bytes dedup to the same hash.
+    fn ingest_component(
+        store: &mut ArtifactStore,
+        path: &str,
+        name: Option<String>,
+    ) -> Result<String, String> {
+        let bytes = fs::read(path).map_err(|e| format!("reading component path {path:?}: {e}"))?;
+        let manifest = component_manifest(&bytes)
+            .map_err(|e| format!("reading component manifest from {path:?}: {e}"))?;
+        Ok(store.upload(
+            &bytes,
+            ArtifactKind::Component,
+            StoredManifest::Component(manifest),
+            name,
+        ))
+    }
+
+    /// Resolve a [`ComponentSelector`] against `store` to its wasm bytes +
+    /// manifest (ADR-0116, issue 1956). Resolution order mirrors the binary
+    /// selector: an exact `query` token wins first (`hash` > `module@actor`
+    /// > `name@version` (latest in v1) > `name`); absent a token, the
+    /// `namespace` / `handled_kind` attribute query resolves, where a query
+    /// matching more than one component is a clean ambiguity error (never a
+    /// silent pick). A `module@actor` token's `@actor` part populates the
+    /// reply `export` so the forwarded `LoadComponent` instantiates that
+    /// actor type (ADR-0096). Returns `Err` for no match / ambiguity.
+    fn resolve_component(
+        store: &mut ArtifactStore,
+        selector: &ComponentSelector,
+    ) -> ResolveComponentResult {
+        // An exact token, with the `@actor` half (if any) split off as the
+        // export selector forwarded to the substrate.
+        if let Some(token) = selector
+            .query
+            .as_deref()
+            .map(str::trim)
+            .filter(|t| !t.is_empty())
+        {
+            return resolve_component_token(store, token);
+        }
+        // No exact token: a namespace / handled-kind attribute query. A
+        // match-more-than-one is a clean ambiguity error.
+        let mut matches = store.list_components(&ListComponents {
+            namespace: selector.namespace.clone(),
+            handled_kind: selector.handled_kind,
+        });
+        match matches.len() {
+            0 => ResolveComponentResult::Err {
+                error: format!(
+                    "no stored component matches the attribute query (namespace = {:?}, handled_kind = {:?})",
+                    selector.namespace, selector.handled_kind,
+                ),
+            },
+            1 => {
+                let hash = matches.remove(0).hash;
+                stored_component_reply(store, &hash, None)
+            }
+            n => ResolveComponentResult::Err {
+                error: format!(
+                    "the attribute query (namespace = {:?}, handled_kind = {:?}) matches {n} components — narrow it to a single component (by hash or name)",
+                    selector.namespace, selector.handled_kind,
+                ),
+            },
+        }
+    }
+
+    /// Resolve an exact component selector token to a [`ResolveComponentResult`]
+    /// (ADR-0116). A `module@actor` token splits into the `module`
+    /// hash/name and the `@actor` export selector; a `name@version` token
+    /// is treated as `name` (latest) — v1 keeps no per-name version index;
+    /// a bare token resolves as a hash first, then a name.
+    fn resolve_component_token(store: &mut ArtifactStore, token: &str) -> ResolveComponentResult {
+        // `module@actor` (ADR-0096) takes precedence: the `@actor` half is a
+        // component `Actor::NAMESPACE`, distinct from a binary `name@version`
+        // build id. Resolve the module half (hash, then name), forward the
+        // actor half as `export`.
+        if let Some((module, actor)) = token.split_once('@') {
+            // A hash never contains `@`, so the module half resolves as a
+            // hash first, then a name (latest). The actor half is the export.
+            if store.contains(module) {
+                return stored_component_reply(store, module, Some(actor.to_owned()));
+            }
+            if let Some(found) = store.get(&Selector::Name(module.to_owned())) {
+                return stored_component_reply(store, &found.hash, Some(actor.to_owned()));
+            }
+            return ResolveComponentResult::Err {
+                error: format!("no stored component matches the selector {token:?}"),
+            };
+        }
+        // A bare token: an exact hash wins, else a name (latest).
+        if store.contains(token) {
+            return stored_component_reply(store, token, None);
+        }
+        if let Some(found) = store.get(&Selector::Name(token.to_owned())) {
+            return stored_component_reply(store, &found.hash, None);
+        }
+        ResolveComponentResult::Err {
+            error: format!("no stored component matches the selector {token:?}"),
+        }
+    }
+
+    /// Read the stored component `hash`'s wasm bytes + manifest off disk and
+    /// build a `ResolveComponentResult::Ok` (ADR-0116). `export` threads a
+    /// `module@actor` selector's actor half through to the forwarded
+    /// `LoadComponent.export`. An entry that isn't a component (a binary
+    /// hash) or whose bytes can't be read is a clean `Err`.
+    fn stored_component_reply(
+        store: &mut ArtifactStore,
+        hash: &str,
+        export: Option<String>,
+    ) -> ResolveComponentResult {
+        let Some(found) = store.get(&Selector::Hash(hash.to_owned())) else {
+            return ResolveComponentResult::Err {
+                error: format!("no stored artifact has hash {hash:?}"),
+            };
+        };
+        let Some(manifest) = found.manifest.as_component().cloned() else {
+            return ResolveComponentResult::Err {
+                error: format!("artifact {hash:?} is not a component"),
+            };
+        };
+        let wasm = match fs::read(&found.path) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                return ResolveComponentResult::Err {
+                    error: format!("reading stored component bytes for {hash:?}: {e}"),
+                };
+            }
+        };
+        ResolveComponentResult::Ok {
+            hash: found.hash,
+            wasm,
+            name: found.name,
+            manifest,
+            export,
         }
     }
 
@@ -853,7 +1064,7 @@ mod server_native {
         }
         // No exact token: an attribute query, else `default` = headless.
         let hash = store
-            .list(&attribute_filter(selector))
+            .list_binaries(&attribute_filter(selector))
             .into_iter()
             .map(|entry| entry.hash)
             .min()?;
@@ -885,7 +1096,7 @@ mod server_native {
     /// `None` when no current entry matches both.
     fn pick_versioned(store: &ArtifactStore, name: &str, version: &str) -> Option<String> {
         store
-            .list(&ListBinaries::default())
+            .list_binaries(&ListBinaries::default())
             .into_iter()
             .find(|entry| entry.name.as_deref() == Some(name) && entry.manifest.git_sha == version)
             .map(|entry| entry.hash)
@@ -1250,7 +1461,12 @@ mod tests {
             )
             .expect("the default selector resolves to the bootstrapped headless bin");
             assert_eq!(
-                resolved.manifest.chassis, "headless",
+                resolved
+                    .manifest
+                    .as_binary()
+                    .expect("the resolved artifact is a binary")
+                    .chassis,
+                "headless",
                 "default resolves to the headless chassis",
             );
 

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -176,7 +176,9 @@ pub use render::RenderCapability;
 #[cfg(feature = "render-native")]
 pub use render::{CaptureBackend, RenderConfig, RenderGpu, RenderHandles};
 #[cfg(feature = "native")]
-pub use store::{ArtifactKind, ArtifactStore, Selector, StoredArtifact};
+pub use store::{
+    ArtifactKind, ArtifactStore, Selector, StoredArtifact, StoredManifest, component_manifest,
+};
 pub use tcp::{TcpCapability, TcpListenerActor};
 pub use test_bench::UnsupportedTestBenchCapability;
 #[cfg(feature = "text")]

--- a/crates/aether-capabilities/src/store.rs
+++ b/crates/aether-capabilities/src/store.rs
@@ -9,8 +9,10 @@
 //!
 //! Artifact-generic from the start — an entry is a content blob plus a
 //! type-tagged ([`ArtifactKind`]) manifest — so the registry extraction
-//! (#1955) lifts it whole. Today the only artifact is a chassis binary and
-//! the manifest is a [`BinaryManifest`].
+//! (#1955) lifts it whole. Two artifact types share the store: a chassis
+//! binary (a [`BinaryManifest`], ADR-0115) and a wasm component (a
+//! [`ComponentManifest`] read straight from the wasm, ADR-0116 / #1956),
+//! carried in the [`StoredManifest`] enum.
 //!
 //! ## Layout
 //!
@@ -48,7 +50,10 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use aether_kinds::{BinaryEntry, BinaryManifest, ListBinaries};
+use aether_kinds::{
+    BinaryEntry, BinaryManifest, ComponentActor, ComponentEntry, ComponentManifest, ListBinaries,
+    ListComponents,
+};
 use aether_substrate::atomic_write::atomic_write;
 use aether_substrate::pid_lock::{LockAcquisition, LockGuard, acquire_lock_pid};
 use serde::{Deserialize, Serialize};
@@ -67,13 +72,46 @@ pub const DEFAULT_DISK_BUDGET_BYTES: u64 = 16 * 1024 * 1024 * 1024;
 
 const TARGET: &str = "aether_capabilities::store";
 
-/// The type tag on a stored artifact (ADR-0115). One variant today — the
-/// store is artifact-generic so #1955 can add more (component packs, asset
-/// bundles) without reshaping the entry.
+/// The type tag on a stored artifact (ADR-0115 / ADR-0116). The store is
+/// artifact-generic: an entry's `kind` selects which [`StoredManifest`]
+/// variant describes it, so binaries and component wasm share one store
+/// (#1955 can add more — asset bundles — without reshaping the entry).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ArtifactKind {
     /// A chassis substrate binary, described by a [`BinaryManifest`].
     Binary,
+    /// A wasm component, described by a [`ComponentManifest`] (ADR-0116).
+    Component,
+}
+
+/// The type-tagged manifest a stored artifact carries (ADR-0115 /
+/// ADR-0116). The store sidecars one of these next to each entry's bytes;
+/// the variant matches the entry's [`ArtifactKind`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum StoredManifest {
+    Binary(BinaryManifest),
+    Component(ComponentManifest),
+}
+
+impl StoredManifest {
+    /// The [`BinaryManifest`] when this artifact is a binary, else `None`.
+    #[must_use]
+    pub fn as_binary(&self) -> Option<&BinaryManifest> {
+        match self {
+            Self::Binary(m) => Some(m),
+            Self::Component(_) => None,
+        }
+    }
+
+    /// The [`ComponentManifest`] when this artifact is a component, else
+    /// `None`.
+    #[must_use]
+    pub fn as_component(&self) -> Option<&ComponentManifest> {
+        match self {
+            Self::Component(m) => Some(m),
+            Self::Binary(_) => None,
+        }
+    }
 }
 
 /// How a caller addresses a stored artifact in [`ArtifactStore::get`] —
@@ -88,31 +126,35 @@ pub enum Selector {
 }
 
 /// One resolved artifact returned by [`ArtifactStore::get`]: its content
-/// hash, the on-disk path of its raw bytes (the fork target for #1954),
-/// the type tag, the manifest, and the name pointing at it (if any).
+/// hash, the on-disk path of its raw bytes (the fork target for #1954, the
+/// resolve-and-forward byte source for #1956), the type tag, the
+/// type-tagged manifest, and the name pointing at it (if any).
 #[derive(Debug, Clone)]
 pub struct StoredArtifact {
     pub hash: String,
     pub path: PathBuf,
     pub kind: ArtifactKind,
-    pub manifest: BinaryManifest,
+    pub manifest: StoredManifest,
     pub name: Option<String>,
 }
 
 /// The JSON sidecar written next to each entry's bytes — the type tag
-/// plus the manifest, so a fresh store rebuilds its index from disk.
+/// plus the type-tagged manifest, so a fresh store rebuilds its index
+/// from disk. `kind` is redundant with the `manifest` variant but kept
+/// for a forward-compatible read of an entry whose manifest variant a
+/// future build doesn't recognize.
 #[derive(Serialize, Deserialize, Clone)]
 struct StoredEntry {
     kind: ArtifactKind,
-    manifest: BinaryManifest,
+    manifest: StoredManifest,
 }
 
 /// In-memory record of one entry. The bytes live on disk at
-/// `entries/<hash>`; only the metadata is held in memory (binaries are
+/// `entries/<hash>`; only the metadata is held in memory (artifacts are
 /// large), read back lazily on [`ArtifactStore::get`].
 struct Entry {
     kind: ArtifactKind,
-    manifest: BinaryManifest,
+    manifest: StoredManifest,
     bytes_len: u64,
     /// Eviction protection independent of naming (an explicit
     /// [`ArtifactStore::pin`]). A named entry is also eviction-protected.
@@ -211,7 +253,7 @@ impl ArtifactStore {
         &mut self,
         bytes: &[u8],
         kind: ArtifactKind,
-        manifest: BinaryManifest,
+        manifest: StoredManifest,
         name: Option<String>,
     ) -> String {
         let hash = hash_hex(bytes);
@@ -282,16 +324,40 @@ impl ArtifactStore {
     /// [`BinaryEntry`]s. The filter fields are AND-combined: `chassis` /
     /// `target` are exact matches, `caps` requires the entry's caps to be
     /// a superset of every listed cap. Each absent field is "no
-    /// constraint".
+    /// constraint". Component entries are excluded — only `Binary`-kind
+    /// artifacts are listed here.
     #[must_use]
-    pub fn list(&self, filter: &ListBinaries) -> Vec<BinaryEntry> {
+    pub fn list_binaries(&self, filter: &ListBinaries) -> Vec<BinaryEntry> {
         self.entries
             .iter()
-            .filter(|(_, entry)| matches_filter(&entry.manifest, filter))
-            .map(|(hash, entry)| BinaryEntry {
-                hash: hash.clone(),
-                name: self.name_for(hash),
-                manifest: entry.manifest.clone(),
+            .filter_map(|(hash, entry)| {
+                let manifest = entry.manifest.as_binary()?;
+                matches_binary_filter(manifest, filter).then(|| BinaryEntry {
+                    hash: hash.clone(),
+                    name: self.name_for(hash),
+                    manifest: manifest.clone(),
+                })
+            })
+            .collect()
+    }
+
+    /// Enumerate the stored components matching `filter` as
+    /// [`ComponentEntry`]s (ADR-0116, issue 1956). The filter fields are
+    /// AND-combined: `namespace` keeps entries exporting that actor
+    /// namespace, `handled_kind` keeps entries handling that `KindId`.
+    /// Each absent field is "no constraint". Binary entries are excluded —
+    /// only `Component`-kind artifacts are listed here.
+    #[must_use]
+    pub fn list_components(&self, filter: &ListComponents) -> Vec<ComponentEntry> {
+        self.entries
+            .iter()
+            .filter_map(|(hash, entry)| {
+                let manifest = entry.manifest.as_component()?;
+                matches_component_filter(manifest, filter).then(|| ComponentEntry {
+                    hash: hash.clone(),
+                    name: self.name_for(hash),
+                    manifest: manifest.clone(),
+                })
             })
             .collect()
     }
@@ -406,8 +472,8 @@ impl ArtifactStore {
     }
 }
 
-/// Whether a manifest passes a [`ListBinaries`] filter.
-fn matches_filter(manifest: &BinaryManifest, filter: &ListBinaries) -> bool {
+/// Whether a binary manifest passes a [`ListBinaries`] filter.
+fn matches_binary_filter(manifest: &BinaryManifest, filter: &ListBinaries) -> bool {
     if let Some(chassis) = &filter.chassis
         && &manifest.chassis != chassis
     {
@@ -419,6 +485,93 @@ fn matches_filter(manifest: &BinaryManifest, filter: &ListBinaries) -> bool {
         return false;
     }
     filter.caps.iter().all(|c| manifest.caps.contains(c))
+}
+
+/// Whether a component manifest passes a [`ListComponents`] filter
+/// (ADR-0116): the optional `namespace` must be one of the exported actor
+/// namespaces, and the optional `handled_kind` must be in the manifest's
+/// handled-kind union. Each absent field is "no constraint".
+fn matches_component_filter(manifest: &ComponentManifest, filter: &ListComponents) -> bool {
+    if let Some(namespace) = &filter.namespace
+        && !manifest.namespaces.iter().any(|n| n == namespace)
+    {
+        return false;
+    }
+    if let Some(handled_kind) = &filter.handled_kind
+        && !manifest.handled_kinds.contains(handled_kind)
+    {
+        return false;
+    }
+    true
+}
+
+/// Read a component's [`ComponentManifest`] straight from its wasm bytes
+/// (ADR-0116, issue 1956) — no execution step. Reuses the substrate's
+/// `wasmparser`-based section readers (the same ones the substrate uses at
+/// load): `read_actor_inputs_from_bytes` for the exported actor groups and
+/// their handled kind ids + `#[fallback]` presence (`aether.kinds.inputs`,
+/// ADR-0033 / ADR-0096), `read_namespace_from_bytes` for a single-actor
+/// module's `aether.namespace`, and `read_producers_from_bytes` for build
+/// provenance. The hub indexes a component by what it self-reports.
+///
+/// Each [`ComponentActor`]'s `namespace` is the group's `Actor::NAMESPACE`
+/// from its `ActorBoundary` record; a single-actor module's implicit group
+/// (`namespace: None`) takes the module's `aether.namespace` section value.
+/// The top-level `handled_kinds` / `fallback` are the union across every
+/// exported actor.
+///
+/// # Errors
+///
+/// Returns the section reader's error string when the wasm can't be parsed
+/// (a malformed `aether.kinds.inputs` section). A component with no inputs
+/// section yields an empty manifest with whatever namespace / provenance is
+/// present.
+pub fn component_manifest(wasm: &[u8]) -> Result<ComponentManifest, String> {
+    use aether_substrate::actor::wasm::kind_manifest;
+
+    let groups = kind_manifest::read_actor_inputs_from_bytes(wasm)?;
+    let module_namespace = kind_manifest::read_namespace_from_bytes(wasm)?;
+    let provenance = kind_manifest::read_producers_from_bytes(wasm);
+
+    let mut actors: Vec<ComponentActor> = Vec::with_capacity(groups.len());
+    for group in groups {
+        // A boundary-named group carries its own `Actor::NAMESPACE`; a
+        // single-actor module's implicit group (`None`) resolves its name
+        // from the `aether.namespace` section, falling back to empty.
+        let namespace = group
+            .namespace
+            .or_else(|| module_namespace.clone())
+            .unwrap_or_default();
+        let handled_kinds: Vec<aether_data::KindId> =
+            group.capabilities.handlers.iter().map(|h| h.id).collect();
+        actors.push(ComponentActor {
+            namespace,
+            handled_kinds,
+            fallback: group.capabilities.fallback.is_some(),
+        });
+    }
+
+    let namespaces: Vec<String> = actors.iter().map(|a| a.namespace.clone()).collect();
+    // The handled-kind union across every exported actor, deduped (the
+    // selector axis "a component that handles K"). A `Vec` is right here —
+    // a component handles a handful of kinds.
+    let mut handled_kinds: Vec<aether_data::KindId> = Vec::new();
+    for actor in &actors {
+        for id in &actor.handled_kinds {
+            if !handled_kinds.contains(id) {
+                handled_kinds.push(*id);
+            }
+        }
+    }
+    let fallback = actors.iter().any(|a| a.fallback);
+
+    Ok(ComponentManifest {
+        namespaces,
+        actors,
+        handled_kinds,
+        fallback,
+        provenance,
+    })
 }
 
 /// sha256 hex over `bytes` — the content address.
@@ -570,7 +723,12 @@ fn now_nanos() -> u128 {
 
 #[cfg(test)]
 mod tests {
-    use super::{ArtifactKind, ArtifactStore, DEFAULT_DISK_BUDGET_BYTES, ListBinaries, Selector};
+    use super::{
+        ArtifactKind, ArtifactStore, DEFAULT_DISK_BUDGET_BYTES, ListBinaries, ListComponents,
+        Selector, StoredManifest,
+    };
+    use aether_data::Kind;
+    use aether_kinds::{ComponentActor, ComponentManifest, Key, Tick};
     use std::path::PathBuf;
     use std::{env, fs, process};
 
@@ -582,14 +740,30 @@ mod tests {
         ))
     }
 
-    fn manifest(chassis: &str) -> aether_kinds::BinaryManifest {
-        aether_kinds::BinaryManifest {
+    fn manifest(chassis: &str) -> StoredManifest {
+        StoredManifest::Binary(aether_kinds::BinaryManifest {
             chassis: chassis.to_owned(),
             caps: vec!["aether.fs".to_owned()],
             git_sha: "deadbee".to_owned(),
             profile: "debug".to_owned(),
             target: "x86_64-unknown-linux-gnu".to_owned(),
-        }
+        })
+    }
+
+    /// A component manifest exporting `namespace`, handling `Tick` + `Key`,
+    /// for the ADR-0116 component-store resolve/list unit tests.
+    fn component_manifest(namespace: &str) -> StoredManifest {
+        StoredManifest::Component(ComponentManifest {
+            namespaces: vec![namespace.to_owned()],
+            actors: vec![ComponentActor {
+                namespace: namespace.to_owned(),
+                handled_kinds: vec![Tick::ID, Key::ID],
+                fallback: false,
+            }],
+            handled_kinds: vec![Tick::ID, Key::ID],
+            fallback: false,
+            provenance: String::new(),
+        })
     }
 
     #[test]
@@ -610,6 +784,85 @@ mod tests {
         );
         assert_eq!(h1, h2, "identical bytes dedup to the same content hash");
         assert_eq!(store.entry_count(), 1, "dedup stores one entry");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn component_store_uploads_dedups_and_resolves_by_attribute() {
+        // ADR-0116, issue 1956: the artifact-generic store holds component
+        // wasm as a second type-tagged artifact. Upload + dedup, name
+        // repoint, resolve by hash / name, list by namespace / handled-kind.
+        let root = temp_root("component");
+        let mut store = ArtifactStore::open(&root, DEFAULT_DISK_BUDGET_BYTES);
+
+        let h1 = store.upload(
+            b"probe-wasm-bytes",
+            ArtifactKind::Component,
+            component_manifest("test_fixture_probe"),
+            Some("probe".to_owned()),
+        );
+        // An identical re-upload dedups to the same hash.
+        let h2 = store.upload(
+            b"probe-wasm-bytes",
+            ArtifactKind::Component,
+            component_manifest("test_fixture_probe"),
+            None,
+        );
+        assert_eq!(h1, h2, "identical component bytes dedup to one hash");
+        assert_eq!(store.entry_count(), 1, "dedup stores one component entry");
+
+        // Resolve by hash and by name; the manifest is the component one.
+        let by_hash = store
+            .get(&Selector::Hash(h1.clone()))
+            .expect("the component resolves by hash");
+        assert_eq!(by_hash.kind, ArtifactKind::Component);
+        assert!(
+            by_hash.manifest.as_component().is_some(),
+            "a component entry carries a component manifest",
+        );
+        let by_name = store
+            .get(&Selector::Name("probe".to_owned()))
+            .expect("the component resolves by name");
+        assert_eq!(by_name.hash, h1, "the name points at the component hash");
+
+        // A component is not listed as a binary, and vice versa.
+        store.upload(
+            b"a-binary",
+            ArtifactKind::Binary,
+            manifest("headless"),
+            None,
+        );
+        assert_eq!(
+            store.list_binaries(&ListBinaries::default()).len(),
+            1,
+            "only the binary lists as a binary",
+        );
+        let components = store.list_components(&ListComponents::default());
+        assert_eq!(
+            components.len(),
+            1,
+            "only the component lists as a component"
+        );
+        assert_eq!(components[0].hash, h1);
+
+        // Attribute filters: namespace + handled-kind keep the entry; a
+        // miss drops it.
+        let by_namespace = store.list_components(&ListComponents {
+            namespace: Some("test_fixture_probe".to_owned()),
+            handled_kind: None,
+        });
+        assert_eq!(by_namespace.len(), 1, "a matching namespace keeps it");
+        let by_kind = store.list_components(&ListComponents {
+            namespace: None,
+            handled_kind: Some(Tick::ID),
+        });
+        assert_eq!(by_kind.len(), 1, "a matching handled-kind keeps it");
+        let miss = store.list_components(&ListComponents {
+            namespace: Some("nope".to_owned()),
+            handled_kind: None,
+        });
+        assert!(miss.is_empty(), "a non-matching namespace drops it");
+
         let _ = fs::remove_dir_all(&root);
     }
 
@@ -717,11 +970,16 @@ mod tests {
             manifest("headless"),
             None,
         );
-        let mut desktop = manifest("desktop");
-        desktop.caps = vec!["aether.fs".to_owned(), "aether.render".to_owned()];
+        let desktop = match manifest("desktop") {
+            StoredManifest::Binary(mut m) => {
+                m.caps = vec!["aether.fs".to_owned(), "aether.render".to_owned()];
+                StoredManifest::Binary(m)
+            }
+            StoredManifest::Component(_) => unreachable!("manifest() returns a binary manifest"),
+        };
         store.upload(b"desktop-bin", ArtifactKind::Binary, desktop, None);
 
-        let headless_only = store.list(&ListBinaries {
+        let headless_only = store.list_binaries(&ListBinaries {
             chassis: Some("headless".to_owned()),
             caps: vec![],
             target: None,
@@ -729,7 +987,7 @@ mod tests {
         assert_eq!(headless_only.len(), 1);
         assert_eq!(headless_only[0].manifest.chassis, "headless");
 
-        let render_capable = store.list(&ListBinaries {
+        let render_capable = store.list_binaries(&ListBinaries {
             chassis: None,
             caps: vec!["aether.render".to_owned()],
             target: None,
@@ -741,7 +999,7 @@ mod tests {
         );
         assert_eq!(render_capable[0].manifest.chassis, "desktop");
 
-        let all = store.list(&ListBinaries::default());
+        let all = store.list_binaries(&ListBinaries::default());
         assert_eq!(all.len(), 2);
         let _ = fs::remove_dir_all(&root);
     }

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1365,6 +1365,174 @@ mod engine {
     pub struct ListBinariesResult {
         pub binaries: Vec<BinaryEntry>,
     }
+
+    /// What a stored component *is*, read straight from the wasm at upload
+    /// time — no `--describe` execution step (ADR-0116, issue 1956). A
+    /// component embeds its manifest in the `aether.kinds.inputs` /
+    /// `aether.namespace` custom sections (ADR-0028 / ADR-0033 / ADR-0096),
+    /// so the hub reads it with `wasmparser`, the same reader the substrate
+    /// uses at load. The store sidecars one of these next to each
+    /// component entry's bytes, and [`ListComponentsResult`] returns it per
+    /// entry so an observer (and the resolve query) can select a component
+    /// by what it is.
+    ///
+    /// - `namespaces` — every exported actor's `Actor::NAMESPACE`. A
+    ///   single-actor module yields one; a multi-actor module
+    ///   (`export!(A, B, …)`) yields one per type, the entry type first.
+    /// - `actors` — one [`ComponentActor`] per exported actor type, the
+    ///   `module@actor` selector axis (ADR-0096 export selector).
+    /// - `handled_kinds` — the union of every actor's handled `KindId`s
+    ///   (ADR-0030), the handled-kind selector axis.
+    /// - `fallback` — whether any exported actor declares a `#[fallback]`.
+    /// - `provenance` — the wasm `producers` custom section rendered as a
+    ///   short string (`"<tool> <version>; …"`), or empty when absent.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+    pub struct ComponentManifest {
+        pub namespaces: Vec<String>,
+        pub actors: Vec<ComponentActor>,
+        pub handled_kinds: Vec<aether_data::KindId>,
+        pub fallback: bool,
+        pub provenance: String,
+    }
+
+    /// One exported actor type within a (possibly multi-actor) component
+    /// module (ADR-0096, issue 1956). `namespace` is the type's
+    /// `Actor::NAMESPACE` — the `@actor` half of a `module@actor` selector;
+    /// `handled_kinds` is the kind ids this actor handles; `fallback` is
+    /// whether it declares a `#[fallback]`. A single-actor module's
+    /// implicit group reports `namespace` as the module's `aether.namespace`
+    /// section value.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+    pub struct ComponentActor {
+        pub namespace: String,
+        pub handled_kinds: Vec<aether_data::KindId>,
+        pub fallback: bool,
+    }
+
+    /// One stored component in a [`ListComponentsResult`] (ADR-0116, issue
+    /// 1956). `hash` is the sha256 hex over the wasm's raw bytes — the
+    /// content-address key. `name` is the optional human-readable name the
+    /// latest upload pointed at this hash (`Actor::NAMESPACE` is the
+    /// natural one). `manifest` is what the wasm self-reported.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+    pub struct ComponentEntry {
+        pub hash: String,
+        pub name: Option<String>,
+        pub manifest: ComponentManifest,
+    }
+
+    /// How a [`ResolveComponent`] names the component wasm to load — a
+    /// registry selector resolved against the hub's content-addressed store
+    /// (ADR-0116), never a host filesystem path (the path is retired from
+    /// `load_component` entirely). The engines cap resolves it in this
+    /// order:
+    ///
+    /// - `query` is the exact selector token: a sha256 content `hash`, a
+    ///   `name@version` (treated as `name` latest in v1 — no per-name
+    ///   version index yet, ADR-0116), or a `name` an upload pointed at a
+    ///   hash. `module@actor` resolves the `module` part as the
+    ///   `name`/`hash` and the `@actor` part as the [`ResolveComponentResult`]
+    ///   `export` (the actor `Actor::NAMESPACE` to instantiate, ADR-0096).
+    /// - `namespace` / `handled_kind` are an attribute query over the
+    ///   type-tagged component manifests, consulted when `query` is `None`:
+    ///   keep only components exporting that `namespace`, or handling that
+    ///   `KindId`. An attribute query that matches more than one component
+    ///   is a clean ambiguity error, not a silent pick.
+    ///
+    /// An exact `query` wins first; absent one, the attribute query
+    /// resolves. A selector that resolves to no stored component fails.
+    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default)]
+    pub struct ComponentSelector {
+        pub query: Option<String>,
+        pub namespace: Option<String>,
+        pub handled_kind: Option<aether_data::KindId>,
+    }
+
+    /// `aether.engine.upload_component` — ingest a component wasm into the
+    /// hub's content-addressed store (ADR-0116, issue 1956). `staged_path`
+    /// is an absolute host path the hub reads itself (aether-mcp never reads
+    /// the bytes — too large for the tool channel); the cap sha256-hashes
+    /// the bytes, dedups against the existing store, reads the manifest
+    /// straight from the wasm (no execution step — `aether.kinds.inputs` +
+    /// `aether.namespace` + the `producers` section), and stores both.
+    /// `name`, when set, points that human-readable name at the resulting
+    /// hash. Reply: [`UploadComponentResult`].
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.engine.upload_component")]
+    pub struct UploadComponent {
+        pub staged_path: String,
+        pub name: Option<String>,
+    }
+
+    /// Reply to [`UploadComponent`] (ADR-0116, issue 1956). `Ok` carries the
+    /// content-address `hash` the bytes stored under (a re-upload of
+    /// identical bytes returns the same hash) and the `name` now pointing
+    /// at it, if any. `Err` carries a free-form reason — an unreadable
+    /// `staged_path` or a wasm whose manifest can't be parsed.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.engine.upload_component_result")]
+    pub enum UploadComponentResult {
+        Ok { hash: String, name: Option<String> },
+        Err { error: String },
+    }
+
+    /// `aether.engine.resolve_component` — resolve a [`ComponentSelector`]
+    /// to a stored component's wasm bytes + manifest (ADR-0116, issue
+    /// 1956). aether-mcp calls this hub-local before forwarding a
+    /// `LoadComponent` to the target substrate, so the resolve hop keeps the
+    /// load seam path-free. Reply: [`ResolveComponentResult`].
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.engine.resolve_component")]
+    pub struct ResolveComponent {
+        pub selector: ComponentSelector,
+    }
+
+    /// Reply to [`ResolveComponent`] (ADR-0116, issue 1956). `Ok` carries
+    /// the resolved content `hash`, the `wasm` bytes the load forwards, the
+    /// `name` pointing at the hash (if any), the `manifest` the store read
+    /// from the wasm, and `export` — the `@actor` half of a `module@actor`
+    /// selector, threaded into the forwarded `LoadComponent.export` so a
+    /// specific actor type is instantiated from a multi-actor module
+    /// (ADR-0096); `None` for a plain selector. `Err` carries a free-form
+    /// reason — a selector that resolves to no stored component, or an
+    /// attribute query matching more than one (a clean ambiguity error).
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.engine.resolve_component_result")]
+    pub enum ResolveComponentResult {
+        Ok {
+            hash: String,
+            wasm: Vec<u8>,
+            name: Option<String>,
+            manifest: ComponentManifest,
+            export: Option<String>,
+        },
+        Err {
+            error: String,
+        },
+    }
+
+    /// `aether.engine.list_components` — enumerate the hub's stored
+    /// components (ADR-0116, issue 1956). The filter fields are
+    /// AND-combined and each defaults to "no constraint": `namespace` keeps
+    /// only entries exporting that actor namespace, `handled_kind` keeps
+    /// only entries handling that `KindId`. Reply: [`ListComponentsResult`].
+    #[derive(
+        aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default,
+    )]
+    #[kind(name = "aether.engine.list_components")]
+    pub struct ListComponents {
+        pub namespace: Option<String>,
+        pub handled_kind: Option<aether_data::KindId>,
+    }
+
+    /// Reply to [`ListComponents`] (ADR-0116, issue 1956): every stored
+    /// component matching the filter, each as a [`ComponentEntry`] carrying
+    /// its hash, optional name, and the manifest read from the wasm.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.engine.list_components_result")]
+    pub struct ListComponentsResult {
+        pub components: Vec<ComponentEntry>,
+    }
 }
 
 mod control_plane {
@@ -4277,6 +4445,107 @@ mod tests {
         assert_eq!(back.chassis.as_deref(), Some("headless"));
         assert_eq!(back.caps, vec!["aether.fs".to_string()]);
         assert_eq!(back.target, None);
+    }
+
+    #[test]
+    fn component_store_kinds_roundtrip() {
+        // The hub component-store registry kinds (ADR-0116, issue 1956) ride
+        // the postcard path — `Option<String>` + `Vec`s + a nested `Schema`
+        // manifest carrying `KindId`s and the wasm bytes. The upload, the
+        // resolve carrying the wasm + manifest + export, and the list reply
+        // with its embedded `ComponentEntry`/`ComponentManifest` must all
+        // survive the engines-cap encode/decode.
+        use alloc::string::ToString;
+        use alloc::vec;
+
+        let upload = UploadComponent {
+            staged_path: "/tmp/staged/probe.wasm".to_string(),
+            name: Some("probe".to_string()),
+        };
+        let back = UploadComponent::decode_from_bytes(&upload.encode_into_bytes())
+            .expect("test setup: UploadComponent decodes");
+        assert_eq!(back.staged_path, upload.staged_path);
+        assert_eq!(back.name.as_deref(), Some("probe"));
+
+        let ok = UploadComponentResult::Ok {
+            hash: "abc123".to_string(),
+            name: Some("probe".to_string()),
+        };
+        match UploadComponentResult::decode_from_bytes(&ok.encode_into_bytes())
+            .expect("test setup: UploadComponentResult decodes")
+        {
+            UploadComponentResult::Ok { hash, name } => {
+                assert_eq!(hash, "abc123");
+                assert_eq!(name.as_deref(), Some("probe"));
+            }
+            UploadComponentResult::Err { error } => panic!("expected Ok, got Err {error}"),
+        }
+
+        let manifest = ComponentManifest {
+            namespaces: vec!["test_fixture_probe".to_string()],
+            actors: vec![ComponentActor {
+                namespace: "test_fixture_probe".to_string(),
+                handled_kinds: vec![Tick::ID, Key::ID],
+                fallback: false,
+            }],
+            handled_kinds: vec![Tick::ID, Key::ID],
+            fallback: false,
+            provenance: "rustc 1.0; processed-by clang".to_string(),
+        };
+
+        let resolved = ResolveComponentResult::Ok {
+            hash: "abc123".to_string(),
+            wasm: vec![0, 1, 2, 3],
+            name: Some("probe".to_string()),
+            manifest: manifest.clone(),
+            export: Some("test_fixture_probe".to_string()),
+        };
+        match ResolveComponentResult::decode_from_bytes(&resolved.encode_into_bytes())
+            .expect("test setup: ResolveComponentResult decodes")
+        {
+            ResolveComponentResult::Ok {
+                hash,
+                wasm,
+                name,
+                manifest: got,
+                export,
+            } => {
+                assert_eq!(hash, "abc123");
+                assert_eq!(wasm, vec![0, 1, 2, 3]);
+                assert_eq!(name.as_deref(), Some("probe"));
+                assert_eq!(got, manifest);
+                assert_eq!(export.as_deref(), Some("test_fixture_probe"));
+            }
+            ResolveComponentResult::Err { error } => panic!("expected Ok, got Err {error}"),
+        }
+
+        let listed = ListComponentsResult {
+            components: vec![ComponentEntry {
+                hash: "abc123".to_string(),
+                name: Some("probe".to_string()),
+                manifest: manifest.clone(),
+            }],
+        };
+        let back = ListComponentsResult::decode_from_bytes(&listed.encode_into_bytes())
+            .expect("test setup: ListComponentsResult decodes");
+        assert_eq!(back.components.len(), 1);
+        assert_eq!(back.components[0].hash, "abc123");
+        assert_eq!(back.components[0].manifest, manifest);
+
+        // A handled-kind attribute selector round-trips its nested `KindId`.
+        let selector = ComponentSelector {
+            query: None,
+            namespace: Some("test_fixture_probe".to_string()),
+            handled_kind: Some(Tick::ID),
+        };
+        let resolve = ResolveComponent { selector };
+        let back = ResolveComponent::decode_from_bytes(&resolve.encode_into_bytes())
+            .expect("test setup: ResolveComponent decodes");
+        assert_eq!(
+            back.selector.namespace.as_deref(),
+            Some("test_fixture_probe")
+        );
+        assert_eq!(back.selector.handled_kind, Some(Tick::ID));
     }
 
     #[test]

--- a/crates/aether-mcp/src/args.rs
+++ b/crates/aether-mcp/src/args.rs
@@ -47,13 +47,20 @@ pub struct SpawnSubstrateArgs {
 }
 
 /// One component in a `spawn_substrate` boot list. Mirrors the
-/// `load_component` arguments (path-addressed, ADR-0096 export
-/// selector), but the substrate reads the files itself at boot rather
-/// than `aether-mcp` forwarding the bytes.
+/// `load_component` arguments (registry selector, ADR-0096 export
+/// selector). aether-mcp pre-resolves each selector against the hub's
+/// component registry (ADR-0116) and stages the resolved bytes for the
+/// substrate to read at boot — the substrate boot path stays path-based,
+/// now fed by the registry rather than host build paths.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ComponentSpec {
-    /// Absolute path to the component's `.wasm` on the fleet host.
-    pub binary_path: String,
+    /// Registry selector for the component, resolved against the hub's
+    /// content-addressed store (ADR-0116) — `upload_component` first if it
+    /// isn't stored. An exact token: a content `hash`, a `name`, or a
+    /// `module@actor` (the `@actor` half picks an exported actor type from
+    /// a multi-actor module). The host wasm path is gone — the path
+    /// survives only as the `upload_component` input.
+    pub selector: String,
     /// Optional human-readable load name. The substrate defaults one
     /// from the wasm if omitted.
     #[serde(default)]
@@ -65,7 +72,8 @@ pub struct ComponentSpec {
     pub config_path: Option<String>,
     /// ADR-0096: which exported actor type to instantiate from a
     /// multi-actor module, named by its `Actor::NAMESPACE`. Omit to load
-    /// the module's entry type.
+    /// the module's entry type. A `module@actor` selector populates this
+    /// from its `@actor` half — set it explicitly to override.
     #[serde(default)]
     pub export: Option<String>,
 }
@@ -91,6 +99,36 @@ pub struct UploadBinaryArgs {
     /// protected from LRU eviction.
     #[serde(default)]
     pub name: Option<String>,
+}
+
+/// `upload_component` arguments (ADR-0116, issue 1956).
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UploadComponentArgs {
+    /// Absolute path to the component `.wasm` on the fleet host. The hub
+    /// reads this path itself, content-addresses it (sha256), and reads its
+    /// manifest straight from the wasm — aether-mcp never reads the bytes
+    /// (a component is too large for the tool channel).
+    pub staged_path: String,
+    /// Optional human-readable name to point at the resulting hash (the
+    /// component's `Actor::NAMESPACE` is the natural one). A later upload
+    /// with the same name repoints it; the named entry is protected from
+    /// LRU eviction.
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+/// `list_components` arguments (ADR-0116, issue 1956). Every field is an
+/// optional AND-combined filter; omit all to list every stored component.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListComponentsArgs {
+    /// Keep only components exporting an actor with this `Actor::NAMESPACE`.
+    #[serde(default)]
+    pub namespace: Option<String>,
+    /// Keep only components handling this kind, by its tagged kind id
+    /// (`knd-…`) or kind name (e.g. `"aether.lifecycle.tick"`). Resolved
+    /// against the substrate kind vocabulary baked into aether-mcp.
+    #[serde(default)]
+    pub handled_kind: Option<String>,
 }
 
 /// `list_binaries` arguments (ADR-0115, issue 1953). Every field is an
@@ -247,10 +285,15 @@ pub struct ReplyEventJson {
 pub struct LoadComponentArgs {
     /// Engine UUID the component loads into (from `list_engines`).
     pub engine_id: String,
-    /// Absolute path to the component's `.wasm`. `aether-mcp` reads
-    /// the bytes and forwards them to the substrate — agents never
-    /// inline wasm through the tool call.
-    pub binary_path: String,
+    /// Registry selector for the component, resolved against the hub's
+    /// content-addressed store (ADR-0116) — `upload_component` first if it
+    /// isn't stored. An exact token: a content `hash`, a `name` (latest
+    /// upload under it), or a `module@actor` (the `@actor` half picks an
+    /// exported actor type from a multi-actor module). The host wasm path
+    /// is retired — the only path anywhere is the `upload_component` input.
+    /// aether-mcp resolves the selector hub-local to the wasm bytes, then
+    /// forwards them to the substrate's `aether.component` mailbox.
+    pub selector: String,
     /// Optional human-readable name. The substrate defaults one from
     /// the wasm if omitted; the reply echoes the resolved name.
     #[serde(default)]
@@ -267,7 +310,8 @@ pub struct LoadComponentArgs {
     /// multi-actor module, named by its `Actor::NAMESPACE` (e.g.
     /// `"ui.panel"`). Omit to load the module's entry type — the first
     /// in its `export!` list, and the only type a single-actor module
-    /// has. An export the module doesn't declare comes back as a
+    /// has. A `module@actor` selector populates this from its `@actor`
+    /// half. An export the module doesn't declare comes back as a
     /// `LoadResult::Err`.
     #[serde(default)]
     pub export: Option<String>,
@@ -281,8 +325,12 @@ pub struct ReplaceComponentArgs {
     /// Tagged mailbox id (`mbx-…`) of the component to replace, as
     /// returned by `load_component`.
     pub mailbox_id: String,
-    /// Absolute path to the replacement `.wasm`.
-    pub binary_path: String,
+    /// Registry selector for the replacement component, resolved against
+    /// the hub's content-addressed store (ADR-0116) — hash-primary, so a
+    /// `hash` pins or rolls a component to an exact build. A `name` or
+    /// `module@actor` resolves too. The host wasm path is retired; the
+    /// only path anywhere is the `upload_component` input.
+    pub selector: String,
     /// Accepted for wire compatibility; currently ignored by the
     /// substrate (post-ADR-0038 the splice is structural).
     #[serde(default)]

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -35,11 +35,13 @@ use aether_data::{EnumVariant, Primitive, SchemaType};
 use aether_kinds::dag::{DagDescriptor, Edge, Node, NodeId};
 use aether_kinds::{
     BinarySelector, Cancel, CancelResult, CaptureFrame, CaptureFrameResult, ComponentCapabilities,
-    CostTail, CostTailResult, DeathReason, FrameCheck, FrameReduction, ListBinaries,
-    ListBinariesResult, ListEngines, ListEnginesResult, ListKinds, ListKindsResult, LoadComponent,
-    LoadResult, MailEnvelope as KindMailEnvelope, ReplaceComponent, ReplaceResult, SimilarityCheck,
-    SpawnEngine, SpawnEngineResult, Status, StatusResult, Submit, SubmitResult, TerminateEngine,
-    TerminateEngineResult, UploadBinary, UploadBinaryResult,
+    ComponentSelector, CostTail, CostTailResult, DeathReason, FrameCheck, FrameReduction,
+    ListBinaries, ListBinariesResult, ListComponents, ListComponentsResult, ListEngines,
+    ListEnginesResult, ListKinds, ListKindsResult, LoadComponent, LoadResult,
+    MailEnvelope as KindMailEnvelope, ReplaceComponent, ReplaceResult, ResolveComponent,
+    ResolveComponentResult, SimilarityCheck, SpawnEngine, SpawnEngineResult, Status, StatusResult,
+    Submit, SubmitResult, TerminateEngine, TerminateEngineResult, UploadBinary, UploadBinaryResult,
+    UploadComponent, UploadComponentResult,
     trace::{
         DescribeTreeResult, DispatchTraced, DispatchTracedAck, MailNodeWire, TRACE_MAILBOX_NAME,
         TraceTail, TraceTailResult,
@@ -61,11 +63,12 @@ use crate::args::{
     CaptureCheckSpec, CaptureFrameArgs, CaptureMailSpec, ComponentSpec, DagCancelArgs,
     DagDescriptorArg, DagStatusArgs, DeadEngineInfo, DescribeComponentArgs, DescribeHandlersArgs,
     DescribeHandlersResponse, DescribeHandlesArgs, DescribeHandlesResponse, DescribeKindsArgs,
-    EngineInfo, HandleSummaryJson, KindSummary, ListBinariesArgs, ListEnginesResponse,
-    LoadComponentArgs, MailIdJson, MailNodeJson, MailSpec, MailStatus, NativeCapHandlers,
-    NativeHandlerJson, NodeArg, ReplaceComponentArgs, ReplyEventJson, SendMailArgs,
-    SendMailTracedArgs, SendMailTracedResponse, SpawnSubstrateArgs, SubmitDagArgs,
+    EngineInfo, HandleSummaryJson, KindSummary, ListBinariesArgs, ListComponentsArgs,
+    ListEnginesResponse, LoadComponentArgs, MailIdJson, MailNodeJson, MailSpec, MailStatus,
+    NativeCapHandlers, NativeHandlerJson, NodeArg, ReplaceComponentArgs, ReplyEventJson,
+    SendMailArgs, SendMailTracedArgs, SendMailTracedResponse, SpawnSubstrateArgs, SubmitDagArgs,
     TerminateSubstrateArgs, TracedMailSpec, TransformListing, UploadBinaryArgs,
+    UploadComponentArgs,
 };
 use crate::reverse::EngineNames;
 use crate::rpc::RpcSession;
@@ -234,25 +237,25 @@ impl Mcp {
     }
 
     #[tool(
-        description = "Fork+exec a substrate binary as a child of the hub, resolved from the hub's content-addressed binary store (ADR-0115) — not a host path. Pass `selector` to pick the binary: a content `hash`, a `name@version`, or a `name` (upload_binary first if it isn't stored). Omit `selector` for `default` — the headless chassis — so a bare spawn_substrate with no arguments returns a working engine. When `selector` is omitted you may instead attribute-query with `chassis` (\"headless\"/\"desktop\"/\"hub\"), `caps` (linked-cap superset), and `target` (build triple). The hub resolves the selector to the stored bytes, materializes them to an executable temp file, assigns a free localhost RPC port (injected as AETHER_RPC_PORT), forks it, and connects a proxy. Returns the engine_id and rpc_port on success; errors if the selector resolves to no stored binary. Pass `components` (each {binary_path, name?, config_path?, export?}) to bring the engine up with those components already loaded in one call — aether-mcp stages a temp boot-manifest the hub injects as AETHER_BOOT_MANIFEST, and the spawned substrate reads the listed wasm itself (single-host), so no follow-up load_component is needed."
+        description = "Fork+exec a substrate binary as a child of the hub, resolved from the hub's content-addressed binary store (ADR-0115) — not a host path. Pass `selector` to pick the binary: a content `hash`, a `name@version`, or a `name` (upload_binary first if it isn't stored). Omit `selector` for `default` — the headless chassis — so a bare spawn_substrate with no arguments returns a working engine. When `selector` is omitted you may instead attribute-query with `chassis` (\"headless\"/\"desktop\"/\"hub\"), `caps` (linked-cap superset), and `target` (build triple). The hub resolves the selector to the stored bytes, materializes them to an executable temp file, assigns a free localhost RPC port (injected as AETHER_RPC_PORT), forks it, and connects a proxy. Returns the engine_id and rpc_port on success; errors if the selector resolves to no stored binary. Pass `components` (each {selector, name?, config_path?, export?}) to bring the engine up with those components already loaded in one call — each selector is a content hash, name, or module@actor resolved against the hub's component registry (ADR-0116; upload_component first). aether-mcp pre-resolves each selector to its wasm bytes, stages a temp boot-manifest the hub injects as AETHER_BOOT_MANIFEST, and the spawned substrate reads the staged wasm itself (single-host), so no follow-up load_component is needed."
     )]
     pub async fn spawn_substrate(
         &self,
         Parameters(args): Parameters<SpawnSubstrateArgs>,
     ) -> Result<String, McpError> {
-        // A boot list rides in as a temp boot-manifest JSON of file
-        // paths; the hub injects its path as AETHER_BOOT_MANIFEST and the
-        // single-host substrate reads the wasm itself (issue 1776). Hold
-        // the temp file across the spawn call — the substrate reads it at
-        // boot, before the spawn reply returns — then clean it up.
-        let manifest = if args.components.is_empty() {
+        // A boot list rides in as a temp boot-manifest JSON of file paths;
+        // the hub injects its path as AETHER_BOOT_MANIFEST and the
+        // single-host substrate reads the staged wasm itself (issue 1776).
+        // ADR-0116: each component is a registry selector, so aether-mcp
+        // pre-resolves it to bytes and stages those bytes to a temp wasm
+        // file the manifest points at — the substrate boot path stays
+        // path-based, now fed by the registry. Hold the temp files across
+        // the spawn call — the substrate reads them at boot, before the
+        // spawn reply returns — then clean them up.
+        let staged = if args.components.is_empty() {
             None
         } else {
-            Some(
-                stage_boot_manifest(&args.components)
-                    .await
-                    .map_err(internal)?,
-            )
+            Some(self.stage_boot_manifest(&args.components).await?)
         };
         let reply = self
             .session
@@ -266,13 +269,15 @@ impl Mcp {
                         target: args.target,
                     },
                     args: args.args,
-                    boot_manifest: manifest.as_ref().map(|p| p.to_string_lossy().into_owned()),
+                    boot_manifest: staged
+                        .as_ref()
+                        .map(|s| s.manifest_path.to_string_lossy().into_owned()),
                 },
             ))
             .await;
-        if let Some(path) = &manifest {
-            // Best-effort cleanup; the substrate has already read it.
-            let _ = fs::remove_file(path).await;
+        if let Some(staged) = &staged {
+            // Best-effort cleanup; the substrate has already read them.
+            staged.cleanup().await;
         }
         let reply = reply.map_err(internal)?;
         match SpawnEngineResult::decode_from_bytes(&reply.payload) {
@@ -365,6 +370,64 @@ impl Mcp {
         match ListBinariesResult::decode_from_bytes(&reply.payload) {
             Some(result) => json(&result.binaries),
             None => Err(internal_msg("undecodable ListBinariesResult")),
+        }
+    }
+
+    #[tool(
+        description = "Upload a WASM component into the hub's content-addressed store (ADR-0116). Pass `staged_path` — an absolute path to the component .wasm on the fleet host — and an optional `name` (the component's Actor::NAMESPACE is the natural one). The hub reads the path itself (aether-mcp never reads the bytes — too large for the tool channel), sha256-hashes it, dedups against the store (a re-upload of identical bytes returns the same hash), reads its manifest straight from the wasm (no execution step — exported actor namespaces, handled kind ids, #[fallback] presence, build provenance), stores both, and points `name` (when given) at the hash. The store persists across a restart-hub. Then load it by selector with load_component — the host wasm path is gone from load_component / replace_component / boot manifests, surviving only here as the upload input. Returns {hash, name}."
+    )]
+    pub async fn upload_component(
+        &self,
+        Parameters(args): Parameters<UploadComponentArgs>,
+    ) -> Result<String, McpError> {
+        // The hub reads the staged path; aether-mcp forwards it, never
+        // reading the bytes (unlike the load_component resolve hop, which
+        // pulls the bytes back from the store).
+        let reply = self
+            .session
+            .call_one(local_envelope(
+                ENGINE_CAP,
+                &UploadComponent {
+                    staged_path: args.staged_path,
+                    name: args.name,
+                },
+            ))
+            .await
+            .map_err(internal)?;
+        match UploadComponentResult::decode_from_bytes(&reply.payload) {
+            Some(UploadComponentResult::Ok { hash, name }) => {
+                json(&serde_json::json!({ "hash": hash, "name": name }))
+            }
+            Some(UploadComponentResult::Err { error }) => Err(internal_msg(&error)),
+            None => Err(internal_msg("undecodable UploadComponentResult")),
+        }
+    }
+
+    #[tool(
+        description = "Enumerate the hub's stored components (ADR-0116). Optional AND-combined filters: `namespace` (keep only components exporting an actor with that Actor::NAMESPACE) and `handled_kind` (keep only components handling that kind, by tagged knd-… id or kind name). Omit both to list every stored component. Returns an array of {hash, name, manifest} — the manifest read straight from each wasm at upload: {namespaces, actors: [{namespace, handled_kinds, fallback}], handled_kinds, fallback, provenance}."
+    )]
+    pub async fn list_components(
+        &self,
+        Parameters(args): Parameters<ListComponentsArgs>,
+    ) -> Result<String, McpError> {
+        let handled_kind = match args.handled_kind.as_deref() {
+            Some(s) => Some(resolve_handled_kind(s)?),
+            None => None,
+        };
+        let reply = self
+            .session
+            .call_one(local_envelope(
+                ENGINE_CAP,
+                &ListComponents {
+                    namespace: args.namespace,
+                    handled_kind,
+                },
+            ))
+            .await
+            .map_err(internal)?;
+        match ListComponentsResult::decode_from_bytes(&reply.payload) {
+            Some(result) => json(&result.components),
+            None => Err(internal_msg("undecodable ListComponentsResult")),
         }
     }
 
@@ -588,20 +651,17 @@ impl Mcp {
     }
 
     #[tool(
-        description = "Load a WASM component into a substrate by filesystem path. aether-mcp reads the binary, forwards it as aether.component.load to the engine's aether.component mailbox, and awaits the LoadResult — returning {mailbox_id, name, capabilities} or an error. The path must exist as given (no ~ expansion, no relative resolution). The component's kind vocabulary rides in the wasm's aether.kinds custom section. Pass config_path to deliver init-config bytes to a typed-config component (ADR-0090): the file must already hold the component's Config kind wire bytes — describe_component reports the expected config kind. Pass export to pick which exported actor type to instantiate from a multi-actor module (ADR-0096), named by its Actor::NAMESPACE; omit it to load the module's entry type (the first in its export! list, and the only type a single-actor module has). The returned name + capabilities describe the selected type. Very large wasm payloads (typically target/wasm32-unknown-unknown/debug/*.wasm, which can run 15-25 MiB) may exceed the RPC framing cap — prefer release builds, or raise the cap via the AETHER_MAX_FRAME_SIZE env var (default 64 MiB, clamped at 1 GiB; issue 1271)."
+        description = "Load a WASM component into a substrate by registry selector (ADR-0116) — upload_component first if it isn't stored. Pass `selector`: a content hash, a name (latest upload under it), or a module@actor (the @actor half picks an exported actor type from a multi-actor module). The host wasm path is gone — the only path anywhere is the upload_component input. aether-mcp resolves the selector hub-local to the wasm bytes, forwards aether.component.load to the engine's aether.component mailbox, and awaits the LoadResult — returning {mailbox_id, name, capabilities} or an error. The component's kind vocabulary rides in the wasm's aether.kinds custom section. Pass config_path to deliver init-config bytes to a typed-config component (ADR-0090): the file must already hold the component's Config kind wire bytes — describe_component reports the expected config kind. Pass export to pick which exported actor type to instantiate from a multi-actor module (ADR-0096), named by its Actor::NAMESPACE; a module@actor selector populates it from its @actor half; omit both to load the module's entry type (the first in its export! list, and the only type a single-actor module has). The returned name + capabilities describe the selected type. Very large wasm payloads (debug builds at 15-25 MiB) may exceed the RPC framing cap — prefer release builds, or raise the cap via the AETHER_MAX_FRAME_SIZE env var (default 64 MiB, clamped at 1 GiB; issue 1271)."
     )]
     pub async fn load_component(
         &self,
         Parameters(args): Parameters<LoadComponentArgs>,
     ) -> Result<String, McpError> {
         let engine = parse_engine_id(&args.engine_id)?;
-        let wasm = fs::read(&args.binary_path).await.map_err(|e| {
-            McpError::invalid_params(
-                format!("reading binary_path {:?}: {e}", args.binary_path),
-                None,
-            )
-        })?;
-        let binary_path = args.binary_path.clone();
+        let selector = args.selector.clone();
+        // ADR-0116: resolve the selector hub-local to the wasm bytes; a
+        // `module@actor` selector's `@actor` half rides back as `export`.
+        let resolved = self.resolve_component(&selector).await?;
         // ADR-0090 (issue 1257): read optional init-config bytes from a
         // file path (already encoded to the component's `Config` kind
         // wire shape). Absent → empty vec → the substrate hands `&[]` to
@@ -612,20 +672,22 @@ impl Mcp {
             })?,
             None => Vec::new(),
         };
+        // An explicit `export` arg wins over the selector's `@actor` half.
+        let export = args.export.or(resolved.export);
         let reply = self
             .session
             .call_one(engine_envelope(
                 engine,
                 COMPONENT_CAP,
                 &LoadComponent {
-                    wasm,
+                    wasm: resolved.wasm,
                     name: args.name,
                     config,
-                    export: args.export,
+                    export,
                 },
             ))
             .await
-            .map_err(|e| frame_size_aware_error(&format!("load_component {binary_path:?}"), e))?;
+            .map_err(|e| frame_size_aware_error(&format!("load_component {selector:?}"), e))?;
         match LoadResult::decode_from_bytes(&reply.payload) {
             Some(LoadResult::Ok {
                 mailbox_id,
@@ -648,7 +710,7 @@ impl Mcp {
     }
 
     #[tool(
-        description = "Atomically replace a live component's WASM with a new binary loaded from a filesystem path (ADR-0022 structural splice). aether-mcp reads the binary and forwards aether.component.replace to the engine's aether.component mailbox. drain_timeout_ms is accepted for wire compatibility but currently ignored. Returns the replaced component's advertised capabilities. Very large wasm payloads (typically debug builds at 15-25 MiB) may exceed the RPC framing cap — prefer release builds, or raise the cap via the AETHER_MAX_FRAME_SIZE env var (default 64 MiB, clamped at 1 GiB; issue 1271)."
+        description = "Atomically replace a live component's WASM with a build resolved from a registry selector (ADR-0022 structural splice; ADR-0116 selector). Pass `selector` (hash-primary — a hash pins or rolls the component to an exact build; a name or module@actor resolves too); the host wasm path is gone, surviving only as the upload_component input. aether-mcp resolves the selector hub-local to the wasm bytes and forwards aether.component.replace to the engine's aether.component mailbox. drain_timeout_ms is accepted for wire compatibility but currently ignored. Returns the replaced component's advertised capabilities. Very large wasm payloads (debug builds at 15-25 MiB) may exceed the RPC framing cap — prefer release builds, or raise the cap via the AETHER_MAX_FRAME_SIZE env var (default 64 MiB, clamped at 1 GiB; issue 1271)."
     )]
     pub async fn replace_component(
         &self,
@@ -656,13 +718,10 @@ impl Mcp {
     ) -> Result<String, McpError> {
         let engine = parse_engine_id(&args.engine_id)?;
         let mailbox_id = parse_mailbox_id(&args.mailbox_id)?;
-        let wasm = fs::read(&args.binary_path).await.map_err(|e| {
-            McpError::invalid_params(
-                format!("reading binary_path {:?}: {e}", args.binary_path),
-                None,
-            )
-        })?;
-        let binary_path = args.binary_path.clone();
+        let selector = args.selector.clone();
+        // ADR-0116: resolve the selector hub-local to the replacement wasm
+        // bytes (hash-primary, so a hash pins/rolls to an exact build).
+        let resolved = self.resolve_component(&selector).await?;
         // ADR-0090 (issue 1257): optional init-config bytes for the
         // replacement instance, read from a file path like the load path.
         let config = match args.config_path {
@@ -678,15 +737,13 @@ impl Mcp {
                 COMPONENT_CAP,
                 &ReplaceComponent {
                     mailbox_id,
-                    wasm,
+                    wasm: resolved.wasm,
                     drain_timeout_ms: args.drain_timeout_ms,
                     config,
                 },
             ))
             .await
-            .map_err(|e| {
-                frame_size_aware_error(&format!("replace_component {binary_path:?}"), e)
-            })?;
+            .map_err(|e| frame_size_aware_error(&format!("replace_component {selector:?}"), e))?;
         match ReplaceResult::decode_from_bytes(&reply.payload) {
             Some(ReplaceResult::Ok { capabilities }) => {
                 self.components
@@ -1247,6 +1304,102 @@ impl Mcp {
         self.session.fire(envelope).await
     }
 
+    /// Resolve a component registry selector hub-local to its wasm bytes +
+    /// `@actor` export (ADR-0116). aether-mcp issues a `ResolveComponent` to
+    /// the `aether.engine` cap (no engine route — the store is hub-level),
+    /// which matches the selector to a single component and replies with the
+    /// wasm bytes from its store; aether-mcp then forwards those bytes to
+    /// the target substrate's `aether.component` mailbox. Shared by
+    /// `load_component`, `replace_component`, and the boot-manifest
+    /// pre-resolution, so the load seam stays path-free. An `Err` reply (no
+    /// match, or an attribute query matching more than one component) is a
+    /// clean tool error.
+    async fn resolve_component(&self, selector: &str) -> Result<ResolvedComponent, McpError> {
+        let reply = self
+            .session
+            .call_one(local_envelope(
+                ENGINE_CAP,
+                &ResolveComponent {
+                    selector: ComponentSelector {
+                        query: Some(selector.to_owned()),
+                        namespace: None,
+                        handled_kind: None,
+                    },
+                },
+            ))
+            .await
+            .map_err(|e| frame_size_aware_error(&format!("resolve_component {selector:?}"), e))?;
+        match ResolveComponentResult::decode_from_bytes(&reply.payload) {
+            Some(ResolveComponentResult::Ok { wasm, export, .. }) => {
+                Ok(ResolvedComponent { wasm, export })
+            }
+            Some(ResolveComponentResult::Err { error }) => Err(internal_msg(&error)),
+            None => Err(internal_msg("undecodable ResolveComponentResult")),
+        }
+    }
+
+    /// Pre-resolve a `spawn_substrate` boot list against the component
+    /// registry (ADR-0116) and stage it as a temp boot-manifest JSON the
+    /// hub injects as `AETHER_BOOT_MANIFEST` (issue 1776). For each spec
+    /// aether-mcp resolves the selector hub-local to its wasm bytes, writes
+    /// the bytes to a per-process-unique temp `.wasm`, and points the
+    /// manifest entry's `wasm` at that staged path — so the substrate boot
+    /// autoload path stays path-based, now fed by the registry rather than
+    /// host build paths. A `module@actor` selector's `@actor` half
+    /// populates the entry's `export` unless the spec set one explicitly.
+    /// Returns the staged paths so the caller cleans them all up once the
+    /// substrate has read them at boot.
+    async fn stage_boot_manifest(
+        &self,
+        components: &[ComponentSpec],
+    ) -> Result<StagedBootManifest, McpError> {
+        use std::env;
+        use std::process;
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+
+        let mut wasm_paths: Vec<PathBuf> = Vec::with_capacity(components.len());
+        let mut entries: Vec<serde_json::Value> = Vec::with_capacity(components.len());
+        for spec in components {
+            let resolved = self.resolve_component(&spec.selector).await?;
+            let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+            let wasm_path =
+                env::temp_dir().join(format!("aether-boot-wasm-{}-{seq}.wasm", process::id()));
+            fs::write(&wasm_path, &resolved.wasm).await.map_err(|e| {
+                internal_msg(&format!(
+                    "staging boot wasm for selector {:?}: {e}",
+                    spec.selector
+                ))
+            })?;
+            let mut entry = serde_json::json!({ "wasm": wasm_path.to_string_lossy() });
+            if let Some(name) = &spec.name {
+                entry["name"] = serde_json::json!(name);
+            }
+            if let Some(config) = &spec.config_path {
+                entry["config"] = serde_json::json!(config);
+            }
+            // An explicit `export` wins over the selector's `@actor` half.
+            if let Some(export) = spec.export.clone().or(resolved.export) {
+                entry["export"] = serde_json::json!(export);
+            }
+            entries.push(entry);
+            wasm_paths.push(wasm_path);
+        }
+
+        let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+        let manifest_path =
+            env::temp_dir().join(format!("aether-boot-manifest-{}-{seq}.json", process::id()));
+        let bytes = serde_json::to_vec(&serde_json::json!({ "components": entries }))
+            .map_err(|e| internal_msg(&format!("encoding boot manifest: {e}")))?;
+        fs::write(&manifest_path, bytes)
+            .await
+            .map_err(|e| internal_msg(&format!("staging boot manifest: {e}")))?;
+        Ok(StagedBootManifest {
+            manifest_path,
+            wasm_paths,
+        })
+    }
+
     /// Resolve a `MailSpec` against the per-engine merged kind view
     /// (static prefill + cached `ListKinds` reply, ADR-0091) and build
     /// the `engine = Some` wire envelope — the shared front half of
@@ -1705,48 +1858,35 @@ fn validate_recipient_scope(recipient_name: &str) -> anyhow::Result<()> {
     })
 }
 
-/// Build the boot-manifest JSON for a `spawn_substrate` component list
-/// (issue 1776). Mirrors the bundle crate's `BundleManifest` schema,
-/// serialized with `serde_json::json!` so `aether-mcp` needn't depend on
-/// the bundle crate — the same approach `cargo xtask bundle` takes on the
-/// write side. Factored from [`stage_boot_manifest`] so the shape is
-/// unit-testable without staging a file. Optional spec fields are only
-/// emitted when set, matching the manifest's `#[serde(default)]` fields.
-fn component_manifest_json(components: &[ComponentSpec]) -> serde_json::Value {
-    let entries: Vec<serde_json::Value> = components
-        .iter()
-        .map(|spec| {
-            let mut entry = serde_json::json!({ "wasm": spec.binary_path });
-            if let Some(name) = &spec.name {
-                entry["name"] = serde_json::json!(name);
-            }
-            if let Some(config) = &spec.config_path {
-                entry["config"] = serde_json::json!(config);
-            }
-            if let Some(export) = &spec.export {
-                entry["export"] = serde_json::json!(export);
-            }
-            entry
-        })
-        .collect();
-    serde_json::json!({ "components": entries })
+/// A component registry selector resolved to its bytes + `@actor` export
+/// (ADR-0116) — the front half of `load_component` / `replace_component` /
+/// the boot-manifest pre-resolution. `export` is the `module@actor`
+/// selector's actor half, threaded into the forwarded `LoadComponent.export`.
+struct ResolvedComponent {
+    wasm: Vec<u8>,
+    export: Option<String>,
 }
 
-/// Stage the `spawn_substrate` boot list as a temporary boot-manifest
-/// JSON file and return its path (issue 1776). The hub injects the path
-/// as `AETHER_BOOT_MANIFEST` at the fork; the caller removes the file
-/// once the spawn settles. The filename is per-process-unique so
-/// concurrent spawns never collide.
-async fn stage_boot_manifest(components: &[ComponentSpec]) -> anyhow::Result<PathBuf> {
-    use std::env;
-    use std::process;
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static SEQ: AtomicU64 = AtomicU64::new(0);
-    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
-    let path = env::temp_dir().join(format!("aether-boot-manifest-{}-{seq}.json", process::id()));
-    let bytes = serde_json::to_vec(&component_manifest_json(components))?;
-    fs::write(&path, bytes).await?;
-    Ok(path)
+/// The temp files a `stage_boot_manifest` wrote (ADR-0116): the
+/// boot-manifest JSON the hub injects as `AETHER_BOOT_MANIFEST` plus the
+/// staged component `.wasm` files it points at. The substrate reads them
+/// at boot, before the spawn reply returns; the spawn caller
+/// [`cleanup`](StagedBootManifest::cleanup)s them once it has.
+struct StagedBootManifest {
+    manifest_path: PathBuf,
+    wasm_paths: Vec<PathBuf>,
+}
+
+impl StagedBootManifest {
+    /// Best-effort remove the staged manifest + every staged wasm file.
+    /// The substrate has already read them at boot by the time the spawn
+    /// reply returns, so a removal failure is harmless.
+    async fn cleanup(&self) {
+        let _ = fs::remove_file(&self.manifest_path).await;
+        for path in &self.wasm_paths {
+            let _ = fs::remove_file(path).await;
+        }
+    }
 }
 
 /// Build a `MailEnvelope` addressed at a hub-local mailbox
@@ -1852,6 +1992,30 @@ fn parse_kind_id(s: &str) -> Result<KindId, McpError> {
             None,
         )
     })
+}
+
+/// Resolve a `handled_kind` filter token (ADR-0116 `list_components`) to a
+/// [`KindId`]: a tagged `knd-…` id or a decimal `u64` resolves directly;
+/// otherwise the token is a kind name resolved against the static substrate
+/// vocabulary (`describe_kinds`'s source). An unknown name is an
+/// invalid-params error.
+fn resolve_handled_kind(s: &str) -> Result<KindId, McpError> {
+    if let Ok(id) = tagged_id::decode_with_tag(s, Tag::Kind) {
+        return Ok(KindId(id));
+    }
+    if let Ok(id) = s.parse::<u64>() {
+        return Ok(KindId(id));
+    }
+    descriptors::all()
+        .into_iter()
+        .find(|d| d.name == s)
+        .map(|d| KindId(kind_id_from_parts(&d.name, &d.schema)))
+        .ok_or_else(|| {
+            McpError::invalid_params(
+                format!("handled_kind: not a tagged `knd-…` id, a decimal u64, or a known kind name: {s:?}"),
+                None,
+            )
+        })
 }
 
 /// Best-effort resolve a [`KindId`] to its name from the static kind
@@ -2896,48 +3060,34 @@ mod tests {
         );
     }
 
-    /// The temp boot-manifest `spawn_substrate` stages from its
-    /// `components` list is a well-formed `BundleManifest` JSON: list
-    /// order is preserved, `binary_path` maps to `wasm`, and the optional
-    /// `config_path` / `name` / `export` ride only when set (issue 1776).
-    #[test]
-    fn component_manifest_json_is_well_formed() {
-        let specs = vec![
-            ComponentSpec {
-                binary_path: "/abs/camera.wasm".to_owned(),
-                name: Some("camera".to_owned()),
-                config_path: Some("/abs/camera.cfg".to_owned()),
-                export: None,
-            },
-            ComponentSpec {
-                binary_path: "/abs/ui.wasm".to_owned(),
-                name: None,
-                config_path: None,
-                export: Some("ui.panel".to_owned()),
-            },
-        ];
-        let manifest = component_manifest_json(&specs);
-        let components = manifest["components"]
-            .as_array()
-            .expect("components is an array");
-        assert_eq!(components.len(), 2);
-
-        assert_eq!(components[0]["wasm"], "/abs/camera.wasm");
-        assert_eq!(components[0]["name"], "camera");
-        assert_eq!(components[0]["config"], "/abs/camera.cfg");
-        assert!(components[0].get("export").is_none());
-
-        assert_eq!(components[1]["wasm"], "/abs/ui.wasm");
-        assert_eq!(components[1]["export"], "ui.panel");
-        assert!(components[1].get("name").is_none());
-        assert!(components[1].get("config").is_none());
-
-        // The staged JSON parses back through the chassis manifest schema
-        // shape (components array of {wasm, ...}).
-        let serialized = serde_json::to_string(&manifest).expect("serialize manifest");
-        let reparsed: serde_json::Value =
-            serde_json::from_str(&serialized).expect("reparse manifest");
-        assert_eq!(reparsed["components"].as_array().unwrap().len(), 2);
+    /// A `spawn_substrate` boot list whose component selector resolves to
+    /// no stored component fails the spawn as a tool error before any fork
+    /// (ADR-0116): aether-mcp pre-resolves each selector via
+    /// `ResolveComponent`, and a miss aborts the staging. The store is
+    /// empty on a fresh hub, so any selector is a miss.
+    #[tokio::test]
+    async fn spawn_substrate_unresolvable_component_selector_is_tool_error() {
+        let (_chassis, port) = boot_hub();
+        let mcp = connect_mcp(port);
+        let result = mcp
+            .spawn_substrate(Parameters(SpawnSubstrateArgs {
+                selector: None,
+                chassis: None,
+                caps: vec![],
+                target: None,
+                args: vec![],
+                components: vec![ComponentSpec {
+                    selector: "no-such-component".to_owned(),
+                    name: None,
+                    config_path: None,
+                    export: None,
+                }],
+            }))
+            .await;
+        assert!(
+            result.is_err(),
+            "an unresolvable component selector should abort the spawn as a tool error",
+        );
     }
 
     /// `terminate_substrate` with a malformed `engine_id` surfaces the
@@ -3113,22 +3263,26 @@ mod tests {
         );
     }
 
-    /// `load_component` with a binary path that doesn't exist fails at
-    /// the file read, before any RPC.
+    /// `load_component` with a selector that resolves to no stored
+    /// component is a tool error: the hub-local `ResolveComponent` misses
+    /// on the empty store (ADR-0116).
     #[tokio::test]
-    async fn load_component_missing_binary_is_tool_error() {
+    async fn load_component_unresolvable_selector_is_tool_error() {
         let (_chassis, port) = boot_hub();
         let mcp = connect_mcp(port);
         let result = mcp
             .load_component(Parameters(LoadComponentArgs {
                 engine_id: "00000000-0000-0000-0000-000000000001".to_owned(),
-                binary_path: "/nonexistent/does-not-exist.wasm".to_owned(),
+                selector: "no-such-component".to_owned(),
                 name: None,
                 config_path: None,
                 export: None,
             }))
             .await;
-        assert!(result.is_err(), "a missing binary should be a tool error");
+        assert!(
+            result.is_err(),
+            "an unresolvable selector should be a tool error",
+        );
     }
 
     /// `replace_component` with a malformed tagged mailbox id is
@@ -3141,7 +3295,7 @@ mod tests {
             .replace_component(Parameters(ReplaceComponentArgs {
                 engine_id: "00000000-0000-0000-0000-000000000001".to_owned(),
                 mailbox_id: "not-a-tagged-id".to_owned(),
-                binary_path: "/tmp/whatever.wasm".to_owned(),
+                selector: "any-selector".to_owned(),
                 drain_timeout_ms: None,
                 config_path: None,
             }))

--- a/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
@@ -50,12 +50,14 @@ use aether_kinds::MailEnvelope as TracedEnvelope;
 use aether_kinds::descriptors;
 use aether_kinds::trace::{DispatchTraced, DispatchTracedAck, TRACE_MAILBOX_NAME};
 use aether_kinds::{
-    BinaryEntry, BinarySelector, Cancel, CancelResult, ComponentCapabilities, DagDescriptor,
-    DeadEngineDescriptor, EngineDescriptor, HandleDescribe, HandleDescribeResult, ListBinaries,
-    ListBinariesResult, ListEngines, ListEnginesResult, LoadComponent, LoadResult, LogTail,
-    LogTailResult, ReplaceComponent, ReplaceResult, SpawnEngine, SpawnEngineResult, Status,
-    StatusResult, Submit, SubmitResult, TerminateEngine, TerminateEngineResult, UploadBinary,
-    UploadBinaryResult,
+    BinaryEntry, BinarySelector, Cancel, CancelResult, ComponentCapabilities, ComponentEntry,
+    ComponentSelector, DagDescriptor, DeadEngineDescriptor, EngineDescriptor, HandleDescribe,
+    HandleDescribeResult, ListBinaries, ListBinariesResult, ListComponents, ListComponentsResult,
+    ListEngines, ListEnginesResult, LoadComponent, LoadResult, LogTail, LogTailResult,
+    ReplaceComponent, ReplaceResult, ResolveComponent, ResolveComponentResult, SpawnEngine,
+    SpawnEngineResult, Status, StatusResult, Submit, SubmitResult, TerminateEngine,
+    TerminateEngineResult, UploadBinary, UploadBinaryResult, UploadComponent,
+    UploadComponentResult,
 };
 use aether_substrate::chassis::Chassis;
 use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver, PassiveChassis};
@@ -182,6 +184,21 @@ impl FleetBench {
     /// exactly that hash — so every run forks the same binary regardless of
     /// local build state, instead of handing the cap a host path.
     pub fn spawn_headless(&mut self) -> EngineId {
+        self.spawn_headless_inner(None)
+    }
+
+    /// Fork a real `aether-substrate-headless` with an `AETHER_BOOT_MANIFEST`
+    /// pointing at `boot_manifest_path` (ADR-0116, issue 1956), so the
+    /// engine comes up with the manifest's components already loading — the
+    /// path a `spawn_substrate` carrying a component list drives. Records
+    /// the engine for teardown.
+    pub fn spawn_headless_with_boot_manifest(&mut self, boot_manifest_path: &Path) -> EngineId {
+        self.spawn_headless_inner(Some(boot_manifest_path.to_string_lossy().into_owned()))
+    }
+
+    /// Shared spawn body: pin the headless bin by content hash, fork it
+    /// through the engines cap, optionally injecting a boot manifest path.
+    fn spawn_headless_inner(&mut self, boot_manifest: Option<String>) -> EngineId {
         let headless = env!("CARGO_BIN_EXE_aether-substrate-headless");
         let hash = match self.upload_binary(headless, Some("headless")) {
             UploadBinaryResult::Ok { hash, .. } => hash,
@@ -198,7 +215,7 @@ impl FleetBench {
                     target: None,
                 },
                 args: vec![],
-                boot_manifest: None,
+                boot_manifest,
             },
         );
         let payload = single_reply(&replies, "SpawnEngine");
@@ -264,6 +281,140 @@ impl FleetBench {
         match ListBinariesResult::decode_from_bytes(&payload) {
             Some(result) => result.binaries,
             None => panic!("undecodable ListBinariesResult"),
+        }
+    }
+
+    /// Upload a component wasm into the hub's content-addressed store
+    /// (ADR-0116, issue 1956) by absolute host path, optionally naming it.
+    /// Hub-local — addressed at `aether.engine` with no engine route. The
+    /// hub reads the path, sha256s it, parses its manifest from the wasm,
+    /// and stores both; returns the decoded [`UploadComponentResult`].
+    pub fn upload_component(
+        &mut self,
+        staged_path: &str,
+        name: Option<&str>,
+    ) -> UploadComponentResult {
+        let replies = self.call(
+            None,
+            "aether.engine",
+            &UploadComponent {
+                staged_path: staged_path.to_owned(),
+                name: name.map(str::to_owned),
+            },
+        );
+        let payload = single_reply(&replies, "UploadComponent");
+        UploadComponentResult::decode_from_bytes(&payload)
+            .expect("undecodable UploadComponentResult")
+    }
+
+    /// Enumerate the hub's stored components (ADR-0116, issue 1956) under
+    /// the given filter. Hub-local — addressed at `aether.engine` with no
+    /// engine route.
+    pub fn list_components(&mut self, filter: &ListComponents) -> Vec<ComponentEntry> {
+        let replies = self.call(None, "aether.engine", filter);
+        let payload = single_reply(&replies, "ListComponents");
+        match ListComponentsResult::decode_from_bytes(&payload) {
+            Some(result) => result.components,
+            None => panic!("undecodable ListComponentsResult"),
+        }
+    }
+
+    /// Resolve a component selector hub-local against the registry
+    /// (ADR-0116, issue 1956) — the `ResolveComponent` hop aether-mcp does
+    /// before forwarding a `LoadComponent` to a substrate. Hub-local —
+    /// addressed at `aether.engine` with no engine route. Returns the
+    /// decoded [`ResolveComponentResult`].
+    pub fn resolve_component(&mut self, selector: ComponentSelector) -> ResolveComponentResult {
+        let replies = self.call(None, "aether.engine", &ResolveComponent { selector });
+        let payload = single_reply(&replies, "ResolveComponent");
+        ResolveComponentResult::decode_from_bytes(&payload)
+            .expect("undecodable ResolveComponentResult")
+    }
+
+    /// Load a component into `engine` by registry selector (ADR-0116, issue
+    /// 1956), mirroring aether-mcp's resolve-then-forward: resolve the
+    /// selector hub-local to the wasm bytes + `@actor` export, then forward
+    /// `LoadComponent { wasm, export }` to the engine's `aether.component`
+    /// mailbox. Returns the loaded component's [`Loaded`] (mailbox id,
+    /// lineage address, capabilities). Panics on a resolve / load error.
+    pub fn load_by_selector(&mut self, engine: EngineId, selector: &str) -> Loaded {
+        let resolved = self.resolve_component(ComponentSelector {
+            query: Some(selector.to_owned()),
+            namespace: None,
+            handled_kind: None,
+        });
+        let (wasm, export) = match resolved {
+            ResolveComponentResult::Ok { wasm, export, .. } => (wasm, export),
+            ResolveComponentResult::Err { error } => {
+                panic!("resolve of selector {selector:?} failed: {error}")
+            }
+        };
+        let replies = self.call(
+            Some(engine),
+            "aether.component",
+            &LoadComponent {
+                wasm,
+                name: None,
+                config: Vec::new(),
+                export,
+            },
+        );
+        let payload = single_reply(&replies, "LoadComponent");
+        match LoadResult::decode_from_bytes(&payload) {
+            Some(LoadResult::Ok {
+                mailbox_id,
+                name,
+                capabilities,
+            }) => Loaded {
+                mailbox_id,
+                addr: name,
+                capabilities,
+            },
+            Some(LoadResult::Err { error }) => {
+                panic!("load by selector {selector:?} failed: {error}")
+            }
+            None => panic!("undecodable LoadResult"),
+        }
+    }
+
+    /// Replace the component bound to `mailbox_id` on `engine` with a build
+    /// resolved from a registry selector (ADR-0116, issue 1956) — the
+    /// resolve-then-forward twin of [`replace`](Self::replace), which loads
+    /// by dist stem. Returns the swapped binary's advertised capabilities.
+    pub fn replace_by_selector(
+        &mut self,
+        engine: EngineId,
+        mailbox_id: MailboxId,
+        selector: &str,
+    ) -> ComponentCapabilities {
+        let resolved = self.resolve_component(ComponentSelector {
+            query: Some(selector.to_owned()),
+            namespace: None,
+            handled_kind: None,
+        });
+        let wasm = match resolved {
+            ResolveComponentResult::Ok { wasm, .. } => wasm,
+            ResolveComponentResult::Err { error } => {
+                panic!("resolve of selector {selector:?} failed: {error}")
+            }
+        };
+        let replies = self.call(
+            Some(engine),
+            "aether.component",
+            &ReplaceComponent {
+                mailbox_id,
+                wasm,
+                drain_timeout_ms: None,
+                config: Vec::new(),
+            },
+        );
+        let payload = single_reply(&replies, "ReplaceComponent");
+        match ReplaceResult::decode_from_bytes(&payload) {
+            Some(ReplaceResult::Ok { capabilities }) => capabilities,
+            Some(ReplaceResult::Err { error }) => {
+                panic!("replace by selector {selector:?} failed: {error}")
+            }
+            None => panic!("undecodable ReplaceResult"),
         }
     }
 
@@ -818,6 +969,18 @@ pub fn dist_manifest_present() -> bool {
 /// it. Tests guard their load path with [`dist_manifest_present`] so a
 /// missing manifest skips rather than reaching this panic.
 pub fn read_component_wasm(stem: &str) -> Vec<u8> {
+    let wasm_path = component_wasm_path(stem);
+    fs::read(&wasm_path)
+        .unwrap_or_else(|e| panic!("reading component wasm {} ({e})", wasm_path.display()))
+}
+
+/// The absolute on-disk path of a component wasm by stem, resolved through
+/// `dist/manifest.json` (the #1445 dist tree) — the staged path the
+/// ADR-0116 `upload_component` reads. Tests guard with
+/// [`dist_manifest_present`] before reaching this. Panics with a
+/// `cargo xtask dist` hint if the manifest is absent or the stem is
+/// missing.
+pub fn component_wasm_path(stem: &str) -> PathBuf {
     let dist = dist_dir();
     let manifest_path = dist.join("manifest.json");
     let raw = fs::read_to_string(&manifest_path).unwrap_or_else(|e| {
@@ -831,7 +994,5 @@ pub fn read_component_wasm(stem: &str) -> Vec<u8> {
     let rel = manifest.components.get(stem).unwrap_or_else(|| {
         panic!("component stem {stem:?} is not in dist/manifest.json; run `cargo xtask dist`")
     });
-    let wasm_path = dist.join(rel);
-    fs::read(&wasm_path)
-        .unwrap_or_else(|e| panic!("reading component wasm {} ({e})", wasm_path.display()))
+    dist.join(rel)
 }

--- a/crates/aether-substrate-bundle/tests/fleetbench_component_store.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_component_store.rs
@@ -1,0 +1,302 @@
+//! `FleetBench` hub component-store proof (ADR-0116, issue 1956): drive the
+//! real hub → RPC → engines-cap stack to upload a component wasm
+//! content-addressed, read its manifest straight from the wasm, resolve it
+//! by name / hash / handled-kind attribute, dedup an identical re-upload,
+//! load + replace by selector, and bring a component up from a boot manifest
+//! of selectors.
+//!
+//! Heavy by construction — it boots a hub chassis and forks a real headless
+//! substrate to load components into — so the test lives in `mod
+//! tests::heavy`, which nextest serializes (`serial-heavy`). Headless: no
+//! GPU, no pixel readback.
+
+mod fleetbench;
+
+mod tests {
+    mod heavy {
+        use std::env;
+        use std::fs;
+        use std::process;
+        use std::thread;
+        use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+        use aether_actor::Actor;
+        use aether_capabilities::WasmTrampoline;
+        use aether_data::Kind;
+        use aether_kinds::{
+            ComponentSelector, ListComponents, LogTailResult, ResolveComponentResult, Tick,
+            UploadComponentResult,
+        };
+
+        use crate::fleetbench::{FleetBench, component_wasm_path, dist_manifest_present};
+
+        /// The probe fixture's declared `Actor::NAMESPACE` (distinct from the
+        /// `probe` wasm stem).
+        const PROBE_NAMESPACE: &str = "test_fixture_probe";
+
+        /// The probe's registered ADR-0099 lineage address.
+        fn probe_lineage_addr() -> String {
+            format!(
+                "aether.component/{}:{PROBE_NAMESPACE}",
+                WasmTrampoline::NAMESPACE,
+            )
+        }
+
+        /// Resolve `selector` hub-local and return the matched content hash,
+        /// panicking on an `Err` (no match / ambiguity).
+        fn resolve_hash(bench: &mut FleetBench, selector: ComponentSelector) -> String {
+            match bench.resolve_component(selector) {
+                ResolveComponentResult::Ok { hash, .. } => hash,
+                ResolveComponentResult::Err { error } => panic!("resolve failed: {error}"),
+            }
+        }
+
+        /// Upload the probe by staged path and assert the store ingested it
+        /// content-addressed with a manifest read from the wasm (no execution
+        /// step): the probe's namespace + handled `Tick`, deduping an
+        /// identical re-upload. Returns the content hash.
+        fn upload_and_assert_manifest(bench: &mut FleetBench, probe_path: &str) -> String {
+            let hash = match bench.upload_component(probe_path, Some("probe")) {
+                UploadComponentResult::Ok { hash, name } => {
+                    assert_eq!(
+                        name.as_deref(),
+                        Some("probe"),
+                        "the upload's name is echoed"
+                    );
+                    assert!(!hash.is_empty(), "the content hash is non-empty");
+                    hash
+                }
+                UploadComponentResult::Err { error } => panic!("upload_component failed: {error}"),
+            };
+
+            let all = bench.list_components(&ListComponents::default());
+            let entry = all
+                .iter()
+                .find(|e| e.hash == hash)
+                .unwrap_or_else(|| panic!("uploaded component {hash} should be listed: {all:?}"));
+            assert!(
+                entry
+                    .manifest
+                    .namespaces
+                    .iter()
+                    .any(|n| n == PROBE_NAMESPACE),
+                "the manifest reports the probe's namespace, got {:?}",
+                entry.manifest.namespaces,
+            );
+            assert!(
+                entry.manifest.handled_kinds.contains(&Tick::ID),
+                "the manifest reports the probe handles Tick",
+            );
+            assert_eq!(
+                entry.name.as_deref(),
+                Some("probe"),
+                "the name points at it"
+            );
+
+            // Attribute filters: namespace + handled-kind keep it, a miss drops it.
+            assert!(
+                bench
+                    .list_components(&ListComponents {
+                        namespace: Some(PROBE_NAMESPACE.to_owned()),
+                        handled_kind: None,
+                    })
+                    .iter()
+                    .any(|e| e.hash == hash),
+                "a matching namespace filter keeps the entry",
+            );
+            assert!(
+                bench
+                    .list_components(&ListComponents {
+                        namespace: None,
+                        handled_kind: Some(Tick::ID),
+                    })
+                    .iter()
+                    .any(|e| e.hash == hash),
+                "a matching handled-kind filter keeps the entry",
+            );
+            assert!(
+                !bench
+                    .list_components(&ListComponents {
+                        namespace: Some("not_a_namespace".to_owned()),
+                        handled_kind: None,
+                    })
+                    .iter()
+                    .any(|e| e.hash == hash),
+                "a non-matching namespace filter drops the entry",
+            );
+
+            // A second identical upload dedups to the same content hash.
+            let again = match bench.upload_component(probe_path, None) {
+                UploadComponentResult::Ok { hash, .. } => hash,
+                UploadComponentResult::Err { error } => panic!("re-upload failed: {error}"),
+            };
+            assert_eq!(
+                again, hash,
+                "an identical re-upload dedups to the same hash"
+            );
+            hash
+        }
+
+        /// Upload the probe component by staged path, then assert the store
+        /// ingested it content-addressed with a manifest read from the wasm,
+        /// resolves + loads it by name / hash / handled-kind, dedups an
+        /// identical re-upload, and replaces by hash.
+        #[test]
+        fn fleetbench_uploads_resolves_loads_and_replaces_a_component() {
+            if !dist_manifest_present() {
+                return;
+            }
+            let probe_path = component_wasm_path("probe").to_string_lossy().into_owned();
+            let mut bench = FleetBench::start();
+
+            let hash = upload_and_assert_manifest(&mut bench, &probe_path);
+
+            // Resolve the same component three ways — by name, by hash, and
+            // by a handled-kind attribute — each lands on the probe hash. (A
+            // single namespace can only be loaded once per engine, so the
+            // three selectors are proven equivalent at the resolve hop, then
+            // the one load below proves resolve-and-forward end to end.)
+            assert_eq!(
+                resolve_hash(
+                    &mut bench,
+                    ComponentSelector {
+                        query: Some("probe".to_owned()),
+                        namespace: None,
+                        handled_kind: None,
+                    }
+                ),
+                hash,
+                "the name selector resolves to the probe hash",
+            );
+            assert_eq!(
+                resolve_hash(
+                    &mut bench,
+                    ComponentSelector {
+                        query: Some(hash.clone()),
+                        namespace: None,
+                        handled_kind: None,
+                    }
+                ),
+                hash,
+                "the hash selector resolves to the probe hash",
+            );
+            assert_eq!(
+                resolve_hash(
+                    &mut bench,
+                    ComponentSelector {
+                        query: None,
+                        namespace: None,
+                        handled_kind: Some(Tick::ID),
+                    }
+                ),
+                hash,
+                "the handled-kind attribute selector resolves to the probe hash",
+            );
+
+            // Fork a headless engine, load by selector (resolve-and-forward),
+            // and assert it registers at the lineage address and answers
+            // LogTail (it's live).
+            let engine = bench.spawn_headless();
+            let expected = probe_lineage_addr();
+            let loaded = bench.load_by_selector(engine, "probe");
+            assert_eq!(
+                loaded.addr, expected,
+                "load by selector registers at the lineage addr"
+            );
+            match bench.log_tail(engine, &expected, None) {
+                LogTailResult::Ok { .. } => {}
+                LogTailResult::Err { error } => {
+                    panic!("the loaded probe should answer LogTail, got Err: {error}")
+                }
+            }
+
+            // Replace the loaded component by hash (ADR-0022 in-place swap,
+            // ADR-0116 selector). The trampoline keeps its lineage address.
+            let caps = bench.replace_by_selector(engine, loaded.mailbox_id, &hash);
+            assert!(
+                caps.handlers.iter().any(|h| h.id == Tick::ID),
+                "the replaced probe still advertises its Tick handler",
+            );
+        }
+
+        /// A `spawn_substrate` boot manifest written in component selectors
+        /// brings the component set up reproducibly: aether-mcp pre-resolves
+        /// each selector to bytes and stages a path-based manifest the
+        /// substrate reads at boot (ADR-0116). `FleetBench` mirrors that
+        /// pre-resolution (it speaks raw frames, not aether-mcp): upload,
+        /// resolve hub-local, stage the bytes, and spawn with the manifest.
+        #[test]
+        fn fleetbench_boots_a_component_set_from_a_selector_manifest() {
+            if !dist_manifest_present() {
+                return;
+            }
+            let probe_path = component_wasm_path("probe").to_string_lossy().into_owned();
+            let mut bench = FleetBench::start();
+
+            let hash = match bench.upload_component(&probe_path, Some("probe")) {
+                UploadComponentResult::Ok { hash, .. } => hash,
+                UploadComponentResult::Err { error } => panic!("upload_component failed: {error}"),
+            };
+
+            // Pre-resolve the selector hub-local to the wasm bytes (the
+            // aether-mcp boot-manifest pre-resolution hop), stage them to a
+            // temp wasm file, and write a path-based boot manifest pointing at
+            // it — the same shape aether-mcp's `stage_boot_manifest` produces.
+            let wasm = match bench.resolve_component(ComponentSelector {
+                query: Some(hash),
+                namespace: None,
+                handled_kind: None,
+            }) {
+                ResolveComponentResult::Ok { wasm, .. } => wasm,
+                ResolveComponentResult::Err { error } => {
+                    panic!("resolve for boot manifest failed: {error}")
+                }
+            };
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_or(0, |d| d.as_nanos());
+            let staged_wasm =
+                env::temp_dir().join(format!("aether-fb-boot-{}-{nanos}.wasm", process::id()));
+            fs::write(&staged_wasm, &wasm).expect("stage the resolved boot wasm");
+            let manifest_path =
+                env::temp_dir().join(format!("aether-fb-manifest-{}-{nanos}.json", process::id()));
+            // No explicit `name`: the trampoline registers at the
+            // namespace-derived ADR-0099 lineage address, matching the load
+            // path and `probe_lineage_addr()`.
+            let manifest_json = serde_json::json!({
+                "components": [{ "wasm": staged_wasm.to_string_lossy() }],
+            });
+            fs::write(
+                &manifest_path,
+                serde_json::to_vec(&manifest_json).expect("serialize boot manifest"),
+            )
+            .expect("write boot manifest");
+
+            // Spawn with the boot manifest; the substrate reads it at boot.
+            let engine = bench.spawn_headless_with_boot_manifest(&manifest_path);
+
+            // The autoloaded probe answers LogTail at its lineage address. The
+            // autoload is async at boot, so poll briefly for it.
+            let expected = probe_lineage_addr();
+            let mut answered = false;
+            for _ in 0..30 {
+                if matches!(
+                    bench.log_tail(engine, &expected, None),
+                    LogTailResult::Ok { .. }
+                ) {
+                    answered = true;
+                    break;
+                }
+                thread::sleep(Duration::from_millis(100));
+            }
+            assert!(
+                answered,
+                "the boot-manifest probe should come up and answer LogTail at {expected}",
+            );
+
+            // Best-effort: clean up the staged temp files.
+            let _ = fs::remove_file(&staged_wasm);
+            let _ = fs::remove_file(&manifest_path);
+        }
+    }
+}

--- a/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
+++ b/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
@@ -51,7 +51,7 @@ use aether_kinds::{
 };
 use serde::de::DeserializeOwned;
 use std::str;
-use wasmparser::{Parser, Payload};
+use wasmparser::{BinaryReader, Parser, Payload, ProducersSectionReader};
 
 /// Section name the derive writes to for canonical schema bytes.
 /// Must match `aether-actor-derive`'s
@@ -192,6 +192,55 @@ pub fn read_namespace_from_bytes(wasm: &[u8]) -> Result<Option<String>, String> 
         }
     }
     Ok(None)
+}
+
+/// Read the wasm tool-conventions `producers` custom section (ADR-0116,
+/// issue 1956) and render it as a short single-line provenance string:
+/// `"<field>: <name> <version>; …"` — e.g.
+/// `"language: Rust; processed-by: rustc 1.86.0"`. Returns an empty string
+/// when the section is absent (a component built without producer
+/// metadata) or can't be parsed — provenance is best-effort, not
+/// load-bearing, so a malformed section degrades to empty rather than
+/// failing the upload. The hub stores this in the [`ComponentManifest`]'s
+/// `provenance` field.
+///
+/// [`ComponentManifest`]: aether_kinds::ComponentManifest
+#[must_use]
+pub fn read_producers_from_bytes(wasm: &[u8]) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    for payload in Parser::new(0).parse_all(wasm) {
+        let Ok(Payload::CustomSection(reader)) = payload else {
+            continue;
+        };
+        if reader.name() != "producers" {
+            continue;
+        }
+        let Ok(producers) =
+            ProducersSectionReader::new(BinaryReader::new(reader.data(), reader.data_offset()))
+        else {
+            return String::new();
+        };
+        for field in producers {
+            let Ok(field) = field else { continue };
+            let values: Vec<String> = field
+                .values
+                .into_iter()
+                .filter_map(Result::ok)
+                .map(|v| {
+                    if v.version.is_empty() {
+                        v.name.to_owned()
+                    } else {
+                        format!("{} {}", v.name, v.version)
+                    }
+                })
+                .collect();
+            if !values.is_empty() {
+                parts.push(format!("{}: {}", field.name, values.join(", ")));
+            }
+        }
+        break;
+    }
+    parts.join("; ")
 }
 
 /// One exported actor's receive-side surface within a (possibly


### PR DESCRIPTION
Closes #1956.

## Summary

The final PR of the hub artifact registry arc (#1952). `load_component` / `replace_component` and `spawn_substrate` boot-manifest component entries took an absolute host filesystem path — aether-mcp `fs::read` the bytes and forwarded them — so every caller had to know the local build layout, and a path reference is unreproducible (a stale `target/` silently loads the wrong build). This implements ADR-0116: component wasm joins the artifact-generic, content-addressed store the `aether.engine` cap already owns (#1953) as a second, type-tagged artifact, and the host path is retired from the load surface in favor of a registry selector.

- **Store generalized** (`store.rs`) — the entry manifest becomes a `StoredManifest` enum (`Binary` / `Component`); `list` splits into `list_binaries` / `list_components` (each excludes the other kind). A `component_manifest(wasm)` helper reads the manifest straight from the wasm — namespaces, exported actors + their handled kind ids + `#[fallback]` presence, and `producers`-section provenance — with no execution step, reusing the substrate's `wasmparser` section readers (a new `read_producers_from_bytes` joins them).
- **Engine-cap handlers** (`engine/server.rs`) — `on_upload_component` (read staged path, sha256, dedup, parse manifest, store type-tagged, set name), `on_resolve_component` (selector → wasm bytes + manifest), `on_list_components`, beside the binary handlers on the cap's own store field. Resolution: an exact token (`hash` > `module@actor` > `name` latest) wins first, else a `namespace` / `handled_kind` attribute query — a query matching more than one component is a clean ambiguity error, never a silent pick; a `module@actor` token's `@actor` half threads through to the forwarded `LoadComponent.export` (ADR-0096). A binary hash passed as a component selector is a clean type-tag error.
- **MCP cutover** (`tools.rs` / `args.rs`) — new `upload_component(staged_path, name?)` + `list_components(filter)` tools (hub-local); `load_component` + `replace_component` reworked from `binary_path` to `selector` (resolve hub-local via `ResolveComponent`, forward the returned bytes to the unchanged substrate-side `LoadComponent` / `ReplaceComponent` wire — only the byte *source* moves). `ComponentSpec` boot entries carry selectors; `stage_boot_manifest` pre-resolves each against the registry and stages the bytes, so the substrate boot path stays path-based (the staged files are cleaned up post-spawn). The host path survives only as the `upload_component` input.

`name@version` resolves as `name` (latest) — v1 keeps no per-name version index (deferred per ADR-0116); signature verification stays deferred. No new ADR — ADR-0116 records the design.

## Test plan

Store unit tests (`store.rs`): component upload + dedup, name repoint, resolve by hash / name, list by namespace / handled-kind, the binary-vs-component list split. Engine-cap kind round-trip. A new headless FleetBench (`fleetbench_component_store.rs`, `mod heavy`): upload → `Ok { hash }` with manifest assertions, resolve by name / hash / handled-kind, identical-bytes dedup, load-by-selector with end-to-end liveness, replace-by-hash, and a `spawn_substrate` boot-manifest-by-selector bring-up. Full `scripts/preflight.sh` green (fmt, clippy `-D warnings`, `nextest --workspace` — 2006 light + 109 heavy, all pass, doc, wasm32 component cross-build).

## Generated by

`/implement` — agent execution of [scoped issue #1956](https://github.com/iamacoffeepot/aether/issues/1956).
