### PR TITLE
refactor(aether-data): stop re-exporting actor-framework macros through the data layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 name = "aether-actor"
 version = "0.3.0-alpha"
 dependencies = [
+ "aether-actor-derive",
  "aether-capabilities",
  "aether-data",
  "aether-kinds",

--- a/crates/aether-actor/Cargo.toml
+++ b/crates/aether-actor/Cargo.toml
@@ -17,6 +17,11 @@ license.workspace = true
 # the wasm FFI into the linker.
 [dependencies]
 aether-data = { path = "../aether-data", features = ["derive"] }
+# The actor-SDK attribute macros (`actor`, `bridge`, `capability`, `fallback`,
+# `handler`, `local`) are sourced directly here now that `aether-data` no
+# longer re-exports them (ADR-0077 / issue 552 consolidated them into this
+# crate for compile cost; aether-data forwards only the data-layer derives).
+aether-actor-derive = { path = "../aether-actor-derive" }
 # ADR-0030 Phase 2: `InitCtx::subscribe_input` self-addresses
 # `aether.input.subscribe` for every `K::IS_INPUT` handler kind.
 # The wasm-shim helpers in `wasm::{io, net, log}` (folded in by issue

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -124,19 +124,19 @@ pub mod __macro_internals {
     pub use tracing;
 }
 
-/// ADR-0033 attribute macros and `Kind` / `Schema` derives, behind
-/// the prior `aether-component`'s re-export of `aether-data`'s
-/// `derive` feature. Issue 552 stage 0 routed the macro home to
-/// `aether-actor-derive`; we forward through `aether-data` so the
-/// derive paths the macro emits (`::aether_data::Kind`, etc.)
-/// continue to resolve through the established re-export chain. The
-/// stage-0 addition `#[capability]` (cfg-gates native cap fields) sits
-/// alongside the existing actor derives so component / capability
-/// authors only need `aether-actor` in their dep list.
-pub use aether_data::{
-    Kind, KindId as DataKindId, MailboxId, Schema, actor, bridge, capability, fallback, handler,
-    local,
-};
+/// ADR-0033 attribute macros and `Kind` / `Schema` derives. Issue 552
+/// stage 0 consolidated the proc-macros into `aether-actor-derive`.
+/// `Kind` / `Schema` / `KindId` / `MailboxId` forward through
+/// `aether-data` so the derive paths the macro emits
+/// (`::aether_data::Kind`, etc.) continue to resolve through the
+/// established re-export chain. The actor-SDK attribute macros
+/// (`actor`, `bridge`, `capability`, `fallback`, `handler`, `local`)
+/// are sourced directly from `aether-actor-derive` — `aether-data` is
+/// the foundational data-layer crate and no longer exports actor-SDK
+/// surface. Component and capability authors need only `aether-actor`
+/// in their dep list; the full macro surface is available from here.
+pub use aether_actor_derive::{actor, bridge, capability, fallback, handler, local};
+pub use aether_data::{Kind, KindId as DataKindId, MailboxId, Schema};
 // ADR-0119: the `#[derive(Singleton)]` / `#[derive(Instanced)]` /
 // `#[derive(Embeddable)]` proc-macros are retired. Cardinality is the
 // `Addressable::Resolver`, and the `Singleton` / `Instanced` marker traits

--- a/crates/aether-data/src/lib.rs
+++ b/crates/aether-data/src/lib.rs
@@ -80,17 +80,16 @@ pub use wire_id::{EngineId, SessionToken, Uuid};
 
 /// Re-exported derive macros from `aether-actor-derive`. Behind the
 /// `derive` feature so `cargo build` on a guest that hand-writes
-/// `impl Kind` doesn't pay the proc-macro compile cost. The
-/// `#[actor]` / `#[handler]` / `#[fallback]` attribute macros
-/// (ADR-0033) ride in the same crate because adding a second proc-
-/// macro crate would double consumer compile cost for no separation
-/// gain — both derives and attributes expand into the same runtime
-/// surface. Issue 552 stage 0 consolidated the prior
-/// `aether-data-derive` + `aether-component`-internal-only macro
-/// split into a single `aether-actor-derive` proc-macro crate so the
-/// SDK and the derive share a home.
+/// `impl Kind` doesn't pay the proc-macro compile cost. Issue 552
+/// stage 0 consolidated the prior `aether-data-derive` +
+/// `aether-component`-internal-only macro split into a single
+/// `aether-actor-derive` proc-macro crate so the data-layer derives
+/// share a home with the actor-SDK attributes. Only the data-layer
+/// derives (`Kind`, `Schema`) are re-exported here; the actor-SDK
+/// attribute macros (`actor`, `bridge`, `capability`, `fallback`,
+/// `handler`, `local`) are exported from `aether-actor` directly.
 #[cfg(feature = "derive")]
-pub use aether_actor_derive::{Kind, Schema, actor, bridge, capability, fallback, handler, local};
+pub use aether_actor_derive::{Kind, Schema};
 
 /// Re-exported `#[transform]` attribute macro from `aether-data-derive`
 /// (ADR-0048 §1). A transform is a pure `Kind -> Kind` data-layer

--- a/crates/aether-substrate/tests/native_actor_macro.rs
+++ b/crates/aether-substrate/tests/native_actor_macro.rs
@@ -86,7 +86,7 @@ struct ProbeConfig {
     ping_total: Arc<AtomicU32>,
 }
 
-#[aether_data::actor]
+#[aether_actor::actor]
 impl NativeActor for MacroProbeCap {
     type Config = ProbeConfig;
     const NAMESPACE: &'static str = "test.macro_native_actor.probe";
@@ -99,13 +99,13 @@ impl NativeActor for MacroProbeCap {
     }
 
     /// Handles structured-shape `Greet` mail.
-    #[aether_data::handler]
+    #[aether_actor::handler]
     fn on_greet(&self, _ctx: &mut NativeCtx<'_>, mail: Greet) {
         self.greet_total.fetch_add(mail.tag, AtomicOrdering::SeqCst);
     }
 
     /// Handles cast-shape `Ping` mail.
-    #[aether_data::handler]
+    #[aether_actor::handler]
     fn on_ping(&self, _ctx: &mut NativeCtx<'_>, mail: Ping) {
         self.ping_total.fetch_add(mail.seq, AtomicOrdering::SeqCst);
     }
@@ -640,7 +640,7 @@ struct TaskRouteCap {
     obs: TaskObservations,
 }
 
-#[aether_data::actor]
+#[aether_actor::actor]
 impl NativeActor for TaskRouteCap {
     type Config = TaskObservations;
     const NAMESPACE: &'static str = "test.macro_native_actor.task_route";
@@ -651,7 +651,7 @@ impl NativeActor for TaskRouteCap {
 
     /// Dispatch a worker that produces a `ResultA`. The completion routes
     /// to `on_result_a` by output type.
-    #[aether_data::handler]
+    #[aether_actor::handler]
     fn on_kick_a(&self, ctx: &mut NativeCtx<'_>, mail: KickA) {
         self.obs.dispatched.fetch_add(1, AtomicOrdering::SeqCst);
         let seed = mail.seed;
@@ -663,7 +663,7 @@ impl NativeActor for TaskRouteCap {
     }
 
     /// Dispatch a worker that produces a `ResultB`.
-    #[aether_data::handler]
+    #[aether_actor::handler]
     fn on_kick_b(&self, ctx: &mut NativeCtx<'_>, mail: KickB) {
         self.obs.dispatched.fetch_add(1, AtomicOrdering::SeqCst);
         let seed = mail.seed;
@@ -672,7 +672,7 @@ impl NativeActor for TaskRouteCap {
 
     /// `ResultA` completion handler. Records the value + a call so the
     /// test can confirm only the `ResultA` dispatch reached it.
-    #[aether_data::handler(task)]
+    #[aether_actor::handler(task)]
     fn on_result_a(&self, ctx: &mut NativeCtx<'_>, done: TaskDone<ResultA>) {
         self.obs
             .a_value
@@ -685,7 +685,7 @@ impl NativeActor for TaskRouteCap {
     }
 
     /// `ResultB` completion handler.
-    #[aether_data::handler(task)]
+    #[aether_actor::handler(task)]
     fn on_result_b(&self, ctx: &mut NativeCtx<'_>, done: TaskDone<ResultB>) {
         self.obs
             .b_tag
@@ -721,7 +721,7 @@ struct Pong {
 /// submits a link-time `HandlerEntry` declaring `Greet -> Pong`.
 struct ReplyMacroCap;
 
-#[aether_data::actor]
+#[aether_actor::actor]
 impl NativeActor for ReplyMacroCap {
     type Config = ();
     const NAMESPACE: &'static str = "test.macro_native_actor.reply";
@@ -735,7 +735,7 @@ impl NativeActor for ReplyMacroCap {
     /// `HandlerEntry` (not handler behaviour) is what this cap exists to
     /// exercise.
     #[allow(clippy::unused_self)]
-    #[aether_data::handler]
+    #[aether_actor::handler]
     fn on_greet_reply(&self, _ctx: &mut NativeCtx<'_>, mail: Greet) -> Pong {
         Pong { echoed: mail.tag }
     }
@@ -914,7 +914,7 @@ struct DeferredReplyCap {
     obs: DeferredObs,
 }
 
-#[aether_data::actor]
+#[aether_actor::actor]
 impl NativeActor for DeferredReplyCap {
     type Config = DeferredObs;
     const NAMESPACE: &'static str = "test.macro_native_actor.deferred";
@@ -927,7 +927,7 @@ impl NativeActor for DeferredReplyCap {
     /// kind on the request signature and arms an `EchoReply` worker; the
     /// macro sends nothing now.
     #[allow(clippy::unused_self)]
-    #[aether_data::handler]
+    #[aether_actor::handler]
     fn on_kick_p(&self, ctx: &mut NativeCtx<'_>, mail: KickP) -> Pending<EchoReply> {
         let seed = mail.seed;
         ctx.dispatch_blocking(move || EchoReply { value: seed })
@@ -935,7 +935,7 @@ impl NativeActor for DeferredReplyCap {
 
     /// Borrow-form completion: returns the reply; the macro calls
     /// `resolve_value` with it and releases the hold.
-    #[aether_data::handler(task)]
+    #[aether_actor::handler(task)]
     fn on_echo_done(&self, _ctx: &mut NativeCtx<'_>, done: &TaskDone<EchoReply>) -> EchoReply {
         self.obs.echo_calls.fetch_add(1, AtomicOrdering::SeqCst);
         EchoReply {
@@ -946,7 +946,7 @@ impl NativeActor for DeferredReplyCap {
     /// No-reply path: returns `()`, so it dispatches via
     /// `dispatch_blocking_with` (no `Pending<R>` contract to declare).
     #[allow(clippy::unused_self)]
-    #[aether_data::handler]
+    #[aether_actor::handler]
     fn on_kick_s(&self, ctx: &mut NativeCtx<'_>, mail: KickS) {
         let seed = mail.seed;
         ctx.dispatch_blocking_with((), move || Silent { value: seed });
@@ -954,7 +954,7 @@ impl NativeActor for DeferredReplyCap {
 
     /// Borrow-form no-reply completion: returns `()`, so the macro calls
     /// `release_no_reply` — the hold releases with no reply sent.
-    #[aether_data::handler(task)]
+    #[aether_actor::handler(task)]
     fn on_silent_done(&self, _ctx: &mut NativeCtx<'_>, done: &TaskDone<Silent>) {
         self.obs
             .silent_value
@@ -1004,7 +1004,7 @@ struct ManualAck {
 /// `-> R` return value.
 struct ManualReplyCap;
 
-#[aether_data::actor]
+#[aether_actor::actor]
 impl NativeActor for ManualReplyCap {
     const NAMESPACE: &'static str = "test.macro_native_actor.manual_reply";
     type Config = ();
@@ -1013,7 +1013,7 @@ impl NativeActor for ManualReplyCap {
         Ok(Self)
     }
 
-    #[aether_data::handler::manual]
+    #[aether_actor::handler::manual]
     #[allow(clippy::unused_self)]
     fn on_ping(&mut self, ctx: &mut NativeCtx<'_, Manual>, ping: ManualPing) {
         ctx.reply(&ManualAck { seq: ping.seq });


### PR DESCRIPTION
Closes #2099.

## Summary

`aether-data` — the `no_std` foundation that describes typed bytes — re-exported six actor-SDK attribute macros (`actor`, `bridge`, `capability`, `fallback`, `handler`, `local`) alongside the legitimate data-layer derives `Kind` / `Schema`, making `#[aether_data::actor]` a valid spelling and inverting the layering. This trims the `aether-data` re-export to `{Kind, Schema}` only.

The macros live in `aether-actor-derive` for compile-cost consolidation (ADR-0077 / issue 552), but their home is the actor SDK. `aether-actor` previously forwarded them through `aether-data`; it now takes a direct `aether-actor-derive` dependency and re-sources the attribute macros from there, so `aether_actor::{actor, handler, …}` is preserved with no public-surface change. Call sites spelling `#[aether_data::actor]` / `#[aether_data::handler]` (in a substrate native-actor-macro test) move to the `aether_actor::` equivalents.

## Test plan

`git grep aether_data::actor` (and the sibling macro spellings) returns only a historical doc-comment in `aether-actor-derive`, no live usage. `scripts/preflight.sh` green (fmt + clippy `-D warnings` + doc + nextest + wasm32 component cross-build), exercising the preserved `aether_actor::*` macro surface across the component crates.

## Generated by

`/implement` — agent execution of [scoped issue #2099](https://github.com/iamacoffeepot/aether/issues/2099).
