### PR TITLE
fix(workflow): give attest.sh a per-run CARGO_TARGET_DIR for parallel attests

### DIFF
--- a/docs/guide/local-verification.md
+++ b/docs/guide/local-verification.md
@@ -19,7 +19,7 @@ for most contributors; the CI runner covers the case you skip it.
 
 `scripts/attest.sh` writes three kinds of scratch under a single base directory:
 
-- a persistent `CARGO_TARGET_DIR` (incremental build cache, kept warm across runs)
+- a per-run `CARGO_TARGET_DIR` (build artifacts, nested under `RUNDIR`, removed on exit)
 - a persistent qodana analysis cache (JBR downloads and prior-analysis snapshots)
 - a per-run fresh clone of HEAD, `RUNDIR`, removed on exit
 
@@ -51,9 +51,12 @@ AETHER_ATTEST_BASE=/mnt/large-volume/.cache
 ```
 
 Substitute the path to a filesystem with enough room for build artifacts. On a
-fresh machine, a few gigabytes for the Rust target cache plus a few hundred
-megabytes for the qodana cache is a reasonable floor; an incremental warm cache
-grows as the codebase does.
+fresh machine, a few gigabytes per attest run for the Rust target cache plus a
+few hundred megabytes for the qodana cache is a reasonable floor; each
+concurrent attest run carries its own full target tree (the default
+`CARGO_TARGET_DIR` is per-run and removed on exit), so N parallel runs need N
+times the target space. Pin `CARGO_TARGET_DIR` explicitly to share one warm
+cache across runs — at the cost of serializing on cargo's target lock.
 
 The `.env` file is gitignored and not sourced by `scripts/preflight.sh` (which
 has no comparable scratch cost), so adding the file has no effect on the fast

--- a/scripts/attest.sh
+++ b/scripts/attest.sh
@@ -94,14 +94,8 @@ QODANA_BASE="$(git merge-base HEAD origin/main)"
 # Must stay a Docker-shared path (qodana's container mounts the clone).
 AETHER_ATTEST_BASE="${AETHER_ATTEST_BASE:-$HOME/.cache}"
 
-# Keep build artifacts out of the clone the git attestor walks, so its tree
-# status stays clean and the material walk stays source-only. Persisted across
-# runs so the producer stays incrementally warm.
-export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$AETHER_ATTEST_BASE/aether-attest-target}"
-mkdir -p "$CARGO_TARGET_DIR"
-
 # Keep qodana's analysis cache and JBR downloads off $HOME and on the same
-# relocatable volume as CARGO_TARGET_DIR. Persisted across runs for incremental
+# relocatable volume as AETHER_ATTEST_BASE. Persisted across runs for incremental
 # warmth; root-owned droppings here are reclaimable via the existing
 # throwaway-root-container reap in the qodana) case below.
 QODANA_CACHE_DIR="${QODANA_CACHE_DIR:-$AETHER_ATTEST_BASE/aether-attest-qodana-cache}"
@@ -116,6 +110,15 @@ RUNDIR="$(mktemp -d "$AETHER_ATTEST_BASE/aether-attest-run.XXXXXX")"
 RUN="$RUNDIR/scan"
 git clone --quiet "$ROOT" "$RUN"
 git -C "$RUN" -c advice.detachedHead=false checkout --quiet "$HEAD_SHA"
+
+# Keep build artifacts out of the clone the git attestor walks ($RUNDIR/scan), so
+# its tree status stays clean and the material walk stays source-only. The default
+# target dir is per-run (nested under RUNDIR), isolating concurrent attests from
+# each other's cargo lock — the trade is no cross-run incremental reuse on the
+# default path. Pin CARGO_TARGET_DIR explicitly to opt back into a shared warm cache
+# (e.g. for /land's re-attest, which pins its own path).
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$RUNDIR/target}"
+mkdir -p "$CARGO_TARGET_DIR"
 
 # Ephemeral PKCS8 signing key in a private temp dir; shredded on exit.
 KEYDIR="$(mktemp -d)"


### PR DESCRIPTION
Closes #2363.

## Summary

`scripts/attest.sh` gave every run a unique `RUNDIR` but a single shared `CARGO_TARGET_DIR` (derived from the host-pinned `AETHER_ATTEST_BASE`), so parallel `--attest` runs launched by `/implement --sweep` serialized on cargo's target lock instead of building in parallel.

The default `CARGO_TARGET_DIR` is now a per-run path nested under the existing per-run `RUNDIR` (`$RUNDIR/target`), giving each concurrent attest a fully isolated build tree. The export is reordered to after `RUNDIR` exists. The `${CARGO_TARGET_DIR:-…}` form is preserved so an explicit caller pin (e.g. `/land`'s re-attest) still wins, and the existing EXIT cleanup trap already removes the per-run subtree — no new cleanup code. Trade: no cross-run incremental warm cache on the default path.

## Test plan

Shell + doc change, no unit-test surface. Verified by inspection that no consumer of `CARGO_TARGET_DIR` sits above the new export site, that `$RUNDIR/target` stays external to the git-attestor-walked clone (`$RUNDIR/scan`), and that the existing cleanup trap covers the new dir. `docs/guide/local-verification.md` updated to describe the per-run semantics and the N×-target disk cost of concurrent runs.

## Generated by

`/implement --sweep` — agent execution of scoped issue #2363.
