### PR TITLE
chore(repo): drop the unused postcard deps and the workspace-root entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,6 @@ dependencies = [
  "aether-kinds",
  "aether-substrate",
  "bytemuck",
- "postcard",
  "serde",
 ]
 
@@ -257,7 +256,6 @@ dependencies = [
  "aether-mesh",
  "aether-substrate-bundle",
  "inventory",
- "postcard",
  "serde",
  "tracing",
 ]
@@ -323,7 +321,6 @@ dependencies = [
  "plotters",
  "png",
  "pollster",
- "postcard",
  "serde",
  "serde_json",
  "signal-hook",
@@ -532,15 +529,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,12 +695,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -1200,12 +1182,6 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
@@ -1855,15 +1831,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,20 +1861,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "foldhash 0.2.0",
-]
-
-[[package]]
-name = "heapless"
-version = "0.7.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
-dependencies = [
- "atomic-polyfill",
- "hash32",
- "rustc_version",
- "serde",
- "spin",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -3192,7 +3145,6 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
- "heapless",
  "serde",
 ]
 
@@ -4039,15 +3991,6 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,11 +61,11 @@ proptest = "1"
 # workspace table so the single-version property is structural — members
 # inherit with `{ workspace = true }` and extend per-member `features` /
 # `optional` locally. The no_std/wasm members need defaults off
-# (postcard's `heapless-cas`, serde's / tracing's `std`), and edition
-# 2024 only lets a member disable defaults when the workspace entry does
-# — so these carry `default-features = false` and the native consumers
-# re-add the default features they rely on (`heapless-cas`, `std`,
-# `attributes`) on their own declaration, keeping Cargo.lock byte-stable.
+# (serde's / tracing's `std`), and edition 2024 only lets a member
+# disable defaults when the workspace entry does — so these carry
+# `default-features = false` and the native consumers re-add the default
+# features they rely on (`std`, `attributes`) on their own declaration,
+# keeping Cargo.lock byte-stable.
 anyhow = "1"
 base64 = "0.22"
 bytemuck = { version = "1.19", default-features = false }
@@ -74,7 +74,6 @@ cpal = "0.17"
 hound = "3"
 inventory = "0.3"
 png = "0.18"
-postcard = { version = "1.1", default-features = false }
 proc-macro2 = "1"
 quote = "1"
 serde = { version = "1", default-features = false }

--- a/crates/aether-labyrinth/Cargo.toml
+++ b/crates/aether-labyrinth/Cargo.toml
@@ -51,11 +51,5 @@ bytemuck = { workspace = true, features = ["derive"] }
 # `native` so the transform-only consumer never pulls it.
 aether-substrate = { path = "../aether-substrate", optional = true }
 
-[dev-dependencies]
-# The recorder cap's tests round-trip `TrajectoryLog` / `RecordResult`
-# bytes and enqueue raw dispatches; postcard is the wire codec. Test-only,
-# so it stays out of the production graph.
-postcard = { workspace = true, features = ["alloc"] }
-
 [lints]
 workspace = true

--- a/crates/aether-mesh-viewer/Cargo.toml
+++ b/crates/aether-mesh-viewer/Cargo.toml
@@ -47,13 +47,6 @@ aether-labyrinth = { path = "../aether-labyrinth" }
 aether-mesh = { path = "../aether-mesh" }
 aether-math = { path = "../aether-math" }
 serde = { workspace = true, default-features = false, features = ["derive", "alloc"] }
-# Issue 1868: the `.field` arm decodes a Serde-derived `ScalarField`
-# (the reachability solver's kind, issue 1857) from `.field` file bytes
-# straight off `aether.fs.read`. Postcard is the wire shape the substrate
-# already uses for kind params, so the file bytes an agent writes via
-# `aether.fs.write` are postcard. `default-features = false` keeps it
-# `no_std` for the wasm guest build.
-postcard = { workspace = true, default-features = false, features = ["alloc"] }
 # ADR-0060: tracing facade reaches the substrate's `aether.log` via
 # the SDK's `MailSubscriber` (installed by `export!`).
 tracing = { workspace = true, default-features = false }

--- a/crates/aether-substrate-bundle/Cargo.toml
+++ b/crates/aether-substrate-bundle/Cargo.toml
@@ -105,7 +105,6 @@ plotters = { version = "0.3", default-features = false, features = [
     "ab_glyph",
     "line_series",
 ] }
-postcard = { workspace = true, default-features = false, features = ["alloc"] }
 # `rmcp` / `axum` / `base64` / `schemars` retired with the embedded MCP
 # server (issue 763 P5e) — the harness moved out-of-process into the
 # `aether-mcp` crate, which owns those deps now.


### PR DESCRIPTION
Closes #2010.
Closes #1985.

## Summary

The capstone of the ADR-0118 postcard removal arc (step 4). The seven per-crate migration children (#2003–#2009) moved every `postcard::` call site onto `aether_data::wire` or the `Kind` trait codec; three crates — `aether-labyrinth`, `aether-mesh-viewer`, `aether-substrate-bundle` — have carried zero call sites since #1986. This drops those three unused manifest entries plus the workspace-root `[workspace.dependencies] postcard` entry, and tidies the now-stale `heapless-cas` citation in the root `default-features` rationale comment.

With no workspace entry, no member crate can name `postcard`, so the `postcard::` path is unresolvable workspace-wide and the off-postcard boundary self-enforces as a compile error — no clippy ban needed (ADR-0118). The crate survives in `Cargo.lock` only as a transitive dependency of `wasmtime`, which is not nameable by workspace crates. No source, public-API, or on-wire change.

## Test plan

`cargo check --workspace` and `cargo nextest run --workspace` green; `git grep postcard` returns only comments / doc text (no resolvable `postcard::` path) — the lone remaining `postcard_echoer` reference is an example *name* string deleted by #1998 (already merged). Full preflight passed locally.

## Generated by

`/implement` — agent execution of scoped issue #2010, recovered in-session after a network interruption.
