### PR TITLE
docs(adr): mark adr-0115 and adr-0116 accepted

### DIFF
--- a/docs/adr/0115-hub-binary-registry.md
+++ b/docs/adr/0115-hub-binary-registry.md
@@ -1,6 +1,6 @@
 # ADR-0115: Hub Binary Registry
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-06-15
 
 ## Context

--- a/docs/adr/0116-component-registry.md
+++ b/docs/adr/0116-component-registry.md
@@ -1,6 +1,6 @@
 # ADR-0116: Component Registry
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-06-15
 
 ## Context


### PR DESCRIPTION
## Summary

The implementation arc for ADR-0115 (hub binary registry) and ADR-0116 (component registry) has fully landed, so flip both records Proposed → Accepted. The flip is the last step of the arc — the ADRs stayed Proposed until the implementation merged.

Landed arc (umbrella #1952):

- #1953 — hub binary store with upload and list (PR #1964)
- #1954 — spawn substrates by registry selector (PR #1968)
- #1956 — load components by registry selector (PR #1973)

Placement language was already amended to "the registry stays in the `aether.engine` cap" in PR #1960; this change only moves the status field.

## Test plan

Docs-only — no code change. ADR status field flip on both files; the rest of each record is untouched.
