### PR TITLE
flake(substrate-bundle): unique substrate materialization path for fixed-path engine tests

### DIFF
--- a/crates/aether-substrate-bundle/tests/engines_cap.rs
+++ b/crates/aether-substrate-bundle/tests/engines_cap.rs
@@ -190,6 +190,16 @@ mod tests {
             .map_or(0, |d| d.as_nanos());
         let store_dir =
             env::temp_dir().join(format!("aether-engcap-binstore-{}-{nanos}", process::id()));
+        let root = env::temp_dir().join(format!("aether-engcap-store-{}-{nanos}", process::id()));
+        // SAFETY: nextest runs each test in its own process, so the env
+        // mutation here doesn't race sibling tests. `AETHER_ENGINE_STORE_ROOT`
+        // must be set before `boot()` so the cap's `engine_store_root()`
+        // resolves to this unique per-run dir instead of the shared default
+        // (`~/.local/share/aether/engines`), which would collide with any
+        // sibling test, leaked orphan, or live MCP engine on id 0…01.
+        unsafe {
+            env::set_var("AETHER_ENGINE_STORE_ROOT", &root);
+        }
 
         let (_chassis, mailer, cells) = boot(bootstrap_store_config(&store_dir, headless));
 
@@ -271,6 +281,7 @@ mod tests {
         );
 
         let _ = fs::remove_dir_all(&store_dir);
+        let _ = fs::remove_dir_all(&root);
     }
 
     /// Two engines spawned via the cap coexist with persistence on: each

--- a/crates/aether-substrate-bundle/tests/rpc_engine_routing.rs
+++ b/crates/aether-substrate-bundle/tests/rpc_engine_routing.rs
@@ -156,6 +156,16 @@ mod tests {
             "aether-rpcroute-binstore-{}-{nanos}",
             process::id()
         ));
+        let root = env::temp_dir().join(format!("aether-rpcroute-store-{}-{nanos}", process::id()));
+        // SAFETY: nextest runs each test in its own process, so the env
+        // mutation here doesn't race sibling tests. `AETHER_ENGINE_STORE_ROOT`
+        // must be set before `boot_hub()` so the cap's `engine_store_root()`
+        // resolves to this unique per-run dir instead of the shared default
+        // (`~/.local/share/aether/engines`), which would collide with any
+        // sibling test, leaked orphan, or live MCP engine on id 0…01.
+        unsafe {
+            env::set_var("AETHER_ENGINE_STORE_ROOT", &root);
+        }
         // The store dir / bootstrap list ride `EngineConfig` (ADR-0090)
         // instead of the env side-channel; the heartbeat stays disabled
         // (the `Default`).
@@ -253,5 +263,6 @@ mod tests {
         assert_eq!(term_kind, <aether_kinds::TerminateEngineResult as Kind>::ID);
 
         let _ = fs::remove_dir_all(&bin_store);
+        let _ = fs::remove_dir_all(&root);
     }
 }


### PR DESCRIPTION
Closes #2135.

## Summary

The engines cap materializes a forked substrate to `engine_store_root()/<engine_id>/substrate` and execs it. `engine_store_root()` falls back to the shared `dirs::data_dir()/aether/engines` default when `AETHER_ENGINE_STORE_ROOT` is unset, and engine ids are assigned sequentially — so the first engine in every process lands at the same `…/engines/0…01/substrate`. Two integration tests forked there without setting a unique root, so a sibling test, a leaked orphan, or a live MCP engine on id `0…01` made the materialize step fail with `Text file busy` (ETXTBSY).

This sets a unique per-process `AETHER_ENGINE_STORE_ROOT` in `engines_cap_spawns_lists_and_terminates_a_real_headless_substrate` and `hub_routes_engine_addressed_calls_to_a_real_substrate` before they spawn, mirroring the passing siblings `two_engines_get_distinct_handle_store_dirs` and FleetBench, plus a cleanup of the dir at test end. Test-only — no product code changes.

## Test plan

`scripts/preflight.sh` green — fmt, clippy `--workspace --all-targets -D warnings`, `cargo doc`, `cargo xtask dist`, and `cargo nextest run --workspace --all-features --profile ci`. Both previously-flaky tests pass; materialization now targets a unique `/tmp/aether-*-store-<pid>-<nanos>` root that cannot collide.

## Generated by

`/implement` — agent execution of scoped issue #2135.
