### PR TITLE
fix(qodana): preflight qodana step collides on a fixed container name across concurrent runs

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -215,6 +215,13 @@ if [[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]]; th
     git -C "$qodana_clone/scan" -c advice.detachedHead=false checkout --quiet "$HEAD_AT_START"
     qodana_dir="$qodana_clone/scan"
 fi
+# Assign a per-run unique container name so two concurrent preflight
+# invocations (e.g. parallel worktree preflights in a /implement --sweep)
+# each get their own container and neither fails with "Only one instance of
+# Qodana". PID is unique per concurrent shell — covers both the linked-worktree
+# branch (where qodana_dir is a mktemp clone) and the main-checkout branch
+# (where qodana_dir is $ROOT and the default path-hash would collide).
+export QODANA_CLI_CONTAINER_NAME="qodana-preflight-$$"
 read -ra qodana_cmd <<< "$(canonical_cmd qodana)"
 run_step "$(canonical_cmd qodana) (diff-scoped to origin/main merge-base)" \
     bash -c 'cd "$1"; shift; exec "$@"' _ "$qodana_dir" "${qodana_cmd[@]}" --diff-start "$qodana_base" -u root


### PR DESCRIPTION
Closes #2404.

## Summary

`scripts/preflight.sh`'s qodana step used the fixed container name from `qodana.yaml`, so two concurrent preflight runs collided with "Only one instance of Qodana", blocking parallel per-worktree preflights during a sweep. Mirroring `scripts/attest.sh`'s per-run unique container name, preflight now exports `QODANA_CLI_CONTAINER_NAME="qodana-preflight-$$"` before the qodana invocation. The PID token disambiguates both the linked-worktree clone branch and the main-checkout branch.

## Test plan

`scripts/preflight.sh`-only change — no code surface. Validated via `scripts/preflight.sh` (CI/repo-config short-circuit).

## Generated by

`/implement` — agent execution of [scoped issue #2404](https://github.com/iamacoffeepot/aether/issues/2404).
