### PR TITLE
fix(ci): make attestation verification work end-to-end

### DIFF
--- a/.github/workflows/attest-verify.yml
+++ b/.github/workflows/attest-verify.yml
@@ -26,8 +26,13 @@ jobs:
 
       - name: Install witness
         run: |
-          curl -sSfL https://raw.githubusercontent.com/in-toto/witness/v0.11.0/install-witness.sh \
-            | bash -s -- -b /usr/local/bin -v v0.11.0
+          cd "$(mktemp -d)"
+          base=https://github.com/in-toto/witness/releases/download/v0.11.0
+          curl -sSL -O "$base/witness_0.11.0_linux_amd64.tar.gz"
+          curl -sSL -O "$base/witness_0.11.0_checksums.txt"
+          grep ' witness_0.11.0_linux_amd64.tar.gz$' witness_0.11.0_checksums.txt | sha256sum -c -
+          tar xzf witness_0.11.0_linux_amd64.tar.gz witness
+          sudo install witness /usr/local/bin/witness
           witness version
 
       - name: Install sshpk-conv

--- a/scripts/attest-verify.sh
+++ b/scripts/attest-verify.sh
@@ -49,7 +49,7 @@ case "$perm" in
 esac
 
 # 2. Fetch the attestation side ref the producer published for this commit.
-git fetch --quiet origin "refs/attestations/$HEAD_SHA:refs/attestations/incoming" 2>/dev/null \
+git fetch --quiet origin "+refs/attestations/$HEAD_SHA:refs/attestations/incoming" 2>/dev/null \
     || fail "no attestations published at refs/attestations/$HEAD_SHA"
 
 work="$(mktemp -d)"
@@ -72,6 +72,11 @@ done < <(curl -fsSL "https://github.com/$PR_AUTHOR.keys")
 (( nkeys > 0 )) || fail "$PR_AUTHOR has no registered SSH keys to verify against"
 keys_json="${keys_json%,}"; funcs_json="${funcs_json%,}"
 
+# Each attestation binds to the commit through a product subject whose digest is
+# sha256(head_sha) — the producer writes the sha into that file. Reconstruct the
+# digest to pass as the verified subject.
+subject_digest="$(printf '%s' "$HEAD_SHA" | openssl dgst -sha256 | awk '{print $NF}')"
+
 # 4. Verify each required step: present, signed by one of the author's keys,
 #    bound to this commit, and recording the canonical command.
 for step in "${REQUIRED_STEPS[@]}"; do
@@ -85,7 +90,8 @@ for step in "${REQUIRED_STEPS[@]}"; do
   "steps": { "$step": { "name":"$step", "functionaries":[ $funcs_json ],
     "attestations":[
       {"type":"https://witness.dev/attestations/material/v0.1","regopolicies":[]},
-      {"type":"https://witness.dev/attestations/command-run/v0.1","regopolicies":[]}]}}}
+      {"type":"https://witness.dev/attestations/command-run/v0.1","regopolicies":[]},
+      {"type":"https://witness.dev/attestations/product/v0.1","regopolicies":[]}]}}}
 EOF
     # The policy is signed with an ephemeral key (integrity within this run); its
     # trust is its content — the functionaries are the author's GitHub keys.
@@ -94,7 +100,7 @@ EOF
     witness sign -f "$work/policy.json" -k "$work/eph.pem" -o "$work/policy.signed.json" \
         -t https://witness.testifysec.com/policy/v0.1 2>/dev/null
 
-    witness verify -p "$work/policy.signed.json" -k "$work/eph.pub" -a "$att" --subjects "$HEAD_SHA" \
+    witness verify -p "$work/policy.signed.json" -k "$work/eph.pub" -a "$att" --subjects "$subject_digest" \
         >/dev/null 2>&1 \
         || fail "step '$step' failed verification (not signed by $PR_AUTHOR, tampered, or wrong commit)"
 

--- a/scripts/attest.sh
+++ b/scripts/attest.sh
@@ -13,10 +13,11 @@
 # already on the author's GitHub account, so nothing new is registered.
 #
 # PII: the witness environment attestor (username / hostname / env vars) is
-# dropped (`-a git`); each step's stdout/stderr is redirected to a local log so
-# the command-run attestor records no `$HOME` paths; materials/products are
-# repo-relative. Build output is kept out of the walked tree via an external
-# CARGO_TARGET_DIR, so materials stay source-only.
+# dropped (`-a ''`); each step's stdout/stderr is redirected to a local log so
+# the command-run attestor records no `$HOME` paths; materials are repo-relative
+# and the only product is the commit-binding subject. Build output is kept out
+# of the walked tree via an external CARGO_TARGET_DIR, so materials stay
+# source-only.
 #
 # Prerequisites on PATH:
 #   witness     — go install github.com/in-toto/witness@latest
@@ -50,18 +51,11 @@ command -v witness    >/dev/null 2>&1 || die "witness not on PATH (go install gi
 command -v sshpk-conv >/dev/null 2>&1 || die "sshpk-conv not on PATH (npm i -g sshpk)"
 [[ -f "$SIGN_KEY" ]] || die "signing key not found: $SIGN_KEY"
 
-# The attestation must reflect a committed tree: the git attestor records the
-# commit, and a dirty worktree would let materials diverge from it.
+# The attestation must reflect a committed tree: each step binds to HEAD via a
+# product subject derived from the commit sha (below), and a dirty worktree
+# would let the recorded materials diverge from that commit.
 [[ -z "$(git status --porcelain)" ]] || die "worktree is dirty; commit or stash before attesting"
 HEAD_SHA="$(git rev-parse HEAD)"
-
-# The verifier binds each attestation to HEAD through witness's git attestor,
-# which can't read commit metadata in a linked worktree (the .git pointer file
-# defeats it) — it would emit attestations with no commit subject to bind. Fail
-# loudly rather than publish proofs the verifier can never accept.
-if [[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]]; then
-    die "running in a linked worktree; attest from a normal checkout (the commit binding needs the main .git)"
-fi
 
 # Keep build artifacts out of the witnessed working tree so the material
 # attestor walks source only (fast, no target/ pollution). Persisted across
@@ -72,8 +66,14 @@ mkdir -p "$CARGO_TARGET_DIR"
 # Ephemeral PKCS8 signing key in a private temp dir; shredded on exit.
 KEYDIR="$(mktemp -d)"
 LOGDIR="$(mktemp -d)"
+# The commit-binding subject: a tree-local file each step's witnessed command
+# fills with the head sha, recorded by the product attestor. Its digest is
+# sha256(head_sha), which the verifier reconstructs — so binding needs no git
+# metadata and works in a linked worktree. Removed after each step and on exit.
+SUBJECT="$ROOT/.aether-attest-subject"
 cleanup() {
     [[ -f "$KEYDIR/key.pem" ]] && { command -v shred >/dev/null 2>&1 && shred -u "$KEYDIR/key.pem" 2>/dev/null || rm -f "$KEYDIR/key.pem"; }
+    rm -f "$SUBJECT"
     rm -rf "$KEYDIR" "$LOGDIR"
 }
 trap cleanup EXIT
@@ -89,22 +89,30 @@ rm -rf "$OUTDIR"; mkdir -p "$OUTDIR"
 attest_step() {
     local name="$1"; shift
     echo "[attest] -> $name"
-    # The log path rides in the environment, never as a command argument: the
-    # command-run attestor records the `cmd` array verbatim, so an arg would
-    # publish the (machine-identifying) tmp path. The environment attestor is
-    # off (`-a git`), so the env value is recorded nowhere. The inner shell
-    # redirects the step's stdout/stderr to that log, keeping cargo's `$HOME`
-    # paths out of the attestation while the real command stays visible in `cmd`.
-    if ! ATTEST_STEP_LOG="$LOGDIR/$name.log" witness run \
+    # One witnessed shell does both binding and PII-scrubbing before exec'ing the
+    # real command:
+    #   * writes the head sha to the tree-local subject file, scoped as the only
+    #     product (--attestor-product-include-glob) — a commit-bound subject that
+    #     needs no git metadata, so this works in a linked worktree.
+    #   * redirects the step's stdout/stderr to a tmpfs log. The log path rides in
+    #     the environment, never as a `cmd` arg, so the command-run attestor's
+    #     verbatim `cmd` carries no machine-identifying path while the real
+    #     command stays visible.
+    # `-a ''` drops the environment attestor (PII) and the git attestor (unused).
+    if ! ATTEST_SHA="$HEAD_SHA" ATTEST_SUBJECT="$SUBJECT" ATTEST_STEP_LOG="$LOGDIR/$name.log" \
+            witness run \
             --step "$name" \
-            -a git \
+            -a '' \
+            --attestor-product-include-glob "$(basename "$SUBJECT")" \
             --signer-file-key-path "$KEYDIR/key.pem" \
             -o "$OUTDIR/$name.json" \
-            -- bash -c 'exec >"$ATTEST_STEP_LOG" 2>&1; exec "$@"' attest "$@"; then
+            -- bash -c 'printf %s "$ATTEST_SHA" > "$ATTEST_SUBJECT"; exec >"$ATTEST_STEP_LOG" 2>&1; exec "$@"' attest "$@"; then
+        rm -f "$SUBJECT"
         echo "[attest] step '$name' FAILED:" >&2
         tail -40 "$LOGDIR/$name.log" >&2 || true
         die "attestation aborted at step '$name'"
     fi
+    rm -f "$SUBJECT"
 }
 
 attest_step fmt    cargo fmt --all -- --check


### PR DESCRIPTION
Makes the attestation system landed in #2115 / #2117 actually operational: the producer couldn't run where work happens (linked worktrees), and the verifier job couldn't install its tooling. Two coupled fixes.

## 1. Producer works in any checkout

The commit binding moved off witness's git attestor — which reads nothing in a linked worktree — onto a product subject each step's witnessed command fills with the head sha (scoped via `--attestor-product-include-glob` to just that file). Its digest is `sha256(head_sha)`, which the verifier reconstructs and passes to `witness verify --subjects`. The git and environment attestors are both dropped (`-a ''`), so attestations are uniform and PII-free everywhere, and the worktree guard is gone.

The verifier binds via the reconstructed subject digest, requires the product attestor, and force-updates the fetched ref so re-verification is idempotent.

## 2. Verifier installs witness from the release binary

`install-witness.sh` fails on the runner (`readlink: invalid option -- 'b'`), so the verify job died before installing anything. It now downloads the pinned v0.11.0 linux-amd64 tarball, checks it against the published checksums, and installs the binary.

## Validation

Run end-to-end in a real linked worktree: a single product subject equal to `sha256(head_sha)`, no git/environment attestor, zero PII. The full verifier integration test against real GitHub still passes — genuine collaborator-signed attestations verify; wrong sha, wrong signer, non-collaborator, and wrong-command (cmd-match) are all rejected. The witness download + checksum + extract is confirmed against the published release.

Closes #2118