### PR TITLE
refactor(capabilities): split the render caps into identity and runtime modules

### DIFF
--- a/crates/aether-capabilities/src/render/headless_runtime.rs
+++ b/crates/aether-capabilities/src/render/headless_runtime.rs
@@ -1,0 +1,31 @@
+//! The `HeadlessRenderCapability` runtime half (ADR-0122 identity/runtime
+//! split). Compiled under the default `feature = "runtime"` gate (the
+//! `mod headless_runtime;` declaration in the parent carries it) — unlike
+//! the GPU-bound [`super::RenderCapability`], the headless companion has no
+//! `render-native` dep, so its runtime half must compile on a no-GPU
+//! headless `runtime` build. The substrate-typed imports are gated once by
+//! this module; the `#[actor] impl` reaches the state + ctx types through
+//! the single `use headless_runtime::*` glob in the parent.
+
+// `io` is named by the parent's `init` body (`io::Error::other`); `Arc` and
+// `HubOutbound` only by the state struct's field. The substrate ctx types
+// the `#[actor] impl` names (`NativeActor` / `NativeCtx` / `NativeInitCtx` /
+// `BootError` / `Manual` / `CaptureFrameResult`) come from the shared
+// `any(render-native, runtime)` seam in `mod.rs`, not from here, so a
+// desktop build doesn't re-export them through two globs.
+pub use std::io;
+
+use std::sync::Arc;
+
+use aether_substrate::mail::outbound::HubOutbound;
+
+/// `HeadlessRenderCapability` runtime state. Holds only the [`HubOutbound`]
+/// captured at init — the headless cap replies `Err` to the GPU-bound
+/// kinds (`CaptureFrame` / `CreateTexture`) and no-ops the accumulator
+/// kinds, so it needs no handles. The addressing identity is the distinct
+/// ZST [`super::HeadlessRenderCapability`]. Living in this private module
+/// keeps it `pub`-enough to satisfy the `NativeActor::State` interface
+/// without exposing it as crate-public API.
+pub struct HeadlessRenderCapabilityState {
+    pub(super) outbound: Arc<HubOutbound>,
+}

--- a/crates/aether-capabilities/src/render/mod.rs
+++ b/crates/aether-capabilities/src/render/mod.rs
@@ -8,11 +8,11 @@
 //!
 //! Driver-side state (wgpu device, queue, pipeline, offscreen
 //! targets, accumulator buffers) lives on [`RenderHandles`] in the
-//! `pipeline` submodule. The driver fetches the booted cap via
-//! `DriverCtx::actor::<RenderCapability>()` and clones `.handles()`
-//! from there. Phase 4 keeps the GPU lifecycle, encoder creation, and
-//! presentation in the chassis driver — this capability owns only the
-//! mail surface and accumulator state.
+//! `pipeline` submodule. `init` publishes the bundle on the chassis's
+//! exported-handle map (`ctx.publish_handle`), and the driver fetches it
+//! via `DriverCtx::handle::<RenderHandles>()`. Phase 4 keeps the GPU
+//! lifecycle, encoder creation, and presentation in the chassis driver —
+//! this capability owns only the mail surface and accumulator state.
 //!
 //! The cap's drawing + texture mail kinds live in [`kinds`] (ADR-0121):
 //! they ride the always-on (marker-only `render`) region so a wasm
@@ -51,9 +51,9 @@
 pub mod kinds;
 pub use kinds::*;
 
-// Native impl seams. Gated identically to the `#[bridge]`-emitted
-// `mod native` body (`not(wasm) AND render-native`) so they're present
-// exactly when that body references them.
+// Native impl seams. Gated identically to the `render` runtime half
+// (`not(wasm) AND render-native`) so they're present exactly when the
+// `runtime` module references them.
 #[cfg(all(not(target_family = "wasm"), feature = "render-native"))]
 mod capture;
 #[cfg(all(not(target_family = "wasm"), feature = "render-native"))]
@@ -64,18 +64,18 @@ mod quad;
 mod texture;
 
 // Handler-signature kinds must be importable at file root because
-// `#[bridge]` emits `impl HandlesKind<K> for X {}` markers as siblings
-// of the mod (always-on, outside the cfg gate). The drawing kinds come
-// from the local `kinds` module (via the glob re-export above);
-// `CaptureFrame` stays in `aether-kinds` (consumed by `aether-mcp`).
+// `#[actor]` emits `impl HandlesKind<K> for X {}` markers always-on
+// (outside the `render-native` gate), against the identity. The drawing
+// kinds come from the local `kinds` module (via the glob re-export
+// above); `CaptureFrame` stays in `aether-kinds` (consumed by
+// `aether-mcp`).
 use aether_kinds::CaptureFrame;
 
 // Auxiliary native-only types the chassis driver consumes alongside
-// `RenderCapability`. `#[bridge]` only re-exports the actor type
-// itself; these need explicit re-exports. Keyed on the `render-native`
-// feature so wasm components that opt into the marker-only `render`
-// feature see only the cap stub + Actor / HandlesKind impls, not
-// these heavy GPU-bound types.
+// `RenderCapability`. Keyed on the `render-native` feature so wasm
+// components that opt into the marker-only `render` feature see only the
+// identity ZST + Actor / HandlesKind impls, not these heavy GPU-bound
+// types.
 #[cfg(all(not(target_family = "wasm"), feature = "render-native"))]
 mod config;
 #[cfg(all(not(target_family = "wasm"), feature = "render-native"))]
@@ -85,302 +85,311 @@ pub use self::pipeline::{RenderGpu, RenderHandles};
 #[cfg(all(not(target_family = "wasm"), feature = "render-native"))]
 pub use config::RenderConfig;
 
-// `HeadlessRenderCapability` is exported through `#[bridge]`'s
-// auto-emitted re-export. It carries no auxiliary native-only types,
-// so nothing extra to surface here.
+// `#[actor]` / `#[handler]` stays always-on (the macro divides what it
+// emits: always-on addressing markers vs. the gated runtime impls). The
+// state-bearing, GPU-bound surface of each cap — its runtime state struct,
+// the wgpu accumulator helpers, the `HubOutbound` — lives in a per-cap
+// runtime module: `runtime` for [`RenderCapability`] (gated `render-native`
+// via the `runtime_feature` override) and `headless_runtime` for
+// [`HeadlessRenderCapability`] (gated the default `runtime`). The
+// `#[actor] impl` reaches each cap's module through its own `use …::*`
+// glob. The `aether_substrate` ctx types both impls name (`NativeActor` /
+// `NativeCtx` / … / `Manual` / `CaptureFrameResult` / `Arc`) are sourced
+// once here behind `any(render-native, runtime)` rather than re-exported
+// from both modules — a desktop build (both gates on) would otherwise pull
+// the same name through two globs and trip the unused-import lint on the
+// redundant re-export.
+use aether_actor::actor;
 
-#[aether_actor::bridge(singleton, feature = "render-native")]
-mod native {
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicU64, Ordering};
-    use std::sync::{Mutex, OnceLock};
+#[cfg(any(feature = "render-native", feature = "runtime"))]
+use {
+    aether_kinds::CaptureFrameResult,
+    aether_substrate::{
+        Manual,
+        actor::native::{NativeActor, NativeCtx, NativeInitCtx},
+        chassis::error::BootError,
+    },
+    std::sync::Arc,
+};
 
-    use aether_actor::actor;
-    use aether_data::Kind;
-    use aether_kinds::CaptureFrameResult;
-    use aether_substrate::Manual;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::capture::PendingCapture;
-    use aether_substrate::chassis::error::BootError;
-    use aether_substrate::mail::helpers::resolve_bundle;
-    use aether_substrate::mail::mailer::Mailer;
-    use aether_substrate::mail::registry::Registry;
-    use aether_substrate::render::IDENTITY_VIEW_PROJ;
+#[cfg(feature = "render-native")]
+#[allow(clippy::wildcard_imports)]
+use runtime::*;
 
-    use super::capture::resolve_reference;
-    use super::config::RenderConfig;
-    use super::pipeline::RenderHandles;
-    use super::quad::QuadBatch;
-    use super::texture::{StagedTexture, TextureRegistry, WHITE_TEXTURE_ID, expected_pixel_bytes};
-    use super::{
-        Camera, CaptureFrame, CreateTexture, CreateTextureResult, DRAW_TRIANGLE_BYTES,
-        DrawSolidQuads, DrawTexturedQuads, DrawTriangle, SolidQuad, TexturedQuad, UpdateTexture,
-    };
+#[cfg(feature = "runtime")]
+#[allow(clippy::wildcard_imports)]
+use headless_runtime::*;
 
-    /// `aether.render` mailbox cap. Holds [`RenderHandles`] (the
-    /// driver-facing accumulator state plus GPU bundle) and the
-    /// per-instance config. The dispatcher thread holds an
-    /// `Arc<Self>` and routes `aether.draw_triangle` / `aether.camera`
-    /// mail through the macro-emitted `NativeDispatch` impl. Driver
-    /// glue fetches handles via
-    /// `DriverCtx::actor::<RenderCapability>()` (post-init) and clones
-    /// the cheap Arc-shared bundle.
-    pub struct RenderCapability {
-        handles: RenderHandles,
+// The render runtime half — the wgpu-typed surface (state, ctx imports,
+// accumulator helpers) — lives in `runtime.rs`, gated once here on the
+// `render-native` override (matching the `#[actor] impl`'s runtime gate).
+#[cfg(feature = "render-native")]
+mod runtime;
+
+// The headless companion's runtime half lives in `headless_runtime.rs`,
+// gated on the default `runtime` feature so a no-GPU headless build still
+// compiles it.
+#[cfg(feature = "runtime")]
+mod headless_runtime;
+
+/// `aether.render` cap **identity** (ADR-0122 identity/runtime split). A
+/// ZST carrying only the addressing — `Addressable`, the per-handler
+/// `HandlesKind` markers, and the name-inventory entry, all emitted
+/// always-on by `#[actor]` so a wasm guest on the marker-only `render`
+/// feature can `ctx.actor::<RenderCapability>().send(&triangle)` without
+/// dragging the GPU stack. The state-bearing runtime
+/// (`RenderCapabilityState`, which holds the wgpu-typed
+/// [`RenderHandles`] plus the substrate registry + mailer) lives behind
+/// the `render-native` gate in the `runtime` module, so a transport- or
+/// marker-only build never names it nor pulls `aether_substrate`/wgpu
+/// through this cap.
+pub struct RenderCapability;
+
+#[actor(singleton, runtime_feature = "render-native")]
+impl NativeActor for RenderCapability {
+    /// The runtime state this identity boots into (ADR-0122 split): the
+    /// driver-facing accumulator handles + config + substrate handles.
+    type State = RenderCapabilityState;
+
+    type Config = RenderConfig;
+
+    /// Components mail `aether.draw_triangle` and `aether.camera`
+    /// (kind ids) to this mailbox; the GPU recorder pulls from here.
+    /// The `aether.<name>` form is the post-ADR-0074 Phase 5
+    /// convention for chassis-owned mailboxes; ADR-0074 §Decision 7
+    /// folded the camera mailbox into render under this name.
+    const NAMESPACE: &'static str = "aether.render";
+
+    /// Allocate the accumulator state up front. Idempotent on the
+    /// driver-facing side: every chassis main passes a fresh
+    /// `RenderConfig`; init only sets up the in-process buffers and
+    /// the wgpu `OnceLock` (the driver fills it in `resumed` /
+    /// post-`build_passive`).
+    ///
+    /// `last_submitted` mirrors `frame_vertices`'s capacity so the
+    /// swap inside `record_frame` (iamacoffeepot/aether#847) lands
+    /// a full-capacity buffer back into the live slot — without the
+    /// pre-allocation, the first frame's swap would leave the live
+    /// accumulator at `last_submitted`'s starting capacity (zero)
+    /// and the next tick's `on_draw_triangle` would reallocate
+    /// from scratch.
+    fn init(
         config: RenderConfig,
-        /// Substrate registry and mailer captured at init for the
-        /// `capture_frame` resolve-bundle / push-pre-mails path. Both
-        /// are Arc-shared with every other cap and the chassis loop.
-        registry: Arc<Registry>,
-        mailer: Arc<Mailer>,
+        ctx: &mut NativeInitCtx<'_>,
+    ) -> Result<RenderCapabilityState, BootError> {
+        let handles = RenderHandles {
+            frame_vertices: Arc::new(Mutex::new(Vec::<u8>::with_capacity(
+                config.vertex_buffer_bytes,
+            ))),
+            last_submitted: Arc::new(Mutex::new(Vec::<u8>::with_capacity(
+                config.vertex_buffer_bytes,
+            ))),
+            triangles_rendered: Arc::new(AtomicU64::new(0)),
+            camera_state: Arc::new(Mutex::new(IDENTITY_VIEW_PROJ)),
+            quad_frame: Arc::new(Mutex::new(Vec::new())),
+            quad_last_submitted: Arc::new(Mutex::new(Vec::new())),
+            textures: Arc::new(Mutex::new(TextureRegistry::new())),
+            gpu: Arc::new(OnceLock::new()),
+        };
+        let mailer = ctx.mailer();
+        let registry = Arc::clone(mailer.registry());
+        // Issue 629 / Phase A: publish the driver-facing handle
+        // bundle on the chassis's `ExportedHandles` map so the
+        // desktop driver retrieves it via `DriverCtx::handle::<RenderHandles>()`.
+        ctx.publish_handle(handles.clone());
+        Ok(RenderCapabilityState {
+            handles,
+            config,
+            registry,
+            mailer,
+        })
     }
 
-    impl RenderCapability {
-        /// Cheap clone of the driver-facing handles bundle. Call this on
-        /// the booted `Arc<RenderCapability>` (fetched via
-        /// `DriverCtx::actor`) — every field is Arc-shared, so the clone
-        /// is just refcount bumps.
-        #[must_use]
-        pub fn handles(&self) -> RenderHandles {
-            self.handles.clone()
+    /// `DrawTriangle` handler. Slice-typed because `Mailbox::send_many`
+    /// (ADR-0019) packs `count` triangles into one envelope — the
+    /// macro decodes the whole payload as `&[DrawTriangle]` so a
+    /// batched mesh reaches the cap intact. Truncates at the cap
+    /// boundary so a single oversized mesh degrades gracefully
+    /// instead of collapsing the whole frame downstream; rounds to
+    /// whole triangles so the GPU vertex buffer never sees a half-
+    /// triangle.
+    ///
+    /// # Agent
+    /// Components mail one or more `DrawTriangle`s (cast-shape,
+    /// `DRAW_TRIANGLE_BYTES` per triangle, batched via `send_many`)
+    /// per tick. Fire-and-forget; the cap accumulates into
+    /// `frame_vertices` until the chassis driver records the frame.
+    #[handler]
+    fn on_draw_triangle(state: &mut Self::State, _ctx: &mut NativeCtx<'_>, mails: &[DrawTriangle]) {
+        if let Some(obs) = &state.config.observed_kinds {
+            obs.lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063")
+                .push(<DrawTriangle as Kind>::NAME.into());
+        }
+        let bytes: &[u8] = bytemuck::cast_slice(mails);
+        let cap_bytes = state.config.vertex_buffer_bytes;
+        let mut verts = state
+            .handles
+            .frame_vertices
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063");
+        let available = cap_bytes.saturating_sub(verts.len());
+        let write_len = bytes.len().min(available);
+        let write_len = write_len - (write_len % DRAW_TRIANGLE_BYTES);
+        if write_len > 0 {
+            verts.extend_from_slice(&bytes[..write_len]);
+            state
+                .handles
+                .triangles_rendered
+                .fetch_add((write_len / DRAW_TRIANGLE_BYTES) as u64, Ordering::Relaxed);
+        }
+        if write_len < bytes.len() {
+            tracing::warn!(
+                target: "aether_substrate::render",
+                accepted_bytes = write_len,
+                dropped_bytes = bytes.len() - write_len,
+                cap = cap_bytes,
+                "render cap dropped triangles beyond fixed vertex buffer",
+            );
         }
     }
 
-    #[actor]
-    impl NativeActor for RenderCapability {
-        type Config = RenderConfig;
+    /// `Camera` handler. Latest-value-wins semantics: each successful
+    /// mail overwrites; the prior value is replaced wholesale.
+    /// Initialised in `init` to [`IDENTITY_VIEW_PROJ`] so the first
+    /// frame draws unchanged until a camera component starts
+    /// publishing.
+    ///
+    /// # Agent
+    /// Camera components mail `aether.camera { view_proj: [f32; 16] }`
+    /// to this mailbox. Fire-and-forget; latest value wins.
+    #[handler]
+    fn on_camera(state: &mut Self::State, _ctx: &mut NativeCtx<'_>, mail: Camera) {
+        if let Some(obs) = &state.config.observed_kinds {
+            obs.lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063")
+                .push(<Camera as Kind>::NAME.into());
+        }
+        *state
+            .handles
+            .camera_state
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063") = mail.view_proj;
+    }
 
-        /// Components mail `aether.draw_triangle` and `aether.camera`
-        /// (kind ids) to this mailbox; the GPU recorder pulls from here.
-        /// The `aether.<name>` form is the post-ADR-0074 Phase 5
-        /// convention for chassis-owned mailboxes; ADR-0074 §Decision 7
-        /// folded the camera mailbox into render under this name.
-        const NAMESPACE: &'static str = "aether.render";
-
-        /// Allocate the accumulator state up front. Idempotent on the
-        /// driver-facing side: every chassis main passes a fresh
-        /// `RenderConfig`; init only sets up the in-process buffers and
-        /// the wgpu `OnceLock` (the driver fills it in `resumed` /
-        /// post-`build_passive`).
-        ///
-        /// `last_submitted` mirrors `frame_vertices`'s capacity so the
-        /// swap inside `record_frame` (iamacoffeepot/aether#847) lands
-        /// a full-capacity buffer back into the live slot — without the
-        /// pre-allocation, the first frame's swap would leave the live
-        /// accumulator at `last_submitted`'s starting capacity (zero)
-        /// and the next tick's `on_draw_triangle` would reallocate
-        /// from scratch.
-        fn init(config: RenderConfig, ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            let handles = RenderHandles {
-                frame_vertices: Arc::new(Mutex::new(Vec::<u8>::with_capacity(
-                    config.vertex_buffer_bytes,
-                ))),
-                last_submitted: Arc::new(Mutex::new(Vec::<u8>::with_capacity(
-                    config.vertex_buffer_bytes,
-                ))),
-                triangles_rendered: Arc::new(AtomicU64::new(0)),
-                camera_state: Arc::new(Mutex::new(IDENTITY_VIEW_PROJ)),
-                quad_frame: Arc::new(Mutex::new(Vec::new())),
-                quad_last_submitted: Arc::new(Mutex::new(Vec::new())),
-                textures: Arc::new(Mutex::new(TextureRegistry::new())),
-                gpu: Arc::new(OnceLock::new()),
-            };
-            let mailer = ctx.mailer();
-            let registry = Arc::clone(mailer.registry());
-            // Issue 629 / Phase A: publish the driver-facing handle
-            // bundle on the chassis's `ExportedHandles` map so the
-            // desktop driver retrieves it via `DriverCtx::handle::<RenderHandles>()`.
-            ctx.publish_handle(handles.clone());
-            Ok(Self {
-                handles,
-                config,
-                registry,
-                mailer,
-            })
+    /// `CaptureFrame` handler. The cap dispatcher thread doesn't
+    /// own the wgpu `Device` — that lives on the chassis main
+    /// thread — so capture is a two-phase handoff: this handler
+    /// resolves the request and parks it on `CaptureBackend.queue`,
+    /// the chassis main loop takes from there on the next redraw,
+    /// performs the GPU readback, dispatches the `after_mails`
+    /// bundle, and replies to the original sender.
+    ///
+    /// Abort-on-first-failure: if either bundle has an unknown
+    /// kind / mailbox the whole request errors before any pre-mail
+    /// is pushed. Decode failure, queue full, and a dead wake
+    /// target also reply inline; only the readback path replies
+    /// from the render thread.
+    ///
+    /// # Agent
+    /// Mail `aether.render.capture_frame { mails, after_mails }`
+    /// for an atomic "set X, capture, restore X" call. Reply is
+    /// `aether.render.capture_frame_result` carrying the PNG on
+    /// success or a free-form reason on failure.
+    #[handler::manual]
+    fn on_capture_frame(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_, Manual>,
+        mail: CaptureFrame,
+    ) {
+        if let Some(obs) = &state.config.observed_kinds {
+            obs.lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063")
+                .push(<CaptureFrame as Kind>::NAME.into());
         }
 
-        /// `DrawTriangle` handler. Slice-typed because `Mailbox::send_many`
-        /// (ADR-0019) packs `count` triangles into one envelope — the
-        /// macro decodes the whole payload as `&[DrawTriangle]` so a
-        /// batched mesh reaches the cap intact. Truncates at the cap
-        /// boundary so a single oversized mesh degrades gracefully
-        /// instead of collapsing the whole frame downstream; rounds to
-        /// whole triangles so the GPU vertex buffer never sees a half-
-        /// triangle.
-        ///
-        /// # Agent
-        /// Components mail one or more `DrawTriangle`s (cast-shape,
-        /// `DRAW_TRIANGLE_BYTES` per triangle, batched via `send_many`)
-        /// per tick. Fire-and-forget; the cap accumulates into
-        /// `frame_vertices` until the chassis driver records the frame.
-        #[handler]
-        fn on_draw_triangle(&self, _ctx: &mut NativeCtx<'_>, mails: &[DrawTriangle]) {
-            if let Some(obs) = &self.config.observed_kinds {
-                obs.lock()
-                    .expect("mutex poisoned; fail-fast per ADR-0063")
-                    .push(<DrawTriangle as Kind>::NAME.into());
-            }
-            let bytes: &[u8] = bytemuck::cast_slice(mails);
-            let cap_bytes = self.config.vertex_buffer_bytes;
-            let mut verts = self
-                .handles
-                .frame_vertices
-                .lock()
-                .expect("mutex poisoned; fail-fast per ADR-0063");
-            let available = cap_bytes.saturating_sub(verts.len());
-            let write_len = bytes.len().min(available);
-            let write_len = write_len - (write_len % DRAW_TRIANGLE_BYTES);
-            if write_len > 0 {
-                verts.extend_from_slice(&bytes[..write_len]);
-                self.handles
-                    .triangles_rendered
-                    .fetch_add((write_len / DRAW_TRIANGLE_BYTES) as u64, Ordering::Relaxed);
-            }
-            if write_len < bytes.len() {
-                tracing::warn!(
-                    target: "aether_substrate::render",
-                    accepted_bytes = write_len,
-                    dropped_bytes = bytes.len() - write_len,
-                    cap = cap_bytes,
-                    "render cap dropped triangles beyond fixed vertex buffer",
-                );
-            }
-        }
+        let sender = ctx.reply_target();
+        let Some(backend) = state.config.capture_backend.as_ref() else {
+            tracing::warn!(
+                target: "aether_capabilities::render",
+                "RenderCapability received capture_frame without capture_backend; replying Err",
+            );
+            return;
+        };
 
-        /// `Camera` handler. Latest-value-wins semantics: each successful
-        /// mail overwrites; the prior value is replaced wholesale.
-        /// Initialised in `init` to [`IDENTITY_VIEW_PROJ`] so the first
-        /// frame draws unchanged until a camera component starts
-        /// publishing.
-        ///
-        /// # Agent
-        /// Camera components mail `aether.camera { view_proj: [f32; 16] }`
-        /// to this mailbox. Fire-and-forget; latest value wins.
-        #[handler]
-        fn on_camera(&self, _ctx: &mut NativeCtx<'_>, mail: Camera) {
-            if let Some(obs) = &self.config.observed_kinds {
-                obs.lock()
-                    .expect("mutex poisoned; fail-fast per ADR-0063")
-                    .push(<Camera as Kind>::NAME.into());
-            }
-            *self
-                .handles
-                .camera_state
-                .lock()
-                .expect("mutex poisoned; fail-fast per ADR-0063") = mail.view_proj;
-        }
-
-        /// `CaptureFrame` handler. The cap dispatcher thread doesn't
-        /// own the wgpu `Device` — that lives on the chassis main
-        /// thread — so capture is a two-phase handoff: this handler
-        /// resolves the request and parks it on `CaptureBackend.queue`,
-        /// the chassis main loop takes from there on the next redraw,
-        /// performs the GPU readback, dispatches the `after_mails`
-        /// bundle, and replies to the original sender.
-        ///
-        /// Abort-on-first-failure: if either bundle has an unknown
-        /// kind / mailbox the whole request errors before any pre-mail
-        /// is pushed. Decode failure, queue full, and a dead wake
-        /// target also reply inline; only the readback path replies
-        /// from the render thread.
-        ///
-        /// # Agent
-        /// Mail `aether.render.capture_frame { mails, after_mails }`
-        /// for an atomic "set X, capture, restore X" call. Reply is
-        /// `aether.render.capture_frame_result` carrying the PNG on
-        /// success or a free-form reason on failure.
-        #[handler::manual]
-        fn on_capture_frame(&self, ctx: &mut NativeCtx<'_, Manual>, mail: CaptureFrame) {
-            if let Some(obs) = &self.config.observed_kinds {
-                obs.lock()
-                    .expect("mutex poisoned; fail-fast per ADR-0063")
-                    .push(<CaptureFrame as Kind>::NAME.into());
-            }
-
-            let sender = ctx.reply_target();
-            let Some(backend) = self.config.capture_backend.as_ref() else {
-                tracing::warn!(
-                    target: "aether_capabilities::render",
-                    "RenderCapability received capture_frame without capture_backend; replying Err",
-                );
+        let pre = match resolve_bundle(&state.registry, &mail.mails, "capture bundle") {
+            Ok(v) => v,
+            Err(error) => {
+                backend
+                    .outbound
+                    .send_reply(sender, &CaptureFrameResult::Err { error });
                 return;
-            };
-
-            let pre = match resolve_bundle(&self.registry, &mail.mails, "capture bundle") {
-                Ok(v) => v,
-                Err(error) => {
-                    backend
-                        .outbound
-                        .send_reply(sender, &CaptureFrameResult::Err { error });
-                    return;
-                }
-            };
-            let after =
-                match resolve_bundle(&self.registry, &mail.after_mails, "capture after bundle") {
-                    Ok(v) => v,
-                    Err(error) => {
-                        backend
-                            .outbound
-                            .send_reply(sender, &CaptureFrameResult::Err { error });
-                        return;
-                    }
-                };
-
-            // iamacoffeepot/aether#860: dispatch each pre-mail as a
-            // fresh chassis-rooted chain via `send_envelope_as_root`
-            // and subscribe to its settlement, so the driver can wait
-            // for the full causal chain (component handler → emitted
-            // DrawTriangle → render cap accumulator) to land before
-            // `render_and_capture` runs. Without this gate the cross-
-            // thread chain races the wake-and-render path and an
-            // empty `frame_vertices` falls back to the (empty) cache
-            // → solid-background frame. Same primitive RpcServer uses
-            // for wire-borne Calls (a pre-mail is causally external
-            // from the cap's perspective — triggered by a wire-borne
-            // CaptureFrame, not forwarded from in-flight context).
-            //
-            // If the chassis didn't install a settlement registry
-            // (some test fixtures), the loop still dispatches the
-            // mails but `pre_settlements` stays empty so the driver
-            // renders immediately — preserving the pre-fix behaviour
-            // on those fixtures.
-            let settlement_registry = self.mailer.settlement_registry().cloned();
-            let mut pre_settlements = Vec::with_capacity(pre.len());
-            for envelope in pre {
-                let mail_id = ctx.send_envelope_as_root(
-                    envelope.recipient,
-                    envelope.kind,
-                    envelope.payload.bytes(),
-                );
-                if let Some(reg) = settlement_registry.as_deref() {
-                    pre_settlements.push(reg.subscribe_settlement(mail_id));
-                }
             }
+        };
+        let after = match resolve_bundle(&state.registry, &mail.after_mails, "capture after bundle")
+        {
+            Ok(v) => v,
+            Err(error) => {
+                backend
+                    .outbound
+                    .send_reply(sender, &CaptureFrameResult::Err { error });
+                return;
+            }
+        };
 
-            // ADR-0106 / iamacoffeepot/aether#1758: capture is a deferred
-            // reply — the render thread sends the reply a frame later, off
-            // this handler's dispatch window. Retain the dispatched
-            // `CaptureFrame` envelope as an `InboundMail` guard via
-            // `take_inbound`: the dispatcher's settlement tail then sees
-            // `None` and does not discharge, so the guard's un-fired
-            // `record_finished` keeps the inbound's chain open until the
-            // render thread replies through `reply.reply(&result)` and
-            // drops it (recording the reply's `Sent` before the inbound's
-            // `Finished`, ADR-0080 §6). This retires the hand-rolled
-            // `SettlementHold` + reply-id mint (#1273 / #1719). The
-            // early-return branches above reply synchronously inside this
-            // handler's own dispatch window, so they leave the inbound for
-            // the dispatcher's tail to settle and don't take the guard.
+        // iamacoffeepot/aether#860: dispatch each pre-mail as a
+        // fresh chassis-rooted chain via `send_envelope_as_root`
+        // and subscribe to its settlement, so the driver can wait
+        // for the full causal chain (component handler → emitted
+        // DrawTriangle → render cap accumulator) to land before
+        // `render_and_capture` runs. Without this gate the cross-
+        // thread chain races the wake-and-render path and an
+        // empty `frame_vertices` falls back to the (empty) cache
+        // → solid-background frame. Same primitive RpcServer uses
+        // for wire-borne Calls (a pre-mail is causally external
+        // from the cap's perspective — triggered by a wire-borne
+        // CaptureFrame, not forwarded from in-flight context).
+        //
+        // If the chassis didn't install a settlement registry
+        // (some test fixtures), the loop still dispatches the
+        // mails but `pre_settlements` stays empty so the driver
+        // renders immediately — preserving the pre-fix behaviour
+        // on those fixtures.
+        let settlement_registry = state.mailer.settlement_registry().cloned();
+        let mut pre_settlements = Vec::with_capacity(pre.len());
+        for envelope in pre {
+            let mail_id = ctx.send_envelope_as_root(
+                envelope.recipient,
+                envelope.kind,
+                envelope.payload.bytes(),
+            );
+            if let Some(reg) = settlement_registry.as_deref() {
+                pre_settlements.push(reg.subscribe_settlement(mail_id));
+            }
+        }
 
-            // iamacoffeepot/aether#1780: read the reference PNG synchronously
-            // on the cap dispatcher thread (not the render thread) so all
-            // filesystem I/O stays off the render hot path. The render thread
-            // only runs the CPU-side MAE comparison against the pre-fetched
-            // bytes.
-            let reference = match resolve_reference(
-                self.config.assets_dir.as_deref(),
-                mail.similarity.as_ref(),
-            ) {
+        // ADR-0106 / iamacoffeepot/aether#1758: capture is a deferred
+        // reply — the render thread sends the reply a frame later, off
+        // this handler's dispatch window. Retain the dispatched
+        // `CaptureFrame` envelope as an `InboundMail` guard via
+        // `take_inbound`: the dispatcher's settlement tail then sees
+        // `None` and does not discharge, so the guard's un-fired
+        // `record_finished` keeps the inbound's chain open until the
+        // render thread replies through `reply.reply(&result)` and
+        // drops it (recording the reply's `Sent` before the inbound's
+        // `Finished`, ADR-0080 §6). This retires the hand-rolled
+        // `SettlementHold` + reply-id mint (#1273 / #1719). The
+        // early-return branches above reply synchronously inside this
+        // handler's own dispatch window, so they leave the inbound for
+        // the dispatcher's tail to settle and don't take the guard.
+
+        // iamacoffeepot/aether#1780: read the reference PNG synchronously
+        // on the cap dispatcher thread (not the render thread) so all
+        // filesystem I/O stays off the render hot path. The render thread
+        // only runs the CPU-side MAE comparison against the pre-fetched
+        // bytes.
+        let reference =
+            match resolve_reference(state.config.assets_dir.as_deref(), mail.similarity.as_ref()) {
                 Ok(reference) => reference,
                 Err(error) => {
                     backend
@@ -390,637 +399,655 @@ mod native {
                 }
             };
 
-            let inbound = ctx.take_inbound();
-            let pending = PendingCapture {
-                reply: inbound,
-                after_mails: after,
-                pre_settlements,
-                checks: mail.checks,
-                reference,
-            };
-            // A rejected request (`Err`) is handed back so its retained
-            // guard can carry the synchronous `Err` reply before it drops
-            // — settling after the reply, ADR-0080 §6.
-            if let Err(rejected) = backend.queue.request(pending) {
-                rejected.reply.reply(&CaptureFrameResult::Err {
-                    error: "capture already pending; try again once the in-flight \
+        let inbound = ctx.take_inbound();
+        let pending = PendingCapture {
+            reply: inbound,
+            after_mails: after,
+            pre_settlements,
+            checks: mail.checks,
+            reference,
+        };
+        // A rejected request (`Err`) is handed back so its retained
+        // guard can carry the synchronous `Err` reply before it drops
+        // — settling after the reply, ADR-0080 §6.
+        if let Err(rejected) = backend.queue.request(pending) {
+            rejected.reply.reply(&CaptureFrameResult::Err {
+                error: "capture already pending; try again once the in-flight \
                         request completes"
-                        .to_owned(),
-                });
-                return;
-            }
-
-            if let Err(reason) = (backend.wake)()
-                && let Some(rejected) = backend.queue.take()
-            {
-                // The wake never reached the render thread, so the request
-                // is still parked: take it back and reply `Err` through its
-                // retained guard, which then drops and settles the chain.
-                rejected.reply.reply(&CaptureFrameResult::Err {
-                    error: reason.to_owned(),
-                });
-            }
+                    .to_owned(),
+            });
+            return;
         }
 
-        /// `CreateTexture` handler (ADR-0105). Validates the dimensions
-        /// and pixel length, stages the RGBA8 pixels CPU-side under the
-        /// next session-scoped `texture_id`, and replies immediately —
-        /// the wgpu texture is realized lazily at the next frame record
-        /// (the GPU bundle isn't installed until the chassis driver
-        /// boots). A zero dimension or a `pixels` length that doesn't
-        /// match `width * height * 4` replies `Err` without registering.
-        ///
-        /// # Agent
-        /// Mail `aether.render.create_texture { width, height, pixels }`;
-        /// the reply `aether.render.create_texture_result` carries the
-        /// `texture_id` to thread into `draw_textured_quads`.
-        #[handler]
-        fn on_create_texture(
-            &self,
-            _ctx: &mut NativeCtx<'_>,
-            mail: CreateTexture,
-        ) -> CreateTextureResult {
-            if let Some(obs) = &self.config.observed_kinds {
-                obs.lock()
-                    .expect("mutex poisoned; fail-fast per ADR-0063")
-                    .push(<CreateTexture as Kind>::NAME.into());
-            }
-            let expected = expected_pixel_bytes(mail.width, mail.height);
-            let Some(expected) = expected else {
-                return CreateTextureResult::Err {
-                    error: format!(
-                        "texture dimensions {}x{} overflow or are zero",
-                        mail.width, mail.height
-                    ),
-                };
-            };
-            if mail.pixels.len() != expected {
-                return CreateTextureResult::Err {
-                    error: format!(
-                        "pixels length {} does not match width*height*4 = {expected}",
-                        mail.pixels.len()
-                    ),
-                };
-            }
-            let mut registry = self
-                .handles
-                .textures
-                .lock()
-                .expect("mutex poisoned; fail-fast per ADR-0063");
-            let texture_id = registry.next_id;
-            registry.next_id += 1;
-            registry.entries.insert(
-                texture_id,
-                StagedTexture {
-                    width: mail.width,
-                    height: mail.height,
-                    pixels: mail.pixels,
-                    realized: None,
-                    dirty: true,
-                },
-            );
-            drop(registry);
-            CreateTextureResult::Ok { texture_id }
-        }
-
-        /// `UpdateTexture` handler (ADR-0105). Overwrites a sub-rectangle
-        /// of a staged texture's pixels and dirties it so the next record
-        /// re-uploads. Fire-and-forget: an unknown `texture_id`, an
-        /// out-of-bounds rect, or a `pixels` length that doesn't match the
-        /// sub-rect logs and drops without touching the staging buffer.
-        ///
-        /// # Agent
-        /// Mail `aether.render.update_texture { texture_id, x, y, width,
-        /// height, pixels }` to grow an atlas; no reply.
-        #[handler]
-        fn on_update_texture(&self, _ctx: &mut NativeCtx<'_>, mail: UpdateTexture) {
-            if let Some(obs) = &self.config.observed_kinds {
-                obs.lock()
-                    .expect("mutex poisoned; fail-fast per ADR-0063")
-                    .push(<UpdateTexture as Kind>::NAME.into());
-            }
-            let mut registry = self
-                .handles
-                .textures
-                .lock()
-                .expect("mutex poisoned; fail-fast per ADR-0063");
-            let Some(entry) = registry.entries.get_mut(&mail.texture_id) else {
-                tracing::warn!(
-                    target: "aether_capabilities::render",
-                    texture_id = mail.texture_id,
-                    "update_texture for unknown texture id; dropping",
-                );
-                return;
-            };
-            if !entry.apply_subrect(mail.x, mail.y, mail.width, mail.height, &mail.pixels) {
-                tracing::warn!(
-                    target: "aether_capabilities::render",
-                    texture_id = mail.texture_id,
-                    "update_texture rect out of bounds, zero-sized, or pixel length mismatch; \
-                     dropping",
-                );
-            }
-        }
-
-        /// `DrawTexturedQuads` handler (ADR-0105). Accumulates the batch
-        /// into the per-frame quad accumulator with the same immediate-
-        /// mode contract as `on_draw_triangle`: the driver consumes it at
-        /// record time. An unknown `texture_id` or a `World` space is
-        /// warn-dropped at encode, not here, so the accumulate path stays
-        /// a cheap push.
-        ///
-        /// # Agent
-        /// Mail `aether.render.draw_textured_quads { texture_id, space,
-        /// quads }` every frame the quads should appear; no reply.
-        #[handler]
-        fn on_draw_textured_quads(&self, _ctx: &mut NativeCtx<'_>, mail: DrawTexturedQuads) {
-            if let Some(obs) = &self.config.observed_kinds {
-                obs.lock()
-                    .expect("mutex poisoned; fail-fast per ADR-0063")
-                    .push(<DrawTexturedQuads as Kind>::NAME.into());
-            }
-            self.handles
-                .quad_frame
-                .lock()
-                .expect("mutex poisoned; fail-fast per ADR-0063")
-                .push(QuadBatch {
-                    texture_id: mail.texture_id,
-                    space: mail.space,
-                    quads: mail.quads,
-                });
-        }
-
-        /// `DrawSolidQuads` handler (ADR-0107 §4). Expands each `SolidQuad`
-        /// into a `TexturedQuad` covering the full uv of a reserved internal
-        /// 1×1 white texture, tinted by `color` — so the white texel ×
-        /// tint produces the flat fill color with no new GPU pipeline.
-        /// Lazily inserts the white texture into the registry on first call.
-        /// Accumulates into the same `quad_frame` accumulator as
-        /// `on_draw_textured_quads`; immediate-mode contract is identical.
-        ///
-        /// # Agent
-        /// Mail `aether.render.draw_solid_quads { space, quads }` every
-        /// frame the rects should appear; no reply.
-        #[handler]
-        fn on_draw_solid_quads(&self, _ctx: &mut NativeCtx<'_>, mail: DrawSolidQuads) {
-            if let Some(obs) = &self.config.observed_kinds {
-                obs.lock()
-                    .expect("mutex poisoned; fail-fast per ADR-0063")
-                    .push(<DrawSolidQuads as Kind>::NAME.into());
-            }
-            let mut registry = self
-                .handles
-                .textures
-                .lock()
-                .expect("mutex poisoned; fail-fast per ADR-0063");
-            registry
-                .entries
-                .entry(WHITE_TEXTURE_ID)
-                .or_insert_with(|| StagedTexture {
-                    width: 1,
-                    height: 1,
-                    pixels: vec![255, 255, 255, 255],
-                    realized: None,
-                    dirty: true,
-                });
-            drop(registry);
-            let quads: Vec<TexturedQuad> = mail
-                .quads
-                .into_iter()
-                .map(
-                    |SolidQuad {
-                         x,
-                         y,
-                         width,
-                         height,
-                         color,
-                     }| TexturedQuad {
-                        x,
-                        y,
-                        width,
-                        height,
-                        u0: 0.0,
-                        v0: 0.0,
-                        u1: 1.0,
-                        v1: 1.0,
-                        tint: color,
-                    },
-                )
-                .collect();
-            self.handles
-                .quad_frame
-                .lock()
-                .expect("mutex poisoned; fail-fast per ADR-0063")
-                .push(QuadBatch {
-                    texture_id: WHITE_TEXTURE_ID,
-                    space: mail.space,
-                    quads,
-                });
+        if let Err(reason) = (backend.wake)()
+            && let Some(rejected) = backend.queue.take()
+        {
+            // The wake never reached the render thread, so the request
+            // is still parked: take it back and reply `Err` through its
+            // retained guard, which then drops and settles the chain.
+            rejected.reply.reply(&CaptureFrameResult::Err {
+                error: reason.to_owned(),
+            });
         }
     }
 
-    #[cfg(test)]
-    mod tests {
-        use std::time::Duration;
-
-        use super::*;
-        use crate::test_chassis::TestChassis;
-        use aether_actor::Addressable;
-        use aether_kinds::QuadSpace;
-        use aether_kinds::trace::Nanos;
-        use aether_substrate::chassis::builder::{Builder, PassiveChassis};
-        use aether_substrate::mail::MailId;
-        use aether_substrate::mail::MailRef;
-        use aether_substrate::mail::mailer::Mailer;
-        use aether_substrate::mail::registry::OwnedDispatch;
-        use aether_substrate::mail::registry::{MailboxEntry, Registry};
-        use aether_substrate::mail::{KindId, Source};
-        use std::thread;
-
-        use crate::test_chassis::fresh_substrate;
-
-        /// ADR-0099 §3/§5: a real `#[bridge(singleton)]` chassis cap keeps
-        /// the default [`aether_actor::Singleton::resolve`], so its id is the
-        /// depth-1 fixed point — exactly the `mailbox_id_from_name(NAMESPACE)`
-        /// value it had before the lineage fold, regardless of the caller's
-        /// carry. Guards the frozen-vocabulary claim: #1431 must not move any
-        /// root-cap id.
-        // Asserts the cap's resolved id against the frozen depth-1 name hash —
-        // the primitive is the reference value under test.
-        #[allow(clippy::disallowed_methods)]
-        #[test]
-        fn render_capability_resolves_to_frozen_depth_one_id() {
-            use aether_data::mailbox_id_from_name;
-
-            let frozen = mailbox_id_from_name(<RenderCapability as Addressable>::NAMESPACE);
-            assert_eq!(<RenderCapability as Addressable>::resolve(0, ()), frozen);
-            assert_eq!(
-                <RenderCapability as Addressable>::resolve(0xFFFF_FFFF_FFFF_FFFF, ()),
-                frozen,
-            );
+    /// `CreateTexture` handler (ADR-0105). Validates the dimensions
+    /// and pixel length, stages the RGBA8 pixels CPU-side under the
+    /// next session-scoped `texture_id`, and replies immediately —
+    /// the wgpu texture is realized lazily at the next frame record
+    /// (the GPU bundle isn't installed until the chassis driver
+    /// boots). A zero dimension or a `pixels` length that doesn't
+    /// match `width * height * 4` replies `Err` without registering.
+    ///
+    /// # Agent
+    /// Mail `aether.render.create_texture { width, height, pixels }`;
+    /// the reply `aether.render.create_texture_result` carries the
+    /// `texture_id` to thread into `draw_textured_quads`.
+    #[handler]
+    fn on_create_texture(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        mail: CreateTexture,
+    ) -> CreateTextureResult {
+        if let Some(obs) = &state.config.observed_kinds {
+            obs.lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063")
+                .push(<CreateTexture as Kind>::NAME.into());
         }
-
-        /// Boots a passive `TestChassis` with a default `RenderCapability`.
-        /// Collapses the four-line `Builder::<TestChassis>::new(...)` chain
-        /// every render test repeated (issue 795).
-        fn build_render_chassis(
-            registry: &Arc<Registry>,
-            mailer: &Arc<Mailer>,
-        ) -> PassiveChassis<TestChassis> {
-            Builder::<TestChassis>::new(Arc::clone(registry), Arc::clone(mailer))
-                .with_actor::<RenderCapability>(RenderConfig::default())
-                .build_passive()
-                .expect("build succeeds")
-        }
-
-        fn deliver(registry: &Registry, name: &str, kind: KindId, payload: &[u8]) {
-            let id = registry.lookup(name).expect("mailbox registered");
-            let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("entry exists")
-            else {
-                panic!("expected mailbox entry for {name}");
+        let expected = expected_pixel_bytes(mail.width, mail.height);
+        let Some(expected) = expected else {
+            return CreateTextureResult::Err {
+                error: format!(
+                    "texture dimensions {}x{} overflow or are zero",
+                    mail.width, mail.height
+                ),
             };
-            handler.enqueue(OwnedDispatch::disarmed(
-                kind,
-                "test.kind".to_owned(),
-                None,
-                Source::NONE,
-                MailRef::from(payload.to_vec()),
-                1,
-                MailId::NONE,
-                MailId::NONE,
-                None,
-                Nanos(0),
-                0,
-                aether_data::MailboxId(0),
-            ));
-        }
-
-        #[test]
-        fn capability_claims_render_mailbox_only() {
-            let (registry, mailer) = fresh_substrate();
-            let chassis = build_render_chassis(&registry, &mailer);
-            assert_eq!(chassis.len(), 1);
-            assert!(registry.lookup(RenderCapability::NAMESPACE).is_some());
-            // Camera mailbox retired (ADR-0074 §Decision 7).
-            assert!(registry.lookup("aether.sink.camera").is_none());
-        }
-
-        // ADR-0082 retired the frame-bound pending counter; the
-        // DrawTriangle → render dispatch path is now covered end-to-end
-        // by the bundle scenario tests (`tick_roundtrip_component_to_sink`
-        // and the `test_bench_scenario` suite), which exercise it through
-        // real settlement rather than a per-mailbox counter poll.
-
-        /// ADR-0107 §4: `draw_solid_quads` accumulates into `quad_frame` under
-        /// the reserved `WHITE_TEXTURE_ID` and records its kind name in
-        /// `observed_kinds`. Verifies the expand-to-TexturedQuad path and the
-        /// lazy white-texture insertion without a GPU.
-        #[test]
-        fn draw_solid_quads_accumulates_and_observed() {
-            let observed = Arc::new(Mutex::new(Vec::<String>::new()));
-            let config = RenderConfig {
-                observed_kinds: Some(Arc::clone(&observed)),
-                ..RenderConfig::default()
+        };
+        if mail.pixels.len() != expected {
+            return CreateTextureResult::Err {
+                error: format!(
+                    "pixels length {} does not match width*height*4 = {expected}",
+                    mail.pixels.len()
+                ),
             };
-            let (registry, mailer) = fresh_substrate();
-            let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
-                .with_actor::<RenderCapability>(config)
-                .build_passive()
-                .expect("build succeeds");
-            let handles = chassis
-                .handle::<RenderHandles>()
-                .expect("RenderCapability publishes RenderHandles");
-
-            let mail = DrawSolidQuads {
-                space: QuadSpace::Screen,
-                quads: vec![SolidQuad {
-                    x: 10.0,
-                    y: 20.0,
-                    width: 30.0,
-                    height: 40.0,
-                    color: [1.0, 0.0, 0.5, 0.8],
-                }],
-            };
-            let payload = mail.encode_into_bytes();
-            deliver(
-                &registry,
-                RenderCapability::NAMESPACE,
-                <DrawSolidQuads as Kind>::ID,
-                &payload,
-            );
-
-            thread::sleep(Duration::from_millis(50));
-
-            let seen = observed
-                .lock()
-                .expect("observed_kinds mutex is not poisoned")
-                .clone();
-            assert!(
-                seen.contains(&DrawSolidQuads::NAME.to_owned()),
-                "draw_solid_quads handler should push its kind name; observed: {seen:?}",
-            );
-
-            let batches = handles
-                .quad_frame
-                .lock()
-                .expect("quad_frame mutex is not poisoned")
-                .clone();
-            assert_eq!(
-                batches.len(),
-                1,
-                "one QuadBatch should be in the accumulator"
-            );
-            assert_eq!(
-                batches[0].texture_id, WHITE_TEXTURE_ID,
-                "batch must use the reserved white texture id",
-            );
-            assert_eq!(
-                batches[0].quads.len(),
-                1,
-                "batch must contain the one expanded quad"
-            );
-            assert_eq!(
-                batches[0].quads[0].tint,
-                [1.0, 0.0, 0.5, 0.8],
-                "expanded quad tint must match the SolidQuad color",
-            );
-            assert_eq!(batches[0].quads[0].width, 30.0);
-
-            let tex_present = handles
-                .textures
-                .lock()
-                .expect("textures mutex is not poisoned")
-                .entries
-                .contains_key(&WHITE_TEXTURE_ID);
-            assert!(
-                tex_present,
-                "white texture must be lazily inserted on first send"
-            );
-
-            drop(chassis);
         }
+        let mut registry = state
+            .handles
+            .textures
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063");
+        let texture_id = registry.next_id;
+        registry.next_id += 1;
+        registry.entries.insert(
+            texture_id,
+            StagedTexture {
+                width: mail.width,
+                height: mail.height,
+                pixels: mail.pixels,
+                realized: None,
+                dirty: true,
+            },
+        );
+        drop(registry);
+        CreateTextureResult::Ok { texture_id }
+    }
 
-        #[test]
-        fn camera_kind_drops_wrong_length_payload() {
-            let (registry, mailer) = fresh_substrate();
-            let chassis = build_render_chassis(&registry, &mailer);
-
-            // 16 bytes — wrong length, decode fails, macro miss path
-            // logs warn at chassis-side dispatcher; identity unchanged.
-            deliver(
-                &registry,
-                RenderCapability::NAMESPACE,
-                <Camera as Kind>::ID,
-                &[1u8; 16],
-            );
-
-            thread::sleep(Duration::from_millis(50));
-            // No further assertion on internal state — passive chassis
-            // doesn't expose `Arc<RenderCapability>`. Decode failure is
-            // observable via the macro miss path's warn-log; this test
-            // asserts shutdown still proceeds cleanly (no dispatcher
-            // panic on malformed input).
-            drop(chassis);
+    /// `UpdateTexture` handler (ADR-0105). Overwrites a sub-rectangle
+    /// of a staged texture's pixels and dirties it so the next record
+    /// re-uploads. Fire-and-forget: an unknown `texture_id`, an
+    /// out-of-bounds rect, or a `pixels` length that doesn't match the
+    /// sub-rect logs and drops without touching the staging buffer.
+    ///
+    /// # Agent
+    /// Mail `aether.render.update_texture { texture_id, x, y, width,
+    /// height, pixels }` to grow an atlas; no reply.
+    #[handler]
+    fn on_update_texture(state: &mut Self::State, _ctx: &mut NativeCtx<'_>, mail: UpdateTexture) {
+        if let Some(obs) = &state.config.observed_kinds {
+            obs.lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063")
+                .push(<UpdateTexture as Kind>::NAME.into());
         }
+        let mut registry = state
+            .handles
+            .textures
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063");
+        let Some(entry) = registry.entries.get_mut(&mail.texture_id) else {
+            tracing::warn!(
+                target: "aether_capabilities::render",
+                texture_id = mail.texture_id,
+                "update_texture for unknown texture id; dropping",
+            );
+            return;
+        };
+        if !entry.apply_subrect(mail.x, mail.y, mail.width, mail.height, &mail.pixels) {
+            tracing::warn!(
+                target: "aether_capabilities::render",
+                texture_id = mail.texture_id,
+                "update_texture rect out of bounds, zero-sized, or pixel length mismatch; \
+                 dropping",
+            );
+        }
+    }
+
+    /// `DrawTexturedQuads` handler (ADR-0105). Accumulates the batch
+    /// into the per-frame quad accumulator with the same immediate-
+    /// mode contract as `on_draw_triangle`: the driver consumes it at
+    /// record time. An unknown `texture_id` or a `World` space is
+    /// warn-dropped at encode, not here, so the accumulate path stays
+    /// a cheap push.
+    ///
+    /// # Agent
+    /// Mail `aether.render.draw_textured_quads { texture_id, space,
+    /// quads }` every frame the quads should appear; no reply.
+    #[handler]
+    fn on_draw_textured_quads(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        mail: DrawTexturedQuads,
+    ) {
+        if let Some(obs) = &state.config.observed_kinds {
+            obs.lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063")
+                .push(<DrawTexturedQuads as Kind>::NAME.into());
+        }
+        state
+            .handles
+            .quad_frame
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063")
+            .push(QuadBatch {
+                texture_id: mail.texture_id,
+                space: mail.space,
+                quads: mail.quads,
+            });
+    }
+
+    /// `DrawSolidQuads` handler (ADR-0107 §4). Expands each `SolidQuad`
+    /// into a `TexturedQuad` covering the full uv of a reserved internal
+    /// 1×1 white texture, tinted by `color` — so the white texel ×
+    /// tint produces the flat fill color with no new GPU pipeline.
+    /// Lazily inserts the white texture into the registry on first call.
+    /// Accumulates into the same `quad_frame` accumulator as
+    /// `on_draw_textured_quads`; immediate-mode contract is identical.
+    ///
+    /// # Agent
+    /// Mail `aether.render.draw_solid_quads { space, quads }` every
+    /// frame the rects should appear; no reply.
+    #[handler]
+    fn on_draw_solid_quads(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        mail: DrawSolidQuads,
+    ) {
+        if let Some(obs) = &state.config.observed_kinds {
+            obs.lock()
+                .expect("mutex poisoned; fail-fast per ADR-0063")
+                .push(<DrawSolidQuads as Kind>::NAME.into());
+        }
+        let mut registry = state
+            .handles
+            .textures
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063");
+        registry
+            .entries
+            .entry(WHITE_TEXTURE_ID)
+            .or_insert_with(|| StagedTexture {
+                width: 1,
+                height: 1,
+                pixels: vec![255, 255, 255, 255],
+                realized: None,
+                dirty: true,
+            });
+        drop(registry);
+        let quads: Vec<TexturedQuad> = mail
+            .quads
+            .into_iter()
+            .map(
+                |SolidQuad {
+                     x,
+                     y,
+                     width,
+                     height,
+                     color,
+                 }| TexturedQuad {
+                    x,
+                    y,
+                    width,
+                    height,
+                    u0: 0.0,
+                    v0: 0.0,
+                    u1: 1.0,
+                    v1: 1.0,
+                    tint: color,
+                },
+            )
+            .collect();
+        state
+            .handles
+            .quad_frame
+            .lock()
+            .expect("mutex poisoned; fail-fast per ADR-0063")
+            .push(QuadBatch {
+                texture_id: WHITE_TEXTURE_ID,
+                space: mail.space,
+                quads,
+            });
     }
 }
 
-#[aether_actor::bridge(singleton)]
-mod native_headless {
-    use std::sync::Arc;
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
 
-    use aether_actor::actor;
-    use aether_kinds::CaptureFrameResult;
-    use aether_substrate::Manual;
-    use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    use aether_substrate::chassis::error::BootError;
-    use aether_substrate::mail::outbound::HubOutbound;
+    use super::*;
+    use crate::test_chassis::TestChassis;
+    use aether_actor::Addressable;
+    use aether_kinds::QuadSpace;
+    use aether_kinds::trace::Nanos;
+    use aether_substrate::chassis::builder::{Builder, PassiveChassis};
+    use aether_substrate::mail::MailId;
+    use aether_substrate::mail::MailRef;
+    use aether_substrate::mail::mailer::Mailer;
+    use aether_substrate::mail::registry::OwnedDispatch;
+    use aether_substrate::mail::registry::{MailboxEntry, Registry};
+    use aether_substrate::mail::{KindId, Source};
+    use std::thread;
 
-    use super::{
-        Camera, CaptureFrame, CreateTexture, CreateTextureResult, DrawSolidQuads,
-        DrawTexturedQuads, DrawTriangle, UpdateTexture,
-    };
-    use std::io;
+    use crate::test_chassis::fresh_substrate;
 
-    /// Chassis-without-GPU companion to [`super::RenderCapability`].
-    /// Claims the same `aether.render` mailbox so desktop-designed
-    /// components loaded on headless can mail `DrawTriangle` /
-    /// `aether.camera` / `aether.render.capture_frame` against a known
-    /// recipient — `DrawTriangle` and `Camera` no-op (the warn-storm
-    /// sink-replacement role pre-issue-603 Phase 2), `CaptureFrame`
-    /// replies `Err` so MCP `capture_frame` fails fast instead of
-    /// timing out.
-    ///
-    /// Headless chassis composes one of [`Self`] / [`super::RenderCapability`],
-    /// never both — the chassis builder rejects double-claiming a
-    /// mailbox.
-    pub struct HeadlessRenderCapability {
-        outbound: Arc<HubOutbound>,
+    /// ADR-0099 §3/§5: a real `#[actor(singleton)]` chassis cap keeps
+    /// the default [`aether_actor::Singleton::resolve`], so its id is the
+    /// depth-1 fixed point — exactly the `mailbox_id_from_name(NAMESPACE)`
+    /// value it had before the lineage fold, regardless of the caller's
+    /// carry. Guards the frozen-vocabulary claim: #1431 must not move any
+    /// root-cap id.
+    // Asserts the cap's resolved id against the frozen depth-1 name hash —
+    // the primitive is the reference value under test.
+    #[allow(clippy::disallowed_methods)]
+    #[test]
+    fn render_capability_resolves_to_frozen_depth_one_id() {
+        use aether_data::mailbox_id_from_name;
+
+        let frozen = mailbox_id_from_name(<RenderCapability as Addressable>::NAMESPACE);
+        assert_eq!(<RenderCapability as Addressable>::resolve(0, ()), frozen);
+        assert_eq!(
+            <RenderCapability as Addressable>::resolve(0xFFFF_FFFF_FFFF_FFFF, ()),
+            frozen,
+        );
     }
 
-    #[actor]
-    impl NativeActor for HeadlessRenderCapability {
-        type Config = ();
-
-        const NAMESPACE: &'static str = "aether.render";
-
-        fn init(_config: (), ctx: &mut NativeInitCtx<'_>) -> Result<Self, BootError> {
-            let outbound = ctx.mailer().outbound().cloned().ok_or_else(|| {
-                BootError::Other(Box::new(io::Error::other(
-                    "HubOutbound must be wired on Mailer before \
-                         HeadlessRenderCapability::init (chassis main connects the hub before \
-                         the Builder chain)",
-                )))
-            })?;
-            Ok(Self { outbound })
-        }
-
-        /// `DrawTriangle` lands here as a no-op so headless boots of
-        /// desktop-designed components (which emit `DrawTriangle` every
-        /// tick) don't trip the unknown-mailbox warn path.
-        // `&self` keeps the dispatch ABI (ADR-0033 / ADR-0038); the body
-        // is a no-op by design — see the doc comment above.
-        #[allow(clippy::unused_self)]
-        #[handler]
-        fn on_draw_triangle(&self, _ctx: &mut NativeCtx<'_>, _mails: &[DrawTriangle]) {}
-
-        /// `Camera` lands here as a no-op for the same reason as
-        /// `on_draw_triangle` — desktop-designed components publish
-        /// `aether.camera` every tick.
-        #[allow(clippy::unused_self)]
-        #[handler]
-        fn on_camera(&self, _ctx: &mut NativeCtx<'_>, _mail: Camera) {}
-
-        /// `CaptureFrame` replies `Err` inline so MCP `capture_frame`
-        /// fails fast on headless instead of hanging on a reply that
-        /// never comes. Mirrors ADR-0035 §Consequences fail-fast shape
-        /// for `set_window_mode`.
-        #[handler::manual]
-        fn on_capture_frame(&self, ctx: &mut NativeCtx<'_, Manual>, _mail: CaptureFrame) {
-            self.outbound.send_reply(
-                ctx.reply_target(),
-                &CaptureFrameResult::Err {
-                    error: "unsupported on headless chassis — no GPU".to_owned(),
-                },
-            );
-        }
-
-        /// `CreateTexture` replies `Err` inline so an agent that creates a
-        /// texture against a headless chassis fails fast instead of
-        /// waiting on a reply that never comes — same fail-fast shape as
-        /// `on_capture_frame` (ADR-0105).
-        #[handler::manual]
-        fn on_create_texture(&self, ctx: &mut NativeCtx<'_, Manual>, _mail: CreateTexture) {
-            self.outbound.send_reply(
-                ctx.reply_target(),
-                &CreateTextureResult::Err {
-                    error: "unsupported on headless chassis — no GPU".to_owned(),
-                },
-            );
-        }
-
-        /// `UpdateTexture` lands here as a no-op so desktop-designed
-        /// components running on headless don't trip the unknown-mailbox
-        /// warn path — mirrors `on_draw_triangle`.
-        #[allow(clippy::unused_self)]
-        #[handler]
-        fn on_update_texture(&self, _ctx: &mut NativeCtx<'_>, _mail: UpdateTexture) {}
-
-        /// `DrawTexturedQuads` lands here as a no-op for the same reason
-        /// as `on_update_texture`.
-        #[allow(clippy::unused_self)]
-        #[handler]
-        fn on_draw_textured_quads(&self, _ctx: &mut NativeCtx<'_>, _mail: DrawTexturedQuads) {}
-
-        /// `DrawSolidQuads` lands here as a no-op for the same reason
-        /// as `on_draw_textured_quads`.
-        #[allow(clippy::unused_self)]
-        #[handler]
-        fn on_draw_solid_quads(&self, _ctx: &mut NativeCtx<'_>, _mail: DrawSolidQuads) {}
+    /// Boots a passive `TestChassis` with a default `RenderCapability`.
+    /// Collapses the four-line `Builder::<TestChassis>::new(...)` chain
+    /// every render test repeated (issue 795).
+    fn build_render_chassis(
+        registry: &Arc<Registry>,
+        mailer: &Arc<Mailer>,
+    ) -> PassiveChassis<TestChassis> {
+        Builder::<TestChassis>::new(Arc::clone(registry), Arc::clone(mailer))
+            .with_actor::<RenderCapability>(RenderConfig::default())
+            .build_passive()
+            .expect("build succeeds")
     }
 
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-        use crate::test_chassis::{decode_reply, test_mailer_and_rx};
-        use aether_data::{MailboxId, Source, SourceAddr};
-        use aether_data::{SessionToken, Uuid};
-        use aether_substrate::actor::native::NativeCtx;
-        use aether_substrate::actor::native::binding::NativeBinding;
+    fn deliver(registry: &Registry, name: &str, kind: KindId, payload: &[u8]) {
+        let id = registry.lookup(name).expect("mailbox registered");
+        let MailboxEntry::Inbox { handler, .. } = registry.entry(id).expect("entry exists") else {
+            panic!("expected mailbox entry for {name}");
+        };
+        handler.enqueue(OwnedDispatch::disarmed(
+            kind,
+            "test.kind".to_owned(),
+            None,
+            Source::NONE,
+            MailRef::from(payload.to_vec()),
+            1,
+            MailId::NONE,
+            MailId::NONE,
+            None,
+            Nanos(0),
+            0,
+            aether_data::MailboxId(0),
+        ));
+    }
 
-        /// ADR-0105: `create_texture` against a headless chassis replies
-        /// `Err` (fail-fast, no GPU) rather than hanging on a reply that
-        /// never comes — mirrors `capture_frame`'s headless shape.
-        #[test]
-        fn headless_create_texture_replies_err() {
-            let (mailer, rx) = test_mailer_and_rx();
-            let outbound = mailer
-                .outbound()
-                .cloned()
-                .expect("test_mailer_and_rx wires a loopback outbound");
-            let cap = HeadlessRenderCapability { outbound };
-            let transport = Arc::new(NativeBinding::new_for_test(
-                Arc::clone(&mailer),
-                MailboxId(0),
-            ));
-            let mut ctx = NativeCtx::new_dispatching(
-                &transport,
-                Source::to(SourceAddr::Session(SessionToken(Uuid::nil()))),
-                aether_data::MailId::NONE,
-                aether_data::MailId::NONE,
-            );
-            cap.on_create_texture(
-                &mut ctx,
-                CreateTexture {
-                    width: 2,
-                    height: 2,
-                    pixels: vec![0u8; 16],
-                },
-            );
-            match decode_reply::<CreateTextureResult>(&rx) {
-                CreateTextureResult::Err { error } => {
-                    assert!(
-                        error.contains("headless"),
-                        "headless create_texture error should name the chassis; got {error}",
-                    );
-                }
-                CreateTextureResult::Ok { .. } => {
-                    panic!("headless create_texture must reply Err, not assign an id")
-                }
+    #[test]
+    fn capability_claims_render_mailbox_only() {
+        let (registry, mailer) = fresh_substrate();
+        let chassis = build_render_chassis(&registry, &mailer);
+        assert_eq!(chassis.len(), 1);
+        assert!(registry.lookup(RenderCapability::NAMESPACE).is_some());
+        // Camera mailbox retired (ADR-0074 §Decision 7).
+        assert!(registry.lookup("aether.sink.camera").is_none());
+    }
+
+    // ADR-0082 retired the frame-bound pending counter; the
+    // DrawTriangle → render dispatch path is now covered end-to-end
+    // by the bundle scenario tests (`tick_roundtrip_component_to_sink`
+    // and the `test_bench_scenario` suite), which exercise it through
+    // real settlement rather than a per-mailbox counter poll.
+
+    /// ADR-0107 §4: `draw_solid_quads` accumulates into `quad_frame` under
+    /// the reserved `WHITE_TEXTURE_ID` and records its kind name in
+    /// `observed_kinds`. Verifies the expand-to-TexturedQuad path and the
+    /// lazy white-texture insertion without a GPU.
+    #[test]
+    fn draw_solid_quads_accumulates_and_observed() {
+        let observed = Arc::new(Mutex::new(Vec::<String>::new()));
+        let config = RenderConfig {
+            observed_kinds: Some(Arc::clone(&observed)),
+            ..RenderConfig::default()
+        };
+        let (registry, mailer) = fresh_substrate();
+        let chassis = Builder::<TestChassis>::new(Arc::clone(&registry), Arc::clone(&mailer))
+            .with_actor::<RenderCapability>(config)
+            .build_passive()
+            .expect("build succeeds");
+        let handles = chassis
+            .handle::<RenderHandles>()
+            .expect("RenderCapability publishes RenderHandles");
+
+        let mail = DrawSolidQuads {
+            space: QuadSpace::Screen,
+            quads: vec![SolidQuad {
+                x: 10.0,
+                y: 20.0,
+                width: 30.0,
+                height: 40.0,
+                color: [1.0, 0.0, 0.5, 0.8],
+            }],
+        };
+        let payload = mail.encode_into_bytes();
+        deliver(
+            &registry,
+            RenderCapability::NAMESPACE,
+            <DrawSolidQuads as Kind>::ID,
+            &payload,
+        );
+
+        thread::sleep(Duration::from_millis(50));
+
+        let seen = observed
+            .lock()
+            .expect("observed_kinds mutex is not poisoned")
+            .clone();
+        assert!(
+            seen.contains(&DrawSolidQuads::NAME.to_owned()),
+            "draw_solid_quads handler should push its kind name; observed: {seen:?}",
+        );
+
+        let batches = handles
+            .quad_frame
+            .lock()
+            .expect("quad_frame mutex is not poisoned")
+            .clone();
+        assert_eq!(
+            batches.len(),
+            1,
+            "one QuadBatch should be in the accumulator"
+        );
+        assert_eq!(
+            batches[0].texture_id, WHITE_TEXTURE_ID,
+            "batch must use the reserved white texture id",
+        );
+        assert_eq!(
+            batches[0].quads.len(),
+            1,
+            "batch must contain the one expanded quad"
+        );
+        assert_eq!(
+            batches[0].quads[0].tint,
+            [1.0, 0.0, 0.5, 0.8],
+            "expanded quad tint must match the SolidQuad color",
+        );
+        assert_eq!(batches[0].quads[0].width, 30.0);
+
+        let tex_present = handles
+            .textures
+            .lock()
+            .expect("textures mutex is not poisoned")
+            .entries
+            .contains_key(&WHITE_TEXTURE_ID);
+        assert!(
+            tex_present,
+            "white texture must be lazily inserted on first send"
+        );
+
+        drop(chassis);
+    }
+
+    #[test]
+    fn camera_kind_drops_wrong_length_payload() {
+        let (registry, mailer) = fresh_substrate();
+        let chassis = build_render_chassis(&registry, &mailer);
+
+        // 16 bytes — wrong length, decode fails, macro miss path
+        // logs warn at chassis-side dispatcher; identity unchanged.
+        deliver(
+            &registry,
+            RenderCapability::NAMESPACE,
+            <Camera as Kind>::ID,
+            &[1u8; 16],
+        );
+
+        thread::sleep(Duration::from_millis(50));
+        // No further assertion on internal state — passive chassis
+        // doesn't expose `Arc<RenderCapability>`. Decode failure is
+        // observable via the macro miss path's warn-log; this test
+        // asserts shutdown still proceeds cleanly (no dispatcher
+        // panic on malformed input).
+        drop(chassis);
+    }
+}
+
+/// `HeadlessRenderCapability` **identity** (ADR-0122 identity/runtime
+/// split). The chassis-without-GPU companion to [`RenderCapability`],
+/// claiming the same `aether.render` mailbox so desktop-designed
+/// components loaded on headless can mail `DrawTriangle` / `aether.camera`
+/// / `aether.render.capture_frame` against a known recipient —
+/// `DrawTriangle` and `Camera` no-op (the warn-storm sink-replacement role
+/// pre-issue-603 Phase 2), `CaptureFrame` replies `Err` so MCP
+/// `capture_frame` fails fast instead of timing out.
+///
+/// A ZST carrying only the addressing; the state-bearing runtime
+/// (`HeadlessRenderCapabilityState`, holding the captured `HubOutbound`)
+/// lives behind the default `runtime` gate in `headless_runtime` — no
+/// `render-native` dep, so it compiles on a no-GPU headless build.
+///
+/// Headless chassis composes one of [`Self`] / [`RenderCapability`], never
+/// both — the chassis builder rejects double-claiming a mailbox.
+pub struct HeadlessRenderCapability;
+
+#[actor(singleton)]
+impl NativeActor for HeadlessRenderCapability {
+    /// The runtime state this identity boots into (ADR-0122 split): the
+    /// captured `HubOutbound` the `Err`/no-op handlers reply through.
+    type State = HeadlessRenderCapabilityState;
+
+    type Config = ();
+
+    const NAMESPACE: &'static str = "aether.render";
+
+    fn init(
+        _config: (),
+        ctx: &mut NativeInitCtx<'_>,
+    ) -> Result<HeadlessRenderCapabilityState, BootError> {
+        let outbound = ctx.mailer().outbound().cloned().ok_or_else(|| {
+            BootError::Other(Box::new(io::Error::other(
+                "HubOutbound must be wired on Mailer before \
+                     HeadlessRenderCapability::init (chassis main connects the hub before \
+                     the Builder chain)",
+            )))
+        })?;
+        Ok(HeadlessRenderCapabilityState { outbound })
+    }
+
+    /// `DrawTriangle` lands here as a no-op so headless boots of
+    /// desktop-designed components (which emit `DrawTriangle` every
+    /// tick) don't trip the unknown-mailbox warn path.
+    #[handler]
+    fn on_draw_triangle(
+        _state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        _mails: &[DrawTriangle],
+    ) {
+    }
+
+    /// `Camera` lands here as a no-op for the same reason as
+    /// `on_draw_triangle` — desktop-designed components publish
+    /// `aether.camera` every tick.
+    #[handler]
+    fn on_camera(_state: &mut Self::State, _ctx: &mut NativeCtx<'_>, _mail: Camera) {}
+
+    /// `CaptureFrame` replies `Err` inline so MCP `capture_frame`
+    /// fails fast on headless instead of hanging on a reply that
+    /// never comes. Mirrors ADR-0035 §Consequences fail-fast shape
+    /// for `set_window_mode`.
+    #[handler::manual]
+    fn on_capture_frame(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_, Manual>,
+        _mail: CaptureFrame,
+    ) {
+        state.outbound.send_reply(
+            ctx.reply_target(),
+            &CaptureFrameResult::Err {
+                error: "unsupported on headless chassis — no GPU".to_owned(),
+            },
+        );
+    }
+
+    /// `CreateTexture` replies `Err` inline so an agent that creates a
+    /// texture against a headless chassis fails fast instead of
+    /// waiting on a reply that never comes — same fail-fast shape as
+    /// `on_capture_frame` (ADR-0105).
+    #[handler::manual]
+    fn on_create_texture(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_, Manual>,
+        _mail: CreateTexture,
+    ) {
+        state.outbound.send_reply(
+            ctx.reply_target(),
+            &CreateTextureResult::Err {
+                error: "unsupported on headless chassis — no GPU".to_owned(),
+            },
+        );
+    }
+
+    /// `UpdateTexture` lands here as a no-op so desktop-designed
+    /// components running on headless don't trip the unknown-mailbox
+    /// warn path — mirrors `on_draw_triangle`.
+    #[handler]
+    fn on_update_texture(_state: &mut Self::State, _ctx: &mut NativeCtx<'_>, _mail: UpdateTexture) {
+    }
+
+    /// `DrawTexturedQuads` lands here as a no-op for the same reason
+    /// as `on_update_texture`.
+    #[handler]
+    fn on_draw_textured_quads(
+        _state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        _mail: DrawTexturedQuads,
+    ) {
+    }
+
+    /// `DrawSolidQuads` lands here as a no-op for the same reason
+    /// as `on_draw_textured_quads`.
+    #[handler]
+    fn on_draw_solid_quads(
+        _state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        _mail: DrawSolidQuads,
+    ) {
+    }
+}
+
+#[cfg(all(test, feature = "runtime"))]
+mod headless_tests {
+    use super::*;
+    use crate::test_chassis::{decode_reply, test_mailer_and_rx};
+    use aether_data::{MailboxId, Source, SourceAddr};
+    use aether_data::{SessionToken, Uuid};
+    use aether_substrate::actor::native::NativeCtx;
+    use aether_substrate::actor::native::binding::NativeBinding;
+
+    /// ADR-0105: `create_texture` against a headless chassis replies
+    /// `Err` (fail-fast, no GPU) rather than hanging on a reply that
+    /// never comes — mirrors `capture_frame`'s headless shape.
+    #[test]
+    fn headless_create_texture_replies_err() {
+        let (mailer, rx) = test_mailer_and_rx();
+        let outbound = mailer
+            .outbound()
+            .cloned()
+            .expect("test_mailer_and_rx wires a loopback outbound");
+        let mut state = HeadlessRenderCapabilityState { outbound };
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            MailboxId(0),
+        ));
+        let mut ctx = NativeCtx::new_dispatching(
+            &transport,
+            Source::to(SourceAddr::Session(SessionToken(Uuid::nil()))),
+            aether_data::MailId::NONE,
+            aether_data::MailId::NONE,
+        );
+        HeadlessRenderCapability::on_create_texture(
+            &mut state,
+            &mut ctx,
+            CreateTexture {
+                width: 2,
+                height: 2,
+                pixels: vec![0u8; 16],
+            },
+        );
+        match decode_reply::<CreateTextureResult>(&rx) {
+            CreateTextureResult::Err { error } => {
+                assert!(
+                    error.contains("headless"),
+                    "headless create_texture error should name the chassis; got {error}",
+                );
+            }
+            CreateTextureResult::Ok { .. } => {
+                panic!("headless create_texture must reply Err, not assign an id")
             }
         }
+    }
 
-        /// ADR-0107 §4: `draw_solid_quads` on the headless chassis is a
-        /// no-op — no panic, no reply, nothing accumulated. Mirrors the
-        /// `on_draw_textured_quads` no-op contract.
-        #[test]
-        fn headless_draw_solid_quads_is_noop() {
-            use aether_kinds::QuadSpace;
+    /// ADR-0107 §4: `draw_solid_quads` on the headless chassis is a
+    /// no-op — no panic, no reply, nothing accumulated. Mirrors the
+    /// `on_draw_textured_quads` no-op contract.
+    #[test]
+    fn headless_draw_solid_quads_is_noop() {
+        use aether_kinds::QuadSpace;
 
-            let (mailer, _rx) = test_mailer_and_rx();
-            let outbound = mailer
-                .outbound()
-                .cloned()
-                .expect("test_mailer_and_rx wires a loopback outbound");
-            let cap = HeadlessRenderCapability { outbound };
-            let transport = Arc::new(NativeBinding::new_for_test(
-                Arc::clone(&mailer),
-                MailboxId(0),
-            ));
-            let mut ctx = NativeCtx::new(
-                &transport,
-                Source::to(SourceAddr::Session(SessionToken(Uuid::nil()))),
-                aether_data::MailId::NONE,
-                aether_data::MailId::NONE,
-            );
-            cap.on_draw_solid_quads(
-                &mut ctx,
-                DrawSolidQuads {
-                    space: QuadSpace::Screen,
-                    quads: vec![],
-                },
-            );
-            // No panic and no reply enqueued — the no-op dropped the mail cleanly.
-        }
+        let (mailer, _rx) = test_mailer_and_rx();
+        let outbound = mailer
+            .outbound()
+            .cloned()
+            .expect("test_mailer_and_rx wires a loopback outbound");
+        let mut state = HeadlessRenderCapabilityState { outbound };
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            MailboxId(0),
+        ));
+        let mut ctx = NativeCtx::new(
+            &transport,
+            Source::to(SourceAddr::Session(SessionToken(Uuid::nil()))),
+            aether_data::MailId::NONE,
+            aether_data::MailId::NONE,
+        );
+        HeadlessRenderCapability::on_draw_solid_quads(
+            &mut state,
+            &mut ctx,
+            DrawSolidQuads {
+                space: QuadSpace::Screen,
+                quads: vec![],
+            },
+        );
+        // No panic and no reply enqueued — the no-op dropped the mail cleanly.
     }
 }

--- a/crates/aether-capabilities/src/render/runtime.rs
+++ b/crates/aether-capabilities/src/render/runtime.rs
@@ -1,0 +1,63 @@
+//! The `aether.render` runtime half (ADR-0122 identity/runtime split).
+//! Compiled only under `feature = "render-native"` (the `mod runtime;`
+//! declaration in the parent carries the gate, matching the `#[actor(…,
+//! runtime_feature = "render-native")]` override on the impl), so a
+//! transport-only or marker-only `render` build of the [`RenderCapability`]
+//! identity never names these types nor pulls the wgpu-bound substrate
+//! runtime through this cap. The substrate-typed imports + GPU-bound
+//! helpers are gated once by this module rather than line-by-line; the
+//! `#[actor] impl` reaches the state, ctx, and accumulator helpers through
+//! the single `use runtime::*` glob in the parent.
+
+// `Arc` is named here only by the state struct's field types; the parent
+// `#[actor] impl` gets its own `Arc` from the shared `any(render-native,
+// runtime)` import in `mod.rs`, so this stays a private import to avoid a
+// redundant re-export. The substrate ctx types (`NativeActor` / `NativeCtx`
+// / `NativeInitCtx` / `BootError` / `Manual` / `CaptureFrameResult`) the
+// `#[actor] impl` names come from that same shared seam, not from here.
+use std::sync::Arc;
+
+pub use std::sync::atomic::{AtomicU64, Ordering};
+pub use std::sync::{Mutex, OnceLock};
+
+pub use aether_data::Kind;
+pub use aether_substrate::capture::PendingCapture;
+pub use aether_substrate::mail::helpers::resolve_bundle;
+pub use aether_substrate::mail::mailer::Mailer;
+pub use aether_substrate::mail::registry::Registry;
+pub use aether_substrate::render::IDENTITY_VIEW_PROJ;
+
+pub use super::config::RenderConfig;
+pub use super::pipeline::RenderHandles;
+
+// These seam items are `pub(super)` (visible in `render`), so the
+// re-export back up to the parent `#[actor] impl` keeps that visibility —
+// `pub use` would try to widen them to `pub` and fail (E0364/E0365).
+// `pub(super)` of this module resolves to `render`, the exact scope the
+// glob in `mod.rs` reaches them from.
+pub(super) use super::capture::resolve_reference;
+pub(super) use super::quad::QuadBatch;
+pub(super) use super::texture::{
+    StagedTexture, TextureRegistry, WHITE_TEXTURE_ID, expected_pixel_bytes,
+};
+
+/// `aether.render` runtime state (ADR-0066). Holds [`RenderHandles`] (the
+/// driver-facing accumulator state plus GPU bundle) and the per-instance
+/// [`RenderConfig`], plus the substrate registry + mailer captured at init
+/// for the `capture_frame` resolve-bundle / push-pre-mails path. The
+/// dispatcher holds this as the cap's state and routes envelopes through
+/// the macro-emitted `Dispatch` impl; the addressing identity is the
+/// distinct ZST [`super::RenderCapability`]. Driver glue fetches the
+/// handle bundle via `DriverCtx::handle::<RenderHandles>()` (published in
+/// `init`), not through this state. Living in this private module keeps it
+/// `pub`-enough to satisfy the `NativeActor::State` interface without
+/// exposing it as crate-public API.
+pub struct RenderCapabilityState {
+    pub(super) handles: RenderHandles,
+    pub(super) config: RenderConfig,
+    /// Substrate registry and mailer captured at init for the
+    /// `capture_frame` resolve-bundle / push-pre-mails path. Both are
+    /// Arc-shared with every other cap and the chassis loop.
+    pub(super) registry: Arc<Registry>,
+    pub(super) mailer: Arc<Mailer>,
+}

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -409,9 +409,9 @@ impl DesktopChassis {
 
         // Issue 552 stage 2d: render is a NativeActor. The chassis
         // builder constructs the cap inside `init` (called from
-        // `with_actor::<RenderCapability>(config)`); the driver pulls
-        // `Arc<RenderCapability>` via `DriverCtx::actor` and clones
-        // `.handles()` from there.
+        // `with_actor::<RenderCapability>(config)`); `init` publishes the
+        // `RenderHandles` bundle on the exported-handle map, and the driver
+        // fetches it via `DriverCtx::handle::<RenderHandles>()`.
         let driver = DesktopDriverCapability {
             event_loop,
             boot,


### PR DESCRIPTION
Closes #2331.

## Summary

Splits both `aether.render` capabilities into the ADR-0122 identity/runtime shape, mirroring the #2317 fs demonstrator. `RenderCapability` (wgpu) and `HeadlessRenderCapability` become ZST addressing identities; their state moves into two runtime modules — `render/runtime.rs` gated `render-native` via `#[actor(singleton, runtime_feature = "render-native")]`, and `render/headless_runtime.rs` under the default `runtime` gate (compiles with `render-native` off). Handlers reshape to `state: &mut Self::State`, with the slice + manual handler shapes carried over unchanged. The dead `RenderCapability::handles()` accessor is dropped — the live path is `DriverCtx::handle::<RenderHandles>()`. No wire / kind / ABI / feature change.

## Test plan

`cargo clippy --workspace --all-targets -- -D warnings` (feature-unified: render-native + runtime on) clean; `-p aether-capabilities --all-features` (desktop dual-glob path) clean. Full attested validation (clippy / doc / test / desktop / qodana under `witness`) green via `--attest`.

## Generated by

`/implement` — agent execution of scoped issue #2331.
