### PR TITLE
feat(data): add aether_data::wire, the owned wire format

### DIFF
--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -53,6 +53,7 @@ pub mod schema;
 pub mod tag_bits;
 pub mod tagged_id;
 pub mod transform;
+pub mod wire;
 pub mod wire_id;
 pub use hash::{
     HANDLE_DOMAIN, KIND_DOMAIN, MAILBOX_DOMAIN, MAX_SCOPE_PATH_BYTES, MAX_SCOPE_PATH_DEPTH,

--- a/crates/aether-data/src/wire/de.rs
+++ b/crates/aether-data/src/wire/de.rs
@@ -1,0 +1,350 @@
+//! `serde::Deserializer` over the aether wire format (ADR-0118).
+//!
+//! The format carries no type or field tags, so it is **not** self-describing:
+//! decoding is driven entirely by the requested type. `deserialize_any` and
+//! `deserialize_ignored_any` therefore error — every value is read against a
+//! concrete `deserialize_*` request whose shape matches the schema both ends
+//! already hold. Structs and tuples decode positionally (`visit_seq`); enums
+//! read the `u32` variant index and dispatch.
+
+use core::str::from_utf8;
+
+use serde::de::{
+    self, DeserializeSeed, EnumAccess, IntoDeserializer, MapAccess, SeqAccess, VariantAccess,
+    Visitor,
+};
+
+use super::Error;
+
+/// A cursor over wire bytes (the version byte already stripped by the caller).
+pub struct Deserializer<'de> {
+    input: &'de [u8],
+}
+
+impl<'de> Deserializer<'de> {
+    pub fn new(input: &'de [u8]) -> Self {
+        Self { input }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.input.is_empty()
+    }
+
+    pub fn remaining(&self) -> &'de [u8] {
+        self.input
+    }
+
+    fn take(&mut self, n: usize) -> Result<&'de [u8], Error> {
+        if self.input.len() < n {
+            return Err(Error::UnexpectedEof);
+        }
+        let (head, tail) = self.input.split_at(n);
+        self.input = tail;
+        Ok(head)
+    }
+
+    fn take_array<const N: usize>(&mut self) -> Result<[u8; N], Error> {
+        let mut out = [0u8; N];
+        out.copy_from_slice(self.take(N)?);
+        Ok(out)
+    }
+
+    fn read_byte(&mut self) -> Result<u8, Error> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn read_count(&mut self) -> Result<u32, Error> {
+        Ok(u32::from_le_bytes(self.take_array::<4>()?))
+    }
+
+    fn read_bool(&mut self) -> Result<bool, Error> {
+        match self.read_byte()? {
+            0 => Ok(false),
+            1 => Ok(true),
+            other => Err(Error::InvalidBool(other)),
+        }
+    }
+
+    fn read_str(&mut self) -> Result<&'de str, Error> {
+        let len = self.read_count()? as usize;
+        let bytes = self.take(len)?;
+        from_utf8(bytes).map_err(|_| Error::Utf8)
+    }
+}
+
+impl<'de> de::Deserializer<'de> for &mut Deserializer<'de> {
+    type Error = Error;
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+
+    fn deserialize_any<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Error> {
+        Err(Error::NotSelfDescribing)
+    }
+
+    fn deserialize_ignored_any<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Error> {
+        Err(Error::NotSelfDescribing)
+    }
+
+    fn deserialize_bool<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        visitor.visit_bool(self.read_bool()?)
+    }
+
+    fn deserialize_i8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        visitor.visit_i8(i8::from_le_bytes(self.take_array::<1>()?))
+    }
+    fn deserialize_i16<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        visitor.visit_i16(i16::from_le_bytes(self.take_array::<2>()?))
+    }
+    fn deserialize_i32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        visitor.visit_i32(i32::from_le_bytes(self.take_array::<4>()?))
+    }
+    fn deserialize_i64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        visitor.visit_i64(i64::from_le_bytes(self.take_array::<8>()?))
+    }
+    fn deserialize_i128<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        visitor.visit_i128(i128::from_le_bytes(self.take_array::<16>()?))
+    }
+
+    fn deserialize_u8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        visitor.visit_u8(self.read_byte()?)
+    }
+    fn deserialize_u16<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        visitor.visit_u16(u16::from_le_bytes(self.take_array::<2>()?))
+    }
+    fn deserialize_u32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        visitor.visit_u32(u32::from_le_bytes(self.take_array::<4>()?))
+    }
+    fn deserialize_u64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        visitor.visit_u64(u64::from_le_bytes(self.take_array::<8>()?))
+    }
+    fn deserialize_u128<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        visitor.visit_u128(u128::from_le_bytes(self.take_array::<16>()?))
+    }
+
+    fn deserialize_f32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        visitor.visit_f32(f32::from_le_bytes(self.take_array::<4>()?))
+    }
+    fn deserialize_f64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        visitor.visit_f64(f64::from_le_bytes(self.take_array::<8>()?))
+    }
+
+    fn deserialize_char<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        let code = u32::from_le_bytes(self.take_array::<4>()?);
+        let c = char::from_u32(code).ok_or(Error::InvalidChar(code))?;
+        visitor.visit_char(c)
+    }
+
+    fn deserialize_str<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        visitor.visit_borrowed_str(self.read_str()?)
+    }
+    fn deserialize_string<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        visitor.visit_borrowed_str(self.read_str()?)
+    }
+
+    fn deserialize_bytes<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        let len = self.read_count()? as usize;
+        visitor.visit_borrowed_bytes(self.take(len)?)
+    }
+    fn deserialize_byte_buf<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        let len = self.read_count()? as usize;
+        visitor.visit_borrowed_bytes(self.take(len)?)
+    }
+
+    fn deserialize_option<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        match self.read_byte()? {
+            0 => visitor.visit_none(),
+            1 => visitor.visit_some(self),
+            other => Err(Error::InvalidBool(other)),
+        }
+    }
+
+    fn deserialize_unit<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        visitor.visit_unit()
+    }
+    fn deserialize_unit_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Error> {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_newtype_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Error> {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_seq<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        let remaining = self.read_count()?;
+        visitor.visit_seq(Counted {
+            de: self,
+            remaining,
+        })
+    }
+
+    fn deserialize_tuple<V: Visitor<'de>>(self, len: usize, visitor: V) -> Result<V::Value, Error> {
+        let remaining = u32::try_from(len).map_err(|_| Error::Length)?;
+        visitor.visit_seq(Counted {
+            de: self,
+            remaining,
+        })
+    }
+
+    fn deserialize_tuple_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Error> {
+        let remaining = u32::try_from(len).map_err(|_| Error::Length)?;
+        visitor.visit_seq(Counted {
+            de: self,
+            remaining,
+        })
+    }
+
+    fn deserialize_map<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        let remaining = self.read_count()?;
+        visitor.visit_map(Counted {
+            de: self,
+            remaining,
+        })
+    }
+
+    fn deserialize_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error> {
+        let remaining = u32::try_from(fields.len()).map_err(|_| Error::Length)?;
+        visitor.visit_seq(Counted {
+            de: self,
+            remaining,
+        })
+    }
+
+    fn deserialize_enum<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error> {
+        visitor.visit_enum(Enum { de: self })
+    }
+
+    fn deserialize_identifier<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
+        visitor.visit_u32(u32::from_le_bytes(self.take_array::<4>()?))
+    }
+}
+
+/// `SeqAccess` / `MapAccess` over a fixed remaining count. For `Vec` / `Map` the
+/// count was read from the wire; for tuples / structs / tuple-and-struct enum
+/// variants it is the schema-known field count (no count on the wire).
+struct Counted<'a, 'de> {
+    de: &'a mut Deserializer<'de>,
+    remaining: u32,
+}
+
+impl<'de> SeqAccess<'de> for Counted<'_, 'de> {
+    type Error = Error;
+
+    fn next_element_seed<T: DeserializeSeed<'de>>(
+        &mut self,
+        seed: T,
+    ) -> Result<Option<T::Value>, Error> {
+        if self.remaining == 0 {
+            return Ok(None);
+        }
+        self.remaining -= 1;
+        seed.deserialize(&mut *self.de).map(Some)
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.remaining as usize)
+    }
+}
+
+impl<'de> MapAccess<'de> for Counted<'_, 'de> {
+    type Error = Error;
+
+    fn next_key_seed<K: DeserializeSeed<'de>>(
+        &mut self,
+        seed: K,
+    ) -> Result<Option<K::Value>, Error> {
+        if self.remaining == 0 {
+            return Ok(None);
+        }
+        self.remaining -= 1;
+        seed.deserialize(&mut *self.de).map(Some)
+    }
+
+    fn next_value_seed<V: DeserializeSeed<'de>>(&mut self, seed: V) -> Result<V::Value, Error> {
+        seed.deserialize(&mut *self.de)
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.remaining as usize)
+    }
+}
+
+/// `EnumAccess`: read the `u32` variant index and feed it to the variant seed,
+/// then expose the variant body.
+struct Enum<'a, 'de> {
+    de: &'a mut Deserializer<'de>,
+}
+
+impl<'a, 'de> EnumAccess<'de> for Enum<'a, 'de> {
+    type Error = Error;
+    type Variant = Variant<'a, 'de>;
+
+    fn variant_seed<V: DeserializeSeed<'de>>(
+        self,
+        seed: V,
+    ) -> Result<(V::Value, Self::Variant), Error> {
+        let index = u32::from_le_bytes(self.de.take_array::<4>()?);
+        let value = seed.deserialize(index.into_deserializer())?;
+        Ok((value, Variant { de: self.de }))
+    }
+}
+
+struct Variant<'a, 'de> {
+    de: &'a mut Deserializer<'de>,
+}
+
+impl<'de> VariantAccess<'de> for Variant<'_, 'de> {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn newtype_variant_seed<T: DeserializeSeed<'de>>(self, seed: T) -> Result<T::Value, Error> {
+        seed.deserialize(&mut *self.de)
+    }
+
+    fn tuple_variant<V: Visitor<'de>>(self, len: usize, visitor: V) -> Result<V::Value, Error> {
+        let remaining = u32::try_from(len).map_err(|_| Error::Length)?;
+        visitor.visit_seq(Counted {
+            de: self.de,
+            remaining,
+        })
+    }
+
+    fn struct_variant<V: Visitor<'de>>(
+        self,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error> {
+        let remaining = u32::try_from(fields.len()).map_err(|_| Error::Length)?;
+        visitor.visit_seq(Counted {
+            de: self.de,
+            remaining,
+        })
+    }
+}

--- a/crates/aether-data/src/wire/de.rs
+++ b/crates/aether-data/src/wire/de.rs
@@ -75,15 +75,7 @@ impl<'de> Deserializer<'de> {
 impl<'de> de::Deserializer<'de> for &mut Deserializer<'de> {
     type Error = Error;
 
-    fn is_human_readable(&self) -> bool {
-        false
-    }
-
     fn deserialize_any<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Error> {
-        Err(Error::NotSelfDescribing)
-    }
-
-    fn deserialize_ignored_any<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Error> {
         Err(Error::NotSelfDescribing)
     }
 
@@ -240,6 +232,14 @@ impl<'de> de::Deserializer<'de> for &mut Deserializer<'de> {
 
     fn deserialize_identifier<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Error> {
         visitor.visit_u32(u32::from_le_bytes(self.take_array::<4>()?))
+    }
+
+    fn deserialize_ignored_any<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Error> {
+        Err(Error::NotSelfDescribing)
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
     }
 }
 

--- a/crates/aether-data/src/wire/mod.rs
+++ b/crates/aether-data/src/wire/mod.rs
@@ -1,0 +1,142 @@
+//! The aether wire format (ADR-0118) — the owned, schema-driven, fixed-width
+//! encoding for structured (non-cast) kinds.
+//!
+//! The format is defined here. `serde` is a *consumer* that drives it: the
+//! `ser` adapter walks a Rust value through serde and emits the bytes, and the
+//! `de` adapter reads them back. The schema-driven JSON walker (in
+//! `aether-codec`, step 2 of the ADR-0118 arc) is the other consumer over the
+//! same byte layout; the two must emit identical bytes for the same value,
+//! which is why the encoding carries no type or field tags — both ends already
+//! know the shape (the Rust type, or the `SchemaType`).
+//!
+//! Encoding rules (ADR-0118 §The format):
+//! - little-endian, fixed-width scalars (the declared width; no variable-length
+//!   integers, no zigzag), bit-faithful floats;
+//! - `bool` and option-presence are one byte (`0` / `1`);
+//! - `String` / `Bytes` / `Vec` / `Map` are a `u32` little-endian count, then
+//!   the elements (maps in ascending encoded-key byte order — canonical);
+//! - struct / tuple / array fields are positional, no names, no count;
+//! - sum-type selectors (`Enum`, `Ref`) are a fixed `u32` (serde's
+//!   `variant_index`), then the selected variant's body.
+//!
+//! Nothing in the workspace encodes through this module yet; ADR-0118 step 2
+//! repoints the derive runtime and the schema walker onto it.
+
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::error::Error as StdError;
+use core::fmt;
+
+use serde::de::Error as DeError;
+use serde::ser::Error as SerError;
+use serde::{Deserialize, Serialize};
+
+mod de;
+mod ser;
+
+#[cfg(test)]
+mod tests;
+
+/// Format-version byte prefixing every top-level payload (ADR-0118 §Envelope).
+/// It versions the *encoding*, independent of `KindId` which versions the
+/// *schema*. Nested values carry no version byte — only the top-level
+/// [`to_vec`] / [`from_bytes`] / [`take_from_bytes`] boundary does.
+pub const WIRE_VERSION: u8 = 1;
+
+/// A wire encode or decode failure. Encoding fails only when a length exceeds
+/// the `u32` ceiling; everything else is a decode-side fault.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Error {
+    /// Input ended mid-value.
+    UnexpectedEof,
+    /// A `bool` or option-presence byte was neither `0` nor `1`.
+    InvalidBool(u8),
+    /// The top-level payload did not begin with [`WIRE_VERSION`].
+    BadVersion(u8),
+    /// A length or count exceeded the `u32` ceiling on encode, or the remaining
+    /// input on decode.
+    Length,
+    /// String bytes were not valid UTF-8.
+    Utf8,
+    /// A `char` code point was out of range.
+    InvalidChar(u32),
+    /// [`from_bytes`] left input unconsumed.
+    TrailingBytes,
+    /// A self-describing operation the format cannot serve (`deserialize_any`).
+    NotSelfDescribing,
+    /// A `serde` `custom` message.
+    Message(String),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnexpectedEof => f.write_str("aether wire: unexpected end of input"),
+            Self::InvalidBool(b) => write!(f, "aether wire: invalid bool/presence byte {b}"),
+            Self::BadVersion(v) => write!(f, "aether wire: bad format version byte {v}"),
+            Self::Length => f.write_str("aether wire: length exceeds the u32 ceiling"),
+            Self::Utf8 => f.write_str("aether wire: string is not valid UTF-8"),
+            Self::InvalidChar(c) => write!(f, "aether wire: invalid char code point {c}"),
+            Self::TrailingBytes => f.write_str("aether wire: trailing bytes after value"),
+            Self::NotSelfDescribing => {
+                f.write_str("aether wire: format is not self-describing (deserialize_any)")
+            }
+            Self::Message(m) => f.write_str(m),
+        }
+    }
+}
+
+impl StdError for Error {}
+
+impl SerError for Error {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        Self::Message(msg.to_string())
+    }
+}
+
+impl DeError for Error {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        Self::Message(msg.to_string())
+    }
+}
+
+/// Encode a value to a versioned wire payload: [`WIRE_VERSION`] followed by the
+/// value's encoding.
+pub fn to_vec<T: Serialize + ?Sized>(value: &T) -> Result<Vec<u8>, Error> {
+    let mut serializer = ser::Serializer::new();
+    value.serialize(&mut serializer)?;
+    let body = serializer.into_output();
+    let mut out = Vec::with_capacity(body.len() + 1);
+    out.push(WIRE_VERSION);
+    out.extend_from_slice(&body);
+    Ok(out)
+}
+
+/// Decode a value from a versioned wire payload, requiring every byte consumed.
+pub fn from_bytes<'a, T: Deserialize<'a>>(bytes: &'a [u8]) -> Result<T, Error> {
+    let body = strip_version(bytes)?;
+    let mut deserializer = de::Deserializer::new(body);
+    let value = T::deserialize(&mut deserializer)?;
+    if deserializer.is_empty() {
+        Ok(value)
+    } else {
+        Err(Error::TrailingBytes)
+    }
+}
+
+/// Decode a value from the front of a versioned wire payload, returning the
+/// value and the unconsumed remainder (after the value, not the version byte).
+pub fn take_from_bytes<'a, T: Deserialize<'a>>(bytes: &'a [u8]) -> Result<(T, &'a [u8]), Error> {
+    let body = strip_version(bytes)?;
+    let mut deserializer = de::Deserializer::new(body);
+    let value = T::deserialize(&mut deserializer)?;
+    Ok((value, deserializer.remaining()))
+}
+
+fn strip_version(bytes: &[u8]) -> Result<&[u8], Error> {
+    match bytes.split_first() {
+        Some((&v, rest)) if v == WIRE_VERSION => Ok(rest),
+        Some((&v, _)) => Err(Error::BadVersion(v)),
+        None => Err(Error::UnexpectedEof),
+    }
+}

--- a/crates/aether-data/src/wire/ser.rs
+++ b/crates/aether-data/src/wire/ser.rs
@@ -1,0 +1,371 @@
+//! `serde::Serializer` over the aether wire format (ADR-0118).
+//!
+//! Emits into an owned `Vec<u8>` (no version byte — `super::to_vec` adds that at
+//! the top-level boundary). Collections are length-prefixed with a `u32`; maps
+//! buffer their entries and emit them in ascending encoded-key byte order so the
+//! encoding is canonical. Sum-type selectors are the `u32` `variant_index`.
+
+use alloc::vec::Vec;
+
+use serde::{Serialize, ser};
+
+use super::Error;
+
+/// Accumulates wire bytes for one value.
+pub struct Serializer {
+    output: Vec<u8>,
+}
+
+impl Serializer {
+    pub fn new() -> Self {
+        Self { output: Vec::new() }
+    }
+
+    pub fn into_output(self) -> Vec<u8> {
+        self.output
+    }
+}
+
+/// Encode a nested value to its own buffer (used by the buffered seq/map
+/// serializers, which must measure or reorder before committing to the parent).
+fn encode<T: ?Sized + Serialize>(value: &T) -> Result<Vec<u8>, Error> {
+    let mut sub = Serializer::new();
+    value.serialize(&mut sub)?;
+    Ok(sub.output)
+}
+
+fn write_count(out: &mut Vec<u8>, len: usize) -> Result<(), Error> {
+    let count = u32::try_from(len).map_err(|_| Error::Length)?;
+    out.extend_from_slice(&count.to_le_bytes());
+    Ok(())
+}
+
+impl<'a> ser::Serializer for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    type SerializeSeq = SeqSerializer<'a>;
+    type SerializeTuple = &'a mut Serializer;
+    type SerializeTupleStruct = &'a mut Serializer;
+    type SerializeTupleVariant = &'a mut Serializer;
+    type SerializeMap = MapSerializer<'a>;
+    type SerializeStruct = &'a mut Serializer;
+    type SerializeStructVariant = &'a mut Serializer;
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+
+    fn serialize_bool(self, v: bool) -> Result<(), Error> {
+        self.output.push(u8::from(v));
+        Ok(())
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<(), Error> {
+        self.output.extend_from_slice(&v.to_le_bytes());
+        Ok(())
+    }
+    fn serialize_i16(self, v: i16) -> Result<(), Error> {
+        self.output.extend_from_slice(&v.to_le_bytes());
+        Ok(())
+    }
+    fn serialize_i32(self, v: i32) -> Result<(), Error> {
+        self.output.extend_from_slice(&v.to_le_bytes());
+        Ok(())
+    }
+    fn serialize_i64(self, v: i64) -> Result<(), Error> {
+        self.output.extend_from_slice(&v.to_le_bytes());
+        Ok(())
+    }
+    fn serialize_i128(self, v: i128) -> Result<(), Error> {
+        self.output.extend_from_slice(&v.to_le_bytes());
+        Ok(())
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<(), Error> {
+        self.output.push(v);
+        Ok(())
+    }
+    fn serialize_u16(self, v: u16) -> Result<(), Error> {
+        self.output.extend_from_slice(&v.to_le_bytes());
+        Ok(())
+    }
+    fn serialize_u32(self, v: u32) -> Result<(), Error> {
+        self.output.extend_from_slice(&v.to_le_bytes());
+        Ok(())
+    }
+    fn serialize_u64(self, v: u64) -> Result<(), Error> {
+        self.output.extend_from_slice(&v.to_le_bytes());
+        Ok(())
+    }
+    fn serialize_u128(self, v: u128) -> Result<(), Error> {
+        self.output.extend_from_slice(&v.to_le_bytes());
+        Ok(())
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<(), Error> {
+        self.output.extend_from_slice(&v.to_le_bytes());
+        Ok(())
+    }
+    fn serialize_f64(self, v: f64) -> Result<(), Error> {
+        self.output.extend_from_slice(&v.to_le_bytes());
+        Ok(())
+    }
+
+    fn serialize_char(self, v: char) -> Result<(), Error> {
+        self.output.extend_from_slice(&u32::from(v).to_le_bytes());
+        Ok(())
+    }
+
+    fn serialize_str(self, v: &str) -> Result<(), Error> {
+        write_count(&mut self.output, v.len())?;
+        self.output.extend_from_slice(v.as_bytes());
+        Ok(())
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<(), Error> {
+        write_count(&mut self.output, v.len())?;
+        self.output.extend_from_slice(v);
+        Ok(())
+    }
+
+    fn serialize_none(self) -> Result<(), Error> {
+        self.output.push(0);
+        Ok(())
+    }
+
+    fn serialize_some<T: ?Sized + Serialize>(self, value: &T) -> Result<(), Error> {
+        self.output.push(1);
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<(), Error> {
+        self.output.extend_from_slice(&variant_index.to_le_bytes());
+        Ok(())
+    }
+
+    fn serialize_newtype_struct<T: ?Sized + Serialize>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<(), Error> {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T: ?Sized + Serialize>(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+        value: &T,
+    ) -> Result<(), Error> {
+        self.output.extend_from_slice(&variant_index.to_le_bytes());
+        value.serialize(self)
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<SeqSerializer<'a>, Error> {
+        Ok(SeqSerializer {
+            ser: self,
+            count: 0,
+            buf: Vec::new(),
+        })
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<&'a mut Serializer, Error> {
+        Ok(self)
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<&'a mut Serializer, Error> {
+        Ok(self)
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<&'a mut Serializer, Error> {
+        self.output.extend_from_slice(&variant_index.to_le_bytes());
+        Ok(self)
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<MapSerializer<'a>, Error> {
+        Ok(MapSerializer {
+            ser: self,
+            entries: Vec::new(),
+            key: None,
+        })
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<&'a mut Serializer, Error> {
+        Ok(self)
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<&'a mut Serializer, Error> {
+        self.output.extend_from_slice(&variant_index.to_le_bytes());
+        Ok(self)
+    }
+}
+
+/// Buffered sequence serializer: elements accumulate in `buf` so the `u32` count
+/// can be written ahead of them even when serde reports no length up front.
+pub struct SeqSerializer<'a> {
+    ser: &'a mut Serializer,
+    count: u32,
+    buf: Vec<u8>,
+}
+
+impl ser::SerializeSeq for SeqSerializer<'_> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_element<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), Error> {
+        self.buf.extend_from_slice(&encode(value)?);
+        self.count = self.count.checked_add(1).ok_or(Error::Length)?;
+        Ok(())
+    }
+
+    fn end(self) -> Result<(), Error> {
+        self.ser.output.extend_from_slice(&self.count.to_le_bytes());
+        self.ser.output.extend_from_slice(&self.buf);
+        Ok(())
+    }
+}
+
+impl ser::SerializeTuple for &mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_element<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), Error> {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+impl ser::SerializeTupleStruct for &mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), Error> {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+impl ser::SerializeTupleVariant for &mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), Error> {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+impl ser::SerializeStruct for &mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized + Serialize>(
+        &mut self,
+        _key: &'static str,
+        value: &T,
+    ) -> Result<(), Error> {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+impl ser::SerializeStructVariant for &mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized + Serialize>(
+        &mut self,
+        _key: &'static str,
+        value: &T,
+    ) -> Result<(), Error> {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+/// Buffered map serializer: collects encoded `(key, value)` pairs and emits them
+/// in ascending key-byte order at `end`, so equal maps encode identically.
+pub struct MapSerializer<'a> {
+    ser: &'a mut Serializer,
+    entries: Vec<(Vec<u8>, Vec<u8>)>,
+    key: Option<Vec<u8>>,
+}
+
+impl ser::SerializeMap for MapSerializer<'_> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_key<T: ?Sized + Serialize>(&mut self, key: &T) -> Result<(), Error> {
+        self.key = Some(encode(key)?);
+        Ok(())
+    }
+
+    fn serialize_value<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), Error> {
+        let key = self
+            .key
+            .take()
+            .ok_or_else(|| Error::Message("map value serialized without a key".into()))?;
+        self.entries.push((key, encode(value)?));
+        Ok(())
+    }
+
+    fn end(mut self) -> Result<(), Error> {
+        self.entries.sort_by(|a, b| a.0.cmp(&b.0));
+        write_count(&mut self.ser.output, self.entries.len())?;
+        for (key, value) in self.entries {
+            self.ser.output.extend_from_slice(&key);
+            self.ser.output.extend_from_slice(&value);
+        }
+        Ok(())
+    }
+}

--- a/crates/aether-data/src/wire/ser.rs
+++ b/crates/aether-data/src/wire/ser.rs
@@ -52,10 +52,6 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     type SerializeStruct = &'a mut Serializer;
     type SerializeStructVariant = &'a mut Serializer;
 
-    fn is_human_readable(&self) -> bool {
-        false
-    }
-
     fn serialize_bool(self, v: bool) -> Result<(), Error> {
         self.output.push(u8::from(v));
         Ok(())
@@ -233,6 +229,10 @@ impl<'a> ser::Serializer for &'a mut Serializer {
         self.output.extend_from_slice(&variant_index.to_le_bytes());
         Ok(self)
     }
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
 }
 
 /// Buffered sequence serializer: elements accumulate in `buf` so the `u32` count
@@ -260,78 +260,36 @@ impl ser::SerializeSeq for SeqSerializer<'_> {
     }
 }
 
-impl ser::SerializeTuple for &mut Serializer {
-    type Ok = ();
-    type Error = Error;
+// Tuples, tuple structs/variants, structs, and struct variants all append
+// their elements positionally to the same buffer and write nothing at `end`.
+// One macro emits the five identical pass-through impls (the struct forms take
+// an ignored field-name argument; the tuple forms do not).
+macro_rules! passthrough_serialize {
+    ($trait:ident, $method:ident $(, $key:ident: $key_ty:ty)?) => {
+        impl ser::$trait for &mut Serializer {
+            type Ok = ();
+            type Error = Error;
 
-    fn serialize_element<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), Error> {
-        value.serialize(&mut **self)
-    }
+            fn $method<T: ?Sized + Serialize>(
+                &mut self,
+                $($key: $key_ty,)?
+                value: &T,
+            ) -> Result<(), Error> {
+                value.serialize(&mut **self)
+            }
 
-    fn end(self) -> Result<(), Error> {
-        Ok(())
-    }
+            fn end(self) -> Result<(), Error> {
+                Ok(())
+            }
+        }
+    };
 }
 
-impl ser::SerializeTupleStruct for &mut Serializer {
-    type Ok = ();
-    type Error = Error;
-
-    fn serialize_field<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), Error> {
-        value.serialize(&mut **self)
-    }
-
-    fn end(self) -> Result<(), Error> {
-        Ok(())
-    }
-}
-
-impl ser::SerializeTupleVariant for &mut Serializer {
-    type Ok = ();
-    type Error = Error;
-
-    fn serialize_field<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), Error> {
-        value.serialize(&mut **self)
-    }
-
-    fn end(self) -> Result<(), Error> {
-        Ok(())
-    }
-}
-
-impl ser::SerializeStruct for &mut Serializer {
-    type Ok = ();
-    type Error = Error;
-
-    fn serialize_field<T: ?Sized + Serialize>(
-        &mut self,
-        _key: &'static str,
-        value: &T,
-    ) -> Result<(), Error> {
-        value.serialize(&mut **self)
-    }
-
-    fn end(self) -> Result<(), Error> {
-        Ok(())
-    }
-}
-
-impl ser::SerializeStructVariant for &mut Serializer {
-    type Ok = ();
-    type Error = Error;
-
-    fn serialize_field<T: ?Sized + Serialize>(
-        &mut self,
-        _key: &'static str,
-        value: &T,
-    ) -> Result<(), Error> {
-        value.serialize(&mut **self)
-    }
-
-    fn end(self) -> Result<(), Error> {
-        Ok(())
-    }
-}
+passthrough_serialize!(SerializeTuple, serialize_element);
+passthrough_serialize!(SerializeTupleStruct, serialize_field);
+passthrough_serialize!(SerializeTupleVariant, serialize_field);
+passthrough_serialize!(SerializeStruct, serialize_field, _key: &'static str);
+passthrough_serialize!(SerializeStructVariant, serialize_field, _key: &'static str);
 
 /// Buffered map serializer: collects encoded `(key, value)` pairs and emits them
 /// in ascending key-byte order at `end`, so equal maps encode identically.

--- a/crates/aether-data/src/wire/tests.rs
+++ b/crates/aether-data/src/wire/tests.rs
@@ -154,13 +154,13 @@ impl Kind for Tiny {
     const NAME: &'static str = "test.tiny";
     const ID: KindId = KindId(0xDEAD_BEEF);
 
-    fn encode_into_bytes(&self) -> Vec<u8> {
-        self.0.to_le_bytes().to_vec()
-    }
-
     fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
         let arr: [u8; 4] = bytes.try_into().ok()?;
         Some(Self(u32::from_le_bytes(arr)))
+    }
+
+    fn encode_into_bytes(&self) -> Vec<u8> {
+        self.0.to_le_bytes().to_vec()
     }
 }
 

--- a/crates/aether-data/src/wire/tests.rs
+++ b/crates/aether-data/src/wire/tests.rs
@@ -1,0 +1,249 @@
+//! Conformance + roundtrip tests for the aether wire format (ADR-0118).
+//!
+//! Golden byte vectors pin the encoding to the ADR table (the authoritative
+//! check until step 2 adds the adapter-vs-schema-walker cross-check); roundtrips
+//! confirm the serializer and deserializer mirror each other.
+#![allow(clippy::unwrap_used)]
+
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Serialize, Serializer};
+
+use super::{Error, WIRE_VERSION, from_bytes, take_from_bytes, to_vec};
+use crate::ids::KindId;
+use crate::{Kind, Ref};
+
+fn versioned(body: &[u8]) -> Vec<u8> {
+    let mut out = vec![WIRE_VERSION];
+    out.extend_from_slice(body);
+    out
+}
+
+#[test]
+fn scalars_are_fixed_little_endian() {
+    assert_eq!(to_vec(&0x0403_0201u32).unwrap(), versioned(&[1, 2, 3, 4]));
+    assert_eq!(to_vec(&7u8).unwrap(), versioned(&[7]));
+    assert_eq!(to_vec(&(-1i16)).unwrap(), versioned(&[0xFF, 0xFF]));
+}
+
+#[test]
+fn bool_is_one_byte() {
+    assert_eq!(to_vec(&true).unwrap(), versioned(&[1]));
+    assert_eq!(to_vec(&false).unwrap(), versioned(&[0]));
+}
+
+#[test]
+fn float_is_bit_faithful() {
+    assert_eq!(
+        to_vec(&1.5f32).unwrap()[1..],
+        1.5f32.to_le_bytes()[..],
+        "f32 is its IEEE bits, little-endian"
+    );
+    // A NaN payload survives unchanged (bit-faithful, no normalization).
+    let nan = f64::from_bits(0x7ff8_0000_0000_0001);
+    let back: f64 = from_bytes(&to_vec(&nan).unwrap()).unwrap();
+    assert_eq!(back.to_bits(), nan.to_bits());
+}
+
+#[test]
+fn string_is_u32_len_then_utf8() {
+    assert_eq!(to_vec("hi").unwrap(), versioned(&[2, 0, 0, 0, b'h', b'i']));
+    let back: String = from_bytes(&to_vec("héllo").unwrap()).unwrap();
+    assert_eq!(back, "héllo");
+}
+
+#[test]
+fn option_is_a_presence_byte() {
+    assert_eq!(to_vec(&Some(7u8)).unwrap(), versioned(&[1, 7]));
+    assert_eq!(to_vec(&Option::<u8>::None).unwrap(), versioned(&[0]));
+}
+
+#[test]
+fn vec_is_u32_count_then_elements() {
+    assert_eq!(
+        to_vec(&vec![1u8, 2, 3]).unwrap(),
+        versioned(&[3, 0, 0, 0, 1, 2, 3])
+    );
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+#[test]
+fn struct_fields_are_positional() {
+    let p = Point { x: 1, y: -1 };
+    let mut body = Vec::new();
+    body.extend_from_slice(&1i32.to_le_bytes());
+    body.extend_from_slice(&(-1i32).to_le_bytes());
+    assert_eq!(to_vec(&p).unwrap(), versioned(&body));
+    assert_eq!(from_bytes::<Point>(&to_vec(&p).unwrap()).unwrap(), p);
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+enum Shape {
+    Dot,
+    Circle(u32),
+    Rect { w: u32, h: u32 },
+}
+
+#[test]
+fn enum_selector_is_u32_then_body() {
+    assert_eq!(to_vec(&Shape::Dot).unwrap(), versioned(&[0, 0, 0, 0]));
+
+    let mut circle = Vec::new();
+    circle.extend_from_slice(&1u32.to_le_bytes());
+    circle.extend_from_slice(&5u32.to_le_bytes());
+    assert_eq!(to_vec(&Shape::Circle(5)).unwrap(), versioned(&circle));
+
+    for shape in [Shape::Dot, Shape::Circle(9), Shape::Rect { w: 2, h: 3 }] {
+        let bytes = to_vec(&shape).unwrap();
+        assert_eq!(from_bytes::<Shape>(&bytes).unwrap(), shape);
+    }
+}
+
+/// Emits map entries in a deliberately unsorted order so the serializer's
+/// canonical key-sort is exercised (a `BTreeMap` would already be sorted).
+struct UnsortedMap(Vec<(u8, u8)>);
+
+impl Serialize for UnsortedMap {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(Some(self.0.len()))?;
+        for (k, v) in &self.0 {
+            map.serialize_entry(k, v)?;
+        }
+        map.end()
+    }
+}
+
+#[test]
+fn map_is_canonical_key_sorted() {
+    let unsorted = UnsortedMap(vec![(3, 30), (1, 10), (2, 20)]);
+    assert_eq!(
+        to_vec(&unsorted).unwrap(),
+        versioned(&[3, 0, 0, 0, 1, 10, 2, 20, 3, 30]),
+        "entries emit in ascending key order regardless of insertion order"
+    );
+
+    let mut map = BTreeMap::new();
+    map.insert(1u8, 10u8);
+    map.insert(2u8, 20u8);
+    assert_eq!(
+        from_bytes::<BTreeMap<u8, u8>>(&to_vec(&map).unwrap()).unwrap(),
+        map
+    );
+}
+
+#[test]
+fn typed_ids_are_eight_le_bytes() {
+    let id = KindId(0x0102_0304_0506_0708);
+    assert_eq!(to_vec(&id).unwrap()[1..], id.0.to_le_bytes()[..]);
+    assert_eq!(from_bytes::<KindId>(&to_vec(&id).unwrap()).unwrap().0, id.0);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Tiny(u32);
+
+impl Kind for Tiny {
+    const NAME: &'static str = "test.tiny";
+    const ID: KindId = KindId(0xDEAD_BEEF);
+
+    fn encode_into_bytes(&self) -> Vec<u8> {
+        self.0.to_le_bytes().to_vec()
+    }
+
+    fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+        let arr: [u8; 4] = bytes.try_into().ok()?;
+        Some(Self(u32::from_le_bytes(arr)))
+    }
+}
+
+#[test]
+fn ref_inline_is_selector_len_prefix_then_kind_image() {
+    let r = Ref::<Tiny>::inline(Tiny(7));
+    let mut body = Vec::new();
+    body.extend_from_slice(&0u32.to_le_bytes()); // inline selector
+    body.extend_from_slice(&4u32.to_le_bytes()); // length-prefixed body
+    body.extend_from_slice(&7u32.to_le_bytes()); // Tiny::encode_into_bytes image
+    assert_eq!(to_vec(&r).unwrap(), versioned(&body));
+    assert_eq!(from_bytes::<Ref<Tiny>>(&to_vec(&r).unwrap()).unwrap(), r);
+}
+
+#[test]
+fn ref_handle_is_selector_then_ids() {
+    let r = Ref::<Tiny>::handle(0xCAFE);
+    let mut body = Vec::new();
+    body.extend_from_slice(&1u32.to_le_bytes()); // handle selector
+    body.extend_from_slice(&0xCAFE_u64.to_le_bytes()); // id
+    body.extend_from_slice(&Tiny::ID.0.to_le_bytes()); // kind_id
+    assert_eq!(to_vec(&r).unwrap(), versioned(&body));
+    assert_eq!(from_bytes::<Ref<Tiny>>(&to_vec(&r).unwrap()).unwrap(), r);
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+struct Rich {
+    name: String,
+    tags: Vec<String>,
+    maybe: Option<u64>,
+    nested: Point,
+    flag: bool,
+}
+
+#[test]
+fn nested_value_roundtrips_and_is_deterministic() {
+    let r = Rich {
+        name: "x".into(),
+        tags: vec!["a".into(), "b".into()],
+        maybe: Some(42),
+        nested: Point { x: 5, y: 6 },
+        flag: true,
+    };
+    let bytes = to_vec(&r).unwrap();
+    assert_eq!(to_vec(&r).unwrap(), bytes, "encoding is deterministic");
+    assert_eq!(from_bytes::<Rich>(&bytes).unwrap(), r);
+}
+
+#[test]
+fn from_bytes_rejects_bad_version() {
+    assert_eq!(from_bytes::<u8>(&[99, 1]), Err(Error::BadVersion(99)));
+    assert_eq!(from_bytes::<u8>(&[]), Err(Error::UnexpectedEof));
+}
+
+#[test]
+fn from_bytes_rejects_trailing_bytes() {
+    assert_eq!(
+        from_bytes::<u8>(&[WIRE_VERSION, 1, 2]),
+        Err(Error::TrailingBytes)
+    );
+}
+
+#[test]
+fn truncated_input_is_unexpected_eof() {
+    assert_eq!(
+        from_bytes::<u32>(&[WIRE_VERSION, 1, 2]),
+        Err(Error::UnexpectedEof)
+    );
+}
+
+#[test]
+fn invalid_bool_byte_is_rejected() {
+    assert_eq!(
+        from_bytes::<bool>(&[WIRE_VERSION, 2]),
+        Err(Error::InvalidBool(2))
+    );
+}
+
+#[test]
+fn take_from_bytes_returns_the_remainder() {
+    let mut bytes = to_vec(&7u8).unwrap();
+    bytes.extend_from_slice(&[0xAA, 0xBB]);
+    let (value, rest): (u8, &[u8]) = take_from_bytes(&bytes).unwrap();
+    assert_eq!(value, 7);
+    assert_eq!(rest, &[0xAA, 0xBB]);
+}


### PR DESCRIPTION
Closes #1979.

## Summary

Step 1 of ADR-0118: `aether_data::wire`, the reference implementation of the aether wire format — the owned, schema-driven, fixed-width encoding for structured (non-cast) kinds.

- **Format:** little-endian fixed-width scalars (no variable-length integers, no zigzag), bit-faithful floats; `bool` / option-presence one byte; `String` / `Bytes` / `Vec` / `Map` are a `u32` count then elements (maps in ascending encoded-key byte order — canonical); struct / tuple / array fields positional; sum-type selectors (`Enum`, `Ref`) a fixed `u32` (serde's `variant_index`). A single format-version byte prefixes each top-level payload.
- **Consumer:** a serde `Serializer` / `Deserializer` adapter drives the format (it is not self-describing — `deserialize_any` errors; structs/tuples decode positionally; enums read the `u32` index and dispatch). Public surface is `wire::{to_vec, from_bytes, take_from_bytes}` over a `wire::Error`.
- **Placement:** `aether-data` (`no_std` + alloc), reachable from the foundation without a dependency cycle. `serde` is already a non-optional dependency, so no new dep and no feature gate.

Purely additive — nothing in the workspace encodes through it yet. ADR-0118 step 2 repoints the derive runtime and the `aether-codec` schema-walker onto it (and adds the adapter-vs-walker cross-check); steps 3–4 migrate call sites and drop the `postcard` dependency.

## Test plan

A golden byte-vector conformance suite (`wire/tests.rs`) pins the encoding to the ADR-0118 table — scalars, bool, bit-faithful floats (incl. a preserved NaN payload), string, option, vec, positional struct, every enum arm, canonical map key-sort, 8-byte typed ids, and `Ref` inline (`u32` selector + length-prefixed kind image) / handle — plus roundtrips, determinism, version-byte / trailing-bytes / truncation / invalid-bool error cases, and `take_from_bytes` remainder. The golden fixtures are the authoritative byte check until step 2 adds the cross-check against the schema-walker.

`cargo clippy -p aether-data --all-targets -- -D warnings` and `cargo nextest run -p aether-data` are green (96 tests).

## Generated by

`/implement` — execution of scoped issue #1979.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
