### PR TITLE
chore(qodana): scope the RsCompileErrorMacro exclude to aether-capabilities

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -22,6 +22,19 @@ exclude:
   # on a linter's say-so is a supply-chain risk, so version bumps stay a
   # deliberate human decision rather than a quality-gate finding.
   - name: NewCrateVersionAvailable
+  # Verified false positive scoped to the struct-hosted #[actor] form
+  # (ADR-0123). The macro harvests a cap's identity by reading its sibling
+  # runtime.rs via proc_macro::Span::local_file(). Qodana's inspection
+  # container builds under path remapping, so local_file() returns None and
+  # the ADR-0123-recorded hard-error fallback fires, producing an
+  # RsCompileErrorMacro finding on every #[actor] invocation in this crate.
+  # Real cargo paths (clippy / nextest / doc / CI) compile every cap cleanly
+  # — the error is Qodana-container-only. Scoped to aether-capabilities (the
+  # only crate hosting the struct-hosted form) so genuine macro compile errors
+  # remain active everywhere else, including aether-actor-derive itself.
+  - name: RsCompileErrorMacro
+    paths:
+      - crates/aether-capabilities
   - name: All
     paths:
       - target


### PR DESCRIPTION
Closes #2405.

## Summary

Qodana's analysis container remaps source paths, so the disk-reading `#[actor]` macro's `Span::local_file()` returns `None` and emits a hard `RsCompileErrorMacro` finding in every struct-hosted cap (ADR-0123). Every real build path (clippy / nextest / doc / CI) compiles these caps fine — the error occurs only inside Qodana's remapped inspection build, so it is a verified false positive, not a defect.

ADR-0123 already records the path-remapping hard-error as its deliberate fallback and the macro is unchanged, so this is a CI-config-only change: a scoped `RsCompileErrorMacro` exclude over `crates/aether-capabilities` in `qodana.yaml` (the 21 struct-hosted `#[actor]` sites are all under that crate). The exclude is scoped to the verified FP only — no project-wide silence, no baseline.

## Test plan

`qodana.yaml`-only change — no code surface. Validated via `scripts/preflight.sh` (CI/repo-config short-circuit). The Qodana scan on this PR confirms the finding no longer trips the gate on the struct-hosted caps.

## Generated by

`/implement` — agent execution of [scoped issue #2405](https://github.com/iamacoffeepot/aether/issues/2405).
