### PR TITLE
refactor(labyrinth): split the trajectory recorder actor into identity and runtime modules

### DIFF
--- a/crates/aether-labyrinth/src/trajectory.rs
+++ b/crates/aether-labyrinth/src/trajectory.rs
@@ -3,7 +3,9 @@
 //! samples into a typed, seed-keyed `TrajectoryLog` that an offline
 //! analysis transform can replay.
 //!
-//! State is a plain `sessions` `HashMap`. Every handler runs on the cap's
+//! The cap identity is `TrajectoryRecorderCapability` (a ZST); its runtime
+//! state (`TrajectoryRecorderCapabilityState`, holding the `sessions` map)
+//! lives in the inline `runtime` module. Every handler runs on the cap's
 //! dispatcher thread (ADR-0078 plain-field, no locks). Registered as
 //! `aether.trajectory` via `with_common_caps` on desktop and headless
 //! chassis; the test-bench chassis adds it explicitly.
@@ -21,431 +23,448 @@
 // decoded bytes so callers can't see references.
 #![allow(clippy::needless_pass_by_value)]
 
-use aether_kinds::{TrajectoryEnd, TrajectorySample};
+use aether_actor::actor;
+use aether_kinds::{
+    RecordResult, TrajectoryEnd, TrajectoryLog, TrajectorySample, TrajectorySampleEntry,
+};
 
-#[aether_actor::bridge(singleton)]
-mod native {
-    use std::collections::HashMap;
+// The `runtime` module is this cap's private runtime-half namespace; the impl
+// reaches all of it (state, ctx types) through this single seam, so the glob
+// is intentional rather than a handful of one-line imports.
+#[allow(clippy::wildcard_imports)]
+use runtime::*;
 
-    use aether_actor::actor;
-    use aether_kinds::{
-        RecordResult, TrajectoryEnd, TrajectoryLog, TrajectorySample, TrajectorySampleEntry,
-    };
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
+/// `aether.trajectory` cap identity (ADR-0122 identity/runtime split). A ZST
+/// carrying only the addressing — `Addressable` (`NAMESPACE`, `Resolver`) and
+/// the per-handler `HandlesKind` markers, emitted always-on by `#[actor]`. The
+/// state-bearing runtime (`TrajectoryRecorderCapabilityState`, which holds the
+/// session buffers) lives in the inline `runtime` module below.
+pub struct TrajectoryRecorderCapability;
 
-    /// `aether.trajectory` mailbox cap. Accumulates per-tick samples
-    /// from a moving point into a typed `TrajectoryLog` that an offline
-    /// analysis transform can replay.
+#[actor(singleton, runtime_feature = "native")]
+impl NativeActor for TrajectoryRecorderCapability {
+    type State = TrajectoryRecorderCapabilityState;
+
+    type Config = ();
+
+    /// ADR-0074 §5: chassis-owned mailbox under the `aether.<name>`
+    /// namespace. Single-segment name matches the dominant chassis-cap
+    /// convention (`aether.input`, `aether.render`).
+    const NAMESPACE: &'static str = "aether.trajectory";
+
+    fn init(
+        (): (),
+        _ctx: &mut NativeInitCtx<'_>,
+    ) -> Result<TrajectoryRecorderCapabilityState, BootError> {
+        Ok(TrajectoryRecorderCapabilityState {
+            sessions: HashMap::new(),
+        })
+    }
+
+    /// Append one per-tick sample to the in-flight buffer for
+    /// `s.seed`. Creates the buffer on first arrival for that seed.
+    /// Fire-and-forget — no reply.
     ///
-    /// State is plain fields — single-threaded, every handler on the
-    /// cap's dispatcher thread (ADR-0078). No locks needed.
-    pub struct TrajectoryRecorderCapability {
+    /// # Agent
+    /// No reply (fire-and-forget). Address this cap by type:
+    /// `ctx.actor::<TrajectoryRecorderCapability>().send(&sample)`.
+    #[handler]
+    fn on_sample(state: &mut Self::State, _ctx: &mut NativeCtx<'_>, s: TrajectorySample) {
+        state
+            .sessions
+            .entry(s.seed)
+            .or_default()
+            .push(TrajectorySampleEntry {
+                tick: s.tick,
+                x: s.x,
+                y: s.y,
+                value: s.value,
+            });
+    }
+
+    /// Flush the in-flight buffer for `e.seed`, build a
+    /// `TrajectoryLog`, and return it inline in `RecordResult`.
+    ///
+    /// # Agent
+    /// Reply: `RecordResult`. `Ok` carries the seed and the complete
+    /// `TrajectoryLog` for the session. `Err` when `seed` names no
+    /// in-flight session (unknown seed or already terminated).
+    #[handler]
+    fn on_end(state: &mut Self::State, _ctx: &mut NativeCtx<'_>, e: TrajectoryEnd) -> RecordResult {
+        let Some(samples) = state.sessions.remove(&e.seed) else {
+            return RecordResult::Err {
+                seed: e.seed,
+                error: format!("no in-flight session for seed {}", e.seed),
+            };
+        };
+
+        let log = TrajectoryLog {
+            seed: e.seed,
+            samples,
+            end_reason: e.reason,
+        };
+
+        RecordResult::Ok { seed: e.seed, log }
+    }
+}
+
+// The runtime half (state + substrate-typed imports). The whole `trajectory`
+// module is already gated at its declaration in `lib.rs` via
+// `#[cfg(feature = "native")] pub mod trajectory;`, so every line here
+// compiles only when `native` is enabled — no inner `#[cfg]` is needed.
+// The `#[actor] impl` above reaches all of it through the single
+// `use runtime::*` glob at module root.
+mod runtime {
+    use super::TrajectorySampleEntry;
+
+    pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    pub use aether_substrate::chassis::error::BootError;
+    pub use std::collections::HashMap;
+
+    /// `aether.trajectory` runtime state (ADR-0122 split). Holds the
+    /// per-seed in-flight sample buffers accumulated by `on_sample` and
+    /// flushed by `on_end`. The addressing identity is the distinct ZST
+    /// `TrajectoryRecorderCapability`.
+    pub struct TrajectoryRecorderCapabilityState {
         /// Per-seed in-flight sample buffers. Created on the first
         /// `TrajectorySample` for a seed; flushed and removed on the
         /// matching `TrajectoryEnd`.
-        sessions: HashMap<u64, Vec<TrajectorySampleEntry>>,
+        pub(super) sessions: HashMap<u64, Vec<TrajectorySampleEntry>>,
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-setup unwraps: fixture construction panic on failure is the assertion"
+)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::mpsc;
+
+    use aether_data::{Kind, MailId, MailboxId};
+    use aether_kinds::descriptors;
+    use aether_kinds::trace::Nanos;
+    use aether_kinds::{
+        RecordResult, TrajectoryEnd, TrajectoryEndReason, TrajectorySample, TrajectorySampleEntry,
+    };
+    use aether_substrate::actor::native::NativeCtx;
+    use aether_substrate::actor::native::binding::NativeBinding;
+    use aether_substrate::mail::mailer::Mailer;
+    use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
+    use aether_substrate::mail::registry::{OwnedDispatch, Registry};
+    use aether_substrate::mail::{MailRef, Source, SourceAddr};
+
+    use super::TrajectoryRecorderCapability;
+    use super::runtime::TrajectoryRecorderCapabilityState;
+    use crate::test_chassis::{TestChassis, boot_test_chassis_with};
+    use aether_actor::Addressable;
+    use aether_substrate::chassis::builder::Builder;
+    use std::collections::HashMap;
+
+    /// Build a substrate for the direct-call unit tests and the heavy
+    /// dispatcher test.
+    fn fresh_substrate() -> (Arc<Mailer>, Arc<Registry>, mpsc::Receiver<EgressEvent>) {
+        let registry = Arc::new(Registry::new());
+        for d in descriptors::all() {
+            let _ = registry.register_kind_with_descriptor(d);
+        }
+        let (outbound, rx) = HubOutbound::attached_loopback();
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry)).with_outbound(outbound));
+        (mailer, registry, rx)
     }
 
-    #[actor]
-    impl NativeActor for TrajectoryRecorderCapability {
-        type Config = ();
-
-        /// ADR-0074 §5: chassis-owned mailbox under the `aether.<name>`
-        /// namespace. Single-segment name matches the dominant chassis-cap
-        /// convention (`aether.input`, `aether.render`).
-        const NAMESPACE: &'static str = "aether.trajectory";
-
-        fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            Ok(Self {
-                sessions: HashMap::new(),
-            })
-        }
-
-        /// Append one per-tick sample to the in-flight buffer for
-        /// `s.seed`. Creates the buffer on first arrival for that seed.
-        /// Fire-and-forget — no reply.
-        ///
-        /// # Agent
-        /// No reply (fire-and-forget). Address this cap by type:
-        /// `ctx.actor::<TrajectoryRecorderCapability>().send(&sample)`.
-        #[handler]
-        fn on_sample(&mut self, _ctx: &mut NativeCtx<'_>, s: TrajectorySample) {
-            self.sessions
-                .entry(s.seed)
-                .or_default()
-                .push(TrajectorySampleEntry {
-                    tick: s.tick,
-                    x: s.x,
-                    y: s.y,
-                    value: s.value,
-                });
-        }
-
-        /// Flush the in-flight buffer for `e.seed`, build a
-        /// `TrajectoryLog`, and return it inline in `RecordResult`.
-        ///
-        /// # Agent
-        /// Reply: `RecordResult`. `Ok` carries the seed and the complete
-        /// `TrajectoryLog` for the session. `Err` when `seed` names no
-        /// in-flight session (unknown seed or already terminated).
-        #[handler]
-        fn on_end(&mut self, _ctx: &mut NativeCtx<'_>, e: TrajectoryEnd) -> RecordResult {
-            let Some(samples) = self.sessions.remove(&e.seed) else {
-                return RecordResult::Err {
-                    seed: e.seed,
-                    error: format!("no in-flight session for seed {}", e.seed),
-                };
-            };
-
-            let log = TrajectoryLog {
-                seed: e.seed,
-                samples,
-                end_reason: e.reason,
-            };
-
-            RecordResult::Ok { seed: e.seed, log }
-        }
-    }
-
-    #[cfg(test)]
-    #[allow(
-        clippy::unwrap_used,
-        reason = "test-setup unwraps: fixture construction panic on failure is the assertion"
-    )]
-    mod tests {
-        use std::sync::Arc;
-        use std::sync::mpsc;
-
-        use aether_data::{Kind, MailId, MailboxId};
-        use aether_kinds::TrajectoryEndReason;
-        use aether_kinds::descriptors;
-        use aether_kinds::trace::Nanos;
-        use aether_substrate::actor::native::binding::NativeBinding;
-        use aether_substrate::mail::mailer::Mailer;
-        use aether_substrate::mail::outbound::{EgressEvent, HubOutbound};
-        use aether_substrate::mail::registry::{OwnedDispatch, Registry};
-        use aether_substrate::mail::{MailRef, Source, SourceAddr};
-
-        use super::*;
-        use crate::test_chassis::{TestChassis, boot_test_chassis_with};
-        use aether_actor::Addressable;
-        use aether_substrate::chassis::builder::Builder;
-
-        /// Build a substrate for the direct-call unit tests and the heavy
-        /// dispatcher test.
-        fn fresh_substrate() -> (Arc<Mailer>, Arc<Registry>, mpsc::Receiver<EgressEvent>) {
-            let registry = Arc::new(Registry::new());
-            for d in descriptors::all() {
-                let _ = registry.register_kind_with_descriptor(d);
-            }
-            let (outbound, rx) = HubOutbound::attached_loopback();
-            let mailer = Arc::new(Mailer::new(Arc::clone(&registry)).with_outbound(outbound));
-            (mailer, registry, rx)
-        }
-
-        /// Create a session-targeted `Source` for direct handler calls.
-        fn session_source() -> Source {
-            use aether_data::{SessionToken, Uuid};
-            Source::to(SourceAddr::Session(SessionToken(Uuid::from_u128(
-                0xfeed_u128,
-            ))))
-        }
-
-        /// Directly-exercised capability fixture (no dispatcher thread).
-        struct DirectFixture {
-            cap: TrajectoryRecorderCapability,
-            transport: Arc<NativeBinding>,
-        }
-
-        fn direct_fixture() -> DirectFixture {
-            let (mailer, _registry, _rx) = fresh_substrate();
-            let transport = Arc::new(NativeBinding::new_for_test(
-                Arc::clone(&mailer),
-                MailboxId(0x1862),
-            ));
-            let cap = TrajectoryRecorderCapability {
-                sessions: HashMap::new(),
-            };
-            DirectFixture { cap, transport }
-        }
-
-        fn make_ctx(transport: &Arc<NativeBinding>) -> NativeCtx<'_> {
-            NativeCtx::new(transport, session_source(), MailId::NONE, MailId::NONE)
-        }
-
-        // Unit tests — direct handler calls, no dispatcher thread.
-
-        /// A sample for a fresh seed creates a buffer and appends the
-        /// entry. A second sample for the same seed appends to the same
-        /// buffer.
-        #[test]
-        fn on_sample_appends_to_seed_buffer() {
-            let mut fix = direct_fixture();
-            let mut ctx = make_ctx(&fix.transport);
-
-            fix.cap.on_sample(
-                &mut ctx,
-                TrajectorySample {
-                    seed: 42,
-                    tick: 1,
-                    x: 3,
-                    y: 4,
-                    value: 99,
-                },
-            );
-            fix.cap.on_sample(
-                &mut ctx,
-                TrajectorySample {
-                    seed: 42,
-                    tick: 2,
-                    x: 5,
-                    y: 6,
-                    value: 100,
-                },
-            );
-
-            let buf = fix.cap.sessions.get(&42).expect("seed 42 buffer exists");
-            assert_eq!(buf.len(), 2, "two samples for seed 42");
-            assert_eq!(
-                buf[0],
-                TrajectorySampleEntry {
-                    tick: 1,
-                    x: 3,
-                    y: 4,
-                    value: 99
-                }
-            );
-            assert_eq!(
-                buf[1],
-                TrajectorySampleEntry {
-                    tick: 2,
-                    x: 5,
-                    y: 6,
-                    value: 100
-                }
-            );
-        }
-
-        /// Two interleaved seeds accumulate into separate buffers; neither
-        /// spills into the other.
-        #[test]
-        fn on_sample_keeps_seeds_separate() {
-            let mut fix = direct_fixture();
-            let mut ctx = make_ctx(&fix.transport);
-
-            fix.cap.on_sample(
-                &mut ctx,
-                TrajectorySample {
-                    seed: 1,
-                    tick: 10,
-                    x: 0,
-                    y: 0,
-                    value: 1,
-                },
-            );
-            fix.cap.on_sample(
-                &mut ctx,
-                TrajectorySample {
-                    seed: 2,
-                    tick: 11,
-                    x: 7,
-                    y: 8,
-                    value: 2,
-                },
-            );
-            fix.cap.on_sample(
-                &mut ctx,
-                TrajectorySample {
-                    seed: 1,
-                    tick: 12,
-                    x: 1,
-                    y: 0,
-                    value: 3,
-                },
-            );
-
-            let buf1 = fix.cap.sessions.get(&1).expect("seed 1 buffer exists");
-            let buf2 = fix.cap.sessions.get(&2).expect("seed 2 buffer exists");
-            assert_eq!(buf1.len(), 2, "seed 1 has two samples");
-            assert_eq!(buf2.len(), 1, "seed 2 has one sample");
-            assert_eq!(
-                buf2[0],
-                TrajectorySampleEntry {
-                    tick: 11,
-                    x: 7,
-                    y: 8,
-                    value: 2
-                }
-            );
-        }
-
-        /// `on_end` returns a `TrajectoryLog` inline carrying the samples
-        /// in tick order, removes the buffer, and returns `RecordResult::Ok`.
-        #[test]
-        fn on_end_returns_inline_log() {
-            let mut fix = direct_fixture();
-            let mut ctx = make_ctx(&fix.transport);
-
-            let seed = 7u64;
-            fix.cap.on_sample(
-                &mut ctx,
-                TrajectorySample {
-                    seed,
-                    tick: 1,
-                    x: 0,
-                    y: 0,
-                    value: 10,
-                },
-            );
-            fix.cap.on_sample(
-                &mut ctx,
-                TrajectorySample {
-                    seed,
-                    tick: 2,
-                    x: 1,
-                    y: 0,
-                    value: 20,
-                },
-            );
-
-            let result = fix.cap.on_end(
-                &mut ctx,
-                TrajectoryEnd {
-                    seed,
-                    reason: TrajectoryEndReason::Completed,
-                },
-            );
-
-            let RecordResult::Ok {
-                seed: out_seed,
-                log,
-            } = result
-            else {
-                panic!("expected RecordResult::Ok, got {result:?}");
-            };
-
-            assert_eq!(out_seed, seed, "seed echoed");
-
-            // Verify the session buffer was cleared.
-            assert!(
-                !fix.cap.sessions.contains_key(&seed),
-                "session buffer removed after on_end"
-            );
-
-            // The inline log carries the expected samples in tick order.
-            assert_eq!(log.seed, seed);
-            assert_eq!(log.end_reason, TrajectoryEndReason::Completed);
-            assert_eq!(log.samples.len(), 2);
-            assert_eq!(
-                log.samples[0],
-                TrajectorySampleEntry {
-                    tick: 1,
-                    x: 0,
-                    y: 0,
-                    value: 10
-                }
-            );
-            assert_eq!(
-                log.samples[1],
-                TrajectorySampleEntry {
-                    tick: 2,
-                    x: 1,
-                    y: 0,
-                    value: 20
-                }
-            );
-        }
-
-        /// `on_end` for a seed with no in-flight session returns
-        /// `RecordResult::Err`.
-        #[test]
-        fn on_end_unknown_seed_returns_err() {
-            let mut fix = direct_fixture();
-            let mut ctx = make_ctx(&fix.transport);
-
-            let result = fix.cap.on_end(
-                &mut ctx,
-                TrajectoryEnd {
-                    seed: 999,
-                    reason: TrajectoryEndReason::Aborted,
-                },
-            );
-
-            assert!(
-                matches!(result, RecordResult::Err { seed: 999, .. }),
-                "expected Err for unknown seed, got {result:?}"
-            );
-        }
-
-        use std::thread;
-        use std::time::{Duration, Instant};
-
+    /// Create a session-targeted `Source` for direct handler calls.
+    fn session_source() -> Source {
         use aether_data::{SessionToken, Uuid};
-        use aether_substrate::mail::registry::MailboxEntry;
+        Source::to(SourceAddr::Session(SessionToken(Uuid::from_u128(
+            0xfeed_u128,
+        ))))
+    }
 
-        /// End-to-end through the dispatcher thread: boot the cap via
-        /// `boot_test_chassis_with`, enqueue `TrajectorySample`s then a
-        /// `TrajectoryEnd`, assert `RecordResult::Ok` arrives on the
-        /// loopback channel carrying the decodable `TrajectoryLog` inline.
-        /// Sleep-polls under a multi-second deadline.
-        #[test]
-        fn capability_routes_end_through_dispatcher_thread() {
-            let (mailer, registry, rx) = fresh_substrate();
+    /// Directly-exercised capability fixture (no dispatcher thread).
+    struct DirectFixture {
+        state: TrajectoryRecorderCapabilityState,
+        transport: Arc<NativeBinding>,
+    }
 
-            let chassis =
-                boot_test_chassis_with::<TrajectoryRecorderCapability>(&registry, &mailer, ());
+    fn direct_fixture() -> DirectFixture {
+        let (mailer, _registry, _rx) = fresh_substrate();
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            MailboxId(0x1862),
+        ));
+        let state = TrajectoryRecorderCapabilityState {
+            sessions: HashMap::new(),
+        };
+        DirectFixture { state, transport }
+    }
 
-            let mbx_id = registry
-                .lookup(TrajectoryRecorderCapability::NAMESPACE)
-                .expect("aether.trajectory registered");
+    // A free fn (not a `&self` method) so the borrow is of `fix.transport`
+    // only, leaving `&mut fix.state` a disjoint field borrow at the call
+    // site — ADR-0122 split: handlers are associated fns on the identity
+    // taking `state: &mut TrajectoryRecorderCapabilityState`.
+    fn make_ctx(transport: &Arc<NativeBinding>) -> NativeCtx<'_> {
+        NativeCtx::new(transport, session_source(), MailId::NONE, MailId::NONE)
+    }
 
-            let MailboxEntry::Inbox { handler, .. } = registry.entry(mbx_id).expect("entry exists")
-            else {
-                panic!("expected Inbox entry");
-            };
+    // Unit tests — direct handler calls, no dispatcher thread.
 
-            let seed = 1234u64;
+    /// A sample for a fresh seed creates a buffer and appends the
+    /// entry. A second sample for the same seed appends to the same
+    /// buffer.
+    #[test]
+    fn on_sample_appends_to_seed_buffer() {
+        let mut fix = direct_fixture();
+        let mut ctx = make_ctx(&fix.transport);
 
-            // Send two samples.
-            for (tick, x, y, value) in [(1u32, 2u32, 3u32, 10u32), (2, 4, 5, 20)] {
-                let s = TrajectorySample {
-                    seed,
-                    tick,
-                    x,
-                    y,
-                    value,
-                };
-                let bytes = s.encode_into_bytes();
-                handler.enqueue(OwnedDispatch::disarmed(
-                    <TrajectorySample as Kind>::ID,
-                    "aether.trajectory.sample".to_owned(),
-                    None,
-                    Source::NONE,
-                    MailRef::from(bytes),
-                    1,
-                    MailId::NONE,
-                    MailId::NONE,
-                    None,
-                    Nanos(0),
-                    0,
-                    MailboxId(0),
-                ));
+        TrajectoryRecorderCapability::on_sample(
+            &mut fix.state,
+            &mut ctx,
+            TrajectorySample {
+                seed: 42,
+                tick: 1,
+                x: 3,
+                y: 4,
+                value: 99,
+            },
+        );
+        TrajectoryRecorderCapability::on_sample(
+            &mut fix.state,
+            &mut ctx,
+            TrajectorySample {
+                seed: 42,
+                tick: 2,
+                x: 5,
+                y: 6,
+                value: 100,
+            },
+        );
+
+        let buf = fix.state.sessions.get(&42).expect("seed 42 buffer exists");
+        assert_eq!(buf.len(), 2, "two samples for seed 42");
+        assert_eq!(
+            buf[0],
+            TrajectorySampleEntry {
+                tick: 1,
+                x: 3,
+                y: 4,
+                value: 99
             }
+        );
+        assert_eq!(
+            buf[1],
+            TrajectorySampleEntry {
+                tick: 2,
+                x: 5,
+                y: 6,
+                value: 100
+            }
+        );
+    }
 
-            // Send the terminal event with a session reply target so
-            // the dispatcher can route the RecordResult reply.
-            let reply_to = Source::to(SourceAddr::Session(SessionToken(Uuid::from_u128(0x1862))));
-            let end = TrajectoryEnd {
+    /// Two interleaved seeds accumulate into separate buffers; neither
+    /// spills into the other.
+    #[test]
+    fn on_sample_keeps_seeds_separate() {
+        let mut fix = direct_fixture();
+        let mut ctx = make_ctx(&fix.transport);
+
+        TrajectoryRecorderCapability::on_sample(
+            &mut fix.state,
+            &mut ctx,
+            TrajectorySample {
+                seed: 1,
+                tick: 10,
+                x: 0,
+                y: 0,
+                value: 1,
+            },
+        );
+        TrajectoryRecorderCapability::on_sample(
+            &mut fix.state,
+            &mut ctx,
+            TrajectorySample {
+                seed: 2,
+                tick: 11,
+                x: 7,
+                y: 8,
+                value: 2,
+            },
+        );
+        TrajectoryRecorderCapability::on_sample(
+            &mut fix.state,
+            &mut ctx,
+            TrajectorySample {
+                seed: 1,
+                tick: 12,
+                x: 1,
+                y: 0,
+                value: 3,
+            },
+        );
+
+        let buf1 = fix.state.sessions.get(&1).expect("seed 1 buffer exists");
+        let buf2 = fix.state.sessions.get(&2).expect("seed 2 buffer exists");
+        assert_eq!(buf1.len(), 2, "seed 1 has two samples");
+        assert_eq!(buf2.len(), 1, "seed 2 has one sample");
+        assert_eq!(
+            buf2[0],
+            TrajectorySampleEntry {
+                tick: 11,
+                x: 7,
+                y: 8,
+                value: 2
+            }
+        );
+    }
+
+    /// `on_end` returns a `TrajectoryLog` inline carrying the samples
+    /// in tick order, removes the buffer, and returns `RecordResult::Ok`.
+    #[test]
+    fn on_end_returns_inline_log() {
+        let mut fix = direct_fixture();
+        let mut ctx = make_ctx(&fix.transport);
+
+        let seed = 7u64;
+        TrajectoryRecorderCapability::on_sample(
+            &mut fix.state,
+            &mut ctx,
+            TrajectorySample {
+                seed,
+                tick: 1,
+                x: 0,
+                y: 0,
+                value: 10,
+            },
+        );
+        TrajectoryRecorderCapability::on_sample(
+            &mut fix.state,
+            &mut ctx,
+            TrajectorySample {
+                seed,
+                tick: 2,
+                x: 1,
+                y: 0,
+                value: 20,
+            },
+        );
+
+        let result = TrajectoryRecorderCapability::on_end(
+            &mut fix.state,
+            &mut ctx,
+            TrajectoryEnd {
                 seed,
                 reason: TrajectoryEndReason::Completed,
+            },
+        );
+
+        let RecordResult::Ok {
+            seed: out_seed,
+            log,
+        } = result
+        else {
+            panic!("expected RecordResult::Ok, got {result:?}");
+        };
+
+        assert_eq!(out_seed, seed, "seed echoed");
+
+        // Verify the session buffer was cleared.
+        assert!(
+            !fix.state.sessions.contains_key(&seed),
+            "session buffer removed after on_end"
+        );
+
+        // The inline log carries the expected samples in tick order.
+        assert_eq!(log.seed, seed);
+        assert_eq!(log.end_reason, TrajectoryEndReason::Completed);
+        assert_eq!(log.samples.len(), 2);
+        assert_eq!(
+            log.samples[0],
+            TrajectorySampleEntry {
+                tick: 1,
+                x: 0,
+                y: 0,
+                value: 10
+            }
+        );
+        assert_eq!(
+            log.samples[1],
+            TrajectorySampleEntry {
+                tick: 2,
+                x: 1,
+                y: 0,
+                value: 20
+            }
+        );
+    }
+
+    /// `on_end` for a seed with no in-flight session returns
+    /// `RecordResult::Err`.
+    #[test]
+    fn on_end_unknown_seed_returns_err() {
+        let mut fix = direct_fixture();
+        let mut ctx = make_ctx(&fix.transport);
+
+        let result = TrajectoryRecorderCapability::on_end(
+            &mut fix.state,
+            &mut ctx,
+            TrajectoryEnd {
+                seed: 999,
+                reason: TrajectoryEndReason::Aborted,
+            },
+        );
+
+        assert!(
+            matches!(result, RecordResult::Err { seed: 999, .. }),
+            "expected Err for unknown seed, got {result:?}"
+        );
+    }
+
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    use aether_data::{SessionToken, Uuid};
+    use aether_substrate::mail::registry::MailboxEntry;
+
+    /// End-to-end through the dispatcher thread: boot the cap via
+    /// `boot_test_chassis_with`, enqueue `TrajectorySample`s then a
+    /// `TrajectoryEnd`, assert `RecordResult::Ok` arrives on the
+    /// loopback channel carrying the decodable `TrajectoryLog` inline.
+    /// Sleep-polls under a multi-second deadline.
+    #[test]
+    fn capability_routes_end_through_dispatcher_thread() {
+        let (mailer, registry, rx) = fresh_substrate();
+
+        let chassis =
+            boot_test_chassis_with::<TrajectoryRecorderCapability>(&registry, &mailer, ());
+
+        let mbx_id = registry
+            .lookup(TrajectoryRecorderCapability::NAMESPACE)
+            .expect("aether.trajectory registered");
+
+        let MailboxEntry::Inbox { handler, .. } = registry.entry(mbx_id).expect("entry exists")
+        else {
+            panic!("expected Inbox entry");
+        };
+
+        let seed = 1234u64;
+
+        // Send two samples.
+        for (tick, x, y, value) in [(1u32, 2u32, 3u32, 10u32), (2, 4, 5, 20)] {
+            let s = TrajectorySample {
+                seed,
+                tick,
+                x,
+                y,
+                value,
             };
-            let bytes = end.encode_into_bytes();
+            let bytes = s.encode_into_bytes();
             handler.enqueue(OwnedDispatch::disarmed(
-                <TrajectoryEnd as Kind>::ID,
-                "aether.trajectory.end".to_owned(),
+                <TrajectorySample as Kind>::ID,
+                "aether.trajectory.sample".to_owned(),
                 None,
-                reply_to,
+                Source::NONE,
                 MailRef::from(bytes),
                 1,
                 MailId::NONE,
@@ -455,60 +474,83 @@ mod native {
                 0,
                 MailboxId(0),
             ));
-
-            // Poll the outbound channel for the RecordResult reply.
-            let deadline = Instant::now() + Duration::from_secs(5);
-            let payload = loop {
-                if let Ok(EgressEvent::ToSession { payload, .. }) = rx.try_recv() {
-                    break payload;
-                }
-                assert!(
-                    Instant::now() < deadline,
-                    "RecordResult reply did not arrive within deadline"
-                );
-                thread::sleep(Duration::from_millis(5));
-            };
-
-            let result = RecordResult::decode_from_bytes(&payload).expect("RecordResult decodes");
-            let RecordResult::Ok {
-                seed: out_seed,
-                log,
-            } = result
-            else {
-                panic!("expected RecordResult::Ok, got {result:?}");
-            };
-
-            assert_eq!(out_seed, seed, "seed echoed");
-
-            // The reply carries the decodable log inline.
-            assert_eq!(log.seed, seed);
-            assert_eq!(log.end_reason, TrajectoryEndReason::Completed);
-            assert_eq!(log.samples.len(), 2);
-
-            drop(chassis);
         }
 
-        /// Builder rejects a duplicate claim on `aether.trajectory`.
-        #[test]
-        fn duplicate_claim_rejects_with_typed_error() {
-            use aether_substrate::chassis::error::BootError;
-            use aether_substrate::mail::registry;
+        // Send the terminal event with a session reply target so
+        // the dispatcher can route the RecordResult reply.
+        let reply_to = Source::to(SourceAddr::Session(SessionToken(Uuid::from_u128(0x1862))));
+        let end = TrajectoryEnd {
+            seed,
+            reason: TrajectoryEndReason::Completed,
+        };
+        let bytes = end.encode_into_bytes();
+        handler.enqueue(OwnedDispatch::disarmed(
+            <TrajectoryEnd as Kind>::ID,
+            "aether.trajectory.end".to_owned(),
+            None,
+            reply_to,
+            MailRef::from(bytes),
+            1,
+            MailId::NONE,
+            MailId::NONE,
+            None,
+            Nanos(0),
+            0,
+            MailboxId(0),
+        ));
 
-            let (mailer, registry_arc, _rx) = fresh_substrate();
-            registry_arc.register_inbox(
-                TrajectoryRecorderCapability::NAMESPACE,
-                registry::noop_handler(),
+        // Poll the outbound channel for the RecordResult reply.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let payload = loop {
+            if let Ok(EgressEvent::ToSession { payload, .. }) = rx.try_recv() {
+                break payload;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "RecordResult reply did not arrive within deadline"
             );
+            thread::sleep(Duration::from_millis(5));
+        };
 
-            let err = Builder::<TestChassis>::new(Arc::clone(&registry_arc), Arc::clone(&mailer))
-                .with_actor::<TrajectoryRecorderCapability>(())
-                .build_passive()
-                .expect_err("collision must surface as BootError");
-            assert!(matches!(
-                err,
-                BootError::MailboxAlreadyClaimed { ref name }
-                    if name == TrajectoryRecorderCapability::NAMESPACE
-            ));
-        }
+        let result = RecordResult::decode_from_bytes(&payload).expect("RecordResult decodes");
+        let RecordResult::Ok {
+            seed: out_seed,
+            log,
+        } = result
+        else {
+            panic!("expected RecordResult::Ok, got {result:?}");
+        };
+
+        assert_eq!(out_seed, seed, "seed echoed");
+
+        // The reply carries the decodable log inline.
+        assert_eq!(log.seed, seed);
+        assert_eq!(log.end_reason, TrajectoryEndReason::Completed);
+        assert_eq!(log.samples.len(), 2);
+
+        drop(chassis);
+    }
+
+    /// Builder rejects a duplicate claim on `aether.trajectory`.
+    #[test]
+    fn duplicate_claim_rejects_with_typed_error() {
+        use aether_substrate::chassis::error::BootError;
+        use aether_substrate::mail::registry;
+
+        let (mailer, registry_arc, _rx) = fresh_substrate();
+        registry_arc.register_inbox(
+            TrajectoryRecorderCapability::NAMESPACE,
+            registry::noop_handler(),
+        );
+
+        let err = Builder::<TestChassis>::new(Arc::clone(&registry_arc), Arc::clone(&mailer))
+            .with_actor::<TrajectoryRecorderCapability>(())
+            .build_passive()
+            .expect_err("collision must surface as BootError");
+        assert!(matches!(
+            err,
+            BootError::MailboxAlreadyClaimed { ref name }
+                if name == TrajectoryRecorderCapability::NAMESPACE
+        ));
     }
 }


### PR DESCRIPTION
Closes #2329.

## Summary

Migrates `TrajectoryRecorderCapability` (`crates/aether-labyrinth/src/trajectory.rs`) off `#[bridge(singleton)]` onto the ADR-0122 identity/runtime split: a ZST identity + a top-level `#[actor(singleton)] impl NativeActor` with handlers over `state: &mut Self::State`, and the substrate-typed half (`TrajectoryRecorderCapabilityState`, holding the `sessions` map) in a `mod runtime` reached via `use runtime::*`.

`aether-labyrinth` has no `runtime` feature — its native half is gated by `feature = "native"`, and the whole `trajectory` module is already `#[cfg(feature = "native")]` at `lib.rs`. So the split uses `#[actor(singleton, runtime_feature = "native")]` (the #2330 override) to gate the macro-emitted runtime impls on `native` rather than the (nonexistent) `runtime`.

## Test plan

- `cargo clippy -p aether-labyrinth --all-targets -- -D warnings`, `cargo nextest run -p aether-labyrinth --features native` (151 passed incl. all 6 trajectory tests), strict `cargo doc`, both default and `--features native` builds — all green.
- Validated via `scripts/attest.sh --publish`.

## Generated by

`/implement --sweep --attest` — agent execution of scoped issue #2329.
