### PR TITLE
refactor(data): consolidate the re-implemented FNV-1a hashers onto crate::hash

### DIFF
--- a/crates/aether-data/src/canonical/mod.rs
+++ b/crates/aether-data/src/canonical/mod.rs
@@ -71,8 +71,8 @@ mod tests {
     //! Each test constructs a schema via `static` so `SchemaCell::Static`
     //! is reachable in const context, runs both passes, and compares
     //! against a hand-built `SchemaShape` that matches the stripped shape.
-    use super::schema::{KIND_DOMAIN, fnv1a_64_prefixed};
     use super::*;
+    use crate::hash::{KIND_DOMAIN, fnv1a_64_prefixed};
     use crate::ids::KindId;
     use crate::schema::{
         EnumVariant, KindLabels, KindShape, LabelCell, LabelNode, NamedField, Primitive,

--- a/crates/aether-data/src/canonical/schema.rs
+++ b/crates/aether-data/src/canonical/schema.rs
@@ -265,14 +265,7 @@ fn variant_to_shape(v: &EnumVariant) -> VariantShape {
     }
 }
 
-/// Domain tag prefixed to every kind-id hash input so the `Kind::ID`
-/// space is disjoint from `MailboxId`. Must stay byte-identical to
-/// `crate::hash::KIND_DOMAIN`; duplicated here at module scope for
-/// the same reason `fnv1a_64_prefixed` is (the canonical-bytes path
-/// hashes `KIND_DOMAIN ++ bytes` without reaching across module
-/// boundaries).
-pub const KIND_DOMAIN: &[u8] = b"kind:";
-
+use crate::hash::{KIND_DOMAIN, fnv1a_64_prefixed};
 use crate::tag_bits::{HASH_MASK, TAG_KIND, TAG_SHIFT};
 
 /// Derive a `Kind::ID` from a `(name, schema)` pair at runtime. Matches
@@ -304,28 +297,6 @@ pub fn kind_id_from_parts(name: &str, schema: &SchemaType) -> u64 {
 pub fn kind_id_from_shape(shape: &KindShape) -> u64 {
     let bytes = wire::to_vec_bare(shape).expect("canonical KindShape serialization is infallible");
     (u64::from(TAG_KIND) << TAG_SHIFT) | (fnv1a_64_prefixed(KIND_DOMAIN, &bytes) & HASH_MASK)
-}
-
-/// FNV-1a 64 over `prefix ++ payload`, mirrored from
-/// `crate::hash::fnv1a_64_prefixed`. Duplicated at module scope so
-/// the canonical-bytes path can hash `KIND_DOMAIN ++ bytes` without
-/// a transient `Vec<u8>` — same offset basis and prime, identical
-/// output.
-pub const fn fnv1a_64_prefixed(prefix: &[u8], payload: &[u8]) -> u64 {
-    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
-    let mut i = 0;
-    while i < prefix.len() {
-        hash ^= prefix[i] as u64;
-        hash = hash.wrapping_mul(0x0100_0000_01b3);
-        i += 1;
-    }
-    let mut i = 0;
-    while i < payload.len() {
-        hash ^= payload[i] as u64;
-        hash = hash.wrapping_mul(0x0100_0000_01b3);
-        i += 1;
-    }
-    hash
 }
 
 const fn write_schema(schema: &SchemaType, out: &mut [u8], cursor: usize) -> usize {

--- a/crates/aether-data/src/hash.rs
+++ b/crates/aether-data/src/hash.rs
@@ -86,19 +86,12 @@ pub const HANDLE_DOMAIN: [u8; 16] = *b"aether/handle/v1";
 #[must_use]
 #[allow(clippy::cast_possible_truncation)]
 pub fn content_addressed_handle_id(transform_id: TransformId, inputs: &[HandleId]) -> HandleId {
-    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
-    let mut feed = |bytes: &[u8]| {
-        for &b in bytes {
-            hash ^= u64::from(b);
-            hash = hash.wrapping_mul(0x0100_0000_01b3);
-        }
-    };
-    feed(&HANDLE_DOMAIN);
-    feed(&transform_id.0.to_le_bytes());
-    feed(&[inputs.len() as u8]);
+    let mut hash = fnv1a_64_fold(0xcbf2_9ce4_8422_2325, &HANDLE_DOMAIN);
+    hash = fnv1a_64_fold(hash, &transform_id.0.to_le_bytes());
+    hash = fnv1a_64_fold(hash, &[inputs.len() as u8]);
     for (slot, handle) in inputs.iter().enumerate() {
-        feed(&[slot as u8]);
-        feed(&handle.0.to_le_bytes());
+        hash = fnv1a_64_fold(hash, &[slot as u8]);
+        hash = fnv1a_64_fold(hash, &handle.0.to_le_bytes());
     }
     HandleId(with_tag(Tag::Handle, hash))
 }

--- a/crates/aether-data/tests/content_addressed_handles.rs
+++ b/crates/aether-data/tests/content_addressed_handles.rs
@@ -91,6 +91,22 @@ fn content_addressed_handles_disjoint_domain() {
     assert_eq!(tag_of(via_transform.0), Some(Tag::Handle));
 }
 
+/// Pin the concrete `HandleId` output for `transform_id=tx(0xabcd)` and
+/// `inputs=[hid(0x1234), hid(0x5678)]` to detect any byte-order regression
+/// in the FNV-1a derivation. The value is produced by the byte-identical
+/// feed sequence: `HANDLE_DOMAIN ++ transform_id LE ++ [input_count] ++
+/// [slot0] ++ input0_LE ++ [slot1] ++ input1_LE`.
+#[test]
+fn content_addressed_handles_golden_value() {
+    let id = content_addressed_handle_id(tx(0xabcd), &[hid(0x1234), hid(0x5678)]);
+    assert_eq!(
+        id.0, GOLDEN_HANDLE_ID,
+        "byte-order regression in FNV-1a derivation"
+    );
+}
+
+const GOLDEN_HANDLE_ID: u64 = 0x3e52_9cb8_843e_6a02;
+
 /// 10k random `(transform_id, inputs)` tuples — no id collides. 10k vs
 /// 64-bit (60-bit body) is well under the birthday bound; a collision
 /// would indicate a derivation bug. Uses a deterministic xorshift PRNG


### PR DESCRIPTION
Closes #1993.

## Summary

Consolidate the re-implemented FNV-1a hashers in `aether-data` onto the single `crate::hash` implementation. The duplicate `KIND_DOMAIN` const and `fnv1a_64_prefixed` fn in `canonical/schema.rs` are deleted in favor of `crate::hash::{KIND_DOMAIN, fnv1a_64_prefixed}`, and the `feed` closure in `content_addressed_handle_id` is replaced with `fnv1a_64_fold` calls in identical byte order.

## Test plan

`cargo nextest run -p aether-data` green; added `content_addressed_handles_golden_value` pinning the known output for a fixed input to guard the byte-order equivalence. Full `scripts/preflight.sh` green (serial run).

## Generated by

`/implement` — agent execution of scoped issue #1993.
