### PR TITLE
refactor(substrate-bundle): migrate AETHER_TEST_BENCH_SIZE onto the Config derive

### DIFF
--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -12,7 +12,6 @@
 // (the `TestBench::start()` API ADR-0067 introduced); both paths
 // share `TestBenchChassis::build_passive`.
 
-use std::env;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use std::time::Duration;
@@ -35,43 +34,10 @@ use aether_substrate::{Chassis, capture::CaptureQueue, chassis::frame_loop, mail
 const FRAME_SETTLEMENT_CAP: Duration = Duration::from_secs(30);
 use aether_substrate_bundle::chassis_root::next_chassis_correlation;
 use aether_substrate_bundle::test_bench::{
-    TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS,
+    RenderSizeConfig, TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS,
     events::{self, ChassisEvent},
     render::Gpu,
 };
-
-/// Parse `AETHER_TEST_BENCH_SIZE=WxH`. Falls back to defaults on
-/// missing/unparseable input with a warn log so scenario scripts can
-/// see what dimensions they actually got.
-// Dev/test tooling: the test-bench binary takes its render size from env — not a
-// capability, no config layer in scope.
-#[allow(clippy::disallowed_methods)]
-fn parse_size_env() -> (u32, u32) {
-    use aether_substrate_bundle::test_bench::{DEFAULT_HEIGHT, DEFAULT_WIDTH};
-    let Ok(raw) = env::var("AETHER_TEST_BENCH_SIZE") else {
-        return (DEFAULT_WIDTH, DEFAULT_HEIGHT);
-    };
-    if let Some((w, h)) = raw.split_once('x') {
-        match (w.parse::<u32>(), h.parse::<u32>()) {
-            (Ok(w), Ok(h)) if w > 0 && h > 0 => (w, h),
-            _ => {
-                tracing::warn!(
-                    target: "aether_substrate::boot",
-                    value = %raw,
-                    "AETHER_TEST_BENCH_SIZE unparseable — falling back to default",
-                );
-                (DEFAULT_WIDTH, DEFAULT_HEIGHT)
-            }
-        }
-    } else {
-        tracing::warn!(
-            target: "aether_substrate::boot",
-            value = %raw,
-            "AETHER_TEST_BENCH_SIZE missing 'x' separator — falling back to default",
-        );
-        (DEFAULT_WIDTH, DEFAULT_HEIGHT)
-    }
-}
 
 fn main() -> anyhow::Result<()> {
     let capture_queue = CaptureQueue::new();
@@ -102,7 +68,7 @@ fn main() -> anyhow::Result<()> {
         kind_tick,
     } = TestBenchChassis::build_passive(env)?;
 
-    let (width, height) = parse_size_env();
+    let (width, height) = RenderSizeConfig::from_env().to_size();
     let gpu = Gpu::new(width, height, render_handles);
     tracing::info!(
         target: "aether_substrate::boot",

--- a/crates/aether-substrate-bundle/src/test_bench/config.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/config.rs
@@ -1,0 +1,97 @@
+//! Configuration for the test-bench chassis (ADR-0090).
+
+use super::bench::{DEFAULT_HEIGHT, DEFAULT_WIDTH};
+
+/// Render-size knob for the standalone test-bench binary
+/// (`AETHER_TEST_BENCH_SIZE=WxH`). Mirrors the single-field
+/// `SettlementConfig` shape:
+/// a `#[derive(aether_substrate::Config)]` struct resolved `from_env()`
+/// and lowered to `(u32, u32)` by [`Self::to_size`].
+///
+/// The explicit `env =` pin is belt-and-suspenders against a future field
+/// rename, matching how `ActorRingConfig` pins its historical keys.
+#[derive(Clone, Debug, Default, aether_substrate::Config)]
+#[config(env_prefix = "AETHER_TEST_BENCH", cli_prefix = "test-bench")]
+pub struct RenderSizeConfig {
+    /// `AETHER_TEST_BENCH_SIZE=WxH` render dimensions for the offscreen
+    /// wgpu surface. Falls back to `800x600` on missing/unparseable input
+    /// with a warn log (default `None`).
+    #[config(env = "AETHER_TEST_BENCH_SIZE")]
+    pub size: Option<String>,
+}
+
+impl RenderSizeConfig {
+    /// Lower the resolved knob to `(width, height)` pixels. Preserves the
+    /// `parse_size_env` semantics verbatim: missing env var, missing `x`
+    /// separator, non-numeric parts, or a zero dimension all fall back to
+    /// [`DEFAULT_WIDTH`] × [`DEFAULT_HEIGHT`] with a `warn` log.
+    #[must_use]
+    pub fn to_size(&self) -> (u32, u32) {
+        let Some(raw) = self.size.as_deref() else {
+            return (DEFAULT_WIDTH, DEFAULT_HEIGHT);
+        };
+        if let Some((w, h)) = raw.split_once('x') {
+            match (w.parse::<u32>(), h.parse::<u32>()) {
+                (Ok(w), Ok(h)) if w > 0 && h > 0 => (w, h),
+                _ => {
+                    tracing::warn!(
+                        target: "aether_substrate::boot",
+                        value = %raw,
+                        "AETHER_TEST_BENCH_SIZE unparseable — falling back to default",
+                    );
+                    (DEFAULT_WIDTH, DEFAULT_HEIGHT)
+                }
+            }
+        } else {
+            tracing::warn!(
+                target: "aether_substrate::boot",
+                value = %raw,
+                "AETHER_TEST_BENCH_SIZE missing 'x' separator — falling back to default",
+            );
+            (DEFAULT_WIDTH, DEFAULT_HEIGHT)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(s: Option<&str>) -> RenderSizeConfig {
+        RenderSizeConfig {
+            size: s.map(str::to_owned),
+        }
+    }
+
+    #[test]
+    fn to_size_valid() {
+        assert_eq!(cfg(Some("640x480")).to_size(), (640, 480));
+    }
+
+    #[test]
+    fn to_size_none_falls_back() {
+        assert_eq!(cfg(None).to_size(), (DEFAULT_WIDTH, DEFAULT_HEIGHT));
+    }
+
+    #[test]
+    fn to_size_no_separator_falls_back() {
+        // Tripwire: missing 'x' separator must fall back (not panic/error).
+        assert_eq!(cfg(Some("640")).to_size(), (DEFAULT_WIDTH, DEFAULT_HEIGHT));
+    }
+
+    #[test]
+    fn to_size_non_numeric_falls_back() {
+        // Tripwire: non-numeric WxH parts must fall back.
+        assert_eq!(cfg(Some("axb")).to_size(), (DEFAULT_WIDTH, DEFAULT_HEIGHT));
+    }
+
+    #[test]
+    fn to_size_zero_dimension_falls_back() {
+        // Tripwire: a zero width or height must fall back (not produce a
+        // zero-sized surface that crashes the GPU init).
+        assert_eq!(
+            cfg(Some("0x480")).to_size(),
+            (DEFAULT_WIDTH, DEFAULT_HEIGHT)
+        );
+    }
+}

--- a/crates/aether-substrate-bundle/src/test_bench/mod.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mod.rs
@@ -16,6 +16,7 @@
 mod bench;
 pub mod cap;
 pub mod chassis;
+pub mod config;
 pub mod events;
 mod execute;
 #[cfg(test)]
@@ -26,4 +27,5 @@ pub mod test_helpers;
 pub use bench::{DEFAULT_HEIGHT, DEFAULT_WIDTH, TestBench, TestBenchBuilder, TestBenchError};
 pub use cap::{TestBenchCapConfig, TestBenchCapability};
 pub use chassis::{TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS};
+pub use config::RenderSizeConfig;
 pub use execute::{BenchOp, BenchOutput, ExecutionError, ExecutionResult};


### PR DESCRIPTION
Closes #2233.

## Summary

Replaces the test-bench binary's hand-rolled parse_size_env() (and its raw env::var read + clippy::disallowed_methods allow) with a RenderSizeConfig #[derive(Config)] struct resolved from_env() and lowered to (u32, u32) by to_size(), mirroring the single-field SettlementConfig template (ADR-0090). The WxH parse / fallback semantics are preserved verbatim and covered by to_size unit tests.

## Test plan

to_size unit tests (valid / none / no-separator / non-numeric / zero-dimension fallback). clippy -D warnings, nextest, and rustdoc strict-flags all clean. Validated via the attested path (scripts/attest.sh --publish); the verify check gates the merge in place of the skipped heavy jobs.

## Generated by

`/implement` — agent execution of scoped issue #2233.
