### PR TITLE
chore(aether-actor): act on the audit-quality clippy-candidate observations

### DIFF
--- a/crates/aether-actor/src/local.rs
+++ b/crates/aether-actor/src/local.rs
@@ -27,7 +27,7 @@
 //!   below — there is one actor, so a `static` slot map is unambiguous and
 //!   no routing is needed.
 //!
-//! This mirrors the substrate's existing injection seams: `InlineRegistry`
+//! This mirrors the substrate's existing injection seams: `Registry`
 //! (a guest-owned `static` the `export!` macro creates) and `MailboxWakeSlot`
 //! (a host-installed hook whose hot-path read is a single relaxed load). The
 //! provider read here is the same shape — an `Acquire` load plus an indirect
@@ -187,7 +187,7 @@ fn current_slots() -> Option<*const ActorSlots> {
 /// that hosts exactly one actor in its address space (the wasm guest — the
 /// linear memory *is* the actor). The `unsafe impl Sync` is licensed by that
 /// single logical thread, the same argument behind `crate::Slot` and
-/// `crate::wasm::inline::InlineRegistry`.
+/// `crate::wasm::inline::Registry`.
 struct StaticBackend(ActorSlots);
 
 // SAFETY: a single-actor image runs on one logical thread (the wasm linear

--- a/crates/aether-actor/src/log.rs
+++ b/crates/aether-actor/src/log.rs
@@ -323,7 +323,7 @@ fn truncate(mut s: String) -> String {
 /// `Sync`. Mirrors `local::SLOTS_PROVIDER` — set once with `Release`,
 /// read with `Acquire`. Null until installed; an event fired before
 /// install is dropped rather than forwarded.
-pub type LogSink = fn(level: u8, target: &str, message: &str);
+pub type Sink = fn(level: u8, target: &str, message: &str);
 
 static LOG_SINK: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 
@@ -333,7 +333,7 @@ static LOG_SINK: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 /// `ffi::bridge::mail::emit_log_event` (wasm32-only); a future C /
 /// OS-process host installs its own. This is the seam that keeps this
 /// module target-blind (issue #2078, mirroring `local.rs` #2070).
-pub fn install_log_sink(sink: LogSink) {
+pub fn install_log_sink(sink: Sink) {
     // A `fn` pointer casts cleanly to a thin data pointer; `current_sink`
     // transmutes it back (pointer → `fn` is not a plain cast).
     let raw: *mut () = sink as *mut ();
@@ -342,21 +342,21 @@ pub fn install_log_sink(sink: LogSink) {
 
 /// Read the installed sink, or `None` before any install.
 #[inline]
-fn current_sink() -> Option<LogSink> {
+fn current_sink() -> Option<Sink> {
     let raw = LOG_SINK.load(Ordering::Acquire);
     if raw.is_null() {
         return None;
     }
-    // SAFETY: `LOG_SINK` only ever holds a `LogSink` cast to a thin
+    // SAFETY: `LOG_SINK` only ever holds a `Sink` cast to a thin
     // pointer by `install_log_sink`; this reconstructs it. A data
     // pointer → `fn` pointer is not a plain cast, so `transmute` is
     // required.
-    Some(unsafe { transmute::<*mut (), LogSink>(raw) })
+    Some(unsafe { transmute::<*mut (), Sink>(raw) })
 }
 
 /// Target-blind `tracing` subscriber: renders each event via
 /// [`render_event`] and forwards `(level, target, message)` to the
-/// installed [`LogSink`]. The guest runtime sets it as `tracing`'s
+/// installed [`Sink`]. The guest runtime sets it as `tracing`'s
 /// global default and installs the FFI sink, so each guest event rides
 /// the trampoline's per-event host fn into the host process, where the
 /// host-side `ActorAwareLayer` lands it in the trampoline's

--- a/crates/aether-actor/src/mail/mailbox.rs
+++ b/crates/aether-actor/src/mail/mailbox.rs
@@ -146,7 +146,9 @@ pub const fn resolve<K: Kind>() -> KindId<K> {
 /// kind already exist on the substrate side at init time.
 // SDK compile-time name→id primitive (the documented `Mailbox<K>` token
 // path) — `mailbox_name` is a const, resolved before any runtime carry exists.
+// Bare `resolve` collides with the sibling `resolve::<K>() -> KindId`; they are distinct verbs.
 #[must_use]
+#[allow(clippy::module_name_repetitions)]
 #[allow(clippy::disallowed_methods)]
 pub const fn resolve_mailbox<K: Kind>(mailbox_name: &str) -> Mailbox<K> {
     Mailbox::__new(mailbox_id_from_name(mailbox_name).0, K::ID.0)

--- a/crates/aether-actor/src/wasm/bridge/log.rs
+++ b/crates/aether-actor/src/wasm/bridge/log.rs
@@ -23,7 +23,7 @@ use crate::wasm::raw;
 /// returning; the guest's borrows are released as soon as the
 /// FFI call completes.
 ///
-/// Only callable from wasm32 — installed as the [`crate::log::LogSink`]
+/// Only callable from wasm32 — installed as the [`crate::log::Sink`]
 /// by the guest runtime (`export!`) and invoked from
 /// [`crate::log::ForwardingSubscriber::event`].
 #[cfg(target_family = "wasm")]

--- a/crates/aether-actor/src/wasm/ctx.rs
+++ b/crates/aether-actor/src/wasm/ctx.rs
@@ -27,7 +27,7 @@ use crate::model::{
     validate_namespace_segment,
 };
 use crate::wasm::bridge::{mail, persist};
-use crate::wasm::inline::{ChainMode, InlineRegistry};
+use crate::wasm::inline::{ChainMode, Registry};
 use crate::wasm::mailbox::WasmActorMailbox;
 use crate::wasm::{ActorInitError, ErasedWasmActor, WasmActor};
 use alloc::boxed::Box;
@@ -37,6 +37,8 @@ use alloc::vec::Vec;
 /// Init-only capability handle for FFI guests. Resolved during
 /// `WasmActor::init`; not available at runtime (the type split fences
 /// "when can I resolve?" against "when can I send?" at compile time).
+// The `Wasm` prefix carries the native/wasm split signal; bare `InitCtx` loses that.
+#[allow(clippy::module_name_repetitions)]
 pub struct WasmInitCtx<'a> {
     mailbox: u64,
     _borrow: PhantomData<&'a ()>,
@@ -105,7 +107,7 @@ pub struct RelativeMailbox<'a> {
     /// [`WasmCtx::parent`] / [`WasmCtx::child`] / [`WasmCtx::sibling`] to the
     /// resolving ctx's `mailbox`.
     sender: u64,
-    inline: &'a InlineRegistry,
+    inline: &'a Registry,
 }
 
 impl RelativeMailbox<'_> {
@@ -177,6 +179,8 @@ pub enum SpawnError {
 /// inherent [`mailbox_id`](WasmCtx::mailbox_id) so `wire`-stage explicit
 /// subscribes (sending `SubscribeInput` to the `InputCapability`) can
 /// self-address.
+// The `Wasm` prefix carries the native/wasm split signal; bare `Ctx` loses that.
+#[allow(clippy::module_name_repetitions)]
 pub struct WasmCtx<'a, M: ReplyMode = Single> {
     mailbox: u64,
     sender: Option<ReplyHandle>,
@@ -198,7 +202,7 @@ pub struct WasmCtx<'a, M: ReplyMode = Single> {
     /// host unit test threads in a local registry. Held by reference
     /// rather than reached as a global — the same discipline the parent
     /// slot (`__AETHER_COMPONENT`) already follows.
-    inline: &'a InlineRegistry,
+    inline: &'a Registry,
     _borrow: PhantomData<&'a ()>,
     /// ADR-0112: phantom reply-mode marker (a ZST, layout-neutral) that
     /// selects which reply surface this ctx exposes. Defaults to
@@ -227,7 +231,7 @@ impl<'a> WasmCtx<'a, Manual> {
     /// [`MailboxId::NONE`] (`0`) for a lifecycle hook with no inbound mail.
     #[doc(hidden)]
     #[must_use]
-    pub fn __new(mailbox: u64, inline: &'a InlineRegistry, source: u64) -> Self {
+    pub fn __new(mailbox: u64, inline: &'a Registry, source: u64) -> Self {
         Self {
             mailbox,
             sender: None,
@@ -365,7 +369,7 @@ impl<M: ReplyMode> WasmCtx<'_, M> {
     /// this trampoline's own slot; the SDK then runs `A::init`
     /// **synchronously** (unlike the detached `spawn_child`, whose `init`
     /// runs later on a fresh trampoline) and inserts the boxed child into
-    /// this ctx's per-component [`InlineRegistry`] keyed by the alias. Mail
+    /// this ctx's per-component [`Registry`] keyed by the alias. Mail
     /// addressed to the alias lands in this slot and the `export!`
     /// membrane demuxes it to the child; the child's own sends stamp the
     /// child's address as origin and its replies route back.
@@ -434,7 +438,7 @@ impl<M: ReplyMode> WasmCtx<'_, M> {
 
     /// ADR-0114: tear down an **inline child** spawned by
     /// [`Self::spawn_inline_child`]. Drops the child from this ctx's
-    /// per-component [`InlineRegistry`] (running the child's `Drop`), so it
+    /// per-component [`Registry`] (running the child's `Drop`), so it
     /// stops handling mail. `child` is the alias [`MailboxId`] that
     /// `spawn_inline_child` returned (the registry key, the natural
     /// handle). Returns `true` if a resident child was removed, `false` if
@@ -584,7 +588,7 @@ fn resolve_subname(subname: Subname<'_>) -> Result<(bool, String), SpawnError> {
 /// the slot so a `replace_component` swap can reconstruct the child by
 /// type and re-fold its metadata.
 fn install_inline_child<A>(
-    registry: &InlineRegistry,
+    registry: &Registry,
     alias: MailboxId,
     type_tag: u64,
     full_subname: String,
@@ -765,6 +769,8 @@ impl CapturedState {
 /// Narrowed capability handle for the `on_dehydrate` save hook.
 /// Outbound mail still works through [`MailSender`]; the reply / resolve
 /// surfaces are intentionally absent.
+// The `Wasm` prefix carries the native/wasm split signal; bare `DropCtx` loses that.
+#[allow(clippy::module_name_repetitions)]
 pub struct WasmDropCtx<'a> {
     /// The actor's own mailbox id (its lineage carry), so a buffered
     /// `send` resolves the receiver through `R::resolve(self.mailbox)`
@@ -937,8 +943,7 @@ impl Persistence for WasmDropCtx<'_> {
 #[cfg(test)]
 mod tests {
     use super::{
-        InlineRegistry, Manual, NO_INBOUND_SOURCE, Single, SpawnError, WasmCtx,
-        install_inline_child,
+        Manual, NO_INBOUND_SOURCE, Registry, Single, SpawnError, WasmCtx, install_inline_child,
     };
     use crate::Addressable;
     use crate::mail::{Mail, PriorState};
@@ -1011,7 +1016,7 @@ mod tests {
     /// it without the panicking `spawn_inline_child` host-fn stub.
     #[test]
     fn install_inline_child_reports_init_failure() {
-        let registry = InlineRegistry::new();
+        let registry = Registry::new();
         let result = install_inline_child::<FailingChild>(
             &registry,
             MailboxId(0x5555),
@@ -1033,7 +1038,7 @@ mod tests {
     /// host build's panicking host-fn stub is never reached).
     #[test]
     fn spawn_inline_child_rejects_invalid_subname() {
-        let registry = InlineRegistry::new();
+        let registry = Registry::new();
         let ctx = WasmCtx::__new(0, &registry, NO_INBOUND_SOURCE);
         let result = ctx.spawn_inline_child::<FailingChild>(Subname::Named("bad:name"), &());
         assert!(
@@ -1050,7 +1055,7 @@ mod tests {
     /// sentinel) yields `None`. No host round-trip is involved.
     #[test]
     fn source_mailbox_reads_the_threaded_source_field() {
-        let registry = InlineRegistry::new();
+        let registry = Registry::new();
 
         let source = MailboxId(0x9999_0000_1234_5678);
         let ctx: WasmCtx<'_, Manual> = WasmCtx::__new(0x10, &registry, source.0);
@@ -1136,7 +1141,7 @@ mod tests {
     /// on the host build). `parent()` of the root is `None` (cross-cluster).
     #[test]
     fn ctx_relative_verbs_resolve_and_route_in_place() {
-        let registry = InlineRegistry::new();
+        let registry = Registry::new();
         let root = 0x7100_u64;
         registry.set_self_id(root);
         // Install a child of the root keyed by a synthetic alias; record the

--- a/crates/aether-actor/src/wasm/inline/compose.rs
+++ b/crates/aether-actor/src/wasm/inline/compose.rs
@@ -3,7 +3,7 @@
 //! multi-actor) so the symmetric walk lives in one place rather than
 //! being copy-pasted per arm.
 //!
-//! On dehydrate ([`compose_dehydrate`]): run the parent's `on_dehydrate`
+//! On dehydrate ([`dehydrate`]): run the parent's `on_dehydrate`
 //! into a capture buffer, walk every resident inline child running its
 //! `erased_on_dehydrate` into its own capture buffer, and pack the
 //! parent's blob plus each child's into one composite (`bundle`).
@@ -27,7 +27,7 @@ use aether_data::{Kind, MailboxId};
 
 use crate::mail::PriorState;
 use crate::wasm::ctx::{CapturedState, NO_INBOUND_SOURCE, WasmDropCtx, WasmInitCtx};
-use crate::wasm::inline::InlineRegistry;
+use crate::wasm::inline::Registry;
 use crate::wasm::inline::bundle::{self, ChildEntry};
 use crate::wasm::{ErasedWasmActor, WasmActor, WasmCtx};
 
@@ -48,9 +48,9 @@ use crate::wasm::{ErasedWasmActor, WasmActor, WasmCtx};
 /// with no inline children that is byte-identical to the parent's own
 /// blob.
 #[must_use]
-pub fn compose_dehydrate(
+pub fn dehydrate(
     mailbox_id: u64,
-    registry: &InlineRegistry,
+    registry: &Registry,
     run_parent_dehydrate: impl FnOnce(&mut WasmDropCtx<'_>),
 ) -> Option<(u32, Vec<u8>)> {
     // Parent half: capture whatever the parent's `on_dehydrate` saves.
@@ -139,9 +139,9 @@ pub struct InlineChildToReconstruct<'a> {
 pub fn reconstruct_inline_children(
     version: u32,
     bytes: &[u8],
-    registry: &InlineRegistry,
+    registry: &Registry,
     run_parent_rehydrate: impl FnOnce(u32, &[u8]),
-    mut reconstruct_child: impl FnMut(&InlineRegistry, &InlineChildToReconstruct<'_>) -> bool,
+    mut reconstruct_child: impl FnMut(&Registry, &InlineChildToReconstruct<'_>) -> bool,
 ) {
     let decomposed = bundle::decompose(version, bytes);
 
@@ -184,7 +184,7 @@ pub fn reconstruct_inline_children(
 /// by `alias` restores addressing with no host round-trip.
 #[must_use]
 pub fn reconstruct_one_child<A>(
-    registry: &InlineRegistry,
+    registry: &Registry,
     to_reconstruct: &InlineChildToReconstruct<'_>,
 ) -> bool
 where
@@ -241,7 +241,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{InlineRegistry, compose_dehydrate, reconstruct_inline_children};
+    use super::{Registry, dehydrate, reconstruct_inline_children};
     use crate::Manual;
     use crate::mail::{Mail, PriorState};
     use crate::wasm::ctx::WasmDropCtx;
@@ -282,7 +282,7 @@ mod tests {
     fn compose_dehydrate_packs_parent_and_children() {
         // Two children with distinct tags + type tags + aliases, in a
         // test-local registry (no shared-global aliasing across tests).
-        let registry = InlineRegistry::new();
+        let registry = Registry::new();
         let id_a = MailboxId(0xA1);
         let id_b = MailboxId(0xB2);
         registry.insert_child(
@@ -303,7 +303,7 @@ mod tests {
         );
 
         // Parent saves a marker blob of its own.
-        let (version, bytes) = compose_dehydrate(0x7000, &registry, |ctx| {
+        let (version, bytes) = dehydrate(0x7000, &registry, |ctx| {
             ctx.save_state(3, &[0xDE, 0xAD]);
         })
         .expect("a parent that saves plus two children yields a bundle");
@@ -368,7 +368,7 @@ mod tests {
         ];
         let (version, bytes) = compose(5, &[7, 7], &children);
 
-        let registry = InlineRegistry::new();
+        let registry = Registry::new();
         let mut parent_runs = 0u32;
         let mut offered: Vec<(u64, Vec<u8>)> = Vec::new();
         reconstruct_inline_children(

--- a/crates/aether-actor/src/wasm/inline/mod.rs
+++ b/crates/aether-actor/src/wasm/inline/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! An inline child shares its parent's WASM instance, slot, and
 //! run-token (ADR-0114). [`WasmCtx::spawn_inline_child`] inserts
-//! the constructed child into the per-component [`InlineRegistry`] the
+//! the constructed child into the per-component [`Registry`] the
 //! [`crate::export!`] macro emits as a `static __AETHER_INLINE` (one per
 //! component, mirroring the parent's `static __AETHER_COMPONENT` slot),
 //! keyed by the child's alias [`MailboxId`]. The `export!` `receive_p32`
@@ -57,7 +57,7 @@ pub mod compose;
 /// One inline child's slot. `actor` is `None` while the child is taken
 /// out for dispatch (the slot-shaped take / reinsert) and `Some` at rest.
 /// The child's alias [`MailboxId`] is carried as the map key in
-/// [`InlineRegistry`]; there is no redundant `id` field here.
+/// [`Registry`]; there is no redundant `id` field here.
 ///
 /// ADR-0114 §5: the slot also records the metadata a `replace_component`
 /// swap needs to reconstruct the child in the fresh instance — the
@@ -82,8 +82,8 @@ struct InlineSlot {
     /// The real folded [`MailboxId`] of the actor that spawned this child
     /// (the spawning ctx's own id at `spawn_inline_child` time). The
     /// logical-tree link the relative-addressing lookups
-    /// ([`InlineRegistry::parent_of`] / [`InlineRegistry::child_of`] /
-    /// [`InlineRegistry::sibling_of`]) walk — resolution is pure registry
+    /// ([`Registry::parent_of`] / [`Registry::child_of`] /
+    /// [`Registry::sibling_of`]) walk — resolution is pure registry
     /// lookup, never a fold (a `MailboxId` is a one-way hash chain, so the
     /// guest cannot reproduce a relative's id by folding; it looks the
     /// recorded id up instead).
@@ -92,9 +92,9 @@ struct InlineSlot {
 }
 
 /// A cloneable snapshot of one resident inline child's reconstruct
-/// metadata (no actor box), produced by [`InlineRegistry::child_metas`]
+/// metadata (no actor box), produced by [`Registry::child_metas`]
 /// for the dehydrate walk. The compose path reads each child's state
-/// through [`InlineRegistry::with_child_mut`] keyed by `id`.
+/// through [`Registry::with_child_mut`] keyed by `id`.
 #[derive(Clone)]
 pub(crate) struct InlineChildMeta {
     /// The child's alias [`MailboxId`] (the registry key).
@@ -108,7 +108,7 @@ pub(crate) struct InlineChildMeta {
 }
 
 /// One intra-cluster send buffered on the per-component queue
-/// ([`InlineRegistry`]). A send whose recipient is a member of this cluster
+/// ([`Registry`]). A send whose recipient is a member of this cluster
 /// — the instance itself or one of its inline children — is pushed here
 /// rather than handed to the host; [`drain_cluster_queue`] dispatches each
 /// one through the membrane after the top-level dispatch returns, so the
@@ -132,7 +132,7 @@ struct QueuedMail {
 
 /// Whether a resolved recipient is in this cluster (dispatch in place
 /// through the queue) or outside it (hand to the host). The membership
-/// decision is factored out of [`InlineRegistry::route_or_enqueue`] as this
+/// decision is factored out of [`Registry::route_or_enqueue`] as this
 /// pure value so it is unit-testable without a live `MAIL_BRIDGE`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RouteDecision {
@@ -144,7 +144,7 @@ pub(crate) enum RouteDecision {
 
 /// Whether a send inherits the handler's in-flight causal chain or starts
 /// a fresh one (ADR-0080 §7). Passed to
-/// [`InlineRegistry::route_or_enqueue`]; on the remote path it controls
+/// [`Registry::route_or_enqueue`]; on the remote path it controls
 /// whether the host stamps the dispatch's `parent`/`root` onto the outbound
 /// send (`Inherit`) or mints a new root chain (`Detached`). The local path
 /// carries no host trace ids, so the mode is irrelevant there.
@@ -171,7 +171,7 @@ pub(crate) enum ChainMode {
 /// addressable at any lineage depth; `queue` is the cluster-local mail
 /// queue an intra-cluster send is pushed to and [`drain_cluster_queue`]
 /// drains in place.
-pub struct InlineRegistry {
+pub struct Registry {
     inner: UnsafeCell<BTreeMap<MailboxId, InlineSlot>>,
     /// The instance's real folded [`MailboxId`] (`Tag::Mailbox`-tagged),
     /// set once from the `init` / `wire` shim's `mailbox_id` argument — the
@@ -199,9 +199,9 @@ pub struct InlineRegistry {
 // the added interior-mutable fields (`self_id`, `queue`): each is touched
 // only from the single run-token thread, and every borrow of `queue` is
 // taken fresh and released before return (never spanning a dispatch).
-unsafe impl Sync for InlineRegistry {}
+unsafe impl Sync for Registry {}
 
-impl InlineRegistry {
+impl Registry {
     /// An empty registry. `const` so it can back a `static`.
     #[must_use]
     pub const fn new() -> Self {
@@ -491,7 +491,7 @@ impl InlineRegistry {
     }
 }
 
-impl Default for InlineRegistry {
+impl Default for Registry {
     fn default() -> Self {
         Self::new()
     }
@@ -524,7 +524,7 @@ impl Default for InlineRegistry {
 pub fn membrane_dispatch<F>(
     own_mailbox_id: u64,
     mail: Mail<'_>,
-    registry: &InlineRegistry,
+    registry: &Registry,
     source: u64,
     dispatch_own: F,
 ) -> u32
@@ -574,7 +574,7 @@ where
 /// Reentrancy and cycles are handled by the queue, not by nested dispatch:
 /// a drained item's handler that sends to a busy cluster member just pushes
 /// a later queue item, which this same loop picks up.
-pub fn drain_cluster_queue<M, Own>(registry: &InlineRegistry, mut mk_own: M)
+pub fn drain_cluster_queue<M, Own>(registry: &Registry, mut mk_own: M)
 where
     M: FnMut(u64) -> Own,
     Own: FnOnce(Mail<'_>) -> u32,
@@ -613,7 +613,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{ChainMode, InlineRegistry, RouteDecision, drain_cluster_queue, membrane_dispatch};
+    use super::{ChainMode, Registry, RouteDecision, drain_cluster_queue, membrane_dispatch};
     use crate::WasmCtx;
     use crate::mail::{Mail, PriorState};
     use crate::model::ctx::OutboundReply;
@@ -756,7 +756,7 @@ mod tests {
     /// through insert → take → reinsert → take.
     #[test]
     fn registry_insert_take_reinsert_round_trips() {
-        let registry = InlineRegistry::new();
+        let registry = Registry::new();
         let id = MailboxId(0x1111);
 
         assert!(registry.take(id).is_none(), "empty registry has no child");
@@ -787,7 +787,7 @@ mod tests {
     /// dehydrate walk.
     #[test]
     fn child_metas_carry_type_tag_and_subname() {
-        let registry = InlineRegistry::new();
+        let registry = Registry::new();
         let id = MailboxId(0x7777);
         let tag = 0xABCD_u64;
         registry.insert_child(
@@ -813,7 +813,7 @@ mod tests {
     /// the child registry.
     #[test]
     fn membrane_routes_own_recipient_to_parent() {
-        let registry = InlineRegistry::new();
+        let registry = Registry::new();
         let own = 0x2000_u64;
         let rc = membrane_dispatch(own, mail_to(own), &registry, MailboxId::NONE.0, |_mail| {
             OWN_CODE
@@ -826,7 +826,7 @@ mod tests {
     /// again (the take/reinsert round-trip under the membrane).
     #[test]
     fn membrane_routes_child_recipient_and_reinserts() {
-        let registry = InlineRegistry::new();
+        let registry = Registry::new();
         let own = 0x3000_u64;
         let child = 0x3001_u64;
         let (recording, dispatches) = RecordingChild::new();
@@ -856,7 +856,7 @@ mod tests {
     /// the parent's unmatched path rather than short-circuit dropping.
     #[test]
     fn membrane_routes_unknown_recipient_to_parent_unmatched_path() {
-        let registry = InlineRegistry::new();
+        let registry = Registry::new();
         let own = 0x4000_u64;
         let stray = 0x4999_u64;
         let rc = membrane_dispatch(own, mail_to(stray), &registry, MailboxId::NONE.0, |_mail| {
@@ -878,7 +878,7 @@ mod tests {
     /// through to the parent's unmatched path.
     #[test]
     fn membrane_self_despawn_drops_box_and_falls_through() {
-        let registry = InlineRegistry::new();
+        let registry = Registry::new();
         let own = 0x5000_u64;
         let child = 0x5001_u64;
         let drops = Rc::new(Cell::new(0));
@@ -919,7 +919,7 @@ mod tests {
     /// Install a recording child under `id` with `parent`, returning the
     /// shared dispatch counter. Shared helper for the addressing /
     /// route / drain tests below.
-    fn install_recording(registry: &InlineRegistry, id: u64, parent: u64) -> Rc<Cell<u32>> {
+    fn install_recording(registry: &Registry, id: u64, parent: u64) -> Rc<Cell<u32>> {
         let (recording, dispatches) = RecordingChild::new();
         registry.insert_child(
             MailboxId(id),
@@ -937,7 +937,7 @@ mod tests {
     /// clean `None` — never a fold.
     #[test]
     fn relative_resolution_walks_recorded_parent_links() {
-        let registry = InlineRegistry::new();
+        let registry = Registry::new();
         let root = 0x1000_u64;
         registry.set_self_id(root);
 
@@ -1018,7 +1018,7 @@ mod tests {
     /// live `MAIL_BRIDGE`.
     #[test]
     fn route_decision_classifies_cluster_membership() {
-        let registry = InlineRegistry::new();
+        let registry = Registry::new();
         let root = 0x2000_u64;
         let child = 0x2001_u64;
         registry.set_self_id(root);
@@ -1046,7 +1046,7 @@ mod tests {
     /// The queue grows by one per local send.
     #[test]
     fn route_or_enqueue_buffers_local_sends() {
-        let registry = InlineRegistry::new();
+        let registry = Registry::new();
         let root = 0x3000_u64;
         let child = 0x3001_u64;
         registry.set_self_id(root);
@@ -1072,7 +1072,7 @@ mod tests {
     /// call.
     #[test]
     fn drain_dispatches_a_seeded_local_item() {
-        let registry = InlineRegistry::new();
+        let registry = Registry::new();
         let root = 0x4000_u64;
         let child = 0x4001_u64;
         registry.set_self_id(root);
@@ -1115,7 +1115,7 @@ mod tests {
     /// child the first time it runs.
     #[test]
     fn drain_runs_a_cascade_in_one_call() {
-        let registry = InlineRegistry::new();
+        let registry = Registry::new();
         let root = 0x5000_u64;
         let child = 0x5001_u64;
         registry.set_self_id(root);
@@ -1181,7 +1181,7 @@ mod tests {
     /// shared dispatch counter and the shared observed-source cell, so a test
     /// can assert the in-place "from" half a drained dispatch reads.
     fn install_recording_with_source(
-        registry: &InlineRegistry,
+        registry: &Registry,
         id: u64,
         parent: u64,
     ) -> (Rc<Cell<u32>>, SourceCell) {
@@ -1204,7 +1204,7 @@ mod tests {
     /// that id, not `None`.
     #[test]
     fn drained_child_reads_enqueuing_sender_parent() {
-        let registry = InlineRegistry::new();
+        let registry = Registry::new();
         let root = 0x6000_u64;
         let child = 0x6001_u64;
         registry.set_self_id(root);
@@ -1232,7 +1232,7 @@ mod tests {
     /// contract directly — there is no host reply-table fallback.)
     #[test]
     fn membrane_dispatch_with_none_source_reads_no_source() {
-        let registry = InlineRegistry::new();
+        let registry = Registry::new();
         let own = 0x8000_u64;
         let child = 0x8001_u64;
         registry.set_self_id(own);

--- a/crates/aether-actor/src/wasm/mailbox.rs
+++ b/crates/aether-actor/src/wasm/mailbox.rs
@@ -25,7 +25,7 @@ use core::marker::PhantomData;
 use aether_data::{ActorId, Kind, MailboxId, Tag, fold_lineage, with_tag};
 
 use crate::model::{Addressable, HandlesKind};
-use crate::wasm::inline::{ChainMode, InlineRegistry};
+use crate::wasm::inline::{ChainMode, Registry};
 
 /// Phantom-typed receiver-actor handle for FFI guests, built by
 /// [`crate::wasm::WasmCtx::actor`] / [`crate::wasm::WasmCtx::resolve_actor`].
@@ -38,6 +38,8 @@ use crate::wasm::inline::{ChainMode, InlineRegistry};
 /// property of the *executing* actor — the handle cannot outlive the handler,
 /// so it can never carry a stale origin the way a stored address-only token
 /// would.
+// Dropping `Mailbox` yields `WasmActor`, colliding with the trait of the same name.
+#[allow(clippy::module_name_repetitions)]
 pub struct WasmActorMailbox<'a, R> {
     mailbox: u64,
     /// The resolving actor's own folded [`aether_data::MailboxId`] raw value —
@@ -47,12 +49,12 @@ pub struct WasmActorMailbox<'a, R> {
     /// the ctx-level constructors to the resolving ctx's own id.
     sender: u64,
     /// The per-component inline registry the send routes through
-    /// ([`InlineRegistry::route_or_enqueue`]): a cluster-member recipient
+    /// ([`Registry::route_or_enqueue`]): a cluster-member recipient
     /// dispatches in place, any other recipient hands off to the host. A typed
     /// peer / cap recipient is always cross-cluster, so this resolves to the
     /// host send — the registry borrow only keeps the routing path uniform with
     /// the in-cluster [`crate::wasm::RelativeMailbox`].
-    inline: &'a InlineRegistry,
+    inline: &'a Registry,
     _r: PhantomData<fn() -> R>,
 }
 
@@ -70,7 +72,7 @@ impl<'a, R> WasmActorMailbox<'a, R> {
     /// per-component inline registry the send routes through.
     #[doc(hidden)]
     #[must_use]
-    pub fn __new(mailbox: u64, sender: u64, inline: &'a InlineRegistry) -> Self {
+    pub fn __new(mailbox: u64, sender: u64, inline: &'a Registry) -> Self {
         Self {
             mailbox,
             sender,

--- a/crates/aether-actor/src/wasm/mod.rs
+++ b/crates/aether-actor/src/wasm/mod.rs
@@ -53,7 +53,11 @@ pub mod inline;
 pub mod mailbox;
 pub mod raw;
 
+// Re-exports of `Wasm*` types — the `Wasm` prefix is deliberate (native/wasm split);
+// allows mirror the def-site allows on each type.
+#[allow(clippy::module_name_repetitions)]
 pub use ctx::{NO_INBOUND_SOURCE, RelativeMailbox, SpawnError, WasmCtx, WasmDropCtx, WasmInitCtx};
+#[allow(clippy::module_name_repetitions)]
 pub use mailbox::WasmActorMailbox;
 
 // Issue 665 retired the `ffi::Mailbox<K>` 1-arg alias and the
@@ -135,6 +139,8 @@ impl From<String> for ActorInitError {
 /// implements it on the addressing identity, forwarding to the inherent
 /// `__aether_dispatch` demux table; for an un-split component `S = Self`, so
 /// `&mut S == &mut self`.
+// The `Wasm` prefix is the deliberate native-vs-wasm disambiguator; public SDK trait.
+#[allow(clippy::module_name_repetitions)]
 pub trait WasmDispatch<S> {
     /// Route one inbound mail to the matching `#[handler]` over the state.
     /// Returns the dispatch result code the `receive` FFI shim relays.
@@ -143,6 +149,8 @@ pub trait WasmDispatch<S> {
     fn dispatch(state: &mut S, ctx: &mut WasmCtx<'_, crate::Manual>, mail: crate::Mail<'_>) -> u32;
 }
 
+// Bare `Actor` collides with `model::Actor`; the `Wasm` prefix is the deliberate native-vs-wasm disambiguator.
+#[allow(clippy::module_name_repetitions)]
 pub trait WasmActor:
     crate::Addressable
     + for<'a> crate::Lifecycle<
@@ -357,8 +365,8 @@ macro_rules! __export_internal {
         // membrane and the dehydrate / rehydrate shims thread
         // `&__AETHER_INLINE` to the inline-child consumers instead of
         // reaching for a crate-global static.
-        static __AETHER_INLINE: $crate::wasm::inline::InlineRegistry =
-            $crate::wasm::inline::InlineRegistry::new();
+        static __AETHER_INLINE: $crate::wasm::inline::Registry =
+            $crate::wasm::inline::Registry::new();
 
         // ADR-0033 / issue 442: pin the actor's `aether.kinds.inputs`
         // bytes into the cdylib's wasm custom section. The const data
@@ -685,7 +693,7 @@ macro_rules! __export_internal {
             // composite is byte-identical to the parent's own blob, so a
             // childless component dehydrates exactly as before; a parent
             // that saves nothing and has no children skips the host save.
-            if let Some((version, bytes)) = $crate::wasm::inline::compose::compose_dehydrate(
+            if let Some((version, bytes)) = $crate::wasm::inline::compose::dehydrate(
                 mailbox_id,
                 &__AETHER_INLINE,
                 |ctx| <$component as $crate::WasmActor>::on_dehydrate(instance, ctx),
@@ -816,8 +824,8 @@ macro_rules! __export_multi_internal {
         // and the dehydrate / rehydrate shims thread `&__AETHER_INLINE` to
         // the inline-child consumers instead of reaching for a crate-global
         // static.
-        static __AETHER_INLINE: $crate::wasm::inline::InlineRegistry =
-            $crate::wasm::inline::InlineRegistry::new();
+        static __AETHER_INLINE: $crate::wasm::inline::Registry =
+            $crate::wasm::inline::Registry::new();
 
         // ADR-0096: per-actor `aether.kinds.inputs` section. Each
         // exported type's records are preceded by an
@@ -1119,7 +1127,7 @@ macro_rules! __export_multi_internal {
             // composite, then `save_state` once (the boxed instance's
             // dehydrate routes through `erased_on_dehydrate`). Childless ⇒
             // byte-identical to the boxed parent's own blob.
-            if let Some((version, bytes)) = $crate::wasm::inline::compose::compose_dehydrate(
+            if let Some((version, bytes)) = $crate::wasm::inline::compose::dehydrate(
                 mailbox_id,
                 &__AETHER_INLINE,
                 |ctx| instance.erased_on_dehydrate(ctx),

--- a/crates/aether-actor/src/wasm/raw.rs
+++ b/crates/aether-actor/src/wasm/raw.rs
@@ -74,7 +74,7 @@ unsafe extern "C" {
     /// ADR-0081 §7: re-emit one `tracing::*` event on the host side
     /// so the trampoline's `ActorAwareLayer` lands it in this guest's
     /// per-actor `ActorLogRing`. Called from `ForwardingSubscriber::event`
-    /// (via the installed `crate::log::LogSink`)
+    /// (via the installed `crate::log::Sink`)
     /// per event. `level` follows the `0 = trace .. 4 = error`
     /// mapping the rest of `aether.log.*` uses. `target_ptr/len` and
     /// `message_ptr/len` are byte slices in guest memory; the host

--- a/crates/aether-capabilities/src/component/mod.rs
+++ b/crates/aether-capabilities/src/component/mod.rs
@@ -108,7 +108,7 @@ mod tests {
     // trampoline-address fold against the flat name hash — the primitive is
     // the reference value under test, not sibling-cap addressing.
     #![allow(clippy::disallowed_methods)]
-    use aether_actor::wasm::inline::InlineRegistry;
+    use aether_actor::wasm::inline::Registry;
     use aether_actor::{Addressable, WasmActorMailbox};
     use aether_data::{ActorId, MailboxId, Tag, fold_lineage, mailbox_id_from_name, with_tag};
 
@@ -130,7 +130,7 @@ mod tests {
         // host carry + the trampoline node name. The ctx binding (sender +
         // inline registry) is irrelevant to id resolution, so a throwaway
         // registry and a zero sender suffice (issue 1987).
-        let registry = InlineRegistry::new();
+        let registry = Registry::new();
         let host = WasmActorMailbox::<ComponentHostCapability>::__new(
             mailbox_id_from_name(ComponentHostCapability::NAMESPACE).0,
             0,


### PR DESCRIPTION
Closes #2439.

## Summary

Acts on the `clippy::module_name_repetitions` observations the `/audit-quality` panel routed aside when it ran over `aether-actor` (behind #2436). The list was never persisted, so it was re-derived from clippy directly: 14 hits, dispositioned as a mix rather than a blanket suppression.

Renamed (the module stutter was dead weight):
- `compose_dehydrate` → `dehydrate` (`compose::dehydrate`)
- `LogSink` → `Sink` (`log::Sink`)
- `InlineRegistry` → `Registry` (`inline::Registry`, incl. the cross-crate use in `aether-capabilities`)

Kept with a targeted per-item `#[allow(clippy::module_name_repetitions)]` + reason (the affix is load-bearing):
- `WasmActor` / `WasmDispatch` / `WasmCtx` / `WasmInitCtx` / `WasmDropCtx` / `WasmActorMailbox` — the `Wasm` prefix is the native-vs-wasm disambiguator (bare `Actor` collides with `model::Actor`).
- `resolve_mailbox` — bare `resolve` collides with the sibling `resolve<K>() -> KindId`.

No crate-level blanket allow.

## Test plan

Existing `aether-actor` + `aether-capabilities` suites. Local: `cargo clippy --workspace --all-targets -- -D warnings` (and `-W clippy::module_name_repetitions` to confirm the kept items are silent and the renamed ones no longer fire), `cargo nextest run --workspace` (1897 passed), strict `cargo doc`, and the wasm32 component cross-build (catches the macro-body `Registry` / `dehydrate` paths).

## Generated by

`/implement` — agent execution of [scoped issue #2439](https://github.com/iamacoffeepot/aether/issues/2439).
