### PR TITLE
chore(repo): remove remaining postcard references across the workspace

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -426,8 +426,8 @@ fn expand_schema_struct(fields: &[FieldInfo]) -> syn::Result<TokenStream2> {
         let name = match &f.ident {
             Some(id) => id.to_string(),
             // Tuple struct field — name positionally so the hub still
-            // has something to render in `describe_kinds`. Postcard
-            // doesn't care; field names are advisory metadata.
+            // has something to render in `describe_kinds`. The wire
+            // format doesn't care; field names are advisory metadata.
             None => idx.to_string(),
         };
         let ty_expr = field_type_schema_expr(&f.ty);
@@ -2729,7 +2729,7 @@ fn expand_native_actor_trait(item: ItemImpl, opts: ActorOpts) -> syn::Result<Tok
             // Slice handler — payload is `count * size_of::<K>()`
             // contiguous bytes (ADR-0019 batch wire). Cast to `&[K]`
             // for the handler. Only meaningful for cast-shape kinds;
-            // postcard kinds have no batched wire shape.
+            // structured kinds have no batched wire shape.
             quote! {
                 if __aether_kind.0 == <#kind_ty as ::aether_data::Kind>::ID.0 {
                     if let Some(__aether_decoded) =
@@ -3104,7 +3104,7 @@ fn validate_native_fallback_sig(sig: &Signature) -> syn::Result<()> {
 ///     contiguous `&[K]` slice via `decode_cast_slice` so a single
 ///     envelope with `count > 1` (`Mailbox::send_many`, ADR-0019)
 ///     reaches the handler intact. Only meaningful for cast-shape
-///     kinds; postcard kinds have no batch wire.
+///     kinds; structured kinds have no batch wire.
 ///
 /// Issue 629 / Phase B: `&mut self` is now allowed alongside `&self`.
 /// The dispatcher owns the cap as `Box<A>` and calls each handler
@@ -3266,7 +3266,7 @@ fn validate_fallback_sig(sig: &Signature) -> syn::Result<()> {
 /// Synthesized body of `__aether_dispatch`. Compares `mail.kind()`
 /// against each `<K as Kind>::ID` const (ADR-0030 Phase 2); on match,
 /// decodes via `Mail::decode_kind::<K>()` and calls the inherent-impl
-/// handler method. Wire shape (cast vs postcard) is picked at K's
+/// handler method. Wire shape (cast vs structured) is picked at K's
 /// `Kind` derive site, not here — `Kind::decode_from_bytes` carries
 /// the per-K body — so this dispatcher never sees the wire choice.
 /// Returns `DISPATCH_HANDLED` on a match or when the `#[fallback]`
@@ -3414,7 +3414,7 @@ fn build_inputs_manifest_consts(
                     );
                 // Per-record section version byte, bumped to 0x05 by
                 // ADR-0118 (issue 1984) — the record is now the owned
-                // aether-wire encoding rather than postcard. Keep in
+                // aether-wire encoding. Keep in
                 // lockstep with `INPUTS_SECTION_VERSION`.
                 out[pos] = 0x05;
                 pos += 1;

--- a/crates/aether-actor-derive/tests/derive.rs
+++ b/crates/aether-actor-derive/tests/derive.rs
@@ -8,7 +8,7 @@
 //     correctly across `#[repr(C)]` / non-repr / nested-substructure
 //     cases.
 //   - `#[derive(Schema)]` produces the right `SchemaType` for unit,
-//     tuple, named-field, cast-eligible, postcard-shaped, and
+//     tuple, named-field, cast-eligible, structured-shaped, and
 //     enum-shaped inputs.
 //   - The `Vec<u8>` field-level specialization lands as `Bytes`, not
 //     `Vec(Scalar(U8))`.
@@ -116,7 +116,7 @@ fn cast_eligible_propagates_through_array_of_substruct() {
 }
 
 #[test]
-fn postcard_struct_marks_repr_c_false_and_specializes_bytes() {
+fn structured_struct_marks_repr_c_false_and_specializes_bytes() {
     const { assert!(!<Note as CastEligible>::ELIGIBLE) };
     let SchemaType::Struct { repr_c, fields } = &<Note as Schema>::SCHEMA else {
         panic!("expected Struct schema");
@@ -200,7 +200,7 @@ fn enum_emits_each_variant_shape_with_sequential_discriminants() {
 // aether-data dispatches through the existing trait. These tests
 // pin that integration: a struct with a `Ref<K>` field gets a
 // `SchemaType::Ref` arm in its layout, the parent's CastEligible
-// flips to false (refs force postcard), and the wire roundtrips
+// flips to false (refs force structured), and the wire roundtrips
 // for both Inline and Handle variants.
 
 #[derive(Serialize, Deserialize, aether_data::Kind, aether_data::Schema)]
@@ -216,7 +216,7 @@ fn ref_field_lands_as_schema_ref_pointing_at_inner_kind() {
     let SchemaType::Struct { fields, repr_c } = &<HeldNote as Schema>::SCHEMA else {
         panic!("expected Struct schema");
     };
-    // Ref<K> forces postcard — a parent with a Ref field can't
+    // Ref<K> forces structured — a parent with a Ref field can't
     // claim `repr_c: true` no matter how the rest of the fields
     // look. ADR-0045 §1.
     assert!(!*repr_c);
@@ -298,7 +298,7 @@ fn ref_schema_cell_uses_static_pointer_for_const_construction() {
 fn cast_eligible_blocked_by_non_pod_field_even_with_repr_c() {
     // A struct with `#[repr(C)]` but a non-eligible field type must
     // still report `ELIGIBLE = false`. Catching this is what stops
-    // the substrate from misclassifying a postcard kind as cast-able.
+    // the substrate from misclassifying a structured kind as cast-able.
     //
     // Kind derive is intentionally omitted here — the autodetect rule
     // (cast iff `#[repr(C)]`) would emit a `decode_cast` body that

--- a/crates/aether-actor/src/actor/ctx/mail_sender.rs
+++ b/crates/aether-actor/src/actor/ctx/mail_sender.rs
@@ -31,7 +31,7 @@ use crate::actor::{HandlesKind, Singleton};
 /// is resolved through `R::resolve(caller_carry)` (ADR-0099 §5) — the
 /// same lineage-aware path `ctx.actor::<R>()` walks — so a non-root
 /// receiver routes to the lineage-folded id, not the flat
-/// `hash(R::NAMESPACE)`. Wire shape (cast or postcard) follows
+/// `hash(R::NAMESPACE)`. Wire shape (cast or structured) follows
 /// `Kind::encode_into_bytes` (issue #240).
 pub trait MailSender {
     /// Send a single payload of kind `K` to the singleton instance of
@@ -50,7 +50,7 @@ pub trait MailSender {
         K: Kind;
 
     /// Send a slice of cast-shape payloads as a contiguous batch.
-    /// Cast-only — postcard has no efficient batched wire shape.
+    /// Cast-only — structured kinds have no efficient batched wire shape.
     fn send_many<R, K>(&mut self, payloads: &[K])
     where
         R: Singleton + HandlesKind<K>,

--- a/crates/aether-actor/src/actor/ctx/outbound_reply.rs
+++ b/crates/aether-actor/src/actor/ctx/outbound_reply.rs
@@ -46,7 +46,7 @@ pub trait OutboundReply: MailSender {
     fn source_mailbox(&self) -> Option<MailboxId>;
 
     /// Reply to the originator of the mail currently being dispatched.
-    /// No-op when there's no reply target. Wire shape (cast or postcard)
+    /// No-op when there's no reply target. Wire shape (cast or structured)
     /// follows `Kind::encode_into_bytes` (ADR-0100), so a reply needs
     /// only `K: Kind` — a `Pod`-without-`Serialize` cast kind is
     /// repliable.

--- a/crates/aether-actor/src/mail/mod.rs
+++ b/crates/aether-actor/src/mail/mod.rs
@@ -90,7 +90,7 @@ pub struct Mail<'a> {
     // sources from `mail.payload.len()` and threads through the
     // receive ABI as a frame parameter (sibling of `kind`/`count`/
     // `sender`). Cast decoders sanity-check against
-    // `size_of::<K>() * count`; postcard decoders use it as the
+    // `size_of::<K>() * count`; structured decoders use it as the
     // exact slice length so the parser can't run past the substrate-
     // written bytes into adjacent linear memory.
     byte_len: u32,
@@ -173,7 +173,7 @@ impl Mail<'_> {
 
     /// Total bytes the substrate placed at `ptr` for this delivery.
     /// Cast decoders treat this as a sanity check
-    /// (`size_of::<K>() * count`); postcard decoders use it as the
+    /// (`size_of::<K>() * count`); structured decoders use it as the
     /// exact slice length so the parser is bounded by the substrate-
     /// written region rather than reading into adjacent memory.
     #[must_use]
@@ -211,7 +211,7 @@ impl Mail<'_> {
 
     /// Decode a single inbound `K` via the wire shape `K`'s `Kind`
     /// derive baked into `Kind::decode_from_bytes` — cast for
-    /// `#[repr(C)]` + `Pod` types, postcard for schema-shaped types.
+    /// `#[repr(C)]` + `Pod` types, structured for schema-shaped types.
     /// This is the canonical receive-side decode and what the
     /// `#[actor]` dispatcher calls on every typed handler.
     ///
@@ -221,7 +221,7 @@ impl Mail<'_> {
     /// Returns `None` on kind mismatch, on `count != 1`, or when
     /// `K::decode_from_bytes` itself returns `None` — which can be
     /// either the default body for hand-rolled `Kind` impls that
-    /// didn't override, a cast-size mismatch, or a postcard decode
+    /// didn't override, a cast-size mismatch, or a structured decode
     /// error.
     #[must_use]
     pub fn decode_kind<K: Kind>(&self) -> Option<K> {
@@ -232,7 +232,7 @@ impl Mail<'_> {
         // substrate's receive ABI; the substrate guarantees
         // `self.byte_len` bytes valid at `self.ptr` for this `Mail`'s
         // lifetime. Bounding the slice by `byte_len` keeps
-        // `K::decode_from_bytes` (cast or postcard) from running past
+        // `K::decode_from_bytes` (cast or structured) from running past
         // the substrate-written region into adjacent linear memory.
         let bytes = unsafe { slice::from_raw_parts(self.ptr as *const u8, self.byte_len as usize) };
         K::decode_from_bytes(bytes)
@@ -358,12 +358,12 @@ mod tests {
         const ID: DataKindId = DataKindId(0xDEAD_BEEF_0001_0001);
     }
 
-    /// Postcard-shape kind for the schema-driven `decode_kind` path.
+    /// Structured-shape kind for the schema-driven `decode_kind` path.
     #[derive(
         ::aether_data::Kind, ::aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq,
     )]
-    #[kind(name = "test.fake_postcard")]
-    struct FakePostcard {
+    #[kind(name = "test.fake_structured")]
+    struct FakeStructured {
         tag: String,
         ids: Vec<u32>,
     }
@@ -441,8 +441,8 @@ mod tests {
     }
 
     #[test]
-    fn mail_decode_kind_postcard_roundtrip() {
-        let value = FakePostcard {
+    fn mail_decode_kind_structured_roundtrip() {
+        let value = FakeStructured {
             tag: String::from("greet"),
             ids: alloc::vec![1, 2, 3, 4],
         };
@@ -451,7 +451,7 @@ mod tests {
         // `mail`; its `(addr, len)` pair is valid for the rest of the body.
         let mail = unsafe {
             Mail::__from_ptr(
-                FakePostcard::ID.0,
+                FakeStructured::ID.0,
                 bytes.as_ptr().addr(),
                 bytes.len() as u32,
                 1,
@@ -459,7 +459,7 @@ mod tests {
                 0,
             )
         };
-        let out = mail.decode_kind::<FakePostcard>().expect("decode");
+        let out = mail.decode_kind::<FakeStructured>().expect("decode");
         assert_eq!(out, value);
     }
 
@@ -498,7 +498,7 @@ mod tests {
 
     #[test]
     fn mail_decode_kind_wrong_kind_returns_none() {
-        let value = FakePostcard {
+        let value = FakeStructured {
             tag: String::from("x"),
             ids: alloc::vec![],
         };
@@ -515,12 +515,12 @@ mod tests {
                 0,
             )
         };
-        assert!(mail.decode_kind::<FakePostcard>().is_none());
+        assert!(mail.decode_kind::<FakeStructured>().is_none());
     }
 
     #[test]
     fn mail_decode_kind_wrong_count_returns_none() {
-        let value = FakePostcard {
+        let value = FakeStructured {
             tag: String::from("x"),
             ids: alloc::vec![],
         };
@@ -529,7 +529,7 @@ mod tests {
         // valid for `bytes.len()` bytes for the rest of the body.
         let mail = unsafe {
             Mail::__from_ptr(
-                FakePostcard::ID.0,
+                FakeStructured::ID.0,
                 bytes.as_ptr().addr(),
                 bytes.len() as u32,
                 2,
@@ -537,12 +537,12 @@ mod tests {
                 0,
             )
         };
-        assert!(mail.decode_kind::<FakePostcard>().is_none());
+        assert!(mail.decode_kind::<FakeStructured>().is_none());
     }
 
     #[test]
     fn mail_decode_kind_truncated_bytes_returns_none() {
-        let value = FakePostcard {
+        let value = FakeStructured {
             tag: String::from("longer"),
             ids: alloc::vec![1, 2, 3],
         };
@@ -555,7 +555,7 @@ mod tests {
         // valid even though it's deliberately a truncation.
         let mail = unsafe {
             Mail::__from_ptr(
-                FakePostcard::ID.0,
+                FakeStructured::ID.0,
                 bytes.as_ptr().addr(),
                 2,
                 1,
@@ -563,7 +563,7 @@ mod tests {
                 0,
             )
         };
-        assert!(mail.decode_kind::<FakePostcard>().is_none());
+        assert!(mail.decode_kind::<FakeStructured>().is_none());
     }
 
     #[test]

--- a/crates/aether-actor/src/wasm/bridge/mail.rs
+++ b/crates/aether-actor/src/wasm/bridge/mail.rs
@@ -18,10 +18,10 @@
 use crate::wasm::raw;
 
 /// Push a typed payload at `recipient`. `bytes` is the wire
-/// encoding of the payload (cast for `#[repr(C)]` kinds, postcard
+/// encoding of the payload (cast for `#[repr(C)]` kinds, structured
 /// for schema-shaped kinds — `Kind::encode_into_bytes` already
 /// resolves which). `count` is `1` for a single send and N for a
-/// batch (cast-only — postcard has no efficient batched wire
+/// batch (cast-only — structured kinds have no efficient batched wire
 /// shape, see `WasmActorMailbox::send_many`).
 ///
 /// `detached` carries the ADR-0080 §7 lineage signal. `false` (the

--- a/crates/aether-actor/src/wasm/mailbox.rs
+++ b/crates/aether-actor/src/wasm/mailbox.rs
@@ -136,7 +136,7 @@ impl<R: Addressable> WasmActorMailbox<'_, R> {
     /// back into the caller's chain. Reach for [`Self::send_detached`]
     /// for the rare fire-and-forget send that should start its own chain.
     ///
-    /// Wire shape (cast or postcard) follows `Kind::encode_into_bytes`
+    /// Wire shape (cast or structured) follows `Kind::encode_into_bytes`
     /// — same single source of truth as the kind-typed sends per
     /// issue #240.
     pub fn send<K>(&self, payload: &K)

--- a/crates/aether-actor/tests/state_framing_roundtrip.rs
+++ b/crates/aether-actor/tests/state_framing_roundtrip.rs
@@ -93,7 +93,7 @@ fn reshaped_state_kind_misses_decode_with_bytes_present() {
     let (_, buf) = ctx.saved.expect("dehydrate deposits a bundle");
 
     // The reshaped kind has a different `Kind::ID`, so the leading-id
-    // compare in `as_kind` rejects before postcard runs.
+    // compare in `as_kind` rejects before the structured decode runs.
     assert_ne!(
         CounterState::ID,
         CounterStateReshaped::ID,

--- a/crates/aether-capabilities/src/component.rs
+++ b/crates/aether-capabilities/src/component.rs
@@ -221,7 +221,7 @@ mod native {
         /// and replies `LoadResult::Ok { mailbox_id, name,
         /// capabilities }` where `name` is the full trampoline
         /// address — agents send subsequent mail to that name.
-        /// Errors (bad postcard, kind conflict, name conflict,
+        /// Errors (bad wire bytes, kind conflict, name conflict,
         /// invalid wasm, instantiation trap) come back as
         /// `LoadResult::Err`.
         #[handler]

--- a/crates/aether-capabilities/src/dag/test_support.rs
+++ b/crates/aether-capabilities/src/dag/test_support.rs
@@ -389,12 +389,12 @@ mod test_deferred_call {
     }
 }
 
-/// A postcard-shape number kind — the transform fixtures' input +
-/// output (ADR-0048 §3, iamacoffeepot/aether#1012). Postcard (serde)
+/// A structured-shape number kind — the transform fixtures' input +
+/// output (ADR-0048 §3, iamacoffeepot/aether#1012). Structured (serde)
 /// rather than cast because `ctx.reply` requires `Serialize`; the
-/// transform's decode / encode picks postcard automatically from the
-/// non-`#[repr(C)]` shape, so source bytes and transform input bytes
-/// agree.
+/// transform's decode / encode picks the structured path automatically
+/// from the non-`#[repr(C)]` shape, so source bytes and transform input
+/// bytes agree.
 #[derive(
     Copy,
     Clone,

--- a/crates/aether-capabilities/src/dag/tests.rs
+++ b/crates/aether-capabilities/src/dag/tests.rs
@@ -135,7 +135,7 @@ fn enqueue<K: Kind>(registry: &Registry, mailbox_name: &str, payload: &K, sender
 }
 
 /// Drain egress until a `ToSession` reply of kind `K` arrives, decoding
-/// it via postcard. Panics on timeout.
+/// it via the wire format. Panics on timeout.
 fn await_session_reply<K: Kind>(rx: &Receiver<EgressEvent>, timeout: Duration) -> K {
     let deadline = Instant::now() + timeout;
     loop {

--- a/crates/aether-capabilities/src/inventory.rs
+++ b/crates/aether-capabilities/src/inventory.rs
@@ -188,9 +188,9 @@ mod native {
         /// calls this on the first `send_mail` for an unknown kind
         /// name, then reuses the cached vocabulary until the next miss
         /// (no TTL, no background poll). The schema rides as opaque
-        /// wire bytes (`schema_postcard`) because `SchemaType` has
+        /// wire bytes (`schema_wire`) because `SchemaType` has
         /// no `Schema` impl of its own; decode it with
-        /// `wire::from_bytes::<SchemaType>(&desc.schema_postcard)`.
+        /// `wire::from_bytes::<SchemaType>(&desc.schema_wire)`.
         #[handler]
         fn on_list_kinds(&mut self, _ctx: &mut NativeCtx<'_>, _mail: ListKinds) -> ListKindsResult {
             let kinds = self
@@ -203,12 +203,12 @@ mod native {
                     // serialization is infallible for `SchemaType`
                     // (no `Map<String, _>` non-string-key edge cases
                     // because every nested field is a derive output).
-                    let schema_postcard = wire::to_vec(&desc.schema)
+                    let schema_wire = wire::to_vec(&desc.schema)
                         .expect("SchemaType always wire-encodes (ADR-0118 canonical form)");
                     KindDescriptorWire {
                         id: KindId(kind_id_from_parts(&desc.name, &desc.schema)),
                         name: desc.name,
-                        schema_postcard,
+                        schema_wire,
                     }
                 })
                 .collect();
@@ -414,7 +414,7 @@ mod native {
         /// — emulating the `register_or_match_all` path
         /// `ComponentHostCapability::handle_load` follows — shows up in
         /// the reply with the matching `KindId`, name, and a
-        /// postcard-encoded `SchemaType` that decodes back to the
+        /// wire-encoded `SchemaType` that decodes back to the
         /// original schema. This is the live-projection ADR-0091
         /// requires: the same `Arc<Registry>` `component.rs` mutates is
         /// what the cap reads on every call.
@@ -456,8 +456,8 @@ mod native {
                     )
                 });
             assert_eq!(entry.id, expected_id, "id matches kind_id_from_parts");
-            let schema: SchemaType = wire::from_bytes(&entry.schema_postcard)
-                .expect("schema_postcard round-trips through wire");
+            let schema: SchemaType =
+                wire::from_bytes(&entry.schema_wire).expect("schema_wire round-trips through wire");
             assert!(
                 matches!(schema, SchemaType::String),
                 "schema decodes back to the originally registered SchemaType",

--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -2,7 +2,7 @@
 //!
 //! Singleton actor. Binds a `TcpListener` on the configured addr at
 //! init, runs a sidecar accept thread that spawns one reader thread
-//! per accepted connection. Reader threads frame postcard
+//! per accepted connection. Reader threads read
 //! length-prefix frames via [`aether_codec::frame`] and push them
 //! through an internal mpsc; an `RpcInboundReady` wake mail tells the
 //! cap's dispatcher to drain.
@@ -1599,7 +1599,7 @@ mod tests {
     /// variant — protects the wire shape against accidental rename /
     /// re-ordering.
     #[test]
-    fn rpc_error_frame_too_large_postcard_roundtrips() {
+    fn rpc_error_frame_too_large_structured_roundtrips() {
         use crate::rpc::RpcError;
         use aether_data::wire;
         let err = RpcError::FrameTooLarge {

--- a/crates/aether-codec/src/conformance.rs
+++ b/crates/aether-codec/src/conformance.rs
@@ -30,7 +30,7 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 use serde_json::{Value, json};
 
-use crate::test_fixtures::{named, postcard_struct, scalar};
+use crate::test_fixtures::{named, scalar, structured_struct};
 use crate::{decode_schema, encode_schema};
 
 /// The conformance law for one `(value, schema, json)` fixture: the
@@ -77,7 +77,7 @@ struct Scalars {
 }
 
 fn scalars_schema() -> SchemaType {
-    postcard_struct(vec![
+    structured_struct(vec![
         scalar("a", Primitive::U8),
         scalar("b", Primitive::U16),
         scalar("c", Primitive::U32),
@@ -142,7 +142,7 @@ struct Collections {
 }
 
 fn collections_schema() -> SchemaType {
-    postcard_struct(vec![
+    structured_struct(vec![
         named(
             "tags",
             SchemaType::Vec(SchemaCell::owned(SchemaType::String)),
@@ -165,7 +165,7 @@ fn collections_schema() -> SchemaType {
         named("blob", SchemaType::Bytes),
         named(
             "nested",
-            postcard_struct(vec![scalar("seq", Primitive::U32)]),
+            structured_struct(vec![scalar("seq", Primitive::U32)]),
         ),
     ])
 }
@@ -294,7 +294,7 @@ impl Kind for Leaf {
 }
 
 fn leaf_schema() -> SchemaType {
-    postcard_struct(vec![
+    structured_struct(vec![
         scalar("code", Primitive::U32),
         named("tag", SchemaType::String),
     ])
@@ -307,7 +307,7 @@ struct RefHolder {
 }
 
 fn ref_holder_schema() -> SchemaType {
-    postcard_struct(vec![
+    structured_struct(vec![
         named("held", SchemaType::Ref(SchemaCell::owned(leaf_schema()))),
         scalar("seq", Primitive::U32),
     ])

--- a/crates/aether-codec/src/decode.rs
+++ b/crates/aether-codec/src/decode.rs
@@ -109,7 +109,7 @@ impl error::Error for DecodeError {}
 
 /// Decode-side allocation budget, in the spirit of `frame.rs`'s
 /// `MAX_FRAME_SIZE`: a wire-decoded length must never drive the decoder
-/// into an unbounded allocation. Every postcard node charges one value
+/// into an unbounded allocation. Every structured node charges one value
 /// against a per-decode budget sized from the input length, so a crafted
 /// length — or a zero-wire-byte-element collection (`Unit`, field-less
 /// `Struct`) whose decode loop allocates per iteration without consuming
@@ -679,7 +679,7 @@ impl<'a> Cursor<'a> {
 mod tests {
     use super::*;
     use crate::encode_schema;
-    use crate::test_fixtures::{cast_struct, pending_ok_err_variants, postcard_struct, scalar};
+    use crate::test_fixtures::{cast_struct, pending_ok_err_variants, scalar, structured_struct};
     use aether_data::SchemaCell;
     use aether_data::tagged_id;
     use serde_json::json;
@@ -687,7 +687,7 @@ mod tests {
     /// Local alias preserving the decode-side spelling that the test
     /// bodies below already use.
     fn pc_struct(fields: Vec<NamedField>) -> SchemaType {
-        postcard_struct(fields)
+        structured_struct(fields)
     }
 
     /// Encode → decode → assert equal. The single most load-bearing
@@ -815,10 +815,10 @@ mod tests {
         assert!(matches!(err, DecodeError::Truncated { .. }));
     }
 
-    // Postcard path — primitives
+    // Structured path — primitives
 
     #[test]
-    fn postcard_bool_field() {
+    fn structured_bool_field() {
         roundtrip(
             json!({"flag": true}),
             &pc_struct(vec![NamedField {
@@ -836,7 +836,7 @@ mod tests {
     }
 
     #[test]
-    fn postcard_invalid_bool_byte_errors() {
+    fn structured_invalid_bool_byte_errors() {
         let schema = pc_struct(vec![NamedField {
             name: "flag".into(),
             ty: SchemaType::Bool,
@@ -846,7 +846,7 @@ mod tests {
     }
 
     #[test]
-    fn postcard_string_field() {
+    fn structured_string_field() {
         roundtrip(
             json!({"body": "hello world"}),
             &pc_struct(vec![NamedField {
@@ -857,7 +857,7 @@ mod tests {
     }
 
     #[test]
-    fn postcard_string_invalid_utf8_errors() {
+    fn structured_string_invalid_utf8_errors() {
         let schema = pc_struct(vec![NamedField {
             name: "body".into(),
             ty: SchemaType::String,
@@ -869,7 +869,7 @@ mod tests {
     }
 
     #[test]
-    fn postcard_bytes_field() {
+    fn structured_bytes_field() {
         roundtrip(
             json!({"blob": [1u8, 2, 3, 4, 5]}),
             &pc_struct(vec![NamedField {
@@ -880,7 +880,7 @@ mod tests {
     }
 
     #[test]
-    fn postcard_option_some_and_none() {
+    fn structured_option_some_and_none() {
         let schema = pc_struct(vec![NamedField {
             name: "name".into(),
             ty: SchemaType::Option(SchemaCell::owned(SchemaType::String)),
@@ -890,7 +890,7 @@ mod tests {
     }
 
     #[test]
-    fn postcard_vec_of_strings() {
+    fn structured_vec_of_strings() {
         let schema = pc_struct(vec![NamedField {
             name: "tags".into(),
             ty: SchemaType::Vec(SchemaCell::owned(SchemaType::String)),
@@ -899,7 +899,7 @@ mod tests {
     }
 
     #[test]
-    fn postcard_vec_of_nested_structs() {
+    fn structured_vec_of_nested_structs() {
         let inner = pc_struct(vec![scalar("seq", Primitive::U32)]);
         let schema = pc_struct(vec![NamedField {
             name: "items".into(),
@@ -918,12 +918,12 @@ mod tests {
     }
 
     #[test]
-    fn postcard_enum_unit_variant_decodes_as_string_tag() {
+    fn structured_enum_unit_variant_decodes_as_string_tag() {
         roundtrip(json!("Pending"), &sum_schema());
     }
 
     #[test]
-    fn postcard_enum_tuple_single_field_decodes_unwrapped() {
+    fn structured_enum_tuple_single_field_decodes_unwrapped() {
         // Encoder accepts both `{"Ok": 42}` and `{"Ok": [42]}` for
         // single-field tuples; decoder normalizes to the unwrapped
         // form so round-trip from `{"Ok": 42}` is byte-equal.
@@ -931,12 +931,12 @@ mod tests {
     }
 
     #[test]
-    fn postcard_enum_struct_variant() {
+    fn structured_enum_struct_variant() {
         roundtrip(json!({"Err": {"reason": "kind conflict"}}), &sum_schema());
     }
 
     #[test]
-    fn postcard_enum_unknown_discriminant_errors() {
+    fn structured_enum_unknown_discriminant_errors() {
         // discriminant 99 isn't in the schema; the u32 selector is
         // little-endian.
         let schema = sum_schema();
@@ -1030,7 +1030,7 @@ mod tests {
     #[test]
     fn map_inside_struct_field_roundtrip() {
         // The expected shape for the named v1 use case: a map field
-        // inside a postcard struct (HTTP-header-style descriptor).
+        // inside a structured struct (HTTP-header-style descriptor).
         let schema = pc_struct(vec![NamedField {
             name: "headers".into(),
             ty: map_schema(SchemaType::String, SchemaType::String),
@@ -1063,7 +1063,7 @@ mod tests {
     // ADR-0065: typed-id round-trips through both wire shapes.
 
     #[test]
-    fn type_id_postcard_round_trips_as_tagged_string() {
+    fn type_id_structured_round_trips_as_tagged_string() {
         // JSON in: tagged string. Wire: u64 varint. JSON out: same
         // tagged string. The post-migration shape an agent sees end
         // to end.

--- a/crates/aether-codec/src/encode.rs
+++ b/crates/aether-codec/src/encode.rs
@@ -861,7 +861,7 @@ fn oor(name: &str, ty: &str) -> EncodeError {
 mod tests {
     use super::*;
     use crate::test_fixtures::{
-        cast_struct, named, pending_ok_err_variants, postcard_struct, scalar,
+        cast_struct, named, pending_ok_err_variants, scalar, structured_struct,
     };
     use aether_data::SchemaCell;
     use serde_json::json;
@@ -1149,7 +1149,7 @@ mod tests {
     }
 
     fn pc_string_schema() -> SchemaType {
-        postcard_struct(vec![NamedField {
+        structured_struct(vec![NamedField {
             name: "body".into(),
             ty: SchemaType::String,
         }])
@@ -1180,7 +1180,7 @@ mod tests {
             blob: vec![1, 2, 3, 4, 5],
         };
         let expected = wire::to_vec(&value).expect("test setup: wire reference bytes");
-        let schema = postcard_struct(vec![NamedField {
+        let schema = structured_struct(vec![NamedField {
             name: "blob".into(),
             ty: SchemaType::Bytes,
         }]);
@@ -1194,7 +1194,7 @@ mod tests {
         // The wire codec is strict and canonical: a `Bytes` field accepts
         // only a JSON byte array. String / base64-object ergonomics live in
         // the aether-mcp preprocessor, never in the codec.
-        let schema = postcard_struct(vec![NamedField {
+        let schema = structured_struct(vec![NamedField {
             name: "blob".into(),
             ty: SchemaType::Bytes,
         }]);
@@ -1208,7 +1208,7 @@ mod tests {
 
     #[test]
     fn wire_option_some_and_none() {
-        let schema = postcard_struct(vec![NamedField {
+        let schema = structured_struct(vec![NamedField {
             name: "name".into(),
             ty: SchemaType::Option(SchemaCell::owned(SchemaType::String)),
         }]);
@@ -1237,7 +1237,7 @@ mod tests {
             tags: vec!["alpha".into(), "beta".into(), "gamma".into()],
         };
         let expected = wire::to_vec(&value).expect("test setup: wire reference vec<string>");
-        let schema = postcard_struct(vec![NamedField {
+        let schema = structured_struct(vec![NamedField {
             name: "tags".into(),
             ty: SchemaType::Vec(SchemaCell::owned(SchemaType::String)),
         }]);
@@ -1252,11 +1252,11 @@ mod tests {
             items: vec![Inner { seq: 1 }, Inner { seq: 256 }, Inner { seq: 0xDEAD }],
         };
         let expected = wire::to_vec(&value).expect("test setup: wire reference vec<inner>");
-        let inner_schema = postcard_struct(vec![NamedField {
+        let inner_schema = structured_struct(vec![NamedField {
             name: "seq".into(),
             ty: SchemaType::Scalar(Primitive::U32),
         }]);
-        let schema = postcard_struct(vec![NamedField {
+        let schema = structured_struct(vec![NamedField {
             name: "items".into(),
             ty: SchemaType::Vec(SchemaCell::owned(inner_schema)),
         }]);
@@ -1343,7 +1343,7 @@ mod tests {
         // `wire` serde adapter — that's the wire shape every receiving
         // substrate will decode into. Sender input is unsorted to lock in
         // the sort-by-encoded-key step.
-        let schema = postcard_struct(vec![NamedField {
+        let schema = structured_struct(vec![NamedField {
             name: "headers".into(),
             ty: map_schema(SchemaType::String, SchemaType::String),
         }]);
@@ -1490,7 +1490,7 @@ mod tests {
         // `mailbox` field carrying a tagged `mbx-...` string lands as
         // a fixed `u64` little-endian — wire-identical to a raw `u64`
         // field.
-        let schema = postcard_struct(vec![NamedField {
+        let schema = structured_struct(vec![NamedField {
             name: "mailbox".into(),
             ty: SchemaType::TypeId(aether_data::MailboxId::TYPE_ID),
         }]);
@@ -1507,7 +1507,7 @@ mod tests {
     fn type_id_wire_accepts_raw_number_for_back_compat() {
         // Pre-ADR-0065 callers passing a JSON number still work — the
         // codec falls through to the back-compat `as_unsigned` path.
-        let schema = postcard_struct(vec![NamedField {
+        let schema = structured_struct(vec![NamedField {
             name: "mailbox".into(),
             ty: SchemaType::TypeId(aether_data::MailboxId::TYPE_ID),
         }]);
@@ -1524,7 +1524,7 @@ mod tests {
         // A `KindId`-tagged string passed to a `MailboxId` field
         // surfaces a typed `OutOfRange` so the agent learns the field
         // expected `mbx-...` rather than corrupting the wire.
-        let schema = postcard_struct(vec![NamedField {
+        let schema = structured_struct(vec![NamedField {
             name: "mailbox".into(),
             ty: SchemaType::TypeId(aether_data::MailboxId::TYPE_ID),
         }]);
@@ -1564,7 +1564,7 @@ mod tests {
         // A schema declaring a `TypeId(...)` value the codec doesn't
         // recognise must surface `UnsupportedSchema` rather than
         // corrupt the wire or silently fall through.
-        let schema = postcard_struct(vec![NamedField {
+        let schema = structured_struct(vec![NamedField {
             name: "mystery".into(),
             ty: SchemaType::TypeId(0xdead_beef_cafe_f00d),
         }]);

--- a/crates/aether-codec/src/lib.rs
+++ b/crates/aether-codec/src/lib.rs
@@ -10,17 +10,17 @@
 //!      under it): `#[repr(C)]` byte layout. Decode is `bytemuck::cast`
 //!      on the substrate side; encode walks the schema and writes the
 //!      same layout.
-//!   2. Postcard (everything else): postcard 1.x wire format, written
-//!      and read directly to match the format byte-for-byte.
+//!   2. Structured (everything else): the `aether_data::wire` format,
+//!      written and read directly to match the format byte-for-byte.
 //!
-//! - **Stream framing** ([`frame`]): length-prefixed postcard for
+//! - **Stream framing** ([`frame`]): length-prefixed frames for
 //!   serde-derived enum types. The hub channel (`aether_hub::wire`)
 //!   is the first consumer; ADR-0072 placed framing here because the
 //!   helpers are codec-shaped and generic over `<T: Serialize>`.
 //!
 //! Future formats (msgpack, protobuf, save-format adapters) land as
 //! sibling modules. Future framing variants subdivide [`frame`] under
-//! `frame::postcard` / `frame::protobuf`.
+//! `frame::wire` / `frame::protobuf`.
 
 mod cast;
 #[cfg(test)]

--- a/crates/aether-codec/src/proptest_roundtrip.rs
+++ b/crates/aether-codec/src/proptest_roundtrip.rs
@@ -14,11 +14,11 @@
 //! exactly as the decoder emits it (so the round-trip is byte-for-byte,
 //! not merely structurally, equal).
 //!
-//! The two cast/postcard wire shapes both get coverage: a struct is
+//! The two cast/structured wire shapes both get coverage: a struct is
 //! generated with `repr_c: true` only when every field is cast-eligible
 //! (mirroring the encoder's own eligibility rule, [`cast_eligible`]), so
 //! the generator produces both the `bytemuck`-cast image and the
-//! postcard image. Values that the JSON layer cannot carry losslessly
+//! structured image. Values that the JSON layer cannot carry losslessly
 //! are excluded at the source — floats are finite and `f32`-representable
 //! (`serde_json` drops `NaN`/`Inf` to null), and `Map` keys honor the
 //! proto3-style `String` / integer-scalar / `Bool` restriction.

--- a/crates/aether-codec/src/test_fixtures.rs
+++ b/crates/aether-codec/src/test_fixtures.rs
@@ -1,6 +1,6 @@
 //! Cross-test `SchemaType` builders shared between `decode` and
 //! `encode` test modules. Both module-local copies of `scalar`,
-//! `cast_struct`, `postcard_struct`, and `pending_ok_err_variants`
+//! `cast_struct`, `structured_struct`, and `pending_ok_err_variants`
 //! moved here so adding a new schema test only declares the helper
 //! once. Kept in its own `#[cfg(test)]` module so production builds
 //! don't pull in the helpers and so the `pub(crate)` visibility
@@ -35,11 +35,9 @@ pub fn cast_struct(fields: Vec<NamedField>) -> SchemaType {
     }
 }
 
-/// `Struct { repr_c: false, fields }` — the postcard-shape struct
-/// builder, for the everything-else wire variant. Decode and encode
-/// modules historically named this `pc_struct` / `postcard_struct`
-/// respectively; the shared name is `postcard_struct`.
-pub fn postcard_struct(fields: Vec<NamedField>) -> SchemaType {
+/// `Struct { repr_c: false, fields }` — the structured-shape struct
+/// builder, for the everything-else wire variant.
+pub fn structured_struct(fields: Vec<NamedField>) -> SchemaType {
     SchemaType::Struct {
         fields: fields.into(),
         repr_c: false,

--- a/crates/aether-data/src/ids.rs
+++ b/crates/aether-data/src/ids.rs
@@ -1,12 +1,12 @@
 //! ADR-0065 typed id newtypes — `MailboxId`, `KindId`, `HandleId`.
 //!
-//! Each type is `#[repr(transparent)]` over a `u64` (postcard
-//! wire-identical to a raw u64; cast-shape kinds keep their
+//! Each type is `#[repr(transparent)]` over a `u64` (wire-identical
+//! to a raw u64; cast-shape kinds keep their
 //! `#[repr(C)]` layout) and exposes a `pub const TYPE_ID: u64`
 //! that downstream `Schema` impls (in `aether-data`) emit as
 //! `SchemaType::TypeId(Self::TYPE_ID)`. The hub's encoder/decoder
 //! dispatch on the `TYPE_ID` value to translate JSON (tagged-string
-//! form per ADR-0064) ↔ postcard (u64 varint) at the wire boundary.
+//! form per ADR-0064) ↔ the structured wire (u64 varint) at the wire boundary.
 //!
 //! The underlying `u64` carries the ADR-0064 tag bits (4-bit type
 //! discriminator in the high nibble + 60-bit FNV-1a hash in the low
@@ -35,7 +35,7 @@ fn fmt_tagged(id: u64, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 
 /// Shared serde body for typed-id types. Branches on the
 /// serializer's `is_human_readable` flag so binary backends
-/// (postcard, the substrate's wire format) get a raw `u64` varint
+/// (the substrate's wire format) get a raw `u64` varint
 /// while text backends (JSON, the MCP wire) get the ADR-0064
 /// tagged-string form. Falls back to a raw `u64` for reserved-tag
 /// sentinels (e.g. `MailboxId::NONE = 0`) so the encoder doesn't
@@ -54,7 +54,7 @@ fn serialize_id<S: Serializer>(id: u64, s: S) -> Result<S::Ok, S::Error> {
 /// Shared serde body for typed-id types. For human-readable
 /// formats (JSON), accepts either a tagged string or a raw u64
 /// number (back-compat for callers that haven't migrated). For
-/// binary formats (postcard), reads a raw u64 varint — the
+/// binary formats (the structured wire), reads a raw u64 varint — the
 /// substrate wire is byte-identical to a `u64` field.
 fn deserialize_id<'de, D: Deserializer<'de>>(d: D, expected: Tag) -> Result<u64, D::Error> {
     use serde::de::{self, Visitor};
@@ -155,7 +155,7 @@ impl MailboxId {
     /// Stable type id — FNV-1a of `TYPE_DOMAIN ++ TYPE_NAME`. The
     /// `Schema` impl (in `aether-data`) emits this as
     /// `SchemaType::TypeId(...)`; the hub's codec arms key on it to
-    /// pick the JSON/postcard translation.
+    /// pick the JSON/structured translation.
     pub const TYPE_ID: u64 = fnv1a_64_prefixed(TYPE_DOMAIN, b"aether.mailbox_id");
 
     /// Canonical name used to compute `TYPE_ID`. Surfaced by

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -13,7 +13,7 @@
 //!     zero-copy to `&T` or `&[T]`. Used for vertex streams, fixed-
 //!     layout structs, anything where throughput or zero-copy matters.
 //!   - Structural: `serde::Serialize + DeserializeOwned` types. Encoded
-//!     with postcard (Rust-native, varint-compact, no_std-friendly).
+//!     with the structured wire format (Rust-native, varint-compact, no_std-friendly).
 //!     Used for small control messages with Option/Vec/enum shape.
 //!
 //! A type picks one tier — not both — as part of its contract.
@@ -30,7 +30,7 @@
 //! - **`Ref<K>`** (ADR-0045): typed handle reference for fields that
 //!   may inline a value or carry a handle into the substrate's store.
 //! - **Encode / decode helpers**: the `encode` / `decode` family for
-//!   POD and postcard kinds.
+//!   POD and structured kinds.
 //! - **`__inventory`** (issue #243): native-only auto-collection of
 //!   `#[derive(Kind)]` types into the substrate's descriptor list.
 
@@ -114,7 +114,7 @@ pub trait Kind {
 
     /// Decode a single instance from substrate-supplied bytes. The
     /// `Kind` derive auto-implements this with the right body for the
-    /// type's wire shape (cast for `#[repr(C)]` + `Pod`, postcard
+    /// type's wire shape (cast for `#[repr(C)]` + `Pod`, structured
     /// otherwise). Hand-rolled `Kind` impls that don't participate in
     /// `#[actor]` receive dispatch can leave the default — it
     /// returns `None`, which the SDK surfaces as a strict-receiver
@@ -136,7 +136,7 @@ pub trait Kind {
     /// Encode `self` into a fresh byte buffer in the wire shape this
     /// kind was declared with. The `Kind` derive auto-implements this
     /// using the same `#[repr(C)]` autodetect as `decode_from_bytes`
-    /// (cast for `#[repr(C)]` + `NoUninit`, postcard otherwise), so a
+    /// (cast for `#[repr(C)]` + `NoUninit`, structured otherwise), so a
     /// single `Sink::send` / `Ctx::reply` call site dispatches both
     /// wire shapes without the caller picking the encoder.
     ///
@@ -150,7 +150,7 @@ pub trait Kind {
     fn encode_into_bytes(&self) -> Vec<u8> {
         panic!(
             "aether-data: Kind::encode_into_bytes called on `{}` whose impl does not override \
-             it. Use `#[derive(Kind)]` (which emits the body for cast or postcard kinds based \
+             it. Use `#[derive(Kind)]` (which emits the body for cast or structured kinds based \
              on `#[repr(C)]`) or hand-roll an override before sending.",
             Self::NAME,
         );
@@ -216,7 +216,7 @@ impl Kind for () {
 /// whose fields are all `CastEligible` is itself eligible *iff* it
 /// also carries `#[repr(C)]`. Anything containing a `String`, `Vec`,
 /// `Option`, enum, or non-`#[repr(C)]` substruct short-circuits to
-/// `false`, which forces the postcard wire path on the descriptor.
+/// `false`, which forces the structured wire path on the descriptor.
 pub trait CastEligible {
     const ELIGIBLE: bool;
 }
@@ -420,7 +420,7 @@ mod ref_serde {
     }
 
     /// Externally-tagged variant discriminant. Binary serializers (the
-    /// postcard wire) read it as `varint` → `visit_u64`; self-describing
+    /// structured wire) read it as `varint` → `visit_u64`; self-describing
     /// ones read the variant name → `visit_str`.
     enum VariantTag {
         Inline,

--- a/crates/aether-data/src/mail.rs
+++ b/crates/aether-data/src/mail.rs
@@ -28,7 +28,7 @@ use crate::{EngineId, MailboxId, Schema, SessionToken};
 /// "no inbound mail" is structurally distinct from "chassis as sender".
 ///
 /// Serde-serializable so the ADR-0080 `TraceEvent` (and its
-/// postcard-shaped `TraceRingEntry`, the per-actor ring's wire element)
+/// structured `TraceRingEntry`, the per-actor ring's wire element)
 /// can carry `MailId` when a trace ring is queried over the wire. The
 /// substrate's host-side `Envelope` and `Mail` types do not serialize,
 /// so the field additions on those remain wire-free.

--- a/crates/aether-data/src/schema.rs
+++ b/crates/aether-data/src/schema.rs
@@ -19,7 +19,7 @@ use core::ops::Deref;
 
 /// One entry in `Hello.kinds`: a kind-name plus its schema. The hub
 /// uses the schema to encode agent-supplied params into the exact
-/// bytes the engine expects (cast-shaped or postcard, ADR-0019).
+/// bytes the engine expects (cast-shaped or structured, ADR-0019).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct KindDescriptor {
     pub name: String,
@@ -75,7 +75,7 @@ pub enum MailboxCategory {
 /// kind's payload in enough detail for the hub to encode it from
 /// agent-supplied params and the substrate to decode it into a typed
 /// value. `Struct.repr_c = true` selects the cast-shaped wire format
-/// (raw `#[repr(C)]` bytes); everything else is postcard.
+/// (raw `#[repr(C)]` bytes); everything else is structured.
 ///
 /// Restrictions on `repr_c = true` (enforced by the SDK derive, not
 /// the wire format): only legal when every field is itself
@@ -118,7 +118,7 @@ pub enum SchemaType {
     /// inline value, so existing decoders only need to learn
     /// the new tag at the field-walk step.
     Ref(SchemaCell),
-    /// Issue #232: keyed lookup table. Wire form is postcard's
+    /// Issue #232: keyed lookup table. Wire form is the structured
     /// `BTreeMap<K, V>` — `varint(len) + (k, v)` pairs in
     /// key-sorted order. Key types are restricted to `String`,
     /// integer `Scalar`s, and `Bool` (proto3-style stringify
@@ -136,7 +136,7 @@ pub enum SchemaType {
     /// disjoint `TYPE_DOMAIN` prefix). The codec's `TypeId` arm
     /// hard-codes the per-id encode/decode logic — for v1, the three
     /// known type ids are `MailboxId`, `KindId`, `HandleId`, all of
-    /// which are u64 varint on postcard and tagged-string on JSON.
+    /// which are u64 varint on the structured wire and tagged-string on JSON.
     /// Cast-shape size/align is 8 bytes, 8-byte align — same as a
     /// `u64`, so a typed-id field embedded in a `repr_c: true`
     /// struct keeps the parent's cast-eligibility.
@@ -147,7 +147,7 @@ pub enum SchemaType {
 /// (ADR-0031). `Static(&'static SchemaType)` is the const-literal arm —
 /// derives and hand-rolled impls reference the nested type's
 /// `<T as Schema>::SCHEMA` through this variant at compile time.
-/// `Owned(Box<SchemaType>)` is the wire arm — the hub's postcard
+/// `Owned(Box<SchemaType>)` is the wire arm — the hub's wire
 /// decoder allocates one `Box` per recursive node. Both `Deref` to
 /// `&SchemaType`, so walkers don't observe which variant carries the
 /// value. `Cow<'static, SchemaType>` would infinite-size through its
@@ -227,7 +227,7 @@ pub struct NamedField {
 /// One variant of a `SchemaType::Enum`. Discriminants are explicit
 /// `u32`s so the wire encoding doesn't depend on declaration order —
 /// adding a variant later (without renumbering existing ones) is
-/// forward-compatible at the postcard level.
+/// forward-compatible at the wire level.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EnumVariant {
     Unit {
@@ -247,7 +247,7 @@ pub enum EnumVariant {
 }
 
 impl EnumVariant {
-    /// Variant's wire name — matches the `#[postcard(...)]` rename (if
+    /// Variant's wire name — matches the `#[serde(rename)]` rename (if
     /// any) or the bare Rust variant identifier. Used on both the
     /// encode and decode sides for lookup and error reporting.
     #[must_use]
@@ -257,7 +257,7 @@ impl EnumVariant {
         }
     }
 
-    /// Postcard discriminant — the varint written on the wire before
+    /// Wire discriminant — the varint written on the wire before
     /// the variant body. Assigned by the derive at schema-build time
     /// and stable for the life of the kind vocabulary.
     #[must_use]
@@ -292,10 +292,10 @@ pub enum Primitive {
 /// ordering, but with every name field stripped (ADR-0032). This is the
 /// wire shape of the hashed `aether.kinds` manifest section and the
 /// input that `fnv1a_64_prefixed` chews on (after the `KIND_DOMAIN`
-/// prefix) to produce `Kind::ID`. Postcard-
+/// prefix) to produce `Kind::ID`. Wire-
 /// compatible with `SchemaType` at the subset of bytes they share — the
 /// canonical serializer emits bytes that deserialize cleanly into
-/// `SchemaShape` via `postcard::from_bytes`.
+/// `SchemaShape` via `wire::from_bytes`.
 ///
 /// Not const-constructible. Lives purely on the decode side of the
 /// wire: hub parses manifest bytes into `SchemaShape`, then merges
@@ -351,11 +351,11 @@ pub enum VariantShape {
 }
 
 /// Kind-level canonical record — the name-plus-positional-schema pair
-/// the `aether.kinds` section carries (ADR-0032). Postcard-compatible
+/// the `aether.kinds` section carries (ADR-0032). Wire-compatible
 /// with `KindDescriptor` at the `name` field (both serialize as
 /// length-prefixed UTF-8), and with the canonical schema bytes at the
 /// `schema` field. The hub decodes one `KindShape` per section record
-/// via `postcard::take_from_bytes`.
+/// via `wire::take_from_bytes`.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct KindShape {
     pub name: Cow<'static, str>,
@@ -365,7 +365,7 @@ pub struct KindShape {
 /// Labels sidecar — parallel-shape tree of nominal information
 /// (ADR-0032). Required at the hub; the canonical schema carries no
 /// names, so the hub needs the labels section to map MCP JSON params
-/// to postcard positions and to render `describe_kinds` output.
+/// to wire positions and to render `describe_kinds` output.
 ///
 /// Arms mirror `SchemaType`'s structure so a walker can step both
 /// trees in lockstep. `Anonymous` covers primitives, `String`, and
@@ -557,7 +557,7 @@ impl Eq for LabelNode {}
 impl Serialize for LabelNode {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // Hand-rolled to match the wire shape of `#[derive(Serialize)]`
-        // over the same variants — postcard treats each enum arm by
+        // over the same variants — the wire format treats each enum arm by
         // position + body.
         use serde::ser::SerializeStructVariant;
         use serde::ser::SerializeTupleVariant;
@@ -616,7 +616,7 @@ impl Serialize for LabelNode {
 impl<'de> Deserialize<'de> for LabelNode {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         // Mirror `LabelNode::Serialize`'s variant tagging. Matches
-        // postcard's enum encoding: varint discriminant, then body.
+        // the structured enum encoding: varint discriminant, then body.
         #[derive(Serialize, Deserialize)]
         enum LabelNodeDe {
             Anonymous,
@@ -808,7 +808,7 @@ pub struct KindLabels {
 /// surfaces this so a caller reads the real reply shape, not a `None`
 /// that lies for a handler that replies by hand.
 ///
-/// **Variant order is the postcard discriminant** — `None` = 0,
+/// **Variant order is the wire discriminant** — `None` = 0,
 /// `One` = 1, `Stream` = 2, `Manual` = 3. The const-fn encoders in
 /// [`crate::canonical`] and the macro emission depend on it; do not
 /// reorder.
@@ -923,7 +923,7 @@ pub enum InputsRecord {
     /// config records, so the reader can group the flat record stream
     /// back into per-type capability sets. `namespace` is the type's
     /// `Addressable::NAMESPACE`; the first boundary names the entry type.
-    /// Appended last so its postcard variant tag stays additive — a
+    /// Appended last so its wire variant tag stays additive — a
     /// single-actor module emits no boundary and decodes byte-identically
     /// under the existing reader, so no section-version bump is needed.
     ActorBoundary { namespace: Cow<'static, str> },
@@ -943,8 +943,8 @@ pub const INPUTS_SECTION: &str = "aether.kinds.inputs";
 /// `Handler` variant; v0x04 (ADR-0112 / issue 1850) widened that field
 /// from `Option<KindId>` to [`ReplyContract`] so a handler's reply
 /// *class* (single / manual / stream) is reported, not just a single
-/// reply kind; v0x05 (ADR-0118 / issue 1984) re-encoded every record
-/// from postcard onto the owned aether-wire format (fixed little-endian
+/// reply kind; v0x05 (ADR-0118 / issue 1984) moved every record
+/// onto the owned aether-wire format (fixed little-endian
 /// selectors / ids / counts). A component built before any of these and
 /// a substrate after would otherwise disagree on the record shape, so
 /// the reader rejects an older version byte loudly — a hard rebuild

--- a/crates/aether-kinds/src/dag.rs
+++ b/crates/aether-kinds/src/dag.rs
@@ -3,7 +3,7 @@
 //! three request kinds (`aether.dag.submit` / `cancel` / `status`),
 //! their reply kinds, and the structured `DagError` set.
 //!
-//! These kinds are postcard-shaped — `Vec<Node>` / `Vec<Edge>` make
+//! These kinds are structured — `Vec<Node>` / `Vec<Edge>` make
 //! the descriptor non-cast — and register in the substrate descriptor
 //! inventory through `#[derive(Kind)]` exactly like the other reply
 //! enums (`LoadResult`, `ReadResult`).
@@ -150,7 +150,7 @@ pub struct DagDescriptor {
 
 /// One self-describing element of a [`Bundle`] — a single correlated
 /// reply, tagged with its own `kind_id`. The `payload` is opaque
-/// postcard bytes the element's own kind decodes downstream.
+/// wire bytes the element's own kind decodes downstream.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Schema)]
 pub struct BundleElement {
     pub kind_id: KindId,

--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -142,7 +142,7 @@ mod tests {
     }
 
     #[test]
-    fn gemini_requests_are_postcard_schemas() {
+    fn gemini_requests_are_structured_schemas() {
         // ADR-0050: both generate kinds carry String/Vec/Option fields.
         let descs = all();
         for name in [NanobananaGenerate::NAME, LyriaGenerate::NAME] {
@@ -153,7 +153,7 @@ mod tests {
             let SchemaType::Struct { repr_c, .. } = &d.schema else {
                 panic!("{name} should be Struct, got {:?}", d.schema);
             };
-            assert!(!*repr_c, "{name} contains String/Vec, must be postcard");
+            assert!(!*repr_c, "{name} contains String/Vec, must be structured");
         }
     }
 
@@ -174,10 +174,10 @@ mod tests {
     }
 
     #[test]
-    fn anthropic_requests_are_postcard_schemas() {
+    fn anthropic_requests_are_structured_schemas() {
         // ADR-0050: the two send kinds carry String/Vec/Option fields,
-        // so they must serialize as non-cast (postcard) structs — the
-        // hub builds them from agent params via the postcard encoder.
+        // so they must serialize as non-cast (structured) structs — the
+        // hub builds them from agent params via the wire encoder.
         let descs = all();
         for name in [MessagesSend::NAME, CliSend::NAME] {
             let d = descs
@@ -187,7 +187,7 @@ mod tests {
             let SchemaType::Struct { repr_c, .. } = &d.schema else {
                 panic!("{name} should be Struct, got {:?}", d.schema);
             };
-            assert!(!*repr_c, "{name} contains String/Vec, must be postcard");
+            assert!(!*repr_c, "{name} contains String/Vec, must be structured");
         }
     }
 
@@ -208,7 +208,7 @@ mod tests {
     }
 
     #[test]
-    fn io_requests_are_postcard_schemas() {
+    fn io_requests_are_structured_schemas() {
         // ADR-0041 §1: request kinds carry `String` namespace + path
         // (and `Vec<u8>` bytes on `Write`), so they must serialize as
         // non-cast structs. Catches an accidental `#[repr(C)]` +
@@ -222,7 +222,7 @@ mod tests {
             let SchemaType::Struct { repr_c, .. } = &d.schema else {
                 panic!("{name} should be Struct, got {:?}", d.schema);
             };
-            assert!(!*repr_c, "{name} contains String/Vec, must be postcard");
+            assert!(!*repr_c, "{name} contains String/Vec, must be structured");
         }
     }
 
@@ -250,11 +250,11 @@ mod tests {
     }
 
     #[test]
-    fn control_kinds_are_postcard_schemas() {
+    fn control_kinds_are_structured_schemas() {
         // ADR-0019: control-plane kinds ship as `Struct{repr_c:false,..}`
         // (LoadComponent, DropComponent, ReplaceComponent) or `Enum{..}`
         // (the *Result variants). Hub builds them from agent params
-        // via the postcard encoder.
+        // via the wire encoder.
         let descs = all();
         for name in [
             LoadComponent::NAME,
@@ -268,7 +268,7 @@ mod tests {
             let SchemaType::Struct { repr_c, .. } = &d.schema else {
                 panic!("{name} should be Struct, got {:?}", d.schema);
             };
-            assert!(!*repr_c, "{name} contains String/Vec, must be postcard");
+            assert!(!*repr_c, "{name} contains String/Vec, must be structured");
         }
         for name in [LoadResult::NAME, DropResult::NAME, ReplaceResult::NAME] {
             let d = descs
@@ -387,7 +387,7 @@ mod tests {
         // `aether_math` primitives directly (`#[repr(C)]` + `Pod`), so
         // its schema is a cast struct whose fields are the nested `Mat4`
         // and `Vec4` cast structs, not flattened `[f32; N]` arrays. A
-        // stray loss of `#[repr(C)]` (flipping it to postcard) is a
+        // stray loss of `#[repr(C)]` (flipping it to structured) is a
         // wire-format mismatch this catches.
         let descs = all();
         let d = descs
@@ -397,7 +397,7 @@ mod tests {
         let SchemaType::Struct { fields, repr_c } = &d.schema else {
             panic!("{} should be Struct, got {:?}", Mat4Apply::NAME, d.schema);
         };
-        assert!(*repr_c, "Mat4Apply must be cast, not postcard");
+        assert!(*repr_c, "Mat4Apply must be cast, not structured");
         assert_eq!(fields.len(), 2);
         assert_eq!(fields[0].name, "matrix");
         assert_eq!(fields[1].name, "vector");
@@ -488,10 +488,10 @@ mod tests {
         }
     }
 
-    /// `TrajectoryLog` is a postcard-shaped `Struct` (it carries a
+    /// `TrajectoryLog` is a structured `Struct` (it carries a
     /// `Vec<TrajectorySampleEntry>` field, so `repr_c` must be false).
     #[test]
-    fn trajectory_log_is_postcard_struct() {
+    fn trajectory_log_is_structured_struct() {
         let descs = all();
         let d = descs
             .iter()
@@ -502,7 +502,7 @@ mod tests {
         };
         assert!(
             !*repr_c,
-            "TrajectoryLog contains Vec — must be postcard, not cast"
+            "TrajectoryLog contains Vec — must be structured, not cast"
         );
     }
 

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -544,7 +544,7 @@ pub struct Camera {
 
 // `aether.camera.*` control kinds (CameraCreate / CameraDestroy /
 // CameraSetActive / CameraSetMode / CameraOrbitSet / CameraTopdownSet)
-// live in `mod control_plane` below — they're postcard-shaped because
+// live in `mod control_plane` below — they're structured because
 // every one carries a `String` name and `Option<...>` per-field
 // deltas, so they can't ride the cast-shaped path.
 
@@ -752,9 +752,9 @@ pub struct MonitorNotice {
 // these kinds inline rather than dispatching to a component — the
 // namespace itself is the routing discriminator. ADR-0019 PR 5 turned
 // these from Opaque markers into real schema-described types: their
-// fields are postcard-encoded on the wire, hub-encodable from agent
+// fields are structured-encoded on the wire, hub-encodable from agent
 // params (no more `payload_bytes` workaround), and the substrate
-// decodes them with `postcard::from_bytes` against the same types
+// decodes them with `wire::from_bytes` against the same types
 // that ship as the kind.
 //
 // Gated behind `descriptors` because the types use `String`/`Vec`/
@@ -916,7 +916,7 @@ mod tcp {
     /// `aether.tcp.session_data` — broadcast emitted by a
     /// `TcpSessionActor` on each chunk read from its peer. Carries
     /// the session subname (`conn-N`), the peer address as a string,
-    /// and the bytes received in one `read()` call. Postcard-shaped
+    /// and the bytes received in one `read()` call. Structured-shaped
     /// (variable-length payload) — agents drain via `receive_mail`.
     #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.tcp.session_data")]
@@ -2061,7 +2061,7 @@ mod control_plane {
     // `aether.render` mailbox compose the generic texture surface text /
     // sprites / HUD images share: register an RGBA8 texture, overwrite a
     // sub-rect of one, and draw a batch of textured alpha-blended quads
-    // in either projection. Postcard-shaped — `CreateTexture` /
+    // in either projection. Structured-shaped — `CreateTexture` /
     // `UpdateTexture` carry `Vec<u8>` pixels, `DrawTexturedQuads` carries
     // a `space` enum and a `Vec` of quads.
 
@@ -2212,7 +2212,7 @@ mod control_plane {
     // ADR-0105 text surface. The `aether.text` capability composes the
     // textured-quad surface above into glyphs: load a TTF off the hot
     // path under a session-scoped `font_id`, then draw a string every
-    // frame in immediate mode. Postcard-shaped; `space` reuses
+    // frame in immediate mode. Structured-shaped; `space` reuses
     // `QuadSpace` so a screen-space HUD string and a world-anchored
     // label ride the same discriminant.
 
@@ -2560,7 +2560,7 @@ mod control_plane {
     // ADR-0104 scheduled note events. One `aether.audio.schedule` mail
     // carries a whole tune as a batch of timed note events; the audio cap
     // schedules them against its own sample clock so relative timing is
-    // sample-accurate. Postcard-shaped — the batch is a `Vec`, not a
+    // sample-accurate. Structured-shaped — the batch is a `Vec`, not a
     // cast-eligible `#[repr(C)]` body.
 
     /// One note action in a scheduled batch (ADR-0104). The payload
@@ -2624,7 +2624,7 @@ mod control_plane {
     // ADR-0103 track playback. The audio cap plays a decoded audio asset
     // (music, ambience) in its own mixer lane, addressed by fs namespace
     // + path the way the rest of the substrate addresses files (ADR-0041).
-    // Postcard-shaped because every field is a `String` / `f32` / `bool`,
+    // Structured-shaped because every field is a `String` / `f32` / `bool`,
     // not a cast-eligible `#[repr(C)]` body like `NoteOn`.
 
     /// `aether.audio.play_track` — fetch, decode, and play an audio asset
@@ -2704,7 +2704,7 @@ mod control_plane {
     // pitched samples at runtime, appends it to the instrument registry
     // past the compiled-in built-ins, and plays it through the unchanged
     // `note_on` / `note_off` surface (a third voice kernel beside the
-    // oscillator and partial-bank patches). Postcard-shaped — the request
+    // oscillator and partial-bank patches). Structured-shaped — the request
     // carries `String` namespace/path, the reply a numeric id + name.
 
     /// `aether.audio.load_instrument` — load a sampled instrument bank
@@ -2752,8 +2752,8 @@ mod control_plane {
     // ADR-0041 substrate file I/O. Four request kinds on the
     // `"aether.fs"` mailbox (read / write / delete / list), paired
     // 1:1 with reply kinds
-    // that carry a structured `FsError` on failure. All postcard-
-    // shaped because every request carries String namespace/path
+    // that carry a structured `FsError` on failure. All structured
+    // because every request carries String namespace/path
     // fields and writes carry `Vec<u8>` bytes.
     //
     // `namespace` is the logical prefix without the `://`: mail
@@ -3114,24 +3114,24 @@ mod control_plane {
 
     /// One kind in a [`ListKindsResult`] (ADR-0091). `id` is the
     /// substrate's authoritative [`KindId`](aether_data::KindId) for the
-    /// kind; `name` is its declared `Kind::NAME`; `schema_postcard` is
-    /// the kind's [`SchemaType`](aether_data::SchemaType) postcard-
-    /// serialized (the wire enum carries the full nominal shape).
+    /// kind; `name` is its declared `Kind::NAME`; `schema_wire` is
+    /// the kind's [`SchemaType`](aether_data::SchemaType) encoded with
+    /// the wire format (the wire enum carries the full nominal shape).
     ///
-    /// The schema rides as opaque postcard bytes rather than a directly
+    /// The schema rides as opaque wire bytes rather than a directly
     /// embedded `SchemaType` because `SchemaType` itself has no
     /// `Schema` impl (it *is* the schema vocabulary, not a value in
     /// it); shipping it as `Bytes` keeps `KindDescriptorWire` and the
     /// whole reply derivable via [`aether_data::Schema`] without a
-    /// hand-roll, at the cost of one extra `postcard::from_bytes` on
-    /// the harness side. Cap encodes via `postcard::to_allocvec`
+    /// hand-roll, at the cost of one extra `wire::from_bytes` on
+    /// the harness side. Cap encodes via `wire::to_vec`
     /// against `descriptor.schema`; client decodes via
-    /// `postcard::from_bytes`.
+    /// `wire::from_bytes`.
     #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
     pub struct KindDescriptorWire {
         pub id: aether_data::KindId,
         pub name: String,
-        pub schema_postcard: Vec<u8>,
+        pub schema_wire: Vec<u8>,
     }
 
     /// `aether.inventory.kinds` — request the running substrate's
@@ -3272,7 +3272,7 @@ mod control_plane {
 
     // ADR-0043 substrate HTTP egress. One request kind + one reply
     // kind on the `"aether.http"` sink, plus supporting `HttpMethod`,
-    // `HttpHeader`, and `HttpError` shapes. All postcard-shaped
+    // `HttpHeader`, and `HttpError` shapes. All structured
     // (Strings, Vecs, Option<u32>).
     //
     // Reply correlation follows the ADR-0041 pattern: the reply
@@ -3788,7 +3788,7 @@ mod control_plane {
     }
 
     /// One environment variable pair carried in [`Spawn::env`]. Pairs
-    /// rather than a `HashMap` because postcard-shaped wire kinds
+    /// rather than a `HashMap` because structured wire kinds
     /// don't have a `Schema` impl for tuple element types and a
     /// keyed-collection schema isn't load-bearing here — duplicate
     /// keys aren't expected and last-write-wins matches the env
@@ -3890,7 +3890,7 @@ mod control_plane {
     // reply with a `*_result` Ok/Err enum carrying the shared `Usage`
     // accounting (also consumed by the `aether.gemini` media kinds,
     // issue 1015) on `Ok` and a provider-specific `AnthropicError` on
-    // `Err`. All postcard-shaped — every request carries `String` /
+    // `Err`. All structured — every request carries `String` /
     // `Vec` / `Option` fields.
 
     /// Conversation role on a [`Message`]. The Messages API only
@@ -4370,7 +4370,7 @@ mod tests {
 
     #[test]
     fn spawn_engine_roundtrip_carries_boot_manifest() {
-        // The spawn kind rides the wire (postcard path — non-`repr(C)`
+        // The spawn kind rides the wire (structured path — non-`repr(C)`
         // struct with a nested `BinarySelector`, `Vec<String>`, and
         // `Option<String>`). Both `Some` (a spawn carrying a component
         // list) and `None` (a bare spawn) must survive the engines-cap
@@ -4422,7 +4422,7 @@ mod tests {
     #[test]
     fn binary_store_kinds_roundtrip() {
         // The hub binary-store registry kinds (ADR-0115, issue 1953) ride
-        // the postcard path — `Option<String>` + `Vec<String>` + a nested
+        // the structured path — `Option<String>` + `Vec<String>` + a nested
         // `Schema` manifest struct. The request, the tagged result, and the
         // list reply with its embedded `BinaryEntry`/`BinaryManifest` must
         // all survive the engines-cap encode/decode.
@@ -4488,7 +4488,7 @@ mod tests {
     #[test]
     fn component_store_kinds_roundtrip() {
         // The hub component-store registry kinds (ADR-0116, issue 1956) ride
-        // the postcard path — `Option<String>` + `Vec`s + a nested `Schema`
+        // the structured path — `Option<String>` + `Vec`s + a nested `Schema`
         // manifest carrying `KindId`s and the wasm bytes. The upload, the
         // resolve carrying the wasm + manifest + export, and the list reply
         // with its embedded `ComponentEntry`/`ComponentManifest` must all
@@ -4591,7 +4591,7 @@ mod tests {
         // `EngineDied` gained a `reason` field — the proxy's self-death
         // paths tag the cause (`Crashed` for a `Bye`, `Evicted` for a
         // heartbeat miss). Both the id and the tagged reason must survive
-        // the postcard encode/decode the proxy → cap mail rides.
+        // the structured encode/decode the proxy → cap mail rides.
         use alloc::string::ToString;
 
         let died = EngineDied {
@@ -5021,7 +5021,7 @@ mod tests {
         fn capture_frame_similarity_check_roundtrip() {
             // A `CaptureFrame` that carries a similarity check and a
             // `CaptureFrameResult::Ok` with populated score + pass survive
-            // a postcard roundtrip (iamacoffeepot/aether#1780).
+            // a structured roundtrip (iamacoffeepot/aether#1780).
             let frame = CaptureFrame {
                 mails: vec![],
                 after_mails: vec![],
@@ -5917,7 +5917,7 @@ mod tests {
         #[test]
         fn load_component_roundtrips_config_bytes() {
             // ADR-0090 c2: the optional init-config carrier must survive
-            // the postcard wire path intact so the substrate hands the
+            // the structured wire path intact so the substrate hands the
             // exact bytes to the guest's typed `init`.
             let load = LoadComponent {
                 wasm: vec![0x00, 0x61, 0x73, 0x6d],
@@ -5957,7 +5957,7 @@ mod tests {
             // fieldless request and a `names: Vec<String>` reply, both on the
             // `aether.component.list` family. They must register in the
             // descriptor inventory (so `describe_kinds(prefix="aether.component")`
-            // surfaces them) and survive the postcard wire path.
+            // surfaces them) and survive the structured wire path.
             assert_eq!(ListComponents::NAME, "aether.component.list");
             assert_eq!(ListComponentsResult::NAME, "aether.component.list_result");
 

--- a/crates/aether-kinds/src/trace.rs
+++ b/crates/aether-kinds/src/trace.rs
@@ -60,7 +60,7 @@ pub struct Nanos(pub u64);
 /// the guided walk (`trace_walk`) joins them to the originating `Sent`
 /// by the mail-id key while stitching the per-actor ring slices.
 ///
-/// Wire shape: postcard. The dispatcher delivers this through normal
+/// Wire shape: structured. The dispatcher delivers this through normal
 /// mail routing; no cast-shape optimisation because the variant tag +
 /// `Option<MailId>` would force padding gymnastics anyway.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, aether_data::Schema)]

--- a/crates/aether-labyrinth/Cargo.toml
+++ b/crates/aether-labyrinth/Cargo.toml
@@ -40,7 +40,7 @@ aether-kinds = { path = "../aether-kinds" }
 # `aether-substrate`-gated, so the bare crate carries only the markers.
 aether-actor = { path = "../aether-actor" }
 # Issue 1914: the relocated `aether.reach.*` / `aether.corridor.*` kinds
-# derive `Serialize` / `Deserialize` over their postcard wire shapes, and
+# derive `Serialize` / `Deserialize` over their structured wire shapes, and
 # the cast-shaped `CrossingQueryParams` derives `bytemuck::Pod` /
 # `Zeroable`. Same dep specs the kinds carried in `aether-kinds`.
 serde = { workspace = true, default-features = false, features = ["derive", "alloc"] }

--- a/crates/aether-labyrinth/src/kinds.rs
+++ b/crates/aether-labyrinth/src/kinds.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 // itself is a pair of native `#[transform]`s in this crate.
 // A family of follow-on field passes (corridor extraction, windowed
 // re-solve, agent populations) all consume `ScalarField`, so the
-// representation lands here once. Postcard-shaped, `Vec`-bearing like
+// representation lands here once. Structured-shaped, `Vec`-bearing like
 // `CreateTexture`.
 
 /// A dense scalar field over a 2D grid and an integer tick axis — the
@@ -147,7 +147,7 @@ pub struct ReachabilityMargin {
 // (priced at the sublevel-filtration threshold of `V` at which raising
 // `B` would merge them), and the inter-tick "flow" edges between
 // components an affordable one-tick stencil step links. A flat,
-// postcard-friendly DAG built by the `build_corridor_graph` transform
+// structured-friendly DAG built by the `build_corridor_graph` transform
 // in this crate: nodes carry summaries, not cell sets, so
 // the graph stays orders of magnitude smaller than `V`, and components
 // are re-derivable from `V` + `B` + the [`MovementStencil`] (all
@@ -252,7 +252,7 @@ pub struct TrajectorySet {
 /// untraveled, and how through-boundary ("punch") traffic splits by
 /// whether punching beat the affordable detour around it.
 ///
-/// A flat, postcard-friendly reduction keyed by the graph's node / edge
+/// A flat, structured-friendly reduction keyed by the graph's node / edge
 /// indices so a consumer joins it back to the graph by index:
 /// `edge_traffic[i]` is the traffic over `CorridorGraph.edges[i]`, and
 /// `node_traffic[i]` the visits to `CorridorGraph.nodes[i]`. The output
@@ -1090,7 +1090,7 @@ mod tests {
         }
 
         #[test]
-        fn traffic_density_postcard_round_trips() {
+        fn traffic_density_structured_round_trips() {
             use aether_data::Kind;
             let density = TrafficDensity {
                 path_count: 3,

--- a/crates/aether-labyrinth/src/trajectory.rs
+++ b/crates/aether-labyrinth/src/trajectory.rs
@@ -15,7 +15,7 @@
 //! - `on_sample` — fire-and-forget: append `(tick, x, y, value)` to the
 //!   buffer for `seed`, creating the buffer on first sample for that seed.
 //! - `on_end` — build a `TrajectoryLog { seed, samples, end_reason }`,
-//!   postcard-encode it via `encode_into_bytes`, publish it to the handle
+//!   wire-encode it via `encode_into_bytes`, publish it to the handle
 //!   store via `next_ephemeral` → `put` → `inc_ref`, drop the in-memory
 //!   buffer, and return `RecordResult` (ADR-0112 return-type reply form).
 

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -1692,7 +1692,7 @@ impl Mcp {
             return;
         };
 
-        // Decode each `schema_postcard` back into a `SchemaType` via
+        // Decode each `schema_wire` back into a `SchemaType` via
         // `wire::from_bytes`; an entry whose schema fails to decode is
         // dropped (the substrate's wire form is canonical, so a decode
         // failure is a substrate / aether-data version mismatch —
@@ -1700,7 +1700,7 @@ impl Mcp {
         let fresh: Vec<KindDescriptor> = kinds
             .into_iter()
             .filter_map(|wire| {
-                let schema = wire::from_bytes::<SchemaType>(&wire.schema_postcard).ok()?;
+                let schema = wire::from_bytes::<SchemaType>(&wire.schema_wire).ok()?;
                 Some(KindDescriptor {
                     name: wire.name,
                     schema,
@@ -4292,7 +4292,7 @@ mod tests {
                 )
             });
         let decoded_schema: SchemaType =
-            wire::from_bytes(&entry.schema_postcard).expect("schema_postcard decodes");
+            wire::from_bytes(&entry.schema_wire).expect("schema_wire decodes");
         assert!(
             matches!(decoded_schema, SchemaType::String),
             "the registered schema round-trips through the wire",

--- a/crates/aether-mesh-viewer/src/lib.rs
+++ b/crates/aether-mesh-viewer/src/lib.rs
@@ -38,7 +38,7 @@ pub struct LoadMesh {
 }
 
 /// `aether.corridor.load` — instruct the mesh viewer to load a
-/// postcard-encoded `aether_labyrinth::CorridorGraph` (issue 1858) from
+/// wire-encoded `aether_labyrinth::CorridorGraph` (issue 1858) from
 /// `namespace://path` and build a tick-indexable scrub datum over it
 /// (issue 1869). The graph is a flat time-layered DAG: per-tick region
 /// components (`nodes`) and directed cross-tick `Flow` / intra-tick
@@ -55,7 +55,7 @@ pub struct LoadMesh {
 pub struct LoadCorridor {
     /// Short namespace prefix (no `://`), e.g. `"save"`, `"assets"`.
     pub namespace: String,
-    /// Relative path within the namespace to the postcard-encoded
+    /// Relative path within the namespace to the wire-encoded
     /// `CorridorGraph` bytes.
     pub path: String,
 }

--- a/crates/aether-mesh-viewer/src/runtime.rs
+++ b/crates/aether-mesh-viewer/src/runtime.rs
@@ -331,7 +331,7 @@ impl WasmActor for MeshViewer {
     ///
     /// # Agent
     /// `namespace` is the short prefix with no `://` — `"save"`,
-    /// `"assets"`, `"config"`. `path` points at a postcard-encoded
+    /// `"assets"`, `"config"`. `path` points at a wire-encoded
     /// `CorridorGraph` (write it via `aether.fs.write`). Send-and-await
     /// the `aether.corridor.load_result` reply to learn whether the load
     /// succeeded. After a successful load, `aether.corridor.scrub` to
@@ -734,7 +734,7 @@ impl MeshViewer {
         LoadOutcome::ok()
     }
 
-    /// Decode a postcard `CorridorGraph` (issue 1858) from corridor-load
+    /// Decode a wire-encoded `CorridorGraph` (issue 1858) from corridor-load
     /// bytes, build a `ScrubIndex` over it, and replace the cached
     /// corridor datum (issue 1869). The scrub cursor clamps to the new
     /// graph's tick span. A decode failure leaves the prior datum intact,
@@ -1445,7 +1445,7 @@ mod tests {
         }
     }
 
-    /// A single-inside-sample `ScalarField` postcard-encoded the way an
+    /// A single-inside-sample `ScalarField` wire-encoded the way an
     /// agent writes it via `aether.fs.write`.
     fn single_voxel_field_bytes() -> Vec<u8> {
         let mut values = vec![0u32; 3 * 3 * 3];
@@ -1459,7 +1459,7 @@ mod tests {
         field.encode_into_bytes()
     }
 
-    /// Issue 1868: a `.field` load decodes a postcard `ScalarField`,
+    /// Issue 1868: a `.field` load decodes a wire-encoded `ScalarField`,
     /// meshes it, and replaces the cache with a non-empty triangle list,
     /// reporting `ok: true`. The single-voxel field meshes to the
     /// 12-triangle closed cube the mesher's own test asserts.
@@ -1481,7 +1481,7 @@ mod tests {
     }
 
     /// Issue 1868: a malformed `.field` buffer keeps the prior cache and
-    /// reports `ok: false`. A non-postcard byte run fails to decode; the
+    /// reports `ok: false`. A non-wire byte run fails to decode; the
     /// previously-loaded triangles survive.
     #[test]
     fn malformed_field_keeps_prior_cache() {
@@ -1926,7 +1926,7 @@ mod tests {
         );
     }
 
-    /// A good corridor load decodes the postcard bytes, builds the index,
+    /// A good corridor load decodes the wire bytes, builds the index,
     /// caches it, and reports `ok`. The scrub cursor clamps into the graph's
     /// tick span.
     #[test]

--- a/crates/aether-mesh-viewer/tests/scenario.rs
+++ b/crates/aether-mesh-viewer/tests/scenario.rs
@@ -162,7 +162,7 @@ fn dsl_box_loads_and_renders() {
     differs_from_background(&img, 5).expect("captured frame should diverge from clear color");
 }
 
-/// Issue 1868 render-path smoke: a `.field` load decodes a postcard
+/// Issue 1868 render-path smoke: a `.field` load decodes a wire-encoded
 /// `ScalarField`, surface-nets it, and replays the triangles to
 /// `aether.render` every frame — `aether.draw_triangle` is observed.
 /// Asserts mesh structure (triangles flow), not pixels, per the GPU-test

--- a/crates/aether-rpc/Cargo.toml
+++ b/crates/aether-rpc/Cargo.toml
@@ -23,7 +23,7 @@ aether-data = { path = "../aether-data" }
 # Trace vocabulary the guided walk reconstructs (`TraceRingEntry`,
 # `MailNodeWire`, `DescribeTreeResult`, `TraceEvent`, `Nanos`).
 aether-kinds = { path = "../aether-kinds" }
-# Length-prefix postcard stream framing the `Call` client reads/writes
+# Length-prefix stream framing the `Call` client reads/writes
 # (ADR-0072). Reached only by the native-only client; harmless in the
 # wasm-header build (`aether-capabilities` already pulls it there).
 aether-codec = { path = "../aether-codec" }

--- a/crates/aether-rpc/src/rpc.rs
+++ b/crates/aether-rpc/src/rpc.rs
@@ -1,7 +1,7 @@
 //! `aether.rpc` wire vocabulary + the `Call` client primitive (issues
 //! 750 / 763, extracted to `aether-rpc` per ADR-0102).
 //!
-//! Length-prefix postcard frames carrying [`WireFrame`] bodies, layered
+//! Length-prefix frames carrying [`WireFrame`] bodies, layered
 //! over the generic stream helpers in `aether-codec::frame` (ADR-0072).
 //! `RpcServerCapability` (in `aether-capabilities`) speaks this wire over
 //! a TCP socket; the wire is intentionally type-erased — endpoints are
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 pub const WIRE_VERSION: u32 = 1;
 
 /// One frame on the wire. Length-prefix-framed via
-/// [`aether_codec::frame`]; postcard-encoded body.
+/// [`aether_codec::frame`]; wire-encoded body.
 ///
 /// `cid` correlates a `Call` to its replies. `Call { cid: None }` is
 /// fire-and-forget; `Call { cid: Some(n) }` expects zero or more

--- a/crates/aether-substrate-bundle/Cargo.toml
+++ b/crates/aether-substrate-bundle/Cargo.toml
@@ -152,7 +152,7 @@ serde_json = { workspace = true }
 # `test_helpers` module through `crate::test_bench::{visual,
 # test_helpers}` directly (post-issue-821, formerly via
 # `aether-scenario`).
-# Length-prefix postcard frame helpers (`aether_codec::frame::{read_frame,
+# Length-prefix frame helpers (`aether_codec::frame::{read_frame,
 # write_frame}`) used by the RPC engine-routing + FleetBench integration
 # tests; no `src/` consumer, so it rides dev-dependencies only.
 aether-codec = { path = "../aether-codec" }

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -38,7 +38,7 @@ use aether_kinds::trace::{DescribeTreeResult, TraceTail, TraceTailResult};
 use aether_kinds::{Advance, AdvanceResult, CaptureFrame, CaptureFrameResult};
 use aether_kinds::{LogTail, LogTailResult, Tick};
 // `push_to_mailbox` encodes any sent kind through the descriptor-aware
-// `Kind::encode_into_bytes` (cast or postcard per the kind's shape);
+// `Kind::encode_into_bytes` (cast or structured per the kind's shape);
 // `encode_empty` builds the zero-byte payload for unit lifecycle kinds.
 use aether_actor::Addressable;
 use aether_capabilities::{RenderCapability, fs::NamespaceRoots};
@@ -67,7 +67,7 @@ pub const DEFAULT_WIDTH: u32 = 800;
 pub const DEFAULT_HEIGHT: u32 = 600;
 
 /// Errors `TestBench` API methods surface. `Boot` covers any failure
-/// in the substrate's `build()`; `Decode` covers postcard reply
+/// in the substrate's `build()`; `Decode` covers structured reply
 /// decode failures (rare — implies a kind shape mismatch); `Timeout`
 /// covers replies that never arrive (chassis hung or wrong target);
 /// `Advance` and `Capture` pass through `Err` variants from the
@@ -801,7 +801,7 @@ impl TestBench {
     /// [`super::ExecutionResult::reply`]. Used for the
     /// component load/replace/drop round trips and the `aether.fs`
     /// `Read`/`Write`/`Delete`/`List` replies — every standard
-    /// `*Result` kind is postcard-encoded.
+    /// `*Result` kind is structured-encoded.
     pub(crate) fn send_bytes_and_await(
         &mut self,
         recipient_name: &str,
@@ -1064,7 +1064,7 @@ impl TestBench {
                 kind_name, payload, ..
             } => {
                 // ADR-0100: decode through the kind's declared codec
-                // (cast or postcard), not a hardcoded postcard path.
+                // (cast or structured), not a hardcoded structured path.
                 R::decode_from_bytes(&payload).ok_or_else(|| {
                     TestBenchError::Decode(format!(
                         "{expected} decode failed via Kind::decode_from_bytes (kind={kind_name})"

--- a/crates/aether-substrate-bundle/src/test_bench/execute.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/execute.rs
@@ -101,7 +101,7 @@ impl BenchOp {
 
     /// Fire-and-settle a typed mail (no reply awaited). Encodes `mail`
     /// via [`Kind::encode_into_bytes`] — works for both cast and
-    /// postcard kinds.
+    /// structured kinds.
     #[must_use]
     pub fn send_mail<K: Kind>(recipient: impl Into<String>, mail: &K) -> Self {
         Self::SendMail {
@@ -169,7 +169,7 @@ impl ExecutionResult {
     /// Decode the reply from a [`BenchOp::SendAndAwait`] step as `R`.
     /// `R` is any reply kind (`LoadResult`, `ReplaceResult`,
     /// `WriteResult`, …); the bytes decode through the kind's declared
-    /// codec (cast or postcard) via `Kind::decode_from_bytes`
+    /// codec (cast or structured) via `Kind::decode_from_bytes`
     /// (ADR-0100). Errors with [`ExecutionError::NoSuchReply`] if
     /// `label` didn't run a `SendAndAwait` (or didn't run at all), or
     /// [`ExecutionError::ReplyDecode`] if the bytes don't decode as
@@ -297,7 +297,7 @@ mod tests {
     use super::*;
 
     /// Cast reply kind with a non-`f32` field — its wire image is the
-    /// raw cast bytes, which a postcard reader would misdecode.
+    /// raw cast bytes, which a structured reader would misdecode.
     #[repr(C)]
     #[derive(Copy, Clone, Debug, PartialEq, Eq, bytemuck::Pod, bytemuck::Zeroable)]
     struct CastReply {
@@ -322,7 +322,7 @@ mod tests {
     /// ADR-0100: the `SendAndAwait` reply accessor decodes the recorded
     /// bytes through `Kind::decode_from_bytes`, so a cast reply kind
     /// round-trips uncorrupted (its `u32` / `u16` fields survive). A
-    /// postcard decode would have misread the raw cast image.
+    /// structured decode would have misread the raw cast image.
     #[test]
     fn execution_result_reply_decodes_cast_kind() {
         let reply = CastReply {

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -84,7 +84,7 @@ const TICK_OBSERVED: &str = "aether.test_fixture.tick_observed";
 
 /// Build a `MailEnvelope` for a `CaptureFrame` mail bundle. Uses
 /// the kind's wire encoding (`encode_into_bytes`) so any K — cast
-/// or postcard — packs correctly.
+/// or structured — packs correctly.
 fn envelope<K: Kind>(recipient: &str, mail: &K) -> MailEnvelope {
     MailEnvelope {
         recipient_name: recipient.to_owned(),

--- a/crates/aether-substrate/src/actor/native/mailbox.rs
+++ b/crates/aether-substrate/src/actor/native/mailbox.rs
@@ -135,7 +135,7 @@ impl<'a, R> NativeActorMailbox<'a, R> {
 
 impl<R: Addressable> NativeActorMailbox<'_, R> {
     /// Send a single payload of kind `K` to actor `R`. Compile-checked
-    /// against `R: HandlesKind<K>`. Wire shape (cast or postcard)
+    /// against `R: HandlesKind<K>`. Wire shape (cast or structured)
     /// follows `Kind::encode_into_bytes`.
     ///
     /// Inherits the handler's in-flight causal chain by default

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -600,10 +600,10 @@ pub const DISPATCH_DROPPED_OVERSIZE: u32 = 2;
 /// `recipient: u64` — the mailbox id the substrate routed this mail to
 /// (the actor's own id for a normal actor; an inline-child alias for
 /// the membrane). The `byte_len: u32` parameter (added
-/// to support postcard-shaped receivers per ADR-0033's "any declared
+/// to support structured-shaped receivers per ADR-0033's "any declared
 /// kind" intent) is the total payload size the substrate wrote at
 /// `ptr`, sourced from `mail.payload.len()`. Cast decoders sanity-
-/// check it against `size_of::<K>() * count`; postcard decoders use
+/// check it against `size_of::<K>() * count`; structured decoders use
 /// it as the exact slice length so a parser bug or a corrupted frame
 /// can't read past the substrate-written bytes into adjacent linear
 /// memory. ADR-0015 + issue 584 add optional `wire`, `unwire`,

--- a/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
+++ b/crates/aether-substrate/src/actor/wasm/kind_manifest.rs
@@ -9,7 +9,7 @@
 // sidecar: type paths, field names, variant names).
 //
 // Record formats (ADR-0118: the bytes are the owned aether-wire
-// encoding, not postcard, since issue 1984):
+// encoding, since issue 1984):
 //   `aether.kinds`         — [0x05] [wire(KindShape)]
 //   `aether.kinds.labels`  — [0x04] [wire(KindLabels)]
 //
@@ -70,7 +70,7 @@ pub const LABELS_SECTION: &str = "aether.kinds.labels";
 /// declares `Component::NAMESPACE` and `export!()` pins the bytes
 /// here; substrate's `load_component` reads the section as the default
 /// recipient name when the load payload omits an explicit `name`. The
-/// payload is the raw UTF-8 bytes — no version prefix, no postcard
+/// payload is the raw UTF-8 bytes — no version prefix, no wire
 /// wrapper, since it's a single fixed-shape string with no anticipated
 /// evolution.
 pub const NAMESPACE_SECTION: &str = "aether.namespace";
@@ -81,7 +81,7 @@ pub const NAMESPACE_SECTION: &str = "aether.namespace";
 /// byte. v0x04 (issue 640) shrunk the per-record framing back to just
 /// `[version_byte][canonical_bytes]` after the v0x03 trailing
 /// `is_stream` byte retired with the auto-subscribe path. v0x05
-/// (ADR-0118 / issue 1984) re-encoded the canonical body from postcard
+/// (ADR-0118 / issue 1984) moved the canonical body
 /// onto the owned aether-wire format (fixed little-endian selectors /
 /// ids / counts), so every `KindId` regenerates; v0x02 / v0x03 / v0x04
 /// are no longer accepted — a loud rebuild-required boundary, same as
@@ -97,7 +97,7 @@ const KINDS_VERSION: u8 = 0x05;
 /// Wire versions accepted in `aether.kinds.labels`. v0x03 added
 /// `kind_id` to `KindLabels`, making records self-identifying so the
 /// reader pairs by id rather than by declaration order. v0x04 (ADR-0118
-/// / issue 1984) re-encoded the record from postcard onto the owned
+/// / issue 1984) moved the record onto the owned
 /// aether-wire format. v0x02 / v0x03 are no longer accepted — a loud
 /// rebuild-required boundary.
 const LABELS_SUPPORTED_VERSIONS: &[u8] = &[0x04];
@@ -1012,7 +1012,7 @@ mod tests {
     }
 
     // ADR-0033: `aether.kinds.inputs` reader. The macro emits
-    // `[INPUTS_SECTION_VERSION][postcard(InputsRecord)]` back to back;
+    // `[INPUTS_SECTION_VERSION][wire(InputsRecord)]` back to back;
     // these tests pin the classifier that turns those records into
     // `ComponentCapabilities`.
 

--- a/crates/aether-substrate/src/chassis/settlement.rs
+++ b/crates/aether-substrate/src/chassis/settlement.rs
@@ -809,7 +809,7 @@ mod tests {
         );
     }
 
-    /// The settlement-notice payload postcard-decodes back to the
+    /// The settlement-notice payload decodes back to the
     /// subscribed root — direct check of the wire contract.
     #[test]
     fn mail_payload_decodes_to_root() {

--- a/crates/aether-substrate/src/handle_store.rs
+++ b/crates/aether-substrate/src/handle_store.rs
@@ -2622,7 +2622,7 @@ mod tests {
 
     /// Wire-shape `Struct { repr_c: false, fields }` builder
     /// shared by the test schemas in this module.
-    fn postcard_struct(fields: Vec<NamedField>) -> SchemaType {
+    fn structured_struct(fields: Vec<NamedField>) -> SchemaType {
         SchemaType::Struct {
             fields: Cow::Owned(fields),
             repr_c: false,
@@ -2649,7 +2649,7 @@ mod tests {
     }
 
     fn note_schema() -> SchemaType {
-        postcard_struct(vec![named("body", SchemaType::String), seq_field()])
+        structured_struct(vec![named("body", SchemaType::String), seq_field()])
     }
 
     #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug, Clone)]
@@ -2672,7 +2672,7 @@ mod tests {
     }
 
     fn held_note_schema() -> SchemaType {
-        postcard_struct(vec![
+        structured_struct(vec![
             named("held", SchemaType::Ref(SchemaCell::owned(note_schema()))),
             seq_field(),
         ])
@@ -2726,7 +2726,7 @@ mod tests {
     }
 
     #[test]
-    fn schema_contains_ref_returns_false_for_pure_postcard_struct() {
+    fn schema_contains_ref_returns_false_for_pure_structured_struct() {
         assert!(!schema_contains_ref(&note_schema()));
     }
 

--- a/crates/aether-substrate/src/handle_store/meta.rs
+++ b/crates/aether-substrate/src/handle_store/meta.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 /// rather than misparse. Pre-1.0 this is a wipe, not a migrate.
 pub const SCHEMA_VERSION: u8 = 4;
 
-/// Postcard-encoded sidecar describing one persistent handle. Written
+/// Wire-encoded sidecar describing one persistent handle. Written
 /// atomically next to the handle's `<hash>.bin` payload; the boot scan
 /// reads it to rebuild the sparse disk index without loading the bytes.
 ///
@@ -137,7 +137,7 @@ mod tests {
     use aether_data::wire;
 
     #[test]
-    fn index_snapshot_postcard_round_trips() {
+    fn index_snapshot_structured_round_trips() {
         let mut entries = HashMap::new();
         entries.insert(
             0x1111_2222_3333_4444,

--- a/crates/aether-substrate/src/mail/outbound.rs
+++ b/crates/aether-substrate/src/mail/outbound.rs
@@ -278,7 +278,7 @@ impl EgressBackend for RecordingBackend {
 /// to `EngineToHub` frames and writes them to a TCP socket).
 ///
 /// `send_reply<K>` is a substrate-side encoding convenience — it does
-/// the postcard encoding and dispatches based on `SourceAddr`. Sinks
+/// the wire encoding and dispatches based on `SourceAddr`. Sinks
 /// and capture handlers call it without caring which backend is wired.
 pub struct HubOutbound {
     backend: OnceLock<Arc<dyn EgressBackend>>,
@@ -405,7 +405,7 @@ impl HubOutbound {
     }
 
     /// Encode `result` through the kind's declared codec
-    /// (`Kind::encode_into_bytes`, cast or postcard, ADR-0100) and route
+    /// (`Kind::encode_into_bytes`, cast or structured, ADR-0100) and route
     /// as a reply addressed at `sender`. Forks on the sender variant:
     /// `Session` routes through `egress_to_session`; `EngineMailbox`
     /// routes through `egress_to_engine_mailbox`; `None` and `Component`

--- a/crates/aether-substrate/tests/native_actor_macro.rs
+++ b/crates/aether-substrate/tests/native_actor_macro.rs
@@ -38,8 +38,8 @@ use aether_substrate::{
 };
 use std::thread;
 
-/// Postcard-shape kind via the derive — exercises the
-/// `decode_from_bytes` postcard path the macro's dispatch arm uses.
+/// Structured-shape kind via the derive — exercises the
+/// `decode_from_bytes` structured path the macro's dispatch arm uses.
 #[derive(
     Clone,
     Debug,
@@ -54,7 +54,7 @@ struct Greet {
     tag: u32,
 }
 
-/// Cast-shape kind so both arms (postcard + cast) get exercised
+/// Cast-shape kind so both arms (structured + cast) get exercised
 /// through one cap.
 #[repr(C)]
 #[derive(
@@ -98,7 +98,7 @@ impl NativeActor for MacroProbeCap {
         })
     }
 
-    /// Handles postcard-shape `Greet` mail.
+    /// Handles structured-shape `Greet` mail.
     #[aether_data::handler]
     fn on_greet(&self, _ctx: &mut NativeCtx<'_>, mail: Greet) {
         self.greet_total.fetch_add(mail.tag, AtomicOrdering::SeqCst);
@@ -165,7 +165,7 @@ fn wait_for(target: u32, counter: &AtomicU32, budget: Duration) -> bool {
 }
 
 #[test]
-fn macro_emitted_cap_routes_postcard_kind_through_dispatch() {
+fn macro_emitted_cap_routes_structured_kind_through_dispatch() {
     let (registry, mailer) = fresh_substrate();
     let greet_total = Arc::new(AtomicU32::new(0));
     let ping_total = Arc::new(AtomicU32::new(0));
@@ -854,8 +854,8 @@ struct KickS {
 }
 
 /// The deferred reply kind — what the `&TaskDone -> EchoReply` completion
-/// returns and the macro sends via `resolve_value`. Postcard-shape so the
-/// reply (postcard-encoded by `Mailer::send_reply`) round-trips through
+/// returns and the macro sends via `resolve_value`. Structured-shape so the
+/// reply (wire-encoded by `Mailer::send_reply`) round-trips through
 /// `EchoReply::decode_from_bytes`.
 #[derive(
     Clone,

--- a/crates/aether-test-fixtures/bundle/src/probe.rs
+++ b/crates/aether-test-fixtures/bundle/src/probe.rs
@@ -40,7 +40,7 @@
 //!
 //! ADR-0090 c1 typed-config fixture. Exercises the
 //! `WasmActor::Config = ProbeConfig` path end-to-end: the host places
-//! postcard-encoded `ProbeConfig` bytes in a delivery region (ADR-0095) during
+//! wire-encoded `ProbeConfig` bytes in a delivery region (ADR-0095) during
 //! `Component::instantiate`; the guest's `init_with_config_p32` shim decodes
 //! them via `<ProbeConfig as Kind>::decode_from_bytes` and threads
 //! the typed struct into `Probe::init(config, ctx)`.

--- a/crates/aether-test-fixtures/kinds/src/lib.rs
+++ b/crates/aether-test-fixtures/kinds/src/lib.rs
@@ -24,7 +24,7 @@ use bytemuck::{Pod, Zeroable};
 /// into the FFI build.
 pub const TEST_BENCH_OBSERVER_MAILBOX_NAME: &str = "aether.test_bench.observer";
 
-/// Broadcast payload emitted on each tick. Postcard-shaped — schema
+/// Broadcast payload emitted on each tick. Structured-shaped — schema
 /// rides in the wasm's `aether.kinds` custom section, so the bench's
 /// loopback decoder can record the kind name without the test
 /// pre-registering anything.
@@ -106,7 +106,7 @@ pub struct ConfigEcho {
 }
 
 /// Driver kind for the typed-config fixture: request a `ConfigEcho`
-/// describing the cached config. Postcard-shaped (unit struct) so the
+/// describing the cached config. Structured-shaped (unit struct) so the
 /// fixture exercises the full schema-driven dispatch path even on the
 /// no-payload query side.
 #[derive(
@@ -124,7 +124,7 @@ pub struct ConfigQuery;
 /// Trigger for the `mat4_source` fixture (issue 1472). A DAG `Source`
 /// dispatches this no-payload trigger to the loaded `mat4_source`
 /// component, whose reply (`Mat4Apply`) feeds the `mat4_apply` transform
-/// downstream. Postcard-shaped unit struct — the trigger carries no
+/// downstream. Structured-shaped unit struct — the trigger carries no
 /// fields, so its `encode_into_bytes` is the descriptor `Source.payload`.
 /// `Default` lets the descriptor build that payload from one instance.
 #[derive(
@@ -146,7 +146,7 @@ pub struct Mat4SourceTrigger;
 /// inner kind id is `Vec4::ID`, which the Transform→Observer edge
 /// type-check matches against the transform's `output_kind_id`.
 ///
-/// Postcard-shaped: the `Ref<Vec4>` field serializes through the
+/// Structured-shaped: the `Ref<Vec4>` field serializes through the
 /// hand-written `impl<K: Kind> Serialize/Deserialize for Ref<K>`
 /// (ADR-0100), which needs only `Vec4: Kind` — no `Vec4` serde.
 #[derive(
@@ -165,7 +165,7 @@ pub struct Vec4Observed {
 
 /// Driver kind for the stateful multi-actor replace fixture (ADR-0101):
 /// each `Bump` increments the fixture's in-memory counter by one.
-/// Postcard-shaped unit struct.
+/// Structured-shaped unit struct.
 #[derive(
     aether_data::Kind,
     aether_data::Schema,
@@ -179,7 +179,7 @@ pub struct Vec4Observed {
 pub struct Bump;
 
 /// Query kind for the stateful replace fixture: request the live counter.
-/// The fixture replies with a `CountReport`. Postcard-shaped unit struct.
+/// The fixture replies with a `CountReport`. Structured-shaped unit struct.
 #[derive(
     aether_data::Kind,
     aether_data::Schema,
@@ -243,7 +243,7 @@ pub struct UiWidgetConfig {
 /// address; the recipient replies an [`InlineEcho`] tagged with `who`
 /// handled it, so the `FleetBench` scenario proves the membrane demuxed
 /// the mail to the child (not the parent) and a control to the parent's
-/// own address is unaffected. Postcard-shaped unit struct.
+/// own address is unaffected. Structured-shaped unit struct.
 #[derive(
     aether_data::Kind,
     aether_data::Schema,
@@ -258,7 +258,7 @@ pub struct InlineProbe;
 
 /// Reply to [`InlineProbe`] — `who` names the actor that handled the
 /// query so the test can assert the demux landed on the child vs the
-/// parent. Postcard-shaped.
+/// parent. Structured-shaped.
 #[derive(
     aether_data::Kind,
     aether_data::Schema,
@@ -286,7 +286,7 @@ pub const INLINE_WHO_CHILD: u32 = 2;
 /// parent (which tears down its stored child via `ctx.despawn_inline_child`)
 /// or to the child's alias (which despawns itself mid-dispatch). Carries no
 /// payload — the recipient address selects which actor tears the child
-/// down. Postcard-shaped unit struct.
+/// down. Structured-shaped unit struct.
 #[derive(
     aether_data::Kind,
     aether_data::Schema,
@@ -384,7 +384,7 @@ pub struct RunMatrix {
 /// which matrix cell the recipient records (one of the `MATRIX_CELL_*`
 /// markers); `fan_out` (set only on the parent → child a ping) instructs the
 /// receiving child to drive the child-origin cells (child → parent, child →
-/// sibling, child → self) and the cross-cluster send. Postcard-shaped.
+/// sibling, child → self) and the cross-cluster send. Structured-shaped.
 #[derive(
     aether_data::Kind,
     aether_data::Schema,
@@ -411,7 +411,7 @@ pub struct MatrixPing {
 /// Issue 1977 report query for the `matrix_sweep` fixture. Sent to the
 /// parent over the wire *after* `RunMatrix` settles; the parent reads the
 /// cluster's shared observation log and replies a [`MatrixReport`].
-/// Postcard-shaped unit struct.
+/// Structured-shaped unit struct.
 #[derive(
     aether_data::Kind,
     aether_data::Schema,
@@ -430,7 +430,7 @@ pub struct CollectMatrix;
 /// raw `MailboxId` the recipient read from `ctx.source_mailbox()` for that
 /// cell (`0` for none). The cross-cluster cell is observed out-of-band by the
 /// separate observer component (read via `log_tail`), so it carries no field
-/// here. Postcard-shaped.
+/// here. Structured-shaped.
 #[derive(
     aether_data::Kind,
     aether_data::Schema,
@@ -484,7 +484,7 @@ mod tests {
 
     use super::Vec4Observed;
 
-    /// The `Ref<Vec4>` slot survives a postcard round-trip through the
+    /// The `Ref<Vec4>` slot survives a wire round-trip through the
     /// ADR-0100 hand-written `Ref<K>` serde: an inline `Vec4` encodes
     /// then decodes unchanged. Guards the #1475-backed derive the
     /// `vec4_observer` fixture rests on (the observer reads its

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -48,7 +48,7 @@ Two layers: infrastructure (describes and moves typed bytes) and runtime
 | Crate | Role |
 |---|---|
 | `aether-data` | The universal data layer (`no_std`). Typed-id newtypes (`MailboxId`, `KindId`, `HandleId`), wire identity, the schema vocabulary (`SchemaType`, `KindShape`), the `Kind` / `Schema` traits, `Ref<K>`, encode/decode, and the native descriptor/transform inventories. Everything that describes typed bytes depends on it. |
-| `aether-codec` | Schema-driven JSON ↔ wire bytes (`encode_schema` / `decode_schema`) plus postcard stream framing ([ADR-0072](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0072-fold-hub-protocol-into-codec-and-hub.md)). |
+| `aether-codec` | Schema-driven JSON ↔ wire bytes (`encode_schema` / `decode_schema`) plus length-prefix stream framing ([ADR-0072](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0072-fold-hub-protocol-into-codec-and-hub.md)). |
 | `aether-kinds` | The substrate kind vocabulary — `Tick`, `Key`, `WindowSize`, `DrawTriangle`, and the `aether.{audio,fs,render,window,input,component,camera,log,handle,dag}.*` families. |
 | `aether-math` | `Vec2/3/4`, `Mat4`, `Quat`, `Aabb` — column-major, right-handed Y-up, `f32`, `no_std`. Reach here before hand-rolling vector math. |
 

--- a/docs/guide/foundations/type-system.md
+++ b/docs/guide/foundations/type-system.md
@@ -67,8 +67,8 @@ Because `ID` and `SCHEMA` are `const`, there is no host round-trip to learn a
 kind's identity or shape — `Kind::ID` is a compile-time value. And because the
 schema travels with the type, the wire layer can encode a kind from JSON and a
 recipient can decode it without a shared header ([ADR-0019](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0019-unified-mail-encoding.md)). On the wire a
-`#[repr(C)]` plain-data kind rides as a raw byte cast; everything else as
-postcard — the derive autodetects from the type's layout, so a single
+`#[repr(C)]` plain-data kind rides as a raw byte cast; everything else as a
+structured encoding — the derive autodetects from the type's layout, so a single
 `send` / `reply` call site handles both.
 
 **What feeds the id — and what doesn't.** The `KindId` hash takes `name +
@@ -106,12 +106,12 @@ worth knowing beyond "it's a type tree":
 
 - **Two wire shapes, and what picks them.** A struct encodes as a raw
   `#[repr(C)]` byte cast (`repr_c = true`) *only if* it is `#[repr(C)]` **and**
-  every field is cast-eligible, recursively; otherwise it encodes as postcard.
+  every field is cast-eligible, recursively; otherwise it encodes as structured.
   Cast-eligible means a scalar primitive, a typed-id newtype (`MailboxId` and
   friends are `#[repr(transparent)]` over `u64`), a fixed `[T; N]` array of
   cast-eligible elements, or a nested all-cast-eligible `#[repr(C)]` struct. A
   single `String`, `Bytes`, `Vec`, `Option`, `Map`, `Enum`, or `Ref` field
-  anywhere short-circuits the whole struct to postcard. You don't choose this —
+  anywhere short-circuits the whole struct to structured. You don't choose this —
   the derive computes it at compile time (`CastEligible::ELIGIBLE` ANDs every
   field) — but it's why two similar-looking kinds can have different wire
   encodings, and it's the `encode` vs `encode_struct` split in the SDK.
@@ -119,12 +119,12 @@ worth knowing beyond "it's a type tree":
   scalar, or `Bool` — the `BTreeMap<K: Ord, V>` bound rules out `f32`/`f64`/
   `Vec`/`Option` at the type level and the codec rejects them defensively.
   Entries serialize in key-sorted order, and a map (being variable-length)
-  always forces its parent struct onto the postcard path.
+  always forces its parent struct onto the structured path.
 - **The canonical bytes are positional-only.** When a schema is serialized for
   hashing and for the `aether.kinds` manifest, field and variant names are
   dropped; a separate labels sidecar (`aether.kinds.labels`) carries them for
   consumers that want human-readable reconstruction, like `describe_kinds`
-  ([ADR-0032](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0032-canonical-schema-bytes-and-labels-sidecar.md)). The wire never carries names — postcard fields are positional.
+  ([ADR-0032](https://github.com/iamacoffeepot/aether/blob/main/docs/adr/0032-canonical-schema-bytes-and-labels-sidecar.md)). The wire never carries names — structured fields are positional.
 - **`Ref` is a schema arm.** A field whose type is `Ref<K>` is a *handle-or-
   inline* slot — see *Handles* below. The
   schema wraps the inner kind's shape, so a recipient decodes the resolved value
@@ -158,7 +158,7 @@ cases that surprise people live at the schema-arm level. Holding the
 - **A same-size type swap** — `{ a: u32 }` ≠ `{ a: i32 }`, and `{ a: u64 }` ≠
   `{ a: MailboxId }` even though both are eight wire bytes: a typed-id field is a
   distinct `TypeId` arm, not a `Scalar`.
-- **Flipping `#[repr(C)]`** when it changes the cast/postcard choice — `repr_c`
+- **Flipping `#[repr(C)]`** when it changes the cast/structured choice — `repr_c`
   is part of the canonical bytes, so the same fields under a different wire
   format are a different kind.
 - **Wrapping a field** — `{ a: u32 }`, `{ a: Option<u32> }`, and `{ a: Ref<u32> }`

--- a/docs/guide/recipes/adding-a-substrate-kind.md
+++ b/docs/guide/recipes/adding-a-substrate-kind.md
@@ -120,7 +120,7 @@ Three checks, cheapest first:
 - **Coverage + schema shape** — `cargo nextest run -p aether-kinds` exercises
   `descriptors.rs`: `covers_every_substrate_kind` proves the kind reaches the
   hub-shipped list, and the shape tests (`signal_kinds_emit_unit`,
-  `cast_kinds_emit_struct_with_repr_c`, the postcard-vs-cast guards) catch a
+  `cast_kinds_emit_struct_with_repr_c`, the structured-vs-cast guards) catch a
   wire-format slip.
 - **Round-trip through the chassis** — drive a `send_and_await` against the
   owning mailbox in the test bench and decode the reply. The pattern is in


### PR DESCRIPTION
Closes #2093.

## Summary

The `postcard` crate is already gone (ADR-0118's #1976→#2033 arc migrated every encode/decode site onto `aether_data::wire` and dropped the deps). What lingered was the stale *name*: "postcard" survived as terminology for the structured (non-cast) wire path in comments, doc-comments, test identifiers, a struct field, three `Cargo.toml` comments, and guide prose. ADR-0118 designed the format from aether's own data rather than inheriting postcard's, so the word now describes nothing real.

This is a terminology rename to ADR-0118's vocabulary — **structured** (the path/shape), **the wire format** / **`aether_data::wire`** (the producer) — not a deletion:

- Identifier renames (def + all call sites): the `postcard_struct` codec fixture → `structured_struct`; the `postcard_*` / `type_id_postcard_*` codec decode tests → `structured_*`; the `schema_postcard` field on `KindDescriptorWire` → `schema_wire` (plus its cross-crate consumers in `aether-kinds` / `aether-capabilities` / `aether-mcp`); `test.fake_postcard` → `test.fake_structured` and `FakePostcard` → `FakeStructured`; the remaining `*_postcard_*` test names across the workspace → structured equivalents.
- Comment / doc-comment sweeps, the three `Cargo.toml` frame-framing comments, and three guide files.

Scope boundaries held: historical `docs/adr/*` files are untouched (they record what was true at the time), `Cargo.lock` is untouched (postcard there is wasmtime's transitive dep), and `varint` is left intact (it names a separate leaf-encoding detail, out of this rename). No public non-test API, wire format, or type identifier changes — `schema_postcard` is an internal field whose bytes are unaffected.

## Test plan

`scripts/preflight.sh` green — fmt, clippy `--workspace --all-targets -D warnings`, `cargo doc --workspace --no-deps`, `cargo nextest run --workspace` (2187 passed, 9 skipped). Verification grep `git grep -nI -i postcard -- crates docs/guide '**/Cargo.toml'` is clean: only `docs/adr/*` (historical) and `Cargo.lock` (wasmtime transitive) retain the word.

## Generated by

`/implement` — agent execution of scoped issue #2093.
