### PR TITLE
fix(qodana): qodana-report.sh swallows findings when unzip warns under set -e

### DIFF
--- a/scripts/qodana-report.sh
+++ b/scripts/qodana-report.sh
@@ -51,7 +51,13 @@ fi
 
 # The artifact may carry a nested qodana-report.zip → unpacked/qodana.sarif.json.
 nested=$(find "$tmp" -name 'qodana-report.zip' | head -1)
-[[ -n "$nested" ]] && unzip -q -o "$nested" -d "$tmp/unpacked"
+if [[ -n "$nested" ]]; then
+    # unzip exits 1 on benign "stripped absolute path spec" warnings even
+    # though it extracted every file successfully. Tolerate it: the
+    # qodana.sarif.json presence check below is the real success gate — if
+    # the extraction actually produced nothing, we fall through to exit 3.
+    unzip -q -o "$nested" -d "$tmp/unpacked" || true
+fi
 sarif=$(find "$tmp" -name 'qodana.sarif.json' | head -1)
 if [[ -z "$sarif" ]]; then
     echo "qodana-report: no qodana.sarif.json inside the artifact" >&2


### PR DESCRIPTION
Closes #2403.

## Summary

`scripts/qodana-report.sh` produced no output despite findings existing: its `unzip` of the nested `qodana-report.zip` emits "stripped absolute path spec" warnings and returns exit 1, and as the rightmost command of a top-level `&&` list it tripped the script's `set -e` before the SARIF was ever parsed. The `&&`-list one-liner is replaced with an `if` block using `unzip … || true` (the files still extract on the warning), leaning on the existing `qodana.sarif.json`-presence gate (exit 3) as the real success check.

## Test plan

`scripts/qodana-report.sh`-only change — no code surface. Validated via `scripts/preflight.sh` (CI/repo-config short-circuit); no CI shell-test harness exists, so behavioral verification is a manual re-run against an artifact with findings.

## Generated by

`/implement` — agent execution of [scoped issue #2403](https://github.com/iamacoffeepot/aether/issues/2403).
