### PR TITLE
flake(capabilities): make the hub proxy-connect budget generous and configurable

### DIFF
--- a/crates/aether-capabilities/src/engine/proxy.rs
+++ b/crates/aether-capabilities/src/engine/proxy.rs
@@ -82,12 +82,7 @@ mod proxy_native {
         mailbox_id_from_name(<EngineServer as Addressable>::NAMESPACE)
     }
 
-    /// Total time [`connect_proxy`] keeps retrying a refused dial when
-    /// the proxy just forked the substrate and it may still be coming
-    /// up. Picked to comfortably cover a debug-build headless cold
-    /// start; far longer than a healthy localhost dial needs.
-    const PROXY_CONNECT_RETRY_BUDGET: Duration = Duration::from_secs(5);
-    /// Pause between dial attempts within [`PROXY_CONNECT_RETRY_BUDGET`].
+    /// Pause between dial attempts within the connect budget.
     const PROXY_CONNECT_RETRY_INTERVAL: Duration = Duration::from_millis(50);
 
     /// Init config for [`EngineProxy`]. `engine_id` is the proxy's
@@ -109,11 +104,20 @@ mod proxy_native {
     /// disables the heartbeat (the engine is then only evicted on a
     /// connection-close `Bye`, never on a wedge); `Some` arms the
     /// timer sidecar.
+    ///
+    /// `connect_budget` is the total time the startup dial keeps
+    /// retrying a refused connection while a freshly-forked substrate
+    /// comes up, resolved from the cap's `EngineConfig`. `Some(d)` caps
+    /// the retry at `d`; `None` is the wait-forever sentinel (retry
+    /// until the dial succeeds or hits a terminal error). Only consulted
+    /// when the proxy forked the substrate (`spawned.is_some()`) — an
+    /// adopted substrate is dialed once.
     pub struct EngineProxyConfig {
         pub engine_id: EngineId,
         pub rpc_addr: String,
         pub spawned: Option<Child>,
         pub heartbeat: Option<HeartbeatParams>,
+        pub connect_budget: Option<Duration>,
     }
 
     /// Resolved liveness-heartbeat tuning for one proxy (issue 1339).
@@ -210,19 +214,25 @@ mod proxy_native {
             // (`spawned.is_none()`) is dialed once — a refused
             // connection there is a real error, not a startup race.
             let retry = config.spawned.is_some();
-            let conn =
-                match connect_proxy(&config.rpc_addr, &mailer, self_mailbox, wake_kind, retry) {
-                    Ok(conn) => conn,
-                    Err(e) => {
-                        // The proxy owns the child it was handed — a
-                        // failed boot must not orphan the substrate.
-                        if let Some(mut child) = config.spawned.take() {
-                            let _ = child.kill();
-                            let _ = child.wait();
-                        }
-                        return Err(BootError::Other(Box::new(e)));
+            let conn = match connect_proxy(
+                &config.rpc_addr,
+                &mailer,
+                self_mailbox,
+                wake_kind,
+                retry,
+                config.connect_budget,
+            ) {
+                Ok(conn) => conn,
+                Err(e) => {
+                    // The proxy owns the child it was handed — a
+                    // failed boot must not orphan the substrate.
+                    if let Some(mut child) = config.spawned.take() {
+                        let _ = child.kill();
+                        let _ = child.wait();
                     }
-                };
+                    return Err(BootError::Other(Box::new(e)));
+                }
+            };
 
             tracing::info!(
                 target: "aether_substrate::engine_proxy",
@@ -463,18 +473,22 @@ mod proxy_native {
     /// Dial the substrate's `RpcServerCapability`, building a fresh
     /// `on_frame` wake closure per attempt. When `retry` is set, a
     /// connection-refused / reset error is retried (after a short
-    /// pause) until [`PROXY_CONNECT_RETRY_BUDGET`] elapses — a
-    /// freshly-forked substrate may not have bound its port yet.
-    /// Handshake / frame errors are always terminal: the peer
-    /// answered, just wrongly.
+    /// pause) until the connect `budget` elapses — a freshly-forked
+    /// substrate may not have bound its port yet. `budget` of `None` is
+    /// the wait-forever sentinel: retry until the dial succeeds or hits
+    /// a terminal error. Handshake / frame errors are always terminal:
+    /// the peer answered, just wrongly.
     fn connect_proxy(
         addr: &str,
         mailer: &Arc<Mailer>,
         self_mailbox: MailboxId,
         wake_kind: KindId,
         retry: bool,
+        budget: Option<Duration>,
     ) -> Result<RpcConnection, RpcClientError> {
-        let deadline = Instant::now() + PROXY_CONNECT_RETRY_BUDGET;
+        // `None` budget → no deadline (wait forever); `Some(d)` → stop
+        // retrying once `d` has elapsed.
+        let deadline = budget.map(|d| Instant::now() + d);
         loop {
             // The reader sidecar fires `RpcInboundReady` at the proxy's
             // own mailbox after every inbound frame so
@@ -500,7 +514,8 @@ mod proxy_native {
             ) {
                 Ok(conn) => Ok(conn),
                 Err(e) => {
-                    if retry && is_transient_connect_error(&e) && Instant::now() < deadline {
+                    let within_budget = deadline.is_none_or(|d| Instant::now() < d);
+                    if retry && is_transient_connect_error(&e) && within_budget {
                         thread::sleep(PROXY_CONNECT_RETRY_INTERVAL);
                         continue;
                     }
@@ -830,6 +845,9 @@ mod tests {
                     rpc_addr: format!("127.0.0.1:{port}"),
                     spawned: None,
                     heartbeat: None,
+                    // Adopted substrate (`spawned: None`) is dialed once,
+                    // so the connect budget is inert here.
+                    connect_budget: None,
                 },
             )
             .finish()
@@ -905,6 +923,7 @@ mod tests {
                     rpc_addr: format!("127.0.0.1:{port}"),
                     spawned: None,
                     heartbeat: None,
+                    connect_budget: None,
                 },
             )
             .finish();
@@ -990,6 +1009,7 @@ mod tests {
                     rpc_addr: format!("127.0.0.1:{port}"),
                     spawned: None,
                     heartbeat,
+                    connect_budget: None,
                 },
             )
             .finish()

--- a/crates/aether-capabilities/src/engine/server.rs
+++ b/crates/aether-capabilities/src/engine/server.rs
@@ -110,6 +110,17 @@ mod server_native {
     /// dead. Small N tolerates a transient hiccup / GC pause.
     const DEFAULT_HEARTBEAT_MISS_LIMIT: u32 = 3;
 
+    /// Default total time a freshly-forked substrate's proxy keeps
+    /// retrying its startup dial before giving up (issue 2072). A debug
+    /// cold start fork+exec+bind can stretch well past a healthy
+    /// localhost dial when many substrates come up at once and
+    /// oversubscribe the cores (e.g. a concurrent `FleetBench` fleet), so
+    /// the budget is generous — far longer than a single cold start
+    /// needs, comfortably under the `FleetBench` client's own spawn cap so
+    /// the hub returns a clean `Err` first rather than the client
+    /// tripping its backstop. `0` is the wait-forever sentinel.
+    const DEFAULT_PROXY_CONNECT_BUDGET_SECS: u64 = 30;
+
     /// Resolved engines-cap configuration (ADR-0090, issue 1339): the
     /// liveness-heartbeat tuning plus the hub binary store's layout dir,
     /// disk budget, and bootstrap list (ADR-0115, #1954 — these last three
@@ -149,6 +160,15 @@ mod server_native {
         /// `miss_limit × interval_secs`.
         #[config(default = 3, parse = parse_heartbeat_miss_limit)]
         pub heartbeat_miss_limit: u32,
+        /// Total seconds a freshly-forked substrate's proxy keeps
+        /// retrying its startup dial before the spawn fails
+        /// (`AETHER_HUB_PROXY_CONNECT_BUDGET_SECS` /
+        /// `--hub-proxy-connect-budget-secs`, issue 2072). Generous by
+        /// default so a debug cold start under fork contention isn't
+        /// called dead prematurely; `0` is the wait-forever sentinel
+        /// (retry until the dial succeeds or hits a terminal error).
+        #[config(default = 30, parse = parse_proxy_connect_budget_secs)]
+        pub proxy_connect_budget_secs: u64,
         /// Layout-root override for the hub's content-addressed binary
         /// store (`AETHER_BINARY_STORE_DIR`, unprefixed — the ops escape
         /// hatch and the fleet tests' per-process isolation knob). Unset
@@ -194,6 +214,11 @@ mod server_native {
             Self {
                 heartbeat_interval_secs: 0,
                 heartbeat_miss_limit: 0,
+                // A real budget (not the heartbeat's inert `0`): tests fork
+                // real substrates, so the proxy needs a generous-but-finite
+                // startup-dial budget — `0` would mean wait-forever and
+                // hang on a genuinely dead substrate.
+                proxy_connect_budget_secs: DEFAULT_PROXY_CONNECT_BUDGET_SECS,
                 binary_store_dir: None,
                 binary_disk_budget_bytes: DEFAULT_DISK_BUDGET_BYTES,
                 binary_bootstrap: HashSet::new(),
@@ -213,6 +238,14 @@ mod server_native {
                     miss_limit: self.heartbeat_miss_limit,
                 })
             }
+        }
+
+        /// The startup-dial connect budget to arm each spawned proxy
+        /// with (issue 2072). `Some(d)` caps the retry; `None` (the `0`
+        /// sentinel) means wait forever.
+        fn connect_budget(&self) -> Option<Duration> {
+            (self.proxy_connect_budget_secs != 0)
+                .then(|| Duration::from_secs(self.proxy_connect_budget_secs))
         }
     }
 
@@ -234,6 +267,14 @@ mod server_native {
         Ok(s.trim().parse().unwrap_or(DEFAULT_HEARTBEAT_MISS_LIMIT))
     }
 
+    /// Parse the proxy connect budget seconds; unparseable → the default.
+    #[allow(clippy::unnecessary_wraps)]
+    fn parse_proxy_connect_budget_secs(s: &str) -> Result<u64, Infallible> {
+        Ok(s.trim()
+            .parse()
+            .unwrap_or(DEFAULT_PROXY_CONNECT_BUDGET_SECS))
+    }
+
     /// Parse the binary-store disk budget; unparseable → the default
     /// `DEFAULT_DISK_BUDGET_BYTES` (mirrors the heartbeat parsers).
     #[allow(clippy::unnecessary_wraps)]
@@ -251,6 +292,43 @@ mod server_native {
             .filter(|p| !p.is_empty())
             .map(str::to_string)
             .collect())
+    }
+
+    #[cfg(test)]
+    mod config_tests {
+        use super::*;
+
+        /// The connect budget resolves a non-zero seconds value to a
+        /// finite `Duration`, and `0` to the wait-forever sentinel `None`.
+        #[test]
+        fn connect_budget_maps_zero_to_wait_forever() {
+            let finite = EngineConfig {
+                proxy_connect_budget_secs: 12,
+                ..EngineConfig::default()
+            };
+            assert_eq!(finite.connect_budget(), Some(Duration::from_secs(12)));
+            let forever = EngineConfig {
+                proxy_connect_budget_secs: 0,
+                ..EngineConfig::default()
+            };
+            assert_eq!(forever.connect_budget(), None);
+        }
+
+        /// The default budget is generous and finite — never the
+        /// wait-forever sentinel — so a debug cold start under fork
+        /// contention isn't called dead prematurely, while a genuinely
+        /// dead substrate still fails the spawn rather than hanging.
+        #[test]
+        fn default_connect_budget_is_generous_and_finite() {
+            let budget = EngineConfig::default()
+                .connect_budget()
+                .expect("default budget is finite, not wait-forever");
+            assert_eq!(
+                budget,
+                Duration::from_secs(DEFAULT_PROXY_CONNECT_BUDGET_SECS)
+            );
+            assert!(budget >= Duration::from_secs(30), "default stays generous");
+        }
     }
 
     /// How many recently-died engines [`EngineServer`] retains for
@@ -303,6 +381,10 @@ mod server_native {
         /// (issue 1339), resolved once from [`EngineConfig`] at init.
         /// `None` disables the heartbeat fleet-wide.
         heartbeat: Option<HeartbeatParams>,
+        /// Startup-dial connect budget each spawned proxy is armed with
+        /// (issue 2072), resolved once from [`EngineConfig`] at init.
+        /// `Some(d)` caps the retry; `None` is the wait-forever sentinel.
+        connect_budget: Option<Duration>,
         /// Bounded ring of the last [`RECENTLY_DIED_CAP`] engines that
         /// left the table and why (issue 1906). `on_terminate` /
         /// `on_engine_died` push a [`DeadRecord`] at the removal site;
@@ -349,6 +431,7 @@ mod server_native {
                 next_engine_seq: 1,
                 mailer: ctx.mailer(),
                 heartbeat: config.heartbeat_params(),
+                connect_budget: config.connect_budget(),
                 recently_died: VecDeque::new(),
                 store,
             })
@@ -505,6 +588,7 @@ mod server_native {
                         rpc_addr,
                         spawned: Some(child),
                         heartbeat: self.heartbeat,
+                        connect_budget: self.connect_budget,
                     },
                 )
                 .finish();

--- a/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
@@ -82,11 +82,13 @@ const READ_REARM: Duration = Duration::from_secs(2);
 
 /// Default cold-start backstop (seconds): the budget the `spawn_headless`
 /// `SpawnEngine` call allows for the hub to fork the substrate, dial it
-/// (the hub retries the refused connection up to its own
-/// `PROXY_CONNECT_RETRY_BUDGET`), and reply once the proxy connects — so
-/// the `SpawnEngineResult::Ok` reply *is* the explicit port-readiness
-/// signal. Generous over a debug-build cold start under CPU pressure;
-/// overridable via `AETHER_FLEETBENCH_SPAWN_CAP_SECS`.
+/// (the hub retries the refused connection up to its own configurable
+/// `AETHER_HUB_PROXY_CONNECT_BUDGET_SECS`), and reply once the proxy
+/// connects — so the `SpawnEngineResult::Ok` reply *is* the explicit
+/// port-readiness signal. Kept comfortably above the hub's connect budget
+/// so the hub returns a clean `Err` first rather than the client tripping
+/// this backstop. Generous over a debug-build cold start under CPU
+/// pressure; overridable via `AETHER_FLEETBENCH_SPAWN_CAP_SECS`.
 const DEFAULT_SPAWN_CAP_SECS: u64 = 60;
 
 /// Default reply backstop (seconds): the deadlock/livelock cap a settled


### PR DESCRIPTION
## What

The hub's proxy startup-dial budget was a hard-coded `PROXY_CONNECT_RETRY_BUDGET = 5s` const in `engine/proxy.rs`. When the engines cap forks a substrate, the proxy retries the refused dial for up to 5s while the process binds its RPC port, then replies `SpawnEngineResult::Err(ConnectionRefused)` once the budget exhausts.

This replaces the const with an `EngineConfig` knob on the ADR-0090 derive-Config path:

- `proxy_connect_budget_secs` — resolved argv > env > default (`AETHER_HUB_PROXY_CONNECT_BUDGET_SECS` / `--hub-proxy-connect-budget-secs`), the same path the `heartbeat_*` fields take.
- Default **30s** — generous over a debug cold start under fork contention, comfortably under the FleetBench client's 60s spawn cap so the hub returns a clean `Err` first rather than the client tripping its backstop.
- `0` is the **wait-forever sentinel** (retry until the dial succeeds or hits a terminal error), mirroring the philosophy of #2062 / #2064.

The budget resolves once at `EngineServer::init` and arms each spawned proxy through `EngineProxyConfig`, threading the same way `HeartbeatParams` already does.

## Why

Five seconds covers a lone cold start but is a wall-clock gate a debug fork+exec+bind blows past when many substrates come up at once and oversubscribe the cores. Surfaced while verifying the #2062 arc: running the `mod heavy` set concurrently (the #2065 gate) failed 7 FleetBench spawn-path tests, all at ~9-10s, all `proxy failed to connect to the spawned substrate: InitFailed(...ConnectionRefused)`. The FleetBench client-side re-arm from #2064 waited patiently; the failure was hub-side, `connect_proxy` giving up at 5s. `serial-heavy` had been masking this second contention source, independent of the settlement-wait flake #2062 fixed. This is the production-code follow-up flagged in #2064's side findings.

## Verification

- Re-ran the `mod heavy` set concurrently (serialization removed locally): the `ConnectionRefused` class is eliminated (7 failing → 0).
- Added a fast unit test of the seconds → `Duration` + `0` → wait-forever mapping, and that the default budget stays generous and finite.
- Full `scripts/preflight.sh` green.

## Arc

PR 4 of the arc rooted at #2062. **#2065** (retire `serial-heavy`) lands after this — and, per a finding recorded there, will also need a per-test `slow-timeout` accommodation, since concurrent FleetBench tests run 45-60s each and the heaviest tips the `ci` 60s `terminate-after` kill.

Closes #2072

🤖 Generated with [Claude Code](https://claude.com/claude-code)
