### PR TITLE
fix(ci): attest.sh completes on non-rootless docker hosts

### DIFF
--- a/scripts/attest.sh
+++ b/scripts/attest.sh
@@ -110,8 +110,22 @@ git -C "$RUN" -c advice.detachedHead=false checkout --quiet "$HEAD_SHA"
 KEYDIR="$(mktemp -d)"
 LOGDIR="$(mktemp -d)"
 cleanup() {
-    [[ -f "$KEYDIR/key.pem" ]] && { command -v shred >/dev/null 2>&1 && shred -u "$KEYDIR/key.pem" 2>/dev/null || rm -f "$KEYDIR/key.pem"; }
-    rm -rf "$KEYDIR" "$LOGDIR" "$RUNDIR"
+    # Capture the triggering status first: a cleanup failure must never mask a
+    # failed run as exit 0 (a failing `rm` in the EXIT trap used to do exactly
+    # that on a non-rootless Docker host).
+    local rc=$?
+    if [[ -f "$KEYDIR/key.pem" ]]; then
+        command -v shred >/dev/null 2>&1 && shred -u "$KEYDIR/key.pem" 2>/dev/null || rm -f "$KEYDIR/key.pem"
+    fi
+    rm -rf "$KEYDIR" "$LOGDIR" 2>/dev/null || true
+    # The qodana step removes its own root-owned droppings, but on a non-rootless
+    # Docker host a stray root-owned file could remain; fall back to a throwaway
+    # root container (Docker is already required for the qodana step) so a failed
+    # plain `rm` can't abort cleanup. Mirrors scripts/preflight.sh's post-#2143 reap.
+    rm -rf "$RUNDIR" 2>/dev/null \
+        || docker run --rm -v "$(dirname "$RUNDIR"):/c" alpine rm -rf "/c/$(basename "$RUNDIR")" 2>/dev/null \
+        || true
+    exit "$rc"
 }
 trap cleanup EXIT
 ( umask 077; sshpk-conv -p -t pkcs8 -f "$SIGN_KEY" > "$KEYDIR/key.pem" 2>/dev/null ) \
@@ -139,7 +153,7 @@ attest_step() {
             witness run --step "$name" -a git \
             --signer-file-key-path "$KEYDIR/key.pem" \
             -o "$OUTDIR/$name.json" \
-            -- bash -c 'exec >"$ATTEST_STEP_LOG" 2>&1; exec "$@"' attest "$@" ); then
+            -- bash -c 'exec >"$ATTEST_STEP_LOG" 2>&1; "$@"; rc=$?; [ -n "${ATTEST_POST:-}" ] && eval "$ATTEST_POST"; exit "$rc"' attest "$@" ); then
         echo "[attest] step '$name' FAILED:" >&2
         tail -40 "$LOGDIR/$name.log" >&2 || true
         die "attestation aborted at step '$name'"
@@ -155,7 +169,21 @@ for step in $CANONICAL_STEPS; do
     case "$step" in
         doc)    attest_step "$step" env RUSTDOCFLAGS="-D rustdoc::redundant_explicit_links -D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links" "${cmd[@]}" ;;
         test)   attest_step "$step" env AETHER_REQUIRE_RUNTIME=1 "${cmd[@]}" ;;
-        qodana) attest_step "$step" "${cmd[@]}" --diff-start "$QODANA_BASE" -u root ;;
+        qodana)
+            # qodana runs `-u root` in a container that does not inherit our
+            # CARGO_TARGET_DIR, so it builds into the clone's root-owned `target/`
+            # (and writes `.qodana/`). witness's product attestor always hashes the
+            # post-command file diff — it cannot be disabled, and the exclude-glob
+            # only drops files as in-toto subjects, not from the walk — so it would
+            # die `permission denied` on those root-owned files (and the EXIT
+            # cleanup could not remove them either). Remove them via a throwaway
+            # root container as the step's last action, before the product attestor
+            # walks, so the diff records no root-owned products. Build artifacts are
+            # not products worth attesting, and the verifier reads only the
+            # material/command-run/git attestations.
+            export ATTEST_POST='docker run --rm -v "$PWD":/c alpine rm -rf /c/target /c/.qodana 2>/dev/null || true'
+            attest_step "$step" "${cmd[@]}" --diff-start "$QODANA_BASE" -u root
+            unset ATTEST_POST ;;
         *)      attest_step "$step" "${cmd[@]}" ;;
     esac
 done


### PR DESCRIPTION
Closes #2148.

## Summary

`attest.sh` couldn't complete on a non-rootless Docker host. The qodana step runs `qodana scan … -u root` (required so `qodana.yaml`'s in-container bootstrap matches CI), so on a rootful daemon the cargo `target/` qodana builds inside the per-run clone — plus `.qodana/` — is owned by host `root`. That broke the run three ways:

1. **Witness product attestor died mid-step.** It always hashes the post-command file diff (it can't be disabled, and `--attestor-product-exclude-glob` only filters in-toto *subjects*, not the walk — verified against witness v0.11.0), so it hit `permission denied` on a root-owned file and failed the qodana step.
2. **Cleanup `rm` failed** on the same root-owned files (the class #2143 fixed for `preflight.sh`, never ported here).
3. **Trap-masked exit code** — the failing cleanup `rm` ran in the EXIT trap and clobbered the status, so attest reported exit 0 on a failed run with no stamp/ref.

Fix: remove qodana's root-owned `target/`+`.qodana/` via a throwaway root container as the step's last action, *before* the product attestor walks (build artifacts aren't products worth attesting; the verifier reads only the material/command-run/git attestations). Port preflight's #2143 container-fallback to the EXIT-trap reap, and capture the triggering status in `cleanup` so a cleanup failure can no longer mask a failed run.

## Test plan

Validated end to end on a non-rootless Docker host (the box this reproduced on):

- `scripts/attest.sh --publish` against the committed HEAD completed **all six** canonical steps including qodana — `[attest] OK — 6 signed attestations`, stamped, and published `refs/attestations/<sha>`. **Zero** `permission denied`; the qodana step no longer aborts.
- `scripts/attest-verify.sh` against the published ref: `all 6 checks verified … by collaborator` (fmt/clippy/doc/dist/test/qodana each signed, clean-checkout, command-verified).
- Mechanism confirmed in isolation: witness's product attestor records create-then-deleted files as no product, and `--attestor-product-exclude-glob` does **not** suppress the hashing walk (only the subject list).

## Generated by

`/implement` — agent execution of [scoped issue #2148](https://github.com/iamacoffeepot/aether/issues/2148).
