### PR TITLE
refactor(aether-actor): rename the guest-init BootError to ActorInitError

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ A component is an `Actor` whose receive side is declared with the **`#[actor]`**
 impl WasmActor for CameraComponent {
     const NAMESPACE: &'static str = "aether.camera";       // default load name
 
-    fn init<C: Resolver>(ctx: &mut C) -> Result<Self, BootError> { /* build state */ }
+    fn init<C: Resolver>(ctx: &mut C) -> Result<Self, ActorInitError> { /* build state */ }
 
     fn wire(&mut self, ctx: &mut WasmCtx<'_>) {              // post-init, mail allowed
         ctx.actor::<LifecycleCapability>().subscribe::<Tick>(); // subscribe the calling actor

--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -1956,7 +1956,7 @@ fn expand_wasm_actor(item: ItemImpl, opts: ActorOpts) -> syn::Result<TokenStream
     let mut init_method = init_method.ok_or_else(|| {
         syn::Error::new_spanned(
             self_ty,
-            "#[actor] requires `fn init(ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError>` \
+            "#[actor] requires `fn init(ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError>` \
              (or, with `type Config = T`, `fn init(config: T, ctx: &mut WasmInitCtx<'_>) -> …`)",
         )
     })?;
@@ -2280,7 +2280,7 @@ fn expand_wasm_actor(item: ItemImpl, opts: ActorOpts) -> syn::Result<TokenStream
 
         impl #impl_generics ::aether_actor::Lifecycle for #self_ty #where_clause {
             #config_type_tokens
-            type InitError = ::aether_actor::BootError;
+            type InitError = ::aether_actor::ActorInitError;
             type InitCtx<'__a> = ::aether_actor::WasmInitCtx<'__a>;
             type Ctx<'__a> = ::aether_actor::WasmCtx<'__a>;
 

--- a/crates/aether-actor-derive/tests/ui/accepts_manual_handler_wasm.rs
+++ b/crates/aether-actor-derive/tests/ui/accepts_manual_handler_wasm.rs
@@ -38,7 +38,7 @@ struct ManualProbe;
 impl aether_actor::WasmActor for ManualProbe {
     const NAMESPACE: &'static str = "manual_probe";
 
-    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::BootError>
+    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::ActorInitError>
     {
         Ok(ManualProbe)
     }

--- a/crates/aether-actor-derive/tests/ui/accepts_minimal_actor.rs
+++ b/crates/aether-actor-derive/tests/ui/accepts_minimal_actor.rs
@@ -25,7 +25,7 @@ struct Minimal;
 impl aether_actor::WasmActor for Minimal {
     const NAMESPACE: &'static str = "minimal";
 
-    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::BootError>
+    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::ActorInitError>
     {
         Ok(Minimal)
     }

--- a/crates/aether-actor-derive/tests/ui/accepts_state_actor.rs
+++ b/crates/aether-actor-derive/tests/ui/accepts_state_actor.rs
@@ -38,7 +38,7 @@ impl aether_actor::WasmActor for Counter {
 
     type State = CounterState;
 
-    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::BootError>
+    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::ActorInitError>
     {
         Ok(Counter { count: 0 })
     }

--- a/crates/aether-actor-derive/tests/ui/rejects_accessor_without_state.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_accessor_without_state.rs
@@ -34,7 +34,7 @@ struct Counter {
 impl aether_actor::WasmActor for Counter {
     const NAMESPACE: &'static str = "counter";
 
-    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::BootError>
+    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::ActorInitError>
     {
         Ok(Counter { count: 0 })
     }

--- a/crates/aether-actor-derive/tests/ui/rejects_duplicate_handler_kind_native.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_duplicate_handler_kind_native.rs
@@ -29,7 +29,7 @@ impl aether_substrate::actor::native::NativeActor for Dup {
     fn init(
         _config: (),
         _ctx: &mut aether_substrate::actor::native::NativeInitCtx<'_>,
-    ) -> Result<Self, aether_actor::BootError> {
+    ) -> Result<Self, aether_actor::ActorInitError> {
         unimplemented!()
     }
 

--- a/crates/aether-actor-derive/tests/ui/rejects_duplicate_handler_kind_wasm.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_duplicate_handler_kind_wasm.rs
@@ -27,7 +27,7 @@ struct Dup;
 impl aether_actor::WasmActor for Dup {
     const NAMESPACE: &'static str = "dup";
 
-    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::BootError>
+    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::ActorInitError>
     {
         Ok(Dup)
     }

--- a/crates/aether-actor-derive/tests/ui/rejects_manual_marker_mismatch_wasm.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_manual_marker_mismatch_wasm.rs
@@ -41,7 +41,7 @@ struct MismatchProbe;
 impl aether_actor::WasmActor for MismatchProbe {
     const NAMESPACE: &'static str = "mismatch_probe";
 
-    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::BootError>
+    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::ActorInitError>
     {
         Ok(MismatchProbe)
     }

--- a/crates/aether-actor-derive/tests/ui/rejects_missing_namespace_native.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_missing_namespace_native.rs
@@ -29,7 +29,7 @@ impl aether_substrate::actor::native::NativeActor for NoNamespace {
     fn init(
         _config: (),
         _ctx: &mut aether_substrate::actor::native::NativeInitCtx<'_>,
-    ) -> Result<Self, aether_actor::BootError> {
+    ) -> Result<Self, aether_actor::ActorInitError> {
         unimplemented!()
     }
 

--- a/crates/aether-actor-derive/tests/ui/rejects_missing_namespace_wasm.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_missing_namespace_wasm.rs
@@ -24,7 +24,7 @@ struct NoNamespace;
 
 #[actor]
 impl aether_actor::WasmActor for NoNamespace {
-    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::BootError>
+    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::ActorInitError>
     {
         Ok(NoNamespace)
     }

--- a/crates/aether-actor-derive/tests/ui/rejects_missing_rehydrate.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_missing_rehydrate.rs
@@ -36,7 +36,7 @@ impl aether_actor::WasmActor for Counter {
 
     type State = CounterState;
 
-    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::BootError>
+    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::ActorInitError>
     {
         Ok(Counter { count: 0 })
     }

--- a/crates/aether-actor-derive/tests/ui/rejects_state_with_manual_hook.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_state_with_manual_hook.rs
@@ -36,7 +36,7 @@ impl aether_actor::WasmActor for Counter {
 
     type State = CounterState;
 
-    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::BootError>
+    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::ActorInitError>
     {
         Ok(Counter { count: 0 })
     }

--- a/crates/aether-actor-derive/tests/ui/rejects_stray_const_native.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_stray_const_native.rs
@@ -32,7 +32,7 @@ impl aether_substrate::actor::native::NativeActor for StrayConst {
     fn init(
         _config: (),
         _ctx: &mut aether_substrate::actor::native::NativeInitCtx<'_>,
-    ) -> Result<Self, aether_actor::BootError> {
+    ) -> Result<Self, aether_actor::ActorInitError> {
         unimplemented!()
     }
 

--- a/crates/aether-actor-derive/tests/ui/rejects_stray_const_wasm.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_stray_const_wasm.rs
@@ -27,7 +27,7 @@ impl aether_actor::WasmActor for StrayConst {
     const NAMESPACE: &'static str = "stray";
     const BUFFER_CAPACITY: usize = 64;
 
-    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::BootError>
+    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::ActorInitError>
     {
         Ok(StrayConst)
     }

--- a/crates/aether-actor-derive/tests/ui/rejects_stream_reserved_native.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_stream_reserved_native.rs
@@ -28,7 +28,7 @@ impl aether_substrate::actor::native::NativeActor for StreamProbe {
     fn init(
         _config: (),
         _ctx: &mut aether_substrate::actor::native::NativeInitCtx<'_>,
-    ) -> Result<Self, aether_actor::BootError> {
+    ) -> Result<Self, aether_actor::ActorInitError> {
         Ok(StreamProbe)
     }
 

--- a/crates/aether-actor-derive/tests/ui/rejects_stream_reserved_wasm.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_stream_reserved_wasm.rs
@@ -24,7 +24,7 @@ struct StreamProbe;
 impl aether_actor::WasmActor for StreamProbe {
     const NAMESPACE: &'static str = "stream_probe";
 
-    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::BootError>
+    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::ActorInitError>
     {
         Ok(StreamProbe)
     }

--- a/crates/aether-actor-derive/tests/ui/single_handler_cannot_reply.rs
+++ b/crates/aether-actor-derive/tests/ui/single_handler_cannot_reply.rs
@@ -41,7 +41,7 @@ struct SilentProbe;
 impl aether_actor::WasmActor for SilentProbe {
     const NAMESPACE: &'static str = "silent_probe";
 
-    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::BootError>
+    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::ActorInitError>
     {
         Ok(SilentProbe)
     }

--- a/crates/aether-actor/examples/hello.rs
+++ b/crates/aether-actor/examples/hello.rs
@@ -21,7 +21,7 @@
 // fine but must keep the signature.
 #![allow(clippy::unused_self)]
 
-use aether_actor::{BootError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::{LifecycleCapability, RenderCapability};
 use aether_kinds::{DrawTriangle, Ping, Pong, Tick, Vertex};
@@ -70,7 +70,7 @@ pub struct Hello {}
 impl WasmActor for Hello {
     const NAMESPACE: &'static str = "hello";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(Hello {})
     }
 

--- a/crates/aether-actor/examples/input_logger.rs
+++ b/crates/aether-actor/examples/input_logger.rs
@@ -21,7 +21,7 @@
 // ADR-0033 / ADR-0038 dispatch ABI but doesn't need any field access.
 #![allow(clippy::unused_self)]
 
-use aether_actor::{BootError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_capabilities::InputCapability;
 use aether_data::{Kind, MailboxId};
 use aether_kinds::{Key, MouseButton, MouseMove, SubscribeInput};
@@ -32,7 +32,7 @@ pub struct InputLogger;
 impl WasmActor for InputLogger {
     const NAMESPACE: &'static str = "input_logger";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(InputLogger)
     }
 

--- a/crates/aether-actor/src/actor/mod.rs
+++ b/crates/aether-actor/src/actor/mod.rs
@@ -185,7 +185,7 @@ pub trait Addressable: Sized + Send + 'static {
 /// native pair), so a `wire`/`unwire` body reaches the concrete ctx's
 /// inherent methods (`ctx.actor::<R>().send(&p)`) with no generic bound at
 /// the call site. `InitError` is pinned per transport subtrait
-/// (`WasmActor: Lifecycle<InitError = BootError>`), so existing generic call
+/// (`WasmActor: Lifecycle<InitError = ActorInitError>`), so existing generic call
 /// sites keep seeing a concrete error type.
 pub trait Lifecycle {
     /// ADR-0090 boot configuration the chassis threads into [`Self::init`].

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -78,8 +78,8 @@ pub use mail::{Mail, NO_REPLY_HANDLE, PriorState, ReplyHandle};
 // `aether_actor::WasmCtx<'_>` / `aether_actor::WasmActor` / etc. without
 // an extra `wasm::` segment.
 pub use wasm::{
-    BootError, ErasedWasmActor, RelativeMailbox, SpawnError, WasmActor, WasmActorMailbox, WasmCtx,
-    WasmDropCtx, WasmInitCtx,
+    ActorInitError, ErasedWasmActor, RelativeMailbox, SpawnError, WasmActor, WasmActorMailbox,
+    WasmCtx, WasmDropCtx, WasmInitCtx,
 };
 
 // Issue 665 retired `MailTransport` and its `MailTransportTrait`

--- a/crates/aether-actor/src/wasm/ctx.rs
+++ b/crates/aether-actor/src/wasm/ctx.rs
@@ -29,7 +29,7 @@ use crate::mail::mailbox::{KindId, Mailbox, resolve, resolve_mailbox};
 use crate::wasm::bridge::{mail, persist};
 use crate::wasm::inline::InlineRegistry;
 use crate::wasm::mailbox::WasmActorMailbox;
-use crate::wasm::{BootError, ErasedWasmActor, WasmActor};
+use crate::wasm::{ActorInitError, ErasedWasmActor, WasmActor};
 use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -152,12 +152,12 @@ pub enum SpawnError {
     /// [`validate_namespace_segment`].
     SubnameInvalid(NamespaceError),
     /// ADR-0114: an inline child's synchronous `init` returned `Err`. The
-    /// wrapped [`BootError`] carries the actor's own failure message.
+    /// wrapped [`ActorInitError`] carries the actor's own failure message.
     /// Unlike the detached `spawn_child` — whose `init` runs later on the
     /// trampoline and logs asynchronously — an inline child's `init` runs
     /// in-guest during [`WasmCtx::spawn_inline_child`], so the boot failure
     /// comes back through this `Result`.
-    InitFailed(BootError),
+    InitFailed(ActorInitError),
 }
 
 /// Per-receive (and post-init `wire` / pre-shutdown `unwire`)
@@ -390,7 +390,7 @@ impl<M: ReplyMode> WasmCtx<'_, M> {
         // it sidesteps a `Clone` bound the detached verb also lacks.
         let bytes = config.encode_into_bytes();
         let Some(owned) = <A::Config as Kind>::decode_from_bytes(&bytes) else {
-            return Err(SpawnError::InitFailed(BootError::new(
+            return Err(SpawnError::InitFailed(ActorInitError::new(
                 "spawn_inline_child: Config round-trip failed",
             )));
         };
@@ -925,7 +925,7 @@ mod tests {
     use crate::actor::ctx::OutboundReply;
     use crate::mail::{Mail, PriorState};
     use crate::wasm::inline::RouteDecision;
-    use crate::wasm::{BootError, ErasedWasmActor, WasmActor, WasmDropCtx, WasmInitCtx};
+    use crate::wasm::{ActorInitError, ErasedWasmActor, WasmActor, WasmDropCtx, WasmInitCtx};
     use aether_data::MailboxId;
     use alloc::string::String;
     use core::mem::{align_of, size_of};
@@ -943,12 +943,12 @@ mod tests {
 
     impl crate::Lifecycle for FailingChild {
         type Config = ();
-        type InitError = BootError;
+        type InitError = ActorInitError;
         type InitCtx<'a> = WasmInitCtx<'a>;
         type Ctx<'a> = WasmCtx<'a>;
 
-        fn init(_config: (), _ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
-            Err(BootError::new("inline child init deliberately fails"))
+        fn init(_config: (), _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
+            Err(ActorInitError::new("inline child init deliberately fails"))
         }
     }
 
@@ -1054,11 +1054,11 @@ mod tests {
 
     impl crate::Lifecycle for SucceedingChild {
         type Config = ();
-        type InitError = BootError;
+        type InitError = ActorInitError;
         type InitCtx<'a> = WasmInitCtx<'a>;
         type Ctx<'a> = WasmCtx<'a>;
 
-        fn init(_config: (), _ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+        fn init(_config: (), _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
             Ok(Self)
         }
     }

--- a/crates/aether-actor/src/wasm/mod.rs
+++ b/crates/aether-actor/src/wasm/mod.rs
@@ -21,7 +21,7 @@
 //!     free — the bridge free functions cover dispatch.
 //!   - [`WasmActor`] trait — entry point with the `init` constructor and
 //!     the `wire` / `unwire` / `on_dehydrate` / `on_rehydrate` lifecycle
-//!     hooks (ADR-0101). `init` returns `Result<Self, BootError>` so a
+//!     hooks (ADR-0101). `init` returns `Result<Self, ActorInitError>` so a
 //!     guest can surface its own error message instead of the panic-hook
 //!     path's generic "guest trapped during init" text.
 //!   - [`crate::export!`] — `#[no_mangle]` `init` / `receive` /
@@ -68,15 +68,15 @@ pub use mailbox::WasmActorMailbox;
 /// panic-hook path's generic "guest trapped during init" text.
 ///
 /// Wraps a `Cow<'static, str>` so static-string callers don't allocate
-/// (`BootError::from("config missing")`) while owned strings still flow
-/// through (`BootError::from(format!("..."))`).
+/// (`ActorInitError::from("config missing")`) while owned strings still flow
+/// through (`ActorInitError::from(format!("..."))`).
 #[derive(Debug, Clone)]
-pub struct BootError {
+pub struct ActorInitError {
     message: Cow<'static, str>,
 }
 
-impl BootError {
-    /// Construct a `BootError` from anything convertible to a
+impl ActorInitError {
+    /// Construct a `ActorInitError` from anything convertible to a
     /// `Cow<'static, str>` — `&'static str` for compile-time messages,
     /// `String` for `format!`-built diagnostics.
     pub fn new<S: Into<Cow<'static, str>>>(message: S) -> Self {
@@ -93,19 +93,19 @@ impl BootError {
     }
 }
 
-impl fmt::Display for BootError {
+impl fmt::Display for ActorInitError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.message)
     }
 }
 
-impl From<&'static str> for BootError {
+impl From<&'static str> for ActorInitError {
     fn from(s: &'static str) -> Self {
         Self::new(s)
     }
 }
 
-impl From<String> for BootError {
+impl From<String> for ActorInitError {
     fn from(s: String) -> Self {
         Self::new(s)
     }
@@ -122,7 +122,7 @@ impl From<String> for BootError {
 /// composes it alongside the identity [`crate::Addressable`] supertrait and
 /// adds only the FFI-specific hot-swap surface (`type State`,
 /// `on_dehydrate`, `on_rehydrate`, ADR-0101). `InitError` is pinned to
-/// [`BootError`] so a guest surfaces its own message in
+/// [`ActorInitError`] so a guest surfaces its own message in
 /// `LoadResult::Err { error }`; `Self::Config` is tightened to
 /// [`Kind`](aether_data::Kind) — FFI config crosses the wasm boundary as
 /// encoded bytes.
@@ -133,7 +133,7 @@ impl From<String> for BootError {
 pub trait WasmActor:
     crate::Addressable
     + for<'a> crate::Lifecycle<
-        InitError = BootError,
+        InitError = ActorInitError,
         Config: aether_data::Kind,
         InitCtx<'a> = WasmInitCtx<'a>,
         Ctx<'a> = WasmCtx<'a>,
@@ -590,7 +590,7 @@ macro_rules! __export_internal {
         /// `init_failed_p32` and returns 1.
         ///
         /// Returns `0` on success and non-zero when the actor's `init`
-        /// returned `Err(BootError)` or its `Config::decode_from_bytes`
+        /// returned `Err(ActorInitError)` or its `Config::decode_from_bytes`
         /// produced `None`.
         #[cfg(target_family = "wasm")]
         #[unsafe(export_name = "init_with_config_p32")]

--- a/crates/aether-actor/src/wasm/raw.rs
+++ b/crates/aether-actor/src/wasm/raw.rs
@@ -62,10 +62,10 @@ unsafe extern "C" {
     /// of this kind."
     #[link_name = "prev_correlation_p32"]
     pub fn prev_correlation() -> u64;
-    /// Issue 525 Phase 4b / issue 531: stage a `BootError` message
+    /// Issue 525 Phase 4b / issue 531: stage a `ActorInitError` message
     /// for the substrate to surface in `LoadResult::Err` after the
     /// guest's `init` returns non-zero. The `export!` macro is the
-    /// only intended caller — user code returns `Err(BootError)`
+    /// only intended caller — user code returns `Err(ActorInitError)`
     /// from `WasmActor::init` and the macro plumbs the bytes
     /// through this import. Bytes at `(ptr, len)` are copied out of
     /// guest memory before the call returns.

--- a/crates/aether-actor/tests/handlers_manifest.rs
+++ b/crates/aether-actor/tests/handlers_manifest.rs
@@ -21,7 +21,7 @@
 // `&mut self` to match the dispatch ABI but don't read state.
 #![allow(clippy::unused_self)]
 
-use aether_actor::{BootError, Manual, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{ActorInitError, Manual, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_data::Kind;
 use aether_data::{INPUTS_SECTION_VERSION, InputsRecord, ReplyContract, wire};
 use bytemuck::{Pod, Zeroable};
@@ -65,7 +65,7 @@ struct ManifestProbe;
 impl WasmActor for ManifestProbe {
     const NAMESPACE: &'static str = "manifest_probe";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(Self)
     }
 

--- a/crates/aether-kit/src/runtime/camera.rs
+++ b/crates/aether-kit/src/runtime/camera.rs
@@ -45,7 +45,7 @@
 
 use std::collections::HashMap;
 
-use aether_actor::{BootError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_capabilities::input::InputMailboxExt;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::{InputCapability, LifecycleCapability, RenderCapability};
@@ -258,7 +258,7 @@ pub struct CameraComponent {
 impl WasmActor for CameraComponent {
     const NAMESPACE: &'static str = "aether.camera";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         let mut cameras = HashMap::new();
         cameras.insert(
             "main".to_owned(),

--- a/crates/aether-kit/src/runtime/locomotion.rs
+++ b/crates/aether-kit/src/runtime/locomotion.rs
@@ -74,7 +74,7 @@ use core::f32::consts::{FRAC_PI_2, PI, TAU};
 use std::cmp::{Ordering, Reverse};
 use std::collections::{BinaryHeap, VecDeque};
 
-use aether_actor::{BootError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_capabilities::input::InputMailboxExt;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::{InputCapability, LifecycleCapability, RenderCapability, UiCapability};
@@ -361,7 +361,7 @@ pub struct Locomotion {
 impl WasmActor for Locomotion {
     const NAMESPACE: &'static str = "aether.locomotion";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         let mover = Mover {
             x: tile_center_octimeters(GRID_W / 2),
             z: tile_center_octimeters(GRID_H / 2),

--- a/crates/aether-mesh-viewer/src/runtime.rs
+++ b/crates/aether-mesh-viewer/src/runtime.rs
@@ -33,7 +33,7 @@
 //!    triangles to `"aether.render"`.
 
 use aether_actor::{
-    BootError, Manual, OutboundReply, ReplyHandle, WasmActor, WasmCtx, WasmInitCtx, actor,
+    ActorInitError, Manual, OutboundReply, ReplyHandle, WasmActor, WasmCtx, WasmInitCtx, actor,
 };
 use aether_capabilities::fs::FsMailboxExt;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
@@ -234,7 +234,7 @@ struct ScrubIndex {
 impl WasmActor for MeshViewer {
     const NAMESPACE: &'static str = "aether.mesh_viewer";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(MeshViewer {
             triangles: Vec::new(),
             overlay: Vec::new(),

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -116,7 +116,7 @@ pub struct ComponentCtx {
     /// surfaces the message back up the control plane.
     pub save_state_error: Option<String>,
     /// Set by the `init_failed_p32` host fn when the guest's `init`
-    /// returns `Err(BootError)`. Issue 525 Phase 4b / issue 531: the
+    /// returns `Err(ActorInitError)`. Issue 525 Phase 4b / issue 531: the
     /// substrate reads this after `init` returns non-zero and
     /// surfaces the message in `LoadResult::Err { error }`. The guest
     /// stages the bytes here and returns 1 from its `init` shim;
@@ -842,7 +842,7 @@ impl Component {
         // that probes `init` first would silently skip the config path.
         //
         // Issue 525 Phase 4b / issue 531: a non-zero return value
-        // means the guest's `WasmActor::init` returned `Err(BootError)`
+        // means the guest's `WasmActor::init` returned `Err(ActorInitError)`
         // and staged the message via `init_failed_p32`. Drain the
         // staged string off the ctx and surface it as a wasmtime
         // error so the existing `dispatch_load_component` failure

--- a/crates/aether-substrate/src/actor/wasm/host_fns.rs
+++ b/crates/aether-substrate/src/actor/wasm/host_fns.rs
@@ -503,7 +503,7 @@ pub fn register(linker: &mut Linker<ComponentCtx>) -> wasmtime::Result<()> {
         |caller: Caller<'_, ComponentCtx>| -> u64 { caller.data().prev_correlation() },
     )?;
 
-    // HOST_FN_OK: ADR-0002 / issue 531. The BootError plumbing
+    // HOST_FN_OK: ADR-0002 / issue 531. The ActorInitError plumbing
     // can't ride a mail sink because mail is not dispatched until
     // the component finishes booting — the `init` FFI call itself
     // is the entry point, and a `Result::Err` returned from it
@@ -511,7 +511,7 @@ pub fn register(linker: &mut Linker<ComponentCtx>) -> wasmtime::Result<()> {
     // substrate before the FFI call returns. A host fn is the
     // only mechanism that's available pre-`init`-completion.
     //
-    // Issue 525 Phase 4b / issue 531: stage a `BootError` message
+    // Issue 525 Phase 4b / issue 531: stage a `ActorInitError` message
     // for `Component::instantiate` to surface in `LoadResult::Err`
     // after the guest's `init` returns non-zero. The bytes are
     // copied out of guest memory before the call returns; OOB or

--- a/crates/aether-test-fixtures/bundle/src/cube.rs
+++ b/crates/aether-test-fixtures/bundle/src/cube.rs
@@ -29,7 +29,7 @@
 
 use core::f32::consts::FRAC_PI_4;
 
-use aether_actor::{BootError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::{LifecycleCapability, RenderCapability};
 use aether_kinds::{Camera, DrawTriangle, Tick, Vertex};
@@ -129,7 +129,7 @@ impl Cube {
 impl WasmActor for Cube {
     const NAMESPACE: &'static str = "cube";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(Cube {
             view_proj: Cube::framing_view_proj(),
         })

--- a/crates/aether-test-fixtures/bundle/src/http_handler.rs
+++ b/crates/aether-test-fixtures/bundle/src/http_handler.rs
@@ -20,7 +20,7 @@
 // ignores `self` is correct but triggers `unused_self`.
 #![allow(clippy::needless_pass_by_value, clippy::unused_self)]
 
-use aether_actor::{BootError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_kinds::{HttpServerRequest, HttpServerResponse};
 
 pub struct HttpHandler;
@@ -29,7 +29,7 @@ pub struct HttpHandler;
 impl WasmActor for HttpHandler {
     const NAMESPACE: &'static str = "web";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(HttpHandler)
     }
 

--- a/crates/aether-test-fixtures/bundle/src/inline_child.rs
+++ b/crates/aether-test-fixtures/bundle/src/inline_child.rs
@@ -49,7 +49,7 @@
 #![allow(clippy::unused_self, clippy::needless_pass_by_value)]
 
 use aether_actor::{
-    BootError, Mail, Manual, OutboundReply, Subname, WasmActor, WasmCtx, WasmInitCtx, actor,
+    ActorInitError, Mail, Manual, OutboundReply, Subname, WasmActor, WasmCtx, WasmInitCtx, actor,
 };
 use aether_data::MailboxId;
 use aether_test_fixtures_kinds::{
@@ -85,7 +85,7 @@ pub struct InlineParent;
 impl WasmActor for InlineParent {
     const NAMESPACE: &'static str = "test.inline.parent";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(InlineParent)
     }
 
@@ -113,7 +113,7 @@ pub struct InlineChild;
 impl WasmActor for InlineChild {
     const NAMESPACE: &'static str = "test.inline.child";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(InlineChild)
     }
 
@@ -136,7 +136,7 @@ pub struct InlineStatefulParent;
 impl WasmActor for InlineStatefulParent {
     const NAMESPACE: &'static str = "test.inline.stateful_parent";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(InlineStatefulParent)
     }
 
@@ -172,7 +172,7 @@ impl WasmActor for InlineStatefulChild {
     /// the composite migration bundle.
     type State = InlineCounterState;
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(InlineStatefulChild { count: 0 })
     }
 
@@ -219,7 +219,7 @@ pub struct InlineDespawnParent {
 impl WasmActor for InlineDespawnParent {
     const NAMESPACE: &'static str = "test.inline.despawn_parent";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(InlineDespawnParent { child: None })
     }
 
@@ -262,7 +262,7 @@ pub struct InlineDespawnChild;
 impl WasmActor for InlineDespawnChild {
     const NAMESPACE: &'static str = "test.inline.despawn_child";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(InlineDespawnChild)
     }
 

--- a/crates/aether-test-fixtures/bundle/src/mat4_source.rs
+++ b/crates/aether-test-fixtures/bundle/src/mat4_source.rs
@@ -35,7 +35,7 @@
 // value to match the dispatch ABI even though it only reads the slot.
 #![allow(clippy::needless_pass_by_value, clippy::unused_self)]
 
-use aether_actor::{BootError, MailSender, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{ActorInitError, MailSender, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_data::Ref;
 use aether_kinds::{Mat4Apply, Write};
 use aether_math::{Mat4, Vec4};
@@ -53,7 +53,7 @@ pub struct MatSource;
 impl WasmActor for MatSource {
     const NAMESPACE: &'static str = "mat4_source";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(MatSource)
     }
 
@@ -91,7 +91,7 @@ pub struct Vec4Observer;
 impl WasmActor for Vec4Observer {
     const NAMESPACE: &'static str = "vec4_observer";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(Vec4Observer)
     }
 

--- a/crates/aether-test-fixtures/bundle/src/matrix_sweep.rs
+++ b/crates/aether-test-fixtures/bundle/src/matrix_sweep.rs
@@ -36,7 +36,8 @@
 use core::cell::UnsafeCell;
 
 use aether_actor::{
-    BootError, MailboxId, Manual, OutboundReply, Subname, WasmActor, WasmCtx, WasmInitCtx, actor,
+    ActorInitError, MailboxId, Manual, OutboundReply, Subname, WasmActor, WasmCtx, WasmInitCtx,
+    actor,
 };
 use aether_test_fixtures_kinds::{
     CollectMatrix, MATRIX_CELL_CHILD_TO_PARENT, MATRIX_CELL_CHILD_TO_SELF,
@@ -141,7 +142,7 @@ pub struct MatrixParent;
 impl WasmActor for MatrixParent {
     const NAMESPACE: &'static str = "test.matrix.parent";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(MatrixParent)
     }
 
@@ -194,7 +195,7 @@ pub struct MatrixChild;
 impl WasmActor for MatrixChild {
     const NAMESPACE: &'static str = "test.matrix.child";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(MatrixChild)
     }
 

--- a/crates/aether-test-fixtures/bundle/src/multi_actor.rs
+++ b/crates/aether-test-fixtures/bundle/src/multi_actor.rs
@@ -19,7 +19,9 @@
 // dispatch ABI even when stateless.
 #![allow(clippy::unused_self)]
 
-use aether_actor::{BootError, Mail, MailSender, Subname, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{
+    ActorInitError, Mail, MailSender, Subname, WasmActor, WasmCtx, WasmInitCtx, actor,
+};
 use aether_kinds::Ping;
 use aether_test_fixtures_kinds::{TEST_BENCH_OBSERVER_MAILBOX_NAME, TickObserved};
 
@@ -31,7 +33,7 @@ pub struct RootManager;
 impl WasmActor for RootManager {
     const NAMESPACE: &'static str = "ui.root";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(RootManager)
     }
 
@@ -56,7 +58,7 @@ pub struct Panel;
 impl WasmActor for Panel {
     const NAMESPACE: &'static str = "ui.panel";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(Panel)
     }
 

--- a/crates/aether-test-fixtures/bundle/src/probe.rs
+++ b/crates/aether-test-fixtures/bundle/src/probe.rs
@@ -59,7 +59,7 @@
 #![allow(clippy::unused_self)]
 
 use aether_actor::{
-    BootError, MailSender, Manual, OutboundReply, WasmActor, WasmCtx, WasmInitCtx, actor,
+    ActorInitError, MailSender, Manual, OutboundReply, WasmActor, WasmCtx, WasmInitCtx, actor,
 };
 use aether_capabilities::input::InputMailboxExt;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
@@ -79,7 +79,7 @@ pub struct Probe {
 impl WasmActor for Probe {
     const NAMESPACE: &'static str = "test_fixture_probe";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(Probe {
             tick_count: 0,
             render: SetRender::default(),
@@ -185,7 +185,7 @@ impl WasmActor for ProbeWithConfig {
     type Config = ProbeConfig;
     const NAMESPACE: &'static str = "test_fixtures_probe_with_config";
 
-    fn init(config: ProbeConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(config: ProbeConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(ProbeWithConfig {
             seed: config.seed,
             label: config.label,

--- a/crates/aether-test-fixtures/bundle/src/source_observer.rs
+++ b/crates/aether-test-fixtures/bundle/src/source_observer.rs
@@ -27,7 +27,8 @@
 #![allow(clippy::unused_self)]
 
 use aether_actor::{
-    BootError, MailSender, MailboxId, Manual, OutboundReply, WasmActor, WasmCtx, WasmInitCtx, actor,
+    ActorInitError, MailSender, MailboxId, Manual, OutboundReply, WasmActor, WasmCtx, WasmInitCtx,
+    actor,
 };
 use aether_test_fixtures_kinds::{
     SendSourceQuery, SourceQuery, SourceReport, TEST_BENCH_OBSERVER_MAILBOX_NAME,
@@ -39,7 +40,7 @@ pub struct SourceObserver;
 impl WasmActor for SourceObserver {
     const NAMESPACE: &'static str = "test.source_observer";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(SourceObserver)
     }
 

--- a/crates/aether-test-fixtures/bundle/src/stateful_replace.rs
+++ b/crates/aether-test-fixtures/bundle/src/stateful_replace.rs
@@ -21,7 +21,7 @@
 #![allow(clippy::unused_self)]
 
 use aether_actor::{
-    BootError, Mail, Manual, OutboundReply, PriorState, WasmActor, WasmCtx, WasmDropCtx,
+    ActorInitError, Mail, Manual, OutboundReply, PriorState, WasmActor, WasmCtx, WasmDropCtx,
     WasmInitCtx, actor,
 };
 use aether_test_fixtures_kinds::{Bump, CountQuery, CountReport};
@@ -36,7 +36,7 @@ pub struct Counter {
 impl WasmActor for Counter {
     const NAMESPACE: &'static str = "stateful.counter";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(Counter { count: 0 })
     }
 
@@ -81,7 +81,7 @@ pub struct Sidecar;
 impl WasmActor for Sidecar {
     const NAMESPACE: &'static str = "stateful.sidecar";
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(Sidecar)
     }
 

--- a/crates/aether-test-fixtures/bundle/src/ui_widget.rs
+++ b/crates/aether-test-fixtures/bundle/src/ui_widget.rs
@@ -23,7 +23,7 @@
 //! Not a demo — its only job is to expose a realistic per-frame widget
 //! cost to the measurement.
 
-use aether_actor::{BootError, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::{LifecycleCapability, RenderCapability};
 use aether_kinds::{DrawSolidQuads, QuadSpace, SolidQuad, Tick};
@@ -38,7 +38,7 @@ impl WasmActor for UiWidget {
     type Config = UiWidgetConfig;
     const NAMESPACE: &'static str = "test_fixtures_ui_widget";
 
-    fn init(config: UiWidgetConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(config: UiWidgetConfig, _ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(UiWidget { config })
     }
 

--- a/crates/aether-test-fixtures/stateful-reshaped/src/lib.rs
+++ b/crates/aether-test-fixtures/stateful-reshaped/src/lib.rs
@@ -11,7 +11,7 @@
 // owned for an all-`Copy` state, so silence the false positive.
 #![allow(clippy::needless_pass_by_value)]
 
-use aether_actor::{BootError, Manual, OutboundReply, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{ActorInitError, Manual, OutboundReply, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_test_fixtures_kinds::{Bump, CountQuery, CountReport};
 
 /// Reshaped durable state — the added `generation` field changes the
@@ -41,7 +41,7 @@ impl WasmActor for Counter {
 
     type State = CounterState;
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(Counter {
             count: 0,
             generation: 0,

--- a/crates/aether-test-fixtures/stateful-typed/src/lib.rs
+++ b/crates/aether-test-fixtures/stateful-typed/src/lib.rs
@@ -17,7 +17,7 @@
 // contract is the point, so silence the false positive here.
 #![allow(clippy::needless_pass_by_value)]
 
-use aether_actor::{BootError, Manual, OutboundReply, WasmActor, WasmCtx, WasmInitCtx, actor};
+use aether_actor::{ActorInitError, Manual, OutboundReply, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_test_fixtures_kinds::{Bump, CountQuery, CountReport};
 
 /// Durable state the `Counter` carries across `replace_component`. The
@@ -47,7 +47,7 @@ impl WasmActor for Counter {
     /// `on_rehydrate` hooks.
     type State = CounterState;
 
-    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, BootError> {
+    fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(Counter { count: 0 })
     }
 

--- a/docs/guide/foundations/actor-model.md
+++ b/docs/guide/foundations/actor-model.md
@@ -62,11 +62,11 @@ contract: it's exactly what you're permitted to do at that point.
 The three stages exist because constructing an actor and letting it participate in
 the mail system are different moments, and only the second is safe to send from.
 `init` runs while the actor is still being built: its mailbox isn't published yet,
-peers may not have booted, and it returns `Result<Self, BootError>` so a failure
+peers may not have booted, and it returns `Result<Self, ActorInitError>` so a failure
 aborts the load cleanly. Sending mail from there would mean announcing yourself
 before you're addressable, or mailing a peer that doesn't exist yet. So `init` stays
 a pure synchronous constructor — resolve kind ids and mailbox addresses, assemble
-state, return it (or fail with a `BootError` that surfaces instead of leaving a
+state, return it (or fail with an `ActorInitError` that surfaces instead of leaving a
 half-built actor behind).
 
 `wire` is the first point where sending is safe. It runs once `init` has succeeded,
@@ -128,7 +128,7 @@ it handles from the method's **third parameter**:
 impl WasmActor for Hello {
     const NAMESPACE: &'static str = "hello";
 
-    fn init<C: Resolver>(_ctx: &mut C) -> Result<Self, BootError> {
+    fn init<C: Resolver>(_ctx: &mut C) -> Result<Self, ActorInitError> {
         Ok(Hello)
     }
 
@@ -175,7 +175,7 @@ impl WasmActor for ProbeWithConfig {
     type Config = ProbeConfig;
     const NAMESPACE: &'static str = "probe_with_config";
 
-    fn init<C>(config: ProbeConfig, ctx: &mut C) -> Result<Self, BootError>
+    fn init<C>(config: ProbeConfig, ctx: &mut C) -> Result<Self, ActorInitError>
     where C: Resolver { … }
 }
 ```

--- a/docs/guide/recipes/serving-http.md
+++ b/docs/guide/recipes/serving-http.md
@@ -32,7 +32,7 @@ status code, optional headers, and a byte body. The server writes the formatted
 HTTP/1.1 response to the client socket and closes the connection.
 
 ```rust
-use aether_actor::{BootError, WasmActor, WasmCtx, OutboundReply, Resolver, actor};
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, OutboundReply, Resolver, actor};
 use aether_kinds::{HttpServerRequest, HttpServerResponse};
 
 pub struct Web;
@@ -41,7 +41,7 @@ pub struct Web;
 impl WasmActor for Web {
     const NAMESPACE: &'static str = "web";
 
-    fn init<C: Resolver>(_ctx: &mut C) -> Result<Self, BootError> {
+    fn init<C: Resolver>(_ctx: &mut C) -> Result<Self, ActorInitError> {
         Ok(Web)
     }
 

--- a/docs/guide/recipes/writing-a-component.md
+++ b/docs/guide/recipes/writing-a-component.md
@@ -73,7 +73,7 @@ method *is* a handler — the macro infers the kind it handles from the method's
 parameter, so there's no typelist to maintain.
 
 ```rust
-use aether_actor::{BootError, WasmActor, WasmCtx, Resolver, actor};
+use aether_actor::{ActorInitError, WasmActor, WasmCtx, Resolver, actor};
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
 use aether_capabilities::{LifecycleCapability, RenderCapability};
 use aether_kinds::{DrawTriangle, Tick};
@@ -84,7 +84,7 @@ pub struct MyComponent {}
 impl WasmActor for MyComponent {
     const NAMESPACE: &'static str = "my_component";   // default load name
 
-    fn init<C>(_ctx: &mut C) -> Result<Self, BootError>
+    fn init<C>(_ctx: &mut C) -> Result<Self, ActorInitError>
     where
         C: Resolver,
     {


### PR DESCRIPTION
Closes #2097.

## Summary

Two unrelated types shared the name `BootError` across the actor/substrate seam — a keyword-scan trap where one term named two concepts. This renames the guest-side type `aether_actor::wasm::BootError` (the `Cow<'static, str>` newtype a wasm actor's `init()` returns) to `ActorInitError`, leaving `aether_substrate::chassis::error::BootError` (the chassis-boot enum) as the sole `BootError`.

Pure name-only refactor: the struct shape, its field, its `new` / `message` / `Display` / `From` impls, and its role as the guest `Lifecycle::InitError` binding are unchanged. The two types are distinguishable by import path at every reference, so only `aether_actor::*` sites rename; every `aether_substrate::*` chassis site stays `BootError`. The `aether-actor-derive` crate carries both paths — only its wasm-path codegen (`type InitError`) and the wasm-path `#[actor]` error-message string changed; the native path is untouched.

## Test plan

- `git grep BootError` returns only chassis sites (`aether-substrate`, native actor path, `aether-capabilities`, bundle, `aether-labyrinth`, derive native path); `git grep ActorInitError` is exactly the former guest sites.
- `scripts/preflight.sh` green: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace`, `cargo doc --workspace --no-deps`, and the wasm32 component cross-build (exercises the `type InitError = ::aether_actor::ActorInitError` codegen).
- The derive `trybuild` UI suite passes unchanged — no `*.stderr` quoted the message text.

## Generated by

`/implement` — agent execution of [scoped issue #2097](https://github.com/iamacoffeepot/aether/issues/2097).
