### PR TITLE
chore(workflow): anchor copy-paste path examples in skill display strings

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -273,7 +273,8 @@ CI green — or green except a sole `Qodana scan` red held for `/land`:
    ✓ #<N> implemented and CI-green.
    Draft PR: <pr-url>
    Branch: <type>/issue-<N>-<slug>
-   Worktree: .claude/worktrees/issue-<N>  (clean up after merge with `git worktree remove`)
+   Worktree: .claude/worktrees/issue-<N>
+   Clean up after merge: git worktree remove "$(git rev-parse --show-toplevel)/.claude/worktrees/issue-<N>"
    Next: review the draft; un-draft (or tell me) to let native auto-merge land it on green. Phase → Done at merge.
    ```
 


### PR DESCRIPTION
Closes #2297.

## Summary

Implements the scoped plan for #2297 (workflow / skill-text). See the issue's Problem statement and Design notes for rationale.

## Test plan

Skill-text / docs change under `.claude/` + `*.md` only; `scripts/preflight.sh` short-circuits and the CI heavy jobs skip on the path filter. No Rust surface.

## Generated by

`/implement --sweep` — agent execution of scoped issue #2297.
