### PR TITLE
refactor(codec): drop the per-payload wire-format version byte

### DIFF
--- a/crates/aether-actor/tests/handlers_manifest.rs
+++ b/crates/aether-actor/tests/handlers_manifest.rs
@@ -105,7 +105,7 @@ fn parse_section(bytes: &[u8]) -> Vec<InputsRecord> {
             "every record must start with the section version byte"
         );
         cursor = &cursor[1..];
-        let (rec, rest) = wire::take_from_bytes_bare::<InputsRecord>(cursor)
+        let (rec, rest) = wire::take_from_bytes::<InputsRecord>(cursor)
             .expect("wire decode of InputsRecord failed");
         out.push(rec);
         cursor = rest;

--- a/crates/aether-capabilities/src/tcp/listener.rs
+++ b/crates/aether-capabilities/src/tcp/listener.rs
@@ -123,10 +123,9 @@ mod listener_native {
                             // Wake the dispatcher: the actual
                             // stream is in the mpsc; this mail just
                             // signals "drain me". The payload is the
-                            // wake kind's own wire image (a single
-                            // `WIRE_VERSION` byte for a fieldless wire
-                            // kind, ADR-0118) so the typed handler
-                            // decodes it.
+                            // wake kind's own wire image (an empty image
+                            // for a fieldless wire kind, ADR-0118) so the
+                            // typed handler decodes it.
                             mailer.push(Mail::new(
                                 self_id,
                                 connection_ready_kind,

--- a/crates/aether-codec/src/decode.rs
+++ b/crates/aether-codec/src/decode.rs
@@ -15,10 +15,10 @@
 //    the same skips. No version byte (the cast image is its own codec).
 //
 // 2. Wire (everything else): consume the ADR-0118 `aether_data::wire`
-//    format directly — a leading `WIRE_VERSION` byte stripped on entry,
-//    then fixed-width little-endian scalars, `u32` lengths/selectors,
-//    presence bytes, length-prefixed strings/vecs/bytes, externally-
-//    tagged enums, encoded-key-sorted maps, and the `Ref` arms.
+//    format directly — fixed-width little-endian scalars, `u32`
+//    lengths/selectors, presence bytes, length-prefixed
+//    strings/vecs/bytes, externally-tagged enums, encoded-key-sorted
+//    maps, and the `Ref` arms. The image is unversioned.
 //
 // We decode the bytes directly rather than going through serde's
 // deserializer because the descriptor is structural (not a typed
@@ -28,7 +28,6 @@
 
 use std::fmt;
 
-use aether_data::wire::WIRE_VERSION;
 use aether_data::{EnumVariant, NamedField, Primitive, SchemaType};
 use serde_json::{Map, Value};
 
@@ -54,13 +53,6 @@ pub enum DecodeError {
     },
     InvalidUtf8 {
         path: String,
-    },
-    /// The top-level wire payload did not begin with [`WIRE_VERSION`]
-    /// (ADR-0118 §Envelope). A reader that strips the version byte on
-    /// entry rejects a bare or wrong-version image rather than
-    /// misparsing it.
-    BadVersion {
-        byte: u8,
     },
     UnknownEnumDiscriminant {
         path: String,
@@ -98,12 +90,6 @@ impl fmt::Display for DecodeError {
                 write!(f, "invalid bool at {path}: 0x{byte:02x} not 0 or 1")
             }
             Self::InvalidUtf8 { path } => write!(f, "invalid utf-8 in string at {path}"),
-            Self::BadVersion { byte } => {
-                write!(
-                    f,
-                    "bad wire format version byte: 0x{byte:02x} (expected {WIRE_VERSION})"
-                )
-            }
             Self::ValueBudgetExceeded { path, budget } => write!(
                 f,
                 "decode value budget exceeded at {path}: more than {budget} values for the input length"
@@ -149,26 +135,18 @@ const VALUES_PER_INPUT_BYTE: usize = 4;
 /// would accept. Dispatches on the schema's wire shape (same split as
 /// the encoder):
 ///
-/// - `Unit` → `null` (bare empty payload, no version byte).
+/// - `Unit` → `null` (bare empty payload).
 /// - `Struct { repr_c: true }` (and the recursive cast-shaped tree
-///   under it) → walk the `#[repr(C)]` byte layout, no version byte.
-/// - Everything else → strip the leading `WIRE_VERSION` byte, then
-///   consume the `aether_data::wire` format.
+///   under it) → walk the `#[repr(C)]` byte layout.
+/// - Everything else → consume the `aether_data::wire` format directly.
+///
+/// The encoding is unversioned (ADR-0118 §Envelope).
 ///
 /// Trailing bytes are an error (the encoder writes exactly the right
 /// number of bytes; extras mean schema/payload drift the agent should
 /// see).
 pub fn decode_schema(bytes: &[u8], schema: &SchemaType) -> Result<Value, DecodeError> {
-    // The cast image and the unit kind are bare; every other (wire)
-    // schema carries the leading version byte at this top-level
-    // kind-image boundary. Interior values are bare, so the recursive
-    // walk never strips again — except the `Ref` inline arm, which
-    // re-enters `decode_schema` on a nested versioned image.
-    let body = match schema {
-        SchemaType::Unit | SchemaType::Struct { repr_c: true, .. } => bytes,
-        _ => strip_version(bytes)?,
-    };
-    let mut cur = Cursor::new(body);
+    let mut cur = Cursor::new(bytes);
     let value = decode_value(&mut cur, schema, "$")?;
     if cur.remaining() != 0 {
         return Err(DecodeError::TrailingBytes {
@@ -177,20 +155,6 @@ pub fn decode_schema(bytes: &[u8], schema: &SchemaType) -> Result<Value, DecodeE
         });
     }
     Ok(value)
-}
-
-/// Strip and validate the leading [`WIRE_VERSION`] byte (ADR-0118
-/// §Envelope) from a top-level or nested kind image.
-fn strip_version(bytes: &[u8]) -> Result<&[u8], DecodeError> {
-    match bytes.split_first() {
-        Some((&v, rest)) if v == WIRE_VERSION => Ok(rest),
-        Some((&v, _)) => Err(DecodeError::BadVersion { byte: v }),
-        None => Err(DecodeError::Truncated {
-            path: "$".into(),
-            needed: 1,
-            had: 0,
-        }),
-    }
 }
 
 fn decode_value(
@@ -877,23 +841,8 @@ mod tests {
             name: "flag".into(),
             ty: SchemaType::Bool,
         }]);
-        let err =
-            decode_schema(&[WIRE_VERSION, 2], &schema).expect_err("non-0/1 bool byte must error");
+        let err = decode_schema(&[2], &schema).expect_err("non-0/1 bool byte must error");
         assert!(matches!(err, DecodeError::InvalidBool { .. }));
-    }
-
-    #[test]
-    fn bare_or_wrong_version_byte_errors() {
-        // A wire-shaped payload that doesn't open with WIRE_VERSION is
-        // rejected on entry (ADR-0118 §Envelope) rather than misparsed.
-        let schema = pc_struct(vec![NamedField {
-            name: "flag".into(),
-            ty: SchemaType::Bool,
-        }]);
-        let err = decode_schema(&[0xEE, 1], &schema).expect_err("wrong version byte must error");
-        assert!(matches!(err, DecodeError::BadVersion { byte: 0xEE }));
-        let err = decode_schema(&[], &schema).expect_err("empty wire payload must error");
-        assert!(matches!(err, DecodeError::Truncated { .. }));
     }
 
     #[test]
@@ -913,8 +862,8 @@ mod tests {
             name: "body".into(),
             ty: SchemaType::String,
         }]);
-        // version byte, u32 length 2, then two invalid utf-8 bytes.
-        let err = decode_schema(&[WIRE_VERSION, 2, 0, 0, 0, 0xff, 0xfe], &schema)
+        // u32 length 2, then two invalid utf-8 bytes.
+        let err = decode_schema(&[2, 0, 0, 0, 0xff, 0xfe], &schema)
             .expect_err("invalid utf-8 string body must error");
         assert!(matches!(err, DecodeError::InvalidUtf8 { .. }));
     }
@@ -989,9 +938,9 @@ mod tests {
     #[test]
     fn postcard_enum_unknown_discriminant_errors() {
         // discriminant 99 isn't in the schema; the u32 selector is
-        // little-endian behind the version byte.
+        // little-endian.
         let schema = sum_schema();
-        let err = decode_schema(&[WIRE_VERSION, 99, 0, 0, 0], &schema)
+        let err = decode_schema(&[99, 0, 0, 0], &schema)
             .expect_err("unknown enum discriminant must error");
         assert!(matches!(err, DecodeError::UnknownEnumDiscriminant { .. }));
     }
@@ -1014,12 +963,12 @@ mod tests {
         // Encoder writes raw f64 bytes; decoder coerces non-finite to
         // null so the JSON value is always valid.
         let schema = pc_struct(vec![scalar("x", Primitive::F64)]);
-        let mut bytes = vec![WIRE_VERSION];
+        let mut bytes: Vec<u8> = Vec::new();
         bytes.extend_from_slice(&f64::NAN.to_le_bytes());
         let v = decode_schema(&bytes, &schema).expect("test setup: decode NaN f64");
         assert_eq!(v, json!({"x": null}));
 
-        let mut bytes = vec![WIRE_VERSION];
+        let mut bytes: Vec<u8> = Vec::new();
         bytes.extend_from_slice(&f64::INFINITY.to_le_bytes());
         let v = decode_schema(&bytes, &schema).expect("test setup: decode infinity f64");
         assert_eq!(v, json!({"x": null}));
@@ -1214,14 +1163,14 @@ mod tests {
         // inner kind standalone (the cast image, no version byte).
         let body = encode_schema(&json!({ "code": 0x0102_0304u32 }), &inner).expect("encode inner");
         assert_eq!(body.len(), 4, "u32 cast image is 4 raw bytes");
-        // Top-level version byte + u32 inline selector + u32 length + body.
-        let mut expected = vec![WIRE_VERSION];
+        // u32 inline selector + u32 length + body.
+        let mut expected: Vec<u8> = Vec::new();
         expected.extend_from_slice(&0u32.to_le_bytes());
         expected.extend_from_slice(&4u32.to_le_bytes());
         expected.extend_from_slice(&body);
         assert_eq!(
             bytes, expected,
-            "inline wire is version + u32 sel 0 + u32 len + cast image"
+            "inline wire is u32 sel 0 + u32 len + cast image"
         );
 
         // JSON descriptor round-trips through wire and back.
@@ -1240,8 +1189,8 @@ mod tests {
     /// reading the first absent element rather than aborting the process.
     #[test]
     fn oversized_collection_length_errors_without_allocating() {
-        // Version byte + a `u32` count of `u32::MAX`, no elements.
-        let mut len_bytes = vec![WIRE_VERSION];
+        // A `u32` count of `u32::MAX`, no elements.
+        let mut len_bytes: Vec<u8> = Vec::new();
         len_bytes.extend_from_slice(&u32::MAX.to_le_bytes());
 
         let vec_schema = SchemaType::Vec(SchemaCell::owned(SchemaType::Scalar(Primitive::U32)));
@@ -1265,8 +1214,8 @@ mod tests {
     /// stops it with `ValueBudgetExceeded`.
     #[test]
     fn zero_byte_element_bomb_exceeds_value_budget() {
-        // Version byte + a `u32` count of `u32::MAX`.
-        let mut count_bytes = vec![WIRE_VERSION];
+        // A `u32` count of `u32::MAX`.
+        let mut count_bytes: Vec<u8> = Vec::new();
         count_bytes.extend_from_slice(&u32::MAX.to_le_bytes());
 
         let unit_vec = SchemaType::Vec(SchemaCell::owned(SchemaType::Unit));
@@ -1305,8 +1254,8 @@ mod tests {
         let value = json!({ "Handle": { "id": 7u64, "kind_id": 42u64 } });
 
         let bytes = encode_schema(&value, &schema).expect("encode Handle Ref");
-        // version + u32 selector 1 + id (8 LE) + kind_id (8 LE).
-        let mut expected = vec![WIRE_VERSION];
+        // u32 selector 1 + id (8 LE) + kind_id (8 LE).
+        let mut expected: Vec<u8> = Vec::new();
         expected.extend_from_slice(&1u32.to_le_bytes());
         expected.extend_from_slice(&7u64.to_le_bytes());
         expected.extend_from_slice(&42u64.to_le_bytes());

--- a/crates/aether-codec/src/encode.rs
+++ b/crates/aether-codec/src/encode.rs
@@ -19,9 +19,8 @@
 //    — the cast image is its own codec, like `<() as Kind>`.
 //
 // 2. Wire (everything else): the ADR-0118 `aether_data::wire` format,
-//    a fixed-width, schema-driven layout written directly. A leading
-//    `WIRE_VERSION` byte prefixes the top-level kind image; interior
-//    values are bare:
+//    a fixed-width, schema-driven layout written directly. The image is
+//    unversioned (ADR-0118 §Envelope):
 //      - bool / option-presence: 1 byte (0 or 1)
 //      - u8..u128 / i8..i128: fixed little-endian of the declared width
 //      - f32/f64: bit-faithful little-endian
@@ -32,7 +31,7 @@
 //      - enum / Ref selector: `u32` little-endian (the variant index)
 //      - struct: concatenated field bytes in declaration order
 //      - Ref handle arm: `id` (8 LE) + `kind_id` (8 LE)
-//      - Ref inline arm: `u32` length + a nested versioned kind image
+//      - Ref inline arm: `u32` length + a nested kind image
 //
 // We write the bytes directly rather than going through a serde
 // serializer because the JSON-driven encoding is structural — matching
@@ -41,7 +40,6 @@
 
 use std::fmt;
 
-use aether_data::wire::WIRE_VERSION;
 use aether_data::{EnumVariant, NamedField, Primitive, SchemaType, tagged_id};
 use serde_json::Value;
 
@@ -112,8 +110,8 @@ impl error::Error for EncodeError {}
 ///   under it) → `#[repr(C)]` byte layout, decodable by
 ///   `bytemuck::cast` on the substrate side. No version byte.
 /// - Everything else → the `aether_data::wire` format, written
-///   directly per the layout described at the top of this file, with a
-///   leading `WIRE_VERSION` byte on the top-level image.
+///   directly per the layout described at the top of this file. The
+///   image is unversioned (ADR-0118 §Envelope).
 pub fn encode_schema(params: &Value, schema: &SchemaType) -> Result<Vec<u8>, EncodeError> {
     match schema {
         SchemaType::Unit => {
@@ -147,10 +145,9 @@ pub fn encode_schema(params: &Value, schema: &SchemaType) -> Result<Vec<u8>, Enc
         }
         // Wire path: every non-cast, non-unit schema. The walker
         // handles top-level scalars / strings / vecs / enums uniformly
-        // with their nested counterparts. The version byte sits at this
-        // top-level kind-image boundary only; interior values are bare.
+        // with their nested counterparts. The image is unversioned.
         _ => {
-            let mut out = vec![WIRE_VERSION];
+            let mut out = Vec::new();
             encode_wire_value(params, schema, "$", &mut out)?;
             Ok(out)
         }
@@ -158,9 +155,9 @@ pub fn encode_schema(params: &Value, schema: &SchemaType) -> Result<Vec<u8>, Enc
 }
 
 /// Recursively encode `value` into the `aether_data::wire` format under
-/// `schema`. Interior values are bare — the caller (`encode_schema`)
-/// owns the single leading `WIRE_VERSION` byte, and the `Ref` inline
-/// arm recurses through `encode_schema` to nest a fresh versioned image.
+/// `schema`. The `Ref` inline arm recurses through `encode_schema` to
+/// nest a fresh kind image (length-prefixed). The encoding is
+/// unversioned (ADR-0118 §Envelope).
 /// `path` is a dotted breadcrumb (`$.field.subfield[2]`) used to make
 /// error messages locate the offending field in deeply-nested params.
 // One match arm per `SchemaType`; each arm is short but they sum up.
@@ -331,18 +328,17 @@ fn encode_wire_value(
             // `{"Handle": {"id": u64, "kind_id": u64}}` chooses the
             // handle arm. Wire is a `u32` little-endian selector + body.
             // The inline body is the inner kind's own codec image (cast
-            // or wire, dispatched on `inner` via `encode_schema`, so a
-            // wire inner carries its own `WIRE_VERSION`) length-prefixed
-            // with a `u32`; the handle body is `id` (8 LE) + `kind_id`
-            // (8 LE).
+            // or wire, dispatched on `inner` via `encode_schema`)
+            // length-prefixed with a `u32`; the handle body is `id`
+            // (8 LE) + `kind_id` (8 LE).
             let (tag, body) = decode_enum_tag(value, path)?;
             match tag {
                 "Inline" => {
                     out.extend_from_slice(&0u32.to_le_bytes());
                     // The inner image is the same bytes `Kind::encode_into_bytes`
                     // produces for the inner kind — `encode_schema` picks
-                    // cast for a `repr_c: true` struct, a versioned wire
-                    // image otherwise.
+                    // cast for a `repr_c: true` struct, a wire image
+                    // otherwise.
                     let body_bytes = encode_schema(body, inner)?;
                     write_count(out, body_bytes.len(), path)?;
                     out.extend_from_slice(&body_bytes);
@@ -1423,7 +1419,7 @@ mod tests {
             .expect("test setup: encode map<u32,u8> field");
         assert_eq!(bytes, expected);
         // The 256 entry (`[0,1,0,0]`) precedes the 1 entry (`[1,0,0,0]`).
-        let mut hand = vec![WIRE_VERSION];
+        let mut hand: Vec<u8> = Vec::new();
         hand.extend_from_slice(&2u32.to_le_bytes()); // count
         hand.extend_from_slice(&256u32.to_le_bytes()); // key 256
         hand.push(20); // value
@@ -1493,7 +1489,7 @@ mod tests {
     fn type_id_wire_accepts_tagged_string() {
         // `mailbox` field carrying a tagged `mbx-...` string lands as
         // a fixed `u64` little-endian — wire-identical to a raw `u64`
-        // field, behind the leading version byte.
+        // field.
         let schema = postcard_struct(vec![NamedField {
             name: "mailbox".into(),
             ty: SchemaType::TypeId(aether_data::MailboxId::TYPE_ID),
@@ -1502,7 +1498,7 @@ mod tests {
         let s = tagged_id::encode(mailbox.0).expect("test setup: encode tagged mailbox id");
         let bytes = encode_schema(&json!({ "mailbox": s }), &schema)
             .expect("test setup: encode typed-id wire field");
-        let mut expected = vec![WIRE_VERSION];
+        let mut expected: Vec<u8> = Vec::new();
         expected.extend_from_slice(&mailbox.0.to_le_bytes());
         assert_eq!(bytes, expected);
     }
@@ -1518,7 +1514,7 @@ mod tests {
         let mailbox = aether_data::MailboxId::from_name("aether.component");
         let bytes = encode_schema(&json!({ "mailbox": mailbox.0 }), &schema)
             .expect("test setup: encode typed-id from raw number");
-        let mut expected = vec![WIRE_VERSION];
+        let mut expected: Vec<u8> = Vec::new();
         expected.extend_from_slice(&mailbox.0.to_le_bytes());
         assert_eq!(bytes, expected);
     }

--- a/crates/aether-codec/src/frame.rs
+++ b/crates/aether-codec/src/frame.rs
@@ -220,13 +220,14 @@ mod tests {
     }
 
     #[test]
-    fn unit_variant_is_nine_bytes() {
-        // 4 byte prefix + 5 byte wire body (1 version byte + 4 byte variant index u32).
+    fn unit_variant_is_eight_bytes() {
+        // 4 byte prefix + 4 byte wire body (the variant index u32; the
+        // image is unversioned, ADR-0118 §Envelope).
         assert_eq!(
             encode_frame(&Msg::Tick)
                 .expect("test setup: encode unit variant")
                 .len(),
-            9,
+            8,
         );
     }
 

--- a/crates/aether-data/src/canonical/inputs.rs
+++ b/crates/aether-data/src/canonical/inputs.rs
@@ -4,9 +4,9 @@
 //! version tag, and drops the bytes into the `aether.kinds.inputs`
 //! custom section. Writing at const-eval time keeps everything in
 //! `#[link_section]` statics with no runtime serializer on the
-//! guest — the wire shape matches `wire::to_vec_bare(InputsRecord)`
+//! guest — the wire shape matches `wire::to_vec(InputsRecord)`
 //! byte-for-byte so the substrate/hub reader decodes via
-//! `wire::take_from_bytes_bare` symmetrically.
+//! `wire::take_from_bytes` symmetrically.
 
 use super::primitives::{
     U32_WIDTH, U64_WIDTH, option_borrowed_str_len, str_len, write_option_borrowed_str, write_str,
@@ -31,7 +31,7 @@ pub const fn reply_contract_len(reply_tag: u8, _reply_id: u64) -> usize {
 
 /// Serialize a [`ReplyContract`](crate::ReplyContract) into `out` at
 /// `pos` from its `(tag, id)` pair, returning the new cursor. Exact
-/// `wire::to_vec_bare(ReplyContract)` shape: a `u32` LE selector then, for
+/// `wire::to_vec(ReplyContract)` shape: a `u32` LE selector then, for
 /// `One` / `Stream`, the `KindId` as a bare `u64` LE.
 #[must_use]
 pub const fn write_reply_contract(

--- a/crates/aether-data/src/canonical/labels.rs
+++ b/crates/aether-data/src/canonical/labels.rs
@@ -1,7 +1,7 @@
 //! Canonical `KindLabels` sidecar serializer (ADR-0032). Produces
 //! ADR-0118 aether-wire bytes for the `aether.kinds.labels` custom
 //! section at const-eval time, matching the substrate/hub runtime
-//! decode via `wire::from_bytes_bare::<KindLabels>`.
+//! decode via `wire::from_bytes::<KindLabels>`.
 
 use crate::schema::{KindLabels, LabelCell, LabelNode, VariantLabel};
 

--- a/crates/aether-data/src/canonical/mod.rs
+++ b/crates/aether-data/src/canonical/mod.rs
@@ -9,7 +9,7 @@
 //! field are omitted. Enum selector positions agree between `SchemaType`
 //! and `SchemaShape` by construction (same arm order, same field
 //! declaration order), so hub-side decode via
-//! `wire::from_bytes_bare::<SchemaShape>` reads the canonical bytes
+//! `wire::from_bytes::<SchemaShape>` reads the canonical bytes
 //! cleanly.
 //!
 //! Only `SchemaCell::Static` / `LabelCell::Static` variants are
@@ -17,7 +17,7 @@
 //! `Static`; passing an `Owned` cell (or an `Owned` `Cow`) to these
 //! const fns is a compile-time panic. Runtime consumers (the hub)
 //! decode the produced bytes back into `Owned` cells via
-//! `wire::from_bytes_bare`.
+//! `wire::from_bytes`.
 //!
 //! Internal submodule layout — module-level re-exports preserve the
 //! `canonical::*` surface so no downstream caller needs an edit:
@@ -56,8 +56,8 @@ pub use schema::{
 #[cfg(test)]
 mod tests {
     //! The contract these tests pin: canonical bytes round-trip through
-    //! `wire::from_bytes_bare::<SchemaShape>` / `wire::from_bytes_bare::<KindLabels>`
-    //! / `wire::from_bytes_bare::<InputsRecord>`. That's what the hub
+    //! `wire::from_bytes::<SchemaShape>` / `wire::from_bytes::<KindLabels>`
+    //! / `wire::from_bytes::<InputsRecord>`. That's what the hub
     //! relies on after reading the `aether.kinds` /
     //! `aether.kinds.labels` / `aether.kinds.inputs` custom sections.
     //! If these diverge, the hub can't decode what derives produce.
@@ -65,7 +65,7 @@ mod tests {
     //! The `*_const_matches_wire_runtime` tests are the load-bearing
     //! silent-corruption guard ADR-0118 §Consequences calls out: the
     //! const-fn writers must emit the exact bytes the serde-driven
-    //! `wire::to_vec_bare` runtime produces for the same value, or a
+    //! `wire::to_vec` runtime produces for the same value, or a
     //! mis-hashed `KindId` would mis-route mail.
     //!
     //! Each test constructs a schema via `static` so `SchemaCell::Static`
@@ -191,7 +191,7 @@ mod tests {
     fn canonical_schema_primitive_round_trips_as_shape() {
         const N: usize = canonical_len_schema(&F32);
         const BYTES: [u8; N] = canonical_serialize_schema::<N>(&F32);
-        let shape: SchemaShape = wire::from_bytes_bare(&BYTES).expect("decode");
+        let shape: SchemaShape = wire::from_bytes(&BYTES).expect("decode");
         assert_eq!(shape, SchemaShape::Scalar(Primitive::F32));
     }
 
@@ -199,7 +199,7 @@ mod tests {
     fn canonical_schema_struct_round_trips_as_shape() {
         const N: usize = canonical_len_schema(&VERTEX);
         const BYTES: [u8; N] = canonical_serialize_schema::<N>(&VERTEX);
-        let shape: SchemaShape = wire::from_bytes_bare(&BYTES).expect("decode");
+        let shape: SchemaShape = wire::from_bytes(&BYTES).expect("decode");
         assert_eq!(shape, vertex_shape());
     }
 
@@ -207,7 +207,7 @@ mod tests {
     fn canonical_schema_nested_array_of_struct_round_trips() {
         const N: usize = canonical_len_schema(&TRIANGLE);
         const BYTES: [u8; N] = canonical_serialize_schema::<N>(&TRIANGLE);
-        let shape: SchemaShape = wire::from_bytes_bare(&BYTES).expect("decode");
+        let shape: SchemaShape = wire::from_bytes(&BYTES).expect("decode");
         let expected = SchemaShape::Struct {
             fields: vec![SchemaShape::Array {
                 element: Box::new(vertex_shape()),
@@ -222,7 +222,7 @@ mod tests {
     fn canonical_schema_enum_all_variants_round_trip() {
         const N: usize = canonical_len_schema(&RESULT);
         const BYTES: [u8; N] = canonical_serialize_schema::<N>(&RESULT);
-        let shape: SchemaShape = wire::from_bytes_bare(&BYTES).expect("decode");
+        let shape: SchemaShape = wire::from_bytes(&BYTES).expect("decode");
         assert_eq!(shape, result_enum_shape());
     }
 
@@ -231,7 +231,7 @@ mod tests {
         const NAME: &str = "test.triangle";
         const N: usize = canonical_len_kind(NAME, &TRIANGLE);
         const BYTES: [u8; N] = canonical_serialize_kind::<N>(NAME, &TRIANGLE);
-        let shape: KindShape = wire::from_bytes_bare(&BYTES).expect("decode");
+        let shape: KindShape = wire::from_bytes(&BYTES).expect("decode");
         assert_eq!(shape.name, "test.triangle");
         let SchemaShape::Struct { fields, repr_c } = &shape.schema else {
             panic!("expected Struct");
@@ -303,7 +303,7 @@ mod tests {
         // Selector 10 (SCHEMA_REF) as a `u32` LE — its low byte is at
         // BYTES[0] — followed by the inner Scalar(F32) shape.
         assert_eq!(BYTES[0], 10);
-        let shape: SchemaShape = wire::from_bytes_bare(&BYTES).expect("decode");
+        let shape: SchemaShape = wire::from_bytes(&BYTES).expect("decode");
         assert_eq!(
             shape,
             SchemaShape::Ref(Box::new(SchemaShape::Scalar(Primitive::F32)))
@@ -348,23 +348,23 @@ mod tests {
     fn canonical_labels_round_trip_via_wire() {
         const N: usize = canonical_len_labels(&TRIANGLE_LABELS);
         const BYTES: [u8; N] = canonical_serialize_labels::<N>(&TRIANGLE_LABELS);
-        let decoded: KindLabels = wire::from_bytes_bare(&BYTES).expect("decode");
+        let decoded: KindLabels = wire::from_bytes(&BYTES).expect("decode");
         assert_eq!(decoded, TRIANGLE_LABELS);
     }
 
     #[test]
     fn canonical_labels_const_matches_wire_runtime() {
         // The const-fn labels writer must emit byte-for-byte what the
-        // serde-driven `wire::to_vec_bare(KindLabels)` runtime produces —
+        // serde-driven `wire::to_vec(KindLabels)` runtime produces —
         // struct + nested array (TRIANGLE) and enum (RESULT) shapes.
         const TN: usize = canonical_len_labels(&TRIANGLE_LABELS);
         const TRIANGLE_CONST: [u8; TN] = canonical_serialize_labels::<TN>(&TRIANGLE_LABELS);
         const RN: usize = canonical_len_labels(&RESULT_LABELS);
         const RESULT_CONST: [u8; RN] = canonical_serialize_labels::<RN>(&RESULT_LABELS);
 
-        let triangle_runtime = wire::to_vec_bare(&TRIANGLE_LABELS).expect("encode");
+        let triangle_runtime = wire::to_vec(&TRIANGLE_LABELS).expect("encode");
         assert_eq!(&TRIANGLE_CONST[..], triangle_runtime.as_slice());
-        let result_runtime = wire::to_vec_bare(&RESULT_LABELS).expect("encode");
+        let result_runtime = wire::to_vec(&RESULT_LABELS).expect("encode");
         assert_eq!(&RESULT_CONST[..], result_runtime.as_slice());
     }
 
@@ -394,7 +394,7 @@ mod tests {
     fn canonical_labels_enum_round_trips() {
         const N: usize = canonical_len_labels(&RESULT_LABELS);
         const BYTES: [u8; N] = canonical_serialize_labels::<N>(&RESULT_LABELS);
-        let decoded: KindLabels = wire::from_bytes_bare(&BYTES).expect("decode");
+        let decoded: KindLabels = wire::from_bytes(&BYTES).expect("decode");
         assert_eq!(decoded, RESULT_LABELS);
     }
 
@@ -414,12 +414,12 @@ mod tests {
     fn canonical_labels_ref_round_trips() {
         const N: usize = canonical_len_labels(&REF_VERTEX_LABELS);
         const BYTES: [u8; N] = canonical_serialize_labels::<N>(&REF_VERTEX_LABELS);
-        let decoded: KindLabels = wire::from_bytes_bare(&BYTES).expect("decode");
+        let decoded: KindLabels = wire::from_bytes(&BYTES).expect("decode");
         assert_eq!(decoded, REF_VERTEX_LABELS);
     }
 
     // ADR-0033: handler/fallback/component record encoders. Round-trip
-    // through `wire::from_bytes_bare::<InputsRecord>` so the substrate
+    // through `wire::from_bytes::<InputsRecord>` so the substrate
     // reader sees exactly the enum shapes the macro emits.
     use crate::schema::InputsRecord;
 
@@ -435,7 +435,7 @@ mod tests {
         const REPLY_ID: u64 = 0x00c0_ffee_0bad_f00d;
         const N: usize = inputs_handler_len(ID, NAME, DOC, REPLY_TAG, REPLY_ID);
         const BYTES: [u8; N] = write_inputs_handler::<N>(ID, NAME, DOC, REPLY_TAG, REPLY_ID);
-        let decoded: InputsRecord = wire::from_bytes_bare(&BYTES).expect("decode");
+        let decoded: InputsRecord = wire::from_bytes(&BYTES).expect("decode");
         match decoded {
             InputsRecord::Handler {
                 id,
@@ -464,7 +464,7 @@ mod tests {
         const REPLY_ID: u64 = 0;
         const N: usize = inputs_handler_len(ID, NAME, DOC, REPLY_TAG, REPLY_ID);
         const BYTES: [u8; N] = write_inputs_handler::<N>(ID, NAME, DOC, REPLY_TAG, REPLY_ID);
-        let decoded: InputsRecord = wire::from_bytes_bare(&BYTES).expect("decode");
+        let decoded: InputsRecord = wire::from_bytes(&BYTES).expect("decode");
         assert_eq!(
             decoded,
             InputsRecord::Handler {
@@ -480,7 +480,7 @@ mod tests {
     fn reply_contract_wire_roundtrip() {
         use crate::schema::ReplyContract;
         // ADR-0112 / ADR-0118: the const-fn `(tag, id)` encoder matches
-        // `wire::to_vec_bare(ReplyContract)` byte-for-byte. The selector is
+        // `wire::to_vec(ReplyContract)` byte-for-byte. The selector is
         // a `u32` LE, so its low byte (buf[0]) is the variant index —
         // `None` = 0, `One` = 1, `Stream` = 2, `Manual` = 3.
         fn check(tag: u8, id: u64, expect: ReplyContract, expect_disc: u8) {
@@ -493,9 +493,9 @@ mod tests {
                 buf[0], expect_disc,
                 "selector's low byte is the variant index"
             );
-            let from_wire = wire::to_vec_bare(&expect).expect("encode");
+            let from_wire = wire::to_vec(&expect).expect("encode");
             assert_eq!(&buf[..len], from_wire.as_slice(), "matches wire runtime");
-            let decoded: ReplyContract = wire::from_bytes_bare(&buf[..len]).expect("decode");
+            let decoded: ReplyContract = wire::from_bytes(&buf[..len]).expect("decode");
             assert_eq!(decoded, expect);
         }
         check(0, 0, ReplyContract::None, 0);
@@ -509,7 +509,7 @@ mod tests {
         const DOC: Option<&str> = Some("Forwards anything unrecognized.");
         const N: usize = inputs_fallback_len(DOC);
         const BYTES: [u8; N] = write_inputs_fallback::<N>(DOC);
-        let decoded: InputsRecord = wire::from_bytes_bare(&BYTES).expect("decode");
+        let decoded: InputsRecord = wire::from_bytes(&BYTES).expect("decode");
         assert_eq!(
             decoded,
             InputsRecord::Fallback {
@@ -523,7 +523,7 @@ mod tests {
         const DOC: &str = "Logs every input event to the broadcast sink.";
         const N: usize = inputs_component_len(DOC);
         const BYTES: [u8; N] = write_inputs_component::<N>(DOC);
-        let decoded: InputsRecord = wire::from_bytes_bare(&BYTES).expect("decode");
+        let decoded: InputsRecord = wire::from_bytes(&BYTES).expect("decode");
         assert_eq!(decoded, InputsRecord::Component { doc: DOC.into() });
     }
 
@@ -536,7 +536,7 @@ mod tests {
         const NAME: &str = "aether.test_fixtures.probe_config";
         const N: usize = inputs_config_len(ID, NAME);
         const BYTES: [u8; N] = write_inputs_config::<N>(ID, NAME);
-        let decoded: InputsRecord = wire::from_bytes_bare(&BYTES).expect("decode");
+        let decoded: InputsRecord = wire::from_bytes(&BYTES).expect("decode");
         assert_eq!(
             decoded,
             InputsRecord::Config {
@@ -555,7 +555,7 @@ mod tests {
         const NS: &str = "ui.panel";
         const N: usize = inputs_actor_boundary_len(NS);
         const BYTES: [u8; N] = write_inputs_actor_boundary::<N>(NS);
-        let decoded: InputsRecord = wire::from_bytes_bare(&BYTES).expect("decode");
+        let decoded: InputsRecord = wire::from_bytes(&BYTES).expect("decode");
         assert_eq!(
             decoded,
             InputsRecord::ActorBoundary {
@@ -570,7 +570,7 @@ mod tests {
         use alloc::borrow::Cow;
         // The strongest inputs guard: the const-fn handler encoder must
         // produce byte-identical output to the serde-driven
-        // `wire::to_vec_bare` over the equivalent `InputsRecord::Handler`.
+        // `wire::to_vec` over the equivalent `InputsRecord::Handler`.
         // It exercises every wire primitive a record uses — `u32` selector,
         // bare `u64` id, length-prefixed name, option-presence doc, and the
         // nested `ReplyContract` enum.
@@ -587,7 +587,7 @@ mod tests {
             doc: DOC.map(Cow::Borrowed),
             reply: ReplyContract::One(KindId(REPLY_ID)),
         };
-        let runtime = wire::to_vec_bare(&record).expect("encode");
+        let runtime = wire::to_vec(&record).expect("encode");
         assert_eq!(&CONST_BYTES[..], runtime.as_slice());
     }
 }

--- a/crates/aether-data/src/canonical/schema.rs
+++ b/crates/aether-data/src/canonical/schema.rs
@@ -9,7 +9,7 @@
 //! can't silently change the wire without showing up here too. They are
 //! the serde `variant_index` of the matching `SchemaShape`/`VariantShape`
 //! arm, written as a fixed `u32` little-endian selector — so the
-//! const-fn output stays byte-identical to `wire::to_vec_bare(KindShape)`,
+//! const-fn output stays byte-identical to `wire::to_vec(KindShape)`,
 //! and the substrate/hub `SchemaShape` enum must keep the same order.
 
 use crate::schema::{EnumVariant, Primitive, SchemaCell, SchemaType};
@@ -57,7 +57,7 @@ const PRIM_F64: u8 = 9;
 
 /// Byte length the canonical schema encoding will take. Each `SchemaShape`
 /// arm is a `u32` little-endian selector (`U32_WIDTH` bytes) followed by its
-/// positional body — the wire encoding `wire::to_vec_bare(SchemaShape)`
+/// positional body — the wire encoding `wire::to_vec(SchemaShape)`
 /// produces.
 #[must_use]
 pub const fn canonical_len_schema(schema: &SchemaType) -> usize {
@@ -189,7 +189,7 @@ pub const fn canonical_serialize_kind<const N: usize>(name: &str, schema: &Schem
 /// manifest, where the length isn't const and the `Cow` variants on
 /// the input are `Owned` (const-path helpers panic on those).
 ///
-/// Implementation goes `SchemaType → SchemaShape → wire::to_vec_bare`.
+/// Implementation goes `SchemaType → SchemaShape → wire::to_vec`.
 /// The canonical bytes are the bare aether-wire body of `KindShape {
 /// name, schema: shape }`, and `SchemaShape` drops every nominal field
 /// the const serializer also drops, so the two paths produce
@@ -198,7 +198,7 @@ pub const fn canonical_serialize_kind<const N: usize>(name: &str, schema: &Schem
 ///
 /// # Panics
 /// Panics if wire encoding of the `KindShape` fails — fail-fast per
-/// ADR-0063: `wire::to_vec_bare` into a growable `Vec` fails only when a
+/// ADR-0063: `wire::to_vec` into a growable `Vec` fails only when a
 /// length exceeds the `u32` ceiling, unreachable for a `KindShape`, so a
 /// failure indicates a serializer bug.
 #[must_use]
@@ -207,7 +207,7 @@ pub fn canonical_kind_bytes(name: &str, schema: &SchemaType) -> Vec<u8> {
         name: Cow::Owned(name.into()),
         schema: schema_to_shape(schema),
     };
-    wire::to_vec_bare(&shape).expect("canonical KindShape serialization is infallible")
+    wire::to_vec(&shape).expect("canonical KindShape serialization is infallible")
 }
 
 fn schema_to_shape(s: &SchemaType) -> SchemaShape {
@@ -290,12 +290,12 @@ pub fn kind_id_from_parts(name: &str, schema: &SchemaType) -> u64 {
 ///
 /// # Panics
 /// Panics if wire encoding of `shape` fails — fail-fast per ADR-0063:
-/// `wire::to_vec_bare` into a growable `Vec` fails only when a length
+/// `wire::to_vec` into a growable `Vec` fails only when a length
 /// exceeds the `u32` ceiling, unreachable for a `KindShape`, so a
 /// failure indicates a serializer bug.
 #[must_use]
 pub fn kind_id_from_shape(shape: &KindShape) -> u64 {
-    let bytes = wire::to_vec_bare(shape).expect("canonical KindShape serialization is infallible");
+    let bytes = wire::to_vec(shape).expect("canonical KindShape serialization is infallible");
     (u64::from(TAG_KIND) << TAG_SHIFT) | (fnv1a_64_prefixed(KIND_DOMAIN, &bytes) & HASH_MASK)
 }
 

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -886,8 +886,8 @@ pub mod __derive_runtime {
     /// `Option` / a tagged enum). `T` satisfies `DeserializeOwned`
     /// via the user's `#[derive(Deserialize)]`; the bound lives on
     /// this helper rather than on `Kind` so cast kinds stay
-    /// independent of `serde`. Strips the leading `WIRE_VERSION` byte
-    /// (ADR-0118) before reading the value.
+    /// independent of `serde`. Reads the unversioned wire body
+    /// (ADR-0118) directly.
     #[must_use]
     pub fn decode_wire<T: DeserializeOwned>(bytes: &[u8]) -> Option<T> {
         wire::from_bytes(bytes).ok()
@@ -904,7 +904,7 @@ pub mod __derive_runtime {
 
     /// Wire-shape encode helper. Mirror of `decode_wire`. The
     /// `Serialize` bound lives here, not on `Kind`, so cast kinds stay
-    /// independent of `serde`. Prepends the leading `WIRE_VERSION` byte
+    /// independent of `serde`. Emits the unversioned wire body
     /// (ADR-0118); encoding fails only past the `u32` length ceiling.
     pub fn encode_wire<T: serde::Serialize>(value: &T) -> Vec<u8> {
         wire::to_vec(value).expect("wire encode to Vec fails only past the u32 length ceiling")
@@ -1188,10 +1188,11 @@ mod tests {
         let handle: Ref<TestStruct> = Ref::Handle { id: 1, kind_id: 1 };
         let inline_bytes = wire::to_vec(&inline).expect("test setup: wire encodes Inline Ref");
         let handle_bytes = wire::to_vec(&handle).expect("test setup: wire encodes Handle Ref");
-        // Selector is a u32 LE at bytes[1..5] (after the version byte at bytes[0]).
+        // Selector is a u32 LE at bytes[0..4] (the image is unversioned,
+        // ADR-0118 §Envelope).
         assert_eq!(
             u32::from_le_bytes(
-                inline_bytes[1..5]
+                inline_bytes[0..4]
                     .try_into()
                     .expect("selector slice is always 4 bytes"),
             ),
@@ -1200,7 +1201,7 @@ mod tests {
         );
         assert_eq!(
             u32::from_le_bytes(
-                handle_bytes[1..5]
+                handle_bytes[0..4]
                     .try_into()
                     .expect("selector slice is always 4 bytes"),
             ),
@@ -1225,10 +1226,11 @@ mod tests {
         };
         let r: Ref<TestPod> = Ref::Inline(v);
         let bytes = wire::to_vec(&r).expect("test setup: wire encodes Inline Ref<TestPod>");
-        // Selector is a u32 LE at bytes[1..5]; length is a u32 LE at bytes[5..9].
+        // Selector is a u32 LE at bytes[0..4]; length is a u32 LE at
+        // bytes[4..8] (the image is unversioned, ADR-0118 §Envelope).
         assert_eq!(
             u32::from_le_bytes(
-                bytes[1..5]
+                bytes[0..4]
                     .try_into()
                     .expect("selector slice is always 4 bytes"),
             ),
@@ -1237,7 +1239,7 @@ mod tests {
         );
         assert_eq!(
             u32::from_le_bytes(
-                bytes[5..9]
+                bytes[4..8]
                     .try_into()
                     .expect("length slice is always 4 bytes"),
             ),
@@ -1245,7 +1247,7 @@ mod tests {
             "u32 LE length prefix of the 8-byte cast image",
         );
         assert_eq!(
-            &bytes[9..],
+            &bytes[8..],
             bytemuck::bytes_of(&v),
             "inline body is the cast image, not a wire-encoded image"
         );
@@ -1261,10 +1263,11 @@ mod tests {
             kind_id: TestPod::ID.0,
         };
         let bytes = wire::to_vec(&r).expect("test setup: wire encodes Handle Ref<TestPod>");
-        // Selector is a u32 LE at bytes[1..5].
+        // Selector is a u32 LE at bytes[0..4] (the image is unversioned,
+        // ADR-0118 §Envelope).
         assert_eq!(
             u32::from_le_bytes(
-                bytes[1..5]
+                bytes[0..4]
                     .try_into()
                     .expect("selector slice is always 4 bytes"),
             ),

--- a/crates/aether-data/src/wire/mod.rs
+++ b/crates/aether-data/src/wire/mod.rs
@@ -37,12 +37,6 @@ mod ser;
 #[cfg(test)]
 mod tests;
 
-/// Format-version byte prefixing every top-level payload (ADR-0118 §Envelope).
-/// It versions the *encoding*, independent of `KindId` which versions the
-/// *schema*. Nested values carry no version byte — only the top-level
-/// [`to_vec`] / [`from_bytes`] / [`take_from_bytes`] boundary does.
-pub const WIRE_VERSION: u8 = 1;
-
 /// A wire encode or decode failure. Encoding fails only when a length exceeds
 /// the `u32` ceiling; everything else is a decode-side fault.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -51,8 +45,6 @@ pub enum Error {
     UnexpectedEof,
     /// A `bool` or option-presence byte was neither `0` nor `1`.
     InvalidBool(u8),
-    /// The top-level payload did not begin with [`WIRE_VERSION`].
-    BadVersion(u8),
     /// A length or count exceeded the `u32` ceiling on encode, or the remaining
     /// input on decode.
     Length,
@@ -73,7 +65,6 @@ impl fmt::Display for Error {
         match self {
             Self::UnexpectedEof => f.write_str("aether wire: unexpected end of input"),
             Self::InvalidBool(b) => write!(f, "aether wire: invalid bool/presence byte {b}"),
-            Self::BadVersion(v) => write!(f, "aether wire: bad format version byte {v}"),
             Self::Length => f.write_str("aether wire: length exceeds the u32 ceiling"),
             Self::Utf8 => f.write_str("aether wire: string is not valid UTF-8"),
             Self::InvalidChar(c) => write!(f, "aether wire: invalid char code point {c}"),
@@ -100,31 +91,19 @@ impl DeError for Error {
     }
 }
 
-/// Encode a value to a versioned wire payload: [`WIRE_VERSION`] followed by the
-/// value's encoding.
+/// Encode a value to wire bytes. The encoding is unversioned: format agreement
+/// is the transport's job (the RPC handshake negotiates a `wire_version` between
+/// binaries) and is compile-time-fixed within one binary, so the bytes carry no
+/// per-payload version (ADR-0118 §Envelope).
 pub fn to_vec<T: Serialize + ?Sized>(value: &T) -> Result<Vec<u8>, Error> {
-    let body = to_vec_bare(value)?;
-    let mut out = Vec::with_capacity(body.len() + 1);
-    out.push(WIRE_VERSION);
-    out.extend_from_slice(&body);
-    Ok(out)
-}
-
-/// Encode a value to **bare** wire bytes with no leading [`WIRE_VERSION`]. The
-/// bytes are an interior value, not a self-describing kind image — for
-/// hand-assembly sites (e.g. the DAG executor) that concatenate interior values
-/// into one kind image and prepend the single version byte themselves. Most
-/// callers want [`to_vec`].
-pub fn to_vec_bare<T: Serialize + ?Sized>(value: &T) -> Result<Vec<u8>, Error> {
     let mut serializer = ser::Serializer::new();
     value.serialize(&mut serializer)?;
     Ok(serializer.into_output())
 }
 
-/// Decode a value from a versioned wire payload, requiring every byte consumed.
+/// Decode a value from a wire payload, requiring every byte consumed.
 pub fn from_bytes<'a, T: Deserialize<'a>>(bytes: &'a [u8]) -> Result<T, Error> {
-    let body = strip_version(bytes)?;
-    let mut deserializer = de::Deserializer::new(body);
+    let mut deserializer = de::Deserializer::new(bytes);
     let value = T::deserialize(&mut deserializer)?;
     if deserializer.is_empty() {
         Ok(value)
@@ -133,48 +112,10 @@ pub fn from_bytes<'a, T: Deserialize<'a>>(bytes: &'a [u8]) -> Result<T, Error> {
     }
 }
 
-/// Decode a value from the front of a versioned wire payload, returning the
-/// value and the unconsumed remainder (after the value, not the version byte).
+/// Decode a value from the front of a wire payload, returning the value and the
+/// unconsumed remainder — for walking back-to-back records in one buffer.
 pub fn take_from_bytes<'a, T: Deserialize<'a>>(bytes: &'a [u8]) -> Result<(T, &'a [u8]), Error> {
-    let body = strip_version(bytes)?;
-    let mut deserializer = de::Deserializer::new(body);
-    let value = T::deserialize(&mut deserializer)?;
-    Ok((value, deserializer.remaining()))
-}
-
-/// Decode a value from **bare** wire bytes carrying no leading [`WIRE_VERSION`],
-/// requiring every byte consumed. The symmetric counterpart to [`to_vec_bare`]:
-/// for sites that frame the bare structural body themselves and version the
-/// frame independently of [`WIRE_VERSION`] — e.g. the `aether.kinds` manifest,
-/// whose per-section version byte versions the encoding and whose bare body is
-/// the `Kind::ID` hash input. Most callers want [`from_bytes`].
-pub fn from_bytes_bare<'a, T: Deserialize<'a>>(bytes: &'a [u8]) -> Result<T, Error> {
-    let mut deserializer = de::Deserializer::new(bytes);
-    let value = T::deserialize(&mut deserializer)?;
-    if deserializer.is_empty() {
-        Ok(value)
-    } else {
-        Err(Error::TrailingBytes)
-    }
-}
-
-/// Decode a value from the front of **bare** wire bytes (no leading
-/// [`WIRE_VERSION`]), returning the value and the unconsumed remainder. The
-/// symmetric counterpart to [`to_vec_bare`] for walking back-to-back bare
-/// records (e.g. the manifest reader stepping `[version][bare body]` records,
-/// where the version byte is the frame's, not [`WIRE_VERSION`]).
-pub fn take_from_bytes_bare<'a, T: Deserialize<'a>>(
-    bytes: &'a [u8],
-) -> Result<(T, &'a [u8]), Error> {
     let mut deserializer = de::Deserializer::new(bytes);
     let value = T::deserialize(&mut deserializer)?;
     Ok((value, deserializer.remaining()))
-}
-
-fn strip_version(bytes: &[u8]) -> Result<&[u8], Error> {
-    match bytes.split_first() {
-        Some((&v, rest)) if v == WIRE_VERSION => Ok(rest),
-        Some((&v, _)) => Err(Error::BadVersion(v)),
-        None => Err(Error::UnexpectedEof),
-    }
 }

--- a/crates/aether-data/src/wire/tests.rs
+++ b/crates/aether-data/src/wire/tests.rs
@@ -13,36 +13,27 @@ use alloc::vec::Vec;
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Serialize, Serializer};
 
-use super::{
-    Error, WIRE_VERSION, from_bytes, from_bytes_bare, take_from_bytes, take_from_bytes_bare,
-    to_vec, to_vec_bare,
-};
+use super::{Error, from_bytes, take_from_bytes, to_vec};
 use crate::ids::KindId;
 use crate::{Kind, Ref};
 
-fn versioned(body: &[u8]) -> Vec<u8> {
-    let mut out = vec![WIRE_VERSION];
-    out.extend_from_slice(body);
-    out
-}
-
 #[test]
 fn scalars_are_fixed_little_endian() {
-    assert_eq!(to_vec(&0x0403_0201u32).unwrap(), versioned(&[1, 2, 3, 4]));
-    assert_eq!(to_vec(&7u8).unwrap(), versioned(&[7]));
-    assert_eq!(to_vec(&(-1i16)).unwrap(), versioned(&[0xFF, 0xFF]));
+    assert_eq!(to_vec(&0x0403_0201u32).unwrap(), vec![1, 2, 3, 4]);
+    assert_eq!(to_vec(&7u8).unwrap(), vec![7]);
+    assert_eq!(to_vec(&(-1i16)).unwrap(), vec![0xFF, 0xFF]);
 }
 
 #[test]
 fn bool_is_one_byte() {
-    assert_eq!(to_vec(&true).unwrap(), versioned(&[1]));
-    assert_eq!(to_vec(&false).unwrap(), versioned(&[0]));
+    assert_eq!(to_vec(&true).unwrap(), vec![1]);
+    assert_eq!(to_vec(&false).unwrap(), vec![0]);
 }
 
 #[test]
 fn float_is_bit_faithful() {
     assert_eq!(
-        to_vec(&1.5f32).unwrap()[1..],
+        to_vec(&1.5f32).unwrap()[..],
         1.5f32.to_le_bytes()[..],
         "f32 is its IEEE bits, little-endian"
     );
@@ -54,23 +45,20 @@ fn float_is_bit_faithful() {
 
 #[test]
 fn string_is_u32_len_then_utf8() {
-    assert_eq!(to_vec("hi").unwrap(), versioned(&[2, 0, 0, 0, b'h', b'i']));
+    assert_eq!(to_vec("hi").unwrap(), vec![2, 0, 0, 0, b'h', b'i']);
     let back: String = from_bytes(&to_vec("héllo").unwrap()).unwrap();
     assert_eq!(back, "héllo");
 }
 
 #[test]
 fn option_is_a_presence_byte() {
-    assert_eq!(to_vec(&Some(7u8)).unwrap(), versioned(&[1, 7]));
-    assert_eq!(to_vec(&Option::<u8>::None).unwrap(), versioned(&[0]));
+    assert_eq!(to_vec(&Some(7u8)).unwrap(), vec![1, 7]);
+    assert_eq!(to_vec(&Option::<u8>::None).unwrap(), vec![0]);
 }
 
 #[test]
 fn vec_is_u32_count_then_elements() {
-    assert_eq!(
-        to_vec(&vec![1u8, 2, 3]).unwrap(),
-        versioned(&[3, 0, 0, 0, 1, 2, 3])
-    );
+    assert_eq!(to_vec(&vec![1u8, 2, 3]).unwrap(), vec![3, 0, 0, 0, 1, 2, 3]);
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -85,7 +73,7 @@ fn struct_fields_are_positional() {
     let mut body = Vec::new();
     body.extend_from_slice(&1i32.to_le_bytes());
     body.extend_from_slice(&(-1i32).to_le_bytes());
-    assert_eq!(to_vec(&p).unwrap(), versioned(&body));
+    assert_eq!(to_vec(&p).unwrap(), body);
     assert_eq!(from_bytes::<Point>(&to_vec(&p).unwrap()).unwrap(), p);
 }
 
@@ -98,12 +86,12 @@ enum Shape {
 
 #[test]
 fn enum_selector_is_u32_then_body() {
-    assert_eq!(to_vec(&Shape::Dot).unwrap(), versioned(&[0, 0, 0, 0]));
+    assert_eq!(to_vec(&Shape::Dot).unwrap(), vec![0, 0, 0, 0]);
 
     let mut circle = Vec::new();
     circle.extend_from_slice(&1u32.to_le_bytes());
     circle.extend_from_slice(&5u32.to_le_bytes());
-    assert_eq!(to_vec(&Shape::Circle(5)).unwrap(), versioned(&circle));
+    assert_eq!(to_vec(&Shape::Circle(5)).unwrap(), circle);
 
     for shape in [Shape::Dot, Shape::Circle(9), Shape::Rect { w: 2, h: 3 }] {
         let bytes = to_vec(&shape).unwrap();
@@ -130,7 +118,7 @@ fn map_is_canonical_key_sorted() {
     let unsorted = UnsortedMap(vec![(3, 30), (1, 10), (2, 20)]);
     assert_eq!(
         to_vec(&unsorted).unwrap(),
-        versioned(&[3, 0, 0, 0, 1, 10, 2, 20, 3, 30]),
+        vec![3, 0, 0, 0, 1, 10, 2, 20, 3, 30],
         "entries emit in ascending key order regardless of insertion order"
     );
 
@@ -146,7 +134,7 @@ fn map_is_canonical_key_sorted() {
 #[test]
 fn typed_ids_are_eight_le_bytes() {
     let id = KindId(0x0102_0304_0506_0708);
-    assert_eq!(to_vec(&id).unwrap()[1..], id.0.to_le_bytes()[..]);
+    assert_eq!(to_vec(&id).unwrap()[..], id.0.to_le_bytes()[..]);
     assert_eq!(from_bytes::<KindId>(&to_vec(&id).unwrap()).unwrap().0, id.0);
 }
 
@@ -174,7 +162,7 @@ fn ref_inline_is_selector_len_prefix_then_kind_image() {
     body.extend_from_slice(&0u32.to_le_bytes()); // inline selector
     body.extend_from_slice(&4u32.to_le_bytes()); // length-prefixed body
     body.extend_from_slice(&7u32.to_le_bytes()); // Tiny::encode_into_bytes image
-    assert_eq!(to_vec(&r).unwrap(), versioned(&body));
+    assert_eq!(to_vec(&r).unwrap(), body);
     assert_eq!(from_bytes::<Ref<Tiny>>(&to_vec(&r).unwrap()).unwrap(), r);
 }
 
@@ -185,7 +173,7 @@ fn ref_handle_is_selector_then_ids() {
     body.extend_from_slice(&1u32.to_le_bytes()); // handle selector
     body.extend_from_slice(&0xCAFE_u64.to_le_bytes()); // id
     body.extend_from_slice(&Tiny::ID.0.to_le_bytes()); // kind_id
-    assert_eq!(to_vec(&r).unwrap(), versioned(&body));
+    assert_eq!(to_vec(&r).unwrap(), body);
     assert_eq!(from_bytes::<Ref<Tiny>>(&to_vec(&r).unwrap()).unwrap(), r);
 }
 
@@ -213,33 +201,18 @@ fn nested_value_roundtrips_and_is_deterministic() {
 }
 
 #[test]
-fn from_bytes_rejects_bad_version() {
-    assert_eq!(from_bytes::<u8>(&[99, 1]), Err(Error::BadVersion(99)));
-    assert_eq!(from_bytes::<u8>(&[]), Err(Error::UnexpectedEof));
-}
-
-#[test]
 fn from_bytes_rejects_trailing_bytes() {
-    assert_eq!(
-        from_bytes::<u8>(&[WIRE_VERSION, 1, 2]),
-        Err(Error::TrailingBytes)
-    );
+    assert_eq!(from_bytes::<u8>(&[1, 2]), Err(Error::TrailingBytes));
 }
 
 #[test]
 fn truncated_input_is_unexpected_eof() {
-    assert_eq!(
-        from_bytes::<u32>(&[WIRE_VERSION, 1, 2]),
-        Err(Error::UnexpectedEof)
-    );
+    assert_eq!(from_bytes::<u32>(&[1, 2]), Err(Error::UnexpectedEof));
 }
 
 #[test]
 fn invalid_bool_byte_is_rejected() {
-    assert_eq!(
-        from_bytes::<bool>(&[WIRE_VERSION, 2]),
-        Err(Error::InvalidBool(2))
-    );
+    assert_eq!(from_bytes::<bool>(&[2]), Err(Error::InvalidBool(2)));
 }
 
 #[test]
@@ -252,41 +225,14 @@ fn take_from_bytes_returns_the_remainder() {
 }
 
 #[test]
-fn bare_roundtrip_carries_no_version_byte() {
-    // `to_vec_bare` emits the structural body with no leading WIRE_VERSION;
-    // `from_bytes_bare` reads it back, requiring every byte consumed.
-    let r = Rich {
-        name: "x".into(),
-        tags: vec!["a".into(), "b".into()],
-        maybe: Some(42),
-        nested: Point { x: 5, y: 6 },
-        flag: true,
-    };
-    let bare = to_vec_bare(&r).unwrap();
-    assert_eq!(
-        bare,
-        to_vec(&r).unwrap()[1..],
-        "bare body equals the versioned payload minus its leading version byte"
-    );
-    assert_eq!(from_bytes_bare::<Rich>(&bare).unwrap(), r);
-}
-
-#[test]
-fn from_bytes_bare_rejects_trailing_bytes() {
-    let mut bare = to_vec_bare(&7u8).unwrap();
-    bare.push(0xAA);
-    assert_eq!(from_bytes_bare::<u8>(&bare), Err(Error::TrailingBytes));
-}
-
-#[test]
-fn take_from_bytes_bare_walks_back_to_back_records() {
-    // Two bare records concatenated decode in sequence, each handing back the
+fn take_from_bytes_walks_back_to_back_records() {
+    // Two records concatenated decode in sequence, each handing back the
     // remainder — the shape the manifest reader relies on.
-    let mut buf = to_vec_bare(&7u8).unwrap();
-    buf.extend_from_slice(&to_vec_bare(&0x0102_0304u32).unwrap());
-    let (first, rest): (u8, &[u8]) = take_from_bytes_bare(&buf).unwrap();
+    let mut buf = to_vec(&7u8).unwrap();
+    buf.extend_from_slice(&to_vec(&0x0102_0304u32).unwrap());
+    let (first, rest): (u8, &[u8]) = take_from_bytes(&buf).unwrap();
     assert_eq!(first, 7);
-    let (second, rest): (u32, &[u8]) = take_from_bytes_bare(rest).unwrap();
+    let (second, rest): (u32, &[u8]) = take_from_bytes(rest).unwrap();
     assert_eq!(second, 0x0102_0304);
     assert!(rest.is_empty());
 }

--- a/crates/aether-substrate/src/actor/native/blob_work.rs
+++ b/crates/aether-substrate/src/actor/native/blob_work.rs
@@ -1077,7 +1077,6 @@ mod tests {
     use crate::mail::{KindId, MailRef};
     use crate::scheduler::{SeizeSeed, SlotState, SpinPark};
     use crate::test_util::fresh_substrate;
-    use aether_data::wire::WIRE_VERSION;
     use aether_data::{KindDescriptor, MailId, SchemaCell, SchemaType};
     use crossbeam_deque::{Injector, Steal};
     use std::sync::mpsc;
@@ -1299,11 +1298,12 @@ mod tests {
             })
             .expect("fresh ref kind registers");
 
-        // A valid versioned wire `Ref::Inline(empty)` image: version byte,
-        // u32 selector 0, u32 inline-length 0. The ref-walk resolves it
-        // (no substitution), and the deposit inbox forwards the resolved
-        // payload's first byte — the retained version byte.
-        let mut ref_payload = vec![WIRE_VERSION];
+        // A valid wire `Ref::Inline(empty)` image (unversioned, ADR-0118
+        // §Envelope): u32 selector 0, u32 inline-length 0. The ref-walk
+        // resolves it (no substitution), and the deposit inbox forwards
+        // the resolved payload's first byte — the inline selector's low
+        // byte (0).
+        let mut ref_payload: Vec<u8> = Vec::new();
         ref_payload.extend_from_slice(&0u32.to_le_bytes()); // inline selector
         ref_payload.extend_from_slice(&0u32.to_le_bytes()); // inline length
         let mut producer = BlobProducer::new(Arc::clone(&mailer), wake_sink(&injector));
@@ -1316,7 +1316,7 @@ mod tests {
         );
         assert_eq!(
             deposit_rx.try_recv().ok(),
-            Some(WIRE_VERSION),
+            Some(0u8),
             "ref kind deposited for the ref-walk"
         );
     }

--- a/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
+++ b/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
@@ -160,7 +160,7 @@ fn decode_kinds_records(data: &[u8], out: &mut Vec<KindShape>) -> Result<(), Str
             ));
         }
         let body = &cursor[1..];
-        match wire::take_from_bytes_bare::<KindShape>(body) {
+        match wire::take_from_bytes::<KindShape>(body) {
             Ok((shape, rest)) => {
                 out.push(shape);
                 cursor = rest;
@@ -391,7 +391,7 @@ fn decode_inputs_records(data: &[u8], out: &mut Vec<InputsRecord>) -> Result<(),
             ));
         }
         let body = &cursor[1..];
-        match wire::take_from_bytes_bare::<InputsRecord>(body) {
+        match wire::take_from_bytes::<InputsRecord>(body) {
             Ok((record, rest)) => {
                 out.push(record);
                 cursor = rest;
@@ -426,7 +426,7 @@ fn decode_records<T: DeserializeOwned>(
             ));
         }
         let body = &cursor[1..];
-        match wire::take_from_bytes_bare::<T>(body) {
+        match wire::take_from_bytes::<T>(body) {
             Ok((record, rest)) => {
                 out.push(record);
                 cursor = rest;
@@ -666,7 +666,7 @@ mod tests {
     /// the canonical body is the owned aether-wire encoding).
     fn push_shape(canonical: &mut Vec<u8>, shape: &KindShape) {
         canonical.push(0x05);
-        canonical.extend(wire::to_vec_bare(shape).unwrap());
+        canonical.extend(wire::to_vec(shape).unwrap());
     }
 
     /// Append `[0x04][wire(KindLabels)]` to `labels_bytes`, and stamp
@@ -677,7 +677,7 @@ mod tests {
     fn push_labels(labels_bytes: &mut Vec<u8>, shape: &KindShape, labels: &mut KindLabels) {
         labels.kind_id = aether_data::KindId(kind_id_from_shape(shape));
         labels_bytes.push(0x04);
-        labels_bytes.extend(wire::to_vec_bare(labels).unwrap());
+        labels_bytes.extend(wire::to_vec(labels).unwrap());
     }
 
     #[test]
@@ -776,7 +776,7 @@ mod tests {
             },
         };
         let mut canonical = vec![0x05u8];
-        canonical.extend(wire::to_vec_bare(&shape).unwrap());
+        canonical.extend(wire::to_vec(&shape).unwrap());
         let wasm = wasm_with_section(MANIFEST_SECTION, &canonical);
         let descs = read_from_bytes(&wasm).unwrap();
         assert_eq!(descs.len(), 1);
@@ -874,7 +874,7 @@ mod tests {
         push_shape(&mut canonical, &shape);
         let mut labels_bytes = Vec::new();
         labels_bytes.push(0x04);
-        labels_bytes.extend(wire::to_vec_bare(&orphan).unwrap());
+        labels_bytes.extend(wire::to_vec(&orphan).unwrap());
         let wasm = wasm_with_two_sections(&canonical, &labels_bytes);
         let descs = read_from_bytes(&wasm).unwrap();
         assert_eq!(descs.len(), 1);
@@ -1020,7 +1020,7 @@ mod tests {
         let mut out = Vec::new();
         for rec in records {
             out.push(INPUTS_SECTION_VERSION);
-            out.extend(wire::to_vec_bare(rec).unwrap());
+            out.extend(wire::to_vec(rec).unwrap());
         }
         out
     }

--- a/crates/aether-substrate/src/dag/executor.rs
+++ b/crates/aether-substrate/src/dag/executor.rs
@@ -41,7 +41,7 @@
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
-use aether_data::wire::{self, WIRE_VERSION};
+use aether_data::wire;
 use aether_data::{
     DagId, HandleId, KindId, MailId, MailboxId, Ref, SchemaType, Tag, TransformId,
     content_addressed_handle_id, with_tag,
@@ -1342,12 +1342,11 @@ fn assemble_request(
     let by_id: HashMap<NodeId, &Node> =
         state.descriptor.nodes.iter().map(|n| (n.id(), n)).collect();
 
-    // The assembled request is one wire kind image: a single leading
-    // `WIRE_VERSION` byte (ADR-0118), then each slot's `Ref::Handle`
-    // encoded **bare** as an interior value and concatenated in
-    // declaration order — exactly what `wire::to_vec` of a struct of
-    // `Ref` fields produces.
-    let mut out: Vec<u8> = vec![WIRE_VERSION];
+    // The assembled request is one unversioned wire kind image
+    // (ADR-0118 §Envelope): each slot's `Ref::Handle` encoded as an
+    // interior value and concatenated in declaration order — exactly what
+    // `wire::to_vec` of a struct of `Ref` fields produces.
+    let mut out: Vec<u8> = Vec::new();
     for (slot_index, cell) in ref_slot_cells.iter().enumerate() {
         let slot = u32::try_from(slot_index).unwrap_or(u32::MAX);
         let from = slot_source.get(&slot)?;
@@ -1355,7 +1354,7 @@ fn assemble_request(
         let stamp = producer_output_kind(by_id.get(from).copied(), registry, cell);
         // The Handle variant carries no `K`, so any `Kind` marker works
         // (`Ref<K>`'s serde needs `K: Kind` post-ADR-0100, and the unit
-        // kind is the zero-cost marker) — emit the bare wire
+        // kind is the zero-cost marker) — emit the wire
         // `Ref::Handle { id, kind_id }` (`u32` selector 1 + two 8-LE
         // ids). The walk-and-resolve path validates against the *field's*
         // expected type at dispatch, splicing the stored bytes inline
@@ -1364,7 +1363,7 @@ fn assemble_request(
             id: handle.0,
             kind_id: stamp.0,
         };
-        let mut field_bytes = wire::to_vec_bare(&r).ok()?;
+        let mut field_bytes = wire::to_vec(&r).ok()?;
         out.append(&mut field_bytes);
     }
     Some(out)
@@ -1569,8 +1568,8 @@ mod assemble_tests {
         DagState::new(DagId(1), validated, handles)
     }
 
-    /// Decode the single emitted `Ref::Handle` from an assembled payload:
-    /// strip the leading `WIRE_VERSION` byte, then read the bare `Ref`.
+    /// Decode the single emitted `Ref::Handle` from an assembled payload
+    /// (an unversioned wire image, ADR-0118 §Envelope).
     fn decode_stamp(payload: &[u8]) -> (u64, u64) {
         let r: Ref<()> = wire::from_bytes(payload).expect("decode Ref wire");
         match r {

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -19,14 +19,12 @@
 //! and substitutes the inline bytes before delivering the mail.
 //!
 //! Wire format (ADR-0045 §1, inline arm revised by ADR-0100,
-//! re-laid-out onto `aether_data::wire` by ADR-0118): the payload is a
-//! versioned kind image — a leading `WIRE_VERSION` byte the walker
-//! strips on entry (and again at each inline-arm descent), then bare
-//! interior values. A `Ref` is:
+//! re-laid-out onto `aether_data::wire` by ADR-0118): the payload is an
+//! unversioned kind image (ADR-0118 §Envelope) the walker reads from the
+//! front, with bare interior values. A `Ref` is:
 //! - Inline arm: `u32` selector 0 + `u32` length + `K::encode_into_bytes`
-//!   (`len` bytes) — the kind's own codec image (cast or wire, itself
-//!   versioned for a wire kind), an opaque length-delimited blob the
-//!   walker skips by length.
+//!   (`len` bytes) — the kind's own codec image (cast or wire), an opaque
+//!   length-delimited blob the walker skips by length.
 //! - Handle arm: `u32` selector 1 + `id` (8 LE) + `kind_id` (8 LE).
 //!
 //! Resolution is structural: the walker reads the schema and skips
@@ -66,7 +64,7 @@ use crate::config::ConfigError;
 use crate::mail::Mail;
 use crate::mail::registry::Registry;
 use crate::pid_lock::{LockAcquisition, LockGuard, acquire_lock_pid};
-use aether_data::wire::{self, WIRE_VERSION};
+use aether_data::wire;
 use aether_data::{EnumVariant, Primitive, SchemaType};
 use aether_data::{HandleId, KindId};
 use std::env;
@@ -604,8 +602,6 @@ pub enum WalkError {
     Truncated,
     InvalidBool,
     UnknownEnumDiscriminant,
-    /// The payload did not open with [`WIRE_VERSION`] (ADR-0118).
-    BadVersion(u8),
     /// A spliced inline body exceeded the `u32` length ceiling.
     Length,
     UnknownRefDiscriminant,
@@ -2063,18 +2059,12 @@ pub fn walk_and_resolve<'a>(
             payload: Cow::Borrowed(payload),
         });
     }
-    // The payload is a versioned wire kind image (ADR-0118). Strip the
-    // leading version byte for reading, but leave it in the output:
-    // `pos` starts after it while `prefix_end` stays at 0, so the first
-    // splice's `flush_up_to` copies the version byte into the resolved
-    // image (and the no-splice path returns the whole input verbatim).
-    let version = *payload.first().ok_or(WalkError::Truncated)?;
-    if version != WIRE_VERSION {
-        return Err(WalkError::BadVersion(version));
-    }
+    // The payload is an unversioned wire kind image (ADR-0118 §Envelope):
+    // the walker reads from the front, and the no-splice path returns the
+    // whole input verbatim.
     let mut state = State {
         input: payload,
-        pos: 1,
+        pos: 0,
         out: Vec::new(),
         prefix_end: 0,
         out_initialised: false,
@@ -3007,21 +2997,19 @@ mod tests {
     }
 
     /// ADR-0118 nested-inline case: the bytes a handle stores are
-    /// themselves a versioned wire image (`HeldNote` whose inner ref is
-    /// already `Inline`). Resolving the outer handle recurses into those
-    /// stored bytes — the walker must strip the *inner* version byte on
-    /// descent to read the ref-bearing struct, yet splice the stored
-    /// image back verbatim (version byte and all). Decoding the result
-    /// proves the inner version byte survived the round-trip.
+    /// themselves a wire image (`HeldNote` whose inner ref is already
+    /// `Inline`). Resolving the outer handle recurses into those stored
+    /// bytes — the walker reads the ref-bearing struct and splices the
+    /// stored image back verbatim. Decoding the result proves the nested
+    /// inline ref survived the round-trip.
     #[test]
-    fn walk_nested_inline_ref_preserves_inner_version_byte() {
+    fn walk_nested_inline_ref_resolves() {
         let outer_schema = SchemaType::Ref(SchemaCell::owned(held_note_schema()));
         let store = HandleStore::new(4096);
 
         // Stored value: a HeldNote that already holds an INLINE Note —
         // no further handle to resolve, but it is ref-bearing, so the
-        // recursive walk_and_resolve does walk (and strips its version
-        // byte on entry).
+        // recursive walk_and_resolve does walk it.
         let stored = HeldNote {
             held: Ref::Inline(Note {
                 body: "inner".to_string(),
@@ -3030,7 +3018,6 @@ mod tests {
             seq: 5,
         };
         let stored_bytes = wire::to_vec(&stored).unwrap();
-        assert_eq!(stored_bytes[0], WIRE_VERSION, "stored image is versioned");
         store
             .put(HandleId(70), KindId(0xBEEF), stored_bytes)
             .unwrap();
@@ -3046,7 +3033,7 @@ mod tests {
             WalkOutcome::Parked { .. } => panic!("expected resolved"),
         };
         // The spliced inline body is a pure byte-copy of the stored
-        // versioned image, so decoding the whole thing reconstructs it.
+        // image, so decoding the whole thing reconstructs it.
         let decoded: Ref<HeldNote> = wire::from_bytes(&resolved).unwrap();
         match decoded {
             Ref::Inline(held) => {
@@ -3087,21 +3074,19 @@ mod tests {
             WalkOutcome::Parked { .. } => panic!("expected resolved"),
         };
 
-        // The resolved image keeps the top-level version byte, then the
-        // spliced inline arm: u32 selector 0 + u32 length 4 + the 4-byte
-        // cast image (the cast image is itself bare — no nested version).
-        assert_eq!(resolved[0], WIRE_VERSION, "top-level version byte");
+        // The resolved image is the spliced inline arm: u32 selector 0 +
+        // u32 length 4 + the 4-byte cast image (the cast image is bare).
         assert_eq!(
-            &resolved[1..5],
+            &resolved[0..4],
             &0u32.to_le_bytes(),
             "spliced Inline selector"
         );
         assert_eq!(
-            &resolved[5..9],
+            &resolved[4..8],
             &4u32.to_le_bytes(),
             "u32 length of the cast image"
         );
-        assert_eq!(&resolved[9..], bytemuck::bytes_of(&pt));
+        assert_eq!(&resolved[8..], bytemuck::bytes_of(&pt));
 
         let back: Ref<Coord> = wire::from_bytes(&resolved).unwrap();
         match back {
@@ -3353,12 +3338,12 @@ mod tests {
             }
             store.snapshot_index();
         }
-        // Flip the schema_version byte; the wire envelope owns byte 0, so
-        // schema_version is at index 1. The rest stays valid, so it
-        // decodes but trips the version gate.
+        // Flip the schema_version byte; the wire image is unversioned
+        // (ADR-0118), so schema_version is the first field at index 0. The
+        // rest stays valid, so it decodes but trips the version gate.
         let path = cfg.index_path();
         let mut raw = fs::read(&path).unwrap();
-        raw[1] = INDEX_FORMAT_VERSION.wrapping_add(1);
+        raw[0] = INDEX_FORMAT_VERSION.wrapping_add(1);
         fs::write(&path, &raw).unwrap();
 
         let restored = HandleStore::with_persist(64 * 1024 * 1024, Some(cfg));

--- a/crates/aether-substrate/src/handle_store/meta.rs
+++ b/crates/aether-substrate/src/handle_store/meta.rs
@@ -24,8 +24,11 @@ use serde::{Deserialize, Serialize};
 /// / issue 1984) carries no struct change — it invalidates entries whose
 /// stored `kind_id` was computed under the pre-wire canonical bytes,
 /// since moving the `Kind::ID` hash input onto the aether-wire format
-/// regenerates every id. Pre-1.0 this is a wipe, not a migrate.
-pub const SCHEMA_VERSION: u8 = 3;
+/// regenerates every id. v4 (ADR-0118 §Envelope) drops the per-value
+/// `WIRE_VERSION` byte the stored `.bin` payloads carried, so prior
+/// entries (whose bodies open with the now-absent byte) invalidate
+/// rather than misparse. Pre-1.0 this is a wipe, not a migrate.
+pub const SCHEMA_VERSION: u8 = 4;
 
 /// Postcard-encoded sidecar describing one persistent handle. Written
 /// atomically next to the handle's `<hash>.bin` payload; the boot scan
@@ -85,8 +88,10 @@ pub struct TransformOrigin {
 /// directory scan rather than trusting a stale-format snapshot. Tracked
 /// independently of [`SCHEMA_VERSION`] (the per-entry `.meta` version):
 /// `index.bin` is a derived summary, so its layout can evolve without
-/// touching the authoritative sidecars.
-pub const INDEX_FORMAT_VERSION: u8 = 1;
+/// touching the authoritative sidecars. Bumped to 2 alongside the
+/// `SCHEMA_VERSION` v4 wire-byte drop (ADR-0118 §Envelope) so a stale
+/// snapshot from a prior binary falls back to a directory scan.
+pub const INDEX_FORMAT_VERSION: u8 = 2;
 
 /// One entry in the [`IndexSnapshot`] boot fast-path summary — a flat
 /// mirror of the in-memory `DiskEntry`, keyed by raw `u64` handle id in
@@ -157,8 +162,9 @@ mod tests {
             entries,
         };
         let bytes = wire::to_vec(&snapshot).expect("snapshot encodes");
-        // Byte 0 is the wire format-version envelope; schema_version is at index 1.
-        assert_eq!(bytes[1], INDEX_FORMAT_VERSION);
+        // The wire image is unversioned (ADR-0118); schema_version is the
+        // first field, at index 0.
+        assert_eq!(bytes[0], INDEX_FORMAT_VERSION);
         let decoded: IndexSnapshot = wire::from_bytes(&bytes).expect("snapshot decodes");
         assert_eq!(decoded, snapshot);
     }

--- a/crates/aether-substrate/src/mail/mailer.rs
+++ b/crates/aether-substrate/src/mail/mailer.rs
@@ -902,7 +902,7 @@ mod tests {
     use crate::mail::MailboxId;
     use crate::mail::outbound::EgressEvent;
     use crate::mail::registry::{InboxHandler, InlineHandler};
-    use aether_data::wire::{self, WIRE_VERSION};
+    use aether_data::wire;
     use aether_data::{Kind, Ref};
     use aether_data::{KindDescriptor, NamedField, Primitive, SchemaCell, SchemaType};
 
@@ -1468,9 +1468,10 @@ mod tests {
         let sink = CapturingSink::new();
         let sink_id = registry.register_inbox("test.sink", sink.inbox_handler());
 
-        // Truncated payload — a valid version byte then a lone body byte,
-        // so the walker bails Truncated mid-walk reading the first field.
-        mailer.push(Mail::new(sink_id, kind_id, vec![WIRE_VERSION, 0u8], 1));
+        // Truncated payload — a lone body byte (the image is unversioned,
+        // ADR-0118), so the walker bails Truncated mid-walk reading the
+        // first field.
+        mailer.push(Mail::new(sink_id, kind_id, vec![0u8], 1));
         assert_eq!(sink.delivery_count.load(Ordering::SeqCst), 0);
     }
 

--- a/docs/adr/0118-own-the-aether-wire-format.md
+++ b/docs/adr/0118-own-the-aether-wire-format.md
@@ -103,27 +103,32 @@ cast kind's inline value stays a cast image.
 
 ### Envelope
 
-One **format-version byte** prefixes each top-level encoded payload. It is
-distinct from kind identity (`KindId` already versions the *schema*); the version
-byte versions the *encoding*, so the format can evolve without ambiguity, and
-"is this aether wire or garbage" stays decidable. It is per-message, not
-per-value.
+The encoding is **unversioned on the wire** — no per-payload format-version byte.
+Format agreement is settled out of band: between binaries the RPC handshake
+negotiates a `wire_version` once per connection (`aether-rpc` `Hello`/`HelloAck`)
+and kicks a mismatched peer, so two peers on the same handshake version share the
+same wire format by construction; within one binary the encoding is fixed at
+compile time and the schema is present on both ends. A per-payload byte buys
+nothing those two mechanisms don't already guarantee, and removing it collapses
+the `to_vec`/`from_bytes` family into one (no `bare`/non-`bare` split). Every
+kind image — the top-level payload, a nested inline-`Ref` body, a retained
+handle body — is read from the front with no version prefix; interior values
+(scalars, fields, collection elements, the `Ref` handle arm) were never
+versioned and still aren't.
 
-A nested inline-`Ref` body — and the bytes the handle store retains for a
-handle — is itself a versioned kind image, so the version byte recurs at every
-*kind-image* boundary (the top-level payload, a nested inline-`Ref` body, a
-retained handle body) and never on interior values (scalars, fields, collection
-elements, the `Ref` handle arm). Every reader strips the byte on entering a kind
-image; no reader assumes a bare body.
-
-The build-time **manifest sections** — `aether.kinds`, `aether.kinds.labels`,
-`aether.kinds.inputs` — sit outside this envelope. Each carries a per-section
-version byte for its own encoding evolution and hashes the *bare* structural
-body (`wire::to_vec_bare`, no leading version byte) into `KindId`. Holding the
-encoding-version out of the hash keeps `KindId` a function of the schema alone:
-a future encoding-only `WIRE_VERSION` bump re-frames mail-path kind images while
-every manifest id stays put, and an id regenerates only when the canonical bytes
-themselves change — as they do at the postcard→wire cutover of these sections.
+Two version mechanisms remain, each scoped to where it earns its keep. The
+build-time **manifest sections** — `aether.kinds`, `aether.kinds.labels`,
+`aether.kinds.inputs` — each carry a per-section version byte for their own
+encoding evolution, and hash the structural body (`wire::to_vec`) into `KindId`;
+the section byte is held out of the hash so `KindId` stays a function of the
+schema alone and an id regenerates only when the canonical bytes themselves
+change. The **handle store** versions itself at the meta level — `HandleMeta`'s
+`schema_version` (vs `SCHEMA_VERSION`), `index.bin`'s `INDEX_FORMAT_VERSION`, the
+`v1/` layout dir, and the stored `kind_id` vs the live registry — so a binary
+reading bytes its past self wrote detects staleness without a per-value byte;
+prior on-disk entries invalidate-and-drop on a `SCHEMA_VERSION` bump. A proper
+versioned file format for the handle store is future work; the meta-level
+versioning carries persistence versioning for now.
 
 ### Determinism
 


### PR DESCRIPTION
Closes #2038.

## Summary

Every structured kind image on the wire opened with a `WIRE_VERSION: u8` byte (ADR-0118 §Envelope), recurring at every kind-image boundary. The byte was redundant: within one binary the encoding is fixed at compile time and the schema is present on both ends; between binaries the RPC handshake (`Hello`/`HelloAck` `wire_version: u32`) already negotiates format agreement and kicks mismatched peers, so two peers on the same handshake version share the same wire format by construction.

This removes the per-payload byte entirely. With it gone, `to_vec` ≡ `to_vec_bare`, `from_bytes` ≡ `from_bytes_bare`, and `take_from_bytes` ≡ `take_from_bytes_bare`, so the two function families collapse into one — the non-`bare` names stay, the `*_bare` trio is deleted, and the `BadVersion` error variants (aether-data, aether-codec, and the handle store's `WalkError`) go with it.

The handle store is safe to strip the byte from: its staleness detection is entirely meta-level (`schema_version` vs `SCHEMA_VERSION`, `index.bin`'s `INDEX_FORMAT_VERSION`, the `v1/` layout dir, stored `kind_id` vs the live registry). Removing the per-value byte loses no detection. The migration bumps `SCHEMA_VERSION` (3 → 4) and `INDEX_FORMAT_VERSION` (1 → 2) so entries a prior binary wrote (whose bodies still carry the old leading byte) invalidate-and-drop cleanly on the next boot.

Out of scope and untouched: the `aether-rpc` `WIRE_VERSION: u32` handshake (distinct mechanism) and the manifest's own per-section version byte (independent of `WIRE_VERSION`).

ADR-0118 is still Proposed (mid-implementation arc), so §Envelope is amended in place rather than via a superseding ADR, and that edit lands in this PR.

## Test plan

- The canonical / golden-byte fixtures (`aether-data/src/canonical/mod.rs`) and the manifest cross-check (`kind_manifest.rs`) are the load-bearing tests — they prove the const-fn / serde / schema-walker paths still agree byte-for-byte without the byte. The const-fn fixtures did not change value (they always emitted the bare body, which `to_vec` now produces); the hand-built golden vectors lost their leading version byte and were updated accordingly.
- Full `scripts/preflight.sh` green: fmt, clippy (`-D warnings`), doc, `nextest run --workspace` (incl. the serial heavy set), and the wasm32 component cross-build.

## Generated by

`/implement` — agent execution of scoped issue #2038.
