### PR TITLE
refactor(aether-actor): act on the audit-quality panel's cleanup findings

### DIFF
--- a/crates/aether-actor/src/mail/mod.rs
+++ b/crates/aether-actor/src/mail/mod.rs
@@ -56,7 +56,7 @@ impl ReplyHandle {
     /// constructor accepts any `u32`.
     #[doc(hidden)]
     #[must_use]
-    pub fn __from_raw(raw: u32) -> Self {
+    pub(crate) fn __from_raw(raw: u32) -> Self {
         Self { raw }
     }
 

--- a/crates/aether-actor/src/wasm/bridge/log.rs
+++ b/crates/aether-actor/src/wasm/bridge/log.rs
@@ -1,0 +1,46 @@
+// Wire-encode: `usize → u32` narrowings forward `(ptr, len)` pairs
+// to the wasm32 host-fn ABI. wasm32 already has 32-bit addresses;
+// `_p32`-suffixed FFI per ADR-0024 documents the convention.
+#![allow(clippy::cast_possible_truncation)]
+
+//! Log FFI bridge — the host-fn-facing layer for log events.
+//!
+//! ADR-0081 §7: re-emit one `tracing::*` event on the host side.
+//! Split from `bridge::mail` (which owns the outbound-mail op family)
+//! to keep one op family per module.
+
+#[cfg(target_family = "wasm")]
+use crate::wasm::raw;
+
+/// ADR-0081 §7: re-emit one `tracing::*` event on the host side.
+/// Called by the wasm subscriber per event so the host's
+/// `ActorAwareLayer` lands the entry in the trampoline's
+/// `ActorLogRing`. `level` is the `0 = trace .. 4 = error`
+/// mapping the rest of `aether.log.*` uses; `target` and
+/// `message` are the pre-rendered tracing field text.
+///
+/// Fire-and-forget: no return code. The host copies before
+/// returning; the guest's borrows are released as soon as the
+/// FFI call completes.
+///
+/// Only callable from wasm32 — installed as the [`crate::log::LogSink`]
+/// by the guest runtime (`export!`) and invoked from
+/// [`crate::log::ForwardingSubscriber::event`].
+#[cfg(target_family = "wasm")]
+pub fn emit_log_event(level: u8, target: &str, message: &str) {
+    let target_bytes = target.as_bytes();
+    let message_bytes = message.as_bytes();
+    // SAFETY: forwards to `raw::log_event`, whose ABI is documented
+    // at the import site in `ffi/raw.rs`. The `(ptr, len)` pairs are
+    // derived from `&str` references valid for `len` bytes for the
+    // call's duration; the host copies before returning.
+    unsafe {
+        raw::log_event(
+            u32::from(level),
+            target_bytes.as_ptr().addr() as u32,
+            target_bytes.len() as u32,
+            message_bytes.as_ptr().addr() as u32,
+            message_bytes.len() as u32,
+        );
+    }
+}

--- a/crates/aether-actor/src/wasm/bridge/mail.rs
+++ b/crates/aether-actor/src/wasm/bridge/mail.rs
@@ -14,6 +14,9 @@
 //! Correlation is universal — every send mints a correlation id so a
 //! handler can match the reply to the request it sent. It's a property
 //! of the outbound mail, so it lives in this module.
+//!
+//! Log-event emission lives in the sibling [`crate::wasm::bridge::log`]
+//! module (a distinct FFI op family).
 
 use crate::wasm::raw;
 
@@ -124,39 +127,6 @@ pub fn prev_correlation() -> u64 {
     // the `#[cfg(target_family = "wasm")]` import gate enforces
     // (the host-target stub panics rather than returning garbage).
     unsafe { raw::prev_correlation() }
-}
-
-/// ADR-0081 §7: re-emit one `tracing::*` event on the host side.
-/// Called by the wasm subscriber per event so the host's
-/// `ActorAwareLayer` lands the entry in the trampoline's
-/// `ActorLogRing`. `level` is the `0 = trace .. 4 = error`
-/// mapping the rest of `aether.log.*` uses; `target` and
-/// `message` are the pre-rendered tracing field text.
-///
-/// Fire-and-forget: no return code. The host copies before
-/// returning; the guest's borrows are released as soon as the
-/// FFI call completes.
-///
-/// Only callable from wasm32 — installed as the [`crate::log::LogSink`]
-/// by the guest runtime (`export!`) and invoked from
-/// [`crate::log::ForwardingSubscriber::event`].
-#[cfg(target_family = "wasm")]
-pub fn emit_log_event(level: u8, target: &str, message: &str) {
-    let target_bytes = target.as_bytes();
-    let message_bytes = message.as_bytes();
-    // SAFETY: forwards to `raw::log_event`, whose ABI is documented
-    // at the import site in `ffi/raw.rs`. The `(ptr, len)` pairs are
-    // derived from `&str` references valid for `len` bytes for the
-    // call's duration; the host copies before returning.
-    unsafe {
-        raw::log_event(
-            u32::from(level),
-            target_bytes.as_ptr().addr() as u32,
-            target_bytes.len() as u32,
-            message_bytes.as_ptr().addr() as u32,
-            message_bytes.len() as u32,
-        );
-    }
 }
 
 /// ADR-0097: stage a sibling-spawn request and return the new

--- a/crates/aether-actor/src/wasm/bridge/mod.rs
+++ b/crates/aether-actor/src/wasm/bridge/mod.rs
@@ -8,11 +8,12 @@
 //! audited ptr/len marshalling) while closing the over-exposure the
 //! `pub static` forms created.
 //!
+//! - `log` — log-event FFI (`emit_log_event`). Split from `mail` because
+//!   it is a distinct op family with no relation to mail routing.
 //! - `mail` — outbound mail (`send_mail`, `reply_mail`,
-//!   `prev_correlation`, `emit_log_event`, `spawn_sibling`,
-//!   `spawn_inline_child`). Correlation lives here because every send
-//!   mints one so a handler can match a reply to the request it sent —
-//!   it's mail-level metadata.
+//!   `prev_correlation`, `spawn_sibling`, `spawn_inline_child`).
+//!   Correlation lives here because every send mints one so a handler
+//!   can match a reply to the request it sent — it's mail-level metadata.
 //! - `persist` — migration-bundle deposit
 //!   (`save_state`), used during `on_dehydrate` only.
 //!
@@ -21,5 +22,6 @@
 //! per-stage capability traits in [`crate::model::ctx`], not a single
 //! transport trait.
 
+pub(crate) mod log;
 pub(crate) mod mail;
 pub(crate) mod persist;

--- a/crates/aether-actor/src/wasm/ctx.rs
+++ b/crates/aether-actor/src/wasm/ctx.rs
@@ -27,7 +27,7 @@ use crate::model::{
     validate_namespace_segment,
 };
 use crate::wasm::bridge::{mail, persist};
-use crate::wasm::inline::InlineRegistry;
+use crate::wasm::inline::{ChainMode, InlineRegistry};
 use crate::wasm::mailbox::WasmActorMailbox;
 use crate::wasm::{ActorInitError, ErasedWasmActor, WasmActor};
 use alloc::boxed::Box;
@@ -122,8 +122,14 @@ impl RelativeMailbox<'_> {
     /// send.
     pub fn send<K: Kind>(&self, payload: &K) {
         let bytes = payload.encode_into_bytes();
-        self.inline
-            .route_or_enqueue(self.id.0, K::ID.0, &bytes, 1, false, self.sender);
+        self.inline.route_or_enqueue(
+            self.id.0,
+            K::ID.0,
+            &bytes,
+            1,
+            ChainMode::Inherit,
+            self.sender,
+        );
     }
 
     /// Fire-and-forget send to this relative (ADR-0080 §7 detach signal).
@@ -132,8 +138,14 @@ impl RelativeMailbox<'_> {
     /// resolved relative never takes.
     pub fn send_detached<K: Kind>(&self, payload: &K) {
         let bytes = payload.encode_into_bytes();
-        self.inline
-            .route_or_enqueue(self.id.0, K::ID.0, &bytes, 1, true, self.sender);
+        self.inline.route_or_enqueue(
+            self.id.0,
+            K::ID.0,
+            &bytes,
+            1,
+            ChainMode::Detached,
+            self.sender,
+        );
     }
 }
 
@@ -167,7 +179,7 @@ pub enum SpawnError {
 /// self-address.
 pub struct WasmCtx<'a, M: ReplyMode = Single> {
     mailbox: u64,
-    sender: Option<u32>,
+    sender: Option<ReplyHandle>,
     /// The inbound source — the folded [`MailboxId`] raw value of whoever
     /// sent the mail currently being dispatched, threaded onto the ctx at
     /// construction (issues 1987 + 2001). For an in-place (intra-cluster)
@@ -252,13 +264,14 @@ impl<M: ReplyMode> WasmCtx<'_, M> {
     /// broadcast mail (which have no reply target) land as `None`.
     #[doc(hidden)]
     pub fn __set_reply_to(&mut self, sender: Option<ReplyHandle>) {
-        self.sender = sender.map(ReplyHandle::raw);
+        self.sender = sender;
     }
 
     /// Reply target for the mail currently being dispatched. Mirrors
     /// [`OutboundReply::reply_target`].
+    #[must_use]
     pub fn reply_target(&self) -> Option<ReplyHandle> {
-        self.sender.map(ReplyHandle::__from_raw)
+        self.sender
     }
 
     /// The component's own mailbox id — the value the substrate uses to
@@ -334,10 +347,10 @@ impl<M: ReplyMode> WasmCtx<'_, M> {
         // ADR-0029) — this is the id definition for the new instance, computed
         // before any lineage carry exists.
         #[allow(clippy::disallowed_methods)]
-        let tag = mailbox_id_from_name(<A as Addressable>::NAMESPACE).0;
+        let type_tag = mailbox_id_from_name(<A as Addressable>::NAMESPACE).0;
         let (is_counter, full_subname) = resolve_subname(subname)?;
         let config_bytes = config.encode_into_bytes();
-        let id = mail::spawn_sibling(tag, is_counter, &full_subname, &config_bytes);
+        let id = mail::spawn_sibling(type_tag, is_counter, &full_subname, &config_bytes);
         Ok(MailboxId(id))
     }
 
@@ -519,8 +532,14 @@ impl<'a, M: ReplyMode> WasmCtx<'a, M> {
     /// handler's in-flight causal chain (ADR-0080 §7).
     pub fn send<K: Kind>(&mut self, mailbox: Mailbox<K>, payload: &K) {
         let bytes = payload.encode_into_bytes();
-        self.inline
-            .route_or_enqueue(mailbox.mailbox(), K::ID.0, &bytes, 1, false, self.mailbox);
+        self.inline.route_or_enqueue(
+            mailbox.mailbox(),
+            K::ID.0,
+            &bytes,
+            1,
+            ChainMode::Inherit,
+            self.mailbox,
+        );
     }
 
     /// Issue 1987: send `payload` to a raw [`MailboxId`], threading this
@@ -533,7 +552,7 @@ impl<'a, M: ReplyMode> WasmCtx<'a, M> {
     pub fn send_to<K: Kind>(&mut self, id: MailboxId, payload: &K) {
         let bytes = payload.encode_into_bytes();
         self.inline
-            .route_or_enqueue(id.0, K::ID.0, &bytes, 1, false, self.mailbox);
+            .route_or_enqueue(id.0, K::ID.0, &bytes, 1, ChainMode::Inherit, self.mailbox);
     }
 }
 
@@ -580,20 +599,16 @@ where
     <A as WasmActor>::State: ErasedWasmActor,
 {
     let mut ctx = WasmInitCtx::__new(alias.0);
-    match A::init(config, &mut ctx) {
-        Ok(child) => {
-            registry.insert_child(
-                alias,
-                type_tag,
-                full_subname,
-                is_counter,
-                parent,
-                Box::new(child),
-            );
-            Ok(alias)
-        }
-        Err(err) => Err(SpawnError::InitFailed(err)),
-    }
+    let child = A::init(config, &mut ctx).map_err(SpawnError::InitFailed)?;
+    registry.insert_child(
+        alias,
+        type_tag,
+        full_subname,
+        is_counter,
+        parent,
+        Box::new(child),
+    );
+    Ok(alias)
 }
 
 // ADR-0114 addressing amendment: every `WasmCtx` send resolves the recipient
@@ -616,7 +631,7 @@ impl<M: ReplyMode> MailSender for WasmCtx<'_, M> {
             K::ID.0,
             &bytes,
             1,
-            false,
+            ChainMode::Inherit,
             self.mailbox,
         );
     }
@@ -633,7 +648,7 @@ impl<M: ReplyMode> MailSender for WasmCtx<'_, M> {
             K::ID.0,
             bytes,
             payloads.len() as u32,
-            false,
+            ChainMode::Inherit,
             self.mailbox,
         );
     }
@@ -649,7 +664,7 @@ impl<M: ReplyMode> MailSender for WasmCtx<'_, M> {
             K::ID.0,
             &bytes,
             1,
-            false,
+            ChainMode::Inherit,
             self.mailbox,
         );
     }
@@ -670,7 +685,7 @@ impl<M: ReplyMode> MailSender for WasmCtx<'_, M> {
             K::ID.0,
             &bytes,
             1,
-            true,
+            ChainMode::Detached,
             self.mailbox,
         );
     }
@@ -685,7 +700,7 @@ impl<M: ReplyMode> MailSender for WasmCtx<'_, M> {
             K::ID.0,
             &bytes,
             1,
-            true,
+            ChainMode::Detached,
             self.mailbox,
         );
     }
@@ -699,7 +714,7 @@ impl OutboundReply for WasmCtx<'_, Manual> {
     type ReplyHandle = ReplyHandle;
 
     fn reply_target(&self) -> Option<ReplyHandle> {
-        self.sender.map(ReplyHandle::__from_raw)
+        self.sender
     }
 
     fn source_mailbox(&self) -> Option<MailboxId> {
@@ -714,9 +729,9 @@ impl OutboundReply for WasmCtx<'_, Manual> {
     }
 
     fn reply<K: Kind>(&mut self, payload: &K) {
-        if let Some(raw) = self.sender {
+        if let Some(handle) = self.sender {
             let bytes = payload.encode_into_bytes();
-            mail::reply_mail(raw, K::ID.0, &bytes, 1, self.mailbox);
+            mail::reply_mail(handle.raw(), K::ID.0, &bytes, 1, self.mailbox);
         }
     }
 
@@ -732,7 +747,7 @@ impl OutboundReply for WasmCtx<'_, Manual> {
 /// it can collect every saved blob and pack them into a single composite,
 /// then call the real host `save_state` once.
 #[derive(Default)]
-pub struct CapturedState {
+pub(crate) struct CapturedState {
     /// The most recent `(version, bytes)` the hook saved. `None` until the
     /// hook calls `save_state`; the last call wins (mirroring the host's
     /// single-`Option<StateBundle>` overwrite contract).
@@ -782,7 +797,7 @@ impl<'a> WasmDropCtx<'a> {
     /// before a single real host `save_state`.
     #[doc(hidden)]
     #[must_use]
-    pub fn __new_capturing(mailbox: u64, capture: &'a mut CapturedState) -> Self {
+    pub(crate) fn __new_capturing(mailbox: u64, capture: &'a mut CapturedState) -> Self {
         Self {
             mailbox,
             capture: Some(capture),

--- a/crates/aether-actor/src/wasm/guest_alloc.rs
+++ b/crates/aether-actor/src/wasm/guest_alloc.rs
@@ -1,0 +1,203 @@
+/// Generic guest allocator backing host→guest payload delivery (ADR-0095).
+///
+/// The substrate writes every inbound payload — mail, init config, rehydrate
+/// state — into a region it obtains from this allocator, then calls the entry
+/// point (`receive` / `init_with_config` / `on_rehydrate`). The host owns no
+/// fixed offset into guest memory; the guest reports where its memory is, so
+/// delivery is independent of the guest's linear-memory layout.
+///
+/// The export is `cabi_realloc`-shaped (the Component Model canonical): one
+/// function that allocates (`old_ptr == 0`), grows possibly-relocating
+/// (`new_size > old_size`), or frees (`new_size == 0`). The substrate drives it
+/// under the run-token invariant — one small region allocated once and reused,
+/// one large region grown to fit, each consumed synchronously — and never frees
+/// (wasm has no `memory.shrink`, so a free reclaims nothing).
+///
+/// The first sub-threshold allocation — the small delivery region the host
+/// obtains once at instantiate (`align = 8`, `new_size <= SMALL_REGION_BYTES`)
+/// — is served from a reused `static` scratch (ADR-0095 point 4) rather than
+/// the global allocator. Every later allocation (the large region, any
+/// subsequent small one) falls through to the global allocator. The scratch is
+/// purely a guest-side optimization beneath the same ABI; a guest in any
+/// language supplies the same export however it likes.
+///
+/// The module is not target-gated so the allocator is host-testable (its body
+/// is plain `alloc`-crate code, like [`crate::Slot`]); the `realloc_p32` FFI
+/// shims that call it remain wasm32-only.
+use alloc::alloc::{Layout, alloc, dealloc, realloc};
+use core::cell::UnsafeCell;
+use core::ptr::{copy_nonoverlapping, null_mut};
+
+/// Size of the `static` scratch that backs the first sub-threshold
+/// delivery allocation. Kept `>=` the host's `SMALL_REGION_BYTES`
+/// (`aether-substrate`, currently 8 KiB) so the scratch covers that
+/// instantiate-time small region. If it ever drifts below the host floor
+/// the first small allocation simply spills to the global allocator —
+/// still correct, just no longer served from the scratch.
+const SCRATCH_REGION_BYTES: usize = 8 * 1024;
+
+/// Alignment the scratch satisfies. The host requests `align = 8` for the
+/// delivery region; a request needing more falls through to the global
+/// allocator even if it would fit by size.
+const SCRATCH_ALIGN: usize = 8;
+
+/// Reused backing store for the first small delivery region plus a
+/// single-shot claim flag. `UnsafeCell` + a blanket `Sync` impl mirrors
+/// [`crate::Slot`]: the guest is single-threaded (ADR-0010 §5) and the
+/// substrate serializes delivery under the run token, so the cell is never
+/// touched concurrently and no atomics are needed. `bytes` is the first
+/// field of a `repr(C, align(8))` struct, so its base is
+/// `SCRATCH_ALIGN`-aligned.
+#[repr(C, align(8))]
+struct Scratch {
+    bytes: UnsafeCell<[u8; SCRATCH_REGION_BYTES]>,
+    claimed: UnsafeCell<bool>,
+}
+
+// SAFETY: a single-threaded WASM guest plus the substrate's serialized,
+// run-token-gated delivery mean `SCRATCH` is only ever touched from one
+// thread at a time — the same argument that licenses `crate::Slot`'s
+// `Sync`. On the host unit-test build the static is reached from one test.
+unsafe impl Sync for Scratch {}
+
+static SCRATCH: Scratch = Scratch {
+    bytes: UnsafeCell::new([0u8; SCRATCH_REGION_BYTES]),
+    claimed: UnsafeCell::new(false),
+};
+
+/// `cabi_realloc`-shaped reallocation.
+///
+/// - `old_ptr == 0` — allocate `new_size` bytes, return the pointer. The
+///   first such call that fits the scratch (`new_size <=
+///   SCRATCH_REGION_BYTES`, `align <= SCRATCH_ALIGN`) returns the reused
+///   `static` scratch base; later calls use the global allocator.
+/// - `new_size == 0` — free the `(old_ptr, old_size, align)` allocation,
+///   return null. Freeing the scratch base is a no-op.
+/// - otherwise — resize the allocation to `new_size`, returning the current
+///   pointer (which differs from `old_ptr` if the block was relocated).
+///
+/// # Safety
+/// `old_ptr` / `old_size` / `align` must describe a live allocation from a
+/// prior call (or `0` / `0` for a fresh allocation), and `align` must be a
+/// nonzero power of two. The guest is single-threaded, so there is no
+/// aliasing.
+pub unsafe fn realloc_bytes(
+    old_ptr: *mut u8,
+    old_size: usize,
+    align: usize,
+    new_size: usize,
+) -> *mut u8 {
+    let scratch_base = SCRATCH.bytes.get().cast::<u8>();
+    if new_size == 0 {
+        if !old_ptr.is_null() && old_ptr != scratch_base {
+            // SAFETY: caller's layout contract holds (`align` a nonzero
+            // power of two), and `old_ptr` is a live global allocation —
+            // the scratch base is excluded above, so this only frees global
+            // memory, never the `static` scratch.
+            unsafe {
+                let layout = Layout::from_size_align_unchecked(old_size, align);
+                dealloc(old_ptr, layout);
+            }
+        }
+        // Freeing the scratch base reclaims nothing (it is a `static`); the
+        // host never frees the small region anyway (ADR-0095 point 6).
+        return null_mut();
+    }
+    if old_ptr.is_null() {
+        // SAFETY: single-threaded guest + serialized delivery — no other
+        // live reference to the claim flag (the `Scratch` `Sync` argument).
+        let already_claimed = unsafe { *SCRATCH.claimed.get() };
+        if !already_claimed && new_size <= SCRATCH_REGION_BYTES && align <= SCRATCH_ALIGN {
+            // SAFETY: same single-threaded / serialized argument; this is
+            // the only writer of the flag, and it transitions once.
+            unsafe { *SCRATCH.claimed.get() = true };
+            return scratch_base;
+        }
+        // SAFETY: caller's layout contract holds; a fresh global allocation.
+        return unsafe {
+            let layout = Layout::from_size_align_unchecked(new_size, align);
+            alloc(layout)
+        };
+    }
+    if old_ptr == scratch_base {
+        // Contractually unreachable — the host grows the large region, not
+        // the scratch-backed small one (ADR-0095 points 4/7). Handle it
+        // without UB by allocating fresh and copying rather than passing the
+        // `static` pointer to `realloc`.
+        // SAFETY: caller's layout contract holds; `scratch_base` is a live,
+        // initialized `static` of `SCRATCH_REGION_BYTES` bytes, `fresh` is a
+        // fresh global allocation of `new_size`, and the copy length is the
+        // min of `old_size` / `new_size`, in-bounds of both regions.
+        return unsafe {
+            let layout = Layout::from_size_align_unchecked(new_size, align);
+            let fresh = alloc(layout);
+            if !fresh.is_null() {
+                copy_nonoverlapping(scratch_base, fresh, old_size.min(new_size));
+            }
+            fresh
+        };
+    }
+    // SAFETY: caller's layout contract holds; `old_ptr` / `old_size` /
+    // `align` describe a live global allocation (scratch base excluded
+    // above), matched by the global `realloc`.
+    unsafe {
+        let old_layout = Layout::from_size_align_unchecked(old_size, align);
+        realloc(old_ptr, old_layout, new_size)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The scratch serves the first eligible sub-threshold allocation and
+    /// only that one; oversized and over-aligned requests bypass it, and a
+    /// second eligible request falls through to the global allocator. Only
+    /// this test claims the process-global single-shot flag, so the
+    /// sequence is deterministic without a reset hook.
+    #[test]
+    fn scratch_serves_first_small_alloc_only() {
+        let base = SCRATCH.bytes.get().cast::<u8>();
+        let null = null_mut();
+        // SAFETY: every call obeys `realloc_bytes`' contract — `null`/`0`
+        // for fresh allocs, and a matching `(ptr, size, align)` triple to
+        // free what a prior call returned. One test thread, no aliasing.
+        unsafe {
+            // Oversized: larger than the scratch → global allocator. The
+            // flag stays unclaimed because the size gate fails.
+            let big = realloc_bytes(null, 0, SCRATCH_ALIGN, SCRATCH_REGION_BYTES + 1);
+            assert_ne!(big, base, "oversized alloc bypasses the scratch");
+            realloc_bytes(big, SCRATCH_REGION_BYTES + 1, SCRATCH_ALIGN, 0);
+
+            // Over-aligned: fits by size but needs more alignment than the
+            // scratch provides → global allocator, flag still unclaimed.
+            let aligned = realloc_bytes(null, 0, SCRATCH_ALIGN * 2, 64);
+            assert_ne!(aligned, base, "over-aligned alloc bypasses the scratch");
+            realloc_bytes(aligned, 64, SCRATCH_ALIGN * 2, 0);
+
+            // First eligible small alloc (the host's instantiate-time small
+            // region) → served from the scratch.
+            let first = realloc_bytes(null, 0, SCRATCH_ALIGN, SCRATCH_REGION_BYTES);
+            assert_eq!(
+                first, base,
+                "first eligible small alloc returns the scratch base"
+            );
+
+            // Single-shot: the next eligible alloc falls through to global.
+            let second = realloc_bytes(null, 0, SCRATCH_ALIGN, 64);
+            assert_ne!(second, base, "scratch is spent after the first claim");
+            realloc_bytes(second, 64, SCRATCH_ALIGN, 0);
+        }
+    }
+
+    /// Freeing the scratch base is a no-op that returns null and must not
+    /// reach the global allocator's `dealloc` (UB on a `static`).
+    #[test]
+    fn freeing_scratch_base_is_a_noop() {
+        let base = SCRATCH.bytes.get().cast::<u8>();
+        // SAFETY: `base` is the scratch `static`; the free branch guards it
+        // and never calls `dealloc` on it.
+        let freed = unsafe { realloc_bytes(base, SCRATCH_REGION_BYTES, SCRATCH_ALIGN, 0) };
+        assert!(freed.is_null(), "freeing the scratch returns null");
+    }
+}

--- a/crates/aether-actor/src/wasm/inline/bundle.rs
+++ b/crates/aether-actor/src/wasm/inline/bundle.rs
@@ -194,8 +194,8 @@ fn parse_framed(bytes: &[u8]) -> Option<Decomposed> {
 /// Narrow a `usize` length to the `u32` the frame stores. A bundle that
 /// large is already past the substrate's 1 MiB `save_state` cap, so the
 /// saturating clamp is a defensive floor that never fires in practice.
-fn len_u32(value: usize) -> u32 {
-    u32::try_from(value).unwrap_or(u32::MAX)
+fn len_u32(len: usize) -> u32 {
+    u32::try_from(len).unwrap_or(u32::MAX)
 }
 
 /// Bounds-checked forward reader over the framed bytes.

--- a/crates/aether-actor/src/wasm/inline/compose.rs
+++ b/crates/aether-actor/src/wasm/inline/compose.rs
@@ -242,6 +242,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::{InlineRegistry, compose_dehydrate, reconstruct_inline_children};
+    use crate::Manual;
     use crate::mail::{Mail, PriorState};
     use crate::wasm::ctx::WasmDropCtx;
     use crate::wasm::inline::bundle;
@@ -263,24 +264,15 @@ mod tests {
         fn erased_namespace(&self) -> &'static str {
             "test.inline.saving_child"
         }
-        fn erased_dispatch(
-            &mut self,
-            _ctx: &mut WasmCtx<'_, crate::Manual>,
-            _mail: Mail<'_>,
-        ) -> u32 {
+        fn erased_dispatch(&mut self, _ctx: &mut WasmCtx<'_, Manual>, _mail: Mail<'_>) -> u32 {
             0
         }
-        fn erased_wire(&mut self, _ctx: &mut WasmCtx<'_, crate::Manual>) {}
-        fn erased_unwire(&mut self, _ctx: &mut WasmCtx<'_, crate::Manual>) {}
+        fn erased_wire(&mut self, _ctx: &mut WasmCtx<'_, Manual>) {}
+        fn erased_unwire(&mut self, _ctx: &mut WasmCtx<'_, Manual>) {}
         fn erased_on_dehydrate(&mut self, ctx: &mut WasmDropCtx<'_>) {
             ctx.save_state(9, &self.tag.to_le_bytes());
         }
-        fn erased_on_rehydrate(
-            &mut self,
-            _ctx: &mut WasmCtx<'_, crate::Manual>,
-            _prior: PriorState<'_>,
-        ) {
-        }
+        fn erased_on_rehydrate(&mut self, _ctx: &mut WasmCtx<'_, Manual>, _prior: PriorState<'_>) {}
     }
 
     /// Step 3 coverage: a parent with two inline children yields a

--- a/crates/aether-actor/src/wasm/inline/mod.rs
+++ b/crates/aether-actor/src/wasm/inline/mod.rs
@@ -142,6 +142,21 @@ pub(crate) enum RouteDecision {
     Remote,
 }
 
+/// Whether a send inherits the handler's in-flight causal chain or starts
+/// a fresh one (ADR-0080 §7). Passed to
+/// [`InlineRegistry::route_or_enqueue`]; on the remote path it controls
+/// whether the host stamps the dispatch's `parent`/`root` onto the outbound
+/// send (`Inherit`) or mints a new root chain (`Detached`). The local path
+/// carries no host trace ids, so the mode is irrelevant there.
+#[derive(Clone, Copy)]
+pub(crate) enum ChainMode {
+    /// Inherit the handler's in-flight causal chain (the default `send`
+    /// path, ADR-0080 §7).
+    Inherit,
+    /// Start a fresh chain root (the `send_detached` escape hatch).
+    Detached,
+}
+
 /// The per-component inline-child registry (ADR-0114 decision #3), keyed
 /// by each child's alias [`MailboxId`]. The [`crate::export!`] macro emits
 /// one as a `static __AETHER_INLINE` per component (mirroring the parent's
@@ -235,24 +250,16 @@ impl InlineRegistry {
         // live borrow of the cell (the `Sync` argument). The borrow is
         // released before this returns, so it never spans a dispatch.
         let map = unsafe { &mut *self.inner.get() };
-        if let Some(slot) = map.get_mut(&id) {
-            slot.type_tag = type_tag;
-            slot.full_subname = full_subname;
-            slot.is_counter = is_counter;
-            slot.parent = parent;
-            slot.actor = Some(actor);
-        } else {
-            map.insert(
-                id,
-                InlineSlot {
-                    type_tag,
-                    full_subname,
-                    is_counter,
-                    parent,
-                    actor: Some(actor),
-                },
-            );
-        }
+        map.insert(
+            id,
+            InlineSlot {
+                type_tag,
+                full_subname,
+                is_counter,
+                parent,
+                actor: Some(actor),
+            },
+        );
     }
 
     /// Take the child out for dispatch, leaving its slot (and its
@@ -401,10 +408,12 @@ impl InlineRegistry {
     /// instance itself or a resident inline child) the send is pushed to
     /// the cluster-local queue for in-place dispatch by
     /// [`drain_cluster_queue`]; otherwise it goes to the host
-    /// (`MAIL_BRIDGE.send_mail`) like any cross-cluster send. `detached`
-    /// rides through to the host on the remote path (the lineage signal,
-    /// ADR-0080 §7); an in-place dispatch carries no host trace ids, so the
-    /// flag is irrelevant on the local path.
+    /// (`MAIL_BRIDGE.send_mail`) like any cross-cluster send. `mode`
+    /// selects [`ChainMode::Inherit`] (the handler's causal chain carries
+    /// through to the host on the remote path, ADR-0080 §7) or
+    /// [`ChainMode::Detached`] (the host mints a fresh chain root); an
+    /// in-place dispatch carries no host trace ids, so the mode is
+    /// irrelevant on the local path.
     ///
     /// `sender` is the sending actor's own folded [`MailboxId`] raw value —
     /// the "from" half. On the `Local` branch it is stored in the
@@ -428,7 +437,7 @@ impl InlineRegistry {
         kind: u64,
         bytes: &[u8],
         count: u32,
-        detached: bool,
+        mode: ChainMode,
         sender: u64,
     ) {
         match self.route_decision(recipient) {
@@ -446,7 +455,14 @@ impl InlineRegistry {
                 });
             }
             RouteDecision::Remote => {
-                mail::send_mail(recipient, kind, bytes, count, detached, sender);
+                mail::send_mail(
+                    recipient,
+                    kind,
+                    bytes,
+                    count,
+                    matches!(mode, ChainMode::Detached),
+                    sender,
+                );
             }
         }
     }
@@ -558,9 +574,9 @@ where
 /// Reentrancy and cycles are handled by the queue, not by nested dispatch:
 /// a drained item's handler that sends to a busy cluster member just pushes
 /// a later queue item, which this same loop picks up.
-pub fn drain_cluster_queue<MakeOwn, Own>(registry: &InlineRegistry, mut mk_own: MakeOwn)
+pub fn drain_cluster_queue<M, Own>(registry: &InlineRegistry, mut mk_own: M)
 where
-    MakeOwn: FnMut(u64) -> Own,
+    M: FnMut(u64) -> Own,
     Own: FnOnce(Mail<'_>) -> u32,
 {
     let self_id = registry.self_id();
@@ -597,7 +613,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{InlineRegistry, RouteDecision, drain_cluster_queue, membrane_dispatch};
+    use super::{ChainMode, InlineRegistry, RouteDecision, drain_cluster_queue, membrane_dispatch};
     use crate::WasmCtx;
     use crate::mail::{Mail, PriorState};
     use crate::model::ctx::OutboundReply;
@@ -784,9 +800,8 @@ mod tests {
         );
 
         let metas = registry.child_metas();
-        let meta = match metas.as_slice() {
-            [one] => one,
-            other => panic!("expected exactly one child meta, got {}", other.len()),
+        let [meta] = metas.as_slice() else {
+            panic!("expected exactly one child meta, got {}", metas.len())
         };
         assert_eq!(meta.id, id, "the meta carries the alias id");
         assert_eq!(meta.type_tag, tag, "the meta carries the actor-type tag");
@@ -1038,13 +1053,13 @@ mod tests {
         install_recording(&registry, child, root);
 
         assert_eq!(registry.queued_len(), 0, "the queue starts empty");
-        registry.route_or_enqueue(root, 7, &[1, 2, 3], 1, false, root);
+        registry.route_or_enqueue(root, 7, &[1, 2, 3], 1, ChainMode::Inherit, root);
         assert_eq!(
             registry.queued_len(),
             1,
             "an own-id send enqueues locally, no host call",
         );
-        registry.route_or_enqueue(child, 8, &[4], 1, false, root);
+        registry.route_or_enqueue(child, 8, &[4], 1, ChainMode::Inherit, root);
         assert_eq!(
             registry.queued_len(),
             2,
@@ -1064,7 +1079,7 @@ mod tests {
         let dispatches = install_recording(&registry, child, root);
 
         // Seed one local send addressed to the child.
-        registry.route_or_enqueue(child, 1, &[0xAB], 1, false, root);
+        registry.route_or_enqueue(child, 1, &[0xAB], 1, ChainMode::Inherit, root);
 
         let own_dispatches = Rc::new(Cell::new(0));
         let own_counter = Rc::clone(&own_dispatches);
@@ -1108,7 +1123,7 @@ mod tests {
 
         // Seed one own-addressed item; the parent dispatch, on its first
         // run, enqueues a follow-up addressed to the child.
-        registry.route_or_enqueue(root, 1, &[0x01], 1, false, root);
+        registry.route_or_enqueue(root, 1, &[0x01], 1, ChainMode::Inherit, root);
 
         // Record the order dispatches happened in, to prove a single drain
         // loop carried both the seed and the cascaded follow-up.
@@ -1130,7 +1145,14 @@ mod tests {
                     if !own_ran_inner.get() {
                         own_ran_inner.set(true);
                         // Cascade: enqueue a follow-up to the child mid-drain.
-                        registry_ref.route_or_enqueue(child, 2, &[0x02], 1, false, root);
+                        registry_ref.route_or_enqueue(
+                            child,
+                            2,
+                            &[0x02],
+                            1,
+                            ChainMode::Inherit,
+                            root,
+                        );
                     }
                 }
                 OWN_CODE
@@ -1189,7 +1211,7 @@ mod tests {
         let (dispatches, observed) = install_recording_with_source(&registry, child, root);
 
         // The parent (root) sends to the child, stamping its own id as sender.
-        registry.route_or_enqueue(child, 1, &[0x00], 1, false, root);
+        registry.route_or_enqueue(child, 1, &[0x00], 1, ChainMode::Inherit, root);
 
         drain_cluster_queue(&registry, |_source| {
             |_mail| panic!("own dispatch must not run for a child-addressed item")

--- a/crates/aether-actor/src/wasm/mailbox.rs
+++ b/crates/aether-actor/src/wasm/mailbox.rs
@@ -22,10 +22,10 @@
 
 use core::marker::PhantomData;
 
-use aether_data::{ActorId, Kind, Tag, fold_lineage, with_tag};
+use aether_data::{ActorId, Kind, MailboxId, Tag, fold_lineage, with_tag};
 
 use crate::model::{Addressable, HandlesKind};
-use crate::wasm::inline::InlineRegistry;
+use crate::wasm::inline::{ChainMode, InlineRegistry};
 
 /// Phantom-typed receiver-actor handle for FFI guests, built by
 /// [`crate::wasm::WasmCtx::actor`] / [`crate::wasm::WasmCtx::resolve_actor`].
@@ -82,8 +82,8 @@ impl<'a, R> WasmActorMailbox<'a, R> {
     /// The receiver's typed mailbox id. Exposed for callers that need
     /// it for diagnostics or a host fn the SDK doesn't yet wrap.
     #[must_use]
-    pub fn mailbox_id(&self) -> aether_data::MailboxId {
-        aether_data::MailboxId(self.mailbox)
+    pub fn mailbox_id(&self) -> MailboxId {
+        MailboxId(self.mailbox)
     }
 
     /// Rewrap a precomputed `mailbox` id as a typed peer handle that
@@ -145,8 +145,14 @@ impl<R: Addressable> WasmActorMailbox<'_, R> {
         K: Kind,
     {
         let bytes = payload.encode_into_bytes();
-        self.inline
-            .route_or_enqueue(self.mailbox, K::ID.0, &bytes, 1, false, self.sender);
+        self.inline.route_or_enqueue(
+            self.mailbox,
+            K::ID.0,
+            &bytes,
+            1,
+            ChainMode::Inherit,
+            self.sender,
+        );
     }
 
     /// Send a slice of payloads as a contiguous batch. Cast-only —
@@ -164,7 +170,7 @@ impl<R: Addressable> WasmActorMailbox<'_, R> {
             K::ID.0,
             bytes,
             payloads.len() as u32,
-            false,
+            ChainMode::Inherit,
             self.sender,
         );
     }
@@ -184,7 +190,13 @@ impl<R: Addressable> WasmActorMailbox<'_, R> {
         K: Kind,
     {
         let bytes = payload.encode_into_bytes();
-        self.inline
-            .route_or_enqueue(self.mailbox, K::ID.0, &bytes, 1, true, self.sender);
+        self.inline.route_or_enqueue(
+            self.mailbox,
+            K::ID.0,
+            &bytes,
+            1,
+            ChainMode::Detached,
+            self.sender,
+        );
     }
 }

--- a/crates/aether-actor/src/wasm/mod.rs
+++ b/crates/aether-actor/src/wasm/mod.rs
@@ -10,9 +10,9 @@
 //!     `_p32` suffix, `aether.kinds.inputs`, `aether.namespace`) are
 //!     an on-the-wire contract the substrate's wasm runtime expects and
 //!     are deliberately unchanged.
-//!   - [`bridge`] — per-concern free-function modules (`bridge::mail`,
-//!     `bridge::persist`). Each module owns one FFI op family and
-//!     forwards calls to the matching `raw::*` host fn.
+//!   - [`bridge`] — per-concern free-function modules (`bridge::log`,
+//!     `bridge::mail`, `bridge::persist`). Each module owns one FFI op
+//!     family and forwards calls to the matching `raw::*` host fn.
 //!   - [`WasmInitCtx`] / [`WasmCtx`] / [`WasmDropCtx`] — concrete per-stage
 //!     ctx structs, each impling the relevant subset of the per-stage
 //!     capability traits in [`crate::model::ctx`].
@@ -284,226 +284,22 @@ pub fn stage_init_failure(message: &str) {
 }
 
 /// Guest-runtime log install (wasm32). Wires the FFI sink
-/// (`bridge::mail::emit_log_event`) into the target-blind
+/// (`bridge::log::emit_log_event`) into the target-blind
 /// [`crate::log`] forwarding seam, then sets the forwarding subscriber
 /// as `tracing`'s global default. Called from the `export!` prologue
 /// before the guest's `init` runs. This is the only wasm-specific log
-/// glue — `bridge::mail` is `pub(crate)`, so the sink can only be wired
+/// glue — `bridge::log` is `pub(crate)`, so the sink can only be wired
 /// from inside the crate; the subscriber itself stays target-blind in
 /// [`crate::log`]. Shared by the `export!` shims so the wiring isn't
 /// repeated per init shim.
 #[cfg(target_family = "wasm")]
 #[doc(hidden)]
 pub fn install_guest_logging() {
-    crate::log::install_log_sink(bridge::mail::emit_log_event);
+    crate::log::install_log_sink(bridge::log::emit_log_event);
     crate::log::install_forwarding_subscriber();
 }
 
-/// Generic guest allocator backing host→guest payload delivery (ADR-0095).
-///
-/// The substrate writes every inbound payload — mail, init config, rehydrate
-/// state — into a region it obtains from this allocator, then calls the entry
-/// point (`receive` / `init_with_config` / `on_rehydrate`). The host owns no
-/// fixed offset into guest memory; the guest reports where its memory is, so
-/// delivery is independent of the guest's linear-memory layout.
-///
-/// The export is `cabi_realloc`-shaped (the Component Model canonical): one
-/// function that allocates (`old_ptr == 0`), grows possibly-relocating
-/// (`new_size > old_size`), or frees (`new_size == 0`). The substrate drives it
-/// under the run-token invariant — one small region allocated once and reused,
-/// one large region grown to fit, each consumed synchronously — and never frees
-/// (wasm has no `memory.shrink`, so a free reclaims nothing).
-///
-/// The first sub-threshold allocation — the small delivery region the host
-/// obtains once at instantiate (`align = 8`, `new_size <= SMALL_REGION_BYTES`)
-/// — is served from a reused `static` scratch (ADR-0095 point 4) rather than
-/// the global allocator. Every later allocation (the large region, any
-/// subsequent small one) falls through to the global allocator. The scratch is
-/// purely a guest-side optimization beneath the same ABI; a guest in any
-/// language supplies the same export however it likes.
-///
-/// The module is not target-gated so the allocator is host-testable (its body
-/// is plain `alloc`-crate code, like [`crate::Slot`]); the `realloc_p32` FFI
-/// shims that call it remain wasm32-only.
-pub mod guest_alloc {
-    use alloc::alloc::{Layout, alloc, dealloc, realloc};
-    use core::cell::UnsafeCell;
-    use core::ptr::{copy_nonoverlapping, null_mut};
-
-    /// Size of the `static` scratch that backs the first sub-threshold
-    /// delivery allocation. Kept `>=` the host's `SMALL_REGION_BYTES`
-    /// (`aether-substrate`, currently 8 KiB) so the scratch covers that
-    /// instantiate-time small region. If it ever drifts below the host floor
-    /// the first small allocation simply spills to the global allocator —
-    /// still correct, just no longer served from the scratch.
-    const SCRATCH_REGION_BYTES: usize = 8 * 1024;
-
-    /// Alignment the scratch satisfies. The host requests `align = 8` for the
-    /// delivery region; a request needing more falls through to the global
-    /// allocator even if it would fit by size.
-    const SCRATCH_ALIGN: usize = 8;
-
-    /// Reused backing store for the first small delivery region plus a
-    /// single-shot claim flag. `UnsafeCell` + a blanket `Sync` impl mirrors
-    /// [`crate::Slot`]: the guest is single-threaded (ADR-0010 §5) and the
-    /// substrate serializes delivery under the run token, so the cell is never
-    /// touched concurrently and no atomics are needed. `bytes` is the first
-    /// field of a `repr(C, align(8))` struct, so its base is
-    /// `SCRATCH_ALIGN`-aligned.
-    #[repr(C, align(8))]
-    struct Scratch {
-        bytes: UnsafeCell<[u8; SCRATCH_REGION_BYTES]>,
-        claimed: UnsafeCell<bool>,
-    }
-
-    // SAFETY: a single-threaded WASM guest plus the substrate's serialized,
-    // run-token-gated delivery mean `SCRATCH` is only ever touched from one
-    // thread at a time — the same argument that licenses `crate::Slot`'s
-    // `Sync`. On the host unit-test build the static is reached from one test.
-    unsafe impl Sync for Scratch {}
-
-    static SCRATCH: Scratch = Scratch {
-        bytes: UnsafeCell::new([0u8; SCRATCH_REGION_BYTES]),
-        claimed: UnsafeCell::new(false),
-    };
-
-    /// `cabi_realloc`-shaped reallocation.
-    ///
-    /// - `old_ptr == 0` — allocate `new_size` bytes, return the pointer. The
-    ///   first such call that fits the scratch (`new_size <=
-    ///   SCRATCH_REGION_BYTES`, `align <= SCRATCH_ALIGN`) returns the reused
-    ///   `static` scratch base; later calls use the global allocator.
-    /// - `new_size == 0` — free the `(old_ptr, old_size, align)` allocation,
-    ///   return null. Freeing the scratch base is a no-op.
-    /// - otherwise — resize the allocation to `new_size`, returning the current
-    ///   pointer (which differs from `old_ptr` if the block was relocated).
-    ///
-    /// # Safety
-    /// `old_ptr` / `old_size` / `align` must describe a live allocation from a
-    /// prior call (or `0` / `0` for a fresh allocation), and `align` must be a
-    /// nonzero power of two. The guest is single-threaded, so there is no
-    /// aliasing.
-    pub unsafe fn realloc_bytes(
-        old_ptr: *mut u8,
-        old_size: usize,
-        align: usize,
-        new_size: usize,
-    ) -> *mut u8 {
-        let scratch_base = SCRATCH.bytes.get().cast::<u8>();
-        if new_size == 0 {
-            if !old_ptr.is_null() && old_ptr != scratch_base {
-                // SAFETY: caller's layout contract holds (`align` a nonzero
-                // power of two), and `old_ptr` is a live global allocation —
-                // the scratch base is excluded above, so this only frees global
-                // memory, never the `static` scratch.
-                unsafe {
-                    let layout = Layout::from_size_align_unchecked(old_size, align);
-                    dealloc(old_ptr, layout);
-                }
-            }
-            // Freeing the scratch base reclaims nothing (it is a `static`); the
-            // host never frees the small region anyway (ADR-0095 point 6).
-            return null_mut();
-        }
-        if old_ptr.is_null() {
-            // SAFETY: single-threaded guest + serialized delivery — no other
-            // live reference to the claim flag (the `Scratch` `Sync` argument).
-            let already_claimed = unsafe { *SCRATCH.claimed.get() };
-            if !already_claimed && new_size <= SCRATCH_REGION_BYTES && align <= SCRATCH_ALIGN {
-                // SAFETY: same single-threaded / serialized argument; this is
-                // the only writer of the flag, and it transitions once.
-                unsafe { *SCRATCH.claimed.get() = true };
-                return scratch_base;
-            }
-            // SAFETY: caller's layout contract holds; a fresh global allocation.
-            return unsafe {
-                let layout = Layout::from_size_align_unchecked(new_size, align);
-                alloc(layout)
-            };
-        }
-        if old_ptr == scratch_base {
-            // Contractually unreachable — the host grows the large region, not
-            // the scratch-backed small one (ADR-0095 points 4/7). Handle it
-            // without UB by allocating fresh and copying rather than passing the
-            // `static` pointer to `realloc`.
-            // SAFETY: caller's layout contract holds; `scratch_base` is a live,
-            // initialized `static` of `SCRATCH_REGION_BYTES` bytes, `fresh` is a
-            // fresh global allocation of `new_size`, and the copy length is the
-            // min of `old_size` / `new_size`, in-bounds of both regions.
-            return unsafe {
-                let layout = Layout::from_size_align_unchecked(new_size, align);
-                let fresh = alloc(layout);
-                if !fresh.is_null() {
-                    copy_nonoverlapping(scratch_base, fresh, old_size.min(new_size));
-                }
-                fresh
-            };
-        }
-        // SAFETY: caller's layout contract holds; `old_ptr` / `old_size` /
-        // `align` describe a live global allocation (scratch base excluded
-        // above), matched by the global `realloc`.
-        unsafe {
-            let old_layout = Layout::from_size_align_unchecked(old_size, align);
-            realloc(old_ptr, old_layout, new_size)
-        }
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-
-        /// The scratch serves the first eligible sub-threshold allocation and
-        /// only that one; oversized and over-aligned requests bypass it, and a
-        /// second eligible request falls through to the global allocator. Only
-        /// this test claims the process-global single-shot flag, so the
-        /// sequence is deterministic without a reset hook.
-        #[test]
-        fn scratch_serves_first_small_alloc_only() {
-            let base = SCRATCH.bytes.get().cast::<u8>();
-            let null = null_mut();
-            // SAFETY: every call obeys `realloc_bytes`' contract — `null`/`0`
-            // for fresh allocs, and a matching `(ptr, size, align)` triple to
-            // free what a prior call returned. One test thread, no aliasing.
-            unsafe {
-                // Oversized: larger than the scratch → global allocator. The
-                // flag stays unclaimed because the size gate fails.
-                let big = realloc_bytes(null, 0, SCRATCH_ALIGN, SCRATCH_REGION_BYTES + 1);
-                assert_ne!(big, base, "oversized alloc bypasses the scratch");
-                realloc_bytes(big, SCRATCH_REGION_BYTES + 1, SCRATCH_ALIGN, 0);
-
-                // Over-aligned: fits by size but needs more alignment than the
-                // scratch provides → global allocator, flag still unclaimed.
-                let aligned = realloc_bytes(null, 0, SCRATCH_ALIGN * 2, 64);
-                assert_ne!(aligned, base, "over-aligned alloc bypasses the scratch");
-                realloc_bytes(aligned, 64, SCRATCH_ALIGN * 2, 0);
-
-                // First eligible small alloc (the host's instantiate-time small
-                // region) → served from the scratch.
-                let first = realloc_bytes(null, 0, SCRATCH_ALIGN, SCRATCH_REGION_BYTES);
-                assert_eq!(
-                    first, base,
-                    "first eligible small alloc returns the scratch base"
-                );
-
-                // Single-shot: the next eligible alloc falls through to global.
-                let second = realloc_bytes(null, 0, SCRATCH_ALIGN, 64);
-                assert_ne!(second, base, "scratch is spent after the first claim");
-                realloc_bytes(second, 64, SCRATCH_ALIGN, 0);
-            }
-        }
-
-        /// Freeing the scratch base is a no-op that returns null and must not
-        /// reach the global allocator's `dealloc` (UB on a `static`).
-        #[test]
-        fn freeing_scratch_base_is_a_noop() {
-            let base = SCRATCH.bytes.get().cast::<u8>();
-            // SAFETY: `base` is the scratch `static`; the free branch guards it
-            // and never calls `dealloc` on it.
-            let freed = unsafe { realloc_bytes(base, SCRATCH_REGION_BYTES, SCRATCH_ALIGN, 0) };
-            assert!(freed.is_null(), "freeing the scratch returns null");
-        }
-    }
-}
+pub mod guest_alloc;
 
 /// Bind a `WasmActor` implementor to the guest's `#[no_mangle]`
 /// `init` / `receive` exports. Expands to:
@@ -640,26 +436,22 @@ macro_rules! __export_internal {
                     )
                 }
             };
-            let decoded = <<$component as $crate::Lifecycle<$component>>::Config as $crate::__macro_internals::Kind>::decode_from_bytes(
+            let Some(config) = <<$component as $crate::Lifecycle<$component>>::Config as $crate::__macro_internals::Kind>::decode_from_bytes(
                 config_bytes,
-            );
-            let config = match decoded {
-                ::core::option::Option::Some(c) => c,
-                ::core::option::Option::None => {
-                    let msg = ::core::concat!(
-                        "guest init: ",
-                        ::core::stringify!($component),
-                        " could not decode Config from bytes",
+            ) else {
+                let msg = ::core::concat!(
+                    "guest init: ",
+                    ::core::stringify!($component),
+                    " could not decode Config from bytes",
+                );
+                let bytes = msg.as_bytes();
+                unsafe {
+                    $crate::wasm::raw::init_failed(
+                        bytes.as_ptr().addr() as u32,
+                        bytes.len() as u32,
                     );
-                    let bytes = msg.as_bytes();
-                    unsafe {
-                        $crate::wasm::raw::init_failed(
-                            bytes.as_ptr().addr() as u32,
-                            bytes.len() as u32,
-                        );
-                    }
-                    return 1;
                 }
+                return 1;
             };
             // ADR-0114 addressing amendment: capture the real folded
             // mailbox id the substrate hands the guest as this cluster's
@@ -1396,18 +1188,15 @@ macro_rules! __export_multi_internal {
     // the result into `__AETHER_MULTI`. Expands inline in an init shim;
     // a decode/init failure stages the message and `return 1`.
     (@construct $ty:ty, $mailbox_id:ident, $config_bytes:ident) => {{
-        let config = match <
+        let Some(config) = <
             <$ty as $crate::Lifecycle<$ty>>::Config as $crate::__macro_internals::Kind
-        >::decode_from_bytes($config_bytes) {
-            ::core::option::Option::Some(c) => c,
-            ::core::option::Option::None => {
-                $crate::wasm::stage_init_failure(::core::concat!(
-                    "guest init: ",
-                    ::core::stringify!($ty),
-                    " could not decode Config from bytes",
-                ));
-                return 1;
-            }
+        >::decode_from_bytes($config_bytes) else {
+            $crate::wasm::stage_init_failure(::core::concat!(
+                "guest init: ",
+                ::core::stringify!($ty),
+                " could not decode Config from bytes",
+            ));
+            return 1;
         };
         let mut ctx: $crate::WasmInitCtx<'_> = $crate::WasmInitCtx::__new($mailbox_id);
         match <$ty as $crate::Lifecycle<$ty>>::init(config, &mut ctx) {


### PR DESCRIPTION
Closes #2436.

## Summary

Acts on the crate-internal cleanup findings the `/audit-quality` judge panel surfaced over `aether-actor` (#2436). All changes are behavior-preserving:

- **Control-flow collapses** — `InlineRegistry::insert_child` if-let/else upsert → one `map.insert`; `install_inline_child` `match A::init` → `?`; the two config-decode `match`es in `init_with_config` / `__export_multi_internal!` `@construct` → `let … else`; the `child_metas` test `match` → `let [meta] = … else`.
- **Module structure** — moved `guest_alloc` to its own `wasm/guest_alloc.rs` (relocation; the macro-emitted `$crate::wasm::guest_alloc::realloc_bytes` path is unchanged); split `emit_log_event` out of `bridge/mail.rs` into `bridge/log.rs` (one op-family per module).
- **Type design** — `route_or_enqueue`'s `false`/`true` bool → a two-variant `ChainMode { Inherit, Detached }`; `WasmCtx.sender` field → `Option<ReplyHandle>`.
- **Visibility** — narrowed the in-crate-only halves `ReplyHandle::__from_raw`, `WasmDropCtx::__new_capturing`, and `CapturedState` to `pub(crate)`. The macro-emitted cross-crate FFI (`Mail::__from_raw`, `PriorState::__from_ptr`, `guest_alloc::realloc_bytes`) and `pub mod bridge` stay `pub`.
- **Naming / imports** — `MakeOwn` generic → `M`; `len_u32(value)` → `(len)`; local `tag` → `type_tag`; `MailboxId` import in `mailbox.rs`; `Manual` import in `compose.rs`'s test module.

The three breaking public-API harmonizations and the 14 clippy candidates the audit surfaced are routed to the issue's §Side findings, not applied here.

## Test plan

No new tests — every change is behavior-preserving, so the existing suite is the oracle (a new test for a pure refactor would be junk per `docs/guide/testing.md`). Validated via `scripts/preflight.sh` — fmt, clippy `-D warnings`, nextest, doc `-D warnings`, and the wasm32 component cross-build, which is the load-bearing gate: it expands the touched `#[macro_export]` bodies in a consumer crate, proving the let-else rewrites and FFI/visibility narrowings don't break consumers.

## Generated by

`/implement` — agent execution of [scoped issue #2436](https://github.com/iamacoffeepot/aether/issues/2436).
