### PR TITLE
refactor(actor): gate the FFI on target_family wasm instead of target_arch wasm32

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -208,7 +208,7 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
         // `[version_byte][canonical_bytes]`, where the canonical bytes are
         // now the owned aether-wire encoding (issue 1984) — so every
         // `Kind::ID` regenerates, gated loudly behind this version byte.
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[used]
         #[unsafe(link_section = "aether.kinds")]
         static #kind_static_ident: [u8; #canonical_len_ident + 1] = {
@@ -222,7 +222,7 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
             out
         };
 
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[used]
         #[unsafe(link_section = "aether.kinds.labels")]
         static #kind_labels_static_ident: [u8; #labels_len_ident + 1] = {
@@ -246,7 +246,7 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
         // `KindDescriptor` list by iterating these inventory entries.
         // Cfg-gated to non-wasm targets because `inventory` doesn't
         // link on `wasm32-unknown-unknown`.
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(target_family = "wasm"))]
         ::aether_data::__inventory::inventory::submit! {
             ::aether_data::__inventory::DescriptorEntry {
                 name: <#name as ::aether_data::Kind>::NAME,
@@ -1141,12 +1141,12 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
     // `mod native` then key on `feature = "X"` too.
     let (stub_cfg, native_cfg) = match feature.as_deref() {
         None => (
-            quote! { #[cfg(target_arch = "wasm32")] },
-            quote! { #[cfg(not(target_arch = "wasm32"))] },
+            quote! { #[cfg(target_family = "wasm")] },
+            quote! { #[cfg(not(target_family = "wasm"))] },
         ),
         Some(feat) => (
-            quote! { #[cfg(any(target_arch = "wasm32", not(feature = #feat)))] },
-            quote! { #[cfg(all(not(target_arch = "wasm32"), feature = #feat))] },
+            quote! { #[cfg(any(target_family = "wasm", not(feature = #feat)))] },
+            quote! { #[cfg(all(not(target_family = "wasm"), feature = #feat))] },
         ),
     };
     let stub_and_reexport = quote! {
@@ -1281,7 +1281,7 @@ fn expand_bridge(mut item_mod: ItemMod, opts: BridgeOpts) -> syn::Result<TokenSt
 
     // Reassemble the mod with the rewritten contents and prepend the
     // cfg gate. `native_cfg` keys on the optional feature too — without
-    // a feature it's the original `not(target_arch = "wasm32")`; with
+    // a feature it's the original `not(target_family = "wasm")`; with
     // one it adds `feature = "X"` so the inner `mod native` only
     // compiles when both the target and the feature say to.
     item_mod.content = Some((brace, items));
@@ -1424,7 +1424,7 @@ pub fn capability(attr: TokenStream, item: TokenStream) -> TokenStream {
         .into();
     }
     let mut item = parse_macro_input!(item as syn::ItemStruct);
-    // Issue 552 stage 4: gate fields on `not(target_arch = "wasm32")`
+    // Issue 552 stage 4: gate fields on `not(target_family = "wasm")`
     // to match the macro-emitted `NativeActor` / `NativeDispatch`
     // impls. Wasm builds see the cap struct with no fields (a pure
     // marker), which is what typed `ctx.actor::<R>().send(...)` needs;
@@ -1436,7 +1436,7 @@ pub fn capability(attr: TokenStream, item: TokenStream) -> TokenStream {
                 if !already_cfg {
                     field
                         .attrs
-                        .push(syn::parse_quote!(#[cfg(not(target_arch = "wasm32"))]));
+                        .push(syn::parse_quote!(#[cfg(not(target_family = "wasm"))]));
                 }
             }
         }
@@ -1446,7 +1446,7 @@ pub fn capability(attr: TokenStream, item: TokenStream) -> TokenStream {
                 if !already_cfg {
                     field
                         .attrs
-                        .push(syn::parse_quote!(#[cfg(not(target_arch = "wasm32"))]));
+                        .push(syn::parse_quote!(#[cfg(not(target_family = "wasm"))]));
                 }
             }
         }
@@ -2919,7 +2919,7 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
                 quote! { ::core::option::Option::None }
             };
             quote! {
-                #[cfg(not(target_arch = "wasm32"))]
+                #[cfg(not(target_family = "wasm"))]
                 ::aether_data::name_inventory::inventory::submit! {
                     ::aether_data::name_inventory::HandlerEntry {
                         namespace: <#self_ty as ::aether_actor::Addressable>::NAMESPACE,
@@ -2938,7 +2938,7 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
     // Issue 552 stage 4: NativeActor + NativeDispatch + the inherent
     // handler-method impl all reach for `::aether_substrate::*` paths
     // and native-only types in their bodies. They're emitted under
-    // `#[cfg(not(target_arch = "wasm32"))]` so `aether-capabilities`
+    // `#[cfg(not(target_family = "wasm"))]` so `aether-capabilities`
     // can compile for `wasm32-unknown-unknown` without the substrate
     // dep — wasm consumers see only the always-on Addressable +
     // HandlesKind markers, which is enough for typed
@@ -2960,7 +2960,7 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
         // `unwire` + `type Config`) lives on the shared `Lifecycle`
         // capability, with the per-target ctx GATs pinned to the concrete
         // native ctx types so an `init`/`wire` body keeps its concrete ctx.
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(target_family = "wasm"))]
         impl #impl_generics ::aether_actor::Lifecycle for #self_ty #where_clause {
             #config_type
             type InitError = ::aether_substrate::BootError;
@@ -2973,10 +2973,10 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
         // `NativeActor` is now the empty composition `Actor +
         // Lifecycle<InitError = BootError>`; per-kind dispatch lives on the
         // sibling `NativeDispatch` impl below.
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(target_family = "wasm"))]
         impl #impl_generics #trait_path for #self_ty #where_clause {}
 
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(target_family = "wasm"))]
         impl #impl_generics ::aether_substrate::NativeDispatch for #self_ty #where_clause {
             // ADR-0112: the dispatch seam carries the most-permissive
             // `Manual` ctx; the arms downgrade per handler class.
@@ -2996,7 +2996,7 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
             #capabilities_override
         }
 
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(target_family = "wasm"))]
         impl #impl_generics #self_ty #where_clause {
             #(#handler_methods)*
             #(#task_handler_methods)*
@@ -3657,7 +3657,7 @@ fn build_kinds_section_retention_statics(
             // (ADR-0118 / issue 1984: the owned aether-wire encoding) so
             // retention records (when this kind lives in a dependency
             // rlib) pair cleanly with the primary records by id.
-            #[cfg(target_arch = "wasm32")]
+            #[cfg(target_family = "wasm")]
             #[used]
             #[unsafe(link_section = "aether.kinds")]
             static #section_ident: [u8; #len_ident + 1] = {
@@ -3702,7 +3702,7 @@ fn build_kinds_section_retention_statics(
                 ::aether_actor::__macro_internals::canonical::canonical_serialize_labels::<#labels_len_ident>(
                     &#labels_static_ident,
                 );
-            #[cfg(target_arch = "wasm32")]
+            #[cfg(target_family = "wasm")]
             #[used]
             #[unsafe(link_section = "aether.kinds.labels")]
             static #labels_section_ident: [u8; #labels_len_ident + 1] = {

--- a/crates/aether-actor/Cargo.toml
+++ b/crates/aether-actor/Cargo.toml
@@ -40,7 +40,7 @@ tracing = { workspace = true, default-features = false }
 # typed `ctx.actor::<R>()` calls (issue 575) — needs the cap markers
 # in scope. Pulls `native` so caps' `mod native` blocks compile (they
 # import `aether_substrate` types and are gated on the bridge's
-# default `cfg(not(target_arch = "wasm32"))`, not on the `native`
+# default `cfg(not(target_family = "wasm"))`, not on the `native`
 # feature). `aether-substrate` deps back on `aether-actor`, but cargo
 # permits dev-dep cycles for the test-target build graph.
 aether-capabilities = { path = "../aether-capabilities", features = ["render"] }

--- a/crates/aether-actor/src/ffi/bridge/mail.rs
+++ b/crates/aether-actor/src/ffi/bridge/mail.rs
@@ -121,7 +121,7 @@ pub fn prev_correlation() -> u64 {
     // SAFETY: `raw::prev_correlation` takes no arguments and reads
     // a host-side scalar set on the most recent `send_mail`; no
     // ABI invariants to uphold beyond "we are the FFI guest", which
-    // the `#[cfg(target_arch = "wasm32")]` import gate enforces
+    // the `#[cfg(target_family = "wasm")]` import gate enforces
     // (the host-target stub panics rather than returning garbage).
     unsafe { raw::prev_correlation() }
 }
@@ -140,7 +140,7 @@ pub fn prev_correlation() -> u64 {
 /// Only callable from wasm32 — installed as the [`crate::log::LogSink`]
 /// by the guest runtime (`export!`) and invoked from
 /// [`crate::log::ForwardingSubscriber::event`].
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 pub fn emit_log_event(level: u8, target: &str, message: &str) {
     let target_bytes = target.as_bytes();
     let message_bytes = message.as_bytes();

--- a/crates/aether-actor/src/ffi/mod.rs
+++ b/crates/aether-actor/src/ffi/mod.rs
@@ -37,7 +37,7 @@
 //! contract substrate's wasm runtime expects.
 //!
 //! No FFI imports are pulled in unconditionally — the host-fn externs
-//! in [`raw`] live behind a `#[cfg(target_arch = "wasm32")]` block and
+//! in [`raw`] live behind a `#[cfg(target_family = "wasm")]` block and
 //! the native-target stubs panic if invoked, so the crate compiles
 //! for `cargo test --workspace` on the host without dragging the FFI
 //! surface into the linker.
@@ -260,7 +260,7 @@ pub trait ErasedFfiActor {
 /// init shims so the byte-staging boilerplate isn't repeated at each
 /// construction site. wasm32-only — the host build carries no FFI
 /// surface.
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 #[doc(hidden)]
 pub fn stage_init_failure(message: &str) {
     let bytes = message.as_bytes();
@@ -280,7 +280,7 @@ pub fn stage_init_failure(message: &str) {
 /// from inside the crate; the subscriber itself stays target-blind in
 /// [`crate::log`]. Shared by the `export!` shims so the wiring isn't
 /// repeated per init shim.
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 #[doc(hidden)]
 pub fn install_guest_logging() {
     crate::log::install_log_sink(bridge::mail::emit_log_event);
@@ -561,7 +561,7 @@ macro_rules! __export_internal {
         // transitive rlib pulls of a `#[actor]`-using crate, which
         // would otherwise stack duplicate Component records and fail
         // the substrate's manifest reader.
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[used]
         #[unsafe(link_section = "aether.kinds.inputs")]
         static __AETHER_INPUTS_SECTION: [u8; <$component>::__AETHER_INPUTS_MANIFEST_LEN] =
@@ -571,7 +571,7 @@ macro_rules! __export_internal {
         // into a sibling `aether.namespace` custom section. The
         // substrate reads this at load time as the default mailbox
         // name when the load payload omits an explicit `name`.
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[used]
         #[unsafe(link_section = "aether.namespace")]
         static __AETHER_NAMESPACE_SECTION: [u8; <$component as $crate::Addressable>::NAMESPACE.len()] = {
@@ -603,7 +603,7 @@ macro_rules! __export_internal {
         /// Returns `0` on success and non-zero when the actor's `init`
         /// returned `Err(BootError)` or its `Config::decode_from_bytes`
         /// produced `None`.
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[unsafe(export_name = "init_with_config_p32")]
         pub unsafe extern "C" fn init_with_config(
             mailbox_id: u64,
@@ -686,7 +686,7 @@ macro_rules! __export_internal {
         /// `Config = ()`); a typed-config actor returns an
         /// `init_failed` here, which is the right behavior for a host
         /// too old to thread config bytes through.
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn init(mailbox_id: u64) -> u32 {
             // SAFETY: forwarding to `init_with_config` with `config_len = 0`
@@ -706,7 +706,7 @@ macro_rules! __export_internal {
         /// Issue 703: uses `FfiCtx` (the send-capable runtime ctx) so
         /// `Subscriber::subscribe_input::<K>()` resolves; `FfiInitCtx`
         /// carries no send surface and can't mail.
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn wire(mailbox_id: u64) -> u32 {
             let Some(instance) = (unsafe { __AETHER_COMPONENT.get_mut() }) else {
@@ -729,7 +729,7 @@ macro_rules! __export_internal {
         /// (on a replace) or the instance drop, on the dying instance
         /// (issue 584 Phase 2b, ADR-0079 amended). Mail-allowed — live
         /// peers are still addressable; sends to a dead peer warn-drop.
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn unwire(mailbox_id: u64) -> u32 {
             let Some(instance) = (unsafe { __AETHER_COMPONENT.get_mut() }) else {
@@ -746,7 +746,7 @@ macro_rules! __export_internal {
         /// the `_p32` suffix per ADR-0024 Phase 1; the trailing
         /// `recipient: u64` (ADR-0114 decision #1) widens like the other
         /// frame slots on the wasm path.
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[unsafe(export_name = "receive_p32")]
         pub unsafe extern "C" fn receive(
             kind: u64,
@@ -836,7 +836,7 @@ macro_rules! __export_internal {
         /// # Safety
         /// Called by the substrate per the layout contract; see
         /// [`$crate::ffi::guest_alloc::realloc_bytes`].
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[unsafe(export_name = "realloc_p32")]
         pub unsafe extern "C" fn realloc_p32(
             old_ptr: u32,
@@ -862,7 +862,7 @@ macro_rules! __export_internal {
         /// immediately before a `replace_component` swap. Forwards to
         /// [`$crate::FfiActor::on_dehydrate`], a no-op unless the actor
         /// overrides it.
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn on_dehydrate() -> u32 {
             let Some(instance) = (unsafe { __AETHER_COMPONENT.get_mut() }) else {
@@ -899,7 +899,7 @@ macro_rules! __export_internal {
         /// Exported under the `_p32` suffix per ADR-0024 Phase 1.
         /// Forwards to [`$crate::FfiActor::on_rehydrate`], a no-op unless
         /// the actor overrides it.
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[unsafe(export_name = "on_rehydrate_p32")]
         pub unsafe extern "C" fn on_rehydrate(version: u32, ptr: u32, len: u32) -> u32 {
             let Some(instance) = (unsafe { __AETHER_COMPONENT.get_mut() }) else {
@@ -1023,7 +1023,7 @@ macro_rules! __export_multi_internal {
         // stream into one capability set per type. The entry type is
         // first. A single-actor `export!` never reaches this arm, so
         // the boundary-free single-actor layout stays byte-identical.
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         const __AETHER_MULTI_INPUTS_LEN: usize = 0usize $(
             + 1
             + $crate::__macro_internals::canonical::inputs_actor_boundary_len(
@@ -1032,7 +1032,7 @@ macro_rules! __export_multi_internal {
             + <$component>::__AETHER_INPUTS_MANIFEST_LEN
         )+;
 
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[used]
         #[unsafe(link_section = "aether.kinds.inputs")]
         static __AETHER_INPUTS_SECTION: [u8; __AETHER_MULTI_INPUTS_LEN] = {
@@ -1078,7 +1078,7 @@ macro_rules! __export_multi_internal {
             out
         };
 
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[used]
         #[unsafe(link_section = "aether.namespace")]
         static __AETHER_NAMESPACE_SECTION: [u8; <$entry as $crate::Addressable>::NAMESPACE.len()] = {
@@ -1094,7 +1094,7 @@ macro_rules! __export_multi_internal {
 
         /// # Safety
         /// Existing 3-arg init ABI; constructs the entry (first) export.
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[unsafe(export_name = "init_with_config_p32")]
         pub unsafe extern "C" fn init_with_config(
             mailbox_id: u64,
@@ -1118,7 +1118,7 @@ macro_rules! __export_multi_internal {
 
         /// # Safety
         /// ADR-0090 legacy zero-config init; forwards to the entry type.
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn init(mailbox_id: u64) -> u32 {
             unsafe { init_with_config(mailbox_id, 0, 0) }
@@ -1127,7 +1127,7 @@ macro_rules! __export_multi_internal {
         /// # Safety
         /// ADR-0096 typed init: `type_tag` selects which exported type
         /// to construct (its `mailbox_id_from_name(NAMESPACE)`).
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[unsafe(export_name = "init_typed_p32")]
         pub unsafe extern "C" fn init_typed(
             mailbox_id: u64,
@@ -1163,7 +1163,7 @@ macro_rules! __export_multi_internal {
             1
         }
 
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn wire(mailbox_id: u64) -> u32 {
             let Some(instance) = (unsafe { __AETHER_MULTI.get_mut() }) else {
@@ -1180,7 +1180,7 @@ macro_rules! __export_multi_internal {
             0
         }
 
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn unwire(mailbox_id: u64) -> u32 {
             let Some(instance) = (unsafe { __AETHER_MULTI.get_mut() }) else {
@@ -1198,7 +1198,7 @@ macro_rules! __export_multi_internal {
         /// `ErasedFfiActor`. Self-mailbox id derived from the live
         /// instance's namespace. The trailing `recipient: u64` (ADR-0114
         /// decision #1) carries the routed mailbox through to `Mail`.
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[unsafe(export_name = "receive_p32")]
         pub unsafe extern "C" fn receive(
             kind: u64,
@@ -1274,7 +1274,7 @@ macro_rules! __export_multi_internal {
         ///
         /// # Safety
         /// Called by the substrate per the layout contract.
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[unsafe(export_name = "realloc_p32")]
         pub unsafe extern "C" fn realloc_p32(
             old_ptr: u32,
@@ -1298,7 +1298,7 @@ macro_rules! __export_multi_internal {
         /// immediately before a `replace_component` swap. Routes through
         /// the boxed `ErasedFfiActor` to the live type's
         /// [`$crate::FfiActor::on_dehydrate`] (ADR-0101).
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn on_dehydrate() -> u32 {
             let Some(instance) = (unsafe { __AETHER_MULTI.get_mut() }) else {
@@ -1333,7 +1333,7 @@ macro_rules! __export_multi_internal {
         /// Routes through the boxed `ErasedFfiActor` to the live type's
         /// [`$crate::FfiActor::on_rehydrate`] (ADR-0101). Self-mailbox id
         /// derived from the live instance's namespace.
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         #[unsafe(export_name = "on_rehydrate_p32")]
         pub unsafe extern "C" fn on_rehydrate(version: u32, ptr: u32, len: u32) -> u32 {
             let Some(instance) = (unsafe { __AETHER_MULTI.get_mut() }) else {

--- a/crates/aether-actor/src/ffi/raw.rs
+++ b/crates/aether-actor/src/ffi/raw.rs
@@ -10,7 +10,7 @@
 // for `cargo test --workspace` on the host — actors can still be
 // unit-tested for pure logic there, they just can't cross the FFI.
 //
-// The `target_arch = "wasm32"` cfg gate matches the only FFI host
+// The `target_family = "wasm"` cfg gate matches the only FFI host
 // the substrate ships today. A future C / OS-process host would
 // either pick a different gate or drop the cfg entirely; the
 // import surface itself is target-agnostic.
@@ -22,7 +22,7 @@
 // the suffix through every call site — `#[link_name]` does the
 // remap.
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 #[link(wasm_import_module = "aether")]
 unsafe extern "C" {
     /// `detached` is the ADR-0080 §7 lineage signal: `0` inherits the
@@ -137,7 +137,7 @@ unsafe extern "C" {
 /// # Panics
 /// Always panics — fail-fast per ADR-0063: the host build of the SDK
 /// has no FFI host to call, so any invocation is a bug.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 #[must_use]
 pub unsafe fn send_mail(
     _recipient: u64,
@@ -160,7 +160,7 @@ pub unsafe fn send_mail(
 /// # Panics
 /// Always panics — fail-fast per ADR-0063: the host build of the SDK
 /// has no FFI host to call, so any invocation is a bug.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 #[must_use]
 pub unsafe fn reply_mail(
     _sender: u32,
@@ -182,7 +182,7 @@ pub unsafe fn reply_mail(
 /// # Panics
 /// Always panics — fail-fast per ADR-0063: the host build of the SDK
 /// has no FFI host to call, so any invocation is a bug.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 #[must_use]
 pub unsafe fn save_state(_version: u32, _ptr: u32, _len: u32) -> u32 {
     panic!("aether-actor: save_state called outside the FFI guest");
@@ -197,7 +197,7 @@ pub unsafe fn save_state(_version: u32, _ptr: u32, _len: u32) -> u32 {
 /// # Panics
 /// Always panics — fail-fast per ADR-0063: the host build of the SDK
 /// has no FFI host to call, so any invocation is a bug.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 #[must_use]
 pub unsafe fn prev_correlation() -> u64 {
     panic!("aether-actor: prev_correlation called outside the FFI guest");
@@ -212,7 +212,7 @@ pub unsafe fn prev_correlation() -> u64 {
 /// # Panics
 /// Always panics — fail-fast per ADR-0063: the host build of the SDK
 /// has no FFI host to call, so any invocation is a bug.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 pub unsafe fn init_failed(_ptr: u32, _len: u32) {
     panic!("aether-actor: init_failed called outside the FFI guest");
 }
@@ -226,7 +226,7 @@ pub unsafe fn init_failed(_ptr: u32, _len: u32) {
 /// # Panics
 /// Always panics — fail-fast per ADR-0063: the host build of the SDK
 /// has no FFI host to call, so any invocation is a bug.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 pub unsafe fn log_event(
     _level: u32,
     _target_ptr: u32,
@@ -246,7 +246,7 @@ pub unsafe fn log_event(
 /// # Panics
 /// Always panics — fail-fast per ADR-0063: the host build of the SDK
 /// has no FFI host to call, so any invocation is a bug.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 #[must_use]
 pub unsafe fn spawn_sibling(
     _tag: u64,
@@ -269,7 +269,7 @@ pub unsafe fn spawn_sibling(
 /// # Panics
 /// Always panics — fail-fast per ADR-0063: the host build of the SDK
 /// has no FFI host to call, so any invocation is a bug.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 #[must_use]
 pub unsafe fn spawn_inline_child(_is_counter: u32, _subname_ptr: u32, _subname_len: u32) -> u64 {
     panic!("aether-actor: spawn_inline_child called outside the FFI guest");

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -38,7 +38,7 @@
 //!     `aether.namespace` custom-section statics.
 //!
 //! No FFI imports are pulled in unconditionally — the host-fn externs
-//! in [`ffi::raw`] live behind a `#[cfg(target_arch = "wasm32")]`
+//! in [`ffi::raw`] live behind a `#[cfg(target_family = "wasm")]`
 //! block and the native-target stubs panic if invoked, so the crate
 //! compiles for `cargo test --workspace` on the host without dragging
 //! the FFI surface into the linker.

--- a/crates/aether-actor/tests/handlers_manifest.rs
+++ b/crates/aether-actor/tests/handlers_manifest.rs
@@ -8,7 +8,7 @@
 //!
 //! Pre-issue-442 the macro emitted N separate `#[link_section]`
 //! statics, one per handler/fallback/component-doc record, gated on
-//! `target_arch = "wasm32"`. That gate fired for both the cdylib
+//! `target_family = "wasm"`. That gate fired for both the cdylib
 //! root and any transitive wasm32 rlib pull, so a cdylib that
 //! depended on a sibling `cdylib + rlib` crate's rlib output would
 //! see both crates' Component records stack in its


### PR DESCRIPTION
Closes #2084.

## Summary

The component FFI in `aether-actor` and the gates `aether-actor-derive` emits were spelled `#[cfg(target_arch = "wasm32")]`, hardcoding one architecture where the real axis is "is this the wasm guest build". This swaps the predicate to the built-in `#[cfg(target_family = "wasm")]` everywhere it gates compilation, in both crates — including the `not(...)` form and the compound `any(...)` / `all(...)` atoms the derive emits via `quote!` / `parse_quote!`. `target_family` is a built-in cfg, so it needs no build.rs and evaluates inside the component crates the derive expands in, closing the cross-crate seam a custom build-script cfg could not reach.

The swap is behavior-identical for every target built today: `target_family = "wasm"` holds exactly when `target_arch = "wasm32"` does on wasm32 and is false on all native targets. The only delta is a hypothetical wasm64 build, which would now count as guest — correct per ADR-0024 and inert. The `_p32` host-fn ABI symbol names and the `_p32` pointer-width prose are deliberately left unchanged.

Coordination note: the one `target_arch = "wasm32"` gate inside the `native_only!` macro is intentionally left untouched here — that macro is removed in #2083 (concurrent), so the two diffs stay disjoint. Once both land, zero `target_arch = "wasm32"` cfg gates remain.

## Test plan

No new test (behavior-identical predicate swap). The load-bearing check is the wasm32 component cross-build, which compiles the derive-emitted gates inside real component crates and proves the swapped predicate still selects the guest body. Full pre-flight green: fmt, `clippy --workspace --all-targets -D warnings`, `cargo doc`, `nextest run --workspace` (2187 passed), and `wasm32-unknown-unknown` builds of `aether-kit` and `aether-mesh-viewer`.

## Generated by

`/implement` — agent execution of [scoped issue #2084](https://github.com/iamacoffeepot/aether/issues/2084).
