### PR TITLE
fix(substrate-bundle): locate component wasm via CARGO_TARGET_DIR

### DIFF
--- a/scripts/attest.sh
+++ b/scripts/attest.sh
@@ -2,10 +2,11 @@
 # Local attestation producer: runs the CI-equivalent checks under `witness`,
 # emitting one signed in-toto attestation per step, bound to the current commit.
 #
-# The verifier (a GitHub Action, separate change) resolves each attestation's
-# signing key against the PR author's `github.com/<author>.keys` and confirms
-# the author is a write-collaborator, so the cheap signed proof can stand in for
-# re-running the expensive checks on the runner.
+# The verifier (scripts/attest-verify.sh, run by the attest-verify workflow)
+# resolves each attestation's signing key against the PR author's
+# `github.com/<author>.keys` and confirms the author is a write-collaborator, so
+# the cheap signed proof can stand in for re-running the expensive checks on the
+# runner.
 #
 # Signing reuses the author's existing SSH key. `witness`'s file signer reads
 # PEM; the OpenSSH key is repacked to PKCS8 with `sshpk-conv` (the published


### PR DESCRIPTION
`locate_component_wasm` (the test harness's wasm resolver) hardcoded `<workspace>/target`, ignoring the standard `CARGO_TARGET_DIR` override. Any out-of-tree build dir — including the attestation producer's external target — left the `AETHER_REQUIRE_RUNTIME` scenario tests unable to find their pre-built wasm, so they hard-failed. Honor `CARGO_TARGET_DIR`, falling back to the in-tree default.

Surfaced by dogfooding `scripts/attest.sh` (which builds into an external target to keep the witness material walk source-only): the `test` step failed with "wasm not pre-built" even though the wasm existed in the external target. Verified the fix locally — the previously-failing scenario tests pass with `CARGO_TARGET_DIR` set.

Also folds in a one-line header cleanup in attest.sh (the verifier is no longer a "separate change").