### PR TITLE
docs(guide): sync config-knob recipe and configuration explainer to the parser-free derive

### DIFF
--- a/docs/guide/recipes/adding-a-config-knob.md
+++ b/docs/guide/recipes/adding-a-config-knob.md
@@ -8,8 +8,8 @@
 > "discovery dump" aren't already familiar.
 
 A knob is a field on a subsystem's resolved-config struct, declared once with a
-`#[config(...)]` hint that supplies its default, its parser, and its env/CLI
-names. That single declaration generates the env layer, the `clap` argument
+`#[config(...)]` hint that supplies its default and its env/CLI names. That
+single declaration generates the env layer, the `clap` argument
 overlay, the layered resolver, and the `--config` discovery entry — so you never
 write an `env::var(...).parse()` read. This recipe adds a knob end to end, with
 the two gotchas (the `native` feature gate, the `*_defaults_match` test) inline at
@@ -17,10 +17,10 @@ the step where each bites.
 
 ## The exemplar to copy
 
-Follow [`HttpConfig`](https://github.com/iamacoffeepot/aether/blob/main/crates/aether-capabilities/src/http.rs)
-in `crates/aether-capabilities/src/http.rs`. It's the same struct the
-[Configuration](../systems/configuration.md) explainer excerpts, it carries every
-hint you'll reach for (`default`, `parse`, `env`, `cli_long`, `csv_set`,
+Follow [`HttpConfig`](https://github.com/iamacoffeepot/aether/blob/main/crates/aether-capabilities/src/http/client.rs)
+in `crates/aether-capabilities/src/http/client.rs`. It's the same struct the
+[Configuration](../systems/configuration.md) explainer excerpts, it carries most
+of the hints you'll reach for (`default`, `env`, `cli_long`, `csv_set`,
 `ms_duration`, `layer_field`), and it's wired into both full-stack chassis. Open
 it alongside this recipe and mirror the field you're closest to.
 
@@ -35,10 +35,10 @@ A capability that ships off (or on) by default exposes that switch as one
 config-API `bool`, resolved through the same derive as every other knob —
 not inferred from another field (a bound address, a configured path) and
 not read out of `env::var` directly. Declare it with a `false` literal
-default and the shared `parse_flag` parser:
+default; a `bool` needs no parser:
 
 ```rust
-#[cfg_attr(feature = "native", config(default = false, parse = parse_flag))]
+#[cfg_attr(feature = "native", config(default = false))]
 pub enabled: bool,
 ```
 
@@ -49,9 +49,9 @@ unsurprising state, and a chassis turns the behaviour on from one
 documented `AETHER_…` key (or its CLI flag). At the composition site the
 chassis maps the resolved flag to its structural choice —
 `cfg.enabled.then_some(cfg)` for an opt-in cap — keeping the flag the
-single source of the on/off decision. `parse_flag` (in
-`aether-capabilities/src/config_env.rs`) accepts `1` / `true` / `yes` /
-`on`.
+single source of the on/off decision. confique's native bool parsing
+accepts `1` / `true` / `yes` / `0` / `false` / `no`, case-insensitive and
+trimmed.
 
 ## Steps
 
@@ -61,25 +61,38 @@ Add the field to the struct in its cap crate and annotate it. The derive reads
 the hint to generate everything downstream:
 
 ```rust
-#[cfg_attr(feature = "native", config(default = false, parse = parse_flag))]
+#[cfg_attr(feature = "native", config(default = false))]
 pub require_https: bool,
 ```
+
+Most fields need no parser. A numeric, `Duration`, or `bool` field rides
+confique's native env parsing: it trims the value, treats an empty one as unset
+(falling back to the default), and hard-errors on a non-empty value that doesn't
+parse — so a typo'd `AETHER_…` number stops the boot with the key named instead
+of silently defaulting.
 
 The hints you have:
 
 - `default = <lit>` — the literal default the layer resolves to when no env or
   argv value is set.
-- `parse = <fn_path>` — a `fn(&str) -> Result<T, impl Error>` that turns the
-  string value into the field type. `parse_flag` (a bool flag), `parse_allowlist`
-  (a CSV set) and the strict numeric parsers in `http.rs` are worked examples.
 - `env = "..."` / `cli_long = "..."` — pin the env key and `--flag` to an exact
   name when the field name doesn't match the historical wire shape. Absent these,
   the names come from the container's `env_prefix` / `cli_prefix` joined to the
   field name.
-- `csv_set` — the overlay accepts one `Option<String>` and splits it on commas.
+- `csv_set` — for a `HashSet<String>` field: the overlay accepts one
+  `Option<String>`, and the env side auto-wires `parse_csv_set` (trim, split on
+  commas, drop empties).
+- `nonzero` — a resolved `0` coerces to the field default, for a knob where `0`
+  is degenerate (a concurrency bound that would deadlock at zero). Requires a
+  `default`.
 - `ms_duration` + `layer_field = "..."` — the domain field is a `Duration` while
   the layer carries `<field>_ms: u32`; the derive bridges via
   `Duration::from_millis`.
+- `parse = <fn_path>` — the escape hatch for a genuinely custom mapping, a
+  `fn(&str) -> Result<T, impl Error>`. `fs`'s `parse_dir` (an empty override is
+  unset; the default is computed at runtime from `dirs::data_dir()`) is the
+  worked example. A plain numeric / `bool` / `Duration` / `String` field never
+  needs it.
 
 The container attribute on the struct sets the prefixes both names derive from:
 
@@ -95,8 +108,8 @@ The container attribute on the struct sets the prefixes both names derive from:
 `HttpConfig` declares `impl Default` separately from the derive's `default = ...`
 literals (the derive feeds the layer; `Default` feeds direct construction in
 tests and call sites). Add your field's default to **both**. The
-`http_from_env_defaults_match` test in the `http.rs` test module is what keeps
-them honest:
+`http_from_env_defaults_match` test in the `http/client.rs` test module is what
+keeps them honest:
 
 ```rust
 #[test]

--- a/docs/guide/systems/configuration.md
+++ b/docs/guide/systems/configuration.md
@@ -119,17 +119,22 @@ a fresh `env::var` read. Derive `Config` on the struct and annotate the field:
 #[cfg_attr(feature = "native", derive(aether_substrate::Config))]
 #[cfg_attr(feature = "native", config(env_prefix = "AETHER_HTTP", cli_prefix = "http"))]
 pub struct HttpConfig {
-    #[cfg_attr(feature = "native", config(default = false, parse = parse_flag))]
+    #[cfg_attr(feature = "native", config(default = false))]
     pub disabled: bool,
-    #[cfg_attr(feature = "native", config(default = [], parse = parse_allowlist, csv_set))]
+    #[cfg_attr(feature = "native", config(default = [], csv_set))]
     pub allowlist: HashSet<String>,
 }
 ```
 
 The derive emits the environment-shaped layer, the `clap` argument overlay, and
-the `from_env` / `from_argv_then_env` resolvers; the field hints (`default`,
-`parse`, `env`, `cli_long`, `ms_duration`, `csv_set`) carry the per-knob shape.
-Two things to know going in:
+the `from_env` / `from_argv_then_env` resolvers. A numeric, `Duration`, or `bool`
+field carries only its `default` — confique's native parsing trims the value,
+treats an empty one as unset (falling back to the default), accepts the usual
+bool spellings (`1` / `true` / `yes` / `0` / `false` / `no`), and hard-errors on
+a non-empty garbage value. The remaining field hints (`env`, `cli_long`,
+`ms_duration`, `csv_set`, `nonzero`) carry the rest of the per-knob shape;
+`parse` names a custom parser for the rare field that needs one. Two things to
+know going in:
 
 - **Gate it on the `native` feature**, as above. The capabilities crate also
   cross-compiles to wasm, where the config machinery isn't available; the


### PR DESCRIPTION
Follow-up to #2220 (which deleted the hand-rolled config parsers). The two guide pages still taught the removed pattern.

## Changes

`docs/guide/recipes/adding-a-config-knob.md`:
- Drops the `config(default = false, parse = parse_flag)` examples — a `bool` needs no parser now.
- Rewrites the field-hints list: a numeric / `Duration` / `bool` field rides confique's native parsing (trim, empty-as-unset, strict-on-garbage, the `1/true/yes/0/false/no` bool spellings), `csv_set` auto-wires `parse_csv_set` on the env side, the new `nonzero` hint is documented, and `parse =` is reframed as the escape hatch whose worked example is `fs`'s `parse_dir`.
- Fixes the stale exemplar path: `crates/aether-capabilities/src/http.rs` is now `http/client.rs` (and the test-module reference with it).

`docs/guide/systems/configuration.md`:
- Drops `parse = parse_flag` / `parse = parse_allowlist` from the "Adding a knob" example and updates the hint list (adds `nonzero`, notes the native-parse behavior).

Verified the mdbook builds clean. Docs-only.
