### PR TITLE
refactor(mcp): move schema decode off postcard onto aether_data::wire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,7 +223,6 @@ dependencies = [
  "base64",
  "futures-util",
  "libc",
- "postcard",
  "reqwest",
  "rmcp",
  "schemars",

--- a/crates/aether-mcp/Cargo.toml
+++ b/crates/aether-mcp/Cargo.toml
@@ -56,11 +56,6 @@ libc = "0.2"
 # through incrementally rather than buffered to EOF. Default features
 # (TLS, etc.) are off — the upstream is plain-HTTP localhost.
 reqwest = { version = "0.13", default-features = false, features = ["stream"] }
-# Used by the per-engine kind cache (ADR-0091) to round-trip a
-# `SchemaType` through the `KindDescriptorWire.schema_postcard` field —
-# `SchemaType` has no `Schema` impl of its own, so it rides as opaque
-# bytes within the `aether.inventory.kinds_result` wire kind.
-postcard = { workspace = true, features = ["heapless-cas"] }
 rmcp = { version = "1.7", features = [
     "server",
     "macros",

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -1183,8 +1183,8 @@ impl Mcp {
         let descriptor = build_descriptor(args.descriptor)
             .await
             .map_err(|e| McpError::invalid_params(format!("submit_dag descriptor: {e}"), None))?;
-        // Encode via the kind's native (postcard) wire encode — ids
-        // serialize in their u64 form, matching the substrate's decode.
+        // Encode via the kind's wire encode — ids serialize in their u64
+        // form, matching the substrate's decode.
         let payload = Submit { descriptor }.encode_into_bytes();
         let envelope = MailEnvelope {
             to: MailboxAddress {
@@ -1588,11 +1588,11 @@ impl Mcp {
             return;
         };
 
-        // Decode each `schema_postcard` back into a `SchemaType`; an
-        // entry whose schema fails to decode is dropped (the
-        // substrate's wire form is canonical, so a decode failure is
-        // a substrate / aether-data version mismatch — better to skip
-        // the entry than panic the tool call).
+        // Decode each `schema_postcard` back into a `SchemaType` via
+        // `wire::from_bytes`; an entry whose schema fails to decode is
+        // dropped (the substrate's wire form is canonical, so a decode
+        // failure is a substrate / aether-data version mismatch —
+        // better to skip the entry than panic the tool call).
         let fresh: Vec<KindDescriptor> = kinds
             .into_iter()
             .filter_map(|wire| {
@@ -3726,7 +3726,7 @@ mod tests {
     /// builders, which bound `K: Kind` (not `K: Kind + Serialize`) and
     /// encode via the descriptor-aware `encode_into_bytes`. The payload
     /// is the kind's cast image (length == `size_of`, distinct from a
-    /// postcard varint encode of these `u64`s) and round-trips through
+    /// wire varint encode of these `u64`s) and round-trips through
     /// `Kind::decode_from_bytes`. Compiling at all is the bound check:
     /// the old `serde::Serialize` bound would reject this kind.
     #[test]
@@ -3739,7 +3739,7 @@ mod tests {
         assert_eq!(
             cast_bytes.len(),
             size_of::<aether_kinds::LifecycleSubscribe>(),
-            "cast image is the fixed struct size, not a postcard varint encode",
+            "cast image is the fixed struct size, not a wire varint encode",
         );
 
         let local = local_envelope("aether.lifecycle", &mail);
@@ -4140,8 +4140,8 @@ mod tests {
             .await
             .expect("build_mail_envelope encodes the component-defined kind");
         // The schema-encoded payload for a `SchemaType::String` is the
-        // postcard string wire shape; decoding back via the same
-        // schema must yield the original JSON value.
+        // wire-codec string shape; decoding back via the same schema
+        // must yield the original JSON value.
         let decoded = aether_codec::decode_schema(&envelope.payload, &component_kind.schema)
             .expect("payload decodes against the cached schema");
         assert_eq!(


### PR DESCRIPTION
Closes #2009.

## Summary

Removes the last `postcard` surface from `aether-mcp`. The two `SchemaType` decode sites in `tools.rs` (`refresh_engine_kinds` at `:1598` and the tools test at `:4113`) were already moved to `aether_data::wire::from_bytes` as part of #2018, which had to migrate the encode/decode pair atomically. This change finishes the job by:

- dropping the `postcard` dependency (and its explanatory comment block) from `crates/aether-mcp/Cargo.toml`,
- refreshing the five stale prose comments in `tools.rs` that still named postcard so they describe the wire codec.

After this, `git grep postcard crates/aether-mcp` returns only the `schema_postcard` wire struct field name, whose rename is deferred to #1985.

## Test plan

- `cargo nextest run -p aether-mcp` — all 74 tests pass.
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt`, `cargo doc --workspace --no-deps` — clean.
- No code logic changed (dep drop + comment refreshes), so behavior is unchanged.

## Generated by

`/implement` — agent execution of scoped issue #2009.
