### PR TITLE
feat(ci): make the attested path an opt-in per PR via the attestation ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       qodana: ${{ steps.filter.outputs.qodana }}
+      attested: ${{ steps.attest.outputs.attested }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -37,6 +38,27 @@ jobs:
               - 'rust-toolchain.toml'
               - '.github/workflows/**'
               - 'qodana.yaml'
+      # A collaborator opts into the attested path by publishing
+      # refs/attestations/<head-sha> before opening the PR. Only someone with
+      # push access can create that ref, so its presence is an authenticated
+      # opt-in; when present, the heavy jobs below skip and the `verify` check
+      # (a separate workflow) validates the attestation and gates the merge
+      # instead. With no ref the author did not opt in, so the heavy jobs run
+      # and gate as usual. Push events have no PR head, so the canary on `main`
+      # always runs the heavy jobs.
+      - name: Detect attestation opt-in
+        id: attest
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ -n "${HEAD_SHA:-}" ]] \
+             && git ls-remote --exit-code origin "refs/attestations/$HEAD_SHA" >/dev/null 2>&1; then
+            echo "attested=true" >> "$GITHUB_OUTPUT"
+            echo "attestation ref present for $HEAD_SHA; heavy jobs skip, verify gates"
+          else
+            echo "attested=false" >> "$GITHUB_OUTPUT"
+            echo "no attestation opt-in; heavy jobs run"
+          fi
 
   fmt:
     name: Format
@@ -65,7 +87,7 @@ jobs:
   clippy:
     name: Clippy
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.attested != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -81,7 +103,7 @@ jobs:
   docs:
     name: Docs
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.attested != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -112,7 +134,7 @@ jobs:
   test:
     name: Test (workspace, linux)
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.attested != 'true'
     runs-on: ubuntu-latest
     # A warm-cache run is ~13 min (cargo xtask dist + the lightweight
     # build/run + the heavy serial pass), so the old 15-min cap left
@@ -220,7 +242,7 @@ jobs:
   qodana:
     name: Qodana scan
     needs: changes
-    if: needs.changes.outputs.qodana == 'true'
+    if: needs.changes.outputs.qodana == 'true' && needs.changes.outputs.attested != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/scripts/attest-verify.sh
+++ b/scripts/attest-verify.sh
@@ -40,12 +40,11 @@ expected_cmd() {
 
 fail() { echo "::error::attest-verify: $*"; exit 1; }
 
-# 1. Classify the author. Only a write-collaborator can produce a verifiable
-#    attestation — they sign with a key GitHub binds to their identity — so they
-#    are the only author class this gate holds to the attested path. A
-#    non-collaborator (typically a fork PR) has no such key relationship, so the
-#    gate passes through and the real CI jobs gate their PR instead. The fork is
-#    on membership, not on whether an attestation happens to be present.
+# 1. The author must be a write-collaborator. Only someone with push access can
+#    publish the attestation ref this gate reads, so a present ref is already an
+#    authenticated opt-in by a collaborator; this check is the matching guard on
+#    the PR author. A non-collaborator (typically a fork PR) cannot opt in, so
+#    the gate passes through and the real CI jobs gate their PR instead.
 perm="$(gh api "repos/$REPO/collaborators/$PR_AUTHOR/permission" -q .permission 2>/dev/null)" \
     || fail "cannot read collaborator permission for $PR_AUTHOR"
 case "$perm" in
@@ -53,9 +52,13 @@ case "$perm" in
     *) echo "attest-verify: $PR_AUTHOR is not a write-collaborator (permission=$perm); deferring to real CI."; exit 0 ;;
 esac
 
-# 2. Fetch the attestation side ref the producer published for this commit.
+# 2. Attestation is opt-in. The author opts into the attested path by publishing
+#    refs/attestations/<sha>; with no such ref they did not opt in, so the gate
+#    passes through and real CI gates the PR. That ref's presence is also what
+#    makes the heavy CI jobs skip (see ci.yml's `changes` job), so validating it
+#    here is the matching gate for the path the author chose.
 git fetch --quiet origin "+refs/attestations/$HEAD_SHA:refs/attestations/incoming" 2>/dev/null \
-    || fail "no attestations published at refs/attestations/$HEAD_SHA"
+    || { echo "attest-verify: no attestation published for $HEAD_SHA; author did not opt into the attested path, deferring to real CI."; exit 0; }
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT


### PR DESCRIPTION
Step 3 of the collaborator-fork gate (no branch-protection change in this PR).

Makes the attested fast-path **opt-in per PR**, signalled by the attestation ref itself. A collaborator who wants to skip the heavy runner jobs publishes `refs/attestations/<head-sha>` (runs the producer) before opening the PR. Only someone with push access can create that ref, so its presence is an authenticated opt-in — no separate collaborator API check is needed to decide the fork, and it intrinsically can't be triggered by a fork.

- **Ref present** → collaborator opted in → heavy jobs (clippy/docs/test/qodana) skip; `verify` validates the attestation and gates.
- **No ref** → not opted in (the default, including collaborators who didn't attest) → heavy jobs run and gate as today; `verify` passes through.
- **Push to main** → no PR head → heavy jobs always run (canary).

Changes:
- `ci.yml`: the `changes` job detects the ref via `git ls-remote` and exposes an `attested` output; the four heavy jobs gate on `attested != 'true'`.
- `attest-verify.sh`: an absent ref now passes through instead of failing.

Fails safe: if a ref is present but the attestation is invalid (tampered, wrong signer, wrong commit), the heavy jobs skip but `verify` fails → blocked. A fork can't publish the ref at all.

### Staging / ordering
This is built but should merge **after** `verify` is added to required checks, so there's no window where an opted-in PR skips heavy CI while `verify` is non-required. It's also itself a code-producing PR (touches `.github/workflows`), so once `verify` is required it'll want an attestation to merge — a natural dogfood.

Draft, held for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)