### PR TITLE
refactor(aether-actor): harmonize public getters to return their newtypes

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -1802,7 +1802,7 @@ fn expand_wasm_actor(item: ItemImpl, opts: &ActorOpts) -> syn::Result<TokenStrea
     // `Self::State` resolves directly inside `impl WasmActor for Self`.
     // `on_dehydrate` snapshots through `self.dehydrate()` and frames the
     // value with `save_state_kind`; `on_rehydrate` decodes via
-    // `PriorState::as_kind` and either restores through `self.rehydrate`
+    // `PriorState::decode_kind` and either restores through `self.rehydrate`
     // or boots fresh, warning only when bytes were present but did not
     // decode (a reshaped state kind — `K::ID` changed). When `type State`
     // was omitted these are empty and the actor keeps the default no-op
@@ -1821,7 +1821,7 @@ fn expand_wasm_actor(item: ItemImpl, opts: &ActorOpts) -> syn::Result<TokenStrea
                 __aether_ctx: &mut ::aether_actor::WasmCtx<'_>,
                 __aether_prior: ::aether_actor::PriorState<'_>,
             ) {
-                match __aether_prior.as_kind::<<Self as ::aether_actor::WasmActor>::Persist>() {
+                match __aether_prior.decode_kind::<<Self as ::aether_actor::WasmActor>::Persist>() {
                     ::core::option::Option::Some(__aether_state) => {
                         self.rehydrate(__aether_state);
                     }
@@ -3441,11 +3441,10 @@ fn build_dispatch_body(handlers: &[HandlerFn], fallback: Option<&FallbackFn>) ->
                 unreachable!("parse_handler_class rejects #[handler::stream]")
             }
         };
-        // `Mail::kind()` returns the raw `u64` the FFI carried; `Kind::ID`
-        // is typed `KindId` post-issue 466, so we drop into `.0` for the
-        // comparison.
+        // `Mail::kind()` and `Kind::ID` are both the typed `KindId`
+        // newtype (`KindId: PartialEq`), so they compare directly.
         quote! {
-            if __aether_kind == <#k as ::aether_actor::__macro_internals::Kind>::ID.0 {
+            if __aether_kind == <#k as ::aether_actor::__macro_internals::Kind>::ID {
                 if let ::core::option::Option::Some(__aether_decoded) =
                     __aether_mail.decode_kind::<#k>()
                 {

--- a/crates/aether-actor/Cargo.toml
+++ b/crates/aether-actor/Cargo.toml
@@ -29,7 +29,7 @@ aether-actor-derive = { path = "../aether-actor-derive" }
 # request kinds — that whole vocabulary lives in `aether-kinds`.
 aether-kinds = { path = "../aether-kinds" }
 bytemuck = { workspace = true, default-features = false }
-# Decoding typed payloads (e.g. `PriorState::as_kind`,
+# Decoding typed payloads (e.g. `PriorState::decode_kind`,
 # `Mail::decode_kind`) is serde-driven via `aether_data::wire`. The crate
 # stays `no_std`-friendly with `default-features = false`.
 serde = { workspace = true, default-features = false, features = ["alloc"] }

--- a/crates/aether-actor/examples/input_logger.rs
+++ b/crates/aether-actor/examples/input_logger.rs
@@ -24,7 +24,7 @@
 use aether_actor::{ActorInitError, WasmActor, WasmCtx, WasmInitCtx, actor};
 use aether_capabilities::InputCapability;
 use aether_capabilities::input::SubscribeInput;
-use aether_data::{Kind, MailboxId};
+use aether_data::Kind;
 use aether_kinds::{Key, MouseButton, MouseMove};
 
 pub struct InputLogger;
@@ -38,7 +38,7 @@ impl WasmActor for InputLogger {
     }
 
     fn wire(&mut self, ctx: &mut WasmCtx<'_>) {
-        let me = MailboxId(ctx.mailbox_id());
+        let me = ctx.mailbox_id();
         let input = ctx.actor::<InputCapability>();
         for kind in [Key::ID, MouseMove::ID, MouseButton::ID] {
             input.send(&SubscribeInput { kind, mailbox: me });

--- a/crates/aether-actor/src/mail/mod.rs
+++ b/crates/aether-actor/src/mail/mod.rs
@@ -22,7 +22,7 @@ pub mod mailbox;
 
 use core::marker::PhantomData;
 
-use aether_data::{Kind, MailboxId, Schema, wire};
+use aether_data::{Kind, KindId, MailboxId, Schema, wire};
 
 /// Sentinel the substrate passes as the reply-handle parameter on
 /// the `receive` shim when there is no reply target — for
@@ -156,12 +156,12 @@ impl Mail<'_> {
         }
     }
 
-    /// Raw kind id the substrate routed this mail under. The canonical
+    /// Kind id the substrate routed this mail under. The canonical
     /// way to consume it is [`Self::decode_kind::<K>()`], which matches
     /// the kind id and decodes in one call.
     #[must_use]
-    pub fn kind(&self) -> u64 {
-        self.kind
+    pub fn kind(&self) -> KindId {
+        KindId(self.kind)
     }
 
     /// Number of items carried on the mail frame — 1 for a single
@@ -316,10 +316,10 @@ impl<'a> PriorState<'a> {
     /// compiled against the new schema sees `None` from the old
     /// instance's save and boots fresh. Components that want to
     /// migrate across a schema change can reach for `bytes()` +
-    /// `schema_version()` directly, or try `as_kind::<OldShape>()`
+    /// `schema_version()` directly, or try `decode_kind::<OldShape>()`
     /// first and fall back if it returns `None`.
     #[must_use]
-    pub fn as_kind<K>(&self) -> Option<K>
+    pub fn decode_kind<K>(&self) -> Option<K>
     where
         K: Kind + Schema + DeserializeOwned,
     {
@@ -543,7 +543,7 @@ mod tests {
     // panics on the wasm transport's host stub), so these tests pair
     // a hand-built bundle matching the documented framing
     // (`[0..8) = K::ID LE`, `[8..) = wire(value)`) against
-    // `PriorState::as_kind` — the one we *can* unit-test on host. A
+    // `PriorState::decode_kind` — the one we *can* unit-test on host. A
     // mismatch between framing and decode surfaces here before either
     // diverges from the ADR's wire shape.
 
@@ -581,7 +581,7 @@ mod tests {
     }
 
     #[test]
-    fn as_kind_roundtrip() {
+    fn decode_kind_roundtrip() {
         let value = StateStruct {
             tag: 11,
             label: String::from("phase-2"),
@@ -590,22 +590,22 @@ mod tests {
         let buf = frame_bundle(&value);
         let prior = prior_from(&buf, 0);
         let decoded = prior
-            .as_kind::<StateStruct>()
+            .decode_kind::<StateStruct>()
             .expect("test setup: round-trip frame decodes back to StateStruct");
         assert_eq!(decoded, value);
     }
 
     #[test]
-    fn as_kind_short_buffer_returns_none() {
+    fn decode_kind_short_buffer_returns_none() {
         // Buffer shorter than the 8-byte leading id — not a kind-
         // typed save (or corrupt). Must not panic.
         let buf: [u8; 3] = [1, 2, 3];
         let prior = prior_from(&buf, 0);
-        assert!(prior.as_kind::<StateStruct>().is_none());
+        assert!(prior.decode_kind::<StateStruct>().is_none());
     }
 
     #[test]
-    fn as_kind_empty_buffer_returns_none() {
+    fn decode_kind_empty_buffer_returns_none() {
         // `on_rehydrate` only fires when the predecessor saved
         // something, but a hypothetical zero-length buffer must
         // still fall through cleanly.
@@ -613,28 +613,28 @@ mod tests {
         // forming a slice over the null pointer; the decode reads
         // through that empty slice and short-circuits.
         let prior = unsafe { PriorState::__from_raw(0, 0, 0) };
-        assert!(prior.as_kind::<StateStruct>().is_none());
+        assert!(prior.decode_kind::<StateStruct>().is_none());
     }
 
     #[test]
-    fn as_kind_correct_id_garbage_payload_returns_none() {
+    fn decode_kind_correct_id_garbage_payload_returns_none() {
         // Leading id matches but the wire tail is truncated.
         // Decode error must surface as None, not a panic.
         let mut buf = Vec::from(StateStruct::ID.0.to_le_bytes());
         buf.push(0xff);
         let prior = prior_from(&buf, 0);
-        assert!(prior.as_kind::<StateStruct>().is_none());
+        assert!(prior.decode_kind::<StateStruct>().is_none());
     }
 
     #[test]
-    fn as_kind_preserves_raw_access_for_migration() {
+    fn decode_kind_preserves_raw_access_for_migration() {
         // ADR-0040 keeps the raw bytes + version reachable so a
-        // component that sees `as_kind::<New>() = None` can pivot to
+        // component that sees `decode_kind::<New>() = None` can pivot to
         // an explicit migration path.
         let value = OtherState { flag: false };
         let buf = frame_bundle(&value);
         let prior = prior_from(&buf, 7);
-        assert!(prior.as_kind::<StateStruct>().is_none());
+        assert!(prior.decode_kind::<StateStruct>().is_none());
         assert_eq!(prior.schema_version(), 7);
         assert_eq!(prior.bytes(), buf.as_slice());
     }

--- a/crates/aether-actor/src/model/ctx/persistence.rs
+++ b/crates/aether-actor/src/model/ctx/persistence.rs
@@ -13,7 +13,7 @@
 //! `save_state_kind` is the typed-state convenience (ADR-0040): the
 //! bundle is framed as `[0..8)` little-endian `K::ID` followed by the
 //! wire encoding of `value`; the replacement instance recovers `K`
-//! via [`crate::mail::PriorState::as_kind`]. Use the raw `save_state`
+//! via [`crate::mail::PriorState::decode_kind`]. Use the raw `save_state`
 //! when persisting bytes that aren't a kind or when driving an
 //! explicit migration off the leading id.
 
@@ -45,10 +45,10 @@ pub trait Persistence {
     /// Persist a typed kind value across `replace_component`
     /// (ADR-0040). The bundle is framed as `[0..8)` little-endian
     /// `K::ID` followed by the wire encoding of `value`; the
-    /// replacement instance recovers `K` via [`crate::mail::PriorState::as_kind`].
+    /// replacement instance recovers `K` via [`crate::mail::PriorState::decode_kind`].
     ///
     /// `K::ID` is the ADR-0030 schema hash — changing the shape of
-    /// `K` changes the id, which is what makes `as_kind::<K>`
+    /// `K` changes the id, which is what makes `decode_kind::<K>`
     /// automatically reject stale bytes after a schema evolution.
     /// `version` is passed through to the substrate unchanged;
     /// components typically leave it `0` since `K::ID` already

--- a/crates/aether-actor/src/wasm/ctx.rs
+++ b/crates/aether-actor/src/wasm/ctx.rs
@@ -56,8 +56,8 @@ impl WasmInitCtx<'_> {
     /// The component's own mailbox id — the value the substrate uses to
     /// address `receive` calls to this instance.
     #[must_use]
-    pub fn mailbox_id(&self) -> u64 {
-        self.mailbox
+    pub fn mailbox_id(&self) -> MailboxId {
+        MailboxId(self.mailbox)
     }
 
     /// Resolve a kind by its `const ID`. Pure compile-time construction
@@ -279,8 +279,8 @@ impl<M: ReplyMode> WasmCtx<'_, M> {
     /// subscribes (sending `SubscribeInput` to the `InputCapability`)
     /// self-address through this.
     #[must_use]
-    pub fn mailbox_id(&self) -> u64 {
-        self.mailbox
+    pub fn mailbox_id(&self) -> MailboxId {
+        MailboxId(self.mailbox)
     }
 
     /// Singleton sender shortcut. Returns a ctx-bound [`WasmActorMailbox`]

--- a/crates/aether-actor/src/wasm/mod.rs
+++ b/crates/aether-actor/src/wasm/mod.rs
@@ -167,7 +167,7 @@ pub trait WasmActor:
     /// [`Self::on_rehydrate`] hooks instead of the author hand-writing
     /// them — the save side snapshots `Persist` and frames it via
     /// `save_state_kind`, the restore side decodes it via
-    /// [`PriorState::as_kind`][crate::PriorState::as_kind] and boots
+    /// [`PriorState::decode_kind`][crate::PriorState::decode_kind] and boots
     /// fresh (with a `tracing::warn!`) when a reshaped `Persist` kind no
     /// longer decodes.
     ///
@@ -207,7 +207,7 @@ pub trait WasmActor:
     /// [`Self::on_dehydrate`] (the substrate skips the call when no
     /// bundle was saved — ADR-0016 §3). Default ignores the prior state;
     /// override to rehydrate from `prior` (typically
-    /// [`PriorState::as_kind`][crate::PriorState::as_kind]).
+    /// [`PriorState::decode_kind`][crate::PriorState::decode_kind]).
     ///
     /// Concrete `&mut WasmCtx<'_>` — the post-init send surface, so an
     /// override can both restore fields and emit mail.

--- a/crates/aether-actor/tests/state_framing_roundtrip.rs
+++ b/crates/aether-actor/tests/state_framing_roundtrip.rs
@@ -3,14 +3,14 @@
 //!
 //! The generated `on_dehydrate` deposits the actor's `type State` via
 //! `Persistence::save_state_kind`; the generated `on_rehydrate` recovers
-//! it via `PriorState::as_kind` and boots fresh (warning) when the decode
+//! it via `PriorState::decode_kind` and boots fresh (warning) when the decode
 //! misses. Those hooks only run on the wasm load/replace path, which the
 //! test bench drives end-to-end — but the test bench cannot observe the
 //! decode-miss warn (it does not route `aether.log` mail through its
 //! observed sinks). This test stands in for that seam on the host: it
-//! exercises the deposit (`save_state_kind`) and recovery (`as_kind`)
+//! exercises the deposit (`save_state_kind`) and recovery (`decode_kind`)
 //! halves through a capture ctx, and asserts the exact decode-miss
-//! predicate the generated warn branches on (`as_kind() == None` while
+//! predicate the generated warn branches on (`decode_kind() == None` while
 //! `bytes()` is non-empty).
 
 use aether_actor::{Persistence, PriorState};
@@ -61,10 +61,10 @@ fn prior_from(buf: &[u8]) -> PriorState<'_> {
 }
 
 /// The deposit half (`save_state_kind`) and the recovery half
-/// (`PriorState::as_kind`) round-trip the state value — the two halves
+/// (`PriorState::decode_kind`) round-trip the state value — the two halves
 /// the generated hooks each own, exercised back to back.
 #[test]
-fn save_state_kind_round_trips_through_as_kind() {
+fn save_state_kind_round_trips_through_decode_kind() {
     let value = CounterState { count: 7 };
 
     let mut ctx = CaptureCtx::default();
@@ -75,7 +75,7 @@ fn save_state_kind_round_trips_through_as_kind() {
 
     let prior = prior_from(&buf);
     let recovered = prior
-        .as_kind::<CounterState>()
+        .decode_kind::<CounterState>()
         .expect("the framed bundle decodes back to the same state kind");
     assert_eq!(recovered, value);
 }
@@ -93,7 +93,7 @@ fn reshaped_state_kind_misses_decode_with_bytes_present() {
     let (_, buf) = ctx.saved.expect("dehydrate deposits a bundle");
 
     // The reshaped kind has a different `Kind::ID`, so the leading-id
-    // compare in `as_kind` rejects before the structured decode runs.
+    // compare in `decode_kind` rejects before the structured decode runs.
     assert_ne!(
         CounterState::ID,
         CounterStateReshaped::ID,
@@ -102,7 +102,7 @@ fn reshaped_state_kind_misses_decode_with_bytes_present() {
 
     let prior = prior_from(&buf);
     assert!(
-        prior.as_kind::<CounterStateReshaped>().is_none(),
+        prior.decode_kind::<CounterStateReshaped>().is_none(),
         "a reshaped state kind must not decode the old bundle",
     );
     assert!(

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -1298,7 +1298,7 @@ fn replace_preserves_multi_actor_state_via_dehydrate_rehydrate() {
 /// wasm at the same mailbox id with the same binary, then re-queries. The
 /// generated `on_dehydrate` frames the `CounterState` via
 /// `save_state_kind`; the generated `on_rehydrate` recovers it via
-/// `as_kind`, so the count survives the swap.
+/// `decode_kind`, so the count survives the swap.
 #[test]
 fn replace_preserves_state_via_typed_state_kind() {
     use aether_actor::Addressable;
@@ -1398,7 +1398,7 @@ fn replace_preserves_state_via_typed_state_kind() {
 
 /// ADR-0113: when a replacement is compiled against a reshaped `type
 /// State` kind (a different `Kind::ID`), the generated `on_rehydrate`
-/// sees `PriorState::as_kind` miss the decode and boots fresh. Loads the
+/// sees `PriorState::decode_kind` miss the decode and boots fresh. Loads the
 /// `stateful_replace_typed` fixture, bumps to 3, then replaces it with
 /// `stateful_replace_reshaped` (same `NAMESPACE`, a `CounterState` that
 /// gained a field). The recovered count is 0 — the fresh-`init` value —

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/inline_child.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/inline_child.rs
@@ -60,7 +60,7 @@ use aether_test_fixtures_kinds::{
 /// Durable state the `InlineStatefulChild` carries across `replace_component`.
 /// Uses the `aether.test_fixtures.inline_counter_state` shape so the macro
 /// frames it via `save_state_kind` on dehydrate and recovers it via
-/// `as_kind` on rehydrate.
+/// `decode_kind` on rehydrate.
 #[derive(
     aether_data::Kind, aether_data::Schema, serde::Serialize, serde::Deserialize, Debug, Clone,
 )]
@@ -277,6 +277,6 @@ impl WasmActor for InlineDespawnChild {
     /// teardown). The child's own alias is the ctx's mailbox id.
     #[handler::manual]
     fn on_despawn(&mut self, ctx: &mut WasmCtx<'_, Manual>, _trigger: DespawnChild) {
-        let _ = ctx.despawn_inline_child(MailboxId(ctx.mailbox_id()));
+        let _ = ctx.despawn_inline_child(ctx.mailbox_id());
     }
 }

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/matrix_sweep.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/matrix_sweep.rs
@@ -161,7 +161,7 @@ impl WasmActor for MatrixParent {
     fn on_run_matrix(&mut self, ctx: &mut WasmCtx<'_>, msg: RunMatrix) {
         let parent_id = ctx.mailbox_id();
         let child_a = ctx.child("a").expect("inline child a is resident");
-        record_ids(parent_id, child_a.mailbox_id().0);
+        record_ids(parent_id.0, child_a.mailbox_id().0);
         child_a.send(&MatrixPing {
             cell: MATRIX_CELL_PARENT_TO_CHILD,
             fan_out: 1,

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/stateful_replace.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/stateful_replace.rs
@@ -65,7 +65,7 @@ impl WasmActor for Counter {
     /// saved. A fresh load (no prior bundle) never reaches here, so the
     /// counter stays at its `init` zero.
     fn on_rehydrate(&mut self, _ctx: &mut WasmCtx<'_>, prior: PriorState<'_>) {
-        if let Some(saved) = prior.as_kind::<CountReport>() {
+        if let Some(saved) = prior.decode_kind::<CountReport>() {
             self.count = saved.count;
         }
     }

--- a/crates/aether-test-fixtures/aether-test-fixtures-stateful-reshaped/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-stateful-reshaped/src/lib.rs
@@ -2,7 +2,7 @@
 //! `NAMESPACE` and the same `CounterState` kind name, but the state shape
 //! gains a `generation` field. Reshaping the schema changes `Kind::ID`,
 //! so when this wasm replaces the typed fixture the generated
-//! `on_rehydrate` sees `PriorState::as_kind::<CounterState>() == None`
+//! `on_rehydrate` sees `PriorState::decode_kind::<CounterState>() == None`
 //! (the saved bundle carries the old id), warns, and boots fresh — the
 //! counter resets to its `init` zero instead of restoring.
 

--- a/crates/aether-test-fixtures/aether-test-fixtures-stateful-typed/src/lib.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-stateful-typed/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! `stateful_replace_reshaped.rs` is the decode-miss companion: same
 //! `NAMESPACE`, a reshaped `CounterState` (an added field changes
-//! `Kind::ID`), so a replacement compiled against it sees `as_kind` =
+//! `Kind::ID`), so a replacement compiled against it sees `decode_kind` =
 //! `None` and boots fresh.
 
 // `rehydrate` takes its `State` by value — the macro hands the decoded
@@ -22,7 +22,7 @@ use aether_test_fixtures_kinds::{Bump, CountQuery, CountReport};
 
 /// Durable state the `Counter` carries across `replace_component`. The
 /// `count` field is the only thing worth persisting — the macro frames it
-/// via `save_state_kind` on dehydrate and recovers it via `as_kind` on
+/// via `save_state_kind` on dehydrate and recovers it via `decode_kind` on
 /// rehydrate. The reshaped companion fixture adds a field, changing
 /// `Kind::ID` so the recovery misses.
 #[derive(

--- a/docs/guide/systems/components.md
+++ b/docs/guide/systems/components.md
@@ -158,7 +158,7 @@ impl WasmActor for MyComponent {
     }
 
     fn on_rehydrate(&mut self, ctx: &mut WasmCtx<'_>, prior: PriorState<'_>) {
-        if let Some(snap) = prior.as_kind::<Snapshot>() { … }
+        if let Some(snap) = prior.decode_kind::<Snapshot>() { … }
     }
 }
 


### PR DESCRIPTION
Closes #2438.

## Summary

Harmonizes three public getters in `aether-actor` to return their newtypes instead of raw `u64` / an `as_`-prefixed name, per the Rust API Guidelines (C-CONV / C-GETTER):

- `PriorState::as_kind<K>` → `decode_kind` — matches `Mail::decode_kind`; the `as_` prefix wrongly implied a cheap borrow, but it decodes.
- `Mail::kind()` → returns `KindId` instead of raw `u64`.
- `WasmCtx::mailbox_id` / `WasmInitCtx::mailbox_id` → return `MailboxId` instead of raw `u64`.

Each getter change lands with its lockstep derive/fixture updates as one atomic edit (the derive's `__aether_mail.kind() == ::ID.0` comparison drops the `.0`; fixtures that wrapped `MailboxId(ctx.mailbox_id())` drop the wrap). No new dependency — `KindId`/`MailboxId` already live in `aether-data`, which `aether-actor` depends on. Merged ADR bodies keep `as_kind` as historical record; present-tense rustdoc and the guide are updated.

## Test plan

Existing `aether-actor` suite incl. the derive trybuild UI test and the stateful replace/rehydrate scenarios. Local: `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace` (1897 passed), strict `cargo doc`, and the wasm32 component cross-build (the decisive gate for the derive lockstep — 5 components built).

## Generated by

`/implement` — agent execution of [scoped issue #2438](https://github.com/iamacoffeepot/aether/issues/2438).
