### PR TITLE
feat(capabilities): engine-local loaded-components query for deterministic boot-autoload readiness

### DIFF
--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -30,7 +30,7 @@
 #![allow(clippy::needless_pass_by_value)]
 
 use aether_actor::{Actor, FfiActorMailbox};
-use aether_kinds::{DropComponent, LoadComponent, ReplaceComponent};
+use aether_kinds::{DropComponent, ListComponents, LoadComponent, ReplaceComponent};
 #[cfg(not(target_arch = "wasm32"))]
 use aether_kinds::{LifecycleUnsubscribeAll, UnsubscribeAll};
 #[cfg(not(target_arch = "wasm32"))]
@@ -128,11 +128,13 @@ mod native {
     use aether_actor::Actor;
     use aether_actor::actor;
     use aether_data::Kind;
-    use aether_kinds::{ComponentCapabilities, LoadResult};
+    use aether_data::MailboxCategory;
+    use aether_kinds::{ComponentCapabilities, ListComponentsResult, LoadResult};
     use wasmtime::{Engine, Linker, Module};
 
     use super::{
-        DropComponent, LifecycleUnsubscribeAll, LoadComponent, ReplaceComponent, UnsubscribeAll,
+        DropComponent, LifecycleUnsubscribeAll, ListComponents, LoadComponent, ReplaceComponent,
+        UnsubscribeAll,
     };
 
     use aether_substrate::actor::native::spawn::Subname;
@@ -280,6 +282,43 @@ mod native {
         #[handler]
         fn on_replace_component(&mut self, ctx: &mut NativeCtx<'_>, payload: ReplaceComponent) {
             self.forward_to_trampoline(ctx, payload.mailbox_id, ReplaceComponent::ID, &payload);
+        }
+
+        /// Enumerate the components this engine has actually loaded and
+        /// registered, by their ADR-0099 lineage names (issue 2020).
+        ///
+        /// Reads the registry's live mailbox snapshot — the same list
+        /// already egressed to the hub after each load — and keeps only the
+        /// [`MailboxCategory::Trampoline`] entries, the loaded-component set.
+        /// Chassis caps are boot-present and static, so the trampolines are
+        /// the only registry membership a readiness poll cares about. The
+        /// reply is names only: the mailbox id is a deterministic hash-chain
+        /// over the lineage the name renders (ADR-0099) and routing is the
+        /// substrate's job, so the caller never needs the handle.
+        ///
+        /// # Agent
+        /// Fieldless `ListComponents` to the `aether.component` mailbox —
+        /// guaranteed present from boot, so the send always resolves and the
+        /// reply is a definitive snapshot. Reply `ListComponentsResult {
+        /// names }` lists every currently-loaded component's full lineage
+        /// address (`aether.component/aether.embedded:NAME`). Poll it after a
+        /// boot-manifest spawn (ADR-0116) to learn deterministically when a
+        /// requested component is loaded, instead of inferring liveness by
+        /// proxy.
+        #[handler]
+        fn on_list_components(
+            &mut self,
+            _ctx: &mut NativeCtx<'_>,
+            _payload: ListComponents,
+        ) -> ListComponentsResult {
+            let names = self
+                .registry
+                .list_mailbox_descriptors()
+                .into_iter()
+                .filter(|d| d.category == Some(MailboxCategory::Trampoline))
+                .map(|d| d.name)
+                .collect();
+            ListComponentsResult { names }
         }
     }
 

--- a/crates/aether-capabilities/src/engine/server.rs
+++ b/crates/aether-capabilities/src/engine/server.rs
@@ -38,8 +38,8 @@
 // `#[bridge]` macro emits `impl HandlesKind<K>` markers as siblings of
 // the mod.
 use aether_kinds::{
-    EngineAlive, EngineDied, ListBinaries, ListComponents, ListEngines, ResolveComponent,
-    RouteEnvelope, SpawnEngine, TerminateEngine, UploadBinary, UploadComponent,
+    EngineAlive, EngineDied, ListComponentBinaries, ListEngineBinaries, ListEngines,
+    ResolveComponent, RouteEnvelope, SpawnEngine, TerminateEngine, UploadBinary, UploadComponent,
 };
 #[cfg(test)]
 use std::sync::{Arc, Mutex};
@@ -55,8 +55,9 @@ pub use server_native::{EngineConfig, EngineOverlay};
 #[aether_actor::bridge(singleton)]
 mod server_native {
     use super::{
-        EngineAlive, EngineDied, ListBinaries, ListComponents, ListEngines, ResolveComponent,
-        RouteEnvelope, SpawnEngine, TerminateEngine, UploadBinary, UploadComponent,
+        EngineAlive, EngineDied, ListComponentBinaries, ListEngineBinaries, ListEngines,
+        ResolveComponent, RouteEnvelope, SpawnEngine, TerminateEngine, UploadBinary,
+        UploadComponent,
     };
     use crate::engine::proxy::{EngineProxy, EngineProxyConfig, HeartbeatParams};
     use crate::store::{
@@ -67,9 +68,9 @@ mod server_native {
     use aether_data::{EngineId, Kind, MailboxId, Uuid};
     use aether_kinds::{
         BinaryManifest, BinarySelector, CallSettled, ComponentSelector, DeadEngineDescriptor,
-        DeathReason, EngineDescriptor, ForwardEnvelope, ListBinariesResult, ListComponentsResult,
-        ListEnginesResult, ResolveComponentResult, SpawnEngineResult, TerminateEngineResult,
-        UploadBinaryResult, UploadComponentResult,
+        DeathReason, EngineDescriptor, ForwardEnvelope, ListComponentBinariesResult,
+        ListEngineBinariesResult, ListEnginesResult, ResolveComponentResult, SpawnEngineResult,
+        TerminateEngineResult, UploadBinaryResult, UploadComponentResult,
     };
     use aether_substrate::Mail;
     use aether_substrate::Subname;
@@ -312,7 +313,7 @@ mod server_native {
         /// Hub-scoped content-addressed binary store (ADR-0115, issue
         /// 1953) — the storage half of the artifact registry.
         /// `on_upload_binary` ingests a staged binary content-addressed;
-        /// `on_list_binaries` enumerates the stored entries. Built from
+        /// `on_list_engine_binaries` enumerates the stored entries. Built from
         /// `EngineConfig` (the layout dir + disk budget) at init so it
         /// persists across a `restart-hub` (the layout root outlives the
         /// hub child); the spawn cutover (#1954) reads it back through the
@@ -735,20 +736,20 @@ mod server_native {
             }
         }
 
-        /// Enumerate the hub's stored binaries.
+        /// Enumerate the hub's stored engine binaries.
         ///
         /// # Agent
-        /// Send `ListBinaries { chassis?, caps, target? }` (each filter
+        /// Send `ListEngineBinaries { chassis?, caps, target? }` (each filter
         /// field AND-combined; an absent / empty field is no constraint).
-        /// Reply: `ListBinariesResult { binaries: [{ hash, name,
+        /// Reply: `ListEngineBinariesResult { binaries: [{ hash, name,
         /// manifest: { chassis, caps, git_sha, profile, target } }] }`.
         #[handler]
-        fn on_list_binaries(
+        fn on_list_engine_binaries(
             &mut self,
             _ctx: &mut NativeCtx<'_>,
-            mail: ListBinaries,
-        ) -> ListBinariesResult {
-            ListBinariesResult {
+            mail: ListEngineBinaries,
+        ) -> ListEngineBinariesResult {
+            ListEngineBinariesResult {
                 binaries: self.store.list_binaries(&mail),
             }
         }
@@ -799,19 +800,19 @@ mod server_native {
             resolve_component(&mut self.store, &mail.selector)
         }
 
-        /// Enumerate the hub's stored components.
+        /// Enumerate the hub's stored component binaries.
         ///
         /// # Agent
-        /// Send `ListComponents { namespace?, handled_kind? }` (each filter
-        /// AND-combined; an absent field is no constraint). Reply:
-        /// `ListComponentsResult { components: [{ hash, name, manifest }] }`.
+        /// Send `ListComponentBinaries { namespace?, handled_kind? }` (each
+        /// filter AND-combined; an absent field is no constraint). Reply:
+        /// `ListComponentBinariesResult { components: [{ hash, name, manifest }] }`.
         #[handler]
-        fn on_list_components(
+        fn on_list_component_binaries(
             &mut self,
             _ctx: &mut NativeCtx<'_>,
-            mail: ListComponents,
-        ) -> ListComponentsResult {
-            ListComponentsResult {
+            mail: ListComponentBinaries,
+        ) -> ListComponentBinariesResult {
+            ListComponentBinariesResult {
                 components: self.store.list_components(&mail),
             }
         }
@@ -937,7 +938,7 @@ mod server_native {
         }
         // No exact token: a namespace / handled-kind attribute query. A
         // match-more-than-one is a clean ambiguity error.
-        let mut matches = store.list_components(&ListComponents {
+        let mut matches = store.list_components(&ListComponentBinaries {
             namespace: selector.namespace.clone(),
             handled_kind: selector.handled_kind,
         });
@@ -1075,15 +1076,15 @@ mod server_native {
     /// `chassis` / `caps` / `target` attribute query, or — when none is
     /// set — the `default` filter selecting the [`DEFAULT_CHASSIS`]
     /// chassis.
-    fn attribute_filter(selector: &BinarySelector) -> ListBinaries {
+    fn attribute_filter(selector: &BinarySelector) -> ListEngineBinaries {
         if selector.chassis.is_none() && selector.caps.is_empty() && selector.target.is_none() {
-            ListBinaries {
+            ListEngineBinaries {
                 chassis: Some(DEFAULT_CHASSIS.to_owned()),
                 caps: Vec::new(),
                 target: None,
             }
         } else {
-            ListBinaries {
+            ListEngineBinaries {
                 chassis: selector.chassis.clone(),
                 caps: selector.caps.clone(),
                 target: selector.target.clone(),
@@ -1096,7 +1097,7 @@ mod server_native {
     /// `None` when no current entry matches both.
     fn pick_versioned(store: &ArtifactStore, name: &str, version: &str) -> Option<String> {
         store
-            .list_binaries(&ListBinaries::default())
+            .list_binaries(&ListEngineBinaries::default())
             .into_iter()
             .find(|entry| entry.name.as_deref() == Some(name) && entry.manifest.git_sha == version)
             .map(|entry| entry.hash)

--- a/crates/aether-capabilities/src/store.rs
+++ b/crates/aether-capabilities/src/store.rs
@@ -51,8 +51,8 @@ use std::process;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use aether_kinds::{
-    BinaryEntry, BinaryManifest, ComponentActor, ComponentEntry, ComponentManifest, ListBinaries,
-    ListComponents,
+    BinaryEntry, BinaryManifest, ComponentActor, ComponentEntry, ComponentManifest,
+    ListComponentBinaries, ListEngineBinaries,
 };
 use aether_substrate::atomic_write::atomic_write;
 use aether_substrate::pid_lock::{LockAcquisition, LockGuard, acquire_lock_pid};
@@ -327,7 +327,7 @@ impl ArtifactStore {
     /// constraint". Component entries are excluded — only `Binary`-kind
     /// artifacts are listed here.
     #[must_use]
-    pub fn list_binaries(&self, filter: &ListBinaries) -> Vec<BinaryEntry> {
+    pub fn list_binaries(&self, filter: &ListEngineBinaries) -> Vec<BinaryEntry> {
         self.entries
             .iter()
             .filter_map(|(hash, entry)| {
@@ -348,7 +348,7 @@ impl ArtifactStore {
     /// Each absent field is "no constraint". Binary entries are excluded —
     /// only `Component`-kind artifacts are listed here.
     #[must_use]
-    pub fn list_components(&self, filter: &ListComponents) -> Vec<ComponentEntry> {
+    pub fn list_components(&self, filter: &ListComponentBinaries) -> Vec<ComponentEntry> {
         self.entries
             .iter()
             .filter_map(|(hash, entry)| {
@@ -472,8 +472,8 @@ impl ArtifactStore {
     }
 }
 
-/// Whether a binary manifest passes a [`ListBinaries`] filter.
-fn matches_binary_filter(manifest: &BinaryManifest, filter: &ListBinaries) -> bool {
+/// Whether a binary manifest passes a [`ListEngineBinaries`] filter.
+fn matches_binary_filter(manifest: &BinaryManifest, filter: &ListEngineBinaries) -> bool {
     if let Some(chassis) = &filter.chassis
         && &manifest.chassis != chassis
     {
@@ -487,11 +487,11 @@ fn matches_binary_filter(manifest: &BinaryManifest, filter: &ListBinaries) -> bo
     filter.caps.iter().all(|c| manifest.caps.contains(c))
 }
 
-/// Whether a component manifest passes a [`ListComponents`] filter
+/// Whether a component manifest passes a [`ListComponentBinaries`] filter
 /// (ADR-0116): the optional `namespace` must be one of the exported actor
 /// namespaces, and the optional `handled_kind` must be in the manifest's
 /// handled-kind union. Each absent field is "no constraint".
-fn matches_component_filter(manifest: &ComponentManifest, filter: &ListComponents) -> bool {
+fn matches_component_filter(manifest: &ComponentManifest, filter: &ListComponentBinaries) -> bool {
     if let Some(namespace) = &filter.namespace
         && !manifest.namespaces.iter().any(|n| n == namespace)
     {
@@ -724,8 +724,8 @@ fn now_nanos() -> u128 {
 #[cfg(test)]
 mod tests {
     use super::{
-        ArtifactKind, ArtifactStore, DEFAULT_DISK_BUDGET_BYTES, ListBinaries, ListComponents,
-        Selector, StoredManifest,
+        ArtifactKind, ArtifactStore, DEFAULT_DISK_BUDGET_BYTES, ListComponentBinaries,
+        ListEngineBinaries, Selector, StoredManifest,
     };
     use aether_data::Kind;
     use aether_kinds::{ComponentActor, ComponentManifest, Key, Tick};
@@ -833,11 +833,11 @@ mod tests {
             None,
         );
         assert_eq!(
-            store.list_binaries(&ListBinaries::default()).len(),
+            store.list_binaries(&ListEngineBinaries::default()).len(),
             1,
             "only the binary lists as a binary",
         );
-        let components = store.list_components(&ListComponents::default());
+        let components = store.list_components(&ListComponentBinaries::default());
         assert_eq!(
             components.len(),
             1,
@@ -847,17 +847,17 @@ mod tests {
 
         // Attribute filters: namespace + handled-kind keep the entry; a
         // miss drops it.
-        let by_namespace = store.list_components(&ListComponents {
+        let by_namespace = store.list_components(&ListComponentBinaries {
             namespace: Some("test_fixture_probe".to_owned()),
             handled_kind: None,
         });
         assert_eq!(by_namespace.len(), 1, "a matching namespace keeps it");
-        let by_kind = store.list_components(&ListComponents {
+        let by_kind = store.list_components(&ListComponentBinaries {
             namespace: None,
             handled_kind: Some(Tick::ID),
         });
         assert_eq!(by_kind.len(), 1, "a matching handled-kind keeps it");
-        let miss = store.list_components(&ListComponents {
+        let miss = store.list_components(&ListComponentBinaries {
             namespace: Some("nope".to_owned()),
             handled_kind: None,
         });
@@ -979,7 +979,7 @@ mod tests {
         };
         store.upload(b"desktop-bin", ArtifactKind::Binary, desktop, None);
 
-        let headless_only = store.list_binaries(&ListBinaries {
+        let headless_only = store.list_binaries(&ListEngineBinaries {
             chassis: Some("headless".to_owned()),
             caps: vec![],
             target: None,
@@ -987,7 +987,7 @@ mod tests {
         assert_eq!(headless_only.len(), 1);
         assert_eq!(headless_only[0].manifest.chassis, "headless");
 
-        let render_capable = store.list_binaries(&ListBinaries {
+        let render_capable = store.list_binaries(&ListEngineBinaries {
             chassis: None,
             caps: vec!["aether.render".to_owned()],
             target: None,
@@ -999,7 +999,7 @@ mod tests {
         );
         assert_eq!(render_capable[0].manifest.chassis, "desktop");
 
-        let all = store.list_binaries(&ListBinaries::default());
+        let all = store.list_binaries(&ListEngineBinaries::default());
         assert_eq!(all.len(), 2);
         let _ = fs::remove_dir_all(&root);
     }

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1105,7 +1105,7 @@ mod engine {
     ///   stored manifests, consulted when `query` is `None`: keep only
     ///   binaries whose `chassis` matches, whose linked `caps` are a
     ///   superset of every listed cap, and whose `target` triple matches.
-    ///   They mirror [`ListBinaries`]' filter shape.
+    ///   They mirror [`ListEngineBinaries`]' filter shape.
     ///
     /// An exact `query` wins first; absent one, the attribute query
     /// resolves, then `default`. A selector that resolves to no stored
@@ -1278,7 +1278,7 @@ mod engine {
     /// What a stored binary *is*, captured once at upload time by forking
     /// the binary with `--describe` (ADR-0115, issue 1953). The
     /// content-addressed store sidecars one of these next to each entry's
-    /// bytes, and [`ListBinariesResult`] returns it per entry so an
+    /// bytes, and [`ListEngineBinariesResult`] returns it per entry so an
     /// observer (and the spawn cutover, #1954) can tell a `headless` from
     /// a `desktop` binary, see which capabilities it links, and read its
     /// build provenance — all without re-running the binary.
@@ -1300,7 +1300,7 @@ mod engine {
         pub target: String,
     }
 
-    /// One stored binary in a [`ListBinariesResult`] (ADR-0115, issue
+    /// One stored binary in a [`ListEngineBinariesResult`] (ADR-0115, issue
     /// 1953). `hash` is the sha256 hex over the binary's raw bytes — the
     /// content-address key. `name` is the optional human-readable name an
     /// upload pointed at this hash (the latest upload that named it wins).
@@ -1346,23 +1346,23 @@ mod engine {
     /// `manifest.chassis` matches, `caps` keeps only entries whose
     /// `manifest.caps` is a superset of every listed cap, `target` keeps
     /// only entries whose `manifest.target` matches. Reply:
-    /// [`ListBinariesResult`].
+    /// [`ListEngineBinariesResult`].
     #[derive(
         aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default,
     )]
     #[kind(name = "aether.engine.list_binaries")]
-    pub struct ListBinaries {
+    pub struct ListEngineBinaries {
         pub chassis: Option<String>,
         pub caps: Vec<String>,
         pub target: Option<String>,
     }
 
-    /// Reply to [`ListBinaries`] (ADR-0115, issue 1953): every stored
+    /// Reply to [`ListEngineBinaries`] (ADR-0115, issue 1953): every stored
     /// binary matching the filter, each as a [`BinaryEntry`] carrying its
     /// hash, optional name, and `--describe` manifest.
     #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.engine.list_binaries_result")]
-    pub struct ListBinariesResult {
+    pub struct ListEngineBinariesResult {
         pub binaries: Vec<BinaryEntry>,
     }
 
@@ -1372,8 +1372,8 @@ mod engine {
     /// `aether.namespace` custom sections (ADR-0028 / ADR-0033 / ADR-0096),
     /// so the hub reads it with `wasmparser`, the same reader the substrate
     /// uses at load. The store sidecars one of these next to each
-    /// component entry's bytes, and [`ListComponentsResult`] returns it per
-    /// entry so an observer (and the resolve query) can select a component
+    /// component entry's bytes, and [`ListComponentBinariesResult`] returns
+    /// it per entry so an observer (and the resolve query) can select a component
     /// by what it is.
     ///
     /// - `namespaces` — every exported actor's `Actor::NAMESPACE`. A
@@ -1409,8 +1409,8 @@ mod engine {
         pub fallback: bool,
     }
 
-    /// One stored component in a [`ListComponentsResult`] (ADR-0116, issue
-    /// 1956). `hash` is the sha256 hex over the wasm's raw bytes — the
+    /// One stored component in a [`ListComponentBinariesResult`] (ADR-0116,
+    /// issue 1956). `hash` is the sha256 hex over the wasm's raw bytes — the
     /// content-address key. `name` is the optional human-readable name the
     /// latest upload pointed at this hash (`Actor::NAMESPACE` is the
     /// natural one). `manifest` is what the wasm self-reported.
@@ -1515,22 +1515,23 @@ mod engine {
     /// components (ADR-0116, issue 1956). The filter fields are
     /// AND-combined and each defaults to "no constraint": `namespace` keeps
     /// only entries exporting that actor namespace, `handled_kind` keeps
-    /// only entries handling that `KindId`. Reply: [`ListComponentsResult`].
+    /// only entries handling that `KindId`. Reply:
+    /// [`ListComponentBinariesResult`].
     #[derive(
         aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default,
     )]
     #[kind(name = "aether.engine.list_components")]
-    pub struct ListComponents {
+    pub struct ListComponentBinaries {
         pub namespace: Option<String>,
         pub handled_kind: Option<aether_data::KindId>,
     }
 
-    /// Reply to [`ListComponents`] (ADR-0116, issue 1956): every stored
-    /// component matching the filter, each as a [`ComponentEntry`] carrying
-    /// its hash, optional name, and the manifest read from the wasm.
+    /// Reply to [`ListComponentBinaries`] (ADR-0116, issue 1956): every
+    /// stored component matching the filter, each as a [`ComponentEntry`]
+    /// carrying its hash, optional name, and the manifest read from the wasm.
     #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.engine.list_components_result")]
-    pub struct ListComponentsResult {
+    pub struct ListComponentBinariesResult {
         pub components: Vec<ComponentEntry>,
     }
 }
@@ -1713,6 +1714,34 @@ mod control_plane {
     pub enum ReplaceResult {
         Ok { capabilities: ComponentCapabilities },
         Err { error: String },
+    }
+
+    /// `aether.component.list` — enumerate the components an engine has
+    /// actually loaded and registered, addressed to its `aether.component`
+    /// mailbox (issue 2020). Fieldless: the query is a definitive snapshot
+    /// of the live trampoline set, the only part of the registry whose
+    /// membership varies (chassis caps are boot-present and static). A
+    /// consumer that spawned an engine with a boot-manifest autoload
+    /// (ADR-0116) polls this to learn deterministically when a requested
+    /// component is loaded and registered at its lineage address, instead
+    /// of inferring liveness by proxy. Reply: `ListComponentsResult`.
+    #[derive(
+        aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default,
+    )]
+    #[kind(name = "aether.component.list")]
+    pub struct ListComponents {}
+
+    /// Reply to `ListComponents` (issue 2020): the ADR-0099 lineage name of
+    /// every currently-loaded component (each registered at
+    /// `aether.component/<name>`). `names` only — no mailbox id: the id is a
+    /// deterministic hash-chain over the lineage the `name` already renders
+    /// (ADR-0099), and routing is the substrate's job (a caller addresses by
+    /// `recipient_name` and the substrate resolves it), so the handle has no
+    /// use at the caller.
+    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+    #[kind(name = "aether.component.list_result")]
+    pub struct ListComponentsResult {
+        pub names: Vec<String>,
     }
 
     // ADR-0021 publish/subscribe routing for substrate input streams,
@@ -4430,27 +4459,27 @@ mod tests {
             profile: "debug".to_string(),
             target: "aarch64-apple-darwin".to_string(),
         };
-        let listed = ListBinariesResult {
+        let listed = ListEngineBinariesResult {
             binaries: vec![BinaryEntry {
                 hash: "abc123".to_string(),
                 name: Some("headless".to_string()),
                 manifest: manifest.clone(),
             }],
         };
-        let back = ListBinariesResult::decode_from_bytes(&listed.encode_into_bytes())
-            .expect("test setup: ListBinariesResult decodes");
+        let back = ListEngineBinariesResult::decode_from_bytes(&listed.encode_into_bytes())
+            .expect("test setup: ListEngineBinariesResult decodes");
         assert_eq!(back.binaries.len(), 1);
         assert_eq!(back.binaries[0].hash, "abc123");
         assert_eq!(back.binaries[0].name.as_deref(), Some("headless"));
         assert_eq!(back.binaries[0].manifest, manifest);
 
-        let filter = ListBinaries {
+        let filter = ListEngineBinaries {
             chassis: Some("headless".to_string()),
             caps: vec!["aether.fs".to_string()],
             target: None,
         };
-        let back = ListBinaries::decode_from_bytes(&filter.encode_into_bytes())
-            .expect("test setup: ListBinaries decodes");
+        let back = ListEngineBinaries::decode_from_bytes(&filter.encode_into_bytes())
+            .expect("test setup: ListEngineBinaries decodes");
         assert_eq!(back.chassis.as_deref(), Some("headless"));
         assert_eq!(back.caps, vec!["aether.fs".to_string()]);
         assert_eq!(back.target, None);
@@ -4528,15 +4557,15 @@ mod tests {
             ResolveComponentResult::Err { error } => panic!("expected Ok, got Err {error}"),
         }
 
-        let listed = ListComponentsResult {
+        let listed = ListComponentBinariesResult {
             components: vec![ComponentEntry {
                 hash: "abc123".to_string(),
                 name: Some("probe".to_string()),
                 manifest: manifest.clone(),
             }],
         };
-        let back = ListComponentsResult::decode_from_bytes(&listed.encode_into_bytes())
-            .expect("test setup: ListComponentsResult decodes");
+        let back = ListComponentBinariesResult::decode_from_bytes(&listed.encode_into_bytes())
+            .expect("test setup: ListComponentBinariesResult decodes");
         assert_eq!(back.components.len(), 1);
         assert_eq!(back.components[0].hash, "abc123");
         assert_eq!(back.components[0].manifest, manifest);
@@ -5920,6 +5949,49 @@ mod tests {
             assert_eq!(back.config, vec![0x01, 0x02, 0x03]);
             assert_eq!(back.mailbox_id, aether_data::MailboxId(7));
             assert_eq!(back.export.as_deref(), Some("ui.panel"));
+        }
+
+        #[test]
+        fn list_components_query_registers_and_roundtrips() {
+            // Issue 2020: the engine-local loaded-components query is a
+            // fieldless request and a `names: Vec<String>` reply, both on the
+            // `aether.component.list` family. They must register in the
+            // descriptor inventory (so `describe_kinds(prefix="aether.component")`
+            // surfaces them) and survive the postcard wire path.
+            assert_eq!(ListComponents::NAME, "aether.component.list");
+            assert_eq!(ListComponentsResult::NAME, "aether.component.list_result");
+
+            let descriptors = descriptors::all();
+            assert!(
+                descriptors.iter().any(|d| d.name == ListComponents::NAME),
+                "ListComponents registers in the descriptor inventory",
+            );
+            assert!(
+                descriptors
+                    .iter()
+                    .any(|d| d.name == ListComponentsResult::NAME),
+                "ListComponentsResult registers in the descriptor inventory",
+            );
+
+            let req = ListComponents {};
+            ListComponents::decode_from_bytes(&req.encode_into_bytes())
+                .expect("decode ListComponents round-trip");
+
+            let reply = ListComponentsResult {
+                names: vec![
+                    "aether.embedded:probe".to_string(),
+                    "aether.embedded:camera".to_string(),
+                ],
+            };
+            let back = ListComponentsResult::decode_from_bytes(&reply.encode_into_bytes())
+                .expect("decode ListComponentsResult round-trip");
+            assert_eq!(
+                back.names,
+                vec![
+                    "aether.embedded:probe".to_string(),
+                    "aether.embedded:camera".to_string(),
+                ]
+            );
         }
 
         #[test]

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -37,12 +37,13 @@ use aether_kinds::dag::{DagDescriptor, Edge, Node, NodeId};
 use aether_kinds::{
     BinarySelector, Cancel, CancelResult, CaptureFrame, CaptureFrameResult, ComponentCapabilities,
     ComponentSelector, CostTail, CostTailResult, DeathReason, FrameCheck, FrameReduction,
-    ListBinaries, ListBinariesResult, ListComponents, ListComponentsResult, ListEngines,
-    ListEnginesResult, ListKinds, ListKindsResult, LoadComponent, LoadResult,
-    MailEnvelope as KindMailEnvelope, ReplaceComponent, ReplaceResult, ResolveComponent,
-    ResolveComponentResult, SimilarityCheck, SpawnEngine, SpawnEngineResult, Status, StatusResult,
-    Submit, SubmitResult, TerminateEngine, TerminateEngineResult, UploadBinary, UploadBinaryResult,
-    UploadComponent, UploadComponentResult,
+    ListComponentBinaries, ListComponentBinariesResult, ListComponents, ListComponentsResult,
+    ListEngineBinaries, ListEngineBinariesResult, ListEngines, ListEnginesResult, ListKinds,
+    ListKindsResult, LoadComponent, LoadResult, MailEnvelope as KindMailEnvelope, ReplaceComponent,
+    ReplaceResult, ResolveComponent, ResolveComponentResult, SimilarityCheck, SpawnEngine,
+    SpawnEngineResult, Status, StatusResult, Submit, SubmitResult, TerminateEngine,
+    TerminateEngineResult, UploadBinary, UploadBinaryResult, UploadComponent,
+    UploadComponentResult,
     trace::{
         DescribeTreeResult, DispatchTraced, DispatchTracedAck, MailNodeWire, TRACE_MAILBOX_NAME,
         TraceTail, TraceTailResult,
@@ -281,18 +282,79 @@ impl Mcp {
             staged.cleanup().await;
         }
         let reply = reply.map_err(internal)?;
-        match SpawnEngineResult::decode_from_bytes(&reply.payload) {
+        let info = match SpawnEngineResult::decode_from_bytes(&reply.payload) {
             Some(SpawnEngineResult::Ok {
                 engine_id,
                 rpc_port,
-            }) => json(&EngineInfo {
+            }) => EngineInfo {
                 engine_id,
                 rpc_port,
                 // A just-spawned engine is alive as of now.
                 last_heartbeat_age_millis: 0,
-            }),
-            Some(SpawnEngineResult::Err { error }) => Err(internal_msg(&error)),
-            None => Err(internal_msg("undecodable SpawnEngineResult")),
+            },
+            Some(SpawnEngineResult::Err { error }) => return Err(internal_msg(&error)),
+            None => return Err(internal_msg("undecodable SpawnEngineResult")),
+        };
+
+        // The spawn reply returns once the proxy connects, before any
+        // boot-manifest autoload (ADR-0116) settles — those loads are
+        // fire-and-forget and emit no completion signal. When components
+        // were requested, poll the engine's loaded-components query (issue
+        // 2020) until all of them register, so the tool hands back a
+        // genuinely-ready engine rather than one mid-boot. The query is a
+        // definitive snapshot of the live trampoline set, so readiness is
+        // the count reaching the requested total — name-agnostic, robust
+        // against the substrate's name derivation.
+        let want = args.components.len();
+        if want > 0 {
+            self.wait_for_loaded_components(&info.engine_id, want)
+                .await?;
+        }
+
+        json(&info)
+    }
+
+    /// Poll the spawned engine's `aether.component.list` query (issue 2020)
+    /// until at least `want` components are loaded and registered, or the
+    /// bounded budget elapses. The boot autoload is async and signalless, so
+    /// this turns the readiness wait into a deterministic poll of the live
+    /// trampoline set rather than a fixed post-spawn sleep. A timeout is a
+    /// clear tool error naming how many of the requested components came up.
+    async fn wait_for_loaded_components(
+        &self,
+        engine_id: &str,
+        want: usize,
+    ) -> Result<(), McpError> {
+        const POLL_INTERVAL: Duration = Duration::from_millis(100);
+        const BUDGET: Duration = Duration::from_secs(30);
+
+        let engine = parse_engine_id(engine_id)?;
+        let deadline = time::Instant::now() + BUDGET;
+        loop {
+            let reply = self
+                .session
+                .call_one(engine_envelope(
+                    engine,
+                    "aether.component",
+                    &ListComponents {},
+                ))
+                .await
+                .map_err(internal)?;
+            let loaded = match ListComponentsResult::decode_from_bytes(&reply.payload) {
+                Some(result) => result.names.len(),
+                None => return Err(internal_msg("undecodable ListComponentsResult")),
+            };
+            if loaded >= want {
+                return Ok(());
+            }
+            if time::Instant::now() >= deadline {
+                return Err(internal_msg(&format!(
+                    "spawned engine did not load all boot components within {}s: \
+                     {loaded} of {want} registered",
+                    BUDGET.as_secs(),
+                )));
+            }
+            time::sleep(POLL_INTERVAL).await;
         }
     }
 
@@ -360,7 +422,7 @@ impl Mcp {
             .session
             .call_one(local_envelope(
                 ENGINE_CAP,
-                &ListBinaries {
+                &ListEngineBinaries {
                     chassis: args.chassis,
                     caps: args.caps,
                     target: args.target,
@@ -368,9 +430,9 @@ impl Mcp {
             ))
             .await
             .map_err(internal)?;
-        match ListBinariesResult::decode_from_bytes(&reply.payload) {
+        match ListEngineBinariesResult::decode_from_bytes(&reply.payload) {
             Some(result) => json(&result.binaries),
-            None => Err(internal_msg("undecodable ListBinariesResult")),
+            None => Err(internal_msg("undecodable ListEngineBinariesResult")),
         }
     }
 
@@ -419,16 +481,16 @@ impl Mcp {
             .session
             .call_one(local_envelope(
                 ENGINE_CAP,
-                &ListComponents {
+                &ListComponentBinaries {
                     namespace: args.namespace,
                     handled_kind,
                 },
             ))
             .await
             .map_err(internal)?;
-        match ListComponentsResult::decode_from_bytes(&reply.payload) {
+        match ListComponentBinariesResult::decode_from_bytes(&reply.payload) {
             Some(result) => json(&result.components),
-            None => Err(internal_msg("undecodable ListComponentsResult")),
+            None => Err(internal_msg("undecodable ListComponentBinariesResult")),
         }
     }
 

--- a/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
@@ -55,12 +55,12 @@ use aether_kinds::trace::{DispatchTraced, DispatchTracedAck, TRACE_MAILBOX_NAME}
 use aether_kinds::{
     BinaryEntry, BinarySelector, Cancel, CancelResult, ComponentCapabilities, ComponentEntry,
     ComponentSelector, DagDescriptor, DeadEngineDescriptor, EngineDescriptor, HandleDescribe,
-    HandleDescribeResult, ListBinaries, ListBinariesResult, ListComponents, ListComponentsResult,
-    ListEngines, ListEnginesResult, LoadComponent, LoadResult, LogTail, LogTailResult,
-    ReplaceComponent, ReplaceResult, ResolveComponent, ResolveComponentResult, SpawnEngine,
-    SpawnEngineResult, Status, StatusResult, Submit, SubmitResult, TerminateEngine,
-    TerminateEngineResult, UploadBinary, UploadBinaryResult, UploadComponent,
-    UploadComponentResult,
+    HandleDescribeResult, ListComponentBinaries, ListComponentBinariesResult, ListComponents,
+    ListComponentsResult, ListEngineBinaries, ListEngineBinariesResult, ListEngines,
+    ListEnginesResult, LoadComponent, LoadResult, LogTail, LogTailResult, ReplaceComponent,
+    ReplaceResult, ResolveComponent, ResolveComponentResult, SpawnEngine, SpawnEngineResult,
+    Status, StatusResult, Submit, SubmitResult, TerminateEngine, TerminateEngineResult,
+    UploadBinary, UploadBinaryResult, UploadComponent, UploadComponentResult,
 };
 use aether_substrate::chassis::Chassis;
 use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver, PassiveChassis};
@@ -275,15 +275,15 @@ impl FleetBench {
         UploadBinaryResult::decode_from_bytes(&payload).expect("undecodable UploadBinaryResult")
     }
 
-    /// Enumerate the hub's stored binaries (ADR-0115, issue 1953) under the
-    /// given filter. Hub-local — addressed at `aether.engine` with no
-    /// engine route.
-    pub fn list_binaries(&mut self, filter: &ListBinaries) -> Vec<BinaryEntry> {
+    /// Enumerate the hub's stored engine binaries (ADR-0115, issue 1953)
+    /// under the given filter. Hub-local — addressed at `aether.engine` with
+    /// no engine route.
+    pub fn list_engine_binaries(&mut self, filter: &ListEngineBinaries) -> Vec<BinaryEntry> {
         let replies = self.call(None, "aether.engine", filter);
-        let payload = single_reply(&replies, "ListBinaries");
-        match ListBinariesResult::decode_from_bytes(&payload) {
+        let payload = single_reply(&replies, "ListEngineBinaries");
+        match ListEngineBinariesResult::decode_from_bytes(&payload) {
             Some(result) => result.binaries,
-            None => panic!("undecodable ListBinariesResult"),
+            None => panic!("undecodable ListEngineBinariesResult"),
         }
     }
 
@@ -310,14 +310,32 @@ impl FleetBench {
             .expect("undecodable UploadComponentResult")
     }
 
-    /// Enumerate the hub's stored components (ADR-0116, issue 1956) under
-    /// the given filter. Hub-local — addressed at `aether.engine` with no
-    /// engine route.
-    pub fn list_components(&mut self, filter: &ListComponents) -> Vec<ComponentEntry> {
+    /// Enumerate the hub's stored component binaries (ADR-0116, issue 1956)
+    /// under the given filter. Hub-local — addressed at `aether.engine` with
+    /// no engine route.
+    pub fn list_component_binaries(
+        &mut self,
+        filter: &ListComponentBinaries,
+    ) -> Vec<ComponentEntry> {
         let replies = self.call(None, "aether.engine", filter);
+        let payload = single_reply(&replies, "ListComponentBinaries");
+        match ListComponentBinariesResult::decode_from_bytes(&payload) {
+            Some(result) => result.components,
+            None => panic!("undecodable ListComponentBinariesResult"),
+        }
+    }
+
+    /// Enumerate the components an `engine` has actually loaded and
+    /// registered, by ADR-0099 lineage name (issue 2020). Engine-local —
+    /// addressed at the engine's own `aether.component` mailbox, a definitive
+    /// snapshot of the live trampoline set. Poll this after a boot-manifest
+    /// spawn to learn deterministically when a requested component is loaded,
+    /// rather than inferring liveness from a log-ring side channel.
+    pub fn list_components(&mut self, engine: EngineId) -> Vec<String> {
+        let replies = self.call(Some(engine), "aether.component", &ListComponents {});
         let payload = single_reply(&replies, "ListComponents");
         match ListComponentsResult::decode_from_bytes(&payload) {
-            Some(result) => result.components,
+            Some(result) => result.names,
             None => panic!("undecodable ListComponentsResult"),
         }
     }

--- a/crates/aether-substrate-bundle/tests/fleetbench_binary_store.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_binary_store.rs
@@ -11,7 +11,7 @@ mod fleetbench;
 
 mod tests {
     mod heavy {
-        use aether_kinds::{ListBinaries, UploadBinaryResult};
+        use aether_kinds::{ListEngineBinaries, UploadBinaryResult};
 
         use crate::fleetbench::FleetBench;
 
@@ -41,7 +41,7 @@ mod tests {
 
             // List with no filter — the entry is present with the headless
             // manifest the `--describe` fork captured.
-            let all = bench.list_binaries(&ListBinaries::default());
+            let all = bench.list_engine_binaries(&ListEngineBinaries::default());
             let entry = all
                 .iter()
                 .find(|e| e.hash == hash)
@@ -62,7 +62,7 @@ mod tests {
             );
 
             // A chassis filter that matches keeps it; one that doesn't drops it.
-            let headless_filtered = bench.list_binaries(&ListBinaries {
+            let headless_filtered = bench.list_engine_binaries(&ListEngineBinaries {
                 chassis: Some("headless".to_owned()),
                 caps: vec![],
                 target: None,
@@ -71,7 +71,7 @@ mod tests {
                 headless_filtered.iter().any(|e| e.hash == hash),
                 "a matching chassis filter keeps the entry",
             );
-            let desktop_filtered = bench.list_binaries(&ListBinaries {
+            let desktop_filtered = bench.list_engine_binaries(&ListEngineBinaries {
                 chassis: Some("desktop".to_owned()),
                 caps: vec![],
                 target: None,

--- a/crates/aether-substrate-bundle/tests/fleetbench_component_store.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_component_store.rs
@@ -24,7 +24,7 @@ mod tests {
         use aether_capabilities::WasmTrampoline;
         use aether_data::Kind;
         use aether_kinds::{
-            ComponentSelector, ListComponents, LogTailResult, ResolveComponentResult, Tick,
+            ComponentSelector, ListComponentBinaries, LogTailResult, ResolveComponentResult, Tick,
             UploadComponentResult,
         };
 
@@ -69,7 +69,7 @@ mod tests {
                 UploadComponentResult::Err { error } => panic!("upload_component failed: {error}"),
             };
 
-            let all = bench.list_components(&ListComponents::default());
+            let all = bench.list_component_binaries(&ListComponentBinaries::default());
             let entry = all
                 .iter()
                 .find(|e| e.hash == hash)
@@ -96,7 +96,7 @@ mod tests {
             // Attribute filters: namespace + handled-kind keep it, a miss drops it.
             assert!(
                 bench
-                    .list_components(&ListComponents {
+                    .list_component_binaries(&ListComponentBinaries {
                         namespace: Some(PROBE_NAMESPACE.to_owned()),
                         handled_kind: None,
                     })
@@ -106,7 +106,7 @@ mod tests {
             );
             assert!(
                 bench
-                    .list_components(&ListComponents {
+                    .list_component_binaries(&ListComponentBinaries {
                         namespace: None,
                         handled_kind: Some(Tick::ID),
                     })
@@ -116,7 +116,7 @@ mod tests {
             );
             assert!(
                 !bench
-                    .list_components(&ListComponents {
+                    .list_component_binaries(&ListComponentBinaries {
                         namespace: Some("not_a_namespace".to_owned()),
                         handled_kind: None,
                     })
@@ -225,12 +225,6 @@ mod tests {
         /// substrate reads at boot (ADR-0116). `FleetBench` mirrors that
         /// pre-resolution (it speaks raw frames, not aether-mcp): upload,
         /// resolve hub-local, stage the bytes, and spawn with the manifest.
-        // Flaky: the boot-manifest autoload path emits no readiness signal, so
-        // this races a fixed 3s liveness poll (`LogTail` as a registration
-        // probe) against a cold-forked substrate's async boot + autoload, which
-        // intermittently overruns the budget under CI load. Re-enabled by the
-        // engine-local loaded-components query tracked in #2020.
-        #[ignore = "flaky pending the boot-autoload readiness query (#2020)"]
         #[test]
         fn fleetbench_boots_a_component_set_from_a_selector_manifest() {
             if !dist_manifest_present() {
@@ -281,23 +275,24 @@ mod tests {
             // Spawn with the boot manifest; the substrate reads it at boot.
             let engine = bench.spawn_headless_with_boot_manifest(&manifest_path);
 
-            // The autoloaded probe answers LogTail at its lineage address. The
-            // autoload is async at boot, so poll briefly for it.
+            // The boot autoload is async, so poll the engine's loaded-components
+            // query (issue 2020) until the probe's lineage address appears. This
+            // is the deterministic registration edge: `aether.component.list`
+            // reflects the live trampoline set, so the probe's name is present
+            // exactly when it is loaded and registered — no log-ring side channel
+            // and no racing a fixed liveness budget.
             let expected = probe_lineage_addr();
-            let mut answered = false;
+            let mut registered = false;
             for _ in 0..30 {
-                if matches!(
-                    bench.log_tail(engine, &expected, None),
-                    LogTailResult::Ok { .. }
-                ) {
-                    answered = true;
+                if bench.list_components(engine).iter().any(|n| n == &expected) {
+                    registered = true;
                     break;
                 }
                 thread::sleep(Duration::from_millis(100));
             }
             assert!(
-                answered,
-                "the boot-manifest probe should come up and answer LogTail at {expected}",
+                registered,
+                "the boot-manifest probe should come up and register at {expected}",
             );
 
             // Best-effort: clean up the staged temp files.

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -37,9 +37,10 @@ use aether_kinds::{
     CachedFontMetrics, Camera, CaptureFrame, CaptureFrameResult, CreateTexture,
     CreateTextureResult, Delete, DeleteResult, DrawSolidQuads, DrawText, DrawTexturedQuads,
     DropComponent, DropResult, FontMetricsRequest, FontMetricsResult, FontRef, FrameCheck,
-    FrameCheckResult, FrameReduction, FsError, List, ListResult, LoadComponent, LoadFont,
-    LoadFontResult, LoadResult, MailEnvelope, Ping, QuadScale, QuadSpace, Read, ReadResult,
-    ReplaceComponent, ReplaceResult, SolidQuad, TexturedQuad, UiBar, UiPanel, Write, WriteResult,
+    FrameCheckResult, FrameReduction, FsError, List, ListComponents, ListComponentsResult,
+    ListResult, LoadComponent, LoadFont, LoadFontResult, LoadResult, MailEnvelope, Ping, QuadScale,
+    QuadSpace, Read, ReadResult, ReplaceComponent, ReplaceResult, SolidQuad, TexturedQuad, UiBar,
+    UiPanel, Write, WriteResult,
 };
 use aether_math::{Mat4, Vec3};
 use aether_substrate_bundle::test_bench::{
@@ -156,6 +157,37 @@ fn load_cube(bench: &mut TestBench, wasm_path: &Path) {
         LoadResult::Ok { .. } => {}
         LoadResult::Err { error } => panic!("load_component(cube): {error}"),
     }
+}
+
+/// The engine-local loaded-components query (issue 2020) lists a
+/// loaded component by its ADR-0099 lineage address. After loading the
+/// probe, a fieldless `ListComponents` to the `aether.component` mailbox
+/// replies with the probe's full trampoline address — the deterministic
+/// registration snapshot a readiness poll consumes instead of inferring
+/// liveness from a log-ring side channel.
+#[test]
+fn list_components_reports_loaded_probe_lineage() {
+    let Some(wasm_path) = require_runtime("probe") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    load_probe(&mut bench, &wasm_path);
+
+    let listed = bench
+        .execute(vec![(
+            "list",
+            BenchOp::send_and_await("aether.component", &ListComponents {}),
+        )])
+        .expect("list sequence");
+    let result = listed
+        .reply::<ListComponentsResult>("list")
+        .expect("decode ListComponentsResult");
+    assert!(
+        result.names.contains(&probe_address()),
+        "the loaded probe should be listed at its lineage address {}, got {:?}",
+        probe_address(),
+        result.names,
+    );
 }
 
 /// Subscribing the fixture to Tick yields exactly one


### PR DESCRIPTION
Closes #2020.

## Summary

Boot-manifest autoload (ADR-0116) loads components fire-and-forget — the chassis pushes each `aether.component.load` and the spawn reply returns before any load settles, with nothing emitting a completion signal. There was no engine-local query answering "is component X loaded and registered at its lineage address": the only `list` kinds enumerate the content-addressed store (what's available to load), not what a running engine actually loaded. Consumers were forced to poll for readiness by proxy — the FleetBench boot test abused `LogTail` as a registration probe on a fixed budget, and `spawn_substrate(components=…)` returned before its components loaded.

This adds the request/reply seam onto the enumeration the engine already does:

- A fieldless `ListComponents` (`aether.component.list`) + `ListComponentsResult { names: Vec<String> }` (`aether.component.list_result`), handled by `on_list_components` on `ComponentHostCapability` — reads `list_mailbox_descriptors()`, keeps `MailboxCategory::Trampoline` entries, projects each to its `name`. No new bookkeeping, no wire-protocol change (rides `Call` / `ReplyEvent` / `ReplyEnd`). Addressed to `aether.component`, a boot-present mailbox, so every send resolves and every reply is a definitive snapshot.
- Step 0 store-family rename to free the canonical name: `ListComponents`/`ListBinaries` → `ListComponentBinaries`/`ListEngineBinaries` (+ `…Result` twins), wire strings unchanged.
- Consumers move onto the new query: the FleetBench `fleetbench_boots_a_component_set_from_a_selector_manifest` test polls `list_components(engine)` instead of `LogTail` (re-enabled, no longer `#[ignore]`); `aether-mcp`'s `spawn_substrate(components=…)` polls `wait_for_loaded_components` (bounded 30s) so it returns a genuinely-ready engine.

## Test plan

New `aether-kinds` descriptor roundtrip test for the two kinds; new TestBench scenario `list_components_reports_loaded_probe_lineage`; the re-enabled FleetBench boot test polls the new query against a real boot-autoloaded component. Full workspace green (`fmt` / `clippy -D warnings` / `nextest` / `doc` / wasm32 cross-build).

## Generated by

`/implement` — agent execution of [scoped issue #2020](https://github.com/iamacoffeepot/aether/issues/2020).
