### PR TITLE
fix(ci): preflight qodana cleanup fails on non-rootless docker hosts

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -218,7 +218,17 @@ fi
 read -ra qodana_cmd <<< "$(canonical_cmd qodana)"
 run_step "$(canonical_cmd qodana) (diff-scoped to origin/main merge-base)" \
     bash -c 'cd "$1"; shift; exec "$@"' _ "$qodana_dir" "${qodana_cmd[@]}" --diff-start "$qodana_base" -u root
-[[ -n "$qodana_clone" ]] && rm -rf "$qodana_clone"
+# Reap the clone. Qodana ran the container as root (`-u root`), so on a
+# non-rootless Docker daemon the build artifacts it wrote under the clone are
+# owned by host root and a plain `rm` as the host user fails — which under
+# `set -e` would abort before `stamp_pass`. Fall back to a throwaway root
+# container (Docker is already required for the qodana step) to delete its own
+# droppings; no host sudo. The fast path is untouched on rootless hosts and CI.
+if [[ -n "$qodana_clone" ]]; then
+    rm -rf "$qodana_clone" 2>/dev/null \
+        || docker run --rm -v "$(dirname "$qodana_clone"):/c" alpine \
+            rm -rf "/c/$(basename "$qodana_clone")"
+fi
 
 stamp_pass
 echo "[preflight] OK."


### PR DESCRIPTION
Closes #2142.

## Summary

On a non-rootless Docker host, `scripts/preflight.sh` could never write its pass-stamp. The qodana step runs `qodana scan … -u root` (matching CI so `qodana.yaml`'s bootstrap can `apt-get`/`rustup` in-container), so on a rootful daemon the cargo `target/` it builds in the mounted clone is owned by host `root`. The cleanup `rm -rf "$qodana_clone"` then runs as the non-root user, fails on those files, and `set -euo pipefail` aborts before `stamp_pass` — even though every check passed. The pre-push hook then blocked every push (the `--no-verify` workaround being the only escape).

This makes the cleanup fall back to a throwaway root container (Docker is already required for the qodana step, and it runs as root) to delete its own root-owned droppings when the plain `rm` can't. The fast `rm` path is untouched on rootless hosts and CI.

## Test plan

The container-fallback cleanup was verified by hand on a non-rootless Docker host — a root container removed real root-owned `~/.cache/aether-qodana.*` droppings with no sudo (the exact mechanism this commit inlines). `scripts/preflight.sh --force` runs the full check set; the Rust checks pass (`nextest` 2210/2210, fmt/clippy/doc/dist green). A `scripts/`-only change skips qodana in both preflight's bucket logic and CI's `changes` filter, so the `Qodana scan` gate is neutral for this PR.

## Generated by

`/implement` — agent execution of scoped issue #2142.
