### PR TITLE
refactor(data): switch the mail-payload codec onto aether_data::wire (ADR-0118 step 2A)

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -88,8 +88,9 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
 
     // ADR-0033 wire-shape autodetect: `#[repr(C)]` on the type means
     // the substrate carried it as raw cast bytes (and the user has
-    // `#[derive(Pod, Zeroable)]`); anything else is postcard-shaped
-    // (and the user has `#[derive(Serialize, Deserialize)]`). The
+    // `#[derive(Pod, Zeroable)]`); anything else is wire-shaped
+    // (ADR-0118 `aether_data::wire`, and the user has
+    // `#[derive(Serialize, Deserialize)]`). The
     // dispatcher in `#[actor]` calls `Kind::decode_from_bytes` via
     // `Mail::decode_kind::<K>()`; emitting the body per-impl here is
     // what lets that one call site compile against types whose Pod /
@@ -98,16 +99,16 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
     let decode_body = if has_repr_c {
         quote! { ::aether_data::__derive_runtime::decode_cast::<Self>(bytes) }
     } else {
-        quote! { ::aether_data::__derive_runtime::decode_postcard::<Self>(bytes) }
+        quote! { ::aether_data::__derive_runtime::decode_wire::<Self>(bytes) }
     };
     // Issue #240: encode mirror. Same `#[repr(C)]` autodetect as
     // `decode_body` — a single `Sink::send` call site routes through
-    // `Kind::encode_into_bytes`, picking cast or postcard at the
+    // `Kind::encode_into_bytes`, picking cast or wire at the
     // kind's derive instead of at every send site.
     let encode_body = if has_repr_c {
         quote! { ::aether_data::__derive_runtime::encode_cast::<Self>(self) }
     } else {
-        quote! { ::aether_data::__derive_runtime::encode_postcard::<Self>(self) }
+        quote! { ::aether_data::__derive_runtime::encode_wire::<Self>(self) }
     };
 
     // ADR-0032 section emission goes through trait dispatch, not a

--- a/crates/aether-capabilities/src/dag.rs
+++ b/crates/aether-capabilities/src/dag.rs
@@ -100,7 +100,12 @@ mod native {
                         if reap_shutdown_for_thread.load(Ordering::Acquire) {
                             break;
                         }
-                        timer_mailer.push(Mail::new(self_id, reap_kind, Vec::new(), 1));
+                        timer_mailer.push(Mail::new(
+                            self_id,
+                            reap_kind,
+                            DagReapTick::default().encode_into_bytes(),
+                            1,
+                        ));
                     }
                 });
             if let Err(e) = spawned {

--- a/crates/aether-capabilities/src/engine/proxy.rs
+++ b/crates/aether-capabilities/src/engine/proxy.rs
@@ -445,7 +445,12 @@ mod proxy_native {
                 // proxy dropped the sender) returns otherwise and ends
                 // the loop.
                 while stop_rx.recv_timeout(interval) == Err(mpsc::RecvTimeoutError::Timeout) {
-                    mailer.push(Mail::new(self_mailbox, tick_kind, Vec::new(), 1));
+                    mailer.push(Mail::new(
+                        self_mailbox,
+                        tick_kind,
+                        EngineHeartbeatTick::default().encode_into_bytes(),
+                        1,
+                    ));
                 }
             })
             .expect("spawn aether-engine-heartbeat thread");
@@ -478,7 +483,12 @@ mod proxy_native {
             // closure, so a retry needs a fresh one.
             let wake_mailer = Arc::clone(mailer);
             let on_frame = move || {
-                wake_mailer.push(Mail::new(self_mailbox, wake_kind, Vec::new(), 1));
+                wake_mailer.push(Mail::new(
+                    self_mailbox,
+                    wake_kind,
+                    RpcInboundReady::default().encode_into_bytes(),
+                    1,
+                ));
             };
             return match RpcClient::connect(
                 addr,

--- a/crates/aether-capabilities/src/http_server.rs
+++ b/crates/aether-capabilities/src/http_server.rs
@@ -294,8 +294,12 @@ mod server_native {
             if self.inbound_tx.send(event).is_err() {
                 return false;
             }
-            self.mailer
-                .push(Mail::new(self.self_id, self.wake_kind, Vec::new(), 1));
+            self.mailer.push(Mail::new(
+                self.self_id,
+                self.wake_kind,
+                HttpInboundReady::default().encode_into_bytes(),
+                1,
+            ));
             true
         }
     }

--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -230,7 +230,12 @@ mod server_native {
                             {
                                 break;
                             }
-                            mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
+                            mailer.push(Mail::new(
+                                self_id,
+                                wake_kind,
+                                RpcInboundReady::default().encode_into_bytes(),
+                                1,
+                            ));
                         } else if accept_shutdown_for_thread.load(Ordering::Acquire) {
                             break;
                         }
@@ -766,14 +771,24 @@ mod server_native {
                     {
                         return;
                     }
-                    mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
+                    mailer.push(Mail::new(
+                        self_id,
+                        wake_kind,
+                        RpcInboundReady::default().encode_into_bytes(),
+                        1,
+                    ));
                 }
                 Err(FrameError::Io(io_err)) if io_err.kind() == io::ErrorKind::UnexpectedEof => {
                     let _ = inbound_tx.send(InboundEvent::ReaderClosed {
                         conn_id,
                         reason: "eof".into(),
                     });
-                    mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
+                    mailer.push(Mail::new(
+                        self_id,
+                        wake_kind,
+                        RpcInboundReady::default().encode_into_bytes(),
+                        1,
+                    ));
                     return;
                 }
                 Err(FrameError::FrameTooLarge { size, max }) => {
@@ -799,7 +814,12 @@ mod server_native {
                         conn_id,
                         reason: format!("read error: {e}"),
                     });
-                    mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
+                    mailer.push(Mail::new(
+                        self_id,
+                        wake_kind,
+                        RpcInboundReady::default().encode_into_bytes(),
+                        1,
+                    ));
                     return;
                 }
             }
@@ -850,7 +870,12 @@ mod server_native {
             if inbound_tx.send(event).is_err() {
                 return OversizeOutcome::Terminal;
             }
-            mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
+            mailer.push(Mail::new(
+                self_id,
+                wake_kind,
+                RpcInboundReady::default().encode_into_bytes(),
+                1,
+            ));
             return OversizeOutcome::Terminal;
         }
         // `take(size)` bounds the drain so a racy / lying peer can't
@@ -863,7 +888,12 @@ mod server_native {
                 conn_id,
                 reason: format!("frame too large drain failed: {size} > {max}"),
             });
-            mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
+            mailer.push(Mail::new(
+                self_id,
+                wake_kind,
+                RpcInboundReady::default().encode_into_bytes(),
+                1,
+            ));
             return OversizeOutcome::Terminal;
         };
         if (drained as usize) != size {
@@ -872,7 +902,12 @@ mod server_native {
                 conn_id,
                 reason: format!("frame too large partial drain: {drained}/{size}"),
             });
-            mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
+            mailer.push(Mail::new(
+                self_id,
+                wake_kind,
+                RpcInboundReady::default().encode_into_bytes(),
+                1,
+            ));
             return OversizeOutcome::Terminal;
         }
         let event = InboundEvent::FrameDecodeError {
@@ -885,7 +920,12 @@ mod server_native {
         if inbound_tx.send(event).is_err() {
             return OversizeOutcome::Terminal;
         }
-        mailer.push(Mail::new(self_id, wake_kind, Vec::new(), 1));
+        mailer.push(Mail::new(
+            self_id,
+            wake_kind,
+            RpcInboundReady::default().encode_into_bytes(),
+            1,
+        ));
         OversizeOutcome::Continue
     }
 }

--- a/crates/aether-capabilities/src/tcp/listener.rs
+++ b/crates/aether-capabilities/src/tcp/listener.rs
@@ -121,11 +121,18 @@ mod listener_native {
                                 break;
                             }
                             // Wake the dispatcher: the actual
-                            // stream is in the mpsc; this mail
-                            // just signals "drain me". Empty
-                            // payload (postcard encodes a unit
-                            // struct as zero bytes).
-                            mailer.push(Mail::new(self_id, connection_ready_kind, Vec::new(), 1));
+                            // stream is in the mpsc; this mail just
+                            // signals "drain me". The payload is the
+                            // wake kind's own wire image (a single
+                            // `WIRE_VERSION` byte for a fieldless wire
+                            // kind, ADR-0118) so the typed handler
+                            // decodes it.
+                            mailer.push(Mail::new(
+                                self_id,
+                                connection_ready_kind,
+                                ConnectionReady::default().encode_into_bytes(),
+                                1,
+                            ));
                         } else if shutdown_for_thread.load(Ordering::Acquire) {
                             break;
                         }

--- a/crates/aether-capabilities/src/tcp/session.rs
+++ b/crates/aether-capabilities/src/tcp/session.rs
@@ -141,7 +141,7 @@ mod session_native {
                                 mailer_for_thread.push(Mail::new(
                                     self_id,
                                     data_ready_kind,
-                                    Vec::new(),
+                                    SessionDataReady::default().encode_into_bytes(),
                                     1,
                                 ));
                                 break;
@@ -154,7 +154,7 @@ mod session_native {
                                 mailer_for_thread.push(Mail::new(
                                     self_id,
                                     data_ready_kind,
-                                    Vec::new(),
+                                    SessionDataReady::default().encode_into_bytes(),
                                     1,
                                 ));
                             }
@@ -167,7 +167,7 @@ mod session_native {
                                 mailer_for_thread.push(Mail::new(
                                     self_id,
                                     data_ready_kind,
-                                    Vec::new(),
+                                    SessionDataReady::default().encode_into_bytes(),
                                     1,
                                 ));
                                 break;

--- a/crates/aether-codec/src/conformance.rs
+++ b/crates/aether-codec/src/conformance.rs
@@ -1,0 +1,343 @@
+//! Adapter-vs-walker conformance for the `aether_data::wire` format
+//! (ADR-0118 step 2A). Two independent encoders write the same byte
+//! layout: the serde adapter (`aether_data::wire::{to_vec, from_bytes}`,
+//! driven by a Rust type) and this crate's schema-driven JSON walker
+//! (`encode_schema` / `decode_schema`, driven by a `SchemaType`). They
+//! must agree byte-for-byte for the same logical value, or a kind sent
+//! over the hub's JSON path would decode differently from one sent
+//! through the guest's typed path.
+//!
+//! The deferred cross-check from #1980: for every fixture, assert
+//!
+//! ```text
+//! wire::to_vec(value)              == encode_schema(json, schema)
+//! decode_schema(wire::to_vec(v), s) == json
+//! wire::from_bytes(encode_schema(j, s)) == value
+//! ```
+//!
+//! all three over versioned images on both sides — the serde adapter
+//! and both halves of the schema walker. The handle-store walker (the
+//! third reader of this layout) is pinned to the same bytes by its own
+//! round-trip tests in `aether-substrate`.
+
+#![cfg(test)]
+
+use core::fmt::Debug;
+
+use aether_data::wire;
+use aether_data::{Kind, KindId, Primitive, Ref, SchemaCell, SchemaType};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use serde_json::{Value, json};
+
+use crate::test_fixtures::{named, postcard_struct, scalar};
+use crate::{decode_schema, encode_schema};
+
+/// The conformance law for one `(value, schema, json)` fixture: the
+/// serde adapter and the schema walker emit identical versioned bytes,
+/// and each side decodes the other's bytes back to the canonical form.
+fn check<T>(value: &T, schema: &SchemaType, json: &Value)
+where
+    T: Serialize + DeserializeOwned + PartialEq + Debug,
+{
+    let adapter = wire::to_vec(value).expect("wire adapter encode");
+    let walker = encode_schema(json, schema).expect("schema walker encode");
+    assert_eq!(
+        adapter, walker,
+        "adapter vs walker encode bytes diverge for {json}"
+    );
+
+    let decoded_json = decode_schema(&adapter, schema).expect("walker decode of adapter bytes");
+    assert_eq!(
+        &decoded_json, json,
+        "walker decode of adapter bytes diverges for {json}"
+    );
+
+    let decoded_value: T = wire::from_bytes(&walker).expect("adapter decode of walker bytes");
+    assert_eq!(
+        &decoded_value, value,
+        "adapter decode of walker bytes diverges"
+    );
+}
+
+#[derive(Serialize, serde::Deserialize, PartialEq, Debug)]
+struct Scalars {
+    a: u8,
+    b: u16,
+    c: u32,
+    d: u64,
+    e: i8,
+    f: i16,
+    g: i32,
+    h: i64,
+    x: f32,
+    y: f64,
+    flag: bool,
+    label: String,
+}
+
+fn scalars_schema() -> SchemaType {
+    postcard_struct(vec![
+        scalar("a", Primitive::U8),
+        scalar("b", Primitive::U16),
+        scalar("c", Primitive::U32),
+        scalar("d", Primitive::U64),
+        scalar("e", Primitive::I8),
+        scalar("f", Primitive::I16),
+        scalar("g", Primitive::I32),
+        scalar("h", Primitive::I64),
+        scalar("x", Primitive::F32),
+        scalar("y", Primitive::F64),
+        named("flag", SchemaType::Bool),
+        named("label", SchemaType::String),
+    ])
+}
+
+#[test]
+fn scalars_conform() {
+    let value = Scalars {
+        a: 1,
+        b: 0x0102,
+        c: 0x0102_0304,
+        d: 0x0102_0304_0506_0708,
+        e: -1,
+        f: -300,
+        g: -70_000,
+        h: -5_000_000_000,
+        x: 1.5,
+        y: -2.25,
+        flag: true,
+        label: "héllo".into(),
+    };
+    let json = json!({
+        "a": 1u8,
+        "b": 0x0102u16,
+        "c": 0x0102_0304u32,
+        "d": 0x0102_0304_0506_0708u64,
+        "e": -1i8,
+        "f": -300i16,
+        "g": -70_000i32,
+        "h": -5_000_000_000i64,
+        "x": 1.5,
+        "y": -2.25,
+        "flag": true,
+        "label": "héllo",
+    });
+    check(&value, &scalars_schema(), &json);
+}
+
+#[derive(Serialize, serde::Deserialize, PartialEq, Debug)]
+struct Inner {
+    seq: u32,
+}
+
+#[derive(Serialize, serde::Deserialize, PartialEq, Debug)]
+struct Collections {
+    tags: Vec<String>,
+    maybe_some: Option<u64>,
+    maybe_none: Option<u64>,
+    triple: [u32; 3],
+    blob: Vec<u8>,
+    nested: Inner,
+}
+
+fn collections_schema() -> SchemaType {
+    postcard_struct(vec![
+        named(
+            "tags",
+            SchemaType::Vec(SchemaCell::owned(SchemaType::String)),
+        ),
+        named(
+            "maybe_some",
+            SchemaType::Option(SchemaCell::owned(SchemaType::Scalar(Primitive::U64))),
+        ),
+        named(
+            "maybe_none",
+            SchemaType::Option(SchemaCell::owned(SchemaType::Scalar(Primitive::U64))),
+        ),
+        named(
+            "triple",
+            SchemaType::Array {
+                element: SchemaCell::owned(SchemaType::Scalar(Primitive::U32)),
+                len: 3,
+            },
+        ),
+        named("blob", SchemaType::Bytes),
+        named(
+            "nested",
+            postcard_struct(vec![scalar("seq", Primitive::U32)]),
+        ),
+    ])
+}
+
+#[test]
+fn collections_conform() {
+    let value = Collections {
+        tags: vec!["alpha".into(), "beta".into()],
+        maybe_some: Some(0x0102_0304_0506_0708),
+        maybe_none: None,
+        triple: [1, 0x0001_0000, 0xFFFF_FFFF],
+        blob: vec![0, 1, 2, 200, 255],
+        nested: Inner { seq: 0xDEAD_BEEF },
+    };
+    let json = json!({
+        "tags": ["alpha", "beta"],
+        "maybe_some": 0x0102_0304_0506_0708u64,
+        "maybe_none": null,
+        "triple": [1u32, 0x0001_0000u32, 0xFFFF_FFFFu32],
+        "blob": [0, 1, 2, 200, 255],
+        "nested": { "seq": 0xDEAD_BEEFu32 },
+    });
+    check(&value, &collections_schema(), &json);
+}
+
+#[derive(Serialize, serde::Deserialize, PartialEq, Debug)]
+enum Sum {
+    Pending,
+    Ok(u64),
+    Pair(u32, i16),
+    Err { reason: String },
+}
+
+fn sum_schema() -> SchemaType {
+    use aether_data::EnumVariant;
+    SchemaType::Enum {
+        variants: vec![
+            EnumVariant::Unit {
+                name: "Pending".into(),
+                discriminant: 0,
+            },
+            EnumVariant::Tuple {
+                name: "Ok".into(),
+                discriminant: 1,
+                fields: vec![SchemaType::Scalar(Primitive::U64)].into(),
+            },
+            EnumVariant::Tuple {
+                name: "Pair".into(),
+                discriminant: 2,
+                fields: vec![
+                    SchemaType::Scalar(Primitive::U32),
+                    SchemaType::Scalar(Primitive::I16),
+                ]
+                .into(),
+            },
+            EnumVariant::Struct {
+                name: "Err".into(),
+                discriminant: 3,
+                fields: vec![named("reason", SchemaType::String)].into(),
+            },
+        ]
+        .into(),
+    }
+}
+
+#[test]
+fn enum_variants_conform() {
+    check(&Sum::Pending, &sum_schema(), &json!("Pending"));
+    check(
+        &Sum::Ok(0x0102_0304),
+        &sum_schema(),
+        &json!({ "Ok": 0x0102_0304u64 }),
+    );
+    check(
+        &Sum::Pair(7, -3),
+        &sum_schema(),
+        &json!({ "Pair": [7u32, -3i16] }),
+    );
+    check(
+        &Sum::Err {
+            reason: "boom".into(),
+        },
+        &sum_schema(),
+        &json!({ "Err": { "reason": "boom" } }),
+    );
+}
+
+#[test]
+fn map_keys_conform_in_encoded_byte_order() {
+    use std::collections::BTreeMap;
+    // Keys 1 and 256 sort numerically as 1 < 256 but in little-endian
+    // u32 bytes as 256 < 1 — the multi-byte key case the encoded-byte
+    // map ordering must reproduce.
+    let mut value: BTreeMap<u32, String> = BTreeMap::new();
+    value.insert(1, "one".into());
+    value.insert(256, "two-fifty-six".into());
+    let schema = SchemaType::Map {
+        key: SchemaCell::owned(SchemaType::Scalar(Primitive::U32)),
+        value: SchemaCell::owned(SchemaType::String),
+    };
+    let json = json!({ "1": "one", "256": "two-fifty-six" });
+    check(&value, &schema, &json);
+}
+
+// A wire-shaped inner kind for the `Ref` fixtures. Hand-rolled (not
+// derived) so the conformance module stays free of the `Kind` derive's
+// inventory machinery; its codec is `wire`, matching the schema-walker's
+// non-cast path.
+#[derive(Serialize, serde::Deserialize, PartialEq, Debug)]
+struct Leaf {
+    code: u32,
+    tag: String,
+}
+
+impl Kind for Leaf {
+    const NAME: &'static str = "conformance.leaf";
+    const ID: KindId = KindId(0xC0FF_EE00_0000_0001);
+
+    fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
+        wire::from_bytes(bytes).ok()
+    }
+
+    fn encode_into_bytes(&self) -> Vec<u8> {
+        wire::to_vec(self).expect("wire encode")
+    }
+}
+
+fn leaf_schema() -> SchemaType {
+    postcard_struct(vec![
+        scalar("code", Primitive::U32),
+        named("tag", SchemaType::String),
+    ])
+}
+
+#[derive(Serialize, serde::Deserialize, PartialEq, Debug)]
+struct RefHolder {
+    held: Ref<Leaf>,
+    seq: u32,
+}
+
+fn ref_holder_schema() -> SchemaType {
+    postcard_struct(vec![
+        named("held", SchemaType::Ref(SchemaCell::owned(leaf_schema()))),
+        scalar("seq", Primitive::U32),
+    ])
+}
+
+#[test]
+fn ref_inline_conforms_with_nested_versioned_image() {
+    let value = RefHolder {
+        held: Ref::Inline(Leaf {
+            code: 0x0102_0304,
+            tag: "leaf".into(),
+        }),
+        seq: 9,
+    };
+    let json = json!({
+        "held": { "Inline": { "code": 0x0102_0304u32, "tag": "leaf" } },
+        "seq": 9u32,
+    });
+    check(&value, &ref_holder_schema(), &json);
+}
+
+#[test]
+fn ref_handle_conforms() {
+    let value = RefHolder {
+        held: Ref::handle(0x00CA_FE00),
+        seq: 11,
+    };
+    let json = json!({
+        "held": { "Handle": { "id": 0x00CA_FE00u64, "kind_id": Leaf::ID.0 } },
+        "seq": 11u32,
+    });
+    check(&value, &ref_holder_schema(), &json);
+}

--- a/crates/aether-codec/src/decode.rs
+++ b/crates/aether-codec/src/decode.rs
@@ -1,8 +1,7 @@
 // Wire-decode: bytes laid out per `SchemaType` → serde_json. The
-// narrowing casts (`u64 → u32`, varint slot to signed via
-// `cast_possible_wrap`) are the load-bearing inverse of the encode
-// path; `From::from` / `try_into` would obscure the byte-layout
-// contract this function implements.
+// narrowing / sign casts (`u8 → i8` in the cast-shape path) are the
+// load-bearing inverse of the encode path; `From::from` / `try_into`
+// would obscure the byte-layout contract this function implements.
 #![allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 
 // `decode_schema`: wire bytes + `SchemaType` descriptor → serde_json
@@ -13,20 +12,23 @@
 //    under it): walk `#[repr(C)]` byte layout, lift each scalar / fixed
 //    array into JSON. Encoder pads to alignment between fields and
 //    rounds total size to the largest field alignment; the decoder does
-//    the same skips.
+//    the same skips. No version byte (the cast image is its own codec).
 //
-// 2. Postcard (everything else): consume the postcard 1.x wire format
-//    directly — varints, zigzag, length-prefixed strings/vecs/bytes,
-//    externally-tagged enums.
+// 2. Wire (everything else): consume the ADR-0118 `aether_data::wire`
+//    format directly — a leading `WIRE_VERSION` byte stripped on entry,
+//    then fixed-width little-endian scalars, `u32` lengths/selectors,
+//    presence bytes, length-prefixed strings/vecs/bytes, externally-
+//    tagged enums, encoded-key-sorted maps, and the `Ref` arms.
 //
 // We decode the bytes directly rather than going through serde's
 // deserializer because the descriptor is structural (not a typed
 // schema), and the encoder writes bytes directly for the same reason.
-// Round-trip tests against the encoder pin the wire format from both
-// sides.
+// Round-trip tests against the encoder — and the adapter-vs-walker
+// conformance test — pin the wire format from both sides.
 
 use std::fmt;
 
+use aether_data::wire::WIRE_VERSION;
 use aether_data::{EnumVariant, NamedField, Primitive, SchemaType};
 use serde_json::{Map, Value};
 
@@ -53,8 +55,12 @@ pub enum DecodeError {
     InvalidUtf8 {
         path: String,
     },
-    VarintOverflow {
-        path: String,
+    /// The top-level wire payload did not begin with [`WIRE_VERSION`]
+    /// (ADR-0118 §Envelope). A reader that strips the version byte on
+    /// entry rejects a bare or wrong-version image rather than
+    /// misparsing it.
+    BadVersion {
+        byte: u8,
     },
     UnknownEnumDiscriminant {
         path: String,
@@ -92,8 +98,11 @@ impl fmt::Display for DecodeError {
                 write!(f, "invalid bool at {path}: 0x{byte:02x} not 0 or 1")
             }
             Self::InvalidUtf8 { path } => write!(f, "invalid utf-8 in string at {path}"),
-            Self::VarintOverflow { path } => {
-                write!(f, "varint at {path} exceeds 10 bytes (overflow)")
+            Self::BadVersion { byte } => {
+                write!(
+                    f,
+                    "bad wire format version byte: 0x{byte:02x} (expected {WIRE_VERSION})"
+                )
             }
             Self::ValueBudgetExceeded { path, budget } => write!(
                 f,
@@ -135,20 +144,31 @@ impl error::Error for DecodeError {}
 const VALUE_BUDGET_BASE: usize = 4096;
 const VALUES_PER_INPUT_BYTE: usize = 4;
 
-/// ADR-0020: decode `bytes` against a `SchemaType` descriptor into a
-/// JSON value symmetric to what `encode_schema` would accept.
-/// Dispatches on the schema's wire shape (same split as the encoder):
+/// ADR-0020 / ADR-0118: decode `bytes` against a `SchemaType`
+/// descriptor into a JSON value symmetric to what `encode_schema`
+/// would accept. Dispatches on the schema's wire shape (same split as
+/// the encoder):
 ///
-/// - `Unit` → `null` (empty payload).
+/// - `Unit` → `null` (bare empty payload, no version byte).
 /// - `Struct { repr_c: true }` (and the recursive cast-shaped tree
-///   under it) → walk the `#[repr(C)]` byte layout.
-/// - Everything else → consume postcard 1.x wire format.
+///   under it) → walk the `#[repr(C)]` byte layout, no version byte.
+/// - Everything else → strip the leading `WIRE_VERSION` byte, then
+///   consume the `aether_data::wire` format.
 ///
 /// Trailing bytes are an error (the encoder writes exactly the right
 /// number of bytes; extras mean schema/payload drift the agent should
 /// see).
 pub fn decode_schema(bytes: &[u8], schema: &SchemaType) -> Result<Value, DecodeError> {
-    let mut cur = Cursor::new(bytes);
+    // The cast image and the unit kind are bare; every other (wire)
+    // schema carries the leading version byte at this top-level
+    // kind-image boundary. Interior values are bare, so the recursive
+    // walk never strips again — except the `Ref` inline arm, which
+    // re-enters `decode_schema` on a nested versioned image.
+    let body = match schema {
+        SchemaType::Unit | SchemaType::Struct { repr_c: true, .. } => bytes,
+        _ => strip_version(bytes)?,
+    };
+    let mut cur = Cursor::new(body);
     let value = decode_value(&mut cur, schema, "$")?;
     if cur.remaining() != 0 {
         return Err(DecodeError::TrailingBytes {
@@ -157,6 +177,20 @@ pub fn decode_schema(bytes: &[u8], schema: &SchemaType) -> Result<Value, DecodeE
         });
     }
     Ok(value)
+}
+
+/// Strip and validate the leading [`WIRE_VERSION`] byte (ADR-0118
+/// §Envelope) from a top-level or nested kind image.
+fn strip_version(bytes: &[u8]) -> Result<&[u8], DecodeError> {
+    match bytes.split_first() {
+        Some((&v, rest)) if v == WIRE_VERSION => Ok(rest),
+        Some((&v, _)) => Err(DecodeError::BadVersion { byte: v }),
+        None => Err(DecodeError::Truncated {
+            path: "$".into(),
+            needed: 1,
+            had: 0,
+        }),
+    }
 }
 
 fn decode_value(
@@ -175,7 +209,7 @@ fn decode_value(
             cur.skip_pad_to(max_align);
             Ok(Value::Object(obj))
         }
-        _ => decode_postcard(cur, schema, path),
+        _ => decode_wire_value(cur, schema, path),
     }
 }
 
@@ -307,17 +341,19 @@ fn alignment_of_schema(ty: &SchemaType) -> Result<usize, DecodeError> {
     }
 }
 
-// Schema-driven postcard decoder: one match arm per `SchemaType`
+// Schema-driven wire decoder: one match arm per `SchemaType`
 // variant. Each arm is short but the arm count adds up — extracting
 // per-type helpers obscures the schema → wire mapping that's the
-// purpose of this fn.
+// purpose of this fn. Values are bare interior bytes; the leading
+// version byte was stripped by `decode_schema` (and the `Ref` inline
+// arm re-enters `decode_schema` on its own nested versioned image).
 #[allow(clippy::too_many_lines)]
-fn decode_postcard(
+fn decode_wire_value(
     cur: &mut Cursor<'_>,
     schema: &SchemaType,
     path: &str,
 ) -> Result<Value, DecodeError> {
-    // Every postcard node charges exactly once — collection elements,
+    // Every wire node charges exactly once — collection elements,
     // struct fields, enum bodies — including through recursion, so the
     // decode-wide budget bounds the zero-wire-byte-element class whose
     // loop allocates without consuming input.
@@ -335,16 +371,16 @@ fn decode_postcard(
                 }),
             }
         }
-        SchemaType::Scalar(p) => read_primitive_postcard(cur, *p, path),
+        SchemaType::Scalar(p) => read_primitive_wire(cur, *p, path),
         SchemaType::String => {
-            let len = read_varint_u64(cur, path)? as usize;
+            let len = cur.read_count(path)? as usize;
             let bytes = cur.take_slice(len, path)?;
             let s = str::from_utf8(bytes)
                 .map_err(|_| DecodeError::InvalidUtf8 { path: path.into() })?;
             Ok(Value::String(s.into()))
         }
         SchemaType::Bytes => {
-            let len = read_varint_u64(cur, path)? as usize;
+            let len = cur.read_count(path)? as usize;
             let bytes = cur.take_slice(len, path)?;
             // Mirror encoder input shape: array of byte values.
             let arr = bytes.iter().map(|b| Value::from(*b)).collect();
@@ -354,7 +390,7 @@ fn decode_postcard(
             let [tag] = cur.take::<1>(path)?;
             match tag {
                 0 => Ok(Value::Null),
-                1 => decode_postcard(cur, inner, path),
+                1 => decode_wire_value(cur, inner, path),
                 _ => Err(DecodeError::InvalidBool {
                     path: path.into(),
                     byte: tag,
@@ -362,16 +398,16 @@ fn decode_postcard(
             }
         }
         SchemaType::Vec(inner) => {
-            let len = read_varint_u64(cur, path)? as usize;
+            let len = cur.read_count(path)? as usize;
             // Clamp the pre-allocation against the bytes that remain: a
-            // varint-encoded element occupies ≥ 1 byte, so a `len` past
+            // wire-encoded element occupies ≥ 1 byte, so a `len` past
             // `remaining` can't be valid non-degenerate input. Zero-byte
             // elements start small and grow by push; the decode-wide
             // budget bounds that loop.
             let mut arr = Vec::with_capacity(len.min(cur.remaining()));
             for i in 0..len {
                 let elem_path = format!("{path}[{i}]");
-                arr.push(decode_postcard(cur, inner, &elem_path)?);
+                arr.push(decode_wire_value(cur, inner, &elem_path)?);
             }
             Ok(Value::Array(arr))
         }
@@ -379,23 +415,22 @@ fn decode_postcard(
             let mut arr = Vec::with_capacity(*len as usize);
             for i in 0..*len {
                 let elem_path = format!("{path}[{i}]");
-                arr.push(decode_postcard(cur, element, &elem_path)?);
+                arr.push(decode_wire_value(cur, element, &elem_path)?);
             }
             Ok(Value::Array(arr))
         }
         SchemaType::Struct { fields, .. } => {
-            // Postcard struct: concatenated field bytes in declaration
-            // order.
+            // Wire struct: concatenated field bytes in declaration order.
             let mut obj = Map::with_capacity(fields.len());
             for field in fields.iter() {
                 let field_path = format!("{path}.{}", field.name);
-                let value = decode_postcard(cur, &field.ty, &field_path)?;
+                let value = decode_wire_value(cur, &field.ty, &field_path)?;
                 obj.insert(field.name.to_string(), value);
             }
             Ok(Value::Object(obj))
         }
         SchemaType::Enum { variants } => {
-            let disc = read_varint_u64(cur, path)? as u32;
+            let disc = cur.read_count(path)?;
             let variant = variants
                 .iter()
                 .find(|v| v.discriminant() == disc)
@@ -409,21 +444,21 @@ fn decode_postcard(
             key: key_schema,
             value: value_schema,
         } => {
-            // Issue #232 + proto3-style JSON mapping. Wire is
-            // postcard's `BTreeMap<K, V>` shape — varint(len) followed
-            // by `(k, v)` pairs in key-sorted order. We emit a JSON
-            // object with the proto3 stringify rule: integer keys as
-            // decimal-string keys, bool keys as `"true"`/`"false"`,
+            // Issue #232 + proto3-style JSON mapping. Wire is the
+            // `aether_data::wire` `Map` shape — `u32(count)` followed by
+            // `(k, v)` pairs in ascending encoded-key byte order. We emit
+            // a JSON object with the proto3 stringify rule: integer keys
+            // as decimal-string keys, bool keys as `"true"`/`"false"`,
             // string keys identity. Order in the emitted object isn't
             // load-bearing for decoders that compare by value.
-            let len = read_varint_u64(cur, path)? as usize;
+            let len = cur.read_count(path)? as usize;
             // Same clamp as the `Vec` arm: a `(k, v)` pair occupies ≥ 1
             // byte, so cap the pre-allocation at the bytes remaining.
             let mut obj = Map::with_capacity(len.min(cur.remaining()));
             for i in 0..len {
                 let entry_path = format!("{path}[{i}]");
-                let key_value = decode_postcard(cur, key_schema, &entry_path)?;
-                let val_value = decode_postcard(cur, value_schema, &entry_path)?;
+                let key_value = decode_wire_value(cur, key_schema, &entry_path)?;
+                let val_value = decode_wire_value(cur, value_schema, &entry_path)?;
                 let key_string = render_map_key(&key_value, key_schema, &entry_path)?;
                 obj.insert(key_string, val_value);
             }
@@ -431,17 +466,18 @@ fn decode_postcard(
         }
         SchemaType::Ref(inner) => {
             // ADR-0045 typed handle, inline arm revised by ADR-0100.
-            // Wire matches the postcard enum encoding: discriminant
-            // varint, then either the inline body (Inline = 0) or two
-            // varints id + kind_id (Handle = 1). The inline body is the
-            // inner kind's own codec image, length-prefixed — read the
-            // length, slice it off, and decode it with the same
-            // cast-or-postcard dispatch as a top-level kind. Render as
-            // externally-tagged JSON to match the encoder's input shape.
-            let disc = read_varint_u64(cur, path)? as u32;
+            // Wire is a `u32` little-endian selector, then either the
+            // inline body (Inline = 0) or `id` (8 LE) + `kind_id` (8 LE)
+            // (Handle = 1). The inline body is the inner kind's own codec
+            // image, `u32`-length-prefixed — read the length, slice it
+            // off, and decode it with the same cast-or-wire dispatch as a
+            // top-level kind (`decode_schema` strips the inner version
+            // byte for a wire inner). Render as externally-tagged JSON to
+            // match the encoder's input shape.
+            let disc = cur.read_count(path)?;
             match disc {
                 0 => {
-                    let len = read_varint_u64(cur, path)? as usize;
+                    let len = cur.read_count(path)? as usize;
                     let body = cur.take_slice(len, path)?;
                     let inner_value = decode_schema(body, inner)?;
                     let mut obj = Map::with_capacity(1);
@@ -449,8 +485,8 @@ fn decode_postcard(
                     Ok(Value::Object(obj))
                 }
                 1 => {
-                    let id = read_varint_u64(cur, &format!("{path}.id"))?;
-                    let kind_id = read_varint_u64(cur, &format!("{path}.kind_id"))?;
+                    let id = u64::from_le_bytes(cur.take::<8>(&format!("{path}.id"))?);
+                    let kind_id = u64::from_le_bytes(cur.take::<8>(&format!("{path}.kind_id"))?);
                     let mut handle_obj = Map::with_capacity(2);
                     handle_obj.insert("id".into(), Value::from(id));
                     handle_obj.insert("kind_id".into(), Value::from(kind_id));
@@ -465,47 +501,31 @@ fn decode_postcard(
             }
         }
         SchemaType::TypeId(type_id) => {
-            // ADR-0065 typed id. Wire is a u64 varint; emit the
-            // tagged string form (or back-compat number for
+            // ADR-0065 typed id. Wire is a `u64` fixed little-endian;
+            // emit the tagged string form (or back-compat number for
             // reserved-tag sentinels).
-            let id = read_varint_u64(cur, path)?;
+            let id = u64::from_le_bytes(cur.take::<8>(path)?);
             render_type_id_value(id, *type_id, path)
         }
     }
 }
 
-fn read_primitive_postcard(
+fn read_primitive_wire(
     cur: &mut Cursor<'_>,
     p: Primitive,
     path: &str,
 ) -> Result<Value, DecodeError> {
+    // Fixed-width little-endian of the declared width — the inverse of
+    // `encode::write_scalar_wire`. No varints, no zigzag.
     match p {
-        Primitive::U8 => Ok(Value::from(cur.take::<1>(path)?[0])),
-        Primitive::U16 => {
-            let n = read_varint_u64(cur, path)?;
-            Ok(Value::from(n as u16))
-        }
-        Primitive::U32 => {
-            let n = read_varint_u64(cur, path)?;
-            Ok(Value::from(n as u32))
-        }
-        Primitive::U64 => {
-            let n = read_varint_u64(cur, path)?;
-            Ok(Value::from(n))
-        }
-        Primitive::I8 => Ok(Value::from(cur.take::<1>(path)?[0] as i8)),
-        Primitive::I16 => {
-            let n = read_varint_u64(cur, path)?;
-            Ok(Value::from(unzigzag(n) as i16))
-        }
-        Primitive::I32 => {
-            let n = read_varint_u64(cur, path)?;
-            Ok(Value::from(unzigzag(n) as i32))
-        }
-        Primitive::I64 => {
-            let n = read_varint_u64(cur, path)?;
-            Ok(Value::from(unzigzag(n)))
-        }
+        Primitive::U8 => Ok(Value::from(u8::from_le_bytes(cur.take::<1>(path)?))),
+        Primitive::U16 => Ok(Value::from(u16::from_le_bytes(cur.take::<2>(path)?))),
+        Primitive::U32 => Ok(Value::from(u32::from_le_bytes(cur.take::<4>(path)?))),
+        Primitive::U64 => Ok(Value::from(u64::from_le_bytes(cur.take::<8>(path)?))),
+        Primitive::I8 => Ok(Value::from(i8::from_le_bytes(cur.take::<1>(path)?))),
+        Primitive::I16 => Ok(Value::from(i16::from_le_bytes(cur.take::<2>(path)?))),
+        Primitive::I32 => Ok(Value::from(i32::from_le_bytes(cur.take::<4>(path)?))),
+        Primitive::I64 => Ok(Value::from(i64::from_le_bytes(cur.take::<8>(path)?))),
         Primitive::F32 => Ok(json_f64(f64::from(f32::from_le_bytes(
             cur.take::<4>(path)?,
         )))),
@@ -528,12 +548,12 @@ fn decode_enum_body(
         EnumVariant::Tuple { fields, .. } => {
             let body = if fields.len() == 1 {
                 let nested_path = format!("{path}::{name}.0");
-                decode_postcard(cur, &fields[0], &nested_path)?
+                decode_wire_value(cur, &fields[0], &nested_path)?
             } else {
                 let mut arr = Vec::with_capacity(fields.len());
                 for (i, ty) in fields.iter().enumerate() {
                     let nested = format!("{path}::{name}.{i}");
-                    arr.push(decode_postcard(cur, ty, &nested)?);
+                    arr.push(decode_wire_value(cur, ty, &nested)?);
                 }
                 Value::Array(arr)
             };
@@ -545,7 +565,7 @@ fn decode_enum_body(
             let mut body = Map::with_capacity(fields.len());
             for field in fields.iter() {
                 let nested = format!("{path}::{name}.{}", field.name);
-                let v = decode_postcard(cur, &field.ty, &nested)?;
+                let v = decode_wire_value(cur, &field.ty, &nested)?;
                 body.insert(field.name.to_string(), v);
             }
             let mut obj = Map::with_capacity(1);
@@ -595,26 +615,6 @@ fn render_map_key(
     }
 }
 
-/// Postcard 1.x varint: 7 bits per byte, MSB set means continue. Cap at
-/// 10 bytes — anything longer is overflow for u64.
-fn read_varint_u64(cur: &mut Cursor<'_>, path: &str) -> Result<u64, DecodeError> {
-    let mut n: u64 = 0;
-    let mut shift = 0u32;
-    for _ in 0..10 {
-        let [b] = cur.take::<1>(path)?;
-        n |= u64::from(b & 0x7f) << shift;
-        if b & 0x80 == 0 {
-            return Ok(n);
-        }
-        shift += 7;
-    }
-    Err(DecodeError::VarintOverflow { path: path.into() })
-}
-
-fn unzigzag(n: u64) -> i64 {
-    ((n >> 1) as i64) ^ -((n & 1) as i64)
-}
-
 /// JSON numbers can't represent NaN/infinity. The encoder accepts
 /// arbitrary `f64`s; on decode we coerce non-finite to `null` so the
 /// JSON value remains valid. Round-trip semantics: finite floats round
@@ -627,7 +627,7 @@ struct Cursor<'a> {
     bytes: &'a [u8],
     pos: usize,
     /// Remaining value budget for this decode (see `VALUE_BUDGET_BASE`).
-    /// Each postcard node decrements it via `charge_value`.
+    /// Each wire node decrements it via `charge_value`.
     values_left: usize,
 }
 
@@ -691,6 +691,13 @@ impl<'a> Cursor<'a> {
         let slice = &self.bytes[self.pos..self.pos + n];
         self.pos += n;
         Ok(slice)
+    }
+
+    /// Read a `u32` little-endian count/length/selector — the `wire`
+    /// framing for string / bytes / vec / map lengths, the enum
+    /// discriminant, and the `Ref` selector.
+    fn read_count(&mut self, path: &str) -> Result<u32, DecodeError> {
+        Ok(u32::from_le_bytes(self.take::<4>(path)?))
     }
 
     /// Advance past zero-padding so `pos` lands on a multiple of `align`.
@@ -870,8 +877,23 @@ mod tests {
             name: "flag".into(),
             ty: SchemaType::Bool,
         }]);
-        let err = decode_schema(&[2], &schema).expect_err("non-0/1 bool byte must error");
+        let err =
+            decode_schema(&[WIRE_VERSION, 2], &schema).expect_err("non-0/1 bool byte must error");
         assert!(matches!(err, DecodeError::InvalidBool { .. }));
+    }
+
+    #[test]
+    fn bare_or_wrong_version_byte_errors() {
+        // A wire-shaped payload that doesn't open with WIRE_VERSION is
+        // rejected on entry (ADR-0118 §Envelope) rather than misparsed.
+        let schema = pc_struct(vec![NamedField {
+            name: "flag".into(),
+            ty: SchemaType::Bool,
+        }]);
+        let err = decode_schema(&[0xEE, 1], &schema).expect_err("wrong version byte must error");
+        assert!(matches!(err, DecodeError::BadVersion { byte: 0xEE }));
+        let err = decode_schema(&[], &schema).expect_err("empty wire payload must error");
+        assert!(matches!(err, DecodeError::Truncated { .. }));
     }
 
     #[test]
@@ -891,8 +913,8 @@ mod tests {
             name: "body".into(),
             ty: SchemaType::String,
         }]);
-        // varint length 2, then two invalid utf-8 bytes.
-        let err = decode_schema(&[2, 0xff, 0xfe], &schema)
+        // version byte, u32 length 2, then two invalid utf-8 bytes.
+        let err = decode_schema(&[WIRE_VERSION, 2, 0, 0, 0, 0xff, 0xfe], &schema)
             .expect_err("invalid utf-8 string body must error");
         assert!(matches!(err, DecodeError::InvalidUtf8 { .. }));
     }
@@ -966,49 +988,25 @@ mod tests {
 
     #[test]
     fn postcard_enum_unknown_discriminant_errors() {
-        // discriminant 99 isn't in the schema.
+        // discriminant 99 isn't in the schema; the u32 selector is
+        // little-endian behind the version byte.
         let schema = sum_schema();
-        let err = decode_schema(&[99], &schema).expect_err("unknown enum discriminant must error");
+        let err = decode_schema(&[WIRE_VERSION, 99, 0, 0, 0], &schema)
+            .expect_err("unknown enum discriminant must error");
         assert!(matches!(err, DecodeError::UnknownEnumDiscriminant { .. }));
     }
 
     #[test]
-    fn varint_decodes_at_byte_boundaries() {
-        for n in [0u64, 127, 128, 16383, 16384, u64::from(u32::MAX), u64::MAX] {
-            let bytes =
-                postcard::to_allocvec(&n).expect("test setup: postcard reference varint u64");
-            let mut cur = Cursor::new(&bytes);
-            let back = read_varint_u64(&mut cur, "$").expect("test setup: read varint u64");
-            assert_eq!(back, n, "varint decode mismatch for {n}");
-        }
-    }
-
-    #[test]
-    fn varint_overflow_errors() {
-        // 11 continuation bytes — exceeds u64.
-        let bytes = vec![0xff; 11];
-        let mut cur = Cursor::new(&bytes);
-        let err = read_varint_u64(&mut cur, "$").expect_err("varint exceeding 10 bytes must error");
-        assert!(matches!(err, DecodeError::VarintOverflow { .. }));
-    }
-
-    #[test]
-    fn zigzag_decodes_to_signed() {
-        for n in [
-            0i64,
-            -1,
-            1,
-            -128,
-            127,
-            i64::from(i32::MIN),
-            i64::from(i32::MAX),
-        ] {
-            let bytes =
-                postcard::to_allocvec(&n).expect("test setup: postcard reference zigzag i64");
-            let mut cur = Cursor::new(&bytes);
-            let raw = read_varint_u64(&mut cur, "$").expect("test setup: read zigzag varint");
-            assert_eq!(unzigzag(raw), n, "zigzag mismatch for {n}");
-        }
+    fn scalars_are_fixed_width_little_endian() {
+        // u16/u32/i16/i32 are the declared width LE, not varints — pin a
+        // couple of round-trips that a varint layout would have shrunk.
+        roundtrip(
+            json!({"a": 256u16, "b": -2i32}),
+            &pc_struct(vec![
+                scalar("a", Primitive::U16),
+                scalar("b", Primitive::I32),
+            ]),
+        );
     }
 
     #[test]
@@ -1016,12 +1014,12 @@ mod tests {
         // Encoder writes raw f64 bytes; decoder coerces non-finite to
         // null so the JSON value is always valid.
         let schema = pc_struct(vec![scalar("x", Primitive::F64)]);
-        let mut bytes = Vec::new();
+        let mut bytes = vec![WIRE_VERSION];
         bytes.extend_from_slice(&f64::NAN.to_le_bytes());
         let v = decode_schema(&bytes, &schema).expect("test setup: decode NaN f64");
         assert_eq!(v, json!({"x": null}));
 
-        let mut bytes = Vec::new();
+        let mut bytes = vec![WIRE_VERSION];
         bytes.extend_from_slice(&f64::INFINITY.to_le_bytes());
         let v = decode_schema(&bytes, &schema).expect("test setup: decode infinity f64");
         assert_eq!(v, json!({"x": null}));
@@ -1172,10 +1170,10 @@ mod tests {
         )
         .expect("encode subscribe_input via TypeId schema");
 
-        // Substrate decode path — wire is byte-identical to a
-        // hand-postcard'd `SubscribeInput`.
-        let decoded: aether_kinds::SubscribeInput = postcard::from_bytes(&bytes)
-            .expect("postcard decode subscribe_input from hub-encoded bytes");
+        // Substrate decode path — the hub-encoded bytes are byte-identical
+        // to `SubscribeInput::encode_into_bytes` (the `wire` image).
+        let decoded = aether_kinds::SubscribeInput::decode_from_bytes(&bytes)
+            .expect("wire decode subscribe_input from hub-encoded bytes");
         assert_eq!(decoded.kind, kind_id);
         assert_eq!(decoded.mailbox, mailbox);
 
@@ -1205,21 +1203,25 @@ mod tests {
     #[test]
     fn ref_inline_cast_inner_wire_is_length_prefixed_cast_image() {
         // ADR-0100: the inline body of a cast inner kind is the raw
-        // cast image, length-prefixed — not a postcard varint image.
+        // cast image, `u32`-length-prefixed — and no nested version byte
+        // (the cast image is bare).
         let inner = cast_struct(vec![scalar("code", Primitive::U32)]);
         let schema = SchemaType::Ref(SchemaCell::owned(inner.clone()));
         let value = json!({ "Inline": { "code": 0x0102_0304u32 } });
 
         let bytes = encode_schema(&value, &schema).expect("encode Inline Ref");
         // The inner image is exactly what `encode_schema` emits for the
-        // inner kind standalone (the cast image).
+        // inner kind standalone (the cast image, no version byte).
         let body = encode_schema(&json!({ "code": 0x0102_0304u32 }), &inner).expect("encode inner");
         assert_eq!(body.len(), 4, "u32 cast image is 4 raw bytes");
-        let mut expected = vec![0u8, 4u8];
+        // Top-level version byte + u32 inline selector + u32 length + body.
+        let mut expected = vec![WIRE_VERSION];
+        expected.extend_from_slice(&0u32.to_le_bytes());
+        expected.extend_from_slice(&4u32.to_le_bytes());
         expected.extend_from_slice(&body);
         assert_eq!(
             bytes, expected,
-            "inline wire is disc 0 + varint(len) + cast image"
+            "inline wire is version + u32 sel 0 + u32 len + cast image"
         );
 
         // JSON descriptor round-trips through wire and back.
@@ -1231,15 +1233,16 @@ mod tests {
     // wire-decoded length must not drive the decoder into an unbounded
     // allocation; the four classes below pin the fix.
 
-    /// (a) The `ASan` repro class (#1562 fuzz crash): a varint of
+    /// (a) The `ASan` repro class (#1562 fuzz crash): a `u32` length of
     /// `u32::MAX` followed by an empty tail against `Vec<u32>` and
     /// `Map<u32, u32>`. The pre-allocation clamp keeps `with_capacity`
     /// from requesting an exabyte; the decode then errors `Truncated`
     /// reading the first absent element rather than aborting the process.
     #[test]
     fn oversized_collection_length_errors_without_allocating() {
-        let len_bytes =
-            postcard::to_allocvec(&u64::from(u32::MAX)).expect("test setup: varint u32::MAX");
+        // Version byte + a `u32` count of `u32::MAX`, no elements.
+        let mut len_bytes = vec![WIRE_VERSION];
+        len_bytes.extend_from_slice(&u32::MAX.to_le_bytes());
 
         let vec_schema = SchemaType::Vec(SchemaCell::owned(SchemaType::Scalar(Primitive::U32)));
         let err = decode_schema(&len_bytes, &vec_schema)
@@ -1262,8 +1265,9 @@ mod tests {
     /// stops it with `ValueBudgetExceeded`.
     #[test]
     fn zero_byte_element_bomb_exceeds_value_budget() {
-        let count_bytes =
-            postcard::to_allocvec(&u64::from(u32::MAX)).expect("test setup: varint count");
+        // Version byte + a `u32` count of `u32::MAX`.
+        let mut count_bytes = vec![WIRE_VERSION];
+        count_bytes.extend_from_slice(&u32::MAX.to_le_bytes());
 
         let unit_vec = SchemaType::Vec(SchemaCell::owned(SchemaType::Unit));
         let err = decode_schema(&count_bytes, &unit_vec)
@@ -1295,14 +1299,18 @@ mod tests {
     }
 
     #[test]
-    fn ref_handle_wire_is_byte_unchanged() {
+    fn ref_handle_wire_is_selector_then_two_le_ids() {
         let inner = cast_struct(vec![scalar("code", Primitive::U32)]);
         let schema = SchemaType::Ref(SchemaCell::owned(inner));
         let value = json!({ "Handle": { "id": 7u64, "kind_id": 42u64 } });
 
         let bytes = encode_schema(&value, &schema).expect("encode Handle Ref");
-        // disc 1 + varint(7) + varint(42) — unchanged from ADR-0045.
-        assert_eq!(bytes, vec![1u8, 7u8, 42u8]);
+        // version + u32 selector 1 + id (8 LE) + kind_id (8 LE).
+        let mut expected = vec![WIRE_VERSION];
+        expected.extend_from_slice(&1u32.to_le_bytes());
+        expected.extend_from_slice(&7u64.to_le_bytes());
+        expected.extend_from_slice(&42u64.to_le_bytes());
+        assert_eq!(bytes, expected);
 
         let back = decode_schema(&bytes, &schema).expect("decode Handle Ref");
         assert_eq!(back, value);

--- a/crates/aether-codec/src/encode.rs
+++ b/crates/aether-codec/src/encode.rs
@@ -1,8 +1,8 @@
 // Wire-encode: serde_json input → bytes laid out per `SchemaType`.
-// The narrowing casts (`u64 → u32 / u16 / u8`, signed varint slot
-// reuse) and sign-loss casts (`i*` to the `u*` zigzag-encoded slot)
-// are the load-bearing byte layout — `From::from` / `try_into` would
-// obscure the wire-format contract these functions implement.
+// The narrowing casts (`u64 → u32 / u16 / u8` length and scalar
+// fits, `f64 → f32`) are the load-bearing fixed-width byte layout —
+// `From::from` / `try_into` would obscure the wire-format contract
+// these functions implement.
 #![allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 
 // `encode_schema`: serde_json params + `SchemaType` descriptor → wire
@@ -15,31 +15,34 @@
 //    under it): `#[repr(C)]` byte layout. Scalars and fixed arrays
 //    laid out at the alignment they'd occupy in a Rust struct;
 //    trailing padding rounds total size to the largest field
-//    alignment. Substrate decode is `bytemuck::cast`.
+//    alignment. Substrate decode is `bytemuck::cast`. No version byte
+//    — the cast image is its own codec, like `<() as Kind>`.
 //
-// 2. Postcard (everything else): postcard 1.x wire format, written
-//    directly:
-//      - bool: 1 byte (0 or 1)
-//      - u8/i8: 1 byte
-//      - u16..u64: LEB128 varint
-//      - i16..i64: zigzag-then-LEB128
-//      - f32/f64: little-endian
-//      - String / &[u8] (Bytes): varint length + bytes
-//      - Vec<T>: varint length + concatenated encoded elements
-//      - [T; N]: concatenated encoded elements (no length prefix)
-//      - Option<T>: 1-byte tag (0 or 1), then T if Some
-//      - enum: varint discriminant, then variant body
+// 2. Wire (everything else): the ADR-0118 `aether_data::wire` format,
+//    a fixed-width, schema-driven layout written directly. A leading
+//    `WIRE_VERSION` byte prefixes the top-level kind image; interior
+//    values are bare:
+//      - bool / option-presence: 1 byte (0 or 1)
+//      - u8..u128 / i8..i128: fixed little-endian of the declared width
+//      - f32/f64: bit-faithful little-endian
+//      - String / Bytes / Vec / Map: `u32` little-endian count, then
+//        elements (maps in ascending encoded-key byte order)
+//      - [T; N]: concatenated encoded elements (no count)
+//      - Option<T>: presence byte, then T if Some
+//      - enum / Ref selector: `u32` little-endian (the variant index)
 //      - struct: concatenated field bytes in declaration order
+//      - Ref handle arm: `id` (8 LE) + `kind_id` (8 LE)
+//      - Ref inline arm: `u32` length + a nested versioned kind image
 //
 // We write the bytes directly rather than going through a serde
 // serializer because the JSON-driven encoding is structural — matching
-// postcard's wire format byte-for-byte is the contract, not "calling
-// postcard".
+// the `wire` byte layout byte-for-byte is the contract (the
+// adapter-vs-walker conformance test pins it), not "calling serde".
 
 use std::fmt;
 
-use aether_data::tagged_id;
-use aether_data::{EnumVariant, NamedField, Primitive, SchemaType};
+use aether_data::wire::WIRE_VERSION;
+use aether_data::{EnumVariant, NamedField, Primitive, SchemaType, tagged_id};
 use serde_json::Value;
 
 use crate::cast::{align_of_primitive, non_cast_variant_error};
@@ -64,8 +67,8 @@ pub enum EncodeError {
         got: usize,
     },
     /// A schema arm the hub encoder can't handle in this position.
-    /// PR 5's postcard path covers every top-level `SchemaType`, so
-    /// this variant only fires for fields-inside-cast-structs that
+    /// The wire path covers every top-level `SchemaType`, so this
+    /// variant only fires for fields-inside-cast-structs that
     /// disqualify the parent from cast eligibility. Carries a short
     /// description so the agent error is actionable.
     UnsupportedSchema(&'static str),
@@ -100,21 +103,24 @@ impl fmt::Display for EncodeError {
 
 impl error::Error for EncodeError {}
 
-/// ADR-0019: encode `params` against a `SchemaType` descriptor.
-/// Dispatches on the schema's wire shape:
+/// ADR-0019 / ADR-0118: encode `params` against a `SchemaType`
+/// descriptor. Dispatches on the schema's wire shape:
 ///
-/// - `Unit` → empty payload.
+/// - `Unit` → empty payload, no version byte (the `<() as Kind>` image
+///   is bare, matching its hand-rolled codec).
 /// - `Struct { repr_c: true }` (and the recursive cast-shaped tree
 ///   under it) → `#[repr(C)]` byte layout, decodable by
-///   `bytemuck::cast` on the substrate side.
-/// - Everything else → postcard wire format, written directly per the
-///   format described at the top of this file.
+///   `bytemuck::cast` on the substrate side. No version byte.
+/// - Everything else → the `aether_data::wire` format, written
+///   directly per the layout described at the top of this file, with a
+///   leading `WIRE_VERSION` byte on the top-level image.
 pub fn encode_schema(params: &Value, schema: &SchemaType) -> Result<Vec<u8>, EncodeError> {
     match schema {
         SchemaType::Unit => {
-            // Empty payload. Accept an empty object or null; reject
-            // explicit non-empty input so a typo doesn't get silently
-            // swallowed.
+            // Empty payload, no version byte — the unit kind's image is
+            // bare (`<() as Kind>::encode_into_bytes` yields `[]`).
+            // Accept an empty object or null; reject explicit non-empty
+            // input so a typo doesn't get silently swallowed.
             if let Some(obj) = params.as_object()
                 && !obj.is_empty()
             {
@@ -139,25 +145,29 @@ pub fn encode_schema(params: &Value, schema: &SchemaType) -> Result<Vec<u8>, Enc
             pad_to(&mut out, max_align);
             Ok(out)
         }
-        // Postcard path: every non-cast schema. The walker handles
-        // top-level scalars / strings / vecs / enums uniformly with
-        // their nested counterparts.
+        // Wire path: every non-cast, non-unit schema. The walker
+        // handles top-level scalars / strings / vecs / enums uniformly
+        // with their nested counterparts. The version byte sits at this
+        // top-level kind-image boundary only; interior values are bare.
         _ => {
-            let mut out = Vec::new();
-            encode_postcard(params, schema, "$", &mut out)?;
+            let mut out = vec![WIRE_VERSION];
+            encode_wire_value(params, schema, "$", &mut out)?;
             Ok(out)
         }
     }
 }
 
-/// Recursively encode `value` into postcard wire format under `schema`.
+/// Recursively encode `value` into the `aether_data::wire` format under
+/// `schema`. Interior values are bare — the caller (`encode_schema`)
+/// owns the single leading `WIRE_VERSION` byte, and the `Ref` inline
+/// arm recurses through `encode_schema` to nest a fresh versioned image.
 /// `path` is a dotted breadcrumb (`$.field.subfield[2]`) used to make
 /// error messages locate the offending field in deeply-nested params.
 // One match arm per `SchemaType`; each arm is short but they sum up.
 // Splitting the arms into helpers would force per-arm context structs
 // without saving readability.
 #[allow(clippy::too_many_lines)]
-fn encode_postcard(
+fn encode_wire_value(
     value: &Value,
     schema: &SchemaType,
     path: &str,
@@ -173,13 +183,13 @@ fn encode_postcard(
             out.push(u8::from(b));
             Ok(())
         }
-        SchemaType::Scalar(p) => write_scalar_postcard(*p, value, path, out),
+        SchemaType::Scalar(p) => write_scalar_wire(*p, value, path, out),
         SchemaType::String => {
             let s = value.as_str().ok_or_else(|| EncodeError::TypeMismatch {
                 field: path.to_owned(),
                 expected: "string",
             })?;
-            write_varint_u64(out, s.len() as u64);
+            write_count(out, s.len(), path)?;
             out.extend_from_slice(s.as_bytes());
             Ok(())
         }
@@ -188,7 +198,7 @@ fn encode_postcard(
                 field: path.to_owned(),
                 expected: "byte array",
             })?;
-            write_varint_u64(out, arr.len() as u64);
+            write_count(out, arr.len(), path)?;
             for (i, v) in arr.iter().enumerate() {
                 let n = as_unsigned(v, path, "u8")?;
                 let b: u8 = n
@@ -203,7 +213,7 @@ fn encode_postcard(
                 out.push(0);
             } else {
                 out.push(1);
-                encode_postcard(value, inner, path, out)?;
+                encode_wire_value(value, inner, path, out)?;
             }
             Ok(())
         }
@@ -212,10 +222,10 @@ fn encode_postcard(
                 field: path.to_owned(),
                 expected: "array",
             })?;
-            write_varint_u64(out, arr.len() as u64);
+            write_count(out, arr.len(), path)?;
             for (i, v) in arr.iter().enumerate() {
                 let elem_path = format!("{path}[{i}]");
-                encode_postcard(v, inner, &elem_path, out)?;
+                encode_wire_value(v, inner, &elem_path, out)?;
             }
             Ok(())
         }
@@ -233,12 +243,12 @@ fn encode_postcard(
             }
             for (i, v) in arr.iter().enumerate() {
                 let elem_path = format!("{path}[{i}]");
-                encode_postcard(v, element, &elem_path, out)?;
+                encode_wire_value(v, element, &elem_path, out)?;
             }
             Ok(())
         }
         SchemaType::Struct { fields, .. } => {
-            // Postcard struct: concatenated field bytes in declaration
+            // Wire struct: concatenated field bytes in declaration
             // order. Reject unexpected keys (typo defense) and require
             // every field to be present.
             let obj = value.as_object().ok_or_else(|| EncodeError::TypeMismatch {
@@ -255,14 +265,15 @@ fn encode_postcard(
                     .get(&*field.name)
                     .ok_or_else(|| EncodeError::MissingField(format!("{path}.{}", field.name)))?;
                 let field_path = format!("{path}.{}", field.name);
-                encode_postcard(v, &field.ty, &field_path, out)?;
+                encode_wire_value(v, &field.ty, &field_path, out)?;
             }
             Ok(())
         }
         SchemaType::Enum { variants } => {
             // Externally-tagged JSON: `{"VariantName": <body>}` for
             // tuple/struct variants, `"VariantName"` (string) for unit
-            // variants. Same shape serde emits by default.
+            // variants. Same shape serde emits by default. Wire is a
+            // `u32` little-endian discriminant, then the variant body.
             let (tag, body) = decode_enum_tag(value, path)?;
             let variant = variants.iter().find(|v| v.name() == tag).ok_or_else(|| {
                 EncodeError::TypeMismatch {
@@ -270,7 +281,7 @@ fn encode_postcard(
                     expected: "enum variant matching schema",
                 }
             })?;
-            write_varint_u64(out, u64::from(variant.discriminant()));
+            out.extend_from_slice(&variant.discriminant().to_le_bytes());
             encode_enum_body(body, variant, path, out)?;
             Ok(())
         }
@@ -281,28 +292,35 @@ fn encode_postcard(
             // Issue #232 + proto3-style JSON mapping. Input is a JSON
             // object: keys live as strings on the wire-side regardless
             // of declared key type. We parse each JSON-string key
-            // through the key schema, then sort by the parsed value
-            // so the wire bytes match what `postcard::to_allocvec`
-            // would produce on a `BTreeMap` with the same contents
-            // (sorted by key). Sender-order independence keeps two
-            // tools producing byte-identical payloads from
-            // semantically-equal inputs.
+            // through the key schema, encode each `(key, value)` pair to
+            // its wire bytes, then sort the pairs by ascending
+            // encoded-key byte order — the canonical map ordering the
+            // `wire` serializer uses (`MapSerializer::end`). Sorting on
+            // the encoded bytes (not the parsed value) is what makes the
+            // walker byte-identical to the serde adapter for multi-byte
+            // integer keys, whose little-endian order differs from their
+            // numeric order. Sender-order independence keeps two tools
+            // producing byte-identical payloads from semantically-equal
+            // inputs.
             let json_map = value.as_object().ok_or_else(|| EncodeError::TypeMismatch {
                 field: path.to_owned(),
                 expected: "object",
             })?;
-            let mut entries: Vec<(ParsedMapKey, Value, &Value)> =
-                Vec::with_capacity(json_map.len());
+            let mut entries: Vec<(Vec<u8>, Vec<u8>)> = Vec::with_capacity(json_map.len());
             for (k_str, v_json) in json_map {
                 let entry_path = format!("{path}.{k_str}");
-                let (parsed, key_json) = parse_map_key(k_str, key_schema, &entry_path)?;
-                entries.push((parsed, key_json, v_json));
+                let key_json = parse_map_key(k_str, key_schema, &entry_path)?;
+                let mut key_bytes = Vec::new();
+                encode_wire_value(&key_json, key_schema, path, &mut key_bytes)?;
+                let mut value_bytes = Vec::new();
+                encode_wire_value(v_json, value_schema, path, &mut value_bytes)?;
+                entries.push((key_bytes, value_bytes));
             }
             entries.sort_by(|a, b| a.0.cmp(&b.0));
-            write_varint_u64(out, entries.len() as u64);
-            for (_pk, k_json, v_json) in &entries {
-                encode_postcard(k_json, key_schema, path, out)?;
-                encode_postcard(v_json, value_schema, path, out)?;
+            write_count(out, entries.len(), path)?;
+            for (key_bytes, value_bytes) in &entries {
+                out.extend_from_slice(key_bytes);
+                out.extend_from_slice(value_bytes);
             }
             Ok(())
         }
@@ -311,25 +329,27 @@ fn encode_postcard(
             // Externally-tagged JSON matches the Rust enum:
             // `{"Inline": <inner-K>}` chooses the inline arm;
             // `{"Handle": {"id": u64, "kind_id": u64}}` chooses the
-            // handle arm. Wire is the postcard enum encoding —
-            // discriminant varint + body. The inline body is the inner
-            // kind's own codec image (cast or postcard, dispatched on
-            // `inner`) length-prefixed (`varint(len)` + bytes); the
-            // handle body is two varints.
+            // handle arm. Wire is a `u32` little-endian selector + body.
+            // The inline body is the inner kind's own codec image (cast
+            // or wire, dispatched on `inner` via `encode_schema`, so a
+            // wire inner carries its own `WIRE_VERSION`) length-prefixed
+            // with a `u32`; the handle body is `id` (8 LE) + `kind_id`
+            // (8 LE).
             let (tag, body) = decode_enum_tag(value, path)?;
             match tag {
                 "Inline" => {
-                    write_varint_u64(out, 0);
+                    out.extend_from_slice(&0u32.to_le_bytes());
                     // The inner image is the same bytes `Kind::encode_into_bytes`
                     // produces for the inner kind — `encode_schema` picks
-                    // cast for a `repr_c: true` struct, postcard otherwise.
+                    // cast for a `repr_c: true` struct, a versioned wire
+                    // image otherwise.
                     let body_bytes = encode_schema(body, inner)?;
-                    write_varint_u64(out, body_bytes.len() as u64);
+                    write_count(out, body_bytes.len(), path)?;
                     out.extend_from_slice(&body_bytes);
                     Ok(())
                 }
                 "Handle" => {
-                    write_varint_u64(out, 1);
+                    out.extend_from_slice(&1u32.to_le_bytes());
                     let obj = body.as_object().ok_or_else(|| EncodeError::TypeMismatch {
                         field: path.to_owned(),
                         expected: "Handle object",
@@ -349,8 +369,8 @@ fn encode_postcard(
                         .ok_or_else(|| EncodeError::MissingField(kind_id_path.clone()))?;
                     let id = as_unsigned(id_v, &id_path, "u64")?;
                     let kind_id = as_unsigned(kind_id_v, &kind_id_path, "u64")?;
-                    write_varint_u64(out, id);
-                    write_varint_u64(out, kind_id);
+                    out.extend_from_slice(&id.to_le_bytes());
+                    out.extend_from_slice(&kind_id.to_le_bytes());
                     Ok(())
                 }
                 _ => Err(EncodeError::TypeMismatch {
@@ -359,14 +379,14 @@ fn encode_postcard(
                 }),
             }
         }
-        // ADR-0065 typed id. Wire is a u64 varint; JSON is the
-        // ADR-0064 tagged-string form (`mbx-XXXX-XXXX-XXXX` etc.)
+        // ADR-0065 typed id. Wire is a `u64` fixed little-endian; JSON is
+        // the ADR-0064 tagged-string form (`mbx-XXXX-XXXX-XXXX` etc.)
         // for the post-migration shape, with a back-compat path that
         // accepts a JSON number for callers (test fixtures, older
         // examples) that haven't migrated yet.
         SchemaType::TypeId(type_id) => {
             let id = decode_type_id_value(value, *type_id, path)?;
-            write_varint_u64(out, id);
+            out.extend_from_slice(&id.to_le_bytes());
             Ok(())
         }
     }
@@ -396,38 +416,21 @@ fn decode_type_id_value(value: &Value, type_id: u64, path: &str) -> Result<u64, 
     }
 }
 
-/// Normalized map-key form for sorting (issue #232). Cross-variant
-/// ordering is irrelevant — every key in a single map shares the
-/// declared key schema, so all `ParsedMapKey` values produced for one
-/// encode call land in the same arm. The derived `Ord` keeps the type
-/// total so callers don't need a custom comparator.
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
-enum ParsedMapKey<'a> {
-    Bool(bool),
-    UInt(u64),
-    SInt(i64),
-    Str(&'a str),
-}
-
-/// Parse a JSON-string map key per the declared key schema and produce
-/// (a) a sortable normalized form and (b) a `serde_json::Value` shaped
-/// for `encode_postcard` so the actual wire bytes flow through the
-/// existing scalar/string/bool encoders. Proto3 stringify rule —
-/// integer keys land as JSON-string digits, bool keys as `"true"` /
-/// `"false"`, string keys identity. Any other key shape is
-/// `UnsupportedSchema`; the `BTreeMap<K: Ord, V>` bound at the Rust
-/// layer makes most of these unreachable, but the codec rejects them
-/// defensively.
-fn parse_map_key<'a>(
-    k_str: &'a str,
-    schema: &SchemaType,
-    path: &str,
-) -> Result<(ParsedMapKey<'a>, Value), EncodeError> {
+/// Parse a JSON-string map key per the declared key schema into a
+/// `serde_json::Value` shaped for `encode_wire_value` so the actual
+/// wire bytes flow through the existing scalar/string/bool encoders.
+/// Proto3 stringify rule — integer keys arrive as JSON-string digits,
+/// bool keys as `"true"` / `"false"`, string keys identity. Any other
+/// key shape is `UnsupportedSchema`; the `BTreeMap<K: Ord, V>` bound at
+/// the Rust layer makes most of these unreachable, but the codec rejects
+/// them defensively. The caller sorts by the encoded key bytes (the
+/// `wire` canonical map order), so no separate sortable form is needed.
+fn parse_map_key(k_str: &str, schema: &SchemaType, path: &str) -> Result<Value, EncodeError> {
     match schema {
-        SchemaType::String => Ok((ParsedMapKey::Str(k_str), Value::String(k_str.to_owned()))),
+        SchemaType::String => Ok(Value::String(k_str.to_owned())),
         SchemaType::Bool => match k_str {
-            "true" => Ok((ParsedMapKey::Bool(true), Value::Bool(true))),
-            "false" => Ok((ParsedMapKey::Bool(false), Value::Bool(false))),
+            "true" => Ok(Value::Bool(true)),
+            "false" => Ok(Value::Bool(false)),
             _ => Err(EncodeError::TypeMismatch {
                 field: path.to_owned(),
                 expected: "\"true\" or \"false\" (bool map key)",
@@ -440,16 +443,16 @@ fn parse_map_key<'a>(
                     expected: "unsigned integer (map key as decimal string)",
                 })?;
                 // Range-check happens at the scalar-write step via
-                // `as_unsigned`; storing as u64 here is lossless for
+                // `as_unsigned`; carrying as u64 here is lossless for
                 // every supported key width.
-                Ok((ParsedMapKey::UInt(n), Value::Number(n.into())))
+                Ok(Value::Number(n.into()))
             }
             Primitive::I8 | Primitive::I16 | Primitive::I32 | Primitive::I64 => {
                 let n: i64 = k_str.parse().map_err(|_| EncodeError::TypeMismatch {
                     field: path.to_owned(),
                     expected: "signed integer (map key as decimal string)",
                 })?;
-                Ok((ParsedMapKey::SInt(n), Value::Number(n.into())))
+                Ok(Value::Number(n.into()))
             }
             Primitive::F32 | Primitive::F64 => {
                 Err(EncodeError::UnsupportedSchema("float as Map key (no Ord)"))
@@ -461,7 +464,10 @@ fn parse_map_key<'a>(
     }
 }
 
-fn write_scalar_postcard(
+/// Write one `Primitive` scalar in the `aether_data::wire` layout:
+/// fixed-width little-endian of the declared width, bit-faithful floats,
+/// no varints and no zigzag.
+fn write_scalar_wire(
     p: Primitive,
     v: &Value,
     name: &str,
@@ -469,42 +475,48 @@ fn write_scalar_postcard(
 ) -> Result<(), EncodeError> {
     match p {
         Primitive::U8 => {
-            let n = as_unsigned(v, name, "u8")?;
-            let n: u8 = n.try_into().map_err(|_| oor(name, "u8"))?;
-            out.push(n);
+            let n: u8 = as_unsigned(v, name, "u8")?
+                .try_into()
+                .map_err(|_| oor(name, "u8"))?;
+            out.extend_from_slice(&n.to_le_bytes());
         }
         Primitive::U16 => {
-            let n = as_unsigned(v, name, "u16")?;
-            let _: u16 = n.try_into().map_err(|_| oor(name, "u16"))?;
-            write_varint_u64(out, n);
+            let n: u16 = as_unsigned(v, name, "u16")?
+                .try_into()
+                .map_err(|_| oor(name, "u16"))?;
+            out.extend_from_slice(&n.to_le_bytes());
         }
         Primitive::U32 => {
-            let n = as_unsigned(v, name, "u32")?;
-            let _: u32 = n.try_into().map_err(|_| oor(name, "u32"))?;
-            write_varint_u64(out, n);
+            let n: u32 = as_unsigned(v, name, "u32")?
+                .try_into()
+                .map_err(|_| oor(name, "u32"))?;
+            out.extend_from_slice(&n.to_le_bytes());
         }
         Primitive::U64 => {
             let n = as_unsigned(v, name, "u64")?;
-            write_varint_u64(out, n);
+            out.extend_from_slice(&n.to_le_bytes());
         }
         Primitive::I8 => {
-            let n = as_signed(v, name, "i8")?;
-            let n: i8 = n.try_into().map_err(|_| oor(name, "i8"))?;
-            out.push(n as u8);
+            let n: i8 = as_signed(v, name, "i8")?
+                .try_into()
+                .map_err(|_| oor(name, "i8"))?;
+            out.extend_from_slice(&n.to_le_bytes());
         }
         Primitive::I16 => {
-            let n = as_signed(v, name, "i16")?;
-            let n: i16 = n.try_into().map_err(|_| oor(name, "i16"))?;
-            write_varint_u64(out, zigzag_i64(i64::from(n)));
+            let n: i16 = as_signed(v, name, "i16")?
+                .try_into()
+                .map_err(|_| oor(name, "i16"))?;
+            out.extend_from_slice(&n.to_le_bytes());
         }
         Primitive::I32 => {
-            let n = as_signed(v, name, "i32")?;
-            let n: i32 = n.try_into().map_err(|_| oor(name, "i32"))?;
-            write_varint_u64(out, zigzag_i64(i64::from(n)));
+            let n: i32 = as_signed(v, name, "i32")?
+                .try_into()
+                .map_err(|_| oor(name, "i32"))?;
+            out.extend_from_slice(&n.to_le_bytes());
         }
         Primitive::I64 => {
             let n = as_signed(v, name, "i64")?;
-            write_varint_u64(out, zigzag_i64(n));
+            out.extend_from_slice(&n.to_le_bytes());
         }
         Primitive::F32 => {
             let n = v.as_f64().ok_or_else(|| EncodeError::TypeMismatch {
@@ -524,18 +536,14 @@ fn write_scalar_postcard(
     Ok(())
 }
 
-/// LEB128-style varint write. Postcard 1.x uses this for u16/u32/u64
-/// and (zigzagged) for i16/i32/i64, plus all collection lengths.
-fn write_varint_u64(out: &mut Vec<u8>, mut n: u64) {
-    while n >= 0x80 {
-        out.push((n as u8) | 0x80);
-        n >>= 7;
-    }
-    out.push(n as u8);
-}
-
-fn zigzag_i64(n: i64) -> u64 {
-    ((n << 1) ^ (n >> 63)) as u64
+/// Write a `u32` little-endian count/length — the `wire` framing for
+/// every string / bytes / vec / map length and the `Ref` inline-body
+/// length. A count past the `u32` ceiling errors (`OutOfRange`) rather
+/// than truncating.
+fn write_count(out: &mut Vec<u8>, len: usize, name: &str) -> Result<(), EncodeError> {
+    let count = u32::try_from(len).map_err(|_| oor(name, "u32 length"))?;
+    out.extend_from_slice(&count.to_le_bytes());
+    Ok(())
 }
 
 /// Pull `(tag, body)` out of an enum-shaped JSON value. Accepts:
@@ -586,7 +594,7 @@ fn encode_enum_body(
             // both interchangeably.
             if fields.len() == 1 {
                 let nested_path = format!("{path}::{name}.0");
-                encode_postcard(body, &fields[0], &nested_path, out)
+                encode_wire_value(body, &fields[0], &nested_path, out)
             } else {
                 let arr = body.as_array().ok_or_else(|| EncodeError::TypeMismatch {
                     field: path.to_owned(),
@@ -601,7 +609,7 @@ fn encode_enum_body(
                 }
                 for (i, (v, ty)) in arr.iter().zip(fields.iter()).enumerate() {
                     let nested = format!("{path}::{name}.{i}");
-                    encode_postcard(v, ty, &nested, out)?;
+                    encode_wire_value(v, ty, &nested, out)?;
                 }
                 Ok(())
             }
@@ -623,7 +631,7 @@ fn encode_enum_body(
                     EncodeError::MissingField(format!("{path}::{name}.{}", field.name))
                 })?;
                 let nested = format!("{path}::{name}.{}", field.name);
-                encode_postcard(v, &field.ty, &nested, out)?;
+                encode_wire_value(v, &field.ty, &nested, out)?;
             }
             Ok(())
         }
@@ -1097,30 +1105,33 @@ mod tests {
         );
     }
 
-    // Postcard path. Each test asserts byte-identity with
-    // `postcard::to_allocvec` on an equivalent typed value — if these
-    // match, the substrate decode (via `postcard::from_bytes`) sees
-    // the same value the agent sent.
+    // Wire path. Each test asserts byte-identity with
+    // `aether_data::wire::to_vec` on an equivalent typed value — if
+    // these match, the substrate decode (via `Kind::decode_from_bytes`,
+    // i.e. `wire::from_bytes`) sees the same value the agent sent. The
+    // dedicated `conformance` module pins the adapter-vs-walker law over
+    // a broader fixture set.
 
+    use aether_data::wire;
     use serde::{Deserialize, Serialize};
 
     #[derive(Serialize, Deserialize)]
-    struct PostcardString {
+    struct WireString {
         body: String,
     }
 
     #[derive(Serialize, Deserialize)]
-    struct PostcardBytes {
+    struct WireBytes {
         blob: Vec<u8>,
     }
 
     #[derive(Serialize, Deserialize)]
-    struct PostcardOption {
+    struct WireOption {
         name: Option<String>,
     }
 
     #[derive(Serialize, Deserialize)]
-    struct PostcardVec {
+    struct WireVec {
         tags: Vec<String>,
     }
 
@@ -1130,7 +1141,7 @@ mod tests {
     }
 
     #[derive(Serialize, Deserialize)]
-    struct PostcardNested {
+    struct WireNested {
         items: Vec<Inner>,
     }
 
@@ -1149,32 +1160,30 @@ mod tests {
     }
 
     #[test]
-    fn postcard_string_field_matches_serde() {
-        let value = PostcardString {
+    fn wire_string_field_matches_serde() {
+        let value = WireString {
             body: "hello world".into(),
         };
-        let expected =
-            postcard::to_allocvec(&value).expect("test setup: postcard reference string");
+        let expected = wire::to_vec(&value).expect("test setup: wire reference string");
         let bytes = encode_schema(&json!({"body": "hello world"}), &pc_string_schema())
             .expect("test setup: encode string field");
         assert_eq!(bytes, expected);
     }
 
     #[test]
-    fn postcard_string_decodes_back() {
+    fn wire_string_decodes_back() {
         let bytes = encode_schema(&json!({"body": "round-trip"}), &pc_string_schema())
             .expect("test setup: encode string for round-trip");
-        let back: PostcardString =
-            postcard::from_bytes(&bytes).expect("test setup: postcard decode string");
+        let back: WireString = wire::from_bytes(&bytes).expect("test setup: wire decode string");
         assert_eq!(back.body, "round-trip");
     }
 
     #[test]
-    fn postcard_bytes_field_matches_serde() {
-        let value = PostcardBytes {
+    fn wire_bytes_field_matches_serde() {
+        let value = WireBytes {
             blob: vec![1, 2, 3, 4, 5],
         };
-        let expected = postcard::to_allocvec(&value).expect("test setup: postcard reference bytes");
+        let expected = wire::to_vec(&value).expect("test setup: wire reference bytes");
         let schema = postcard_struct(vec![NamedField {
             name: "blob".into(),
             ty: SchemaType::Bytes,
@@ -1185,7 +1194,7 @@ mod tests {
     }
 
     #[test]
-    fn postcard_bytes_non_array_errors() {
+    fn wire_bytes_non_array_errors() {
         // The wire codec is strict and canonical: a `Bytes` field accepts
         // only a JSON byte array. String / base64-object ergonomics live in
         // the aether-mcp preprocessor, never in the codec.
@@ -1202,37 +1211,36 @@ mod tests {
     }
 
     #[test]
-    fn postcard_option_some_and_none() {
+    fn wire_option_some_and_none() {
         let schema = postcard_struct(vec![NamedField {
             name: "name".into(),
             ty: SchemaType::Option(SchemaCell::owned(SchemaType::String)),
         }]);
-        let some = PostcardOption {
+        let some = WireOption {
             name: Some("Aether".into()),
         };
         let some_bytes = encode_schema(&json!({"name": "Aether"}), &schema)
             .expect("test setup: encode some(name)");
         assert_eq!(
             some_bytes,
-            postcard::to_allocvec(&some).expect("test setup: postcard reference some")
+            wire::to_vec(&some).expect("test setup: wire reference some")
         );
 
-        let none = PostcardOption { name: None };
+        let none = WireOption { name: None };
         let none_bytes =
             encode_schema(&json!({"name": null}), &schema).expect("test setup: encode none(name)");
         assert_eq!(
             none_bytes,
-            postcard::to_allocvec(&none).expect("test setup: postcard reference none")
+            wire::to_vec(&none).expect("test setup: wire reference none")
         );
     }
 
     #[test]
-    fn postcard_vec_of_strings_matches_serde() {
-        let value = PostcardVec {
+    fn wire_vec_of_strings_matches_serde() {
+        let value = WireVec {
             tags: vec!["alpha".into(), "beta".into(), "gamma".into()],
         };
-        let expected =
-            postcard::to_allocvec(&value).expect("test setup: postcard reference vec<string>");
+        let expected = wire::to_vec(&value).expect("test setup: wire reference vec<string>");
         let schema = postcard_struct(vec![NamedField {
             name: "tags".into(),
             ty: SchemaType::Vec(SchemaCell::owned(SchemaType::String)),
@@ -1243,12 +1251,11 @@ mod tests {
     }
 
     #[test]
-    fn postcard_vec_of_nested_structs_matches_serde() {
-        let value = PostcardNested {
+    fn wire_vec_of_nested_structs_matches_serde() {
+        let value = WireNested {
             items: vec![Inner { seq: 1 }, Inner { seq: 256 }, Inner { seq: 0xDEAD }],
         };
-        let expected =
-            postcard::to_allocvec(&value).expect("test setup: postcard reference vec<inner>");
+        let expected = wire::to_vec(&value).expect("test setup: wire reference vec<inner>");
         let inner_schema = postcard_struct(vec![NamedField {
             name: "seq".into(),
             ty: SchemaType::Scalar(Primitive::U32),
@@ -1270,92 +1277,58 @@ mod tests {
     }
 
     #[test]
-    fn postcard_enum_unit_variant_as_string_tag() {
+    fn wire_enum_unit_variant_as_string_tag() {
         // Unit variant accepts the bare-string form `"Pending"`.
         let bytes = encode_schema(&json!("Pending"), &sum_schema())
             .expect("test setup: encode unit variant");
         assert_eq!(
             bytes,
-            postcard::to_allocvec(&SimpleSum::Pending)
-                .expect("test setup: postcard reference pending")
+            wire::to_vec(&SimpleSum::Pending).expect("test setup: wire reference pending")
         );
     }
 
     #[test]
-    fn postcard_enum_tuple_variant_with_unwrapped_body() {
+    fn wire_enum_tuple_variant_with_unwrapped_body() {
         // Single-element tuple variants accept either `{"Ok": 42}` or
         // `{"Ok": [42]}`. Cover the unwrapped-body form here.
         let bytes = encode_schema(&json!({"Ok": 42u64}), &sum_schema())
             .expect("test setup: encode tuple variant");
         assert_eq!(
             bytes,
-            postcard::to_allocvec(&SimpleSum::Ok(42))
-                .expect("test setup: postcard reference ok(42)")
+            wire::to_vec(&SimpleSum::Ok(42)).expect("test setup: wire reference ok(42)")
         );
     }
 
     #[test]
-    fn postcard_enum_struct_variant() {
+    fn wire_enum_struct_variant() {
         let bytes = encode_schema(&json!({"Err": {"reason": "kind conflict"}}), &sum_schema())
             .expect("test setup: encode struct variant");
-        let expected = postcard::to_allocvec(&SimpleSum::Err {
+        let expected = wire::to_vec(&SimpleSum::Err {
             reason: "kind conflict".into(),
         })
-        .expect("test setup: postcard reference err{reason}");
+        .expect("test setup: wire reference err{reason}");
         assert_eq!(bytes, expected);
     }
 
     #[test]
-    fn postcard_enum_unknown_tag_errors() {
+    fn wire_enum_unknown_tag_errors() {
         let err =
             encode_schema(&json!("Nope"), &sum_schema()).expect_err("unknown enum tag must error");
         assert!(matches!(err, EncodeError::TypeMismatch { .. }));
     }
 
     #[test]
-    fn postcard_string_rejects_non_string() {
+    fn wire_string_rejects_non_string() {
         let err = encode_schema(&json!({"body": 7}), &pc_string_schema())
             .expect_err("number for string field must error");
         assert!(matches!(err, EncodeError::TypeMismatch { .. }));
     }
 
     #[test]
-    fn postcard_struct_rejects_unexpected_field() {
+    fn wire_struct_rejects_unexpected_field() {
         let err = encode_schema(&json!({"body": "ok", "extra": "nope"}), &pc_string_schema())
-            .expect_err("extra field in postcard struct must error");
+            .expect_err("extra field in wire struct must error");
         assert!(matches!(err, EncodeError::UnexpectedField(_)));
-    }
-
-    #[test]
-    fn varint_matches_postcard_for_boundaries() {
-        // 0, 127, 128, 16383, 16384 — each crosses a varint byte
-        // boundary and is the most likely place for an off-by-one.
-        for n in [0u64, 127, 128, 16383, 16384, u64::from(u32::MAX), u64::MAX] {
-            let mut ours = Vec::new();
-            write_varint_u64(&mut ours, n);
-            let theirs =
-                postcard::to_allocvec(&n).expect("test setup: postcard reference varint u64");
-            assert_eq!(ours, theirs, "varint mismatch for {n}");
-        }
-    }
-
-    #[test]
-    fn zigzag_matches_postcard_for_signed() {
-        for n in [
-            0i64,
-            -1,
-            1,
-            -128,
-            127,
-            i64::from(i32::MIN),
-            i64::from(i32::MAX),
-        ] {
-            let mut ours = Vec::new();
-            write_varint_u64(&mut ours, zigzag_i64(n));
-            let theirs =
-                postcard::to_allocvec(&n).expect("test setup: postcard reference zigzag i64");
-            assert_eq!(ours, theirs, "zigzag mismatch for {n}");
-        }
     }
 
     // Issue #232 — `SchemaType::Map` encode tests. proto3-style JSON:
@@ -1369,11 +1342,11 @@ mod tests {
     }
 
     #[test]
-    fn map_string_keys_matches_postcard_btreemap() {
-        // Reference value is a `BTreeMap<String, String>` postcarded by
-        // serde — that's the wire shape every receiving substrate will
-        // decode into. Sender input is unsorted to lock in the
-        // sort-after-parse step.
+    fn map_string_keys_matches_wire_btreemap() {
+        // Reference value is a `BTreeMap<String, String>` encoded by the
+        // `wire` serde adapter — that's the wire shape every receiving
+        // substrate will decode into. Sender input is unsorted to lock in
+        // the sort-by-encoded-key step.
         let schema = postcard_struct(vec![NamedField {
             name: "headers".into(),
             ty: map_schema(SchemaType::String, SchemaType::String),
@@ -1383,8 +1356,8 @@ mod tests {
         reference.insert("content-type".into(), "application/json".into());
         reference.insert("x-trace".into(), "abc123".into());
 
-        let expected = postcard::to_allocvec(&reference)
-            .expect("test setup: postcard reference btreemap<string,string>");
+        let expected =
+            wire::to_vec(&reference).expect("test setup: wire reference btreemap<string,string>");
 
         let bytes = encode_schema(
             &json!({"headers": {"x-trace": "abc123", "content-type": "application/json"}}),
@@ -1392,16 +1365,16 @@ mod tests {
         )
         .expect("test setup: encode map<string,string> field");
 
-        // Strip the schema-struct field-prefix bytes — there are none
-        // here since the field's value is the whole map. The encoded
-        // payload is exactly the BTreeMap postcard bytes.
+        // A one-field wire struct adds no framing, so the encoded payload
+        // is exactly the BTreeMap wire image (one leading version byte +
+        // the encoded-key-sorted entries).
         assert_eq!(bytes, expected);
     }
 
     #[test]
     fn map_string_keys_sender_order_independent() {
         // Two callers produce the same wire bytes regardless of JSON
-        // input order. Pins the sort-by-parsed-key step.
+        // input order. Pins the sort-by-encoded-key step.
         let schema = map_schema(SchemaType::String, SchemaType::Scalar(Primitive::U32));
         let a = encode_schema(&json!({"alpha": 1, "beta": 2, "gamma": 3}), &schema)
             .expect("test setup: encode map in order A");
@@ -1411,7 +1384,7 @@ mod tests {
     }
 
     #[test]
-    fn map_u32_keys_match_postcard_btreemap() {
+    fn map_u32_keys_match_wire_btreemap() {
         let schema = map_schema(SchemaType::Scalar(Primitive::U32), SchemaType::String);
 
         let mut reference: BTreeMap<u32, String> = BTreeMap::new();
@@ -1419,8 +1392,8 @@ mod tests {
         reference.insert(42, "answer".into());
         reference.insert(255, "max-u8".into());
 
-        let expected = postcard::to_allocvec(&reference)
-            .expect("test setup: postcard reference btreemap<u32,string>");
+        let expected =
+            wire::to_vec(&reference).expect("test setup: wire reference btreemap<u32,string>");
 
         let bytes = encode_schema(
             &json!({"42": "answer", "1": "one", "255": "max-u8"}),
@@ -1431,13 +1404,42 @@ mod tests {
     }
 
     #[test]
-    fn map_bool_keys_match_postcard_btreemap() {
+    fn map_u32_keys_sort_by_encoded_little_endian_bytes() {
+        // Keys 1 and 256 sort numerically as 1 < 256, but their
+        // little-endian u32 encodings (`[1,0,0,0]` vs `[0,1,0,0]`) sort
+        // 256 < 1. The codec must match `wire`'s encoded-byte order — this
+        // is the multi-byte-key case the adapter-vs-walker cross-check
+        // guards.
+        let schema = map_schema(
+            SchemaType::Scalar(Primitive::U32),
+            SchemaType::Scalar(Primitive::U8),
+        );
+        let mut reference: BTreeMap<u32, u8> = BTreeMap::new();
+        reference.insert(1, 10);
+        reference.insert(256, 20);
+        let expected =
+            wire::to_vec(&reference).expect("test setup: wire reference btreemap<u32,u8>");
+        let bytes = encode_schema(&json!({"1": 10, "256": 20}), &schema)
+            .expect("test setup: encode map<u32,u8> field");
+        assert_eq!(bytes, expected);
+        // The 256 entry (`[0,1,0,0]`) precedes the 1 entry (`[1,0,0,0]`).
+        let mut hand = vec![WIRE_VERSION];
+        hand.extend_from_slice(&2u32.to_le_bytes()); // count
+        hand.extend_from_slice(&256u32.to_le_bytes()); // key 256
+        hand.push(20); // value
+        hand.extend_from_slice(&1u32.to_le_bytes()); // key 1
+        hand.push(10); // value
+        assert_eq!(bytes, hand);
+    }
+
+    #[test]
+    fn map_bool_keys_match_wire_btreemap() {
         let schema = map_schema(SchemaType::Bool, SchemaType::Scalar(Primitive::U32));
         let mut reference: BTreeMap<bool, u32> = BTreeMap::new();
         reference.insert(false, 0);
         reference.insert(true, 1);
-        let expected = postcard::to_allocvec(&reference)
-            .expect("test setup: postcard reference btreemap<bool,u32>");
+        let expected =
+            wire::to_vec(&reference).expect("test setup: wire reference btreemap<bool,u32>");
         let bytes = encode_schema(&json!({"true": 1, "false": 0}), &schema)
             .expect("test setup: encode map<bool,u32> field");
         assert_eq!(bytes, expected);
@@ -1485,12 +1487,13 @@ mod tests {
         assert!(matches!(err, EncodeError::UnsupportedSchema(_)));
     }
 
-    // ADR-0065: typed-id JSON ↔ postcard.
+    // ADR-0065: typed-id JSON ↔ wire.
 
     #[test]
-    fn type_id_postcard_accepts_tagged_string() {
+    fn type_id_wire_accepts_tagged_string() {
         // `mailbox` field carrying a tagged `mbx-...` string lands as
-        // a postcard u64 varint — wire-identical to a raw `u64` field.
+        // a fixed `u64` little-endian — wire-identical to a raw `u64`
+        // field, behind the leading version byte.
         let schema = postcard_struct(vec![NamedField {
             name: "mailbox".into(),
             ty: SchemaType::TypeId(aether_data::MailboxId::TYPE_ID),
@@ -1498,14 +1501,14 @@ mod tests {
         let mailbox = aether_data::MailboxId::from_name("aether.component");
         let s = tagged_id::encode(mailbox.0).expect("test setup: encode tagged mailbox id");
         let bytes = encode_schema(&json!({ "mailbox": s }), &schema)
-            .expect("test setup: encode typed-id postcard field");
-        let mut expected = Vec::new();
-        write_varint_u64(&mut expected, mailbox.0);
+            .expect("test setup: encode typed-id wire field");
+        let mut expected = vec![WIRE_VERSION];
+        expected.extend_from_slice(&mailbox.0.to_le_bytes());
         assert_eq!(bytes, expected);
     }
 
     #[test]
-    fn type_id_postcard_accepts_raw_number_for_back_compat() {
+    fn type_id_wire_accepts_raw_number_for_back_compat() {
         // Pre-ADR-0065 callers passing a JSON number still work — the
         // codec falls through to the back-compat `as_unsigned` path.
         let schema = postcard_struct(vec![NamedField {
@@ -1515,13 +1518,13 @@ mod tests {
         let mailbox = aether_data::MailboxId::from_name("aether.component");
         let bytes = encode_schema(&json!({ "mailbox": mailbox.0 }), &schema)
             .expect("test setup: encode typed-id from raw number");
-        let mut expected = Vec::new();
-        write_varint_u64(&mut expected, mailbox.0);
+        let mut expected = vec![WIRE_VERSION];
+        expected.extend_from_slice(&mailbox.0.to_le_bytes());
         assert_eq!(bytes, expected);
     }
 
     #[test]
-    fn type_id_postcard_rejects_wrong_tag() {
+    fn type_id_wire_rejects_wrong_tag() {
         // A `KindId`-tagged string passed to a `MailboxId` field
         // surfaces a typed `OutOfRange` so the agent learns the field
         // expected `mbx-...` rather than corrupting the wire.
@@ -1561,7 +1564,7 @@ mod tests {
     }
 
     #[test]
-    fn type_id_postcard_rejects_unknown_type_id() {
+    fn type_id_wire_rejects_unknown_type_id() {
         // A schema declaring a `TypeId(...)` value the codec doesn't
         // recognise must surface `UnsupportedSchema` rather than
         // corrupt the wire or silently fall through.

--- a/crates/aether-codec/src/lib.rs
+++ b/crates/aether-codec/src/lib.rs
@@ -23,6 +23,8 @@
 //! `frame::postcard` / `frame::protobuf`.
 
 mod cast;
+#[cfg(test)]
+mod conformance;
 mod decode;
 mod encode;
 pub mod frame;

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -852,6 +852,8 @@ pub mod __derive_runtime {
     pub use alloc::vec::Vec;
     use serde::de::DeserializeOwned;
 
+    use crate::wire;
+
     /// Cast-shape decode helper. Routes through `bytemuck::pod_read_unaligned`
     /// after a length check so the Kind derive can emit a uniform call
     /// without the user crate needing `bytemuck` in scope. `T` satisfies
@@ -879,15 +881,16 @@ pub mod __derive_runtime {
         bytemuck::try_cast_slice(bytes).ok()
     }
 
-    /// Postcard-shape decode helper. Sibling of `decode_cast` for
+    /// Wire-shape decode helper. Sibling of `decode_cast` for
     /// schema-shaped kinds (anything carrying `Vec` / `String` /
     /// `Option` / a tagged enum). `T` satisfies `DeserializeOwned`
     /// via the user's `#[derive(Deserialize)]`; the bound lives on
     /// this helper rather than on `Kind` so cast kinds stay
-    /// independent of `serde`.
+    /// independent of `serde`. Strips the leading `WIRE_VERSION` byte
+    /// (ADR-0118) before reading the value.
     #[must_use]
-    pub fn decode_postcard<T: DeserializeOwned>(bytes: &[u8]) -> Option<T> {
-        postcard::from_bytes(bytes).ok()
+    pub fn decode_wire<T: DeserializeOwned>(bytes: &[u8]) -> Option<T> {
+        wire::from_bytes(bytes).ok()
     }
 
     /// Cast-shape encode helper. Mirror of `decode_cast`. Routes
@@ -899,11 +902,12 @@ pub mod __derive_runtime {
         bytemuck::bytes_of(value).to_vec()
     }
 
-    /// Postcard-shape encode helper. Mirror of `decode_postcard`. The
+    /// Wire-shape encode helper. Mirror of `decode_wire`. The
     /// `Serialize` bound lives here, not on `Kind`, so cast kinds stay
-    /// independent of `serde`.
-    pub fn encode_postcard<T: serde::Serialize>(value: &T) -> Vec<u8> {
-        postcard::to_allocvec(value).expect("postcard encode to Vec is infallible")
+    /// independent of `serde`. Prepends the leading `WIRE_VERSION` byte
+    /// (ADR-0118); encoding fails only past the `u32` length ceiling.
+    pub fn encode_wire<T: serde::Serialize>(value: &T) -> Vec<u8> {
+        wire::to_vec(value).expect("wire encode to Vec fails only past the u32 length ceiling")
     }
 }
 
@@ -916,8 +920,8 @@ pub enum DecodeError {
     SizeMismatch { expected: usize, actual: usize },
     /// Alignment of the input slice is incompatible with the target type.
     Alignment,
-    /// Postcard decode failed for a structural payload.
-    Postcard(postcard::Error),
+    /// Wire decode failed for a structural payload (ADR-0118).
+    Wire(wire::Error),
 }
 
 impl fmt::Display for DecodeError {
@@ -930,7 +934,7 @@ impl fmt::Display for DecodeError {
                 )
             }
             Self::Alignment => f.write_str("data payload alignment mismatch"),
-            Self::Postcard(e) => write!(f, "postcard decode failed: {e}"),
+            Self::Wire(e) => write!(f, "wire decode failed: {e}"),
         }
     }
 }
@@ -951,9 +955,9 @@ impl From<bytemuck::PodCastError> for DecodeError {
     }
 }
 
-impl From<postcard::Error> for DecodeError {
-    fn from(err: postcard::Error) -> Self {
-        Self::Postcard(err)
+impl From<wire::Error> for DecodeError {
+    fn from(err: wire::Error) -> Self {
+        Self::Wire(err)
     }
 }
 
@@ -1048,11 +1052,11 @@ mod tests {
         const ID: KindId = KindId(0xDEAD_BEEF_0000_0003);
 
         fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-            __derive_runtime::decode_postcard::<Self>(bytes)
+            __derive_runtime::decode_wire::<Self>(bytes)
         }
 
         fn encode_into_bytes(&self) -> Vec<u8> {
-            __derive_runtime::encode_postcard::<Self>(self)
+            __derive_runtime::encode_wire::<Self>(self)
         }
     }
 

--- a/crates/aether-data/src/wire/mod.rs
+++ b/crates/aether-data/src/wire/mod.rs
@@ -103,13 +103,22 @@ impl DeError for Error {
 /// Encode a value to a versioned wire payload: [`WIRE_VERSION`] followed by the
 /// value's encoding.
 pub fn to_vec<T: Serialize + ?Sized>(value: &T) -> Result<Vec<u8>, Error> {
-    let mut serializer = ser::Serializer::new();
-    value.serialize(&mut serializer)?;
-    let body = serializer.into_output();
+    let body = to_vec_bare(value)?;
     let mut out = Vec::with_capacity(body.len() + 1);
     out.push(WIRE_VERSION);
     out.extend_from_slice(&body);
     Ok(out)
+}
+
+/// Encode a value to **bare** wire bytes with no leading [`WIRE_VERSION`]. The
+/// bytes are an interior value, not a self-describing kind image — for
+/// hand-assembly sites (e.g. the DAG executor) that concatenate interior values
+/// into one kind image and prepend the single version byte themselves. Most
+/// callers want [`to_vec`].
+pub fn to_vec_bare<T: Serialize + ?Sized>(value: &T) -> Result<Vec<u8>, Error> {
+    let mut serializer = ser::Serializer::new();
+    value.serialize(&mut serializer)?;
+    Ok(serializer.into_output())
 }
 
 /// Decode a value from a versioned wire payload, requiring every byte consumed.

--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -521,10 +521,11 @@ mod tests {
         );
     }
 
-    /// Postcard round-trip for `TrajectoryLog`: encode via `Kind::encode_into_bytes`,
-    /// decode via postcard, assert equality of all fields and samples in order.
+    /// Wire round-trip for `TrajectoryLog`: encode and decode through the
+    /// `Kind` codec (ADR-0118 `aether_data::wire`), asserting equality of
+    /// all fields and samples in order.
     #[test]
-    fn trajectory_log_postcard_roundtrip() {
+    fn trajectory_log_wire_roundtrip() {
         use crate::{TrajectoryEndReason, TrajectorySampleEntry};
 
         let original = TrajectoryLog {
@@ -547,8 +548,8 @@ mod tests {
         };
 
         let bytes = original.encode_into_bytes();
-        let decoded: TrajectoryLog =
-            postcard::from_bytes(&bytes).expect("TrajectoryLog round-trips via postcard");
+        let decoded = TrajectoryLog::decode_from_bytes(&bytes)
+            .expect("TrajectoryLog round-trips through the wire codec");
 
         assert_eq!(decoded.seed, original.seed);
         assert_eq!(decoded.samples.len(), 2);

--- a/crates/aether-labyrinth/src/trajectory.rs
+++ b/crates/aether-labyrinth/src/trajectory.rs
@@ -388,8 +388,8 @@ mod native {
             let (stored_kind, stored_bytes) =
                 fix.store.get(handle_id).expect("handle exists in store");
             assert_eq!(stored_kind, TrajectoryLog::ID, "stored kind id matches");
-            let log: TrajectoryLog =
-                postcard::from_bytes(&stored_bytes).expect("stored bytes decode to TrajectoryLog");
+            let log = TrajectoryLog::decode_from_bytes(&stored_bytes)
+                .expect("stored bytes decode to TrajectoryLog");
             assert_eq!(log.seed, seed);
             assert_eq!(log.end_reason, TrajectoryEndReason::Completed);
             assert_eq!(log.samples.len(), 2);
@@ -550,7 +550,7 @@ mod native {
                 let (stored_kind, stored_bytes) =
                     store.get(handle_id).expect("handle exists in store");
                 assert_eq!(stored_kind, TrajectoryLog::ID);
-                let log: TrajectoryLog = postcard::from_bytes(&stored_bytes)
+                let log = TrajectoryLog::decode_from_bytes(&stored_bytes)
                     .expect("stored bytes decode to TrajectoryLog");
                 assert_eq!(log.seed, seed);
                 assert_eq!(log.end_reason, TrajectoryEndReason::Completed);

--- a/crates/aether-substrate/src/actor/native/blob_work.rs
+++ b/crates/aether-substrate/src/actor/native/blob_work.rs
@@ -1077,6 +1077,7 @@ mod tests {
     use crate::mail::{KindId, MailRef};
     use crate::scheduler::{SeizeSeed, SlotState, SpinPark};
     use crate::test_util::fresh_substrate;
+    use aether_data::wire::WIRE_VERSION;
     use aether_data::{KindDescriptor, MailId, SchemaCell, SchemaType};
     use crossbeam_deque::{Injector, Steal};
     use std::sync::mpsc;
@@ -1298,13 +1299,15 @@ mod tests {
             })
             .expect("fresh ref kind registers");
 
+        // A valid versioned wire `Ref::Inline(empty)` image: version byte,
+        // u32 selector 0, u32 inline-length 0. The ref-walk resolves it
+        // (no substitution), and the deposit inbox forwards the resolved
+        // payload's first byte — the retained version byte.
+        let mut ref_payload = vec![WIRE_VERSION];
+        ref_payload.extend_from_slice(&0u32.to_le_bytes()); // inline selector
+        ref_payload.extend_from_slice(&0u32.to_le_bytes()); // inline length
         let mut producer = BlobProducer::new(Arc::clone(&mailer), wake_sink(&injector));
-        producer.flush(vec![Mail::new(
-            id,
-            ref_kind,
-            MailRef::from(vec![0u8, 0u8]),
-            1,
-        )]);
+        producer.flush(vec![Mail::new(id, ref_kind, MailRef::from(ref_payload), 1)]);
         drain_injector(&injector);
 
         assert!(
@@ -1313,7 +1316,7 @@ mod tests {
         );
         assert_eq!(
             deposit_rx.try_recv().ok(),
-            Some(0),
+            Some(WIRE_VERSION),
             "ref kind deposited for the ref-walk"
         );
     }

--- a/crates/aether-substrate/src/dag/executor.rs
+++ b/crates/aether-substrate/src/dag/executor.rs
@@ -41,6 +41,7 @@
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
+use aether_data::wire::{self, WIRE_VERSION};
 use aether_data::{
     DagId, HandleId, KindId, MailId, MailboxId, Ref, SchemaType, Tag, TransformId,
     content_addressed_handle_id, with_tag,
@@ -1341,7 +1342,12 @@ fn assemble_request(
     let by_id: HashMap<NodeId, &Node> =
         state.descriptor.nodes.iter().map(|n| (n.id(), n)).collect();
 
-    let mut out: Vec<u8> = Vec::new();
+    // The assembled request is one wire kind image: a single leading
+    // `WIRE_VERSION` byte (ADR-0118), then each slot's `Ref::Handle`
+    // encoded **bare** as an interior value and concatenated in
+    // declaration order — exactly what `wire::to_vec` of a struct of
+    // `Ref` fields produces.
+    let mut out: Vec<u8> = vec![WIRE_VERSION];
     for (slot_index, cell) in ref_slot_cells.iter().enumerate() {
         let slot = u32::try_from(slot_index).unwrap_or(u32::MAX);
         let from = slot_source.get(&slot)?;
@@ -1349,15 +1355,16 @@ fn assemble_request(
         let stamp = producer_output_kind(by_id.get(from).copied(), registry, cell);
         // The Handle variant carries no `K`, so any `Kind` marker works
         // (`Ref<K>`'s serde needs `K: Kind` post-ADR-0100, and the unit
-        // kind is the zero-cost marker) — emit the wire
-        // `Ref::Handle { id, kind_id }`. The walk-and-resolve path
-        // validates against the *field's* expected type at dispatch,
-        // splicing the stored bytes inline (or parking).
+        // kind is the zero-cost marker) — emit the bare wire
+        // `Ref::Handle { id, kind_id }` (`u32` selector 1 + two 8-LE
+        // ids). The walk-and-resolve path validates against the *field's*
+        // expected type at dispatch, splicing the stored bytes inline
+        // (or parking).
         let r: Ref<()> = Ref::Handle {
             id: handle.0,
             kind_id: stamp.0,
         };
-        let mut field_bytes = postcard::to_allocvec(&r).ok()?;
+        let mut field_bytes = wire::to_vec_bare(&r).ok()?;
         out.append(&mut field_bytes);
     }
     Some(out)
@@ -1480,6 +1487,7 @@ mod config_tests {
 mod assemble_tests {
     use std::collections::HashMap;
 
+    use aether_data::wire;
     use aether_data::{DagId, HandleId, Kind, KindDescriptor, Ref, Schema, TransformId};
     use aether_kinds::{DagDescriptor, Edge, Node, NodeId};
 
@@ -1561,9 +1569,10 @@ mod assemble_tests {
         DagState::new(DagId(1), validated, handles)
     }
 
-    /// Decode the single emitted `Ref::Handle` from an assembled payload.
+    /// Decode the single emitted `Ref::Handle` from an assembled payload:
+    /// strip the leading `WIRE_VERSION` byte, then read the bare `Ref`.
     fn decode_stamp(payload: &[u8]) -> (u64, u64) {
-        let r: Ref<()> = postcard::from_bytes(payload).expect("decode Ref wire");
+        let r: Ref<()> = wire::from_bytes(payload).expect("decode Ref wire");
         match r {
             Ref::Handle { id, kind_id } => (id, kind_id),
             Ref::Inline(()) => panic!("assemble emits the Handle arm"),

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -1,7 +1,7 @@
-// Wire-encode: `usize → u32` narrowings encode handle-cache byte
-// lengths into the postcard varint slots described in the wire
-// format below; `u32 → u64` widenings move handle ids into the
-// 64-bit id slot. Both are part of the load-bearing wire layout.
+// Wire-encode: `usize → u32` narrowings write handle-cache byte
+// lengths into the `u32` length slots of the `aether_data::wire` format
+// below; `u32 → u64` widenings move handle ids into the 64-bit id slot.
+// Both are part of the load-bearing wire layout.
 #![allow(clippy::cast_lossless, clippy::cast_possible_truncation)]
 // `HandleStore` Mutex guards are intentionally held across read-then-
 // update sequences (lookup + refcount mutation, eviction scan + drop)
@@ -18,14 +18,19 @@
 //! of the inline value; the substrate resolves the handle on dispatch
 //! and substitutes the inline bytes before delivering the mail.
 //!
-//! Wire format (ADR-0045 §1, inline arm revised by ADR-0100):
-//! - Inline arm: discriminant 0 + `varint(len)` + `K::encode_into_bytes`
-//!   (`len` bytes) — the kind's own codec image (cast or postcard),
-//!   an opaque length-delimited blob the walker skips by length.
-//! - Handle arm: discriminant 1 + `varint(id)` + `varint(kind_id)`.
+//! Wire format (ADR-0045 §1, inline arm revised by ADR-0100,
+//! re-laid-out onto `aether_data::wire` by ADR-0118): the payload is a
+//! versioned kind image — a leading `WIRE_VERSION` byte the walker
+//! strips on entry (and again at each inline-arm descent), then bare
+//! interior values. A `Ref` is:
+//! - Inline arm: `u32` selector 0 + `u32` length + `K::encode_into_bytes`
+//!   (`len` bytes) — the kind's own codec image (cast or wire, itself
+//!   versioned for a wire kind), an opaque length-delimited blob the
+//!   walker skips by length.
+//! - Handle arm: `u32` selector 1 + `id` (8 LE) + `kind_id` (8 LE).
 //!
 //! Resolution is structural: the walker reads the schema and skips
-//! through the payload bytes, splicing inline-discriminant + cached
+//! through the payload bytes, splicing inline-selector + cached
 //! bytes at every Handle position. Mail addressed to an unresolved
 //! handle parks under that handle's id; the next put-and-resolve
 //! drains the queue and re-routes through the mailer.
@@ -61,6 +66,7 @@ use crate::config::ConfigError;
 use crate::mail::Mail;
 use crate::mail::registry::Registry;
 use crate::pid_lock::{LockAcquisition, LockGuard, acquire_lock_pid};
+use aether_data::wire::WIRE_VERSION;
 use aether_data::{EnumVariant, Primitive, SchemaType};
 use aether_data::{HandleId, KindId};
 use std::env;
@@ -464,9 +470,10 @@ fn now_millis() -> u64 {
         .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
 }
 
-/// Per-entry store record. Bytes are the postcard-encoded `K` body
-/// (the same shape `Ref::Inline` would carry), kept owned because the
-/// walker copies them into spliced output during dispatch.
+/// Per-entry store record. Bytes are `K`'s own codec image
+/// (`K::encode_into_bytes` — a versioned wire image, or a bare cast
+/// image), the same shape `Ref::Inline` would carry, kept owned because
+/// the walker copies them into spliced output during dispatch.
 #[derive(Debug)]
 struct HandleEntry {
     kind: KindId,
@@ -597,7 +604,10 @@ pub enum WalkError {
     Truncated,
     InvalidBool,
     UnknownEnumDiscriminant,
-    VarintOverflow,
+    /// The payload did not open with [`WIRE_VERSION`] (ADR-0118).
+    BadVersion(u8),
+    /// A spliced inline body exceeded the `u32` length ceiling.
+    Length,
     UnknownRefDiscriminant,
 }
 
@@ -2053,9 +2063,18 @@ pub fn walk_and_resolve<'a>(
             payload: Cow::Borrowed(payload),
         });
     }
+    // The payload is a versioned wire kind image (ADR-0118). Strip the
+    // leading version byte for reading, but leave it in the output:
+    // `pos` starts after it while `prefix_end` stays at 0, so the first
+    // splice's `flush_up_to` copies the version byte into the resolved
+    // image (and the no-splice path returns the whole input verbatim).
+    let version = *payload.first().ok_or(WalkError::Truncated)?;
+    if version != WIRE_VERSION {
+        return Err(WalkError::BadVersion(version));
+    }
     let mut state = State {
         input: payload,
-        pos: 0,
+        pos: 1,
         out: Vec::new(),
         prefix_end: 0,
         out_initialised: false,
@@ -2111,18 +2130,27 @@ impl<'a> State<'a> {
         Ok(b)
     }
 
-    fn read_varint(&mut self) -> Result<u64, WalkError> {
-        let mut n: u64 = 0;
-        let mut shift: u32 = 0;
-        for _ in 0..10 {
-            let b = self.read_byte()?;
-            n |= ((b & 0x7f) as u64) << shift;
-            if b & 0x80 == 0 {
-                return Ok(n);
-            }
-            shift += 7;
+    fn read_array<const N: usize>(&mut self) -> Result<[u8; N], WalkError> {
+        if self.pos + N > self.input.len() {
+            return Err(WalkError::Truncated);
         }
-        Err(WalkError::VarintOverflow)
+        let mut out = [0u8; N];
+        out.copy_from_slice(&self.input[self.pos..self.pos + N]);
+        self.pos += N;
+        Ok(out)
+    }
+
+    /// Read a `u32` little-endian count / length / selector — the `wire`
+    /// framing for string / bytes / vec / map lengths, the enum
+    /// discriminant, and the `Ref` selector.
+    fn read_count(&mut self) -> Result<u32, WalkError> {
+        Ok(u32::from_le_bytes(self.read_array::<4>()?))
+    }
+
+    /// Read a `u64` little-endian id — the `Ref` handle arm's `id` and
+    /// `kind_id`.
+    fn read_u64(&mut self) -> Result<u64, WalkError> {
+        Ok(u64::from_le_bytes(self.read_array::<8>()?))
     }
 
     fn skip_n(&mut self, n: usize) -> Result<(), WalkError> {
@@ -2132,22 +2160,12 @@ impl<'a> State<'a> {
         self.pos += n;
         Ok(())
     }
-
-    fn skip_varint(&mut self) -> Result<(), WalkError> {
-        for _ in 0..10 {
-            let b = self.read_byte()?;
-            if b & 0x80 == 0 {
-                return Ok(());
-            }
-        }
-        Err(WalkError::VarintOverflow)
-    }
 }
 
-/// Walk one `schema` node, advancing `state.pos` past its postcard
-/// wire. Returns `Ok(Some((handle, kind)))` to signal "park on this
-/// handle", `Ok(None)` for fully-walked, `Err(...)` for malformed
-/// wire.
+/// Walk one `schema` node, advancing `state.pos` past its
+/// `aether_data::wire` bytes. Returns `Ok(Some((handle, kind)))` to
+/// signal "park on this handle", `Ok(None)` for fully-walked,
+/// `Err(...)` for malformed wire.
 // One match arm per `SchemaType` variant; extracting per-type helpers
 // would force per-arm `&mut State<'_>` plumbing without saving
 // readability.
@@ -2167,11 +2185,11 @@ fn walk(
             Ok(None)
         }
         SchemaType::Scalar(p) => {
-            skip_primitive_postcard(state, *p)?;
+            skip_primitive_wire(state, *p)?;
             Ok(None)
         }
         SchemaType::String | SchemaType::Bytes => {
-            let len = state.read_varint()? as usize;
+            let len = state.read_count()? as usize;
             state.skip_n(len)?;
             Ok(None)
         }
@@ -2184,7 +2202,7 @@ fn walk(
             }
         }
         SchemaType::Vec(inner) => {
-            let len = state.read_varint()? as usize;
+            let len = state.read_count()? as usize;
             for _ in 0..len {
                 if let Some(parked) = walk(inner, state, store)? {
                     return Ok(Some(parked));
@@ -2201,11 +2219,11 @@ fn walk(
             Ok(None)
         }
         SchemaType::Struct { fields, .. } => {
-            // Postcard wire encodes a struct as concatenated field
-            // bytes regardless of `repr_c`. The walker is only
-            // invoked on postcard kinds (cast-shaped kinds skip the
-            // walker via the fast path), so descending into each
-            // field as postcard is correct.
+            // The wire format encodes a struct as concatenated field
+            // bytes regardless of `repr_c`. The walker is only invoked
+            // on wire (ref-bearing) kinds (cast-shaped kinds skip the
+            // walker via the fast path), so descending into each field
+            // as a wire value is correct.
             for f in fields.iter() {
                 if let Some(parked) = walk(&f.ty, state, store)? {
                     return Ok(Some(parked));
@@ -2214,7 +2232,7 @@ fn walk(
             Ok(None)
         }
         SchemaType::Enum { variants } => {
-            let disc = state.read_varint()? as u32;
+            let disc = state.read_count()?;
             let variant = variants
                 .iter()
                 .find(|v| v.discriminant() == disc)
@@ -2247,7 +2265,7 @@ fn walk(
             // rules, but the walker treats them uniformly so a
             // hand-rolled `Schema` impl that lands a `Ref` key here
             // doesn't silently corrupt the wire.
-            let len = state.read_varint()? as usize;
+            let len = state.read_count()? as usize;
             for _ in 0..len {
                 if let Some(parked) = walk(key, state, store)? {
                     return Ok(Some(parked));
@@ -2260,23 +2278,24 @@ fn walk(
         }
         SchemaType::Ref(inner) => {
             let ref_disc_start = state.pos;
-            let disc = state.read_varint()? as u32;
+            let disc = state.read_count()?;
             match disc {
                 0 => {
                     // ADR-0100: the inline body is an opaque
-                    // length-prefixed blob (`varint(len)` +
+                    // length-prefixed blob (`u32(len)` +
                     // `K::encode_into_bytes`) — the kind's own codec
-                    // image, cast or postcard. Skip it by length rather
+                    // image, cast or wire. Skip it by length rather
                     // than re-deriving `K`'s byte layout from `inner`;
-                    // a cast image is not a schema-walkable postcard
-                    // structure.
-                    let len = state.read_varint()? as usize;
+                    // a cast image is not a schema-walkable wire
+                    // structure, and the wire inner carries its own
+                    // version byte inside the blob.
+                    let len = state.read_count()? as usize;
                     state.skip_n(len)?;
                     Ok(None)
                 }
                 1 => {
-                    let id = HandleId(state.read_varint()?);
-                    let kind = KindId(state.read_varint()?);
+                    let id = HandleId(state.read_u64()?);
+                    let kind = KindId(state.read_u64()?);
                     let after_handle = state.pos;
                     let Some((stored_kind, bytes)) = store.get(id) else {
                         return Ok(Some((id, kind)));
@@ -2311,15 +2330,20 @@ fn walk(
                     match resolved_inner {
                         WalkOutcome::Parked { handle, kind } => Ok(Some((handle, kind))),
                         WalkOutcome::Resolved { payload } => {
-                            // Splice: flush prefix, write the Inline arm
-                            // (disc 0 + varint(len) + payload, ADR-0100),
-                            // skip past the Handle wire bytes. The
-                            // payload is the resolved inline blob — the
-                            // byte image is identical whether it arrived
-                            // inline or was spliced from a handle here.
+                            // Splice: flush prefix (which carries the
+                            // top-level version byte), write the Inline
+                            // arm (`u32` selector 0 + `u32` length +
+                            // payload, ADR-0118), skip past the Handle
+                            // wire bytes. The payload is the resolved
+                            // inline blob — a pure byte-copy of the
+                            // stored versioned (or cast) image, identical
+                            // whether the value arrived inline or was
+                            // spliced from a handle here.
+                            let len =
+                                u32::try_from(payload.len()).map_err(|_| WalkError::Length)?;
                             state.flush_up_to(ref_disc_start);
-                            state.out.push(0u8);
-                            push_varint(&mut state.out, payload.len() as u64);
+                            state.out.extend_from_slice(&0u32.to_le_bytes());
+                            state.out.extend_from_slice(&len.to_le_bytes());
                             state.out.extend_from_slice(&payload);
                             state.prefix_end = after_handle;
                             Ok(None)
@@ -2329,45 +2353,24 @@ fn walk(
                 _ => Err(WalkError::UnknownRefDiscriminant),
             }
         }
-        // ADR-0065: typed-id wire is a u64 varint regardless of
-        // which `TYPE_ID` is set. Skip the varint; nothing to
+        // ADR-0065: typed-id wire is a `u64` fixed little-endian
+        // regardless of which `TYPE_ID` is set. Skip 8 bytes; nothing to
         // resolve since typed-ids don't embed `Ref`s.
         SchemaType::TypeId(_) => {
-            state.skip_varint()?;
+            state.skip_n(8)?;
             Ok(None)
         }
     }
 }
 
-/// Append `value` as an unsigned LEB128 varint — the same encoding
-/// postcard uses for the inline arm's `varint(len)` length prefix
-/// (ADR-0100). Mirror of [`State::read_varint`].
-fn push_varint(out: &mut Vec<u8>, mut value: u64) {
-    loop {
-        let byte = (value & 0x7f) as u8;
-        value >>= 7;
-        if value == 0 {
-            out.push(byte);
-            return;
-        }
-        out.push(byte | 0x80);
-    }
-}
-
-fn skip_primitive_postcard(state: &mut State<'_>, p: Primitive) -> Result<(), WalkError> {
+/// Skip one `Primitive` scalar in the `aether_data::wire` layout: a
+/// fixed little-endian of the declared width (no varints, no zigzag).
+fn skip_primitive_wire(state: &mut State<'_>, p: Primitive) -> Result<(), WalkError> {
     match p {
         Primitive::U8 | Primitive::I8 => state.skip_n(1),
-        // Multi-byte integers ride varints (with zigzag for signed).
-        // The zigzag transform doesn't change byte length, so skipping
-        // a varint covers both.
-        Primitive::U16
-        | Primitive::U32
-        | Primitive::U64
-        | Primitive::I16
-        | Primitive::I32
-        | Primitive::I64 => state.skip_varint(),
-        Primitive::F32 => state.skip_n(4),
-        Primitive::F64 => state.skip_n(8),
+        Primitive::U16 | Primitive::I16 => state.skip_n(2),
+        Primitive::U32 | Primitive::I32 | Primitive::F32 => state.skip_n(4),
+        Primitive::U64 | Primitive::I64 | Primitive::F64 => state.skip_n(8),
     }
 }
 
@@ -2380,6 +2383,7 @@ mod tests {
     use Arc;
 
     use crate::mail::{Mail, MailboxId};
+    use aether_data::wire;
     use aether_data::{Kind, Ref};
     use aether_data::{NamedField, SchemaCell};
 
@@ -2601,7 +2605,7 @@ mod tests {
 
     // Walker tests — schema-driven over real Ref<K> wire
 
-    /// Tiny postcard kind for walker tests. Kept here rather than
+    /// Tiny wire kind for walker tests. Kept here rather than
     /// pulling the derive macro into substrate-core's dev-deps:
     /// the derive expansion is exercised end-to-end in
     /// aether-actor-derive's tests; here we just need a payload that
@@ -2618,15 +2622,15 @@ mod tests {
         const ID: KindId = KindId(0xDEAD_BEEF_0002_0001);
 
         fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-            postcard::from_bytes(bytes).ok()
+            wire::from_bytes(bytes).ok()
         }
 
         fn encode_into_bytes(&self) -> Vec<u8> {
-            postcard::to_allocvec(self).expect("postcard encode to Vec is infallible")
+            wire::to_vec(self).expect("wire encode to Vec is infallible")
         }
     }
 
-    /// Postcard-shape `Struct { repr_c: false, fields }` builder
+    /// Wire-shape `Struct { repr_c: false, fields }` builder
     /// shared by the test schemas in this module.
     fn postcard_struct(fields: Vec<NamedField>) -> SchemaType {
         SchemaType::Struct {
@@ -2669,11 +2673,11 @@ mod tests {
         const ID: KindId = KindId(0xDEAD_BEEF_0002_0002);
 
         fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-            postcard::from_bytes(bytes).ok()
+            wire::from_bytes(bytes).ok()
         }
 
         fn encode_into_bytes(&self) -> Vec<u8> {
-            postcard::to_allocvec(self).expect("postcard encode to Vec is infallible")
+            wire::to_vec(self).expect("wire encode to Vec is infallible")
         }
     }
 
@@ -2686,8 +2690,9 @@ mod tests {
 
     /// Cast-shaped walker fixture with non-`f32` fields (`u16`). ADR-0100
     /// makes its inline body a raw cast image, whose `u16` bytes a
-    /// postcard reader would misread — the walker must treat the inline
-    /// body as an opaque length-prefixed blob, not walk it as postcard.
+    /// wire reader would misread — the walker must treat the inline
+    /// body as an opaque length-prefixed blob, not walk it as a wire
+    /// structure.
     #[repr(C)]
     #[derive(Copy, Clone, Debug, PartialEq, Eq, bytemuck::Pod, bytemuck::Zeroable)]
     struct Coord {
@@ -2742,7 +2747,7 @@ mod tests {
             body: "hi".to_string(),
             seq: 7,
         };
-        let bytes = postcard::to_allocvec(&note).unwrap();
+        let bytes = wire::to_vec(&note).unwrap();
         let outcome = walk_and_resolve(&note_schema(), &bytes, &store).unwrap();
         match outcome {
             WalkOutcome::Resolved {
@@ -2768,7 +2773,7 @@ mod tests {
             held: Ref::Inline(inner),
             seq: 11,
         };
-        let bytes = postcard::to_allocvec(&outer).unwrap();
+        let bytes = wire::to_vec(&outer).unwrap();
         let outcome = walk_and_resolve(&held_note_schema(), &bytes, &store).unwrap();
         // Inline refs cause no substitution; payload should still be
         // Cow::Borrowed.
@@ -2790,7 +2795,7 @@ mod tests {
             held: Ref::handle(0xCAFE),
             seq: 11,
         };
-        let bytes = postcard::to_allocvec(&outer).unwrap();
+        let bytes = wire::to_vec(&outer).unwrap();
         let outcome = walk_and_resolve(&held_note_schema(), &bytes, &store).unwrap();
         match outcome {
             WalkOutcome::Parked { handle, kind } => {
@@ -2808,14 +2813,14 @@ mod tests {
             body: "stored".to_string(),
             seq: 99,
         };
-        let inner_bytes = postcard::to_allocvec(&inner).unwrap();
+        let inner_bytes = wire::to_vec(&inner).unwrap();
         store.put(HandleId(0xCAFE), Note::ID, inner_bytes).unwrap();
 
         let outer = HeldNote {
             held: Ref::handle(0xCAFE),
             seq: 11,
         };
-        let outer_bytes = postcard::to_allocvec(&outer).unwrap();
+        let outer_bytes = wire::to_vec(&outer).unwrap();
 
         let outcome = walk_and_resolve(&held_note_schema(), &outer_bytes, &store).unwrap();
         let resolved_bytes = match outcome {
@@ -2825,7 +2830,7 @@ mod tests {
 
         // The resolved payload should decode as HeldNote with
         // `held = Ref::Inline(inner)`.
-        let decoded: HeldNote = postcard::from_bytes(&resolved_bytes).unwrap();
+        let decoded: HeldNote = wire::from_bytes(&resolved_bytes).unwrap();
         assert_eq!(decoded.seq, 11);
         match decoded.held {
             Ref::Inline(got) => {
@@ -2853,18 +2858,10 @@ mod tests {
             seq: 2,
         };
         store
-            .put(
-                HandleId(1),
-                Note::ID,
-                postcard::to_allocvec(&stored_a).unwrap(),
-            )
+            .put(HandleId(1), Note::ID, wire::to_vec(&stored_a).unwrap())
             .unwrap();
         store
-            .put(
-                HandleId(2),
-                Note::ID,
-                postcard::to_allocvec(&stored_b).unwrap(),
-            )
+            .put(HandleId(2), Note::ID, wire::to_vec(&stored_b).unwrap())
             .unwrap();
 
         let outer: Vec<Ref<Note>> = vec![
@@ -2875,14 +2872,14 @@ mod tests {
             }),
             Ref::handle(2),
         ];
-        let bytes = postcard::to_allocvec(&outer).unwrap();
+        let bytes = wire::to_vec(&outer).unwrap();
         let outcome = walk_and_resolve(&schema, &bytes, &store).unwrap();
         let resolved = match outcome {
             WalkOutcome::Resolved { payload } => payload.into_owned(),
             WalkOutcome::Parked { .. } => panic!("expected resolved"),
         };
 
-        let decoded: Vec<Ref<Note>> = postcard::from_bytes(&resolved).unwrap();
+        let decoded: Vec<Ref<Note>> = wire::from_bytes(&resolved).unwrap();
         assert_eq!(decoded.len(), 3);
         for r in &decoded {
             assert!(r.is_inline(), "every ref should be inline after walk");
@@ -2901,15 +2898,11 @@ mod tests {
             seq: 1,
         };
         store
-            .put(
-                HandleId(1),
-                Note::ID,
-                postcard::to_allocvec(&stored).unwrap(),
-            )
+            .put(HandleId(1), Note::ID, wire::to_vec(&stored).unwrap())
             .unwrap();
 
         let outer: Vec<Ref<Note>> = vec![Ref::handle(1), Ref::handle(99)];
-        let bytes = postcard::to_allocvec(&outer).unwrap();
+        let bytes = wire::to_vec(&outer).unwrap();
         let outcome = walk_and_resolve(&schema, &bytes, &store).unwrap();
         match outcome {
             WalkOutcome::Parked { handle, .. } => {
@@ -2930,7 +2923,7 @@ mod tests {
             }),
             seq: 1,
         };
-        let mut bytes = postcard::to_allocvec(&outer).unwrap();
+        let mut bytes = wire::to_vec(&outer).unwrap();
         bytes.truncate(2);
         let err = walk_and_resolve(&held_note_schema(), &bytes, &store).unwrap_err();
         assert!(matches!(err, WalkError::Truncated));
@@ -2942,7 +2935,7 @@ mod tests {
     #[test]
     fn walk_fast_path_avoids_allocation_for_ref_free_schema() {
         let store = HandleStore::new(64);
-        let bytes = postcard::to_allocvec(&Note {
+        let bytes = wire::to_vec(&Note {
             body: "x".to_string(),
             seq: 1,
         })
@@ -2975,7 +2968,7 @@ mod tests {
             body: "deep".to_string(),
             seq: 7,
         };
-        let inner_bytes = postcard::to_allocvec(&inner_note).unwrap();
+        let inner_bytes = wire::to_vec(&inner_note).unwrap();
         store.put(HandleId(20), Note::ID, inner_bytes).unwrap();
 
         // Mid-level HeldNote, with held = Handle(Y), goes under X.
@@ -2983,7 +2976,7 @@ mod tests {
             held: Ref::handle(20),
             seq: 5,
         };
-        let mid_bytes = postcard::to_allocvec(&mid).unwrap();
+        let mid_bytes = wire::to_vec(&mid).unwrap();
         // Use a synthetic kind id for HeldNote — the walker only uses
         // the kind id to validate against the wire, and the test
         // schemas don't go through registry registration.
@@ -2994,13 +2987,13 @@ mod tests {
             id: 10,
             kind_id: 0xBEEF,
         };
-        let bytes = postcard::to_allocvec(&top).unwrap();
+        let bytes = wire::to_vec(&top).unwrap();
         let outcome = walk_and_resolve(&outer_schema, &bytes, &store).unwrap();
         let resolved = match outcome {
             WalkOutcome::Resolved { payload } => payload.into_owned(),
             WalkOutcome::Parked { .. } => panic!("expected resolved"),
         };
-        let decoded: Ref<HeldNote> = postcard::from_bytes(&resolved).unwrap();
+        let decoded: Ref<HeldNote> = wire::from_bytes(&resolved).unwrap();
         match decoded {
             Ref::Inline(held) => match held.held {
                 Ref::Inline(note) => {
@@ -3013,11 +3006,68 @@ mod tests {
         }
     }
 
+    /// ADR-0118 nested-inline case: the bytes a handle stores are
+    /// themselves a versioned wire image (`HeldNote` whose inner ref is
+    /// already `Inline`). Resolving the outer handle recurses into those
+    /// stored bytes — the walker must strip the *inner* version byte on
+    /// descent to read the ref-bearing struct, yet splice the stored
+    /// image back verbatim (version byte and all). Decoding the result
+    /// proves the inner version byte survived the round-trip.
+    #[test]
+    fn walk_nested_inline_ref_preserves_inner_version_byte() {
+        let outer_schema = SchemaType::Ref(SchemaCell::owned(held_note_schema()));
+        let store = HandleStore::new(4096);
+
+        // Stored value: a HeldNote that already holds an INLINE Note —
+        // no further handle to resolve, but it is ref-bearing, so the
+        // recursive walk_and_resolve does walk (and strips its version
+        // byte on entry).
+        let stored = HeldNote {
+            held: Ref::Inline(Note {
+                body: "inner".to_string(),
+                seq: 3,
+            }),
+            seq: 5,
+        };
+        let stored_bytes = wire::to_vec(&stored).unwrap();
+        assert_eq!(stored_bytes[0], WIRE_VERSION, "stored image is versioned");
+        store
+            .put(HandleId(70), KindId(0xBEEF), stored_bytes)
+            .unwrap();
+
+        let top: Ref<HeldNote> = Ref::Handle {
+            id: 70,
+            kind_id: 0xBEEF,
+        };
+        let bytes = wire::to_vec(&top).unwrap();
+        let outcome = walk_and_resolve(&outer_schema, &bytes, &store).unwrap();
+        let resolved = match outcome {
+            WalkOutcome::Resolved { payload } => payload.into_owned(),
+            WalkOutcome::Parked { .. } => panic!("expected resolved"),
+        };
+        // The spliced inline body is a pure byte-copy of the stored
+        // versioned image, so decoding the whole thing reconstructs it.
+        let decoded: Ref<HeldNote> = wire::from_bytes(&resolved).unwrap();
+        match decoded {
+            Ref::Inline(held) => {
+                assert_eq!(held.seq, 5);
+                match held.held {
+                    Ref::Inline(note) => {
+                        assert_eq!(note.body, "inner");
+                        assert_eq!(note.seq, 3);
+                    }
+                    Ref::Handle { .. } => panic!("inner ref was inline, must stay inline"),
+                }
+            }
+            Ref::Handle { .. } => panic!("outer ref must be resolved"),
+        }
+    }
+
     /// ADR-0100: a handle to a non-`f32` cast kind resolves to an inline
     /// arm whose body is the raw cast image, and the spliced wire decodes
     /// on the guest path (`Ref<Coord>::decode → Kind::decode_from_bytes`)
     /// uncorrupted — the `u16` fields survive because the walker never
-    /// re-interprets the cast image as postcard.
+    /// re-interprets the cast image as a wire structure.
     #[test]
     fn walk_handle_ref_resolves_cast_kind_non_f32() {
         let schema = SchemaType::Ref(SchemaCell::owned(coord_schema()));
@@ -3030,20 +3080,30 @@ mod tests {
         let cast_bytes = bytemuck::bytes_of(&pt).to_vec();
         store.put(HandleId(3), Coord::ID, cast_bytes).unwrap();
 
-        let wire = postcard::to_allocvec(&Ref::<Coord>::handle(3)).unwrap();
-        let outcome = walk_and_resolve(&schema, &wire, &store).unwrap();
+        let handle_wire = wire::to_vec(&Ref::<Coord>::handle(3)).unwrap();
+        let outcome = walk_and_resolve(&schema, &handle_wire, &store).unwrap();
         let resolved = match outcome {
             WalkOutcome::Resolved { payload } => payload.into_owned(),
             WalkOutcome::Parked { .. } => panic!("expected resolved"),
         };
 
-        // The spliced inline arm carries the 4-byte cast image,
-        // length-prefixed: disc 0 + varint(4) + 4 raw bytes.
-        assert_eq!(resolved[0], 0, "spliced Inline discriminant");
-        assert_eq!(resolved[1], 4, "varint length of the 4-byte cast image");
-        assert_eq!(&resolved[2..], bytemuck::bytes_of(&pt));
+        // The resolved image keeps the top-level version byte, then the
+        // spliced inline arm: u32 selector 0 + u32 length 4 + the 4-byte
+        // cast image (the cast image is itself bare — no nested version).
+        assert_eq!(resolved[0], WIRE_VERSION, "top-level version byte");
+        assert_eq!(
+            &resolved[1..5],
+            &0u32.to_le_bytes(),
+            "spliced Inline selector"
+        );
+        assert_eq!(
+            &resolved[5..9],
+            &4u32.to_le_bytes(),
+            "u32 length of the cast image"
+        );
+        assert_eq!(&resolved[9..], bytemuck::bytes_of(&pt));
 
-        let back: Ref<Coord> = postcard::from_bytes(&resolved).unwrap();
+        let back: Ref<Coord> = wire::from_bytes(&resolved).unwrap();
         match back {
             Ref::Inline(got) => assert_eq!(got, pt, "u16 cast fields survive resolution"),
             Ref::Handle { .. } => panic!("walker must replace Handle with Inline"),

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -496,7 +496,7 @@ impl Mailer {
                 .is_some_and(|outbound| outbound.send_reply(sender, result)),
             SourceAddr::Component(mailbox) => {
                 // ADR-0100: encode the reply through the kind's declared
-                // codec (cast or postcard), not a hardcoded postcard path.
+                // codec (cast or wire), not a hardcoded codec path.
                 let payload = result.encode_into_bytes();
                 // ADR-0042: echo the caller's correlation_id onto the
                 // reply envelope so the originating handler can pick
@@ -902,6 +902,7 @@ mod tests {
     use crate::mail::MailboxId;
     use crate::mail::outbound::EgressEvent;
     use crate::mail::registry::{InboxHandler, InlineHandler};
+    use aether_data::wire::{self, WIRE_VERSION};
     use aether_data::{Kind, Ref};
     use aether_data::{KindDescriptor, NamedField, Primitive, SchemaCell, SchemaType};
 
@@ -1123,11 +1124,11 @@ mod tests {
         const ID: KindId = KindId(0xDEAD_BEEF_0003_0001);
 
         fn decode_from_bytes(bytes: &[u8]) -> Option<Self> {
-            postcard::from_bytes(bytes).ok()
+            wire::from_bytes(bytes).ok()
         }
 
         fn encode_into_bytes(&self) -> Vec<u8> {
-            postcard::to_allocvec(self).expect("postcard encode to Vec is infallible")
+            wire::to_vec(self).expect("wire encode to Vec is infallible")
         }
     }
 
@@ -1247,7 +1248,7 @@ mod tests {
 
     /// ADR-0100: `Mailer::send_reply_unchained` to a `Component` target encodes the
     /// reply through `Kind::encode_into_bytes`. A cast reply kind reaches
-    /// the sink as its raw cast image, not a postcard varint image — and
+    /// the sink as its raw cast image, not a wire image — and
     /// a `Pod`-without-`Serialize` kind is repliable at all.
     #[test]
     fn send_reply_cast_kind_delivers_cast_image() {
@@ -1373,7 +1374,7 @@ mod tests {
             body: "verbatim".into(),
             seq: 1,
         };
-        let bytes = postcard::to_allocvec(&note).unwrap();
+        let bytes = wire::to_vec(&note).unwrap();
         mailer.push(Mail::new(sink_id, note_id, bytes.clone(), 1));
 
         let captured = sink.captured.read().unwrap().clone();
@@ -1415,7 +1416,7 @@ mod tests {
             },
             seq: 11,
         };
-        let outer_bytes = postcard::to_allocvec(&outer).unwrap();
+        let outer_bytes = wire::to_vec(&outer).unwrap();
         mailer.push(Mail::new(sink_id, outer_kind_id, outer_bytes, 1));
         assert_eq!(
             sink.delivery_count.load(Ordering::SeqCst),
@@ -1430,7 +1431,7 @@ mod tests {
             body: "resolved".into(),
             seq: 99,
         };
-        let inner_bytes = postcard::to_allocvec(&inner).unwrap();
+        let inner_bytes = wire::to_vec(&inner).unwrap();
         mailer
             .resolve_handle(HandleId(7), inner_kind_id, inner_bytes)
             .unwrap();
@@ -1438,7 +1439,7 @@ mod tests {
         assert_eq!(sink.delivery_count.load(Ordering::SeqCst), 1);
 
         let captured = sink.captured.read().unwrap();
-        let delivered: HeldNote = postcard::from_bytes(&captured[0]).unwrap();
+        let delivered: HeldNote = wire::from_bytes(&captured[0]).unwrap();
         assert_eq!(delivered.seq, 11);
         match delivered.held {
             Ref::Inline(got) => {
@@ -1467,8 +1468,9 @@ mod tests {
         let sink = CapturingSink::new();
         let sink_id = registry.register_inbox("test.sink", sink.inbox_handler());
 
-        // Truncated payload — the walker bails Truncated mid-walk.
-        mailer.push(Mail::new(sink_id, kind_id, vec![0u8; 1], 1));
+        // Truncated payload — a valid version byte then a lone body byte,
+        // so the walker bails Truncated mid-walk reading the first field.
+        mailer.push(Mail::new(sink_id, kind_id, vec![WIRE_VERSION, 0u8], 1));
         assert_eq!(sink.delivery_count.load(Ordering::SeqCst), 0);
     }
 
@@ -1542,7 +1544,7 @@ mod tests {
             },
             seq: 7,
         };
-        let payload = postcard::to_allocvec(&held).unwrap();
+        let payload = wire::to_vec(&held).unwrap();
 
         let mail = Mail::new(sink_id, outer_kind_id, payload, 1).with_lineage(root, root, None);
         mailer.push(mail);
@@ -1570,7 +1572,7 @@ mod tests {
             body: "hi".into(),
             seq: 99,
         };
-        let note_bytes = postcard::to_allocvec(&note).unwrap();
+        let note_bytes = wire::to_vec(&note).unwrap();
         mailer
             .resolve_handle(handle, inner_kind_id, note_bytes)
             .expect("resolve_handle");
@@ -1628,7 +1630,7 @@ mod tests {
             },
             seq: 42,
         };
-        let payload = postcard::to_allocvec(&held).unwrap();
+        let payload = wire::to_vec(&held).unwrap();
 
         let mail = Mail::new(sink_id, outer_kind_id, payload, 1).with_lineage(root, root, None);
         mailer.push(mail);
@@ -1877,7 +1879,7 @@ mod tests {
                         },
                         seq: 1,
                     };
-                    let payload = postcard::to_allocvec(&held).unwrap();
+                    let payload = wire::to_vec(&held).unwrap();
                     mailer.push(
                         Mail::new(id, outer_kind_id, payload, 1)
                             .with_lineage(mail_id, mail_id, None),

--- a/docs/adr/0118-own-the-aether-wire-format.md
+++ b/docs/adr/0118-own-the-aether-wire-format.md
@@ -109,6 +109,13 @@ byte versions the *encoding*, so the format can evolve without ambiguity, and
 "is this aether wire or garbage" stays decidable. It is per-message, not
 per-value.
 
+A nested inline-`Ref` body — and the bytes the handle store retains for a
+handle — is itself a versioned kind image, so the version byte recurs at every
+*kind-image* boundary (the top-level payload, a nested inline-`Ref` body, a
+retained handle body) and never on interior values (scalars, fields, collection
+elements, the `Ref` handle arm). Every reader strips the byte on entering a kind
+image; no reader assumes a bare body.
+
 ### Determinism
 
 Encoding is deterministic by construction — the same value always produces the


### PR DESCRIPTION
Closes #1983.

## Summary

ADR-0118 step 2A: flip the structured mail-payload codec from postcard onto `aether_data::wire` across the three walkers of that one byte layout — the derive runtime (`__derive_runtime::{encode,decode}_*` → `wire`, `DecodeError::Postcard → Wire`), the `aether-codec` schema-walker (`encode_schema` / `decode_schema` rewritten to the fixed-width layout), and the `handle_store::walk_and_resolve` mail-hot-path walker — plus the `dag/executor.rs` bare-`Ref` assembly and the `mailer.rs` test Kinds. Governed by one invariant: **every encoded kind image carries `WIRE_VERSION` at its front; every reader strips it on entry; interior values stay bare.** `KindId`-neutral (canonical untouched, #1984); postcard stays a dependency until #1985.

A new `wire::to_vec_bare` (body, no version prefix) backs the dag-executor hand-assembly, which prepends one `WIRE_VERSION` to the assembled struct body. The handle-store walker strips the version byte on entry and at each inline-`Ref` descent; the splice stays a pure byte-copy of the stored versioned image. ADR-0118 §Envelope gains one sentence clarifying that the version byte recurs at every kind-image boundary, never on interior values.

## Scope note — beyond the originally-listed surfaces

The format flip changes a fieldless kind's image from `[]` to `[WIRE_VERSION]`, which broke the codebase-wide "fire an empty-payload wake mail" idiom: a `Mail::new(.., Vec::new(), 1)` for a fieldless signal kind no longer decodes (`decode_from_bytes(&[])` → `None` → wake dropped), caught by the full-workspace preflight (rpc handshake/call tests timing out — server never woke). Fixed at ~13 wake sites across `aether-capabilities` (`rpc/server`, `engine/proxy`, `http_server`, `tcp/{listener,session}`, `dag`), `aether-kinds`, and `aether-labyrinth` by sending the kind's encoded image (`K::default().encode_into_bytes()`) instead of a raw empty `Vec` — #1986's "go through the `Kind` trait" principle applied to mail-payload sites its postcard-grep couldn't see. These crates were not in the issue's §Affected surfaces; the change is mechanical and required for the flip to be green.

## Test plan

- New `aether-codec` conformance cross-check: `wire::to_vec(value) == encode_schema(json, schema)` and the decode mirror over scalars/collections/enums/maps/`Ref`(inline+handle), versioned both sides — adapter == codec-walker; the handle-store walker is pinned to the same bytes by its round-trip tests (incl. a new nested-inline-`Ref` version-byte test).
- `KindId`s confirmed unchanged (`canonical` untouched).
- Full preflight green: fmt + clippy `--workspace --all-targets -D warnings` + doc + nextest (2038 default + 110 heavy, incl. the real-wire fleetbench / rpc_engine_routing / http_serving heavy tests) + wasm32 component cross-build.

## Generated by

`/implement` — agent execution of [scoped issue #1983](https://github.com/iamacoffeepot/aether/issues/1983).
