### PR TITLE
refactor(ci): unify the canonical check set in scripts/checks.sh

### DIFF
--- a/scripts/attest-verify.sh
+++ b/scripts/attest-verify.sh
@@ -22,21 +22,14 @@ set -euo pipefail
 
 : "${REPO:?}"; : "${PR_AUTHOR:?}"; : "${HEAD_SHA:?}"
 
-# Canonical checks. The expected-command fragment binds each attestation to the
-# real check, so an attestation that ran `true` under the name "clippy" is
-# rejected. Keep in lockstep with scripts/attest.sh / .github/workflows/ci.yml.
-REQUIRED_STEPS=(fmt clippy doc dist test qodana)
-expected_cmd() {
-    case "$1" in
-        fmt)    echo "cargo fmt --all -- --check" ;;
-        clippy) echo "cargo clippy --workspace --all-targets -- -D warnings" ;;
-        doc)    echo "cargo doc --workspace --no-deps" ;;
-        dist)   echo "cargo xtask dist --no-bins" ;;
-        test)   echo "cargo nextest run --workspace --all-features --profile ci" ;;
-        qodana) echo "qodana scan" ;;
-        *)      return 1 ;;
-    esac
-}
+# Canonical check set: shared with the producer (scripts/attest.sh) via
+# scripts/checks.sh, so the command each attestation records and the fragment
+# this verifier matches against cannot drift. The fragment binds each attestation
+# to the real check, so one that ran `true` under the name "clippy" is rejected.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/checks.sh
+source "$SCRIPT_DIR/checks.sh"
+read -ra REQUIRED_STEPS <<< "$CANONICAL_STEPS"
 
 fail() { echo "::error::attest-verify: $*"; exit 1; }
 
@@ -130,7 +123,7 @@ PY
         || fail "step '$step' attests commit $v_commit, not the PR head $HEAD_SHA"
     [[ "$v_dirty" == "0" ]] \
         || fail "step '$step' ran on a dirty tree ($v_dirty modified/untracked files); result does not reflect the committed code"
-    [[ "$v_cmd" == *"$(expected_cmd "$step")"* ]] \
+    [[ "$v_cmd" == *"$(canonical_cmd "$step")"* ]] \
         || fail "step '$step' attested the wrong command: $v_cmd"
     echo "  ✓ $step — signed by $PR_AUTHOR, ran on a clean checkout of $HEAD_SHA, command verified"
 done

--- a/scripts/attest.sh
+++ b/scripts/attest.sh
@@ -40,6 +40,10 @@ set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
+# Canonical check set (CANONICAL_STEPS / canonical_cmd), shared with the verifier.
+# shellcheck source=scripts/checks.sh
+source "$ROOT/scripts/checks.sh"
+
 # shellcheck disable=SC2153
 SIGN_KEY="${AETHER_ATTEST_KEY:-$HOME/.ssh/id_ed25519}"
 
@@ -96,9 +100,7 @@ trap cleanup EXIT
 OUTDIR="$(git rev-parse --git-dir)/aether-attestations/$HEAD_SHA"
 rm -rf "$OUTDIR"; mkdir -p "$OUTDIR"
 
-# Canonical check set. MUST mirror scripts/preflight.sh and .github/workflows/
-# ci.yml — the attestation is only meaningful if it runs the same gates CI does.
-# (Unifying these onto one shared definition is a follow-up.)
+# attest_step runs one canonical check (scripts/checks.sh) under witness.
 attest_step() {
     local name="$1"; shift
     echo "[attest] -> $name"
@@ -124,15 +126,19 @@ attest_step() {
     fi
 }
 
-attest_step fmt    cargo fmt --all -- --check
-attest_step clippy cargo clippy --workspace --all-targets -- -D warnings
-attest_step doc    env RUSTDOCFLAGS="-D rustdoc::redundant_explicit_links -D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links" cargo doc --workspace --no-deps
-attest_step dist   cargo xtask dist --no-bins
-attest_step test   env AETHER_REQUIRE_RUNTIME=1 cargo nextest run --workspace --all-features --profile ci
+# Run each canonical step in order, adding the per-run wrappers each needs.
 # qodana runs last: its .qodana/ output is untracked (not gitignored), so a step
-# after it would see a dirty tree. The clone gives it the full history it needs
+# after it would see a dirty tree; the clone gives it the full history it needs
 # to diff-scope to the origin/main merge-base.
-attest_step qodana qodana scan --diff-start "$QODANA_BASE" -u root
+for step in $CANONICAL_STEPS; do
+    read -ra cmd <<< "$(canonical_cmd "$step")"
+    case "$step" in
+        doc)    attest_step "$step" env RUSTDOCFLAGS="-D rustdoc::redundant_explicit_links -D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links" "${cmd[@]}" ;;
+        test)   attest_step "$step" env AETHER_REQUIRE_RUNTIME=1 "${cmd[@]}" ;;
+        qodana) attest_step "$step" "${cmd[@]}" --diff-start "$QODANA_BASE" -u root ;;
+        *)      attest_step "$step" "${cmd[@]}" ;;
+    esac
+done
 
 echo "[attest] OK — $(ls "$OUTDIR"/*.json | wc -l | tr -d ' ') signed attestations for $HEAD_SHA"
 echo "[attest] $OUTDIR"

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -1,0 +1,32 @@
+# Canonical CI check set — the single definition the attestation producer
+# (scripts/attest.sh) runs and the verifier (scripts/attest-verify.sh) matches
+# against, so the command each attestation records and the fragment the verifier
+# requires cannot drift.
+#
+# Sourced, not executed. Bash 3.2 compatible (no associative arrays).
+#
+# scripts/preflight.sh and .github/workflows/ci.yml run the same checks through
+# structurally different drivers (a local runner; CI jobs and the qodana
+# action), so they cannot source this file directly — keep their commands in
+# step with the ones below. ci.yml is also the push-to-main canary, so a drift
+# there surfaces as a red canary.
+
+# Ordered canonical step names.
+CANONICAL_STEPS="fmt clippy doc dist test qodana"
+
+# The identifying command for a step. The producer runs exactly this, adding
+# per-run wrappers (RUSTDOCFLAGS for doc, AETHER_REQUIRE_RUNTIME for test,
+# qodana's --diff-start), and the verifier requires the attestation's recorded
+# command to contain it — so an attestation that ran `true` under the name
+# "clippy" is rejected.
+canonical_cmd() {
+    case "$1" in
+        fmt)    echo "cargo fmt --all -- --check" ;;
+        clippy) echo "cargo clippy --workspace --all-targets -- -D warnings" ;;
+        doc)    echo "cargo doc --workspace --no-deps" ;;
+        dist)   echo "cargo xtask dist --no-bins" ;;
+        test)   echo "cargo nextest run --workspace --all-features --profile ci" ;;
+        qodana) echo "qodana scan" ;;
+        *)      return 1 ;;
+    esac
+}


### PR DESCRIPTION
The attestation producer's per-step commands and the verifier's expected-command fragments were maintained in two places, so a change to one could silently drift from the other — accepting a wrong command or rejecting a valid one.

This moves the step list (`CANONICAL_STEPS`) and the identifying command per step (`canonical_cmd`) into a single sourced `scripts/checks.sh`, used by both:

- **`attest.sh`** iterates `CANONICAL_STEPS`, adding each step's per-run wrappers (`RUSTDOCFLAGS`, `AETHER_REQUIRE_RUNTIME`, qodana's `--diff-start`).
- **`attest-verify.sh`** reads the same step list and matches against the same fragments.

Behavior-preserving — the resolved commands are byte-identical to before (verified by re-resolving the loop) and the refactored verifier re-verifies a previously published attestation set with no change.

`preflight.sh` and `ci.yml` run the same checks through structurally different drivers (a local runner; CI jobs and the qodana action) and can't source a shell file; a comment in `checks.sh` keeps them in step, and `ci.yml` is the canary that catches any drift. Folding those in is a separate step (preflight is a sign-off-gated guardrail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)