### PR TITLE
refactor(capabilities): split the tcp caps into identity and runtime modules

### DIFF
--- a/crates/aether-capabilities/src/tcp/listener.rs
+++ b/crates/aether-capabilities/src/tcp/listener.rs
@@ -13,210 +13,206 @@
 //! (in `unwire`) joins the accept thread.
 
 // Handler-signature kinds must be importable at file root because
-// `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
-// of the mod (always-on, outside the cfg gate).
+// `#[actor]` emits `impl HandlesKind<K> for X {}` markers against the
+// identity (always-on, outside the `feature = "runtime"` gate).
 use super::kinds::{Close, ConnectionReady};
 
-#[aether_actor::bridge(instanced, one_per = "listener")]
-mod listener_native {
-    use super::{Close, ConnectionReady};
-    use aether_actor::actor;
-    use aether_data::Kind;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
-    use aether_substrate::{KindId, Mail, Mailer};
-    use std::net::{SocketAddr, TcpStream};
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::mpsc;
-    use std::thread::JoinHandle;
-    use std::time::Duration;
+/// `aether.tcp.listener` **identity** (ADR-0122 identity/runtime split). A ZST
+/// carrying only the addressing — `Addressable` (`NAMESPACE`, `Resolver`), the
+/// per-handler `HandlesKind` markers, and the instanced
+/// `OnePer("listener")` name-inventory entry, all emitted always-on by
+/// `#[actor]`. The state-bearing runtime (`TcpListenerState`, which holds the
+/// `std::net::TcpListener`'s accept thread + the connection channel) lives
+/// behind the one `feature = "runtime"` gate, so a transport-only build never
+/// names `TcpListenerState` nor pulls `aether_substrate` through this actor.
+pub struct TcpListenerActor;
 
-    use crate::tcp::config::{TcpListenerConfig, TcpSessionConfig};
-    use crate::tcp::session::TcpSessionActor;
-    use std::thread;
+// The `#[actor]` attribute path stays always-on (the macro divides what it
+// emits). Everything that names an `aether_substrate` / `std::net` type — the
+// handler/init ctx, the runtime state, the accept thread — lives in the
+// `runtime` module below, gated once by `feature = "runtime"` and reached
+// through the single `use runtime::*` glob.
+use aether_actor::actor;
 
-    /// Issue 607 Phase 6b: the accept thread can't call
-    /// `ctx.spawn_child` (no dispatcher ctx), so it pushes accepted
-    /// streams over `connection_rx` and fires a [`ConnectionReady`]
-    /// wake mail. The dispatcher's `on_connection_ready` handler
-    /// drains the mpsc and spawns one `TcpSessionActor` per pending
-    /// stream.
-    pub struct TcpListenerActor {
-        local_port: u16,
-        shutdown: Arc<AtomicBool>,
-        accept_thread: Option<JoinHandle<()>>,
-        connection_rx: mpsc::Receiver<(TcpStream, SocketAddr)>,
-        next_subname: u64,
-    }
+#[cfg(feature = "runtime")]
+#[allow(clippy::wildcard_imports)]
+use runtime::*;
 
-    #[actor]
-    impl NativeActor for TcpListenerActor {
-        type Config = TcpListenerConfig;
-        const NAMESPACE: &'static str = "aether.tcp.listener";
+#[cfg(feature = "runtime")]
+mod runtime;
 
-        fn init(
-            mut config: TcpListenerConfig,
-            ctx: &mut NativeInitCtx<'_>,
-        ) -> Result<Self, BootError> {
-            let listener = config
-                .listener
-                .take()
-                .expect("TcpListenerConfig::listener consumed exactly once");
-            let addr = config.addr;
-            let port = config.port;
-            // Stay blocking — the accept loop wakes via self-connect
-            // on `unwire`. Nonblocking would require a poll loop +
-            // CPU burn for no win.
-            listener
-                .set_nonblocking(false)
-                .map_err(|e| BootError::Other(Box::new(e)))?;
-            let shutdown = Arc::new(AtomicBool::new(false));
-            let shutdown_for_thread = Arc::clone(&shutdown);
+#[actor(instanced, one_per = "listener")]
+impl NativeActor for TcpListenerActor {
+    /// The runtime state this identity boots into (ADR-0122 split): the
+    /// accept-thread + connection-channel bundle.
+    type State = TcpListenerState;
+    type Config = TcpListenerConfig;
+    const NAMESPACE: &'static str = "aether.tcp.listener";
 
-            // mpsc for accept→dispatcher stream handoff. Unbounded —
-            // the kernel's accept backlog already bounds incoming
-            // connections, and the dispatcher drains the channel on
-            // every `ConnectionReady` mail.
-            let (connection_tx, connection_rx) = mpsc::channel::<(TcpStream, SocketAddr)>();
+    fn init(
+        mut config: TcpListenerConfig,
+        ctx: &mut NativeInitCtx<'_>,
+    ) -> Result<TcpListenerState, BootError> {
+        let listener = config
+            .listener
+            .take()
+            .expect("TcpListenerConfig::listener consumed exactly once");
+        let addr = config.addr;
+        let port = config.port;
+        // Stay blocking — the accept loop wakes via self-connect
+        // on `unwire`. Nonblocking would require a poll loop +
+        // CPU burn for no win.
+        listener
+            .set_nonblocking(false)
+            .map_err(|e| BootError::Other(Box::new(e)))?;
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_for_thread = Arc::clone(&shutdown);
 
-            // Wake-mail plumbing: capture the mailer + this actor's
-            // own MailboxId so the accept thread can fire a
-            // ConnectionReady mail at us per accept.
-            let mailer: Arc<Mailer> = ctx.mailer();
-            let self_id = ctx.self_id();
-            let connection_ready_kind = KindId(<ConnectionReady as Kind>::ID.0);
+        // mpsc for accept→dispatcher stream handoff. Unbounded —
+        // the kernel's accept backlog already bounds incoming
+        // connections, and the dispatcher drains the channel on
+        // every `ConnectionReady` mail.
+        let (connection_tx, connection_rx) = mpsc::channel::<(TcpStream, SocketAddr)>();
 
-            // Transport thread below the mail layer — it carries inbound mail in;
-            // no inbound chain to inherit, so no settlement umbrella to honor.
-            #[allow(clippy::disallowed_methods)]
-            let thread = thread::Builder::new()
-                .name(format!("aether-tcp-accept-{port}"))
-                .spawn(move || {
-                    while !shutdown_for_thread.load(Ordering::Acquire) {
-                        if let Ok((stream, peer)) = listener.accept() {
-                            if shutdown_for_thread.load(Ordering::Acquire) {
-                                drop(stream);
-                                break;
-                            }
-                            if connection_tx.send((stream, peer)).is_err() {
-                                // Dispatcher's receiver gone — actor
-                                // is shutting down or already dropped.
-                                break;
-                            }
-                            // Wake the dispatcher: the actual
-                            // stream is in the mpsc; this mail just
-                            // signals "drain me". The payload is the
-                            // wake kind's own wire image (an empty image
-                            // for a fieldless wire kind, ADR-0118) so the
-                            // typed handler decodes it.
-                            mailer.push(Mail::new(
-                                self_id,
-                                connection_ready_kind,
-                                ConnectionReady::default().encode_into_bytes(),
-                                1,
-                            ));
-                        } else if shutdown_for_thread.load(Ordering::Acquire) {
+        // Wake-mail plumbing: capture the mailer + this actor's
+        // own MailboxId so the accept thread can fire a
+        // ConnectionReady mail at us per accept.
+        let mailer: Arc<Mailer> = ctx.mailer();
+        let self_id = ctx.self_id();
+        let connection_ready_kind = KindId(<ConnectionReady as Kind>::ID.0);
+
+        // Transport thread below the mail layer — it carries inbound mail in;
+        // no inbound chain to inherit, so no settlement umbrella to honor.
+        #[allow(clippy::disallowed_methods)]
+        let thread = thread::Builder::new()
+            .name(format!("aether-tcp-accept-{port}"))
+            .spawn(move || {
+                while !shutdown_for_thread.load(Ordering::Acquire) {
+                    if let Ok((stream, peer)) = listener.accept() {
+                        if shutdown_for_thread.load(Ordering::Acquire) {
+                            drop(stream);
                             break;
                         }
+                        if connection_tx.send((stream, peer)).is_err() {
+                            // Dispatcher's receiver gone — actor
+                            // is shutting down or already dropped.
+                            break;
+                        }
+                        // Wake the dispatcher: the actual
+                        // stream is in the mpsc; this mail just
+                        // signals "drain me". The payload is the
+                        // wake kind's own wire image (an empty image
+                        // for a fieldless wire kind, ADR-0118) so the
+                        // typed handler decodes it.
+                        mailer.push(Mail::new(
+                            self_id,
+                            connection_ready_kind,
+                            ConnectionReady::default().encode_into_bytes(),
+                            1,
+                        ));
+                    } else if shutdown_for_thread.load(Ordering::Acquire) {
+                        break;
                     }
-                })
-                .map_err(|e| BootError::Other(Box::new(e)))?;
-
-            tracing::info!(
-                target: "aether_substrate::tcp",
-                addr = %addr,
-                port = port,
-                "tcp listener bound",
-            );
-
-            Ok(Self {
-                local_port: port,
-                shutdown,
-                accept_thread: Some(thread),
-                connection_rx,
-                next_subname: 0,
+                }
             })
-        }
+            .map_err(|e| BootError::Other(Box::new(e)))?;
 
-        fn unwire(&mut self, _ctx: &mut NativeCtx<'_>) {
-            self.shutdown.store(true, Ordering::Release);
-            // Wake the blocked accept(). Self-connect to the bound
-            // port; the accept returns, sees the flag, breaks. Short
-            // connect timeout so a misconfigured listener (port
-            // unreachable) doesn't hang the close path.
-            let addr_str = format!("127.0.0.1:{}", self.local_port);
-            if let Ok(addr) = addr_str.parse::<SocketAddr>() {
-                let _ = TcpStream::connect_timeout(&addr, Duration::from_millis(100));
-            }
-            if let Some(thread) = self.accept_thread.take() {
-                let _ = thread.join();
-            }
-            tracing::info!(
-                target: "aether_substrate::tcp",
-                port = self.local_port,
-                "tcp listener closed",
-            );
-        }
+        tracing::info!(
+            target: "aether_substrate::tcp",
+            addr = %addr,
+            port = port,
+            "tcp listener bound",
+        );
 
-        /// Cooperative external close. The unbind path on
-        /// `TcpCapability` mails this; we shut down so the dispatcher
-        /// drains, runs `unwire`, and the close fan-out fires
-        /// `MonitorNotice` to the cap.
-        // Stateless close request: `&mut self` rides the dispatch ABI;
-        // shutdown is requested through `ctx`, not through any field.
-        #[allow(clippy::unused_self)]
-        #[handler]
-        fn on_close_request(&mut self, ctx: &mut NativeCtx<'_>, _mail: Close) {
-            ctx.shutdown();
-        }
+        Ok(TcpListenerState {
+            local_port: port,
+            shutdown,
+            accept_thread: Some(thread),
+            connection_rx,
+            next_subname: 0,
+        })
+    }
 
-        /// Sidecar wake. Drain every pending accepted connection and
-        /// spawn a `TcpSessionActor` per stream. Each session is a
-        /// child of this listener (parent `Source` stamps as our own
-        /// mailbox), so on session close the close fan-out reaches
-        /// us via the standard monitor path.
-        ///
-        /// The accept thread fires one wake mail per accepted
-        /// connection, but the handler drains until empty regardless
-        /// — if multiple wakes coalesce into one dispatcher tick,
-        /// we'll see the queue already drained on the second handler
-        /// call and exit fast.
-        #[handler]
-        fn on_connection_ready(&mut self, ctx: &mut NativeCtx<'_>, _mail: ConnectionReady) {
-            while let Ok((stream, peer)) = self.connection_rx.try_recv() {
-                let subname = format!("conn-{}", self.next_subname);
-                self.next_subname += 1;
-                let peer_str = peer.to_string();
-                let session_config = TcpSessionConfig {
-                    stream: Some(stream),
-                    peer: peer_str.clone(),
-                    session_name: subname.clone(),
-                };
-                match ctx
-                    .spawn_child::<TcpSessionActor>(
-                        aether_substrate::Subname::Named(&subname),
-                        session_config,
-                    )
-                    .finish()
-                {
-                    Ok(_) => {
-                        tracing::debug!(
-                            target: "aether_substrate::tcp",
-                            session = %subname,
-                            peer = %peer_str,
-                            "tcp session spawned",
-                        );
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            target: "aether_substrate::tcp",
-                            session = %subname,
-                            peer = %peer_str,
-                            error = ?e,
-                            "tcp session spawn failed; closing stream",
-                        );
-                    }
+    fn unwire(state: &mut Self::State, _ctx: &mut NativeCtx<'_>) {
+        state.shutdown.store(true, Ordering::Release);
+        // Wake the blocked accept(). Self-connect to the bound
+        // port; the accept returns, sees the flag, breaks. Short
+        // connect timeout so a misconfigured listener (port
+        // unreachable) doesn't hang the close path.
+        let addr_str = format!("127.0.0.1:{}", state.local_port);
+        if let Ok(addr) = addr_str.parse::<SocketAddr>() {
+            let _ = TcpStream::connect_timeout(&addr, Duration::from_millis(100));
+        }
+        if let Some(thread) = state.accept_thread.take() {
+            let _ = thread.join();
+        }
+        tracing::info!(
+            target: "aether_substrate::tcp",
+            port = state.local_port,
+            "tcp listener closed",
+        );
+    }
+
+    /// Cooperative external close. The unbind path on
+    /// `TcpCapability` mails this; we shut down so the dispatcher
+    /// drains, runs `unwire`, and the close fan-out fires
+    /// `MonitorNotice` to the cap.
+    // Stateless close request: shutdown is requested through `ctx`, not
+    // through any state field, so `_state` is unused.
+    #[handler]
+    fn on_close_request(_state: &mut Self::State, ctx: &mut NativeCtx<'_>, _mail: Close) {
+        ctx.shutdown();
+    }
+
+    /// Sidecar wake. Drain every pending accepted connection and
+    /// spawn a `TcpSessionActor` per stream. Each session is a
+    /// child of this listener (parent `Source` stamps as our own
+    /// mailbox), so on session close the close fan-out reaches
+    /// us via the standard monitor path.
+    ///
+    /// The accept thread fires one wake mail per accepted
+    /// connection, but the handler drains until empty regardless
+    /// — if multiple wakes coalesce into one dispatcher tick,
+    /// we'll see the queue already drained on the second handler
+    /// call and exit fast.
+    #[handler]
+    fn on_connection_ready(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        _mail: ConnectionReady,
+    ) {
+        while let Ok((stream, peer)) = state.connection_rx.try_recv() {
+            let subname = format!("conn-{}", state.next_subname);
+            state.next_subname += 1;
+            let peer_str = peer.to_string();
+            let session_config = TcpSessionConfig {
+                stream: Some(stream),
+                peer: peer_str.clone(),
+                session_name: subname.clone(),
+            };
+            match ctx
+                .spawn_child::<TcpSessionActor>(
+                    aether_substrate::Subname::Named(&subname),
+                    session_config,
+                )
+                .finish()
+            {
+                Ok(_) => {
+                    tracing::debug!(
+                        target: "aether_substrate::tcp",
+                        session = %subname,
+                        peer = %peer_str,
+                        "tcp session spawned",
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        target: "aether_substrate::tcp",
+                        session = %subname,
+                        peer = %peer_str,
+                        error = ?e,
+                        "tcp session spawn failed; closing stream",
+                    );
                 }
             }
         }

--- a/crates/aether-capabilities/src/tcp/listener/runtime.rs
+++ b/crates/aether-capabilities/src/tcp/listener/runtime.rs
@@ -1,0 +1,38 @@
+//! The `aether.tcp.listener` runtime half (ADR-0122 identity/runtime split).
+//! Compiled only under `feature = "runtime"` (the `mod runtime;` declaration
+//! in the parent carries the gate), so a transport-only build of the
+//! [`TcpListenerActor`](super::TcpListenerActor) identity never names these
+//! types nor pulls `aether_substrate`. The substrate / `std::net`-typed
+//! imports are gated once by this module rather than line-by-line; the
+//! `#[actor] impl` reaches the state, ctx types, and config / session types
+//! through the single `use runtime::*` glob in the parent.
+
+pub use std::net::{SocketAddr, TcpStream};
+pub use std::sync::Arc;
+pub use std::sync::atomic::{AtomicBool, Ordering};
+pub use std::sync::mpsc;
+pub use std::thread::{self, JoinHandle};
+pub use std::time::Duration;
+
+pub use aether_data::Kind;
+pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub use aether_substrate::chassis::error::BootError;
+pub use aether_substrate::{KindId, Mail, Mailer};
+
+pub use crate::tcp::config::{TcpListenerConfig, TcpSessionConfig};
+pub use crate::tcp::session::TcpSessionActor;
+
+/// `aether.tcp.listener` runtime state (issue 607 Phase 6b, ADR-0079). The
+/// accept thread can't call `ctx.spawn_child` (no dispatcher ctx), so it
+/// pushes accepted streams over `connection_rx` and fires a
+/// [`ConnectionReady`](super::ConnectionReady) wake mail. The dispatcher's
+/// `on_connection_ready` handler drains the mpsc and spawns one
+/// `TcpSessionActor` per pending stream. The addressing identity is the
+/// distinct ZST [`TcpListenerActor`](super::TcpListenerActor).
+pub struct TcpListenerState {
+    pub(super) local_port: u16,
+    pub(super) shutdown: Arc<AtomicBool>,
+    pub(super) accept_thread: Option<JoinHandle<()>>,
+    pub(super) connection_rx: mpsc::Receiver<(TcpStream, SocketAddr)>,
+    pub(super) next_subname: u64,
+}

--- a/crates/aether-capabilities/src/tcp/mod.rs
+++ b/crates/aether-capabilities/src/tcp/mod.rs
@@ -320,560 +320,536 @@ impl TcpNativeExt for NativeActorMailbox<'_, TcpCapability> {
     }
 }
 
-#[aether_actor::bridge(singleton)]
-mod cap_native {
-    // Trait-marker kinds the wasm32 bridge stub needs to satisfy
-    // HandlesKind; these stay always-imported.
-    use super::{BindListener, ListListeners, MonitorNotice, UnbindListener};
-    // Reply / payload kinds + native-only types (TcpListenerActor /
-    // TcpListenerConfig) only consumed by native handler bodies. The
-    // wasm32 stub bridge emits doesn't reference them, so they're
-    // gated to avoid an unused-import warning.
-    #[cfg(not(target_arch = "wasm32"))]
-    use super::{
-        BindListenerResult, Close, ListListenersResult, ListenerInfo, TcpListenerActor,
-        TcpListenerConfig, UnbindListenerResult,
-    };
-    use aether_actor::actor::ctx::OutboundReply;
-    use aether_actor::{Manual, actor};
-    use aether_substrate::actor::monitor::MonitorHandle;
-    use aether_substrate::actor::native::spawn::Subname;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
-    use std::collections::HashMap;
-    use std::net::TcpListener;
+/// `aether.tcp` cap **identity** (ADR-0122 identity/runtime split). A ZST
+/// carrying only the addressing — `Addressable` (`NAMESPACE`, `Resolver`), the
+/// per-handler `HandlesKind` markers, and the singleton name-inventory entry,
+/// all emitted always-on by `#[actor]`. The state-bearing runtime
+/// (`TcpCapabilityState`, the cap's listener-fleet supervisor map) lives
+/// behind the one `feature = "runtime"` gate, so a transport-only build never
+/// names `TcpCapabilityState` nor pulls `aether_substrate` through this cap.
+///
+/// The cap is the supervisor of its listener fleet: it spawns listeners,
+/// monitors them, and replies to unbind requests on their close. It holds its
+/// own `MailboxId → ListenerEntry` map; it does NOT walk the chassis-wide
+/// actor registry to enumerate children.
+pub struct TcpCapability;
 
-    /// Singleton control-plane cap. Owns the listener fleet directly
-    /// — the cap is the supervisor, not a thin shim over the chassis
-    /// registry. Each spawn registers a monitor on the new listener
-    /// and inserts a `ListenerEntry` into the cap-local map; the
-    /// `on_monitor_notice` handler removes the entry on listener
-    /// close.
+// The `#[actor]` attribute path stays always-on (the macro divides what it
+// emits). Everything that names an `aether_substrate` / `std::net` type — the
+// handler/init ctx, the runtime state, the supervisor structs — lives in the
+// `runtime` module below, gated once by `feature = "runtime"` and reached
+// through the single `use runtime::*` glob. The handled kinds (`BindListener`
+// / `UnbindListener` / `ListListeners`) stay always-on via `pub use kinds::*`
+// and `MonitorNotice` via the always-on `aether_kinds` import above — the
+// always-on `HandlesKind<K>` markers name them.
+use aether_actor::actor;
+
+#[cfg(feature = "runtime")]
+#[allow(clippy::wildcard_imports)]
+use runtime::*;
+
+#[cfg(feature = "runtime")]
+mod runtime;
+
+#[actor(singleton)]
+impl NativeActor for TcpCapability {
+    /// The runtime state this identity boots into (ADR-0122 split): the
+    /// cap-local listener-fleet supervisor map.
+    type State = TcpCapabilityState;
+    type Config = ();
+    const NAMESPACE: &'static str = "aether.tcp";
+
+    fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<TcpCapabilityState, BootError> {
+        Ok(TcpCapabilityState {
+            listeners: HashMap::new(),
+            pending_unbinds: HashMap::new(),
+        })
+    }
+
+    /// Spawn a fresh `TcpListenerActor` bound to `mail.addr`.
     ///
-    /// Issue 629 / Phase B: plain `HashMap` fields. The dispatcher
-    /// thread is the sole writer / reader; pre-Phase-A's
-    /// `Mutex<HashMap<...>>` was a worker-pool-era tax, not a
-    /// contention point.
-    pub struct TcpCapability {
-        /// Live listeners spawned by this cap. Key is the listener's
-        /// full-name `MailboxId`. Each entry holds the bind metadata
-        /// surfaced via `ListListeners` plus the monitor handle that
-        /// pins the cap's monitor on the listener until close.
-        listeners: HashMap<aether_data::MailboxId, ListenerEntry>,
-        /// Outstanding unbind replies parked until `MonitorNotice`
-        /// arrives from the listener being closed. Key is the same
-        /// `MailboxId` as `listeners`; the cap's monitor (registered
-        /// at spawn time) is what fires the notice.
-        pending_unbinds: HashMap<aether_data::MailboxId, PendingUnbind>,
-    }
-
-    /// Cap-local supervisor state for one live listener. Drops with
-    /// the entry; `MonitorHandle::Drop` is idempotent with the close
-    /// path's index drain.
-    struct ListenerEntry {
-        addr: String,
-        port: u16,
-        name: String,
-        // Held to keep the cap's monitor registered against the
-        // listener for its lifetime. Drops when the entry is removed
-        // (in `on_monitor_notice`).
-        _monitor_handle: MonitorHandle,
-    }
-
-    struct PendingUnbind {
-        sender: aether_data::Source,
-        listener_name: String,
-    }
-
-    #[actor]
-    impl NativeActor for TcpCapability {
-        type Config = ();
-        const NAMESPACE: &'static str = "aether.tcp";
-
-        fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            Ok(Self {
-                listeners: HashMap::new(),
-                pending_unbinds: HashMap::new(),
-            })
-        }
-
-        /// Spawn a fresh `TcpListenerActor` bound to `mail.addr`.
-        ///
-        /// Binds the socket on the dispatcher thread (so a bind
-        /// failure replies `Err` synchronously), then hands the bound
-        /// listener through `spawn_child`. After spawn the cap
-        /// registers a monitor and inserts the listener into its
-        /// supervisor map.
-        ///
-        /// # Agent
-        /// Reply: `BindListenerResult`. `Ok` on successful bind +
-        /// spawn; `Err` on addr parse / bind / spawn / monitor failure.
-        #[handler]
-        fn on_bind(&mut self, ctx: &mut NativeCtx<'_>, mail: BindListener) -> BindListenerResult {
-            let listener = match TcpListener::bind(&mail.addr) {
-                Ok(l) => l,
-                Err(e) => {
-                    return BindListenerResult::Err {
-                        addr: mail.addr,
-                        reason: format!("bind failed: {e}"),
-                    };
-                }
-            };
-            let local_port = match listener.local_addr() {
-                Ok(addr) => addr.port(),
-                Err(e) => {
-                    return BindListenerResult::Err {
-                        addr: mail.addr,
-                        reason: format!("local_addr failed: {e}"),
-                    };
-                }
-            };
-            let subname_str = mail.name.clone().unwrap_or_else(|| format!("{local_port}"));
-
-            let listener_id = match ctx
-                .spawn_child::<TcpListenerActor>(
-                    Subname::Named(&subname_str),
-                    TcpListenerConfig {
-                        listener: Some(listener),
-                        addr: mail.addr.clone(),
-                        port: local_port,
-                    },
-                )
-                .finish()
-            {
-                Ok(id) => id,
-                Err(e) => {
-                    return BindListenerResult::Err {
-                        addr: mail.addr,
-                        reason: format!("spawn failed: {e:?}"),
-                    };
-                }
-            };
-
-            // Register the cap's monitor on the freshly-spawned
-            // listener. The monitor pins until the entry is removed
-            // (in on_monitor_notice).
-            let monitor_handle = match ctx.monitor(listener_id) {
-                Ok(h) => h,
-                Err(e) => {
-                    // Listener spawned but monitor failed — extremely
-                    // unlikely (listener was just inserted Live). Reply
-                    // Err and let the listener live; chassis shutdown
-                    // will reap it.
-                    return BindListenerResult::Err {
-                        addr: mail.addr,
-                        reason: format!("monitor failed: {e:?}"),
-                    };
-                }
-            };
-
-            self.listeners.insert(
-                listener_id,
-                ListenerEntry {
+    /// Binds the socket on the dispatcher thread (so a bind
+    /// failure replies `Err` synchronously), then hands the bound
+    /// listener through `spawn_child`. After spawn the cap
+    /// registers a monitor and inserts the listener into its
+    /// supervisor map.
+    ///
+    /// # Agent
+    /// Reply: `BindListenerResult`. `Ok` on successful bind +
+    /// spawn; `Err` on addr parse / bind / spawn / monitor failure.
+    #[handler]
+    fn on_bind(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        mail: BindListener,
+    ) -> BindListenerResult {
+        let listener = match TcpListener::bind(&mail.addr) {
+            Ok(l) => l,
+            Err(e) => {
+                return BindListenerResult::Err {
                     addr: mail.addr,
+                    reason: format!("bind failed: {e}"),
+                };
+            }
+        };
+        let local_port = match listener.local_addr() {
+            Ok(addr) => addr.port(),
+            Err(e) => {
+                return BindListenerResult::Err {
+                    addr: mail.addr,
+                    reason: format!("local_addr failed: {e}"),
+                };
+            }
+        };
+        let subname_str = mail.name.clone().unwrap_or_else(|| format!("{local_port}"));
+
+        let listener_id = match ctx
+            .spawn_child::<TcpListenerActor>(
+                Subname::Named(&subname_str),
+                TcpListenerConfig {
+                    listener: Some(listener),
+                    addr: mail.addr.clone(),
                     port: local_port,
-                    name: subname_str.clone(),
-                    _monitor_handle: monitor_handle,
                 },
-            );
-
-            BindListenerResult::Ok {
-                listener_name: subname_str,
-                listener_id,
-                local_port,
+            )
+            .finish()
+        {
+            Ok(id) => id,
+            Err(e) => {
+                return BindListenerResult::Err {
+                    addr: mail.addr,
+                    reason: format!("spawn failed: {e:?}"),
+                };
             }
-        }
+        };
 
-        /// Mail `Close` to the named listener and park the
-        /// originator's reply target. Reply fires from
-        /// `on_monitor_notice` once the listener tombstones.
-        ///
-        /// # Agent
-        /// Reply: `UnbindListenerResult`. Asynchronous — the response
-        /// fires after the listener's accept thread joins and its
-        /// `MonitorNotice` arrives at this cap.
-        #[handler::manual]
-        fn on_unbind(&mut self, ctx: &mut NativeCtx<'_, Manual>, mail: UnbindListener) {
-            // Resolve listener_id from the cap-local supervisor map by
-            // name. The cap is the source of truth for "what listeners
-            // exist"; no registry walk needed.
-            let listener_id = self
-                .listeners
-                .iter()
-                .find(|(_, entry)| entry.name == mail.listener_name)
-                .map(|(id, _)| *id);
-            let Some(listener_id) = listener_id else {
-                ctx.reply(&UnbindListenerResult::Err {
-                    listener_name: mail.listener_name,
-                    reason: "no such listener (or already closed)".into(),
-                });
-                return;
-            };
-            // Park the reply target keyed on listener_id. The cap's
-            // already-registered monitor (set at spawn time) fires
-            // MonitorNotice on close, which drives the reply.
-            self.pending_unbinds.insert(
-                listener_id,
-                PendingUnbind {
-                    sender: ctx.reply_target(),
-                    listener_name: mail.listener_name,
-                },
-            );
-            // Mail Close to the listener by its stored id. ADR-0099 §3:
-            // the listener is a spawned child, so its id is the lineage
-            // fold, not `hash(NAMESPACE:name)` — re-resolving by name
-            // would reach a flat id nothing is registered under. The cap
-            // already holds the folded id from the spawn (the
-            // `self.listeners` key), so address it directly.
-            ctx.actor_at::<TcpListenerActor>(listener_id)
-                .send(&Close::default());
-        }
-
-        /// Walk the cap-local listener map and report metadata.
-        ///
-        /// # Agent
-        /// Reply: `ListListenersResult`.
-        #[handler]
-        fn on_list(
-            &mut self,
-            _ctx: &mut NativeCtx<'_>,
-            _mail: ListListeners,
-        ) -> ListListenersResult {
-            let listeners: Vec<ListenerInfo> = self
-                .listeners
-                .values()
-                .map(|entry| ListenerInfo {
-                    name: entry.name.clone(),
-                    addr: entry.addr.clone(),
-                    port: entry.port,
-                })
-                .collect();
-            ListListenersResult { listeners }
-        }
-
-        /// Listener tombstoned — remove from the supervisor map and
-        /// fire the parked unbind reply if one is waiting.
-        ///
-        /// `MonitorNotice.target` identifies which listener closed.
-        /// The cap's monitor on every spawned listener (registered in
-        /// `on_bind`) fires this notice; if the close came from an
-        /// unbind request, `pending_unbinds` has an entry with the
-        /// originator to reply to.
-        #[handler::manual]
-        fn on_monitor_notice(&mut self, ctx: &mut NativeCtx<'_, Manual>, notice: MonitorNotice) {
-            // Drop the supervisor entry. The held MonitorHandle drops
-            // here; deregister is idempotent with the close path's
-            // forward-index drain.
-            let _entry = self.listeners.remove(&notice.target);
-            // Fire the parked unbind reply if one was waiting.
-            let parked = self.pending_unbinds.remove(&notice.target);
-            if let Some(parked) = parked {
-                ctx.reply_to(
-                    parked.sender,
-                    &UnbindListenerResult::Ok {
-                        listener_name: parked.listener_name,
-                    },
-                );
+        // Register the cap's monitor on the freshly-spawned
+        // listener. The monitor pins until the entry is removed
+        // (in on_monitor_notice).
+        let monitor_handle = match ctx.monitor(listener_id) {
+            Ok(h) => h,
+            Err(e) => {
+                // Listener spawned but monitor failed — extremely
+                // unlikely (listener was just inserted Live). Reply
+                // Err and let the listener live; chassis shutdown
+                // will reap it.
+                return BindListenerResult::Err {
+                    addr: mail.addr,
+                    reason: format!("monitor failed: {e:?}"),
+                };
             }
-            // Else: notice came from a non-unbind close (chassis
-            // shutdown, future trap). Nothing to reply to; the
-            // supervisor entry is gone, that's the cleanup.
+        };
+
+        state.listeners.insert(
+            listener_id,
+            ListenerEntry {
+                addr: mail.addr,
+                port: local_port,
+                name: subname_str.clone(),
+                _monitor_handle: monitor_handle,
+            },
+        );
+
+        BindListenerResult::Ok {
+            listener_name: subname_str,
+            listener_id,
+            local_port,
         }
     }
 
-    #[cfg(test)]
-    mod tests {
-        use std::sync::Arc;
-        use std::sync::mpsc;
-        use std::thread;
-        use std::time::{Duration, Instant};
-
-        use super::{
-            BindListener, BindListenerResult, ListListeners, ListListenersResult, TcpCapability,
-            UnbindListener, UnbindListenerResult,
+    /// Mail `Close` to the named listener and park the
+    /// originator's reply target. Reply fires from
+    /// `on_monitor_notice` once the listener tombstones.
+    ///
+    /// # Agent
+    /// Reply: `UnbindListenerResult`. Asynchronous — the response
+    /// fires after the listener's accept thread joins and its
+    /// `MonitorNotice` arrives at this cap.
+    #[handler::manual]
+    fn on_unbind(state: &mut Self::State, ctx: &mut NativeCtx<'_, Manual>, mail: UnbindListener) {
+        // Resolve listener_id from the cap-local supervisor map by
+        // name. The cap is the source of truth for "what listeners
+        // exist"; no registry walk needed.
+        let listener_id = state
+            .listeners
+            .iter()
+            .find(|(_, entry)| entry.name == mail.listener_name)
+            .map(|(id, _)| *id);
+        let Some(listener_id) = listener_id else {
+            ctx.reply(&UnbindListenerResult::Err {
+                listener_name: mail.listener_name,
+                reason: "no such listener (or already closed)".into(),
+            });
+            return;
         };
-        use crate::test_chassis::TestChassis;
-        use aether_actor::Addressable;
-        use aether_data::{Kind, SessionToken, Uuid};
-        use aether_kinds::descriptors;
-        use aether_kinds::trace::Nanos;
-        use aether_substrate::chassis::builder::{Builder, PassiveChassis};
-        use aether_substrate::mail::MailId;
-        use aether_substrate::mail::mailer::Mailer;
-        use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
-        use aether_substrate::mail::registry::OwnedDispatch;
-        use aether_substrate::mail::registry::{MailboxEntry, Registry};
-        use aether_substrate::mail::{MailRef, Source, SourceAddr};
+        // Park the reply target keyed on listener_id. The cap's
+        // already-registered monitor (set at spawn time) fires
+        // MonitorNotice on close, which drives the reply.
+        state.pending_unbinds.insert(
+            listener_id,
+            PendingUnbind {
+                sender: ctx.reply_target(),
+                listener_name: mail.listener_name,
+            },
+        );
+        // Mail Close to the listener by its stored id. ADR-0099 §3:
+        // the listener is a spawned child, so its id is the lineage
+        // fold, not `hash(NAMESPACE:name)` — re-resolving by name
+        // would reach a flat id nothing is registered under. The cap
+        // already holds the folded id from the spawn (the
+        // `state.listeners` key), so address it directly.
+        ctx.actor_at::<TcpListenerActor>(listener_id)
+            .send(&Close::default());
+    }
 
-        fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>, mpsc::Receiver<EgressEvent>) {
-            let registry = Arc::new(Registry::new());
-            for d in descriptors::all() {
-                let _ = registry.register_kind_with_descriptor(d);
-            }
-            let (outbound, rx) = HubOutbound::attached_loopback();
-            let mailer = Arc::new(Mailer::new(Arc::clone(&registry)).with_outbound(outbound));
-            (registry, mailer, rx)
-        }
+    /// Walk the cap-local listener map and report metadata.
+    ///
+    /// # Agent
+    /// Reply: `ListListenersResult`.
+    #[handler]
+    fn on_list(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        _mail: ListListeners,
+    ) -> ListListenersResult {
+        let listeners: Vec<ListenerInfo> = state
+            .listeners
+            .values()
+            .map(|entry| ListenerInfo {
+                name: entry.name.clone(),
+                addr: entry.addr.clone(),
+                port: entry.port,
+            })
+            .collect();
+        ListListenersResult { listeners }
+    }
 
-        /// Boot a fresh substrate with `TcpCapability` registered as a
-        /// passive actor and return the pieces every test in this
-        /// module reaches for: the kind registry (for mailbox lookup
-        /// in [`drive_and_decode`]), the egress receiver (for reply
-        /// decode), and the [`PassiveChassis`] (held by the caller so
-        /// the cap's actor thread stays alive for the test body).
-        ///
-        /// Collapses the previously-duplicated `fresh_substrate()` +
-        /// `Builder::<TestChassis>::new(...)` chain that opened every
-        /// test (issue 796).
-        fn boot_tcp_substrate() -> (
-            Arc<Registry>,
-            mpsc::Receiver<EgressEvent>,
-            PassiveChassis<TestChassis>,
-        ) {
-            let (registry, mailer, rx) = fresh_substrate();
-            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-                .with_actor::<TcpCapability>(())
-                .build_passive()
-                .expect("TcpCapability boots");
-            (registry, rx, chassis)
-        }
-
-        fn session_reply() -> Source {
-            Source::to(SourceAddr::Session(SessionToken(Uuid::from_u128(0xfeed))))
-        }
-
-        /// Push an encoded mail (via the kind's `encode_into_bytes`) at
-        /// the cap's mailbox via the registered sink handler, then wait
-        /// for the next outbound reply on `rx` and decode as `R`.
-        fn drive_and_decode<K, R>(
-            registry: &Arc<Registry>,
-            rx: &mpsc::Receiver<EgressEvent>,
-            cap_namespace: &str,
-            mail: &K,
-        ) -> R
-        where
-            K: Kind,
-            R: Kind,
-        {
-            let id = registry
-                .lookup(cap_namespace)
-                .expect("cap mailbox registered");
-            let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("cap entry") else {
-                panic!("expected mailbox entry");
-            };
-            let bytes = mail.encode_into_bytes();
-            handler.enqueue(OwnedDispatch::disarmed(
-                K::ID,
-                K::NAME.to_owned(),
-                None,
-                session_reply(),
-                MailRef::from(bytes),
-                1,
-                MailId::NONE,
-                MailId::NONE,
-                None,
-                Nanos(0),
-                0,
-                aether_data::MailboxId(0),
-            ));
-
-            let deadline = Instant::now() + Duration::from_secs(2);
-            let frame = loop {
-                if let Ok(f) = rx.try_recv() {
-                    break f;
-                }
-                assert!(
-                    Instant::now() < deadline,
-                    "reply did not arrive within deadline for {}",
-                    K::NAME
-                );
-                thread::sleep(Duration::from_millis(5));
-            };
-            let payload = match frame {
-                EgressEvent::ToSession { payload, .. } => payload,
-                other => panic!("expected ToSession egress, got {other:?}"),
-            };
-            R::decode_from_bytes(&payload).expect("decode reply")
-        }
-
-        /// Issue 607 Phase 6a: bind → list → unbind round-trip on a
-        /// loopback port. Asserts the cap-local supervisor map
-        /// reflects every step (bound, listed, unbound).
-        #[test]
-        fn bind_then_list_then_unbind_roundtrip() {
-            let (registry, rx, _chassis) = boot_tcp_substrate();
-
-            // Bind to port 0 — let the OS pick a free port.
-            let bind_reply: BindListenerResult = drive_and_decode(
-                &registry,
-                &rx,
-                TcpCapability::NAMESPACE,
-                &BindListener {
-                    addr: "127.0.0.1:0".into(),
-                    name: None,
+    /// Listener tombstoned — remove from the supervisor map and
+    /// fire the parked unbind reply if one is waiting.
+    ///
+    /// `MonitorNotice.target` identifies which listener closed.
+    /// The cap's monitor on every spawned listener (registered in
+    /// `on_bind`) fires this notice; if the close came from an
+    /// unbind request, `pending_unbinds` has an entry with the
+    /// originator to reply to.
+    #[handler::manual]
+    fn on_monitor_notice(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_, Manual>,
+        notice: MonitorNotice,
+    ) {
+        // Drop the supervisor entry. The held MonitorHandle drops
+        // here; deregister is idempotent with the close path's
+        // forward-index drain.
+        let _entry = state.listeners.remove(&notice.target);
+        // Fire the parked unbind reply if one was waiting.
+        let parked = state.pending_unbinds.remove(&notice.target);
+        if let Some(parked) = parked {
+            ctx.reply_to(
+                parked.sender,
+                &UnbindListenerResult::Ok {
+                    listener_name: parked.listener_name,
                 },
             );
-            let (listener_name, local_port) = match bind_reply {
-                BindListenerResult::Ok {
-                    listener_name,
-                    local_port,
-                    ..
-                } => (listener_name, local_port),
-                BindListenerResult::Err { reason, .. } => panic!("bind failed: {reason}"),
-            };
-            assert_eq!(
-                listener_name,
-                local_port.to_string(),
-                "default subname should be the bound port",
-            );
-            assert!(local_port > 0, "OS-picked port should be non-zero");
+        }
+        // Else: notice came from a non-unbind close (chassis
+        // shutdown, future trap). Nothing to reply to; the
+        // supervisor entry is gone, that's the cleanup.
+    }
+}
 
-            // List enumerates the one listener.
-            let list_reply: ListListenersResult = drive_and_decode(
-                &registry,
-                &rx,
-                TcpCapability::NAMESPACE,
-                &ListListeners::default(),
-            );
-            assert_eq!(list_reply.listeners.len(), 1, "exactly one listener");
-            let entry = &list_reply.listeners[0];
-            assert_eq!(entry.name, listener_name);
-            assert_eq!(entry.port, local_port);
-            assert_eq!(entry.addr, "127.0.0.1:0");
+#[cfg(all(test, feature = "runtime"))]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::{Duration, Instant};
 
-            // Unbind — asynchronous reply via MonitorNotice.
-            let unbind_reply: UnbindListenerResult = drive_and_decode(
-                &registry,
-                &rx,
-                TcpCapability::NAMESPACE,
-                &UnbindListener {
-                    listener_name: listener_name.clone(),
-                },
-            );
-            match unbind_reply {
-                UnbindListenerResult::Ok { listener_name: ln } => assert_eq!(ln, listener_name),
-                UnbindListenerResult::Err { reason, .. } => panic!("unbind failed: {reason}"),
+    use super::{
+        BindListener, BindListenerResult, ListListeners, ListListenersResult, TcpCapability,
+        UnbindListener, UnbindListenerResult,
+    };
+    use crate::test_chassis::TestChassis;
+    use aether_actor::Addressable;
+    use aether_data::{Kind, SessionToken, Uuid};
+    use aether_kinds::descriptors;
+    use aether_kinds::trace::Nanos;
+    use aether_substrate::chassis::builder::{Builder, PassiveChassis};
+    use aether_substrate::mail::MailId;
+    use aether_substrate::mail::mailer::Mailer;
+    use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
+    use aether_substrate::mail::registry::OwnedDispatch;
+    use aether_substrate::mail::registry::{MailboxEntry, Registry};
+    use aether_substrate::mail::{MailRef, Source, SourceAddr};
+
+    fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>, mpsc::Receiver<EgressEvent>) {
+        let registry = Arc::new(Registry::new());
+        for d in descriptors::all() {
+            let _ = registry.register_kind_with_descriptor(d);
+        }
+        let (outbound, rx) = HubOutbound::attached_loopback();
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry)).with_outbound(outbound));
+        (registry, mailer, rx)
+    }
+
+    /// Boot a fresh substrate with `TcpCapability` registered as a
+    /// passive actor and return the pieces every test in this
+    /// module reaches for: the kind registry (for mailbox lookup
+    /// in [`drive_and_decode`]), the egress receiver (for reply
+    /// decode), and the [`PassiveChassis`] (held by the caller so
+    /// the cap's actor thread stays alive for the test body).
+    ///
+    /// Collapses the previously-duplicated `fresh_substrate()` +
+    /// `Builder::<TestChassis>::new(...)` chain that opened every
+    /// test (issue 796).
+    fn boot_tcp_substrate() -> (
+        Arc<Registry>,
+        mpsc::Receiver<EgressEvent>,
+        PassiveChassis<TestChassis>,
+    ) {
+        let (registry, mailer, rx) = fresh_substrate();
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<TcpCapability>(())
+            .build_passive()
+            .expect("TcpCapability boots");
+        (registry, rx, chassis)
+    }
+
+    fn session_reply() -> Source {
+        Source::to(SourceAddr::Session(SessionToken(Uuid::from_u128(0xfeed))))
+    }
+
+    /// Push an encoded mail (via the kind's `encode_into_bytes`) at
+    /// the cap's mailbox via the registered sink handler, then wait
+    /// for the next outbound reply on `rx` and decode as `R`.
+    fn drive_and_decode<K, R>(
+        registry: &Arc<Registry>,
+        rx: &mpsc::Receiver<EgressEvent>,
+        cap_namespace: &str,
+        mail: &K,
+    ) -> R
+    where
+        K: Kind,
+        R: Kind,
+    {
+        let id = registry
+            .lookup(cap_namespace)
+            .expect("cap mailbox registered");
+        let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("cap entry") else {
+            panic!("expected mailbox entry");
+        };
+        let bytes = mail.encode_into_bytes();
+        handler.enqueue(OwnedDispatch::disarmed(
+            K::ID,
+            K::NAME.to_owned(),
+            None,
+            session_reply(),
+            MailRef::from(bytes),
+            1,
+            MailId::NONE,
+            MailId::NONE,
+            None,
+            Nanos(0),
+            0,
+            aether_data::MailboxId(0),
+        ));
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let frame = loop {
+            if let Ok(f) = rx.try_recv() {
+                break f;
             }
-
-            // List should now be empty — cap-local supervisor map
-            // dropped the entry on MonitorNotice.
-            let list_reply: ListListenersResult = drive_and_decode(
-                &registry,
-                &rx,
-                TcpCapability::NAMESPACE,
-                &ListListeners::default(),
-            );
             assert!(
-                list_reply.listeners.is_empty(),
-                "list should drop the unbound listener",
+                Instant::now() < deadline,
+                "reply did not arrive within deadline for {}",
+                K::NAME
             );
+            thread::sleep(Duration::from_millis(5));
+        };
+        let payload = match frame {
+            EgressEvent::ToSession { payload, .. } => payload,
+            other => panic!("expected ToSession egress, got {other:?}"),
+        };
+        R::decode_from_bytes(&payload).expect("decode reply")
+    }
+
+    /// Issue 607 Phase 6a: bind → list → unbind round-trip on a
+    /// loopback port. Asserts the cap-local supervisor map
+    /// reflects every step (bound, listed, unbound).
+    #[test]
+    fn bind_then_list_then_unbind_roundtrip() {
+        let (registry, rx, _chassis) = boot_tcp_substrate();
+
+        // Bind to port 0 — let the OS pick a free port.
+        let bind_reply: BindListenerResult = drive_and_decode(
+            &registry,
+            &rx,
+            TcpCapability::NAMESPACE,
+            &BindListener {
+                addr: "127.0.0.1:0".into(),
+                name: None,
+            },
+        );
+        let (listener_name, local_port) = match bind_reply {
+            BindListenerResult::Ok {
+                listener_name,
+                local_port,
+                ..
+            } => (listener_name, local_port),
+            BindListenerResult::Err { reason, .. } => panic!("bind failed: {reason}"),
+        };
+        assert_eq!(
+            listener_name,
+            local_port.to_string(),
+            "default subname should be the bound port",
+        );
+        assert!(local_port > 0, "OS-picked port should be non-zero");
+
+        // List enumerates the one listener.
+        let list_reply: ListListenersResult = drive_and_decode(
+            &registry,
+            &rx,
+            TcpCapability::NAMESPACE,
+            &ListListeners::default(),
+        );
+        assert_eq!(list_reply.listeners.len(), 1, "exactly one listener");
+        let entry = &list_reply.listeners[0];
+        assert_eq!(entry.name, listener_name);
+        assert_eq!(entry.port, local_port);
+        assert_eq!(entry.addr, "127.0.0.1:0");
+
+        // Unbind — asynchronous reply via MonitorNotice.
+        let unbind_reply: UnbindListenerResult = drive_and_decode(
+            &registry,
+            &rx,
+            TcpCapability::NAMESPACE,
+            &UnbindListener {
+                listener_name: listener_name.clone(),
+            },
+        );
+        match unbind_reply {
+            UnbindListenerResult::Ok { listener_name: ln } => assert_eq!(ln, listener_name),
+            UnbindListenerResult::Err { reason, .. } => panic!("unbind failed: {reason}"),
         }
 
-        /// Binding the same port twice fails the second bind. Uses
-        /// the first bind's actually-bound port to drive the second.
-        #[test]
-        fn bind_port_in_use_returns_err() {
-            let (registry, rx, _chassis) = boot_tcp_substrate();
+        // List should now be empty — cap-local supervisor map
+        // dropped the entry on MonitorNotice.
+        let list_reply: ListListenersResult = drive_and_decode(
+            &registry,
+            &rx,
+            TcpCapability::NAMESPACE,
+            &ListListeners::default(),
+        );
+        assert!(
+            list_reply.listeners.is_empty(),
+            "list should drop the unbound listener",
+        );
+    }
 
-            let first: BindListenerResult = drive_and_decode(
-                &registry,
-                &rx,
-                TcpCapability::NAMESPACE,
-                &BindListener {
-                    addr: "127.0.0.1:0".into(),
-                    name: Some("first".into()),
-                },
-            );
-            let local_port = match first {
-                BindListenerResult::Ok { local_port, .. } => local_port,
-                BindListenerResult::Err { reason, .. } => panic!("first bind failed: {reason}"),
-            };
+    /// Binding the same port twice fails the second bind. Uses
+    /// the first bind's actually-bound port to drive the second.
+    #[test]
+    fn bind_port_in_use_returns_err() {
+        let (registry, rx, _chassis) = boot_tcp_substrate();
 
-            // Second bind on the same port — must fail.
-            let second: BindListenerResult = drive_and_decode(
-                &registry,
-                &rx,
-                TcpCapability::NAMESPACE,
-                &BindListener {
-                    addr: format!("127.0.0.1:{local_port}"),
-                    name: Some("second".into()),
-                },
-            );
-            match second {
-                BindListenerResult::Ok { .. } => panic!("expected port-in-use Err"),
-                BindListenerResult::Err { reason, addr } => {
-                    assert_eq!(addr, format!("127.0.0.1:{local_port}"));
-                    assert!(
-                        reason.starts_with("bind failed:"),
-                        "expected bind-fail reason, got: {reason}",
-                    );
-                }
+        let first: BindListenerResult = drive_and_decode(
+            &registry,
+            &rx,
+            TcpCapability::NAMESPACE,
+            &BindListener {
+                addr: "127.0.0.1:0".into(),
+                name: Some("first".into()),
+            },
+        );
+        let local_port = match first {
+            BindListenerResult::Ok { local_port, .. } => local_port,
+            BindListenerResult::Err { reason, .. } => panic!("first bind failed: {reason}"),
+        };
+
+        // Second bind on the same port — must fail.
+        let second: BindListenerResult = drive_and_decode(
+            &registry,
+            &rx,
+            TcpCapability::NAMESPACE,
+            &BindListener {
+                addr: format!("127.0.0.1:{local_port}"),
+                name: Some("second".into()),
+            },
+        );
+        match second {
+            BindListenerResult::Ok { .. } => panic!("expected port-in-use Err"),
+            BindListenerResult::Err { reason, addr } => {
+                assert_eq!(addr, format!("127.0.0.1:{local_port}"));
+                assert!(
+                    reason.starts_with("bind failed:"),
+                    "expected bind-fail reason, got: {reason}",
+                );
             }
         }
+    }
 
-        /// Unbind on an unknown name surfaces an Err with the name
-        /// echoed back.
-        #[test]
-        fn unbind_unknown_listener_errors() {
-            let (registry, rx, _chassis) = boot_tcp_substrate();
+    /// Unbind on an unknown name surfaces an Err with the name
+    /// echoed back.
+    #[test]
+    fn unbind_unknown_listener_errors() {
+        let (registry, rx, _chassis) = boot_tcp_substrate();
 
-            let reply: UnbindListenerResult = drive_and_decode(
-                &registry,
-                &rx,
-                TcpCapability::NAMESPACE,
-                &UnbindListener {
-                    listener_name: "nope".into(),
-                },
-            );
-            match reply {
-                UnbindListenerResult::Err { listener_name, .. } => {
-                    assert_eq!(listener_name, "nope");
-                }
-                UnbindListenerResult::Ok { .. } => panic!("expected Err for unknown listener"),
+        let reply: UnbindListenerResult = drive_and_decode(
+            &registry,
+            &rx,
+            TcpCapability::NAMESPACE,
+            &UnbindListener {
+                listener_name: "nope".into(),
+            },
+        );
+        match reply {
+            UnbindListenerResult::Err { listener_name, .. } => {
+                assert_eq!(listener_name, "nope");
             }
+            UnbindListenerResult::Ok { .. } => panic!("expected Err for unknown listener"),
         }
+    }
 
-        // Pre-#775 the session round-trip test asserted that
-        // SessionData / SessionClosed broadcasts arrived at the egress
-        // after a real TCP client wrote then dropped. Issue 775 retired
-        // the BroadcastCapability + observation fan-out, so the
-        // session actor no longer publishes those kinds — the test was
-        // deleted with the broadcasts.
+    // Pre-#775 the session round-trip test asserted that
+    // SessionData / SessionClosed broadcasts arrived at the egress
+    // after a real TCP client wrote then dropped. Issue 775 retired
+    // the BroadcastCapability + observation fan-out, so the
+    // session actor no longer publishes those kinds — the test was
+    // deleted with the broadcasts.
 
-        /// Two concurrent binds on different ports both surface in
-        /// `ListListeners`.
-        #[test]
-        fn list_enumerates_two_concurrent_listeners() {
-            let (registry, rx, _chassis) = boot_tcp_substrate();
+    /// Two concurrent binds on different ports both surface in
+    /// `ListListeners`.
+    #[test]
+    fn list_enumerates_two_concurrent_listeners() {
+        let (registry, rx, _chassis) = boot_tcp_substrate();
 
-            let _: BindListenerResult = drive_and_decode(
-                &registry,
-                &rx,
-                TcpCapability::NAMESPACE,
-                &BindListener {
-                    addr: "127.0.0.1:0".into(),
-                    name: Some("admin".into()),
-                },
-            );
-            let _: BindListenerResult = drive_and_decode(
-                &registry,
-                &rx,
-                TcpCapability::NAMESPACE,
-                &BindListener {
-                    addr: "127.0.0.1:0".into(),
-                    name: Some("game".into()),
-                },
-            );
+        let _: BindListenerResult = drive_and_decode(
+            &registry,
+            &rx,
+            TcpCapability::NAMESPACE,
+            &BindListener {
+                addr: "127.0.0.1:0".into(),
+                name: Some("admin".into()),
+            },
+        );
+        let _: BindListenerResult = drive_and_decode(
+            &registry,
+            &rx,
+            TcpCapability::NAMESPACE,
+            &BindListener {
+                addr: "127.0.0.1:0".into(),
+                name: Some("game".into()),
+            },
+        );
 
-            let list: ListListenersResult = drive_and_decode(
-                &registry,
-                &rx,
-                TcpCapability::NAMESPACE,
-                &ListListeners::default(),
-            );
-            let mut names: Vec<String> = list.listeners.iter().map(|l| l.name.clone()).collect();
-            names.sort();
-            assert_eq!(names, vec!["admin".to_string(), "game".to_string()]);
-        }
+        let list: ListListenersResult = drive_and_decode(
+            &registry,
+            &rx,
+            TcpCapability::NAMESPACE,
+            &ListListeners::default(),
+        );
+        let mut names: Vec<String> = list.listeners.iter().map(|l| l.name.clone()).collect();
+        names.sort();
+        assert_eq!(names, vec!["admin".to_string(), "game".to_string()]);
     }
 }

--- a/crates/aether-capabilities/src/tcp/runtime.rs
+++ b/crates/aether-capabilities/src/tcp/runtime.rs
@@ -1,0 +1,65 @@
+//! The `aether.tcp` cap runtime half (ADR-0122 identity/runtime split).
+//! Compiled only under `feature = "runtime"` (the `mod runtime;` declaration
+//! in the parent carries the gate), so a transport-only build of the
+//! [`TcpCapability`](super::TcpCapability) identity never names these types
+//! nor pulls `aether_substrate`. The substrate / `std::net`-typed imports are
+//! gated once by this module rather than line-by-line; the `#[actor] impl`
+//! reaches the state, ctx types, and supervisor structs through the single
+//! `use runtime::*` glob in the parent.
+
+pub use std::collections::HashMap;
+pub use std::net::TcpListener;
+
+pub use aether_actor::Manual;
+// The manual handlers (`on_unbind` / `on_monitor_notice`) issue their own
+// replies through `ctx.reply` / `ctx.reply_to`, the `OutboundReply` trait
+// methods, so the trait must be in scope where those handler bodies expand.
+pub use aether_actor::OutboundReply;
+pub use aether_substrate::actor::monitor::MonitorHandle;
+pub use aether_substrate::actor::native::spawn::Subname;
+pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub use aether_substrate::chassis::error::BootError;
+
+/// `aether.tcp` runtime state (issue 607 Phase 6a, ADR-0079). The singleton
+/// control-plane cap owns its listener fleet directly — it is the supervisor,
+/// not a thin shim over the chassis registry. Each `on_bind` registers a
+/// monitor on the new listener and inserts a [`ListenerEntry`] into
+/// `listeners`; `on_monitor_notice` removes the entry on listener close.
+/// The addressing identity is the distinct ZST
+/// [`TcpCapability`](super::TcpCapability). Living in this private module keeps
+/// it `pub`-enough to satisfy the `NativeActor::State` interface without
+/// exposing it as crate-public API.
+///
+/// Issue 629 / Phase B: plain `HashMap` fields. The dispatcher thread is the
+/// sole writer / reader; pre-Phase-A's `Mutex<HashMap<...>>` was a
+/// worker-pool-era tax, not a contention point.
+pub struct TcpCapabilityState {
+    /// Live listeners spawned by this cap. Key is the listener's
+    /// full-name `MailboxId`. Each entry holds the bind metadata
+    /// surfaced via `ListListeners` plus the monitor handle that
+    /// pins the cap's monitor on the listener until close.
+    pub(super) listeners: HashMap<aether_data::MailboxId, ListenerEntry>,
+    /// Outstanding unbind replies parked until `MonitorNotice`
+    /// arrives from the listener being closed. Key is the same
+    /// `MailboxId` as `listeners`; the cap's monitor (registered
+    /// at spawn time) is what fires the notice.
+    pub(super) pending_unbinds: HashMap<aether_data::MailboxId, PendingUnbind>,
+}
+
+/// Cap-local supervisor state for one live listener. Drops with
+/// the entry; `MonitorHandle::Drop` is idempotent with the close
+/// path's index drain.
+pub(super) struct ListenerEntry {
+    pub(super) addr: String,
+    pub(super) port: u16,
+    pub(super) name: String,
+    // Held to keep the cap's monitor registered against the
+    // listener for its lifetime. Drops when the entry is removed
+    // (in `on_monitor_notice`).
+    pub(super) _monitor_handle: MonitorHandle,
+}
+
+pub(super) struct PendingUnbind {
+    pub(super) sender: aether_data::Source,
+    pub(super) listener_name: String,
+}

--- a/crates/aether-capabilities/src/tcp/session.rs
+++ b/crates/aether-capabilities/src/tcp/session.rs
@@ -31,222 +31,209 @@
 #![allow(clippy::needless_pass_by_value)]
 
 // Handler-signature kinds need to be importable at file root for
-// the `#[bridge]`-emitted `HandlesKind` markers.
+// the `#[actor]`-emitted `HandlesKind` markers against the identity
+// (always-on, outside the `feature = "runtime"` gate).
 use super::kinds::{SessionClose, SessionDataReady, SessionWrite};
 
-#[aether_actor::bridge(instanced, one_per = "connection")]
-mod session_native {
-    use super::{SessionClose, SessionDataReady, SessionWrite};
-    use aether_actor::actor;
-    use aether_data::Kind;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
-    use aether_substrate::{KindId, Mail, Mailer};
-    use std::io::{Read, Write};
-    use std::net::{Shutdown, TcpStream};
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::mpsc;
-    use std::thread;
-    use std::thread::JoinHandle;
+/// `aether.tcp.session` **identity** (ADR-0122 identity/runtime split). A ZST
+/// carrying only the addressing — `Addressable` (`NAMESPACE`, `Resolver`), the
+/// per-handler `HandlesKind` markers, and the instanced
+/// `OnePer("connection")` name-inventory entry, all emitted always-on by
+/// `#[actor]`. The state-bearing runtime (`TcpSessionState`, which holds the
+/// `TcpStream` write half + the read thread) lives behind the one
+/// `feature = "runtime"` gate, so a transport-only build never names
+/// `TcpSessionState` nor pulls `aether_substrate` through this actor.
+pub struct TcpSessionActor;
 
-    use crate::tcp::config::TcpSessionConfig;
+// The `#[actor]` attribute path stays always-on (the macro divides what it
+// emits). Everything that names an `aether_substrate` / `std::net` type — the
+// handler/init ctx, the runtime state, the read thread — lives in the
+// `runtime` module below, gated once by `feature = "runtime"` and reached
+// through the single `use runtime::*` glob.
+use aether_actor::actor;
 
-    /// Default per-read buffer size. 64 KiB matches the typical
-    /// kernel TCP buffer; any larger and we just block waiting for
-    /// the kernel to fill it. Smaller adds syscall overhead per
-    /// chunk.
-    const READ_BUFFER_BYTES: usize = 64 * 1024;
+#[cfg(feature = "runtime")]
+#[allow(clippy::wildcard_imports)]
+use runtime::*;
 
-    /// One end of a split `TcpStream`. The read sidecar owns the
-    /// read half; the dispatcher owns the write half (used by
-    /// `on_session_write`). Read-side errors / EOF flow back to the
-    /// dispatcher via the `bytes_rx` channel as `Err(reason)`; the
-    /// dispatcher discards them today (issue 775 retired the
-    /// SessionData/SessionClosed broadcast path).
-    pub struct TcpSessionActor {
-        peer: String,
-        session_name: String,
-        write_half: TcpStream,
-        shutdown: Arc<AtomicBool>,
-        read_thread: Option<JoinHandle<()>>,
-        bytes_rx: mpsc::Receiver<Result<Vec<u8>, String>>,
-    }
+#[cfg(feature = "runtime")]
+mod runtime;
 
-    #[actor]
-    impl NativeActor for TcpSessionActor {
-        type Config = TcpSessionConfig;
-        const NAMESPACE: &'static str = "aether.tcp.session";
+#[actor(instanced, one_per = "connection")]
+impl NativeActor for TcpSessionActor {
+    /// The runtime state this identity boots into (ADR-0122 split): the
+    /// write-half + read-thread bundle.
+    type State = TcpSessionState;
+    type Config = TcpSessionConfig;
+    const NAMESPACE: &'static str = "aether.tcp.session";
 
-        fn init(
-            mut config: TcpSessionConfig,
-            ctx: &mut NativeInitCtx<'_>,
-        ) -> Result<Self, BootError> {
-            let stream = config
-                .stream
-                .take()
-                .expect("TcpSessionConfig::stream consumed exactly once");
-            // Split read/write via try_clone — both halves point at
-            // the same underlying socket, but each is independently
-            // owned. Read sidecar uses one for blocking reads; the
-            // dispatcher uses the other for writes + Shutdown.
-            let read_half = stream
-                .try_clone()
-                .map_err(|e| BootError::Other(Box::new(e)))?;
-            let write_half = stream;
+    fn init(
+        mut config: TcpSessionConfig,
+        ctx: &mut NativeInitCtx<'_>,
+    ) -> Result<TcpSessionState, BootError> {
+        let stream = config
+            .stream
+            .take()
+            .expect("TcpSessionConfig::stream consumed exactly once");
+        // Split read/write via try_clone — both halves point at
+        // the same underlying socket, but each is independently
+        // owned. Read sidecar uses one for blocking reads; the
+        // dispatcher uses the other for writes + Shutdown.
+        let read_half = stream
+            .try_clone()
+            .map_err(|e| BootError::Other(Box::new(e)))?;
+        let write_half = stream;
 
-            let shutdown = Arc::new(AtomicBool::new(false));
-            let shutdown_for_thread = Arc::clone(&shutdown);
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_for_thread = Arc::clone(&shutdown);
 
-            // mpsc carrying read chunks OR an Err signaling EOF /
-            // read error. The dispatcher drains in `on_data_ready`
-            // and turns each item into a SessionData broadcast (Ok)
-            // or a SessionClosed broadcast + ctx.shutdown() (Err).
-            let (bytes_tx, bytes_rx) = mpsc::channel::<Result<Vec<u8>, String>>();
+        // mpsc carrying read chunks OR an Err signaling EOF /
+        // read error. The dispatcher drains in `on_data_ready`
+        // and turns each item into a SessionData broadcast (Ok)
+        // or a SessionClosed broadcast + ctx.shutdown() (Err).
+        let (bytes_tx, bytes_rx) = mpsc::channel::<Result<Vec<u8>, String>>();
 
-            let mailer_for_thread: Arc<Mailer> = ctx.mailer();
-            let self_id = ctx.self_id();
-            let data_ready_kind = KindId(<SessionDataReady as Kind>::ID.0);
+        let mailer_for_thread: Arc<Mailer> = ctx.mailer();
+        let self_id = ctx.self_id();
+        let data_ready_kind = KindId(<SessionDataReady as Kind>::ID.0);
 
-            let thread_name = format!("aether-tcp-read-{}", config.session_name);
-            // Transport thread below the mail layer — it carries inbound mail in;
-            // no inbound chain to inherit, so no settlement umbrella to honor.
-            #[allow(clippy::disallowed_methods)]
-            let thread = thread::Builder::new()
-                .name(thread_name)
-                .spawn(move || {
-                    let mut read_half = read_half;
-                    let mut buf = vec![0u8; READ_BUFFER_BYTES];
-                    loop {
-                        if shutdown_for_thread.load(Ordering::Acquire) {
+        let thread_name = format!("aether-tcp-read-{}", config.session_name);
+        // Transport thread below the mail layer — it carries inbound mail in;
+        // no inbound chain to inherit, so no settlement umbrella to honor.
+        #[allow(clippy::disallowed_methods)]
+        let thread = thread::Builder::new()
+            .name(thread_name)
+            .spawn(move || {
+                let mut read_half = read_half;
+                let mut buf = vec![0u8; READ_BUFFER_BYTES];
+                loop {
+                    if shutdown_for_thread.load(Ordering::Acquire) {
+                        break;
+                    }
+                    match read_half.read(&mut buf) {
+                        Ok(0) => {
+                            let _ = bytes_tx.send(Err("eof".to_owned()));
+                            mailer_for_thread.push(Mail::new(
+                                self_id,
+                                data_ready_kind,
+                                SessionDataReady::default().encode_into_bytes(),
+                                1,
+                            ));
                             break;
                         }
-                        match read_half.read(&mut buf) {
-                            Ok(0) => {
-                                let _ = bytes_tx.send(Err("eof".to_owned()));
-                                mailer_for_thread.push(Mail::new(
-                                    self_id,
-                                    data_ready_kind,
-                                    SessionDataReady::default().encode_into_bytes(),
-                                    1,
-                                ));
+                        Ok(n) => {
+                            let chunk = buf[..n].to_vec();
+                            if bytes_tx.send(Ok(chunk)).is_err() {
                                 break;
                             }
-                            Ok(n) => {
-                                let chunk = buf[..n].to_vec();
-                                if bytes_tx.send(Ok(chunk)).is_err() {
-                                    break;
-                                }
-                                mailer_for_thread.push(Mail::new(
-                                    self_id,
-                                    data_ready_kind,
-                                    SessionDataReady::default().encode_into_bytes(),
-                                    1,
-                                ));
-                            }
-                            Err(e) => {
-                                if shutdown_for_thread.load(Ordering::Acquire) {
-                                    break;
-                                }
-                                let reason = format!("read error: {e}");
-                                let _ = bytes_tx.send(Err(reason));
-                                mailer_for_thread.push(Mail::new(
-                                    self_id,
-                                    data_ready_kind,
-                                    SessionDataReady::default().encode_into_bytes(),
-                                    1,
-                                ));
+                            mailer_for_thread.push(Mail::new(
+                                self_id,
+                                data_ready_kind,
+                                SessionDataReady::default().encode_into_bytes(),
+                                1,
+                            ));
+                        }
+                        Err(e) => {
+                            if shutdown_for_thread.load(Ordering::Acquire) {
                                 break;
                             }
+                            let reason = format!("read error: {e}");
+                            let _ = bytes_tx.send(Err(reason));
+                            mailer_for_thread.push(Mail::new(
+                                self_id,
+                                data_ready_kind,
+                                SessionDataReady::default().encode_into_bytes(),
+                                1,
+                            ));
+                            break;
                         }
                     }
-                })
-                .map_err(|e| BootError::Other(Box::new(e)))?;
-
-            tracing::info!(
-                target: "aether_substrate::tcp",
-                session = %config.session_name,
-                peer = %config.peer,
-                "tcp session opened",
-            );
-
-            Ok(Self {
-                peer: config.peer,
-                session_name: config.session_name,
-                write_half,
-                shutdown,
-                read_thread: Some(thread),
-                bytes_rx,
+                }
             })
-        }
+            .map_err(|e| BootError::Other(Box::new(e)))?;
 
-        fn unwire(&mut self, _ctx: &mut NativeCtx<'_>) {
-            self.shutdown.store(true, Ordering::Release);
-            // Aborting the socket from the write half wakes any
-            // blocked `read()` on the read half (same underlying fd).
-            // Best-effort: a peer that already closed gives EBADF or
-            // ENOTCONN here, which is fine.
-            let _ = self.write_half.shutdown(Shutdown::Both);
-            if let Some(t) = self.read_thread.take() {
-                let _ = t.join();
-            }
-            tracing::info!(
-                target: "aether_substrate::tcp",
-                session = %self.session_name,
-                peer = %self.peer,
-                "tcp session closed",
-            );
-        }
+        tracing::info!(
+            target: "aether_substrate::tcp",
+            session = %config.session_name,
+            peer = %config.peer,
+            "tcp session opened",
+        );
 
-        /// Sidecar read wake. Drain every pending chunk; `Ok` bytes
-        /// are dropped (issue 775 retired the `SessionData` broadcast)
-        /// and `Err` ends the session via `ctx.shutdown()`. One wake
-        /// fires per chunk, but the handler drains until the queue
-        /// is empty so coalesced wakes process all outstanding chunks
-        /// in one dispatcher tick.
-        #[handler]
-        fn on_data_ready(&mut self, ctx: &mut NativeCtx<'_>, _mail: SessionDataReady) {
-            while let Ok(item) = self.bytes_rx.try_recv() {
-                match item {
-                    Ok(_bytes) => {
-                        // Bytes drop on the floor pending a user-space
-                        // TCP observer rewire (issue 775).
-                    }
-                    Err(_reason) => {
-                        ctx.shutdown();
-                        return;
-                    }
+        Ok(TcpSessionState {
+            peer: config.peer,
+            session_name: config.session_name,
+            write_half,
+            shutdown,
+            read_thread: Some(thread),
+            bytes_rx,
+        })
+    }
+
+    fn unwire(state: &mut Self::State, _ctx: &mut NativeCtx<'_>) {
+        state.shutdown.store(true, Ordering::Release);
+        // Aborting the socket from the write half wakes any
+        // blocked `read()` on the read half (same underlying fd).
+        // Best-effort: a peer that already closed gives EBADF or
+        // ENOTCONN here, which is fine.
+        let _ = state.write_half.shutdown(Shutdown::Both);
+        if let Some(t) = state.read_thread.take() {
+            let _ = t.join();
+        }
+        tracing::info!(
+            target: "aether_substrate::tcp",
+            session = %state.session_name,
+            peer = %state.peer,
+            "tcp session closed",
+        );
+    }
+
+    /// Sidecar read wake. Drain every pending chunk; `Ok` bytes
+    /// are dropped (issue 775 retired the `SessionData` broadcast)
+    /// and `Err` ends the session via `ctx.shutdown()`. One wake
+    /// fires per chunk, but the handler drains until the queue
+    /// is empty so coalesced wakes process all outstanding chunks
+    /// in one dispatcher tick.
+    #[handler]
+    fn on_data_ready(state: &mut Self::State, ctx: &mut NativeCtx<'_>, _mail: SessionDataReady) {
+        while let Ok(item) = state.bytes_rx.try_recv() {
+            match item {
+                Ok(_bytes) => {
+                    // Bytes drop on the floor pending a user-space
+                    // TCP observer rewire (issue 775).
+                }
+                Err(_reason) => {
+                    ctx.shutdown();
+                    return;
                 }
             }
         }
+    }
 
-        /// Write `bytes` to the connected peer. Blocking write on
-        /// the dispatcher thread; for chunks larger than the kernel
-        /// buffer this can block briefly, but typical request /
-        /// response traffic clears in microseconds.
-        #[handler]
-        fn on_session_write(&mut self, ctx: &mut NativeCtx<'_>, mail: SessionWrite) {
-            if let Err(e) = self.write_half.write_all(&mail.bytes) {
-                tracing::warn!(
-                    target: "aether_substrate::tcp",
-                    session = %self.session_name,
-                    peer = %self.peer,
-                    error = %e,
-                    "tcp session write failed",
-                );
-                ctx.shutdown();
-            }
-        }
-
-        /// Cooperative external close. Peer mails this, we call
-        /// `ctx.shutdown()`, the dispatcher drains remaining inbox
-        /// mail, runs `unwire` (which joins the read thread).
-        // Stateless close-request handler: `&mut self` is required by
-        // the dispatch ABI (ADR-0033 / ADR-0038); shutdown is via ctx.
-        #[allow(clippy::unused_self)]
-        #[handler]
-        fn on_close_request(&mut self, ctx: &mut NativeCtx<'_>, _mail: SessionClose) {
+    /// Write `bytes` to the connected peer. Blocking write on
+    /// the dispatcher thread; for chunks larger than the kernel
+    /// buffer this can block briefly, but typical request /
+    /// response traffic clears in microseconds.
+    #[handler]
+    fn on_session_write(state: &mut Self::State, ctx: &mut NativeCtx<'_>, mail: SessionWrite) {
+        if let Err(e) = state.write_half.write_all(&mail.bytes) {
+            tracing::warn!(
+                target: "aether_substrate::tcp",
+                session = %state.session_name,
+                peer = %state.peer,
+                error = %e,
+                "tcp session write failed",
+            );
             ctx.shutdown();
         }
+    }
+
+    /// Cooperative external close. Peer mails this, we call
+    /// `ctx.shutdown()`, the dispatcher drains remaining inbox
+    /// mail, runs `unwire` (which joins the read thread).
+    // Stateless close-request handler: shutdown is via ctx, so `_state`
+    // is unused.
+    #[handler]
+    fn on_close_request(_state: &mut Self::State, ctx: &mut NativeCtx<'_>, _mail: SessionClose) {
+        ctx.shutdown();
     }
 }

--- a/crates/aether-capabilities/src/tcp/session/runtime.rs
+++ b/crates/aether-capabilities/src/tcp/session/runtime.rs
@@ -1,0 +1,44 @@
+//! The `aether.tcp.session` runtime half (ADR-0122 identity/runtime split).
+//! Compiled only under `feature = "runtime"` (the `mod runtime;` declaration
+//! in the parent carries the gate), so a transport-only build of the
+//! [`TcpSessionActor`](super::TcpSessionActor) identity never names these
+//! types nor pulls `aether_substrate`. The substrate / `std::net`-typed
+//! imports are gated once by this module rather than line-by-line; the
+//! `#[actor] impl` reaches the state, ctx types, and config through the
+//! single `use runtime::*` glob in the parent.
+
+pub use std::io::{Read, Write};
+pub use std::net::{Shutdown, TcpStream};
+pub use std::sync::Arc;
+pub use std::sync::atomic::{AtomicBool, Ordering};
+pub use std::sync::mpsc;
+pub use std::thread::{self, JoinHandle};
+
+pub use aether_data::Kind;
+pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub use aether_substrate::chassis::error::BootError;
+pub use aether_substrate::{KindId, Mail, Mailer};
+
+pub use crate::tcp::config::TcpSessionConfig;
+
+/// Default per-read buffer size. 64 KiB matches the typical
+/// kernel TCP buffer; any larger and we just block waiting for
+/// the kernel to fill it. Smaller adds syscall overhead per
+/// chunk.
+pub const READ_BUFFER_BYTES: usize = 64 * 1024;
+
+/// `aether.tcp.session` runtime state (issue 607 Phase 6b, ADR-0079). One end
+/// of a split `TcpStream`: the read sidecar owns the read half; the dispatcher
+/// owns `write_half` (used by `on_session_write`). Read-side errors / EOF flow
+/// back to the dispatcher via the `bytes_rx` channel as `Err(reason)`; the
+/// dispatcher discards them today (issue 775 retired the
+/// `SessionData` / `SessionClosed` broadcast path). The addressing identity is
+/// the distinct ZST [`TcpSessionActor`](super::TcpSessionActor).
+pub struct TcpSessionState {
+    pub(super) peer: String,
+    pub(super) session_name: String,
+    pub(super) write_half: TcpStream,
+    pub(super) shutdown: Arc<AtomicBool>,
+    pub(super) read_thread: Option<JoinHandle<()>>,
+    pub(super) bytes_rx: mpsc::Receiver<Result<Vec<u8>, String>>,
+}


### PR DESCRIPTION
Closes #2324.

## Summary

Migrates the three `aether.tcp` caps off `#[bridge]` onto the ADR-0122 identity/runtime split: `TcpCapability` (singleton), `TcpListenerActor` (instanced, `one_per = "listener"`), `TcpSessionActor` (instanced, `one_per = "connection"`). Each is a ZST identity + a top-level `#[actor(<cardinality>)] impl NativeActor` with handlers (incl. the two `#[handler::manual]`) over `state: &mut Self::State`; the substrate/socket-typed half lives in a `#[cfg(feature = "runtime")] mod runtime;` file per cap (`tcp/runtime.rs`, `tcp/listener/runtime.rs`, `tcp/session/runtime.rs`), reached via one `use runtime::*` glob.

Uses the #2330 split-path `one_per` support directly — the name inventory still reports `OnePer("listener")` / `OnePer("connection")` (no regression to `Unbounded`).

## Test plan

- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo nextest run -p aether-capabilities` (248 passed incl. the tcp bind/list/unbind roundtrip), strict `cargo doc`, transport-only build — all green.
- Validated via `scripts/attest.sh --publish`.

## Generated by

`/implement --sweep --attest` — agent execution of scoped issue #2324.
