### PR TITLE
fix(aether-capabilities): rustfmt the component import block

### DIFF
--- a/crates/aether-capabilities/src/component/mod.rs
+++ b/crates/aether-capabilities/src/component/mod.rs
@@ -49,9 +49,9 @@ mod load;
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::input::UnsubscribeAll;
-use aether_kinds::{DropComponent, ListComponents, LoadComponent, ReplaceComponent};
 #[cfg(not(target_arch = "wasm32"))]
 use aether_kinds::LifecycleUnsubscribeAll;
+use aether_kinds::{DropComponent, ListComponents, LoadComponent, ReplaceComponent};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use native::ComponentHostConfig;


### PR DESCRIPTION
## Summary

The #2164 input-kinds rebase landed an unformatted cfg-attributed `use` block in `component/mod.rs` — the non-cfg `aether_kinds` group sorted ahead of the cfg-gated `LifecycleUnsubscribeAll`, reddening the `Format` check on `main`. This reorders the block per rustfmt.

## Test plan

- `cargo fmt --all -- --check` clean. Import-order-only; no behavior change.