### PR TITLE
refactor(capabilities): make engine own its kinds and split server and proxy

### DIFF
--- a/crates/aether-capabilities/src/engine/kinds.rs
+++ b/crates/aether-capabilities/src/engine/kinds.rs
@@ -1,0 +1,158 @@
+//! `aether.engine.*` mail kinds the engine capability owns (ADR-0121).
+//!
+//! The engine-internal control-plane vocabulary — proxy forwarding
+//! (`ForwardEnvelope` / `RouteEnvelope`), call settlement (`CallSettled`),
+//! and fleet liveness (`EngineHeartbeatTick` / `EngineDied` /
+//! `EngineAlive`). Each is consumed only inside `aether-capabilities` and
+//! embedded in no kind that stays in `aether-kinds`, so the engine cap
+//! owns it here (capabilities → kinds is the allowed dependency
+//! direction; the embedded `DeathReason` re-imports back from
+//! `aether_kinds`).
+//!
+//! The engine cap's request / result / descriptor kinds
+//! (`SpawnEngine`, `ListEngines`, `TerminateEngine`, the upload / resolve
+//! families, and their support descriptors) stay in `aether-kinds`: they
+//! are the MCP harness's RPC protocol, and `aether-mcp` consumes them
+//! while being barred from depending on `aether-capabilities`.
+
+use aether_kinds::DeathReason;
+use serde::{Deserialize, Serialize};
+
+/// `aether.engine.forward` — hand a per-engine proxy
+/// (`aether.engine.proxy:<id>`) one mail to relay to its substrate
+/// over the proxy's outbound RPC connection. Issue 763 P3.
+///
+/// Carries the *remote* target explicitly: a plain mail to the
+/// proxy is only `kind` + `payload` — it can't say *which mailbox
+/// on the substrate* to deliver to. `ForwardEnvelope` is that
+/// carrier. The proxy wraps `mailbox` + `kind` + the already-encoded
+/// `payload` into an RPC `Call`; the substrate's
+/// `RpcServerCapability` dispatches it into its local actor system.
+/// Any reply streams back through the proxy and routes to whoever
+/// sent this `ForwardEnvelope` — the proxy keys reply correlation
+/// off the inbound mail's `Source`.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.engine.forward")]
+pub struct ForwardEnvelope {
+    pub mailbox: aether_data::MailboxId,
+    pub kind: aether_data::KindId,
+    pub payload: Vec<u8>,
+}
+
+/// `aether.engine.route` — ask the engines cap (`aether.engine`) to
+/// relay one mail to a *specific* engine's substrate. Issue 763 P5a.
+///
+/// The engine-addressed sibling of [`ForwardEnvelope`]: where
+/// `ForwardEnvelope` already names a proxy and only needs the
+/// substrate-local `mailbox` + `kind` + `payload`, `RouteEnvelope`
+/// also carries the `engine_id`, because the sender (the hub's
+/// `RpcServerCapability`, relaying an `engine = Some(_)` wire
+/// `Call`) doesn't know which proxy hosts that engine. The engines
+/// cap looks the engine up in its table and re-emits a
+/// `ForwardEnvelope` at the right `aether.engine.proxy:<id>`,
+/// propagating the original reply-to so the substrate's reply
+/// streams back to the originating `RpcServerCapability`.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.engine.route")]
+pub struct RouteEnvelope {
+    pub engine_id: String,
+    pub mailbox: aether_data::MailboxId,
+    pub kind: aether_data::KindId,
+    pub payload: Vec<u8>,
+}
+
+/// `aether.engine.call_settled` — a per-engine proxy's signal that
+/// a forwarded RPC call has run to completion. Issue 763 P5a.
+///
+/// When the proxy relays a [`ForwardEnvelope`] as an RPC `Call`,
+/// the substrate eventually answers with a wire `ReplyEnd`. The
+/// proxy lifts that terminal frame into this kind and pushes it
+/// back to whoever opened the call (correlation preserved) — the
+/// hub's `RpcServerCapability` matches it to the in-flight wire
+/// call and writes its own `ReplyEnd` to the RPC client. (Local,
+/// non-forwarded calls close on chassis settlement instead; a
+/// forwarded call has no local chain to settle, so it needs this
+/// explicit terminal signal.) `Err` carries the wire `RpcError`
+/// rendered as a string — the structured variant doesn't survive
+/// the `aether-kinds` layer, which can't depend on the RPC crate.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.engine.call_settled")]
+pub enum CallSettled {
+    Ok,
+    Err { error: String },
+}
+
+/// `aether.engine.heartbeat_tick` — the per-engine proxy's own
+/// liveness timer wake (issue 1339). Internal control-plane mail,
+/// not a user surface: a sidecar thread the proxy spawns at init
+/// fires this (empty-payload) at the proxy's own mailbox every
+/// heartbeat interval, the same wake-mail shape `RpcInboundReady`
+/// uses for the reader sidecar. The handler pings the substrate and
+/// counts consecutive misses, evicting the engine once the miss
+/// limit is crossed.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default)]
+#[kind(name = "aether.engine.heartbeat_tick")]
+pub struct EngineHeartbeatTick {}
+
+/// `aether.engine.died` — a per-engine proxy telling the engines
+/// cap (`aether.engine`) that its substrate is gone, so the cap
+/// drops it from the supervised-engine table (issue 1339). The
+/// proxy sends this when it observes the connection close (`Bye` /
+/// `eof`) or when the liveness heartbeat crosses its miss limit —
+/// the positive signal the lazy connection-drop path misses for a
+/// wedged-but-alive engine. Idempotent on the cap side: a `died`
+/// for an already-removed engine (e.g. one a concurrent
+/// `TerminateEngine` already dropped) is a no-op. `engine_id` is
+/// the plain UUID string, matching `TerminateEngine`.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.engine.died")]
+pub struct EngineDied {
+    pub engine_id: String,
+    /// Why the proxy is reporting the death, so the cap can record it
+    /// into its recently-died ring: `Crashed` for a connection-close
+    /// (`Bye` / eof), `Evicted` for a heartbeat miss-limit crossing. A
+    /// deliberate terminate never sends `EngineDied` — the cap records
+    /// `Terminated` itself at the removal site.
+    pub reason: DeathReason,
+}
+
+/// `aether.engine.alive` — a per-engine proxy reporting a confirmed
+/// liveness signal (a `Pong` answering its heartbeat `Ping`) to the
+/// engines cap (issue 1339). The cap stamps the engine's
+/// last-seen-alive time so `ListEnginesResult` can report
+/// `last_heartbeat_age_millis`. Fire-and-forget; an `alive` for an
+/// unknown engine is a no-op. `engine_id` is the plain UUID string.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.engine.alive")]
+pub struct EngineAlive {
+    pub engine_id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_data::Kind;
+
+    #[test]
+    fn engine_died_carries_death_reason() {
+        // `EngineDied` gained a `reason` field — the proxy's self-death
+        // paths tag the cause (`Crashed` for a `Bye`, `Evicted` for a
+        // heartbeat miss). Both the id and the tagged reason must survive
+        // the structured encode/decode the proxy → cap mail rides.
+        let died = EngineDied {
+            engine_id: "00000000-0000-0000-0000-000000000001".to_string(),
+            reason: DeathReason::Crashed {
+                detail: "peer closed: eof".to_string(),
+            },
+        };
+        let back = EngineDied::decode_from_bytes(&died.encode_into_bytes())
+            .expect("test setup: EngineDied decodes");
+        assert_eq!(back.engine_id, died.engine_id);
+        assert_eq!(
+            back.reason,
+            DeathReason::Crashed {
+                detail: "peer closed: eof".to_string(),
+            },
+        );
+    }
+}

--- a/crates/aether-capabilities/src/engine/mod.rs
+++ b/crates/aether-capabilities/src/engine/mod.rs
@@ -9,9 +9,13 @@
 //!
 //! See issue 763 for the full design.
 
+pub mod kinds;
 pub mod proxy;
 pub mod server;
 
+pub use kinds::{
+    CallSettled, EngineAlive, EngineDied, EngineHeartbeatTick, ForwardEnvelope, RouteEnvelope,
+};
 pub use proxy::EngineProxy;
 #[cfg(not(target_arch = "wasm32"))]
 pub use proxy::EngineProxyConfig;

--- a/crates/aether-capabilities/src/engine/proxy/config.rs
+++ b/crates/aether-capabilities/src/engine/proxy/config.rs
@@ -1,0 +1,55 @@
+//! Init config for the per-engine proxy (ADR-0090). `EngineProxyConfig`
+//! is handed in by the engines cap at `spawn_child`; `HeartbeatParams`
+//! is the liveness tuning the cap resolved from its `EngineConfig`.
+//! Native-only: the config owns a `std::process::Child` handle.
+
+use aether_data::EngineId;
+use std::process::Child;
+use std::time::Duration;
+
+/// Init config for `EngineProxy`. `engine_id` is the proxy's
+/// engine identity (also the per-instance subname — full address
+/// `aether.engine.proxy:<engine_id>`); `rpc_addr` is the
+/// substrate's `RpcServerCapability` bind address the proxy dials
+/// at init.
+///
+/// `spawned` is `Some` when the engines cap (`aether.engine`)
+/// fork+exec'd the substrate and handed its child handle here —
+/// the proxy then owns that process: it retries the startup dial
+/// (the substrate may not have bound its port yet), kills it on a
+/// failed boot, and SIGKILLs + reaps it on `Drop`. `None` for an
+/// adopted / externally-running substrate, whose lifetime the
+/// proxy doesn't manage.
+///
+/// `heartbeat` is the liveness-probe tuning the cap resolved from
+/// its [`EngineConfig`](crate::engine::server) (issue 1339). `None`
+/// disables the heartbeat (the engine is then only evicted on a
+/// connection-close `Bye`, never on a wedge); `Some` arms the
+/// timer sidecar.
+///
+/// `connect_budget` is the total time the startup dial keeps
+/// retrying a refused connection while a freshly-forked substrate
+/// comes up, resolved from the cap's `EngineConfig`. `Some(d)` caps
+/// the retry at `d`; `None` is the wait-forever sentinel (retry
+/// until the dial succeeds or hits a terminal error). Only consulted
+/// when the proxy forked the substrate (`spawned.is_some()`) — an
+/// adopted substrate is dialed once.
+pub struct EngineProxyConfig {
+    pub engine_id: EngineId,
+    pub rpc_addr: String,
+    pub spawned: Option<Child>,
+    pub heartbeat: Option<HeartbeatParams>,
+    pub connect_budget: Option<Duration>,
+}
+
+/// Resolved liveness-heartbeat tuning for one proxy (issue 1339).
+/// `interval` is the ping cadence; `miss_limit` is how many
+/// consecutive unanswered pings mark the engine dead — a small N
+/// tolerates a transient hiccup without flapping. Detection latency
+/// is `miss_limit × interval`. Built by the engines cap from its
+/// `EngineConfig` and handed down via [`EngineProxyConfig`].
+#[derive(Clone, Copy, Debug)]
+pub struct HeartbeatParams {
+    pub interval: Duration,
+    pub miss_limit: u32,
+}

--- a/crates/aether-capabilities/src/engine/proxy/connect.rs
+++ b/crates/aether-capabilities/src/engine/proxy/connect.rs
@@ -1,0 +1,83 @@
+//! Startup-dial bring-up for the per-engine proxy: dial the substrate's
+//! `RpcServerCapability`, retrying a refused connection while a
+//! freshly-forked substrate comes up. Native-only (owns the outbound
+//! `RpcConnection`).
+
+use crate::rpc::{PeerKind, RpcClient, RpcClientError, RpcConnection};
+use aether_data::{Kind, KindId, MailboxId};
+use aether_kinds::RpcInboundReady;
+use aether_substrate::Mail;
+use aether_substrate::mail::mailer::Mailer;
+use std::io::ErrorKind;
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Pause between dial attempts within the connect budget.
+const PROXY_CONNECT_RETRY_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Dial the substrate's `RpcServerCapability`, building a fresh
+/// `on_frame` wake closure per attempt. When `retry` is set, a
+/// connection-refused / reset error is retried (after a short
+/// pause) until the connect `budget` elapses — a freshly-forked
+/// substrate may not have bound its port yet. `budget` of `None` is
+/// the wait-forever sentinel: retry until the dial succeeds or hits
+/// a terminal error. Handshake / frame errors are always terminal:
+/// the peer answered, just wrongly.
+pub(super) fn connect_proxy(
+    addr: &str,
+    mailer: &Arc<Mailer>,
+    self_mailbox: MailboxId,
+    wake_kind: KindId,
+    retry: bool,
+    budget: Option<Duration>,
+) -> Result<RpcConnection, RpcClientError> {
+    // `None` budget → no deadline (wait forever); `Some(d)` → stop
+    // retrying once `d` has elapsed.
+    let deadline = budget.map(|d| Instant::now() + d);
+    loop {
+        // The reader sidecar fires `RpcInboundReady` at the proxy's
+        // own mailbox after every inbound frame so
+        // `on_inbound_ready` drains `conn.inbound` on the
+        // dispatcher thread. `RpcClient::connect` consumes the
+        // closure, so a retry needs a fresh one.
+        let wake_mailer = Arc::clone(mailer);
+        let on_frame = move || {
+            wake_mailer.push(Mail::new(
+                self_mailbox,
+                wake_kind,
+                RpcInboundReady::default().encode_into_bytes(),
+                1,
+            ));
+        };
+        return match RpcClient::connect(
+            addr,
+            PeerKind::Client {
+                client_name: "aether.engine.proxy".to_owned(),
+                client_version: env!("CARGO_PKG_VERSION").to_owned(),
+            },
+            on_frame,
+        ) {
+            Ok(conn) => Ok(conn),
+            Err(e) => {
+                let within_budget = deadline.is_none_or(|d| Instant::now() < d);
+                if retry && is_transient_connect_error(&e) && within_budget {
+                    thread::sleep(PROXY_CONNECT_RETRY_INTERVAL);
+                    continue;
+                }
+                Err(e)
+            }
+        };
+    }
+}
+
+/// `true` for the connection-level errors a still-coming-up
+/// substrate produces — worth retrying. Handshake / frame errors
+/// mean the peer answered wrongly: terminal, never retried.
+fn is_transient_connect_error(e: &RpcClientError) -> bool {
+    matches!(
+        e,
+        RpcClientError::Connect(io)
+            if matches!(io.kind(), ErrorKind::ConnectionRefused | ErrorKind::ConnectionReset)
+    )
+}

--- a/crates/aether-capabilities/src/engine/proxy/heartbeat.rs
+++ b/crates/aether-capabilities/src/engine/proxy/heartbeat.rs
@@ -1,0 +1,77 @@
+//! The per-proxy liveness-heartbeat timer sidecar (issue 1339): a
+//! thread that fires an `EngineHeartbeatTick` wake-mail at the proxy's
+//! own mailbox each interval, plus the RAII handle that stops + joins it
+//! on drop. Native-only (owns an OS thread + channel).
+
+use crate::engine::kinds::EngineHeartbeatTick;
+use aether_data::{Kind, KindId, MailboxId};
+use aether_substrate::Mail;
+use aether_substrate::mail::mailer::Mailer;
+use std::sync::Arc;
+use std::sync::mpsc;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+/// Owns the per-proxy heartbeat timer thread (issue 1339). The
+/// thread sleeps `interval` on a `recv_timeout` over the stop
+/// channel and fires an [`EngineHeartbeatTick`] wake-mail at the
+/// proxy's own mailbox each interval — the same sidecar-wake shape
+/// the RPC reader uses. `Drop` disconnects the channel (so the
+/// thread's `recv_timeout` returns `Disconnected` and it breaks)
+/// then joins, mirroring `RpcReaderHandle`'s orderly teardown.
+pub(super) struct HeartbeatHandle {
+    stop: Option<mpsc::Sender<()>>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl Drop for HeartbeatHandle {
+    fn drop(&mut self) {
+        // Dropping the sender disconnects the channel; the thread's
+        // next `recv_timeout` returns `Disconnected` and it exits.
+        drop(self.stop.take());
+        if let Some(t) = self.thread.take() {
+            let _ = t.join();
+        }
+    }
+}
+
+/// Spawn the per-proxy heartbeat timer thread. It sleeps `interval`
+/// on a `recv_timeout` over the returned handle's stop channel and
+/// pushes an [`EngineHeartbeatTick`] wake-mail at `self_mailbox`
+/// each interval — the empty-payload wake shape the RPC reader
+/// sidecar uses (the timer carries no data, only the schedule). The
+/// handle's `Drop` stops + joins the thread.
+pub(super) fn spawn_heartbeat(
+    mailer: Arc<Mailer>,
+    self_mailbox: MailboxId,
+    interval: Duration,
+) -> HeartbeatHandle {
+    let (stop_tx, stop_rx) = mpsc::channel::<()>();
+    let tick_kind = KindId(<EngineHeartbeatTick as Kind>::ID.0);
+    // Infra timer thread below the mail layer — like the RPC reader
+    // sidecar it only fires a wake-mail (no inbound chain to inherit,
+    // so no settlement umbrella to honor), and the proxy is instanced
+    // so `spawn_detached` (Singleton-only) doesn't apply.
+    #[allow(clippy::disallowed_methods)]
+    let thread = thread::Builder::new()
+        .name("aether-engine-heartbeat".into())
+        .spawn(move || {
+            // `recv_timeout` returns `Timeout` each interval (fire a
+            // tick); a stop signal or a disconnected channel (the
+            // proxy dropped the sender) returns otherwise and ends
+            // the loop.
+            while stop_rx.recv_timeout(interval) == Err(mpsc::RecvTimeoutError::Timeout) {
+                mailer.push(Mail::new(
+                    self_mailbox,
+                    tick_kind,
+                    EngineHeartbeatTick::default().encode_into_bytes(),
+                    1,
+                ));
+            }
+        })
+        .expect("spawn aether-engine-heartbeat thread");
+    HeartbeatHandle {
+        stop: Some(stop_tx),
+        thread: Some(thread),
+    }
+}

--- a/crates/aether-capabilities/src/engine/proxy/mod.rs
+++ b/crates/aether-capabilities/src/engine/proxy/mod.rs
@@ -37,37 +37,50 @@
 // Handler-signature kinds must be importable at file root — the
 // `#[bridge]` macro emits `impl HandlesKind<K>` markers as siblings of
 // the mod.
-use aether_kinds::{EngineHeartbeatTick, ForwardEnvelope, RpcInboundReady, TerminateEngine};
+use crate::engine::kinds::{EngineHeartbeatTick, ForwardEnvelope};
+use aether_kinds::{RpcInboundReady, TerminateEngine};
+
+// The proxy's implementation, split along its seams (ADR-0121):
+// `config` (the init config + heartbeat tuning), `connect` (the
+// startup-dial bring-up), `heartbeat` (the liveness-timer sidecar), and
+// `sinks` (the test-only capture actors). All are native-only — the
+// proxy owns a `TcpStream` and OS threads — so they elide on wasm
+// alongside the bridge mod.
+#[cfg(not(target_arch = "wasm32"))]
+mod config;
+#[cfg(not(target_arch = "wasm32"))]
+mod connect;
+#[cfg(not(target_arch = "wasm32"))]
+mod heartbeat;
+#[cfg(test)]
+mod sinks;
 
 // `EngineProxyConfig` / `HeartbeatParams` carry only wasm-safe types,
-// but they live inside the bridge mod (which the macro elides on wasm),
-// so the re-export is gated like `TcpListenerConfig`.
+// but the proxy that consumes them is native-only, so the re-export is
+// gated like `TcpListenerConfig`.
 #[cfg(not(target_arch = "wasm32"))]
-pub use proxy_native::{EngineProxyConfig, HeartbeatParams};
+pub use config::{EngineProxyConfig, HeartbeatParams};
 
 #[aether_actor::bridge(instanced, one_per = "engine")]
 mod proxy_native {
+    use super::config::EngineProxyConfig;
+    use super::connect::connect_proxy;
+    use super::heartbeat::{HeartbeatHandle, spawn_heartbeat};
     use super::{EngineHeartbeatTick, ForwardEnvelope, RpcInboundReady, TerminateEngine};
     use crate::engine::EngineServer;
-    use crate::rpc::{
-        MailEnvelope, MailboxAddress, PeerKind, RpcClient, RpcClientError, RpcConnection, RpcError,
-        WireFrame,
-    };
+    use crate::engine::kinds::{CallSettled, EngineAlive, EngineDied};
+    use crate::rpc::{MailEnvelope, MailboxAddress, RpcConnection, RpcError, WireFrame};
     use aether_actor::{Addressable, actor};
     use aether_data::{EngineId, Kind, KindId, MailboxId, mailbox_id_from_name};
-    use aether_kinds::{CallSettled, DeathReason, EngineAlive, EngineDied};
+    use aether_kinds::DeathReason;
     use aether_substrate::Mail;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
     use aether_substrate::mail::mailer::Mailer;
     use aether_substrate::mail::{Source, SourceAddr};
     use std::collections::HashMap;
-    use std::io::ErrorKind;
     use std::process::Child;
     use std::sync::Arc;
-    use std::sync::mpsc;
-    use std::thread::{self, JoinHandle};
-    use std::time::{Duration, Instant};
 
     /// Mailbox of the engines cap (`aether.engine`) — where a proxy
     /// reports its own liveness transitions (`EngineAlive` / `EngineDied`,
@@ -80,79 +93,6 @@ mod proxy_native {
     #[allow(clippy::disallowed_methods)]
     fn engine_cap_mailbox() -> MailboxId {
         mailbox_id_from_name(<EngineServer as Addressable>::NAMESPACE)
-    }
-
-    /// Pause between dial attempts within the connect budget.
-    const PROXY_CONNECT_RETRY_INTERVAL: Duration = Duration::from_millis(50);
-
-    /// Init config for [`EngineProxy`]. `engine_id` is the proxy's
-    /// engine identity (also the per-instance subname — full address
-    /// `aether.engine.proxy:<engine_id>`); `rpc_addr` is the
-    /// substrate's `RpcServerCapability` bind address the proxy dials
-    /// at init.
-    ///
-    /// `spawned` is `Some` when the engines cap (`aether.engine`)
-    /// fork+exec'd the substrate and handed its child handle here —
-    /// the proxy then owns that process: it retries the startup dial
-    /// (the substrate may not have bound its port yet), kills it on a
-    /// failed boot, and SIGKILLs + reaps it on `Drop`. `None` for an
-    /// adopted / externally-running substrate, whose lifetime the
-    /// proxy doesn't manage.
-    ///
-    /// `heartbeat` is the liveness-probe tuning the cap resolved from
-    /// its [`EngineConfig`](crate::engine::server) (issue 1339). `None`
-    /// disables the heartbeat (the engine is then only evicted on a
-    /// connection-close `Bye`, never on a wedge); `Some` arms the
-    /// timer sidecar.
-    ///
-    /// `connect_budget` is the total time the startup dial keeps
-    /// retrying a refused connection while a freshly-forked substrate
-    /// comes up, resolved from the cap's `EngineConfig`. `Some(d)` caps
-    /// the retry at `d`; `None` is the wait-forever sentinel (retry
-    /// until the dial succeeds or hits a terminal error). Only consulted
-    /// when the proxy forked the substrate (`spawned.is_some()`) — an
-    /// adopted substrate is dialed once.
-    pub struct EngineProxyConfig {
-        pub engine_id: EngineId,
-        pub rpc_addr: String,
-        pub spawned: Option<Child>,
-        pub heartbeat: Option<HeartbeatParams>,
-        pub connect_budget: Option<Duration>,
-    }
-
-    /// Resolved liveness-heartbeat tuning for one proxy (issue 1339).
-    /// `interval` is the ping cadence; `miss_limit` is how many
-    /// consecutive unanswered pings mark the engine dead — a small N
-    /// tolerates a transient hiccup without flapping. Detection latency
-    /// is `miss_limit × interval`. Built by the engines cap from its
-    /// `EngineConfig` and handed down via [`EngineProxyConfig`].
-    #[derive(Clone, Copy, Debug)]
-    pub struct HeartbeatParams {
-        pub interval: Duration,
-        pub miss_limit: u32,
-    }
-
-    /// Owns the per-proxy heartbeat timer thread (issue 1339). The
-    /// thread sleeps `interval` on a `recv_timeout` over the stop
-    /// channel and fires an [`EngineHeartbeatTick`] wake-mail at the
-    /// proxy's own mailbox each interval — the same sidecar-wake shape
-    /// the RPC reader uses. `Drop` disconnects the channel (so the
-    /// thread's `recv_timeout` returns `Disconnected` and it breaks)
-    /// then joins, mirroring `RpcReaderHandle`'s orderly teardown.
-    struct HeartbeatHandle {
-        stop: Option<mpsc::Sender<()>>,
-        thread: Option<JoinHandle<()>>,
-    }
-
-    impl Drop for HeartbeatHandle {
-        fn drop(&mut self) {
-            // Dropping the sender disconnects the channel; the thread's
-            // next `recv_timeout` returns `Disconnected` and it exits.
-            drop(self.stop.take());
-            if let Some(t) = self.thread.take() {
-                let _ = t.join();
-            }
-        }
     }
 
     /// Per-engine proxy: one outbound RPC connection to one substrate,
@@ -429,113 +369,6 @@ mod proxy_native {
         }
     }
 
-    /// Spawn the per-proxy heartbeat timer thread. It sleeps `interval`
-    /// on a `recv_timeout` over the returned handle's stop channel and
-    /// pushes an [`EngineHeartbeatTick`] wake-mail at `self_mailbox`
-    /// each interval — the empty-payload wake shape the RPC reader
-    /// sidecar uses (the timer carries no data, only the schedule). The
-    /// handle's `Drop` stops + joins the thread.
-    fn spawn_heartbeat(
-        mailer: Arc<Mailer>,
-        self_mailbox: MailboxId,
-        interval: Duration,
-    ) -> HeartbeatHandle {
-        let (stop_tx, stop_rx) = mpsc::channel::<()>();
-        let tick_kind = KindId(<EngineHeartbeatTick as Kind>::ID.0);
-        // Infra timer thread below the mail layer — like the RPC reader
-        // sidecar it only fires a wake-mail (no inbound chain to inherit,
-        // so no settlement umbrella to honor), and the proxy is instanced
-        // so `spawn_detached` (Singleton-only) doesn't apply.
-        #[allow(clippy::disallowed_methods)]
-        let thread = thread::Builder::new()
-            .name("aether-engine-heartbeat".into())
-            .spawn(move || {
-                // `recv_timeout` returns `Timeout` each interval (fire a
-                // tick); a stop signal or a disconnected channel (the
-                // proxy dropped the sender) returns otherwise and ends
-                // the loop.
-                while stop_rx.recv_timeout(interval) == Err(mpsc::RecvTimeoutError::Timeout) {
-                    mailer.push(Mail::new(
-                        self_mailbox,
-                        tick_kind,
-                        EngineHeartbeatTick::default().encode_into_bytes(),
-                        1,
-                    ));
-                }
-            })
-            .expect("spawn aether-engine-heartbeat thread");
-        HeartbeatHandle {
-            stop: Some(stop_tx),
-            thread: Some(thread),
-        }
-    }
-
-    /// Dial the substrate's `RpcServerCapability`, building a fresh
-    /// `on_frame` wake closure per attempt. When `retry` is set, a
-    /// connection-refused / reset error is retried (after a short
-    /// pause) until the connect `budget` elapses — a freshly-forked
-    /// substrate may not have bound its port yet. `budget` of `None` is
-    /// the wait-forever sentinel: retry until the dial succeeds or hits
-    /// a terminal error. Handshake / frame errors are always terminal:
-    /// the peer answered, just wrongly.
-    fn connect_proxy(
-        addr: &str,
-        mailer: &Arc<Mailer>,
-        self_mailbox: MailboxId,
-        wake_kind: KindId,
-        retry: bool,
-        budget: Option<Duration>,
-    ) -> Result<RpcConnection, RpcClientError> {
-        // `None` budget → no deadline (wait forever); `Some(d)` → stop
-        // retrying once `d` has elapsed.
-        let deadline = budget.map(|d| Instant::now() + d);
-        loop {
-            // The reader sidecar fires `RpcInboundReady` at the proxy's
-            // own mailbox after every inbound frame so
-            // `on_inbound_ready` drains `conn.inbound` on the
-            // dispatcher thread. `RpcClient::connect` consumes the
-            // closure, so a retry needs a fresh one.
-            let wake_mailer = Arc::clone(mailer);
-            let on_frame = move || {
-                wake_mailer.push(Mail::new(
-                    self_mailbox,
-                    wake_kind,
-                    RpcInboundReady::default().encode_into_bytes(),
-                    1,
-                ));
-            };
-            return match RpcClient::connect(
-                addr,
-                PeerKind::Client {
-                    client_name: "aether.engine.proxy".to_owned(),
-                    client_version: env!("CARGO_PKG_VERSION").to_owned(),
-                },
-                on_frame,
-            ) {
-                Ok(conn) => Ok(conn),
-                Err(e) => {
-                    let within_budget = deadline.is_none_or(|d| Instant::now() < d);
-                    if retry && is_transient_connect_error(&e) && within_budget {
-                        thread::sleep(PROXY_CONNECT_RETRY_INTERVAL);
-                        continue;
-                    }
-                    Err(e)
-                }
-            };
-        }
-    }
-
-    /// `true` for the connection-level errors a still-coming-up
-    /// substrate produces — worth retrying. Handshake / frame errors
-    /// mean the peer answered wrongly: terminal, never retried.
-    fn is_transient_connect_error(e: &RpcClientError) -> bool {
-        matches!(
-            e,
-            RpcClientError::Connect(io)
-                if matches!(io.kind(), ErrorKind::ConnectionRefused | ErrorKind::ConnectionReset)
-        )
-    }
-
     impl Drop for EngineProxy {
         /// SIGKILL + reap the child substrate this proxy forked, so a
         /// terminated proxy (or a chassis teardown) never orphans a
@@ -661,112 +494,9 @@ mod proxy_native {
 }
 
 #[cfg(test)]
-use crate::rpc::test_echo::TestEchoReply;
-// Handler-signature kinds for the test sink below — must be importable
-// at file root so the `#[bridge]` macro's `HandlesKind` markers stay
-// addressable, the same constraint as the proxy's own handler kinds.
+use aether_kinds::DeathReason;
 #[cfg(test)]
-use aether_kinds::{DeathReason, EngineAlive, EngineDied};
-#[cfg(test)]
-use std::sync::{Arc, Mutex};
-
-/// Shared capture cells for [`EngineCapSink`]. Lives at file root (not
-/// inside the bridge mod) like `EngineServer`'s `ReplyCells` — it's the
-/// sink actor's `Config`, so it must be addressable as `super::…` from
-/// the bridge mod. `died` keeps the whole [`EngineDied`] (id + reason) so
-/// the death-path tests can assert the surfaced cause.
-#[cfg(test)]
-#[derive(Clone, Default)]
-pub struct EngineCapCells {
-    pub alive: Arc<Mutex<Vec<String>>>,
-    pub died: Arc<Mutex<Vec<EngineDied>>>,
-}
-
-/// Test-only stand-in for the engines cap, registered at the cap's own
-/// `aether.engine` mailbox so a proxy's `EngineAlive` / `EngineDied`
-/// reports land here without booting the real `EngineServer`. Records
-/// the reported `engine_id`s into shared vecs the heartbeat tests
-/// assert on. Lives at file root for `#[bridge]` marker addressability.
-#[cfg(test)]
-#[aether_actor::bridge(singleton)]
-mod engine_cap_sink {
-    use super::{EngineAlive, EngineCapCells, EngineDied};
-    use aether_actor::actor;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
-
-    pub struct EngineCapSink {
-        cells: EngineCapCells,
-    }
-
-    #[actor]
-    impl NativeActor for EngineCapSink {
-        type Config = EngineCapCells;
-        const NAMESPACE: &'static str = "aether.engine";
-
-        fn init(cells: EngineCapCells, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            Ok(Self { cells })
-        }
-
-        #[handler]
-        fn on_alive(&mut self, _ctx: &mut NativeCtx<'_>, mail: EngineAlive) {
-            self.cells
-                .alive
-                .lock()
-                .expect("test setup: alive cell mutex poisoned")
-                .push(mail.engine_id);
-        }
-
-        #[handler]
-        fn on_died(&mut self, _ctx: &mut NativeCtx<'_>, mail: EngineDied) {
-            self.cells
-                .died
-                .lock()
-                .expect("test setup: died cell mutex poisoned")
-                .push(mail);
-        }
-    }
-}
-
-/// Test-only sink: records the `value` of every [`TestEchoReply`] it
-/// receives into a shared cell so the round-trip test can observe a
-/// reply routed back through the proxy. Lives at file root (not nested
-/// in `mod tests`) so the `#[bridge]` macro's marker emission stays
-/// addressable.
-#[cfg(test)]
-#[aether_actor::bridge(singleton)]
-mod proxy_reply_sink {
-    use super::TestEchoReply;
-    use aether_actor::actor;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
-    use std::sync::{Arc, Mutex};
-
-    pub struct ProxyReplySink {
-        recorded: Arc<Mutex<Option<u64>>>,
-    }
-
-    #[actor]
-    impl NativeActor for ProxyReplySink {
-        type Config = Arc<Mutex<Option<u64>>>;
-        const NAMESPACE: &'static str = "aether.engine.test.reply_sink";
-
-        fn init(
-            recorded: Arc<Mutex<Option<u64>>>,
-            _ctx: &mut NativeInitCtx<'_>,
-        ) -> Result<Self, BootError> {
-            Ok(Self { recorded })
-        }
-
-        #[handler]
-        fn on_reply(&mut self, _ctx: &mut NativeCtx<'_>, reply: TestEchoReply) {
-            *self
-                .recorded
-                .lock()
-                .expect("test setup: recorded mutex poisoned") = Some(reply.value);
-        }
-    }
-}
+use sinks::{EngineCapCells, EngineCapSink, ProxyReplySink};
 
 #[cfg(test)]
 mod tests {
@@ -777,6 +507,7 @@ mod tests {
         DeathReason, EngineCapCells, EngineCapSink, EngineProxy, EngineProxyConfig,
         HeartbeatParams, ProxyReplySink,
     };
+    use crate::engine::kinds::ForwardEnvelope;
     use crate::rpc::server::{RpcServerCapability, RpcServerConfig, RpcServerHandle};
     use crate::rpc::test_echo::{TestEchoActor, TestEchoRequest};
     use crate::rpc::{HelloAck, PeerKind, WIRE_VERSION, WireFrame};
@@ -860,7 +591,7 @@ mod tests {
         // Forge a `ForwardEnvelope` at the proxy, reply-to the sink.
         // `mailer.push` directly (rather than through an actor send) so
         // the test controls the `Source` the proxy parks.
-        let fwd = aether_kinds::ForwardEnvelope {
+        let fwd = ForwardEnvelope {
             mailbox: echo_mailbox,
             kind: <TestEchoRequest as Kind>::ID,
             payload: TestEchoRequest { value: 42 }.encode_into_bytes(),
@@ -868,7 +599,7 @@ mod tests {
         mailer.push(
             Mail::new(
                 proxy_mailbox,
-                <aether_kinds::ForwardEnvelope as Kind>::ID,
+                <ForwardEnvelope as Kind>::ID,
                 fwd.encode_into_bytes(),
                 1,
             )

--- a/crates/aether-capabilities/src/engine/proxy/sinks.rs
+++ b/crates/aether-capabilities/src/engine/proxy/sinks.rs
@@ -1,0 +1,104 @@
+//! Test-only capture actors for the proxy's round-trip / heartbeat
+//! tests: a stand-in engines cap that records `EngineAlive` /
+//! `EngineDied` reports, and a reply sink that records routed
+//! `TestEchoReply` values. The whole module is `#[cfg(test)]` (gated at
+//! its `mod` declaration), so none of it ships in the cap's surface.
+
+use crate::engine::kinds::{EngineAlive, EngineDied};
+use crate::rpc::test_echo::TestEchoReply;
+use std::sync::{Arc, Mutex};
+
+/// Shared capture cells for [`EngineCapSink`]. Lives at file root (not
+/// inside the bridge mod) like `EngineServer`'s `ReplyCells` — it's the
+/// sink actor's `Config`, so it must be addressable as `super::…` from
+/// the bridge mod. `died` keeps the whole [`EngineDied`] (id + reason) so
+/// the death-path tests can assert the surfaced cause.
+#[derive(Clone, Default)]
+pub struct EngineCapCells {
+    pub alive: Arc<Mutex<Vec<String>>>,
+    pub died: Arc<Mutex<Vec<EngineDied>>>,
+}
+
+/// Test-only stand-in for the engines cap, registered at the cap's own
+/// `aether.engine` mailbox so a proxy's `EngineAlive` / `EngineDied`
+/// reports land here without booting the real `EngineServer`. Records
+/// the reported `engine_id`s into shared vecs the heartbeat tests
+/// assert on. Lives at file root for `#[bridge]` marker addressability.
+#[aether_actor::bridge(singleton)]
+mod engine_cap_sink {
+    use super::{EngineAlive, EngineCapCells, EngineDied};
+    use aether_actor::actor;
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+
+    pub struct EngineCapSink {
+        cells: EngineCapCells,
+    }
+
+    #[actor]
+    impl NativeActor for EngineCapSink {
+        type Config = EngineCapCells;
+        const NAMESPACE: &'static str = "aether.engine";
+
+        fn init(cells: EngineCapCells, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            Ok(Self { cells })
+        }
+
+        #[handler]
+        fn on_alive(&mut self, _ctx: &mut NativeCtx<'_>, mail: EngineAlive) {
+            self.cells
+                .alive
+                .lock()
+                .expect("test setup: alive cell mutex poisoned")
+                .push(mail.engine_id);
+        }
+
+        #[handler]
+        fn on_died(&mut self, _ctx: &mut NativeCtx<'_>, mail: EngineDied) {
+            self.cells
+                .died
+                .lock()
+                .expect("test setup: died cell mutex poisoned")
+                .push(mail);
+        }
+    }
+}
+
+/// Test-only sink: records the `value` of every [`TestEchoReply`] it
+/// receives into a shared cell so the round-trip test can observe a
+/// reply routed back through the proxy. Lives at file root (not nested
+/// in `mod tests`) so the `#[bridge]` macro's marker emission stays
+/// addressable.
+#[aether_actor::bridge(singleton)]
+mod proxy_reply_sink {
+    use super::TestEchoReply;
+    use aether_actor::actor;
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+    use std::sync::{Arc, Mutex};
+
+    pub struct ProxyReplySink {
+        recorded: Arc<Mutex<Option<u64>>>,
+    }
+
+    #[actor]
+    impl NativeActor for ProxyReplySink {
+        type Config = Arc<Mutex<Option<u64>>>;
+        const NAMESPACE: &'static str = "aether.engine.test.reply_sink";
+
+        fn init(
+            recorded: Arc<Mutex<Option<u64>>>,
+            _ctx: &mut NativeInitCtx<'_>,
+        ) -> Result<Self, BootError> {
+            Ok(Self { recorded })
+        }
+
+        #[handler]
+        fn on_reply(&mut self, _ctx: &mut NativeCtx<'_>, reply: TestEchoReply) {
+            *self
+                .recorded
+                .lock()
+                .expect("test setup: recorded mutex poisoned") = Some(reply.value);
+        }
+    }
+}

--- a/crates/aether-capabilities/src/engine/server/artifacts.rs
+++ b/crates/aether-capabilities/src/engine/server/artifacts.rs
@@ -1,0 +1,328 @@
+//! Binary / component artifact resolution + ingestion for the engines
+//! cap (ADR-0115 / ADR-0116). The content-addressed store seams the
+//! handlers delegate to: ingest an uploaded binary / component, resolve
+//! a [`BinarySelector`] / `ComponentSelector` to stored bytes, and
+//! realize stored bytes to an executable temp file for fork+exec.
+//! Native-only (forks `--describe`, reads / copies files).
+
+use crate::store::{
+    ArtifactKind, ArtifactStore, Selector, StoredArtifact, StoredManifest, component_manifest,
+};
+use aether_kinds::{
+    BinaryManifest, BinarySelector, ComponentSelector, ListComponentBinaries, ListEngineBinaries,
+    ResolveComponentResult,
+};
+use std::collections::HashSet;
+use std::fs;
+use std::io;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+/// The chassis a `default` selector (an empty [`BinarySelector::query`]
+/// with no attribute filters) resolves to (ADR-0115): `headless` has no
+/// window and runs on any host, so a bare spawn is self-sufficient.
+const DEFAULT_CHASSIS: &str = "headless";
+
+/// Fork `binary_path --describe` and parse the JSON manifest it prints
+/// (ADR-0115, issue 1953). The one-time capture of what a binary *is* —
+/// its chassis kind, linked caps, and build provenance — without the
+/// hub linking the chassis crate. `stdin` is nulled so a describe can't
+/// block on input.
+fn describe_binary(binary_path: &str) -> Result<BinaryManifest, String> {
+    let output = Command::new(binary_path)
+        .arg("--describe")
+        .stdin(Stdio::null())
+        .output()
+        .map_err(|e| format!("forking {binary_path:?} --describe: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "{binary_path:?} --describe exited {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim(),
+        ));
+    }
+    serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("parsing {binary_path:?} --describe manifest JSON: {e}"))
+}
+
+/// Ingest the binary at `path` into `store` content-addressed,
+/// capturing its manifest via a one-time `<path> --describe` fork
+/// (ADR-0115, issue 1953). Shared by the `on_upload_binary` handler and
+/// the [`bootstrap_ingest`] boot path. Returns the stored content hash,
+/// or a human-readable error for an unreadable path or a `--describe`
+/// that failed / yielded no parseable manifest. Idempotent — identical
+/// bytes dedup to the same hash.
+pub(super) fn ingest_binary(
+    store: &mut ArtifactStore,
+    path: &str,
+    name: Option<String>,
+) -> Result<String, String> {
+    let bytes = fs::read(path).map_err(|e| format!("reading binary path {path:?}: {e}"))?;
+    let manifest = describe_binary(path)?;
+    Ok(store.upload(
+        &bytes,
+        ArtifactKind::Binary,
+        StoredManifest::Binary(manifest),
+        name,
+    ))
+}
+
+/// Bootstrap-ingest each chassis bin in `paths` into `store`, naming
+/// each by its file stem so a `default` / `name` selector resolves in a
+/// fresh or `restart-hub`'d hub (ADR-0115, issue 1954). The list rides
+/// `EngineConfig`'s `binary_bootstrap` field (its `AETHER_BINARY_BOOTSTRAP`
+/// env layer, ADR-0090). A path that can't be read or `--describe`d is
+/// logged and skipped — a bad bootstrap entry must not fail hub boot.
+/// Idempotent via content dedup.
+pub(super) fn bootstrap_ingest(store: &mut ArtifactStore, paths: &HashSet<String>) {
+    for path_str in paths {
+        let name = Path::new(path_str)
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .map(str::to_owned);
+        match ingest_binary(store, path_str, name) {
+            Ok(hash) => tracing::info!(
+                target: "aether_substrate::engine_server",
+                path = path_str.as_str(),
+                hash = %hash,
+                "binary bootstrap: ingested a chassis bin",
+            ),
+            Err(error) => tracing::warn!(
+                target: "aether_substrate::engine_server",
+                path = path_str.as_str(),
+                error = %error,
+                "binary bootstrap: skipping a bin that failed to ingest",
+            ),
+        }
+    }
+}
+
+/// Ingest the component wasm at `path` into `store` content-addressed,
+/// reading its manifest straight from the wasm (ADR-0116, issue 1956) —
+/// no execution step. Returns the stored content hash, or a
+/// human-readable error for an unreadable path or an unparseable wasm.
+/// Idempotent — identical bytes dedup to the same hash.
+pub(super) fn ingest_component(
+    store: &mut ArtifactStore,
+    path: &str,
+    name: Option<String>,
+) -> Result<String, String> {
+    let bytes = fs::read(path).map_err(|e| format!("reading component path {path:?}: {e}"))?;
+    let manifest = component_manifest(&bytes)
+        .map_err(|e| format!("reading component manifest from {path:?}: {e}"))?;
+    Ok(store.upload(
+        &bytes,
+        ArtifactKind::Component,
+        StoredManifest::Component(manifest),
+        name,
+    ))
+}
+
+/// Resolve a [`ComponentSelector`] against `store` to its wasm bytes +
+/// manifest (ADR-0116, issue 1956). Resolution order mirrors the binary
+/// selector: an exact `query` token wins first
+/// (`hash` > `module@actor` > `name@version` (latest in v1) > `name`);
+/// absent a token, the `namespace` / `handled_kind` attribute query
+/// resolves, where a query
+/// matching more than one component is a clean ambiguity error (never a
+/// silent pick). A `module@actor` token's `@actor` part populates the
+/// reply `export` so the forwarded `LoadComponent` instantiates that
+/// actor type (ADR-0096). Returns `Err` for no match / ambiguity.
+pub(super) fn resolve_component(
+    store: &mut ArtifactStore,
+    selector: &ComponentSelector,
+) -> ResolveComponentResult {
+    // An exact token, with the `@actor` half (if any) split off as the
+    // export selector forwarded to the substrate.
+    if let Some(token) = selector
+        .query
+        .as_deref()
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+    {
+        return resolve_component_token(store, token);
+    }
+    // No exact token: a namespace / handled-kind attribute query. A
+    // match-more-than-one is a clean ambiguity error.
+    let mut matches = store.list_components(&ListComponentBinaries {
+        namespace: selector.namespace.clone(),
+        handled_kind: selector.handled_kind,
+    });
+    match matches.len() {
+        0 => ResolveComponentResult::Err {
+            error: format!(
+                "no stored component matches the attribute query (namespace = {:?}, handled_kind = {:?})",
+                selector.namespace, selector.handled_kind,
+            ),
+        },
+        1 => {
+            let hash = matches.remove(0).hash;
+            stored_component_reply(store, &hash, None)
+        }
+        n => ResolveComponentResult::Err {
+            error: format!(
+                "the attribute query (namespace = {:?}, handled_kind = {:?}) matches {n} components — narrow it to a single component (by hash or name)",
+                selector.namespace, selector.handled_kind,
+            ),
+        },
+    }
+}
+
+/// Resolve an exact component selector token to a [`ResolveComponentResult`]
+/// (ADR-0116). A `module@actor` token splits into the `module`
+/// hash/name and the `@actor` export selector; a `name@version` token
+/// is treated as `name` (latest) — v1 keeps no per-name version index;
+/// a bare token resolves as a hash first, then a name.
+fn resolve_component_token(store: &mut ArtifactStore, token: &str) -> ResolveComponentResult {
+    // `module@actor` (ADR-0096) takes precedence: the `@actor` half is a
+    // component `Addressable::NAMESPACE`, distinct from a binary `name@version`
+    // build id. Resolve the module half (hash, then name), forward the
+    // actor half as `export`.
+    if let Some((module, actor)) = token.split_once('@') {
+        // A hash never contains `@`, so the module half resolves as a
+        // hash first, then a name (latest). The actor half is the export.
+        if store.contains(module) {
+            return stored_component_reply(store, module, Some(actor.to_owned()));
+        }
+        if let Some(found) = store.get(&Selector::Name(module.to_owned())) {
+            return stored_component_reply(store, &found.hash, Some(actor.to_owned()));
+        }
+        return ResolveComponentResult::Err {
+            error: format!("no stored component matches the selector {token:?}"),
+        };
+    }
+    // A bare token: an exact hash wins, else a name (latest).
+    if store.contains(token) {
+        return stored_component_reply(store, token, None);
+    }
+    if let Some(found) = store.get(&Selector::Name(token.to_owned())) {
+        return stored_component_reply(store, &found.hash, None);
+    }
+    ResolveComponentResult::Err {
+        error: format!("no stored component matches the selector {token:?}"),
+    }
+}
+
+/// Read the stored component `hash`'s wasm bytes + manifest off disk and
+/// build a `ResolveComponentResult::Ok` (ADR-0116). `export` threads a
+/// `module@actor` selector's actor half through to the forwarded
+/// `LoadComponent.export`. An entry that isn't a component (a binary
+/// hash) or whose bytes can't be read is a clean `Err`.
+fn stored_component_reply(
+    store: &mut ArtifactStore,
+    hash: &str,
+    export: Option<String>,
+) -> ResolveComponentResult {
+    let Some(found) = store.get(&Selector::Hash(hash.to_owned())) else {
+        return ResolveComponentResult::Err {
+            error: format!("no stored artifact has hash {hash:?}"),
+        };
+    };
+    let Some(manifest) = found.manifest.as_component().cloned() else {
+        return ResolveComponentResult::Err {
+            error: format!("artifact {hash:?} is not a component"),
+        };
+    };
+    let wasm = match fs::read(&found.path) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            return ResolveComponentResult::Err {
+                error: format!("reading stored component bytes for {hash:?}: {e}"),
+            };
+        }
+    };
+    ResolveComponentResult::Ok {
+        hash: found.hash,
+        wasm,
+        name: found.name,
+        manifest,
+        export,
+    }
+}
+
+/// Resolve a [`BinarySelector`] against `store` to the stored content
+/// bytes the spawn forks (ADR-0115). Resolution order: an exact `query`
+/// token wins first (`hash` > `name@version` > `name`); absent a token,
+/// the `chassis` / `caps` / `target` attribute query resolves, and with
+/// no attribute filters either, `default` = the [`DEFAULT_CHASSIS`]
+/// binary. `None` when nothing matched.
+pub(super) fn resolve_selector(
+    store: &mut ArtifactStore,
+    selector: &BinarySelector,
+) -> Option<StoredArtifact> {
+    if let Some(token) = selector
+        .query
+        .as_deref()
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+    {
+        // Exact hash wins outright.
+        if let Some(found) = store.get(&Selector::Hash(token.to_owned())) {
+            return Some(found);
+        }
+        // `name@version`: the binary's self-reported build id (the
+        // manifest `git_sha`) pins a specific entry of a name.
+        if let Some((name, version)) = token.split_once('@') {
+            let hash = pick_versioned(store, name, version)?;
+            return store.get(&Selector::Hash(hash));
+        }
+        // A bare name points at the latest hash uploaded under it.
+        return store.get(&Selector::Name(token.to_owned()));
+    }
+    // No exact token: an attribute query, else `default` = headless.
+    let hash = store
+        .list_binaries(&attribute_filter(selector))
+        .into_iter()
+        .map(|entry| entry.hash)
+        .min()?;
+    store.get(&Selector::Hash(hash))
+}
+
+/// The store filter for a tokenless [`BinarySelector`]: the explicit
+/// `chassis` / `caps` / `target` attribute query, or — when none is
+/// set — the `default` filter selecting the [`DEFAULT_CHASSIS`]
+/// chassis.
+fn attribute_filter(selector: &BinarySelector) -> ListEngineBinaries {
+    if selector.chassis.is_none() && selector.caps.is_empty() && selector.target.is_none() {
+        ListEngineBinaries {
+            chassis: Some(DEFAULT_CHASSIS.to_owned()),
+            caps: Vec::new(),
+            target: None,
+        }
+    } else {
+        ListEngineBinaries {
+            chassis: selector.chassis.clone(),
+            caps: selector.caps.clone(),
+            target: selector.target.clone(),
+        }
+    }
+}
+
+/// The content hash of the entry named `name` whose manifest build id
+/// (`git_sha`) is `version` — the `name@version` selector (ADR-0115).
+/// `None` when no current entry matches both.
+fn pick_versioned(store: &ArtifactStore, name: &str, version: &str) -> Option<String> {
+    store
+        .list_binaries(&ListEngineBinaries::default())
+        .into_iter()
+        .find(|entry| entry.name.as_deref() == Some(name) && entry.manifest.git_sha == version)
+        .map(|entry| entry.hash)
+}
+
+/// Copy the content bytes at `src` to `dest` and mark `dest`
+/// executable (`0o755` on Unix; the `from_mode` precedent in
+/// `anthropic/cli.rs`), creating `dest`'s parent dir. The
+/// realize-to-exec step for spawn: stored bytes aren't directly
+/// fork-exec'able (ADR-0115 §Execution).
+pub(super) fn realize_executable(src: &Path, dest: &Path) -> io::Result<()> {
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::copy(src, dest)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(dest, fs::Permissions::from_mode(0o755))?;
+    }
+    Ok(())
+}

--- a/crates/aether-capabilities/src/engine/server/config.rs
+++ b/crates/aether-capabilities/src/engine/server/config.rs
@@ -1,0 +1,239 @@
+//! Engines-cap configuration (ADR-0090) — the liveness-heartbeat
+//! tuning plus the hub binary store's layout dir, disk budget, and
+//! bootstrap list. Native-only: resolved by the hub chassis and handed
+//! into [`EngineServer::init`](super::EngineServer) via
+//! `with_actor::<EngineServer>(cfg)`.
+
+use crate::engine::proxy::HeartbeatParams;
+use crate::store::DEFAULT_DISK_BUDGET_BYTES;
+use std::collections::HashSet;
+use std::convert::Infallible;
+use std::time::Duration;
+
+/// Default heartbeat ping cadence (issue 1339). 5 s × the miss
+/// limit is the detection-latency vs. flap-tolerance tradeoff.
+const DEFAULT_HEARTBEAT_INTERVAL_SECS: u64 = 5;
+/// Default consecutive-miss threshold before an engine is declared
+/// dead. Small N tolerates a transient hiccup / GC pause.
+const DEFAULT_HEARTBEAT_MISS_LIMIT: u32 = 3;
+
+/// Default total time a freshly-forked substrate's proxy keeps
+/// retrying its startup dial before giving up (issue 2072). A debug
+/// cold start fork+exec+bind can stretch well past a healthy
+/// localhost dial when many substrates come up at once and
+/// oversubscribe the cores (e.g. a concurrent `FleetBench` fleet), so
+/// the budget is generous — far longer than a single cold start
+/// needs, comfortably under the `FleetBench` client's own spawn cap so
+/// the hub returns a clean `Err` first rather than the client
+/// tripping its backstop. `0` is the wait-forever sentinel.
+pub(super) const DEFAULT_PROXY_CONNECT_BUDGET_SECS: u64 = 30;
+
+/// Resolved engines-cap configuration (ADR-0090, issue 1339): the
+/// liveness-heartbeat tuning plus the hub binary store's layout dir,
+/// disk budget, and bootstrap list (ADR-0115, #1954 — these last three
+/// moved onto the config off their pre-ADR-0090 naked `env::var`
+/// readers). The inline `AETHER_ENGINE_STORE_ROOT` reader
+/// (`engine_store_root`) is a separate, still-inline knob.
+///
+/// `#[derive(aether_substrate::Config)]` emits the env-shaped
+/// `EngineConfigLayer`, the clap-shaped `EngineOverlay`, and the
+/// inherent `from_env` / `from_argv_then_env` shims (argv beats env
+/// beats the literal default). The hub chassis resolves it with
+/// `EngineConfig::from_argv_then_env(cli.engine.into_layer())` and
+/// hands it to `with_actor::<EngineServer>(cfg)`; tests build it
+/// directly. `env_prefix = "AETHER_HUB"` + the `heartbeat_*` /
+/// `binary_disk_budget_bytes` field names compose the
+/// `AETHER_HUB_HEARTBEAT_*` / `AETHER_HUB_BINARY_DISK_BUDGET_BYTES`
+/// env keys and `--hub-*` flags; `binary_store_dir` / `binary_bootstrap`
+/// pin the unprefixed `AETHER_BINARY_STORE_DIR` / `AETHER_BINARY_BOOTSTRAP`
+/// keys via per-field `env` overrides. `Default` (the test constructor)
+/// resolves the heartbeat to `0/0` (disabled) and the store fields to
+/// unset / `16 GiB`; production picks up the `default = 5/3` / `16 GiB`
+/// literals and the env layers through `from_argv_then_env`.
+#[derive(Clone, Debug, aether_substrate::Config)]
+#[config(env_prefix = "AETHER_HUB", cli_prefix = "hub")]
+pub struct EngineConfig {
+    /// Heartbeat ping cadence in seconds
+    /// (`AETHER_HUB_HEARTBEAT_INTERVAL_SECS` /
+    /// `--hub-heartbeat-interval-secs`). `0` disables the heartbeat
+    /// entirely (engines are then only evicted on a
+    /// connection-close, never on a wedge).
+    #[config(default = 5, parse = parse_heartbeat_interval_secs)]
+    pub heartbeat_interval_secs: u64,
+    /// Consecutive missed pings that mark an engine dead
+    /// (`AETHER_HUB_HEARTBEAT_MISS_LIMIT` /
+    /// `--hub-heartbeat-miss-limit`). Small N tolerates a transient
+    /// hiccup; `0` also disables the heartbeat. Detection latency is
+    /// `miss_limit × interval_secs`.
+    #[config(default = 3, parse = parse_heartbeat_miss_limit)]
+    pub heartbeat_miss_limit: u32,
+    /// Total seconds a freshly-forked substrate's proxy keeps
+    /// retrying its startup dial before the spawn fails
+    /// (`AETHER_HUB_PROXY_CONNECT_BUDGET_SECS` /
+    /// `--hub-proxy-connect-budget-secs`, issue 2072). Generous by
+    /// default so a debug cold start under fork contention isn't
+    /// called dead prematurely; `0` is the wait-forever sentinel
+    /// (retry until the dial succeeds or hits a terminal error).
+    #[config(default = 30, parse = parse_proxy_connect_budget_secs)]
+    pub proxy_connect_budget_secs: u64,
+    /// Layout-root override for the hub's content-addressed binary
+    /// store (`AETHER_BINARY_STORE_DIR`, unprefixed — the ops escape
+    /// hatch and the fleet tests' per-process isolation knob). Unset
+    /// (`None`) → the computed default `data_dir/aether/binaries/v1`
+    /// (`ArtifactStore::default_root`). A bare `Option<String>` (not a
+    /// `PathBuf`) keeps that runtime-computed default in `init`, so
+    /// `EngineConfig` needs no `skip_from_layer`; `EngineServer::init`
+    /// joins the store's layout-version dir to a set override.
+    #[config(env = "AETHER_BINARY_STORE_DIR")]
+    pub binary_store_dir: Option<String>,
+    /// On-disk byte budget for the binary store
+    /// (`AETHER_HUB_BINARY_DISK_BUDGET_BYTES`, derived from the
+    /// `AETHER_HUB` prefix / `--hub-binary-disk-budget-bytes`). Default
+    /// 16 GiB (`DEFAULT_DISK_BUDGET_BYTES`); LRU eviction over unpinned,
+    /// unnamed entries holds it.
+    #[config(default = 17_179_869_184u64, parse = parse_binary_disk_budget)]
+    pub binary_disk_budget_bytes: u64,
+    /// Chassis bins to bootstrap-ingest at init so a `default` / `name`
+    /// selector resolves in a fresh or `restart-hub`'d hub
+    /// (`AETHER_BINARY_BOOTSTRAP`, unprefixed, comma-separated). Each is
+    /// ingested content-addressed and named by its file stem;
+    /// idempotent via content dedup. `ensure-tunnel.sh` exports the
+    /// freshly-built chassis bins here.
+    #[config(
+        env = "AETHER_BINARY_BOOTSTRAP",
+        default = [],
+        parse = parse_binary_bootstrap,
+        csv_set
+    )]
+    pub binary_bootstrap: HashSet<String>,
+}
+
+impl Default for EngineConfig {
+    /// The test constructor: heartbeat disabled (`0/0`) but a real
+    /// `DEFAULT_DISK_BUDGET_BYTES` budget — `0` is inert for the
+    /// heartbeat (no pinging) yet destructive for the store (it would
+    /// evict every unnamed upload), so the budget can't share the
+    /// heartbeat's zero. Store dir unset (the computed default) and an
+    /// empty bootstrap. Production resolves all five through the layer
+    /// (`from_argv_then_env`); this matches the prior `from_env()`
+    /// store budget every `EngineConfig::default()` consumer saw.
+    fn default() -> Self {
+        Self {
+            heartbeat_interval_secs: 0,
+            heartbeat_miss_limit: 0,
+            // A real budget (not the heartbeat's inert `0`): tests fork
+            // real substrates, so the proxy needs a generous-but-finite
+            // startup-dial budget — `0` would mean wait-forever and
+            // hang on a genuinely dead substrate.
+            proxy_connect_budget_secs: DEFAULT_PROXY_CONNECT_BUDGET_SECS,
+            binary_store_dir: None,
+            binary_disk_budget_bytes: DEFAULT_DISK_BUDGET_BYTES,
+            binary_bootstrap: HashSet::new(),
+        }
+    }
+}
+
+impl EngineConfig {
+    /// The [`HeartbeatParams`] to arm each proxy with, or `None`
+    /// when the heartbeat is disabled (`0` interval or miss limit).
+    pub(super) fn heartbeat_params(&self) -> Option<HeartbeatParams> {
+        if self.heartbeat_interval_secs == 0 || self.heartbeat_miss_limit == 0 {
+            None
+        } else {
+            Some(HeartbeatParams {
+                interval: Duration::from_secs(self.heartbeat_interval_secs),
+                miss_limit: self.heartbeat_miss_limit,
+            })
+        }
+    }
+
+    /// The startup-dial connect budget to arm each spawned proxy
+    /// with (issue 2072). `Some(d)` caps the retry; `None` (the `0`
+    /// sentinel) means wait forever.
+    pub(super) fn connect_budget(&self) -> Option<Duration> {
+        (self.proxy_connect_budget_secs != 0)
+            .then(|| Duration::from_secs(self.proxy_connect_budget_secs))
+    }
+}
+
+// confique's `parse_env` contract is `fn(&str) -> Result<T, impl
+// Error>`; these total helpers carry a `Result` they never fill with
+// `Err` — an unparseable value folds back to the default (soft, like
+// the DAG validator's caps; the ADR-0090 §4 strict/erroring variant
+// is a follow-up). Hence the `unnecessary_wraps` allow.
+
+/// Parse the heartbeat interval; unparseable → the default.
+#[allow(clippy::unnecessary_wraps)]
+fn parse_heartbeat_interval_secs(s: &str) -> Result<u64, Infallible> {
+    Ok(s.trim().parse().unwrap_or(DEFAULT_HEARTBEAT_INTERVAL_SECS))
+}
+
+/// Parse the heartbeat miss limit; unparseable → the default.
+#[allow(clippy::unnecessary_wraps)]
+fn parse_heartbeat_miss_limit(s: &str) -> Result<u32, Infallible> {
+    Ok(s.trim().parse().unwrap_or(DEFAULT_HEARTBEAT_MISS_LIMIT))
+}
+
+/// Parse the proxy connect budget seconds; unparseable → the default.
+#[allow(clippy::unnecessary_wraps)]
+fn parse_proxy_connect_budget_secs(s: &str) -> Result<u64, Infallible> {
+    Ok(s.trim()
+        .parse()
+        .unwrap_or(DEFAULT_PROXY_CONNECT_BUDGET_SECS))
+}
+
+/// Parse the binary-store disk budget; unparseable → the default
+/// `DEFAULT_DISK_BUDGET_BYTES` (mirrors the heartbeat parsers).
+#[allow(clippy::unnecessary_wraps)]
+fn parse_binary_disk_budget(s: &str) -> Result<u64, Infallible> {
+    Ok(s.trim().parse().unwrap_or(DEFAULT_DISK_BUDGET_BYTES))
+}
+
+/// Split a comma-separated bootstrap path list, trimming and dropping
+/// empties (mirrors the http allowlist's `parse_allowlist`). Total —
+/// never errors.
+#[allow(clippy::unnecessary_wraps)]
+fn parse_binary_bootstrap(s: &str) -> Result<HashSet<String>, Infallible> {
+    Ok(s.split(',')
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+#[cfg(test)]
+mod config_tests {
+    use super::*;
+
+    /// The connect budget resolves a non-zero seconds value to a
+    /// finite `Duration`, and `0` to the wait-forever sentinel `None`.
+    #[test]
+    fn connect_budget_maps_zero_to_wait_forever() {
+        let finite = EngineConfig {
+            proxy_connect_budget_secs: 12,
+            ..EngineConfig::default()
+        };
+        assert_eq!(finite.connect_budget(), Some(Duration::from_secs(12)));
+        let forever = EngineConfig {
+            proxy_connect_budget_secs: 0,
+            ..EngineConfig::default()
+        };
+        assert_eq!(forever.connect_budget(), None);
+    }
+
+    /// The default budget is generous and finite — never the
+    /// wait-forever sentinel — so a debug cold start under fork
+    /// contention isn't called dead prematurely, while a genuinely
+    /// dead substrate still fails the spawn rather than hanging.
+    #[test]
+    fn default_connect_budget_is_generous_and_finite() {
+        let budget = EngineConfig::default()
+            .connect_budget()
+            .expect("default budget is finite, not wait-forever");
+        assert_eq!(
+            budget,
+            Duration::from_secs(DEFAULT_PROXY_CONNECT_BUDGET_SECS)
+        );
+        assert!(budget >= Duration::from_secs(30), "default stays generous");
+    }
+}

--- a/crates/aether-capabilities/src/engine/server/fleet.rs
+++ b/crates/aether-capabilities/src/engine/server/fleet.rs
@@ -1,0 +1,78 @@
+//! Fleet-runtime helpers for the engines cap: settle a routed call the
+//! cap can't satisfy, pick a free localhost RPC port, and resolve the
+//! per-engine spawn-dir parent. Native-only (sockets, process env,
+//! mail pushes).
+
+use crate::engine::kinds::CallSettled;
+use aether_data::{Kind, MailboxId};
+use aether_substrate::Mail;
+use aether_substrate::mail::mailer::Mailer;
+use aether_substrate::mail::{Source, SourceAddr};
+use std::env;
+use std::io;
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+/// Env override for the parent directory under which the cap
+/// allocates per-engine handle-store dirs (issue 1274). Absent →
+/// fall through to `dirs::data_dir().join("aether/engines")`, then
+/// to `std::env::temp_dir().join("aether-engines")` if no data dir
+/// is resolvable.
+const ENV_ENGINE_STORE_ROOT: &str = "AETHER_ENGINE_STORE_ROOT";
+
+/// Push a `CallSettled::Err` back to `target` (correlation
+/// preserved) so a routed call that the cap can't satisfy — bad
+/// `engine_id`, unknown engine — closes with a wire `ReplyEnd`
+/// instead of leaving the RPC client hanging.
+pub(super) fn settle_err(mailer: &Arc<Mailer>, target: MailboxId, correlation: u64, error: String) {
+    mailer.push(
+        Mail::new(
+            target,
+            <CallSettled as Kind>::ID,
+            CallSettled::Err { error }.encode_into_bytes(),
+            1,
+        )
+        .with_reply_to(Source::with_correlation(SourceAddr::None, correlation)),
+    );
+}
+
+/// Bind `127.0.0.1:0`, read the OS-assigned port, drop the
+/// listener. A tiny TOCTOU window exists before the substrate
+/// rebinds the port, but on localhost it's negligible — and this
+/// sidesteps both a wire change to report an ephemeral port back
+/// from the substrate and an un-recycled incrementing port pool.
+pub(super) fn free_local_port() -> io::Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+    Ok(port)
+}
+
+/// Parent directory under which the cap allocates per-engine
+/// handle-store dirs (issue 1274). Priority:
+///
+/// 1. `AETHER_ENGINE_STORE_ROOT` env override (ops escape hatch).
+/// 2. `dirs::data_dir().join("aether/engines")` (cross-platform
+///    default — `~/Library/Application Support/aether/engines` on
+///    macOS, `$XDG_DATA_HOME/aether/engines` on Linux, etc.).
+/// 3. `std::env::temp_dir().join("aether-engines")` if no data
+///    dir is resolvable.
+// External ops escape hatch (AETHER_ENGINE_STORE_ROOT) for the per-engine
+// spawn-dir parent — the directory forked substrates and their handle
+// stores live under, resolved in a static spawn helper. #1968 deliberately
+// kept this knob inline (separate from the binary-artifact store, which it
+// moved onto EngineConfig); it is a process-level deployment override, not
+// a cap config field.
+#[allow(clippy::disallowed_methods)]
+pub(super) fn engine_store_root() -> PathBuf {
+    if let Ok(raw) = env::var(ENV_ENGINE_STORE_ROOT)
+        && !raw.is_empty()
+    {
+        return PathBuf::from(raw);
+    }
+    if let Some(data) = dirs::data_dir() {
+        return data.join("aether").join("engines");
+    }
+    env::temp_dir().join("aether-engines")
+}

--- a/crates/aether-capabilities/src/engine/server/mod.rs
+++ b/crates/aether-capabilities/src/engine/server/mod.rs
@@ -37,12 +37,27 @@
 // Handler-signature kinds must be importable at file root — the
 // `#[bridge]` macro emits `impl HandlesKind<K>` markers as siblings of
 // the mod.
+use crate::engine::kinds::{EngineAlive, EngineDied, RouteEnvelope};
 use aether_kinds::{
-    EngineAlive, EngineDied, ListComponentBinaries, ListEngineBinaries, ListEngines,
-    ResolveComponent, RouteEnvelope, SpawnEngine, TerminateEngine, UploadBinary, UploadComponent,
+    ListComponentBinaries, ListEngineBinaries, ListEngines, ResolveComponent, SpawnEngine,
+    TerminateEngine, UploadBinary, UploadComponent,
 };
 #[cfg(test)]
 use std::sync::{Arc, Mutex};
+
+// The engines cap's implementation, split along its seams (ADR-0121):
+// `config` (the ADR-0090 config struct + parsers), `artifacts` (the
+// content-addressed store resolution / ingestion the handlers delegate
+// to), and `fleet` (free-port allocation, routed-call settlement, and
+// spawn-dir resolution). All three are native-only — the cap forks
+// processes and owns sockets — so they elide on wasm alongside the
+// bridge mod.
+#[cfg(not(target_arch = "wasm32"))]
+mod artifacts;
+#[cfg(not(target_arch = "wasm32"))]
+mod config;
+#[cfg(not(target_arch = "wasm32"))]
+mod fleet;
 
 // `EngineConfig` (+ its derive-emitted `EngineOverlay`) ride through
 // file root for the hub chassis bin, which flattens the overlay into
@@ -50,25 +65,28 @@ use std::sync::{Arc, Mutex};
 // `with_actor::<EngineServer>(cfg)` (ADR-0090). Native-only re-export —
 // the engines cap is native-only, so the config has no wasm consumer.
 #[cfg(not(target_arch = "wasm32"))]
-pub use server_native::{EngineConfig, EngineOverlay};
+pub use config::{EngineConfig, EngineOverlay};
 
 #[aether_actor::bridge(singleton)]
 mod server_native {
+    use super::artifacts::{
+        bootstrap_ingest, ingest_binary, ingest_component, realize_executable, resolve_component,
+        resolve_selector,
+    };
+    use super::config::EngineConfig;
+    use super::fleet::{engine_store_root, free_local_port, settle_err};
     use super::{
         EngineAlive, EngineDied, ListComponentBinaries, ListEngineBinaries, ListEngines,
         ResolveComponent, RouteEnvelope, SpawnEngine, TerminateEngine, UploadBinary,
         UploadComponent,
     };
+    use crate::engine::kinds::ForwardEnvelope;
     use crate::engine::proxy::{EngineProxy, EngineProxyConfig, HeartbeatParams};
-    use crate::store::{
-        ArtifactKind, ArtifactStore, DEFAULT_DISK_BUDGET_BYTES, LAYOUT_VERSION_DIR, Selector,
-        StoredArtifact, StoredManifest, component_manifest,
-    };
+    use crate::store::{ArtifactStore, LAYOUT_VERSION_DIR};
     use aether_actor::actor;
     use aether_data::{EngineId, Kind, MailboxId, Uuid};
     use aether_kinds::{
-        BinaryManifest, BinarySelector, CallSettled, ComponentSelector, DeadEngineDescriptor,
-        DeathReason, EngineDescriptor, ForwardEnvelope, ListComponentBinariesResult,
+        DeadEngineDescriptor, DeathReason, EngineDescriptor, ListComponentBinariesResult,
         ListEngineBinariesResult, ListEnginesResult, ResolveComponentResult, SpawnEngineResult,
         TerminateEngineResult, UploadBinaryResult, UploadComponentResult,
     };
@@ -76,260 +94,14 @@ mod server_native {
     use aether_substrate::Subname;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
+    use aether_substrate::mail::SourceAddr;
     use aether_substrate::mail::mailer::Mailer;
-    use aether_substrate::mail::{Source, SourceAddr};
     use std::collections::HashMap;
-    use std::collections::HashSet;
     use std::collections::VecDeque;
-    use std::convert::Infallible;
-    use std::env;
-    use std::fs;
-    use std::io;
-    use std::net::TcpListener;
-    use std::path::{Path, PathBuf};
+    use std::path::PathBuf;
     use std::process::{Command, Stdio};
     use std::sync::Arc;
     use std::time::{Duration, Instant};
-
-    /// Env override for the parent directory under which the cap
-    /// allocates per-engine handle-store dirs (issue 1274). Absent →
-    /// fall through to `dirs::data_dir().join("aether/engines")`, then
-    /// to `std::env::temp_dir().join("aether-engines")` if no data dir
-    /// is resolvable.
-    const ENV_ENGINE_STORE_ROOT: &str = "AETHER_ENGINE_STORE_ROOT";
-
-    /// The chassis a `default` selector (an empty [`BinarySelector::query`]
-    /// with no attribute filters) resolves to (ADR-0115): `headless` has no
-    /// window and runs on any host, so a bare spawn is self-sufficient.
-    const DEFAULT_CHASSIS: &str = "headless";
-
-    /// Default heartbeat ping cadence (issue 1339). 5 s × the miss
-    /// limit is the detection-latency vs. flap-tolerance tradeoff.
-    const DEFAULT_HEARTBEAT_INTERVAL_SECS: u64 = 5;
-    /// Default consecutive-miss threshold before an engine is declared
-    /// dead. Small N tolerates a transient hiccup / GC pause.
-    const DEFAULT_HEARTBEAT_MISS_LIMIT: u32 = 3;
-
-    /// Default total time a freshly-forked substrate's proxy keeps
-    /// retrying its startup dial before giving up (issue 2072). A debug
-    /// cold start fork+exec+bind can stretch well past a healthy
-    /// localhost dial when many substrates come up at once and
-    /// oversubscribe the cores (e.g. a concurrent `FleetBench` fleet), so
-    /// the budget is generous — far longer than a single cold start
-    /// needs, comfortably under the `FleetBench` client's own spawn cap so
-    /// the hub returns a clean `Err` first rather than the client
-    /// tripping its backstop. `0` is the wait-forever sentinel.
-    const DEFAULT_PROXY_CONNECT_BUDGET_SECS: u64 = 30;
-
-    /// Resolved engines-cap configuration (ADR-0090, issue 1339): the
-    /// liveness-heartbeat tuning plus the hub binary store's layout dir,
-    /// disk budget, and bootstrap list (ADR-0115, #1954 — these last three
-    /// moved onto the config off their pre-ADR-0090 naked `env::var`
-    /// readers). The inline `AETHER_ENGINE_STORE_ROOT` reader
-    /// (`engine_store_root`) is a separate, still-inline knob.
-    ///
-    /// `#[derive(aether_substrate::Config)]` emits the env-shaped
-    /// `EngineConfigLayer`, the clap-shaped `EngineOverlay`, and the
-    /// inherent `from_env` / `from_argv_then_env` shims (argv beats env
-    /// beats the literal default). The hub chassis resolves it with
-    /// `EngineConfig::from_argv_then_env(cli.engine.into_layer())` and
-    /// hands it to `with_actor::<EngineServer>(cfg)`; tests build it
-    /// directly. `env_prefix = "AETHER_HUB"` + the `heartbeat_*` /
-    /// `binary_disk_budget_bytes` field names compose the
-    /// `AETHER_HUB_HEARTBEAT_*` / `AETHER_HUB_BINARY_DISK_BUDGET_BYTES`
-    /// env keys and `--hub-*` flags; `binary_store_dir` / `binary_bootstrap`
-    /// pin the unprefixed `AETHER_BINARY_STORE_DIR` / `AETHER_BINARY_BOOTSTRAP`
-    /// keys via per-field `env` overrides. `Default` (the test constructor)
-    /// resolves the heartbeat to `0/0` (disabled) and the store fields to
-    /// unset / `16 GiB`; production picks up the `default = 5/3` / `16 GiB`
-    /// literals and the env layers through `from_argv_then_env`.
-    #[derive(Clone, Debug, aether_substrate::Config)]
-    #[config(env_prefix = "AETHER_HUB", cli_prefix = "hub")]
-    pub struct EngineConfig {
-        /// Heartbeat ping cadence in seconds
-        /// (`AETHER_HUB_HEARTBEAT_INTERVAL_SECS` /
-        /// `--hub-heartbeat-interval-secs`). `0` disables the heartbeat
-        /// entirely (engines are then only evicted on a
-        /// connection-close, never on a wedge).
-        #[config(default = 5, parse = parse_heartbeat_interval_secs)]
-        pub heartbeat_interval_secs: u64,
-        /// Consecutive missed pings that mark an engine dead
-        /// (`AETHER_HUB_HEARTBEAT_MISS_LIMIT` /
-        /// `--hub-heartbeat-miss-limit`). Small N tolerates a transient
-        /// hiccup; `0` also disables the heartbeat. Detection latency is
-        /// `miss_limit × interval_secs`.
-        #[config(default = 3, parse = parse_heartbeat_miss_limit)]
-        pub heartbeat_miss_limit: u32,
-        /// Total seconds a freshly-forked substrate's proxy keeps
-        /// retrying its startup dial before the spawn fails
-        /// (`AETHER_HUB_PROXY_CONNECT_BUDGET_SECS` /
-        /// `--hub-proxy-connect-budget-secs`, issue 2072). Generous by
-        /// default so a debug cold start under fork contention isn't
-        /// called dead prematurely; `0` is the wait-forever sentinel
-        /// (retry until the dial succeeds or hits a terminal error).
-        #[config(default = 30, parse = parse_proxy_connect_budget_secs)]
-        pub proxy_connect_budget_secs: u64,
-        /// Layout-root override for the hub's content-addressed binary
-        /// store (`AETHER_BINARY_STORE_DIR`, unprefixed — the ops escape
-        /// hatch and the fleet tests' per-process isolation knob). Unset
-        /// (`None`) → the computed default `data_dir/aether/binaries/v1`
-        /// (`ArtifactStore::default_root`). A bare `Option<String>` (not a
-        /// `PathBuf`) keeps that runtime-computed default in `init`, so
-        /// `EngineConfig` needs no `skip_from_layer`; `EngineServer::init`
-        /// joins the store's layout-version dir to a set override.
-        #[config(env = "AETHER_BINARY_STORE_DIR")]
-        pub binary_store_dir: Option<String>,
-        /// On-disk byte budget for the binary store
-        /// (`AETHER_HUB_BINARY_DISK_BUDGET_BYTES`, derived from the
-        /// `AETHER_HUB` prefix / `--hub-binary-disk-budget-bytes`). Default
-        /// 16 GiB (`DEFAULT_DISK_BUDGET_BYTES`); LRU eviction over unpinned,
-        /// unnamed entries holds it.
-        #[config(default = 17_179_869_184u64, parse = parse_binary_disk_budget)]
-        pub binary_disk_budget_bytes: u64,
-        /// Chassis bins to bootstrap-ingest at init so a `default` / `name`
-        /// selector resolves in a fresh or `restart-hub`'d hub
-        /// (`AETHER_BINARY_BOOTSTRAP`, unprefixed, comma-separated). Each is
-        /// ingested content-addressed and named by its file stem;
-        /// idempotent via content dedup. `ensure-tunnel.sh` exports the
-        /// freshly-built chassis bins here.
-        #[config(
-            env = "AETHER_BINARY_BOOTSTRAP",
-            default = [],
-            parse = parse_binary_bootstrap,
-            csv_set
-        )]
-        pub binary_bootstrap: HashSet<String>,
-    }
-
-    impl Default for EngineConfig {
-        /// The test constructor: heartbeat disabled (`0/0`) but a real
-        /// `DEFAULT_DISK_BUDGET_BYTES` budget — `0` is inert for the
-        /// heartbeat (no pinging) yet destructive for the store (it would
-        /// evict every unnamed upload), so the budget can't share the
-        /// heartbeat's zero. Store dir unset (the computed default) and an
-        /// empty bootstrap. Production resolves all five through the layer
-        /// (`from_argv_then_env`); this matches the prior `from_env()`
-        /// store budget every `EngineConfig::default()` consumer saw.
-        fn default() -> Self {
-            Self {
-                heartbeat_interval_secs: 0,
-                heartbeat_miss_limit: 0,
-                // A real budget (not the heartbeat's inert `0`): tests fork
-                // real substrates, so the proxy needs a generous-but-finite
-                // startup-dial budget — `0` would mean wait-forever and
-                // hang on a genuinely dead substrate.
-                proxy_connect_budget_secs: DEFAULT_PROXY_CONNECT_BUDGET_SECS,
-                binary_store_dir: None,
-                binary_disk_budget_bytes: DEFAULT_DISK_BUDGET_BYTES,
-                binary_bootstrap: HashSet::new(),
-            }
-        }
-    }
-
-    impl EngineConfig {
-        /// The [`HeartbeatParams`] to arm each proxy with, or `None`
-        /// when the heartbeat is disabled (`0` interval or miss limit).
-        fn heartbeat_params(&self) -> Option<HeartbeatParams> {
-            if self.heartbeat_interval_secs == 0 || self.heartbeat_miss_limit == 0 {
-                None
-            } else {
-                Some(HeartbeatParams {
-                    interval: Duration::from_secs(self.heartbeat_interval_secs),
-                    miss_limit: self.heartbeat_miss_limit,
-                })
-            }
-        }
-
-        /// The startup-dial connect budget to arm each spawned proxy
-        /// with (issue 2072). `Some(d)` caps the retry; `None` (the `0`
-        /// sentinel) means wait forever.
-        fn connect_budget(&self) -> Option<Duration> {
-            (self.proxy_connect_budget_secs != 0)
-                .then(|| Duration::from_secs(self.proxy_connect_budget_secs))
-        }
-    }
-
-    // confique's `parse_env` contract is `fn(&str) -> Result<T, impl
-    // Error>`; these total helpers carry a `Result` they never fill with
-    // `Err` — an unparseable value folds back to the default (soft, like
-    // the DAG validator's caps; the ADR-0090 §4 strict/erroring variant
-    // is a follow-up). Hence the `unnecessary_wraps` allow.
-
-    /// Parse the heartbeat interval; unparseable → the default.
-    #[allow(clippy::unnecessary_wraps)]
-    fn parse_heartbeat_interval_secs(s: &str) -> Result<u64, Infallible> {
-        Ok(s.trim().parse().unwrap_or(DEFAULT_HEARTBEAT_INTERVAL_SECS))
-    }
-
-    /// Parse the heartbeat miss limit; unparseable → the default.
-    #[allow(clippy::unnecessary_wraps)]
-    fn parse_heartbeat_miss_limit(s: &str) -> Result<u32, Infallible> {
-        Ok(s.trim().parse().unwrap_or(DEFAULT_HEARTBEAT_MISS_LIMIT))
-    }
-
-    /// Parse the proxy connect budget seconds; unparseable → the default.
-    #[allow(clippy::unnecessary_wraps)]
-    fn parse_proxy_connect_budget_secs(s: &str) -> Result<u64, Infallible> {
-        Ok(s.trim()
-            .parse()
-            .unwrap_or(DEFAULT_PROXY_CONNECT_BUDGET_SECS))
-    }
-
-    /// Parse the binary-store disk budget; unparseable → the default
-    /// `DEFAULT_DISK_BUDGET_BYTES` (mirrors the heartbeat parsers).
-    #[allow(clippy::unnecessary_wraps)]
-    fn parse_binary_disk_budget(s: &str) -> Result<u64, Infallible> {
-        Ok(s.trim().parse().unwrap_or(DEFAULT_DISK_BUDGET_BYTES))
-    }
-
-    /// Split a comma-separated bootstrap path list, trimming and dropping
-    /// empties (mirrors the http allowlist's `parse_allowlist`). Total —
-    /// never errors.
-    #[allow(clippy::unnecessary_wraps)]
-    fn parse_binary_bootstrap(s: &str) -> Result<HashSet<String>, Infallible> {
-        Ok(s.split(',')
-            .map(str::trim)
-            .filter(|p| !p.is_empty())
-            .map(str::to_string)
-            .collect())
-    }
-
-    #[cfg(test)]
-    mod config_tests {
-        use super::*;
-
-        /// The connect budget resolves a non-zero seconds value to a
-        /// finite `Duration`, and `0` to the wait-forever sentinel `None`.
-        #[test]
-        fn connect_budget_maps_zero_to_wait_forever() {
-            let finite = EngineConfig {
-                proxy_connect_budget_secs: 12,
-                ..EngineConfig::default()
-            };
-            assert_eq!(finite.connect_budget(), Some(Duration::from_secs(12)));
-            let forever = EngineConfig {
-                proxy_connect_budget_secs: 0,
-                ..EngineConfig::default()
-            };
-            assert_eq!(forever.connect_budget(), None);
-        }
-
-        /// The default budget is generous and finite — never the
-        /// wait-forever sentinel — so a debug cold start under fork
-        /// contention isn't called dead prematurely, while a genuinely
-        /// dead substrate still fails the spawn rather than hanging.
-        #[test]
-        fn default_connect_budget_is_generous_and_finite() {
-            let budget = EngineConfig::default()
-                .connect_budget()
-                .expect("default budget is finite, not wait-forever");
-            assert_eq!(
-                budget,
-                Duration::from_secs(DEFAULT_PROXY_CONNECT_BUDGET_SECS)
-            );
-            assert!(budget >= Duration::from_secs(30), "default stays generous");
-        }
-    }
 
     /// How many recently-died engines [`EngineServer`] retains for
     /// `list_engines`' `recently_died` sidecar (issue 1906). A small
@@ -896,365 +668,6 @@ mod server_native {
             }
         }
     }
-
-    /// Fork `binary_path --describe` and parse the JSON manifest it prints
-    /// (ADR-0115, issue 1953). The one-time capture of what a binary *is* —
-    /// its chassis kind, linked caps, and build provenance — without the
-    /// hub linking the chassis crate. `stdin` is nulled so a describe can't
-    /// block on input.
-    fn describe_binary(binary_path: &str) -> Result<BinaryManifest, String> {
-        let output = Command::new(binary_path)
-            .arg("--describe")
-            .stdin(Stdio::null())
-            .output()
-            .map_err(|e| format!("forking {binary_path:?} --describe: {e}"))?;
-        if !output.status.success() {
-            return Err(format!(
-                "{binary_path:?} --describe exited {}: {}",
-                output.status,
-                String::from_utf8_lossy(&output.stderr).trim(),
-            ));
-        }
-        serde_json::from_slice(&output.stdout)
-            .map_err(|e| format!("parsing {binary_path:?} --describe manifest JSON: {e}"))
-    }
-
-    /// Ingest the binary at `path` into `store` content-addressed,
-    /// capturing its manifest via a one-time `<path> --describe` fork
-    /// (ADR-0115, issue 1953). Shared by the `on_upload_binary` handler and
-    /// the [`bootstrap_ingest`] boot path. Returns the stored content hash,
-    /// or a human-readable error for an unreadable path or a `--describe`
-    /// that failed / yielded no parseable manifest. Idempotent — identical
-    /// bytes dedup to the same hash.
-    fn ingest_binary(
-        store: &mut ArtifactStore,
-        path: &str,
-        name: Option<String>,
-    ) -> Result<String, String> {
-        let bytes = fs::read(path).map_err(|e| format!("reading binary path {path:?}: {e}"))?;
-        let manifest = describe_binary(path)?;
-        Ok(store.upload(
-            &bytes,
-            ArtifactKind::Binary,
-            StoredManifest::Binary(manifest),
-            name,
-        ))
-    }
-
-    /// Bootstrap-ingest each chassis bin in `paths` into `store`, naming
-    /// each by its file stem so a `default` / `name` selector resolves in a
-    /// fresh or `restart-hub`'d hub (ADR-0115, issue 1954). The list rides
-    /// `EngineConfig`'s `binary_bootstrap` field (its `AETHER_BINARY_BOOTSTRAP`
-    /// env layer, ADR-0090). A path that can't be read or `--describe`d is
-    /// logged and skipped — a bad bootstrap entry must not fail hub boot.
-    /// Idempotent via content dedup.
-    pub(super) fn bootstrap_ingest(store: &mut ArtifactStore, paths: &HashSet<String>) {
-        for path_str in paths {
-            let name = Path::new(path_str)
-                .file_stem()
-                .and_then(|stem| stem.to_str())
-                .map(str::to_owned);
-            match ingest_binary(store, path_str, name) {
-                Ok(hash) => tracing::info!(
-                    target: "aether_substrate::engine_server",
-                    path = path_str.as_str(),
-                    hash = %hash,
-                    "binary bootstrap: ingested a chassis bin",
-                ),
-                Err(error) => tracing::warn!(
-                    target: "aether_substrate::engine_server",
-                    path = path_str.as_str(),
-                    error = %error,
-                    "binary bootstrap: skipping a bin that failed to ingest",
-                ),
-            }
-        }
-    }
-
-    /// Ingest the component wasm at `path` into `store` content-addressed,
-    /// reading its manifest straight from the wasm (ADR-0116, issue 1956) —
-    /// no execution step. Returns the stored content hash, or a
-    /// human-readable error for an unreadable path or an unparseable wasm.
-    /// Idempotent — identical bytes dedup to the same hash.
-    fn ingest_component(
-        store: &mut ArtifactStore,
-        path: &str,
-        name: Option<String>,
-    ) -> Result<String, String> {
-        let bytes = fs::read(path).map_err(|e| format!("reading component path {path:?}: {e}"))?;
-        let manifest = component_manifest(&bytes)
-            .map_err(|e| format!("reading component manifest from {path:?}: {e}"))?;
-        Ok(store.upload(
-            &bytes,
-            ArtifactKind::Component,
-            StoredManifest::Component(manifest),
-            name,
-        ))
-    }
-
-    /// Resolve a [`ComponentSelector`] against `store` to its wasm bytes +
-    /// manifest (ADR-0116, issue 1956). Resolution order mirrors the binary
-    /// selector: an exact `query` token wins first (`hash` > `module@actor`
-    /// > `name@version` (latest in v1) > `name`); absent a token, the
-    /// `namespace` / `handled_kind` attribute query resolves, where a query
-    /// matching more than one component is a clean ambiguity error (never a
-    /// silent pick). A `module@actor` token's `@actor` part populates the
-    /// reply `export` so the forwarded `LoadComponent` instantiates that
-    /// actor type (ADR-0096). Returns `Err` for no match / ambiguity.
-    fn resolve_component(
-        store: &mut ArtifactStore,
-        selector: &ComponentSelector,
-    ) -> ResolveComponentResult {
-        // An exact token, with the `@actor` half (if any) split off as the
-        // export selector forwarded to the substrate.
-        if let Some(token) = selector
-            .query
-            .as_deref()
-            .map(str::trim)
-            .filter(|t| !t.is_empty())
-        {
-            return resolve_component_token(store, token);
-        }
-        // No exact token: a namespace / handled-kind attribute query. A
-        // match-more-than-one is a clean ambiguity error.
-        let mut matches = store.list_components(&ListComponentBinaries {
-            namespace: selector.namespace.clone(),
-            handled_kind: selector.handled_kind,
-        });
-        match matches.len() {
-            0 => ResolveComponentResult::Err {
-                error: format!(
-                    "no stored component matches the attribute query (namespace = {:?}, handled_kind = {:?})",
-                    selector.namespace, selector.handled_kind,
-                ),
-            },
-            1 => {
-                let hash = matches.remove(0).hash;
-                stored_component_reply(store, &hash, None)
-            }
-            n => ResolveComponentResult::Err {
-                error: format!(
-                    "the attribute query (namespace = {:?}, handled_kind = {:?}) matches {n} components — narrow it to a single component (by hash or name)",
-                    selector.namespace, selector.handled_kind,
-                ),
-            },
-        }
-    }
-
-    /// Resolve an exact component selector token to a [`ResolveComponentResult`]
-    /// (ADR-0116). A `module@actor` token splits into the `module`
-    /// hash/name and the `@actor` export selector; a `name@version` token
-    /// is treated as `name` (latest) — v1 keeps no per-name version index;
-    /// a bare token resolves as a hash first, then a name.
-    fn resolve_component_token(store: &mut ArtifactStore, token: &str) -> ResolveComponentResult {
-        // `module@actor` (ADR-0096) takes precedence: the `@actor` half is a
-        // component `Addressable::NAMESPACE`, distinct from a binary `name@version`
-        // build id. Resolve the module half (hash, then name), forward the
-        // actor half as `export`.
-        if let Some((module, actor)) = token.split_once('@') {
-            // A hash never contains `@`, so the module half resolves as a
-            // hash first, then a name (latest). The actor half is the export.
-            if store.contains(module) {
-                return stored_component_reply(store, module, Some(actor.to_owned()));
-            }
-            if let Some(found) = store.get(&Selector::Name(module.to_owned())) {
-                return stored_component_reply(store, &found.hash, Some(actor.to_owned()));
-            }
-            return ResolveComponentResult::Err {
-                error: format!("no stored component matches the selector {token:?}"),
-            };
-        }
-        // A bare token: an exact hash wins, else a name (latest).
-        if store.contains(token) {
-            return stored_component_reply(store, token, None);
-        }
-        if let Some(found) = store.get(&Selector::Name(token.to_owned())) {
-            return stored_component_reply(store, &found.hash, None);
-        }
-        ResolveComponentResult::Err {
-            error: format!("no stored component matches the selector {token:?}"),
-        }
-    }
-
-    /// Read the stored component `hash`'s wasm bytes + manifest off disk and
-    /// build a `ResolveComponentResult::Ok` (ADR-0116). `export` threads a
-    /// `module@actor` selector's actor half through to the forwarded
-    /// `LoadComponent.export`. An entry that isn't a component (a binary
-    /// hash) or whose bytes can't be read is a clean `Err`.
-    fn stored_component_reply(
-        store: &mut ArtifactStore,
-        hash: &str,
-        export: Option<String>,
-    ) -> ResolveComponentResult {
-        let Some(found) = store.get(&Selector::Hash(hash.to_owned())) else {
-            return ResolveComponentResult::Err {
-                error: format!("no stored artifact has hash {hash:?}"),
-            };
-        };
-        let Some(manifest) = found.manifest.as_component().cloned() else {
-            return ResolveComponentResult::Err {
-                error: format!("artifact {hash:?} is not a component"),
-            };
-        };
-        let wasm = match fs::read(&found.path) {
-            Ok(bytes) => bytes,
-            Err(e) => {
-                return ResolveComponentResult::Err {
-                    error: format!("reading stored component bytes for {hash:?}: {e}"),
-                };
-            }
-        };
-        ResolveComponentResult::Ok {
-            hash: found.hash,
-            wasm,
-            name: found.name,
-            manifest,
-            export,
-        }
-    }
-
-    /// Resolve a [`BinarySelector`] against `store` to the stored content
-    /// bytes the spawn forks (ADR-0115). Resolution order: an exact `query`
-    /// token wins first (`hash` > `name@version` > `name`); absent a token,
-    /// the `chassis` / `caps` / `target` attribute query resolves, and with
-    /// no attribute filters either, `default` = the [`DEFAULT_CHASSIS`]
-    /// binary. `None` when nothing matched.
-    pub(super) fn resolve_selector(
-        store: &mut ArtifactStore,
-        selector: &BinarySelector,
-    ) -> Option<StoredArtifact> {
-        if let Some(token) = selector
-            .query
-            .as_deref()
-            .map(str::trim)
-            .filter(|t| !t.is_empty())
-        {
-            // Exact hash wins outright.
-            if let Some(found) = store.get(&Selector::Hash(token.to_owned())) {
-                return Some(found);
-            }
-            // `name@version`: the binary's self-reported build id (the
-            // manifest `git_sha`) pins a specific entry of a name.
-            if let Some((name, version)) = token.split_once('@') {
-                let hash = pick_versioned(store, name, version)?;
-                return store.get(&Selector::Hash(hash));
-            }
-            // A bare name points at the latest hash uploaded under it.
-            return store.get(&Selector::Name(token.to_owned()));
-        }
-        // No exact token: an attribute query, else `default` = headless.
-        let hash = store
-            .list_binaries(&attribute_filter(selector))
-            .into_iter()
-            .map(|entry| entry.hash)
-            .min()?;
-        store.get(&Selector::Hash(hash))
-    }
-
-    /// The store filter for a tokenless [`BinarySelector`]: the explicit
-    /// `chassis` / `caps` / `target` attribute query, or — when none is
-    /// set — the `default` filter selecting the [`DEFAULT_CHASSIS`]
-    /// chassis.
-    fn attribute_filter(selector: &BinarySelector) -> ListEngineBinaries {
-        if selector.chassis.is_none() && selector.caps.is_empty() && selector.target.is_none() {
-            ListEngineBinaries {
-                chassis: Some(DEFAULT_CHASSIS.to_owned()),
-                caps: Vec::new(),
-                target: None,
-            }
-        } else {
-            ListEngineBinaries {
-                chassis: selector.chassis.clone(),
-                caps: selector.caps.clone(),
-                target: selector.target.clone(),
-            }
-        }
-    }
-
-    /// The content hash of the entry named `name` whose manifest build id
-    /// (`git_sha`) is `version` — the `name@version` selector (ADR-0115).
-    /// `None` when no current entry matches both.
-    fn pick_versioned(store: &ArtifactStore, name: &str, version: &str) -> Option<String> {
-        store
-            .list_binaries(&ListEngineBinaries::default())
-            .into_iter()
-            .find(|entry| entry.name.as_deref() == Some(name) && entry.manifest.git_sha == version)
-            .map(|entry| entry.hash)
-    }
-
-    /// Copy the content bytes at `src` to `dest` and mark `dest`
-    /// executable (`0o755` on Unix; the `from_mode` precedent in
-    /// `anthropic/cli.rs`), creating `dest`'s parent dir. The
-    /// realize-to-exec step for spawn: stored bytes aren't directly
-    /// fork-exec'able (ADR-0115 §Execution).
-    fn realize_executable(src: &Path, dest: &Path) -> io::Result<()> {
-        if let Some(parent) = dest.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        fs::copy(src, dest)?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            fs::set_permissions(dest, fs::Permissions::from_mode(0o755))?;
-        }
-        Ok(())
-    }
-
-    /// Push a `CallSettled::Err` back to `target` (correlation
-    /// preserved) so a routed call that the cap can't satisfy — bad
-    /// `engine_id`, unknown engine — closes with a wire `ReplyEnd`
-    /// instead of leaving the RPC client hanging.
-    fn settle_err(mailer: &Arc<Mailer>, target: MailboxId, correlation: u64, error: String) {
-        mailer.push(
-            Mail::new(
-                target,
-                <CallSettled as Kind>::ID,
-                CallSettled::Err { error }.encode_into_bytes(),
-                1,
-            )
-            .with_reply_to(Source::with_correlation(SourceAddr::None, correlation)),
-        );
-    }
-
-    /// Bind `127.0.0.1:0`, read the OS-assigned port, drop the
-    /// listener. A tiny TOCTOU window exists before the substrate
-    /// rebinds the port, but on localhost it's negligible — and this
-    /// sidesteps both a wire change to report an ephemeral port back
-    /// from the substrate and an un-recycled incrementing port pool.
-    fn free_local_port() -> io::Result<u16> {
-        let listener = TcpListener::bind("127.0.0.1:0")?;
-        let port = listener.local_addr()?.port();
-        drop(listener);
-        Ok(port)
-    }
-
-    /// Parent directory under which the cap allocates per-engine
-    /// handle-store dirs (issue 1274). Priority:
-    ///
-    /// 1. `AETHER_ENGINE_STORE_ROOT` env override (ops escape hatch).
-    /// 2. `dirs::data_dir().join("aether/engines")` (cross-platform
-    ///    default — `~/Library/Application Support/aether/engines` on
-    ///    macOS, `$XDG_DATA_HOME/aether/engines` on Linux, etc.).
-    /// 3. `std::env::temp_dir().join("aether-engines")` if no data
-    ///    dir is resolvable.
-    // External ops escape hatch (AETHER_ENGINE_STORE_ROOT) for the per-engine
-    // spawn-dir parent — the directory forked substrates and their handle
-    // stores live under, resolved in a static spawn helper. #1968 deliberately
-    // kept this knob inline (separate from the binary-artifact store, which it
-    // moved onto EngineConfig); it is a process-level deployment override, not
-    // a cap config field.
-    #[allow(clippy::disallowed_methods)]
-    fn engine_store_root() -> PathBuf {
-        if let Ok(raw) = env::var(ENV_ENGINE_STORE_ROOT)
-            && !raw.is_empty()
-        {
-            return PathBuf::from(raw);
-        }
-        if let Some(data) = dirs::data_dir() {
-            return data.join("aether").join("engines");
-        }
-        env::temp_dir().join("aether-engines")
-    }
 }
 
 // The sink's handler-signature kinds must be importable at file root
@@ -1335,13 +748,14 @@ mod tests {
     // for fixture wiring — reference id derivation, not sibling-cap addressing.
     #![allow(clippy::disallowed_methods)]
     use super::{EngineConfig, EngineServer, ReplyCells, ReplySink};
+    use crate::engine::kinds::{EngineAlive, EngineDied};
     use crate::test_chassis::TestChassis;
     use aether_actor::Addressable;
     use aether_data::{Kind, mailbox_id_from_name};
     use aether_kinds::descriptors;
     use aether_kinds::{
-        BinarySelector, DeathReason, EngineAlive, EngineDied, ListEngines, SpawnEngine,
-        SpawnEngineResult, TerminateEngine, TerminateEngineResult,
+        BinarySelector, DeathReason, ListEngines, SpawnEngine, SpawnEngineResult, TerminateEngine,
+        TerminateEngineResult,
     };
     use aether_substrate::chassis::builder::{Builder, PassiveChassis};
     use aether_substrate::mail::mailer::Mailer;
@@ -1496,7 +910,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn bootstrap_populates_and_default_resolves_to_headless() {
-        use super::server_native::{bootstrap_ingest, resolve_selector};
+        use super::artifacts::{bootstrap_ingest, resolve_selector};
         use crate::store::{ArtifactStore, DEFAULT_DISK_BUDGET_BYTES};
         use std::collections::HashSet;
         use std::fs;

--- a/crates/aether-capabilities/src/rpc/server.rs
+++ b/crates/aether-capabilities/src/rpc/server.rs
@@ -37,6 +37,7 @@ use aether_rpc::rpc::PeerKind;
 mod server_native {
     use super::{PeerKind, RpcInboundReady, Settled};
     use crate::engine::EngineServer;
+    use crate::engine::kinds::{CallSettled, RouteEnvelope};
     use crate::rpc::{
         Hello, HelloAck, MailEnvelope, MailboxAddress, RpcError, WIRE_VERSION, WireFrame,
     };
@@ -44,7 +45,6 @@ mod server_native {
     use aether_codec::frame::FrameError;
     use aether_codec::frame::{read_frame, write_frame};
     use aether_data::{Kind, KindId, MailId, MailboxId, mailbox_id_from_name};
-    use aether_kinds::{CallSettled, RouteEnvelope};
     use aether_substrate::Mail;
     use aether_substrate::actor::native::envelope::Envelope;
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -987,27 +987,6 @@ mod engine {
 
     use serde::{Deserialize, Serialize};
 
-    /// `aether.engine.forward` — hand a per-engine proxy
-    /// (`aether.engine.proxy:<id>`) one mail to relay to its substrate
-    /// over the proxy's outbound RPC connection. Issue 763 P3.
-    ///
-    /// Carries the *remote* target explicitly: a plain mail to the
-    /// proxy is only `kind` + `payload` — it can't say *which mailbox
-    /// on the substrate* to deliver to. `ForwardEnvelope` is that
-    /// carrier. The proxy wraps `mailbox` + `kind` + the already-encoded
-    /// `payload` into an RPC `Call`; the substrate's
-    /// `RpcServerCapability` dispatches it into its local actor system.
-    /// Any reply streams back through the proxy and routes to whoever
-    /// sent this `ForwardEnvelope` — the proxy keys reply correlation
-    /// off the inbound mail's `Source`.
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.engine.forward")]
-    pub struct ForwardEnvelope {
-        pub mailbox: aether_data::MailboxId,
-        pub kind: aether_data::KindId,
-        pub payload: Vec<u8>,
-    }
-
     /// `aether.engine.list` — ask the engines cap (`aether.engine`) to
     /// enumerate every engine it currently supervises. Fieldless
     /// request; the reply is a [`ListEnginesResult`]. Issue 763 P4.
@@ -1039,7 +1018,7 @@ mod engine {
     }
 
     /// Why an engine left the supervised-engine table, as carried in a
-    /// [`DeadEngineDescriptor`] (and in the [`EngineDied`] signal for the
+    /// [`DeadEngineDescriptor`] (and in the `EngineDied` signal for the
     /// two self-death paths). A tagged enum so an observer can branch on
     /// the cause without parsing free text; the `detail` string on the
     /// non-clean variants carries the specifics.
@@ -1180,97 +1159,6 @@ mod engine {
     pub enum TerminateEngineResult {
         Ok,
         Err { error: String },
-    }
-
-    /// `aether.engine.route` — ask the engines cap (`aether.engine`) to
-    /// relay one mail to a *specific* engine's substrate. Issue 763 P5a.
-    ///
-    /// The engine-addressed sibling of [`ForwardEnvelope`]: where
-    /// `ForwardEnvelope` already names a proxy and only needs the
-    /// substrate-local `mailbox` + `kind` + `payload`, `RouteEnvelope`
-    /// also carries the `engine_id`, because the sender (the hub's
-    /// `RpcServerCapability`, relaying an `engine = Some(_)` wire
-    /// `Call`) doesn't know which proxy hosts that engine. The engines
-    /// cap looks the engine up in its table and re-emits a
-    /// `ForwardEnvelope` at the right `aether.engine.proxy:<id>`,
-    /// propagating the original reply-to so the substrate's reply
-    /// streams back to the originating `RpcServerCapability`.
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.engine.route")]
-    pub struct RouteEnvelope {
-        pub engine_id: String,
-        pub mailbox: aether_data::MailboxId,
-        pub kind: aether_data::KindId,
-        pub payload: Vec<u8>,
-    }
-
-    /// `aether.engine.call_settled` — a per-engine proxy's signal that
-    /// a forwarded RPC call has run to completion. Issue 763 P5a.
-    ///
-    /// When the proxy relays a [`ForwardEnvelope`] as an RPC `Call`,
-    /// the substrate eventually answers with a wire `ReplyEnd`. The
-    /// proxy lifts that terminal frame into this kind and pushes it
-    /// back to whoever opened the call (correlation preserved) — the
-    /// hub's `RpcServerCapability` matches it to the in-flight wire
-    /// call and writes its own `ReplyEnd` to the RPC client. (Local,
-    /// non-forwarded calls close on chassis settlement instead; a
-    /// forwarded call has no local chain to settle, so it needs this
-    /// explicit terminal signal.) `Err` carries the wire `RpcError`
-    /// rendered as a string — the structured variant doesn't survive
-    /// the `aether-kinds` layer, which can't depend on the RPC crate.
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.engine.call_settled")]
-    pub enum CallSettled {
-        Ok,
-        Err { error: String },
-    }
-
-    /// `aether.engine.heartbeat_tick` — the per-engine proxy's own
-    /// liveness timer wake (issue 1339). Internal control-plane mail,
-    /// not a user surface: a sidecar thread the proxy spawns at init
-    /// fires this (empty-payload) at the proxy's own mailbox every
-    /// heartbeat interval, the same wake-mail shape `RpcInboundReady`
-    /// uses for the reader sidecar. The handler pings the substrate and
-    /// counts consecutive misses, evicting the engine once the miss
-    /// limit is crossed.
-    #[derive(
-        aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default,
-    )]
-    #[kind(name = "aether.engine.heartbeat_tick")]
-    pub struct EngineHeartbeatTick {}
-
-    /// `aether.engine.died` — a per-engine proxy telling the engines
-    /// cap (`aether.engine`) that its substrate is gone, so the cap
-    /// drops it from the supervised-engine table (issue 1339). The
-    /// proxy sends this when it observes the connection close (`Bye` /
-    /// `eof`) or when the liveness heartbeat crosses its miss limit —
-    /// the positive signal the lazy connection-drop path misses for a
-    /// wedged-but-alive engine. Idempotent on the cap side: a `died`
-    /// for an already-removed engine (e.g. one a concurrent
-    /// `TerminateEngine` already dropped) is a no-op. `engine_id` is
-    /// the plain UUID string, matching [`TerminateEngine`].
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.engine.died")]
-    pub struct EngineDied {
-        pub engine_id: String,
-        /// Why the proxy is reporting the death, so the cap can record it
-        /// into its recently-died ring: `Crashed` for a connection-close
-        /// (`Bye` / eof), `Evicted` for a heartbeat miss-limit crossing. A
-        /// deliberate terminate never sends `EngineDied` — the cap records
-        /// `Terminated` itself at the removal site.
-        pub reason: DeathReason,
-    }
-
-    /// `aether.engine.alive` — a per-engine proxy reporting a confirmed
-    /// liveness signal (a `Pong` answering its heartbeat `Ping`) to the
-    /// engines cap (issue 1339). The cap stamps the engine's
-    /// last-seen-alive time so [`ListEnginesResult`] can report
-    /// `last_heartbeat_age_millis`. Fire-and-forget; an `alive` for an
-    /// unknown engine is a no-op. `engine_id` is the plain UUID string.
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.engine.alive")]
-    pub struct EngineAlive {
-        pub engine_id: String,
     }
 
     /// What a stored binary *is*, captured once at upload time by forking
@@ -4512,31 +4400,6 @@ mod tests {
             Some("test_fixture_probe")
         );
         assert_eq!(back.selector.handled_kind, Some(Tick::ID));
-    }
-
-    #[test]
-    fn engine_died_carries_death_reason() {
-        // `EngineDied` gained a `reason` field — the proxy's self-death
-        // paths tag the cause (`Crashed` for a `Bye`, `Evicted` for a
-        // heartbeat miss). Both the id and the tagged reason must survive
-        // the structured encode/decode the proxy → cap mail rides.
-        use alloc::string::ToString;
-
-        let died = EngineDied {
-            engine_id: "00000000-0000-0000-0000-000000000001".to_string(),
-            reason: DeathReason::Crashed {
-                detail: "peer closed: eof".to_string(),
-            },
-        };
-        let back = EngineDied::decode_from_bytes(&died.encode_into_bytes())
-            .expect("test setup: EngineDied decodes");
-        assert_eq!(back.engine_id, died.engine_id);
-        assert_eq!(
-            back.reason,
-            DeathReason::Crashed {
-                detail: "peer closed: eof".to_string(),
-            },
-        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #2174.

## Summary

Part of the ADR-0121 capabilities-own-their-kinds refactor (one capability = one PR). The `engine` capability takes ownership of its internal kinds and splits its server and proxy.

The six engine-internal kinds (`ForwardEnvelope`, `RouteEnvelope`, `CallSettled`, `EngineHeartbeatTick`, `EngineDied`, `EngineAlive`) move out of `aether-kinds` into `engine/kinds.rs`; the MCP-harness request/result/descriptor family stays central. `engine/server.rs` splits into `server/{mod,config,artifacts,fleet}` and `engine/proxy.rs` into `proxy/{mod,config,connect,heartbeat,sinks}`. The macro-coupled handlers and field-touching methods stay in each `mod.rs`; field-independent helpers move to siblings, with no `pub(super)` field loosening. No wire change.

## Test plan

- The `EngineDied` round-trip test moves alongside its kind; the FleetBench engine-cap wire tests (`engines_cap`, `fleetbench_spawn`/`mail`/`terminate`/`binary_store`, `rpc_engine_routing`) all run green.
- `cargo fmt -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace` (2029 passed, 9 skipped), `cargo doc --workspace --no-deps` under the strict CI rustdoc flags, and the wasm32 cross-build all pass.

## Generated by

`/implement` — agent execution of [scoped issue #2174](https://github.com/iamacoffeepot/aether/issues/2174).
