### PR TITLE
refactor(actor): route direct mail-payload codecs through the Kind trait

### DIFF
--- a/crates/aether-actor/src/mail/mod.rs
+++ b/crates/aether-actor/src/mail/mod.rs
@@ -674,10 +674,9 @@ mod tests {
             tag: String::from("greet"),
             ids: alloc::vec![1, 2, 3, 4],
         };
-        let bytes =
-            postcard::to_allocvec(&value).expect("test setup: postcard encodes FakePostcard");
-        // SAFETY: `bytes` (a `Vec<u8>` from postcard) outlives `mail`;
-        // its `(addr, len)` pair is valid for the rest of the body.
+        let bytes = value.encode_into_bytes();
+        // SAFETY: `bytes` (a `Vec<u8>` from the kind encoder) outlives
+        // `mail`; its `(addr, len)` pair is valid for the rest of the body.
         let mail = unsafe {
             Mail::__from_ptr(
                 FakePostcard::ID.0,
@@ -731,8 +730,7 @@ mod tests {
             tag: String::from("x"),
             ids: alloc::vec![],
         };
-        let bytes =
-            postcard::to_allocvec(&value).expect("test setup: postcard encodes FakePostcard");
+        let bytes = value.encode_into_bytes();
         // SAFETY: `bytes` outlives `mail`; the `(addr, len)` pair is
         // valid for `bytes.len()` bytes for the rest of the body.
         let mail = unsafe {
@@ -754,8 +752,7 @@ mod tests {
             tag: String::from("x"),
             ids: alloc::vec![],
         };
-        let bytes =
-            postcard::to_allocvec(&value).expect("test setup: postcard encodes FakePostcard");
+        let bytes = value.encode_into_bytes();
         // SAFETY: `bytes` outlives `mail`; the `(addr, len)` pair is
         // valid for `bytes.len()` bytes for the rest of the body.
         let mail = unsafe {
@@ -777,11 +774,10 @@ mod tests {
             tag: String::from("longer"),
             ids: alloc::vec![1, 2, 3],
         };
-        let bytes =
-            postcard::to_allocvec(&value).expect("test setup: postcard encodes FakePostcard");
+        let bytes = value.encode_into_bytes();
         // Pretend the substrate only wrote the first 2 bytes —
-        // `decode_from_bytes` (postcard arm) gets the truncated slice
-        // and surfaces the parse error as `None`.
+        // `decode_from_bytes` gets the truncated slice and surfaces the
+        // parse error as `None`.
         // SAFETY: `bytes` outlives `mail`; the declared `byte_len=2`
         // is within the actual allocation so the bounded read is
         // valid even though it's deliberately a truncation.

--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -496,19 +496,9 @@ mod native {
             kind: KindId,
             payload: &P,
         ) where
-            P: serde::Serialize,
+            P: Kind,
         {
-            let bytes = match postcard::to_allocvec(payload) {
-                Ok(b) => b,
-                Err(e) => {
-                    tracing::error!(
-                        target: "aether_capabilities::component",
-                        error = %e,
-                        "encode failed forwarding to trampoline; mail dropped",
-                    );
-                    return;
-                }
-            };
+            let bytes = payload.encode_into_bytes();
             let _ =
                 ctx.send_envelope_traced_with_reply_to(recipient, kind, &bytes, ctx.reply_target());
         }

--- a/crates/aether-capabilities/src/dag/tests.rs
+++ b/crates/aether-capabilities/src/dag/tests.rs
@@ -35,7 +35,6 @@ use aether_kinds::{
     Bundle, Cancel, CancelResult, DagDescriptor, DagReapTick, Edge, Node, NodeId, Status,
     StatusResult, Submit, SubmitResult,
 };
-use serde::de::DeserializeOwned;
 
 use aether_substrate::chassis::builder::{Builder, PassiveChassis};
 use aether_substrate::handle_store::HandleStore;
@@ -137,10 +136,7 @@ fn enqueue<K: Kind>(registry: &Registry, mailbox_name: &str, payload: &K, sender
 
 /// Drain egress until a `ToSession` reply of kind `K` arrives, decoding
 /// it via postcard. Panics on timeout.
-fn await_session_reply<K: Kind + DeserializeOwned>(
-    rx: &Receiver<EgressEvent>,
-    timeout: Duration,
-) -> K {
+fn await_session_reply<K: Kind>(rx: &Receiver<EgressEvent>, timeout: Duration) -> K {
     let deadline = Instant::now() + timeout;
     loop {
         let remaining = deadline.saturating_duration_since(Instant::now());
@@ -152,7 +148,7 @@ fn await_session_reply<K: Kind + DeserializeOwned>(
         } = event
             && kind_name == K::NAME
         {
-            return postcard::from_bytes(&payload).expect("decode session reply");
+            return K::decode_from_bytes(&payload).expect("decode session reply");
         }
     }
 }
@@ -223,9 +219,9 @@ fn mbx<A: Actor>() -> MailboxId {
     MailboxId(aether_data::mailbox_id_from_name(A::NAMESPACE).0)
 }
 
-/// Postcard-encode a `TestSourceRequest`.
+/// Encode a `TestSourceRequest` via the kind codec.
 fn source_req(value: u64, fail: bool) -> Vec<u8> {
-    postcard::to_allocvec(&super::test_support::TestSourceRequest { value, fail }).unwrap()
+    super::test_support::TestSourceRequest { value, fail }.encode_into_bytes()
 }
 
 /// The `TestSourceRequest` kind id.
@@ -694,7 +690,7 @@ fn dag_executor_call_collects_multi_reply_bundle() {
     let bundle = run_call_dag_to(&registry, &rx, &recorder, mbx::<TestCallActor>());
     assert_eq!(bundle.elements.len(), 3);
     for (i, el) in bundle.elements.iter().enumerate() {
-        let reply: TestCallReply = postcard::from_bytes(&el.payload).unwrap();
+        let reply = TestCallReply::decode_from_bytes(&el.payload).unwrap();
         assert_eq!(reply.index, i as u64);
     }
 
@@ -721,7 +717,7 @@ fn dag_executor_call_inherited_worker_counts_toward_settlement() {
         1,
         "the deferred worker's reply must land in the bundle, not an already-closed one",
     );
-    let reply: TestCallReply = postcard::from_bytes(&bundle.elements[0].payload).unwrap();
+    let reply = TestCallReply::decode_from_bytes(&bundle.elements[0].payload).unwrap();
     assert_eq!(reply.index, 1);
 
     drop(chassis);

--- a/crates/aether-capabilities/src/engine/proxy.rs
+++ b/crates/aether-capabilities/src/engine/proxy.rs
@@ -837,15 +837,13 @@ mod tests {
         let fwd = aether_kinds::ForwardEnvelope {
             mailbox: echo_mailbox,
             kind: <TestEchoRequest as Kind>::ID,
-            payload: postcard::to_allocvec(&TestEchoRequest { value: 42 })
-                .expect("test setup: TestEchoRequest serializes via postcard"),
+            payload: TestEchoRequest { value: 42 }.encode_into_bytes(),
         };
         mailer.push(
             Mail::new(
                 proxy_mailbox,
                 <aether_kinds::ForwardEnvelope as Kind>::ID,
-                postcard::to_allocvec(&fwd)
-                    .expect("test setup: ForwardEnvelope serializes via postcard"),
+                fwd.encode_into_bytes(),
                 1,
             )
             .with_reply_to(Source::with_correlation(

--- a/crates/aether-capabilities/src/handle.rs
+++ b/crates/aether-capabilities/src/handle.rs
@@ -281,8 +281,7 @@ mod native {
                     kind_id: KindId(0xCAFE),
                     bytes: vec![1, 2, 3, 4, 5],
                 };
-                let bytes = postcard::to_allocvec(&req)
-                    .expect("test setup: HandlePublish serializes via postcard");
+                let bytes = req.encode_into_bytes();
                 handler.enqueue(OwnedDispatch::disarmed(
                     <HandlePublish as Kind>::ID,
                     "aether.handle.publish".to_owned(),
@@ -313,8 +312,8 @@ mod native {
                     EgressEvent::ToSession { payload, .. } => payload,
                     other => panic!("expected ToSession egress, got {other:?}"),
                 };
-                let result: HandlePublishResult = postcard::from_bytes(&payload)
-                    .expect("test setup: HandlePublishResult decodes via postcard");
+                let result = HandlePublishResult::decode_from_bytes(&payload)
+                    .expect("test setup: HandlePublishResult decodes");
                 let HandlePublishResult::Ok {
                     kind_id,
                     id: handle_id,
@@ -363,7 +362,7 @@ mod native {
                 };
 
                 let req = HandleDescribe { max: 16 };
-                let bytes = postcard::to_allocvec(&req).expect("HandleDescribe serializes");
+                let bytes = req.encode_into_bytes();
                 handler.enqueue(OwnedDispatch::disarmed(
                     <HandleDescribe as Kind>::ID,
                     "aether.handle.describe".to_owned(),
@@ -391,8 +390,8 @@ mod native {
                     EgressEvent::ToSession { payload, .. } => payload,
                     other => panic!("expected ToSession egress, got {other:?}"),
                 };
-                let result: HandleDescribeResult =
-                    postcard::from_bytes(&payload).expect("HandleDescribeResult decodes");
+                let result = HandleDescribeResult::decode_from_bytes(&payload)
+                    .expect("HandleDescribeResult decodes");
                 assert_eq!(result.total_entries, 3);
                 assert_eq!(result.in_memory_entries, 3);
                 assert_eq!(result.pinned_entries, 1);

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -1559,7 +1559,7 @@ mod native {
                     color: [1.0, 0.0, 0.5, 0.8],
                 }],
             };
-            let payload = postcard::to_allocvec(&mail).expect("encode DrawSolidQuads");
+            let payload = mail.encode_into_bytes();
             deliver(
                 &registry,
                 RenderCapability::NAMESPACE,

--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -1083,8 +1083,7 @@ mod tests {
 
         // Fire a Call against the echo actor. cid = 0xabc; the cap
         // correlates and ends with ReplyEnd matching the same cid.
-        let echo_payload = postcard::to_allocvec(&TestEchoRequest { value: 42 })
-            .expect("test setup: TestEchoRequest serializes via postcard");
+        let echo_payload = TestEchoRequest { value: 42 }.encode_into_bytes();
         let echo_mailbox = mailbox_id_from_name(<TestEchoActor as Actor>::NAMESPACE);
         write_frame(
             &mut stream,
@@ -1112,7 +1111,7 @@ mod tests {
             other => panic!("expected ReplyEvent, got {other:?}"),
         };
         assert_eq!(envelope.kind, <TestEchoReply as Kind>::ID);
-        let decoded: TestEchoReply = postcard::from_bytes(&envelope.payload).expect("decode reply");
+        let decoded = TestEchoReply::decode_from_bytes(&envelope.payload).expect("decode reply");
         assert_eq!(decoded.value, 42);
 
         // Then the ReplyEnd closes the call.
@@ -1159,12 +1158,12 @@ mod tests {
         let mut stream = connect_to_rpc_server(&chassis, Duration::from_secs(5));
         complete_handshake(&mut stream);
 
-        let payload = postcard::to_allocvec(&SetWindowMode {
+        let payload = SetWindowMode {
             mode: WindowMode::Windowed,
             width: None,
             height: None,
-        })
-        .expect("test setup: SetWindowMode serializes via postcard");
+        }
+        .encode_into_bytes();
         let window_mailbox = mailbox_id_from_name(<HeadlessWindowCapability as Actor>::NAMESPACE);
         write_frame(
             &mut stream,
@@ -1192,8 +1191,8 @@ mod tests {
             other => panic!("expected ReplyEvent, got {other:?}"),
         };
         assert_eq!(envelope.kind, <SetWindowModeResult as Kind>::ID);
-        let decoded: SetWindowModeResult =
-            postcard::from_bytes(&envelope.payload).expect("decode SetWindowModeResult");
+        let decoded = SetWindowModeResult::decode_from_bytes(&envelope.payload)
+            .expect("decode SetWindowModeResult");
         assert!(
             matches!(decoded, SetWindowModeResult::Err { .. }),
             "headless window cap replies Err, got {decoded:?}"
@@ -1228,8 +1227,7 @@ mod tests {
 
         let (_chassis, mut stream) = boot_with_deferred_echo(Duration::from_secs(5));
 
-        let payload = postcard::to_allocvec(&DeferredEchoRequest { value: 99 })
-            .expect("test setup: DeferredEchoRequest serializes via postcard");
+        let payload = DeferredEchoRequest { value: 99 }.encode_into_bytes();
         let mailbox = mailbox_id_from_name(<DeferredEchoActor as Actor>::NAMESPACE);
         write_frame(
             &mut stream,
@@ -1258,8 +1256,8 @@ mod tests {
             other => panic!("expected ReplyEvent for the deferred reply, got {other:?}"),
         };
         assert_eq!(envelope.kind, <DeferredEchoReply as Kind>::ID);
-        let decoded: DeferredEchoReply =
-            postcard::from_bytes(&envelope.payload).expect("decode deferred reply");
+        let decoded =
+            DeferredEchoReply::decode_from_bytes(&envelope.payload).expect("decode deferred reply");
         assert_eq!(decoded.value, 99);
 
         // ReplyEnd follows — settlement fired after the deferred reply,
@@ -1315,21 +1313,19 @@ mod tests {
                 TracedEnvelope {
                     recipient_name: <DeferredEchoActor as Actor>::NAMESPACE.into(),
                     kind_name: <DeferredEchoRequest as Kind>::NAME.into(),
-                    payload: postcard::to_allocvec(&DeferredEchoRequest { value: 11 })
-                        .expect("encode req 11"),
+                    payload: DeferredEchoRequest { value: 11 }.encode_into_bytes(),
                     count: 1,
                 },
                 TracedEnvelope {
                     recipient_name: <DeferredEchoActor as Actor>::NAMESPACE.into(),
                     kind_name: <DeferredEchoRequest as Kind>::NAME.into(),
-                    payload: postcard::to_allocvec(&DeferredEchoRequest { value: 22 })
-                        .expect("encode req 22"),
+                    payload: DeferredEchoRequest { value: 22 }.encode_into_bytes(),
                     count: 1,
                 },
             ],
         };
         let trace_mailbox = mailbox_id_from_name(<TraceDispatchCapability as Actor>::NAMESPACE);
-        let payload = postcard::to_allocvec(&batch).expect("encode DispatchTraced");
+        let payload = batch.encode_into_bytes();
         write_frame(
             &mut stream,
             &WireFrame::Call {
@@ -1361,8 +1357,8 @@ mod tests {
                 WireFrame::ReplyEvent { cid, envelope } => {
                     assert_eq!(cid, 0xbeef);
                     if envelope.kind == <DeferredEchoReply as Kind>::ID {
-                        let decoded: DeferredEchoReply =
-                            postcard::from_bytes(&envelope.payload).expect("decode deferred reply");
+                        let decoded = DeferredEchoReply::decode_from_bytes(&envelope.payload)
+                            .expect("decode deferred reply");
                         deferred_values.push(decoded.value);
                     } else {
                         // Otherwise this is the DispatchTracedAck::Ok
@@ -1423,8 +1419,7 @@ mod tests {
         // Fire-and-forget Call (cid = None). The echo actor will
         // still reply, but with cid None there's no in-flight entry
         // so the reply has no matching correlation and gets dropped.
-        let echo_payload = postcard::to_allocvec(&TestEchoRequest { value: 7 })
-            .expect("test setup: TestEchoRequest serializes via postcard");
+        let echo_payload = TestEchoRequest { value: 7 }.encode_into_bytes();
         let echo_mailbox = mailbox_id_from_name(<TestEchoActor as Actor>::NAMESPACE);
         write_frame(
             &mut stream,
@@ -1633,8 +1628,7 @@ mod tests {
             PeerKind::Client { .. } => panic!("expected Substrate peer kind from server"),
         }
 
-        let echo_payload = postcard::to_allocvec(&TestEchoRequest { value: 42 })
-            .expect("test setup: TestEchoRequest serializes via postcard");
+        let echo_payload = TestEchoRequest { value: 42 }.encode_into_bytes();
         let echo_mailbox = mailbox_id_from_name(<TestEchoActor as Actor>::NAMESPACE);
         let cid = conn
             .client
@@ -1665,7 +1659,7 @@ mod tests {
             other => panic!("expected ReplyEvent, got {other:?}"),
         };
         assert_eq!(envelope.kind, <TestEchoReply as Kind>::ID);
-        let decoded: TestEchoReply = postcard::from_bytes(&envelope.payload).expect("decode reply");
+        let decoded = TestEchoReply::decode_from_bytes(&envelope.payload).expect("decode reply");
         assert_eq!(decoded.value, 42);
 
         // Then ReplyEnd closes the call.

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -600,7 +600,6 @@ mod cap_native {
         use aether_substrate::mail::registry::OwnedDispatch;
         use aether_substrate::mail::registry::{MailboxEntry, Registry};
         use aether_substrate::mail::{MailRef, Source, SourceAddr};
-        use serde::de::DeserializeOwned;
 
         fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>, mpsc::Receiver<EgressEvent>) {
             let registry = Arc::new(Registry::new());
@@ -652,7 +651,7 @@ mod cap_native {
         ) -> R
         where
             K: Kind,
-            R: DeserializeOwned,
+            R: Kind,
         {
             let id = registry
                 .lookup(cap_namespace)
@@ -692,7 +691,7 @@ mod cap_native {
                 EgressEvent::ToSession { payload, .. } => payload,
                 other => panic!("expected ToSession egress, got {other:?}"),
             };
-            postcard::from_bytes(&payload).expect("decode reply")
+            R::decode_from_bytes(&payload).expect("decode reply")
         }
 
         /// Contention-sensitive driver tests: each boots a

--- a/crates/aether-capabilities/src/test_chassis.rs
+++ b/crates/aether-capabilities/src/test_chassis.rs
@@ -31,7 +31,6 @@ use aether_substrate::handle_store::HandleStore;
 use aether_substrate::mail::mailer::Mailer;
 use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
 use aether_substrate::mail::registry::Registry;
-use serde::de::DeserializeOwned;
 
 /// Canonical test chassis. `build()` is unreachable — every consumer
 /// drives the chassis through `Builder::<TestChassis>::new(...)` directly
@@ -158,7 +157,7 @@ pub fn drive_task_completion<A>(
 }
 
 /// Drain egress until a `ToSession` reply of kind `K` arrives, decoding
-/// it via postcard. Skips non-`ToSession` events and replies of other
+/// it via the kind codec. Skips non-`ToSession` events and replies of other
 /// kinds — the content-gen caps spawn a real ephemeral dispatch thread
 /// whose loopback mail (to an unregistered stand-in mailbox in
 /// `new_for_test`) bubbles up as a non-`ToSession` egress, so a cap
@@ -167,7 +166,7 @@ pub fn drive_task_completion<A>(
 /// `aether.anthropic` / `aether.gemini` test modules.
 pub fn decode_session_reply<K>(rx: &Receiver<EgressEvent>) -> K
 where
-    K: Kind + DeserializeOwned,
+    K: Kind,
 {
     loop {
         let event = rx
@@ -178,8 +177,7 @@ where
         } = event
             && kind_name == K::NAME
         {
-            return postcard::from_bytes(&payload)
-                .expect("test: reply payload decodes via postcard");
+            return K::decode_from_bytes(&payload).expect("test: reply payload decodes");
         }
     }
 }
@@ -194,7 +192,7 @@ where
 #[allow(dead_code)]
 pub fn decode_reply<K>(rx: &Receiver<EgressEvent>) -> K
 where
-    K: Kind + DeserializeOwned,
+    K: Kind,
 {
     let event = rx
         .recv_timeout(Duration::from_secs(1))
@@ -206,7 +204,7 @@ where
         panic!("expected ToSession egress, got {event:?}");
     };
     assert_eq!(kind_name, K::NAME);
-    postcard::from_bytes(&payload).expect("test: reply payload decodes via postcard")
+    K::decode_from_bytes(&payload).expect("test: reply payload decodes")
 }
 
 /// Manual tempdir under the system temp root, namespaced by `prefix` and

--- a/crates/aether-capabilities/src/text.rs
+++ b/crates/aether-capabilities/src/text.rs
@@ -1088,8 +1088,8 @@ mod native {
                 } = event
                     && kind_id == DrawTexturedQuads::ID
                 {
-                    return postcard::from_bytes(&payload)
-                        .expect("test: DrawTexturedQuads payload decodes via postcard");
+                    return DrawTexturedQuads::decode_from_bytes(&payload)
+                        .expect("test: DrawTexturedQuads payload decodes");
                 }
             }
         }

--- a/crates/aether-capabilities/src/ui.rs
+++ b/crates/aether-capabilities/src/ui.rs
@@ -328,8 +328,8 @@ mod native {
                 } = event
                     && kind_id == UiClicked::ID
                 {
-                    let decoded: UiClicked =
-                        postcard::from_bytes(&payload).expect("test: decodes UiClicked");
+                    let decoded =
+                        UiClicked::decode_from_bytes(&payload).expect("test: decodes UiClicked");
                     return (recipient_mailbox_id, decoded);
                 }
             }
@@ -405,8 +405,8 @@ mod native {
                 panic!("expected UnresolvedMail for DrawSolidQuads");
             };
             assert_eq!(kind_id, DrawSolidQuads::ID, "expected DrawSolidQuads");
-            let decoded: DrawSolidQuads =
-                postcard::from_bytes(&payload).expect("test: decodes DrawSolidQuads");
+            let decoded =
+                DrawSolidQuads::decode_from_bytes(&payload).expect("test: decodes DrawSolidQuads");
             assert_eq!(decoded.quads.len(), 2, "bar emits track + fill quad");
             assert_eq!(decoded.quads[1].width, 100.0, "fill is frac * full width");
         }
@@ -436,8 +436,8 @@ mod native {
                 panic!("expected UnresolvedMail");
             };
             assert_eq!(kind_id, DrawSolidQuads::ID);
-            let decoded: DrawSolidQuads =
-                postcard::from_bytes(&payload).expect("test: decodes DrawSolidQuads");
+            let decoded =
+                DrawSolidQuads::decode_from_bytes(&payload).expect("test: decodes DrawSolidQuads");
             assert_eq!(
                 decoded.quads[1].width, 200.0,
                 "frac > 1 clamps to full width"
@@ -469,8 +469,8 @@ mod native {
                 panic!("expected UnresolvedMail");
             };
             assert_eq!(kind_id, DrawSolidQuads::ID);
-            let decoded: DrawSolidQuads =
-                postcard::from_bytes(&payload).expect("test: decodes DrawSolidQuads");
+            let decoded =
+                DrawSolidQuads::decode_from_bytes(&payload).expect("test: decodes DrawSolidQuads");
             assert_eq!(decoded.quads[1].width, 0.0, "frac < 0 clamps to zero width");
         }
 
@@ -501,7 +501,7 @@ mod native {
                 panic!("expected UnresolvedMail for DrawText");
             };
             assert_eq!(kind_id, DrawText::ID, "expected DrawText");
-            let decoded: DrawText = postcard::from_bytes(&payload).expect("test: decodes DrawText");
+            let decoded = DrawText::decode_from_bytes(&payload).expect("test: decodes DrawText");
             assert_eq!(decoded.space, QuadSpace::Screen, "label uses Screen space");
             assert_eq!(decoded.origin, [50.0, 100.0], "label origin is (x, y)");
         }

--- a/crates/aether-labyrinth/src/kinds.rs
+++ b/crates/aether-labyrinth/src/kinds.rs
@@ -932,7 +932,8 @@ mod tests {
         }
 
         #[test]
-        fn crossing_classification_postcard_round_trips() {
+        fn crossing_classification_round_trips() {
+            use aether_data::Kind;
             let cls = CrossingClassification {
                 crossings: vec![
                     CrossingVerdict {
@@ -957,10 +958,9 @@ mod tests {
                     },
                 ],
             };
-            let bytes = postcard::to_allocvec(&cls)
-                .expect("test setup: postcard encodes CrossingClassification");
-            let back: CrossingClassification = postcard::from_bytes(&bytes)
-                .expect("test setup: postcard decodes CrossingClassification");
+            let bytes = cls.encode_into_bytes();
+            let back = CrossingClassification::decode_from_bytes(&bytes)
+                .expect("decodes CrossingClassification");
             assert_eq!(back, cls);
         }
 

--- a/crates/aether-labyrinth/src/trajectory.rs
+++ b/crates/aether-labyrinth/src/trajectory.rs
@@ -477,7 +477,7 @@ mod native {
                         y,
                         value,
                     };
-                    let bytes = postcard::to_allocvec(&s).expect("TrajectorySample serializes");
+                    let bytes = s.encode_into_bytes();
                     handler.enqueue(OwnedDispatch::disarmed(
                         <TrajectorySample as Kind>::ID,
                         "aether.trajectory.sample".to_owned(),
@@ -502,7 +502,7 @@ mod native {
                     seed,
                     reason: TrajectoryEndReason::Completed,
                 };
-                let bytes = postcard::to_allocvec(&end).expect("TrajectoryEnd serializes");
+                let bytes = end.encode_into_bytes();
                 handler.enqueue(OwnedDispatch::disarmed(
                     <TrajectoryEnd as Kind>::ID,
                     "aether.trajectory.end".to_owned(),
@@ -531,8 +531,8 @@ mod native {
                     thread::sleep(Duration::from_millis(5));
                 };
 
-                let result: RecordResult =
-                    postcard::from_bytes(&payload).expect("RecordResult decodes via postcard");
+                let result =
+                    RecordResult::decode_from_bytes(&payload).expect("RecordResult decodes");
                 let RecordResult::Ok {
                     seed: out_seed,
                     handle_id,

--- a/crates/aether-mesh-viewer/src/runtime.rs
+++ b/crates/aether-mesh-viewer/src/runtime.rs
@@ -622,16 +622,12 @@ impl MeshViewer {
     /// frames the result through `view_proj`. A decode or mesh failure
     /// leaves the prior cache intact, mirroring the `.dsl` / `.obj` arms.
     fn try_replace_field(&mut self, bytes: &[u8]) -> LoadOutcome {
-        let field: ScalarField = match postcard::from_bytes(bytes) {
-            Ok(field) => field,
-            Err(error) => {
-                tracing::warn!(
-                    target: "aether_mesh_viewer",
-                    error = ?error,
-                    "ScalarField decode failed; keeping prior mesh",
-                );
-                return LoadOutcome::failed(format!("ScalarField decode failed: {error}"));
-            }
+        let Some(field) = ScalarField::decode_from_bytes(bytes) else {
+            tracing::warn!(
+                target: "aether_mesh_viewer",
+                "ScalarField decode failed; keeping prior mesh",
+            );
+            return LoadOutcome::failed("ScalarField decode failed".to_string());
         };
         let expected = (field.width as usize)
             .saturating_mul(field.height as usize)
@@ -1463,7 +1459,7 @@ mod tests {
             ticks: 3,
             values,
         };
-        postcard::to_allocvec(&field).expect("test setup: encode ScalarField")
+        field.encode_into_bytes()
     }
 
     /// Issue 1868: a `.field` load decodes a postcard `ScalarField`,
@@ -1524,7 +1520,7 @@ mod tests {
             ticks: 4,
             values: vec![1u32; 10], // not 4*4*4
         };
-        let bytes = postcard::to_allocvec(&field).expect("encode mismatched field");
+        let bytes = field.encode_into_bytes();
         let outcome = viewer.load_bytes("mismatch.field", &bytes);
         assert!(outcome.error.is_some(), "length mismatch reports a failure");
         assert_eq!(
@@ -1560,7 +1556,7 @@ mod tests {
 
     fn paths_bytes(logs: Vec<aether_kinds::TrajectoryLog>) -> Vec<u8> {
         let set = TrajectorySet { logs };
-        postcard::to_allocvec(&set).expect("test setup: encode TrajectorySet")
+        set.encode_into_bytes()
     }
 
     /// Issue 1870: `segment_tube` emits a `+`-cross of two ribbons (4
@@ -1750,7 +1746,7 @@ mod tests {
             ticks: t,
             values,
         };
-        let bytes = postcard::to_allocvec(&field).expect("encode rate field");
+        let bytes = field.encode_into_bytes();
 
         let mut viewer = empty_viewer();
         let outcome = viewer.load_bytes("rate.field", &bytes);

--- a/crates/aether-mesh-viewer/tests/scenario.rs
+++ b/crates/aether-mesh-viewer/tests/scenario.rs
@@ -20,6 +20,7 @@
 //! `TestBench::builder().namespace_roots(...)` rather than env-var
 //! mutation.
 
+use aether_data::Kind;
 use aether_kinds::{
     LoadComponent, LoadResult, MeshLoadResult, TrajectoryEndReason, TrajectoryLog,
     TrajectorySampleEntry,
@@ -184,7 +185,7 @@ fn field_loads_and_renders() {
         ticks: t,
         values,
     };
-    let bytes = postcard::to_allocvec(&field).expect("encode ScalarField fixture");
+    let bytes = field.encode_into_bytes();
     let path = write_fixture("reach.field", &bytes);
 
     let mut bench = TestBench::builder()
@@ -234,7 +235,7 @@ fn field_then_paths_overlay_renders() {
         ticks: t,
         values: vec![1u32; (w * h * t) as usize],
     };
-    let field_bytes = postcard::to_allocvec(&field).expect("encode ScalarField fixture");
+    let field_bytes = field.encode_into_bytes();
     let field_path = write_fixture("reach.field", &field_bytes);
 
     // Two paths threading the volume; they share the first grid step so
@@ -258,7 +259,7 @@ fn field_then_paths_overlay_renders() {
             make_log(2, &[(0, 0, 0), (1, 1, 0), (2, 2, 1), (3, 3, 1)]),
         ],
     };
-    let paths_bytes = postcard::to_allocvec(&set).expect("encode TrajectorySet fixture");
+    let paths_bytes = set.encode_into_bytes();
     let paths_path = write_fixture("herd.paths", &paths_bytes);
 
     let mut bench = TestBench::builder()
@@ -539,7 +540,7 @@ fn split_corridor_bytes() -> Vec<u8> {
         nodes: vec![node(0, 0, 16), node(1, 0, 8), node(1, 1, 8)],
         edges: vec![flow(0, 1, 5), flow(0, 2, 5)],
     };
-    postcard::to_allocvec(&graph).expect("encode CorridorGraph fixture")
+    graph.encode_into_bytes()
 }
 
 /// Issue 1869 acceptance: load a fixture `CorridorGraph`, scrub to two

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -824,26 +824,20 @@ impl App {
             return;
         }
         if mail.kind() == self.kind_set_window_mode {
-            let payload: SetWindowMode = match postcard::from_bytes(mail.payload()) {
-                Ok(p) => p,
-                Err(e) => {
-                    mail.reply(&SetWindowModeResult::Err {
-                        error: format!("postcard decode failed: {e}"),
-                    });
-                    return;
-                }
+            let Some(payload) = SetWindowMode::decode_from_bytes(mail.payload()) else {
+                mail.reply(&SetWindowModeResult::Err {
+                    error: "SetWindowMode decode failed".to_owned(),
+                });
+                return;
             };
             let result = self.apply_window_mode(payload.mode, payload.width, payload.height);
             mail.reply(&result);
         } else if mail.kind() == self.kind_set_window_title {
-            let payload: SetWindowTitle = match postcard::from_bytes(mail.payload()) {
-                Ok(p) => p,
-                Err(e) => {
-                    mail.reply(&SetWindowTitleResult::Err {
-                        error: format!("postcard decode failed: {e}"),
-                    });
-                    return;
-                }
+            let Some(payload) = SetWindowTitle::decode_from_bytes(mail.payload()) else {
+                mail.reply(&SetWindowTitleResult::Err {
+                    error: "SetWindowTitle decode failed".to_owned(),
+                });
+                return;
             };
             let result = self.apply_window_title(payload.title);
             mail.reply(&result);
@@ -1633,12 +1627,12 @@ mod tests {
         let mail_id = MailId::new(window_mailbox, 2);
         mailer.record_sent_inflight(root);
         let caller_source = Source::with_correlation(SourceAddr::Component(caller_mailbox), 0x99);
-        let bytes = postcard::to_allocvec(&LogTail {
+        let bytes = LogTail {
             max: 8,
             min_level: None,
             since: None,
-        })
-        .expect("encode LogTail");
+        }
+        .encode_into_bytes();
         mailer.push(
             Mail::new(window_mailbox, <LogTail as Kind>::ID, bytes, 1)
                 .with_reply_to(caller_source)
@@ -1711,10 +1705,10 @@ mod tests {
 
         // A `MailId::NONE` push keeps the drained guard disarmed (no armed
         // Call to settle) — the test pins only the skip verdict.
-        let payload = postcard::to_allocvec(&SetWindowTitle {
+        let payload = SetWindowTitle {
             title: "ignored".to_owned(),
-        })
-        .expect("encode SetWindowTitle");
+        }
+        .encode_into_bytes();
         mailer.push(
             Mail::new(window_mailbox, <SetWindowTitle as Kind>::ID, payload, 1).with_lineage(
                 MailId::NONE,
@@ -1753,10 +1747,10 @@ mod tests {
         use aether_substrate::mail::registry::{InboxHandler, Registry};
 
         fn title_payload() -> Vec<u8> {
-            postcard::to_allocvec(&SetWindowTitle {
+            SetWindowTitle {
                 title: "ignored".to_owned(),
-            })
-            .expect("encode SetWindowTitle")
+            }
+            .encode_into_bytes()
         }
 
         let registry = Arc::new(Registry::new());

--- a/crates/aether-substrate/src/actor/native/dispatch_blocking.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch_blocking.rs
@@ -631,9 +631,9 @@ mod tests {
             Answer::ID,
             "reply carries the worker's output kind"
         );
-        // A Component-targeted reply is postcard-encoded by
+        // A Component-targeted reply is encoded through the kind codec by
         // `Mailer::send_reply` (not cast), so decode it the same way.
-        let answer: Answer = postcard::from_bytes(reply.payload.bytes()).expect("reply decodes");
+        let answer = Answer::decode_from_bytes(reply.payload.bytes()).expect("reply decodes");
         assert_eq!(answer, Answer { value: 42 });
         assert_eq!(
             reply.sender.correlation_id, 77,
@@ -784,9 +784,9 @@ mod tests {
         let reply = reply_rx
             .recv_timeout(Duration::from_secs(2))
             .expect("the mapped re-reply lands");
-        // A Component-targeted reply is postcard-encoded by
+        // A Component-targeted reply is encoded through the kind codec by
         // `Mailer::send_reply` (not cast), so decode it the same way.
-        let answer: Answer = postcard::from_bytes(reply.payload.bytes()).expect("reply decodes");
+        let answer = Answer::decode_from_bytes(reply.payload.bytes()).expect("reply decodes");
         assert_eq!(
             answer,
             Answer { value: 107 },

--- a/crates/aether-substrate/src/chassis/settlement.rs
+++ b/crates/aether-substrate/src/chassis/settlement.rs
@@ -44,7 +44,8 @@ use std::time::{Duration, Instant};
 
 use crate::mail::Mail;
 use crate::mail::mailer::Mailer;
-use aether_data::{KindId, MailId, MailboxId};
+use aether_data::{Kind, KindId, MailId, MailboxId};
+use aether_kinds::trace::Settled;
 use crossbeam_channel::{Receiver, RecvTimeoutError, Sender, bounded};
 
 /// Chassis-owned settlement notification registry. Owned by the
@@ -80,8 +81,8 @@ struct Inner {
 enum SettlementSubscriber {
     /// Wake an in-thread waiter on a `bounded(1)` channel.
     Channel(Sender<()>),
-    /// Push a notification mail to `target` via `mailer` with the
-    /// settled root postcard-encoded as the payload.
+    /// Push a notification mail to `target` via `mailer` carrying a
+    /// [`Settled`] with the settled root as the payload.
     Mail {
         target: MailboxId,
         kind: KindId,
@@ -157,8 +158,8 @@ impl SettlementRegistry {
 
     /// Subscribe a mailbox to receive a notification mail when `root`
     /// settles. The notification is a [`Mail`] with the
-    /// given `kind`, the [`MailId`] of the settled root postcard-encoded
-    /// as payload, and `count = 1`. Pre-fires immediately (synchronously
+    /// given `kind`, a [`Settled`] carrying the settled root as payload,
+    /// and `count = 1`. Pre-fires immediately (synchronously
     /// pushes the mail) if `root` has already settled at least once.
     ///
     /// Coexists with [`Self::subscribe_settlement`] — a root can have
@@ -268,22 +269,10 @@ impl SettlementRegistry {
 }
 
 /// Push a settlement-notice mail to `target` via `mailer`. The payload
-/// is the postcard-encoded settled-root [`MailId`]; on encode failure
-/// the notification is dropped (logged at error) — `MailId` is a small
-/// `repr(C)` postcard-shaped struct, so encode failure here is a "this
-/// should never happen" path rather than a recoverable condition.
+/// is a [`Settled`] carrying the settled root, encoded through the kind
+/// codec — the same shape the consumer's `on_settled` handler decodes.
 fn push_settlement_notice(mailer: &Mailer, target: MailboxId, kind: KindId, root: MailId) {
-    let payload = match postcard::to_allocvec(&root) {
-        Ok(p) => p,
-        Err(e) => {
-            tracing::error!(
-                target: "aether_substrate::settlement",
-                error = %e,
-                "settlement registry: postcard encode of MailId failed; notification dropped"
-            );
-            return;
-        }
-    };
+    let payload = Settled { root }.encode_into_bytes();
     mailer.push(Mail::new(target, kind, payload, 1));
 }
 
@@ -616,7 +605,9 @@ mod tests {
         let mail = &captured[0];
         assert_eq!(mail.kind, kind);
         assert_eq!(mail.count, 1);
-        let decoded: MailId = postcard::from_bytes(&mail.payload).expect("decode MailId");
+        let decoded = Settled::decode_from_bytes(&mail.payload)
+            .expect("decode Settled")
+            .root;
         assert_eq!(decoded, r);
     }
 
@@ -639,7 +630,9 @@ mod tests {
         let captured = captured.lock().unwrap();
         assert_eq!(captured.len(), 1);
         assert_eq!(captured[0].kind, kind);
-        let decoded: MailId = postcard::from_bytes(&captured[0].payload).expect("decode MailId");
+        let decoded = Settled::decode_from_bytes(&captured[0].payload)
+            .expect("decode Settled")
+            .root;
         assert_eq!(decoded, r);
     }
 
@@ -664,7 +657,9 @@ mod tests {
         assert_eq!(captured.len(), 3);
         for entry in captured.iter() {
             assert_eq!(entry.kind, kind);
-            let decoded: MailId = postcard::from_bytes(&entry.payload).expect("decode MailId");
+            let decoded = Settled::decode_from_bytes(&entry.payload)
+                .expect("decode Settled")
+                .root;
             assert_eq!(decoded, r);
         }
     }
@@ -712,7 +707,9 @@ mod tests {
 
         let after_r1 = captured.lock().unwrap().clone();
         assert_eq!(after_r1.len(), 1);
-        let decoded: MailId = postcard::from_bytes(&after_r1[0].payload).expect("decode MailId");
+        let decoded = Settled::decode_from_bytes(&after_r1[0].payload)
+            .expect("decode Settled")
+            .root;
         assert_eq!(decoded, r1);
 
         reg.fire_settled(r2);
@@ -720,7 +717,9 @@ mod tests {
 
         let after_r2 = captured.lock().unwrap().clone();
         assert_eq!(after_r2.len(), 2);
-        let decoded: MailId = postcard::from_bytes(&after_r2[1].payload).expect("decode MailId");
+        let decoded = Settled::decode_from_bytes(&after_r2[1].payload)
+            .expect("decode Settled")
+            .root;
         assert_eq!(decoded, r2);
     }
 
@@ -832,7 +831,9 @@ mod tests {
 
         let captured = captured.lock().unwrap();
         assert_eq!(captured.len(), 1);
-        let decoded: MailId = postcard::from_bytes(&captured[0].payload).expect("decode MailId");
+        let decoded = Settled::decode_from_bytes(&captured[0].payload)
+            .expect("decode Settled")
+            .root;
         assert_eq!(decoded, r);
     }
 }

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -1013,7 +1013,7 @@ mod tests {
         let (kind, correlation, payload) = &recorded[0];
         assert_eq!(*kind, <LogTailResult as Kind>::ID);
         assert_eq!(*correlation, 0xCAFE, "correlation echoed onto the reply");
-        match postcard::from_bytes::<LogTailResult>(payload).unwrap() {
+        match LogTailResult::decode_from_bytes(payload).unwrap() {
             LogTailResult::Err { error } => assert!(
                 error.contains(&unknown.to_string()),
                 "error names the recipient id: {error}",
@@ -1099,7 +1099,7 @@ mod tests {
         let (kind, correlation, payload) = &recorded[0];
         assert_eq!(*kind, TraceTailResult::ID);
         assert_eq!(*correlation, 0xCAFE, "correlation echoed onto the reply");
-        match postcard::from_bytes::<TraceTailResult>(payload).unwrap() {
+        match TraceTailResult::decode_from_bytes(payload).unwrap() {
             TraceTailResult::Ok { entries, .. } => assert!(
                 entries
                     .iter()


### PR DESCRIPTION
## What

Prerequisite for #1983 (ADR-0118 step 2A). Route every direct-postcard **mail-payload** site through `Kind::encode_into_bytes` / `decode_from_bytes`, so the format flip in #1983 becomes a clean backend + walker change with nothing bypassing the trait.

This is a **byte-identical no-op** today — the trait still does postcard until #1983 — proven by the full workspace suite staying green (2142 tests, including the heavy FleetBench set).

## Why

After #1983 flips the `Kind`-trait backend to `aether_data::wire`, any site that encodes/decodes a kind mail payload by calling `postcard` directly would exchange postcard bytes with trait/walker peers that now speak `wire` — a silent wire mismatch on live mail paths. Migrating those sites onto the trait now, while the bytes don't change, removes the hazard ahead of the flip.

## How each site was classified

Every postcard site was **traced to its decode peer** before migrating (the lesson of the first scope bounce: the original site list named `mail/mod.rs:439` as `Mail::as_kind` when it is actually `PriorState::as_kind`, a closed persistence pair). A site is migrated only if it encodes/decodes a kind payload that crosses the mail wire to a peer decoding via the trait or the walker.

### Prod sites migrated
- `aether-capabilities` `forward_to_trampoline` — `P: Serialize` → `P: Kind` (bound tightened); the only public-surface change.
- `aether-substrate` settlement-notice producer — now emits a `Settled` kind (byte-identical to the bare `MailId`: single-field struct), matching the consumer's `on_settled` decode.
- `aether-substrate-bundle` desktop window driver — `SetWindowMode` / `SetWindowTitle` mail decodes (found during the implement-time workspace sweep; this crate wasn't in the original scope surface).
- `aether-mesh-viewer` `try_replace_field` `ScalarField` decode — brought in line with its already-trait-routed `TrajectorySet` / `CorridorGraph` siblings.

### Test mail-payload sites migrated
`decode_kind` setups (aether-actor), the `test_chassis` / `tcp` / `dag` reply decoders (bounds tightened `DeserializeOwned` → `Kind`, unused imports dropped), rpc/engine/render/handle/ui/text echo+reply payloads, the settlement notice decodes (now decode `Settled`), the log/trace-tail and `Answer` reply decodes, and the mesh-viewer / labyrinth / desktop-driver fixture encodes.

### Deliberately left (traced, out of scope)
- **#1983 (flip with the walker):** the derive-runtime `encode_postcard`/`decode_postcard` backend + `DecodeError::Postcard`; the bare-`Ref::Handle` walker emission in `dag/executor.rs`; the mailer's ADR-0045 Ref-resolution test section (walker-conformance + hand-rolled test-Kind impls — `wire ≠ postcard`, so not byte-identical here).
- **#1984:** the canonical / `KindShape` / manifest path.
- **#1985:** handle-store snapshots, `schema_postcard`, the actor-state persistence pair, and self-contained kind roundtrip tests in aether-kinds/aether-data (self-consistent — they don't break at the flip).

## Notes
- `chassis/helpers.rs::decode_payload` (a pub control-plane decode helper) has **zero callers** — stale doc, dead code. Left as-is and flagged for #1985 rather than migrating dead code into this PR.

Closes #1986.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
