### PR TITLE
feat(capabilities): thread an export selector through component replace

### DIFF
--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -271,9 +271,12 @@ mod native {
         /// `NativeBinding`, which outlives the swap.
         ///
         /// # Agent
-        /// `ReplaceComponent { mailbox_id, wasm, drain_timeout_ms }`.
+        /// `ReplaceComponent { mailbox_id, wasm, drain_timeout_ms, config, export }`.
         /// `drain_timeout_ms` is accepted for wire compatibility but
         /// ignored under the trampoline's binding-stable replace.
+        /// `export` (ADR-0096) names which exported actor type of the
+        /// replacement module to instantiate; `None` reuses the type the
+        /// trampoline currently hosts.
         #[handler]
         fn on_replace_component(&mut self, ctx: &mut NativeCtx<'_>, payload: ReplaceComponent) {
             self.forward_to_trampoline(ctx, payload.mailbox_id, ReplaceComponent::ID, &payload);

--- a/crates/aether-capabilities/src/trampoline.rs
+++ b/crates/aether-capabilities/src/trampoline.rs
@@ -456,6 +456,79 @@ mod native {
             }
         }
 
+        /// ADR-0096: resolve the **effective tag** an export-targeted
+        /// replace instantiates, paired with the capability group to
+        /// advertise. `export = Some(ns)` names an exported actor type of
+        /// the replacement module, hashed to its tag the same way the load
+        /// path resolves `LoadComponent.export` (component.rs `handle_load`);
+        /// an export the new module doesn't declare is a clean `Err`,
+        /// mirroring the load "export not found" message. `export = None`
+        /// reuses the type THIS trampoline currently hosts (`self.type_tag`)
+        /// — the byte-for-byte legacy path: entry (first actor) when the tag
+        /// is None, else the actor whose namespace hashes to the tag, with
+        /// an `Err` if the new module doesn't export it. The returned tag
+        /// drives both the reply capabilities and `Component::instantiate`,
+        /// and on success the caller promotes it to the new `self.type_tag`
+        /// so a later bare replace reuses the *current* hosted type rather
+        /// than reverting to the original load's.
+        fn resolve_replace_target(
+            &self,
+            export: Option<&str>,
+            actors: &[ActorInputs],
+        ) -> Result<(ComponentCapabilities, Option<u64>), String> {
+            if let Some(requested) = export {
+                let group = actors
+                    .iter()
+                    .find(|a| a.namespace.as_deref() == Some(requested))
+                    .ok_or_else(|| {
+                        let available: Vec<&str> = actors
+                            .iter()
+                            .filter_map(|a| a.namespace.as_deref())
+                            .collect();
+                        format!(
+                            "export {requested:?} not found in module; exported types: {available:?}"
+                        )
+                    })?;
+                return Ok((
+                    group.capabilities.clone(),
+                    // Runtime-name routing: `requested` is the export
+                    // namespace from the wire replace request, resolved to
+                    // its actor-type tag exactly as the load path does.
+                    #[allow(clippy::disallowed_methods)]
+                    Some(aether_data::mailbox_id_from_name(requested).0),
+                ));
+            }
+            // Bare replace (`export: None`): reuse the type this trampoline
+            // currently hosts. With no tag yet (post-drop refill) that's the
+            // entry actor — first in the export list — with a `None` tag.
+            let Some(tag) = self.type_tag else {
+                return Ok((
+                    actors
+                        .first()
+                        .map(|a| a.capabilities.clone())
+                        .unwrap_or_default(),
+                    None,
+                ));
+            };
+            actors
+                .iter()
+                .find(|a| {
+                    // Runtime-name match: hash each replacement actor's
+                    // declared namespace to find the one whose tag was
+                    // loaded — not a hardcoded sibling.
+                    #[allow(clippy::disallowed_methods)]
+                    a.namespace
+                        .as_deref()
+                        .is_some_and(|ns| aether_data::mailbox_id_from_name(ns).0 == tag)
+                })
+                .map(|group| (group.capabilities.clone(), Some(tag)))
+                .ok_or_else(|| {
+                    format!(
+                        "replace: new module does not export the actor type (tag {tag:#x}) this trampoline loaded"
+                    )
+                })
+        }
+
         fn handle_replace(&mut self, payload: ReplaceComponent) -> ReplaceResult {
             // `payload.wasm` is the new module bytes; `mailbox_id` is
             // the trampoline's own id (the agent already addressed
@@ -472,41 +545,23 @@ mod native {
             };
 
             // ADR-0033 / ADR-0096 / ADR-0097: parse every exported type's
-            // capability group from the new wasm. `capabilities` is the
-            // group for the type THIS trampoline hosts (entry when
-            // `type_tag` is None), so the reply carries the post-replace
-            // handler vocabulary; the full `actors` set refreshes
-            // `self.actor_caps` below so post-replace sibling spawns see
-            // the new module's types. A tag absent from the new module is
-            // an `Err` — the replacement doesn't export the loaded type.
+            // capability group from the new wasm. The full `actors` set
+            // refreshes `self.actor_caps` below so post-replace sibling
+            // spawns see the new module's types.
             let actors = match kind_manifest::read_actor_inputs_from_bytes(&payload.wasm) {
                 Ok(a) => a,
                 Err(error) => return ReplaceResult::Err { error },
             };
-            let capabilities = match self.type_tag {
-                None => actors
-                    .first()
-                    .map(|a| a.capabilities.clone())
-                    .unwrap_or_default(),
-                Some(tag) => match actors.iter().find(|a| {
-                    // Runtime-name match: hash each replacement actor's declared
-                    // namespace to find the one whose tag was loaded — not a
-                    // hardcoded sibling.
-                    #[allow(clippy::disallowed_methods)]
-                    a.namespace
-                        .as_deref()
-                        .is_some_and(|ns| aether_data::mailbox_id_from_name(ns).0 == tag)
-                }) {
-                    Some(group) => group.capabilities.clone(),
-                    None => {
-                        return ReplaceResult::Err {
-                            error: format!(
-                                "replace: new module does not export the actor type (tag {tag:#x}) this trampoline loaded"
-                            ),
-                        };
-                    }
-                },
-            };
+
+            // ADR-0096: resolve the effective tag the replacement
+            // instantiates plus the capability group to advertise —
+            // export-named, or the trampoline's current hosted type for a
+            // bare replace. See [`Self::resolve_replace_target`].
+            let (capabilities, effective_tag) =
+                match self.resolve_replace_target(payload.export.as_deref(), &actors) {
+                    Ok(resolved) => resolved,
+                    Err(error) => return ReplaceResult::Err { error },
+                };
 
             // Run unwire then on_dehydrate on the old instance and lift
             // any saved-state bundle. If the trampoline is currently
@@ -554,7 +609,7 @@ mod native {
                 &module,
                 substrate_ctx,
                 &payload.config,
-                self.type_tag,
+                effective_tag,
             ) {
                 Ok(c) => c,
                 Err(e) => {
@@ -569,6 +624,11 @@ mod native {
             // replace re-instantiate the new code, not the old.
             self.module = module;
             self.actor_caps = actors;
+            // ADR-0096: track the actor type this trampoline now hosts, so
+            // a later bare (`export: None`) replace reuses the *current*
+            // type rather than reverting to the original load's. A bare
+            // replace leaves this unchanged (`effective_tag == self.type_tag`).
+            self.type_tag = effective_tag;
 
             // ADR-0016 §4: rehydrate the new instance if the old one
             // produced a bundle. A failed rehydrate still installs the

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1694,6 +1694,15 @@ mod control_plane {
         /// the same way [`LoadComponent::config`] is on first load. An
         /// empty vec means "no config".
         pub config: Vec<u8>,
+        /// ADR-0096: which exported actor type to instantiate from the
+        /// replacement module, named by its `Actor::NAMESPACE`. `None`
+        /// reuses the trampoline's **current hosted type** (not
+        /// necessarily the entry), so a bare replace preserves
+        /// today's behaviour byte-for-byte. `Some(ns)` instantiates the
+        /// named export — mirroring [`LoadComponent::export`] — and an
+        /// export the replacement module doesn't declare is a clean
+        /// `ReplaceResult::Err`.
+        pub export: Option<String>,
     }
 
     /// Reply to `ReplaceComponent`. Carries the new component's
@@ -5903,12 +5912,14 @@ mod tests {
                 wasm: vec![0x00, 0x61, 0x73, 0x6d],
                 drain_timeout_ms: Some(2500),
                 config: vec![0x01, 0x02, 0x03],
+                export: Some("ui.panel".to_string()),
             };
             let bytes = replace.encode_into_bytes();
             let back = ReplaceComponent::decode_from_bytes(&bytes)
                 .expect("decode ReplaceComponent round-trip");
             assert_eq!(back.config, vec![0x01, 0x02, 0x03]);
             assert_eq!(back.mailbox_id, aether_data::MailboxId(7));
+            assert_eq!(back.export.as_deref(), Some("ui.panel"));
         }
 
         #[test]

--- a/crates/aether-mcp/src/args.rs
+++ b/crates/aether-mcp/src/args.rs
@@ -341,6 +341,15 @@ pub struct ReplaceComponentArgs {
     /// on first load.
     #[serde(default)]
     pub config_path: Option<String>,
+    /// ADR-0096: which exported actor type to instantiate from the
+    /// replacement module, named by its `Actor::NAMESPACE` (e.g.
+    /// `"ui.panel"`). Omit to reuse the actor type the trampoline
+    /// currently hosts — not necessarily the entry — preserving today's
+    /// replace behaviour. A `module@actor` selector populates this from
+    /// its `@actor` half. An export the replacement module doesn't
+    /// declare comes back as a `ReplaceResult::Err`.
+    #[serde(default)]
+    pub export: Option<String>,
 }
 
 /// `describe_component` arguments.

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -711,7 +711,7 @@ impl Mcp {
     }
 
     #[tool(
-        description = "Atomically replace a live component's WASM with a build resolved from a registry selector (ADR-0022 structural splice; ADR-0116 selector). Pass `selector` (hash-primary — a hash pins or rolls the component to an exact build; a name or module@actor resolves too); the host wasm path is gone, surviving only as the upload_component input. aether-mcp resolves the selector hub-local to the wasm bytes and forwards aether.component.replace to the engine's aether.component mailbox. drain_timeout_ms is accepted for wire compatibility but currently ignored. Returns the replaced component's advertised capabilities. Very large wasm payloads (debug builds at 15-25 MiB) may exceed the RPC framing cap — prefer release builds, or raise the cap via the AETHER_MAX_FRAME_SIZE env var (default 64 MiB, clamped at 1 GiB; issue 1271)."
+        description = "Atomically replace a live component's WASM with a build resolved from a registry selector (ADR-0022 structural splice; ADR-0116 selector). Pass `selector` (hash-primary — a hash pins or rolls the component to an exact build; a name or module@actor resolves too); the host wasm path is gone, surviving only as the upload_component input. aether-mcp resolves the selector hub-local to the wasm bytes and forwards aether.component.replace to the engine's aether.component mailbox. drain_timeout_ms is accepted for wire compatibility but currently ignored. Pass export to instantiate a specific exported actor type from a multi-actor replacement module (ADR-0096), named by its Actor::NAMESPACE; a module@actor selector populates it from its @actor half. Omit export to reuse the actor type the trampoline currently hosts — not necessarily the module entry — preserving today's replace behaviour; an export the replacement module doesn't declare comes back as an error. Returns the replaced component's advertised capabilities. Very large wasm payloads (debug builds at 15-25 MiB) may exceed the RPC framing cap — prefer release builds, or raise the cap via the AETHER_MAX_FRAME_SIZE env var (default 64 MiB, clamped at 1 GiB; issue 1271)."
     )]
     pub async fn replace_component(
         &self,
@@ -731,6 +731,10 @@ impl Mcp {
             })?,
             None => Vec::new(),
         };
+        // ADR-0096: an explicit `export` arg wins over the selector's
+        // `@actor` half; `None` reuses the actor type the trampoline
+        // currently hosts.
+        let export = args.export.or(resolved.export);
         let reply = self
             .session
             .call_one(engine_envelope(
@@ -741,6 +745,7 @@ impl Mcp {
                     wasm: resolved.wasm,
                     drain_timeout_ms: args.drain_timeout_ms,
                     config,
+                    export,
                 },
             ))
             .await
@@ -3299,6 +3304,7 @@ mod tests {
                 selector: "any-selector".to_owned(),
                 drain_timeout_ms: None,
                 config_path: None,
+                export: None,
             }))
             .await;
         assert!(

--- a/crates/aether-substrate-bundle/tests/cap_registry.rs
+++ b/crates/aether-substrate-bundle/tests/cap_registry.rs
@@ -168,6 +168,7 @@ fn cap_registry_updates_on_replace() {
                     wasm: camera_wasm,
                     drain_timeout_ms: None,
                     config: Vec::new(),
+                    export: None,
                 },
             ),
         )])

--- a/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
@@ -395,8 +395,8 @@ impl FleetBench {
             namespace: None,
             handled_kind: None,
         });
-        let wasm = match resolved {
-            ResolveComponentResult::Ok { wasm, .. } => wasm,
+        let (wasm, export) = match resolved {
+            ResolveComponentResult::Ok { wasm, export, .. } => (wasm, export),
             ResolveComponentResult::Err { error } => {
                 panic!("resolve of selector {selector:?} failed: {error}")
             }
@@ -409,6 +409,10 @@ impl FleetBench {
                 wasm,
                 drain_timeout_ms: None,
                 config: Vec::new(),
+                // ADR-0096: thread the selector's `@actor` half, so a
+                // `module@actor` replace instantiates the named export
+                // instead of the trampoline's current hosted type.
+                export,
             },
         );
         let payload = single_reply(&replies, "ReplaceComponent");
@@ -548,12 +552,50 @@ impl FleetBench {
                 wasm,
                 drain_timeout_ms: None,
                 config: Vec::new(),
+                // Replace-by-stem reuses the trampoline's current hosted
+                // type — no export selector.
+                export: None,
             },
         );
         let payload = single_reply(&replies, "ReplaceComponent");
         match ReplaceResult::decode_from_bytes(&payload) {
             Some(ReplaceResult::Ok { capabilities }) => capabilities,
             Some(ReplaceResult::Err { error }) => panic!("replace with {stem:?} failed: {error}"),
+            None => panic!("undecodable ReplaceResult"),
+        }
+    }
+
+    /// Replace by stem like [`replace`](Self::replace), but select a
+    /// specific exported actor type from a multi-actor replacement
+    /// module via `export` (ADR-0096) — the `ReplaceComponent.export`
+    /// twin of [`load_full_export`](Self::load_full_export). The
+    /// `export` string is the target actor's `NAMESPACE`. Returns the
+    /// instantiated export's advertised capabilities.
+    pub fn replace_export(
+        &mut self,
+        engine: EngineId,
+        mailbox_id: MailboxId,
+        stem: &str,
+        export: &str,
+    ) -> ComponentCapabilities {
+        let wasm = read_component_wasm(stem);
+        let replies = self.call(
+            Some(engine),
+            "aether.component",
+            &ReplaceComponent {
+                mailbox_id,
+                wasm,
+                drain_timeout_ms: None,
+                config: Vec::new(),
+                export: Some(export.to_owned()),
+            },
+        );
+        let payload = single_reply(&replies, "ReplaceComponent");
+        match ReplaceResult::decode_from_bytes(&payload) {
+            Some(ReplaceResult::Ok { capabilities }) => capabilities,
+            Some(ReplaceResult::Err { error }) => {
+                panic!("replace with {stem:?}@{export:?} failed: {error}")
+            }
             None => panic!("undecodable ReplaceResult"),
         }
     }

--- a/crates/aether-substrate-bundle/tests/fleetbench_replace.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_replace.rs
@@ -16,7 +16,7 @@ mod tests {
         use aether_camera::CameraCreate;
         use aether_capabilities::WasmTrampoline;
         use aether_data::Kind;
-        use aether_kinds::{ComponentCapabilities, LogTailResult, Tick};
+        use aether_kinds::{ComponentCapabilities, LogTailResult, Ping, Tick};
         use aether_test_fixtures::SetRender;
 
         use crate::fleetbench::{FleetBench, dist_manifest_present};
@@ -91,6 +91,78 @@ mod tests {
                     LogTailResult::Ok { .. },
                 ),
                 "the lineage address should still route to the live mailbox after replace",
+            );
+        }
+
+        /// ADR-0096 wire regression for `ReplaceComponent.export`: load
+        /// the `multi_actor` module's **entry** actor (`RootManager`, a
+        /// strict receiver — no `#[fallback]`), then replace it with the
+        /// non-entry export `ui.panel` (`Panel`, which carries a
+        /// `#[fallback]`) at the same trampoline `mailbox_id`. The
+        /// post-replace capabilities must be `Panel`'s — `fallback`
+        /// flips from `None` to `Some` — proving the new `export` field
+        /// survived the real `Call` wire and drove the trampoline's
+        /// effective-tag selection to a non-entry actor (which a bare
+        /// replace, reusing the hosted entry tag, could never reach).
+        /// `FleetBench` is the right harness: the field must round-trip the
+        /// wire, not just the in-process path.
+        #[test]
+        fn fleetbench_replace_targets_a_non_entry_export() {
+            if !dist_manifest_present() {
+                return;
+            }
+            let mut bench = FleetBench::start();
+            let engine = bench.spawn_headless();
+
+            // Load the entry export (RootManager). `export: None` on load
+            // instantiates the first type in the `export!` list.
+            let loaded = bench.load_full(engine, "multi_actor");
+
+            // Pre-replace: the entry is a strict receiver — it declares a
+            // Ping handler and no fallback.
+            assert!(
+                loaded
+                    .capabilities
+                    .handlers
+                    .iter()
+                    .any(|h| h.id == Ping::ID),
+                "the entry RootManager should declare a Ping handler: {:?}",
+                loaded.capabilities.handlers,
+            );
+            assert!(
+                loaded.capabilities.fallback.is_none(),
+                "the entry RootManager is a strict receiver — no fallback: {:?}",
+                loaded.capabilities.fallback,
+            );
+
+            // Replace into the non-entry export `ui.panel`, at the same
+            // mailbox id, carrying the export over the wire.
+            let caps = bench.replace_export(engine, loaded.mailbox_id, "multi_actor", "ui.panel");
+
+            // Post-replace: Panel's capability group is active — still a
+            // Ping handler, but now with a fallback, the observable
+            // distinction the fixture is built to expose.
+            assert!(
+                caps.handlers.iter().any(|h| h.id == Ping::ID),
+                "Panel should declare a Ping handler: {:?}",
+                caps.handlers,
+            );
+            assert!(
+                caps.fallback.is_some(),
+                "the non-entry Panel carries a #[fallback]; the export-targeted \
+                 replace should surface it: {:?}",
+                caps.fallback,
+            );
+
+            // The lineage address still routes to the live mailbox: the
+            // same trampoline was swapped in place, now hosting Panel.
+            assert!(
+                matches!(
+                    bench.log_tail(engine, &loaded.addr, None),
+                    LogTailResult::Ok { .. },
+                ),
+                "the lineage address should still route to the live mailbox after an \
+                 export-targeted replace",
             );
         }
     }

--- a/crates/aether-substrate-bundle/tests/replace_drop_reply_routing.rs
+++ b/crates/aether-substrate-bundle/tests/replace_drop_reply_routing.rs
@@ -69,6 +69,7 @@ mod tests {
                     wasm,
                     drain_timeout_ms: None,
                     config: Vec::new(),
+                    export: None,
                 },
             );
             assert!(

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -1106,6 +1106,7 @@ fn replace_component_preserves_mailbox_identity() {
                     wasm,
                     drain_timeout_ms: None,
                     config: Vec::new(),
+                    export: None,
                 },
             ),
         )])
@@ -1215,6 +1216,7 @@ fn replace_preserves_multi_actor_state_via_dehydrate_rehydrate() {
                     wasm,
                     drain_timeout_ms: None,
                     config: Vec::new(),
+                    export: None,
                 },
             ),
         )])
@@ -1321,6 +1323,7 @@ fn replace_preserves_state_via_typed_state_kind() {
                     wasm,
                     drain_timeout_ms: None,
                     config: Vec::new(),
+                    export: None,
                 },
             ),
         )])
@@ -1431,6 +1434,7 @@ fn typed_state_decode_miss_boots_fresh() {
                     wasm: reshaped_wasm,
                     drain_timeout_ms: None,
                     config: Vec::new(),
+                    export: None,
                 },
             ),
         )])
@@ -2367,6 +2371,7 @@ fn replace_preserves_inline_child_state_via_reconstruct() {
                     wasm,
                     drain_timeout_ms: None,
                     config: Vec::new(),
+                    export: None,
                 },
             ),
         )])
@@ -2572,6 +2577,7 @@ fn childless_component_hot_reloads_unchanged() {
                     wasm,
                     drain_timeout_ms: None,
                     config: Vec::new(),
+                    export: None,
                 },
             ),
         )])


### PR DESCRIPTION
Closes #2027.

## Summary

`LoadComponent` can name which exported actor of a multi-actor module (ADR-0096) to instantiate, but `ReplaceComponent` could not — the trampoline reused the actor it loaded with (`self.type_tag`, entry for a single-actor load), so a live mailbox could only ever be replaced by the replacement module's entry actor.

This adds `export: Option<String>` to `ReplaceComponent`, mirroring `LoadComponent.export`. The trampoline computes an effective tag — the hashed export namespace when `Some`, else the currently-hosted `self.type_tag` (today's byte-for-byte path) — validates it against the replacement module's exported actors (a clean `Err` mirroring the load "export not found"), drives both the reply capabilities and `Component::instantiate` with it, and promotes it to `self.type_tag` on success so a later bare replace reuses the current hosted type rather than reverting to the original load's. `export: None` defaults everywhere, so every existing replace is unaffected. The resolution is factored into a `resolve_replace_target` helper.

The MCP `replace_component` tool (`export` arg + extended description) and FleetBench's `replace_by_selector` thread the resolved `module@actor` export that was previously parsed and discarded.

## Test plan

A FleetBench `mod heavy` regression test (`fleetbench_replace_targets_a_non_entry_export`) loads the `multi_actor` module's entry actor (`RootManager`, strict — no fallback) and replaces it with the non-entry `ui.panel` export (`Panel`, which carries a `#[fallback]`) at the same mailbox id, asserting the capability group flips (`fallback` `None` → `Some`) over the real `Call` wire — the externally-addressable assertion FleetBench is the right harness for. The `aether-kinds` roundtrip test covers the new field; existing replace tests (the `export: None` path) stay green. Full preflight passed locally.

## Generated by

`/implement` — agent execution of scoped issue #2027, with in-session recovery of the test surface + regression test.
