### PR TITLE
chore(actor): remove unused/dead public api in aether-actor

### DIFF
--- a/crates/aether-actor-derive/tests/ui/single_handler_cannot_reply.stderr
+++ b/crates/aether-actor-derive/tests/ui/single_handler_cannot_reply.stderr
@@ -2,10 +2,4 @@ error[E0599]: no method named `reply` found for mutable reference `&mut WasmCtx<
   --> tests/ui/single_handler_cannot_reply.rs:53:13
    |
 53 |         ctx.reply(&Ack { seq: ping.seq });
-   |             ^^^^^
-   |
-help: there is a method `reply_kind` with a similar name, but with different arguments
-  --> $WORKSPACE/crates/aether-actor/src/wasm/ctx.rs
-   |
-   |     pub fn reply_kind<K: Kind>(&self, sender: ReplyHandle, kind: KindId<K>, payload: &K) {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^ method not found in `&mut WasmCtx<'_>`

--- a/crates/aether-actor/src/actor/ctx/reply_mode.rs
+++ b/crates/aether-actor/src/actor/ctx/reply_mode.rs
@@ -16,8 +16,7 @@
 //!
 //! The trait is sealed through a private supertrait so a guest crate
 //! cannot add a fourth mode — the closed set of three is what the
-//! `#[actor]` macro's downgrade-only coercions (`as_single` /
-//! `as_stream`) rely on.
+//! `#[actor]` macro's downgrade-only coercion (`as_single`) relies on.
 
 mod sealed {
     /// Private supertrait sealing [`super::ReplyMode`] — only the three

--- a/crates/aether-actor/src/mail/mod.rs
+++ b/crates/aether-actor/src/mail/mod.rs
@@ -24,8 +24,6 @@ use core::marker::PhantomData;
 
 use aether_data::{Kind, MailboxId, Schema, wire};
 
-use crate::mail::mailbox::KindId;
-
 /// Sentinel the substrate passes as the reply-handle parameter on
 /// the `receive` shim when there is no reply target — for
 /// component-originated mail (no Claude session involved) and for
@@ -109,7 +107,7 @@ pub struct Mail<'a> {
     _borrow: PhantomData<&'a [u8]>,
 }
 
-impl<'a> Mail<'a> {
+impl Mail<'_> {
     /// Not part of the public API; called only by `export!`. The FFI
     /// delivers `ptr` as a wasm32 offset (`u32`); this widens it.
     #[doc(hidden)]
@@ -158,9 +156,9 @@ impl<'a> Mail<'a> {
         }
     }
 
-    /// Raw kind id the substrate routed this mail under. Match against
-    /// a cached `KindId<K>` via `kind_id.matches(mail.kind())`, or use
-    /// `decode::<K>(kind_id)` and let it be the discriminator.
+    /// Raw kind id the substrate routed this mail under. The canonical
+    /// way to consume it is [`Self::decode_kind::<K>()`], which matches
+    /// the kind id and decodes in one call.
     #[must_use]
     pub fn kind(&self) -> u64 {
         self.kind
@@ -211,116 +209,16 @@ impl<'a> Mail<'a> {
         MailboxId(self.recipient)
     }
 
-    /// Decode as a single owned `K`. Returns `None` if the kind does
-    /// not match or if `count` is not 1. Copies rather than borrows so
-    /// alignment of the underlying bytes doesn't matter.
-    #[must_use]
-    pub fn decode<K: Kind + bytemuck::AnyBitPattern>(&self, kind_id: KindId<K>) -> Option<K> {
-        if !kind_id.matches(self.kind) || self.count != 1 {
-            return None;
-        }
-        let byte_len = size_of::<K>();
-        // SAFETY: `self.ptr` / `self.byte_len` originate from the
-        // substrate's receive ABI (`Mail::__from_raw` / `__from_ptr`),
-        // which guarantees the substrate wrote `self.byte_len >=
-        // size_of::<K>()` bytes valid at `self.ptr` for the lifetime
-        // of this `Mail`. `'a` ties the borrow to that lifetime.
-        let bytes = unsafe { slice::from_raw_parts(self.ptr as *const u8, byte_len) };
-        Some(bytemuck::pod_read_unaligned(bytes))
-    }
-
-    /// Decode as a zero-copy slice of `K`. Returns `None` if the kind
-    /// does not match or the bytes are not aligned for `K`. The
-    /// returned slice borrows from actor linear memory for the
-    /// lifetime of this `Mail`.
-    #[must_use]
-    pub fn decode_slice<K: Kind + bytemuck::AnyBitPattern>(
-        &self,
-        kind_id: KindId<K>,
-    ) -> Option<&'a [K]> {
-        if !kind_id.matches(self.kind) {
-            return None;
-        }
-        let byte_len = size_of::<K>() * self.count as usize;
-        // SAFETY: `self.ptr` / `self.byte_len` originate from the
-        // substrate's receive ABI; the substrate guarantees at least
-        // `size_of::<K>() * self.count` bytes valid at `self.ptr` for
-        // the lifetime of this `Mail`. `'a` ties the returned slice
-        // to that lifetime; `try_cast_slice` returns `None` on
-        // alignment mismatch.
-        let bytes = unsafe { slice::from_raw_parts(self.ptr as *const u8, byte_len) };
-        bytemuck::try_cast_slice(bytes).ok()
-    }
-
-    /// True if the inbound mail's kind id matches `<K as Kind>::ID`
-    /// (ADR-0030 compile-time hash). Zero-cost — just a `u64` compare
-    /// against a const. Useful as the discriminator before deciding
-    /// how to handle a kind, or as a signal check when `K` is a
-    /// zero-sized input marker like `Tick` / `MouseButton`.
-    #[must_use]
-    pub fn is<K: Kind>(&self) -> bool {
-        self.kind == K::ID.0
-    }
-
-    /// Type-driven sibling of `decode`: takes `K` as a type parameter
-    /// and uses `<K as Kind>::ID` directly (ADR-0030 compile-time hash),
-    /// so no `KindId<K>` thread-through is needed. Returns `None` if
-    /// the inbound kind doesn't match `K::ID`, if `count != 1`, or
-    /// if `byte_len` doesn't equal `size_of::<K>()` (a sender/receiver
-    /// schema-skew guard the substrate's frame metadata makes free).
-    /// Copies rather than borrows so alignment of the underlying bytes
-    /// doesn't matter — same semantics as `decode`.
-    #[must_use]
-    pub fn decode_typed<K: Kind + bytemuck::AnyBitPattern>(&self) -> Option<K> {
-        if self.kind != K::ID.0 || self.count != 1 {
-            return None;
-        }
-        let byte_len = size_of::<K>();
-        if self.byte_len as usize != byte_len {
-            return None;
-        }
-        // SAFETY: `self.ptr` / `self.byte_len` originate from the
-        // substrate's receive ABI; the `byte_len` check above proves
-        // the host promised exactly `size_of::<K>()` bytes valid at
-        // `self.ptr` for this `Mail`'s lifetime.
-        let bytes = unsafe { slice::from_raw_parts(self.ptr as *const u8, byte_len) };
-        Some(bytemuck::pod_read_unaligned(bytes))
-    }
-
-    /// Type-driven sibling of `decode_slice`. Borrowed, alignment
-    /// required (returns `None` if misaligned).
-    #[must_use]
-    pub fn decode_slice_typed<K: Kind + bytemuck::AnyBitPattern>(&self) -> Option<&'a [K]> {
-        if self.kind != K::ID.0 {
-            return None;
-        }
-        let byte_len = size_of::<K>() * self.count as usize;
-        if self.byte_len as usize != byte_len {
-            return None;
-        }
-        // SAFETY: `self.ptr` / `self.byte_len` originate from the
-        // substrate's receive ABI; the `byte_len` check above proves
-        // the host promised `size_of::<K>() * count` bytes valid at
-        // `self.ptr` for this `Mail`'s lifetime. `try_cast_slice`
-        // returns `None` on alignment mismatch.
-        let bytes = unsafe { slice::from_raw_parts(self.ptr as *const u8, byte_len) };
-        bytemuck::try_cast_slice(bytes).ok()
-    }
-
     /// Decode a single inbound `K` via the wire shape `K`'s `Kind`
     /// derive baked into `Kind::decode_from_bytes` — cast for
     /// `#[repr(C)]` + `Pod` types, postcard for schema-shaped types.
     /// This is the canonical receive-side decode and what the
-    /// `#[actor]` dispatcher calls on every typed handler;
-    /// `decode` / `decode_typed` / `decode_slice` / `decode_slice_typed`
-    /// remain as low-level escape hatches for fallback handlers that
-    /// want explicit wire-shape control.
+    /// `#[actor]` dispatcher calls on every typed handler.
     ///
     /// Hands `K::decode_from_bytes` exactly `byte_len` bytes from
     /// `ptr` so the decoder is bounded by the substrate-written
     /// frame and can't read past it into adjacent linear memory.
-    /// Returns `None` on kind mismatch, on `count != 1` (batch
-    /// receives go through `decode_slice_typed`), or when
+    /// Returns `None` on kind mismatch, on `count != 1`, or when
     /// `K::decode_from_bytes` itself returns `None` — which can be
     /// either the default body for hand-rolled `Kind` impls that
     /// didn't override, a cast-size mismatch, or a postcard decode
@@ -451,29 +349,13 @@ mod tests {
     use alloc::vec::Vec;
     use serde::{Deserialize, Serialize};
 
-    // The local `crate::mail::mailbox::KindId<K>` shadows the
-    // crate-level `aether_data::KindId` newtype; tests construct the
-    // raw newtype via the aliased import to keep both available.
-
     /// Hand-rolled `Kind` with a stable test sentinel id so the
-    /// decode tests can fabricate matching `Mail` frames without
+    /// decode tests can fabricate mismatched `Mail` frames without
     /// depending on a real schema-hashed id.
     struct FakeKind;
     impl Kind for FakeKind {
         const NAME: &'static str = "test.fake";
         const ID: DataKindId = DataKindId(0xDEAD_BEEF_0001_0001);
-    }
-
-    /// Cast-shape Pod kind for the slice / single-decode happy paths.
-    #[repr(C)]
-    #[derive(Copy, Clone, Debug, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
-    struct FakePod {
-        a: u32,
-        b: u32,
-    }
-    impl Kind for FakePod {
-        const NAME: &'static str = "test.fake_pod";
-        const ID: DataKindId = DataKindId(0xDEAD_BEEF_0001_0002);
     }
 
     /// Postcard-shape kind for the schema-driven `decode_kind` path.
@@ -497,57 +379,6 @@ mod tests {
     // variants rely on the `bytes()` / `decode*` accessors honouring
     // the `len == 0` early-return rather than forming a slice over the
     // null pointer.
-
-    #[test]
-    fn mail_decode_single_roundtrip() {
-        let value = FakePod { a: 5, b: 9 };
-        let ptr_raw = (&raw const value).addr();
-        let byte_len = size_of::<FakePod>() as u32;
-        // SAFETY: see module-level test fixture justification above.
-        let mail = unsafe { Mail::__from_ptr(7, ptr_raw, byte_len, 1, NO_REPLY_HANDLE, 0) };
-        let kind: KindId<FakePod> = KindId::__new(7);
-        let out = mail
-            .decode(kind)
-            .expect("test setup: matching kind id decodes");
-        assert_eq!(out, value);
-    }
-
-    #[test]
-    fn mail_decode_wrong_kind_returns_none() {
-        let value = FakePod { a: 5, b: 9 };
-        let ptr_raw = (&raw const value).addr();
-        let byte_len = size_of::<FakePod>() as u32;
-        // SAFETY: see module-level test fixture justification above.
-        let mail = unsafe { Mail::__from_ptr(7, ptr_raw, byte_len, 1, NO_REPLY_HANDLE, 0) };
-        let wrong: KindId<FakePod> = KindId::__new(8);
-        assert!(mail.decode(wrong).is_none());
-    }
-
-    #[test]
-    fn mail_decode_wrong_count_returns_none() {
-        let values = [FakePod { a: 5, b: 9 }, FakePod { a: 1, b: 1 }];
-        let ptr_raw = values.as_ptr().addr();
-        let byte_len = (size_of::<FakePod>() * 2) as u32;
-        // SAFETY: see module-level test fixture justification above.
-        let mail = unsafe { Mail::__from_ptr(7, ptr_raw, byte_len, 2, NO_REPLY_HANDLE, 0) };
-        let kind: KindId<FakePod> = KindId::__new(7);
-        // `decode` requires count == 1; use `decode_slice` for batches.
-        assert!(mail.decode(kind).is_none());
-    }
-
-    #[test]
-    fn mail_decode_slice_roundtrip() {
-        let values = [FakePod { a: 1, b: 2 }, FakePod { a: 3, b: 4 }];
-        let ptr_raw = values.as_ptr().addr();
-        let byte_len = (size_of::<FakePod>() * 2) as u32;
-        // SAFETY: see module-level test fixture justification above.
-        let mail = unsafe { Mail::__from_ptr(7, ptr_raw, byte_len, 2, NO_REPLY_HANDLE, 0) };
-        let kind: KindId<FakePod> = KindId::__new(7);
-        let out = mail
-            .decode_slice(kind)
-            .expect("test setup: matching kind id decodes slice");
-        assert_eq!(out, &values);
-    }
 
     #[test]
     fn mail_sender_none_for_sentinel_handle() {
@@ -607,65 +438,6 @@ mod tests {
         let prior = unsafe { PriorState::__from_ptr(3, buf.as_ptr().addr(), buf.len()) };
         assert_eq!(prior.schema_version(), 3);
         assert_eq!(prior.bytes(), &buf);
-    }
-
-    #[test]
-    fn mail_is_typed_matches_kind_id() {
-        // SAFETY: no pointer is dereferenced (`is::<K>` reads `kind`).
-        let mail = unsafe { Mail::__from_ptr(FakeKind::ID.0, 0, 0, 0, NO_REPLY_HANDLE, 0) };
-        assert!(mail.is::<FakeKind>());
-        assert!(!mail.is::<FakePod>());
-    }
-
-    #[test]
-    fn mail_decode_typed_roundtrip() {
-        let value = FakePod { a: 5, b: 9 };
-        let ptr_raw = (&raw const value).addr();
-        let byte_len = size_of::<FakePod>() as u32;
-        // SAFETY: see module-level test fixture justification above.
-        let mail =
-            unsafe { Mail::__from_ptr(FakePod::ID.0, ptr_raw, byte_len, 1, NO_REPLY_HANDLE, 0) };
-        let out = mail
-            .decode_typed::<FakePod>()
-            .expect("test setup: matching kind id decodes typed");
-        assert_eq!(out, value);
-    }
-
-    #[test]
-    fn mail_decode_typed_wrong_kind_returns_none() {
-        let value = FakePod { a: 5, b: 9 };
-        let ptr_raw = (&raw const value).addr();
-        let byte_len = size_of::<FakePod>() as u32;
-        // Kind id deliberately mismatched (FakeKind instead of FakePod).
-        // SAFETY: see module-level test fixture justification above.
-        let mail =
-            unsafe { Mail::__from_ptr(FakeKind::ID.0, ptr_raw, byte_len, 1, NO_REPLY_HANDLE, 0) };
-        assert!(mail.decode_typed::<FakePod>().is_none());
-    }
-
-    #[test]
-    fn mail_decode_typed_wrong_count_returns_none() {
-        let values = [FakePod { a: 5, b: 9 }, FakePod { a: 1, b: 1 }];
-        let ptr_raw = values.as_ptr().addr();
-        let byte_len = (size_of::<FakePod>() * 2) as u32;
-        // SAFETY: see module-level test fixture justification above.
-        let mail =
-            unsafe { Mail::__from_ptr(FakePod::ID.0, ptr_raw, byte_len, 2, NO_REPLY_HANDLE, 0) };
-        assert!(mail.decode_typed::<FakePod>().is_none());
-    }
-
-    #[test]
-    fn mail_decode_slice_typed_roundtrip() {
-        let values = [FakePod { a: 1, b: 2 }, FakePod { a: 3, b: 4 }];
-        let ptr_raw = values.as_ptr().addr();
-        let byte_len = (size_of::<FakePod>() * 2) as u32;
-        // SAFETY: see module-level test fixture justification above.
-        let mail =
-            unsafe { Mail::__from_ptr(FakePod::ID.0, ptr_raw, byte_len, 2, NO_REPLY_HANDLE, 0) };
-        let out = mail
-            .decode_slice_typed::<FakePod>()
-            .expect("test setup: matching kind id decodes typed slice");
-        assert_eq!(out, &values);
     }
 
     #[test]
@@ -816,33 +588,6 @@ mod tests {
             )
         };
         assert!(mail.decode_kind::<FakeKind>().is_none());
-    }
-
-    #[test]
-    fn mail_decode_typed_byte_len_mismatch_returns_none() {
-        // Cast decode now sanity-checks byte_len against
-        // `size_of::<K>() * count`. If the substrate ever delivers a
-        // mail whose declared byte_len doesn't match the kind's size,
-        // decode bails rather than reading the wrong window.
-        let value = FakePod { a: 5, b: 9 };
-        let ptr_raw = (&raw const value).addr();
-        let bogus_byte_len = (size_of::<FakePod>() + 4) as u32;
-        // SAFETY: the bogus `byte_len` is intentional; `decode_typed`
-        // detects the size mismatch and returns `None` before reading.
-        // The pointer is still valid for `size_of::<FakePod>()` bytes
-        // (the `value` allocation), so even if decode did read it
-        // would touch only valid memory.
-        let mail = unsafe {
-            Mail::__from_ptr(
-                FakePod::ID.0,
-                ptr_raw,
-                bogus_byte_len,
-                1,
-                NO_REPLY_HANDLE,
-                0,
-            )
-        };
-        assert!(mail.decode_typed::<FakePod>().is_none());
     }
 
     // ADR-0040 typed-state framing. `DropCtx::save_state_kind` can't be

--- a/crates/aether-actor/src/wasm/ctx.rs
+++ b/crates/aether-actor/src/wasm/ctx.rs
@@ -19,7 +19,7 @@ use aether_data::{Kind, MailboxId, mailbox_id_from_name};
 use crate::actor::ctx::mail_sender::MailSender;
 use crate::actor::ctx::outbound_reply::OutboundReply;
 use crate::actor::ctx::persistence::Persistence;
-use crate::actor::ctx::reply_mode::{Manual, ReplyMode, Single, Stream};
+use crate::actor::ctx::reply_mode::{Manual, ReplyMode, Single};
 use crate::actor::{
     Addressable, HandlesKind, Instanced, NamespaceError, Singleton, Subname,
     validate_namespace_segment,
@@ -243,18 +243,6 @@ impl<'a> WasmCtx<'a, Manual> {
         // capability, never adds it.
         unsafe { &mut *ptr::from_mut(self).cast::<WasmCtx<'a, Single>>() }
     }
-
-    /// ADR-0112 forward-only coercion to the reserved [`Stream`] view.
-    /// `#[handler::stream]` is rejected by the macro today, so this has
-    /// no in-tree caller yet; it exists so the stream class has its
-    /// downgrade path the day the emit surface lands.
-    #[doc(hidden)]
-    #[must_use]
-    pub fn as_stream(&mut self) -> &mut WasmCtx<'a, Stream> {
-        // SAFETY: same as `as_single` — `M` is `PhantomData`-only, so the
-        // marker swap is a layout-identity reborrow.
-        unsafe { &mut *ptr::from_mut(self).cast::<WasmCtx<'a, Stream>>() }
-    }
 }
 
 impl<M: ReplyMode> WasmCtx<'_, M> {
@@ -265,21 +253,6 @@ impl<M: ReplyMode> WasmCtx<'_, M> {
     #[doc(hidden)]
     pub fn __set_reply_to(&mut self, sender: Option<ReplyHandle>) {
         self.sender = sender.map(ReplyHandle::raw);
-    }
-
-    /// Reply with an explicit `sender` + cached `KindId<K>`.
-    ///
-    /// Prefer the trait surface: [`OutboundReply::reply`] replies to the
-    /// dispatcher-stamped sender (a no-op when there's none), and
-    /// [`OutboundReply::reply_to`] takes an explicit [`ReplyHandle`]. Both
-    /// derive the kind from `K::ID`, so the cached `KindId<K>` argument
-    /// here is redundant.
-    #[deprecated(
-        note = "use OutboundReply::reply / reply_to; ADR-0100 dropped the Serialize bound"
-    )]
-    pub fn reply_kind<K: Kind>(&self, sender: ReplyHandle, kind: KindId<K>, payload: &K) {
-        let bytes = payload.encode_into_bytes();
-        mail::reply_mail(sender.raw(), kind.raw(), &bytes, 1, self.mailbox);
     }
 
     /// Reply target for the mail currently being dispatched. Mirrors
@@ -1139,7 +1112,7 @@ mod tests {
 
     /// ADR-0112: the mode marker is layout-neutral — the `Single` and
     /// `Manual` views have identical size + alignment. This is the
-    /// invariant the `as_single` / `as_stream` pointer reborrows rest on.
+    /// invariant the `as_single` pointer reborrow rests on.
     #[test]
     fn ffi_ctx_layout_identical_across_modes() {
         assert_eq!(

--- a/crates/aether-actor/src/wasm/mailbox.rs
+++ b/crates/aether-actor/src/wasm/mailbox.rs
@@ -22,7 +22,7 @@
 
 use core::marker::PhantomData;
 
-use aether_data::{ActorId, Kind, Tag, fold_lineage, mailbox_id_from_name, with_tag};
+use aether_data::{ActorId, Kind, Tag, fold_lineage, with_tag};
 
 use crate::actor::{Addressable, HandlesKind};
 use crate::wasm::inline::InlineRegistry;
@@ -89,30 +89,12 @@ impl<'a, R> WasmActorMailbox<'a, R> {
     /// Rewrap a precomputed `mailbox` id as a typed peer handle that
     /// inherits this handle's ctx binding (`sender` + inline registry), so
     /// the rewrapped handle's sends stamp the same origin and route the
-    /// same way. The by-id counterpart of [`Self::resolve_peer`], for a cap
-    /// that folds a child / session id itself rather than resolving by name.
+    /// same way. The by-id counterpart of [`Self::resolve_peer_scoped`], for
+    /// a cap that folds a child / session id itself rather than resolving by
+    /// name.
     #[must_use]
     pub fn at<Peer>(&self, mailbox: u64) -> WasmActorMailbox<'a, Peer> {
         WasmActorMailbox::__new(mailbox, self.sender, self.inline)
-    }
-
-    /// Resolve a sibling mailbox on the same transport, addressed by
-    /// `name`. Same FNV-hash name resolution as
-    /// [`crate::wasm::WasmCtx::resolve_actor`] — `name` must be the peer's
-    /// **full registered name** (flat ADR-0029 hash). A caller that needs
-    /// a lineage-folded child id (ADR-0099 §3) uses
-    /// [`Self::resolve_peer_scoped`] instead. Kept as an inherent
-    /// method so cap-owned ext traits (which only have a mailbox in
-    /// hand, not a ctx) can hand back peer handles without rethreading
-    /// the ctx. The resolving actor's `sender` + inline registry ride
-    /// through, so the peer handle's sends stamp the same origin and
-    /// route the same way.
-    // Runtime-name escape hatch (the by-name peer-resolution counterpart of
-    // `WasmCtx::resolve_actor`): the peer name is supplied at runtime.
-    #[must_use]
-    #[allow(clippy::disallowed_methods)]
-    pub fn resolve_peer<Peer: Addressable>(&self, name: &str) -> WasmActorMailbox<'a, Peer> {
-        WasmActorMailbox::__new(mailbox_id_from_name(name).0, self.sender, self.inline)
     }
 
     /// Resolve a child mailbox of *this* actor, where the child is the

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -22,7 +22,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use aether_actor::actor::ctx::{MailSender, OutboundReply};
-use aether_actor::{Addressable, HandlesKind, Manual, ReplyMode, Single, Singleton, Stream};
+use aether_actor::{Addressable, HandlesKind, Manual, ReplyMode, Single, Singleton};
 use core::marker::PhantomData;
 use core::ptr;
 
@@ -210,18 +210,6 @@ impl<'a> NativeCtx<'a, Manual> {
         // The reborrow swaps the marker without touching any real field and
         // only removes capability, never adds it.
         unsafe { &mut *ptr::from_mut(self).cast::<NativeCtx<'a, Single>>() }
-    }
-
-    /// ADR-0112 forward-only coercion to the reserved [`Stream`] view.
-    /// `#[handler::stream]` is rejected by the macro today, so this has
-    /// no in-tree caller yet; it exists so the stream class has its
-    /// downgrade path the day the emit surface lands.
-    #[doc(hidden)]
-    #[must_use]
-    pub fn as_stream(&mut self) -> &mut NativeCtx<'a, Stream> {
-        // SAFETY: same as `as_single` — `M` is `PhantomData`-only, so the
-        // marker swap is a layout-identity reborrow.
-        unsafe { &mut *ptr::from_mut(self).cast::<NativeCtx<'a, Stream>>() }
     }
 
     /// #1757: the per-dispatch constructor — moves the single dispatched
@@ -1300,7 +1288,7 @@ mod tests {
 
     /// ADR-0112: the mode marker is layout-neutral — the `Single` and
     /// `Manual` views have identical size + alignment. This is the
-    /// invariant the `as_single` / `as_stream` pointer reborrows rest on.
+    /// invariant the `as_single` pointer reborrow rests on.
     #[test]
     fn native_ctx_layout_identical_across_modes() {
         use std::mem::{align_of, size_of};

--- a/crates/aether-substrate/src/actor/native/mailbox.rs
+++ b/crates/aether-substrate/src/actor/native/mailbox.rs
@@ -17,7 +17,7 @@
 use core::marker::PhantomData;
 
 use aether_actor::{Addressable, HandlesKind};
-use aether_data::{ActorId, Kind, MailId, Tag, fold_lineage, mailbox_id_from_name, with_tag};
+use aether_data::{ActorId, Kind, MailId, Tag, fold_lineage, with_tag};
 
 use crate::actor::native::binding::NativeBinding;
 
@@ -109,32 +109,6 @@ impl<'a, R> NativeActorMailbox<'a, R> {
         self.binding
     }
 
-    /// Resolve a sibling mailbox on the same binding, addressed by
-    /// `name`. Same FNV-hash name resolution as
-    /// [`NativeCtx::resolve_actor`](crate::actor::native::ctx::NativeCtx) —
-    /// `name` must be the peer's **full
-    /// registered name** (flat ADR-0029 hash). A caller that needs a
-    /// lineage-folded child id (ADR-0099 §3) uses
-    /// [`Self::resolve_peer_scoped`] instead. Kept as an inherent method
-    /// so cap-owned ext traits (which only have a mailbox in hand, not a
-    /// ctx) can hand back peer handles without rethreading the ctx.
-    /// Threads the existing `'a` binding ref, so the returned handle
-    /// inherits the parent mailbox's borrow lifetime.
-    // Runtime-name escape hatch (the by-name peer-resolution counterpart of
-    // `NativeCtx::resolve_actor`): the peer name is supplied at runtime.
-    #[must_use]
-    #[allow(clippy::disallowed_methods)]
-    pub fn resolve_peer<Peer: Addressable>(&self, name: &str) -> NativeActorMailbox<'a, Peer> {
-        // Carry this handle's captured lineage onto the peer handle so a
-        // send from it stays in the caller's chain (ADR-0080 §7).
-        NativeActorMailbox::__new_in_flight(
-            mailbox_id_from_name(name).0,
-            self.binding,
-            self.parent,
-            self.root,
-        )
-    }
-
     /// Resolve a child mailbox of *this* actor, where the child is the
     /// instanced node `scope:segment` (ADR-0099 §3). The child's id folds
     /// that node's `ActorId` onto this actor's lineage carry, so a cap
@@ -142,7 +116,7 @@ impl<'a, R> NativeActorMailbox<'a, R> {
     /// component, a socket listener reaching a session — composes the
     /// registered fold id without allocating a name. `self.mailbox` is
     /// the parent carry (exact for a root-pinned cap, depth-1). Threads
-    /// the existing `'a` binding ref like [`Self::resolve_peer`].
+    /// the existing `'a` binding ref from the parent handle.
     #[must_use]
     pub fn resolve_peer_scoped<Peer: Addressable>(
         &self,

--- a/docs/guide/foundations/actor-model.md
+++ b/docs/guide/foundations/actor-model.md
@@ -128,9 +128,8 @@ it handles from the method's **third parameter**:
 impl WasmActor for Hello {
     const NAMESPACE: &'static str = "hello";
 
-    fn init<C>(ctx: &mut C) -> Result<Self, BootError>
-    where C: Resolver {
-        Ok(Hello { pong: ctx.resolve::<Pong>() })
+    fn init<C: Resolver>(_ctx: &mut C) -> Result<Self, BootError> {
+        Ok(Hello)
     }
 
     fn wire(&mut self, ctx: &mut WasmCtx<'_>) {
@@ -142,10 +141,10 @@ impl WasmActor for Hello {
         ctx.actor::<RenderCapability>().send(&TRIANGLE);   // draw every tick
     }
 
-    #[handler]
-    fn on_ping(&mut self, ctx: &mut WasmCtx<'_>, ping: Ping) {
+    #[handler::manual]
+    fn on_ping(&mut self, ctx: &mut WasmCtx<'_, Manual>, ping: Ping) {
         if let Some(sender) = ctx.reply_target() {
-            ctx.reply_kind(sender, self.pong, &Pong { seq: ping.seq });
+            ctx.reply_to(sender, &Pong { seq: ping.seq });
         }
     }
 }


### PR DESCRIPTION
Closes #2092.

## Summary

`aether-actor` (and its native mirror in `aether-substrate`) carried two pockets of public API that no production code, macro, or consumer called — only their own doc-comments and unit tests referenced them. Semantic find-references across the workspace confirmed each item dead before removal:

- **Group A** (zero callers anywhere): `WasmCtx::reply_kind`, `WasmCtx::as_stream`, `WasmActorMailbox::resolve_peer`.
- **Group B** (the `KindId<K>` bytemuck cast-decode family on `Mail`, exercised only by its own unit tests): `Mail::{decode, decode_slice, decode_typed, decode_slice_typed, is}` and the ten orphaned tests. The live path (`Mail::decode_kind` / `as_kind`) is untouched, and its six `mail_decode_kind_*` tests stay.
- **Native parallels**: `NativeCtx::as_stream`, `NativeActorMailbox::resolve_peer`.

Orphaned intra-doc links and prose mentions were reworded so `cargo doc -D warnings` stays clean. Deletion fallout cleaned up: an elidable lifetime on `impl Mail`, unused imports/fixtures, and the `single_handler_cannot_reply.stderr` snapshot (the removed `reply_kind` no longer appears in the compiler's "similar name" hint).

## Test plan

`scripts/preflight.sh` green — fmt, clippy `--workspace --all-targets -D warnings`, `cargo doc --workspace --no-deps`, `cargo nextest run --workspace` (2177 passed, 9 skipped), and the wasm32 component cross-build (confirms the guest FFI shims still compile after the `WasmCtx` / `Mail` surface shrink). The live `decode_kind` suite stays intact.

## Generated by

`/implement` — agent execution of scoped issue #2092.
