### PR TITLE
refactor(aether-kinds): rename MailEnvelope to disambiguate it from the rpc wire envelope

### DIFF
--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -1341,7 +1341,7 @@ mod tests {
         use crate::trace::TraceDispatchCapability;
         use aether_actor::Addressable;
         use aether_data::{Kind, mailbox_id_from_name};
-        use aether_kinds::MailEnvelope as TracedEnvelope;
+        use aether_kinds::NamedMail;
         use aether_kinds::trace::DispatchTraced;
 
         let (_chassis, mut stream) = boot_with_deferred_echo(Duration::from_secs(10));
@@ -1351,13 +1351,13 @@ mod tests {
         // trace cap resolves names through the registry).
         let batch = DispatchTraced {
             mails: vec![
-                TracedEnvelope {
+                NamedMail {
                     recipient_name: <DeferredEchoActor as Addressable>::NAMESPACE.into(),
                     kind_name: <DeferredEchoRequest as Kind>::NAME.into(),
                     payload: DeferredEchoRequest { value: 11 }.encode_into_bytes(),
                     count: 1,
                 },
-                TracedEnvelope {
+                NamedMail {
                     recipient_name: <DeferredEchoActor as Addressable>::NAMESPACE.into(),
                     kind_name: <DeferredEchoRequest as Kind>::NAME.into(),
                     payload: DeferredEchoRequest { value: 22 }.encode_into_bytes(),

--- a/crates/aether-capabilities/src/trace.rs
+++ b/crates/aether-capabilities/src/trace.rs
@@ -183,7 +183,7 @@ mod native {
         /// carrying the inbound mail id.
         #[test]
         fn on_dispatch_traced_resolves_each_envelope_and_acks_with_root() {
-            use aether_kinds::MailEnvelope;
+            use aether_kinds::NamedMail;
             use std::sync::Mutex;
 
             type Capture = (KindId, MailId, Option<MailId>, Vec<u8>);
@@ -218,13 +218,13 @@ mod native {
                 &mut ctx,
                 DispatchTraced {
                     mails: vec![
-                        MailEnvelope {
+                        NamedMail {
                             recipient_name: "aether.test.spec_a".into(),
                             kind_name: "aether.test.kind_a".into(),
                             payload: vec![1u8, 2],
                             count: 1,
                         },
-                        MailEnvelope {
+                        NamedMail {
                             recipient_name: "aether.test.spec_b".into(),
                             kind_name: "aether.test.kind_b".into(),
                             payload: vec![3u8, 4, 5],
@@ -276,7 +276,7 @@ mod native {
         /// to `DispatchTracedAck::Err`; no envelope dispatches.
         #[test]
         fn on_dispatch_traced_replies_err_on_unknown_recipient() {
-            use aether_kinds::MailEnvelope;
+            use aether_kinds::NamedMail;
 
             let mut fix = dispatch_traced_fixture();
             let inbound = MailId::new(MailboxId(0xC0DE), 99);
@@ -284,7 +284,7 @@ mod native {
             let ack = fix.cap.on_dispatch_traced(
                 &mut ctx,
                 DispatchTraced {
-                    mails: vec![MailEnvelope {
+                    mails: vec![NamedMail {
                         recipient_name: "aether.test.does_not_exist".into(),
                         kind_name: "aether.test.also_missing".into(),
                         payload: vec![],

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1893,8 +1893,8 @@ mod control_plane {
     #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
     #[kind(name = "aether.render.capture_frame")]
     pub struct CaptureFrame {
-        pub mails: Vec<MailEnvelope>,
-        pub after_mails: Vec<MailEnvelope>,
+        pub mails: Vec<NamedMail>,
+        pub after_mails: Vec<NamedMail>,
         pub checks: Vec<FrameCheck>,
         /// Optional reference-image similarity check
         /// (iamacoffeepot/aether#1780). `None` means no comparison.
@@ -1904,12 +1904,12 @@ mod control_plane {
     /// One mail in a `CaptureFrame.mails` bundle. Structurally mirrors
     /// `aether_data::MailFrame` — a pre-encoded payload plus
     /// the name-level addressing the substrate uses to resolve it.
-    /// The hub encodes each envelope's `payload` via the kind's
+    /// The hub encodes each entry's `payload` via the kind's
     /// descriptor before wrapping it into the bundle, so the
     /// substrate side just pushes `Mail::new(mailbox, kind_id,
     /// payload, count)` directly.
     #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    pub struct MailEnvelope {
+    pub struct NamedMail {
         pub recipient_name: String,
         pub kind_name: String,
         pub payload: Vec<u8>,

--- a/crates/aether-kinds/src/trace.rs
+++ b/crates/aether-kinds/src/trace.rs
@@ -19,7 +19,7 @@ use alloc::vec::Vec;
 use aether_data::{KindId, MailId, MailboxId, ThreadId};
 use serde::{Deserialize, Serialize};
 
-use crate::MailEnvelope;
+use crate::NamedMail;
 
 /// ADR-0080 §3 (slimmed by ADR-0086 Phase 3c): well-known mailbox name
 /// the `TraceDispatchCapability` (in `aether-capabilities`) registers
@@ -338,7 +338,7 @@ pub struct Settled {
 /// itself, then replies synchronously with [`DispatchTracedAck`]
 /// carrying that root id.
 ///
-/// Carries [`MailEnvelope`]s — the same name-addressed batch shape
+/// Carries [`NamedMail`]s — the same name-addressed batch shape
 /// `CaptureFrame` uses. The substrate-side handler resolves the
 /// recipient and kind names against its registry at dispatch time.
 ///
@@ -352,7 +352,7 @@ pub struct Settled {
 #[derive(Clone, Debug, Serialize, Deserialize, aether_data::Kind, aether_data::Schema)]
 #[kind(name = "aether.trace.dispatch_traced")]
 pub struct DispatchTraced {
-    pub mails: Vec<MailEnvelope>,
+    pub mails: Vec<NamedMail>,
 }
 
 /// Issue 749: synchronous reply to [`DispatchTraced`]. `Ok` carries

--- a/crates/aether-mcp/src/tools.rs
+++ b/crates/aether-mcp/src/tools.rs
@@ -39,11 +39,10 @@ use aether_kinds::{
     ComponentSelector, CostTail, CostTailResult, DeathReason, FrameCheck, FrameReduction,
     ListComponentBinaries, ListComponentBinariesResult, ListComponents, ListComponentsResult,
     ListEngineBinaries, ListEngineBinariesResult, ListEngines, ListEnginesResult, ListKinds,
-    ListKindsResult, LoadComponent, LoadResult, MailEnvelope as KindMailEnvelope, ReplaceComponent,
-    ReplaceResult, ResolveComponent, ResolveComponentResult, SimilarityCheck, SpawnEngine,
-    SpawnEngineResult, Status, StatusResult, Submit, SubmitResult, TerminateEngine,
-    TerminateEngineResult, UploadBinary, UploadBinaryResult, UploadComponent,
-    UploadComponentResult,
+    ListKindsResult, LoadComponent, LoadResult, NamedMail, ReplaceComponent, ReplaceResult,
+    ResolveComponent, ResolveComponentResult, SimilarityCheck, SpawnEngine, SpawnEngineResult,
+    Status, StatusResult, Submit, SubmitResult, TerminateEngine, TerminateEngineResult,
+    UploadBinary, UploadBinaryResult, UploadComponent, UploadComponentResult,
     trace::{
         DescribeTreeResult, DispatchTraced, DispatchTracedAck, MailNodeWire, TRACE_MAILBOX_NAME,
         TraceTail, TraceTailResult,
@@ -574,7 +573,7 @@ impl Mcp {
         let engine = parse_engine_id(&args.engine_id)?;
         // Encode the batch before sending — a bad spec produces a
         // clean invalid-params error and never touches the wire.
-        // Same shape `CaptureFrame` carries: `Vec<MailEnvelope>` with
+        // Same shape `CaptureFrame` carries: `Vec<NamedMail>` with
         // name-level addressing the substrate resolves at dispatch
         // time via `resolve_bundle`. ADR-0091: descriptors come from
         // the per-engine merged view so a component's own kinds
@@ -2340,7 +2339,7 @@ async fn build_descriptor(arg: DagDescriptorArg) -> anyhow::Result<DagDescriptor
 }
 
 impl Mcp {
-    /// Encode a `send_mail_traced` batch into the same `MailEnvelope`
+    /// Encode a `send_mail_traced` batch into the same `NamedMail`
     /// shape `CaptureFrame` carries: name-level addressing + schema-
     /// encoded payload. The substrate's `TraceObserver` resolves the
     /// names through its registry at dispatch time. Same lookup path
@@ -2350,7 +2349,7 @@ impl Mcp {
         &self,
         engine: EngineId,
         specs: &[TracedMailSpec],
-    ) -> anyhow::Result<Vec<KindMailEnvelope>> {
+    ) -> anyhow::Result<Vec<NamedMail>> {
         let mut out = Vec::with_capacity(specs.len());
         for spec in specs {
             let desc = self.lookup_descriptor(engine, &spec.kind_name).await?;
@@ -2362,7 +2361,7 @@ impl Mcp {
                 })?;
             let payload = aether_codec::encode_schema(&params, &desc.schema)
                 .map_err(|e| anyhow::anyhow!("param encode failed for {}: {e}", spec.kind_name))?;
-            out.push(KindMailEnvelope {
+            out.push(NamedMail {
                 recipient_name: spec.recipient_name.clone(),
                 kind_name: spec.kind_name.clone(),
                 payload,
@@ -2441,13 +2440,13 @@ impl Mcp {
     /// Encode a `capture_frame` mail bundle: resolve each spec's kind
     /// against the per-engine merged view (ADR-0091, static prefill +
     /// cached `ListKinds` reply), schema-encode its params, and wrap
-    /// into the substrate-side `aether_kinds::MailEnvelope` shape
+    /// into the substrate-side `aether_kinds::NamedMail` shape
     /// (name-level addressing + pre-encoded payload).
     async fn encode_capture_bundle(
         &self,
         engine: EngineId,
         specs: &[CaptureMailSpec],
-    ) -> anyhow::Result<Vec<aether_kinds::MailEnvelope>> {
+    ) -> anyhow::Result<Vec<NamedMail>> {
         let mut out = Vec::with_capacity(specs.len());
         for spec in specs {
             let desc = self.lookup_descriptor(engine, &spec.kind_name).await?;
@@ -2459,7 +2458,7 @@ impl Mcp {
                 })?;
             let payload = aether_codec::encode_schema(&params, &desc.schema)
                 .map_err(|e| anyhow::anyhow!("param encode failed for {}: {e}", spec.kind_name))?;
-            out.push(aether_kinds::MailEnvelope {
+            out.push(NamedMail {
                 recipient_name: spec.recipient_name.clone(),
                 kind_name: spec.kind_name.clone(),
                 payload,

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -871,8 +871,8 @@ impl TestBench {
     /// the wire shape of the MCP `capture_frame` tool.
     pub(crate) fn capture_with_mails(
         &mut self,
-        pre: Vec<aether_kinds::MailEnvelope>,
-        after: Vec<aether_kinds::MailEnvelope>,
+        pre: Vec<aether_kinds::NamedMail>,
+        after: Vec<aether_kinds::NamedMail>,
     ) -> Result<Vec<u8>, TestBenchError> {
         let cid = self.fresh_correlation_id();
         // Issue 603 Phase 2: capture_frame moved to the render

--- a/crates/aether-substrate-bundle/src/test_bench/execute.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/execute.rs
@@ -24,7 +24,7 @@ use std::error;
 use std::fmt;
 
 use aether_data::{Kind, KindId};
-use aether_kinds::MailEnvelope;
+use aether_kinds::NamedMail;
 
 use super::bench::{TestBench, TestBenchError};
 
@@ -74,8 +74,8 @@ pub enum BenchOp {
     /// pre-mail's geometry must land in the same frame as the
     /// readback.
     CaptureWithMails {
-        pre: Vec<MailEnvelope>,
-        after: Vec<MailEnvelope>,
+        pre: Vec<NamedMail>,
+        after: Vec<NamedMail>,
     },
 }
 
@@ -95,7 +95,7 @@ impl BenchOp {
     /// Capture with pre/after mail bundles dispatched atomically
     /// around the readback. See [`BenchOp::CaptureWithMails`].
     #[must_use]
-    pub fn capture_with_mails(pre: Vec<MailEnvelope>, after: Vec<MailEnvelope>) -> Self {
+    pub fn capture_with_mails(pre: Vec<NamedMail>, after: Vec<NamedMail>) -> Self {
         Self::CaptureWithMails { pre, after }
     }
 

--- a/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
@@ -50,7 +50,7 @@ use aether_capabilities::trace::TraceDispatchCapability;
 use aether_capabilities::{EngineConfig, EngineServer};
 use aether_codec::frame::{FrameError, read_frame, write_frame};
 use aether_data::{DagId, EngineId, Kind, KindId, MailId, MailboxId, Uuid, mailbox_id_from_path};
-use aether_kinds::MailEnvelope as TracedEnvelope;
+use aether_kinds::NamedMail;
 use aether_kinds::descriptors;
 use aether_kinds::trace::{DispatchTraced, DispatchTracedAck, TRACE_MAILBOX_NAME};
 use aether_kinds::{
@@ -1041,7 +1041,7 @@ impl FleetBench {
         K: Kind + Serialize,
     {
         let batch = DispatchTraced {
-            mails: vec![TracedEnvelope {
+            mails: vec![NamedMail {
                 recipient_name: recipient.to_owned(),
                 kind_name: K::NAME.to_owned(),
                 payload: mail.encode_into_bytes(),

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -38,7 +38,7 @@ use aether_kinds::{
     CreateTextureResult, Delete, DeleteResult, DrawSolidQuads, DrawText, DrawTexturedQuads,
     DropComponent, DropResult, FontMetricsRequest, FontMetricsResult, FontRef, FrameCheck,
     FrameCheckResult, FrameReduction, FsError, List, ListComponents, ListComponentsResult,
-    ListResult, LoadComponent, LoadFont, LoadFontResult, LoadResult, MailEnvelope, Ping, QuadScale,
+    ListResult, LoadComponent, LoadFont, LoadFontResult, LoadResult, NamedMail, Ping, QuadScale,
     QuadSpace, Read, ReadResult, ReplaceComponent, ReplaceResult, SolidQuad, TexturedQuad, UiBar,
     UiPanel, Write, WriteResult,
 };
@@ -82,11 +82,11 @@ fn probe_address() -> String {
 }
 const TICK_OBSERVED: &str = "aether.test_fixture.tick_observed";
 
-/// Build a `MailEnvelope` for a `CaptureFrame` mail bundle. Uses
+/// Build a `NamedMail` for a `CaptureFrame` mail bundle. Uses
 /// the kind's wire encoding (`encode_into_bytes`) so any K — cast
 /// or structured — packs correctly.
-fn envelope<K: Kind>(recipient: &str, mail: &K) -> MailEnvelope {
-    MailEnvelope {
+fn envelope<K: Kind>(recipient: &str, mail: &K) -> NamedMail {
+    NamedMail {
         recipient_name: recipient.to_owned(),
         kind_name: K::NAME.to_owned(),
         payload: mail.encode_into_bytes(),
@@ -523,7 +523,7 @@ fn capture_frame_round_trip_runs_pre_and_after_mails() {
                 visible: 1,
             },
         ),
-        MailEnvelope {
+        NamedMail {
             recipient_name: probe_address(),
             kind_name: "aether.lifecycle.tick".to_owned(),
             payload: Vec::new(),

--- a/crates/aether-substrate/src/mail/helpers.rs
+++ b/crates/aether-substrate/src/mail/helpers.rs
@@ -6,7 +6,7 @@
 //! decode helper lives in `chassis/helpers.rs`.
 
 use aether_data::KindDescriptor;
-use aether_kinds::MailEnvelope;
+use aether_kinds::NamedMail;
 
 use crate::mail::Mail;
 use crate::mail::registry::Registry;
@@ -17,7 +17,7 @@ use crate::mail::registry::Registry;
 /// caller surfaces it as a `*Result::Err`.
 pub fn resolve_bundle(
     registry: &Registry,
-    bundle: &[MailEnvelope],
+    bundle: &[NamedMail],
     label: &str,
 ) -> Result<Vec<Mail>, String> {
     let mut out = Vec::with_capacity(bundle.len());

--- a/crates/aether-test-fixtures/kinds/src/lib.rs
+++ b/crates/aether-test-fixtures/kinds/src/lib.rs
@@ -53,7 +53,7 @@ pub struct KeyObserved {
 /// Driver kind: scenarios send this to flip a probe fixture's render
 /// state. `visible == 0` halts the per-tick draw; any other value
 /// enables it. Cast-shape so encoding is just a memcpy of four
-/// bytes — keeps the test-side `MailEnvelope.payload` construction
+/// bytes — keeps the test-side `NamedMail.payload` construction
 /// trivial.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Pod, Zeroable, aether_data::Kind, aether_data::Schema)]


### PR DESCRIPTION
Closes #2100.

## Summary

Two unrelated types shared the name `MailEnvelope` across the actor/rpc seam — a keyword-scan trap. This renames the `aether-kinds` *kind* type to `NamedMail`, leaving `MailEnvelope` to mean the rpc *wire* envelope (`aether-rpc`, `aether-mcp/src/rpc.rs`) exclusively. Pure name-only refactor; the struct's fields and `Schema`-derived encoding are untouched.

The two types are distinguishable by import path at every reference, so only `aether_kinds::MailEnvelope` sites rename; every wire-envelope reference (`crate::rpc::MailEnvelope`, `aether_rpc::rpc::MailEnvelope`) stays. Two prior clash-dodge aliases (`KindMailEnvelope` in `tools.rs`, `TracedEnvelope` in `rpc/server.rs` and fleetbench) collapse to plain `NamedMail`.

## Test plan

`git grep NamedMail` covers the kind type and its consumers; `git grep MailEnvelope` is now wire-type-only (plus ADR-0102/0109 prose, intentionally untouched). `scripts/preflight.sh` green (fmt + clippy `-D warnings` + doc + nextest + wasm32 component cross-build).

## Generated by

`/implement` — agent execution of [scoped issue #2100](https://github.com/iamacoffeepot/aether/issues/2100).
