### PR TITLE
refactor(aether-derive): let the Config derive own parse-with-default, delete hand-rolled config parsers

### DIFF
--- a/crates/aether-capabilities/src/anthropic/mod.rs
+++ b/crates/aether-capabilities/src/anthropic/mod.rs
@@ -133,10 +133,6 @@ impl AnthropicAdapter for CombinedAnthropicAdapter {
 
 mod config {
     use super::{DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MILLIS};
-    // confique consumes these through `#[config(parse_env = …)]`; IntelliJ-Rust
-    // doesn't trace macro-attr path args (Qodana FP), but rustc + clippy do.
-    #[allow(unused_imports)]
-    use crate::config_env::{parse_flag, parse_millis_strict, parse_provider_max_in_flight_strict};
     use std::time::Duration;
 
     /// Resolved configuration for the `aether.anthropic` cap. Chassis
@@ -172,16 +168,14 @@ mod config {
             config(
                 env = "AETHER_ANTHROPIC_DISABLE",
                 cli_long = "anthropic-disable",
-                default = false,
-                parse = parse_flag
+                default = false
             )
         )]
         pub disabled: bool,
         /// Per-cap concurrency bound (doubles as rate-limit throttling).
-        #[cfg_attr(
-            feature = "native",
-            config(default = 2, parse = parse_provider_max_in_flight_strict)
-        )]
+        /// The `nonzero` hint coerces a resolved `0` (a zero-concurrency
+        /// provider deadlocks) back to the default.
+        #[cfg_attr(feature = "native", config(default = 2, nonzero))]
         pub max_in_flight: usize,
         /// Per-request timeout for the Messages API. The derive's
         /// `ms_duration` hint + `layer_field = "timeout_ms"` pin the
@@ -189,12 +183,7 @@ mod config {
         /// (`AETHER_ANTHROPIC_TIMEOUT_MS`, `--anthropic-timeout-ms`).
         #[cfg_attr(
             feature = "native",
-            config(
-                default = 120_000,
-                parse = parse_millis_strict::<DEFAULT_TIMEOUT_MILLIS>,
-                ms_duration,
-                layer_field = "timeout_ms"
-            )
+            config(default = 120_000, ms_duration, layer_field = "timeout_ms")
         )]
         pub timeout: Duration,
     }

--- a/crates/aether-capabilities/src/audio/config.rs
+++ b/crates/aether-capabilities/src/audio/config.rs
@@ -1,9 +1,6 @@
 //! Resolved audio synth configuration (ADR-0090). The `#[derive(Config)]`
 //! layer the chassis builds from argv/env and hands to `AudioCapability::init`.
 
-#[allow(unused_imports)]
-use crate::config_env::parse_flag;
-
 /// Resolved configuration for the audio synth. Chassis mains read
 /// env vars (`AETHER_AUDIO_DISABLE`, `AETHER_AUDIO_SAMPLE_RATE`)
 /// into an `AudioConfig` and pass it to `with_actor::<AudioCapability>(cfg)`
@@ -30,8 +27,7 @@ pub struct AudioConfig {
     #[config(
         env = "AETHER_AUDIO_DISABLE",
         cli_long = "audio-disable",
-        default = false,
-        parse = parse_flag
+        default = false
     )]
     pub disabled: bool,
     /// `AETHER_AUDIO_SAMPLE_RATE=<hz>` requests a specific rate. If

--- a/crates/aether-capabilities/src/config_env.rs
+++ b/crates/aether-capabilities/src/config_env.rs
@@ -1,115 +1,17 @@
-//! Shared confique `parse_env` helpers used by the capabilities'
-//! `*Layer` structs (ADR-0090). Centralized here so each per-cap
-//! migration doesn't carry its own copy of the identical bool /
-//! `> 0`-filtered concurrency parsers (Qodana `DuplicatedCode`).
+//! Shared config defaults for the capabilities' `#[derive(Config)]`
+//! structs (ADR-0090).
 //!
-//! Two parser families live here. [`parse_flag`] is total —
-//! `Result<bool, Infallible>` — because a bool reader can't fail (any
-//! non-truthy string is `false`). The **strict** (erroring) numeric
-//! variants are the ADR-0090 §4 hard-error half (unit e1): a malformed
-//! *known* env value returns `Err`, which confique surfaces from
-//! `.load()` and the chassis env resolver converts into a
-//! `ConfigError`. An empty value is treated as unset (falls back to
-//! the default) — only a non-empty unparseable value aborts boot.
-
-use std::convert::Infallible;
-use std::num::ParseIntError;
+//! The per-cap `parse_env` helpers that once lived here are gone: a
+//! numeric / `Duration` / `bool` field rides confique's native env
+//! deserialization (which trims, treats an empty value as unset →
+//! default, and hard-errors on a non-empty garbage value, ADR-0090 §4),
+//! a `csv_set` field auto-wires `aether_substrate::config::parse_csv_set`
+//! through the derive, and a zero-is-degenerate knob carries the
+//! `nonzero` hint. Only genuinely-bespoke parsers (the `aether.fs`
+//! `parse_dir`) still name a `parse =` function.
 
 /// Default per-cap concurrency bound shared by the content-gen
 /// providers (`aether.gemini`, `aether.anthropic`) when their
 /// `AETHER_*_MAX_IN_FLIGHT` env var is unset, non-positive, or
 /// unparseable. ADR-0050.
 pub const DEFAULT_PROVIDER_MAX_IN_FLIGHT: usize = 2;
-
-/// `"1"` or `"true"` (case-insensitive) → `true`, anything else
-/// `false`, matching the prior hand-rolled flag readers across
-/// http / gemini / anthropic / audio.
-#[allow(clippy::unnecessary_wraps)]
-pub fn parse_flag(s: &str) -> Result<bool, Infallible> {
-    Ok(s == "1" || s.eq_ignore_ascii_case("true"))
-}
-
-/// Strict ms parser (ADR-0090 §4 hard-error half): a non-empty value
-/// that doesn't parse as `u32` returns `Err`, which confique surfaces
-/// from `.load()` and the chassis env resolver converts into a
-/// `ConfigError`. An *empty* string is treated as unset and falls back
-/// to `DEFAULT_MILLIS` (an env var set to `""` is not a typo to abort on).
-///
-/// # Errors
-///
-/// Returns the underlying [`ParseIntError`] when a non-empty value is
-/// not a valid `u32`.
-pub fn parse_millis_strict<const DEFAULT_MILLIS: u32>(s: &str) -> Result<u32, ParseIntError> {
-    if s.trim().is_empty() {
-        return Ok(DEFAULT_MILLIS);
-    }
-    s.trim().parse()
-}
-
-/// Strict provider concurrency bound (ADR-0090 §4 hard-error half).
-/// Empty → [`DEFAULT_PROVIDER_MAX_IN_FLIGHT`] (unset); a non-empty
-/// value that doesn't parse as `usize` errors; a parsed `0` clamps up
-/// to the default (a zero-concurrency provider deadlocks, so it is
-/// treated as "use the default", not a hard error — matching the soft
-/// variant's `> 0` filter).
-///
-/// # Errors
-///
-/// Returns the underlying [`ParseIntError`] when a non-empty value is
-/// not a valid `usize`.
-pub fn parse_provider_max_in_flight_strict(s: &str) -> Result<usize, ParseIntError> {
-    if s.trim().is_empty() {
-        return Ok(DEFAULT_PROVIDER_MAX_IN_FLIGHT);
-    }
-    let n: usize = s.trim().parse()?;
-    Ok(if n > 0 {
-        n
-    } else {
-        DEFAULT_PROVIDER_MAX_IN_FLIGHT
-    })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{
-        DEFAULT_PROVIDER_MAX_IN_FLIGHT, parse_flag, parse_millis_strict,
-        parse_provider_max_in_flight_strict,
-    };
-
-    #[test]
-    fn parse_flag_matches_legacy_bool_reader() {
-        for truthy in ["1", "true", "TRUE", "True"] {
-            assert!(parse_flag(truthy).unwrap(), "{truthy} should be truthy");
-        }
-        for falsy in ["0", "", "yes", "false", "garbage"] {
-            assert!(!parse_flag(falsy).unwrap(), "{falsy} should be falsy");
-        }
-    }
-
-    #[test]
-    fn parse_provider_max_in_flight_strict_errors_on_garbage() {
-        // ADR-0090 §4: a parseable value passes; `0` clamps to the
-        // default (zero-concurrency deadlocks); empty is unset; a
-        // non-empty non-number errors rather than silently defaulting.
-        assert_eq!(parse_provider_max_in_flight_strict("4"), Ok(4));
-        assert_eq!(
-            parse_provider_max_in_flight_strict("0"),
-            Ok(DEFAULT_PROVIDER_MAX_IN_FLIGHT)
-        );
-        assert_eq!(
-            parse_provider_max_in_flight_strict(""),
-            Ok(DEFAULT_PROVIDER_MAX_IN_FLIGHT)
-        );
-        assert!(parse_provider_max_in_flight_strict("garbage").is_err());
-    }
-
-    #[test]
-    fn parse_millis_strict_errors_on_garbage() {
-        assert_eq!(parse_millis_strict::<30_000>("5000"), Ok(5000));
-        assert_eq!(parse_millis_strict::<30_000>(""), Ok(30_000));
-        assert!(parse_millis_strict::<30_000>("garbage").is_err());
-        // Different turbofish → different defaults (the unset path),
-        // keeping the per-cap call sites textually distinct.
-        assert_eq!(parse_millis_strict::<120_000>(""), Ok(120_000));
-    }
-}

--- a/crates/aether-capabilities/src/engine/server/config.rs
+++ b/crates/aether-capabilities/src/engine/server/config.rs
@@ -7,15 +7,7 @@
 use crate::engine::proxy::HeartbeatParams;
 use crate::store::DEFAULT_DISK_BUDGET_BYTES;
 use std::collections::HashSet;
-use std::convert::Infallible;
 use std::time::Duration;
-
-/// Default heartbeat ping cadence (issue 1339). 5 s × the miss
-/// limit is the detection-latency vs. flap-tolerance tradeoff.
-const DEFAULT_HEARTBEAT_INTERVAL_SECS: u64 = 5;
-/// Default consecutive-miss threshold before an engine is declared
-/// dead. Small N tolerates a transient hiccup / GC pause.
-const DEFAULT_HEARTBEAT_MISS_LIMIT: u32 = 3;
 
 /// Default total time a freshly-forked substrate's proxy keeps
 /// retrying its startup dial before giving up (issue 2072). A debug
@@ -58,14 +50,14 @@ pub struct EngineConfig {
     /// `--hub-heartbeat-interval-secs`). `0` disables the heartbeat
     /// entirely (engines are then only evicted on a
     /// connection-close, never on a wedge).
-    #[config(default = 5, parse = parse_heartbeat_interval_secs)]
+    #[config(default = 5)]
     pub heartbeat_interval_secs: u64,
     /// Consecutive missed pings that mark an engine dead
     /// (`AETHER_HUB_HEARTBEAT_MISS_LIMIT` /
     /// `--hub-heartbeat-miss-limit`). Small N tolerates a transient
     /// hiccup; `0` also disables the heartbeat. Detection latency is
     /// `miss_limit × interval_secs`.
-    #[config(default = 3, parse = parse_heartbeat_miss_limit)]
+    #[config(default = 3)]
     pub heartbeat_miss_limit: u32,
     /// Total seconds a freshly-forked substrate's proxy keeps
     /// retrying its startup dial before the spawn fails
@@ -74,7 +66,7 @@ pub struct EngineConfig {
     /// default so a debug cold start under fork contention isn't
     /// called dead prematurely; `0` is the wait-forever sentinel
     /// (retry until the dial succeeds or hits a terminal error).
-    #[config(default = 30, parse = parse_proxy_connect_budget_secs)]
+    #[config(default = 30)]
     pub proxy_connect_budget_secs: u64,
     /// Layout-root override for the hub's content-addressed binary
     /// store (`AETHER_BINARY_STORE_DIR`, unprefixed — the ops escape
@@ -91,7 +83,7 @@ pub struct EngineConfig {
     /// `AETHER_HUB` prefix / `--hub-binary-disk-budget-bytes`). Default
     /// 16 GiB (`DEFAULT_DISK_BUDGET_BYTES`); LRU eviction over unpinned,
     /// unnamed entries holds it.
-    #[config(default = 17_179_869_184u64, parse = parse_binary_disk_budget)]
+    #[config(default = 17_179_869_184u64)]
     pub binary_disk_budget_bytes: u64,
     /// Chassis bins to bootstrap-ingest at init so a `default` / `name`
     /// selector resolves in a fresh or `restart-hub`'d hub
@@ -99,12 +91,7 @@ pub struct EngineConfig {
     /// ingested content-addressed and named by its file stem;
     /// idempotent via content dedup. `ensure-tunnel.sh` exports the
     /// freshly-built chassis bins here.
-    #[config(
-        env = "AETHER_BINARY_BOOTSTRAP",
-        default = [],
-        parse = parse_binary_bootstrap,
-        csv_set
-    )]
+    #[config(env = "AETHER_BINARY_BOOTSTRAP", default = [], csv_set)]
     pub binary_bootstrap: HashSet<String>,
 }
 
@@ -154,51 +141,6 @@ impl EngineConfig {
         (self.proxy_connect_budget_secs != 0)
             .then(|| Duration::from_secs(self.proxy_connect_budget_secs))
     }
-}
-
-// confique's `parse_env` contract is `fn(&str) -> Result<T, impl
-// Error>`; these total helpers carry a `Result` they never fill with
-// `Err` — an unparseable value folds back to the default (soft, like
-// the DAG validator's caps; the ADR-0090 §4 strict/erroring variant
-// is a follow-up). Hence the `unnecessary_wraps` allow.
-
-/// Parse the heartbeat interval; unparseable → the default.
-#[allow(clippy::unnecessary_wraps)]
-fn parse_heartbeat_interval_secs(s: &str) -> Result<u64, Infallible> {
-    Ok(s.trim().parse().unwrap_or(DEFAULT_HEARTBEAT_INTERVAL_SECS))
-}
-
-/// Parse the heartbeat miss limit; unparseable → the default.
-#[allow(clippy::unnecessary_wraps)]
-fn parse_heartbeat_miss_limit(s: &str) -> Result<u32, Infallible> {
-    Ok(s.trim().parse().unwrap_or(DEFAULT_HEARTBEAT_MISS_LIMIT))
-}
-
-/// Parse the proxy connect budget seconds; unparseable → the default.
-#[allow(clippy::unnecessary_wraps)]
-fn parse_proxy_connect_budget_secs(s: &str) -> Result<u64, Infallible> {
-    Ok(s.trim()
-        .parse()
-        .unwrap_or(DEFAULT_PROXY_CONNECT_BUDGET_SECS))
-}
-
-/// Parse the binary-store disk budget; unparseable → the default
-/// `DEFAULT_DISK_BUDGET_BYTES` (mirrors the heartbeat parsers).
-#[allow(clippy::unnecessary_wraps)]
-fn parse_binary_disk_budget(s: &str) -> Result<u64, Infallible> {
-    Ok(s.trim().parse().unwrap_or(DEFAULT_DISK_BUDGET_BYTES))
-}
-
-/// Split a comma-separated bootstrap path list, trimming and dropping
-/// empties (mirrors the http allowlist's `parse_allowlist`). Total —
-/// never errors.
-#[allow(clippy::unnecessary_wraps)]
-fn parse_binary_bootstrap(s: &str) -> Result<HashSet<String>, Infallible> {
-    Ok(s.split(',')
-        .map(str::trim)
-        .filter(|p| !p.is_empty())
-        .map(str::to_string)
-        .collect())
 }
 
 #[cfg(test)]

--- a/crates/aether-capabilities/src/gemini/config.rs
+++ b/crates/aether-capabilities/src/gemini/config.rs
@@ -1,8 +1,4 @@
 use super::{DEFAULT_MAX_IN_FLIGHT, DEFAULT_TIMEOUT_MILLIS};
-// confique consumes these through `#[config(parse_env = …)]`; IntelliJ-Rust
-// doesn't trace macro-attr path args (Qodana FP), but rustc + clippy do.
-#[allow(unused_imports)]
-use crate::config_env::{parse_flag, parse_millis_strict, parse_provider_max_in_flight_strict};
 use std::time::Duration;
 
 /// Resolved configuration for the `aether.gemini` cap. Chassis mains
@@ -37,16 +33,14 @@ pub struct GeminiConfig {
         config(
             env = "AETHER_GEMINI_DISABLE",
             cli_long = "gemini-disable",
-            default = false,
-            parse = parse_flag
+            default = false
         )
     )]
     pub disabled: bool,
-    /// Per-cap concurrency bound (doubles as rate-limit throttling).
-    #[cfg_attr(
-        feature = "native",
-        config(default = 2, parse = parse_provider_max_in_flight_strict)
-    )]
+    /// Per-cap concurrency bound (doubles as rate-limit throttling). The
+    /// `nonzero` hint coerces a resolved `0` (a zero-concurrency provider
+    /// deadlocks) back to the default.
+    #[cfg_attr(feature = "native", config(default = 2, nonzero))]
     pub max_in_flight: usize,
     /// Per-request timeout for the media APIs. The derive's
     /// `ms_duration` hint + `layer_field = "timeout_ms"` pin the
@@ -54,12 +48,7 @@ pub struct GeminiConfig {
     /// (`AETHER_GEMINI_TIMEOUT_MS`, `--gemini-timeout-ms`).
     #[cfg_attr(
         feature = "native",
-        config(
-            default = 180_000,
-            parse = parse_millis_strict::<DEFAULT_TIMEOUT_MILLIS>,
-            ms_duration,
-            layer_field = "timeout_ms"
-        )
+        config(default = 180_000, ms_duration, layer_field = "timeout_ms")
     )]
     pub timeout: Duration,
 }
@@ -74,11 +63,6 @@ impl Default for GeminiConfig {
         }
     }
 }
-
-// confique's `parse_env` contract is `fn(&str) -> Result<T, impl Error>`,
-// so these total helpers carry a `Result` they never fill with `Err`.
-// The strict (erroring) variants land with the ADR-0090 §4 validation
-// pass; hence the per-fn `unnecessary_wraps` allow.
 
 #[cfg(all(test, feature = "native"))]
 mod tests {

--- a/crates/aether-capabilities/src/http/client.rs
+++ b/crates/aether-capabilities/src/http/client.rs
@@ -13,25 +13,15 @@
 //!   `Fetch.timeout_ms`.
 
 use std::collections::HashSet;
-#[cfg(feature = "native")]
-use std::num::ParseIntError;
 use std::time::Duration;
 
 // Handler-signature kinds must be importable at file root because
 // `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
 // of the mod (always-on, outside the cfg gate).
-// confique consumes `parse_flag` through the `#[config(parse_env = …)]`
-// attribute path; IntelliJ-Rust doesn't trace macro-attr path args and
-// flags this as unused (Qodana FP), but rustc + clippy resolve it.
-#[cfg(feature = "native")]
-#[allow(unused_imports)]
-use crate::config_env::parse_flag;
 use crate::http::kinds::{Fetch, HttpError, HttpHeader, HttpMethod};
 use aether_actor::WasmActorMailbox;
 #[cfg(not(target_arch = "wasm32"))]
 use aether_substrate::actor::native::NativeActorMailbox;
-#[cfg(feature = "native")]
-use std::convert::Infallible;
 
 /// Default response-body cap when `AETHER_HTTP_MAX_BODY_BYTES` is
 /// unset. 16MB matches ADR-0043 §3.
@@ -112,28 +102,22 @@ pub struct HttpConfig {
         config(
             env = "AETHER_HTTP_DISABLE",
             cli_long = "http-disable",
-            default = false,
-            parse = parse_flag
+            default = false
         )
     )]
     pub disabled: bool,
     /// Hostnames the adapter will dial. Empty = deny all
-    /// (deny-by-default per ADR-0043).
-    #[cfg_attr(
-        feature = "native",
-        config(default = [], parse = parse_allowlist, csv_set)
-    )]
+    /// (deny-by-default per ADR-0043). The `csv_set` hint auto-wires the
+    /// shared comma-split parser on the env side.
+    #[cfg_attr(feature = "native", config(default = [], csv_set))]
     pub allowlist: HashSet<String>,
     /// `AETHER_HTTP_REQUIRE_HTTPS=1` rejects `http://` URLs with
     /// `HttpError::InvalidUrl`.
-    #[cfg_attr(feature = "native", config(default = false, parse = parse_flag))]
+    #[cfg_attr(feature = "native", config(default = false))]
     pub require_https: bool,
     /// Cap on inbound and outbound body bytes. Defaults to
     /// [`DEFAULT_MAX_BODY_BYTES`] (16 MB).
-    #[cfg_attr(
-        feature = "native",
-        config(default = 16_777_216, parse = parse_max_body_bytes)
-    )]
+    #[cfg_attr(feature = "native", config(default = 16_777_216))]
     pub max_body_bytes: usize,
     /// Default per-request timeout when `Fetch.timeout_ms` is
     /// `None`. Defaults to [`DEFAULT_TIMEOUT_MILLIS`] (30 s). The derive's
@@ -141,15 +125,10 @@ pub struct HttpConfig {
     /// bridges via `Duration::from_millis(u64::from(...))`;
     /// `layer_field = "timeout_ms"` pins the Layer / env / CLI shape to
     /// the pre-derive name (`AETHER_HTTP_TIMEOUT_MS`,
-    /// `--http-timeout-ms`) for byte-identical compat.
+    /// `--http-timeout-ms`).
     #[cfg_attr(
         feature = "native",
-        config(
-            default = 30_000,
-            parse = parse_timeout_millis,
-            ms_duration,
-            layer_field = "timeout_ms"
-        )
+        config(default = 30_000, ms_duration, layer_field = "timeout_ms")
     )]
     pub default_timeout: Duration,
 }
@@ -164,57 +143,6 @@ impl Default for HttpConfig {
             default_timeout: Duration::from_millis(u64::from(DEFAULT_TIMEOUT_MILLIS)),
         }
     }
-}
-
-// confique's `parse_env` contract is `fn(&str) -> Result<T, impl Error>`, so
-// these helpers carry a `Result` they never fill with `Err` — a flag, a CSV
-// list, and a default-on-unparseable number are all total. Hence the per-fn
-// `unnecessary_wraps` allow; the strict (erroring) variants land with the
-// ADR-0090 §4 validation pass.
-
-/// Split a comma-separated host list, trimming and dropping empties.
-/// Total — never errors.
-#[cfg(feature = "native")]
-#[allow(clippy::unnecessary_wraps)]
-fn parse_allowlist(s: &str) -> Result<HashSet<String>, Infallible> {
-    Ok(s.split(',')
-        .map(str::trim)
-        .filter(|h| !h.is_empty())
-        .map(str::to_string)
-        .collect())
-}
-
-/// Parse a byte cap (ADR-0090 §4 hard-error half): empty → unset,
-/// falling back to [`DEFAULT_MAX_BODY_BYTES`]; a non-empty value that
-/// doesn't parse as `usize` errors, which confique surfaces from
-/// `.load()` and the chassis env resolver turns into a `ConfigError`.
-///
-/// # Errors
-///
-/// Returns a [`ParseIntError`] for a
-/// non-empty value that isn't a valid `usize`.
-#[cfg(feature = "native")]
-fn parse_max_body_bytes(s: &str) -> Result<usize, ParseIntError> {
-    if s.trim().is_empty() {
-        return Ok(DEFAULT_MAX_BODY_BYTES);
-    }
-    s.trim().parse()
-}
-
-/// Parse a timeout in milliseconds (ADR-0090 §4 hard-error half):
-/// empty → [`DEFAULT_TIMEOUT_MILLIS`]; a non-empty value that doesn't
-/// parse as `u32` errors.
-///
-/// # Errors
-///
-/// Returns a [`ParseIntError`] for a
-/// non-empty value that isn't a valid `u32`.
-#[cfg(feature = "native")]
-fn parse_timeout_millis(s: &str) -> Result<u32, ParseIntError> {
-    if s.trim().is_empty() {
-        return Ok(DEFAULT_TIMEOUT_MILLIS);
-    }
-    s.trim().parse()
 }
 
 /// Sender-side facade for actors addressed via
@@ -599,39 +527,11 @@ mod native {
         use crate::test_chassis::{TestChassis, fresh_substrate};
         use aether_substrate::mail::registry;
 
-        // ADR-0090: the confique migration is byte-identical to the prior
-        // hand-rolled reader. These exercise the resolution logic without
-        // touching process env (issue 464) — the parsers are pure, and the
-        // defaults check loads the layer with no `.env()` source.
-
-        #[test]
-        fn parse_allowlist_splits_trims_and_drops_empties() {
-            use super::super::parse_allowlist;
-            let got = parse_allowlist("a.com, b.com ,, c.com").unwrap();
-            let want: HashSet<String> = ["a.com", "b.com", "c.com"]
-                .iter()
-                .map(|s| (*s).to_string())
-                .collect();
-            assert_eq!(got, want);
-            assert!(parse_allowlist("").unwrap().is_empty());
-        }
-
-        #[test]
-        fn parse_numbers_strict_error_on_garbage() {
-            // ADR-0090 §4 hard-error half: a valid value parses, an
-            // empty value falls back to the default (unset), and a
-            // non-empty garbage value errors rather than silently
-            // defaulting.
-            use super::super::{
-                DEFAULT_TIMEOUT_MILLIS, parse_max_body_bytes, parse_timeout_millis,
-            };
-            assert_eq!(parse_max_body_bytes("1024"), Ok(1024));
-            assert_eq!(parse_max_body_bytes(""), Ok(DEFAULT_MAX_BODY_BYTES));
-            assert!(parse_max_body_bytes("not-a-number").is_err());
-            assert_eq!(parse_timeout_millis("5000"), Ok(5000));
-            assert_eq!(parse_timeout_millis(""), Ok(DEFAULT_TIMEOUT_MILLIS));
-            assert!(parse_timeout_millis("garbage").is_err());
-        }
+        // ADR-0090: the defaults check loads the layer with no `.env()`
+        // source. The env-value behavior (trim, empty → default, garbage
+        // → hard-error) is now confique's native deserialization, covered
+        // by `aether_substrate::config`'s confique tests; the CSV split is
+        // covered by `parse_csv_set` there.
 
         #[test]
         fn http_from_env_defaults_match() {

--- a/crates/aether-capabilities/src/http/server.rs
+++ b/crates/aether-capabilities/src/http/server.rs
@@ -35,11 +35,6 @@
 use crate::http::kinds::HttpInboundReady;
 use aether_kinds::trace::Settled;
 
-// confique `parse_env` helpers below never error; their `Result` carries
-// the never-type.
-#[cfg(feature = "native")]
-use std::convert::Infallible;
-
 // Default bind address. Loopback per ADR-0108 §6 — binding a public
 // interface is an explicit operator choice.
 /// Default `bind_addr` when unset: loopback, OS-assigned port (ADR-0108 §6).
@@ -83,41 +78,31 @@ pub struct HttpServerConfig {
     /// Whether to bind the listening socket at all. Default `false` —
     /// the HTTP server is opt-in, so an unconfigured chassis binds no
     /// port. The remaining fields are consulted only when this is `true`.
-    #[cfg_attr(feature = "native", config(default = false, parse = parse_flag))]
+    #[cfg_attr(feature = "native", config(default = false))]
     pub enabled: bool,
     /// Address to bind the listening socket. Defaults to loopback
     /// ([`DEFAULT_BIND_ADDR`]); a public interface is an explicit choice.
-    #[cfg_attr(
-        feature = "native",
-        config(default = "127.0.0.1:8080", parse = parse_bind_addr)
-    )]
+    /// A blank override (`AETHER_HTTP_SERVER_BIND_ADDR=`) falls back to
+    /// the default — the derive treats an empty `String` as unset.
+    #[cfg_attr(feature = "native", config(default = "127.0.0.1:8080"))]
     pub bind_addr: String,
     /// The single handler mailbox every request is dispatched to (e.g.
     /// `"aether.component/aether.embedded:web"`). Empty = every request is
     /// answered `503` (no handler resolves).
-    #[cfg_attr(feature = "native", config(default = "", parse = parse_handler_mailbox))]
+    #[cfg_attr(feature = "native", config(default = ""))]
     pub handler_mailbox: String,
     /// Cap on the request body in bytes ([`DEFAULT_MAX_REQUEST_BYTES`]);
     /// an announced `Content-Length` past this is answered `413`.
-    #[cfg_attr(
-        feature = "native",
-        config(default = 1_048_576, parse = parse_max_request_bytes)
-    )]
+    #[cfg_attr(feature = "native", config(default = 1_048_576))]
     pub max_request_bytes: usize,
     /// Cap on the request line + header bytes ([`DEFAULT_MAX_HEADER_BYTES`]);
     /// a head that grows past this is answered `431`.
-    #[cfg_attr(
-        feature = "native",
-        config(default = 65_536, parse = parse_max_header_bytes)
-    )]
+    #[cfg_attr(feature = "native", config(default = 65_536))]
     pub max_header_bytes: usize,
     /// Per-read socket timeout (slow-loris guard) and handler response
     /// deadline in milliseconds ([`DEFAULT_REQUEST_TIMEOUT_MILLIS`]); a
     /// handler that doesn't reply in time yields `504`.
-    #[cfg_attr(
-        feature = "native",
-        config(default = 30_000, parse = parse_request_timeout_millis)
-    )]
+    #[cfg_attr(feature = "native", config(default = 30_000))]
     pub request_timeout_millis: u64,
 }
 
@@ -132,50 +117,6 @@ impl Default for HttpServerConfig {
             request_timeout_millis: DEFAULT_REQUEST_TIMEOUT_MILLIS,
         }
     }
-}
-
-// confique's `parse_env` contract is `fn(&str) -> Result<T, impl Error>`;
-// these total helpers carry a `Result` they never fill with `Err` — an
-// unparseable numeric folds back to the default (soft, like the engines
-// cap's heartbeat parse; the ADR-0090 §4 strict/erroring variant is a
-// follow-up). Hence the per-fn `unnecessary_wraps` allow.
-
-#[cfg(feature = "native")]
-use crate::config_env::parse_flag;
-
-#[cfg(feature = "native")]
-#[allow(clippy::unnecessary_wraps)]
-fn parse_bind_addr(s: &str) -> Result<String, Infallible> {
-    let trimmed = s.trim();
-    Ok(if trimmed.is_empty() {
-        DEFAULT_BIND_ADDR.to_string()
-    } else {
-        trimmed.to_string()
-    })
-}
-
-#[cfg(feature = "native")]
-#[allow(clippy::unnecessary_wraps)]
-fn parse_handler_mailbox(s: &str) -> Result<String, Infallible> {
-    Ok(s.trim().to_string())
-}
-
-#[cfg(feature = "native")]
-#[allow(clippy::unnecessary_wraps)]
-fn parse_max_request_bytes(s: &str) -> Result<usize, Infallible> {
-    Ok(s.trim().parse().unwrap_or(DEFAULT_MAX_REQUEST_BYTES))
-}
-
-#[cfg(feature = "native")]
-#[allow(clippy::unnecessary_wraps)]
-fn parse_max_header_bytes(s: &str) -> Result<usize, Infallible> {
-    Ok(s.trim().parse().unwrap_or(DEFAULT_MAX_HEADER_BYTES))
-}
-
-#[cfg(feature = "native")]
-#[allow(clippy::unnecessary_wraps)]
-fn parse_request_timeout_millis(s: &str) -> Result<u64, Infallible> {
-    Ok(s.trim().parse().unwrap_or(DEFAULT_REQUEST_TIMEOUT_MILLIS))
 }
 
 #[aether_actor::bridge(singleton)]

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -39,10 +39,9 @@ pub mod component;
 // elides cleanly on the wasm-component build.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod contentgen;
-// Shared confique `parse_env` helpers + provider defaults (ADR-0090).
-// Kept ungated so the per-provider `DEFAULT_MAX_IN_FLIGHT` constants can
-// alias `DEFAULT_PROVIDER_MAX_IN_FLIGHT` at file top level; the parser
-// fns are tiny pure-Rust dead code on non-native builds.
+// Shared provider config defaults (ADR-0090). The per-provider
+// `DEFAULT_MAX_IN_FLIGHT` constants alias `DEFAULT_PROVIDER_MAX_IN_FLIGHT`
+// from here.
 mod config_env;
 
 pub mod engine;

--- a/crates/aether-derive/src/config.rs
+++ b/crates/aether-derive/src/config.rs
@@ -58,7 +58,15 @@ struct FieldAttr {
     /// `<field>_ms: u32`.
     ms_duration: bool,
     /// `csv_set` hint — overlay accepts `Option<String>` and splits CSV.
+    /// On the env side the derive auto-wires
+    /// `aether_substrate::config::parse_csv_set` as the `parse_env`, so a
+    /// cap declares `csv_set` and never names a split parser.
     csv_set: bool,
+    /// `nonzero` hint — a resolved `0` coerces to the field's `default`
+    /// in `from_layer` (a zero is the unset sentinel for knobs where it
+    /// is degenerate, e.g. a `0`-concurrency bound that would deadlock).
+    /// Requires a `default`.
+    nonzero: bool,
     /// `layer_field = "..."` — overrides the Layer-side field
     /// identifier (and the env key derivation if `env` isn't also set).
     /// Used when the domain name differs from the historical Layer
@@ -209,6 +217,9 @@ fn parse_field_attr(attrs: &[Attribute]) -> syn::Result<FieldAttr> {
             } else if meta.path.is_ident("csv_set") {
                 out.csv_set = true;
                 Ok(())
+            } else if meta.path.is_ident("nonzero") {
+                out.nonzero = true;
+                Ok(())
             } else if meta.path.is_ident("layer_field") {
                 out.layer_field = Some(meta.value()?.parse::<LitStr>()?.value());
                 Ok(())
@@ -216,7 +227,7 @@ fn parse_field_attr(attrs: &[Attribute]) -> syn::Result<FieldAttr> {
                 Err(meta.error(
                     "unknown field attribute; expected one of \
                      `env = \"...\"`, `cli_long = \"...\"`, `default = <lit>`, \
-                     `parse = <fn_path>`, `ms_duration`, `csv_set`, \
+                     `parse = <fn_path>`, `ms_duration`, `csv_set`, `nonzero`, \
                      `layer_field = \"...\"`",
                 ))
             }
@@ -261,8 +272,15 @@ fn field_info(field: &Field, container: &ContainerAttr) -> syn::Result<FieldInfo
             "`ms_duration` hint requires field type `std::time::Duration`",
         ));
     }
+    if attr.nonzero && attr.default.is_none() {
+        return Err(syn::Error::new(
+            span,
+            "`nonzero` hint requires a `default` (a resolved `0` coerces to it)",
+        ));
+    }
 
     let is_bool = is_bool_type(&domain_ty);
+    let is_string = matches!(&domain_ty, Type::Path(tp) if path_is(&tp.path, "String"));
     let inner_option_ty = unwrap_option(&domain_ty);
     // Whether this is `Option<numeric>` whose Layer rep is `Option<String>`.
     let is_option_numeric = inner_option_ty.as_ref().is_some_and(is_numeric_type);
@@ -350,16 +368,31 @@ fn field_info(field: &Field, container: &ContainerAttr) -> syn::Result<FieldInfo
     });
     let cli_id = cli_long.replace('-', "_");
 
-    let layer_attrs = build_layer_attrs(&env_key, attr.default.as_ref(), attr.parse.as_ref());
+    let resolved_parse = resolve_parse_env(&attr);
+    let layer_attrs = build_layer_attrs(&env_key, attr.default.as_ref(), resolved_parse.as_ref());
     let overlay_attrs = build_overlay_attrs(&cli_id, &cli_long, is_bool);
 
+    // Resolve the `from_layer` body shape (priority-ordered): the typed
+    // shapes first, then the hint-driven coercions, then a plain move.
+    let from_layer_kind = if attr.ms_duration {
+        FromLayerKind::MsDuration
+    } else if is_option_string {
+        FromLayerKind::OptionString
+    } else if is_option_numeric {
+        FromLayerKind::OptionNumeric
+    } else if attr.nonzero {
+        FromLayerKind::Nonzero
+    } else if is_string && attr.default.is_some() {
+        FromLayerKind::StringWithDefault
+    } else {
+        FromLayerKind::Plain
+    };
     let from_layer_expr = build_from_layer_expr(
         &ident,
         &layer_ident,
         &domain_ty,
-        attr.ms_duration,
-        is_option_string,
-        is_option_numeric,
+        &from_layer_kind,
+        attr.default.as_ref(),
     );
     let into_layer_stmt =
         build_into_layer_stmt(&ident, &layer_ident, attr.csv_set, is_option_numeric);
@@ -373,6 +406,19 @@ fn field_info(field: &Field, container: &ContainerAttr) -> syn::Result<FieldInfo
         layer_attrs,
         overlay_attrs,
         into_layer_stmt,
+    })
+}
+
+/// Resolve the Layer `parse_env`: an explicit `parse =` wins (the
+/// `parse_dir` escape hatch); else a `csv_set` field auto-wires the
+/// shared trim+split helper so the cap never names it. Plain numeric /
+/// `Duration` / `bool` / `String` fields resolve to `None` and ride
+/// confique's native deserialization (which trims, treats an empty value
+/// as unset → default, and hard-errors on garbage — ADR-0090 §4).
+fn resolve_parse_env(attr: &FieldAttr) -> Option<Path> {
+    attr.parse.clone().or_else(|| {
+        attr.csv_set
+            .then(|| syn::parse_quote!(::aether_substrate::config::parse_csv_set))
     })
 }
 
@@ -405,34 +451,69 @@ fn build_overlay_attrs(cli_id: &str, cli_long: &str, is_bool: bool) -> TokenStre
     }
 }
 
+/// Which `from_layer` body a field gets — resolved from its type +
+/// hints in [`field_info`], so the builder takes one tag rather than a
+/// fistful of booleans.
+enum FromLayerKind {
+    /// `Duration` domain, `<field>_ms: u32` Layer.
+    MsDuration,
+    /// `Option<String>` — empty string ≡ unset.
+    OptionString,
+    /// `Option<numeric>` — Layer holds `Option<String>`, soft-parsed.
+    OptionNumeric,
+    /// `nonzero` — a resolved `0` coerces to the field default.
+    Nonzero,
+    /// `String` with a `default` — an empty value coerces to the default.
+    StringWithDefault,
+    /// Straight move of the Layer field.
+    Plain,
+}
+
 fn build_from_layer_expr(
     domain_ident: &Ident,
     layer_ident: &Ident,
     domain_ty: &Type,
-    ms_duration: bool,
-    is_option_string: bool,
-    is_option_numeric: bool,
+    kind: &FromLayerKind,
+    default: Option<&Expr>,
 ) -> TokenStream2 {
-    if ms_duration {
-        // Domain stays the domain ident; layer is `<ident>_ms`.
-        quote! {
+    match kind {
+        FromLayerKind::MsDuration => quote! {
             #domain_ident: ::std::time::Duration::from_millis(::core::convert::From::from(layer.#layer_ident))
-        }
-    } else if is_option_string {
-        // `Option<String>` — empty string ≡ unset.
-        quote! {
+        },
+        FromLayerKind::OptionString => quote! {
             #domain_ident: layer.#layer_ident.filter(|s| !s.is_empty())
+        },
+        FromLayerKind::OptionNumeric => {
+            let inner = unwrap_option(domain_ty).expect("checked is_option_numeric");
+            quote! {
+                #domain_ident: layer.#layer_ident.and_then(|s| s.parse::<#inner>().ok())
+            }
         }
-    } else if is_option_numeric {
-        // Layer holds `Option<String>`; parse softly here.
-        let inner = unwrap_option(domain_ty).expect("checked is_option_numeric");
-        quote! {
-            #domain_ident: layer.#layer_ident.and_then(|s| s.parse::<#inner>().ok())
+        FromLayerKind::Nonzero => {
+            let default = default.expect("checked by `nonzero` guard");
+            quote! {
+                #domain_ident: {
+                    let resolved = layer.#layer_ident;
+                    if resolved == 0 { #default } else { resolved }
+                }
+            }
         }
-    } else {
-        quote! {
+        FromLayerKind::StringWithDefault => {
+            let default = default.expect("checked by `StringWithDefault`");
+            quote! {
+                #domain_ident: {
+                    let resolved = layer.#layer_ident;
+                    if resolved.is_empty() {
+                        ::std::string::ToString::to_string(&#default)
+                    } else {
+                        resolved
+                    }
+                }
+            }
+        }
+        FromLayerKind::Plain => quote! {
             #domain_ident: layer.#layer_ident
-        }
+        },
     }
 }
 

--- a/crates/aether-derive/src/lib.rs
+++ b/crates/aether-derive/src/lib.rs
@@ -30,18 +30,33 @@ mod config;
 /// ## Field attributes
 ///
 /// - `#[config(default = <lit>)]` — confique default literal.
-/// - `#[config(parse = <fn_path>)]` — confique `parse_env` function;
-///   turbofish-bearing paths are supported (`parse_u32_ms_or::<DEFAULT_TIMEOUT_MS>`).
+/// - `#[config(parse = <fn_path>)]` — an explicit confique `parse_env`
+///   function (turbofish-bearing paths supported), for a genuinely-custom
+///   mapping like `aether-capabilities::fs`'s `parse_dir`. A plain
+///   numeric / `Duration` / `bool` / `String` field needs none — see
+///   "Type-driven emission" below.
 /// - `#[config(ms_duration)]` — domain field is `Duration`; Layer
 ///   carries `<field>_ms: u32`; `from_layer` does the millis → Duration
 ///   map.
 /// - `#[config(csv_set)]` — domain + Layer share `HashSet<String>`;
-///   overlay carries `Option<String>` and splits CSV inline.
+///   overlay carries `Option<String>` and splits CSV inline; the env side
+///   auto-wires `aether_substrate::config::parse_csv_set` (trim + split +
+///   drop-empties).
+/// - `#[config(nonzero)]` — a resolved `0` coerces to the field
+///   `default` in `from_layer` (requires a `default`); for a knob where
+///   `0` is degenerate, e.g. a concurrency bound that would deadlock.
 /// - `#[config(env = "...")]` — per-field env-name override (used for
 ///   un-prefixed keys like `GEMINI_API_KEY`).
 ///
 /// ## Type-driven emission (no explicit hint)
 ///
+/// - numeric / `Duration` / `bool` — no `parse_env`; confique's native
+///   env deserialization trims, treats an empty value as unset → default,
+///   accepts the usual bool spellings, and hard-errors on a non-empty
+///   garbage value (ADR-0090 §4).
+/// - `String` with a `default` — `from_layer` maps an empty value to the
+///   default (confique resolves an unset var to the default but a
+///   set-but-empty var to `""`, since empty is a valid string).
 /// - `Option<String>` — `from_layer` always applies `.filter(|s| !s.is_empty())`
 ///   (empty env ≡ unset).
 /// - `Option<<numeric>>` — Layer holds `Option<String>`; `from_layer`

--- a/crates/aether-derive/tests/expand.rs
+++ b/crates/aether-derive/tests/expand.rs
@@ -13,7 +13,9 @@ fn ui() {
     t.pass("tests/ui/accepts_full_http.rs");
     t.pass("tests/ui/accepts_optional_field.rs");
     t.pass("tests/ui/accepts_ms_duration.rs");
+    t.pass("tests/ui/accepts_auto_wired.rs");
     t.compile_fail("tests/ui/rejects_ms_duration_on_non_duration.rs");
     t.compile_fail("tests/ui/rejects_missing_env_prefix.rs");
     t.compile_fail("tests/ui/rejects_unknown_hint.rs");
+    t.compile_fail("tests/ui/rejects_nonzero_without_default.rs");
 }

--- a/crates/aether-derive/tests/ui/accepts_auto_wired.rs
+++ b/crates/aether-derive/tests/ui/accepts_auto_wired.rs
@@ -1,0 +1,24 @@
+//! Accept case for the parser-free shapes: a bare numeric and `bool`
+//! field (confique native deserialization, no `parse`), a `nonzero`
+//! field (resolved `0` → default), and a `String` field with a default
+//! (empty → default in `from_layer`). Proves the Layer + Overlay +
+//! impls compile with no hand-rolled `parse_env` in sight.
+//!
+//! (The `csv_set` auto-wire emits a path into `aether_substrate`, which
+//! `aether-derive` can't depend on; it is covered by the cap configs and
+//! the `parse_csv_set` unit test instead.)
+
+#[derive(aether_derive::Config)]
+#[config(env_prefix = "AETHER_AUTO", cli_prefix = "auto")]
+pub struct AutoConfig {
+    #[config(default = false)]
+    pub disabled: bool,
+    #[config(default = 30_000)]
+    pub max_bytes: usize,
+    #[config(default = 2, nonzero)]
+    pub max_in_flight: usize,
+    #[config(default = "127.0.0.1:8080")]
+    pub bind_addr: String,
+}
+
+fn main() {}

--- a/crates/aether-derive/tests/ui/rejects_nonzero_without_default.rs
+++ b/crates/aether-derive/tests/ui/rejects_nonzero_without_default.rs
@@ -1,0 +1,12 @@
+//! `nonzero` coerces a resolved `0` to the field default, so it
+//! requires a `default` — applying it to a field without one is a
+//! programmer error caught at expansion time.
+
+#[derive(aether_derive::Config)]
+#[config(env_prefix = "AETHER_BAD", cli_prefix = "bad")]
+pub struct BadConfig {
+    #[config(nonzero)]
+    pub max_in_flight: usize,
+}
+
+fn main() {}

--- a/crates/aether-derive/tests/ui/rejects_nonzero_without_default.stderr
+++ b/crates/aether-derive/tests/ui/rejects_nonzero_without_default.stderr
@@ -1,0 +1,5 @@
+error: `nonzero` hint requires a `default` (a resolved `0` coerces to it)
+ --> tests/ui/rejects_nonzero_without_default.rs:8:5
+  |
+8 |     #[config(nonzero)]
+  |     ^

--- a/crates/aether-derive/tests/ui/rejects_unknown_hint.stderr
+++ b/crates/aether-derive/tests/ui/rejects_unknown_hint.stderr
@@ -1,4 +1,4 @@
-error: unknown field attribute; expected one of `env = "..."`, `cli_long = "..."`, `default = <lit>`, `parse = <fn_path>`, `ms_duration`, `csv_set`, `layer_field = "..."`
+error: unknown field attribute; expected one of `env = "..."`, `cli_long = "..."`, `default = <lit>`, `parse = <fn_path>`, `ms_duration`, `csv_set`, `nonzero`, `layer_field = "..."`
  --> tests/ui/rejects_unknown_hint.rs:7:14
   |
 7 |     #[config(magic)]

--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -13,7 +13,6 @@
 
 use std::env;
 use std::net::SocketAddr;
-use std::num::ParseIntError;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -118,31 +117,19 @@ pub struct ActorRingConfig {
     /// `AETHER_ACTOR_LOG_RING_SIZE=<entries>` per-actor log-ring capacity
     /// (default [`DEFAULT_RING_CAP`]). Zero clamps to 1 inside
     /// `ActorLogRing::with_capacity`.
-    #[config(
-        env = "AETHER_ACTOR_LOG_RING_SIZE",
-        default = 1024,
-        parse = parse_ring_capacity::<DEFAULT_RING_CAP>
-    )]
+    #[config(env = "AETHER_ACTOR_LOG_RING_SIZE", default = 1024)]
     pub log_ring_capacity: usize,
     /// `AETHER_ACTOR_TRACE_RING_SIZE=<entries>` per-actor (and
     /// chassis-host) trace-ring *floor* — the size each ring starts at
     /// (default [`DEFAULT_TRACE_RING_CAP`]). Zero clamps to 1 inside
     /// `ActorTraceRing::with_growth`.
-    #[config(
-        env = "AETHER_ACTOR_TRACE_RING_SIZE",
-        default = 4096,
-        parse = parse_ring_capacity::<DEFAULT_TRACE_RING_CAP>
-    )]
+    #[config(env = "AETHER_ACTOR_TRACE_RING_SIZE", default = 4096)]
     pub trace_ring_capacity: usize,
     /// `AETHER_ACTOR_TRACE_RING_MAX_SIZE=<entries>` ceiling a saturating
     /// trace ring grows to before it resumes drop-oldest (default
     /// [`DEFAULT_TRACE_RING_MAX_CAP`]). A value below the floor clamps up
     /// to the floor inside `ActorTraceRing::with_growth`.
-    #[config(
-        env = "AETHER_ACTOR_TRACE_RING_MAX_SIZE",
-        default = 65536,
-        parse = parse_ring_capacity::<DEFAULT_TRACE_RING_MAX_CAP>
-    )]
+    #[config(env = "AETHER_ACTOR_TRACE_RING_MAX_SIZE", default = 65536)]
     pub trace_ring_max_size: usize,
 }
 
@@ -167,22 +154,6 @@ impl ActorRingConfig {
             trace_max: self.trace_ring_max_size,
         }
     }
-}
-
-/// Parse a ring-capacity env value (ADR-0090 §4 hard-error half): empty →
-/// unset, falling back to the const default `D`; a non-empty value that
-/// isn't a valid `usize` errors, which confique surfaces from `.load()`
-/// and the chassis env resolver turns into a `ConfigError`.
-///
-/// # Errors
-///
-/// Returns a [`ParseIntError`] for a non-empty value that isn't a valid
-/// `usize`.
-fn parse_ring_capacity<const D: usize>(s: &str) -> Result<usize, ParseIntError> {
-    if s.trim().is_empty() {
-        return Ok(D);
-    }
-    s.trim().parse::<usize>()
 }
 
 /// Default cumulative settlement-patience cap, in seconds (issue 2062).
@@ -211,11 +182,7 @@ pub struct SettlementConfig {
     /// [`DEFAULT_SETTLEMENT_CAP_SECS`]). `0` is the sentinel for "no cap —
     /// wait forever," for attaching a debugger to a suspected deadlock; in
     /// that mode the per-round warn log stays the live signal.
-    #[config(
-        env = "AETHER_SETTLEMENT_CAP_SECS",
-        default = 300,
-        parse = parse_cap_secs
-    )]
+    #[config(env = "AETHER_SETTLEMENT_CAP_SECS", default = 300)]
     pub cap_secs: u64,
 }
 
@@ -240,23 +207,6 @@ impl SettlementConfig {
             Duration::from_secs(self.cap_secs)
         }
     }
-}
-
-/// Parse `AETHER_SETTLEMENT_CAP_SECS` (seconds; ADR-0090 §4 hard-error
-/// half): empty → unset, falling back to [`DEFAULT_SETTLEMENT_CAP_SECS`];
-/// a non-empty value that isn't a valid `u64` errors, which confique
-/// surfaces from `.load()` and the chassis env resolver turns into a
-/// `ConfigError`.
-///
-/// # Errors
-///
-/// Returns a [`ParseIntError`] for a non-empty value that isn't a valid
-/// `u64`.
-fn parse_cap_secs(s: &str) -> Result<u64, ParseIntError> {
-    if s.trim().is_empty() {
-        return Ok(DEFAULT_SETTLEMENT_CAP_SECS);
-    }
-    s.trim().parse::<u64>()
 }
 
 /// Assemble the chassis-wide [`KnownKeys`] set (ADR-0090 §4): every

--- a/crates/aether-substrate-bundle/src/cli.rs
+++ b/crates/aether-substrate-bundle/src/cli.rs
@@ -12,8 +12,8 @@
 //! prefix, lowercase, hyphenate. `AETHER_HTTP_TIMEOUT_MS` →
 //! `--http-timeout-ms`, `GEMINI_API_KEY` → `--gemini-api-key`.
 //! Bool flags accept zero or one value (`--http-disable` ⇒ `true`,
-//! `--http-disable=false` ⇒ `false`, absent ⇒ `None`), matching the
-//! env-side `parse_flag` semantics.
+//! `--http-disable=false` ⇒ `false`, absent ⇒ `None`), matching
+//! confique's native env-side bool deserialization.
 //!
 //! Chassis-wide knobs (`workers`, `tick_hz`, `window_mode`,
 //! `window_title`, `rpc_port`) live as plain `Option<T>` fields on the

--- a/crates/aether-substrate/src/config.rs
+++ b/crates/aether-substrate/src/config.rs
@@ -16,25 +16,34 @@
 //!     config(env_prefix = "AETHER_HTTP", cli_prefix = "http")
 //! )]
 //! pub struct HttpConfig {
-//!     #[cfg_attr(feature = "native", config(default = false, parse = parse_flag))]
+//!     #[cfg_attr(feature = "native", config(default = false))]
 //!     pub disabled: bool,
 //!     #[cfg_attr(
 //!         feature = "native",
-//!         config(default = 30_000, parse = parse_timeout_ms, ms_duration)
+//!         config(default = 30_000, ms_duration)
 //!     )]
 //!     pub default_timeout: Duration,
 //! }
 //! ```
+//!
+//! A numeric / `Duration` / `bool` field needs no parser: confique's
+//! native env deserialization trims the value, treats an empty value as
+//! unset (falling back to the `default`), accepts the usual bool
+//! spellings (`1` / `true` / `yes` / `0` / `false` / `no`), and
+//! hard-errors on a non-empty garbage value (ADR-0090 §4). Only a
+//! genuinely-custom mapping names a `parse =` function.
 //!
 //! The derive emits the env-shaped `*Layer`, the clap-shaped
 //! `*Overlay` (next to the domain struct in the cap crate; the
 //! bundle's `cli.rs` `pub use`s them), the `FromArgvThenEnv` impl,
 //! and inherent `from_env()` / `from_argv_then_env(argv)` shims. Per-
 //! field hints (`default`, `parse`, `env`, `cli_long`, `ms_duration`,
-//! `csv_set`, `layer_field`) cover the d-era wire shapes; the
+//! `csv_set`, `nonzero`, `layer_field`) cover the wire shapes; the
 //! container `skip_from_layer` opt-out lets a cap hand-write
 //! `from_layer` when its defaults are runtime-computed (the
-//! `NamespaceRoots` case).
+//! `NamespaceRoots` case). `csv_set` auto-wires
+//! [`parse_csv_set`] on the env side; `nonzero` coerces a resolved `0`
+//! to the field default in `from_layer`.
 //!
 //! [`FromArgvThenEnv`] still exists as the underlying trait — the
 //! derive emits an impl of it. Hand-written impls remain valid where
@@ -51,7 +60,7 @@
 //! owns:
 //!
 //! ```ignore
-//! #[cfg_attr(feature = "native", config(default = false, parse = parse_flag))]
+//! #[cfg_attr(feature = "native", config(default = false))]
 //! pub enabled: bool,
 //! ```
 //!
@@ -60,10 +69,12 @@
 //! until suppressed — names it `disabled`. Both default to `false`, so
 //! the literal default always reads as the unsurprising state, and the
 //! chassis maps the resolved `bool` to its structural choice at the one
-//! composition site (`cfg.enabled.then_some(cfg)`). The `parse_flag`
-//! helper accepts the usual `1` / `true` / `yes` / `on` spellings.
+//! composition site (`cfg.enabled.then_some(cfg)`). confique's native
+//! bool deserialization accepts the usual `1` / `true` / `yes` / `0` /
+//! `false` / `no` spellings (case-insensitive, trimmed).
 
 use std::collections::HashSet;
+use std::convert::Infallible;
 use std::env;
 use std::error::Error as StdError;
 use std::fmt;
@@ -74,6 +85,30 @@ use aether_actor::trace_ring::{DEFAULT_TRACE_RING_CAP, DEFAULT_TRACE_RING_MAX_CA
 use confique::meta::{Expr, Field, FieldKind, LeafKind, Meta};
 
 use crate::BootError;
+
+/// Split a comma-separated env value into a `HashSet`, trimming each
+/// element and dropping empties. The `#[derive(Config)]` macro wires
+/// this as the `parse_env` for any field carrying the `csv_set` hint
+/// (the allowlist / bootstrap-path knobs), so a cap declares `csv_set`
+/// and never hand-rolls the split. Total — a missing/empty value yields
+/// the empty set, which confique then overrides with the field default
+/// when the var is unset.
+///
+/// Unlike confique's own `env::parse::list_by_sep`, this trims each
+/// element and drops empties, so `"a, ,b,"` is `{"a", "b"}` rather than
+/// `{"a", " ", "b", ""}`.
+///
+/// # Errors
+///
+/// Never errors (the return type is [`Infallible`]); the `Result` is the
+/// shape confique's `parse_env` contract requires.
+pub fn parse_csv_set(s: &str) -> Result<HashSet<String>, Infallible> {
+    Ok(s.split(',')
+        .map(str::trim)
+        .filter(|element| !element.is_empty())
+        .map(str::to_string)
+        .collect())
+}
 
 /// The two per-actor ring capacities resolved once at chassis boot and
 /// threaded down the spawn path (ADR-0081 log ring + ADR-0086 trace
@@ -570,6 +605,18 @@ mod tests {
 
     fn parse_count(raw: &str) -> Result<u32, ParseIntError> {
         raw.trim().parse()
+    }
+
+    #[test]
+    fn parse_csv_set_trims_and_drops_empties() {
+        let got = parse_csv_set("a.com, b.com ,, c.com").expect("infallible");
+        let want: HashSet<String> = ["a.com", "b.com", "c.com"]
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+        assert_eq!(got, want);
+        assert!(parse_csv_set("").expect("infallible").is_empty());
+        assert!(parse_csv_set("  ,  , ").expect("infallible").is_empty());
     }
 
     /// A real `ParseIntError` for the `ConfigError` constructor tests


### PR DESCRIPTION
## What

Every capability hand-rolled a near-identical `parse_env` function whose only job was to reimplement what confique already does. Reading confique 0.4's source (`internal.rs`, `env/mod.rs`) plus a couple of probe tests confirmed that its native env deserialization, for a numeric or `Duration` field, already:

- trims the value (`self.value.trim()`),
- treats a set-but-empty value as unset, falling back to the field `default`,
- and hard-errors on a non-empty garbage value (surfaced from `.load()`, ADR-0090 §4).

Its bool deserialization accepts `1` / `true` / `yes` / `0` / `false` / `no` (case-insensitive, trimmed) and errors on garbage — a strict superset of the old `parse_flag`. So a numeric / `Duration` / `bool` field needs no parser at all.

This drops `parse =` from every such field and deletes the functions: `parse_flag`, `parse_millis_strict`, `parse_provider_max_in_flight_strict` (config_env), the http client/server parsers, the engine/hub parsers, and chassis_common's `parse_ring_capacity` / `parse_cap_secs`. The default is now written once, as the field default; the const-generic turbofish hack is gone. The Layer field stays its concrete type, so the `--config` discovery dump still reads the default off the confique `Meta`.

## Derive additions for the residue

- `csv_set` now auto-wires `aether_substrate::config::parse_csv_set` (trim + split + drop-empties into a `HashSet`) on the env side, so the allowlist / bootstrap fields declare the hint and name no function.
- New `nonzero` hint: a resolved `0` coerces to the field default in `from_layer`, for a knob where `0` is degenerate (the provider max-in-flight bound, which would deadlock at zero concurrency). Requires a `default`.
- A `String` field with a `default` gets empty to default in `from_layer`, since confique resolves a set-but-empty string to the empty string rather than unset (empty is a valid string). This keeps the http-server bind address falling back to loopback on a blank override.

`parse =` survives as the escape hatch for the one genuinely-custom parser, `fs`'s `parse_dir` (empty to Err plus runtime `dirs::data_dir()` defaults under `skip_from_layer`).

## Behavior change

The http-server and engine/hub knobs parsed softly before — a garbage value warned and fell back to the default. They are now strict like every other knob, so a malformed known value aborts boot per ADR-0090 §4. This was a deliberate choice to unify on the §4 end state rather than carry a `soft` hint.

## Tests

- New `parse_csv_set` unit test in `aether-substrate::config`.
- New derive UI fixtures: `accepts_auto_wired` (parser-free numeric / bool / nonzero / String-with-default) and `rejects_nonzero_without_default`.
- The per-cap defaults-match tests and the central confique strict-error test cover the resolution path; full preflight (fmt, clippy, doc, nextest, wasm32 cross-build, qodana) is green.

Closes #2218
