### PR TITLE
refactor(capabilities): make inventory a submodule that owns its kinds

### DIFF
--- a/crates/aether-capabilities/src/inventory/manifest.rs
+++ b/crates/aether-capabilities/src/inventory/manifest.rs
@@ -1,0 +1,34 @@
+//! Manifest projection helpers for `aether.inventory`.
+//!
+//! Projects link-time [`ParamKind`] and [`Cardinality`] values onto
+//! their wire mirrors for the `aether.inventory.manifest` reply
+//! (ADR-0088 §4 v2). The `#[actor] impl` in `mod.rs` delegates here.
+
+use aether_data::name_inventory::{Cardinality, ParamKind};
+use aether_kinds::{CardinalityWire, ParamKindWire};
+
+/// Project one link-time `ParamKind` onto its wire mirror. `Bounded`
+/// / `Declared` carry their range / domain so the client expands the
+/// family locally; `Dynamic` carries only the shape (its instances
+/// reverse via [`Resolve`](aether_kinds::Resolve)).
+pub fn param_kind_wire(param: &ParamKind) -> ParamKindWire {
+    match *param {
+        ParamKind::Bounded { lo, hi } => ParamKindWire::Bounded { lo, hi },
+        ParamKind::Declared { domain } => ParamKindWire::Declared {
+            domain: domain.to_vec(),
+        },
+        ParamKind::Dynamic => ParamKindWire::Dynamic,
+    }
+}
+
+/// Project one link-time `Cardinality` onto its wire mirror (ADR-0088
+/// §4 v2) — the orthogonal how-many axis the client surfaces verbatim.
+pub fn cardinality_wire(cardinality: &Cardinality) -> CardinalityWire {
+    match *cardinality {
+        Cardinality::Bounded(count) => CardinalityWire::Bounded { count },
+        Cardinality::OnePer(entity) => CardinalityWire::OnePer {
+            entity: entity.into(),
+        },
+        Cardinality::Unbounded => CardinalityWire::Unbounded,
+    }
+}

--- a/crates/aether-capabilities/src/inventory/mod.rs
+++ b/crates/aether-capabilities/src/inventory/mod.rs
@@ -54,8 +54,15 @@ use aether_kinds::{
     ResolveResult,
 };
 
+#[cfg(not(target_arch = "wasm32"))]
+mod manifest;
+#[cfg(not(target_arch = "wasm32"))]
+mod resolve;
+
 #[aether_actor::bridge(singleton)]
 mod native {
+    use super::manifest::{cardinality_wire, param_kind_wire};
+    use super::resolve::resolve_ids;
     use super::{
         HandlersResult, ListHandlers, ListKinds, ListKindsResult, Manifest, ManifestResult,
         Resolve, ResolveResult,
@@ -64,20 +71,22 @@ mod native {
     use aether_actor::actor;
     use aether_data::KindId;
     use aether_data::canonical::kind_id_from_parts;
-    use aether_data::name_inventory::{
-        Cardinality, ParamKind, handler_entries, name_entries, template_entries,
-    };
-    use aether_data::tagged_id;
+    use aether_data::name_inventory::{handler_entries, name_entries, template_entries};
     use aether_data::wire;
-    use aether_kinds::{
-        CardinalityWire, HandlerEntryWire, KindDescriptorWire, NameEntryWire, ParamKindWire,
-        ResolvedName, TemplateEntryWire,
-    };
+    use aether_kinds::{HandlerEntryWire, KindDescriptorWire, NameEntryWire, TemplateEntryWire};
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
     use aether_substrate::mail::registry::Registry;
-    use aether_substrate::runtime::thread_name::resolve_runtime;
     use std::sync::Arc;
+
+    // Used only by the test suite — gate to avoid unused-import warnings in
+    // the non-test build (they flow in via `use super::*` inside `mod tests`).
+    #[cfg(test)]
+    use aether_data::tagged_id;
+    #[cfg(test)]
+    use aether_kinds::{CardinalityWire, ParamKindWire};
+    #[cfg(test)]
+    use aether_substrate::runtime::thread_name::resolve_runtime;
 
     /// `aether.inventory` cap (ADR-0088 §6, widened by ADR-0091 §5). The
     /// `Manifest` and `Resolve` arms read process-global tables (the
@@ -90,32 +99,6 @@ mod native {
     /// without any cross-cap event channel.
     pub struct InventoryCapability {
         registry: Arc<Registry>,
-    }
-
-    /// Project one link-time `ParamKind` onto its wire mirror. `Bounded`
-    /// / `Declared` carry their range / domain so the client expands the
-    /// family locally; `Dynamic` carries only the shape (its instances
-    /// reverse via [`Resolve`]).
-    fn param_kind_wire(param: &ParamKind) -> ParamKindWire {
-        match *param {
-            ParamKind::Bounded { lo, hi } => ParamKindWire::Bounded { lo, hi },
-            ParamKind::Declared { domain } => ParamKindWire::Declared {
-                domain: domain.to_vec(),
-            },
-            ParamKind::Dynamic => ParamKindWire::Dynamic,
-        }
-    }
-
-    /// Project one link-time `Cardinality` onto its wire mirror (ADR-0088
-    /// §4 v2) — the orthogonal how-many axis the client surfaces verbatim.
-    fn cardinality_wire(cardinality: &Cardinality) -> CardinalityWire {
-        match *cardinality {
-            Cardinality::Bounded(count) => CardinalityWire::Bounded { count },
-            Cardinality::OnePer(entity) => CardinalityWire::OnePer {
-                entity: entity.into(),
-            },
-            Cardinality::Unbounded => CardinalityWire::Unbounded,
-        }
     }
 
     #[actor]
@@ -232,18 +215,9 @@ mod native {
         #[allow(clippy::unused_self)]
         #[handler]
         fn on_resolve(&mut self, _ctx: &mut NativeCtx<'_>, mail: Resolve) -> ResolveResult {
-            let resolved = mail
-                .ids
-                .into_iter()
-                .map(|id| {
-                    // A malformed tagged-id string reports `None` rather
-                    // than aborting the batch — one bad id doesn't sink
-                    // its siblings.
-                    let name = tagged_id::decode(&id).ok().and_then(resolve_runtime);
-                    ResolvedName { id, name }
-                })
-                .collect();
-            ResolveResult { resolved }
+            ResolveResult {
+                resolved: resolve_ids(mail.ids),
+            }
         }
 
         /// Reply with the native handler manifest (ADR-0109 §5): every

--- a/crates/aether-capabilities/src/inventory/resolve.rs
+++ b/crates/aether-capabilities/src/inventory/resolve.rs
@@ -1,0 +1,27 @@
+//! Runtime reverse-lookup helper for `aether.inventory`.
+//!
+//! Projects a list of tagged-id strings onto [`ResolvedName`] via the
+//! runtime-registry arm of the ADR-0088 §2 chain
+//! (`thread_name::resolve_runtime`). The `#[actor] impl` in `mod.rs`
+//! delegates here.
+
+use aether_data::tagged_id;
+use aether_kinds::ResolvedName;
+use aether_substrate::runtime::thread_name::resolve_runtime;
+
+/// Resolve each tagged-id string to its origin name via the
+/// runtime-registry arm of the reverse-lookup chain. Returns one
+/// [`ResolvedName`] per input, in request order with the `id` echoed
+/// for correlation. `name` is `Some` for a dynamically-minted instance
+/// the substrate has registered; `None` on a miss or a malformed id
+/// (a malformed id does not abort its siblings).
+pub fn resolve_ids(ids: Vec<String>) -> Vec<ResolvedName> {
+    ids.into_iter()
+        .map(|id| {
+            // A malformed tagged-id string reports `None` rather than
+            // aborting the batch — one bad id doesn't sink its siblings.
+            let name = tagged_id::decode(&id).ok().and_then(resolve_runtime);
+            ResolvedName { id, name }
+        })
+        .collect()
+}


### PR DESCRIPTION
Closes #2165.

## Summary

Part of the ADR-0121 capabilities-own-their-kinds refactor (one capability = one PR). The `inventory` capability becomes a directory submodule.

`inventory.rs` splits into `inventory/{mod,manifest,resolve}` — the cap shell, the manifest types, and the resolve path. This is a split-only slice; no kinds move (all public paths preserved).

## Test plan

- The inventory cap's tests run from their new homes in the submodule.
- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace`, `cargo doc --workspace --no-deps` under the strict CI rustdoc flags, and the wasm32 cross-build all pass (validated end-to-end by the attested CI path).

## Generated by

`/implement` — agent execution of [scoped issue #2165](https://github.com/iamacoffeepot/aether/issues/2165).
