### PR TITLE
fix(workflow): attest.sh leaves an orphan qodana container when killed mid-run

### DIFF
--- a/scripts/attest.sh
+++ b/scripts/attest.sh
@@ -129,6 +129,11 @@ cleanup() {
         command -v shred >/dev/null 2>&1 && shred -u "$KEYDIR/key.pem" 2>/dev/null || rm -f "$KEYDIR/key.pem"
     fi
     rm -rf "$KEYDIR" "$LOGDIR" 2>/dev/null || true
+    # Stop + remove the run's qodana container (named from the unique RUNDIR in
+    # the qodana step) so a mid-run kill leaves no orphan. No-op if no container
+    # exists (killed outside the qodana step) or docker is unavailable; runs
+    # before the RUNDIR rm so the container's bind-mount is released first.
+    docker rm -f "qodana-attest-$(basename "$RUNDIR")" >/dev/null 2>&1 || true
     # The qodana step removes its own root-owned droppings, but on a non-rootless
     # Docker host a stray root-owned file could remain; fall back to a throwaway
     # root container (Docker is already required for the qodana step) so a failed


### PR DESCRIPTION
Closes #2263.

## Summary

When `scripts/attest.sh` is killed mid-run, its cleanup trap removed the `RUNDIR` scratch but left the qodana docker container running, orphaning a `qodana-attest-*` container that had to be `docker stop`ped by hand. This adds a guarded `docker rm -f` of the run's container to `cleanup()` before the `RUNDIR` removal (releasing the bind-mount so the fast-path rm succeeds), with the container name recomputed from `RUNDIR` rather than the step-local env var that is unset outside the qodana step. `rc=$?` is already captured before this line, so no exit-status masking.

Touches `scripts/attest.sh` (cleanup trap).

## Test plan

Shell-script change; `scripts/preflight.sh` short-circuits (CI/repo-config-only class), CI self-validates.

## Generated by

`/implement` — agent execution of [scoped issue #2263](https://github.com/iamacoffeepot/aether/issues/2263).
