### PR TITLE
fix(ci): attest.sh sources the main checkout .env, not the worktree's

### DIFF
--- a/scripts/attest.sh
+++ b/scripts/attest.sh
@@ -47,11 +47,15 @@ set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
-# Per-machine config: a gitignored repo-root .env, sourced like
-# scripts/ensure-tunnel.sh so per-machine settings (e.g. AETHER_ATTEST_BASE)
-# apply however the script is invoked — interactive, non-interactive, or from an
-# agent — without depending on the user's shell profile being sourced.
-[[ -f "$ROOT/.env" ]] && . "$ROOT/.env"
+# Per-machine config: a gitignored .env at the MAIN checkout root, sourced so
+# per-machine settings (e.g. AETHER_ATTEST_BASE) apply however the script is
+# invoked — interactive, non-interactive, or from an agent — without depending
+# on the user's shell profile. Resolve the main checkout from any linked worktree
+# via the common git dir: a gitignored .env is absent from a fresh worktree
+# checkout (where $ROOT points), and attest's primary caller runs it inside an
+# issue worktree, so sourcing $ROOT/.env would miss it.
+MAIN_ROOT="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
+[[ -f "$MAIN_ROOT/.env" ]] && . "$MAIN_ROOT/.env"
 
 # Canonical check set (CANONICAL_STEPS / canonical_cmd), shared with the verifier.
 # shellcheck source=scripts/checks.sh


### PR DESCRIPTION
Closes #2152.

## Summary

Follow-up to #2149. That change sourced `$ROOT/.env`, but `$ROOT` (`git rev-parse --show-toplevel`) is the *worktree* root, and a gitignored `.env` isn't present in a fresh linked worktree. attest's primary caller — the `/implement --attest` parent — runs it **inside an issue worktree**, so it never saw the `.env` and reverted to the `$HOME/.cache` default that fills `/` (which is why every attest run this session had to pass `CARGO_TARGET_DIR` by hand).

Source the `.env` from the **main checkout root**, resolved from any linked worktree via the common git dir:

```bash
MAIN_ROOT="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
[[ -f "$MAIN_ROOT/.env" ]] && . "$MAIN_ROOT/.env"
```

From the main checkout `MAIN_ROOT == $ROOT`, so that case is unchanged; from a linked worktree it resolves to the primary checkout where the gitignored `.env` lives.

## Test plan

- `bash -n scripts/attest.sh` — syntax OK.
- From a linked worktree: `MAIN_ROOT` resolves to the main checkout and the main `.env` is sourced (`AETHER_ATTEST_BASE` set) — the case #2149 missed.
- From the main checkout: `MAIN_ROOT == git rev-parse --show-toplevel`, so behavior is unchanged.

## Generated by

`/implement --quick` — agent execution of [#2152](https://github.com/iamacoffeepot/aether/issues/2152).
