### PR TITLE
refactor(substrate-bundle): split the bridge test fixtures into identity and runtime modules

### DIFF
--- a/crates/aether-substrate-bundle/Cargo.toml
+++ b/crates/aether-substrate-bundle/Cargo.toml
@@ -64,6 +64,18 @@ path = "src/bin/perf-compare.rs"
 name = "aether-perf-plot"
 path = "src/bin/perf-plot.rs"
 
+# The `runtime` feature exists solely to drive the `#[actor]` split
+# path's hardcoded `feature = "runtime"` gate (the macro convention from
+# iamacoffeepot/aether#2311 / ADR-0122): a split cap's `NativeActor` /
+# `Lifecycle` / `NativeDispatch` impls compile only when this feature is
+# active. The bundle never builds to wasm and has no transport-only
+# consumer, so it is default-on. `aether-substrate` / `aether-capabilities`
+# already arrive with their own `runtime` / `native` defaults via the
+# non-`default-features = false` deps below, so no forwarding is needed.
+[features]
+default = ["runtime"]
+runtime = []
+
 [dependencies]
 aether-substrate = { path = "../aether-substrate", features = ["render"] }
 aether-capabilities = { path = "../aether-capabilities", features = ["render-native", "audio-native", "text-native", "ui-native"] }

--- a/crates/aether-substrate-bundle/src/test_bench/cap.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/cap.rs
@@ -19,89 +19,115 @@
 #![allow(clippy::needless_pass_by_value)]
 
 // Handler-signature kinds must be importable at file root because
-// `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
-// of the mod (always-on, outside the cfg gate).
+// `#[actor]` emits `impl HandlesKind<K> for X {}` markers against the
+// identity always-on, outside the `feature = "runtime"` gate.
 use aether_kinds::Advance;
 
-// `TestBenchCapConfig` lives inside the bridge mod (carries the
-// substrate-side `EventSender`); re-export at file root so callers
-// don't have to reach into `native::`.
-pub use native::TestBenchCapConfig;
+// `EventSender` is a bundle-local channel sender (not an
+// `aether_substrate` type), so the always-on config carries it at file
+// root.
+use crate::test_bench::events::EventSender;
 
-#[aether_actor::bridge(singleton)]
-mod native {
+/// Configuration for [`TestBenchCapability`]. Carries the
+/// `EventSender` the embedder loop reads on, so the handler can hand
+/// the embedder a request + reply target. Always-on at file root — it
+/// names no `aether_substrate` type.
+pub struct TestBenchCapConfig {
+    pub events: EventSender,
+}
+
+/// `aether.test_bench` cap **identity** (ADR-0122 identity/runtime
+/// split). A ZST carrying only the addressing — `Addressable`
+/// (`NAMESPACE`, `Resolver`), the per-handler `HandlesKind` markers, and
+/// the name-inventory entry, all emitted always-on by `#[actor]`. The
+/// state-bearing runtime (`TestBenchCapabilityState`, which holds the
+/// `aether_substrate`-typed `HubOutbound`) lives behind the one
+/// `feature = "runtime"` gate.
+pub struct TestBenchCapability;
+
+// The `#[actor]` / `#[handler]` attribute path stays always-on (the
+// macro divides what it emits). Everything that names an
+// `aether_substrate` type — the handler/init ctx, the runtime state —
+// lives in the `runtime` module below, gated once by `feature =
+// "runtime"`; the `#[actor] impl` reaches all of it through the single
+// `use runtime::*` glob.
+use aether_actor::actor;
+#[cfg(feature = "runtime")]
+#[allow(clippy::wildcard_imports)]
+use runtime::*;
+
+#[actor(singleton)]
+impl NativeActor for TestBenchCapability {
+    type State = TestBenchCapabilityState;
+
+    type Config = TestBenchCapConfig;
+
+    const NAMESPACE: &'static str = "aether.test_bench";
+
+    fn init(
+        config: TestBenchCapConfig,
+        ctx: &mut NativeInitCtx<'_>,
+    ) -> Result<TestBenchCapabilityState, BootError> {
+        let outbound = ctx.mailer().outbound().cloned().ok_or_else(|| {
+            BootError::Other(Box::new(io::Error::other(
+                "HubOutbound must be wired on Mailer before \
+                 TestBenchCapability::init (test-bench attaches its loopback before \
+                 the Builder chain)",
+            )))
+        })?;
+        Ok(TestBenchCapabilityState {
+            events: config.events,
+            outbound,
+        })
+    }
+
+    /// Push `ChassisEvent::Advance` onto the embedder loop. If the
+    /// receiver is gone (chassis shutting down) reply `Err` inline
+    /// so the caller doesn't hang.
+    #[handler]
+    fn on_advance(state: &mut Self::State, ctx: &mut NativeCtx<'_>, mail: Advance) {
+        let sender = ctx.reply_target();
+        if state
+            .events
+            .send(ChassisEvent::Advance {
+                reply_to: sender,
+                ticks: mail.ticks,
+            })
+            .is_err()
+        {
+            state.outbound.send_reply(
+                sender,
+                &AdvanceResult::Err {
+                    error: "test-bench chassis shutting down — advance aborted".to_owned(),
+                },
+            );
+        }
+    }
+}
+
+// The runtime half — the whole `aether_substrate`-typed surface (imports,
+// `TestBenchCapabilityState`) — gated once here. The `#[actor] impl`
+// above reaches it through the `use runtime::*` glob, so the items the
+// impl names are re-exported with `pub use`.
+#[cfg(feature = "runtime")]
+mod runtime {
+    use super::EventSender;
     use std::sync::Arc;
 
-    use aether_actor::actor;
-    use aether_kinds::AdvanceResult;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
-    use aether_substrate::mail::outbound::HubOutbound;
+    pub use crate::test_bench::events::ChassisEvent;
+    pub use aether_kinds::AdvanceResult;
+    pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    pub use aether_substrate::chassis::error::BootError;
+    pub use aether_substrate::mail::outbound::HubOutbound;
+    pub use std::io;
 
-    use super::Advance;
-    use crate::test_bench::events::{ChassisEvent, EventSender};
-    use std::io;
-
-    /// Configuration for [`TestBenchCapability`]. Carries the
-    /// `EventSender` the embedder loop reads on, so the handler can
-    /// hand the embedder a request + reply target.
-    pub struct TestBenchCapConfig {
-        pub events: EventSender,
-    }
-
-    /// `aether.test_bench` cap on the test-bench chassis. Handles
-    /// `Advance` by pushing onto the embedder event channel; the
-    /// embedder's `run_frame` loop runs the requested ticks then
-    /// replies via outbound.
-    pub struct TestBenchCapability {
-        events: EventSender,
-        outbound: Arc<HubOutbound>,
-    }
-
-    #[actor]
-    impl NativeActor for TestBenchCapability {
-        type Config = TestBenchCapConfig;
-
-        const NAMESPACE: &'static str = "aether.test_bench";
-
-        fn init(
-            config: TestBenchCapConfig,
-            ctx: &mut NativeInitCtx<'_>,
-        ) -> Result<Self, BootError> {
-            let outbound = ctx.mailer().outbound().cloned().ok_or_else(|| {
-                BootError::Other(Box::new(io::Error::other(
-                    "HubOutbound must be wired on Mailer before \
-                     TestBenchCapability::init (test-bench attaches its loopback before \
-                     the Builder chain)",
-                )))
-            })?;
-            Ok(Self {
-                events: config.events,
-                outbound,
-            })
-        }
-
-        /// Push `ChassisEvent::Advance` onto the embedder loop. If the
-        /// receiver is gone (chassis shutting down) reply `Err` inline
-        /// so the caller doesn't hang.
-        #[handler]
-        fn on_advance(&self, ctx: &mut NativeCtx<'_>, mail: Advance) {
-            let sender = ctx.reply_target();
-            if self
-                .events
-                .send(ChassisEvent::Advance {
-                    reply_to: sender,
-                    ticks: mail.ticks,
-                })
-                .is_err()
-            {
-                self.outbound.send_reply(
-                    sender,
-                    &AdvanceResult::Err {
-                        error: "test-bench chassis shutting down — advance aborted".to_owned(),
-                    },
-                );
-            }
-        }
+    /// `aether.test_bench` runtime state (ADR-0122 split). Holds the
+    /// embedder event channel the handler pushes onto plus the
+    /// `HubOutbound` it replies through when the channel is gone. The
+    /// dispatcher holds this as the cap's state; the addressing identity
+    /// is the distinct ZST `TestBenchCapability`.
+    pub struct TestBenchCapabilityState {
+        pub(super) events: EventSender,
+        pub(super) outbound: Arc<HubOutbound>,
     }
 }

--- a/crates/aether-substrate-bundle/tests/engines_cap.rs
+++ b/crates/aether-substrate-bundle/tests/engines_cap.rs
@@ -47,9 +47,9 @@ impl Chassis for TestChassis {
     }
 }
 
-// Reply sink: records the latest reply of each engines-cap reply kind
-// into shared cells. Lives at module root so the `#[bridge]` macro's
-// marker emission stays addressable.
+// Reply sink config: records the latest reply of each engines-cap reply
+// kind into shared cells. Lives at module root always-on (it names no
+// `aether_substrate` type) and is the cap's `Config`.
 #[derive(Clone, Default)]
 pub struct ReplyCells {
     pub list: Arc<Mutex<Option<ListEnginesResult>>>,
@@ -57,57 +57,82 @@ pub struct ReplyCells {
     pub terminate: Arc<Mutex<Option<TerminateEngineResult>>>,
 }
 
-#[aether_actor::bridge(singleton)]
-mod sink {
-    use super::{ListEnginesResult, ReplyCells, SpawnEngineResult, TerminateEngineResult};
-    use aether_actor::actor;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
+/// `aether.engine.test.reply_sink` **identity** (ADR-0122 identity/runtime
+/// split). A ZST carrying only the addressing — `Addressable` and the
+/// per-handler `HandlesKind` markers, emitted always-on by `#[actor]`. The
+/// state-bearing runtime (`ReplySinkState`) lives behind the bundle's one
+/// `feature = "runtime"` gate (default-on; the integration target rides it
+/// like the lib).
+pub struct ReplySink;
 
-    pub struct ReplySink {
-        cells: ReplyCells,
+// The `#[actor]` attribute path stays always-on (the macro divides what
+// it emits). The substrate-typed ctx imports + the runtime state live in
+// the gated `runtime` module below, reached through the `use runtime::*`
+// glob.
+use aether_actor::actor;
+#[cfg(feature = "runtime")]
+#[allow(clippy::wildcard_imports)]
+use runtime::*;
+
+#[actor(singleton)]
+impl NativeActor for ReplySink {
+    type State = ReplySinkState;
+    type Config = ReplyCells;
+    const NAMESPACE: &'static str = "aether.engine.test.reply_sink";
+
+    fn init(cells: ReplyCells, _ctx: &mut NativeInitCtx<'_>) -> Result<ReplySinkState, BootError> {
+        Ok(ReplySinkState { cells })
     }
 
-    #[actor]
-    impl NativeActor for ReplySink {
-        type Config = ReplyCells;
-        const NAMESPACE: &'static str = "aether.engine.test.reply_sink";
+    #[handler]
+    fn on_list_result(state: &mut Self::State, _ctx: &mut NativeCtx<'_>, reply: ListEnginesResult) {
+        *state
+            .cells
+            .list
+            .lock()
+            .expect("test setup: list cell mutex is never poisoned") = Some(reply);
+    }
 
-        fn init(cells: ReplyCells, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            Ok(Self { cells })
-        }
+    #[handler]
+    fn on_spawn_result(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        reply: SpawnEngineResult,
+    ) {
+        *state
+            .cells
+            .spawn
+            .lock()
+            .expect("test setup: spawn cell mutex is never poisoned") = Some(reply);
+    }
 
-        #[handler]
-        fn on_list_result(&mut self, _ctx: &mut NativeCtx<'_>, reply: ListEnginesResult) {
-            *self
-                .cells
-                .list
-                .lock()
-                .expect("test setup: list cell mutex is never poisoned") = Some(reply);
-        }
-
-        #[handler]
-        fn on_spawn_result(&mut self, _ctx: &mut NativeCtx<'_>, reply: SpawnEngineResult) {
-            *self
-                .cells
-                .spawn
-                .lock()
-                .expect("test setup: spawn cell mutex is never poisoned") = Some(reply);
-        }
-
-        #[handler]
-        fn on_terminate_result(&mut self, _ctx: &mut NativeCtx<'_>, reply: TerminateEngineResult) {
-            *self
-                .cells
-                .terminate
-                .lock()
-                .expect("test setup: terminate cell mutex is never poisoned") = Some(reply);
-        }
+    #[handler]
+    fn on_terminate_result(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        reply: TerminateEngineResult,
+    ) {
+        *state
+            .cells
+            .terminate
+            .lock()
+            .expect("test setup: terminate cell mutex is never poisoned") = Some(reply);
     }
 }
 
-// `ReplySink` is re-exported to this module root by the `#[bridge]`
-// macro — no explicit `use sink::ReplySink` needed.
+// The runtime half — the substrate-typed ctx imports + the state — gated
+// once here; the `#[actor] impl` above reaches it through the glob.
+#[cfg(feature = "runtime")]
+mod runtime {
+    use super::ReplyCells;
+    pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+
+    /// Runtime state for the reply sink: the shared cells the handlers
+    /// record into. The addressing identity is the ZST `ReplySink`.
+    pub struct ReplySinkState {
+        pub(super) cells: ReplyCells,
+    }
+}
 
 fn boot(engine_config: EngineConfig) -> (PassiveChassis<TestChassis>, Arc<Mailer>, ReplyCells) {
     let registry = Arc::new(Registry::new());


### PR DESCRIPTION
Closes #2328.

## Summary

Migrates the two `aether-substrate-bundle` `#[bridge(singleton)]` test fixtures — `TestBenchCapability` (`src/test_bench/cap.rs`) and `ReplySink` (`tests/engines_cap.rs`) — onto the ADR-0122 identity/runtime split (the `aether.fs` template), so the crate carries no `#[bridge]`. Both are light, so each uses an inline `#[cfg(feature = "runtime")] mod runtime`.

The load-bearing gate decision: `aether-substrate-bundle` had no `runtime` feature, so the split path's hardcoded `#[cfg(feature = "runtime")]` had nothing to key on. A default-on `runtime` feature is added to the crate's `Cargo.toml`; Cargo propagates it to all package targets, so the `tests/engines_cap.rs` integration target sees the gate under the default set with no separate wiring.

## Test plan

- `aether-heavy cargo clippy -p aether-substrate-bundle --all-targets -- -D warnings` clean.
- `aether-heavy cargo nextest run -p aether-substrate-bundle` — 208 passed (incl. the real-headless-substrate `engines_cap` spawn/list/terminate test and the test-bench scenarios).
- Validated via `scripts/attest.sh --publish`.

## Generated by

`/implement --sweep --attest` — agent execution of scoped issue #2328.
