### PR TITLE
feat(workflow): run attest sweeps in parallel with a unique qodana container name per run

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -142,7 +142,7 @@ The sweep never auto-confirms and never dispatches the serial tail (push / PR / 
 - **Re-attest on each fix push:** every fix is a new head sha, so re-run `attest.sh --publish` before each Refine-loop push; skipping it degrades gracefully (heavy CI just runs for that sha).
 - **Qodana is local, not deferred:** attest runs and attests qodana, so the "sole `Qodana scan` red held for `/land`" branch does not apply — qodana is covered by the attestation and gated by `verify`.
 
-**Serial-tail only.** `--attest` lives in the in-session serial tail (where preflight, push, and the PR open already live) — it is **never** handed to a dispatched background agent, which must not push the attestation ref, consistent with the rule that push / PR / CI stay in-session. In hybrid background-agent / `--sweep` runs the parent owns the attest-and-publish step the same way it owns preflight and the push.
+**Serial-tail only.** `--attest` lives in the in-session serial tail (where preflight, push, and the PR open already live) — it is **never** handed to a dispatched background agent, which must not push the attestation ref, consistent with the rule that push / PR / CI stay in-session. In hybrid background-agent / `--sweep` runs the parent owns the attest-and-publish step the same way it owns preflight and the push. Across a sweep the parent may run these per-worktree `attest.sh --publish` calls **in parallel**, bounded only by the `aether-heavy` N=2 cargo semaphore; no qodana-singleton serialization is needed because `attest.sh` exports a unique `QODANA_CLI_CONTAINER_NAME` per run (derived from the `mktemp`-unique clone dir) and retries the rare `Only one instance of Qodana` transient exactly once at the witness-invocation level.
 
 ## Worktree setup
 

--- a/scripts/attest.sh
+++ b/scripts/attest.sh
@@ -145,6 +145,26 @@ trap cleanup EXIT
 OUTDIR="$(git rev-parse --git-dir)/aether-attestations/$HEAD_SHA"
 rm -rf "$OUTDIR"; mkdir -p "$OUTDIR"
 
+# run_witness runs one witness invocation for the given step, writing output to
+# $LOGDIR/$name.log and the signed attestation to $OUTDIR/$name.json. Returns
+# the witness exit code; does NOT reset the clone or die on failure, so the
+# caller can inspect the log (e.g. for a retriable transient) before deciding
+# what to do.
+# Run inside the clone (CWD = the real-`.git` checkout) so `-a git` binds the
+# step to the commit and records the tree status. `-a git` adds only the git
+# attestor — no environment attestor, so no machine/env PII. stdout/stderr go
+# to a tmpfs log whose path rides in the environment, never a `cmd` arg, so
+# the command-run attestor records no machine path while the command stays
+# visible.
+run_witness() {
+    local name="$1"; shift
+    ( cd "$RUN" && ATTEST_STEP_LOG="$LOGDIR/$name.log" \
+        witness run --step "$name" -a git \
+        --signer-file-key-path "$KEYDIR/key.pem" \
+        -o "$OUTDIR/$name.json" \
+        -- bash -c 'exec >"$ATTEST_STEP_LOG" 2>&1; "$@"; rc=$?; [ -n "${ATTEST_POST:-}" ] && eval "$ATTEST_POST"; exit "$rc"' attest "$@" )
+}
+
 # attest_step runs one canonical check (scripts/checks.sh) under witness.
 attest_step() {
     local name="$1"; shift
@@ -154,17 +174,7 @@ attest_step() {
     # clears stray untracked files such as qodana's .qodana/).
     git -C "$RUN" reset -q --hard HEAD
     git -C "$RUN" clean -qfd
-    # Run inside the clone (CWD = the real-`.git` checkout) so `-a git` binds the
-    # step to the commit and records the tree status. `-a git` adds only the git
-    # attestor — no environment attestor, so no machine/env PII. stdout/stderr go
-    # to a tmpfs log whose path rides in the environment, never a `cmd` arg, so
-    # the command-run attestor records no machine path while the command stays
-    # visible.
-    if ! ( cd "$RUN" && ATTEST_STEP_LOG="$LOGDIR/$name.log" \
-            witness run --step "$name" -a git \
-            --signer-file-key-path "$KEYDIR/key.pem" \
-            -o "$OUTDIR/$name.json" \
-            -- bash -c 'exec >"$ATTEST_STEP_LOG" 2>&1; "$@"; rc=$?; [ -n "${ATTEST_POST:-}" ] && eval "$ATTEST_POST"; exit "$rc"' attest "$@" ); then
+    if ! run_witness "$name" "$@"; then
         echo "[attest] step '$name' FAILED:" >&2
         tail -40 "$LOGDIR/$name.log" >&2 || true
         die "attestation aborted at step '$name'"
@@ -193,8 +203,39 @@ for step in $CANONICAL_STEPS; do
             # not products worth attesting, and the verifier reads only the
             # material/command-run/git attestations.
             export ATTEST_POST='docker run --rm -v "$PWD":/c alpine rm -rf /c/target /c/.qodana 2>/dev/null || true'
-            attest_step "$step" "${cmd[@]}" --diff-start "$QODANA_BASE" --cache-dir "$QODANA_CACHE_DIR" -u root
-            unset ATTEST_POST ;;
+            # Pin a unique container name derived from the unique run dir so
+            # concurrent attest runs on one host use distinct containers instead of
+            # colliding on the Qodana CLI's default path-hash. Belt-and-suspenders:
+            # the unique clone path already produces a distinct container name, but
+            # this makes the guarantee explicit and independent of that mktemp
+            # detail.
+            export QODANA_CLI_CONTAINER_NAME="qodana-attest-$(basename "$RUNDIR")"
+            echo "[attest] -> $step"
+            git -C "$RUN" reset -q --hard HEAD
+            git -C "$RUN" clean -qfd
+            if ! run_witness "$step" "${cmd[@]}" --diff-start "$QODANA_BASE" --cache-dir "$QODANA_CACHE_DIR" -u root; then
+                # Retry exactly once on the rare "Only one instance of Qodana"
+                # transient (a CLI startup race or EAP license cooldown). The
+                # retry runs at the witness-invocation level so the recorded
+                # command stays `qodana scan …` and the verifier's substring
+                # check is unaffected. Any other error, or a second failure,
+                # tails the log and dies.
+                if grep -q "Only one instance of Qodana" "$LOGDIR/$step.log" 2>/dev/null; then
+                    echo "[attest] qodana: 'Only one instance' transient, retrying once..." >&2
+                    git -C "$RUN" reset -q --hard HEAD
+                    git -C "$RUN" clean -qfd
+                    if ! run_witness "$step" "${cmd[@]}" --diff-start "$QODANA_BASE" --cache-dir "$QODANA_CACHE_DIR" -u root; then
+                        echo "[attest] step '$step' FAILED (after retry):" >&2
+                        tail -40 "$LOGDIR/$step.log" >&2 || true
+                        die "attestation aborted at step '$step'"
+                    fi
+                else
+                    echo "[attest] step '$step' FAILED:" >&2
+                    tail -40 "$LOGDIR/$step.log" >&2 || true
+                    die "attestation aborted at step '$step'"
+                fi
+            fi
+            unset ATTEST_POST QODANA_CLI_CONTAINER_NAME ;;
         *)      attest_step "$step" "${cmd[@]}" ;;
     esac
 done


### PR DESCRIPTION
Closes #2249.

## Summary

Made `scripts/attest.sh`'s qodana step parallel-safe: factored `run_witness` out of `attest_step` so the `qodana)` case can inspect exit status, set a per-run `QODANA_CLI_CONTAINER_NAME`, and added a single retry on the `Only one instance of Qodana` transient at the witness-invocation level — keeping the recorded `qodana scan` argv intact for the verifier's substring check. Documented in `/implement` that sweep-owned attests may run in parallel, bounded only by the `aether-heavy` N=2 semaphore.

## Test plan

`bash -n scripts/attest.sh`; confirmed the qodana invocation still literally contains `qodana scan` (the `attest-verify.sh` substring gate).

## Generated by

`/implement` — agent execution of scoped issue #2249.
