### PR TITLE
refactor(capabilities): split render into a submodule and move its drawing kinds

### DIFF
--- a/crates/aether-actor/examples/hello.rs
+++ b/crates/aether-actor/examples/hello.rs
@@ -23,8 +23,9 @@
 
 use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
+use aether_capabilities::render::{DrawTriangle, Vertex};
 use aether_capabilities::{LifecycleCapability, RenderCapability};
-use aether_kinds::{DrawTriangle, Ping, Pong, Tick, Vertex};
+use aether_kinds::{Ping, Pong, Tick};
 
 static TRIANGLE: DrawTriangle = DrawTriangle {
     verts: [

--- a/crates/aether-capabilities/Cargo.toml
+++ b/crates/aether-capabilities/Cargo.toml
@@ -54,8 +54,11 @@ native = [
 # the feature gates the cap module so its always-on `Actor` /
 # `Singleton` / `HandlesKind` impls + wasm-stub `pub struct` are
 # reachable, without dragging the GPU / audio native deps in.
-# Empty bodies on purpose: the markers compile from pure-Rust sources
-# already pulled in unconditionally (`aether-actor`, `aether-kinds`).
+# Empty body: the render cap's cast-shaped kinds (`DrawTriangle` /
+# `Vertex` / `Camera`) derive `bytemuck::Pod` + `Zeroable`, but `bytemuck`
+# is already an unconditional dependency (the always-on `aether.input`
+# cast kinds pull it), so a marker-only guest sees the kind types with no
+# extra feature wiring.
 render = []
 # ADR-0121: the audio cap owns its kinds in `audio/kinds.rs`. Its
 # cast-shaped triggers (`NoteOn` / `NoteOff` / `SetMasterGain`) are
@@ -67,8 +70,10 @@ audio = []
 # the render texture surface entirely by mail — but gated the same two-
 # layer way so a wasm component can address it via
 # `ctx.actor::<TextCapability>()` without dragging `fontdue` into the wasm
-# graph.
-text = []
+# graph. Pulls the `render` marker because the text cap receives the
+# render-owned `CreateTextureResult` reply kind (ADR-0121) and addresses
+# the render texture/quad kinds — both now live in `crate::render`.
+text = ["render"]
 # ADR-0107 `aether.ui` cap marker. CPU-only — it composes the render
 # solid-quad and text surfaces entirely by mail — gated the same two-
 # layer way so a wasm component can address it via

--- a/crates/aether-capabilities/src/render/capture.rs
+++ b/crates/aether-capabilities/src/render/capture.rs
@@ -1,0 +1,86 @@
+//! Cross-thread capture machinery for the `aether.render` cap
+//! (iamacoffeepot/aether#1758 / #1780). The cap dispatcher thread
+//! doesn't own the wgpu `Device` — it parks a resolved request on the
+//! [`CaptureBackend`] queue for the chassis main loop to read back, and
+//! reads the optional reference PNG synchronously off the render hot
+//! path via [`resolve_reference`].
+
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+use aether_kinds::SimilarityCheck;
+use aether_substrate::capture::{CaptureQueue, ReferenceCapture};
+use aether_substrate::mail::outbound::HubOutbound;
+
+/// Per-chassis plumbing the [`super::RenderCapability`] capture handler
+/// needs to defer the readback to the chassis main thread. The
+/// cap's dispatcher thread can't touch the wgpu `Device` (it lives
+/// on the render thread); the handler resolves the request, parks
+/// it on `queue`, and the chassis main loop reads from there on
+/// the next redraw. `wake` nudges that loop — desktop fires an
+/// `EventLoopProxy<UserEvent>::Capture`; test-bench sends on its
+/// `EventSender`.
+///
+/// `outbound` is the cap's reply edge for the inline-failure
+/// paths (decode error, bundle-resolution error, queue full,
+/// wake target dead). All four bail before parking the request,
+/// so the only happy-path reply comes from the render thread
+/// after readback completes — that path uses its own outbound
+/// clone the chassis driver keeps.
+#[derive(Clone)]
+pub struct CaptureBackend {
+    pub queue: CaptureQueue,
+    pub wake: Arc<dyn Fn() -> Result<(), &'static str> + Send + Sync>,
+    pub outbound: Arc<HubOutbound>,
+}
+
+/// Resolve the optional reference image for a `#1780` similarity
+/// check, reading it synchronously on the cap dispatcher thread so all
+/// filesystem I/O stays off the render hot path. `Ok(None)` when no
+/// check was requested; `Err(message)` when the reference can't be
+/// used (unsupported namespace, no assets dir, forbidden path, or an
+/// unreadable file) — the caller replies that message as
+/// `CaptureFrameResult::Err`.
+pub(super) fn resolve_reference(
+    assets_dir: Option<&Path>,
+    similarity: Option<&SimilarityCheck>,
+) -> Result<Option<ReferenceCapture>, String> {
+    let Some(sim) = similarity else {
+        return Ok(None);
+    };
+    // Only the "assets" namespace is supported in v1.
+    if sim.namespace != "assets" {
+        return Err(format!(
+            "capture_frame similarity: namespace {:?} is not supported in v1 — use \"assets\"",
+            sim.namespace,
+        ));
+    }
+    let Some(assets_dir) = assets_dir else {
+        return Err(
+            "capture_frame similarity: no assets directory is configured on this \
+                    chassis; similarity checks are unavailable"
+                .to_owned(),
+        );
+    };
+    // Reject path components that would escape the assets root
+    // (mirrors `LocalFileAdapter::resolve`).
+    if sim.reference_path.starts_with('/') || sim.reference_path.split('/').any(|c| c == "..") {
+        return Err(format!(
+            "capture_frame similarity: reference_path {:?} is forbidden (contains '..' or \
+             starts with '/')",
+            sim.reference_path,
+        ));
+    }
+    let full_path = assets_dir.join(&sim.reference_path);
+    match fs::read(&full_path) {
+        Ok(bytes) => Ok(Some(ReferenceCapture {
+            png_bytes: bytes,
+            threshold: sim.threshold,
+        })),
+        Err(e) => Err(format!(
+            "capture_frame similarity: could not read reference {:?}: {e}",
+            sim.reference_path,
+        )),
+    }
+}

--- a/crates/aether-capabilities/src/render/kinds.rs
+++ b/crates/aether-capabilities/src/render/kinds.rs
@@ -1,0 +1,390 @@
+//! The `aether.render` cap's drawing + texture mail kinds (ADR-0121).
+//!
+//! These ride the always-on (marker-only `render`) region of the render
+//! module, so a wasm guest on the `render` feature sees the kind types
+//! for typed `ctx.actor::<RenderCapability>().send(&kind)` addressing
+//! without the `render-native` GPU stack. The capture-request kinds
+//! (`CaptureFrame` / `CaptureFrameResult` / `SimilarityCheck`) and the
+//! `FrameCheck` verification family stay in `aether-kinds`: the former
+//! are consumed by `aether-mcp` and the latter by the substrate core, so
+//! moving them here would close a dependency cycle (ADR-0121). The
+//! `QuadSpace` / `QuadScale` projection types also stay central — the
+//! `aether.text.draw` kind in `aether-kinds` consumes them — so the quad
+//! draw kinds below import them from there.
+
+use aether_kinds::QuadSpace;
+use bytemuck::{Pod, Zeroable};
+use serde::{Deserialize, Serialize};
+
+/// A single world-space vertex with per-vertex color. Matches the
+/// substrate's `VertexBufferLayout`: `(pos: vec3<f32>, color: vec3<f32>)`,
+/// 24 bytes on the wire. Positions are world-space; the shader
+/// multiplies by the camera's `view_proj` uniform to produce clip
+/// space. Not a kind on its own — only addressable as the element
+/// type inside `DrawTriangle.verts`.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_data::Schema)]
+pub struct Vertex {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+    pub r: f32,
+    pub g: f32,
+    pub b: f32,
+}
+
+/// A draw-triangle item. One `DrawTriangle` is three vertices; the mail
+/// `count` field is the number of triangles in the payload when
+/// sent as a slice.
+#[repr(C)]
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "aether.draw_triangle")]
+pub struct DrawTriangle {
+    pub verts: [Vertex; 3],
+}
+
+/// Wire size of one `aether.draw_triangle` item: three `Vertex`es.
+/// Property of the wire shape, lives next to `DrawTriangle` so any
+/// chassis / sink that needs to clamp at whole-triangle boundaries
+/// has one canonical source. `repr(C)` + `Pod` + `[Vertex; 3]` packs
+/// without padding, so `size_of::<DrawTriangle>()` is exactly the
+/// per-triangle wire footprint.
+pub const DRAW_TRIANGLE_BYTES: usize = size_of::<DrawTriangle>();
+
+/// Camera state: column-major `view_proj` matrix (world → clip). The
+/// desktop chassis's `camera` sink writes the latest payload into the
+/// GPU uniform every frame; the WGSL vertex shader multiplies each
+/// vertex position by this matrix. Column-major layout matches wgpu's
+/// uniform upload — 64 bytes uploaded verbatim, no transpose. Camera
+/// components emit this on every `Tick`; the substrate reads only the
+/// most recent value before issuing the next draw. Before the first
+/// `Camera` arrives, the uniform holds identity and vertices render
+/// in clip-space 1:1 (the pre-camera behaviour).
+#[repr(C)]
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "aether.camera")]
+pub struct Camera {
+    pub view_proj: [f32; 16],
+}
+
+/// `aether.render.create_texture` — register an RGBA8 texture in the
+/// render cap's session-scoped texture registry. `pixels` is exactly
+/// `width * height * 4` bytes (RGBA8, row-major, top-down). The cap
+/// validates the dimensions, assigns the next `texture_id` past any
+/// previously created texture (the same id-assignment shape ADR-0103
+/// uses for instrument ids), stages the pixels CPU-side, and replies
+/// as soon as the id is assigned — the wgpu texture is realized lazily
+/// at the next frame record. Reply: `CreateTextureResult`. Desktop-
+/// only — the headless chassis replies `Err` (fail-fast, ADR-0105).
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.render.create_texture")]
+pub struct CreateTexture {
+    pub width: u32,
+    pub height: u32,
+    pub pixels: Vec<u8>,
+}
+
+/// Reply to `CreateTexture`. `Ok` carries the assigned `texture_id` —
+/// thread it into `DrawTexturedQuads.texture_id` and
+/// `UpdateTexture.texture_id`. `Err` carries a human-readable reason —
+/// a zero dimension, or a `pixels` length that doesn't match
+/// `width * height * 4`.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.render.create_texture_result")]
+pub enum CreateTextureResult {
+    Ok { texture_id: u32 },
+    Err { error: String },
+}
+
+/// `aether.render.update_texture` — overwrite a sub-rectangle of a
+/// previously-created texture's pixels (atlas growth — e.g. the text
+/// cap rasterizing a new glyph into its atlas). `pixels` is exactly
+/// `width * height * 4` bytes covering the `(x, y, width, height)`
+/// sub-rect. Fire-and-forget; a bad `texture_id` or an out-of-bounds
+/// rect logs and drops. The staged pixels update immediately; the GPU
+/// texture re-uploads at the next frame record.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.render.update_texture")]
+pub struct UpdateTexture {
+    pub texture_id: u32,
+    pub x: u32,
+    pub y: u32,
+    pub width: u32,
+    pub height: u32,
+    pub pixels: Vec<u8>,
+}
+
+/// One textured quad in a `DrawTexturedQuads` batch. `(x, y)` is the
+/// top-left corner and `(width, height)` the size, both in the unit
+/// the batch's `space` selects — window pixels for `Screen`, pixel
+/// offsets from the anchor for `World`. `(u0, v0)`–`(u1, v1)` is the
+/// uv sub-rect sampled from the batch's texture (`0,0` top-left to
+/// `1,1` bottom-right). `tint` is a linear RGBA multiplier applied to
+/// the sampled texel — `[1.0; 4]` draws the texture unmodified; the
+/// alpha channel scales the blend. Not a kind on its own — only
+/// addressable inside `DrawTexturedQuads.quads`.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct TexturedQuad {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+    pub u0: f32,
+    pub v0: f32,
+    pub u1: f32,
+    pub v1: f32,
+    pub tint: [f32; 4],
+}
+
+/// `aether.render.draw_textured_quads` — draw a batch of textured,
+/// alpha-blended quads sampling one texture, in the projection `space`
+/// selects. Accumulated per frame with the same immediate-mode
+/// contract as `aether.draw_triangle`: send it every frame the quads
+/// should appear, or they vanish next frame. `texture_id` is a
+/// registry id from a prior `CreateTexture`; an unknown id warn-drops
+/// the batch. Fire-and-forget; no reply.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.render.draw_textured_quads")]
+pub struct DrawTexturedQuads {
+    pub texture_id: u32,
+    pub space: QuadSpace,
+    pub quads: Vec<TexturedQuad>,
+}
+
+/// One flat-colored quad in a `DrawSolidQuads` batch. `(x, y)` is the
+/// top-left corner and `(width, height)` the size, both in the unit
+/// the batch's `space` selects — window pixels for `Screen`, pixel
+/// offsets from the anchor for `World`. `color` is a linear RGBA value;
+/// the alpha channel scales the blend. Not a kind on its own — only
+/// addressable inside `DrawSolidQuads.quads`.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct SolidQuad {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+    pub color: [f32; 4],
+}
+
+/// `aether.render.draw_solid_quads` — draw a batch of flat-colored,
+/// alpha-blended quads in the projection `space` selects. Accumulated
+/// per frame with the same immediate-mode contract as
+/// `aether.draw_triangle`: send it every frame the quads should appear,
+/// or they vanish next frame. Reuses the textured-quad overlay pipeline
+/// with a reserved internal 1×1 white texture tinted by `color` — no
+/// new GPU pipeline. Fire-and-forget; no reply.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.render.draw_solid_quads")]
+pub struct DrawSolidQuads {
+    pub space: QuadSpace,
+    pub quads: Vec<SolidQuad>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_data::{Kind, Schema, SchemaType, decode_slice, encode_slice};
+    use aether_kinds::QuadScale;
+
+    /// The moved drawing/texture kinds keep their wire names verbatim
+    /// across the crate move (a kind id is `fnv1a_64` over name + schema,
+    /// neither of which a crate move touches), so the `aether.render.*`
+    /// vocabulary is unchanged.
+    #[test]
+    fn moved_kind_names_are_stable() {
+        assert_eq!(DrawTriangle::NAME, "aether.draw_triangle");
+        assert_eq!(Camera::NAME, "aether.camera");
+        assert_eq!(CreateTexture::NAME, "aether.render.create_texture");
+        assert_eq!(
+            CreateTextureResult::NAME,
+            "aether.render.create_texture_result"
+        );
+        assert_eq!(UpdateTexture::NAME, "aether.render.update_texture");
+        assert_eq!(DrawTexturedQuads::NAME, "aether.render.draw_textured_quads");
+        assert_eq!(DrawSolidQuads::NAME, "aether.render.draw_solid_quads");
+    }
+
+    #[test]
+    fn draw_triangle_slice_size() {
+        let v = Vertex {
+            x: 0.0,
+            y: 0.5,
+            z: 0.0,
+            r: 1.0,
+            g: 0.0,
+            b: 0.0,
+        };
+        let tris = [
+            DrawTriangle { verts: [v, v, v] },
+            DrawTriangle { verts: [v, v, v] },
+        ];
+        let bytes = encode_slice(&tris);
+        assert_eq!(bytes.len(), 2 * 72);
+        let back: &[DrawTriangle] =
+            decode_slice(&bytes).expect("test setup: DrawTriangle slice decodes zero-copy");
+        assert_eq!(back, &tris);
+    }
+
+    #[test]
+    fn draw_triangle_schema_recurses_into_vertex() {
+        let SchemaType::Struct { repr_c, fields } = &<DrawTriangle as Schema>::SCHEMA else {
+            panic!("expected Struct");
+        };
+        assert!(*repr_c);
+        assert_eq!(fields.len(), 1);
+        assert_eq!(fields[0].name, "verts");
+        let SchemaType::Array { element, len } = &fields[0].ty else {
+            panic!("expected Array");
+        };
+        assert_eq!(*len, 3);
+        let SchemaType::Struct {
+            repr_c: nested_repr,
+            fields: nested_fields,
+        } = &**element
+        else {
+            panic!("expected nested Struct");
+        };
+        assert!(*nested_repr);
+        assert_eq!(nested_fields.len(), 6);
+        assert_eq!(nested_fields[0].name, "x");
+        assert_eq!(nested_fields[2].name, "z");
+        assert_eq!(nested_fields[5].name, "b");
+    }
+
+    #[test]
+    fn create_texture_request_roundtrip() {
+        let c = CreateTexture {
+            width: 2,
+            height: 2,
+            pixels: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+        };
+        let bytes = c.encode_into_bytes();
+        let back: CreateTexture = CreateTexture::decode_from_bytes(&bytes)
+            .expect("test setup: kind codec decodes CreateTexture");
+        assert_eq!(back.width, 2);
+        assert_eq!(back.height, 2);
+        assert_eq!(back.pixels.len(), 16);
+    }
+
+    #[test]
+    fn create_texture_result_roundtrip_both_arms() {
+        let ok = CreateTextureResult::Ok { texture_id: 7 };
+        let bytes = ok.encode_into_bytes();
+        let back: CreateTextureResult = CreateTextureResult::decode_from_bytes(&bytes)
+            .expect("test setup: kind codec decodes CreateTextureResult::Ok");
+        match back {
+            CreateTextureResult::Ok { texture_id } => assert_eq!(texture_id, 7),
+            CreateTextureResult::Err { .. } => panic!("expected Ok"),
+        }
+
+        let err = CreateTextureResult::Err {
+            error: "pixels length mismatch".to_string(),
+        };
+        let bytes = err.encode_into_bytes();
+        let back: CreateTextureResult = CreateTextureResult::decode_from_bytes(&bytes)
+            .expect("test setup: kind codec decodes CreateTextureResult::Err");
+        match back {
+            CreateTextureResult::Err { error } => assert_eq!(error, "pixels length mismatch"),
+            CreateTextureResult::Ok { .. } => panic!("expected Err"),
+        }
+    }
+
+    #[test]
+    fn update_texture_request_roundtrip() {
+        let u = UpdateTexture {
+            texture_id: 3,
+            x: 4,
+            y: 5,
+            width: 1,
+            height: 1,
+            pixels: vec![9, 8, 7, 6],
+        };
+        let bytes = u.encode_into_bytes();
+        let back: UpdateTexture = UpdateTexture::decode_from_bytes(&bytes)
+            .expect("test setup: kind codec decodes UpdateTexture");
+        assert_eq!(back.texture_id, 3);
+        assert_eq!((back.x, back.y), (4, 5));
+        assert_eq!(back.pixels, vec![9, 8, 7, 6]);
+    }
+
+    #[test]
+    fn draw_textured_quads_screen_roundtrip() {
+        let d = DrawTexturedQuads {
+            texture_id: 1,
+            space: QuadSpace::Screen,
+            quads: vec![TexturedQuad {
+                x: 10.0,
+                y: 8.0,
+                width: 20.0,
+                height: 16.0,
+                u0: 0.0,
+                v0: 0.0,
+                u1: 1.0,
+                v1: 1.0,
+                tint: [1.0, 1.0, 1.0, 1.0],
+            }],
+        };
+        let bytes = d.encode_into_bytes();
+        let back: DrawTexturedQuads = DrawTexturedQuads::decode_from_bytes(&bytes)
+            .expect("test setup: kind codec decodes DrawTexturedQuads");
+        assert_eq!(back.texture_id, 1);
+        assert_eq!(back.space, QuadSpace::Screen);
+        assert_eq!(back.quads.len(), 1);
+        assert_eq!(back.quads[0].width, 20.0);
+        assert_eq!(back.quads[0].tint, [1.0, 1.0, 1.0, 1.0]);
+    }
+
+    #[test]
+    fn draw_textured_quads_world_roundtrip_carries_anchor_and_scale() {
+        let d = DrawTexturedQuads {
+            texture_id: 2,
+            space: QuadSpace::World {
+                anchor: [1.0, 2.0, 3.0],
+                scale: QuadScale::Distance {
+                    reference_distance: 5.0,
+                },
+            },
+            quads: vec![],
+        };
+        let bytes = d.encode_into_bytes();
+        let back: DrawTexturedQuads = DrawTexturedQuads::decode_from_bytes(&bytes)
+            .expect("test setup: kind codec decodes DrawTexturedQuads (World)");
+        match back.space {
+            QuadSpace::World { anchor, scale } => {
+                assert_eq!(anchor, [1.0, 2.0, 3.0]);
+                assert_eq!(
+                    scale,
+                    QuadScale::Distance {
+                        reference_distance: 5.0
+                    }
+                );
+            }
+            QuadSpace::Screen => panic!("expected World"),
+        }
+    }
+
+    #[test]
+    fn draw_solid_quads_screen_roundtrip() {
+        let d = DrawSolidQuads {
+            space: QuadSpace::Screen,
+            quads: vec![SolidQuad {
+                x: 10.0,
+                y: 8.0,
+                width: 20.0,
+                height: 16.0,
+                color: [1.0, 0.0, 0.5, 1.0],
+            }],
+        };
+        let bytes = d.encode_into_bytes();
+        let back: DrawSolidQuads = DrawSolidQuads::decode_from_bytes(&bytes)
+            .expect("test setup: kind codec decodes DrawSolidQuads");
+        assert_eq!(back.space, QuadSpace::Screen);
+        assert_eq!(back.quads.len(), 1);
+        assert_eq!(back.quads[0].width, 20.0);
+        assert_eq!(back.quads[0].color, [1.0, 0.0, 0.5, 1.0]);
+    }
+}

--- a/crates/aether-capabilities/src/render/mod.rs
+++ b/crates/aether-capabilities/src/render/mod.rs
@@ -7,12 +7,25 @@
 //! counter.
 //!
 //! Driver-side state (wgpu device, queue, pipeline, offscreen
-//! targets, accumulator buffers) lives on [`RenderHandles`]. The
-//! driver fetches the booted cap via
+//! targets, accumulator buffers) lives on [`RenderHandles`] in the
+//! `pipeline` submodule. The driver fetches the booted cap via
 //! `DriverCtx::actor::<RenderCapability>()` and clones `.handles()`
 //! from there. Phase 4 keeps the GPU lifecycle, encoder creation, and
 //! presentation in the chassis driver — this capability owns only the
 //! mail surface and accumulator state.
+//!
+//! The cap's drawing + texture mail kinds live in [`kinds`] (ADR-0121):
+//! they ride the always-on (marker-only `render`) region so a wasm
+//! guest sees the kind types for typed addressing without the
+//! `render-native` GPU stack. The capture-request and `FrameCheck`
+//! verification kinds stay in `aether-kinds` (consumed upstream by
+//! `aether-mcp` and the substrate core), as do the `QuadSpace` /
+//! `QuadScale` projection types the `aether.text` kinds share.
+//!
+//! The decomposition is along the cap's cohesion seams: `pipeline`
+//! (GPU bundle + accumulator handles), `texture` (the texture
+//! registry), `quad` (the quad-batch accumulator), and `capture`
+//! (the cross-thread readback machinery).
 //!
 //! [`HeadlessRenderCapability`] is the chassis-without-GPU companion:
 //! same `aether.render` mailbox, no-op `DrawTriangle` / `Camera`
@@ -32,13 +45,30 @@
 // where a sibling tick's producer mutates the buffer in between.
 #![allow(clippy::significant_drop_tightening)]
 
+// The cap's drawing + texture mail kinds (ADR-0121). Always-on (the
+// `render` marker feature gates the whole module) so a wasm guest on the
+// marker-only `render` feature sees the kind types.
+pub mod kinds;
+pub use kinds::*;
+
+// Native impl seams. Gated identically to the `#[bridge]`-emitted
+// `mod native` body (`not(wasm) AND render-native`) so they're present
+// exactly when that body references them.
+#[cfg(all(not(target_family = "wasm"), feature = "render-native"))]
+mod capture;
+#[cfg(all(not(target_family = "wasm"), feature = "render-native"))]
+mod pipeline;
+#[cfg(all(not(target_family = "wasm"), feature = "render-native"))]
+mod quad;
+#[cfg(all(not(target_family = "wasm"), feature = "render-native"))]
+mod texture;
+
 // Handler-signature kinds must be importable at file root because
 // `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
-// of the mod (always-on, outside the cfg gate).
-use aether_kinds::{
-    Camera, CaptureFrame, CreateTexture, DrawSolidQuads, DrawTexturedQuads, DrawTriangle,
-    UpdateTexture,
-};
+// of the mod (always-on, outside the cfg gate). The drawing kinds come
+// from the local `kinds` module (via the glob re-export above);
+// `CaptureFrame` stays in `aether-kinds` (consumed by `aether-mcp`).
+use aether_kinds::CaptureFrame;
 
 // Auxiliary native-only types the chassis driver consumes alongside
 // `RenderCapability`. `#[bridge]` only re-exports the actor type
@@ -46,8 +76,12 @@ use aether_kinds::{
 // feature so wasm components that opt into the marker-only `render`
 // feature see only the cap stub + Actor / HandlesKind impls, not
 // these heavy GPU-bound types.
-#[cfg(all(not(target_arch = "wasm32"), feature = "render-native"))]
-pub use native::{CaptureBackend, RenderConfig, RenderGpu, RenderHandles};
+#[cfg(all(not(target_family = "wasm"), feature = "render-native"))]
+pub use self::capture::CaptureBackend;
+#[cfg(all(not(target_family = "wasm"), feature = "render-native"))]
+pub use self::native::RenderConfig;
+#[cfg(all(not(target_family = "wasm"), feature = "render-native"))]
+pub use self::pipeline::{RenderGpu, RenderHandles};
 
 // `HeadlessRenderCapability` is exported through `#[bridge]`'s
 // auto-emitted re-export. It carries no auxiliary native-only types,
@@ -55,41 +89,31 @@ pub use native::{CaptureBackend, RenderConfig, RenderGpu, RenderHandles};
 
 #[aether_actor::bridge(singleton, feature = "render-native")]
 mod native {
-    use std::collections::HashMap;
-    use std::fs;
-    use std::path::{Path, PathBuf};
+    use std::path::PathBuf;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::{Mutex, OnceLock};
 
     use aether_actor::actor;
     use aether_data::Kind;
-    use aether_kinds::{
-        CaptureFrameResult, CreateTextureResult, DRAW_TRIANGLE_BYTES, QuadScale, QuadSpace,
-        SimilarityCheck, SolidQuad, TexturedQuad,
-    };
+    use aether_kinds::CaptureFrameResult;
     use aether_substrate::Manual;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::capture::{CaptureQueue, PendingCapture, ReferenceCapture};
+    use aether_substrate::capture::PendingCapture;
     use aether_substrate::chassis::error::BootError;
     use aether_substrate::mail::helpers::resolve_bundle;
     use aether_substrate::mail::mailer::Mailer;
-    use aether_substrate::mail::outbound::HubOutbound;
     use aether_substrate::mail::registry::Registry;
-    use aether_substrate::render::{
-        CaptureMeta, IDENTITY_VIEW_PROJ, OverlayDraw, Pipeline, QUAD_VERTEX_STRIDE,
-        QUAD_VERTICES_PER_QUAD, QuadPipeline, RealizedTexture, RenderError, Targets,
-        build_main_pipeline, build_quad_pipeline, finish_capture, map_capture_rgba,
-        prepare_capture_copy, push_screen_quad_vertices, push_world_quad_vertices, realize_texture,
-        record_main_pass, record_quad_overlay_pass, upload_texture_full,
-    };
+    use aether_substrate::render::{IDENTITY_VIEW_PROJ, VERTEX_BUFFER_BYTES};
 
+    use super::capture::{CaptureBackend, resolve_reference};
+    use super::pipeline::RenderHandles;
+    use super::quad::QuadBatch;
+    use super::texture::{StagedTexture, TextureRegistry, WHITE_TEXTURE_ID, expected_pixel_bytes};
     use super::{
-        Camera, CaptureFrame, CreateTexture, DrawSolidQuads, DrawTexturedQuads, DrawTriangle,
-        UpdateTexture,
+        Camera, CaptureFrame, CreateTexture, CreateTextureResult, DRAW_TRIANGLE_BYTES,
+        DrawSolidQuads, DrawTexturedQuads, DrawTriangle, SolidQuad, TexturedQuad, UpdateTexture,
     };
-    use aether_substrate::render::VERTEX_BUFFER_BYTES;
-    use std::mem;
 
     /// Configuration for [`RenderCapability`]. `vertex_buffer_bytes` is
     /// the maximum bytes the render accumulator will hold before
@@ -135,149 +159,6 @@ mod native {
                 observed_kinds: None,
                 capture_backend: None,
                 assets_dir: None,
-            }
-        }
-    }
-
-    /// Per-chassis plumbing the [`RenderCapability`] capture handler
-    /// needs to defer the readback to the chassis main thread. The
-    /// cap's dispatcher thread can't touch the wgpu `Device` (it lives
-    /// on the render thread); the handler resolves the request, parks
-    /// it on `queue`, and the chassis main loop reads from there on
-    /// the next redraw. `wake` nudges that loop — desktop fires an
-    /// `EventLoopProxy<UserEvent>::Capture`; test-bench sends on its
-    /// `EventSender`.
-    ///
-    /// `outbound` is the cap's reply edge for the inline-failure
-    /// paths (decode error, bundle-resolution error, queue full,
-    /// wake target dead). All four bail before parking the request,
-    /// so the only happy-path reply comes from the render thread
-    /// after readback completes — that path uses its own outbound
-    /// clone the chassis driver keeps.
-    #[derive(Clone)]
-    pub struct CaptureBackend {
-        pub queue: CaptureQueue,
-        pub wake: Arc<dyn Fn() -> Result<(), &'static str> + Send + Sync>,
-        pub outbound: Arc<HubOutbound>,
-    }
-
-    /// One accumulated `draw_textured_quads` batch (ADR-0105): the
-    /// texture it samples, the projection it draws under, and the quad
-    /// list. Cloned out of the accumulator at record time so the cap
-    /// dispatcher thread can keep appending the next frame's batches
-    /// while the driver thread expands these.
-    #[derive(Clone)]
-    pub struct QuadBatch {
-        pub texture_id: u32,
-        pub space: QuadSpace,
-        pub quads: Vec<TexturedQuad>,
-    }
-
-    /// A texture registered via `create_texture`: the staged RGBA8 pixels
-    /// (the CPU source of truth), plus the lazily-realized GPU texture +
-    /// bind group. `create_texture` / `update_texture` run on the cap
-    /// dispatcher thread and only touch the staging side; the wgpu
-    /// resources are realized at record time on the driver thread (the
-    /// `RenderGpu` `OnceLock` isn't filled until the chassis driver boots
-    /// the GPU). `dirty` flags staging that the GPU copy hasn't caught up
-    /// to yet — the next record re-uploads the whole texture.
-    struct StagedTexture {
-        width: u32,
-        height: u32,
-        pixels: Vec<u8>,
-        realized: Option<RealizedTexture>,
-        dirty: bool,
-    }
-
-    impl StagedTexture {
-        /// Overwrite the `(x, y, width, height)` sub-rect of the staged
-        /// pixels with `pixels` (RGBA8, row-major) and dirty the texture.
-        /// Returns `false` without touching the buffer if the rect is
-        /// out of bounds, has a zero dimension, or `pixels` isn't exactly
-        /// `width * height * 4` bytes — the caller logs and drops.
-        fn apply_subrect(
-            &mut self,
-            x: u32,
-            y: u32,
-            width: u32,
-            height: u32,
-            pixels: &[u8],
-        ) -> bool {
-            let Some(rect_bytes) = expected_pixel_bytes(width, height) else {
-                return false;
-            };
-            let in_bounds = x
-                .checked_add(width)
-                .is_some_and(|right| right <= self.width)
-                && y.checked_add(height)
-                    .is_some_and(|bottom| bottom <= self.height);
-            if !in_bounds || pixels.len() != rect_bytes {
-                return false;
-            }
-            let row_bytes = width as usize * 4;
-            let dst_stride = self.width as usize * 4;
-            for row in 0..height as usize {
-                let src_start = row * row_bytes;
-                let dst_row = y as usize + row;
-                let dst_start = dst_row * dst_stride + x as usize * 4;
-                self.pixels[dst_start..dst_start + row_bytes]
-                    .copy_from_slice(&pixels[src_start..src_start + row_bytes]);
-            }
-            self.dirty = true;
-            true
-        }
-
-        /// Realize the GPU texture if it isn't yet, or re-upload the
-        /// staged pixels if `update_texture` dirtied them since the last
-        /// record. Runs at record time on the driver thread, where a
-        /// device + queue are available.
-        fn ensure_realized(
-            &mut self,
-            device: &wgpu::Device,
-            queue: &wgpu::Queue,
-            pipeline: &QuadPipeline,
-        ) {
-            if let Some(realized) = &self.realized {
-                // Already on the GPU; re-upload only if `update_texture`
-                // dirtied the staging buffer since the last record.
-                if self.dirty {
-                    upload_texture_full(queue, realized, &self.pixels);
-                }
-            } else {
-                self.realized = Some(realize_texture(
-                    device,
-                    queue,
-                    pipeline,
-                    self.width,
-                    self.height,
-                    &self.pixels,
-                ));
-            }
-            self.dirty = false;
-        }
-    }
-
-    /// Reserved sentinel `texture_id` for the internal 1×1 white texture
-    /// used by `on_draw_solid_quads`. `create_texture` starts at `0` and
-    /// increments, so `u32::MAX` is outside the range any caller-visible id
-    /// occupies — the white texture is never handed to a caller and never
-    /// collides with a user-created texture.
-    const WHITE_TEXTURE_ID: u32 = u32::MAX;
-
-    /// Session-scoped texture registry. `next_id` hands out the
-    /// `texture_id` a `create_texture` reply carries — assigned in
-    /// sequence the same way ADR-0103 assigns instrument ids, so ids are
-    /// stable for the session and depend only on creation order.
-    struct TextureRegistry {
-        next_id: u32,
-        entries: HashMap<u32, StagedTexture>,
-    }
-
-    impl TextureRegistry {
-        fn new() -> Self {
-            Self {
-                next_id: 0,
-                entries: HashMap::new(),
             }
         }
     }
@@ -784,592 +665,6 @@ mod native {
         }
     }
 
-    /// Resolve the optional reference image for a `#1780` similarity
-    /// check, reading it synchronously on the cap dispatcher thread so all
-    /// filesystem I/O stays off the render hot path. `Ok(None)` when no
-    /// check was requested; `Err(message)` when the reference can't be
-    /// used (unsupported namespace, no assets dir, forbidden path, or an
-    /// unreadable file) — the caller replies that message as
-    /// `CaptureFrameResult::Err`.
-    fn resolve_reference(
-        assets_dir: Option<&Path>,
-        similarity: Option<&SimilarityCheck>,
-    ) -> Result<Option<ReferenceCapture>, String> {
-        let Some(sim) = similarity else {
-            return Ok(None);
-        };
-        // Only the "assets" namespace is supported in v1.
-        if sim.namespace != "assets" {
-            return Err(format!(
-                "capture_frame similarity: namespace {:?} is not supported in v1 — use \"assets\"",
-                sim.namespace,
-            ));
-        }
-        let Some(assets_dir) = assets_dir else {
-            return Err(
-                "capture_frame similarity: no assets directory is configured on this \
-                        chassis; similarity checks are unavailable"
-                    .to_owned(),
-            );
-        };
-        // Reject path components that would escape the assets root
-        // (mirrors `LocalFileAdapter::resolve`).
-        if sim.reference_path.starts_with('/') || sim.reference_path.split('/').any(|c| c == "..") {
-            return Err(format!(
-                "capture_frame similarity: reference_path {:?} is forbidden (contains '..' or \
-                 starts with '/')",
-                sim.reference_path,
-            ));
-        }
-        let full_path = assets_dir.join(&sim.reference_path);
-        match fs::read(&full_path) {
-            Ok(bytes) => Ok(Some(ReferenceCapture {
-                png_bytes: bytes,
-                threshold: sim.threshold,
-            })),
-            Err(e) => Err(format!(
-                "capture_frame similarity: could not read reference {:?}: {e}",
-                sim.reference_path,
-            )),
-        }
-    }
-
-    /// RGBA8 byte count for a `width x height` texture, or `None` if the
-    /// dimensions are zero or the product overflows `usize`. Shared by the
-    /// `create_texture` validation and the `update_texture` sub-rect
-    /// check.
-    fn expected_pixel_bytes(width: u32, height: u32) -> Option<usize> {
-        if width == 0 || height == 0 {
-            return None;
-        }
-        (width as usize)
-            .checked_mul(height as usize)
-            .and_then(|pixels| pixels.checked_mul(4))
-    }
-
-    /// Bundle of accumulator state plus GPU resources, shared between
-    /// the cap's dispatcher thread (write side for accumulators) and the
-    /// chassis driver (read side for accumulators, install + read for
-    /// GPU). All fields are `Arc`s so cloning is cheap and shutdown
-    /// drops are independent.
-    #[derive(Clone)]
-    pub struct RenderHandles {
-        /// Per-frame accumulator. `on_draw_triangle` appends bytes
-        /// here; `record_frame` consumes by swapping with
-        /// `last_submitted` and clearing.
-        pub frame_vertices: Arc<Mutex<Vec<u8>>>,
-        /// Most-recently-rendered geometry, kept across frames
-        /// (iamacoffeepot/aether#847). When `record_frame` runs with
-        /// an empty `frame_vertices` — typically a `TestBench::capture`
-        /// that didn't dispatch a `Tick` — the GPU draw replays this
-        /// buffer so the captured frame matches "what the user would
-        /// see right now" instead of clear-color.
-        ///
-        /// Lock ordering: `frame_vertices` first, then `last_submitted`
-        /// when both are held. Today only `record_frame` holds both;
-        /// callers reading `last_submitted` in isolation are fine.
-        pub last_submitted: Arc<Mutex<Vec<u8>>>,
-        pub triangles_rendered: Arc<AtomicU64>,
-        pub camera_state: Arc<Mutex<[f32; 16]>>,
-        /// Per-frame textured-quad accumulator (ADR-0105). `on_draw_
-        /// textured_quads` pushes a [`QuadBatch`] here; `record_overlay_
-        /// pass` consumes by swapping with `quad_last_submitted` — the
-        /// same immediate-mode cache the triangle path uses, so a
-        /// `TestBench::capture` replays the last committed quads.
-        quad_frame: Arc<Mutex<Vec<QuadBatch>>>,
-        /// Most-recently-rendered quad batches, kept across frames so an
-        /// idle `capture` (no producer this frame) replays them, matching
-        /// `last_submitted`'s role for triangles.
-        quad_last_submitted: Arc<Mutex<Vec<QuadBatch>>>,
-        /// Session-scoped texture registry: staged CPU pixels + lazily-
-        /// realized GPU textures. Written by the cap dispatcher thread
-        /// (`create_texture` / `update_texture`), realized + read by the
-        /// driver thread at record time.
-        textures: Arc<Mutex<TextureRegistry>>,
-        /// wgpu state, installed post-cap-construction by the driver via
-        /// [`Self::install_gpu`]. Boots empty because winit 0.30's
-        /// `ActiveEventLoop::create_window` only fires inside `resumed`,
-        /// after `Builder::build` has returned. Test-bench (no surface)
-        /// installs immediately after `build_passive`; desktop installs
-        /// in its `resumed` handler. Encoder-level methods panic if
-        /// called before install — in practice every code path that
-        /// calls them runs after the install site.
-        gpu: Arc<OnceLock<RenderGpu>>,
-    }
-
-    impl RenderHandles {
-        /// Install the wgpu resources the encoder-level methods read.
-        /// The driver constructs [`RenderGpu`] once it has a device +
-        /// queue — for desktop that's inside `resumed` after winit hands
-        /// back a window and surface; for test-bench it's right after
-        /// `build_passive` returns.
-        ///
-        /// # Panics
-        /// Panics if called more than once — fail-fast per ADR-0063:
-        /// install is the chassis's promise that wgpu state is now
-        /// ready and stable for the chassis lifetime; a double install
-        /// indicates a chassis-wiring bug.
-        pub fn install_gpu(&self, gpu: RenderGpu) {
-            self.gpu
-                .set(gpu)
-                .ok()
-                .expect("RenderHandles::install_gpu called twice");
-        }
-
-        /// Returns the installed [`RenderGpu`], or `None` if `install_gpu`
-        /// hasn't been called yet. Chassis-side glue that needs raw
-        /// access to the pipeline's bind group layouts (e.g. desktop's
-        /// wireframe overlay pipeline construction) reaches in here.
-        #[must_use]
-        pub fn gpu(&self) -> Option<&RenderGpu> {
-            self.gpu.get()
-        }
-
-        fn expect_gpu(&self) -> &RenderGpu {
-            self.gpu.get().expect(
-                "RenderHandles::install_gpu must be called before encoder-level methods. \
-             Desktop installs in winit's resumed; test-bench installs after build_passive.",
-            )
-        }
-
-        /// Read the latest camera view-proj and record the main render
-        /// pass into `encoder` against the current frame's geometry.
-        /// `extra_pipelines` are drawn after the main pipeline inside
-        /// the same render pass — desktop passes a wireframe overlay
-        /// pipeline here when `AETHER_WIREFRAME=overlay`; test-bench
-        /// passes `&[]`.
-        ///
-        /// ## Cache semantics (iamacoffeepot/aether#847)
-        ///
-        /// If `frame_vertices` holds new emissions from this tick's
-        /// `on_draw_triangle` calls, swap them into `last_submitted`
-        /// and clear the live accumulator (the swapped-out buffer,
-        /// now in `live`, becomes the next tick's staging area). The
-        /// render pass then draws from `last_submitted`.
-        ///
-        /// If `frame_vertices` is empty, `replay_cache_when_idle`
-        /// picks the behaviour:
-        ///
-        /// - `false` — **commit-current**: clear `last_submitted` so
-        ///   the next frame reflects "the producer chose not to
-        ///   emit," and render an empty draw list (clear-color
-        ///   frame). Used by desktop's per-frame draw and by the
-        ///   test-bench's advance path. Matches a game's normal
-        ///   semantic: if the producer stops drawing, the screen
-        ///   goes to clear color.
-        /// - `true` — **replay-cache**: leave `last_submitted`
-        ///   untouched and render its current contents. Used by
-        ///   `TestBench::capture` when it didn't dispatch a `Tick`
-        ///   of its own — the cache holds whatever the last advance
-        ///   committed, which is the right "what would the user
-        ///   see right now" answer. Retires the historical
-        ///   `nudge_tick` boilerplate.
-        ///
-        /// Lock ordering: `frame_vertices` first, then
-        /// `last_submitted`. Today only this function holds both.
-        ///
-        /// # Panics
-        /// Panics if `install_gpu` hasn't been called, or if any of the
-        /// internal mutexes (frame vertices, last submitted, camera
-        /// state, targets) are poisoned — fail-fast per ADR-0063: both
-        /// indicate a substrate-level invariant violation.
-        pub fn record_frame(
-            &self,
-            encoder: &mut wgpu::CommandEncoder,
-            extra_pipelines: &[&wgpu::RenderPipeline],
-            replay_cache_when_idle: bool,
-        ) -> Result<(), RenderError> {
-            let gpu = self.expect_gpu();
-            {
-                let mut live = self
-                    .frame_vertices
-                    .lock()
-                    .expect("mutex poisoned; fail-fast per ADR-0063");
-                let mut last = self
-                    .last_submitted
-                    .lock()
-                    .expect("mutex poisoned; fail-fast per ADR-0063");
-                if !live.is_empty() {
-                    // Producer emitted: swap into cache.
-                    mem::swap(&mut *live, &mut *last);
-                    // Post-swap, `live` holds what `last` held before
-                    // — stale geometry from however many frames ago.
-                    // Clear (preserves capacity) so the next tick's
-                    // `on_draw_triangle` appends into an empty buffer
-                    // without reallocating.
-                    live.clear();
-                } else if !replay_cache_when_idle {
-                    // Commit-current: producer chose not to emit
-                    // this frame, so the cache should reflect that
-                    // for any subsequent replay-cache caller.
-                    last.clear();
-                }
-                // else: replay-cache + empty live — leave cache
-                // alone, render its current contents.
-            }
-            let view_proj = *self
-                .camera_state
-                .lock()
-                .expect("mutex poisoned; fail-fast per ADR-0063");
-            let last = self
-                .last_submitted
-                .lock()
-                .expect("mutex poisoned; fail-fast per ADR-0063");
-            let targets = gpu
-                .targets
-                .lock()
-                .expect("mutex poisoned; fail-fast per ADR-0063");
-            record_main_pass(
-                &gpu.queue,
-                encoder,
-                &gpu.pipeline,
-                &targets,
-                &last,
-                &view_proj,
-                extra_pipelines,
-            )
-        }
-
-        /// Record the textured-quad overlay pass (ADR-0105) into `encoder`
-        /// after [`Self::record_frame`] — a sibling pass that draws the
-        /// accumulated `Screen`-space quads over the world geometry with
-        /// alpha blending and no depth.
-        ///
-        /// `replay_cache_when_idle` mirrors [`Self::record_frame`]'s cache
-        /// semantics for quads: an empty live accumulator commits-current
-        /// (clears the cache) under `false` — the per-frame draw / advance
-        /// path — and replays the cache under `true` — `TestBench::capture`
-        /// without a dispatched tick.
-        ///
-        /// Each batch realizes its texture lazily (creating the wgpu
-        /// texture + bind group on first use, re-uploading on a dirtied
-        /// staging buffer), expands its quads into vertices, and draws
-        /// with that texture's bind group. An unknown `texture_id`
-        /// warn-drops the batch. `World`-space quads transform their
-        /// anchor through the latest `view_proj` (ADR-0105).
-        ///
-        /// # Panics
-        /// Panics if `install_gpu` hasn't been called, or if any internal
-        /// mutex is poisoned — fail-fast per ADR-0063.
-        // Two-pass texture realization + quad expansion in a single
-        // function avoids threading split borrows through multiple
-        // helpers; the line count reflects the World/Screen branching
-        // added in #1699.
-        #[allow(clippy::too_many_lines)]
-        pub fn record_overlay_pass(
-            &self,
-            encoder: &mut wgpu::CommandEncoder,
-            replay_cache_when_idle: bool,
-        ) {
-            let gpu = self.expect_gpu();
-            {
-                let mut live = self
-                    .quad_frame
-                    .lock()
-                    .expect("mutex poisoned; fail-fast per ADR-0063");
-                let mut last = self
-                    .quad_last_submitted
-                    .lock()
-                    .expect("mutex poisoned; fail-fast per ADR-0063");
-                if !live.is_empty() {
-                    mem::swap(&mut *live, &mut *last);
-                    live.clear();
-                } else if !replay_cache_when_idle {
-                    last.clear();
-                }
-            }
-            let batches = self
-                .quad_last_submitted
-                .lock()
-                .expect("mutex poisoned; fail-fast per ADR-0063")
-                .clone();
-            if batches.is_empty() {
-                return;
-            }
-
-            let targets = gpu
-                .targets
-                .lock()
-                .expect("mutex poisoned; fail-fast per ADR-0063");
-            #[allow(clippy::cast_precision_loss)]
-            let viewport = [targets.width() as f32, targets.height() as f32];
-
-            let view_proj = *self
-                .camera_state
-                .lock()
-                .expect("mutex poisoned; fail-fast per ADR-0063");
-
-            let mut registry = self
-                .textures
-                .lock()
-                .expect("mutex poisoned; fail-fast per ADR-0063");
-
-            // First pass: realize / re-upload every texture the frame
-            // references (Screen and World batches share the same atlas),
-            // mutably borrowing the registry.
-            for batch in &batches {
-                if let Some(entry) = registry.entries.get_mut(&batch.texture_id) {
-                    entry.ensure_realized(&gpu.device, &gpu.queue, &gpu.quad_pipeline);
-                } else {
-                    tracing::warn!(
-                        target: "aether_capabilities::render",
-                        texture_id = batch.texture_id,
-                        "draw_textured_quads for unknown texture id; dropping the batch",
-                    );
-                }
-            }
-
-            // Second pass: expand quads into vertices and build the draw
-            // list, immutably borrowing each realized texture's bind group.
-            let mut vertex_bytes = Vec::new();
-            let mut draws: Vec<OverlayDraw<'_>> = Vec::new();
-            for batch in &batches {
-                let Some(entry) = registry.entries.get(&batch.texture_id) else {
-                    continue;
-                };
-                let Some(realized) = entry.realized.as_ref() else {
-                    continue;
-                };
-                #[allow(clippy::cast_possible_truncation)]
-                let first_vertex = (vertex_bytes.len() / QUAD_VERTEX_STRIDE as usize) as u32;
-                match &batch.space {
-                    QuadSpace::Screen => {
-                        for quad in &batch.quads {
-                            push_screen_quad_vertices(
-                                &mut vertex_bytes,
-                                [quad.x, quad.y, quad.width, quad.height],
-                                [quad.u0, quad.v0, quad.u1, quad.v1],
-                                quad.tint,
-                            );
-                        }
-                    }
-                    QuadSpace::World { anchor, scale } => {
-                        // k < 0 => Pixels mode (shader uses clip.w for
-                        // constant on-screen size). k > 0 => Distance mode
-                        // (constant k, label shrinks with depth; holds its
-                        // size at reference_distance).
-                        let k = match scale {
-                            QuadScale::Pixels => -1.0_f32,
-                            QuadScale::Distance { reference_distance } => *reference_distance,
-                        };
-                        for quad in &batch.quads {
-                            push_world_quad_vertices(
-                                &mut vertex_bytes,
-                                *anchor,
-                                [quad.x, quad.y, quad.width, quad.height],
-                                [quad.u0, quad.v0, quad.u1, quad.v1],
-                                quad.tint,
-                                k,
-                            );
-                        }
-                    }
-                }
-                #[allow(clippy::cast_possible_truncation)]
-                let vertex_count = (batch.quads.len() * QUAD_VERTICES_PER_QUAD) as u32;
-                if vertex_count == 0 {
-                    continue;
-                }
-                draws.push(OverlayDraw {
-                    bind_group: realized.bind_group(),
-                    first_vertex,
-                    vertex_count,
-                });
-            }
-
-            record_quad_overlay_pass(
-                &gpu.queue,
-                encoder,
-                &gpu.quad_pipeline,
-                &targets,
-                &vertex_bytes,
-                &draws,
-                viewport,
-                view_proj,
-            );
-        }
-
-        /// Encode a copy of the offscreen color target into a readback
-        /// buffer. Pair with [`Self::finish_capture`] after submit. The
-        /// readback buffer is reallocated on size mismatch with the
-        /// current offscreen, so any sequence of resize → `record_frame` →
-        /// `record_capture_copy` → submit → `finish_capture` works.
-        ///
-        /// # Panics
-        /// Panics if `install_gpu` hasn't been called or if the targets
-        /// mutex is poisoned — fail-fast per ADR-0063.
-        pub fn record_capture_copy(&self, encoder: &mut wgpu::CommandEncoder) -> CaptureMeta {
-            let gpu = self.expect_gpu();
-            let mut targets = gpu
-                .targets
-                .lock()
-                .expect("mutex poisoned; fail-fast per ADR-0063");
-            prepare_capture_copy(&gpu.device, &mut targets, encoder)
-        }
-
-        /// Map the readback buffer prepared by [`Self::record_capture_copy`]
-        /// and return the encoded PNG. Call after the encoder containing
-        /// the matching `record_capture_copy` has been submitted.
-        ///
-        /// # Panics
-        /// Panics if `install_gpu` hasn't been called or if the targets
-        /// mutex is poisoned — fail-fast per ADR-0063.
-        pub fn finish_capture(&self, meta: &CaptureMeta) -> Result<Vec<u8>, String> {
-            let gpu = self.expect_gpu();
-            let targets = gpu
-                .targets
-                .lock()
-                .expect("mutex poisoned; fail-fast per ADR-0063");
-            finish_capture(&gpu.device, &targets, meta)
-        }
-
-        /// Map the readback buffer prepared by [`Self::record_capture_copy`]
-        /// and return the raw de-padded RGBA8 frame — the exact pixels
-        /// [`Self::finish_capture`] PNG-encodes. The bundle render thread
-        /// scores a verdict on these bytes and encodes the PNG from the
-        /// same buffer, so the readback is mapped just once
-        /// (iamacoffeepot/aether#1777). Call after the encoder containing
-        /// the matching `record_capture_copy` has been submitted.
-        ///
-        /// # Panics
-        /// Panics if `install_gpu` hasn't been called or if the targets
-        /// mutex is poisoned — fail-fast per ADR-0063.
-        pub fn map_capture_rgba(&self, meta: &CaptureMeta) -> Result<Vec<u8>, String> {
-            let gpu = self.expect_gpu();
-            let targets = gpu
-                .targets
-                .lock()
-                .expect("mutex poisoned; fail-fast per ADR-0063");
-            map_capture_rgba(&gpu.device, &targets, meta)
-        }
-
-        /// Resize the offscreen color + depth targets. Idempotent on
-        /// zero dimensions (matches winit's `Resized(0, 0)` on minimize).
-        ///
-        /// # Panics
-        /// Panics if `install_gpu` hasn't been called or if the targets
-        /// mutex is poisoned — fail-fast per ADR-0063.
-        pub fn resize(&self, width: u32, height: u32) {
-            let gpu = self.expect_gpu();
-            let mut targets = gpu
-                .targets
-                .lock()
-                .expect("mutex poisoned; fail-fast per ADR-0063");
-            targets.resize(&gpu.device, width, height);
-        }
-
-        /// Cloned `Arc<wgpu::Device>`. Drivers that need the device for
-        /// their own pipelines (e.g. desktop's wireframe overlay pipeline,
-        /// swapchain blit) clone here.
-        #[must_use]
-        pub fn device(&self) -> Arc<wgpu::Device> {
-            Arc::clone(&self.expect_gpu().device)
-        }
-
-        /// Cloned `Arc<wgpu::Queue>`. Drivers submit through this; the
-        /// shared queue means render's `record_frame` writes and the
-        /// driver's swapchain submit go through the same submission
-        /// order.
-        #[must_use]
-        pub fn queue(&self) -> Arc<wgpu::Queue> {
-            Arc::clone(&self.expect_gpu().queue)
-        }
-
-        /// Format the offscreen color target was created with. Capture's
-        /// BGRA-vs-RGBA decision keys on this; desktop's swapchain blit
-        /// matches its surface format against this to pick a direct copy
-        /// vs a manual swizzle.
-        #[must_use]
-        pub fn color_format(&self) -> wgpu::TextureFormat {
-            self.expect_gpu().color_format
-        }
-
-        /// Current offscreen color target dimensions. Drivers reading
-        /// after a `resize` see the new dimensions immediately.
-        ///
-        /// # Panics
-        /// Panics if `install_gpu` hasn't been called or if the targets
-        /// mutex is poisoned — fail-fast per ADR-0063.
-        #[must_use]
-        pub fn color_size(&self) -> (u32, u32) {
-            let targets = self
-                .expect_gpu()
-                .targets
-                .lock()
-                .expect("mutex poisoned; fail-fast per ADR-0063");
-            (targets.width(), targets.height())
-        }
-
-        /// Run `f` with a borrow of the offscreen color texture. Used by
-        /// desktop's swapchain blit: the closure body holds the targets
-        /// mutex, so any encoder commands recorded inside are sequenced
-        /// against any concurrent resize. Test-bench reaches the
-        /// offscreen via the capture path and doesn't need this.
-        ///
-        /// # Panics
-        /// Panics if `install_gpu` hasn't been called or if the targets
-        /// mutex is poisoned — fail-fast per ADR-0063.
-        pub fn with_color_texture<F, R>(&self, f: F) -> R
-        where
-            F: FnOnce(&wgpu::Texture) -> R,
-        {
-            let gpu = self.expect_gpu();
-            let targets = gpu
-                .targets
-                .lock()
-                .expect("mutex poisoned; fail-fast per ADR-0063");
-            f(targets.color_texture())
-        }
-    }
-
-    /// Bundle of wgpu resources `RenderHandles` exposes post-install.
-    /// Constructed by the driver from a wgpu device + queue obtained via
-    /// `Adapter::request_device` (desktop: with surface compatibility;
-    /// test-bench: offscreen-only). Holds the pipeline + offscreen
-    /// targets so encoder-level methods can record draws and capture
-    /// copies without the driver threading these through every call.
-    pub struct RenderGpu {
-        pub device: Arc<wgpu::Device>,
-        pub queue: Arc<wgpu::Queue>,
-        pub pipeline: Pipeline,
-        /// Textured-quad overlay pipeline (ADR-0105). Built alongside the
-        /// main pipeline so `record_overlay_pass` can draw the
-        /// accumulated quads into the same offscreen target after the
-        /// world pass.
-        pub quad_pipeline: QuadPipeline,
-        pub targets: Mutex<Targets>,
-        pub color_format: wgpu::TextureFormat,
-    }
-
-    impl RenderGpu {
-        /// Build the standard render pipeline + offscreen targets at the
-        /// given size and pass [`Self`] to [`RenderHandles::install_gpu`].
-        /// `polygon_mode` is `Fill` for the normal case; desktop's
-        /// `AETHER_WIREFRAME=line` chassis env passes `Line` so the main
-        /// pipeline draws as wireframe instead of building a separate
-        /// overlay pipeline.
-        #[must_use]
-        pub fn new(
-            device: Arc<wgpu::Device>,
-            queue: Arc<wgpu::Queue>,
-            color_format: wgpu::TextureFormat,
-            width: u32,
-            height: u32,
-            polygon_mode: wgpu::PolygonMode,
-        ) -> Self {
-            let pipeline = build_main_pipeline(&device, &queue, color_format, polygon_mode);
-            let quad_pipeline = build_quad_pipeline(&device, color_format);
-            let targets = Targets::new(&device, color_format, width, height);
-            Self {
-                device,
-                queue,
-                pipeline,
-                quad_pipeline,
-                targets: Mutex::new(targets),
-                color_format,
-            }
-        }
-    }
-
     #[cfg(test)]
     mod tests {
         use std::time::Duration;
@@ -1377,6 +672,7 @@ mod native {
         use super::*;
         use crate::test_chassis::TestChassis;
         use aether_actor::Addressable;
+        use aether_kinds::QuadSpace;
         use aether_kinds::trace::Nanos;
         use aether_substrate::chassis::builder::{Builder, PassiveChassis};
         use aether_substrate::mail::MailId;
@@ -1460,73 +756,6 @@ mod native {
         // by the bundle scenario tests (`tick_roundtrip_component_to_sink`
         // and the `test_bench_scenario` suite), which exercise it through
         // real settlement rather than a per-mailbox counter poll.
-
-        /// ADR-0105: `expected_pixel_bytes` is the single source of the
-        /// RGBA8 length rule. Zero dimensions and overflowing products
-        /// return `None`; a valid texture returns `width * height * 4`.
-        #[test]
-        fn expected_pixel_bytes_validates_dimensions() {
-            assert_eq!(expected_pixel_bytes(2, 3), Some(24));
-            assert_eq!(expected_pixel_bytes(0, 4), None);
-            assert_eq!(expected_pixel_bytes(4, 0), None);
-            assert_eq!(expected_pixel_bytes(u32::MAX, u32::MAX), None);
-        }
-
-        /// The registry hands out ids in creation order, starting at 0 —
-        /// the same id-assignment shape ADR-0103 uses for instruments.
-        #[test]
-        fn texture_registry_assigns_sequential_ids() {
-            let mut registry = TextureRegistry::new();
-            let mut next = || {
-                let id = registry.next_id;
-                registry.next_id += 1;
-                registry.entries.insert(
-                    id,
-                    StagedTexture {
-                        width: 1,
-                        height: 1,
-                        pixels: vec![0, 0, 0, 0],
-                        realized: None,
-                        dirty: true,
-                    },
-                );
-                id
-            };
-            assert_eq!(next(), 0);
-            assert_eq!(next(), 1);
-            assert_eq!(next(), 2);
-            assert_eq!(registry.entries.len(), 3);
-        }
-
-        /// `apply_subrect` writes an in-bounds rect into the staged pixels
-        /// and dirties the texture; an out-of-bounds rect, a zero
-        /// dimension, or a pixel-length mismatch leaves the buffer
-        /// untouched and returns `false`.
-        #[test]
-        fn staged_texture_apply_subrect_bounds() {
-            let mut texture = StagedTexture {
-                width: 2,
-                height: 2,
-                pixels: vec![0u8; 16],
-                realized: None,
-                dirty: false,
-            };
-            // Overwrite the bottom-right pixel (1, 1) with 0xAA bytes.
-            assert!(texture.apply_subrect(1, 1, 1, 1, &[0xAA, 0xAA, 0xAA, 0xAA]));
-            assert!(texture.dirty);
-            assert_eq!(&texture.pixels[12..16], &[0xAA, 0xAA, 0xAA, 0xAA]);
-            // The other three pixels are untouched.
-            assert_eq!(&texture.pixels[0..12], &[0u8; 12]);
-
-            // Out of bounds (rect extends past the right edge).
-            texture.dirty = false;
-            assert!(!texture.apply_subrect(1, 0, 2, 1, &[1, 2, 3, 4, 5, 6, 7, 8]));
-            assert!(!texture.dirty);
-            // Pixel-length mismatch for the declared rect.
-            assert!(!texture.apply_subrect(0, 0, 1, 1, &[1, 2, 3]));
-            // Zero-sized rect.
-            assert!(!texture.apply_subrect(0, 0, 0, 1, &[]));
-        }
 
         /// ADR-0107 §4: `draw_solid_quads` accumulates into `quad_frame` under
         /// the reserved `WHITE_TEXTURE_ID` and records its kind name in
@@ -1647,15 +876,15 @@ mod native_headless {
     use std::sync::Arc;
 
     use aether_actor::actor;
-    use aether_kinds::{CaptureFrameResult, CreateTextureResult};
+    use aether_kinds::CaptureFrameResult;
     use aether_substrate::Manual;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
     use aether_substrate::mail::outbound::HubOutbound;
 
     use super::{
-        Camera, CaptureFrame, CreateTexture, DrawSolidQuads, DrawTexturedQuads, DrawTriangle,
-        UpdateTexture,
+        Camera, CaptureFrame, CreateTexture, CreateTextureResult, DrawSolidQuads,
+        DrawTexturedQuads, DrawTriangle, UpdateTexture,
     };
     use std::io;
 
@@ -1762,7 +991,6 @@ mod native_headless {
         use crate::test_chassis::{decode_reply, test_mailer_and_rx};
         use aether_data::{MailboxId, Source, SourceAddr};
         use aether_data::{SessionToken, Uuid};
-        use aether_kinds::CreateTexture;
         use aether_substrate::actor::native::NativeCtx;
         use aether_substrate::actor::native::binding::NativeBinding;
 
@@ -1813,7 +1041,7 @@ mod native_headless {
         /// `on_draw_textured_quads` no-op contract.
         #[test]
         fn headless_draw_solid_quads_is_noop() {
-            use aether_kinds::{DrawSolidQuads, QuadSpace};
+            use aether_kinds::QuadSpace;
 
             let (mailer, _rx) = test_mailer_and_rx();
             let outbound = mailer

--- a/crates/aether-capabilities/src/render/pipeline.rs
+++ b/crates/aether-capabilities/src/render/pipeline.rs
@@ -1,0 +1,551 @@
+//! Driver-facing GPU bundle ([`RenderGpu`]) and accumulator state
+//! ([`RenderHandles`]) for the `aether.render` cap. Shared between the
+//! cap's dispatcher thread (write side for accumulators) and the
+//! chassis driver (read side for accumulators, install + read for GPU).
+//! All accumulator fields are `Arc`s so cloning is cheap and shutdown
+//! drops are independent.
+
+// Frame-vertex / last-submitted Mutex guards are held through the
+// per-frame swap and append sequence on purpose — the swap and
+// subsequent length math read the buffer's current state and write
+// back; releasing the guard mid-sequence opens a TOCTOU window
+// where a sibling tick's producer mutates the buffer in between.
+#![allow(clippy::significant_drop_tightening)]
+
+use std::mem;
+use std::sync::atomic::AtomicU64;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use aether_kinds::{QuadScale, QuadSpace};
+use aether_substrate::render::{
+    CaptureMeta, OverlayDraw, Pipeline, QUAD_VERTEX_STRIDE, QUAD_VERTICES_PER_QUAD, QuadPipeline,
+    RenderError, Targets, build_main_pipeline, build_quad_pipeline, finish_capture,
+    map_capture_rgba, prepare_capture_copy, push_screen_quad_vertices, push_world_quad_vertices,
+    record_main_pass, record_quad_overlay_pass,
+};
+
+use super::quad::QuadBatch;
+use super::texture::TextureRegistry;
+
+/// Bundle of accumulator state plus GPU resources, shared between
+/// the cap's dispatcher thread (write side for accumulators) and the
+/// chassis driver (read side for accumulators, install + read for
+/// GPU). All fields are `Arc`s so cloning is cheap and shutdown
+/// drops are independent.
+#[derive(Clone)]
+pub struct RenderHandles {
+    /// Per-frame accumulator. `on_draw_triangle` appends bytes
+    /// here; `record_frame` consumes by swapping with
+    /// `last_submitted` and clearing.
+    pub frame_vertices: Arc<Mutex<Vec<u8>>>,
+    /// Most-recently-rendered geometry, kept across frames
+    /// (iamacoffeepot/aether#847). When `record_frame` runs with
+    /// an empty `frame_vertices` — typically a `TestBench::capture`
+    /// that didn't dispatch a `Tick` — the GPU draw replays this
+    /// buffer so the captured frame matches "what the user would
+    /// see right now" instead of clear-color.
+    ///
+    /// Lock ordering: `frame_vertices` first, then `last_submitted`
+    /// when both are held. Today only `record_frame` holds both;
+    /// callers reading `last_submitted` in isolation are fine.
+    pub last_submitted: Arc<Mutex<Vec<u8>>>,
+    pub triangles_rendered: Arc<AtomicU64>,
+    pub camera_state: Arc<Mutex<[f32; 16]>>,
+    /// Per-frame textured-quad accumulator (ADR-0105). `on_draw_
+    /// textured_quads` pushes a [`QuadBatch`] here; `record_overlay_
+    /// pass` consumes by swapping with `quad_last_submitted` — the
+    /// same immediate-mode cache the triangle path uses, so a
+    /// `TestBench::capture` replays the last committed quads.
+    pub(super) quad_frame: Arc<Mutex<Vec<QuadBatch>>>,
+    /// Most-recently-rendered quad batches, kept across frames so an
+    /// idle `capture` (no producer this frame) replays them, matching
+    /// `last_submitted`'s role for triangles.
+    pub(super) quad_last_submitted: Arc<Mutex<Vec<QuadBatch>>>,
+    /// Session-scoped texture registry: staged CPU pixels + lazily-
+    /// realized GPU textures. Written by the cap dispatcher thread
+    /// (`create_texture` / `update_texture`), realized + read by the
+    /// driver thread at record time.
+    pub(super) textures: Arc<Mutex<TextureRegistry>>,
+    /// wgpu state, installed post-cap-construction by the driver via
+    /// [`Self::install_gpu`]. Boots empty because winit 0.30's
+    /// `ActiveEventLoop::create_window` only fires inside `resumed`,
+    /// after `Builder::build` has returned. Test-bench (no surface)
+    /// installs immediately after `build_passive`; desktop installs
+    /// in its `resumed` handler. Encoder-level methods panic if
+    /// called before install — in practice every code path that
+    /// calls them runs after the install site.
+    pub(super) gpu: Arc<OnceLock<RenderGpu>>,
+}
+
+impl RenderHandles {
+    /// Install the wgpu resources the encoder-level methods read.
+    /// The driver constructs [`RenderGpu`] once it has a device +
+    /// queue — for desktop that's inside `resumed` after winit hands
+    /// back a window and surface; for test-bench it's right after
+    /// `build_passive` returns.
+    ///
+    /// # Panics
+    /// Panics if called more than once — fail-fast per ADR-0063:
+    /// install is the chassis's promise that wgpu state is now
+    /// ready and stable for the chassis lifetime; a double install
+    /// indicates a chassis-wiring bug.
+    pub fn install_gpu(&self, gpu: RenderGpu) {
+        self.gpu
+            .set(gpu)
+            .ok()
+            .expect("RenderHandles::install_gpu called twice");
+    }
+
+    /// Returns the installed [`RenderGpu`], or `None` if `install_gpu`
+    /// hasn't been called yet. Chassis-side glue that needs raw
+    /// access to the pipeline's bind group layouts (e.g. desktop's
+    /// wireframe overlay pipeline construction) reaches in here.
+    #[must_use]
+    pub fn gpu(&self) -> Option<&RenderGpu> {
+        self.gpu.get()
+    }
+
+    fn expect_gpu(&self) -> &RenderGpu {
+        self.gpu.get().expect(
+            "RenderHandles::install_gpu must be called before encoder-level methods. \
+         Desktop installs in winit's resumed; test-bench installs after build_passive.",
+        )
+    }
+
+    /// Read the latest camera view-proj and record the main render
+    /// pass into `encoder` against the current frame's geometry.
+    /// `extra_pipelines` are drawn after the main pipeline inside
+    /// the same render pass — desktop passes a wireframe overlay
+    /// pipeline here when `AETHER_WIREFRAME=overlay`; test-bench
+    /// passes `&[]`.
+    ///
+    /// ## Cache semantics (iamacoffeepot/aether#847)
+    ///
+    /// If `frame_vertices` holds new emissions from this tick's
+    /// `on_draw_triangle` calls, swap them into `last_submitted`
+    /// and clear the live accumulator (the swapped-out buffer,
+    /// now in `live`, becomes the next tick's staging area). The
+    /// render pass then draws from `last_submitted`.
+    ///
+    /// If `frame_vertices` is empty, `replay_cache_when_idle`
+    /// picks the behaviour:
+    ///
+    /// - `false` — **commit-current**: clear `last_submitted` so
+    ///   the next frame reflects "the producer chose not to
+    ///   emit," and render an empty draw list (clear-color
+    ///   frame). Used by desktop's per-frame draw and by the
+    ///   test-bench's advance path. Matches a game's normal
+    ///   semantic: if the producer stops drawing, the screen
+    ///   goes to clear color.
+    /// - `true` — **replay-cache**: leave `last_submitted`
+    ///   untouched and render its current contents. Used by
+    ///   `TestBench::capture` when it didn't dispatch a `Tick`
+    ///   of its own — the cache holds whatever the last advance
+    ///   committed, which is the right "what would the user
+    ///   see right now" answer. Retires the historical
+    ///   `nudge_tick` boilerplate.
+    ///
+    /// Lock ordering: `frame_vertices` first, then
+    /// `last_submitted`. Today only this function holds both.
+    ///
+    /// # Panics
+    /// Panics if `install_gpu` hasn't been called, or if any of the
+    /// internal mutexes (frame vertices, last submitted, camera
+    /// state, targets) are poisoned — fail-fast per ADR-0063: both
+    /// indicate a substrate-level invariant violation.
+    pub fn record_frame(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        extra_pipelines: &[&wgpu::RenderPipeline],
+        replay_cache_when_idle: bool,
+    ) -> Result<(), RenderError> {
+        let gpu = self.expect_gpu();
+        {
+            let mut live = self
+                .frame_vertices
+                .lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063");
+            let mut last = self
+                .last_submitted
+                .lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063");
+            if !live.is_empty() {
+                // Producer emitted: swap into cache.
+                mem::swap(&mut *live, &mut *last);
+                // Post-swap, `live` holds what `last` held before
+                // — stale geometry from however many frames ago.
+                // Clear (preserves capacity) so the next tick's
+                // `on_draw_triangle` appends into an empty buffer
+                // without reallocating.
+                live.clear();
+            } else if !replay_cache_when_idle {
+                // Commit-current: producer chose not to emit
+                // this frame, so the cache should reflect that
+                // for any subsequent replay-cache caller.
+                last.clear();
+            }
+            // else: replay-cache + empty live — leave cache
+            // alone, render its current contents.
+        }
+        let view_proj = *self
+            .camera_state
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063");
+        let last = self
+            .last_submitted
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063");
+        let targets = gpu
+            .targets
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063");
+        record_main_pass(
+            &gpu.queue,
+            encoder,
+            &gpu.pipeline,
+            &targets,
+            &last,
+            &view_proj,
+            extra_pipelines,
+        )
+    }
+
+    /// Record the textured-quad overlay pass (ADR-0105) into `encoder`
+    /// after [`Self::record_frame`] — a sibling pass that draws the
+    /// accumulated `Screen`-space quads over the world geometry with
+    /// alpha blending and no depth.
+    ///
+    /// `replay_cache_when_idle` mirrors [`Self::record_frame`]'s cache
+    /// semantics for quads: an empty live accumulator commits-current
+    /// (clears the cache) under `false` — the per-frame draw / advance
+    /// path — and replays the cache under `true` — `TestBench::capture`
+    /// without a dispatched tick.
+    ///
+    /// Each batch realizes its texture lazily (creating the wgpu
+    /// texture + bind group on first use, re-uploading on a dirtied
+    /// staging buffer), expands its quads into vertices, and draws
+    /// with that texture's bind group. An unknown `texture_id`
+    /// warn-drops the batch. `World`-space quads transform their
+    /// anchor through the latest `view_proj` (ADR-0105).
+    ///
+    /// # Panics
+    /// Panics if `install_gpu` hasn't been called, or if any internal
+    /// mutex is poisoned — fail-fast per ADR-0063.
+    // Two-pass texture realization + quad expansion in a single
+    // function avoids threading split borrows through multiple
+    // helpers; the line count reflects the World/Screen branching
+    // added in #1699.
+    #[allow(clippy::too_many_lines)]
+    pub fn record_overlay_pass(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        replay_cache_when_idle: bool,
+    ) {
+        let gpu = self.expect_gpu();
+        {
+            let mut live = self
+                .quad_frame
+                .lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063");
+            let mut last = self
+                .quad_last_submitted
+                .lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063");
+            if !live.is_empty() {
+                mem::swap(&mut *live, &mut *last);
+                live.clear();
+            } else if !replay_cache_when_idle {
+                last.clear();
+            }
+        }
+        let batches = self
+            .quad_last_submitted
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063")
+            .clone();
+        if batches.is_empty() {
+            return;
+        }
+
+        let targets = gpu
+            .targets
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063");
+        #[allow(clippy::cast_precision_loss)]
+        let viewport = [targets.width() as f32, targets.height() as f32];
+
+        let view_proj = *self
+            .camera_state
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063");
+
+        let mut registry = self
+            .textures
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063");
+
+        // First pass: realize / re-upload every texture the frame
+        // references (Screen and World batches share the same atlas),
+        // mutably borrowing the registry.
+        for batch in &batches {
+            if let Some(entry) = registry.entries.get_mut(&batch.texture_id) {
+                entry.ensure_realized(&gpu.device, &gpu.queue, &gpu.quad_pipeline);
+            } else {
+                tracing::warn!(
+                    target: "aether_capabilities::render",
+                    texture_id = batch.texture_id,
+                    "draw_textured_quads for unknown texture id; dropping the batch",
+                );
+            }
+        }
+
+        // Second pass: expand quads into vertices and build the draw
+        // list, immutably borrowing each realized texture's bind group.
+        let mut vertex_bytes = Vec::new();
+        let mut draws: Vec<OverlayDraw<'_>> = Vec::new();
+        for batch in &batches {
+            let Some(entry) = registry.entries.get(&batch.texture_id) else {
+                continue;
+            };
+            let Some(realized) = entry.realized.as_ref() else {
+                continue;
+            };
+            #[allow(clippy::cast_possible_truncation)]
+            let first_vertex = (vertex_bytes.len() / QUAD_VERTEX_STRIDE as usize) as u32;
+            match &batch.space {
+                QuadSpace::Screen => {
+                    for quad in &batch.quads {
+                        push_screen_quad_vertices(
+                            &mut vertex_bytes,
+                            [quad.x, quad.y, quad.width, quad.height],
+                            [quad.u0, quad.v0, quad.u1, quad.v1],
+                            quad.tint,
+                        );
+                    }
+                }
+                QuadSpace::World { anchor, scale } => {
+                    // k < 0 => Pixels mode (shader uses clip.w for
+                    // constant on-screen size). k > 0 => Distance mode
+                    // (constant k, label shrinks with depth; holds its
+                    // size at reference_distance).
+                    let k = match scale {
+                        QuadScale::Pixels => -1.0_f32,
+                        QuadScale::Distance { reference_distance } => *reference_distance,
+                    };
+                    for quad in &batch.quads {
+                        push_world_quad_vertices(
+                            &mut vertex_bytes,
+                            *anchor,
+                            [quad.x, quad.y, quad.width, quad.height],
+                            [quad.u0, quad.v0, quad.u1, quad.v1],
+                            quad.tint,
+                            k,
+                        );
+                    }
+                }
+            }
+            #[allow(clippy::cast_possible_truncation)]
+            let vertex_count = (batch.quads.len() * QUAD_VERTICES_PER_QUAD) as u32;
+            if vertex_count == 0 {
+                continue;
+            }
+            draws.push(OverlayDraw {
+                bind_group: realized.bind_group(),
+                first_vertex,
+                vertex_count,
+            });
+        }
+
+        record_quad_overlay_pass(
+            &gpu.queue,
+            encoder,
+            &gpu.quad_pipeline,
+            &targets,
+            &vertex_bytes,
+            &draws,
+            viewport,
+            view_proj,
+        );
+    }
+
+    /// Encode a copy of the offscreen color target into a readback
+    /// buffer. Pair with [`Self::finish_capture`] after submit. The
+    /// readback buffer is reallocated on size mismatch with the
+    /// current offscreen, so any sequence of resize → `record_frame` →
+    /// `record_capture_copy` → submit → `finish_capture` works.
+    ///
+    /// # Panics
+    /// Panics if `install_gpu` hasn't been called or if the targets
+    /// mutex is poisoned — fail-fast per ADR-0063.
+    pub fn record_capture_copy(&self, encoder: &mut wgpu::CommandEncoder) -> CaptureMeta {
+        let gpu = self.expect_gpu();
+        let mut targets = gpu
+            .targets
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063");
+        prepare_capture_copy(&gpu.device, &mut targets, encoder)
+    }
+
+    /// Map the readback buffer prepared by [`Self::record_capture_copy`]
+    /// and return the encoded PNG. Call after the encoder containing
+    /// the matching `record_capture_copy` has been submitted.
+    ///
+    /// # Panics
+    /// Panics if `install_gpu` hasn't been called or if the targets
+    /// mutex is poisoned — fail-fast per ADR-0063.
+    pub fn finish_capture(&self, meta: &CaptureMeta) -> Result<Vec<u8>, String> {
+        let gpu = self.expect_gpu();
+        let targets = gpu
+            .targets
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063");
+        finish_capture(&gpu.device, &targets, meta)
+    }
+
+    /// Map the readback buffer prepared by [`Self::record_capture_copy`]
+    /// and return the raw de-padded RGBA8 frame — the exact pixels
+    /// [`Self::finish_capture`] PNG-encodes. The bundle render thread
+    /// scores a verdict on these bytes and encodes the PNG from the
+    /// same buffer, so the readback is mapped just once
+    /// (iamacoffeepot/aether#1777). Call after the encoder containing
+    /// the matching `record_capture_copy` has been submitted.
+    ///
+    /// # Panics
+    /// Panics if `install_gpu` hasn't been called or if the targets
+    /// mutex is poisoned — fail-fast per ADR-0063.
+    pub fn map_capture_rgba(&self, meta: &CaptureMeta) -> Result<Vec<u8>, String> {
+        let gpu = self.expect_gpu();
+        let targets = gpu
+            .targets
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063");
+        map_capture_rgba(&gpu.device, &targets, meta)
+    }
+
+    /// Resize the offscreen color + depth targets. Idempotent on
+    /// zero dimensions (matches winit's `Resized(0, 0)` on minimize).
+    ///
+    /// # Panics
+    /// Panics if `install_gpu` hasn't been called or if the targets
+    /// mutex is poisoned — fail-fast per ADR-0063.
+    pub fn resize(&self, width: u32, height: u32) {
+        let gpu = self.expect_gpu();
+        let mut targets = gpu
+            .targets
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063");
+        targets.resize(&gpu.device, width, height);
+    }
+
+    /// Cloned `Arc<wgpu::Device>`. Drivers that need the device for
+    /// their own pipelines (e.g. desktop's wireframe overlay pipeline,
+    /// swapchain blit) clone here.
+    #[must_use]
+    pub fn device(&self) -> Arc<wgpu::Device> {
+        Arc::clone(&self.expect_gpu().device)
+    }
+
+    /// Cloned `Arc<wgpu::Queue>`. Drivers submit through this; the
+    /// shared queue means render's `record_frame` writes and the
+    /// driver's swapchain submit go through the same submission
+    /// order.
+    #[must_use]
+    pub fn queue(&self) -> Arc<wgpu::Queue> {
+        Arc::clone(&self.expect_gpu().queue)
+    }
+
+    /// Format the offscreen color target was created with. Capture's
+    /// BGRA-vs-RGBA decision keys on this; desktop's swapchain blit
+    /// matches its surface format against this to pick a direct copy
+    /// vs a manual swizzle.
+    #[must_use]
+    pub fn color_format(&self) -> wgpu::TextureFormat {
+        self.expect_gpu().color_format
+    }
+
+    /// Current offscreen color target dimensions. Drivers reading
+    /// after a `resize` see the new dimensions immediately.
+    ///
+    /// # Panics
+    /// Panics if `install_gpu` hasn't been called or if the targets
+    /// mutex is poisoned — fail-fast per ADR-0063.
+    #[must_use]
+    pub fn color_size(&self) -> (u32, u32) {
+        let targets = self
+            .expect_gpu()
+            .targets
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063");
+        (targets.width(), targets.height())
+    }
+
+    /// Run `f` with a borrow of the offscreen color texture. Used by
+    /// desktop's swapchain blit: the closure body holds the targets
+    /// mutex, so any encoder commands recorded inside are sequenced
+    /// against any concurrent resize. Test-bench reaches the
+    /// offscreen via the capture path and doesn't need this.
+    ///
+    /// # Panics
+    /// Panics if `install_gpu` hasn't been called or if the targets
+    /// mutex is poisoned — fail-fast per ADR-0063.
+    pub fn with_color_texture<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&wgpu::Texture) -> R,
+    {
+        let gpu = self.expect_gpu();
+        let targets = gpu
+            .targets
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063");
+        f(targets.color_texture())
+    }
+}
+
+/// Bundle of wgpu resources `RenderHandles` exposes post-install.
+/// Constructed by the driver from a wgpu device + queue obtained via
+/// `Adapter::request_device` (desktop: with surface compatibility;
+/// test-bench: offscreen-only). Holds the pipeline + offscreen
+/// targets so encoder-level methods can record draws and capture
+/// copies without the driver threading these through every call.
+pub struct RenderGpu {
+    pub device: Arc<wgpu::Device>,
+    pub queue: Arc<wgpu::Queue>,
+    pub pipeline: Pipeline,
+    /// Textured-quad overlay pipeline (ADR-0105). Built alongside the
+    /// main pipeline so `record_overlay_pass` can draw the
+    /// accumulated quads into the same offscreen target after the
+    /// world pass.
+    pub quad_pipeline: QuadPipeline,
+    pub targets: Mutex<Targets>,
+    pub color_format: wgpu::TextureFormat,
+}
+
+impl RenderGpu {
+    /// Build the standard render pipeline + offscreen targets at the
+    /// given size and pass [`Self`] to [`RenderHandles::install_gpu`].
+    /// `polygon_mode` is `Fill` for the normal case; desktop's
+    /// `AETHER_WIREFRAME=line` chassis env passes `Line` so the main
+    /// pipeline draws as wireframe instead of building a separate
+    /// overlay pipeline.
+    #[must_use]
+    pub fn new(
+        device: Arc<wgpu::Device>,
+        queue: Arc<wgpu::Queue>,
+        color_format: wgpu::TextureFormat,
+        width: u32,
+        height: u32,
+        polygon_mode: wgpu::PolygonMode,
+    ) -> Self {
+        let pipeline = build_main_pipeline(&device, &queue, color_format, polygon_mode);
+        let quad_pipeline = build_quad_pipeline(&device, color_format);
+        let targets = Targets::new(&device, color_format, width, height);
+        Self {
+            device,
+            queue,
+            pipeline,
+            quad_pipeline,
+            targets: Mutex::new(targets),
+            color_format,
+        }
+    }
+}

--- a/crates/aether-capabilities/src/render/quad.rs
+++ b/crates/aether-capabilities/src/render/quad.rs
@@ -1,0 +1,20 @@
+//! Per-frame textured-quad accumulator state for the `aether.render`
+//! cap (ADR-0105). `on_draw_textured_quads` / `on_draw_solid_quads`
+//! push a [`QuadBatch`] into the accumulator; the driver's
+//! `record_overlay_pass` consumes them at record time.
+
+use aether_kinds::QuadSpace;
+
+use super::kinds::TexturedQuad;
+
+/// One accumulated `draw_textured_quads` batch (ADR-0105): the
+/// texture it samples, the projection it draws under, and the quad
+/// list. Cloned out of the accumulator at record time so the cap
+/// dispatcher thread can keep appending the next frame's batches
+/// while the driver thread expands these.
+#[derive(Clone)]
+pub(super) struct QuadBatch {
+    pub(super) texture_id: u32,
+    pub(super) space: QuadSpace,
+    pub(super) quads: Vec<TexturedQuad>,
+}

--- a/crates/aether-capabilities/src/render/texture.rs
+++ b/crates/aether-capabilities/src/render/texture.rs
@@ -1,0 +1,205 @@
+//! Session-scoped texture registry for the `aether.render` cap
+//! (ADR-0105). Staged CPU RGBA8 pixels are the source of truth; the
+//! wgpu texture + bind group are realized lazily at record time on the
+//! driver thread. `create_texture` / `update_texture` run on the cap
+//! dispatcher thread and only touch the staging side.
+
+use std::collections::HashMap;
+
+use aether_substrate::render::{
+    QuadPipeline, RealizedTexture, realize_texture, upload_texture_full,
+};
+
+/// A texture registered via `create_texture`: the staged RGBA8 pixels
+/// (the CPU source of truth), plus the lazily-realized GPU texture +
+/// bind group. `create_texture` / `update_texture` run on the cap
+/// dispatcher thread and only touch the staging side; the wgpu
+/// resources are realized at record time on the driver thread (the
+/// `RenderGpu` `OnceLock` isn't filled until the chassis driver boots
+/// the GPU). `dirty` flags staging that the GPU copy hasn't caught up
+/// to yet — the next record re-uploads the whole texture.
+pub(super) struct StagedTexture {
+    pub(super) width: u32,
+    pub(super) height: u32,
+    pub(super) pixels: Vec<u8>,
+    pub(super) realized: Option<RealizedTexture>,
+    pub(super) dirty: bool,
+}
+
+impl StagedTexture {
+    /// Overwrite the `(x, y, width, height)` sub-rect of the staged
+    /// pixels with `pixels` (RGBA8, row-major) and dirty the texture.
+    /// Returns `false` without touching the buffer if the rect is
+    /// out of bounds, has a zero dimension, or `pixels` isn't exactly
+    /// `width * height * 4` bytes — the caller logs and drops.
+    pub(super) fn apply_subrect(
+        &mut self,
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+        pixels: &[u8],
+    ) -> bool {
+        let Some(rect_bytes) = expected_pixel_bytes(width, height) else {
+            return false;
+        };
+        let in_bounds = x
+            .checked_add(width)
+            .is_some_and(|right| right <= self.width)
+            && y.checked_add(height)
+                .is_some_and(|bottom| bottom <= self.height);
+        if !in_bounds || pixels.len() != rect_bytes {
+            return false;
+        }
+        let row_bytes = width as usize * 4;
+        let dst_stride = self.width as usize * 4;
+        for row in 0..height as usize {
+            let src_start = row * row_bytes;
+            let dst_row = y as usize + row;
+            let dst_start = dst_row * dst_stride + x as usize * 4;
+            self.pixels[dst_start..dst_start + row_bytes]
+                .copy_from_slice(&pixels[src_start..src_start + row_bytes]);
+        }
+        self.dirty = true;
+        true
+    }
+
+    /// Realize the GPU texture if it isn't yet, or re-upload the
+    /// staged pixels if `update_texture` dirtied them since the last
+    /// record. Runs at record time on the driver thread, where a
+    /// device + queue are available.
+    pub(super) fn ensure_realized(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        pipeline: &QuadPipeline,
+    ) {
+        if let Some(realized) = &self.realized {
+            // Already on the GPU; re-upload only if `update_texture`
+            // dirtied the staging buffer since the last record.
+            if self.dirty {
+                upload_texture_full(queue, realized, &self.pixels);
+            }
+        } else {
+            self.realized = Some(realize_texture(
+                device,
+                queue,
+                pipeline,
+                self.width,
+                self.height,
+                &self.pixels,
+            ));
+        }
+        self.dirty = false;
+    }
+}
+
+/// Reserved sentinel `texture_id` for the internal 1×1 white texture
+/// used by `on_draw_solid_quads`. `create_texture` starts at `0` and
+/// increments, so `u32::MAX` is outside the range any caller-visible id
+/// occupies — the white texture is never handed to a caller and never
+/// collides with a user-created texture.
+pub(super) const WHITE_TEXTURE_ID: u32 = u32::MAX;
+
+/// Session-scoped texture registry. `next_id` hands out the
+/// `texture_id` a `create_texture` reply carries — assigned in
+/// sequence the same way ADR-0103 assigns instrument ids, so ids are
+/// stable for the session and depend only on creation order.
+pub(super) struct TextureRegistry {
+    pub(super) next_id: u32,
+    pub(super) entries: HashMap<u32, StagedTexture>,
+}
+
+impl TextureRegistry {
+    pub(super) fn new() -> Self {
+        Self {
+            next_id: 0,
+            entries: HashMap::new(),
+        }
+    }
+}
+
+/// RGBA8 byte count for a `width x height` texture, or `None` if the
+/// dimensions are zero or the product overflows `usize`. Shared by the
+/// `create_texture` validation and the `update_texture` sub-rect
+/// check.
+pub(super) fn expected_pixel_bytes(width: u32, height: u32) -> Option<usize> {
+    if width == 0 || height == 0 {
+        return None;
+    }
+    (width as usize)
+        .checked_mul(height as usize)
+        .and_then(|pixels| pixels.checked_mul(4))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// ADR-0105: `expected_pixel_bytes` is the single source of the
+    /// RGBA8 length rule. Zero dimensions and overflowing products
+    /// return `None`; a valid texture returns `width * height * 4`.
+    #[test]
+    fn expected_pixel_bytes_validates_dimensions() {
+        assert_eq!(expected_pixel_bytes(2, 3), Some(24));
+        assert_eq!(expected_pixel_bytes(0, 4), None);
+        assert_eq!(expected_pixel_bytes(4, 0), None);
+        assert_eq!(expected_pixel_bytes(u32::MAX, u32::MAX), None);
+    }
+
+    /// The registry hands out ids in creation order, starting at 0 —
+    /// the same id-assignment shape ADR-0103 uses for instruments.
+    #[test]
+    fn texture_registry_assigns_sequential_ids() {
+        let mut registry = TextureRegistry::new();
+        let mut next = || {
+            let id = registry.next_id;
+            registry.next_id += 1;
+            registry.entries.insert(
+                id,
+                StagedTexture {
+                    width: 1,
+                    height: 1,
+                    pixels: vec![0, 0, 0, 0],
+                    realized: None,
+                    dirty: true,
+                },
+            );
+            id
+        };
+        assert_eq!(next(), 0);
+        assert_eq!(next(), 1);
+        assert_eq!(next(), 2);
+        assert_eq!(registry.entries.len(), 3);
+    }
+
+    /// `apply_subrect` writes an in-bounds rect into the staged pixels
+    /// and dirties the texture; an out-of-bounds rect, a zero
+    /// dimension, or a pixel-length mismatch leaves the buffer
+    /// untouched and returns `false`.
+    #[test]
+    fn staged_texture_apply_subrect_bounds() {
+        let mut texture = StagedTexture {
+            width: 2,
+            height: 2,
+            pixels: vec![0u8; 16],
+            realized: None,
+            dirty: false,
+        };
+        // Overwrite the bottom-right pixel (1, 1) with 0xAA bytes.
+        assert!(texture.apply_subrect(1, 1, 1, 1, &[0xAA, 0xAA, 0xAA, 0xAA]));
+        assert!(texture.dirty);
+        assert_eq!(&texture.pixels[12..16], &[0xAA, 0xAA, 0xAA, 0xAA]);
+        // The other three pixels are untouched.
+        assert_eq!(&texture.pixels[0..12], &[0u8; 12]);
+
+        // Out of bounds (rect extends past the right edge).
+        texture.dirty = false;
+        assert!(!texture.apply_subrect(1, 0, 2, 1, &[1, 2, 3, 4, 5, 6, 7, 8]));
+        assert!(!texture.dirty);
+        // Pixel-length mismatch for the declared rect.
+        assert!(!texture.apply_subrect(0, 0, 1, 1, &[1, 2, 3]));
+        // Zero-sized rect.
+        assert!(!texture.apply_subrect(0, 0, 0, 1, &[]));
+    }
+}

--- a/crates/aether-capabilities/src/text/layout.rs
+++ b/crates/aether-capabilities/src/text/layout.rs
@@ -6,10 +6,10 @@
 
 use std::path::Path;
 
-use aether_kinds::{DrawTexturedQuads, FontMetrics, GlyphAdvance, QuadSpace, TexturedQuad};
+use aether_kinds::{FontMetrics, GlyphAdvance, QuadSpace};
 use aether_substrate::actor::native::NativeCtx;
 
-use crate::render::RenderCapability;
+use crate::render::{DrawTexturedQuads, RenderCapability, TexturedQuad};
 
 use super::atlas::AtlasEntry;
 

--- a/crates/aether-capabilities/src/text/mod.rs
+++ b/crates/aether-capabilities/src/text/mod.rs
@@ -36,9 +36,11 @@
 // Handler-signature kinds must be importable at file root because
 // `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings of
 // the mod (always-on, outside the cfg gate). The `aether.text` mail kinds
-// (ADR-0121) live in `kinds` and re-export here; the substrate-core kinds
-// (`CreateTextureResult` / `ReadResult`) come from `aether-kinds`.
-use aether_kinds::{CreateTextureResult, ReadResult};
+// (ADR-0121) live in `kinds` and re-export here; `ReadResult` comes from
+// `aether-kinds`, and `CreateTextureResult` is a render-cap kind the text
+// cap receives as a reply (ADR-0121 moved it to the render submodule).
+use crate::render::CreateTextureResult;
+use aether_kinds::ReadResult;
 
 // ADR-0121: the cap owns its mail kinds. Always-on + wasm-safe (only
 // `aether-data` + `serde`), re-exported so callers address them as
@@ -65,13 +67,13 @@ mod native {
 
     use aether_actor::{OutboundReply, actor};
     use aether_data::Source;
-    use aether_kinds::{CreateTexture, QuadSpace, Read, TexturedQuad, UpdateTexture};
+    use aether_kinds::{QuadSpace, Read};
     use aether_substrate::Manual;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
     use aether_substrate::chassis::error::BootError;
 
     use crate::fs::FsCapability;
-    use crate::render::RenderCapability;
+    use crate::render::{CreateTexture, RenderCapability, TexturedQuad, UpdateTexture};
 
     use super::atlas::{ATLAS_SIZE, Atlas, AtlasEntry, GlyphKey, GlyphSlot};
     use super::layout::{
@@ -624,13 +626,14 @@ mod native {
         #![allow(clippy::unwrap_used)]
 
         use super::*;
+        use crate::render::DrawTexturedQuads;
         use crate::test_chassis::{
             TestChassis, decode_session_reply, drive_task_completion, fresh_substrate,
             test_mailer_and_rx,
         };
         use aether_actor::Addressable;
         use aether_data::{Kind, MailId, SessionToken, SourceAddr, Uuid};
-        use aether_kinds::{DrawTexturedQuads, FsError};
+        use aether_kinds::FsError;
         use aether_substrate::actor::native::binding::NativeBinding;
         use aether_substrate::chassis::builder::Builder;
         use aether_substrate::mail::outbound::EgressEvent;

--- a/crates/aether-capabilities/src/ui/widgets.rs
+++ b/crates/aether-capabilities/src/ui/widgets.rs
@@ -31,13 +31,13 @@ mod native {
 
     use aether_actor::actor;
     use aether_data::MailboxId;
-    use aether_kinds::{DrawSolidQuads, QuadSpace, SolidQuad};
+    use aether_kinds::QuadSpace;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
 
     use crate::input::{InputCapability, InputMailboxExt};
     use crate::lifecycle::{LifecycleCapability, LifecycleMailboxExt};
-    use crate::render::RenderCapability;
+    use crate::render::{DrawSolidQuads, RenderCapability, SolidQuad};
     use crate::text::{DrawText, TextCapability};
 
     use super::{MouseButton, MouseMove, Tick, UiBar, UiButton, UiClicked, UiLabel, UiPanel};
@@ -285,9 +285,9 @@ mod native {
         use std::sync::mpsc::Receiver;
         use std::time::Duration;
 
+        use crate::render::DrawSolidQuads;
         use crate::text::DrawText;
         use aether_data::{Kind, MailId, MailboxId, SessionToken, Source, SourceAddr, Uuid};
-        use aether_kinds::DrawSolidQuads;
         use aether_substrate::actor::native::binding::NativeBinding;
         use aether_substrate::mail::outbound::EgressEvent;
 

--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -51,7 +51,7 @@ mod tests {
     use aether_data::{Primitive, SchemaType};
 
     use crate::{
-        Delete, DeleteResult, DrawTriangle, DropComponent, DropResult, FsFetch, FsFetchResult, Key,
+        Delete, DeleteResult, DropComponent, DropResult, FsFetch, FsFetchResult, Key,
         LifecycleUnsubscribeAll, List, ListResult, LoadComponent, LoadResult, Mat4Apply,
         MouseButton, MouseMove, Ping, Pong, ProcessExited, Read, ReadResult, RecordResult,
         ReplaceComponent, ReplaceResult, Spawn, SpawnResult, Terminate, TerminateResult, Tick,
@@ -96,7 +96,6 @@ mod tests {
         assert!(names.contains(&Key::NAME));
         assert!(names.contains(&MouseButton::NAME));
         assert!(names.contains(&MouseMove::NAME));
-        assert!(names.contains(&DrawTriangle::NAME));
         assert!(names.contains(&Ping::NAME));
         assert!(names.contains(&Pong::NAME));
         assert!(names.contains(&LoadComponent::NAME));
@@ -202,13 +201,7 @@ mod tests {
     #[test]
     fn cast_kinds_emit_struct_with_repr_c() {
         let descs = all();
-        for name in [
-            Key::NAME,
-            MouseMove::NAME,
-            DrawTriangle::NAME,
-            Ping::NAME,
-            Pong::NAME,
-        ] {
+        for name in [Key::NAME, MouseMove::NAME, Ping::NAME, Pong::NAME] {
             let d = descs
                 .iter()
                 .find(|d| d.name == name)
@@ -264,33 +257,9 @@ mod tests {
         assert_eq!(fields[1].ty, SchemaType::Scalar(Primitive::F32));
     }
 
-    #[test]
-    fn draw_triangle_recurses_into_vertex() {
-        let descs = all();
-        let dt = descs
-            .iter()
-            .find(|d| d.name == DrawTriangle::NAME)
-            .expect("test setup: DrawTriangle kind is registered in descriptor inventory");
-        let SchemaType::Struct { fields, repr_c } = &dt.schema else {
-            panic!("expected Struct")
-        };
-        assert!(*repr_c);
-        assert_eq!(fields.len(), 1);
-        assert_eq!(fields[0].name, "verts");
-        let SchemaType::Array { element, len } = &fields[0].ty else {
-            panic!("expected Array");
-        };
-        assert_eq!(*len, 3);
-        let SchemaType::Struct {
-            repr_c: nested_repr,
-            fields: nested_fields,
-        } = &**element
-        else {
-            panic!("expected nested Struct");
-        };
-        assert!(*nested_repr);
-        assert_eq!(nested_fields.len(), 6);
-    }
+    // `draw_triangle_recurses_into_vertex` re-homed with `DrawTriangle`
+    // to `aether_capabilities::render::kinds` (ADR-0121); its descriptor
+    // submission now links from `aether-capabilities`, not this crate.
 
     #[test]
     fn mat4_apply_is_registered_cast_schema() {

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -485,60 +485,12 @@ pub struct WindowSize {
     pub height: u32,
 }
 
-/// A single world-space vertex with per-vertex color. Matches the
-/// substrate's `VertexBufferLayout`: `(pos: vec3<f32>, color: vec3<f32>)`,
-/// 24 bytes on the wire. Positions are world-space; the shader
-/// multiplies by the camera's `view_proj` uniform to produce clip
-/// space. Not a kind on its own — only addressable as the element
-/// type inside `DrawTriangle.verts`.
-#[repr(C)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_data::Schema)]
-pub struct Vertex {
-    pub x: f32,
-    pub y: f32,
-    pub z: f32,
-    pub r: f32,
-    pub g: f32,
-    pub b: f32,
-}
-
-/// A draw-triangle item. One `DrawTriangle` is three vertices; the mail
-/// `count` field is the number of triangles in the payload when
-/// sent as a slice.
-#[repr(C)]
-#[derive(
-    Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_data::Kind, aether_data::Schema,
-)]
-#[kind(name = "aether.draw_triangle")]
-pub struct DrawTriangle {
-    pub verts: [Vertex; 3],
-}
-
-/// Wire size of one `aether.draw_triangle` item: three `Vertex`es.
-/// Property of the wire shape, lives next to `DrawTriangle` so any
-/// chassis / sink that needs to clamp at whole-triangle boundaries
-/// has one canonical source. `repr(C)` + `Pod` + `[Vertex; 3]` packs
-/// without padding, so `size_of::<DrawTriangle>()` is exactly the
-/// per-triangle wire footprint.
-pub const DRAW_TRIANGLE_BYTES: usize = size_of::<DrawTriangle>();
-
-/// Camera state: column-major `view_proj` matrix (world → clip). The
-/// desktop chassis's `camera` sink writes the latest payload into the
-/// GPU uniform every frame; the WGSL vertex shader multiplies each
-/// vertex position by this matrix. Column-major layout matches wgpu's
-/// uniform upload — 64 bytes uploaded verbatim, no transpose. Camera
-/// components emit this on every `Tick`; the substrate reads only the
-/// most recent value before issuing the next draw. Before the first
-/// `Camera` arrives, the uniform holds identity and vertices render
-/// in clip-space 1:1 (the pre-camera behaviour).
-#[repr(C)]
-#[derive(
-    Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_data::Kind, aether_data::Schema,
-)]
-#[kind(name = "aether.camera")]
-pub struct Camera {
-    pub view_proj: [f32; 16],
-}
+// The render cap's drawing/texture kinds — `Vertex` / `DrawTriangle` /
+// `DRAW_TRIANGLE_BYTES` / `Camera` and the `aether.render.*` texture +
+// quad family — moved to `aether_capabilities::render::kinds` (ADR-0121,
+// "capabilities own their kinds"). The capture-request and `FrameCheck`
+// verification kinds stay below: `aether-mcp` and the substrate core
+// consume them, so moving them would close a dependency cycle.
 
 // `aether.camera.*` control kinds (CameraCreate / CameraDestroy /
 // CameraSetActive / CameraSetMode / CameraOrbitSet / CameraTopdownSet)
@@ -1562,82 +1514,15 @@ mod control_plane {
         pub max_y: u32,
     }
 
-    // ADR-0105 textured-quad render surface. Three kinds on the
-    // `aether.render` mailbox compose the generic texture surface text /
-    // sprites / HUD images share: register an RGBA8 texture, overwrite a
-    // sub-rect of one, and draw a batch of textured alpha-blended quads
-    // in either projection. Structured-shaped — `CreateTexture` /
-    // `UpdateTexture` carry `Vec<u8>` pixels, `DrawTexturedQuads` carries
-    // a `space` enum and a `Vec` of quads.
-
-    /// `aether.render.create_texture` — register an RGBA8 texture in the
-    /// render cap's session-scoped texture registry. `pixels` is exactly
-    /// `width * height * 4` bytes (RGBA8, row-major, top-down). The cap
-    /// validates the dimensions, assigns the next `texture_id` past any
-    /// previously created texture (the same id-assignment shape ADR-0103
-    /// uses for instrument ids), stages the pixels CPU-side, and replies
-    /// as soon as the id is assigned — the wgpu texture is realized lazily
-    /// at the next frame record. Reply: `CreateTextureResult`. Desktop-
-    /// only — the headless chassis replies `Err` (fail-fast, ADR-0105).
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.render.create_texture")]
-    pub struct CreateTexture {
-        pub width: u32,
-        pub height: u32,
-        pub pixels: Vec<u8>,
-    }
-
-    /// Reply to `CreateTexture`. `Ok` carries the assigned `texture_id` —
-    /// thread it into `DrawTexturedQuads.texture_id` and
-    /// `UpdateTexture.texture_id`. `Err` carries a human-readable reason —
-    /// a zero dimension, or a `pixels` length that doesn't match
-    /// `width * height * 4`.
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.render.create_texture_result")]
-    pub enum CreateTextureResult {
-        Ok { texture_id: u32 },
-        Err { error: String },
-    }
-
-    /// `aether.render.update_texture` — overwrite a sub-rectangle of a
-    /// previously-created texture's pixels (atlas growth — e.g. the text
-    /// cap rasterizing a new glyph into its atlas). `pixels` is exactly
-    /// `width * height * 4` bytes covering the `(x, y, width, height)`
-    /// sub-rect. Fire-and-forget; a bad `texture_id` or an out-of-bounds
-    /// rect logs and drops. The staged pixels update immediately; the GPU
-    /// texture re-uploads at the next frame record.
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.render.update_texture")]
-    pub struct UpdateTexture {
-        pub texture_id: u32,
-        pub x: u32,
-        pub y: u32,
-        pub width: u32,
-        pub height: u32,
-        pub pixels: Vec<u8>,
-    }
-
-    /// One textured quad in a `DrawTexturedQuads` batch. `(x, y)` is the
-    /// top-left corner and `(width, height)` the size, both in the unit
-    /// the batch's `space` selects — window pixels for `Screen`, pixel
-    /// offsets from the anchor for `World`. `(u0, v0)`–`(u1, v1)` is the
-    /// uv sub-rect sampled from the batch's texture (`0,0` top-left to
-    /// `1,1` bottom-right). `tint` is a linear RGBA multiplier applied to
-    /// the sampled texel — `[1.0; 4]` draws the texture unmodified; the
-    /// alpha channel scales the blend. Not a kind on its own — only
-    /// addressable inside `DrawTexturedQuads.quads`.
-    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq)]
-    pub struct TexturedQuad {
-        pub x: f32,
-        pub y: f32,
-        pub width: f32,
-        pub height: f32,
-        pub u0: f32,
-        pub v0: f32,
-        pub u1: f32,
-        pub v1: f32,
-        pub tint: [f32; 4],
-    }
+    // ADR-0105 textured-quad render surface. The texture + quad draw
+    // kinds (`CreateTexture` / `CreateTextureResult` / `UpdateTexture` /
+    // `TexturedQuad` / `DrawTexturedQuads` / `SolidQuad` /
+    // `DrawSolidQuads`) moved to `aether_capabilities::render::kinds`
+    // (ADR-0121). The `QuadScale` / `QuadSpace` projection types stay
+    // central: the `aether.text.draw` kind below consumes `QuadSpace`,
+    // and `aether-kinds` has no dependency on `aether-capabilities`, so
+    // moving them would close a cycle — they're sibling-kind-consumed and
+    // therefore pinned here.
 
     /// How a `QuadSpace::World` quad's clip-space scale factor `k`
     /// relates on-screen size to distance (ADR-0105).
@@ -1668,50 +1553,6 @@ mod control_plane {
     pub enum QuadSpace {
         Screen,
         World { anchor: [f32; 3], scale: QuadScale },
-    }
-
-    /// `aether.render.draw_textured_quads` — draw a batch of textured,
-    /// alpha-blended quads sampling one texture, in the projection `space`
-    /// selects. Accumulated per frame with the same immediate-mode
-    /// contract as `aether.draw_triangle`: send it every frame the quads
-    /// should appear, or they vanish next frame. `texture_id` is a
-    /// registry id from a prior `CreateTexture`; an unknown id warn-drops
-    /// the batch. Fire-and-forget; no reply.
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.render.draw_textured_quads")]
-    pub struct DrawTexturedQuads {
-        pub texture_id: u32,
-        pub space: QuadSpace,
-        pub quads: Vec<TexturedQuad>,
-    }
-
-    /// One flat-colored quad in a `DrawSolidQuads` batch. `(x, y)` is the
-    /// top-left corner and `(width, height)` the size, both in the unit
-    /// the batch's `space` selects — window pixels for `Screen`, pixel
-    /// offsets from the anchor for `World`. `color` is a linear RGBA value;
-    /// the alpha channel scales the blend. Not a kind on its own — only
-    /// addressable inside `DrawSolidQuads.quads`.
-    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq)]
-    pub struct SolidQuad {
-        pub x: f32,
-        pub y: f32,
-        pub width: f32,
-        pub height: f32,
-        pub color: [f32; 4],
-    }
-
-    /// `aether.render.draw_solid_quads` — draw a batch of flat-colored,
-    /// alpha-blended quads in the projection `space` selects. Accumulated
-    /// per frame with the same immediate-mode contract as
-    /// `aether.draw_triangle`: send it every frame the quads should appear,
-    /// or they vanish next frame. Reuses the textured-quad overlay pipeline
-    /// with a reserved internal 1×1 white texture tinted by `color` — no
-    /// new GPU pipeline. Fire-and-forget; no reply.
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.render.draw_solid_quads")]
-    pub struct DrawSolidQuads {
-        pub space: QuadSpace,
-        pub quads: Vec<SolidQuad>,
     }
 
     // ADR-0105 text surface. The `aether.text` capability composes the
@@ -2927,7 +2768,7 @@ mod trajectory {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aether_data::{Kind, decode, decode_slice, encode, encode_slice};
+    use aether_data::{Kind, decode, encode};
     #[test]
     fn key_roundtrip() {
         let k = Key { code: 42 };
@@ -3214,26 +3055,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn draw_triangle_slice_size() {
-        let v = Vertex {
-            x: 0.0,
-            y: 0.5,
-            z: 0.0,
-            r: 1.0,
-            g: 0.0,
-            b: 0.0,
-        };
-        let tris = [
-            DrawTriangle { verts: [v, v, v] },
-            DrawTriangle { verts: [v, v, v] },
-        ];
-        let bytes = encode_slice(&tris);
-        assert_eq!(bytes.len(), 2 * 72);
-        let back: &[DrawTriangle] =
-            decode_slice(&bytes).expect("test setup: DrawTriangle slice decodes zero-copy");
-        assert_eq!(back, &tris);
-    }
+    // `draw_triangle_slice_size` and `draw_triangle_schema_recurses_into_vertex`
+    // re-homed to `aether_capabilities::render::kinds` with `DrawTriangle`
+    // (ADR-0121).
 
     #[test]
     #[allow(clippy::too_many_lines)]
@@ -3272,7 +3096,6 @@ mod tests {
         assert_eq!(KeyRelease::NAME, "aether.key_release");
         assert_eq!(MouseButton::NAME, "aether.mouse_button");
         assert_eq!(MouseMove::NAME, "aether.mouse_move");
-        assert_eq!(DrawTriangle::NAME, "aether.draw_triangle");
         assert_eq!(Ping::NAME, "aether.ping");
         assert_eq!(Pong::NAME, "aether.pong");
         assert_eq!(LoadComponent::NAME, "aether.component.load");
@@ -3286,21 +3109,16 @@ mod tests {
             CaptureFrameResult::NAME,
             "aether.render.capture_frame_result"
         );
-        assert_eq!(CreateTexture::NAME, "aether.render.create_texture");
-        assert_eq!(
-            CreateTextureResult::NAME,
-            "aether.render.create_texture_result"
-        );
-        assert_eq!(UpdateTexture::NAME, "aether.render.update_texture");
-        assert_eq!(DrawTexturedQuads::NAME, "aether.render.draw_textured_quads");
-        assert_eq!(DrawSolidQuads::NAME, "aether.render.draw_solid_quads");
+        // The `aether.render.*` texture + quad draw kind names are
+        // asserted in `aether_capabilities::render::kinds` (ADR-0121).
         assert_eq!(SetWindowMode::NAME, "aether.window.set_mode");
         assert_eq!(SetWindowModeResult::NAME, "aether.window.set_mode_result");
         assert_eq!(SetWindowTitle::NAME, "aether.window.set_title");
         assert_eq!(SetWindowTitleResult::NAME, "aether.window.set_title_result");
         assert_eq!(FocusWindow::NAME, "aether.window.focus");
         assert_eq!(FocusWindowResult::NAME, "aether.window.focus_result");
-        assert_eq!(Camera::NAME, "aether.camera");
+        // `aether.camera` (the view-proj sink kind) name is asserted in
+        // `aether_capabilities::render::kinds` (ADR-0121).
         // ADR-0066: aether.camera.{create,destroy,set_active,set_mode,
         // orbit.set,topdown.set} kind-name asserts live in
         // `aether-kit::camera`'s tests; the `aether.mesh.load` *request*
@@ -3356,8 +3174,6 @@ mod tests {
         fn cast_kinds_pick_repr_c_true() {
             const { assert!(<Key as CastEligible>::ELIGIBLE) };
             const { assert!(<MouseMove as CastEligible>::ELIGIBLE) };
-            const { assert!(<Vertex as CastEligible>::ELIGIBLE) };
-            const { assert!(<DrawTriangle as CastEligible>::ELIGIBLE) };
             const { assert!(<Ping as CastEligible>::ELIGIBLE) };
             const { assert!(<Pong as CastEligible>::ELIGIBLE) };
         }
@@ -3373,31 +3189,8 @@ mod tests {
             assert_eq!(fields[0].ty, SchemaType::Scalar(Primitive::U32));
         }
 
-        #[test]
-        fn draw_triangle_schema_recurses_into_vertex() {
-            let SchemaType::Struct { repr_c, fields } = &<DrawTriangle as Schema>::SCHEMA else {
-                panic!("expected Struct");
-            };
-            assert!(*repr_c);
-            assert_eq!(fields.len(), 1);
-            assert_eq!(fields[0].name, "verts");
-            let SchemaType::Array { element, len } = &fields[0].ty else {
-                panic!("expected Array");
-            };
-            assert_eq!(*len, 3);
-            let SchemaType::Struct {
-                repr_c: nested_repr,
-                fields: nested_fields,
-            } = &**element
-            else {
-                panic!("expected nested Struct");
-            };
-            assert!(*nested_repr);
-            assert_eq!(nested_fields.len(), 6);
-            assert_eq!(nested_fields[0].name, "x");
-            assert_eq!(nested_fields[2].name, "z");
-            assert_eq!(nested_fields[5].name, "b");
-        }
+        // `draw_triangle_schema_recurses_into_vertex` re-homed with
+        // `DrawTriangle` to `aether_capabilities::render::kinds` (ADR-0121).
     }
 
     // iamacoffeepot/aether#1777 capture-verdict kind roundtrips. The
@@ -3585,149 +3378,6 @@ mod tests {
                 }
                 CaptureFrameResult::Err { .. } => panic!("expected Ok"),
             }
-        }
-    }
-
-    // ADR-0105 textured-quad render-surface kind roundtrips. The request
-    // types carry `Vec<u8>` pixels and a `space` enum carrying nested
-    // arrays; kind codec roundtrip proves the derived Serialize/Deserialize
-    // agree on the wire for each shape.
-    mod render_quad_roundtrips {
-        use super::*;
-        use alloc::string::ToString;
-        use alloc::vec;
-
-        #[test]
-        fn create_texture_request_roundtrip() {
-            let c = CreateTexture {
-                width: 2,
-                height: 2,
-                pixels: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-            };
-            let bytes = c.encode_into_bytes();
-            let back: CreateTexture = CreateTexture::decode_from_bytes(&bytes)
-                .expect("test setup: kind codec decodes CreateTexture");
-            assert_eq!(back.width, 2);
-            assert_eq!(back.height, 2);
-            assert_eq!(back.pixels.len(), 16);
-        }
-
-        #[test]
-        fn create_texture_result_roundtrip_both_arms() {
-            let ok = CreateTextureResult::Ok { texture_id: 7 };
-            let bytes = ok.encode_into_bytes();
-            let back: CreateTextureResult = CreateTextureResult::decode_from_bytes(&bytes)
-                .expect("test setup: kind codec decodes CreateTextureResult::Ok");
-            match back {
-                CreateTextureResult::Ok { texture_id } => assert_eq!(texture_id, 7),
-                CreateTextureResult::Err { .. } => panic!("expected Ok"),
-            }
-
-            let err = CreateTextureResult::Err {
-                error: "pixels length mismatch".to_string(),
-            };
-            let bytes = err.encode_into_bytes();
-            let back: CreateTextureResult = CreateTextureResult::decode_from_bytes(&bytes)
-                .expect("test setup: kind codec decodes CreateTextureResult::Err");
-            match back {
-                CreateTextureResult::Err { error } => assert_eq!(error, "pixels length mismatch"),
-                CreateTextureResult::Ok { .. } => panic!("expected Err"),
-            }
-        }
-
-        #[test]
-        fn update_texture_request_roundtrip() {
-            let u = UpdateTexture {
-                texture_id: 3,
-                x: 4,
-                y: 5,
-                width: 1,
-                height: 1,
-                pixels: vec![9, 8, 7, 6],
-            };
-            let bytes = u.encode_into_bytes();
-            let back: UpdateTexture = UpdateTexture::decode_from_bytes(&bytes)
-                .expect("test setup: kind codec decodes UpdateTexture");
-            assert_eq!(back.texture_id, 3);
-            assert_eq!((back.x, back.y), (4, 5));
-            assert_eq!(back.pixels, vec![9, 8, 7, 6]);
-        }
-
-        #[test]
-        fn draw_textured_quads_screen_roundtrip() {
-            let d = DrawTexturedQuads {
-                texture_id: 1,
-                space: QuadSpace::Screen,
-                quads: vec![TexturedQuad {
-                    x: 10.0,
-                    y: 8.0,
-                    width: 20.0,
-                    height: 16.0,
-                    u0: 0.0,
-                    v0: 0.0,
-                    u1: 1.0,
-                    v1: 1.0,
-                    tint: [1.0, 1.0, 1.0, 1.0],
-                }],
-            };
-            let bytes = d.encode_into_bytes();
-            let back: DrawTexturedQuads = DrawTexturedQuads::decode_from_bytes(&bytes)
-                .expect("test setup: kind codec decodes DrawTexturedQuads");
-            assert_eq!(back.texture_id, 1);
-            assert_eq!(back.space, QuadSpace::Screen);
-            assert_eq!(back.quads.len(), 1);
-            assert_eq!(back.quads[0].width, 20.0);
-            assert_eq!(back.quads[0].tint, [1.0, 1.0, 1.0, 1.0]);
-        }
-
-        #[test]
-        fn draw_textured_quads_world_roundtrip_carries_anchor_and_scale() {
-            let d = DrawTexturedQuads {
-                texture_id: 2,
-                space: QuadSpace::World {
-                    anchor: [1.0, 2.0, 3.0],
-                    scale: QuadScale::Distance {
-                        reference_distance: 5.0,
-                    },
-                },
-                quads: vec![],
-            };
-            let bytes = d.encode_into_bytes();
-            let back: DrawTexturedQuads = DrawTexturedQuads::decode_from_bytes(&bytes)
-                .expect("test setup: kind codec decodes DrawTexturedQuads (World)");
-            match back.space {
-                QuadSpace::World { anchor, scale } => {
-                    assert_eq!(anchor, [1.0, 2.0, 3.0]);
-                    assert_eq!(
-                        scale,
-                        QuadScale::Distance {
-                            reference_distance: 5.0
-                        }
-                    );
-                }
-                QuadSpace::Screen => panic!("expected World"),
-            }
-        }
-
-        #[test]
-        fn draw_solid_quads_screen_roundtrip() {
-            let d = DrawSolidQuads {
-                space: QuadSpace::Screen,
-                quads: vec![SolidQuad {
-                    x: 10.0,
-                    y: 8.0,
-                    width: 20.0,
-                    height: 16.0,
-                    color: [1.0, 0.0, 0.5, 1.0],
-                }],
-            };
-            let bytes = d.encode_into_bytes();
-            let back: DrawSolidQuads = DrawSolidQuads::decode_from_bytes(&bytes)
-                .expect("test setup: kind codec decodes DrawSolidQuads");
-            assert_eq!(back.space, QuadSpace::Screen);
-            assert_eq!(back.quads.len(), 1);
-            assert_eq!(back.quads[0].width, 20.0);
-            assert_eq!(back.quads[0].color, [1.0, 0.0, 0.5, 1.0]);
         }
     }
 

--- a/crates/aether-kit/src/runtime/camera.rs
+++ b/crates/aether-kit/src/runtime/camera.rs
@@ -48,8 +48,9 @@ use std::collections::HashMap;
 use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_capabilities::input::InputMailboxExt;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
+use aether_capabilities::render::Camera;
 use aether_capabilities::{InputCapability, LifecycleCapability, RenderCapability};
-use aether_kinds::{Camera, Render, Tick, WindowSize};
+use aether_kinds::{Render, Tick, WindowSize};
 use aether_math::{Mat4, PI, Quat, TAU, Vec2, Vec3};
 
 use crate::camera::{

--- a/crates/aether-kit/src/runtime/locomotion.rs
+++ b/crates/aether-kit/src/runtime/locomotion.rs
@@ -77,13 +77,11 @@ use std::collections::{BinaryHeap, VecDeque};
 use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_capabilities::input::InputMailboxExt;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
+use aether_capabilities::render::{Camera, DrawTriangle, Vertex};
 use aether_capabilities::{
     InputCapability, LifecycleCapability, RenderCapability, UiBar, UiCapability, UiPanel,
 };
-use aether_kinds::{
-    Camera, DrawTriangle, Key, KeyRelease, MouseButton, MouseMove, Render, Tick, Vertex,
-    WindowSize, keycode,
-};
+use aether_kinds::{Key, KeyRelease, MouseButton, MouseMove, Render, Tick, WindowSize, keycode};
 use aether_math::{Mat4, Vec3};
 
 use crate::arena::{Arena, HH, HW, SUB, ShapeClass};

--- a/crates/aether-labyrinth/src/kinds.rs
+++ b/crates/aether-labyrinth/src/kinds.rs
@@ -152,7 +152,7 @@ pub struct ReachabilityMargin {
 // the graph stays orders of magnitude smaller than `V`, and components
 // are re-derivable from `V` + `B` + the [`MovementStencil`] (all
 // content-addressed) rather than stored as per-tick label images.
-// `Vec`-bearing like [`aether_kinds::DrawTexturedQuads`].
+// `Vec`-bearing like the render cap's `DrawTexturedQuads`.
 
 /// One node in a [`CorridorGraph`] — a single connected component of
 /// the affordable set `{cell : V(cell, tick) <= budget}` at one tick.
@@ -235,8 +235,8 @@ pub struct CorridorGraph {
 /// derives `Schema`, the same way [`aether_kinds::Mat4Apply`] embeds the
 /// top-level Kind `Vec4`. Each log replays one moving point's tick-
 /// ordered path; the aggregation snaps every sample to its corridor
-/// component and accumulates per-edge traffic. `Vec`-bearing like
-/// [`aether_kinds::DrawTexturedQuads`].
+/// component and accumulates per-edge traffic. `Vec`-bearing like the
+/// render cap's `DrawTexturedQuads`.
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.corridor.trajectory_set")]
 pub struct TrajectorySet {

--- a/crates/aether-mesh-viewer/src/runtime.rs
+++ b/crates/aether-mesh-viewer/src/runtime.rs
@@ -37,11 +37,10 @@ use aether_actor::{
 };
 use aether_capabilities::fs::FsMailboxExt;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
+use aether_capabilities::render::{DrawTriangle, Vertex};
 use aether_capabilities::{FsCapability, LifecycleCapability, RenderCapability};
 use aether_data::Kind;
-use aether_kinds::{
-    DrawTriangle, MeshLoadResult, ReadResult, Render, TrajectorySampleEntry, Vertex,
-};
+use aether_kinds::{MeshLoadResult, ReadResult, Render, TrajectorySampleEntry};
 use aether_labyrinth::{CorridorGraph, EdgeKind, ScalarField, TrajectorySet};
 use aether_math::Vec3;
 use aether_mesh::{Point3, Polygon, tessellate_polygon};

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -32,18 +32,20 @@
 
 use std::path::Path;
 
+use aether_capabilities::render::{
+    Camera, CreateTexture, CreateTextureResult, DrawSolidQuads, DrawTexturedQuads, SolidQuad,
+    TexturedQuad,
+};
 use aether_capabilities::text::{
     DrawText, FontMetricsRequest, FontMetricsResult, FontRef, LoadFont, LoadFontResult,
 };
 use aether_capabilities::{UiBar, UiPanel};
 use aether_data::{Kind, MailboxId};
 use aether_kinds::{
-    CachedFontMetrics, Camera, CaptureFrame, CaptureFrameResult, CreateTexture,
-    CreateTextureResult, Delete, DeleteResult, DrawSolidQuads, DrawTexturedQuads, DropComponent,
+    CachedFontMetrics, CaptureFrame, CaptureFrameResult, Delete, DeleteResult, DropComponent,
     DropResult, FrameCheck, FrameCheckResult, FrameReduction, FsError, List, ListComponents,
     ListComponentsResult, ListResult, LoadComponent, LoadResult, NamedMail, Ping, QuadScale,
-    QuadSpace, Read, ReadResult, ReplaceComponent, ReplaceResult, SolidQuad, TexturedQuad, Write,
-    WriteResult,
+    QuadSpace, Read, ReadResult, ReplaceComponent, ReplaceResult, Write, WriteResult,
 };
 use aether_math::{Mat4, Vec3};
 use aether_substrate_bundle::test_bench::{

--- a/crates/aether-test-fixtures/bundle/src/cube.rs
+++ b/crates/aether-test-fixtures/bundle/src/cube.rs
@@ -31,8 +31,9 @@ use core::f32::consts::FRAC_PI_4;
 
 use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
+use aether_capabilities::render::{Camera, DrawTriangle, Vertex};
 use aether_capabilities::{LifecycleCapability, RenderCapability};
-use aether_kinds::{Camera, DrawTriangle, Tick, Vertex};
+use aether_kinds::Tick;
 use aether_math::{Mat4, Vec3};
 
 /// Half-extent of the unit cube: corners sit at ±`HALF` on every axis,

--- a/crates/aether-test-fixtures/bundle/src/probe.rs
+++ b/crates/aether-test-fixtures/bundle/src/probe.rs
@@ -63,8 +63,9 @@ use aether_actor::{
 };
 use aether_capabilities::input::InputMailboxExt;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
+use aether_capabilities::render::{DrawTriangle, Vertex};
 use aether_capabilities::{InputCapability, LifecycleCapability, RenderCapability};
-use aether_kinds::{DrawTriangle, Key, Tick, Vertex};
+use aether_kinds::{Key, Tick};
 use aether_test_fixtures_kinds::{
     ConfigEcho, ConfigQuery, KeyObserved, ProbeConfig, SetRender, TEST_BENCH_OBSERVER_MAILBOX_NAME,
     TickObserved,

--- a/crates/aether-test-fixtures/bundle/src/ui_widget.rs
+++ b/crates/aether-test-fixtures/bundle/src/ui_widget.rs
@@ -25,8 +25,9 @@
 
 use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
+use aether_capabilities::render::{DrawSolidQuads, SolidQuad};
 use aether_capabilities::{LifecycleCapability, RenderCapability};
-use aether_kinds::{DrawSolidQuads, QuadSpace, SolidQuad, Tick};
+use aether_kinds::{QuadSpace, Tick};
 use aether_test_fixtures_kinds::UiWidgetConfig;
 
 pub struct UiWidget {


### PR DESCRIPTION
Closes #2170.

## Summary

Part of the ADR-0121 capabilities-own-their-kinds refactor (one capability = one PR). The `render` capability becomes a directory submodule that owns its drawing kinds.

`render.rs` (~1844 lines) splits into `render/{mod,pipeline,texture,quad,capture,kinds}`. The drawing kinds — `DrawTriangle`/`Vertex`/`DRAW_TRIANGLE_BYTES`, `Camera`, `CreateTexture`/`CreateTextureResult`, `UpdateTexture`, `TexturedQuad`/`DrawTexturedQuads`, `SolidQuad`/`DrawSolidQuads` — move out of `aether-kinds` into `render/kinds.rs`.

`QuadSpace`/`QuadScale` stay central: `aether-kinds`'s own `aether.text.draw` (`DrawText`) consumes `QuadSpace`, so moving it would close an `aether-kinds → aether-capabilities` cycle. They are sibling-kind-consumed and pinned central exactly like `NamedMail`/`FrameCheck`/`Mat4Apply`; the moved quad-draw kinds import them back from `aether-kinds`. Kind names — and wire ids — are unchanged.

## Test plan

- The relocated codec / name-stability / schema tests for the moved drawing kinds run from `render/kinds.rs`; the texture-registry tests run from `render/texture.rs`.
- `cargo fmt -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace` (2029 passed, 9 skipped), `cargo doc --workspace --no-deps`, and the wasm32 cross-builds all pass.

## Generated by

`/implement` — agent execution of [scoped issue #2170](https://github.com/iamacoffeepot/aether/issues/2170).
