### PR TITLE
refactor(kinds): rename the anthropic and gemini wire _ms fields to _millis

### DIFF
--- a/crates/aether-capabilities/src/anthropic/api.rs
+++ b/crates/aether-capabilities/src/anthropic/api.rs
@@ -77,7 +77,7 @@ impl UreqAnthropicAdapter {
             // the cap's `error::status_to_error` mapping reconstructs
             // the typed variant. The cap parses the leading status.
             return Err(format!(
-                "status={status} retry_after_ms={retry_after_millis:?} body={text}"
+                "status={status} retry_after_millis={retry_after_millis:?} body={text}"
             ));
         }
 
@@ -110,7 +110,7 @@ fn build_request_body(req: &AnthropicRequest) -> Value {
 pub fn parse_messages_response(
     json: &str,
     fallback_model: &str,
-    wall_clock_ms: u32,
+    wall_clock_millis: u32,
 ) -> Result<AnthropicResponse, String> {
     let parsed: Value = serde_json::from_str(json).map_err(|e| format!("parse response: {e}"))?;
 
@@ -149,7 +149,7 @@ pub fn parse_messages_response(
         usage: AdapterUsage {
             input_tokens: clamp_u32(input_tokens),
             output_tokens: clamp_u32(output_tokens),
-            wall_clock_ms,
+            wall_clock_millis,
             cost_micros: None,
         },
     })
@@ -181,7 +181,7 @@ mod tests {
         assert_eq!(resp.model_used, "claude-opus-4-7");
         assert_eq!(resp.usage.input_tokens, 12);
         assert_eq!(resp.usage.output_tokens, 9);
-        assert_eq!(resp.usage.wall_clock_ms, 42);
+        assert_eq!(resp.usage.wall_clock_millis, 42);
     }
 
     #[test]

--- a/crates/aether-capabilities/src/anthropic/cli.rs
+++ b/crates/aether-capabilities/src/anthropic/cli.rs
@@ -4,7 +4,7 @@
 //! `aether.anthropic.cli.send` is a first-class call surface: spawn
 //! `claude`, pipe the prompt to stdin, read the completion from
 //! stdout, route stderr to the actor log ring. `Usage` carries only
-//! `wall_clock_ms` — the subprocess reports no token counts.
+//! `wall_clock_millis` — the subprocess reports no token counts.
 //!
 //! The blocking `std::process::Command` call runs on issue 1013's
 //! spawn-and-die ephemeral thread, never on the dispatcher.
@@ -23,8 +23,8 @@ use crate::shared::contentgen::adapter::{AdapterUsage, AnthropicRequest, Anthrop
 pub const CLI_NOT_FOUND: &str = "cli-not-found";
 
 /// Sentinel prefix returned when the `claude` subprocess overruns its
-/// deadline and is killed. Formatted as `timeout=<elapsed_ms>` so the
-/// cap maps it onto `AnthropicError::Timeout { elapsed_ms }` (the cap
+/// deadline and is killed. Formatted as `timeout=<elapsed_millis>` so the
+/// cap maps it onto `AnthropicError::Timeout { elapsed_millis }` (the cap
 /// parses the trailing integer the way it parses `status=`).
 pub const TIMEOUT_SENTINEL: &str = "timeout=";
 
@@ -160,7 +160,7 @@ impl ClaudeCliAdapter {
         }
 
         let text = String::from_utf8_lossy(&stdout_bytes).trim().to_string();
-        let wall_clock_ms = u32::try_from(started.elapsed().as_millis()).unwrap_or(u32::MAX);
+        let wall_clock_millis = u32::try_from(started.elapsed().as_millis()).unwrap_or(u32::MAX);
 
         Ok(AnthropicResponse {
             text,
@@ -168,7 +168,7 @@ impl ClaudeCliAdapter {
             usage: AdapterUsage {
                 input_tokens: 0,
                 output_tokens: 0,
-                wall_clock_ms,
+                wall_clock_millis,
                 cost_micros: None,
             },
         })

--- a/crates/aether-capabilities/src/anthropic/error.rs
+++ b/crates/aether-capabilities/src/anthropic/error.rs
@@ -31,16 +31,16 @@ pub fn adapter_error_to_typed(raw: &str) -> AnthropicError {
         return AnthropicError::Unauthorized;
     }
     if let Some(rest) = raw.strip_prefix(TIMEOUT_SENTINEL) {
-        // `timeout=<elapsed_ms>` — parse the trailing integer the way
+        // `timeout=<elapsed_millis>` — parse the trailing integer the way
         // the `status=` prefix is parsed. A malformed tail falls back to
         // 0 rather than dropping the timeout classification.
-        let elapsed_ms = rest.trim().parse::<u32>().unwrap_or(0);
-        return AnthropicError::Timeout { elapsed_ms };
+        let elapsed_millis = rest.trim().parse::<u32>().unwrap_or(0);
+        return AnthropicError::Timeout { elapsed_millis };
     }
     if let Some(rest) = raw.strip_prefix("status=")
-        && let Some((status, retry_after_ms)) = parse_status_prefix(rest)
+        && let Some((status, retry_after_millis)) = parse_status_prefix(rest)
     {
-        return status_to_error(status, retry_after_ms, rest);
+        return status_to_error(status, retry_after_millis, rest);
     }
     AnthropicError::AdapterError(snippet(raw))
 }
@@ -51,16 +51,16 @@ pub fn adapter_error_to_typed(raw: &str) -> AnthropicError {
 /// codes that don't have a typed variant.
 ///
 /// - `401` / `403` → `Unauthorized` (bad / missing key)
-/// - `429` → `RateLimited` (the `retry_after_ms` is parsed from the
+/// - `429` → `RateLimited` (the `retry_after_millis` is parsed from the
 ///   `retry-after` header by the caller and threaded in)
 /// - `529` → `Overloaded` (Anthropic's "service overloaded")
 /// - everything else non-2xx → `AdapterError` carrying the status +
 ///   body snippet
 #[must_use]
-pub fn status_to_error(status: u16, retry_after_ms: Option<u32>, body: &str) -> AnthropicError {
+pub fn status_to_error(status: u16, retry_after_millis: Option<u32>, body: &str) -> AnthropicError {
     match status {
         401 | 403 => AnthropicError::Unauthorized,
-        429 => AnthropicError::RateLimited { retry_after_ms },
+        429 => AnthropicError::RateLimited { retry_after_millis },
         529 => AnthropicError::Overloaded,
         other => AnthropicError::AdapterError(format!("http {other}: {}", snippet(body))),
     }
@@ -77,7 +77,9 @@ mod tests {
         let raw = format!("{TIMEOUT_SENTINEL}1500");
         assert_eq!(
             adapter_error_to_typed(&raw),
-            AnthropicError::Timeout { elapsed_ms: 1500 }
+            AnthropicError::Timeout {
+                elapsed_millis: 1500
+            }
         );
     }
 
@@ -86,7 +88,7 @@ mod tests {
         let raw = format!("{TIMEOUT_SENTINEL}garbage");
         assert_eq!(
             adapter_error_to_typed(&raw),
-            AnthropicError::Timeout { elapsed_ms: 0 }
+            AnthropicError::Timeout { elapsed_millis: 0 }
         );
     }
 
@@ -101,7 +103,7 @@ mod tests {
         assert_eq!(
             status_to_error(429, Some(1500), "slow down"),
             AnthropicError::RateLimited {
-                retry_after_ms: Some(1500)
+                retry_after_millis: Some(1500)
             }
         );
     }

--- a/crates/aether-capabilities/src/anthropic/kinds.rs
+++ b/crates/aether-capabilities/src/anthropic/kinds.rs
@@ -45,7 +45,7 @@ pub struct Message {
 pub enum AnthropicError {
     Overloaded,
     RateLimited {
-        retry_after_ms: Option<u32>,
+        retry_after_millis: Option<u32>,
     },
     ContextLengthExceeded {
         limit: u32,
@@ -58,7 +58,7 @@ pub enum AnthropicError {
         supported: Vec<String>,
     },
     Timeout {
-        elapsed_ms: u32,
+        elapsed_millis: u32,
     },
     ParamNotSupported {
         param: String,
@@ -120,7 +120,7 @@ pub enum MessagesSendResult {
 }
 
 /// Reply to [`CliSend`]. Same shape as [`MessagesSendResult`]; the
-/// CLI backend populates only `Usage.wall_clock_ms` (the subprocess
+/// CLI backend populates only `Usage.wall_clock_millis` (the subprocess
 /// reports no token counts).
 #[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.anthropic.cli.send_result")]

--- a/crates/aether-capabilities/src/anthropic/runtime.rs
+++ b/crates/aether-capabilities/src/anthropic/runtime.rs
@@ -291,7 +291,7 @@ fn to_usage(u: AdapterUsage) -> Usage {
     Usage {
         input_tokens: u.input_tokens,
         output_tokens: u.output_tokens,
-        wall_clock_ms: u.wall_clock_ms,
+        wall_clock_millis: u.wall_clock_millis,
         cost_micros: u.cost_micros,
     }
 }

--- a/crates/aether-capabilities/src/gemini/adapter.rs
+++ b/crates/aether-capabilities/src/gemini/adapter.rs
@@ -78,7 +78,7 @@ impl UreqGeminiAdapter {
             shared::run_request(&self.agent, http_req, self.timeout)?;
         if !(200..300).contains(&status) {
             return Err(format!(
-                "status={status} retry_after_ms={retry_after_millis:?} body={text}"
+                "status={status} retry_after_millis={retry_after_millis:?} body={text}"
             ));
         }
         Ok(text)

--- a/crates/aether-capabilities/src/gemini/error.rs
+++ b/crates/aether-capabilities/src/gemini/error.rs
@@ -15,7 +15,7 @@ use crate::shared::contentgen::shared::{parse_status_prefix, snippet};
 pub const UNAUTHORIZED_SENTINEL: &str = "unauthorized";
 
 /// Map an HTTP status code from a Gemini API onto a [`GeminiError`].
-/// `retry_after_ms` is parsed from the `retry-after` header by the
+/// `retry_after_millis` is parsed from the `retry-after` header by the
 /// caller; `body` is the response text, preserved in `AdapterError`
 /// for the codes without a typed variant.
 ///
@@ -23,10 +23,10 @@ pub const UNAUTHORIZED_SENTINEL: &str = "unauthorized";
 /// - `429` → `RateLimited`
 /// - everything else non-2xx → `AdapterError` carrying status + snippet
 #[must_use]
-pub fn status_to_error(status: u16, retry_after_ms: Option<u32>, body: &str) -> GeminiError {
+pub fn status_to_error(status: u16, retry_after_millis: Option<u32>, body: &str) -> GeminiError {
     match status {
         401 | 403 => GeminiError::Unauthorized,
-        429 => GeminiError::RateLimited { retry_after_ms },
+        429 => GeminiError::RateLimited { retry_after_millis },
         other => GeminiError::AdapterError(format!("http {other}: {}", snippet(body))),
     }
 }
@@ -41,9 +41,9 @@ pub fn adapter_error_to_typed(raw: &str) -> GeminiError {
         return GeminiError::Unauthorized;
     }
     if let Some(rest) = raw.strip_prefix("status=")
-        && let Some((status, retry_after_ms)) = parse_status_prefix(rest)
+        && let Some((status, retry_after_millis)) = parse_status_prefix(rest)
     {
-        return status_to_error(status, retry_after_ms, rest);
+        return status_to_error(status, retry_after_millis, rest);
     }
     GeminiError::AdapterError(snippet(raw))
 }
@@ -64,7 +64,7 @@ mod tests {
         assert_eq!(
             status_to_error(429, Some(2000), ""),
             GeminiError::RateLimited {
-                retry_after_ms: Some(2000)
+                retry_after_millis: Some(2000)
             }
         );
     }
@@ -79,11 +79,11 @@ mod tests {
 
     #[test]
     fn status_prefix_round_trips_through_typed() {
-        let raw = "status=429 retry_after_ms=Some(1500) body=slow down";
+        let raw = "status=429 retry_after_millis=Some(1500) body=slow down";
         assert_eq!(
             adapter_error_to_typed(raw),
             GeminiError::RateLimited {
-                retry_after_ms: Some(1500)
+                retry_after_millis: Some(1500)
             }
         );
     }

--- a/crates/aether-capabilities/src/gemini/kinds.rs
+++ b/crates/aether-capabilities/src/gemini/kinds.rs
@@ -90,7 +90,7 @@ pub struct GroundingMetadata {
 #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum GeminiError {
     RateLimited {
-        retry_after_ms: Option<u32>,
+        retry_after_millis: Option<u32>,
     },
     ContentPolicyRefused,
     Unauthorized,

--- a/crates/aether-capabilities/src/gemini/runtime.rs
+++ b/crates/aether-capabilities/src/gemini/runtime.rs
@@ -284,7 +284,7 @@ fn to_usage(u: AdapterUsage) -> Usage {
     Usage {
         input_tokens: u.input_tokens,
         output_tokens: u.output_tokens,
-        wall_clock_ms: u.wall_clock_ms,
+        wall_clock_millis: u.wall_clock_millis,
         cost_micros: u.cost_micros,
     }
 }

--- a/crates/aether-capabilities/src/shared/contentgen/adapter.rs
+++ b/crates/aether-capabilities/src/shared/contentgen/adapter.rs
@@ -76,7 +76,7 @@ pub struct GeminiResponse {
 pub struct AdapterUsage {
     pub input_tokens: u32,
     pub output_tokens: u32,
-    pub wall_clock_ms: u32,
+    pub wall_clock_millis: u32,
     pub cost_micros: Option<u64>,
 }
 
@@ -250,7 +250,7 @@ impl AnthropicAdapter for StubAnthropicAdapter {
             usage: AdapterUsage {
                 input_tokens: 1,
                 output_tokens: 1,
-                wall_clock_ms: 0,
+                wall_clock_millis: 0,
                 cost_micros: Some(0),
             },
         })
@@ -263,7 +263,7 @@ impl AnthropicAdapter for StubAnthropicAdapter {
             usage: AdapterUsage {
                 input_tokens: 0,
                 output_tokens: 0,
-                wall_clock_ms: 0,
+                wall_clock_millis: 0,
                 cost_micros: None,
             },
         })

--- a/crates/aether-capabilities/src/shared/contentgen/shared.rs
+++ b/crates/aether-capabilities/src/shared/contentgen/shared.rs
@@ -26,7 +26,7 @@ pub fn agent() -> ureq::Agent {
 }
 
 /// Run a built request through `agent` with a global timeout and return
-/// `(status, retry_after_ms, body_text)`. The `retry-after` header (in
+/// `(status, retry_after_millis, body_text)`. The `retry-after` header (in
 /// seconds) is converted to milliseconds when present. Errors are
 /// free-form strings the caller maps onto its provider error taxonomy.
 pub fn run_request(
@@ -55,16 +55,16 @@ pub fn run_request(
     Ok((status, retry_after_millis, text))
 }
 
-/// Parse the `<status> retry_after_ms=<Debug-of-Option<u32>>` prefix a
+/// Parse the `<status> retry_after_millis=<Debug-of-Option<u32>>` prefix a
 /// backend prepends to a non-2xx error string (after the caller strips
-/// the leading `status=`). Returns `(status, retry_after_ms)` on a
+/// the leading `status=`). Returns `(status, retry_after_millis)` on a
 /// clean parse. Both providers format the prefix identically.
 #[must_use]
 pub fn parse_status_prefix(rest: &str) -> Option<(u16, Option<u32>)> {
     let mut parts = rest.split_whitespace();
     let status = parts.next()?.parse::<u16>().ok()?;
     let retry_after_millis = parts.next().and_then(|tok| {
-        tok.strip_prefix("retry_after_ms=").and_then(|v| {
+        tok.strip_prefix("retry_after_millis=").and_then(|v| {
             // The backend formats `Option<u32>` via Debug — `Some(1500)`
             // or `None`. Extract the inner integer when present.
             v.strip_prefix("Some(")
@@ -99,11 +99,11 @@ mod tests {
     #[test]
     fn parse_status_prefix_extracts_status_and_retry() {
         assert_eq!(
-            parse_status_prefix("429 retry_after_ms=Some(1500) body=x"),
+            parse_status_prefix("429 retry_after_millis=Some(1500) body=x"),
             Some((429, Some(1500)))
         );
         assert_eq!(
-            parse_status_prefix("500 retry_after_ms=None body=oops"),
+            parse_status_prefix("500 retry_after_millis=None body=oops"),
             Some((500, None))
         );
         assert_eq!(parse_status_prefix("not-a-status"), None);

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -2340,7 +2340,7 @@ mod control_plane {
     /// Token + wall-clock accounting returned on a successful
     /// content-gen completion. Shared across the Anthropic text kinds
     /// (issue 1014) and the Gemini media kinds (issue 1015). The CLI
-    /// backend can only report `wall_clock_ms` (the subprocess gives no
+    /// backend can only report `wall_clock_millis` (the subprocess gives no
     /// token counts), leaving the token / cost fields zero / `None`;
     /// the Messages API and the Gemini APIs populate the rest where the
     /// provider reports them.
@@ -2348,7 +2348,7 @@ mod control_plane {
     pub struct Usage {
         pub input_tokens: u32,
         pub output_tokens: u32,
-        pub wall_clock_ms: u32,
+        pub wall_clock_millis: u32,
         pub cost_micros: Option<u64>,
     }
 }

--- a/docs/adr/0050-llm-completion-sink.md
+++ b/docs/adr/0050-llm-completion-sink.md
@@ -57,13 +57,13 @@ enum Role { User, Assistant }
 struct Usage {
     input_tokens: u32,
     output_tokens: u32,
-    wall_clock_ms: u32,
+    wall_clock_millis: u32,
     cost_micros: Option<u64>,   // 1/1_000_000 USD; API reports it, CLI subscription leaves it None
 }
 
 enum AnthropicError {
     Overloaded,
-    RateLimited { retry_after_ms: Option<u32> },
+    RateLimited { retry_after_millis: Option<u32> },
     ContextLengthExceeded { limit: u32 },
     Unauthorized,
     ContentPolicyRefused,
@@ -114,7 +114,7 @@ aether.gemini.lyria.generate_result : Ok  { request_id, output_path, model_used,
 
 ```rust
 enum GeminiError {
-    RateLimited { retry_after_ms: Option<u32> },
+    RateLimited { retry_after_millis: Option<u32> },
     ContentPolicyRefused,
     Unauthorized,
     UnknownModel { model: String, supported: Vec<String> },
@@ -160,7 +160,7 @@ Output PNG bytes stage to `save://gen/<uuid>.png`; `output_paths` is a `Vec` bec
 
 ```rust
 enum OpenaiError {
-    RateLimited { retry_after_ms: Option<u32> },
+    RateLimited { retry_after_millis: Option<u32> },
     ContentPolicyRefused,
     Unauthorized,
     UnknownModel { model: String, supported: Vec<String> },
@@ -213,7 +213,7 @@ There is **no `Semaphore` and no `Mutex`.** Because the actor is single-threaded
 **`aether.anthropic`** — two backend paths under one cap:
 
 - **Messages API** (`aether.anthropic.messages.send`). HTTPS to `api.anthropic.com/v1/messages`. Loaded when `ANTHROPIC_API_KEY` is set; per-token billing; reports full `Usage` including `cost_micros` from the API pricing table. Absent in the user's default workflow.
-- **CLI subprocess** (`aether.anthropic.cli.send`). Runs the local `claude` binary as a child process per request, request piped through stdin, `text` captured from stdout, stderr to the actor log ring. The load-bearing v1 path: the user runs Claude via subscription exercised through the CLI, no API key configured. Validated empirically in `spikes/prompt-pipeline-spike/` — five experiment runs across Haiku / Sonnet / Opus profiles, content-addressed caching, no failures; the spike's `src/claude.rs` is the reference. `Usage` from the CLI reports `wall_clock_ms` only; `input_tokens` / `output_tokens` are `0` and `cost_micros` is `None` (the CLI's text-output mode doesn't surface tokens, and subscription billing isn't per-call). If `claude` isn't on PATH, `cli.send` replies `Err { error: CliNotFound }`.
+- **CLI subprocess** (`aether.anthropic.cli.send`). Runs the local `claude` binary as a child process per request, request piped through stdin, `text` captured from stdout, stderr to the actor log ring. The load-bearing v1 path: the user runs Claude via subscription exercised through the CLI, no API key configured. Validated empirically in `spikes/prompt-pipeline-spike/` — five experiment runs across Haiku / Sonnet / Opus profiles, content-addressed caching, no failures; the spike's `src/claude.rs` is the reference. `Usage` from the CLI reports `wall_clock_millis` only; `input_tokens` / `output_tokens` are `0` and `cost_micros` is `None` (the CLI's text-output mode doesn't surface tokens, and subscription billing isn't per-call). If `claude` isn't on PATH, `cli.send` replies `Err { error: CliNotFound }`.
 
 Both kinds share the cap's rate-limit budget tracker when the user is on one Anthropic account — at the provider level they aren't separate buckets, though today CLI uses subscription quota and Messages uses per-token billing, so the two paths don't actually interact.
 
@@ -271,7 +271,7 @@ Per-request entries land in the per-actor log ring (ADR-0081):
 - **WARN** — adapter error, retry, ignored unsupported parameter, per-model validation rejection.
 - **ERROR** — irrecoverable failure, with the provider error variant.
 
-**Per-call cost rides the reply, not a broadcast.** Each completion's reply carries a `usage` field (`input_tokens`, `output_tokens`, `wall_clock_ms`, `cost_micros`) — the minimum cost surface, available to the caller without polling. There is no `aether.observation.llm_cost` 30-second broadcast: the broadcast sink and the entire `aether.observation.*` family retired in issue #775, so there is no fan-out target. A future user-space observer (TCP / websocket / session-targeted mail) is the path forward for engine-out cost fan-out if a long-running session wants a near-real-time roll-up; until then, callers aggregate the reply-carried `usage` themselves.
+**Per-call cost rides the reply, not a broadcast.** Each completion's reply carries a `usage` field (`input_tokens`, `output_tokens`, `wall_clock_millis`, `cost_micros`) — the minimum cost surface, available to the caller without polling. There is no `aether.observation.llm_cost` 30-second broadcast: the broadcast sink and the entire `aether.observation.*` family retired in issue #775, so there is no fan-out target. A future user-space observer (TCP / websocket / session-targeted mail) is the path forward for engine-out cost fan-out if a long-running session wants a near-real-time roll-up; until then, callers aggregate the reply-carried `usage` themselves.
 
 ### 8. Chassis coverage
 
@@ -310,7 +310,7 @@ Provider integration tests are the only place in the DAG-handles tree that touch
 
 ### Negative
 
-- **CLI path has limited usage telemetry.** `claude` text mode doesn't report token counts and subscription billing isn't per-call, so `cli.send` reports `wall_clock_ms` only and `cost_micros: None`. Fine-grained cost accounting needs the API path.
+- **CLI path has limited usage telemetry.** `claude` text mode doesn't report token counts and subscription billing isn't per-call, so `cli.send` reports `wall_clock_millis` only and `cost_micros: None`. Fine-grained cost accounting needs the API path.
 - **Per-substrate cap set, not per-component.** All components on a substrate share each cap's auth and budget. Per-component overrides are a future complication without a forcing function.
 - **No streaming, vision, or embeddings in v1.** Buffered replies only; deferred to follow-up ADRs.
 - **Credential management is env-var only.** No rotation, no per-component keys. Acceptable for v1.


### PR DESCRIPTION
Closes #2443.

## Summary

The `aether.anthropic.*` and `aether.gemini.*` content-gen wire surfaces carried `_ms`-suffixed field names, violating the CLAUDE.md rule banning two-letter unit abbreviations. Because these are `aether_data::Schema` + serde types, each field name is also the JSON wire key, so the abbreviation was baked into the wire contract and documented in ADR-0050.

This renames every `_ms` identifier and its serialization key across the shared content-gen surface to `_millis`, as one coherent cross-crate change (a partial rename would leave the wire surface half-converted):

- `aether_kinds::Usage.wall_clock_ms` → `wall_clock_millis` (the shared accounting type) + every constructor/reader.
- `AnthropicError::RateLimited.retry_after_ms` → `retry_after_millis`, `Timeout.elapsed_ms` → `elapsed_millis`.
- `GeminiError::RateLimited.retry_after_ms` → `retry_after_millis`.
- The shared `retry_after_ms=` string-format token in the content-gen error protocol (parser + both formatters).
- ADR-0050's documented field names.

Pre-1.0 with only in-repo consumers, so the wire-key change is low-cost now. The unrelated `desktop/driver.rs` `elapsed_ms` frame-timing tracing field is out of scope (not a content-gen wire surface) and left untouched.

## Test plan

`scripts/preflight.sh` green (fmt + clippy + doc + nextest + wasm cross-build + diff-scoped Qodana). Coverage is pinned by the existing `anthropic/error.rs`, `gemini/error.rs`, `shared/contentgen/shared.rs` parse tests and the `usage.wall_clock_*` assertion in `anthropic/api.rs` tests, which update with the rename.

## Generated by

`/implement` — agent execution of [scoped issue #2443](https://github.com/iamacoffeepot/aether/issues/2443).
