### PR TITLE
refactor(capabilities): move walled runtime imports into the mod runtime submodule

### DIFF
--- a/crates/aether-capabilities/src/input/subscription.rs
+++ b/crates/aether-capabilities/src/input/subscription.rs
@@ -16,7 +16,7 @@ use aether_actor::actor;
 /// `aether.input` cap **identity** (ADR-0122 identity/runtime split). A
 /// ZST carrying only the addressing — the `Addressable` / `HandlesKind`
 /// markers and the name-inventory entry, all emitted always-on by
-/// `#[actor]`. The state-bearing runtime ([`InputCapabilityState`],
+/// `#[actor]`. The state-bearing runtime (`InputCapabilityState`,
 /// holding the substrate registry handle + the subscriber table) lives
 /// behind the one `feature = "runtime"` gate, so a transport-only build
 /// never names it nor pulls `aether_substrate` through this cap.
@@ -43,33 +43,71 @@ pub struct InputCapability;
 #[cfg(not(target_arch = "wasm32"))]
 use super::kinds::SubscribeInputResult;
 #[cfg(feature = "runtime")]
-use aether_data::{Kind, KindId};
-#[cfg(feature = "runtime")]
-use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-#[cfg(feature = "runtime")]
-use aether_substrate::chassis::error::BootError;
-#[cfg(feature = "runtime")]
-use aether_substrate::mail::MailboxId;
-#[cfg(feature = "runtime")]
-use aether_substrate::mail::registry::{MailboxEntry, Registry};
-#[cfg(feature = "runtime")]
-use std::collections::{BTreeSet, HashMap};
-#[cfg(feature = "runtime")]
-use std::sync::Arc;
+#[allow(clippy::wildcard_imports)]
+use runtime::*;
 
+/// The `aether.input` runtime half (ADR-0122 identity/runtime split):
+/// the `aether_substrate`-typed imports, the state struct + its `fanout`
+/// helper, and the shared mailbox-validation fn, gated once by this module
+/// rather than per-import. The `#[actor] impl` reaches them through the
+/// single `use runtime::*` glob above.
 #[cfg(feature = "runtime")]
-use crate::input::config::InputConfig;
+mod runtime {
+    pub use aether_data::{Kind, KindId};
+    pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    pub use aether_substrate::chassis::error::BootError;
+    pub use aether_substrate::mail::MailboxId;
+    pub use aether_substrate::mail::registry::{MailboxEntry, Registry};
+    pub use std::collections::{BTreeSet, HashMap};
+    pub use std::sync::Arc;
 
-/// `aether.input` runtime state (ADR-0021). Owns the substrate registry
-/// handle (for subscriber-mailbox validation) plus the subscriber table
-/// keyed by stream kind id. Plain-field shape (ADR-0078) — single-
-/// threaded, every handler runs on the cap's dispatcher thread, so no
-/// `Mutex` / `Arc<Atomic*>` is needed. The addressing identity is the
-/// distinct ZST `InputCapability`.
-#[cfg(feature = "runtime")]
-pub struct InputCapabilityState {
-    registry: Arc<Registry>,
-    subscribers: HashMap<KindId, BTreeSet<MailboxId>>,
+    pub use crate::input::config::InputConfig;
+
+    /// `aether.input` runtime state (ADR-0021). Owns the substrate registry
+    /// handle (for subscriber-mailbox validation) plus the subscriber table
+    /// keyed by stream kind id. Plain-field shape (ADR-0078) — single-
+    /// threaded, every handler runs on the cap's dispatcher thread, so no
+    /// `Mutex` / `Arc<Atomic*>` is needed. The addressing identity is the
+    /// distinct ZST `InputCapability`.
+    pub struct InputCapabilityState {
+        pub(super) registry: Arc<Registry>,
+        pub(super) subscribers: HashMap<KindId, BTreeSet<MailboxId>>,
+    }
+
+    impl InputCapabilityState {
+        /// Push one mail per subscriber for `K`. Routes through
+        /// [`NativeCtx::fanout`] so each subscriber-bound copy carries
+        /// the inbound `(mail_id, root)` as `parent_mail` +
+        /// `inherited_root` — the trace observer sees N children
+        /// fanning out under the same parent edge (ADR-0080 §6,
+        /// issue iamacoffeepot/aether#723).
+        pub(super) fn fanout<K: Kind>(&self, ctx: &mut NativeCtx<'_>, payload: &K) {
+            let Some(subs) = self.subscribers.get(&K::ID) else {
+                return;
+            };
+            ctx.fanout(subs.iter().copied(), payload);
+        }
+    }
+
+    /// Shared validation: the mailbox id must name a live (non-dropped)
+    /// dispatchable mailbox. Issue 634 Phase 4 collapsed Component
+    /// and chassis-bound mailboxes into a single `Closure` variant —
+    /// trampolines and chassis caps both pass this check today.
+    /// Issue 838 added a `Sink` variant (synchronous-handler
+    /// mailboxes); production callers (the input stream fan-out)
+    /// only address trampoline mailboxes here, but accepting `Sink`
+    /// too keeps the check from rejecting legitimate sync-handler
+    /// subscribers if any future driver wants one.
+    pub(super) fn validate_subscriber_mailbox(
+        registry: &Registry,
+        id: MailboxId,
+    ) -> Result<(), String> {
+        match registry.entry(id) {
+            Some(MailboxEntry::Inbox { .. } | MailboxEntry::Inline(_)) => Ok(()),
+            Some(MailboxEntry::Dropped) => Err(format!("mailbox {id:?} already dropped")),
+            None => Err(format!("unknown mailbox id {id:?}")),
+        }
+    }
 }
 
 #[actor(singleton)]
@@ -255,40 +293,6 @@ impl NativeActor for InputCapability {
     #[handler]
     fn on_window_size(state: &mut Self::State, ctx: &mut NativeCtx<'_>, payload: WindowSize) {
         state.fanout(ctx, &payload);
-    }
-}
-
-#[cfg(feature = "runtime")]
-impl InputCapabilityState {
-    /// Push one mail per subscriber for `K`. Routes through
-    /// [`NativeCtx::fanout`] so each subscriber-bound copy carries
-    /// the inbound `(mail_id, root)` as `parent_mail` +
-    /// `inherited_root` — the trace observer sees N children
-    /// fanning out under the same parent edge (ADR-0080 §6,
-    /// issue iamacoffeepot/aether#723).
-    fn fanout<K: Kind>(&self, ctx: &mut NativeCtx<'_>, payload: &K) {
-        let Some(subs) = self.subscribers.get(&K::ID) else {
-            return;
-        };
-        ctx.fanout(subs.iter().copied(), payload);
-    }
-}
-
-/// Shared validation: the mailbox id must name a live (non-dropped)
-/// dispatchable mailbox. Issue 634 Phase 4 collapsed Component
-/// and chassis-bound mailboxes into a single `Closure` variant —
-/// trampolines and chassis caps both pass this check today.
-/// Issue 838 added a `Sink` variant (synchronous-handler
-/// mailboxes); production callers (the input stream fan-out)
-/// only address trampoline mailboxes here, but accepting `Sink`
-/// too keeps the check from rejecting legitimate sync-handler
-/// subscribers if any future driver wants one.
-#[cfg(feature = "runtime")]
-fn validate_subscriber_mailbox(registry: &Registry, id: MailboxId) -> Result<(), String> {
-    match registry.entry(id) {
-        Some(MailboxEntry::Inbox { .. } | MailboxEntry::Inline(_)) => Ok(()),
-        Some(MailboxEntry::Dropped) => Err(format!("mailbox {id:?} already dropped")),
-        None => Err(format!("unknown mailbox id {id:?}")),
     }
 }
 

--- a/crates/aether-capabilities/src/inventory/mod.rs
+++ b/crates/aether-capabilities/src/inventory/mod.rs
@@ -67,7 +67,7 @@ mod resolve;
 /// ADR-0088 §6, widened by ADR-0091 §5). A ZST carrying only the
 /// addressing — the `Addressable` / `HandlesKind` markers and the
 /// name-inventory entry, all emitted always-on by `#[actor]`. The
-/// state-bearing runtime ([`InventoryCapabilityState`], holding the
+/// state-bearing runtime (`InventoryCapabilityState`, holding the
 /// substrate `Arc<Registry>` the `ListKinds` arm projects) lives behind
 /// the one `feature = "runtime"` gate, so a transport-only build never
 /// names it nor pulls `aether_substrate` through this cap.
@@ -91,28 +91,42 @@ pub struct InventoryCapability;
 use aether_kinds::{HandlersResult, ListKindsResult, ManifestResult, ResolveResult};
 
 #[cfg(feature = "runtime")]
-use self::manifest::{cardinality_wire, param_kind_wire};
-#[cfg(feature = "runtime")]
-use self::resolve::resolve_ids;
+#[allow(clippy::wildcard_imports)]
+use runtime::*;
 
+/// The `aether.inventory` runtime half (ADR-0122 identity/runtime split):
+/// the wire-projection helpers, the `aether_substrate`-typed imports, and
+/// the state struct, gated once by this module rather than per-import. The
+/// `#[actor] impl` reaches them through the single `use runtime::*` glob
+/// above.
 #[cfg(feature = "runtime")]
-use aether_data::KindId;
-#[cfg(feature = "runtime")]
-use aether_data::canonical::kind_id_from_parts;
-#[cfg(feature = "runtime")]
-use aether_data::name_inventory::{handler_entries, name_entries, template_entries};
-#[cfg(feature = "runtime")]
-use aether_data::wire;
-#[cfg(feature = "runtime")]
-use aether_kinds::{HandlerEntryWire, KindDescriptorWire, NameEntryWire, TemplateEntryWire};
-#[cfg(feature = "runtime")]
-use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-#[cfg(feature = "runtime")]
-use aether_substrate::chassis::error::BootError;
-#[cfg(feature = "runtime")]
-use aether_substrate::mail::registry::Registry;
-#[cfg(feature = "runtime")]
-use std::sync::Arc;
+mod runtime {
+    pub use super::manifest::{cardinality_wire, param_kind_wire};
+    pub use super::resolve::resolve_ids;
+
+    pub use aether_data::KindId;
+    pub use aether_data::canonical::kind_id_from_parts;
+    pub use aether_data::name_inventory::{handler_entries, name_entries, template_entries};
+    pub use aether_data::wire;
+    pub use aether_kinds::{
+        HandlerEntryWire, KindDescriptorWire, NameEntryWire, TemplateEntryWire,
+    };
+    pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    pub use aether_substrate::chassis::error::BootError;
+    pub use aether_substrate::mail::registry::Registry;
+    pub use std::sync::Arc;
+
+    /// `aether.inventory` runtime state (ADR-0091 §2). Holds the substrate's
+    /// shared `Arc<Registry>` — the same `Arc` `ComponentHostCapability`
+    /// clones for `register_or_match_all` — so a load-time registration is
+    /// visible to `on_list_kinds` the moment it returns. The `Manifest` /
+    /// `Resolve` / `ListHandlers` arms are stateless reads of process-global
+    /// link-time tables. The addressing identity is the distinct ZST
+    /// `InventoryCapability`.
+    pub struct InventoryCapabilityState {
+        pub(super) registry: Arc<Registry>,
+    }
+}
 
 // Used only by the test suite — gate to avoid unused-import warnings in
 // the non-test build (they flow in via `use super::*` inside `mod tests`).
@@ -122,18 +136,6 @@ use aether_data::tagged_id;
 use aether_kinds::{CardinalityWire, ParamKindWire};
 #[cfg(all(test, feature = "runtime"))]
 use aether_substrate::runtime::thread_name::resolve_runtime;
-
-/// `aether.inventory` runtime state (ADR-0091 §2). Holds the substrate's
-/// shared `Arc<Registry>` — the same `Arc` `ComponentHostCapability`
-/// clones for `register_or_match_all` — so a load-time registration is
-/// visible to `on_list_kinds` the moment it returns. The `Manifest` /
-/// `Resolve` / `ListHandlers` arms are stateless reads of process-global
-/// link-time tables. The addressing identity is the distinct ZST
-/// `InventoryCapability`.
-#[cfg(feature = "runtime")]
-pub struct InventoryCapabilityState {
-    registry: Arc<Registry>,
-}
 
 #[actor(singleton)]
 impl NativeActor for InventoryCapability {

--- a/crates/aether-capabilities/src/lifecycle/mod.rs
+++ b/crates/aether-capabilities/src/lifecycle/mod.rs
@@ -47,9 +47,8 @@ use aether_kinds::{
 // handlers' reply kind `::ID`, so a transport-only build must see it.
 // `LifecycleAdvanceComplete` is the reply of the two `#[handler::manual]`
 // arms, which declare no manifest reply kind, so it is named only by the
-// runtime handler bodies and rides the `runtime` gate.
-#[cfg(feature = "runtime")]
-use aether_kinds::LifecycleAdvanceComplete;
+// runtime handler bodies and lives in `mod runtime` behind the `runtime`
+// gate.
 #[cfg(not(target_arch = "wasm32"))]
 use aether_kinds::LifecycleSubscribeResult;
 
@@ -75,8 +74,11 @@ mod settlement;
 
 #[cfg(feature = "runtime")]
 mod config;
+// `LifecycleConfig` configures the runtime-only `LifecycleCapabilityState`,
+// so its re-export rides the `runtime` gate through `mod runtime` (where the
+// rest of the runtime half lives) rather than a per-import gate here.
 #[cfg(feature = "runtime")]
-pub use config::LifecycleConfig;
+pub use runtime::LifecycleConfig;
 
 /// The `aether.lifecycle` cap **identity** (ADR-0122 identity/runtime
 /// split, ADR-0082). A ZST carrying only the addressing — the

--- a/crates/aether-capabilities/src/lifecycle/runtime.rs
+++ b/crates/aether-capabilities/src/lifecycle/runtime.rs
@@ -12,6 +12,7 @@
 // and exempts only `pub use`).
 use super::LifecycleGraphData;
 
+pub use super::config::LifecycleConfig;
 #[cfg(test)]
 pub use super::settlement::ADVANCE_TIMEOUT_MS_DEFAULT;
 pub use super::settlement::{PendingAdvance, Step, resolve_edge};
@@ -20,6 +21,7 @@ pub use super::subscribers::broadcast_to_subscribers;
 pub use aether_actor::Manual;
 pub use aether_actor::actor::ctx::OutboundReply;
 pub use aether_data::{Kind, KindId, MailboxId as DataMailboxId, mailbox_id_from_name};
+pub use aether_kinds::LifecycleAdvanceComplete;
 pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
 pub use aether_substrate::chassis::error::BootError;
 pub use aether_substrate::mail::mailer::Mailer;

--- a/crates/aether-capabilities/src/trace/mod.rs
+++ b/crates/aether-capabilities/src/trace/mod.rs
@@ -35,7 +35,7 @@ use aether_actor::actor;
 /// split, ADR-0086 Phase 3c). A ZST carrying only the addressing — the
 /// `Addressable` / `HandlesKind` markers and the name-inventory entry,
 /// all emitted always-on by `#[actor]`. The state-bearing runtime
-/// ([`TraceDispatchCapabilityState`], holding the substrate registry
+/// (`TraceDispatchCapabilityState`, holding the substrate registry
 /// handle) lives behind the one `feature = "runtime"` gate, so a
 /// transport-only build never names it nor pulls `aether_substrate`
 /// through this cap.
@@ -52,35 +52,41 @@ pub struct TraceDispatchCapability;
 // `with_registry` ctor) sits behind the one `feature = "runtime"` gate.
 #[cfg(not(target_arch = "wasm32"))]
 use aether_kinds::trace::DispatchTracedAck;
-#[cfg(feature = "runtime")]
-use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-#[cfg(feature = "runtime")]
-use aether_substrate::chassis::error::BootError;
-#[cfg(feature = "runtime")]
-use aether_substrate::mail::helpers::resolve_bundle;
-#[cfg(feature = "runtime")]
-use aether_substrate::mail::registry::Registry;
-#[cfg(feature = "runtime")]
-use std::sync::Arc;
-
-/// `aether.trace` runtime state (ADR-0086 Phase 3c). Holds the
-/// substrate registry handle for `DispatchTraced`'s per-envelope name
-/// resolution (recipient mailbox name → id, kind name → id). The
-/// addressing identity is the distinct ZST `TraceDispatchCapability`.
-#[cfg(feature = "runtime")]
-pub struct TraceDispatchCapabilityState {
-    /// Substrate registry handle for `DispatchTraced`'s per-envelope
-    /// name resolution. Cloned from `ctx.mailer().registry()` at init;
-    /// matches the `RenderCapability` pattern that resolves
-    /// `CaptureFrame` mail bundles through the same registry.
-    registry: Arc<Registry>,
-}
 
 #[cfg(feature = "runtime")]
-impl TraceDispatchCapabilityState {
-    /// The single struct-construction site.
-    fn with_registry(registry: Arc<Registry>) -> Self {
-        Self { registry }
+#[allow(clippy::wildcard_imports)]
+use runtime::*;
+
+/// The `aether.trace` runtime half (ADR-0122 identity/runtime split):
+/// the `aether_substrate`-typed imports and the state struct + its
+/// `with_registry` ctor, gated once by this module rather than per-import.
+/// The `#[actor] impl` reaches them through the single `use runtime::*`
+/// glob above.
+#[cfg(feature = "runtime")]
+mod runtime {
+    pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    pub use aether_substrate::chassis::error::BootError;
+    pub use aether_substrate::mail::helpers::resolve_bundle;
+    pub use aether_substrate::mail::registry::Registry;
+    pub use std::sync::Arc;
+
+    /// `aether.trace` runtime state (ADR-0086 Phase 3c). Holds the
+    /// substrate registry handle for `DispatchTraced`'s per-envelope name
+    /// resolution (recipient mailbox name → id, kind name → id). The
+    /// addressing identity is the distinct ZST `TraceDispatchCapability`.
+    pub struct TraceDispatchCapabilityState {
+        /// Substrate registry handle for `DispatchTraced`'s per-envelope
+        /// name resolution. Cloned from `ctx.mailer().registry()` at init;
+        /// matches the `RenderCapability` pattern that resolves
+        /// `CaptureFrame` mail bundles through the same registry.
+        pub(super) registry: Arc<Registry>,
+    }
+
+    impl TraceDispatchCapabilityState {
+        /// The single struct-construction site.
+        pub(super) fn with_registry(registry: Arc<Registry>) -> Self {
+            Self { registry }
+        }
     }
 }
 

--- a/crates/aether-capabilities/src/window/mod.rs
+++ b/crates/aether-capabilities/src/window/mod.rs
@@ -43,18 +43,26 @@ pub struct HeadlessWindowCapability;
 // runtime half, so this cap's identity compiles transport-only.
 #[cfg(not(target_arch = "wasm32"))]
 use aether_kinds::{FocusWindowResult, SetWindowModeResult, SetWindowTitleResult};
-#[cfg(feature = "runtime")]
-use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-#[cfg(feature = "runtime")]
-use aether_substrate::chassis::error::BootError;
 
-/// `aether.window` headless-companion runtime state (ADR-0122 split).
-/// The cap is stateless — every handler `Err`-replies off `ctx` alone —
-/// so this is a named empty struct standing in for future state rather
-/// than `()` or `Self`. The addressing identity is the distinct ZST
-/// `HeadlessWindowCapability`.
 #[cfg(feature = "runtime")]
-pub struct HeadlessWindowCapabilityState;
+#[allow(clippy::wildcard_imports)]
+use runtime::*;
+
+/// The `aether.window` headless-companion runtime half (ADR-0122 split):
+/// the `aether_substrate`-typed ctx imports and the state struct, gated once
+/// by this module rather than per-import.
+#[cfg(feature = "runtime")]
+mod runtime {
+    pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    pub use aether_substrate::chassis::error::BootError;
+
+    /// `aether.window` headless-companion runtime state (ADR-0122 split).
+    /// The cap is stateless — every handler `Err`-replies off `ctx` alone —
+    /// so this is a named empty struct standing in for future state rather
+    /// than `()` or `Self`. The addressing identity is the distinct ZST
+    /// [`HeadlessWindowCapability`](super::HeadlessWindowCapability).
+    pub struct HeadlessWindowCapabilityState;
+}
 
 #[actor(singleton)]
 impl NativeActor for HeadlessWindowCapability {


### PR DESCRIPTION
Closes #2344.

## Summary

The #2319 core-chassis split gated each `aether_substrate`-typed import with its own `#[cfg(feature = "runtime")]` line at module scope — the per-import wall the project forbids. This moves the gated imports, state struct, and runtime helpers for `window` / `input` / `lifecycle` / `trace` / `inventory` into a `mod runtime` submodule gated once (the `fs/runtime.rs` shape), reached from the `#[actor] impl` through the single `#[cfg(feature = "runtime")] #[allow(clippy::wildcard_imports)] use runtime::*;` glob. Lifecycle's two stray imports fold into its existing `runtime.rs`.

Import organization only — no handler body, signature, or `#[actor] impl` changed. The `#[cfg(not(target_arch = "wasm32"))]` reply-kind imports (named by the macro's always-on handler-inventory submission) stay at module scope, as does the lone crate-public `pub use ...Config` re-export.

## Test plan

- `git grep` confirms no per-import `#[cfg(feature = "runtime")] use` remains (only `mod runtime` + `use runtime::*`).
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo nextest run -p aether-capabilities` (248 passed), strict `cargo doc`, and transport-only (`--no-default-features --features native`) build all green.
- Validated via `scripts/attest.sh --publish`.

## Generated by

`/implement --attest` — de-wall cleanup of the #2319 batch (#2344).
