### PR TITLE
refactor(capabilities): make anthropic own its kinds

### DIFF
--- a/crates/aether-capabilities/src/anthropic/error.rs
+++ b/crates/aether-capabilities/src/anthropic/error.rs
@@ -6,7 +6,7 @@
 //! failure modes inline. Keeping the status table here keeps the
 //! provider-compat translation in one place per ADR-0050 §4.
 
-use aether_kinds::AnthropicError;
+use crate::anthropic::kinds::AnthropicError;
 
 use crate::anthropic::cli::{CLI_NOT_FOUND, TIMEOUT_SENTINEL};
 use crate::contentgen::shared::{parse_status_prefix, snippet};
@@ -70,7 +70,7 @@ pub fn status_to_error(status: u16, retry_after_ms: Option<u32>, body: &str) -> 
 mod tests {
     use super::{adapter_error_to_typed, status_to_error};
     use crate::anthropic::cli::TIMEOUT_SENTINEL;
-    use aether_kinds::AnthropicError;
+    use crate::anthropic::kinds::AnthropicError;
 
     #[test]
     fn timeout_sentinel_maps_to_timeout() {

--- a/crates/aether-capabilities/src/anthropic/kinds.rs
+++ b/crates/aether-capabilities/src/anthropic/kinds.rs
@@ -1,0 +1,219 @@
+//! Wire kinds for the `aether.anthropic` capability (ADR-0050, ADR-0121).
+//!
+//! The seven anthropic-specific types moved here from `aether-kinds` so the
+//! capability owns its mail vocabulary. [`aether_kinds::Usage`] stays central
+//! — it is shared with the `aether.gemini` result kinds, so moving it here
+//! would force gemini to reach across capabilities.
+
+use serde::{Deserialize, Serialize};
+
+use aether_kinds::Usage;
+
+/// Conversation role on a [`Message`]. The Messages API only
+/// distinguishes user vs assistant turns; `system` rides as a
+/// separate top-level field on the request, not a role.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    User,
+    Assistant,
+}
+
+/// One turn in an Anthropic completion request. `content` is the
+/// flat text of the turn (v1 doesn't model multi-part content
+/// blocks); `role` distinguishes user from assistant.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct Message {
+    pub role: Role,
+    pub content: String,
+}
+
+/// Structured failure reason for an Anthropic completion (ADR-0050
+/// §1). Typed variants cover the branches a caller routinely
+/// matches on — `Overloaded` / `RateLimited` → back off,
+/// `ContextLengthExceeded` → trim the prompt, `Unauthorized` →
+/// config issue, `ContentPolicyRefused` → surface to the user,
+/// `CliNotFound` → the `claude` binary isn't on PATH,
+/// `UnknownModel` → typo / unsupported id,
+/// `Timeout` → a backend call (notably the `claude` subprocess)
+/// exceeded the cap's per-request deadline and the child was killed.
+/// `ParamNotSupported` → the request set a knob the backend has no
+/// way to honor (e.g. `max_tokens` / `temperature` on the CLI path,
+/// which the `claude` binary exposes no flag for — reject rather than
+/// silently drop). `AdapterError` is the catchall preserving
+/// backend-specific detail as free-form text.
+#[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub enum AnthropicError {
+    Overloaded,
+    RateLimited {
+        retry_after_ms: Option<u32>,
+    },
+    ContextLengthExceeded {
+        limit: u32,
+    },
+    Unauthorized,
+    ContentPolicyRefused,
+    CliNotFound,
+    UnknownModel {
+        model: String,
+        supported: Vec<String>,
+    },
+    Timeout {
+        elapsed_ms: u32,
+    },
+    ParamNotSupported {
+        param: String,
+        reason: String,
+    },
+    AdapterError(String),
+}
+
+/// `aether.anthropic.messages.send` — request a text completion via
+/// the official Anthropic Messages API (HTTPS). Mailed to the
+/// `"aether.anthropic"` mailbox; reply lands as
+/// `MessagesSendResult`. `request_id` correlates the reply
+/// (caller-minted, echoed on both arms). `model` selects the
+/// Messages model; `max_tokens` / `temperature` / `system` are the
+/// usual completion knobs.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.anthropic.messages.send")]
+pub struct MessagesSend {
+    pub request_id: u64,
+    pub model: String,
+    pub messages: Vec<Message>,
+    pub max_tokens: Option<u32>,
+    pub temperature: Option<f32>,
+    pub system: Option<String>,
+}
+
+/// `aether.anthropic.cli.send` — request a text completion via the
+/// local `claude` subprocess (the user's subscription rail).
+/// Identical input schema to [`MessagesSend`]; the routing choice
+/// is the kind name. Reply lands as `CliSendResult`.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.anthropic.cli.send")]
+pub struct CliSend {
+    pub request_id: u64,
+    pub model: String,
+    pub messages: Vec<Message>,
+    pub max_tokens: Option<u32>,
+    pub temperature: Option<f32>,
+    pub system: Option<String>,
+}
+
+/// Reply to [`MessagesSend`]. Both arms echo the originating
+/// `request_id` for correlation. `Ok` carries the completion text,
+/// the model the provider actually served, and `Usage` accounting;
+/// `Err` carries an `AnthropicError`.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.anthropic.messages.send_result")]
+pub enum MessagesSendResult {
+    Ok {
+        request_id: u64,
+        text: String,
+        model_used: String,
+        usage: Usage,
+    },
+    Err {
+        request_id: u64,
+        error: AnthropicError,
+    },
+}
+
+/// Reply to [`CliSend`]. Same shape as [`MessagesSendResult`]; the
+/// CLI backend populates only `Usage.wall_clock_ms` (the subprocess
+/// reports no token counts).
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.anthropic.cli.send_result")]
+pub enum CliSendResult {
+    Ok {
+        request_id: u64,
+        text: String,
+        model_used: String,
+        usage: Usage,
+    },
+    Err {
+        request_id: u64,
+        error: AnthropicError,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use aether_data::{Kind, Schema, SchemaType};
+    use aether_kinds::descriptors;
+
+    use super::{
+        AnthropicError, CliSend, CliSendResult, Message, MessagesSend, MessagesSendResult, Role,
+    };
+
+    /// Registration guard: the moved kinds must still appear in the global
+    /// descriptor inventory now that they live in `aether-capabilities`
+    /// instead of `aether-kinds`. The `Kind` derive's `inventory::submit!`
+    /// fires whenever the binary links `aether-capabilities`, so a chassis
+    /// test binary (which does) carries the entries. This runs in the
+    /// `aether-capabilities` test binary, so `descriptors::all()`
+    /// includes the moved kinds.
+    #[test]
+    fn anthropic_kinds_are_registered_in_descriptor_inventory() {
+        let descs = descriptors::all();
+        let names: Vec<&str> = descs.iter().map(|d| d.name.as_str()).collect();
+        assert!(names.contains(&MessagesSend::NAME), "MessagesSend missing");
+        assert!(
+            names.contains(&MessagesSendResult::NAME),
+            "MessagesSendResult missing"
+        );
+        assert!(names.contains(&CliSend::NAME), "CliSend missing");
+        assert!(
+            names.contains(&CliSendResult::NAME),
+            "CliSendResult missing"
+        );
+    }
+
+    #[test]
+    fn anthropic_requests_are_structured_schemas() {
+        let descs = descriptors::all();
+        for name in [MessagesSend::NAME, CliSend::NAME] {
+            let d = descs
+                .iter()
+                .find(|d| d.name == name)
+                .expect("test setup: anthropic request kind is registered in descriptor inventory");
+            let SchemaType::Struct { repr_c, .. } = &d.schema else {
+                panic!("{name} should be Struct, got {:?}", d.schema);
+            };
+            assert!(!*repr_c, "{name} contains String/Vec, must be structured");
+        }
+    }
+
+    #[test]
+    fn anthropic_results_are_enum_schemas() {
+        let descs = descriptors::all();
+        for name in [MessagesSendResult::NAME, CliSendResult::NAME] {
+            let d = descs
+                .iter()
+                .find(|d| d.name == name)
+                .expect("test setup: anthropic result kind is registered in descriptor inventory");
+            assert!(
+                matches!(d.schema, SchemaType::Enum { .. }),
+                "{name} should be Enum, got {:?}",
+                d.schema
+            );
+        }
+    }
+
+    #[test]
+    fn role_and_message_schema_shapes() {
+        // Role is a fieldless enum, Message is a struct — sanity-check the
+        // schemas move intact.
+        assert!(matches!(Role::SCHEMA, SchemaType::Enum { .. }));
+        assert!(matches!(Message::SCHEMA, SchemaType::Struct { .. }));
+    }
+
+    #[test]
+    fn anthropic_error_is_an_enum_schema() {
+        assert!(
+            matches!(AnthropicError::SCHEMA, SchemaType::Enum { .. }),
+            "AnthropicError should be Enum, got {:?}",
+            AnthropicError::SCHEMA
+        );
+    }
+}

--- a/crates/aether-capabilities/src/anthropic/mod.rs
+++ b/crates/aether-capabilities/src/anthropic/mod.rs
@@ -27,6 +27,10 @@
 mod api;
 mod cli;
 mod error;
+mod kinds;
+pub use kinds::{
+    AnthropicError, CliSend, CliSendResult, Message, MessagesSend, MessagesSendResult, Role,
+};
 
 use std::time::Duration;
 
@@ -240,11 +244,14 @@ mod config {
 // Handler-signature kinds must be importable at file root because
 // `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
 // of the mod (always-on, outside the cfg gate).
-use aether_kinds::{CliSend, CliSendResult, MessagesSend, MessagesSendResult};
+// Handler-signature kinds are brought into file-root scope via
+// `pub use kinds::{..., CliSend, ...}` above; the bridge macro's
+// `impl HandlesKind<K>` markers outside `mod native` can see them there.
+// No separate `use` needed.
 
 /// Convert an adapter error string into the typed `AnthropicError`.
 /// Shared by both result paths.
-fn map_adapter_error(raw: &str) -> aether_kinds::AnthropicError {
+fn map_adapter_error(raw: &str) -> AnthropicError {
     error::adapter_error_to_typed(raw)
 }
 
@@ -260,7 +267,9 @@ mod native {
     use crate::contentgen::adapter::{AdapterUsage, AnthropicResponse};
     use crate::contentgen::task_queue::TaskQueue;
     use aether_actor::{Manual, OutboundReply, actor};
-    use aether_kinds::{AnthropicError, Message, Role, Usage};
+    use aether_kinds::Usage;
+
+    use super::kinds::{AnthropicError, Message, Role};
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
     use aether_substrate::chassis::error::BootError;
 
@@ -554,6 +563,9 @@ mod native {
         use super::super::{
             AnthropicAdapter, AnthropicConfig, ClaudeCliAdapter, DisabledAnthropicAdapter,
         };
+        use super::super::{
+            AnthropicError, CliSend, CliSendResult, Message, MessagesSend, MessagesSendResult, Role,
+        };
         use super::AnthropicCapability;
         use crate::contentgen::adapter::{
             AnthropicRequest, AnthropicResponse, StubAnthropicAdapter,
@@ -564,9 +576,6 @@ mod native {
         };
         use aether_actor::Addressable;
         use aether_data::{Kind, MailboxId, SessionToken, Source, SourceAddr, Uuid};
-        use aether_kinds::{
-            AnthropicError, CliSend, CliSendResult, Message, MessagesSend, MessagesSendResult, Role,
-        };
         use aether_substrate::actor::native::binding::NativeBinding;
         use aether_substrate::actor::native::ctx::NativeCtx;
         use aether_substrate::chassis::builder::Builder;

--- a/crates/aether-kinds/src/descriptors.rs
+++ b/crates/aether-kinds/src/descriptors.rs
@@ -51,14 +51,13 @@ mod tests {
     use aether_data::{Primitive, SchemaType};
 
     use crate::{
-        CliSend, CliSendResult, Delete, DeleteResult, DrawTriangle, DropComponent, DropResult,
-        FsFetch, FsFetchResult, Key, LifecycleUnsubscribeAll, List, ListResult, LoadComponent,
-        LoadResult, LyriaGenerate, LyriaGenerateResult, Mat4Apply, MessagesSend,
-        MessagesSendResult, MouseButton, MouseMove, NanobananaGenerate, NanobananaGenerateResult,
-        Ping, Pong, ProcessExited, Read, ReadResult, RecordResult, ReplaceComponent, ReplaceResult,
-        Spawn, SpawnResult, SubscribeInput, SubscribeInputResult, Terminate, TerminateResult, Tick,
-        TrajectoryEnd, TrajectoryLog, TrajectorySample, UnsubscribeAll, UnsubscribeInput, Write,
-        WriteResult,
+        Delete, DeleteResult, DrawTriangle, DropComponent, DropResult, FsFetch, FsFetchResult, Key,
+        LifecycleUnsubscribeAll, List, ListResult, LoadComponent, LoadResult, LyriaGenerate,
+        LyriaGenerateResult, Mat4Apply, MouseButton, MouseMove, NanobananaGenerate,
+        NanobananaGenerateResult, Ping, Pong, ProcessExited, Read, ReadResult, RecordResult,
+        ReplaceComponent, ReplaceResult, Spawn, SpawnResult, SubscribeInput, SubscribeInputResult,
+        Terminate, TerminateResult, Tick, TrajectoryEnd, TrajectoryLog, TrajectorySample,
+        UnsubscribeAll, UnsubscribeInput, Write, WriteResult,
     };
 
     #[test]
@@ -128,10 +127,6 @@ mod tests {
         assert!(names.contains(&Terminate::NAME));
         assert!(names.contains(&TerminateResult::NAME));
         assert!(names.contains(&ProcessExited::NAME));
-        assert!(names.contains(&MessagesSend::NAME));
-        assert!(names.contains(&MessagesSendResult::NAME));
-        assert!(names.contains(&CliSend::NAME));
-        assert!(names.contains(&CliSendResult::NAME));
         assert!(names.contains(&NanobananaGenerate::NAME));
         assert!(names.contains(&NanobananaGenerateResult::NAME));
         assert!(names.contains(&LyriaGenerate::NAME));
@@ -162,40 +157,6 @@ mod tests {
                 .iter()
                 .find(|d| d.name == name)
                 .expect("test setup: gemini result kind is registered in descriptor inventory");
-            assert!(
-                matches!(d.schema, SchemaType::Enum { .. }),
-                "{name} should be Enum, got {:?}",
-                d.schema
-            );
-        }
-    }
-
-    #[test]
-    fn anthropic_requests_are_structured_schemas() {
-        // ADR-0050: the two send kinds carry String/Vec/Option fields,
-        // so they must serialize as non-cast (structured) structs — the
-        // hub builds them from agent params via the wire encoder.
-        let descs = all();
-        for name in [MessagesSend::NAME, CliSend::NAME] {
-            let d = descs
-                .iter()
-                .find(|d| d.name == name)
-                .expect("test setup: anthropic request kind is registered in descriptor inventory");
-            let SchemaType::Struct { repr_c, .. } = &d.schema else {
-                panic!("{name} should be Struct, got {:?}", d.schema);
-            };
-            assert!(!*repr_c, "{name} contains String/Vec, must be structured");
-        }
-    }
-
-    #[test]
-    fn anthropic_results_are_enum_schemas() {
-        let descs = all();
-        for name in [MessagesSendResult::NAME, CliSendResult::NAME] {
-            let d = descs
-                .iter()
-                .find(|d| d.name == name)
-                .expect("test setup: anthropic result kind is registered in descriptor inventory");
             assert!(
                 matches!(d.schema, SchemaType::Enum { .. }),
                 "{name} should be Enum, got {:?}",

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -2886,34 +2886,10 @@ mod control_plane {
     }
 
     // ADR-0050 per-provider content-gen caps. The `aether.anthropic`
-    // cap (issue 1014) exposes two sibling text-completion request
-    // kinds — `messages.send` (HTTPS to the official Messages API) and
-    // `cli.send` (the local `claude` subprocess against the user's
-    // subscription) — with identical input schemas; the routing choice
-    // is the visible kind name, not an opaque adapter detail. Both
-    // reply with a `*_result` Ok/Err enum carrying the shared `Usage`
-    // accounting (also consumed by the `aether.gemini` media kinds,
-    // issue 1015) on `Ok` and a provider-specific `AnthropicError` on
-    // `Err`. All structured — every request carries `String` /
-    // `Vec` / `Option` fields.
-
-    /// Conversation role on a [`Message`]. The Messages API only
-    /// distinguishes user vs assistant turns; `system` rides as a
-    /// separate top-level field on the request, not a role.
-    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
-    pub enum Role {
-        User,
-        Assistant,
-    }
-
-    /// One turn in an Anthropic completion request. `content` is the
-    /// flat text of the turn (v1 doesn't model multi-part content
-    /// blocks); `role` distinguishes user from assistant.
-    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-    pub struct Message {
-        pub role: Role,
-        pub content: String,
-    }
+    // kinds (Role, Message, AnthropicError, MessagesSend, CliSend,
+    // MessagesSendResult, CliSendResult) are owned by the capability and
+    // live in `aether-capabilities::anthropic::kinds` (ADR-0121). `Usage`
+    // stays central — it is shared with the `aether.gemini` result kinds.
 
     /// Token + wall-clock accounting returned on a successful
     /// content-gen completion. Shared across the Anthropic text kinds
@@ -2928,116 +2904,6 @@ mod control_plane {
         pub output_tokens: u32,
         pub wall_clock_ms: u32,
         pub cost_micros: Option<u64>,
-    }
-
-    /// Structured failure reason for an Anthropic completion (ADR-0050
-    /// §1). Typed variants cover the branches a caller routinely
-    /// matches on — `Overloaded` / `RateLimited` → back off,
-    /// `ContextLengthExceeded` → trim the prompt, `Unauthorized` →
-    /// config issue, `ContentPolicyRefused` → surface to the user,
-    /// `CliNotFound` → the `claude` binary isn't on PATH,
-    /// `UnknownModel` → typo / unsupported id,
-    /// `Timeout` → a backend call (notably the `claude` subprocess)
-    /// exceeded the cap's per-request deadline and the child was killed.
-    /// `ParamNotSupported` → the request set a knob the backend has no
-    /// way to honor (e.g. `max_tokens` / `temperature` on the CLI path,
-    /// which the `claude` binary exposes no flag for — reject rather than
-    /// silently drop). `AdapterError` is the catchall preserving
-    /// backend-specific detail as free-form text.
-    #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-    pub enum AnthropicError {
-        Overloaded,
-        RateLimited {
-            retry_after_ms: Option<u32>,
-        },
-        ContextLengthExceeded {
-            limit: u32,
-        },
-        Unauthorized,
-        ContentPolicyRefused,
-        CliNotFound,
-        UnknownModel {
-            model: String,
-            supported: Vec<String>,
-        },
-        Timeout {
-            elapsed_ms: u32,
-        },
-        ParamNotSupported {
-            param: String,
-            reason: String,
-        },
-        AdapterError(String),
-    }
-
-    /// `aether.anthropic.messages.send` — request a text completion via
-    /// the official Anthropic Messages API (HTTPS). Mailed to the
-    /// `"aether.anthropic"` mailbox; reply lands as
-    /// `MessagesSendResult`. `request_id` correlates the reply
-    /// (caller-minted, echoed on both arms). `model` selects the
-    /// Messages model; `max_tokens` / `temperature` / `system` are the
-    /// usual completion knobs.
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.anthropic.messages.send")]
-    pub struct MessagesSend {
-        pub request_id: u64,
-        pub model: String,
-        pub messages: Vec<Message>,
-        pub max_tokens: Option<u32>,
-        pub temperature: Option<f32>,
-        pub system: Option<String>,
-    }
-
-    /// `aether.anthropic.cli.send` — request a text completion via the
-    /// local `claude` subprocess (the user's subscription rail).
-    /// Identical input schema to [`MessagesSend`]; the routing choice
-    /// is the kind name. Reply lands as `CliSendResult`.
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.anthropic.cli.send")]
-    pub struct CliSend {
-        pub request_id: u64,
-        pub model: String,
-        pub messages: Vec<Message>,
-        pub max_tokens: Option<u32>,
-        pub temperature: Option<f32>,
-        pub system: Option<String>,
-    }
-
-    /// Reply to [`MessagesSend`]. Both arms echo the originating
-    /// `request_id` for correlation. `Ok` carries the completion text,
-    /// the model the provider actually served, and `Usage` accounting;
-    /// `Err` carries an `AnthropicError`.
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.anthropic.messages.send_result")]
-    pub enum MessagesSendResult {
-        Ok {
-            request_id: u64,
-            text: String,
-            model_used: String,
-            usage: Usage,
-        },
-        Err {
-            request_id: u64,
-            error: AnthropicError,
-        },
-    }
-
-    /// Reply to [`CliSend`]. Same shape as [`MessagesSendResult`]; the
-    /// CLI backend populates only `Usage.wall_clock_ms` (the subprocess
-    /// reports no token counts).
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.anthropic.cli.send_result")]
-    pub enum CliSendResult {
-        Ok {
-            request_id: u64,
-            text: String,
-            model_used: String,
-            usage: Usage,
-        },
-        Err {
-            request_id: u64,
-            error: AnthropicError,
-        },
     }
 
     // ADR-0050 `aether.gemini` cap (issue 1015). Media generation only


### PR DESCRIPTION
Closes #2173.

## Summary

Part of the ADR-0121 capabilities-own-their-kinds refactor (one capability = one PR). The `anthropic` capability takes ownership of its kinds.

The `aether.anthropic.*` mail kinds move out of `aether-kinds` into the cap-owned `anthropic/kinds.rs` (re-exported at `anthropic::*`), with their descriptor / name-stability coverage relocated alongside. Kind ids are unchanged, so the wire stays stable.

## Test plan

- The relocated anthropic kind tests run from `anthropic/kinds.rs`; the `aether-kinds` descriptor inventory is updated to drop the moved kinds.
- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace`, `cargo doc --workspace --no-deps` under the strict CI rustdoc flags, and the wasm32 cross-build all pass (validated end-to-end by the attested CI path).

## Generated by

`/implement` — agent execution of [scoped issue #2173](https://github.com/iamacoffeepot/aether/issues/2173).
