### PR TITLE
fix(repo): pre-push stamp check reads the main checkout's HEAD, not the pushing worktree

### DIFF
--- a/.claude/hooks/check-pre-push.sh
+++ b/.claude/hooks/check-pre-push.sh
@@ -16,6 +16,7 @@ set -u
 
 input=$(cat)
 command=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""')
 
 # Match `git push` / `gh pr create` only in command position — at the
 # start of a line or right after a separator (`;`, `&`, `|`, and thus
@@ -37,19 +38,23 @@ if ! command -v git >/dev/null 2>&1; then
     exit 0
 fi
 
-# iamacoffeepot/aether#1199: the gated command may target a worktree via a
-# leading `cd <path> &&` — the /implement skill pushes from
-# `.claude/worktrees/<slug>` / `/tmp/aether-*`. Evaluate git state in that
-# directory rather than the hook's own cwd (the main checkout); otherwise
-# HEAD and the stamp gitdir resolve against the wrong tree and a clean
-# in-worktree preflight is false-blocked. No `cd` prefix (the main-checkout
-# push) leaves cwd untouched, so that path is unchanged.
+# Worktree resolution — most-specific source wins:
+# (1) explicit `cd <path> &&` prefix on the gated command (#1199 behavior, unchanged);
+# (2) session cwd from the hook input JSON (.cwd), supplied by Claude Code for
+#     worktree-bound agents — closes the bare-push gap without a cd prefix
+#     (iamacoffeepot/aether#2200);
+# (3) current process cwd (main-checkout fallback when neither source is available).
+# Guard both hops with -n/-d before cd so a missing/garbage value fails open.
 cd_prefix_re='^[[:space:]]*cd[[:space:]]+([^[:space:];&|]+)'
 if [[ "$command" =~ $cd_prefix_re ]]; then
     target_dir="${BASH_REMATCH[1]}"
-    if [[ -n "$target_dir" && -d "$target_dir" ]]; then
-        cd "$target_dir" || true
-    fi
+elif [[ -n "$hook_cwd" && -d "$hook_cwd" ]]; then
+    target_dir="$hook_cwd"
+else
+    target_dir=""
+fi
+if [[ -n "$target_dir" && -d "$target_dir" ]]; then
+    cd "$target_dir" || true
 fi
 
 if ! git rev-parse --git-dir >/dev/null 2>&1; then

--- a/.claude/hooks/tests/run.sh
+++ b/.claude/hooks/tests/run.sh
@@ -110,6 +110,30 @@ else
 fi
 expect "release: no session id -> exit 0" release-session-worktree.sh '{}' 0
 
+echo "## check-pre-push.sh — session-cwd worktree resolution"
+SESS_WT="$SCAFFOLD/.claude/worktrees/SESS"
+SESS_GITDIR=$(git -C "$SESS_WT" rev-parse --git-dir)
+SESS_HEAD=$(git -C "$SESS_WT" rev-parse HEAD)
+SESS_STAMP="$SESS_GITDIR/aether-preflight-passed"
+
+# (d) --no-verify bypasses the gate regardless of stamp state.
+rm -f "$SESS_STAMP"
+expect "pre-push: --no-verify bypasses gate" check-pre-push.sh \
+  "{\"cwd\":\"$SESS_WT\",\"tool_input\":{\"command\":\"git push --no-verify\"}}" 0
+
+# (b) absent stamp for worktree HEAD → block.
+expect "pre-push: no stamp for worktree HEAD -> block" check-pre-push.sh \
+  "{\"cwd\":\"$SESS_WT\",\"tool_input\":{\"command\":\"git push\"}}" 2
+
+# (a) correct stamp + bare push resolved via .cwd → allow (#2200 fix).
+echo "$SESS_HEAD" > "$SESS_STAMP"
+expect "pre-push: stamped worktree HEAD, bare push via cwd -> allow" check-pre-push.sh \
+  "{\"cwd\":\"$SESS_WT\",\"tool_input\":{\"command\":\"git push\"}}" 0
+
+# (c) correct stamp + explicit cd-prefix form → allow (#1199 regression guard).
+expect "pre-push: stamped worktree HEAD, cd-prefix form -> allow" check-pre-push.sh \
+  "{\"cwd\":\"$SCAFFOLD\",\"tool_input\":{\"command\":\"cd $SESS_WT && git push\"}}" 0
+
 echo
 echo "$pass passed, $fail failed"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #2200.

## Summary

Resolves the pre-push stamp check against the pushing worktree instead of the main checkout. `.claude/hooks/check-pre-push.sh` gains a three-level cwd-resolution precedence: an explicit `cd <path> &&` prefix (unchanged #1199 behavior), else the hook-input JSON `.cwd` field (the worktree the session runs in), else the hook process cwd. Both hops are guarded with `-n`/`-d` so a missing field fails open. A worktree whose committed HEAD is stamped now pushes without `--no-verify`.

`.claude/hooks/check-pre-push.sh` is a guardrail file — this change was made under explicit user sign-off.

## Test plan

`.claude/hooks/tests/run.sh` extended with a `check-pre-push.sh` block: bare push via `.cwd` with a valid stamp exits 0; absent stamp exits 2; the `cd`-prefix form still exits 0 (#1199 regression guard); `--no-verify` exits 0. Full suite: 18 passed, 0 failed.

## Generated by

`/implement --sweep` — agent execution of scoped issue #2200.
