### PR TITLE
fix(ci): scan a clone so preflight qodana works in worktrees

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -188,8 +188,26 @@ if [[ -z "$qodana_base" ]]; then
     echo "[preflight] run 'git fetch origin main' and retry." >&2
     exit 1
 fi
+
+# `--diff-start` only counts *new* findings if Qodana can read git history. In a
+# linked worktree the `.git` pointer references a gitdir outside the tree that
+# Qodana's analysis container can't reach (`fatal: not a git repository`), so it
+# silently fails to diff and flags every pre-existing finding in a changed file.
+# Scan a throwaway self-contained clone of HEAD (real `.git` + full history)
+# under a Docker-shared path ($HOME, not $TMPDIR's /var/folders) so the diff
+# scoping behaves exactly as CI's full checkout does.
+qodana_dir="$ROOT"
+qodana_clone=""
+if [[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]]; then
+    mkdir -p "$HOME/.cache"
+    qodana_clone="$(mktemp -d "$HOME/.cache/aether-qodana.XXXXXX")"
+    git clone --quiet "$ROOT" "$qodana_clone/scan"
+    git -C "$qodana_clone/scan" -c advice.detachedHead=false checkout --quiet "$HEAD_AT_START"
+    qodana_dir="$qodana_clone/scan"
+fi
 run_step "qodana scan (diff-scoped to origin/main merge-base)" \
-    qodana scan --diff-start "$qodana_base" -u root
+    bash -c 'cd "$1" && qodana scan --diff-start "$2" -u root' _ "$qodana_dir" "$qodana_base"
+[[ -n "$qodana_clone" ]] && rm -rf "$qodana_clone"
 
 stamp_pass
 echo "[preflight] OK."


### PR DESCRIPTION
`scripts/preflight.sh`'s qodana step (added in #2112) silently mis-scopes in a linked worktree, failing the gate on pre-existing debt instead of the change.

## The bug

`qodana scan --diff-start <base>` only counts *new* findings when Qodana can read git history. In a worktree, `.git` is a pointer to a gitdir outside the tree, which Qodana's analysis container can't reach:

```
level=error msg="rev-parse --show-toplevel exited with code 128
  fatal: not a git repository: .../.git/worktrees/<name>"
!  Cannot run analysis for commit <base> ... Check that you retrieve the full git history
```

With no history it can't diff, so it reports every finding in each changed file. A 20-line change that touched a test helper failed the gate with 29 problems — a Critical "unsized param" and 18 duplicate-code fragments that long predate the change. CI is unaffected because it checks out a real repo with `fetch-depth: 0`.

## The fix

When in a linked worktree, scan a throwaway self-contained clone of HEAD (real `.git` plus full history). The clone lives under the home dir, because Docker Desktop does not mount the macOS temp root (`/var/folders`) that `mktemp` defaults to. Normal checkouts are unchanged. Verified: the same change that reported 29 now reports `0 new problems` and preflight passes.