### PR TITLE
refactor(capabilities): split the core chassis caps into identity and runtime modules

### DIFF
--- a/crates/aether-capabilities/src/input/subscription.rs
+++ b/crates/aether-capabilities/src/input/subscription.rs
@@ -2,310 +2,355 @@
 
 use aether_kinds::{Key, KeyRelease, MouseButton, MouseMove, WindowSize};
 
+// Handler-signature kinds must be importable at module root because
+// `#[actor]` emits `impl HandlesKind<K> for InputCapability {}` markers
+// always-on, outside the `feature = "runtime"` gate. The reply kind
+// (`SubscribeInputResult`) is named only by the gated handler bodies, so
+// it rides the runtime gate below.
 use super::kinds::{
-    SubscribeInput, SubscribeInputResult, SubscribeInputSelf, UnsubscribeAll, UnsubscribeInput,
-    UnsubscribeInputSelf,
+    SubscribeInput, SubscribeInputSelf, UnsubscribeAll, UnsubscribeInput, UnsubscribeInputSelf,
 };
 
-#[aether_actor::bridge(singleton)]
-mod native {
-    use super::{
-        Key, KeyRelease, MouseButton, MouseMove, SubscribeInput, SubscribeInputResult,
-        SubscribeInputSelf, UnsubscribeAll, UnsubscribeInput, UnsubscribeInputSelf, WindowSize,
-    };
-    use aether_actor::actor;
-    use aether_data::{Kind, KindId};
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
-    use aether_substrate::mail::MailboxId;
-    use aether_substrate::mail::registry::{MailboxEntry, Registry};
-    use std::collections::{BTreeSet, HashMap};
-    use std::sync::Arc;
+use aether_actor::actor;
 
-    use crate::input::config::InputConfig;
+/// `aether.input` cap **identity** (ADR-0122 identity/runtime split). A
+/// ZST carrying only the addressing — the `Addressable` / `HandlesKind`
+/// markers and the name-inventory entry, all emitted always-on by
+/// `#[actor]`. The state-bearing runtime ([`InputCapabilityState`],
+/// holding the substrate registry handle + the subscriber table) lives
+/// behind the one `feature = "runtime"` gate, so a transport-only build
+/// never names it nor pulls `aether_substrate` through this cap.
+///
+/// The single owner of the input-stream subscriber table. Handles two
+/// classes of mail:
+///
+/// 1. **Subscribe / Unsubscribe / `UnsubscribeAll`** — mutates the
+///    table on the runtime state. Reply target: the original sender.
+///
+/// 2. **Input events** (`Key`, `KeyRelease`, `MouseMove`,
+///    `MouseButton`, `WindowSize`) — pushed by the chassis driver
+///    after each platform event; the cap fans out one mail per
+///    subscriber. Fire-and-forget; no reply.
+pub struct InputCapability;
 
-    /// `aether.input` cap. The single owner of the input-stream
-    /// subscriber table. Handles three classes of mail:
+// The reply kind rides the native gate (not `runtime`): the `#[actor]`
+// macro's ADR-0109 `HandlerEntry` inventory submission — emitted on every
+// native build, runtime or not — names each handler's reply kind `::ID`,
+// so a transport-only build must still see it. The rest of the runtime
+// half (the `aether_substrate`-typed imports, the state struct + its
+// `fanout` helper, and the shared mailbox-validation fn) sits behind the
+// one `feature = "runtime"` gate.
+#[cfg(not(target_arch = "wasm32"))]
+use super::kinds::SubscribeInputResult;
+#[cfg(feature = "runtime")]
+use aether_data::{Kind, KindId};
+#[cfg(feature = "runtime")]
+use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+#[cfg(feature = "runtime")]
+use aether_substrate::chassis::error::BootError;
+#[cfg(feature = "runtime")]
+use aether_substrate::mail::MailboxId;
+#[cfg(feature = "runtime")]
+use aether_substrate::mail::registry::{MailboxEntry, Registry};
+#[cfg(feature = "runtime")]
+use std::collections::{BTreeSet, HashMap};
+#[cfg(feature = "runtime")]
+use std::sync::Arc;
+
+#[cfg(feature = "runtime")]
+use crate::input::config::InputConfig;
+
+/// `aether.input` runtime state (ADR-0021). Owns the substrate registry
+/// handle (for subscriber-mailbox validation) plus the subscriber table
+/// keyed by stream kind id. Plain-field shape (ADR-0078) — single-
+/// threaded, every handler runs on the cap's dispatcher thread, so no
+/// `Mutex` / `Arc<Atomic*>` is needed. The addressing identity is the
+/// distinct ZST `InputCapability`.
+#[cfg(feature = "runtime")]
+pub struct InputCapabilityState {
+    registry: Arc<Registry>,
+    subscribers: HashMap<KindId, BTreeSet<MailboxId>>,
+}
+
+#[actor(singleton)]
+impl NativeActor for InputCapability {
+    /// The runtime state this identity boots into (ADR-0122 split): the
+    /// registry handle + subscriber table.
+    type State = InputCapabilityState;
+
+    type Config = InputConfig;
+    const NAMESPACE: &'static str = "aether.input";
+
+    fn init(
+        _config: InputConfig,
+        ctx: &mut NativeInitCtx<'_>,
+    ) -> Result<InputCapabilityState, BootError> {
+        let registry = Arc::clone(ctx.mailer().registry());
+        Ok(InputCapabilityState {
+            registry,
+            subscribers: HashMap::new(),
+        })
+    }
+
+    /// Subscribe a mailbox to an input stream (ADR-0021).
     ///
-    /// 1. **Subscribe / Unsubscribe / `UnsubscribeAll`** — mutates the
-    ///    table on `&mut self`. Reply target: the original sender.
+    /// # Agent
+    /// `SubscribeInput { kind, mailbox }`. Component mailboxes only —
+    /// sinks and dropped mailboxes are rejected.
+    #[handler]
+    fn on_subscribe(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        payload: SubscribeInput,
+    ) -> SubscribeInputResult {
+        match validate_subscriber_mailbox(&state.registry, payload.mailbox) {
+            Ok(()) => {
+                state
+                    .subscribers
+                    .entry(payload.kind)
+                    .or_default()
+                    .insert(payload.mailbox);
+                SubscribeInputResult::Ok
+            }
+            Err(error) => SubscribeInputResult::Err { error },
+        }
+    }
+
+    /// Subscribe the *sending* actor to an input stream (ADR-0021,
+    /// ADR-0083). Resolves the subscriber from the inbound
+    /// envelope's host-stamped `Source` via
+    /// [`source_mailbox`](NativeCtx::source_mailbox) rather than a
+    /// caller-supplied mailbox, so the subscriber cannot be forged
+    /// and the reflexive op is gated to in-process actors by
+    /// construction — a sender with no local mailbox (an external
+    /// session or another engine) gets an `Err` reply and is
+    /// subscribed to nothing. The host stamp already names a live
+    /// component mailbox, so no [`validate_subscriber_mailbox`]
+    /// pass is needed on this path.
     ///
-    /// 2. **Input events** (`Key`, `KeyRelease`, `MouseMove`,
-    ///    `MouseButton`, `WindowSize`) — pushed by the chassis driver
-    ///    after each platform event; the cap fans out one mail per
-    ///    subscriber. Fire-and-forget; no reply.
+    /// # Agent
+    /// `SubscribeInputSelf { kind }`.
+    #[handler]
+    fn on_subscribe_self(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        payload: SubscribeInputSelf,
+    ) -> SubscribeInputResult {
+        match ctx.source_mailbox() {
+            Some(mailbox) => {
+                state
+                    .subscribers
+                    .entry(payload.kind)
+                    .or_default()
+                    .insert(mailbox);
+                SubscribeInputResult::Ok
+            }
+            None => SubscribeInputResult::Err {
+                error: "aether.input.subscribe_self requires a local component sender; an \
+                        external session or remote engine must use aether.input.subscribe \
+                        with an explicit mailbox"
+                    .to_string(),
+            },
+        }
+    }
+
+    /// Unsubscribe a mailbox from an input stream (ADR-0021).
     ///
-    /// Plain-field shape (ADR-0078) — single-threaded, every handler
-    /// runs on the cap's dispatcher thread.
-    pub struct InputCapability {
-        registry: Arc<Registry>,
-        subscribers: HashMap<KindId, BTreeSet<MailboxId>>,
-    }
-
-    #[actor]
-    impl NativeActor for InputCapability {
-        type Config = InputConfig;
-        const NAMESPACE: &'static str = "aether.input";
-
-        fn init(_config: InputConfig, ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            let registry = Arc::clone(ctx.mailer().registry());
-            Ok(Self {
-                registry,
-                subscribers: HashMap::new(),
-            })
-        }
-
-        /// Subscribe a mailbox to an input stream (ADR-0021).
-        ///
-        /// # Agent
-        /// `SubscribeInput { kind, mailbox }`. Component mailboxes only —
-        /// sinks and dropped mailboxes are rejected.
-        #[handler]
-        fn on_subscribe(
-            &mut self,
-            _ctx: &mut NativeCtx<'_>,
-            payload: SubscribeInput,
-        ) -> SubscribeInputResult {
-            match validate_subscriber_mailbox(&self.registry, payload.mailbox) {
-                Ok(()) => {
-                    self.subscribers
-                        .entry(payload.kind)
-                        .or_default()
-                        .insert(payload.mailbox);
-                    SubscribeInputResult::Ok
+    /// # Agent
+    /// `UnsubscribeInput { kind, mailbox }`. Idempotent on
+    /// "not currently subscribed"; rejects unknown / sink mailboxes.
+    #[handler]
+    fn on_unsubscribe(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        payload: UnsubscribeInput,
+    ) -> SubscribeInputResult {
+        match validate_subscriber_mailbox(&state.registry, payload.mailbox) {
+            Ok(()) => {
+                if let Some(set) = state.subscribers.get_mut(&payload.kind) {
+                    set.remove(&payload.mailbox);
                 }
-                Err(error) => SubscribeInputResult::Err { error },
+                SubscribeInputResult::Ok
             }
-        }
-
-        /// Subscribe the *sending* actor to an input stream (ADR-0021,
-        /// ADR-0083). Resolves the subscriber from the inbound
-        /// envelope's host-stamped `Source` via
-        /// [`source_mailbox`](NativeCtx::source_mailbox) rather than a
-        /// caller-supplied mailbox, so the subscriber cannot be forged
-        /// and the reflexive op is gated to in-process actors by
-        /// construction — a sender with no local mailbox (an external
-        /// session or another engine) gets an `Err` reply and is
-        /// subscribed to nothing. The host stamp already names a live
-        /// component mailbox, so no [`validate_subscriber_mailbox`]
-        /// pass is needed on this path.
-        ///
-        /// # Agent
-        /// `SubscribeInputSelf { kind }`.
-        #[handler]
-        fn on_subscribe_self(
-            &mut self,
-            ctx: &mut NativeCtx<'_>,
-            payload: SubscribeInputSelf,
-        ) -> SubscribeInputResult {
-            match ctx.source_mailbox() {
-                Some(mailbox) => {
-                    self.subscribers
-                        .entry(payload.kind)
-                        .or_default()
-                        .insert(mailbox);
-                    SubscribeInputResult::Ok
-                }
-                None => SubscribeInputResult::Err {
-                    error: "aether.input.subscribe_self requires a local component sender; an \
-                            external session or remote engine must use aether.input.subscribe \
-                            with an explicit mailbox"
-                        .to_string(),
-                },
-            }
-        }
-
-        /// Unsubscribe a mailbox from an input stream (ADR-0021).
-        ///
-        /// # Agent
-        /// `UnsubscribeInput { kind, mailbox }`. Idempotent on
-        /// "not currently subscribed"; rejects unknown / sink mailboxes.
-        #[handler]
-        fn on_unsubscribe(
-            &mut self,
-            _ctx: &mut NativeCtx<'_>,
-            payload: UnsubscribeInput,
-        ) -> SubscribeInputResult {
-            match validate_subscriber_mailbox(&self.registry, payload.mailbox) {
-                Ok(()) => {
-                    if let Some(set) = self.subscribers.get_mut(&payload.kind) {
-                        set.remove(&payload.mailbox);
-                    }
-                    SubscribeInputResult::Ok
-                }
-                Err(error) => SubscribeInputResult::Err { error },
-            }
-        }
-
-        /// Unsubscribe the *sending* actor from an input stream
-        /// (ADR-0021, ADR-0083). Resolves the subscriber from the
-        /// inbound's host-stamped `Source`, mirroring
-        /// [`Self::on_subscribe_self`]. `None` (no local sender) replies
-        /// `Err`. Idempotent on "not currently subscribed."
-        ///
-        /// # Agent
-        /// `UnsubscribeInputSelf { kind }`.
-        #[handler]
-        fn on_unsubscribe_self(
-            &mut self,
-            ctx: &mut NativeCtx<'_>,
-            payload: UnsubscribeInputSelf,
-        ) -> SubscribeInputResult {
-            match ctx.source_mailbox() {
-                Some(mailbox) => {
-                    if let Some(set) = self.subscribers.get_mut(&payload.kind) {
-                        set.remove(&mailbox);
-                    }
-                    SubscribeInputResult::Ok
-                }
-                None => SubscribeInputResult::Err {
-                    error: "aether.input.unsubscribe_self requires a local component sender; an \
-                            external session or remote engine must use aether.input.unsubscribe \
-                            with an explicit mailbox"
-                        .to_string(),
-                },
-            }
-        }
-
-        /// Remove `mailbox` from every input stream's subscriber set.
-        /// Issued by `ComponentHostCapability` on `DropComponent` so a
-        /// dropped trampoline doesn't keep receiving fan-out mail.
-        /// No mailbox-validation: the trampoline's mailbox is already
-        /// torn down by the time this fires; we accept any id and
-        /// purge it from the table.
-        ///
-        /// # Agent
-        /// `UnsubscribeAll { mailbox }`. Idempotent.
-        #[handler]
-        fn on_unsubscribe_all(&mut self, _ctx: &mut NativeCtx<'_>, payload: UnsubscribeAll) {
-            for set in self.subscribers.values_mut() {
-                set.remove(&payload.mailbox);
-            }
-        }
-
-        /// Key-press fan-out.
-        #[handler]
-        fn on_key(&mut self, ctx: &mut NativeCtx<'_>, payload: Key) {
-            self.fanout(ctx, &payload);
-        }
-
-        /// Key-release fan-out (paired with [`Key`] for hold-to-act
-        /// semantics).
-        #[handler]
-        fn on_key_release(&mut self, ctx: &mut NativeCtx<'_>, payload: KeyRelease) {
-            self.fanout(ctx, &payload);
-        }
-
-        /// Cursor-move fan-out.
-        #[handler]
-        fn on_mouse_move(&mut self, ctx: &mut NativeCtx<'_>, payload: MouseMove) {
-            self.fanout(ctx, &payload);
-        }
-
-        /// Mouse-press fan-out. Empty payload.
-        #[handler]
-        fn on_mouse_button(&mut self, ctx: &mut NativeCtx<'_>, payload: MouseButton) {
-            self.fanout(ctx, &payload);
-        }
-
-        /// Window-resize fan-out.
-        #[handler]
-        fn on_window_size(&mut self, ctx: &mut NativeCtx<'_>, payload: WindowSize) {
-            self.fanout(ctx, &payload);
+            Err(error) => SubscribeInputResult::Err { error },
         }
     }
 
-    impl InputCapability {
-        /// Push one mail per subscriber for `K`. Routes through
-        /// [`NativeCtx::fanout`] so each subscriber-bound copy carries
-        /// the inbound `(mail_id, root)` as `parent_mail` +
-        /// `inherited_root` — the trace observer sees N children
-        /// fanning out under the same parent edge (ADR-0080 §6,
-        /// issue iamacoffeepot/aether#723).
-        fn fanout<K: Kind>(&self, ctx: &mut NativeCtx<'_>, payload: &K) {
-            let Some(subs) = self.subscribers.get(&K::ID) else {
-                return;
-            };
-            ctx.fanout(subs.iter().copied(), payload);
-        }
-    }
-
-    /// Shared validation: the mailbox id must name a live (non-dropped)
-    /// dispatchable mailbox. Issue 634 Phase 4 collapsed Component
-    /// and chassis-bound mailboxes into a single `Closure` variant —
-    /// trampolines and chassis caps both pass this check today.
-    /// Issue 838 added a `Sink` variant (synchronous-handler
-    /// mailboxes); production callers (the input stream fan-out)
-    /// only address trampoline mailboxes here, but accepting `Sink`
-    /// too keeps the check from rejecting legitimate sync-handler
-    /// subscribers if any future driver wants one.
-    fn validate_subscriber_mailbox(registry: &Registry, id: MailboxId) -> Result<(), String> {
-        match registry.entry(id) {
-            Some(MailboxEntry::Inbox { .. } | MailboxEntry::Inline(_)) => Ok(()),
-            Some(MailboxEntry::Dropped) => Err(format!("mailbox {id:?} already dropped")),
-            None => Err(format!("unknown mailbox id {id:?}")),
-        }
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-        use aether_substrate::actor::native::binding::NativeBinding;
-        use aether_substrate::mail::mailer::Mailer;
-        use aether_substrate::mail::{MailId, Source, SourceAddr};
-
-        fn test_cap() -> InputCapability {
-            InputCapability {
-                registry: Arc::new(Registry::new()),
-                subscribers: HashMap::new(),
+    /// Unsubscribe the *sending* actor from an input stream
+    /// (ADR-0021, ADR-0083). Resolves the subscriber from the
+    /// inbound's host-stamped `Source`, mirroring
+    /// [`Self::on_subscribe_self`]. `None` (no local sender) replies
+    /// `Err`. Idempotent on "not currently subscribed."
+    ///
+    /// # Agent
+    /// `UnsubscribeInputSelf { kind }`.
+    #[handler]
+    fn on_unsubscribe_self(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        payload: UnsubscribeInputSelf,
+    ) -> SubscribeInputResult {
+        match ctx.source_mailbox() {
+            Some(mailbox) => {
+                if let Some(set) = state.subscribers.get_mut(&payload.kind) {
+                    set.remove(&mailbox);
+                }
+                SubscribeInputResult::Ok
             }
+            None => SubscribeInputResult::Err {
+                error: "aether.input.unsubscribe_self requires a local component sender; an \
+                        external session or remote engine must use aether.input.unsubscribe \
+                        with an explicit mailbox"
+                    .to_string(),
+            },
         }
+    }
 
-        fn test_mailer() -> Arc<Mailer> {
-            Arc::new(Mailer::new(Arc::new(Registry::new())))
+    /// Remove `mailbox` from every input stream's subscriber set.
+    /// Issued by `ComponentHostCapability` on `DropComponent` so a
+    /// dropped trampoline doesn't keep receiving fan-out mail.
+    /// No mailbox-validation: the trampoline's mailbox is already
+    /// torn down by the time this fires; we accept any id and
+    /// purge it from the table.
+    ///
+    /// # Agent
+    /// `UnsubscribeAll { mailbox }`. Idempotent.
+    #[handler]
+    fn on_unsubscribe_all(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        payload: UnsubscribeAll,
+    ) {
+        for set in state.subscribers.values_mut() {
+            set.remove(&payload.mailbox);
         }
+    }
 
-        /// A `subscribe_self` carrying a `Component` source lands *that*
-        /// mailbox in the stream set (ADR-0083: the cap reads the
-        /// subscriber off the host-stamped envelope, not a payload field).
-        #[test]
-        fn subscribe_self_subscribes_the_component_source() {
-            let mut cap = test_cap();
-            let key = <Key as Kind>::ID;
-            let sender = MailboxId(0x00C0_FFEE);
+    /// Key-press fan-out.
+    #[handler]
+    fn on_key(state: &mut Self::State, ctx: &mut NativeCtx<'_>, payload: Key) {
+        state.fanout(ctx, &payload);
+    }
 
-            let transport = Arc::new(NativeBinding::new_for_test(test_mailer(), MailboxId(0)));
-            let source = Source::to(SourceAddr::Component(sender));
-            let mut ctx = NativeCtx::new(&transport, source, MailId::NONE, MailId::NONE);
-            cap.on_subscribe_self(&mut ctx, SubscribeInputSelf { kind: key });
+    /// Key-release fan-out (paired with [`Key`] for hold-to-act
+    /// semantics).
+    #[handler]
+    fn on_key_release(state: &mut Self::State, ctx: &mut NativeCtx<'_>, payload: KeyRelease) {
+        state.fanout(ctx, &payload);
+    }
 
-            assert!(
-                cap.subscribers
-                    .get(&key)
-                    .is_some_and(|s| s.contains(&sender)),
-                "a Component-source subscribe_self lands that mailbox in the stream set"
-            );
+    /// Cursor-move fan-out.
+    #[handler]
+    fn on_mouse_move(state: &mut Self::State, ctx: &mut NativeCtx<'_>, payload: MouseMove) {
+        state.fanout(ctx, &payload);
+    }
+
+    /// Mouse-press fan-out. Empty payload.
+    #[handler]
+    fn on_mouse_button(state: &mut Self::State, ctx: &mut NativeCtx<'_>, payload: MouseButton) {
+        state.fanout(ctx, &payload);
+    }
+
+    /// Window-resize fan-out.
+    #[handler]
+    fn on_window_size(state: &mut Self::State, ctx: &mut NativeCtx<'_>, payload: WindowSize) {
+        state.fanout(ctx, &payload);
+    }
+}
+
+#[cfg(feature = "runtime")]
+impl InputCapabilityState {
+    /// Push one mail per subscriber for `K`. Routes through
+    /// [`NativeCtx::fanout`] so each subscriber-bound copy carries
+    /// the inbound `(mail_id, root)` as `parent_mail` +
+    /// `inherited_root` — the trace observer sees N children
+    /// fanning out under the same parent edge (ADR-0080 §6,
+    /// issue iamacoffeepot/aether#723).
+    fn fanout<K: Kind>(&self, ctx: &mut NativeCtx<'_>, payload: &K) {
+        let Some(subs) = self.subscribers.get(&K::ID) else {
+            return;
+        };
+        ctx.fanout(subs.iter().copied(), payload);
+    }
+}
+
+/// Shared validation: the mailbox id must name a live (non-dropped)
+/// dispatchable mailbox. Issue 634 Phase 4 collapsed Component
+/// and chassis-bound mailboxes into a single `Closure` variant —
+/// trampolines and chassis caps both pass this check today.
+/// Issue 838 added a `Sink` variant (synchronous-handler
+/// mailboxes); production callers (the input stream fan-out)
+/// only address trampoline mailboxes here, but accepting `Sink`
+/// too keeps the check from rejecting legitimate sync-handler
+/// subscribers if any future driver wants one.
+#[cfg(feature = "runtime")]
+fn validate_subscriber_mailbox(registry: &Registry, id: MailboxId) -> Result<(), String> {
+    match registry.entry(id) {
+        Some(MailboxEntry::Inbox { .. } | MailboxEntry::Inline(_)) => Ok(()),
+        Some(MailboxEntry::Dropped) => Err(format!("mailbox {id:?} already dropped")),
+        None => Err(format!("unknown mailbox id {id:?}")),
+    }
+}
+
+#[cfg(all(test, feature = "runtime"))]
+mod tests {
+    use super::*;
+    use aether_substrate::actor::native::binding::NativeBinding;
+    use aether_substrate::mail::mailer::Mailer;
+    use aether_substrate::mail::{MailId, Source, SourceAddr};
+
+    fn test_state() -> InputCapabilityState {
+        InputCapabilityState {
+            registry: Arc::new(Registry::new()),
+            subscribers: HashMap::new(),
         }
+    }
 
-        /// A `subscribe_self` from a non-`Component` source (an external
-        /// session) replies `Err` and subscribes nothing — the reflexive
-        /// form is gated to in-process actors by construction.
-        #[test]
-        fn subscribe_self_rejects_non_component_source() {
-            use aether_data::{SessionToken, Uuid};
+    fn test_mailer() -> Arc<Mailer> {
+        Arc::new(Mailer::new(Arc::new(Registry::new())))
+    }
 
-            let mut cap = test_cap();
-            let key = <Key as Kind>::ID;
+    /// A `subscribe_self` carrying a `Component` source lands *that*
+    /// mailbox in the stream set (ADR-0083: the cap reads the
+    /// subscriber off the host-stamped envelope, not a payload field).
+    #[test]
+    fn subscribe_self_subscribes_the_component_source() {
+        let mut state = test_state();
+        let key = <Key as Kind>::ID;
+        let sender = MailboxId(0x00C0_FFEE);
 
-            let transport = Arc::new(NativeBinding::new_for_test(test_mailer(), MailboxId(0)));
-            let source = Source::to(SourceAddr::Session(SessionToken(Uuid::from_u128(0xFEED))));
-            let mut ctx = NativeCtx::new(&transport, source, MailId::NONE, MailId::NONE);
-            cap.on_subscribe_self(&mut ctx, SubscribeInputSelf { kind: key });
+        let transport = Arc::new(NativeBinding::new_for_test(test_mailer(), MailboxId(0)));
+        let source = Source::to(SourceAddr::Component(sender));
+        let mut ctx = NativeCtx::new(&transport, source, MailId::NONE, MailId::NONE);
+        InputCapability::on_subscribe_self(&mut state, &mut ctx, SubscribeInputSelf { kind: key });
 
-            assert!(
-                cap.subscribers.get(&key).is_none_or(BTreeSet::is_empty),
-                "a non-Component source subscribes nothing"
-            );
-        }
+        assert!(
+            state
+                .subscribers
+                .get(&key)
+                .is_some_and(|s| s.contains(&sender)),
+            "a Component-source subscribe_self lands that mailbox in the stream set"
+        );
+    }
+
+    /// A `subscribe_self` from a non-`Component` source (an external
+    /// session) replies `Err` and subscribes nothing — the reflexive
+    /// form is gated to in-process actors by construction.
+    #[test]
+    fn subscribe_self_rejects_non_component_source() {
+        use aether_data::{SessionToken, Uuid};
+
+        let mut state = test_state();
+        let key = <Key as Kind>::ID;
+
+        let transport = Arc::new(NativeBinding::new_for_test(test_mailer(), MailboxId(0)));
+        let source = Source::to(SourceAddr::Session(SessionToken(Uuid::from_u128(0xFEED))));
+        let mut ctx = NativeCtx::new(&transport, source, MailId::NONE, MailId::NONE);
+        InputCapability::on_subscribe_self(&mut state, &mut ctx, SubscribeInputSelf { kind: key });
+
+        assert!(
+            state.subscribers.get(&key).is_none_or(BTreeSet::is_empty),
+            "a non-Component source subscribes nothing"
+        );
     }
 }

--- a/crates/aether-capabilities/src/inventory/mod.rs
+++ b/crates/aether-capabilities/src/inventory/mod.rs
@@ -21,7 +21,7 @@
 //!   `thread_name::resolve_runtime`). `None` on a miss so the client
 //!   falls back to rendering the ADR-0064 tagged-id string itself.
 //! - [`ListKinds`] → [`ListKindsResult`] (ADR-0091): every
-//!   [`KindId`](aether_data::KindId) currently registered in the
+//!   [`KindId`] currently registered in the
 //!   substrate's `Registry`, with its full
 //!   [`SchemaType`](aether_data::SchemaType). The harness folds the
 //!   reply into a per-engine encode cache so a `send_mail` against a
@@ -45,557 +45,595 @@
 //! `load_component`'s registrations are visible to `ListKinds` the
 //! moment they return; no event channel, no cache invalidation. The
 //! manifest / resolve arms remain stateless reads of process-global
-//! link-time tables. `#[bridge(singleton)]` auto-submits its own
+//! link-time tables. `#[actor(singleton)]` auto-submits its own
 //! `NameEntry` for `NAMESPACE`, so `aether.inventory` reverses through
 //! the same static map it serves.
 
-use aether_kinds::{
-    HandlersResult, ListHandlers, ListKinds, ListKindsResult, Manifest, ManifestResult, Resolve,
-    ResolveResult,
-};
+// Handler-signature kinds must be importable at module root because
+// `#[actor]` emits `impl HandlesKind<K> for InventoryCapability {}`
+// markers always-on, outside the `feature = "runtime"` gate. The reply
+// kinds are named only by the gated handler bodies, so they ride the
+// runtime gate below.
+use aether_kinds::{ListHandlers, ListKinds, Manifest, Resolve};
+
+use aether_actor::actor;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod manifest;
 #[cfg(not(target_arch = "wasm32"))]
 mod resolve;
 
-#[aether_actor::bridge(singleton)]
-mod native {
-    use super::manifest::{cardinality_wire, param_kind_wire};
-    use super::resolve::resolve_ids;
-    use super::{
-        HandlersResult, ListHandlers, ListKinds, ListKindsResult, Manifest, ManifestResult,
-        Resolve, ResolveResult,
-    };
+/// `aether.inventory` cap **identity** (ADR-0122 identity/runtime split,
+/// ADR-0088 §6, widened by ADR-0091 §5). A ZST carrying only the
+/// addressing — the `Addressable` / `HandlesKind` markers and the
+/// name-inventory entry, all emitted always-on by `#[actor]`. The
+/// state-bearing runtime ([`InventoryCapabilityState`], holding the
+/// substrate `Arc<Registry>` the `ListKinds` arm projects) lives behind
+/// the one `feature = "runtime"` gate, so a transport-only build never
+/// names it nor pulls `aether_substrate` through this cap.
+///
+/// The `Manifest` and `Resolve` arms read process-global tables (the
+/// link-time inventories, the runtime registry) directly with no
+/// per-cap state. The `ListKinds` arm projects the substrate's shared
+/// `Arc<Registry>`, captured in `init` from the bench / chassis mailer —
+/// load-time registrations performed by `ComponentHostCapability` mutate
+/// the same `Arc<Registry>`, so the reply reflects whatever vocabulary
+/// the substrate currently holds without any cross-cap event channel.
+pub struct InventoryCapability;
 
-    use aether_actor::actor;
-    use aether_data::KindId;
-    use aether_data::canonical::kind_id_from_parts;
-    use aether_data::name_inventory::{handler_entries, name_entries, template_entries};
-    use aether_data::wire;
-    use aether_kinds::{HandlerEntryWire, KindDescriptorWire, NameEntryWire, TemplateEntryWire};
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
+// The reply kinds ride the native gate (not `runtime`): the `#[actor]`
+// macro's ADR-0109 `HandlerEntry` inventory submission — emitted on every
+// native build, runtime or not — names each handler's reply kind `::ID`,
+// so a transport-only build must still see them. The wire-projection
+// helpers, the `aether_substrate`-typed imports, and the state struct
+// sit behind the one `feature = "runtime"` gate.
+#[cfg(not(target_arch = "wasm32"))]
+use aether_kinds::{HandlersResult, ListKindsResult, ManifestResult, ResolveResult};
+
+#[cfg(feature = "runtime")]
+use self::manifest::{cardinality_wire, param_kind_wire};
+#[cfg(feature = "runtime")]
+use self::resolve::resolve_ids;
+
+#[cfg(feature = "runtime")]
+use aether_data::KindId;
+#[cfg(feature = "runtime")]
+use aether_data::canonical::kind_id_from_parts;
+#[cfg(feature = "runtime")]
+use aether_data::name_inventory::{handler_entries, name_entries, template_entries};
+#[cfg(feature = "runtime")]
+use aether_data::wire;
+#[cfg(feature = "runtime")]
+use aether_kinds::{HandlerEntryWire, KindDescriptorWire, NameEntryWire, TemplateEntryWire};
+#[cfg(feature = "runtime")]
+use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+#[cfg(feature = "runtime")]
+use aether_substrate::chassis::error::BootError;
+#[cfg(feature = "runtime")]
+use aether_substrate::mail::registry::Registry;
+#[cfg(feature = "runtime")]
+use std::sync::Arc;
+
+// Used only by the test suite — gate to avoid unused-import warnings in
+// the non-test build (they flow in via `use super::*` inside `mod tests`).
+#[cfg(all(test, feature = "runtime"))]
+use aether_data::tagged_id;
+#[cfg(all(test, feature = "runtime"))]
+use aether_kinds::{CardinalityWire, ParamKindWire};
+#[cfg(all(test, feature = "runtime"))]
+use aether_substrate::runtime::thread_name::resolve_runtime;
+
+/// `aether.inventory` runtime state (ADR-0091 §2). Holds the substrate's
+/// shared `Arc<Registry>` — the same `Arc` `ComponentHostCapability`
+/// clones for `register_or_match_all` — so a load-time registration is
+/// visible to `on_list_kinds` the moment it returns. The `Manifest` /
+/// `Resolve` / `ListHandlers` arms are stateless reads of process-global
+/// link-time tables. The addressing identity is the distinct ZST
+/// `InventoryCapability`.
+#[cfg(feature = "runtime")]
+pub struct InventoryCapabilityState {
+    registry: Arc<Registry>,
+}
+
+#[actor(singleton)]
+impl NativeActor for InventoryCapability {
+    /// The runtime state this identity boots into (ADR-0122 split): the
+    /// shared substrate `Arc<Registry>` the `ListKinds` arm projects.
+    type State = InventoryCapabilityState;
+
+    type Config = ();
+
+    /// ADR-0088 §6 chassis-owned mailbox. Registered on the desktop +
+    /// headless chassis (via `with_common_caps`), matching `aether.fs`.
+    const NAMESPACE: &'static str = "aether.inventory";
+
+    fn init((): (), ctx: &mut NativeInitCtx<'_>) -> Result<InventoryCapabilityState, BootError> {
+        // Clone the substrate's shared `Arc<Registry>` — the same
+        // `Arc` `ComponentHostCapability` clones for
+        // `register_or_match_all` at `component.rs:170`. The shared
+        // `Arc` is the propagation channel per ADR-0091 §2: a
+        // load-time registration is visible to `on_list_kinds` the
+        // moment it returns.
+        let registry = Arc::clone(ctx.mailer().registry());
+        Ok(InventoryCapabilityState { registry })
+    }
+
+    /// Reply with the per-build reverse-lookup manifest: every
+    /// declared name + every instanced-family template.
+    ///
+    /// # Agent
+    /// Reply: `ManifestResult`. Carries `names` (declared mailbox
+    /// namespaces, kinds, transforms) + `templates` (instanced
+    /// families, preserving their `Bounded`/`Declared`/`Dynamic`
+    /// shape). Fold `names` into a hash → name map and expand the
+    /// `Bounded`/`Declared` templates locally; resolve `Dynamic`
+    /// families per-id via `aether.inventory.resolve`.
+    // The manifest is read from the process-global link-time
+    // inventories — `state.registry` is only consulted by
+    // `on_list_kinds`, so this arm takes `_state`.
+    #[handler]
+    fn on_manifest(
+        _state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        _mail: Manifest,
+    ) -> ManifestResult {
+        let names = name_entries()
+            .map(|entry| NameEntryWire {
+                domain: entry.domain.to_vec(),
+                name: entry.name.into(),
+            })
+            .collect();
+        let templates = template_entries()
+            .map(|entry| TemplateEntryWire {
+                domain: entry.domain.to_vec(),
+                // The wire form carries the full `prefix ++ template`
+                // pattern; the split is an internal const-construction
+                // detail (ADR-0099 §5/§6 forward-feed).
+                template: entry.pattern().into_owned(),
+                param: param_kind_wire(&entry.param),
+                cardinality: cardinality_wire(&entry.cardinality),
+            })
+            .collect();
+        ManifestResult { names, templates }
+    }
+
+    /// Reply with the substrate's live kind vocabulary: every
+    /// [`KindDescriptor`](aether_data::KindDescriptor) currently
+    /// registered in the engine's `Registry`, projected onto the
+    /// wire (id + name + wire-encoded
+    /// [`SchemaType`](aether_data::SchemaType)). ADR-0091 §1–§2.
+    ///
+    /// # Agent
+    /// Reply: `ListKindsResult`. The harness folds this into a
+    /// per-engine encode cache so a `send_mail` against a
+    /// component-defined kind encodes correctly the moment the
+    /// `aether.component.load` returns. Lazy-on-miss: the harness
+    /// calls this on the first `send_mail` for an unknown kind
+    /// name, then reuses the cached vocabulary until the next miss
+    /// (no TTL, no background poll). The schema rides as opaque
+    /// wire bytes (`schema_wire`) because `SchemaType` has
+    /// no `Schema` impl of its own; decode it with
+    /// `wire::from_bytes::<SchemaType>(&desc.schema_wire)`.
+    #[handler]
+    fn on_list_kinds(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        _mail: ListKinds,
+    ) -> ListKindsResult {
+        let kinds = state
+            .registry
+            .list_kind_descriptors()
+            .into_iter()
+            .map(|desc| {
+                // The schema rides as opaque wire bytes — see
+                // `KindDescriptorWire` for the rationale. The
+                // serialization is infallible for `SchemaType`
+                // (no `Map<String, _>` non-string-key edge cases
+                // because every nested field is a derive output).
+                let schema_wire = wire::to_vec(&desc.schema)
+                    .expect("SchemaType always wire-encodes (ADR-0118 canonical form)");
+                KindDescriptorWire {
+                    id: KindId(kind_id_from_parts(&desc.name, &desc.schema)),
+                    name: desc.name,
+                    schema_wire,
+                }
+            })
+            .collect();
+        ListKindsResult { kinds }
+    }
+
+    /// Resolve each requested tagged-id string to its origin name via
+    /// the runtime-registry arm of the reverse-lookup chain.
+    ///
+    /// # Agent
+    /// Reply: `ResolveResult`. One `ResolvedName { id, name }` per
+    /// requested id, in request order and echoing `id` for
+    /// correlation. `name` is `Some` for a dynamically-minted
+    /// instance the substrate has registered; `None` on a miss (or an
+    /// unparseable id), at which point the caller renders the
+    /// ADR-0064 tagged-id string itself. Call this only for ids a
+    /// locally-folded manifest couldn't resolve.
+    // Stateless arm — `resolve` reads the process-global runtime
+    // registry, not the cap state, so it takes `_state`.
+    #[handler]
+    fn on_resolve(
+        _state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        mail: Resolve,
+    ) -> ResolveResult {
+        ResolveResult {
+            resolved: resolve_ids(mail.ids),
+        }
+    }
+
+    /// Reply with the native handler manifest (ADR-0109 §5): every
+    /// `#[handler]` across every native actor linked into the
+    /// substrate, each carrying its owning `namespace`, input kind
+    /// (id + name), and declared reply kind id. Read from the
+    /// process-global link-time
+    /// [`HandlerEntry`](aether_data::name_inventory::HandlerEntry)
+    /// inventory the `#[actor]` macro populates — the native
+    /// analogue of the wasm `aether.kinds.inputs` custom section.
+    ///
+    /// # Agent
+    /// Reply: `HandlersResult`. One `HandlerEntryWire` per native
+    /// handler; `reply` is the kind a `-> R` handler answers with
+    /// (`None` for a fire-and-forget `-> ()` handler). Fold per
+    /// `namespace` to read each native cap (`aether.fs`,
+    /// `aether.render`, …) as a `describe_component`-style
+    /// `In -> Out` handler list.
+    // The manifest is read from the process-global link-time
+    // inventory, so this arm takes `_state`.
+    #[handler]
+    fn on_handlers(
+        _state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        _mail: ListHandlers,
+    ) -> HandlersResult {
+        let handlers = handler_entries()
+            .map(|entry| HandlerEntryWire {
+                namespace: entry.namespace.into(),
+                id: entry.id,
+                name: entry.name.into(),
+                reply: entry.reply,
+            })
+            .collect();
+        HandlersResult { handlers }
+    }
+}
+
+#[cfg(all(test, feature = "runtime"))]
+mod tests {
+    use super::*;
+    use aether_data::{
+        MailboxId, SessionToken, ThreadId, Uuid, mailbox_id_from_name, thread_id_from_name,
+    };
+    use aether_substrate::actor::native::binding::NativeBinding;
+    use aether_substrate::mail::mailer::Mailer;
+    use aether_substrate::mail::outbound::HubOutbound;
     use aether_substrate::mail::registry::Registry;
+    use aether_substrate::mail::{Source, SourceAddr};
+    use aether_substrate::runtime::thread_name::register;
     use std::sync::Arc;
 
-    // Used only by the test suite — gate to avoid unused-import warnings in
-    // the non-test build (they flow in via `use super::*` inside `mod tests`).
-    #[cfg(test)]
-    use aether_data::tagged_id;
-    #[cfg(test)]
-    use aether_kinds::{CardinalityWire, ParamKindWire};
-    #[cfg(test)]
-    use aether_substrate::runtime::thread_name::resolve_runtime;
-
-    /// `aether.inventory` cap (ADR-0088 §6, widened by ADR-0091 §5). The
-    /// `Manifest` and `Resolve` arms read process-global tables (the
-    /// link-time inventories, the runtime registry) directly with no
-    /// per-cap state. The `ListKinds` arm projects the substrate's
-    /// shared `Arc<Registry>`, captured in `init` from the bench /
-    /// chassis mailer — load-time registrations performed by
-    /// `ComponentHostCapability` mutate the same `Arc<Registry>`, so the
-    /// reply reflects whatever vocabulary the substrate currently holds
-    /// without any cross-cap event channel.
-    pub struct InventoryCapability {
-        registry: Arc<Registry>,
+    /// Runtime state + fully-wired test mailer + `NativeBinding`
+    /// transport. Handlers are called directly and return their
+    /// result; no egress channel decode needed (ADR-0112 `-> R`
+    /// migration).
+    struct Fixture {
+        transport: Arc<NativeBinding>,
+        state: InventoryCapabilityState,
     }
 
-    #[actor]
-    impl NativeActor for InventoryCapability {
-        type Config = ();
-
-        /// ADR-0088 §6 chassis-owned mailbox. Registered on the desktop +
-        /// headless chassis (via `with_common_caps`), matching `aether.fs`.
-        const NAMESPACE: &'static str = "aether.inventory";
-
-        fn init((): (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            // Clone the substrate's shared `Arc<Registry>` — the same
-            // `Arc` `ComponentHostCapability` clones for
-            // `register_or_match_all` at `component.rs:170`. The shared
-            // `Arc` is the propagation channel per ADR-0091 §2: a
-            // load-time registration is visible to `on_list_kinds` the
-            // moment it returns.
-            let registry = Arc::clone(ctx.mailer().registry());
-            Ok(Self { registry })
-        }
-
-        /// Reply with the per-build reverse-lookup manifest: every
-        /// declared name + every instanced-family template.
-        ///
-        /// # Agent
-        /// Reply: `ManifestResult`. Carries `names` (declared mailbox
-        /// namespaces, kinds, transforms) + `templates` (instanced
-        /// families, preserving their `Bounded`/`Declared`/`Dynamic`
-        /// shape). Fold `names` into a hash → name map and expand the
-        /// `Bounded`/`Declared` templates locally; resolve `Dynamic`
-        /// families per-id via `aether.inventory.resolve`.
-        // The manifest is read from the process-global link-time
-        // inventories — `self.registry` is only consulted by
-        // `on_list_kinds`. `&mut self` is the `#[handler]` dispatch
-        // signature, not a state read here.
-        #[allow(clippy::unused_self)]
-        #[handler]
-        fn on_manifest(&mut self, _ctx: &mut NativeCtx<'_>, _mail: Manifest) -> ManifestResult {
-            let names = name_entries()
-                .map(|entry| NameEntryWire {
-                    domain: entry.domain.to_vec(),
-                    name: entry.name.into(),
-                })
-                .collect();
-            let templates = template_entries()
-                .map(|entry| TemplateEntryWire {
-                    domain: entry.domain.to_vec(),
-                    // The wire form carries the full `prefix ++ template`
-                    // pattern; the split is an internal const-construction
-                    // detail (ADR-0099 §5/§6 forward-feed).
-                    template: entry.pattern().into_owned(),
-                    param: param_kind_wire(&entry.param),
-                    cardinality: cardinality_wire(&entry.cardinality),
-                })
-                .collect();
-            ManifestResult { names, templates }
-        }
-
-        /// Reply with the substrate's live kind vocabulary: every
-        /// [`KindDescriptor`](aether_data::KindDescriptor) currently
-        /// registered in the engine's `Registry`, projected onto the
-        /// wire (id + name + wire-encoded
-        /// [`SchemaType`](aether_data::SchemaType)). ADR-0091 §1–§2.
-        ///
-        /// # Agent
-        /// Reply: `ListKindsResult`. The harness folds this into a
-        /// per-engine encode cache so a `send_mail` against a
-        /// component-defined kind encodes correctly the moment the
-        /// `aether.component.load` returns. Lazy-on-miss: the harness
-        /// calls this on the first `send_mail` for an unknown kind
-        /// name, then reuses the cached vocabulary until the next miss
-        /// (no TTL, no background poll). The schema rides as opaque
-        /// wire bytes (`schema_wire`) because `SchemaType` has
-        /// no `Schema` impl of its own; decode it with
-        /// `wire::from_bytes::<SchemaType>(&desc.schema_wire)`.
-        #[handler]
-        fn on_list_kinds(&mut self, _ctx: &mut NativeCtx<'_>, _mail: ListKinds) -> ListKindsResult {
-            let kinds = self
-                .registry
-                .list_kind_descriptors()
-                .into_iter()
-                .map(|desc| {
-                    // The schema rides as opaque wire bytes — see
-                    // `KindDescriptorWire` for the rationale. The
-                    // serialization is infallible for `SchemaType`
-                    // (no `Map<String, _>` non-string-key edge cases
-                    // because every nested field is a derive output).
-                    let schema_wire = wire::to_vec(&desc.schema)
-                        .expect("SchemaType always wire-encodes (ADR-0118 canonical form)");
-                    KindDescriptorWire {
-                        id: KindId(kind_id_from_parts(&desc.name, &desc.schema)),
-                        name: desc.name,
-                        schema_wire,
-                    }
-                })
-                .collect();
-            ListKindsResult { kinds }
-        }
-
-        /// Resolve each requested tagged-id string to its origin name via
-        /// the runtime-registry arm of the reverse-lookup chain.
-        ///
-        /// # Agent
-        /// Reply: `ResolveResult`. One `ResolvedName { id, name }` per
-        /// requested id, in request order and echoing `id` for
-        /// correlation. `name` is `Some` for a dynamically-minted
-        /// instance the substrate has registered; `None` on a miss (or an
-        /// unparseable id), at which point the caller renders the
-        /// ADR-0064 tagged-id string itself. Call this only for ids a
-        /// locally-folded manifest couldn't resolve.
-        // Stateless cap — `resolve` reads the process-global runtime
-        // registry, not `self`. `&mut self` is the `#[handler]` dispatch
-        // signature, not a state read.
-        #[allow(clippy::unused_self)]
-        #[handler]
-        fn on_resolve(&mut self, _ctx: &mut NativeCtx<'_>, mail: Resolve) -> ResolveResult {
-            ResolveResult {
-                resolved: resolve_ids(mail.ids),
-            }
-        }
-
-        /// Reply with the native handler manifest (ADR-0109 §5): every
-        /// `#[handler]` across every native actor linked into the
-        /// substrate, each carrying its owning `namespace`, input kind
-        /// (id + name), and declared reply kind id. Read from the
-        /// process-global link-time
-        /// [`HandlerEntry`](aether_data::name_inventory::HandlerEntry)
-        /// inventory the `#[actor]` macro populates — the native
-        /// analogue of the wasm `aether.kinds.inputs` custom section.
-        ///
-        /// # Agent
-        /// Reply: `HandlersResult`. One `HandlerEntryWire` per native
-        /// handler; `reply` is the kind a `-> R` handler answers with
-        /// (`None` for a fire-and-forget `-> ()` handler). Fold per
-        /// `namespace` to read each native cap (`aether.fs`,
-        /// `aether.render`, …) as a `describe_component`-style
-        /// `In -> Out` handler list.
-        // The manifest is read from the process-global link-time
-        // inventory — `&mut self` is the `#[handler]` dispatch signature,
-        // not a state read.
-        #[allow(clippy::unused_self)]
-        #[handler]
-        fn on_handlers(&mut self, _ctx: &mut NativeCtx<'_>, _mail: ListHandlers) -> HandlersResult {
-            let handlers = handler_entries()
-                .map(|entry| HandlerEntryWire {
-                    namespace: entry.namespace.into(),
-                    id: entry.id,
-                    name: entry.name.into(),
-                    reply: entry.reply,
-                })
-                .collect();
-            HandlersResult { handlers }
+    fn fixture() -> Fixture {
+        let registry = Arc::new(Registry::new());
+        let (outbound, _rx) = HubOutbound::attached_loopback();
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry)).with_outbound(outbound));
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            MailboxId(0x1117),
+        ));
+        Fixture {
+            transport,
+            state: InventoryCapabilityState {
+                registry: Arc::clone(&registry),
+            },
         }
     }
 
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-        use aether_data::{
-            MailboxId, SessionToken, ThreadId, Uuid, mailbox_id_from_name, thread_id_from_name,
-        };
-        use aether_substrate::actor::native::binding::NativeBinding;
-        use aether_substrate::mail::mailer::Mailer;
-        use aether_substrate::mail::outbound::HubOutbound;
-        use aether_substrate::mail::registry::Registry;
-        use aether_substrate::mail::{Source, SourceAddr};
-        use aether_substrate::runtime::thread_name::register;
-        use std::sync::Arc;
+    fn session_ctx(transport: &Arc<NativeBinding>) -> NativeCtx<'_> {
+        let sender = Source::to(SourceAddr::Session(SessionToken(Uuid::nil())));
+        NativeCtx::new(
+            transport,
+            sender,
+            aether_data::MailId::NONE,
+            aether_data::MailId::NONE,
+        )
+    }
 
-        /// Cap + fully-wired test mailer + `NativeBinding` transport.
-        /// Handlers are called directly and return their result; no egress
-        /// channel decode needed (ADR-0112 `-> R` migration).
-        struct Fixture {
-            transport: Arc<NativeBinding>,
-            cap: InventoryCapability,
-        }
+    /// The served manifest carries a known chassis mailbox name
+    /// (`aether.fs`, a declared `NameEntry`) and a known instanced
+    /// family (`aether-worker-{N}`, a `Bounded` `TemplateEntry`).
+    /// Touching `FsCapability` forces its module — and the macro-
+    /// auto-emitted `NameEntry` — into this unit-test binary; the
+    /// substrate's `thread_name` module submits the worker template.
+    #[test]
+    fn manifest_contains_chassis_name_and_worker_template() {
+        // Force `FsCapability`'s `NameEntry` submission to link.
+        use crate::fs::FsCapability;
+        use aether_actor::Addressable;
+        assert_eq!(FsCapability::NAMESPACE, "aether.fs");
+        // Force the substrate's worker / root / instanced thread-name
+        // templates to link by referencing the resolve chain.
+        let _ = resolve_runtime(0);
 
-        fn fixture() -> Fixture {
-            let registry = Arc::new(Registry::new());
-            let (outbound, _rx) = HubOutbound::attached_loopback();
-            let mailer = Arc::new(Mailer::new(Arc::clone(&registry)).with_outbound(outbound));
-            let transport = Arc::new(NativeBinding::new_for_test(
-                Arc::clone(&mailer),
-                MailboxId(0x1117),
-            ));
-            Fixture {
-                transport,
-                cap: InventoryCapability {
-                    registry: Arc::clone(&registry),
-                },
-            }
-        }
+        let mut fix = fixture();
+        let mut ctx = session_ctx(&fix.transport);
+        let result = InventoryCapability::on_manifest(&mut fix.state, &mut ctx, Manifest {});
+        drop(ctx);
 
-        fn session_ctx(transport: &Arc<NativeBinding>) -> NativeCtx<'_> {
-            let sender = Source::to(SourceAddr::Session(SessionToken(Uuid::nil())));
-            NativeCtx::new(
-                transport,
-                sender,
-                aether_data::MailId::NONE,
-                aether_data::MailId::NONE,
-            )
-        }
-
-        /// The served manifest carries a known chassis mailbox name
-        /// (`aether.fs`, a declared `NameEntry`) and a known instanced
-        /// family (`aether-worker-{N}`, a `Bounded` `TemplateEntry`).
-        /// Touching `FsCapability` forces its module — and the macro-
-        /// auto-emitted `NameEntry` — into this unit-test binary; the
-        /// substrate's `thread_name` module submits the worker template.
-        #[test]
-        fn manifest_contains_chassis_name_and_worker_template() {
-            // Force `FsCapability`'s `NameEntry` submission to link.
-            use crate::fs::FsCapability;
-            use aether_actor::Addressable;
-            assert_eq!(FsCapability::NAMESPACE, "aether.fs");
-            // Force the substrate's worker / root / instanced thread-name
-            // templates to link by referencing the resolve chain.
-            let _ = resolve_runtime(0);
-
-            let mut fix = fixture();
-            let mut ctx = session_ctx(&fix.transport);
-            let result = fix.cap.on_manifest(&mut ctx, Manifest {});
-            drop(ctx);
-
-            assert!(
-                result.names.iter().any(|n| n.name == "aether.fs"),
-                "manifest should carry the aether.fs chassis mailbox NameEntry; names: {:?}",
-                result.names.iter().map(|n| &n.name).collect::<Vec<_>>(),
-            );
-            // The worker template is `Bounded` on both axes: a `Bounded`
-            // `param` (enumerable integer hole) and a `Bounded` cardinality
-            // (the prehashed instance ceiling) — ADR-0088 §4 v2.
-            assert!(
-                result.templates.iter().any(|t| {
-                    t.template == "aether-worker-{N}"
-                        && matches!(t.param, ParamKindWire::Bounded { .. })
-                        && matches!(t.cardinality, CardinalityWire::Bounded { .. })
-                }),
-                "manifest should carry the aether-worker-{{N}} Bounded template; templates: {:?}",
-                result
-                    .templates
-                    .iter()
-                    .map(|t| &t.template)
-                    .collect::<Vec<_>>(),
-            );
-        }
-
-        /// ADR-0088 §4 v2: an instanced actor declaring `one_per` surfaces
-        /// a `OnePer(<entity>)` cardinality in the manifest, so a consumer
-        /// reads "trampoline = one mailbox per loaded component" instead of
-        /// an opaque `Dynamic` family. `WasmTrampoline` is the canonical
-        /// case (`#[bridge(instanced, one_per = "component")]`); touching
-        /// its `NAMESPACE` forces the macro-emitted `TemplateEntry` into
-        /// this test binary.
-        #[test]
-        fn manifest_surfaces_one_per_cardinality_for_trampoline() {
-            use crate::trampoline::WasmTrampoline;
-            use aether_actor::Addressable;
-            assert_eq!(WasmTrampoline::NAMESPACE, "aether.embedded");
-
-            let mut fix = fixture();
-            let mut ctx = session_ctx(&fix.transport);
-            let result = fix.cap.on_manifest(&mut ctx, Manifest {});
-            drop(ctx);
-
-            let trampoline = result
+        assert!(
+            result.names.iter().any(|n| n.name == "aether.fs"),
+            "manifest should carry the aether.fs chassis mailbox NameEntry; names: {:?}",
+            result.names.iter().map(|n| &n.name).collect::<Vec<_>>(),
+        );
+        // The worker template is `Bounded` on both axes: a `Bounded`
+        // `param` (enumerable integer hole) and a `Bounded` cardinality
+        // (the prehashed instance ceiling) — ADR-0088 §4 v2.
+        assert!(
+            result.templates.iter().any(|t| {
+                t.template == "aether-worker-{N}"
+                    && matches!(t.param, ParamKindWire::Bounded { .. })
+                    && matches!(t.cardinality, CardinalityWire::Bounded { .. })
+            }),
+            "manifest should carry the aether-worker-{{N}} Bounded template; templates: {:?}",
+            result
                 .templates
                 .iter()
-                .find(|t| t.template == "aether.embedded:{subname}")
-                .expect("manifest should carry the trampoline instanced-family template");
-            // Shape axis unchanged (opaque runtime string); cardinality
-            // axis now names the entity each instance tracks.
-            assert!(matches!(trampoline.param, ParamKindWire::Dynamic));
-            assert!(
-                matches!(&trampoline.cardinality, CardinalityWire::OnePer { entity } if entity == "component"),
-                "trampoline cardinality should be OnePer(\"component\"); got {:?}",
-                trampoline.cardinality,
-            );
+                .map(|t| &t.template)
+                .collect::<Vec<_>>(),
+        );
+    }
+
+    /// ADR-0088 §4 v2: an instanced actor declaring `one_per` surfaces
+    /// a `OnePer(<entity>)` cardinality in the manifest, so a consumer
+    /// reads "trampoline = one mailbox per loaded component" instead of
+    /// an opaque `Dynamic` family. `WasmTrampoline` is the canonical
+    /// case (`#[bridge(instanced, one_per = "component")]`); touching
+    /// its `NAMESPACE` forces the macro-emitted `TemplateEntry` into
+    /// this test binary.
+    #[test]
+    fn manifest_surfaces_one_per_cardinality_for_trampoline() {
+        use crate::trampoline::WasmTrampoline;
+        use aether_actor::Addressable;
+        assert_eq!(WasmTrampoline::NAMESPACE, "aether.embedded");
+
+        let mut fix = fixture();
+        let mut ctx = session_ctx(&fix.transport);
+        let result = InventoryCapability::on_manifest(&mut fix.state, &mut ctx, Manifest {});
+        drop(ctx);
+
+        let trampoline = result
+            .templates
+            .iter()
+            .find(|t| t.template == "aether.embedded:{subname}")
+            .expect("manifest should carry the trampoline instanced-family template");
+        // Shape axis unchanged (opaque runtime string); cardinality
+        // axis now names the entity each instance tracks.
+        assert!(matches!(trampoline.param, ParamKindWire::Dynamic));
+        assert!(
+            matches!(&trampoline.cardinality, CardinalityWire::OnePer { entity } if entity == "component"),
+            "trampoline cardinality should be OnePer(\"component\"); got {:?}",
+            trampoline.cardinality,
+        );
+    }
+
+    /// ADR-0091: `ListKinds` returns the substrate's authoritative
+    /// kind vocabulary. A kind registered in the bench's `Registry`
+    /// — emulating the `register_or_match_all` path
+    /// `ComponentHostCapability::handle_load` follows — shows up in
+    /// the reply with the matching `KindId`, name, and a
+    /// wire-encoded `SchemaType` that decodes back to the
+    /// original schema. This is the live-projection ADR-0091
+    /// requires: the same `Arc<Registry>` `component.rs` mutates is
+    /// what the cap reads on every call.
+    #[test]
+    fn list_kinds_projects_a_registered_kind() {
+        use aether_data::{KindDescriptor, KindId, SchemaType, canonical::kind_id_from_parts};
+
+        let mut fix = fixture();
+
+        // Register a fresh kind directly on the registry — same
+        // entry point `register_or_match_all` walks per descriptor.
+        // A `String`-shaped param keeps the schema lookup distinct
+        // from any link-time entry the static vocabulary already
+        // submits.
+        let desc = KindDescriptor {
+            name: "aether.test.list_kinds_projection".to_owned(),
+            schema: SchemaType::String,
+        };
+        let expected_id = KindId(kind_id_from_parts(&desc.name, &desc.schema));
+        // Use the bench's registry (the one the cap also cloned in
+        // `fixture`) so the read sees what we just wrote.
+        fix.state
+            .registry
+            .register_kind_with_descriptor(desc.clone())
+            .expect("register fresh kind");
+
+        let mut ctx = session_ctx(&fix.transport);
+        let result = InventoryCapability::on_list_kinds(&mut fix.state, &mut ctx, ListKinds {});
+        drop(ctx);
+
+        let entry = result
+            .kinds
+            .iter()
+            .find(|k| k.name == desc.name)
+            .unwrap_or_else(|| {
+                panic!(
+                    "ListKindsResult should carry the registered kind; names: {:?}",
+                    result.kinds.iter().map(|k| &k.name).collect::<Vec<_>>(),
+                )
+            });
+        assert_eq!(entry.id, expected_id, "id matches kind_id_from_parts");
+        let schema: SchemaType =
+            wire::from_bytes(&entry.schema_wire).expect("schema_wire round-trips through wire");
+        assert!(
+            matches!(schema, SchemaType::String),
+            "schema decodes back to the originally registered SchemaType",
+        );
+    }
+
+    /// A registered dynamic-instance id resolves to its name; an
+    /// unregistered id and a malformed string both report `None`
+    /// (the latter without sinking its siblings). Order + `id` echo
+    /// are preserved.
+    // Constructs a well-formed mailbox id the runtime registry never holds
+    // to drive the miss path — incidental test data, not a real address.
+    #[allow(clippy::disallowed_methods)]
+    #[test]
+    fn resolve_returns_registered_name_and_none_on_miss() {
+        // Register a dynamic instance name the way the runtime name
+        // builders do (a name no static template instantiates).
+        let registered = ThreadId::from_name("aether-instanced-inventory-test:7");
+        register(registered.0, "aether-instanced-inventory-test:7");
+        let registered_tag = tagged_id::encode(registered.0).expect("ThreadId always tag-encodes");
+
+        // An id the registry has never seen.
+        let unseen = thread_id_from_name("aether-instanced-never-registered");
+        let unseen_tag = tagged_id::encode(unseen.0).expect("ThreadId always tag-encodes");
+
+        // A well-formed mailbox id that the runtime registry doesn't
+        // hold (statics live in the static map, not the dynamic arm),
+        // so `resolve_runtime` misses it -> None.
+        let mailbox = mailbox_id_from_name("aether.fs");
+        let mailbox_tag = tagged_id::encode(mailbox.0).expect("MailboxId tag-encodes");
+
+        let mut fix = fixture();
+        let mut ctx = session_ctx(&fix.transport);
+        let result = InventoryCapability::on_resolve(
+            &mut fix.state,
+            &mut ctx,
+            Resolve {
+                ids: vec![
+                    registered_tag.clone(),
+                    unseen_tag.clone(),
+                    mailbox_tag.clone(),
+                    "not-a-tagged-id".to_string(),
+                ],
+            },
+        );
+        drop(ctx);
+        assert_eq!(result.resolved.len(), 4, "one entry per requested id");
+
+        assert_eq!(result.resolved[0].id, registered_tag);
+        assert_eq!(
+            result.resolved[0].name.as_deref(),
+            Some("aether-instanced-inventory-test:7"),
+            "registered dynamic instance reverses to its name",
+        );
+
+        assert_eq!(result.resolved[1].id, unseen_tag);
+        assert_eq!(
+            result.resolved[1].name, None,
+            "unregistered id misses the runtime registry",
+        );
+
+        assert_eq!(result.resolved[2].id, mailbox_tag);
+        assert_eq!(
+            result.resolved[2].name, None,
+            "a static name lives in the manifest, not the dynamic arm",
+        );
+
+        assert_eq!(result.resolved[3].id, "not-a-tagged-id");
+        assert_eq!(
+            result.resolved[3].name, None,
+            "a malformed id reports None without aborting the batch",
+        );
+    }
+
+    /// A native test cap with a synchronous `-> R` handler — the
+    /// surface ADR-0109 §5 makes `aether.inventory.handlers` carry.
+    /// Its `#[actor]` expansion submits a link-time `HandlerEntry`
+    /// declaring `ProbeReq -> ProbeReply`.
+    #[derive(
+        serde::Serialize, serde::Deserialize, aether_data::Kind, aether_data::Schema, Debug, Clone,
+    )]
+    #[kind(name = "aether.test.inventory_handlers.req")]
+    struct ProbeReq {}
+
+    #[derive(
+        serde::Serialize, serde::Deserialize, aether_data::Kind, aether_data::Schema, Debug, Clone,
+    )]
+    #[kind(name = "aether.test.inventory_handlers.reply")]
+    struct ProbeReply {}
+
+    struct ReplyProbeCap;
+
+    #[actor]
+    impl NativeActor for ReplyProbeCap {
+        type Config = ();
+        const NAMESPACE: &'static str = "aether.test.inventory_handlers.probe";
+
+        fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+            Ok(Self)
         }
 
-        /// ADR-0091: `ListKinds` returns the substrate's authoritative
-        /// kind vocabulary. A kind registered in the bench's `Registry`
-        /// — emulating the `register_or_match_all` path
-        /// `ComponentHostCapability::handle_load` follows — shows up in
-        /// the reply with the matching `KindId`, name, and a
-        /// wire-encoded `SchemaType` that decodes back to the
-        /// original schema. This is the live-projection ADR-0091
-        /// requires: the same `Arc<Registry>` `component.rs` mutates is
-        /// what the cap reads on every call.
-        #[test]
-        fn list_kinds_projects_a_registered_kind() {
-            use aether_data::{KindDescriptor, KindId, SchemaType, canonical::kind_id_from_parts};
-
-            let mut fix = fixture();
-
-            // Register a fresh kind directly on the registry — same
-            // entry point `register_or_match_all` walks per descriptor.
-            // A `String`-shaped param keeps the schema lookup distinct
-            // from any link-time entry the static vocabulary already
-            // submits.
-            let desc = KindDescriptor {
-                name: "aether.test.list_kinds_projection".to_owned(),
-                schema: SchemaType::String,
-            };
-            let expected_id = KindId(kind_id_from_parts(&desc.name, &desc.schema));
-            // Use the bench's registry (the one the cap also cloned in
-            // `fixture`) so the read sees what we just wrote.
-            fix.cap
-                .registry
-                .register_kind_with_descriptor(desc.clone())
-                .expect("register fresh kind");
-
-            let mut ctx = session_ctx(&fix.transport);
-            let result = fix.cap.on_list_kinds(&mut ctx, ListKinds {});
-            drop(ctx);
-
-            let entry = result
-                .kinds
-                .iter()
-                .find(|k| k.name == desc.name)
-                .unwrap_or_else(|| {
-                    panic!(
-                        "ListKindsResult should carry the registered kind; names: {:?}",
-                        result.kinds.iter().map(|k| &k.name).collect::<Vec<_>>(),
-                    )
-                });
-            assert_eq!(entry.id, expected_id, "id matches kind_id_from_parts");
-            let schema: SchemaType =
-                wire::from_bytes(&entry.schema_wire).expect("schema_wire round-trips through wire");
-            assert!(
-                matches!(schema, SchemaType::String),
-                "schema decodes back to the originally registered SchemaType",
-            );
+        /// A synchronous `-> ProbeReply` handler — the reply contract
+        /// the link-time inventory captures. Stateless: the link-time
+        /// `HandlerEntry` is what the test reads, not handler state.
+        #[allow(clippy::unused_self)]
+        #[handler]
+        fn on_probe(&mut self, _ctx: &mut NativeCtx<'_>, _mail: ProbeReq) -> ProbeReply {
+            ProbeReply {}
         }
+    }
 
-        /// A registered dynamic-instance id resolves to its name; an
-        /// unregistered id and a malformed string both report `None`
-        /// (the latter without sinking its siblings). Order + `id` echo
-        /// are preserved.
-        // Constructs a well-formed mailbox id the runtime registry never holds
-        // to drive the miss path — incidental test data, not a real address.
-        #[allow(clippy::disallowed_methods)]
-        #[test]
-        fn resolve_returns_registered_name_and_none_on_miss() {
-            // Register a dynamic instance name the way the runtime name
-            // builders do (a name no static template instantiates).
-            let registered = ThreadId::from_name("aether-instanced-inventory-test:7");
-            register(registered.0, "aether-instanced-inventory-test:7");
-            let registered_tag =
-                tagged_id::encode(registered.0).expect("ThreadId always tag-encodes");
+    /// ADR-0109 §5: a native cap's `-> R` handler surfaces `In -> Out`
+    /// through `aether.inventory.handlers`. `on_handlers` projects the
+    /// process-global link-time `HandlerEntry` inventory onto
+    /// `HandlersResult`; the `ReplyProbeCap` entry round-trips its
+    /// input kind (id + name) and its `Some(ProbeReply)` reply
+    /// contract.
+    #[test]
+    fn handlers_surfaces_native_reply_contract() {
+        use aether_actor::Addressable;
+        use aether_data::Kind;
+        // Force `ReplyProbeCap`'s `#[actor]` HandlerEntry submission to
+        // link into this test binary.
+        assert_eq!(
+            ReplyProbeCap::NAMESPACE,
+            "aether.test.inventory_handlers.probe"
+        );
 
-            // An id the registry has never seen.
-            let unseen = thread_id_from_name("aether-instanced-never-registered");
-            let unseen_tag = tagged_id::encode(unseen.0).expect("ThreadId always tag-encodes");
+        let mut fix = fixture();
+        let mut ctx = session_ctx(&fix.transport);
+        let result = InventoryCapability::on_handlers(&mut fix.state, &mut ctx, ListHandlers {});
+        drop(ctx);
 
-            // A well-formed mailbox id that the runtime registry doesn't
-            // hold (statics live in the static map, not the dynamic arm),
-            // so `resolve_runtime` misses it -> None.
-            let mailbox = mailbox_id_from_name("aether.fs");
-            let mailbox_tag = tagged_id::encode(mailbox.0).expect("MailboxId tag-encodes");
-
-            let mut fix = fixture();
-            let mut ctx = session_ctx(&fix.transport);
-            let result = fix.cap.on_resolve(
-                &mut ctx,
-                Resolve {
-                    ids: vec![
-                        registered_tag.clone(),
-                        unseen_tag.clone(),
-                        mailbox_tag.clone(),
-                        "not-a-tagged-id".to_string(),
-                    ],
-                },
-            );
-            drop(ctx);
-            assert_eq!(result.resolved.len(), 4, "one entry per requested id");
-
-            assert_eq!(result.resolved[0].id, registered_tag);
-            assert_eq!(
-                result.resolved[0].name.as_deref(),
-                Some("aether-instanced-inventory-test:7"),
-                "registered dynamic instance reverses to its name",
-            );
-
-            assert_eq!(result.resolved[1].id, unseen_tag);
-            assert_eq!(
-                result.resolved[1].name, None,
-                "unregistered id misses the runtime registry",
-            );
-
-            assert_eq!(result.resolved[2].id, mailbox_tag);
-            assert_eq!(
-                result.resolved[2].name, None,
-                "a static name lives in the manifest, not the dynamic arm",
-            );
-
-            assert_eq!(result.resolved[3].id, "not-a-tagged-id");
-            assert_eq!(
-                result.resolved[3].name, None,
-                "a malformed id reports None without aborting the batch",
-            );
-        }
-
-        /// A native test cap with a synchronous `-> R` handler — the
-        /// surface ADR-0109 §5 makes `aether.inventory.handlers` carry.
-        /// Its `#[actor]` expansion submits a link-time `HandlerEntry`
-        /// declaring `ProbeReq -> ProbeReply`.
-        #[derive(
-            serde::Serialize,
-            serde::Deserialize,
-            aether_data::Kind,
-            aether_data::Schema,
-            Debug,
-            Clone,
-        )]
-        #[kind(name = "aether.test.inventory_handlers.req")]
-        struct ProbeReq {}
-
-        #[derive(
-            serde::Serialize,
-            serde::Deserialize,
-            aether_data::Kind,
-            aether_data::Schema,
-            Debug,
-            Clone,
-        )]
-        #[kind(name = "aether.test.inventory_handlers.reply")]
-        struct ProbeReply {}
-
-        struct ReplyProbeCap;
-
-        #[actor]
-        impl NativeActor for ReplyProbeCap {
-            type Config = ();
-            const NAMESPACE: &'static str = "aether.test.inventory_handlers.probe";
-
-            fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-                Ok(Self)
-            }
-
-            /// A synchronous `-> ProbeReply` handler — the reply contract
-            /// the link-time inventory captures. Stateless: the link-time
-            /// `HandlerEntry` is what the test reads, not handler state.
-            #[allow(clippy::unused_self)]
-            #[handler]
-            fn on_probe(&mut self, _ctx: &mut NativeCtx<'_>, _mail: ProbeReq) -> ProbeReply {
-                ProbeReply {}
-            }
-        }
-
-        /// ADR-0109 §5: a native cap's `-> R` handler surfaces `In -> Out`
-        /// through `aether.inventory.handlers`. `on_handlers` projects the
-        /// process-global link-time `HandlerEntry` inventory onto
-        /// `HandlersResult`; the `ReplyProbeCap` entry round-trips its
-        /// input kind (id + name) and its `Some(ProbeReply)` reply
-        /// contract.
-        #[test]
-        fn handlers_surfaces_native_reply_contract() {
-            use aether_actor::Addressable;
-            use aether_data::Kind;
-            // Force `ReplyProbeCap`'s `#[actor]` HandlerEntry submission to
-            // link into this test binary.
-            assert_eq!(
-                ReplyProbeCap::NAMESPACE,
-                "aether.test.inventory_handlers.probe"
-            );
-
-            let mut fix = fixture();
-            let mut ctx = session_ctx(&fix.transport);
-            let result = fix.cap.on_handlers(&mut ctx, ListHandlers {});
-            drop(ctx);
-
-            let entry = result
-                .handlers
-                .iter()
-                .find(|h| h.namespace == ReplyProbeCap::NAMESPACE && h.id == <ProbeReq as Kind>::ID)
-                .unwrap_or_else(|| {
-                    panic!(
-                        "HandlersResult should carry the ReplyProbeCap probe handler; \
+        let entry = result
+            .handlers
+            .iter()
+            .find(|h| h.namespace == ReplyProbeCap::NAMESPACE && h.id == <ProbeReq as Kind>::ID)
+            .unwrap_or_else(|| {
+                panic!(
+                    "HandlersResult should carry the ReplyProbeCap probe handler; \
                          namespaces: {:?}",
-                        result
-                            .handlers
-                            .iter()
-                            .map(|h| &h.namespace)
-                            .collect::<Vec<_>>(),
-                    )
-                });
-            assert_eq!(
-                entry.name,
-                <ProbeReq as Kind>::NAME,
-                "input kind name round-trips"
-            );
-            assert_eq!(
-                entry.reply,
-                Some(<ProbeReply as Kind>::ID),
-                "a `-> ProbeReply` handler surfaces ProbeReply as its reply (In -> Out)",
-            );
-        }
+                    result
+                        .handlers
+                        .iter()
+                        .map(|h| &h.namespace)
+                        .collect::<Vec<_>>(),
+                )
+            });
+        assert_eq!(
+            entry.name,
+            <ProbeReq as Kind>::NAME,
+            "input kind name round-trips"
+        );
+        assert_eq!(
+            entry.reply,
+            Some(<ProbeReply as Kind>::ID),
+            "a `-> ProbeReply` handler surfaces ProbeReply as its reply (In -> Out)",
+        );
     }
 }

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -147,7 +147,10 @@ pub use input::InputCapability;
 #[cfg(not(target_arch = "wasm32"))]
 pub use input::InputConfig;
 pub use inventory::InventoryCapability;
-#[cfg(not(target_arch = "wasm32"))]
+// ADR-0122 split: `LifecycleConfig` configures the runtime-only
+// `LifecycleCapabilityState`, so it rides the `runtime` gate with the
+// rest of the lifecycle runtime half.
+#[cfg(feature = "runtime")]
 pub use lifecycle::LifecycleConfig;
 pub use lifecycle::{LifecycleCapability, LifecycleMailboxExt};
 

--- a/crates/aether-capabilities/src/lifecycle/mod.rs
+++ b/crates/aether-capabilities/src/lifecycle/mod.rs
@@ -1,5 +1,5 @@
-//! `aether.lifecycle` cap (ADR-0082). The bridged, non-generic
-//! capability the chassis drives one frame at a time.
+//! `aether.lifecycle` cap (ADR-0082). The non-generic capability the
+//! chassis drives one frame at a time.
 //!
 //! The chassis owns cadence: it sends [`LifecycleAdvance`] once per
 //! frame. The cap owns everything else — the lifecycle graph (a data
@@ -8,7 +8,7 @@
 //! the fan-out (the sender side + `broadcast_to_subscribers` in
 //! `mod subscribers`), and the settlement gating (the
 //! advance state machine in `mod settlement`). Because it
-//! is `#[bridge(singleton)]`d like
+//! is `#[actor(singleton)]`d like
 //! [`InputCapability`](crate::input::InputCapability) and
 //! `RenderCapability`, its
 //! `NAMESPACE` is wasm-reachable: a component subscribes a stage via
@@ -41,12 +41,24 @@ use aether_kinds::{
     LifecycleAdvance, LifecycleSubscribe, LifecycleSubscribeSelf, LifecycleUnsubscribe,
     LifecycleUnsubscribeAll, LifecycleUnsubscribeSelf, Quit,
 };
-// Reply types ride only the native handler bodies (via `super::`), so they
-// elide on wasm where `mod native` is compiled out.
+// `LifecycleSubscribeResult` rides the native gate (not `runtime`): the
+// `#[actor]` macro's ADR-0109 `HandlerEntry` inventory submission —
+// emitted on every native build, runtime or not — names the subscribe
+// handlers' reply kind `::ID`, so a transport-only build must see it.
+// `LifecycleAdvanceComplete` is the reply of the two `#[handler::manual]`
+// arms, which declare no manifest reply kind, so it is named only by the
+// runtime handler bodies and rides the `runtime` gate.
+#[cfg(feature = "runtime")]
+use aether_kinds::LifecycleAdvanceComplete;
 #[cfg(not(target_arch = "wasm32"))]
-use aether_kinds::{LifecycleAdvanceComplete, LifecycleSubscribeResult};
+use aether_kinds::LifecycleSubscribeResult;
+
+use aether_actor::actor;
 
 mod graph;
+// `LifecycleStateData` is named only by `mod settlement`'s `resolve_edge`,
+// which rides the `runtime` gate, so the re-export does too.
+#[cfg(feature = "runtime")]
 pub(crate) use graph::LifecycleStateData;
 pub use graph::{
     BuildError, LifecycleGraphBuilder, LifecycleGraphData, NoOpen, OpenNoNext, OpenWithNext,
@@ -55,795 +67,774 @@ pub use graph::{
 mod subscribers;
 pub use subscribers::LifecycleMailboxExt;
 
-#[cfg(not(target_arch = "wasm32"))]
+// The settlement state machine and the boot-config both name the
+// runtime-only `LifecycleCapabilityState`, so both ride the one
+// `feature = "runtime"` gate alongside the rest of the runtime half.
+#[cfg(feature = "runtime")]
 mod settlement;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "runtime")]
 mod config;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "runtime")]
 pub use config::LifecycleConfig;
 
-#[aether_actor::bridge(singleton)]
-mod native {
-    use std::collections::{BTreeMap, BTreeSet};
-    use std::sync::Arc;
-    use std::time::{Duration, Instant};
+/// The `aether.lifecycle` cap **identity** (ADR-0122 identity/runtime
+/// split, ADR-0082). A ZST carrying only the addressing — the
+/// `Addressable` / `HandlesKind` markers and the name-inventory entry,
+/// all emitted always-on by `#[actor]` — so a wasm guest names it via
+/// `ctx.actor::<LifecycleCapability>()` without pulling the substrate
+/// runtime. The state-bearing runtime (`LifecycleCapabilityState` in
+/// `mod runtime`, which owns the data graph, subscriber table, fan-out,
+/// and settlement gating) lives behind the one `feature = "runtime"`
+/// gate; the chassis only feeds the cap [`LifecycleAdvance`] cadence.
+pub struct LifecycleCapability;
 
-    use aether_actor::actor::ctx::OutboundReply;
-    use aether_actor::{Manual, actor};
-    use aether_data::{Kind, KindId, MailboxId as DataMailboxId, mailbox_id_from_name};
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
-    use aether_substrate::mail::mailer::Mailer;
+// The runtime half — the whole `aether_substrate`-typed surface (imports,
+// `LifecycleCapabilityState`, the settlement + fan-out names) — lives in
+// `runtime.rs`, gated once here. The `#[actor] impl` and the state's
+// inherent-method cluster reach it through the `use runtime::*` glob.
+#[cfg(feature = "runtime")]
+mod runtime;
+#[cfg(feature = "runtime")]
+#[allow(clippy::wildcard_imports)]
+use runtime::*;
 
-    use super::config::LifecycleConfig;
-    #[cfg(test)]
-    use super::settlement::ADVANCE_TIMEOUT_MS_DEFAULT;
-    use super::settlement::{PendingAdvance, Step, resolve_edge};
-    use super::subscribers::broadcast_to_subscribers;
-    use super::{
-        LifecycleAdvance, LifecycleAdvanceComplete, LifecycleGraphData, LifecycleSubscribe,
-        LifecycleSubscribeResult, LifecycleSubscribeSelf, LifecycleUnsubscribe,
-        LifecycleUnsubscribeAll, LifecycleUnsubscribeSelf, Quit, Settled,
-    };
+#[actor(singleton)]
+impl NativeActor for LifecycleCapability {
+    /// The runtime state this identity boots into (ADR-0122 split): the
+    /// data graph, subscriber table, state pointer, and settlement gating.
+    type State = LifecycleCapabilityState;
 
-    /// The `aether.lifecycle` capability (ADR-0082). Non-generic and
-    /// bridged, so a wasm guest names it via
-    /// `ctx.actor::<LifecycleCapability>()`. Owns the data graph, the
-    /// subscriber table, the fan-out, and the settlement gating; the
-    /// chassis only feeds it [`LifecycleAdvance`] cadence.
-    ///
-    /// Plain-field shape (ADR-0078): every handler runs on the cap's
-    /// single dispatcher thread, so no `Mutex` / `Arc<Atomic*>` is needed
-    /// for the subscriber table or state pointer.
-    ///
-    /// Fields are `pub(crate)` so the settlement state machine
-    /// (`mod settlement`) can carry its inherent-impl
-    /// cluster in a sibling file without nesting under `native`.
-    pub struct LifecycleCapability {
-        pub(crate) graph: LifecycleGraphData,
-        /// Subscriber table keyed by stage kind id (ADR-0082 §7).
-        pub(crate) subscribers: BTreeMap<KindId, BTreeSet<DataMailboxId>>,
-        /// Kind id of the state the cap will broadcast on the next
-        /// [`LifecycleAdvance`]. Starts at `graph.start()`; mutated after
-        /// each settled advance to the resolved next/quit edge target.
-        pub(crate) current_state: KindId,
-        /// True once the lifecycle reached a terminal — further advances
-        /// are no-ops.
-        pub(crate) terminal_reached: bool,
-        /// Quit flag (ADR-0082 §3). Set by inbound [`Quit`] mail;
-        /// consumed at the next state whose graph declares a `quit` edge.
-        pub(crate) quit_pending: bool,
-        /// In-flight advance awaiting settlement (ADR-0082 §6).
-        pub(crate) pending: Option<PendingAdvance>,
-        /// Deadline for a pending advance's `Settled`
-        /// (iamacoffeepot/aether#1048). Set from
-        /// `AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS`.
-        pub(crate) advance_timeout: Duration,
-        /// EWMA of observed `Sent`→`Settled` latency (ADR-0082 §6),
-        /// updated once per settle. `None` until the first settlement.
-        pub(crate) settlement_latency_ewma: Option<Duration>,
-        /// Last time a slow-settlement warn fired, for the
-        /// `SLOW_SETTLE_WARN_COOLDOWN` rate limit.
-        pub(crate) last_slow_warn: Option<Instant>,
-        /// `Arc<Mailer>` cached at init for `subscribe_settlement_mail`
-        /// calls inside handlers.
-        pub(crate) mailer: Arc<Mailer>,
+    type Config = LifecycleConfig;
+    const NAMESPACE: &'static str = "aether.lifecycle";
+
+    fn init(
+        config: LifecycleConfig,
+        ctx: &mut NativeInitCtx<'_>,
+    ) -> Result<LifecycleCapabilityState, BootError> {
+        let LifecycleConfig {
+            graph,
+            initial_subscribers,
+            advance_timeout_millis,
+        } = config;
+        let current_state = graph.start();
+        let mailer = ctx.mailer();
+        let mut subscribers: BTreeMap<KindId, BTreeSet<DataMailboxId>> = BTreeMap::new();
+        for (stage, mailbox) in initial_subscribers {
+            // Reject unknown-stage subscriptions at boot rather than
+            // silently dropping mail at runtime — ADR-0082 §7's
+            // fail-fast contract applies to compile-site config too.
+            if graph.state(stage).is_none() && !graph.is_terminal(stage) {
+                return Err(BootError::Other(
+                    format!(
+                        "aether.lifecycle: initial subscriber references stage {stage:?} not \
+                         declared by graph"
+                    )
+                    .into(),
+                ));
+            }
+            subscribers.entry(stage).or_default().insert(mailbox);
+        }
+        Ok(LifecycleCapabilityState {
+            graph,
+            subscribers,
+            current_state,
+            terminal_reached: false,
+            quit_pending: false,
+            pending: None,
+            advance_timeout: Duration::from_millis(advance_timeout_millis),
+            settlement_latency_ewma: None,
+            last_slow_warn: None,
+            mailer,
+        })
     }
 
-    #[actor]
-    impl NativeActor for LifecycleCapability {
-        type Config = LifecycleConfig;
-        const NAMESPACE: &'static str = "aether.lifecycle";
-
-        fn init(config: LifecycleConfig, ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            let LifecycleConfig {
-                graph,
-                initial_subscribers,
-                advance_timeout_millis,
-            } = config;
-            let current_state = graph.start();
-            let mailer = ctx.mailer();
-            let mut subscribers: BTreeMap<KindId, BTreeSet<DataMailboxId>> = BTreeMap::new();
-            for (stage, mailbox) in initial_subscribers {
-                // Reject unknown-stage subscriptions at boot rather than
-                // silently dropping mail at runtime — ADR-0082 §7's
-                // fail-fast contract applies to compile-site config too.
-                if graph.state(stage).is_none() && !graph.is_terminal(stage) {
-                    return Err(BootError::Other(
-                        format!(
-                            "aether.lifecycle: initial subscriber references stage {stage:?} not \
-                             declared by graph"
-                        )
-                        .into(),
-                    ));
-                }
-                subscribers.entry(stage).or_default().insert(mailbox);
-            }
-            Ok(Self {
-                graph,
-                subscribers,
-                current_state,
-                terminal_reached: false,
-                quit_pending: false,
-                pending: None,
-                advance_timeout: Duration::from_millis(advance_timeout_millis),
-                settlement_latency_ewma: None,
-                last_slow_warn: None,
-                mailer,
-            })
-        }
-
-        /// Subscribe a mailbox to a lifecycle stage broadcast (ADR-0082
-        /// §7). Replies with [`LifecycleSubscribeResult`] —
-        /// `Err { stage, error }` when the stage isn't declared in this
-        /// chassis's graph (fail-fast at wire time).
-        ///
-        /// # Agent
-        /// `LifecycleSubscribe { stage, mailbox }`. Stage must be a kind
-        /// id registered as a state or terminal in the lifecycle graph.
-        #[handler]
-        fn on_subscribe(
-            &mut self,
-            _ctx: &mut NativeCtx<'_>,
-            payload: LifecycleSubscribe,
-        ) -> LifecycleSubscribeResult {
-            let stage_kind = KindId(payload.stage);
-            let mailbox = DataMailboxId(payload.mailbox);
-            let known =
-                self.graph.state(stage_kind).is_some() || self.graph.is_terminal(stage_kind);
-            if known {
-                self.subscribers
-                    .entry(stage_kind)
-                    .or_default()
-                    .insert(mailbox);
-                LifecycleSubscribeResult::Ok
-            } else {
-                LifecycleSubscribeResult::Err {
-                    stage: payload.stage,
-                    error: format!(
-                        "stage {stage_kind:?} is not declared by this chassis's lifecycle graph"
-                    ),
-                }
+    /// Subscribe a mailbox to a lifecycle stage broadcast (ADR-0082
+    /// §7). Replies with [`LifecycleSubscribeResult`] —
+    /// `Err { stage, error }` when the stage isn't declared in this
+    /// chassis's graph (fail-fast at wire time).
+    ///
+    /// # Agent
+    /// `LifecycleSubscribe { stage, mailbox }`. Stage must be a kind
+    /// id registered as a state or terminal in the lifecycle graph.
+    #[handler]
+    fn on_subscribe(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        payload: LifecycleSubscribe,
+    ) -> LifecycleSubscribeResult {
+        let stage_kind = KindId(payload.stage);
+        let mailbox = DataMailboxId(payload.mailbox);
+        let known = state.graph.state(stage_kind).is_some() || state.graph.is_terminal(stage_kind);
+        if known {
+            state
+                .subscribers
+                .entry(stage_kind)
+                .or_default()
+                .insert(mailbox);
+            LifecycleSubscribeResult::Ok
+        } else {
+            LifecycleSubscribeResult::Err {
+                stage: payload.stage,
+                error: format!(
+                    "stage {stage_kind:?} is not declared by this chassis's lifecycle graph"
+                ),
             }
         }
+    }
 
-        /// Subscribe the *sending* actor to a lifecycle stage broadcast
-        /// (ADR-0082 §7, ADR-0083). Resolves the subscriber from the
-        /// inbound envelope's host-stamped `Source` via
-        /// [`source_mailbox`](NativeCtx::source_mailbox) rather than a
-        /// caller-supplied mailbox, so the subscriber cannot be forged.
-        /// `None` means the sender has no local mailbox (an external
-        /// session or another engine) — reply `Err` and subscribe
-        /// nothing, which gates the reflexive form to in-process actors
-        /// by construction. Reuses [`Self::on_subscribe`]'s insert path
-        /// once the mailbox is resolved.
-        ///
-        /// # Agent
-        /// `LifecycleSubscribeSelf { stage }`. Stage must be a kind id
-        /// registered as a state or terminal in the lifecycle graph.
-        #[handler]
-        fn on_subscribe_self(
-            &mut self,
-            ctx: &mut NativeCtx<'_>,
-            payload: LifecycleSubscribeSelf,
-        ) -> LifecycleSubscribeResult {
-            let stage_kind = KindId(payload.stage);
-            match ctx.source_mailbox() {
-                None => LifecycleSubscribeResult::Err {
-                    stage: payload.stage,
-                    error: "aether.lifecycle.subscribe_self requires a local component sender; \
+    /// Subscribe the *sending* actor to a lifecycle stage broadcast
+    /// (ADR-0082 §7, ADR-0083). Resolves the subscriber from the
+    /// inbound envelope's host-stamped `Source` via
+    /// [`source_mailbox`](NativeCtx::source_mailbox) rather than a
+    /// caller-supplied mailbox, so the subscriber cannot be forged.
+    /// `None` means the sender has no local mailbox (an external
+    /// session or another engine) — reply `Err` and subscribe
+    /// nothing, which gates the reflexive form to in-process actors
+    /// by construction. Reuses [`Self::on_subscribe`]'s insert path
+    /// once the mailbox is resolved.
+    ///
+    /// # Agent
+    /// `LifecycleSubscribeSelf { stage }`. Stage must be a kind id
+    /// registered as a state or terminal in the lifecycle graph.
+    #[handler]
+    fn on_subscribe_self(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        payload: LifecycleSubscribeSelf,
+    ) -> LifecycleSubscribeResult {
+        let stage_kind = KindId(payload.stage);
+        match ctx.source_mailbox() {
+            None => LifecycleSubscribeResult::Err {
+                stage: payload.stage,
+                error: "aether.lifecycle.subscribe_self requires a local component sender; \
                             an external session or remote engine must use \
                             aether.lifecycle.subscribe with an explicit mailbox"
-                        .to_string(),
-                },
-                Some(sender) => {
-                    let known = self.graph.state(stage_kind).is_some()
-                        || self.graph.is_terminal(stage_kind);
-                    if known {
-                        self.subscribers
-                            .entry(stage_kind)
-                            .or_default()
-                            .insert(DataMailboxId(sender.0));
-                        LifecycleSubscribeResult::Ok
-                    } else {
-                        LifecycleSubscribeResult::Err {
-                            stage: payload.stage,
-                            error: format!(
-                                "stage {stage_kind:?} is not declared by this chassis's \
+                    .to_string(),
+            },
+            Some(sender) => {
+                let known =
+                    state.graph.state(stage_kind).is_some() || state.graph.is_terminal(stage_kind);
+                if known {
+                    state
+                        .subscribers
+                        .entry(stage_kind)
+                        .or_default()
+                        .insert(DataMailboxId(sender.0));
+                    LifecycleSubscribeResult::Ok
+                } else {
+                    LifecycleSubscribeResult::Err {
+                        stage: payload.stage,
+                        error: format!(
+                            "stage {stage_kind:?} is not declared by this chassis's \
                                  lifecycle graph"
-                            ),
-                        }
+                        ),
                     }
                 }
             }
         }
+    }
 
-        /// Unsubscribe a mailbox from a lifecycle stage broadcast.
-        /// Idempotent on "not currently subscribed."
-        ///
-        /// # Agent
-        /// `LifecycleUnsubscribe { stage, mailbox }`.
-        #[handler]
-        fn on_unsubscribe(
-            &mut self,
-            _ctx: &mut NativeCtx<'_>,
-            payload: LifecycleUnsubscribe,
-        ) -> LifecycleSubscribeResult {
-            let stage_kind = KindId(payload.stage);
-            let mailbox = DataMailboxId(payload.mailbox);
-            let known =
-                self.graph.state(stage_kind).is_some() || self.graph.is_terminal(stage_kind);
-            if known {
-                if let Some(set) = self.subscribers.get_mut(&stage_kind) {
-                    set.remove(&mailbox);
-                }
-                LifecycleSubscribeResult::Ok
-            } else {
-                LifecycleSubscribeResult::Err {
-                    stage: payload.stage,
-                    error: format!(
-                        "stage {stage_kind:?} is not declared by this chassis's lifecycle graph"
-                    ),
-                }
+    /// Unsubscribe a mailbox from a lifecycle stage broadcast.
+    /// Idempotent on "not currently subscribed."
+    ///
+    /// # Agent
+    /// `LifecycleUnsubscribe { stage, mailbox }`.
+    #[handler]
+    fn on_unsubscribe(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        payload: LifecycleUnsubscribe,
+    ) -> LifecycleSubscribeResult {
+        let stage_kind = KindId(payload.stage);
+        let mailbox = DataMailboxId(payload.mailbox);
+        let known = state.graph.state(stage_kind).is_some() || state.graph.is_terminal(stage_kind);
+        if known {
+            if let Some(set) = state.subscribers.get_mut(&stage_kind) {
+                set.remove(&mailbox);
+            }
+            LifecycleSubscribeResult::Ok
+        } else {
+            LifecycleSubscribeResult::Err {
+                stage: payload.stage,
+                error: format!(
+                    "stage {stage_kind:?} is not declared by this chassis's lifecycle graph"
+                ),
             }
         }
+    }
 
-        /// Unsubscribe the *sending* actor from a lifecycle stage
-        /// broadcast (ADR-0082 §7, ADR-0083). Resolves the subscriber
-        /// from the inbound envelope's host-stamped `Source` via
-        /// [`source_mailbox`](NativeCtx::source_mailbox), mirroring
-        /// [`Self::on_subscribe_self`]. `None` (no local sender) replies
-        /// `Err`. Idempotent on "not currently subscribed."
-        ///
-        /// # Agent
-        /// `LifecycleUnsubscribeSelf { stage }`.
-        #[handler]
-        fn on_unsubscribe_self(
-            &mut self,
-            ctx: &mut NativeCtx<'_>,
-            payload: LifecycleUnsubscribeSelf,
-        ) -> LifecycleSubscribeResult {
-            let stage_kind = KindId(payload.stage);
-            match ctx.source_mailbox() {
-                None => LifecycleSubscribeResult::Err {
-                    stage: payload.stage,
-                    error: "aether.lifecycle.unsubscribe_self requires a local component sender; \
+    /// Unsubscribe the *sending* actor from a lifecycle stage
+    /// broadcast (ADR-0082 §7, ADR-0083). Resolves the subscriber
+    /// from the inbound envelope's host-stamped `Source` via
+    /// [`source_mailbox`](NativeCtx::source_mailbox), mirroring
+    /// [`Self::on_subscribe_self`]. `None` (no local sender) replies
+    /// `Err`. Idempotent on "not currently subscribed."
+    ///
+    /// # Agent
+    /// `LifecycleUnsubscribeSelf { stage }`.
+    #[handler]
+    fn on_unsubscribe_self(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        payload: LifecycleUnsubscribeSelf,
+    ) -> LifecycleSubscribeResult {
+        let stage_kind = KindId(payload.stage);
+        match ctx.source_mailbox() {
+            None => LifecycleSubscribeResult::Err {
+                stage: payload.stage,
+                error: "aether.lifecycle.unsubscribe_self requires a local component sender; \
                             an external session or remote engine must use \
                             aether.lifecycle.unsubscribe with an explicit mailbox"
-                        .to_string(),
-                },
-                Some(sender) => {
-                    let known = self.graph.state(stage_kind).is_some()
-                        || self.graph.is_terminal(stage_kind);
-                    if known {
-                        if let Some(set) = self.subscribers.get_mut(&stage_kind) {
-                            set.remove(&DataMailboxId(sender.0));
-                        }
-                        LifecycleSubscribeResult::Ok
-                    } else {
-                        LifecycleSubscribeResult::Err {
-                            stage: payload.stage,
-                            error: format!(
-                                "stage {stage_kind:?} is not declared by this chassis's \
+                    .to_string(),
+            },
+            Some(sender) => {
+                let known =
+                    state.graph.state(stage_kind).is_some() || state.graph.is_terminal(stage_kind);
+                if known {
+                    if let Some(set) = state.subscribers.get_mut(&stage_kind) {
+                        set.remove(&DataMailboxId(sender.0));
+                    }
+                    LifecycleSubscribeResult::Ok
+                } else {
+                    LifecycleSubscribeResult::Err {
+                        stage: payload.stage,
+                        error: format!(
+                            "stage {stage_kind:?} is not declared by this chassis's \
                                  lifecycle graph"
-                            ),
-                        }
+                        ),
                     }
                 }
             }
         }
+    }
 
-        /// Remove `mailbox` from every lifecycle stage's subscriber set.
-        /// Issued by `ComponentHostCapability` on `DropComponent` so a
-        /// dropped trampoline doesn't keep receiving stage-broadcast mail
-        /// — the lifecycle-family counterpart of
-        /// [`InputCapability::on_unsubscribe_all`](crate::input::InputCapability),
-        /// which the same drop path notifies for `aether.input`. No
-        /// mailbox-validation: the trampoline's mailbox is already torn
-        /// down by the time this fires; we accept any id and purge it from
-        /// every stage. No reply.
-        ///
-        /// # Agent
-        /// `LifecycleUnsubscribeAll { mailbox }`. Idempotent.
-        #[handler]
-        fn on_unsubscribe_all(
-            &mut self,
-            _ctx: &mut NativeCtx<'_>,
-            payload: LifecycleUnsubscribeAll,
-        ) {
-            for set in self.subscribers.values_mut() {
-                set.remove(&DataMailboxId(payload.mailbox));
+    /// Remove `mailbox` from every lifecycle stage's subscriber set.
+    /// Issued by `ComponentHostCapability` on `DropComponent` so a
+    /// dropped trampoline doesn't keep receiving stage-broadcast mail
+    /// — the lifecycle-family counterpart of
+    /// [`InputCapability::on_unsubscribe_all`](crate::input::InputCapability),
+    /// which the same drop path notifies for `aether.input`. No
+    /// mailbox-validation: the trampoline's mailbox is already torn
+    /// down by the time this fires; we accept any id and purge it from
+    /// every stage. No reply.
+    ///
+    /// # Agent
+    /// `LifecycleUnsubscribeAll { mailbox }`. Idempotent.
+    #[handler]
+    fn on_unsubscribe_all(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        payload: LifecycleUnsubscribeAll,
+    ) {
+        for set in state.subscribers.values_mut() {
+            set.remove(&DataMailboxId(payload.mailbox));
+        }
+    }
+
+    /// Lifecycle escape signal (ADR-0082 §3). Sets `quit_pending =
+    /// true`; the next state in the graph that declares a `quit` edge
+    /// consumes the flag.
+    ///
+    /// # Agent
+    /// `Quit {}`. Sent by chassis bridges from ctrlc / winit
+    /// `WindowEvent::CloseRequested` / future hub-shutdown mail.
+    #[handler]
+    fn on_quit(state: &mut Self::State, _ctx: &mut NativeCtx<'_>, _payload: Quit) {
+        state.quit_pending = true;
+    }
+
+    /// Drive the lifecycle one step (ADR-0082 §2). Broadcast the
+    /// current state's signal to every subscriber registered for
+    /// that stage, subscribe settlement on the broadcast root, and
+    /// stash a [`PendingAdvance`] until [`Settled`] arrives. The
+    /// state pointer mutates in [`Self::on_settled`], not here, so a
+    /// chassis that overruns its cadence and sends two
+    /// `LifecycleAdvance` mails in close succession sees the second
+    /// warn-drop rather than skipping ahead through unsettled states.
+    ///
+    /// # Agent
+    /// `LifecycleAdvance {}`. Sent by the chassis main loop each
+    /// frame. Reply: [`LifecycleAdvanceComplete`] once the broadcast
+    /// root settles.
+    #[handler::manual]
+    fn on_advance(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_, Manual>,
+        _payload: LifecycleAdvance,
+    ) {
+        if state.terminal_reached {
+            // Already done — reply immediately with zeros so the
+            // chassis main loop unblocks and can break on `next == 0`.
+            ctx.reply(&LifecycleAdvanceComplete {
+                completed: 0,
+                next: 0,
+            });
+            return;
+        }
+
+        if state.pending.is_some() {
+            // Overlap: a prior advance hasn't settled yet. Normally
+            // the chassis main loop wait-replies on every Advance, so
+            // this is a duplicate-cadence-source bug — warn-and-drop
+            // without state mutation. But if the pending advance has
+            // blown past `advance_timeout`, its `Settled` is not
+            // coming (a saturated settlement pipeline,
+            // iamacoffeepot/aether#1048): force-complete it so the
+            // lifecycle degrades to a stutter instead of wedging
+            // forever, then fall through to process *this* advance.
+            if !state.pending_timed_out() {
+                let pending = state
+                    .pending
+                    .as_ref()
+                    .expect("pending.is_some() checked above");
+                tracing::warn!(
+                    target: "aether_capabilities::lifecycle",
+                    current = ?state.current_state,
+                    pending_root = ?pending.root,
+                    pending_for_millis = pending.started.elapsed().as_millis(),
+                    stuck_stage = %pending.completed_kind,
+                    fanout = ?state.subscribers.get(&pending.completed_kind),
+                    "LifecycleAdvance received while a prior advance is still in flight; dropping"
+                );
+                return;
             }
-        }
-
-        /// Lifecycle escape signal (ADR-0082 §3). Sets `quit_pending =
-        /// true`; the next state in the graph that declares a `quit` edge
-        /// consumes the flag.
-        ///
-        /// # Agent
-        /// `Quit {}`. Sent by chassis bridges from ctrlc / winit
-        /// `WindowEvent::CloseRequested` / future hub-shutdown mail.
-        #[handler]
-        fn on_quit(&mut self, _ctx: &mut NativeCtx<'_>, _payload: Quit) {
-            self.quit_pending = true;
-        }
-
-        /// Drive the lifecycle one step (ADR-0082 §2). Broadcast the
-        /// current state's signal to every subscriber registered for
-        /// that stage, subscribe settlement on the broadcast root, and
-        /// stash a [`PendingAdvance`] until [`Settled`] arrives. The
-        /// state pointer mutates in [`Self::on_settled`], not here, so a
-        /// chassis that overruns its cadence and sends two
-        /// `LifecycleAdvance` mails in close succession sees the second
-        /// warn-drop rather than skipping ahead through unsettled states.
-        ///
-        /// # Agent
-        /// `LifecycleAdvance {}`. Sent by the chassis main loop each
-        /// frame. Reply: [`LifecycleAdvanceComplete`] once the broadcast
-        /// root settles.
-        #[handler::manual]
-        fn on_advance(&mut self, ctx: &mut NativeCtx<'_, Manual>, _payload: LifecycleAdvance) {
-            if self.terminal_reached {
-                // Already done — reply immediately with zeros so the
-                // chassis main loop unblocks and can break on `next == 0`.
+            state.force_complete_pending(ctx);
+            if state.terminal_reached {
                 ctx.reply(&LifecycleAdvanceComplete {
                     completed: 0,
                     next: 0,
                 });
                 return;
             }
+        }
 
-            if self.pending.is_some() {
-                // Overlap: a prior advance hasn't settled yet. Normally
-                // the chassis main loop wait-replies on every Advance, so
-                // this is a duplicate-cadence-source bug — warn-and-drop
-                // without state mutation. But if the pending advance has
-                // blown past `advance_timeout`, its `Settled` is not
-                // coming (a saturated settlement pipeline,
-                // iamacoffeepot/aether#1048): force-complete it so the
-                // lifecycle degrades to a stutter instead of wedging
-                // forever, then fall through to process *this* advance.
-                if !self.pending_timed_out() {
-                    let pending = self
-                        .pending
-                        .as_ref()
-                        .expect("pending.is_some() checked above");
-                    tracing::warn!(
-                        target: "aether_capabilities::lifecycle",
-                        current = ?self.current_state,
-                        pending_root = ?pending.root,
-                        pending_for_millis = pending.started.elapsed().as_millis(),
-                        stuck_stage = %pending.completed_kind,
-                        fanout = ?self.subscribers.get(&pending.completed_kind),
-                        "LifecycleAdvance received while a prior advance is still in flight; dropping"
-                    );
-                    return;
-                }
-                self.force_complete_pending(ctx);
-                if self.terminal_reached {
-                    ctx.reply(&LifecycleAdvanceComplete {
-                        completed: 0,
-                        next: 0,
-                    });
-                    return;
-                }
+        // Decide what to broadcast and the post-settlement state.
+        let step = if let Some(state_data) = state.graph.state(state.current_state) {
+            let next = resolve_edge(state_data, &mut state.quit_pending);
+            Step::StateAdvance {
+                broadcast: state.current_state,
+                next,
             }
+        } else if state.graph.is_terminal(state.current_state) {
+            Step::Terminal {
+                broadcast: state.current_state,
+            }
+        } else {
+            // Defensive — builder finalize prevents this.
+            Step::Unknown
+        };
 
-            // Decide what to broadcast and the post-settlement state.
-            let step = if let Some(state) = self.graph.state(self.current_state) {
-                let next = resolve_edge(state, &mut self.quit_pending);
-                Step::StateAdvance {
-                    broadcast: self.current_state,
-                    next,
-                }
-            } else if self.graph.is_terminal(self.current_state) {
-                Step::Terminal {
-                    broadcast: self.current_state,
-                }
-            } else {
-                // Defensive — builder finalize prevents this.
-                Step::Unknown
-            };
-
-            let (broadcast, next_kind, is_terminal) = match step {
-                Step::StateAdvance { broadcast, next } => (broadcast, next, false),
-                Step::Terminal { broadcast } => (broadcast, KindId(0), true),
-                Step::Unknown => {
-                    ctx.reply(&LifecycleAdvanceComplete {
-                        completed: 0,
-                        next: 0,
-                    });
-                    return;
-                }
-            };
-
-            // Broadcast first — children inherit the inbound's chain root
-            // and parent edge. ADR-0080 settlement counts each child as
-            // in-flight against the root. Stage payloads are empty
-            // signals.
-            broadcast_to_subscribers(ctx, &self.subscribers, broadcast);
-
-            // Subscribe settlement on the inbound's chain root. The
-            // broadcast subtree is part of that chain; settlement fires
-            // once the inbound's `Finished` event drops the in-flight
-            // count to zero (which includes every fan-out descendant).
-            let root = ctx.in_flight_root();
-            let reply_to = ctx.reply_target();
-            if let Some(registry) = self.mailer.settlement_registry() {
-                registry.subscribe_settlement_mail(
-                    root,
-                    // The cap's own mailbox id (Self::NAMESPACE) for its
-                    // settlement subscription — a self-address compute with no
-                    // sibling ctx, not a hardcoded peer namespace.
-                    #[allow(clippy::disallowed_methods)]
-                    mailbox_id_from_name(<Self as aether_actor::Addressable>::NAMESPACE),
-                    <Settled as Kind>::ID,
-                    Arc::clone(&self.mailer),
-                );
-                self.pending = Some(PendingAdvance {
-                    root,
-                    completed_kind: broadcast,
-                    next_kind,
-                    is_terminal,
-                    reply_to,
-                    started: Instant::now(),
-                });
-            } else {
-                // No settlement registry wired (test harness without
-                // tracing). Fall back to fire-and-advance: reply
-                // immediately and mutate state inline.
-                if is_terminal {
-                    self.terminal_reached = true;
-                } else {
-                    self.current_state = next_kind;
-                }
+        let (broadcast, next_kind, is_terminal) = match step {
+            Step::StateAdvance { broadcast, next } => (broadcast, next, false),
+            Step::Terminal { broadcast } => (broadcast, KindId(0), true),
+            Step::Unknown => {
                 ctx.reply(&LifecycleAdvanceComplete {
-                    completed: broadcast.0,
-                    next: next_kind.0,
+                    completed: 0,
+                    next: 0,
                 });
-            }
-        }
-
-        /// Settlement notice for the broadcast root pending in
-        /// [`Self::pending`] (ADR-0082 §6). Advances the state pointer,
-        /// flips `terminal_reached` if the settling broadcast was a
-        /// terminal, and replies [`LifecycleAdvanceComplete`] to the
-        /// chassis main loop that issued the [`LifecycleAdvance`].
-        ///
-        /// `Settled` notices for unrelated roots drop without state
-        /// mutation.
-        ///
-        /// # Agent
-        /// `Settled { root }`. Synthesised by the settlement registry
-        /// when the in-flight count for `root` reaches zero; not a public
-        /// API for user code.
-        #[handler::manual]
-        fn on_settled(&mut self, ctx: &mut NativeCtx<'_, Manual>, payload: Settled) {
-            let Some(pending) = self.pending.as_ref() else {
-                return;
-            };
-            if payload.root != pending.root {
                 return;
             }
-            let latency = pending.started.elapsed();
-            let root = pending.root;
-            let completed = pending.completed_kind.0;
-            let next = pending.next_kind.0;
-            let reply_to = pending.reply_to;
-            let is_terminal = pending.is_terminal;
-            let next_kind = pending.next_kind;
-            // Drop pending before reply so the reply-side mutation is
-            // visible if a follow-on Advance lands inside the reply path.
-            self.pending = None;
-            if is_terminal {
-                self.terminal_reached = true;
-            } else {
-                self.current_state = next_kind;
-            }
-            self.record_settlement_latency(latency, root);
-            // Route the reply to whoever issued the LifecycleAdvance —
-            // chassis main loops block on it to gate the next frame.
-            ctx.reply_to(reply_to, &LifecycleAdvanceComplete { completed, next });
-        }
-    }
+        };
 
-    impl LifecycleCapability {
-        /// Read-only access to the current state's kind id (test/inspect
-        /// surface). Production callers observe lifecycle progress via
-        /// subscribed stage broadcasts rather than peeking at this.
-        #[must_use]
-        pub fn current_state(&self) -> KindId {
-            self.current_state
-        }
+        // Broadcast first — children inherit the inbound's chain root
+        // and parent edge. ADR-0080 settlement counts each child as
+        // in-flight against the root. Stage payloads are empty
+        // signals.
+        broadcast_to_subscribers(ctx, &state.subscribers, broadcast);
 
-        /// True once the lifecycle has broadcast a terminal state and
-        /// further advances are no-ops.
-        #[must_use]
-        pub fn is_terminal(&self) -> bool {
-            self.terminal_reached
-        }
-
-        /// True if a [`Quit`] mail has arrived but not yet been consumed.
-        #[must_use]
-        pub fn quit_pending(&self) -> bool {
-            self.quit_pending
-        }
-    }
-
-    /// Construction-level cap fixture: a Render→Present→Shutdown
-    /// data graph + a fresh mailer, built directly (no chassis boot),
-    /// with the supplied advance timeout. Shared with
-    /// `mod settlement`'s tests via `pub(crate)`.
-    #[cfg(test)]
-    pub fn test_cap(advance_timeout: Duration) -> LifecycleCapability {
-        use aether_kinds::{Present, Render, Shutdown};
-        use aether_substrate::mail::registry::Registry;
-
-        let graph = LifecycleGraphData::builder()
-            .state::<Render>()
-            .next::<Present>()
-            .state::<Present>()
-            .next::<Shutdown>()
-            .quit::<Shutdown>()
-            .terminal::<Shutdown>()
-            .start::<Render>()
-            .build()
-            .expect("test setup: graph builds");
-        let mailer = Arc::new(Mailer::new(Arc::new(Registry::default())));
-        LifecycleCapability {
-            current_state: graph.start(),
-            graph,
-            subscribers: BTreeMap::new(),
-            terminal_reached: false,
-            quit_pending: false,
-            pending: None,
-            advance_timeout,
-            settlement_latency_ewma: None,
-            last_slow_warn: None,
-            mailer,
-        }
-    }
-
-    /// A `Tick`→`Shutdown` graph fixture (the round-trip test wants
-    /// `Tick` as a declared stage, which [`test_cap`]'s Render-rooted
-    /// graph doesn't carry).
-    #[cfg(test)]
-    pub fn tick_start_graph_cap() -> LifecycleCapability {
-        use aether_kinds::{Shutdown, Tick};
-        use aether_substrate::mail::registry::Registry;
-
-        let graph = LifecycleGraphData::builder()
-            .state::<Tick>()
-            .next::<Shutdown>()
-            .terminal::<Shutdown>()
-            .start::<Tick>()
-            .build()
-            .expect("test setup: tick graph builds");
-        let mailer = Arc::new(Mailer::new(Arc::new(Registry::default())));
-        LifecycleCapability {
-            current_state: graph.start(),
-            graph,
-            subscribers: BTreeMap::new(),
-            terminal_reached: false,
-            quit_pending: false,
-            pending: None,
-            advance_timeout: Duration::from_millis(ADVANCE_TIMEOUT_MS_DEFAULT),
-            settlement_latency_ewma: None,
-            last_slow_warn: None,
-            mailer,
-        }
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-        use aether_kinds::{Present, Render, Tick};
-
-        #[test]
-        fn cap_initial_state_is_graph_start() {
-            let cap = test_cap(Duration::from_millis(ADVANCE_TIMEOUT_MS_DEFAULT));
-            assert_eq!(cap.current_state(), <Render as Kind>::ID);
-            assert!(!cap.is_terminal());
-            assert!(!cap.quit_pending());
-        }
-
-        #[test]
-        fn on_unsubscribe_all_purges_mailbox_from_every_stage() {
-            // A dropped trampoline's mailbox must leave every stage's
-            // subscriber set in one shot (the drop-cleanup contract,
-            // mirroring `InputCapability::on_unsubscribe_all`), while
-            // co-subscribers on a shared stage survive.
-            use aether_substrate::actor::native::binding::NativeBinding;
-            use aether_substrate::mail::{MailId, MailboxId, Source};
-
-            let mut cap = test_cap(Duration::from_millis(ADVANCE_TIMEOUT_MS_DEFAULT));
-            let dropped = DataMailboxId(0xDEAD);
-            let survivor = DataMailboxId(0xBEEF);
-            let render = <Render as Kind>::ID;
-            let present = <Present as Kind>::ID;
-            cap.subscribers.entry(render).or_default().insert(dropped);
-            cap.subscribers.entry(render).or_default().insert(survivor);
-            cap.subscribers.entry(present).or_default().insert(dropped);
-
-            let transport = Arc::new(NativeBinding::new_for_test(
-                Arc::clone(&cap.mailer),
-                MailboxId(0),
-            ));
-            let mut ctx = NativeCtx::new(&transport, Source::NONE, MailId::NONE, MailId::NONE);
-            cap.on_unsubscribe_all(&mut ctx, LifecycleUnsubscribeAll { mailbox: dropped.0 });
-
-            assert!(
-                !cap.subscribers[&render].contains(&dropped),
-                "dropped mailbox must leave the Render stage"
+        // Subscribe settlement on the inbound's chain root. The
+        // broadcast subtree is part of that chain; settlement fires
+        // once the inbound's `Finished` event drops the in-flight
+        // count to zero (which includes every fan-out descendant).
+        let root = ctx.in_flight_root();
+        let reply_to = ctx.reply_target();
+        if let Some(registry) = state.mailer.settlement_registry() {
+            registry.subscribe_settlement_mail(
+                root,
+                // The cap's own mailbox id (Self::NAMESPACE) for its
+                // settlement subscription — a self-address compute with no
+                // sibling ctx, not a hardcoded peer namespace.
+                #[allow(clippy::disallowed_methods)]
+                mailbox_id_from_name(<Self as aether_actor::Addressable>::NAMESPACE),
+                <Settled as Kind>::ID,
+                Arc::clone(&state.mailer),
             );
-            assert!(
-                !cap.subscribers[&present].contains(&dropped),
-                "dropped mailbox must leave the Present stage"
-            );
-            assert!(
-                cap.subscribers[&render].contains(&survivor),
-                "co-subscribers on a shared stage must survive the purge"
-            );
-        }
-
-        /// A `subscribe_self` carrying a `Component` source lands *that*
-        /// mailbox in the stage set (ADR-0083: the cap reads the
-        /// subscriber off the host-stamped envelope, not a payload field).
-        #[test]
-        fn subscribe_self_subscribes_the_component_source() {
-            use aether_substrate::actor::native::binding::NativeBinding;
-            use aether_substrate::mail::{MailId, MailboxId, Source, SourceAddr};
-
-            let mut cap = test_cap(Duration::from_millis(ADVANCE_TIMEOUT_MS_DEFAULT));
-            let render = <Render as Kind>::ID;
-            let sender = DataMailboxId(0x00C0_FFEE);
-
-            let transport = Arc::new(NativeBinding::new_for_test(
-                Arc::clone(&cap.mailer),
-                MailboxId(0),
-            ));
-            let source = Source::to(SourceAddr::Component(MailboxId(sender.0)));
-            let mut ctx = NativeCtx::new(&transport, source, MailId::NONE, MailId::NONE);
-            cap.on_subscribe_self(&mut ctx, LifecycleSubscribeSelf { stage: render.0 });
-
-            assert!(
-                cap.subscribers
-                    .get(&render)
-                    .is_some_and(|s| s.contains(&sender)),
-                "a Component-source subscribe_self lands that mailbox in the stage set"
-            );
-        }
-
-        /// A `subscribe_self` from a non-`Component` source (an external
-        /// session) replies `Err` and subscribes nothing — the reflexive
-        /// form is gated to in-process actors by construction.
-        #[test]
-        fn subscribe_self_rejects_non_component_source() {
-            use aether_data::{SessionToken, Uuid};
-            use aether_substrate::actor::native::binding::NativeBinding;
-            use aether_substrate::mail::{MailId, MailboxId, Source, SourceAddr};
-
-            let mut cap = test_cap(Duration::from_millis(ADVANCE_TIMEOUT_MS_DEFAULT));
-            let render = <Render as Kind>::ID;
-
-            let transport = Arc::new(NativeBinding::new_for_test(
-                Arc::clone(&cap.mailer),
-                MailboxId(0),
-            ));
-            let source = Source::to(SourceAddr::Session(SessionToken(Uuid::from_u128(0xFEED))));
-            let mut ctx = NativeCtx::new(&transport, source, MailId::NONE, MailId::NONE);
-            cap.on_subscribe_self(&mut ctx, LifecycleSubscribeSelf { stage: render.0 });
-
-            assert!(
-                cap.subscribers.get(&render).is_none_or(BTreeSet::is_empty),
-                "a non-Component source subscribes nothing"
-            );
-        }
-
-        /// Round trip through the host SDK path: calling
-        /// `subscribe::<Tick>()` on a `NativeActorMailbox<LifecycleCapability>`
-        /// emits `LifecycleSubscribeSelf { stage = Tick::ID }` whose
-        /// `Source` the transport host-stamps to the calling actor, and
-        /// delivering that mail to the cap lands the calling actor in the
-        /// `Tick` stage set. The wasm FFI shims `export!` emits are
-        /// wasm32-only, so the host test drives the cap through a
-        /// `NativeBinding`.
-        #[test]
-        fn subscribe_via_native_mailbox_lands_calling_actor_in_stage_set() {
-            use std::sync::mpsc;
-
-            use aether_substrate::actor::native::NativeActorMailbox;
-            use aether_substrate::actor::native::binding::NativeBinding;
-            use aether_substrate::mail::registry::{InboxHandler, OwnedDispatch};
-            use aether_substrate::mail::{MailId, MailboxId, Source, SourceAddr};
-
-            use crate::lifecycle::LifecycleMailboxExt;
-            use crate::test_chassis::fresh_substrate;
-
-            let (registry, mailer) = fresh_substrate();
-
-            // Capturing sink at the lifecycle mailbox: records the single
-            // mail the SDK `subscribe::<Tick>()` emits so the test can read
-            // back the kind, the host-stamped `Source`, and the payload.
-            let (tx, rx) = mpsc::channel::<(KindId, Source, Vec<u8>)>();
-            let handler: Arc<dyn InboxHandler> = Arc::new(move |dispatch: OwnedDispatch| {
-                let captured = (
-                    dispatch.kind,
-                    dispatch.sender,
-                    dispatch.payload.bytes().to_vec(),
-                );
-                dispatch.discharge();
-                let _ = tx.send(captured);
+            state.pending = Some(PendingAdvance {
+                root,
+                completed_kind: broadcast,
+                next_kind,
+                is_terminal,
+                reply_to,
+                started: Instant::now(),
             });
-            let lifecycle_id = registry.register_inbox(
-                <LifecycleCapability as aether_actor::Addressable>::NAMESPACE,
-                handler,
-            );
-
-            // The calling actor: a transport stamped with SENDER as its
-            // self-mailbox, so its sends carry `Source::Component(SENDER)`.
-            let sender = DataMailboxId(0x00C0_FFEE);
-            let tx_binding = NativeBinding::new_for_test(Arc::clone(&mailer), MailboxId(sender.0));
-            let lifecycle =
-                NativeActorMailbox::<LifecycleCapability>::__new(lifecycle_id.0, &tx_binding);
-            lifecycle.subscribe::<Tick>();
-            tx_binding.flush_outbound();
-
-            let (kind, source, bytes) =
-                rx.try_recv().expect("subscribe::<Tick>() emitted one mail");
-            assert_eq!(
-                kind,
-                <LifecycleSubscribeSelf as Kind>::ID,
-                "the SDK self-subscribe sends LifecycleSubscribeSelf"
-            );
-            assert_eq!(
-                source.addr,
-                SourceAddr::Component(MailboxId(sender.0)),
-                "the host stamps the calling actor as the Source"
-            );
-            let decoded = LifecycleSubscribeSelf::decode_from_bytes(&bytes)
-                .expect("payload decodes as LifecycleSubscribeSelf");
-            assert_eq!(
-                decoded.stage,
-                <Tick as Kind>::ID.0,
-                "the payload carries the Tick stage id"
-            );
-
-            // Deliver the captured mail to the cap exactly as the
-            // dispatcher would, and confirm the calling actor is now in the
-            // Tick stage set.
-            let mut cap = tick_start_graph_cap();
-            let cap_transport = Arc::new(NativeBinding::new_for_test(
-                Arc::clone(&cap.mailer),
-                MailboxId(0),
-            ));
-            let mut ctx = NativeCtx::new(&cap_transport, source, MailId::NONE, MailId::NONE);
-            cap.on_subscribe_self(&mut ctx, decoded);
-
-            assert!(
-                cap.subscribers
-                    .get(&<Tick as Kind>::ID)
-                    .is_some_and(|s| s.contains(&sender)),
-                "the calling actor lands in the Tick stage set"
-            );
+        } else {
+            // No settlement registry wired (test harness without
+            // tracing). Fall back to fire-and-advance: reply
+            // immediately and mutate state inline.
+            if is_terminal {
+                state.terminal_reached = true;
+            } else {
+                state.current_state = next_kind;
+            }
+            ctx.reply(&LifecycleAdvanceComplete {
+                completed: broadcast.0,
+                next: next_kind.0,
+            });
         }
+    }
 
-        /// The typed-send gate the ext relies on: `ctx.actor::<LifecycleCapability>()`
-        /// can only `.send()` the lifecycle subscribe kinds. A compile-time
-        /// assertion — if a future edit drops a `HandlesKind` impl (e.g. the
-        /// bridge stops emitting it), this stops building.
-        #[test]
-        fn cap_handles_the_subscribe_kinds() {
-            use aether_actor::{HandlesKind, Singleton};
-            fn assert_handles<R: HandlesKind<K>, K: Kind>() {}
-            fn assert_singleton<R: Singleton>() {}
-            assert_handles::<LifecycleCapability, LifecycleSubscribe>();
-            assert_handles::<LifecycleCapability, LifecycleSubscribeSelf>();
-            assert_handles::<LifecycleCapability, LifecycleUnsubscribe>();
-            assert_handles::<LifecycleCapability, LifecycleUnsubscribeSelf>();
-            assert_handles::<LifecycleCapability, LifecycleUnsubscribeAll>();
-            assert_singleton::<LifecycleCapability>();
+    /// Settlement notice for the broadcast root pending in
+    /// [`Self::pending`] (ADR-0082 §6). Advances the state pointer,
+    /// flips `terminal_reached` if the settling broadcast was a
+    /// terminal, and replies [`LifecycleAdvanceComplete`] to the
+    /// chassis main loop that issued the [`LifecycleAdvance`].
+    ///
+    /// `Settled` notices for unrelated roots drop without state
+    /// mutation.
+    ///
+    /// # Agent
+    /// `Settled { root }`. Synthesised by the settlement registry
+    /// when the in-flight count for `root` reaches zero; not a public
+    /// API for user code.
+    #[handler::manual]
+    fn on_settled(state: &mut Self::State, ctx: &mut NativeCtx<'_, Manual>, payload: Settled) {
+        let Some(pending) = state.pending.as_ref() else {
+            return;
+        };
+        if payload.root != pending.root {
+            return;
         }
+        let latency = pending.started.elapsed();
+        let root = pending.root;
+        let completed = pending.completed_kind.0;
+        let next = pending.next_kind.0;
+        let reply_to = pending.reply_to;
+        let is_terminal = pending.is_terminal;
+        let next_kind = pending.next_kind;
+        // Drop pending before reply so the reply-side mutation is
+        // visible if a follow-on Advance lands inside the reply path.
+        state.pending = None;
+        if is_terminal {
+            state.terminal_reached = true;
+        } else {
+            state.current_state = next_kind;
+        }
+        state.record_settlement_latency(latency, root);
+        // Route the reply to whoever issued the LifecycleAdvance —
+        // chassis main loops block on it to gate the next frame.
+        ctx.reply_to(reply_to, &LifecycleAdvanceComplete { completed, next });
+    }
+}
+
+/// Read-only inspect surface on the runtime state (ADR-0122 split).
+/// Production callers observe lifecycle progress via subscribed stage
+/// broadcasts rather than peeking at these.
+#[cfg(feature = "runtime")]
+impl LifecycleCapabilityState {
+    /// Read-only access to the current state's kind id.
+    #[must_use]
+    pub fn current_state(&self) -> KindId {
+        self.current_state
+    }
+
+    /// True once the lifecycle has broadcast a terminal state and
+    /// further advances are no-ops.
+    #[must_use]
+    pub fn is_terminal(&self) -> bool {
+        self.terminal_reached
+    }
+
+    /// True if a [`Quit`] mail has arrived but not yet been consumed.
+    #[must_use]
+    pub fn quit_pending(&self) -> bool {
+        self.quit_pending
+    }
+}
+
+/// Construction-level state fixture: a Render→Present→Shutdown
+/// data graph + a fresh mailer, built directly (no chassis boot),
+/// with the supplied advance timeout. Shared with
+/// `mod settlement`'s tests via `pub(crate)`.
+#[cfg(all(test, feature = "runtime"))]
+pub(crate) fn test_cap(advance_timeout: Duration) -> LifecycleCapabilityState {
+    use aether_kinds::{Present, Render, Shutdown};
+    use aether_substrate::mail::registry::Registry;
+
+    let graph = LifecycleGraphData::builder()
+        .state::<Render>()
+        .next::<Present>()
+        .state::<Present>()
+        .next::<Shutdown>()
+        .quit::<Shutdown>()
+        .terminal::<Shutdown>()
+        .start::<Render>()
+        .build()
+        .expect("test setup: graph builds");
+    let mailer = Arc::new(Mailer::new(Arc::new(Registry::default())));
+    LifecycleCapabilityState {
+        current_state: graph.start(),
+        graph,
+        subscribers: BTreeMap::new(),
+        terminal_reached: false,
+        quit_pending: false,
+        pending: None,
+        advance_timeout,
+        settlement_latency_ewma: None,
+        last_slow_warn: None,
+        mailer,
+    }
+}
+
+/// A `Tick`→`Shutdown` graph fixture (the round-trip test wants
+/// `Tick` as a declared stage, which [`test_cap`]'s Render-rooted
+/// graph doesn't carry).
+#[cfg(all(test, feature = "runtime"))]
+pub(crate) fn tick_start_graph_cap() -> LifecycleCapabilityState {
+    use aether_kinds::{Shutdown, Tick};
+    use aether_substrate::mail::registry::Registry;
+
+    let graph = LifecycleGraphData::builder()
+        .state::<Tick>()
+        .next::<Shutdown>()
+        .terminal::<Shutdown>()
+        .start::<Tick>()
+        .build()
+        .expect("test setup: tick graph builds");
+    let mailer = Arc::new(Mailer::new(Arc::new(Registry::default())));
+    LifecycleCapabilityState {
+        current_state: graph.start(),
+        graph,
+        subscribers: BTreeMap::new(),
+        terminal_reached: false,
+        quit_pending: false,
+        pending: None,
+        advance_timeout: Duration::from_millis(ADVANCE_TIMEOUT_MS_DEFAULT),
+        settlement_latency_ewma: None,
+        last_slow_warn: None,
+        mailer,
+    }
+}
+
+#[cfg(all(test, feature = "runtime"))]
+mod tests {
+    use super::*;
+    use aether_kinds::{Present, Render, Tick};
+
+    #[test]
+    fn cap_initial_state_is_graph_start() {
+        let cap = test_cap(Duration::from_millis(ADVANCE_TIMEOUT_MS_DEFAULT));
+        assert_eq!(cap.current_state(), <Render as Kind>::ID);
+        assert!(!cap.is_terminal());
+        assert!(!cap.quit_pending());
+    }
+
+    #[test]
+    fn on_unsubscribe_all_purges_mailbox_from_every_stage() {
+        // A dropped trampoline's mailbox must leave every stage's
+        // subscriber set in one shot (the drop-cleanup contract,
+        // mirroring `InputCapability::on_unsubscribe_all`), while
+        // co-subscribers on a shared stage survive.
+        use aether_substrate::actor::native::binding::NativeBinding;
+        use aether_substrate::mail::{MailId, MailboxId, Source};
+
+        let mut cap = test_cap(Duration::from_millis(ADVANCE_TIMEOUT_MS_DEFAULT));
+        let dropped = DataMailboxId(0xDEAD);
+        let survivor = DataMailboxId(0xBEEF);
+        let render = <Render as Kind>::ID;
+        let present = <Present as Kind>::ID;
+        cap.subscribers.entry(render).or_default().insert(dropped);
+        cap.subscribers.entry(render).or_default().insert(survivor);
+        cap.subscribers.entry(present).or_default().insert(dropped);
+
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&cap.mailer),
+            MailboxId(0),
+        ));
+        let mut ctx = NativeCtx::new(&transport, Source::NONE, MailId::NONE, MailId::NONE);
+        LifecycleCapability::on_unsubscribe_all(
+            &mut cap,
+            &mut ctx,
+            LifecycleUnsubscribeAll { mailbox: dropped.0 },
+        );
+
+        assert!(
+            !cap.subscribers[&render].contains(&dropped),
+            "dropped mailbox must leave the Render stage"
+        );
+        assert!(
+            !cap.subscribers[&present].contains(&dropped),
+            "dropped mailbox must leave the Present stage"
+        );
+        assert!(
+            cap.subscribers[&render].contains(&survivor),
+            "co-subscribers on a shared stage must survive the purge"
+        );
+    }
+
+    /// A `subscribe_self` carrying a `Component` source lands *that*
+    /// mailbox in the stage set (ADR-0083: the cap reads the
+    /// subscriber off the host-stamped envelope, not a payload field).
+    #[test]
+    fn subscribe_self_subscribes_the_component_source() {
+        use aether_substrate::actor::native::binding::NativeBinding;
+        use aether_substrate::mail::{MailId, MailboxId, Source, SourceAddr};
+
+        let mut cap = test_cap(Duration::from_millis(ADVANCE_TIMEOUT_MS_DEFAULT));
+        let render = <Render as Kind>::ID;
+        let sender = DataMailboxId(0x00C0_FFEE);
+
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&cap.mailer),
+            MailboxId(0),
+        ));
+        let source = Source::to(SourceAddr::Component(MailboxId(sender.0)));
+        let mut ctx = NativeCtx::new(&transport, source, MailId::NONE, MailId::NONE);
+        LifecycleCapability::on_subscribe_self(
+            &mut cap,
+            &mut ctx,
+            LifecycleSubscribeSelf { stage: render.0 },
+        );
+
+        assert!(
+            cap.subscribers
+                .get(&render)
+                .is_some_and(|s| s.contains(&sender)),
+            "a Component-source subscribe_self lands that mailbox in the stage set"
+        );
+    }
+
+    /// A `subscribe_self` from a non-`Component` source (an external
+    /// session) replies `Err` and subscribes nothing — the reflexive
+    /// form is gated to in-process actors by construction.
+    #[test]
+    fn subscribe_self_rejects_non_component_source() {
+        use aether_data::{SessionToken, Uuid};
+        use aether_substrate::actor::native::binding::NativeBinding;
+        use aether_substrate::mail::{MailId, MailboxId, Source, SourceAddr};
+
+        let mut cap = test_cap(Duration::from_millis(ADVANCE_TIMEOUT_MS_DEFAULT));
+        let render = <Render as Kind>::ID;
+
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&cap.mailer),
+            MailboxId(0),
+        ));
+        let source = Source::to(SourceAddr::Session(SessionToken(Uuid::from_u128(0xFEED))));
+        let mut ctx = NativeCtx::new(&transport, source, MailId::NONE, MailId::NONE);
+        LifecycleCapability::on_subscribe_self(
+            &mut cap,
+            &mut ctx,
+            LifecycleSubscribeSelf { stage: render.0 },
+        );
+
+        assert!(
+            cap.subscribers.get(&render).is_none_or(BTreeSet::is_empty),
+            "a non-Component source subscribes nothing"
+        );
+    }
+
+    /// Round trip through the host SDK path: calling
+    /// `subscribe::<Tick>()` on a `NativeActorMailbox<LifecycleCapability>`
+    /// emits `LifecycleSubscribeSelf { stage = Tick::ID }` whose
+    /// `Source` the transport host-stamps to the calling actor, and
+    /// delivering that mail to the cap lands the calling actor in the
+    /// `Tick` stage set. The wasm FFI shims `export!` emits are
+    /// wasm32-only, so the host test drives the cap through a
+    /// `NativeBinding`.
+    #[test]
+    fn subscribe_via_native_mailbox_lands_calling_actor_in_stage_set() {
+        use std::sync::mpsc;
+
+        use aether_substrate::actor::native::NativeActorMailbox;
+        use aether_substrate::actor::native::binding::NativeBinding;
+        use aether_substrate::mail::registry::{InboxHandler, OwnedDispatch};
+        use aether_substrate::mail::{MailId, MailboxId, Source, SourceAddr};
+
+        use crate::lifecycle::LifecycleMailboxExt;
+        use crate::test_chassis::fresh_substrate;
+
+        let (registry, mailer) = fresh_substrate();
+
+        // Capturing sink at the lifecycle mailbox: records the single
+        // mail the SDK `subscribe::<Tick>()` emits so the test can read
+        // back the kind, the host-stamped `Source`, and the payload.
+        let (tx, rx) = mpsc::channel::<(KindId, Source, Vec<u8>)>();
+        let handler: Arc<dyn InboxHandler> = Arc::new(move |dispatch: OwnedDispatch| {
+            let captured = (
+                dispatch.kind,
+                dispatch.sender,
+                dispatch.payload.bytes().to_vec(),
+            );
+            dispatch.discharge();
+            let _ = tx.send(captured);
+        });
+        let lifecycle_id = registry.register_inbox(
+            <LifecycleCapability as aether_actor::Addressable>::NAMESPACE,
+            handler,
+        );
+
+        // The calling actor: a transport stamped with SENDER as its
+        // self-mailbox, so its sends carry `Source::Component(SENDER)`.
+        let sender = DataMailboxId(0x00C0_FFEE);
+        let tx_binding = NativeBinding::new_for_test(Arc::clone(&mailer), MailboxId(sender.0));
+        let lifecycle =
+            NativeActorMailbox::<LifecycleCapability>::__new(lifecycle_id.0, &tx_binding);
+        lifecycle.subscribe::<Tick>();
+        tx_binding.flush_outbound();
+
+        let (kind, source, bytes) = rx.try_recv().expect("subscribe::<Tick>() emitted one mail");
+        assert_eq!(
+            kind,
+            <LifecycleSubscribeSelf as Kind>::ID,
+            "the SDK self-subscribe sends LifecycleSubscribeSelf"
+        );
+        assert_eq!(
+            source.addr,
+            SourceAddr::Component(MailboxId(sender.0)),
+            "the host stamps the calling actor as the Source"
+        );
+        let decoded = LifecycleSubscribeSelf::decode_from_bytes(&bytes)
+            .expect("payload decodes as LifecycleSubscribeSelf");
+        assert_eq!(
+            decoded.stage,
+            <Tick as Kind>::ID.0,
+            "the payload carries the Tick stage id"
+        );
+
+        // Deliver the captured mail to the cap exactly as the
+        // dispatcher would, and confirm the calling actor is now in the
+        // Tick stage set.
+        let mut cap = tick_start_graph_cap();
+        let cap_transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&cap.mailer),
+            MailboxId(0),
+        ));
+        let mut ctx = NativeCtx::new(&cap_transport, source, MailId::NONE, MailId::NONE);
+        LifecycleCapability::on_subscribe_self(&mut cap, &mut ctx, decoded);
+
+        assert!(
+            cap.subscribers
+                .get(&<Tick as Kind>::ID)
+                .is_some_and(|s| s.contains(&sender)),
+            "the calling actor lands in the Tick stage set"
+        );
+    }
+
+    /// The typed-send gate the ext relies on: `ctx.actor::<LifecycleCapability>()`
+    /// can only `.send()` the lifecycle subscribe kinds. A compile-time
+    /// assertion — if a future edit drops a `HandlesKind` impl (e.g. the
+    /// bridge stops emitting it), this stops building.
+    #[test]
+    fn cap_handles_the_subscribe_kinds() {
+        use aether_actor::{HandlesKind, Singleton};
+        fn assert_handles<R: HandlesKind<K>, K: Kind>() {}
+        fn assert_singleton<R: Singleton>() {}
+        assert_handles::<LifecycleCapability, LifecycleSubscribe>();
+        assert_handles::<LifecycleCapability, LifecycleSubscribeSelf>();
+        assert_handles::<LifecycleCapability, LifecycleUnsubscribe>();
+        assert_handles::<LifecycleCapability, LifecycleUnsubscribeSelf>();
+        assert_handles::<LifecycleCapability, LifecycleUnsubscribeAll>();
+        assert_singleton::<LifecycleCapability>();
     }
 }

--- a/crates/aether-capabilities/src/lifecycle/runtime.rs
+++ b/crates/aether-capabilities/src/lifecycle/runtime.rs
@@ -1,0 +1,76 @@
+//! The `aether.lifecycle` runtime half (ADR-0122 identity/runtime split).
+//! Compiled only under `feature = "runtime"` (the `mod runtime;`
+//! declaration in the parent carries the gate), so a transport-only build
+//! of the `LifecycleCapability` identity never names these types nor pulls
+//! `aether_substrate`. The substrate-typed imports are gated once by this
+//! module rather than line-by-line; the `#[actor] impl` reaches the state,
+//! ctx, settlement, and fan-out names through the single `use runtime::*`
+//! glob in the parent.
+
+// Lifecycle-level names the state and handlers reach. Explicit `use
+// super::{…}` (never `use super::*` — clippy `wildcard_imports` is denied
+// and exempts only `pub use`).
+use super::LifecycleGraphData;
+
+#[cfg(test)]
+pub use super::settlement::ADVANCE_TIMEOUT_MS_DEFAULT;
+pub use super::settlement::{PendingAdvance, Step, resolve_edge};
+pub use super::subscribers::broadcast_to_subscribers;
+
+pub use aether_actor::Manual;
+pub use aether_actor::actor::ctx::OutboundReply;
+pub use aether_data::{Kind, KindId, MailboxId as DataMailboxId, mailbox_id_from_name};
+pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub use aether_substrate::chassis::error::BootError;
+pub use aether_substrate::mail::mailer::Mailer;
+pub use std::collections::{BTreeMap, BTreeSet};
+pub use std::sync::Arc;
+pub use std::time::{Duration, Instant};
+
+/// `aether.lifecycle` runtime state (ADR-0082). Owns the lifecycle data
+/// graph, the subscriber table, the state pointer, and the settlement
+/// gating; the chassis only feeds the cap [`LifecycleAdvance`](aether_kinds::LifecycleAdvance)
+/// cadence. The dispatcher holds this as the cap's state and routes
+/// envelopes through the macro-emitted `Dispatch` impl; the addressing
+/// identity is the distinct ZST `LifecycleCapability`. Living in this
+/// private module keeps it `pub`-enough to satisfy the `NativeActor::State`
+/// interface without exposing it as crate-public API.
+///
+/// Plain-field shape (ADR-0078): every handler runs on the cap's single
+/// dispatcher thread, so no `Mutex` / `Arc<Atomic*>` is needed for the
+/// subscriber table or state pointer.
+///
+/// Fields are `pub(crate)` so the settlement state machine
+/// (`mod settlement`) can carry its inherent-impl cluster in a sibling
+/// file and the parent's handlers can read them.
+pub struct LifecycleCapabilityState {
+    pub(crate) graph: LifecycleGraphData,
+    /// Subscriber table keyed by stage kind id (ADR-0082 §7).
+    pub(crate) subscribers: BTreeMap<KindId, BTreeSet<DataMailboxId>>,
+    /// Kind id of the state the cap will broadcast on the next
+    /// [`LifecycleAdvance`](aether_kinds::LifecycleAdvance). Starts at
+    /// `graph.start()`; mutated after each settled advance to the resolved
+    /// next/quit edge target.
+    pub(crate) current_state: KindId,
+    /// True once the lifecycle reached a terminal — further advances
+    /// are no-ops.
+    pub(crate) terminal_reached: bool,
+    /// Quit flag (ADR-0082 §3). Set by inbound [`Quit`](aether_kinds::Quit)
+    /// mail; consumed at the next state whose graph declares a `quit` edge.
+    pub(crate) quit_pending: bool,
+    /// In-flight advance awaiting settlement (ADR-0082 §6).
+    pub(crate) pending: Option<PendingAdvance>,
+    /// Deadline for a pending advance's `Settled`
+    /// (iamacoffeepot/aether#1048). Set from
+    /// `AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS`.
+    pub(crate) advance_timeout: Duration,
+    /// EWMA of observed `Sent`→`Settled` latency (ADR-0082 §6),
+    /// updated once per settle. `None` until the first settlement.
+    pub(crate) settlement_latency_ewma: Option<Duration>,
+    /// Last time a slow-settlement warn fired, for the
+    /// `SLOW_SETTLE_WARN_COOLDOWN` rate limit.
+    pub(crate) last_slow_warn: Option<Instant>,
+    /// `Arc<Mailer>` cached at init for `subscribe_settlement_mail`
+    /// calls inside handlers.
+    pub(crate) mailer: Arc<Mailer>,
+}

--- a/crates/aether-capabilities/src/lifecycle/settlement.rs
+++ b/crates/aether-capabilities/src/lifecycle/settlement.rs
@@ -1,8 +1,10 @@
 //! The settlement-gated advance state machine (ADR-0082 §6). Carries
 //! the in-flight [`PendingAdvance`], the edge-resolution + force-complete
 //! decision logic, and the rolling settlement-latency EWMA with its
-//! slow-warn gate (iamacoffeepot/aether#1048 / #1052). Native-only — the
-//! whole settlement path elides on wasm32 with `mod native`.
+//! slow-warn gate (iamacoffeepot/aether#1048 / #1052). Runtime-only — the
+//! whole settlement path sits behind the `feature = "runtime"` gate (the
+//! `mod settlement;` declaration carries it), alongside the rest of the
+//! `LifecycleCapability` runtime half (ADR-0122).
 
 use std::time::{Duration, Instant};
 
@@ -14,7 +16,7 @@ use aether_substrate::actor::native::NativeCtx;
 use aether_substrate::mail::{MailId, Source};
 
 use super::LifecycleStateData;
-use super::native::LifecycleCapability;
+use super::runtime::LifecycleCapabilityState;
 
 /// Default deadline for a pending advance's `Settled` to arrive
 /// before [`LifecycleCapability::on_advance`](super) force-completes it
@@ -71,7 +73,7 @@ pub struct PendingAdvance {
     pub(crate) started: Instant,
 }
 
-impl LifecycleCapability {
+impl LifecycleCapabilityState {
     /// Fold one observed `Sent`→`Settled` latency into the rolling
     /// EWMA and emit a rate-limited warn when a settle blows past the
     /// slow threshold (`advance_timeout / SLOW_SETTLE_DIVISOR`). The
@@ -183,7 +185,7 @@ mod tests {
     //! frame-loop scenarios; the decision functions below carry the
     //! ADR-0082 §3 quit-flag semantics and the #1048/#1052
     //! settlement-latency gate, pinned at the unit layer.
-    use super::super::native::test_cap;
+    use super::super::test_cap;
     use super::*;
     use aether_data::Kind;
     use aether_kinds::{Present, Render};

--- a/crates/aether-capabilities/src/trace/mod.rs
+++ b/crates/aether-capabilities/src/trace/mod.rs
@@ -22,277 +22,315 @@
 //!   retired with the fold (Phase 3c) — there is no `BatchedTraceEvents`
 //!   stream anymore.
 
-use aether_kinds::trace::{DispatchTraced, DispatchTracedAck};
+// Handler-signature kind must be importable at module root because
+// `#[actor]` emits `impl HandlesKind<DispatchTraced> for X {}` always-on,
+// outside the `feature = "runtime"` gate. The reply kind
+// (`DispatchTracedAck`) is named only by the gated handler body, so it
+// rides the runtime gate below.
+use aether_kinds::trace::DispatchTraced;
 
-#[aether_actor::bridge(singleton)]
-mod native {
-    use super::{DispatchTraced, DispatchTracedAck};
-    use std::sync::Arc;
+use aether_actor::actor;
 
-    use aether_actor::actor;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
-    use aether_substrate::mail::helpers::resolve_bundle;
-    use aether_substrate::mail::registry::Registry;
+/// Thin `aether.trace` cap **identity** (ADR-0122 identity/runtime
+/// split, ADR-0086 Phase 3c). A ZST carrying only the addressing — the
+/// `Addressable` / `HandlesKind` markers and the name-inventory entry,
+/// all emitted always-on by `#[actor]`. The state-bearing runtime
+/// ([`TraceDispatchCapabilityState`], holding the substrate registry
+/// handle) lives behind the one `feature = "runtime"` gate, so a
+/// transport-only build never names it nor pulls `aether_substrate`
+/// through this cap.
+///
+/// Services [`DispatchTraced`] only; the trace fold + `Settled` emission
+/// it used to host retired with the central queue (see module doc).
+pub struct TraceDispatchCapability;
 
-    /// Thin `aether.trace` cap (ADR-0086 Phase 3c). Services
-    /// [`DispatchTraced`] only; the trace fold + `Settled` emission it
-    /// used to host retired with the central queue (see module doc).
-    pub struct TraceDispatchCapability {
-        /// Substrate registry handle for `DispatchTraced`'s per-envelope
-        /// name resolution (recipient mailbox name → id, kind name →
-        /// id). Cloned from `ctx.mailer().registry()` at init; matches
-        /// the `RenderCapability` pattern that resolves `CaptureFrame`
-        /// mail bundles through the same registry.
+// The reply kind rides the native gate (not `runtime`): the `#[actor]`
+// macro's ADR-0109 `HandlerEntry` inventory submission — emitted on every
+// native build, runtime or not — names the handler's reply kind `::ID`,
+// so a transport-only build must still see it. The rest of the runtime
+// half (the `aether_substrate`-typed imports and the state struct + its
+// `with_registry` ctor) sits behind the one `feature = "runtime"` gate.
+#[cfg(not(target_arch = "wasm32"))]
+use aether_kinds::trace::DispatchTracedAck;
+#[cfg(feature = "runtime")]
+use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+#[cfg(feature = "runtime")]
+use aether_substrate::chassis::error::BootError;
+#[cfg(feature = "runtime")]
+use aether_substrate::mail::helpers::resolve_bundle;
+#[cfg(feature = "runtime")]
+use aether_substrate::mail::registry::Registry;
+#[cfg(feature = "runtime")]
+use std::sync::Arc;
+
+/// `aether.trace` runtime state (ADR-0086 Phase 3c). Holds the
+/// substrate registry handle for `DispatchTraced`'s per-envelope name
+/// resolution (recipient mailbox name → id, kind name → id). The
+/// addressing identity is the distinct ZST `TraceDispatchCapability`.
+#[cfg(feature = "runtime")]
+pub struct TraceDispatchCapabilityState {
+    /// Substrate registry handle for `DispatchTraced`'s per-envelope
+    /// name resolution. Cloned from `ctx.mailer().registry()` at init;
+    /// matches the `RenderCapability` pattern that resolves
+    /// `CaptureFrame` mail bundles through the same registry.
+    registry: Arc<Registry>,
+}
+
+#[cfg(feature = "runtime")]
+impl TraceDispatchCapabilityState {
+    /// The single struct-construction site.
+    fn with_registry(registry: Arc<Registry>) -> Self {
+        Self { registry }
+    }
+}
+
+#[actor(singleton)]
+impl NativeActor for TraceDispatchCapability {
+    /// The runtime state this identity boots into (ADR-0122 split): the
+    /// substrate registry handle.
+    type State = TraceDispatchCapabilityState;
+
+    type Config = ();
+    // `aether.trace` (matches
+    // `aether_kinds::trace::TRACE_MAILBOX_NAME`). Has to be a literal
+    // here for the `#[actor]` macro's expansion.
+    const NAMESPACE: &'static str = "aether.trace";
+
+    fn init(
+        (): (),
+        ctx: &mut NativeInitCtx<'_>,
+    ) -> Result<TraceDispatchCapabilityState, BootError> {
+        let registry = Arc::clone(ctx.mailer().registry());
+        Ok(TraceDispatchCapabilityState::with_registry(registry))
+    }
+
+    /// # Agent
+    /// Atomic batched dispatch with shared trace root, backing the
+    /// MCP `send_mail_traced` tool. Captures this handler's inbound
+    /// `MailId` as the batch root, dispatches every spec inheriting
+    /// the chain (so all children appear under one tree), and
+    /// replies synchronously with [`DispatchTracedAck`] carrying the
+    /// root. The caller waits for the wire `ReplyEnd` (chain
+    /// settled), then reconstructs the populated tree by walking the
+    /// per-actor trace rings from this root (`aether.trace.tail`,
+    /// stitched client-side — ADR-0086 Phase 3b). Issue 749.
+    ///
+    /// **Reply forwarding (issue 1265).** Each child is dispatched
+    /// with `reply_to = ctx.reply_target()` (the caller of this
+    /// `DispatchTraced` — typically the RPC server holding the wire
+    /// `cid`'s in-flight entry) rather than the default
+    /// `Component(self_mailbox)`. This trace cap is a re-dispatcher
+    /// with no handler for child reply kinds, so without the
+    /// forward each child's deferred reply (the ADR-0093
+    /// hold-until-resolve dispatch in content-gen caps) lands here and
+    /// silently drops, leaving the wire call with no `ReplyEvent`s.
+    /// Forwarding lets every child's reply (sync or deferred)
+    /// bubble straight to the original caller with the same
+    /// `correlation_id`, so the RPC server's `on_any` fallback wraps
+    /// each into a `ReplyEvent` on the wire.
+    #[handler]
+    fn on_dispatch_traced(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        batch: DispatchTraced,
+    ) -> DispatchTracedAck {
+        let root = ctx.in_flight_mail_id();
+        let forward_reply_to = ctx.reply_target();
+        let DispatchTraced { mails } = batch;
+        // Resolve every envelope's name addressing through the
+        // substrate registry — same path `CaptureFrame`'s bundle
+        // resolution uses (`render::on_capture_frame`). A single
+        // unresolved name aborts the whole batch, surfaced as the
+        // ack's `Err` variant so the MCP caller fails fast.
+        let resolved = match resolve_bundle(&state.registry, &mails, "dispatch_traced batch") {
+            Ok(v) => v,
+            Err(error) => {
+                return DispatchTracedAck::Err { error };
+            }
+        };
+        for mail in resolved {
+            let _ = ctx.send_envelope_traced_with_reply_to(
+                mail.recipient,
+                mail.kind,
+                mail.payload.bytes(),
+                forward_reply_to,
+            );
+        }
+        DispatchTracedAck::Ok { root }
+    }
+}
+
+#[cfg(all(test, feature = "runtime"))]
+// Tests hold the capture `Mutex` guard across the assertion block
+// so the snapshot reads atomically against the concurrent push.
+#[allow(clippy::significant_drop_tightening)]
+mod tests {
+    use super::*;
+    use aether_data::{KindId, MailId, MailboxId, SessionToken, Uuid};
+    use aether_substrate::actor::native::binding::NativeBinding;
+    use aether_substrate::mail::mailer::Mailer;
+    use aether_substrate::mail::outbound::HubOutbound;
+    use aether_substrate::mail::registry::MailDispatch;
+    use aether_substrate::mail::{Source, SourceAddr};
+
+    /// Shared scaffolding for the `on_dispatch_traced` tests:
+    /// fresh registry + mailer + outbound + transport + state wired
+    /// together. The state doesn't go through `init` (which reads ctx
+    /// state); construct it directly with the registry handle the
+    /// resolve path needs.
+    struct DispatchTracedFixture {
         registry: Arc<Registry>,
+        transport: Arc<NativeBinding>,
+        state: TraceDispatchCapabilityState,
     }
 
-    impl TraceDispatchCapability {
-        /// The single struct-construction site.
-        fn with_registry(registry: Arc<Registry>) -> Self {
-            Self { registry }
-        }
-    }
-
-    #[actor]
-    impl NativeActor for TraceDispatchCapability {
-        type Config = ();
-        // `aether.trace` (matches
-        // `aether_kinds::trace::TRACE_MAILBOX_NAME`). Has to be a literal
-        // here for the `#[actor]` macro's expansion.
-        const NAMESPACE: &'static str = "aether.trace";
-
-        fn init((): (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            let registry = Arc::clone(ctx.mailer().registry());
-            Ok(Self::with_registry(registry))
-        }
-
-        /// # Agent
-        /// Atomic batched dispatch with shared trace root, backing the
-        /// MCP `send_mail_traced` tool. Captures this handler's inbound
-        /// `MailId` as the batch root, dispatches every spec inheriting
-        /// the chain (so all children appear under one tree), and
-        /// replies synchronously with [`DispatchTracedAck`] carrying the
-        /// root. The caller waits for the wire `ReplyEnd` (chain
-        /// settled), then reconstructs the populated tree by walking the
-        /// per-actor trace rings from this root (`aether.trace.tail`,
-        /// stitched client-side — ADR-0086 Phase 3b). Issue 749.
-        ///
-        /// **Reply forwarding (issue 1265).** Each child is dispatched
-        /// with `reply_to = ctx.reply_target()` (the caller of this
-        /// `DispatchTraced` — typically the RPC server holding the wire
-        /// `cid`'s in-flight entry) rather than the default
-        /// `Component(self_mailbox)`. This trace cap is a re-dispatcher
-        /// with no handler for child reply kinds, so without the
-        /// forward each child's deferred reply (the ADR-0093
-        /// hold-until-resolve dispatch in content-gen caps) lands here and
-        /// silently drops, leaving the wire call with no `ReplyEvent`s.
-        /// Forwarding lets every child's reply (sync or deferred)
-        /// bubble straight to the original caller with the same
-        /// `correlation_id`, so the RPC server's `on_any` fallback wraps
-        /// each into a `ReplyEvent` on the wire.
-        #[handler]
-        fn on_dispatch_traced(
-            &mut self,
-            ctx: &mut NativeCtx<'_>,
-            batch: DispatchTraced,
-        ) -> DispatchTracedAck {
-            let root = ctx.in_flight_mail_id();
-            let forward_reply_to = ctx.reply_target();
-            let DispatchTraced { mails } = batch;
-            // Resolve every envelope's name addressing through the
-            // substrate registry — same path `CaptureFrame`'s bundle
-            // resolution uses (`render::on_capture_frame`). A single
-            // unresolved name aborts the whole batch, surfaced as the
-            // ack's `Err` variant so the MCP caller fails fast.
-            let resolved = match resolve_bundle(&self.registry, &mails, "dispatch_traced batch") {
-                Ok(v) => v,
-                Err(error) => {
-                    return DispatchTracedAck::Err { error };
-                }
-            };
-            for mail in resolved {
-                let _ = ctx.send_envelope_traced_with_reply_to(
-                    mail.recipient,
-                    mail.kind,
-                    mail.payload.bytes(),
-                    forward_reply_to,
-                );
-            }
-            DispatchTracedAck::Ok { root }
+    fn dispatch_traced_fixture() -> DispatchTracedFixture {
+        let registry = Arc::new(Registry::new());
+        let (outbound, _rx) = HubOutbound::attached_loopback();
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry)).with_outbound(outbound));
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            MailboxId(0x7ACE),
+        ));
+        let state = TraceDispatchCapabilityState::with_registry(Arc::clone(&registry));
+        DispatchTracedFixture {
+            registry,
+            transport,
+            state,
         }
     }
 
-    #[cfg(test)]
-    // Tests hold the capture `Mutex` guard across the assertion block
-    // so the snapshot reads atomically against the concurrent push.
-    #[allow(clippy::significant_drop_tightening)]
-    mod tests {
-        use super::*;
-        use aether_data::{KindId, MailId, MailboxId, SessionToken, Uuid};
-        use aether_substrate::actor::native::binding::NativeBinding;
-        use aether_substrate::mail::mailer::Mailer;
-        use aether_substrate::mail::outbound::HubOutbound;
-        use aether_substrate::mail::registry::MailDispatch;
-        use aether_substrate::mail::{Source, SourceAddr};
+    /// Build a chassis-root `NativeCtx` against the fixture's
+    /// transport, anchoring the in-flight + reply-to fields to a
+    /// session sender so the ack reply egresses as `ToSession`.
+    fn chassis_root_ctx(transport: &Arc<NativeBinding>, inbound: MailId) -> NativeCtx<'_> {
+        let sender = Source::to(SourceAddr::Session(SessionToken(Uuid::nil())));
+        NativeCtx::new(transport, sender, inbound, inbound)
+    }
 
-        /// Shared scaffolding for the `on_dispatch_traced` tests:
-        /// fresh registry + mailer + outbound + transport + cap wired
-        /// together. The cap doesn't go through `init` (which reads ctx
-        /// state); construct it directly with the registry handle the
-        /// resolve path needs.
-        struct DispatchTracedFixture {
-            registry: Arc<Registry>,
-            transport: Arc<NativeBinding>,
-            cap: TraceDispatchCapability,
-        }
+    /// Issue 749: `on_dispatch_traced` resolves each envelope's
+    /// name addressing through the registry (matching
+    /// `CaptureFrame`'s bundle pattern), dispatches each via
+    /// `send_envelope_traced` so children inherit the chain, and
+    /// replies synchronously with `DispatchTracedAck::Ok { root }`
+    /// carrying the inbound mail id.
+    #[test]
+    fn on_dispatch_traced_resolves_each_envelope_and_acks_with_root() {
+        use aether_kinds::NamedMail;
+        use std::sync::Mutex;
 
-        fn dispatch_traced_fixture() -> DispatchTracedFixture {
-            let registry = Arc::new(Registry::new());
-            let (outbound, _rx) = HubOutbound::attached_loopback();
-            let mailer = Arc::new(Mailer::new(Arc::clone(&registry)).with_outbound(outbound));
-            let transport = Arc::new(NativeBinding::new_for_test(
-                Arc::clone(&mailer),
-                MailboxId(0x7ACE),
-            ));
-            let cap = TraceDispatchCapability::with_registry(Arc::clone(&registry));
-            DispatchTracedFixture {
-                registry,
-                transport,
-                cap,
-            }
-        }
+        type Capture = (KindId, MailId, Option<MailId>, Vec<u8>);
 
-        /// Build a chassis-root `NativeCtx` against the fixture's
-        /// transport, anchoring the in-flight + reply-to fields to a
-        /// session sender so the ack reply egresses as `ToSession`.
-        fn chassis_root_ctx(transport: &Arc<NativeBinding>, inbound: MailId) -> NativeCtx<'_> {
-            let sender = Source::to(SourceAddr::Session(SessionToken(Uuid::nil())));
-            NativeCtx::new(transport, sender, inbound, inbound)
-        }
-
-        /// Issue 749: `on_dispatch_traced` resolves each envelope's
-        /// name addressing through the registry (matching
-        /// `CaptureFrame`'s bundle pattern), dispatches each via
-        /// `send_envelope_traced` so children inherit the chain, and
-        /// replies synchronously with `DispatchTracedAck::Ok { root }`
-        /// carrying the inbound mail id.
-        #[test]
-        fn on_dispatch_traced_resolves_each_envelope_and_acks_with_root() {
-            use aether_kinds::NamedMail;
-            use std::sync::Mutex;
-
-            type Capture = (KindId, MailId, Option<MailId>, Vec<u8>);
-
-            /// Inline handler that records every dispatched mail's
-            /// `(kind, root, parent, payload)` into the shared
-            /// `Vec`. Used twice to register two stub recipients.
-            fn register_capture(registry: &Registry, name: &str, sink: Arc<Mutex<Vec<Capture>>>) {
-                registry.register_inline(
-                    name,
-                    Arc::new(move |d: MailDispatch<'_>| {
-                        sink.lock()
-                            .expect("test stub: captured mutex poisoned")
-                            .push((d.kind, d.root, d.parent_mail, d.payload.to_vec()));
-                    }),
-                );
-            }
-
-            let mut fix = dispatch_traced_fixture();
-            // Resolve_bundle needs both mailbox (by name) and kind to
-            // be registered, else it short-circuits with the early-
-            // abort `Err` path the other test exercises.
-            let captured: Arc<Mutex<Vec<Capture>>> = Arc::new(Mutex::new(Vec::new()));
-            register_capture(&fix.registry, "aether.test.spec_a", Arc::clone(&captured));
-            register_capture(&fix.registry, "aether.test.spec_b", Arc::clone(&captured));
-            let kind_alpha = fix.registry.register_kind("aether.test.kind_a");
-            let kind_beta = fix.registry.register_kind("aether.test.kind_b");
-
-            let inbound = MailId::new(MailboxId(0xC0DE), 7);
-            let mut ctx = chassis_root_ctx(&fix.transport, inbound);
-            let ack = fix.cap.on_dispatch_traced(
-                &mut ctx,
-                DispatchTraced {
-                    mails: vec![
-                        NamedMail {
-                            recipient_name: "aether.test.spec_a".into(),
-                            kind_name: "aether.test.kind_a".into(),
-                            payload: vec![1u8, 2],
-                            count: 1,
-                        },
-                        NamedMail {
-                            recipient_name: "aether.test.spec_b".into(),
-                            kind_name: "aether.test.kind_b".into(),
-                            payload: vec![3u8, 4, 5],
-                            count: 1,
-                        },
-                    ],
-                },
+        /// Inline handler that records every dispatched mail's
+        /// `(kind, root, parent, payload)` into the shared
+        /// `Vec`. Used twice to register two stub recipients.
+        fn register_capture(registry: &Registry, name: &str, sink: Arc<Mutex<Vec<Capture>>>) {
+            registry.register_inline(
+                name,
+                Arc::new(move |d: MailDispatch<'_>| {
+                    sink.lock()
+                        .expect("test stub: captured mutex poisoned")
+                        .push((d.kind, d.root, d.parent_mail, d.payload.to_vec()));
+                }),
             );
-            // 2b: the handler buffers its forwarded envelopes into the
-            // actor's send-side ring; they route on handler-end flush.
-            // Driving the handler directly (no dispatch loop), we drop the
-            // ctx to trigger that flush — mirroring the per-envelope ctx
-            // drop in `DispatcherSlot::dispatch_one` — before inspecting
-            // the sink.
-            drop(ctx);
-
-            let snapshot = captured
-                .lock()
-                .expect("test stub: captured mutex poisoned")
-                .clone();
-            assert_eq!(snapshot.len(), 2, "expected each envelope to dispatch");
-            assert!(
-                snapshot.iter().any(|(k, root, parent, p)| *k == kind_alpha
-                    && *root == inbound
-                    && *parent == Some(inbound)
-                    && p == &vec![1u8, 2]),
-                "envelope A missing or chain not inherited; captured: {snapshot:?}"
-            );
-            assert!(
-                snapshot.iter().any(|(k, root, parent, p)| *k == kind_beta
-                    && *root == inbound
-                    && *parent == Some(inbound)
-                    && p == &vec![3u8, 4, 5]),
-                "envelope B missing or chain not inherited; captured: {snapshot:?}"
-            );
-
-            match ack {
-                DispatchTracedAck::Ok { root } => assert_eq!(
-                    root, inbound,
-                    "Ok ack must echo the in-flight inbound mail id as the chassis root"
-                ),
-                DispatchTracedAck::Err { error } => {
-                    panic!("expected Ok ack, got Err: {error}")
-                }
-            }
         }
 
-        /// Issue 749: an unresolvable name in the batch short-circuits
-        /// to `DispatchTracedAck::Err`; no envelope dispatches.
-        #[test]
-        fn on_dispatch_traced_replies_err_on_unknown_recipient() {
-            use aether_kinds::NamedMail;
+        let mut fix = dispatch_traced_fixture();
+        // Resolve_bundle needs both mailbox (by name) and kind to
+        // be registered, else it short-circuits with the early-
+        // abort `Err` path the other test exercises.
+        let captured: Arc<Mutex<Vec<Capture>>> = Arc::new(Mutex::new(Vec::new()));
+        register_capture(&fix.registry, "aether.test.spec_a", Arc::clone(&captured));
+        register_capture(&fix.registry, "aether.test.spec_b", Arc::clone(&captured));
+        let kind_alpha = fix.registry.register_kind("aether.test.kind_a");
+        let kind_beta = fix.registry.register_kind("aether.test.kind_b");
 
-            let mut fix = dispatch_traced_fixture();
-            let inbound = MailId::new(MailboxId(0xC0DE), 99);
-            let mut ctx = chassis_root_ctx(&fix.transport, inbound);
-            let ack = fix.cap.on_dispatch_traced(
-                &mut ctx,
-                DispatchTraced {
-                    mails: vec![NamedMail {
-                        recipient_name: "aether.test.does_not_exist".into(),
-                        kind_name: "aether.test.also_missing".into(),
-                        payload: vec![],
+        let inbound = MailId::new(MailboxId(0xC0DE), 7);
+        let mut ctx = chassis_root_ctx(&fix.transport, inbound);
+        let ack = TraceDispatchCapability::on_dispatch_traced(
+            &mut fix.state,
+            &mut ctx,
+            DispatchTraced {
+                mails: vec![
+                    NamedMail {
+                        recipient_name: "aether.test.spec_a".into(),
+                        kind_name: "aether.test.kind_a".into(),
+                        payload: vec![1u8, 2],
                         count: 1,
-                    }],
-                },
-            );
+                    },
+                    NamedMail {
+                        recipient_name: "aether.test.spec_b".into(),
+                        kind_name: "aether.test.kind_b".into(),
+                        payload: vec![3u8, 4, 5],
+                        count: 1,
+                    },
+                ],
+            },
+        );
+        // 2b: the handler buffers its forwarded envelopes into the
+        // actor's send-side ring; they route on handler-end flush.
+        // Driving the handler directly (no dispatch loop), we drop the
+        // ctx to trigger that flush — mirroring the per-envelope ctx
+        // drop in `DispatcherSlot::dispatch_one` — before inspecting
+        // the sink.
+        drop(ctx);
 
-            assert!(
-                matches!(&ack, DispatchTracedAck::Err { error } if error.contains("unknown recipient")),
-                "expected Err with 'unknown recipient' message, got: {ack:?}"
-            );
+        let snapshot = captured
+            .lock()
+            .expect("test stub: captured mutex poisoned")
+            .clone();
+        assert_eq!(snapshot.len(), 2, "expected each envelope to dispatch");
+        assert!(
+            snapshot.iter().any(|(k, root, parent, p)| *k == kind_alpha
+                && *root == inbound
+                && *parent == Some(inbound)
+                && p == &vec![1u8, 2]),
+            "envelope A missing or chain not inherited; captured: {snapshot:?}"
+        );
+        assert!(
+            snapshot.iter().any(|(k, root, parent, p)| *k == kind_beta
+                && *root == inbound
+                && *parent == Some(inbound)
+                && p == &vec![3u8, 4, 5]),
+            "envelope B missing or chain not inherited; captured: {snapshot:?}"
+        );
+
+        match ack {
+            DispatchTracedAck::Ok { root } => assert_eq!(
+                root, inbound,
+                "Ok ack must echo the in-flight inbound mail id as the chassis root"
+            ),
+            DispatchTracedAck::Err { error } => {
+                panic!("expected Ok ack, got Err: {error}")
+            }
         }
+    }
+
+    /// Issue 749: an unresolvable name in the batch short-circuits
+    /// to `DispatchTracedAck::Err`; no envelope dispatches.
+    #[test]
+    fn on_dispatch_traced_replies_err_on_unknown_recipient() {
+        use aether_kinds::NamedMail;
+
+        let mut fix = dispatch_traced_fixture();
+        let inbound = MailId::new(MailboxId(0xC0DE), 99);
+        let mut ctx = chassis_root_ctx(&fix.transport, inbound);
+        let ack = TraceDispatchCapability::on_dispatch_traced(
+            &mut fix.state,
+            &mut ctx,
+            DispatchTraced {
+                mails: vec![NamedMail {
+                    recipient_name: "aether.test.does_not_exist".into(),
+                    kind_name: "aether.test.also_missing".into(),
+                    payload: vec![],
+                    count: 1,
+                }],
+            },
+        );
+
+        assert!(
+            matches!(&ack, DispatchTracedAck::Err { error } if error.contains("unknown recipient")),
+            "expected Err with 'unknown recipient' message, got: {ack:?}"
+        );
     }
 }

--- a/crates/aether-capabilities/src/window/mod.rs
+++ b/crates/aether-capabilities/src/window/mod.rs
@@ -8,198 +8,226 @@
 //! companion that headless and test-bench compose to fail-fast with
 //! `Err`-replies on `set_mode` / `set_title`.
 
-// Handler-signature kinds must be importable at file root because
-// `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
-// of the mod (always-on, outside the cfg gate).
+// Handler-signature kinds must be importable at module root because
+// `#[actor]` emits `impl HandlesKind<K> for X {}` markers always-on,
+// outside the `feature = "runtime"` gate.
 use aether_kinds::{FocusWindow, SetWindowMode, SetWindowTitle};
 
-#[aether_actor::bridge(singleton)]
-mod native {
-    use aether_actor::actor;
-    use aether_kinds::{FocusWindowResult, SetWindowModeResult, SetWindowTitleResult};
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
+use aether_actor::actor;
 
-    use super::{FocusWindow, SetWindowMode, SetWindowTitle};
+/// `aether.window` headless-companion cap **identity** (ADR-0122
+/// identity/runtime split). A ZST carrying only the addressing — the
+/// `Addressable` / `HandlesKind` markers and the name-inventory entry,
+/// all emitted always-on by `#[actor]`. The state-bearing runtime
+/// (`HeadlessWindowCapabilityState`) lives behind the one
+/// `feature = "runtime"` gate, so a transport-only build never names it
+/// nor pulls `aether_substrate` through this cap.
+///
+/// Chassis-without-window companion to the desktop driver's
+/// driver-as-actor `aether.window` claim. Mirrors
+/// [`crate::HeadlessRenderCapability`]: same mailbox the desktop
+/// owner claims, `Err`-replying handlers so MCP `set_window_mode`
+/// / `set_window_title` fail fast on chassis without a window
+/// (headless and test-bench).
+///
+/// Each chassis composes one of {desktop driver, this cap}, never
+/// both — the chassis builder rejects double-claiming a mailbox.
+pub struct HeadlessWindowCapability;
 
-    /// Chassis-without-window companion to the desktop driver's
-    /// driver-as-actor `aether.window` claim. Mirrors
-    /// [`crate::HeadlessRenderCapability`]: same mailbox the desktop
-    /// owner claims, `Err`-replying handlers so MCP `set_window_mode`
-    /// / `set_window_title` fail fast on chassis without a window
-    /// (headless and test-bench).
+// The reply kinds ride the native gate (not `runtime`): the `#[actor]`
+// macro's ADR-0109 `HandlerEntry` inventory submission — emitted on every
+// native build, runtime or not — names each handler's reply kind `::ID`,
+// so a transport-only build must still see them. The `aether_substrate`-
+// typed ctx imports and the empty state struct sit behind the one
+// `feature = "runtime"` gate; the macro gates everything it emits for the
+// runtime half, so this cap's identity compiles transport-only.
+#[cfg(not(target_arch = "wasm32"))]
+use aether_kinds::{FocusWindowResult, SetWindowModeResult, SetWindowTitleResult};
+#[cfg(feature = "runtime")]
+use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+#[cfg(feature = "runtime")]
+use aether_substrate::chassis::error::BootError;
+
+/// `aether.window` headless-companion runtime state (ADR-0122 split).
+/// The cap is stateless — every handler `Err`-replies off `ctx` alone —
+/// so this is a named empty struct standing in for future state rather
+/// than `()` or `Self`. The addressing identity is the distinct ZST
+/// `HeadlessWindowCapability`.
+#[cfg(feature = "runtime")]
+pub struct HeadlessWindowCapabilityState;
+
+#[actor(singleton)]
+impl NativeActor for HeadlessWindowCapability {
+    /// The runtime state this identity boots into (ADR-0122 split): a
+    /// named empty struct, the stateless cap's stand-in for future state.
+    type State = HeadlessWindowCapabilityState;
+
+    type Config = ();
+
+    const NAMESPACE: &'static str = "aether.window";
+
+    fn init(
+        _config: (),
+        _ctx: &mut NativeInitCtx<'_>,
+    ) -> Result<HeadlessWindowCapabilityState, BootError> {
+        Ok(HeadlessWindowCapabilityState)
+    }
+
+    /// Reply `Err` so MCP `set_window_mode` fails fast instead of
+    /// hanging on a reply that never comes.
     ///
-    /// Each chassis composes one of {desktop driver, this cap}, never
-    /// both — the chassis builder rejects double-claiming a mailbox.
-    pub struct HeadlessWindowCapability;
-
-    #[actor]
-    impl NativeActor for HeadlessWindowCapability {
-        type Config = ();
-
-        const NAMESPACE: &'static str = "aether.window";
-
-        fn init(_config: (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            Ok(Self)
-        }
-
-        /// Reply `Err` so MCP `set_window_mode` fails fast instead of
-        /// hanging on a reply that never comes.
-        ///
-        /// Reply through the typed `ctx.reply()` (the
-        /// `NativeBinding::send_reply_for_handler` path), which mints the
-        /// reply id and joins the caller's ADR-0080 causal chain so the
-        /// blocking `set_window_mode` settles on the reply's `Finished`.
-        /// It routes every `SourceAddr` — including the `Component`
-        /// local-RPC-server reply target an MCP-spawned engine tags
-        /// (iamacoffeepot/aether#1321) that `HubOutbound::send_reply`
-        /// silently drops.
-        // `&self` keeps the dispatch ABI (ADR-0033 / ADR-0038); the
-        // capability is stateless, so the reply routes purely off `ctx`.
-        #[allow(clippy::unused_self)]
-        #[handler]
-        fn on_set_mode(
-            &self,
-            _ctx: &mut NativeCtx<'_>,
-            _mail: SetWindowMode,
-        ) -> SetWindowModeResult {
-            SetWindowModeResult::Err {
-                error: "unsupported on this chassis — no window peripheral".to_owned(),
-            }
-        }
-
-        /// Reply `Err` for the same reason as `on_set_mode`.
-        #[allow(clippy::unused_self)]
-        #[handler]
-        fn on_set_title(
-            &self,
-            _ctx: &mut NativeCtx<'_>,
-            _mail: SetWindowTitle,
-        ) -> SetWindowTitleResult {
-            SetWindowTitleResult::Err {
-                error: "unsupported on this chassis — no window peripheral".to_owned(),
-            }
-        }
-
-        /// Reply `Err` for the same reason as `on_set_mode`
-        /// (iamacoffeepot/aether#1318): a chassis without a window
-        /// peripheral can't foreground one.
-        #[allow(clippy::unused_self)]
-        #[handler]
-        fn on_focus(&self, _ctx: &mut NativeCtx<'_>, _mail: FocusWindow) -> FocusWindowResult {
-            FocusWindowResult::Err {
-                error: "unsupported on this chassis — no window peripheral".to_owned(),
-            }
+    /// Reply through the typed `ctx.reply()` (the
+    /// `NativeBinding::send_reply_for_handler` path), which mints the
+    /// reply id and joins the caller's ADR-0080 causal chain so the
+    /// blocking `set_window_mode` settles on the reply's `Finished`.
+    /// It routes every `SourceAddr` — including the `Component`
+    /// local-RPC-server reply target an MCP-spawned engine tags
+    /// (iamacoffeepot/aether#1321) that `HubOutbound::send_reply`
+    /// silently drops.
+    #[handler]
+    fn on_set_mode(
+        _state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        _mail: SetWindowMode,
+    ) -> SetWindowModeResult {
+        SetWindowModeResult::Err {
+            error: "unsupported on this chassis — no window peripheral".to_owned(),
         }
     }
 
-    #[cfg(test)]
-    #[allow(
-        clippy::unwrap_used,
-        reason = "test-setup unwraps: fixture construction panic on failure is the assertion"
-    )]
-    mod tests {
-        use super::*;
-        use aether_data::{Kind, MailId, Source, SourceAddr};
-        use aether_kinds::{FocusWindow, SetWindowMode, SetWindowTitle, WindowMode};
-        use aether_substrate::actor::native::Dispatch;
-        use aether_substrate::actor::native::binding::NativeBinding;
-        use aether_substrate::mail::mailer::Mailer;
-        use aether_substrate::{HubOutbound, InboxHandler, MailboxId, OwnedDispatch, Registry};
-        use std::sync::Arc;
-        use std::sync::mpsc;
-        use std::time::Duration;
-
-        /// `(mailer, caller_mailbox, reply_rx)` — a mailer with a
-        /// `Component`-target caller inbox that discharges each delivered
-        /// reply and forwards the dispatch so the test can read its
-        /// lineage. Mirrors the audio cap's `settlement_substrate`.
-        fn settlement_substrate() -> (Arc<Mailer>, MailboxId, mpsc::Receiver<OwnedDispatch>) {
-            let registry = Arc::new(Registry::new());
-            let (outbound, _egress_rx) = HubOutbound::attached_loopback();
-            let mailer = Arc::new(Mailer::new(Arc::clone(&registry)).with_outbound(outbound));
-            let (reply_tx, reply_rx) = mpsc::channel::<OwnedDispatch>();
-            let caller_mailbox = registry.register_inbox(
-                "test.window.settlement.caller",
-                Arc::new(move |dispatch: OwnedDispatch| {
-                    // ADR-0094: terminal consumer — discharge before forwarding.
-                    dispatch.discharge();
-                    let _ = reply_tx.send(dispatch);
-                }) as Arc<dyn InboxHandler>,
-            );
-            (mailer, caller_mailbox, reply_rx)
+    /// Reply `Err` for the same reason as `on_set_mode`.
+    #[handler]
+    fn on_set_title(
+        _state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        _mail: SetWindowTitle,
+    ) -> SetWindowTitleResult {
+        SetWindowTitleResult::Err {
+            error: "unsupported on this chassis — no window peripheral".to_owned(),
         }
+    }
 
-        /// #1701 / #1710 conformance: a blocking `set_mode` / `set_title` /
-        /// `focus` reply from the headless window cap joins the caller's
-        /// causal chain — the reply's `Sent` holds the root open until its
-        /// `Finished` fires, instead of detaching through the lineage-less
-        /// unchained path. Each handler is a single-class `-> R` handler;
-        /// the macro-emitted dispatch issues the reply so they all share the
-        /// proof via the dispatch trampoline (ADR-0112).
-        #[test]
-        fn err_reply_joins_caller_chain() {
-            let (mailer, caller_mailbox, reply_rx) = settlement_substrate();
-            let counter = Arc::clone(mailer.trace_handle().settlement_counter());
-            let transport = Arc::new(NativeBinding::new_for_test(
-                Arc::clone(&mailer),
-                MailboxId(0),
-            ));
-            let mut cap = HeadlessWindowCapability;
-
-            // Run each handler under its own root through the dispatch
-            // trampoline (ADR-0112: `NativeCtx::new_dispatching` + `__aether_dispatch_envelope`)
-            // and assert the reply holds, then settles, that root.
-            let mut next_correlation = 0_u64;
-            let mut drive = |kind_id: aether_data::KindId, payload: &[u8]| {
-                next_correlation += 1;
-                let root = MailId::new(MailboxId(0x1710), next_correlation);
-                let caller_source = Source::with_correlation(
-                    SourceAddr::Component(caller_mailbox),
-                    next_correlation,
-                );
-
-                {
-                    let mut ctx = NativeCtx::new_dispatching(&transport, caller_source, root, root);
-                    <HeadlessWindowCapability as Dispatch<HeadlessWindowCapability>>::dispatch(
-                        &mut cap, &mut ctx, kind_id, payload,
-                    );
-                }
-
-                assert_eq!(
-                    counter.live_roots(),
-                    1,
-                    "the macro-emitted reply holds the caller chain open",
-                );
-                let dispatch = reply_rx
-                    .recv_timeout(Duration::from_secs(2))
-                    .expect("Err reply reached the caller inbox");
-                assert_eq!(dispatch.root, root, "reply inherits the caller's root");
-                mailer.record_finished(dispatch.mail_id, dispatch.root);
-                assert_eq!(
-                    counter.live_roots(),
-                    0,
-                    "chain settles after the reply's Finished fires",
-                );
-            };
-
-            drive(
-                SetWindowMode::ID,
-                &SetWindowMode {
-                    mode: WindowMode::Windowed,
-                    width: None,
-                    height: None,
-                }
-                .encode_into_bytes(),
-            );
-            drive(
-                SetWindowTitle::ID,
-                &SetWindowTitle {
-                    title: "test".to_owned(),
-                }
-                .encode_into_bytes(),
-            );
-            drive(FocusWindow::ID, &FocusWindow {}.encode_into_bytes());
+    /// Reply `Err` for the same reason as `on_set_mode`
+    /// (iamacoffeepot/aether#1318): a chassis without a window
+    /// peripheral can't foreground one.
+    #[handler]
+    fn on_focus(
+        _state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        _mail: FocusWindow,
+    ) -> FocusWindowResult {
+        FocusWindowResult::Err {
+            error: "unsupported on this chassis — no window peripheral".to_owned(),
         }
+    }
+}
+
+#[cfg(all(test, feature = "runtime"))]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture construction panic on failure is the assertion"
+)]
+mod tests {
+    use super::*;
+    use aether_data::{Kind, MailId, Source, SourceAddr};
+    use aether_kinds::{FocusWindow, SetWindowMode, SetWindowTitle, WindowMode};
+    use aether_substrate::actor::native::Dispatch;
+    use aether_substrate::actor::native::binding::NativeBinding;
+    use aether_substrate::mail::mailer::Mailer;
+    use aether_substrate::{HubOutbound, InboxHandler, MailboxId, OwnedDispatch, Registry};
+    use std::sync::Arc;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    /// `(mailer, caller_mailbox, reply_rx)` — a mailer with a
+    /// `Component`-target caller inbox that discharges each delivered
+    /// reply and forwards the dispatch so the test can read its
+    /// lineage. Mirrors the audio cap's `settlement_substrate`.
+    fn settlement_substrate() -> (Arc<Mailer>, MailboxId, mpsc::Receiver<OwnedDispatch>) {
+        let registry = Arc::new(Registry::new());
+        let (outbound, _egress_rx) = HubOutbound::attached_loopback();
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry)).with_outbound(outbound));
+        let (reply_tx, reply_rx) = mpsc::channel::<OwnedDispatch>();
+        let caller_mailbox = registry.register_inbox(
+            "test.window.settlement.caller",
+            Arc::new(move |dispatch: OwnedDispatch| {
+                // ADR-0094: terminal consumer — discharge before forwarding.
+                dispatch.discharge();
+                let _ = reply_tx.send(dispatch);
+            }) as Arc<dyn InboxHandler>,
+        );
+        (mailer, caller_mailbox, reply_rx)
+    }
+
+    /// #1701 / #1710 conformance: a blocking `set_mode` / `set_title` /
+    /// `focus` reply from the headless window cap joins the caller's
+    /// causal chain — the reply's `Sent` holds the root open until its
+    /// `Finished` fires, instead of detaching through the lineage-less
+    /// unchained path. Each handler is a single-class `-> R` handler;
+    /// the macro-emitted dispatch issues the reply so they all share the
+    /// proof via the dispatch trampoline (ADR-0112).
+    #[test]
+    fn err_reply_joins_caller_chain() {
+        let (mailer, caller_mailbox, reply_rx) = settlement_substrate();
+        let counter = Arc::clone(mailer.trace_handle().settlement_counter());
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            MailboxId(0),
+        ));
+        // ADR-0122 split: the dispatch trampoline routes over the runtime
+        // state, not the identity.
+        let mut state = HeadlessWindowCapabilityState;
+
+        // Run each handler under its own root through the dispatch
+        // trampoline (ADR-0112: `NativeCtx::new_dispatching` + `__aether_dispatch_envelope`)
+        // and assert the reply holds, then settles, that root.
+        let mut next_correlation = 0_u64;
+        let mut drive = |kind_id: aether_data::KindId, payload: &[u8]| {
+            next_correlation += 1;
+            let root = MailId::new(MailboxId(0x1710), next_correlation);
+            let caller_source =
+                Source::with_correlation(SourceAddr::Component(caller_mailbox), next_correlation);
+
+            {
+                let mut ctx = NativeCtx::new_dispatching(&transport, caller_source, root, root);
+                <HeadlessWindowCapability as Dispatch<HeadlessWindowCapabilityState>>::dispatch(
+                    &mut state, &mut ctx, kind_id, payload,
+                );
+            }
+
+            assert_eq!(
+                counter.live_roots(),
+                1,
+                "the macro-emitted reply holds the caller chain open",
+            );
+            let dispatch = reply_rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("Err reply reached the caller inbox");
+            assert_eq!(dispatch.root, root, "reply inherits the caller's root");
+            mailer.record_finished(dispatch.mail_id, dispatch.root);
+            assert_eq!(
+                counter.live_roots(),
+                0,
+                "chain settles after the reply's Finished fires",
+            );
+        };
+
+        drive(
+            SetWindowMode::ID,
+            &SetWindowMode {
+                mode: WindowMode::Windowed,
+                width: None,
+                height: None,
+            }
+            .encode_into_bytes(),
+        );
+        drive(
+            SetWindowTitle::ID,
+            &SetWindowTitle {
+                title: "test".to_owned(),
+            }
+            .encode_into_bytes(),
+        );
+        drive(FocusWindow::ID, &FocusWindow {}.encode_into_bytes());
     }
 }


### PR DESCRIPTION
Closes #2319.

## Summary

Migrates the five core chassis caps off `#[bridge(singleton)]` onto the ADR-0122 identity/runtime split (the `aether.fs` template): `HeadlessWindowCapability` (window), `InputCapability` (input/subscription), `LifecycleCapability` (lifecycle — heavy, gets its own `runtime.rs` + `settlement.rs`), `TraceDispatchCapability` (trace), `InventoryCapability` (inventory). Each becomes a ZST identity + a `#[cfg(feature = "runtime")]`-gated runtime module (inline for the light caps, a file for lifecycle), handlers over `state: &mut Self::State`. Stateless caps get a named empty state struct (never `()` / `Self`).

One gating nuance: a handler's reply-kind `HandlerEntry` inventory submission (ADR-0109) is emitted on every native build, so reply kinds ride the `not(target_arch = "wasm32")` gate while only the substrate-typed state/imports ride `feature = "runtime"`.

## Test plan

- `cargo clippy -p aether-capabilities --all-targets --all-features -- -D warnings` clean; `cargo nextest run -p aether-capabilities` — 248 passed; transport-only (`--no-default-features --features native`) build compiles (the split's contract).
- Validated via `scripts/attest.sh --publish`.

## Generated by

`/implement --sweep --attest` — agent execution of scoped issue #2319.
