### PR TITLE
chore(meta:repo): sync Cargo.lock with aether-kinds manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,6 @@ dependencies = [
  "aether-math",
  "bytemuck",
  "inventory",
- "postcard",
  "serde",
 ]
 


### PR DESCRIPTION
## What

Removes the stale `postcard` entry from `aether-kinds`'s locked dependency set so the committed `Cargo.lock` matches the manifests.

## Why

#2015 dropped `postcard` from `crates/aether-kinds/Cargo.toml` but did not regenerate the lock. The sibling postcard-removal PRs (#2013, #2016, #2018, #2019) each updated `Cargo.lock`; #2015 is the one gap. As a result the committed lock still lists `postcard` under `aether-kinds`, so every cargo resolve — and RustRover re-resolving on its own — deletes the line and leaves the working tree dirty.

## Change

One line: drop `"postcard"` from the `aether-kinds` package entry in `Cargo.lock`. No manifest or code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)