### PR TITLE
refactor(capabilities): split the test-bench fixture into identity and runtime modules

### DIFF
--- a/crates/aether-capabilities/src/test_bench.rs
+++ b/crates/aether-capabilities/src/test_bench.rs
@@ -12,61 +12,94 @@
 //! `HeadlessWindowCapability`: same mailbox name across chassis,
 //! cap variants per chassis profile.
 
-// Handler-signature kinds must be importable at file root because
-// `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
-// of the mod (always-on, outside the cfg gate).
-use aether_kinds::Advance;
+// Handler-signature kinds resolve at file root — `#[actor]` emits the
+// `impl HandlesKind<K> for X {}` markers always-on against the identity,
+// outside the `feature = "runtime"` gate, so they reference these kinds
+// from here. `AdvanceResult` is used in the `on_advance` handler body
+// inside the `#[actor] impl` at file root.
+use aether_kinds::{Advance, AdvanceResult};
 
-#[aether_actor::bridge(singleton)]
-mod native {
-    use std::sync::Arc;
+use aether_actor::actor;
 
-    use aether_actor::actor;
-    use aether_kinds::AdvanceResult;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
-    use aether_substrate::mail::outbound::HubOutbound;
+// The `runtime` module is this cap's private runtime-half namespace; the
+// impl reaches all of it (state, ctx types, substrate imports) through
+// this single seam, so the glob is intentional rather than a dozen
+// one-line imports.
+#[cfg(feature = "runtime")]
+#[allow(clippy::wildcard_imports)]
+use runtime::*;
 
-    use super::Advance;
-    use std::io;
+/// Stub cap for `aether.test_bench` on chassis without test-bench drive
+/// (desktop, headless). Replies `AdvanceResult::Err` so MCP
+/// `aether.test_bench.advance` mail fails fast instead of hanging on a
+/// reply that never comes (ADR-0122 identity/runtime split).
+pub struct UnsupportedTestBenchCapability;
 
-    /// Stub cap for `aether.test_bench` on chassis without test-bench
-    /// drive (desktop, headless). Replies `AdvanceResult::Err` so MCP
-    /// `aether.test_bench.advance` mail fails fast instead of hanging
-    /// on a reply that never comes.
-    pub struct UnsupportedTestBenchCapability {
-        outbound: Arc<HubOutbound>,
+// The `#[actor]` / `#[handler]` attribute path stays always-on (the macro
+// divides what it emits). Everything that names an `aether_substrate` type —
+// the handler/init ctx, the runtime state — lives in the `runtime` module
+// below, gated once by `feature = "runtime"` and written cfg-free within;
+// the `#[actor] impl` reaches all of it through the single `use runtime::*`
+// glob above.
+#[actor(singleton)]
+impl NativeActor for UnsupportedTestBenchCapability {
+    /// Runtime state: the `HubOutbound` captured at `init` and used by
+    /// `on_advance` to send the fail-fast reply (ADR-0122 split).
+    type State = UnsupportedTestBenchCapabilityState;
+
+    type Config = ();
+
+    /// ADR-0074 Phase 4 chassis-owned mailbox.
+    const NAMESPACE: &'static str = "aether.test_bench";
+
+    fn init(
+        _config: (),
+        ctx: &mut NativeInitCtx<'_>,
+    ) -> Result<UnsupportedTestBenchCapabilityState, BootError> {
+        let outbound = ctx.mailer().outbound().cloned().ok_or_else(|| {
+            BootError::Other(Box::new(io::Error::other(
+                "HubOutbound must be wired on Mailer before \
+                 UnsupportedTestBenchCapability::init (chassis main connects the hub before \
+                 the Builder chain)",
+            )))
+        })?;
+        Ok(UnsupportedTestBenchCapabilityState { outbound })
     }
 
-    #[actor]
-    impl NativeActor for UnsupportedTestBenchCapability {
-        type Config = ();
+    /// Reply `Err` so MCP `advance` fails fast on chassis that don't
+    /// drive ticks via the embedder loop.
+    #[handler]
+    fn on_advance(state: &mut Self::State, ctx: &mut NativeCtx<'_>, _mail: Advance) {
+        state.outbound.send_reply(
+            ctx.reply_target(),
+            &AdvanceResult::Err {
+                error: "unsupported on this chassis — aether.test_bench.advance is \
+                    test-bench-only (ADR-0067)"
+                    .to_owned(),
+            },
+        );
+    }
+}
 
-        const NAMESPACE: &'static str = "aether.test_bench";
+// The runtime half — the whole `aether_substrate`-typed surface (imports,
+// `UnsupportedTestBenchCapabilityState`) — lives in this inline module, gated
+// once here. The `#[actor] impl` above reaches it through the `use runtime::*`
+// glob.
+#[cfg(feature = "runtime")]
+mod runtime {
+    pub use std::io;
+    pub use std::sync::Arc;
 
-        fn init(_config: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            let outbound = ctx.mailer().outbound().cloned().ok_or_else(|| {
-                BootError::Other(Box::new(io::Error::other(
-                    "HubOutbound must be wired on Mailer before \
-                     UnsupportedTestBenchCapability::init (chassis main connects the hub before \
-                     the Builder chain)",
-                )))
-            })?;
-            Ok(Self { outbound })
-        }
+    pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    pub use aether_substrate::chassis::error::BootError;
+    pub use aether_substrate::mail::outbound::HubOutbound;
 
-        /// Reply `Err` so MCP `advance` fails fast on chassis that don't
-        /// drive ticks via the embedder loop.
-        #[handler]
-        fn on_advance(&self, ctx: &mut NativeCtx<'_>, _mail: Advance) {
-            self.outbound.send_reply(
-                ctx.reply_target(),
-                &AdvanceResult::Err {
-                    error: "unsupported on this chassis — aether.test_bench.advance is \
-                        test-bench-only (ADR-0067)"
-                        .to_owned(),
-                },
-            );
-        }
+    /// Runtime state for `UnsupportedTestBenchCapability` (ADR-0122 split).
+    /// Holds the `HubOutbound` captured at `init`; read in `on_advance` to
+    /// send the fail-fast reply. Living in this private module keeps it
+    /// `pub`-enough to satisfy the `NativeActor::State` interface without
+    /// exposing it as crate-public API.
+    pub struct UnsupportedTestBenchCapabilityState {
+        pub(super) outbound: Arc<HubOutbound>,
     }
 }


### PR DESCRIPTION
Closes #2327.

## Summary

Migrates `UnsupportedTestBenchCapability` (`crates/aether-capabilities/src/test_bench.rs`, the desktop/headless fail-fast stub for `aether.test_bench.advance`) off `#[bridge(singleton)]` onto the ADR-0122 identity/runtime split (the `aether.fs` template). A ZST identity at module root, a top-level `#[actor(singleton)] impl NativeActor` with `type State = UnsupportedTestBenchCapabilityState` (holds the one `outbound: Arc<HubOutbound>` field), `on_advance` over `state: &mut Self::State`, and an inline `#[cfg(feature = "runtime")] mod runtime` (light cap) reached via `#[allow(clippy::wildcard_imports)] use runtime::*`.

## Test plan

- `aether-heavy cargo clippy -p aether-capabilities --all-targets -- -D warnings` clean.
- `aether-heavy cargo nextest run -p aether-capabilities` — 248 passed.
- Validated via `scripts/attest.sh --publish`.

## Generated by

`/implement --sweep --attest` — agent execution of scoped issue #2327.
