### PR TITLE
refactor(substrate-bundle): migrate chassis-owned config knobs onto the Config derive

### DIFF
--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -11,7 +11,6 @@
 //! minimal RPC-only chassis, test-bench drives a loopback), so the
 //! helper module stays scoped to the two full-stack chassis.
 
-use std::env;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -48,53 +47,23 @@ use aether_substrate::scheduler::SCHEDULER_KNOBS;
 use confique::Config as _;
 use confique::meta::Meta;
 
+use crate::desktop::driver::WindowConfigLayer;
+use crate::headless::driver::TickConfigLayer;
+
 /// Chassis-direct env knobs that aren't `#[derive(Config)]` fields —
-/// the bare-shadowed knobs the chassis bins read inline
-/// (`AETHER_WORKERS`, `AETHER_TICK_HZ`, `AETHER_RPC_PORT`, the desktop
-/// window knobs). Registered as [`KnobRecord`]s so e1's
-/// unknown-`AETHER_*` sweep doesn't flag them and e2's `--config`
-/// dump lists them. ADR-0090 §1/§4. The scheduler hot-path knobs are
-/// registered separately by unit b2's `SCHEDULER_KNOBS`.
-pub const CHASSIS_KNOBS: &[KnobRecord] = &[
-    KnobRecord {
-        env_key: "AETHER_WORKERS",
-        doc: "Worker-pool size override (unset → available_parallelism()-1, min 1).",
-        default: None,
-        kind: KnobKind::HandRegistered,
-    },
-    KnobRecord {
-        env_key: "AETHER_TICK_HZ",
-        doc: "Headless tick cadence in hertz.",
-        default: Some("60"),
-        kind: KnobKind::HandRegistered,
-    },
-    KnobRecord {
-        env_key: "AETHER_RPC_PORT",
-        doc: "aether.rpc.server bind port (desktop/headless skip the server when unset).",
-        default: None,
-        kind: KnobKind::HandRegistered,
-    },
-    KnobRecord {
-        env_key: "AETHER_BOOT_MANIFEST",
-        doc: "Path to a BundleManifest JSON of components to auto-load at boot \
-              (the runtime twin of the standalone-bundle compile-time pack; \
-              injected by the engines cap on a spawn_substrate carrying components).",
-        default: None,
-        kind: KnobKind::HandRegistered,
-    },
-    KnobRecord {
-        env_key: "AETHER_WINDOW_MODE",
-        doc: "Desktop window mode: windowed[:WxH] / fullscreen-borderless / exclusive:WxH@HZ.",
-        default: None,
-        kind: KnobKind::HandRegistered,
-    },
-    KnobRecord {
-        env_key: "AETHER_WINDOW_TITLE",
-        doc: "Desktop window title text.",
-        default: None,
-        kind: KnobKind::HandRegistered,
-    },
-];
+/// the remaining hand-registered knob the chassis bins read inline
+/// (`AETHER_RPC_PORT`). Registered as a [`KnobRecord`] so e1's
+/// unknown-`AETHER_*` sweep doesn't flag it and e2's `--config`
+/// dump lists it. ADR-0090 §1/§4. The scheduler hot-path knobs are
+/// registered separately by unit b2's `SCHEDULER_KNOBS`; the chassis
+/// boot / window / tick knobs are now covered by the derive-emitted
+/// `*Layer::META`s in [`chassis_registry`].
+pub const CHASSIS_KNOBS: &[KnobRecord] = &[KnobRecord {
+    env_key: "AETHER_RPC_PORT",
+    doc: "aether.rpc.server bind port (desktop/headless skip the server when unset).",
+    default: None,
+    kind: KnobKind::HandRegistered,
+}];
 
 /// Per-actor ring-capacity knob (issue 1990, ADR-0081 / ADR-0086). The
 /// `#[derive(aether_substrate::Config)]` emits the env-shaped
@@ -209,10 +178,86 @@ impl SettlementConfig {
     }
 }
 
+/// Default lifecycle advance timeout in milliseconds. The literal
+/// `default = 1000` on [`ChassisBootConfig`] must equal this;
+/// `chassis_boot_config_defaults_match` guards the pair.
+const DEFAULT_LIFECYCLE_ADVANCE_TIMEOUT_MS: u64 = 1_000;
+
+/// Shared boot knobs for the desktop and headless chassis
+/// (ADR-0090 §1/§2 applied to the chassis's own knobs). The
+/// `#[derive(aether_substrate::Config)]` emits the env-shaped
+/// `ChassisBootConfigLayer`, the clap-shaped `ChassisBootOverlay`,
+/// the `FromArgvThenEnv` impl, and the inherent `from_env` /
+/// `from_argv_then_env` / `try_*` shims — mirrors [`ActorRingConfig`].
+///
+/// `env_prefix = "AETHER"` joins the field env keys; explicit
+/// `cli_long` overrides pin the historical flag names so existing
+/// scripts and operators are unaffected.
+#[derive(Clone, Debug, aether_substrate::Config)]
+#[config(env_prefix = "AETHER", cli_prefix = "chassis")]
+pub struct ChassisBootConfig {
+    /// `AETHER_WORKERS=<n>` worker-pool size override (unset →
+    /// `available_parallelism()-1`, min 1). `Option<usize>` soft-parses
+    /// (unparseable → `None`, matching the old `parse_workers_env`
+    /// fallback). The 0→1 clamp logic lives in [`Self::to_workers`].
+    #[config(cli_long = "workers")]
+    pub workers: Option<usize>,
+    /// `AETHER_BOOT_MANIFEST=<path>` path to a `BundleManifest` JSON
+    /// of components to auto-load at boot (the runtime twin of the
+    /// standalone-bundle compile-time pack; injected by the engines cap
+    /// on a `spawn_substrate` carrying components). `Option<String>`
+    /// filters empty → `None`, exactly matching `boot_manifest_from_env`.
+    #[config(cli_long = "boot-manifest")]
+    pub boot_manifest: Option<String>,
+    /// `AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS=<ms>` force-complete deadline
+    /// (ms) for a pending lifecycle advance's `Settled` (issue 1048,
+    /// ADR-0082). Default [`DEFAULT_LIFECYCLE_ADVANCE_TIMEOUT_MS`] (1 s).
+    /// A garbage value hard-errors at boot (ADR-0090 §4 strict path),
+    /// replacing the old soft-warn fallback.
+    #[config(
+        env = "AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS",
+        cli_long = "lifecycle-advance-timeout-millis",
+        default = 1000
+    )]
+    pub lifecycle_advance_timeout_millis: u64,
+}
+
+impl Default for ChassisBootConfig {
+    fn default() -> Self {
+        Self {
+            workers: None,
+            boot_manifest: None,
+            lifecycle_advance_timeout_millis: DEFAULT_LIFECYCLE_ADVANCE_TIMEOUT_MS,
+        }
+    }
+}
+
+impl ChassisBootConfig {
+    /// Lower the resolved `workers` knob to the pool-size `Option<usize>`
+    /// the chassis builder's `with_workers` takes. The 0→1 clamp is the
+    /// only piece of logic this crate owns (the rest is pure field reads):
+    /// `0` is invalid for the pool (it requires at least one worker) and
+    /// users who set it almost certainly meant "any" (i.e. the system
+    /// default), so we clamp + warn rather than hard-error.
+    pub fn to_workers(&self) -> Option<usize> {
+        match self.workers {
+            None => None,
+            Some(0) => {
+                tracing::warn!(
+                    target: "aether_substrate::boot",
+                    "AETHER_WORKERS=0 — clamping to 1",
+                );
+                Some(1)
+            }
+            Some(n) => Some(n),
+        }
+    }
+}
+
 /// Assemble the chassis-wide [`KnownKeys`] set (ADR-0090 §4): every
-/// migrated `*Layer::META` (http / gemini / anthropic / audio / fs)
-/// plus the hand-registered chassis knobs ([`CHASSIS_KNOBS`])
-/// and scheduler hot-path knobs (b2's
+/// migrated `*Layer::META` (http / gemini / anthropic / audio / fs /
+/// chassis-boot / window / tick) plus the hand-registered chassis knob
+/// ([`CHASSIS_KNOBS`]) and scheduler hot-path knobs (b2's
 /// `aether_substrate::scheduler::SCHEDULER_KNOBS`). e1's
 /// [`validate_env`](aether_substrate::config::validate_env) sweeps the
 /// process env against this; e2's `--config` dump walks the same
@@ -243,6 +288,9 @@ fn chassis_registry() -> (&'static [&'static Meta], Vec<KnobRecord>) {
         &NamespaceRootsLayer::META,
         &ActorRingConfigLayer::META,
         &SettlementConfigLayer::META,
+        &ChassisBootConfigLayer::META,
+        &WindowConfigLayer::META,
+        &TickConfigLayer::META,
     ];
     let mut records: Vec<KnobRecord> = CHASSIS_KNOBS.to_vec();
     records.extend_from_slice(SCHEDULER_KNOBS);
@@ -267,12 +315,16 @@ pub fn chassis_config_dump() -> String {
 /// `Tick → Render → Present` graph from `frame_lifecycle_config()`
 /// below instead.
 ///
+/// `advance_timeout_millis` is the resolved value from
+/// [`ChassisBootConfig::lifecycle_advance_timeout_millis`] (or
+/// [`LifecycleConfig::ADVANCE_TIMEOUT_MS_DEFAULT`] for the test-bench).
+///
 /// # Panics
 /// Panics if the (compile-time-fixed) graph fails to build — it can't,
 /// the shape is structurally valid; the `expect` documents the
 /// invariant.
 #[must_use]
-pub fn tick_only_lifecycle_config() -> LifecycleConfig {
+pub fn tick_only_lifecycle_config(advance_timeout_millis: u64) -> LifecycleConfig {
     let graph = LifecycleGraphData::builder()
         .state::<Tick>()
         .next::<Tick>()
@@ -284,21 +336,8 @@ pub fn tick_only_lifecycle_config() -> LifecycleConfig {
     LifecycleConfig {
         graph,
         initial_subscribers: vec![],
-        advance_timeout_millis: lifecycle_advance_timeout_millis(),
+        advance_timeout_millis,
     }
-}
-
-/// Resolve the lifecycle force-complete deadline (ms) chassis-side
-/// (iamacoffeepot/aether#1048): the `AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS`
-/// override over the cap's default. Read here, in the chassis builder, so
-/// `LifecycleCapability::init` configures through `LifecycleConfig`
-/// rather than a naked env read.
-#[allow(clippy::disallowed_methods)] // chassis-level process tuning knob: the lifecycle force-complete deadline (#1048) is a per-process override resolved here into LifecycleConfig, not a cap-internal env read
-fn lifecycle_advance_timeout_millis() -> u64 {
-    env::var("AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS")
-        .ok()
-        .and_then(|s| s.parse::<u64>().ok())
-        .unwrap_or(LifecycleConfig::ADVANCE_TIMEOUT_MS_DEFAULT)
 }
 
 /// Build the three-stage frame lifecycle config the display-driving
@@ -327,12 +366,16 @@ fn lifecycle_advance_timeout_millis() -> u64 {
 /// [`tick_only_lifecycle_config`] (its render cap is a no-op, so a
 /// `Render` / `Present` stage would settle to no GPU work).
 ///
+/// `advance_timeout_millis` is the resolved value from
+/// [`ChassisBootConfig::lifecycle_advance_timeout_millis`] (or
+/// [`LifecycleConfig::ADVANCE_TIMEOUT_MS_DEFAULT`] for the test-bench).
+///
 /// # Panics
 /// Panics if the (compile-time-fixed) graph fails to build — it can't,
 /// the shape is structurally valid; the `expect` documents the
 /// invariant.
 #[must_use]
-pub fn frame_lifecycle_config() -> LifecycleConfig {
+pub fn frame_lifecycle_config(advance_timeout_millis: u64) -> LifecycleConfig {
     let graph = LifecycleGraphData::builder()
         .state::<Tick>()
         .next::<Render>()
@@ -348,7 +391,7 @@ pub fn frame_lifecycle_config() -> LifecycleConfig {
     LifecycleConfig {
         graph,
         initial_subscribers: vec![],
-        advance_timeout_millis: lifecycle_advance_timeout_millis(),
+        advance_timeout_millis,
     }
 }
 
@@ -476,73 +519,26 @@ pub fn maybe_with_http_server<C: Chassis>(
     builder.with_actor::<HttpServerCapability>(config)
 }
 
-/// Read `AETHER_BOOT_MANIFEST` into the optional boot-manifest path —
-/// a `BundleManifest` JSON of components to auto-load at boot. `None`
-/// when unset; the chassis then boots componentless (the bare-spawn /
-/// hub-load path). Mirrors [`crate::hub::rpc_port_from_env`]: the env
-/// read is the fallback for an absent `--boot-manifest` CLI flag.
-/// Shared by the desktop + headless chassis.
-#[must_use]
-// Chassis-level boot config: the env fallback for an absent --boot-manifest CLI
-// flag (argv > env > default at the process boundary), read in a chassis builder.
-#[allow(clippy::disallowed_methods)]
-pub fn boot_manifest_from_env() -> Option<String> {
-    env::var("AETHER_BOOT_MANIFEST")
-        .ok()
-        .filter(|p| !p.is_empty())
-}
-
-/// Parse `AETHER_WORKERS`. Unset → `None` (chassis falls back to
-/// [`aether_substrate::scheduler::PoolConfig::default`]); positive →
-/// `Some(n)`; `0` → `Some(1)` with a warn (the pool requires at least
-/// one worker); unparseable → `None` with a warn. Issue 745. Shared by
-/// the desktop + headless chassis, which both fall back to it when the
-/// CLI `--workers` flag is absent.
-// Chassis-level boot config: the env fallback for an absent --workers CLI flag
-// (argv > env > default at the process boundary), read in a chassis builder.
-#[allow(clippy::disallowed_methods)]
-pub fn parse_workers_env() -> Option<usize> {
-    let raw = env::var("AETHER_WORKERS").ok()?;
-    match raw.trim().parse::<usize>() {
-        Ok(0) => {
-            tracing::warn!(
-                target: "aether_substrate::boot",
-                value = %raw,
-                "AETHER_WORKERS=0 — clamping to 1",
-            );
-            Some(1)
-        }
-        Ok(n) => Some(n),
-        Err(e) => {
-            tracing::warn!(
-                target: "aether_substrate::boot",
-                value = %raw,
-                error = %e,
-                "AETHER_WORKERS unparseable — falling back to PoolConfig::default",
-            );
-            None
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::ActorRingConfig;
     use super::ActorRingConfigLayer;
+    use super::ChassisBootConfig;
+    use super::ChassisBootConfigLayer;
+    use super::DEFAULT_LIFECYCLE_ADVANCE_TIMEOUT_MS;
     use super::DEFAULT_SETTLEMENT_CAP_SECS;
     use super::SettlementConfig;
     use super::chassis_known_keys;
-    use super::parse_workers_env;
     use aether_actor::log::DEFAULT_RING_CAP;
     use aether_actor::trace_ring::{DEFAULT_TRACE_RING_CAP, DEFAULT_TRACE_RING_MAX_CAP};
+    use aether_capabilities::LifecycleConfig;
     use std::env;
     use std::sync::Mutex;
     use std::sync::PoisonError;
     use std::time::Duration;
 
     /// Process-wide guard around the `AETHER_ACTOR_*` ring env mutation,
-    /// distinct from `ENV_LOCK` so a ring test and a workers test don't
-    /// contend on one lock.
+    /// so ring tests serialise their set/remove pairs.
     static RING_ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
@@ -656,55 +652,59 @@ mod tests {
         assert!(known.contains("AETHER_SETTLEMENT_CAP_SECS"));
     }
 
-    /// Process-wide guard around `AETHER_WORKERS` env mutation —
-    /// `cargo test` parallelises within a binary, so each parser test
-    /// has to serialise its set/remove pair.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    fn with_env<R>(value: Option<&str>, f: impl FnOnce() -> R) -> R {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
-        // Safety: this test owns the AETHER_WORKERS slot for the
-        // duration of the closure via ENV_LOCK; no other thread inside
-        // the same test binary mutates it concurrently. Edition-2024
-        // marked the env mutators unsafe due to non-test signal-handler
-        // races that don't apply here.
-        unsafe {
-            match value {
-                Some(v) => env::set_var("AETHER_WORKERS", v),
-                None => env::remove_var("AETHER_WORKERS"),
-            }
-        }
-        let out = f();
-        // SAFETY: same justification as the prior block — this test
-        // still owns the `AETHER_WORKERS` slot via `ENV_LOCK`.
-        unsafe {
-            env::remove_var("AETHER_WORKERS");
-        }
-        out
+    #[test]
+    fn chassis_boot_config_defaults_match() {
+        use confique::Config as _;
+        // No `.env()` source: literal defaults only — env-free. The
+        // `default = 1000` literal must equal `LifecycleConfig::ADVANCE_TIMEOUT_MS_DEFAULT`
+        // so an unset knob reproduces the cap's const default.
+        // Tripwire: drifts when the producing const or the derive literal changes.
+        let _guard = RING_ENV_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
+        let layer = ChassisBootConfigLayer::builder()
+            .load()
+            .expect("defaults load");
+        assert_eq!(
+            layer.lifecycle_advance_timeout_millis, DEFAULT_LIFECYCLE_ADVANCE_TIMEOUT_MS,
+            "derive default must match DEFAULT_LIFECYCLE_ADVANCE_TIMEOUT_MS",
+        );
+        assert_eq!(
+            DEFAULT_LIFECYCLE_ADVANCE_TIMEOUT_MS,
+            LifecycleConfig::ADVANCE_TIMEOUT_MS_DEFAULT,
+            "DEFAULT_LIFECYCLE_ADVANCE_TIMEOUT_MS must match LifecycleConfig::ADVANCE_TIMEOUT_MS_DEFAULT",
+        );
+        let default = ChassisBootConfig::default();
+        assert_eq!(
+            default.lifecycle_advance_timeout_millis,
+            DEFAULT_LIFECYCLE_ADVANCE_TIMEOUT_MS,
+        );
+        assert_eq!(default.workers, None);
+        assert_eq!(default.boot_manifest, None);
     }
 
     #[test]
-    fn parse_workers_unset_returns_none() {
-        let parsed = with_env(None, parse_workers_env);
-        assert_eq!(parsed, None);
+    fn to_workers_none_returns_none() {
+        // No workers knob set — pool uses PoolConfig::default.
+        assert_eq!(ChassisBootConfig::default().to_workers(), None);
     }
 
     #[test]
-    fn parse_workers_positive_returns_some() {
-        let parsed = with_env(Some("4"), parse_workers_env);
-        assert_eq!(parsed, Some(4));
+    fn to_workers_positive_returns_some() {
+        // Positive value passes through unchanged.
+        let cfg = ChassisBootConfig {
+            workers: Some(4),
+            ..ChassisBootConfig::default()
+        };
+        assert_eq!(cfg.to_workers(), Some(4));
     }
 
     #[test]
-    fn parse_workers_zero_clamps_to_one() {
-        let parsed = with_env(Some("0"), parse_workers_env);
-        assert_eq!(parsed, Some(1));
-    }
-
-    #[test]
-    fn parse_workers_unparseable_returns_none() {
-        let parsed = with_env(Some("abc"), parse_workers_env);
-        assert_eq!(parsed, None);
+    fn to_workers_zero_clamps_to_one() {
+        // The 0→1 clamp: the only real logic this crate owns for the workers knob.
+        let cfg = ChassisBootConfig {
+            workers: Some(0),
+            ..ChassisBootConfig::default()
+        };
+        assert_eq!(cfg.to_workers(), Some(1));
     }
 
     #[test]
@@ -723,7 +723,7 @@ mod tests {
         use aether_data::Kind;
         use aether_kinds::{Present, Render, Shutdown, Tick};
 
-        let cfg = super::frame_lifecycle_config();
+        let cfg = super::frame_lifecycle_config(LifecycleConfig::ADVANCE_TIMEOUT_MS_DEFAULT);
         let graph_dbg = format!("{:?}", cfg.graph);
         let tick = format!("{:?}", <Tick as Kind>::ID);
         let render = format!("{:?}", <Render as Kind>::ID);
@@ -759,26 +759,46 @@ mod tests {
 
     #[test]
     fn chassis_known_keys_includes_scheduler_hot_path_knobs() {
-        // ADR-0090 unit b2: the six scheduler / lifecycle hot-path
-        // knobs join the known-key set, so e1's unknown-AETHER_ sweep
-        // doesn't flag them.
+        // ADR-0090 unit b2: the scheduler hot-path knobs join the
+        // known-key set, so e1's unknown-AETHER_ sweep doesn't flag them.
         let known = chassis_known_keys();
         for key in [
             "AETHER_LOCAL_STICKY_MAX",
             "AETHER_LOCAL_TIME_BUDGET_US",
             "AETHER_PEER_STEAL",
             "AETHER_HANDOFF_COST_NS",
-            "AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS",
         ] {
             assert!(known.contains(key), "chassis_known_keys missing {key}");
         }
     }
 
     #[test]
+    fn chassis_boot_config_keys_are_known() {
+        // Guards the three `ChassisBootConfigLayer::META` keys joining
+        // the chassis known-key set. `AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS`
+        // relocated here from the scheduler knob list (it was only
+        // registered scheduler-side because `aether-capabilities` couldn't
+        // hold it; the bundle can, so the workaround is gone).
+        let known = chassis_known_keys();
+        assert!(
+            known.contains("AETHER_WORKERS"),
+            "AETHER_WORKERS must be a known key",
+        );
+        assert!(
+            known.contains("AETHER_BOOT_MANIFEST"),
+            "AETHER_BOOT_MANIFEST must be a known key",
+        );
+        assert!(
+            known.contains("AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS"),
+            "AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS must be a known key",
+        );
+    }
+
+    #[test]
     fn chassis_known_keys_includes_a_representative_cap_key() {
         // The cap layer META walk lands the per-cap env keys (a
-        // representative from each migrated cap) plus the bare chassis
-        // knobs — the set is non-empty and covers more than scheduler.
+        // representative from each migrated cap) plus the derive-Config
+        // chassis knobs — the set is non-empty and covers more than scheduler.
         let known = chassis_known_keys();
         assert!(known.contains("AETHER_HTTP_DISABLE"));
         assert!(known.contains("AETHER_WORKERS"));
@@ -809,7 +829,7 @@ mod tests {
     fn chassis_config_dump_lists_a_knob_from_each_cap_plus_scheduler() {
         // ADR-0090 §4 `--config`: the dump walks the same registry as
         // the sweep, so it lists a representative knob from each cap, a
-        // bare chassis knob, and a scheduler hot-path knob — with a
+        // chassis-boot knob, and a scheduler hot-path knob — with a
         // header row.
         let dump = super::chassis_config_dump();
         assert!(dump.contains("KEY"));
@@ -817,7 +837,7 @@ mod tests {
         assert!(dump.contains("AETHER_HTTP_SERVER_BIND_ADDR")); // http server cap
         assert!(dump.contains("AETHER_GEMINI_TIMEOUT_MS")); // gemini cap
         assert!(dump.contains("AETHER_AUDIO_DISABLE")); // audio cap
-        assert!(dump.contains("AETHER_WORKERS")); // bare chassis knob
+        assert!(dump.contains("AETHER_WORKERS")); // chassis-boot derive-Config knob
         assert!(dump.contains("AETHER_LOCAL_STICKY_MAX")); // scheduler knob
     }
 
@@ -826,12 +846,10 @@ mod tests {
     /// derive-`Config` (`*Config::from_argv_then_env`), never a raw
     /// `env::var` read in a chassis builder. This is the shape #1761 put
     /// the http server on; the guard keeps a future cap from regressing to
-    /// presence-inference or a hand-rolled env read.
-    ///
-    /// Scoped to the cap *flag* keys on purpose — `AETHER_WINDOW_MODE` /
-    /// `AETHER_WINDOW_TITLE` are hand-parsed desktop boot overrides, not
-    /// derive-`Config` knobs, and are read via `env::var` by design, so a
-    /// blanket "no `env::var` of a known key" scan would false-positive.
+    /// presence-inference or a hand-rolled env read. The chassis window /
+    /// tick / boot knobs are now also derive-`Config` (`WindowConfig`,
+    /// `TickConfig`, `ChassisBootConfig`), so no raw `env::var` of any
+    /// known `AETHER_*` key should appear in the chassis builder sources.
     #[test]
     fn chassis_builders_resolve_cap_enable_flags_via_config() {
         // Enable / disable env keys owned by a derive-`Config` cap. Add a

--- a/crates/aether-substrate-bundle/src/cli.rs
+++ b/crates/aether-substrate-bundle/src/cli.rs
@@ -15,11 +15,12 @@
 //! `--http-disable=false` ⇒ `false`, absent ⇒ `None`), matching
 //! confique's native env-side bool deserialization.
 //!
-//! Chassis-wide knobs (`workers`, `tick_hz`, `window_mode`,
-//! `window_title`, `rpc_port`) live as plain `Option<T>` fields on the
-//! root `CommonOverlay` / `DesktopCli` / `HeadlessCli` and are
-//! ad-hoc-shadowed in the bin (`cli.workers.or_else(parse_workers_env)`).
-//! Unit e1 will lift them into their own confique layers.
+//! Chassis-wide knobs (`workers`, `boot_manifest`,
+//! `lifecycle_advance_timeout_millis`, `rpc_port`) and per-chassis knobs
+//! (`window_mode` / `window_title` for desktop, `tick_hz` for headless)
+//! are now fully migrated to `#[derive(aether_substrate::Config)]` overlays:
+//! `ChassisBootOverlay` / `WindowOverlay` / `TickOverlay`. Only
+//! `rpc_port` remains hand-written (its per-chassis default differs).
 //!
 //! ADR-0090 unit g (iamacoffeepot/aether#1264): the per-cap `*Overlay`
 //! structs now ride the `#[derive(aether_substrate::Config)]` next to
@@ -46,10 +47,14 @@ pub use aether_capabilities::gemini::GeminiOverlay;
 pub use aether_capabilities::http::HttpOverlay;
 pub use aether_capabilities::http::HttpServerOverlay;
 
+pub use crate::chassis_common::ChassisBootOverlay;
+pub use crate::desktop::driver::WindowOverlay;
+pub use crate::headless::driver::TickOverlay;
+
 /// Argv overlay shared by every full-stack chassis (desktop +
 /// headless). Captures every cap whose config layer is the same on
-/// both chassis. Per-chassis extras (audio for desktop, tick-hz +
-/// window-* for desktop) live on their own root struct.
+/// both chassis. Per-chassis extras (audio for desktop, tick / window
+/// for desktop) live on their own root struct.
 #[derive(Args, Debug, Default, Clone)]
 pub struct CommonOverlay {
     #[command(flatten)]
@@ -62,22 +67,16 @@ pub struct CommonOverlay {
     pub anthropic: AnthropicOverlay,
     #[command(flatten)]
     pub gemini: GeminiOverlay,
-
-    /// `AETHER_WORKERS` — worker pool size override.
-    #[arg(long)]
-    pub workers: Option<usize>,
+    /// Shared chassis boot knobs: `--workers`, `--boot-manifest`,
+    /// `--lifecycle-advance-timeout-millis`.
+    #[command(flatten)]
+    pub chassis_boot: ChassisBootOverlay,
 
     /// `AETHER_RPC_PORT` — `aether.rpc.server` bind port. Absent →
     /// chassis-specific default (desktop / headless skip the RPC
     /// server entirely; hub falls back to `DEFAULT_RPC_PORT`).
     #[arg(long = "rpc-port")]
     pub rpc_port: Option<u16>,
-
-    /// `AETHER_BOOT_MANIFEST` — path to a `BundleManifest` JSON of
-    /// components to auto-load at boot (the runtime twin of the
-    /// standalone-bundle compile-time pack). Absent → boot componentless.
-    #[arg(long = "boot-manifest")]
-    pub boot_manifest: Option<String>,
 }
 
 /// Desktop chassis CLI root.
@@ -91,14 +90,9 @@ pub struct DesktopCli {
     pub common: CommonOverlay,
     #[command(flatten)]
     pub audio: AudioOverlay,
-
-    /// `AETHER_WINDOW_MODE` — `windowed[:WxH]` /
-    /// `fullscreen-borderless` / `exclusive:WxH@HZ`.
-    #[arg(long = "window-mode")]
-    pub window_mode: Option<String>,
-    /// `AETHER_WINDOW_TITLE` — window title text.
-    #[arg(long = "window-title")]
-    pub window_title: Option<String>,
+    /// Desktop window knobs: `--window-mode`, `--window-title`.
+    #[command(flatten)]
+    pub window: WindowOverlay,
 
     /// Print every config knob (source-resolved value, default, doc)
     /// and exit before boot (ADR-0090 §4 discovery dump).
@@ -122,10 +116,9 @@ pub struct DesktopCli {
 pub struct HeadlessCli {
     #[command(flatten)]
     pub common: CommonOverlay,
-
-    /// `AETHER_TICK_HZ` — tick cadence in hertz (default 60).
-    #[arg(long = "tick-hz")]
-    pub tick_hz: Option<u32>,
+    /// Headless tick knob: `--tick-hz`.
+    #[command(flatten)]
+    pub tick: TickOverlay,
 
     /// Print every config knob (source-resolved value, default, doc)
     /// and exit before boot (ADR-0090 §4 discovery dump).

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -34,19 +34,17 @@ use aether_substrate::{Chassis, SubstrateBoot, capture::CaptureQueue};
 use winit::error::EventLoopError;
 use winit::event_loop::EventLoop;
 
-use super::driver::{DesktopDriverCapability, parse_window_mode_env};
+use super::driver::{DesktopDriverCapability, WindowConfig};
 use crate::autoload::{AutoloadComponent, autoload_mail, boot_manifest_autoload};
 use crate::chassis_common::{
-    ActorRingConfig, CommonBoot, boot_manifest_from_env, chassis_known_keys,
-    frame_lifecycle_config, maybe_with_http_server, maybe_with_rpc_server, parse_workers_env,
-    with_common_caps,
+    ActorRingConfig, ChassisBootConfig, CommonBoot, chassis_known_keys, frame_lifecycle_config,
+    maybe_with_http_server, maybe_with_rpc_server, with_common_caps,
 };
 use crate::cli::{CommonOverlay, DesktopCli};
 use crate::hub;
 use aether_substrate::config::{ConfigError, RingCapacities, validate_env};
 use aether_substrate::runtime::lifecycle::FatalAborter;
 use aether_substrate::runtime::lifecycle::OutboundFatalAborter;
-use std::env;
 use std::path::Path;
 use winit::event_loop::ControlFlow;
 
@@ -193,14 +191,19 @@ pub struct DesktopEnv {
     /// `RpcServerCapability` so existing chassis behavior is unchanged.
     pub rpc_addr: Option<SocketAddr>,
     /// Issue 745: optional worker-pool size override. Populated from
-    /// `AETHER_WORKERS`; `None` keeps `PoolConfig::default()` behavior
-    /// (`available_parallelism() - 1`, min 1).
+    /// `AETHER_WORKERS` / `--workers`; `None` keeps `PoolConfig::default()`
+    /// behavior (`available_parallelism() - 1`, min 1).
     pub workers: Option<usize>,
     /// Issue 1990: per-actor ring capacities resolved from the
     /// `ActorRingConfig` knob (`AETHER_ACTOR_LOG_RING_SIZE` /
     /// `AETHER_ACTOR_TRACE_RING_SIZE`). Default is
     /// [`RingCapacities::default`] (the `aether-actor` const caps).
     pub ring_caps: RingCapacities,
+    /// Force-complete deadline (ms) for a pending lifecycle advance's
+    /// `Settled` (issue 1048). Resolved from
+    /// `AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS` via `ChassisBootConfig`;
+    /// default [`aether_capabilities::LifecycleConfig::ADVANCE_TIMEOUT_MS_DEFAULT`].
+    pub lifecycle_advance_timeout_millis: u64,
     /// Components to auto-load on boot, in order. A bundled standalone build
     /// populates this so the game comes up with no hub; the normal desktop bin
     /// leaves it empty and loads components over the hub instead.
@@ -237,19 +240,13 @@ impl DesktopEnv {
     /// # Errors
     ///
     /// See [`Self::from_env`].
-    // Desktop chassis boot resolver (argv > env): AETHER_WINDOW_MODE /
-    // AETHER_WINDOW_TITLE are hand-parsed boot overrides read by design here at
-    // the process boundary (see chassis_common's cap-flag-convention guard) — not
-    // a cap config knob.
-    #[allow(clippy::disallowed_methods)]
     pub fn from_env_with_argv(cli: DesktopCli) -> Result<Self, DesktopBootError> {
         // ADR-0090 §4 (e1): warn on any unknown AETHER_ env var.
         validate_env(&chassis_known_keys())?;
         let DesktopCli {
             common,
             audio: audio_overlay,
-            window_mode: cli_window_mode,
-            window_title: cli_window_title,
+            window: window_overlay,
             // The bin handles `--config` / `--describe` (print + exit)
             // before this resolver runs; ignore them here.
             config: _,
@@ -261,16 +258,20 @@ impl DesktopEnv {
             fs,
             anthropic,
             gemini,
-            workers: cli_workers,
+            chassis_boot: chassis_boot_overlay,
             rpc_port: cli_rpc_port,
-            boot_manifest: cli_boot_manifest,
         } = common;
 
-        // Boot manifest: argv wins over `AETHER_BOOT_MANIFEST`. When set,
-        // the listed components' wasm + config are read into the autoload
-        // list `build_inner` drains into `aether.component.load`; an
-        // unreadable manifest aborts boot (ADR-0090 §4) via `ConfigError`.
-        let autoload = match cli_boot_manifest.or_else(boot_manifest_from_env) {
+        let chassis_boot =
+            ChassisBootConfig::try_from_argv_then_env(chassis_boot_overlay.into_layer())?;
+        let window_config = WindowConfig::from_argv_then_env(window_overlay.into_layer());
+
+        // Boot manifest: argv wins over `AETHER_BOOT_MANIFEST` (resolved
+        // through `ChassisBootConfig`). When set, the listed components'
+        // wasm + config are read into the autoload list `build_inner`
+        // drains into `aether.component.load`; an unreadable manifest
+        // aborts boot (ADR-0090 §4) via `ConfigError`.
+        let autoload = match chassis_boot.boot_manifest.clone() {
             Some(path) => boot_manifest_autoload(Path::new(&path))?,
             None => Vec::new(),
         };
@@ -291,43 +292,12 @@ impl DesktopEnv {
         let http_server = http_server_config.enabled.then_some(http_server_config);
         let audio = AudioConf::try_from_argv_then_env(audio_overlay.into_layer())?;
 
-        // Window mode: argv wins over `AETHER_WINDOW_MODE` env. The
-        // parser is shared (`parse_window_mode_env`); a bad argv string
-        // warn-logs and falls back to Windowed, matching the env path.
-        #[allow(clippy::option_if_let_else)]
-        let (boot_mode, boot_size) = if let Some(s) = cli_window_mode {
-            match parse_window_mode_env(&s) {
-                Ok(parsed) => parsed,
-                Err(e) => {
-                    tracing::warn!(
-                        target: "aether_substrate::boot",
-                        value = %s,
-                        error = %e,
-                        "--window-mode unparseable — falling back to Windowed",
-                    );
-                    (WindowMode::Windowed, None)
-                }
-            }
-        } else {
-            match env::var("AETHER_WINDOW_MODE") {
-                Ok(s) => match parse_window_mode_env(&s) {
-                    Ok(parsed) => parsed,
-                    Err(e) => {
-                        tracing::warn!(
-                            target: "aether_substrate::boot",
-                            value = %s,
-                            error = %e,
-                            "AETHER_WINDOW_MODE unparseable — falling back to Windowed",
-                        );
-                        (WindowMode::Windowed, None)
-                    }
-                },
-                Err(_) => (WindowMode::Windowed, None),
-            }
-        };
-        let boot_title = cli_window_title
-            .or_else(|| env::var("AETHER_WINDOW_TITLE").ok())
-            .unwrap_or_else(|| "aether".to_owned());
+        // Window mode and title: resolved through `WindowConfig` (argv > env >
+        // default). `to_boot_mode` delegates to `parse_window_mode_env` and
+        // soft-falls back to `Windowed` on a bad value; `to_boot_title` maps
+        // `None` / empty to `"aether"`.
+        let (boot_mode, boot_size) = window_config.to_boot_mode();
+        let boot_title = window_config.to_boot_title();
 
         let rpc_addr = {
             use std::net::{IpAddr, Ipv4Addr};
@@ -336,7 +306,8 @@ impl DesktopEnv {
                 .map(|p| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), p))
         };
 
-        let workers = cli_workers.or_else(parse_workers_env);
+        let workers = chassis_boot.to_workers();
+        let lifecycle_advance_timeout_millis = chassis_boot.lifecycle_advance_timeout_millis;
         // Issue 1990: resolve the per-actor ring capacities from
         // `AETHER_ACTOR_{LOG,TRACE}_RING_SIZE` (ADR-0090 §4 hard-error on
         // an unparseable known value, surfaced as `DesktopBootError::Config`).
@@ -357,6 +328,7 @@ impl DesktopEnv {
             rpc_addr,
             workers,
             ring_caps,
+            lifecycle_advance_timeout_millis,
             autoload,
         })
     }
@@ -387,6 +359,7 @@ impl DesktopChassis {
             rpc_addr,
             workers,
             ring_caps,
+            lifecycle_advance_timeout_millis,
             autoload,
         } = env;
 
@@ -472,7 +445,9 @@ impl DesktopChassis {
             .with_actor::<AudioCapability>(audio)
             .with_actor::<RenderCapability>(render_config)
             .with_actor::<UnsupportedTestBenchCapability>(())
-            .with_actor::<LifecycleCapability>(frame_lifecycle_config());
+            .with_actor::<LifecycleCapability>(frame_lifecycle_config(
+                lifecycle_advance_timeout_millis,
+            ));
         let builder = maybe_with_rpc_server(builder, rpc_addr, "aether-desktop");
         let builder = maybe_with_http_server(builder, http_server);
         let built = builder.driver(driver).build()?;

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -273,6 +273,64 @@ fn map_winit_keycode(k: KeyCode) -> Option<u32> {
     })
 }
 
+/// Desktop window boot knobs (ADR-0090 §1/§2 applied to the chassis's
+/// own window knobs). The `#[derive(aether_substrate::Config)]` emits
+/// the env-shaped `WindowConfigLayer`, the clap-shaped `WindowOverlay`,
+/// the `FromArgvThenEnv` impl, and the inherent `from_env` /
+/// `from_argv_then_env` shims — mirrors `ActorRingConfig` in `chassis_common`.
+///
+/// `env_prefix = "AETHER_WINDOW"` joins the field env keys — `mode` →
+/// `AETHER_WINDOW_MODE`, `title` → `AETHER_WINDOW_TITLE` — matching the
+/// historical key names exactly without per-field overrides. Both fields
+/// are `Option<String>` (soft: missing or empty → `None`).
+#[derive(Clone, Debug, Default, aether_substrate::Config)]
+#[config(env_prefix = "AETHER_WINDOW", cli_prefix = "window")]
+pub struct WindowConfig {
+    /// `AETHER_WINDOW_MODE=<value>` desktop window mode at boot:
+    /// `windowed[:WxH]` / `fullscreen-borderless` / `exclusive:WxH@HZ`.
+    /// Lowered via [`Self::to_boot_mode`] which delegates to
+    /// [`parse_window_mode_env`] and soft-falls back to `Windowed` on
+    /// a bad value (keeping the pre-migration behaviour).
+    pub mode: Option<String>,
+    /// `AETHER_WINDOW_TITLE=<text>` desktop window title at boot.
+    /// Lowered via [`Self::to_boot_title`]; empty / unset → `"aether"`.
+    pub title: Option<String>,
+}
+
+impl WindowConfig {
+    /// Lower `mode` to the `(WindowMode, Option<(u32, u32)>)` pair the
+    /// chassis threads into `DesktopEnv`. Delegates to
+    /// [`parse_window_mode_env`]; a bad value warn-logs and falls back
+    /// to `Windowed`, preserving the pre-migration soft-fallback
+    /// behaviour for `AETHER_WINDOW_MODE`.
+    #[must_use]
+    pub fn to_boot_mode(&self) -> (WindowMode, Option<(u32, u32)>) {
+        self.mode.as_ref().map_or(
+            (WindowMode::Windowed, None),
+            |s| match parse_window_mode_env(s) {
+                Ok(parsed) => parsed,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "aether_substrate::boot",
+                        value = %s,
+                        error = %e,
+                        "AETHER_WINDOW_MODE unparseable — falling back to Windowed",
+                    );
+                    (WindowMode::Windowed, None)
+                }
+            },
+        )
+    }
+
+    /// Lower `title` to the boot title string. `None` (unset or empty —
+    /// the derive's `Option<String>` filters empty → `None`) maps to
+    /// `"aether"`; a provided value passes through verbatim.
+    #[must_use]
+    pub fn to_boot_title(&self) -> String {
+        self.title.clone().unwrap_or_else(|| "aether".to_owned())
+    }
+}
+
 /// Parse `AETHER_WINDOW_MODE`. Grammar:
 ///   `windowed`              — default size
 ///   `windowed:WxH`          — windowed, `WxH` physical pixels
@@ -1492,6 +1550,22 @@ mod tests {
     // in fixtures — reference id derivation, not sibling-cap addressing.
     #![allow(clippy::disallowed_methods)]
     use super::*;
+
+    #[test]
+    fn to_boot_title_none_returns_default() {
+        // Unset title → "aether" default.
+        assert_eq!(WindowConfig::default().to_boot_title(), "aether");
+    }
+
+    #[test]
+    fn to_boot_title_some_returns_value() {
+        // Provided title passes through verbatim.
+        let cfg = WindowConfig {
+            mode: None,
+            title: Some("my game".to_owned()),
+        };
+        assert_eq!(cfg.to_boot_title(), "my game");
+    }
 
     #[test]
     fn parse_windowed_defaults() {

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -33,12 +33,11 @@ use aether_substrate::chassis::builder::{Builder, BuiltChassis};
 use aether_substrate::chassis::error::BootError;
 use aether_substrate::{Chassis, SubstrateBoot};
 
-use super::driver::{HeadlessTimerDriverCapability, parse_tick_hz_env};
+use super::driver::{HeadlessTimerDriverCapability, TickConfig};
 use crate::autoload::{AutoloadComponent, autoload_mail, boot_manifest_autoload};
 use crate::chassis_common::{
-    ActorRingConfig, CommonBoot, boot_manifest_from_env, chassis_known_keys,
-    maybe_with_http_server, maybe_with_rpc_server, parse_workers_env, tick_only_lifecycle_config,
-    with_common_caps,
+    ActorRingConfig, ChassisBootConfig, CommonBoot, chassis_known_keys, maybe_with_http_server,
+    maybe_with_rpc_server, tick_only_lifecycle_config, with_common_caps,
 };
 use crate::cli::{CommonOverlay, HeadlessCli};
 use crate::hub;
@@ -117,6 +116,10 @@ pub struct HeadlessEnv {
     /// `AETHER_ACTOR_TRACE_RING_SIZE`). Default is
     /// [`RingCapacities::default`] (the `aether-actor` const caps).
     pub ring_caps: RingCapacities,
+    /// `AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS` — timeout for one lifecycle
+    /// advance step (Tick) before the scheduler logs a slow-frame warning.
+    /// Resolved through `ChassisBootConfig`; default is 1000 ms.
+    pub lifecycle_advance_timeout_millis: u64,
     /// Components to auto-load on boot, in order. A bundled standalone build
     /// populates this so the components come up with no hub; the normal
     /// headless bin leaves it empty and loads components over the hub instead.
@@ -155,7 +158,7 @@ impl HeadlessEnv {
         validate_env(&chassis_known_keys())?;
         let HeadlessCli {
             common,
-            tick_hz: cli_tick_hz,
+            tick: tick_overlay,
             // The bin handles `--config` / `--describe` (print + exit)
             // before this resolver runs; ignore them here.
             config: _,
@@ -167,15 +170,20 @@ impl HeadlessEnv {
             fs,
             anthropic,
             gemini,
-            workers: cli_workers,
+            chassis_boot: chassis_boot_overlay,
             rpc_port: cli_rpc_port,
-            boot_manifest: cli_boot_manifest,
         } = common;
-        // Boot manifest: argv wins over `AETHER_BOOT_MANIFEST`. When set,
-        // the listed components' wasm + config are read into the autoload
-        // list `build_inner` drains into `aether.component.load`; an
-        // unreadable manifest aborts boot (ADR-0090 §4) via `ConfigError`.
-        let autoload = match cli_boot_manifest.or_else(boot_manifest_from_env) {
+
+        let chassis_boot =
+            ChassisBootConfig::try_from_argv_then_env(chassis_boot_overlay.into_layer())?;
+        let tick_config = TickConfig::try_from_argv_then_env(tick_overlay.into_layer())?;
+
+        // Boot manifest: argv wins over `AETHER_BOOT_MANIFEST` (resolved
+        // through `ChassisBootConfig`). When set, the listed components'
+        // wasm + config are read into the autoload list `build_inner`
+        // drains into `aether.component.load`; an unreadable manifest
+        // aborts boot (ADR-0090 §4) via `ConfigError`.
+        let autoload = match chassis_boot.boot_manifest.clone() {
             Some(path) => boot_manifest_autoload(Path::new(&path))?,
             None => Vec::new(),
         };
@@ -189,17 +197,14 @@ impl HeadlessEnv {
         let http_server_config =
             HttpServerConfig::try_from_argv_then_env(http_server_overlay.into_layer())?;
         let http_server = http_server_config.enabled.then_some(http_server_config);
-        // Chassis-wide knobs: argv-then-env shadow (ad-hoc, lifted to
-        // confique in unit e1). `cli.tick_hz` wins when `Some`, falls
-        // through to `AETHER_TICK_HZ` / default otherwise.
-        let tick_hz = cli_tick_hz
-            .filter(|hz| *hz > 0)
-            .unwrap_or_else(parse_tick_hz_env);
-        let tick_period = Duration::from_nanos(1_000_000_000 / u64::from(tick_hz));
+        // Tick cadence: resolved through `TickConfig` (argv > env > default).
+        // `nonzero` maps 0 to the default (60 Hz); a garbage value hard-errors.
+        let tick_period = tick_config.to_tick_period();
         let rpc_addr = cli_rpc_port
             .or_else(hub::rpc_port_from_env)
             .map(|p| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), p));
-        let workers = cli_workers.or_else(parse_workers_env);
+        let workers = chassis_boot.to_workers();
+        let lifecycle_advance_timeout_millis = chassis_boot.lifecycle_advance_timeout_millis;
         // Issue 1990: resolve the per-actor ring capacities from
         // `AETHER_ACTOR_{LOG,TRACE}_RING_SIZE` (ADR-0090 §4 hard-error on
         // an unparseable known value, surfaced as `ConfigError`).
@@ -214,6 +219,7 @@ impl HeadlessEnv {
             rpc_addr,
             workers,
             ring_caps,
+            lifecycle_advance_timeout_millis,
             autoload,
         })
     }
@@ -238,6 +244,7 @@ impl HeadlessChassis {
             rpc_addr,
             workers,
             ring_caps,
+            lifecycle_advance_timeout_millis,
             autoload,
         } = env;
 
@@ -333,7 +340,9 @@ impl HeadlessChassis {
             .with_actor::<HeadlessRenderCapability>(())
             .with_actor::<HeadlessWindowCapability>(())
             .with_actor::<UnsupportedTestBenchCapability>(())
-            .with_actor::<LifecycleCapability>(tick_only_lifecycle_config());
+            .with_actor::<LifecycleCapability>(tick_only_lifecycle_config(
+                lifecycle_advance_timeout_millis,
+            ));
         let builder = maybe_with_rpc_server(builder, rpc_addr, "aether-headless");
         let builder = maybe_with_http_server(builder, http_server);
         let built = builder.driver(driver).build()?;

--- a/crates/aether-substrate-bundle/src/headless/driver.rs
+++ b/crates/aether-substrate-bundle/src/headless/driver.rs
@@ -20,7 +20,6 @@
 //! (ADR-0049 §7), and the `index.bin` boot-snapshot — the headless
 //! analogue of desktop returning from winit's `event_loop.run_app`.
 
-use std::env;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::thread;
@@ -38,32 +37,41 @@ use crate::chassis_root::next_chassis_correlation;
 
 pub const DEFAULT_TICK_HZ: u32 = 60;
 
-/// Parse `AETHER_TICK_HZ`. Unset → [`DEFAULT_TICK_HZ`]; non-positive
-/// or unparseable → log + fall back to default. Tests bypass this by
-/// constructing `HeadlessEnv` with a chosen `tick_period` directly.
-#[must_use]
-// Headless chassis boot config: the AETHER_TICK_HZ tick-cadence override read at
-// the process boundary — not a cap config knob.
-#[allow(clippy::disallowed_methods)]
-pub fn parse_tick_hz_env() -> u32 {
-    // Match arms read cleaner than `map_or` here because the Ok arm
-    // is a chained iterator/closure that warn-logs on parse failure.
-    #[allow(clippy::option_if_let_else)]
-    match env::var("AETHER_TICK_HZ") {
-        Ok(s) => s
-            .trim()
-            .parse::<u32>()
-            .ok()
-            .filter(|&hz| hz > 0)
-            .unwrap_or_else(|| {
-                tracing::warn!(
-                    target: "aether_substrate::boot",
-                    value = %s,
-                    "AETHER_TICK_HZ unparseable or zero — falling back to default",
-                );
-                DEFAULT_TICK_HZ
-            }),
-        Err(_) => DEFAULT_TICK_HZ,
+/// Headless tick-cadence knob (ADR-0090 §1/§2 applied to the chassis's
+/// own tick knob). The `#[derive(aether_substrate::Config)]` emits the
+/// env-shaped `TickConfigLayer`, the clap-shaped `TickOverlay`, the
+/// `FromArgvThenEnv` impl, and the inherent `from_env` /
+/// `from_argv_then_env` / `try_*` shims — mirrors
+/// `ActorRingConfig` in `chassis_common`.
+///
+/// `env_prefix = "AETHER_TICK"` + field `hz` → `AETHER_TICK_HZ`, matching
+/// the historical key. The `nonzero` hint maps a resolved `0` to the
+/// default (60), reproducing the old `parse_tick_hz_env` `>0` filter. A
+/// garbage value hard-errors at boot (ADR-0090 §4 strict path) instead of
+/// the old soft-warn fallback.
+#[derive(Clone, Debug, aether_substrate::Config)]
+#[config(env_prefix = "AETHER_TICK", cli_prefix = "tick")]
+pub struct TickConfig {
+    /// `AETHER_TICK_HZ=<hz>` headless tick cadence in hertz (default 60).
+    /// `nonzero` maps `0` to the default so the timer always gets a valid
+    /// period; a garbage string hard-errors at boot.
+    #[config(default = 60, nonzero)]
+    pub hz: u32,
+}
+
+impl Default for TickConfig {
+    fn default() -> Self {
+        Self {
+            hz: DEFAULT_TICK_HZ,
+        }
+    }
+}
+
+impl TickConfig {
+    /// Lower to the tick [`Duration`] the chassis timer uses.
+    #[must_use]
+    pub fn to_tick_period(&self) -> Duration {
+        Duration::from_nanos(1_000_000_000 / u64::from(self.hz))
     }
 }
 
@@ -238,5 +246,39 @@ impl DriverRunning for HeadlessTimerRunning {
         // `boot` joins the scheduler workers — the teardown a bare
         // SIGKILL would skip.
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DEFAULT_TICK_HZ, TickConfig, TickConfigLayer};
+    use confique::Config as _;
+    use std::time::Duration;
+
+    #[test]
+    fn tick_config_defaults_match() {
+        // No `.env()` source: literal defaults only — env-free. The
+        // `default = 60` literal must equal `DEFAULT_TICK_HZ` so an
+        // unset knob reproduces the const default.
+        // Tripwire: drifts when `DEFAULT_TICK_HZ` or the derive literal changes.
+        let layer = TickConfigLayer::builder().load().expect("defaults load");
+        assert_eq!(
+            layer.hz, DEFAULT_TICK_HZ,
+            "derive default must match DEFAULT_TICK_HZ",
+        );
+        assert_eq!(TickConfig::default().hz, DEFAULT_TICK_HZ);
+    }
+
+    #[test]
+    fn to_tick_period_maps_hz_to_duration() {
+        // The only lowering logic this crate owns: hz → Duration.
+        assert_eq!(
+            TickConfig { hz: 60 }.to_tick_period(),
+            Duration::from_nanos(1_000_000_000 / 60),
+        );
+        assert_eq!(
+            TickConfig { hz: 120 }.to_tick_period(),
+            Duration::from_nanos(1_000_000_000 / 120),
+        );
     }
 }

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -32,6 +32,7 @@ use aether_substrate::{
 use super::cap::{TestBenchCapConfig, TestBenchCapability};
 use super::events::{ChassisEvent, EventSender};
 use crate::chassis_common::frame_lifecycle_config;
+use aether_capabilities::LifecycleConfig;
 use aether_substrate::mail::registry::MailDispatch;
 use std::io;
 
@@ -324,7 +325,9 @@ impl TestBenchChassis {
             .with_actor::<UiCapability>(())
             .with_actor::<HeadlessWindowCapability>(())
             .with_actor::<TestBenchCapability>(test_bench_cap_config)
-            .with_actor::<LifecycleCapability>(frame_lifecycle_config());
+            .with_actor::<LifecycleCapability>(frame_lifecycle_config(
+                LifecycleConfig::ADVANCE_TIMEOUT_MS_DEFAULT,
+            ));
         if let Some(roots) = io_roots {
             builder = builder.with_actor::<FsCapability>(roots);
         }

--- a/crates/aether-substrate-bundle/tests/headless_autoload.rs
+++ b/crates/aether-substrate-bundle/tests/headless_autoload.rs
@@ -83,6 +83,7 @@ mod tests {
             rpc_addr: None,
             workers: None,
             ring_caps: aether_substrate_bundle::RingCapacities::default(),
+            lifecycle_advance_timeout_millis: 1_000,
             autoload: decoded
                 .components
                 .into_iter()
@@ -157,6 +158,7 @@ mod tests {
             rpc_addr: None,
             workers: None,
             ring_caps: aether_substrate_bundle::RingCapacities::default(),
+            lifecycle_advance_timeout_millis: 1_000,
             autoload,
         };
 

--- a/crates/aether-substrate-bundle/tests/http_serving.rs
+++ b/crates/aether-substrate-bundle/tests/http_serving.rs
@@ -128,6 +128,7 @@ mod tests {
             rpc_addr: None,
             workers: None,
             ring_caps: aether_substrate_bundle::RingCapacities::default(),
+            lifecycle_advance_timeout_millis: 1_000,
             autoload: vec![AutoloadComponent {
                 wasm,
                 config: Vec::new(),

--- a/crates/aether-substrate/src/scheduler/mod.rs
+++ b/crates/aether-substrate/src/scheduler/mod.rs
@@ -50,35 +50,21 @@ pub use spin_park::{Acquired, SpinPark};
 pub use worker_deque::{burst_note_mail, pending_depth, time_budget};
 
 use crate::actor::native::blob_work::RECRUIT_KNOBS;
-use crate::config::{KnobKind, KnobRecord};
+use crate::config::KnobRecord;
 
-/// The lifecycle advance-timeout knob (ADR-0090 unit b2,
-/// iamacoffeepot/aether#1255). The `AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS`
-/// override is read directly in `LifecycleCapability::init`
-/// (`aether-capabilities`); the record lives here, substrate-side,
-/// because the config-discovery aggregation below
-/// ([`SCHEDULER_KNOBS`]) is substrate-side and `aether-capabilities`
-/// depends on `aether-substrate`, not the reverse.
-pub const LIFECYCLE_KNOBS: &[KnobRecord] = &[KnobRecord {
-    env_key: "AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS",
-    doc: "Deadline (ms) for a pending lifecycle advance's Settled before the next \
-          inbound advance force-completes it (degrades a wedged settlement pipeline \
-          into a visible stutter).",
-    default: Some("1000"),
-    kind: KnobKind::HandRegistered,
-}];
-
-/// The scheduler + lifecycle hot-path tuning knobs registered for
-/// config discovery (ADR-0090 unit b2, iamacoffeepot/aether#1255).
-/// Concatenates the four deque / keep-local-valve knobs
-/// (`worker_deque::DEQUE_KNOBS`), the handoff-cost calibration knob
-/// (`calibrate::CALIBRATE_KNOBS`), the lifecycle advance-timeout knob
-/// ([`LIFECYCLE_KNOBS`]), the three blob-recruiter knobs
-/// (`blob_work::RECRUIT_KNOBS`), and the spin-window knob
-/// (`pool::SPIN_KNOBS`) into the single slice e1's `chassis_known_keys()`
-/// folds into the known-key set and e2's `--config` dump renders. Pure
-/// `&'static` metadata — there is no change to any hot-path `OnceLock`
-/// read.
+/// The scheduler hot-path tuning knobs registered for config discovery
+/// (ADR-0090 unit b2, iamacoffeepot/aether#1255). Concatenates the four
+/// deque / keep-local-valve knobs (`worker_deque::DEQUE_KNOBS`), the
+/// handoff-cost calibration knob (`calibrate::CALIBRATE_KNOBS`), the three
+/// blob-recruiter knobs (`blob_work::RECRUIT_KNOBS`), and the spin-window
+/// knob (`pool::SPIN_KNOBS`) into the single slice e1's
+/// `chassis_known_keys()` folds into the known-key set and e2's `--config`
+/// dump renders. Pure `&'static` metadata — there is no change to any
+/// hot-path `OnceLock` read.
+///
+/// `AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS` moved to `ChassisBootConfigLayer`
+/// in `aether-substrate-bundle` (issue 2230): its record now rides the
+/// derive-emitted `META` rather than a hand-written `KnobRecord` here.
 ///
 /// The element-by-element array (rather than a runtime concat) keeps
 /// `SCHEDULER_KNOBS` a `const`: each record is still *defined* once in
@@ -89,7 +75,6 @@ pub const SCHEDULER_KNOBS: &[KnobRecord] = &[
     worker_deque::DEQUE_KNOBS[2],
     worker_deque::DEQUE_KNOBS[3],
     calibrate::CALIBRATE_KNOBS[0],
-    LIFECYCLE_KNOBS[0],
     RECRUIT_KNOBS[0],
     RECRUIT_KNOBS[1],
     RECRUIT_KNOBS[2],
@@ -110,7 +95,6 @@ mod knob_tests {
             "AETHER_PEER_STEAL",
             "AETHER_LOCAL_CHAIN_BACKSTOP",
             "AETHER_HANDOFF_COST_NS",
-            "AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS",
             "AETHER_BLOB_RECRUIT_MIN",
             "AETHER_BLOB_RECRUIT_MAX",
             "AETHER_WAKE_COST_NANOS",
@@ -121,7 +105,7 @@ mod knob_tests {
                 "SCHEDULER_KNOBS missing {expected}; has {keys:?}",
             );
         }
-        assert_eq!(SCHEDULER_KNOBS.len(), 10);
+        assert_eq!(SCHEDULER_KNOBS.len(), 9);
     }
 
     #[test]


### PR DESCRIPTION
Closes #2230.

## Summary

The four chassis (`desktop`, `headless`, `hub`, `test-bench`) still hand-parsed their own boot knobs from raw env/argv while every capability already resolves through `#[derive(aether_substrate::Config)]`. This migrates the chassis-owned knobs onto the same derive path, so resolution, `--config` discovery, unknown-key validation, and argv overrides all flow from one declaration per knob (ADR-0090 §1/§2/§4 applied to the chassis's own knobs).

- Adds `ChassisBootConfig` (`workers`, `boot_manifest`, `lifecycle_advance_timeout_millis`), `WindowConfig` (`mode`, `title`), and `TickConfig` (`hz`) — each mirroring `ActorRingConfig` / `EngineConfig`, with `to_*` lowerings for the domain shapes the chassis thread.
- Retires the inline parsers (`parse_workers_env`, `boot_manifest_from_env`, `lifecycle_advance_timeout_millis`, `parse_tick_hz_env`) and the raw `env::var("AETHER_WINDOW_TITLE")` read with its `#[allow(clippy::disallowed_methods)]`.
- Shrinks `CHASSIS_KNOBS` to its lone `AETHER_RPC_PORT` record; the migrated keys now come from the new `*Layer::META`s in `chassis_registry()`.
- Relocates the `LIFECYCLE_KNOBS` discovery record out of `aether-substrate`'s `SCHEDULER_KNOBS` (10 → 9) into `ChassisBootConfigLayer::META`, retiring the registered-scheduler-side workaround.

Per ADR-0090 §4, a garbage value on a now-typed numeric knob (`AETHER_TICK_HZ`, `AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS`) now hard-errors at boot rather than silently falling back — the same strict shift the http-server + engine caps already shipped. Valid-value resolution is unchanged.

The hub `HUB_KNOBS` and test-bench-size groups were spun off into #2232 and #2233 (both landed) and are out of scope here.

## Test plan

`to_workers` clamp/passthrough/none, the `to_boot_title` and `to_tick_period` lowerings, and the defaults-match tripwire guards (`default` literals == the `LifecycleConfig` / tick consts) are unit-tested; the amended `knob_tests` covers the `SCHEDULER_KNOBS` slice. Existing `chassis_known_keys_*` / `chassis_config_dump_*` and the FleetBench/TestBench boot paths exercise the threading end-to-end. Validated via `scripts/attest.sh --publish` (full canonical check set — clippy, workspace nextest, doc, wasm32 cross-build, qodana — signed).

## Generated by

`/implement --sweep --attest` — agent execution of scoped issue #2230.
