### PR TITLE
refactor(actor): support a #[handler(task)] on the #[actor] split path

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -1699,7 +1699,7 @@ fn parse_handler_class(attr: &Attribute) -> syn::Result<HandlerClass> {
 /// are its generic arguments, not a kind. `is_borrow` is `true` when the
 /// parameter is `&TaskDone<…>` (the ADR-0109 opt-in for a macro-driven
 /// reply) versus the by-value `TaskDone<…>` self-resolve form.
-fn extract_task_handler_types(sig: &Signature) -> syn::Result<(Type, Type, bool)> {
+fn extract_task_handler_types(sig: &Signature, is_split: bool) -> syn::Result<(Type, Type, bool)> {
     if sig.inputs.len() != 3 {
         return Err(syn::Error::new_spanned(
             sig,
@@ -1709,7 +1709,22 @@ fn extract_task_handler_types(sig: &Signature) -> syn::Result<(Type, Type, bool)
         ));
     }
     let first = &sig.inputs[0];
-    if !matches!(first, FnArg::Receiver(_)) {
+    if is_split {
+        // iamacoffeepot/aether#2341: a split `#[actor]` (`type State = …`) is on
+        // the identity, so a `#[handler(task)]` takes the runtime state
+        // explicitly — `(state: &mut Self::State, ctx: &mut NativeCtx<'_>, done:
+        // TaskDone<O>)` — rather than a `self` receiver, mirroring the split
+        // `#[handler]` / `#[fallback]` shapes. `rewrite_self_state_first_param`
+        // is already applied to `task_handlers` and the task-completion dispatch
+        // arm already passes `__aether_state`; this validator was the last gap.
+        if !matches!(first, FnArg::Typed(_)) {
+            return Err(syn::Error::new_spanned(
+                first,
+                "a split `#[actor]` (`type State = …`) #[handler(task)]'s first parameter \
+                 must be `state: &mut Self::State` (the runtime state), not a `self` receiver",
+            ));
+        }
+    } else if !matches!(first, FnArg::Receiver(_)) {
         return Err(syn::Error::new_spanned(
             first,
             "#[handler(task)] first parameter must be `&self` or `&mut self`",
@@ -2607,7 +2622,7 @@ fn expand_native_actor_trait(item: ItemImpl, opts: &ActorOpts) -> syn::Result<To
                         }
                         HandlerVariant::Task => {
                             let (output_ty, context_ty, is_borrow) =
-                                extract_task_handler_types(&f.sig)?;
+                                extract_task_handler_types(&f.sig, is_split)?;
                             let mode = classify_task_reply_mode(&f.sig, is_borrow)?;
                             task_handlers.push(NativeActorTaskHandlerFn {
                                 method: f,

--- a/crates/aether-actor-derive/tests/ui.rs
+++ b/crates/aether-actor-derive/tests/ui.rs
@@ -64,4 +64,8 @@ fn ui() {
     // whose first param is `state: &mut Self::State` (the validator gained the
     // `is_split` branch the split `#[handler]` path already had).
     t.pass("tests/ui/accepts_actor_split_fallback.rs");
+    // iamacoffeepot/aether#2341: a split `#[actor]` may carry a `#[handler(task)]`
+    // whose first param is `state: &mut Self::State` (the last native-split
+    // first-param validator to gain the `is_split` branch).
+    t.pass("tests/ui/accepts_actor_split_task_handler.rs");
 }

--- a/crates/aether-actor-derive/tests/ui/accepts_actor_split_task_handler.rs
+++ b/crates/aether-actor-derive/tests/ui/accepts_actor_split_task_handler.rs
@@ -1,0 +1,73 @@
+//! iamacoffeepot/aether#2341: a split `#[actor] impl NativeActor` (with
+//! `type State = …`) may carry a `#[handler(task)]` (ADR-0093 deferred
+//! completion) whose first parameter is `state: &mut Self::State` rather than a
+//! `self` receiver, mirroring the split `#[handler]` / `#[fallback]` shapes.
+//! Before this, `extract_task_handler_types` lacked the `is_split` branch and
+//! rejected the typed first param, blocking every split cap with a task handler
+//! (rpc deferred-echo, gemini/anthropic). The substrate-typed runtime impls cfg
+//! out in this fixture bin (no `runtime` feature), so the assertion is that the
+//! macro accepts the split task-handler signature instead of erroring.
+
+use aether_actor::actor;
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.ping_task")]
+struct Ping {
+    seq: u32,
+}
+
+#[allow(dead_code)]
+struct Reply {
+    value: u32,
+}
+
+pub struct TaskCap;
+
+#[allow(dead_code)]
+struct TaskCapState {
+    seen: u32,
+}
+
+#[actor(singleton)]
+impl aether_substrate::actor::native::NativeActor for TaskCap {
+    type State = TaskCapState;
+    type Config = ();
+
+    const NAMESPACE: &'static str = "test.task_cap";
+
+    fn init(
+        _config: (),
+        _ctx: &mut aether_substrate::actor::native::NativeInitCtx<'_>,
+    ) -> Result<TaskCapState, aether_substrate::chassis::error::BootError> {
+        Ok(TaskCapState { seen: 0 })
+    }
+
+    #[handler]
+    fn on_ping(
+        state: &mut Self::State,
+        _ctx: &mut aether_substrate::actor::native::NativeCtx<'_>,
+        _ping: Ping,
+    ) {
+        state.seen += 1;
+    }
+
+    #[handler(task)]
+    fn on_ping_done(
+        state: &mut Self::State,
+        ctx: &mut aether_substrate::actor::native::NativeCtx<'_>,
+        done: aether_substrate::actor::native::TaskDone<Reply>,
+    ) {
+        done.resolve(ctx);
+        state.seen += 1;
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Closes #2341.

## Summary

The `#[actor]` split path rejected a `#[handler(task)]` (ADR-0093 deferred completion) whose first parameter is `state: &mut Self::State`: `extract_task_handler_types` had no `is_split` branch, so the macro expansion aborted (cascading into "NativeActor/Addressable not satisfied" downstream). `rewrite_self_state_first_param` is already applied to the task handlers and the task-completion dispatch arm already passes `__aether_state` — the validator was the last gap.

Mirror the split `#[handler]` / `#[fallback]` branches: when the impl declares `type State != Self`, accept a typed `state: &mut Self::State` first parameter. This completes the native-split first-param validation set (handler #2311, fallback #2338, task-handler — here). Additive; un-split `&self`/`&mut self` task handlers are unchanged. Unblocks every split cap with a `#[handler(task)]`: RpcServerCapability / test-echo (#2322), gemini + anthropic (#2325).

## Test plan

- New trybuild fixture `accepts_actor_split_task_handler.rs` — a split `#[actor]` with a `#[handler(task)]` over `state: &mut Self::State` compiles.
- Validated via `scripts/attest.sh --publish`.

## Generated by

`/implement --attest` — agent execution of scoped issue #2341.
