### PR TITLE
chore(aether-actor): remove junk tests that re-test machinery or duplicate siblings

### DIFF
--- a/crates/aether-actor/src/local.rs
+++ b/crates/aether-actor/src/local.rs
@@ -410,15 +410,4 @@ mod tests {
         assert!(Probe::try_with(|p| p.0).is_none());
         assert!(Probe::try_with_mut(|p| p.0).is_none());
     }
-
-    #[test]
-    fn static_backend_routes_through_the_provider() {
-        // `install_static_backend` is the single-actor install; once a
-        // provider is set the test provider wins (set-once), so assert the
-        // install call is a no-op rather than a panic and the API exists.
-        install_static_backend();
-        let slots = ActorSlots::new();
-        test_stamped(&slots, || Probe::with_mut(|p| p.0 = 5));
-        test_stamped(&slots, || Probe::with(|p| assert_eq!(p.0, 5)));
-    }
 }

--- a/crates/aether-actor/src/mail/mailbox.rs
+++ b/crates/aether-actor/src/mail/mailbox.rs
@@ -180,21 +180,4 @@ mod tests {
         assert!(!a.matches(8));
         assert_eq!(a.raw(), 7);
     }
-
-    #[test]
-    fn mailbox_accessors() {
-        let s: Mailbox<FakeKind> = Mailbox::__new(3u64, 11);
-        assert_eq!(s.mailbox(), 3u64);
-        assert_eq!(s.kind(), 11);
-    }
-
-    // Asserts `resolve_mailbox` matches the name hash — the primitive is the
-    // reference value under test.
-    #[allow(clippy::disallowed_methods)]
-    #[test]
-    fn resolve_mailbox_uses_name_hash_and_kind_id() {
-        let s = resolve_mailbox::<FakeKind>("hand.rolled");
-        assert_eq!(s.mailbox(), mailbox_id_from_name("hand.rolled").0);
-        assert_eq!(s.kind(), FakeKind::ID.0);
-    }
 }

--- a/crates/aether-actor/src/mail/mod.rs
+++ b/crates/aether-actor/src/mail/mod.rs
@@ -399,25 +399,6 @@ mod tests {
     }
 
     #[test]
-    fn mail_recipient_roundtrips_from_raw_address() {
-        // ADR-0114 decision #1: the receive ABI threads the routed
-        // mailbox through as the trailing `recipient` frame slot; the
-        // accessor wraps it back into a `MailboxId`. Independent of the
-        // reply-handle `sender` slot — distinct values must not bleed.
-        // SAFETY: no pointer is dereferenced; only the scalar slots are
-        // inspected.
-        let mail = unsafe { Mail::__from_ptr(0, 0, 0, 0, 42, 0x1234_5678_9ABC_DEF0) };
-        assert_eq!(mail.recipient(), MailboxId(0x1234_5678_9ABC_DEF0));
-        // `__from_raw` (the wasm32 path) carries the same recipient
-        // unchanged — only the address widens, never the recipient.
-        // SAFETY: no pointer is dereferenced; only the scalar slots are
-        // inspected.
-        let raw_mail = unsafe { Mail::__from_raw(0, 0, 0, 0, NO_REPLY_HANDLE, 0xDEAD_BEEF) };
-        assert_eq!(raw_mail.recipient(), MailboxId(0xDEAD_BEEF));
-        assert!(raw_mail.reply_handle().is_none());
-    }
-
-    #[test]
     fn prior_state_empty_bytes_does_not_deref() {
         // With len=0, `bytes()` must not materialise a pointer — a
         // raw 0 ptr with len>0 would be UB if anyone called
@@ -460,39 +441,6 @@ mod tests {
             )
         };
         let out = mail.decode_kind::<FakeStructured>().expect("decode");
-        assert_eq!(out, value);
-    }
-
-    #[test]
-    fn mail_decode_kind_cast_roundtrip() {
-        // Cast arm — Kind derive on a `#[repr(C)] + Pod` type emits
-        // `decode_cast` as the body, so `decode_kind` lands on the
-        // bytemuck reader without any per-handler annotation.
-        #[repr(C)]
-        #[derive(
-            Copy,
-            Clone,
-            Debug,
-            PartialEq,
-            bytemuck::Pod,
-            bytemuck::Zeroable,
-            ::aether_data::Kind,
-            ::aether_data::Schema,
-        )]
-        #[kind(name = "test.fake_cast_kind")]
-        struct FakeCastKind {
-            a: u32,
-            b: u32,
-        }
-
-        let value = FakeCastKind { a: 5, b: 9 };
-        let ptr_raw = (&raw const value).addr();
-        let byte_len = size_of::<FakeCastKind>() as u32;
-        // SAFETY: see module-level test fixture justification above.
-        let mail = unsafe {
-            Mail::__from_ptr(FakeCastKind::ID.0, ptr_raw, byte_len, 1, NO_REPLY_HANDLE, 0)
-        };
-        let out = mail.decode_kind::<FakeCastKind>().expect("decode");
         assert_eq!(out, value);
     }
 
@@ -645,16 +593,6 @@ mod tests {
             .as_kind::<StateStruct>()
             .expect("test setup: round-trip frame decodes back to StateStruct");
         assert_eq!(decoded, value);
-    }
-
-    #[test]
-    fn as_kind_id_mismatch_returns_none() {
-        // Frame under one kind, decode as a different one — the
-        // leading `K::ID` compare rejects before wire runs.
-        let value = OtherState { flag: true };
-        let buf = frame_bundle(&value);
-        let prior = prior_from(&buf, 0);
-        assert!(prior.as_kind::<StateStruct>().is_none());
     }
 
     #[test]

--- a/crates/aether-actor/src/wasm/ctx.rs
+++ b/crates/aether-actor/src/wasm/ctx.rs
@@ -1079,36 +1079,6 @@ mod tests {
         fn erased_on_rehydrate(&mut self, _ctx: &mut WasmCtx<'_, Manual>, _prior: PriorState<'_>) {}
     }
 
-    /// Step 2: `despawn_inline_child` removes a resident inline child
-    /// (returns `true`) and is idempotent — a second despawn of the same
-    /// alias returns `false`, not an error. Installs the child directly
-    /// (the host build's `spawn_inline_child` host fn is a panicking stub).
-    #[test]
-    fn despawn_inline_child_removes_then_idempotent() {
-        let registry = InlineRegistry::new();
-        let alias = MailboxId(0x6161);
-        install_inline_child::<SucceedingChild>(
-            &registry,
-            alias,
-            0,
-            String::from("widget"),
-            false,
-            0,
-            (),
-        )
-        .expect("a succeeding init installs the inline child");
-
-        let ctx = WasmCtx::__new(alias.0, &registry, NO_INBOUND_SOURCE);
-        assert!(
-            ctx.despawn_inline_child(alias),
-            "despawning a resident child returns true",
-        );
-        assert!(
-            !ctx.despawn_inline_child(alias),
-            "a second despawn of the same alias returns false (idempotent)",
-        );
-    }
-
     /// ADR-0112: the mode marker is layout-neutral — the `Single` and
     /// `Manual` views have identical size + alignment. This is the
     /// invariant the `as_single` pointer reborrow rests on.
@@ -1122,16 +1092,6 @@ mod tests {
             align_of::<WasmCtx<'static, Single>>(),
             align_of::<WasmCtx<'static, Manual>>(),
         );
-    }
-
-    /// ADR-0112: `OutboundReply` is reachable from the `Manual` ctx
-    /// only. The single-locked ctx carries no reply surface, so a `-> ()`
-    /// single handler is provably silent (a stray single-ctx `ctx.reply`
-    /// is a compile error, not a manifest lie).
-    #[test]
-    fn outbound_reply_present_on_manual() {
-        fn assert_impls<C: OutboundReply>() {}
-        assert_impls::<WasmCtx<'static, Manual>>();
     }
 
     /// ADR-0114 addressing amendment: a ctx self-identified as the cluster

--- a/crates/aether-actor/src/wasm/inline/mod.rs
+++ b/crates/aether-actor/src/wasm/inline/mod.rs
@@ -853,40 +853,6 @@ mod tests {
         );
     }
 
-    /// Step 1 coverage: `remove` drops a resident child (the alias goes
-    /// absent) and is idempotent — a second `remove` of the same id is a
-    /// clean `false`.
-    #[test]
-    fn registry_remove_drops_child_and_is_idempotent() {
-        let registry = InlineRegistry::new();
-        let id = MailboxId(0x8888);
-
-        assert!(
-            !registry.remove(id),
-            "removing an absent id returns false (idempotent)",
-        );
-        registry.insert_child(
-            id,
-            0,
-            String::from("widget"),
-            false,
-            0,
-            Box::new(RecordingChild::new().0),
-        );
-        assert!(
-            registry.remove(id),
-            "removing a resident child returns true",
-        );
-        assert!(
-            registry.take(id).is_none(),
-            "a removed child is absent from the registry",
-        );
-        assert!(
-            !registry.remove(id),
-            "a second remove of the same id is a clean false",
-        );
-    }
-
     /// Step 3 coverage: a child that despawns itself mid-dispatch drops
     /// correctly. `membrane_dispatch` takes it out, the dispatch removes the
     /// now-empty slot via `ctx.despawn_inline_child` (driving the same
@@ -1234,42 +1200,6 @@ mod tests {
             observed.get(),
             Some(MailboxId(root)),
             "the drained child reads the enqueuing parent's id as its source, not None",
-        );
-    }
-
-    /// Task 1: a child dispatched off the drain reads
-    /// `ctx.source_mailbox()` == the sending sibling — the child → sibling
-    /// direction. A sibling enqueues a send to the recipient child stamped
-    /// with the sibling's own id; the drained child observes exactly that
-    /// sibling id.
-    #[test]
-    fn drained_child_reads_enqueuing_sender_sibling() {
-        let registry = InlineRegistry::new();
-        let root = 0x7000_u64;
-        let sender_sibling = 0x7001_u64;
-        let recipient_child = 0x7002_u64;
-        registry.set_self_id(root);
-        // Both children are siblings under the root.
-        install_recording(&registry, sender_sibling, root);
-        let (dispatches, observed) =
-            install_recording_with_source(&registry, recipient_child, root);
-
-        // The sibling sends to the recipient child, stamping its own id.
-        registry.route_or_enqueue(recipient_child, 1, &[0x00], 1, false, sender_sibling);
-
-        drain_cluster_queue(&registry, |_source| {
-            |_mail| panic!("own dispatch must not run for a child-addressed item")
-        });
-
-        assert_eq!(
-            dispatches.get(),
-            1,
-            "the recipient child was dispatched once"
-        );
-        assert_eq!(
-            observed.get(),
-            Some(MailboxId(sender_sibling)),
-            "the drained child reads the sending sibling's id as its source",
         );
     }
 


### PR DESCRIPTION
Closes #2227.

## Summary

Removes 10 junk tests from aether-actor — tests that re-exercise machinery another crate owns or duplicate a sibling, per the testing policy (docs/guide/testing.md). No production code, public trait, wire format, or ADR is touched.

## Test plan

Test count 94 -> 84. Remaining suite passes (nextest), clippy -D warnings clean, rustdoc strict-flags clean. Validated via the attested path (scripts/attest.sh --publish); the verify check gates the merge in place of the skipped heavy jobs.

## Generated by

`/implement` — agent execution of scoped issue #2227.
