### PR TITLE
refactor(actor): move postcard call sites onto aether_data::wire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,6 @@ dependencies = [
  "aether-kinds",
  "bytemuck",
  "inventory",
- "postcard",
  "serde",
  "tracing",
 ]

--- a/crates/aether-actor/Cargo.toml
+++ b/crates/aether-actor/Cargo.toml
@@ -24,10 +24,9 @@ aether-data = { path = "../aether-data", features = ["derive"] }
 # request kinds — that whole vocabulary lives in `aether-kinds`.
 aether-kinds = { path = "../aether-kinds" }
 bytemuck = { workspace = true, default-features = false }
-postcard = { workspace = true, default-features = false, features = ["alloc"] }
-# Postcard-decoding typed payloads (e.g. `PriorState::as_kind`,
-# `Mail::decode_kind`) is serde-driven. The crate stays
-# `no_std`-friendly with `default-features = false`.
+# Decoding typed payloads (e.g. `PriorState::as_kind`,
+# `Mail::decode_kind`) is serde-driven via `aether_data::wire`. The crate
+# stays `no_std`-friendly with `default-features = false`.
 serde = { workspace = true, default-features = false, features = ["alloc"] }
 # ADR-0060: the wasm shim installs a `tracing::Subscriber`
 # (`MailSubscriber`) at component boot that turns `tracing::warn!` /
@@ -47,7 +46,6 @@ tracing = { workspace = true, default-features = false }
 aether-capabilities = { path = "../aether-capabilities", features = ["render"] }
 serde = { workspace = true, default-features = false, features = ["derive", "alloc"] }
 bytemuck = { workspace = true, features = ["derive"] }
-postcard = { workspace = true, features = ["alloc", "heapless-cas"] }
 # Issue #243: `#[derive(Kind)]` test fixtures emit `inventory::submit!`
 # on native targets; the macro path needs `::inventory` reachable.
 # Tests run native, so an unconditional dev-dep is fine.

--- a/crates/aether-actor/src/actor/ctx/persistence.rs
+++ b/crates/aether-actor/src/actor/ctx/persistence.rs
@@ -12,14 +12,14 @@
 //!
 //! `save_state_kind` is the typed-state convenience (ADR-0040): the
 //! bundle is framed as `[0..8)` little-endian `K::ID` followed by the
-//! postcard encoding of `value`; the replacement instance recovers `K`
+//! wire encoding of `value`; the replacement instance recovers `K`
 //! via [`crate::mail::PriorState::as_kind`]. Use the raw `save_state`
 //! when persisting bytes that aren't a kind or when driving an
 //! explicit migration off the leading id.
 
 use alloc::vec::Vec;
 
-use aether_data::{Kind, Schema};
+use aether_data::{Kind, Schema, wire};
 
 /// Migration-bundle deposit surface for the `on_dehydrate` save hook.
 /// Init / runtime ctxs deliberately don't implement this.
@@ -44,7 +44,7 @@ pub trait Persistence {
 
     /// Persist a typed kind value across `replace_component`
     /// (ADR-0040). The bundle is framed as `[0..8)` little-endian
-    /// `K::ID` followed by the postcard encoding of `value`; the
+    /// `K::ID` followed by the wire encoding of `value`; the
     /// replacement instance recovers `K` via [`crate::mail::PriorState::as_kind`].
     ///
     /// `K::ID` is the ADR-0030 schema hash — changing the shape of
@@ -60,7 +60,7 @@ pub trait Persistence {
         K: Kind + Schema + serde::Serialize,
     {
         let mut out = Vec::from(K::ID.0.to_le_bytes());
-        let payload = postcard::to_allocvec(value).expect("postcard encode to Vec is infallible");
+        let payload = wire::to_vec(value).expect("wire encode to Vec is infallible");
         out.extend_from_slice(&payload);
         self.save_state(version, &out);
     }

--- a/crates/aether-actor/src/mail/mod.rs
+++ b/crates/aether-actor/src/mail/mod.rs
@@ -22,7 +22,7 @@ pub mod mailbox;
 
 use core::marker::PhantomData;
 
-use aether_data::{Kind, MailboxId, Schema};
+use aether_data::{Kind, MailboxId, Schema, wire};
 
 use crate::mail::mailbox::KindId;
 
@@ -409,7 +409,7 @@ impl<'a> PriorState<'a> {
 
     /// Decode the prior-state bundle as kind `K` (ADR-0040). Returns
     /// `Some(K)` when the leading 8 bytes match `K::ID` (little-
-    /// endian) and the trailing bytes decode cleanly via postcard;
+    /// endian) and the trailing bytes decode cleanly via wire;
     /// `None` on id mismatch, short buffer (fewer than 8 bytes), or
     /// decode failure.
     ///
@@ -436,7 +436,7 @@ impl<'a> PriorState<'a> {
         if id != K::ID.0 {
             return None;
         }
-        postcard::from_bytes(payload).ok()
+        wire::from_bytes(payload).ok()
     }
 }
 
@@ -849,7 +849,7 @@ mod tests {
     // exercised end-to-end on host (the underlying `T::save_state`
     // panics on the wasm transport's host stub), so these tests pair
     // a hand-built bundle matching the documented framing
-    // (`[0..8) = K::ID LE`, `[8..) = postcard(value)`) against
+    // (`[0..8) = K::ID LE`, `[8..) = wire(value)`) against
     // `PriorState::as_kind` — the one we *can* unit-test on host. A
     // mismatch between framing and decode surfaces here before either
     // diverges from the ADR's wire shape.
@@ -874,8 +874,7 @@ mod tests {
 
     fn frame_bundle<K: Kind + Schema + Serialize>(value: &K) -> Vec<u8> {
         let mut out = Vec::from(K::ID.0.to_le_bytes());
-        let payload =
-            postcard::to_allocvec(value).expect("test setup: postcard encodes test value");
+        let payload = wire::to_vec(value).expect("test setup: wire encodes test value");
         out.extend_from_slice(&payload);
         out
     }
@@ -906,7 +905,7 @@ mod tests {
     #[test]
     fn as_kind_id_mismatch_returns_none() {
         // Frame under one kind, decode as a different one — the
-        // leading `K::ID` compare rejects before postcard runs.
+        // leading `K::ID` compare rejects before wire runs.
         let value = OtherState { flag: true };
         let buf = frame_bundle(&value);
         let prior = prior_from(&buf, 0);
@@ -936,7 +935,7 @@ mod tests {
 
     #[test]
     fn as_kind_correct_id_garbage_payload_returns_none() {
-        // Leading id matches but the postcard tail is truncated.
+        // Leading id matches but the wire tail is truncated.
         // Decode error must surface as None, not a panic.
         let mut buf = Vec::from(StateStruct::ID.0.to_le_bytes());
         buf.push(0xff);


### PR DESCRIPTION
Closes #2008.

## Summary

Moves the last `postcard` call sites in `aether-actor` onto `aether_data::wire`, removing the crate's dependency on postcard:

- `Persistence::save_state_kind` encode (`persistence.rs`): `postcard::to_allocvec` → `wire::to_vec` (still framed after the leading `K::ID` LE bytes).
- `PriorState::as_kind` decode (`mail/mod.rs`): `postcard::from_bytes` → `wire::from_bytes`.
- The `frame_bundle` test helper swapped to `wire::to_vec` so the `as_kind` round-trip stays a faithful encode/decode pair.
- Both `postcard` manifest entries dropped (the dep and the dev-dep); the `serde` comment refreshed to describe the wire codec.

The `postcard_echoer.rs` guard (plan step 4) was satisfied: `grep -nE 'postcard::|#\[handler\(postcard'` over the examples returned only stale doc-comment text, no live `postcard::` code path, so both manifest entries were safe to drop. After this, `grep -rE 'postcard::' crates/aether-actor/` returns nothing.

## Test plan

- `cargo nextest run -p aether-actor` — all 104 tests pass, including `state_framing_roundtrip::save_state_kind_round_trips_through_as_kind` and the `as_kind_*` framing tests that exercise the encode/decode swap.
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt`, `cargo doc --workspace --no-deps` — clean.
- `cargo xtask dist --no-bins` (wasm32 component cross-build) — 19 components built.

## Generated by

`/implement` — agent execution of scoped issue #2008.
