### PR TITLE
refactor(capabilities): migrate the component host cap to the struct-hosted actor macro

### DIFF
--- a/crates/aether-capabilities/src/component/mod.rs
+++ b/crates/aether-capabilities/src/component/mod.rs
@@ -73,24 +73,16 @@ use aether_kinds::{
     ReplaceComponent,
 };
 
-// The crate-local wiring the `#[actor] impl` handler bodies name (sibling caps,
-// the unsubscribe kind, the `Kind` / `MailboxCategory` vocabulary) lives in
-// `mod runtime` and reaches here through the `use runtime::*` glob below.
-
-// The `#[actor]` / `#[handler]` attribute path stays always-on (the macro
-// divides what it emits). Everything that names an `aether_substrate` /
-// `wasmtime` type — the handler/init ctx, the runtime state, the
+// The `#[actor]` attribute sits on the capability struct (the struct-hosted
+// ADR-0123 form): it reads the sibling `runtime` module off disk and emits the
+// always-on addressing markers + handler inventory against the identity here.
+// Everything that names an `aether_substrate` / `wasmtime` type — the
+// `#[runtime] impl NativeActor`, the handler/init ctx, the runtime state, the
 // `forward_to_trampoline` helper — lives in the `runtime` module below, gated
-// once by `feature = "runtime"` and written cfg-free within; the `#[actor]
-// impl` reaches all of it through the single `use runtime::*` glob.
+// once by `feature = "runtime"`; the body sources those names beside itself, so
+// only the handler-argument kinds the emitted markers lift verbatim must keep
+// resolving at this file's root (the `aether_kinds` import above).
 use aether_actor::actor;
-
-// The `runtime` module is this cap's private runtime-half namespace; the impl
-// reaches all of it (state, ctx types, the forward helper) through this single
-// seam, so the glob is intentional rather than a dozen one-line imports.
-#[cfg(feature = "runtime")]
-#[allow(clippy::wildcard_imports)]
-use runtime::*;
 
 /// `aether.component` cap **identity** (ADR-0122 identity/runtime split). A
 /// ZST carrying only the addressing — `Addressable` (`NAMESPACE`, `Resolver`),
@@ -100,160 +92,14 @@ use runtime::*;
 /// and the egress handles) lives behind the one `feature = "runtime"` gate, so
 /// a transport-only build never names the state nor pulls `aether_substrate` /
 /// `wasmtime` through this cap.
+#[actor(singleton)]
 pub struct ComponentHostCapability;
 
-#[actor(singleton)]
-impl NativeActor for ComponentHostCapability {
-    /// The runtime state this identity boots into (ADR-0122 split): the
-    /// wasmtime instances, mail registry, egress handles, and default-name
-    /// counter every load instantiates against.
-    type State = ComponentHostCapabilityState;
-
-    type Config = ComponentHostConfig;
-    const NAMESPACE: &'static str = "aether.component";
-
-    fn init(
-        config: ComponentHostConfig,
-        ctx: &mut NativeInitCtx<'_>,
-    ) -> Result<ComponentHostCapabilityState, BootError> {
-        let mailer = ctx.mailer();
-        let registry = Arc::clone(mailer.registry());
-        Ok(ComponentHostCapabilityState {
-            engine: config.engine,
-            linker: config.linker,
-            registry,
-            mailer,
-            outbound: config.hub_outbound,
-            default_name_counter: AtomicU64::new(0),
-        })
-    }
-
-    /// Load a fresh wasm component into the substrate.
-    ///
-    /// # Agent
-    /// Pass the wasm bytes plus an optional `name`. On Ok the cap
-    /// registers the kinds the wasm declared in its `aether.kinds`
-    /// section, picks a final name (caller value > wasm's
-    /// `aether.namespace` > `component_N`), spawns a
-    /// [`WasmTrampoline`](crate::trampoline::WasmTrampoline) under
-    /// `aether.embedded:NAME`, and replies `LoadResult::Ok { mailbox_id,
-    /// name, capabilities }` where `name` is the full trampoline
-    /// address — agents send subsequent mail to that name.
-    /// Errors (bad wire bytes, kind conflict, name conflict,
-    /// invalid wasm, instantiation trap) come back as
-    /// `LoadResult::Err`.
-    #[handler]
-    fn on_load_component(
-        state: &mut Self::State,
-        ctx: &mut NativeCtx<'_>,
-        payload: LoadComponent,
-    ) -> LoadResult {
-        // ADR-0109: the return type is the reply contract — the
-        // `#[actor]` macro routes this `LoadResult` back to the sender
-        // through `OutboundReply::reply`, so no manual `ctx.reply`.
-        state.handle_load(ctx, payload)
-    }
-
-    /// Drop a component by its mailbox id. Forwards
-    /// [`DropComponent`] mail to the addressed trampoline; the
-    /// trampoline's `WasmTrampoline::on_drop_component` handler
-    /// replies `DropResult::Ok` and shuts itself down.
-    ///
-    /// Before forwarding, purges the dying trampoline's mailbox from
-    /// every fan-out subscriber table so no cap keeps firing at a
-    /// dropped mailbox: `aether.input`'s input-stream tables (via
-    /// [`UnsubscribeAll`]) and `aether.lifecycle`'s per-stage tables
-    /// (via [`LifecycleUnsubscribeAll`]).
-    ///
-    /// # Agent
-    /// `DropComponent { mailbox_id }`. The `mailbox_id` is the
-    /// trampoline's id from the `LoadResult.mailbox_id` field.
-    #[handler]
-    fn on_drop_component(
-        _state: &mut Self::State,
-        ctx: &mut NativeCtx<'_>,
-        payload: DropComponent,
-    ) {
-        // Cap-side cleanup: ask each owning cap to drop the dying
-        // trampoline from its fan-out sets. Mail rather than direct
-        // mutation post-issue-640 — each cap is the sole owner of its
-        // own subscriber table.
-        ctx.actor::<InputCapability>().send(&UnsubscribeAll {
-            mailbox: payload.mailbox_id,
-        });
-        ctx.actor::<LifecycleCapability>()
-            .send(&LifecycleUnsubscribeAll {
-                mailbox: payload.mailbox_id.0,
-            });
-        forward_to_trampoline(ctx, payload.mailbox_id, DropComponent::ID, &payload);
-    }
-
-    /// Replace the component at `mailbox_id` with a fresh wasm
-    /// binary. Forwards [`ReplaceComponent`] to the trampoline;
-    /// the trampoline's `WasmTrampoline::on_replace_component`
-    /// handler swaps `Component` internally and replies
-    /// `ReplaceResult`. ADR-0022 + ADR-0038 splice invariants
-    /// hold because the inbox channel is the trampoline's
-    /// `NativeBinding`, which outlives the swap.
-    ///
-    /// # Agent
-    /// `ReplaceComponent { mailbox_id, wasm, drain_timeout_ms, config, export }`.
-    /// `drain_timeout_ms` is accepted for wire compatibility but
-    /// ignored under the trampoline's binding-stable replace.
-    /// `export` (ADR-0096) names which exported actor type of the
-    /// replacement module to instantiate; `None` reuses the type the
-    /// trampoline currently hosts.
-    #[handler]
-    fn on_replace_component(
-        _state: &mut Self::State,
-        ctx: &mut NativeCtx<'_>,
-        payload: ReplaceComponent,
-    ) {
-        forward_to_trampoline(ctx, payload.mailbox_id, ReplaceComponent::ID, &payload);
-    }
-
-    /// Enumerate the components this engine has actually loaded and
-    /// registered, by their ADR-0099 lineage names (issue 2020).
-    ///
-    /// Reads the registry's live mailbox snapshot — the same list
-    /// already egressed to the hub after each load — and keeps only the
-    /// [`MailboxCategory::Trampoline`] entries, the loaded-component set.
-    /// Chassis caps are boot-present and static, so the trampolines are
-    /// the only registry membership a readiness poll cares about. The
-    /// reply is names only: the mailbox id is a deterministic hash-chain
-    /// over the lineage the name renders (ADR-0099) and routing is the
-    /// substrate's job, so the caller never needs the handle.
-    ///
-    /// # Agent
-    /// Fieldless `ListComponents` to the `aether.component` mailbox —
-    /// guaranteed present from boot, so the send always resolves and the
-    /// reply is a definitive snapshot. Reply `ListComponentsResult {
-    /// names }` lists every currently-loaded component's full lineage
-    /// address (`aether.component/aether.embedded:NAME`). Poll it after a
-    /// boot-manifest spawn (ADR-0116) to learn deterministically when a
-    /// requested component is loaded, instead of inferring liveness by
-    /// proxy.
-    #[handler]
-    fn on_list_components(
-        state: &mut Self::State,
-        _ctx: &mut NativeCtx<'_>,
-        _payload: ListComponents,
-    ) -> ListComponentsResult {
-        let names = state
-            .registry
-            .list_mailbox_descriptors()
-            .into_iter()
-            .filter(|d| d.category == Some(MailboxCategory::Trampoline))
-            .map(|d| d.name)
-            .collect();
-        ListComponentsResult { names }
-    }
-}
-
 // The runtime half — the whole `aether_substrate` / `wasmtime`-typed surface
-// (imports, `ComponentHostCapabilityState`, `forward_to_trampoline`) — lives
-// in `runtime.rs`, gated once here. The `#[actor] impl` above reaches it
-// through the `use runtime::*` glob.
+// (imports, `ComponentHostCapabilityState`, `forward_to_trampoline`, and the
+// `#[runtime] impl NativeActor`) — lives in `runtime.rs`, gated once here. The
+// struct-hosted `#[actor]` above reads that module off disk to emit the
+// identity markers; the runtime body is self-contained there.
 #[cfg(feature = "runtime")]
 mod runtime;
 

--- a/crates/aether-capabilities/src/component/runtime.rs
+++ b/crates/aether-capabilities/src/component/runtime.rs
@@ -8,6 +8,20 @@
 //! `use runtime::*` glob in the parent, and the `load` sibling reaches the
 //! state fields through their `pub(in crate::component)` visibility.
 
+// The moved `#[runtime] impl NativeActor for ComponentHostCapability` body
+// names the `#[runtime]` attribute, the cap struct, the cap kinds (input +
+// reply), and `ComponentHostConfig` (its `Config` type), which previously
+// resolved at `mod.rs` root — now sourced here beside the body.
+use aether_actor::runtime;
+
+use super::ComponentHostCapability;
+use super::config::ComponentHostConfig;
+
+use aether_kinds::{
+    DropComponent, ListComponents, ListComponentsResult, LoadComponent, LoadResult,
+    ReplaceComponent,
+};
+
 // Crate-local wiring the `#[actor] impl` handler bodies name (sibling caps it
 // mails, the unsubscribe kind, the `Kind` / `MailboxCategory` vocabulary),
 // re-exported so the parent reaches them through its `use runtime::*` glob.
@@ -58,8 +72,7 @@ pub struct ComponentHostCapabilityState {
 
 /// Forward an arbitrary kind to a trampoline's mailbox, preserving the
 /// original `reply_to` so the trampoline's reply lands at the agent (not the
-/// cap). Used for [`DropComponent`](aether_kinds::DropComponent) and
-/// [`ReplaceComponent`](aether_kinds::ReplaceComponent).
+/// cap). Used for [`DropComponent`] and [`ReplaceComponent`].
 ///
 /// The forward threads the child mail under the cap's current in-flight root
 /// and bumps that root's `in_flight` count before the calling handler returns
@@ -83,4 +96,152 @@ pub fn forward_to_trampoline<P>(
 {
     let bytes = payload.encode_into_bytes();
     let _ = ctx.send_envelope_traced_with_reply_to(recipient, kind, &bytes, ctx.reply_target());
+}
+
+#[runtime]
+impl NativeActor for ComponentHostCapability {
+    /// The runtime state this identity boots into (ADR-0122 split): the
+    /// wasmtime instances, mail registry, egress handles, and default-name
+    /// counter every load instantiates against.
+    type State = ComponentHostCapabilityState;
+
+    type Config = ComponentHostConfig;
+    const NAMESPACE: &'static str = "aether.component";
+
+    fn init(
+        config: ComponentHostConfig,
+        ctx: &mut NativeInitCtx<'_>,
+    ) -> Result<ComponentHostCapabilityState, BootError> {
+        let mailer = ctx.mailer();
+        let registry = Arc::clone(mailer.registry());
+        Ok(ComponentHostCapabilityState {
+            engine: config.engine,
+            linker: config.linker,
+            registry,
+            mailer,
+            outbound: config.hub_outbound,
+            default_name_counter: AtomicU64::new(0),
+        })
+    }
+
+    /// Load a fresh wasm component into the substrate.
+    ///
+    /// # Agent
+    /// Pass the wasm bytes plus an optional `name`. On Ok the cap
+    /// registers the kinds the wasm declared in its `aether.kinds`
+    /// section, picks a final name (caller value > wasm's
+    /// `aether.namespace` > `component_N`), spawns a
+    /// [`WasmTrampoline`](crate::trampoline::WasmTrampoline) under
+    /// `aether.embedded:NAME`, and replies `LoadResult::Ok { mailbox_id,
+    /// name, capabilities }` where `name` is the full trampoline
+    /// address — agents send subsequent mail to that name.
+    /// Errors (bad wire bytes, kind conflict, name conflict,
+    /// invalid wasm, instantiation trap) come back as
+    /// `LoadResult::Err`.
+    #[handler]
+    fn on_load_component(
+        state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        payload: LoadComponent,
+    ) -> LoadResult {
+        // ADR-0109: the return type is the reply contract — the
+        // `#[actor]` macro routes this `LoadResult` back to the sender
+        // through `OutboundReply::reply`, so no manual `ctx.reply`.
+        state.handle_load(ctx, payload)
+    }
+
+    /// Drop a component by its mailbox id. Forwards
+    /// [`DropComponent`] mail to the addressed trampoline; the
+    /// trampoline's `WasmTrampoline::on_drop_component` handler
+    /// replies `DropResult::Ok` and shuts itself down.
+    ///
+    /// Before forwarding, purges the dying trampoline's mailbox from
+    /// every fan-out subscriber table so no cap keeps firing at a
+    /// dropped mailbox: `aether.input`'s input-stream tables (via
+    /// [`UnsubscribeAll`]) and `aether.lifecycle`'s per-stage tables
+    /// (via [`LifecycleUnsubscribeAll`]).
+    ///
+    /// # Agent
+    /// `DropComponent { mailbox_id }`. The `mailbox_id` is the
+    /// trampoline's id from the `LoadResult.mailbox_id` field.
+    #[handler]
+    fn on_drop_component(
+        _state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        payload: DropComponent,
+    ) {
+        // Cap-side cleanup: ask each owning cap to drop the dying
+        // trampoline from its fan-out sets. Mail rather than direct
+        // mutation post-issue-640 — each cap is the sole owner of its
+        // own subscriber table.
+        ctx.actor::<InputCapability>().send(&UnsubscribeAll {
+            mailbox: payload.mailbox_id,
+        });
+        ctx.actor::<LifecycleCapability>()
+            .send(&LifecycleUnsubscribeAll {
+                mailbox: payload.mailbox_id.0,
+            });
+        forward_to_trampoline(ctx, payload.mailbox_id, DropComponent::ID, &payload);
+    }
+
+    /// Replace the component at `mailbox_id` with a fresh wasm
+    /// binary. Forwards [`ReplaceComponent`] to the trampoline;
+    /// the trampoline's `WasmTrampoline::on_replace_component`
+    /// handler swaps `Component` internally and replies
+    /// `ReplaceResult`. ADR-0022 + ADR-0038 splice invariants
+    /// hold because the inbox channel is the trampoline's
+    /// `NativeBinding`, which outlives the swap.
+    ///
+    /// # Agent
+    /// `ReplaceComponent { mailbox_id, wasm, drain_timeout_ms, config, export }`.
+    /// `drain_timeout_ms` is accepted for wire compatibility but
+    /// ignored under the trampoline's binding-stable replace.
+    /// `export` (ADR-0096) names which exported actor type of the
+    /// replacement module to instantiate; `None` reuses the type the
+    /// trampoline currently hosts.
+    #[handler]
+    fn on_replace_component(
+        _state: &mut Self::State,
+        ctx: &mut NativeCtx<'_>,
+        payload: ReplaceComponent,
+    ) {
+        forward_to_trampoline(ctx, payload.mailbox_id, ReplaceComponent::ID, &payload);
+    }
+
+    /// Enumerate the components this engine has actually loaded and
+    /// registered, by their ADR-0099 lineage names (issue 2020).
+    ///
+    /// Reads the registry's live mailbox snapshot — the same list
+    /// already egressed to the hub after each load — and keeps only the
+    /// [`MailboxCategory::Trampoline`] entries, the loaded-component set.
+    /// Chassis caps are boot-present and static, so the trampolines are
+    /// the only registry membership a readiness poll cares about. The
+    /// reply is names only: the mailbox id is a deterministic hash-chain
+    /// over the lineage the name renders (ADR-0099) and routing is the
+    /// substrate's job, so the caller never needs the handle.
+    ///
+    /// # Agent
+    /// Fieldless `ListComponents` to the `aether.component` mailbox —
+    /// guaranteed present from boot, so the send always resolves and the
+    /// reply is a definitive snapshot. Reply `ListComponentsResult {
+    /// names }` lists every currently-loaded component's full lineage
+    /// address (`aether.component/aether.embedded:NAME`). Poll it after a
+    /// boot-manifest spawn (ADR-0116) to learn deterministically when a
+    /// requested component is loaded, instead of inferring liveness by
+    /// proxy.
+    #[handler]
+    fn on_list_components(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        _payload: ListComponents,
+    ) -> ListComponentsResult {
+        let names = state
+            .registry
+            .list_mailbox_descriptors()
+            .into_iter()
+            .filter(|d| d.category == Some(MailboxCategory::Trampoline))
+            .map(|d| d.name)
+            .collect();
+        ListComponentsResult { names }
+    }
 }


### PR DESCRIPTION
Closes #2378.

## Summary

Migrate this capability to the struct-hosted actor form (ADR-0123): the `#[actor]` attribute moves onto the capability/actor struct and the `impl NativeActor` block moves into the runtime module under `#[runtime]`, beside its state. Cardinality, `NAMESPACE`, the handler set, and the public surface are preserved verbatim — no behavior change.

## Test plan

No new tests (a no-behavior-change relocation). Validated by the agent locally across the split's feature axes — `cargo clippy --workspace --all-targets -D warnings`, `cargo nextest run --workspace`, `cargo doc --workspace --no-deps`, `cargo build -p aether-capabilities --features runtime`, and the wasm32 `--no-default-features` identity build — and re-checked by CI.

## Generated by

`/implement --sweep` — agent execution of scoped issue #2378.
