### PR TITLE
refactor(capabilities): enable unreachable_pub and tighten pub visibility

### DIFF
--- a/crates/aether-capabilities/src/anthropic/api.rs
+++ b/crates/aether-capabilities/src/anthropic/api.rs
@@ -107,7 +107,7 @@ fn build_request_body(req: &AnthropicRequest) -> Value {
 /// reads the model the provider served (falling back to the requested
 /// `fallback_model`) and the token usage. Factored out so a
 /// fixture-replay test locks the response shape (ADR-0050 §4).
-pub fn parse_messages_response(
+pub(super) fn parse_messages_response(
     json: &str,
     fallback_model: &str,
     wall_clock_millis: u32,

--- a/crates/aether-capabilities/src/anthropic/cli.rs
+++ b/crates/aether-capabilities/src/anthropic/cli.rs
@@ -20,13 +20,13 @@ use crate::shared::contentgen::adapter::{AdapterUsage, AnthropicRequest, Anthrop
 /// Sentinel returned when the `claude` binary isn't on PATH so the cap
 /// maps it onto `AnthropicError::CliNotFound`. Matched as a string
 /// prefix — the dispatch boundary is `Result<_, String>`.
-pub const CLI_NOT_FOUND: &str = "cli-not-found";
+pub(super) const CLI_NOT_FOUND: &str = "cli-not-found";
 
 /// Sentinel prefix returned when the `claude` subprocess overruns its
 /// deadline and is killed. Formatted as `timeout=<elapsed_millis>` so the
 /// cap maps it onto `AnthropicError::Timeout { elapsed_millis }` (the cap
 /// parses the trailing integer the way it parses `status=`).
-pub const TIMEOUT_SENTINEL: &str = "timeout=";
+pub(super) const TIMEOUT_SENTINEL: &str = "timeout=";
 
 /// How often the deadline loop polls `child.try_wait()`. Short enough
 /// that a hung call is killed promptly after expiry without busy-waiting.

--- a/crates/aether-capabilities/src/anthropic/error.rs
+++ b/crates/aether-capabilities/src/anthropic/error.rs
@@ -15,7 +15,7 @@ use crate::shared::contentgen::shared::{parse_status_prefix, snippet};
 /// onto [`AnthropicError::Unauthorized`] without the adapter depending
 /// on the kind enum. The `DisabledAnthropicAdapter` returns this for
 /// Messages requests.
-pub const UNAUTHORIZED_SENTINEL: &str = "unauthorized";
+pub(super) const UNAUTHORIZED_SENTINEL: &str = "unauthorized";
 
 /// Convert a free-form adapter error string into the typed
 /// [`AnthropicError`]. Recognises the structured sentinels the
@@ -23,7 +23,7 @@ pub const UNAUTHORIZED_SENTINEL: &str = "unauthorized";
 /// `UNAUTHORIZED_SENTINEL`, and the `status=<n>` prefix the Messages
 /// backend uses) and falls back to `AdapterError` for everything else.
 #[must_use]
-pub fn adapter_error_to_typed(raw: &str) -> AnthropicError {
+pub(super) fn adapter_error_to_typed(raw: &str) -> AnthropicError {
     if raw == CLI_NOT_FOUND {
         return AnthropicError::CliNotFound;
     }
@@ -57,7 +57,11 @@ pub fn adapter_error_to_typed(raw: &str) -> AnthropicError {
 /// - everything else non-2xx → `AdapterError` carrying the status +
 ///   body snippet
 #[must_use]
-pub fn status_to_error(status: u16, retry_after_millis: Option<u32>, body: &str) -> AnthropicError {
+pub(super) fn status_to_error(
+    status: u16,
+    retry_after_millis: Option<u32>,
+    body: &str,
+) -> AnthropicError {
     match status {
         401 | 403 => AnthropicError::Unauthorized,
         429 => AnthropicError::RateLimited { retry_after_millis },

--- a/crates/aether-capabilities/src/anthropic/runtime.rs
+++ b/crates/aether-capabilities/src/anthropic/runtime.rs
@@ -14,16 +14,16 @@ use super::{
 };
 use crate::shared::contentgen::adapter::{AdapterUsage, AnthropicRequest, AnthropicResponse};
 
-pub use crate::shared::contentgen::task_queue::TaskQueue;
-pub use std::sync::Arc;
+pub(super) use crate::shared::contentgen::task_queue::TaskQueue;
+pub(super) use std::sync::Arc;
 
 use aether_actor::OutboundReply;
 use aether_actor::runtime;
 use aether_kinds::Usage;
 
-pub use aether_actor::Manual;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
-pub use aether_substrate::chassis::error::BootError;
+pub(super) use aether_actor::Manual;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
+pub(super) use aether_substrate::chassis::error::BootError;
 
 /// Which send path a request rode. The generate handler threads it
 /// into the worker closure to pick the blocking call + result kind.
@@ -243,7 +243,7 @@ impl NativeActor for AnthropicCapability {
     }
 }
 
-pub fn build_adapter(config: &AnthropicConfig) -> Arc<dyn AnthropicAdapter> {
+pub(super) fn build_adapter(config: &AnthropicConfig) -> Arc<dyn AnthropicAdapter> {
     if config.disabled {
         tracing::info!(
             target: "aether_capabilities::anthropic",
@@ -273,7 +273,7 @@ pub fn build_adapter(config: &AnthropicConfig) -> Arc<dyn AnthropicAdapter> {
 /// Flatten the conversation into a single prompt string. v1 doesn't
 /// model multi-turn API content; it concatenates the user/assistant
 /// turns so the adapter sees one prompt.
-pub fn flatten_prompt(messages: &[Message]) -> String {
+pub(super) fn flatten_prompt(messages: &[Message]) -> String {
     messages
         .iter()
         .map(|m| {
@@ -296,7 +296,7 @@ fn to_usage(u: AdapterUsage) -> Usage {
     }
 }
 
-pub fn messages_reply(
+pub(super) fn messages_reply(
     request_id: u64,
     result: Result<AnthropicResponse, String>,
 ) -> MessagesSendResult {
@@ -314,7 +314,10 @@ pub fn messages_reply(
     }
 }
 
-pub fn cli_reply(request_id: u64, result: Result<AnthropicResponse, String>) -> CliSendResult {
+pub(super) fn cli_reply(
+    request_id: u64,
+    result: Result<AnthropicResponse, String>,
+) -> CliSendResult {
     match result {
         Ok(resp) => CliSendResult::Ok {
             request_id,

--- a/crates/aether-capabilities/src/audio/runtime/decode.rs
+++ b/crates/aether-capabilities/src/audio/runtime/decode.rs
@@ -26,7 +26,9 @@ use std::io::Cursor;
 /// common agent failure, so a bad file comes back loud rather than
 /// logged-and-dropped.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DecodeError {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) enum DecodeError {
     /// `hound` could not parse the container or header — a truncated
     /// file, a non-WAV byte stream, or a corrupt chunk table. Carries
     /// `hound`'s own message.
@@ -62,7 +64,7 @@ impl Error for DecodeError {}
 /// file's rate to `target_rate`. Pure: no I/O, no allocation beyond the
 /// returned buffer's working set. Errors are loud — an unsupported format
 /// or a malformed header surfaces as a [`DecodeError`] the cap relays.
-pub fn decode_wav_to_mono(bytes: &[u8], target_rate: u32) -> Result<Vec<f32>, DecodeError> {
+pub(super) fn decode_wav_to_mono(bytes: &[u8], target_rate: u32) -> Result<Vec<f32>, DecodeError> {
     let cursor = Cursor::new(bytes);
     let mut reader =
         hound::WavReader::new(cursor).map_err(|e| DecodeError::Malformed(e.to_string()))?;

--- a/crates/aether-capabilities/src/audio/runtime/event.rs
+++ b/crates/aether-capabilities/src/audio/runtime/event.rs
@@ -16,7 +16,7 @@ use super::sample::SampleBank;
 /// 100-note-per-second stream; overflow is warn-dropped, which the
 /// ADR-0039 timing-quantization section already documents as a v1
 /// limitation (tight-burst percussion may drop notes under load).
-pub const EVENT_QUEUE_CAPACITY: usize = 1024;
+pub(super) const EVENT_QUEUE_CAPACITY: usize = 1024;
 
 /// Event a handler pushes into the audio callback's queue. The
 /// `sender_mailbox` is baked in here (not re-derived on the callback
@@ -26,7 +26,9 @@ pub const EVENT_QUEUE_CAPACITY: usize = 1024;
 /// (the decoded asset) and owned namespace / path strings (ADR-0103
 /// §3). The queue never required `Copy`.
 #[derive(Clone, Debug)]
-pub enum AudioEvent {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) enum AudioEvent {
     NoteOn {
         sender_mailbox: MailboxId,
         pitch: u8,
@@ -90,17 +92,19 @@ pub enum AudioEvent {
 /// building the pipeline) and pushes events on every inbound `NoteOn`
 /// / `NoteOff` / `SetMasterGain`.
 #[derive(Clone)]
-pub struct AudioEventSender {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct AudioEventSender {
     pub queue: Arc<ArrayQueue<AudioEvent>>,
 }
 
 impl AudioEventSender {
-    pub fn push(&self, event: AudioEvent) -> Result<(), AudioEvent> {
+    pub(crate) fn push(&self, event: AudioEvent) -> Result<(), AudioEvent> {
         self.queue.push(event)
     }
 }
 
-pub fn new_event_channel() -> (AudioEventSender, Arc<ArrayQueue<AudioEvent>>) {
+pub(super) fn new_event_channel() -> (AudioEventSender, Arc<ArrayQueue<AudioEvent>>) {
     let queue = Arc::new(ArrayQueue::new(EVENT_QUEUE_CAPACITY));
     (
         AudioEventSender {

--- a/crates/aether-capabilities/src/audio/runtime/instrument.rs
+++ b/crates/aether-capabilities/src/audio/runtime/instrument.rs
@@ -15,7 +15,7 @@
 /// base frequency under the noise (`0.0` is pure noise); it is the one
 /// patch field that turns a hat patch into a snare.
 #[derive(Copy, Clone, Debug)]
-pub enum Wave {
+pub(super) enum Wave {
     Sine,
     Square,
     Triangle,
@@ -27,7 +27,7 @@ pub enum Wave {
 /// are held in seconds; the voice converts to per-sample step on
 /// instantiation so the hot loop is add-only.
 #[derive(Copy, Clone, Debug)]
-pub struct Adsr {
+pub(super) struct Adsr {
     pub attack_s: f32,
     pub decay_s: f32,
     pub sustain: f32,
@@ -41,7 +41,7 @@ pub struct Adsr {
 /// constant. The decay is precomputed as a per-sample multiplier at
 /// `note_on`, so the hot loop pays one extra multiply.
 #[derive(Copy, Clone, Debug)]
-pub struct PitchSweep {
+pub(super) struct PitchSweep {
     /// Phase-step multiplier at the note's onset. `4.0` starts two
     /// octaves above the base frequency; `1.0` is no sweep.
     pub start_ratio: f32,
@@ -54,18 +54,18 @@ pub struct PitchSweep {
 /// voice stays `Copy` and stack-friendly in the pool; the hot loop is
 /// one `sin`, one multiply-accumulate, and one decay multiply per
 /// partial.
-pub const PARTIAL_COUNT: usize = 8;
+pub(super) const PARTIAL_COUNT: usize = 8;
 
 /// Reference pitch (MIDI C4) for partial-bank decay scaling. A note's
 /// per-partial decay rates scale by `f0 / REFERENCE_FREQ`, so higher
 /// notes ring shorter and lower notes longer.
-pub const REFERENCE_FREQ: f32 = 261.625_57;
+pub(super) const REFERENCE_FREQ: f32 = 261.625_57;
 
 /// Relative amplitude below which a sustaining (un-released)
 /// partial-bank voice frees itself. Piano partials decay
 /// exponentially and never reach exactly zero, so the voice retires
 /// once its summed partial energy crosses this floor.
-pub const PARTIAL_SILENCE_FLOOR: f32 = 1.0e-4;
+pub(super) const PARTIAL_SILENCE_FLOOR: f32 = 1.0e-4;
 
 /// A struck/sustained partial-bank voice patch. Partial `n` is tuned
 /// to `n * f0 * sqrt(1 + inharmonicity * n^2)` plus a small
@@ -74,7 +74,7 @@ pub const PARTIAL_SILENCE_FLOOR: f32 = 1.0e-4;
 /// partial decays at `decay_base * (1 + i * decay_spread)` scaled by
 /// pitch. A global attack/release ramp wraps the bank.
 #[derive(Copy, Clone, Debug)]
-pub struct PartialBankDef {
+pub(super) struct PartialBankDef {
     /// Stiffness coefficient `B`: stretches overtone `n` to
     /// `n * f0 * sqrt(1 + B * n^2)`. `0.0` is perfectly harmonic.
     pub inharmonicity: f32,
@@ -105,7 +105,7 @@ pub struct PartialBankDef {
 /// `Oscillator`; the partial-bank patches add struck-string and
 /// sustained timbres without a wire change.
 #[derive(Copy, Clone, Debug)]
-pub enum VoiceDef {
+pub(super) enum VoiceDef {
     Oscillator { wave: Wave, adsr: Adsr },
     PartialBank(PartialBankDef),
 }
@@ -114,7 +114,7 @@ pub enum VoiceDef {
 /// into the built-in registry; the registry hands the voice a copy of
 /// this struct at `note_on` time so each voice is self-contained.
 #[derive(Copy, Clone, Debug)]
-pub struct InstrumentDef {
+pub(super) struct InstrumentDef {
     pub name: &'static str,
     pub voice: VoiceDef,
     pub base_amp: f32,
@@ -128,7 +128,7 @@ pub struct InstrumentDef {
 /// Reordering these is a breaking change on the wire — adds go at
 /// the end. Future follow-up: mailed patch definitions fill in past
 /// the built-ins (ADR-0039 "runtime-defined patches" parked item).
-pub const BUILTINS: &[InstrumentDef] = &[
+pub(super) const BUILTINS: &[InstrumentDef] = &[
     InstrumentDef {
         name: "sine_lead",
         voice: VoiceDef::Oscillator {
@@ -316,25 +316,27 @@ pub const BUILTINS: &[InstrumentDef] = &[
     },
 ];
 
-pub fn instrument_by_id(id: u8) -> Option<&'static InstrumentDef> {
+pub(super) fn instrument_by_id(id: u8) -> Option<&'static InstrumentDef> {
     BUILTINS.get(id as usize)
 }
 
 /// Number of built-in instruments. Used by the boot log so MCP
 /// agents can cross-reference.
-pub fn builtin_count() -> usize {
+pub(super) fn builtin_count() -> usize {
     BUILTINS.len()
 }
 
 /// Names of the built-in instruments, in id order.
-pub fn builtin_names() -> Vec<&'static str> {
+pub(super) fn builtin_names() -> Vec<&'static str> {
     BUILTINS.iter().map(|d| d.name).collect()
 }
 
 /// The first instrument id available to a loaded bank — one past the
 /// last compiled-in built-in. The cap's `next_instrument_id` starts
 /// here, the synth's bank table begins at the same offset.
-pub fn builtin_id_ceiling() -> u8 {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) fn builtin_id_ceiling() -> u8 {
     // `BUILTINS` is a small fixed table (11 today); the length fits a
     // `u8` with room to spare, and a load count that overflowed `u8`
     // would be absurd.

--- a/crates/aether-capabilities/src/audio/runtime/mod.rs
+++ b/crates/aether-capabilities/src/audio/runtime/mod.rs
@@ -63,19 +63,19 @@ use super::kinds::{
 // The substrate-typed + native-only surface the parent's `#[actor] impl`
 // reaches through `use runtime::*`. Gated once here so a marker-only build
 // never names any of it.
-pub use std::collections::HashMap;
-pub use std::sync::Arc;
+pub(super) use std::collections::HashMap;
+pub(super) use std::sync::Arc;
 
-pub use aether_actor::{Manual, OutboundReply};
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
-pub use aether_substrate::chassis::error::BootError;
+pub(super) use aether_actor::{Manual, OutboundReply};
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
+pub(super) use aether_substrate::chassis::error::BootError;
 
-pub use self::event::AudioEvent;
-pub use self::instrument::builtin_id_ceiling;
-pub use self::sample::{BankAssemblyContext, BankAssemblyOutput, PendingInstrument};
-pub use self::schedule::{SCHEDULE_MAX_EVENTS, SCHEDULE_MAX_MILLIS};
-pub use self::track::{DecodeOutput, PendingTrack, TrackDecodeContext};
-pub use crate::fs::{FsCapability, Read, ReadResult};
+pub(super) use self::event::AudioEvent;
+pub(super) use self::instrument::builtin_id_ceiling;
+pub(super) use self::sample::{BankAssemblyContext, BankAssemblyOutput, PendingInstrument};
+pub(super) use self::schedule::{SCHEDULE_MAX_EVENTS, SCHEDULE_MAX_MILLIS};
+pub(super) use self::track::{DecodeOutput, PendingTrack, TrackDecodeContext};
+pub(super) use crate::fs::{FsCapability, Read, ReadResult};
 
 /// Extract the sender's mailbox id for voice-table keying. Component
 /// senders come through as `EngineMailbox { mailbox_id }`; Claude

--- a/crates/aether-capabilities/src/audio/runtime/sample.rs
+++ b/crates/aether-capabilities/src/audio/runtime/sample.rs
@@ -14,16 +14,16 @@ use super::voice::BankStage;
 /// Attack ramp (seconds) wrapping a sample voice — a short swell so a
 /// re-pitched recording doesn't click on at full level (ADR-0103 §6,
 /// the partial bank's ramp shape).
-pub const SAMPLE_ATTACK_SECS: f32 = 0.003;
+pub(super) const SAMPLE_ATTACK_SECS: f32 = 0.003;
 
 /// Release ramp (seconds) on `note_off` for a sample voice — the
 /// damper that ends a held note faster than the sample's natural decay.
-pub const SAMPLE_RELEASE_SECS: f32 = 0.08;
+pub(super) const SAMPLE_RELEASE_SECS: f32 = 0.08;
 
 /// Base amplitude of a sample voice before velocity scaling. Sampled
 /// recordings already carry their own level; this trims headroom so a
 /// dense chord doesn't clip past the soft-clip.
-pub const SAMPLE_BASE_AMP: f32 = 0.6;
+pub(super) const SAMPLE_BASE_AMP: f32 = 0.6;
 
 /// A region's sustain loop in device-rate coordinates (ADR-0103 §6).
 /// The SFZ frame offsets are scaled at bank assembly by the load-time
@@ -32,7 +32,9 @@ pub const SAMPLE_BASE_AMP: f32 = 0.6;
 /// and `end` index the region's device-rate PCM; the voice cycles the
 /// half-open `[start, end)` interval while it sounds.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct SampleLoop {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct SampleLoop {
     pub start: f32,
     pub end: f32,
 }
@@ -45,7 +47,9 @@ pub struct SampleLoop {
 /// The PCM is `Arc`'d so every region naming the same sample shares one
 /// buffer and a spawned voice holds a cheap reference, not a copy.
 #[derive(Clone, Debug)]
-pub struct SampleRegion {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct SampleRegion {
     pub lokey: u8,
     pub hikey: u8,
     pub lovel: u8,
@@ -62,7 +66,9 @@ pub struct SampleRegion {
 /// `.sfz` filename, and the total decoded PCM the bank holds resident
 /// (reported in the load reply — there is no unload in v1).
 #[derive(Debug)]
-pub struct SampleBank {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct SampleBank {
     pub name: String,
     pub regions: Vec<SampleRegion>,
     pub resident_bytes: usize,
@@ -72,7 +78,7 @@ impl SampleBank {
     /// The first region whose key and velocity ranges both contain
     /// `(pitch, velocity)`, or `None` when the note falls in a gap the
     /// bank doesn't cover (the `note_on` then drops).
-    pub fn select(&self, pitch: u8, velocity: u8) -> Option<&SampleRegion> {
+    pub(crate) fn select(&self, pitch: u8, velocity: u8) -> Option<&SampleRegion> {
         self.regions.iter().find(|r| {
             (r.lokey..=r.hikey).contains(&pitch) && (r.lovel..=r.hivel).contains(&velocity)
         })
@@ -89,7 +95,7 @@ impl SampleBank {
 /// `note_off` release ramp completes (the loop keeps cycling beneath
 /// the fade).
 #[derive(Clone, Debug)]
-pub struct SampleVoice {
+pub(super) struct SampleVoice {
     /// Device-rate mono PCM of the selected region, shared with the
     /// bank.
     pub pcm: Arc<[f32]>,
@@ -117,7 +123,7 @@ pub struct SampleVoice {
 }
 
 impl SampleVoice {
-    pub fn new(pitch: u8, velocity: u8, region: &SampleRegion) -> Self {
+    pub(super) fn new(pitch: u8, velocity: u8, region: &SampleRegion) -> Self {
         let semitones = f32::from(pitch) - f32::from(region.pitch_keycenter);
         let rate = (semitones / 12.0).exp2();
         let v = f32::from(velocity) / 127.0;
@@ -139,18 +145,18 @@ impl SampleVoice {
         }
     }
 
-    pub fn note_off(&mut self) {
+    pub(super) fn note_off(&mut self) {
         self.stage.begin_release(self.attack_s);
     }
 
-    pub fn done(&self) -> bool {
+    pub(super) fn done(&self) -> bool {
         self.finished || matches!(self.stage, BankStage::Done)
     }
 
     /// Advance the attack/release ramp one sample, returning its current
     /// level — the shared bank ramp over the sample voice's own
     /// attack/release times.
-    pub fn advance_ramp(&mut self, dt: f32) -> f32 {
+    pub(super) fn advance_ramp(&mut self, dt: f32) -> f32 {
         self.stage.advance(dt, self.attack_s, self.release_s)
     }
 
@@ -158,7 +164,7 @@ impl SampleVoice {
     // sane sample, so the index-to-float and float-to-index casts in the
     // looped / unlooped readers are exact and non-negative on the hot
     // path.
-    pub fn next_sample(&mut self, dt: f32) -> f32 {
+    pub(super) fn next_sample(&mut self, dt: f32) -> f32 {
         let ramp = self.advance_ramp(dt);
         if self.finished {
             return 0.0;
@@ -181,7 +187,7 @@ impl SampleVoice {
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss
     )]
-    pub fn next_unlooped(&mut self, len: usize, ramp: f32) -> f32 {
+    pub(super) fn next_unlooped(&mut self, len: usize, ramp: f32) -> f32 {
         let i = self.pos.floor() as usize;
         if i >= len {
             self.finished = true;
@@ -210,7 +216,7 @@ impl SampleVoice {
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss
     )]
-    pub fn next_looped(&mut self, lp: SampleLoop, len: usize, ramp: f32) -> f32 {
+    pub(super) fn next_looped(&mut self, lp: SampleLoop, len: usize, ramp: f32) -> f32 {
         // `pos < loop_end <= len` holds going in, so `i` is in range.
         let i = (self.pos.floor() as usize).min(len - 1);
         let a = self.pcm[i];
@@ -246,7 +252,9 @@ impl SampleVoice {
 /// `(namespace, path)` of the `.sfz`. Only the original requester's
 /// reply route lives here — the namespace / path come back on the
 /// `ReadResult`, and the bank's name is derived from the `.sfz` path.
-pub struct PendingInstrument {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct PendingInstrument {
     pub source: Source,
 }
 
@@ -254,7 +262,9 @@ pub struct PendingInstrument {
 /// in the `.sfz` (resolved against `default_path`), the fs path it is
 /// read from (joined with the `.sfz`'s own directory), and its bytes
 /// once the `aether.fs.read` lands.
-pub struct SampleSlot {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct SampleSlot {
     pub sample_rel: String,
     pub fs_path: String,
     pub bytes: Option<Vec<u8>>,
@@ -265,7 +275,9 @@ pub struct SampleSlot {
 /// the last reply lands (ADR-0103 §2). Keyed in
 /// `AudioCapabilityState::assemblies` by a minted id; the per-sample reads
 /// correlate back to it through `AudioCapabilityState::pending_samples`.
-pub struct BankAssembly {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct BankAssembly {
     /// The original `load_instrument` requester — the
     /// `LoadInstrumentResult` reply routes here.
     pub source: Source,
@@ -289,7 +301,9 @@ pub struct BankAssembly {
 /// `#[handler(task)]` arm can build the `Err` reply (`Ok` carries the
 /// assembled bank's own name / id / bytes). Mirrors
 /// [`TrackDecodeContext`] for the load path.
-pub struct BankAssemblyContext {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct BankAssemblyContext {
     pub namespace: String,
     pub path: String,
 }
@@ -297,13 +311,15 @@ pub struct BankAssemblyContext {
 /// Output of the bank-assembly dispatch worker — the assembled,
 /// device-rate bank behind an `Arc`, or a human-readable decode failure
 /// to relay as `LoadInstrumentResult::Err`.
-pub type BankAssemblyOutput = Result<Arc<SampleBank>, String>;
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) type BankAssemblyOutput = Result<Arc<SampleBank>, String>;
 
 /// Decode every unique sample to device-rate mono PCM and assemble the
 /// bank (ADR-0103 §6). Pure + `Send` so it runs on the blocking-dispatch
 /// worker, off the realtime path. A failed decode aborts with a
 /// human-readable reason the cap relays as `LoadInstrumentResult::Err`.
-pub fn assemble_bank(
+pub(super) fn assemble_bank(
     name: String,
     regions: &[SfzRegion],
     sample_bytes: &[(String, Vec<u8>)],
@@ -355,7 +371,7 @@ pub fn assemble_bank(
 /// load-time resample ratio; `decode_wav_to_mono` consumes the same
 /// header but only returns the resampled PCM. Parses the header chunk
 /// only — the sample data is not read.
-pub fn wav_source_rate(bytes: &[u8]) -> Result<u32, String> {
+pub(super) fn wav_source_rate(bytes: &[u8]) -> Result<u32, String> {
     let reader = hound::WavReader::new(Cursor::new(bytes)).map_err(|e| e.to_string())?;
     let rate = reader.spec().sample_rate;
     if rate == 0 {
@@ -371,7 +387,7 @@ pub fn wav_source_rate(bytes: &[u8]) -> Result<u32, String> {
 /// `None` when the resampled region is too short to loop or the bounds
 /// collapse after clamping, degrading the region to unlooped.
 #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
-pub fn scale_loop(
+pub(super) fn scale_loop(
     lp: SfzLoop,
     source_rate: u32,
     target_rate: u32,
@@ -395,7 +411,7 @@ pub fn scale_loop(
 /// The directory portion of an fs path (everything before the last
 /// `/`), or `""` when the path has no directory. A bank's samples are
 /// addressed relative to the `.sfz`'s own directory (ADR-0103 §5).
-pub fn sfz_dir(path: &str) -> &str {
+pub(super) fn sfz_dir(path: &str) -> &str {
     match path.rsplit_once('/') {
         Some((dir, _)) => dir,
         None => "",
@@ -404,7 +420,7 @@ pub fn sfz_dir(path: &str) -> &str {
 
 /// Join a sample path onto the `.sfz`'s directory. An empty directory
 /// leaves the sample as-is.
-pub fn join_fs(dir: &str, rel: &str) -> String {
+pub(super) fn join_fs(dir: &str, rel: &str) -> String {
     if dir.is_empty() {
         rel.to_owned()
     } else {
@@ -415,7 +431,7 @@ pub fn join_fs(dir: &str, rel: &str) -> String {
 /// Derive a bank name from the `.sfz` filename stem (the last path
 /// segment without its extension). Falls back to `"instrument"` for a
 /// pathological empty stem.
-pub fn bank_name_from_path(path: &str) -> String {
+pub(super) fn bank_name_from_path(path: &str) -> String {
     let file = path.rsplit('/').next().unwrap_or(path);
     let stem = file.rsplit_once('.').map_or(file, |(stem, _)| stem);
     if stem.is_empty() {

--- a/crates/aether-capabilities/src/audio/runtime/schedule.rs
+++ b/crates/aether-capabilities/src/audio/runtime/schedule.rs
@@ -13,13 +13,17 @@ use super::super::kinds::ScheduledNote;
 /// this bounds the synth's pending heap rather than the queue; 8192
 /// events is several minutes of a dense melody (note-on + note-off per
 /// note). An over-cap batch rejects atomically in the handler reply.
-pub const SCHEDULE_MAX_EVENTS: usize = 8192;
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) const SCHEDULE_MAX_EVENTS: usize = 8192;
 
 /// Furthest future a scheduled event may be parked, in milliseconds
 /// (ADR-0104). The horizon bounds how much future a sender can hold in
 /// the pending heap; ten minutes is generous for a tune dispatched in
 /// one call. An over-horizon `at_millis` rejects the whole batch.
-pub const SCHEDULE_MAX_MILLIS: u32 = 600_000;
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) const SCHEDULE_MAX_MILLIS: u32 = 600_000;
 
 /// One pending scheduled note in the synth's min-heap (ADR-0104).
 /// Ordered by `(due_frame, seq)` only — `seq` is a monotonic stamp in
@@ -27,7 +31,7 @@ pub const SCHEDULE_MAX_MILLIS: u32 = 600_000;
 /// the order they were sent. The note payload takes no part in
 /// ordering, which is why the ordering impls are hand-written rather
 /// than derived (`ScheduledNote` is not `Ord`).
-pub struct ScheduledEntry {
+pub(super) struct ScheduledEntry {
     pub due_frame: u64,
     pub seq: u64,
     pub sender_mailbox: MailboxId,
@@ -57,7 +61,7 @@ impl Ord for ScheduledEntry {
 /// Convert a play-at offset in milliseconds to a frame count at the
 /// device rate (ADR-0104). Added to the frame clock at receipt to land
 /// the absolute due frame.
-pub fn millis_to_frames(at_millis: u32, sample_rate: f32) -> u64 {
+pub(super) fn millis_to_frames(at_millis: u32, sample_rate: f32) -> u64 {
     // `at_millis` is bounded by `SCHEDULE_MAX_MILLIS` and the device
     // rate is a small positive integer, so the product is well within
     // u64 and non-negative.

--- a/crates/aether-capabilities/src/audio/runtime/sfz.rs
+++ b/crates/aether-capabilities/src/audio/runtime/sfz.rs
@@ -37,7 +37,9 @@ use std::fmt;
 /// cycling through the release ramp rather than playing a post-loop tail),
 /// but the parser carries the distinction the file declared.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LoopMode {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) enum LoopMode {
     /// `loop_continuous`: cycle the loop region for as long as the voice
     /// sounds, including under the release ramp.
     Continuous,
@@ -53,7 +55,9 @@ pub enum LoopMode {
 /// fractional device-rate positions (ADR-0103 §6). A loop is only emitted
 /// when `start < end`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct SfzLoop {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct SfzLoop {
     pub start: u32,
     pub end: u32,
     pub mode: LoopMode,
@@ -67,7 +71,9 @@ pub struct SfzLoop {
 /// joins it with the `.sfz` file's own directory to address the WAV
 /// through `aether.fs`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SfzRegion {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct SfzRegion {
     pub sample: String,
     pub lokey: u8,
     pub hikey: u8,
@@ -82,7 +88,7 @@ pub struct SfzRegion {
 /// A parsed bank: the resolved region list. The referenced sample paths
 /// (deduplicated) are what the cap fans out `aether.fs.read`s for.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BankSpec {
+pub(super) struct BankSpec {
     pub regions: Vec<SfzRegion>,
 }
 
@@ -91,7 +97,7 @@ impl BankSpec {
     /// order. The cap fetches each exactly once and shares the decoded
     /// PCM across every region that names it.
     #[must_use]
-    pub fn sample_paths(&self) -> Vec<String> {
+    pub(super) fn sample_paths(&self) -> Vec<String> {
         let mut seen = Vec::new();
         for region in &self.regions {
             if !seen.iter().any(|s: &String| s == &region.sample) {
@@ -107,7 +113,7 @@ impl BankSpec {
 /// back loud rather than logged-and-dropped, matching the rest of the
 /// load path.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SfzError {
+pub(super) enum SfzError {
     /// A header tag opened with `<` but never closed with `>` on the same
     /// line — a truncated or hand-corrupted file. Carries the offending
     /// fragment.
@@ -232,7 +238,7 @@ impl OpcodeSet {
 /// inherited by following regions; `default_path` from `<control>`
 /// prefixes every region's `sample`. Opcodes outside the subset (loop
 /// points, envelopes, …) warn and are ignored so real sample sets load.
-pub fn parse_sfz(text: &str) -> Result<BankSpec, SfzError> {
+pub(super) fn parse_sfz(text: &str) -> Result<BankSpec, SfzError> {
     let mut default_path = String::new();
     let mut group = OpcodeSet::defaults();
     let mut section = Section::None;

--- a/crates/aether-capabilities/src/audio/runtime/synth.rs
+++ b/crates/aether-capabilities/src/audio/runtime/synth.rs
@@ -22,7 +22,7 @@ use super::voice::{MAX_VOICES, Voice, VoiceKernel, build_builtin_kernel};
 
 /// Whole-process synth state. Lives on the cpal callback thread;
 /// the cap communicates via the event queue.
-pub struct Synth {
+pub(super) struct Synth {
     pub events: Arc<ArrayQueue<AudioEvent>>,
     pub voices: Vec<Voice>,
     /// Track playback lane (ADR-0103 §3) — separate from `voices` so a
@@ -53,7 +53,7 @@ pub struct Synth {
 }
 
 impl Synth {
-    pub fn new(events: Arc<ArrayQueue<AudioEvent>>, sample_rate: f32) -> Self {
+    pub(super) fn new(events: Arc<ArrayQueue<AudioEvent>>, sample_rate: f32) -> Self {
         Self {
             events,
             voices: Vec::with_capacity(MAX_VOICES),
@@ -72,14 +72,14 @@ impl Synth {
     /// cheap `Arc` clone (or `None` for an id still inside the built-in
     /// range or past the loaded banks). The `note_on` path falls back
     /// to this when `instrument_by_id` misses.
-    pub fn bank_for(&self, instrument_id: u8) -> Option<Arc<SampleBank>> {
+    pub(super) fn bank_for(&self, instrument_id: u8) -> Option<Arc<SampleBank>> {
         let index = (instrument_id as usize).checked_sub(BUILTINS.len())?;
         self.banks.get(index).map(Arc::clone)
     }
 
     /// Number of output samples in the `stop_track` fade-out at this
     /// device rate.
-    pub fn fade_samples(&self) -> u32 {
+    pub(super) fn fade_samples(&self) -> u32 {
         // Fade window is a few milliseconds at audio rates — well
         // within u32 and non-negative.
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
@@ -94,7 +94,7 @@ impl Synth {
     /// A miss on both kernel sources (unknown id, or a bank with no
     /// region covering the note) warn-drops without touching the pool
     /// (ADR-0103 §6).
-    pub fn trigger_note_on(
+    pub(super) fn trigger_note_on(
         &mut self,
         sender_mailbox: MailboxId,
         pitch: u8,
@@ -161,7 +161,12 @@ impl Synth {
     /// pitch)`, if one is sounding. A miss is a silent no-op (a late or
     /// unmatched note-off), matching the immediate `note_off` path.
     /// Shared by the queue-drained note-off and the scheduled note-off.
-    pub fn trigger_note_off(&mut self, sender_mailbox: MailboxId, pitch: u8, instrument_id: u8) {
+    pub(super) fn trigger_note_off(
+        &mut self,
+        sender_mailbox: MailboxId,
+        pitch: u8,
+        instrument_id: u8,
+    ) {
         if let Some(v) = self.voices.iter_mut().find(|v| {
             v.sender_mailbox == sender_mailbox
                 && v.instrument_id == instrument_id
@@ -173,7 +178,7 @@ impl Synth {
 
     /// Fire one scheduled note event through the same paths the
     /// immediate mail would take (ADR-0104).
-    pub fn fire_scheduled(&mut self, sender_mailbox: MailboxId, note: &ScheduledNote) {
+    pub(super) fn fire_scheduled(&mut self, sender_mailbox: MailboxId, note: &ScheduledNote) {
         match *note {
             ScheduledNote::On {
                 pitch,
@@ -187,7 +192,7 @@ impl Synth {
         }
     }
 
-    pub fn drain_events(&mut self) {
+    pub(super) fn drain_events(&mut self) {
         while let Some(ev) = self.events.pop() {
             match ev {
                 AudioEvent::NoteOn {
@@ -268,7 +273,7 @@ impl Synth {
     /// `(sender_mailbox, lane, namespace, path)` key drops the existing
     /// track first, so a key never stacks.
     #[allow(clippy::too_many_arguments)]
-    pub fn start_track(
+    pub(super) fn start_track(
         &mut self,
         sender_mailbox: MailboxId,
         lane: Option<String>,
@@ -297,7 +302,7 @@ impl Synth {
     }
 
     /// Arm the fade-out on the track at this key, if one is playing.
-    pub fn stop_track(
+    pub(super) fn stop_track(
         &mut self,
         sender_mailbox: MailboxId,
         lane: Option<&String>,
@@ -314,7 +319,7 @@ impl Synth {
         }
     }
 
-    pub fn fill(&mut self, buffer: &mut [f32], channels: usize) {
+    pub(super) fn fill(&mut self, buffer: &mut [f32], channels: usize) {
         self.drain_events();
         let dt = 1.0 / self.sample_rate;
         let frames = buffer.len() / channels.max(1);
@@ -373,32 +378,32 @@ impl Synth {
     }
 
     #[cfg(test)]
-    pub fn voice_count(&self) -> usize {
+    pub(super) fn voice_count(&self) -> usize {
         self.voices.len()
     }
 
     #[cfg(test)]
-    pub fn has_voice_with_pitch(&self, pitch: u8) -> bool {
+    pub(super) fn has_voice_with_pitch(&self, pitch: u8) -> bool {
         self.voices.iter().any(|v| v.pitch == pitch)
     }
 
     #[cfg(test)]
-    pub fn master_gain_value(&self) -> f32 {
+    pub(super) fn master_gain_value(&self) -> f32 {
         self.master_gain
     }
 
     #[cfg(test)]
-    pub fn track_count(&self) -> usize {
+    pub(super) fn track_count(&self) -> usize {
         self.tracks.len()
     }
 
     #[cfg(test)]
-    pub fn bank_count(&self) -> usize {
+    pub(super) fn bank_count(&self) -> usize {
         self.banks.len()
     }
 
     #[cfg(test)]
-    pub fn scheduled_count(&self) -> usize {
+    pub(super) fn scheduled_count(&self) -> usize {
         self.scheduled.len()
     }
 }
@@ -408,7 +413,7 @@ impl Synth {
 /// so the stream is constructed on, owned by, and dropped from the
 /// same thread. Dropping the pipeline silences every voice and tears
 /// down the cpal stream.
-pub struct AudioPipeline {
+pub(super) struct AudioPipeline {
     pub sender: AudioEventSender,
     /// The device output rate the synth runs at. The cap reads it back
     /// (via the init channel) as the resample target for track decode
@@ -418,7 +423,9 @@ pub struct AudioPipeline {
 }
 
 #[derive(Debug)]
-pub enum AudioBuildError {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) enum AudioBuildError {
     NoDevice,
     RateUnsupported(u32),
     ConfigQuery(String),
@@ -438,7 +445,7 @@ impl fmt::Display for AudioBuildError {
     }
 }
 
-pub fn try_build_pipeline(
+pub(super) fn try_build_pipeline(
     requested_sample_rate: Option<u32>,
 ) -> Result<AudioPipeline, AudioBuildError> {
     let host = cpal::default_host();
@@ -501,7 +508,7 @@ pub fn try_build_pipeline(
     })
 }
 
-pub fn find_config_for_rate(device: &cpal::Device, rate: u32) -> Option<cpal::StreamConfig> {
+pub(super) fn find_config_for_rate(device: &cpal::Device, rate: u32) -> Option<cpal::StreamConfig> {
     let configs = device.supported_output_configs().ok()?;
     for cfg in configs {
         let min = cfg.min_sample_rate();

--- a/crates/aether-capabilities/src/audio/runtime/track.rs
+++ b/crates/aether-capabilities/src/audio/runtime/track.rs
@@ -11,14 +11,14 @@ use super::decode::DecodeError;
 /// Linear fade-out duration (seconds) applied when a track is stopped,
 /// so `stop_track` releases through a short ramp instead of truncating
 /// to a click (ADR-0103 §3).
-pub const TRACK_FADE_SECS: f32 = 0.005;
+pub(super) const TRACK_FADE_SECS: f32 = 0.005;
 
 /// Fade state of a [`TrackVoice`]. A track plays at full level until
 /// `stop_track` arms a short linear fade-out; `remaining` counts down
 /// per output sample and the track retires when it hits zero (ADR-0103
 /// §3).
 #[derive(Clone, Debug)]
-pub enum TrackFade {
+pub(super) enum TrackFade {
     Playing,
     FadingOut { remaining: u32, total: u32 },
 }
@@ -30,7 +30,7 @@ pub enum TrackFade {
 /// be evicted by a note flurry. Keyed by `(sender_mailbox, lane,
 /// namespace, path)`, mirroring the voice key plus the caller-supplied
 /// `lane` that disambiguates senders sharing a source mailbox.
-pub struct TrackVoice {
+pub(super) struct TrackVoice {
     pub sender_mailbox: MailboxId,
     pub lane: Option<String>,
     pub namespace: String,
@@ -44,7 +44,7 @@ pub struct TrackVoice {
 }
 
 impl TrackVoice {
-    pub fn new(
+    pub(super) fn new(
         sender_mailbox: MailboxId,
         lane: Option<String>,
         namespace: String,
@@ -69,7 +69,7 @@ impl TrackVoice {
 
     /// True when this event's key matches the track's
     /// `(sender_mailbox, lane, namespace, path)`.
-    pub fn matches(
+    pub(super) fn matches(
         &self,
         sender_mailbox: MailboxId,
         lane: Option<&String>,
@@ -84,7 +84,7 @@ impl TrackVoice {
 
     /// Arm the fade-out. Idempotent — a second `stop` while already
     /// fading keeps the first fade's progress.
-    pub fn stop(&mut self, fade_samples: u32) {
+    pub(super) fn stop(&mut self, fade_samples: u32) {
         if matches!(self.fade, TrackFade::Playing) {
             let total = fade_samples.max(1);
             self.fade = TrackFade::FadingOut {
@@ -94,14 +94,14 @@ impl TrackVoice {
         }
     }
 
-    pub fn done(&self) -> bool {
+    pub(super) fn done(&self) -> bool {
         self.done
     }
 
     /// Render this track's next sample (already gained + faded) and
     /// advance the position. Returns `0.0` once retired; an empty PCM
     /// buffer retires immediately.
-    pub fn next_sample(&mut self) -> f32 {
+    pub(super) fn next_sample(&mut self) -> f32 {
         if self.done || self.pcm.is_empty() {
             self.done = true;
             return 0.0;
@@ -156,7 +156,9 @@ impl TrackVoice {
 /// by the echoed `(namespace, path)` the `ReadResult` carries; the
 /// original requester's reply route + the synth-side track key live
 /// here until the bytes land.
-pub struct PendingTrack {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct PendingTrack {
     /// The original `play_track` requester — the `PlayTrackResult`
     /// reply routes here across the fs round-trip + decode.
     pub source: Source,
@@ -176,7 +178,9 @@ pub struct PendingTrack {
 /// `#[handler(task)]` arm can build the `TrackStart` event + the reply
 /// without re-deriving anything (ADR-0093 §5). The worker produces the
 /// decoded PCM; this carries the synth key + play parameters alongside.
-pub struct TrackDecodeContext {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct TrackDecodeContext {
     pub sender_mailbox: MailboxId,
     pub lane: Option<String>,
     pub namespace: String,
@@ -187,4 +191,6 @@ pub struct TrackDecodeContext {
 
 /// Output of the decode dispatch worker — the resampled mono PCM, or
 /// the decode failure to relay as `PlayTrackResult::Err`.
-pub type DecodeOutput = Result<Vec<f32>, DecodeError>;
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) type DecodeOutput = Result<Vec<f32>, DecodeError>;

--- a/crates/aether-capabilities/src/audio/runtime/voice.rs
+++ b/crates/aether-capabilities/src/audio/runtime/voice.rs
@@ -16,14 +16,14 @@ use super::sample::SampleVoice;
 /// as "more than a string section fits in one component" — on
 /// saturation, voice-steal always evicts the oldest sounding note,
 /// never causing audio glitches.
-pub const MAX_VOICES: usize = 64;
+pub(super) const MAX_VOICES: usize = 64;
 
 /// Envelope state machine. `Release` captures the level it was at
 /// when the note was released, since a note can be released mid-attack
 /// or mid-decay — the release ramp starts from that value, not from
 /// the sustain level.
 #[derive(Copy, Clone, Debug)]
-pub enum EnvelopeStage {
+pub(super) enum EnvelopeStage {
     Attack { t: f32 },
     Decay { t: f32 },
     Sustain,
@@ -35,7 +35,7 @@ pub enum EnvelopeStage {
 /// ADSR. Every field is touched per sample, so the struct stays
 /// compact for cache friendliness in the voice pool.
 #[derive(Copy, Clone, Debug)]
-pub struct OscVoice {
+pub(super) struct OscVoice {
     /// Oscillator phase in turns (`[0.0, 1.0)`), incremented by
     /// `freq / sample_rate` per sample.
     pub phase: f32,
@@ -65,7 +65,7 @@ pub struct OscVoice {
 /// One step of an xorshift32 PRNG, mapped to white noise in `[-1.0,
 /// 1.0)`. The state is per-voice so percussion voices are independent
 /// and a fixed seed is reproducible.
-pub fn next_noise(state: &mut u32) -> f32 {
+pub(super) fn next_noise(state: &mut u32) -> f32 {
     let mut x = *state;
     x ^= x << 13;
     x ^= x >> 17;
@@ -82,7 +82,7 @@ pub fn next_noise(state: &mut u32) -> f32 {
 /// (`sender_mailbox`, `instrument_id`, `pitch`) so a fixed key renders
 /// the same noise sequence every run. Forced non-zero — xorshift32 is
 /// stuck at zero.
-pub fn voice_seed(sender_mailbox: MailboxId, instrument_id: u8, pitch: u8) -> u32 {
+pub(super) fn voice_seed(sender_mailbox: MailboxId, instrument_id: u8, pitch: u8) -> u32 {
     // Truncating the 64-bit mailbox id into the hash is intended; the
     // seed only needs to vary per key, not round-trip.
     #[allow(clippy::cast_possible_truncation)]
@@ -97,7 +97,7 @@ pub fn voice_seed(sender_mailbox: MailboxId, instrument_id: u8, pitch: u8) -> u3
 }
 
 impl OscVoice {
-    pub fn new(
+    pub(super) fn new(
         pitch: u8,
         velocity: u8,
         wave: Wave,
@@ -129,7 +129,7 @@ impl OscVoice {
     /// `next_sample` reads `1.0 + sweep_offset` as the phase-step
     /// multiplier. A non-positive time constant is treated as no
     /// sweep (the voice keeps its base frequency).
-    pub fn with_pitch_sweep(mut self, sweep: PitchSweep, sample_rate: f32) -> Self {
+    pub(super) fn with_pitch_sweep(mut self, sweep: PitchSweep, sample_rate: f32) -> Self {
         if sweep.time_constant_secs > 0.0 {
             let dt = 1.0 / sample_rate;
             self.sweep_offset = sweep.start_ratio - 1.0;
@@ -138,7 +138,7 @@ impl OscVoice {
         self
     }
 
-    pub fn note_off(&mut self) {
+    pub(super) fn note_off(&mut self) {
         let from_level = match self.envelope {
             EnvelopeStage::Attack { t } => {
                 if self.adsr.attack_s > 0.0 {
@@ -161,11 +161,11 @@ impl OscVoice {
         self.envelope = EnvelopeStage::Release { t: 0.0, from_level };
     }
 
-    pub fn done(&self) -> bool {
+    pub(super) fn done(&self) -> bool {
         matches!(self.envelope, EnvelopeStage::Done)
     }
 
-    pub fn advance_envelope(&mut self, dt: f32) -> f32 {
+    pub(super) fn advance_envelope(&mut self, dt: f32) -> f32 {
         match &mut self.envelope {
             EnvelopeStage::Attack { t } => {
                 *t += dt;
@@ -202,7 +202,7 @@ impl OscVoice {
     /// Render the raw waveform at the current phase. Takes `&mut self`
     /// because the `Noise` wave advances its PRNG and one-pole filter
     /// state; the periodic waves only read `phase`.
-    pub fn waveform(&mut self) -> f32 {
+    pub(super) fn waveform(&mut self) -> f32 {
         match self.wave {
             Wave::Sine => (self.phase * TAU).sin(),
             Wave::Square => {
@@ -236,7 +236,7 @@ impl OscVoice {
         }
     }
 
-    pub fn next_sample(&mut self, dt: f32) -> f32 {
+    pub(super) fn next_sample(&mut self, dt: f32) -> f32 {
         let env = self.advance_envelope(dt);
         let s = self.waveform() * self.amplitude * env;
         let ratio = 1.0 + self.sweep_offset;
@@ -253,7 +253,7 @@ impl OscVoice {
 /// each sample by `decay_mul = exp(-rate * dt)`, so the hot loop holds
 /// no transcendentals beyond the `sin`.
 #[derive(Copy, Clone, Debug)]
-pub struct Partial {
+pub(super) struct Partial {
     pub phase: f32,
     pub phase_step: f32,
     pub amp: f32,
@@ -273,7 +273,7 @@ impl Partial {
 /// carry their own per-sample decay; this ramp swells the voice in at
 /// `note_on` and damps it out at `note_off`.
 #[derive(Copy, Clone, Debug)]
-pub enum BankStage {
+pub(super) enum BankStage {
     Attack { t: f32 },
     Sustain,
     Release { t: f32, from_level: f32 },
@@ -337,7 +337,7 @@ impl BankStage {
 /// attack/release ramp. Built once at `note_on`; the per-sample path
 /// is `sin` + multiply-accumulate + decay multiply per partial.
 #[derive(Copy, Clone, Debug)]
-pub struct PartialBankVoice {
+pub(super) struct PartialBankVoice {
     pub partials: [Partial; PARTIAL_COUNT],
     /// Overall level after velocity scaling; the partial amps carry
     /// the (normalised) spectral shape, this carries the loudness.
@@ -348,7 +348,7 @@ pub struct PartialBankVoice {
 }
 
 impl PartialBankVoice {
-    pub fn new(
+    pub(super) fn new(
         pitch: u8,
         velocity: u8,
         def: &PartialBankDef,
@@ -397,19 +397,19 @@ impl PartialBankVoice {
         }
     }
 
-    pub fn note_off(&mut self) {
+    pub(super) fn note_off(&mut self) {
         self.stage.begin_release(self.attack_s);
     }
 
-    pub fn done(&self) -> bool {
+    pub(super) fn done(&self) -> bool {
         matches!(self.stage, BankStage::Done)
     }
 
-    pub fn advance_ramp(&mut self, dt: f32) -> f32 {
+    pub(super) fn advance_ramp(&mut self, dt: f32) -> f32 {
         self.stage.advance(dt, self.attack_s, self.release_s)
     }
 
-    pub fn next_sample(&mut self, dt: f32) -> f32 {
+    pub(super) fn next_sample(&mut self, dt: f32) -> f32 {
         let ramp = self.advance_ramp(dt);
         let mut acc = 0.0f32;
         let mut amp_sum = 0.0f32;
@@ -434,12 +434,12 @@ impl PartialBankVoice {
     }
 
     #[cfg(test)]
-    pub fn envelope_level(&self) -> f32 {
+    pub(super) fn envelope_level(&self) -> f32 {
         self.partials.iter().map(|p| p.amp.abs()).sum()
     }
 
     #[cfg(test)]
-    pub fn partial_amps(&self) -> [f32; PARTIAL_COUNT] {
+    pub(super) fn partial_amps(&self) -> [f32; PARTIAL_COUNT] {
         let mut out = [0.0f32; PARTIAL_COUNT];
         for (slot, p) in out.iter_mut().zip(self.partials.iter()) {
             *slot = p.amp;
@@ -448,7 +448,7 @@ impl PartialBankVoice {
     }
 
     #[cfg(test)]
-    pub fn in_sustain(&self) -> bool {
+    pub(super) fn in_sustain(&self) -> bool {
         matches!(self.stage, BankStage::Sustain)
     }
 }
@@ -457,7 +457,7 @@ impl PartialBankVoice {
 /// instrument at `note_on`: a built-in oscillator or partial-bank
 /// patch, or a loaded sampled instrument (ADR-0103 §6).
 #[derive(Clone, Debug)]
-pub enum VoiceKernel {
+pub(super) enum VoiceKernel {
     Oscillator(OscVoice),
     PartialBank(PartialBankVoice),
     Sample(SampleVoice),
@@ -467,7 +467,7 @@ pub enum VoiceKernel {
 /// partial bank). Split out of [`Voice`] so the `note_on` path can
 /// resolve a built-in or a loaded sample bank into a `VoiceKernel`
 /// before the steal / dedup bookkeeping, then stamp one `Voice`.
-pub fn build_builtin_kernel(
+pub(super) fn build_builtin_kernel(
     sender_mailbox: MailboxId,
     instrument_id: u8,
     pitch: u8,
@@ -506,7 +506,7 @@ pub fn build_builtin_kernel(
 /// used by voice-steal to locate the oldest voice regardless of the
 /// pool's current order (which `swap_remove` scrambles).
 #[derive(Clone, Debug)]
-pub struct Voice {
+pub(super) struct Voice {
     pub sender_mailbox: MailboxId,
     pub instrument_id: u8,
     pub pitch: u8,
@@ -515,7 +515,7 @@ pub struct Voice {
 }
 
 impl Voice {
-    pub fn note_off(&mut self) {
+    pub(super) fn note_off(&mut self) {
         match &mut self.kernel {
             VoiceKernel::Oscillator(v) => v.note_off(),
             VoiceKernel::PartialBank(v) => v.note_off(),
@@ -523,7 +523,7 @@ impl Voice {
         }
     }
 
-    pub fn done(&self) -> bool {
+    pub(super) fn done(&self) -> bool {
         match &self.kernel {
             VoiceKernel::Oscillator(v) => v.done(),
             VoiceKernel::PartialBank(v) => v.done(),
@@ -531,7 +531,7 @@ impl Voice {
         }
     }
 
-    pub fn next_sample(&mut self, dt: f32) -> f32 {
+    pub(super) fn next_sample(&mut self, dt: f32) -> f32 {
         match &mut self.kernel {
             VoiceKernel::Oscillator(v) => v.next_sample(dt),
             VoiceKernel::PartialBank(v) => v.next_sample(dt),

--- a/crates/aether-capabilities/src/component/runtime/mod.rs
+++ b/crates/aether-capabilities/src/component/runtime/mod.rs
@@ -35,23 +35,23 @@ use aether_kinds::{
 // Crate-local wiring the `#[actor] impl` handler bodies name (sibling caps it
 // mails, the unsubscribe kind, the `Kind` / `MailboxCategory` vocabulary),
 // re-exported so the parent reaches them through its `use runtime::*` glob.
-pub use crate::input::{InputCapability, UnsubscribeAll};
-pub use crate::lifecycle::LifecycleCapability;
-pub use aether_data::{Kind, MailboxCategory};
-pub use aether_kinds::LifecycleUnsubscribeAll;
+pub(super) use crate::input::{InputCapability, UnsubscribeAll};
+pub(super) use crate::lifecycle::LifecycleCapability;
+pub(super) use aether_data::{Kind, MailboxCategory};
+pub(super) use aether_kinds::LifecycleUnsubscribeAll;
 
-pub use std::sync::Arc;
-pub use std::sync::atomic::AtomicU64;
+pub(super) use std::sync::Arc;
+pub(super) use std::sync::atomic::AtomicU64;
 
-pub use wasmtime::{Engine, Linker};
+pub(super) use wasmtime::{Engine, Linker};
 
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::actor::wasm::component::ComponentCtx;
-pub use aether_substrate::chassis::error::BootError;
-pub use aether_substrate::mail::mailer::Mailer;
-pub use aether_substrate::mail::outbound::HubOutbound;
-pub use aether_substrate::mail::registry::Registry;
-pub use aether_substrate::mail::{KindId, MailboxId};
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::actor::wasm::component::ComponentCtx;
+pub(super) use aether_substrate::chassis::error::BootError;
+pub(super) use aether_substrate::mail::mailer::Mailer;
+pub(super) use aether_substrate::mail::outbound::HubOutbound;
+pub(super) use aether_substrate::mail::registry::Registry;
+pub(super) use aether_substrate::mail::{KindId, MailboxId};
 
 /// `aether.component` runtime state (ADR-0122 split). Holds the wasmtime
 /// `engine` + `linker` every load instantiates against, the mail `registry`,
@@ -96,7 +96,7 @@ pub struct ComponentHostCapabilityState {
 /// A free fn (no `self`) under the ADR-0122 split: the state-bearing struct
 /// holds no field this helper reads, so it stays stateless and the handlers
 /// reach it through the parent's `use runtime::*` glob.
-pub fn forward_to_trampoline<P>(
+pub(super) fn forward_to_trampoline<P>(
     ctx: &mut NativeCtx<'_>,
     recipient: MailboxId,
     kind: KindId,

--- a/crates/aether-capabilities/src/engine/proxy/connect.rs
+++ b/crates/aether-capabilities/src/engine/proxy/connect.rs
@@ -24,7 +24,7 @@ const PROXY_CONNECT_RETRY_INTERVAL: Duration = Duration::from_millis(50);
 /// `init` so the engines cap can tell a re-forkable startup death from
 /// a genuinely unreachable substrate.
 #[derive(Debug)]
-pub enum ProxyConnectError {
+pub(super) enum ProxyConnectError {
     /// The dial never connected within the budget (or hit a terminal
     /// handshake / frame error). Genuinely unreachable — not
     /// re-forkable.
@@ -74,7 +74,7 @@ impl StdError for ProxyConnectError {
 /// [`ProxyConnectError::ChildExited`] immediately rather than dialing
 /// a dead port for the full budget, so the cap can re-fork on a fresh
 /// port. `None` for an adopted substrate (no child to watch).
-pub fn connect_proxy(
+pub(super) fn connect_proxy(
     addr: &str,
     mailer: &Arc<Mailer>,
     self_mailbox: MailboxId,

--- a/crates/aether-capabilities/src/engine/proxy/heartbeat.rs
+++ b/crates/aether-capabilities/src/engine/proxy/heartbeat.rs
@@ -41,7 +41,7 @@ impl Drop for HeartbeatHandle {
 /// each interval — the empty-payload wake shape the RPC reader
 /// sidecar uses (the timer carries no data, only the schedule). The
 /// handle's `Drop` stops + joins the thread.
-pub fn spawn_heartbeat(
+pub(super) fn spawn_heartbeat(
     mailer: Arc<Mailer>,
     self_mailbox: MailboxId,
     interval: Duration,

--- a/crates/aether-capabilities/src/engine/proxy/runtime.rs
+++ b/crates/aether-capabilities/src/engine/proxy/runtime.rs
@@ -13,23 +13,23 @@
 //! state.
 
 use super::{EngineProxy, EngineProxyConfig};
-pub use crate::engine::kinds::{CallSettled, EngineAlive, EngineDied};
+pub(super) use crate::engine::kinds::{CallSettled, EngineAlive, EngineDied};
 use crate::engine::kinds::{EngineHeartbeatTick, ForwardEnvelope};
 use crate::rpc::RpcInboundReady;
-pub use crate::rpc::{MailEnvelope, MailboxAddress, RpcConnection, RpcError, WireFrame};
-pub use aether_actor::Addressable;
+pub(super) use crate::rpc::{MailEnvelope, MailboxAddress, RpcConnection, RpcError, WireFrame};
+pub(super) use aether_actor::Addressable;
 use aether_actor::runtime;
-pub use aether_data::{EngineId, Kind, KindId, MailboxId, mailbox_id_from_name};
-pub use aether_kinds::DeathReason;
+pub(super) use aether_data::{EngineId, Kind, KindId, MailboxId, mailbox_id_from_name};
+pub(super) use aether_kinds::DeathReason;
 use aether_kinds::TerminateEngine;
-pub use aether_substrate::Mail;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::chassis::error::BootError;
-pub use aether_substrate::mail::mailer::Mailer;
-pub use aether_substrate::mail::{Source, SourceAddr};
-pub use std::collections::HashMap;
-pub use std::process::Child;
-pub use std::sync::Arc;
+pub(super) use aether_substrate::Mail;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::chassis::error::BootError;
+pub(super) use aether_substrate::mail::mailer::Mailer;
+pub(super) use aether_substrate::mail::{Source, SourceAddr};
+pub(super) use std::collections::HashMap;
+pub(super) use std::process::Child;
+pub(super) use std::sync::Arc;
 
 use super::heartbeat::HeartbeatHandle;
 use crate::engine::EngineServer;
@@ -37,8 +37,8 @@ use crate::engine::EngineServer;
 // The init-only bring-up helpers live in the native-only `connect` /
 // `heartbeat` submodules; re-export them here so the parent's `use runtime::*`
 // glob reaches them alongside the rest of the runtime half.
-pub use super::connect::connect_proxy;
-pub use super::heartbeat::spawn_heartbeat;
+pub(super) use super::connect::connect_proxy;
+pub(super) use super::heartbeat::spawn_heartbeat;
 
 /// Mailbox of the engines cap (`aether.engine`) — where a proxy
 /// reports its own liveness transitions (`EngineAlive` / `EngineDied`,

--- a/crates/aether-capabilities/src/engine/proxy/sinks.rs
+++ b/crates/aether-capabilities/src/engine/proxy/sinks.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, Mutex};
 /// `died` keeps the whole [`EngineDied`] (id + reason) so the death-path
 /// tests can assert the surfaced cause.
 #[derive(Clone, Default)]
-pub struct EngineCapCells {
+pub(super) struct EngineCapCells {
     pub alive: Arc<Mutex<Vec<String>>>,
     pub died: Arc<Mutex<Vec<EngineDied>>>,
 }
@@ -28,7 +28,7 @@ pub struct EngineCapCells {
 /// the reported `engine_id`s into shared vecs the heartbeat tests
 /// assert on. A field-bearing `#[cfg(test)]` actor, so it stays the
 /// un-split `type State = Self` shape (ADR-0122).
-pub struct EngineCapSink {
+pub(super) struct EngineCapSink {
     cells: EngineCapCells,
 }
 
@@ -64,7 +64,7 @@ impl NativeActor for EngineCapSink {
 /// receives into a shared cell so the round-trip test can observe a
 /// reply routed back through the proxy. A field-bearing `#[cfg(test)]`
 /// actor, so it stays the un-split `type State = Self` shape (ADR-0122).
-pub struct ProxyReplySink {
+pub(super) struct ProxyReplySink {
     recorded: Arc<Mutex<Option<u64>>>,
 }
 

--- a/crates/aether-capabilities/src/engine/server/artifacts.rs
+++ b/crates/aether-capabilities/src/engine/server/artifacts.rs
@@ -52,7 +52,7 @@ fn describe_binary(binary_path: &str) -> Result<BinaryManifest, String> {
 /// or a human-readable error for an unreadable path or a `--describe`
 /// that failed / yielded no parseable manifest. Idempotent — identical
 /// bytes dedup to the same hash.
-pub fn ingest_binary(
+pub(super) fn ingest_binary(
     store: &mut ArtifactStore,
     path: &str,
     name: Option<String>,
@@ -74,7 +74,7 @@ pub fn ingest_binary(
 /// env layer, ADR-0090). A path that can't be read or `--describe`d is
 /// logged and skipped — a bad bootstrap entry must not fail hub boot.
 /// Idempotent via content dedup.
-pub fn bootstrap_ingest(store: &mut ArtifactStore, paths: &HashSet<String>) {
+pub(super) fn bootstrap_ingest(store: &mut ArtifactStore, paths: &HashSet<String>) {
     for path_str in paths {
         let name = Path::new(path_str)
             .file_stem()
@@ -102,7 +102,7 @@ pub fn bootstrap_ingest(store: &mut ArtifactStore, paths: &HashSet<String>) {
 /// no execution step. Returns the stored content hash, or a
 /// human-readable error for an unreadable path or an unparseable wasm.
 /// Idempotent — identical bytes dedup to the same hash.
-pub fn ingest_component(
+pub(super) fn ingest_component(
     store: &mut ArtifactStore,
     path: &str,
     name: Option<String>,
@@ -128,7 +128,7 @@ pub fn ingest_component(
 /// silent pick). A `module@actor` token's `@actor` part populates the
 /// reply `export` so the forwarded `LoadComponent` instantiates that
 /// actor type (ADR-0096). Returns `Err` for no match / ambiguity.
-pub fn resolve_component(
+pub(super) fn resolve_component(
     store: &mut ArtifactStore,
     selector: &ComponentSelector,
 ) -> ResolveComponentResult {
@@ -246,7 +246,7 @@ fn stored_component_reply(
 /// the `chassis` / `caps` / `target` attribute query resolves, and with
 /// no attribute filters either, `default` = the [`DEFAULT_CHASSIS`]
 /// binary. `None` when nothing matched.
-pub fn resolve_selector(
+pub(super) fn resolve_selector(
     store: &mut ArtifactStore,
     selector: &BinarySelector,
 ) -> Option<StoredArtifact> {
@@ -314,7 +314,7 @@ fn pick_versioned(store: &ArtifactStore, name: &str, version: &str) -> Option<St
 /// `anthropic/cli.rs`), creating `dest`'s parent dir. The
 /// realize-to-exec step for spawn: stored bytes aren't directly
 /// fork-exec'able (ADR-0115 §Execution).
-pub fn realize_executable(src: &Path, dest: &Path) -> io::Result<()> {
+pub(super) fn realize_executable(src: &Path, dest: &Path) -> io::Result<()> {
     if let Some(parent) = dest.parent() {
         fs::create_dir_all(parent)?;
     }

--- a/crates/aether-capabilities/src/engine/server/fleet.rs
+++ b/crates/aether-capabilities/src/engine/server/fleet.rs
@@ -25,7 +25,7 @@ const ENV_ENGINE_STORE_ROOT: &str = "AETHER_ENGINE_STORE_ROOT";
 /// preserved) so a routed call that the cap can't satisfy — bad
 /// `engine_id`, unknown engine — closes with a wire `ReplyEnd`
 /// instead of leaving the RPC client hanging.
-pub fn settle_err(mailer: &Arc<Mailer>, target: MailboxId, correlation: u64, error: String) {
+pub(super) fn settle_err(mailer: &Arc<Mailer>, target: MailboxId, correlation: u64, error: String) {
     mailer.push(
         Mail::new(
             target,
@@ -42,7 +42,7 @@ pub fn settle_err(mailer: &Arc<Mailer>, target: MailboxId, correlation: u64, err
 /// rebinds the port, but on localhost it's negligible — and this
 /// sidesteps both a wire change to report an ephemeral port back
 /// from the substrate and an un-recycled incrementing port pool.
-pub fn free_local_port() -> io::Result<u16> {
+pub(super) fn free_local_port() -> io::Result<u16> {
     let listener = TcpListener::bind("127.0.0.1:0")?;
     let port = listener.local_addr()?.port();
     drop(listener);
@@ -65,7 +65,7 @@ pub fn free_local_port() -> io::Result<u16> {
 // moved onto EngineConfig); it is a process-level deployment override, not
 // a cap config field.
 #[allow(clippy::disallowed_methods)]
-pub fn engine_store_root() -> PathBuf {
+pub(super) fn engine_store_root() -> PathBuf {
     if let Ok(raw) = env::var(ENV_ENGINE_STORE_ROOT)
         && !raw.is_empty()
     {

--- a/crates/aether-capabilities/src/engine/server/runtime.rs
+++ b/crates/aether-capabilities/src/engine/server/runtime.rs
@@ -8,15 +8,15 @@
 //! single `use runtime::*` glob in the parent.
 
 use super::{EngineConfig, EngineServer};
-pub use crate::engine::kinds::ForwardEnvelope;
+pub(super) use crate::engine::kinds::ForwardEnvelope;
 use crate::engine::kinds::{EngineAlive, EngineDied, RouteEnvelope};
-pub use crate::engine::proxy::{
+pub(super) use crate::engine::proxy::{
     EngineProxy, EngineProxyConfig, HeartbeatParams, is_reforkable_spawn_failure,
 };
-pub use crate::engine::store::{ArtifactStore, LAYOUT_VERSION_DIR};
+pub(super) use crate::engine::store::{ArtifactStore, LAYOUT_VERSION_DIR};
 use aether_actor::runtime;
-pub use aether_data::{EngineId, Kind, MailboxId, Uuid};
-pub use aether_kinds::{
+pub(super) use aether_data::{EngineId, Kind, MailboxId, Uuid};
+pub(super) use aether_kinds::{
     DeadEngineDescriptor, DeathReason, EngineDescriptor, ListComponentBinariesResult,
     ListEngineBinariesResult, ListEnginesResult, ResolveComponentResult, SpawnEngineResult,
     TerminateEngineResult, UploadBinaryResult, UploadComponentResult,
@@ -25,28 +25,28 @@ use aether_kinds::{
     ListComponentBinaries, ListEngineBinaries, ListEngines, ResolveComponent, SpawnEngine,
     TerminateEngine, UploadBinary, UploadComponent,
 };
-pub use aether_substrate::Mail;
-pub use aether_substrate::Subname;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::chassis::error::BootError;
-pub use aether_substrate::mail::SourceAddr;
-pub use aether_substrate::mail::mailer::Mailer;
-pub use std::collections::HashMap;
-pub use std::collections::VecDeque;
-pub use std::path::PathBuf;
-pub use std::process::{Command, Stdio};
-pub use std::sync::Arc;
-pub use std::time::{Duration, Instant};
+pub(super) use aether_substrate::Mail;
+pub(super) use aether_substrate::Subname;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::chassis::error::BootError;
+pub(super) use aether_substrate::mail::SourceAddr;
+pub(super) use aether_substrate::mail::mailer::Mailer;
+pub(super) use std::collections::HashMap;
+pub(super) use std::collections::VecDeque;
+pub(super) use std::path::PathBuf;
+pub(super) use std::process::{Command, Stdio};
+pub(super) use std::sync::Arc;
+pub(super) use std::time::{Duration, Instant};
 
 // The artifact-store + fleet helpers the handlers delegate to live in the
 // native-only `artifacts` / `fleet` submodules; re-export them here so the
 // parent's `use runtime::*` glob reaches them alongside the rest of the
 // runtime half.
-pub use super::artifacts::{
+pub(super) use super::artifacts::{
     bootstrap_ingest, ingest_binary, ingest_component, realize_executable, resolve_component,
     resolve_selector,
 };
-pub use super::fleet::{engine_store_root, free_local_port, settle_err};
+pub(super) use super::fleet::{engine_store_root, free_local_port, settle_err};
 
 /// How many recently-died engines [`EngineServer`](super::EngineServer)
 /// retains for `list_engines`' `recently_died` sidecar (issue 1906). A small
@@ -58,7 +58,7 @@ const RECENTLY_DIED_CAP: usize = 16;
 /// ring (issue 1906). Cap-internal — holds the wire fields plus the
 /// `Instant` the cap removed the engine, so `on_list` can compute the
 /// `died_age_millis` it reports in a [`DeadEngineDescriptor`].
-pub struct DeadRecord {
+pub(super) struct DeadRecord {
     pub(super) engine_id: String,
     pub(super) rpc_port: u16,
     pub(super) reason: DeathReason,
@@ -66,7 +66,7 @@ pub struct DeadRecord {
 }
 
 /// One supervised engine in [`EngineServerState`]'s table.
-pub struct EngineEntry {
+pub(super) struct EngineEntry {
     /// Mailbox of the `aether.engine.proxy:<id>` actor — the
     /// forward target for `TerminateEngine`.
     pub(super) proxy_mailbox: MailboxId,

--- a/crates/aether-capabilities/src/engine/store/manifest.rs
+++ b/crates/aether-capabilities/src/engine/store/manifest.rs
@@ -13,7 +13,9 @@ use serde::{Deserialize, Serialize};
 /// variant describes it, so binaries and component wasm share one store
 /// (#1955 can add more — asset bundles — without reshaping the entry).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum ArtifactKind {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) enum ArtifactKind {
     /// A chassis substrate binary, described by a [`BinaryManifest`].
     Binary,
     /// A wasm component, described by a [`ComponentManifest`] (ADR-0116).
@@ -24,7 +26,9 @@ pub enum ArtifactKind {
 /// ADR-0116). The store sidecars one of these next to each entry's bytes;
 /// the variant matches the entry's [`ArtifactKind`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum StoredManifest {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) enum StoredManifest {
     Binary(BinaryManifest),
     Component(ComponentManifest),
 }
@@ -32,7 +36,7 @@ pub enum StoredManifest {
 impl StoredManifest {
     /// The [`BinaryManifest`] when this artifact is a binary, else `None`.
     #[must_use]
-    pub fn as_binary(&self) -> Option<&BinaryManifest> {
+    pub(crate) fn as_binary(&self) -> Option<&BinaryManifest> {
         match self {
             Self::Binary(m) => Some(m),
             Self::Component(_) => None,
@@ -42,7 +46,7 @@ impl StoredManifest {
     /// The [`ComponentManifest`] when this artifact is a component, else
     /// `None`.
     #[must_use]
-    pub fn as_component(&self) -> Option<&ComponentManifest> {
+    pub(crate) fn as_component(&self) -> Option<&ComponentManifest> {
         match self {
             Self::Component(m) => Some(m),
             Self::Binary(_) => None,
@@ -54,7 +58,9 @@ impl StoredManifest {
 /// by its content hash or by a human-readable name. The seam #1954's
 /// spawn cutover consumes to resolve a registry reference to bytes.
 #[derive(Debug, Clone)]
-pub enum Selector {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) enum Selector {
     /// The sha256 hex content address.
     Hash(String),
     /// A name an upload pointed at a hash.
@@ -66,7 +72,9 @@ pub enum Selector {
 /// resolve-and-forward byte source for #1956), the type tag, the
 /// type-tagged manifest, and the name pointing at it (if any).
 #[derive(Debug, Clone)]
-pub struct StoredArtifact {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct StoredArtifact {
     pub hash: String,
     pub path: PathBuf,
     #[allow(dead_code)]
@@ -135,7 +143,9 @@ pub(super) fn matches_component_filter(
 /// (a malformed `aether.kinds.inputs` section). A component with no inputs
 /// section yields an empty manifest with whatever namespace / provenance is
 /// present.
-pub fn component_manifest(wasm: &[u8]) -> Result<ComponentManifest, String> {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) fn component_manifest(wasm: &[u8]) -> Result<ComponentManifest, String> {
     use aether_substrate::actor::wasm::kind_manifest;
 
     let groups = kind_manifest::read_actor_inputs_from_bytes(wasm)?;

--- a/crates/aether-capabilities/src/engine/store/mod.rs
+++ b/crates/aether-capabilities/src/engine/store/mod.rs
@@ -55,20 +55,22 @@ use aether_substrate::atomic_write::atomic_write;
 use aether_substrate::pid_lock::LockGuard;
 use serde::{Deserialize, Serialize};
 
-pub use manifest::{ArtifactKind, Selector, StoredArtifact, StoredManifest, component_manifest};
+pub(super) use manifest::{
+    ArtifactKind, Selector, StoredArtifact, StoredManifest, component_manifest,
+};
 use manifest::{matches_binary_filter, matches_component_filter};
 use persistence::{RestoredIndex, acquire_lock, ensure_root, hash_hex, restore, write_sidecar};
 
 /// Layout-version subdirectory under the resolved root, so a future
 /// on-disk format change can land beside `v1` without a migration.
-pub const LAYOUT_VERSION_DIR: &str = "v1";
+pub(super) const LAYOUT_VERSION_DIR: &str = "v1";
 
 /// Default on-disk byte budget. 16 GiB; binaries are tens of megabytes,
 /// so this holds a deep history before LRU eviction kicks in.
 /// `EngineConfig`'s `binary_disk_budget_bytes`
 /// carries this as its literal default (`17_179_869_184`) and folds an
 /// unparseable env value back to it.
-pub const DEFAULT_DISK_BUDGET_BYTES: u64 = 16 * 1024 * 1024 * 1024;
+pub(super) const DEFAULT_DISK_BUDGET_BYTES: u64 = 16 * 1024 * 1024 * 1024;
 
 const TARGET: &str = "aether_capabilities::engine::store";
 
@@ -101,7 +103,7 @@ struct Entry {
 /// (ADR-0115). Owned by the single-threaded `aether.engine` cap, so its
 /// index lives in plain fields behind `&mut self`; #1955 can wrap it
 /// behind a lock when a multi-owner registry needs one.
-pub struct ArtifactStore {
+pub(super) struct ArtifactStore {
     /// The layout-versioned root holding `entries/`, `names.json`,
     /// `lock.pid`.
     root: PathBuf,
@@ -132,7 +134,7 @@ impl ArtifactStore {
     /// [`LAYOUT_VERSION_DIR`] to a configured override or falls back here
     /// when it's unset.
     #[must_use]
-    pub fn default_root() -> PathBuf {
+    pub(super) fn default_root() -> PathBuf {
         if let Some(data) = dirs::data_dir() {
             return data
                 .join("aether")
@@ -151,7 +153,7 @@ impl ArtifactStore {
     /// lock is reclaimed; a live holder leaves the store unlocked but
     /// still operating.
     #[must_use]
-    pub fn open(root: &Path, disk_budget_bytes: u64) -> Self {
+    pub(super) fn open(root: &Path, disk_budget_bytes: u64) -> Self {
         let root = ensure_root(root);
         let lock = acquire_lock(&root);
         let RestoredIndex {
@@ -174,7 +176,7 @@ impl ArtifactStore {
     /// The layout root this store resolved to (after any temp fallback).
     #[must_use]
     #[allow(dead_code)]
-    pub fn root(&self) -> &Path {
+    pub(super) fn root(&self) -> &Path {
         &self.root
     }
 
@@ -184,7 +186,7 @@ impl ArtifactStore {
     /// hash comes back, but a fresh `name` still repoints. Returns the
     /// sha256 hex the bytes stored under. Runs LRU eviction afterward to
     /// hold the disk budget.
-    pub fn upload(
+    pub(super) fn upload(
         &mut self,
         bytes: &[u8],
         kind: ArtifactKind,
@@ -242,7 +244,7 @@ impl ArtifactStore {
     /// entry has that hash. Persistence of the pin flag is a fast-follow —
     /// today a pin holds for the store's lifetime (the hub process).
     #[allow(dead_code)]
-    pub fn set_pinned(&mut self, hash: &str, pinned: bool) -> bool {
+    pub(super) fn set_pinned(&mut self, hash: &str, pinned: bool) -> bool {
         if let Some(entry) = self.entries.get_mut(hash) {
             entry.pinned = pinned;
             true
@@ -253,7 +255,7 @@ impl ArtifactStore {
 
     /// Pin an entry by hash. Convenience for `set_pinned(hash, true)`.
     #[allow(dead_code)]
-    pub fn pin(&mut self, hash: &str) -> bool {
+    pub(super) fn pin(&mut self, hash: &str) -> bool {
         self.set_pinned(hash, true)
     }
 
@@ -264,7 +266,7 @@ impl ArtifactStore {
     /// constraint". Component entries are excluded — only `Binary`-kind
     /// artifacts are listed here.
     #[must_use]
-    pub fn list_binaries(&self, filter: &ListEngineBinaries) -> Vec<BinaryEntry> {
+    pub(super) fn list_binaries(&self, filter: &ListEngineBinaries) -> Vec<BinaryEntry> {
         self.entries
             .iter()
             .filter_map(|(hash, entry)| {
@@ -285,7 +287,7 @@ impl ArtifactStore {
     /// Each absent field is "no constraint". Binary entries are excluded —
     /// only `Component`-kind artifacts are listed here.
     #[must_use]
-    pub fn list_components(&self, filter: &ListComponentBinaries) -> Vec<ComponentEntry> {
+    pub(super) fn list_components(&self, filter: &ListComponentBinaries) -> Vec<ComponentEntry> {
         self.entries
             .iter()
             .filter_map(|(hash, entry)| {
@@ -302,7 +304,7 @@ impl ArtifactStore {
     /// Resolve an artifact by hash or name to its on-disk path + manifest
     /// (ADR-0115; the seam #1954 consumes). `None` if the hash / name
     /// isn't stored. Bumps the entry's recency.
-    pub fn get(&mut self, selector: &Selector) -> Option<StoredArtifact> {
+    pub(super) fn get(&mut self, selector: &Selector) -> Option<StoredArtifact> {
         let hash = match selector {
             Selector::Hash(h) => h.clone(),
             Selector::Name(n) => self.names.get(n)?.clone(),
@@ -326,20 +328,20 @@ impl ArtifactStore {
     /// Number of stored entries.
     #[must_use]
     #[allow(dead_code)]
-    pub fn entry_count(&self) -> usize {
+    pub(super) fn entry_count(&self) -> usize {
         self.entries.len()
     }
 
     /// Approximate on-disk byte total.
     #[must_use]
     #[allow(dead_code)]
-    pub fn total_bytes(&self) -> u64 {
+    pub(super) fn total_bytes(&self) -> u64 {
         self.total_bytes
     }
 
     /// Whether an entry with `hash` is stored.
     #[must_use]
-    pub fn contains(&self, hash: &str) -> bool {
+    pub(super) fn contains(&self, hash: &str) -> bool {
         self.entries.contains_key(hash)
     }
 

--- a/crates/aether-capabilities/src/fs/adapter.rs
+++ b/crates/aether-capabilities/src/fs/adapter.rs
@@ -162,7 +162,7 @@ impl FileAdapter for LocalFileAdapter {
 // `to_string()` both borrow, so technically `&Error` would work, but
 // it'd force ad-hoc closures at every call site.
 #[allow(clippy::needless_pass_by_value)]
-pub fn fs_error_from_std(err: io::Error) -> FsError {
+pub(super) fn fs_error_from_std(err: io::Error) -> FsError {
     match err.kind() {
         ErrorKind::NotFound => FsError::NotFound,
         ErrorKind::PermissionDenied => FsError::Forbidden,

--- a/crates/aether-capabilities/src/fs/runtime.rs
+++ b/crates/aether-capabilities/src/fs/runtime.rs
@@ -19,16 +19,16 @@ use super::{
 };
 use aether_actor::runtime;
 
-pub use std::any::Any;
-pub use std::fs;
-pub use std::panic::{self, AssertUnwindSafe};
-pub use std::sync::Arc;
+pub(super) use std::any::Any;
+pub(super) use std::fs;
+pub(super) use std::panic::{self, AssertUnwindSafe};
+pub(super) use std::sync::Arc;
 
-pub use super::adapter::fs_error_from_std;
-pub use aether_data::TransformError;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::chassis::error::BootError;
-pub use aether_substrate::transform::{FoldError, TransformRegistry};
+pub(super) use super::adapter::fs_error_from_std;
+pub(super) use aether_data::TransformError;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::chassis::error::BootError;
+pub(super) use aether_substrate::transform::{FoldError, TransformRegistry};
 
 /// `aether.fs` runtime state (ADR-0041). Owns the resolved adapter
 /// registry plus the link-time native-transform registry (ADR-0048 §2)
@@ -46,7 +46,7 @@ pub struct FsCapabilityState {
     pub(super) transforms: TransformRegistry,
 }
 
-pub fn map_fold_error(e: &FoldError) -> FsFoldError {
+pub(super) fn map_fold_error(e: &FoldError) -> FsFoldError {
     match e {
         FoldError::UnknownTransform(id) => FsFoldError::UnknownTransform(*id),
         FoldError::NonLinearArity { at_index, arity } => FsFoldError::NonLinearArity {
@@ -65,7 +65,7 @@ pub fn map_fold_error(e: &FoldError) -> FsFoldError {
     }
 }
 
-pub fn map_transform_error(e: &TransformError) -> FsTransformError {
+pub(super) fn map_transform_error(e: &TransformError) -> FsTransformError {
     match e {
         TransformError::InputDecode { slot } => {
             FsTransformError::InputDecode { slot: *slot as u64 }
@@ -81,7 +81,7 @@ pub fn map_transform_error(e: &TransformError) -> FsTransformError {
     }
 }
 
-pub fn panic_message(payload: &(dyn Any + Send)) -> String {
+pub(super) fn panic_message(payload: &(dyn Any + Send)) -> String {
     payload
         .downcast_ref::<&'static str>()
         .map(|s| (*s).to_owned())

--- a/crates/aether-capabilities/src/gemini/adapter.rs
+++ b/crates/aether-capabilities/src/gemini/adapter.rs
@@ -217,7 +217,7 @@ fn base64_encode(bytes: &[u8]) -> String {
 }
 
 /// Map the wire `AspectRatio` to the provider's `W:H` string.
-pub fn aspect_ratio_str(ar: AspectRatio) -> &'static str {
+pub(super) fn aspect_ratio_str(ar: AspectRatio) -> &'static str {
     use AspectRatio as A;
     match ar {
         A::ASPECT_RATIO_1_1 => "1:1",
@@ -239,7 +239,7 @@ pub fn aspect_ratio_str(ar: AspectRatio) -> &'static str {
 
 /// Map the wire `ImageSize` to the provider's `imageConfig.imageSize`
 /// string. Uppercase `K`; `"512"` has no `K`.
-pub fn image_size_str(size: ImageSize) -> &'static str {
+pub(super) fn image_size_str(size: ImageSize) -> &'static str {
     use ImageSize as S;
     match size {
         S::S512 => "512",
@@ -251,7 +251,7 @@ pub fn image_size_str(size: ImageSize) -> &'static str {
 
 /// Map the wire `ThinkingLevel` to the provider's
 /// `thinkingConfig.thinkingLevel` string.
-pub fn thinking_level_str(level: ThinkingLevel) -> &'static str {
+pub(super) fn thinking_level_str(level: ThinkingLevel) -> &'static str {
     use ThinkingLevel as T;
     match level {
         T::Minimal => "minimal",
@@ -260,7 +260,7 @@ pub fn thinking_level_str(level: ThinkingLevel) -> &'static str {
 }
 
 /// Convert an adapter error string into the typed `GeminiError`.
-pub fn map_adapter_error(raw: &str) -> GeminiError {
+pub(super) fn map_adapter_error(raw: &str) -> GeminiError {
     error::adapter_error_to_typed(raw)
 }
 

--- a/crates/aether-capabilities/src/gemini/error.rs
+++ b/crates/aether-capabilities/src/gemini/error.rs
@@ -12,7 +12,7 @@ use crate::shared::contentgen::shared::{parse_status_prefix, snippet};
 /// Sentinel an adapter returns to mean "no API key" so the cap maps it
 /// onto [`GeminiError::Unauthorized`]. The `DisabledGeminiAdapter`
 /// returns this for every request.
-pub const UNAUTHORIZED_SENTINEL: &str = "unauthorized";
+pub(super) const UNAUTHORIZED_SENTINEL: &str = "unauthorized";
 
 /// Map an HTTP status code from a Gemini API onto a [`GeminiError`].
 /// `retry_after_millis` is parsed from the `retry-after` header by the
@@ -23,7 +23,11 @@ pub const UNAUTHORIZED_SENTINEL: &str = "unauthorized";
 /// - `429` → `RateLimited`
 /// - everything else non-2xx → `AdapterError` carrying status + snippet
 #[must_use]
-pub fn status_to_error(status: u16, retry_after_millis: Option<u32>, body: &str) -> GeminiError {
+pub(super) fn status_to_error(
+    status: u16,
+    retry_after_millis: Option<u32>,
+    body: &str,
+) -> GeminiError {
     match status {
         401 | 403 => GeminiError::Unauthorized,
         429 => GeminiError::RateLimited { retry_after_millis },
@@ -36,7 +40,7 @@ pub fn status_to_error(status: u16, retry_after_millis: Option<u32>, body: &str)
 /// `status=<n>` prefix the ureq backends prepend; falls back to
 /// `AdapterError`.
 #[must_use]
-pub fn adapter_error_to_typed(raw: &str) -> GeminiError {
+pub(super) fn adapter_error_to_typed(raw: &str) -> GeminiError {
     if raw == UNAUTHORIZED_SENTINEL {
         return GeminiError::Unauthorized;
     }

--- a/crates/aether-capabilities/src/gemini/lyria.rs
+++ b/crates/aether-capabilities/src/gemini/lyria.rs
@@ -17,24 +17,28 @@
 use super::GeminiError;
 
 /// Supported Lyria models (2026-05-20 snapshot).
-pub const MODELS: &[&str] = &["lyria-2", "lyria-3", "lyria-3-pro"];
+pub(super) const MODELS: &[&str] = &["lyria-2", "lyria-3", "lyria-3-pro"];
 
 /// Whether `model` is a supported Lyria model.
 #[must_use]
-pub fn is_supported(model: &str) -> bool {
+pub(super) fn is_supported(model: &str) -> bool {
     MODELS.contains(&model)
 }
 
 /// Every supported model id, for `UnknownModel { supported }`.
 #[must_use]
-pub fn supported_model_ids() -> Vec<String> {
+pub(super) fn supported_model_ids() -> Vec<String> {
     MODELS.iter().map(|s| (*s).to_string()).collect()
 }
 
 /// Validate a Lyria request before dispatch. `seed` and `sample_count`
 /// are mutually exclusive — both set is rejected (the same
 /// constraint-validation pattern as Nano Banana's per-model checks).
-pub fn validate(model: &str, seed_set: bool, sample_count_set: bool) -> Result<(), GeminiError> {
+pub(super) fn validate(
+    model: &str,
+    seed_set: bool,
+    sample_count_set: bool,
+) -> Result<(), GeminiError> {
     if seed_set && sample_count_set {
         return Err(GeminiError::MissingRequiredField {
             model: model.to_string(),
@@ -47,7 +51,7 @@ pub fn validate(model: &str, seed_set: bool, sample_count_set: bool) -> Result<(
 /// Parse base64 WAV clips out of a Vertex Lyria response. Returns one
 /// `Vec<u8>` per clip. Factored out so a fixture-replay test can lock
 /// the response shape (ADR-0050 §4).
-pub fn parse_clip_response(json: &str) -> Result<Vec<Vec<u8>>, String> {
+pub(super) fn parse_clip_response(json: &str) -> Result<Vec<Vec<u8>>, String> {
     use serde_json::Value;
 
     let parsed: Value = serde_json::from_str(json).map_err(|e| format!("parse response: {e}"))?;

--- a/crates/aether-capabilities/src/gemini/nanobanana.rs
+++ b/crates/aether-capabilities/src/gemini/nanobanana.rs
@@ -13,7 +13,7 @@ use super::{AspectRatio, GeminiError, ImageSize};
 /// support shape. Drives both `UnknownModel` rejection and the
 /// `aspect_ratio` / `image_size` / reference-count validation.
 #[derive(Clone, Copy)]
-pub struct ModelShape {
+pub(super) struct ModelShape {
     /// The wire model id.
     pub id: &'static str,
     /// Whether the NB2-only knobs (`thinking_level`, `include_thoughts`,
@@ -29,7 +29,7 @@ pub struct ModelShape {
 
 /// The supported Nano Banana models (2026-05 survey). Order is the
 /// `supported`-list order surfaced in `UnknownModel`.
-pub const MODELS: &[ModelShape] = &[
+pub(super) const MODELS: &[ModelShape] = &[
     // NB1 — flash image. K1 only; no reference images; not NB2.
     ModelShape {
         id: "gemini-2.5-flash-image",
@@ -81,13 +81,13 @@ const NB2_ONLY_RATIOS: &[AspectRatio] = &[
 
 /// Look up a model's shape, or `None` if unsupported.
 #[must_use]
-pub fn lookup_model(model: &str) -> Option<&'static ModelShape> {
+pub(super) fn lookup_model(model: &str) -> Option<&'static ModelShape> {
     MODELS.iter().find(|m| m.id == model)
 }
 
 /// Every supported model id, for the `UnknownModel { supported }` list.
 #[must_use]
-pub fn supported_model_ids() -> Vec<String> {
+pub(super) fn supported_model_ids() -> Vec<String> {
     MODELS.iter().map(|m| m.id.to_string()).collect()
 }
 
@@ -103,7 +103,7 @@ fn supported_ratios(shape: &ModelShape) -> Vec<AspectRatio> {
 /// The request facts a per-model validation pass needs. Bundled into a
 /// struct so [`validate`] stays under the argument cap and the cap
 /// builds it once from the wire kind.
-pub struct ValidationInputs {
+pub(super) struct ValidationInputs {
     pub aspect_ratio: AspectRatio,
     pub image_size: Option<ImageSize>,
     /// Whether the NB2-only knobs were set on the request.
@@ -121,7 +121,7 @@ pub struct ValidationInputs {
 /// rejected by the cap before this is called). Checks, in order:
 /// aspect ratio, image size, reference-path counts, and the NB2-only
 /// knobs.
-pub fn validate(shape: &ModelShape, inputs: &ValidationInputs) -> Result<(), GeminiError> {
+pub(super) fn validate(shape: &ModelShape, inputs: &ValidationInputs) -> Result<(), GeminiError> {
     let ratios = supported_ratios(shape);
     if !ratios.contains(&inputs.aspect_ratio) {
         return Err(GeminiError::AspectRatioNotSupportedByModel {
@@ -184,7 +184,7 @@ pub fn validate(shape: &ModelShape, inputs: &ValidationInputs) -> Result<(), Gem
 /// Parse the base64 image payload + grounding/thought metadata out of a
 /// Nano Banana response. Factored out so a fixture-replay test locks the
 /// shape.
-pub fn parse_image_response(json: &str) -> Result<ParsedImage, String> {
+pub(super) fn parse_image_response(json: &str) -> Result<ParsedImage, String> {
     use serde_json::Value;
 
     let parsed: Value = serde_json::from_str(json).map_err(|e| format!("parse response: {e}"))?;
@@ -267,7 +267,7 @@ fn parse_grounding(candidate: &serde_json::Value) -> Option<(Vec<String>, Vec<St
 }
 
 /// Result of [`parse_image_response`].
-pub struct ParsedImage {
+pub(super) struct ParsedImage {
     pub bytes: Vec<u8>,
     pub thought_signature: Option<String>,
     /// Grounding `(search_queries, source_urls)` parsed from
@@ -278,7 +278,7 @@ pub struct ParsedImage {
 /// Shared base64 decode for the media backends (the image path here and
 /// the Lyria clip path in `lyria.rs`). Thin re-export of the local
 /// decoder so both sit on one implementation.
-pub fn decode_base64_for_media(input: &str) -> Result<Vec<u8>, String> {
+pub(super) fn decode_base64_for_media(input: &str) -> Result<Vec<u8>, String> {
     base64_decode(input)
 }
 

--- a/crates/aether-capabilities/src/gemini/runtime.rs
+++ b/crates/aether-capabilities/src/gemini/runtime.rs
@@ -22,15 +22,15 @@ use crate::shared::contentgen::adapter::{
 };
 use crate::shared::contentgen::staging::{gen_root, stage_gen_output};
 
-pub use crate::shared::contentgen::task_queue::TaskQueue;
-pub use std::sync::Arc;
+pub(super) use crate::shared::contentgen::task_queue::TaskQueue;
+pub(super) use std::sync::Arc;
 
 use aether_actor::runtime;
 use aether_kinds::Usage;
 
-pub use aether_actor::{Manual, OutboundReply};
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
-pub use aether_substrate::chassis::error::BootError;
+pub(super) use aether_actor::{Manual, OutboundReply};
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
+pub(super) use aether_substrate::chassis::error::BootError;
 
 /// `aether.gemini` runtime state (ADR-0050). Owns the resolved adapter +
 /// the cap-level rate-limit queue over the ADR-0093 dispatch primitive.
@@ -233,7 +233,7 @@ impl NativeActor for GeminiCapability {
     }
 }
 
-pub fn build_adapter(config: &GeminiConfig) -> Arc<dyn GeminiAdapter> {
+pub(super) fn build_adapter(config: &GeminiConfig) -> Arc<dyn GeminiAdapter> {
     if config.disabled {
         tracing::info!(
             target: "aether_capabilities::gemini",
@@ -263,7 +263,7 @@ pub fn build_adapter(config: &GeminiConfig) -> Arc<dyn GeminiAdapter> {
 /// paths (tool JSON takes paths, the wire stays bytes —
 /// `feedback_no_bytes_in_llm_json`). A read failure aborts the
 /// request with an `AdapterError`.
-pub fn read_reference_images(paths: &[String]) -> Result<Vec<Vec<u8>>, GeminiError> {
+pub(super) fn read_reference_images(paths: &[String]) -> Result<Vec<Vec<u8>>, GeminiError> {
     if paths.is_empty() {
         return Ok(Vec::new());
     }
@@ -289,7 +289,7 @@ fn to_usage(u: AdapterUsage) -> Usage {
     }
 }
 
-pub fn nanobanana_reply(
+pub(super) fn nanobanana_reply(
     request_id: u64,
     include_sig: bool,
     result: Result<GeminiResponse, String>,
@@ -341,7 +341,10 @@ pub fn nanobanana_reply(
     }
 }
 
-pub fn lyria_reply(request_id: u64, result: Result<GeminiResponse, String>) -> LyriaGenerateResult {
+pub(super) fn lyria_reply(
+    request_id: u64,
+    result: Result<GeminiResponse, String>,
+) -> LyriaGenerateResult {
     match result {
         Ok(resp) => {
             let mut output_paths = Vec::with_capacity(resp.artifacts.len());

--- a/crates/aether-capabilities/src/http/client/mod.rs
+++ b/crates/aether-capabilities/src/http/client/mod.rs
@@ -463,8 +463,8 @@ mod runtime {
     use std::sync::Arc;
     use std::time::Duration;
 
-    pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    pub use aether_substrate::chassis::error::BootError;
+    pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    pub(super) use aether_substrate::chassis::error::BootError;
 
     /// `aether.http` runtime state (ADR-0043). Owns the resolved adapter
     /// and the default per-request timeout applied when `Fetch.timeout_ms`

--- a/crates/aether-capabilities/src/http/server/mod.rs
+++ b/crates/aether-capabilities/src/http/server/mod.rs
@@ -116,11 +116,11 @@ mod test_handlers {
     /// Replies `200` and echoes the request's method / path / query (as
     /// headers) and body (verbatim), so a test can assert the full request
     /// round-tripped to the handler.
-    pub struct EchoHttpHandler;
+    pub(super) struct EchoHttpHandler;
 
     /// Empty runtime state for the stateless echo handler (ADR-0122: a
     /// stateless cap still names a state type rather than `()` / `Self`).
-    pub struct EchoHttpHandlerState;
+    pub(super) struct EchoHttpHandlerState;
 
     #[actor(singleton)]
     impl NativeActor for EchoHttpHandler {
@@ -166,10 +166,10 @@ mod test_handlers {
 
     /// Receives the request and returns without replying — the response-less
     /// chain the `502` settlement safety net covers.
-    pub struct SilentHttpHandler;
+    pub(super) struct SilentHttpHandler;
 
     /// Empty runtime state for the stateless silent handler (ADR-0122).
-    pub struct SilentHttpHandlerState;
+    pub(super) struct SilentHttpHandlerState;
 
     #[actor(singleton)]
     impl NativeActor for SilentHttpHandler {

--- a/crates/aether-capabilities/src/http/server/runtime.rs
+++ b/crates/aether-capabilities/src/http/server/runtime.rs
@@ -26,23 +26,23 @@
 use super::{HttpInboundReady, HttpServerCapability, HttpServerConfig, HttpServerHandle, Settled};
 use aether_actor::runtime;
 
-pub use std::collections::HashMap;
-pub use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
-pub use std::sync::Arc;
-pub use std::sync::atomic::{AtomicBool, Ordering};
-pub use std::sync::mpsc;
-pub use std::thread;
-pub use std::time::Duration;
+pub(super) use std::collections::HashMap;
+pub(super) use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
+pub(super) use std::sync::Arc;
+pub(super) use std::sync::atomic::{AtomicBool, Ordering};
+pub(super) use std::sync::mpsc;
+pub(super) use std::thread;
+pub(super) use std::time::Duration;
 
-pub use aether_data::{Kind, KindId, MailboxId};
-pub use aether_substrate::actor::native::envelope::Envelope;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::chassis::error::BootError;
-pub use aether_substrate::mail::mailer::Mailer;
+pub(super) use aether_data::{Kind, KindId, MailboxId};
+pub(super) use aether_substrate::actor::native::envelope::Envelope;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::chassis::error::BootError;
+pub(super) use aether_substrate::mail::mailer::Mailer;
 
 // The parent `#[actor] impl` writes the `502` reply path, so it names
 // `HttpServerResponse`; the rest of the kind vocabulary is used only here.
-pub use crate::http::kinds::HttpServerResponse;
+pub(super) use crate::http::kinds::HttpServerResponse;
 use crate::http::kinds::{HttpHeader, HttpMethod, HttpServerRequest};
 
 use aether_substrate::Mail;
@@ -53,7 +53,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// Per-connection identifier, monotonic within this cap. Distinct from
 /// the OS-level peer addr (one peer may reconnect; ids stay unique for
 /// the cap's lifetime).
-pub type ConnId = u64;
+pub(super) type ConnId = u64;
 
 /// Header-array size for the inbound parse (doubles as the header-count
 /// cap: a request with more headers is answered `431`). ADR-0108 §6.
@@ -63,7 +63,7 @@ const MAX_HEADER_COUNT: usize = 64;
 /// dispatcher. The method stays a raw `String` here; the dispatcher
 /// maps it to [`HttpMethod`] and answers `501` for a non-enumerated
 /// verb before any dispatch.
-pub struct ParsedRequest {
+pub(super) struct ParsedRequest {
     method: String,
     path: String,
     query: String,
@@ -75,7 +75,7 @@ pub struct ParsedRequest {
 /// dispatcher via an mpsc. The matching wake-mail kind is
 /// [`HttpInboundReady`] (empty payload) — `on_inbound_ready` drains the
 /// channel and acts per item.
-pub enum InboundEvent {
+pub(super) enum InboundEvent {
     /// The accept thread took a new connection.
     PeerAccepted { stream: TcpStream, peer: SocketAddr },
     /// A reader parsed a complete, size-bounded request.
@@ -101,7 +101,7 @@ pub enum InboundEvent {
 /// Per-connection state owned by the cap dispatcher. The reader sidecar
 /// holds `shutdown` + the read half; the dispatcher writes the response
 /// through `write_half`.
-pub struct ConnState {
+pub(super) struct ConnState {
     peer: SocketAddr,
     /// Dispatcher's half — used to write the HTTP/1.1 response.
     pub(super) write_half: TcpStream,
@@ -117,14 +117,14 @@ pub struct ConnState {
 /// `MailId.correlation_id`, which is also the root id since the cap
 /// always dispatches via `send_envelope_as_root`).
 #[derive(Copy, Clone)]
-pub struct PendingRequest {
+pub(super) struct PendingRequest {
     pub(super) conn_id: ConnId,
 }
 
 /// Wake sink shared with the accept + reader sidecar threads: push an
 /// [`InboundEvent`] over the mpsc, then fire an [`HttpInboundReady`]
 /// wake mail at the cap so the dispatcher drains.
-pub struct WakeSink {
+pub(super) struct WakeSink {
     pub(super) inbound_tx: mpsc::Sender<InboundEvent>,
     pub(super) mailer: Arc<Mailer>,
     pub(super) self_id: MailboxId,

--- a/crates/aether-capabilities/src/input/subscription.rs
+++ b/crates/aether-capabilities/src/input/subscription.rs
@@ -53,15 +53,15 @@ use runtime::*;
 /// single `use runtime::*` glob above.
 #[cfg(feature = "runtime")]
 mod runtime {
-    pub use aether_data::{Kind, KindId};
-    pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    pub use aether_substrate::chassis::error::BootError;
-    pub use aether_substrate::mail::MailboxId;
-    pub use aether_substrate::mail::registry::{MailboxEntry, Registry};
-    pub use std::collections::{BTreeSet, HashMap};
-    pub use std::sync::Arc;
+    pub(super) use aether_data::{Kind, KindId};
+    pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    pub(super) use aether_substrate::chassis::error::BootError;
+    pub(super) use aether_substrate::mail::MailboxId;
+    pub(super) use aether_substrate::mail::registry::{MailboxEntry, Registry};
+    pub(super) use std::collections::{BTreeSet, HashMap};
+    pub(super) use std::sync::Arc;
 
-    pub use crate::input::config::InputConfig;
+    pub(super) use crate::input::config::InputConfig;
 
     /// `aether.input` runtime state (ADR-0021). Owns the substrate registry
     /// handle (for subscriber-mailbox validation) plus the subscriber table

--- a/crates/aether-capabilities/src/inventory/manifest.rs
+++ b/crates/aether-capabilities/src/inventory/manifest.rs
@@ -11,7 +11,7 @@ use aether_kinds::ParamKindWire;
 /// / `Declared` carry their range / domain so the client expands the
 /// family locally; `Dynamic` carries only the shape (its instances
 /// reverse via [`Resolve`](aether_kinds::Resolve)).
-pub fn param_kind_wire(param: &ParamKind) -> ParamKindWire {
+pub(super) fn param_kind_wire(param: &ParamKind) -> ParamKindWire {
     match *param {
         ParamKind::Bounded { lo, hi } => ParamKindWire::Bounded { lo, hi },
         ParamKind::Declared { domain } => ParamKindWire::Declared {

--- a/crates/aether-capabilities/src/inventory/mod.rs
+++ b/crates/aether-capabilities/src/inventory/mod.rs
@@ -101,20 +101,20 @@ use runtime::*;
 /// above.
 #[cfg(feature = "runtime")]
 mod runtime {
-    pub use super::manifest::param_kind_wire;
-    pub use super::resolve::resolve_ids;
+    pub(super) use super::manifest::param_kind_wire;
+    pub(super) use super::resolve::resolve_ids;
 
-    pub use aether_data::KindId;
-    pub use aether_data::canonical::kind_id_from_parts;
-    pub use aether_data::name_inventory::{handler_entries, name_entries, template_entries};
-    pub use aether_data::wire;
-    pub use aether_kinds::{
+    pub(super) use aether_data::KindId;
+    pub(super) use aether_data::canonical::kind_id_from_parts;
+    pub(super) use aether_data::name_inventory::{handler_entries, name_entries, template_entries};
+    pub(super) use aether_data::wire;
+    pub(super) use aether_kinds::{
         HandlerEntryWire, KindDescriptorWire, NameEntryWire, TemplateEntryWire,
     };
-    pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    pub use aether_substrate::chassis::error::BootError;
-    pub use aether_substrate::mail::registry::Registry;
-    pub use std::sync::Arc;
+    pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    pub(super) use aether_substrate::chassis::error::BootError;
+    pub(super) use aether_substrate::mail::registry::Registry;
+    pub(super) use std::sync::Arc;
 
     /// `aether.inventory` runtime state (ADR-0091 §2). Holds the substrate's
     /// shared `Arc<Registry>` — the same `Arc` `ComponentHostCapability`

--- a/crates/aether-capabilities/src/inventory/resolve.rs
+++ b/crates/aether-capabilities/src/inventory/resolve.rs
@@ -15,7 +15,7 @@ use aether_substrate::runtime::thread_name::resolve_runtime;
 /// for correlation. `name` is `Some` for a dynamically-minted instance
 /// the substrate has registered; `None` on a miss or a malformed id
 /// (a malformed id does not abort its siblings).
-pub fn resolve_ids(ids: Vec<String>) -> Vec<ResolvedName> {
+pub(super) fn resolve_ids(ids: Vec<String>) -> Vec<ResolvedName> {
     ids.into_iter()
         .map(|id| {
             // A malformed tagged-id string reports `None` rather than

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -25,6 +25,12 @@
 //! [`NativeActor`]: aether_substrate::actor::native::NativeActor
 //! [`Addressable`]: aether_actor::Addressable
 
+// Every `pub` item this crate exposes outside `lib.rs`'s re-export set is
+// reachable only within the crate, so overstating its reach misleads a
+// reader. The lint flags each such item; narrow it to its true minimal
+// visibility (the re-exported surface below stays `pub`).
+#![warn(unreachable_pub)]
+
 // `aether.anthropic` content-gen cap (ADR-0050, issue 1014). Native-
 // only — embeds the native-only contentgen dispatch helper and makes
 // blocking ureq / subprocess calls.

--- a/crates/aether-capabilities/src/lifecycle/graph.rs
+++ b/crates/aether-capabilities/src/lifecycle/graph.rs
@@ -16,7 +16,9 @@ use aether_data::{Kind, KindId};
 /// gone (the data graph is non-generic, which is what makes the cap
 /// bridgeable).
 #[derive(Clone)]
-pub struct LifecycleStateData {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct LifecycleStateData {
     pub(crate) kind: KindId,
     pub(crate) next: KindId,
     pub(crate) quit: Option<KindId>,

--- a/crates/aether-capabilities/src/lifecycle/runtime/mod.rs
+++ b/crates/aether-capabilities/src/lifecycle/runtime/mod.rs
@@ -20,9 +20,9 @@ use super::{LifecycleCapability, LifecycleGraphData};
 
 pub use self::config::LifecycleConfig;
 #[cfg(test)]
-pub use self::settlement::ADVANCE_TIMEOUT_MS_DEFAULT;
-pub use self::settlement::{PendingAdvance, Step, resolve_edge};
-pub use super::subscribers::broadcast_to_subscribers;
+pub(super) use self::settlement::ADVANCE_TIMEOUT_MS_DEFAULT;
+pub(super) use self::settlement::{PendingAdvance, Step, resolve_edge};
+pub(super) use super::subscribers::broadcast_to_subscribers;
 
 // Handler-argument and reply kinds named by the moved `#[runtime] impl`
 // bodies. Private to this module — the identity in the parent resolves the
@@ -34,16 +34,16 @@ use aether_kinds::{
     LifecycleUnsubscribe, LifecycleUnsubscribeAll, LifecycleUnsubscribeSelf, Quit,
 };
 
-pub use aether_actor::Manual;
-pub use aether_actor::OutboundReply;
-pub use aether_data::{Kind, KindId, MailboxId as DataMailboxId, mailbox_id_from_name};
-pub use aether_kinds::LifecycleAdvanceComplete;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::chassis::error::BootError;
-pub use aether_substrate::mail::mailer::Mailer;
-pub use std::collections::{BTreeMap, BTreeSet};
-pub use std::sync::Arc;
-pub use std::time::{Duration, Instant};
+pub(super) use aether_actor::Manual;
+pub(super) use aether_actor::OutboundReply;
+pub(super) use aether_data::{Kind, KindId, MailboxId as DataMailboxId, mailbox_id_from_name};
+pub(super) use aether_kinds::LifecycleAdvanceComplete;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::chassis::error::BootError;
+pub(super) use aether_substrate::mail::mailer::Mailer;
+pub(super) use std::collections::{BTreeMap, BTreeSet};
+pub(super) use std::sync::Arc;
+pub(super) use std::time::{Duration, Instant};
 
 /// `aether.lifecycle` runtime state (ADR-0082). Owns the lifecycle data
 /// graph, the subscriber table, the state pointer, and the settlement

--- a/crates/aether-capabilities/src/lifecycle/runtime/settlement.rs
+++ b/crates/aether-capabilities/src/lifecycle/runtime/settlement.rs
@@ -30,7 +30,9 @@ use super::LifecycleCapabilityState;
 /// fires when the settlement pipeline has actually stalled —
 /// degrading a permanent wedge into a visible stutter rather than
 /// tripping on ordinary jitter.
-pub const ADVANCE_TIMEOUT_MS_DEFAULT: u64 = 1_000;
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) const ADVANCE_TIMEOUT_MS_DEFAULT: u64 = 1_000;
 
 /// Early-warning threshold for slow settlement
 /// (iamacoffeepot/aether#1052, the prevention follow-up to #1048). A
@@ -39,28 +41,32 @@ pub const ADVANCE_TIMEOUT_MS_DEFAULT: u64 = 1_000;
 /// sub-tick norm but a full 10× short of the force-complete deadline,
 /// so the warn surfaces a degrading settlement pipeline *before* it
 /// wedges, with headroom to act.
-pub const SLOW_SETTLE_DIVISOR: u32 = 10;
+pub(super) const SLOW_SETTLE_DIVISOR: u32 = 10;
 
 /// EWMA smoothing factor for the rolling settlement-latency stat, as
 /// a permille (200 ‰ = 0.2). A single spike moves the average ~20%.
-pub const SETTLE_EWMA_ALPHA_PERMILLE: u32 = 200;
+pub(super) const SETTLE_EWMA_ALPHA_PERMILLE: u32 = 200;
 
 /// Minimum spacing between slow-settlement warns. A saturating
 /// pipeline settles slowly on *every* advance, so an unguarded warn
 /// would itself spam the rings; one line per episode is enough.
-pub const SLOW_SETTLE_WARN_COOLDOWN: Duration = Duration::from_secs(5);
+pub(super) const SLOW_SETTLE_WARN_COOLDOWN: Duration = Duration::from_secs(5);
 
 /// Internal state-advance decision produced by `on_advance` before
 /// the cap mutates its own fields. Declared at module scope to keep
 /// the handler body statement-only (`clippy::items_after_statements`).
-pub enum Step {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) enum Step {
     StateAdvance { broadcast: KindId, next: KindId },
     Terminal { broadcast: KindId },
     Unknown,
 }
 
 /// Per-advance state tracked across `on_advance` → `on_settled`.
-pub struct PendingAdvance {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct PendingAdvance {
     /// Causal-chain root of the in-flight broadcast (ADR-0080 §6).
     pub(crate) root: MailId,
     /// Kind id of the state just broadcast — echoed in `completed`.
@@ -174,7 +180,9 @@ impl LifecycleCapabilityState {
 /// `quit_pending` flag (ADR-0082 §3). If `quit_pending` is set AND
 /// the state declares a `quit` edge, consume the flag and return the
 /// quit target; otherwise return the unconditional `next` target.
-pub fn resolve_edge(state: &LifecycleStateData, quit_pending: &mut bool) -> KindId {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) fn resolve_edge(state: &LifecycleStateData, quit_pending: &mut bool) -> KindId {
     if *quit_pending && let Some(quit_target) = state.quit {
         *quit_pending = false;
         return quit_target;

--- a/crates/aether-capabilities/src/lifecycle/subscribers.rs
+++ b/crates/aether-capabilities/src/lifecycle/subscribers.rs
@@ -125,7 +125,7 @@ impl LifecycleMailboxExt for NativeActorMailbox<'_, LifecycleCapability> {
 /// `(parent, root)` lineage so settlement counts each child against
 /// the root (ADR-0080 §6).
 #[cfg(not(target_family = "wasm"))]
-pub fn broadcast_to_subscribers<M: ReplyMode>(
+pub(super) fn broadcast_to_subscribers<M: ReplyMode>(
     ctx: &mut NativeCtx<'_, M>,
     subscribers: &BTreeMap<KindId, BTreeSet<MailboxId>>,
     stage: KindId,

--- a/crates/aether-capabilities/src/render/headless_runtime.rs
+++ b/crates/aether-capabilities/src/render/headless_runtime.rs
@@ -13,7 +13,7 @@
 // `BootError` / `Manual` / `CaptureFrameResult`) come from the shared
 // `any(render-runtime, runtime)` seam in `mod.rs`, not from here, so a
 // desktop build doesn't re-export them through two globs.
-pub use std::io;
+pub(super) use std::io;
 
 use std::sync::Arc;
 

--- a/crates/aether-capabilities/src/render/runtime/mod.rs
+++ b/crates/aether-capabilities/src/render/runtime/mod.rs
@@ -16,15 +16,15 @@
 // `#[actor] impl` names come from that same shared seam, not from here.
 use std::sync::Arc;
 
-pub use std::sync::atomic::{AtomicU64, Ordering};
-pub use std::sync::{Mutex, OnceLock};
+pub(super) use std::sync::atomic::{AtomicU64, Ordering};
+pub(super) use std::sync::{Mutex, OnceLock};
 
-pub use aether_data::Kind;
-pub use aether_substrate::capture::PendingCapture;
-pub use aether_substrate::mail::helpers::resolve_bundle;
-pub use aether_substrate::mail::mailer::Mailer;
-pub use aether_substrate::mail::registry::Registry;
-pub use aether_substrate::render::IDENTITY_VIEW_PROJ;
+pub(super) use aether_data::Kind;
+pub(super) use aether_substrate::capture::PendingCapture;
+pub(super) use aether_substrate::mail::helpers::resolve_bundle;
+pub(super) use aether_substrate::mail::mailer::Mailer;
+pub(super) use aether_substrate::mail::registry::Registry;
+pub(super) use aether_substrate::render::IDENTITY_VIEW_PROJ;
 
 // The native impl seams, now nested under this `runtime` directory so the one
 // `mod runtime;` gate in the parent covers them (no per-sibling `#[cfg]`):

--- a/crates/aether-capabilities/src/rpc/server/runtime.rs
+++ b/crates/aether-capabilities/src/rpc/server/runtime.rs
@@ -34,28 +34,28 @@ use aether_actor::runtime;
 // `#[actor] impl` body in `mod.rs` names; it reaches them through the
 // single `use runtime::*` glob. Types named only by the inherent helper
 // methods below ride the same wall (used locally here).
-pub use crate::engine::EngineServer;
-pub use crate::engine::kinds::{CallSettled, RouteEnvelope};
-pub use crate::rpc::{
+pub(super) use crate::engine::EngineServer;
+pub(super) use crate::engine::kinds::{CallSettled, RouteEnvelope};
+pub(super) use crate::rpc::{
     Hello, HelloAck, MailEnvelope, MailboxAddress, RpcError, WIRE_VERSION, WireFrame,
 };
-pub use aether_actor::Addressable;
-pub use aether_codec::frame::{FrameError, write_frame};
-pub use aether_data::{Kind, KindId, MailId, MailboxId, mailbox_id_from_name};
-pub use aether_substrate::Mail;
-pub use aether_substrate::actor::native::envelope::Envelope;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::chassis::error::BootError;
-pub use aether_substrate::mail::SourceAddr;
-pub use aether_substrate::mail::mailer::Mailer;
-pub use std::collections::HashMap;
-pub use std::io;
-pub use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
-pub use std::sync::Arc;
-pub use std::sync::atomic::{AtomicBool, Ordering};
-pub use std::sync::mpsc;
-pub use std::thread::{self, JoinHandle};
-pub use std::time::Duration;
+pub(super) use aether_actor::Addressable;
+pub(super) use aether_codec::frame::{FrameError, write_frame};
+pub(super) use aether_data::{Kind, KindId, MailId, MailboxId, mailbox_id_from_name};
+pub(super) use aether_substrate::Mail;
+pub(super) use aether_substrate::actor::native::envelope::Envelope;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::chassis::error::BootError;
+pub(super) use aether_substrate::mail::SourceAddr;
+pub(super) use aether_substrate::mail::mailer::Mailer;
+pub(super) use std::collections::HashMap;
+pub(super) use std::io;
+pub(super) use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
+pub(super) use std::sync::Arc;
+pub(super) use std::sync::atomic::{AtomicBool, Ordering};
+pub(super) use std::sync::mpsc;
+pub(super) use std::thread::{self, JoinHandle};
+pub(super) use std::time::Duration;
 
 /// Exported handle bundle published at boot. Reachable from the
 /// chassis via `PassiveChassis::handle::<RpcServerHandle>()`;

--- a/crates/aether-capabilities/src/rpc/test_echo.rs
+++ b/crates/aether-capabilities/src/rpc/test_echo.rs
@@ -41,7 +41,9 @@ use std::time::Duration;
     aether_data::Schema,
 )]
 #[kind(name = "aether.rpc.test.echo_request")]
-pub struct TestEchoRequest {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct TestEchoRequest {
     pub value: u64,
 }
 
@@ -59,7 +61,9 @@ pub struct TestEchoRequest {
     aether_data::Schema,
 )]
 #[kind(name = "aether.rpc.test.echo_reply")]
-pub struct TestEchoReply {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct TestEchoReply {
     pub value: u64,
 }
 
@@ -70,11 +74,15 @@ pub struct TestEchoReply {
 /// `aether.rpc.test.echo` identity (ADR-0122 split). A ZST carrying only
 /// the addressing markers `#[actor]` emits always-on; the (empty) runtime
 /// state lives in `TestEchoActorState`.
-pub struct TestEchoActor;
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct TestEchoActor;
 
 /// Runtime state for [`TestEchoActor`]: a named empty stand-in (ADR-0122
 /// hard rule — never `()` / `Self`) for an actor that holds nothing.
-pub struct TestEchoActorState;
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct TestEchoActorState;
 
 #[actor(singleton)]
 impl NativeActor for TestEchoActor {
@@ -118,7 +126,7 @@ impl NativeActor for TestEchoActor {
     aether_data::Schema,
 )]
 #[kind(name = "aether.rpc.test.deferred_echo_request")]
-pub struct DeferredEchoRequest {
+pub(super) struct DeferredEchoRequest {
     pub value: u64,
 }
 
@@ -138,7 +146,7 @@ pub struct DeferredEchoRequest {
     aether_data::Schema,
 )]
 #[kind(name = "aether.rpc.test.deferred_echo_reply")]
-pub struct DeferredEchoReply {
+pub(super) struct DeferredEchoReply {
     pub value: u64,
 }
 
@@ -153,11 +161,11 @@ pub struct DeferredEchoReply {
 /// carrying the addressing markers; its runtime state — the
 /// `TaskQueue` backing the off-thread dispatch — lives in
 /// `DeferredEchoActorState`.
-pub struct DeferredEchoActor;
+pub(super) struct DeferredEchoActor;
 
 /// Runtime state for [`DeferredEchoActor`]: the ADR-0093 hold-until-resolve
 /// task queue the deferred handler submits onto.
-pub struct DeferredEchoActorState {
+pub(super) struct DeferredEchoActorState {
     tasks: TaskQueue,
 }
 

--- a/crates/aether-capabilities/src/tcp/listener/runtime.rs
+++ b/crates/aether-capabilities/src/tcp/listener/runtime.rs
@@ -7,20 +7,20 @@
 //! `#[actor] impl` reaches the state, ctx types, and config / session types
 //! through the single `use runtime::*` glob in the parent.
 
-pub use std::net::{SocketAddr, TcpStream};
-pub use std::sync::Arc;
-pub use std::sync::atomic::{AtomicBool, Ordering};
-pub use std::sync::mpsc;
-pub use std::thread::{self, JoinHandle};
-pub use std::time::Duration;
+pub(super) use std::net::{SocketAddr, TcpStream};
+pub(super) use std::sync::Arc;
+pub(super) use std::sync::atomic::{AtomicBool, Ordering};
+pub(super) use std::sync::mpsc;
+pub(super) use std::thread::{self, JoinHandle};
+pub(super) use std::time::Duration;
 
-pub use aether_data::Kind;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::chassis::error::BootError;
-pub use aether_substrate::{KindId, Mail, Mailer};
+pub(super) use aether_data::Kind;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::chassis::error::BootError;
+pub(super) use aether_substrate::{KindId, Mail, Mailer};
 
-pub use crate::tcp::config::{TcpListenerConfig, TcpSessionConfig};
-pub use crate::tcp::session::TcpSessionActor;
+pub(super) use crate::tcp::config::{TcpListenerConfig, TcpSessionConfig};
+pub(super) use crate::tcp::session::TcpSessionActor;
 
 use aether_actor::runtime;
 // The moved handler bodies name the cap kinds backing their signatures; bring

--- a/crates/aether-capabilities/src/tcp/runtime.rs
+++ b/crates/aether-capabilities/src/tcp/runtime.rs
@@ -7,18 +7,18 @@
 //! reaches the state, ctx types, and supervisor structs through the single
 //! `use runtime::*` glob in the parent.
 
-pub use std::collections::HashMap;
-pub use std::net::TcpListener;
+pub(super) use std::collections::HashMap;
+pub(super) use std::net::TcpListener;
 
-pub use aether_actor::Manual;
+pub(super) use aether_actor::Manual;
 // The manual handlers (`on_unbind` / `on_monitor_notice`) issue their own
 // replies through `ctx.reply` / `ctx.reply_to`, the `OutboundReply` trait
 // methods, so the trait must be in scope where those handler bodies expand.
-pub use aether_actor::OutboundReply;
-pub use aether_substrate::actor::monitor::MonitorHandle;
-pub use aether_substrate::actor::native::spawn::Subname;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::chassis::error::BootError;
+pub(super) use aether_actor::OutboundReply;
+pub(super) use aether_substrate::actor::monitor::MonitorHandle;
+pub(super) use aether_substrate::actor::native::spawn::Subname;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::chassis::error::BootError;
 
 use aether_actor::runtime;
 // `MonitorNotice` is named by `on_monitor_notice`'s signature; the parent's

--- a/crates/aether-capabilities/src/tcp/session/runtime.rs
+++ b/crates/aether-capabilities/src/tcp/session/runtime.rs
@@ -11,19 +11,19 @@
 // dispatch contract; the by-value `SessionWrite` arg trips this lint.
 #![allow(clippy::needless_pass_by_value)]
 
-pub use std::io::{Read, Write};
-pub use std::net::{Shutdown, TcpStream};
-pub use std::sync::Arc;
-pub use std::sync::atomic::{AtomicBool, Ordering};
-pub use std::sync::mpsc;
-pub use std::thread::{self, JoinHandle};
+pub(super) use std::io::{Read, Write};
+pub(super) use std::net::{Shutdown, TcpStream};
+pub(super) use std::sync::Arc;
+pub(super) use std::sync::atomic::{AtomicBool, Ordering};
+pub(super) use std::sync::mpsc;
+pub(super) use std::thread::{self, JoinHandle};
 
-pub use aether_data::Kind;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::chassis::error::BootError;
-pub use aether_substrate::{KindId, Mail, Mailer};
+pub(super) use aether_data::Kind;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::chassis::error::BootError;
+pub(super) use aether_substrate::{KindId, Mail, Mailer};
 
-pub use crate::tcp::config::TcpSessionConfig;
+pub(super) use crate::tcp::config::TcpSessionConfig;
 
 use aether_actor::runtime;
 // The moved handler bodies name the cap kinds backing their signatures; bring
@@ -36,7 +36,7 @@ use super::TcpSessionActor;
 /// kernel TCP buffer; any larger and we just block waiting for
 /// the kernel to fill it. Smaller adds syscall overhead per
 /// chunk.
-pub const READ_BUFFER_BYTES: usize = 64 * 1024;
+pub(super) const READ_BUFFER_BYTES: usize = 64 * 1024;
 
 /// `aether.tcp.session` runtime state (issue 607 Phase 6b, ADR-0079). One end
 /// of a split `TcpStream`: the read sidecar owns the read half; the dispatcher

--- a/crates/aether-capabilities/src/test_bench.rs
+++ b/crates/aether-capabilities/src/test_bench.rs
@@ -87,12 +87,12 @@ impl NativeActor for UnsupportedTestBenchCapability {
 // glob.
 #[cfg(feature = "runtime")]
 mod runtime {
-    pub use std::io;
-    pub use std::sync::Arc;
+    pub(super) use std::io;
+    pub(super) use std::sync::Arc;
 
-    pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    pub use aether_substrate::chassis::error::BootError;
-    pub use aether_substrate::mail::outbound::HubOutbound;
+    pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    pub(super) use aether_substrate::chassis::error::BootError;
+    pub(super) use aether_substrate::mail::outbound::HubOutbound;
 
     /// Runtime state for `UnsupportedTestBenchCapability` (ADR-0122 split).
     /// Holds the `HubOutbound` captured at `init`; read in `on_advance` to

--- a/crates/aether-capabilities/src/test_chassis.rs
+++ b/crates/aether-capabilities/src/test_chassis.rs
@@ -34,7 +34,9 @@ use aether_substrate::mail::registry::Registry;
 /// Canonical test chassis. `build()` is unreachable — every consumer
 /// drives the chassis through `Builder::<TestChassis>::new(...)` directly
 /// rather than going through `TestChassis::build(())`.
-pub struct TestChassis;
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct TestChassis;
 
 //noinspection DuplicatedCode
 impl Chassis for TestChassis {
@@ -54,7 +56,9 @@ impl Chassis for TestChassis {
 /// wired but inert — tests that never hit it (audio, fs, http handler
 /// paths) see no behavioural difference, and tests that do hit it
 /// (rpc, engine proxy) get the connected backend they need.
-pub fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
     let registry = Arc::new(Registry::new());
     for d in descriptors::all() {
         let _ = registry.register_kind_with_descriptor(d);
@@ -71,7 +75,9 @@ pub fn fresh_substrate() -> (Arc<Registry>, Arc<Mailer>) {
 /// sends (the cap-level reply path used by `aether.fs` / `aether.http`
 /// / `aether.audio`). The registry is bare — no kind descriptors —
 /// so tests can register only what they exercise.
-pub fn test_mailer_and_rx() -> (Arc<Mailer>, Receiver<EgressEvent>) {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) fn test_mailer_and_rx() -> (Arc<Mailer>, Receiver<EgressEvent>) {
     let (outbound, rx) = HubOutbound::attached_loopback();
     let registry = Arc::new(Registry::new());
     let mailer = Arc::new(Mailer::new(registry).with_outbound(outbound));
@@ -97,7 +103,9 @@ pub fn test_mailer_and_rx() -> (Arc<Mailer>, Receiver<EgressEvent>) {
 /// The driving `NativeCtx` carries no inbound reply target ([`Source::NONE`]):
 /// the completion's reply routes through the reply target captured at
 /// dispatch and parked in the framework's in-flight ledger, not this ctx.
-pub fn drive_task_completion<A>(
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) fn drive_task_completion<A>(
     state: &mut A::State,
     binding: &Arc<NativeBinding>,
     rx: &Receiver<EgressEvent>,
@@ -139,7 +147,9 @@ pub fn drive_task_completion<A>(
 /// test that drives the actual re-reply via `on_*_result` reads past
 /// the bubble-up to the `ToSession` re-reply. Shared by the
 /// `aether.anthropic` / `aether.gemini` test modules.
-pub fn decode_session_reply<K>(rx: &Receiver<EgressEvent>) -> K
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) fn decode_session_reply<K>(rx: &Receiver<EgressEvent>) -> K
 where
     K: Kind,
 {
@@ -165,7 +175,9 @@ where
 // Used by render.rs tests (feature = "render-runtime"); dead_code fires in
 // the default build without that feature.
 #[allow(dead_code)]
-pub fn decode_reply<K>(rx: &Receiver<EgressEvent>) -> K
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) fn decode_reply<K>(rx: &Receiver<EgressEvent>) -> K
 where
     K: Kind,
 {
@@ -186,7 +198,9 @@ where
 /// `tag` plus the pid and a nanosecond nonce so concurrent tests never
 /// collide. Avoids pulling in the `tempfile` crate; the caller cleans up
 /// via [`cleanup`] after asserting.
-pub fn scratch_dir(prefix: &str, tag: &str) -> PathBuf {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) fn scratch_dir(prefix: &str, tag: &str) -> PathBuf {
     let pid = process::id();
     let nonce: u64 = SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| {
         // Nanosecond clock fits comfortably in u64 for the next ~584 years.
@@ -200,6 +214,8 @@ pub fn scratch_dir(prefix: &str, tag: &str) -> PathBuf {
 }
 
 /// Remove a [`scratch_dir`] tree, ignoring errors (best-effort teardown).
-pub fn cleanup(path: &Path) {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) fn cleanup(path: &Path) {
     let _ = fs::remove_dir_all(path);
 }

--- a/crates/aether-capabilities/src/text/runtime/atlas.rs
+++ b/crates/aether-capabilities/src/text/runtime/atlas.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 
 /// Side length of the square atlas in pixels. One fixed texture per
 /// session; 512×512 holds a few hundred small glyphs.
-pub const ATLAS_SIZE: u32 = 512;
+pub(super) const ATLAS_SIZE: u32 = 512;
 
 /// One transparent-pixel gutter between packed glyphs so bilinear
 /// sampling at a quad edge never bleeds a neighbor's coverage in.
@@ -31,7 +31,9 @@ const GLYPH_PADDING: u32 = 1;
 /// what integer pixel size. `size_pixels` is quantized (rounded) so two
 /// draws at the same nominal size share one raster.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-pub struct GlyphKey {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct GlyphKey {
     pub font_id: u32,
     pub glyph_index: u16,
     pub size_pixels: u32,
@@ -41,7 +43,9 @@ pub struct GlyphKey {
 /// matching uv sub-rect (`0,0` top-left .. `1,1` bottom-right) to thread
 /// into a `TexturedQuad`.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct AtlasEntry {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct AtlasEntry {
     pub x: u32,
     pub y: u32,
     pub width: u32,
@@ -53,7 +57,9 @@ pub struct AtlasEntry {
 }
 
 /// Outcome of looking a glyph up in the atlas.
-pub enum GlyphSlot {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) enum GlyphSlot {
     /// Cached or newly placed — sample the atlas at `entry`. `uploaded`
     /// is `true` only the frame the glyph was first rasterized, signaling
     /// the caller to emit one `update_texture` for `entry`'s rect.
@@ -79,7 +85,9 @@ fn cached_slot(entry: Option<AtlasEntry>) -> GlyphSlot {
 
 /// Fixed-size RGBA8 atlas with a left-to-right, top-to-bottom shelf
 /// packer.
-pub struct Atlas {
+// pub(crate) is its true minimal reach (re-exported / used across the crate's modules); redundant_pub_crate sees only the private-module ancestor.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct Atlas {
     pixels: Vec<u8>,
     cache: HashMap<GlyphKey, Option<AtlasEntry>>,
     shelf_x: u32,
@@ -96,7 +104,7 @@ impl Default for Atlas {
 
 impl Atlas {
     /// A zeroed (fully transparent) atlas.
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             pixels: vec![0u8; (ATLAS_SIZE * ATLAS_SIZE * 4) as usize],
             cache: HashMap::new(),
@@ -108,14 +116,14 @@ impl Atlas {
     }
 
     /// The full RGBA8 buffer — uploaded once via `create_texture`.
-    pub fn pixels(&self) -> &[u8] {
+    pub(crate) fn pixels(&self) -> &[u8] {
         &self.pixels
     }
 
     /// `true` once any glyph failed to pack into the atlas. The text cap
     /// checks this before each draw and calls [`Self::reset`] to free
     /// space for the next frame's glyphs.
-    pub fn is_full(&self) -> bool {
+    pub(crate) fn is_full(&self) -> bool {
         self.full
     }
 
@@ -124,7 +132,7 @@ impl Atlas {
     /// re-syncs the GPU side by emitting one full-rect `update_texture`
     /// immediately after, then re-rasterizes the frame's glyphs into the
     /// fresh atlas as cache misses.
-    pub fn reset(&mut self) {
+    pub(crate) fn reset(&mut self) {
         self.pixels.fill(0);
         self.cache.clear();
         self.shelf_x = 0;
@@ -136,7 +144,7 @@ impl Atlas {
     /// Cheap cache probe: the cached slot for `key`, or `None` if the
     /// glyph has never been seen (the caller then rasterizes and calls
     /// [`Self::get_or_insert`]). Lets the cap skip rasterization on a hit.
-    pub fn cached(&self, key: &GlyphKey) -> Option<GlyphSlot> {
+    pub(crate) fn cached(&self, key: &GlyphKey) -> Option<GlyphSlot> {
         self.cache.get(key).map(|cached| cached_slot(*cached))
     }
 
@@ -147,7 +155,7 @@ impl Atlas {
     /// uv coordinates are an exact `pixel / ATLAS_SIZE` ratio; both fit in
     /// `f32` without loss for any in-bounds glyph.
     #[allow(clippy::cast_precision_loss)]
-    pub fn get_or_insert(
+    pub(crate) fn get_or_insert(
         &mut self,
         key: GlyphKey,
         width: u32,
@@ -191,7 +199,7 @@ impl Atlas {
 
     /// The RGBA8 bytes of a placed glyph's rect, row-major — the payload
     /// for the `update_texture` that uploads it.
-    pub fn rect_rgba(&self, entry: &AtlasEntry) -> Vec<u8> {
+    pub(crate) fn rect_rgba(&self, entry: &AtlasEntry) -> Vec<u8> {
         let mut out = Vec::with_capacity((entry.width * entry.height * 4) as usize);
         for row in 0..entry.height {
             let start = (((entry.y + row) * ATLAS_SIZE + entry.x) * 4) as usize;

--- a/crates/aether-capabilities/src/text/runtime/mod.rs
+++ b/crates/aether-capabilities/src/text/runtime/mod.rs
@@ -10,17 +10,17 @@
 use std::collections::HashMap;
 use std::collections::VecDeque;
 
-pub use std::sync::Arc;
+pub(super) use std::sync::Arc;
 
-pub use aether_actor::OutboundReply;
-pub use aether_data::Source;
-pub use aether_kinds::QuadSpace;
-pub use aether_substrate::Manual;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
-pub use aether_substrate::chassis::error::BootError;
+pub(super) use aether_actor::OutboundReply;
+pub(super) use aether_data::Source;
+pub(super) use aether_kinds::QuadSpace;
+pub(super) use aether_substrate::Manual;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx, TaskDone};
+pub(super) use aether_substrate::chassis::error::BootError;
 
-pub use crate::fs::{FsCapability, Read, ReadResult};
-pub use crate::render::{
+pub(super) use crate::fs::{FsCapability, Read, ReadResult};
+pub(super) use crate::render::{
     CreateTexture, CreateTextureResult, RenderCapability, TexturedQuad, UpdateTexture,
 };
 
@@ -42,7 +42,7 @@ use self::atlas::{ATLAS_SIZE, Atlas, AtlasEntry, GlyphKey, GlyphSlot};
 /// `aether.fs` fetch + parse path; this rides along so the completion
 /// arm replies in the caller's shape.
 #[derive(Clone, Copy)]
-pub enum PendingReply {
+pub(super) enum PendingReply {
     /// Reply `LoadFontResult` — the original `load_font` caller.
     LoadFont,
     /// Reply `FontMetricsResult` — a `font_metrics` grab that missed
@@ -54,14 +54,14 @@ pub enum PendingReply {
 /// keyed in [`TextCapabilityState::pending_fonts`] by the echoed
 /// `(namespace, path)`. Carries the original requester so the deferred
 /// reply lands on the caller, plus the shape that reply takes.
-pub struct PendingFont {
+pub(super) struct PendingFont {
     pub source: Source,
     pub reply: PendingReply,
 }
 
 /// Context carried through the font-parse task so the completion arm
 /// can shape the reply the parked request is owed.
-pub struct FontParseContext {
+pub(super) struct FontParseContext {
     pub namespace: String,
     pub path: String,
     pub name: String,
@@ -70,14 +70,14 @@ pub struct FontParseContext {
 
 /// A successfully parsed font plus the byte length the reply reports as
 /// `resident_bytes`.
-pub struct ParsedFont {
+pub(super) struct ParsedFont {
     pub font: Arc<fontdue::Font>,
     pub resident_bytes: u64,
 }
 
 /// Off-hot-path parse outcome — `Err` carries the reason the cap relays
 /// as `LoadFontResult::Err`.
-pub type FontParseOutput = Result<ParsedFont, String>;
+pub(super) type FontParseOutput = Result<ParsedFont, String>;
 
 /// `aether.text` runtime state (ADR-0105). CPU-only — no GPU handles,
 /// just the font registry, the glyph atlas, and the parked `load_font`

--- a/crates/aether-capabilities/src/trace/mod.rs
+++ b/crates/aether-capabilities/src/trace/mod.rs
@@ -64,11 +64,11 @@ use runtime::*;
 /// glob above.
 #[cfg(feature = "runtime")]
 mod runtime {
-    pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    pub use aether_substrate::chassis::error::BootError;
-    pub use aether_substrate::mail::helpers::resolve_bundle;
-    pub use aether_substrate::mail::registry::Registry;
-    pub use std::sync::Arc;
+    pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    pub(super) use aether_substrate::chassis::error::BootError;
+    pub(super) use aether_substrate::mail::helpers::resolve_bundle;
+    pub(super) use aether_substrate::mail::registry::Registry;
+    pub(super) use std::sync::Arc;
 
     /// `aether.trace` runtime state (ADR-0086 Phase 3c). Holds the
     /// substrate registry handle for `DispatchTraced`'s per-envelope name

--- a/crates/aether-capabilities/src/trampoline/runtime/mod.rs
+++ b/crates/aether-capabilities/src/trampoline/runtime/mod.rs
@@ -18,25 +18,25 @@ mod replace;
 mod state;
 
 pub use config::WasmTrampolineConfig;
-pub use state::WasmTrampolineState;
+pub(super) use state::WasmTrampolineState;
 
 // The `aether_substrate` / `wasmtime` / `std` names the parent `#[actor] impl`
 // body references, re-exported so the parent `use runtime::*` glob sees them
 // (the fs `runtime.rs` `pub use` pattern). `DropResult` / `ReplaceResult` ride
 // this glob; `DropComponent` / `ReplaceComponent` stay at the parent file root
 // (always-on, for the `HandlesKind<K>` markers).
-pub use std::io;
-pub use std::sync::Arc;
+pub(super) use std::io;
+pub(super) use std::sync::Arc;
 
 use super::WasmTrampoline;
-pub use aether_actor::Local;
+pub(super) use aether_actor::Local;
 use aether_actor::runtime;
-pub use aether_kinds::{DropComponent, DropResult, ReplaceComponent, ReplaceResult};
-pub use aether_substrate::actor::native::envelope::Envelope;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::actor::wasm::component::{Component, ComponentCtx};
-pub use aether_substrate::chassis::error::BootError;
-pub use aether_substrate::mail::{CostCells, KindId, Mail};
+pub(super) use aether_kinds::{DropComponent, DropResult, ReplaceComponent, ReplaceResult};
+pub(super) use aether_substrate::actor::native::envelope::Envelope;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::actor::wasm::component::{Component, ComponentCtx};
+pub(super) use aether_substrate::chassis::error::BootError;
+pub(super) use aether_substrate::mail::{CostCells, KindId, Mail};
 
 #[runtime]
 impl NativeActor for WasmTrampoline {

--- a/crates/aether-capabilities/src/ui/runtime.rs
+++ b/crates/aether-capabilities/src/ui/runtime.rs
@@ -13,21 +13,21 @@
 
 use aether_data::MailboxId;
 
-pub use core::iter::once;
-pub use core::mem::swap;
+pub(super) use core::iter::once;
+pub(super) use core::mem::swap;
 
-pub use crate::input::{InputCapability, InputMailboxExt};
-pub use crate::lifecycle::{LifecycleCapability, LifecycleMailboxExt};
-pub use crate::render::{DrawSolidQuads, RenderCapability, SolidQuad};
-pub use crate::text::{DrawText, TextCapability};
-pub use aether_kinds::QuadSpace;
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::chassis::error::BootError;
+pub(super) use crate::input::{InputCapability, InputMailboxExt};
+pub(super) use crate::lifecycle::{LifecycleCapability, LifecycleMailboxExt};
+pub(super) use crate::render::{DrawSolidQuads, RenderCapability, SolidQuad};
+pub(super) use crate::text::{DrawText, TextCapability};
+pub(super) use aether_kinds::QuadSpace;
+pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+pub(super) use aether_substrate::chassis::error::BootError;
 
 /// A button's hit-test record for one frame: where it was drawn, the
 /// caller's widget `id`, and the component that drew it (the
 /// `UiClicked` recipient on a hit).
-pub struct ButtonRect {
+pub(super) struct ButtonRect {
     /// `[x, y, width, height]` in window pixels.
     pub(super) rect: [f32; 4],
     /// Caller-stable widget id echoed back in `UiClicked`.

--- a/crates/aether-capabilities/src/window/mod.rs
+++ b/crates/aether-capabilities/src/window/mod.rs
@@ -53,8 +53,8 @@ use runtime::*;
 /// by this module rather than per-import.
 #[cfg(feature = "runtime")]
 mod runtime {
-    pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-    pub use aether_substrate::chassis::error::BootError;
+    pub(super) use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+    pub(super) use aether_substrate::chassis::error::BootError;
 
     /// `aether.window` headless-companion runtime state (ADR-0122 split).
     /// The cap is stateless — every handler `Err`-replies off `ctx` alone —


### PR DESCRIPTION
Closes #2444.

## Summary

Enables `#![warn(unreachable_pub)]` for `aether-capabilities` and narrows every flagged item to its minimal lint-clean visibility. No behavior change; the crate's public surface (the `lib.rs` re-exports) is character-identical to `origin/main`.

There is no uniform `pub(crate)` floor: the workspace enables `nursery = warn` (`redundant_pub_crate`) under `-D warnings`, so the `pub(crate)` that `unreachable_pub` asks for is itself rejected by `redundant_pub_crate` inside a private module. Narrowing each site to its true minimum *is* the pass — converged by compiler feedback, which also surfaced a third lint in the same fight (`private_interfaces`, where a `pub(super)` type leaked through a `pub(crate)` interface).

**480 bare-`pub` declarations** narrowed across 58 files:
- **433 → `pub(super)`** (module-local — the common case)
- **47 → `pub(crate)` + a per-item `#[allow(clippy::redundant_pub_crate)]`** with a one-line reason — items genuinely reachable across the crate's modules but lexically inside a private module, so the required `pub(crate)` trips `redundant_pub_crate`. No crate-root `#![allow]`.
- **0 left `pub`** — every flagged item was truly unreachable through `lib.rs`.

The `pub(crate)` count exceeds the original ~10 estimate because narrowing was converged under the full feature matrix the workspace build unifies to (`render-runtime,audio-runtime,text-runtime,ui-runtime`); the plan directs acting on the complete present-day lint output.

## Test plan

`scripts/preflight.sh` against the committed HEAD ran green through fmt, `cargo clippy --workspace --all-targets -- -D warnings`, strict `cargo doc --workspace --no-deps`, `cargo nextest run --workspace` (1898 passed, 8 skipped), and the wasm32 component cross-build. The diff-scoped Qodana sweep is left to CI's authoritative `Qodana scan` required check.

## Generated by

`/implement` — agent execution of [scoped issue #2444](https://github.com/iamacoffeepot/aether/issues/2444).
