### PR TITLE
refactor(actor): implement ADR-0119 resolver-strategy addressing

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -750,13 +750,20 @@ pub fn actor(attr: TokenStream, item: TokenStream) -> TokenStream {
     }
 }
 
-/// Parsed `#[actor(...)]` attribute arguments. Only `skip_markers` is
-/// recognised today (issue 565: tells the expander not to emit
-/// `Addressable` + `HandlesKind` impls because a wrapping `#[bridge]`
-/// already emitted them as siblings of a cfg-gated module).
+/// Parsed `#[actor(...)]` attribute arguments. `skip_markers` (issue 565)
+/// tells the expander not to emit `Addressable` + `HandlesKind` impls because
+/// a wrapping `#[bridge]` already emitted them as siblings of a cfg-gated
+/// module. `singleton` / `instanced` (ADR-0119) declare cardinality, mapped to
+/// the `Addressable::Resolver` per transport.
 #[derive(Default, Clone, Copy)]
 struct ActorOpts {
     skip_markers: bool,
+    /// ADR-0119 cardinality from `#[actor(singleton|instanced)]`, mapped to
+    /// the resolver per transport — native: `One` / `Many`; FFI: `Embedded`
+    /// (default) / `EmbeddedMany`. `None` on a `skip_markers` block (the
+    /// wrapping `#[bridge]` owns the resolver) or where the transport supplies
+    /// a default (FFI ⇒ `Embedded`).
+    cardinality: Option<BridgeCardinality>,
 }
 
 fn parse_actor_opts(attr: TokenStream2) -> syn::Result<ActorOpts> {
@@ -768,8 +775,26 @@ fn parse_actor_opts(attr: TokenStream2) -> syn::Result<ActorOpts> {
         if meta.path.is_ident("skip_markers") {
             opts.skip_markers = true;
             Ok(())
+        } else if meta.path.is_ident("singleton") {
+            if matches!(opts.cardinality, Some(BridgeCardinality::Instanced)) {
+                return Err(
+                    meta.error("`singleton` and `instanced` are mutually exclusive (ADR-0079)")
+                );
+            }
+            opts.cardinality = Some(BridgeCardinality::Singleton);
+            Ok(())
+        } else if meta.path.is_ident("instanced") {
+            if matches!(opts.cardinality, Some(BridgeCardinality::Singleton)) {
+                return Err(
+                    meta.error("`singleton` and `instanced` are mutually exclusive (ADR-0079)")
+                );
+            }
+            opts.cardinality = Some(BridgeCardinality::Instanced);
+            Ok(())
         } else {
-            Err(meta.error("unrecognised #[actor] argument; only `skip_markers` is supported"))
+            Err(meta.error(
+                "unrecognised #[actor] argument; expected `singleton`, `instanced`, or `skip_markers`",
+            ))
         }
     });
     Parser::parse2(parser, attr)?;
@@ -1131,16 +1156,22 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
         #native_cfg
         pub use #mod_ident::#type_ident;
     };
-    // Issue 625: cardinality is an explicit declaration on the bridge
-    // attribute per ADR-0079. The bridge sits over two struct
-    // definition sites — the wasm stub at file root and the native
-    // struct inside `mod native` — and the cardinality marker impl
-    // must land at file root to cover both. The author writes
-    // `#[bridge(singleton)]` or `#[bridge(instanced)]`; absence is
-    // hand-rolled (test fixtures, future cases that don't fit either).
+    // Issue 625 / ADR-0119: cardinality is an explicit declaration on the
+    // bridge attribute (`#[bridge(singleton|instanced)]`), mapped to the
+    // `Addressable::Resolver` — `One` (default / `singleton`) or `Many`
+    // (`instanced`). `Singleton` / `Instanced` are derived from the resolver
+    // via blanket impls, so nothing emits a separate marker impl. The
+    // Addressable impl lands at file root so the wasm stub and the native
+    // struct both carry it.
+    let resolver_ty = if matches!(cardinality, Some(BridgeCardinality::Instanced)) {
+        quote! { ::aether_actor::Many }
+    } else {
+        quote! { ::aether_actor::One }
+    };
     let actor_marker = quote! {
         impl #impl_generics ::aether_actor::Addressable for #self_ty #where_clause {
             const NAMESPACE: &'static str = #namespace_expr;
+            type Resolver = #resolver_ty;
         }
     };
     // The cardinality marker (issue 625 / ADR-0079) plus its ADR-0088
@@ -1169,9 +1200,12 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
     } else {
         quote! { ::aether_data::name_inventory::Cardinality::Unbounded }
     };
+    // ADR-0119: the marker impls are gone (derived from the resolver); this
+    // is now purely the ADR-0088 §3/§4 name-inventory submission, keyed by
+    // cardinality. `None` submits nothing (the Addressable still resolves via
+    // the default `One`).
     let cardinality_marker = match cardinality {
         Some(BridgeCardinality::Singleton) => quote! {
-            impl #impl_generics ::aether_actor::Singleton for #self_ty #where_clause {}
             #native_cfg
             ::aether_data::name_inventory::inventory::submit! {
                 ::aether_data::name_inventory::NameEntry {
@@ -1181,14 +1215,13 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
             }
         },
         Some(BridgeCardinality::Instanced) => quote! {
-            impl #impl_generics ::aether_actor::Instanced for #self_ty #where_clause {}
             #native_cfg
             ::aether_data::name_inventory::inventory::submit! {
                 ::aether_data::name_inventory::TemplateEntry {
                     domain: ::aether_data::MAILBOX_DOMAIN,
                     // Split the namespace (prefix) from the structural
                     // `:{subname}` suffix so a forward-fed const NAMESPACE
-                    // (e.g. `EmbeddedHost::NAMESPACE`, ADR-0099 §5/§6) works —
+                    // (e.g. `EMBEDDED_SCOPE`, ADR-0099 §5/§6) works —
                     // `concat!` would reject a non-literal namespace.
                     prefix: #namespace_expr,
                     template: ":{subname}",
@@ -1350,94 +1383,13 @@ pub fn local(_attr: TokenStream, item: TokenStream) -> TokenStream {
     .into()
 }
 
-/// `#[derive(Singleton)]` — emits `impl ::aether_actor::Singleton for T {}`.
-///
-/// Per ADR-0079 (issue 607) cardinality is first-class:
-/// [`Singleton`] and [`Instanced`] are mutually exclusive at the type
-/// level. Issue 625 made the choice explicit at the struct
-/// definition rather than auto-emitted by `#[bridge]` — `Singleton`
-/// is a property of the type, not of any one trait it implements.
-/// Authors place `#[derive(Singleton)]` on the cap struct alongside
-/// `pub struct X` inside the bridge mod; absence selects the other
-/// cardinality (and the type-system catches mistakes — `Builder::with_actor`
-/// requires `Singleton`, `ctx.spawn_child` requires `Instanced`).
-#[proc_macro_derive(Singleton)]
-pub fn derive_singleton(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
-    let name = &input.ident;
-    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-    quote! {
-        impl #impl_generics ::aether_actor::Singleton for #name #ty_generics #where_clause {}
-    }
-    .into()
-}
-
-/// `#[derive(Instanced)]` — emits `impl ::aether_actor::Instanced for T {}`.
-///
-/// The instanced counterpart of [`derive_singleton`]. Per ADR-0079
-/// (issue 607), instanced actors carry a runtime subname under their
-/// `NAMESPACE` prefix — full names hash to `"{NAMESPACE}:{subname}"`
-/// (e.g. `aether.tcp.listener:8080`). Authors place
-/// `#[derive(Instanced)]` on the cap struct inside the bridge mod;
-/// `Builder::with_actor` rejects instanced types at compile time
-/// (the chassis-builder boots singletons only), and
-/// `ctx.spawn_child` requires the `Instanced` bound.
-#[proc_macro_derive(Instanced)]
-pub fn derive_instanced(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
-    let name = &input.ident;
-    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-    quote! {
-        impl #impl_generics ::aether_actor::Instanced for #name #ty_generics #where_clause {}
-    }
-    .into()
-}
-
-/// `#[derive(Embeddable)]` — marks an **embeddable** actor: an FFI/wasm
-/// component reached by peers as `ctx.actor::<T>()`. Emits the `Singleton`
-/// marker with a `resolve` override that **delegates to the embedding-host
-/// class** (ADR-0099 §5/§6) instead of the depth-1 default:
-///
-/// ```ignore
-/// impl Singleton for T {
-///     fn resolve(_caller_carry: u64) -> MailboxId {
-///         ::aether_capabilities::resolve_embedded(<T as Addressable>::NAMESPACE)
-///     }
-/// }
-/// ```
-///
-/// The override ignores the caller's carry — an embeddable component's
-/// address is absolute, rooted at the component host, not relative to the
-/// caller. It folds the component's own `NAMESPACE` as an instance under
-/// the reserved `aether.embedded` class namespace onto the host cap's
-/// carry, landing on the registered mailbox a bare-`NAMESPACE` hash would
-/// miss (iamacoffeepot/aether#1364).
-///
-/// The macro writes **no namespace literal** — it emits a *call* to
-/// `resolve_embedded`, which reads `aether.embedded` only inside its
-/// owner (`aether_actor::EmbeddedHost`) and the `aether.component` host
-/// carry only from `ComponentHostCapability`. The
-/// only string the author writes is `T`'s own `NAMESPACE` (ADR-0099 §5's
-/// read-from-owner rule). Because the emitted path is
-/// `::aether_capabilities::resolve_embedded`, a peer-addressable
-/// embeddable depends on `aether-capabilities` (as `aether-kit` already
-/// does). Use in place of `#[derive(Singleton)]`, not alongside it.
-#[proc_macro_derive(Embeddable)]
-pub fn derive_embeddable(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
-    let name = &input.ident;
-    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-    quote! {
-        impl #impl_generics ::aether_actor::Singleton for #name #ty_generics #where_clause {
-            fn resolve(_caller_carry: u64) -> ::aether_data::MailboxId {
-                ::aether_capabilities::resolve_embedded(
-                    <#name #ty_generics as ::aether_actor::Addressable>::NAMESPACE,
-                )
-            }
-        }
-    }
-    .into()
-}
+// ADR-0119: `#[derive(Singleton)]` / `#[derive(Instanced)]` /
+// `#[derive(Embeddable)]` are retired. Cardinality is now the
+// `Addressable::Resolver` (`One` / `Many` / `Embedded` / `EmbeddedMany`); the
+// `Singleton` / `Instanced` markers derive from it by blanket impl, so a
+// hand-emitted marker would conflict. `#[actor]` / `#[bridge]` emit the
+// resolver from their `singleton` / `instanced` arg; a hand-written actor sets
+// `type Resolver` directly.
 
 /// `#[capability]` — attribute macro for native chassis capability
 /// structs. Cfg-gates every field with `#[cfg(feature = "native")]`
@@ -1547,7 +1499,7 @@ fn expand_handlers(item: ItemImpl, opts: ActorOpts) -> syn::Result<TokenStream2>
                          `impl NativeActor for X` blocks wrapped by `#[bridge]`",
                     ));
                 }
-                expand_wasm_actor(item)
+                expand_wasm_actor(item, opts)
             }
             other => Err(syn::Error::new_spanned(
                 trait_path,
@@ -1856,7 +1808,7 @@ fn classify_task_reply_mode(sig: &Signature, is_borrow: bool) -> syn::Result<Tas
 /// statics, plus the `HandlesKind<K>` and `Addressable` impls common to both
 /// shapes.
 #[allow(clippy::too_many_lines)] // emits the full wasm-actor surface in one go
-fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
+fn expand_wasm_actor(item: ItemImpl, opts: ActorOpts) -> syn::Result<TokenStream2> {
     let self_ty = &item.self_ty;
     let generics = &item.generics;
     let (impl_generics, _ty_generics, where_clause) = generics.split_for_impl();
@@ -2205,12 +2157,23 @@ fn expand_wasm_actor(item: ItemImpl) -> syn::Result<TokenStream2> {
         ));
     }
     let const_tokens = consts.iter();
+    // ADR-0119: an FFI/wasm component is embedded — it resolves under the
+    // reserved `aether.embedded` scope. Default `Embedded` (keyless ⇒
+    // `Singleton`, reached by `ctx.actor::<R>()`); `#[actor(instanced)]`
+    // selects `EmbeddedMany` for a spawn-sibling child (ADR-0097). Cardinality
+    // is derived from the resolver; nothing emits `impl Singleton` here.
+    let resolver_ty = if matches!(opts.cardinality, Some(BridgeCardinality::Instanced)) {
+        quote! { ::aether_actor::EmbeddedMany }
+    } else {
+        quote! { ::aether_actor::Embedded }
+    };
     let actor_impl = if consts.is_empty() {
         quote! {}
     } else {
         quote! {
             impl #impl_generics ::aether_actor::Addressable for #self_ty #where_clause {
                 #(#const_tokens)*
+                type Resolver = #resolver_ty;
             }
         }
     };
@@ -2681,12 +2644,22 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
     // NAMESPACE passes through unchanged because its RHS is a
     // primitive that doesn't require resolution.
     let const_tokens: Vec<TokenStream2> = consts.iter().map(|c| quote! { #c }).collect();
+    // ADR-0119: a native actor's cardinality picks its resolver — `One`
+    // (default, or `#[actor(singleton)]`) or `Many` (`#[actor(instanced)]`).
+    // `Singleton` / `Instanced` are derived from it; the old hand-written
+    // `impl Singleton/Instanced for X {}` next to `#[actor]` is retired.
+    let resolver_ty = if matches!(opts.cardinality, Some(BridgeCardinality::Instanced)) {
+        quote! { ::aether_actor::Many }
+    } else {
+        quote! { ::aether_actor::One }
+    };
     let actor_impl = if opts.skip_markers || consts.is_empty() {
         quote! {}
     } else {
         quote! {
             impl #impl_generics ::aether_actor::Addressable for #self_ty #where_clause {
                 #(#const_tokens)*
+                type Resolver = #resolver_ty;
             }
         }
     };

--- a/crates/aether-actor/src/actor/mod.rs
+++ b/crates/aether-actor/src/actor/mod.rs
@@ -25,6 +25,100 @@ pub mod slot;
 
 use aether_data::{ActorId, Kind, MailboxId, Tag, fold_lineage, with_tag};
 
+/// A resolution strategy (ADR-0119): given a caller's lineage carry, the
+/// actor's own `NAMESPACE`, and whatever args the strategy needs, produce
+/// the `MailboxId`. An actor selects one of these as its
+/// [`Addressable::Resolver`]; cardinality is *derived* from the resolver's
+/// [`Args`](Resolve::Args) shape rather than declared.
+///
+/// `Args` is a generic associated type because a keyed resolver borrows its
+/// key (`&'a str`): keyless strategies set `Args<'a> = ()`, keyed ones set
+/// `Args<'a> = &'a str`.
+pub trait Resolve {
+    /// What addressing this strategy requires: `()` keyless, a borrowed key
+    /// for a keyed (instanced) target.
+    type Args<'a>;
+
+    /// Produce the mailbox for `namespace` as this strategy sees it, given
+    /// the caller's lineage carry and the strategy-specific `args`.
+    #[must_use]
+    fn resolve(caller_carry: u64, namespace: &str, args: Self::Args<'_>) -> MailboxId;
+}
+
+/// Root-pinned keyless resolution (ADR-0119): the depth-1 fixed point
+/// (ADR-0099 §3), this actor's own [`ActorId`] tagged as a mailbox,
+/// **ignoring the caller's carry** because a root cap sits at the root. It
+/// equals `mailbox_id_from_name(NAMESPACE)` because [`with_tag`] is
+/// idempotent on an already-`Mailbox`-tagged value, so every chassis cap
+/// keeps the exact id it has today. Makes its actor a [`Singleton`].
+pub struct One;
+
+impl Resolve for One {
+    type Args<'a> = ();
+    fn resolve(_caller_carry: u64, namespace: &str, _args: ()) -> MailboxId {
+        MailboxId(with_tag(Tag::Mailbox, ActorId::singleton(namespace).0))
+    }
+}
+
+/// Keyed resolution (ADR-0119): folds `ActorId::instanced(NAMESPACE, subname)`
+/// onto the caller's carry, so the same type resolves to a different mailbox
+/// under each parent and for each subname. Makes its actor an [`Instanced`].
+pub struct Many;
+
+impl Resolve for Many {
+    type Args<'a> = &'a str;
+    fn resolve(caller_carry: u64, namespace: &str, subname: &str) -> MailboxId {
+        MailboxId(with_tag(
+            Tag::Mailbox,
+            fold_lineage(caller_carry, ActorId::instanced(namespace, subname)),
+        ))
+    }
+}
+
+/// The reserved scope under which every embedded actor — an FFI/wasm
+/// component hosted by the component-host trampoline — resolves (ADR-0099
+/// §5/§6, ADR-0119). The sole owner of the `"aether.embedded"` literal;
+/// concrete hosts (the trampoline, the substrate `TRAMPOLINE_NAMESPACE`)
+/// forward-feed this const rather than re-declaring it.
+pub const EMBEDDED_SCOPE: &str = "aether.embedded";
+
+/// Keyless embedded resolution (ADR-0119): folds
+/// `instanced(EMBEDDED_SCOPE, NAMESPACE)` onto the caller's carry — the
+/// component's own name as an instance under the reserved embed scope.
+/// Resolution is relative (ADR-0099 §5): in the embedding context the caller
+/// is the component host, whose carry is `aether.component`, so the result is
+/// the component's registered mailbox. The carry is supplied by the caller
+/// (`aether-capabilities`'s `resolve_embedded` for by-name lookups), not
+/// re-derived here. Keyless (`Args<'a> = ()`), so an embedded actor is a
+/// [`Singleton`].
+pub struct Embedded;
+
+impl Resolve for Embedded {
+    type Args<'a> = ();
+    fn resolve(caller_carry: u64, namespace: &str, _args: ()) -> MailboxId {
+        MailboxId(with_tag(
+            Tag::Mailbox,
+            fold_lineage(caller_carry, ActorId::instanced(EMBEDDED_SCOPE, namespace)),
+        ))
+    }
+}
+
+/// Keyed embedded resolution (ADR-0119, ADR-0097): a spawned sibling under
+/// the embed scope, keyed by a runtime `subname` rather than the actor's own
+/// `NAMESPACE`. Folds `instanced(EMBEDDED_SCOPE, subname)` onto the caller's
+/// carry. Keyed (`Args<'a> = &'a str`), so it is an [`Instanced`].
+pub struct EmbeddedMany;
+
+impl Resolve for EmbeddedMany {
+    type Args<'a> = &'a str;
+    fn resolve(caller_carry: u64, _namespace: &str, subname: &str) -> MailboxId {
+        MailboxId(with_tag(
+            Tag::Mailbox,
+            fold_lineage(caller_carry, ActorId::instanced(EMBEDDED_SCOPE, subname)),
+        ))
+    }
+}
+
 /// The symmetric trait every actor implements: the recipient name it
 /// claims. Lifecycle methods (`boot` for native chassis caps, `init`
 /// for wasm components) live on per-transport subtraits; this trait
@@ -48,6 +142,25 @@ pub trait Addressable: Sized + Send + 'static {
     /// default name registers at `aether.embedded:camera`
     /// under its component-host, not at the bare `"camera"`.
     const NAMESPACE: &'static str;
+
+    /// The resolution strategy this actor selects (ADR-0119). Cardinality
+    /// is derived from it: a keyless resolver ([`One`] / [`Embedded`],
+    /// `Args<'a> = ()`) makes the actor a [`Singleton`]; a keyed resolver
+    /// ([`Many`] / [`EmbeddedMany`], `Args<'a> = &'a str`) makes it
+    /// [`Instanced`]. The `#[bridge]` / `#[actor]` macros emit this; a
+    /// hand-written actor sets it directly.
+    type Resolver: Resolve;
+
+    /// This actor's [`MailboxId`] as seen by a caller whose lineage carry is
+    /// `caller_carry` (ADR-0099 §5), produced by delegating to the selected
+    /// [`Resolver`](Self::Resolver). Declared once here, never overridden —
+    /// variation lives in the chosen resolver, not in this method (ADR-0119).
+    /// `ctx.actor::<R>()` calls this with `()`; `ctx.resolve_actor::<R>(key)`
+    /// calls it with the borrowed key.
+    #[must_use]
+    fn resolve(caller_carry: u64, args: <Self::Resolver as Resolve>::Args<'_>) -> MailboxId {
+        <Self::Resolver as Resolve>::resolve(caller_carry, Self::NAMESPACE, args)
+    }
 }
 
 /// The boot/teardown capability an actor composes onto its identity
@@ -137,32 +250,12 @@ pub trait Lifecycle {
 /// Mutually exclusive with [`Instanced`] at the type level: an actor is
 /// either one-of-a-kind within a scope (singleton) or N-instances under
 /// a shared prefix (instanced, name-keyed). ADR-0079.
-pub trait Singleton: Addressable {
-    /// This actor's [`MailboxId`] as seen by a caller whose lineage carry
-    /// is `caller_carry` (ADR-0099 §5). `ctx.actor::<R>()` calls
-    /// `R::resolve(self_carry)` and addresses the result.
-    ///
-    /// The default is the static, root-pinned resolution: the depth-1
-    /// fixed point (§3), this actor's own [`ActorId`] tagged as a mailbox,
-    /// **ignoring the caller's carry** because a root cap sits at the root,
-    /// not below the caller. It equals today's `mailbox_id_from_name(NAMESPACE)`
-    /// because [`with_tag`] is idempotent on an already-`Mailbox`-tagged
-    /// value — so every chassis cap keeps the exact id it has today.
-    ///
-    /// A non-root actor overrides this. A direct child folds the caller's
-    /// carry — `with_tag(Mailbox, fold_lineage(caller_carry, ActorId::singleton(NAMESPACE)))`
-    /// — and an embeddable component delegates to its embedding-host class
-    /// ([`EmbeddedHost`], iamacoffeepot/aether#1432). The override is the only
-    /// carrier of the §2 position fact: a root-pinned actor keeps the default,
-    /// and nothing else about position is held at the type level.
-    #[must_use]
-    fn resolve(_caller_carry: u64) -> MailboxId {
-        MailboxId(with_tag(
-            Tag::Mailbox,
-            ActorId::singleton(Self::NAMESPACE).0,
-        ))
-    }
-}
+/// Derived from the resolver (ADR-0119): a keyless [`Resolver`](Addressable::Resolver)
+/// (`Args<'a> = ()` — [`One`] for root caps, [`Embedded`] for components)
+/// makes the actor a `Singleton`, reached by `ctx.actor::<R>()`. The blanket
+/// impl supplies it; nobody writes `impl Singleton`.
+pub trait Singleton: Addressable<Resolver: for<'a> Resolve<Args<'a> = ()>> {}
+impl<T: Addressable<Resolver: for<'a> Resolve<Args<'a> = ()>>> Singleton for T {}
 
 /// Cardinality marker: many instances of this actor type can be live
 /// per substrate, each under its own subname. `R::NAMESPACE` is a
@@ -176,52 +269,13 @@ pub trait Singleton: Addressable {
 /// address an instance by name through `ctx.resolve_actor::<R>(subname)`.
 ///
 /// Mutually exclusive with [`Singleton`] at the type level. ADR-0079.
-pub trait Instanced: Addressable {
-    /// This actor's [`MailboxId`] for the instance named `subname`, as seen
-    /// by a caller whose lineage carry is `caller_carry` (ADR-0099 §5).
-    /// Symmetric to [`Singleton::resolve`]: an instanced node folds its
-    /// `ActorId` — `hash(NAMESPACE:subname)` — onto the caller's carry, so
-    /// the same type resolves to a different mailbox under each parent and
-    /// for each subname.
-    ///
-    /// The embedding-host class [`EmbeddedHost`] is the instanced type
-    /// behind every embeddable actor's resolution: a component folds its
-    /// own `NAMESPACE` as an instance under `aether.embedded` onto the
-    /// component-host cap's carry (the composition that supplies that carry
-    /// lives with the host cap — `aether-capabilities`'s `resolve_embedded`).
-    #[must_use]
-    fn resolve(caller_carry: u64, subname: &str) -> MailboxId {
-        MailboxId(with_tag(
-            Tag::Mailbox,
-            fold_lineage(caller_carry, ActorId::instanced(Self::NAMESPACE, subname)),
-        ))
-    }
-}
-
-/// The embedding-host class (ADR-0099 §5/§6): the reserved namespace
-/// `aether.embedded` under which every **embeddable** actor — an FFI/wasm
-/// component — resolves, independent of the concrete host that embeds it
-/// (`WasmTrampoline` today, a dynamic-library host tomorrow). This type is
-/// the sole owner of the `"aether.embedded"` literal; concrete hosts
-/// forward-feed `EmbeddedHost::NAMESPACE` rather than re-declaring it, so an
-/// embeddable actor's id depends on what the code is, not how it is hosted,
-/// and the class namespace is read only here (ADR-0099 §5's read-from-owner
-/// rule).
-///
-/// `EmbeddedHost` is [`Instanced`] — one node per embedded component, keyed
-/// by the component's own `NAMESPACE`. An embeddable actor resolves by
-/// folding its name as an instance under this class onto the component-host
-/// cap's carry; the carry is supplied by the composition co-located with the
-/// host cap (`aether-capabilities`'s `resolve_embedded`), which names neither
-/// the `aether.component` host nor `aether.embedded` itself — each is read
-/// only from its owner.
-pub struct EmbeddedHost;
-
-impl Addressable for EmbeddedHost {
-    const NAMESPACE: &'static str = "aether.embedded";
-}
-
-impl Instanced for EmbeddedHost {}
+/// Derived from the resolver (ADR-0119): a keyed [`Resolver`](Addressable::Resolver)
+/// (`Args<'a> = &'a str` — [`Many`], or [`EmbeddedMany`] for spawned
+/// siblings) makes the actor an `Instanced`, reached by
+/// `ctx.resolve_actor::<R>(subname)`. The blanket impl supplies it; nobody
+/// writes `impl Instanced`.
+pub trait Instanced: Addressable<Resolver: for<'a> Resolve<Args<'a> = &'a str>> {}
+impl<T: Addressable<Resolver: for<'a> Resolve<Args<'a> = &'a str>>> Instanced for T {}
 
 /// How a spawned child's mailbox subname is derived (ADR-0079). The
 /// full mailbox name is `"{A::NAMESPACE}:{subname}"`; the substrate
@@ -335,104 +389,68 @@ mod tests {
     use super::*;
     use aether_data::{fold_lineage, mailbox_id_from_name};
 
-    /// Issue 625 (ADR-0079): `#[derive(Singleton)]` and
-    /// `#[derive(Instanced)]` are the explicit author-side surface
-    /// for cardinality. Trait mutual exclusion is documentation +
-    /// use-site bounds (no sealed-trait enforcement); this smoke
-    /// confirms both derives produce reachable marker impls
-    /// independently.
+    /// ADR-0119: cardinality is derived from the resolver. A keyless
+    /// [`One`] resolver makes the actor a reachable [`Singleton`] via
+    /// the blanket impl — no hand-written `impl Singleton`.
     #[test]
-    fn singleton_derive_emits_marker_impl() {
-        #[derive(crate::Singleton)]
+    fn one_resolver_derives_singleton() {
         struct UniqueCap;
         impl Addressable for UniqueCap {
             const NAMESPACE: &'static str = "test.cardinality.unique";
+            type Resolver = One;
         }
         fn requires_singleton<T: Singleton>() {}
         requires_singleton::<UniqueCap>();
     }
 
+    /// ADR-0119: a keyed [`Many`] resolver makes the actor a reachable
+    /// [`Instanced`] via the blanket impl.
     #[test]
-    fn instanced_derive_emits_marker_impl() {
-        #[derive(crate::Instanced)]
+    fn many_resolver_derives_instanced() {
         struct PerThing;
         impl Addressable for PerThing {
             const NAMESPACE: &'static str = "test.cardinality.per_thing";
+            type Resolver = Many;
         }
         fn requires_instanced<T: Instanced>() {}
         requires_instanced::<PerThing>();
     }
 
-    /// ADR-0099 §5 static default: a root-pinned singleton's [`Singleton::resolve`]
-    /// ignores the caller's carry and returns the depth-1 fixed point —
-    /// the id `mailbox_id_from_name(NAMESPACE)` yields today, so the
-    /// chassis-cap vocabulary stays frozen (§3).
+    /// ADR-0099 §5 / ADR-0119: the [`One`] resolver ignores the caller's
+    /// carry and returns the depth-1 fixed point — the id
+    /// `mailbox_id_from_name(NAMESPACE)` yields today, so the chassis-cap
+    /// vocabulary stays frozen (§3).
     #[test]
-    fn singleton_resolve_default_is_frozen_depth_one() {
+    fn one_resolver_is_frozen_depth_one() {
         struct RootCap;
         impl Addressable for RootCap {
             const NAMESPACE: &'static str = "test.resolve.rootcap";
+            type Resolver = One;
         }
-        impl Singleton for RootCap {}
 
         let frozen = mailbox_id_from_name("test.resolve.rootcap");
         assert_eq!(
-            RootCap::resolve(0),
+            <RootCap as Addressable>::resolve(0, ()),
             frozen,
-            "default resolve is the depth-1 id"
+            "One is the depth-1 id"
         );
         assert_eq!(
-            RootCap::resolve(0xDEAD_BEEF),
+            <RootCap as Addressable>::resolve(0xDEAD_BEEF, ()),
             frozen,
-            "a root cap ignores the caller's carry"
+            "One ignores the caller's carry"
         );
     }
 
-    /// ADR-0099 §5 own-child path: a non-root singleton overrides
-    /// [`Singleton::resolve`] to fold the caller's carry, so the same type
-    /// resolves to a different mailbox under each parent.
+    /// ADR-0099 §5 / ADR-0119: the [`Many`] resolver folds
+    /// `ActorId::instanced(NAMESPACE, subname)` onto the caller's carry, so
+    /// each instance under a parent gets its own id keyed by subname.
     #[test]
-    fn singleton_resolve_override_folds_caller_carry() {
-        struct Child;
-        impl Addressable for Child {
-            const NAMESPACE: &'static str = "test.resolve.child";
-        }
-        impl Singleton for Child {
-            fn resolve(caller_carry: u64) -> MailboxId {
-                MailboxId(with_tag(
-                    Tag::Mailbox,
-                    fold_lineage(
-                        caller_carry,
-                        ActorId::singleton(<Self as Addressable>::NAMESPACE),
-                    ),
-                ))
-            }
-        }
-
-        let carry = 0x1234_5678_u64;
-        let expected = MailboxId(with_tag(
-            Tag::Mailbox,
-            fold_lineage(carry, ActorId::singleton("test.resolve.child")),
-        ));
-        assert_eq!(Child::resolve(carry), expected, "override folds the carry");
-        assert_ne!(
-            Child::resolve(carry),
-            mailbox_id_from_name("test.resolve.child"),
-            "a folded child id differs from the flat depth-1 hash"
-        );
-    }
-
-    /// ADR-0099 §5 instanced default: an [`Instanced`] type's provided
-    /// `resolve` folds its `ActorId::instanced(NAMESPACE, subname)` onto the
-    /// caller's carry — symmetric to the singleton own-child override, but
-    /// keyed by `subname` so each instance under a parent gets its own id.
-    #[test]
-    fn instanced_resolve_default_folds_carry_and_subname() {
+    fn many_resolver_folds_carry_and_subname() {
         struct PerThing;
         impl Addressable for PerThing {
             const NAMESPACE: &'static str = "test.resolve.per_thing";
+            type Resolver = Many;
         }
-        impl Instanced for PerThing {}
 
         let carry = 0x0BAD_F00D_u64;
         let expected = MailboxId(with_tag(
@@ -440,41 +458,14 @@ mod tests {
             fold_lineage(carry, ActorId::instanced("test.resolve.per_thing", "42")),
         ));
         assert_eq!(
-            PerThing::resolve(carry, "42"),
+            <PerThing as Addressable>::resolve(carry, "42"),
             expected,
             "folds carry+subname"
         );
         assert_ne!(
-            PerThing::resolve(carry, "42"),
-            PerThing::resolve(carry, "43"),
+            <PerThing as Addressable>::resolve(carry, "42"),
+            <PerThing as Addressable>::resolve(carry, "43"),
             "different subnames resolve to different mailboxes"
-        );
-    }
-
-    /// ADR-0099 §5/§6: the embedding-host class [`EmbeddedHost`] owns the
-    /// reserved `aether.embedded` namespace and resolves an embedded instance
-    /// by folding `aether.embedded:<name>` onto the host cap's carry. This is
-    /// the fold `aether-capabilities`'s `resolve_embedded` composes (with the
-    /// component-host carry supplied there).
-    #[test]
-    fn embedded_host_folds_under_reserved_namespace() {
-        assert_eq!(EmbeddedHost::NAMESPACE, "aether.embedded");
-
-        // Stand in for the `aether.component` host cap's depth-1 carry.
-        let host_carry = mailbox_id_from_name("aether.component").0;
-        let expected = MailboxId(with_tag(
-            Tag::Mailbox,
-            fold_lineage(host_carry, ActorId::instanced("aether.embedded", "camera")),
-        ));
-        assert_eq!(
-            EmbeddedHost::resolve(host_carry, "camera"),
-            expected,
-            "embeddable id is the host-class fold"
-        );
-        assert_ne!(
-            EmbeddedHost::resolve(host_carry, "camera"),
-            mailbox_id_from_name("camera"),
-            "the fold differs from the bare-NAMESPACE hash (the #1364 miss)"
         );
     }
 }

--- a/crates/aether-actor/src/ffi/ctx.rs
+++ b/crates/aether-actor/src/ffi/ctx.rs
@@ -309,7 +309,7 @@ impl<M: ReplyMode> FfiCtx<'_, M> {
     /// the inline registry the send routes through.
     #[must_use]
     pub fn actor<R: Singleton>(&self) -> FfiActorMailbox<'_, R> {
-        FfiActorMailbox::__new(R::resolve(self.mailbox).0, self.mailbox, self.inline)
+        FfiActorMailbox::__new(R::resolve(self.mailbox, ()).0, self.mailbox, self.inline)
     }
 
     /// Multi-instance sender. Resolve a ctx-bound [`FfiActorMailbox`]
@@ -639,7 +639,7 @@ impl<M: ReplyMode> MailSender for FfiCtx<'_, M> {
     {
         let bytes = payload.encode_into_bytes();
         self.inline.route_or_enqueue(
-            R::resolve(self.mailbox).0,
+            R::resolve(self.mailbox, ()).0,
             K::ID.0,
             &bytes,
             1,
@@ -656,7 +656,7 @@ impl<M: ReplyMode> MailSender for FfiCtx<'_, M> {
     {
         let bytes: &[u8] = bytemuck::cast_slice(payloads);
         self.inline.route_or_enqueue(
-            R::resolve(self.mailbox).0,
+            R::resolve(self.mailbox, ()).0,
             K::ID.0,
             bytes,
             payloads.len() as u32,
@@ -693,7 +693,7 @@ impl<M: ReplyMode> MailSender for FfiCtx<'_, M> {
     {
         let bytes = payload.encode_into_bytes();
         self.inline.route_or_enqueue(
-            R::resolve(self.mailbox).0,
+            R::resolve(self.mailbox, ()).0,
             K::ID.0,
             &bytes,
             1,
@@ -857,7 +857,7 @@ impl MailSender for FfiDropCtx<'_> {
     {
         let bytes = payload.encode_into_bytes();
         mail::send_mail(
-            R::resolve(self.mailbox).0,
+            R::resolve(self.mailbox, ()).0,
             K::ID.0,
             &bytes,
             1,
@@ -874,7 +874,7 @@ impl MailSender for FfiDropCtx<'_> {
     {
         let bytes: &[u8] = bytemuck::cast_slice(payloads);
         mail::send_mail(
-            R::resolve(self.mailbox).0,
+            R::resolve(self.mailbox, ()).0,
             K::ID.0,
             bytes,
             payloads.len() as u32,
@@ -911,7 +911,7 @@ impl MailSender for FfiDropCtx<'_> {
     {
         let bytes = payload.encode_into_bytes();
         mail::send_mail(
-            R::resolve(self.mailbox).0,
+            R::resolve(self.mailbox, ()).0,
             K::ID.0,
             &bytes,
             1,
@@ -952,8 +952,8 @@ mod tests {
         FfiCtx, InlineRegistry, Manual, NO_INBOUND_SOURCE, Single, SpawnError, install_inline_child,
     };
     use crate::Addressable;
+    use crate::actor::Subname;
     use crate::actor::ctx::OutboundReply;
-    use crate::actor::{Instanced, Subname};
     use crate::ffi::inline::RouteDecision;
     use crate::ffi::{BootError, ErasedFfiActor, FfiActor, FfiDropCtx, FfiInitCtx};
     use crate::mail::{Mail, PriorState};
@@ -969,9 +969,8 @@ mod tests {
 
     impl Addressable for FailingChild {
         const NAMESPACE: &'static str = "test.inline.failing_child";
+        type Resolver = crate::Many;
     }
-
-    impl Instanced for FailingChild {}
 
     impl crate::Lifecycle for FailingChild {
         type Config = ();
@@ -1081,9 +1080,8 @@ mod tests {
 
     impl Addressable for SucceedingChild {
         const NAMESPACE: &'static str = "test.inline.succeeding_child";
+        type Resolver = crate::Many;
     }
-
-    impl Instanced for SucceedingChild {}
 
     impl crate::Lifecycle for SucceedingChild {
         type Config = ();

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -65,8 +65,9 @@ pub mod trace_ring;
 pub use actor::ctx::{MailSender, Manual, OutboundReply, Persistence, ReplyMode, Single, Stream};
 pub use actor::slot::Slot;
 pub use actor::{
-    Actor, Addressable, EmbeddedHost, HandlesKind, Instanced, Lifecycle, NAMESPACE_SEGMENT_MAX_LEN,
-    NamespaceError, Singleton, Subname, validate_namespace_segment,
+    Actor, Addressable, EMBEDDED_SCOPE, Embedded, EmbeddedMany, HandlesKind, Instanced, Lifecycle,
+    Many, NAMESPACE_SEGMENT_MAX_LEN, NamespaceError, One, Resolve, Singleton, Subname,
+    validate_namespace_segment,
 };
 pub use local::Local;
 // Issue 665: `Mailbox<K, T>` and `ActorMailbox<'_, R, T>` retired; the
@@ -134,32 +135,18 @@ pub mod __macro_internals {
 /// `aether-actor-derive`; we forward through `aether-data` so the
 /// derive paths the macro emits (`::aether_data::Kind`, etc.)
 /// continue to resolve through the established re-export chain. The
-/// stage-0 additions `#[capability]` (cfg-gates native cap fields)
-/// and `#[derive(Singleton)]` (emits the `Singleton` marker) sit
+/// stage-0 addition `#[capability]` (cfg-gates native cap fields) sits
 /// alongside the existing actor derives so component / capability
 /// authors only need `aether-actor` in their dep list.
 pub use aether_data::{
     Kind, KindId as DataKindId, MailboxId, Schema, actor, bridge, capability, fallback, handler,
     local,
 };
-// `Singleton` and `Instanced` each live in two namespaces:
-//   - the type namespace for the marker trait (`Addressable` super-trait),
-//     re-exported above as part of `actor::*`.
-//   - the macro namespace for the `#[derive(Singleton)]` /
-//     `#[derive(Instanced)]` proc-macros, forwarded through
-//     `aether-data` (which itself re-exports them from
-//     `aether-actor-derive` behind the `derive` feature).
-// Rust resolves derive names from the macro namespace and type names
-// from the type namespace, so the same identifier covers both
-// `impl Singleton for X` / `impl Instanced for X` and the
-// `#[derive(...)]` form without ambiguity at the user's call site.
-// The `#[doc(inline)]` flattens the rustdoc page so the derives show
-// up at `aether_actor::{Singleton, Instanced}` rather than under
-// synthetic re-export shims. Issue 625 (ADR-0079) made the cardinality
-// derives the explicit author-side surface — `#[bridge]` no longer
-// auto-emits either.
-#[doc(inline)]
-pub use aether_data::{Embeddable, Instanced, Singleton};
+// ADR-0119: the `#[derive(Singleton)]` / `#[derive(Instanced)]` /
+// `#[derive(Embeddable)]` proc-macros are retired. Cardinality is the
+// `Addressable::Resolver`, and the `Singleton` / `Instanced` marker traits
+// derive from it by blanket impl — so the only `aether_actor::{Singleton,
+// Instanced}` surface now is the trait (re-exported via `actor::*` above).
 
 /// Wrap one-or-more items in `#[cfg(not(target_arch = "wasm32"))]`.
 /// Issue 552 stage 4's wasm-header-only build of `aether-capabilities`

--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -97,27 +97,29 @@ impl ComponentHostNativeExt for NativeActorMailbox<'_, ComponentHostCapability> 
 }
 
 /// Resolve the [`MailboxId`](aether_data::MailboxId) of the embeddable
-/// component loaded under `name`, by delegating to its embedding-host
-/// **class** (ADR-0099 §5/§6). Folds the class instance node
-/// `aether.embedded:<name>` ([`EmbeddedHost`](aether_actor::EmbeddedHost))
-/// onto the `aether.component` host cap's carry.
+/// component loaded under `name`, by folding the instance node
+/// `aether.embedded:<name>` (the [`Embedded`](aether_actor::Embedded)
+/// resolver) onto the `aether.component` host cap's carry (ADR-0099 §5/§6,
+/// ADR-0119).
 ///
-/// This is the composition behind every embeddable actor's
-/// `Singleton::resolve` override (the `#[derive(Embeddable)]` surface):
-/// it names neither the `aether.component` host nor `aether.embedded`
-/// itself — each namespace is read only from its owner
-/// ([`ComponentHostCapability`] supplies the host carry via its own
-/// `resolve`, [`EmbeddedHost`](aether_actor::EmbeddedHost) supplies the
-/// class node). Equal by construction to the by-name verb
-/// [`loaded::<R>(name)`](ComponentHostFfiExt::loaded), which folds the same
-/// node onto the same carry, so bare-type and by-name addressing agree.
-/// Available on every target — a wasm peer resolves an embeddable the same
-/// way a native one does, no transport branch (ADR-0029 client-side
-/// no-lookup).
+/// This is the by-name carry-supplier. `aether-actor`'s `Embedded` resolver
+/// owns the fold and the reserved scope
+/// ([`EMBEDDED_SCOPE`](aether_actor::EMBEDDED_SCOPE)); this fn supplies the
+/// `aether.component` carry, read only from its owner
+/// [`ComponentHostCapability`]. Equal by construction to a component's own
+/// `type Resolver = Embedded` and to the by-name verb
+/// [`loaded::<R>(name)`](ComponentHostFfiExt::loaded), so bare-type and
+/// by-name addressing agree. Available on every target — a wasm peer resolves
+/// an embeddable the same way a native one does, no transport branch
+/// (ADR-0029 client-side no-lookup).
 #[must_use]
 pub fn resolve_embedded(name: &str) -> aether_data::MailboxId {
-    use aether_actor::{EmbeddedHost, Instanced, Singleton};
-    <EmbeddedHost as Instanced>::resolve(<ComponentHostCapability as Singleton>::resolve(0).0, name)
+    use aether_actor::{Addressable, Embedded, Resolve};
+    Embedded::resolve(
+        <ComponentHostCapability as Addressable>::resolve(0, ()).0,
+        name,
+        (),
+    )
 }
 
 #[aether_actor::bridge(singleton)]

--- a/crates/aether-capabilities/src/render.rs
+++ b/crates/aether-capabilities/src/render.rs
@@ -1400,13 +1400,12 @@ mod native {
         #[allow(clippy::disallowed_methods)]
         #[test]
         fn render_capability_resolves_to_frozen_depth_one_id() {
-            use aether_actor::Singleton;
             use aether_data::mailbox_id_from_name;
 
             let frozen = mailbox_id_from_name(<RenderCapability as Addressable>::NAMESPACE);
-            assert_eq!(<RenderCapability as Singleton>::resolve(0), frozen);
+            assert_eq!(<RenderCapability as Addressable>::resolve(0, ()), frozen);
             assert_eq!(
-                <RenderCapability as Singleton>::resolve(0xFFFF_FFFF_FFFF_FFFF),
+                <RenderCapability as Addressable>::resolve(0xFFFF_FFFF_FFFF_FFFF, ()),
                 frozen,
             );
         }

--- a/crates/aether-capabilities/src/trampoline.rs
+++ b/crates/aether-capabilities/src/trampoline.rs
@@ -182,19 +182,18 @@ mod native {
     #[actor]
     impl NativeActor for WasmTrampoline {
         type Config = WasmTrampolineConfig;
-        /// The embedding-host class namespace (ADR-0099 §5/§6),
-        /// **forward-fed** from [`EmbeddedHost`](aether_actor::EmbeddedHost)
-        /// — the sole owner of the `"aether.embedded"` literal. The
-        /// trampoline references the class const rather than re-declaring
-        /// the name, so an embeddable actor's id depends on what the code
-        /// is, not how it is hosted, and the namespace is written only on
-        /// its owner. Reachable on every target because the bridge stub
-        /// emits the always-on `Addressable` impl at file root. ADR-0097: the
+        /// The embedding-host scope namespace (ADR-0099 §5/§6, ADR-0119),
+        /// **forward-fed** from [`EMBEDDED_SCOPE`](aether_actor::EMBEDDED_SCOPE)
+        /// — `aether-actor`'s sole owner of the `"aether.embedded"` literal.
+        /// The trampoline references the const rather than re-declaring the
+        /// name, so an embeddable actor's id depends on what the code is, not
+        /// how it is hosted, and the namespace is written only on its owner.
+        /// Reachable on every target because the bridge stub emits the
+        /// always-on `Addressable` impl at file root. ADR-0097: the
         /// substrate's `TRAMPOLINE_NAMESPACE` forward-feeds the same const,
         /// collapsing the former two-literal mirror into one source; the
         /// `trampoline_namespace_matches_substrate` test guards the match.
-        const NAMESPACE: &'static str =
-            <aether_actor::EmbeddedHost as aether_actor::Addressable>::NAMESPACE;
+        const NAMESPACE: &'static str = aether_actor::EMBEDDED_SCOPE;
 
         fn init(
             config: WasmTrampolineConfig,
@@ -676,25 +675,24 @@ mod native {
 
     #[cfg(test)]
     mod tests {
-        use aether_actor::{Addressable, EmbeddedHost};
+        use aether_actor::{Addressable, EMBEDDED_SCOPE};
         use aether_substrate::actor::wasm::component::TRAMPOLINE_NAMESPACE;
 
-        /// ADR-0099 §5/§6: both `WasmTrampoline::NAMESPACE` (capabilities)
-        /// and the substrate's `TRAMPOLINE_NAMESPACE` forward-feed the
-        /// embedding-host class const `EmbeddedHost::NAMESPACE` — the sole
-        /// owner of the `"aether.embedded"` literal, which sits below both
-        /// crates. The former two-literal mirror is now one source; this
-        /// guards that the forward-feed stays wired, so an embedded
-        /// component registers under and resolves to the same class
-        /// namespace on both layers.
+        /// ADR-0099 §5/§6, ADR-0119: both `WasmTrampoline::NAMESPACE`
+        /// (capabilities) and the substrate's `TRAMPOLINE_NAMESPACE`
+        /// forward-feed [`EMBEDDED_SCOPE`] — `aether-actor`'s sole owner of
+        /// the `"aether.embedded"` literal, which sits below both crates. The
+        /// former two-literal mirror is now one source; this guards that the
+        /// forward-feed stays wired, so an embedded component registers under
+        /// and resolves to the same scope namespace on both layers.
         #[test]
         fn trampoline_namespace_matches_substrate() {
             assert_eq!(
                 <super::WasmTrampoline as Addressable>::NAMESPACE,
-                EmbeddedHost::NAMESPACE,
+                EMBEDDED_SCOPE,
             );
-            assert_eq!(TRAMPOLINE_NAMESPACE, EmbeddedHost::NAMESPACE);
-            assert_eq!(EmbeddedHost::NAMESPACE, "aether.embedded");
+            assert_eq!(TRAMPOLINE_NAMESPACE, EMBEDDED_SCOPE);
+            assert_eq!(EMBEDDED_SCOPE, "aether.embedded");
         }
     }
 }

--- a/crates/aether-capabilities/tests/embeddable_resolution.rs
+++ b/crates/aether-capabilities/tests/embeddable_resolution.rs
@@ -1,66 +1,71 @@
-//! ADR-0099 §5/§6 — embeddable resolution, the close of
+//! ADR-0099 §5/§6, ADR-0119 — embeddable resolution, the close of
 //! iamacoffeepot/aether#1364.
 //!
-//! A peer that names a loaded component by type (`ctx.actor::<Camera>()`)
-//! resolves it through the **embedding-host class** under the reserved
-//! `aether.embedded` namespace, landing on the mailbox the host registered
-//! it under instead of the bare `hash(NAMESPACE)` that misses. This drives
-//! the mechanism through a fixture; wiring real shipped components (e.g.
-//! `aether-kit`) to expose a peer-nameable marker is follow-up.
+//! A loaded component resolves under the reserved `aether.embedded` scope.
+//! The [`Embedded`] resolver folds the `aether.embedded:<NAMESPACE>` node onto
+//! the caller's carry (ADR-0119 — caller-relative); the by-name verb
+//! [`resolve_embedded`] supplies the `aether.component` host carry, landing on
+//! the mailbox the host registered the component under instead of the bare
+//! `hash(NAMESPACE)` that misses.
 
-// Asserts the host-class fold differs from the bare-NAMESPACE hash — the
-// primitive yields the reference id under test, not a sibling-cap address.
+// Asserts the host-class fold differs from the bare-NAMESPACE hash, and stands
+// in the `aether.component` carry by name — the primitive yields the reference
+// id under test, not a sibling-cap address.
 #![allow(clippy::disallowed_methods)]
 
-use aether_actor::{Addressable, Embeddable, Singleton};
+use aether_actor::{Addressable, Embedded};
 use aether_capabilities::resolve_embedded;
 use aether_data::{mailbox_id_from_name, mailbox_id_from_path};
 
-/// A fixture embeddable — stands in for a loaded wasm component. The
-/// `#[derive(Embeddable)]` surface emits the `Singleton::resolve` override
-/// that delegates to the embedding-host class; the author names no parent
-/// and the macro writes no namespace literal (ADR-0099 §5 read-from-owner).
-#[derive(Embeddable)]
+/// A fixture embeddable — stands in for a loaded wasm component, selecting the
+/// [`Embedded`] resolver (ADR-0119) that `#[actor]` emits for real components.
+/// `Embedded` is keyless, so the fixture is a singleton reached by type.
 struct FixtureComponent;
 
 impl Addressable for FixtureComponent {
     const NAMESPACE: &'static str = "test.embeddable.fixture";
+    type Resolver = Embedded;
 }
 
 #[test]
-fn embeddable_resolves_through_host_class_not_bare_hash() {
-    // An embeddable's address is absolute — rooted at the component host,
-    // not relative to whoever addresses it — so its `resolve` ignores the
-    // caller's lineage carry. A native peer and a wasm peer therefore
-    // compute the same id; there is no transport branch in the fold below.
+fn embeddable_resolves_under_the_host_class() {
+    // The `aether.component` host's carry — its depth-1 mailbox id (ADR-0099
+    // §3), what the trampoline folds embedded children onto. Equal to
+    // `<ComponentHostCapability as Addressable>::resolve(0, ())` (a root
+    // singleton), which is what `resolve_embedded` supplies internally.
+    let host_carry = mailbox_id_from_name("aether.component").0;
+
+    // ADR-0119: the `Embedded` resolver is caller-RELATIVE — it folds the
+    // `aether.embedded:<NAMESPACE>` node onto the caller's carry. Given the host
+    // carry it lands on exactly what the by-name verb `resolve_embedded`
+    // computes, so by-type and by-name addressing agree in the host context.
     assert_eq!(
-        FixtureComponent::resolve(0),
-        FixtureComponent::resolve(0xDEAD_BEEF),
-        "embeddable address is caller-carry-independent",
+        <FixtureComponent as Addressable>::resolve(host_carry, ()),
+        resolve_embedded(FixtureComponent::NAMESPACE),
+        "by-type Embedded resolve (host carry) == resolve_embedded",
     );
 
-    // The derive delegates to the host-class composition.
-    assert_eq!(
-        FixtureComponent::resolve(0),
-        resolve_embedded(FixtureComponent::NAMESPACE),
-        "#[derive(Embeddable)] delegates to resolve_embedded",
+    // A different caller carry resolves to a different mailbox — caller-relative
+    // (the opposite of the old hardcoded-host override).
+    assert_ne!(
+        <FixtureComponent as Addressable>::resolve(0, ()),
+        <FixtureComponent as Addressable>::resolve(0xDEAD_BEEF, ()),
+        "Embedded folds onto the caller carry",
     );
 
     // resolve_embedded folds the rendered lineage
     // `aether.component/aether.embedded:<name>` (ADR-0099 §4/§5) — exactly the
     // id the host registers the loaded component under, and exactly what the
-    // by-name verb `loaded::<R>(name)` computes (it folds the same
-    // `aether.embedded:<name>` node onto the same `aether.component` carry).
+    // by-name verb `loaded::<R>(name)` computes.
     assert_eq!(
         resolve_embedded(FixtureComponent::NAMESPACE),
         mailbox_id_from_path("aether.component/aether.embedded:test.embeddable.fixture"),
         "resolves to the registered [aether.component, aether.embedded:name] fold",
     );
 
-    // The #1364 miss: the bare-NAMESPACE hash lands on a mailbox nothing is
-    // registered under. The host-class fold lands on the registered one.
+    // The #1364 miss: the bare-NAMESPACE hash lands where nothing is registered.
     assert_ne!(
-        FixtureComponent::resolve(0),
+        resolve_embedded(FixtureComponent::NAMESPACE),
         mailbox_id_from_name("test.embeddable.fixture"),
         "the host-class fold differs from the bare hash — the #1364 fix",
     );

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -90,10 +90,7 @@ pub use wire_id::{EngineId, SessionToken, Uuid};
 /// split into a single `aether-actor-derive` proc-macro crate so the
 /// SDK and the derive share a home.
 #[cfg(feature = "derive")]
-pub use aether_actor_derive::{
-    Embeddable, Instanced, Kind, Schema, Singleton, actor, bridge, capability, fallback, handler,
-    local,
-};
+pub use aether_actor_derive::{Kind, Schema, actor, bridge, capability, fallback, handler, local};
 
 /// Re-exported `#[transform]` attribute macro from `aether-data-derive`
 /// (ADR-0048 §1). A transform is a pure `Kind -> Kind` data-layer

--- a/crates/aether-substrate-bundle/src/perf/harness.rs
+++ b/crates/aether-substrate-bundle/src/perf/harness.rs
@@ -161,8 +161,8 @@ pub struct Relay {
 
 impl aether_actor::Addressable for Relay {
     const NAMESPACE: &'static str = "mlat.relay";
+    type Resolver = aether_actor::Many;
 }
-impl aether_actor::Instanced for Relay {}
 impl aether_actor::HandlesKind<Ping> for Relay {}
 impl aether_actor::Lifecycle for Relay {
     type Config = RelayConfig;
@@ -254,8 +254,8 @@ pub struct TickSource {
 
 impl aether_actor::Addressable for TickSource {
     const NAMESPACE: &'static str = "mlat.ticksrc";
+    type Resolver = aether_actor::Many;
 }
-impl aether_actor::Instanced for TickSource {}
 impl aether_actor::HandlesKind<Tick> for TickSource {}
 impl aether_actor::Lifecycle for TickSource {
     /// `(entry, burst)`: the relay-0 mailbox and the number of `Ping`s to

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -1492,7 +1492,7 @@ mod tests {
         /// dispatch.
         #[test]
         fn spawn_instanced_actor_smoke() {
-            use aether_actor::{Addressable as ActorTrait, HandlesKind, Instanced};
+            use aether_actor::{Addressable as ActorTrait, HandlesKind};
             use aether_data::{Kind as DataKind, KindId as DataKindId, mailbox_id_from_name};
             use aether_substrate::{
                 BootError, NativeActor, NativeCtx, NativeDispatch, NativeInitCtx, SpawnError,
@@ -1516,8 +1516,8 @@ mod tests {
             }
             impl ActorTrait for Child {
                 const NAMESPACE: &'static str = "test.spawn.child";
+                type Resolver = aether_actor::Many;
             }
-            impl Instanced for Child {}
             impl HandlesKind<Bump> for Child {}
             impl aether_actor::Lifecycle for Child {
                 type Config = Arc<AtomicU32>;

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -59,8 +59,8 @@ struct RingRelay {
 
 impl aether_actor::Addressable for RingRelay {
     const NAMESPACE: &'static str = "mlat.ring";
+    type Resolver = aether_actor::Many;
 }
-impl aether_actor::Instanced for RingRelay {}
 impl aether_actor::HandlesKind<Ping> for RingRelay {}
 impl aether_actor::Lifecycle for RingRelay {
     type Config = MailboxId;
@@ -111,13 +111,12 @@ struct HoldRelay;
 
 impl aether_actor::Addressable for HoldRelay {
     const NAMESPACE: &'static str = "mlat.hold";
+    // ADR-0119: `Many` (Instanced) lets the bench's `spawn_actor` place it.
+    // `spawn_inherit` no longer requires its worker actor type to be a
+    // Singleton, so the old dual-marker hack is retired — cardinality is now
+    // exactly one resolver.
+    type Resolver = aether_actor::Many;
 }
-// Both markers: `Instanced` lets the bench's `spawn_actor` place it,
-// `Singleton` satisfies `spawn_inherit`'s bound (the worker-thread hold
-// primitive is singleton-oriented). A test fixture only — production
-// actors pick one role.
-impl aether_actor::Instanced for HoldRelay {}
-impl aether_actor::Singleton for HoldRelay {}
 impl aether_actor::HandlesKind<Ping> for HoldRelay {}
 impl aether_actor::Lifecycle for HoldRelay {
     type Config = ();

--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -1129,54 +1129,12 @@ mod tests {
         );
     }
 
-    /// ADR-0099 §5 own-child path through the real `ctx.actor` call site:
-    /// a non-root singleton overrides [`Singleton::resolve`] to fold the
-    /// caller's carry, and `ctx.actor::<R>()` feeds it `self.binding.carry()`.
-    /// A parent at carry `C` addressing this child by bare type lands on
-    /// `fold(C, ActorId::singleton(NAMESPACE))`, not the flat `hash(NAMESPACE)`
-    /// — the miss the lineage fold closes (#1364).
-    #[test]
-    fn ctx_actor_folds_own_child_singleton_onto_caller_carry() {
-        use crate::actor::native::ctx::NativeCtx;
-        use aether_actor::{Addressable, Singleton};
-        use aether_data::{ActorId, Tag, fold_lineage, mailbox_id_from_name, with_tag};
-
-        struct OwnChild;
-        impl Addressable for OwnChild {
-            const NAMESPACE: &'static str = "test.actor_fold.child";
-        }
-        impl Singleton for OwnChild {
-            fn resolve(caller_carry: u64) -> MailboxId {
-                MailboxId(with_tag(
-                    Tag::Mailbox,
-                    fold_lineage(
-                        caller_carry,
-                        ActorId::singleton(<Self as Addressable>::NAMESPACE),
-                    ),
-                ))
-            }
-        }
-
-        let (_registry, mailer) = fresh_substrate();
-        let parent_carry = 0x0BAD_F00D_u64;
-        let transport = Arc::new(NativeBinding::new_for_test(mailer, MailboxId(parent_carry)));
-        let ctx = NativeCtx::new(&transport, Source::NONE, MailId::NONE, MailId::NONE);
-
-        let resolved = ctx.actor::<OwnChild>().mailbox_id();
-        let expected = MailboxId(with_tag(
-            Tag::Mailbox,
-            fold_lineage(parent_carry, ActorId::singleton("test.actor_fold.child")),
-        ));
-        assert_eq!(
-            resolved, expected,
-            "ctx.actor feeds self.carry to Singleton::resolve, folding the own-child node"
-        );
-        assert_ne!(
-            resolved,
-            mailbox_id_from_name("test.actor_fold.child"),
-            "the folded own-child id differs from the flat depth-1 hash"
-        );
-    }
+    // ADR-0119: the per-impl `Singleton::resolve` override (the
+    // "folded-child singleton") is retired — resolution is the chosen
+    // resolver, not an overridable method. `ctx.actor` carry-folding is now
+    // exercised through the `Embedded` resolver (aether-actor's resolve unit
+    // tests + the send-path test below), so the dedicated own-child ctx.actor
+    // test is dropped rather than retargeted.
 
     /// ADR-0099 §5 own-child path through the generic `MailSender::send`
     /// surface: `send::<R>` resolves the receiver through
@@ -1190,30 +1148,26 @@ mod tests {
     fn mailsender_send_routes_through_resolve_not_flat_hash() {
         use crate::actor::native::ctx::NativeCtx;
         use aether_actor::actor::HandlesKind;
-        use aether_actor::{Addressable, MailSender, Singleton};
+        use aether_actor::{Addressable, Embedded, MailSender};
         use aether_data::mailbox_id_from_name;
         use aether_kinds::Tick;
 
         struct Child;
         impl Addressable for Child {
             const NAMESPACE: &'static str = "test.send_fold.child";
-        }
-        impl Singleton for Child {
-            // A carry-dependent target distinct from the flat hash: a different
-            // caller carry resolves to a different mailbox, so a send that lands
-            // here proves the carry was threaded through `resolve` rather than
-            // dropped for `mailbox_id_from_name(NAMESPACE)`. The exact ADR-0099
-            // fold is exercised by aether-actor's own resolve unit tests.
-            fn resolve(caller_carry: u64) -> MailboxId {
-                mailbox_id_from_name(&format!("test.send_fold.child.{caller_carry:x}"))
-            }
+            // ADR-0119: `Embedded` folds the caller carry under the embed
+            // scope, so a different caller carry resolves to a different
+            // mailbox — a carry-dependent target distinct from the flat hash.
+            // A send landing here proves the carry was threaded through
+            // `resolve` rather than dropped for `mailbox_id_from_name`.
+            type Resolver = Embedded;
         }
         impl HandlesKind<Tick> for Child {}
 
         let (registry, mailer) = fresh_substrate();
         let parent_carry = 0x0BAD_F00D_u64;
 
-        let resolved = Child::resolve(parent_carry);
+        let resolved = <Child as Addressable>::resolve(parent_carry, ());
         let flat = mailbox_id_from_name("test.send_fold.child");
         assert_ne!(
             resolved, flat,

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -104,7 +104,7 @@ macro_rules! native_sender_methods {
         pub fn actor<R: Singleton>(&self) -> NativeActorMailbox<'_, R> {
             let (parent, root) = self.outbound_lineage();
             NativeActorMailbox::__new_in_flight(
-                R::resolve(self.binding.carry()).0,
+                R::resolve(self.binding.carry(), ()).0,
                 self.binding,
                 parent,
                 root,
@@ -333,7 +333,11 @@ impl<M: ReplyMode> NativeCtx<'_, M> {
     /// lifetime today.
     pub fn spawn_inherit<A, F>(&self, f: F) -> JoinHandle<()>
     where
-        A: Addressable + Singleton + 'static,
+        // ADR-0119: `A` only supplies `A::NAMESPACE` (thread name) and
+        // parameterizes `InheritCtx<A>` (Addressable-only). The former
+        // `Singleton` bound was incidental, and single-cardinality
+        // enforcement made it block instanced workers — relaxed to Addressable.
+        A: Addressable + 'static,
         F: FnOnce(InheritCtx<A>) + Send + 'static,
     {
         spawn_thread::spawn_inherit::<A, F>(
@@ -1040,7 +1044,7 @@ impl<M: ReplyMode> MailSender for NativeCtx<'_, M> {
     {
         let bytes = payload.encode_into_bytes();
         self.binding.push_envelope_buffered(
-            R::resolve(self.binding.carry()).0,
+            R::resolve(self.binding.carry(), ()).0,
             K::ID.0,
             &bytes,
             1,
@@ -1061,7 +1065,7 @@ impl<M: ReplyMode> MailSender for NativeCtx<'_, M> {
         #[allow(clippy::cast_possible_truncation)]
         let count = payloads.len() as u32;
         self.binding.push_envelope_buffered(
-            R::resolve(self.binding.carry()).0,
+            R::resolve(self.binding.carry(), ()).0,
             K::ID.0,
             bytes,
             count,
@@ -1100,7 +1104,7 @@ impl<M: ReplyMode> MailSender for NativeCtx<'_, M> {
         // ADR-0080 §7: suppress the in-flight lineage so the recipient
         // starts a fresh causal chain (the trait default would inherit).
         self.binding.push_envelope_buffered(
-            R::resolve(self.binding.carry()).0,
+            R::resolve(self.binding.carry(), ()).0,
             K::ID.0,
             &bytes,
             1,
@@ -1245,9 +1249,8 @@ mod tests {
 
     impl Addressable for StubActor {
         const NAMESPACE: &'static str = "test.stub";
+        type Resolver = aether_actor::One;
     }
-
-    impl Singleton for StubActor {}
 
     impl aether_actor::Lifecycle for StubActor {
         type Config = ();

--- a/crates/aether-substrate/src/actor/native/spawn_thread.rs
+++ b/crates/aether-substrate/src/actor/native/spawn_thread.rs
@@ -130,7 +130,7 @@ impl<A: Addressable> MailSender for InheritCtx<A> {
     {
         let bytes = payload.encode_into_bytes();
         self.binding.send_mail_with_lineage(
-            R::resolve(self.binding.carry()).0,
+            R::resolve(self.binding.carry(), ()).0,
             K::ID.0,
             &bytes,
             1,
@@ -151,7 +151,7 @@ impl<A: Addressable> MailSender for InheritCtx<A> {
         #[allow(clippy::cast_possible_truncation)]
         let count = payloads.len() as u32;
         self.binding.send_mail_with_lineage(
-            R::resolve(self.binding.carry()).0,
+            R::resolve(self.binding.carry(), ()).0,
             K::ID.0,
             bytes,
             count,
@@ -213,7 +213,7 @@ impl<A: Addressable> MailSender for RootCtx<A> {
         // No inherited parent / root — each send mints its own chain
         // rooted at the freshly minted `MailId` (sender = A.mailbox).
         self.binding.send_mail_with_lineage(
-            R::resolve(self.binding.carry()).0,
+            R::resolve(self.binding.carry(), ()).0,
             K::ID.0,
             &bytes,
             1,
@@ -233,7 +233,7 @@ impl<A: Addressable> MailSender for RootCtx<A> {
         #[allow(clippy::cast_possible_truncation)]
         let count = payloads.len() as u32;
         self.binding.send_mail_with_lineage(
-            R::resolve(self.binding.carry()).0,
+            R::resolve(self.binding.carry(), ()).0,
             K::ID.0,
             bytes,
             count,
@@ -278,7 +278,9 @@ pub(crate) fn spawn_inherit<A, F>(
     f: F,
 ) -> JoinHandle<()>
 where
-    A: Addressable + Singleton + 'static,
+    // ADR-0119: `A` is used only for `A::NAMESPACE` + `InheritCtx<A>`
+    // (Addressable-only); the former `Singleton` bound was incidental.
+    A: Addressable + 'static,
     F: FnOnce(InheritCtx<A>) + Send + 'static,
 {
     // ADR-0080 §12 / iamacoffeepot/aether#716: acquire the settlement
@@ -339,7 +341,6 @@ mod tests {
     use super::*;
     use std::sync::Mutex;
 
-    use aether_actor::Singleton;
     use aether_data::{KindId, MailboxId};
 
     use crate::handle_store::HandleStore;
@@ -353,9 +354,8 @@ mod tests {
 
     impl Addressable for StubActor {
         const NAMESPACE: &'static str = "test.spawn_thread.stub";
+        type Resolver = aether_actor::One;
     }
-
-    impl Singleton for StubActor {}
 
     #[derive(Clone, Debug)]
     struct CapturedDispatch {

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -177,17 +177,16 @@ pub struct ComponentCtx {
 }
 
 /// The mailbox-name prefix every wasm component (loaded or spawned)
-/// registers under: `aether.embedded:<name>` — the embedding-host class
-/// namespace (ADR-0099 §5/§6). The `spawn_sibling` host fn (ADR-0097)
-/// needs this string to predict a spawned sibling's
+/// registers under: `aether.embedded:<name>` — the embedding-host scope
+/// namespace (ADR-0099 §5/§6, ADR-0119). The `spawn_sibling` host fn
+/// (ADR-0097) needs this string to predict a spawned sibling's
 /// `MailboxId = fold(host_carry, hash("{prefix}:{subname}"))`
 /// synchronously. It **forward-feeds** the sole owner of the literal,
-/// [`EmbeddedHost`](aether_actor::EmbeddedHost), which sits below this
+/// [`EMBEDDED_SCOPE`](aether_actor::EMBEDDED_SCOPE), which sits below this
 /// crate, so substrate and the capabilities-layer `WasmTrampoline` now
 /// reference one const instead of mirroring two literals; capabilities'
 /// `trampoline_namespace_matches_substrate` test guards the match.
-pub const TRAMPOLINE_NAMESPACE: &str =
-    <aether_actor::EmbeddedHost as aether_actor::Addressable>::NAMESPACE;
+pub const TRAMPOLINE_NAMESPACE: &str = aether_actor::EMBEDDED_SCOPE;
 
 /// ADR-0097: a sibling-spawn request the `spawn_sibling` host fn stages
 /// onto [`ComponentCtx`] for the trampoline to drain and execute.

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -1656,8 +1656,8 @@ mod tests {
     struct StubLog;
     impl Addressable for StubLog {
         const NAMESPACE: &'static str = "test.chassis_builder.stub_log";
+        type Resolver = aether_actor::One;
     }
-    impl aether_actor::Singleton for StubLog {}
 
     impl aether_actor::Lifecycle for StubLog {
         type Config = ();
@@ -1779,8 +1779,8 @@ mod tests {
         struct FailingCap;
         impl Addressable for FailingCap {
             const NAMESPACE: &'static str = "test.phase7.failing_cap";
+            type Resolver = aether_actor::One;
         }
-        impl aether_actor::Singleton for FailingCap {}
 
         impl aether_actor::Lifecycle for FailingCap {
             type Config = ();
@@ -1876,8 +1876,8 @@ mod tests {
             }
             impl Addressable for ProbeCap {
                 const NAMESPACE: &'static str = "test.with_actor.probe";
+                type Resolver = aether_actor::One;
             }
-            impl aether_actor::Singleton for ProbeCap {}
             impl HandlesKind<Ping> for ProbeCap {}
 
             impl aether_actor::Lifecycle for ProbeCap {
@@ -2002,8 +2002,8 @@ mod tests {
             }
             impl Addressable for LocalProbe {
                 const NAMESPACE: &'static str = "test.local.probe";
+                type Resolver = aether_actor::One;
             }
-            impl aether_actor::Singleton for LocalProbe {}
             impl HandlesKind<Tick> for LocalProbe {}
 
             // Newtype-per-slot is the Local convention: each
@@ -2106,7 +2106,7 @@ mod tests {
         fn ctx_spawn_child_routes_through_handler() {
             use crate::actor::native::spawn::Subname;
             use crate::mail::registry::MailboxEntry;
-            use aether_actor::{HandlesKind, Instanced};
+            use aether_actor::HandlesKind;
             use aether_data::{Kind, KindId as DataKindId};
             use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 
@@ -2153,8 +2153,8 @@ mod tests {
             }
             impl Addressable for ChildCap {
                 const NAMESPACE: &'static str = "test.spawn_child.child";
+                type Resolver = aether_actor::Many;
             }
-            impl Instanced for ChildCap {}
             impl HandlesKind<Ping> for ChildCap {}
             impl aether_actor::Lifecycle for ChildCap {
                 type Config = Arc<AtomicU32>;
@@ -2191,8 +2191,8 @@ mod tests {
             }
             impl Addressable for ParentCap {
                 const NAMESPACE: &'static str = "test.spawn_child.parent";
+                type Resolver = aether_actor::One;
             }
-            impl aether_actor::Singleton for ParentCap {}
             impl HandlesKind<Hatch> for ParentCap {}
             impl aether_actor::Lifecycle for ParentCap {
                 type Config = (Arc<AtomicU32>, Arc<AtomicU32>);
@@ -2304,7 +2304,7 @@ mod tests {
         fn ctx_shutdown_marks_dead_runs_unwire_tombstones_id() {
             use crate::actor::native::spawn::{SpawnError, Subname};
             use crate::mail::registry::MailboxEntry;
-            use aether_actor::{HandlesKind, Instanced};
+            use aether_actor::HandlesKind;
             use aether_data::{Kind, KindId as DataKindId};
             use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 
@@ -2332,8 +2332,8 @@ mod tests {
             }
             impl Addressable for Closer {
                 const NAMESPACE: &'static str = "test.shutdown.closer";
+                type Resolver = aether_actor::Many;
             }
-            impl Instanced for Closer {}
             impl HandlesKind<Quit> for Closer {}
             impl aether_actor::Lifecycle for Closer {
                 type Config = Arc<AtomicU32>;
@@ -2450,7 +2450,7 @@ mod tests {
         #[test]
         fn chassis_teardown_runs_unwire_for_pooled_spawned_actors() {
             use crate::actor::native::spawn::Subname;
-            use aether_actor::Instanced;
+
             use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 
             struct Quiet {
@@ -2458,8 +2458,8 @@ mod tests {
             }
             impl Addressable for Quiet {
                 const NAMESPACE: &'static str = "test.teardown.quiet";
+                type Resolver = aether_actor::Many;
             }
-            impl Instanced for Quiet {}
             impl aether_actor::Lifecycle for Quiet {
                 type Config = Arc<AtomicU32>;
                 type InitError = BootError;
@@ -2528,7 +2528,7 @@ mod tests {
         #[test]
         fn chassis_teardown_runs_unwire_for_many_pooled_actors() {
             use crate::actor::native::spawn::Subname;
-            use aether_actor::Instanced;
+
             use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 
             struct Quiet {
@@ -2536,8 +2536,8 @@ mod tests {
             }
             impl Addressable for Quiet {
                 const NAMESPACE: &'static str = "test.teardown.quiet_many";
+                type Resolver = aether_actor::Many;
             }
-            impl Instanced for Quiet {}
             impl aether_actor::Lifecycle for Quiet {
                 type Config = Arc<AtomicU32>;
                 type InitError = BootError;
@@ -2607,13 +2607,12 @@ mod tests {
         #[test]
         fn resolve_actor_returns_none_on_type_mismatch() {
             use crate::actor::native::spawn::Subname;
-            use aether_actor::Instanced;
 
             struct Foo;
             impl Addressable for Foo {
                 const NAMESPACE: &'static str = "test.resolve_mismatch.foo";
+                type Resolver = aether_actor::Many;
             }
-            impl Instanced for Foo {}
             impl aether_actor::Lifecycle for Foo {
                 type Config = ();
                 type InitError = BootError;
@@ -2638,8 +2637,8 @@ mod tests {
             struct Bar;
             impl Addressable for Bar {
                 const NAMESPACE: &'static str = "test.resolve_mismatch.bar";
+                type Resolver = aether_actor::Many;
             }
-            impl Instanced for Bar {}
             impl aether_actor::Lifecycle for Bar {
                 type Config = ();
                 type InitError = BootError;
@@ -2697,7 +2696,7 @@ mod tests {
         fn ctx_monitor_fires_notice_at_target_close() {
             use crate::actor::native::spawn::Subname;
             use crate::mail::registry::MailboxEntry;
-            use aether_actor::{HandlesKind, Instanced};
+            use aether_actor::HandlesKind;
             use aether_data::{Kind, KindId as DataKindId};
             use std::sync::Mutex;
             use std::sync::atomic::{AtomicU32, AtomicU64, Ordering as AtomicOrdering};
@@ -2747,8 +2746,8 @@ mod tests {
             struct Target;
             impl Addressable for Target {
                 const NAMESPACE: &'static str = "test.monitor.target";
+                type Resolver = aether_actor::Many;
             }
-            impl Instanced for Target {}
             impl HandlesKind<Quit> for Target {}
             impl aether_actor::Lifecycle for Target {
                 type Config = ();
@@ -2786,8 +2785,8 @@ mod tests {
             }
             impl Addressable for Watcher {
                 const NAMESPACE: &'static str = "test.monitor.watcher";
+                type Resolver = aether_actor::Many;
             }
-            impl Instanced for Watcher {}
             impl HandlesKind<WatchOrder> for Watcher {}
             impl HandlesKind<aether_kinds::MonitorNotice> for Watcher {}
             impl aether_actor::Lifecycle for Watcher {
@@ -2960,7 +2959,7 @@ mod tests {
         fn watcher_close_prunes_targets_forward_index() {
             use crate::actor::native::spawn::Subname;
             use crate::mail::registry::MailboxEntry;
-            use aether_actor::{HandlesKind, Instanced};
+            use aether_actor::HandlesKind;
             use aether_data::{Kind, KindId as DataKindId};
             use std::sync::Mutex;
             use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
@@ -3006,8 +3005,8 @@ mod tests {
             struct Target;
             impl Addressable for Target {
                 const NAMESPACE: &'static str = "test.monitor.target2";
+                type Resolver = aether_actor::Many;
             }
-            impl Instanced for Target {}
             impl aether_actor::Lifecycle for Target {
                 type Config = ();
                 type InitError = BootError;
@@ -3035,8 +3034,8 @@ mod tests {
             }
             impl Addressable for Watcher {
                 const NAMESPACE: &'static str = "test.monitor.watcher2";
+                type Resolver = aether_actor::Many;
             }
-            impl Instanced for Watcher {}
             impl HandlesKind<WatchOrder> for Watcher {}
             impl HandlesKind<Quit> for Watcher {}
             impl aether_actor::Lifecycle for Watcher {
@@ -3177,7 +3176,7 @@ mod tests {
         fn resolve_actor_finds_named_instance_resolve_actors_enumerates() {
             use crate::actor::native::spawn::Subname;
             use crate::mail::registry::MailboxEntry;
-            use aether_actor::{HandlesKind, Instanced};
+            use aether_actor::HandlesKind;
             use aether_data::{Kind, KindId as DataKindId};
             use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 
@@ -3211,8 +3210,8 @@ mod tests {
             }
             impl Addressable for Member {
                 const NAMESPACE: &'static str = "test.resolve.member";
+                type Resolver = aether_actor::Many;
             }
-            impl Instanced for Member {}
             impl HandlesKind<Quit> for Member {}
             impl aether_actor::Lifecycle for Member {
                 type Config = u32;
@@ -3352,7 +3351,7 @@ mod tests {
         fn instanced_can_spawn_grandchild() {
             use crate::actor::native::spawn::Subname;
             use crate::mail::registry::MailboxEntry;
-            use aether_actor::{HandlesKind, Instanced};
+            use aether_actor::HandlesKind;
             use aether_data::{Kind, KindId as DataKindId};
             use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 
@@ -3421,8 +3420,8 @@ mod tests {
             }
             impl Addressable for Grandchild {
                 const NAMESPACE: &'static str = "test.recursive.grandchild";
+                type Resolver = aether_actor::Many;
             }
-            impl Instanced for Grandchild {}
             impl HandlesKind<Ping> for Grandchild {}
             impl aether_actor::Lifecycle for Grandchild {
                 type Config = Arc<AtomicU32>;
@@ -3458,8 +3457,8 @@ mod tests {
             }
             impl Addressable for Parent {
                 const NAMESPACE: &'static str = "test.recursive.parent";
+                type Resolver = aether_actor::Many;
             }
-            impl Instanced for Parent {}
             impl HandlesKind<Hatch> for Parent {}
             impl HandlesKind<Quit> for Parent {}
             impl aether_actor::Lifecycle for Parent {
@@ -3641,7 +3640,7 @@ mod tests {
         #[test]
         fn spawn_actor_runs_wire_once_after_init() {
             use crate::actor::native::spawn::Subname;
-            use aether_actor::Instanced;
+
             use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 
             struct WireSpawnProbe {
@@ -3649,8 +3648,8 @@ mod tests {
             }
             impl Addressable for WireSpawnProbe {
                 const NAMESPACE: &'static str = "test.spawn_wire.probe";
+                type Resolver = aether_actor::Many;
             }
-            impl Instanced for WireSpawnProbe {}
             impl aether_actor::Lifecycle for WireSpawnProbe {
                 type Config = Arc<AtomicU32>;
                 type InitError = BootError;
@@ -3712,8 +3711,8 @@ mod tests {
         }
         impl Addressable for WireProbe {
             const NAMESPACE: &'static str = "test.wire.singleton";
+            type Resolver = aether_actor::One;
         }
-        impl aether_actor::Singleton for WireProbe {}
         impl aether_actor::Lifecycle for WireProbe {
             type Config = Arc<AtomicU32>;
             type InitError = BootError;
@@ -3783,8 +3782,8 @@ mod tests {
         }
         impl Addressable for Pinger {
             const NAMESPACE: &'static str = "test.barrier.pinger";
+            type Resolver = aether_actor::One;
         }
-        impl aether_actor::Singleton for Pinger {}
         impl aether_actor::Lifecycle for Pinger {
             type Config = Arc<AtomicU32>;
             type InitError = BootError;
@@ -3818,8 +3817,8 @@ mod tests {
         }
         impl Addressable for Ponger {
             const NAMESPACE: &'static str = "test.barrier.ponger";
+            type Resolver = aether_actor::One;
         }
-        impl aether_actor::Singleton for Ponger {}
         impl HandlesKind<WireBarrierPing> for Ponger {}
         impl aether_actor::Lifecycle for Ponger {
             type Config = Arc<AtomicU32>;

--- a/crates/aether-substrate/tests/native_actor_macro.rs
+++ b/crates/aether-substrate/tests/native_actor_macro.rs
@@ -77,8 +77,6 @@ struct MacroProbeCap {
     ping_total: Arc<AtomicU32>,
 }
 
-impl aether_actor::Singleton for MacroProbeCap {}
-
 /// Per-cap config — caps without a domain-specific config type
 /// would write `()`, but here we thread shared atomic counters in
 /// so the test can observe each handler's effect.
@@ -651,8 +649,6 @@ struct TaskRouteCap {
     obs: TaskObservations,
 }
 
-impl aether_actor::Singleton for TaskRouteCap {}
-
 #[aether_data::actor]
 impl NativeActor for TaskRouteCap {
     type Config = TaskObservations;
@@ -926,8 +922,6 @@ impl DeferredObs {
 struct DeferredReplyCap {
     obs: DeferredObs,
 }
-
-impl aether_actor::Singleton for DeferredReplyCap {}
 
 #[aether_data::actor]
 impl NativeActor for DeferredReplyCap {

--- a/crates/aether-test-fixtures/bundle/src/inline_child.rs
+++ b/crates/aether-test-fixtures/bundle/src/inline_child.rs
@@ -49,7 +49,7 @@
 #![allow(clippy::unused_self, clippy::needless_pass_by_value)]
 
 use aether_actor::{
-    BootError, FfiActor, FfiCtx, FfiInitCtx, Instanced, Mail, Manual, OutboundReply, Subname, actor,
+    BootError, FfiActor, FfiCtx, FfiInitCtx, Mail, Manual, OutboundReply, Subname, actor,
 };
 use aether_data::MailboxId;
 use aether_test_fixtures_kinds::{
@@ -109,9 +109,7 @@ impl FfiActor for InlineParent {
 /// constructs it in-process).
 pub struct InlineChild;
 
-impl Instanced for InlineChild {}
-
-#[actor]
+#[actor(instanced)]
 impl FfiActor for InlineChild {
     const NAMESPACE: &'static str = "test.inline.child";
 
@@ -164,9 +162,7 @@ pub struct InlineStatefulChild {
     count: u32,
 }
 
-impl Instanced for InlineStatefulChild {}
-
-#[actor]
+#[actor(instanced)]
 impl FfiActor for InlineStatefulChild {
     const NAMESPACE: &'static str = "test.inline.stateful_child";
 
@@ -262,9 +258,7 @@ impl FfiActor for InlineDespawnParent {
 /// not exported (the parent constructs it in-process).
 pub struct InlineDespawnChild;
 
-impl Instanced for InlineDespawnChild {}
-
-#[actor]
+#[actor(instanced)]
 impl FfiActor for InlineDespawnChild {
     const NAMESPACE: &'static str = "test.inline.despawn_child";
 

--- a/crates/aether-test-fixtures/bundle/src/matrix_sweep.rs
+++ b/crates/aether-test-fixtures/bundle/src/matrix_sweep.rs
@@ -36,8 +36,7 @@
 use core::cell::UnsafeCell;
 
 use aether_actor::{
-    BootError, FfiActor, FfiCtx, FfiInitCtx, Instanced, MailboxId, Manual, OutboundReply, Subname,
-    actor,
+    BootError, FfiActor, FfiCtx, FfiInitCtx, MailboxId, Manual, OutboundReply, Subname, actor,
 };
 use aether_test_fixtures_kinds::{
     CollectMatrix, MATRIX_CELL_CHILD_TO_PARENT, MATRIX_CELL_CHILD_TO_SELF,
@@ -191,9 +190,7 @@ impl FfiActor for MatrixParent {
 /// the multi-actor module's type set includes it.
 pub struct MatrixChild;
 
-impl Instanced for MatrixChild {}
-
-#[actor]
+#[actor(instanced)]
 impl FfiActor for MatrixChild {
     const NAMESPACE: &'static str = "test.matrix.child";
 

--- a/crates/aether-test-fixtures/bundle/src/multi_actor.rs
+++ b/crates/aether-test-fixtures/bundle/src/multi_actor.rs
@@ -19,9 +19,7 @@
 // dispatch ABI even when stateless.
 #![allow(clippy::unused_self)]
 
-use aether_actor::{
-    BootError, FfiActor, FfiCtx, FfiInitCtx, Instanced, Mail, MailSender, Subname, actor,
-};
+use aether_actor::{BootError, FfiActor, FfiCtx, FfiInitCtx, Mail, MailSender, Subname, actor};
 use aether_kinds::Ping;
 use aether_test_fixtures_kinds::{TEST_BENCH_OBSERVER_MAILBOX_NAME, TickObserved};
 
@@ -54,9 +52,7 @@ impl FfiActor for RootManager {
 /// entry type's strict receiver.
 pub struct Panel;
 
-impl Instanced for Panel {}
-
-#[actor]
+#[actor(instanced)]
 impl FfiActor for Panel {
     const NAMESPACE: &'static str = "ui.panel";
 

--- a/crates/aether-test-fixtures/bundle/src/stateful_replace.rs
+++ b/crates/aether-test-fixtures/bundle/src/stateful_replace.rs
@@ -21,8 +21,8 @@
 #![allow(clippy::unused_self)]
 
 use aether_actor::{
-    BootError, FfiActor, FfiCtx, FfiDropCtx, FfiInitCtx, Instanced, Mail, Manual, OutboundReply,
-    PriorState, actor,
+    BootError, FfiActor, FfiCtx, FfiDropCtx, FfiInitCtx, Mail, Manual, OutboundReply, PriorState,
+    actor,
 };
 use aether_test_fixtures_kinds::{Bump, CountQuery, CountReport};
 
@@ -77,9 +77,7 @@ impl FfiActor for Counter {
 /// `#[fallback]` so its capability group is observably distinct.
 pub struct Sidecar;
 
-impl Instanced for Sidecar {}
-
-#[actor]
+#[actor(instanced)]
 impl FfiActor for Sidecar {
     const NAMESPACE: &'static str = "stateful.sidecar";
 

--- a/docs/adr/0119-actor-addressing-via-a-resolver-strategy.md
+++ b/docs/adr/0119-actor-addressing-via-a-resolver-strategy.md
@@ -1,7 +1,8 @@
 # ADR-0119: Actor addressing via a Resolver strategy
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-06-18
+- **Accepted:** 2026-06-19 (implementation arc iamacoffeepot/aether#2063 landed)
 
 ## Context
 


### PR DESCRIPTION
Closes #2063.

## Summary

Implements ADR-0119: actor resolution moves onto `Addressable` as a selected `Resolver` strategy. An actor declares one associated type (`type Resolver: Resolve`); `resolve` is declared once and delegates to it; cardinality is *derived* from the resolver's argument shape via supertrait-pinned `Singleton` / `Instanced` markers, rather than declared.

The payoff: embedding stops being a special case. The `EmbeddedHost` ZST phantom and the `#[derive(Embeddable)]` opt-in dissolve into a single `Embedded` resolver plus an `EMBEDDED_SCOPE` const; the embedding fold and reserved scope now live in one place.

## Shape

- **aether-actor** — `Resolve` (GAT `Args<'a>`), the `One` / `Many` / `Embedded` / `EmbeddedMany` resolvers, `EMBEDDED_SCOPE`, and `Addressable::{Resolver, resolve}`; `Singleton` / `Instanced` rebased as derived blanket markers; the `EmbeddedHost` ZST deleted.
- **aether-actor-derive** — `#[actor(singleton|instanced)]` and `#[bridge]` emit `type Resolver` per transport (FFI to `Embedded` / `EmbeddedMany`, native to `One` / `Many`); the `Singleton` / `Instanced` / `Embeddable` derives are retired (cardinality is the resolver now, so a hand-emitted marker would conflict with the blanket).
- **aether-capabilities** — `resolve_embedded` supplies the component-host carry to the `Embedded` fold; `EMBEDDED_SCOPE` forward-fed by the trampoline and the substrate `TRAMPOLINE_NAMESPACE`.
- **ctx / send surface** — routes through `Addressable::resolve`; ~40 hand-written cardinality-marker fixtures convert to `type Resolver`.

## Two design-surface findings (resolved)

- **Single-cardinality is now enforced** (one resolver per type). This exposed an *incidental* `Singleton` bound on `spawn_inherit<A>` — its body uses only `A::NAMESPACE` and `InheritCtx<A>` is `Addressable`-only — relaxed to `Addressable`.
- **`Embedded` is caller-relative** (folds onto the caller's carry; the host context supplies the `aether.component` carry), so the old `embeddable_resolution` test's caller-independence premise is retired and the test rewritten. Inline children (ADR-0114) use `EmbeddedMany`; their resolver is a bound-satisfier, not routing-used — the host folds the `aether.embedded:<subname>` alias.

No wire-format change: resolved `MailboxId`s are byte-identical for every real resolution path.

## Test plan

`scripts/preflight.sh` — fmt + clippy (`-D warnings`) + strict rustdoc + nextest (2164 tests pass) + wasm32 cross-build of all five components (exercises the macro emitting `type Resolver = Embedded` / `EmbeddedMany`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
