### PR TITLE
fix(repo): pre-push stamp hook checks the main checkout instead of the pushed worktree

### DIFF
--- a/.claude/hooks/check-pre-push.sh
+++ b/.claude/hooks/check-pre-push.sh
@@ -61,20 +61,56 @@ if ! git rev-parse --git-dir >/dev/null 2>&1; then
     exit 0
 fi
 
-head_sha=$(git rev-parse HEAD 2>/dev/null || true)
-[[ -z "$head_sha" ]] && exit 0
-
-stamp_file="$(git rev-parse --git-dir)/aether-preflight-passed"
-if [[ -f "$stamp_file" ]]; then
-    stamped_sha=$(awk '{print $1}' "$stamp_file" 2>/dev/null || echo)
-    if [[ "$stamped_sha" == "$head_sha" ]]; then
-        exit 0
-    fi
+# Resolve the pushed sha. Parse the command for an explicit refspec: after
+# "push", drop flags (-*) and the first bare positional (the remote, e.g.
+# "origin"); the next positional is the refspec — take its local side (left
+# of ":"). If no refspec positional is found, fall back to the resolved cwd's
+# HEAD. For `gh pr create` (no refspec) we also fall through to HEAD.
+local_ref=""
+if [[ "$command" =~ git[[:space:]]+push(.*) ]]; then
+    positional_count=0
+    for tok in ${BASH_REMATCH[1]}; do
+        case "$tok" in
+            -*) ;;
+            *)
+                positional_count=$((positional_count + 1))
+                if [[ $positional_count -eq 2 ]]; then
+                    local_ref="${tok%%:*}"
+                    break
+                fi
+                ;;
+        esac
+    done
 fi
 
-# No matching stamp — tell Claude to run the pre-flight.
+if [[ -n "$local_ref" ]]; then
+    pushed_sha=$(git rev-parse --verify "${local_ref}^{commit}" 2>/dev/null || true)
+else
+    pushed_sha=$(git rev-parse --verify HEAD 2>/dev/null || true)
+fi
+
+# Fail open when the pushed sha can't be resolved — defer to .githooks/pre-push.
+[[ -z "$pushed_sha" ]] && exit 0
+
+# Scan every worktree stamp: the common git dir's own stamp and every linked
+# worktree's per-worktree stamp. A match on any allows the push — the stamp
+# records the exact attested sha, so a cross-worktree scan cannot false-allow.
+common=$(git rev-parse --git-common-dir 2>/dev/null || true)
+[[ -z "$common" ]] && exit 0
+[[ "$common" = /* ]] || common="$(pwd)/$common"
+
+for stamp_file in "$common/aether-preflight-passed" "$common"/worktrees/*/aether-preflight-passed; do
+    if [[ -f "$stamp_file" ]]; then
+        stamped_sha=$(awk '{print $1}' "$stamp_file" 2>/dev/null || true)
+        if [[ "$stamped_sha" == "$pushed_sha" ]]; then
+            exit 0
+        fi
+    fi
+done
+
+# No matching stamp anywhere — tell Claude to run the pre-flight.
 {
-    echo "[claude pre-push] no pre-flight stamp for HEAD ($head_sha)."
+    echo "[claude pre-push] no pre-flight stamp for HEAD ($pushed_sha)."
     echo
     echo "Before pushing, run the local pre-flight:"
     echo

--- a/.claude/hooks/tests/run.sh
+++ b/.claude/hooks/tests/run.sh
@@ -134,6 +134,19 @@ expect "pre-push: stamped worktree HEAD, bare push via cwd -> allow" check-pre-p
 expect "pre-push: stamped worktree HEAD, cd-prefix form -> allow" check-pre-push.sh \
   "{\"cwd\":\"$SCAFFOLD\",\"tool_input\":{\"command\":\"cd $SESS_WT && git push\"}}" 0
 
+# (e) cross-checkout allow: stamp lives in the SESS worktree's git-dir, but the
+#     push command runs from the main checkout cwd and names the worktree's
+#     branch explicitly (#2247 fix). The hook must scan all worktree stamps and
+#     allow on match.
+echo "$SESS_HEAD" > "$SESS_STAMP"
+expect "pre-push: stamped worktree, main-cwd push by branch name -> allow" check-pre-push.sh \
+  "{\"cwd\":\"$SCAFFOLD\",\"tool_input\":{\"command\":\"git push origin SESS\"}}" 0
+
+# (f) same main-checkout cwd but no stamp anywhere — must block.
+rm -f "$SESS_STAMP"
+expect "pre-push: no stamp, main-cwd push by branch name -> block" check-pre-push.sh \
+  "{\"cwd\":\"$SCAFFOLD\",\"tool_input\":{\"command\":\"git push origin SESS\"}}" 2
+
 echo
 echo "$pass passed, $fail failed"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #2247.

## Summary

The Claude pre-push hook resolved `HEAD` against the main checkout (`CLAUDE_PROJECT_DIR`), so a pre-flight stamp written into a session/issue worktree was never found — false-blocking genuinely-validated worktree pushes. The hook now resolves the pushed sha from the push refspec (falling back to the resolved cwd's HEAD) and scans every linked worktree's stamp (`<common-dir>` + `worktrees/*`), failing open when the sha is unresolvable and blocking only on a resolved-but-unstamped sha.

## Test plan

`.claude/hooks/tests/run.sh` — 20 cases pass, including 2 new cross-checkout fixtures covering the main-cwd-pushes-worktree-branch case that previously false-blocked.

## Generated by

`/implement` — agent execution of scoped issue #2247.
