### PR TITLE
fix(capabilities): text-native feature omits render despite the text cap using RenderCapability

### DIFF
--- a/crates/aether-capabilities/Cargo.toml
+++ b/crates/aether-capabilities/Cargo.toml
@@ -88,7 +88,7 @@ audio-native = ["audio", "native", "dep:cpal", "dep:crossbeam-queue", "dep:hound
 # `fontdue` rides `text-native` the way `hound` rides `audio-native`:
 # the pure-Rust TTF parse + rasterize + horizontal layout the cap runs
 # off the hot path. Implies the marker layer + `native`.
-text-native = ["text", "native", "dep:fontdue"]
+text-native = ["text", "native", "render", "dep:fontdue"]
 # `ui-native` has no heavy deps — the cap only sends mail to the render
 # and text caps. Implies the marker layer + `native` + the two surface
 # marker layers the native impl addresses.


### PR DESCRIPTION
Closes #2207.

## Summary

Adds `render` to the `text-native` feature in `crates/aether-capabilities/Cargo.toml`, so enabling the native text capability pulls in the `RenderCapability` it addresses. Before this, a standalone `cargo check -p aether-capabilities --no-default-features --features text-native` failed (no `crate::render`); the gap was masked under full-workspace feature unification. Mirrors the already-correct `ui-native = [..., "render", ...]`.

## Test plan

`cargo check -p aether-capabilities --no-default-features --features text-native` — fails before the edit (unresolved `crate::render`), passes after. Full `scripts/preflight.sh` run green (fmt, clippy, nextest, doc, wasm32 cross-build, qodana).

## Generated by

`/implement --sweep` — agent execution of scoped issue #2207.
