### PR TITLE
refactor(capabilities): split http client and server into submodule dirs with their own config.rs

### DIFF
--- a/crates/aether-capabilities/src/http/client/config.rs
+++ b/crates/aether-capabilities/src/http/client/config.rs
@@ -1,0 +1,82 @@
+//! Resolved HTTP egress configuration (ADR-0090). The `#[derive(Config)]`
+//! layer the chassis builds from argv/env and hands to
+//! `with_actor::<HttpCapability>(config)`.
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+use super::{DEFAULT_MAX_BODY_BYTES, DEFAULT_TIMEOUT_MILLIS};
+
+/// Resolved configuration for the substrate's HTTP adapter. Chassis
+/// mains read env vars (`AETHER_HTTP_DISABLE`, `AETHER_HTTP_ALLOWLIST`,
+/// `AETHER_HTTP_REQUIRE_HTTPS`, `AETHER_HTTP_MAX_BODY_BYTES`,
+/// `AETHER_HTTP_TIMEOUT_MS`) into a `HttpConfig` and pass it to
+/// `HttpCapability::new`. Tests build a `HttpConfig` directly,
+/// never touching process env (issue 464).
+///
+/// ADR-0090 unit g (iamacoffeepot/aether#1264): the
+/// `#[derive(aether_substrate::Config)]` emits the env-shaped
+/// `HttpConfigLayer`, the clap-shaped `HttpOverlay`, the
+/// `FromArgvThenEnv` impl, and the inherent `from_env` /
+/// `from_argv_then_env` shims under `feature = "native"`. The
+/// wasm-marker build carries only the domain struct.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "native", derive(aether_substrate::Config))]
+#[cfg_attr(
+    feature = "native",
+    config(env_prefix = "AETHER_HTTP", cli_prefix = "http")
+)]
+pub struct HttpConfig {
+    /// `AETHER_HTTP_DISABLE=1` swaps the `UreqHttpAdapter` for a
+    /// `DisabledHttpAdapter` that replies `HttpError::Disabled` to
+    /// every fetch. `env` + `cli_long` overrides pin the wire shape
+    /// (`AETHER_HTTP_DISABLE`, `--http-disable`) to the pre-derive
+    /// names while the domain field stays `disabled` for read-site
+    /// clarity.
+    #[cfg_attr(
+        feature = "native",
+        config(
+            env = "AETHER_HTTP_DISABLE",
+            cli_long = "http-disable",
+            default = false
+        )
+    )]
+    pub disabled: bool,
+    /// Hostnames the adapter will dial. Empty = deny all
+    /// (deny-by-default per ADR-0043). The `csv_set` hint auto-wires the
+    /// shared comma-split parser on the env side.
+    #[cfg_attr(feature = "native", config(default = [], csv_set))]
+    pub allowlist: HashSet<String>,
+    /// `AETHER_HTTP_REQUIRE_HTTPS=1` rejects `http://` URLs with
+    /// `HttpError::InvalidUrl`.
+    #[cfg_attr(feature = "native", config(default = false))]
+    pub require_https: bool,
+    /// Cap on inbound and outbound body bytes. Defaults to
+    /// [`DEFAULT_MAX_BODY_BYTES`] (16 MB).
+    #[cfg_attr(feature = "native", config(default = 16_777_216))]
+    pub max_body_bytes: usize,
+    /// Default per-request timeout when `Fetch.timeout_ms` is
+    /// `None`. Defaults to [`DEFAULT_TIMEOUT_MILLIS`] (30 s). The derive's
+    /// `ms_duration` hint stores the Layer field as `u32`-ms and
+    /// bridges via `Duration::from_millis(u64::from(...))`;
+    /// `layer_field = "timeout_ms"` pins the Layer / env / CLI shape to
+    /// the pre-derive name (`AETHER_HTTP_TIMEOUT_MS`,
+    /// `--http-timeout-ms`).
+    #[cfg_attr(
+        feature = "native",
+        config(default = 30_000, ms_duration, layer_field = "timeout_ms")
+    )]
+    pub default_timeout: Duration,
+}
+
+impl Default for HttpConfig {
+    fn default() -> Self {
+        Self {
+            disabled: false,
+            allowlist: HashSet::new(),
+            require_https: false,
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            default_timeout: Duration::from_millis(u64::from(DEFAULT_TIMEOUT_MILLIS)),
+        }
+    }
+}

--- a/crates/aether-capabilities/src/http/client/mod.rs
+++ b/crates/aether-capabilities/src/http/client/mod.rs
@@ -12,8 +12,16 @@
 //! - Default request timeout 30s, per-request override via
 //!   `Fetch.timeout_ms`.
 
-use std::collections::HashSet;
 use std::time::Duration;
+
+mod config;
+
+pub use config::HttpConfig;
+// The `Config` derive on `HttpConfig` emits these native-only sibling types
+// in `config`; chassis CLI / boot wiring addresses them through the
+// `client::` path, so re-export them here.
+#[cfg(feature = "native")]
+pub use config::{HttpConfigLayer, HttpOverlay};
 
 // Handler-signature kinds must be importable at file root because
 // `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
@@ -68,80 +76,6 @@ pub struct DisabledHttpAdapter;
 impl HttpAdapter for DisabledHttpAdapter {
     fn fetch(&self, _req: FetchRequest) -> Result<FetchResponse, HttpError> {
         Err(HttpError::Disabled)
-    }
-}
-
-/// Resolved configuration for the substrate's HTTP adapter. Chassis
-/// mains read env vars (`AETHER_HTTP_DISABLE`, `AETHER_HTTP_ALLOWLIST`,
-/// `AETHER_HTTP_REQUIRE_HTTPS`, `AETHER_HTTP_MAX_BODY_BYTES`,
-/// `AETHER_HTTP_TIMEOUT_MS`) into a `HttpConfig` and pass it to
-/// `HttpCapability::new`. Tests build a `HttpConfig` directly,
-/// never touching process env (issue 464).
-///
-/// ADR-0090 unit g (iamacoffeepot/aether#1264): the
-/// `#[derive(aether_substrate::Config)]` emits the env-shaped
-/// `HttpConfigLayer`, the clap-shaped `HttpOverlay`, the
-/// `FromArgvThenEnv` impl, and the inherent `from_env` /
-/// `from_argv_then_env` shims under `feature = "native"`. The
-/// wasm-marker build carries only the domain struct.
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "native", derive(aether_substrate::Config))]
-#[cfg_attr(
-    feature = "native",
-    config(env_prefix = "AETHER_HTTP", cli_prefix = "http")
-)]
-pub struct HttpConfig {
-    /// `AETHER_HTTP_DISABLE=1` swaps the `UreqHttpAdapter` for a
-    /// `DisabledHttpAdapter` that replies `HttpError::Disabled` to
-    /// every fetch. `env` + `cli_long` overrides pin the wire shape
-    /// (`AETHER_HTTP_DISABLE`, `--http-disable`) to the pre-derive
-    /// names while the domain field stays `disabled` for read-site
-    /// clarity.
-    #[cfg_attr(
-        feature = "native",
-        config(
-            env = "AETHER_HTTP_DISABLE",
-            cli_long = "http-disable",
-            default = false
-        )
-    )]
-    pub disabled: bool,
-    /// Hostnames the adapter will dial. Empty = deny all
-    /// (deny-by-default per ADR-0043). The `csv_set` hint auto-wires the
-    /// shared comma-split parser on the env side.
-    #[cfg_attr(feature = "native", config(default = [], csv_set))]
-    pub allowlist: HashSet<String>,
-    /// `AETHER_HTTP_REQUIRE_HTTPS=1` rejects `http://` URLs with
-    /// `HttpError::InvalidUrl`.
-    #[cfg_attr(feature = "native", config(default = false))]
-    pub require_https: bool,
-    /// Cap on inbound and outbound body bytes. Defaults to
-    /// [`DEFAULT_MAX_BODY_BYTES`] (16 MB).
-    #[cfg_attr(feature = "native", config(default = 16_777_216))]
-    pub max_body_bytes: usize,
-    /// Default per-request timeout when `Fetch.timeout_ms` is
-    /// `None`. Defaults to [`DEFAULT_TIMEOUT_MILLIS`] (30 s). The derive's
-    /// `ms_duration` hint stores the Layer field as `u32`-ms and
-    /// bridges via `Duration::from_millis(u64::from(...))`;
-    /// `layer_field = "timeout_ms"` pins the Layer / env / CLI shape to
-    /// the pre-derive name (`AETHER_HTTP_TIMEOUT_MS`,
-    /// `--http-timeout-ms`).
-    #[cfg_attr(
-        feature = "native",
-        config(default = 30_000, ms_duration, layer_field = "timeout_ms")
-    )]
-    pub default_timeout: Duration,
-}
-
-impl Default for HttpConfig {
-    fn default() -> Self {
-        Self {
-            disabled: false,
-            allowlist: HashSet::new(),
-            require_https: false,
-            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
-            default_timeout: Duration::from_millis(u64::from(DEFAULT_TIMEOUT_MILLIS)),
-        }
     }
 }
 

--- a/crates/aether-capabilities/src/http/server/config.rs
+++ b/crates/aether-capabilities/src/http/server/config.rs
@@ -1,0 +1,75 @@
+//! Resolved HTTP server configuration (ADR-0090). The `#[derive(Config)]`
+//! layer the chassis builds from argv/env and hands to
+//! `with_actor::<HttpServerCapability>(config)`.
+
+use super::{
+    DEFAULT_BIND_ADDR, DEFAULT_MAX_HEADER_BYTES, DEFAULT_MAX_REQUEST_BYTES,
+    DEFAULT_REQUEST_TIMEOUT_MILLIS,
+};
+
+/// Init config for [`HttpServerCapability`](super::HttpServerCapability) (ADR-0108).
+///
+/// `bind_addr` is the address to bind (e.g. `"127.0.0.1:8080"`,
+/// `"127.0.0.1:0"` to let the OS pick a port). `handler_mailbox` names the
+/// single component mailbox every request is dispatched to — resolved by
+/// name at dispatch time (late binding), so the handler component can load
+/// or reload independently of the server. `max_request_bytes` caps the
+/// request body, `max_header_bytes` caps the request line + headers, and
+/// `request_timeout_millis` bounds both the per-read slow-loris timeout and
+/// the handler response deadline.
+///
+/// `#[derive(aether_substrate::Config)]` (ADR-0090) emits the env-shaped
+/// `HttpServerConfigLayer`, the clap-shaped `HttpServerOverlay`, and the
+/// inherent `from_env` / `from_argv_then_env` shims under
+/// `feature = "native"`; the wasm-marker build carries only this domain
+/// struct.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "native", derive(aether_substrate::Config))]
+#[cfg_attr(
+    feature = "native",
+    config(env_prefix = "AETHER_HTTP_SERVER", cli_prefix = "http-server")
+)]
+pub struct HttpServerConfig {
+    /// Whether to bind the listening socket at all. Default `false` —
+    /// the HTTP server is opt-in, so an unconfigured chassis binds no
+    /// port. The remaining fields are consulted only when this is `true`.
+    #[cfg_attr(feature = "native", config(default = false))]
+    pub enabled: bool,
+    /// Address to bind the listening socket. Defaults to loopback
+    /// ([`DEFAULT_BIND_ADDR`]); a public interface is an explicit choice.
+    /// A blank override (`AETHER_HTTP_SERVER_BIND_ADDR=`) falls back to
+    /// the default — the derive treats an empty `String` as unset.
+    #[cfg_attr(feature = "native", config(default = "127.0.0.1:8080"))]
+    pub bind_addr: String,
+    /// The single handler mailbox every request is dispatched to (e.g.
+    /// `"aether.component/aether.embedded:web"`). Empty = every request is
+    /// answered `503` (no handler resolves).
+    #[cfg_attr(feature = "native", config(default = ""))]
+    pub handler_mailbox: String,
+    /// Cap on the request body in bytes ([`DEFAULT_MAX_REQUEST_BYTES`]);
+    /// an announced `Content-Length` past this is answered `413`.
+    #[cfg_attr(feature = "native", config(default = 1_048_576))]
+    pub max_request_bytes: usize,
+    /// Cap on the request line + header bytes ([`DEFAULT_MAX_HEADER_BYTES`]);
+    /// a head that grows past this is answered `431`.
+    #[cfg_attr(feature = "native", config(default = 65_536))]
+    pub max_header_bytes: usize,
+    /// Per-read socket timeout (slow-loris guard) and handler response
+    /// deadline in milliseconds ([`DEFAULT_REQUEST_TIMEOUT_MILLIS`]); a
+    /// handler that doesn't reply in time yields `504`.
+    #[cfg_attr(feature = "native", config(default = 30_000))]
+    pub request_timeout_millis: u64,
+}
+
+impl Default for HttpServerConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            bind_addr: DEFAULT_BIND_ADDR.to_string(),
+            handler_mailbox: String::new(),
+            max_request_bytes: DEFAULT_MAX_REQUEST_BYTES,
+            max_header_bytes: DEFAULT_MAX_HEADER_BYTES,
+            request_timeout_millis: DEFAULT_REQUEST_TIMEOUT_MILLIS,
+        }
+    }
+}

--- a/crates/aether-capabilities/src/http/server/mod.rs
+++ b/crates/aether-capabilities/src/http/server/mod.rs
@@ -46,78 +46,19 @@ pub const DEFAULT_MAX_HEADER_BYTES: usize = 65_536;
 /// Default `request_timeout_millis` (slow-loris read + response deadline): 30 s.
 pub const DEFAULT_REQUEST_TIMEOUT_MILLIS: u64 = 30_000;
 
+mod config;
+
+pub use config::HttpServerConfig;
+// The `Config` derive on `HttpServerConfig` emits these native-only sibling
+// types in `config`; chassis CLI / boot wiring addresses them through the
+// `server::` path, so re-export them here.
+#[cfg(feature = "native")]
+pub use config::{HttpServerConfigLayer, HttpServerOverlay};
+
 // Re-export the cap's handle struct at file root for chassis builders +
-// embedders that read the bound port. The native-only `*Layer` /
-// `*Overlay` the `Config` derive emits live next to `HttpServerConfig`.
+// embedders that read the bound port.
 #[cfg(not(target_arch = "wasm32"))]
 pub use server_native::HttpServerHandle;
-
-/// Init config for [`HttpServerCapability`] (ADR-0108).
-///
-/// `bind_addr` is the address to bind (e.g. `"127.0.0.1:8080"`,
-/// `"127.0.0.1:0"` to let the OS pick a port). `handler_mailbox` names the
-/// single component mailbox every request is dispatched to — resolved by
-/// name at dispatch time (late binding), so the handler component can load
-/// or reload independently of the server. `max_request_bytes` caps the
-/// request body, `max_header_bytes` caps the request line + headers, and
-/// `request_timeout_millis` bounds both the per-read slow-loris timeout and
-/// the handler response deadline.
-///
-/// `#[derive(aether_substrate::Config)]` (ADR-0090) emits the env-shaped
-/// `HttpServerConfigLayer`, the clap-shaped `HttpServerOverlay`, and the
-/// inherent `from_env` / `from_argv_then_env` shims under
-/// `feature = "native"`; the wasm-marker build carries only this domain
-/// struct.
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "native", derive(aether_substrate::Config))]
-#[cfg_attr(
-    feature = "native",
-    config(env_prefix = "AETHER_HTTP_SERVER", cli_prefix = "http-server")
-)]
-pub struct HttpServerConfig {
-    /// Whether to bind the listening socket at all. Default `false` —
-    /// the HTTP server is opt-in, so an unconfigured chassis binds no
-    /// port. The remaining fields are consulted only when this is `true`.
-    #[cfg_attr(feature = "native", config(default = false))]
-    pub enabled: bool,
-    /// Address to bind the listening socket. Defaults to loopback
-    /// ([`DEFAULT_BIND_ADDR`]); a public interface is an explicit choice.
-    /// A blank override (`AETHER_HTTP_SERVER_BIND_ADDR=`) falls back to
-    /// the default — the derive treats an empty `String` as unset.
-    #[cfg_attr(feature = "native", config(default = "127.0.0.1:8080"))]
-    pub bind_addr: String,
-    /// The single handler mailbox every request is dispatched to (e.g.
-    /// `"aether.component/aether.embedded:web"`). Empty = every request is
-    /// answered `503` (no handler resolves).
-    #[cfg_attr(feature = "native", config(default = ""))]
-    pub handler_mailbox: String,
-    /// Cap on the request body in bytes ([`DEFAULT_MAX_REQUEST_BYTES`]);
-    /// an announced `Content-Length` past this is answered `413`.
-    #[cfg_attr(feature = "native", config(default = 1_048_576))]
-    pub max_request_bytes: usize,
-    /// Cap on the request line + header bytes ([`DEFAULT_MAX_HEADER_BYTES`]);
-    /// a head that grows past this is answered `431`.
-    #[cfg_attr(feature = "native", config(default = 65_536))]
-    pub max_header_bytes: usize,
-    /// Per-read socket timeout (slow-loris guard) and handler response
-    /// deadline in milliseconds ([`DEFAULT_REQUEST_TIMEOUT_MILLIS`]); a
-    /// handler that doesn't reply in time yields `504`.
-    #[cfg_attr(feature = "native", config(default = 30_000))]
-    pub request_timeout_millis: u64,
-}
-
-impl Default for HttpServerConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            bind_addr: DEFAULT_BIND_ADDR.to_string(),
-            handler_mailbox: String::new(),
-            max_request_bytes: DEFAULT_MAX_REQUEST_BYTES,
-            max_header_bytes: DEFAULT_MAX_HEADER_BYTES,
-            request_timeout_millis: DEFAULT_REQUEST_TIMEOUT_MILLIS,
-        }
-    }
-}
 
 #[aether_actor::bridge(singleton)]
 mod server_native {


### PR DESCRIPTION
Closes #2226.

## Summary

The two HTTP capabilities become submodule directories so each cap's config lives in its own file, per the requirement to spin up further submodules for the HTTP server and client. Mechanical move, no behavior change:

- `http/client.rs` → `http/client/{mod.rs, config.rs}` — `HttpConfig` (and its native-only `HttpConfigLayer` / `HttpOverlay`) moves to `config.rs`; the adapter types, `DEFAULT_*` consts, native module, and tests stay in `mod.rs`.
- `http/server.rs` → `http/server/{mod.rs, config.rs}` — `HttpServerConfig` (and `HttpServerConfigLayer` / `HttpServerOverlay`) moves to `config.rs`; `HttpServerHandle` stays in `mod.rs`.

Each new `mod.rs` re-adds the native-gated root re-exports (`pub use config::{HttpConfigLayer, HttpOverlay}` etc. plus the always-on `pub use config::HttpConfig`), so existing paths (`client::HttpConfig`) and intra-module `super::` imports keep resolving. `http/mod.rs`'s `pub mod client;` / `pub mod server;` and `pub use` surface are unchanged — they now resolve to the directories transparently, preserving the ADR-0121 two-cap co-location. Child of #2221.

## Test plan

No behavior change, so the bar is `scripts/preflight.sh` green end-to-end: fmt, clippy `-D warnings`, nextest (2036/2036), rustdoc, and the wasm32 cross-build that catches a mis-mirrored `native` gate. All green locally (one pre-existing load-sensitive flake in `engine::proxy` unrelated to this diff cleared on re-run).

## Generated by

`/implement` — agent execution of scoped issue #2226.
