### PR TITLE
feat(actor-derive): runtime impl attribute and struct-hosted actor macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "aether-test-fixtures-split-cap"
+version = "0.3.0-alpha"
+dependencies = [
+ "aether-actor",
+ "aether-data",
+ "aether-substrate",
+ "bytemuck",
+ "inventory",
+]
+
+[[package]]
 name = "aether-test-fixtures-stateful-reshaped"
 version = "0.3.0-alpha"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "crates/aether-test-fixtures/aether-test-fixtures-bundle",
     "crates/aether-test-fixtures/aether-test-fixtures-stateful-typed",
     "crates/aether-test-fixtures/aether-test-fixtures-stateful-reshaped",
+    "crates/aether-test-fixtures/aether-test-fixtures-split-cap",
     "xtask",
 ]
 exclude = [

--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -40,6 +40,9 @@
 //! `SchemaType::Bytes` / `LabelNode::Anonymous` directly when it
 //! sees `Vec<u8>`. Every other shape goes through trait dispatch.
 
+use std::fs;
+use std::path::Path;
+
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
@@ -48,8 +51,8 @@ use syn::parse::Parser;
 use syn::spanned::Spanned;
 use syn::{
     Attribute, Data, DataEnum, DataStruct, DeriveInput, Expr, ExprLit, Fields, FnArg,
-    GenericArgument, ImplItem, ItemImpl, Lit, Meta, PathArguments, ReturnType, Signature, Type,
-    parse_macro_input,
+    GenericArgument, ImplItem, ItemImpl, ItemStruct, Lit, Meta, PathArguments, ReturnType,
+    Signature, Type, parse_macro_input,
 };
 
 #[proc_macro_derive(Kind, attributes(kind))]
@@ -742,8 +745,61 @@ pub fn actor(attr: TokenStream, item: TokenStream) -> TokenStream {
         Ok(opts) => opts,
         Err(e) => return e.to_compile_error().into(),
     };
+    // ADR-0123: `#[actor]` may now sit on the capability *struct* (the
+    // struct-hosted identity form) as well as on an `impl WasmActor /
+    // NativeActor for X` block (the impl-hosted form). A struct input takes
+    // the disk-read identity path — it parses the sibling runtime module file,
+    // lifts the `NAMESPACE` const + `#[handler]` kinds out of the
+    // `impl NativeActor` there, and emits the always-on identity markers
+    // against the struct. Any other input is the existing impl-hosted path.
+    let item2: TokenStream2 = item.clone().into();
+    if let Ok(item_struct) = syn::parse2::<ItemStruct>(item2) {
+        return match expand_struct_hosted_actor(&item_struct, &opts) {
+            Ok(ts) => ts.into(),
+            Err(e) => e.to_compile_error().into(),
+        };
+    }
     let item = parse_macro_input!(item as ItemImpl);
     match expand_handlers(item, &opts) {
+        Ok(ts) => ts.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+/// `#[runtime]` (ADR-0123): sits on the `impl NativeActor for Cap` block in a
+/// capability's `mod runtime;` file. It emits only the gated runtime surface —
+/// `Lifecycle`, `Dispatch`, the `NativeActor` composition pinning `type State`,
+/// and the handler bodies as an inherent impl — and consumes the `NAMESPACE`
+/// const (lifted into `Addressable` by the struct-side `#[actor]`). It emits no
+/// addressing markers; those come from the struct. The runtime impls ride the
+/// `#[cfg]` on the `mod runtime;` line, so this attribute adds no gate of its
+/// own.
+#[proc_macro_attribute]
+pub fn runtime(attr: TokenStream, item: TokenStream) -> TokenStream {
+    if !attr.is_empty() {
+        return syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "#[runtime] takes no arguments",
+        )
+        .to_compile_error()
+        .into();
+    }
+    let item = parse_macro_input!(item as ItemImpl);
+    let is_native_actor = item
+        .trait_
+        .as_ref()
+        .and_then(|(_, p, _)| p.segments.last())
+        .is_some_and(|s| s.ident == "NativeActor");
+    if !is_native_actor {
+        return syn::Error::new_spanned(
+            &item.self_ty,
+            "#[runtime] expects `impl NativeActor for X` — it emits the gated native \
+             runtime surface for a struct-hosted (`#[actor]`-on-the-struct) split capability",
+        )
+        .to_compile_error()
+        .into();
+    }
+    match expand_native_actor_trait(item, &ActorOpts::default(), NativeEmit::RuntimeOnly) {
         Ok(ts) => ts.into(),
         Err(e) => e.to_compile_error().into(),
     }
@@ -766,6 +822,11 @@ struct ActorOpts {
     /// names it here so the runtime impls gate on that feature rather than the
     /// generic `runtime`. `None` ⇒ the default `feature = "runtime"`.
     runtime_feature: Option<String>,
+    /// ADR-0123: the runtime module name the struct-hosted `#[actor]` reads off
+    /// disk, from a bare positional ident — `#[actor(singleton, other)]` reads
+    /// `other.rs`. `None` ⇒ the conventional sibling `runtime`. Only consulted
+    /// on the struct-hosted path; the impl-hosted path ignores it.
+    runtime_module: Option<syn::Ident>,
 }
 
 fn parse_actor_opts(attr: TokenStream2) -> syn::Result<ActorOpts> {
@@ -797,10 +858,25 @@ fn parse_actor_opts(attr: TokenStream2) -> syn::Result<ActorOpts> {
             let lit: syn::LitStr = value.parse()?;
             opts.runtime_feature = Some(lit.value());
             Ok(())
+        } else if meta.path.get_ident().is_some() && !meta.input.peek(syn::Token![=]) {
+            // ADR-0123: a bare positional ident names the runtime module the
+            // struct-hosted `#[actor]` reads off disk (default `runtime`).
+            let id = meta
+                .path
+                .get_ident()
+                .expect("checked is_some above")
+                .clone();
+            if opts.runtime_module.is_some() {
+                return Err(
+                    meta.error("duplicate runtime module name in #[actor] — name it at most once")
+                );
+            }
+            opts.runtime_module = Some(id);
+            Ok(())
         } else {
             Err(meta.error(
                 "unrecognised #[actor] argument; expected `singleton`, `instanced`, \
-                 or `runtime_feature = \"name\"`",
+                 `runtime_feature = \"name\"`, or a bare runtime module name",
             ))
         }
     });
@@ -884,7 +960,7 @@ pub fn fallback(_attr: TokenStream, _item: TokenStream) -> TokenStream {
 /// mostly for completeness.
 #[proc_macro_attribute]
 pub fn local(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(item as syn::ItemStruct);
+    let input = parse_macro_input!(item as ItemStruct);
     let name = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     quote! {
@@ -934,7 +1010,7 @@ pub fn capability(attr: TokenStream, item: TokenStream) -> TokenStream {
         .to_compile_error()
         .into();
     }
-    let mut item = parse_macro_input!(item as syn::ItemStruct);
+    let mut item = parse_macro_input!(item as ItemStruct);
     // Issue 552 stage 4: gate fields on `not(target_family = "wasm")`
     // to match the macro-emitted `NativeActor` / `NativeDispatch`
     // impls. Wasm builds see the cap struct with no fields (a pure
@@ -999,7 +1075,7 @@ fn expand_handlers(item: ItemImpl, opts: &ActorOpts) -> syn::Result<TokenStream2
             .map(|s| s.ident.to_string())
             .unwrap_or_default();
         match last.as_str() {
-            "NativeActor" => expand_native_actor_trait(item, opts),
+            "NativeActor" => expand_native_actor_trait(item, opts, NativeEmit::Full),
             // `WasmActor` is the post-552 trait name; `Component` is
             // the back-compat alias retained until stage 4.
             "WasmActor" | "Component" => expand_wasm_actor(item, opts),
@@ -1966,12 +2042,33 @@ fn expand_wasm_actor(item: ItemImpl, opts: &ActorOpts) -> syn::Result<TokenStrea
 ///
 /// `#[fallback]` is rejected — native actors are typed receivers;
 /// unknown kinds are programming errors, not fallback paths.
+/// What an `impl NativeActor for X` expansion emits, selecting between the two
+/// attribute sites that drive a native cap (ADR-0122 / ADR-0123).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum NativeEmit {
+    /// Impl-hosted `#[actor] impl NativeActor for X`: the always-on addressing
+    /// markers (`Addressable` / `HandlesKind` / name inventory) *plus* the
+    /// runtime surface, the latter `#[cfg]`-gated (split caps gate on the
+    /// runtime feature, un-split on `not(wasm)`).
+    Full,
+    /// Struct-hosted `#[runtime] impl NativeActor for X` (ADR-0123): only the
+    /// runtime surface (`Lifecycle` / `Dispatch` / `NativeActor` / inherent
+    /// handler impl), ungated — the `mod runtime;` line carries the `#[cfg]`.
+    /// The addressing markers come from the struct-side `#[actor]`, so none are
+    /// emitted here and the `NAMESPACE` const is consumed (dropped).
+    RuntimeOnly,
+}
+
 // Emits the full `NativeActor` surface in one walk: dispatch table,
 // `init` wrapper, `HandlesKind<K>` impls per handler, plus the
 // dispatch ABI plumbing. Splitting into helpers would force shared
 // per-handler context structs without saving readability.
 #[allow(clippy::too_many_lines)]
-fn expand_native_actor_trait(item: ItemImpl, opts: &ActorOpts) -> syn::Result<TokenStream2> {
+fn expand_native_actor_trait(
+    item: ItemImpl,
+    opts: &ActorOpts,
+    emit: NativeEmit,
+) -> syn::Result<TokenStream2> {
     let self_ty = &item.self_ty;
     let generics = &item.generics;
     let (impl_generics, _ty_generics, where_clause) = generics.split_for_impl();
@@ -2239,58 +2336,40 @@ fn expand_native_actor_trait(item: ItemImpl, opts: &ActorOpts) -> syn::Result<To
              `const NAMESPACE: &'static str = ...` so the marker `impl Addressable` can carry it",
         ));
     }
-    // NAMESPACE passes through unchanged because its RHS is a
-    // primitive that doesn't require resolution.
-    let const_tokens: Vec<TokenStream2> = consts.iter().map(|c| quote! { #c }).collect();
-    // ADR-0119: a native actor's cardinality picks its resolver — `One`
-    // (default, or `#[actor(singleton)]`) or `Many` (`#[actor(instanced)]`).
-    // `Singleton` / `Instanced` are derived from it; the old hand-written
-    // `impl Singleton/Instanced for X {}` next to `#[actor]` is retired.
-    let resolver_ty = if matches!(opts.cardinality, Some(ActorCardinality::Instanced)) {
-        quote! { ::aether_actor::Many }
-    } else {
-        quote! { ::aether_actor::One }
-    };
-    let actor_impl = if consts.is_empty() {
-        quote! {}
-    } else {
-        quote! {
-            impl #impl_generics ::aether_actor::Addressable for #self_ty #where_clause {
-                #(#const_tokens)*
-                type Resolver = #resolver_ty;
-            }
-        }
-    };
+    // NAMESPACE passes through unchanged because its RHS is a primitive that
+    // doesn't require resolution. The `Addressable` body restates the const
+    // (built inside the helper) so the struct-hosted path (which has only the
+    // harvested expr) and this path share one emission helper.
+    let namespace_expr: &Expr = consts
+        .iter()
+        .find_map(|c| (c.ident == "NAMESPACE").then_some(&c.expr))
+        .expect("has_namespace checked above");
 
-    // Issue 576 + issue 603: only-fallback (true catch-all) caps emit
-    // a single blanket `impl<K: Kind> HandlesKind<K> for X {}` so any
-    // typed `ctx.actor::<X>().send(&payload)` compiles for every K.
-    // Strict receivers and hybrid caps (handlers + fallback safety
-    // net) keep per-handler impls — only declared kinds compile via
-    // typed sends; the fallback handles unknown kinds at runtime
-    // (e.g. mail arriving by mailbox name).
-    let handles_kind_impls: Vec<TokenStream2> = if fallback.is_some() && handlers.is_empty() {
-        let kind_param: syn::Ident = syn::parse_quote!(__AetherCatchAllK);
-        let mut blanket_generics = generics.clone();
-        blanket_generics.params.push(syn::parse_quote!(
-            #kind_param: ::aether_actor::__macro_internals::Kind
-        ));
-        let (blanket_impl, _, blanket_where) = blanket_generics.split_for_impl();
-        vec![quote! {
-            impl #blanket_impl ::aether_actor::HandlesKind<#kind_param>
-                for #self_ty #blanket_where {}
-        }]
-    } else {
-        handlers
-            .iter()
-            .map(|h| {
-                let kind_ty = &h.kind_ty;
-                quote! {
-                    impl #impl_generics ::aether_actor::HandlesKind<#kind_ty>
-                        for #self_ty #where_clause {}
-                }
-            })
-            .collect()
+    // ADR-0122 / ADR-0123: the always-on addressing markers (`Addressable` /
+    // per-kind `HandlesKind` / name inventory) are shared with the struct-hosted
+    // `#[actor]` path. The impl-hosted form emits them here (`Full`); the
+    // `#[runtime]` form (`RuntimeOnly`) leaves them to the struct's `#[actor]`.
+    let markers = match emit {
+        NativeEmit::Full => {
+            // Mail handlers only — task completions get no `HandlesKind` /
+            // name-inventory entry (a completion is not inbound mail).
+            let handler_kinds: Vec<HandlerMarker> = handlers
+                .iter()
+                .map(|h| (h.kind_ty.clone(), h.reply.manifest_kind().cloned()))
+                .collect();
+            emit_native_identity_markers(
+                self_ty,
+                generics,
+                namespace_expr,
+                opts.cardinality,
+                &handler_kinds,
+                fallback.is_some(),
+                // The name-inventory entry is split-only (an un-split cap
+                // registers its name through the chassis builder, not the macro).
+                is_split,
+            )
+        }
+        NativeEmit::RuntimeOnly => quote! {},
     };
 
     // ADR-0081 retired the chassis-pushed `ConfigureLogDrain` mail;
@@ -2563,43 +2642,6 @@ fn expand_native_actor_trait(item: ItemImpl, opts: &ActorOpts) -> syn::Result<To
         }
     };
 
-    // ADR-0109 §5: the native analogue of the wasm `aether.kinds.inputs`
-    // custom section. Submit one link-time `HandlerEntry` per
-    // `#[handler]` — the owning `NAMESPACE`, the input kind (id + name),
-    // and the reply kind id read off the return type (the same
-    // `classify_handler_reply` the auto-reply arm uses). The
-    // `aether.inventory` cap folds these into the
-    // `aether.inventory.handlers` reply, so a native cap surfaces its
-    // `In -> Out` the way `describe_component` does for a wasm component.
-    // Gated on `not(wasm32)` to match the rest of the native surface
-    // (the `inventory` crate doesn't link on wasm32). Skipped for a
-    // generic native actor — none exist, and `<Self as Addressable>::NAMESPACE`
-    // wouldn't const-resolve in the non-generic inventory static.
-    let handler_inventory = if generics.params.is_empty() {
-        let submissions = handlers.iter().map(|h| {
-            let kind_ty = &h.kind_ty;
-            let reply_expr = if let Some(reply_ty) = h.reply.manifest_kind() {
-                quote! { ::core::option::Option::Some(<#reply_ty as ::aether_data::Kind>::ID) }
-            } else {
-                quote! { ::core::option::Option::None }
-            };
-            quote! {
-                #[cfg(not(target_family = "wasm"))]
-                ::aether_data::name_inventory::inventory::submit! {
-                    ::aether_data::name_inventory::HandlerEntry {
-                        namespace: <#self_ty as ::aether_actor::Addressable>::NAMESPACE,
-                        id: <#kind_ty as ::aether_data::Kind>::ID,
-                        name: <#kind_ty as ::aether_data::Kind>::NAME,
-                        reply: #reply_expr,
-                    }
-                }
-            }
-        });
-        quote! { #(#submissions)* }
-    } else {
-        quote! {}
-    };
-
     // Issue 552 stage 4: NativeActor + NativeDispatch + the inherent
     // handler-method impl all reach for `::aether_substrate::*` paths
     // and native-only types in their bodies. They're emitted under
@@ -2634,14 +2676,19 @@ fn expand_native_actor_trait(item: ItemImpl, opts: &ActorOpts) -> syn::Result<To
     // native half lives behind `render-native` / `audio-native` / … name it so
     // a plain-`runtime` build never tries to compile their substrate-typed
     // impls without the heavy dep).
-    let runtime_gate = if is_split {
-        if let Some(feat) = opts.runtime_feature.as_deref() {
-            quote! { #[cfg(feature = #feat)] }
-        } else {
-            quote! { #[cfg(feature = "runtime")] }
+    let runtime_gate = match emit {
+        // ADR-0123: `#[runtime]` emits the runtime surface ungated — the
+        // `#[cfg]` rides the author-written `mod runtime;` line, so the impls
+        // already only exist in a build where the runtime module is present.
+        NativeEmit::RuntimeOnly => quote! {},
+        NativeEmit::Full if is_split => {
+            if let Some(feat) = opts.runtime_feature.as_deref() {
+                quote! { #[cfg(feature = #feat)] }
+            } else {
+                quote! { #[cfg(feature = "runtime")] }
+            }
         }
-    } else {
-        quote! { #[cfg(not(target_family = "wasm"))] }
+        NativeEmit::Full => quote! { #[cfg(not(target_family = "wasm"))] },
     };
 
     // Composed shape: `Lifecycle<S>::wire` / `unwire` forward to the inherent
@@ -2674,57 +2721,14 @@ fn expand_native_actor_trait(item: ItemImpl, opts: &ActorOpts) -> syn::Result<To
         quote! {}
     };
 
-    // A split (`#[actor] impl NativeActor`) cap carries its own always-on
-    // name-inventory submission, keyed by cardinality off the single
-    // `#namespace_expr` and gated `not(wasm)` so it rides the transport build
-    // but never the wasm header build. Only the split path emits it.
-    let name_entry = if is_split && has_namespace {
-        let namespace_expr = consts.iter().find_map(|c| {
-            if c.ident == "NAMESPACE" {
-                Some(&c.expr)
-            } else {
-                None
-            }
-        });
-        match (namespace_expr, opts.cardinality) {
-            (Some(ns), Some(ActorCardinality::Instanced)) => quote! {
-                #[cfg(not(target_family = "wasm"))]
-                ::aether_data::name_inventory::inventory::submit! {
-                    ::aether_data::name_inventory::TemplateEntry {
-                        domain: ::aether_data::MAILBOX_DOMAIN,
-                        prefix: #ns,
-                        template: ":{subname}",
-                        param: ::aether_data::name_inventory::ParamKind::Dynamic,
-                    }
-                }
-            },
-            (Some(ns), _) => quote! {
-                #[cfg(not(target_family = "wasm"))]
-                ::aether_data::name_inventory::inventory::submit! {
-                    ::aether_data::name_inventory::NameEntry {
-                        domain: ::aether_data::MAILBOX_DOMAIN,
-                        name: #ns,
-                    }
-                }
-            },
-            (None, _) => quote! {},
-        }
-    } else {
-        quote! {}
-    };
-
     Ok(quote! {
-        // Always-on addressing markers: the identity carries `Addressable`
-        // (`NAMESPACE` / `Resolver`), the per-handler `HandlesKind<K>` impls,
-        // and (split caps) the name-inventory entry — none of which name the
-        // runtime state or pull `aether_substrate`.
-        #actor_impl
-
-        #(#handles_kind_impls)*
-
-        #name_entry
-
-        #handler_inventory
+        // Always-on addressing markers (`Full` only): the identity carries
+        // `Addressable` (`NAMESPACE` / `Resolver`), the per-handler
+        // `HandlesKind<K>` impls, and (split caps) the name-inventory entry —
+        // none of which name the runtime state or pull `aether_substrate`. On
+        // the `RuntimeOnly` (`#[runtime]`) path this is empty: the struct-side
+        // `#[actor]` emits the markers.
+        #markers
 
         // Composed shape: the addressing identity carries the two native
         // behaviour traits parameterised by the runtime state, plus the
@@ -2789,6 +2793,299 @@ fn expand_native_actor_trait(item: ItemImpl, opts: &ActorOpts) -> syn::Result<To
             #(#helper_methods)*
         }
     })
+}
+
+/// One mail handler's marker payload: its inbound kind type plus the manifest
+/// reply kind read off the handler's return type (`None` for `-> ()`).
+type HandlerMarker = (Type, Option<Type>);
+
+/// Emit the always-on native addressing markers shared by the impl-hosted
+/// `#[actor]` path (ADR-0122) and the struct-hosted one (ADR-0123): the
+/// `Addressable` impl (`NAMESPACE` + the cardinality resolver), one
+/// `HandlesKind<K>` per mail handler (a single blanket impl for a
+/// fallback-only catch-all cap), the cardinality-keyed name-inventory entry
+/// (`emit_name_entry`), and the per-handler `HandlerEntry` inventory
+/// submissions. None of these name the runtime state or pull `aether_substrate`,
+/// so they compile in a transport-only / wasm build where the runtime module is
+/// stripped. `handler_kinds` carries each mail handler's `(kind, reply)`; task
+/// completions are not inbound mail and carry no marker.
+fn emit_native_identity_markers(
+    self_ty: &Type,
+    generics: &syn::Generics,
+    namespace_expr: &Expr,
+    cardinality: Option<ActorCardinality>,
+    handler_kinds: &[HandlerMarker],
+    has_fallback: bool,
+    emit_name_entry: bool,
+) -> TokenStream2 {
+    let (impl_generics, _ty_generics, where_clause) = generics.split_for_impl();
+
+    // ADR-0119: cardinality picks the resolver — `One` (default / `singleton`)
+    // or `Many` (`instanced`). `Singleton` / `Instanced` derive from it.
+    let resolver_ty = if matches!(cardinality, Some(ActorCardinality::Instanced)) {
+        quote! { ::aether_actor::Many }
+    } else {
+        quote! { ::aether_actor::One }
+    };
+    // The `NAMESPACE` const restated in the `Addressable` body — built here so
+    // both call sites pass just the expr.
+    let actor_impl = quote! {
+        impl #impl_generics ::aether_actor::Addressable for #self_ty #where_clause {
+            const NAMESPACE: &'static str = #namespace_expr;
+            type Resolver = #resolver_ty;
+        }
+    };
+
+    // Issue 576 + issue 603: a fallback-only (true catch-all) cap emits a single
+    // blanket `impl<K: Kind> HandlesKind<K>` so any typed
+    // `ctx.actor::<X>().send(&payload)` compiles for every K. Strict / hybrid
+    // caps keep per-handler impls — only declared kinds compile via typed sends.
+    let handles_kind_impls: Vec<TokenStream2> = if has_fallback && handler_kinds.is_empty() {
+        let kind_param: syn::Ident = syn::parse_quote!(__AetherCatchAllK);
+        let mut blanket_generics = generics.clone();
+        blanket_generics.params.push(syn::parse_quote!(
+            #kind_param: ::aether_actor::__macro_internals::Kind
+        ));
+        let (blanket_impl, _, blanket_where) = blanket_generics.split_for_impl();
+        vec![quote! {
+            impl #blanket_impl ::aether_actor::HandlesKind<#kind_param>
+                for #self_ty #blanket_where {}
+        }]
+    } else {
+        handler_kinds
+            .iter()
+            .map(|(kind_ty, _)| {
+                quote! {
+                    impl #impl_generics ::aether_actor::HandlesKind<#kind_ty>
+                        for #self_ty #where_clause {}
+                }
+            })
+            .collect()
+    };
+
+    // A split cap carries its own always-on name-inventory submission, keyed by
+    // cardinality off the `NAMESPACE` expr and gated `not(wasm)` so it rides the
+    // transport build but never the wasm header build.
+    let name_entry = if !emit_name_entry {
+        quote! {}
+    } else if matches!(cardinality, Some(ActorCardinality::Instanced)) {
+        quote! {
+            #[cfg(not(target_family = "wasm"))]
+            ::aether_data::name_inventory::inventory::submit! {
+                ::aether_data::name_inventory::TemplateEntry {
+                    domain: ::aether_data::MAILBOX_DOMAIN,
+                    prefix: #namespace_expr,
+                    template: ":{subname}",
+                    param: ::aether_data::name_inventory::ParamKind::Dynamic,
+                }
+            }
+        }
+    } else {
+        quote! {
+            #[cfg(not(target_family = "wasm"))]
+            ::aether_data::name_inventory::inventory::submit! {
+                ::aether_data::name_inventory::NameEntry {
+                    domain: ::aether_data::MAILBOX_DOMAIN,
+                    name: #namespace_expr,
+                }
+            }
+        }
+    };
+
+    // ADR-0109 §5: the native analogue of the wasm `aether.kinds.inputs` custom
+    // section — one link-time `HandlerEntry` per mail handler (owning
+    // `NAMESPACE`, input kind id + name, reply kind id off the return type),
+    // gated `not(wasm32)`. Skipped for a generic native actor (none exist):
+    // `<Self as Addressable>::NAMESPACE` wouldn't const-resolve in the
+    // non-generic inventory static.
+    let handler_inventory = if generics.params.is_empty() {
+        let submissions = handler_kinds.iter().map(|(kind_ty, reply)| {
+            let reply_expr = if let Some(reply_ty) = reply {
+                quote! { ::core::option::Option::Some(<#reply_ty as ::aether_data::Kind>::ID) }
+            } else {
+                quote! { ::core::option::Option::None }
+            };
+            quote! {
+                #[cfg(not(target_family = "wasm"))]
+                ::aether_data::name_inventory::inventory::submit! {
+                    ::aether_data::name_inventory::HandlerEntry {
+                        namespace: <#self_ty as ::aether_actor::Addressable>::NAMESPACE,
+                        id: <#kind_ty as ::aether_data::Kind>::ID,
+                        name: <#kind_ty as ::aether_data::Kind>::NAME,
+                        reply: #reply_expr,
+                    }
+                }
+            }
+        });
+        quote! { #(#submissions)* }
+    } else {
+        quote! {}
+    };
+
+    quote! {
+        #actor_impl
+        #(#handles_kind_impls)*
+        #name_entry
+        #handler_inventory
+    }
+}
+
+/// ADR-0123 struct-hosted `#[actor]`: `#[actor(<cardinality>[, <module>])]` on
+/// the capability *struct*. It reads the sibling runtime module off disk
+/// (default `runtime`), lifts the native cap's identity out of the
+/// `#[handler]`-bearing `impl NativeActor` there, and emits the always-on
+/// addressing markers against the struct — passing the struct itself through
+/// unchanged. The behaviour + state stay in the runtime module (under
+/// `#[runtime]`); none of the emitted markers name the runtime state or pull
+/// `aether_substrate`, so the identity survives a `--no-default-features` build
+/// where `mod runtime` is `#[cfg]`-stripped.
+fn expand_struct_hosted_actor(item: &ItemStruct, opts: &ActorOpts) -> syn::Result<TokenStream2> {
+    let ident = &item.ident;
+    let (_impl_generics, ty_generics, _where_clause) = item.generics.split_for_impl();
+    let self_ty: Type = syn::parse_quote!(#ident #ty_generics);
+
+    // The runtime module name (default `runtime`) plus a span in the invoking
+    // file to resolve it from. A defaulted module has no ident of its own, so
+    // borrow the struct ident's span — it lives in the same file.
+    let (module_name, module_span) = match &opts.runtime_module {
+        Some(id) => (id.to_string(), id.span()),
+        None => ("runtime".to_string(), ident.span()),
+    };
+
+    let (namespace_expr, handler_kinds, has_fallback) =
+        harvest_runtime_identity(&module_name, module_span)?;
+
+    let markers = emit_native_identity_markers(
+        &self_ty,
+        &item.generics,
+        &namespace_expr,
+        opts.cardinality,
+        &handler_kinds,
+        has_fallback,
+        // The struct-hosted form is always a split identity, so it always
+        // carries its own name-inventory entry.
+        true,
+    );
+
+    Ok(quote! {
+        #item
+        #markers
+    })
+}
+
+/// Read the sibling runtime module file off disk and lift the native cap's
+/// identity out of its `#[handler]`-bearing `impl NativeActor` block: the
+/// `NAMESPACE` const expression, each *mail* handler's `(kind, reply)`, and
+/// whether a `#[fallback]` is present. The read is cfg-blind — `syn` does not
+/// evaluate `cfg`, so the identity is harvested even when `mod runtime` is
+/// stripped from the build. `module_span` both resolves the on-disk path
+/// (`Span::local_file`) and anchors every diagnostic back at the `#[actor]`
+/// invocation rather than into the parsed (span-less) runtime file.
+fn harvest_runtime_identity(
+    module_name: &str,
+    module_span: proc_macro2::Span,
+) -> syn::Result<(Expr, Vec<HandlerMarker>, bool)> {
+    // `Span::local_file()` (stable since 1.88) → the on-disk path of the file
+    // holding the `#[actor]` invocation. It is `None` only under path remapping
+    // (`--remap-path-prefix`), where the runtime file can't be located — a hard
+    // error, per ADR-0123's recorded fallback.
+    let Some(decl_path) = module_span.unwrap().local_file() else {
+        return Err(syn::Error::new(
+            module_span,
+            "#[actor]: Span::local_file() returned None — the source path is unavailable \
+             (path remapping?), so the runtime module file can't be located. The struct-hosted \
+             identity form needs an un-remapped build (ADR-0123).",
+        ));
+    };
+    let dir = decl_path.parent().unwrap_or_else(|| Path::new("."));
+    let flat = dir.join(format!("{module_name}.rs"));
+    let nested = dir.join(module_name).join("mod.rs");
+    let target = if flat.exists() { flat } else { nested };
+
+    let src = fs::read_to_string(&target).map_err(|e| {
+        syn::Error::new(
+            module_span,
+            format!(
+                "#[actor]: cannot read runtime module `{module_name}` (expected \
+                 `{module_name}.rs` or `{module_name}/mod.rs` beside this file): {e}"
+            ),
+        )
+    })?;
+    let parsed = syn::parse_file(&src).map_err(|e| {
+        syn::Error::new(
+            module_span,
+            format!("#[actor]: parse error in runtime module `{module_name}`: {e}"),
+        )
+    })?;
+
+    let remap = |e: syn::Error| {
+        syn::Error::new(
+            module_span,
+            format!("#[actor]: harvesting runtime module `{module_name}`: {e}"),
+        )
+    };
+
+    for syn_item in &parsed.items {
+        let syn::Item::Impl(imp) = syn_item else {
+            continue;
+        };
+        let mut handler_kinds: Vec<(Type, Option<Type>)> = Vec::new();
+        let mut has_fallback = false;
+        let mut saw_handler = false;
+        for impl_item in &imp.items {
+            let ImplItem::Fn(f) = impl_item else {
+                continue;
+            };
+            if f.attrs.iter().any(attr_is_fallback) {
+                has_fallback = true;
+                continue;
+            }
+            let Some(handler_attr) = f.attrs.iter().find(|a| attr_is_handler(a)) else {
+                continue;
+            };
+            saw_handler = true;
+            // Task completions get no `HandlesKind` / inventory marker.
+            if matches!(
+                parse_handler_variant(handler_attr).map_err(remap)?,
+                HandlerVariant::Task
+            ) {
+                continue;
+            }
+            let (kind_ty, _is_slice) =
+                extract_native_actor_handler_kind(&f.sig, true).map_err(remap)?;
+            let reply = classify_handler_reply(&f.sig.output)
+                .manifest_kind()
+                .cloned();
+            handler_kinds.push((kind_ty, reply));
+        }
+        // Not the runtime impl — some other trait impl in the file.
+        if !saw_handler && !has_fallback {
+            continue;
+        }
+        let namespace_expr = imp.items.iter().find_map(|impl_item| match impl_item {
+            ImplItem::Const(c) if c.ident == "NAMESPACE" => Some(c.expr.clone()),
+            _ => None,
+        });
+        let Some(namespace_expr) = namespace_expr else {
+            return Err(syn::Error::new(
+                module_span,
+                format!(
+                    "#[actor]: the runtime impl in module `{module_name}` has #[handler]s but \
+                     no `const NAMESPACE` to lift into Addressable"
+                ),
+            ));
+        };
+        return Ok((namespace_expr, handler_kinds, has_fallback));
+    }
+
+    Err(syn::Error::new(
+        module_span,
+        format!(
+            "#[actor]: no `#[handler]`-bearing impl found in runtime module `{module_name}` — \
+             the struct-hosted form expects a sibling `#[runtime] impl NativeActor` with at \
+             least one `#[handler]` (or a `#[fallback]`)"
+        ),
+    ))
 }
 
 struct NativeActorHandlerFn {

--- a/crates/aether-actor-derive/tests/ui.rs
+++ b/crates/aether-actor-derive/tests/ui.rs
@@ -64,4 +64,16 @@ fn ui() {
     // whose first param is `state: &mut Self::State` (the last native-split
     // first-param validator to gain the `is_split` branch).
     t.pass("tests/ui/accepts_actor_split_task_handler.rs");
+    // ADR-0123 struct-hosted `#[actor]` diagnostics. An unrecognised arg fails
+    // at parse; the disk-read harvest hard-errors on a missing runtime module,
+    // a runtime module with no `#[handler]`-bearing impl, and a handler-bearing
+    // impl that omits `const NAMESPACE`. (The `local_file() == None` path under
+    // `--remap-path-prefix` is not trybuild-reproducible — it is covered by the
+    // hard-error branch in `harvest_runtime_identity` and exercised live.) The
+    // `rt_nohandler.rs` / `rt_nonamespace.rs` siblings are read off disk by the
+    // harvest, never compiled as fixtures.
+    t.compile_fail("tests/ui/rejects_actor_unknown_arg.rs");
+    t.compile_fail("tests/ui/rejects_struct_missing_runtime.rs");
+    t.compile_fail("tests/ui/rejects_struct_no_handler.rs");
+    t.compile_fail("tests/ui/rejects_struct_no_namespace.rs");
 }

--- a/crates/aether-actor-derive/tests/ui/rejects_actor_unknown_arg.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_actor_unknown_arg.rs
@@ -1,0 +1,11 @@
+//! ADR-0123: an unrecognised `#[actor]` argument is rejected at parse time,
+//! before any struct/impl branch or disk read. `bogus = 1` is neither a known
+//! key (`singleton` / `instanced` / `runtime_feature`) nor a bare module name
+//! (the `= value` rules out the positional-ident branch).
+
+use aether_actor::actor;
+
+#[actor(bogus = 1)]
+pub struct Cap;
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/rejects_actor_unknown_arg.stderr
+++ b/crates/aether-actor-derive/tests/ui/rejects_actor_unknown_arg.stderr
@@ -1,0 +1,5 @@
+error: unrecognised #[actor] argument; expected `singleton`, `instanced`, `runtime_feature = "name"`, or a bare runtime module name
+ --> tests/ui/rejects_actor_unknown_arg.rs:8:9
+  |
+8 | #[actor(bogus = 1)]
+  |         ^^^^^

--- a/crates/aether-actor-derive/tests/ui/rejects_struct_missing_runtime.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_struct_missing_runtime.rs
@@ -1,0 +1,10 @@
+//! ADR-0123: a struct-hosted `#[actor]` whose runtime module file does not
+//! exist on disk is a hard error — the sibling `rt_absent.rs` / `rt_absent/mod.rs`
+//! cannot be read, so the identity can't be lifted.
+
+use aether_actor::actor;
+
+#[actor(singleton, rt_absent)]
+pub struct Cap;
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/rejects_struct_missing_runtime.stderr
+++ b/crates/aether-actor-derive/tests/ui/rejects_struct_missing_runtime.stderr
@@ -1,0 +1,5 @@
+error: #[actor]: cannot read runtime module `rt_absent` (expected `rt_absent.rs` or `rt_absent/mod.rs` beside this file): No such file or directory (os error 2)
+ --> tests/ui/rejects_struct_missing_runtime.rs:7:20
+  |
+7 | #[actor(singleton, rt_absent)]
+  |                    ^^^^^^^^^

--- a/crates/aether-actor-derive/tests/ui/rejects_struct_no_handler.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_struct_no_handler.rs
@@ -1,0 +1,9 @@
+//! ADR-0123: a struct-hosted `#[actor]` whose runtime module has no
+//! `#[handler]`-bearing impl is rejected — there is nothing to lift.
+
+use aether_actor::actor;
+
+#[actor(singleton, rt_nohandler)]
+pub struct Cap;
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/rejects_struct_no_handler.stderr
+++ b/crates/aether-actor-derive/tests/ui/rejects_struct_no_handler.stderr
@@ -1,0 +1,5 @@
+error: #[actor]: no `#[handler]`-bearing impl found in runtime module `rt_nohandler` — the struct-hosted form expects a sibling `#[runtime] impl NativeActor` with at least one `#[handler]` (or a `#[fallback]`)
+ --> tests/ui/rejects_struct_no_handler.rs:6:20
+  |
+6 | #[actor(singleton, rt_nohandler)]
+  |                    ^^^^^^^^^^^^

--- a/crates/aether-actor-derive/tests/ui/rejects_struct_no_namespace.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_struct_no_namespace.rs
@@ -1,0 +1,10 @@
+//! ADR-0123: a struct-hosted `#[actor]` whose runtime impl carries `#[handler]`s
+//! but no `const NAMESPACE` is rejected — there is no name to lift into
+//! `Addressable`.
+
+use aether_actor::actor;
+
+#[actor(singleton, rt_nonamespace)]
+pub struct Cap;
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/rejects_struct_no_namespace.stderr
+++ b/crates/aether-actor-derive/tests/ui/rejects_struct_no_namespace.stderr
@@ -1,0 +1,5 @@
+error: #[actor]: the runtime impl in module `rt_nonamespace` has #[handler]s but no `const NAMESPACE` to lift into Addressable
+ --> tests/ui/rejects_struct_no_namespace.rs:7:20
+  |
+7 | #[actor(singleton, rt_nonamespace)]
+  |                    ^^^^^^^^^^^^^^

--- a/crates/aether-actor-derive/tests/ui/rt_nohandler.rs
+++ b/crates/aether-actor-derive/tests/ui/rt_nohandler.rs
@@ -1,0 +1,7 @@
+// Sibling runtime stub for `rejects_struct_no_handler.rs` — read off disk by
+// the struct-hosted `#[actor]` harvest, never compiled as a fixture itself. It
+// has an impl but no `#[handler]`, so the harvest finds nothing to lift.
+struct Whatever;
+impl SomeTrait for Whatever {
+    const NAMESPACE: &'static str = "x";
+}

--- a/crates/aether-actor-derive/tests/ui/rt_nonamespace.rs
+++ b/crates/aether-actor-derive/tests/ui/rt_nonamespace.rs
@@ -1,0 +1,8 @@
+// Sibling runtime stub for `rejects_struct_no_namespace.rs` — read off disk by
+// the harvest, never compiled as a fixture. It has a `#[handler]` but no
+// `const NAMESPACE`, so the harvest errors on the missing name.
+struct Whatever;
+impl SomeTrait for Whatever {
+    #[handler]
+    fn on_x(state: &mut Self::State, ctx: &mut Ctx, mail: Ping) {}
+}

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -135,7 +135,7 @@ pub mod __macro_internals {
 /// the foundational data-layer crate and no longer exports actor-SDK
 /// surface. Component and capability authors need only `aether-actor`
 /// in their dep list; the full macro surface is available from here.
-pub use aether_actor_derive::{actor, capability, fallback, handler, local};
+pub use aether_actor_derive::{actor, capability, fallback, handler, local, runtime};
 pub use aether_data::{Kind, KindId as DataKindId, MailboxId, Schema};
 // ADR-0119: the `#[derive(Singleton)]` / `#[derive(Instanced)]` /
 // `#[derive(Embeddable)]` proc-macros are retired. Cardinality is the

--- a/crates/aether-test-fixtures/aether-test-fixtures-split-cap/Cargo.toml
+++ b/crates/aether-test-fixtures/aether-test-fixtures-split-cap/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "aether-test-fixtures-split-cap"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# ADR-0123 struct-hosted split-cap fixture: `#[actor(singleton)]` on the
+# capability struct in `src/lib.rs` (the always-on identity) plus
+# `#[runtime] impl NativeActor` in `src/runtime.rs` (the feature-gated
+# behaviour). A `lib` (not a `cdylib`) because it exercises the *native* split
+# path — unlike the wasm cdylib fixtures alongside. The `runtime` feature gates
+# `mod runtime;` and the `aether-substrate` dep, so a `--no-default-features`
+# build compiles only the cap's lifted identity + addressing markers and never
+# names the state type nor pulls the substrate runtime.
+
+[features]
+default = []
+runtime = ["dep:aether-substrate"]
+
+[dependencies]
+# Always-on identity deps — these compile feature-off and carry the markers.
+aether-actor = { path = "../../aether-actor" }
+aether-data = { path = "../../aether-data", features = ["derive"] }
+bytemuck = { workspace = true, features = ["derive"] }
+# Native runtime half — pulled in only under `feature = "runtime"`.
+aether-substrate = { path = "../../aether-substrate", optional = true }
+
+# The `Kind` derive + the `#[actor]`-lifted handler inventory emit
+# `cfg(not(wasm32))`-gated `inventory::submit!`s, so a native (host) build needs
+# `inventory` reachable. The fixture is host-only, so this is unconditional.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+inventory = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/aether-test-fixtures/aether-test-fixtures-split-cap/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-split-cap/src/lib.rs
@@ -1,0 +1,94 @@
+//! ADR-0123 struct-hosted split-cap fixture.
+//!
+//! The always-on *identity* surface lives here: the kind vocabulary, the
+//! capability ZST, and the markers `#[actor]` lifts. The behaviour + runtime
+//! state live in `runtime.rs`, gated behind `feature = "runtime"`.
+//! `#[actor(singleton)]` on the struct reads `runtime.rs` off disk and lifts
+//! the identity (`Addressable` + per-handler `HandlesKind<K>` + the
+//! name-inventory entry) up to here, so it survives a `--no-default-features`
+//! build where `mod runtime` is `#[cfg]`-stripped.
+
+use aether_actor::actor;
+
+/// A cast-shaped mail kind the cap handles. `Pod`/`Zeroable` so it needs no
+/// serde; defined here in the identity so the lifted `HandlesKind<Ping>` marker
+/// resolves feature-off.
+#[repr(C)]
+#[derive(
+    Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "test.split_cap.ping")]
+pub struct Ping {
+    pub seq: u32,
+}
+
+/// A second handled kind, so the lift emits more than one `HandlesKind` marker.
+#[repr(C)]
+#[derive(
+    Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "test.split_cap.pong")]
+pub struct Pong {
+    pub seq: u32,
+}
+
+/// The capability identity ZST. `#[actor(singleton)]` reads the sibling
+/// `runtime` module off disk and lifts `impl Addressable` (`NAMESPACE` from the
+/// runtime impl's const, `Resolver = One` from `singleton`) plus one
+/// `impl HandlesKind<K>` per `#[handler]` here — all always-on. An explicit
+/// `#[actor(singleton, other_module)]` would override the module name.
+#[actor(singleton)]
+pub struct SplitCap;
+
+#[cfg(feature = "runtime")]
+mod runtime;
+
+// Proof the identity survives a feature-off build. The turbofish forces rustc
+// to prove the bounds at this site; the body is type-checked even though it is
+// never called. Compiling with `--no-default-features` — where `mod runtime` is
+// stripped — means the `Addressable` + `HandlesKind<_>` impls came only from
+// `#[actor]`'s disk read.
+#[allow(dead_code)]
+fn assert_identity_present() {
+    fn requires<T>()
+    where
+        T: aether_actor::HandlesKind<Ping>
+            + aether_actor::HandlesKind<Pong>
+            + aether_actor::Addressable<Resolver = aether_actor::One>,
+    {
+    }
+    requires::<SplitCap>();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_actor::Addressable;
+
+    // Runs in both feature configs (the test lib compiles ungated). Proves the
+    // namespace `#[actor]` lifted is the value read from the runtime impl's
+    // const, even when `mod runtime` itself is stripped.
+    #[test]
+    fn namespace_lifted_from_runtime_const() {
+        assert_eq!(<SplitCap as Addressable>::NAMESPACE, "test.split_cap");
+    }
+
+    // Behaviour survives the split: only meaningful (and compiled) with the
+    // runtime feature, where `#[runtime]` emitted the `Lifecycle` impl carrying
+    // `init` over the declared state. The bound proof forces rustc to confirm
+    // the impl exists without standing up a chassis to call `init`.
+    #[cfg(feature = "runtime")]
+    #[test]
+    fn runtime_lifecycle_present() {
+        fn requires<T: aether_actor::Lifecycle<runtime::SplitCapState>>() {}
+        requires::<SplitCap>();
+    }
+
+    // The runtime state is plain data the dispatch surface runs over.
+    #[cfg(feature = "runtime")]
+    #[test]
+    fn runtime_state_is_plain_data() {
+        let state = runtime::SplitCapState { pings: 0, pongs: 0 };
+        assert_eq!(state.pings + state.pongs, 0);
+    }
+}

--- a/crates/aether-test-fixtures/aether-test-fixtures-split-cap/src/runtime.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-split-cap/src/runtime.rs
@@ -1,0 +1,45 @@
+//! The runtime half — behaviour + state. Compiled only under
+//! `feature = "runtime"` (the gate sits on the `mod runtime;` line in `lib.rs`).
+//! `#[actor]` in `lib.rs` still reads this file in every configuration to lift
+//! the identity, so the `NAMESPACE` const and the `#[handler]` kinds here drive
+//! the always-on `Addressable` + `HandlesKind<K>` markers up there.
+//!
+//! Names in signatures (`SplitCap`, `Ping`, `Pong`) are written bare so the
+//! kind tokens `#[actor]` lifts resolve in `lib.rs`'s scope too; `use super::*`
+//! brings them in here.
+
+use super::{Ping, Pong, SplitCap};
+use aether_actor::runtime;
+use aether_substrate::BootError;
+use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+
+/// The feature-gated, substrate-typed runtime state the identity boots into.
+pub struct SplitCapState {
+    pub pings: u32,
+    pub pongs: u32,
+}
+
+/// The behaviour impl. `#[runtime]` keeps `type State` / `type Config` / `init`
+/// on the gated runtime surface, moves the `#[handler]` bodies to an inherent
+/// impl, and consumes `NAMESPACE` (lifted into `Addressable` by `#[actor]`).
+#[runtime]
+impl NativeActor for SplitCap {
+    type State = SplitCapState;
+    type Config = ();
+
+    const NAMESPACE: &'static str = "test.split_cap";
+
+    fn init(_config: (), _ctx: &mut NativeInitCtx<'_>) -> Result<SplitCapState, BootError> {
+        Ok(SplitCapState { pings: 0, pongs: 0 })
+    }
+
+    #[handler]
+    fn on_ping(state: &mut Self::State, _ctx: &mut NativeCtx<'_>, _ping: Ping) {
+        state.pings += 1;
+    }
+
+    #[handler]
+    fn on_pong(state: &mut Self::State, _ctx: &mut NativeCtx<'_>, _pong: Pong) {
+        state.pongs += 1;
+    }
+}


### PR DESCRIPTION
Closes #2365.

## Summary

Implements ADR-0123 — the macro support for authoring a split native capability as an `#[actor]` on the capability struct plus a `#[runtime]` attribute on the `impl NativeActor` block, so the behavior and dispatch live next to their state in `mod runtime` while the always-on identity stays reachable even when `mod runtime` is `#[cfg]`-stripped.

- `parse_actor_opts` gains a positional runtime-module-name arg (default `runtime`); `actor()` branches on `ItemStruct` to a new struct-hosted identity path that resolves the sibling runtime file via `Span::local_file()`, parses it cfg-blind with `syn::parse_file`, harvests the `NAMESPACE` + per-handler kinds + fallback presence, and emits the always-on identity (`Addressable`, per-kind `HandlesKind<K>`, the name-inventory entry) against the struct.
- A new `#[runtime]` proc-macro attribute on the `impl NativeActor` block emits the gated runtime surface (`Lifecycle`, native `Dispatch`, the `NativeActor` composition pinning `type State`, handler bodies as an inherent impl) and consumes the `NAMESPACE` const. Marker emission is factored into a shared helper used by both the impl-hosted and struct-hosted paths.
- `Span::local_file()` returning `None` (path remapping) is a clear hard error.
- Purely additive — the existing impl-hosted `#[actor] impl` form stays valid for wasm guests and un-split caps. No real capability is migrated here (per-cap migrations are ADR-0123 follow-ons).

## Test plan

Proven on a new native test-fixture cap (`crates/aether-test-fixtures/aether-test-fixtures-split-cap/`) authored in the new shape, built and tested both ways:
- feature-off (`--no-default-features`): identity resolves, `aether-substrate` never compiles.
- feature-on (`--features runtime`): behavior runs.
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo nextest run --workspace` green; trybuild goldens for the new struct-path diagnostics (unknown `#[actor]` arg, missing runtime file, no `#[handler]`-bearing impl, handlers-without-`NAMESPACE`).

Validated locally via `scripts/attest.sh --publish` (attested CI path).

## Known limitation — rust-analyzer

The struct-hosted identity is harvested by reading the sibling runtime file from disk via `proc_macro::Span::local_file()`. rust-analyzer's proc-macro server (1.96) returns `None` from `local_file()`, so under RA the struct's `#[actor]` hits the hard-error branch and typed `ctx.actor::<Cap>().send(&kind)` against the lifted identity shows red in-editor. **cargo is green throughout** — this is an RA-vs-cargo divergence, not a correctness issue, and is an accepted known limitation. RustRover uses its own engine and is a separate (untested) consumer. ADR-0123 stays `Proposed` until this impl arc + the per-cap migrations land.

## Generated by

`/implement --sweep` — agent execution of scoped issue #2365.
