### PR TITLE
flake(substrate-bundle): give fleetbench fork tests a generous shared poll budget

### DIFF
--- a/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
@@ -131,6 +131,47 @@ fn spawn_cap() -> Duration {
     ))
 }
 
+/// Interval between [`poll_until`] attempts — short enough to settle
+/// promptly, long enough not to busy-spin while a forked engine boots.
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Default in-test poll budget (seconds): how long a registration /
+/// liveness wait — a forked engine appearing in `ListEngines`, a
+/// boot-manifest component registering, a log entry surfacing — is
+/// given before it is called a failure. Generous over a debug-build
+/// cold start under a saturated `nextest --workspace` run, the same
+/// CPU-pressure regime [`DEFAULT_SPAWN_CAP_SECS`] covers, so a
+/// slow-but-healthy fork that registers late is not called dead.
+/// Overridable via `AETHER_FLEETBENCH_POLL_SECS`.
+const DEFAULT_POLL_SECS: u64 = 30;
+
+/// Resolve the in-test poll budget from `AETHER_FLEETBENCH_POLL_SECS`
+/// (default [`DEFAULT_POLL_SECS`]; `0` → wait forever).
+fn poll_budget() -> Duration {
+    cap_from_secs(env_secs("AETHER_FLEETBENCH_POLL_SECS", DEFAULT_POLL_SECS))
+}
+
+/// Poll `predicate` every [`POLL_INTERVAL`] until it returns `true` or
+/// the [`poll_budget`] elapses; returns whether it became true. Replaces
+/// the per-test `for _ in 0..N { … sleep }` loops whose fixed iteration
+/// counts flake under CI contention: the budget is wall-clock and
+/// generous, so a starved fork that registers late still passes, while a
+/// genuinely dead one still fails within the bound. `predicate` is
+/// `FnMut` so a caller can capture the matched value out through it.
+pub fn poll_until(mut predicate: impl FnMut() -> bool) -> bool {
+    let budget = poll_budget();
+    let start = Instant::now();
+    loop {
+        if predicate() {
+            return true;
+        }
+        if start.elapsed() >= budget {
+            return false;
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
 /// Read a `u64` seconds knob from the environment, falling back to
 /// `default` when unset or unparseable — a test harness tolerates a
 /// typo'd override rather than aborting the run.

--- a/crates/aether-substrate-bundle/tests/fleetbench_component_store.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_component_store.rs
@@ -11,8 +11,7 @@ mod tests {
     use std::env;
     use std::fs;
     use std::process;
-    use std::thread;
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     use aether_actor::Addressable;
     use aether_capabilities::WasmTrampoline;
@@ -22,7 +21,7 @@ mod tests {
         UploadComponentResult,
     };
 
-    use crate::fleetbench::{FleetBench, component_wasm_path, dist_manifest_present};
+    use crate::fleetbench::{FleetBench, component_wasm_path, dist_manifest_present, poll_until};
 
     /// The probe fixture's declared `Addressable::NAMESPACE` (distinct from the
     /// `probe` wasm stem).
@@ -280,14 +279,8 @@ mod tests {
         // exactly when it is loaded and registered — no log-ring side channel
         // and no racing a fixed liveness budget.
         let expected = probe_lineage_addr();
-        let mut registered = false;
-        for _ in 0..30 {
-            if bench.list_components(engine).iter().any(|n| n == &expected) {
-                registered = true;
-                break;
-            }
-            thread::sleep(Duration::from_millis(100));
-        }
+        let registered =
+            poll_until(|| bench.list_components(engine).iter().any(|n| n == &expected));
         assert!(
             registered,
             "the boot-manifest probe should come up and register at {expected}",

--- a/crates/aether-substrate-bundle/tests/fleetbench_logs.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_logs.rs
@@ -7,20 +7,9 @@
 mod fleetbench;
 
 mod tests {
-    use std::thread;
-    use std::time::Duration;
-
     use aether_kinds::LogTailResult;
 
-    use crate::fleetbench::{FleetBench, dist_manifest_present};
-
-    /// Up to ~3s of bounded polling closes the wire→first-tick race:
-    /// the headless chassis auto-ticks at 60Hz, so the probe's first
-    /// tick (which emits the entry) fires within a few frames of
-    /// `wire`, and the lone entry is never evicted from a 100-slot
-    /// ring.
-    const POLL_ATTEMPTS: usize = 30;
-    const POLL_INTERVAL: Duration = Duration::from_millis(100);
+    use crate::fleetbench::{FleetBench, dist_manifest_present, poll_until};
 
     /// `info` in the `0 = trace .. 4 = error` level mapping shared
     /// across `aether.log.*`.
@@ -42,7 +31,7 @@ mod tests {
 
         let mut last_reply = None;
         let mut found = None;
-        for _ in 0..POLL_ATTEMPTS {
+        poll_until(|| {
             let reply = bench.log_tail(engine, &addr, None);
             if let LogTailResult::Ok {
                 entries,
@@ -54,16 +43,17 @@ mod tests {
                     .find(|e| e.message == "typed_send_alive" && e.level == LEVEL_INFO)
             {
                 found = Some((entry.clone(), *next_since));
-                break;
+                true
+            } else {
+                last_reply = Some(reply);
+                false
             }
-            last_reply = Some(reply);
-            thread::sleep(POLL_INTERVAL);
-        }
+        });
 
         let (entry, next_since) = found.unwrap_or_else(|| {
             panic!(
-                "probe's `typed_send_alive` info entry never appeared after {POLL_ATTEMPTS} \
-                     polls; last reply: {last_reply:?}",
+                "probe's `typed_send_alive` info entry never appeared within the poll \
+                 budget; last reply: {last_reply:?}",
             )
         });
 

--- a/crates/aether-substrate-bundle/tests/fleetbench_terminate.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench_terminate.rs
@@ -6,36 +6,39 @@
 mod fleetbench;
 
 mod tests {
-    use crate::fleetbench::FleetBench;
+    use crate::fleetbench::{FleetBench, poll_until};
     use aether_kinds::DeathReason;
 
-    /// Spawn two headless substrates and assert both appear in
-    /// `ListEngines` with fresh heartbeats — the standalone
-    /// `list_engines` row: the hub's fleet table round-trips the
-    /// spawned set, not just a single engine.
+    /// Spawn two headless substrates and assert both round-trip through
+    /// `ListEngines` — the standalone `list_engines` row: the hub's fleet
+    /// table reflects the spawned set, not just a single engine.
     #[test]
     fn fleetbench_lists_the_spawned_engine_set() {
         let mut bench = FleetBench::start();
         let first = bench.spawn_headless();
         let second = bench.spawn_headless();
+        let wanted = [first.0.to_string(), second.0.to_string()];
 
-        let engines = bench.list_engines();
-        for engine in [first, second] {
-            let engine_id = engine.0.to_string();
-            let descriptor = engines
+        // Assert both spawned engines appear in the fleet table. Registration
+        // is synchronous with the spawn reply (the hub holds
+        // `SpawnEngineResult::Ok` until its proxy connects), so the poll just
+        // absorbs any async slack under load rather than depending on a wall
+        // clock. Heartbeat freshness is deliberately not asserted here:
+        // FleetBench runs with the heartbeat disabled (`EngineConfig`
+        // default), so `last_heartbeat_age_millis` only measures time since
+        // registration, not liveness — the pong-refresh / miss-eviction logic
+        // is covered deterministically by the `engine::proxy` unit tests.
+        let listed = poll_until(|| {
+            let engines = bench.list_engines();
+            wanted
                 .iter()
-                .find(|e| e.engine_id == engine_id)
-                .unwrap_or_else(|| {
-                    panic!("spawned engine {engine_id} should appear in ListEngines: {engines:?}")
-                });
-            // Freshly spawned ⇒ recently seen; the cap evicts only at
-            // the miss limit (default 5s × 3), far above this bound.
-            assert!(
-                descriptor.last_heartbeat_age_millis < 10_000,
-                "freshly spawned engine should have a near-zero heartbeat age, got {}ms",
-                descriptor.last_heartbeat_age_millis,
-            );
-        }
+                .all(|id| engines.iter().any(|e| &e.engine_id == id))
+        });
+        assert!(
+            listed,
+            "both spawned engines should round-trip through ListEngines: {:?}",
+            bench.list_engines(),
+        );
     }
 
     /// Spawn one headless substrate, confirm it is supervised, then


### PR DESCRIPTION
Closes #2081.

## Summary

The FleetBench fork tests carried tight wall-clock budgets that flake under full-parallel CI now that #2075 retired the heavy-test serialization. With the fork-heavy tests no longer serialized, they contend for CPU with the rest of the suite, so a cold fork + register or the spawn→list sequence overruns a fixed 3s poll or a one-shot wall-clock bound. Confirmed pre-existing: `main` HEAD `c1d3e768` is itself CI-red on `fleetbench_lists_the_spawned_engine_set` (run 27848576255), and it took down PRs #2079 and #2080 as collateral.

Fix — align the in-test budgets with the cold-start backstop philosophy the harness already established (`DEFAULT_SPAWN_CAP_SECS = 60`, env-overridable), **without** re-introducing serialization:

- New `poll_until(predicate) -> bool` helper + `DEFAULT_POLL_SECS` (30s, env-overridable via `AETHER_FLEETBENCH_POLL_SECS`) in `tests/fleetbench/mod.rs`, in the same style as the existing `reply_cap` / `spawn_cap` resolvers.
- `fleetbench_lists_the_spawned_engine_set`: assert both engines **round-trip through `ListEngines`** (poll for appearance), and **drop** the `last_heartbeat_age_millis < 10_000` assertion. FleetBench runs with the heartbeat **disabled** (`EngineConfig` default), so `last_alive` is never refreshed and the age only measures time-since-registration, not liveness — the 10s bound was a wall-clock race on cold-fork speed, not a freshness check. Pong-refresh and miss-eviction are covered deterministically by the `engine::proxy` unit tests.
- `fleetbench_boots_a_component_set_from_a_selector_manifest`: replace the bare `30 × 100ms` loop with `poll_until` (it polls for a registration edge that genuinely fires).
- `fleetbench_actor_logs_surface_the_probe_first_tick_entry`: the same latent `30 × 100ms` poll, retrofitted to the shared helper.

Test-only — no production change.

## Test plan

`scripts/preflight.sh` green (2187 passed); the three affected tests pass locally, including the corrected `fleetbench_lists_the_spawned_engine_set` in isolation. Unblocks #2079 and #2080 once landed (rebase them onto this).

## Generated by

`/implement` — execution of [issue #2081](https://github.com/iamacoffeepot/aether/issues/2081).
