### PR TITLE
refactor(capabilities): split the gemini and anthropic caps into identity and runtime modules

### DIFF
--- a/crates/aether-capabilities/src/anthropic/mod.rs
+++ b/crates/aether-capabilities/src/anthropic/mod.rs
@@ -8,7 +8,7 @@
 //! Long-tail calls (a multi-second Messages request, a `claude`
 //! subprocess) ride the ADR-0093 hold-until-resolve dispatch: the
 //! generate handler submits the blocking call to a
-//! [`TaskQueue`](crate::shared::contentgen::TaskQueue), which hands it to
+//! [`TaskQueue`], which hands it to
 //! `ctx.dispatch_blocking` — the substrate spawns an ephemeral worker,
 //! holds the chain open in its in-flight ledger, and routes the
 //! completion to the cap's `#[handler(task)]` as a `TaskDone`. The cap
@@ -132,730 +132,583 @@ impl AnthropicAdapter for CombinedAnthropicAdapter {
 
 mod config;
 
-// Handler-signature kinds must be importable at file root because
-// `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
-// of the mod (always-on, outside the cfg gate).
-// Handler-signature kinds are brought into file-root scope via
-// `pub use kinds::{..., CliSend, ...}` above; the bridge macro's
-// `impl HandlesKind<K>` markers outside `mod native` can see them there.
-// No separate `use` needed.
-
 /// Convert an adapter error string into the typed `AnthropicError`.
 /// Shared by both result paths.
 fn map_adapter_error(raw: &str) -> AnthropicError {
     error::adapter_error_to_typed(raw)
 }
 
-#[aether_actor::bridge(singleton)]
-mod native {
-    use std::sync::Arc;
+/// `aether.anthropic` mailbox cap **identity** (ADR-0122 identity/runtime
+/// split). A ZST carrying only the addressing — `Addressable`
+/// (`NAMESPACE`, `Resolver`), the per-handler `HandlesKind` markers, and
+/// the name-inventory entry, all emitted always-on by `#[actor]`. The
+/// state-bearing runtime (`AnthropicCapabilityState`,
+/// which holds the `aether_substrate`-typed adapter + task queue) lives
+/// behind the one `feature = "runtime"` gate, so a transport-only build
+/// never names it nor pulls `aether_substrate` through this cap.
+//
+// Handler-signature kinds (`MessagesSend` / `CliSend` / their results)
+// resolve at file root through the `pub use kinds::{…}` re-export above —
+// `#[actor]` emits the always-on `impl HandlesKind<K>` markers against the
+// identity, outside the `feature = "runtime"` gate, so they reference these
+// kinds from here.
+pub struct AnthropicCapability;
 
+// The `#[actor]` / `#[handler]` attribute path stays always-on (the macro
+// divides what it emits). Everything that names an `aether_substrate` type —
+// the handler/init ctx, the runtime state, the gate/reply helpers, the reply
+// assembly — lives in the `runtime` module, gated once by `feature = "runtime"`;
+// the `#[actor] impl` reaches all of it through the single `use runtime::*` glob.
+use aether_actor::actor;
+
+// The `runtime` module is this cap's private runtime-half namespace; the impl
+// reaches all of it (state, ctx types, gate/reply helpers) through this single
+// seam, so the glob is intentional rather than a dozen one-line imports.
+#[cfg(feature = "runtime")]
+#[allow(clippy::wildcard_imports)]
+use runtime::*;
+
+#[cfg(feature = "runtime")]
+mod runtime;
+
+#[actor(singleton)]
+impl NativeActor for AnthropicCapability {
+    /// The runtime state this identity boots into (ADR-0122 split): the
+    /// state-bearing struct holding the adapter + the rate-limit queue.
+    type State = AnthropicCapabilityState;
+
+    type Config = AnthropicConfig;
+
+    /// ADR-0050 + ADR-0074 Phase 5 chassis-owned mailbox.
+    const NAMESPACE: &'static str = "aether.anthropic";
+
+    /// Build the adapter from the resolved config and capture the
+    /// mailer + own mailbox so the spawn-and-die helper can land
+    /// loopback result mails. The adapter is built immediately so a
+    /// key-absent boot still loads (replying Unauthorized) rather
+    /// than warn-dropping.
+    fn init(
+        config: AnthropicConfig,
+        _ctx: &mut NativeInitCtx<'_>,
+    ) -> Result<AnthropicCapabilityState, BootError> {
+        Ok(AnthropicCapabilityState {
+            adapter: build_adapter(&config),
+            tasks: TaskQueue::new(config.max_in_flight),
+        })
+    }
+
+    /// Run a Messages-API completion off the dispatcher thread.
+    ///
+    /// # Agent
+    /// Reply: `MessagesSendResult`. Validates `model` against the
+    /// supported table synchronously (`UnknownModel` on a miss),
+    /// then dispatches the blocking HTTPS call on an ephemeral
+    /// thread; the reply lands when the call returns.
+    #[handler::manual]
+    fn on_messages_send(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_, Manual>,
+        mail: MessagesSend,
+    ) {
+        let request_id = mail.request_id;
+        if !state.gate_model(ctx, SendPath::Messages, request_id, &mail.model) {
+            return;
+        }
+        let req = AnthropicRequest {
+            prompt: flatten_prompt(&mail.messages),
+            model: mail.model,
+            system: mail.system,
+            max_tokens: mail.max_tokens,
+            temperature: mail.temperature,
+        };
+        let adapter = Arc::clone(&state.adapter);
+        state.tasks.submit(ctx, move || {
+            let result = adapter.messages_send(req);
+            messages_reply(request_id, result)
+        });
+    }
+
+    /// Run a `claude`-subprocess completion off the dispatcher
+    /// thread.
+    ///
+    /// # Agent
+    /// Reply: `CliSendResult`. Replies `Err { CliNotFound }` when
+    /// `claude` isn't on PATH. The CLI uses the user's subscription,
+    /// so it works even when `ANTHROPIC_API_KEY` is unset. The
+    /// `claude` binary exposes no `--max-tokens` / `--temperature`
+    /// flag, so setting either replies `Err { ParamNotSupported }`
+    /// synchronously (no dispatch) rather than silently dropping it —
+    /// route sampling knobs through `aether.anthropic.messages.send`.
+    #[handler::manual]
+    fn on_cli_send(state: &mut Self::State, ctx: &mut NativeCtx<'_, Manual>, mail: CliSend) {
+        // The `claude` CLI has no flag for either knob; reject when
+        // set instead of silently dropping (the outcome to avoid —
+        // `feedback_explicit_nulls_over_absent_fields`).
+        let mut unsupported = Vec::new();
+        if mail.max_tokens.is_some() {
+            unsupported.push("max_tokens");
+        }
+        if mail.temperature.is_some() {
+            unsupported.push("temperature");
+        }
+        if !unsupported.is_empty() {
+            let error = AnthropicError::ParamNotSupported {
+                param: unsupported.join(", "),
+                reason: "the claude CLI has no flag for this; use aether.anthropic.messages.send"
+                    .to_string(),
+            };
+            AnthropicCapabilityState::reply_err(ctx, SendPath::Cli, mail.request_id, error);
+            return;
+        }
+        let request_id = mail.request_id;
+        // CLI passes the model through to `claude` (no gate), so no
+        // `gate_model` call here.
+        let req = AnthropicRequest {
+            prompt: flatten_prompt(&mail.messages),
+            model: mail.model,
+            system: mail.system,
+            max_tokens: mail.max_tokens,
+            temperature: mail.temperature,
+        };
+        let adapter = Arc::clone(&state.adapter);
+        state.tasks.submit(ctx, move || {
+            let result = adapter.cli_send(req);
+            cli_reply(request_id, result)
+        });
+    }
+
+    /// ADR-0093 completion for a finished Messages call: re-reply the
+    /// worker's result to the original caller (drops the hold), then
+    /// free the in-flight slot (draining the next pending request).
+    #[handler(task)]
+    fn on_messages_done(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        done: TaskDone<MessagesSendResult>,
+    ) {
+        done.resolve(ctx);
+        state.tasks.on_complete(ctx);
+    }
+
+    /// ADR-0093 completion for a finished CLI call.
+    #[handler(task)]
+    fn on_cli_done(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        done: TaskDone<CliSendResult>,
+    ) {
+        done.resolve(ctx);
+        state.tasks.on_complete(ctx);
+    }
+}
+
+#[cfg(all(test, feature = "runtime"))]
+mod tests {
+    use super::runtime::AnthropicCapabilityState;
+    use super::{AnthropicAdapter, AnthropicConfig, ClaudeCliAdapter, DisabledAnthropicAdapter};
     use super::{
-        AnthropicAdapter, AnthropicConfig, AnthropicRequest, CliSend, CliSendResult,
-        CombinedAnthropicAdapter, DisabledAnthropicAdapter, MessagesSend, MessagesSendResult,
-        map_adapter_error,
+        AnthropicCapability, AnthropicError, CliSend, CliSendResult, Message, MessagesSend,
+        MessagesSendResult, Role,
     };
-    use crate::shared::contentgen::adapter::{AdapterUsage, AnthropicResponse};
-    use crate::shared::contentgen::task_queue::TaskQueue;
-    use aether_actor::{Manual, OutboundReply, actor};
-    use aether_kinds::Usage;
+    use crate::shared::contentgen::adapter::{
+        AnthropicRequest, AnthropicResponse, StubAnthropicAdapter,
+    };
+    use crate::test_chassis::{
+        TestChassis, decode_session_reply, drive_task_completion, fresh_substrate,
+        test_mailer_and_rx,
+    };
+    use aether_actor::Addressable;
+    use aether_data::{Kind, MailboxId, SessionToken, Source, SourceAddr, Uuid};
+    use aether_substrate::actor::native::binding::NativeBinding;
+    use aether_substrate::actor::native::ctx::NativeCtx;
+    use aether_substrate::chassis::builder::Builder;
+    use aether_substrate::mail::mailer::Mailer;
+    use aether_substrate::mail::outbound::EgressEvent;
+    use serde::de::DeserializeOwned;
+    use std::sync::Arc;
+    use std::sync::mpsc::Receiver;
+    use std::time::Duration;
 
-    use super::kinds::{AnthropicError, Message, Role};
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
-    use aether_substrate::chassis::error::BootError;
-
-    /// Which send path a request rode. The generate handler threads it
-    /// into the worker closure to pick the blocking call + result kind.
-    #[derive(Copy, Clone)]
-    enum SendPath {
-        Messages,
-        Cli,
+    fn session_sender() -> Source {
+        Source::to(SourceAddr::Session(SessionToken(Uuid::nil())))
     }
 
-    /// `aether.anthropic` mailbox cap. Owns the resolved adapter and the
-    /// cap-level rate-limit queue over the ADR-0093 dispatch primitive.
-    /// Single-threaded post-ADR-0038, so the queue state lives in plain
-    /// fields with no lock.
-    pub struct AnthropicCapability {
-        adapter: Arc<dyn AnthropicAdapter>,
-        tasks: TaskQueue,
+    fn user_msg(text: &str) -> Vec<Message> {
+        vec![Message {
+            role: Role::User,
+            content: text.to_string(),
+        }]
     }
 
-    #[cfg(test)]
-    impl AnthropicCapability {
-        /// Test-only constructor. Production boots through
-        /// `Builder::with_actor::<AnthropicCapability>(config)`; tests
-        /// hand in a stub adapter directly.
-        pub(crate) fn from_parts(adapter: Arc<dyn AnthropicAdapter>, max_in_flight: usize) -> Self {
-            Self {
-                adapter,
-                tasks: TaskQueue::new(max_in_flight),
-            }
-        }
+    /// Thin alias over the shared `decode_session_reply` so call
+    /// sites stay terse.
+    fn decode_reply<K: Kind + DeserializeOwned>(rx: &Receiver<EgressEvent>) -> K {
+        decode_session_reply(rx)
+    }
 
-        /// White-box accessor for tests asserting the queue's in-flight
-        /// counter (e.g. that a synchronous validation error never spawned
-        /// work).
-        pub(crate) fn test_in_flight(&self) -> usize {
-            self.tasks.in_flight()
+    /// Adapter that records the prompt it saw and returns canned text.
+    struct RecordingStub {
+        inner: StubAnthropicAdapter,
+    }
+
+    impl AnthropicAdapter for RecordingStub {
+        fn messages_send(&self, req: AnthropicRequest) -> Result<AnthropicResponse, String> {
+            self.inner.messages_send(req)
+        }
+        fn cli_send(&self, req: AnthropicRequest) -> Result<AnthropicResponse, String> {
+            self.inner.cli_send(req)
+        }
+        fn supported_models(&self) -> Vec<String> {
+            vec!["claude-test".to_string()]
         }
     }
 
-    fn build_adapter(config: &AnthropicConfig) -> Arc<dyn AnthropicAdapter> {
-        if config.disabled {
-            tracing::info!(
-                target: "aether_capabilities::anthropic",
-                "anthropic adapter disabled — messages reply Unauthorized; cli still routes",
-            );
-            return Arc::new(DisabledAnthropicAdapter::new(config.timeout));
-        }
-        config.api_key.as_ref().map_or_else(
-            || {
-                tracing::info!(
-                    target: "aether_capabilities::anthropic",
-                    "ANTHROPIC_API_KEY unset — messages reply Unauthorized; cli still routes",
-                );
-                Arc::new(DisabledAnthropicAdapter::new(config.timeout)) as Arc<dyn AnthropicAdapter>
+    /// Boot the cap against a default (key-absent) config and confirm
+    /// the mailbox registers.
+    #[test]
+    fn capability_boots_and_registers_mailbox() {
+        let (registry, mailer) = fresh_substrate();
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<AnthropicCapability>(AnthropicConfig::default())
+            .build_passive()
+            .expect("anthropic capability boots");
+        assert!(
+            registry.lookup(AnthropicCapability::NAMESPACE).is_some(),
+            "anthropic mailbox registered"
+        );
+        drop(chassis);
+    }
+
+    /// Drive a stub Messages request end-to-end through the ADR-0093
+    /// dispatch primitive: the cap submits to the `TaskQueue`, the real
+    /// worker runs the stub call, pushes a completion wake, and the
+    /// cap's `#[handler(task)]` re-replies the `Ok` to the caller.
+    #[test]
+    fn anthropic_stub_messages() {
+        let (mailer, rx) = test_mailer_and_rx();
+        let cap_mailbox = MailboxId(0);
+        let mut state = AnthropicCapabilityState::from_parts(
+            Arc::new(RecordingStub {
+                inner: StubAnthropicAdapter::default(),
+            }),
+            4,
+        );
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            cap_mailbox,
+        ));
+        let mut ctx = NativeCtx::new_dispatching(
+            &transport,
+            session_sender(),
+            aether_data::MailId::NONE,
+            aether_data::MailId::NONE,
+        );
+        AnthropicCapability::on_messages_send(
+            &mut state,
+            &mut ctx,
+            MessagesSend {
+                request_id: 7,
+                model: "claude-test".to_string(),
+                messages: user_msg("hi"),
+                max_tokens: Some(8),
+                temperature: None,
+                system: None,
             },
-            |key| {
-                tracing::info!(
-                    target: "aether_capabilities::anthropic",
-                    "anthropic adapter configured (messages + cli)",
-                );
-                Arc::new(CombinedAnthropicAdapter::new(key.clone(), config.timeout))
-                    as Arc<dyn AnthropicAdapter>
+        );
+        // The worker runs the stub call and pushes the completion wake;
+        // route it through the cap's task handler.
+        drive_task_completion::<AnthropicCapability>(&mut state, &transport, &rx);
+        match decode_reply::<MessagesSendResult>(&rx) {
+            MessagesSendResult::Ok {
+                request_id, text, ..
+            } => {
+                assert_eq!(request_id, 7);
+                assert_eq!(text, "stub completion");
+            }
+            other @ MessagesSendResult::Err { .. } => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    /// Unknown model errors synchronously, before any dispatch.
+    #[test]
+    fn anthropic_unknown_model_errors() {
+        let (mailer, rx) = test_mailer_and_rx();
+        let cap_mailbox = MailboxId(0);
+        let mut state = AnthropicCapabilityState::from_parts(
+            Arc::new(RecordingStub {
+                inner: StubAnthropicAdapter::default(),
+            }),
+            4,
+        );
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            cap_mailbox,
+        ));
+        let mut ctx = NativeCtx::new_dispatching(
+            &transport,
+            session_sender(),
+            aether_data::MailId::NONE,
+            aether_data::MailId::NONE,
+        );
+        AnthropicCapability::on_messages_send(
+            &mut state,
+            &mut ctx,
+            MessagesSend {
+                request_id: 3,
+                model: "claude-bogus".to_string(),
+                messages: user_msg("hi"),
+                max_tokens: None,
+                temperature: None,
+                system: None,
             },
-        )
-    }
-
-    /// Flatten the conversation into a single prompt string. v1 doesn't
-    /// model multi-turn API content; it concatenates the user/assistant
-    /// turns so the adapter sees one prompt.
-    fn flatten_prompt(messages: &[Message]) -> String {
-        messages
-            .iter()
-            .map(|m| {
-                let speaker = match m.role {
-                    Role::User => "User",
-                    Role::Assistant => "Assistant",
-                };
-                format!("{speaker}: {}", m.content)
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
-    }
-
-    impl AnthropicCapability {
-        /// Gate a request's model before any dispatch. Returns `false`
-        /// (after replying `UnknownModel`) when the Messages path's
-        /// supported-model table rejects it; `true` to proceed. Empty
-        /// `supported` = accept-any (disabled / CLI passthrough); the CLI
-        /// path always passes through.
-        fn gate_model(
-            &self,
-            ctx: &mut NativeCtx<'_, Manual>,
-            path: SendPath,
-            request_id: u64,
-            model: &str,
-        ) -> bool {
-            let supported = self.adapter.supported_models();
-            let gate = matches!(path, SendPath::Messages) && !supported.is_empty();
-            if gate && !supported.iter().any(|m| m == model) {
-                let err = AnthropicError::UnknownModel {
-                    model: model.to_string(),
-                    supported,
-                };
-                Self::reply_err(ctx, path, request_id, err);
-                return false;
-            }
-            true
-        }
-
-        /// Reply an `Err` synchronously (model validation failure)
-        /// before any dispatch.
-        fn reply_err(
-            ctx: &mut NativeCtx<'_, Manual>,
-            path: SendPath,
-            request_id: u64,
-            error: AnthropicError,
-        ) {
-            match path {
-                SendPath::Messages => {
-                    OutboundReply::reply(ctx, &MessagesSendResult::Err { request_id, error });
-                }
-                SendPath::Cli => {
-                    OutboundReply::reply(ctx, &CliSendResult::Err { request_id, error });
-                }
-            }
-        }
-    }
-
-    fn to_usage(u: AdapterUsage) -> Usage {
-        Usage {
-            input_tokens: u.input_tokens,
-            output_tokens: u.output_tokens,
-            wall_clock_ms: u.wall_clock_ms,
-            cost_micros: u.cost_micros,
-        }
-    }
-
-    fn messages_reply(
-        request_id: u64,
-        result: Result<AnthropicResponse, String>,
-    ) -> MessagesSendResult {
-        match result {
-            Ok(resp) => MessagesSendResult::Ok {
+        );
+        match decode_reply::<MessagesSendResult>(&rx) {
+            MessagesSendResult::Err {
                 request_id,
-                text: resp.text,
-                model_used: resp.model_used,
-                usage: to_usage(resp.usage),
-            },
-            Err(raw) => MessagesSendResult::Err {
-                request_id,
-                error: map_adapter_error(&raw),
-            },
+                error: AnthropicError::UnknownModel { model, supported },
+            } => {
+                assert_eq!(request_id, 3);
+                assert_eq!(model, "claude-bogus");
+                assert!(supported.contains(&"claude-test".to_string()));
+            }
+            other => panic!("expected UnknownModel, got {other:?}"),
         }
+        // No in-flight work was spawned — the synchronous error path
+        // never touched the dispatch helper.
+        assert_eq!(cap_in_flight(&state), 0);
     }
 
-    fn cli_reply(request_id: u64, result: Result<AnthropicResponse, String>) -> CliSendResult {
-        match result {
-            Ok(resp) => CliSendResult::Ok {
-                request_id,
-                text: resp.text,
-                model_used: resp.model_used,
-                usage: to_usage(resp.usage),
+    /// Boot a cap against the recording stub and fire a `CliSend`
+    /// carrying the given knobs at `on_cli_send`, returning the state so
+    /// the caller can assert `test_in_flight()`. The reply lands on
+    /// the `mailer`'s loopback rx (held separately by the caller).
+    fn cli_send_with(
+        mailer: &Arc<Mailer>,
+        max_tokens: Option<u32>,
+        temperature: Option<f32>,
+    ) -> AnthropicCapabilityState {
+        let cap_mailbox = MailboxId(0);
+        let mut state = AnthropicCapabilityState::from_parts(
+            Arc::new(RecordingStub {
+                inner: StubAnthropicAdapter::default(),
+            }),
+            4,
+        );
+        let transport = Arc::new(NativeBinding::new_for_test(Arc::clone(mailer), cap_mailbox));
+        let mut ctx = NativeCtx::new_dispatching(
+            &transport,
+            session_sender(),
+            aether_data::MailId::NONE,
+            aether_data::MailId::NONE,
+        );
+        AnthropicCapability::on_cli_send(
+            &mut state,
+            &mut ctx,
+            CliSend {
+                request_id: 11,
+                model: "claude-test".to_string(),
+                messages: user_msg("hi"),
+                max_tokens,
+                temperature,
+                system: None,
             },
-            Err(raw) => CliSendResult::Err {
-                request_id,
-                error: map_adapter_error(&raw),
-            },
-        }
+        );
+        state
     }
 
-    #[actor]
-    impl NativeActor for AnthropicCapability {
-        type Config = AnthropicConfig;
-
-        /// ADR-0050 + ADR-0074 Phase 5 chassis-owned mailbox.
-        const NAMESPACE: &'static str = "aether.anthropic";
-
-        /// Build the adapter from the resolved config and capture the
-        /// mailer + own mailbox so the spawn-and-die helper can land
-        /// loopback result mails. The adapter is built immediately so a
-        /// key-absent boot still loads (replying Unauthorized) rather
-        /// than warn-dropping.
-        fn init(config: AnthropicConfig, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            Ok(Self {
-                adapter: build_adapter(&config),
-                tasks: TaskQueue::new(config.max_in_flight),
-            })
-        }
-
-        /// Run a Messages-API completion off the dispatcher thread.
-        ///
-        /// # Agent
-        /// Reply: `MessagesSendResult`. Validates `model` against the
-        /// supported table synchronously (`UnknownModel` on a miss),
-        /// then dispatches the blocking HTTPS call on an ephemeral
-        /// thread; the reply lands when the call returns.
-        #[handler::manual]
-        fn on_messages_send(&mut self, ctx: &mut NativeCtx<'_, Manual>, mail: MessagesSend) {
-            let request_id = mail.request_id;
-            if !self.gate_model(ctx, SendPath::Messages, request_id, &mail.model) {
-                return;
+    /// `on_cli_send` with `max_tokens` set replies
+    /// `Err { ParamNotSupported }` synchronously and spawns no work —
+    /// the `claude` CLI has no flag to honor it.
+    #[test]
+    fn anthropic_cli_rejects_max_tokens() {
+        let (mailer, rx) = test_mailer_and_rx();
+        let state = cli_send_with(&mailer, Some(256), None);
+        match decode_reply::<CliSendResult>(&rx) {
+            CliSendResult::Err {
+                request_id,
+                error: AnthropicError::ParamNotSupported { param, reason },
+            } => {
+                assert_eq!(request_id, 11);
+                assert!(param.contains("max_tokens"), "param was {param:?}");
+                assert!(reason.contains("messages.send"), "reason was {reason:?}");
             }
-            let req = AnthropicRequest {
-                prompt: flatten_prompt(&mail.messages),
-                model: mail.model,
-                system: mail.system,
-                max_tokens: mail.max_tokens,
-                temperature: mail.temperature,
-            };
-            let adapter = Arc::clone(&self.adapter);
-            self.tasks.submit(ctx, move || {
-                let result = adapter.messages_send(req);
-                messages_reply(request_id, result)
-            });
+            other => panic!("expected ParamNotSupported, got {other:?}"),
         }
-
-        /// Run a `claude`-subprocess completion off the dispatcher
-        /// thread.
-        ///
-        /// # Agent
-        /// Reply: `CliSendResult`. Replies `Err { CliNotFound }` when
-        /// `claude` isn't on PATH. The CLI uses the user's subscription,
-        /// so it works even when `ANTHROPIC_API_KEY` is unset. The
-        /// `claude` binary exposes no `--max-tokens` / `--temperature`
-        /// flag, so setting either replies `Err { ParamNotSupported }`
-        /// synchronously (no dispatch) rather than silently dropping it —
-        /// route sampling knobs through `aether.anthropic.messages.send`.
-        #[handler::manual]
-        fn on_cli_send(&mut self, ctx: &mut NativeCtx<'_, Manual>, mail: CliSend) {
-            // The `claude` CLI has no flag for either knob; reject when
-            // set instead of silently dropping (the outcome to avoid —
-            // `feedback_explicit_nulls_over_absent_fields`).
-            let mut unsupported = Vec::new();
-            if mail.max_tokens.is_some() {
-                unsupported.push("max_tokens");
-            }
-            if mail.temperature.is_some() {
-                unsupported.push("temperature");
-            }
-            if !unsupported.is_empty() {
-                let error = AnthropicError::ParamNotSupported {
-                    param: unsupported.join(", "),
-                    reason:
-                        "the claude CLI has no flag for this; use aether.anthropic.messages.send"
-                            .to_string(),
-                };
-                Self::reply_err(ctx, SendPath::Cli, mail.request_id, error);
-                return;
-            }
-            let request_id = mail.request_id;
-            // CLI passes the model through to `claude` (no gate), so no
-            // `gate_model` call here.
-            let req = AnthropicRequest {
-                prompt: flatten_prompt(&mail.messages),
-                model: mail.model,
-                system: mail.system,
-                max_tokens: mail.max_tokens,
-                temperature: mail.temperature,
-            };
-            let adapter = Arc::clone(&self.adapter);
-            self.tasks.submit(ctx, move || {
-                let result = adapter.cli_send(req);
-                cli_reply(request_id, result)
-            });
-        }
-
-        /// ADR-0093 completion for a finished Messages call: re-reply the
-        /// worker's result to the original caller (drops the hold), then
-        /// free the in-flight slot (draining the next pending request).
-        #[handler(task)]
-        fn on_messages_done(
-            &mut self,
-            ctx: &mut NativeCtx<'_>,
-            done: TaskDone<MessagesSendResult>,
-        ) {
-            done.resolve(ctx);
-            self.tasks.on_complete(ctx);
-        }
-
-        /// ADR-0093 completion for a finished CLI call.
-        #[handler(task)]
-        fn on_cli_done(&mut self, ctx: &mut NativeCtx<'_>, done: TaskDone<CliSendResult>) {
-            done.resolve(ctx);
-            self.tasks.on_complete(ctx);
-        }
+        // Synchronous error path never touched the dispatch helper.
+        assert_eq!(cap_in_flight(&state), 0);
     }
 
-    #[cfg(test)]
-    mod tests {
-        use super::super::{
-            AnthropicAdapter, AnthropicConfig, ClaudeCliAdapter, DisabledAnthropicAdapter,
-        };
-        use super::super::{
-            AnthropicError, CliSend, CliSendResult, Message, MessagesSend, MessagesSendResult, Role,
-        };
-        use super::AnthropicCapability;
-        use crate::shared::contentgen::adapter::{
-            AnthropicRequest, AnthropicResponse, StubAnthropicAdapter,
-        };
-        use crate::test_chassis::{
-            TestChassis, decode_session_reply, drive_task_completion, fresh_substrate,
-            test_mailer_and_rx,
-        };
-        use aether_actor::Addressable;
-        use aether_data::{Kind, MailboxId, SessionToken, Source, SourceAddr, Uuid};
-        use aether_substrate::actor::native::binding::NativeBinding;
-        use aether_substrate::actor::native::ctx::NativeCtx;
-        use aether_substrate::chassis::builder::Builder;
-        use aether_substrate::mail::mailer::Mailer;
-        use aether_substrate::mail::outbound::EgressEvent;
-        use serde::de::DeserializeOwned;
-        use std::sync::Arc;
-        use std::sync::mpsc::Receiver;
-        use std::time::Duration;
-
-        fn session_sender() -> Source {
-            Source::to(SourceAddr::Session(SessionToken(Uuid::nil())))
+    /// `on_cli_send` with `temperature` set replies
+    /// `Err { ParamNotSupported }` synchronously and spawns no work.
+    #[test]
+    fn anthropic_cli_rejects_temperature() {
+        let (mailer, rx) = test_mailer_and_rx();
+        let state = cli_send_with(&mailer, None, Some(0.7));
+        match decode_reply::<CliSendResult>(&rx) {
+            CliSendResult::Err {
+                request_id,
+                error: AnthropicError::ParamNotSupported { param, .. },
+            } => {
+                assert_eq!(request_id, 11);
+                assert!(param.contains("temperature"), "param was {param:?}");
+            }
+            other => panic!("expected ParamNotSupported, got {other:?}"),
         }
+        assert_eq!(cap_in_flight(&state), 0);
+    }
 
-        fn user_msg(text: &str) -> Vec<Message> {
-            vec![Message {
-                role: Role::User,
-                content: text.to_string(),
-            }]
+    /// A `CliSend` with both knobs `None` dispatches normally — the
+    /// synchronous reject path is skipped and work is spawned.
+    #[test]
+    fn anthropic_cli_no_params_dispatches() {
+        let (mailer, _rx) = test_mailer_and_rx();
+        let state = cli_send_with(&mailer, None, None);
+        assert_eq!(
+            cap_in_flight(&state),
+            1,
+            "a param-free CliSend should dispatch one in-flight call"
+        );
+    }
+
+    /// CLI send with a missing `claude` binary replies
+    /// `Err { CliNotFound }` — a graceful skip, not a hang.
+    #[test]
+    fn anthropic_cli_skips_when_no_claude_on_path() {
+        // A disabled adapter routes CLI through the real subprocess
+        // backend; pointing it at a missing binary exercises the
+        // CliNotFound path without depending on the host's `claude`.
+        struct MissingCliAdapter {
+            cli: ClaudeCliAdapter,
         }
-
-        /// Thin alias over the shared `decode_session_reply` so call
-        /// sites stay terse.
-        fn decode_reply<K: Kind + DeserializeOwned>(rx: &Receiver<EgressEvent>) -> K {
-            decode_session_reply(rx)
-        }
-
-        /// Adapter that records the prompt it saw and returns canned text.
-        struct RecordingStub {
-            inner: StubAnthropicAdapter,
-        }
-
-        impl AnthropicAdapter for RecordingStub {
-            fn messages_send(&self, req: AnthropicRequest) -> Result<AnthropicResponse, String> {
-                self.inner.messages_send(req)
+        impl AnthropicAdapter for MissingCliAdapter {
+            fn messages_send(&self, _req: AnthropicRequest) -> Result<AnthropicResponse, String> {
+                Err(super::error::UNAUTHORIZED_SENTINEL.to_string())
             }
             fn cli_send(&self, req: AnthropicRequest) -> Result<AnthropicResponse, String> {
-                self.inner.cli_send(req)
-            }
-            fn supported_models(&self) -> Vec<String> {
-                vec!["claude-test".to_string()]
+                self.cli.cli_send(&req)
             }
         }
 
-        /// Boot the cap against a default (key-absent) config and confirm
-        /// the mailbox registers.
-        #[test]
-        fn capability_boots_and_registers_mailbox() {
-            let (registry, mailer) = fresh_substrate();
-            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-                .with_actor::<AnthropicCapability>(AnthropicConfig::default())
-                .build_passive()
-                .expect("anthropic capability boots");
-            assert!(
-                registry.lookup(AnthropicCapability::NAMESPACE).is_some(),
-                "anthropic mailbox registered"
-            );
-            drop(chassis);
-        }
-
-        /// Drive a stub Messages request end-to-end through the ADR-0093
-        /// dispatch primitive: the cap submits to the `TaskQueue`, the real
-        /// worker runs the stub call, pushes a completion wake, and the
-        /// cap's `#[handler(task)]` re-replies the `Ok` to the caller.
-        #[test]
-        fn anthropic_stub_messages() {
-            let (mailer, rx) = test_mailer_and_rx();
-            let cap_mailbox = MailboxId(0);
-            let mut cap = AnthropicCapability::from_parts(
-                Arc::new(RecordingStub {
-                    inner: StubAnthropicAdapter::default(),
-                }),
-                4,
-            );
-            let transport = Arc::new(NativeBinding::new_for_test(
-                Arc::clone(&mailer),
-                cap_mailbox,
-            ));
-            let mut ctx = NativeCtx::new_dispatching(
-                &transport,
-                session_sender(),
-                aether_data::MailId::NONE,
-                aether_data::MailId::NONE,
-            );
-            cap.on_messages_send(
-                &mut ctx,
-                MessagesSend {
-                    request_id: 7,
-                    model: "claude-test".to_string(),
-                    messages: user_msg("hi"),
-                    max_tokens: Some(8),
-                    temperature: None,
-                    system: None,
-                },
-            );
-            // The worker runs the stub call and pushes the completion wake;
-            // route it through the cap's task handler.
-            drive_task_completion(&mut cap, &transport, &rx);
-            match decode_reply::<MessagesSendResult>(&rx) {
-                MessagesSendResult::Ok {
-                    request_id, text, ..
-                } => {
-                    assert_eq!(request_id, 7);
-                    assert_eq!(text, "stub completion");
-                }
-                other @ MessagesSendResult::Err { .. } => panic!("expected Ok, got {other:?}"),
+        let (mailer, rx) = test_mailer_and_rx();
+        let cap_mailbox = MailboxId(0);
+        let mut state = AnthropicCapabilityState::from_parts(
+            Arc::new(MissingCliAdapter {
+                cli: ClaudeCliAdapter::new(
+                    "aether-nonexistent-claude-binary-xyzzy".to_string(),
+                    Duration::from_secs(30),
+                ),
+            }),
+            4,
+        );
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            cap_mailbox,
+        ));
+        let mut ctx = NativeCtx::new_dispatching(
+            &transport,
+            session_sender(),
+            aether_data::MailId::NONE,
+            aether_data::MailId::NONE,
+        );
+        AnthropicCapability::on_cli_send(
+            &mut state,
+            &mut ctx,
+            CliSend {
+                request_id: 5,
+                model: "claude-test".to_string(),
+                messages: user_msg("hi"),
+                max_tokens: None,
+                temperature: None,
+                system: None,
+            },
+        );
+        // The CLI backend runs on the real worker against a missing
+        // binary, yielding CliNotFound; route the completion through the
+        // cap's task handler.
+        drive_task_completion::<AnthropicCapability>(&mut state, &transport, &rx);
+        match decode_reply::<CliSendResult>(&rx) {
+            CliSendResult::Err {
+                request_id,
+                error: AnthropicError::CliNotFound,
+            } => {
+                assert_eq!(request_id, 5);
             }
+            other => panic!("expected CliNotFound, got {other:?}"),
         }
+    }
 
-        /// Unknown model errors synchronously, before any dispatch.
-        #[test]
-        fn anthropic_unknown_model_errors() {
-            let (mailer, rx) = test_mailer_and_rx();
-            let cap_mailbox = MailboxId(0);
-            let mut cap = AnthropicCapability::from_parts(
-                Arc::new(RecordingStub {
-                    inner: StubAnthropicAdapter::default(),
-                }),
-                4,
-            );
-            let transport = Arc::new(NativeBinding::new_for_test(
-                Arc::clone(&mailer),
-                cap_mailbox,
-            ));
-            let mut ctx = NativeCtx::new_dispatching(
-                &transport,
-                session_sender(),
-                aether_data::MailId::NONE,
-                aether_data::MailId::NONE,
-            );
-            cap.on_messages_send(
-                &mut ctx,
-                MessagesSend {
-                    request_id: 3,
-                    model: "claude-bogus".to_string(),
-                    messages: user_msg("hi"),
-                    max_tokens: None,
-                    temperature: None,
-                    system: None,
-                },
-            );
-            match decode_reply::<MessagesSendResult>(&rx) {
-                MessagesSendResult::Err {
-                    request_id,
-                    error: AnthropicError::UnknownModel { model, supported },
-                } => {
-                    assert_eq!(request_id, 3);
-                    assert_eq!(model, "claude-bogus");
-                    assert!(supported.contains(&"claude-test".to_string()));
-                }
-                other => panic!("expected UnknownModel, got {other:?}"),
-            }
-            // No in-flight work was spawned — the synchronous error path
-            // never touched the dispatch helper.
-            assert_eq!(cap_in_flight(&cap), 0);
+    /// Disabled adapter replies `Unauthorized` to a Messages request.
+    #[test]
+    fn anthropic_disabled_messages_replies_unauthorized() {
+        let (mailer, rx) = test_mailer_and_rx();
+        let cap_mailbox = MailboxId(0);
+        let mut state =
+            AnthropicCapabilityState::from_parts(Arc::new(DisabledAnthropicAdapter::default()), 4);
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            cap_mailbox,
+        ));
+        let mut ctx = NativeCtx::new_dispatching(
+            &transport,
+            session_sender(),
+            aether_data::MailId::NONE,
+            aether_data::MailId::NONE,
+        );
+        AnthropicCapability::on_messages_send(
+            &mut state,
+            &mut ctx,
+            MessagesSend {
+                request_id: 9,
+                model: "claude-anything".to_string(),
+                messages: user_msg("hi"),
+                max_tokens: None,
+                temperature: None,
+                system: None,
+            },
+        );
+        // Disabled adapter has an empty supported-models table, so the
+        // model gate is skipped and the request dispatches; the worker
+        // produces the Unauthorized result. Route the completion through
+        // the cap's task handler.
+        drive_task_completion::<AnthropicCapability>(&mut state, &transport, &rx);
+        match decode_reply::<MessagesSendResult>(&rx) {
+            MessagesSendResult::Err {
+                request_id,
+                error: AnthropicError::Unauthorized,
+            } => assert_eq!(request_id, 9),
+            other => panic!("expected Unauthorized, got {other:?}"),
         }
+    }
 
-        /// Boot a cap against the recording stub and fire a `CliSend`
-        /// carrying the given knobs at `on_cli_send`, returning the cap so
-        /// the caller can assert `test_in_flight()`. The reply lands on
-        /// the `mailer`'s loopback rx (held separately by the caller).
-        fn cli_send_with(
-            mailer: &Arc<Mailer>,
-            max_tokens: Option<u32>,
-            temperature: Option<f32>,
-        ) -> AnthropicCapability {
-            let cap_mailbox = MailboxId(0);
-            let mut cap = AnthropicCapability::from_parts(
-                Arc::new(RecordingStub {
-                    inner: StubAnthropicAdapter::default(),
-                }),
-                4,
-            );
-            let transport = Arc::new(NativeBinding::new_for_test(Arc::clone(mailer), cap_mailbox));
-            let mut ctx = NativeCtx::new_dispatching(
-                &transport,
-                session_sender(),
-                aether_data::MailId::NONE,
-                aether_data::MailId::NONE,
-            );
-            cap.on_cli_send(
-                &mut ctx,
-                CliSend {
-                    request_id: 11,
-                    model: "claude-test".to_string(),
-                    messages: user_msg("hi"),
-                    max_tokens,
-                    temperature,
-                    system: None,
-                },
-            );
-            cap
-        }
+    /// Real-API smoke. Hits the live Messages API with a tiny
+    /// 5-`max_tokens` request — ignored by default so CI stays
+    /// zero-cost; run with `ANTHROPIC_API_KEY` set.
+    #[test]
+    #[ignore = "needs ANTHROPIC_API_KEY"]
+    fn anthropic_api_smoke() {
+        use super::UreqAnthropicAdapter;
+        use crate::shared::contentgen::adapter::AnthropicRequest;
+        use std::env;
+        // Test-only: the live-API smoke reads an external credential
+        // (ANTHROPIC_API_KEY), not cap config; gated `#[ignore]`.
+        #[allow(clippy::disallowed_methods)]
+        let key = env::var("ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY set for smoke");
+        let adapter = UreqAnthropicAdapter::new(key, Duration::from_secs(30));
+        let resp = adapter
+            .messages_send(&AnthropicRequest {
+                model: "claude-haiku-4-5-20251001".to_string(),
+                prompt: "say hi".to_string(),
+                system: None,
+                max_tokens: Some(5),
+                temperature: None,
+            })
+            .expect("live messages request succeeds");
+        assert!(!resp.text.is_empty());
+    }
 
-        /// `on_cli_send` with `max_tokens` set replies
-        /// `Err { ParamNotSupported }` synchronously and spawns no work —
-        /// the `claude` CLI has no flag to honor it.
-        #[test]
-        fn anthropic_cli_rejects_max_tokens() {
-            let (mailer, rx) = test_mailer_and_rx();
-            let cap = cli_send_with(&mailer, Some(256), None);
-            match decode_reply::<CliSendResult>(&rx) {
-                CliSendResult::Err {
-                    request_id,
-                    error: AnthropicError::ParamNotSupported { param, reason },
-                } => {
-                    assert_eq!(request_id, 11);
-                    assert!(param.contains("max_tokens"), "param was {param:?}");
-                    assert!(reason.contains("messages.send"), "reason was {reason:?}");
-                }
-                other => panic!("expected ParamNotSupported, got {other:?}"),
-            }
-            // Synchronous error path never touched the dispatch helper.
-            assert_eq!(cap_in_flight(&cap), 0);
-        }
-
-        /// `on_cli_send` with `temperature` set replies
-        /// `Err { ParamNotSupported }` synchronously and spawns no work.
-        #[test]
-        fn anthropic_cli_rejects_temperature() {
-            let (mailer, rx) = test_mailer_and_rx();
-            let cap = cli_send_with(&mailer, None, Some(0.7));
-            match decode_reply::<CliSendResult>(&rx) {
-                CliSendResult::Err {
-                    request_id,
-                    error: AnthropicError::ParamNotSupported { param, .. },
-                } => {
-                    assert_eq!(request_id, 11);
-                    assert!(param.contains("temperature"), "param was {param:?}");
-                }
-                other => panic!("expected ParamNotSupported, got {other:?}"),
-            }
-            assert_eq!(cap_in_flight(&cap), 0);
-        }
-
-        /// A `CliSend` with both knobs `None` dispatches normally — the
-        /// synchronous reject path is skipped and work is spawned.
-        #[test]
-        fn anthropic_cli_no_params_dispatches() {
-            let (mailer, _rx) = test_mailer_and_rx();
-            let cap = cli_send_with(&mailer, None, None);
-            assert_eq!(
-                cap_in_flight(&cap),
-                1,
-                "a param-free CliSend should dispatch one in-flight call"
-            );
-        }
-
-        /// CLI send with a missing `claude` binary replies
-        /// `Err { CliNotFound }` — a graceful skip, not a hang.
-        #[test]
-        fn anthropic_cli_skips_when_no_claude_on_path() {
-            // A disabled adapter routes CLI through the real subprocess
-            // backend; pointing it at a missing binary exercises the
-            // CliNotFound path without depending on the host's `claude`.
-            struct MissingCliAdapter {
-                cli: ClaudeCliAdapter,
-            }
-            impl AnthropicAdapter for MissingCliAdapter {
-                fn messages_send(
-                    &self,
-                    _req: AnthropicRequest,
-                ) -> Result<AnthropicResponse, String> {
-                    Err(super::super::error::UNAUTHORIZED_SENTINEL.to_string())
-                }
-                fn cli_send(&self, req: AnthropicRequest) -> Result<AnthropicResponse, String> {
-                    self.cli.cli_send(&req)
-                }
-            }
-
-            let (mailer, rx) = test_mailer_and_rx();
-            let cap_mailbox = MailboxId(0);
-            let mut cap = AnthropicCapability::from_parts(
-                Arc::new(MissingCliAdapter {
-                    cli: ClaudeCliAdapter::new(
-                        "aether-nonexistent-claude-binary-xyzzy".to_string(),
-                        Duration::from_secs(30),
-                    ),
-                }),
-                4,
-            );
-            let transport = Arc::new(NativeBinding::new_for_test(
-                Arc::clone(&mailer),
-                cap_mailbox,
-            ));
-            let mut ctx = NativeCtx::new_dispatching(
-                &transport,
-                session_sender(),
-                aether_data::MailId::NONE,
-                aether_data::MailId::NONE,
-            );
-            cap.on_cli_send(
-                &mut ctx,
-                CliSend {
-                    request_id: 5,
-                    model: "claude-test".to_string(),
-                    messages: user_msg("hi"),
-                    max_tokens: None,
-                    temperature: None,
-                    system: None,
-                },
-            );
-            // The CLI backend runs on the real worker against a missing
-            // binary, yielding CliNotFound; route the completion through the
-            // cap's task handler.
-            drive_task_completion(&mut cap, &transport, &rx);
-            match decode_reply::<CliSendResult>(&rx) {
-                CliSendResult::Err {
-                    request_id,
-                    error: AnthropicError::CliNotFound,
-                } => {
-                    assert_eq!(request_id, 5);
-                }
-                other => panic!("expected CliNotFound, got {other:?}"),
-            }
-        }
-
-        /// Disabled adapter replies `Unauthorized` to a Messages request.
-        #[test]
-        fn anthropic_disabled_messages_replies_unauthorized() {
-            let (mailer, rx) = test_mailer_and_rx();
-            let cap_mailbox = MailboxId(0);
-            let mut cap =
-                AnthropicCapability::from_parts(Arc::new(DisabledAnthropicAdapter::default()), 4);
-            let transport = Arc::new(NativeBinding::new_for_test(
-                Arc::clone(&mailer),
-                cap_mailbox,
-            ));
-            let mut ctx = NativeCtx::new_dispatching(
-                &transport,
-                session_sender(),
-                aether_data::MailId::NONE,
-                aether_data::MailId::NONE,
-            );
-            cap.on_messages_send(
-                &mut ctx,
-                MessagesSend {
-                    request_id: 9,
-                    model: "claude-anything".to_string(),
-                    messages: user_msg("hi"),
-                    max_tokens: None,
-                    temperature: None,
-                    system: None,
-                },
-            );
-            // Disabled adapter has an empty supported-models table, so the
-            // model gate is skipped and the request dispatches; the worker
-            // produces the Unauthorized result. Route the completion through
-            // the cap's task handler.
-            drive_task_completion(&mut cap, &transport, &rx);
-            match decode_reply::<MessagesSendResult>(&rx) {
-                MessagesSendResult::Err {
-                    request_id,
-                    error: AnthropicError::Unauthorized,
-                } => assert_eq!(request_id, 9),
-                other => panic!("expected Unauthorized, got {other:?}"),
-            }
-        }
-
-        /// Real-API smoke. Hits the live Messages API with a tiny
-        /// 5-`max_tokens` request — ignored by default so CI stays
-        /// zero-cost; run with `ANTHROPIC_API_KEY` set.
-        #[test]
-        #[ignore = "needs ANTHROPIC_API_KEY"]
-        fn anthropic_api_smoke() {
-            use super::super::UreqAnthropicAdapter;
-            use crate::shared::contentgen::adapter::AnthropicRequest;
-            use std::env;
-            // Test-only: the live-API smoke reads an external credential
-            // (ANTHROPIC_API_KEY), not cap config; gated `#[ignore]`.
-            #[allow(clippy::disallowed_methods)]
-            let key = env::var("ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY set for smoke");
-            let adapter = UreqAnthropicAdapter::new(key, Duration::from_secs(30));
-            let resp = adapter
-                .messages_send(&AnthropicRequest {
-                    model: "claude-haiku-4-5-20251001".to_string(),
-                    prompt: "say hi".to_string(),
-                    system: None,
-                    max_tokens: Some(5),
-                    temperature: None,
-                })
-                .expect("live messages request succeeds");
-            assert!(!resp.text.is_empty());
-        }
-
-        // White-box accessor for the queue's in-flight count; the cap's
-        // `tasks` field is private, so tests read it through this shim.
-        fn cap_in_flight(cap: &AnthropicCapability) -> usize {
-            cap.test_in_flight()
-        }
+    // White-box accessor for the queue's in-flight count; the state's
+    // `tasks` field is private, so tests read it through this shim.
+    fn cap_in_flight(state: &AnthropicCapabilityState) -> usize {
+        state.test_in_flight()
     }
 }

--- a/crates/aether-capabilities/src/anthropic/runtime.rs
+++ b/crates/aether-capabilities/src/anthropic/runtime.rs
@@ -1,0 +1,198 @@
+//! The `aether.anthropic` runtime half (ADR-0122 identity/runtime split).
+//! Compiled only under `feature = "runtime"` (the `mod runtime;` declaration in
+//! the parent carries the gate), so a transport-only build of the
+//! `AnthropicCapability` identity never names these types nor pulls
+//! `aether_substrate`. The substrate-typed imports are gated once by this
+//! module rather than line-by-line; the `#[actor] impl` reaches the state, ctx
+//! types, gate/reply helpers, and reply assembly through the single
+//! `use runtime::*` glob in the parent.
+
+use super::kinds::{AnthropicError, Message, MessagesSendResult, Role};
+use super::{
+    AnthropicAdapter, AnthropicConfig, CliSendResult, CombinedAnthropicAdapter,
+    DisabledAnthropicAdapter, map_adapter_error,
+};
+use crate::shared::contentgen::adapter::{AdapterUsage, AnthropicResponse};
+
+pub use crate::shared::contentgen::task_queue::TaskQueue;
+pub use std::sync::Arc;
+
+use aether_actor::OutboundReply;
+use aether_kinds::Usage;
+
+pub use aether_actor::Manual;
+pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
+pub use aether_substrate::chassis::error::BootError;
+
+/// Which send path a request rode. The generate handler threads it
+/// into the worker closure to pick the blocking call + result kind.
+#[derive(Copy, Clone)]
+pub enum SendPath {
+    Messages,
+    Cli,
+}
+
+/// `aether.anthropic` runtime state (ADR-0050). Owns the resolved adapter
+/// and the cap-level rate-limit queue over the ADR-0093 dispatch
+/// primitive. Single-threaded post-ADR-0038, so the queue state lives in
+/// plain fields with no lock. The dispatcher holds this as the cap's state
+/// and routes envelopes through the macro-emitted `Dispatch` impl; the
+/// addressing identity is the distinct ZST
+/// [`AnthropicCapability`](super::AnthropicCapability). Living in this
+/// private module keeps it `pub`-enough to satisfy the `NativeActor::State`
+/// interface without exposing it as crate-public API.
+pub struct AnthropicCapabilityState {
+    pub(super) adapter: Arc<dyn AnthropicAdapter>,
+    pub(super) tasks: TaskQueue,
+}
+
+#[cfg(test)]
+impl AnthropicCapabilityState {
+    /// Test-only constructor. Production boots through
+    /// `Builder::with_actor::<AnthropicCapability>(config)`; tests
+    /// hand in a stub adapter directly.
+    pub(crate) fn from_parts(adapter: Arc<dyn AnthropicAdapter>, max_in_flight: usize) -> Self {
+        Self {
+            adapter,
+            tasks: TaskQueue::new(max_in_flight),
+        }
+    }
+
+    /// White-box accessor for tests asserting the queue's in-flight
+    /// counter (e.g. that a synchronous validation error never spawned
+    /// work).
+    pub(crate) fn test_in_flight(&self) -> usize {
+        self.tasks.in_flight()
+    }
+}
+
+impl AnthropicCapabilityState {
+    /// Gate a request's model before any dispatch. Returns `false`
+    /// (after replying `UnknownModel`) when the Messages path's
+    /// supported-model table rejects it; `true` to proceed. Empty
+    /// `supported` = accept-any (disabled / CLI passthrough); the CLI
+    /// path always passes through.
+    pub fn gate_model(
+        &self,
+        ctx: &mut NativeCtx<'_, Manual>,
+        path: SendPath,
+        request_id: u64,
+        model: &str,
+    ) -> bool {
+        let supported = self.adapter.supported_models();
+        let gate = matches!(path, SendPath::Messages) && !supported.is_empty();
+        if gate && !supported.iter().any(|m| m == model) {
+            let err = AnthropicError::UnknownModel {
+                model: model.to_string(),
+                supported,
+            };
+            Self::reply_err(ctx, path, request_id, err);
+            return false;
+        }
+        true
+    }
+
+    /// Reply an `Err` synchronously (model validation failure)
+    /// before any dispatch.
+    pub fn reply_err(
+        ctx: &mut NativeCtx<'_, Manual>,
+        path: SendPath,
+        request_id: u64,
+        error: AnthropicError,
+    ) {
+        match path {
+            SendPath::Messages => {
+                OutboundReply::reply(ctx, &MessagesSendResult::Err { request_id, error });
+            }
+            SendPath::Cli => {
+                OutboundReply::reply(ctx, &CliSendResult::Err { request_id, error });
+            }
+        }
+    }
+}
+
+pub fn build_adapter(config: &AnthropicConfig) -> Arc<dyn AnthropicAdapter> {
+    if config.disabled {
+        tracing::info!(
+            target: "aether_capabilities::anthropic",
+            "anthropic adapter disabled — messages reply Unauthorized; cli still routes",
+        );
+        return Arc::new(DisabledAnthropicAdapter::new(config.timeout));
+    }
+    config.api_key.as_ref().map_or_else(
+        || {
+            tracing::info!(
+                target: "aether_capabilities::anthropic",
+                "ANTHROPIC_API_KEY unset — messages reply Unauthorized; cli still routes",
+            );
+            Arc::new(DisabledAnthropicAdapter::new(config.timeout)) as Arc<dyn AnthropicAdapter>
+        },
+        |key| {
+            tracing::info!(
+                target: "aether_capabilities::anthropic",
+                "anthropic adapter configured (messages + cli)",
+            );
+            Arc::new(CombinedAnthropicAdapter::new(key.clone(), config.timeout))
+                as Arc<dyn AnthropicAdapter>
+        },
+    )
+}
+
+/// Flatten the conversation into a single prompt string. v1 doesn't
+/// model multi-turn API content; it concatenates the user/assistant
+/// turns so the adapter sees one prompt.
+pub fn flatten_prompt(messages: &[Message]) -> String {
+    messages
+        .iter()
+        .map(|m| {
+            let speaker = match m.role {
+                Role::User => "User",
+                Role::Assistant => "Assistant",
+            };
+            format!("{speaker}: {}", m.content)
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn to_usage(u: AdapterUsage) -> Usage {
+    Usage {
+        input_tokens: u.input_tokens,
+        output_tokens: u.output_tokens,
+        wall_clock_ms: u.wall_clock_ms,
+        cost_micros: u.cost_micros,
+    }
+}
+
+pub fn messages_reply(
+    request_id: u64,
+    result: Result<AnthropicResponse, String>,
+) -> MessagesSendResult {
+    match result {
+        Ok(resp) => MessagesSendResult::Ok {
+            request_id,
+            text: resp.text,
+            model_used: resp.model_used,
+            usage: to_usage(resp.usage),
+        },
+        Err(raw) => MessagesSendResult::Err {
+            request_id,
+            error: map_adapter_error(&raw),
+        },
+    }
+}
+
+pub fn cli_reply(request_id: u64, result: Result<AnthropicResponse, String>) -> CliSendResult {
+    match result {
+        Ok(resp) => CliSendResult::Ok {
+            request_id,
+            text: resp.text,
+            model_used: resp.model_used,
+            usage: to_usage(resp.usage),
+        },
+        Err(raw) => CliSendResult::Err {
+            request_id,
+            error: map_adapter_error(&raw),
+        },
+    }
+}

--- a/crates/aether-capabilities/src/audio/mod.rs
+++ b/crates/aether-capabilities/src/audio/mod.rs
@@ -2134,7 +2134,7 @@ mod native {
             );
             // The decode worker runs off-thread and pushes the completion
             // wake; route it through the cap's #[handler(task)] arm.
-            drive_task_completion(&mut cap, &transport, &rx);
+            drive_task_completion::<AudioCapability>(&mut cap, &transport, &rx);
 
             match decode_session_reply::<PlayTrackResult>(&rx) {
                 PlayTrackResult::Ok {
@@ -2197,7 +2197,7 @@ mod native {
                     bytes: wav,
                 },
             );
-            drive_task_completion(&mut cap, &transport, &rx);
+            drive_task_completion::<AudioCapability>(&mut cap, &transport, &rx);
 
             match decode_session_reply::<PlayTrackResult>(&rx) {
                 PlayTrackResult::Ok { lane, .. } => {
@@ -2988,7 +2988,7 @@ sample=c5.wav lokey=72 hikey=83 pitch_keycenter=72
                 },
             );
             // The last sample triggers the assembly dispatch off-thread.
-            drive_task_completion(&mut cap, &transport, &rx);
+            drive_task_completion::<AudioCapability>(&mut cap, &transport, &rx);
 
             match decode_session_reply::<LoadInstrumentResult>(&rx) {
                 LoadInstrumentResult::Ok {
@@ -3170,7 +3170,7 @@ sample=c5.wav lokey=72 hikey=83 pitch_keycenter=72
                 );
             }
 
-            drive_task_completion(&mut cap, &transport, &rx);
+            drive_task_completion::<AudioCapability>(&mut cap, &transport, &rx);
 
             // The settlement hold was released inside resolve_with, but the
             // reply is now in-flight on the caller root — live_roots must
@@ -3236,7 +3236,7 @@ sample=c5.wav lokey=72 hikey=83 pitch_keycenter=72
                 );
             }
 
-            drive_task_completion(&mut cap, &transport, &rx);
+            drive_task_completion::<AudioCapability>(&mut cap, &transport, &rx);
 
             assert_eq!(
                 counter.live_roots(),
@@ -3322,7 +3322,7 @@ sample=c5.wav lokey=72 hikey=83 pitch_keycenter=72
                 );
             }
 
-            drive_task_completion(&mut cap, &transport, &rx);
+            drive_task_completion::<AudioCapability>(&mut cap, &transport, &rx);
 
             assert_eq!(
                 counter.live_roots(),

--- a/crates/aether-capabilities/src/gemini/capability.rs
+++ b/crates/aether-capabilities/src/gemini/capability.rs
@@ -5,808 +5,669 @@
 //! back as `TaskDone` to the `#[handler(task)]` arms.
 
 // Handler-signature kinds must be importable at file root because
-// `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
-// of the mod.
-use super::adapter::{
-    DisabledGeminiAdapter, UreqGeminiAdapter, aspect_ratio_str, image_size_str, map_adapter_error,
-    thinking_level_str,
-};
+// `#[actor]` emits the `impl HandlesKind<K> for X {}` markers always-on
+// against the identity (outside the `feature = "runtime"` gate), so they
+// reference these kinds from here.
+use super::adapter::{aspect_ratio_str, image_size_str, thinking_level_str};
 use super::config::GeminiConfig;
 use super::{
-    LyriaGenerate, LyriaGenerateResult, NanobananaGenerate, NanobananaGenerateResult, lyria,
-    nanobanana,
+    GeminiError, LyriaGenerate, LyriaGenerateResult, NanobananaGenerate, NanobananaGenerateResult,
+    lyria, nanobanana,
 };
-use crate::shared::contentgen::adapter::{GeminiAdapter, GeminiImageRequest, GeminiMusicRequest};
+use crate::shared::contentgen::adapter::{GeminiImageRequest, GeminiMusicRequest};
 
-#[aether_actor::bridge(singleton)]
-mod native {
-    use std::sync::Arc;
+/// `aether.gemini` mailbox cap **identity** (ADR-0122 identity/runtime
+/// split). A ZST carrying only the addressing — `Addressable`
+/// (`NAMESPACE`, `Resolver`), the per-handler `HandlesKind` markers, and
+/// the name-inventory entry, all emitted always-on by `#[actor]`. The
+/// state-bearing runtime (`GeminiCapabilityState`,
+/// which holds the `aether_substrate`-typed adapter + task queue) lives
+/// behind the one `feature = "runtime"` gate, so a transport-only build
+/// never names it nor pulls `aether_substrate` through this cap.
+pub struct GeminiCapability;
 
-    use super::{
-        DisabledGeminiAdapter, GeminiAdapter, GeminiConfig, GeminiImageRequest, GeminiMusicRequest,
-        LyriaGenerate, LyriaGenerateResult, NanobananaGenerate, NanobananaGenerateResult,
-        UreqGeminiAdapter, aspect_ratio_str, image_size_str, lyria, map_adapter_error, nanobanana,
-        thinking_level_str,
-    };
-    use crate::fs::{FileAdapter, LocalFileAdapter};
-    use crate::shared::contentgen::adapter::{AdapterUsage, GeminiResponse};
-    use crate::shared::contentgen::staging::{gen_root, stage_gen_output};
-    use crate::shared::contentgen::task_queue::TaskQueue;
-    use aether_actor::{Manual, OutboundReply, actor};
-    use aether_kinds::Usage;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
-    use aether_substrate::chassis::error::BootError;
+// The `#[actor]` / `#[handler]` attribute path stays always-on (the macro
+// divides what it emits). Everything that names an `aether_substrate` type —
+// the handler/init ctx, the runtime state, the reply helpers — lives in the
+// `runtime` module (declared in `gemini/mod.rs`), gated once by
+// `feature = "runtime"`; the `#[actor] impl` reaches all of it through the
+// single `use super::runtime::*` glob.
+use aether_actor::actor;
 
-    use super::super::{GeminiError, GroundingMetadata};
+// The `runtime` module is this cap's private runtime-half namespace; the impl
+// reaches all of it (state, ctx types, reply helpers) through this single
+// seam, so the glob is intentional rather than a dozen one-line imports.
+#[cfg(feature = "runtime")]
+#[allow(clippy::wildcard_imports)]
+use super::runtime::*;
 
-    /// `aether.gemini` mailbox cap. Owns the resolved adapter + the
-    /// cap-level rate-limit queue over the ADR-0093 dispatch primitive.
-    /// Single-threaded post-ADR-0038, so the queue state lives in plain
-    /// fields.
-    pub struct GeminiCapability {
-        adapter: Arc<dyn GeminiAdapter>,
-        tasks: TaskQueue,
+#[actor(singleton)]
+impl NativeActor for GeminiCapability {
+    /// The runtime state this identity boots into (ADR-0122 split): the
+    /// state-bearing struct holding the adapter + the rate-limit queue.
+    type State = GeminiCapabilityState;
+
+    type Config = GeminiConfig;
+
+    /// ADR-0050 + ADR-0074 Phase 5 chassis-owned mailbox.
+    const NAMESPACE: &'static str = "aether.gemini";
+
+    fn init(
+        config: GeminiConfig,
+        _ctx: &mut NativeInitCtx<'_>,
+    ) -> Result<GeminiCapabilityState, BootError> {
+        Ok(GeminiCapabilityState {
+            adapter: build_adapter(&config),
+            tasks: TaskQueue::new(config.max_in_flight),
+        })
     }
 
-    #[cfg(test)]
-    impl GeminiCapability {
-        pub(crate) fn from_parts(adapter: Arc<dyn GeminiAdapter>, max_in_flight: usize) -> Self {
-            Self {
-                adapter,
-                tasks: TaskQueue::new(max_in_flight),
-            }
-        }
-
-        pub(crate) fn test_in_flight(&self) -> usize {
-            self.tasks.in_flight()
-        }
-    }
-
-    fn build_adapter(config: &GeminiConfig) -> Arc<dyn GeminiAdapter> {
-        if config.disabled {
-            tracing::info!(
-                target: "aether_capabilities::gemini",
-                "gemini adapter disabled — every request replies Unauthorized",
-            );
-            return Arc::new(DisabledGeminiAdapter);
-        }
-        config.api_key.as_ref().map_or_else(
-            || {
-                tracing::info!(
-                    target: "aether_capabilities::gemini",
-                    "GEMINI_API_KEY unset — every request replies Unauthorized",
-                );
-                Arc::new(DisabledGeminiAdapter) as Arc<dyn GeminiAdapter>
-            },
-            |key| {
-                tracing::info!(
-                    target: "aether_capabilities::gemini",
-                    "gemini adapter configured (nanobanana + lyria)",
-                );
-                Arc::new(UreqGeminiAdapter::new(key.clone(), config.timeout))
-                    as Arc<dyn GeminiAdapter>
-            },
-        )
-    }
-
-    /// Read reference-image bytes from the supplied save-namespace
-    /// paths (tool JSON takes paths, the wire stays bytes —
-    /// `feedback_no_bytes_in_llm_json`). A read failure aborts the
-    /// request with an `AdapterError`.
-    fn read_reference_images(paths: &[String]) -> Result<Vec<Vec<u8>>, GeminiError> {
-        if paths.is_empty() {
-            return Ok(Vec::new());
-        }
-        let root = gen_root();
-        let adapter = LocalFileAdapter::new(root, true)
-            .map_err(|e| GeminiError::AdapterError(e.to_string()))?;
-        let mut out = Vec::with_capacity(paths.len());
-        for path in paths {
-            let bytes = adapter
-                .read(path)
-                .map_err(|e| GeminiError::AdapterError(format!("reference {path}: {e:?}")))?;
-            out.push(bytes);
-        }
-        Ok(out)
-    }
-
-    fn to_usage(u: AdapterUsage) -> Usage {
-        Usage {
-            input_tokens: u.input_tokens,
-            output_tokens: u.output_tokens,
-            wall_clock_ms: u.wall_clock_ms,
-            cost_micros: u.cost_micros,
-        }
-    }
-
-    fn nanobanana_reply(
-        request_id: u64,
-        include_sig: bool,
-        result: Result<GeminiResponse, String>,
-    ) -> NanobananaGenerateResult {
-        match result {
-            Ok(resp) => {
-                let model_used = resp.model_used;
-                let usage = to_usage(resp.usage);
-                // Opt-in / default-off: clear the signature unless the
-                // caller asked to retain it for a multi-turn continuation
-                // (a signature can run to multiple MB and dominate the
-                // reply). Parse stays unconditional; the gate is here.
-                let thought_signature = if include_sig {
-                    resp.thought_signature
-                } else {
-                    None
-                };
-                let grounding =
-                    resp.grounding
-                        .map(|(search_queries, source_urls)| GroundingMetadata {
-                            search_queries,
-                            source_urls,
-                        });
-                let Some(artifact) = resp.artifacts.into_iter().next() else {
-                    return NanobananaGenerateResult::Err {
-                        request_id,
-                        error: GeminiError::AdapterError("adapter returned no image".to_string()),
-                    };
-                };
-                match stage_gen_output(&artifact.bytes, &artifact.ext) {
-                    Ok(output_path) => NanobananaGenerateResult::Ok {
-                        request_id,
-                        output_path,
-                        model_used,
-                        usage,
-                        thought_signature,
-                        grounding,
-                    },
-                    Err(e) => NanobananaGenerateResult::Err {
-                        request_id,
-                        error: GeminiError::AdapterError(format!("stage image: {e:?}")),
-                    },
-                }
-            }
-            Err(raw) => NanobananaGenerateResult::Err {
-                request_id,
-                error: map_adapter_error(&raw),
-            },
-        }
-    }
-
-    fn lyria_reply(request_id: u64, result: Result<GeminiResponse, String>) -> LyriaGenerateResult {
-        match result {
-            Ok(resp) => {
-                let mut output_paths = Vec::with_capacity(resp.artifacts.len());
-                for artifact in &resp.artifacts {
-                    match stage_gen_output(&artifact.bytes, &artifact.ext) {
-                        Ok(path) => output_paths.push(path),
-                        Err(e) => {
-                            return LyriaGenerateResult::Err {
-                                request_id,
-                                error: GeminiError::AdapterError(format!("stage clip: {e:?}")),
-                            };
-                        }
-                    }
-                }
-                LyriaGenerateResult::Ok {
+    /// Generate an image via Nano Banana off the dispatcher thread.
+    ///
+    /// # Agent
+    /// Reply: `NanobananaGenerateResult` carrying a staged
+    /// `save://gen/<uuid>.png` path. Validates the model and the
+    /// per-model `aspect_ratio` / `image_size` / reference-count
+    /// rules synchronously (the matching `…NotSupportedByModel` /
+    /// `UnknownModel` error on a miss) before any dispatch.
+    #[handler::manual]
+    fn on_nanobanana_generate(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_, Manual>,
+        mail: NanobananaGenerate,
+    ) {
+        let request_id = mail.request_id;
+        // Opt-in / default-off; cross-model, so never validated.
+        let include_sig = mail.include_thought_signature.unwrap_or(false);
+        let Some(shape) = nanobanana::lookup_model(&mail.model) else {
+            OutboundReply::reply(
+                ctx,
+                &NanobananaGenerateResult::Err {
                     request_id,
-                    output_paths,
-                    model_used: resp.model_used,
-                    usage: to_usage(resp.usage),
-                }
-            }
-            Err(raw) => LyriaGenerateResult::Err {
-                request_id,
-                error: map_adapter_error(&raw),
-            },
-        }
-    }
-
-    #[actor]
-    impl NativeActor for GeminiCapability {
-        type Config = GeminiConfig;
-
-        /// ADR-0050 + ADR-0074 Phase 5 chassis-owned mailbox.
-        const NAMESPACE: &'static str = "aether.gemini";
-
-        fn init(config: GeminiConfig, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            Ok(Self {
-                adapter: build_adapter(&config),
-                tasks: TaskQueue::new(config.max_in_flight),
-            })
-        }
-
-        /// Generate an image via Nano Banana off the dispatcher thread.
-        ///
-        /// # Agent
-        /// Reply: `NanobananaGenerateResult` carrying a staged
-        /// `save://gen/<uuid>.png` path. Validates the model and the
-        /// per-model `aspect_ratio` / `image_size` / reference-count
-        /// rules synchronously (the matching `…NotSupportedByModel` /
-        /// `UnknownModel` error on a miss) before any dispatch.
-        #[handler::manual]
-        fn on_nanobanana_generate(
-            &mut self,
-            ctx: &mut NativeCtx<'_, Manual>,
-            mail: NanobananaGenerate,
-        ) {
-            let request_id = mail.request_id;
-            // Opt-in / default-off; cross-model, so never validated.
-            let include_sig = mail.include_thought_signature.unwrap_or(false);
-            let Some(shape) = nanobanana::lookup_model(&mail.model) else {
-                OutboundReply::reply(
-                    ctx,
-                    &NanobananaGenerateResult::Err {
-                        request_id,
-                        error: GeminiError::UnknownModel {
-                            model: mail.model,
-                            supported: nanobanana::supported_model_ids(),
-                        },
+                    error: GeminiError::UnknownModel {
+                        model: mail.model,
+                        supported: nanobanana::supported_model_ids(),
                     },
-                );
-                return;
-            };
-            let inputs = nanobanana::ValidationInputs {
-                aspect_ratio: mail.aspect_ratio,
-                image_size: mail.image_size,
-                thinking_level_set: mail.thinking_level.is_some(),
-                include_thoughts_set: mail.include_thoughts.is_some(),
-                use_grounding_set: mail.use_grounding.is_some(),
-                object_ref_count: mail.object_reference_paths.len(),
-                character_ref_count: mail.character_reference_paths.len(),
-            };
-            if let Err(error) = nanobanana::validate(shape, &inputs) {
+                },
+            );
+            return;
+        };
+        let inputs = nanobanana::ValidationInputs {
+            aspect_ratio: mail.aspect_ratio,
+            image_size: mail.image_size,
+            thinking_level_set: mail.thinking_level.is_some(),
+            include_thoughts_set: mail.include_thoughts.is_some(),
+            use_grounding_set: mail.use_grounding.is_some(),
+            object_ref_count: mail.object_reference_paths.len(),
+            character_ref_count: mail.character_reference_paths.len(),
+        };
+        if let Err(error) = nanobanana::validate(shape, &inputs) {
+            OutboundReply::reply(ctx, &NanobananaGenerateResult::Err { request_id, error });
+            return;
+        }
+
+        // Read reference bytes on the dispatcher thread (small,
+        // local) before handing the network call off-thread.
+        let mut ref_paths = mail.object_reference_paths;
+        ref_paths.extend(mail.character_reference_paths);
+        let reference_images = match read_reference_images(&ref_paths) {
+            Ok(b) => b,
+            Err(error) => {
                 OutboundReply::reply(ctx, &NanobananaGenerateResult::Err { request_id, error });
                 return;
             }
+        };
 
-            // Read reference bytes on the dispatcher thread (small,
-            // local) before handing the network call off-thread.
-            let mut ref_paths = mail.object_reference_paths;
-            ref_paths.extend(mail.character_reference_paths);
-            let reference_images = match read_reference_images(&ref_paths) {
-                Ok(b) => b,
-                Err(error) => {
-                    OutboundReply::reply(ctx, &NanobananaGenerateResult::Err { request_id, error });
-                    return;
-                }
-            };
+        let req = GeminiImageRequest {
+            model: mail.model,
+            prompt: mail.prompt,
+            aspect_ratio: aspect_ratio_str(mail.aspect_ratio).to_string(),
+            image_size: mail.image_size.map(|s| image_size_str(s).to_string()),
+            thinking_level: mail
+                .thinking_level
+                .map(|l| thinking_level_str(l).to_string()),
+            include_thoughts: mail.include_thoughts,
+            use_grounding: mail.use_grounding.unwrap_or(false),
+            reference_images,
+        };
+        let adapter = Arc::clone(&state.adapter);
+        state.tasks.submit(ctx, move || {
+            let result = adapter.nanobanana_generate(req);
+            // Staging runs here on the worker (blocking disk I/O), so
+            // a megabyte PNG never rides the mail wire — the reply
+            // carries the staged path.
+            nanobanana_reply(request_id, include_sig, result)
+        });
+    }
 
-            let req = GeminiImageRequest {
-                model: mail.model,
-                prompt: mail.prompt,
-                aspect_ratio: aspect_ratio_str(mail.aspect_ratio).to_string(),
-                image_size: mail.image_size.map(|s| image_size_str(s).to_string()),
-                thinking_level: mail
-                    .thinking_level
-                    .map(|l| thinking_level_str(l).to_string()),
-                include_thoughts: mail.include_thoughts,
-                use_grounding: mail.use_grounding.unwrap_or(false),
-                reference_images,
-            };
-            let adapter = Arc::clone(&self.adapter);
-            self.tasks.submit(ctx, move || {
-                let result = adapter.nanobanana_generate(req);
-                // Staging runs here on the worker (blocking disk I/O), so
-                // a megabyte PNG never rides the mail wire — the reply
-                // carries the staged path.
-                nanobanana_reply(request_id, include_sig, result)
-            });
-        }
-
-        /// Generate music via Lyria off the dispatcher thread.
-        ///
-        /// # Agent
-        /// Reply: `LyriaGenerateResult` carrying one staged
-        /// `save://gen/<uuid>.wav` path per clip. Rejects an unknown
-        /// model and a both-set `seed` + `sample_count` synchronously
-        /// before any dispatch.
-        #[handler::manual]
-        fn on_lyria_generate(&mut self, ctx: &mut NativeCtx<'_, Manual>, mail: LyriaGenerate) {
-            let request_id = mail.request_id;
-            if !lyria::is_supported(&mail.model) {
-                OutboundReply::reply(
-                    ctx,
-                    &LyriaGenerateResult::Err {
-                        request_id,
-                        error: GeminiError::UnknownModel {
-                            model: mail.model,
-                            supported: lyria::supported_model_ids(),
-                        },
+    /// Generate music via Lyria off the dispatcher thread.
+    ///
+    /// # Agent
+    /// Reply: `LyriaGenerateResult` carrying one staged
+    /// `save://gen/<uuid>.wav` path per clip. Rejects an unknown
+    /// model and a both-set `seed` + `sample_count` synchronously
+    /// before any dispatch.
+    #[handler::manual]
+    fn on_lyria_generate(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_, Manual>,
+        mail: LyriaGenerate,
+    ) {
+        let request_id = mail.request_id;
+        if !lyria::is_supported(&mail.model) {
+            OutboundReply::reply(
+                ctx,
+                &LyriaGenerateResult::Err {
+                    request_id,
+                    error: GeminiError::UnknownModel {
+                        model: mail.model,
+                        supported: lyria::supported_model_ids(),
                     },
-                );
-                return;
-            }
-            if let Err(error) = lyria::validate(
-                &mail.model,
-                mail.seed.is_some(),
-                mail.sample_count.is_some(),
-            ) {
-                OutboundReply::reply(ctx, &LyriaGenerateResult::Err { request_id, error });
-                return;
-            }
-
-            let req = GeminiMusicRequest {
-                model: mail.model,
-                prompt: mail.prompt,
-                sample_count: mail.sample_count.unwrap_or(1),
-            };
-            let adapter = Arc::clone(&self.adapter);
-            self.tasks.submit(ctx, move || {
-                let result = adapter.lyria_generate(req);
-                // Staging (one path per clip) runs here on the worker.
-                lyria_reply(request_id, result)
-            });
+                },
+            );
+            return;
         }
-
-        /// ADR-0093 completion for a finished Nano Banana call: re-reply
-        /// the worker's staged result to the original caller (drops the
-        /// hold), then free the in-flight slot (draining the next pending
-        /// request).
-        #[handler(task)]
-        fn on_nanobanana_done(
-            &mut self,
-            ctx: &mut NativeCtx<'_>,
-            done: TaskDone<NanobananaGenerateResult>,
+        if let Err(error) = lyria::validate(
+            &mail.model,
+            mail.seed.is_some(),
+            mail.sample_count.is_some(),
         ) {
-            done.resolve(ctx);
-            self.tasks.on_complete(ctx);
+            OutboundReply::reply(ctx, &LyriaGenerateResult::Err { request_id, error });
+            return;
         }
 
-        /// ADR-0093 completion for a finished Lyria call.
-        #[handler(task)]
-        fn on_lyria_done(&mut self, ctx: &mut NativeCtx<'_>, done: TaskDone<LyriaGenerateResult>) {
-            done.resolve(ctx);
-            self.tasks.on_complete(ctx);
+        let req = GeminiMusicRequest {
+            model: mail.model,
+            prompt: mail.prompt,
+            sample_count: mail.sample_count.unwrap_or(1),
+        };
+        let adapter = Arc::clone(&state.adapter);
+        state.tasks.submit(ctx, move || {
+            let result = adapter.lyria_generate(req);
+            // Staging (one path per clip) runs here on the worker.
+            lyria_reply(request_id, result)
+        });
+    }
+
+    /// ADR-0093 completion for a finished Nano Banana call: re-reply
+    /// the worker's staged result to the original caller (drops the
+    /// hold), then free the in-flight slot (draining the next pending
+    /// request).
+    #[handler(task)]
+    fn on_nanobanana_done(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        done: TaskDone<NanobananaGenerateResult>,
+    ) {
+        done.resolve(ctx);
+        state.tasks.on_complete(ctx);
+    }
+
+    /// ADR-0093 completion for a finished Lyria call.
+    #[handler(task)]
+    fn on_lyria_done(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        done: TaskDone<LyriaGenerateResult>,
+    ) {
+        done.resolve(ctx);
+        state.tasks.on_complete(ctx);
+    }
+}
+
+#[cfg(all(test, feature = "runtime"))]
+mod tests {
+    use super::GeminiCapability;
+    use crate::gemini::runtime::{GeminiCapabilityState, nanobanana_reply};
+    use crate::gemini::{
+        AspectRatio, GeminiError, ImageSize, LyriaGenerate, LyriaGenerateResult,
+        NanobananaGenerate, NanobananaGenerateResult,
+    };
+    use crate::gemini::{DisabledGeminiAdapter, GeminiConfig};
+    use crate::shared::contentgen::adapter::STUB_PNG;
+    use crate::shared::contentgen::adapter::StubGeminiAdapter;
+    use crate::shared::contentgen::adapter::{AdapterUsage, GeminiArtifact, GeminiResponse};
+    use crate::test_chassis::{
+        TestChassis, decode_session_reply, drive_task_completion, fresh_substrate,
+        test_mailer_and_rx,
+    };
+    use aether_actor::Addressable;
+    use aether_data::{Kind, MailboxId, SessionToken, Source, SourceAddr, Uuid};
+    use aether_substrate::actor::native::binding::NativeBinding;
+    use aether_substrate::actor::native::ctx::NativeCtx;
+    use aether_substrate::chassis::builder::Builder;
+    use aether_substrate::mail::outbound::EgressEvent;
+    use serde::de::DeserializeOwned;
+    use std::sync::mpsc::Receiver;
+    use std::sync::{Arc, Mutex, PoisonError};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::{env, fs, process};
+
+    fn session_sender() -> Source {
+        Source::to(SourceAddr::Session(SessionToken(Uuid::nil())))
+    }
+
+    /// Thin alias over the shared `decode_session_reply`.
+    fn decode_reply<K: Kind + DeserializeOwned>(rx: &Receiver<EgressEvent>) -> K {
+        decode_session_reply(rx)
+    }
+
+    fn nb_request(model: &str, aspect_ratio: AspectRatio) -> NanobananaGenerate {
+        NanobananaGenerate {
+            request_id: 1,
+            model: model.to_string(),
+            prompt: "a cat".to_string(),
+            aspect_ratio,
+            image_size: None,
+            thinking_level: None,
+            include_thoughts: None,
+            object_reference_paths: Vec::new(),
+            character_reference_paths: Vec::new(),
+            use_grounding: None,
+            include_thought_signature: None,
         }
     }
 
-    #[cfg(test)]
-    mod tests {
-        use super::super::{DisabledGeminiAdapter, GeminiConfig};
-        use super::GeminiCapability;
-        use crate::gemini::{
-            AspectRatio, GeminiError, ImageSize, LyriaGenerate, LyriaGenerateResult,
-            NanobananaGenerate, NanobananaGenerateResult,
-        };
-        use crate::shared::contentgen::adapter::STUB_PNG;
-        use crate::shared::contentgen::adapter::StubGeminiAdapter;
-        use crate::shared::contentgen::adapter::{AdapterUsage, GeminiArtifact, GeminiResponse};
-        use crate::test_chassis::{
-            TestChassis, decode_session_reply, drive_task_completion, fresh_substrate,
-            test_mailer_and_rx,
-        };
-        use aether_actor::Addressable;
-        use aether_data::{Kind, MailboxId, SessionToken, Source, SourceAddr, Uuid};
-        use aether_substrate::actor::native::binding::NativeBinding;
-        use aether_substrate::actor::native::ctx::NativeCtx;
-        use aether_substrate::chassis::builder::Builder;
-        use aether_substrate::mail::outbound::EgressEvent;
-        use serde::de::DeserializeOwned;
-        use std::sync::mpsc::Receiver;
-        use std::sync::{Arc, Mutex, PoisonError};
-        use std::time::{SystemTime, UNIX_EPOCH};
-        use std::{env, fs, process};
+    #[test]
+    fn capability_boots_and_registers_mailbox() {
+        let (registry, mailer) = fresh_substrate();
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<GeminiCapability>(GeminiConfig::default())
+            .build_passive()
+            .expect("gemini capability boots");
+        assert!(
+            registry.lookup(GeminiCapability::NAMESPACE).is_some(),
+            "gemini mailbox registered"
+        );
+        drop(chassis);
+    }
 
-        fn session_sender() -> Source {
-            Source::to(SourceAddr::Session(SessionToken(Uuid::nil())))
+    /// End-to-end through the ADR-0093 dispatch primitive: the stub
+    /// Nano Banana adapter runs on the real worker thread, stages a PNG
+    /// under a scratch `AETHER_GEN_DIR`, and the cap's
+    /// `#[handler(task)]` completion re-replies the `Ok` result —
+    /// carrying a staged `gen/<uuid>.png` path that exists on disk — to
+    /// the original caller.
+    #[test]
+    fn gemini_stub_nanobanana() {
+        let _guard = GEN_DIR_ENV_LOCK
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let scratch = env::temp_dir().join(format!(
+            "aether-gemini-nb-{}-{}",
+            process::id(),
+            request_nonce()
+        ));
+        fs::create_dir_all(&scratch).expect("scratch dir creates");
+        // SAFETY: serialized by GEN_DIR_ENV_LOCK against the other
+        // gen-dir tests; the real worker stages here.
+        unsafe {
+            env::set_var("AETHER_GEN_DIR", &scratch);
         }
 
-        /// Thin alias over the shared `decode_session_reply`.
-        fn decode_reply<K: Kind + DeserializeOwned>(rx: &Receiver<EgressEvent>) -> K {
-            decode_session_reply(rx)
-        }
+        let (mailer, rx) = test_mailer_and_rx();
+        let cap_mailbox = MailboxId(0);
+        let mut state = GeminiCapabilityState::from_parts(Arc::new(StubGeminiAdapter), 4);
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            cap_mailbox,
+        ));
+        let mut ctx = NativeCtx::new_dispatching(
+            &transport,
+            session_sender(),
+            aether_data::MailId::NONE,
+            aether_data::MailId::NONE,
+        );
+        GeminiCapability::on_nanobanana_generate(
+            &mut state,
+            &mut ctx,
+            nb_request(
+                "gemini-3.1-flash-image-preview",
+                AspectRatio::ASPECT_RATIO_1_1,
+            ),
+        );
+        // The worker runs the stub call + staging and pushes the
+        // completion wake; route it through the cap's task handler.
+        drive_task_completion::<GeminiCapability>(&mut state, &transport, &rx);
 
-        fn nb_request(model: &str, aspect_ratio: AspectRatio) -> NanobananaGenerate {
-            NanobananaGenerate {
-                request_id: 1,
-                model: model.to_string(),
-                prompt: "a cat".to_string(),
-                aspect_ratio,
-                image_size: None,
-                thinking_level: None,
-                include_thoughts: None,
-                object_reference_paths: Vec::new(),
-                character_reference_paths: Vec::new(),
-                use_grounding: None,
-                include_thought_signature: None,
+        match decode_reply::<NanobananaGenerateResult>(&rx) {
+            NanobananaGenerateResult::Ok { output_path, .. } => {
+                assert!(
+                    output_path.starts_with("gen/"),
+                    "staged path was {output_path:?}"
+                );
+                assert_eq!(output_path.rsplit('.').next(), Some("png"));
+                let bytes =
+                    fs::read(scratch.join(&output_path)).expect("staged file exists on disk");
+                assert_eq!(&bytes[..8], &STUB_PNG[..8]);
             }
-        }
-
-        #[test]
-        fn capability_boots_and_registers_mailbox() {
-            let (registry, mailer) = fresh_substrate();
-            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-                .with_actor::<GeminiCapability>(GeminiConfig::default())
-                .build_passive()
-                .expect("gemini capability boots");
-            assert!(
-                registry.lookup(GeminiCapability::NAMESPACE).is_some(),
-                "gemini mailbox registered"
-            );
-            drop(chassis);
-        }
-
-        /// End-to-end through the ADR-0093 dispatch primitive: the stub
-        /// Nano Banana adapter runs on the real worker thread, stages a PNG
-        /// under a scratch `AETHER_GEN_DIR`, and the cap's
-        /// `#[handler(task)]` completion re-replies the `Ok` result —
-        /// carrying a staged `gen/<uuid>.png` path that exists on disk — to
-        /// the original caller.
-        #[test]
-        fn gemini_stub_nanobanana() {
-            let _guard = GEN_DIR_ENV_LOCK
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner);
-            let scratch = env::temp_dir().join(format!(
-                "aether-gemini-nb-{}-{}",
-                process::id(),
-                request_nonce()
-            ));
-            fs::create_dir_all(&scratch).expect("scratch dir creates");
-            // SAFETY: serialized by GEN_DIR_ENV_LOCK against the other
-            // gen-dir tests; the real worker stages here.
-            unsafe {
-                env::set_var("AETHER_GEN_DIR", &scratch);
-            }
-
-            let (mailer, rx) = test_mailer_and_rx();
-            let cap_mailbox = MailboxId(0);
-            let mut cap = GeminiCapability::from_parts(Arc::new(StubGeminiAdapter), 4);
-            let transport = Arc::new(NativeBinding::new_for_test(
-                Arc::clone(&mailer),
-                cap_mailbox,
-            ));
-            let mut ctx = NativeCtx::new_dispatching(
-                &transport,
-                session_sender(),
-                aether_data::MailId::NONE,
-                aether_data::MailId::NONE,
-            );
-            cap.on_nanobanana_generate(
-                &mut ctx,
-                nb_request(
-                    "gemini-3.1-flash-image-preview",
-                    AspectRatio::ASPECT_RATIO_1_1,
-                ),
-            );
-            // The worker runs the stub call + staging and pushes the
-            // completion wake; route it through the cap's task handler.
-            drive_task_completion(&mut cap, &transport, &rx);
-
-            match decode_reply::<NanobananaGenerateResult>(&rx) {
-                NanobananaGenerateResult::Ok { output_path, .. } => {
-                    assert!(
-                        output_path.starts_with("gen/"),
-                        "staged path was {output_path:?}"
-                    );
-                    assert_eq!(output_path.rsplit('.').next(), Some("png"));
-                    let bytes =
-                        fs::read(scratch.join(&output_path)).expect("staged file exists on disk");
-                    assert_eq!(&bytes[..8], &STUB_PNG[..8]);
-                }
-                other @ NanobananaGenerateResult::Err { .. } => {
-                    panic!("expected Ok, got {other:?}")
-                }
-            }
-
-            // SAFETY: same lock-guarded window as the set above.
-            unsafe {
-                env::remove_var("AETHER_GEN_DIR");
-            }
-            let _ = fs::remove_dir_all(&scratch);
-        }
-
-        /// Per-model validation: an unsupported aspect ratio / image
-        /// size / over-count reference combo errors before any dispatch.
-        #[test]
-        fn gemini_nanobanana_per_model_validation() {
-            let (mailer, rx) = test_mailer_and_rx();
-            let cap_mailbox = MailboxId(0);
-            let mut cap = GeminiCapability::from_parts(Arc::new(StubGeminiAdapter), 4);
-            let transport = Arc::new(NativeBinding::new_for_test(
-                Arc::clone(&mailer),
-                cap_mailbox,
-            ));
-            let mut ctx = NativeCtx::new_dispatching(
-                &transport,
-                session_sender(),
-                aether_data::MailId::NONE,
-                aether_data::MailId::NONE,
-            );
-            // NB1 + the NB2-only extreme aspect ratio -> rejected.
-            cap.on_nanobanana_generate(
-                &mut ctx,
-                nb_request("gemini-2.5-flash-image", AspectRatio::ASPECT_RATIO_8_1),
-            );
-            match decode_reply::<NanobananaGenerateResult>(&rx) {
-                NanobananaGenerateResult::Err {
-                    error: GeminiError::AspectRatioNotSupportedByModel { .. },
-                    ..
-                } => {}
-                other => panic!("expected AspectRatioNotSupportedByModel, got {other:?}"),
-            }
-            // No dispatch happened — the synchronous validation error
-            // never spawned work.
-            assert_eq!(cap.test_in_flight(), 0);
-
-            // NB1 + an unsupported image size -> rejected.
-            let mut req = nb_request("gemini-2.5-flash-image", AspectRatio::ASPECT_RATIO_1_1);
-            req.image_size = Some(ImageSize::S512);
-            cap.on_nanobanana_generate(&mut ctx, req);
-            match decode_reply::<NanobananaGenerateResult>(&rx) {
-                NanobananaGenerateResult::Err {
-                    error: GeminiError::ImageSizeNotSupportedByModel { .. },
-                    ..
-                } => {}
-                other => panic!("expected ImageSizeNotSupportedByModel, got {other:?}"),
+            other @ NanobananaGenerateResult::Err { .. } => {
+                panic!("expected Ok, got {other:?}")
             }
         }
 
-        #[test]
-        fn gemini_unknown_model_errors() {
-            let (mailer, rx) = test_mailer_and_rx();
-            let cap_mailbox = MailboxId(0);
-            let mut cap = GeminiCapability::from_parts(Arc::new(StubGeminiAdapter), 4);
-            let transport = Arc::new(NativeBinding::new_for_test(
-                Arc::clone(&mailer),
-                cap_mailbox,
-            ));
-            let mut ctx = NativeCtx::new_dispatching(
-                &transport,
-                session_sender(),
-                aether_data::MailId::NONE,
-                aether_data::MailId::NONE,
-            );
-            cap.on_nanobanana_generate(
-                &mut ctx,
-                nb_request("gemini-bogus", AspectRatio::ASPECT_RATIO_1_1),
-            );
-            match decode_reply::<NanobananaGenerateResult>(&rx) {
-                NanobananaGenerateResult::Err {
-                    error: GeminiError::UnknownModel { model, supported },
-                    ..
-                } => {
-                    assert_eq!(model, "gemini-bogus");
-                    assert!(supported.contains(&"gemini-3.1-flash-image-preview".to_string()));
-                }
-                other => panic!("expected UnknownModel, got {other:?}"),
+        // SAFETY: same lock-guarded window as the set above.
+        unsafe {
+            env::remove_var("AETHER_GEN_DIR");
+        }
+        let _ = fs::remove_dir_all(&scratch);
+    }
+
+    /// Per-model validation: an unsupported aspect ratio / image
+    /// size / over-count reference combo errors before any dispatch.
+    #[test]
+    fn gemini_nanobanana_per_model_validation() {
+        let (mailer, rx) = test_mailer_and_rx();
+        let cap_mailbox = MailboxId(0);
+        let mut state = GeminiCapabilityState::from_parts(Arc::new(StubGeminiAdapter), 4);
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            cap_mailbox,
+        ));
+        let mut ctx = NativeCtx::new_dispatching(
+            &transport,
+            session_sender(),
+            aether_data::MailId::NONE,
+            aether_data::MailId::NONE,
+        );
+        // NB1 + the NB2-only extreme aspect ratio -> rejected.
+        GeminiCapability::on_nanobanana_generate(
+            &mut state,
+            &mut ctx,
+            nb_request("gemini-2.5-flash-image", AspectRatio::ASPECT_RATIO_8_1),
+        );
+        match decode_reply::<NanobananaGenerateResult>(&rx) {
+            NanobananaGenerateResult::Err {
+                error: GeminiError::AspectRatioNotSupportedByModel { .. },
+                ..
+            } => {}
+            other => panic!("expected AspectRatioNotSupportedByModel, got {other:?}"),
+        }
+        // No dispatch happened — the synchronous validation error
+        // never spawned work.
+        assert_eq!(state.test_in_flight(), 0);
+
+        // NB1 + an unsupported image size -> rejected.
+        let mut req = nb_request("gemini-2.5-flash-image", AspectRatio::ASPECT_RATIO_1_1);
+        req.image_size = Some(ImageSize::S512);
+        GeminiCapability::on_nanobanana_generate(&mut state, &mut ctx, req);
+        match decode_reply::<NanobananaGenerateResult>(&rx) {
+            NanobananaGenerateResult::Err {
+                error: GeminiError::ImageSizeNotSupportedByModel { .. },
+                ..
+            } => {}
+            other => panic!("expected ImageSizeNotSupportedByModel, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn gemini_unknown_model_errors() {
+        let (mailer, rx) = test_mailer_and_rx();
+        let cap_mailbox = MailboxId(0);
+        let mut state = GeminiCapabilityState::from_parts(Arc::new(StubGeminiAdapter), 4);
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            cap_mailbox,
+        ));
+        let mut ctx = NativeCtx::new_dispatching(
+            &transport,
+            session_sender(),
+            aether_data::MailId::NONE,
+            aether_data::MailId::NONE,
+        );
+        GeminiCapability::on_nanobanana_generate(
+            &mut state,
+            &mut ctx,
+            nb_request("gemini-bogus", AspectRatio::ASPECT_RATIO_1_1),
+        );
+        match decode_reply::<NanobananaGenerateResult>(&rx) {
+            NanobananaGenerateResult::Err {
+                error: GeminiError::UnknownModel { model, supported },
+                ..
+            } => {
+                assert_eq!(model, "gemini-bogus");
+                assert!(supported.contains(&"gemini-3.1-flash-image-preview".to_string()));
             }
+            other => panic!("expected UnknownModel, got {other:?}"),
+        }
+    }
+
+    /// Lyria stub runs on the real worker, stages WAV clips under a
+    /// scratch `AETHER_GEN_DIR`, and the `#[handler(task)]` completion
+    /// re-replies an `Ok` carrying one staged path per clip.
+    #[test]
+    fn gemini_stub_lyria() {
+        let _guard = GEN_DIR_ENV_LOCK
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let scratch = env::temp_dir().join(format!(
+            "aether-gemini-lyria-{}-{}",
+            process::id(),
+            request_nonce()
+        ));
+        fs::create_dir_all(&scratch).expect("scratch dir creates");
+        // SAFETY: serialized by GEN_DIR_ENV_LOCK against the other
+        // gen-dir tests; the real worker stages here.
+        unsafe {
+            env::set_var("AETHER_GEN_DIR", &scratch);
         }
 
-        /// Lyria stub runs on the real worker, stages WAV clips under a
-        /// scratch `AETHER_GEN_DIR`, and the `#[handler(task)]` completion
-        /// re-replies an `Ok` carrying one staged path per clip.
-        #[test]
-        fn gemini_stub_lyria() {
-            let _guard = GEN_DIR_ENV_LOCK
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner);
-            let scratch = env::temp_dir().join(format!(
-                "aether-gemini-lyria-{}-{}",
-                process::id(),
-                request_nonce()
-            ));
-            fs::create_dir_all(&scratch).expect("scratch dir creates");
-            // SAFETY: serialized by GEN_DIR_ENV_LOCK against the other
-            // gen-dir tests; the real worker stages here.
-            unsafe {
-                env::set_var("AETHER_GEN_DIR", &scratch);
+        let (mailer, rx) = test_mailer_and_rx();
+        let cap_mailbox = MailboxId(0);
+        let mut state = GeminiCapabilityState::from_parts(Arc::new(StubGeminiAdapter), 4);
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            cap_mailbox,
+        ));
+        let mut ctx = NativeCtx::new_dispatching(
+            &transport,
+            session_sender(),
+            aether_data::MailId::NONE,
+            aether_data::MailId::NONE,
+        );
+        GeminiCapability::on_lyria_generate(
+            &mut state,
+            &mut ctx,
+            LyriaGenerate {
+                request_id: 2,
+                model: "lyria-3".to_string(),
+                prompt: "ambient".to_string(),
+                negative_prompt: None,
+                seed: None,
+                sample_count: Some(2),
+            },
+        );
+        // The worker runs the stub call + per-clip staging and pushes
+        // the completion wake; route it through the cap's task handler.
+        drive_task_completion::<GeminiCapability>(&mut state, &transport, &rx);
+        match decode_reply::<LyriaGenerateResult>(&rx) {
+            LyriaGenerateResult::Ok { output_paths, .. } => {
+                assert_eq!(output_paths.len(), 2);
+                assert!(
+                    output_paths
+                        .iter()
+                        .all(|p| p.starts_with("gen/") && p.rsplit('.').next() == Some("wav"))
+                );
             }
-
-            let (mailer, rx) = test_mailer_and_rx();
-            let cap_mailbox = MailboxId(0);
-            let mut cap = GeminiCapability::from_parts(Arc::new(StubGeminiAdapter), 4);
-            let transport = Arc::new(NativeBinding::new_for_test(
-                Arc::clone(&mailer),
-                cap_mailbox,
-            ));
-            let mut ctx = NativeCtx::new_dispatching(
-                &transport,
-                session_sender(),
-                aether_data::MailId::NONE,
-                aether_data::MailId::NONE,
-            );
-            cap.on_lyria_generate(
-                &mut ctx,
-                LyriaGenerate {
-                    request_id: 2,
-                    model: "lyria-3".to_string(),
-                    prompt: "ambient".to_string(),
-                    negative_prompt: None,
-                    seed: None,
-                    sample_count: Some(2),
-                },
-            );
-            // The worker runs the stub call + per-clip staging and pushes
-            // the completion wake; route it through the cap's task handler.
-            drive_task_completion(&mut cap, &transport, &rx);
-            match decode_reply::<LyriaGenerateResult>(&rx) {
-                LyriaGenerateResult::Ok { output_paths, .. } => {
-                    assert_eq!(output_paths.len(), 2);
-                    assert!(
-                        output_paths
-                            .iter()
-                            .all(|p| p.starts_with("gen/") && p.rsplit('.').next() == Some("wav"))
-                    );
-                }
-                other @ LyriaGenerateResult::Err { .. } => panic!("expected Ok, got {other:?}"),
-            }
-
-            // SAFETY: same lock-guarded window as the set above.
-            unsafe {
-                env::remove_var("AETHER_GEN_DIR");
-            }
-            let _ = fs::remove_dir_all(&scratch);
+            other @ LyriaGenerateResult::Err { .. } => panic!("expected Ok, got {other:?}"),
         }
 
-        #[test]
-        fn gemini_disabled_replies_unauthorized() {
-            let (mailer, rx) = test_mailer_and_rx();
-            let cap_mailbox = MailboxId(0);
-            let mut cap = GeminiCapability::from_parts(Arc::new(DisabledGeminiAdapter), 4);
-            let transport = Arc::new(NativeBinding::new_for_test(
-                Arc::clone(&mailer),
-                cap_mailbox,
-            ));
-            let mut ctx = NativeCtx::new_dispatching(
-                &transport,
-                session_sender(),
-                aether_data::MailId::NONE,
-                aether_data::MailId::NONE,
-            );
-            cap.on_nanobanana_generate(
-                &mut ctx,
-                nb_request(
-                    "gemini-3.1-flash-image-preview",
-                    AspectRatio::ASPECT_RATIO_1_1,
-                ),
-            );
-            // The disabled adapter returns the Unauthorized sentinel on the
-            // worker; the completion re-replies the mapped error.
-            drive_task_completion(&mut cap, &transport, &rx);
-            match decode_reply::<NanobananaGenerateResult>(&rx) {
-                NanobananaGenerateResult::Err {
-                    error: GeminiError::Unauthorized,
-                    ..
-                } => {}
-                other => panic!("expected Unauthorized, got {other:?}"),
+        // SAFETY: same lock-guarded window as the set above.
+        unsafe {
+            env::remove_var("AETHER_GEN_DIR");
+        }
+        let _ = fs::remove_dir_all(&scratch);
+    }
+
+    #[test]
+    fn gemini_disabled_replies_unauthorized() {
+        let (mailer, rx) = test_mailer_and_rx();
+        let cap_mailbox = MailboxId(0);
+        let mut state = GeminiCapabilityState::from_parts(Arc::new(DisabledGeminiAdapter), 4);
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            cap_mailbox,
+        ));
+        let mut ctx = NativeCtx::new_dispatching(
+            &transport,
+            session_sender(),
+            aether_data::MailId::NONE,
+            aether_data::MailId::NONE,
+        );
+        GeminiCapability::on_nanobanana_generate(
+            &mut state,
+            &mut ctx,
+            nb_request(
+                "gemini-3.1-flash-image-preview",
+                AspectRatio::ASPECT_RATIO_1_1,
+            ),
+        );
+        // The disabled adapter returns the Unauthorized sentinel on the
+        // worker; the completion re-replies the mapped error.
+        drive_task_completion::<GeminiCapability>(&mut state, &transport, &rx);
+        match decode_reply::<NanobananaGenerateResult>(&rx) {
+            NanobananaGenerateResult::Err {
+                error: GeminiError::Unauthorized,
+                ..
+            } => {}
+            other => panic!("expected Unauthorized, got {other:?}"),
+        }
+    }
+
+    fn request_nonce() -> u64 {
+        SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| {
+            #[allow(clippy::cast_possible_truncation)]
+            let n = d.as_nanos() as u64;
+            n
+        })
+    }
+
+    /// Serializes the two seam tests that pin `AETHER_GEN_DIR` so
+    /// their process-env mutation can't race nextest's other threads.
+    static GEN_DIR_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Build a single-artifact `GeminiResponse` whose parse carried a
+    /// `thought_signature`, the shape the cap's reply assembly sees.
+    fn nb_response_with_signature(sig: &str) -> GeminiResponse {
+        GeminiResponse {
+            artifacts: vec![GeminiArtifact {
+                bytes: STUB_PNG.to_vec(),
+                ext: "png".to_string(),
+            }],
+            model_used: "gemini-3-pro-image-preview".to_string(),
+            usage: AdapterUsage::default(),
+            thought_signature: Some(sig.to_string()),
+            grounding: None,
+        }
+    }
+
+    /// Stage `nanobanana_reply` under a scratch `AETHER_GEN_DIR` so
+    /// the seam tests never touch the user's real save dir. Holds the
+    /// env lock across the set/reply/clear window.
+    fn reply_under_scratch_gen_dir(
+        include_sig: bool,
+        resp: GeminiResponse,
+    ) -> NanobananaGenerateResult {
+        let _guard = GEN_DIR_ENV_LOCK
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let scratch = env::temp_dir().join(format!(
+            "aether-gemini-sig-{}-{}",
+            process::id(),
+            request_nonce()
+        ));
+        fs::create_dir_all(&scratch).expect("scratch dir creates");
+        // SAFETY: serialized by GEN_DIR_ENV_LOCK against the other
+        // seam test; no other test reads this var.
+        unsafe {
+            env::set_var("AETHER_GEN_DIR", &scratch);
+        }
+        let reply = nanobanana_reply(1, include_sig, Ok(resp));
+        // SAFETY: same lock-guarded window as the set above.
+        unsafe {
+            env::remove_var("AETHER_GEN_DIR");
+        }
+        let _ = fs::remove_dir_all(&scratch);
+        reply
+    }
+
+    /// Default-off: a response carrying a `thought_signature` is
+    /// cleared from the reply when the flag is unset/false — the
+    /// fix for the multi-MB signature dominating the result.
+    #[test]
+    fn thought_signature_cleared_when_flag_off() {
+        let reply = reply_under_scratch_gen_dir(false, nb_response_with_signature("sig-abc"));
+        match reply {
+            NanobananaGenerateResult::Ok {
+                thought_signature, ..
+            } => {
+                assert_eq!(
+                    thought_signature, None,
+                    "flag off clears the signature from the reply"
+                );
+            }
+            other @ NanobananaGenerateResult::Err { .. } => {
+                panic!("expected Ok, got {other:?}")
             }
         }
+    }
 
-        fn request_nonce() -> u64 {
-            SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| {
-                #[allow(clippy::cast_possible_truncation)]
-                let n = d.as_nanos() as u64;
-                n
-            })
-        }
-
-        /// Serializes the two seam tests that pin `AETHER_GEN_DIR` so
-        /// their process-env mutation can't race nextest's other threads.
-        static GEN_DIR_ENV_LOCK: Mutex<()> = Mutex::new(());
-
-        /// Build a single-artifact `GeminiResponse` whose parse carried a
-        /// `thought_signature`, the shape the cap's reply assembly sees.
-        fn nb_response_with_signature(sig: &str) -> GeminiResponse {
-            GeminiResponse {
-                artifacts: vec![GeminiArtifact {
-                    bytes: STUB_PNG.to_vec(),
-                    ext: "png".to_string(),
-                }],
-                model_used: "gemini-3-pro-image-preview".to_string(),
-                usage: AdapterUsage::default(),
-                thought_signature: Some(sig.to_string()),
-                grounding: None,
+    /// Opt-in: the multi-turn continuation path is unaffected — with
+    /// the flag true the signature is retained exactly as parsed.
+    #[test]
+    fn thought_signature_retained_when_flag_on() {
+        let reply = reply_under_scratch_gen_dir(true, nb_response_with_signature("sig-abc"));
+        match reply {
+            NanobananaGenerateResult::Ok {
+                thought_signature, ..
+            } => {
+                assert_eq!(
+                    thought_signature.as_deref(),
+                    Some("sig-abc"),
+                    "flag on retains the signature for a multi-turn continuation"
+                );
+            }
+            other @ NanobananaGenerateResult::Err { .. } => {
+                panic!("expected Ok, got {other:?}")
             }
         }
+    }
 
-        /// Stage `nanobanana_reply` under a scratch `AETHER_GEN_DIR` so
-        /// the seam tests never touch the user's real save dir. Holds the
-        /// env lock across the set/reply/clear window.
-        fn reply_under_scratch_gen_dir(
-            include_sig: bool,
-            resp: GeminiResponse,
-        ) -> NanobananaGenerateResult {
-            let _guard = GEN_DIR_ENV_LOCK
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner);
-            let scratch = env::temp_dir().join(format!(
-                "aether-gemini-sig-{}-{}",
-                process::id(),
-                request_nonce()
-            ));
-            fs::create_dir_all(&scratch).expect("scratch dir creates");
-            // SAFETY: serialized by GEN_DIR_ENV_LOCK against the other
-            // seam test; no other test reads this var.
-            unsafe {
-                env::set_var("AETHER_GEN_DIR", &scratch);
-            }
-            let reply = super::nanobanana_reply(1, include_sig, Ok(resp));
-            // SAFETY: same lock-guarded window as the set above.
-            unsafe {
-                env::remove_var("AETHER_GEN_DIR");
-            }
-            let _ = fs::remove_dir_all(&scratch);
-            reply
-        }
-
-        /// Default-off: a response carrying a `thought_signature` is
-        /// cleared from the reply when the flag is unset/false — the
-        /// fix for the multi-MB signature dominating the result.
-        #[test]
-        fn thought_signature_cleared_when_flag_off() {
-            let reply = reply_under_scratch_gen_dir(false, nb_response_with_signature("sig-abc"));
-            match reply {
-                NanobananaGenerateResult::Ok {
-                    thought_signature, ..
-                } => {
-                    assert_eq!(
-                        thought_signature, None,
-                        "flag off clears the signature from the reply"
-                    );
-                }
-                other @ NanobananaGenerateResult::Err { .. } => {
-                    panic!("expected Ok, got {other:?}")
-                }
-            }
-        }
-
-        /// Opt-in: the multi-turn continuation path is unaffected — with
-        /// the flag true the signature is retained exactly as parsed.
-        #[test]
-        fn thought_signature_retained_when_flag_on() {
-            let reply = reply_under_scratch_gen_dir(true, nb_response_with_signature("sig-abc"));
-            match reply {
-                NanobananaGenerateResult::Ok {
-                    thought_signature, ..
-                } => {
-                    assert_eq!(
-                        thought_signature.as_deref(),
-                        Some("sig-abc"),
-                        "flag on retains the signature for a multi-turn continuation"
-                    );
-                }
-                other @ NanobananaGenerateResult::Err { .. } => {
-                    panic!("expected Ok, got {other:?}")
-                }
-            }
-        }
-
-        /// The flag is cross-model, not an NB2-only knob: Pro accepts
-        /// `include_thought_signature: Some(true)` and dispatches rather
-        /// than rejecting with `MissingRequiredField`. Mirror of
-        /// `nb2_only_knob_rejected_on_older_model`, asserting acceptance.
-        #[test]
-        fn thought_signature_flag_accepted_on_pro() {
-            // Acceptance dispatches off-thread, so the reply lands
-            // asynchronously — peeking at the reply channel here would race
-            // that dispatch (iamacoffeepot/aether#1296). The deterministic
-            // proof of acceptance is the in-flight count, which `submit`
-            // bumps synchronously on this thread; a synchronous validation
-            // error `return`s before dispatch, leaving it at 0. So we don't
-            // need the reply channel at all.
-            let (mailer, _rx) = test_mailer_and_rx();
-            let cap_mailbox = MailboxId(0);
-            let mut cap = GeminiCapability::from_parts(Arc::new(StubGeminiAdapter), 4);
-            let transport = Arc::new(NativeBinding::new_for_test(
-                Arc::clone(&mailer),
-                cap_mailbox,
-            ));
-            let mut ctx = NativeCtx::new_dispatching(
-                &transport,
-                session_sender(),
-                aether_data::MailId::NONE,
-                aether_data::MailId::NONE,
-            );
-            let mut req = nb_request("gemini-3-pro-image-preview", AspectRatio::ASPECT_RATIO_1_1);
-            req.image_size = Some(ImageSize::K1);
-            req.include_thought_signature = Some(true);
-            cap.on_nanobanana_generate(&mut ctx, req);
-            assert_eq!(
-                cap.test_in_flight(),
-                1,
-                "Pro must accept the cross-model signature flag and dispatch \
-                 it rather than rejecting synchronously"
-            );
-        }
+    /// The flag is cross-model, not an NB2-only knob: Pro accepts
+    /// `include_thought_signature: Some(true)` and dispatches rather
+    /// than rejecting with `MissingRequiredField`. Mirror of
+    /// `nb2_only_knob_rejected_on_older_model`, asserting acceptance.
+    #[test]
+    fn thought_signature_flag_accepted_on_pro() {
+        // Acceptance dispatches off-thread, so the reply lands
+        // asynchronously — peeking at the reply channel here would race
+        // that dispatch (iamacoffeepot/aether#1296). The deterministic
+        // proof of acceptance is the in-flight count, which `submit`
+        // bumps synchronously on this thread; a synchronous validation
+        // error `return`s before dispatch, leaving it at 0. So we don't
+        // need the reply channel at all.
+        let (mailer, _rx) = test_mailer_and_rx();
+        let cap_mailbox = MailboxId(0);
+        let mut state = GeminiCapabilityState::from_parts(Arc::new(StubGeminiAdapter), 4);
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            cap_mailbox,
+        ));
+        let mut ctx = NativeCtx::new_dispatching(
+            &transport,
+            session_sender(),
+            aether_data::MailId::NONE,
+            aether_data::MailId::NONE,
+        );
+        let mut req = nb_request("gemini-3-pro-image-preview", AspectRatio::ASPECT_RATIO_1_1);
+        req.image_size = Some(ImageSize::K1);
+        req.include_thought_signature = Some(true);
+        GeminiCapability::on_nanobanana_generate(&mut state, &mut ctx, req);
+        assert_eq!(
+            state.test_in_flight(),
+            1,
+            "Pro must accept the cross-model signature flag and dispatch \
+             it rather than rejecting synchronously"
+        );
     }
 }

--- a/crates/aether-capabilities/src/gemini/mod.rs
+++ b/crates/aether-capabilities/src/gemini/mod.rs
@@ -30,6 +30,14 @@ mod kinds;
 mod lyria;
 mod nanobanana;
 
+// The `aether.gemini` runtime half (ADR-0122 identity/runtime split): the
+// `aether_substrate`-typed state + reply helpers the `#[actor] impl` in
+// `capability` reaches through `use super::runtime::*`. Gated once here so a
+// transport-only build of the `GeminiCapability` identity never names the
+// state nor pulls `aether_substrate` through this cap.
+#[cfg(feature = "runtime")]
+mod runtime;
+
 pub use adapter::{DisabledGeminiAdapter, UreqGeminiAdapter};
 pub use capability::GeminiCapability;
 pub use config::{GeminiConfig, GeminiConfigLayer, GeminiOverlay};

--- a/crates/aether-capabilities/src/gemini/runtime.rs
+++ b/crates/aether-capabilities/src/gemini/runtime.rs
@@ -1,0 +1,188 @@
+//! The `aether.gemini` runtime half (ADR-0122 identity/runtime split). Compiled
+//! only under `feature = "runtime"` (the `mod runtime;` declaration in the
+//! parent carries the gate), so a transport-only build of the
+//! `GeminiCapability` identity never names these types nor pulls
+//! `aether_substrate`. The substrate-typed imports are gated once by this
+//! module rather than line-by-line; the `#[actor] impl` reaches the state, ctx
+//! types, and reply helpers through the single `use super::runtime::*` glob in
+//! the parent.
+
+use super::adapter::{DisabledGeminiAdapter, UreqGeminiAdapter, map_adapter_error};
+use super::config::GeminiConfig;
+use super::{GeminiError, GroundingMetadata, LyriaGenerateResult, NanobananaGenerateResult};
+use crate::fs::{FileAdapter, LocalFileAdapter};
+use crate::shared::contentgen::adapter::{AdapterUsage, GeminiAdapter, GeminiResponse};
+use crate::shared::contentgen::staging::{gen_root, stage_gen_output};
+
+pub use crate::shared::contentgen::task_queue::TaskQueue;
+pub use std::sync::Arc;
+
+use aether_kinds::Usage;
+
+pub use aether_actor::{Manual, OutboundReply};
+pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
+pub use aether_substrate::chassis::error::BootError;
+
+/// `aether.gemini` runtime state (ADR-0050). Owns the resolved adapter +
+/// the cap-level rate-limit queue over the ADR-0093 dispatch primitive.
+/// Single-threaded post-ADR-0038, so the queue state lives in plain
+/// fields. The dispatcher holds this as the cap's state and routes
+/// envelopes through the macro-emitted `Dispatch` impl; the addressing
+/// identity is the distinct ZST [`GeminiCapability`](super::GeminiCapability).
+/// Living in this private module keeps it `pub`-enough to satisfy the
+/// `NativeActor::State` interface without exposing it as crate-public API.
+pub struct GeminiCapabilityState {
+    pub(super) adapter: Arc<dyn GeminiAdapter>,
+    pub(super) tasks: TaskQueue,
+}
+
+#[cfg(test)]
+impl GeminiCapabilityState {
+    pub(crate) fn from_parts(adapter: Arc<dyn GeminiAdapter>, max_in_flight: usize) -> Self {
+        Self {
+            adapter,
+            tasks: TaskQueue::new(max_in_flight),
+        }
+    }
+
+    pub(crate) fn test_in_flight(&self) -> usize {
+        self.tasks.in_flight()
+    }
+}
+
+pub fn build_adapter(config: &GeminiConfig) -> Arc<dyn GeminiAdapter> {
+    if config.disabled {
+        tracing::info!(
+            target: "aether_capabilities::gemini",
+            "gemini adapter disabled — every request replies Unauthorized",
+        );
+        return Arc::new(DisabledGeminiAdapter);
+    }
+    config.api_key.as_ref().map_or_else(
+        || {
+            tracing::info!(
+                target: "aether_capabilities::gemini",
+                "GEMINI_API_KEY unset — every request replies Unauthorized",
+            );
+            Arc::new(DisabledGeminiAdapter) as Arc<dyn GeminiAdapter>
+        },
+        |key| {
+            tracing::info!(
+                target: "aether_capabilities::gemini",
+                "gemini adapter configured (nanobanana + lyria)",
+            );
+            Arc::new(UreqGeminiAdapter::new(key.clone(), config.timeout)) as Arc<dyn GeminiAdapter>
+        },
+    )
+}
+
+/// Read reference-image bytes from the supplied save-namespace
+/// paths (tool JSON takes paths, the wire stays bytes —
+/// `feedback_no_bytes_in_llm_json`). A read failure aborts the
+/// request with an `AdapterError`.
+pub fn read_reference_images(paths: &[String]) -> Result<Vec<Vec<u8>>, GeminiError> {
+    if paths.is_empty() {
+        return Ok(Vec::new());
+    }
+    let root = gen_root();
+    let adapter =
+        LocalFileAdapter::new(root, true).map_err(|e| GeminiError::AdapterError(e.to_string()))?;
+    let mut out = Vec::with_capacity(paths.len());
+    for path in paths {
+        let bytes = adapter
+            .read(path)
+            .map_err(|e| GeminiError::AdapterError(format!("reference {path}: {e:?}")))?;
+        out.push(bytes);
+    }
+    Ok(out)
+}
+
+fn to_usage(u: AdapterUsage) -> Usage {
+    Usage {
+        input_tokens: u.input_tokens,
+        output_tokens: u.output_tokens,
+        wall_clock_ms: u.wall_clock_ms,
+        cost_micros: u.cost_micros,
+    }
+}
+
+pub fn nanobanana_reply(
+    request_id: u64,
+    include_sig: bool,
+    result: Result<GeminiResponse, String>,
+) -> NanobananaGenerateResult {
+    match result {
+        Ok(resp) => {
+            let model_used = resp.model_used;
+            let usage = to_usage(resp.usage);
+            // Opt-in / default-off: clear the signature unless the
+            // caller asked to retain it for a multi-turn continuation
+            // (a signature can run to multiple MB and dominate the
+            // reply). Parse stays unconditional; the gate is here.
+            let thought_signature = if include_sig {
+                resp.thought_signature
+            } else {
+                None
+            };
+            let grounding = resp
+                .grounding
+                .map(|(search_queries, source_urls)| GroundingMetadata {
+                    search_queries,
+                    source_urls,
+                });
+            let Some(artifact) = resp.artifacts.into_iter().next() else {
+                return NanobananaGenerateResult::Err {
+                    request_id,
+                    error: GeminiError::AdapterError("adapter returned no image".to_string()),
+                };
+            };
+            match stage_gen_output(&artifact.bytes, &artifact.ext) {
+                Ok(output_path) => NanobananaGenerateResult::Ok {
+                    request_id,
+                    output_path,
+                    model_used,
+                    usage,
+                    thought_signature,
+                    grounding,
+                },
+                Err(e) => NanobananaGenerateResult::Err {
+                    request_id,
+                    error: GeminiError::AdapterError(format!("stage image: {e:?}")),
+                },
+            }
+        }
+        Err(raw) => NanobananaGenerateResult::Err {
+            request_id,
+            error: map_adapter_error(&raw),
+        },
+    }
+}
+
+pub fn lyria_reply(request_id: u64, result: Result<GeminiResponse, String>) -> LyriaGenerateResult {
+    match result {
+        Ok(resp) => {
+            let mut output_paths = Vec::with_capacity(resp.artifacts.len());
+            for artifact in &resp.artifacts {
+                match stage_gen_output(&artifact.bytes, &artifact.ext) {
+                    Ok(path) => output_paths.push(path),
+                    Err(e) => {
+                        return LyriaGenerateResult::Err {
+                            request_id,
+                            error: GeminiError::AdapterError(format!("stage clip: {e:?}")),
+                        };
+                    }
+                }
+            }
+            LyriaGenerateResult::Ok {
+                request_id,
+                output_paths,
+                model_used: resp.model_used,
+                usage: to_usage(resp.usage),
+            }
+        }
+        Err(raw) => LyriaGenerateResult::Err {
+            request_id,
+            error: map_adapter_error(&raw),
+        },
+    }
+}

--- a/crates/aether-capabilities/src/test_chassis.rs
+++ b/crates/aether-capabilities/src/test_chassis.rs
@@ -123,13 +123,14 @@ pub fn test_mailer_and_rx() -> (Arc<Mailer>, Receiver<EgressEvent>) {
 /// the completion's reply routes through the reply target captured at
 /// dispatch and parked in the framework's in-flight ledger, not this ctx.
 pub fn drive_task_completion<A>(
-    cap: &mut A,
+    state: &mut A::State,
     binding: &Arc<NativeBinding>,
     rx: &Receiver<EgressEvent>,
 ) where
-    // Spike fold: dispatch is a `NativeActor` assoc fn over `&mut Self::State`.
-    // This helper drives un-split caps, so `State = A`.
-    A: NativeActor<State = A>,
+    // Dispatch is a `NativeActor` assoc fn over `&mut Self::State` (ADR-0122
+    // identity/runtime split). The param is the associated projection, so `A`
+    // is not inferable from it — every call site names it via turbofish.
+    A: NativeActor,
 {
     let payload = loop {
         let event = rx
@@ -151,7 +152,7 @@ pub fn drive_task_completion<A>(
         aether_data::MailId::NONE,
         aether_data::MailId::NONE,
     );
-    A::dispatch(cap, &mut ctx, TaskCompletionWake::ID, &payload)
+    A::dispatch(state, &mut ctx, TaskCompletionWake::ID, &payload)
         .expect("test: task completion routes to a #[handler(task)] arm");
 }
 

--- a/crates/aether-capabilities/src/text/mod.rs
+++ b/crates/aether-capabilities/src/text/mod.rs
@@ -747,7 +747,7 @@ mod native {
                     bytes: vec![0xDE, 0xAD, 0xBE, 0xEF],
                 },
             );
-            drive_task_completion(&mut cap, &binding, &rx);
+            drive_task_completion::<TextCapability>(&mut cap, &binding, &rx);
             match decode_session_reply::<LoadFontResult>(&rx) {
                 LoadFontResult::Err { error, .. } => {
                     assert!(error.contains("parse"), "unexpected error: {error}");
@@ -1162,7 +1162,7 @@ mod native {
                     bytes: test_font_bytes().to_vec(),
                 },
             );
-            drive_task_completion(&mut cap, &binding, &rx);
+            drive_task_completion::<TextCapability>(&mut cap, &binding, &rx);
             match decode_session_reply::<FontMetricsResult>(&rx) {
                 FontMetricsResult::Ok { metrics } => {
                     assert!(!metrics.advances.is_empty());


### PR DESCRIPTION
Closes #2325.

## Summary

Migrates the two AI caps off `#[bridge]` onto the ADR-0122 identity/runtime split: `GeminiCapability` and `AnthropicCapability` (both singleton, heavy — `adapter: Arc<dyn …>` + `tasks: TaskQueue`), each a ZST identity + top-level `#[actor(singleton)] impl NativeActor` with handlers (incl. `#[handler::manual]` and `#[handler(task)]`) over `state: &mut Self::State`, and its substrate-typed half in a `#[cfg(feature = "runtime")] mod runtime;` file reached via one `use runtime::*` glob.

Generalizes the shared `test_chassis::drive_task_completion` helper from `A: NativeActor<State = A>` to `A: NativeActor` (taking `state: &mut A::State`); the now-ambiguous call sites in the still-un-split `audio` (6) and `text` (2) test modules get an `::<Cap>` turbofish — a forward-compatible no-op for their later split.

## Test plan

- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo nextest run -p aether-capabilities --features audio-native,text-native` (381 passed incl. all gemini/anthropic dispatch tests), strict `cargo doc`, transport-only build — all green.
- Validated via `scripts/attest.sh --publish`.

## Generated by

`/implement --sweep --attest` — agent execution of scoped issue #2325.
