### PR TITLE
feat(ci): local per-step attestation producer

### DIFF
--- a/scripts/attest.sh
+++ b/scripts/attest.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Local attestation producer: runs the CI-equivalent checks under `witness`,
+# emitting one signed in-toto attestation per step, bound to the current commit.
+#
+# The verifier (a GitHub Action, separate change) resolves each attestation's
+# signing key against the PR author's `github.com/<author>.keys` and confirms
+# the author is a write-collaborator, so the cheap signed proof can stand in for
+# re-running the expensive checks on the runner.
+#
+# Signing reuses the author's existing SSH key. `witness`'s file signer reads
+# PEM; the OpenSSH key is repacked to PKCS8 with `sshpk-conv` (the published
+# `sshpk` tool) into tmpfs, used to sign, and shredded — the same public key is
+# already on the author's GitHub account, so nothing new is registered.
+#
+# PII: the witness environment attestor (username / hostname / env vars) is
+# dropped (`-a git`); each step's stdout/stderr is redirected to a local log so
+# the command-run attestor records no `$HOME` paths; materials/products are
+# repo-relative. Build output is kept out of the walked tree via an external
+# CARGO_TARGET_DIR, so materials stay source-only.
+#
+# Prerequisites on PATH:
+#   witness     — go install github.com/in-toto/witness@latest
+#   sshpk-conv  — npm i -g sshpk
+#
+# Usage:
+#   scripts/attest.sh                 # attest the current (clean) HEAD locally
+#   scripts/attest.sh --publish       # also push the proofs to the side ref
+#   AETHER_ATTEST_KEY=~/.ssh/id_x scripts/attest.sh
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+# shellcheck disable=SC2153
+SIGN_KEY="${AETHER_ATTEST_KEY:-$HOME/.ssh/id_ed25519}"
+
+publish=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --publish) publish=1; shift ;;
+        -h|--help) sed -n '2,28p' "$0" | sed 's/^# \?//'; exit 0 ;;
+        *) echo "attest: unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+die() { echo "[attest] $*" >&2; exit 1; }
+
+command -v witness    >/dev/null 2>&1 || die "witness not on PATH (go install github.com/in-toto/witness@latest)"
+command -v sshpk-conv >/dev/null 2>&1 || die "sshpk-conv not on PATH (npm i -g sshpk)"
+[[ -f "$SIGN_KEY" ]] || die "signing key not found: $SIGN_KEY"
+
+# The attestation must reflect a committed tree: the git attestor records the
+# commit, and a dirty worktree would let materials diverge from it.
+[[ -z "$(git status --porcelain)" ]] || die "worktree is dirty; commit or stash before attesting"
+HEAD_SHA="$(git rev-parse HEAD)"
+
+# Keep build artifacts out of the witnessed working tree so the material
+# attestor walks source only (fast, no target/ pollution). Persisted across
+# runs so the producer stays incrementally warm.
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$HOME/.cache/aether-attest-target}"
+mkdir -p "$CARGO_TARGET_DIR"
+
+# Ephemeral PKCS8 signing key in a private temp dir; shredded on exit.
+KEYDIR="$(mktemp -d)"
+LOGDIR="$(mktemp -d)"
+cleanup() {
+    [[ -f "$KEYDIR/key.pem" ]] && { command -v shred >/dev/null 2>&1 && shred -u "$KEYDIR/key.pem" 2>/dev/null || rm -f "$KEYDIR/key.pem"; }
+    rm -rf "$KEYDIR" "$LOGDIR"
+}
+trap cleanup EXIT
+( umask 077; sshpk-conv -p -t pkcs8 -f "$SIGN_KEY" > "$KEYDIR/key.pem" 2>/dev/null ) \
+    || die "key conversion failed (encrypted key? only unencrypted ed25519 supported)"
+
+OUTDIR="$(git rev-parse --git-dir)/aether-attestations/$HEAD_SHA"
+rm -rf "$OUTDIR"; mkdir -p "$OUTDIR"
+
+# Canonical check set. MUST mirror scripts/preflight.sh and .github/workflows/
+# ci.yml — the attestation is only meaningful if it runs the same gates CI does.
+# (Unifying these onto one shared definition is a follow-up.)
+attest_step() {
+    local name="$1"; shift
+    echo "[attest] -> $name"
+    # The log path rides in the environment, never as a command argument: the
+    # command-run attestor records the `cmd` array verbatim, so an arg would
+    # publish the (machine-identifying) tmp path. The environment attestor is
+    # off (`-a git`), so the env value is recorded nowhere. The inner shell
+    # redirects the step's stdout/stderr to that log, keeping cargo's `$HOME`
+    # paths out of the attestation while the real command stays visible in `cmd`.
+    if ! ATTEST_STEP_LOG="$LOGDIR/$name.log" witness run \
+            --step "$name" \
+            -a git \
+            --signer-file-key-path "$KEYDIR/key.pem" \
+            -o "$OUTDIR/$name.json" \
+            -- bash -c 'exec >"$ATTEST_STEP_LOG" 2>&1; exec "$@"' attest "$@"; then
+        echo "[attest] step '$name' FAILED:" >&2
+        tail -40 "$LOGDIR/$name.log" >&2 || true
+        die "attestation aborted at step '$name'"
+    fi
+}
+
+attest_step fmt    cargo fmt --all -- --check
+attest_step clippy cargo clippy --workspace --all-targets -- -D warnings
+attest_step doc    env RUSTDOCFLAGS="-D rustdoc::redundant_explicit_links -D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links" cargo doc --workspace --no-deps
+attest_step dist   cargo xtask dist --no-bins
+attest_step test   env AETHER_REQUIRE_RUNTIME=1 cargo nextest run --workspace --all-features --profile ci
+attest_step qodana qodana scan --diff-start "$(git merge-base HEAD origin/main)" -u root
+
+echo "[attest] OK — $(ls "$OUTDIR"/*.json | wc -l | tr -d ' ') signed attestations for $HEAD_SHA"
+echo "[attest] $OUTDIR"
+
+# Publish onto a side ref keyed by the commit sha — refs/attestations/<sha>.
+# The attestations become git objects pushed under their own ref namespace; the
+# working tree, index, and every branch are untouched (a private index builds
+# the tree, never $GIT_INDEX_FILE's default). The verifier fetches this ref by
+# the PR's head sha. Re-publishing the same sha is idempotent (force is safe on
+# a content-keyed ref).
+if (( publish )); then
+    ref="refs/attestations/$HEAD_SHA"
+    index="$(mktemp)"
+    GIT_INDEX_FILE="$index" git read-tree --empty
+    for f in "$OUTDIR"/*.json; do
+        blob="$(git hash-object -w "$f")"
+        GIT_INDEX_FILE="$index" git update-index --add --cacheinfo "100644,$blob,$(basename "$f")"
+    done
+    tree="$(GIT_INDEX_FILE="$index" git write-tree)"
+    rm -f "$index"
+    commit="$(git commit-tree "$tree" -m "attestations for $HEAD_SHA")"
+    git push --force origin "$commit:$ref"
+    echo "[attest] published $ref"
+fi


### PR DESCRIPTION
First PR of the local-attestation arc — produce a cheap, signed proof of the expensive checks locally so the verifier (a follow-up) can gate PRs without the runner re-running them. This change is the **producer** only; it is inert until the verifier and branch-protection wiring land.

## What it does

`scripts/attest.sh` runs the CI-equivalent checks (fmt, clippy, doc, dist, nextest, qodana) under `witness`, emitting one signed in-toto attestation per step to `.git/aether-attestations/<sha>/` (staging inside `.git`, never committed). With `--publish` it pushes them to a `refs/attestations/<sha>` side ref — a private index builds the tree, so the working tree, branches, and history are untouched.

## Key reuse, no new key

`witness`'s file signer reads PEM and rejects the OpenSSH container, so the author's existing ed25519 key is repacked to PKCS8 with `sshpk-conv` (the published `sshpk` tool — no hand-rolled parser) into tmpfs, used to sign, then shredded. The conversion is a format-only repack of the same seed, so the public key already on the author's GitHub account verifies it; nothing new is generated or registered.

## No PII in the attestations

- Environment attestor dropped (`-a git`) — no username, hostname, or env vars.
- Each step's stdout/stderr is redirected to a local log, and the log path rides in the environment rather than as a command argument, so the command-run attestor records no `$HOME` paths while the real command stays visible.
- An external `CARGO_TARGET_DIR` keeps build output out of the walked tree, so materials stay source-only.

Verified: a signed `fmt` attestation scans clean for username / hostname / `/Users` / tmp-path / key-name leaks.

## Prerequisites (dev box)

- `witness` — `go install github.com/in-toto/witness@latest`
- `sshpk-conv` — `npm i -g sshpk`

## Not in scope (follow-ups)

- The verifier Action: resolve each attestation's signing key against the PR author's `github.com/<author>.keys`, confirm the author is a write-collaborator, gate the PR.
- Branch-protection wiring + demoting real CI to a main canary.
- Unifying the step list with `scripts/preflight.sh` onto one shared definition (touches a sign-off-gated guardrail).

Closes #2114