### PR TITLE
docs(guide): update config-knob recipe citations after http split

### DIFF
--- a/docs/guide/recipes/adding-a-config-knob.md
+++ b/docs/guide/recipes/adding-a-config-knob.md
@@ -17,8 +17,8 @@ the step where each bites.
 
 ## The exemplar to copy
 
-Follow [`HttpConfig`](https://github.com/iamacoffeepot/aether/blob/main/crates/aether-capabilities/src/http/client.rs)
-in `crates/aether-capabilities/src/http/client.rs`. It's the same struct the
+Follow [`HttpConfig`](https://github.com/iamacoffeepot/aether/blob/main/crates/aether-capabilities/src/http/client/config.rs)
+in `crates/aether-capabilities/src/http/client/config.rs`. It's the same struct the
 [Configuration](../systems/configuration.md) explainer excerpts, it carries most
 of the hints you'll reach for (`default`, `env`, `cli_long`, `csv_set`,
 `ms_duration`, `layer_field`), and it's wired into both full-stack chassis. Open
@@ -108,7 +108,7 @@ The container attribute on the struct sets the prefixes both names derive from:
 `HttpConfig` declares `impl Default` separately from the derive's `default = ...`
 literals (the derive feeds the layer; `Default` feeds direct construction in
 tests and call sites). Add your field's default to **both**. The
-`http_from_env_defaults_match` test in the `http/client.rs` test module is what
+`http_from_env_defaults_match` test in the `http/client/mod.rs` test module is what
 keeps them honest:
 
 ```rust


### PR DESCRIPTION
Closes #2229.

## Summary

The adding-a-config-knob recipe cited the pre-split http config layout. After #2226 split the http client/server into submodule dirs with their own config.rs, those citations were stale. This repoints the deep-link and prose path from http/client.rs to http/client/config.rs, and the test-module reference to http/client/mod.rs where #2226 keeps the test module.

## Test plan

Docs-only. Each updated citation was verified against the current code layout on origin/main (the embedded snippet's module path was confirmed correct as-is).

## Generated by

`/implement` — agent execution of scoped issue #2229.
