### PR TITLE
fix(workflow): implement-agent local validation should match CI rustdoc and clippy strictness

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -160,11 +160,12 @@ Type comes from the issue's `type:*` label. Slug is the issue title sanitized: l
 
 2. Implement per the issue body's `## Implementation plan` section. The agent follows the plan literally: same files, same sequence, same test coverage. Deviations are bounces, not freelancing.
 
-3. Run local pre-flight before pushing:
+3. Run local pre-flight before pushing (keep this list in lockstep with `scripts/checks.sh` — that file is the canonical source):
    - `cargo fmt`
+   - `cargo clean -p <crate>` for each crate the diff touches (ensures the final clippy below runs against a non-incremental target and cannot inherit a stale cache that masks a warning, e.g. an unused import left after a move)
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace`
-   - `cargo doc --workspace --no-deps`
+   - `RUSTDOCFLAGS="-D rustdoc::redundant_explicit_links -D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links" cargo doc --workspace --no-deps`
    - wasm32 cross-build for component crates (`cargo metadata` → packages with `crate-type = cdylib` and `aether-actor` dep)
    - `scripts/preflight.sh` if present (writes the stamp file expected by the pre-push hook). Qodana is **not** run here — it is a required CI gate (`Qodana scan`, in `ci-pass`) resolved at `/land` from the `qodana-report` artifact, so a sole `Qodana scan` red holds the draft for `/land` rather than blocking the push (see the Refine loop's CI-green branch)
 


### PR DESCRIPTION
Closes #2203.

## Summary

Mirrors the canonical CI check definitions in `/implement` Execute step 3 so a green agent self-validation reliably implies green CI: the inline `cargo doc` gains the canonical three-flag `RUSTDOCFLAGS` (byte-identical to `scripts/checks.sh` / `ci.yml`), a `cargo clean -p <crate>` runs before the final clippy so a stale incremental target can't mask a warning, and a lockstep note names `scripts/checks.sh` as the canonical source to deter future drift.

## Test plan

Docs-only change to `.claude/skills/implement/SKILL.md` (CI/repo-config-only pre-flight exception class). Validated by review; the flag string matches `ci.yml:123-126` / `preflight.sh:160`.

## Generated by

`/implement --sweep` — agent execution of scoped issue #2203.
