### PR TITLE
refactor(actor): prefix example namespaces with example.

### DIFF
--- a/crates/aether-actor/examples/hello.rs
+++ b/crates/aether-actor/examples/hello.rs
@@ -68,7 +68,7 @@ pub struct Hello {}
 /// sender; the matching `aether.pong` lands back at your session.
 #[actor]
 impl WasmActor for Hello {
-    const NAMESPACE: &'static str = "hello";
+    const NAMESPACE: &'static str = "example.hello";
 
     fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(Hello {})

--- a/crates/aether-actor/examples/input_logger.rs
+++ b/crates/aether-actor/examples/input_logger.rs
@@ -30,7 +30,7 @@ pub struct InputLogger;
 
 #[actor]
 impl WasmActor for InputLogger {
-    const NAMESPACE: &'static str = "input_logger";
+    const NAMESPACE: &'static str = "example.input_logger";
 
     fn init(_ctx: &mut WasmInitCtx<'_>) -> Result<Self, ActorInitError> {
         Ok(InputLogger)

--- a/docs/guide/foundations/actor-model.md
+++ b/docs/guide/foundations/actor-model.md
@@ -126,7 +126,7 @@ it handles from the method's **third parameter**:
 ```rust
 #[actor]
 impl WasmActor for Hello {
-    const NAMESPACE: &'static str = "hello";
+    const NAMESPACE: &'static str = "example.hello";
 
     fn init<C: Resolver>(_ctx: &mut C) -> Result<Self, ActorInitError> {
         Ok(Hello)


### PR DESCRIPTION
Closes #2157.

## Summary

Prefix the example actors' namespaces with `example.` so they read unambiguously as examples rather than potential real capability names. The `NAMESPACE` consts in `aether-actor/examples/hello.rs` (`"hello"` → `"example.hello"`) and `input_logger.rs` (`"input_logger"` → `"example.input_logger"`) are renamed, and the matching guide snippet in `docs/guide/foundations/actor-model.md` is updated. Cargo `[[example]]` target names and wasm artifact stems are left untouched.

## Test plan

- `cargo fmt -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace` (2029 passed, 9 skipped), `cargo doc --workspace --no-deps` under the strict CI rustdoc flags, and the wasm32 component cross-build (`xtask dist`, 5 components) all pass.

## Generated by

`/implement` — agent execution of [scoped issue #2157](https://github.com/iamacoffeepot/aether/issues/2157).
