### PR TITLE
refactor(actor): support a native #[fallback] on the #[actor] split path

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -2624,7 +2624,7 @@ fn expand_native_actor_trait(item: ItemImpl, opts: &ActorOpts) -> syn::Result<To
                             "at most one #[fallback] method per native actor",
                         ));
                     }
-                    validate_native_fallback_sig(&f.sig)?;
+                    validate_native_fallback_sig(&f.sig, is_split)?;
                     f.attrs.remove(idx);
                     fallback = Some(NativeFallbackFn { method: f });
                 } else if f.sig.ident == "init" {
@@ -3413,7 +3413,7 @@ struct NativeFallbackFn {
 /// Issue 629 / Phase B: `&mut self` is now allowed alongside `&self`.
 /// The dispatcher owns the cap as `Box<A>` and calls the fallback
 /// through `&mut Box<A>`, so either receiver shape works.
-fn validate_native_fallback_sig(sig: &Signature) -> syn::Result<()> {
+fn validate_native_fallback_sig(sig: &Signature, is_split: bool) -> syn::Result<()> {
     if sig.inputs.len() != 3 {
         return Err(syn::Error::new_spanned(
             sig,
@@ -3422,7 +3422,22 @@ fn validate_native_fallback_sig(sig: &Signature) -> syn::Result<()> {
         ));
     }
     let first = &sig.inputs[0];
-    if !matches!(first, FnArg::Receiver(_)) {
+    if is_split {
+        // iamacoffeepot/aether#2338: a split `#[actor]` (`type State = …`) is on
+        // the identity, so the `#[fallback]` takes the runtime state explicitly —
+        // `(state: &mut Self::State, ctx: &mut NativeCtx<'_>, env: &Envelope)` —
+        // rather than a `self` receiver, mirroring the split `#[handler]` shape.
+        // `dispatch_fallback` already passes `__aether_state` and
+        // `rewrite_self_state_first_param` already rewrites the first param; this
+        // validator was the only gap.
+        if !matches!(first, FnArg::Typed(_)) {
+            return Err(syn::Error::new_spanned(
+                first,
+                "a split `#[actor]` (`type State = …`) #[fallback]'s first parameter \
+                 must be `state: &mut Self::State` (the runtime state), not a `self` receiver",
+            ));
+        }
+    } else if !matches!(first, FnArg::Receiver(_)) {
         return Err(syn::Error::new_spanned(
             first,
             "#[fallback] first parameter must be `&self` or `&mut self`",

--- a/crates/aether-actor-derive/tests/ui.rs
+++ b/crates/aether-actor-derive/tests/ui.rs
@@ -60,4 +60,8 @@ fn ui() {
     t.pass("tests/ui/accepts_actor_runtime_feature.rs");
     t.pass("tests/ui/accepts_actor_one_per.rs");
     t.compile_fail("tests/ui/rejects_actor_one_per_without_instanced.rs");
+    // iamacoffeepot/aether#2338: a split `#[actor]` may carry a `#[fallback]`
+    // whose first param is `state: &mut Self::State` (the validator gained the
+    // `is_split` branch the split `#[handler]` path already had).
+    t.pass("tests/ui/accepts_actor_split_fallback.rs");
 }

--- a/crates/aether-actor-derive/tests/ui/accepts_actor_split_fallback.rs
+++ b/crates/aether-actor-derive/tests/ui/accepts_actor_split_fallback.rs
@@ -1,0 +1,67 @@
+//! iamacoffeepot/aether#2338: a split `#[actor] impl NativeActor` (with
+//! `type State = …`) may carry a `#[fallback]` whose first parameter is
+//! `state: &mut Self::State` (the runtime state) rather than a `self` receiver,
+//! mirroring the split `#[handler]` shape. Before this, the fallback validator
+//! lacked the `is_split` branch and rejected the typed first param, blocking
+//! every split cap with a catch-all (rpc server, wasm trampoline, http server).
+//! The substrate-typed runtime impls cfg out in this fixture bin (no `runtime`
+//! feature), so the marker surface is what compiles; the point is that the
+//! macro accepts the split-fallback signature instead of erroring.
+
+use aether_actor::actor;
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.ping_fb")]
+struct Ping {
+    seq: u32,
+}
+
+pub struct FallbackCap;
+
+#[allow(dead_code)]
+struct FallbackCapState {
+    seen: u32,
+}
+
+#[actor(singleton)]
+impl aether_substrate::actor::native::NativeActor for FallbackCap {
+    type State = FallbackCapState;
+    type Config = ();
+
+    const NAMESPACE: &'static str = "test.fallback_cap";
+
+    fn init(
+        _config: (),
+        _ctx: &mut aether_substrate::actor::native::NativeInitCtx<'_>,
+    ) -> Result<FallbackCapState, aether_substrate::chassis::error::BootError> {
+        Ok(FallbackCapState { seen: 0 })
+    }
+
+    #[handler]
+    fn on_ping(
+        state: &mut Self::State,
+        _ctx: &mut aether_substrate::actor::native::NativeCtx<'_>,
+        _ping: Ping,
+    ) {
+        state.seen += 1;
+    }
+
+    #[fallback]
+    fn on_any(
+        state: &mut Self::State,
+        _ctx: &mut aether_substrate::actor::native::NativeCtx<'_>,
+        _env: &aether_substrate::actor::native::envelope::Envelope,
+    ) {
+        state.seen += 1;
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Closes #2338.

## Summary

The `#[actor]` split path (`impl NativeActor` with `type State = …`) rejected a `#[fallback]`: `validate_native_fallback_sig` had no `is_split` branch, so a `state: &mut Self::State` first parameter failed validation, and the `&mut self` form then mismatched the generated `dispatch_fallback` UFCS call over `&mut State`. `dispatch_fallback` already passes `__aether_state` and `rewrite_self_state_first_param` already rewrites the fallback's first param — the validator was the only gap.

Mirror the split `#[handler]` branch: when the impl declares `type State != Self`, accept a typed `state: &mut Self::State` first parameter. Additive — `&mut self` fallbacks on un-split caps are unchanged.

A second `#[actor]` split-path gap (after #2330's `one_per`/`runtime_feature`) the `aether.fs` demonstrator never exercised. Unblocks the split migration of every fallback-bearing cap: RpcServerCapability (#2322), HttpServerCapability (#2323), WasmTrampoline (#2326).

## Test plan

- New trybuild fixture `accepts_actor_split_fallback.rs` — a split `#[actor]` with a `#[fallback]` over `state: &mut Self::State` compiles (the substrate-typed runtime impls cfg out in the fixture bin, so the macro accepting the signature is the assertion).
- Validated via `scripts/attest.sh --publish`.

## Generated by

`/implement --attest` — agent execution of scoped issue #2338.
