### PR TITLE
fix(ci): sudo the attest-verify sshpk install for runner perms

### DIFF
--- a/.github/workflows/attest-verify.yml
+++ b/.github/workflows/attest-verify.yml
@@ -36,7 +36,12 @@ jobs:
           witness version
 
       - name: Install sshpk-conv
-        run: npm install -g sshpk@1.18.0
+        # `sudo` so npm can write its global man-page symlinks under
+        # /usr/local/share/man — the default runner user can't, which fails the
+        # plain `-g` install (EACCES) on the Node 24 runner image. Mirrors the
+        # `sudo install` used for witness above. `ssh-keygen` can't substitute:
+        # its PKCS8 export rejects ed25519, the key type this gate signs with.
+        run: sudo npm install -g sshpk@1.18.0
 
       - name: Verify attestations
         env:


### PR DESCRIPTION
The `verify` job's `npm install -g sshpk` started failing with EACCES on the Node 24 runner image: the default runner user can't write npm's global man-page symlinks under /usr/local/share/man.

Run the install under sudo, mirroring the witness install step right above it. ssh-keygen can't replace sshpk here — its PKCS8 export rejects ed25519, the key type this gate signs with.

This must land on main to take effect, since the verify workflow always runs the base-branch copy. Note: even fixed, `verify` stays red on a normal PR until the producer publishes attestations for that head — that is by design, not a failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)