### PR TITLE
refactor(labyrinth): reuse aether_data fnv1a_64_bytes in the reachability baseline digest

### DIFF
--- a/crates/aether-labyrinth/src/reachability_baselines.rs
+++ b/crates/aether-labyrinth/src/reachability_baselines.rs
@@ -57,18 +57,15 @@ fn start_at_origin(width: usize, height: usize) -> Vec<u32> {
     s
 }
 
-/// Cheap FNV-1a digest of a `Vec<u32>` result field (interpreted as
-/// little-endian bytes). Returns a `u64` that serves as the inline
-/// content anchor for seed-deterministic runs.
+/// Cheap FNV-1a digest of a `Vec<u32>` result field (each element
+/// interpreted as little-endian bytes). Returns a `u64` that serves as
+/// the inline content anchor for seed-deterministic runs. Composes
+/// `aether_data::fnv1a_64_bytes` over the concatenated little-endian
+/// byte stream to reuse the shared primitive rather than re-implementing
+/// the fold.
 fn fnv1a_digest(v: &[u32]) -> u64 {
-    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
-    for &val in v {
-        for byte in val.to_le_bytes() {
-            hash ^= u64::from(byte);
-            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
-        }
-    }
-    hash
+    let bytes: Vec<u8> = v.iter().flat_map(|val| val.to_le_bytes()).collect();
+    aether_data::fnv1a_64_bytes(&bytes)
 }
 
 /// Minimum cost-to-reach over the final tick of `v`.


### PR DESCRIPTION
Closes #2000.

## Summary

Reuse `aether_data::fnv1a_64_bytes` in the labyrinth reachability baseline digest instead of the locally re-implemented FNV-1a fold. Explicit `to_le_bytes()` preserves cross-platform determinism; the existing baseline tests stay green against their unchanged expected-digest literals.

## Test plan

`cargo nextest run -p aether-labyrinth` green (seed_a / seed_b baselines unchanged). Full `scripts/preflight.sh` green (serial run).

## Generated by

`/implement` — agent execution of scoped issue #2000.
