### PR TITLE
chore(substrate-bundle): reap forked substrate children leaked by failing spawn tests

### DIFF
--- a/crates/aether-substrate-bundle/tests/engines_cap.rs
+++ b/crates/aether-substrate-bundle/tests/engines_cap.rs
@@ -176,6 +176,59 @@ fn drive<K: Kind, T>(
     }
 }
 
+/// RAII guard that best-effort terminates a spawned engine on drop so a
+/// panic between spawn and the explicit terminate doesn't leave the forked
+/// headless substrate child running. Disarm with [`EngineReaper::disarm`]
+/// once the engine is explicitly terminated; the guard then no-ops on drop
+/// (a double-terminate is harmless but wastes a round trip on the happy path).
+struct EngineReaper {
+    mailer: Arc<Mailer>,
+    cells: ReplyCells,
+    engine_id: Option<String>,
+}
+
+impl EngineReaper {
+    fn disarm(&mut self) {
+        self.engine_id = None;
+    }
+}
+
+impl Drop for EngineReaper {
+    fn drop(&mut self) {
+        let Some(engine_id) = self.engine_id.take() else {
+            return;
+        };
+        let server = mailbox_id_from_name(<EngineServer as Addressable>::NAMESPACE);
+        let sink = mailbox_id_from_name(<ReplySink as Addressable>::NAMESPACE);
+        self.mailer.push(
+            Mail::new(
+                server,
+                TerminateEngine::ID,
+                TerminateEngine { engine_id }.encode_into_bytes(),
+                1,
+            )
+            .with_reply_to(Source::with_correlation(SourceAddr::Component(sink), 1)),
+        );
+        let until = Instant::now() + Duration::from_secs(5);
+        loop {
+            if self
+                .cells
+                .terminate
+                .lock()
+                .ok()
+                .and_then(|mut g| g.take())
+                .is_some()
+            {
+                break;
+            }
+            if Instant::now() >= until {
+                break;
+            }
+            thread::sleep(Duration::from_millis(25));
+        }
+    }
+}
+
 mod tests {
     use super::*;
 
@@ -232,6 +285,11 @@ mod tests {
             }
             SpawnEngineResult::Err { error } => panic!("spawn failed: {error}"),
         };
+        let mut reaper = EngineReaper {
+            mailer: Arc::clone(&mailer),
+            cells: cells.clone(),
+            engine_id: Some(engine_id.clone()),
+        };
 
         // List: the freshly-spawned engine shows up in the cap's table.
         let list = drive(&mailer, &ListEngines {}, Duration::from_secs(5), || {
@@ -266,6 +324,7 @@ mod tests {
             matches!(terminate, TerminateEngineResult::Ok),
             "terminate of a live engine should succeed: {terminate:?}",
         );
+        reaper.disarm();
 
         // After terminate, the engine is gone from the table.
         let list_after = drive(&mailer, &ListEngines {}, Duration::from_secs(5), || {

--- a/crates/aether-substrate-bundle/tests/rpc_engine_routing.rs
+++ b/crates/aether-substrate-bundle/tests/rpc_engine_routing.rs
@@ -140,6 +140,84 @@ fn call_round_trip<K: Kind>(
     }
 }
 
+/// Open a fresh TCP connection to the hub at `hub_port`, perform the
+/// `Hello`/`HelloAck` handshake, and return the connected stream. Returns
+/// `None` on any error so the reaper guard can use it best-effort.
+fn connect_and_shake(hub_port: u16) -> Option<TcpStream> {
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{hub_port}")).ok()?;
+    stream.set_read_timeout(Some(Duration::from_secs(5))).ok()?;
+    write_frame(
+        &mut stream,
+        &WireFrame::Hello(Hello {
+            wire_version: WIRE_VERSION,
+            peer: PeerKind::Client {
+                client_name: "rpc-engine-routing-test".into(),
+                client_version: "0.0.1".into(),
+            },
+        }),
+    )
+    .ok()?;
+    match read_frame(&mut stream).ok()? {
+        WireFrame::HelloAck(_) => Some(stream),
+        _ => None,
+    }
+}
+
+/// RAII guard that best-effort terminates a spawned engine on drop so a
+/// panic between spawn and the explicit terminate doesn't leave the forked
+/// headless substrate child running. Opens a fresh connection on drop —
+/// the guard must not hold `&mut` the test's stream (borrow conflict).
+/// Disarm with [`SubstrateReaper::disarm`] once the engine is explicitly
+/// terminated.
+struct SubstrateReaper {
+    hub_port: u16,
+    engine_id: Option<String>,
+}
+
+impl SubstrateReaper {
+    fn disarm(&mut self) {
+        self.engine_id = None;
+    }
+}
+
+impl Drop for SubstrateReaper {
+    fn drop(&mut self) {
+        let Some(engine_id) = self.engine_id.take() else {
+            return;
+        };
+        let Some(mut stream) = connect_and_shake(self.hub_port) else {
+            return;
+        };
+        let req = TerminateEngine { engine_id };
+        if write_frame(
+            &mut stream,
+            &WireFrame::Call {
+                cid: Some(99),
+                envelope: MailEnvelope {
+                    to: MailboxAddress {
+                        engine: None,
+                        mailbox: mailbox_id_from_name("aether.engine"),
+                    },
+                    from: None,
+                    kind: TerminateEngine::ID,
+                    correlation_id: None,
+                    payload: req.encode_into_bytes(),
+                },
+            },
+        )
+        .is_err()
+        {
+            return;
+        }
+        loop {
+            match read_frame(&mut stream) {
+                Ok(WireFrame::ReplyEnd { cid: 99, result: _ }) | Err(_) => break,
+                Ok(_) => {}
+            }
+        }
+    }
+}
+
 mod tests {
     use super::*;
 
@@ -229,6 +307,10 @@ mod tests {
             None => panic!("undecodable SpawnEngineResult"),
         };
         let engine_id = EngineId(Uuid::parse_str(&engine_id).expect("engine_id parses"));
+        let mut reaper = SubstrateReaper {
+            hub_port,
+            engine_id: Some(engine_id.0.to_string()),
+        };
 
         // 2. engine = Some(_): a ROUTED call. The hub forwards it through
         //    aether.engine -> proxy -> (RPC) -> the substrate's aether.fs
@@ -261,6 +343,7 @@ mod tests {
             },
         );
         assert_eq!(term_kind, <aether_kinds::TerminateEngineResult as Kind>::ID);
+        reaper.disarm();
 
         let _ = fs::remove_dir_all(&bin_store);
         let _ = fs::remove_dir_all(&root);


### PR DESCRIPTION
Closes #2139.

## Summary

A substrate-forking integration test that panics after a successful spawn but before its explicit `TerminateEngine` orphans the forked headless child (nextest `FAIL + LEAK`). The product proxy already SIGKILLs the child on its own `Drop`, and tests unwind under `PanicAborter` — but `engines_cap_spawns_lists_and_terminates_a_real_headless_substrate` and `hub_routes_engine_addressed_calls_to_a_real_substrate` relied on implicit chassis-drop teardown, which doesn't reliably reap on the panic path. FleetBench never leaks because its own `Drop` terminates each tracked engine.

This adds a per-engine RAII reaper guard to both tests, mirroring FleetBench: on `Drop` it best-effort sends `TerminateEngine` (engines_cap via the existing mailer + reply cells; rpc_engine_routing via a fresh `TcpStream`), so a panic before the explicit terminate still reaps the fork. The guard is disarmed after the happy-path terminate so there's no redundant double-terminate. Test-only — no product change.

## Test plan

`scripts/preflight.sh` green — fmt, clippy `--workspace --all-targets -D warnings`, `cargo doc`, `cargo xtask dist`, `cargo nextest run --workspace --all-features --profile ci` (2210 passed), qodana clean, and the wasm32 component cross-build. The reaper was verified by injecting a post-spawn `panic!` and confirming zero orphaned `aether-substrate-headless` processes remained, then reverting the injected panic before commit.

## Generated by

`/implement` — agent execution of scoped issue #2139.
