### PR TITLE
docs(test-fixtures): correct stale probe.rs path in a doc comment

### DIFF
--- a/crates/aether-test-fixtures/bundle/src/probe.rs
+++ b/crates/aether-test-fixtures/bundle/src/probe.rs
@@ -31,7 +31,7 @@
 //!   captured PNG.
 //!
 //! ADR-0090 c1: this fixture moved from `aether-test-fixture-probe`'s
-//! `src/lib.rs` to `aether-test-fixtures/examples/probe.rs`. The
+//! `src/lib.rs` to `aether-test-fixtures/bundle/src/probe.rs`. The
 //! actor source is unchanged; the shared `TickObserved` / `SetRender`
 //! kinds moved to the sibling lib so integration tests can import
 //! them without reaching into a cdylib.


### PR DESCRIPTION
Closes #2295.

## Summary

Corrects one stale path literal in the module doc comment in the test-fixtures bundle's `probe.rs` (it cited a historical `examples/probe.rs` location). One-line doc-comment fix, no behavior change.

## Test plan

Validated via `attest.sh --publish` (the heavy-CI surface path — the file lives under `crates/`): signed clippy/doc/test/desktop/qodana over the canonical check set; `verify` gates the merge.

## Generated by

`/implement --sweep --attest` — agent execution of scoped issue #2295.
