### PR TITLE
refactor(actor): invert the guest log subscriber onto a target-blind sink seam

### DIFF
--- a/crates/aether-actor/src/ffi/bridge/mail.rs
+++ b/crates/aether-actor/src/ffi/bridge/mail.rs
@@ -137,8 +137,9 @@ pub fn prev_correlation() -> u64 {
 /// returning; the guest's borrows are released as soon as the
 /// FFI call completes.
 ///
-/// Only callable from wasm32 — the only caller (`crate::log::WasmSubscriber`)
-/// is gated behind `#[cfg(target_arch = "wasm32")]`.
+/// Only callable from wasm32 — installed as the [`crate::log::LogSink`]
+/// by the guest runtime (`export!`) and invoked from
+/// [`crate::log::ForwardingSubscriber::event`].
 #[cfg(target_arch = "wasm32")]
 pub fn emit_log_event(level: u8, target: &str, message: &str) {
     let target_bytes = target.as_bytes();

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -271,6 +271,22 @@ pub fn stage_init_failure(message: &str) {
     }
 }
 
+/// Guest-runtime log install (wasm32). Wires the FFI sink
+/// (`bridge::mail::emit_log_event`) into the target-blind
+/// [`crate::log`] forwarding seam, then sets the forwarding subscriber
+/// as `tracing`'s global default. Called from the `export!` prologue
+/// before the guest's `init` runs. This is the only wasm-specific log
+/// glue — `bridge::mail` is `pub(crate)`, so the sink can only be wired
+/// from inside the crate; the subscriber itself stays target-blind in
+/// [`crate::log`]. Shared by the `export!` shims so the wiring isn't
+/// repeated per init shim.
+#[cfg(target_arch = "wasm32")]
+#[doc(hidden)]
+pub fn install_guest_logging() {
+    crate::log::install_log_sink(bridge::mail::emit_log_event);
+    crate::log::install_forwarding_subscriber();
+}
+
 /// Generic guest allocator backing host→guest payload delivery (ADR-0095).
 ///
 /// The substrate writes every inbound payload — mail, init config, rehydrate
@@ -594,7 +610,7 @@ macro_rules! __export_internal {
             config_ptr: u32,
             config_len: u32,
         ) -> u32 {
-            $crate::log::install_wasm_subscriber();
+            $crate::ffi::install_guest_logging();
             // Build the config slice. Empty-len short-circuits to `&[]`
             // so a null/zero `config_ptr` is not dereferenced — mirrors
             // `PriorState::bytes`.
@@ -1085,7 +1101,7 @@ macro_rules! __export_multi_internal {
             config_ptr: u32,
             config_len: u32,
         ) -> u32 {
-            $crate::log::install_wasm_subscriber();
+            $crate::ffi::install_guest_logging();
             let config_bytes: &[u8] = if config_len == 0 {
                 &[]
             } else {
@@ -1119,7 +1135,7 @@ macro_rules! __export_multi_internal {
             config_ptr: u32,
             config_len: u32,
         ) -> u32 {
-            $crate::log::install_wasm_subscriber();
+            $crate::ffi::install_guest_logging();
             let config_bytes: &[u8] = if config_len == 0 {
                 &[]
             } else {

--- a/crates/aether-actor/src/ffi/raw.rs
+++ b/crates/aether-actor/src/ffi/raw.rs
@@ -73,7 +73,8 @@ unsafe extern "C" {
     pub fn init_failed(ptr: u32, len: u32);
     /// ADR-0081 §7: re-emit one `tracing::*` event on the host side
     /// so the trampoline's `ActorAwareLayer` lands it in this guest's
-    /// per-actor `ActorLogRing`. Called by `WasmSubscriber::event`
+    /// per-actor `ActorLogRing`. Called from `ForwardingSubscriber::event`
+    /// (via the installed `crate::log::LogSink`)
     /// per event. `level` follows the `0 = trace .. 4 = error`
     /// mapping the rest of `aether.log.*` uses. `target_ptr/len` and
     /// `message_ptr/len` are byte slices in guest memory; the host

--- a/crates/aether-actor/src/log.rs
+++ b/crates/aether-actor/src/log.rs
@@ -30,16 +30,18 @@ use core::fmt::Write as _;
 
 use aether_kinds::{LogEntry, LogTail, LogTailResult};
 use tracing::{
-    Event, Level,
+    Event, Level, Subscriber,
+    dispatcher::{Dispatch, set_global_default},
     field::{Field, Visit},
+    span,
 };
-// Wasm-only `tracing` imports needed by [`WasmSubscriber`]'s
-// `Subscriber` impl.
-#[cfg(target_arch = "wasm32")]
-use tracing::{Subscriber, span};
 
 use crate::Local;
+use crate::local::install_static_backend;
 use core::fmt;
+use core::mem::transmute;
+use core::ptr;
+use core::sync::atomic::{AtomicBool, AtomicPtr, AtomicU64, Ordering};
 
 /// Default per-actor ring capacity. Overridable at substrate boot
 /// via `AETHER_ACTOR_LOG_RING_SIZE` — the substrate parses the env
@@ -316,47 +318,80 @@ fn truncate(mut s: String) -> String {
     s
 }
 
-/// Wasm-side tracing subscriber. Each `tracing::*` event the guest
-/// fires walks through this subscriber's `event()` and rides the
-/// trampoline's per-event FFI host fn back into the host process,
-/// where the host-side `ActorAwareLayer` lands it in the
-/// trampoline's [`ActorLogRing`]. ADR-0081 §7 — the previous
-/// guest-side `LogBuffer` + `drain_buffer` + `LogBatch` flush hop
-/// retired alongside this rewrite.
-#[cfg(target_arch = "wasm32")]
-pub struct WasmSubscriber {
-    next_span: core::sync::atomic::AtomicU64,
+/// Process-global log sink: a non-capturing `fn` the driver installs
+/// once, stored behind an `AtomicPtr` so the cell is `no_std`-safe and
+/// `Sync`. Mirrors `local::SLOTS_PROVIDER` — set once with `Release`,
+/// read with `Acquire`. Null until installed; an event fired before
+/// install is dropped rather than forwarded.
+pub type LogSink = fn(level: u8, target: &str, message: &str);
+
+static LOG_SINK: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
+
+/// Install the process-global log sink. Set-once: the first install
+/// wins and later ones are ignored. The driver installs the target-
+/// specific forwarder — the wasm guest passes
+/// `ffi::bridge::mail::emit_log_event` (wasm32-only); a future C /
+/// OS-process host installs its own. This is the seam that keeps this
+/// module target-blind (issue #2078, mirroring `local.rs` #2070).
+pub fn install_log_sink(sink: LogSink) {
+    // A `fn` pointer casts cleanly to a thin data pointer; `current_sink`
+    // transmutes it back (pointer → `fn` is not a plain cast).
+    let raw: *mut () = sink as *mut ();
+    let _ = LOG_SINK.compare_exchange(ptr::null_mut(), raw, Ordering::Release, Ordering::Relaxed);
 }
 
-#[cfg(target_arch = "wasm32")]
-impl WasmSubscriber {
+/// Read the installed sink, or `None` before any install.
+#[inline]
+fn current_sink() -> Option<LogSink> {
+    let raw = LOG_SINK.load(Ordering::Acquire);
+    if raw.is_null() {
+        return None;
+    }
+    // SAFETY: `LOG_SINK` only ever holds a `LogSink` cast to a thin
+    // pointer by `install_log_sink`; this reconstructs it. A data
+    // pointer → `fn` pointer is not a plain cast, so `transmute` is
+    // required.
+    Some(unsafe { transmute::<*mut (), LogSink>(raw) })
+}
+
+/// Target-blind `tracing` subscriber: renders each event via
+/// [`render_event`] and forwards `(level, target, message)` to the
+/// installed [`LogSink`]. The guest runtime sets it as `tracing`'s
+/// global default and installs the FFI sink, so each guest event rides
+/// the trampoline's per-event host fn into the host process, where the
+/// host-side `ActorAwareLayer` lands it in the trampoline's
+/// [`ActorLogRing`] (ADR-0081 §7). The host installs its own subscriber
+/// stack and never sets this one. Issue #2078 made this target-blind —
+/// the wasm-specificity now lives only in the installed sink.
+pub struct ForwardingSubscriber {
+    next_span: AtomicU64,
+}
+
+impl ForwardingSubscriber {
+    #[must_use]
     pub const fn new() -> Self {
         Self {
-            next_span: core::sync::atomic::AtomicU64::new(1),
+            next_span: AtomicU64::new(1),
         }
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-impl Default for WasmSubscriber {
+impl Default for ForwardingSubscriber {
     fn default() -> Self {
         Self::new()
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-impl Subscriber for WasmSubscriber {
+impl Subscriber for ForwardingSubscriber {
     fn enabled(&self, _metadata: &tracing::Metadata<'_>) -> bool {
-        // Filtering happens on the substrate side; the wasm
-        // subscriber forwards everything so the host's `EnvFilter`
-        // sees the guest's reported target.
+        // Filtering happens on the substrate side; the forwarder
+        // forwards everything so the host's `EnvFilter` sees the
+        // reported target.
         true
     }
 
     fn new_span(&self, _attrs: &span::Attributes<'_>) -> span::Id {
-        let id = self
-            .next_span
-            .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+        let id = self.next_span.fetch_add(1, Ordering::Relaxed);
         span::Id::from_u64(id.max(1))
     }
 
@@ -366,32 +401,31 @@ impl Subscriber for WasmSubscriber {
     fn exit(&self, _: &span::Id) {}
 
     fn event(&self, event: &Event<'_>) {
-        let (level, target, message) = render_event(event);
-        crate::ffi::bridge::mail::emit_log_event(level, &target, &message);
+        if let Some(sink) = current_sink() {
+            let (level, target, message) = render_event(event);
+            sink(level, &target, &message);
+        }
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-static WASM_INSTALLED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+static SUBSCRIBER_INSTALLED: AtomicBool = AtomicBool::new(false);
 
-/// Install the wasm-side actor-aware subscriber as `tracing`'s
-/// global default. Called from the `export!` macro before the
-/// guest's `Component::init` runs (so logging from `init` works).
-/// Idempotent.
-#[cfg(target_arch = "wasm32")]
-pub fn install_wasm_subscriber() {
-    use core::sync::atomic::Ordering;
-    // Install the single-actor static slot backend before the subscriber is
-    // set: the subscriber pushes into the per-actor `ActorLogRing` (a
-    // `Local`) on its first event, so the slots provider must be live first
-    // (iamacoffeepot/aether#2070). Set-once, so a repeat call is a no-op.
-    crate::local::install_static_backend();
-    if WASM_INSTALLED.swap(true, Ordering::SeqCst) {
+/// Install the [`ForwardingSubscriber`] as `tracing`'s global default.
+/// Called from the `export!` macro before the guest's `init` runs (so
+/// logging from `init` works). Also installs the single-actor static
+/// `Local` backend the guest's per-actor slots need (#2070) — set
+/// before the subscriber so a first-event `Local` access has a live
+/// provider. Idempotent. Target-blind, but only the guest runtime calls
+/// it; the host installs its own subscriber stack.
+pub fn install_forwarding_subscriber() {
+    // Install the single-actor static slot backend before the subscriber
+    // is set, so a first-event `Local` access resolves (#2070). Set-once,
+    // so a repeat call is a no-op.
+    install_static_backend();
+    if SUBSCRIBER_INSTALLED.swap(true, Ordering::SeqCst) {
         return;
     }
-    let _ = tracing::dispatcher::set_global_default(tracing::dispatcher::Dispatch::new(
-        WasmSubscriber::new(),
-    ));
+    let _ = set_global_default(Dispatch::new(ForwardingSubscriber::new()));
 }
 
 /// `aether::log_trace!("msg")` — equivalent to `tracing::trace!`.

--- a/crates/aether-substrate/src/actor/wasm/host_fns.rs
+++ b/crates/aether-substrate/src/actor/wasm/host_fns.rs
@@ -541,7 +541,8 @@ pub fn register(linker: &mut Linker<ComponentCtx>) -> wasmtime::Result<()> {
     )?;
 
     // ADR-0081 §7: `log_event_p32` re-fires a guest `tracing::*` event
-    // on the host side. `WasmSubscriber::event` calls this per event
+    // on the host side. `ForwardingSubscriber::event` calls this (via the
+    // installed log sink) per event
     // (no buffer, no flush hop — the pre-ADR-0081 `LogBatch` route
     // retired alongside `LogCapability`). The host re-emits via
     // `emit_host_event` on the trampoline's dispatcher thread, where


### PR DESCRIPTION
Closes #2078.

## Summary

`aether-actor::log` should name no target, but it carried the wasm guest subscriber: `WasmSubscriber` (a `tracing::Subscriber` impl), `WASM_INSTALLED`, and `install_wasm_subscriber()` behind `#[cfg(target_arch = "wasm32")]`, with the dependency running backwards (the target-blind log module reaching into `ffi::bridge::mail::emit_log_event`).

This applies the `local.rs` inversion (#2070): collapse the wasm-specificity into an installed fn pointer so there is no wasm-specific type to home.

- `log.rs` is now fully target-blind — a `ForwardingSubscriber` that renders via `render_event` and forwards each event to an installed `LogSink`, plus an `install_log_sink` seam mirroring `local::install_slots_provider`. **Zero `#[cfg(target_arch = "wasm32")]`** in the module.
- The guest runtime installs the FFI forwarder. Because `ffi::bridge::mail` is `pub(crate)`, the wiring can't be inlined into the `export!` expansion (which runs in the guest crate); a minimal `#[cfg(wasm32)] ffi::install_guest_logging()` wires `emit_log_event` into the seam in-crate and the `export!` prologue calls it. `emit_log_event` stays the wasm FFI op it already was, where it already was.

Net effect: aether-actor's `#[cfg(target_arch = "wasm32")]` count drops **48 → 41**. No wire / ABI change — the `log_event` FFI op and link-section names are untouched; behaviour and the #2070 `install_static_backend` guest install are preserved. The change corrects the dependency direction: the concrete implementation installs *into* the target-blind core, never the reverse.

## Test plan

`scripts/preflight.sh` green: fmt + clippy (`-D warnings`) + doc (strict rustdoc) + the wasm32 component cross-build (5 components — the real proof the guest forwarding path links through `install_guest_logging`) + `cargo nextest` (2187 passed).

## Generated by

`/implement` — execution of [issue #2078](https://github.com/iamacoffeepot/aether/issues/2078).
