### PR TITLE
refactor(capabilities): make text a submodule that owns its kinds

### DIFF
--- a/crates/aether-capabilities/Cargo.toml
+++ b/crates/aether-capabilities/Cargo.toml
@@ -74,7 +74,7 @@ text = []
 # solid-quad and text surfaces entirely by mail — gated the same two-
 # layer way so a wasm component can address it via
 # `ctx.actor::<UiCapability>()` without pulling native deps.
-ui = []
+ui = ["text"]
 
 # Native impl layers — adds the substrate-side runtime + heavy deps
 # atop the marker layer. Chassis bins activate these. Each implies its

--- a/crates/aether-capabilities/src/text/kinds.rs
+++ b/crates/aether-capabilities/src/text/kinds.rs
@@ -1,0 +1,271 @@
+//! `aether.text` mail kinds (ADR-0105, ADR-0121). The capability owns its
+//! own mail contract: the five `aether.text.*` kinds plus the `FontRef`
+//! request param live here, beside the implementation that dispatches
+//! them. Always-on and wasm-safe — they need only `aether-data` + `serde`
+//! — so a wasm component can address the cap by type without pulling
+//! `fontdue` into its graph. Their `inventory::submit!` descriptor entries
+//! ride the `Kind` derive (`cfg(not(wasm32))`-gated), so
+//! `aether_kinds::descriptors::all()` still surfaces them.
+//!
+//! Two value sub-types stay central in `aether-kinds`: `FontMetrics` and
+//! `GlyphAdvance` are consumed by `aether_kinds::text_metrics`'s wasm-safe
+//! scaling primitive, so moving them would form a crate cycle. The moved
+//! kinds reference them via `use aether_kinds::{FontMetrics, QuadSpace}` —
+//! the existing `capabilities → kinds` direction.
+
+use aether_kinds::{FontMetrics, QuadSpace};
+use serde::{Deserialize, Serialize};
+
+/// `aether.text.load_font` — fetch a TTF through `aether.fs` and
+/// register it under a session-scoped `font_id` (assigned the same
+/// way ADR-0103 assigns instrument ids). `namespace` / `path` address
+/// the file the same way `aether.fs.read` does (e.g. `"assets"` /
+/// `"fonts/RobotoMono.ttf"`). The capability forwards the read,
+/// parses the font off the hot path, and replies `LoadFontResult`.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.text.load_font")]
+pub struct LoadFont {
+    pub namespace: String,
+    pub path: String,
+}
+
+/// Reply to `LoadFont`. `Ok` carries the assigned `font_id` — thread
+/// it into `DrawText.font_id` — the derived `name` (the file stem),
+/// and `resident_bytes` (the parsed TTF's byte length). `Err` echoes
+/// the `namespace` / `path` for correlation plus a human-readable
+/// reason — a bad path, or a file fontdue could not parse as a font.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.text.load_font_result")]
+pub enum LoadFontResult {
+    Ok {
+        font_id: u32,
+        name: String,
+        resident_bytes: u64,
+    },
+    Err {
+        namespace: String,
+        path: String,
+        error: String,
+    },
+}
+
+/// `aether.text.draw` — lay out and draw `text` in the font named by
+/// `font_id` at `size_pixels`, every frame the string should appear
+/// (the same immediate-mode contract as `aether.draw_triangle`: send
+/// it each frame or it vanishes). `color` is a linear RGBA multiplier
+/// over the glyph coverage — the alpha channel scales the blend.
+/// `origin` is the screen-pixel top-left the string flows from along
+/// the baseline in `Screen` mode — `[0.0, 0.0]` is the window's
+/// top-left corner, the same as the pre-origin behavior. In `World`
+/// mode `origin` is ignored; the `anchor` positions the string there.
+/// `space` selects the projection: `Screen` flows the string from
+/// `origin` along the baseline; `World { anchor, scale }` anchors it
+/// in the scene. An unknown `font_id` warn-drops. Fire-and-forget; no
+/// reply.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.text.draw")]
+pub struct DrawText {
+    pub font_id: u32,
+    pub text: String,
+    pub size_pixels: f32,
+    pub color: [f32; 4],
+    /// Screen-pixel top-left the string flows from in `Screen` mode.
+    /// `[0.0, 0.0]` is the window's top-left corner. Ignored in
+    /// `World` mode — the `anchor` positions there.
+    pub origin: [f32; 2],
+    pub space: QuadSpace,
+}
+
+/// Names the font a `FontMetricsRequest` measures: by the
+/// session-scoped `font_id` a prior `LoadFont` (or metrics grab)
+/// assigned, or by the `aether.fs` `namespace` / `path` of its TTF —
+/// the latter loads the font on a miss the same way `LoadFont` does.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub enum FontRef {
+    /// A session-scoped `font_id` from a prior load or grab.
+    Id(u32),
+    /// A TTF addressed the same way `aether.fs.read` addresses a file
+    /// (e.g. `"assets"` / `"fonts/RobotoMono.ttf"`).
+    Path { namespace: String, path: String },
+}
+
+/// `aether.text.font_metrics` — grab a font's complete,
+/// size-independent `FontMetrics` table so a consumer measures text
+/// locally and synchronously (fit-to-content sizing, caret placement,
+/// hit-testing) without a per-measurement mail round trip. `font`
+/// references the font by id or by path; an unresident path loads on
+/// the miss, reusing the `aether.fs` fetch + parse path. The cap
+/// replies `FontMetricsResult`.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.text.font_metrics")]
+pub struct FontMetricsRequest {
+    pub font: FontRef,
+}
+
+/// Reply to `FontMetricsRequest`. `Ok` carries the resolved
+/// `FontMetrics` table; `Err` carries a human-readable reason — an
+/// unknown `font_id`, a bad path, or a file fontdue could not parse.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.text.font_metrics_result")]
+pub enum FontMetricsResult {
+    Ok { metrics: FontMetrics },
+    Err { error: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_data::Kind;
+    use aether_kinds::GlyphAdvance;
+
+    #[test]
+    fn text_kind_names_are_stable() {
+        assert_eq!(LoadFont::NAME, "aether.text.load_font");
+        assert_eq!(LoadFontResult::NAME, "aether.text.load_font_result");
+        assert_eq!(DrawText::NAME, "aether.text.draw");
+        assert_eq!(FontMetricsRequest::NAME, "aether.text.font_metrics");
+        assert_eq!(FontMetricsResult::NAME, "aether.text.font_metrics_result");
+    }
+
+    #[test]
+    fn load_font_request_roundtrip() {
+        let r = LoadFont {
+            namespace: "assets".to_string(),
+            path: "fonts/RobotoMono.ttf".to_string(),
+        };
+        let bytes = r.encode_into_bytes();
+        let back: LoadFont =
+            LoadFont::decode_from_bytes(&bytes).expect("test setup: kind codec decodes LoadFont");
+        assert_eq!(back.namespace, r.namespace);
+        assert_eq!(back.path, r.path);
+    }
+
+    #[test]
+    fn load_font_result_roundtrip_both_arms() {
+        let ok = LoadFontResult::Ok {
+            font_id: 3,
+            name: "RobotoMono".to_string(),
+            resident_bytes: 183_700,
+        };
+        let bytes = ok.encode_into_bytes();
+        let back: LoadFontResult = LoadFontResult::decode_from_bytes(&bytes)
+            .expect("test setup: kind codec decodes LoadFontResult::Ok");
+        match back {
+            LoadFontResult::Ok {
+                font_id,
+                name,
+                resident_bytes,
+            } => {
+                assert_eq!(font_id, 3);
+                assert_eq!(name, "RobotoMono");
+                assert_eq!(resident_bytes, 183_700);
+            }
+            LoadFontResult::Err { .. } => panic!("expected Ok"),
+        }
+
+        let err = LoadFontResult::Err {
+            namespace: "assets".to_string(),
+            path: "missing.ttf".to_string(),
+            error: "file read failed".to_string(),
+        };
+        let bytes = err.encode_into_bytes();
+        let back: LoadFontResult = LoadFontResult::decode_from_bytes(&bytes)
+            .expect("test setup: kind codec decodes LoadFontResult::Err");
+        match back {
+            LoadFontResult::Err {
+                namespace,
+                path,
+                error,
+            } => {
+                assert_eq!(namespace, "assets");
+                assert_eq!(path, "missing.ttf");
+                assert_eq!(error, "file read failed");
+            }
+            LoadFontResult::Ok { .. } => panic!("expected Err"),
+        }
+    }
+
+    #[test]
+    fn draw_text_screen_roundtrip() {
+        let d = DrawText {
+            font_id: 1,
+            text: "hello aether".to_string(),
+            size_pixels: 32.0,
+            color: [1.0, 0.5, 0.25, 1.0],
+            origin: [24.0, 48.0],
+            space: QuadSpace::Screen,
+        };
+        let bytes = d.encode_into_bytes();
+        let back: DrawText =
+            DrawText::decode_from_bytes(&bytes).expect("test setup: kind codec decodes DrawText");
+        assert_eq!(back.font_id, 1);
+        assert_eq!(back.text, "hello aether");
+        assert_eq!(back.size_pixels, 32.0);
+        assert_eq!(back.color, [1.0, 0.5, 0.25, 1.0]);
+        assert_eq!(back.origin, [24.0, 48.0]);
+        assert_eq!(back.space, QuadSpace::Screen);
+    }
+
+    #[test]
+    fn font_metrics_request_roundtrip_both_refs() {
+        for font in [
+            FontRef::Id(7),
+            FontRef::Path {
+                namespace: "assets".to_string(),
+                path: "fonts/RobotoMono.ttf".to_string(),
+            },
+        ] {
+            let r = FontMetricsRequest { font: font.clone() };
+            let bytes = r.encode_into_bytes();
+            let back: FontMetricsRequest = FontMetricsRequest::decode_from_bytes(&bytes)
+                .expect("test setup: kind codec decodes FontMetricsRequest");
+            assert_eq!(back.font, font);
+        }
+    }
+
+    #[test]
+    fn font_metrics_result_roundtrip_both_arms() {
+        let ok = FontMetricsResult::Ok {
+            metrics: FontMetrics {
+                units_per_em: 1000.0,
+                ascent: 800.0,
+                descent: -200.0,
+                line_gap: 0.0,
+                default_advance: 600.0,
+                advances: vec![
+                    GlyphAdvance {
+                        codepoint: u32::from('A'),
+                        advance_units: 600.0,
+                    },
+                    GlyphAdvance {
+                        codepoint: u32::from('i'),
+                        advance_units: 600.0,
+                    },
+                ],
+            },
+        };
+        let bytes = ok.encode_into_bytes();
+        let back: FontMetricsResult = FontMetricsResult::decode_from_bytes(&bytes)
+            .expect("test setup: kind codec decodes FontMetricsResult::Ok");
+        match back {
+            FontMetricsResult::Ok { metrics } => {
+                assert_eq!(metrics.units_per_em, 1000.0);
+                assert_eq!(metrics.descent, -200.0);
+                assert_eq!(metrics.advances.len(), 2);
+                assert_eq!(metrics.advances[0].codepoint, u32::from('A'));
+            }
+            FontMetricsResult::Err { .. } => panic!("expected Ok"),
+        }
+
+        let err = FontMetricsResult::Err {
+            error: "unknown font_id".to_string(),
+        };
+        let bytes = err.encode_into_bytes();
+        let back: FontMetricsResult = FontMetricsResult::decode_from_bytes(&bytes)
+            .expect("test setup: kind codec decodes FontMetricsResult::Err");
+        match back {
+            FontMetricsResult::Err { error } => assert_eq!(error, "unknown font_id"),
+            FontMetricsResult::Ok { .. } => panic!("expected Err"),
+        }
+    }
+}

--- a/crates/aether-capabilities/src/text/layout.rs
+++ b/crates/aether-capabilities/src/text/layout.rs
@@ -1,0 +1,121 @@
+//! Pure glyph-rasterization + immediate-mode layout helpers for the
+//! `aether.text` cap (ADR-0105). Native-only — they run fontdue's
+//! horizontal metrics and shape the textured-quad batch the cap emits to
+//! `aether.render` — so they ride the same `text-native` gate as the
+//! actor in `super` (the `#[bridge] mod native` block).
+
+use std::path::Path;
+
+use aether_kinds::{DrawTexturedQuads, FontMetrics, GlyphAdvance, QuadSpace, TexturedQuad};
+use aether_substrate::actor::native::NativeCtx;
+
+use crate::render::RenderCapability;
+
+use super::atlas::AtlasEntry;
+
+/// Emit the accumulated quad batch to `aether.render`.
+pub(super) fn emit_draw(
+    ctx: &mut NativeCtx<'_>,
+    texture_id: u32,
+    space: QuadSpace,
+    quads: Vec<TexturedQuad>,
+) {
+    let draw = DrawTexturedQuads {
+        texture_id,
+        space,
+        quads,
+    };
+    ctx.actor::<RenderCapability>().send(&draw);
+}
+
+/// A glyph bitmap's pixel dimensions. fontdue bounds these well below
+/// `u32::MAX`, so the `usize → u32` narrowing is exact.
+#[allow(clippy::cast_possible_truncation)]
+pub(super) fn glyph_dimensions(metrics: &fontdue::Metrics) -> (u32, u32) {
+    (metrics.width as u32, metrics.height as u32)
+}
+
+/// Place a glyph's quad in screen pixels. fontdue uses +y up with
+/// `ymin` the glyph's bottom above the baseline; screen space is y-down
+/// with the baseline at `baseline`, so the top row sits at
+/// `baseline - (ymin + height)` and the left edge at `pen_x + xmin`.
+/// Glyph extents are small integers, exact in `f32`.
+#[allow(clippy::cast_precision_loss)]
+pub(super) fn glyph_quad(
+    metrics: &fontdue::Metrics,
+    pen_x: f32,
+    baseline: f32,
+    entry: &AtlasEntry,
+    tint: [f32; 4],
+) -> TexturedQuad {
+    let top = baseline - (metrics.ymin as f32 + metrics.height as f32);
+    let left = pen_x + metrics.xmin as f32;
+    TexturedQuad {
+        x: left,
+        y: top,
+        width: metrics.width as f32,
+        height: metrics.height as f32,
+        u0: entry.u0,
+        v0: entry.v0,
+        u1: entry.u1,
+        v1: entry.v1,
+        tint,
+    }
+}
+
+/// Round a pixel size to its nearest integer for the glyph cache key,
+/// clamped to at least 1.
+pub(super) fn quantize_size(size_pixels: f32) -> u32 {
+    // Caller already checked `size_pixels` is finite and positive.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let rounded = size_pixels.round().max(1.0) as u32;
+    rounded
+}
+
+/// The font's display name — the file stem of its path (e.g.
+/// `fonts/RobotoMono.ttf` → `RobotoMono`), or the whole path when it
+/// has no stem.
+pub(super) fn font_name_from_path(path: &str) -> String {
+    Path::new(path)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .map_or_else(|| path.to_owned(), ToOwned::to_owned)
+}
+
+/// Walk a parsed font into its size-independent [`FontMetrics`] table
+/// — `units_per_em`, the horizontal line metrics, and every cmap
+/// glyph's advance, all in font units.
+///
+/// Evaluating fontdue at `px = units_per_em` makes its scale factor
+/// exactly `1.0`, so each `metrics(..).advance_width` is the raw
+/// font-unit advance with no rounding — the value a consumer scales
+/// back up with `aether_kinds::scale_units` to reproduce this cap's
+/// draw-path advance (`metrics(ch, size).advance_width`) bit-for-bit.
+pub(super) fn build_font_metrics(font: &fontdue::Font) -> FontMetrics {
+    let units_per_em = font.units_per_em();
+    let (ascent, descent, line_gap) = font
+        .horizontal_line_metrics(units_per_em)
+        .map_or((0.0, 0.0, 0.0), |line| {
+            (line.ascent, line.descent, line.line_gap)
+        });
+    // Glyph 0 is `.notdef` — the advance the draw path uses for a
+    // codepoint the font has no glyph for.
+    let default_advance = font.metrics_indexed(0, units_per_em).advance_width;
+    let mut advances: Vec<GlyphAdvance> = font
+        .chars()
+        .keys()
+        .map(|&ch| GlyphAdvance {
+            codepoint: u32::from(ch),
+            advance_units: font.metrics(ch, units_per_em).advance_width,
+        })
+        .collect();
+    advances.sort_unstable_by_key(|glyph| glyph.codepoint);
+    FontMetrics {
+        units_per_em,
+        ascent,
+        descent,
+        line_gap,
+        default_advance,
+        advances,
+    }
+}

--- a/crates/aether-capabilities/src/text/mod.rs
+++ b/crates/aether-capabilities/src/text/mod.rs
@@ -35,8 +35,16 @@
 
 // Handler-signature kinds must be importable at file root because
 // `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings of
-// the mod (always-on, outside the cfg gate).
-use aether_kinds::{CreateTextureResult, DrawText, FontMetricsRequest, LoadFont, ReadResult};
+// the mod (always-on, outside the cfg gate). The `aether.text` mail kinds
+// (ADR-0121) live in `kinds` and re-export here; the substrate-core kinds
+// (`CreateTextureResult` / `ReadResult`) come from `aether-kinds`.
+use aether_kinds::{CreateTextureResult, ReadResult};
+
+// ADR-0121: the cap owns its mail kinds. Always-on + wasm-safe (only
+// `aether-data` + `serde`), re-exported so callers address them as
+// `aether_capabilities::text::DrawText`.
+mod kinds;
+pub use kinds::*;
 
 // ADR-0105 shelf-packed RGBA8 glyph atlas (`text/atlas.rs`). Native-only —
 // it is pure CPU but only the native cap consumes it, so it rides the same
@@ -44,19 +52,20 @@ use aether_kinds::{CreateTextureResult, DrawText, FontMetricsRequest, LoadFont, 
 #[cfg(all(not(target_arch = "wasm32"), feature = "text-native"))]
 mod atlas;
 
+// Pure layout / rasterization helpers split out of `mod native` (ADR-0121).
+// Same `text-native` gate — they run fontdue off the hot path.
+#[cfg(all(not(target_arch = "wasm32"), feature = "text-native"))]
+mod layout;
+
 #[aether_actor::bridge(singleton, feature = "text-native")]
 mod native {
     use std::collections::HashMap;
     use std::collections::VecDeque;
-    use std::path::Path;
     use std::sync::Arc;
 
     use aether_actor::{OutboundReply, actor};
     use aether_data::Source;
-    use aether_kinds::{
-        CreateTexture, DrawTexturedQuads, FontMetrics, FontMetricsResult, FontRef, GlyphAdvance,
-        LoadFontResult, QuadSpace, Read, TexturedQuad, UpdateTexture,
-    };
+    use aether_kinds::{CreateTexture, QuadSpace, Read, TexturedQuad, UpdateTexture};
     use aether_substrate::Manual;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
     use aether_substrate::chassis::error::BootError;
@@ -65,7 +74,14 @@ mod native {
     use crate::render::RenderCapability;
 
     use super::atlas::{ATLAS_SIZE, Atlas, AtlasEntry, GlyphKey, GlyphSlot};
-    use super::{CreateTextureResult, DrawText, FontMetricsRequest, LoadFont, ReadResult};
+    use super::layout::{
+        build_font_metrics, emit_draw, font_name_from_path, glyph_dimensions, glyph_quad,
+        quantize_size,
+    };
+    use super::{
+        CreateTextureResult, DrawText, FontMetricsRequest, FontMetricsResult, FontRef, LoadFont,
+        LoadFontResult, ReadResult,
+    };
 
     /// Which reply shape a parked font request is owed once its font is
     /// resident. `load_font` and the `font_metrics` grab share the
@@ -603,113 +619,6 @@ mod native {
         }
     }
 
-    /// Emit the accumulated quad batch to `aether.render`.
-    fn emit_draw(
-        ctx: &mut NativeCtx<'_>,
-        texture_id: u32,
-        space: QuadSpace,
-        quads: Vec<TexturedQuad>,
-    ) {
-        let draw = DrawTexturedQuads {
-            texture_id,
-            space,
-            quads,
-        };
-        ctx.actor::<RenderCapability>().send(&draw);
-    }
-
-    /// A glyph bitmap's pixel dimensions. fontdue bounds these well below
-    /// `u32::MAX`, so the `usize → u32` narrowing is exact.
-    #[allow(clippy::cast_possible_truncation)]
-    fn glyph_dimensions(metrics: &fontdue::Metrics) -> (u32, u32) {
-        (metrics.width as u32, metrics.height as u32)
-    }
-
-    /// Place a glyph's quad in screen pixels. fontdue uses +y up with
-    /// `ymin` the glyph's bottom above the baseline; screen space is y-down
-    /// with the baseline at `baseline`, so the top row sits at
-    /// `baseline - (ymin + height)` and the left edge at `pen_x + xmin`.
-    /// Glyph extents are small integers, exact in `f32`.
-    #[allow(clippy::cast_precision_loss)]
-    fn glyph_quad(
-        metrics: &fontdue::Metrics,
-        pen_x: f32,
-        baseline: f32,
-        entry: &AtlasEntry,
-        tint: [f32; 4],
-    ) -> TexturedQuad {
-        let top = baseline - (metrics.ymin as f32 + metrics.height as f32);
-        let left = pen_x + metrics.xmin as f32;
-        TexturedQuad {
-            x: left,
-            y: top,
-            width: metrics.width as f32,
-            height: metrics.height as f32,
-            u0: entry.u0,
-            v0: entry.v0,
-            u1: entry.u1,
-            v1: entry.v1,
-            tint,
-        }
-    }
-
-    /// Round a pixel size to its nearest integer for the glyph cache key,
-    /// clamped to at least 1.
-    fn quantize_size(size_pixels: f32) -> u32 {
-        // Caller already checked `size_pixels` is finite and positive.
-        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-        let rounded = size_pixels.round().max(1.0) as u32;
-        rounded
-    }
-
-    /// The font's display name — the file stem of its path (e.g.
-    /// `fonts/RobotoMono.ttf` → `RobotoMono`), or the whole path when it
-    /// has no stem.
-    fn font_name_from_path(path: &str) -> String {
-        Path::new(path)
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .map_or_else(|| path.to_owned(), ToOwned::to_owned)
-    }
-
-    /// Walk a parsed font into its size-independent [`FontMetrics`] table
-    /// — `units_per_em`, the horizontal line metrics, and every cmap
-    /// glyph's advance, all in font units.
-    ///
-    /// Evaluating fontdue at `px = units_per_em` makes its scale factor
-    /// exactly `1.0`, so each `metrics(..).advance_width` is the raw
-    /// font-unit advance with no rounding — the value a consumer scales
-    /// back up with `aether_kinds::scale_units` to reproduce this cap's
-    /// draw-path advance (`metrics(ch, size).advance_width`) bit-for-bit.
-    fn build_font_metrics(font: &fontdue::Font) -> FontMetrics {
-        let units_per_em = font.units_per_em();
-        let (ascent, descent, line_gap) = font
-            .horizontal_line_metrics(units_per_em)
-            .map_or((0.0, 0.0, 0.0), |line| {
-                (line.ascent, line.descent, line.line_gap)
-            });
-        // Glyph 0 is `.notdef` — the advance the draw path uses for a
-        // codepoint the font has no glyph for.
-        let default_advance = font.metrics_indexed(0, units_per_em).advance_width;
-        let mut advances: Vec<GlyphAdvance> = font
-            .chars()
-            .keys()
-            .map(|&ch| GlyphAdvance {
-                codepoint: u32::from(ch),
-                advance_units: font.metrics(ch, units_per_em).advance_width,
-            })
-            .collect();
-        advances.sort_unstable_by_key(|glyph| glyph.codepoint);
-        FontMetrics {
-            units_per_em,
-            ascent,
-            descent,
-            line_gap,
-            default_advance,
-            advances,
-        }
-    }
-
     #[cfg(test)]
     mod tests {
         #![allow(clippy::unwrap_used)]
@@ -721,7 +630,7 @@ mod native {
         };
         use aether_actor::Addressable;
         use aether_data::{Kind, MailId, SessionToken, SourceAddr, Uuid};
-        use aether_kinds::FsError;
+        use aether_kinds::{DrawTexturedQuads, FsError};
         use aether_substrate::actor::native::binding::NativeBinding;
         use aether_substrate::chassis::builder::Builder;
         use aether_substrate::mail::outbound::EgressEvent;
@@ -1120,7 +1029,7 @@ mod native {
         /// The raw bytes of [`test_font`], for the read-result tests that
         /// feed the parse path a real TTF.
         fn test_font_bytes() -> &'static [u8] {
-            include_bytes!("../../aether-substrate-bundle/assets/fonts/RobotoMono.ttf")
+            include_bytes!("../../../aether-substrate-bundle/assets/fonts/RobotoMono.ttf")
         }
 
         /// `build_font_metrics`'s table scales back to fontdue's draw-path

--- a/crates/aether-capabilities/src/ui.rs
+++ b/crates/aether-capabilities/src/ui.rs
@@ -29,14 +29,14 @@ mod native {
 
     use aether_actor::actor;
     use aether_data::MailboxId;
-    use aether_kinds::{DrawSolidQuads, DrawText, QuadSpace, SolidQuad, UiClicked};
+    use aether_kinds::{DrawSolidQuads, QuadSpace, SolidQuad, UiClicked};
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
 
     use crate::input::{InputCapability, InputMailboxExt};
     use crate::lifecycle::{LifecycleCapability, LifecycleMailboxExt};
     use crate::render::RenderCapability;
-    use crate::text::TextCapability;
+    use crate::text::{DrawText, TextCapability};
 
     use super::{MouseButton, MouseMove, Tick, UiBar, UiButton, UiLabel, UiPanel};
 
@@ -283,8 +283,9 @@ mod native {
         use std::sync::mpsc::Receiver;
         use std::time::Duration;
 
+        use crate::text::DrawText;
         use aether_data::{Kind, MailId, MailboxId, SessionToken, Source, SourceAddr, Uuid};
-        use aether_kinds::{DrawSolidQuads, DrawText};
+        use aether_kinds::DrawSolidQuads;
         use aether_substrate::actor::native::binding::NativeBinding;
         use aether_substrate::mail::outbound::EgressEvent;
 

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -2143,66 +2143,6 @@ mod control_plane {
     // `QuadSpace` so a screen-space HUD string and a world-anchored
     // label ride the same discriminant.
 
-    /// `aether.text.load_font` — fetch a TTF through `aether.fs` and
-    /// register it under a session-scoped `font_id` (assigned the same
-    /// way ADR-0103 assigns instrument ids). `namespace` / `path` address
-    /// the file the same way `aether.fs.read` does (e.g. `"assets"` /
-    /// `"fonts/RobotoMono.ttf"`). The capability forwards the read,
-    /// parses the font off the hot path, and replies `LoadFontResult`.
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.text.load_font")]
-    pub struct LoadFont {
-        pub namespace: String,
-        pub path: String,
-    }
-
-    /// Reply to `LoadFont`. `Ok` carries the assigned `font_id` — thread
-    /// it into `DrawText.font_id` — the derived `name` (the file stem),
-    /// and `resident_bytes` (the parsed TTF's byte length). `Err` echoes
-    /// the `namespace` / `path` for correlation plus a human-readable
-    /// reason — a bad path, or a file fontdue could not parse as a font.
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.text.load_font_result")]
-    pub enum LoadFontResult {
-        Ok {
-            font_id: u32,
-            name: String,
-            resident_bytes: u64,
-        },
-        Err {
-            namespace: String,
-            path: String,
-            error: String,
-        },
-    }
-
-    /// `aether.text.draw` — lay out and draw `text` in the font named by
-    /// `font_id` at `size_pixels`, every frame the string should appear
-    /// (the same immediate-mode contract as `aether.draw_triangle`: send
-    /// it each frame or it vanishes). `color` is a linear RGBA multiplier
-    /// over the glyph coverage — the alpha channel scales the blend.
-    /// `origin` is the screen-pixel top-left the string flows from along
-    /// the baseline in `Screen` mode — `[0.0, 0.0]` is the window's
-    /// top-left corner, the same as the pre-origin behavior. In `World`
-    /// mode `origin` is ignored; the `anchor` positions the string there.
-    /// `space` selects the projection: `Screen` flows the string from
-    /// `origin` along the baseline; `World { anchor, scale }` anchors it
-    /// in the scene. An unknown `font_id` warn-drops. Fire-and-forget; no
-    /// reply.
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.text.draw")]
-    pub struct DrawText {
-        pub font_id: u32,
-        pub text: String,
-        pub size_pixels: f32,
-        pub color: [f32; 4],
-        /// Screen-pixel top-left the string flows from in `Screen` mode.
-        /// `[0.0, 0.0]` is the window's top-left corner. Ignored in
-        /// `World` mode — the `anchor` positions there.
-        pub origin: [f32; 2],
-        pub space: QuadSpace,
-    }
-
     /// One glyph's horizontal advance, in font units (em-square
     /// subdivisions), keyed by the Unicode scalar value (`char as u32`)
     /// it maps to through the font's cmap. Scale to pixels with
@@ -2245,42 +2185,6 @@ mod control_plane {
         /// Per-codepoint horizontal advances in font units, sorted by
         /// `codepoint`, the cmap folded in.
         pub advances: Vec<GlyphAdvance>,
-    }
-
-    /// Names the font a `FontMetricsRequest` measures: by the
-    /// session-scoped `font_id` a prior `LoadFont` (or metrics grab)
-    /// assigned, or by the `aether.fs` `namespace` / `path` of its TTF —
-    /// the latter loads the font on a miss the same way `LoadFont` does.
-    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-    pub enum FontRef {
-        /// A session-scoped `font_id` from a prior load or grab.
-        Id(u32),
-        /// A TTF addressed the same way `aether.fs.read` addresses a file
-        /// (e.g. `"assets"` / `"fonts/RobotoMono.ttf"`).
-        Path { namespace: String, path: String },
-    }
-
-    /// `aether.text.font_metrics` — grab a font's complete,
-    /// size-independent `FontMetrics` table so a consumer measures text
-    /// locally and synchronously (fit-to-content sizing, caret placement,
-    /// hit-testing) without a per-measurement mail round trip. `font`
-    /// references the font by id or by path; an unresident path loads on
-    /// the miss, reusing the `aether.fs` fetch + parse path. The cap
-    /// replies `FontMetricsResult`.
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.text.font_metrics")]
-    pub struct FontMetricsRequest {
-        pub font: FontRef,
-    }
-
-    /// Reply to `FontMetricsRequest`. `Ok` carries the resolved
-    /// `FontMetrics` table; `Err` carries a human-readable reason — an
-    /// unknown `font_id`, a bad path, or a file fontdue could not parse.
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.text.font_metrics_result")]
-    pub enum FontMetricsResult {
-        Ok { metrics: FontMetrics },
-        Err { error: String },
     }
 
     // ADR-0107 `aether.ui` widget kinds. Immediate-mode: the component
@@ -4398,11 +4302,6 @@ mod tests {
         assert_eq!(UpdateTexture::NAME, "aether.render.update_texture");
         assert_eq!(DrawTexturedQuads::NAME, "aether.render.draw_textured_quads");
         assert_eq!(DrawSolidQuads::NAME, "aether.render.draw_solid_quads");
-        assert_eq!(LoadFont::NAME, "aether.text.load_font");
-        assert_eq!(LoadFontResult::NAME, "aether.text.load_font_result");
-        assert_eq!(DrawText::NAME, "aether.text.draw");
-        assert_eq!(FontMetricsRequest::NAME, "aether.text.font_metrics");
-        assert_eq!(FontMetricsResult::NAME, "aether.text.font_metrics_result");
         assert_eq!(UiPanel::NAME, "aether.ui.panel");
         assert_eq!(UiBar::NAME, "aether.ui.bar");
         assert_eq!(UiLabel::NAME, "aether.ui.label");
@@ -4842,148 +4741,6 @@ mod tests {
             assert_eq!(back.quads.len(), 1);
             assert_eq!(back.quads[0].width, 20.0);
             assert_eq!(back.quads[0].color, [1.0, 0.0, 0.5, 1.0]);
-        }
-
-        #[test]
-        fn load_font_request_roundtrip() {
-            let r = LoadFont {
-                namespace: "assets".to_string(),
-                path: "fonts/RobotoMono.ttf".to_string(),
-            };
-            let bytes = r.encode_into_bytes();
-            let back: LoadFont = LoadFont::decode_from_bytes(&bytes)
-                .expect("test setup: kind codec decodes LoadFont");
-            assert_eq!(back.namespace, r.namespace);
-            assert_eq!(back.path, r.path);
-        }
-
-        #[test]
-        fn load_font_result_roundtrip_both_arms() {
-            let ok = LoadFontResult::Ok {
-                font_id: 3,
-                name: "RobotoMono".to_string(),
-                resident_bytes: 183_700,
-            };
-            let bytes = ok.encode_into_bytes();
-            let back: LoadFontResult = LoadFontResult::decode_from_bytes(&bytes)
-                .expect("test setup: kind codec decodes LoadFontResult::Ok");
-            match back {
-                LoadFontResult::Ok {
-                    font_id,
-                    name,
-                    resident_bytes,
-                } => {
-                    assert_eq!(font_id, 3);
-                    assert_eq!(name, "RobotoMono");
-                    assert_eq!(resident_bytes, 183_700);
-                }
-                LoadFontResult::Err { .. } => panic!("expected Ok"),
-            }
-
-            let err = LoadFontResult::Err {
-                namespace: "assets".to_string(),
-                path: "missing.ttf".to_string(),
-                error: "file read failed".to_string(),
-            };
-            let bytes = err.encode_into_bytes();
-            let back: LoadFontResult = LoadFontResult::decode_from_bytes(&bytes)
-                .expect("test setup: kind codec decodes LoadFontResult::Err");
-            match back {
-                LoadFontResult::Err {
-                    namespace,
-                    path,
-                    error,
-                } => {
-                    assert_eq!(namespace, "assets");
-                    assert_eq!(path, "missing.ttf");
-                    assert_eq!(error, "file read failed");
-                }
-                LoadFontResult::Ok { .. } => panic!("expected Err"),
-            }
-        }
-
-        #[test]
-        fn draw_text_screen_roundtrip() {
-            let d = DrawText {
-                font_id: 1,
-                text: "hello aether".to_string(),
-                size_pixels: 32.0,
-                color: [1.0, 0.5, 0.25, 1.0],
-                origin: [24.0, 48.0],
-                space: QuadSpace::Screen,
-            };
-            let bytes = d.encode_into_bytes();
-            let back: DrawText = DrawText::decode_from_bytes(&bytes)
-                .expect("test setup: kind codec decodes DrawText");
-            assert_eq!(back.font_id, 1);
-            assert_eq!(back.text, "hello aether");
-            assert_eq!(back.size_pixels, 32.0);
-            assert_eq!(back.color, [1.0, 0.5, 0.25, 1.0]);
-            assert_eq!(back.origin, [24.0, 48.0]);
-            assert_eq!(back.space, QuadSpace::Screen);
-        }
-
-        #[test]
-        fn font_metrics_request_roundtrip_both_refs() {
-            for font in [
-                FontRef::Id(7),
-                FontRef::Path {
-                    namespace: "assets".to_string(),
-                    path: "fonts/RobotoMono.ttf".to_string(),
-                },
-            ] {
-                let r = FontMetricsRequest { font: font.clone() };
-                let bytes = r.encode_into_bytes();
-                let back: FontMetricsRequest = FontMetricsRequest::decode_from_bytes(&bytes)
-                    .expect("test setup: kind codec decodes FontMetricsRequest");
-                assert_eq!(back.font, font);
-            }
-        }
-
-        #[test]
-        fn font_metrics_result_roundtrip_both_arms() {
-            let ok = FontMetricsResult::Ok {
-                metrics: FontMetrics {
-                    units_per_em: 1000.0,
-                    ascent: 800.0,
-                    descent: -200.0,
-                    line_gap: 0.0,
-                    default_advance: 600.0,
-                    advances: vec![
-                        GlyphAdvance {
-                            codepoint: u32::from('A'),
-                            advance_units: 600.0,
-                        },
-                        GlyphAdvance {
-                            codepoint: u32::from('i'),
-                            advance_units: 600.0,
-                        },
-                    ],
-                },
-            };
-            let bytes = ok.encode_into_bytes();
-            let back: FontMetricsResult = FontMetricsResult::decode_from_bytes(&bytes)
-                .expect("test setup: kind codec decodes FontMetricsResult::Ok");
-            match back {
-                FontMetricsResult::Ok { metrics } => {
-                    assert_eq!(metrics.units_per_em, 1000.0);
-                    assert_eq!(metrics.descent, -200.0);
-                    assert_eq!(metrics.advances.len(), 2);
-                    assert_eq!(metrics.advances[0].codepoint, u32::from('A'));
-                }
-                FontMetricsResult::Err { .. } => panic!("expected Ok"),
-            }
-
-            let err = FontMetricsResult::Err {
-                error: "unknown font_id".to_string(),
-            };
-            let bytes = err.encode_into_bytes();
-            let back: FontMetricsResult = FontMetricsResult::decode_from_bytes(&bytes)
-                .expect("test setup: kind codec decodes FontMetricsResult::Err");
-            match back {
-                FontMetricsResult::Err { error } => assert_eq!(error, "unknown font_id"),
-                FontMetricsResult::Ok { .. } => panic!("expected Err"),
-            }
         }
     }
 

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -32,13 +32,15 @@
 
 use std::path::Path;
 
+use aether_capabilities::text::{
+    DrawText, FontMetricsRequest, FontMetricsResult, FontRef, LoadFont, LoadFontResult,
+};
 use aether_data::{Kind, MailboxId};
 use aether_kinds::{
     CachedFontMetrics, Camera, CaptureFrame, CaptureFrameResult, CreateTexture,
-    CreateTextureResult, Delete, DeleteResult, DrawSolidQuads, DrawText, DrawTexturedQuads,
-    DropComponent, DropResult, FontMetricsRequest, FontMetricsResult, FontRef, FrameCheck,
-    FrameCheckResult, FrameReduction, FsError, List, ListComponents, ListComponentsResult,
-    ListResult, LoadComponent, LoadFont, LoadFontResult, LoadResult, NamedMail, Ping, QuadScale,
+    CreateTextureResult, Delete, DeleteResult, DrawSolidQuads, DrawTexturedQuads, DropComponent,
+    DropResult, FrameCheck, FrameCheckResult, FrameReduction, FsError, List, ListComponents,
+    ListComponentsResult, ListResult, LoadComponent, LoadResult, NamedMail, Ping, QuadScale,
     QuadSpace, Read, ReadResult, ReplaceComponent, ReplaceResult, SolidQuad, TexturedQuad, UiBar,
     UiPanel, Write, WriteResult,
 };


### PR DESCRIPTION
Closes #2156.

## Summary

Part of the ADR-0121 capabilities-own-their-kinds refactor (one capability = one PR). The `aether.text` capability becomes a directory submodule that owns its mail kinds.

`text.rs` collapses into `text/{mod,layout,kinds}` (beside the existing `atlas.rs`). The five `aether.text.*` mail kinds plus `FontRef` move out of `aether-kinds` into `text/kinds.rs`, re-exported at `aether_capabilities::text::*`. `FontMetrics` / `GlyphAdvance` stay central per the cycle rule. The `ui = ["text"]` feature edge and the importers in `ui.rs` and the bundle test are repointed.

## Test plan

- The relocated NAME-stability and codec round-trip tests for the text kinds run from their new home in `text/kinds.rs`, alongside the text TestBench scenarios.
- `cargo fmt -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace` (2030 passed, 9 skipped), `cargo doc --workspace --no-deps`, and the wasm32 cross-build of every component crate all pass.

## Generated by

`/implement` — agent execution of [scoped issue #2156](https://github.com/iamacoffeepot/aether/issues/2156).
