### PR TITLE
fix(substrate-bundle): locate component wasm via CARGO_TARGET_DIR

### DIFF
--- a/crates/aether-substrate-bundle/src/test_bench/test_helpers.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/test_helpers.rs
@@ -94,16 +94,19 @@ pub fn has_wgpu_adapter() -> bool {
 /// integration-test binaries (`crates/<crate>/tests/...`), so the
 /// workspace root is always two levels up.
 #[must_use]
+// Test-only: CARGO_TARGET_DIR is the standard cargo build-output override, not
+// cap config — honor it so wasm built into an out-of-tree target dir (e.g. the
+// attestation producer's) is found.
+#[allow(clippy::disallowed_methods)]
 pub fn locate_component_wasm(crate_name: &str) -> Option<PathBuf> {
     let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .and_then(|p| p.parent())
         .expect("workspace root reachable from CARGO_MANIFEST_DIR");
+    let target_root =
+        env::var_os("CARGO_TARGET_DIR").map_or_else(|| workspace.join("target"), PathBuf::from);
     for profile in ["release", "debug"] {
-        let base = workspace
-            .join("target")
-            .join("wasm32-unknown-unknown")
-            .join(profile);
+        let base = target_root.join("wasm32-unknown-unknown").join(profile);
         // Top-level cdylib crates land directly under the profile dir.
         let top_level = base.join(format!("{crate_name}.wasm"));
         if top_level.exists() {


### PR DESCRIPTION
`locate_component_wasm` hardcoded `<workspace>/target`, so an out-of-tree build directory set through `CARGO_TARGET_DIR` (for example the attestation producer's external target) left the `AETHER_REQUIRE_RUNTIME` scenario tests unable to find their pre-built wasm — the strict-mode gate then panicked.

Honor the standard `CARGO_TARGET_DIR` override, falling back to the in-tree default when it is unset.

Surfaced while dogfooding the local attestation producer, which builds under an external target dir to keep the witnessed material walk source-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)