### PR TITLE
feat(ci): bind attestations to the actual code via witness's git attestor

### DIFF
--- a/scripts/attest-verify.sh
+++ b/scripts/attest-verify.sh
@@ -80,13 +80,10 @@ done < <(curl -fsSL "https://github.com/$PR_AUTHOR.keys")
 (( nkeys > 0 )) || fail "$PR_AUTHOR has no registered SSH keys to verify against"
 keys_json="${keys_json%,}"; funcs_json="${funcs_json%,}"
 
-# Each attestation binds to the commit through a product subject whose digest is
-# sha256(head_sha) — the producer writes the sha into that file. Reconstruct the
-# digest to pass as the verified subject.
-subject_digest="$(printf '%s' "$HEAD_SHA" | openssl dgst -sha256 | awk '{print $NF}')"
-
 # 4. Verify each required step: present, signed by one of the author's keys,
-#    bound to this commit, and recording the canonical command.
+#    proven by witness's git attestor to have run on a clean checkout of this
+#    exact commit, and recording the canonical command. The commit sha is the git
+#    attestor's `commithash` subject, so it is passed directly to `--subjects`.
 for step in "${REQUIRED_STEPS[@]}"; do
     att="$work/$step.att.json"
     git show "refs/attestations/incoming:$step.json" > "$att" 2>/dev/null \
@@ -97,9 +94,9 @@ for step in "${REQUIRED_STEPS[@]}"; do
   "publickeys": { $keys_json },
   "steps": { "$step": { "name":"$step", "functionaries":[ $funcs_json ],
     "attestations":[
+      {"type":"https://witness.dev/attestations/git/v0.1","regopolicies":[]},
       {"type":"https://witness.dev/attestations/material/v0.1","regopolicies":[]},
-      {"type":"https://witness.dev/attestations/command-run/v0.1","regopolicies":[]},
-      {"type":"https://witness.dev/attestations/product/v0.1","regopolicies":[]}]}}}
+      {"type":"https://witness.dev/attestations/command-run/v0.1","regopolicies":[]}]}}}
 EOF
     # The policy is signed with an ephemeral key (integrity within this run); its
     # trust is its content — the functionaries are the author's GitHub keys.
@@ -108,21 +105,34 @@ EOF
     witness sign -f "$work/policy.json" -k "$work/eph.pem" -o "$work/policy.signed.json" \
         -t https://witness.testifysec.com/policy/v0.1 2>/dev/null
 
-    witness verify -p "$work/policy.signed.json" -k "$work/eph.pub" -a "$att" --subjects "$subject_digest" \
+    # Signature + policy + commit binding: --subjects requires the attestation's
+    # git `commithash` subject to equal the PR head.
+    witness verify -p "$work/policy.signed.json" -k "$work/eph.pub" -a "$att" --subjects "$HEAD_SHA" \
         >/dev/null 2>&1 \
         || fail "step '$step' failed verification (not signed by $PR_AUTHOR, tampered, or wrong commit)"
 
-    cmd="$(python3 - "$att" <<'PY'
+    # Read the git attestor's commit + tree-status count and the recorded command
+    # from one parse. A non-empty status means modified or untracked files were
+    # present when the check ran, so the result does not reflect the committed
+    # code — reject it.
+    read -r v_commit v_dirty v_cmd < <(python3 - "$att" <<'PY'
 import base64, json, sys
 d = json.load(open(sys.argv[1]))
 j = json.loads(base64.b64decode(d["payload"]))
-cr = next(a for a in j["predicate"]["attestations"] if "command-run" in a["type"])
-print(" ".join(cr["attestation"].get("cmd", [])))
+atts = j["predicate"]["attestations"]
+git = next(a for a in atts if "/git/v0.1" in a["type"])["attestation"]
+cr  = next(a for a in atts if "command-run" in a["type"])["attestation"]
+status = git.get("status") or {}
+print(git.get("commithash", ""), len(status), " ".join(cr.get("cmd", [])))
 PY
-)"
-    [[ "$cmd" == *"$(expected_cmd "$step")"* ]] \
-        || fail "step '$step' attested the wrong command: $cmd"
-    echo "  ✓ $step — signed by $PR_AUTHOR, bound to $HEAD_SHA, command verified"
+)
+    [[ "$v_commit" == "$HEAD_SHA" ]] \
+        || fail "step '$step' attests commit $v_commit, not the PR head $HEAD_SHA"
+    [[ "$v_dirty" == "0" ]] \
+        || fail "step '$step' ran on a dirty tree ($v_dirty modified/untracked files); result does not reflect the committed code"
+    [[ "$v_cmd" == *"$(expected_cmd "$step")"* ]] \
+        || fail "step '$step' attested the wrong command: $v_cmd"
+    echo "  ✓ $step — signed by $PR_AUTHOR, ran on a clean checkout of $HEAD_SHA, command verified"
 done
 
 echo "attest-verify: all ${#REQUIRED_STEPS[@]} checks verified for $HEAD_SHA by collaborator $PR_AUTHOR"

--- a/scripts/attest.sh
+++ b/scripts/attest.sh
@@ -13,12 +13,18 @@
 # `sshpk` tool) into tmpfs, used to sign, and shredded — the same public key is
 # already on the author's GitHub account, so nothing new is registered.
 #
-# PII: the witness environment attestor (username / hostname / env vars) is
-# dropped (`-a ''`); each step's stdout/stderr is redirected to a local log so
-# the command-run attestor records no `$HOME` paths; materials are repo-relative
-# and the only product is the commit-binding subject. Build output is kept out
-# of the walked tree via an external CARGO_TARGET_DIR, so materials stay
-# source-only.
+# Each step runs in a fresh clone of HEAD so witness's git attestor has a real
+# repository to read: it binds the step to the commit (`commithash`) and records
+# the tree status, so the verifier can prove each check ran on a clean checkout
+# of the PR head — not just a self-declared sha. Running in a clone also gives
+# qodana the history it needs to diff-scope.
+#
+# PII: only the git attestor is added (`-a git`) — it records commit metadata
+# (author / committer / remote), already public in the PR, and no machine, env,
+# or username data; the environment attestor stays off. Each step's stdout/stderr
+# is redirected to a local log so the command-run attestor records no `$HOME`
+# paths, and an external CARGO_TARGET_DIR keeps build output out of the clone the
+# git attestor walks.
 #
 # Prerequisites on PATH:
 #   witness     — go install github.com/in-toto/witness@latest
@@ -41,7 +47,7 @@ publish=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --publish) publish=1; shift ;;
-        -h|--help) sed -n '2,28p' "$0" | sed 's/^# \?//'; exit 0 ;;
+        -h|--help) sed -n '2,36p' "$0" | sed 's/^# \?//'; exit 0 ;;
         *) echo "attest: unknown arg: $1" >&2; exit 2 ;;
     esac
 done
@@ -52,30 +58,36 @@ command -v witness    >/dev/null 2>&1 || die "witness not on PATH (go install gi
 command -v sshpk-conv >/dev/null 2>&1 || die "sshpk-conv not on PATH (npm i -g sshpk)"
 [[ -f "$SIGN_KEY" ]] || die "signing key not found: $SIGN_KEY"
 
-# The attestation must reflect a committed tree: each step binds to HEAD via a
-# product subject derived from the commit sha (below), and a dirty worktree
-# would let the recorded materials diverge from that commit.
+# The attestation must reflect a committed tree, so refuse a dirty worktree up
+# front; the git attestor and verifier enforce the clean-tree claim per step too.
 [[ -z "$(git status --porcelain)" ]] || die "worktree is dirty; commit or stash before attesting"
 HEAD_SHA="$(git rev-parse HEAD)"
+# Computed here in the real checkout (which has origin/main) for qodana's
+# diff-scope; the merge-base is an ancestor of HEAD, so it is present in the
+# clone below.
+QODANA_BASE="$(git merge-base HEAD origin/main)"
 
-# Keep build artifacts out of the witnessed working tree so the material
-# attestor walks source only (fast, no target/ pollution). Persisted across
+# Keep build artifacts out of the clone the git attestor walks, so its tree
+# status stays clean and the material walk stays source-only. Persisted across
 # runs so the producer stays incrementally warm.
 export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$HOME/.cache/aether-attest-target}"
 mkdir -p "$CARGO_TARGET_DIR"
 
+# A fresh clone of HEAD with a real `.git`, under a Docker-shared path ($HOME,
+# for qodana's container). Every step runs here: witness's git attestor reads
+# this repo to bind each step to the commit and record a clean tree, and qodana
+# gets the history it needs to diff-scope. Removed on exit.
+RUNDIR="$(mktemp -d "$HOME/.cache/aether-attest-run.XXXXXX")"
+RUN="$RUNDIR/scan"
+git clone --quiet "$ROOT" "$RUN"
+git -C "$RUN" -c advice.detachedHead=false checkout --quiet "$HEAD_SHA"
+
 # Ephemeral PKCS8 signing key in a private temp dir; shredded on exit.
 KEYDIR="$(mktemp -d)"
 LOGDIR="$(mktemp -d)"
-# The commit-binding subject: a tree-local file each step's witnessed command
-# fills with the head sha, recorded by the product attestor. Its digest is
-# sha256(head_sha), which the verifier reconstructs — so binding needs no git
-# metadata and works in a linked worktree. Removed after each step and on exit.
-SUBJECT="$ROOT/.aether-attest-subject"
 cleanup() {
     [[ -f "$KEYDIR/key.pem" ]] && { command -v shred >/dev/null 2>&1 && shred -u "$KEYDIR/key.pem" 2>/dev/null || rm -f "$KEYDIR/key.pem"; }
-    rm -f "$SUBJECT"
-    rm -rf "$KEYDIR" "$LOGDIR"
+    rm -rf "$KEYDIR" "$LOGDIR" "$RUNDIR"
 }
 trap cleanup EXIT
 ( umask 077; sshpk-conv -p -t pkcs8 -f "$SIGN_KEY" > "$KEYDIR/key.pem" 2>/dev/null ) \
@@ -90,30 +102,26 @@ rm -rf "$OUTDIR"; mkdir -p "$OUTDIR"
 attest_step() {
     local name="$1"; shift
     echo "[attest] -> $name"
-    # One witnessed shell does both binding and PII-scrubbing before exec'ing the
-    # real command:
-    #   * writes the head sha to the tree-local subject file, scoped as the only
-    #     product (--attestor-product-include-glob) — a commit-bound subject that
-    #     needs no git metadata, so this works in a linked worktree.
-    #   * redirects the step's stdout/stderr to a tmpfs log. The log path rides in
-    #     the environment, never as a `cmd` arg, so the command-run attestor's
-    #     verbatim `cmd` carries no machine-identifying path while the real
-    #     command stays visible.
-    # `-a ''` drops the environment attestor (PII) and the git attestor (unused).
-    if ! ATTEST_SHA="$HEAD_SHA" ATTEST_SUBJECT="$SUBJECT" ATTEST_STEP_LOG="$LOGDIR/$name.log" \
-            witness run \
-            --step "$name" \
-            -a '' \
-            --attestor-product-include-glob "$(basename "$SUBJECT")" \
+    # Reset the clone to a pristine HEAD checkout so the git attestor records a
+    # clean tree (build output is in the external CARGO_TARGET_DIR; this only
+    # clears stray untracked files such as qodana's .qodana/).
+    git -C "$RUN" reset -q --hard HEAD
+    git -C "$RUN" clean -qfd
+    # Run inside the clone (CWD = the real-`.git` checkout) so `-a git` binds the
+    # step to the commit and records the tree status. `-a git` adds only the git
+    # attestor — no environment attestor, so no machine/env PII. stdout/stderr go
+    # to a tmpfs log whose path rides in the environment, never a `cmd` arg, so
+    # the command-run attestor records no machine path while the command stays
+    # visible.
+    if ! ( cd "$RUN" && ATTEST_STEP_LOG="$LOGDIR/$name.log" \
+            witness run --step "$name" -a git \
             --signer-file-key-path "$KEYDIR/key.pem" \
             -o "$OUTDIR/$name.json" \
-            -- bash -c 'printf %s "$ATTEST_SHA" > "$ATTEST_SUBJECT"; exec >"$ATTEST_STEP_LOG" 2>&1; exec "$@"' attest "$@"; then
-        rm -f "$SUBJECT"
+            -- bash -c 'exec >"$ATTEST_STEP_LOG" 2>&1; exec "$@"' attest "$@" ); then
         echo "[attest] step '$name' FAILED:" >&2
         tail -40 "$LOGDIR/$name.log" >&2 || true
         die "attestation aborted at step '$name'"
     fi
-    rm -f "$SUBJECT"
 }
 
 attest_step fmt    cargo fmt --all -- --check
@@ -121,28 +129,10 @@ attest_step clippy cargo clippy --workspace --all-targets -- -D warnings
 attest_step doc    env RUSTDOCFLAGS="-D rustdoc::redundant_explicit_links -D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links" cargo doc --workspace --no-deps
 attest_step dist   cargo xtask dist --no-bins
 attest_step test   env AETHER_REQUIRE_RUNTIME=1 cargo nextest run --workspace --all-features --profile ci
-
-# Qodana only counts *new* findings when it can read git history. In a linked
-# worktree the `.git` pointer references a gitdir the analysis container can't
-# reach, so it mis-scopes and flags the whole pre-existing backlog as new. When
-# in a worktree, scan a throwaway self-contained clone of HEAD (real `.git`)
-# under a Docker-shared path ($HOME, not $TMPDIR's /var/folders); the main
-# checkout scans in place. The scan dir rides in the environment, never as a
-# `cmd` arg, so the command-run attestor records no machine-identifying path —
-# the same PII discipline as the per-step log redirect.
-qodana_base="$(git merge-base HEAD origin/main)"
-qodana_dir="$ROOT"
-qodana_clone=""
-if [[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]]; then
-    mkdir -p "$HOME/.cache"
-    qodana_clone="$(mktemp -d "$HOME/.cache/aether-qodana.XXXXXX")"
-    git clone --quiet "$ROOT" "$qodana_clone/scan"
-    git -C "$qodana_clone/scan" -c advice.detachedHead=false checkout --quiet "$HEAD_SHA"
-    qodana_dir="$qodana_clone/scan"
-fi
-export ATTEST_QODANA_DIR="$qodana_dir" ATTEST_QODANA_BASE="$qodana_base"
-attest_step qodana bash -c 'cd "$ATTEST_QODANA_DIR" && qodana scan --diff-start "$ATTEST_QODANA_BASE" -u root'
-[[ -n "$qodana_clone" ]] && rm -rf "$qodana_clone"
+# qodana runs last: its .qodana/ output is untracked (not gitignored), so a step
+# after it would see a dirty tree. The clone gives it the full history it needs
+# to diff-scope to the origin/main merge-base.
+attest_step qodana qodana scan --diff-start "$QODANA_BASE" -u root
 
 echo "[attest] OK — $(ls "$OUTDIR"/*.json | wc -l | tr -d ' ') signed attestations for $HEAD_SHA"
 echo "[attest] $OUTDIR"


### PR DESCRIPTION
Closes the gap where an attestation proved *which commit* it was about but not that the checks actually **ran on that commit's code**. Previously the binding was a sha string the producer wrote into a file — a collaborator could run the checks on a passing tree and stamp any sha.

Now each step proves it ran on a **clean checkout of the PR head**:
- The producer runs the whole check set in a fresh clone of HEAD (real `.git`) and enables witness's git attestor (`-a git`), which records the commit and the tree status inside each signed run.
- The verifier passes the commit to `witness verify --subjects` (the git attestor's `commithash` subject) and **rejects any step whose recorded git status is non-empty** — modified or untracked files present when the check ran.

Validated locally end-to-end: clean attestation verifies; wrong-commit rejected (subjects); **dirty-tree rejected** (the new status check) even though its `commithash` still matches.

Also folds away the per-step qodana clone (the whole run is now in one real-`.git` clone) and drops the `.aether-attest-subject` product mechanism. `-a git` records only commit metadata (author/committer/remote, already public in the PR) — no environment, machine, or username data, so the PII posture is unchanged.

Note: this PR's own `verify` can't exercise the new logic — `pull_request_target` runs main's pre-merge verifier, which expects the old product-subject. I'll dogfood the full new producer→verifier path locally and report before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)