### PR TITLE
fix(math): correct from_euler_yxz to documented YXZ order

### DIFF
--- a/crates/aether-math/src/quat.rs
+++ b/crates/aether-math/src/quat.rs
@@ -39,10 +39,10 @@ impl Quat {
         let (sp, cp) = (libm::sinf(pitch * 0.5), libm::cosf(pitch * 0.5));
         let (sr, cr) = (libm::sinf(roll * 0.5), libm::cosf(roll * 0.5));
         Self::new(
-            cr * sp * cy - sr * cp * sy,
-            cr * cp * sy + sr * sp * cy,
-            cr * sp * sy + sr * cp * cy,
-            cr * cp * cy - sr * sp * sy,
+            cr * sp * cy + sr * cp * sy,
+            cr * cp * sy - sr * sp * cy,
+            sr * cp * cy - cr * sp * sy,
+            cr * cp * cy + sr * sp * sy,
         )
     }
 
@@ -175,6 +175,20 @@ mod tests {
         let pitch = 0.4;
         let a = Quat::from_euler_yxz(0.0, pitch, 0.0);
         let b = Quat::from_axis_angle(Vec3::X, pitch);
+        let v = Vec3::new(1.0, 2.0, 3.0);
+        assert!(approx_eq_vec3(a * v, b * v));
+    }
+
+    #[test]
+    fn combined_yaw_pitch_roll_matches_axis_angle_product() {
+        // Tripwire: from_euler_yxz must equal the explicit YXZ axis-angle
+        // product Ry(yaw)·Rx(pitch)·Rz(roll); single-axis tests can't catch
+        // a reversed composition order.
+        let (yaw, pitch, roll) = (0.3, 0.5, 0.7);
+        let a = Quat::from_euler_yxz(yaw, pitch, roll);
+        let b = Quat::from_axis_angle(Vec3::Y, yaw)
+            * Quat::from_axis_angle(Vec3::X, pitch)
+            * Quat::from_axis_angle(Vec3::Z, roll);
         let v = Vec3::new(1.0, 2.0, 3.0);
         assert!(approx_eq_vec3(a * v, b * v));
     }


### PR DESCRIPTION
Closes #2448.

## Summary

`Quat::from_euler_yxz` composed its rotations in reversed (ZXY) order versus the YXZ convention its doc-comment documents, so any combined yaw+pitch+roll produced the wrong orientation. This corrects the formula to the documented `Ry·Rx·Rz` order.

The single-axis tests could not catch it (both the old and new formulas coincide when only one angle is nonzero). The only production consumer is the aether-kit orbit camera (`OrbitState::view_proj`), which calls with `roll=0` and contains no code compensating for the reversed order — it consumes the orientation directly, so after this fix it gets the correct spherical orbit it already documents. No caller change is required; a post-merge visual sanity check of the camera is warranted.

## Test plan

- New `combined_yaw_pitch_roll_matches_axis_angle_product` tripwire test asserts equivalence to the explicit `from_axis_angle(Vec3::Y, yaw) * from_axis_angle(Vec3::X, pitch) * from_axis_angle(Vec3::Z, roll)` product, compared via rotated-vector equivalence to sidestep quaternion double-cover sign ambiguity.
- Existing single-axis euler tests unchanged and passing (1898/1898).

## Generated by

`/implement` — agent execution of scoped issue #2448.
