### PR TITLE
refactor(data): own the canonical schema / KindId codec (ADR-0118 step 2B)

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -204,17 +204,16 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
                 &#labels_ident,
             );
 
-        // ADR-0028 / ADR-0032 / issue 640: `aether.kinds` v0x04 ships
-        // just `[version_byte][canonical_bytes]` — the v0x03 trailing
-        // `is_stream` byte retired with the auto-subscribe path.
-        // Canonical bytes (and therefore `Kind::ID`) unchanged from
-        // v0x02 / v0x03; only the per-record framing shrunk by one byte.
+        // ADR-0028 / ADR-0032 / ADR-0118: `aether.kinds` v0x05 ships
+        // `[version_byte][canonical_bytes]`, where the canonical bytes are
+        // now the owned aether-wire encoding (issue 1984) — so every
+        // `Kind::ID` regenerates, gated loudly behind this version byte.
         #[cfg(target_arch = "wasm32")]
         #[used]
         #[unsafe(link_section = "aether.kinds")]
         static #kind_static_ident: [u8; #canonical_len_ident + 1] = {
             let mut out = [0u8; #canonical_len_ident + 1];
-            out[0] = 0x04;
+            out[0] = 0x05;
             let mut i = 0;
             while i < #canonical_len_ident {
                 out[i + 1] = #canonical_bytes_ident[i];
@@ -228,9 +227,10 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
         #[unsafe(link_section = "aether.kinds.labels")]
         static #kind_labels_static_ident: [u8; #labels_len_ident + 1] = {
             let mut out = [0u8; #labels_len_ident + 1];
-            // v0x03: `KindLabels` gained `kind_id`, making records
-            // self-identifying. Reader pairs by id, not index.
-            out[0] = 0x03;
+            // v0x04 (ADR-0118 / issue 1984): the labels record is the owned
+            // aether-wire encoding of `KindLabels`. v0x03 made records
+            // self-identifying (`kind_id`); the reader still pairs by id.
+            out[0] = 0x04;
             let mut i = 0;
             while i < #labels_len_ident {
                 out[i + 1] = #labels_bytes_ident[i];
@@ -3336,7 +3336,7 @@ fn build_dispatch_body(handlers: &[HandlerFn], fallback: Option<&FallbackFn>) ->
 /// `__AETHER_INPUTS_MANIFEST_LEN: usize` and
 /// `__AETHER_INPUTS_MANIFEST: [u8; …LEN]` — carrying the
 /// concatenated `aether.kinds.inputs` record bytes. Each record is
-/// `[INPUTS_SECTION_VERSION (0x03), ..postcard(InputsRecord)..]`,
+/// `[INPUTS_SECTION_VERSION (0x05), ..wire(InputsRecord)..]`,
 /// assembled at const-eval via the hub-protocol const-fn encoders.
 /// `aether_actor::export!()` reads these consts and emits the
 /// `#[unsafe(link_section = "aether.kinds.inputs")]` static in the
@@ -3406,11 +3406,11 @@ fn build_inputs_manifest_consts(
                         #reply_tag_expr,
                         #reply_id_expr,
                     );
-                // Per-record section version byte, bumped to 0x04 by
-                // ADR-0112 (issue 1850) — the `Handler` variant's reply
-                // field widened from `Option<KindId>` to `ReplyContract`.
-                // Keep in lockstep with `INPUTS_SECTION_VERSION`.
-                out[pos] = 0x04;
+                // Per-record section version byte, bumped to 0x05 by
+                // ADR-0118 (issue 1984) — the record is now the owned
+                // aether-wire encoding rather than postcard. Keep in
+                // lockstep with `INPUTS_SECTION_VERSION`.
+                out[pos] = 0x05;
                 pos += 1;
                 let mut i = 0;
                 while i < REC_LEN {
@@ -3434,8 +3434,8 @@ fn build_inputs_manifest_consts(
                 const REC_BYTES: [u8; REC_LEN] =
                     ::aether_actor::__macro_internals::canonical::write_inputs_fallback::<REC_LEN>(#doc_expr);
                 // Per-record section version byte, in lockstep with
-                // `INPUTS_SECTION_VERSION` (0x04, ADR-0112 / issue 1850).
-                out[pos] = 0x04;
+                // `INPUTS_SECTION_VERSION` (0x05, ADR-0118 / issue 1984).
+                out[pos] = 0x05;
                 pos += 1;
                 let mut i = 0;
                 while i < REC_LEN {
@@ -3459,8 +3459,8 @@ fn build_inputs_manifest_consts(
                 const REC_BYTES: [u8; REC_LEN] =
                     ::aether_actor::__macro_internals::canonical::write_inputs_component::<REC_LEN>(#doc_lit);
                 // Per-record section version byte, in lockstep with
-                // `INPUTS_SECTION_VERSION` (0x04, ADR-0112 / issue 1850).
-                out[pos] = 0x04;
+                // `INPUTS_SECTION_VERSION` (0x05, ADR-0118 / issue 1984).
+                out[pos] = 0x05;
                 pos += 1;
                 let mut i = 0;
                 while i < REC_LEN {
@@ -3496,9 +3496,9 @@ fn build_inputs_manifest_consts(
                         <#cfg as ::aether_actor::__macro_internals::Kind>::ID.0,
                         <#cfg as ::aether_actor::__macro_internals::Kind>::NAME,
                     );
-                // Per-record section version byte (0x04), in lockstep
-                // with `INPUTS_SECTION_VERSION` (ADR-0112 / issue 1850).
-                out[pos] = 0x04;
+                // Per-record section version byte (0x05), in lockstep
+                // with `INPUTS_SECTION_VERSION` (ADR-0118 / issue 1984).
+                out[pos] = 0x05;
                 pos += 1;
                 let mut i = 0;
                 while i < REC_LEN {
@@ -3647,18 +3647,16 @@ fn build_kinds_section_retention_statics(
                     <#k as ::aether_actor::__macro_internals::Kind>::NAME,
                     &#schema_ident,
                 );
-            // ADR-0068 v0x03: trailing byte after canonical bytes
-            // Same v0x04 wire shape as `expand_kind`'s primary
-            // emission so retention records (when this kind lives in a
-            // dependency rlib) pair cleanly with the primary records
-            // by id (issue 640 retired the v0x03 trailing IS_STREAM
-            // byte alongside the auto-subscribe path).
+            // Same v0x05 wire shape as `expand_kind`'s primary emission
+            // (ADR-0118 / issue 1984: the owned aether-wire encoding) so
+            // retention records (when this kind lives in a dependency
+            // rlib) pair cleanly with the primary records by id.
             #[cfg(target_arch = "wasm32")]
             #[used]
             #[unsafe(link_section = "aether.kinds")]
             static #section_ident: [u8; #len_ident + 1] = {
                 let mut out = [0u8; #len_ident + 1];
-                out[0] = 0x04;
+                out[0] = 0x05;
                 let mut i = 0;
                 while i < #len_ident {
                     out[i + 1] = #bytes_ident[i];
@@ -3703,7 +3701,9 @@ fn build_kinds_section_retention_statics(
             #[unsafe(link_section = "aether.kinds.labels")]
             static #labels_section_ident: [u8; #labels_len_ident + 1] = {
                 let mut out = [0u8; #labels_len_ident + 1];
-                out[0] = 0x03;
+                // v0x04 (ADR-0118 / issue 1984): the owned aether-wire
+                // encoding of `KindLabels`, matching `expand_kind`.
+                out[0] = 0x04;
                 let mut i = 0;
                 while i < #labels_len_ident {
                     out[i + 1] = #labels_bytes_ident[i];

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -1091,11 +1091,11 @@ macro_rules! __export_multi_internal {
                             <$component as $crate::Actor>::NAMESPACE,
                         );
                     // Per-record section version byte, in lockstep with
-                    // `INPUTS_SECTION_VERSION` (0x04, bumped by ADR-0112 /
-                    // issue 1850; the multi-actor boundary record is a
+                    // `INPUTS_SECTION_VERSION` (0x05, bumped by ADR-0118 /
+                    // issue 1984; the multi-actor boundary record is a
                     // per-record frame and tracks the same version as the
                     // single-actor records emitted by the derive macro).
-                    out[pos] = 0x04;
+                    out[pos] = 0x05;
                     pos += 1;
                     let mut i = 0;
                     while i < BOUNDARY_LEN {

--- a/crates/aether-actor/tests/handlers_manifest.rs
+++ b/crates/aether-actor/tests/handlers_manifest.rs
@@ -23,7 +23,7 @@
 
 use aether_actor::{BootError, FfiActor, FfiCtx, Manual, Resolver, actor};
 use aether_data::Kind;
-use aether_data::{INPUTS_SECTION_VERSION, InputsRecord, ReplyContract};
+use aether_data::{INPUTS_SECTION_VERSION, InputsRecord, ReplyContract, wire};
 use bytemuck::{Pod, Zeroable};
 
 #[repr(C)]
@@ -108,8 +108,8 @@ fn parse_section(bytes: &[u8]) -> Vec<InputsRecord> {
             "every record must start with the section version byte"
         );
         cursor = &cursor[1..];
-        let (rec, rest) = postcard::take_from_bytes::<InputsRecord>(cursor)
-            .expect("postcard decode of InputsRecord failed");
+        let (rec, rest) = wire::take_from_bytes_bare::<InputsRecord>(cursor)
+            .expect("wire decode of InputsRecord failed");
         out.push(rec);
         cursor = rest;
     }

--- a/crates/aether-data/src/canonical/inputs.rs
+++ b/crates/aether-data/src/canonical/inputs.rs
@@ -1,38 +1,38 @@
 //! `InputsRecord` const-fn encoders (ADR-0033). The `#[actor]`
-//! macro emits one postcard-compatible byte array per handler /
+//! macro emits one ADR-0118 aether-wire byte array per handler /
 //! fallback / component-doc record, length-prefixed with the section
 //! version tag, and drops the bytes into the `aether.kinds.inputs`
 //! custom section. Writing at const-eval time keeps everything in
 //! `#[link_section]` statics with no runtime serializer on the
-//! guest — the wire shape matches `postcard(InputsRecord)`
+//! guest — the wire shape matches `wire::to_vec_bare(InputsRecord)`
 //! byte-for-byte so the substrate/hub reader decodes via
-//! `postcard::take_from_bytes` symmetrically.
+//! `wire::take_from_bytes_bare` symmetrically.
 
 use super::primitives::{
-    option_borrowed_str_len, str_len, varint_u64_len, write_option_borrowed_str, write_str,
-    write_varint_u64,
+    U32_WIDTH, U64_WIDTH, option_borrowed_str_len, str_len, write_option_borrowed_str, write_str,
+    write_u32_le, write_u64_le,
 };
 
-/// Byte length of a [`ReplyContract`](crate::ReplyContract)'s postcard
-/// encoding from its `(tag, id)` pair. The discriminant varint is one
-/// byte for these four variants; the `One` / `Stream` arms carry a
-/// trailing `varint(id)`, the `None` / `Manual` arms carry nothing.
-/// Variant order (`None` = 0, `One` = 1, `Stream` = 2, `Manual` = 3) is
-/// the discriminant, matching the enum's declared order.
+/// Byte length of a [`ReplyContract`](crate::ReplyContract)'s aether-wire
+/// encoding from its `(tag, id)` pair. The selector is a fixed `u32`; the
+/// `One` / `Stream` arms carry a trailing `KindId` (a bare `u64`), the
+/// `None` / `Manual` arms carry nothing. Variant order (`None` = 0,
+/// `One` = 1, `Stream` = 2, `Manual` = 3) is the selector, matching the
+/// enum's declared order.
 #[must_use]
-pub const fn reply_contract_len(reply_tag: u8, reply_id: u64) -> usize {
+pub const fn reply_contract_len(reply_tag: u8, _reply_id: u64) -> usize {
     match reply_tag {
-        // One / Stream carry a trailing varint(id).
-        1 | 2 => 1 + varint_u64_len(reply_id),
-        // None / Manual (and any other) carry just the discriminant.
-        _ => 1,
+        // One / Stream carry a trailing `KindId` (bare u64).
+        1 | 2 => U32_WIDTH + U64_WIDTH,
+        // None / Manual (and any other) carry just the selector.
+        _ => U32_WIDTH,
     }
 }
 
 /// Serialize a [`ReplyContract`](crate::ReplyContract) into `out` at
 /// `pos` from its `(tag, id)` pair, returning the new cursor. Exact
-/// `postcard(ReplyContract)` wire shape: `varint(tag)` then, for
-/// `One` / `Stream`, `varint(id)`.
+/// `wire::to_vec_bare(ReplyContract)` shape: a `u32` LE selector then, for
+/// `One` / `Stream`, the `KindId` as a bare `u64` LE.
 #[must_use]
 pub const fn write_reply_contract(
     reply_tag: u8,
@@ -40,34 +40,34 @@ pub const fn write_reply_contract(
     out: &mut [u8],
     mut pos: usize,
 ) -> usize {
-    out[pos] = reply_tag;
-    pos += 1;
+    pos = write_u32_le(reply_tag as u32, out, pos);
     if reply_tag == 1 || reply_tag == 2 {
-        pos = write_varint_u64(reply_id, out, pos);
+        pos = write_u64_le(reply_id, out, pos);
     }
     pos
 }
 
-/// Byte length of a `Handler` record's postcard encoding. One-byte
-/// enum-variant tag (`0x00`) + `varint(id)` + `postcard(name)` +
+/// Byte length of a `Handler` record's aether-wire encoding. A `u32` LE
+/// variant selector (`0`) + the `KindId` id (bare `u64`) + `wire(name)` +
 /// `option_str(doc)` + `reply_contract(reply_tag, reply_id)` — the
 /// ADR-0112 reply class.
 #[must_use]
 pub const fn inputs_handler_len(
-    id: u64,
+    _id: u64,
     name: &str,
     doc: Option<&str>,
     reply_tag: u8,
     reply_id: u64,
 ) -> usize {
-    1 + varint_u64_len(id)
+    U32_WIDTH
+        + U64_WIDTH
         + str_len(name)
         + option_borrowed_str_len(doc)
         + reply_contract_len(reply_tag, reply_id)
 }
 
 /// Serialize an `InputsRecord::Handler` into a fixed-size array sized
-/// by `inputs_handler_len`. Exact postcard wire shape for
+/// by `inputs_handler_len`. Exact aether-wire shape for
 /// `InputsRecord::Handler { id, name, doc, reply }`.
 #[must_use]
 pub const fn write_inputs_handler<const N: usize>(
@@ -78,10 +78,8 @@ pub const fn write_inputs_handler<const N: usize>(
     reply_id: u64,
 ) -> [u8; N] {
     let mut out = [0u8; N];
-    let mut pos = 0usize;
-    out[pos] = 0; // variant tag: Handler
-    pos += 1;
-    pos = write_varint_u64(id, &mut out, pos);
+    let mut pos = write_u32_le(0, &mut out, 0); // variant selector: Handler
+    pos = write_u64_le(id, &mut out, pos);
     pos = write_str(name, &mut out, pos);
     pos = write_option_borrowed_str(doc, &mut out, pos);
     pos = write_reply_contract(reply_tag, reply_id, &mut out, pos);
@@ -90,82 +88,74 @@ pub const fn write_inputs_handler<const N: usize>(
     out
 }
 
-/// Byte length of a `Fallback` record's postcard encoding.
+/// Byte length of a `Fallback` record's aether-wire encoding.
 #[must_use]
 pub const fn inputs_fallback_len(doc: Option<&str>) -> usize {
-    1 + option_borrowed_str_len(doc)
+    U32_WIDTH + option_borrowed_str_len(doc)
 }
 
 /// Serialize an `InputsRecord::Fallback` into a fixed-size array.
 #[must_use]
 pub const fn write_inputs_fallback<const N: usize>(doc: Option<&str>) -> [u8; N] {
     let mut out = [0u8; N];
-    let mut pos = 0usize;
-    out[pos] = 1; // variant tag: Fallback
-    pos += 1;
+    let mut pos = write_u32_le(1, &mut out, 0); // variant selector: Fallback
     pos = write_option_borrowed_str(doc, &mut out, pos);
     let _ = pos;
     out
 }
 
-/// Byte length of a `Component` record's postcard encoding.
+/// Byte length of a `Component` record's aether-wire encoding.
 #[must_use]
 pub const fn inputs_component_len(doc: &str) -> usize {
-    1 + str_len(doc)
+    U32_WIDTH + str_len(doc)
 }
 
 /// Serialize an `InputsRecord::Component` into a fixed-size array.
 #[must_use]
 pub const fn write_inputs_component<const N: usize>(doc: &str) -> [u8; N] {
     let mut out = [0u8; N];
-    let mut pos = 0usize;
-    out[pos] = 2; // variant tag: Component
-    pos += 1;
+    let mut pos = write_u32_le(2, &mut out, 0); // variant selector: Component
     pos = write_str(doc, &mut out, pos);
     let _ = pos;
     out
 }
 
-/// Byte length of a `Config` record's postcard encoding (ADR-0090 /
-/// issue 1257). One-byte enum-variant tag (`0x03`) + `varint(id)` +
-/// `postcard(name)`.
+/// Byte length of a `Config` record's aether-wire encoding (ADR-0090 /
+/// issue 1257). A `u32` LE variant selector (`3`) + the `KindId` id (bare
+/// `u64`) + `wire(name)`.
 #[must_use]
-pub const fn inputs_config_len(id: u64, name: &str) -> usize {
-    1 + varint_u64_len(id) + str_len(name)
+pub const fn inputs_config_len(_id: u64, name: &str) -> usize {
+    U32_WIDTH + U64_WIDTH + str_len(name)
 }
 
 /// Serialize an `InputsRecord::Config` into a fixed-size array sized by
-/// `inputs_config_len`. Exact postcard wire shape for
+/// `inputs_config_len`. Exact aether-wire shape for
 /// `InputsRecord::Config { id, name }`.
 #[must_use]
 pub const fn write_inputs_config<const N: usize>(id: u64, name: &str) -> [u8; N] {
     let mut out = [0u8; N];
-    let mut pos = 0usize;
-    out[pos] = 3; // variant tag: Config
-    pos += 1;
-    pos = write_varint_u64(id, &mut out, pos);
+    let mut pos = write_u32_le(3, &mut out, 0); // variant selector: Config
+    pos = write_u64_le(id, &mut out, pos);
     pos = write_str(name, &mut out, pos);
     let _ = pos;
     out
 }
 
-/// Byte length of an `ActorBoundary` record's postcard encoding
-/// (ADR-0096). One-byte enum-variant tag (`0x04`) + `postcard(namespace)`.
+/// Byte length of an `ActorBoundary` record's aether-wire encoding
+/// (ADR-0096). A `u32` LE variant selector (`4`) + `wire(namespace)`.
 #[must_use]
 pub const fn inputs_actor_boundary_len(namespace: &str) -> usize {
-    1 + str_len(namespace)
+    U32_WIDTH + str_len(namespace)
 }
 
 /// Serialize an `InputsRecord::ActorBoundary` into a fixed-size array
-/// sized by `inputs_actor_boundary_len`. Exact postcard wire shape for
+/// sized by `inputs_actor_boundary_len`. Exact aether-wire shape for
 /// `InputsRecord::ActorBoundary { namespace }` — the per-actor group
 /// marker `export!(A, B, …)` writes ahead of each type's records.
 #[must_use]
 pub const fn write_inputs_actor_boundary<const N: usize>(namespace: &str) -> [u8; N] {
     let mut out = [0u8; N];
-    let mut pos = 0usize;
-    out[pos] = 4; // variant tag: ActorBoundary
-    pos += 1;
+    let mut pos = write_u32_le(4, &mut out, 0); // variant selector: ActorBoundary
     pos = write_str(namespace, &mut out, pos);
     let _ = pos;
     out

--- a/crates/aether-data/src/canonical/labels.rs
+++ b/crates/aether-data/src/canonical/labels.rs
@@ -1,14 +1,13 @@
 //! Canonical `KindLabels` sidecar serializer (ADR-0032). Produces
-//! postcard-compatible bytes for the `aether.kinds.labels` custom
+//! ADR-0118 aether-wire bytes for the `aether.kinds.labels` custom
 //! section at const-eval time, matching the substrate/hub runtime
-//! decode via `postcard::from_bytes::<KindLabels>`.
+//! decode via `wire::from_bytes_bare::<KindLabels>`.
 
 use crate::schema::{KindLabels, LabelCell, LabelNode, VariantLabel};
 
 use super::primitives::{
-    cow_label_nodes, cow_str_as_str, cow_strs, cow_variant_labels, option_str_len, str_len,
-    varint_u64_len, varint_usize_len, write_option_str, write_str, write_varint_u64,
-    write_varint_usize,
+    U32_WIDTH, U64_WIDTH, cow_label_nodes, cow_str_as_str, cow_strs, cow_variant_labels,
+    option_str_len, str_len, write_count, write_option_str, write_str, write_u32_le, write_u64_le,
 };
 
 const LABEL_ANONYMOUS: u8 = 0;
@@ -24,21 +23,20 @@ const VARIANT_LABEL_UNIT: u8 = 0;
 const VARIANT_LABEL_TUPLE: u8 = 1;
 const VARIANT_LABEL_STRUCT: u8 = 2;
 
-/// Byte length for `KindLabels` postcard encoding.
+/// Byte length for `KindLabels` aether-wire encoding. `kind_id` is a
+/// `KindId`, which wire-encodes as its bare `u64` (`U64_WIDTH` bytes).
 #[must_use]
 pub const fn canonical_len_labels(labels: &KindLabels) -> usize {
-    varint_u64_len(labels.kind_id.0)
-        + str_len(cow_str_as_str(&labels.kind_label))
-        + label_node_len(&labels.root)
+    U64_WIDTH + str_len(cow_str_as_str(&labels.kind_label)) + label_node_len(&labels.root)
 }
 
 const fn label_node_len(node: &LabelNode) -> usize {
     match node {
-        LabelNode::Anonymous => 1,
+        LabelNode::Anonymous => U32_WIDTH,
         LabelNode::Option(cell)
         | LabelNode::Vec(cell)
         | LabelNode::Array(cell)
-        | LabelNode::Ref(cell) => 1 + label_cell_len(cell),
+        | LabelNode::Ref(cell) => U32_WIDTH + label_cell_len(cell),
         LabelNode::Struct {
             type_label,
             field_names,
@@ -46,14 +44,14 @@ const fn label_node_len(node: &LabelNode) -> usize {
         } => {
             let names = cow_strs(field_names);
             let fs = cow_label_nodes(fields);
-            let mut total = 1 + option_str_len(type_label);
-            total += varint_usize_len(names.len());
+            let mut total = U32_WIDTH + option_str_len(type_label);
+            total += U32_WIDTH;
             let mut i = 0;
             while i < names.len() {
                 total += str_len(cow_str_as_str(&names[i]));
                 i += 1;
             }
-            total += varint_usize_len(fs.len());
+            total += U32_WIDTH;
             let mut i = 0;
             while i < fs.len() {
                 total += label_node_len(&fs[i]);
@@ -66,8 +64,8 @@ const fn label_node_len(node: &LabelNode) -> usize {
             variants,
         } => {
             let vs = cow_variant_labels(variants);
-            let mut total = 1 + option_str_len(type_label);
-            total += varint_usize_len(vs.len());
+            let mut total = U32_WIDTH + option_str_len(type_label);
+            total += U32_WIDTH;
             let mut i = 0;
             while i < vs.len() {
                 total += variant_label_len(&vs[i]);
@@ -75,7 +73,7 @@ const fn label_node_len(node: &LabelNode) -> usize {
             }
             total
         }
-        LabelNode::Map { key, value } => 1 + label_cell_len(key) + label_cell_len(value),
+        LabelNode::Map { key, value } => U32_WIDTH + label_cell_len(key) + label_cell_len(value),
     }
 }
 
@@ -90,10 +88,10 @@ const fn label_cell_len(cell: &LabelCell) -> usize {
 
 const fn variant_label_len(v: &VariantLabel) -> usize {
     match v {
-        VariantLabel::Unit { name } => 1 + str_len(cow_str_as_str(name)),
+        VariantLabel::Unit { name } => U32_WIDTH + str_len(cow_str_as_str(name)),
         VariantLabel::Tuple { name, fields } => {
             let fs = cow_label_nodes(fields);
-            let mut total = 1 + str_len(cow_str_as_str(name)) + varint_usize_len(fs.len());
+            let mut total = U32_WIDTH + str_len(cow_str_as_str(name)) + U32_WIDTH;
             let mut i = 0;
             while i < fs.len() {
                 total += label_node_len(&fs[i]);
@@ -108,14 +106,14 @@ const fn variant_label_len(v: &VariantLabel) -> usize {
         } => {
             let names = cow_strs(field_names);
             let fs = cow_label_nodes(fields);
-            let mut total = 1 + str_len(cow_str_as_str(name));
-            total += varint_usize_len(names.len());
+            let mut total = U32_WIDTH + str_len(cow_str_as_str(name));
+            total += U32_WIDTH;
             let mut i = 0;
             while i < names.len() {
                 total += str_len(cow_str_as_str(&names[i]));
                 i += 1;
             }
-            total += varint_usize_len(fs.len());
+            total += U32_WIDTH;
             let mut i = 0;
             while i < fs.len() {
                 total += label_node_len(&fs[i]);
@@ -126,7 +124,7 @@ const fn variant_label_len(v: &VariantLabel) -> usize {
     }
 }
 
-/// Serialize `labels` into `N` bytes of canonical postcard form.
+/// Serialize `labels` into `N` bytes of canonical aether-wire form.
 ///
 /// # Panics
 /// Panics if `N` does not match the byte length the size pass
@@ -136,7 +134,7 @@ const fn variant_label_len(v: &VariantLabel) -> usize {
 #[must_use]
 pub const fn canonical_serialize_labels<const N: usize>(labels: &KindLabels) -> [u8; N] {
     let mut out = [0u8; N];
-    let mut pos = write_varint_u64(labels.kind_id.0, &mut out, 0);
+    let mut pos = write_u64_le(labels.kind_id.0, &mut out, 0);
     pos = write_str(cow_str_as_str(&labels.kind_label), &mut out, pos);
     pos = write_label_node(&labels.root, &mut out, pos);
     assert!(
@@ -150,22 +148,18 @@ const fn write_label_node(node: &LabelNode, out: &mut [u8], cursor: usize) -> us
     let mut pos = cursor;
     match node {
         LabelNode::Anonymous => {
-            out[pos] = LABEL_ANONYMOUS;
-            pos += 1;
+            pos = write_u32_le(LABEL_ANONYMOUS as u32, out, pos);
         }
         LabelNode::Option(cell) => {
-            out[pos] = LABEL_OPTION;
-            pos += 1;
+            pos = write_u32_le(LABEL_OPTION as u32, out, pos);
             pos = write_label_cell(cell, out, pos);
         }
         LabelNode::Vec(cell) => {
-            out[pos] = LABEL_VEC;
-            pos += 1;
+            pos = write_u32_le(LABEL_VEC as u32, out, pos);
             pos = write_label_cell(cell, out, pos);
         }
         LabelNode::Array(cell) => {
-            out[pos] = LABEL_ARRAY;
-            pos += 1;
+            pos = write_u32_le(LABEL_ARRAY as u32, out, pos);
             pos = write_label_cell(cell, out, pos);
         }
         LabelNode::Struct {
@@ -175,16 +169,15 @@ const fn write_label_node(node: &LabelNode, out: &mut [u8], cursor: usize) -> us
         } => {
             let names = cow_strs(field_names);
             let fs = cow_label_nodes(fields);
-            out[pos] = LABEL_STRUCT;
-            pos += 1;
+            pos = write_u32_le(LABEL_STRUCT as u32, out, pos);
             pos = write_option_str(type_label, out, pos);
-            pos = write_varint_usize(names.len(), out, pos);
+            pos = write_count(names.len(), out, pos);
             let mut i = 0;
             while i < names.len() {
                 pos = write_str(cow_str_as_str(&names[i]), out, pos);
                 i += 1;
             }
-            pos = write_varint_usize(fs.len(), out, pos);
+            pos = write_count(fs.len(), out, pos);
             let mut i = 0;
             while i < fs.len() {
                 pos = write_label_node(&fs[i], out, pos);
@@ -196,10 +189,9 @@ const fn write_label_node(node: &LabelNode, out: &mut [u8], cursor: usize) -> us
             variants,
         } => {
             let vs = cow_variant_labels(variants);
-            out[pos] = LABEL_ENUM;
-            pos += 1;
+            pos = write_u32_le(LABEL_ENUM as u32, out, pos);
             pos = write_option_str(type_label, out, pos);
-            pos = write_varint_usize(vs.len(), out, pos);
+            pos = write_count(vs.len(), out, pos);
             let mut i = 0;
             while i < vs.len() {
                 pos = write_variant_label(&vs[i], out, pos);
@@ -207,13 +199,11 @@ const fn write_label_node(node: &LabelNode, out: &mut [u8], cursor: usize) -> us
             }
         }
         LabelNode::Ref(cell) => {
-            out[pos] = LABEL_REF;
-            pos += 1;
+            pos = write_u32_le(LABEL_REF as u32, out, pos);
             pos = write_label_cell(cell, out, pos);
         }
         LabelNode::Map { key, value } => {
-            out[pos] = LABEL_MAP;
-            pos += 1;
+            pos = write_u32_le(LABEL_MAP as u32, out, pos);
             pos = write_label_cell(key, out, pos);
             pos = write_label_cell(value, out, pos);
         }
@@ -234,16 +224,14 @@ const fn write_variant_label(v: &VariantLabel, out: &mut [u8], cursor: usize) ->
     let mut pos = cursor;
     match v {
         VariantLabel::Unit { name } => {
-            out[pos] = VARIANT_LABEL_UNIT;
-            pos += 1;
+            pos = write_u32_le(VARIANT_LABEL_UNIT as u32, out, pos);
             pos = write_str(cow_str_as_str(name), out, pos);
         }
         VariantLabel::Tuple { name, fields } => {
             let fs = cow_label_nodes(fields);
-            out[pos] = VARIANT_LABEL_TUPLE;
-            pos += 1;
+            pos = write_u32_le(VARIANT_LABEL_TUPLE as u32, out, pos);
             pos = write_str(cow_str_as_str(name), out, pos);
-            pos = write_varint_usize(fs.len(), out, pos);
+            pos = write_count(fs.len(), out, pos);
             let mut i = 0;
             while i < fs.len() {
                 pos = write_label_node(&fs[i], out, pos);
@@ -257,16 +245,15 @@ const fn write_variant_label(v: &VariantLabel, out: &mut [u8], cursor: usize) ->
         } => {
             let names = cow_strs(field_names);
             let fs = cow_label_nodes(fields);
-            out[pos] = VARIANT_LABEL_STRUCT;
-            pos += 1;
+            pos = write_u32_le(VARIANT_LABEL_STRUCT as u32, out, pos);
             pos = write_str(cow_str_as_str(name), out, pos);
-            pos = write_varint_usize(names.len(), out, pos);
+            pos = write_count(names.len(), out, pos);
             let mut i = 0;
             while i < names.len() {
                 pos = write_str(cow_str_as_str(&names[i]), out, pos);
                 i += 1;
             }
-            pos = write_varint_usize(fs.len(), out, pos);
+            pos = write_count(fs.len(), out, pos);
             let mut i = 0;
             while i < fs.len() {
                 pos = write_label_node(&fs[i], out, pos);

--- a/crates/aether-data/src/canonical/mod.rs
+++ b/crates/aether-data/src/canonical/mod.rs
@@ -1,27 +1,28 @@
 //! Const-fn canonical serializer for `SchemaType`, `KindLabels`, and
-//! `InputsRecord` (ADR-0032, ADR-0033). Produces postcard-compatible
+//! `InputsRecord` (ADR-0032, ADR-0033). Produces ADR-0118 aether-wire
 //! bytes at const-eval time so they can be embedded directly in
 //! `#[link_section]` statics and hashed to derive `Kind::ID`.
 //!
-//! The canonical schema format matches postcard of `SchemaShape`
-//! byte-for-byte: the only difference from `postcard(SchemaType)` is
-//! that `NamedField.name` and `EnumVariant`'s `name` field are
-//! omitted. Enum discriminant positions agree between `SchemaType`
+//! The canonical schema bytes are the bare aether-wire body of
+//! `SchemaShape` byte-for-byte: the only difference from the wire body
+//! of `SchemaType` is that `NamedField.name` and `EnumVariant`'s `name`
+//! field are omitted. Enum selector positions agree between `SchemaType`
 //! and `SchemaShape` by construction (same arm order, same field
 //! declaration order), so hub-side decode via
-//! `postcard::from_bytes::<SchemaShape>` reads the canonical bytes
+//! `wire::from_bytes_bare::<SchemaShape>` reads the canonical bytes
 //! cleanly.
 //!
 //! Only `SchemaCell::Static` / `LabelCell::Static` variants are
 //! legal in const context here. Derive-emitted schemas always use
 //! `Static`; passing an `Owned` cell (or an `Owned` `Cow`) to these
 //! const fns is a compile-time panic. Runtime consumers (the hub)
-//! decode the produced bytes back into `Owned` cells via postcard.
+//! decode the produced bytes back into `Owned` cells via
+//! `wire::from_bytes_bare`.
 //!
 //! Internal submodule layout — module-level re-exports preserve the
 //! `canonical::*` surface so no downstream caller needs an edit:
-//!   - `primitives`: shared const-fn postcard helpers (varint, str,
-//!     option, cow-narrowing) the other submodules build on.
+//!   - `primitives`: shared const-fn aether-wire helpers (fixed-LE
+//!     integers, str, option, cow-narrowing) the other submodules build on.
 //!   - `schema`: `SchemaType` + `(name, schema)` serializers plus the
 //!     runtime `kind_id_from_parts` sibling used by the substrate.
 //!   - `labels`: `KindLabels` sidecar serializer.
@@ -47,7 +48,6 @@ pub use inputs::{
     write_inputs_config, write_inputs_fallback, write_inputs_handler, write_reply_contract,
 };
 pub use labels::{canonical_len_labels, canonical_serialize_labels};
-pub use primitives::{varint_u32_len, varint_u64_len, varint_usize_len};
 pub use schema::{
     canonical_kind_bytes, canonical_len_kind, canonical_len_schema, canonical_serialize_kind,
     canonical_serialize_schema, kind_id_from_parts, kind_id_from_shape,
@@ -56,26 +56,30 @@ pub use schema::{
 #[cfg(test)]
 mod tests {
     //! The contract these tests pin: canonical bytes round-trip through
-    //! `postcard::from_bytes::<SchemaShape>` / `postcard::from_bytes::<KindLabels>`
-    //! / `postcard::from_bytes::<InputsRecord>`. That's what the hub
+    //! `wire::from_bytes_bare::<SchemaShape>` / `wire::from_bytes_bare::<KindLabels>`
+    //! / `wire::from_bytes_bare::<InputsRecord>`. That's what the hub
     //! relies on after reading the `aether.kinds` /
     //! `aether.kinds.labels` / `aether.kinds.inputs` custom sections.
     //! If these diverge, the hub can't decode what derives produce.
     //!
+    //! The `*_const_matches_wire_runtime` tests are the load-bearing
+    //! silent-corruption guard ADR-0118 §Consequences calls out: the
+    //! const-fn writers must emit the exact bytes the serde-driven
+    //! `wire::to_vec_bare` runtime produces for the same value, or a
+    //! mis-hashed `KindId` would mis-route mail.
+    //!
     //! Each test constructs a schema via `static` so `SchemaCell::Static`
     //! is reachable in const context, runs both passes, and compares
     //! against a hand-built `SchemaShape` that matches the stripped shape.
+    use super::schema::{KIND_DOMAIN, fnv1a_64_prefixed};
     use super::*;
-    use super::{
-        primitives::write_varint_u64,
-        schema::{KIND_DOMAIN, fnv1a_64_prefixed},
-    };
     use crate::ids::KindId;
     use crate::schema::{
         EnumVariant, KindLabels, KindShape, LabelCell, LabelNode, NamedField, Primitive,
         SchemaCell, SchemaShape, SchemaType, VariantLabel, VariantShape,
     };
     use crate::tag_bits::{HASH_MASK, TAG_KIND, TAG_SHIFT};
+    use crate::wire;
     use alloc::borrow::Cow;
     use alloc::boxed::Box;
     use alloc::vec;
@@ -187,7 +191,7 @@ mod tests {
     fn canonical_schema_primitive_round_trips_as_shape() {
         const N: usize = canonical_len_schema(&F32);
         const BYTES: [u8; N] = canonical_serialize_schema::<N>(&F32);
-        let shape: SchemaShape = postcard::from_bytes(&BYTES).expect("decode");
+        let shape: SchemaShape = wire::from_bytes_bare(&BYTES).expect("decode");
         assert_eq!(shape, SchemaShape::Scalar(Primitive::F32));
     }
 
@@ -195,7 +199,7 @@ mod tests {
     fn canonical_schema_struct_round_trips_as_shape() {
         const N: usize = canonical_len_schema(&VERTEX);
         const BYTES: [u8; N] = canonical_serialize_schema::<N>(&VERTEX);
-        let shape: SchemaShape = postcard::from_bytes(&BYTES).expect("decode");
+        let shape: SchemaShape = wire::from_bytes_bare(&BYTES).expect("decode");
         assert_eq!(shape, vertex_shape());
     }
 
@@ -203,7 +207,7 @@ mod tests {
     fn canonical_schema_nested_array_of_struct_round_trips() {
         const N: usize = canonical_len_schema(&TRIANGLE);
         const BYTES: [u8; N] = canonical_serialize_schema::<N>(&TRIANGLE);
-        let shape: SchemaShape = postcard::from_bytes(&BYTES).expect("decode");
+        let shape: SchemaShape = wire::from_bytes_bare(&BYTES).expect("decode");
         let expected = SchemaShape::Struct {
             fields: vec![SchemaShape::Array {
                 element: Box::new(vertex_shape()),
@@ -218,7 +222,7 @@ mod tests {
     fn canonical_schema_enum_all_variants_round_trip() {
         const N: usize = canonical_len_schema(&RESULT);
         const BYTES: [u8; N] = canonical_serialize_schema::<N>(&RESULT);
-        let shape: SchemaShape = postcard::from_bytes(&BYTES).expect("decode");
+        let shape: SchemaShape = wire::from_bytes_bare(&BYTES).expect("decode");
         assert_eq!(shape, result_enum_shape());
     }
 
@@ -227,7 +231,7 @@ mod tests {
         const NAME: &str = "test.triangle";
         const N: usize = canonical_len_kind(NAME, &TRIANGLE);
         const BYTES: [u8; N] = canonical_serialize_kind::<N>(NAME, &TRIANGLE);
-        let shape: KindShape = postcard::from_bytes(&BYTES).expect("decode");
+        let shape: KindShape = wire::from_bytes_bare(&BYTES).expect("decode");
         assert_eq!(shape.name, "test.triangle");
         let SchemaShape::Struct { fields, repr_c } = &shape.schema else {
             panic!("expected Struct");
@@ -296,10 +300,10 @@ mod tests {
     fn canonical_schema_ref_round_trips_as_shape() {
         const N: usize = canonical_len_schema(&REF_F32);
         const BYTES: [u8; N] = canonical_serialize_schema::<N>(&REF_F32);
-        // Tag 10 (SCHEMA_REF) followed by the inner schema's tag
-        // (Scalar = 2, F32 = 8).
+        // Selector 10 (SCHEMA_REF) as a `u32` LE — its low byte is at
+        // BYTES[0] — followed by the inner Scalar(F32) shape.
         assert_eq!(BYTES[0], 10);
-        let shape: SchemaShape = postcard::from_bytes(&BYTES).expect("decode");
+        let shape: SchemaShape = wire::from_bytes_bare(&BYTES).expect("decode");
         assert_eq!(
             shape,
             SchemaShape::Ref(Box::new(SchemaShape::Scalar(Primitive::F32)))
@@ -318,7 +322,8 @@ mod tests {
         const INLINE_BYTES: [u8; INLINE_LEN] = canonical_serialize_schema::<INLINE_LEN>(&F32);
         const REF_BYTES: [u8; REF_LEN] = canonical_serialize_schema::<REF_LEN>(&REF_F32);
         assert_ne!(&INLINE_BYTES[..], &REF_BYTES[..]);
-        assert_eq!(REF_BYTES.len(), INLINE_BYTES.len() + 1);
+        // The `Ref` wrapper prepends one 4-byte `u32` LE selector.
+        assert_eq!(REF_BYTES.len(), INLINE_BYTES.len() + 4);
     }
 
     // Labels tests — these exercise the full `KindLabels` round-trip.
@@ -340,11 +345,27 @@ mod tests {
     };
 
     #[test]
-    fn canonical_labels_round_trip_via_postcard() {
+    fn canonical_labels_round_trip_via_wire() {
         const N: usize = canonical_len_labels(&TRIANGLE_LABELS);
         const BYTES: [u8; N] = canonical_serialize_labels::<N>(&TRIANGLE_LABELS);
-        let decoded: KindLabels = postcard::from_bytes(&BYTES).expect("decode");
+        let decoded: KindLabels = wire::from_bytes_bare(&BYTES).expect("decode");
         assert_eq!(decoded, TRIANGLE_LABELS);
+    }
+
+    #[test]
+    fn canonical_labels_const_matches_wire_runtime() {
+        // The const-fn labels writer must emit byte-for-byte what the
+        // serde-driven `wire::to_vec_bare(KindLabels)` runtime produces —
+        // struct + nested array (TRIANGLE) and enum (RESULT) shapes.
+        const TN: usize = canonical_len_labels(&TRIANGLE_LABELS);
+        const TRIANGLE_CONST: [u8; TN] = canonical_serialize_labels::<TN>(&TRIANGLE_LABELS);
+        const RN: usize = canonical_len_labels(&RESULT_LABELS);
+        const RESULT_CONST: [u8; RN] = canonical_serialize_labels::<RN>(&RESULT_LABELS);
+
+        let triangle_runtime = wire::to_vec_bare(&TRIANGLE_LABELS).expect("encode");
+        assert_eq!(&TRIANGLE_CONST[..], triangle_runtime.as_slice());
+        let result_runtime = wire::to_vec_bare(&RESULT_LABELS).expect("encode");
+        assert_eq!(&RESULT_CONST[..], result_runtime.as_slice());
     }
 
     static RESULT_LABELS: KindLabels = KindLabels {
@@ -373,7 +394,7 @@ mod tests {
     fn canonical_labels_enum_round_trips() {
         const N: usize = canonical_len_labels(&RESULT_LABELS);
         const BYTES: [u8; N] = canonical_serialize_labels::<N>(&RESULT_LABELS);
-        let decoded: KindLabels = postcard::from_bytes(&BYTES).expect("decode");
+        let decoded: KindLabels = wire::from_bytes_bare(&BYTES).expect("decode");
         assert_eq!(decoded, RESULT_LABELS);
     }
 
@@ -393,12 +414,12 @@ mod tests {
     fn canonical_labels_ref_round_trips() {
         const N: usize = canonical_len_labels(&REF_VERTEX_LABELS);
         const BYTES: [u8; N] = canonical_serialize_labels::<N>(&REF_VERTEX_LABELS);
-        let decoded: KindLabels = postcard::from_bytes(&BYTES).expect("decode");
+        let decoded: KindLabels = wire::from_bytes_bare(&BYTES).expect("decode");
         assert_eq!(decoded, REF_VERTEX_LABELS);
     }
 
     // ADR-0033: handler/fallback/component record encoders. Round-trip
-    // through `postcard::from_bytes::<InputsRecord>` so the substrate
+    // through `wire::from_bytes_bare::<InputsRecord>` so the substrate
     // reader sees exactly the enum shapes the macro emits.
     use crate::schema::InputsRecord;
 
@@ -414,7 +435,7 @@ mod tests {
         const REPLY_ID: u64 = 0x00c0_ffee_0bad_f00d;
         const N: usize = inputs_handler_len(ID, NAME, DOC, REPLY_TAG, REPLY_ID);
         const BYTES: [u8; N] = write_inputs_handler::<N>(ID, NAME, DOC, REPLY_TAG, REPLY_ID);
-        let decoded: InputsRecord = postcard::from_bytes(&BYTES).expect("decode");
+        let decoded: InputsRecord = wire::from_bytes_bare(&BYTES).expect("decode");
         match decoded {
             InputsRecord::Handler {
                 id,
@@ -443,7 +464,7 @@ mod tests {
         const REPLY_ID: u64 = 0;
         const N: usize = inputs_handler_len(ID, NAME, DOC, REPLY_TAG, REPLY_ID);
         const BYTES: [u8; N] = write_inputs_handler::<N>(ID, NAME, DOC, REPLY_TAG, REPLY_ID);
-        let decoded: InputsRecord = postcard::from_bytes(&BYTES).expect("decode");
+        let decoded: InputsRecord = wire::from_bytes_bare(&BYTES).expect("decode");
         assert_eq!(
             decoded,
             InputsRecord::Handler {
@@ -456,22 +477,25 @@ mod tests {
     }
 
     #[test]
-    fn reply_contract_postcard_roundtrip() {
+    fn reply_contract_wire_roundtrip() {
         use crate::schema::ReplyContract;
-        // ADR-0112: the const-fn `(tag, id)` encoder matches
-        // `postcard(ReplyContract)` byte-for-byte, and the leading byte is
-        // the variant discriminant — `None` = 0, `One` = 1, `Stream` = 2,
-        // `Manual` = 3.
+        // ADR-0112 / ADR-0118: the const-fn `(tag, id)` encoder matches
+        // `wire::to_vec_bare(ReplyContract)` byte-for-byte. The selector is
+        // a `u32` LE, so its low byte (buf[0]) is the variant index —
+        // `None` = 0, `One` = 1, `Stream` = 2, `Manual` = 3.
         fn check(tag: u8, id: u64, expect: ReplyContract, expect_disc: u8) {
-            // Reuse a fixed-cap scratch buffer; `reply_contract_len` <= 11.
+            // Reuse a fixed-cap scratch buffer; `reply_contract_len` <= 12.
             let len = reply_contract_len(tag, id);
             let mut buf = [0u8; 16];
             let written = write_reply_contract(tag, id, &mut buf, 0);
             assert_eq!(written, len, "cursor advance matches reported length");
-            assert_eq!(buf[0], expect_disc, "leading byte is the discriminant");
-            let from_postcard = postcard::to_allocvec(&expect).expect("encode");
-            assert_eq!(&buf[..len], from_postcard.as_slice(), "matches postcard");
-            let decoded: ReplyContract = postcard::from_bytes(&buf[..len]).expect("decode");
+            assert_eq!(
+                buf[0], expect_disc,
+                "selector's low byte is the variant index"
+            );
+            let from_wire = wire::to_vec_bare(&expect).expect("encode");
+            assert_eq!(&buf[..len], from_wire.as_slice(), "matches wire runtime");
+            let decoded: ReplyContract = wire::from_bytes_bare(&buf[..len]).expect("decode");
             assert_eq!(decoded, expect);
         }
         check(0, 0, ReplyContract::None, 0);
@@ -485,7 +509,7 @@ mod tests {
         const DOC: Option<&str> = Some("Forwards anything unrecognized.");
         const N: usize = inputs_fallback_len(DOC);
         const BYTES: [u8; N] = write_inputs_fallback::<N>(DOC);
-        let decoded: InputsRecord = postcard::from_bytes(&BYTES).expect("decode");
+        let decoded: InputsRecord = wire::from_bytes_bare(&BYTES).expect("decode");
         assert_eq!(
             decoded,
             InputsRecord::Fallback {
@@ -499,7 +523,7 @@ mod tests {
         const DOC: &str = "Logs every input event to the broadcast sink.";
         const N: usize = inputs_component_len(DOC);
         const BYTES: [u8; N] = write_inputs_component::<N>(DOC);
-        let decoded: InputsRecord = postcard::from_bytes(&BYTES).expect("decode");
+        let decoded: InputsRecord = wire::from_bytes_bare(&BYTES).expect("decode");
         assert_eq!(decoded, InputsRecord::Component { doc: DOC.into() });
     }
 
@@ -512,7 +536,7 @@ mod tests {
         const NAME: &str = "aether.test_fixtures.probe_config";
         const N: usize = inputs_config_len(ID, NAME);
         const BYTES: [u8; N] = write_inputs_config::<N>(ID, NAME);
-        let decoded: InputsRecord = postcard::from_bytes(&BYTES).expect("decode");
+        let decoded: InputsRecord = wire::from_bytes_bare(&BYTES).expect("decode");
         assert_eq!(
             decoded,
             InputsRecord::Config {
@@ -531,7 +555,7 @@ mod tests {
         const NS: &str = "ui.panel";
         const N: usize = inputs_actor_boundary_len(NS);
         const BYTES: [u8; N] = write_inputs_actor_boundary::<N>(NS);
-        let decoded: InputsRecord = postcard::from_bytes(&BYTES).expect("decode");
+        let decoded: InputsRecord = wire::from_bytes_bare(&BYTES).expect("decode");
         assert_eq!(
             decoded,
             InputsRecord::ActorBoundary {
@@ -541,18 +565,29 @@ mod tests {
     }
 
     #[test]
-    fn varint_u64_matches_postcard_encoding() {
-        // Spot-check the new u64 varint against postcard's own encoder.
-        // `varint_u64_len` / `write_varint_u64` must agree on every
-        // boundary — the macro relies on it for handler ids that are
-        // full 64-bit FNV hashes.
-        for &v in &[0u64, 1, 0x7f, 0x80, 0xff, 0xffff_ffff, u64::MAX] {
-            let mut out = [0u8; 10];
-            let used = write_varint_u64(v, &mut out, 0);
-            let postcard_bytes =
-                postcard::to_allocvec(&v).expect("test setup: postcard encodes u64");
-            assert_eq!(&out[..used], &postcard_bytes[..], "mismatch for {v:#x}");
-            assert_eq!(used, varint_u64_len(v), "len mismatch for {v:#x}");
-        }
+    fn inputs_handler_const_matches_wire_runtime() {
+        use crate::schema::ReplyContract;
+        use alloc::borrow::Cow;
+        // The strongest inputs guard: the const-fn handler encoder must
+        // produce byte-identical output to the serde-driven
+        // `wire::to_vec_bare` over the equivalent `InputsRecord::Handler`.
+        // It exercises every wire primitive a record uses — `u32` selector,
+        // bare `u64` id, length-prefixed name, option-presence doc, and the
+        // nested `ReplyContract` enum.
+        const ID: u64 = 0xdead_beef_cafe_f00d;
+        const NAME: &str = "aether.tick";
+        const DOC: Option<&str> = Some("Not useful to send manually.");
+        const REPLY_TAG: u8 = 1;
+        const REPLY_ID: u64 = 0x00c0_ffee_0bad_f00d;
+        const N: usize = inputs_handler_len(ID, NAME, DOC, REPLY_TAG, REPLY_ID);
+        const CONST_BYTES: [u8; N] = write_inputs_handler::<N>(ID, NAME, DOC, REPLY_TAG, REPLY_ID);
+        let record = InputsRecord::Handler {
+            id: KindId(ID),
+            name: Cow::Borrowed(NAME),
+            doc: DOC.map(Cow::Borrowed),
+            reply: ReplyContract::One(KindId(REPLY_ID)),
+        };
+        let runtime = wire::to_vec_bare(&record).expect("encode");
+        assert_eq!(&CONST_BYTES[..], runtime.as_slice());
     }
 }

--- a/crates/aether-data/src/canonical/primitives.rs
+++ b/crates/aether-data/src/canonical/primitives.rs
@@ -1,18 +1,25 @@
-// Wire-encode: postcard varint slot writes narrow `u64 → u8` after
-// the LEB128 logic guarantees the high bytes are zero (or the
-// continuation bit is set). The byte layout is the load-bearing
-// contract; `try_into` would obscure the wire-format shape.
+// Wire-encode: the `write_count` slot narrows a `usize` length to `u32`
+// after an explicit `<= u32::MAX` assert (a count past the ceiling is an
+// encode error, not a silent truncation). The fixed little-endian byte
+// layout is the load-bearing contract; `try_into` would obscure it and is
+// not available in const context anyway.
 #![allow(clippy::cast_possible_truncation)]
 
-//! Const-fn postcard primitives shared across the canonical
-//! submodules (schema / labels / inputs). Varint encoders, string
-//! length + write helpers, `Option<str>` helpers, and the `Cow`
-//! narrowing shims that hand out `&[T]` / `&str` from a borrowed
-//! `Cow` in const context.
+//! Const-fn aether-wire primitives shared across the canonical
+//! submodules (schema / labels / inputs). Fixed little-endian integer
+//! writers, string length + write helpers, `Option<str>` helpers, and
+//! the `Cow` narrowing shims that hand out `&[T]` / `&str` from a
+//! borrowed `Cow` in const context.
 //!
-//! Everything here is either `pub` (re-exported at `canonical::*`)
-//! or `pub(super)` (reachable from sibling submodules via
-//! `super::primitives::*`). No runtime allocations; no `std`.
+//! The encoding is the ADR-0118 aether wire format (the same layout
+//! `aether_data::wire` drives through serde): little-endian fixed-width
+//! integers, a `u32` little-endian length prefix on strings, a one-byte
+//! option-presence flag. The const-fn writers here must stay byte-for-byte
+//! identical to that runtime path — the `*_runtime_matches_const` cross-checks
+//! in `canonical::tests` are the guard.
+//!
+//! Everything here is `pub(super)` — reachable from sibling submodules via
+//! `super::primitives::*`. No runtime allocations; no `std`.
 
 use alloc::borrow::Cow;
 
@@ -79,91 +86,66 @@ pub(super) const fn cow_str_as_str<'a>(c: &'a Cow<'static, str>) -> &'a str {
     }
 }
 
-/// Byte count of `val` in postcard's unsigned-varint encoding
-/// (7 bits per byte, MSB set until the last byte).
-#[must_use]
-pub const fn varint_u32_len(val: u32) -> usize {
-    if val < (1 << 7) {
-        1
-    } else if val < (1 << 14) {
-        2
-    } else if val < (1 << 21) {
-        3
-    } else if val < (1 << 28) {
-        4
-    } else {
-        5
+/// Byte width of a fixed little-endian `u32` on the wire — the size of a
+/// collection/string count, a sum-type selector (serde's `variant_index`),
+/// and a schema discriminant.
+pub(super) const U32_WIDTH: usize = 4;
+
+/// Byte width of a fixed little-endian `u64` on the wire — the size of a
+/// typed id (`KindId`) and a `SchemaType::TypeId`.
+pub(super) const U64_WIDTH: usize = 8;
+
+/// Byte width of a one-byte flag — `bool` and option-presence.
+pub(super) const FLAG_WIDTH: usize = 1;
+
+/// Write `val` as four fixed little-endian bytes (the wire encoding of a
+/// `u32` count / selector / discriminant), returning the advanced cursor.
+pub(super) const fn write_u32_le(val: u32, out: &mut [u8], cursor: usize) -> usize {
+    let bytes = val.to_le_bytes();
+    let mut i = 0;
+    while i < U32_WIDTH {
+        out[cursor + i] = bytes[i];
+        i += 1;
     }
+    cursor + U32_WIDTH
 }
 
-/// Byte count of `val` in postcard's unsigned-varint encoding, after
-/// narrowing `usize` to `u32`. Used by `const` size passes that walk
-/// schema arrays whose lengths fit in `u32` by construction.
+/// Write `val` as eight fixed little-endian bytes (the wire encoding of a
+/// `u64` typed id / `TypeId`), returning the advanced cursor.
+pub(super) const fn write_u64_le(val: u64, out: &mut [u8], cursor: usize) -> usize {
+    let bytes = val.to_le_bytes();
+    let mut i = 0;
+    while i < U64_WIDTH {
+        out[cursor + i] = bytes[i];
+        i += 1;
+    }
+    cursor + U64_WIDTH
+}
+
+/// Write a wire collection/string count: `val` narrowed to a fixed
+/// little-endian `u32`.
 ///
 /// # Panics
-/// Panics if `val > u32::MAX` — fail-fast per ADR-0063: callers
-/// guarantee the input fits in `u32` by walking bounded `const`
-/// structures, so an overflow indicates a bug in the caller.
-#[must_use]
-pub const fn varint_usize_len(val: usize) -> usize {
+/// Panics if `val > u32::MAX` — fail-fast per ADR-0063: callers walk
+/// bounded `const` structures whose lengths fit in `u32` by construction,
+/// so an overflow indicates a bug in the caller.
+pub(super) const fn write_count(val: usize, out: &mut [u8], cursor: usize) -> usize {
     assert!(
         val <= u32::MAX as usize,
-        "varint_usize_len: value exceeds u32::MAX"
+        "canonical: count exceeds u32::MAX"
     );
-    varint_u32_len(val as u32)
+    write_u32_le(val as u32, out, cursor)
 }
 
-/// Byte count of `val` in postcard's unsigned-varint encoding for u64.
-/// Extends `varint_u32_len` to the full u64 range needed by `Kind::ID`.
-#[must_use]
-pub const fn varint_u64_len(val: u64) -> usize {
-    let mut bytes = 1usize;
-    let mut v = val >> 7;
-    while v != 0 {
-        bytes += 1;
-        v >>= 7;
-    }
-    bytes
-}
-
-pub(super) const fn write_varint_u32(mut val: u32, out: &mut [u8], cursor: usize) -> usize {
-    let mut pos = cursor;
-    while val >= 0x80 {
-        out[pos] = ((val & 0x7F) as u8) | 0x80;
-        val >>= 7;
-        pos += 1;
-    }
-    out[pos] = val as u8;
-    pos + 1
-}
-
-pub(super) const fn write_varint_usize(val: usize, out: &mut [u8], cursor: usize) -> usize {
-    assert!(
-        val <= u32::MAX as usize,
-        "write_varint_usize: value exceeds u32::MAX"
-    );
-    write_varint_u32(val as u32, out, cursor)
-}
-
-pub(super) const fn write_varint_u64(mut val: u64, out: &mut [u8], cursor: usize) -> usize {
-    let mut pos = cursor;
-    while val >= 0x80 {
-        out[pos] = ((val & 0x7F) as u8) | 0x80;
-        val >>= 7;
-        pos += 1;
-    }
-    out[pos] = val as u8;
-    pos + 1
-}
-
+/// Wire byte length of `s`: a `u32` little-endian length prefix plus the
+/// UTF-8 bytes.
 pub(super) const fn str_len(s: &str) -> usize {
-    let bytes = s.as_bytes();
-    varint_usize_len(bytes.len()) + bytes.len()
+    U32_WIDTH + s.len()
 }
 
 pub(super) const fn write_str(s: &str, out: &mut [u8], cursor: usize) -> usize {
     let bytes = s.as_bytes();
-    let mut pos = write_varint_usize(bytes.len(), out, cursor);
+    let mut pos = write_count(bytes.len(), out, cursor);
     let mut i = 0;
     while i < bytes.len() {
         out[pos] = bytes[i];

--- a/crates/aether-data/src/canonical/schema.rs
+++ b/crates/aether-data/src/canonical/schema.rs
@@ -1,23 +1,27 @@
 //! Canonical `SchemaType` + `(name, schema)` kind serializers
-//! (ADR-0032). Produces postcard-compatible bytes at const-eval time
+//! (ADR-0032). Produces ADR-0118 aether-wire bytes at const-eval time
 //! plus a runtime sibling (`canonical_kind_bytes`) that goes through
 //! `SchemaShape` so the hub can re-derive ids for kinds decoded off
 //! the wire.
 //!
-//! The wire-tag constants here are hand-pinned (not source-order
+//! The selector constants here are hand-pinned (not source-order
 //! inferred) so rearranging `SchemaType`/`EnumVariant` in `types.rs`
-//! can't silently change the wire without showing up here too. The
-//! substrate/hub `SchemaShape` enum must keep the same order.
+//! can't silently change the wire without showing up here too. They are
+//! the serde `variant_index` of the matching `SchemaShape`/`VariantShape`
+//! arm, written as a fixed `u32` little-endian selector — so the
+//! const-fn output stays byte-identical to `wire::to_vec_bare(KindShape)`,
+//! and the substrate/hub `SchemaShape` enum must keep the same order.
 
 use crate::schema::{EnumVariant, Primitive, SchemaCell, SchemaType};
 
 use super::primitives::{
-    cow_enum_variants, cow_named_fields, cow_schema_types, str_len, varint_u32_len, varint_u64_len,
-    varint_usize_len, write_str, write_varint_u32, write_varint_u64, write_varint_usize,
+    FLAG_WIDTH, U32_WIDTH, U64_WIDTH, cow_enum_variants, cow_named_fields, cow_schema_types,
+    str_len, write_count, write_str, write_u32_le, write_u64_le,
 };
 use crate::schema::KindShape;
 use crate::schema::SchemaShape;
 use crate::schema::VariantShape;
+use crate::wire;
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
@@ -51,31 +55,35 @@ const PRIM_I64: u8 = 7;
 const PRIM_F32: u8 = 8;
 const PRIM_F64: u8 = 9;
 
-/// Byte length the canonical schema encoding will take.
+/// Byte length the canonical schema encoding will take. Each `SchemaShape`
+/// arm is a `u32` little-endian selector (`U32_WIDTH` bytes) followed by its
+/// positional body — the wire encoding `wire::to_vec_bare(SchemaShape)`
+/// produces.
 #[must_use]
 pub const fn canonical_len_schema(schema: &SchemaType) -> usize {
     match schema {
-        SchemaType::Unit | SchemaType::Bool | SchemaType::String | SchemaType::Bytes => 1,
-        SchemaType::Scalar(_) => 1 + 1,
+        SchemaType::Unit | SchemaType::Bool | SchemaType::String | SchemaType::Bytes => U32_WIDTH,
+        // Selector + the inner `Primitive` as its own `u32` unit-variant index.
+        SchemaType::Scalar(_) => U32_WIDTH + U32_WIDTH,
         SchemaType::Option(cell) | SchemaType::Vec(cell) | SchemaType::Ref(cell) => {
-            1 + canonical_len_cell(cell)
+            U32_WIDTH + canonical_len_cell(cell)
         }
-        SchemaType::Array { element, len } => {
-            1 + canonical_len_cell(element) + varint_u32_len(*len)
+        SchemaType::Array { element, len: _ } => {
+            U32_WIDTH + canonical_len_cell(element) + U32_WIDTH
         }
         SchemaType::Struct { fields, repr_c: _ } => {
             let slice = cow_named_fields(fields);
-            let mut total = 1 + varint_usize_len(slice.len());
+            let mut total = U32_WIDTH + U32_WIDTH;
             let mut i = 0;
             while i < slice.len() {
                 total += canonical_len_schema(&slice[i].ty);
                 i += 1;
             }
-            total + 1
+            total + FLAG_WIDTH
         }
         SchemaType::Enum { variants } => {
             let slice = cow_enum_variants(variants);
-            let mut total = 1 + varint_usize_len(slice.len());
+            let mut total = U32_WIDTH + U32_WIDTH;
             let mut i = 0;
             while i < slice.len() {
                 total += canonical_len_variant(&slice[i]);
@@ -83,8 +91,10 @@ pub const fn canonical_len_schema(schema: &SchemaType) -> usize {
             }
             total
         }
-        SchemaType::Map { key, value } => 1 + canonical_len_cell(key) + canonical_len_cell(value),
-        SchemaType::TypeId(id) => 1 + varint_u64_len(*id),
+        SchemaType::Map { key, value } => {
+            U32_WIDTH + canonical_len_cell(key) + canonical_len_cell(value)
+        }
+        SchemaType::TypeId(_) => U32_WIDTH + U64_WIDTH,
     }
 }
 
@@ -99,14 +109,12 @@ const fn canonical_len_cell(cell: &SchemaCell) -> usize {
 
 const fn canonical_len_variant(variant: &EnumVariant) -> usize {
     match variant {
-        EnumVariant::Unit { discriminant, .. } => 1 + varint_u32_len(*discriminant),
-        EnumVariant::Tuple {
-            discriminant,
-            fields,
-            ..
-        } => {
+        // `VariantShape` selector + the `discriminant: u32` field.
+        EnumVariant::Unit { .. } => U32_WIDTH + U32_WIDTH,
+        EnumVariant::Tuple { fields, .. } => {
             let slice = cow_schema_types(fields);
-            let mut total = 1 + varint_u32_len(*discriminant) + varint_usize_len(slice.len());
+            // selector + discriminant + the `fields: Vec` count.
+            let mut total = U32_WIDTH + U32_WIDTH + U32_WIDTH;
             let mut i = 0;
             while i < slice.len() {
                 total += canonical_len_schema(&slice[i]);
@@ -114,13 +122,9 @@ const fn canonical_len_variant(variant: &EnumVariant) -> usize {
             }
             total
         }
-        EnumVariant::Struct {
-            discriminant,
-            fields,
-            ..
-        } => {
+        EnumVariant::Struct { fields, .. } => {
             let slice = cow_named_fields(fields);
-            let mut total = 1 + varint_u32_len(*discriminant) + varint_usize_len(slice.len());
+            let mut total = U32_WIDTH + U32_WIDTH + U32_WIDTH;
             let mut i = 0;
             while i < slice.len() {
                 total += canonical_len_schema(&slice[i].ty);
@@ -131,7 +135,7 @@ const fn canonical_len_variant(variant: &EnumVariant) -> usize {
     }
 }
 
-/// Serialize `schema` into `N` bytes of canonical postcard form.
+/// Serialize `schema` into `N` bytes of canonical aether-wire form.
 /// Caller passes `N = canonical_len_schema(schema)`.
 ///
 /// # Panics
@@ -150,14 +154,14 @@ pub const fn canonical_serialize_schema<const N: usize>(schema: &SchemaType) -> 
     out
 }
 
-/// Byte length for a full `(name, schema)` canonical record —
-/// matches `postcard(KindShape { name, schema })`.
+/// Byte length for a full `(name, schema)` canonical record — matches
+/// the bare aether-wire body of `KindShape { name, schema }`.
 #[must_use]
 pub const fn canonical_len_kind(name: &str, schema: &SchemaType) -> usize {
     str_len(name) + canonical_len_schema(schema)
 }
 
-/// Serialize `(name, schema)` into `N` bytes of a canonical postcard
+/// Serialize `(name, schema)` into `N` bytes of a canonical aether-wire
 /// record. These are the bytes that populate `aether.kinds` (one
 /// record per `#[derive(Kind)]` type) and that `Kind::ID` hashes over.
 ///
@@ -185,24 +189,25 @@ pub const fn canonical_serialize_kind<const N: usize>(name: &str, schema: &Schem
 /// manifest, where the length isn't const and the `Cow` variants on
 /// the input are `Owned` (const-path helpers panic on those).
 ///
-/// Implementation goes `SchemaType → SchemaShape → postcard`. The
-/// canonical bytes format is defined as `postcard(KindShape { name,
-/// schema: shape })`, and `SchemaShape` drops every nominal field the
-/// const serializer also drops, so the two paths produce
+/// Implementation goes `SchemaType → SchemaShape → wire::to_vec_bare`.
+/// The canonical bytes are the bare aether-wire body of `KindShape {
+/// name, schema: shape }`, and `SchemaShape` drops every nominal field
+/// the const serializer also drops, so the two paths produce
 /// byte-identical output. Pinned by the `canonical_kind_bytes_runtime_
 /// matches_const` test below.
 ///
 /// # Panics
-/// Panics if postcard encoding of the `KindShape` fails — fail-fast
-/// per ADR-0063: `postcard::to_allocvec` into a growable `Vec` cannot
-/// fail for `KindShape`, so a failure indicates a serializer bug.
+/// Panics if wire encoding of the `KindShape` fails — fail-fast per
+/// ADR-0063: `wire::to_vec_bare` into a growable `Vec` fails only when a
+/// length exceeds the `u32` ceiling, unreachable for a `KindShape`, so a
+/// failure indicates a serializer bug.
 #[must_use]
 pub fn canonical_kind_bytes(name: &str, schema: &SchemaType) -> Vec<u8> {
     let shape = KindShape {
         name: Cow::Owned(name.into()),
         schema: schema_to_shape(schema),
     };
-    postcard::to_allocvec(&shape).expect("canonical KindShape serialization is infallible")
+    wire::to_vec_bare(&shape).expect("canonical KindShape serialization is infallible")
 }
 
 fn schema_to_shape(s: &SchemaType) -> SchemaShape {
@@ -285,19 +290,19 @@ pub fn kind_id_from_parts(name: &str, schema: &SchemaType) -> u64 {
 }
 
 /// Derive a `Kind::ID` from a decoded `KindShape`. Same hash as
-/// `kind_id_from_parts` — the canonical bytes format is
-/// `postcard(KindShape)`, so we postcard the shape directly without a
+/// `kind_id_from_parts` — the canonical bytes are the bare aether-wire
+/// body of `KindShape`, so we wire-encode the shape directly without a
 /// `SchemaShape → SchemaType` detour. Used by `kind_manifest` to key
 /// labels records by id after decoding both sections off the wasm.
 ///
 /// # Panics
-/// Panics if postcard encoding of `shape` fails — fail-fast per
-/// ADR-0063: `postcard::to_allocvec` into a growable `Vec` cannot fail
-/// for `KindShape`, so a failure indicates a serializer bug.
+/// Panics if wire encoding of `shape` fails — fail-fast per ADR-0063:
+/// `wire::to_vec_bare` into a growable `Vec` fails only when a length
+/// exceeds the `u32` ceiling, unreachable for a `KindShape`, so a
+/// failure indicates a serializer bug.
 #[must_use]
 pub fn kind_id_from_shape(shape: &KindShape) -> u64 {
-    let bytes =
-        postcard::to_allocvec(shape).expect("canonical KindShape serialization is infallible");
+    let bytes = wire::to_vec_bare(shape).expect("canonical KindShape serialization is infallible");
     (u64::from(TAG_KIND) << TAG_SHIFT) | (fnv1a_64_prefixed(KIND_DOMAIN, &bytes) & HASH_MASK)
 }
 
@@ -327,48 +332,38 @@ const fn write_schema(schema: &SchemaType, out: &mut [u8], cursor: usize) -> usi
     let mut pos = cursor;
     match schema {
         SchemaType::Unit => {
-            out[pos] = SCHEMA_UNIT;
-            pos += 1;
+            pos = write_u32_le(SCHEMA_UNIT as u32, out, pos);
         }
         SchemaType::Bool => {
-            out[pos] = SCHEMA_BOOL;
-            pos += 1;
+            pos = write_u32_le(SCHEMA_BOOL as u32, out, pos);
         }
         SchemaType::Scalar(p) => {
-            out[pos] = SCHEMA_SCALAR;
-            pos += 1;
-            out[pos] = primitive_tag(*p);
-            pos += 1;
+            pos = write_u32_le(SCHEMA_SCALAR as u32, out, pos);
+            pos = write_u32_le(primitive_tag(*p) as u32, out, pos);
         }
         SchemaType::String => {
-            out[pos] = SCHEMA_STRING;
-            pos += 1;
+            pos = write_u32_le(SCHEMA_STRING as u32, out, pos);
         }
         SchemaType::Bytes => {
-            out[pos] = SCHEMA_BYTES;
-            pos += 1;
+            pos = write_u32_le(SCHEMA_BYTES as u32, out, pos);
         }
         SchemaType::Option(cell) => {
-            out[pos] = SCHEMA_OPTION;
-            pos += 1;
+            pos = write_u32_le(SCHEMA_OPTION as u32, out, pos);
             pos = write_cell(cell, out, pos);
         }
         SchemaType::Vec(cell) => {
-            out[pos] = SCHEMA_VEC;
-            pos += 1;
+            pos = write_u32_le(SCHEMA_VEC as u32, out, pos);
             pos = write_cell(cell, out, pos);
         }
         SchemaType::Array { element, len } => {
-            out[pos] = SCHEMA_ARRAY;
-            pos += 1;
+            pos = write_u32_le(SCHEMA_ARRAY as u32, out, pos);
             pos = write_cell(element, out, pos);
-            pos = write_varint_u32(*len, out, pos);
+            pos = write_u32_le(*len, out, pos);
         }
         SchemaType::Struct { fields, repr_c } => {
             let slice = cow_named_fields(fields);
-            out[pos] = SCHEMA_STRUCT;
-            pos += 1;
-            pos = write_varint_usize(slice.len(), out, pos);
+            pos = write_u32_le(SCHEMA_STRUCT as u32, out, pos);
+            pos = write_count(slice.len(), out, pos);
             let mut i = 0;
             while i < slice.len() {
                 pos = write_schema(&slice[i].ty, out, pos);
@@ -379,9 +374,8 @@ const fn write_schema(schema: &SchemaType, out: &mut [u8], cursor: usize) -> usi
         }
         SchemaType::Enum { variants } => {
             let slice = cow_enum_variants(variants);
-            out[pos] = SCHEMA_ENUM;
-            pos += 1;
-            pos = write_varint_usize(slice.len(), out, pos);
+            pos = write_u32_le(SCHEMA_ENUM as u32, out, pos);
+            pos = write_count(slice.len(), out, pos);
             let mut i = 0;
             while i < slice.len() {
                 pos = write_variant(&slice[i], out, pos);
@@ -389,20 +383,17 @@ const fn write_schema(schema: &SchemaType, out: &mut [u8], cursor: usize) -> usi
             }
         }
         SchemaType::Ref(cell) => {
-            out[pos] = SCHEMA_REF;
-            pos += 1;
+            pos = write_u32_le(SCHEMA_REF as u32, out, pos);
             pos = write_cell(cell, out, pos);
         }
         SchemaType::Map { key, value } => {
-            out[pos] = SCHEMA_MAP;
-            pos += 1;
+            pos = write_u32_le(SCHEMA_MAP as u32, out, pos);
             pos = write_cell(key, out, pos);
             pos = write_cell(value, out, pos);
         }
         SchemaType::TypeId(id) => {
-            out[pos] = SCHEMA_TYPE_ID;
-            pos += 1;
-            pos = write_varint_u64(*id, out, pos);
+            pos = write_u32_le(SCHEMA_TYPE_ID as u32, out, pos);
+            pos = write_u64_le(*id, out, pos);
         }
     }
     pos
@@ -421,9 +412,8 @@ const fn write_variant(variant: &EnumVariant, out: &mut [u8], cursor: usize) -> 
     let mut pos = cursor;
     match variant {
         EnumVariant::Unit { discriminant, .. } => {
-            out[pos] = VARIANT_UNIT;
-            pos += 1;
-            pos = write_varint_u32(*discriminant, out, pos);
+            pos = write_u32_le(VARIANT_UNIT as u32, out, pos);
+            pos = write_u32_le(*discriminant, out, pos);
         }
         EnumVariant::Tuple {
             discriminant,
@@ -431,10 +421,9 @@ const fn write_variant(variant: &EnumVariant, out: &mut [u8], cursor: usize) -> 
             ..
         } => {
             let slice = cow_schema_types(fields);
-            out[pos] = VARIANT_TUPLE;
-            pos += 1;
-            pos = write_varint_u32(*discriminant, out, pos);
-            pos = write_varint_usize(slice.len(), out, pos);
+            pos = write_u32_le(VARIANT_TUPLE as u32, out, pos);
+            pos = write_u32_le(*discriminant, out, pos);
+            pos = write_count(slice.len(), out, pos);
             let mut i = 0;
             while i < slice.len() {
                 pos = write_schema(&slice[i], out, pos);
@@ -447,10 +436,9 @@ const fn write_variant(variant: &EnumVariant, out: &mut [u8], cursor: usize) -> 
             ..
         } => {
             let slice = cow_named_fields(fields);
-            out[pos] = VARIANT_STRUCT;
-            pos += 1;
-            pos = write_varint_u32(*discriminant, out, pos);
-            pos = write_varint_usize(slice.len(), out, pos);
+            pos = write_u32_le(VARIANT_STRUCT as u32, out, pos);
+            pos = write_u32_le(*discriminant, out, pos);
+            pos = write_count(slice.len(), out, pos);
             let mut i = 0;
             while i < slice.len() {
                 pos = write_schema(&slice[i].ty, out, pos);

--- a/crates/aether-data/src/schema.rs
+++ b/crates/aether-data/src/schema.rs
@@ -943,11 +943,14 @@ pub const INPUTS_SECTION: &str = "aether.kinds.inputs";
 /// `Handler` variant; v0x04 (ADR-0112 / issue 1850) widened that field
 /// from `Option<KindId>` to [`ReplyContract`] so a handler's reply
 /// *class* (single / manual / stream) is reported, not just a single
-/// reply kind. A component built before any of these and a substrate
-/// after would otherwise disagree on the record shape, so the reader
-/// rejects an older version byte loudly — a hard rebuild boundary.
+/// reply kind; v0x05 (ADR-0118 / issue 1984) re-encoded every record
+/// from postcard onto the owned aether-wire format (fixed little-endian
+/// selectors / ids / counts). A component built before any of these and
+/// a substrate after would otherwise disagree on the record shape, so
+/// the reader rejects an older version byte loudly — a hard rebuild
+/// boundary.
 ///
-/// Distinct from the `aether.kinds` section's own version (also `0x04`,
+/// Distinct from the `aether.kinds` section's own version (also `0x05`,
 /// `kind_manifest::KINDS_VERSION`): the two sections version
 /// independently and happen to share a number at this revision.
-pub const INPUTS_SECTION_VERSION: u8 = 0x04;
+pub const INPUTS_SECTION_VERSION: u8 = 0x05;

--- a/crates/aether-data/src/wire/mod.rs
+++ b/crates/aether-data/src/wire/mod.rs
@@ -142,6 +142,35 @@ pub fn take_from_bytes<'a, T: Deserialize<'a>>(bytes: &'a [u8]) -> Result<(T, &'
     Ok((value, deserializer.remaining()))
 }
 
+/// Decode a value from **bare** wire bytes carrying no leading [`WIRE_VERSION`],
+/// requiring every byte consumed. The symmetric counterpart to [`to_vec_bare`]:
+/// for sites that frame the bare structural body themselves and version the
+/// frame independently of [`WIRE_VERSION`] — e.g. the `aether.kinds` manifest,
+/// whose per-section version byte versions the encoding and whose bare body is
+/// the `Kind::ID` hash input. Most callers want [`from_bytes`].
+pub fn from_bytes_bare<'a, T: Deserialize<'a>>(bytes: &'a [u8]) -> Result<T, Error> {
+    let mut deserializer = de::Deserializer::new(bytes);
+    let value = T::deserialize(&mut deserializer)?;
+    if deserializer.is_empty() {
+        Ok(value)
+    } else {
+        Err(Error::TrailingBytes)
+    }
+}
+
+/// Decode a value from the front of **bare** wire bytes (no leading
+/// [`WIRE_VERSION`]), returning the value and the unconsumed remainder. The
+/// symmetric counterpart to [`to_vec_bare`] for walking back-to-back bare
+/// records (e.g. the manifest reader stepping `[version][bare body]` records,
+/// where the version byte is the frame's, not [`WIRE_VERSION`]).
+pub fn take_from_bytes_bare<'a, T: Deserialize<'a>>(
+    bytes: &'a [u8],
+) -> Result<(T, &'a [u8]), Error> {
+    let mut deserializer = de::Deserializer::new(bytes);
+    let value = T::deserialize(&mut deserializer)?;
+    Ok((value, deserializer.remaining()))
+}
+
 fn strip_version(bytes: &[u8]) -> Result<&[u8], Error> {
     match bytes.split_first() {
         Some((&v, rest)) if v == WIRE_VERSION => Ok(rest),

--- a/crates/aether-data/src/wire/tests.rs
+++ b/crates/aether-data/src/wire/tests.rs
@@ -13,7 +13,10 @@ use alloc::vec::Vec;
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Serialize, Serializer};
 
-use super::{Error, WIRE_VERSION, from_bytes, take_from_bytes, to_vec};
+use super::{
+    Error, WIRE_VERSION, from_bytes, from_bytes_bare, take_from_bytes, take_from_bytes_bare,
+    to_vec, to_vec_bare,
+};
 use crate::ids::KindId;
 use crate::{Kind, Ref};
 
@@ -246,4 +249,44 @@ fn take_from_bytes_returns_the_remainder() {
     let (value, rest): (u8, &[u8]) = take_from_bytes(&bytes).unwrap();
     assert_eq!(value, 7);
     assert_eq!(rest, &[0xAA, 0xBB]);
+}
+
+#[test]
+fn bare_roundtrip_carries_no_version_byte() {
+    // `to_vec_bare` emits the structural body with no leading WIRE_VERSION;
+    // `from_bytes_bare` reads it back, requiring every byte consumed.
+    let r = Rich {
+        name: "x".into(),
+        tags: vec!["a".into(), "b".into()],
+        maybe: Some(42),
+        nested: Point { x: 5, y: 6 },
+        flag: true,
+    };
+    let bare = to_vec_bare(&r).unwrap();
+    assert_eq!(
+        bare,
+        to_vec(&r).unwrap()[1..],
+        "bare body equals the versioned payload minus its leading version byte"
+    );
+    assert_eq!(from_bytes_bare::<Rich>(&bare).unwrap(), r);
+}
+
+#[test]
+fn from_bytes_bare_rejects_trailing_bytes() {
+    let mut bare = to_vec_bare(&7u8).unwrap();
+    bare.push(0xAA);
+    assert_eq!(from_bytes_bare::<u8>(&bare), Err(Error::TrailingBytes));
+}
+
+#[test]
+fn take_from_bytes_bare_walks_back_to_back_records() {
+    // Two bare records concatenated decode in sequence, each handing back the
+    // remainder — the shape the manifest reader relies on.
+    let mut buf = to_vec_bare(&7u8).unwrap();
+    buf.extend_from_slice(&to_vec_bare(&0x0102_0304u32).unwrap());
+    let (first, rest): (u8, &[u8]) = take_from_bytes_bare(&buf).unwrap();
+    assert_eq!(first, 7);
+    let (second, rest): (u32, &[u8]) = take_from_bytes_bare(rest).unwrap();
+    assert_eq!(second, 0x0102_0304);
+    assert!(rest.is_empty());
 }

--- a/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
+++ b/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
@@ -8,9 +8,10 @@
 // the `Kind::ID` hash input) and `aether.kinds.labels` (Rust-nominal
 // sidecar: type paths, field names, variant names).
 //
-// Record formats:
-//   `aether.kinds`         — [0x04] [postcard(KindShape)]
-//   `aether.kinds.labels`  — [0x03] [postcard(KindLabels)]
+// Record formats (ADR-0118: the bytes are the owned aether-wire
+// encoding, not postcard, since issue 1984):
+//   `aether.kinds`         — [0x05] [wire(KindShape)]
+//   `aether.kinds.labels`  — [0x04] [wire(KindLabels)]
 //
 // `aether.kinds` records are identified by computing
 // `kind_id_from_parts(&shape.name, &shape.schema)`. `aether.kinds.labels`
@@ -26,7 +27,7 @@
 // rebuild-required boundary is explicit rather than "single-field
 // cast kinds have empty fields and encode-from-JSON silently fails."
 //
-// The parser walks each section sequentially; postcard stops decoding
+// The parser walks each section sequentially; the wire decoder stops
 // exactly at the record's end, so the next byte is the next record's
 // version tag. Unknown version bytes abort the parse rather than
 // silently skip.
@@ -44,7 +45,7 @@ use std::collections::HashMap;
 use aether_data::{
     EnumVariant, INPUTS_SECTION, INPUTS_SECTION_VERSION, InputsRecord, KindDescriptor, KindLabels,
     KindShape, LabelNode, NamedField, SchemaCell, SchemaShape, SchemaType, VariantLabel,
-    canonical::kind_id_from_shape,
+    canonical::kind_id_from_shape, wire,
 };
 use aether_kinds::{
     ComponentCapabilities, ConfigCapability, FallbackCapability, HandlerCapability,
@@ -75,28 +76,31 @@ pub const LABELS_SECTION: &str = "aether.kinds.labels";
 pub const NAMESPACE_SECTION: &str = "aether.namespace";
 
 /// Wire versions accepted in `aether.kinds`. The shape record's bytes
-/// are `Kind::ID` hash input, so the format is pinned indefinitely at
-/// the canonical-bytes layout — any change there would shift every id.
-/// v0x04 (issue 640) shrunk the per-record framing back to just
+/// are `Kind::ID` hash input, so a change to their layout regenerates
+/// every id — a deliberate clean break, taken loudly via this version
+/// byte. v0x04 (issue 640) shrunk the per-record framing back to just
 /// `[version_byte][canonical_bytes]` after the v0x03 trailing
-/// `is_stream` byte retired with the auto-subscribe path. The
-/// canonical bytes themselves are unchanged from v0x02 / v0x03 so
-/// `Kind::ID` is stable; only the framing shrunk by one byte. v0x02 /
-/// v0x03 are no longer accepted — a loud rebuild-required boundary,
-/// same as the v0x02→v0x03 bump on `aether.kinds.labels`.
+/// `is_stream` byte retired with the auto-subscribe path. v0x05
+/// (ADR-0118 / issue 1984) re-encoded the canonical body from postcard
+/// onto the owned aether-wire format (fixed little-endian selectors /
+/// ids / counts), so every `KindId` regenerates; v0x02 / v0x03 / v0x04
+/// are no longer accepted — a loud rebuild-required boundary, same as
+/// the bump on `aether.kinds.labels`.
 ///
 /// Note: this is the `aether.kinds` section version, distinct from the
 /// `aether.kinds.inputs` section version (`INPUTS_SECTION_VERSION`, also
-/// `0x04` since ADR-0112 / issue 1850). The two sections version
+/// `0x05` since ADR-0118 / issue 1984). The two sections version
 /// independently and happen to coincide at this revision — a shared
 /// number, not a shared format.
-const KINDS_VERSION: u8 = 0x04;
+const KINDS_VERSION: u8 = 0x05;
 
 /// Wire versions accepted in `aether.kinds.labels`. v0x03 added
 /// `kind_id` to `KindLabels`, making records self-identifying so the
-/// reader pairs by id rather than by declaration order. v0x02 is no
-/// longer accepted — a loud rebuild-required boundary.
-const LABELS_SUPPORTED_VERSIONS: &[u8] = &[0x03];
+/// reader pairs by id rather than by declaration order. v0x04 (ADR-0118
+/// / issue 1984) re-encoded the record from postcard onto the owned
+/// aether-wire format. v0x02 / v0x03 are no longer accepted — a loud
+/// rebuild-required boundary.
+const LABELS_SUPPORTED_VERSIONS: &[u8] = &[0x04];
 
 /// Decode every kind record in the component's `aether.kinds` and
 /// (when present) `aether.kinds.labels` sections, merging labels into
@@ -142,10 +146,10 @@ pub fn read_from_bytes(wasm: &[u8]) -> Result<Vec<KindDescriptor>, String> {
     Ok(descriptors)
 }
 
-/// Walk the `aether.kinds` v0x04 section: each record is
-/// `[0x04][postcard(KindShape)]`. Postcard stops decoding exactly at
-/// the shape record's end, so the next byte is the next record's
-/// version tag.
+/// Walk the `aether.kinds` v0x05 section: each record is
+/// `[0x05][wire(KindShape)]`. The wire decoder stops exactly at the
+/// shape record's end, so the next byte is the next record's version
+/// tag.
 fn decode_kinds_records(data: &[u8], out: &mut Vec<KindShape>) -> Result<(), String> {
     let mut cursor = data;
     while !cursor.is_empty() {
@@ -156,14 +160,14 @@ fn decode_kinds_records(data: &[u8], out: &mut Vec<KindShape>) -> Result<(), Str
             ));
         }
         let body = &cursor[1..];
-        match postcard::take_from_bytes::<KindShape>(body) {
+        match wire::take_from_bytes_bare::<KindShape>(body) {
             Ok((shape, rest)) => {
                 out.push(shape);
                 cursor = rest;
             }
             Err(e) => {
                 return Err(format!(
-                    "{MANIFEST_SECTION}: postcard decode failed at record {}: {e}",
+                    "{MANIFEST_SECTION}: wire decode failed at record {}: {e}",
                     out.len() + 1
                 ));
             }
@@ -262,7 +266,7 @@ pub struct ActorInputs {
 
 /// Decode the component's `aether.kinds.inputs` section (ADR-0033 /
 /// ADR-0096) into one [`ActorInputs`] per exported actor type. The
-/// record stream is `[0x03][postcard(InputsRecord)]` back-to-back; an
+/// record stream is `[0x05][wire(InputsRecord)]` back-to-back; an
 /// `ActorBoundary { namespace }` record opens a new group and the
 /// Handler / Fallback / Component / Config records that follow belong
 /// to it, in declaration order. A single-actor module emits no
@@ -387,14 +391,14 @@ fn decode_inputs_records(data: &[u8], out: &mut Vec<InputsRecord>) -> Result<(),
             ));
         }
         let body = &cursor[1..];
-        match postcard::take_from_bytes::<InputsRecord>(body) {
+        match wire::take_from_bytes_bare::<InputsRecord>(body) {
             Ok((record, rest)) => {
                 out.push(record);
                 cursor = rest;
             }
             Err(e) => {
                 return Err(format!(
-                    "{INPUTS_SECTION}: postcard decode failed at record {}: {e}",
+                    "{INPUTS_SECTION}: wire decode failed at record {}: {e}",
                     out.len() + 1
                 ));
             }
@@ -403,10 +407,10 @@ fn decode_inputs_records(data: &[u8], out: &mut Vec<InputsRecord>) -> Result<(),
     Ok(())
 }
 
-/// Walk one custom section: `[version][postcard(T)]` records until
-/// the section is exhausted. Abort on unknown version or postcard
-/// decode error. Per-section version allowlists are passed in so the
-/// shape and labels sections can evolve independently.
+/// Walk one custom section: `[version][wire(T)]` records until the
+/// section is exhausted. Abort on unknown version or wire decode error.
+/// Per-section version allowlists are passed in so the shape and labels
+/// sections can evolve independently.
 fn decode_records<T: DeserializeOwned>(
     section_name: &str,
     supported_versions: &[u8],
@@ -422,14 +426,14 @@ fn decode_records<T: DeserializeOwned>(
             ));
         }
         let body = &cursor[1..];
-        match postcard::take_from_bytes::<T>(body) {
+        match wire::take_from_bytes_bare::<T>(body) {
             Ok((record, rest)) => {
                 out.push(record);
                 cursor = rest;
             }
             Err(e) => {
                 return Err(format!(
-                    "{section_name}: postcard decode failed at record {}: {e}",
+                    "{section_name}: wire decode failed at record {}: {e}",
                     out.len() + 1
                 ));
             }
@@ -657,23 +661,23 @@ mod tests {
         wat::parse_str(wat).unwrap()
     }
 
-    /// Append `[0x03][postcard(shape)][is_stream_byte]` to `canonical`.
-    /// Matches what the Kind derive emits into the `aether.kinds`
-    /// section. Issue 640 retired the v0x03 trailing `is_stream`
-    /// byte; v0x04 is `[version_byte][postcard(KindShape)]`.
+    /// Append `[0x05][wire(KindShape)]` to `canonical`. Matches what the
+    /// Kind derive emits into the `aether.kinds` section (ADR-0118 v0x05:
+    /// the canonical body is the owned aether-wire encoding).
     fn push_shape(canonical: &mut Vec<u8>, shape: &KindShape) {
-        canonical.push(0x04);
-        canonical.extend(postcard::to_allocvec(shape).unwrap());
+        canonical.push(0x05);
+        canonical.extend(wire::to_vec_bare(shape).unwrap());
     }
 
-    /// Append `[0x03][postcard(labels)]` to `labels_bytes`, and stamp
+    /// Append `[0x04][wire(KindLabels)]` to `labels_bytes`, and stamp
     /// `labels.kind_id` from the paired shape so the reader's by-id
     /// merge finds it. Matches what the Kind derive emits into
-    /// `aether.kinds.labels` (v0x03 adds `kind_id`).
+    /// `aether.kinds.labels` (ADR-0118 v0x04: the owned aether-wire
+    /// encoding).
     fn push_labels(labels_bytes: &mut Vec<u8>, shape: &KindShape, labels: &mut KindLabels) {
         labels.kind_id = aether_data::KindId(kind_id_from_shape(shape));
-        labels_bytes.push(0x03);
-        labels_bytes.extend(postcard::to_allocvec(labels).unwrap());
+        labels_bytes.push(0x04);
+        labels_bytes.extend(wire::to_vec_bare(labels).unwrap());
     }
 
     #[test]
@@ -771,8 +775,8 @@ mod tests {
                 repr_c: false,
             },
         };
-        let mut canonical = vec![0x04u8];
-        canonical.extend(postcard::to_allocvec(&shape).unwrap());
+        let mut canonical = vec![0x05u8];
+        canonical.extend(wire::to_vec_bare(&shape).unwrap());
         let wasm = wasm_with_section(MANIFEST_SECTION, &canonical);
         let descs = read_from_bytes(&wasm).unwrap();
         assert_eq!(descs.len(), 1);
@@ -869,8 +873,8 @@ mod tests {
         let mut canonical = Vec::new();
         push_shape(&mut canonical, &shape);
         let mut labels_bytes = Vec::new();
-        labels_bytes.push(0x03);
-        labels_bytes.extend(postcard::to_allocvec(&orphan).unwrap());
+        labels_bytes.push(0x04);
+        labels_bytes.extend(wire::to_vec_bare(&orphan).unwrap());
         let wasm = wasm_with_two_sections(&canonical, &labels_bytes);
         let descs = read_from_bytes(&wasm).unwrap();
         assert_eq!(descs.len(), 1);
@@ -1016,7 +1020,7 @@ mod tests {
         let mut out = Vec::new();
         for rec in records {
             out.push(INPUTS_SECTION_VERSION);
-            out.extend(postcard::to_allocvec(rec).unwrap());
+            out.extend(wire::to_vec_bare(rec).unwrap());
         }
         out
     }

--- a/crates/aether-substrate/src/handle_store/meta.rs
+++ b/crates/aether-substrate/src/handle_store/meta.rs
@@ -20,8 +20,12 @@ use serde::{Deserialize, Serialize};
 ///
 /// v2 (issue #988) added `kind_name` so the schema-evolution check can
 /// look the kind up in the current registry by name; v1 entries (which
-/// lack the field) are un-rescuable and evict on mismatch.
-pub const SCHEMA_VERSION: u8 = 2;
+/// lack the field) are un-rescuable and evict on mismatch. v3 (ADR-0118
+/// / issue 1984) carries no struct change — it invalidates entries whose
+/// stored `kind_id` was computed under the pre-wire canonical bytes,
+/// since moving the `Kind::ID` hash input onto the aether-wire format
+/// regenerates every id. Pre-1.0 this is a wipe, not a migrate.
+pub const SCHEMA_VERSION: u8 = 3;
 
 /// Postcard-encoded sidecar describing one persistent handle. Written
 /// atomically next to the handle's `<hash>.bin` payload; the boot scan

--- a/docs/adr/0118-own-the-aether-wire-format.md
+++ b/docs/adr/0118-own-the-aether-wire-format.md
@@ -116,6 +116,15 @@ retained handle body) and never on interior values (scalars, fields, collection
 elements, the `Ref` handle arm). Every reader strips the byte on entering a kind
 image; no reader assumes a bare body.
 
+The build-time **manifest sections** — `aether.kinds`, `aether.kinds.labels`,
+`aether.kinds.inputs` — sit outside this envelope. Each carries a per-section
+version byte for its own encoding evolution and hashes the *bare* structural
+body (`wire::to_vec_bare`, no leading version byte) into `KindId`. Holding the
+encoding-version out of the hash keeps `KindId` a function of the schema alone:
+a future encoding-only `WIRE_VERSION` bump re-frames mail-path kind images while
+every manifest id stays put, and an id regenerates only when the canonical bytes
+themselves change — as they do at the postcard→wire cutover of these sections.
+
 ### Determinism
 
 Encoding is deterministic by construction — the same value always produces the


### PR DESCRIPTION
Closes #1984.

## Summary

Step 2B of ADR-0118: move the canonical schema / `KindId` codec — the last postcard holdout in the kind-identity path — onto the owned aether-wire format. The const-fn writers in `aether-data/src/canonical/` (schema / labels / inputs) and their runtime siblings now emit fixed little-endian aether-wire (selectors and `KindId`s widen from postcard varints to fixed `u32`/`u64` LE), and the substrate manifest reader decodes that layout via `wire::take_from_bytes_bare`. Every `KindId` regenerates — the deliberate clean break ADR-0118 §"Identity and wire break" calls for, taken while pre-1.0 makes it cheap.

The `KindId` hash input is the **bare** structural body (`wire::to_vec_bare`), not a `WIRE_VERSION`-prefixed image, so schema-identity stays decoupled from encoding-version per ADR-0118 §Envelope (a future encoding-only bump won't regenerate ids). Each manifest section keeps its own per-section version byte as the encoding-evolution signal.

The cutover is atomic between the guest manifest producer and the substrate reader, gated loudly behind per-section version bumps so an old-format wasm fails the version check rather than misparsing:

- `aether.kinds` `0x04 → 0x05`
- `aether.kinds.labels` `0x03 → 0x04`
- `aether.kinds.inputs` (`INPUTS_SECTION_VERSION`) `0x04 → 0x05`

Persisted handle-store data is invalidated through the existing mechanism — `handle_store::meta::SCHEMA_VERSION` `2 → 3` evicts-on-restore entries whose `kind_id` was computed under the pre-wire bytes (a pre-1.0 wipe, not a migrate).

New `wire::from_bytes_bare` / `take_from_bytes_bare` are the symmetric decode counterpart to the `to_vec_bare` #1983 added. ADR-0118 §Envelope gains a clarification that the build-time manifest sections sit outside the `WIRE_VERSION` envelope (folded into this PR, as #1983 did for its own §Envelope note).

## Scope note for review

Three files beyond the issue's §Affected surfaces change here, all **mechanical lockstep** with the version bump step 6 mandates — no design latitude. The version byte is written on the producer side too, and a reader-only bump would make every freshly-built component fail to load:

- `aether-actor-derive` — the derive macro stamps the new `aether.kinds` / `.labels` / `.inputs` version bytes.
- `aether-actor` (`ffi/mod.rs`) — `export!`'s multi-actor boundary record stamps the new inputs version byte.
- `aether-actor/tests/handlers_manifest.rs` — decodes the macro-emitted section via `wire::take_from_bytes_bare`.

## Test plan

- `aether-data` const-vs-`wire::to_vec_bare` cross-checks generalized from kinds to **labels and inputs** (`canonical_labels_const_matches_wire_runtime`, `inputs_handler_const_matches_wire_runtime`) — the silent-corruption guard ADR-0118 §Consequences names, since a mis-hashed `KindId` mis-routes mail.
- `aether-data` conformance round-trips moved from `postcard::from_bytes` onto `wire::from_bytes_bare`; new bare round-trip / remainder tests on `wire`.
- `kind_manifest` reader + `handlers_manifest` producer tests re-encode via wire and bump their version bytes.
- Full `scripts/preflight.sh` green, including the wasm32 component cross-build and the fleetbench tests that spawn real headless substrates loading freshly-built components — the end-to-end proof that producer and reader agree across the boundary.

## Generated by

`/implement` — agent execution of [scoped issue #1984](https://github.com/iamacoffeepot/aether/issues/1984).
