### PR TITLE
refactor(capabilities): split the component host cap into identity and runtime modules

### DIFF
--- a/crates/aether-capabilities/src/component/load.rs
+++ b/crates/aether-capabilities/src/component/load.rs
@@ -1,9 +1,10 @@
 //! `handle_load` — the wasm component load sequence.
 //!
-//! Declared as `mod load;` at the `component` level (outside `mod native`).
-//! Fields on [`ComponentHostCapability`] carry `pub(in crate::component)`
-//! visibility so this sibling module retains the same access as an
-//! inline impl block would.
+//! Declared as `mod load;` at the `component` level (a sibling of `runtime`).
+//! Under the ADR-0122 split the sequence is a method on
+//! `ComponentHostCapabilityState`; its fields carry
+//! `pub(in crate::component)` visibility so this sibling module retains the
+//! same access as an inline impl block would.
 
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -19,9 +20,9 @@ use aether_substrate::mail::helpers::register_or_match_all;
 
 use crate::trampoline::{WasmTrampoline, WasmTrampolineConfig};
 
-use super::ComponentHostCapability;
+use crate::component::runtime::ComponentHostCapabilityState;
 
-impl ComponentHostCapability {
+impl ComponentHostCapabilityState {
     #[allow(
         clippy::too_many_lines,
         reason = "one cohesive load sequence: parse + register kinds, resolve the export, \

--- a/crates/aether-capabilities/src/component/mod.rs
+++ b/crates/aether-capabilities/src/component/mod.rs
@@ -19,20 +19,31 @@
 //!
 //! [`NativeActor`]: aether_substrate::NativeActor
 //!
-//! The cap is a `#[bridge] mod native { ... }` per the ADR-0076 /
-//! issue 565 pattern. Plain fields (no `Arc<Inner>` wrapper) per
-//! ADR-0078 — the cap is single-threaded, every handler runs on the
-//! cap's dispatcher thread.
+//! The cap follows the ADR-0122 identity/runtime split (the `aether.fs`
+//! worked example, #2318): the addressing identity is the ZST
+//! [`ComponentHostCapability`] — the `#[actor(singleton)]` markers
+//! (`Addressable`, the per-handler `HandlesKind`, the name inventory) ride it
+//! always-on, so a transport-only build addresses the cap without naming the
+//! substrate-typed state. The state-bearing runtime
+//! (`ComponentHostCapabilityState`,
+//! holding the wasmtime `engine` + `linker`, the `registry`, the egress
+//! handles, and the default-name counter) lives behind the one
+//! `feature = "runtime"` gate. Plain fields (no `Arc<Inner>` wrapper) per
+//! ADR-0078 — the cap is single-threaded, every handler runs on the cap's
+//! dispatcher thread.
 //!
-//! The implementation is split into three files:
-//! - `mod.rs` — this file: the bridge module, struct, config, and
-//!   four thin lifecycle handlers.
+//! The implementation is split across files:
+//! - `mod.rs` — this file: the identity ZST, the `#[actor(singleton)] impl
+//!   NativeActor` with `init` + the four lifecycle handlers over
+//!   `state: &mut Self::State`.
+//! - `runtime.rs` — the `feature = "runtime"` half: the state struct, the
+//!   substrate / wasmtime imports, and the free `forward_to_trampoline`.
 //! - `route.rs` — the send-side peer-addressing facades
 //!   ([`ComponentHostWasmExt`], [`ComponentHostNativeExt`],
 //!   [`resolve_embedded`]).
-//! - `load.rs` — the `handle_load` sequence; fields on
-//!   [`ComponentHostCapability`] carry `pub(in crate::component)`
-//!   so this sibling module can access them.
+//! - `load.rs` — the `handle_load` sequence as a method on the state; the
+//!   state fields carry `pub(in crate::component)` so this sibling reaches
+//!   them.
 
 // `#[handler]` methods take their decoded payload by value per the
 // ADR-0033 dispatch ABI; the macro-generated trampoline owns the
@@ -44,243 +55,207 @@ mod route;
 pub use route::ComponentHostNativeExt;
 pub use route::{ComponentHostWasmExt, resolve_embedded};
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "runtime")]
 mod load;
 
-#[cfg(not(target_arch = "wasm32"))]
-use crate::input::UnsubscribeAll;
-#[cfg(not(target_arch = "wasm32"))]
-use aether_kinds::LifecycleUnsubscribeAll;
-use aether_kinds::{DropComponent, ListComponents, LoadComponent, ReplaceComponent};
-
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "runtime")]
 mod config;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "runtime")]
 pub use config::ComponentHostConfig;
 
-#[aether_actor::bridge(singleton)]
-mod native {
-    use std::sync::Arc;
-    use std::sync::atomic::AtomicU64;
+// Handler-signature kinds resolve at file root always-on: `#[actor]` emits the
+// `impl HandlesKind<K>` markers AND the `aether.kinds.inputs` handler-inventory
+// (which names each handler's reply kind via `<R as Kind>::ID`) against the
+// identity, outside the `feature = "runtime"` gate — so both the input kinds
+// and the reply kinds must be in scope here, not behind the runtime gate.
+use aether_kinds::{
+    DropComponent, ListComponents, ListComponentsResult, LoadComponent, LoadResult,
+    ReplaceComponent,
+};
 
-    use aether_actor::actor;
-    use aether_data::Kind;
-    use aether_data::MailboxCategory;
-    use aether_kinds::{ListComponentsResult, LoadResult};
-    use wasmtime::{Engine, Linker};
+// The crate-local wiring the `#[actor] impl` handler bodies name (sibling caps,
+// the unsubscribe kind, the `Kind` / `MailboxCategory` vocabulary) lives in
+// `mod runtime` and reaches here through the `use runtime::*` glob below.
 
-    use super::config::ComponentHostConfig;
-    use super::{
-        DropComponent, LifecycleUnsubscribeAll, ListComponents, LoadComponent, ReplaceComponent,
-        UnsubscribeAll,
-    };
+// The `#[actor]` / `#[handler]` attribute path stays always-on (the macro
+// divides what it emits). Everything that names an `aether_substrate` /
+// `wasmtime` type — the handler/init ctx, the runtime state, the
+// `forward_to_trampoline` helper — lives in the `runtime` module below, gated
+// once by `feature = "runtime"` and written cfg-free within; the `#[actor]
+// impl` reaches all of it through the single `use runtime::*` glob.
+use aether_actor::actor;
 
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::actor::wasm::component::ComponentCtx;
-    use aether_substrate::chassis::error::BootError;
-    use aether_substrate::mail::mailer::Mailer;
-    use aether_substrate::mail::outbound::HubOutbound;
-    use aether_substrate::mail::registry::Registry;
-    use aether_substrate::mail::{KindId, MailboxId};
+// The `runtime` module is this cap's private runtime-half namespace; the impl
+// reaches all of it (state, ctx types, the forward helper) through this single
+// seam, so the glob is intentional rather than a dozen one-line imports.
+#[cfg(feature = "runtime")]
+#[allow(clippy::wildcard_imports)]
+use runtime::*;
 
-    use crate::input::InputCapability;
-    use crate::lifecycle::LifecycleCapability;
+/// `aether.component` cap **identity** (ADR-0122 identity/runtime split). A
+/// ZST carrying only the addressing — `Addressable` (`NAMESPACE`, `Resolver`),
+/// the per-handler `HandlesKind` markers, and the name-inventory entry, all
+/// emitted always-on by `#[actor]`. The state-bearing runtime
+/// (`ComponentHostCapabilityState`, holding the wasmtime `engine` + `linker`
+/// and the egress handles) lives behind the one `feature = "runtime"` gate, so
+/// a transport-only build never names the state nor pulls `aether_substrate` /
+/// `wasmtime` through this cap.
+pub struct ComponentHostCapability;
 
-    /// `aether.component` cap. Plain-fields shape — single-threaded
-    /// owner running on its dispatcher thread; no shared state. Input
-    /// subscribe / unsubscribe go through `aether.input` via mail
-    /// (post-issue-640) — the cap doesn't carry an `input_mailbox`
-    /// field; `ctx.actor::<InputCapability>().send(...)` resolves it
-    /// inline at the call site.
+#[actor(singleton)]
+impl NativeActor for ComponentHostCapability {
+    /// The runtime state this identity boots into (ADR-0122 split): the
+    /// wasmtime instances, mail registry, egress handles, and default-name
+    /// counter every load instantiates against.
+    type State = ComponentHostCapabilityState;
+
+    type Config = ComponentHostConfig;
+    const NAMESPACE: &'static str = "aether.component";
+
+    fn init(
+        config: ComponentHostConfig,
+        ctx: &mut NativeInitCtx<'_>,
+    ) -> Result<ComponentHostCapabilityState, BootError> {
+        let mailer = ctx.mailer();
+        let registry = Arc::clone(mailer.registry());
+        Ok(ComponentHostCapabilityState {
+            engine: config.engine,
+            linker: config.linker,
+            registry,
+            mailer,
+            outbound: config.hub_outbound,
+            default_name_counter: AtomicU64::new(0),
+        })
+    }
+
+    /// Load a fresh wasm component into the substrate.
     ///
-    /// Fields carry `pub(in crate::component)` so the `load` submodule
-    /// (which holds `handle_load`) can access them as a sibling rather
-    /// than a child of `mod native`.
-    pub struct ComponentHostCapability {
-        pub(in crate::component) engine: Arc<Engine>,
-        pub(in crate::component) linker: Arc<Linker<ComponentCtx>>,
-        pub(in crate::component) registry: Arc<Registry>,
-        pub(in crate::component) mailer: Arc<Mailer>,
-        pub(in crate::component) outbound: Arc<HubOutbound>,
-        /// Monotonic counter for `component_N` default names when an
-        /// agent passes `name: None` and the wasm doesn't declare an
-        /// `aether.namespace`. `AtomicU64` because the bridge macro
-        /// emits handlers behind `&self` for some patterns; the
-        /// counter is fine either way.
-        pub(in crate::component) default_name_counter: AtomicU64,
+    /// # Agent
+    /// Pass the wasm bytes plus an optional `name`. On Ok the cap
+    /// registers the kinds the wasm declared in its `aether.kinds`
+    /// section, picks a final name (caller value > wasm's
+    /// `aether.namespace` > `component_N`), spawns a
+    /// [`WasmTrampoline`](crate::trampoline::WasmTrampoline) under
+    /// `aether.embedded:NAME`, and replies `LoadResult::Ok { mailbox_id,
+    /// name, capabilities }` where `name` is the full trampoline
+    /// address — agents send subsequent mail to that name.
+    /// Errors (bad wire bytes, kind conflict, name conflict,
+    /// invalid wasm, instantiation trap) come back as
+    /// `LoadResult::Err`.
+    #[handler]
+    fn on_load_component(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        payload: LoadComponent,
+    ) -> LoadResult {
+        // ADR-0109: the return type is the reply contract — the
+        // `#[actor]` macro routes this `LoadResult` back to the sender
+        // through `OutboundReply::reply`, so no manual `ctx.reply`.
+        state.handle_load(ctx, payload)
     }
 
-    #[actor]
-    impl NativeActor for ComponentHostCapability {
-        type Config = ComponentHostConfig;
-        const NAMESPACE: &'static str = "aether.component";
-
-        fn init(
-            config: ComponentHostConfig,
-            ctx: &mut NativeInitCtx<'_>,
-        ) -> Result<Self, BootError> {
-            let mailer = ctx.mailer();
-            let registry = Arc::clone(mailer.registry());
-            Ok(Self {
-                engine: config.engine,
-                linker: config.linker,
-                registry,
-                mailer,
-                outbound: config.hub_outbound,
-                default_name_counter: AtomicU64::new(0),
-            })
-        }
-
-        /// Load a fresh wasm component into the substrate.
-        ///
-        /// # Agent
-        /// Pass the wasm bytes plus an optional `name`. On Ok the cap
-        /// registers the kinds the wasm declared in its `aether.kinds`
-        /// section, picks a final name (caller value > wasm's
-        /// `aether.namespace` > `component_N`), spawns a
-        /// [`WasmTrampoline`] under `aether.embedded:NAME`,
-        /// and replies `LoadResult::Ok { mailbox_id, name,
-        /// capabilities }` where `name` is the full trampoline
-        /// address — agents send subsequent mail to that name.
-        /// Errors (bad wire bytes, kind conflict, name conflict,
-        /// invalid wasm, instantiation trap) come back as
-        /// `LoadResult::Err`.
-        #[handler]
-        fn on_load_component(
-            &mut self,
-            ctx: &mut NativeCtx<'_>,
-            payload: LoadComponent,
-        ) -> LoadResult {
-            // ADR-0109: the return type is the reply contract — the
-            // `#[actor]` macro routes this `LoadResult` back to the sender
-            // through `OutboundReply::reply`, so no manual `ctx.reply`.
-            self.handle_load(ctx, payload)
-        }
-
-        /// Drop a component by its mailbox id. Forwards
-        /// [`DropComponent`] mail to the addressed trampoline; the
-        /// trampoline's [`WasmTrampoline::on_drop_component`] handler
-        /// replies `DropResult::Ok` and shuts itself down.
-        ///
-        /// Before forwarding, purges the dying trampoline's mailbox from
-        /// every fan-out subscriber table so no cap keeps firing at a
-        /// dropped mailbox: `aether.input`'s input-stream tables (via
-        /// [`UnsubscribeAll`]) and `aether.lifecycle`'s per-stage tables
-        /// (via [`LifecycleUnsubscribeAll`]).
-        ///
-        /// # Agent
-        /// `DropComponent { mailbox_id }`. The `mailbox_id` is the
-        /// trampoline's id from the `LoadResult.mailbox_id` field.
-        #[handler]
-        fn on_drop_component(&mut self, ctx: &mut NativeCtx<'_>, payload: DropComponent) {
-            // Cap-side cleanup: ask each owning cap to drop the dying
-            // trampoline from its fan-out sets. Mail rather than direct
-            // mutation post-issue-640 — each cap is the sole owner of its
-            // own subscriber table.
-            ctx.actor::<InputCapability>().send(&UnsubscribeAll {
-                mailbox: payload.mailbox_id,
+    /// Drop a component by its mailbox id. Forwards
+    /// [`DropComponent`] mail to the addressed trampoline; the
+    /// trampoline's `WasmTrampoline::on_drop_component` handler
+    /// replies `DropResult::Ok` and shuts itself down.
+    ///
+    /// Before forwarding, purges the dying trampoline's mailbox from
+    /// every fan-out subscriber table so no cap keeps firing at a
+    /// dropped mailbox: `aether.input`'s input-stream tables (via
+    /// [`UnsubscribeAll`]) and `aether.lifecycle`'s per-stage tables
+    /// (via [`LifecycleUnsubscribeAll`]).
+    ///
+    /// # Agent
+    /// `DropComponent { mailbox_id }`. The `mailbox_id` is the
+    /// trampoline's id from the `LoadResult.mailbox_id` field.
+    #[handler]
+    fn on_drop_component(
+        _state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        payload: DropComponent,
+    ) {
+        // Cap-side cleanup: ask each owning cap to drop the dying
+        // trampoline from its fan-out sets. Mail rather than direct
+        // mutation post-issue-640 — each cap is the sole owner of its
+        // own subscriber table.
+        ctx.actor::<InputCapability>().send(&UnsubscribeAll {
+            mailbox: payload.mailbox_id,
+        });
+        ctx.actor::<LifecycleCapability>()
+            .send(&LifecycleUnsubscribeAll {
+                mailbox: payload.mailbox_id.0,
             });
-            ctx.actor::<LifecycleCapability>()
-                .send(&LifecycleUnsubscribeAll {
-                    mailbox: payload.mailbox_id.0,
-                });
-            self.forward_to_trampoline(ctx, payload.mailbox_id, DropComponent::ID, &payload);
-        }
-
-        /// Replace the component at `mailbox_id` with a fresh wasm
-        /// binary. Forwards [`ReplaceComponent`] to the trampoline;
-        /// the trampoline's [`WasmTrampoline::on_replace_component`]
-        /// handler swaps `Component` internally and replies
-        /// `ReplaceResult`. ADR-0022 + ADR-0038 splice invariants
-        /// hold because the inbox channel is the trampoline's
-        /// `NativeBinding`, which outlives the swap.
-        ///
-        /// # Agent
-        /// `ReplaceComponent { mailbox_id, wasm, drain_timeout_ms, config, export }`.
-        /// `drain_timeout_ms` is accepted for wire compatibility but
-        /// ignored under the trampoline's binding-stable replace.
-        /// `export` (ADR-0096) names which exported actor type of the
-        /// replacement module to instantiate; `None` reuses the type the
-        /// trampoline currently hosts.
-        #[handler]
-        fn on_replace_component(&mut self, ctx: &mut NativeCtx<'_>, payload: ReplaceComponent) {
-            self.forward_to_trampoline(ctx, payload.mailbox_id, ReplaceComponent::ID, &payload);
-        }
-
-        /// Enumerate the components this engine has actually loaded and
-        /// registered, by their ADR-0099 lineage names (issue 2020).
-        ///
-        /// Reads the registry's live mailbox snapshot — the same list
-        /// already egressed to the hub after each load — and keeps only the
-        /// [`MailboxCategory::Trampoline`] entries, the loaded-component set.
-        /// Chassis caps are boot-present and static, so the trampolines are
-        /// the only registry membership a readiness poll cares about. The
-        /// reply is names only: the mailbox id is a deterministic hash-chain
-        /// over the lineage the name renders (ADR-0099) and routing is the
-        /// substrate's job, so the caller never needs the handle.
-        ///
-        /// # Agent
-        /// Fieldless `ListComponents` to the `aether.component` mailbox —
-        /// guaranteed present from boot, so the send always resolves and the
-        /// reply is a definitive snapshot. Reply `ListComponentsResult {
-        /// names }` lists every currently-loaded component's full lineage
-        /// address (`aether.component/aether.embedded:NAME`). Poll it after a
-        /// boot-manifest spawn (ADR-0116) to learn deterministically when a
-        /// requested component is loaded, instead of inferring liveness by
-        /// proxy.
-        #[handler]
-        fn on_list_components(
-            &mut self,
-            _ctx: &mut NativeCtx<'_>,
-            _payload: ListComponents,
-        ) -> ListComponentsResult {
-            let names = self
-                .registry
-                .list_mailbox_descriptors()
-                .into_iter()
-                .filter(|d| d.category == Some(MailboxCategory::Trampoline))
-                .map(|d| d.name)
-                .collect();
-            ListComponentsResult { names }
-        }
+        forward_to_trampoline(ctx, payload.mailbox_id, DropComponent::ID, &payload);
     }
 
-    impl ComponentHostCapability {
-        /// Forward an arbitrary kind to a trampoline's mailbox,
-        /// preserving the original `reply_to` so the trampoline's
-        /// reply lands at the agent (not the cap). Used for
-        /// [`DropComponent`] and [`ReplaceComponent`].
-        ///
-        /// The forward threads the child mail under the cap's current
-        /// in-flight root and bumps that root's `in_flight` count before
-        /// this handler returns (`send_envelope_traced_with_reply_to`),
-        /// so the originating call stays open across the boundary: the
-        /// trampoline's deferred `ctx.reply` streams back under a still-
-        /// open root and settlement fires `ReplyEnd` only after it. A
-        /// bare enqueue would let the cap handler's return settle the
-        /// call before the trampoline replied, dropping the reply (the
-        /// deferred-reply hold-open contract).
-        ///
-        /// Kept a method (not an associated fn) so its two `#[handler]`
-        /// call sites read `self`; the macro-dispatched handlers must
-        /// take `&mut self`, so dropping the receiver here would only
-        /// move the `unused_self` lint onto them.
-        #[allow(clippy::unused_self)]
-        fn forward_to_trampoline<P>(
-            &self,
-            ctx: &mut NativeCtx<'_>,
-            recipient: MailboxId,
-            kind: KindId,
-            payload: &P,
-        ) where
-            P: Kind,
-        {
-            let bytes = payload.encode_into_bytes();
-            let _ =
-                ctx.send_envelope_traced_with_reply_to(recipient, kind, &bytes, ctx.reply_target());
-        }
+    /// Replace the component at `mailbox_id` with a fresh wasm
+    /// binary. Forwards [`ReplaceComponent`] to the trampoline;
+    /// the trampoline's `WasmTrampoline::on_replace_component`
+    /// handler swaps `Component` internally and replies
+    /// `ReplaceResult`. ADR-0022 + ADR-0038 splice invariants
+    /// hold because the inbox channel is the trampoline's
+    /// `NativeBinding`, which outlives the swap.
+    ///
+    /// # Agent
+    /// `ReplaceComponent { mailbox_id, wasm, drain_timeout_ms, config, export }`.
+    /// `drain_timeout_ms` is accepted for wire compatibility but
+    /// ignored under the trampoline's binding-stable replace.
+    /// `export` (ADR-0096) names which exported actor type of the
+    /// replacement module to instantiate; `None` reuses the type the
+    /// trampoline currently hosts.
+    #[handler]
+    fn on_replace_component(
+        _state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        payload: ReplaceComponent,
+    ) {
+        forward_to_trampoline(ctx, payload.mailbox_id, ReplaceComponent::ID, &payload);
+    }
+
+    /// Enumerate the components this engine has actually loaded and
+    /// registered, by their ADR-0099 lineage names (issue 2020).
+    ///
+    /// Reads the registry's live mailbox snapshot — the same list
+    /// already egressed to the hub after each load — and keeps only the
+    /// [`MailboxCategory::Trampoline`] entries, the loaded-component set.
+    /// Chassis caps are boot-present and static, so the trampolines are
+    /// the only registry membership a readiness poll cares about. The
+    /// reply is names only: the mailbox id is a deterministic hash-chain
+    /// over the lineage the name renders (ADR-0099) and routing is the
+    /// substrate's job, so the caller never needs the handle.
+    ///
+    /// # Agent
+    /// Fieldless `ListComponents` to the `aether.component` mailbox —
+    /// guaranteed present from boot, so the send always resolves and the
+    /// reply is a definitive snapshot. Reply `ListComponentsResult {
+    /// names }` lists every currently-loaded component's full lineage
+    /// address (`aether.component/aether.embedded:NAME`). Poll it after a
+    /// boot-manifest spawn (ADR-0116) to learn deterministically when a
+    /// requested component is loaded, instead of inferring liveness by
+    /// proxy.
+    #[handler]
+    fn on_list_components(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        _payload: ListComponents,
+    ) -> ListComponentsResult {
+        let names = state
+            .registry
+            .list_mailbox_descriptors()
+            .into_iter()
+            .filter(|d| d.category == Some(MailboxCategory::Trampoline))
+            .map(|d| d.name)
+            .collect();
+        ListComponentsResult { names }
     }
 }
+
+// The runtime half — the whole `aether_substrate` / `wasmtime`-typed surface
+// (imports, `ComponentHostCapabilityState`, `forward_to_trampoline`) — lives
+// in `runtime.rs`, gated once here. The `#[actor] impl` above reaches it
+// through the `use runtime::*` glob.
+#[cfg(feature = "runtime")]
+mod runtime;
 
 #[cfg(test)]
 mod tests {

--- a/crates/aether-capabilities/src/component/runtime.rs
+++ b/crates/aether-capabilities/src/component/runtime.rs
@@ -1,0 +1,86 @@
+//! The `aether.component` runtime half (ADR-0122 identity/runtime split).
+//! Compiled only under `feature = "runtime"` (the `mod runtime;` declaration
+//! in the parent carries the gate), so a transport-only build of the
+//! `ComponentHostCapability` identity never names these types nor pulls
+//! `aether_substrate` / `wasmtime`. The substrate-typed imports are gated once
+//! by this module rather than line-by-line; the `#[actor] impl` reaches the
+//! state and the `forward_to_trampoline` helper through the single
+//! `use runtime::*` glob in the parent, and the `load` sibling reaches the
+//! state fields through their `pub(in crate::component)` visibility.
+
+// Crate-local wiring the `#[actor] impl` handler bodies name (sibling caps it
+// mails, the unsubscribe kind, the `Kind` / `MailboxCategory` vocabulary),
+// re-exported so the parent reaches them through its `use runtime::*` glob.
+pub use crate::input::{InputCapability, UnsubscribeAll};
+pub use crate::lifecycle::LifecycleCapability;
+pub use aether_data::{Kind, MailboxCategory};
+pub use aether_kinds::LifecycleUnsubscribeAll;
+
+pub use std::sync::Arc;
+pub use std::sync::atomic::AtomicU64;
+
+pub use wasmtime::{Engine, Linker};
+
+pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub use aether_substrate::actor::wasm::component::ComponentCtx;
+pub use aether_substrate::chassis::error::BootError;
+pub use aether_substrate::mail::mailer::Mailer;
+pub use aether_substrate::mail::outbound::HubOutbound;
+pub use aether_substrate::mail::registry::Registry;
+pub use aether_substrate::mail::{KindId, MailboxId};
+
+/// `aether.component` runtime state (ADR-0122 split). Holds the wasmtime
+/// `engine` + `linker` every load instantiates against, the mail `registry`,
+/// the `mailer` / `outbound` egress handles, and the monotonic
+/// `default_name_counter` for `component_N` default names. Plain fields (no
+/// `Arc<Inner>` wrapper) per ADR-0078 — the cap is single-threaded, every
+/// handler runs on the cap's dispatcher thread. Input subscribe / unsubscribe
+/// go through `aether.input` via mail (post-issue-640): no `input_mailbox`
+/// field; `ctx.actor::<InputCapability>().send(...)` resolves it inline.
+///
+/// The dispatcher holds this as the cap's state and routes envelopes through
+/// the macro-emitted `Dispatch` impl; the addressing identity is the distinct
+/// ZST `ComponentHostCapability`. Living in this private module keeps it
+/// `pub`-enough to satisfy the `NativeActor::State` interface without exposing
+/// it as crate-public API. Fields carry `pub(in crate::component)` so the
+/// `load` submodule (which holds `handle_load`) can reach them as a sibling
+/// within `crate::component`.
+pub struct ComponentHostCapabilityState {
+    pub(in crate::component) engine: Arc<Engine>,
+    pub(in crate::component) linker: Arc<Linker<ComponentCtx>>,
+    pub(in crate::component) registry: Arc<Registry>,
+    pub(in crate::component) mailer: Arc<Mailer>,
+    pub(in crate::component) outbound: Arc<HubOutbound>,
+    /// Monotonic counter for `component_N` default names when an agent passes
+    /// `name: None` and the wasm doesn't declare an `aether.namespace`.
+    pub(in crate::component) default_name_counter: AtomicU64,
+}
+
+/// Forward an arbitrary kind to a trampoline's mailbox, preserving the
+/// original `reply_to` so the trampoline's reply lands at the agent (not the
+/// cap). Used for [`DropComponent`](aether_kinds::DropComponent) and
+/// [`ReplaceComponent`](aether_kinds::ReplaceComponent).
+///
+/// The forward threads the child mail under the cap's current in-flight root
+/// and bumps that root's `in_flight` count before the calling handler returns
+/// (`send_envelope_traced_with_reply_to`), so the originating call stays open
+/// across the boundary: the trampoline's deferred `ctx.reply` streams back
+/// under a still-open root and settlement fires `ReplyEnd` only after it. A
+/// bare enqueue would let the cap handler's return settle the call before the
+/// trampoline replied, dropping the reply (the deferred-reply hold-open
+/// contract).
+///
+/// A free fn (no `self`) under the ADR-0122 split: the state-bearing struct
+/// holds no field this helper reads, so it stays stateless and the handlers
+/// reach it through the parent's `use runtime::*` glob.
+pub fn forward_to_trampoline<P>(
+    ctx: &mut NativeCtx<'_>,
+    recipient: MailboxId,
+    kind: KindId,
+    payload: &P,
+) where
+    P: Kind,
+{
+    let bytes = payload.encode_into_bytes();
+    let _ = ctx.send_envelope_traced_with_reply_to(recipient, kind, &bytes, ctx.reply_target());
+}

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -120,11 +120,12 @@ pub use shared::contentgen::{
     stage_gen_output,
 };
 // `ComponentHostConfig` is wasmtime-bound (it holds `Arc<Engine>` /
-// `Arc<Linker<ComponentCtx>>`). It re-exports only on the native
-// target — wasm-component consumers see the cap stub via
-// `ComponentHostCapability` for typed `ctx.actor::<...>()` addressing
-// without dragging the wasmtime stack into the wasm graph.
-#[cfg(not(target_arch = "wasm32"))]
+// `Arc<Linker<ComponentCtx>>`). Under the ADR-0122 split it lives behind
+// the `feature = "runtime"` gate (only the runtime half names it), so it
+// re-exports only when that feature is on — a transport-only build sees the
+// cap stub via `ComponentHostCapability` for typed `ctx.actor::<...>()`
+// addressing without dragging the wasmtime stack in.
+#[cfg(feature = "runtime")]
 pub use component::ComponentHostConfig;
 pub use engine::EngineProxy;
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
Closes #2320.

## Summary

Migrates `ComponentHostCapability` off `#[bridge(singleton)]` onto the ADR-0122 identity/runtime split: a ZST identity + a top-level `#[actor(singleton)] impl NativeActor` with the four handlers over `state: &mut Self::State`, and the substrate/wasmtime-typed half (`ComponentHostCapabilityState`, the imports, and `forward_to_trampoline`) in `component/runtime.rs` gated behind `feature = "runtime"` and reached via one `use runtime::*` glob. The `load` sibling submodule keeps reaching the state's fields through their `pub(in crate::component)` visibility.

## Test plan

- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo nextest run -p aether-capabilities` (248 passed incl. both component identity tests), strict `cargo doc`, transport-only (`--no-default-features --features native`) build — all green.
- Validated via `scripts/attest.sh --publish`.

## Generated by

`/implement --sweep --attest` — agent execution of scoped issue #2320.
