### PR TITLE
refactor(substrate-bundle): derive the hub --config dump from EngineConfigLayer META

### DIFF
--- a/crates/aether-capabilities/src/engine/mod.rs
+++ b/crates/aether-capabilities/src/engine/mod.rs
@@ -21,4 +21,4 @@ pub use proxy::EngineProxy;
 pub use proxy::EngineProxyConfig;
 pub use server::EngineServer;
 #[cfg(not(target_arch = "wasm32"))]
-pub use server::{EngineConfig, EngineOverlay};
+pub use server::{EngineConfig, EngineConfigLayer, EngineOverlay};

--- a/crates/aether-capabilities/src/engine/server/mod.rs
+++ b/crates/aether-capabilities/src/engine/server/mod.rs
@@ -65,7 +65,7 @@ mod fleet;
 // `with_actor::<EngineServer>(cfg)` (ADR-0090). Native-only re-export —
 // the engines cap is native-only, so the config has no wasm consumer.
 #[cfg(not(target_arch = "wasm32"))]
-pub use config::{EngineConfig, EngineOverlay};
+pub use config::{EngineConfig, EngineConfigLayer, EngineOverlay};
 
 #[aether_actor::bridge(singleton)]
 mod server_native {

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -137,7 +137,7 @@ pub use engine::EngineProxy;
 pub use engine::EngineProxyConfig;
 pub use engine::EngineServer;
 #[cfg(not(target_arch = "wasm32"))]
-pub use engine::{EngineConfig, EngineOverlay};
+pub use engine::{EngineConfig, EngineConfigLayer, EngineOverlay};
 pub use http::{HttpCapability, HttpConfig};
 // ADR-0108 `aether.http.server` cap (issue 1760). `HttpServerConfig` is the
 // always-on domain struct; the `Config`-derive `HttpServerConfigLayer` /

--- a/crates/aether-substrate-bundle/src/bin/hub.rs
+++ b/crates/aether-substrate-bundle/src/bin/hub.rs
@@ -10,40 +10,31 @@
 #![allow(clippy::print_stderr)]
 #![allow(clippy::print_stdout)]
 
+use aether_capabilities::EngineConfigLayer;
 use aether_substrate::config::{KnobKind, KnobRecord, dump_config};
 use aether_substrate_bundle::cli::HubCli;
 use aether_substrate_bundle::hub::{Chassis, HubChassis, HubEnv};
 use clap::Parser as _;
+use confique::Config as _;
 
-/// The hub chassis is coordinator-only — the full-stack cap knobs
-/// don't apply, so the hub dumps just its own (RPC bind port + the
-/// engines-cap liveness heartbeat, issue 1339) rather than the shared
-/// `chassis_config_dump`.
-const HUB_KNOBS: &[KnobRecord] = &[
-    KnobRecord {
-        env_key: "AETHER_RPC_PORT",
-        doc: "aether.rpc.server bind port (default 8901).",
-        default: Some("8901"),
-        kind: KnobKind::HandRegistered,
-    },
-    KnobRecord {
-        env_key: "AETHER_HUB_HEARTBEAT_INTERVAL_SECS",
-        doc: "Engine liveness-heartbeat ping cadence in seconds; 0 disables (--hub-heartbeat-interval-secs).",
-        default: Some("5"),
-        kind: KnobKind::HandRegistered,
-    },
-    KnobRecord {
-        env_key: "AETHER_HUB_HEARTBEAT_MISS_LIMIT",
-        doc: "Consecutive missed pings before an engine is evicted (--hub-heartbeat-miss-limit).",
-        default: Some("3"),
-        kind: KnobKind::HandRegistered,
-    },
-];
+/// `AETHER_RPC_PORT` is the hub's chassis-special bind-port knob —
+/// resolved via `HubCli --rpc-port` rather than an `EngineConfig`
+/// field, so it cannot ride the `EngineConfigLayer::META` walk and
+/// stays a hand `KnobRecord`.
+const RPC_PORT_RECORD: KnobRecord = KnobRecord {
+    env_key: "AETHER_RPC_PORT",
+    doc: "aether.rpc.server bind port (default 8901).",
+    default: Some("8901"),
+    kind: KnobKind::HandRegistered,
+};
 
 fn main() -> anyhow::Result<()> {
     let cli = HubCli::parse();
     if cli.config {
-        print!("{}", dump_config(&[], HUB_KNOBS));
+        print!(
+            "{}",
+            dump_config(&[&EngineConfigLayer::META], &[RPC_PORT_RECORD])
+        );
         return Ok(());
     }
     // `--describe` (ADR-0115, issue 1953): print this binary's manifest —


### PR DESCRIPTION
Closes #2232.

## Summary

Drops the hand-maintained HUB_KNOBS slice and sources the hub's --config dump from EngineConfigLayer::META, the same META-walk every other cap dump uses (ADR-0090 §4). AETHER_RPC_PORT stays a hand KnobRecord since it resolves via HubCli --rpc-port rather than an EngineConfig field. EngineConfigLayer is re-exported through engine::server -> engine -> crate root so the hub bin can reach it.

## Test plan

clippy -D warnings, nextest, and rustdoc strict-flags all clean. Validated via the attested path (scripts/attest.sh --publish); the verify check gates the merge in place of the skipped heavy jobs.

## Generated by

`/implement` — agent execution of scoped issue #2232.
