### PR TITLE
fix(workflow): ground scope/implement agent reads against current origin/main

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -124,6 +124,8 @@ Worktree path is `.claude/worktrees/issue-<N>` (gitignored per CLAUDE.md §Workf
 
 Before the `git worktree add`, run the same [stale-worktree probe](#sweep-dispatch) §Sweep dispatch uses, for this one issue: if `.claude/worktrees/issue-<N>` already exists from a prior aborted or bounced attempt, check its uncommitted-file count, whether its branch is ahead of `origin/main`, and whether an open PR is attached (the REST `pulls?head=` form). Auto-clear when safe — clean worktree, branch not ahead, no open PR — with `git worktree remove` plus `git branch -D`, then proceed with the add. Surface and stop when the worktree is dirty, ahead, or PR-attached: clearing would discard uncommitted bounce context or unpushed work, so report the state and let the user decide rather than forcing the add.
 
+Ground every read against the current ref per `/scope`'s canonical [Grounding against `origin/main`](../scope/SKILL.md#grounding-against-originmain) section — fast-forward to `origin/main` before reading, verify `HEAD == origin/main`, and treat a surprise call site as a staleness smell to diff before escalating. The worktree this skill cuts is branched from `main`, and a per-agent tree can be cut before a sibling PR lands, so without this an implement run grounds its work against code that has already changed on main.
+
 Type comes from the issue's `type:*` label. Slug is the issue title sanitized: lowercased, alnum + dashes, max 30 chars.
 
 ## Execute phase

--- a/.claude/skills/scope/SKILL.md
+++ b/.claude/skills/scope/SKILL.md
@@ -63,6 +63,18 @@ Two things differ from `/implement --sweep`:
 
 The sweep never auto-confirms. A scoper agent that hits a tied design decision or an unframable body self-bounces its own issue (the single-issue Bounce mechanics), and the parent surfaces that bounce in the roll-up rather than guessing. `--sweep` takes no `--phase` (that is a single-issue resume control).
 
+## Grounding against `origin/main`
+
+This section is the canonical grounding rule for the whole pipeline — `/implement` routes its reads by it. Every `/scope` and `/implement` run reads code from a working filesystem, but that filesystem can lag `origin/main`: a role-bound session worktree (ADR-0110) is branched at session start and never auto-synced, so it drifts behind as sibling PRs land, and a dispatched per-agent worktree can be cut before a sibling PR merges. Either way an agent that reads the lagging tree grounds its plan against code that has already changed on `origin/main`, producing a wrong scope or a wrong plan. Ground every read against `origin/main`, by these three rules:
+
+1. **Sync before reading.** Whoever holds the worktree — the session for an in-place run, or the parent before it dispatches agents — fetches and fast-forwards the clean tree first: `git fetch origin main` then `git merge --ff-only origin/main`. A dirty or diverged tree that cannot fast-forward is surfaced, not forced — report it and stop rather than papering over real divergence.
+
+2. **Verify, then ground claims against the ref.** As step 1 of any scope or implement read, verify the tree is current — `git rev-parse HEAD` equals `git rev-parse origin/main`. Ground every `file:line` claim against the `origin/main` ref directly (`git grep <pat> origin/main -- <path>`, `git show origin/main:<path>`), authoritative whatever the worktree HEAD happens to be.
+
+3. **A surprise is staleness first.** An "extra" call site, an "untracked surface", or a site the issue body never listed is a staleness signal before it is a defect. Diff that path against the ref (`git diff --name-only HEAD origin/main` over it) to confirm the tree is current, and only then escalate the finding as a real defect or a §Side finding.
+
+Both execution contexts ground by these rules: the role-bound session worktree (the common path for a scoper) and the dispatched per-agent worktree (the common path under `--sweep`). The worked example is the case that motivated the rule — a session worktree one commit behind `origin/main`, where that one commit had deleted the exact call sites a child issue targeted, so a scoper reading the lagging tree produced a false "untracked surface" finding and a wrong plan grounded on code that no longer existed on main.
+
 ## Phase walk
 
 For each sub-phase: read inputs, write the corresponding body section, and reconcile the issue's `phase:*` label (see [Phase label reconcile](#phase-label-reconcile)). If a sub-phase has nothing to do (already complete on a resumed run), skip it.


### PR DESCRIPTION
Closes #2011.

## Summary

`/scope` and `/implement` runs read code from a working filesystem, but a role-bound session worktree (ADR-0110) is branched at session start and never auto-synced — so it drifts behind `origin/main` as sibling PRs land — and a dispatched per-agent worktree can be cut before a sibling PR merges. Either way an agent grounds its plan against code that has already changed on main, producing a wrong scope or plan. Neither skill stated any grounding rule.

This adds one canonical **Grounding against `origin/main`** section to `.claude/skills/scope/SKILL.md` (placed before §Phase walk so it gates all reads), holding three rules — sync-before-reading (`fetch` + `merge --ff-only`, surface a non-ff tree), verify-`HEAD == origin/main`-and-ground-claims-against-the-ref, and surprise-finding-is-staleness-first — covering both the session-worktree and per-agent-worktree contexts. `.claude/skills/implement/SKILL.md` gets a one-line pointer to it from §Worktree setup, mirroring the "scope is canonical, others route by it" structure the GitHub API budget section already uses.

## Test plan

Docs-only (`.claude/**`, CI/repo-config exception class) — no code, no tests. Verified the new section reads as normative process prose and integrates with each skill's existing structure.

## Generated by

`/implement` — agent execution of [scoped issue #2011](https://github.com/iamacoffeepot/aether/issues/2011).
