### PR TITLE
chore(data): deep-fuzz the aether wire format

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -1,12 +1,13 @@
 name: fuzz-nightly
 
-# Coverage-guided fuzz of `aether_codec::decode_schema`, off the merge
-# critical path (issue 1562). cargo-fuzz needs nightly and is unbounded
-# by design, so it runs on a schedule, never as a `ci-pass` gate. A
-# crash uploads its reproducer and files (or comments on) a triage
-# issue. `workflow_dispatch` runs it on demand without waiting for the
-# nightly tick. Scheduled workflows fire only from the file on `main`,
-# run in UTC, and can be delayed under load — all fine for a nightly.
+# Coverage-guided fuzz of `aether_codec::decode_schema` and the
+# `aether_data::wire` roundtrip / panic-freedom targets, off the merge
+# critical path (issue 1562, issue 1982). cargo-fuzz needs nightly and is
+# unbounded by design, so it runs on a schedule, never as a `ci-pass` gate.
+# A crash uploads its reproducer and files (or comments on) a triage issue.
+# `workflow_dispatch` runs it on demand without waiting for the nightly tick.
+# Scheduled workflows fire only from the file on `main`, run in UTC, and can
+# be delayed under load — all fine for a nightly.
 
 on:
   schedule:
@@ -17,14 +18,18 @@ permissions:
   contents: read
 
 jobs:
-  decode_schema:
-    name: fuzz decode_schema
+  fuzz:
+    name: fuzz ${{ matrix.target }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [decode_schema, wire_roundtrip, wire_decode_str, wire_decode_seq, wire_decode_enum]
     env:
-      FUZZ_TARGET: decode_schema
+      FUZZ_TARGET: ${{ matrix.target }}
       # Per-run time box. 300s warm accretes coverage on top of the
       # persisted corpus rather than restarting cold each night.
       MAX_TOTAL_TIME: "300"
@@ -56,10 +61,10 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
             fuzz/target
-            fuzz/corpus/decode_schema
-          key: fuzz-decode_schema-${{ runner.os }}-${{ github.run_id }}
+            fuzz/corpus/${{ matrix.target }}
+          key: fuzz-${{ matrix.target }}-${{ runner.os }}-${{ github.run_id }}
           restore-keys: |
-            fuzz-decode_schema-${{ runner.os }}-
+            fuzz-${{ matrix.target }}-${{ runner.os }}-
 
       - name: Install cargo-fuzz
         run: cargo fuzz --version || cargo install cargo-fuzz
@@ -71,7 +76,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: fuzz-artifacts-decode_schema
+          name: fuzz-artifacts-${{ matrix.target }}
           path: fuzz/artifacts/
           if-no-files-found: ignore
 
@@ -96,7 +101,7 @@ jobs:
             echo "The \`${FUZZ_TARGET}\` nightly fuzz run crashed."
             echo
             echo "- Run: ${RUN_URL}"
-            echo "- Reproducers (also attached as the \`fuzz-artifacts-decode_schema\` artifact):"
+            echo "- Reproducers (also attached as the \`fuzz-artifacts-${FUZZ_TARGET}\` artifact):"
             echo
             for f in $repros; do
               echo "  - \`$(basename "$f")\`"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -7,7 +7,6 @@ name = "aether-codec"
 version = "0.3.0-alpha"
 dependencies = [
  "aether-data",
- "postcard",
  "serde",
  "serde_json",
 ]
@@ -18,7 +17,10 @@ version = "0.0.0"
 dependencies = [
  "aether-codec",
  "aether-data",
+ "arbitrary",
  "libfuzzer-sys",
+ "serde",
+ "serde_bytes",
  "serde_json",
 ]
 
@@ -28,7 +30,6 @@ version = "0.3.0-alpha"
 dependencies = [
  "bytemuck",
  "inventory",
- "postcard",
  "serde",
  "uuid",
 ]
@@ -38,14 +39,8 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-
-[[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
- "critical-section",
+ "derive_arbitrary",
 ]
 
 [[package]]
@@ -69,12 +64,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,31 +82,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cobs"
-version = "0.3.0"
+name = "derive_arbitrary"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
- "thiserror",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
-name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -135,29 +108,6 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
-]
-
-[[package]]
-name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "heapless"
-version = "0.7.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
-dependencies = [
- "atomic-polyfill",
- "hash32",
- "rustc_version",
- "serde",
- "spin",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -202,32 +152,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
-
-[[package]]
-name = "postcard"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
-dependencies = [
- "cobs",
- "embedded-io 0.4.0",
- "embedded-io 0.6.1",
- "heapless",
- "serde",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -254,31 +182,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -288,6 +195,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -330,21 +247,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,26 +255,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,7 +14,10 @@ cargo-fuzz = true
 [workspace]
 
 [dependencies]
+arbitrary = { version = "1", features = ["derive"] }
 libfuzzer-sys = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_bytes = "0.11"
 serde_json = "1"
 
 [dependencies.aether-codec]
@@ -42,6 +45,34 @@ bench = false
 [[bin]]
 name = "decode_schema"
 path = "fuzz_targets/decode_schema.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "wire_roundtrip"
+path = "fuzz_targets/wire_roundtrip.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "wire_decode_str"
+path = "fuzz_targets/wire_decode_str.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "wire_decode_seq"
+path = "fuzz_targets/wire_decode_seq.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "wire_decode_enum"
+path = "fuzz_targets/wire_decode_enum.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/wire_decode_enum.rs
+++ b/fuzz/fuzz_targets/wire_decode_enum.rs
@@ -1,0 +1,21 @@
+#![no_main]
+
+//! Coverage-guided fuzz of `aether_data::wire::from_bytes` over arbitrary
+//! bytes, decoding into a discriminant-and-scalar type. The decoder's
+//! contract is "any bytes → `Ok` or `Err`, never panic"; libFuzzer treats
+//! any panic / abort as a crash, so the target calls the decoder and
+//! discards the `Result`.
+//!
+//! `WireDiscriminants` leads with a multi-variant enum, so the
+//! `variant_index` selector faults on byte zero (an out-of-range
+//! discriminant must `Err`, not index past the variant table), then walks
+//! `bool` (`InvalidBool`), `char` (`InvalidChar`), and a truncatable `u64`
+//! (`UnexpectedEof`) — the validation paths a value-generating roundtrip
+//! never reaches.
+
+use aether_codec_fuzz::WireDiscriminants;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = aether_data::wire::from_bytes::<WireDiscriminants>(data);
+});

--- a/fuzz/fuzz_targets/wire_decode_seq.rs
+++ b/fuzz/fuzz_targets/wire_decode_seq.rs
@@ -1,0 +1,19 @@
+#![no_main]
+
+//! Coverage-guided fuzz of `aether_data::wire::from_bytes` over arbitrary
+//! bytes, decoding into a collection-only type. The decoder's contract is
+//! "any bytes → `Ok` or `Err`, never panic"; libFuzzer treats any panic /
+//! abort as a crash, so the target calls the decoder and discards the
+//! `Result`.
+//!
+//! `WireSeqs` is the collection length-prefix surface (`Vec`, byte
+//! sequence, map) with the `Vec<u32>` length read first, so a length that
+//! claims more elements than the buffer holds must fault as `Length` on
+//! byte zero rather than over-read or pre-allocate unboundedly.
+
+use aether_codec_fuzz::WireSeqs;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = aether_data::wire::from_bytes::<WireSeqs>(data);
+});

--- a/fuzz/fuzz_targets/wire_decode_str.rs
+++ b/fuzz/fuzz_targets/wire_decode_str.rs
@@ -1,0 +1,18 @@
+#![no_main]
+
+//! Coverage-guided fuzz of `aether_data::wire::from_bytes` over arbitrary
+//! bytes, decoding into a string-only type. The decoder's contract is "any
+//! bytes → `Ok` or `Err`, never panic"; libFuzzer treats any panic / abort
+//! as a crash, so the target calls the decoder and discards the `Result`.
+//!
+//! `WireStrings` is the string length-prefix + UTF-8 surface with nothing
+//! ahead of it, so the fuzzer hits the `Length` and `Utf8` error paths on
+//! byte zero instead of after the scalar/option fields a composite type
+//! would interpose.
+
+use aether_codec_fuzz::WireStrings;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = aether_data::wire::from_bytes::<WireStrings>(data);
+});

--- a/fuzz/fuzz_targets/wire_roundtrip.rs
+++ b/fuzz/fuzz_targets/wire_roundtrip.rs
@@ -1,0 +1,33 @@
+#![no_main]
+
+//! Coverage-guided fuzz of the `aether_data::wire` encode→decode→encode
+//! byte fixed-point. The fuzzer generates arbitrary `WireValue` inputs;
+//! for each one the target:
+//!
+//! 1. Encodes to bytes (`b1 = to_vec(&value)`).
+//! 2. Decodes back (`v2 = from_bytes::<WireValue>(&b1).unwrap()`).
+//! 3. Re-encodes (`b2 = to_vec(&v2).unwrap()`).
+//! 4. Asserts `b1 == b2`.
+//!
+//! Byte comparison rather than value comparison is deliberate: the format is
+//! bit-faithful for `f32`/`f64`, so an `Arbitrary` `NaN` survives the
+//! roundtrip as identical bits while `value == v2` would be false. Comparing
+//! the re-encoded bytes is `NaN`-safe and still catches any real
+//! encode/decode asymmetry. This assertion also subsumes encode determinism:
+//! if the same value produces different bytes on two calls, the fixed-point
+//! would fail.
+//!
+//! `.unwrap()` on encode is safe because `to_vec` only errors when a
+//! length exceeds the `u32` ceiling, which libFuzzer-sized inputs cannot
+//! reach. `.unwrap()` on `from_bytes` is the actual roundtrip assertion:
+//! freshly encoded bytes must decode without error.
+
+use aether_codec_fuzz::WireValue;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|value: WireValue| {
+    let b1 = aether_data::wire::to_vec(&value).unwrap();
+    let v2: WireValue = aether_data::wire::from_bytes(&b1).unwrap();
+    let b2 = aether_data::wire::to_vec(&v2).unwrap();
+    assert_eq!(b1, b2);
+});

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -15,6 +15,7 @@
 //! same schema across table revisions.
 
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 
 use aether_data::{EnumVariant, NamedField, Primitive, SchemaCell, SchemaType};
 use serde_json::{Value, json};
@@ -167,4 +168,130 @@ fn ref_cast_inner() -> SchemaType {
         fields: Cow::Owned(vec![scalar("code", Primitive::U32)]),
         repr_c: true,
     }))
+}
+
+/// A multi-variant enum for the wire-format fuzz targets. Every arm
+/// exercises a different `variant_index` selector path in the `de` adapter.
+#[derive(arbitrary::Arbitrary, serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub enum WireVariant {
+    /// Unit variant — body is empty.
+    Unit,
+    /// Tuple variant — body is one `u64`.
+    Tuple(u64),
+    /// Struct variant — body is one named `u32` field.
+    Struct { code: u32 },
+}
+
+/// A nested struct carried inside `WireValue` to exercise positional field
+/// encoding without field names or counts.
+#[derive(arbitrary::Arbitrary, serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub struct WireNested {
+    pub x: i32,
+    pub y: i32,
+}
+
+/// Corpus type for the `wire_roundtrip` fuzz target.
+///
+/// Roundtrip is a symmetry check over *valid* values, so one composite
+/// type that spans every branch is the right shape: a single `Arbitrary`
+/// value exercises all of them at once, and there is no positional gating
+/// to worry about (the value is generated, not decoded from bytes).
+///
+/// Panic-freedom on *malformed* bytes is a different concern with a
+/// different failure mode — the decoder consumes bytes positionally, so a
+/// risky path buried behind earlier fields is reached only after the fuzzer
+/// learns a prefix past them. That surface is covered by the focused
+/// `wire_decode_{str,seq,enum}` targets below, each decoding into a small
+/// type that puts its risk path at byte zero.
+///
+/// Covers every encoding branch documented in `aether_data::wire`:
+///
+/// - Fixed-width scalars (`u8`, `u16`, `u32`, `u64`, `i8`, `i16`, `i32`,
+///   `i64`, `f32`, `f64`).
+/// - `bool` and option-presence (one byte, `0` / `1`).
+/// - `String` (length-prefixed UTF-8).
+/// - `serde_bytes::ByteBuf` — hits the `serialize_bytes` / length-prefixed
+///   byte-sequence path rather than the per-element `Vec<u8>` path.
+/// - `Vec<u32>` — length-prefixed element sequence.
+/// - `BTreeMap<String, u32>` — length-prefixed map in ascending key order.
+/// - `WireVariant` — multi-variant enum, `variant_index` selector.
+/// - `WireNested` — nested struct, positional fields.
+/// - A two-element tuple `(u16, u64)`.
+/// - A fixed-size byte array `[u8; 4]`.
+///
+/// `PartialEq` is deliberately omitted: the roundtrip assertion compares
+/// re-encoded bytes rather than values, which is `NaN`-safe for `f32`/`f64`
+/// (bit-faithful format, `NaN != NaN` but identical bit patterns re-encode
+/// identically).
+#[derive(arbitrary::Arbitrary, serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub struct WireValue {
+    pub u8_field: u8,
+    pub u16_field: u16,
+    pub u32_field: u32,
+    pub u64_field: u64,
+    pub i8_field: i8,
+    pub i16_field: i16,
+    pub i32_field: i32,
+    pub i64_field: i64,
+    pub f32_field: f32,
+    pub f64_field: f64,
+    pub bool_field: bool,
+    pub opt_field: Option<u32>,
+    pub string_field: String,
+    #[serde(with = "serde_bytes")]
+    pub bytes_field: Vec<u8>,
+    pub vec_field: Vec<u32>,
+    pub map_field: BTreeMap<String, u32>,
+    pub variant_field: WireVariant,
+    pub nested_field: WireNested,
+    pub tuple_field: (u16, u64),
+    pub array_field: [u8; 4],
+}
+
+/// Decode-target corpus for the `wire_decode_str` target: the string
+/// length-prefix and UTF-8 paths, ungated.
+///
+/// `String` decode reads a length prefix and then validates the bytes as
+/// UTF-8 — the two ways a string decode can fault (`Length` past the
+/// buffer, `Utf8` on bad bytes). Both fields are strings so the first one
+/// faults on byte zero; the `Option<String>` adds the option discriminant
+/// (`0` / `1`) wrapped around a string. Only `Deserialize` is needed — the
+/// target decodes arbitrary bytes and discards the result.
+#[derive(serde::Deserialize)]
+pub struct WireStrings {
+    pub a: String,
+    pub b: String,
+    pub c: Option<String>,
+}
+
+/// Decode-target corpus for the `wire_decode_seq` target: the
+/// collection length-prefix paths, ungated.
+///
+/// Each field is a length-prefixed collection — a per-element `Vec`, a
+/// `serialize_bytes` byte sequence, and an ascending-key map — so a
+/// malformed length (claiming more elements than the buffer holds) must
+/// return `Err` rather than over-read or pre-allocate unboundedly. The
+/// `Vec<u32>` leads so its length read faults at byte zero.
+#[derive(serde::Deserialize)]
+pub struct WireSeqs {
+    pub list: Vec<u32>,
+    #[serde(with = "serde_bytes")]
+    pub bytes: Vec<u8>,
+    pub map: BTreeMap<String, u32>,
+}
+
+/// Decode-target corpus for the `wire_decode_enum` target: the
+/// discriminant and scalar-validation paths, ungated.
+///
+/// The leading `WireVariant` exercises the `variant_index` selector (an
+/// out-of-range discriminant must `Err`, not index past the variant
+/// table); `bool` exercises the `0` / `1` validation, `char` the
+/// `InvalidChar` path, and the trailing `u64` a fixed-width read that
+/// faults on truncation. `WireVariant` already derives `Deserialize`.
+#[derive(serde::Deserialize)]
+pub struct WireDiscriminants {
+    pub variant: WireVariant,
+    pub flag: bool,
+    pub ch: char,
+    pub scalar: u64,
 }


### PR DESCRIPTION
Closes #1982.

## Summary

The `aether_data::wire` codec (ADR-0118) is a hand-written serde `Serializer` / `Deserializer` over a fixed-width, tagless byte layout — its decoder does its own bounds checks, UTF-8 validation, and length handling on bytes that are attacker-shaped at a transport boundary. The golden-fixture conformance suite covers known-good cases by construction but cannot exhaustively probe the malformed-input space (where a missing bounds check panics instead of returning `wire::Error`) nor the encode/decode-asymmetry space (where a roundtrip silently corrupts).

This adds cargo-fuzz targets in the existing `fuzz/` crate, split by concern:

- **`wire_roundtrip`** — encode/decode *symmetry* on valid values. A composite `WireValue` (every wire branch: scalars, bool, Option, String, bytes, Vec, BTreeMap, multi-variant enum, nested struct, tuple, array) is generated via `Arbitrary`, then `to_vec → from_bytes → to_vec` must reproduce identical bytes. One composite type is right here — the value is generated, not decoded, so there is no positional gating, and a NaN survives as bit-identical (the assertion compares re-encoded bytes, not values).
- **`wire_decode_str` / `wire_decode_seq` / `wire_decode_enum`** — *panic-freedom* on arbitrary bytes, split by risk surface. The decoder consumes bytes positionally, so a single composite decode type buries each risky path behind earlier fields; the fuzzer only reaches it after learning a prefix past them. Three small focused types put each surface at byte zero instead: `WireStrings` (string length-prefix + UTF-8), `WireSeqs` (collection length prefixes — `Vec` / bytes / map), `WireDiscriminants` (enum `variant_index` + `bool` / `char` validation + a truncatable scalar).

The corpus types live in the fuzz crate; `aether-data` does not gain an `arbitrary` dependency, and ADR-0118 is unchanged. The nightly fuzz workflow runs all four wire targets via a matrix alongside the existing `decode_schema` target.

## Test plan

All targets build under `cargo build` in the `fuzz/` crate; fmt + clippy clean on the fuzz crate; the sanitized fuzz run is the nightly CI job's responsibility. Full workspace (`fmt` / `clippy -D warnings` / `nextest` / `doc`) stays green.

## Generated by

`/implement` — agent execution of [scoped issue #1982](https://github.com/iamacoffeepot/aether/issues/1982), with the decode-target split refined during implementation.
