### PR TITLE
flake(substrate-bundle): bounded re-fork recovers a stolen spawn port

### DIFF
--- a/crates/aether-capabilities/src/engine/proxy/connect.rs
+++ b/crates/aether-capabilities/src/engine/proxy/connect.rs
@@ -6,14 +6,58 @@
 use crate::rpc::{PeerKind, RpcClient, RpcClientError, RpcConnection, RpcInboundReady};
 use aether_data::{Kind, KindId, MailboxId};
 use aether_substrate::Mail;
+use aether_substrate::actor::native::SpawnError;
+use aether_substrate::chassis::error::BootError;
 use aether_substrate::mail::mailer::Mailer;
+use std::error::Error as StdError;
+use std::fmt;
 use std::io::ErrorKind;
+use std::process::{Child, ExitStatus};
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
 /// Pause between dial attempts within the connect budget.
 const PROXY_CONNECT_RETRY_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Outcome distinctions [`connect_proxy`] surfaces to the proxy's
+/// `init` so the engines cap can tell a re-forkable startup death from
+/// a genuinely unreachable substrate.
+#[derive(Debug)]
+pub enum ProxyConnectError {
+    /// The dial never connected within the budget (or hit a terminal
+    /// handshake / frame error). Genuinely unreachable — not
+    /// re-forkable.
+    Dial(RpcClientError),
+    /// The forked child substrate exited before the proxy could
+    /// connect — the bind-stolen-port death (`free_local_port`'s
+    /// TOCTOU window let another socket take the ephemeral port, so
+    /// the substrate's fatal bind exited it). Distinct from
+    /// [`Self::Dial`] so `on_spawn` re-forks on a fresh port rather
+    /// than dialing a dead port for the full budget. `status` is the
+    /// child's exit status when `try_wait` captured it.
+    ChildExited { status: Option<ExitStatus> },
+}
+
+impl fmt::Display for ProxyConnectError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Dial(e) => write!(f, "{e}"),
+            Self::ChildExited { status } => {
+                write!(f, "substrate exited during startup (status: {status:?})")
+            }
+        }
+    }
+}
+
+impl StdError for ProxyConnectError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::Dial(e) => Some(e),
+            Self::ChildExited { .. } => None,
+        }
+    }
+}
 
 /// Dial the substrate's `RpcServerCapability`, building a fresh
 /// `on_frame` wake closure per attempt. When `retry` is set, a
@@ -23,6 +67,13 @@ const PROXY_CONNECT_RETRY_INTERVAL: Duration = Duration::from_millis(50);
 /// the wait-forever sentinel: retry until the dial succeeds or hits
 /// a terminal error. Handshake / frame errors are always terminal:
 /// the peer answered, just wrongly.
+///
+/// `child` is the forked substrate's handle (when the cap spawned it).
+/// Each retry iteration `try_wait`s it: a child that has already
+/// exited (the bind-stolen-port death) returns a terminal
+/// [`ProxyConnectError::ChildExited`] immediately rather than dialing
+/// a dead port for the full budget, so the cap can re-fork on a fresh
+/// port. `None` for an adopted substrate (no child to watch).
 pub fn connect_proxy(
     addr: &str,
     mailer: &Arc<Mailer>,
@@ -30,7 +81,8 @@ pub fn connect_proxy(
     wake_kind: KindId,
     retry: bool,
     budget: Option<Duration>,
-) -> Result<RpcConnection, RpcClientError> {
+    mut child: Option<&mut Child>,
+) -> Result<RpcConnection, ProxyConnectError> {
     // `None` budget → no deadline (wait forever); `Some(d)` → stop
     // retrying once `d` has elapsed.
     let deadline = budget.map(|d| Instant::now() + d);
@@ -59,15 +111,45 @@ pub fn connect_proxy(
         ) {
             Ok(conn) => Ok(conn),
             Err(e) => {
+                // If we own the child and it has already exited, the
+                // substrate died during startup (e.g. a stolen RPC
+                // port made its bind fatal). Stop dialing a dead port
+                // and return a terminal child-exited outcome the cap
+                // can re-fork on — this converts a full-budget hang
+                // into a sub-second failure.
+                if let Some(child) = child.as_deref_mut()
+                    && let Ok(Some(status)) = child.try_wait()
+                {
+                    return Err(ProxyConnectError::ChildExited {
+                        status: Some(status),
+                    });
+                }
                 let within_budget = deadline.is_none_or(|d| Instant::now() < d);
                 if retry && is_transient_connect_error(&e) && within_budget {
                     thread::sleep(PROXY_CONNECT_RETRY_INTERVAL);
                     continue;
                 }
-                Err(e)
+                Err(ProxyConnectError::Dial(e))
             }
         };
     }
+}
+
+/// `true` when a failed `spawn_child::<EngineProxy>` is the re-forkable
+/// child-exited-during-startup death — a stolen RPC port made the
+/// substrate's bind fatal, surfaced through `SpawnError::InitFailed` →
+/// `BootError::Other` → a boxed `ProxyConnectError::ChildExited`.
+/// The engines cap re-forks on a fresh port for this; any other
+/// failure is terminal.
+#[must_use]
+pub fn is_reforkable_spawn_failure(err: &SpawnError) -> bool {
+    let SpawnError::InitFailed(BootError::Other(boxed)) = err else {
+        return false;
+    };
+    matches!(
+        boxed.downcast_ref::<ProxyConnectError>(),
+        Some(ProxyConnectError::ChildExited { .. })
+    )
 }
 
 /// `true` for the connection-level errors a still-coming-up
@@ -79,4 +161,66 @@ fn is_transient_connect_error(e: &RpcClientError) -> bool {
         RpcClientError::Connect(io)
             if matches!(io.kind(), ErrorKind::ConnectionRefused | ErrorKind::ConnectionReset)
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_substrate::mail::registry::Registry;
+    use std::process::Command;
+
+    /// A child that exits immediately must fast-fail the startup dial
+    /// well under the connect budget: `connect_proxy` `try_wait`s the
+    /// child each retry and, once it has exited, returns
+    /// [`ProxyConnectError::ChildExited`] rather than dialing the dead
+    /// port for the full budget.
+    ///
+    /// Tripwire: without the child-exit fast-fail this dial blocks the
+    /// entire (generous) budget; the assertion that it returns in a
+    /// small fraction of the budget is what the fast-fail guarantees.
+    #[test]
+    fn child_exit_fast_fails_well_under_budget() {
+        let mailer = Arc::new(Mailer::new(Arc::new(Registry::new())));
+        let self_mailbox = MailboxId(1);
+        let wake_kind = KindId(<RpcInboundReady as Kind>::ID.0);
+
+        // A child that exits immediately. The dial targets a port
+        // nothing is listening on, so every attempt refuses — the only
+        // way out under a long budget is the child-exit fast-fail.
+        let mut child = Command::new("true")
+            .spawn()
+            .expect("spawn a trivially-exiting child");
+
+        // Pick an almost-certainly-unbound port and never bind it, so
+        // the dial refuses on every attempt.
+        let addr = "127.0.0.1:1";
+        let budget = Duration::from_secs(30);
+
+        let start = Instant::now();
+        let result = connect_proxy(
+            addr,
+            &mailer,
+            self_mailbox,
+            wake_kind,
+            true,
+            Some(budget),
+            Some(&mut child),
+        );
+        let elapsed = start.elapsed();
+
+        let _ = child.wait();
+
+        assert!(
+            matches!(result, Err(ProxyConnectError::ChildExited { .. })),
+            "an immediately-exiting child must surface ChildExited (got {})",
+            match &result {
+                Ok(_) => "an unexpected successful connection".to_owned(),
+                Err(e) => format!("{e}"),
+            },
+        );
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "child-exit fast-fail must return well under the {budget:?} budget, took {elapsed:?}",
+        );
+    }
 }

--- a/crates/aether-capabilities/src/engine/proxy/mod.rs
+++ b/crates/aether-capabilities/src/engine/proxy/mod.rs
@@ -70,6 +70,13 @@ mod sinks;
 #[cfg(not(target_family = "wasm"))]
 pub use config::{EngineProxyConfig, HeartbeatParams};
 
+// The engines cap (`aether.engine`) classifies a failed `spawn_child`
+// with this to decide whether to re-fork on a fresh port (a stolen-port
+// child-exited death) or report a dead spawn. Native-only — it names
+// `SpawnError` / `BootError`.
+#[cfg(not(target_family = "wasm"))]
+pub use connect::is_reforkable_spawn_failure;
+
 /// `aether.engine.proxy:<id>` cap **identity** (ADR-0122 identity/runtime
 /// split). A ZST carrying only the addressing — `Addressable` (`NAMESPACE`,
 /// `Resolver`), the per-handler `HandlesKind` markers, and the instanced

--- a/crates/aether-capabilities/src/engine/proxy/runtime.rs
+++ b/crates/aether-capabilities/src/engine/proxy/runtime.rs
@@ -251,6 +251,7 @@ impl NativeActor for EngineProxy {
             wake_kind,
             retry,
             config.connect_budget,
+            config.spawned.as_mut(),
         ) {
             Ok(conn) => conn,
             Err(e) => {

--- a/crates/aether-capabilities/src/engine/server/config.rs
+++ b/crates/aether-capabilities/src/engine/server/config.rs
@@ -68,6 +68,17 @@ pub struct EngineConfig {
     /// (retry until the dial succeeds or hits a terminal error).
     #[config(default = 30)]
     pub proxy_connect_budget_secs: u64,
+    /// How many times `on_spawn` re-forks a substrate on a fresh port
+    /// before giving up (`AETHER_HUB_PROXY_SPAWN_ATTEMPTS` /
+    /// `--hub-proxy-spawn-attempts`, issue 2422). A freshly-forked
+    /// substrate can lose its guessed RPC port to another socket in
+    /// `free_local_port`'s TOCTOU window and exit on a fatal bind; a
+    /// re-fork on a fresh port escapes the stolen port, since the theft
+    /// is per-port and independent across attempts, so N attempts drop
+    /// the failure probability geometrically. `1` preserves the
+    /// single-attempt behavior (no re-fork).
+    #[config(default = 3)]
+    pub proxy_spawn_attempts: u32,
     /// Layout-root override for the hub's content-addressed binary
     /// store (`AETHER_BINARY_STORE_DIR`, unprefixed — the ops escape
     /// hatch and the fleet tests' per-process isolation knob). Unset
@@ -113,6 +124,10 @@ impl Default for EngineConfig {
             // startup-dial budget — `0` would mean wait-forever and
             // hang on a genuinely dead substrate.
             proxy_connect_budget_secs: DEFAULT_PROXY_CONNECT_BUDGET_SECS,
+            // A single attempt by default in tests: the re-fork loop is
+            // a contention mitigation, and tests fork real substrates
+            // serially, so one attempt keeps the path deterministic.
+            proxy_spawn_attempts: 1,
             binary_store_dir: None,
             binary_disk_budget_bytes: DEFAULT_DISK_BUDGET_BYTES,
             binary_bootstrap: HashSet::new(),
@@ -140,6 +155,12 @@ impl EngineConfig {
     pub(super) fn connect_budget(&self) -> Option<Duration> {
         (self.proxy_connect_budget_secs != 0)
             .then(|| Duration::from_secs(self.proxy_connect_budget_secs))
+    }
+
+    /// The bounded re-fork attempt count for `on_spawn` (issue 2422),
+    /// clamped to at least 1 — `0` would never fork at all.
+    pub(super) fn spawn_attempts(&self) -> u32 {
+        self.proxy_spawn_attempts.max(1)
     }
 }
 

--- a/crates/aether-capabilities/src/engine/server/runtime.rs
+++ b/crates/aether-capabilities/src/engine/server/runtime.rs
@@ -10,7 +10,9 @@
 use super::{EngineConfig, EngineServer};
 pub use crate::engine::kinds::ForwardEnvelope;
 use crate::engine::kinds::{EngineAlive, EngineDied, RouteEnvelope};
-pub use crate::engine::proxy::{EngineProxy, EngineProxyConfig, HeartbeatParams};
+pub use crate::engine::proxy::{
+    EngineProxy, EngineProxyConfig, HeartbeatParams, is_reforkable_spawn_failure,
+};
 pub use crate::engine::store::{ArtifactStore, LAYOUT_VERSION_DIR};
 use aether_actor::runtime;
 pub use aether_data::{EngineId, Kind, MailboxId, Uuid};
@@ -105,6 +107,13 @@ pub struct EngineServerState {
     /// (issue 2072), resolved once from `EngineConfig` at init.
     /// `Some(d)` caps the retry; `None` is the wait-forever sentinel.
     pub(super) connect_budget: Option<Duration>,
+    /// How many times `on_spawn` re-forks a substrate on a fresh port
+    /// before giving up (issue 2422), resolved once from `EngineConfig`
+    /// at init. A freshly-forked substrate can lose its guessed RPC
+    /// port to another socket in `free_local_port`'s TOCTOU window and
+    /// exit on a fatal bind; a re-fork on a fresh port escapes it.
+    /// Clamped to at least 1.
+    pub(super) spawn_attempts: u32,
     /// Bounded ring of the last [`RECENTLY_DIED_CAP`] engines that
     /// left the table and why (issue 1906). `on_terminate` /
     /// `on_engine_died` push a [`DeadRecord`] at the removal site;
@@ -174,6 +183,7 @@ impl NativeActor for EngineServer {
             mailer: ctx.mailer(),
             heartbeat: config.heartbeat_params(),
             connect_budget: config.connect_budget(),
+            spawn_attempts: config.spawn_attempts(),
             recently_died: VecDeque::new(),
             store,
         })
@@ -253,98 +263,135 @@ impl NativeActor for EngineServer {
             };
         };
 
-        let rpc_port = match free_local_port() {
-            Ok(port) => port,
-            Err(e) => {
-                return SpawnEngineResult::Err {
-                    error: format!("could not allocate an RPC port: {e}"),
-                };
-            }
-        };
-
-        // Allocate a unique scratch subdirectory per spawned engine to
-        // hold its materialized executable.
-        let engine_id = EngineId(Uuid::from_u128(state.next_engine_seq));
-        state.next_engine_seq += 1;
-        let engine_store_dir = engine_store_root().join(engine_id.0.simple().to_string());
-
-        // Stored bytes are content-addressed and not directly
-        // fork-exec'able, so materialize the resolved entry to an
-        // executable temp file under this engine's scratch dir and fork
-        // that (ADR-0115 §Execution); the caller never sees the path.
-        let exec_path = engine_store_dir.join("substrate");
-        if let Err(e) = realize_executable(&artifact.path, &exec_path) {
-            return SpawnEngineResult::Err {
-                error: format!(
-                    "materializing binary {} to {}: {e}",
-                    artifact.hash,
-                    exec_path.display()
-                ),
+        // Bounded re-fork (issue 2422): a freshly-forked substrate can
+        // lose its guessed RPC port to another socket in
+        // `free_local_port`'s TOCTOU window and exit on its fatal bind,
+        // surfacing as a child-exited-during-startup failure. Each
+        // attempt allocates a *fresh* port (and engine id / scratch
+        // dir) and re-forks; the theft is per-port and independent
+        // across attempts, so N attempts drop the failure probability
+        // geometrically. Any non-re-forkable failure returns
+        // immediately. The proxy already kills the child it owns on a
+        // failed init, so an abandoned attempt leaves no orphan.
+        let attempts = state.spawn_attempts;
+        let mut last_error = String::new();
+        for attempt in 0..attempts {
+            let rpc_port = match free_local_port() {
+                Ok(port) => port,
+                Err(e) => {
+                    return SpawnEngineResult::Err {
+                        error: format!("could not allocate an RPC port: {e}"),
+                    };
+                }
             };
-        }
 
-        let mut command = Command::new(&exec_path);
-        command
-            .args(&mail.args)
-            .env("AETHER_RPC_PORT", rpc_port.to_string())
-            .stdin(Stdio::null());
-        // A spawn carrying a component list rides in as a boot-manifest
-        // path; inject it the same way as the RPC port so the spawned
-        // chassis reads the listed wasm itself and comes up with those
-        // components already loading (issue 1776).
-        if let Some(boot_manifest) = &mail.boot_manifest {
-            command.env("AETHER_BOOT_MANIFEST", boot_manifest);
-        }
-        let child = match command.spawn() {
-            Ok(child) => child,
-            Err(e) => {
+            // Allocate a unique scratch subdirectory per attempt to
+            // hold its materialized executable.
+            let engine_id = EngineId(Uuid::from_u128(state.next_engine_seq));
+            state.next_engine_seq += 1;
+            let engine_store_dir = engine_store_root().join(engine_id.0.simple().to_string());
+
+            // Stored bytes are content-addressed and not directly
+            // fork-exec'able, so materialize the resolved entry to an
+            // executable temp file under this engine's scratch dir and
+            // fork that (ADR-0115 §Execution); the caller never sees the
+            // path.
+            let exec_path = engine_store_dir.join("substrate");
+            if let Err(e) = realize_executable(&artifact.path, &exec_path) {
                 return SpawnEngineResult::Err {
-                    error: format!("failed to spawn {}: {e}", exec_path.display()),
+                    error: format!(
+                        "materializing binary {} to {}: {e}",
+                        artifact.hash,
+                        exec_path.display()
+                    ),
                 };
             }
-        };
 
-        let subname = engine_id.0.simple().to_string();
-        let rpc_addr = format!("127.0.0.1:{rpc_port}");
+            let mut command = Command::new(&exec_path);
+            command
+                .args(&mail.args)
+                .env("AETHER_RPC_PORT", rpc_port.to_string())
+                .stdin(Stdio::null());
+            // A spawn carrying a component list rides in as a
+            // boot-manifest path; inject it the same way as the RPC port
+            // so the spawned chassis reads the listed wasm itself and
+            // comes up with those components already loading (issue
+            // 1776).
+            if let Some(boot_manifest) = &mail.boot_manifest {
+                command.env("AETHER_BOOT_MANIFEST", boot_manifest);
+            }
+            let child = match command.spawn() {
+                Ok(child) => child,
+                Err(e) => {
+                    return SpawnEngineResult::Err {
+                        error: format!("failed to spawn {}: {e}", exec_path.display()),
+                    };
+                }
+            };
 
-        // `finish()` runs `EngineProxy::init` on this thread: it
-        // dials the substrate (retrying while it comes up) and, on
-        // failure, kills the child it was handed — so a failed
-        // spawn never leaves an orphan for the cap to clean up.
-        let result = ctx
-            .spawn_child::<EngineProxy>(
-                Subname::Named(&subname),
-                EngineProxyConfig {
-                    engine_id,
-                    rpc_addr,
-                    spawned: Some(child),
-                    heartbeat: state.heartbeat,
-                    connect_budget: state.connect_budget,
-                },
-            )
-            .finish();
+            let subname = engine_id.0.simple().to_string();
+            let rpc_addr = format!("127.0.0.1:{rpc_port}");
 
-        match result {
-            Ok(proxy_mailbox) => {
-                state.engines.insert(
-                    engine_id,
-                    EngineEntry {
-                        proxy_mailbox,
-                        rpc_port,
-                        // Just connected = alive; the heartbeat
-                        // refreshes this on each confirmed Pong.
-                        last_alive: Instant::now(),
+            // `finish()` runs `EngineProxy::init` on this thread: it
+            // dials the substrate (retrying while it comes up) and, on
+            // failure, kills the child it was handed — so a failed
+            // spawn never leaves an orphan for the cap to clean up.
+            let result = ctx
+                .spawn_child::<EngineProxy>(
+                    Subname::Named(&subname),
+                    EngineProxyConfig {
+                        engine_id,
+                        rpc_addr,
+                        spawned: Some(child),
+                        heartbeat: state.heartbeat,
+                        connect_budget: state.connect_budget,
                     },
-                );
-                SpawnEngineResult::Ok {
-                    engine_id: engine_id.0.to_string(),
-                    rpc_port,
+                )
+                .finish();
+
+            match result {
+                Ok(proxy_mailbox) => {
+                    state.engines.insert(
+                        engine_id,
+                        EngineEntry {
+                            proxy_mailbox,
+                            rpc_port,
+                            // Just connected = alive; the heartbeat
+                            // refreshes this on each confirmed Pong.
+                            last_alive: Instant::now(),
+                        },
+                    );
+                    return SpawnEngineResult::Ok {
+                        engine_id: engine_id.0.to_string(),
+                        rpc_port,
+                    };
+                }
+                Err(e) => {
+                    last_error = format!("proxy failed to connect to the spawned substrate: {e:?}");
+                    // Re-fork only the bind-stolen-port child-exited
+                    // death, and only if attempts remain. Any other
+                    // failure is terminal — re-forking it would just
+                    // burn the budget again.
+                    if is_reforkable_spawn_failure(&e) && attempt + 1 < attempts {
+                        tracing::warn!(
+                            target: "aether_substrate::engine_server",
+                            engine_id = %engine_id.0,
+                            rpc_port,
+                            attempt = attempt + 1,
+                            attempts,
+                            "engine spawn: substrate exited during startup (likely a stolen RPC port); re-forking on a fresh port",
+                        );
+                        continue;
+                    }
+                    return SpawnEngineResult::Err { error: last_error };
                 }
             }
-            Err(e) => SpawnEngineResult::Err {
-                error: format!("proxy failed to connect to the spawned substrate: {e:?}"),
-            },
         }
+
+        // Only reached if `attempts` is 0, which `spawn_attempts()`
+        // clamps away — keep an honest terminal `Err` rather than an
+        // unreachable panic.
+        SpawnEngineResult::Err { error: last_error }
     }
 
     /// Terminate a supervised engine.


### PR DESCRIPTION
Closes #2422.

## Summary

A freshly-forked substrate's proxy-connect intermittently failed with `ConnectionRefused (os 61)` under concurrent-spawn host contention, while an isolated spawn succeeded. The original "no retry/backoff" premise was stale — #2072 already added a bounded retry. The real root cause is a TOCTOU port-allocation race: `free_local_port()` binds `:0`, reads the OS-assigned port, drops the listener, and returns the bare port; under contention the kernel can hand that ephemeral port to another socket before the forked substrate re-binds it, so the substrate's fatal bind exits it and the proxy dials a dead port for the full 30 s budget.

The fix makes a stolen port recoverable instead of fatal, two composing pieces inside `aether-capabilities`:

- **Child-exit fast-fail.** `connect_proxy` now takes the forked `Child` and `try_wait`s it each retry iteration. A child that has already exited (the bind-stolen-port death) returns a new terminal `ProxyConnectError::ChildExited` immediately rather than dialing a dead port for the whole budget — converting a 30 s hang into a sub-second failure, which relieves the secondary symptom (a blocked spawn starving the single-threaded engines-cap dispatcher).
- **Bounded re-fork.** `on_spawn` wraps port-allocate → fork → `finish()` in a bounded loop driven by a new `proxy_spawn_attempts` knob (`#[config(default = 3)]`, `AETHER_HUB_PROXY_SPAWN_ATTEMPTS`). A re-forkable child-exited failure (classified via `is_reforkable_spawn_failure` downcasting through `SpawnError::InitFailed`) re-forks on a *fresh* port; anything else is terminal. The theft is per-port and independent across attempts, so N attempts drop the failure probability geometrically. The proxy kills the child it owns on a failed init, so an abandoned attempt leaves no orphan. `1` preserves single-attempt behavior.

Crate-local; no wire/startup-protocol change. The readiness/port-report handshake that would eliminate the TOCTOU window outright is recorded in the issue as the heavier alternative if re-fork proves insufficient.

## Test plan

Deterministic tripwire unit test in `connect.rs` (`child_exit_fast_fails_well_under_budget`): an immediately-exiting child dialing an unbound port under a generous 30 s budget must surface `ChildExited` in well under 5 s — without the fast-fail this blocks the full budget. The end-to-end re-fork recovery is exercised by the real fork+exec FleetBench path but is not deterministically unit-testable (port theft can't be provoked on demand), so no flaky concurrent-spawn assertion is authored, per the plan. Full local validation: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace` (1892 passed), `cargo doc --workspace --no-deps`.

## Generated by

`/implement` — agent execution of [scoped issue #2422](https://github.com/iamacoffeepot/aether/issues/2422).
