### PR TITLE
chore(math): act on the review panel's cleanup findings

### DIFF
--- a/crates/aether-math/src/aabb.rs
+++ b/crates/aether-math/src/aabb.rs
@@ -1,5 +1,13 @@
 use crate::vec::Vec3;
 
+/// A named world axis, used to select which component an operation acts on.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Axis {
+    X,
+    Y,
+    Z,
+}
+
 /// Axis-aligned bounding box in `f32` world coordinates.
 ///
 /// `min[i] > max[i]` along any axis denotes the empty box (no points).
@@ -76,14 +84,14 @@ impl Aabb {
         let mn = self.min;
         let mx = self.max;
         [
-            Vec3::new(mn.x, mn.y, mn.z),
+            mn,
             Vec3::new(mx.x, mn.y, mn.z),
             Vec3::new(mn.x, mx.y, mn.z),
             Vec3::new(mx.x, mx.y, mn.z),
             Vec3::new(mn.x, mn.y, mx.z),
             Vec3::new(mx.x, mn.y, mx.z),
             Vec3::new(mn.x, mx.y, mx.z),
-            Vec3::new(mx.x, mx.y, mx.z),
+            mx,
         ]
     }
 
@@ -223,36 +231,31 @@ impl Aabb {
         out
     }
 
-    /// Mirror across the plane `axis_index = 0` (`0 = X, 1 = Y, 2 = Z`).
+    /// Mirror across the plane perpendicular to `axis` through the origin.
     /// The bounds along that axis flip sign and swap; the others are
     /// unchanged.
-    ///
-    /// # Panics
-    /// Panics if `axis_index > 2` — the only valid values are `0`, `1`,
-    /// or `2`.
     #[must_use]
-    pub fn mirror(&self, axis_index: usize) -> Self {
-        assert!(axis_index < 3, "axis_index must be 0, 1, or 2");
+    pub fn mirror(&self, axis: Axis) -> Self {
         if self.is_empty() {
             return *self;
         }
         let mut out = *self;
-        let (lo, hi) = match axis_index {
-            0 => {
+        let (lo, hi) = match axis {
+            Axis::X => {
                 let lo = -self.max.x;
                 let hi = -self.min.x;
                 out.min.x = lo;
                 out.max.x = hi;
                 (lo, hi)
             }
-            1 => {
+            Axis::Y => {
                 let lo = -self.max.y;
                 let hi = -self.min.y;
                 out.min.y = lo;
                 out.max.y = hi;
                 (lo, hi)
             }
-            _ => {
+            Axis::Z => {
                 let lo = -self.max.z;
                 let hi = -self.min.z;
                 out.min.z = lo;
@@ -442,7 +445,7 @@ mod tests {
     #[test]
     fn mirror_x_flips_x_bounds() {
         let a = Aabb::from_min_max(Vec3::new(1.0, 2.0, 3.0), Vec3::new(4.0, 5.0, 6.0));
-        let m = a.mirror(0);
+        let m = a.mirror(Axis::X);
         assert_eq!(m.min, Vec3::new(-4.0, 2.0, 3.0));
         assert_eq!(m.max, Vec3::new(-1.0, 5.0, 6.0));
     }
@@ -450,32 +453,25 @@ mod tests {
     #[test]
     fn mirror_each_axis_only_touches_that_axis() {
         let a = Aabb::from_min_max(Vec3::new(1.0, 2.0, 3.0), Vec3::new(4.0, 5.0, 6.0));
-        for axis in 0..3 {
+        for axis in [Axis::X, Axis::Y, Axis::Z] {
             let m = a.mirror(axis);
-            for i in 0..3 {
-                if i == axis {
+            for other in [Axis::X, Axis::Y, Axis::Z] {
+                if other == axis {
                     continue;
                 }
-                let from_min = match i {
-                    0 => (a.min.x, m.min.x),
-                    1 => (a.min.y, m.min.y),
-                    _ => (a.min.z, m.min.z),
+                let (orig_min, mirrored_min) = match other {
+                    Axis::X => (a.min.x, m.min.x),
+                    Axis::Y => (a.min.y, m.min.y),
+                    Axis::Z => (a.min.z, m.min.z),
                 };
-                let from_max = match i {
-                    0 => (a.max.x, m.max.x),
-                    1 => (a.max.y, m.max.y),
-                    _ => (a.max.z, m.max.z),
+                let (orig_max, mirrored_max) = match other {
+                    Axis::X => (a.max.x, m.max.x),
+                    Axis::Y => (a.max.y, m.max.y),
+                    Axis::Z => (a.max.z, m.max.z),
                 };
-                assert_eq!(from_min.0, from_min.1);
-                assert_eq!(from_max.0, from_max.1);
+                assert_eq!(orig_min, mirrored_min);
+                assert_eq!(orig_max, mirrored_max);
             }
         }
-    }
-
-    #[test]
-    #[should_panic(expected = "axis_index")]
-    fn mirror_panics_on_bad_axis() {
-        // Panic is the assertion; the returned Aabb is unreachable.
-        let _ = Aabb::from_half_extents(1.0, 1.0, 1.0).mirror(3);
     }
 }

--- a/crates/aether-math/src/lib.rs
+++ b/crates/aether-math/src/lib.rs
@@ -38,7 +38,7 @@ mod quat;
 mod test_helpers;
 mod vec;
 
-pub use aabb::Aabb;
+pub use aabb::{Aabb, Axis};
 pub use mat::Mat4;
 pub use quat::Quat;
 pub use vec::{Vec2, Vec3, Vec4};

--- a/crates/aether-math/src/mat.rs
+++ b/crates/aether-math/src/mat.rs
@@ -398,12 +398,23 @@ mod tests {
     }
 
     #[test]
-    fn transpose_round_trips() {
-        let m = Mat4::from_rigid(
-            Quat::from_axis_angle(Vec3::X, 0.3),
-            Vec3::new(7.0, -3.0, 2.0),
-        );
-        assert_eq!(m.transpose().transpose(), m);
+    fn transpose_swaps_rows_and_columns() {
+        // Tripwire: column-major transpose layout — element [r][c] moves to
+        // [c][r]; a self-roundtrip has no independent oracle so this test
+        // checks against a known asymmetric expected value instead.
+        let m = Mat4::from_cols_array([
+            1.0, 2.0, 3.0, 4.0, //
+            5.0, 6.0, 7.0, 8.0, //
+            9.0, 10.0, 11.0, 12.0, //
+            13.0, 14.0, 15.0, 16.0, //
+        ]);
+        let expected = Mat4::from_cols_array([
+            1.0, 5.0, 9.0, 13.0, //
+            2.0, 6.0, 10.0, 14.0, //
+            3.0, 7.0, 11.0, 15.0, //
+            4.0, 8.0, 12.0, 16.0, //
+        ]);
+        assert_eq!(m.transpose(), expected);
     }
 
     #[test]

--- a/crates/aether-math/src/quat.rs
+++ b/crates/aether-math/src/quat.rs
@@ -20,6 +20,9 @@ impl Quat {
         Self { x, y, z, w }
     }
 
+    /// Quaternion for a rotation of `angle_rad` radians around `axis`.
+    /// A zero-length axis returns [`IDENTITY`](Self::IDENTITY) — the same
+    /// opinion as [`Quat::normalize`] for degenerate input.
     #[inline]
     #[must_use]
     pub fn from_axis_angle(axis: Vec3, angle_rad: f32) -> Self {
@@ -27,6 +30,9 @@ impl Quat {
         let s = libm::sinf(half);
         let c = libm::cosf(half);
         let axis = axis.normalize();
+        if axis.length_squared() == 0.0 {
+            return Self::IDENTITY;
+        }
         Self::new(axis.x * s, axis.y * s, axis.z * s, c)
     }
 
@@ -129,13 +135,9 @@ impl Mul<Vec3> for Quat {
 mod tests {
     use super::*;
     use crate::PI;
-    use crate::test_helpers::approx_eq_vec3 as approx_eq_vec3_helper;
+    use crate::test_helpers::approx_eq_vec3;
 
     const EPS: f32 = 1e-5;
-
-    fn approx_eq_vec3(a: Vec3, b: Vec3) -> bool {
-        approx_eq_vec3_helper(a, b, EPS)
-    }
 
     #[test]
     fn identity_leaves_vec_unchanged() {
@@ -146,19 +148,24 @@ mod tests {
     #[test]
     fn from_axis_angle_y_rotates_x_to_negz() {
         let q = Quat::from_axis_angle(Vec3::Y, PI * 0.5);
-        assert!(approx_eq_vec3(q * Vec3::X, Vec3::new(0.0, 0.0, -1.0)));
+        assert!(approx_eq_vec3(q * Vec3::X, Vec3::new(0.0, 0.0, -1.0), EPS));
     }
 
     #[test]
     fn from_axis_angle_x_rotates_y_to_z() {
         let q = Quat::from_axis_angle(Vec3::X, PI * 0.5);
-        assert!(approx_eq_vec3(q * Vec3::Y, Vec3::Z));
+        assert!(approx_eq_vec3(q * Vec3::Y, Vec3::Z, EPS));
     }
 
     #[test]
     fn from_axis_angle_z_rotates_x_to_y() {
         let q = Quat::from_axis_angle(Vec3::Z, PI * 0.5);
-        assert!(approx_eq_vec3(q * Vec3::X, Vec3::Y));
+        assert!(approx_eq_vec3(q * Vec3::X, Vec3::Y, EPS));
+    }
+
+    #[test]
+    fn from_axis_angle_zero_axis_returns_identity() {
+        assert_eq!(Quat::from_axis_angle(Vec3::ZERO, 1.0), Quat::IDENTITY);
     }
 
     #[test]
@@ -167,7 +174,7 @@ mod tests {
         let a = Quat::from_euler_yxz(yaw, 0.0, 0.0);
         let b = Quat::from_axis_angle(Vec3::Y, yaw);
         let v = Vec3::new(1.0, 2.0, 3.0);
-        assert!(approx_eq_vec3(a * v, b * v));
+        assert!(approx_eq_vec3(a * v, b * v, EPS));
     }
 
     #[test]
@@ -176,7 +183,7 @@ mod tests {
         let a = Quat::from_euler_yxz(0.0, pitch, 0.0);
         let b = Quat::from_axis_angle(Vec3::X, pitch);
         let v = Vec3::new(1.0, 2.0, 3.0);
-        assert!(approx_eq_vec3(a * v, b * v));
+        assert!(approx_eq_vec3(a * v, b * v, EPS));
     }
 
     #[test]
@@ -190,7 +197,7 @@ mod tests {
             * Quat::from_axis_angle(Vec3::X, pitch)
             * Quat::from_axis_angle(Vec3::Z, roll);
         let v = Vec3::new(1.0, 2.0, 3.0);
-        assert!(approx_eq_vec3(a * v, b * v));
+        assert!(approx_eq_vec3(a * v, b * v, EPS));
     }
 
     #[test]

--- a/crates/aether-math/src/test_helpers.rs
+++ b/crates/aether-math/src/test_helpers.rs
@@ -1,8 +1,4 @@
-//! Shared `f32` near-equality helpers for unit tests across
-//! `aether-math`. Pre-extraction, `mat::tests::approx_eq_vec4` and
-//! `quat::tests::approx_eq_vec3` (and a couple of inline `(a - b).abs()
-//! < EPS` ad-hoc checks elsewhere) repeated the same component-wise
-//! diff body. Moved here so the comparison logic appears in one place.
+//! Shared `f32` near-equality helpers for unit tests across `aether-math`.
 
 #![cfg(test)]
 
@@ -16,14 +12,10 @@ fn near(a: f32, b: f32, eps: f32) -> bool {
 
 /// `true` iff every `Vec4` component pair is within `eps`.
 pub fn approx_eq_vec4(a: Vec4, b: Vec4, eps: f32) -> bool {
-    [(a.x, b.x), (a.y, b.y), (a.z, b.z), (a.w, b.w)]
-        .iter()
-        .all(|&(p, q)| near(p, q, eps))
+    near(a.x, b.x, eps) && near(a.y, b.y, eps) && near(a.z, b.z, eps) && near(a.w, b.w, eps)
 }
 
 /// `Vec3` counterpart of [`approx_eq_vec4`].
 pub fn approx_eq_vec3(a: Vec3, b: Vec3, eps: f32) -> bool {
-    [(a.x, b.x), (a.y, b.y), (a.z, b.z)]
-        .iter()
-        .all(|&(p, q)| near(p, q, eps))
+    near(a.x, b.x, eps) && near(a.y, b.y, eps) && near(a.z, b.z, eps)
 }


### PR DESCRIPTION
Closes #2449.

## Summary

Acts on the confirmed economy and test-integrity findings the `review` workflow raised against `aether-math`. Cleanup, behavior-preserving except one small correctness guard:

- `Quat::from_axis_angle`: guard the degenerate zero-axis case (returns `IDENTITY` rather than a malformed non-unit quaternion), mirroring how `Quat::normalize` / `inverse` treat it.
- `Aabb::mirror`: replace the `axis_index: usize` parameter with a `pub enum Axis { X, Y, Z }`, removing the runtime assert and `# Panics` doc (the type now rejects invalid axes at the call site). `Axis` is re-exported from the crate root.
- `Aabb::corners`: drop the identity `Vec3` reconstructions.
- `mat.rs`: replace the symmetric `transpose_round_trips` test with an asymmetric-matrix oracle (a real tripwire).
- `test_helpers.rs`: trim project-history prose from the module doc; simplify the `approx_eq` helpers.
- `quat.rs` tests: drop the alias + wrapper, import the helper directly.

The `Vec3::parallel_sign` finding from the same review run was dropped as a false positive during scope (its threshold is already scale-invariant).

## Test plan

- `from_axis_angle` zero-axis guard covered by a new test.
- `Aabb::mirror` callers migrated to `Axis`; the now-unconstructable `mirror_panics_on_bad_axis` test removed.
- `transpose` rewritten to assert against a hand-computed transpose of an asymmetric matrix.
- Full suite green (1897/1897).

## Generated by

`/implement` — agent execution of scoped issue #2449.
