### PR TITLE
fix(ci): attest.sh qodana cache fills / with root-owned files

### DIFF
--- a/scripts/attest.sh
+++ b/scripts/attest.sh
@@ -100,6 +100,13 @@ AETHER_ATTEST_BASE="${AETHER_ATTEST_BASE:-$HOME/.cache}"
 export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$AETHER_ATTEST_BASE/aether-attest-target}"
 mkdir -p "$CARGO_TARGET_DIR"
 
+# Keep qodana's analysis cache and JBR downloads off $HOME and on the same
+# relocatable volume as CARGO_TARGET_DIR. Persisted across runs for incremental
+# warmth; root-owned droppings here are reclaimable via the existing
+# throwaway-root-container reap in the qodana) case below.
+QODANA_CACHE_DIR="${QODANA_CACHE_DIR:-$AETHER_ATTEST_BASE/aether-attest-qodana-cache}"
+mkdir -p "$QODANA_CACHE_DIR"
+
 # A fresh clone of HEAD with a real `.git`, under a Docker-shared path
 # (AETHER_ATTEST_BASE, $HOME/.cache by default — it must stay accessible to
 # qodana's container). Every step runs here: witness's git attestor reads
@@ -186,7 +193,7 @@ for step in $CANONICAL_STEPS; do
             # not products worth attesting, and the verifier reads only the
             # material/command-run/git attestations.
             export ATTEST_POST='docker run --rm -v "$PWD":/c alpine rm -rf /c/target /c/.qodana 2>/dev/null || true'
-            attest_step "$step" "${cmd[@]}" --diff-start "$QODANA_BASE" -u root
+            attest_step "$step" "${cmd[@]}" --diff-start "$QODANA_BASE" --cache-dir "$QODANA_CACHE_DIR" -u root
             unset ATTEST_POST ;;
         *)      attest_step "$step" "${cmd[@]}" ;;
     esac


### PR DESCRIPTION
Closes #2199.

## Summary

Redirects qodana's cache off `$HOME` onto `AETHER_ATTEST_BASE` in `scripts/attest.sh`, mirroring the existing `CARGO_TARGET_DIR` redirect: a persistent `$AETHER_ATTEST_BASE/aether-attest-qodana-cache` dir is created next to the target-dir export and passed as `--cache-dir` on the `qodana scan` invocation. Pointing `AETHER_ATTEST_BASE` at a work volume now keeps `$HOME/.cache/JetBrains` flat across repeated attested runs. `scripts/checks.sh`'s canonical `qodana scan` string is untouched (verifier containment holds).

`scripts/attest.sh` is a guardrail-adjacent file — this change was made under explicit user sign-off.

## Test plan

`bash -n scripts/attest.sh` passes; diff scoped to `scripts/attest.sh`. **Live verification not run** — Docker/qodana is unavailable in the agent environment, so the empirical confirmation (plan steps 1 and 4: that `$HOME/.cache/JetBrains` stays flat and any separate global JBR dir is also covered) needs one manual `scripts/attest.sh` run with `AETHER_ATTEST_BASE` off `$HOME` before merge.

## Generated by

`/implement --sweep` — agent execution of scoped issue #2199.
