### PR TITLE
feat(ci): verify PR attestations against the author's GitHub keys

### DIFF
--- a/.github/workflows/attest-verify.yml
+++ b/.github/workflows/attest-verify.yml
@@ -1,0 +1,42 @@
+name: Attestation verify
+
+# Runs on pull_request_target so the gate logic always comes from the trusted
+# base branch, never the PR head. The job only reads the attestation side ref
+# and the author's public keys — it never checks out or runs PR-head code, so
+# the usual pull_request_target risk (executing untrusted code with a write
+# token) does not apply here.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: attest-verify-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out base (trusted verifier logic)
+        uses: actions/checkout@v4
+
+      - name: Install witness
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/in-toto/witness/v0.11.0/install-witness.sh \
+            | bash -s -- -b /usr/local/bin -v v0.11.0
+          witness version
+
+      - name: Install sshpk-conv
+        run: npm install -g sshpk@1.18.0
+
+      - name: Verify attestations
+        env:
+          REPO: ${{ github.repository }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/attest-verify.sh

--- a/scripts/attest-verify.sh
+++ b/scripts/attest-verify.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Attestation verifier: confirm a PR's checks were attested by the PR author,
+# who must be a write-collaborator. Run by .github/workflows/attest-verify.yml
+# on `pull_request_target`, so this logic always comes from the trusted base
+# branch — never the PR head — and it only reads the attestation ref + the
+# author's public keys (it never checks out or runs PR code).
+#
+# Trust model: a collaborator vouches for their own checks by signing the
+# attestations with a key already on their GitHub account. The verifier proves
+# the signer is that collaborator; it does not re-run the checks. The main
+# canary (real CI on push) is the backstop.
+#
+# Required inputs (environment):
+#   REPO       — owner/name
+#   PR_AUTHOR  — the PR author's GitHub login
+#   HEAD_SHA   — the PR head commit sha
+#   GH_TOKEN   — token for `gh api` (read-only is enough)
+#
+# Prerequisites on PATH: witness, sshpk-conv, gh, openssl, python3, curl.
+
+set -euo pipefail
+
+: "${REPO:?}"; : "${PR_AUTHOR:?}"; : "${HEAD_SHA:?}"
+
+# Canonical checks. The expected-command fragment binds each attestation to the
+# real check, so an attestation that ran `true` under the name "clippy" is
+# rejected. Keep in lockstep with scripts/attest.sh / .github/workflows/ci.yml.
+REQUIRED_STEPS=(fmt clippy doc dist test qodana)
+expected_cmd() {
+    case "$1" in
+        fmt)    echo "cargo fmt --all -- --check" ;;
+        clippy) echo "cargo clippy --workspace --all-targets -- -D warnings" ;;
+        doc)    echo "cargo doc --workspace --no-deps" ;;
+        dist)   echo "cargo xtask dist --no-bins" ;;
+        test)   echo "cargo nextest run --workspace --all-features --profile ci" ;;
+        qodana) echo "qodana scan" ;;
+        *)      return 1 ;;
+    esac
+}
+
+fail() { echo "::error::attest-verify: $*"; exit 1; }
+
+# 1. The author must be a write-collaborator on this repo.
+perm="$(gh api "repos/$REPO/collaborators/$PR_AUTHOR/permission" -q .permission 2>/dev/null)" \
+    || fail "cannot read collaborator permission for $PR_AUTHOR"
+case "$perm" in
+    admin|write|maintain) ;;
+    *) fail "$PR_AUTHOR is not a write-collaborator (permission=$perm)" ;;
+esac
+
+# 2. Fetch the attestation side ref the producer published for this commit.
+git fetch --quiet origin "refs/attestations/$HEAD_SHA:refs/attestations/incoming" 2>/dev/null \
+    || fail "no attestations published at refs/attestations/$HEAD_SHA"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# 3. Resolve the author's registered keys into witness functionaries. The keyid
+#    is the sha256 of the PEM public key (witness's scheme); the same key must
+#    have signed the attestations.
+keys_json=""; funcs_json=""; nkeys=0
+while read -r ktype kval _; do
+    [[ "$ktype" == ssh-* ]] || continue
+    printf '%s %s\n' "$ktype" "$kval" > "$work/k$nkeys.pub"
+    sshpk-conv -t pem -f "$work/k$nkeys.pub" > "$work/k$nkeys.pem" 2>/dev/null || continue
+    kid="$(openssl dgst -sha256 < "$work/k$nkeys.pem" | awk '{print $NF}')"
+    kb64="$(base64 < "$work/k$nkeys.pem" | tr -d '\n')"
+    keys_json+="\"$kid\":{\"keyid\":\"$kid\",\"key\":\"$kb64\"},"
+    funcs_json+="{\"type\":\"publickey\",\"publickeyid\":\"$kid\"},"
+    nkeys=$((nkeys + 1))
+done < <(curl -fsSL "https://github.com/$PR_AUTHOR.keys")
+(( nkeys > 0 )) || fail "$PR_AUTHOR has no registered SSH keys to verify against"
+keys_json="${keys_json%,}"; funcs_json="${funcs_json%,}"
+
+# 4. Verify each required step: present, signed by one of the author's keys,
+#    bound to this commit, and recording the canonical command.
+for step in "${REQUIRED_STEPS[@]}"; do
+    att="$work/$step.att.json"
+    git show "refs/attestations/incoming:$step.json" > "$att" 2>/dev/null \
+        || fail "missing attestation for required step '$step'"
+
+    cat > "$work/policy.json" <<EOF
+{ "expires":"2099-01-01T00:00:00Z",
+  "publickeys": { $keys_json },
+  "steps": { "$step": { "name":"$step", "functionaries":[ $funcs_json ],
+    "attestations":[
+      {"type":"https://witness.dev/attestations/material/v0.1","regopolicies":[]},
+      {"type":"https://witness.dev/attestations/command-run/v0.1","regopolicies":[]}]}}}
+EOF
+    # The policy is signed with an ephemeral key (integrity within this run); its
+    # trust is its content — the functionaries are the author's GitHub keys.
+    openssl genpkey -algorithm ed25519 -out "$work/eph.pem" 2>/dev/null
+    openssl pkey -in "$work/eph.pem" -pubout -out "$work/eph.pub" 2>/dev/null
+    witness sign -f "$work/policy.json" -k "$work/eph.pem" -o "$work/policy.signed.json" \
+        -t https://witness.testifysec.com/policy/v0.1 2>/dev/null
+
+    witness verify -p "$work/policy.signed.json" -k "$work/eph.pub" -a "$att" --subjects "$HEAD_SHA" \
+        >/dev/null 2>&1 \
+        || fail "step '$step' failed verification (not signed by $PR_AUTHOR, tampered, or wrong commit)"
+
+    cmd="$(python3 - "$att" <<'PY'
+import base64, json, sys
+d = json.load(open(sys.argv[1]))
+j = json.loads(base64.b64decode(d["payload"]))
+cr = next(a for a in j["predicate"]["attestations"] if "command-run" in a["type"])
+print(" ".join(cr["attestation"].get("cmd", [])))
+PY
+)"
+    [[ "$cmd" == *"$(expected_cmd "$step")"* ]] \
+        || fail "step '$step' attested the wrong command: $cmd"
+    echo "  ✓ $step — signed by $PR_AUTHOR, bound to $HEAD_SHA, command verified"
+done
+
+echo "attest-verify: all ${#REQUIRED_STEPS[@]} checks verified for $HEAD_SHA by collaborator $PR_AUTHOR"

--- a/scripts/attest.sh
+++ b/scripts/attest.sh
@@ -55,6 +55,14 @@ command -v sshpk-conv >/dev/null 2>&1 || die "sshpk-conv not on PATH (npm i -g s
 [[ -z "$(git status --porcelain)" ]] || die "worktree is dirty; commit or stash before attesting"
 HEAD_SHA="$(git rev-parse HEAD)"
 
+# The verifier binds each attestation to HEAD through witness's git attestor,
+# which can't read commit metadata in a linked worktree (the .git pointer file
+# defeats it) — it would emit attestations with no commit subject to bind. Fail
+# loudly rather than publish proofs the verifier can never accept.
+if [[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]]; then
+    die "running in a linked worktree; attest from a normal checkout (the commit binding needs the main .git)"
+fi
+
 # Keep build artifacts out of the witnessed working tree so the material
 # attestor walks source only (fast, no target/ pollution). Persisted across
 # runs so the producer stays incrementally warm.


### PR DESCRIPTION
Second PR of the local-attestation arc — turn the producer's signed proofs (#2115) into a PR gate. Inert until it is made a required check (next PR), so this lands without changing how anything merges today.

## What it does

`scripts/attest-verify.sh`, run by `.github/workflows/attest-verify.yml` on `pull_request_target`:

1. Confirms the PR author is a write-collaborator (`gh api .../collaborators/<author>/permission`).
2. Fetches the attestations from `refs/attestations/<head-sha>`.
3. Resolves the author's `github.com/<author>.keys` into witness functionaries — keyid is the sha256 of the PEM public key, witness's own scheme.
4. Verifies each required step (fmt, clippy, doc, dist, test, qodana): signed by one of the author's keys, bound to the head commit via the git attestor's commit subject, and recording the canonical command — so an attestation that renamed `true` to "clippy" is rejected.

## Why pull_request_target is safe here

The gate logic always comes from the trusted base branch, never the PR head. The job only reads the attestation ref and the author's public keys; it never checks out or runs PR-head code, so the usual `pull_request_target` risk (running untrusted code with a write token) does not apply.

## Producer guard

`scripts/attest.sh` now refuses to run in a linked worktree, where witness's git attestor can't read commit metadata and would emit attestations with no commit subject for the verifier to bind.

## Validation

Exercised end-to-end against real GitHub with a collaborator's key: all six steps signed and bound verify (pass); a non-collaborator author is rejected; a missing attestation ref is rejected; a tampered or wrong-signer attestation fails witness verification.

## Trust model

A collaborator vouches for their own checks by signing with a key already on their account. The verifier proves the signer is that collaborator; it does not re-run the checks. The main canary (next PR) is the backstop.

## Not in scope (follow-up)

Make this a required status check, demote real CI to a push-to-main canary, add nightly + a main-red ping.

Closes #2116