### PR TITLE
refactor(capabilities): simplify visibility modifiers

### DIFF
--- a/crates/aether-capabilities/src/anthropic/runtime.rs
+++ b/crates/aether-capabilities/src/anthropic/runtime.rs
@@ -14,16 +14,16 @@ use super::{
 };
 use crate::shared::contentgen::adapter::{AdapterUsage, AnthropicRequest, AnthropicResponse};
 
-pub use crate::shared::contentgen::task_queue::TaskQueue;
-pub use std::sync::Arc;
+pub(super) use crate::shared::contentgen::task_queue::TaskQueue;
+pub(super) use std::sync::Arc;
 
 use aether_actor::OutboundReply;
 use aether_actor::runtime;
 use aether_kinds::Usage;
 
-pub use aether_actor::Manual;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
-pub use aether_substrate::chassis::error::BootError;
+pub(super) use aether_actor::Manual;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
+pub(super) use aether_substrate::chassis::error::BootError;
 
 /// Which send path a request rode. The generate handler threads it
 /// into the worker closure to pick the blocking call + result kind.
@@ -52,7 +52,7 @@ impl AnthropicCapabilityState {
     /// Test-only constructor. Production boots through
     /// `Builder::with_actor::<AnthropicCapability>(config)`; tests
     /// hand in a stub adapter directly.
-    pub(crate) fn from_parts(adapter: Arc<dyn AnthropicAdapter>, max_in_flight: usize) -> Self {
+    fn from_parts(adapter: Arc<dyn AnthropicAdapter>, max_in_flight: usize) -> Self {
         Self {
             adapter,
             tasks: TaskQueue::new(max_in_flight),
@@ -62,7 +62,7 @@ impl AnthropicCapabilityState {
     /// White-box accessor for tests asserting the queue's in-flight
     /// counter (e.g. that a synchronous validation error never spawned
     /// work).
-    pub(crate) fn test_in_flight(&self) -> usize {
+    fn test_in_flight(&self) -> usize {
         self.tasks.in_flight()
     }
 }

--- a/crates/aether-capabilities/src/audio/runtime/mod.rs
+++ b/crates/aether-capabilities/src/audio/runtime/mod.rs
@@ -63,19 +63,19 @@ use super::kinds::{
 // The substrate-typed + native-only surface the parent's `#[actor] impl`
 // reaches through `use runtime::*`. Gated once here so a marker-only build
 // never names any of it.
-pub use std::collections::HashMap;
-pub use std::sync::Arc;
+pub(super) use std::collections::HashMap;
+pub(super) use std::sync::Arc;
 
-pub use aether_actor::{Manual, OutboundReply};
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
-pub use aether_substrate::chassis::error::BootError;
+pub(super) use aether_actor::{Manual, OutboundReply};
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
+pub(super) use aether_substrate::chassis::error::BootError;
 
-pub use self::event::AudioEvent;
-pub use self::instrument::builtin_id_ceiling;
-pub use self::sample::{BankAssemblyContext, BankAssemblyOutput, PendingInstrument};
-pub use self::schedule::{SCHEDULE_MAX_EVENTS, SCHEDULE_MAX_MILLIS};
-pub use self::track::{DecodeOutput, PendingTrack, TrackDecodeContext};
-pub use crate::fs::{FsCapability, Read, ReadResult};
+pub(super) use self::event::AudioEvent;
+pub(super) use self::instrument::builtin_id_ceiling;
+pub(super) use self::sample::{BankAssemblyContext, BankAssemblyOutput, PendingInstrument};
+pub(super) use self::schedule::{SCHEDULE_MAX_EVENTS, SCHEDULE_MAX_MILLIS};
+pub(super) use self::track::{DecodeOutput, PendingTrack, TrackDecodeContext};
+pub(super) use crate::fs::{FsCapability, Read, ReadResult};
 
 /// Extract the sender's mailbox id for voice-table keying. Component
 /// senders come through as `EngineMailbox { mailbox_id }`; Claude
@@ -88,7 +88,7 @@ pub use crate::fs::{FsCapability, Read, ReadResult};
 /// mail — collapses to `MailboxId(0)`. Callers that share this id
 /// disambiguate their tracks with the payload's `lane` field rather
 /// than the sender (ADR-0103 keying).
-pub(super) fn sender_mailbox_id(sender: Source) -> MailboxId {
+fn sender_mailbox_id(sender: Source) -> MailboxId {
     match sender.addr {
         SourceAddr::EngineMailbox { mailbox_id, .. } => mailbox_id,
         _ => MailboxId(0),
@@ -113,29 +113,29 @@ pub struct AudioCapabilityState {
     /// keyed by the echoed `(namespace, path)`. A `VecDeque` per key so
     /// two concurrent plays of the same path correlate FIFO rather than
     /// clobbering each other.
-    pub(super) pending_tracks: HashMap<(String, String), VecDeque<PendingTrack>>,
+    pending_tracks: HashMap<(String, String), VecDeque<PendingTrack>>,
     /// `load_instrument` requests awaiting their `.sfz` read, keyed by
     /// the echoed `(namespace, path)` of the `.sfz` (ADR-0103 §5).
-    pub(super) pending_instruments: HashMap<(String, String), VecDeque<PendingInstrument>>,
+    pending_instruments: HashMap<(String, String), VecDeque<PendingInstrument>>,
     /// Bank loads whose `.sfz` has parsed and whose sample reads are in
     /// flight, keyed by a minted assembly id.
-    pub(super) assemblies: HashMap<u64, BankAssembly>,
+    assemblies: HashMap<u64, BankAssembly>,
     /// Sample reads in flight, keyed by the echoed `(namespace, fs_path)`
     /// to the assembly id(s) awaiting that sample (FIFO across banks
     /// that happen to share a sample path).
-    pub(super) pending_samples: HashMap<(String, String), VecDeque<u64>>,
+    pending_samples: HashMap<(String, String), VecDeque<u64>>,
     /// Monotonic source of [`BankAssembly`] keys.
-    pub(super) next_assembly_id: u64,
+    next_assembly_id: u64,
     /// Next instrument id to assign a loaded bank — starts at
     /// `BUILTINS.len()` and counts up in load order (ADR-0103 §4),
     /// matching the synth's append-only bank table.
-    pub(super) next_instrument_id: u8,
+    next_instrument_id: u8,
     pub(super) thread: Option<JoinHandle<()>>,
     pub(super) shutdown: Option<mpsc::Sender<()>>,
 }
 
 impl AudioCapabilityState {
-    pub(super) fn nop() -> Self {
+    fn nop() -> Self {
         Self {
             sender: None,
             sample_rate: None,
@@ -153,7 +153,7 @@ impl AudioCapabilityState {
     /// Pop the oldest `play_track` parked under `(namespace, path)` —
     /// the FIFO correlation for the `aether.fs.read` reply. Removes the
     /// key's queue when it empties.
-    pub(super) fn take_pending(&mut self, namespace: &str, path: &str) -> Option<PendingTrack> {
+    fn take_pending(&mut self, namespace: &str, path: &str) -> Option<PendingTrack> {
         let key = (namespace.to_owned(), path.to_owned());
         let queue = self.pending_tracks.get_mut(&key)?;
         let pending = queue.pop_front();
@@ -165,7 +165,7 @@ impl AudioCapabilityState {
 
     /// Pop the oldest `load_instrument` parked under the `.sfz`'s
     /// `(namespace, path)`. Sibling of [`Self::take_pending`].
-    pub(super) fn take_pending_instrument(
+    fn take_pending_instrument(
         &mut self,
         namespace: &str,
         path: &str,
@@ -181,7 +181,7 @@ impl AudioCapabilityState {
 
     /// Pop the oldest assembly awaiting a sample read at
     /// `(namespace, fs_path)`.
-    pub(super) fn take_pending_sample(&mut self, namespace: &str, path: &str) -> Option<u64> {
+    fn take_pending_sample(&mut self, namespace: &str, path: &str) -> Option<u64> {
         let key = (namespace.to_owned(), path.to_owned());
         let queue = self.pending_samples.get_mut(&key)?;
         let id = queue.pop_front();
@@ -195,7 +195,7 @@ impl AudioCapabilityState {
     /// pinning the deferred `PlayTrackResult` to the original
     /// `play_track` caller. Split out of `on_read_result` so the one
     /// handler can route three fetch paths.
-    pub(super) fn start_track_decode(
+    fn start_track_decode(
         &mut self,
         ctx: &mut NativeCtx<'_, Manual>,
         pending: &PendingTrack,
@@ -243,7 +243,7 @@ impl AudioCapabilityState {
     /// `aether.fs.read` per unique referenced sample (ADR-0103 §5). A
     /// bad UTF-8 / parse replies `Err` immediately; otherwise a
     /// [`BankAssembly`] is parked until the sample reads complete.
-    pub(super) fn on_sfz_loaded(
+    fn on_sfz_loaded(
         &mut self,
         ctx: &mut NativeCtx<'_, Manual>,
         pending: &PendingInstrument,
@@ -329,7 +329,7 @@ impl AudioCapabilityState {
     /// the last sample is in, dispatch the decode + assembly off the
     /// realtime path (ADR-0093 / ADR-0103 §6). A late / orphan reply
     /// (its assembly already failed) is dropped.
-    pub(super) fn on_sample_loaded(
+    fn on_sample_loaded(
         &mut self,
         ctx: &mut NativeCtx<'_, Manual>,
         assembly_id: u64,
@@ -402,12 +402,7 @@ impl AudioCapabilityState {
     /// original requester and discard the partial assembly (ADR-0103
     /// §2). Sibling sample reads still in flight prune from the pending
     /// table; their replies will find no assembly and drop.
-    pub(super) fn fail_assembly(
-        &mut self,
-        ctx: &mut NativeCtx<'_, Manual>,
-        assembly_id: u64,
-        error: String,
-    ) {
+    fn fail_assembly(&mut self, ctx: &mut NativeCtx<'_, Manual>, assembly_id: u64, error: String) {
         let Some(assembly) = self.assemblies.remove(&assembly_id) else {
             return;
         };
@@ -451,7 +446,7 @@ impl Drop for AudioCapabilityState {
 /// worker thread + shutdown sender for the cap to manage. On
 /// pipeline build failure, the worker thread exits cleanly and the
 /// caller sees the error.
-pub(super) fn spawn_audio_worker(
+fn spawn_audio_worker(
     requested_sample_rate: Option<u32>,
 ) -> Result<(AudioEventSender, u32, JoinHandle<()>, mpsc::Sender<()>), AudioBuildError> {
     let (init_tx, init_rx) = mpsc::channel::<Result<(AudioEventSender, u32), AudioBuildError>>();

--- a/crates/aether-capabilities/src/component/mod.rs
+++ b/crates/aether-capabilities/src/component/mod.rs
@@ -42,8 +42,8 @@
 //!   ([`ComponentHostWasmExt`], [`ComponentHostNativeExt`],
 //!   [`resolve_embedded`]).
 //! - `load.rs` — the `handle_load` sequence as a method on the state; the
-//!   state fields carry `pub(in crate::component)` so this sibling reaches
-//!   them.
+//!   state fields carry `pub(in crate::component::runtime)` so this sibling
+//!   reaches them.
 
 // `#[handler]` methods take their decoded payload by value per the
 // ADR-0033 dispatch ABI; the macro-generated trampoline owns the

--- a/crates/aether-capabilities/src/component/runtime/load.rs
+++ b/crates/aether-capabilities/src/component/runtime/load.rs
@@ -1,10 +1,10 @@
 //! `handle_load` — the wasm component load sequence.
 //!
-//! Declared as `mod load;` at the `component` level (a sibling of `runtime`).
+//! Declared as `mod load;` under `runtime` (a sibling of `config`).
 //! Under the ADR-0122 split the sequence is a method on
 //! `ComponentHostCapabilityState`; its fields carry
-//! `pub(in crate::component)` visibility so this sibling module retains the
-//! same access as an inline impl block would.
+//! `pub(in crate::component::runtime)` visibility so this sibling module retains
+//! the same access as an inline impl block would.
 
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -30,7 +30,7 @@ impl ComponentHostCapabilityState {
                   would thread the load payload + registry/engine handles through a helper \
                   for no clarity gain."
     )]
-    pub(in crate::component) fn handle_load(
+    pub(in crate::component::runtime) fn handle_load(
         &mut self,
         ctx: &mut NativeCtx<'_>,
         payload: LoadComponent,

--- a/crates/aether-capabilities/src/component/runtime/mod.rs
+++ b/crates/aether-capabilities/src/component/runtime/mod.rs
@@ -6,7 +6,7 @@
 //! by this module rather than line-by-line; the `#[actor] impl` reaches the
 //! state and the `forward_to_trampoline` helper through the single
 //! `use runtime::*` glob in the parent, and the `load` sibling reaches the
-//! state fields through their `pub(in crate::component)` visibility.
+//! state fields through their `pub(in crate::component::runtime)` visibility.
 
 // The moved `#[runtime] impl NativeActor for ComponentHostCapability` body
 // names the `#[runtime]` attribute, the cap struct, the cap kinds (input +
@@ -18,7 +18,8 @@ use aether_actor::runtime;
 // (the `ComponentHostConfig` init bundle), now nested under this `runtime`
 // directory so the one `mod runtime;` gate in the parent covers them (no
 // per-sibling `#[cfg]`). The `load` impl reaches the state fields through their
-// `pub(in crate::component)` visibility, unchanged by the move.
+// `pub(in crate::component::runtime)` visibility — scoped to this runtime
+// subtree now that the siblings live under it.
 mod config;
 mod load;
 
@@ -35,23 +36,23 @@ use aether_kinds::{
 // Crate-local wiring the `#[actor] impl` handler bodies name (sibling caps it
 // mails, the unsubscribe kind, the `Kind` / `MailboxCategory` vocabulary),
 // re-exported so the parent reaches them through its `use runtime::*` glob.
-pub use crate::input::{InputCapability, UnsubscribeAll};
-pub use crate::lifecycle::LifecycleCapability;
-pub use aether_data::{Kind, MailboxCategory};
-pub use aether_kinds::LifecycleUnsubscribeAll;
+pub(super) use crate::input::{InputCapability, UnsubscribeAll};
+pub(super) use crate::lifecycle::LifecycleCapability;
+pub(super) use aether_data::{Kind, MailboxCategory};
+pub(super) use aether_kinds::LifecycleUnsubscribeAll;
 
-pub use std::sync::Arc;
-pub use std::sync::atomic::AtomicU64;
+pub(super) use std::sync::Arc;
+pub(super) use std::sync::atomic::AtomicU64;
 
-pub use wasmtime::{Engine, Linker};
+pub(super) use wasmtime::{Engine, Linker};
 
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::actor::wasm::component::ComponentCtx;
-pub use aether_substrate::chassis::error::BootError;
-pub use aether_substrate::mail::mailer::Mailer;
-pub use aether_substrate::mail::outbound::HubOutbound;
-pub use aether_substrate::mail::registry::Registry;
-pub use aether_substrate::mail::{KindId, MailboxId};
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::actor::wasm::component::ComponentCtx;
+pub(super) use aether_substrate::chassis::error::BootError;
+pub(super) use aether_substrate::mail::mailer::Mailer;
+pub(super) use aether_substrate::mail::outbound::HubOutbound;
+pub(super) use aether_substrate::mail::registry::Registry;
+pub(super) use aether_substrate::mail::{KindId, MailboxId};
 
 /// `aether.component` runtime state (ADR-0122 split). Holds the wasmtime
 /// `engine` + `linker` every load instantiates against, the mail `registry`,
@@ -66,18 +67,18 @@ pub use aether_substrate::mail::{KindId, MailboxId};
 /// the macro-emitted `Dispatch` impl; the addressing identity is the distinct
 /// ZST `ComponentHostCapability`. Living in this private module keeps it
 /// `pub`-enough to satisfy the `NativeActor::State` interface without exposing
-/// it as crate-public API. Fields carry `pub(in crate::component)` so the
+/// it as crate-public API. Fields carry `pub(in crate::component::runtime)` so the
 /// `load` submodule (which holds `handle_load`) can reach them as a sibling
 /// within `crate::component`.
 pub struct ComponentHostCapabilityState {
-    pub(in crate::component) engine: Arc<Engine>,
-    pub(in crate::component) linker: Arc<Linker<ComponentCtx>>,
-    pub(in crate::component) registry: Arc<Registry>,
-    pub(in crate::component) mailer: Arc<Mailer>,
-    pub(in crate::component) outbound: Arc<HubOutbound>,
+    pub(in crate::component::runtime) engine: Arc<Engine>,
+    pub(in crate::component::runtime) linker: Arc<Linker<ComponentCtx>>,
+    pub(in crate::component::runtime) registry: Arc<Registry>,
+    pub(in crate::component::runtime) mailer: Arc<Mailer>,
+    pub(in crate::component::runtime) outbound: Arc<HubOutbound>,
     /// Monotonic counter for `component_N` default names when an agent passes
     /// `name: None` and the wasm doesn't declare an `aether.namespace`.
-    pub(in crate::component) default_name_counter: AtomicU64,
+    pub(in crate::component::runtime) default_name_counter: AtomicU64,
 }
 
 /// Forward an arbitrary kind to a trampoline's mailbox, preserving the

--- a/crates/aether-capabilities/src/engine/proxy/runtime.rs
+++ b/crates/aether-capabilities/src/engine/proxy/runtime.rs
@@ -13,23 +13,23 @@
 //! state.
 
 use super::{EngineProxy, EngineProxyConfig};
-pub use crate::engine::kinds::{CallSettled, EngineAlive, EngineDied};
+pub(super) use crate::engine::kinds::{CallSettled, EngineAlive, EngineDied};
 use crate::engine::kinds::{EngineHeartbeatTick, ForwardEnvelope};
 use crate::rpc::RpcInboundReady;
-pub use crate::rpc::{MailEnvelope, MailboxAddress, RpcConnection, RpcError, WireFrame};
-pub use aether_actor::Addressable;
+pub(super) use crate::rpc::{MailEnvelope, MailboxAddress, RpcConnection, RpcError, WireFrame};
+pub(super) use aether_actor::Addressable;
 use aether_actor::runtime;
-pub use aether_data::{EngineId, Kind, KindId, MailboxId, mailbox_id_from_name};
-pub use aether_kinds::DeathReason;
+pub(super) use aether_data::{EngineId, Kind, KindId, MailboxId, mailbox_id_from_name};
+pub(super) use aether_kinds::DeathReason;
 use aether_kinds::TerminateEngine;
-pub use aether_substrate::Mail;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::chassis::error::BootError;
-pub use aether_substrate::mail::mailer::Mailer;
-pub use aether_substrate::mail::{Source, SourceAddr};
-pub use std::collections::HashMap;
-pub use std::process::Child;
-pub use std::sync::Arc;
+pub(super) use aether_substrate::Mail;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::chassis::error::BootError;
+pub(super) use aether_substrate::mail::mailer::Mailer;
+pub(super) use aether_substrate::mail::{Source, SourceAddr};
+pub(super) use std::collections::HashMap;
+pub(super) use std::process::Child;
+pub(super) use std::sync::Arc;
 
 use super::heartbeat::HeartbeatHandle;
 use crate::engine::EngineServer;
@@ -37,8 +37,8 @@ use crate::engine::EngineServer;
 // The init-only bring-up helpers live in the native-only `connect` /
 // `heartbeat` submodules; re-export them here so the parent's `use runtime::*`
 // glob reaches them alongside the rest of the runtime half.
-pub use super::connect::connect_proxy;
-pub use super::heartbeat::spawn_heartbeat;
+pub(super) use super::connect::connect_proxy;
+pub(super) use super::heartbeat::spawn_heartbeat;
 
 /// Mailbox of the engines cap (`aether.engine`) — where a proxy
 /// reports its own liveness transitions (`EngineAlive` / `EngineDied`,
@@ -83,7 +83,7 @@ pub struct EngineProxyState {
     /// (issue 1339). Incremented each `on_heartbeat_tick`, reset to
     /// `0` on any inbound `Pong`. Crossing `miss_limit` evicts the
     /// engine.
-    pub(super) missed_heartbeats: u32,
+    missed_heartbeats: u32,
     /// Consecutive-miss threshold that marks the engine dead. `0`
     /// when the heartbeat is disabled (`heartbeat: None`), in which
     /// case `on_heartbeat_tick` never fires anyway.
@@ -91,11 +91,11 @@ pub struct EngineProxyState {
     /// Monotonic nonce stamped on each heartbeat `Ping` — for log
     /// correlation only; a `Pong` carrying any nonce counts as
     /// liveness, since there is at most one heartbeat outstanding.
-    pub(super) heartbeat_seq: u64,
+    heartbeat_seq: u64,
     /// The heartbeat timer thread, when armed. `Drop` stops + joins
     /// it. Held as the field's RAII guard — the leading `_` marks
     /// it as owned-for-its-Drop, not read.
-    pub(super) _heartbeat: Option<HeartbeatHandle>,
+    _heartbeat: Option<HeartbeatHandle>,
 }
 
 impl Drop for EngineProxyState {
@@ -118,7 +118,7 @@ impl EngineProxyState {
     /// 1339). Sent as a fresh root: the `Pong` that triggered it is
     /// an external event causally unrelated to whatever inbound
     /// mail woke the handler.
-    pub(super) fn report_alive(&self, ctx: &NativeCtx<'_>) {
+    fn report_alive(&self, ctx: &NativeCtx<'_>) {
         let alive = EngineAlive {
             engine_id: self.engine_id.0.to_string(),
         };
@@ -156,7 +156,7 @@ impl EngineProxyState {
     /// original `correlation_id` echoed (reply-to `None` — nobody
     /// replies to a reply) so a correlation-matching caller picks
     /// it up.
-    pub(super) fn route_reply(&mut self, cid: u64, envelope: MailEnvelope) {
+    fn route_reply(&mut self, cid: u64, envelope: MailEnvelope) {
         let Some(reply_to) = self.in_flight.get(&cid).copied() else {
             tracing::debug!(
                 target: "aether_substrate::engine_proxy",
@@ -187,7 +187,7 @@ impl EngineProxyState {
     /// originating `RpcServerCapability` learns to close its wire
     /// call. The wire `RpcError` is rendered to a string; the
     /// `aether-kinds` layer can't carry the structured variant.
-    pub(super) fn route_settled(&mut self, cid: u64, result: Result<(), RpcError>) {
+    fn route_settled(&mut self, cid: u64, result: Result<(), RpcError>) {
         let Some(reply_to) = self.in_flight.remove(&cid) else {
             tracing::debug!(
                 target: "aether_substrate::engine_proxy",

--- a/crates/aether-capabilities/src/engine/server/config.rs
+++ b/crates/aether-capabilities/src/engine/server/config.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 /// needs, comfortably under the `FleetBench` client's own spawn cap so
 /// the hub returns a clean `Err` first rather than the client
 /// tripping its backstop. `0` is the wait-forever sentinel.
-pub(super) const DEFAULT_PROXY_CONNECT_BUDGET_SECS: u64 = 30;
+const DEFAULT_PROXY_CONNECT_BUDGET_SECS: u64 = 30;
 
 /// Resolved engines-cap configuration (ADR-0090, issue 1339): the
 /// liveness-heartbeat tuning plus the hub binary store's layout dir,

--- a/crates/aether-capabilities/src/engine/server/runtime.rs
+++ b/crates/aether-capabilities/src/engine/server/runtime.rs
@@ -8,13 +8,13 @@
 //! single `use runtime::*` glob in the parent.
 
 use super::{EngineConfig, EngineServer};
-pub use crate::engine::kinds::ForwardEnvelope;
+pub(super) use crate::engine::kinds::ForwardEnvelope;
 use crate::engine::kinds::{EngineAlive, EngineDied, RouteEnvelope};
-pub use crate::engine::proxy::{EngineProxy, EngineProxyConfig, HeartbeatParams};
-pub use crate::engine::store::{ArtifactStore, LAYOUT_VERSION_DIR};
+pub(super) use crate::engine::proxy::{EngineProxy, EngineProxyConfig, HeartbeatParams};
+pub(super) use crate::engine::store::{ArtifactStore, LAYOUT_VERSION_DIR};
 use aether_actor::runtime;
-pub use aether_data::{EngineId, Kind, MailboxId, Uuid};
-pub use aether_kinds::{
+pub(super) use aether_data::{EngineId, Kind, MailboxId, Uuid};
+pub(super) use aether_kinds::{
     DeadEngineDescriptor, DeathReason, EngineDescriptor, ListComponentBinariesResult,
     ListEngineBinariesResult, ListEnginesResult, ResolveComponentResult, SpawnEngineResult,
     TerminateEngineResult, UploadBinaryResult, UploadComponentResult,
@@ -23,28 +23,28 @@ use aether_kinds::{
     ListComponentBinaries, ListEngineBinaries, ListEngines, ResolveComponent, SpawnEngine,
     TerminateEngine, UploadBinary, UploadComponent,
 };
-pub use aether_substrate::Mail;
-pub use aether_substrate::Subname;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::chassis::error::BootError;
-pub use aether_substrate::mail::SourceAddr;
-pub use aether_substrate::mail::mailer::Mailer;
-pub use std::collections::HashMap;
-pub use std::collections::VecDeque;
-pub use std::path::PathBuf;
-pub use std::process::{Command, Stdio};
-pub use std::sync::Arc;
-pub use std::time::{Duration, Instant};
+pub(super) use aether_substrate::Mail;
+pub(super) use aether_substrate::Subname;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::chassis::error::BootError;
+pub(super) use aether_substrate::mail::SourceAddr;
+pub(super) use aether_substrate::mail::mailer::Mailer;
+pub(super) use std::collections::HashMap;
+pub(super) use std::collections::VecDeque;
+pub(super) use std::path::PathBuf;
+pub(super) use std::process::{Command, Stdio};
+pub(super) use std::sync::Arc;
+pub(super) use std::time::{Duration, Instant};
 
 // The artifact-store + fleet helpers the handlers delegate to live in the
 // native-only `artifacts` / `fleet` submodules; re-export them here so the
 // parent's `use runtime::*` glob reaches them alongside the rest of the
 // runtime half.
-pub use super::artifacts::{
+pub(super) use super::artifacts::{
     bootstrap_ingest, ingest_binary, ingest_component, realize_executable, resolve_component,
     resolve_selector,
 };
-pub use super::fleet::{engine_store_root, free_local_port, settle_err};
+pub(super) use super::fleet::{engine_store_root, free_local_port, settle_err};
 
 /// How many recently-died engines [`EngineServer`](super::EngineServer)
 /// retains for `list_engines`' `recently_died` sidecar (issue 1906). A small
@@ -58,9 +58,9 @@ const RECENTLY_DIED_CAP: usize = 16;
 /// `died_age_millis` it reports in a [`DeadEngineDescriptor`].
 pub struct DeadRecord {
     pub(super) engine_id: String,
-    pub(super) rpc_port: u16,
+    rpc_port: u16,
     pub(super) reason: DeathReason,
-    pub(super) died_at: Instant,
+    died_at: Instant,
 }
 
 /// One supervised engine in [`EngineServerState`]'s table.
@@ -69,12 +69,12 @@ pub struct EngineEntry {
     /// forward target for `TerminateEngine`.
     pub(super) proxy_mailbox: MailboxId,
     /// The localhost RPC port the cap assigned this substrate.
-    pub(super) rpc_port: u16,
+    rpc_port: u16,
     /// When the cap last saw this engine alive (issue 1339): set at
     /// spawn (just-connected = alive) and refreshed on each
     /// `EngineAlive` the proxy reports from a confirmed `Pong`.
     /// `on_list` reports `now - last_alive` as the heartbeat age.
-    pub(super) last_alive: Instant,
+    last_alive: Instant,
 }
 
 /// `aether.engine` runtime state (ADR-0122 split): supervises a fleet of
@@ -91,7 +91,7 @@ pub struct EngineServerState {
     /// process-local counter delivers that without a `uuid` rng
     /// dependency. Starts at 1 (`Uuid::from_u128(0)` is the nil
     /// uuid).
-    pub(super) next_engine_seq: u128,
+    next_engine_seq: u128,
     /// Cached so `on_route` can push a `ForwardEnvelope` at a proxy
     /// while *propagating the inbound reply-to* — `NativeCtx`'s
     /// sends stamp the cap as sender, but a routed call's reply

--- a/crates/aether-capabilities/src/fs/config.rs
+++ b/crates/aether-capabilities/src/fs/config.rs
@@ -120,7 +120,7 @@ impl aether_substrate::FromArgvThenEnv for NamespaceRoots {
 /// treats it as unset (preserving the prior `env_or_default`'s
 /// `Ok(s) if !s.is_empty()` guard); any non-empty value is a path.
 #[cfg(feature = "native")]
-pub(super) fn parse_dir(s: &str) -> Result<PathBuf, EmptyDir> {
+fn parse_dir(s: &str) -> Result<PathBuf, EmptyDir> {
     if s.is_empty() {
         Err(EmptyDir)
     } else {
@@ -132,7 +132,7 @@ pub(super) fn parse_dir(s: &str) -> Result<PathBuf, EmptyDir> {
 /// confique's parse path (`Err` + empty → `None`).
 #[cfg(feature = "native")]
 #[derive(Debug)]
-pub(super) struct EmptyDir;
+struct EmptyDir;
 
 #[cfg(feature = "native")]
 impl fmt::Display for EmptyDir {

--- a/crates/aether-capabilities/src/fs/runtime.rs
+++ b/crates/aether-capabilities/src/fs/runtime.rs
@@ -19,16 +19,16 @@ use super::{
 };
 use aether_actor::runtime;
 
-pub use std::any::Any;
-pub use std::fs;
-pub use std::panic::{self, AssertUnwindSafe};
-pub use std::sync::Arc;
+pub(super) use std::any::Any;
+pub(super) use std::fs;
+pub(super) use std::panic::{self, AssertUnwindSafe};
+pub(super) use std::sync::Arc;
 
-pub use super::adapter::fs_error_from_std;
-pub use aether_data::TransformError;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::chassis::error::BootError;
-pub use aether_substrate::transform::{FoldError, TransformRegistry};
+pub(super) use super::adapter::fs_error_from_std;
+pub(super) use aether_data::TransformError;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::chassis::error::BootError;
+pub(super) use aether_substrate::transform::{FoldError, TransformRegistry};
 
 /// `aether.fs` runtime state (ADR-0041). Owns the resolved adapter
 /// registry plus the link-time native-transform registry (ADR-0048 §2)
@@ -95,7 +95,7 @@ impl FsCapabilityState {
     /// `Builder::with_actor::<FsCapability>(roots)` which calls the
     /// generated `Lifecycle::init`; handler-unit tests that want to drive
     /// a handler without a full chassis hand a pre-built registry directly.
-    pub(crate) fn from_registry(registry: Arc<AdapterRegistry>) -> Self {
+    fn from_registry(registry: Arc<AdapterRegistry>) -> Self {
         Self {
             registry,
             transforms: TransformRegistry::from_inventory(),

--- a/crates/aether-capabilities/src/gemini/runtime.rs
+++ b/crates/aether-capabilities/src/gemini/runtime.rs
@@ -22,15 +22,15 @@ use crate::shared::contentgen::adapter::{
 };
 use crate::shared::contentgen::staging::{gen_root, stage_gen_output};
 
-pub use crate::shared::contentgen::task_queue::TaskQueue;
-pub use std::sync::Arc;
+pub(super) use crate::shared::contentgen::task_queue::TaskQueue;
+pub(super) use std::sync::Arc;
 
 use aether_actor::runtime;
 use aether_kinds::Usage;
 
-pub use aether_actor::{Manual, OutboundReply};
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
-pub use aether_substrate::chassis::error::BootError;
+pub(super) use aether_actor::{Manual, OutboundReply};
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
+pub(super) use aether_substrate::chassis::error::BootError;
 
 /// `aether.gemini` runtime state (ADR-0050). Owns the resolved adapter +
 /// the cap-level rate-limit queue over the ADR-0093 dispatch primitive.
@@ -47,14 +47,14 @@ pub struct GeminiCapabilityState {
 
 #[cfg(test)]
 impl GeminiCapabilityState {
-    pub(crate) fn from_parts(adapter: Arc<dyn GeminiAdapter>, max_in_flight: usize) -> Self {
+    fn from_parts(adapter: Arc<dyn GeminiAdapter>, max_in_flight: usize) -> Self {
         Self {
             adapter,
             tasks: TaskQueue::new(max_in_flight),
         }
     }
 
-    pub(crate) fn test_in_flight(&self) -> usize {
+    fn test_in_flight(&self) -> usize {
         self.tasks.in_flight()
     }
 }

--- a/crates/aether-capabilities/src/http/client/mod.rs
+++ b/crates/aether-capabilities/src/http/client/mod.rs
@@ -463,8 +463,8 @@ mod runtime {
     use std::sync::Arc;
     use std::time::Duration;
 
-    pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    pub use aether_substrate::chassis::error::BootError;
+    pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    pub(super) use aether_substrate::chassis::error::BootError;
 
     /// `aether.http` runtime state (ADR-0043). Owns the resolved adapter
     /// and the default per-request timeout applied when `Fetch.timeout_ms`
@@ -485,7 +485,7 @@ mod runtime {
         /// `Builder::with_actor::<HttpCapability>(config)` which calls the
         /// generated `Lifecycle::init`; tests that drive the handler with a
         /// stub adapter hand it in directly.
-        pub(crate) fn from_adapter(
+        pub(super) fn from_adapter(
             adapter: Arc<dyn HttpAdapter>,
             default_timeout: Duration,
         ) -> Self {

--- a/crates/aether-capabilities/src/http/server/runtime.rs
+++ b/crates/aether-capabilities/src/http/server/runtime.rs
@@ -26,23 +26,23 @@
 use super::{HttpInboundReady, HttpServerCapability, HttpServerConfig, HttpServerHandle, Settled};
 use aether_actor::runtime;
 
-pub use std::collections::HashMap;
-pub use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
-pub use std::sync::Arc;
-pub use std::sync::atomic::{AtomicBool, Ordering};
-pub use std::sync::mpsc;
-pub use std::thread;
-pub use std::time::Duration;
+pub(super) use std::collections::HashMap;
+pub(super) use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
+pub(super) use std::sync::Arc;
+pub(super) use std::sync::atomic::{AtomicBool, Ordering};
+pub(super) use std::sync::mpsc;
+pub(super) use std::thread;
+pub(super) use std::time::Duration;
 
-pub use aether_data::{Kind, KindId, MailboxId};
-pub use aether_substrate::actor::native::envelope::Envelope;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::chassis::error::BootError;
-pub use aether_substrate::mail::mailer::Mailer;
+pub(super) use aether_data::{Kind, KindId, MailboxId};
+pub(super) use aether_substrate::actor::native::envelope::Envelope;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::chassis::error::BootError;
+pub(super) use aether_substrate::mail::mailer::Mailer;
 
 // The parent `#[actor] impl` writes the `502` reply path, so it names
 // `HttpServerResponse`; the rest of the kind vocabulary is used only here.
-pub use crate::http::kinds::HttpServerResponse;
+pub(super) use crate::http::kinds::HttpServerResponse;
 use crate::http::kinds::{HttpHeader, HttpMethod, HttpServerRequest};
 
 use aether_substrate::Mail;
@@ -158,7 +158,7 @@ pub struct HttpServerCapabilityState {
     pub(super) handler_mailbox: String,
     pub(super) max_request_bytes: usize,
     pub(super) max_header_bytes: usize,
-    pub(super) request_timeout: Duration,
+    request_timeout: Duration,
     pub(super) self_mailbox: MailboxId,
     /// Cached `Arc<Mailer>` so the dispatcher can fire wake mails into
     /// the cap, resolve the handler mailbox by name at dispatch time,
@@ -180,7 +180,7 @@ pub struct HttpServerCapabilityState {
 impl HttpServerCapabilityState {
     /// Allocate a fresh `ConnId`, store the connection's write half, and
     /// spin a reader thread for the read half.
-    pub(super) fn spawn_reader_for_peer(&mut self, stream: TcpStream, peer: SocketAddr) {
+    fn spawn_reader_for_peer(&mut self, stream: TcpStream, peer: SocketAddr) {
         let conn_id = self.next_conn_id;
         self.next_conn_id += 1;
 
@@ -267,7 +267,7 @@ impl HttpServerCapabilityState {
 
     /// Map the method, resolve the handler, dispatch the request, and
     /// record the in-flight entry. Answers `501` / `503` inline.
-    pub(super) fn dispatch_request(
+    fn dispatch_request(
         &mut self,
         ctx: &mut NativeCtx<'_>,
         conn_id: ConnId,
@@ -313,18 +313,14 @@ impl HttpServerCapabilityState {
     }
 
     /// Format + write the handler's [`HttpServerResponse`].
-    pub(super) fn write_handler_response(
-        &mut self,
-        conn_id: ConnId,
-        response: &HttpServerResponse,
-    ) {
+    fn write_handler_response(&mut self, conn_id: ConnId, response: &HttpServerResponse) {
         let bytes = render_handler_response(response);
         self.write_raw_to(conn_id, &bytes);
     }
 
     /// Format + write a canned status response (the cap's own
     /// `413` / `431` / `501` / `502` / `503` / `504`).
-    pub(super) fn write_status_response(&mut self, conn_id: ConnId, status: u16, message: &str) {
+    fn write_status_response(&mut self, conn_id: ConnId, status: u16, message: &str) {
         let bytes = render_status_response(status, message);
         self.write_raw_to(conn_id, &bytes);
     }
@@ -347,7 +343,7 @@ impl HttpServerCapabilityState {
         }
     }
 
-    pub(super) fn close_connection(&mut self, conn_id: ConnId, reason: &str) {
+    fn close_connection(&mut self, conn_id: ConnId, reason: &str) {
         let Some(mut conn) = self.connections.remove(&conn_id) else {
             return;
         };

--- a/crates/aether-capabilities/src/inventory/mod.rs
+++ b/crates/aether-capabilities/src/inventory/mod.rs
@@ -104,17 +104,17 @@ mod runtime {
     pub use super::manifest::param_kind_wire;
     pub use super::resolve::resolve_ids;
 
-    pub use aether_data::KindId;
-    pub use aether_data::canonical::kind_id_from_parts;
-    pub use aether_data::name_inventory::{handler_entries, name_entries, template_entries};
-    pub use aether_data::wire;
-    pub use aether_kinds::{
+    pub(super) use aether_data::KindId;
+    pub(super) use aether_data::canonical::kind_id_from_parts;
+    pub(super) use aether_data::name_inventory::{handler_entries, name_entries, template_entries};
+    pub(super) use aether_data::wire;
+    pub(super) use aether_kinds::{
         HandlerEntryWire, KindDescriptorWire, NameEntryWire, TemplateEntryWire,
     };
-    pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    pub use aether_substrate::chassis::error::BootError;
-    pub use aether_substrate::mail::registry::Registry;
-    pub use std::sync::Arc;
+    pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    pub(super) use aether_substrate::chassis::error::BootError;
+    pub(super) use aether_substrate::mail::registry::Registry;
+    pub(super) use std::sync::Arc;
 
     /// `aether.inventory` runtime state (ADR-0091 §2). Holds the substrate's
     /// shared `Arc<Registry>` — the same `Arc` `ComponentHostCapability`

--- a/crates/aether-capabilities/src/lifecycle/graph.rs
+++ b/crates/aether-capabilities/src/lifecycle/graph.rs
@@ -17,9 +17,9 @@ use aether_data::{Kind, KindId};
 /// bridgeable).
 #[derive(Clone)]
 pub struct LifecycleStateData {
-    pub(crate) kind: KindId,
-    pub(crate) next: KindId,
-    pub(crate) quit: Option<KindId>,
+    pub(in crate::lifecycle) kind: KindId,
+    pub(in crate::lifecycle) next: KindId,
+    pub(in crate::lifecycle) quit: Option<KindId>,
 }
 
 /// A compiled lifecycle graph as plain data (ADR-0082 §1). Built via
@@ -62,17 +62,17 @@ impl LifecycleGraphData {
 
     /// Look up the state registered at `kind`. `None` for an unknown
     /// kind or a terminal.
-    pub(crate) fn state(&self, kind: KindId) -> Option<&LifecycleStateData> {
+    pub(in crate::lifecycle) fn state(&self, kind: KindId) -> Option<&LifecycleStateData> {
         self.states.iter().find(|s| s.kind == kind)
     }
 
     /// True if `kind` is a registered terminal.
-    pub(crate) fn is_terminal(&self, kind: KindId) -> bool {
+    pub(in crate::lifecycle) fn is_terminal(&self, kind: KindId) -> bool {
         self.terminals.contains(&kind)
     }
 
     /// The configured start state's kind id.
-    pub(crate) fn start(&self) -> KindId {
+    pub(in crate::lifecycle) fn start(&self) -> KindId {
         self.start
     }
 }

--- a/crates/aether-capabilities/src/lifecycle/mod.rs
+++ b/crates/aether-capabilities/src/lifecycle/mod.rs
@@ -58,7 +58,7 @@ mod graph;
 // `LifecycleStateData` is named only by `mod settlement`'s `resolve_edge`,
 // which rides the `runtime` gate, so the re-export does too.
 #[cfg(feature = "runtime")]
-pub(crate) use graph::LifecycleStateData;
+pub(in crate::lifecycle) use graph::LifecycleStateData;
 pub use graph::{
     BuildError, LifecycleGraphBuilder, LifecycleGraphData, NoOpen, OpenNoNext, OpenWithNext,
 };
@@ -124,9 +124,9 @@ impl LifecycleCapabilityState {
 /// Construction-level state fixture: a Render→Present→Shutdown
 /// data graph + a fresh mailer, built directly (no chassis boot),
 /// with the supplied advance timeout. Shared with
-/// `mod settlement`'s tests via `pub(crate)`.
+/// `mod settlement`'s tests via `pub(in crate::lifecycle)`.
 #[cfg(all(test, feature = "runtime"))]
-pub(crate) fn test_cap(advance_timeout: Duration) -> LifecycleCapabilityState {
+pub(in crate::lifecycle) fn test_cap(advance_timeout: Duration) -> LifecycleCapabilityState {
     use aether_kinds::{Present, Render, Shutdown};
     use aether_substrate::mail::registry::Registry;
 
@@ -159,7 +159,7 @@ pub(crate) fn test_cap(advance_timeout: Duration) -> LifecycleCapabilityState {
 /// `Tick` as a declared stage, which [`test_cap`]'s Render-rooted
 /// graph doesn't carry).
 #[cfg(all(test, feature = "runtime"))]
-pub(crate) fn tick_start_graph_cap() -> LifecycleCapabilityState {
+pub(in crate::lifecycle) fn tick_start_graph_cap() -> LifecycleCapabilityState {
     use aether_kinds::{Shutdown, Tick};
     use aether_substrate::mail::registry::Registry;
 

--- a/crates/aether-capabilities/src/lifecycle/runtime/mod.rs
+++ b/crates/aether-capabilities/src/lifecycle/runtime/mod.rs
@@ -20,9 +20,9 @@ use super::{LifecycleCapability, LifecycleGraphData};
 
 pub use self::config::LifecycleConfig;
 #[cfg(test)]
-pub use self::settlement::ADVANCE_TIMEOUT_MS_DEFAULT;
-pub use self::settlement::{PendingAdvance, Step, resolve_edge};
-pub use super::subscribers::broadcast_to_subscribers;
+pub(super) use self::settlement::ADVANCE_TIMEOUT_MS_DEFAULT;
+pub(super) use self::settlement::{PendingAdvance, Step, resolve_edge};
+pub(super) use super::subscribers::broadcast_to_subscribers;
 
 // Handler-argument and reply kinds named by the moved `#[runtime] impl`
 // bodies. Private to this module — the identity in the parent resolves the
@@ -34,16 +34,16 @@ use aether_kinds::{
     LifecycleUnsubscribe, LifecycleUnsubscribeAll, LifecycleUnsubscribeSelf, Quit,
 };
 
-pub use aether_actor::Manual;
-pub use aether_actor::actor::ctx::OutboundReply;
-pub use aether_data::{Kind, KindId, MailboxId as DataMailboxId, mailbox_id_from_name};
-pub use aether_kinds::LifecycleAdvanceComplete;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::chassis::error::BootError;
-pub use aether_substrate::mail::mailer::Mailer;
-pub use std::collections::{BTreeMap, BTreeSet};
-pub use std::sync::Arc;
-pub use std::time::{Duration, Instant};
+pub(super) use aether_actor::Manual;
+pub(super) use aether_actor::actor::ctx::OutboundReply;
+pub(super) use aether_data::{Kind, KindId, MailboxId as DataMailboxId, mailbox_id_from_name};
+pub(super) use aether_kinds::LifecycleAdvanceComplete;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::chassis::error::BootError;
+pub(super) use aether_substrate::mail::mailer::Mailer;
+pub(super) use std::collections::{BTreeMap, BTreeSet};
+pub(super) use std::sync::Arc;
+pub(super) use std::time::{Duration, Instant};
 
 /// `aether.lifecycle` runtime state (ADR-0082). Owns the lifecycle data
 /// graph, the subscriber table, the state pointer, and the settlement
@@ -58,39 +58,39 @@ pub use std::time::{Duration, Instant};
 /// dispatcher thread, so no `Mutex` / `Arc<Atomic*>` is needed for the
 /// subscriber table or state pointer.
 ///
-/// Fields are `pub(crate)` so the settlement state machine
+/// Fields are `pub(in crate::lifecycle)` so the settlement state machine
 /// (`mod settlement`) can carry its inherent-impl cluster in a sibling
 /// file and the parent's handlers can read them.
 pub struct LifecycleCapabilityState {
-    pub(crate) graph: LifecycleGraphData,
+    pub(in crate::lifecycle) graph: LifecycleGraphData,
     /// Subscriber table keyed by stage kind id (ADR-0082 §7).
-    pub(crate) subscribers: BTreeMap<KindId, BTreeSet<DataMailboxId>>,
+    pub(in crate::lifecycle) subscribers: BTreeMap<KindId, BTreeSet<DataMailboxId>>,
     /// Kind id of the state the cap will broadcast on the next
     /// [`LifecycleAdvance`]. Starts at
     /// `graph.start()`; mutated after each settled advance to the resolved
     /// next/quit edge target.
-    pub(crate) current_state: KindId,
+    pub(in crate::lifecycle) current_state: KindId,
     /// True once the lifecycle reached a terminal — further advances
     /// are no-ops.
-    pub(crate) terminal_reached: bool,
+    pub(in crate::lifecycle) terminal_reached: bool,
     /// Quit flag (ADR-0082 §3). Set by inbound [`Quit`]
     /// mail; consumed at the next state whose graph declares a `quit` edge.
-    pub(crate) quit_pending: bool,
+    pub(in crate::lifecycle) quit_pending: bool,
     /// In-flight advance awaiting settlement (ADR-0082 §6).
-    pub(crate) pending: Option<PendingAdvance>,
+    pub(in crate::lifecycle) pending: Option<PendingAdvance>,
     /// Deadline for a pending advance's `Settled`
     /// (iamacoffeepot/aether#1048). Set from
     /// `AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS`.
-    pub(crate) advance_timeout: Duration,
+    pub(in crate::lifecycle) advance_timeout: Duration,
     /// EWMA of observed `Sent`→`Settled` latency (ADR-0082 §6),
     /// updated once per settle. `None` until the first settlement.
-    pub(crate) settlement_latency_ewma: Option<Duration>,
+    pub(in crate::lifecycle) settlement_latency_ewma: Option<Duration>,
     /// Last time a slow-settlement warn fired, for the
     /// `SLOW_SETTLE_WARN_COOLDOWN` rate limit.
-    pub(crate) last_slow_warn: Option<Instant>,
+    pub(in crate::lifecycle) last_slow_warn: Option<Instant>,
     /// `Arc<Mailer>` cached at init for `subscribe_settlement_mail`
     /// calls inside handlers.
-    pub(crate) mailer: Arc<Mailer>,
+    pub(in crate::lifecycle) mailer: Arc<Mailer>,
 }
 
 #[runtime]

--- a/crates/aether-capabilities/src/lifecycle/runtime/settlement.rs
+++ b/crates/aether-capabilities/src/lifecycle/runtime/settlement.rs
@@ -15,7 +15,7 @@ use aether_kinds::LifecycleAdvanceComplete;
 use aether_substrate::actor::native::NativeCtx;
 use aether_substrate::mail::{MailId, Source};
 
-// `LifecycleStateData` is the cap-root `pub(crate)` re-export over `graph`
+// `LifecycleStateData` is the cap-root `pub(in crate::lifecycle)` re-export over `graph`
 // (which stays at cap root as always-on public surface); `super::super` reaches
 // it from this nested `runtime` module. `LifecycleCapabilityState` lives in the
 // parent `runtime/mod.rs`, one level up.
@@ -62,19 +62,19 @@ pub enum Step {
 /// Per-advance state tracked across `on_advance` → `on_settled`.
 pub struct PendingAdvance {
     /// Causal-chain root of the in-flight broadcast (ADR-0080 §6).
-    pub(crate) root: MailId,
+    pub(in crate::lifecycle) root: MailId,
     /// Kind id of the state just broadcast — echoed in `completed`.
-    pub(crate) completed_kind: KindId,
+    pub(in crate::lifecycle) completed_kind: KindId,
     /// Kind id of the state to broadcast next — echoed in `next`.
     /// `KindId(0)` when the settling broadcast was a terminal.
-    pub(crate) next_kind: KindId,
+    pub(in crate::lifecycle) next_kind: KindId,
     /// True if the settling broadcast is a terminal state.
-    pub(crate) is_terminal: bool,
+    pub(in crate::lifecycle) is_terminal: bool,
     /// Original chassis sender of the [`LifecycleAdvance`](aether_kinds::LifecycleAdvance) mail.
-    pub(crate) reply_to: Source,
+    pub(in crate::lifecycle) reply_to: Source,
     /// When this advance was issued. Drives the `advance_timeout`
     /// force-complete fallback (iamacoffeepot/aether#1048).
-    pub(crate) started: Instant,
+    pub(in crate::lifecycle) started: Instant,
 }
 
 impl LifecycleCapabilityState {
@@ -87,7 +87,7 @@ impl LifecycleCapabilityState {
     /// deadline, naming the offending `root` so a
     /// `describe_tree <root>` surfaces the in-flight nodes. O(1) per
     /// settle.
-    pub(crate) fn record_settlement_latency(&mut self, latency: Duration, root: MailId) {
+    pub(super) fn record_settlement_latency(&mut self, latency: Duration, root: MailId) {
         // EWMA in nanos, α = SETTLE_EWMA_ALPHA_PERMILLE/1000. Up and
         // down moves are handled separately so the whole thing stays
         // in u128 (no signed casts): next = prev ± α·|sample − prev|.
@@ -132,7 +132,7 @@ impl LifecycleCapabilityState {
     /// True when a pending advance has exceeded
     /// [`Self::advance_timeout`](super) without settling
     /// (iamacoffeepot/aether#1048). `false` when nothing is pending.
-    pub(crate) fn pending_timed_out(&self) -> bool {
+    pub(super) fn pending_timed_out(&self) -> bool {
         self.pending
             .as_ref()
             .is_some_and(|p| p.started.elapsed() >= self.advance_timeout)
@@ -143,7 +143,7 @@ impl LifecycleCapabilityState {
     /// state mutation + reply but logs at `error`: reaching here means
     /// the settlement pipeline stalled past `advance_timeout`. No-op when
     /// nothing is pending.
-    pub(crate) fn force_complete_pending(&mut self, ctx: &mut NativeCtx<'_, Manual>) {
+    pub(super) fn force_complete_pending(&mut self, ctx: &mut NativeCtx<'_, Manual>) {
         let Some(pending) = self.pending.take() else {
             return;
         };

--- a/crates/aether-capabilities/src/render/headless_runtime.rs
+++ b/crates/aether-capabilities/src/render/headless_runtime.rs
@@ -13,7 +13,7 @@
 // `BootError` / `Manual` / `CaptureFrameResult`) come from the shared
 // `any(render-native, runtime)` seam in `mod.rs`, not from here, so a
 // desktop build doesn't re-export them through two globs.
-pub use std::io;
+pub(super) use std::io;
 
 use std::sync::Arc;
 

--- a/crates/aether-capabilities/src/render/runtime/mod.rs
+++ b/crates/aether-capabilities/src/render/runtime/mod.rs
@@ -17,15 +17,15 @@
 // `#[actor] impl` names come from that same shared seam, not from here.
 use std::sync::Arc;
 
-pub use std::sync::atomic::{AtomicU64, Ordering};
-pub use std::sync::{Mutex, OnceLock};
+pub(super) use std::sync::atomic::{AtomicU64, Ordering};
+pub(super) use std::sync::{Mutex, OnceLock};
 
-pub use aether_data::Kind;
-pub use aether_substrate::capture::PendingCapture;
-pub use aether_substrate::mail::helpers::resolve_bundle;
-pub use aether_substrate::mail::mailer::Mailer;
-pub use aether_substrate::mail::registry::Registry;
-pub use aether_substrate::render::IDENTITY_VIEW_PROJ;
+pub(super) use aether_data::Kind;
+pub(super) use aether_substrate::capture::PendingCapture;
+pub(super) use aether_substrate::mail::helpers::resolve_bundle;
+pub(super) use aether_substrate::mail::mailer::Mailer;
+pub(super) use aether_substrate::mail::registry::Registry;
+pub(super) use aether_substrate::render::IDENTITY_VIEW_PROJ;
 
 // The native impl seams, now nested under this `runtime` directory so the one
 // `mod runtime;` gate in the parent covers them (no per-sibling `#[cfg]`):

--- a/crates/aether-capabilities/src/rpc/server/runtime.rs
+++ b/crates/aether-capabilities/src/rpc/server/runtime.rs
@@ -34,28 +34,28 @@ use aether_actor::runtime;
 // `#[actor] impl` body in `mod.rs` names; it reaches them through the
 // single `use runtime::*` glob. Types named only by the inherent helper
 // methods below ride the same wall (used locally here).
-pub use crate::engine::EngineServer;
-pub use crate::engine::kinds::{CallSettled, RouteEnvelope};
-pub use crate::rpc::{
+pub(super) use crate::engine::EngineServer;
+pub(super) use crate::engine::kinds::{CallSettled, RouteEnvelope};
+pub(super) use crate::rpc::{
     Hello, HelloAck, MailEnvelope, MailboxAddress, RpcError, WIRE_VERSION, WireFrame,
 };
-pub use aether_actor::Addressable;
+pub(super) use aether_actor::Addressable;
 pub use aether_codec::frame::{FrameError, write_frame};
-pub use aether_data::{Kind, KindId, MailId, MailboxId, mailbox_id_from_name};
-pub use aether_substrate::Mail;
-pub use aether_substrate::actor::native::envelope::Envelope;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::chassis::error::BootError;
-pub use aether_substrate::mail::SourceAddr;
-pub use aether_substrate::mail::mailer::Mailer;
-pub use std::collections::HashMap;
-pub use std::io;
-pub use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
-pub use std::sync::Arc;
-pub use std::sync::atomic::{AtomicBool, Ordering};
-pub use std::sync::mpsc;
-pub use std::thread::{self, JoinHandle};
-pub use std::time::Duration;
+pub(super) use aether_data::{Kind, KindId, MailId, MailboxId, mailbox_id_from_name};
+pub(super) use aether_substrate::Mail;
+pub(super) use aether_substrate::actor::native::envelope::Envelope;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::chassis::error::BootError;
+pub(super) use aether_substrate::mail::SourceAddr;
+pub(super) use aether_substrate::mail::mailer::Mailer;
+pub(super) use std::collections::HashMap;
+pub(super) use std::io;
+pub(super) use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
+pub(super) use std::sync::Arc;
+pub(super) use std::sync::atomic::{AtomicBool, Ordering};
+pub(super) use std::sync::mpsc;
+pub(super) use std::thread::{self, JoinHandle};
+pub(super) use std::time::Duration;
 
 /// Exported handle bundle published at boot. Reachable from the
 /// chassis via `PassiveChassis::handle::<RpcServerHandle>()`;
@@ -77,7 +77,7 @@ pub struct RpcServerHandle {
 #[derive(Copy, Clone)]
 pub(super) struct InFlight {
     pub(super) conn_id: ConnId,
-    pub(super) wire_cid: u64,
+    wire_cid: u64,
 }
 
 /// `aether.rpc.server` runtime state (ADR-0122 split). Owns one TCP
@@ -114,7 +114,7 @@ pub struct RpcServerState {
 impl RpcServerState {
     /// Allocate a fresh `ConnId`, store the connection's write half,
     /// spin a reader thread for the read half.
-    pub(super) fn spawn_reader_for_peer(
+    fn spawn_reader_for_peer(
         &mut self,
         _ctx: &mut NativeCtx<'_>,
         stream: TcpStream,
@@ -191,12 +191,7 @@ impl RpcServerState {
     }
 
     /// Dispatch one incoming frame.
-    pub(super) fn dispatch_frame(
-        &mut self,
-        ctx: &mut NativeCtx<'_>,
-        conn_id: ConnId,
-        frame: WireFrame,
-    ) {
+    fn dispatch_frame(&mut self, ctx: &mut NativeCtx<'_>, conn_id: ConnId, frame: WireFrame) {
         match frame {
             WireFrame::Hello(hello) => self.handle_hello(conn_id, hello),
             WireFrame::HelloAck(_) => {
@@ -228,7 +223,7 @@ impl RpcServerState {
         }
     }
 
-    pub(super) fn handle_hello(&mut self, conn_id: ConnId, hello: Hello) {
+    fn handle_hello(&mut self, conn_id: ConnId, hello: Hello) {
         if hello.wire_version != WIRE_VERSION {
             self.write_frame_to(
                 conn_id,
@@ -254,7 +249,7 @@ impl RpcServerState {
         );
     }
 
-    pub(super) fn handle_call(
+    fn handle_call(
         &mut self,
         ctx: &mut NativeCtx<'_>,
         conn_id: ConnId,
@@ -341,7 +336,7 @@ impl RpcServerState {
             .insert(mail_id.correlation_id, InFlight { conn_id, wire_cid });
     }
 
-    pub(super) fn close_connection(&mut self, conn_id: ConnId, reason: &str) {
+    fn close_connection(&mut self, conn_id: ConnId, reason: &str) {
         let Some(mut conn) = self.connections.remove(&conn_id) else {
             return;
         };
@@ -364,7 +359,7 @@ impl RpcServerState {
         );
     }
 
-    pub(super) fn write_frame_to(&mut self, conn_id: ConnId, frame: &WireFrame) {
+    fn write_frame_to(&mut self, conn_id: ConnId, frame: &WireFrame) {
         let Some(conn) = self.connections.get_mut(&conn_id) else {
             return;
         };

--- a/crates/aether-capabilities/src/tcp/listener/runtime.rs
+++ b/crates/aether-capabilities/src/tcp/listener/runtime.rs
@@ -7,20 +7,20 @@
 //! `#[actor] impl` reaches the state, ctx types, and config / session types
 //! through the single `use runtime::*` glob in the parent.
 
-pub use std::net::{SocketAddr, TcpStream};
-pub use std::sync::Arc;
-pub use std::sync::atomic::{AtomicBool, Ordering};
-pub use std::sync::mpsc;
-pub use std::thread::{self, JoinHandle};
-pub use std::time::Duration;
+pub(super) use std::net::{SocketAddr, TcpStream};
+pub(super) use std::sync::Arc;
+pub(super) use std::sync::atomic::{AtomicBool, Ordering};
+pub(super) use std::sync::mpsc;
+pub(super) use std::thread::{self, JoinHandle};
+pub(super) use std::time::Duration;
 
-pub use aether_data::Kind;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::chassis::error::BootError;
-pub use aether_substrate::{KindId, Mail, Mailer};
+pub(super) use aether_data::Kind;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::chassis::error::BootError;
+pub(super) use aether_substrate::{KindId, Mail, Mailer};
 
-pub use crate::tcp::config::{TcpListenerConfig, TcpSessionConfig};
-pub use crate::tcp::session::TcpSessionActor;
+pub(super) use crate::tcp::config::{TcpListenerConfig, TcpSessionConfig};
+pub(super) use crate::tcp::session::TcpSessionActor;
 
 use aether_actor::runtime;
 // The moved handler bodies name the cap kinds backing their signatures; bring
@@ -40,8 +40,8 @@ pub struct TcpListenerState {
     pub(super) local_port: u16,
     pub(super) shutdown: Arc<AtomicBool>,
     pub(super) accept_thread: Option<JoinHandle<()>>,
-    pub(super) connection_rx: mpsc::Receiver<(TcpStream, SocketAddr)>,
-    pub(super) next_subname: u64,
+    connection_rx: mpsc::Receiver<(TcpStream, SocketAddr)>,
+    next_subname: u64,
 }
 
 #[runtime]

--- a/crates/aether-capabilities/src/tcp/runtime.rs
+++ b/crates/aether-capabilities/src/tcp/runtime.rs
@@ -7,18 +7,18 @@
 //! reaches the state, ctx types, and supervisor structs through the single
 //! `use runtime::*` glob in the parent.
 
-pub use std::collections::HashMap;
-pub use std::net::TcpListener;
+pub(super) use std::collections::HashMap;
+pub(super) use std::net::TcpListener;
 
-pub use aether_actor::Manual;
+pub(super) use aether_actor::Manual;
 // The manual handlers (`on_unbind` / `on_monitor_notice`) issue their own
 // replies through `ctx.reply` / `ctx.reply_to`, the `OutboundReply` trait
 // methods, so the trait must be in scope where those handler bodies expand.
-pub use aether_actor::OutboundReply;
-pub use aether_substrate::actor::monitor::MonitorHandle;
-pub use aether_substrate::actor::native::spawn::Subname;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::chassis::error::BootError;
+pub(super) use aether_actor::OutboundReply;
+pub(super) use aether_substrate::actor::monitor::MonitorHandle;
+pub(super) use aether_substrate::actor::native::spawn::Subname;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::chassis::error::BootError;
 
 use aether_actor::runtime;
 // `MonitorNotice` is named by `on_monitor_notice`'s signature; the parent's
@@ -54,7 +54,7 @@ pub struct TcpCapabilityState {
     /// arrives from the listener being closed. Key is the same
     /// `MailboxId` as `listeners`; the cap's monitor (registered
     /// at spawn time) is what fires the notice.
-    pub(super) pending_unbinds: HashMap<aether_data::MailboxId, PendingUnbind>,
+    pending_unbinds: HashMap<aether_data::MailboxId, PendingUnbind>,
 }
 
 /// Cap-local supervisor state for one live listener. Drops with
@@ -67,10 +67,10 @@ pub(super) struct ListenerEntry {
     // Held to keep the cap's monitor registered against the
     // listener for its lifetime. Drops when the entry is removed
     // (in `on_monitor_notice`).
-    pub(super) _monitor_handle: MonitorHandle,
+    _monitor_handle: MonitorHandle,
 }
 
-pub(super) struct PendingUnbind {
+struct PendingUnbind {
     pub(super) sender: aether_data::Source,
     pub(super) listener_name: String,
 }

--- a/crates/aether-capabilities/src/tcp/session/runtime.rs
+++ b/crates/aether-capabilities/src/tcp/session/runtime.rs
@@ -11,19 +11,19 @@
 // dispatch contract; the by-value `SessionWrite` arg trips this lint.
 #![allow(clippy::needless_pass_by_value)]
 
-pub use std::io::{Read, Write};
-pub use std::net::{Shutdown, TcpStream};
-pub use std::sync::Arc;
-pub use std::sync::atomic::{AtomicBool, Ordering};
-pub use std::sync::mpsc;
-pub use std::thread::{self, JoinHandle};
+pub(super) use std::io::{Read, Write};
+pub(super) use std::net::{Shutdown, TcpStream};
+pub(super) use std::sync::Arc;
+pub(super) use std::sync::atomic::{AtomicBool, Ordering};
+pub(super) use std::sync::mpsc;
+pub(super) use std::thread::{self, JoinHandle};
 
-pub use aether_data::Kind;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::chassis::error::BootError;
-pub use aether_substrate::{KindId, Mail, Mailer};
+pub(super) use aether_data::Kind;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::chassis::error::BootError;
+pub(super) use aether_substrate::{KindId, Mail, Mailer};
 
-pub use crate::tcp::config::TcpSessionConfig;
+pub(super) use crate::tcp::config::TcpSessionConfig;
 
 use aether_actor::runtime;
 // The moved handler bodies name the cap kinds backing their signatures; bring
@@ -50,8 +50,8 @@ pub struct TcpSessionState {
     pub(super) session_name: String,
     pub(super) write_half: TcpStream,
     pub(super) shutdown: Arc<AtomicBool>,
-    pub(super) read_thread: Option<JoinHandle<()>>,
-    pub(super) bytes_rx: mpsc::Receiver<Result<Vec<u8>, String>>,
+    read_thread: Option<JoinHandle<()>>,
+    bytes_rx: mpsc::Receiver<Result<Vec<u8>, String>>,
 }
 
 #[runtime]

--- a/crates/aether-capabilities/src/text/runtime/mod.rs
+++ b/crates/aether-capabilities/src/text/runtime/mod.rs
@@ -10,17 +10,17 @@
 use std::collections::HashMap;
 use std::collections::VecDeque;
 
-pub use std::sync::Arc;
+pub(super) use std::sync::Arc;
 
-pub use aether_actor::OutboundReply;
-pub use aether_data::Source;
-pub use aether_kinds::QuadSpace;
-pub use aether_substrate::Manual;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
-pub use aether_substrate::chassis::error::BootError;
+pub(super) use aether_actor::OutboundReply;
+pub(super) use aether_data::Source;
+pub(super) use aether_kinds::QuadSpace;
+pub(super) use aether_substrate::Manual;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
+pub(super) use aether_substrate::chassis::error::BootError;
 
-pub use crate::fs::{FsCapability, Read, ReadResult};
-pub use crate::render::{
+pub(super) use crate::fs::{FsCapability, Read, ReadResult};
+pub(super) use crate::render::{
     CreateTexture, CreateTextureResult, RenderCapability, TexturedQuad, UpdateTexture,
 };
 
@@ -89,30 +89,30 @@ pub type FontParseOutput = Result<ParsedFont, String>;
 pub struct TextCapabilityState {
     /// Session-scoped font registry. Index is the `font_id` a
     /// `LoadFontResult::Ok` handed back and `DrawText.font_id` names.
-    pub(super) fonts: HashMap<u32, Arc<fontdue::Font>>,
+    fonts: HashMap<u32, Arc<fontdue::Font>>,
     /// Reverse index from `(namespace, path)` to the `font_id` that
     /// file is resident under. Dedups the registry: a repeat load or
     /// a `font_metrics` grab of the same file reuses one resident
     /// font and a stable id rather than parsing a second copy.
-    pub(super) font_ids: HashMap<(String, String), u32>,
+    font_ids: HashMap<(String, String), u32>,
     /// Next `font_id` to assign — monotonic, session-scoped.
-    pub(super) next_font_id: u32,
+    next_font_id: u32,
     /// `load_font` requests awaiting their `aether.fs.read` reply,
     /// keyed by the echoed `(namespace, path)`. A `VecDeque` so
     /// concurrent loads of the same path correlate FIFO.
-    pub(super) pending_fonts: HashMap<(String, String), VecDeque<PendingFont>>,
+    pending_fonts: HashMap<(String, String), VecDeque<PendingFont>>,
     /// The shelf-packed glyph atlas (CPU-side source of truth).
     pub(super) atlas: Atlas,
     /// The render-cap `texture_id` backing [`Self::atlas`], once
     /// `create_texture` has replied. `None` until then.
-    pub(super) atlas_texture_id: Option<u32>,
+    atlas_texture_id: Option<u32>,
     /// `true` between sending `create_texture` and its reply, so a
     /// burst of `draw`s sends exactly one creation request.
-    pub(super) atlas_create_inflight: bool,
+    atlas_create_inflight: bool,
 }
 
 impl TextCapabilityState {
-    pub(super) fn new() -> Self {
+    fn new() -> Self {
         Self {
             fonts: HashMap::new(),
             font_ids: HashMap::new(),
@@ -125,7 +125,7 @@ impl TextCapabilityState {
     }
 
     /// Pop the oldest `load_font` parked under `(namespace, path)`.
-    pub(super) fn take_pending(&mut self, namespace: &str, path: &str) -> Option<PendingFont> {
+    fn take_pending(&mut self, namespace: &str, path: &str) -> Option<PendingFont> {
         let key = (namespace.to_owned(), path.to_owned());
         let queue = self.pending_fonts.get_mut(&key)?;
         let pending = queue.pop_front();
@@ -140,12 +140,7 @@ impl TextCapabilityState {
     /// returns its existing id (and drops the freshly-parsed `font`),
     /// so repeat loads and metric grabs of one file share a single
     /// resident font and a stable id.
-    pub(super) fn register_font(
-        &mut self,
-        namespace: &str,
-        path: &str,
-        font: Arc<fontdue::Font>,
-    ) -> u32 {
+    fn register_font(&mut self, namespace: &str, path: &str, font: Arc<fontdue::Font>) -> u32 {
         let key = (namespace.to_owned(), path.to_owned());
         if let Some(&existing) = self.font_ids.get(&key) {
             return existing;
@@ -161,7 +156,7 @@ impl TextCapabilityState {
     /// `aether.fs.read`. The `ReadResult` routes back to
     /// `on_read_result`, which parses the bytes and replies in the
     /// shape `reply` selects.
-    pub(super) fn forward_font_read(
+    fn forward_font_read(
         &mut self,
         ctx: &mut NativeCtx<'_, Manual>,
         namespace: String,
@@ -185,7 +180,7 @@ impl TextCapabilityState {
     /// already in flight. The reply (`CreateTextureResult`) routes back
     /// to this cap's own mailbox, where `on_create_texture_result`
     /// stores the assigned id.
-    pub(super) fn ensure_atlas_texture(&mut self, ctx: &mut NativeCtx<'_>) {
+    fn ensure_atlas_texture(&mut self, ctx: &mut NativeCtx<'_>) {
         if self.atlas_texture_id.is_some() || self.atlas_create_inflight {
             return;
         }
@@ -202,12 +197,7 @@ impl TextCapabilityState {
     }
 
     /// Send one `update_texture` for a newly-rasterized glyph's rect.
-    pub(super) fn upload_glyph(
-        &self,
-        ctx: &mut NativeCtx<'_>,
-        texture_id: u32,
-        entry: &AtlasEntry,
-    ) {
+    fn upload_glyph(&self, ctx: &mut NativeCtx<'_>, texture_id: u32, entry: &AtlasEntry) {
         let update = UpdateTexture {
             texture_id,
             x: entry.x,
@@ -223,7 +213,7 @@ impl TextCapabilityState {
     /// zeroed buffer. This ensures the render cap's staged pixels are a
     /// clean mirror of the reset CPU atlas before per-glyph uploads layer
     /// on top. Uses the same `update_texture` path as `upload_glyph`.
-    pub(super) fn resync_atlas(&self, ctx: &mut NativeCtx<'_>, texture_id: u32) {
+    fn resync_atlas(&self, ctx: &mut NativeCtx<'_>, texture_id: u32) {
         let update = UpdateTexture {
             texture_id,
             x: 0,

--- a/crates/aether-capabilities/src/trace/mod.rs
+++ b/crates/aether-capabilities/src/trace/mod.rs
@@ -64,11 +64,11 @@ use runtime::*;
 /// glob above.
 #[cfg(feature = "runtime")]
 mod runtime {
-    pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    pub use aether_substrate::chassis::error::BootError;
-    pub use aether_substrate::mail::helpers::resolve_bundle;
-    pub use aether_substrate::mail::registry::Registry;
-    pub use std::sync::Arc;
+    pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    pub(super) use aether_substrate::chassis::error::BootError;
+    pub(super) use aether_substrate::mail::helpers::resolve_bundle;
+    pub(super) use aether_substrate::mail::registry::Registry;
+    pub(super) use std::sync::Arc;
 
     /// `aether.trace` runtime state (ADR-0086 Phase 3c). Holds the
     /// substrate registry handle for `DispatchTraced`'s per-envelope name

--- a/crates/aether-capabilities/src/trampoline/runtime/mod.rs
+++ b/crates/aether-capabilities/src/trampoline/runtime/mod.rs
@@ -18,25 +18,25 @@ mod replace;
 mod state;
 
 pub use config::WasmTrampolineConfig;
-pub use state::WasmTrampolineState;
+pub(super) use state::WasmTrampolineState;
 
 // The `aether_substrate` / `wasmtime` / `std` names the parent `#[actor] impl`
 // body references, re-exported so the parent `use runtime::*` glob sees them
 // (the fs `runtime.rs` `pub use` pattern). `DropResult` / `ReplaceResult` ride
 // this glob; `DropComponent` / `ReplaceComponent` stay at the parent file root
 // (always-on, for the `HandlesKind<K>` markers).
-pub use std::io;
-pub use std::sync::Arc;
+pub(super) use std::io;
+pub(super) use std::sync::Arc;
 
 use super::WasmTrampoline;
-pub use aether_actor::Local;
+pub(super) use aether_actor::Local;
 use aether_actor::runtime;
-pub use aether_kinds::{DropComponent, DropResult, ReplaceComponent, ReplaceResult};
-pub use aether_substrate::actor::native::envelope::Envelope;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::actor::wasm::component::{Component, ComponentCtx};
-pub use aether_substrate::chassis::error::BootError;
-pub use aether_substrate::mail::{CostCells, KindId, Mail};
+pub(super) use aether_kinds::{DropComponent, DropResult, ReplaceComponent, ReplaceResult};
+pub(super) use aether_substrate::actor::native::envelope::Envelope;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::actor::wasm::component::{Component, ComponentCtx};
+pub(super) use aether_substrate::chassis::error::BootError;
+pub(super) use aether_substrate::mail::{CostCells, KindId, Mail};
 
 #[runtime]
 impl NativeActor for WasmTrampoline {

--- a/crates/aether-capabilities/src/trampoline/runtime/replace.rs
+++ b/crates/aether-capabilities/src/trampoline/runtime/replace.rs
@@ -28,7 +28,7 @@ impl WasmTrampolineState {
     /// own capability group (looked up by actor-type tag). A
     /// spawn-time failure surfaces here, asynchronously to the guest
     /// (which already received the `MailboxId`): logged, not fatal.
-    pub(in crate::trampoline) fn spawn_sibling(
+    pub(in crate::trampoline::runtime) fn spawn_sibling(
         &self,
         ctx: &mut NativeCtx<'_>,
         pending: PendingSpawn,
@@ -87,7 +87,7 @@ impl WasmTrampolineState {
     /// and on success the caller promotes it to the new `self.type_tag`
     /// so a later bare replace reuses the *current* hosted type rather
     /// than reverting to the original load's.
-    pub(in crate::trampoline) fn resolve_replace_target(
+    fn resolve_replace_target(
         &self,
         export: Option<&str>,
         actors: &[ActorInputs],
@@ -145,7 +145,7 @@ impl WasmTrampolineState {
             })
     }
 
-    pub(in crate::trampoline) fn handle_replace(
+    pub(in crate::trampoline::runtime) fn handle_replace(
         &mut self,
         payload: ReplaceComponent,
     ) -> ReplaceResult {

--- a/crates/aether-capabilities/src/trampoline/runtime/state.rs
+++ b/crates/aether-capabilities/src/trampoline/runtime/state.rs
@@ -23,33 +23,33 @@ pub struct WasmTrampolineState {
     /// `Some` while wasm is loaded; `None` after a `DropComponent`.
     /// Mail arriving in the `None` state warn-drops via the
     /// fallback (the trampoline is just an empty named slot).
-    pub(in crate::trampoline) component: Option<Component>,
+    pub(in crate::trampoline::runtime) component: Option<Component>,
     /// Held for [`Self::on_replace_component`] so a fresh
     /// `Component::instantiate` against the same engine + linker
     /// is reachable from the handler.
-    pub(in crate::trampoline) engine: Arc<Engine>,
-    pub(in crate::trampoline) linker: Arc<Linker<ComponentCtx>>,
-    pub(in crate::trampoline) registry: Arc<Registry>,
-    pub(in crate::trampoline) mailer: Arc<Mailer>,
-    pub(in crate::trampoline) outbound: Arc<HubOutbound>,
+    pub(in crate::trampoline::runtime) engine: Arc<Engine>,
+    pub(in crate::trampoline::runtime) linker: Arc<Linker<ComponentCtx>>,
+    pub(in crate::trampoline::runtime) registry: Arc<Registry>,
+    pub(in crate::trampoline::runtime) mailer: Arc<Mailer>,
+    pub(in crate::trampoline::runtime) outbound: Arc<HubOutbound>,
     /// The trampoline's own mailbox id
     /// (== `MailboxId::from_name(full_name)`). Cached because
     /// `NativeCtx` only exposes `self_id()` via the
     /// `NativeInitCtx` flavour today; storing it here avoids
     /// reaching into `ctx.binding().self_mailbox()` on every
     /// handler call.
-    pub(in crate::trampoline) mailbox: MailboxId,
+    pub(in crate::trampoline::runtime) mailbox: MailboxId,
     /// ADR-0096: the selected export's actor-type tag, or `None`
     /// for the entry type. Held so [`Self::handle_replace`]
     /// re-instantiates the same exported type from the new wasm
     /// and re-reads that type's capability group.
-    pub(in crate::trampoline) type_tag: Option<u64>,
+    pub(in crate::trampoline::runtime) type_tag: Option<u64>,
     /// ADR-0097: the resident `Module`, retained so a sibling spawn
     /// re-instantiates it (a cheap `Arc` clone — wasmtime shares the
     /// compiled code) without a re-compile, and refreshed on replace.
-    pub(in crate::trampoline) module: Module,
+    pub(in crate::trampoline::runtime) module: Module,
     /// ADR-0097: every exported type's capability group (see
     /// [`WasmTrampolineConfig::actor_caps`]). A spawned sibling looks
     /// up its own handler set here by actor-type tag.
-    pub(in crate::trampoline) actor_caps: Vec<ActorInputs>,
+    pub(in crate::trampoline::runtime) actor_caps: Vec<ActorInputs>,
 }

--- a/crates/aether-capabilities/src/ui/runtime.rs
+++ b/crates/aether-capabilities/src/ui/runtime.rs
@@ -16,13 +16,13 @@ use aether_data::MailboxId;
 pub use core::iter::once;
 pub use core::mem::swap;
 
-pub use crate::input::{InputCapability, InputMailboxExt};
-pub use crate::lifecycle::{LifecycleCapability, LifecycleMailboxExt};
-pub use crate::render::{DrawSolidQuads, RenderCapability, SolidQuad};
-pub use crate::text::{DrawText, TextCapability};
-pub use aether_kinds::QuadSpace;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::chassis::error::BootError;
+pub(super) use crate::input::{InputCapability, InputMailboxExt};
+pub(super) use crate::lifecycle::{LifecycleCapability, LifecycleMailboxExt};
+pub(super) use crate::render::{DrawSolidQuads, RenderCapability, SolidQuad};
+pub(super) use crate::text::{DrawText, TextCapability};
+pub(super) use aether_kinds::QuadSpace;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::chassis::error::BootError;
 
 /// A button's hit-test record for one frame: where it was drawn, the
 /// caller's widget `id`, and the component that drew it (the
@@ -33,7 +33,7 @@ pub struct ButtonRect {
     /// Caller-stable widget id echoed back in `UiClicked`.
     pub(super) id: u32,
     /// Mailbox of the component that sent the `UiButton`.
-    pub(super) owner: MailboxId,
+    owner: MailboxId,
 }
 
 /// `aether.ui` runtime state (ADR-0122 split). Owns the cursor position

--- a/crates/aether-capabilities/src/window/mod.rs
+++ b/crates/aether-capabilities/src/window/mod.rs
@@ -53,8 +53,8 @@ use runtime::*;
 /// by this module rather than per-import.
 #[cfg(feature = "runtime")]
 mod runtime {
-    pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    pub use aether_substrate::chassis::error::BootError;
+    pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    pub(super) use aether_substrate::chassis::error::BootError;
 
     /// `aether.window` headless-companion runtime state (ADR-0122 split).
     /// The cap is stateless — every handler `Err`-replies off `ctx` alone —


### PR DESCRIPTION
Closes #2415.

## Summary

`aether-capabilities` over-published its internals — ~226 `pub(super)` plus `pub(crate)` / `pub(in …)` modifiers, much of it a layout artifact: a runtime-only sibling sitting at cap root wrote `pub(super)` to climb into the shared cap-root parent. After #2414 re-homed those siblings under each cap's `runtime/` directory, `super::` resolves to the `runtime` module, so items shared only within `runtime/` no longer need cap-root visibility.

This is the follow-through sweep: a compile-driven, leaf-first tighten of every visibility modifier to the narrowest form that still compiles across the cap's feature matrix, with no change to the crate's public API.

- Privatized item helpers, RAII guards, and per-cap state fields used only within their own file.
- Narrowed each cap runtime module's over-published std/substrate plumbing re-exports `pub use` → `pub(super) use` (consumed only by the parent's `use runtime::*` glob); public config/type re-exports (`AudioConfig`, `RenderGpu`, …) kept `pub`.
- Scoped component/trampoline state fields `pub(in crate::<cap>)` → `pub(in crate::<cap>::runtime)`.
- Narrowed the lifecycle cap's crate-wide `pub(crate)` graph/state surface to `pub(in crate::lifecycle)`.

Terminal state: no modifier can be narrowed further without a feature combo failing to compile.

## Test plan

Verified each iteration across default (`native,runtime`), `--all-features`, and the four wasm32-target marker builds (render/audio/text/ui), gated by `clippy --all-targets -D warnings` (dead-code / private-interfaces). `scripts/preflight.sh` green: fmt + `clippy --workspace --all-targets -D warnings` + doc + `nextest --workspace --all-features` + wasm32 component cross-build + diff-scoped Qodana (no new problems).

## Generated by

`/implement` — agent execution of [scoped issue #2415](https://github.com/iamacoffeepot/aether/issues/2415).
