### PR TITLE
refactor(capabilities): move impl-file-buried capability configs into config.rs

### DIFF
--- a/crates/aether-capabilities/src/fs/config.rs
+++ b/crates/aether-capabilities/src/fs/config.rs
@@ -1,0 +1,180 @@
+//! Resolved filesystem-root configuration (ADR-0090). The
+//! `#[derive(Config)]` layer the chassis builds from argv/env and
+//! hands to `with_actor::<FsCapability>(roots)` (`registry`).
+
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+
+#[cfg(feature = "native")]
+use std::error::Error;
+#[cfg(feature = "native")]
+use std::fmt;
+
+/// Resolved filesystem roots for the three ADR-0041 namespaces. The
+/// chassis reads this at boot, hands each path to a `LocalFileAdapter`,
+/// and registers the result in an `AdapterRegistry` keyed on the
+/// namespace short name (`"save"`, `"assets"`, `"config"`).
+///
+/// ADR-0090 unit g (iamacoffeepot/aether#1264) escape hatch: the
+/// `#[derive(aether_substrate::Config)]` emits the Layer +
+/// `NamespaceRootsOverlay` + inherent `from_env` / `from_argv_then_env`
+/// shims, but `#[config(skip_from_layer)]` opts the cap out of the
+/// auto-generated `FromArgvThenEnv::from_layer`. The hand-written impl
+/// (below) applies the runtime-computed `dirs::data_dir()` /
+/// `current_exe()` / `dirs::config_dir()` fallbacks that confique
+/// cannot express as literals. Per-field `env = "..."` overrides pin
+/// the unprefixed `AETHER_*_DIR` env keys.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "native", derive(aether_substrate::Config))]
+#[cfg_attr(
+    feature = "native",
+    config(env_prefix = "AETHER", cli_prefix = "", skip_from_layer)
+)]
+pub struct NamespaceRoots {
+    #[cfg_attr(
+        feature = "native",
+        config(env = "AETHER_SAVE_DIR", cli_long = "save-dir", parse = parse_dir)
+    )]
+    pub save: PathBuf,
+    #[cfg_attr(
+        feature = "native",
+        config(env = "AETHER_ASSETS_DIR", cli_long = "assets-dir", parse = parse_dir)
+    )]
+    pub assets: PathBuf,
+    #[cfg_attr(
+        feature = "native",
+        config(env = "AETHER_CONFIG_DIR", cli_long = "config-dir", parse = parse_dir)
+    )]
+    pub config: PathBuf,
+}
+
+impl NamespaceRoots {
+    /// Pre-validate the configured roots: create each directory if
+    /// missing, then canonicalize. Mirrors what `LocalFileAdapter::new`
+    /// does inside `FsCapability::init`, but exposed so embedders
+    /// can validate before building the chassis. Used by chassis
+    /// builders that want to surface root-validity as a "skip the
+    /// `aether.fs` cap and continue" decision rather than letting
+    /// init failure abort the whole boot.
+    pub fn ensure_dirs(&self) -> io::Result<()> {
+        fs::create_dir_all(&self.save)?;
+        fs::create_dir_all(&self.assets)?;
+        fs::create_dir_all(&self.config)?;
+        self.save.canonicalize()?;
+        self.assets.canonicalize()?;
+        self.config.canonicalize()?;
+        Ok(())
+    }
+}
+
+/// Hand-written `FromArgvThenEnv` impl for the `NamespaceRoots`
+/// escape hatch (ADR-0090 unit g, iamacoffeepot/aether#1264). The
+/// derive's `skip_from_layer` opt-out delegates `from_layer` here
+/// because the defaults are *runtime-computed*
+/// (`dirs::data_dir()` / `current_exe()` / `dirs::config_dir()`),
+/// not literals confique can hold. Behaviour is byte-identical to
+/// the prior `env_or_default` reader — an unset / empty
+/// `AETHER_*_DIR` lands as `None` (the macro auto-promotes the
+/// `PathBuf` domain to `Option<PathBuf>` on the Layer side when no
+/// literal default is supplied), then the platform fallback
+/// resolves it here.
+///
+/// On a platform-directory lookup failure (e.g. no `HOME`) or
+/// `current_exe()` resolution failure, the fallback is
+/// `temp_dir()/aether/...` so a boot always finishes even on
+/// headless CI.
+#[cfg(feature = "native")]
+impl aether_substrate::FromArgvThenEnv for NamespaceRoots {
+    type Layer = NamespaceRootsLayer;
+
+    fn from_layer(layer: NamespaceRootsLayer) -> Self {
+        use std::env;
+        use std::path::Path;
+        Self {
+            save: layer.save.unwrap_or_else(|| {
+                dirs::data_dir()
+                    .unwrap_or_else(env::temp_dir)
+                    .join("aether")
+                    .join("save")
+            }),
+            assets: layer.assets.unwrap_or_else(|| {
+                env::current_exe()
+                    .ok()
+                    .and_then(|p| p.parent().map(Path::to_path_buf))
+                    .map_or_else(
+                        || env::temp_dir().join("aether").join("assets"),
+                        |p| p.join("assets"),
+                    )
+            }),
+            config: layer.config.unwrap_or_else(|| {
+                dirs::config_dir()
+                    .unwrap_or_else(env::temp_dir)
+                    .join("aether")
+            }),
+        }
+    }
+}
+
+/// Parse a directory override. An empty string errors so confique
+/// treats it as unset (preserving the prior `env_or_default`'s
+/// `Ok(s) if !s.is_empty()` guard); any non-empty value is a path.
+#[cfg(feature = "native")]
+pub(super) fn parse_dir(s: &str) -> Result<PathBuf, EmptyDir> {
+    if s.is_empty() {
+        Err(EmptyDir)
+    } else {
+        Ok(PathBuf::from(s))
+    }
+}
+
+/// Sentinel error: an empty `AETHER_*_DIR` value, treated as unset by
+/// confique's parse path (`Err` + empty → `None`).
+#[cfg(feature = "native")]
+#[derive(Debug)]
+pub(super) struct EmptyDir;
+
+#[cfg(feature = "native")]
+impl fmt::Display for EmptyDir {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("empty directory override")
+    }
+}
+
+#[cfg(feature = "native")]
+impl Error for EmptyDir {}
+
+// ADR-0090: the confique migration is byte-identical to the prior
+// `env_or_default` reader. These exercise resolution without touching
+// process env (issue 464) — the parser is pure, and the defaults check
+// loads the layer with no `.env()` source. Native-only because the
+// `Config` derive (and `parse_dir` / the Layer) only exist under the
+// `native` feature.
+#[cfg(all(test, feature = "native"))]
+mod tests {
+    use super::{NamespaceRootsLayer, parse_dir};
+    use std::path::PathBuf;
+
+    #[test]
+    fn parse_dir_treats_empty_as_unset() {
+        assert!(parse_dir("").is_err(), "empty → unset (Err → None)");
+        assert_eq!(
+            parse_dir("/tmp/aether-save").expect("non-empty parses to a path"),
+            PathBuf::from("/tmp/aether-save")
+        );
+    }
+
+    #[test]
+    fn namespace_roots_layer_defaults_are_none() {
+        use confique::Config as _;
+        // No `.env()` source: each root has no literal default, so it
+        // resolves to `None` and `from_env` applies the runtime
+        // platform fallback. Env-free.
+        let layer = NamespaceRootsLayer::builder()
+            .load()
+            .expect("defaults load");
+        assert_eq!(layer.save, None);
+        assert_eq!(layer.assets, None);
+        assert_eq!(layer.config, None);
+    }
+}

--- a/crates/aether-capabilities/src/fs/mod.rs
+++ b/crates/aether-capabilities/src/fs/mod.rs
@@ -16,19 +16,21 @@
 pub mod kinds;
 
 mod adapter;
+mod config;
 mod registry;
 
 pub use kinds::*;
 
 pub use adapter::{FileAdapter, FsResult, LocalFileAdapter};
-pub use registry::{AdapterRegistry, NamespaceRoots, build_registry};
+pub use config::NamespaceRoots;
 // The `Config` derive on `NamespaceRoots` emits these sibling types in
-// `registry`; chassis CLI / boot wiring addresses them through the
+// `config`; chassis CLI / boot wiring addresses them through the
 // `fs::` path, so re-export them here (native-only — the derive is
 // feature-gated). Inherent shims (`from_env` / `from_argv_then_env` /
 // `into_layer`) ride the type and need no re-export.
 #[cfg(feature = "native")]
-pub use registry::{NamespaceRootsLayer, NamespaceRootsOverlay};
+pub use config::{NamespaceRootsLayer, NamespaceRootsOverlay};
+pub use registry::{AdapterRegistry, build_registry};
 
 // Handler-signature kinds resolve at file root through the `pub use
 // kinds::*` re-export above (the `#[bridge]` emits `impl HandlesKind<K>

--- a/crates/aether-capabilities/src/fs/registry.rs
+++ b/crates/aether-capabilities/src/fs/registry.rs
@@ -6,16 +6,11 @@
 //! wires the three ADR-0041 namespaces into a populated registry.
 
 use std::collections::HashMap;
-#[cfg(feature = "native")]
-use std::error::Error;
-#[cfg(feature = "native")]
-use std::fmt;
-use std::fs;
 use std::io;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use super::adapter::{FileAdapter, LocalFileAdapter};
+use super::config::NamespaceRoots;
 
 /// Namespace → adapter table built at chassis boot. The cap reads
 /// `namespace` off an incoming `Read`/`Write`/etc. mail, looks up
@@ -54,63 +49,6 @@ impl Default for AdapterRegistry {
     }
 }
 
-/// Resolved filesystem roots for the three ADR-0041 namespaces. The
-/// chassis reads this at boot, hands each path to a `LocalFileAdapter`,
-/// and registers the result in an `AdapterRegistry` keyed on the
-/// namespace short name (`"save"`, `"assets"`, `"config"`).
-///
-/// ADR-0090 unit g (iamacoffeepot/aether#1264) escape hatch: the
-/// `#[derive(aether_substrate::Config)]` emits the Layer +
-/// `NamespaceRootsOverlay` + inherent `from_env` / `from_argv_then_env`
-/// shims, but `#[config(skip_from_layer)]` opts the cap out of the
-/// auto-generated `FromArgvThenEnv::from_layer`. The hand-written impl
-/// (below) applies the runtime-computed `dirs::data_dir()` /
-/// `current_exe()` / `dirs::config_dir()` fallbacks that confique
-/// cannot express as literals. Per-field `env = "..."` overrides pin
-/// the unprefixed `AETHER_*_DIR` env keys.
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "native", derive(aether_substrate::Config))]
-#[cfg_attr(
-    feature = "native",
-    config(env_prefix = "AETHER", cli_prefix = "", skip_from_layer)
-)]
-pub struct NamespaceRoots {
-    #[cfg_attr(
-        feature = "native",
-        config(env = "AETHER_SAVE_DIR", cli_long = "save-dir", parse = parse_dir)
-    )]
-    pub save: PathBuf,
-    #[cfg_attr(
-        feature = "native",
-        config(env = "AETHER_ASSETS_DIR", cli_long = "assets-dir", parse = parse_dir)
-    )]
-    pub assets: PathBuf,
-    #[cfg_attr(
-        feature = "native",
-        config(env = "AETHER_CONFIG_DIR", cli_long = "config-dir", parse = parse_dir)
-    )]
-    pub config: PathBuf,
-}
-
-impl NamespaceRoots {
-    /// Pre-validate the configured roots: create each directory if
-    /// missing, then canonicalize. Mirrors what `LocalFileAdapter::new`
-    /// does inside `FsCapability::init`, but exposed so embedders
-    /// can validate before building the chassis. Used by chassis
-    /// builders that want to surface root-validity as a "skip the
-    /// `aether.fs` cap and continue" decision rather than letting
-    /// init failure abort the whole boot.
-    pub fn ensure_dirs(&self) -> io::Result<()> {
-        fs::create_dir_all(&self.save)?;
-        fs::create_dir_all(&self.assets)?;
-        fs::create_dir_all(&self.config)?;
-        self.save.canonicalize()?;
-        self.assets.canonicalize()?;
-        self.config.canonicalize()?;
-        Ok(())
-    }
-}
-
 /// Populate a fresh `AdapterRegistry` with `LocalFileAdapter`s for
 /// each of the three ADR-0041 namespaces using the supplied
 /// [`NamespaceRoots`]. `save` and `config` are writable; `assets` is
@@ -126,115 +64,4 @@ pub fn build_registry(roots: NamespaceRoots) -> io::Result<(Arc<AdapterRegistry>
     registry.register("assets", assets as Arc<dyn FileAdapter>);
     registry.register("config", config as Arc<dyn FileAdapter>);
     Ok((Arc::new(registry), roots))
-}
-
-/// Hand-written `FromArgvThenEnv` impl for the `NamespaceRoots`
-/// escape hatch (ADR-0090 unit g, iamacoffeepot/aether#1264). The
-/// derive's `skip_from_layer` opt-out delegates `from_layer` here
-/// because the defaults are *runtime-computed*
-/// (`dirs::data_dir()` / `current_exe()` / `dirs::config_dir()`),
-/// not literals confique can hold. Behaviour is byte-identical to
-/// the prior `env_or_default` reader — an unset / empty
-/// `AETHER_*_DIR` lands as `None` (the macro auto-promotes the
-/// `PathBuf` domain to `Option<PathBuf>` on the Layer side when no
-/// literal default is supplied), then the platform fallback
-/// resolves it here.
-///
-/// On a platform-directory lookup failure (e.g. no `HOME`) or
-/// `current_exe()` resolution failure, the fallback is
-/// `temp_dir()/aether/...` so a boot always finishes even on
-/// headless CI.
-#[cfg(feature = "native")]
-impl aether_substrate::FromArgvThenEnv for NamespaceRoots {
-    type Layer = NamespaceRootsLayer;
-
-    fn from_layer(layer: NamespaceRootsLayer) -> Self {
-        use std::env;
-        use std::path::Path;
-        Self {
-            save: layer.save.unwrap_or_else(|| {
-                dirs::data_dir()
-                    .unwrap_or_else(env::temp_dir)
-                    .join("aether")
-                    .join("save")
-            }),
-            assets: layer.assets.unwrap_or_else(|| {
-                env::current_exe()
-                    .ok()
-                    .and_then(|p| p.parent().map(Path::to_path_buf))
-                    .map_or_else(
-                        || env::temp_dir().join("aether").join("assets"),
-                        |p| p.join("assets"),
-                    )
-            }),
-            config: layer.config.unwrap_or_else(|| {
-                dirs::config_dir()
-                    .unwrap_or_else(env::temp_dir)
-                    .join("aether")
-            }),
-        }
-    }
-}
-
-/// Parse a directory override. An empty string errors so confique
-/// treats it as unset (preserving the prior `env_or_default`'s
-/// `Ok(s) if !s.is_empty()` guard); any non-empty value is a path.
-#[cfg(feature = "native")]
-pub(super) fn parse_dir(s: &str) -> Result<PathBuf, EmptyDir> {
-    if s.is_empty() {
-        Err(EmptyDir)
-    } else {
-        Ok(PathBuf::from(s))
-    }
-}
-
-/// Sentinel error: an empty `AETHER_*_DIR` value, treated as unset by
-/// confique's parse path (`Err` + empty → `None`).
-#[cfg(feature = "native")]
-#[derive(Debug)]
-pub(super) struct EmptyDir;
-
-#[cfg(feature = "native")]
-impl fmt::Display for EmptyDir {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("empty directory override")
-    }
-}
-
-#[cfg(feature = "native")]
-impl Error for EmptyDir {}
-
-// ADR-0090: the confique migration is byte-identical to the prior
-// `env_or_default` reader. These exercise resolution without touching
-// process env (issue 464) — the parser is pure, and the defaults check
-// loads the layer with no `.env()` source. Native-only because the
-// `Config` derive (and `parse_dir` / the Layer) only exist under the
-// `native` feature.
-#[cfg(all(test, feature = "native"))]
-mod tests {
-    use super::{NamespaceRootsLayer, parse_dir};
-    use std::path::PathBuf;
-
-    #[test]
-    fn parse_dir_treats_empty_as_unset() {
-        assert!(parse_dir("").is_err(), "empty → unset (Err → None)");
-        assert_eq!(
-            parse_dir("/tmp/aether-save").expect("non-empty parses to a path"),
-            PathBuf::from("/tmp/aether-save")
-        );
-    }
-
-    #[test]
-    fn namespace_roots_layer_defaults_are_none() {
-        use confique::Config as _;
-        // No `.env()` source: each root has no literal default, so it
-        // resolves to `None` and `from_env` applies the runtime
-        // platform fallback. Env-free.
-        let layer = NamespaceRootsLayer::builder()
-            .load()
-            .expect("defaults load");
-        assert_eq!(layer.save, None);
-        assert_eq!(layer.assets, None);
-        assert_eq!(layer.config, None);
-    }
 }

--- a/crates/aether-capabilities/src/input/config.rs
+++ b/crates/aether-capabilities/src/input/config.rs
@@ -1,0 +1,11 @@
+//! Init config for the input subscription cap (ADR-0090).
+
+/// Configuration for [`InputCapability`](super::InputCapability). Empty
+/// today — the cap builds its subscriber table from scratch and reaches
+/// for `Mailer` / `Registry` through `NativeInitCtx`. Kept as a struct
+/// so the chassis composes the cap with the same
+/// `Builder::with_actor::<InputCapability>(InputConfig {})` shape
+/// as every other cap and a future config knob (e.g. ring caps,
+/// per-stream gates) lands without API churn.
+#[derive(Default)]
+pub struct InputConfig {}

--- a/crates/aether-capabilities/src/input/mod.rs
+++ b/crates/aether-capabilities/src/input/mod.rs
@@ -27,6 +27,8 @@
 // decoded bytes so callers can't see references.
 #![allow(clippy::needless_pass_by_value)]
 
+#[cfg(not(target_arch = "wasm32"))]
+mod config;
 pub mod kinds;
 pub mod subscription;
 
@@ -34,7 +36,7 @@ pub use kinds::*;
 pub use subscription::InputCapability;
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use subscription::InputConfig;
+pub use config::InputConfig;
 
 use aether_actor::WasmActorMailbox;
 use aether_data::{Kind, MailboxId};

--- a/crates/aether-capabilities/src/input/subscription.rs
+++ b/crates/aether-capabilities/src/input/subscription.rs
@@ -1,8 +1,5 @@
 //! Native subscriber-table cap for `aether.input`.
 
-#[cfg(not(target_arch = "wasm32"))]
-pub use native::InputConfig;
-
 use aether_kinds::{Key, KeyRelease, MouseButton, MouseMove, WindowSize};
 
 use super::kinds::{
@@ -25,15 +22,7 @@ mod native {
     use std::collections::{BTreeSet, HashMap};
     use std::sync::Arc;
 
-    /// Configuration for [`InputCapability`]. Empty today — the cap
-    /// builds its subscriber table from scratch and reaches for
-    /// `Mailer` / `Registry` through `NativeInitCtx`. Kept as a struct
-    /// so the chassis composes the cap with the same
-    /// `Builder::with_actor::<InputCapability>(InputConfig {})` shape
-    /// as every other cap and a future config knob (e.g. ring caps,
-    /// per-stream gates) lands without API churn.
-    #[derive(Default)]
-    pub struct InputConfig {}
+    use crate::input::config::InputConfig;
 
     /// `aether.input` cap. The single owner of the input-stream
     /// subscriber table. Handles three classes of mail:

--- a/crates/aether-capabilities/src/tcp/config.rs
+++ b/crates/aether-capabilities/src/tcp/config.rs
@@ -1,0 +1,26 @@
+//! Init configs for the TCP listener and session actors (ADR-0090).
+//! Both carry `std::net` types and are native-only.
+
+use std::net::{TcpListener, TcpStream};
+
+/// Init config for [`TcpListenerActor`](super::TcpListenerActor).
+/// `TcpCapability::on_bind` binds the socket on the dispatcher thread
+/// (so addr-parse / port-in-use failures surface synchronously) and
+/// hands the bound listener through `spawn_child`. The `listener`
+/// field is `Option` so init can move it out into the accept thread.
+pub struct TcpListenerConfig {
+    pub listener: Option<TcpListener>,
+    pub addr: String,
+    pub port: u16,
+}
+
+/// Init config for [`TcpSessionActor`](super::TcpSessionActor). The
+/// listener's `on_connection_ready` builds this per accepted stream
+/// and hands it through `spawn_child`. `stream` is `Option` so init
+/// can `.take()` and split it; `peer` and `session_name` are retained
+/// for log attribution.
+pub struct TcpSessionConfig {
+    pub stream: Option<TcpStream>,
+    pub peer: String,
+    pub session_name: String,
+}

--- a/crates/aether-capabilities/src/tcp/listener.rs
+++ b/crates/aether-capabilities/src/tcp/listener.rs
@@ -17,12 +17,6 @@
 // of the mod (always-on, outside the cfg gate).
 use super::kinds::{Close, ConnectionReady};
 
-// `TcpListenerConfig` carries `std::net::TcpListener` (native-only) so
-// it lives inside the bridge mod. Re-export at file root for the cap
-// module to consume.
-#[cfg(not(target_arch = "wasm32"))]
-pub use listener_native::TcpListenerConfig;
-
 #[aether_actor::bridge(instanced, one_per = "listener")]
 mod listener_native {
     use super::{Close, ConnectionReady};
@@ -31,26 +25,16 @@ mod listener_native {
     use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
     use aether_substrate::chassis::error::BootError;
     use aether_substrate::{KindId, Mail, Mailer};
-    use std::net::{SocketAddr, TcpListener, TcpStream};
+    use std::net::{SocketAddr, TcpStream};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::mpsc;
     use std::thread::JoinHandle;
     use std::time::Duration;
 
-    use crate::tcp::session::{TcpSessionActor, TcpSessionConfig};
+    use crate::tcp::config::{TcpListenerConfig, TcpSessionConfig};
+    use crate::tcp::session::TcpSessionActor;
     use std::thread;
-
-    /// Init config for [`TcpListenerActor`]. `TcpCapability::on_bind`
-    /// binds the socket on the dispatcher thread (so addr-parse / port-
-    /// in-use failures surface synchronously) and hands the bound
-    /// listener through `spawn_child`. The `listener` field is
-    /// `Option` so init can move it out into the accept thread.
-    pub struct TcpListenerConfig {
-        pub listener: Option<TcpListener>,
-        pub addr: String,
-        pub port: u16,
-    }
 
     /// Issue 607 Phase 6b: the accept thread can't call
     /// `ctx.spawn_child` (no dispatcher ctx), so it pushes accepted

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -38,6 +38,8 @@
 //! to its bound port to wake the blocked accept; the accept returns,
 //! sees the flag, breaks; the dispatcher thread joins.
 
+#[cfg(not(target_arch = "wasm32"))]
+mod config;
 pub mod kinds;
 mod listener;
 mod session;
@@ -46,15 +48,12 @@ pub use kinds::*;
 pub use listener::TcpListenerActor;
 pub use session::TcpSessionActor;
 // `TcpListenerConfig` and `TcpSessionConfig` carry `std::net`
-// types (native-only) so they live inside the native bridge mod
-// and only re-export under `not(target_arch = "wasm32")`. The
-// actor markers themselves (above) are always-on so wasm callers
-// can name them in [`TcpWasmExt::listener`] / [`TcpWasmExt::session`]
-// type parameters.
+// types (native-only) so they live in `config` and only re-export
+// under `not(target_arch = "wasm32")`. The actor markers themselves
+// (above) are always-on so wasm callers can name them in
+// [`TcpWasmExt::listener`] / [`TcpWasmExt::session`] type parameters.
 #[cfg(not(target_arch = "wasm32"))]
-pub use listener::TcpListenerConfig;
-#[cfg(not(target_arch = "wasm32"))]
-pub use session::TcpSessionConfig;
+pub use config::{TcpListenerConfig, TcpSessionConfig};
 
 use aether_actor::{Addressable, WasmActorMailbox};
 use aether_data::{ActorId, Tag, fold_lineage, with_tag};

--- a/crates/aether-capabilities/src/tcp/session.rs
+++ b/crates/aether-capabilities/src/tcp/session.rs
@@ -34,11 +34,6 @@
 // the `#[bridge]`-emitted `HandlesKind` markers.
 use super::kinds::{SessionClose, SessionDataReady, SessionWrite};
 
-// `TcpSessionActor` is auto-re-exported by `#[bridge]` at file
-// root; only `TcpSessionConfig` needs the manual re-export.
-#[cfg(not(target_arch = "wasm32"))]
-pub use session_native::TcpSessionConfig;
-
 #[aether_actor::bridge(instanced, one_per = "connection")]
 mod session_native {
     use super::{SessionClose, SessionDataReady, SessionWrite};
@@ -55,22 +50,13 @@ mod session_native {
     use std::thread;
     use std::thread::JoinHandle;
 
+    use crate::tcp::config::TcpSessionConfig;
+
     /// Default per-read buffer size. 64 KiB matches the typical
     /// kernel TCP buffer; any larger and we just block waiting for
     /// the kernel to fill it. Smaller adds syscall overhead per
     /// chunk.
     const READ_BUFFER_BYTES: usize = 64 * 1024;
-
-    /// Init config for [`TcpSessionActor`]. The listener's
-    /// `on_connection_ready` builds this per accepted stream and
-    /// hands it through `spawn_child`. `stream` is `Option` so init
-    /// can `.take()` and split it; `peer` and `session_name` are
-    /// retained for log attribution.
-    pub struct TcpSessionConfig {
-        pub stream: Option<TcpStream>,
-        pub peer: String,
-        pub session_name: String,
-    }
 
     /// One end of a split `TcpStream`. The read sidecar owns the
     /// read half; the dispatcher owns the write half (used by

--- a/crates/aether-capabilities/src/trampoline/config.rs
+++ b/crates/aether-capabilities/src/trampoline/config.rs
@@ -1,0 +1,46 @@
+//! Init config for the wasm trampoline actor (ADR-0090).
+
+use std::sync::Arc;
+
+use aether_kinds::ComponentCapabilities;
+use aether_substrate::actor::wasm::component::ComponentCtx;
+use aether_substrate::actor::wasm::kind_manifest::ActorInputs;
+use aether_substrate::mail::outbound::HubOutbound;
+use aether_substrate::mail::registry::Registry;
+use wasmtime::{Engine, Linker, Module};
+
+/// Configuration handed to [`Lifecycle::init`](aether_actor::Lifecycle::init) by the spawn
+/// path. Carries the wasmtime engine / linker plus the parsed
+/// module bytes; `init` instantiates the `Component` against the
+/// trampoline's binding.
+pub struct WasmTrampolineConfig {
+    pub engine: Arc<Engine>,
+    pub linker: Arc<Linker<ComponentCtx>>,
+    pub module: Module,
+    pub registry: Arc<Registry>,
+    pub outbound: Arc<HubOutbound>,
+    /// Component capabilities parsed from the wasm's
+    /// `aether.kinds.inputs` custom section, surfaced through
+    /// `LoadResult::Ok.capabilities` at the cap. The trampoline
+    /// keeps a handle so it can rehydrate after a replace.
+    pub capabilities: ComponentCapabilities,
+    /// ADR-0090 (issue 1257): init-config bytes from the
+    /// `aether.component.load` mail, handed to the guest's typed
+    /// `WasmActor::init` via `Component::instantiate`. Empty means
+    /// "no config" — a `Config = ()` guest decodes `&[]` uniformly.
+    pub config: Vec<u8>,
+    /// ADR-0096: the selected export's actor-type tag
+    /// (`mailbox_id_from_name(NAMESPACE)`), threaded through to
+    /// `Component::instantiate` so it calls `init_typed_p32`.
+    /// `None` instantiates the module's entry type via the legacy
+    /// `init_with_config_p32` path — the only type a single-actor
+    /// module has. Stored on the trampoline so a later
+    /// `ReplaceComponent` rebuilds the same export.
+    pub type_tag: Option<u64>,
+    /// ADR-0097: every exported type's capability group, parsed once
+    /// at load. The trampoline keeps it so a `spawn_child::<Sibling>`
+    /// host-fn request can register the spawned sibling's *own*
+    /// handler set (looked up by actor-type tag), and so each
+    /// spawned sibling carries the same map for its own spawns.
+    pub actor_caps: Vec<ActorInputs>,
+}

--- a/crates/aether-capabilities/src/trampoline/mod.rs
+++ b/crates/aether-capabilities/src/trampoline/mod.rs
@@ -69,6 +69,10 @@
 // markers (always-on, outside the cfg gate) resolve.
 use aether_kinds::{DropComponent, ReplaceComponent};
 
+// Init config — native-only (wasmtime types are not wasm32-safe).
+#[cfg(not(target_arch = "wasm32"))]
+mod config;
+
 // Struct definitions — native-only (wasmtime types are not wasm32-safe).
 // Declared at file root, outside the bridge, following the audio/decode
 // precedent for file-root submodules that assist the bridge block without
@@ -83,14 +87,15 @@ mod state;
 mod replace;
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use state::WasmTrampolineConfig;
+pub use config::WasmTrampolineConfig;
 
 #[aether_actor::bridge(instanced, one_per = "component")]
 mod native {
-    // Re-export the struct from the file-root `state` sibling so the
+    // Re-export the structs from the file-root siblings so the
     // bridge's always-on `pub use native::WasmTrampoline;` emission
     // resolves to the same type on non-wasm32.
-    pub use super::state::{WasmTrampoline, WasmTrampolineConfig};
+    pub use super::config::WasmTrampolineConfig;
+    pub use super::state::WasmTrampoline;
 
     use std::io;
     use std::sync::Arc;

--- a/crates/aether-capabilities/src/trampoline/replace.rs
+++ b/crates/aether-capabilities/src/trampoline/replace.rs
@@ -13,7 +13,8 @@ use aether_substrate::mail::capability::MailboxCaps;
 use aether_substrate::mail::{CostCells, KindId};
 use wasmtime::Module;
 
-use super::state::{WasmTrampoline, WasmTrampolineConfig};
+use super::config::WasmTrampolineConfig;
+use super::state::WasmTrampoline;
 
 impl WasmTrampoline {
     /// ADR-0097: perform the sibling spawn the guest staged via the

--- a/crates/aether-capabilities/src/trampoline/state.rs
+++ b/crates/aether-capabilities/src/trampoline/state.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use aether_kinds::ComponentCapabilities;
 use aether_substrate::actor::wasm::component::{Component, ComponentCtx};
 use aether_substrate::actor::wasm::kind_manifest::ActorInputs;
 use aether_substrate::mail::MailboxId;
@@ -8,42 +7,6 @@ use aether_substrate::mail::mailer::Mailer;
 use aether_substrate::mail::outbound::HubOutbound;
 use aether_substrate::mail::registry::Registry;
 use wasmtime::{Engine, Linker, Module};
-
-/// Configuration handed to [`Lifecycle::init`](aether_actor::Lifecycle::init) by the spawn
-/// path. Carries the wasmtime engine / linker plus the parsed
-/// module bytes; `init` instantiates the `Component` against the
-/// trampoline's binding.
-pub struct WasmTrampolineConfig {
-    pub engine: Arc<Engine>,
-    pub linker: Arc<Linker<ComponentCtx>>,
-    pub module: Module,
-    pub registry: Arc<Registry>,
-    pub outbound: Arc<HubOutbound>,
-    /// Component capabilities parsed from the wasm's
-    /// `aether.kinds.inputs` custom section, surfaced through
-    /// `LoadResult::Ok.capabilities` at the cap. The trampoline
-    /// keeps a handle so it can rehydrate after a replace.
-    pub capabilities: ComponentCapabilities,
-    /// ADR-0090 (issue 1257): init-config bytes from the
-    /// `aether.component.load` mail, handed to the guest's typed
-    /// `WasmActor::init` via `Component::instantiate`. Empty means
-    /// "no config" — a `Config = ()` guest decodes `&[]` uniformly.
-    pub config: Vec<u8>,
-    /// ADR-0096: the selected export's actor-type tag
-    /// (`mailbox_id_from_name(NAMESPACE)`), threaded through to
-    /// `Component::instantiate` so it calls `init_typed_p32`.
-    /// `None` instantiates the module's entry type via the legacy
-    /// `init_with_config_p32` path — the only type a single-actor
-    /// module has. Stored on the trampoline so a later
-    /// `ReplaceComponent` rebuilds the same export.
-    pub type_tag: Option<u64>,
-    /// ADR-0097: every exported type's capability group, parsed once
-    /// at load. The trampoline keeps it so a `spawn_child::<Sibling>`
-    /// host-fn request can register the spawned sibling's *own*
-    /// handler set (looked up by actor-type tag), and so each
-    /// spawned sibling carries the same map for its own spawns.
-    pub actor_caps: Vec<ActorInputs>,
-}
 
 /// Per-component trampoline. Holds the wasm `Component`
 /// optionally — `None` means the wasm has been unloaded by


### PR DESCRIPTION
Closes #2225.

## Summary

Capability config structs that shared an unrelated impl file now live in their cap module's dedicated `config.rs`, matching the established `audio/config.rs` / `gemini/config.rs` exemplar. Mechanical move, no behavior change:

- `fs/registry.rs` `NamespaceRoots` (and its coupled `parse_dir` / `EmptyDir` / `FromArgvThenEnv` cluster + tests) → `fs/config.rs`
- `tcp/listener.rs` `TcpListenerConfig` + `tcp/session.rs` `TcpSessionConfig` → `tcp/config.rs`
- `trampoline/state.rs` `WasmTrampolineConfig` → `trampoline/config.rs`
- `input/subscription.rs` `InputConfig` → `input/config.rs`

Each module's `mod.rs` gains `mod config;` (cfg-gating preserved per-cap: `fs` keeps per-item `feature = "native"` gates with an un-gated module; the others gate the whole `mod config;` on `not(target_arch = "wasm32")`), and the existing `pub use` re-exports (incl. derive-emitted `*Layer` / `*Overlay`) are re-pointed to `config::` so public paths are unchanged. Child of #2221.

## Test plan

No behavior change, so the bar is `scripts/preflight.sh` green end-to-end: fmt, clippy `-D warnings`, nextest (2036/2036), rustdoc, and the wasm32 cross-build that catches a mis-mirrored `native` gate. All green locally.

## Generated by

`/implement` — agent execution of scoped issue #2225.
