### PR TITLE
chore(aether-actor): remove the unused native_only! macro

### DIFF
--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -146,27 +146,3 @@ pub use aether_data::{
 // `Addressable::Resolver`, and the `Singleton` / `Instanced` marker traits
 // derive from it by blanket impl — so the only `aether_actor::{Singleton,
 // Instanced}` surface now is the trait (re-exported via `actor::*` above).
-
-/// Wrap one-or-more items in `#[cfg(not(target_arch = "wasm32"))]`.
-/// Issue 552 stage 4's wasm-header-only build of `aether-capabilities`
-/// gates per-cap native imports + helpers + impls behind that cfg;
-/// this macro compresses what would otherwise be 5-7 sprinkled
-/// attributes per cap file into one block per native-only chunk.
-///
-/// ```ignore
-/// aether_actor::native_only! {
-///     use aether_substrate::chassis::error::BootError;
-///     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-///
-///     fn put_error_to_handle_error(e: PutError) -> HandleError { ... }
-/// }
-/// ```
-///
-/// expands to each `$item` annotated with `#[cfg(not(target_arch = "wasm32"))]`.
-/// Pure mechanical wrap — no clever cfg, no feature flags.
-#[macro_export]
-macro_rules! native_only {
-    ($($item:item)*) => {
-        $( #[cfg(not(target_arch = "wasm32"))] $item )*
-    };
-}


### PR DESCRIPTION
Closes #2083.

## Summary

`aether_actor::native_only!` was a `#[macro_export]` declarative macro in `crates/aether-actor/src/lib.rs` whose only job was to wrap a block of items in `#[cfg(not(target_arch = "wasm32"))]`. It was introduced for issue 552 stage 4 to compress per-cap native-only attribute sprawl in `aether-capabilities`, but that crate never adopted it — the only references in the tree were the definition and its own rustdoc example, zero call sites. It was exported public SDK surface carrying documentation weight and an implicit support promise while doing nothing.

This removes the macro and its rustdoc block outright (24 lines). `aether-capabilities` already gates its native code with inline `#[cfg(not(target_arch = "wasm32"))]` attributes, so dropping the unused alternative leaves one way to do it. Pure dead-code removal — no call sites, no migration.

## Test plan

No new test (deleting dead code with no behavioral surface to assert). Verified by the full pre-flight: fmt, `clippy --workspace --all-targets -D warnings`, `cargo doc`, `nextest run --workspace` (2187 passed), and the wasm32 component cross-build (`aether-kit`, `aether-mesh-viewer`) — all green. `git grep native_only` returns empty.

## Generated by

`/implement` — agent execution of [scoped issue #2083](https://github.com/iamacoffeepot/aether/issues/2083).
