### PR TITLE
refactor(actor-derive): single source of truth for kinds section-version bytes

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -206,16 +206,18 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
                 &#labels_ident,
             );
 
-        // ADR-0028 / ADR-0032 / ADR-0118: `aether.kinds` v0x05 ships
+        // ADR-0028 / ADR-0032 / ADR-0118: `aether.kinds` ships
         // `[version_byte][canonical_bytes]`, where the canonical bytes are
         // now the owned aether-wire encoding (issue 1984) — so every
         // `Kind::ID` regenerates, gated loudly behind this version byte.
+        // The version byte is `aether_data::KINDS_SECTION_VERSION`, the
+        // single source of truth the reader also reads.
         #[cfg(target_family = "wasm")]
         #[used]
         #[unsafe(link_section = "aether.kinds")]
         static #kind_static_ident: [u8; #canonical_len_ident + 1] = {
             let mut out = [0u8; #canonical_len_ident + 1];
-            out[0] = 0x05;
+            out[0] = ::aether_data::KINDS_SECTION_VERSION;
             let mut i = 0;
             while i < #canonical_len_ident {
                 out[i + 1] = #canonical_bytes_ident[i];
@@ -229,10 +231,12 @@ fn expand_kind(input: &DeriveInput) -> syn::Result<TokenStream2> {
         #[unsafe(link_section = "aether.kinds.labels")]
         static #kind_labels_static_ident: [u8; #labels_len_ident + 1] = {
             let mut out = [0u8; #labels_len_ident + 1];
-            // v0x04 (ADR-0118 / issue 1984): the labels record is the owned
+            // ADR-0118 / issue 1984: the labels record is the owned
             // aether-wire encoding of `KindLabels`. v0x03 made records
             // self-identifying (`kind_id`); the reader still pairs by id.
-            out[0] = 0x04;
+            // The version byte is `aether_data::LABELS_SECTION_VERSION`,
+            // the single source of truth the reader also reads.
+            out[0] = ::aether_data::LABELS_SECTION_VERSION;
             let mut i = 0;
             while i < #labels_len_ident {
                 out[i + 1] = #labels_bytes_ident[i];
@@ -3493,8 +3497,34 @@ fn build_dispatch_body(handlers: &[HandlerFn], fallback: Option<&FallbackFn>) ->
 /// using crate is pulled in as a wasm32 rlib by another cdylib (a
 /// rlib that doesn't call `export!()` contributes no section bytes).
 // One const-eval byte-copy block per record kind (handler / fallback /
-// component-doc / config); inlining them in one walk keeps each emitted
-// block contiguous and reads better than four near-identical helpers.
+// component-doc / config). The four blocks differ only in the two
+// const-fn calls that compute the record's length and bytes; the
+// version-byte write and the copy-loop tail are identical, so they
+// share `emit_inputs_copy_block`.
+fn emit_inputs_copy_block(
+    rec_len_expr: &TokenStream2,
+    rec_bytes_expr: &TokenStream2,
+) -> TokenStream2 {
+    quote! {
+        {
+            const REC_LEN: usize = #rec_len_expr;
+            const REC_BYTES: [u8; REC_LEN] = #rec_bytes_expr;
+            // Per-record section version byte — a token reference to
+            // `INPUTS_SECTION_VERSION` (ADR-0118 / issue 1984: the record
+            // is the owned aether-wire encoding) so the writer folds from
+            // the same source of truth the reader reads.
+            out[pos] = ::aether_actor::__macro_internals::INPUTS_SECTION_VERSION;
+            pos += 1;
+            let mut i = 0;
+            while i < REC_LEN {
+                out[pos] = REC_BYTES[i];
+                pos += 1;
+                i += 1;
+            }
+        }
+    }
+}
+
 #[allow(clippy::too_many_lines)]
 fn build_inputs_manifest_consts(
     handlers: &[HandlerFn],
@@ -3536,38 +3566,26 @@ fn build_inputs_manifest_consts(
                 #reply_id_expr,
             ))
         });
-        copy_blocks.push(quote! {
-            {
-                const REC_LEN: usize =
-                    ::aether_actor::__macro_internals::canonical::inputs_handler_len(
-                        <#k as ::aether_actor::__macro_internals::Kind>::ID.0,
-                        <#k as ::aether_actor::__macro_internals::Kind>::NAME,
-                        #doc_expr,
-                        #reply_tag_expr,
-                        #reply_id_expr,
-                    );
-                const REC_BYTES: [u8; REC_LEN] =
-                    ::aether_actor::__macro_internals::canonical::write_inputs_handler::<REC_LEN>(
-                        <#k as ::aether_actor::__macro_internals::Kind>::ID.0,
-                        <#k as ::aether_actor::__macro_internals::Kind>::NAME,
-                        #doc_expr,
-                        #reply_tag_expr,
-                        #reply_id_expr,
-                    );
-                // Per-record section version byte, bumped to 0x05 by
-                // ADR-0118 (issue 1984) — the record is now the owned
-                // aether-wire encoding. Keep in
-                // lockstep with `INPUTS_SECTION_VERSION`.
-                out[pos] = 0x05;
-                pos += 1;
-                let mut i = 0;
-                while i < REC_LEN {
-                    out[pos] = REC_BYTES[i];
-                    pos += 1;
-                    i += 1;
-                }
-            }
-        });
+        copy_blocks.push(emit_inputs_copy_block(
+            &quote! {
+                ::aether_actor::__macro_internals::canonical::inputs_handler_len(
+                    <#k as ::aether_actor::__macro_internals::Kind>::ID.0,
+                    <#k as ::aether_actor::__macro_internals::Kind>::NAME,
+                    #doc_expr,
+                    #reply_tag_expr,
+                    #reply_id_expr,
+                )
+            },
+            &quote! {
+                ::aether_actor::__macro_internals::canonical::write_inputs_handler::<REC_LEN>(
+                    <#k as ::aether_actor::__macro_internals::Kind>::ID.0,
+                    <#k as ::aether_actor::__macro_internals::Kind>::NAME,
+                    #doc_expr,
+                    #reply_tag_expr,
+                    #reply_id_expr,
+                )
+            },
+        ));
     }
 
     if let Some(f) = fallback {
@@ -3575,24 +3593,14 @@ fn build_inputs_manifest_consts(
         len_terms.push(quote! {
             (1 + ::aether_actor::__macro_internals::canonical::inputs_fallback_len(#doc_expr))
         });
-        copy_blocks.push(quote! {
-            {
-                const REC_LEN: usize =
-                    ::aether_actor::__macro_internals::canonical::inputs_fallback_len(#doc_expr);
-                const REC_BYTES: [u8; REC_LEN] =
-                    ::aether_actor::__macro_internals::canonical::write_inputs_fallback::<REC_LEN>(#doc_expr);
-                // Per-record section version byte, in lockstep with
-                // `INPUTS_SECTION_VERSION` (0x05, ADR-0118 / issue 1984).
-                out[pos] = 0x05;
-                pos += 1;
-                let mut i = 0;
-                while i < REC_LEN {
-                    out[pos] = REC_BYTES[i];
-                    pos += 1;
-                    i += 1;
-                }
-            }
-        });
+        copy_blocks.push(emit_inputs_copy_block(
+            &quote! {
+                ::aether_actor::__macro_internals::canonical::inputs_fallback_len(#doc_expr)
+            },
+            &quote! {
+                ::aether_actor::__macro_internals::canonical::write_inputs_fallback::<REC_LEN>(#doc_expr)
+            },
+        ));
     }
 
     if let Some(doc) = component_doc {
@@ -3600,24 +3608,14 @@ fn build_inputs_manifest_consts(
         len_terms.push(quote! {
             (1 + ::aether_actor::__macro_internals::canonical::inputs_component_len(#doc_lit))
         });
-        copy_blocks.push(quote! {
-            {
-                const REC_LEN: usize =
-                    ::aether_actor::__macro_internals::canonical::inputs_component_len(#doc_lit);
-                const REC_BYTES: [u8; REC_LEN] =
-                    ::aether_actor::__macro_internals::canonical::write_inputs_component::<REC_LEN>(#doc_lit);
-                // Per-record section version byte, in lockstep with
-                // `INPUTS_SECTION_VERSION` (0x05, ADR-0118 / issue 1984).
-                out[pos] = 0x05;
-                pos += 1;
-                let mut i = 0;
-                while i < REC_LEN {
-                    out[pos] = REC_BYTES[i];
-                    pos += 1;
-                    i += 1;
-                }
-            }
-        });
+        copy_blocks.push(emit_inputs_copy_block(
+            &quote! {
+                ::aether_actor::__macro_internals::canonical::inputs_component_len(#doc_lit)
+            },
+            &quote! {
+                ::aether_actor::__macro_internals::canonical::write_inputs_component::<REC_LEN>(#doc_lit)
+            },
+        ));
     }
 
     // ADR-0090 (issue 1257): emit a `Config` record keyed by the
@@ -3632,30 +3630,20 @@ fn build_inputs_manifest_consts(
                 <#cfg as ::aether_actor::__macro_internals::Kind>::NAME,
             ))
         });
-        copy_blocks.push(quote! {
-            {
-                const REC_LEN: usize =
-                    ::aether_actor::__macro_internals::canonical::inputs_config_len(
-                        <#cfg as ::aether_actor::__macro_internals::Kind>::ID.0,
-                        <#cfg as ::aether_actor::__macro_internals::Kind>::NAME,
-                    );
-                const REC_BYTES: [u8; REC_LEN] =
-                    ::aether_actor::__macro_internals::canonical::write_inputs_config::<REC_LEN>(
-                        <#cfg as ::aether_actor::__macro_internals::Kind>::ID.0,
-                        <#cfg as ::aether_actor::__macro_internals::Kind>::NAME,
-                    );
-                // Per-record section version byte (0x05), in lockstep
-                // with `INPUTS_SECTION_VERSION` (ADR-0118 / issue 1984).
-                out[pos] = 0x05;
-                pos += 1;
-                let mut i = 0;
-                while i < REC_LEN {
-                    out[pos] = REC_BYTES[i];
-                    pos += 1;
-                    i += 1;
-                }
-            }
-        });
+        copy_blocks.push(emit_inputs_copy_block(
+            &quote! {
+                ::aether_actor::__macro_internals::canonical::inputs_config_len(
+                    <#cfg as ::aether_actor::__macro_internals::Kind>::ID.0,
+                    <#cfg as ::aether_actor::__macro_internals::Kind>::NAME,
+                )
+            },
+            &quote! {
+                ::aether_actor::__macro_internals::canonical::write_inputs_config::<REC_LEN>(
+                    <#cfg as ::aether_actor::__macro_internals::Kind>::ID.0,
+                    <#cfg as ::aether_actor::__macro_internals::Kind>::NAME,
+                )
+            },
+        ));
     }
 
     let len_expr = if len_terms.is_empty() {
@@ -3795,7 +3783,7 @@ fn build_kinds_section_retention_statics(
                     <#k as ::aether_actor::__macro_internals::Kind>::NAME,
                     &#schema_ident,
                 );
-            // Same v0x05 wire shape as `expand_kind`'s primary emission
+            // Same wire shape as `expand_kind`'s primary emission
             // (ADR-0118 / issue 1984: the owned aether-wire encoding) so
             // retention records (when this kind lives in a dependency
             // rlib) pair cleanly with the primary records by id.
@@ -3804,7 +3792,7 @@ fn build_kinds_section_retention_statics(
             #[unsafe(link_section = "aether.kinds")]
             static #section_ident: [u8; #len_ident + 1] = {
                 let mut out = [0u8; #len_ident + 1];
-                out[0] = 0x05;
+                out[0] = ::aether_actor::__macro_internals::KINDS_SECTION_VERSION;
                 let mut i = 0;
                 while i < #len_ident {
                     out[i + 1] = #bytes_ident[i];
@@ -3849,9 +3837,9 @@ fn build_kinds_section_retention_statics(
             #[unsafe(link_section = "aether.kinds.labels")]
             static #labels_section_ident: [u8; #labels_len_ident + 1] = {
                 let mut out = [0u8; #labels_len_ident + 1];
-                // v0x04 (ADR-0118 / issue 1984): the owned aether-wire
+                // ADR-0118 / issue 1984: the owned aether-wire
                 // encoding of `KindLabels`, matching `expand_kind`.
-                out[0] = 0x04;
+                out[0] = ::aether_actor::__macro_internals::LABELS_SECTION_VERSION;
                 let mut i = 0;
                 while i < #labels_len_ident {
                     out[i + 1] = #labels_bytes_ident[i];

--- a/crates/aether-actor/src/lib.rs
+++ b/crates/aether-actor/src/lib.rs
@@ -113,6 +113,10 @@ pub const DISPATCH_UNKNOWN_KIND: u32 = 1;
 pub mod __macro_internals {
     pub use aether_data::__derive_runtime::{Cow, KindLabels, SchemaType, canonical};
     pub use aether_data::{Kind, Schema, mailbox_id_from_name};
+    // Section-version bytes the `#[actor]` / `export!` writers emit as
+    // token references so the literals const-fold from one source of
+    // truth in `aether-data`.
+    pub use aether_data::{INPUTS_SECTION_VERSION, KINDS_SECTION_VERSION, LABELS_SECTION_VERSION};
     // ADR-0096: the multi-actor `export!` arm stores the instance as
     // `Box<dyn ErasedWasmActor>`; re-export `Box` so the emitted code
     // doesn't depend on the guest crate's prelude exposing `alloc`.

--- a/crates/aether-actor/src/wasm/mod.rs
+++ b/crates/aether-actor/src/wasm/mod.rs
@@ -862,12 +862,12 @@ macro_rules! __export_multi_internal {
                         $crate::__macro_internals::canonical::write_inputs_actor_boundary::<BOUNDARY_LEN>(
                             <$component as $crate::Addressable>::NAMESPACE,
                         );
-                    // Per-record section version byte, in lockstep with
-                    // `INPUTS_SECTION_VERSION` (0x05, bumped by ADR-0118 /
+                    // Per-record section version byte — a token reference
+                    // to `INPUTS_SECTION_VERSION` (bumped by ADR-0118 /
                     // issue 1984; the multi-actor boundary record is a
                     // per-record frame and tracks the same version as the
                     // single-actor records emitted by the derive macro).
-                    out[pos] = 0x05;
+                    out[pos] = $crate::__macro_internals::INPUTS_SECTION_VERSION;
                     pos += 1;
                     let mut i = 0;
                     while i < BOUNDARY_LEN {

--- a/crates/aether-data/src/schema.rs
+++ b/crates/aether-data/src/schema.rs
@@ -935,3 +935,18 @@ pub const INPUTS_SECTION: &str = "aether.kinds.inputs";
 /// `kind_manifest::KINDS_VERSION`): the two sections version
 /// independently and happen to share a number at this revision.
 pub const INPUTS_SECTION_VERSION: u8 = 0x05;
+
+/// Version byte the `aether.kinds` wasm custom section opens with —
+/// the single source of truth both the derive's writers and the
+/// substrate reader share. A format bump is a one-line edit here that
+/// const-folds into every writer site. Distinct from the
+/// `aether.kinds.inputs` section's own version
+/// ([`INPUTS_SECTION_VERSION`], also `0x05`): the two sections version
+/// independently and happen to share a number at this revision.
+pub const KINDS_SECTION_VERSION: u8 = 0x05;
+
+/// Version byte the `aether.kinds.labels` wasm custom section opens
+/// with — the single source of truth both the derive's writers and the
+/// substrate reader share. A format bump is a one-line edit here that
+/// const-folds into every writer site.
+pub const LABELS_SECTION_VERSION: u8 = 0x04;


### PR DESCRIPTION
Closes #2458.

## Summary

The wasm section-version bytes the derive emits had no single source of truth — `aether.kinds` (0x05), `aether.kinds.labels` (0x04), and `aether.kinds.inputs` (0x05) were hand-maintained literals scattered across the writer crates, guarded only by a lockstep comment. This promotes `KINDS_SECTION_VERSION` / `LABELS_SECTION_VERSION` to pub consts in aether-data beside the existing `INPUTS_SECTION_VERSION`, re-exports all three through `aether_actor::__macro_internals`, and replaces every writer literal with a token reference that const-folds to the same byte. The four near-identical inputs copy-block emitters collapse into one `emit_inputs_copy_block` helper. No behavior change — the emitted sections are byte-identical.

## Test plan

Workspace `cargo nextest run` (1898 passed / 8 skipped) covers the real component-load paths (guest config load, TestBench / FleetBench loads, `handlers_manifest.rs` against `INPUTS_SECTION_VERSION`), so a drifted byte would fail load. `git grep` confirms no `out[..] = 0x0N` writer literal survives. Full local validation green: fmt, clippy `-D warnings`, doc with strict rustdoc flags, wasm32 cross-build of the component crates.

## Generated by

`/implement` — agent execution of scoped issue #2458.
