### PR TITLE
refactor(capabilities): split the http client and server caps into identity and runtime modules

### DIFF
--- a/crates/aether-capabilities/src/http/client/mod.rs
+++ b/crates/aether-capabilities/src/http/client/mod.rs
@@ -23,9 +23,11 @@ pub use config::HttpConfig;
 #[cfg(feature = "native")]
 pub use config::{HttpConfigLayer, HttpOverlay};
 
-// Handler-signature kinds must be importable at file root because
-// `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
-// of the mod (always-on, outside the cfg gate).
+// Handler-signature kinds resolve at file root through this import —
+// `#[actor]` emits the `impl HandlesKind<K> for X {}` markers always-on
+// against the identity (outside the `feature = "runtime"` gate), so they
+// reference these kinds from here. The `DisabledHttpAdapter` /
+// `FetchRequest` / `FetchResponse` types below name them too.
 use crate::http::kinds::{Fetch, HttpError, HttpHeader, HttpMethod};
 use aether_actor::WasmActorMailbox;
 #[cfg(not(target_arch = "wasm32"))]
@@ -162,221 +164,327 @@ impl HttpMailboxExt for NativeActorMailbox<'_, HttpCapability> {
     }
 }
 
-#[aether_actor::bridge(singleton)]
-mod native {
-    use std::collections::HashSet;
+/// `aether.http` cap **identity** (ADR-0122 identity/runtime split). A ZST
+/// carrying only the addressing — `Addressable` (`NAMESPACE`, `Resolver`),
+/// the per-handler `HandlesKind` markers, and the name-inventory entry,
+/// all emitted always-on by `#[actor]`. The state-bearing runtime
+/// (`HttpCapabilityState`, which holds the resolved `Arc<dyn HttpAdapter>`)
+/// lives behind the one `feature = "runtime"` gate, so a transport-only
+/// build never names `HttpCapabilityState` nor pulls `aether_substrate`
+/// through this cap.
+pub struct HttpCapability;
+
+// The `#[actor]` / `#[handler]` attribute path stays always-on (the macro
+// divides what it emits). Everything that names an `aether_substrate` type —
+// the handler/init ctx, the runtime state — lives in the `runtime` module
+// below, gated once by `feature = "runtime"`; the `#[actor] impl` reaches it
+// through the single `use runtime::*` glob. The ureq adapter stack names
+// `ureq` / `url` (not `aether_substrate`), so it stays at file root under
+// `feature = "native"` (the `mod native` wrapper supplied that gate before;
+// `runtime` implies `native`).
+use aether_actor::actor;
+
+// The `runtime` module is this cap's private runtime-half namespace; the impl
+// reaches all of it (state, ctx types) through this single seam, so the glob
+// is intentional rather than a handful of one-line imports.
+#[cfg(feature = "runtime")]
+#[allow(clippy::wildcard_imports)]
+use runtime::*;
+
+// The wire reply kind. Named by the runtime-gated handler and by the
+// always-on (non-wasm) handler-inventory submission `#[actor]` emits for
+// `on_fetch`'s reply type, so it gates on `not(wasm32)` rather than `runtime`.
+#[cfg(not(target_arch = "wasm32"))]
+use crate::http::kinds::FetchResult;
+
+#[actor(singleton)]
+impl NativeActor for HttpCapability {
+    /// The runtime state this identity boots into (ADR-0122 split): the
+    /// resolved adapter plus the default per-request timeout.
+    type State = HttpCapabilityState;
+
+    type Config = HttpConfig;
+
+    /// ADR-0043 + ADR-0074 Phase 5 chassis-owned mailbox.
+    const NAMESPACE: &'static str = "aether.http";
+
+    /// Build the HTTP adapter from the resolved config. The adapter is
+    /// built immediately so configuration errors surface at chassis-
+    /// builder time, not at first fetch.
+    fn init(
+        config: HttpConfig,
+        _ctx: &mut NativeInitCtx<'_>,
+    ) -> Result<HttpCapabilityState, BootError> {
+        let default_timeout = config.default_timeout;
+        Ok(HttpCapabilityState {
+            adapter: build_http_adapter(config),
+            default_timeout,
+        })
+    }
+
+    /// Run a fetch request and reply with the response.
+    ///
+    /// # Agent
+    /// Reply: `FetchResult`. Synchronous on the dispatcher thread —
+    /// long-running fetches block other HTTP mail until they finish.
+    #[handler]
+    fn on_fetch(state: &mut Self::State, _ctx: &mut NativeCtx<'_>, mail: Fetch) -> FetchResult {
+        let timeout = mail.timeout_ms.map_or(state.default_timeout, |ms| {
+            Duration::from_millis(u64::from(ms))
+        });
+
+        let url = mail.url.clone();
+        let adapter_req = FetchRequest {
+            url: mail.url,
+            method: mail.method,
+            headers: mail.headers,
+            body: mail.body,
+            timeout,
+        };
+
+        match state.adapter.fetch(adapter_req) {
+            Ok(r) => FetchResult::Ok {
+                url,
+                status: r.status,
+                headers: r.headers,
+                body: r.body,
+            },
+            Err(error) => FetchResult::Err { url, error },
+        }
+    }
+}
+
+// The ureq adapter stack. Names `ureq` / `url` (both `dep:` under the
+// `native` feature) but never `aether_substrate`, so it lives at file root
+// gated on `feature = "native"` rather than in the `runtime` module.
+#[cfg(feature = "native")]
+use std::collections::HashSet;
+#[cfg(feature = "native")]
+use std::sync::Arc;
+#[cfg(feature = "native")]
+use ureq::http::Method;
+#[cfg(feature = "native")]
+use ureq::http::Request;
+
+/// `ureq`-backed adapter. Holds the shared agent, the allowlist
+/// (empty = deny all), the response cap, and the `require_https`
+/// flag. Thread-safe: `ureq::Agent` is cheaply cloneable and
+/// internally synchronised, so the same adapter drives the cap from
+/// one dispatch thread today and would parallelise cleanly behind a
+/// multi-thread dispatcher later.
+#[cfg(feature = "native")]
+pub struct UreqHttpAdapter {
+    agent: ureq::Agent,
+    allowlist: HashSet<String>,
+    require_https: bool,
+    max_body_bytes: usize,
+}
+
+#[cfg(feature = "native")]
+impl UreqHttpAdapter {
+    /// Construct an adapter with explicit knobs. Chassis code uses
+    /// [`build_http_adapter`] for env-derived construction;
+    /// tests build adapters directly to avoid env contamination.
+    #[must_use]
+    pub fn new(allowlist: HashSet<String>, require_https: bool, max_body_bytes: usize) -> Self {
+        let config = ureq::Agent::config_builder()
+            .http_status_as_error(false)
+            .build();
+        let agent = ureq::Agent::new_with_config(config);
+        Self {
+            agent,
+            allowlist,
+            require_https,
+            max_body_bytes,
+        }
+    }
+
+    fn check_allowlist(&self, host: &str) -> Result<(), HttpError> {
+        if self.allowlist.contains(host) {
+            Ok(())
+        } else {
+            Err(HttpError::AllowlistDenied)
+        }
+    }
+}
+
+#[cfg(feature = "native")]
+impl HttpAdapter for UreqHttpAdapter {
+    fn fetch(&self, req: FetchRequest) -> Result<FetchResponse, HttpError> {
+        use ureq::RequestExt;
+
+        let parsed =
+            url::Url::parse(&req.url).map_err(|e| HttpError::InvalidUrl(format!("{e}")))?;
+
+        if self.require_https && parsed.scheme() != "https" {
+            return Err(HttpError::InvalidUrl(
+                "http scheme not allowed (AETHER_HTTP_REQUIRE_HTTPS=1)".to_string(),
+            ));
+        }
+
+        let host = parsed
+            .host_str()
+            .ok_or_else(|| HttpError::InvalidUrl("no host in url".to_string()))?;
+        self.check_allowlist(host)?;
+
+        if req.body.len() > self.max_body_bytes {
+            return Err(HttpError::BodyTooLarge);
+        }
+
+        let mut builder = Request::builder()
+            .method(http_method_to_http_crate(req.method))
+            .uri(&req.url);
+
+        // Host header is derived from the URL by ureq; reject any
+        // caller-set Host so it can't be used to bypass the
+        // allowlist (component requests allowlisted A, TLS SNI is A,
+        // but `Host: B` routes the vhost to B server-side). User-
+        // Agent defaults to `aether/<version>` if not set.
+        let mut saw_user_agent = false;
+        for h in &req.headers {
+            if h.name.eq_ignore_ascii_case("host") {
+                tracing::warn!(
+                    target: "aether_substrate::http",
+                    value = %h.value,
+                    "stripping caller-set Host header",
+                );
+                continue;
+            }
+            if h.name.eq_ignore_ascii_case("user-agent") {
+                saw_user_agent = true;
+            }
+            builder = builder.header(&h.name, &h.value);
+        }
+        if !saw_user_agent {
+            builder = builder.header("User-Agent", concat!("aether/", env!("CARGO_PKG_VERSION")));
+        }
+
+        let http_req = builder
+            .body(req.body)
+            .map_err(|e| HttpError::InvalidUrl(format!("{e}")))?;
+
+        let mut response = http_req
+            .with_agent(&self.agent)
+            .configure()
+            .timeout_global(Some(req.timeout))
+            .build()
+            .run()
+            .map_err(ureq_error_to_http_error)?;
+
+        let status = response.status().as_u16();
+
+        let mut headers = Vec::with_capacity(response.headers().len());
+        for (name, value) in response.headers() {
+            // Non-UTF8 header values are rare but real (binary
+            // cookies, broken servers). Skip rather than fail the
+            // whole fetch.
+            if let Ok(value_str) = value.to_str() {
+                headers.push(HttpHeader {
+                    name: name.as_str().to_string(),
+                    value: value_str.to_string(),
+                });
+            }
+        }
+
+        let body = match response
+            .body_mut()
+            .with_config()
+            .limit(self.max_body_bytes as u64)
+            .read_to_vec()
+        {
+            Ok(b) => b,
+            Err(ureq::Error::BodyExceedsLimit(_)) => return Err(HttpError::BodyTooLarge),
+            Err(e) => return Err(HttpError::AdapterError(format!("body read: {e}"))),
+        };
+
+        Ok(FetchResponse {
+            status,
+            headers,
+            body,
+        })
+    }
+}
+
+#[cfg(feature = "native")]
+fn http_method_to_http_crate(m: HttpMethod) -> Method {
+    match m {
+        HttpMethod::Get => Method::GET,
+        HttpMethod::Post => Method::POST,
+        HttpMethod::Put => Method::PUT,
+        HttpMethod::Delete => Method::DELETE,
+        HttpMethod::Patch => Method::PATCH,
+        HttpMethod::Head => Method::HEAD,
+        HttpMethod::Options => Method::OPTIONS,
+    }
+}
+
+#[cfg(feature = "native")]
+fn ureq_error_to_http_error(e: ureq::Error) -> HttpError {
+    match e {
+        ureq::Error::Timeout(_) => HttpError::Timeout,
+        ureq::Error::BodyExceedsLimit(_) => HttpError::BodyTooLarge,
+        other => HttpError::AdapterError(format!("{other}")),
+    }
+}
+
+/// Build an HTTP adapter from explicit configuration.
+#[cfg(feature = "native")]
+pub fn build_http_adapter(config: HttpConfig) -> Arc<dyn HttpAdapter> {
+    if config.disabled {
+        tracing::info!(
+            target: "aether_substrate::http",
+            "http adapter disabled — every fetch replies Disabled",
+        );
+        return Arc::new(DisabledHttpAdapter);
+    }
+
+    tracing::info!(
+        target: "aether_substrate::http",
+        allowlist_size = config.allowlist.len(),
+        require_https = config.require_https,
+        max_body_bytes = config.max_body_bytes,
+        "http adapter configured",
+    );
+
+    Arc::new(UreqHttpAdapter::new(
+        config.allowlist,
+        config.require_https,
+        config.max_body_bytes,
+    ))
+}
+
+// The runtime half — the `aether_substrate`-typed surface (ctx imports +
+// `HttpCapabilityState`) — gated once here. Small enough to ride an inline
+// module rather than its own file; the `#[actor] impl` above reaches it
+// through the `use runtime::*` glob.
+#[cfg(feature = "runtime")]
+mod runtime {
+    use super::HttpAdapter;
     use std::sync::Arc;
     use std::time::Duration;
 
-    use super::{
-        DisabledHttpAdapter, Fetch, FetchRequest, FetchResponse, HttpAdapter, HttpConfig,
-        HttpError, HttpHeader, HttpMethod,
-    };
-    use crate::http::kinds::FetchResult;
-    use aether_actor::actor;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
-    use ureq::http::Method;
-    use ureq::http::Request;
+    pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    pub use aether_substrate::chassis::error::BootError;
 
-    /// `ureq`-backed adapter. Holds the shared agent, the allowlist
-    /// (empty = deny all), the response cap, and the `require_https`
-    /// flag. Thread-safe: `ureq::Agent` is cheaply cloneable and
-    /// internally synchronised, so the same adapter drives the cap from
-    /// one dispatch thread today and would parallelise cleanly behind a
-    /// multi-thread dispatcher later.
-    pub struct UreqHttpAdapter {
-        agent: ureq::Agent,
-        allowlist: HashSet<String>,
-        require_https: bool,
-        max_body_bytes: usize,
-    }
-
-    impl UreqHttpAdapter {
-        /// Construct an adapter with explicit knobs. Chassis code uses
-        /// [`build_http_adapter`] for env-derived construction;
-        /// tests build adapters directly to avoid env contamination.
-        pub fn new(allowlist: HashSet<String>, require_https: bool, max_body_bytes: usize) -> Self {
-            let config = ureq::Agent::config_builder()
-                .http_status_as_error(false)
-                .build();
-            let agent = ureq::Agent::new_with_config(config);
-            Self {
-                agent,
-                allowlist,
-                require_https,
-                max_body_bytes,
-            }
-        }
-
-        fn check_allowlist(&self, host: &str) -> Result<(), HttpError> {
-            if self.allowlist.contains(host) {
-                Ok(())
-            } else {
-                Err(HttpError::AllowlistDenied)
-            }
-        }
-    }
-
-    impl HttpAdapter for UreqHttpAdapter {
-        fn fetch(&self, req: FetchRequest) -> Result<FetchResponse, HttpError> {
-            use ureq::RequestExt;
-
-            let parsed =
-                url::Url::parse(&req.url).map_err(|e| HttpError::InvalidUrl(format!("{e}")))?;
-
-            if self.require_https && parsed.scheme() != "https" {
-                return Err(HttpError::InvalidUrl(
-                    "http scheme not allowed (AETHER_HTTP_REQUIRE_HTTPS=1)".to_string(),
-                ));
-            }
-
-            let host = parsed
-                .host_str()
-                .ok_or_else(|| HttpError::InvalidUrl("no host in url".to_string()))?;
-            self.check_allowlist(host)?;
-
-            if req.body.len() > self.max_body_bytes {
-                return Err(HttpError::BodyTooLarge);
-            }
-
-            let mut builder = Request::builder()
-                .method(http_method_to_http_crate(req.method))
-                .uri(&req.url);
-
-            // Host header is derived from the URL by ureq; reject any
-            // caller-set Host so it can't be used to bypass the
-            // allowlist (component requests allowlisted A, TLS SNI is A,
-            // but `Host: B` routes the vhost to B server-side). User-
-            // Agent defaults to `aether/<version>` if not set.
-            let mut saw_user_agent = false;
-            for h in &req.headers {
-                if h.name.eq_ignore_ascii_case("host") {
-                    tracing::warn!(
-                        target: "aether_substrate::http",
-                        value = %h.value,
-                        "stripping caller-set Host header",
-                    );
-                    continue;
-                }
-                if h.name.eq_ignore_ascii_case("user-agent") {
-                    saw_user_agent = true;
-                }
-                builder = builder.header(&h.name, &h.value);
-            }
-            if !saw_user_agent {
-                builder =
-                    builder.header("User-Agent", concat!("aether/", env!("CARGO_PKG_VERSION")));
-            }
-
-            let http_req = builder
-                .body(req.body)
-                .map_err(|e| HttpError::InvalidUrl(format!("{e}")))?;
-
-            let mut response = http_req
-                .with_agent(&self.agent)
-                .configure()
-                .timeout_global(Some(req.timeout))
-                .build()
-                .run()
-                .map_err(ureq_error_to_http_error)?;
-
-            let status = response.status().as_u16();
-
-            let mut headers = Vec::with_capacity(response.headers().len());
-            for (name, value) in response.headers() {
-                // Non-UTF8 header values are rare but real (binary
-                // cookies, broken servers). Skip rather than fail the
-                // whole fetch.
-                if let Ok(value_str) = value.to_str() {
-                    headers.push(HttpHeader {
-                        name: name.as_str().to_string(),
-                        value: value_str.to_string(),
-                    });
-                }
-            }
-
-            let body = match response
-                .body_mut()
-                .with_config()
-                .limit(self.max_body_bytes as u64)
-                .read_to_vec()
-            {
-                Ok(b) => b,
-                Err(ureq::Error::BodyExceedsLimit(_)) => return Err(HttpError::BodyTooLarge),
-                Err(e) => return Err(HttpError::AdapterError(format!("body read: {e}"))),
-            };
-
-            Ok(FetchResponse {
-                status,
-                headers,
-                body,
-            })
-        }
-    }
-
-    fn http_method_to_http_crate(m: HttpMethod) -> Method {
-        match m {
-            HttpMethod::Get => Method::GET,
-            HttpMethod::Post => Method::POST,
-            HttpMethod::Put => Method::PUT,
-            HttpMethod::Delete => Method::DELETE,
-            HttpMethod::Patch => Method::PATCH,
-            HttpMethod::Head => Method::HEAD,
-            HttpMethod::Options => Method::OPTIONS,
-        }
-    }
-
-    fn ureq_error_to_http_error(e: ureq::Error) -> HttpError {
-        match e {
-            ureq::Error::Timeout(_) => HttpError::Timeout,
-            ureq::Error::BodyExceedsLimit(_) => HttpError::BodyTooLarge,
-            other => HttpError::AdapterError(format!("{other}")),
-        }
-    }
-
-    /// Build an HTTP adapter from explicit configuration.
-    pub fn build_http_adapter(config: HttpConfig) -> Arc<dyn HttpAdapter> {
-        if config.disabled {
-            tracing::info!(
-                target: "aether_substrate::http",
-                "http adapter disabled — every fetch replies Disabled",
-            );
-            return Arc::new(DisabledHttpAdapter);
-        }
-
-        tracing::info!(
-            target: "aether_substrate::http",
-            allowlist_size = config.allowlist.len(),
-            require_https = config.require_https,
-            max_body_bytes = config.max_body_bytes,
-            "http adapter configured",
-        );
-
-        Arc::new(UreqHttpAdapter::new(
-            config.allowlist,
-            config.require_https,
-            config.max_body_bytes,
-        ))
-    }
-
-    /// `aether.http` mailbox cap. Owns the resolved adapter and the
-    /// default per-request timeout applied when `Fetch.timeout_ms` is
-    /// `None`. The dispatcher thread holds an `Arc<Self>` and routes
-    /// envelopes through the macro-emitted `NativeDispatch` impl;
-    /// replies route via `ctx.reply(&result)` through the substrate's
-    /// `Mailer::send_reply`.
-    pub struct HttpCapability {
-        adapter: Arc<dyn HttpAdapter>,
-        default_timeout: Duration,
+    /// `aether.http` runtime state (ADR-0043). Owns the resolved adapter
+    /// and the default per-request timeout applied when `Fetch.timeout_ms`
+    /// is `None`. The dispatcher holds this as the cap's state and routes
+    /// envelopes through the macro-emitted `Dispatch` impl; replies return
+    /// directly from the `#[handler]` method (ADR-0112). The addressing
+    /// identity is the distinct ZST `HttpCapability`. Living in this private
+    /// module keeps it `pub`-enough to satisfy the `NativeActor::State`
+    /// interface without exposing it as crate-public API.
+    pub struct HttpCapabilityState {
+        pub(super) adapter: Arc<dyn HttpAdapter>,
+        pub(super) default_timeout: Duration,
     }
 
     #[cfg(test)]
-    impl HttpCapability {
+    impl HttpCapabilityState {
         /// Test-only direct constructor. Production boots through
-        /// `Builder::with_actor::<HttpCapability>(config)` which calls
-        /// `init`; tests that drive the cap with a stub adapter hand it
-        /// in directly.
+        /// `Builder::with_actor::<HttpCapability>(config)` which calls the
+        /// generated `Lifecycle::init`; tests that drive the handler with a
+        /// stub adapter hand it in directly.
         pub(crate) fn from_adapter(
             adapter: Arc<dyn HttpAdapter>,
             default_timeout: Duration,
@@ -387,426 +495,378 @@ mod native {
             }
         }
     }
+}
 
-    #[actor]
-    impl NativeActor for HttpCapability {
-        type Config = HttpConfig;
+#[cfg(all(test, feature = "runtime"))]
+mod tests {
+    use std::sync::Mutex;
 
-        /// ADR-0043 + ADR-0074 Phase 5 chassis-owned mailbox.
-        const NAMESPACE: &'static str = "aether.http";
+    use super::runtime::HttpCapabilityState;
+    use super::{
+        Arc, DEFAULT_MAX_BODY_BYTES, DisabledHttpAdapter, Duration, Fetch, FetchRequest,
+        FetchResponse, FetchResult, HashSet, HttpAdapter, HttpCapability, HttpConfig, HttpError,
+        HttpHeader, HttpMethod, UreqHttpAdapter, build_http_adapter,
+    };
+    use aether_actor::Addressable;
+    use aether_data::MailboxId;
+    use aether_substrate::actor::native::binding::NativeBinding;
+    use aether_substrate::actor::native::ctx::NativeCtx;
+    use aether_substrate::chassis::builder::Builder;
+    use aether_substrate::chassis::error::BootError;
+    use aether_substrate::mail::Source;
 
-        /// Build the HTTP adapter from the resolved config. The adapter is
-        /// built immediately so configuration errors surface at chassis-
-        /// builder time, not at first fetch.
-        fn init(config: HttpConfig, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            let default_timeout = config.default_timeout;
-            Ok(Self {
-                adapter: build_http_adapter(config),
-                default_timeout,
+    use crate::test_chassis::{TestChassis, fresh_substrate};
+    use aether_substrate::mail::registry;
+
+    // ADR-0090: the defaults check loads the layer with no `.env()`
+    // source. The env-value behavior (trim, empty → default, garbage
+    // → hard-error) is now confique's native deserialization, covered
+    // by `aether_substrate::config`'s confique tests; the CSV split is
+    // covered by `parse_csv_set` there.
+
+    #[test]
+    fn http_from_env_defaults_match() {
+        use super::HttpConfigLayer;
+        use confique::Config as _;
+        // No `.env()` source: loads literal defaults only, so this is
+        // env-free and guards the layer's literal defaults against the
+        // named consts + `HttpConfig::default()`.
+        let layer = HttpConfigLayer::builder().load().expect("defaults load");
+        let default = HttpConfig::default();
+        assert!(!layer.disabled);
+        assert!(layer.allowlist.is_empty());
+        assert!(!layer.require_https);
+        assert_eq!(layer.max_body_bytes, DEFAULT_MAX_BODY_BYTES);
+        assert_eq!(
+            Duration::from_millis(u64::from(layer.timeout_ms)),
+            default.default_timeout
+        );
+    }
+
+    struct StubAdapter {
+        response: Mutex<Option<Result<FetchResponse, HttpError>>>,
+        last_request: Mutex<Option<FetchRequest>>,
+    }
+
+    impl StubAdapter {
+        fn with(response: Result<FetchResponse, HttpError>) -> Arc<Self> {
+            Arc::new(Self {
+                response: Mutex::new(Some(response)),
+                last_request: Mutex::new(None),
             })
-        }
-
-        /// Run a fetch request and reply with the response.
-        ///
-        /// # Agent
-        /// Reply: `FetchResult`. Synchronous on the dispatcher thread —
-        /// long-running fetches block other HTTP mail until they finish.
-        #[handler]
-        fn on_fetch(&self, _ctx: &mut NativeCtx<'_>, mail: Fetch) -> FetchResult {
-            let timeout = mail.timeout_ms.map_or(self.default_timeout, |ms| {
-                Duration::from_millis(u64::from(ms))
-            });
-
-            let url = mail.url.clone();
-            let adapter_req = FetchRequest {
-                url: mail.url,
-                method: mail.method,
-                headers: mail.headers,
-                body: mail.body,
-                timeout,
-            };
-
-            match self.adapter.fetch(adapter_req) {
-                Ok(r) => FetchResult::Ok {
-                    url,
-                    status: r.status,
-                    headers: r.headers,
-                    body: r.body,
-                },
-                Err(error) => FetchResult::Err { url, error },
-            }
         }
     }
 
-    #[cfg(test)]
-    mod tests {
-        use std::sync::Mutex;
+    impl HttpAdapter for StubAdapter {
+        fn fetch(&self, req: FetchRequest) -> Result<FetchResponse, HttpError> {
+            *self
+                .last_request
+                .lock()
+                .expect("test stub: last_request mutex poisoned") = Some(FetchRequest {
+                url: req.url.clone(),
+                method: req.method,
+                headers: req.headers.clone(),
+                body: req.body.clone(),
+                timeout: req.timeout,
+            });
+            self.response
+                .lock()
+                .expect("test stub: response mutex poisoned")
+                .take()
+                .expect("stub response already consumed")
+        }
+    }
 
-        use super::super::{
-            DEFAULT_MAX_BODY_BYTES, DisabledHttpAdapter, FetchRequest, FetchResponse, HttpAdapter,
-            HttpConfig, HttpError, HttpHeader, HttpMethod,
+    use aether_data::{SessionToken, SourceAddr, Uuid};
+
+    fn session_sender() -> Source {
+        Source::to(SourceAddr::Session(SessionToken(Uuid::nil())))
+    }
+
+    use crate::test_chassis::test_mailer_and_rx;
+
+    /// Boot the cap against a default disabled `HttpConfig` and confirm
+    /// the mailbox is registered.
+    #[test]
+    fn capability_boots_and_registers_mailbox() {
+        let (registry, mailer) = fresh_substrate();
+        let config = HttpConfig {
+            disabled: true,
+            ..HttpConfig::default()
         };
-        use super::{
-            Arc, Duration, Fetch, FetchResult, HashSet, HttpCapability, UreqHttpAdapter,
-            build_http_adapter,
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<HttpCapability>(config)
+            .build_passive()
+            .expect("http capability boots");
+        assert!(
+            registry.lookup(HttpCapability::NAMESPACE).is_some(),
+            "http mailbox registered"
+        );
+        drop(chassis);
+    }
+
+    /// Builder rejects a duplicate claim.
+    #[test]
+    fn duplicate_claim_rejects_with_typed_error() {
+        let (registry, mailer) = fresh_substrate();
+        registry.register_inbox(HttpCapability::NAMESPACE, registry::noop_handler());
+        let config = HttpConfig {
+            disabled: true,
+            ..HttpConfig::default()
         };
-        use aether_actor::Addressable;
-        use aether_data::MailboxId;
-        use aether_substrate::actor::native::binding::NativeBinding;
-        use aether_substrate::actor::native::ctx::NativeCtx;
-        use aether_substrate::chassis::builder::Builder;
-        use aether_substrate::chassis::error::BootError;
-        use aether_substrate::mail::Source;
 
-        use crate::test_chassis::{TestChassis, fresh_substrate};
-        use aether_substrate::mail::registry;
+        let err = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<HttpCapability>(config)
+            .build_passive()
+            .expect_err("collision must surface as BootError");
+        assert!(matches!(
+            err,
+            BootError::MailboxAlreadyClaimed { ref name }
+                if name == HttpCapability::NAMESPACE
+        ));
+    }
 
-        // ADR-0090: the defaults check loads the layer with no `.env()`
-        // source. The env-value behavior (trim, empty → default, garbage
-        // → hard-error) is now confique's native deserialization, covered
-        // by `aether_substrate::config`'s confique tests; the CSV split is
-        // covered by `parse_csv_set` there.
-
-        #[test]
-        fn http_from_env_defaults_match() {
-            use super::super::HttpConfigLayer;
-            use confique::Config as _;
-            // No `.env()` source: loads literal defaults only, so this is
-            // env-free and guards the layer's literal defaults against the
-            // named consts + `HttpConfig::default()`.
-            let layer = HttpConfigLayer::builder().load().expect("defaults load");
-            let default = HttpConfig::default();
-            assert!(!layer.disabled);
-            assert!(layer.allowlist.is_empty());
-            assert!(!layer.require_https);
-            assert_eq!(layer.max_body_bytes, DEFAULT_MAX_BODY_BYTES);
-            assert_eq!(
-                Duration::from_millis(u64::from(layer.timeout_ms)),
-                default.default_timeout
-            );
-        }
-
-        struct StubAdapter {
-            response: Mutex<Option<Result<FetchResponse, HttpError>>>,
-            last_request: Mutex<Option<FetchRequest>>,
-        }
-
-        impl StubAdapter {
-            fn with(response: Result<FetchResponse, HttpError>) -> Arc<Self> {
-                Arc::new(Self {
-                    response: Mutex::new(Some(response)),
-                    last_request: Mutex::new(None),
-                })
-            }
-        }
-
-        impl HttpAdapter for StubAdapter {
-            fn fetch(&self, req: FetchRequest) -> Result<FetchResponse, HttpError> {
-                *self
-                    .last_request
-                    .lock()
-                    .expect("test stub: last_request mutex poisoned") = Some(FetchRequest {
-                    url: req.url.clone(),
-                    method: req.method,
-                    headers: req.headers.clone(),
-                    body: req.body.clone(),
-                    timeout: req.timeout,
-                });
-                self.response
-                    .lock()
-                    .expect("test stub: response mutex poisoned")
-                    .take()
-                    .expect("stub response already consumed")
-            }
-        }
-
-        use aether_data::{SessionToken, SourceAddr, Uuid};
-
-        fn session_sender() -> Source {
-            Source::to(SourceAddr::Session(SessionToken(Uuid::nil())))
-        }
-
-        use crate::test_chassis::test_mailer_and_rx;
-
-        /// Boot the cap against a default disabled `HttpConfig` and confirm
-        /// the mailbox is registered.
-        #[test]
-        fn capability_boots_and_registers_mailbox() {
-            let (registry, mailer) = fresh_substrate();
-            let config = HttpConfig {
-                disabled: true,
-                ..HttpConfig::default()
-            };
-            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-                .with_actor::<HttpCapability>(config)
-                .build_passive()
-                .expect("http capability boots");
-            assert!(
-                registry.lookup(HttpCapability::NAMESPACE).is_some(),
-                "http mailbox registered"
-            );
-            drop(chassis);
-        }
-
-        /// Builder rejects a duplicate claim.
-        #[test]
-        fn duplicate_claim_rejects_with_typed_error() {
-            let (registry, mailer) = fresh_substrate();
-            registry.register_inbox(HttpCapability::NAMESPACE, registry::noop_handler());
-            let config = HttpConfig {
-                disabled: true,
-                ..HttpConfig::default()
-            };
-
-            let err = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-                .with_actor::<HttpCapability>(config)
-                .build_passive()
-                .expect_err("collision must surface as BootError");
-            assert!(matches!(
-                err,
-                BootError::MailboxAlreadyClaimed { ref name }
-                    if name == HttpCapability::NAMESPACE
-            ));
-        }
-
-        #[test]
-        fn disabled_adapter_replies_disabled() {
-            let (mailer, _) = test_mailer_and_rx();
-            let cap = HttpCapability::from_adapter(
-                Arc::new(DisabledHttpAdapter),
-                HttpConfig::default().default_timeout,
-            );
-            let transport = Arc::new(NativeBinding::new_for_test(mailer, MailboxId(0)));
-            let mut ctx = NativeCtx::new(
-                &transport,
-                session_sender(),
-                aether_data::MailId::NONE,
-                aether_data::MailId::NONE,
-            );
-            match cap.on_fetch(
-                &mut ctx,
-                Fetch {
-                    url: "https://api.example.com/".to_string(),
-                    method: HttpMethod::Get,
-                    headers: vec![],
-                    body: vec![],
-                    timeout_ms: None,
-                },
-            ) {
-                FetchResult::Err {
-                    url,
-                    error: HttpError::Disabled,
-                } => {
-                    assert_eq!(url, "https://api.example.com/");
-                }
-                other => panic!("expected Err Disabled, got {other:?}"),
-            }
-        }
-
-        #[test]
-        fn allowlist_empty_rejects_every_host() {
-            let adapter = UreqHttpAdapter::new(HashSet::new(), false, DEFAULT_MAX_BODY_BYTES);
-            let resp = adapter.fetch(FetchRequest {
+    #[test]
+    fn disabled_adapter_replies_disabled() {
+        let (mailer, _) = test_mailer_and_rx();
+        let mut state = HttpCapabilityState::from_adapter(
+            Arc::new(DisabledHttpAdapter),
+            HttpConfig::default().default_timeout,
+        );
+        let transport = Arc::new(NativeBinding::new_for_test(mailer, MailboxId(0)));
+        let mut ctx = NativeCtx::new(
+            &transport,
+            session_sender(),
+            aether_data::MailId::NONE,
+            aether_data::MailId::NONE,
+        );
+        match HttpCapability::on_fetch(
+            &mut state,
+            &mut ctx,
+            Fetch {
                 url: "https://api.example.com/".to_string(),
                 method: HttpMethod::Get,
                 headers: vec![],
                 body: vec![],
-                timeout: Duration::from_secs(30),
-            });
-            assert!(matches!(resp, Err(HttpError::AllowlistDenied)));
-        }
-
-        #[test]
-        fn allowlist_miss_returns_denied_without_making_request() {
-            let mut allowlist = HashSet::new();
-            allowlist.insert("allowed.example.com".to_string());
-            let adapter = UreqHttpAdapter::new(allowlist, false, DEFAULT_MAX_BODY_BYTES);
-            let resp = adapter.fetch(FetchRequest {
-                url: "https://denied.example.com/".to_string(),
-                method: HttpMethod::Get,
-                headers: vec![],
-                body: vec![],
-                timeout: Duration::from_secs(30),
-            });
-            assert!(matches!(resp, Err(HttpError::AllowlistDenied)));
-        }
-
-        #[test]
-        fn invalid_url_returns_invalid_url_variant() {
-            let adapter = UreqHttpAdapter::new(HashSet::new(), false, DEFAULT_MAX_BODY_BYTES);
-            let resp = adapter.fetch(FetchRequest {
-                url: "not-a-url".to_string(),
-                method: HttpMethod::Get,
-                headers: vec![],
-                body: vec![],
-                timeout: Duration::from_secs(30),
-            });
-            assert!(matches!(resp, Err(HttpError::InvalidUrl(_))));
-        }
-
-        #[test]
-        fn require_https_rejects_http_scheme() {
-            let mut allowlist = HashSet::new();
-            allowlist.insert("example.com".to_string());
-            let adapter = UreqHttpAdapter::new(allowlist, true, DEFAULT_MAX_BODY_BYTES);
-            let resp = adapter.fetch(FetchRequest {
-                url: "http://example.com/".to_string(),
-                method: HttpMethod::Get,
-                headers: vec![],
-                body: vec![],
-                timeout: Duration::from_secs(30),
-            });
-            assert!(matches!(resp, Err(HttpError::InvalidUrl(_))));
-        }
-
-        #[test]
-        fn oversize_request_body_returns_body_too_large() {
-            let mut allowlist = HashSet::new();
-            allowlist.insert("example.com".to_string());
-            let adapter = UreqHttpAdapter::new(allowlist, false, 10);
-            let resp = adapter.fetch(FetchRequest {
-                url: "https://example.com/".to_string(),
-                method: HttpMethod::Post,
-                headers: vec![],
-                body: vec![0u8; 20],
-                timeout: Duration::from_secs(30),
-            });
-            assert!(matches!(resp, Err(HttpError::BodyTooLarge)));
-        }
-
-        #[test]
-        fn cap_fetch_ok_replies_with_response() {
-            let (mailer, _) = test_mailer_and_rx();
-            let stub = StubAdapter::with(Ok(FetchResponse {
-                status: 200,
-                headers: vec![HttpHeader {
-                    name: "content-type".to_string(),
-                    value: "application/json".to_string(),
-                }],
-                body: b"{}".to_vec(),
-            }));
-            let cap = HttpCapability::from_adapter(
-                stub as Arc<dyn HttpAdapter>,
-                HttpConfig::default().default_timeout,
-            );
-            let transport = Arc::new(NativeBinding::new_for_test(mailer, MailboxId(0)));
-            let mut ctx = NativeCtx::new(
-                &transport,
-                session_sender(),
-                aether_data::MailId::NONE,
-                aether_data::MailId::NONE,
-            );
-            match cap.on_fetch(
-                &mut ctx,
-                Fetch {
-                    url: "https://api.example.com/v1".to_string(),
-                    method: HttpMethod::Get,
-                    headers: vec![],
-                    body: vec![],
-                    timeout_ms: Some(5000),
-                },
-            ) {
-                FetchResult::Ok {
-                    url,
-                    status,
-                    headers,
-                    body,
-                } => {
-                    assert_eq!(url, "https://api.example.com/v1");
-                    assert_eq!(status, 200);
-                    assert_eq!(headers.len(), 1);
-                    assert_eq!(body, b"{}".to_vec());
-                }
-                FetchResult::Err { error, .. } => panic!("expected Ok, got Err({error:?})"),
+                timeout_ms: None,
+            },
+        ) {
+            FetchResult::Err {
+                url,
+                error: HttpError::Disabled,
+            } => {
+                assert_eq!(url, "https://api.example.com/");
             }
+            other => panic!("expected Err Disabled, got {other:?}"),
         }
+    }
 
-        #[test]
-        fn cap_fetch_err_echoes_url_and_error() {
-            let (mailer, _) = test_mailer_and_rx();
-            let cap = HttpCapability::from_adapter(
-                StubAdapter::with(Err(HttpError::Timeout)) as Arc<dyn HttpAdapter>,
-                HttpConfig::default().default_timeout,
-            );
-            let transport = Arc::new(NativeBinding::new_for_test(mailer, MailboxId(0)));
-            let mut ctx = NativeCtx::new(
-                &transport,
-                session_sender(),
-                aether_data::MailId::NONE,
-                aether_data::MailId::NONE,
-            );
-            match cap.on_fetch(
-                &mut ctx,
-                Fetch {
-                    url: "https://slow.example.com/".to_string(),
-                    method: HttpMethod::Get,
-                    headers: vec![],
-                    body: vec![],
-                    timeout_ms: None,
-                },
-            ) {
-                FetchResult::Err { url, error } => {
-                    assert_eq!(url, "https://slow.example.com/");
-                    assert_eq!(error, HttpError::Timeout);
-                }
-                FetchResult::Ok { .. } => panic!("expected Err"),
-            }
-        }
+    #[test]
+    fn allowlist_empty_rejects_every_host() {
+        let adapter = UreqHttpAdapter::new(HashSet::new(), false, DEFAULT_MAX_BODY_BYTES);
+        let resp = adapter.fetch(FetchRequest {
+            url: "https://api.example.com/".to_string(),
+            method: HttpMethod::Get,
+            headers: vec![],
+            body: vec![],
+            timeout: Duration::from_secs(30),
+        });
+        assert!(matches!(resp, Err(HttpError::AllowlistDenied)));
+    }
 
-        #[test]
-        fn cap_uses_default_timeout_when_none_provided() {
-            let (mailer, _rx) = test_mailer_and_rx();
-            let stub = StubAdapter::with(Ok(FetchResponse {
-                status: 200,
-                headers: vec![],
-                body: vec![],
-            }));
-            let stub_clone = Arc::clone(&stub);
-            let cap = HttpCapability::from_adapter(
-                stub as Arc<dyn HttpAdapter>,
-                HttpConfig::default().default_timeout,
-            );
-            let transport = Arc::new(NativeBinding::new_for_test(mailer, MailboxId(0)));
-            let mut ctx = NativeCtx::new(
-                &transport,
-                session_sender(),
-                aether_data::MailId::NONE,
-                aether_data::MailId::NONE,
-            );
-            let _ = cap.on_fetch(
-                &mut ctx,
-                Fetch {
-                    url: "https://api.example.com/".to_string(),
-                    method: HttpMethod::Get,
-                    headers: vec![],
-                    body: vec![],
-                    timeout_ms: None,
-                },
-            );
-            let observed = stub_clone
-                .last_request
-                .lock()
-                .expect("test stub: last_request mutex poisoned")
-                .take()
-                .expect("adapter was not called");
-            assert!(observed.timeout > Duration::ZERO);
-        }
+    #[test]
+    fn allowlist_miss_returns_denied_without_making_request() {
+        let mut allowlist = HashSet::new();
+        allowlist.insert("allowed.example.com".to_string());
+        let adapter = UreqHttpAdapter::new(allowlist, false, DEFAULT_MAX_BODY_BYTES);
+        let resp = adapter.fetch(FetchRequest {
+            url: "https://denied.example.com/".to_string(),
+            method: HttpMethod::Get,
+            headers: vec![],
+            body: vec![],
+            timeout: Duration::from_secs(30),
+        });
+        assert!(matches!(resp, Err(HttpError::AllowlistDenied)));
+    }
 
-        #[test]
-        fn build_http_adapter_with_disable_returns_disabled() {
-            let cfg = HttpConfig {
-                disabled: true,
-                ..HttpConfig::default()
-            };
-            let a = build_http_adapter(cfg);
-            let resp = a.fetch(FetchRequest {
-                url: "https://example.com/".to_string(),
+    #[test]
+    fn invalid_url_returns_invalid_url_variant() {
+        let adapter = UreqHttpAdapter::new(HashSet::new(), false, DEFAULT_MAX_BODY_BYTES);
+        let resp = adapter.fetch(FetchRequest {
+            url: "not-a-url".to_string(),
+            method: HttpMethod::Get,
+            headers: vec![],
+            body: vec![],
+            timeout: Duration::from_secs(30),
+        });
+        assert!(matches!(resp, Err(HttpError::InvalidUrl(_))));
+    }
+
+    #[test]
+    fn require_https_rejects_http_scheme() {
+        let mut allowlist = HashSet::new();
+        allowlist.insert("example.com".to_string());
+        let adapter = UreqHttpAdapter::new(allowlist, true, DEFAULT_MAX_BODY_BYTES);
+        let resp = adapter.fetch(FetchRequest {
+            url: "http://example.com/".to_string(),
+            method: HttpMethod::Get,
+            headers: vec![],
+            body: vec![],
+            timeout: Duration::from_secs(30),
+        });
+        assert!(matches!(resp, Err(HttpError::InvalidUrl(_))));
+    }
+
+    #[test]
+    fn oversize_request_body_returns_body_too_large() {
+        let mut allowlist = HashSet::new();
+        allowlist.insert("example.com".to_string());
+        let adapter = UreqHttpAdapter::new(allowlist, false, 10);
+        let resp = adapter.fetch(FetchRequest {
+            url: "https://example.com/".to_string(),
+            method: HttpMethod::Post,
+            headers: vec![],
+            body: vec![0u8; 20],
+            timeout: Duration::from_secs(30),
+        });
+        assert!(matches!(resp, Err(HttpError::BodyTooLarge)));
+    }
+
+    #[test]
+    fn cap_fetch_ok_replies_with_response() {
+        let (mailer, _) = test_mailer_and_rx();
+        let stub = StubAdapter::with(Ok(FetchResponse {
+            status: 200,
+            headers: vec![HttpHeader {
+                name: "content-type".to_string(),
+                value: "application/json".to_string(),
+            }],
+            body: b"{}".to_vec(),
+        }));
+        let mut state = HttpCapabilityState::from_adapter(
+            stub as Arc<dyn HttpAdapter>,
+            HttpConfig::default().default_timeout,
+        );
+        let transport = Arc::new(NativeBinding::new_for_test(mailer, MailboxId(0)));
+        let mut ctx = NativeCtx::new(
+            &transport,
+            session_sender(),
+            aether_data::MailId::NONE,
+            aether_data::MailId::NONE,
+        );
+        match HttpCapability::on_fetch(
+            &mut state,
+            &mut ctx,
+            Fetch {
+                url: "https://api.example.com/v1".to_string(),
                 method: HttpMethod::Get,
                 headers: vec![],
                 body: vec![],
-                timeout: Duration::from_secs(30),
-            });
-            assert!(matches!(resp, Err(HttpError::Disabled)));
+                timeout_ms: Some(5000),
+            },
+        ) {
+            FetchResult::Ok {
+                url,
+                status,
+                headers,
+                body,
+            } => {
+                assert_eq!(url, "https://api.example.com/v1");
+                assert_eq!(status, 200);
+                assert_eq!(headers.len(), 1);
+                assert_eq!(body, b"{}".to_vec());
+            }
+            FetchResult::Err { error, .. } => panic!("expected Ok, got Err({error:?})"),
         }
+    }
+
+    #[test]
+    fn cap_fetch_err_echoes_url_and_error() {
+        let (mailer, _) = test_mailer_and_rx();
+        let mut state = HttpCapabilityState::from_adapter(
+            StubAdapter::with(Err(HttpError::Timeout)) as Arc<dyn HttpAdapter>,
+            HttpConfig::default().default_timeout,
+        );
+        let transport = Arc::new(NativeBinding::new_for_test(mailer, MailboxId(0)));
+        let mut ctx = NativeCtx::new(
+            &transport,
+            session_sender(),
+            aether_data::MailId::NONE,
+            aether_data::MailId::NONE,
+        );
+        match HttpCapability::on_fetch(
+            &mut state,
+            &mut ctx,
+            Fetch {
+                url: "https://slow.example.com/".to_string(),
+                method: HttpMethod::Get,
+                headers: vec![],
+                body: vec![],
+                timeout_ms: None,
+            },
+        ) {
+            FetchResult::Err { url, error } => {
+                assert_eq!(url, "https://slow.example.com/");
+                assert_eq!(error, HttpError::Timeout);
+            }
+            FetchResult::Ok { .. } => panic!("expected Err"),
+        }
+    }
+
+    #[test]
+    fn cap_uses_default_timeout_when_none_provided() {
+        let (mailer, _rx) = test_mailer_and_rx();
+        let stub = StubAdapter::with(Ok(FetchResponse {
+            status: 200,
+            headers: vec![],
+            body: vec![],
+        }));
+        let stub_clone = Arc::clone(&stub);
+        let mut state = HttpCapabilityState::from_adapter(
+            stub as Arc<dyn HttpAdapter>,
+            HttpConfig::default().default_timeout,
+        );
+        let transport = Arc::new(NativeBinding::new_for_test(mailer, MailboxId(0)));
+        let mut ctx = NativeCtx::new(
+            &transport,
+            session_sender(),
+            aether_data::MailId::NONE,
+            aether_data::MailId::NONE,
+        );
+        let _ = HttpCapability::on_fetch(
+            &mut state,
+            &mut ctx,
+            Fetch {
+                url: "https://api.example.com/".to_string(),
+                method: HttpMethod::Get,
+                headers: vec![],
+                body: vec![],
+                timeout_ms: None,
+            },
+        );
+        let observed = stub_clone
+            .last_request
+            .lock()
+            .expect("test stub: last_request mutex poisoned")
+            .take()
+            .expect("adapter was not called");
+        assert!(observed.timeout > Duration::ZERO);
+    }
+
+    #[test]
+    fn build_http_adapter_with_disable_returns_disabled() {
+        let cfg = HttpConfig {
+            disabled: true,
+            ..HttpConfig::default()
+        };
+        let a = build_http_adapter(cfg);
+        let resp = a.fetch(FetchRequest {
+            url: "https://example.com/".to_string(),
+            method: HttpMethod::Get,
+            headers: vec![],
+            body: vec![],
+            timeout: Duration::from_secs(30),
+        });
+        assert!(matches!(resp, Err(HttpError::Disabled)));
     }
 }

--- a/crates/aether-capabilities/src/http/server/mod.rs
+++ b/crates/aether-capabilities/src/http/server/mod.rs
@@ -16,12 +16,17 @@
 //! to the inbound request), records the open response socket in an
 //! in-flight table keyed by the dispatch's correlation id, and subscribes
 //! to settlement of the dispatched root. The handler replies
-//! [`HttpServerResponse`](crate::http::kinds::HttpServerResponse); the reply
+//! [`HttpServerResponse`]; the reply
 //! routes back to the cap, the
 //! reply-interception fallback formats the HTTP/1.1 response and writes it
 //! to the held socket. A response-less chain settles into `502`, a
 //! per-request timeout into `504`, and the trust caps reject oversize or
 //! malformed input with `413` / `431` / `501` before any dispatch.
+//!
+//! ADR-0122 identity/runtime split: the addressing identity is the ZST
+//! [`HttpServerCapability`]; the state-bearing runtime (the listener, the
+//! accept thread, the connection table) lives in the `runtime` module behind the
+//! one `feature = "runtime"` gate.
 //!
 //! [`RpcServerCapability`]: crate::rpc::RpcServerCapability
 
@@ -30,8 +35,9 @@
 // bytes so callers can't see references.
 #![allow(clippy::needless_pass_by_value)]
 
-// Handler-signature kinds need to be importable at file root for the
-// `#[bridge]`-emitted `HandlesKind<K>` markers.
+// Handler-signature kinds resolve at file root through these imports —
+// `#[actor]` emits the `HandlesKind<K>` markers always-on against the
+// identity, and the `init` / handler bodies name these kinds.
 use crate::http::kinds::HttpInboundReady;
 use aether_kinds::trace::Settled;
 
@@ -55,1065 +61,343 @@ pub use config::HttpServerConfig;
 #[cfg(feature = "native")]
 pub use config::{HttpServerConfigLayer, HttpServerOverlay};
 
-// Re-export the cap's handle struct at file root for chassis builders +
-// embedders that read the bound port.
+/// Exported handle bundle published at boot. Reachable from the chassis
+/// via `PassiveChassis::handle::<HttpServerHandle>()`; the load-bearing
+/// field is `local_port` so embedders / tests can connect to the
+/// OS-picked port when `bind_addr` requested port 0.
+///
+/// Plain data (no substrate type), so it stays at file root under the
+/// existing `not(target_arch = "wasm32")` gate — the `pub use
+/// server::HttpServerHandle` chain in `http/mod.rs` reads it from here.
 #[cfg(not(target_arch = "wasm32"))]
-pub use server_native::HttpServerHandle;
+#[derive(Clone)]
+pub struct HttpServerHandle {
+    pub local_port: u16,
+}
 
-#[aether_actor::bridge(singleton)]
-mod server_native {
-    use super::{HttpInboundReady, Settled};
-    use crate::http::kinds::{HttpHeader, HttpMethod, HttpServerRequest, HttpServerResponse};
-    use aether_actor::actor;
-    use aether_data::{Kind, KindId, MailboxId};
-    use aether_substrate::Mail;
-    use aether_substrate::actor::native::envelope::Envelope;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
-    use aether_substrate::mail::mailer::Mailer;
-    use std::collections::HashMap;
-    use std::io::{self, Read, Write};
-    use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::mpsc;
-    use std::thread::{self, JoinHandle};
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+/// `aether.http.server` cap **identity** (ADR-0122 identity/runtime split). A
+/// ZST carrying only the addressing — `Addressable`, the per-handler
+/// `HandlesKind` markers, the `#[fallback]` reply-interception marker, and the
+/// name-inventory entry, all emitted always-on by `#[actor]`. The
+/// state-bearing runtime (`HttpServerCapabilityState`, which owns the
+/// listener + accept thread + connection table) lives behind the one
+/// `feature = "runtime"` gate, so a transport-only build never names the state
+/// type nor pulls `aether_substrate` through this cap.
+pub struct HttpServerCapability;
 
-    /// Per-connection identifier, monotonic within this cap. Distinct from
-    /// the OS-level peer addr (one peer may reconnect; ids stay unique for
-    /// the cap's lifetime).
-    type ConnId = u64;
+use aether_actor::actor;
 
-    /// Header-array size for the inbound parse (doubles as the header-count
-    /// cap: a request with more headers is answered `431`). ADR-0108 §6.
-    const MAX_HEADER_COUNT: usize = 64;
+// The runtime half — the whole `aether_substrate`-typed surface (the state,
+// the sidecar threads, the parse/render machinery) — lives in `runtime.rs`,
+// gated once here; the `#[actor] impl` reaches it through the `use runtime::*`
+// glob.
+#[cfg(feature = "runtime")]
+mod runtime;
 
-    /// One parsed inbound HTTP/1.1 request the reader hands to the
-    /// dispatcher. The method stays a raw `String` here; the dispatcher
-    /// maps it to [`HttpMethod`] and answers `501` for a non-enumerated
-    /// verb before any dispatch.
-    struct ParsedRequest {
-        method: String,
-        path: String,
-        query: String,
-        headers: Vec<HttpHeader>,
-        body: Vec<u8>,
-    }
+#[cfg(feature = "runtime")]
+#[allow(clippy::wildcard_imports)]
+use runtime::*;
 
-    /// Internal event the accept / reader sidecar threads push to the cap
-    /// dispatcher via an mpsc. The matching wake-mail kind is
-    /// [`HttpInboundReady`] (empty payload) — `on_inbound_ready` drains the
-    /// channel and acts per item.
-    enum InboundEvent {
-        /// The accept thread took a new connection.
-        PeerAccepted { stream: TcpStream, peer: SocketAddr },
-        /// A reader parsed a complete, size-bounded request.
-        RequestParsed {
-            conn_id: ConnId,
-            request: ParsedRequest,
-        },
-        /// A reader hit a trust cap or a parse error before any dispatch;
-        /// the dispatcher writes the canned status response and closes.
-        RequestRejected {
-            conn_id: ConnId,
-            status: u16,
-            message: &'static str,
-        },
-        /// A reader saw EOF / a read error / a slow-loris timeout; the
-        /// dispatcher tears the connection down.
-        ReaderClosed { conn_id: ConnId, reason: String },
-        /// The handler didn't reply within `request_timeout`; the
-        /// dispatcher writes `504` if the request is still in-flight.
-        RequestTimedOut { conn_id: ConnId },
-    }
+#[actor(singleton)]
+impl NativeActor for HttpServerCapability {
+    /// The runtime state this identity boots into (ADR-0122 split): the
+    /// listener port, the accept thread, the connection table, and the
+    /// in-flight correlation table.
+    type State = HttpServerCapabilityState;
 
-    /// Per-connection state owned by the cap dispatcher. The reader sidecar
-    /// holds `shutdown` + the read half; the dispatcher writes the response
-    /// through `write_half`.
-    struct ConnState {
-        peer: SocketAddr,
-        /// Dispatcher's half — used to write the HTTP/1.1 response.
-        write_half: TcpStream,
-        /// Reader thread's shutdown flag. Cap flips it + shuts down the
-        /// socket to wake the blocked `read()`.
-        shutdown: Arc<AtomicBool>,
-        /// Reader thread handle. Joined in `unwire`, detached on close.
-        reader_thread: Option<JoinHandle<()>>,
-    }
+    type Config = HttpServerConfig;
 
-    /// Bookkeeping for one in-flight request. Looked up by the dispatch's
-    /// auto-minted `correlation_id` (== the dispatched envelope's
-    /// `MailId.correlation_id`, which is also the root id since the cap
-    /// always dispatches via `send_envelope_as_root`).
-    #[derive(Copy, Clone)]
-    struct PendingRequest {
-        conn_id: ConnId,
-    }
+    const NAMESPACE: &'static str = "aether.http.server";
 
-    /// Exported handle bundle published at boot. Reachable from the chassis
-    /// via `PassiveChassis::handle::<HttpServerHandle>()`; the load-bearing
-    /// field is `local_port` so embedders / tests can connect to the
-    /// OS-picked port when `bind_addr` requested port 0.
-    #[derive(Clone)]
-    pub struct HttpServerHandle {
-        pub local_port: u16,
-    }
+    fn init(
+        config: HttpServerConfig,
+        ctx: &mut NativeInitCtx<'_>,
+    ) -> Result<HttpServerCapabilityState, BootError> {
+        let listener =
+            TcpListener::bind(&config.bind_addr).map_err(|e| BootError::Other(Box::new(e)))?;
+        let local_addr = listener
+            .local_addr()
+            .map_err(|e| BootError::Other(Box::new(e)))?;
+        let port = local_addr.port();
+        listener
+            .set_nonblocking(false)
+            .map_err(|e| BootError::Other(Box::new(e)))?;
 
-    /// Wake sink shared with the accept + reader sidecar threads: push an
-    /// [`InboundEvent`] over the mpsc, then fire an [`HttpInboundReady`]
-    /// wake mail at the cap so the dispatcher drains.
-    struct WakeSink {
-        inbound_tx: mpsc::Sender<InboundEvent>,
-        mailer: Arc<Mailer>,
-        self_id: MailboxId,
-        wake_kind: KindId,
-    }
+        let accept_shutdown = Arc::new(AtomicBool::new(false));
+        let accept_shutdown_for_thread = Arc::clone(&accept_shutdown);
 
-    impl WakeSink {
-        /// Post one event + wake. Returns `false` when the receiver is gone
-        /// (the cap tore down) so the caller stops.
-        fn post(&self, event: InboundEvent) -> bool {
-            if self.inbound_tx.send(event).is_err() {
-                return false;
-            }
-            self.mailer.push(Mail::new(
-                self.self_id,
-                self.wake_kind,
-                HttpInboundReady::default().encode_into_bytes(),
-                1,
-            ));
-            true
-        }
-    }
+        let (inbound_tx, inbound_rx) = mpsc::channel::<InboundEvent>();
+        let mailer: Arc<Mailer> = ctx.mailer();
+        let self_id = ctx.self_id();
+        let wake_kind = KindId(<HttpInboundReady as Kind>::ID.0);
 
-    /// Singleton HTTP server cap. Owns one TCP listener + per-connection
-    /// state + the in-flight correlation table.
-    pub struct HttpServerCapability {
-        handler_mailbox: String,
-        max_request_bytes: usize,
-        max_header_bytes: usize,
-        request_timeout: Duration,
-        self_mailbox: MailboxId,
-        /// Cached `Arc<Mailer>` so the dispatcher can fire wake mails into
-        /// the cap, resolve the handler mailbox by name at dispatch time,
-        /// and subscribe to settlement. The cap is single-threaded
-        /// post-ADR-0038 so direct storage is fine.
-        mailer: Arc<Mailer>,
-        listener_port: u16,
-        accept_shutdown: Arc<AtomicBool>,
-        accept_thread: Option<JoinHandle<()>>,
-        inbound_rx: mpsc::Receiver<InboundEvent>,
-        inbound_tx: mpsc::Sender<InboundEvent>,
-        connections: HashMap<ConnId, ConnState>,
-        next_conn_id: ConnId,
-        /// Dispatch-correlation → open response socket. Populated on
-        /// dispatch; cleared on reply, settlement, timeout, or close.
-        in_flight: HashMap<u64, PendingRequest>,
-    }
+        let accept_sink = WakeSink {
+            inbound_tx: inbound_tx.clone(),
+            mailer: Arc::clone(&mailer),
+            self_id,
+            wake_kind,
+        };
 
-    #[actor]
-    impl NativeActor for HttpServerCapability {
-        type Config = super::HttpServerConfig;
-        const NAMESPACE: &'static str = "aether.http.server";
-
-        fn init(
-            config: super::HttpServerConfig,
-            ctx: &mut NativeInitCtx<'_>,
-        ) -> Result<Self, BootError> {
-            let listener =
-                TcpListener::bind(&config.bind_addr).map_err(|e| BootError::Other(Box::new(e)))?;
-            let local_addr = listener
-                .local_addr()
-                .map_err(|e| BootError::Other(Box::new(e)))?;
-            let port = local_addr.port();
-            listener
-                .set_nonblocking(false)
-                .map_err(|e| BootError::Other(Box::new(e)))?;
-
-            let accept_shutdown = Arc::new(AtomicBool::new(false));
-            let accept_shutdown_for_thread = Arc::clone(&accept_shutdown);
-
-            let (inbound_tx, inbound_rx) = mpsc::channel::<InboundEvent>();
-            let mailer: Arc<Mailer> = ctx.mailer();
-            let self_id = ctx.self_id();
-            let wake_kind = KindId(<HttpInboundReady as Kind>::ID.0);
-
-            let accept_sink = WakeSink {
-                inbound_tx: inbound_tx.clone(),
-                mailer: Arc::clone(&mailer),
-                self_id,
-                wake_kind,
-            };
-
-            // Transport thread below the mail layer — it accepts sockets
-            // that carry inbound mail in; no inbound chain to inherit, no
-            // settlement umbrella.
-            #[allow(clippy::disallowed_methods)]
-            let accept_thread = thread::Builder::new()
-                .name(format!("aether-http-accept-{port}"))
-                .spawn(move || {
-                    while !accept_shutdown_for_thread.load(Ordering::Acquire) {
-                        match listener.accept() {
-                            Ok((stream, peer)) => {
-                                if accept_shutdown_for_thread.load(Ordering::Acquire) {
-                                    drop(stream);
-                                    break;
-                                }
-                                if !accept_sink.post(InboundEvent::PeerAccepted { stream, peer }) {
-                                    break;
-                                }
+        // Transport thread below the mail layer — it accepts sockets
+        // that carry inbound mail in; no inbound chain to inherit, no
+        // settlement umbrella.
+        #[allow(clippy::disallowed_methods)]
+        let accept_thread = thread::Builder::new()
+            .name(format!("aether-http-accept-{port}"))
+            .spawn(move || {
+                while !accept_shutdown_for_thread.load(Ordering::Acquire) {
+                    match listener.accept() {
+                        Ok((stream, peer)) => {
+                            if accept_shutdown_for_thread.load(Ordering::Acquire) {
+                                drop(stream);
+                                break;
                             }
-                            Err(_) => {
-                                if accept_shutdown_for_thread.load(Ordering::Acquire) {
-                                    break;
-                                }
+                            if !accept_sink.post(InboundEvent::PeerAccepted { stream, peer }) {
+                                break;
+                            }
+                        }
+                        Err(_) => {
+                            if accept_shutdown_for_thread.load(Ordering::Acquire) {
+                                break;
                             }
                         }
                     }
-                })
-                .map_err(|e| BootError::Other(Box::new(e)))?;
-
-            tracing::info!(
-                target: "aether_substrate::http_server",
-                addr = %config.bind_addr,
-                port,
-                handler = %config.handler_mailbox,
-                "http server bound",
-            );
-
-            ctx.publish_handle(HttpServerHandle { local_port: port });
-
-            Ok(Self {
-                handler_mailbox: config.handler_mailbox,
-                max_request_bytes: config.max_request_bytes,
-                max_header_bytes: config.max_header_bytes,
-                request_timeout: Duration::from_millis(config.request_timeout_millis),
-                self_mailbox: self_id,
-                mailer,
-                listener_port: port,
-                accept_shutdown,
-                accept_thread: Some(accept_thread),
-                inbound_rx,
-                inbound_tx,
-                connections: HashMap::new(),
-                next_conn_id: 0,
-                in_flight: HashMap::new(),
+                }
             })
-        }
+            .map_err(|e| BootError::Other(Box::new(e)))?;
 
-        fn unwire(&mut self, _ctx: &mut NativeCtx<'_>) {
-            // Stop the accept thread; self-connect to unblock its
-            // blocking `accept()`.
-            self.accept_shutdown.store(true, Ordering::Release);
-            if let Ok(addr) = format!("127.0.0.1:{}", self.listener_port).parse::<SocketAddr>() {
-                let _ = TcpStream::connect_timeout(&addr, Duration::from_millis(100));
-            }
-            if let Some(thread) = self.accept_thread.take() {
-                let _ = thread.join();
-            }
-            // Stop every per-connection reader. Shutting the socket down
-            // wakes the blocked `read()`; the reader sees the flag and exits.
-            for conn in self.connections.values_mut() {
-                conn.shutdown.store(true, Ordering::Release);
-                let _ = conn.write_half.shutdown(Shutdown::Both);
-                if let Some(thread) = conn.reader_thread.take() {
-                    let _ = thread.join();
-                }
-            }
-            tracing::info!(
-                target: "aether_substrate::http_server",
-                port = self.listener_port,
-                "http server closed",
-            );
-        }
+        tracing::info!(
+            target: "aether_substrate::http_server",
+            addr = %config.bind_addr,
+            port,
+            handler = %config.handler_mailbox,
+            "http server bound",
+        );
 
-        /// Sidecar wake. Drain every pending inbound event.
-        ///
-        /// # Agent
-        /// Internal wake mail — not part of the cap's external surface. The
-        /// accept / reader sidecars fire this; the handler drains the mpsc
-        /// and acts per item.
-        #[handler]
-        fn on_inbound_ready(&mut self, ctx: &mut NativeCtx<'_>, _mail: HttpInboundReady) {
-            while let Ok(event) = self.inbound_rx.try_recv() {
-                match event {
-                    InboundEvent::PeerAccepted { stream, peer } => {
-                        self.spawn_reader_for_peer(stream, peer);
-                    }
-                    InboundEvent::RequestParsed { conn_id, request } => {
-                        self.dispatch_request(ctx, conn_id, request);
-                    }
-                    InboundEvent::RequestRejected {
-                        conn_id,
-                        status,
-                        message,
-                    } => {
-                        self.write_status_response(conn_id, status, message);
-                        self.close_connection(conn_id, "request rejected");
-                    }
-                    InboundEvent::ReaderClosed { conn_id, reason } => {
-                        self.close_connection(conn_id, &reason);
-                    }
-                    InboundEvent::RequestTimedOut { conn_id } => {
-                        if self.in_flight.values().any(|p| p.conn_id == conn_id) {
-                            self.write_status_response(conn_id, 504, "gateway timeout");
-                        }
-                        self.close_connection(conn_id, "request timeout");
-                    }
-                }
-            }
-        }
+        ctx.publish_handle(HttpServerHandle { local_port: port });
 
-        /// Settlement notice. The root corresponds to a dispatched request
-        /// we subscribed to; if it settled with no [`HttpServerResponse`]
-        /// written, answer `502` (ADR-0108 §5) and clear the entry.
-        ///
-        /// # Agent
-        /// Internal — fires from the settlement registry, not external mail.
-        #[handler]
-        fn on_settled(&mut self, _ctx: &mut NativeCtx<'_>, mail: Settled) {
-            let correlation = mail.root.correlation_id;
-            let Some(pending) = self.in_flight.remove(&correlation) else {
-                // Already answered (the reply landed first) or never ours.
-                return;
-            };
-            self.write_status_response(pending.conn_id, 502, "no response from handler");
-            self.close_connection(pending.conn_id, "settled without response");
-        }
-
-        /// Reply interception. Any mail addressed at this cap that isn't one
-        /// of the typed wake / settlement kinds is treated as the handler's
-        /// reply; if its `correlation_id` matches an in-flight request and
-        /// it is an [`HttpServerResponse`], format the HTTP/1.1 response,
-        /// write it to the held socket, and close.
-        ///
-        /// # Agent
-        /// Not user-callable — this is the cap's reply-interception path. A
-        /// by-value `#[handler]` can't read the inbound `sender.correlation_id`,
-        /// so reply correlation goes through this envelope fallback
-        /// (ADR-0108 §5).
-        #[fallback]
-        fn on_any(&mut self, _ctx: &mut NativeCtx<'_>, env: &Envelope) {
-            let correlation = env.sender.correlation_id;
-            let Some(pending) = self.in_flight.get(&correlation).copied() else {
-                return;
-            };
-            if env.kind != <HttpServerResponse as Kind>::ID {
-                // Unexpected kind with a matching correlation — leave the
-                // in-flight entry for the settlement / timeout safety net.
-                return;
-            }
-            match HttpServerResponse::decode_from_bytes(env.payload.bytes()) {
-                Some(response) => self.write_handler_response(pending.conn_id, &response),
-                None => {
-                    self.write_status_response(pending.conn_id, 502, "malformed handler response");
-                }
-            }
-            self.in_flight.remove(&correlation);
-            self.close_connection(pending.conn_id, "response written");
-        }
+        Ok(HttpServerCapabilityState {
+            handler_mailbox: config.handler_mailbox,
+            max_request_bytes: config.max_request_bytes,
+            max_header_bytes: config.max_header_bytes,
+            request_timeout: Duration::from_millis(config.request_timeout_millis),
+            self_mailbox: self_id,
+            mailer,
+            listener_port: port,
+            accept_shutdown,
+            accept_thread: Some(accept_thread),
+            inbound_rx,
+            inbound_tx,
+            connections: HashMap::new(),
+            next_conn_id: 0,
+            in_flight: HashMap::new(),
+        })
     }
 
-    impl HttpServerCapability {
-        /// Allocate a fresh `ConnId`, store the connection's write half, and
-        /// spin a reader thread for the read half.
-        fn spawn_reader_for_peer(&mut self, stream: TcpStream, peer: SocketAddr) {
-            let conn_id = self.next_conn_id;
-            self.next_conn_id += 1;
-
-            let read_half = match stream.try_clone() {
-                Ok(half) => half,
-                Err(e) => {
-                    tracing::warn!(
-                        target: "aether_substrate::http_server",
-                        %peer,
-                        error = %e,
-                        "http conn: try_clone failed; dropping",
-                    );
-                    return;
-                }
-            };
-            // Slow-loris guard + response deadline (ADR-0108 §6): bound
-            // every blocking read on this socket.
-            if let Err(e) = read_half.set_read_timeout(Some(self.request_timeout)) {
-                tracing::warn!(
-                    target: "aether_substrate::http_server",
-                    %peer,
-                    error = %e,
-                    "http conn: set_read_timeout failed; dropping",
-                );
-                return;
-            }
-            let write_half = stream;
-            let shutdown = Arc::new(AtomicBool::new(false));
-            let shutdown_for_thread = Arc::clone(&shutdown);
-
-            let sink = WakeSink {
-                inbound_tx: self.inbound_tx.clone(),
-                mailer: Arc::clone(&self.mailer),
-                self_id: self.self_mailbox,
-                wake_kind: KindId(<HttpInboundReady as Kind>::ID.0),
-            };
-            let max_request_bytes = self.max_request_bytes;
-            let max_header_bytes = self.max_header_bytes;
-
-            // Per-connection transport reader below the mail layer — carries
-            // inbound mail in; no inbound chain to inherit, no settlement
-            // umbrella.
-            #[allow(clippy::disallowed_methods)]
-            let thread = match thread::Builder::new()
-                .name(format!("aether-http-reader-{conn_id}"))
-                .spawn(move || {
-                    run_reader_loop(
-                        read_half,
-                        conn_id,
-                        &shutdown_for_thread,
-                        &sink,
-                        max_request_bytes,
-                        max_header_bytes,
-                    );
-                }) {
-                Ok(thread) => thread,
-                Err(e) => {
-                    tracing::warn!(
-                        target: "aether_substrate::http_server",
-                        %peer,
-                        error = %e,
-                        "http reader thread spawn failed",
-                    );
-                    return;
-                }
-            };
-
-            self.connections.insert(
-                conn_id,
-                ConnState {
-                    peer,
-                    write_half,
-                    shutdown,
-                    reader_thread: Some(thread),
-                },
-            );
-            tracing::debug!(
-                target: "aether_substrate::http_server",
-                conn = conn_id,
-                %peer,
-                "http conn accepted",
-            );
+    fn unwire(state: &mut Self::State, _ctx: &mut NativeCtx<'_>) {
+        // Stop the accept thread; self-connect to unblock its
+        // blocking `accept()`.
+        state.accept_shutdown.store(true, Ordering::Release);
+        if let Ok(addr) = format!("127.0.0.1:{}", state.listener_port).parse::<SocketAddr>() {
+            let _ = TcpStream::connect_timeout(&addr, Duration::from_millis(100));
         }
-
-        /// Map the method, resolve the handler, dispatch the request, and
-        /// record the in-flight entry. Answers `501` / `503` inline.
-        fn dispatch_request(
-            &mut self,
-            ctx: &mut NativeCtx<'_>,
-            conn_id: ConnId,
-            request: ParsedRequest,
-        ) {
-            let Some(method) = parse_http_method(&request.method) else {
-                self.write_status_response(conn_id, 501, "method not implemented");
-                self.close_connection(conn_id, "unsupported method");
-                return;
-            };
-            // Late-binding handler resolution (ADR-0108 §3): resolve the
-            // configured mailbox by name at dispatch time through the
-            // registry — the sanctioned runtime-name path, which folds a
-            // lineage-rendered name to its id and reports a miss as `None`.
-            // Nothing live under the name → `503`.
-            let Some(handler) = self.mailer.registry().lookup(&self.handler_mailbox) else {
-                self.write_status_response(conn_id, 503, "no handler registered");
-                self.close_connection(conn_id, "handler unresolved");
-                return;
-            };
-            let payload = HttpServerRequest {
-                method,
-                path: request.path,
-                query: request.query,
-                headers: request.headers,
-                body: request.body,
-            }
-            .encode_into_bytes();
-            let mail_id =
-                ctx.send_envelope_as_root(handler, <HttpServerRequest as Kind>::ID, &payload);
-            // Safety net (ADR-0108 §5): if the chain settles with no
-            // response, `on_settled` answers `502`. Best-effort — a chassis
-            // without the settlement registry still serves the reply path.
-            if let Some(registry) = self.mailer.settlement_registry() {
-                registry.subscribe_settlement_mail(
-                    mail_id,
-                    self.self_mailbox,
-                    <Settled as Kind>::ID,
-                    Arc::clone(&self.mailer),
-                );
-            }
-            self.in_flight
-                .insert(mail_id.correlation_id, PendingRequest { conn_id });
+        if let Some(thread) = state.accept_thread.take() {
+            let _ = thread.join();
         }
-
-        /// Format + write the handler's [`HttpServerResponse`].
-        fn write_handler_response(&mut self, conn_id: ConnId, response: &HttpServerResponse) {
-            let bytes = render_handler_response(response);
-            self.write_raw_to(conn_id, &bytes);
-        }
-
-        /// Format + write a canned status response (the cap's own
-        /// `413` / `431` / `501` / `502` / `503` / `504`).
-        fn write_status_response(&mut self, conn_id: ConnId, status: u16, message: &str) {
-            let bytes = render_status_response(status, message);
-            self.write_raw_to(conn_id, &bytes);
-        }
-
-        fn write_raw_to(&mut self, conn_id: ConnId, bytes: &[u8]) {
-            let Some(conn) = self.connections.get_mut(&conn_id) else {
-                return;
-            };
-            if let Err(e) = conn
-                .write_half
-                .write_all(bytes)
-                .and_then(|()| conn.write_half.flush())
-            {
-                tracing::debug!(
-                    target: "aether_substrate::http_server",
-                    conn = conn_id,
-                    error = %e,
-                    "http response write failed",
-                );
-            }
-        }
-
-        fn close_connection(&mut self, conn_id: ConnId, reason: &str) {
-            let Some(mut conn) = self.connections.remove(&conn_id) else {
-                return;
-            };
+        // Stop every per-connection reader. Shutting the socket down
+        // wakes the blocked `read()`; the reader sees the flag and exits.
+        for conn in state.connections.values_mut() {
             conn.shutdown.store(true, Ordering::Release);
             let _ = conn.write_half.shutdown(Shutdown::Both);
-            // Detach the reader without joining inline — the dispatcher must
-            // not block on it. The thread sees the shutdown (or its own EOF)
-            // and exits; the JoinHandle drop detaches.
-            drop(conn.reader_thread.take());
-            // Drop any in-flight entry pinned to this connection so we don't
-            // write to a dead socket.
-            self.in_flight
-                .retain(|_, pending| pending.conn_id != conn_id);
-            tracing::debug!(
-                target: "aether_substrate::http_server",
-                conn = conn_id,
-                peer = %conn.peer,
-                reason,
-                "http conn closed",
-            );
-        }
-    }
-
-    /// Outcome of [`read_more`].
-    enum ReadStep {
-        Filled(usize),
-        Eof,
-        Timeout,
-        Error(String),
-    }
-
-    /// One bounded read off the socket, retrying past `Interrupted` and
-    /// folding `WouldBlock` / `TimedOut` (the `set_read_timeout` expiry)
-    /// into [`ReadStep::Timeout`].
-    fn read_more(stream: &mut TcpStream, chunk: &mut [u8]) -> ReadStep {
-        loop {
-            match stream.read(chunk) {
-                Ok(0) => return ReadStep::Eof,
-                Ok(n) => return ReadStep::Filled(n),
-                Err(e)
-                    if e.kind() == io::ErrorKind::WouldBlock
-                        || e.kind() == io::ErrorKind::TimedOut =>
-                {
-                    return ReadStep::Timeout;
-                }
-                Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
-                Err(e) => return ReadStep::Error(format!("read error: {e}")),
+            if let Some(thread) = conn.reader_thread.take() {
+                let _ = thread.join();
             }
         }
-    }
-
-    /// One parsed request head.
-    struct RequestHead {
-        head_len: usize,
-        method: String,
-        path: String,
-        query: String,
-        headers: Vec<HttpHeader>,
-        content_length: usize,
-    }
-
-    /// Outcome of [`parse_head`].
-    enum HeadParse {
-        Complete(RequestHead),
-        NeedMore,
-        Reject { status: u16, message: &'static str },
-    }
-
-    /// Parse the accumulated bytes as an HTTP/1.1 request head (request line
-    /// + headers). Enforces the header-count cap (`431` via
-    /// `TooManyHeaders`) and surfaces the header-byte cap to the caller via
-    /// [`HeadParse::NeedMore`] (the caller rejects `431` once `buf` outgrows
-    /// `max_header_bytes`).
-    fn parse_head(buf: &[u8], max_header_bytes: usize) -> HeadParse {
-        let mut headers = [httparse::EMPTY_HEADER; MAX_HEADER_COUNT];
-        let mut request = httparse::Request::new(&mut headers);
-        match request.parse(buf) {
-            Ok(httparse::Status::Complete(head_len)) => {
-                let method = request.method.unwrap_or_default().to_string();
-                let raw_path = request.path.unwrap_or("/");
-                let (path, query) = match raw_path.split_once('?') {
-                    Some((before, after)) => (before.to_string(), after.to_string()),
-                    None => (raw_path.to_string(), String::new()),
-                };
-                let mut out_headers = Vec::with_capacity(request.headers.len());
-                let mut content_length = 0usize;
-                let mut bad_length = false;
-                for header in &*request.headers {
-                    let value = String::from_utf8_lossy(header.value).into_owned();
-                    if header.name.eq_ignore_ascii_case("content-length") {
-                        match value.trim().parse::<usize>() {
-                            Ok(n) => content_length = n,
-                            Err(_) => bad_length = true,
-                        }
-                    }
-                    out_headers.push(HttpHeader {
-                        name: header.name.to_string(),
-                        value,
-                    });
-                }
-                if bad_length {
-                    return HeadParse::Reject {
-                        status: 400,
-                        message: "invalid content-length",
-                    };
-                }
-                HeadParse::Complete(RequestHead {
-                    head_len,
-                    method,
-                    path,
-                    query,
-                    headers: out_headers,
-                    content_length,
-                })
-            }
-            Ok(httparse::Status::Partial) => {
-                if buf.len() > max_header_bytes {
-                    HeadParse::Reject {
-                        status: 431,
-                        message: "request header fields too large",
-                    }
-                } else {
-                    HeadParse::NeedMore
-                }
-            }
-            Err(httparse::Error::TooManyHeaders) => HeadParse::Reject {
-                status: 431,
-                message: "too many request headers",
-            },
-            Err(_) => HeadParse::Reject {
-                status: 400,
-                message: "malformed request",
-            },
-        }
-    }
-
-    /// Per-connection reader thread body. Reads one HTTP/1.1 request (head +
-    /// `Content-Length`-bounded body), posts it, then blocks until the
-    /// dispatcher writes the response and closes the socket (EOF) or the
-    /// read timeout fires (`504`). Returns when the connection closes.
-    #[allow(clippy::too_many_lines)]
-    fn run_reader_loop(
-        read_half: TcpStream,
-        conn_id: ConnId,
-        shutdown: &AtomicBool,
-        sink: &WakeSink,
-        max_request_bytes: usize,
-        max_header_bytes: usize,
-    ) {
-        let mut stream = read_half;
-        let mut buf: Vec<u8> = Vec::with_capacity(8 * 1024);
-        let mut chunk = [0u8; 8 * 1024];
-
-        // Phase 1: accumulate the request head.
-        let head = loop {
-            if shutdown.load(Ordering::Acquire) {
-                return;
-            }
-            match parse_head(&buf, max_header_bytes) {
-                HeadParse::Complete(head) => break head,
-                HeadParse::Reject { status, message } => {
-                    sink.post(InboundEvent::RequestRejected {
-                        conn_id,
-                        status,
-                        message,
-                    });
-                    return;
-                }
-                HeadParse::NeedMore => {}
-            }
-            match read_more(&mut stream, &mut chunk) {
-                ReadStep::Filled(n) => buf.extend_from_slice(&chunk[..n]),
-                ReadStep::Eof => {
-                    sink.post(InboundEvent::ReaderClosed {
-                        conn_id,
-                        reason: "eof before request head".to_string(),
-                    });
-                    return;
-                }
-                ReadStep::Timeout => {
-                    sink.post(InboundEvent::ReaderClosed {
-                        conn_id,
-                        reason: "read timeout (head)".to_string(),
-                    });
-                    return;
-                }
-                ReadStep::Error(reason) => {
-                    sink.post(InboundEvent::ReaderClosed { conn_id, reason });
-                    return;
-                }
-            }
-        };
-
-        // Body cap (ADR-0108 §6): reject before reading any body bytes.
-        if head.content_length > max_request_bytes {
-            sink.post(InboundEvent::RequestRejected {
-                conn_id,
-                status: 413,
-                message: "request body exceeds limit",
-            });
-            return;
-        }
-
-        // Phase 2: read the `Content-Length`-bounded body. Leftover bytes
-        // already in `buf` past the head come first.
-        let mut body: Vec<u8> = Vec::with_capacity(head.content_length);
-        let leftover = &buf[head.head_len..];
-        let take = leftover.len().min(head.content_length);
-        body.extend_from_slice(&leftover[..take]);
-        while body.len() < head.content_length {
-            if shutdown.load(Ordering::Acquire) {
-                return;
-            }
-            match read_more(&mut stream, &mut chunk) {
-                ReadStep::Filled(n) => {
-                    let want = head.content_length - body.len();
-                    body.extend_from_slice(&chunk[..n.min(want)]);
-                }
-                ReadStep::Eof => {
-                    sink.post(InboundEvent::ReaderClosed {
-                        conn_id,
-                        reason: "eof mid-body".to_string(),
-                    });
-                    return;
-                }
-                ReadStep::Timeout => {
-                    sink.post(InboundEvent::ReaderClosed {
-                        conn_id,
-                        reason: "read timeout (body)".to_string(),
-                    });
-                    return;
-                }
-                ReadStep::Error(reason) => {
-                    sink.post(InboundEvent::ReaderClosed { conn_id, reason });
-                    return;
-                }
-            }
-        }
-
-        let request = ParsedRequest {
-            method: head.method,
-            path: head.path,
-            query: head.query,
-            headers: head.headers,
-            body,
-        };
-        if !sink.post(InboundEvent::RequestParsed { conn_id, request }) {
-            return;
-        }
-
-        // Phase 3: response deadline. Block until the dispatcher writes the
-        // response and closes the socket (EOF) or the read timeout fires
-        // (handler too slow → `504`). v1 serves one request per connection.
-        loop {
-            if shutdown.load(Ordering::Acquire) {
-                return;
-            }
-            match read_more(&mut stream, &mut chunk) {
-                ReadStep::Eof | ReadStep::Error(_) => return,
-                ReadStep::Filled(_) => {}
-                ReadStep::Timeout => {
-                    sink.post(InboundEvent::RequestTimedOut { conn_id });
-                    return;
-                }
-            }
-        }
-    }
-
-    /// Headers the cap supplies itself (ADR-0108 §2) — stripped from a
-    /// handler's response so they aren't doubled.
-    fn is_cap_owned_header(name: &str) -> bool {
-        name.eq_ignore_ascii_case("content-length")
-            || name.eq_ignore_ascii_case("connection")
-            || name.eq_ignore_ascii_case("date")
-            || name.eq_ignore_ascii_case("transfer-encoding")
-    }
-
-    /// Render the handler's [`HttpServerResponse`] as an HTTP/1.1 response,
-    /// supplying `Content-Length` / `Date` / `Connection` (ADR-0108 §2).
-    fn render_handler_response(response: &HttpServerResponse) -> Vec<u8> {
-        use std::fmt::Write as _;
-        let mut head = format!(
-            "HTTP/1.1 {} {}\r\n",
-            response.status,
-            reason_phrase(response.status)
+        tracing::info!(
+            target: "aether_substrate::http_server",
+            port = state.listener_port,
+            "http server closed",
         );
-        for header in &response.headers {
-            if is_cap_owned_header(&header.name) {
-                continue;
+    }
+
+    /// Sidecar wake. Drain every pending inbound event.
+    ///
+    /// # Agent
+    /// Internal wake mail — not part of the cap's external surface. The
+    /// accept / reader sidecars fire this; the handler drains the mpsc
+    /// and acts per item.
+    #[handler]
+    fn on_inbound_ready(state: &mut Self::State, ctx: &mut NativeCtx<'_>, _mail: HttpInboundReady) {
+        while let Ok(event) = state.inbound_rx.try_recv() {
+            match event {
+                InboundEvent::PeerAccepted { stream, peer } => {
+                    state.spawn_reader_for_peer(stream, peer);
+                }
+                InboundEvent::RequestParsed { conn_id, request } => {
+                    state.dispatch_request(ctx, conn_id, request);
+                }
+                InboundEvent::RequestRejected {
+                    conn_id,
+                    status,
+                    message,
+                } => {
+                    state.write_status_response(conn_id, status, message);
+                    state.close_connection(conn_id, "request rejected");
+                }
+                InboundEvent::ReaderClosed { conn_id, reason } => {
+                    state.close_connection(conn_id, &reason);
+                }
+                InboundEvent::RequestTimedOut { conn_id } => {
+                    if state.in_flight.values().any(|p| p.conn_id == conn_id) {
+                        state.write_status_response(conn_id, 504, "gateway timeout");
+                    }
+                    state.close_connection(conn_id, "request timeout");
+                }
             }
-            let _ = write!(head, "{}: {}\r\n", header.name, header.value);
-        }
-        let _ = write!(head, "Content-Length: {}\r\n", response.body.len());
-        let _ = write!(head, "Date: {}\r\n", http_date(SystemTime::now()));
-        head.push_str("Connection: close\r\n\r\n");
-        let mut out = head.into_bytes();
-        out.extend_from_slice(&response.body);
-        out
-    }
-
-    /// Render a canned status response with a plain-text body.
-    fn render_status_response(status: u16, message: &str) -> Vec<u8> {
-        use std::fmt::Write as _;
-        let body = message.as_bytes();
-        let mut head = format!("HTTP/1.1 {} {}\r\n", status, reason_phrase(status));
-        head.push_str("Content-Type: text/plain; charset=utf-8\r\n");
-        let _ = write!(head, "Content-Length: {}\r\n", body.len());
-        let _ = write!(head, "Date: {}\r\n", http_date(SystemTime::now()));
-        head.push_str("Connection: close\r\n\r\n");
-        let mut out = head.into_bytes();
-        out.extend_from_slice(body);
-        out
-    }
-
-    /// Map a raw HTTP method token to the typed [`HttpMethod`]; `None` for a
-    /// non-enumerated verb (answered `501` before any dispatch).
-    fn parse_http_method(method: &str) -> Option<HttpMethod> {
-        match method {
-            "GET" => Some(HttpMethod::Get),
-            "POST" => Some(HttpMethod::Post),
-            "PUT" => Some(HttpMethod::Put),
-            "DELETE" => Some(HttpMethod::Delete),
-            "PATCH" => Some(HttpMethod::Patch),
-            "HEAD" => Some(HttpMethod::Head),
-            "OPTIONS" => Some(HttpMethod::Options),
-            _ => None,
         }
     }
 
-    /// HTTP reason phrase for the status codes the cap emits.
-    fn reason_phrase(status: u16) -> &'static str {
-        match status {
-            200 => "OK",
-            201 => "Created",
-            204 => "No Content",
-            400 => "Bad Request",
-            404 => "Not Found",
-            413 => "Payload Too Large",
-            414 => "URI Too Long",
-            431 => "Request Header Fields Too Large",
-            500 => "Internal Server Error",
-            501 => "Not Implemented",
-            502 => "Bad Gateway",
-            503 => "Service Unavailable",
-            504 => "Gateway Timeout",
-            _ => "Status",
-        }
+    /// Settlement notice. The root corresponds to a dispatched request
+    /// we subscribed to; if it settled with no [`HttpServerResponse`]
+    /// written, answer `502` (ADR-0108 §5) and clear the entry.
+    ///
+    /// # Agent
+    /// Internal — fires from the settlement registry, not external mail.
+    #[handler]
+    fn on_settled(state: &mut Self::State, _ctx: &mut NativeCtx<'_>, mail: Settled) {
+        let correlation = mail.root.correlation_id;
+        let Some(pending) = state.in_flight.remove(&correlation) else {
+            // Already answered (the reply landed first) or never ours.
+            return;
+        };
+        state.write_status_response(pending.conn_id, 502, "no response from handler");
+        state.close_connection(pending.conn_id, "settled without response");
     }
 
-    /// Format `now` as an RFC 7231 IMF-fixdate (`Sun, 06 Nov 1994 08:49:37
-    /// GMT`) for the `Date` response header. Pure integer arithmetic
-    /// (Howard Hinnant's civil-from-days) — no date crate.
-    fn http_date(now: SystemTime) -> String {
-        const WEEKDAYS: [&str; 7] = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-        const MONTHS: [&str; 12] = [
-            "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
-        ];
-        let secs = now.duration_since(UNIX_EPOCH).map_or(0, |d| d.as_secs());
-        let total = i64::try_from(secs).unwrap_or(i64::MAX);
-        let days = total.div_euclid(86_400);
-        let rem = total.rem_euclid(86_400);
-        let hour = rem / 3_600;
-        let minute = (rem % 3_600) / 60;
-        let second = rem % 60;
-        let weekday = (days + 4).rem_euclid(7);
-        // Civil date from days-since-epoch.
-        let z = days + 719_468;
-        let era = z.div_euclid(146_097);
-        let doe = z - era * 146_097;
-        let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
-        let year = yoe + era * 400;
-        let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-        let mp = (5 * doy + 2) / 153;
-        let day = doy - (153 * mp + 2) / 5 + 1;
-        let month = if mp < 10 { mp + 3 } else { mp - 9 };
-        let year = if month <= 2 { year + 1 } else { year };
-        let weekday_name = WEEKDAYS[usize::try_from(weekday).unwrap_or(0)];
-        let month_name = MONTHS[usize::try_from(month - 1).unwrap_or(0)];
-        format!(
-            "{weekday_name}, {day:02} {month_name} {year:04} {hour:02}:{minute:02}:{second:02} GMT"
-        )
-    }
-
-    #[cfg(test)]
-    mod unit_tests {
-        use super::{http_date, parse_http_method, reason_phrase};
-        use crate::http::kinds::HttpMethod;
-        use std::time::{Duration, UNIX_EPOCH};
-
-        #[test]
-        fn http_date_formats_the_rfc_example() {
-            // RFC 7231 §7.1.1.1 canonical example.
-            let when = UNIX_EPOCH + Duration::from_secs(784_111_777);
-            assert_eq!(http_date(when), "Sun, 06 Nov 1994 08:49:37 GMT");
+    /// Reply interception. Any mail addressed at this cap that isn't one
+    /// of the typed wake / settlement kinds is treated as the handler's
+    /// reply; if its `correlation_id` matches an in-flight request and
+    /// it is an [`HttpServerResponse`], format the HTTP/1.1 response,
+    /// write it to the held socket, and close.
+    ///
+    /// # Agent
+    /// Not user-callable — this is the cap's reply-interception path. A
+    /// by-value `#[handler]` can't read the inbound `sender.correlation_id`,
+    /// so reply correlation goes through this envelope fallback
+    /// (ADR-0108 §5).
+    #[fallback]
+    fn on_any(state: &mut Self::State, _ctx: &mut NativeCtx<'_>, env: &Envelope) {
+        let correlation = env.sender.correlation_id;
+        let Some(pending) = state.in_flight.get(&correlation).copied() else {
+            return;
+        };
+        if env.kind != <HttpServerResponse as Kind>::ID {
+            // Unexpected kind with a matching correlation — leave the
+            // in-flight entry for the settlement / timeout safety net.
+            return;
         }
-
-        #[test]
-        fn known_methods_map_unknown_is_none() {
-            assert_eq!(parse_http_method("GET"), Some(HttpMethod::Get));
-            assert_eq!(parse_http_method("POST"), Some(HttpMethod::Post));
-            assert_eq!(parse_http_method("OPTIONS"), Some(HttpMethod::Options));
-            assert_eq!(parse_http_method("FROB"), None);
-            assert_eq!(parse_http_method("get"), None);
+        match HttpServerResponse::decode_from_bytes(env.payload.bytes()) {
+            Some(response) => state.write_handler_response(pending.conn_id, &response),
+            None => {
+                state.write_status_response(pending.conn_id, 502, "malformed handler response");
+            }
         }
-
-        #[test]
-        fn reason_phrases_cover_emitted_statuses() {
-            assert_eq!(reason_phrase(200), "OK");
-            assert_eq!(reason_phrase(413), "Payload Too Large");
-            assert_eq!(reason_phrase(501), "Not Implemented");
-            assert_eq!(reason_phrase(502), "Bad Gateway");
-            assert_eq!(reason_phrase(503), "Service Unavailable");
-            assert_eq!(reason_phrase(504), "Gateway Timeout");
-        }
-
-        #[test]
-        fn config_layer_defaults_match_the_named_consts() {
-            use super::super::{
-                DEFAULT_BIND_ADDR, DEFAULT_MAX_HEADER_BYTES, DEFAULT_MAX_REQUEST_BYTES,
-                DEFAULT_REQUEST_TIMEOUT_MILLIS, HttpServerConfig, HttpServerConfigLayer,
-            };
-            use confique::Config as _;
-            // No `.env()` source: loads the literal defaults only, so this is
-            // env-free and guards the layer defaults against the consts +
-            // `HttpServerConfig::default()`.
-            let layer = HttpServerConfigLayer::builder()
-                .load()
-                .expect("defaults load");
-            let default = HttpServerConfig::default();
-            assert_eq!(layer.bind_addr, DEFAULT_BIND_ADDR);
-            assert_eq!(layer.bind_addr, default.bind_addr);
-            assert_eq!(layer.handler_mailbox, "");
-            assert_eq!(layer.max_request_bytes, DEFAULT_MAX_REQUEST_BYTES);
-            assert_eq!(layer.max_header_bytes, DEFAULT_MAX_HEADER_BYTES);
-            assert_eq!(layer.request_timeout_millis, DEFAULT_REQUEST_TIMEOUT_MILLIS);
-        }
+        state.in_flight.remove(&correlation);
+        state.close_connection(pending.conn_id, "response written");
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "runtime"))]
 mod test_handlers {
     //! Minimal native handler actors behind the server in the integration
     //! tests: one that replies `200` echoing the request, one that drops
     //! the request without replying (the `502` safety-net path).
+    use aether_actor::actor;
+    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    use aether_substrate::chassis::error::BootError;
+
     use crate::http::kinds::{HttpHeader, HttpServerRequest, HttpServerResponse};
 
     /// Replies `200` and echoes the request's method / path / query (as
     /// headers) and body (verbatim), so a test can assert the full request
     /// round-tripped to the handler.
-    #[aether_actor::bridge(singleton)]
-    mod echo_handler {
-        use super::{HttpHeader, HttpServerRequest, HttpServerResponse};
-        use aether_actor::actor;
-        use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-        use aether_substrate::chassis::error::BootError;
+    pub struct EchoHttpHandler;
 
-        pub struct EchoHttpHandler;
+    /// Empty runtime state for the stateless echo handler (ADR-0122: a
+    /// stateless cap still names a state type rather than `()` / `Self`).
+    pub struct EchoHttpHandlerState;
 
-        #[actor]
-        impl NativeActor for EchoHttpHandler {
-            type Config = ();
-            const NAMESPACE: &'static str = "aether.http.test_echo_handler";
+    #[actor(singleton)]
+    impl NativeActor for EchoHttpHandler {
+        type State = EchoHttpHandlerState;
+        type Config = ();
+        const NAMESPACE: &'static str = "aether.http.test_echo_handler";
 
-            fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-                Ok(Self)
-            }
+        fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<EchoHttpHandlerState, BootError> {
+            Ok(EchoHttpHandlerState)
+        }
 
-            #[allow(clippy::unused_self)]
-            #[handler]
-            fn on_request(
-                &mut self,
-                _ctx: &mut NativeCtx<'_>,
-                request: HttpServerRequest,
-            ) -> HttpServerResponse {
-                let headers = vec![
-                    HttpHeader {
-                        name: "x-aether-method".to_string(),
-                        value: format!("{:?}", request.method),
-                    },
-                    HttpHeader {
-                        name: "x-aether-path".to_string(),
-                        value: request.path.clone(),
-                    },
-                    HttpHeader {
-                        name: "x-aether-query".to_string(),
-                        value: request.query.clone(),
-                    },
-                    HttpHeader {
-                        name: "content-type".to_string(),
-                        value: "text/plain".to_string(),
-                    },
-                ];
-                HttpServerResponse {
-                    status: 200,
-                    headers,
-                    body: request.body,
-                }
+        #[handler]
+        fn on_request(
+            _state: &mut Self::State,
+            _ctx: &mut NativeCtx<'_>,
+            request: HttpServerRequest,
+        ) -> HttpServerResponse {
+            let headers = vec![
+                HttpHeader {
+                    name: "x-aether-method".to_string(),
+                    value: format!("{:?}", request.method),
+                },
+                HttpHeader {
+                    name: "x-aether-path".to_string(),
+                    value: request.path.clone(),
+                },
+                HttpHeader {
+                    name: "x-aether-query".to_string(),
+                    value: request.query.clone(),
+                },
+                HttpHeader {
+                    name: "content-type".to_string(),
+                    value: "text/plain".to_string(),
+                },
+            ];
+            HttpServerResponse {
+                status: 200,
+                headers,
+                body: request.body,
             }
         }
     }
 
     /// Receives the request and returns without replying — the response-less
     /// chain the `502` settlement safety net covers.
-    #[aether_actor::bridge(singleton)]
-    mod silent_handler {
-        use super::HttpServerRequest;
-        use aether_actor::actor;
-        use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-        use aether_substrate::chassis::error::BootError;
+    pub struct SilentHttpHandler;
 
-        pub struct SilentHttpHandler;
+    /// Empty runtime state for the stateless silent handler (ADR-0122).
+    pub struct SilentHttpHandlerState;
 
-        #[actor]
-        impl NativeActor for SilentHttpHandler {
-            type Config = ();
-            const NAMESPACE: &'static str = "aether.http.test_silent_handler";
+    #[actor(singleton)]
+    impl NativeActor for SilentHttpHandler {
+        type State = SilentHttpHandlerState;
+        type Config = ();
+        const NAMESPACE: &'static str = "aether.http.test_silent_handler";
 
-            fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-                Ok(Self)
-            }
+        fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<SilentHttpHandlerState, BootError> {
+            Ok(SilentHttpHandlerState)
+        }
 
-            #[allow(clippy::unused_self)]
-            #[handler]
-            fn on_request(&mut self, _ctx: &mut NativeCtx<'_>, _request: HttpServerRequest) {
-                // Intentionally drops the request without replying.
-            }
+        #[handler]
+        fn on_request(
+            _state: &mut Self::State,
+            _ctx: &mut NativeCtx<'_>,
+            _request: HttpServerRequest,
+        ) {
+            // Intentionally drops the request without replying.
         }
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "runtime"))]
 mod tests {
     use super::test_handlers::{EchoHttpHandler, SilentHttpHandler};
     use super::{HttpServerCapability, HttpServerConfig, HttpServerHandle};

--- a/crates/aether-capabilities/src/http/server/runtime.rs
+++ b/crates/aether-capabilities/src/http/server/runtime.rs
@@ -1,0 +1,776 @@
+//! The `aether.http.server` runtime half (ADR-0122 identity/runtime split).
+//! Compiled only under `feature = "runtime"` (the `mod runtime;` declaration
+//! in the parent carries the gate), so a transport-only build of the
+//! `HttpServerCapability` identity never names these types nor pulls
+//! `aether_substrate`. The substrate-typed imports are gated once by this
+//! module rather than line-by-line; the `#[actor] impl` in the parent reaches
+//! the state, ctx, and helper types through the single `use runtime::*` glob.
+//!
+//! Holds the state-bearing `HttpServerCapabilityState` (the 11 fields: the
+//! listener port, the accept thread, the per-connection table, the internal
+//! mpsc, and the in-flight correlation table), its helper-method impl, the
+//! reader/accept sidecar free functions, and the parse/render support types.
+//! The reader and accept threads capture only `Arc` / channel / id clones
+//! built from locals in `init` (parent) and `spawn_reader_for_peer` (here) —
+//! never the cap struct — so the field-home move into this state does not
+//! change what the threads capture.
+
+// Parent-level items this module names.
+use super::{HttpInboundReady, Settled};
+
+pub use std::collections::HashMap;
+pub use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
+pub use std::sync::Arc;
+pub use std::sync::atomic::{AtomicBool, Ordering};
+pub use std::sync::mpsc;
+pub use std::thread;
+pub use std::time::Duration;
+
+pub use aether_data::{Kind, KindId, MailboxId};
+pub use aether_substrate::actor::native::envelope::Envelope;
+pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub use aether_substrate::chassis::error::BootError;
+pub use aether_substrate::mail::mailer::Mailer;
+
+// The parent `#[actor] impl` writes the `502` reply path, so it names
+// `HttpServerResponse`; the rest of the kind vocabulary is used only here.
+pub use crate::http::kinds::HttpServerResponse;
+use crate::http::kinds::{HttpHeader, HttpMethod, HttpServerRequest};
+
+use aether_substrate::Mail;
+use std::io::{self, Read, Write};
+use std::thread::JoinHandle;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Per-connection identifier, monotonic within this cap. Distinct from
+/// the OS-level peer addr (one peer may reconnect; ids stay unique for
+/// the cap's lifetime).
+pub type ConnId = u64;
+
+/// Header-array size for the inbound parse (doubles as the header-count
+/// cap: a request with more headers is answered `431`). ADR-0108 §6.
+const MAX_HEADER_COUNT: usize = 64;
+
+/// One parsed inbound HTTP/1.1 request the reader hands to the
+/// dispatcher. The method stays a raw `String` here; the dispatcher
+/// maps it to [`HttpMethod`] and answers `501` for a non-enumerated
+/// verb before any dispatch.
+pub struct ParsedRequest {
+    method: String,
+    path: String,
+    query: String,
+    headers: Vec<HttpHeader>,
+    body: Vec<u8>,
+}
+
+/// Internal event the accept / reader sidecar threads push to the cap
+/// dispatcher via an mpsc. The matching wake-mail kind is
+/// [`HttpInboundReady`] (empty payload) — `on_inbound_ready` drains the
+/// channel and acts per item.
+pub enum InboundEvent {
+    /// The accept thread took a new connection.
+    PeerAccepted { stream: TcpStream, peer: SocketAddr },
+    /// A reader parsed a complete, size-bounded request.
+    RequestParsed {
+        conn_id: ConnId,
+        request: ParsedRequest,
+    },
+    /// A reader hit a trust cap or a parse error before any dispatch;
+    /// the dispatcher writes the canned status response and closes.
+    RequestRejected {
+        conn_id: ConnId,
+        status: u16,
+        message: &'static str,
+    },
+    /// A reader saw EOF / a read error / a slow-loris timeout; the
+    /// dispatcher tears the connection down.
+    ReaderClosed { conn_id: ConnId, reason: String },
+    /// The handler didn't reply within `request_timeout`; the
+    /// dispatcher writes `504` if the request is still in-flight.
+    RequestTimedOut { conn_id: ConnId },
+}
+
+/// Per-connection state owned by the cap dispatcher. The reader sidecar
+/// holds `shutdown` + the read half; the dispatcher writes the response
+/// through `write_half`.
+pub struct ConnState {
+    peer: SocketAddr,
+    /// Dispatcher's half — used to write the HTTP/1.1 response.
+    pub(super) write_half: TcpStream,
+    /// Reader thread's shutdown flag. Cap flips it + shuts down the
+    /// socket to wake the blocked `read()`.
+    pub(super) shutdown: Arc<AtomicBool>,
+    /// Reader thread handle. Joined in `unwire`, detached on close.
+    pub(super) reader_thread: Option<JoinHandle<()>>,
+}
+
+/// Bookkeeping for one in-flight request. Looked up by the dispatch's
+/// auto-minted `correlation_id` (== the dispatched envelope's
+/// `MailId.correlation_id`, which is also the root id since the cap
+/// always dispatches via `send_envelope_as_root`).
+#[derive(Copy, Clone)]
+pub struct PendingRequest {
+    pub(super) conn_id: ConnId,
+}
+
+/// Wake sink shared with the accept + reader sidecar threads: push an
+/// [`InboundEvent`] over the mpsc, then fire an [`HttpInboundReady`]
+/// wake mail at the cap so the dispatcher drains.
+pub struct WakeSink {
+    pub(super) inbound_tx: mpsc::Sender<InboundEvent>,
+    pub(super) mailer: Arc<Mailer>,
+    pub(super) self_id: MailboxId,
+    pub(super) wake_kind: KindId,
+}
+
+impl WakeSink {
+    /// Post one event + wake. Returns `false` when the receiver is gone
+    /// (the cap tore down) so the caller stops.
+    pub(super) fn post(&self, event: InboundEvent) -> bool {
+        if self.inbound_tx.send(event).is_err() {
+            return false;
+        }
+        self.mailer.push(Mail::new(
+            self.self_id,
+            self.wake_kind,
+            HttpInboundReady::default().encode_into_bytes(),
+            1,
+        ));
+        true
+    }
+}
+
+/// `aether.http.server` runtime state. Owns one TCP listener + per-connection
+/// state + the in-flight correlation table. The dispatcher holds this as the
+/// cap's state and routes envelopes through the macro-emitted `Dispatch`
+/// impl; the addressing identity is the distinct ZST `HttpServerCapability`.
+/// Living in this private module keeps it `pub`-enough to satisfy the
+/// `NativeActor::State` interface without exposing it as crate-public API.
+pub struct HttpServerCapabilityState {
+    pub(super) handler_mailbox: String,
+    pub(super) max_request_bytes: usize,
+    pub(super) max_header_bytes: usize,
+    pub(super) request_timeout: Duration,
+    pub(super) self_mailbox: MailboxId,
+    /// Cached `Arc<Mailer>` so the dispatcher can fire wake mails into
+    /// the cap, resolve the handler mailbox by name at dispatch time,
+    /// and subscribe to settlement. The cap is single-threaded
+    /// post-ADR-0038 so direct storage is fine.
+    pub(super) mailer: Arc<Mailer>,
+    pub(super) listener_port: u16,
+    pub(super) accept_shutdown: Arc<AtomicBool>,
+    pub(super) accept_thread: Option<JoinHandle<()>>,
+    pub(super) inbound_rx: mpsc::Receiver<InboundEvent>,
+    pub(super) inbound_tx: mpsc::Sender<InboundEvent>,
+    pub(super) connections: HashMap<ConnId, ConnState>,
+    pub(super) next_conn_id: ConnId,
+    /// Dispatch-correlation → open response socket. Populated on
+    /// dispatch; cleared on reply, settlement, timeout, or close.
+    pub(super) in_flight: HashMap<u64, PendingRequest>,
+}
+
+impl HttpServerCapabilityState {
+    /// Allocate a fresh `ConnId`, store the connection's write half, and
+    /// spin a reader thread for the read half.
+    pub(super) fn spawn_reader_for_peer(&mut self, stream: TcpStream, peer: SocketAddr) {
+        let conn_id = self.next_conn_id;
+        self.next_conn_id += 1;
+
+        let read_half = match stream.try_clone() {
+            Ok(half) => half,
+            Err(e) => {
+                tracing::warn!(
+                    target: "aether_substrate::http_server",
+                    %peer,
+                    error = %e,
+                    "http conn: try_clone failed; dropping",
+                );
+                return;
+            }
+        };
+        // Slow-loris guard + response deadline (ADR-0108 §6): bound
+        // every blocking read on this socket.
+        if let Err(e) = read_half.set_read_timeout(Some(self.request_timeout)) {
+            tracing::warn!(
+                target: "aether_substrate::http_server",
+                %peer,
+                error = %e,
+                "http conn: set_read_timeout failed; dropping",
+            );
+            return;
+        }
+        let write_half = stream;
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_for_thread = Arc::clone(&shutdown);
+
+        let sink = WakeSink {
+            inbound_tx: self.inbound_tx.clone(),
+            mailer: Arc::clone(&self.mailer),
+            self_id: self.self_mailbox,
+            wake_kind: KindId(<HttpInboundReady as Kind>::ID.0),
+        };
+        let max_request_bytes = self.max_request_bytes;
+        let max_header_bytes = self.max_header_bytes;
+
+        // Per-connection transport reader below the mail layer — carries
+        // inbound mail in; no inbound chain to inherit, no settlement
+        // umbrella.
+        #[allow(clippy::disallowed_methods)]
+        let thread = match thread::Builder::new()
+            .name(format!("aether-http-reader-{conn_id}"))
+            .spawn(move || {
+                run_reader_loop(
+                    read_half,
+                    conn_id,
+                    &shutdown_for_thread,
+                    &sink,
+                    max_request_bytes,
+                    max_header_bytes,
+                );
+            }) {
+            Ok(thread) => thread,
+            Err(e) => {
+                tracing::warn!(
+                    target: "aether_substrate::http_server",
+                    %peer,
+                    error = %e,
+                    "http reader thread spawn failed",
+                );
+                return;
+            }
+        };
+
+        self.connections.insert(
+            conn_id,
+            ConnState {
+                peer,
+                write_half,
+                shutdown,
+                reader_thread: Some(thread),
+            },
+        );
+        tracing::debug!(
+            target: "aether_substrate::http_server",
+            conn = conn_id,
+            %peer,
+            "http conn accepted",
+        );
+    }
+
+    /// Map the method, resolve the handler, dispatch the request, and
+    /// record the in-flight entry. Answers `501` / `503` inline.
+    pub(super) fn dispatch_request(
+        &mut self,
+        ctx: &mut NativeCtx<'_>,
+        conn_id: ConnId,
+        request: ParsedRequest,
+    ) {
+        let Some(method) = parse_http_method(&request.method) else {
+            self.write_status_response(conn_id, 501, "method not implemented");
+            self.close_connection(conn_id, "unsupported method");
+            return;
+        };
+        // Late-binding handler resolution (ADR-0108 §3): resolve the
+        // configured mailbox by name at dispatch time through the
+        // registry — the sanctioned runtime-name path, which folds a
+        // lineage-rendered name to its id and reports a miss as `None`.
+        // Nothing live under the name → `503`.
+        let Some(handler) = self.mailer.registry().lookup(&self.handler_mailbox) else {
+            self.write_status_response(conn_id, 503, "no handler registered");
+            self.close_connection(conn_id, "handler unresolved");
+            return;
+        };
+        let payload = HttpServerRequest {
+            method,
+            path: request.path,
+            query: request.query,
+            headers: request.headers,
+            body: request.body,
+        }
+        .encode_into_bytes();
+        let mail_id = ctx.send_envelope_as_root(handler, <HttpServerRequest as Kind>::ID, &payload);
+        // Safety net (ADR-0108 §5): if the chain settles with no
+        // response, `on_settled` answers `502`. Best-effort — a chassis
+        // without the settlement registry still serves the reply path.
+        if let Some(registry) = self.mailer.settlement_registry() {
+            registry.subscribe_settlement_mail(
+                mail_id,
+                self.self_mailbox,
+                <Settled as Kind>::ID,
+                Arc::clone(&self.mailer),
+            );
+        }
+        self.in_flight
+            .insert(mail_id.correlation_id, PendingRequest { conn_id });
+    }
+
+    /// Format + write the handler's [`HttpServerResponse`].
+    pub(super) fn write_handler_response(
+        &mut self,
+        conn_id: ConnId,
+        response: &HttpServerResponse,
+    ) {
+        let bytes = render_handler_response(response);
+        self.write_raw_to(conn_id, &bytes);
+    }
+
+    /// Format + write a canned status response (the cap's own
+    /// `413` / `431` / `501` / `502` / `503` / `504`).
+    pub(super) fn write_status_response(&mut self, conn_id: ConnId, status: u16, message: &str) {
+        let bytes = render_status_response(status, message);
+        self.write_raw_to(conn_id, &bytes);
+    }
+
+    fn write_raw_to(&mut self, conn_id: ConnId, bytes: &[u8]) {
+        let Some(conn) = self.connections.get_mut(&conn_id) else {
+            return;
+        };
+        if let Err(e) = conn
+            .write_half
+            .write_all(bytes)
+            .and_then(|()| conn.write_half.flush())
+        {
+            tracing::debug!(
+                target: "aether_substrate::http_server",
+                conn = conn_id,
+                error = %e,
+                "http response write failed",
+            );
+        }
+    }
+
+    pub(super) fn close_connection(&mut self, conn_id: ConnId, reason: &str) {
+        let Some(mut conn) = self.connections.remove(&conn_id) else {
+            return;
+        };
+        conn.shutdown.store(true, Ordering::Release);
+        let _ = conn.write_half.shutdown(Shutdown::Both);
+        // Detach the reader without joining inline — the dispatcher must
+        // not block on it. The thread sees the shutdown (or its own EOF)
+        // and exits; the JoinHandle drop detaches.
+        drop(conn.reader_thread.take());
+        // Drop any in-flight entry pinned to this connection so we don't
+        // write to a dead socket.
+        self.in_flight
+            .retain(|_, pending| pending.conn_id != conn_id);
+        tracing::debug!(
+            target: "aether_substrate::http_server",
+            conn = conn_id,
+            peer = %conn.peer,
+            reason,
+            "http conn closed",
+        );
+    }
+}
+
+/// Outcome of [`read_more`].
+enum ReadStep {
+    Filled(usize),
+    Eof,
+    Timeout,
+    Error(String),
+}
+
+/// One bounded read off the socket, retrying past `Interrupted` and
+/// folding `WouldBlock` / `TimedOut` (the `set_read_timeout` expiry)
+/// into [`ReadStep::Timeout`].
+fn read_more(stream: &mut TcpStream, chunk: &mut [u8]) -> ReadStep {
+    loop {
+        match stream.read(chunk) {
+            Ok(0) => return ReadStep::Eof,
+            Ok(n) => return ReadStep::Filled(n),
+            Err(e)
+                if e.kind() == io::ErrorKind::WouldBlock || e.kind() == io::ErrorKind::TimedOut =>
+            {
+                return ReadStep::Timeout;
+            }
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) => return ReadStep::Error(format!("read error: {e}")),
+        }
+    }
+}
+
+/// One parsed request head.
+struct RequestHead {
+    head_len: usize,
+    method: String,
+    path: String,
+    query: String,
+    headers: Vec<HttpHeader>,
+    content_length: usize,
+}
+
+/// Outcome of [`parse_head`].
+enum HeadParse {
+    Complete(RequestHead),
+    NeedMore,
+    Reject { status: u16, message: &'static str },
+}
+
+/// Parse the accumulated bytes as an HTTP/1.1 request head (request line
+/// and headers). Enforces the header-count cap (`431` via
+/// `TooManyHeaders`) and surfaces the header-byte cap to the caller via
+/// [`HeadParse::NeedMore`] (the caller rejects `431` once `buf` outgrows
+/// `max_header_bytes`).
+fn parse_head(buf: &[u8], max_header_bytes: usize) -> HeadParse {
+    let mut headers = [httparse::EMPTY_HEADER; MAX_HEADER_COUNT];
+    let mut request = httparse::Request::new(&mut headers);
+    match request.parse(buf) {
+        Ok(httparse::Status::Complete(head_len)) => {
+            let method = request.method.unwrap_or_default().to_string();
+            let raw_path = request.path.unwrap_or("/");
+            let (path, query) = match raw_path.split_once('?') {
+                Some((before, after)) => (before.to_string(), after.to_string()),
+                None => (raw_path.to_string(), String::new()),
+            };
+            let mut out_headers = Vec::with_capacity(request.headers.len());
+            let mut content_length = 0usize;
+            let mut bad_length = false;
+            for header in &*request.headers {
+                let value = String::from_utf8_lossy(header.value).into_owned();
+                if header.name.eq_ignore_ascii_case("content-length") {
+                    match value.trim().parse::<usize>() {
+                        Ok(n) => content_length = n,
+                        Err(_) => bad_length = true,
+                    }
+                }
+                out_headers.push(HttpHeader {
+                    name: header.name.to_string(),
+                    value,
+                });
+            }
+            if bad_length {
+                return HeadParse::Reject {
+                    status: 400,
+                    message: "invalid content-length",
+                };
+            }
+            HeadParse::Complete(RequestHead {
+                head_len,
+                method,
+                path,
+                query,
+                headers: out_headers,
+                content_length,
+            })
+        }
+        Ok(httparse::Status::Partial) => {
+            if buf.len() > max_header_bytes {
+                HeadParse::Reject {
+                    status: 431,
+                    message: "request header fields too large",
+                }
+            } else {
+                HeadParse::NeedMore
+            }
+        }
+        Err(httparse::Error::TooManyHeaders) => HeadParse::Reject {
+            status: 431,
+            message: "too many request headers",
+        },
+        Err(_) => HeadParse::Reject {
+            status: 400,
+            message: "malformed request",
+        },
+    }
+}
+
+/// Per-connection reader thread body. Reads one HTTP/1.1 request (head +
+/// `Content-Length`-bounded body), posts it, then blocks until the
+/// dispatcher writes the response and closes the socket (EOF) or the
+/// read timeout fires (`504`). Returns when the connection closes.
+#[allow(clippy::too_many_lines)]
+fn run_reader_loop(
+    read_half: TcpStream,
+    conn_id: ConnId,
+    shutdown: &AtomicBool,
+    sink: &WakeSink,
+    max_request_bytes: usize,
+    max_header_bytes: usize,
+) {
+    let mut stream = read_half;
+    let mut buf: Vec<u8> = Vec::with_capacity(8 * 1024);
+    let mut chunk = [0u8; 8 * 1024];
+
+    // Phase 1: accumulate the request head.
+    let head = loop {
+        if shutdown.load(Ordering::Acquire) {
+            return;
+        }
+        match parse_head(&buf, max_header_bytes) {
+            HeadParse::Complete(head) => break head,
+            HeadParse::Reject { status, message } => {
+                sink.post(InboundEvent::RequestRejected {
+                    conn_id,
+                    status,
+                    message,
+                });
+                return;
+            }
+            HeadParse::NeedMore => {}
+        }
+        match read_more(&mut stream, &mut chunk) {
+            ReadStep::Filled(n) => buf.extend_from_slice(&chunk[..n]),
+            ReadStep::Eof => {
+                sink.post(InboundEvent::ReaderClosed {
+                    conn_id,
+                    reason: "eof before request head".to_string(),
+                });
+                return;
+            }
+            ReadStep::Timeout => {
+                sink.post(InboundEvent::ReaderClosed {
+                    conn_id,
+                    reason: "read timeout (head)".to_string(),
+                });
+                return;
+            }
+            ReadStep::Error(reason) => {
+                sink.post(InboundEvent::ReaderClosed { conn_id, reason });
+                return;
+            }
+        }
+    };
+
+    // Body cap (ADR-0108 §6): reject before reading any body bytes.
+    if head.content_length > max_request_bytes {
+        sink.post(InboundEvent::RequestRejected {
+            conn_id,
+            status: 413,
+            message: "request body exceeds limit",
+        });
+        return;
+    }
+
+    // Phase 2: read the `Content-Length`-bounded body. Leftover bytes
+    // already in `buf` past the head come first.
+    let mut body: Vec<u8> = Vec::with_capacity(head.content_length);
+    let leftover = &buf[head.head_len..];
+    let take = leftover.len().min(head.content_length);
+    body.extend_from_slice(&leftover[..take]);
+    while body.len() < head.content_length {
+        if shutdown.load(Ordering::Acquire) {
+            return;
+        }
+        match read_more(&mut stream, &mut chunk) {
+            ReadStep::Filled(n) => {
+                let want = head.content_length - body.len();
+                body.extend_from_slice(&chunk[..n.min(want)]);
+            }
+            ReadStep::Eof => {
+                sink.post(InboundEvent::ReaderClosed {
+                    conn_id,
+                    reason: "eof mid-body".to_string(),
+                });
+                return;
+            }
+            ReadStep::Timeout => {
+                sink.post(InboundEvent::ReaderClosed {
+                    conn_id,
+                    reason: "read timeout (body)".to_string(),
+                });
+                return;
+            }
+            ReadStep::Error(reason) => {
+                sink.post(InboundEvent::ReaderClosed { conn_id, reason });
+                return;
+            }
+        }
+    }
+
+    let request = ParsedRequest {
+        method: head.method,
+        path: head.path,
+        query: head.query,
+        headers: head.headers,
+        body,
+    };
+    if !sink.post(InboundEvent::RequestParsed { conn_id, request }) {
+        return;
+    }
+
+    // Phase 3: response deadline. Block until the dispatcher writes the
+    // response and closes the socket (EOF) or the read timeout fires
+    // (handler too slow → `504`). v1 serves one request per connection.
+    loop {
+        if shutdown.load(Ordering::Acquire) {
+            return;
+        }
+        match read_more(&mut stream, &mut chunk) {
+            ReadStep::Eof | ReadStep::Error(_) => return,
+            ReadStep::Filled(_) => {}
+            ReadStep::Timeout => {
+                sink.post(InboundEvent::RequestTimedOut { conn_id });
+                return;
+            }
+        }
+    }
+}
+
+/// Headers the cap supplies itself (ADR-0108 §2) — stripped from a
+/// handler's response so they aren't doubled.
+fn is_cap_owned_header(name: &str) -> bool {
+    name.eq_ignore_ascii_case("content-length")
+        || name.eq_ignore_ascii_case("connection")
+        || name.eq_ignore_ascii_case("date")
+        || name.eq_ignore_ascii_case("transfer-encoding")
+}
+
+/// Render the handler's [`HttpServerResponse`] as an HTTP/1.1 response,
+/// supplying `Content-Length` / `Date` / `Connection` (ADR-0108 §2).
+fn render_handler_response(response: &HttpServerResponse) -> Vec<u8> {
+    use std::fmt::Write as _;
+    let mut head = format!(
+        "HTTP/1.1 {} {}\r\n",
+        response.status,
+        reason_phrase(response.status)
+    );
+    for header in &response.headers {
+        if is_cap_owned_header(&header.name) {
+            continue;
+        }
+        let _ = write!(head, "{}: {}\r\n", header.name, header.value);
+    }
+    let _ = write!(head, "Content-Length: {}\r\n", response.body.len());
+    let _ = write!(head, "Date: {}\r\n", http_date(SystemTime::now()));
+    head.push_str("Connection: close\r\n\r\n");
+    let mut out = head.into_bytes();
+    out.extend_from_slice(&response.body);
+    out
+}
+
+/// Render a canned status response with a plain-text body.
+fn render_status_response(status: u16, message: &str) -> Vec<u8> {
+    use std::fmt::Write as _;
+    let body = message.as_bytes();
+    let mut head = format!("HTTP/1.1 {} {}\r\n", status, reason_phrase(status));
+    head.push_str("Content-Type: text/plain; charset=utf-8\r\n");
+    let _ = write!(head, "Content-Length: {}\r\n", body.len());
+    let _ = write!(head, "Date: {}\r\n", http_date(SystemTime::now()));
+    head.push_str("Connection: close\r\n\r\n");
+    let mut out = head.into_bytes();
+    out.extend_from_slice(body);
+    out
+}
+
+/// Map a raw HTTP method token to the typed [`HttpMethod`]; `None` for a
+/// non-enumerated verb (answered `501` before any dispatch).
+fn parse_http_method(method: &str) -> Option<HttpMethod> {
+    match method {
+        "GET" => Some(HttpMethod::Get),
+        "POST" => Some(HttpMethod::Post),
+        "PUT" => Some(HttpMethod::Put),
+        "DELETE" => Some(HttpMethod::Delete),
+        "PATCH" => Some(HttpMethod::Patch),
+        "HEAD" => Some(HttpMethod::Head),
+        "OPTIONS" => Some(HttpMethod::Options),
+        _ => None,
+    }
+}
+
+/// HTTP reason phrase for the status codes the cap emits.
+fn reason_phrase(status: u16) -> &'static str {
+    match status {
+        200 => "OK",
+        201 => "Created",
+        204 => "No Content",
+        400 => "Bad Request",
+        404 => "Not Found",
+        413 => "Payload Too Large",
+        414 => "URI Too Long",
+        431 => "Request Header Fields Too Large",
+        500 => "Internal Server Error",
+        501 => "Not Implemented",
+        502 => "Bad Gateway",
+        503 => "Service Unavailable",
+        504 => "Gateway Timeout",
+        _ => "Status",
+    }
+}
+
+/// Format `now` as an RFC 7231 IMF-fixdate (`Sun, 06 Nov 1994 08:49:37
+/// GMT`) for the `Date` response header. Pure integer arithmetic
+/// (Howard Hinnant's civil-from-days) — no date crate.
+fn http_date(now: SystemTime) -> String {
+    const WEEKDAYS: [&str; 7] = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+    const MONTHS: [&str; 12] = [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ];
+    let secs = now.duration_since(UNIX_EPOCH).map_or(0, |d| d.as_secs());
+    let total = i64::try_from(secs).unwrap_or(i64::MAX);
+    let days = total.div_euclid(86_400);
+    let rem = total.rem_euclid(86_400);
+    let hour = rem / 3_600;
+    let minute = (rem % 3_600) / 60;
+    let second = rem % 60;
+    let weekday = (days + 4).rem_euclid(7);
+    // Civil date from days-since-epoch.
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let year = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year = if month <= 2 { year + 1 } else { year };
+    let weekday_name = WEEKDAYS[usize::try_from(weekday).unwrap_or(0)];
+    let month_name = MONTHS[usize::try_from(month - 1).unwrap_or(0)];
+    format!("{weekday_name}, {day:02} {month_name} {year:04} {hour:02}:{minute:02}:{second:02} GMT")
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::{http_date, parse_http_method, reason_phrase};
+    use crate::http::kinds::HttpMethod;
+    use std::time::{Duration, UNIX_EPOCH};
+
+    #[test]
+    fn http_date_formats_the_rfc_example() {
+        // RFC 7231 §7.1.1.1 canonical example.
+        let when = UNIX_EPOCH + Duration::from_secs(784_111_777);
+        assert_eq!(http_date(when), "Sun, 06 Nov 1994 08:49:37 GMT");
+    }
+
+    #[test]
+    fn known_methods_map_unknown_is_none() {
+        assert_eq!(parse_http_method("GET"), Some(HttpMethod::Get));
+        assert_eq!(parse_http_method("POST"), Some(HttpMethod::Post));
+        assert_eq!(parse_http_method("OPTIONS"), Some(HttpMethod::Options));
+        assert_eq!(parse_http_method("FROB"), None);
+        assert_eq!(parse_http_method("get"), None);
+    }
+
+    #[test]
+    fn reason_phrases_cover_emitted_statuses() {
+        assert_eq!(reason_phrase(200), "OK");
+        assert_eq!(reason_phrase(413), "Payload Too Large");
+        assert_eq!(reason_phrase(501), "Not Implemented");
+        assert_eq!(reason_phrase(502), "Bad Gateway");
+        assert_eq!(reason_phrase(503), "Service Unavailable");
+        assert_eq!(reason_phrase(504), "Gateway Timeout");
+    }
+
+    #[test]
+    fn config_layer_defaults_match_the_named_consts() {
+        use super::super::{
+            DEFAULT_BIND_ADDR, DEFAULT_MAX_HEADER_BYTES, DEFAULT_MAX_REQUEST_BYTES,
+            DEFAULT_REQUEST_TIMEOUT_MILLIS, HttpServerConfig, HttpServerConfigLayer,
+        };
+        use confique::Config as _;
+        // No `.env()` source: loads the literal defaults only, so this is
+        // env-free and guards the layer defaults against the consts +
+        // `HttpServerConfig::default()`.
+        let layer = HttpServerConfigLayer::builder()
+            .load()
+            .expect("defaults load");
+        let default = HttpServerConfig::default();
+        assert_eq!(layer.bind_addr, DEFAULT_BIND_ADDR);
+        assert_eq!(layer.bind_addr, default.bind_addr);
+        assert_eq!(layer.handler_mailbox, "");
+        assert_eq!(layer.max_request_bytes, DEFAULT_MAX_REQUEST_BYTES);
+        assert_eq!(layer.max_header_bytes, DEFAULT_MAX_HEADER_BYTES);
+        assert_eq!(layer.request_timeout_millis, DEFAULT_REQUEST_TIMEOUT_MILLIS);
+    }
+}


### PR DESCRIPTION
Closes #2323.

## Summary

Migrates the two `aether.http` caps off `#[bridge]` onto the ADR-0122 identity/runtime split: `HttpCapability` (client, singleton, light — inline `mod runtime`) and `HttpServerCapability` (singleton, heavy — `http/server/runtime.rs`, spawns a reader thread, has a `#[fallback]`). Each is a ZST identity + a top-level `#[actor(singleton)] impl NativeActor` with handlers and the server's `#[fallback]` over `state: &mut Self::State`; the substrate-typed half lives behind a `#[cfg(feature = "runtime")] mod runtime` reached via one `use runtime::*` glob. The two `#[bridge]` test handlers in `mod test_handlers` migrate likewise.

The server's accept/reader threads capture init-local handles (`Arc`/channel/id clones), never the cap struct, so `unwire`'s join is a field-home move. `HttpServerHandle`'s public path and the `HttpCapability` client name are preserved (cross-crate consumers).

## Test plan

- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo nextest run -p aether-capabilities` (248 passed incl. both http suites: server round-trip/413/501/503/502-settlement, client adapter + handler-unit), strict `cargo doc`, transport-only build — all green.
- Validated via `scripts/attest.sh --publish`.

## Generated by

`/implement --sweep --attest` — agent execution of scoped issue #2323.
