### PR TITLE
refactor(capabilities): split the rpc server and test-echo actors into identity and runtime modules

### DIFF
--- a/crates/aether-capabilities/src/rpc/mod.rs
+++ b/crates/aether-capabilities/src/rpc/mod.rs
@@ -33,4 +33,10 @@ pub use aether_rpc::rpc::*;
 
 pub use server::RpcServerCapability;
 #[cfg(not(target_arch = "wasm32"))]
-pub use server::{RpcServerConfig, RpcServerHandle};
+pub use server::RpcServerConfig;
+// `RpcServerHandle` is a live-server boot artifact (published only inside
+// runtime `init`), so it rides the runtime half's gate rather than the
+// `not(wasm32)` marker gate (ADR-0122). Every consumer is a chassis/test
+// build with `runtime` on.
+#[cfg(feature = "runtime")]
+pub use server::RpcServerHandle;

--- a/crates/aether-capabilities/src/rpc/server/connection.rs
+++ b/crates/aether-capabilities/src/rpc/server/connection.rs
@@ -1,8 +1,8 @@
 //! Connection-side plumbing for the `RpcServerCapability`: the
 //! sidecar->dispatcher event type, per-connection state, the
 //! per-connection reader loop, and the oversize-frame guard. These are
-//! plain items (no actor-macro surface), split out of the
-//! `#[bridge(singleton)]` module so the actor core stays navigable.
+//! plain items (no actor-macro surface), split out of the cap's identity +
+//! runtime modules so the actor core stays navigable.
 
 use super::RpcInboundReady;
 use crate::rpc::{RpcError, WireFrame};

--- a/crates/aether-capabilities/src/rpc/server/mod.rs
+++ b/crates/aether-capabilities/src/rpc/server/mod.rs
@@ -23,662 +23,363 @@
 #![allow(clippy::needless_pass_by_value)]
 
 // Handler-signature kinds need to be importable at file root for the
-// `#[bridge]`-emitted `HandlesKind<K>` markers. `RpcInboundReady` is the
-// cap's own wake-mail kind (ADR-0121); `Settled` stays in `aether-kinds`.
+// `#[actor]`-emitted `HandlesKind<K>` markers (always-on against the
+// identity, ADR-0122). `RpcInboundReady` is the cap's own wake-mail kind
+// (ADR-0121); `Settled` stays in `aether-kinds`.
 use crate::rpc::kinds::RpcInboundReady;
 use aether_kinds::trace::Settled;
 
-// Re-export the cap's config + handle struct at file root for chassis
-// builders + embedders that read the bound port.
+// Re-export the cap's config at file root for chassis builders. The
+// `RpcServerConfig` type names no `aether_substrate` type, so it stays a
+// top-level `not(wasm32)` plain struct; the `RpcServerHandle` boot artifact
+// lives in the runtime half and is re-exported below under the runtime
+// gate.
 #[cfg(not(target_arch = "wasm32"))]
 mod config;
 #[cfg(not(target_arch = "wasm32"))]
 pub use config::RpcServerConfig;
-#[cfg(not(target_arch = "wasm32"))]
-pub use server_native::RpcServerHandle;
+#[cfg(feature = "runtime")]
+pub use runtime::RpcServerHandle;
 
+// Named at file root so the runtime half reaches it through `super::`
+// (`RpcServerState` stores `peer_kind: PeerKind`).
 use aether_rpc::rpc::PeerKind;
 
 // The standalone connection plumbing (sidecar event type, per-connection
-// state, reader loop, oversize guard) lives in `connection`; the
-// `#[bridge(singleton)]` actor module `use`s it. Native-only — it owns a
-// `TcpStream` + OS threads, elided on the wasm marker build.
+// state, reader loop, oversize guard) lives in `connection`; the runtime
+// half `use`s it. Native-only — it owns a `TcpStream` + OS threads, elided
+// on the wasm marker build.
 #[cfg(not(target_arch = "wasm32"))]
 mod connection;
+// `on_inbound_ready` (in the runtime-gated `#[actor] impl` below) matches on
+// `InboundEvent` directly, so it is imported here rather than re-exported
+// through the `runtime` glob: `InboundEvent` is `pub(super)` in `connection`,
+// and a `pub use` of a restricted-visibility item does not glob-export up to
+// this module. `feature = "runtime"` implies `not(wasm32)`, so `connection`
+// exists wherever this import is active.
+#[cfg(feature = "runtime")]
+use connection::InboundEvent;
 
 #[cfg(test)]
 mod tests;
 
-#[aether_actor::bridge(singleton)]
-mod server_native {
-    use super::config::RpcServerConfig;
-    use super::connection::{ConnId, ConnState, InboundEvent, run_reader_loop};
-    use super::{PeerKind, RpcInboundReady, Settled};
-    use crate::engine::EngineServer;
-    use crate::engine::kinds::{CallSettled, RouteEnvelope};
-    use crate::rpc::{
-        Hello, HelloAck, MailEnvelope, MailboxAddress, RpcError, WIRE_VERSION, WireFrame,
-    };
-    use aether_actor::{Addressable, actor};
-    use aether_codec::frame::FrameError;
-    use aether_codec::frame::write_frame;
-    use aether_data::{Kind, KindId, MailId, MailboxId, mailbox_id_from_name};
-    use aether_substrate::Mail;
-    use aether_substrate::actor::native::envelope::Envelope;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
-    use aether_substrate::mail::SourceAddr;
-    use aether_substrate::mail::mailer::Mailer;
-    use std::collections::HashMap;
-    use std::io;
-    use std::net::Shutdown;
-    use std::net::{SocketAddr, TcpListener, TcpStream};
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::mpsc;
-    use std::thread;
-    use std::thread::JoinHandle;
-    use std::time::Duration;
+/// `aether.rpc.server` cap **identity** (ADR-0122 identity/runtime split). A
+/// ZST carrying only the addressing — `Addressable` (`NAMESPACE`,
+/// `Resolver`), the per-handler `HandlesKind` markers, and the
+/// name-inventory entry, all emitted always-on by `#[actor]`. The
+/// state-bearing runtime (`RpcServerState`, which
+/// owns the TCP listener bookkeeping and per-connection state) plus the
+/// helper methods live behind the one `feature = "runtime"` gate, so a
+/// transport-only build never names `RpcServerState` nor pulls
+/// `aether_substrate` through this cap.
+pub struct RpcServerCapability;
 
-    /// Exported handle bundle published at boot. Reachable from the
-    /// chassis via `PassiveChassis::handle::<RpcServerHandle>()`;
-    /// the load-bearing field is `local_port` so embedders (driver
-    /// threads, tests) can connect to the OS-picked port when
-    /// `bind_addr` requested port 0.
-    #[derive(Clone)]
-    pub struct RpcServerHandle {
-        pub local_port: u16,
-    }
+// The `#[actor]` / `#[handler]` attribute path stays always-on (the macro
+// divides what it emits). Everything that names an `aether_substrate` type —
+// the handler/init/unwire ctxs, the runtime state + `InFlight` bookkeeping,
+// the `RpcServerHandle` boot artifact, the per-connection helper methods —
+// lives in the `runtime` module below, gated once by `feature = "runtime"`
+// and written cfg-free within; the `#[actor] impl` reaches all of it through
+// the single `use runtime::*` glob. The kind types (`RpcInboundReady` /
+// `Settled`) stay always-on at file root — the always-on `HandlesKind<K>`
+// markers name them.
+use aether_actor::actor;
 
-    /// Bookkeeping for one in-flight call (cid passed `Some` on the
-    /// wire). Looked up by the dispatch's auto-minted
-    /// `correlation_id` (== `MailId.correlation_id` of the dispatched
-    /// envelope, which is also the root id since we always dispatch
-    /// as chassis-root via `send_envelope_as_root`).
-    #[derive(Copy, Clone)]
-    struct InFlight {
-        conn_id: ConnId,
-        wire_cid: u64,
-    }
+// The `runtime` module is this cap's private runtime-half namespace; the impl
+// reaches all of it (state, ctx types, helper methods) through this single
+// seam, so the glob is intentional rather than a wall of one-line imports.
+#[cfg(feature = "runtime")]
+#[allow(clippy::wildcard_imports)]
+use runtime::*;
 
-    /// Singleton RPC server cap. Owns one TCP listener + per-
-    /// connection state.
-    pub struct RpcServerCapability {
-        peer_kind: PeerKind,
-        self_mailbox: MailboxId,
-        /// Cached `Arc<Mailer>` so per-handler ctxs (`NativeCtx`,
-        /// which doesn't expose `mailer()`) can fire wake mails into
-        /// the cap from internal helpers — and so the `Call`
-        /// dispatcher can pass the same Arc into
-        /// `subscribe_settlement_mail`. Init grabs it from
-        /// `NativeInitCtx::mailer()`; the cap is single-threaded
-        /// post-ADR-0038 so direct storage is fine.
-        mailer: Arc<Mailer>,
-        listener_port: u16,
-        accept_shutdown: Arc<AtomicBool>,
-        accept_thread: Option<JoinHandle<()>>,
-        inbound_rx: mpsc::Receiver<InboundEvent>,
-        inbound_tx: mpsc::Sender<InboundEvent>,
-        connections: HashMap<ConnId, ConnState>,
-        next_conn_id: ConnId,
-        /// Internal-correlation → connection / wire-cid. Populated on
-        /// `Call { cid: Some(n) }` dispatch; cleared on settlement.
-        in_flight: HashMap<u64, InFlight>,
-    }
+#[actor(singleton)]
+impl NativeActor for RpcServerCapability {
+    /// The runtime state this identity boots into (ADR-0122 split): the
+    /// state-bearing struct holding the TCP listener bookkeeping +
+    /// per-connection state.
+    type State = RpcServerState;
+    type Config = RpcServerConfig;
+    const NAMESPACE: &'static str = "aether.rpc.server";
 
-    #[actor]
-    impl NativeActor for RpcServerCapability {
-        type Config = RpcServerConfig;
-        const NAMESPACE: &'static str = "aether.rpc.server";
+    fn init(
+        config: RpcServerConfig,
+        ctx: &mut NativeInitCtx<'_>,
+    ) -> Result<RpcServerState, BootError> {
+        let listener =
+            TcpListener::bind(&config.bind_addr).map_err(|e| BootError::Other(Box::new(e)))?;
+        let local_addr = listener
+            .local_addr()
+            .map_err(|e| BootError::Other(Box::new(e)))?;
+        let port = local_addr.port();
+        listener
+            .set_nonblocking(false)
+            .map_err(|e| BootError::Other(Box::new(e)))?;
 
-        fn init(config: RpcServerConfig, ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            let listener =
-                TcpListener::bind(&config.bind_addr).map_err(|e| BootError::Other(Box::new(e)))?;
-            let local_addr = listener
-                .local_addr()
-                .map_err(|e| BootError::Other(Box::new(e)))?;
-            let port = local_addr.port();
-            listener
-                .set_nonblocking(false)
-                .map_err(|e| BootError::Other(Box::new(e)))?;
+        let accept_shutdown = Arc::new(AtomicBool::new(false));
+        let accept_shutdown_for_thread = Arc::clone(&accept_shutdown);
 
-            let accept_shutdown = Arc::new(AtomicBool::new(false));
-            let accept_shutdown_for_thread = Arc::clone(&accept_shutdown);
+        let (inbound_tx, inbound_rx) = mpsc::channel::<InboundEvent>();
+        let inbound_tx_for_thread = inbound_tx.clone();
 
-            let (inbound_tx, inbound_rx) = mpsc::channel::<InboundEvent>();
-            let inbound_tx_for_thread = inbound_tx.clone();
+        let mailer: Arc<Mailer> = ctx.mailer();
+        let self_id = ctx.self_id();
+        let wake_kind = KindId(<RpcInboundReady as Kind>::ID.0);
 
-            let mailer: Arc<Mailer> = ctx.mailer();
-            let self_id = ctx.self_id();
-            let wake_kind = KindId(<RpcInboundReady as Kind>::ID.0);
-
-            // Transport thread below the mail layer — it accepts sockets that carry
-            // inbound mail in; no inbound chain to inherit, no settlement umbrella.
-            #[allow(clippy::disallowed_methods)]
-            let thread = thread::Builder::new()
-                .name(format!("aether-rpc-accept-{port}"))
-                .spawn(move || {
-                    while !accept_shutdown_for_thread.load(Ordering::Acquire) {
-                        if let Ok((stream, peer)) = listener.accept() {
-                            if accept_shutdown_for_thread.load(Ordering::Acquire) {
-                                drop(stream);
-                                break;
-                            }
-                            if inbound_tx_for_thread
-                                .send(InboundEvent::PeerAccepted { stream, peer })
-                                .is_err()
-                            {
-                                break;
-                            }
-                            mailer.push(Mail::new(
-                                self_id,
-                                wake_kind,
-                                RpcInboundReady::default().encode_into_bytes(),
-                                1,
-                            ));
-                        } else if accept_shutdown_for_thread.load(Ordering::Acquire) {
+        // Transport thread below the mail layer — it accepts sockets that carry
+        // inbound mail in; no inbound chain to inherit, no settlement umbrella.
+        #[allow(clippy::disallowed_methods)]
+        let thread = thread::Builder::new()
+            .name(format!("aether-rpc-accept-{port}"))
+            .spawn(move || {
+                while !accept_shutdown_for_thread.load(Ordering::Acquire) {
+                    if let Ok((stream, peer)) = listener.accept() {
+                        if accept_shutdown_for_thread.load(Ordering::Acquire) {
+                            drop(stream);
                             break;
                         }
+                        if inbound_tx_for_thread
+                            .send(InboundEvent::PeerAccepted { stream, peer })
+                            .is_err()
+                        {
+                            break;
+                        }
+                        mailer.push(Mail::new(
+                            self_id,
+                            wake_kind,
+                            RpcInboundReady::default().encode_into_bytes(),
+                            1,
+                        ));
+                    } else if accept_shutdown_for_thread.load(Ordering::Acquire) {
+                        break;
                     }
-                })
-                .map_err(|e| BootError::Other(Box::new(e)))?;
-
-            tracing::info!(
-                target: "aether_substrate::rpc",
-                addr = %config.bind_addr,
-                port = port,
-                "rpc server bound",
-            );
-
-            ctx.publish_handle(RpcServerHandle { local_port: port });
-
-            Ok(Self {
-                peer_kind: config.peer_kind,
-                self_mailbox: self_id,
-                mailer: ctx.mailer(),
-                listener_port: port,
-                accept_shutdown,
-                accept_thread: Some(thread),
-                inbound_rx,
-                inbound_tx,
-                connections: HashMap::new(),
-                next_conn_id: 0,
-                in_flight: HashMap::new(),
+                }
             })
-        }
+            .map_err(|e| BootError::Other(Box::new(e)))?;
 
-        fn unwire(&mut self, _ctx: &mut NativeCtx<'_>) {
-            // Stop the accept thread.
-            self.accept_shutdown.store(true, Ordering::Release);
-            let addr_str = format!("127.0.0.1:{}", self.listener_port);
-            if let Ok(addr) = addr_str.parse::<SocketAddr>() {
-                let _ = TcpStream::connect_timeout(&addr, Duration::from_millis(100));
-            }
-            if let Some(t) = self.accept_thread.take() {
+        tracing::info!(
+            target: "aether_substrate::rpc",
+            addr = %config.bind_addr,
+            port = port,
+            "rpc server bound",
+        );
+
+        ctx.publish_handle(RpcServerHandle { local_port: port });
+
+        Ok(RpcServerState {
+            peer_kind: config.peer_kind,
+            self_mailbox: self_id,
+            mailer: ctx.mailer(),
+            listener_port: port,
+            accept_shutdown,
+            accept_thread: Some(thread),
+            inbound_rx,
+            inbound_tx,
+            connections: HashMap::new(),
+            next_conn_id: 0,
+            in_flight: HashMap::new(),
+        })
+    }
+
+    fn unwire(state: &mut Self::State, _ctx: &mut NativeCtx<'_>) {
+        // Stop the accept thread.
+        state.accept_shutdown.store(true, Ordering::Release);
+        let addr_str = format!("127.0.0.1:{}", state.listener_port);
+        if let Ok(addr) = addr_str.parse::<SocketAddr>() {
+            let _ = TcpStream::connect_timeout(&addr, Duration::from_millis(100));
+        }
+        if let Some(t) = state.accept_thread.take() {
+            let _ = t.join();
+        }
+        // Stop every per-connection reader. Shutting down the read
+        // half wakes the blocked `read()`; the reader sees the
+        // shutdown flag and exits.
+        for conn in state.connections.values_mut() {
+            conn.shutdown.store(true, Ordering::Release);
+            let _ = conn.write_half.shutdown(Shutdown::Read);
+            if let Some(t) = conn.reader_thread.take() {
                 let _ = t.join();
             }
-            // Stop every per-connection reader. Shutting down the read
-            // half wakes the blocked `read()`; the reader sees the
-            // shutdown flag and exits.
-            for conn in self.connections.values_mut() {
-                conn.shutdown.store(true, Ordering::Release);
-                let _ = conn.write_half.shutdown(Shutdown::Read);
-                if let Some(t) = conn.reader_thread.take() {
-                    let _ = t.join();
+        }
+        tracing::info!(
+            target: "aether_substrate::rpc",
+            port = state.listener_port,
+            "rpc server closed",
+        );
+    }
+
+    /// Sidecar wake. Drain every pending inbound event.
+    ///
+    /// # Agent
+    /// Internal wake mail — not part of the cap's external surface.
+    /// The accept / reader sidecars fire this to wake the
+    /// dispatcher; the handler drains the mpsc and dispatches per
+    /// item.
+    #[handler]
+    fn on_inbound_ready(state: &mut Self::State, ctx: &mut NativeCtx<'_>, _mail: RpcInboundReady) {
+        while let Ok(event) = state.inbound_rx.try_recv() {
+            match event {
+                InboundEvent::PeerAccepted { stream, peer } => {
+                    state.spawn_reader_for_peer(ctx, stream, peer);
+                }
+                InboundEvent::FrameReceived { conn_id, frame } => {
+                    state.dispatch_frame(ctx, conn_id, frame);
+                }
+                InboundEvent::ReaderClosed { conn_id, reason } => {
+                    state.close_connection(conn_id, &reason);
+                }
+                InboundEvent::FrameDecodeError { conn_id, error } => {
+                    // The reader kept frame-sync (body drained).
+                    // Write a structured `ReplyEnd { cid: 0, Err }`
+                    // and leave the connection up so further calls
+                    // on this socket still work (issue 1271).
+                    //
+                    // `cid = 0` is the sentinel: the wire couldn't
+                    // be decoded far enough to learn the real cid,
+                    // so we report against id 0 and the mcp router
+                    // surfaces it as a wire-level out-of-band
+                    // failure rather than a per-call settled-Err.
+                    tracing::warn!(
+                        target: "aether_substrate::rpc",
+                        conn = conn_id,
+                        error = ?error,
+                        "rpc inbound frame decode error; keeping connection alive",
+                    );
+                    state.write_frame_to(
+                        conn_id,
+                        &WireFrame::ReplyEnd {
+                            cid: 0,
+                            result: Err(error),
+                        },
+                    );
+                }
+                InboundEvent::FrameDecodeAborted { conn_id, error } => {
+                    // The announced body was big enough to be its
+                    // own OOM vector (size > 2 * max). Write a
+                    // structured `Bye` so the peer sees a named
+                    // close instead of a bare reset, then tear the
+                    // connection down (issue 1271).
+                    let reason = match &error {
+                        RpcError::FrameTooLarge { size, max } => {
+                            format!("frame too large: {size} > {max}")
+                        }
+                        other => format!("frame decode aborted: {other:?}"),
+                    };
+                    tracing::warn!(
+                        target: "aether_substrate::rpc",
+                        conn = conn_id,
+                        reason = %reason,
+                        "rpc inbound frame too large to drain; closing connection",
+                    );
+                    state.write_frame_to(
+                        conn_id,
+                        &WireFrame::Bye {
+                            reason: reason.clone(),
+                        },
+                    );
+                    state.close_connection(conn_id, &reason);
                 }
             }
-            tracing::info!(
+        }
+    }
+
+    /// Settlement notice from the chassis. The root corresponds
+    /// to a `Call` dispatch we subscribed to; close the call by
+    /// writing `ReplyEnd { cid, result: Ok(()) }` and dropping
+    /// the in-flight entry.
+    ///
+    /// # Agent
+    /// Internal — fires from `SettlementRegistry::fire_settled`,
+    /// not from external mail. Subscribers parked in the registry
+    /// receive one of these per settled root.
+    #[handler]
+    fn on_settled(state: &mut Self::State, _ctx: &mut NativeCtx<'_>, mail: Settled) {
+        let correlation = mail.root.correlation_id;
+        let Some(entry) = state.in_flight.remove(&correlation) else {
+            // No matching in-flight call. Either we never owned
+            // this root or the connection already closed and we
+            // cleared eagerly. Either way: drop silently.
+            return;
+        };
+        state.write_frame_to(
+            entry.conn_id,
+            &WireFrame::ReplyEnd {
+                cid: entry.wire_cid,
+                result: Ok(()),
+            },
+        );
+    }
+
+    /// Catch-all. Any mail addressed at this cap that's not one of
+    /// the typed wake / settlement kinds is treated as a reply
+    /// mail from a downstream actor; if its `correlation_id`
+    /// matches an in-flight call, the cap wraps it as a
+    /// `ReplyEvent` and writes to the originating connection.
+    ///
+    /// # Agent
+    /// Not user-callable — this is the cap's reply interception
+    /// path. The wire is mail-shaped (issue 750 §wire), so any
+    /// kind two peers share is reachable; reply correlation goes
+    /// through this fallback.
+    #[fallback]
+    fn on_any(state: &mut Self::State, _ctx: &mut NativeCtx<'_>, env: &Envelope) {
+        let correlation = env.sender.correlation_id;
+        let Some(entry) = state.in_flight.get(&correlation).copied() else {
+            tracing::debug!(
                 target: "aether_substrate::rpc",
-                port = self.listener_port,
-                "rpc server closed",
+                kind = %env.kind_name,
+                correlation,
+                "rpc reply with no matching in-flight call; dropping",
             );
-        }
+            return;
+        };
 
-        /// Sidecar wake. Drain every pending inbound event.
-        ///
-        /// # Agent
-        /// Internal wake mail — not part of the cap's external surface.
-        /// The accept / reader sidecars fire this to wake the
-        /// dispatcher; the handler drains the mpsc and dispatches per
-        /// item.
-        #[handler]
-        fn on_inbound_ready(&mut self, ctx: &mut NativeCtx<'_>, _mail: RpcInboundReady) {
-            while let Ok(event) = self.inbound_rx.try_recv() {
-                match event {
-                    InboundEvent::PeerAccepted { stream, peer } => {
-                        self.spawn_reader_for_peer(ctx, stream, peer);
-                    }
-                    InboundEvent::FrameReceived { conn_id, frame } => {
-                        self.dispatch_frame(ctx, conn_id, frame);
-                    }
-                    InboundEvent::ReaderClosed { conn_id, reason } => {
-                        self.close_connection(conn_id, &reason);
-                    }
-                    InboundEvent::FrameDecodeError { conn_id, error } => {
-                        // The reader kept frame-sync (body drained).
-                        // Write a structured `ReplyEnd { cid: 0, Err }`
-                        // and leave the connection up so further calls
-                        // on this socket still work (issue 1271).
-                        //
-                        // `cid = 0` is the sentinel: the wire couldn't
-                        // be decoded far enough to learn the real cid,
-                        // so we report against id 0 and the mcp router
-                        // surfaces it as a wire-level out-of-band
-                        // failure rather than a per-call settled-Err.
-                        tracing::warn!(
-                            target: "aether_substrate::rpc",
-                            conn = conn_id,
-                            error = ?error,
-                            "rpc inbound frame decode error; keeping connection alive",
-                        );
-                        self.write_frame_to(
-                            conn_id,
-                            &WireFrame::ReplyEnd {
-                                cid: 0,
-                                result: Err(error),
-                            },
-                        );
-                    }
-                    InboundEvent::FrameDecodeAborted { conn_id, error } => {
-                        // The announced body was big enough to be its
-                        // own OOM vector (size > 2 * max). Write a
-                        // structured `Bye` so the peer sees a named
-                        // close instead of a bare reset, then tear the
-                        // connection down (issue 1271).
-                        let reason = match &error {
-                            RpcError::FrameTooLarge { size, max } => {
-                                format!("frame too large: {size} > {max}")
-                            }
-                            other => format!("frame decode aborted: {other:?}"),
-                        };
-                        tracing::warn!(
-                            target: "aether_substrate::rpc",
-                            conn = conn_id,
-                            reason = %reason,
-                            "rpc inbound frame too large to drain; closing connection",
-                        );
-                        self.write_frame_to(
-                            conn_id,
-                            &WireFrame::Bye {
-                                reason: reason.clone(),
-                            },
-                        );
-                        self.close_connection(conn_id, &reason);
-                    }
-                }
-            }
-        }
-
-        /// Settlement notice from the chassis. The root corresponds
-        /// to a `Call` dispatch we subscribed to; close the call by
-        /// writing `ReplyEnd { cid, result: Ok(()) }` and dropping
-        /// the in-flight entry.
-        ///
-        /// # Agent
-        /// Internal — fires from `SettlementRegistry::fire_settled`,
-        /// not from external mail. Subscribers parked in the registry
-        /// receive one of these per settled root.
-        #[handler]
-        fn on_settled(&mut self, _ctx: &mut NativeCtx<'_>, mail: Settled) {
-            let correlation = mail.root.correlation_id;
-            let Some(entry) = self.in_flight.remove(&correlation) else {
-                // No matching in-flight call. Either we never owned
-                // this root or the connection already closed and we
-                // cleared eagerly. Either way: drop silently.
-                return;
+        // A forwarded engine call (issue 763 P5a) closes when its
+        // proxy lifts the substrate's terminal `ReplyEnd` into a
+        // `CallSettled` — there's no local chain for `on_settled`
+        // to catch. Recognize it here, write the wire `ReplyEnd`,
+        // and clear the in-flight entry.
+        if env.kind == <CallSettled as Kind>::ID {
+            let result = match CallSettled::decode_from_bytes(env.payload.bytes()) {
+                Some(CallSettled::Ok) => Ok(()),
+                Some(CallSettled::Err { error }) => Err(RpcError::Other { reason: error }),
+                None => Err(RpcError::Other {
+                    reason: "malformed CallSettled payload".into(),
+                }),
             };
-            self.write_frame_to(
+            state.write_frame_to(
                 entry.conn_id,
                 &WireFrame::ReplyEnd {
                     cid: entry.wire_cid,
-                    result: Ok(()),
+                    result,
                 },
             );
+            state.in_flight.remove(&correlation);
+            return;
         }
 
-        /// Catch-all. Any mail addressed at this cap that's not one of
-        /// the typed wake / settlement kinds is treated as a reply
-        /// mail from a downstream actor; if its `correlation_id`
-        /// matches an in-flight call, the cap wraps it as a
-        /// `ReplyEvent` and writes to the originating connection.
-        ///
-        /// # Agent
-        /// Not user-callable — this is the cap's reply interception
-        /// path. The wire is mail-shaped (issue 750 §wire), so any
-        /// kind two peers share is reachable; reply correlation goes
-        /// through this fallback.
-        #[fallback]
-        fn on_any(&mut self, _ctx: &mut NativeCtx<'_>, env: &Envelope) {
-            let correlation = env.sender.correlation_id;
-            let Some(entry) = self.in_flight.get(&correlation).copied() else {
-                tracing::debug!(
-                    target: "aether_substrate::rpc",
-                    kind = %env.kind_name,
-                    correlation,
-                    "rpc reply with no matching in-flight call; dropping",
-                );
-                return;
-            };
-
-            // A forwarded engine call (issue 763 P5a) closes when its
-            // proxy lifts the substrate's terminal `ReplyEnd` into a
-            // `CallSettled` — there's no local chain for `on_settled`
-            // to catch. Recognize it here, write the wire `ReplyEnd`,
-            // and clear the in-flight entry.
-            if env.kind == <CallSettled as Kind>::ID {
-                let result = match CallSettled::decode_from_bytes(env.payload.bytes()) {
-                    Some(CallSettled::Ok) => Ok(()),
-                    Some(CallSettled::Err { error }) => Err(RpcError::Other { reason: error }),
-                    None => Err(RpcError::Other {
-                        reason: "malformed CallSettled payload".into(),
-                    }),
-                };
-                self.write_frame_to(
-                    entry.conn_id,
-                    &WireFrame::ReplyEnd {
-                        cid: entry.wire_cid,
-                        result,
-                    },
-                );
-                self.in_flight.remove(&correlation);
-                return;
-            }
-
-            let envelope = MailEnvelope {
-                to: MailboxAddress::local(self.self_mailbox),
-                from: match env.sender.addr {
-                    SourceAddr::Component(id) => Some(MailboxAddress::local(id)),
-                    _ => None,
-                },
-                kind: env.kind,
-                correlation_id: Some(entry.wire_cid),
-                payload: env.payload.bytes().to_vec(),
-            };
-            self.write_frame_to(
-                entry.conn_id,
-                &WireFrame::ReplyEvent {
-                    cid: entry.wire_cid,
-                    envelope,
-                },
-            );
-        }
-    }
-
-    impl RpcServerCapability {
-        /// Allocate a fresh `ConnId`, store the connection's write half,
-        /// spin a reader thread for the read half.
-        fn spawn_reader_for_peer(
-            &mut self,
-            _ctx: &mut NativeCtx<'_>,
-            stream: TcpStream,
-            peer: SocketAddr,
-        ) {
-            let conn_id = self.next_conn_id;
-            self.next_conn_id += 1;
-
-            let read_half = match stream.try_clone() {
-                Ok(c) => c,
-                Err(e) => {
-                    tracing::warn!(
-                        target: "aether_substrate::rpc",
-                        peer = %peer,
-                        error = %e,
-                        "rpc conn: try_clone failed; dropping",
-                    );
-                    return;
-                }
-            };
-            let write_half = stream;
-            let shutdown = Arc::new(AtomicBool::new(false));
-            let shutdown_for_thread = Arc::clone(&shutdown);
-
-            let mailer: Arc<Mailer> = Arc::clone(&self.mailer);
-            let self_id = self.self_mailbox;
-            let wake_kind = KindId(<RpcInboundReady as Kind>::ID.0);
-            let inbound_tx = self.inbound_tx.clone();
-
-            // Per-connection transport reader below the mail layer — carries inbound
-            // mail in; no inbound chain to inherit, no settlement umbrella.
-            #[allow(clippy::disallowed_methods)]
-            let thread = match thread::Builder::new()
-                .name(format!("aether-rpc-reader-{conn_id}"))
-                .spawn(move || {
-                    run_reader_loop(
-                        read_half,
-                        conn_id,
-                        &shutdown_for_thread,
-                        &inbound_tx,
-                        &mailer,
-                        self_id,
-                        wake_kind,
-                    );
-                }) {
-                Ok(t) => t,
-                Err(e) => {
-                    tracing::warn!(
-                        target: "aether_substrate::rpc",
-                        peer = %peer,
-                        error = %e,
-                        "rpc reader thread spawn failed",
-                    );
-                    return;
-                }
-            };
-
-            self.connections.insert(
-                conn_id,
-                ConnState {
-                    peer,
-                    write_half,
-                    shutdown,
-                    reader_thread: Some(thread),
-                    hello_received: false,
-                },
-            );
-            tracing::debug!(
-                target: "aether_substrate::rpc",
-                conn = conn_id,
-                peer = %peer,
-                "rpc conn accepted",
-            );
-        }
-
-        /// Dispatch one incoming frame.
-        fn dispatch_frame(&mut self, ctx: &mut NativeCtx<'_>, conn_id: ConnId, frame: WireFrame) {
-            match frame {
-                WireFrame::Hello(hello) => self.handle_hello(conn_id, hello),
-                WireFrame::HelloAck(_) => {
-                    // Server doesn't expect HelloAck — only clients do.
-                    tracing::debug!(
-                        target: "aether_substrate::rpc",
-                        conn = conn_id,
-                        "received HelloAck on server side; ignoring",
-                    );
-                }
-                WireFrame::Call { cid, envelope } => self.handle_call(ctx, conn_id, cid, envelope),
-                WireFrame::ReplyEvent { .. } | WireFrame::ReplyEnd { .. } => {
-                    // Server doesn't expect reply frames inbound.
-                    tracing::debug!(
-                        target: "aether_substrate::rpc",
-                        conn = conn_id,
-                        "received reply frame on server side; ignoring",
-                    );
-                }
-                WireFrame::Ping(token) => {
-                    self.write_frame_to(conn_id, &WireFrame::Pong(token));
-                }
-                WireFrame::Pong(_) => {
-                    // Cap doesn't initiate Pings v1; nothing to track.
-                }
-                WireFrame::Bye { reason } => {
-                    self.close_connection(conn_id, &format!("peer bye: {reason}"));
-                }
-            }
-        }
-
-        fn handle_hello(&mut self, conn_id: ConnId, hello: Hello) {
-            if hello.wire_version != WIRE_VERSION {
-                self.write_frame_to(
-                    conn_id,
-                    &WireFrame::Bye {
-                        reason: format!(
-                            "wire_version mismatch: peer={}, server={WIRE_VERSION}",
-                            hello.wire_version,
-                        ),
-                    },
-                );
-                self.close_connection(conn_id, "wire_version mismatch");
-                return;
-            }
-            if let Some(conn) = self.connections.get_mut(&conn_id) {
-                conn.hello_received = true;
-            }
-            self.write_frame_to(
-                conn_id,
-                &WireFrame::HelloAck(HelloAck {
-                    wire_version: WIRE_VERSION,
-                    server: self.peer_kind.clone(),
-                }),
-            );
-        }
-
-        fn handle_call(
-            &mut self,
-            ctx: &mut NativeCtx<'_>,
-            conn_id: ConnId,
-            cid: Option<u64>,
-            envelope: MailEnvelope,
-        ) {
-            // Engine-addressed Calls (issue 763 P5a): relay to the
-            // engines cap (`aether.engine`), which owns the
-            // `EngineId -> proxy` table and re-emits a `ForwardEnvelope`
-            // at the right proxy. The substrate's reply streams back
-            // here as a normal reply mail (handled by `on_any` as a
-            // `ReplyEvent`); its terminal `ReplyEnd` arrives — via the
-            // proxy — as a `CallSettled` (also handled by `on_any`).
-            //
-            // Crucially this path does NOT subscribe to settlement: the
-            // local `RouteEnvelope` chain settles almost immediately,
-            // long before the remote substrate replies, so settlement
-            // would close the wire call prematurely. The terminal close
-            // comes from `CallSettled` instead.
-            //
-            // On a chassis with no engines cap the `RouteEnvelope`
-            // warn-drops and the call never closes — only the hub
-            // chassis wires `aether.engine`, and only the hub fields
-            // engine-addressed Calls.
-            if let Some(engine_id) = envelope.to.engine {
-                let route = RouteEnvelope {
-                    engine_id: engine_id.0.to_string(),
-                    mailbox: envelope.to.mailbox,
-                    kind: envelope.kind,
-                    payload: envelope.payload,
-                };
-                // Runtime-name routing: forwarding a wire `Call` to the
-                // well-known engines cap (`EngineServer::NAMESPACE`); the server
-                // holds opaque MailboxId/KindId/bytes, with no compile-time
-                // sibling type to resolve through.
-                #[allow(clippy::disallowed_methods)]
-                let engine_cap = mailbox_id_from_name(<EngineServer as Addressable>::NAMESPACE);
-                let mail_id = ctx.send_envelope_as_root(
-                    engine_cap,
-                    <RouteEnvelope as Kind>::ID,
-                    &route.encode_into_bytes(),
-                );
-                if let Some(wire_cid) = cid {
-                    self.in_flight
-                        .insert(mail_id.correlation_id, InFlight { conn_id, wire_cid });
-                }
-                return;
-            }
-            // Dispatch the envelope as a fresh chain. The returned
-            // MailId is the new chain's root; if cid is Some, subscribe
-            // to its settlement to know when to write ReplyEnd.
-            let recipient = envelope.to.mailbox;
-            let kind = envelope.kind;
-            let payload = envelope.payload;
-            let mail_id: MailId = ctx.send_envelope_as_root(recipient, kind, &payload);
-
-            let Some(wire_cid) = cid else {
-                // Fire-and-forget at the wire layer. No bookkeeping.
-                return;
-            };
-
-            // Subscribe to settlement of the dispatched chain so we
-            // close the call with a ReplyEnd. Requires the chassis
-            // settlement registry — fail loud if not wired.
-            let Some(reg) = self.mailer.settlement_registry() else {
-                self.write_frame_to(
-                    conn_id,
-                    &WireFrame::ReplyEnd {
-                        cid: wire_cid,
-                        result: Err(RpcError::Other {
-                            reason: "settlement registry unavailable on this chassis".into(),
-                        }),
-                    },
-                );
-                return;
-            };
-            reg.subscribe_settlement_mail(
-                mail_id,
-                self.self_mailbox,
-                <Settled as Kind>::ID,
-                Arc::clone(&self.mailer),
-            );
-            self.in_flight
-                .insert(mail_id.correlation_id, InFlight { conn_id, wire_cid });
-        }
-
-        fn close_connection(&mut self, conn_id: ConnId, reason: &str) {
-            let Some(mut conn) = self.connections.remove(&conn_id) else {
-                return;
-            };
-            conn.shutdown.store(true, Ordering::Release);
-            let _ = conn.write_half.shutdown(Shutdown::Both);
-            // Drop reader_thread without joining inline — the
-            // dispatcher must not block on the reader. The thread sees
-            // the shutdown flag (or its own EOF) and exits; the
-            // JoinHandle drop detaches.
-            drop(conn.reader_thread.take());
-            // Clear in-flight entries pinned to this connection so we
-            // don't write ReplyEvents / ReplyEnds to a dead socket.
-            self.in_flight.retain(|_, entry| entry.conn_id != conn_id);
-            tracing::debug!(
-                target: "aether_substrate::rpc",
-                conn = conn_id,
-                peer = %conn.peer,
-                reason,
-                "rpc conn closed",
-            );
-        }
-
-        fn write_frame_to(&mut self, conn_id: ConnId, frame: &WireFrame) {
-            let Some(conn) = self.connections.get_mut(&conn_id) else {
-                return;
-            };
-            if let Err(e) = write_frame(&mut conn.write_half, frame) {
-                let reason = match &e {
-                    FrameError::Io(io_err)
-                        if matches!(
-                            io_err.kind(),
-                            io::ErrorKind::BrokenPipe
-                                | io::ErrorKind::ConnectionReset
-                                | io::ErrorKind::WriteZero
-                        ) =>
-                    {
-                        "peer hung up"
-                    }
-                    FrameError::Io(_) => "write error",
-                    _ => "frame encode error",
-                };
-                tracing::debug!(
-                    target: "aether_substrate::rpc",
-                    conn = conn_id,
-                    error = %e,
-                    "rpc frame write failed",
-                );
-                self.close_connection(conn_id, reason);
-            }
-        }
+        let envelope = MailEnvelope {
+            to: MailboxAddress::local(state.self_mailbox),
+            from: match env.sender.addr {
+                SourceAddr::Component(id) => Some(MailboxAddress::local(id)),
+                _ => None,
+            },
+            kind: env.kind,
+            correlation_id: Some(entry.wire_cid),
+            payload: env.payload.bytes().to_vec(),
+        };
+        state.write_frame_to(
+            entry.conn_id,
+            &WireFrame::ReplyEvent {
+                cid: entry.wire_cid,
+                envelope,
+            },
+        );
     }
 }
+
+// The runtime half — the whole `aether_substrate`-typed surface (imports,
+// `RpcServerState`, `InFlight`, the `RpcServerHandle` boot artifact, the
+// per-connection helper methods) — lives in `runtime.rs`, gated once here.
+// The `#[actor] impl` above reaches it through the `use runtime::*` glob.
+#[cfg(feature = "runtime")]
+mod runtime;

--- a/crates/aether-capabilities/src/rpc/server/runtime.rs
+++ b/crates/aether-capabilities/src/rpc/server/runtime.rs
@@ -1,0 +1,389 @@
+//! The `aether.rpc.server` runtime half (ADR-0122 identity/runtime split).
+//! Compiled only under `feature = "runtime"` (the `mod runtime;`
+//! declaration in the parent carries the gate), so a transport-only build
+//! of the [`RpcServerCapability`](super::RpcServerCapability) identity never
+//! names these types nor pulls `aether_substrate`. The substrate-typed
+//! imports are gated once by this module rather than line-by-line; the
+//! `#[actor] impl` in the parent reaches the state, ctx types, the
+//! `RpcServerHandle` boot artifact, and the per-connection helpers through
+//! the single `use runtime::*` glob.
+//!
+//! The accept thread (spawned in `init`) and the per-connection reader
+//! threads (spawned in [`RpcServerState::spawn_reader_for_peer`]) capture
+//! only cloned channel / `Arc<Mailer>` / `MailboxId` handles built in
+//! `init` or cloned out of the state — never the `RpcServerState` value —
+//! so the thread spawn / wake-mail / settlement-subscription / shutdown
+//! path transfers from the pre-split cap struct unchanged.
+
+// Sibling / cap-level types named by the state, the helpers, and the
+// top-level `#[actor] impl`, reached through the parent module. `super::`
+// works because `runtime` is a descendant of `server` (the parent's
+// private `use` aliases + the `pub(super)` connection items are visible to
+// it). `RpcServerConfig` is named only in the parent's `init` and resolves
+// there through the file-root re-export, so it is not pulled here.
+use super::connection::{ConnId, ConnState, InboundEvent, run_reader_loop};
+use super::{PeerKind, RpcInboundReady, Settled};
+
+// Re-export every substrate / std / cross-crate type the top-level
+// `#[actor] impl` body in `mod.rs` names; it reaches them through the
+// single `use runtime::*` glob. Types named only by the inherent helper
+// methods below ride the same wall (used locally here).
+pub use crate::engine::EngineServer;
+pub use crate::engine::kinds::{CallSettled, RouteEnvelope};
+pub use crate::rpc::{
+    Hello, HelloAck, MailEnvelope, MailboxAddress, RpcError, WIRE_VERSION, WireFrame,
+};
+pub use aether_actor::Addressable;
+pub use aether_codec::frame::{FrameError, write_frame};
+pub use aether_data::{Kind, KindId, MailId, MailboxId, mailbox_id_from_name};
+pub use aether_substrate::Mail;
+pub use aether_substrate::actor::native::envelope::Envelope;
+pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub use aether_substrate::chassis::error::BootError;
+pub use aether_substrate::mail::SourceAddr;
+pub use aether_substrate::mail::mailer::Mailer;
+pub use std::collections::HashMap;
+pub use std::io;
+pub use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
+pub use std::sync::Arc;
+pub use std::sync::atomic::{AtomicBool, Ordering};
+pub use std::sync::mpsc;
+pub use std::thread::{self, JoinHandle};
+pub use std::time::Duration;
+
+/// Exported handle bundle published at boot. Reachable from the
+/// chassis via `PassiveChassis::handle::<RpcServerHandle>()`;
+/// the load-bearing field is `local_port` so embedders (driver
+/// threads, tests) can connect to the OS-picked port when
+/// `bind_addr` requested port 0.
+#[derive(Clone)]
+pub struct RpcServerHandle {
+    pub local_port: u16,
+}
+
+/// Bookkeeping for one in-flight call (cid passed `Some` on the
+/// wire). Looked up by the dispatch's auto-minted
+/// `correlation_id` (== `MailId.correlation_id` of the dispatched
+/// envelope, which is also the root id since we always dispatch
+/// as chassis-root via `send_envelope_as_root`). Fields are
+/// `pub(super)` so the parent's `on_settled` / `on_any` handlers can
+/// read them after `remove` / `get`.
+#[derive(Copy, Clone)]
+pub(super) struct InFlight {
+    pub(super) conn_id: ConnId,
+    pub(super) wire_cid: u64,
+}
+
+/// `aether.rpc.server` runtime state (ADR-0122 split). Owns one TCP
+/// listener's bookkeeping plus per-connection state. The dispatcher holds
+/// this as the cap's state and routes envelopes through the macro-emitted
+/// `Dispatch` impl; the addressing identity is the distinct ZST
+/// [`RpcServerCapability`](super::RpcServerCapability). Living in this
+/// private module keeps it `pub`-enough to satisfy the `NativeActor::State`
+/// interface without exposing it as crate-public API; fields are
+/// `pub(super)` so the parent's handlers / `init` / `unwire` reach them.
+pub struct RpcServerState {
+    pub(super) peer_kind: PeerKind,
+    pub(super) self_mailbox: MailboxId,
+    /// Cached `Arc<Mailer>` so per-handler ctxs (`NativeCtx`,
+    /// which doesn't expose `mailer()`) can fire wake mails into
+    /// the cap from internal helpers — and so the `Call`
+    /// dispatcher can pass the same Arc into
+    /// `subscribe_settlement_mail`. Init grabs it from
+    /// `NativeInitCtx::mailer()`; the cap is single-threaded
+    /// post-ADR-0038 so direct storage is fine.
+    pub(super) mailer: Arc<Mailer>,
+    pub(super) listener_port: u16,
+    pub(super) accept_shutdown: Arc<AtomicBool>,
+    pub(super) accept_thread: Option<JoinHandle<()>>,
+    pub(super) inbound_rx: mpsc::Receiver<InboundEvent>,
+    pub(super) inbound_tx: mpsc::Sender<InboundEvent>,
+    pub(super) connections: HashMap<ConnId, ConnState>,
+    pub(super) next_conn_id: ConnId,
+    /// Internal-correlation → connection / wire-cid. Populated on
+    /// `Call { cid: Some(n) }` dispatch; cleared on settlement.
+    pub(super) in_flight: HashMap<u64, InFlight>,
+}
+
+impl RpcServerState {
+    /// Allocate a fresh `ConnId`, store the connection's write half,
+    /// spin a reader thread for the read half.
+    pub(super) fn spawn_reader_for_peer(
+        &mut self,
+        _ctx: &mut NativeCtx<'_>,
+        stream: TcpStream,
+        peer: SocketAddr,
+    ) {
+        let conn_id = self.next_conn_id;
+        self.next_conn_id += 1;
+
+        let read_half = match stream.try_clone() {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(
+                    target: "aether_substrate::rpc",
+                    peer = %peer,
+                    error = %e,
+                    "rpc conn: try_clone failed; dropping",
+                );
+                return;
+            }
+        };
+        let write_half = stream;
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_for_thread = Arc::clone(&shutdown);
+
+        let mailer: Arc<Mailer> = Arc::clone(&self.mailer);
+        let self_id = self.self_mailbox;
+        let wake_kind = KindId(<RpcInboundReady as Kind>::ID.0);
+        let inbound_tx = self.inbound_tx.clone();
+
+        // Per-connection transport reader below the mail layer — carries inbound
+        // mail in; no inbound chain to inherit, no settlement umbrella.
+        #[allow(clippy::disallowed_methods)]
+        let thread = match thread::Builder::new()
+            .name(format!("aether-rpc-reader-{conn_id}"))
+            .spawn(move || {
+                run_reader_loop(
+                    read_half,
+                    conn_id,
+                    &shutdown_for_thread,
+                    &inbound_tx,
+                    &mailer,
+                    self_id,
+                    wake_kind,
+                );
+            }) {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(
+                    target: "aether_substrate::rpc",
+                    peer = %peer,
+                    error = %e,
+                    "rpc reader thread spawn failed",
+                );
+                return;
+            }
+        };
+
+        self.connections.insert(
+            conn_id,
+            ConnState {
+                peer,
+                write_half,
+                shutdown,
+                reader_thread: Some(thread),
+                hello_received: false,
+            },
+        );
+        tracing::debug!(
+            target: "aether_substrate::rpc",
+            conn = conn_id,
+            peer = %peer,
+            "rpc conn accepted",
+        );
+    }
+
+    /// Dispatch one incoming frame.
+    pub(super) fn dispatch_frame(
+        &mut self,
+        ctx: &mut NativeCtx<'_>,
+        conn_id: ConnId,
+        frame: WireFrame,
+    ) {
+        match frame {
+            WireFrame::Hello(hello) => self.handle_hello(conn_id, hello),
+            WireFrame::HelloAck(_) => {
+                // Server doesn't expect HelloAck — only clients do.
+                tracing::debug!(
+                    target: "aether_substrate::rpc",
+                    conn = conn_id,
+                    "received HelloAck on server side; ignoring",
+                );
+            }
+            WireFrame::Call { cid, envelope } => self.handle_call(ctx, conn_id, cid, envelope),
+            WireFrame::ReplyEvent { .. } | WireFrame::ReplyEnd { .. } => {
+                // Server doesn't expect reply frames inbound.
+                tracing::debug!(
+                    target: "aether_substrate::rpc",
+                    conn = conn_id,
+                    "received reply frame on server side; ignoring",
+                );
+            }
+            WireFrame::Ping(token) => {
+                self.write_frame_to(conn_id, &WireFrame::Pong(token));
+            }
+            WireFrame::Pong(_) => {
+                // Cap doesn't initiate Pings v1; nothing to track.
+            }
+            WireFrame::Bye { reason } => {
+                self.close_connection(conn_id, &format!("peer bye: {reason}"));
+            }
+        }
+    }
+
+    pub(super) fn handle_hello(&mut self, conn_id: ConnId, hello: Hello) {
+        if hello.wire_version != WIRE_VERSION {
+            self.write_frame_to(
+                conn_id,
+                &WireFrame::Bye {
+                    reason: format!(
+                        "wire_version mismatch: peer={}, server={WIRE_VERSION}",
+                        hello.wire_version,
+                    ),
+                },
+            );
+            self.close_connection(conn_id, "wire_version mismatch");
+            return;
+        }
+        if let Some(conn) = self.connections.get_mut(&conn_id) {
+            conn.hello_received = true;
+        }
+        self.write_frame_to(
+            conn_id,
+            &WireFrame::HelloAck(HelloAck {
+                wire_version: WIRE_VERSION,
+                server: self.peer_kind.clone(),
+            }),
+        );
+    }
+
+    pub(super) fn handle_call(
+        &mut self,
+        ctx: &mut NativeCtx<'_>,
+        conn_id: ConnId,
+        cid: Option<u64>,
+        envelope: MailEnvelope,
+    ) {
+        // Engine-addressed Calls (issue 763 P5a): relay to the
+        // engines cap (`aether.engine`), which owns the
+        // `EngineId -> proxy` table and re-emits a `ForwardEnvelope`
+        // at the right proxy. The substrate's reply streams back
+        // here as a normal reply mail (handled by `on_any` as a
+        // `ReplyEvent`); its terminal `ReplyEnd` arrives — via the
+        // proxy — as a `CallSettled` (also handled by `on_any`).
+        //
+        // Crucially this path does NOT subscribe to settlement: the
+        // local `RouteEnvelope` chain settles almost immediately,
+        // long before the remote substrate replies, so settlement
+        // would close the wire call prematurely. The terminal close
+        // comes from `CallSettled` instead.
+        //
+        // On a chassis with no engines cap the `RouteEnvelope`
+        // warn-drops and the call never closes — only the hub
+        // chassis wires `aether.engine`, and only the hub fields
+        // engine-addressed Calls.
+        if let Some(engine_id) = envelope.to.engine {
+            let route = RouteEnvelope {
+                engine_id: engine_id.0.to_string(),
+                mailbox: envelope.to.mailbox,
+                kind: envelope.kind,
+                payload: envelope.payload,
+            };
+            // Runtime-name routing: forwarding a wire `Call` to the
+            // well-known engines cap (`EngineServer::NAMESPACE`); the server
+            // holds opaque MailboxId/KindId/bytes, with no compile-time
+            // sibling type to resolve through.
+            #[allow(clippy::disallowed_methods)]
+            let engine_cap = mailbox_id_from_name(<EngineServer as Addressable>::NAMESPACE);
+            let mail_id = ctx.send_envelope_as_root(
+                engine_cap,
+                <RouteEnvelope as Kind>::ID,
+                &route.encode_into_bytes(),
+            );
+            if let Some(wire_cid) = cid {
+                self.in_flight
+                    .insert(mail_id.correlation_id, InFlight { conn_id, wire_cid });
+            }
+            return;
+        }
+        // Dispatch the envelope as a fresh chain. The returned
+        // MailId is the new chain's root; if cid is Some, subscribe
+        // to its settlement to know when to write ReplyEnd.
+        let recipient = envelope.to.mailbox;
+        let kind = envelope.kind;
+        let payload = envelope.payload;
+        let mail_id: MailId = ctx.send_envelope_as_root(recipient, kind, &payload);
+
+        let Some(wire_cid) = cid else {
+            // Fire-and-forget at the wire layer. No bookkeeping.
+            return;
+        };
+
+        // Subscribe to settlement of the dispatched chain so we
+        // close the call with a ReplyEnd. Requires the chassis
+        // settlement registry — fail loud if not wired.
+        let Some(reg) = self.mailer.settlement_registry() else {
+            self.write_frame_to(
+                conn_id,
+                &WireFrame::ReplyEnd {
+                    cid: wire_cid,
+                    result: Err(RpcError::Other {
+                        reason: "settlement registry unavailable on this chassis".into(),
+                    }),
+                },
+            );
+            return;
+        };
+        reg.subscribe_settlement_mail(
+            mail_id,
+            self.self_mailbox,
+            <Settled as Kind>::ID,
+            Arc::clone(&self.mailer),
+        );
+        self.in_flight
+            .insert(mail_id.correlation_id, InFlight { conn_id, wire_cid });
+    }
+
+    pub(super) fn close_connection(&mut self, conn_id: ConnId, reason: &str) {
+        let Some(mut conn) = self.connections.remove(&conn_id) else {
+            return;
+        };
+        conn.shutdown.store(true, Ordering::Release);
+        let _ = conn.write_half.shutdown(Shutdown::Both);
+        // Drop reader_thread without joining inline — the
+        // dispatcher must not block on the reader. The thread sees
+        // the shutdown flag (or its own EOF) and exits; the
+        // JoinHandle drop detaches.
+        drop(conn.reader_thread.take());
+        // Clear in-flight entries pinned to this connection so we
+        // don't write ReplyEvents / ReplyEnds to a dead socket.
+        self.in_flight.retain(|_, entry| entry.conn_id != conn_id);
+        tracing::debug!(
+            target: "aether_substrate::rpc",
+            conn = conn_id,
+            peer = %conn.peer,
+            reason,
+            "rpc conn closed",
+        );
+    }
+
+    pub(super) fn write_frame_to(&mut self, conn_id: ConnId, frame: &WireFrame) {
+        let Some(conn) = self.connections.get_mut(&conn_id) else {
+            return;
+        };
+        if let Err(e) = write_frame(&mut conn.write_half, frame) {
+            let reason = match &e {
+                FrameError::Io(io_err)
+                    if matches!(
+                        io_err.kind(),
+                        io::ErrorKind::BrokenPipe
+                            | io::ErrorKind::ConnectionReset
+                            | io::ErrorKind::WriteZero
+                    ) =>
+                {
+                    "peer hung up"
+                }
+                FrameError::Io(_) => "write error",
+                _ => "frame encode error",
+            };
+            tracing::debug!(
+                target: "aether_substrate::rpc",
+                conn = conn_id,
+                error = %e,
+                "rpc frame write failed",
+            );
+            self.close_connection(conn_id, reason);
+        }
+    }
+}

--- a/crates/aether-capabilities/src/rpc/test_echo.rs
+++ b/crates/aether-capabilities/src/rpc/test_echo.rs
@@ -12,6 +12,20 @@
 
 use serde::{Deserialize, Serialize};
 
+// The actor halves are substrate-typed (ADR-0122 split). The whole module
+// is `#[cfg(test)]` (gated at its `mod` declaration in `rpc/mod.rs`) and
+// tests always carry `runtime`, so these resolve; the `#[actor]` macro
+// additionally gates the emitted `NativeActor` / `Dispatch` runtime impls
+// behind `feature = "runtime"`. The kind types above stay always-on so
+// their `Kind`-derived inventory submissions register for the test
+// substrate's registry walk.
+use crate::shared::contentgen::task_queue::TaskQueue;
+use aether_actor::actor;
+use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
+use aether_substrate::chassis::error::BootError;
+use std::thread;
+use std::time::Duration;
+
 /// Echo request kind — the test driver sends one of these; the echo
 /// actor replies with a [`TestEchoReply`] carrying the same `value`.
 #[derive(
@@ -53,37 +67,35 @@ pub struct TestEchoReply {
 /// matching [`TestEchoReply`]. The minimum viable receiver for
 /// exercising the RPC `Call → ReplyEvent → ReplyEnd` path without
 /// coupling a test to a production cap's semantics.
-#[aether_actor::bridge(singleton)]
-mod test_echo_actor {
-    use super::{TestEchoReply, TestEchoRequest};
-    use aether_actor::actor;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
+/// `aether.rpc.test.echo` identity (ADR-0122 split). A ZST carrying only
+/// the addressing markers `#[actor]` emits always-on; the (empty) runtime
+/// state lives in `TestEchoActorState`.
+pub struct TestEchoActor;
 
-    pub struct TestEchoActor;
+/// Runtime state for [`TestEchoActor`]: a named empty stand-in (ADR-0122
+/// hard rule — never `()` / `Self`) for an actor that holds nothing.
+pub struct TestEchoActorState;
 
-    #[actor]
-    impl NativeActor for TestEchoActor {
-        type Config = ();
-        const NAMESPACE: &'static str = "aether.rpc.test.echo";
+#[actor(singleton)]
+impl NativeActor for TestEchoActor {
+    type State = TestEchoActorState;
+    type Config = ();
+    const NAMESPACE: &'static str = "aether.rpc.test.echo";
 
-        fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            Ok(Self)
-        }
+    fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<TestEchoActorState, BootError> {
+        Ok(TestEchoActorState)
+    }
 
-        // Stateless echo handler — keeps `&mut self` to match the
-        // dispatch ABI (ADR-0033 / ADR-0038) even though the body
-        // doesn't touch component state.
-        #[allow(clippy::unused_self)]
-        #[handler]
-        fn on_echo(&mut self, _ctx: &mut NativeCtx<'_>, mail: TestEchoRequest) -> TestEchoReply {
-            TestEchoReply { value: mail.value }
-        }
+    /// Stateless echo handler — the empty state is unused.
+    #[handler]
+    fn on_echo(
+        _state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        mail: TestEchoRequest,
+    ) -> TestEchoReply {
+        TestEchoReply { value: mail.value }
     }
 }
-
-// `TestEchoActor` is re-exported at this module's root by the
-// `#[bridge]` macro itself — no explicit `pub use` needed.
 
 /// Deferred-echo request — like [`TestEchoRequest`] but the actor
 /// answers it through the ADR-0093 hold-until-resolve dispatch
@@ -137,60 +149,59 @@ pub struct DeferredEchoReply {
 /// -> re-reply). The whole point is that the reply happens *after* the
 /// handler returns, so the framework-held settlement hold must keep the
 /// chain open across the gap.
-#[aether_actor::bridge(singleton)]
-mod deferred_echo_actor {
-    use super::{DeferredEchoReply, DeferredEchoRequest};
-    use crate::shared::contentgen::task_queue::TaskQueue;
-    use aether_actor::actor;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
-    use aether_substrate::chassis::error::BootError;
-    use std::thread;
-    use std::time::Duration;
+/// `aether.rpc.test.deferred_echo` identity (ADR-0122 split). A ZST
+/// carrying the addressing markers; its runtime state — the
+/// `TaskQueue` backing the off-thread dispatch — lives in
+/// `DeferredEchoActorState`.
+pub struct DeferredEchoActor;
 
-    pub struct DeferredEchoActor {
-        tasks: TaskQueue,
-    }
-
-    #[actor]
-    impl NativeActor for DeferredEchoActor {
-        type Config = ();
-        const NAMESPACE: &'static str = "aether.rpc.test.deferred_echo";
-
-        fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            Ok(Self {
-                tasks: TaskQueue::new(4),
-            })
-        }
-
-        /// Submit the echo off-thread via the ADR-0093 dispatch primitive.
-        /// The worker sleeps briefly so the handler reliably returns
-        /// (queuing its `Finished`) before the reply lands — the window the
-        /// bug used to settle in. The framework-held `SettlementHold` keeps
-        /// the chain open until the deferred re-reply.
-        #[handler]
-        fn on_deferred_echo(&mut self, ctx: &mut NativeCtx<'_>, mail: DeferredEchoRequest) {
-            let value = mail.value;
-            self.tasks.submit(ctx, move || {
-                // Brief blocking work standing in for a provider call.
-                thread::sleep(Duration::from_millis(50));
-                DeferredEchoReply { value }
-            });
-        }
-
-        /// ADR-0093 completion: re-reply to the original caller (drops the
-        /// hold after the reply — `Sent` precedes `Release`), then free the
-        /// in-flight slot.
-        #[handler(task)]
-        fn on_deferred_echo_done(
-            &mut self,
-            ctx: &mut NativeCtx<'_>,
-            done: TaskDone<DeferredEchoReply>,
-        ) {
-            done.resolve(ctx);
-            self.tasks.on_complete(ctx);
-        }
-    }
+/// Runtime state for [`DeferredEchoActor`]: the ADR-0093 hold-until-resolve
+/// task queue the deferred handler submits onto.
+pub struct DeferredEchoActorState {
+    tasks: TaskQueue,
 }
 
-// `DeferredEchoActor` is re-exported at this module's root by the
-// `#[bridge]` macro.
+#[actor(singleton)]
+impl NativeActor for DeferredEchoActor {
+    type State = DeferredEchoActorState;
+    type Config = ();
+    const NAMESPACE: &'static str = "aether.rpc.test.deferred_echo";
+
+    fn init((): (), _ctx: &mut NativeInitCtx<'_>) -> Result<DeferredEchoActorState, BootError> {
+        Ok(DeferredEchoActorState {
+            tasks: TaskQueue::new(4),
+        })
+    }
+
+    /// Submit the echo off-thread via the ADR-0093 dispatch primitive.
+    /// The worker sleeps briefly so the handler reliably returns
+    /// (queuing its `Finished`) before the reply lands — the window the
+    /// bug used to settle in. The framework-held `SettlementHold` keeps
+    /// the chain open until the deferred re-reply.
+    #[handler]
+    fn on_deferred_echo(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        mail: DeferredEchoRequest,
+    ) {
+        let value = mail.value;
+        state.tasks.submit(ctx, move || {
+            // Brief blocking work standing in for a provider call.
+            thread::sleep(Duration::from_millis(50));
+            DeferredEchoReply { value }
+        });
+    }
+
+    /// ADR-0093 completion: re-reply to the original caller (drops the
+    /// hold after the reply — `Sent` precedes `Release`), then free the
+    /// in-flight slot.
+    #[handler(task)]
+    fn on_deferred_echo_done(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        done: TaskDone<DeferredEchoReply>,
+    ) {
+        done.resolve(ctx);
+        state.tasks.on_complete(ctx);
+    }
+}


### PR DESCRIPTION
Closes #2322.

## Summary

Migrates `RpcServerCapability` + the test-echo actors off `#[bridge]` onto the ADR-0122 identity/runtime split: ZST identities, `RpcServerState` in a `feature = "runtime"`-gated `rpc/server/runtime.rs`, and the handlers, the `#[fallback]`, and the deferred-echo `#[handler(task)]` all over `state: &mut Self::State`.

Thread shutdown is preserved: the accept and per-connection reader threads capture init-local handles (`Arc`/`mpsc`/ids), never the cap or state struct, so the `unwire` join is a field-home move. The split exercised — and depended on — the split-path macro completion landed earlier in this arc (`#[fallback]` #2338, `#[handler(task)]` #2341).

## Test plan

- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo nextest run -p aether-capabilities` (the rpc server round-trip + deferred-echo settlement tests), strict `cargo doc`, transport-only build — all green.
- Validated via `scripts/attest.sh --publish`.

## Generated by

`/implement --sweep --attest` — agent execution of scoped issue #2322.
