### PR TITLE
feat(workflow): land should re-attest after a rebase to preserve the attested fast-path

### DIFF
--- a/.claude/skills/land/SKILL.md
+++ b/.claude/skills/land/SKILL.md
@@ -83,12 +83,34 @@ Single-mode steps, executed once per PR (sweep mode iterates this per PR in orde
 2. **Predict conflict state.** Run [Conflict prediction and routing](#conflict-prediction-and-routing) for this PR's branch. If `dirty`, surface and abort — do not un-draft a dirty branch.
 
 3. **Auto-rebase a `behind` branch.** If the branch is `behind`:
+
+   Capture the pre-rebase head first — it is the attestation key for detection:
    ```bash
+   old=$(git rev-parse origin/<branch>)
    git fetch origin
    git rebase origin/main <branch>
+   ```
+   If the rebase produces conflicts, the branch becomes `dirty` — surface and abort.
+
+   **Re-attest on the attested path.** Before the force-push, detect whether this PR is on the attested path using the same signal `ci.yml` keys on — the presence of a `refs/attestations/<sha>` ref:
+   ```bash
+   git ls-remote --exit-code origin "refs/attestations/$old"
+   ```
+   When the ref is present (exit 0), the PR was on the attested fast-path; run `scripts/attest.sh --publish` against the post-rebase worktree HEAD to publish a fresh `refs/attestations/<new-sha>` before CI sees the new push:
+   ```bash
+   CARGO_TARGET_DIR=/mnt/dev/tmp/aether-attest-target \
+     TMPDIR=/mnt/dev/tmp \
+     scripts/attest.sh --publish
+   ```
+   This must complete before the force-push so the attestation ref lands before CI's `synchronize` event triggers the `changes` job's ref-keyed opt-in check. When the ref is absent (exit non-zero), the PR was not on the attested path — skip re-attest; the force-push triggers normal heavy CI for the new sha, which is the correct behavior.
+
+   If attest tooling is unavailable (`witness` / `sshpk-conv` / Docker / signing key — see `/implement`'s "Attested path (`--attest`)" precondition table), degrade gracefully: surface that the attested fast-path was dropped for this rebase and proceed with the force-push. The merge is never blocked — `scripts/attest-verify.sh` exits 0 (pass-through) when no attestation ref is present for the head sha, so the new sha runs full heavy CI and still merges. The bare cost is the lost fast-path.
+
+   Then force-push:
+   ```bash
    git push --force-with-lease origin <branch>
    ```
-   Then re-predict. If the rebase produces conflicts, the branch becomes `dirty` — surface and abort.
+   Then re-predict. In `--sweep` mode the recompute loop iterates this same rebase action after every sibling merge, so a branch that becomes `behind` after a sibling lands is re-attested by the same path — no separate sweep handling is needed.
 
 4. **Qodana sweep (only when `Qodana scan` is the sole red).** When gate-check found `Qodana scan` as the one failing required check, resolve it before un-drafting — run the [Qodana sweep](#qodana-sweep): fetch the findings from the `qodana-report` artifact, triage and fix them in the worktree, re-push, and wait for `CI pass` green. Only then proceed. Skip this step when the PR is already fully green; bail to the user (do not un-draft) when the sweep surfaces an artifact-missing / outside-the-diff / uncertain case.
 


### PR DESCRIPTION
Closes #2248.

## Summary

`/land`'s auto-rebase force-pushes a new head sha, orphaning the attestation bound to the old sha and losing the attested CI fast-path. Added a gated re-attest substep to the Landing sequence: capture the pre-rebase sha, detect the attested path via `git ls-remote refs/attestations/<old-sha>`, and re-run `scripts/attest.sh --publish` against the rebased HEAD before the force-push. Non-attested PRs pay nothing; missing attest tooling degrades gracefully. `--sweep`'s recompute loop inherits the behavior.

## Test plan

Skill-prose change to `.claude/skills/land/SKILL.md`; manual review of the re-attest substep against the surrounding `/land` sequence.

## Generated by

`/implement` — agent execution of scoped issue #2248.
