### PR TITLE
flake(substrate-bundle): ignore the flaky boot-manifest autoload fleetbench test

### DIFF
--- a/crates/aether-substrate-bundle/tests/fleetbench_component_store.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_component_store.rs
@@ -225,6 +225,12 @@ mod tests {
         /// substrate reads at boot (ADR-0116). `FleetBench` mirrors that
         /// pre-resolution (it speaks raw frames, not aether-mcp): upload,
         /// resolve hub-local, stage the bytes, and spawn with the manifest.
+        // Flaky: the boot-manifest autoload path emits no readiness signal, so
+        // this races a fixed 3s liveness poll (`LogTail` as a registration
+        // probe) against a cold-forked substrate's async boot + autoload, which
+        // intermittently overruns the budget under CI load. Re-enabled by the
+        // engine-local loaded-components query tracked in #2020.
+        #[ignore = "flaky pending the boot-autoload readiness query (#2020)"]
         #[test]
         fn fleetbench_boots_a_component_set_from_a_selector_manifest() {
             if !dist_manifest_present() {


### PR DESCRIPTION
Ignore the flaky `fleetbench_boots_a_component_set_from_a_selector_manifest` test.

## Why

The boot-manifest autoload path (ADR-0116) emits no readiness signal — the chassis queues the autoload mail and `build()` returns before any component load settles. The test therefore polls `LogTail` as a registration probe on a fixed 3s budget (30×100ms), racing a cold-forked substrate's async boot + autoload. Under CI load that race intermittently overruns the budget and the assert at `fleetbench_component_store.rs:292` fires.

This is a stopgap. The real fix — an engine-local loaded-components query the test can poll honestly (and that closes the same readiness gap in `aether-mcp`'s `spawn_substrate`) — is tracked in #2020. The `#[ignore]` reason points there so the test is re-enabled when that lands.

## Test plan

`#[ignore]` only; the heavy serial group no longer runs this test. No logic change.

## Generated by

`/implement` — quick fix.
