### PR TITLE
refactor(capabilities): make ui a submodule that owns its kinds

### DIFF
--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -184,7 +184,7 @@ pub use trampoline::WasmTrampoline;
 #[cfg(not(target_arch = "wasm32"))]
 pub use trampoline::WasmTrampolineConfig;
 #[cfg(feature = "ui")]
-pub use ui::UiCapability;
+pub use ui::{UiBar, UiButton, UiCapability, UiClicked, UiLabel, UiPanel};
 pub use window::HeadlessWindowCapability;
 
 #[cfg(all(test, feature = "native"))]

--- a/crates/aether-capabilities/src/ui/kinds.rs
+++ b/crates/aether-capabilities/src/ui/kinds.rs
@@ -1,0 +1,175 @@
+use serde::{Deserialize, Serialize};
+
+// ADR-0107 `aether.ui` widget kinds. Immediate-mode: the component
+// lays out and sends these each frame; the `aether.ui` cap translates
+// them to `draw_solid_quads` and `draw_text` calls the same tick.
+// Screen-space; `rect` is `[x, y, width, height]` in window pixels.
+
+/// `aether.ui.panel` — draw a flat-colored panel at `rect` in
+/// screen-pixel space. `color` is a linear RGBA value; the alpha
+/// channel scales the blend. Fire-and-forget; resend every frame.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.ui.panel")]
+pub struct UiPanel {
+    /// `[x, y, width, height]` in window pixels.
+    pub rect: [f32; 4],
+    pub color: [f32; 4],
+}
+
+/// `aether.ui.bar` — draw a two-layer progress bar at `rect` in
+/// screen-pixel space. The track (`track_color`) fills the full rect;
+/// the fill (`fill_color`) covers `frac` × width, clamped to [0, 1].
+/// Fire-and-forget; resend every frame.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.ui.bar")]
+pub struct UiBar {
+    /// `[x, y, width, height]` in window pixels.
+    pub rect: [f32; 4],
+    /// Filled fraction, clamped to [0, 1] by the cap.
+    pub frac: f32,
+    pub track_color: [f32; 4],
+    pub fill_color: [f32; 4],
+}
+
+/// `aether.ui.label` — draw a string at `(x, y)` in screen-pixel
+/// space using the font registered under `font_id` (via
+/// `aether.text.load_font`). Fire-and-forget; resend every frame.
+/// An unknown `font_id` warn-drops in the `aether.text` cap.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.ui.label")]
+pub struct UiLabel {
+    pub x: f32,
+    pub y: f32,
+    pub font_id: u32,
+    pub text: String,
+    pub size_pixels: f32,
+    pub color: [f32; 4],
+}
+
+/// `aether.ui.button` — draw a clickable button at `rect` in
+/// screen-pixel space (ADR-0107 §3). The cap forwards the fill
+/// (`color`) as a panel quad and the `text` label, and records the
+/// rect + `id` + the sending component for hit-testing. A left-click
+/// inside the rect replies `aether.ui.clicked { id }` to the sender
+/// within one frame (topmost button wins on overlap). v1: the mouse-
+/// button stream carries no button discriminant or release, so the
+/// button activates on left-press only. Fire-and-forget; resend every
+/// frame — `id` is the caller's stable handle for the widget.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.ui.button")]
+pub struct UiButton {
+    /// Caller-stable widget id echoed back in `UiClicked` on a hit.
+    pub id: u32,
+    /// `[x, y, width, height]` in window pixels.
+    pub rect: [f32; 4],
+    /// Background fill, linear RGBA.
+    pub color: [f32; 4],
+    /// Font for the label, registered via `aether.text.load_font`.
+    pub font_id: u32,
+    /// Label drawn at the button's top-left corner.
+    pub text: String,
+    pub size_pixels: f32,
+    /// Label color, linear RGBA.
+    pub text_color: [f32; 4],
+}
+
+/// `aether.ui.clicked` — the cap's interaction reply (ADR-0107 §3).
+/// Sent to the component that drew the `UiButton` carrying the same
+/// `id` when a left-click lands inside that button's rect. Delivered
+/// by id to the recorded owner — the button mail's sender — within one
+/// frame of the click.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.ui.clicked")]
+pub struct UiClicked {
+    /// The `id` of the `UiButton` that was clicked.
+    pub id: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{UiBar, UiButton, UiClicked, UiLabel, UiPanel};
+    use aether_data::Kind;
+
+    #[test]
+    fn ui_panel_roundtrip() {
+        let p = UiPanel {
+            rect: [10.0, 20.0, 100.0, 50.0],
+            color: [0.1, 0.2, 0.3, 0.8],
+        };
+        let bytes = p.encode_into_bytes();
+        let back: UiPanel =
+            UiPanel::decode_from_bytes(&bytes).expect("test setup: kind codec decodes UiPanel");
+        assert_eq!(back.rect, [10.0, 20.0, 100.0, 50.0]);
+        assert_eq!(back.color, [0.1, 0.2, 0.3, 0.8]);
+    }
+
+    #[test]
+    fn ui_bar_roundtrip() {
+        let b = UiBar {
+            rect: [0.0, 0.0, 200.0, 24.0],
+            frac: 0.75,
+            track_color: [0.2, 0.2, 0.2, 1.0],
+            fill_color: [0.1, 0.8, 0.2, 1.0],
+        };
+        let bytes = b.encode_into_bytes();
+        let back: UiBar =
+            UiBar::decode_from_bytes(&bytes).expect("test setup: kind codec decodes UiBar");
+        assert_eq!(back.rect, [0.0, 0.0, 200.0, 24.0]);
+        assert_eq!(back.frac, 0.75);
+        assert_eq!(back.track_color, [0.2, 0.2, 0.2, 1.0]);
+        assert_eq!(back.fill_color, [0.1, 0.8, 0.2, 1.0]);
+    }
+
+    #[test]
+    fn ui_label_roundtrip() {
+        let l = UiLabel {
+            x: 10.0,
+            y: 20.0,
+            font_id: 2,
+            text: "HP: 100".to_string(),
+            size_pixels: 16.0,
+            color: [1.0, 1.0, 1.0, 1.0],
+        };
+        let bytes = l.encode_into_bytes();
+        let back: UiLabel =
+            UiLabel::decode_from_bytes(&bytes).expect("test setup: kind codec decodes UiLabel");
+        assert_eq!(back.x, 10.0);
+        assert_eq!(back.y, 20.0);
+        assert_eq!(back.font_id, 2);
+        assert_eq!(back.text, "HP: 100");
+        assert_eq!(back.size_pixels, 16.0);
+        assert_eq!(back.color, [1.0, 1.0, 1.0, 1.0]);
+    }
+
+    #[test]
+    fn ui_button_roundtrip() {
+        let b = UiButton {
+            id: 7,
+            rect: [4.0, 8.0, 120.0, 32.0],
+            color: [0.15, 0.15, 0.2, 1.0],
+            font_id: 1,
+            text: "Play".to_string(),
+            size_pixels: 18.0,
+            text_color: [0.9, 0.9, 0.9, 1.0],
+        };
+        let bytes = b.encode_into_bytes();
+        let back: UiButton =
+            UiButton::decode_from_bytes(&bytes).expect("test setup: kind codec decodes UiButton");
+        assert_eq!(back.id, 7);
+        assert_eq!(back.rect, [4.0, 8.0, 120.0, 32.0]);
+        assert_eq!(back.color, [0.15, 0.15, 0.2, 1.0]);
+        assert_eq!(back.font_id, 1);
+        assert_eq!(back.text, "Play");
+        assert_eq!(back.size_pixels, 18.0);
+        assert_eq!(back.text_color, [0.9, 0.9, 0.9, 1.0]);
+    }
+
+    #[test]
+    fn ui_clicked_roundtrip() {
+        let c = UiClicked { id: 7 };
+        let bytes = c.encode_into_bytes();
+        let back: UiClicked =
+            UiClicked::decode_from_bytes(&bytes).expect("test setup: kind codec decodes UiClicked");
+        assert_eq!(back.id, 7);
+    }
+}

--- a/crates/aether-capabilities/src/ui/mod.rs
+++ b/crates/aether-capabilities/src/ui/mod.rs
@@ -1,0 +1,12 @@
+//! `aether.ui` cap and widget kinds (ADR-0107).
+//!
+//! The five widget kinds (`UiPanel`, `UiBar`, `UiLabel`, `UiButton`,
+//! `UiClicked`) live here — cycle-free from `aether-kinds` — and the
+//! `UiCapability` implementation that translates them into render + text
+//! sends.
+
+pub mod kinds;
+mod widgets;
+
+pub use kinds::{UiBar, UiButton, UiClicked, UiLabel, UiPanel};
+pub use widgets::UiCapability;

--- a/crates/aether-capabilities/src/ui/widgets.rs
+++ b/crates/aether-capabilities/src/ui/widgets.rs
@@ -20,7 +20,9 @@
 // Handler-signature kinds must be importable at file root because
 // `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings of
 // the mod (always-on, outside the cfg gate).
-use aether_kinds::{MouseButton, MouseMove, Tick, UiBar, UiButton, UiLabel, UiPanel};
+use aether_kinds::{MouseButton, MouseMove, Tick};
+
+use super::kinds::{UiBar, UiButton, UiClicked, UiLabel, UiPanel};
 
 #[aether_actor::bridge(singleton, feature = "ui-native")]
 mod native {
@@ -29,7 +31,7 @@ mod native {
 
     use aether_actor::actor;
     use aether_data::MailboxId;
-    use aether_kinds::{DrawSolidQuads, QuadSpace, SolidQuad, UiClicked};
+    use aether_kinds::{DrawSolidQuads, QuadSpace, SolidQuad};
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
 
@@ -38,7 +40,7 @@ mod native {
     use crate::render::RenderCapability;
     use crate::text::{DrawText, TextCapability};
 
-    use super::{MouseButton, MouseMove, Tick, UiBar, UiButton, UiLabel, UiPanel};
+    use super::{MouseButton, MouseMove, Tick, UiBar, UiButton, UiClicked, UiLabel, UiPanel};
 
     /// A button's hit-test record for one frame: where it was drawn, the
     /// caller's widget `id`, and the component that drew it (the

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -1858,91 +1858,6 @@ mod control_plane {
         pub advances: Vec<GlyphAdvance>,
     }
 
-    // ADR-0107 `aether.ui` widget kinds. Immediate-mode: the component
-    // lays out and sends these each frame; the `aether.ui` cap translates
-    // them to `draw_solid_quads` and `draw_text` calls the same tick.
-    // Screen-space; `rect` is `[x, y, width, height]` in window pixels.
-
-    /// `aether.ui.panel` — draw a flat-colored panel at `rect` in
-    /// screen-pixel space. `color` is a linear RGBA value; the alpha
-    /// channel scales the blend. Fire-and-forget; resend every frame.
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.ui.panel")]
-    pub struct UiPanel {
-        /// `[x, y, width, height]` in window pixels.
-        pub rect: [f32; 4],
-        pub color: [f32; 4],
-    }
-
-    /// `aether.ui.bar` — draw a two-layer progress bar at `rect` in
-    /// screen-pixel space. The track (`track_color`) fills the full rect;
-    /// the fill (`fill_color`) covers `frac` × width, clamped to [0, 1].
-    /// Fire-and-forget; resend every frame.
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.ui.bar")]
-    pub struct UiBar {
-        /// `[x, y, width, height]` in window pixels.
-        pub rect: [f32; 4],
-        /// Filled fraction, clamped to [0, 1] by the cap.
-        pub frac: f32,
-        pub track_color: [f32; 4],
-        pub fill_color: [f32; 4],
-    }
-
-    /// `aether.ui.label` — draw a string at `(x, y)` in screen-pixel
-    /// space using the font registered under `font_id` (via
-    /// `aether.text.load_font`). Fire-and-forget; resend every frame.
-    /// An unknown `font_id` warn-drops in the `aether.text` cap.
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.ui.label")]
-    pub struct UiLabel {
-        pub x: f32,
-        pub y: f32,
-        pub font_id: u32,
-        pub text: String,
-        pub size_pixels: f32,
-        pub color: [f32; 4],
-    }
-
-    /// `aether.ui.button` — draw a clickable button at `rect` in
-    /// screen-pixel space (ADR-0107 §3). The cap forwards the fill
-    /// (`color`) as a panel quad and the `text` label, and records the
-    /// rect + `id` + the sending component for hit-testing. A left-click
-    /// inside the rect replies `aether.ui.clicked { id }` to the sender
-    /// within one frame (topmost button wins on overlap). v1: the mouse-
-    /// button stream carries no button discriminant or release, so the
-    /// button activates on left-press only. Fire-and-forget; resend every
-    /// frame — `id` is the caller's stable handle for the widget.
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.ui.button")]
-    pub struct UiButton {
-        /// Caller-stable widget id echoed back in `UiClicked` on a hit.
-        pub id: u32,
-        /// `[x, y, width, height]` in window pixels.
-        pub rect: [f32; 4],
-        /// Background fill, linear RGBA.
-        pub color: [f32; 4],
-        /// Font for the label, registered via `aether.text.load_font`.
-        pub font_id: u32,
-        /// Label drawn at the button's top-left corner.
-        pub text: String,
-        pub size_pixels: f32,
-        /// Label color, linear RGBA.
-        pub text_color: [f32; 4],
-    }
-
-    /// `aether.ui.clicked` — the cap's interaction reply (ADR-0107 §3).
-    /// Sent to the component that drew the `UiButton` carrying the same
-    /// `id` when a left-click lands inside that button's rect. Delivered
-    /// by id to the recorded owner — the button mail's sender — within one
-    /// frame of the click.
-    #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
-    #[kind(name = "aether.ui.clicked")]
-    pub struct UiClicked {
-        /// The `id` of the `UiButton` that was clicked.
-        pub id: u32,
-    }
-
     /// The three window presentation modes. `Windowed` has no fields —
     /// the current size lives on `SetWindowModeResult`.
     /// `FullscreenExclusive` carries the specific video mode; the
@@ -3801,11 +3716,6 @@ mod tests {
         assert_eq!(UpdateTexture::NAME, "aether.render.update_texture");
         assert_eq!(DrawTexturedQuads::NAME, "aether.render.draw_textured_quads");
         assert_eq!(DrawSolidQuads::NAME, "aether.render.draw_solid_quads");
-        assert_eq!(UiPanel::NAME, "aether.ui.panel");
-        assert_eq!(UiBar::NAME, "aether.ui.bar");
-        assert_eq!(UiLabel::NAME, "aether.ui.label");
-        assert_eq!(UiButton::NAME, "aether.ui.button");
-        assert_eq!(UiClicked::NAME, "aether.ui.clicked");
         assert_eq!(SetWindowMode::NAME, "aether.window.set_mode");
         assert_eq!(SetWindowModeResult::NAME, "aether.window.set_mode_result");
         assert_eq!(SetWindowTitle::NAME, "aether.window.set_title");
@@ -4240,97 +4150,6 @@ mod tests {
             assert_eq!(back.quads.len(), 1);
             assert_eq!(back.quads[0].width, 20.0);
             assert_eq!(back.quads[0].color, [1.0, 0.0, 0.5, 1.0]);
-        }
-    }
-
-    // ADR-0107 `aether.ui` widget kind round-trips. Each kind is
-    // encoded and decoded via the kind codec, proving the derived
-    // Serialize/Deserialize agree on the wire for each shape.
-    mod ui_roundtrips {
-        use super::*;
-        use alloc::string::ToString;
-
-        #[test]
-        fn ui_panel_roundtrip() {
-            let p = UiPanel {
-                rect: [10.0, 20.0, 100.0, 50.0],
-                color: [0.1, 0.2, 0.3, 0.8],
-            };
-            let bytes = p.encode_into_bytes();
-            let back: UiPanel =
-                UiPanel::decode_from_bytes(&bytes).expect("test setup: kind codec decodes UiPanel");
-            assert_eq!(back.rect, [10.0, 20.0, 100.0, 50.0]);
-            assert_eq!(back.color, [0.1, 0.2, 0.3, 0.8]);
-        }
-
-        #[test]
-        fn ui_bar_roundtrip() {
-            let b = UiBar {
-                rect: [0.0, 0.0, 200.0, 24.0],
-                frac: 0.75,
-                track_color: [0.2, 0.2, 0.2, 1.0],
-                fill_color: [0.1, 0.8, 0.2, 1.0],
-            };
-            let bytes = b.encode_into_bytes();
-            let back: UiBar =
-                UiBar::decode_from_bytes(&bytes).expect("test setup: kind codec decodes UiBar");
-            assert_eq!(back.rect, [0.0, 0.0, 200.0, 24.0]);
-            assert_eq!(back.frac, 0.75);
-            assert_eq!(back.track_color, [0.2, 0.2, 0.2, 1.0]);
-            assert_eq!(back.fill_color, [0.1, 0.8, 0.2, 1.0]);
-        }
-
-        #[test]
-        fn ui_label_roundtrip() {
-            let l = UiLabel {
-                x: 10.0,
-                y: 20.0,
-                font_id: 2,
-                text: "HP: 100".to_string(),
-                size_pixels: 16.0,
-                color: [1.0, 1.0, 1.0, 1.0],
-            };
-            let bytes = l.encode_into_bytes();
-            let back: UiLabel =
-                UiLabel::decode_from_bytes(&bytes).expect("test setup: kind codec decodes UiLabel");
-            assert_eq!(back.x, 10.0);
-            assert_eq!(back.y, 20.0);
-            assert_eq!(back.font_id, 2);
-            assert_eq!(back.text, "HP: 100");
-            assert_eq!(back.size_pixels, 16.0);
-            assert_eq!(back.color, [1.0, 1.0, 1.0, 1.0]);
-        }
-
-        #[test]
-        fn ui_button_roundtrip() {
-            let b = UiButton {
-                id: 7,
-                rect: [4.0, 8.0, 120.0, 32.0],
-                color: [0.15, 0.15, 0.2, 1.0],
-                font_id: 1,
-                text: "Play".to_string(),
-                size_pixels: 18.0,
-                text_color: [0.9, 0.9, 0.9, 1.0],
-            };
-            let bytes = b.encode_into_bytes();
-            let back: UiButton = UiButton::decode_from_bytes(&bytes)
-                .expect("test setup: kind codec decodes UiButton");
-            assert_eq!(back.id, 7);
-            assert_eq!(back.rect, [4.0, 8.0, 120.0, 32.0]);
-            assert_eq!(back.color, [0.15, 0.15, 0.2, 1.0]);
-            assert_eq!(back.font_id, 1);
-            assert_eq!(back.text, "Play");
-            assert_eq!(back.size_pixels, 18.0);
-            assert_eq!(back.text_color, [0.9, 0.9, 0.9, 1.0]);
-        }
-
-        #[test]
-        fn ui_clicked_roundtrip() {
-            let c = UiClicked { id: 7 };
-            let bytes = c.encode_into_bytes();
-            let back: UiClicked = UiClicked::decode_from_bytes(&bytes)
-                .expect("test setup: kind codec decodes UiClicked");
-            assert_eq!(back.id, 7);
         }
     }
 

--- a/crates/aether-kit/src/runtime/locomotion.rs
+++ b/crates/aether-kit/src/runtime/locomotion.rs
@@ -77,10 +77,12 @@ use std::collections::{BinaryHeap, VecDeque};
 use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_capabilities::input::InputMailboxExt;
 use aether_capabilities::lifecycle::LifecycleMailboxExt;
-use aether_capabilities::{InputCapability, LifecycleCapability, RenderCapability, UiCapability};
+use aether_capabilities::{
+    InputCapability, LifecycleCapability, RenderCapability, UiBar, UiCapability, UiPanel,
+};
 use aether_kinds::{
-    Camera, DrawTriangle, Key, KeyRelease, MouseButton, MouseMove, Render, Tick, UiBar, UiPanel,
-    Vertex, WindowSize, keycode,
+    Camera, DrawTriangle, Key, KeyRelease, MouseButton, MouseMove, Render, Tick, Vertex,
+    WindowSize, keycode,
 };
 use aether_math::{Mat4, Vec3};
 

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -35,14 +35,15 @@ use std::path::Path;
 use aether_capabilities::text::{
     DrawText, FontMetricsRequest, FontMetricsResult, FontRef, LoadFont, LoadFontResult,
 };
+use aether_capabilities::{UiBar, UiPanel};
 use aether_data::{Kind, MailboxId};
 use aether_kinds::{
     CachedFontMetrics, Camera, CaptureFrame, CaptureFrameResult, CreateTexture,
     CreateTextureResult, Delete, DeleteResult, DrawSolidQuads, DrawTexturedQuads, DropComponent,
     DropResult, FrameCheck, FrameCheckResult, FrameReduction, FsError, List, ListComponents,
     ListComponentsResult, ListResult, LoadComponent, LoadResult, NamedMail, Ping, QuadScale,
-    QuadSpace, Read, ReadResult, ReplaceComponent, ReplaceResult, SolidQuad, TexturedQuad, UiBar,
-    UiPanel, Write, WriteResult,
+    QuadSpace, Read, ReadResult, ReplaceComponent, ReplaceResult, SolidQuad, TexturedQuad, Write,
+    WriteResult,
 };
 use aether_math::{Mat4, Vec3};
 use aether_substrate_bundle::test_bench::{


### PR DESCRIPTION
Closes #2171.

## Summary

Part of the ADR-0121 capabilities-own-their-kinds refactor (one capability = one PR). The `ui` capability becomes a submodule that owns its kinds.

`ui.rs` splits into `ui/{mod,kinds,widgets}`. The five widget kinds (`UiPanel`, `UiBar`, `UiLabel`, `UiButton`, `UiClicked`) move out of `aether-kinds` into `ui/kinds.rs`; consumers in `aether-kit`'s `locomotion.rs` and the bundle `test_bench_scenario.rs` are repointed. Kind ids are unchanged.

## Test plan

- The relocated widget-kind tests run from `ui/kinds.rs`.
- `cargo fmt -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace` (2029 passed), `cargo doc --workspace --no-deps` under the strict CI rustdoc flags, and the wasm32 cross-build all pass.

## Generated by

`/implement` — agent execution of [scoped issue #2171](https://github.com/iamacoffeepot/aether/issues/2171).
