### PR TITLE
chore(workflow): define per-skill concurrency caps for sweep modes

### DIFF
--- a/.claude/skills/approve/SKILL.md
+++ b/.claude/skills/approve/SKILL.md
@@ -40,7 +40,7 @@ The primary human review point of the release flow. The user invokes `/approve <
    Confirm approve? (no label write happens until your go-ahead)
    ```
 
-4. **On confirmation, approve the batch.** Apply [Actions on pass](#actions-on-pass) over the passing set — reconcile each passing issue's label to `phase:ready` (a REST `PUT …/labels` per issue, see [Phase label reconcile](#phase-label-reconcile)). The sweep never auto-confirms.
+4. **On confirmation, approve the batch.** Apply [Actions on pass](#actions-on-pass) over the passing set — reconcile each passing issue's label to `phase:ready` (a REST `PUT …/labels` per issue, see [Phase label reconcile](#phase-label-reconcile)). The sweep never auto-confirms. `--sweep` dispatches no background agents — the parent applies the `phase:ready` label PUTs inline — so there is no concurrency cap to set.
 
 `--sweep` takes no issue argument — it discovers them. It does not combine with `--note` or `--skip-adr`, both single-issue concerns.
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -43,7 +43,7 @@ Either mode opens the PR **as a draft**, drives CI green, and holds it in draft 
 
 2. **Gate-check each candidate.** Run the same [per-issue preconditions](#preconditions) the single-issue path runs — `phase:ready` present, no `## Sub-issues` umbrella, `## Implementation plan` present, exactly one `model:*` label. Drop any issue that fails and record the reason; the sweep does not silently skip — every dropped issue is listed in the plan with its drop reason.
 
-3. **Pack and order.** Apply the **Batched dispatch** rules above (under the hybrid background-agent mode): budget-based packing against the `size:*`-label priors refined by each body read, crate-affinity co-queueing with the trivial-mechanical exception, broadest-exploration-first ordering within each queue.
+3. **Pack and order.** Apply the **Batched dispatch** rules above (under the hybrid background-agent mode): budget-based packing against the `size:*`-label priors refined by each body read, crate-affinity co-queueing with the trivial-mechanical exception, broadest-exploration-first ordering within each queue. Concurrency equals the number of packed queues, bounded by the ~150k context-budget packing threshold (§Batched dispatch), not a flat agent count — the binding axis is per-agent context, not the REST pool.
 
    **Stale-worktree probe.** A re-swept issue from a prior bounced or aborted attempt can leave a stale `.claude/worktrees/issue-<N>` worktree and branch behind, so probe each packed candidate before dispatch: does the worktree exist, how many files are uncommitted in it, is its branch ahead of `origin/main`, and is there an open PR for the head branch (the REST `pulls?head=` form, never `gh pr list`):
 

--- a/.claude/skills/land/SKILL.md
+++ b/.claude/skills/land/SKILL.md
@@ -72,7 +72,7 @@ Read PR draft state and `mergeable_state` over REST (`gh api repos/iamacoffeepot
 
 5. **On confirmation, land in sequence.** Land each PR through the [Landing sequence](#landing-sequence) in the printed order. After every merge, **recompute the remaining predictions** — the HEAD of `main` has advanced and a previously-clean branch may now be `behind`. A recomputed `dirty` halts the sequence and surfaces the conflict to the user before proceeding to the next PR.
 
-The sweep never auto-confirms and never auto-resolves a `dirty` conflict.
+The sweep never auto-confirms and never auto-resolves a `dirty` conflict. Landing is serial by construction — each merge advances `main` and the recompute loop updates conflict state after it — so sweep concurrency is 1 and no cap applies.
 
 ## Landing sequence
 

--- a/.claude/skills/scope/SKILL.md
+++ b/.claude/skills/scope/SKILL.md
@@ -59,7 +59,7 @@ Two things differ from `/implement --sweep`:
    Confirm scope? (the agents spawn only on your go-ahead)
    ```
 
-4. **On confirmation, dispatch.** Spawn one background agent per candidate, capped at a small concurrency (default ~3) so a sweep doesn't burst the shared per-user REST pool: fill the cap, and as each agent finishes the next candidate starts. Each agent runs the full single-issue `/scope` procedure on its issue and stops; the parent collects each outcome — landed at Plan, or self-bounced — and prints the roll-up.
+4. **On confirmation, dispatch.** Spawn one background agent per candidate, capped at **4** concurrent agents — the binding constraint is concurrent design-agent compute (scope runs Opus) and roll-up legibility, not the REST pool (a scope agent issues ~10 REST calls over several minutes, far below the 5,000/hr budget at any plausible concurrency): fill the cap, and as each agent finishes the next candidate starts. Each agent runs the full single-issue `/scope` procedure on its issue and stops; the parent collects each outcome — landed at Plan, or self-bounced — and prints the roll-up.
 
 The sweep never auto-confirms. A scoper agent that hits a tied design decision or an unframable body self-bounces its own issue (the single-issue Bounce mechanics), and the parent surfaces that bounce in the roll-up rather than guessing. `--sweep` takes no `--phase` (that is a single-issue resume control).
 


### PR DESCRIPTION
Closes #2238.

## Summary

The sweep-capable skills lacked an explicit concurrency-cap posture. This records one per skill: scope's per-pass cap is set to 4 with the binding-constraint rationale (Opus compute + roll-up legibility, not the REST budget); implement notes concurrency equals the packed-queue count bounded by the ~150k context-budget threshold, not a flat count; approve records that --sweep dispatches no background agents (inline label PUTs), so no cap applies; land records that landing is serial by construction, so sweep concurrency is 1.

## Test plan

Docs-only — four SKILL.md files under .claude/skills/. No crate, no code, no wire/kind/ADR change.

## Generated by

`/implement` — agent execution of scoped issue #2238.
