### PR TITLE
chore(ci): raise the workspace Test job timeout to 30 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,10 +114,15 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
-    # Normal run is ≤ 2 min; cap at 15 so a hang doesn't eat the
-    # default 6h quota before anyone notices. If this tripping
-    # becomes routine, lower it — routine failure is a signal.
-    timeout-minutes: 15
+    # A warm-cache run is ~13 min (cargo xtask dist + the lightweight
+    # build/run + the heavy serial pass), so the old 15-min cap left
+    # almost no margin: under runner-load variance the heavy step ran
+    # into the wall and the job was cancelled mid-run ("The operation
+    # was canceled", no test failure). Cap at 30 — roughly 2× the warm
+    # run — so variance no longer trips it, while a genuine hang still
+    # can't eat the default 6h quota. Splitting the heavy pass into its
+    # own job to cut the warm time back down is tracked separately.
+    timeout-minutes: 30
     env:
       # Use mold to reduce peak link memory and speed up the test
       # build — keeps the linker OOM (collect2: ld terminated with


### PR DESCRIPTION
Raise the `Test (workspace, linux)` job `timeout-minutes` from 15 to 30.

## Why

A warm-cache run of that job is ~13 min — `cargo xtask dist` (~3m), the lightweight build/run (~5–8m, runner-dependent), and the heavy serial pass (~4m). The 15-min cap left almost no margin, so under runner-load variance (e.g. many PRs running concurrently and competing for the shared runner pool) the heavy step ran into the wall and the whole job was cancelled mid-run.

The symptom was "Error: The operation was canceled" in the heavy step with no test failure, no panic, and no nextest slow-timeout — the signature of the GitHub job-level `timeout-minutes` firing, not a hung test (nextest's 60s `slow-timeout` would name a hung test). Measured: a cancelled run logged 15m16s wall (#2012); a green run finished in 13m13s (#2018) — ~1.5 min of headroom.

30 minutes is ~2× the warm run, so variance no longer trips a spurious cancel, while a genuine hang still can't eat the default 6h quota.

This is the immediate unblock. Cutting the warm run time back down by splitting the heavy pass into its own job (which also gives the heavy contention tests the quiet, uncontended runner they want) is tracked as a follow-up.

## Test plan

CI-config-only change (`.github/workflows/ci.yml`); no code touched.

## Generated by

`/implement` — quick fix.
