### PR TITLE
refactor(capabilities): split the engine caps into identity and runtime modules

### DIFF
--- a/crates/aether-capabilities/src/engine/proxy/connect.rs
+++ b/crates/aether-capabilities/src/engine/proxy/connect.rs
@@ -23,7 +23,7 @@ const PROXY_CONNECT_RETRY_INTERVAL: Duration = Duration::from_millis(50);
 /// the wait-forever sentinel: retry until the dial succeeds or hits
 /// a terminal error. Handshake / frame errors are always terminal:
 /// the peer answered, just wrongly.
-pub(super) fn connect_proxy(
+pub fn connect_proxy(
     addr: &str,
     mailer: &Arc<Mailer>,
     self_mailbox: MailboxId,

--- a/crates/aether-capabilities/src/engine/proxy/heartbeat.rs
+++ b/crates/aether-capabilities/src/engine/proxy/heartbeat.rs
@@ -41,7 +41,7 @@ impl Drop for HeartbeatHandle {
 /// each interval — the empty-payload wake shape the RPC reader
 /// sidecar uses (the timer carries no data, only the schedule). The
 /// handle's `Drop` stops + joins the thread.
-pub(super) fn spawn_heartbeat(
+pub fn spawn_heartbeat(
     mailer: Arc<Mailer>,
     self_mailbox: MailboxId,
     interval: Duration,

--- a/crates/aether-capabilities/src/engine/proxy/mod.rs
+++ b/crates/aether-capabilities/src/engine/proxy/mod.rs
@@ -30,18 +30,23 @@
 //! engines cap. The cached `HelloAck` manifest the describe handler
 //! will read is already in hand on `conn.server`.
 //!
-//! Native-only: the module owns a `TcpStream` (via `RpcConnection`)
-//! and an OS thread. The `#[bridge]` macro emits the wasm-side marker
-//! stub so `aether-capabilities` still compiles for `wasm32`.
+//! Native-only: the state owns a `TcpStream` (via `RpcConnection`)
+//! and an OS thread, so the substrate-typed runtime half lives behind
+//! `feature = "runtime"` in the `runtime` module. The `#[actor]` macro divides the
+//! identity from that runtime (ADR-0122): the [`EngineProxy`] ZST and its
+//! addressing markers stay always-on so `aether-capabilities` still compiles
+//! for `wasm32`, while the state, handlers, and `Drop` compile only under
+//! `runtime`.
 
 // Handler-signature kinds must be importable at file root — the
-// `#[bridge]` macro emits `impl HandlesKind<K>` markers as siblings of
-// the mod.
+// `#[actor]` macro emits `impl HandlesKind<K>` markers always-on against
+// the identity, outside the `feature = "runtime"` gate, so they reference
+// these kinds from here.
 use crate::engine::kinds::{EngineHeartbeatTick, ForwardEnvelope};
 use aether_kinds::TerminateEngine;
 // `RpcInboundReady` is owned by the RPC server cap (ADR-0121); the proxy
-// shares the wake-mail kind. Imported at file root for the `#[bridge]`-
-// emitted `HandlesKind<RpcInboundReady>` marker.
+// shares the wake-mail kind. Imported at file root for the always-on
+// `HandlesKind<RpcInboundReady>` marker.
 use crate::rpc::RpcInboundReady;
 
 // The proxy's implementation, split along its seams (ADR-0121):
@@ -49,7 +54,7 @@ use crate::rpc::RpcInboundReady;
 // startup-dial bring-up), `heartbeat` (the liveness-timer sidecar), and
 // `sinks` (the test-only capture actors). All are native-only — the
 // proxy owns a `TcpStream` and OS threads — so they elide on wasm
-// alongside the bridge mod.
+// alongside the runtime half.
 #[cfg(not(target_arch = "wasm32"))]
 mod config;
 #[cfg(not(target_arch = "wasm32"))]
@@ -65,437 +70,282 @@ mod sinks;
 #[cfg(not(target_arch = "wasm32"))]
 pub use config::{EngineProxyConfig, HeartbeatParams};
 
-#[aether_actor::bridge(instanced, one_per = "engine")]
-mod proxy_native {
-    use super::config::EngineProxyConfig;
-    use super::connect::connect_proxy;
-    use super::heartbeat::{HeartbeatHandle, spawn_heartbeat};
-    use super::{EngineHeartbeatTick, ForwardEnvelope, RpcInboundReady, TerminateEngine};
-    use crate::engine::EngineServer;
-    use crate::engine::kinds::{CallSettled, EngineAlive, EngineDied};
-    use crate::rpc::{MailEnvelope, MailboxAddress, RpcConnection, RpcError, WireFrame};
-    use aether_actor::{Addressable, actor};
-    use aether_data::{EngineId, Kind, KindId, MailboxId, mailbox_id_from_name};
-    use aether_kinds::DeathReason;
-    use aether_substrate::Mail;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
-    use aether_substrate::mail::mailer::Mailer;
-    use aether_substrate::mail::{Source, SourceAddr};
-    use std::collections::HashMap;
-    use std::process::Child;
-    use std::sync::Arc;
+/// `aether.engine.proxy:<id>` cap **identity** (ADR-0122 identity/runtime
+/// split). A ZST carrying only the addressing — `Addressable` (`NAMESPACE`,
+/// `Resolver`), the per-handler `HandlesKind` markers, and the instanced
+/// name-inventory entry (`one_per = "engine"`), all emitted always-on by
+/// `#[actor]`. The state-bearing runtime (`runtime::EngineProxyState`, which
+/// holds the `aether_substrate`-typed RPC connection + the forked child +
+/// heartbeat handle) lives behind the one `feature = "runtime"` gate, so a
+/// transport-only build never names `EngineProxyState` nor pulls
+/// `aether_substrate` through this cap.
+pub struct EngineProxy;
 
-    /// Mailbox of the engines cap (`aether.engine`) — where a proxy
-    /// reports its own liveness transitions (`EngineAlive` / `EngineDied`,
-    /// issue 1339). A compile-time const derived from
-    /// `<EngineServer as Addressable>::NAMESPACE`, so no host round-trip; matches
-    /// the `RpcServerCapability`'s own route lookup.
-    // Well-known engines-cap route shared with `RpcServerCapability`'s own
-    // lookup; a ctx-less free helper in the proxy bridge mod, so there is no
-    // sibling `ctx.actor::<_>()` to resolve through.
-    #[allow(clippy::disallowed_methods)]
-    fn engine_cap_mailbox() -> MailboxId {
-        mailbox_id_from_name(<EngineServer as Addressable>::NAMESPACE)
+// The `#[actor]` / `#[handler]` attribute path stays always-on (the macro
+// divides what it emits). Everything that names an `aether_substrate` type —
+// the handler/init ctx, the runtime state, the connect/heartbeat helpers,
+// `Drop` — lives in the `runtime` module below, gated once by
+// `feature = "runtime"`; the `#[actor] impl` reaches all of it through the
+// single `use runtime::*` glob. The handler-signature kinds
+// (`ForwardEnvelope` / `RpcInboundReady` / …) stay always-on at file root —
+// the always-on `HandlesKind<K>` markers name them.
+use aether_actor::actor;
+
+// The `runtime` module is this cap's private runtime-half namespace; the impl
+// reaches all of it (state, ctx types, connect/heartbeat helpers) through this
+// single seam, so the glob is intentional rather than a dozen one-line
+// imports.
+#[cfg(feature = "runtime")]
+#[allow(clippy::wildcard_imports)]
+use runtime::*;
+
+#[actor(instanced, one_per = "engine")]
+impl NativeActor for EngineProxy {
+    /// The runtime state this identity boots into (ADR-0122 split): the
+    /// per-engine outbound RPC connection plus the in-flight
+    /// reply-correlation table.
+    type State = EngineProxyState;
+    type Config = EngineProxyConfig;
+    const NAMESPACE: &'static str = "aether.engine.proxy";
+
+    fn init(
+        mut config: EngineProxyConfig,
+        ctx: &mut NativeInitCtx<'_>,
+    ) -> Result<EngineProxyState, BootError> {
+        let self_mailbox = ctx.self_id();
+        let mailer = ctx.mailer();
+        let wake_kind = KindId(<RpcInboundReady as Kind>::ID.0);
+
+        // A freshly-forked substrate (`spawned.is_some()`) may not
+        // have bound its RPC port yet, so the startup dial retries
+        // briefly. An adopted / externally-running substrate
+        // (`spawned.is_none()`) is dialed once — a refused
+        // connection there is a real error, not a startup race.
+        let retry = config.spawned.is_some();
+        let conn = match connect_proxy(
+            &config.rpc_addr,
+            &mailer,
+            self_mailbox,
+            wake_kind,
+            retry,
+            config.connect_budget,
+        ) {
+            Ok(conn) => conn,
+            Err(e) => {
+                // The proxy owns the child it was handed — a
+                // failed boot must not orphan the substrate.
+                if let Some(mut child) = config.spawned.take() {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                }
+                return Err(BootError::Other(Box::new(e)));
+            }
+        };
+
+        tracing::info!(
+            target: "aether_substrate::engine_proxy",
+            engine_id = ?config.engine_id,
+            addr = %config.rpc_addr,
+            spawned = config.spawned.is_some(),
+            "engine proxy connected",
+        );
+
+        // Arm the liveness heartbeat, if configured. The sidecar
+        // thread fires an `EngineHeartbeatTick` at this proxy's own
+        // mailbox every `interval`; `on_heartbeat_tick` does the
+        // ping + miss accounting on the dispatcher thread (so the
+        // RPC write and all proxy state stay single-threaded).
+        let (heartbeat, miss_limit) = match config.heartbeat {
+            Some(params) if !params.interval.is_zero() && params.miss_limit > 0 => {
+                let handle = spawn_heartbeat(Arc::clone(&mailer), self_mailbox, params.interval);
+                (Some(handle), params.miss_limit)
+            }
+            _ => (None, 0),
+        };
+
+        Ok(EngineProxyState {
+            engine_id: config.engine_id,
+            mailer,
+            conn,
+            in_flight: HashMap::new(),
+            spawned: config.spawned,
+            missed_heartbeats: 0,
+            miss_limit,
+            heartbeat_seq: 0,
+            _heartbeat: heartbeat,
+        })
     }
 
-    /// Per-engine proxy: one outbound RPC connection to one substrate,
-    /// plus the in-flight reply-correlation table.
-    pub struct EngineProxy {
-        engine_id: EngineId,
-        /// Cached so `on_inbound_ready` can push correlation-preserving
-        /// reply mail — `NativeCtx` doesn't expose `mailer()`, only
-        /// `NativeInitCtx` does.
-        mailer: Arc<Mailer>,
-        /// The live outbound connection: `.client` writes `Call`s,
-        /// `.inbound` carries reply frames, `.reader` joins on drop.
-        /// `.server` holds the substrate's `HelloAck` identity (the
-        /// kind manifest P4's describe handler will read).
-        conn: RpcConnection,
-        /// wire `cid` → the `Source` of the `ForwardEnvelope` that
-        /// opened the call. `ReplyEvent` frames route back here;
-        /// `ReplyEnd` clears the entry.
-        in_flight: HashMap<u64, Source>,
-        /// The forked child substrate, when the engines cap spawned it
-        /// (see [`EngineProxyConfig::spawned`]). `Drop` SIGKILLs +
-        /// reaps it; `None` once taken or for an adopted substrate.
-        spawned: Option<Child>,
-        /// Consecutive heartbeat pings sent without a `Pong` reply
-        /// (issue 1339). Incremented each `on_heartbeat_tick`, reset to
-        /// `0` on any inbound `Pong`. Crossing `miss_limit` evicts the
-        /// engine.
-        missed_heartbeats: u32,
-        /// Consecutive-miss threshold that marks the engine dead. `0`
-        /// when the heartbeat is disabled (`heartbeat: None`), in which
-        /// case `on_heartbeat_tick` never fires anyway.
-        miss_limit: u32,
-        /// Monotonic nonce stamped on each heartbeat `Ping` — for log
-        /// correlation only; a `Pong` carrying any nonce counts as
-        /// liveness, since there is at most one heartbeat outstanding.
-        heartbeat_seq: u64,
-        /// The heartbeat timer thread, when armed. `Drop` stops + joins
-        /// it. Held as the field's RAII guard — the leading `_` marks
-        /// it as owned-for-its-Drop, not read.
-        _heartbeat: Option<HeartbeatHandle>,
-    }
-
-    #[actor]
-    impl NativeActor for EngineProxy {
-        type Config = EngineProxyConfig;
-        const NAMESPACE: &'static str = "aether.engine.proxy";
-
-        fn init(
-            mut config: EngineProxyConfig,
-            ctx: &mut NativeInitCtx<'_>,
-        ) -> Result<Self, BootError> {
-            let self_mailbox = ctx.self_id();
-            let mailer = ctx.mailer();
-            let wake_kind = KindId(<RpcInboundReady as Kind>::ID.0);
-
-            // A freshly-forked substrate (`spawned.is_some()`) may not
-            // have bound its RPC port yet, so the startup dial retries
-            // briefly. An adopted / externally-running substrate
-            // (`spawned.is_none()`) is dialed once — a refused
-            // connection there is a real error, not a startup race.
-            let retry = config.spawned.is_some();
-            let conn = match connect_proxy(
-                &config.rpc_addr,
-                &mailer,
-                self_mailbox,
-                wake_kind,
-                retry,
-                config.connect_budget,
-            ) {
-                Ok(conn) => conn,
-                Err(e) => {
-                    // The proxy owns the child it was handed — a
-                    // failed boot must not orphan the substrate.
-                    if let Some(mut child) = config.spawned.take() {
-                        let _ = child.kill();
-                        let _ = child.wait();
-                    }
-                    return Err(BootError::Other(Box::new(e)));
-                }
-            };
-
-            tracing::info!(
-                target: "aether_substrate::engine_proxy",
-                engine_id = ?config.engine_id,
-                addr = %config.rpc_addr,
-                spawned = config.spawned.is_some(),
-                "engine proxy connected",
-            );
-
-            // Arm the liveness heartbeat, if configured. The sidecar
-            // thread fires an `EngineHeartbeatTick` at this proxy's own
-            // mailbox every `interval`; `on_heartbeat_tick` does the
-            // ping + miss accounting on the dispatcher thread (so the
-            // RPC write and all proxy state stay single-threaded).
-            let (heartbeat, miss_limit) = match config.heartbeat {
-                Some(params) if !params.interval.is_zero() && params.miss_limit > 0 => {
-                    let handle =
-                        spawn_heartbeat(Arc::clone(&mailer), self_mailbox, params.interval);
-                    (Some(handle), params.miss_limit)
-                }
-                _ => (None, 0),
-            };
-
-            Ok(Self {
-                engine_id: config.engine_id,
-                mailer,
-                conn,
-                in_flight: HashMap::new(),
-                spawned: config.spawned,
-                missed_heartbeats: 0,
-                miss_limit,
-                heartbeat_seq: 0,
-                _heartbeat: heartbeat,
-            })
+    /// Relay one mail to the substrate as an RPC `Call`.
+    ///
+    /// # Agent
+    /// Hand the proxy a `ForwardEnvelope { mailbox, kind, payload }`
+    /// — the `mailbox` is the *substrate-local* recipient, `kind` +
+    /// `payload` the mail to deliver there. Any reply routes back to
+    /// the sender of this `ForwardEnvelope`.
+    #[handler]
+    fn on_forward(state: &mut Self::State, ctx: &mut NativeCtx<'_>, mail: ForwardEnvelope) {
+        let envelope = MailEnvelope {
+            to: MailboxAddress::local(mail.mailbox),
+            from: None,
+            kind: mail.kind,
+            correlation_id: None,
+            payload: mail.payload,
+        };
+        match state.conn.client.call(envelope) {
+            Ok(cid) => {
+                state.in_flight.insert(cid, ctx.reply_target());
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "aether_substrate::engine_proxy",
+                    engine_id = ?state.engine_id,
+                    error = %e,
+                    "engine proxy: Call write failed; dropping forward",
+                );
+            }
         }
+    }
 
-        /// Relay one mail to the substrate as an RPC `Call`.
-        ///
-        /// # Agent
-        /// Hand the proxy a `ForwardEnvelope { mailbox, kind, payload }`
-        /// — the `mailbox` is the *substrate-local* recipient, `kind` +
-        /// `payload` the mail to deliver there. Any reply routes back to
-        /// the sender of this `ForwardEnvelope`.
-        #[handler]
-        fn on_forward(&mut self, ctx: &mut NativeCtx<'_>, mail: ForwardEnvelope) {
-            let envelope = MailEnvelope {
-                to: MailboxAddress::local(mail.mailbox),
-                from: None,
-                kind: mail.kind,
-                correlation_id: None,
-                payload: mail.payload,
-            };
-            match self.conn.client.call(envelope) {
-                Ok(cid) => {
-                    self.in_flight.insert(cid, ctx.reply_target());
+    /// Reader-sidecar wake. Drain every inbound frame.
+    ///
+    /// # Agent
+    /// Internal wake mail — not part of the proxy's external
+    /// surface. The reader thread fires this after pushing a frame;
+    /// the handler drains `conn.inbound` and routes each frame.
+    #[handler]
+    fn on_inbound_ready(state: &mut Self::State, ctx: &mut NativeCtx<'_>, _mail: RpcInboundReady) {
+        while let Ok(frame) = state.conn.inbound.try_recv() {
+            match frame {
+                WireFrame::ReplyEvent { cid, envelope } => state.route_reply(cid, envelope),
+                WireFrame::ReplyEnd { cid, result } => state.route_settled(cid, result),
+                // A `Pong` answers this proxy's heartbeat `Ping`
+                // (issue 1339): the substrate is alive. Clear the
+                // miss counter and report the liveness up to the
+                // engines cap so `list_engines` can show a fresh
+                // heartbeat age. The nonce is for log correlation
+                // only — any `Pong` is a liveness signal.
+                WireFrame::Pong(_nonce) => {
+                    state.missed_heartbeats = 0;
+                    state.report_alive(ctx);
                 }
-                Err(e) => {
-                    tracing::warn!(
+                WireFrame::Bye { reason } => {
+                    tracing::info!(
                         target: "aether_substrate::engine_proxy",
-                        engine_id = ?self.engine_id,
-                        error = %e,
-                        "engine proxy: Call write failed; dropping forward",
+                        engine_id = ?state.engine_id,
+                        reason = %reason,
+                        "engine proxy: substrate closed the connection; shutting down",
+                    );
+                    // Tell the engines cap the engine is gone so it
+                    // drops the registry entry — without this the
+                    // proxy dies but `list_engines` keeps reporting
+                    // a corpse (issue 1339). The substrate closed the
+                    // connection on its own — a crash, not a
+                    // deliberate terminate; carry the `Bye` reason so
+                    // `list_engines` can show why.
+                    state.report_died(ctx, DeathReason::Crashed { detail: reason });
+                    ctx.shutdown();
+                    return;
+                }
+                // Hello / HelloAck / Call / Ping: a client-side proxy
+                // never expects these inbound. Drop with a debug
+                // line rather than warn-storming.
+                other => {
+                    tracing::debug!(
+                        target: "aether_substrate::engine_proxy",
+                        engine_id = ?state.engine_id,
+                        frame = ?other,
+                        "engine proxy: unexpected inbound frame; ignoring",
                     );
                 }
             }
         }
+    }
 
-        /// Reader-sidecar wake. Drain every inbound frame.
-        ///
-        /// # Agent
-        /// Internal wake mail — not part of the proxy's external
-        /// surface. The reader thread fires this after pushing a frame;
-        /// the handler drains `conn.inbound` and routes each frame.
-        #[handler]
-        fn on_inbound_ready(&mut self, ctx: &mut NativeCtx<'_>, _mail: RpcInboundReady) {
-            while let Ok(frame) = self.conn.inbound.try_recv() {
-                match frame {
-                    WireFrame::ReplyEvent { cid, envelope } => self.route_reply(cid, envelope),
-                    WireFrame::ReplyEnd { cid, result } => self.route_settled(cid, result),
-                    // A `Pong` answers this proxy's heartbeat `Ping`
-                    // (issue 1339): the substrate is alive. Clear the
-                    // miss counter and report the liveness up to the
-                    // engines cap so `list_engines` can show a fresh
-                    // heartbeat age. The nonce is for log correlation
-                    // only — any `Pong` is a liveness signal.
-                    WireFrame::Pong(_nonce) => {
-                        self.missed_heartbeats = 0;
-                        self.report_alive(ctx);
-                    }
-                    WireFrame::Bye { reason } => {
-                        tracing::info!(
-                            target: "aether_substrate::engine_proxy",
-                            engine_id = ?self.engine_id,
-                            reason = %reason,
-                            "engine proxy: substrate closed the connection; shutting down",
-                        );
-                        // Tell the engines cap the engine is gone so it
-                        // drops the registry entry — without this the
-                        // proxy dies but `list_engines` keeps reporting
-                        // a corpse (issue 1339). The substrate closed the
-                        // connection on its own — a crash, not a
-                        // deliberate terminate; carry the `Bye` reason so
-                        // `list_engines` can show why.
-                        self.report_died(ctx, DeathReason::Crashed { detail: reason });
-                        ctx.shutdown();
-                        return;
-                    }
-                    // Hello / HelloAck / Call / Ping: a client-side proxy
-                    // never expects these inbound. Drop with a debug
-                    // line rather than warn-storming.
-                    other => {
-                        tracing::debug!(
-                            target: "aether_substrate::engine_proxy",
-                            engine_id = ?self.engine_id,
-                            frame = ?other,
-                            "engine proxy: unexpected inbound frame; ignoring",
-                        );
-                    }
-                }
-            }
-        }
+    /// Shut this proxy's substrate down.
+    ///
+    /// # Agent
+    /// Sent by the engines cap (`aether.engine`) on a terminate
+    /// request. The proxy self-shuts-down; its `Drop` SIGKILLs and
+    /// reaps the child substrate it forked (if any), and the
+    /// outbound RPC connection closes as the actor drops. The
+    /// `engine_id` field is ignored — a proxy only ever terminates
+    /// its own engine.
+    #[handler]
+    fn on_terminate(state: &mut Self::State, ctx: &mut NativeCtx<'_>, _mail: TerminateEngine) {
+        tracing::info!(
+            target: "aether_substrate::engine_proxy",
+            engine_id = ?state.engine_id,
+            "engine proxy: terminate requested; shutting down",
+        );
+        // No `report_died` here: the engines cap initiated this
+        // terminate and already dropped the registry entry, so the
+        // proxy reporting back would be a redundant (idempotent)
+        // no-op. The self-death paths (`Bye`, heartbeat timeout) are
+        // the ones the cap doesn't already know about.
+        ctx.shutdown();
+    }
 
-        /// Shut this proxy's substrate down.
-        ///
-        /// # Agent
-        /// Sent by the engines cap (`aether.engine`) on a terminate
-        /// request. The proxy self-shuts-down; its `Drop` SIGKILLs and
-        /// reaps the child substrate it forked (if any), and the
-        /// outbound RPC connection closes as the actor drops. The
-        /// `engine_id` field is ignored — a proxy only ever terminates
-        /// its own engine.
-        #[handler]
-        fn on_terminate(&mut self, ctx: &mut NativeCtx<'_>, _mail: TerminateEngine) {
-            tracing::info!(
+    /// Liveness-heartbeat timer wake (issue 1339).
+    ///
+    /// # Agent
+    /// Internal wake mail — not part of the proxy's external
+    /// surface. The heartbeat sidecar thread fires this every
+    /// interval. The handler counts the tick as an outstanding miss
+    /// (a `Pong` since the last tick would have cleared the
+    /// counter), and once `miss_limit` consecutive ticks go
+    /// unanswered it declares the engine dead: reports `EngineDied`
+    /// to the engines cap and self-shuts-down (its `Drop` SIGKILLs
+    /// the wedged child). Otherwise it sends a fresh `Ping`.
+    #[handler]
+    fn on_heartbeat_tick(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        _mail: EngineHeartbeatTick,
+    ) {
+        state.heartbeat_seq += 1;
+        // A write failure means the socket is already broken — the
+        // reader sidecar will surface a `Bye` and `on_inbound_ready`
+        // handles the eviction. Count it as a miss and carry on so
+        // the miss-limit path also covers it (whichever fires first
+        // evicts; the cap side is idempotent).
+        if let Err(e) = state.conn.client.ping(state.heartbeat_seq) {
+            tracing::debug!(
                 target: "aether_substrate::engine_proxy",
-                engine_id = ?self.engine_id,
-                "engine proxy: terminate requested; shutting down",
-            );
-            // No `report_died` here: the engines cap initiated this
-            // terminate and already dropped the registry entry, so the
-            // proxy reporting back would be a redundant (idempotent)
-            // no-op. The self-death paths (`Bye`, heartbeat timeout) are
-            // the ones the cap doesn't already know about.
-            ctx.shutdown();
-        }
-
-        /// Liveness-heartbeat timer wake (issue 1339).
-        ///
-        /// # Agent
-        /// Internal wake mail — not part of the proxy's external
-        /// surface. The heartbeat sidecar thread fires this every
-        /// interval. The handler counts the tick as an outstanding miss
-        /// (a `Pong` since the last tick would have cleared the
-        /// counter), and once `miss_limit` consecutive ticks go
-        /// unanswered it declares the engine dead: reports `EngineDied`
-        /// to the engines cap and self-shuts-down (its `Drop` SIGKILLs
-        /// the wedged child). Otherwise it sends a fresh `Ping`.
-        #[handler]
-        fn on_heartbeat_tick(&mut self, ctx: &mut NativeCtx<'_>, _mail: EngineHeartbeatTick) {
-            self.heartbeat_seq += 1;
-            // A write failure means the socket is already broken — the
-            // reader sidecar will surface a `Bye` and `on_inbound_ready`
-            // handles the eviction. Count it as a miss and carry on so
-            // the miss-limit path also covers it (whichever fires first
-            // evicts; the cap side is idempotent).
-            if let Err(e) = self.conn.client.ping(self.heartbeat_seq) {
-                tracing::debug!(
-                    target: "aether_substrate::engine_proxy",
-                    engine_id = ?self.engine_id,
-                    error = %e,
-                    "engine proxy: heartbeat ping write failed",
-                );
-            }
-            self.missed_heartbeats += 1;
-            if self.missed_heartbeats >= self.miss_limit {
-                tracing::warn!(
-                    target: "aether_substrate::engine_proxy",
-                    engine_id = ?self.engine_id,
-                    missed = self.missed_heartbeats,
-                    miss_limit = self.miss_limit,
-                    "engine proxy: heartbeat miss limit crossed; evicting engine",
-                );
-                self.report_died(
-                    ctx,
-                    DeathReason::Evicted {
-                        detail: format!(
-                            "heartbeat miss limit {} of {}",
-                            self.missed_heartbeats, self.miss_limit
-                        ),
-                    },
-                );
-                ctx.shutdown();
-            }
-        }
-    }
-
-    impl Drop for EngineProxy {
-        /// SIGKILL + reap the child substrate this proxy forked, so a
-        /// terminated proxy (or a chassis teardown) never orphans a
-        /// substrate process. A no-op for an adopted substrate
-        /// (`spawned` is `None`). Graceful SIGTERM is a follow-up;
-        /// v1 is forceful.
-        fn drop(&mut self) {
-            if let Some(mut child) = self.spawned.take() {
-                let _ = child.kill();
-                let _ = child.wait();
-            }
-        }
-    }
-
-    impl EngineProxy {
-        /// Report a confirmed liveness signal to the engines cap so it
-        /// refreshes this engine's last-heartbeat timestamp (issue
-        /// 1339). Sent as a fresh root: the `Pong` that triggered it is
-        /// an external event causally unrelated to whatever inbound
-        /// mail woke the handler.
-        fn report_alive(&self, ctx: &NativeCtx<'_>) {
-            let alive = EngineAlive {
-                engine_id: self.engine_id.0.to_string(),
-            };
-            let _ = ctx.send_envelope_as_root(
-                engine_cap_mailbox(),
-                <EngineAlive as Kind>::ID,
-                &alive.encode_into_bytes(),
+                engine_id = ?state.engine_id,
+                error = %e,
+                "engine proxy: heartbeat ping write failed",
             );
         }
-
-        /// Report this engine's death to the engines cap so it drops the
-        /// registry entry and records the cause in its recently-died ring
-        /// (issue 1339, issue 1906). `reason` distinguishes a crash
-        /// (`Crashed`, connection-close) from a heartbeat eviction
-        /// (`Evicted`); a deliberate terminate never reaches here.
-        /// Idempotent on the cap side — a `died` for an already-evicted
-        /// engine is a no-op. Sent as a fresh root for the same reason as
-        /// [`Self::report_alive`].
-        fn report_died(&self, ctx: &NativeCtx<'_>, reason: DeathReason) {
-            let died = EngineDied {
-                engine_id: self.engine_id.0.to_string(),
-                reason,
-            };
-            let _ = ctx.send_envelope_as_root(
-                engine_cap_mailbox(),
-                <EngineDied as Kind>::ID,
-                &died.encode_into_bytes(),
+        state.missed_heartbeats += 1;
+        if state.missed_heartbeats >= state.miss_limit {
+            tracing::warn!(
+                target: "aether_substrate::engine_proxy",
+                engine_id = ?state.engine_id,
+                missed = state.missed_heartbeats,
+                miss_limit = state.miss_limit,
+                "engine proxy: heartbeat miss limit crossed; evicting engine",
             );
-        }
-
-        /// Route a `ReplyEvent`'s envelope back to whoever sent the
-        /// `ForwardEnvelope` that opened `cid`. Mirrors
-        /// `Mailer::send_reply`'s `Component` branch: push a `Mail`
-        /// carrying the reply kind + already-encoded bytes, with the
-        /// original `correlation_id` echoed (reply-to `None` — nobody
-        /// replies to a reply) so a correlation-matching caller picks
-        /// it up.
-        fn route_reply(&mut self, cid: u64, envelope: MailEnvelope) {
-            let Some(reply_to) = self.in_flight.get(&cid).copied() else {
-                tracing::debug!(
-                    target: "aether_substrate::engine_proxy",
-                    engine_id = ?self.engine_id,
-                    cid,
-                    "engine proxy: ReplyEvent with no matching in-flight forward; dropping",
-                );
-                return;
-            };
-            let SourceAddr::Component(target) = reply_to.addr else {
-                // The `ForwardEnvelope` arrived with no `Component`
-                // reply target (broadcast / `None`) — there's nowhere
-                // local to route the reply.
-                return;
-            };
-            self.mailer.push(
-                Mail::new(target, envelope.kind, envelope.payload, 1).with_reply_to(
-                    Source::with_correlation(SourceAddr::None, reply_to.correlation_id),
-                ),
-            );
-        }
-
-        /// Lift the substrate's terminal `ReplyEnd` for `cid` into a
-        /// [`CallSettled`] mail back to whoever opened the call, then
-        /// clear the in-flight entry. Mirrors [`Self::route_reply`]'s
-        /// correlation handling — a forwarded call has no local chain
-        /// to settle, so this explicit terminal signal is how the
-        /// originating `RpcServerCapability` learns to close its wire
-        /// call. The wire `RpcError` is rendered to a string; the
-        /// `aether-kinds` layer can't carry the structured variant.
-        fn route_settled(&mut self, cid: u64, result: Result<(), RpcError>) {
-            let Some(reply_to) = self.in_flight.remove(&cid) else {
-                tracing::debug!(
-                    target: "aether_substrate::engine_proxy",
-                    engine_id = ?self.engine_id,
-                    cid,
-                    "engine proxy: ReplyEnd with no matching in-flight forward; dropping",
-                );
-                return;
-            };
-            let SourceAddr::Component(target) = reply_to.addr else {
-                return;
-            };
-            let settled = match result {
-                Ok(()) => CallSettled::Ok,
-                Err(e) => CallSettled::Err {
-                    error: format!("{e:?}"),
+            state.report_died(
+                ctx,
+                DeathReason::Evicted {
+                    detail: format!(
+                        "heartbeat miss limit {} of {}",
+                        state.missed_heartbeats, state.miss_limit
+                    ),
                 },
-            };
-            self.mailer.push(
-                Mail::new(
-                    target,
-                    <CallSettled as Kind>::ID,
-                    settled.encode_into_bytes(),
-                    1,
-                )
-                .with_reply_to(Source::with_correlation(
-                    SourceAddr::None,
-                    reply_to.correlation_id,
-                )),
             );
+            ctx.shutdown();
         }
     }
 }
+
+// The runtime half — the whole `aether_substrate`-typed surface (imports,
+// `EngineProxyState`, its `Drop` + helper methods, `engine_cap_mailbox`) —
+// lives in `runtime.rs`, gated once here. The `#[actor] impl` above reaches it
+// through the `use runtime::*` glob.
+#[cfg(feature = "runtime")]
+mod runtime;
 
 #[cfg(test)]
 use aether_kinds::DeathReason;

--- a/crates/aether-capabilities/src/engine/proxy/runtime.rs
+++ b/crates/aether-capabilities/src/engine/proxy/runtime.rs
@@ -1,0 +1,217 @@
+//! The `aether.engine.proxy:<id>` runtime half (ADR-0122 identity/runtime
+//! split). Compiled only under `feature = "runtime"` (the `mod runtime;`
+//! declaration in the parent carries the gate), so a transport-only build of
+//! the [`EngineProxy`](super::EngineProxy) identity never names these types
+//! nor pulls `aether_substrate`. The substrate-typed imports are gated once by
+//! this module rather than line-by-line; the `#[actor] impl` reaches the
+//! state, ctx types, and connect/heartbeat helpers through the single
+//! `use runtime::*` glob in the parent.
+//!
+//! Native-only: the state owns a `TcpStream` (via [`RpcConnection`]) and an OS
+//! thread (the heartbeat sidecar). `Drop` SIGKILLs the forked child and joins
+//! the heartbeat thread, so the RAII teardown follows the fields onto the
+//! state.
+
+pub use crate::engine::kinds::{CallSettled, EngineAlive, EngineDied};
+pub use crate::rpc::{MailEnvelope, MailboxAddress, RpcConnection, RpcError, WireFrame};
+pub use aether_actor::Addressable;
+pub use aether_data::{EngineId, Kind, KindId, MailboxId, mailbox_id_from_name};
+pub use aether_kinds::DeathReason;
+pub use aether_substrate::Mail;
+pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub use aether_substrate::chassis::error::BootError;
+pub use aether_substrate::mail::mailer::Mailer;
+pub use aether_substrate::mail::{Source, SourceAddr};
+pub use std::collections::HashMap;
+pub use std::process::Child;
+pub use std::sync::Arc;
+
+use super::heartbeat::HeartbeatHandle;
+use crate::engine::EngineServer;
+
+// The init-only bring-up helpers live in the native-only `connect` /
+// `heartbeat` submodules; re-export them here so the parent's `use runtime::*`
+// glob reaches them alongside the rest of the runtime half.
+pub use super::connect::connect_proxy;
+pub use super::heartbeat::spawn_heartbeat;
+
+/// Mailbox of the engines cap (`aether.engine`) — where a proxy
+/// reports its own liveness transitions (`EngineAlive` / `EngineDied`,
+/// issue 1339). A compile-time const derived from
+/// `<EngineServer as Addressable>::NAMESPACE`, so no host round-trip; matches
+/// the `RpcServerCapability`'s own route lookup.
+// Well-known engines-cap route shared with `RpcServerCapability`'s own
+// lookup; a ctx-less free helper, so there is no sibling `ctx.actor::<_>()`
+// to resolve through.
+#[allow(clippy::disallowed_methods)]
+fn engine_cap_mailbox() -> MailboxId {
+    mailbox_id_from_name(<EngineServer as Addressable>::NAMESPACE)
+}
+
+/// `aether.engine.proxy:<id>` runtime state (ADR-0122 split): one outbound
+/// RPC connection to one substrate, plus the in-flight reply-correlation
+/// table. The addressing identity is the distinct ZST
+/// [`EngineProxy`](super::EngineProxy); the dispatcher holds this as the
+/// proxy's state and routes envelopes through the macro-emitted `Dispatch`
+/// impl. Living in this private module keeps it `pub`-enough to satisfy the
+/// `NativeActor::State` interface without exposing it as crate-public API.
+pub struct EngineProxyState {
+    pub(super) engine_id: EngineId,
+    /// Cached so `on_inbound_ready` can push correlation-preserving
+    /// reply mail — `NativeCtx` doesn't expose `mailer()`, only
+    /// `NativeInitCtx` does.
+    pub(super) mailer: Arc<Mailer>,
+    /// The live outbound connection: `.client` writes `Call`s,
+    /// `.inbound` carries reply frames, `.reader` joins on drop.
+    /// `.server` holds the substrate's `HelloAck` identity (the
+    /// kind manifest P4's describe handler will read).
+    pub(super) conn: RpcConnection,
+    /// wire `cid` → the `Source` of the `ForwardEnvelope` that
+    /// opened the call. `ReplyEvent` frames route back here;
+    /// `ReplyEnd` clears the entry.
+    pub(super) in_flight: HashMap<u64, Source>,
+    /// The forked child substrate, when the engines cap spawned it
+    /// (see [`EngineProxyConfig::spawned`]). `Drop` SIGKILLs +
+    /// reaps it; `None` once taken or for an adopted substrate.
+    pub(super) spawned: Option<Child>,
+    /// Consecutive heartbeat pings sent without a `Pong` reply
+    /// (issue 1339). Incremented each `on_heartbeat_tick`, reset to
+    /// `0` on any inbound `Pong`. Crossing `miss_limit` evicts the
+    /// engine.
+    pub(super) missed_heartbeats: u32,
+    /// Consecutive-miss threshold that marks the engine dead. `0`
+    /// when the heartbeat is disabled (`heartbeat: None`), in which
+    /// case `on_heartbeat_tick` never fires anyway.
+    pub(super) miss_limit: u32,
+    /// Monotonic nonce stamped on each heartbeat `Ping` — for log
+    /// correlation only; a `Pong` carrying any nonce counts as
+    /// liveness, since there is at most one heartbeat outstanding.
+    pub(super) heartbeat_seq: u64,
+    /// The heartbeat timer thread, when armed. `Drop` stops + joins
+    /// it. Held as the field's RAII guard — the leading `_` marks
+    /// it as owned-for-its-Drop, not read.
+    pub(super) _heartbeat: Option<HeartbeatHandle>,
+}
+
+impl Drop for EngineProxyState {
+    /// SIGKILL + reap the child substrate this proxy forked, so a
+    /// terminated proxy (or a chassis teardown) never orphans a
+    /// substrate process. A no-op for an adopted substrate
+    /// (`spawned` is `None`). Graceful SIGTERM is a follow-up;
+    /// v1 is forceful.
+    fn drop(&mut self) {
+        if let Some(mut child) = self.spawned.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+impl EngineProxyState {
+    /// Report a confirmed liveness signal to the engines cap so it
+    /// refreshes this engine's last-heartbeat timestamp (issue
+    /// 1339). Sent as a fresh root: the `Pong` that triggered it is
+    /// an external event causally unrelated to whatever inbound
+    /// mail woke the handler.
+    pub(super) fn report_alive(&self, ctx: &NativeCtx<'_>) {
+        let alive = EngineAlive {
+            engine_id: self.engine_id.0.to_string(),
+        };
+        let _ = ctx.send_envelope_as_root(
+            engine_cap_mailbox(),
+            <EngineAlive as Kind>::ID,
+            &alive.encode_into_bytes(),
+        );
+    }
+
+    /// Report this engine's death to the engines cap so it drops the
+    /// registry entry and records the cause in its recently-died ring
+    /// (issue 1339, issue 1906). `reason` distinguishes a crash
+    /// (`Crashed`, connection-close) from a heartbeat eviction
+    /// (`Evicted`); a deliberate terminate never reaches here.
+    /// Idempotent on the cap side — a `died` for an already-evicted
+    /// engine is a no-op. Sent as a fresh root for the same reason as
+    /// [`Self::report_alive`].
+    pub(super) fn report_died(&self, ctx: &NativeCtx<'_>, reason: DeathReason) {
+        let died = EngineDied {
+            engine_id: self.engine_id.0.to_string(),
+            reason,
+        };
+        let _ = ctx.send_envelope_as_root(
+            engine_cap_mailbox(),
+            <EngineDied as Kind>::ID,
+            &died.encode_into_bytes(),
+        );
+    }
+
+    /// Route a `ReplyEvent`'s envelope back to whoever sent the
+    /// `ForwardEnvelope` that opened `cid`. Mirrors
+    /// `Mailer::send_reply`'s `Component` branch: push a `Mail`
+    /// carrying the reply kind + already-encoded bytes, with the
+    /// original `correlation_id` echoed (reply-to `None` — nobody
+    /// replies to a reply) so a correlation-matching caller picks
+    /// it up.
+    pub(super) fn route_reply(&mut self, cid: u64, envelope: MailEnvelope) {
+        let Some(reply_to) = self.in_flight.get(&cid).copied() else {
+            tracing::debug!(
+                target: "aether_substrate::engine_proxy",
+                engine_id = ?self.engine_id,
+                cid,
+                "engine proxy: ReplyEvent with no matching in-flight forward; dropping",
+            );
+            return;
+        };
+        let SourceAddr::Component(target) = reply_to.addr else {
+            // The `ForwardEnvelope` arrived with no `Component`
+            // reply target (broadcast / `None`) — there's nowhere
+            // local to route the reply.
+            return;
+        };
+        self.mailer.push(
+            Mail::new(target, envelope.kind, envelope.payload, 1).with_reply_to(
+                Source::with_correlation(SourceAddr::None, reply_to.correlation_id),
+            ),
+        );
+    }
+
+    /// Lift the substrate's terminal `ReplyEnd` for `cid` into a
+    /// [`CallSettled`] mail back to whoever opened the call, then
+    /// clear the in-flight entry. Mirrors [`Self::route_reply`]'s
+    /// correlation handling — a forwarded call has no local chain
+    /// to settle, so this explicit terminal signal is how the
+    /// originating `RpcServerCapability` learns to close its wire
+    /// call. The wire `RpcError` is rendered to a string; the
+    /// `aether-kinds` layer can't carry the structured variant.
+    pub(super) fn route_settled(&mut self, cid: u64, result: Result<(), RpcError>) {
+        let Some(reply_to) = self.in_flight.remove(&cid) else {
+            tracing::debug!(
+                target: "aether_substrate::engine_proxy",
+                engine_id = ?self.engine_id,
+                cid,
+                "engine proxy: ReplyEnd with no matching in-flight forward; dropping",
+            );
+            return;
+        };
+        let SourceAddr::Component(target) = reply_to.addr else {
+            return;
+        };
+        let settled = match result {
+            Ok(()) => CallSettled::Ok,
+            Err(e) => CallSettled::Err {
+                error: format!("{e:?}"),
+            },
+        };
+        self.mailer.push(
+            Mail::new(
+                target,
+                <CallSettled as Kind>::ID,
+                settled.encode_into_bytes(),
+                1,
+            )
+            .with_reply_to(Source::with_correlation(
+                SourceAddr::None,
+                reply_to.correlation_id,
+            )),
+        );
+    }
+}

--- a/crates/aether-capabilities/src/engine/proxy/sinks.rs
+++ b/crates/aether-capabilities/src/engine/proxy/sinks.rs
@@ -6,13 +6,16 @@
 
 use crate::engine::kinds::{EngineAlive, EngineDied};
 use crate::rpc::test_echo::TestEchoReply;
+use aether_actor::actor;
+use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+use aether_substrate::chassis::error::BootError;
 use std::sync::{Arc, Mutex};
 
 /// Shared capture cells for [`EngineCapSink`]. Lives at file root (not
-/// inside the bridge mod) like `EngineServer`'s `ReplyCells` — it's the
-/// sink actor's `Config`, so it must be addressable as `super::…` from
-/// the bridge mod. `died` keeps the whole [`EngineDied`] (id + reason) so
-/// the death-path tests can assert the surfaced cause.
+/// inside an actor's state) like `EngineServer`'s `ReplyCells` — it's the
+/// sink actor's `Config`, so it must be addressable from the actor's `init`.
+/// `died` keeps the whole [`EngineDied`] (id + reason) so the death-path
+/// tests can assert the surfaced cause.
 #[derive(Clone, Default)]
 pub struct EngineCapCells {
     pub alive: Arc<Mutex<Vec<String>>>,
@@ -23,82 +26,65 @@ pub struct EngineCapCells {
 /// `aether.engine` mailbox so a proxy's `EngineAlive` / `EngineDied`
 /// reports land here without booting the real `EngineServer`. Records
 /// the reported `engine_id`s into shared vecs the heartbeat tests
-/// assert on. Lives at file root for `#[bridge]` marker addressability.
-#[aether_actor::bridge(singleton)]
-mod engine_cap_sink {
-    use super::{EngineAlive, EngineCapCells, EngineDied};
-    use aether_actor::actor;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
+/// assert on. A field-bearing `#[cfg(test)]` actor, so it stays the
+/// un-split `type State = Self` shape (ADR-0122).
+pub struct EngineCapSink {
+    cells: EngineCapCells,
+}
 
-    pub struct EngineCapSink {
-        cells: EngineCapCells,
+#[actor(singleton)]
+impl NativeActor for EngineCapSink {
+    type Config = EngineCapCells;
+    const NAMESPACE: &'static str = "aether.engine";
+
+    fn init(cells: EngineCapCells, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        Ok(Self { cells })
     }
 
-    #[actor]
-    impl NativeActor for EngineCapSink {
-        type Config = EngineCapCells;
-        const NAMESPACE: &'static str = "aether.engine";
+    #[handler]
+    fn on_alive(&mut self, _ctx: &mut NativeCtx<'_>, mail: EngineAlive) {
+        self.cells
+            .alive
+            .lock()
+            .expect("test setup: alive cell mutex poisoned")
+            .push(mail.engine_id);
+    }
 
-        fn init(cells: EngineCapCells, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            Ok(Self { cells })
-        }
-
-        #[handler]
-        fn on_alive(&mut self, _ctx: &mut NativeCtx<'_>, mail: EngineAlive) {
-            self.cells
-                .alive
-                .lock()
-                .expect("test setup: alive cell mutex poisoned")
-                .push(mail.engine_id);
-        }
-
-        #[handler]
-        fn on_died(&mut self, _ctx: &mut NativeCtx<'_>, mail: EngineDied) {
-            self.cells
-                .died
-                .lock()
-                .expect("test setup: died cell mutex poisoned")
-                .push(mail);
-        }
+    #[handler]
+    fn on_died(&mut self, _ctx: &mut NativeCtx<'_>, mail: EngineDied) {
+        self.cells
+            .died
+            .lock()
+            .expect("test setup: died cell mutex poisoned")
+            .push(mail);
     }
 }
 
 /// Test-only sink: records the `value` of every [`TestEchoReply`] it
 /// receives into a shared cell so the round-trip test can observe a
-/// reply routed back through the proxy. Lives at file root (not nested
-/// in `mod tests`) so the `#[bridge]` macro's marker emission stays
-/// addressable.
-#[aether_actor::bridge(singleton)]
-mod proxy_reply_sink {
-    use super::TestEchoReply;
-    use aether_actor::actor;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
-    use std::sync::{Arc, Mutex};
+/// reply routed back through the proxy. A field-bearing `#[cfg(test)]`
+/// actor, so it stays the un-split `type State = Self` shape (ADR-0122).
+pub struct ProxyReplySink {
+    recorded: Arc<Mutex<Option<u64>>>,
+}
 
-    pub struct ProxyReplySink {
+#[actor(singleton)]
+impl NativeActor for ProxyReplySink {
+    type Config = Arc<Mutex<Option<u64>>>;
+    const NAMESPACE: &'static str = "aether.engine.test.reply_sink";
+
+    fn init(
         recorded: Arc<Mutex<Option<u64>>>,
+        _ctx: &mut NativeInitCtx<'_>,
+    ) -> Result<Self, BootError> {
+        Ok(Self { recorded })
     }
 
-    #[actor]
-    impl NativeActor for ProxyReplySink {
-        type Config = Arc<Mutex<Option<u64>>>;
-        const NAMESPACE: &'static str = "aether.engine.test.reply_sink";
-
-        fn init(
-            recorded: Arc<Mutex<Option<u64>>>,
-            _ctx: &mut NativeInitCtx<'_>,
-        ) -> Result<Self, BootError> {
-            Ok(Self { recorded })
-        }
-
-        #[handler]
-        fn on_reply(&mut self, _ctx: &mut NativeCtx<'_>, reply: TestEchoReply) {
-            *self
-                .recorded
-                .lock()
-                .expect("test setup: recorded mutex poisoned") = Some(reply.value);
-        }
+    #[handler]
+    fn on_reply(&mut self, _ctx: &mut NativeCtx<'_>, reply: TestEchoReply) {
+        *self
+            .recorded
+            .lock()
+            .expect("test setup: recorded mutex poisoned") = Some(reply.value);
     }
 }

--- a/crates/aether-capabilities/src/engine/server/artifacts.rs
+++ b/crates/aether-capabilities/src/engine/server/artifacts.rs
@@ -52,7 +52,7 @@ fn describe_binary(binary_path: &str) -> Result<BinaryManifest, String> {
 /// or a human-readable error for an unreadable path or a `--describe`
 /// that failed / yielded no parseable manifest. Idempotent — identical
 /// bytes dedup to the same hash.
-pub(super) fn ingest_binary(
+pub fn ingest_binary(
     store: &mut ArtifactStore,
     path: &str,
     name: Option<String>,
@@ -74,7 +74,7 @@ pub(super) fn ingest_binary(
 /// env layer, ADR-0090). A path that can't be read or `--describe`d is
 /// logged and skipped — a bad bootstrap entry must not fail hub boot.
 /// Idempotent via content dedup.
-pub(super) fn bootstrap_ingest(store: &mut ArtifactStore, paths: &HashSet<String>) {
+pub fn bootstrap_ingest(store: &mut ArtifactStore, paths: &HashSet<String>) {
     for path_str in paths {
         let name = Path::new(path_str)
             .file_stem()
@@ -102,7 +102,7 @@ pub(super) fn bootstrap_ingest(store: &mut ArtifactStore, paths: &HashSet<String
 /// no execution step. Returns the stored content hash, or a
 /// human-readable error for an unreadable path or an unparseable wasm.
 /// Idempotent — identical bytes dedup to the same hash.
-pub(super) fn ingest_component(
+pub fn ingest_component(
     store: &mut ArtifactStore,
     path: &str,
     name: Option<String>,
@@ -128,7 +128,7 @@ pub(super) fn ingest_component(
 /// silent pick). A `module@actor` token's `@actor` part populates the
 /// reply `export` so the forwarded `LoadComponent` instantiates that
 /// actor type (ADR-0096). Returns `Err` for no match / ambiguity.
-pub(super) fn resolve_component(
+pub fn resolve_component(
     store: &mut ArtifactStore,
     selector: &ComponentSelector,
 ) -> ResolveComponentResult {
@@ -246,7 +246,7 @@ fn stored_component_reply(
 /// the `chassis` / `caps` / `target` attribute query resolves, and with
 /// no attribute filters either, `default` = the [`DEFAULT_CHASSIS`]
 /// binary. `None` when nothing matched.
-pub(super) fn resolve_selector(
+pub fn resolve_selector(
     store: &mut ArtifactStore,
     selector: &BinarySelector,
 ) -> Option<StoredArtifact> {
@@ -314,7 +314,7 @@ fn pick_versioned(store: &ArtifactStore, name: &str, version: &str) -> Option<St
 /// `anthropic/cli.rs`), creating `dest`'s parent dir. The
 /// realize-to-exec step for spawn: stored bytes aren't directly
 /// fork-exec'able (ADR-0115 §Execution).
-pub(super) fn realize_executable(src: &Path, dest: &Path) -> io::Result<()> {
+pub fn realize_executable(src: &Path, dest: &Path) -> io::Result<()> {
     if let Some(parent) = dest.parent() {
         fs::create_dir_all(parent)?;
     }

--- a/crates/aether-capabilities/src/engine/server/fleet.rs
+++ b/crates/aether-capabilities/src/engine/server/fleet.rs
@@ -25,7 +25,7 @@ const ENV_ENGINE_STORE_ROOT: &str = "AETHER_ENGINE_STORE_ROOT";
 /// preserved) so a routed call that the cap can't satisfy — bad
 /// `engine_id`, unknown engine — closes with a wire `ReplyEnd`
 /// instead of leaving the RPC client hanging.
-pub(super) fn settle_err(mailer: &Arc<Mailer>, target: MailboxId, correlation: u64, error: String) {
+pub fn settle_err(mailer: &Arc<Mailer>, target: MailboxId, correlation: u64, error: String) {
     mailer.push(
         Mail::new(
             target,
@@ -42,7 +42,7 @@ pub(super) fn settle_err(mailer: &Arc<Mailer>, target: MailboxId, correlation: u
 /// rebinds the port, but on localhost it's negligible — and this
 /// sidesteps both a wire change to report an ephemeral port back
 /// from the substrate and an un-recycled incrementing port pool.
-pub(super) fn free_local_port() -> io::Result<u16> {
+pub fn free_local_port() -> io::Result<u16> {
     let listener = TcpListener::bind("127.0.0.1:0")?;
     let port = listener.local_addr()?.port();
     drop(listener);
@@ -65,7 +65,7 @@ pub(super) fn free_local_port() -> io::Result<u16> {
 // moved onto EngineConfig); it is a process-level deployment override, not
 // a cap config field.
 #[allow(clippy::disallowed_methods)]
-pub(super) fn engine_store_root() -> PathBuf {
+pub fn engine_store_root() -> PathBuf {
     if let Ok(raw) = env::var(ENV_ENGINE_STORE_ROOT)
         && !raw.is_empty()
     {

--- a/crates/aether-capabilities/src/engine/server/mod.rs
+++ b/crates/aether-capabilities/src/engine/server/mod.rs
@@ -1,6 +1,6 @@
 //! `aether.engine` — engines capability (issue 763 P4).
 //!
-//! A `#[bridge(singleton)]` `NativeActor` that supervises a fleet of
+//! A singleton `NativeActor` that supervises a fleet of
 //! `EngineProxy` actors — the engine-management surface of the
 //! forward-model architecture (issue 763). Three handlers:
 //!
@@ -25,9 +25,12 @@
 //! an out-of-process RPC client drives the hub.
 //!
 //! Native-only: the cap fork+execs processes and threads the
-//! `std::process::Child` handle into the proxy. The `#[bridge]` macro
-//! emits the wasm-side marker stub so `aether-capabilities` still
-//! compiles for `wasm32`.
+//! `std::process::Child` handle into the proxy, so its substrate-typed
+//! runtime half lives behind `feature = "runtime"` in the `runtime` module. The
+//! `#[actor]` macro divides the identity from that runtime (ADR-0122): the
+//! [`EngineServer`] ZST and its addressing markers stay always-on so
+//! `aether-capabilities` still compiles for `wasm32`, while the state and
+//! handlers compile only under `runtime`.
 
 // `#[handler]` methods take their decoded payload by value per the
 // ADR-0033 dispatch ABI; the macro-generated trampoline owns the
@@ -35,8 +38,9 @@
 #![allow(clippy::needless_pass_by_value)]
 
 // Handler-signature kinds must be importable at file root — the
-// `#[bridge]` macro emits `impl HandlesKind<K>` markers as siblings of
-// the mod.
+// `#[actor]` macro emits `impl HandlesKind<K>` markers always-on against
+// the identity, outside the `feature = "runtime"` gate, so they reference
+// these kinds from here.
 use crate::engine::kinds::{EngineAlive, EngineDied, RouteEnvelope};
 use aether_kinds::{
     ListComponentBinaries, ListEngineBinaries, ListEngines, ResolveComponent, SpawnEngine,
@@ -51,7 +55,7 @@ use std::sync::{Arc, Mutex};
 // to), and `fleet` (free-port allocation, routed-call settlement, and
 // spawn-dir resolution). All three are native-only — the cap forks
 // processes and owns sockets — so they elide on wasm alongside the
-// bridge mod.
+// runtime half.
 #[cfg(not(target_arch = "wasm32"))]
 mod artifacts;
 #[cfg(not(target_arch = "wasm32"))]
@@ -67,619 +71,546 @@ mod fleet;
 #[cfg(not(target_arch = "wasm32"))]
 pub use config::{EngineConfig, EngineConfigLayer, EngineOverlay};
 
-#[aether_actor::bridge(singleton)]
-mod server_native {
-    use super::artifacts::{
-        bootstrap_ingest, ingest_binary, ingest_component, realize_executable, resolve_component,
-        resolve_selector,
-    };
-    use super::config::EngineConfig;
-    use super::fleet::{engine_store_root, free_local_port, settle_err};
-    use super::{
-        EngineAlive, EngineDied, ListComponentBinaries, ListEngineBinaries, ListEngines,
-        ResolveComponent, RouteEnvelope, SpawnEngine, TerminateEngine, UploadBinary,
-        UploadComponent,
-    };
-    use crate::engine::kinds::ForwardEnvelope;
-    use crate::engine::proxy::{EngineProxy, EngineProxyConfig, HeartbeatParams};
-    use crate::engine::store::{ArtifactStore, LAYOUT_VERSION_DIR};
-    use aether_actor::actor;
-    use aether_data::{EngineId, Kind, MailboxId, Uuid};
-    use aether_kinds::{
-        DeadEngineDescriptor, DeathReason, EngineDescriptor, ListComponentBinariesResult,
-        ListEngineBinariesResult, ListEnginesResult, ResolveComponentResult, SpawnEngineResult,
-        TerminateEngineResult, UploadBinaryResult, UploadComponentResult,
-    };
-    use aether_substrate::Mail;
-    use aether_substrate::Subname;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
-    use aether_substrate::mail::SourceAddr;
-    use aether_substrate::mail::mailer::Mailer;
-    use std::collections::HashMap;
-    use std::collections::VecDeque;
-    use std::path::PathBuf;
-    use std::process::{Command, Stdio};
-    use std::sync::Arc;
-    use std::time::{Duration, Instant};
+/// `aether.engine` engines-cap **identity** (ADR-0122 identity/runtime
+/// split). A ZST carrying only the addressing — `Addressable` (`NAMESPACE`,
+/// `Resolver`), the per-handler `HandlesKind` markers, and the
+/// name-inventory entry, all emitted always-on by `#[actor]`. The
+/// state-bearing runtime (`runtime::EngineServerState`, which holds the
+/// supervised-fleet table + the `aether_substrate`-typed mailer + the
+/// artifact store) lives behind the one `feature = "runtime"` gate, so a
+/// transport-only build never names `EngineServerState` nor pulls
+/// `aether_substrate` through this cap.
+pub struct EngineServer;
 
-    /// How many recently-died engines [`EngineServer`] retains for
-    /// `list_engines`' `recently_died` sidecar (issue 1906). A small
-    /// bound: the surface is "what just left and why", not an audit log —
-    /// the oldest record is dropped once the ring is full.
-    const RECENTLY_DIED_CAP: usize = 16;
+// The `#[actor]` / `#[handler]` attribute path stays always-on (the macro
+// divides what it emits). Everything that names an `aether_substrate` type —
+// the handler/init ctx, the runtime state, the artifact/fleet helpers — lives
+// in the `runtime` module below, gated once by `feature = "runtime"`; the
+// `#[actor] impl` reaches all of it through the single `use runtime::*` glob.
+// The handler-signature kinds (`ListEngines` / `SpawnEngine` / …) stay
+// always-on at file root — the always-on `HandlesKind<K>` markers name them.
+use aether_actor::actor;
 
-    /// One recently-departed engine in [`EngineServer`]'s recently-died
-    /// ring (issue 1906). Cap-internal — holds the wire fields plus the
-    /// `Instant` the cap removed the engine, so `on_list` can compute the
-    /// `died_age_millis` it reports in a [`DeadEngineDescriptor`].
-    struct DeadRecord {
-        engine_id: String,
-        rpc_port: u16,
-        reason: DeathReason,
-        died_at: Instant,
-    }
+// The `runtime` module is this cap's private runtime-half namespace; the impl
+// reaches all of it (state, ctx types, artifact/fleet helpers, result kinds)
+// through this single seam, so the glob is intentional rather than a few dozen
+// one-line imports.
+#[cfg(feature = "runtime")]
+#[allow(clippy::wildcard_imports)]
+use runtime::*;
 
-    /// One supervised engine in [`EngineServer`]'s table.
-    struct EngineEntry {
-        /// Mailbox of the `aether.engine.proxy:<id>` actor — the
-        /// forward target for [`TerminateEngine`].
-        proxy_mailbox: MailboxId,
-        /// The localhost RPC port the cap assigned this substrate.
-        rpc_port: u16,
-        /// When the cap last saw this engine alive (issue 1339): set at
-        /// spawn (just-connected = alive) and refreshed on each
-        /// `EngineAlive` the proxy reports from a confirmed `Pong`.
-        /// `on_list` reports `now - last_alive` as the heartbeat age.
-        last_alive: Instant,
-    }
+#[actor(singleton)]
+impl NativeActor for EngineServer {
+    /// The runtime state this identity boots into (ADR-0122 split): the
+    /// supervised-fleet table plus the content-addressed artifact store.
+    type State = EngineServerState;
+    type Config = EngineConfig;
+    const NAMESPACE: &'static str = "aether.engine";
 
-    /// Engines capability: supervises a fleet of [`EngineProxy`]
-    /// actors, one per spawned substrate. Singleton at `aether.engine`.
-    pub struct EngineServer {
-        engines: HashMap<EngineId, EngineEntry>,
-        /// Monotonic source of `EngineId`s. Engine ids only need to be
-        /// unique among the engines this cap currently supervises — a
-        /// process-local counter delivers that without a `uuid` rng
-        /// dependency. Starts at 1 (`Uuid::from_u128(0)` is the nil
-        /// uuid).
-        next_engine_seq: u128,
-        /// Cached so `on_route` can push a `ForwardEnvelope` at a proxy
-        /// while *propagating the inbound reply-to* — `NativeCtx`'s
-        /// sends stamp the cap as sender, but a routed call's reply
-        /// must reach the originating `RpcServerCapability`, not here.
-        mailer: Arc<Mailer>,
-        /// Liveness-heartbeat tuning each spawned proxy is armed with
-        /// (issue 1339), resolved once from [`EngineConfig`] at init.
-        /// `None` disables the heartbeat fleet-wide.
-        heartbeat: Option<HeartbeatParams>,
-        /// Startup-dial connect budget each spawned proxy is armed with
-        /// (issue 2072), resolved once from [`EngineConfig`] at init.
-        /// `Some(d)` caps the retry; `None` is the wait-forever sentinel.
-        connect_budget: Option<Duration>,
-        /// Bounded ring of the last [`RECENTLY_DIED_CAP`] engines that
-        /// left the table and why (issue 1906). `on_terminate` /
-        /// `on_engine_died` push a [`DeadRecord`] at the removal site;
-        /// `on_list` renders it into the reply's `recently_died` sidecar
-        /// so an observer can tell a clean terminate from a crash or a
-        /// heartbeat eviction.
-        recently_died: VecDeque<DeadRecord>,
-        /// Hub-scoped content-addressed binary store (ADR-0115, issue
-        /// 1953) — the storage half of the artifact registry.
-        /// `on_upload_binary` ingests a staged binary content-addressed;
-        /// `on_list_engine_binaries` enumerates the stored entries. Built from
-        /// `EngineConfig` (the layout dir + disk budget) at init so it
-        /// persists across a `restart-hub` (the layout root outlives the
-        /// hub child); the spawn cutover (#1954) reads it back through the
-        /// store's `get` seam.
-        store: ArtifactStore,
-    }
-
-    #[actor]
-    impl NativeActor for EngineServer {
-        type Config = EngineConfig;
-        const NAMESPACE: &'static str = "aether.engine";
-
-        fn init(config: EngineConfig, ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            // Build the hub-scoped store from `EngineConfig` (ADR-0090): the
-            // layout-dir override + disk budget ride config fields (their
-            // `AETHER_BINARY_*` env keys are the config env layer), then
-            // bootstrap-ingest the chassis bins in `binary_bootstrap` so
-            // `default` / `name` resolve in a fresh or `restart-hub`'d hub
-            // (ADR-0115, #1954). An unset store dir falls back to the
-            // computed default; a set one gets the layout-version dir joined
-            // (matching the prior `AETHER_BINARY_STORE_DIR` reader).
-            let store_dir = config
-                .binary_store_dir
-                .as_deref()
-                .filter(|d| !d.is_empty())
-                .map_or_else(ArtifactStore::default_root, |dir| {
-                    PathBuf::from(dir).join(LAYOUT_VERSION_DIR)
-                });
-            let mut store = ArtifactStore::open(&store_dir, config.binary_disk_budget_bytes);
-            bootstrap_ingest(&mut store, &config.binary_bootstrap);
-            Ok(Self {
-                engines: HashMap::new(),
-                next_engine_seq: 1,
-                mailer: ctx.mailer(),
-                heartbeat: config.heartbeat_params(),
-                connect_budget: config.connect_budget(),
-                recently_died: VecDeque::new(),
-                store,
-            })
-        }
-
-        /// Push a [`DeadRecord`] onto the recently-died ring, evicting the
-        /// oldest entry once the ring is full (issue 1906).
-        fn record_death(&mut self, engine_id: String, rpc_port: u16, reason: DeathReason) {
-            if self.recently_died.len() >= RECENTLY_DIED_CAP {
-                self.recently_died.pop_front();
-            }
-            self.recently_died.push_back(DeadRecord {
-                engine_id,
-                rpc_port,
-                reason,
-                died_at: Instant::now(),
+    fn init(
+        config: EngineConfig,
+        ctx: &mut NativeInitCtx<'_>,
+    ) -> Result<EngineServerState, BootError> {
+        // Build the hub-scoped store from `EngineConfig` (ADR-0090): the
+        // layout-dir override + disk budget ride config fields (their
+        // `AETHER_BINARY_*` env keys are the config env layer), then
+        // bootstrap-ingest the chassis bins in `binary_bootstrap` so
+        // `default` / `name` resolve in a fresh or `restart-hub`'d hub
+        // (ADR-0115, #1954). An unset store dir falls back to the
+        // computed default; a set one gets the layout-version dir joined
+        // (matching the prior `AETHER_BINARY_STORE_DIR` reader).
+        let store_dir = config
+            .binary_store_dir
+            .as_deref()
+            .filter(|d| !d.is_empty())
+            .map_or_else(ArtifactStore::default_root, |dir| {
+                PathBuf::from(dir).join(LAYOUT_VERSION_DIR)
             });
-        }
+        let mut store = ArtifactStore::open(&store_dir, config.binary_disk_budget_bytes);
+        bootstrap_ingest(&mut store, &config.binary_bootstrap);
+        Ok(EngineServerState {
+            engines: HashMap::new(),
+            next_engine_seq: 1,
+            mailer: ctx.mailer(),
+            heartbeat: config.heartbeat_params(),
+            connect_budget: config.connect_budget(),
+            recently_died: VecDeque::new(),
+            store,
+        })
+    }
 
-        /// Enumerate every engine the cap currently supervises.
-        ///
-        /// # Agent
-        /// Send `ListEngines` (fieldless). Reply: `ListEnginesResult
-        /// { engines: [{ engine_id, rpc_port, last_heartbeat_age_millis }],
-        /// recently_died: [{ engine_id, rpc_port, reason, died_age_millis }] }`.
-        #[handler]
-        fn on_list(&mut self, _ctx: &mut NativeCtx<'_>, _mail: ListEngines) -> ListEnginesResult {
-            let now = Instant::now();
-            let engines = self
-                .engines
-                .iter()
-                .map(|(id, entry)| EngineDescriptor {
-                    engine_id: id.0.to_string(),
-                    rpc_port: entry.rpc_port,
-                    last_heartbeat_age_millis: u64::try_from(
-                        now.saturating_duration_since(entry.last_alive).as_millis(),
-                    )
-                    .unwrap_or(u64::MAX),
-                })
-                .collect();
-            let recently_died = self
-                .recently_died
-                .iter()
-                .map(|record| DeadEngineDescriptor {
-                    engine_id: record.engine_id.clone(),
-                    rpc_port: record.rpc_port,
-                    reason: record.reason.clone(),
-                    died_age_millis: u64::try_from(
-                        now.saturating_duration_since(record.died_at).as_millis(),
-                    )
-                    .unwrap_or(u64::MAX),
-                })
-                .collect();
-            ListEnginesResult {
-                engines,
-                recently_died,
-            }
-        }
-
-        /// Fork+exec a substrate binary and connect a proxy to it.
-        ///
-        /// # Agent
-        /// Send `SpawnEngine { selector, args, boot_manifest }`. The cap
-        /// resolves `selector` against its content-addressed binary store
-        /// (ADR-0115), materializes the resolved bytes to an executable
-        /// temp file, assigns a free localhost port for the substrate's
-        /// RPC server, injects it as `AETHER_RPC_PORT`, forks the realized
-        /// binary, then boots an `aether.engine.proxy:<id>` actor that
-        /// dials it. Reply: `SpawnEngineResult::Ok { engine_id, rpc_port }`
-        /// on success, or `Err { error }` if the selector resolves to no
-        /// stored binary, the fork fails, or the substrate never comes up.
-        #[handler]
-        fn on_spawn(&mut self, ctx: &mut NativeCtx<'_>, mail: SpawnEngine) -> SpawnEngineResult {
-            // Resolve the registry selector to stored content bytes before
-            // any side effect, so a miss returns without reserving a port
-            // or burning an engine id (ADR-0115, #1954).
-            let Some(artifact) = resolve_selector(&mut self.store, &mail.selector) else {
-                return SpawnEngineResult::Err {
-                    error: format!(
-                        "no binary in the registry matched selector {:?}",
-                        mail.selector
-                    ),
-                };
-            };
-
-            let rpc_port = match free_local_port() {
-                Ok(port) => port,
-                Err(e) => {
-                    return SpawnEngineResult::Err {
-                        error: format!("could not allocate an RPC port: {e}"),
-                    };
-                }
-            };
-
-            // Allocate a unique scratch subdirectory per spawned engine to
-            // hold its materialized executable.
-            let engine_id = EngineId(Uuid::from_u128(self.next_engine_seq));
-            self.next_engine_seq += 1;
-            let engine_store_dir = engine_store_root().join(engine_id.0.simple().to_string());
-
-            // Stored bytes are content-addressed and not directly
-            // fork-exec'able, so materialize the resolved entry to an
-            // executable temp file under this engine's scratch dir and fork
-            // that (ADR-0115 §Execution); the caller never sees the path.
-            let exec_path = engine_store_dir.join("substrate");
-            if let Err(e) = realize_executable(&artifact.path, &exec_path) {
-                return SpawnEngineResult::Err {
-                    error: format!(
-                        "materializing binary {} to {}: {e}",
-                        artifact.hash,
-                        exec_path.display()
-                    ),
-                };
-            }
-
-            let mut command = Command::new(&exec_path);
-            command
-                .args(&mail.args)
-                .env("AETHER_RPC_PORT", rpc_port.to_string())
-                .stdin(Stdio::null());
-            // A spawn carrying a component list rides in as a boot-manifest
-            // path; inject it the same way as the RPC port so the spawned
-            // chassis reads the listed wasm itself and comes up with those
-            // components already loading (issue 1776).
-            if let Some(boot_manifest) = &mail.boot_manifest {
-                command.env("AETHER_BOOT_MANIFEST", boot_manifest);
-            }
-            let child = match command.spawn() {
-                Ok(child) => child,
-                Err(e) => {
-                    return SpawnEngineResult::Err {
-                        error: format!("failed to spawn {}: {e}", exec_path.display()),
-                    };
-                }
-            };
-
-            let subname = engine_id.0.simple().to_string();
-            let rpc_addr = format!("127.0.0.1:{rpc_port}");
-
-            // `finish()` runs `EngineProxy::init` on this thread: it
-            // dials the substrate (retrying while it comes up) and, on
-            // failure, kills the child it was handed — so a failed
-            // spawn never leaves an orphan for the cap to clean up.
-            let result = ctx
-                .spawn_child::<EngineProxy>(
-                    Subname::Named(&subname),
-                    EngineProxyConfig {
-                        engine_id,
-                        rpc_addr,
-                        spawned: Some(child),
-                        heartbeat: self.heartbeat,
-                        connect_budget: self.connect_budget,
-                    },
+    /// Enumerate every engine the cap currently supervises.
+    ///
+    /// # Agent
+    /// Send `ListEngines` (fieldless). Reply: `ListEnginesResult
+    /// { engines: [{ engine_id, rpc_port, last_heartbeat_age_millis }],
+    /// recently_died: [{ engine_id, rpc_port, reason, died_age_millis }] }`.
+    #[handler]
+    fn on_list(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        _mail: ListEngines,
+    ) -> ListEnginesResult {
+        let now = Instant::now();
+        let engines = state
+            .engines
+            .iter()
+            .map(|(id, entry)| EngineDescriptor {
+                engine_id: id.0.to_string(),
+                rpc_port: entry.rpc_port,
+                last_heartbeat_age_millis: u64::try_from(
+                    now.saturating_duration_since(entry.last_alive).as_millis(),
                 )
-                .finish();
-
-            match result {
-                Ok(proxy_mailbox) => {
-                    self.engines.insert(
-                        engine_id,
-                        EngineEntry {
-                            proxy_mailbox,
-                            rpc_port,
-                            // Just connected = alive; the heartbeat
-                            // refreshes this on each confirmed Pong.
-                            last_alive: Instant::now(),
-                        },
-                    );
-                    SpawnEngineResult::Ok {
-                        engine_id: engine_id.0.to_string(),
-                        rpc_port,
-                    }
-                }
-                Err(e) => SpawnEngineResult::Err {
-                    error: format!("proxy failed to connect to the spawned substrate: {e:?}"),
-                },
-            }
+                .unwrap_or(u64::MAX),
+            })
+            .collect();
+        let recently_died = state
+            .recently_died
+            .iter()
+            .map(|record| DeadEngineDescriptor {
+                engine_id: record.engine_id.clone(),
+                rpc_port: record.rpc_port,
+                reason: record.reason.clone(),
+                died_age_millis: u64::try_from(
+                    now.saturating_duration_since(record.died_at).as_millis(),
+                )
+                .unwrap_or(u64::MAX),
+            })
+            .collect();
+        ListEnginesResult {
+            engines,
+            recently_died,
         }
+    }
 
-        /// Terminate a supervised engine.
-        ///
-        /// # Agent
-        /// Send `TerminateEngine { engine_id }` (the string from a
-        /// prior `SpawnEngineResult` / `ListEnginesResult`). The cap
-        /// forwards the kind to the engine's proxy — which SIGKILLs
-        /// its substrate and self-shuts-down — and drops its table
-        /// entry. Reply: `TerminateEngineResult::Ok`, or `Err { error }`
-        /// for an `engine_id` that doesn't parse or names no
-        /// supervised engine.
-        #[handler]
-        fn on_terminate(
-            &mut self,
-            ctx: &mut NativeCtx<'_>,
-            mail: TerminateEngine,
-        ) -> TerminateEngineResult {
-            let engine_id = match Uuid::parse_str(&mail.engine_id) {
-                Ok(uuid) => EngineId(uuid),
-                Err(e) => {
-                    return TerminateEngineResult::Err {
-                        error: format!("engine_id {:?} is not a valid UUID: {e}", mail.engine_id),
-                    };
-                }
+    /// Fork+exec a substrate binary and connect a proxy to it.
+    ///
+    /// # Agent
+    /// Send `SpawnEngine { selector, args, boot_manifest }`. The cap
+    /// resolves `selector` against its content-addressed binary store
+    /// (ADR-0115), materializes the resolved bytes to an executable
+    /// temp file, assigns a free localhost port for the substrate's
+    /// RPC server, injects it as `AETHER_RPC_PORT`, forks the realized
+    /// binary, then boots an `aether.engine.proxy:<id>` actor that
+    /// dials it. Reply: `SpawnEngineResult::Ok { engine_id, rpc_port }`
+    /// on success, or `Err { error }` if the selector resolves to no
+    /// stored binary, the fork fails, or the substrate never comes up.
+    #[handler]
+    fn on_spawn(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        mail: SpawnEngine,
+    ) -> SpawnEngineResult {
+        // Resolve the registry selector to stored content bytes before
+        // any side effect, so a miss returns without reserving a port
+        // or burning an engine id (ADR-0115, #1954).
+        let Some(artifact) = resolve_selector(&mut state.store, &mail.selector) else {
+            return SpawnEngineResult::Err {
+                error: format!(
+                    "no binary in the registry matched selector {:?}",
+                    mail.selector
+                ),
             };
+        };
 
-            let Some(entry) = self.engines.remove(&engine_id) else {
-                return TerminateEngineResult::Err {
-                    error: format!("no supervised engine {}", mail.engine_id),
+        let rpc_port = match free_local_port() {
+            Ok(port) => port,
+            Err(e) => {
+                return SpawnEngineResult::Err {
+                    error: format!("could not allocate an RPC port: {e}"),
                 };
+            }
+        };
+
+        // Allocate a unique scratch subdirectory per spawned engine to
+        // hold its materialized executable.
+        let engine_id = EngineId(Uuid::from_u128(state.next_engine_seq));
+        state.next_engine_seq += 1;
+        let engine_store_dir = engine_store_root().join(engine_id.0.simple().to_string());
+
+        // Stored bytes are content-addressed and not directly
+        // fork-exec'able, so materialize the resolved entry to an
+        // executable temp file under this engine's scratch dir and fork
+        // that (ADR-0115 §Execution); the caller never sees the path.
+        let exec_path = engine_store_dir.join("substrate");
+        if let Err(e) = realize_executable(&artifact.path, &exec_path) {
+            return SpawnEngineResult::Err {
+                error: format!(
+                    "materializing binary {} to {}: {e}",
+                    artifact.hash,
+                    exec_path.display()
+                ),
             };
-
-            // Record the deliberate shutdown in the recently-died ring so
-            // `list_engines` can show it left cleanly (issue 1906). The
-            // proxy deliberately does not `report_died` for a terminate —
-            // the cap initiated it — so there is no second signal to
-            // reconcile and this is the one record for this death.
-            let proxy_mailbox = entry.proxy_mailbox;
-            self.record_death(
-                mail.engine_id.clone(),
-                entry.rpc_port,
-                DeathReason::Terminated,
-            );
-
-            // Forward to the proxy: it SIGKILLs its substrate and
-            // self-shuts-down. Fire-and-forget — the proxy doesn't
-            // reply, and the table entry is already gone, so the
-            // returned MailId has nothing to subscribe against.
-            let payload = mail.encode_into_bytes();
-            let _ =
-                ctx.send_envelope_traced(proxy_mailbox, <TerminateEngine as Kind>::ID, &payload);
-            TerminateEngineResult::Ok
         }
 
-        /// Relay one mail to a specific engine's substrate.
-        ///
-        /// # Agent
-        /// Not a user-facing tool — the hub's `RpcServerCapability`
-        /// sends this when an RPC client addresses a `Call` at
-        /// `engine = Some(_)`. The cap looks the engine up in its
-        /// table and re-emits a `ForwardEnvelope` at the matching
-        /// `aether.engine.proxy:<id>`, propagating the inbound
-        /// reply-to verbatim so the substrate's reply (and the proxy's
-        /// terminal `CallSettled`) stream straight back to that
-        /// `RpcServerCapability`. An unknown / unparseable `engine_id`
-        /// is answered with `CallSettled::Err` so the originating wire
-        /// call closes instead of hanging.
-        #[handler]
-        fn on_route(&mut self, ctx: &mut NativeCtx<'_>, mail: RouteEnvelope) {
-            let reply_to = ctx.reply_target();
-            let SourceAddr::Component(reply_target) = reply_to.addr else {
-                // A routed call always carries a Component reply-to
-                // (the originating RpcServerCapability). Without one
-                // there's nowhere to stream the reply or the
-                // CallSettled — drop rather than guess.
-                tracing::warn!(
-                    target: "aether_substrate::engine_server",
-                    engine_id = %mail.engine_id,
-                    "engine route: no Component reply-to; dropping",
-                );
-                return;
-            };
-            let correlation = reply_to.correlation_id;
+        let mut command = Command::new(&exec_path);
+        command
+            .args(&mail.args)
+            .env("AETHER_RPC_PORT", rpc_port.to_string())
+            .stdin(Stdio::null());
+        // A spawn carrying a component list rides in as a boot-manifest
+        // path; inject it the same way as the RPC port so the spawned
+        // chassis reads the listed wasm itself and comes up with those
+        // components already loading (issue 1776).
+        if let Some(boot_manifest) = &mail.boot_manifest {
+            command.env("AETHER_BOOT_MANIFEST", boot_manifest);
+        }
+        let child = match command.spawn() {
+            Ok(child) => child,
+            Err(e) => {
+                return SpawnEngineResult::Err {
+                    error: format!("failed to spawn {}: {e}", exec_path.display()),
+                };
+            }
+        };
 
-            let engine_id = match Uuid::parse_str(&mail.engine_id) {
-                Ok(uuid) => EngineId(uuid),
-                Err(e) => {
-                    settle_err(
-                        &self.mailer,
-                        reply_target,
-                        correlation,
-                        format!("engine_id {:?} is not a valid UUID: {e}", mail.engine_id),
-                    );
-                    return;
+        let subname = engine_id.0.simple().to_string();
+        let rpc_addr = format!("127.0.0.1:{rpc_port}");
+
+        // `finish()` runs `EngineProxy::init` on this thread: it
+        // dials the substrate (retrying while it comes up) and, on
+        // failure, kills the child it was handed — so a failed
+        // spawn never leaves an orphan for the cap to clean up.
+        let result = ctx
+            .spawn_child::<EngineProxy>(
+                Subname::Named(&subname),
+                EngineProxyConfig {
+                    engine_id,
+                    rpc_addr,
+                    spawned: Some(child),
+                    heartbeat: state.heartbeat,
+                    connect_budget: state.connect_budget,
+                },
+            )
+            .finish();
+
+        match result {
+            Ok(proxy_mailbox) => {
+                state.engines.insert(
+                    engine_id,
+                    EngineEntry {
+                        proxy_mailbox,
+                        rpc_port,
+                        // Just connected = alive; the heartbeat
+                        // refreshes this on each confirmed Pong.
+                        last_alive: Instant::now(),
+                    },
+                );
+                SpawnEngineResult::Ok {
+                    engine_id: engine_id.0.to_string(),
+                    rpc_port,
                 }
+            }
+            Err(e) => SpawnEngineResult::Err {
+                error: format!("proxy failed to connect to the spawned substrate: {e:?}"),
+            },
+        }
+    }
+
+    /// Terminate a supervised engine.
+    ///
+    /// # Agent
+    /// Send `TerminateEngine { engine_id }` (the string from a
+    /// prior `SpawnEngineResult` / `ListEnginesResult`). The cap
+    /// forwards the kind to the engine's proxy — which SIGKILLs
+    /// its substrate and self-shuts-down — and drops its table
+    /// entry. Reply: `TerminateEngineResult::Ok`, or `Err { error }`
+    /// for an `engine_id` that doesn't parse or names no
+    /// supervised engine.
+    #[handler]
+    fn on_terminate(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        mail: TerminateEngine,
+    ) -> TerminateEngineResult {
+        let engine_id = match Uuid::parse_str(&mail.engine_id) {
+            Ok(uuid) => EngineId(uuid),
+            Err(e) => {
+                return TerminateEngineResult::Err {
+                    error: format!("engine_id {:?} is not a valid UUID: {e}", mail.engine_id),
+                };
+            }
+        };
+
+        let Some(entry) = state.engines.remove(&engine_id) else {
+            return TerminateEngineResult::Err {
+                error: format!("no supervised engine {}", mail.engine_id),
             };
-            let Some(entry) = self.engines.get(&engine_id) else {
+        };
+
+        // Record the deliberate shutdown in the recently-died ring so
+        // `list_engines` can show it left cleanly (issue 1906). The
+        // proxy deliberately does not `report_died` for a terminate —
+        // the cap initiated it — so there is no second signal to
+        // reconcile and this is the one record for this death.
+        let proxy_mailbox = entry.proxy_mailbox;
+        state.record_death(
+            mail.engine_id.clone(),
+            entry.rpc_port,
+            DeathReason::Terminated,
+        );
+
+        // Forward to the proxy: it SIGKILLs its substrate and
+        // self-shuts-down. Fire-and-forget — the proxy doesn't
+        // reply, and the table entry is already gone, so the
+        // returned MailId has nothing to subscribe against.
+        let payload = mail.encode_into_bytes();
+        let _ = ctx.send_envelope_traced(proxy_mailbox, <TerminateEngine as Kind>::ID, &payload);
+        TerminateEngineResult::Ok
+    }
+
+    /// Relay one mail to a specific engine's substrate.
+    ///
+    /// # Agent
+    /// Not a user-facing tool — the hub's `RpcServerCapability`
+    /// sends this when an RPC client addresses a `Call` at
+    /// `engine = Some(_)`. The cap looks the engine up in its
+    /// table and re-emits a `ForwardEnvelope` at the matching
+    /// `aether.engine.proxy:<id>`, propagating the inbound
+    /// reply-to verbatim so the substrate's reply (and the proxy's
+    /// terminal `CallSettled`) stream straight back to that
+    /// `RpcServerCapability`. An unknown / unparseable `engine_id`
+    /// is answered with `CallSettled::Err` so the originating wire
+    /// call closes instead of hanging.
+    #[handler]
+    fn on_route(state: &mut Self::State, ctx: &mut NativeCtx<'_>, mail: RouteEnvelope) {
+        let reply_to = ctx.reply_target();
+        let SourceAddr::Component(reply_target) = reply_to.addr else {
+            // A routed call always carries a Component reply-to
+            // (the originating RpcServerCapability). Without one
+            // there's nowhere to stream the reply or the
+            // CallSettled — drop rather than guess.
+            tracing::warn!(
+                target: "aether_substrate::engine_server",
+                engine_id = %mail.engine_id,
+                "engine route: no Component reply-to; dropping",
+            );
+            return;
+        };
+        let correlation = reply_to.correlation_id;
+
+        let engine_id = match Uuid::parse_str(&mail.engine_id) {
+            Ok(uuid) => EngineId(uuid),
+            Err(e) => {
                 settle_err(
-                    &self.mailer,
+                    &state.mailer,
                     reply_target,
                     correlation,
-                    format!("no supervised engine {}", mail.engine_id),
+                    format!("engine_id {:?} is not a valid UUID: {e}", mail.engine_id),
                 );
                 return;
-            };
-
-            // Re-emit as a ForwardEnvelope at the proxy, carrying the
-            // inbound reply-to verbatim so the substrate's reply — and
-            // the proxy's CallSettled — route straight back to the
-            // originating RpcServerCapability.
-            let forward = ForwardEnvelope {
-                mailbox: mail.mailbox,
-                kind: mail.kind,
-                payload: mail.payload,
-            };
-            self.mailer.push(
-                Mail::new(
-                    entry.proxy_mailbox,
-                    <ForwardEnvelope as Kind>::ID,
-                    forward.encode_into_bytes(),
-                    1,
-                )
-                .with_reply_to(reply_to),
+            }
+        };
+        let Some(entry) = state.engines.get(&engine_id) else {
+            settle_err(
+                &state.mailer,
+                reply_target,
+                correlation,
+                format!("no supervised engine {}", mail.engine_id),
             );
-        }
+            return;
+        };
 
-        /// Evict a dead engine from the table (issue 1339).
-        ///
-        /// # Agent
-        /// Not a user-facing tool — a proxy sends `EngineDied` when it
-        /// observes its substrate's connection close or its liveness
-        /// heartbeat cross the miss limit. The cap drops the table entry
-        /// so `list_engines` stops reporting a corpse. Idempotent: a
-        /// `died` for an already-removed engine (e.g. one a concurrent
-        /// `terminate_substrate` already dropped) is a logged no-op, so
-        /// it can't race the terminate path.
-        #[handler]
-        fn on_engine_died(&mut self, _ctx: &mut NativeCtx<'_>, mail: EngineDied) {
-            let Ok(uuid) = Uuid::parse_str(&mail.engine_id) else {
-                tracing::warn!(
-                    target: "aether_substrate::engine_server",
-                    engine_id = %mail.engine_id,
-                    "engine died: unparseable engine_id; ignoring",
-                );
-                return;
-            };
-            if let Some(entry) = self.engines.remove(&EngineId(uuid)) {
-                tracing::info!(
-                    target: "aether_substrate::engine_server",
-                    engine_id = %mail.engine_id,
-                    reason = ?mail.reason,
-                    "engine evicted: proxy reported death",
-                );
-                // Record inside the `is_some` guard so a duplicate `died`
-                // (e.g. one a concurrent terminate already dropped) adds no
-                // second record — one record per death (issue 1339/1906).
-                let rpc_port = entry.rpc_port;
-                self.record_death(mail.engine_id, rpc_port, mail.reason);
-            }
-        }
+        // Re-emit as a ForwardEnvelope at the proxy, carrying the
+        // inbound reply-to verbatim so the substrate's reply — and
+        // the proxy's CallSettled — route straight back to the
+        // originating RpcServerCapability.
+        let forward = ForwardEnvelope {
+            mailbox: mail.mailbox,
+            kind: mail.kind,
+            payload: mail.payload,
+        };
+        state.mailer.push(
+            Mail::new(
+                entry.proxy_mailbox,
+                <ForwardEnvelope as Kind>::ID,
+                forward.encode_into_bytes(),
+                1,
+            )
+            .with_reply_to(reply_to),
+        );
+    }
 
-        /// Refresh an engine's last-seen-alive time (issue 1339).
-        ///
-        /// # Agent
-        /// Not a user-facing tool — a proxy sends `EngineAlive` each
-        /// time it confirms a heartbeat `Pong`. The cap stamps the
-        /// table entry so `list_engines` reports a fresh
-        /// `last_heartbeat_age_millis`. An `alive` for an unknown engine
-        /// (already evicted) is a silent no-op.
-        #[handler]
-        fn on_engine_alive(&mut self, _ctx: &mut NativeCtx<'_>, mail: EngineAlive) {
-            let Ok(uuid) = Uuid::parse_str(&mail.engine_id) else {
-                return;
-            };
-            if let Some(entry) = self.engines.get_mut(&EngineId(uuid)) {
-                entry.last_alive = Instant::now();
-            }
+    /// Evict a dead engine from the table (issue 1339).
+    ///
+    /// # Agent
+    /// Not a user-facing tool — a proxy sends `EngineDied` when it
+    /// observes its substrate's connection close or its liveness
+    /// heartbeat cross the miss limit. The cap drops the table entry
+    /// so `list_engines` stops reporting a corpse. Idempotent: a
+    /// `died` for an already-removed engine (e.g. one a concurrent
+    /// `terminate_substrate` already dropped) is a logged no-op, so
+    /// it can't race the terminate path.
+    #[handler]
+    fn on_engine_died(state: &mut Self::State, _ctx: &mut NativeCtx<'_>, mail: EngineDied) {
+        let Ok(uuid) = Uuid::parse_str(&mail.engine_id) else {
+            tracing::warn!(
+                target: "aether_substrate::engine_server",
+                engine_id = %mail.engine_id,
+                "engine died: unparseable engine_id; ignoring",
+            );
+            return;
+        };
+        if let Some(entry) = state.engines.remove(&EngineId(uuid)) {
+            tracing::info!(
+                target: "aether_substrate::engine_server",
+                engine_id = %mail.engine_id,
+                reason = ?mail.reason,
+                "engine evicted: proxy reported death",
+            );
+            // Record inside the `is_some` guard so a duplicate `died`
+            // (e.g. one a concurrent terminate already dropped) adds no
+            // second record — one record per death (issue 1339/1906).
+            let rpc_port = entry.rpc_port;
+            state.record_death(mail.engine_id, rpc_port, mail.reason);
         }
+    }
 
-        /// Ingest a binary into the hub's content-addressed store.
-        ///
-        /// # Agent
-        /// Send `UploadBinary { staged_path, name }`. The hub reads the
-        /// staged path itself (aether-mcp never reads the bytes — too
-        /// large for the tool channel), sha256-hashes it, dedups against
-        /// the store, forks `staged_path --describe` to capture its
-        /// `BinaryManifest`, stores both, and points `name` (when set) at
-        /// the hash. Reply: `UploadBinaryResult::Ok { hash, name }`, or
-        /// `Err { error }` for an unreadable path or a `--describe` that
-        /// failed or didn't yield a parseable manifest.
-        #[handler]
-        fn on_upload_binary(
-            &mut self,
-            _ctx: &mut NativeCtx<'_>,
-            mail: UploadBinary,
-        ) -> UploadBinaryResult {
-            match ingest_binary(&mut self.store, &mail.staged_path, mail.name.clone()) {
-                Ok(hash) => UploadBinaryResult::Ok {
-                    hash,
-                    name: mail.name,
-                },
-                Err(error) => UploadBinaryResult::Err { error },
-            }
+    /// Refresh an engine's last-seen-alive time (issue 1339).
+    ///
+    /// # Agent
+    /// Not a user-facing tool — a proxy sends `EngineAlive` each
+    /// time it confirms a heartbeat `Pong`. The cap stamps the
+    /// table entry so `list_engines` reports a fresh
+    /// `last_heartbeat_age_millis`. An `alive` for an unknown engine
+    /// (already evicted) is a silent no-op.
+    #[handler]
+    fn on_engine_alive(state: &mut Self::State, _ctx: &mut NativeCtx<'_>, mail: EngineAlive) {
+        let Ok(uuid) = Uuid::parse_str(&mail.engine_id) else {
+            return;
+        };
+        if let Some(entry) = state.engines.get_mut(&EngineId(uuid)) {
+            entry.last_alive = Instant::now();
         }
+    }
 
-        /// Enumerate the hub's stored engine binaries.
-        ///
-        /// # Agent
-        /// Send `ListEngineBinaries { chassis?, caps, target? }` (each filter
-        /// field AND-combined; an absent / empty field is no constraint).
-        /// Reply: `ListEngineBinariesResult { binaries: [{ hash, name,
-        /// manifest: { chassis, caps, git_sha, profile, target } }] }`.
-        #[handler]
-        fn on_list_engine_binaries(
-            &mut self,
-            _ctx: &mut NativeCtx<'_>,
-            mail: ListEngineBinaries,
-        ) -> ListEngineBinariesResult {
-            ListEngineBinariesResult {
-                binaries: self.store.list_binaries(&mail),
-            }
+    /// Ingest a binary into the hub's content-addressed store.
+    ///
+    /// # Agent
+    /// Send `UploadBinary { staged_path, name }`. The hub reads the
+    /// staged path itself (aether-mcp never reads the bytes — too
+    /// large for the tool channel), sha256-hashes it, dedups against
+    /// the store, forks `staged_path --describe` to capture its
+    /// `BinaryManifest`, stores both, and points `name` (when set) at
+    /// the hash. Reply: `UploadBinaryResult::Ok { hash, name }`, or
+    /// `Err { error }` for an unreadable path or a `--describe` that
+    /// failed or didn't yield a parseable manifest.
+    #[handler]
+    fn on_upload_binary(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        mail: UploadBinary,
+    ) -> UploadBinaryResult {
+        match ingest_binary(&mut state.store, &mail.staged_path, mail.name.clone()) {
+            Ok(hash) => UploadBinaryResult::Ok {
+                hash,
+                name: mail.name,
+            },
+            Err(error) => UploadBinaryResult::Err { error },
         }
+    }
 
-        /// Ingest a component wasm into the hub's content-addressed store
-        /// (ADR-0116, issue 1956).
-        ///
-        /// # Agent
-        /// Send `UploadComponent { staged_path, name }`. The hub reads the
-        /// staged path itself (aether-mcp never reads the bytes — too large
-        /// for the tool channel), sha256-hashes it, dedups against the
-        /// store, reads the manifest straight from the wasm (no execution
-        /// step), stores both, and points `name` (when set) at the hash.
-        /// Reply: `UploadComponentResult::Ok { hash, name }`, or
-        /// `Err { error }` for an unreadable path or an unparseable wasm.
-        #[handler]
-        fn on_upload_component(
-            &mut self,
-            _ctx: &mut NativeCtx<'_>,
-            mail: UploadComponent,
-        ) -> UploadComponentResult {
-            match ingest_component(&mut self.store, &mail.staged_path, mail.name.clone()) {
-                Ok(hash) => UploadComponentResult::Ok {
-                    hash,
-                    name: mail.name,
-                },
-                Err(error) => UploadComponentResult::Err { error },
-            }
+    /// Enumerate the hub's stored engine binaries.
+    ///
+    /// # Agent
+    /// Send `ListEngineBinaries { chassis?, caps, target? }` (each filter
+    /// field AND-combined; an absent / empty field is no constraint).
+    /// Reply: `ListEngineBinariesResult { binaries: [{ hash, name,
+    /// manifest: { chassis, caps, git_sha, profile, target } }] }`.
+    #[handler]
+    fn on_list_engine_binaries(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        mail: ListEngineBinaries,
+    ) -> ListEngineBinariesResult {
+        ListEngineBinariesResult {
+            binaries: state.store.list_binaries(&mail),
         }
+    }
 
-        /// Resolve a component selector to its wasm bytes + manifest.
-        ///
-        /// # Agent
-        /// Send `ResolveComponent { selector }`. aether-mcp calls this
-        /// hub-local before forwarding a `LoadComponent` to the target
-        /// substrate, so the load seam stays path-free. The selector is a
-        /// `hash` / `name` (latest) / `module@actor` exact token, or a
-        /// namespace / handled-kind attribute query (an attribute query
-        /// matching more than one component is a clean ambiguity error).
-        /// Reply: `ResolveComponentResult::Ok { hash, wasm, name, manifest,
-        /// export }`, or `Err { error }` for no match / ambiguity.
-        #[handler]
-        fn on_resolve_component(
-            &mut self,
-            _ctx: &mut NativeCtx<'_>,
-            mail: ResolveComponent,
-        ) -> ResolveComponentResult {
-            resolve_component(&mut self.store, &mail.selector)
+    /// Ingest a component wasm into the hub's content-addressed store
+    /// (ADR-0116, issue 1956).
+    ///
+    /// # Agent
+    /// Send `UploadComponent { staged_path, name }`. The hub reads the
+    /// staged path itself (aether-mcp never reads the bytes — too large
+    /// for the tool channel), sha256-hashes it, dedups against the
+    /// store, reads the manifest straight from the wasm (no execution
+    /// step), stores both, and points `name` (when set) at the hash.
+    /// Reply: `UploadComponentResult::Ok { hash, name }`, or
+    /// `Err { error }` for an unreadable path or an unparseable wasm.
+    #[handler]
+    fn on_upload_component(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        mail: UploadComponent,
+    ) -> UploadComponentResult {
+        match ingest_component(&mut state.store, &mail.staged_path, mail.name.clone()) {
+            Ok(hash) => UploadComponentResult::Ok {
+                hash,
+                name: mail.name,
+            },
+            Err(error) => UploadComponentResult::Err { error },
         }
+    }
 
-        /// Enumerate the hub's stored component binaries.
-        ///
-        /// # Agent
-        /// Send `ListComponentBinaries { namespace?, handled_kind? }` (each
-        /// filter AND-combined; an absent field is no constraint). Reply:
-        /// `ListComponentBinariesResult { components: [{ hash, name, manifest }] }`.
-        #[handler]
-        fn on_list_component_binaries(
-            &mut self,
-            _ctx: &mut NativeCtx<'_>,
-            mail: ListComponentBinaries,
-        ) -> ListComponentBinariesResult {
-            ListComponentBinariesResult {
-                components: self.store.list_components(&mail),
-            }
+    /// Resolve a component selector to its wasm bytes + manifest.
+    ///
+    /// # Agent
+    /// Send `ResolveComponent { selector }`. aether-mcp calls this
+    /// hub-local before forwarding a `LoadComponent` to the target
+    /// substrate, so the load seam stays path-free. The selector is a
+    /// `hash` / `name` (latest) / `module@actor` exact token, or a
+    /// namespace / handled-kind attribute query (an attribute query
+    /// matching more than one component is a clean ambiguity error).
+    /// Reply: `ResolveComponentResult::Ok { hash, wasm, name, manifest,
+    /// export }`, or `Err { error }` for no match / ambiguity.
+    #[handler]
+    fn on_resolve_component(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        mail: ResolveComponent,
+    ) -> ResolveComponentResult {
+        resolve_component(&mut state.store, &mail.selector)
+    }
+
+    /// Enumerate the hub's stored component binaries.
+    ///
+    /// # Agent
+    /// Send `ListComponentBinaries { namespace?, handled_kind? }` (each
+    /// filter AND-combined; an absent field is no constraint). Reply:
+    /// `ListComponentBinariesResult { components: [{ hash, name, manifest }] }`.
+    #[handler]
+    fn on_list_component_binaries(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        mail: ListComponentBinaries,
+    ) -> ListComponentBinariesResult {
+        ListComponentBinariesResult {
+            components: state.store.list_components(&mail),
         }
     }
 }
 
-// The sink's handler-signature kinds must be importable at file root
-// — the `#[bridge]` macro emits `impl HandlesKind<K>` markers as
-// siblings of the `sink` mod.
-#[cfg(test)]
-use aether_kinds::{ListEnginesResult, SpawnEngineResult, TerminateEngineResult};
+// The runtime half — the whole `aether_substrate`-typed surface (imports,
+// `EngineServerState`, the `EngineEntry` / `DeadRecord` helper types, the
+// `record_death` helper) — lives in `runtime.rs`, gated once here. The
+// `#[actor] impl` above reaches it through the `use runtime::*` glob.
+#[cfg(feature = "runtime")]
+mod runtime;
+
+// The `#[cfg(test)]` [`ReplySink`] is a field-bearing test fixture, so it
+// stays the un-split `type State = Self` shape (ADR-0122). Its substrate-typed
+// surface (`NativeActor` / `NativeCtx` / `NativeInitCtx` / `BootError`) and its
+// reply-kind handler signatures (`ListEnginesResult` / … — named by the
+// always-on `HandlesKind<K>` markers) resolve through the same
+// `feature = "runtime"` `use runtime::*` glob the `EngineServer` impl uses; a
+// `#[cfg(test)]` build is always native + runtime, so the glob is in scope.
 
 /// Reply sink: records the latest reply of each engines-cap reply
 /// kind into shared cells so a unit test can drive a handler via
 /// `mailer.push` and observe what it replied. Lives at file root (not
-/// nested in `mod tests`) so the `#[bridge]` macro's marker emission
+/// nested in `mod tests`) so the `#[actor]` macro's marker emission
 /// stays addressable.
 // `pub` (not `pub(crate)`) because it's the `NativeActor::Config` of
 // the test `ReplySink` below, and the `#[actor]` macro's trait impl is
@@ -693,52 +624,45 @@ pub struct ReplyCells {
 }
 
 #[cfg(test)]
-#[aether_actor::bridge(singleton)]
-mod sink {
-    use super::{ListEnginesResult, ReplyCells, SpawnEngineResult, TerminateEngineResult};
-    use aether_actor::actor;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
+pub struct ReplySink {
+    cells: ReplyCells,
+}
 
-    pub struct ReplySink {
-        cells: ReplyCells,
+#[cfg(test)]
+#[actor(singleton)]
+impl NativeActor for ReplySink {
+    type Config = ReplyCells;
+    const NAMESPACE: &'static str = "aether.engine.test.reply_sink";
+
+    fn init(cells: ReplyCells, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
+        Ok(Self { cells })
     }
 
-    #[actor]
-    impl NativeActor for ReplySink {
-        type Config = ReplyCells;
-        const NAMESPACE: &'static str = "aether.engine.test.reply_sink";
+    #[handler]
+    fn on_list_result(&mut self, _ctx: &mut NativeCtx<'_>, reply: ListEnginesResult) {
+        *self
+            .cells
+            .list
+            .lock()
+            .expect("test setup: list cell mutex poisoned") = Some(reply);
+    }
 
-        fn init(cells: ReplyCells, _ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            Ok(Self { cells })
-        }
+    #[handler]
+    fn on_spawn_result(&mut self, _ctx: &mut NativeCtx<'_>, reply: SpawnEngineResult) {
+        *self
+            .cells
+            .spawn
+            .lock()
+            .expect("test setup: spawn cell mutex poisoned") = Some(reply);
+    }
 
-        #[handler]
-        fn on_list_result(&mut self, _ctx: &mut NativeCtx<'_>, reply: ListEnginesResult) {
-            *self
-                .cells
-                .list
-                .lock()
-                .expect("test setup: list cell mutex poisoned") = Some(reply);
-        }
-
-        #[handler]
-        fn on_spawn_result(&mut self, _ctx: &mut NativeCtx<'_>, reply: SpawnEngineResult) {
-            *self
-                .cells
-                .spawn
-                .lock()
-                .expect("test setup: spawn cell mutex poisoned") = Some(reply);
-        }
-
-        #[handler]
-        fn on_terminate_result(&mut self, _ctx: &mut NativeCtx<'_>, reply: TerminateEngineResult) {
-            *self
-                .cells
-                .terminate
-                .lock()
-                .expect("test setup: terminate cell mutex poisoned") = Some(reply);
-        }
+    #[handler]
+    fn on_terminate_result(&mut self, _ctx: &mut NativeCtx<'_>, reply: TerminateEngineResult) {
+        *self
+            .cells
+            .terminate
+            .lock()
+            .expect("test setup: terminate cell mutex poisoned") = Some(reply);
     }
 }
 

--- a/crates/aether-capabilities/src/engine/server/runtime.rs
+++ b/crates/aether-capabilities/src/engine/server/runtime.rs
@@ -1,0 +1,133 @@
+//! The `aether.engine` engines-cap runtime half (ADR-0122 identity/runtime
+//! split). Compiled only under `feature = "runtime"` (the `mod runtime;`
+//! declaration in the parent carries the gate), so a transport-only build of
+//! the [`EngineServer`](super::EngineServer) identity never names these types
+//! nor pulls `aether_substrate`. The substrate-typed imports are gated once by
+//! this module rather than line-by-line; the `#[actor] impl` reaches the
+//! state, ctx types, artifact/fleet helpers, and result kinds through the
+//! single `use runtime::*` glob in the parent.
+
+pub use crate::engine::kinds::ForwardEnvelope;
+pub use crate::engine::proxy::{EngineProxy, EngineProxyConfig, HeartbeatParams};
+pub use crate::engine::store::{ArtifactStore, LAYOUT_VERSION_DIR};
+pub use aether_data::{EngineId, Kind, MailboxId, Uuid};
+pub use aether_kinds::{
+    DeadEngineDescriptor, DeathReason, EngineDescriptor, ListComponentBinariesResult,
+    ListEngineBinariesResult, ListEnginesResult, ResolveComponentResult, SpawnEngineResult,
+    TerminateEngineResult, UploadBinaryResult, UploadComponentResult,
+};
+pub use aether_substrate::Mail;
+pub use aether_substrate::Subname;
+pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub use aether_substrate::chassis::error::BootError;
+pub use aether_substrate::mail::SourceAddr;
+pub use aether_substrate::mail::mailer::Mailer;
+pub use std::collections::HashMap;
+pub use std::collections::VecDeque;
+pub use std::path::PathBuf;
+pub use std::process::{Command, Stdio};
+pub use std::sync::Arc;
+pub use std::time::{Duration, Instant};
+
+// The artifact-store + fleet helpers the handlers delegate to live in the
+// native-only `artifacts` / `fleet` submodules; re-export them here so the
+// parent's `use runtime::*` glob reaches them alongside the rest of the
+// runtime half.
+pub use super::artifacts::{
+    bootstrap_ingest, ingest_binary, ingest_component, realize_executable, resolve_component,
+    resolve_selector,
+};
+pub use super::fleet::{engine_store_root, free_local_port, settle_err};
+
+/// How many recently-died engines [`EngineServer`](super::EngineServer)
+/// retains for `list_engines`' `recently_died` sidecar (issue 1906). A small
+/// bound: the surface is "what just left and why", not an audit log —
+/// the oldest record is dropped once the ring is full.
+const RECENTLY_DIED_CAP: usize = 16;
+
+/// One recently-departed engine in [`EngineServerState`]'s recently-died
+/// ring (issue 1906). Cap-internal — holds the wire fields plus the
+/// `Instant` the cap removed the engine, so `on_list` can compute the
+/// `died_age_millis` it reports in a [`DeadEngineDescriptor`].
+pub struct DeadRecord {
+    pub(super) engine_id: String,
+    pub(super) rpc_port: u16,
+    pub(super) reason: DeathReason,
+    pub(super) died_at: Instant,
+}
+
+/// One supervised engine in [`EngineServerState`]'s table.
+pub struct EngineEntry {
+    /// Mailbox of the `aether.engine.proxy:<id>` actor — the
+    /// forward target for `TerminateEngine`.
+    pub(super) proxy_mailbox: MailboxId,
+    /// The localhost RPC port the cap assigned this substrate.
+    pub(super) rpc_port: u16,
+    /// When the cap last saw this engine alive (issue 1339): set at
+    /// spawn (just-connected = alive) and refreshed on each
+    /// `EngineAlive` the proxy reports from a confirmed `Pong`.
+    /// `on_list` reports `now - last_alive` as the heartbeat age.
+    pub(super) last_alive: Instant,
+}
+
+/// `aether.engine` runtime state (ADR-0122 split): supervises a fleet of
+/// [`EngineProxy`] actors, one per spawned substrate. The addressing identity
+/// is the distinct ZST [`EngineServer`](super::EngineServer); the dispatcher
+/// holds this as the cap's state and routes envelopes through the
+/// macro-emitted `Dispatch` impl. Living in this private module keeps it
+/// `pub`-enough to satisfy the `NativeActor::State` interface without exposing
+/// it as crate-public API.
+pub struct EngineServerState {
+    pub(super) engines: HashMap<EngineId, EngineEntry>,
+    /// Monotonic source of `EngineId`s. Engine ids only need to be
+    /// unique among the engines this cap currently supervises — a
+    /// process-local counter delivers that without a `uuid` rng
+    /// dependency. Starts at 1 (`Uuid::from_u128(0)` is the nil
+    /// uuid).
+    pub(super) next_engine_seq: u128,
+    /// Cached so `on_route` can push a `ForwardEnvelope` at a proxy
+    /// while *propagating the inbound reply-to* — `NativeCtx`'s
+    /// sends stamp the cap as sender, but a routed call's reply
+    /// must reach the originating `RpcServerCapability`, not here.
+    pub(super) mailer: Arc<Mailer>,
+    /// Liveness-heartbeat tuning each spawned proxy is armed with
+    /// (issue 1339), resolved once from `EngineConfig` at init.
+    /// `None` disables the heartbeat fleet-wide.
+    pub(super) heartbeat: Option<HeartbeatParams>,
+    /// Startup-dial connect budget each spawned proxy is armed with
+    /// (issue 2072), resolved once from `EngineConfig` at init.
+    /// `Some(d)` caps the retry; `None` is the wait-forever sentinel.
+    pub(super) connect_budget: Option<Duration>,
+    /// Bounded ring of the last [`RECENTLY_DIED_CAP`] engines that
+    /// left the table and why (issue 1906). `on_terminate` /
+    /// `on_engine_died` push a [`DeadRecord`] at the removal site;
+    /// `on_list` renders it into the reply's `recently_died` sidecar
+    /// so an observer can tell a clean terminate from a crash or a
+    /// heartbeat eviction.
+    pub(super) recently_died: VecDeque<DeadRecord>,
+    /// Hub-scoped content-addressed binary store (ADR-0115, issue
+    /// 1953) — the storage half of the artifact registry.
+    /// `on_upload_binary` ingests a staged binary content-addressed;
+    /// `on_list_engine_binaries` enumerates the stored entries. Built from
+    /// `EngineConfig` (the layout dir + disk budget) at init so it
+    /// persists across a `restart-hub` (the layout root outlives the
+    /// hub child); the spawn cutover (#1954) reads it back through the
+    /// store's `get` seam.
+    pub(super) store: ArtifactStore,
+}
+
+impl EngineServerState {
+    /// Push a [`DeadRecord`] onto the recently-died ring, evicting the
+    /// oldest entry once the ring is full (issue 1906).
+    pub(super) fn record_death(&mut self, engine_id: String, rpc_port: u16, reason: DeathReason) {
+        if self.recently_died.len() >= RECENTLY_DIED_CAP {
+            self.recently_died.pop_front();
+        }
+        self.recently_died.push_back(DeadRecord {
+            engine_id,
+            rpc_port,
+            reason,
+            died_at: Instant::now(),
+        });
+    }
+}


### PR DESCRIPTION
Closes #2321.

## Summary

Migrates the `engine/` caps off `#[bridge]` onto the ADR-0122 identity/runtime split: `EngineServer` (singleton) and `EngineProxy` (instanced, `one_per = "engine"`) become ZST identities + top-level `#[actor(<cardinality>)] impl NativeActor` with handlers over `state: &mut Self::State` and their substrate-typed half (incl. `EngineProxy`'s `impl Drop` SIGKILL-on-drop + heartbeat-thread join, which ride `EngineProxyState`) in per-cap `runtime.rs` files reached via `use runtime::*`. The three `#[cfg(test)]` sinks (`ReplySink` / `EngineCapSink` / `ProxyReplySink`) de-bridge to `#[actor(singleton)]` keeping `type State = Self` (the test-fixture exception). Uses the #2330 `one_per` split-path support; the name inventory still reports `OnePer("engine")`.

The runtime-only crate-private helpers (`connect_proxy` / `spawn_heartbeat` / the `artifacts` + `fleet` fns) live in the `runtime` submodules, so no runtime imports are gated at module scope.

## Test plan

- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo nextest run -p aether-capabilities` (248 passed incl. the engine round-trip / heartbeat / spawn / list suite), strict `cargo doc`, transport-only build — all green.
- Validated via `scripts/attest.sh --publish`.

## Generated by

`/implement --sweep --attest` — agent execution of scoped issue #2321.
