### PR TITLE
refactor(capabilities): apply audit-quality cleanups to the fs module

### DIFF
--- a/crates/aether-capabilities/src/fs/adapter.rs
+++ b/crates/aether-capabilities/src/fs/adapter.rs
@@ -7,7 +7,9 @@
 use std::fs;
 use std::io;
 use std::io::ErrorKind;
-use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::path::Path;
+use std::path::PathBuf;
 use std::process;
 
 use super::kinds::FsError;
@@ -36,6 +38,14 @@ pub trait FileAdapter: Send + Sync {
     fn list(&self, prefix: &str) -> FsResult<Vec<String>>;
 }
 
+/// Access mode for a `LocalFileAdapter`. `ReadWrite` allows all four
+/// operations; `ReadOnly` rejects `write` and `delete` with `Forbidden`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Access {
+    ReadOnly,
+    ReadWrite,
+}
+
 /// Local-filesystem adapter. One instance per namespace root; the
 /// chassis boots one `LocalFileAdapter` per entry in the namespace
 /// config and registers them in an `AdapterRegistry`.
@@ -56,7 +66,7 @@ pub trait FileAdapter: Send + Sync {
 /// pre-compromised disk state.
 pub struct LocalFileAdapter {
     root: PathBuf,
-    writable: bool,
+    access: Access,
 }
 
 impl LocalFileAdapter {
@@ -70,14 +80,14 @@ impl LocalFileAdapter {
     // of `dirs::data_dir()` / a `PathBuf::from(env)` straight in and
     // we shadow-rebind to the canonicalised form.
     #[allow(clippy::needless_pass_by_value)]
-    pub fn new(root: PathBuf, writable: bool) -> io::Result<Self> {
+    pub fn new(root: PathBuf, access: Access) -> io::Result<Self> {
         fs::create_dir_all(&root)?;
         let root = root.canonicalize()?;
-        Ok(Self { root, writable })
+        Ok(Self { root, access })
     }
 
-    /// Exposed for tests and chassis boot logging. Not a routing
-    /// surface — components address by namespace name, never by root.
+    /// The adapter root, used in tests to inspect on-disk state.
+    #[cfg(test)]
     #[must_use]
     pub fn root(&self) -> &Path {
         &self.root
@@ -87,10 +97,8 @@ impl LocalFileAdapter {
         if path.starts_with('/') {
             return Err(FsError::Forbidden);
         }
-        for component in path.split('/') {
-            if component == ".." {
-                return Err(FsError::Forbidden);
-            }
+        if path.split('/').any(|c| c == "..") {
+            return Err(FsError::Forbidden);
         }
         Ok(self.root.join(path))
     }
@@ -99,14 +107,11 @@ impl LocalFileAdapter {
 impl FileAdapter for LocalFileAdapter {
     fn read(&self, path: &str) -> FsResult<Vec<u8>> {
         let resolved = self.resolve(path)?;
-        match fs::read(&resolved) {
-            Ok(bytes) => Ok(bytes),
-            Err(e) => Err(fs_error_from_std(e)),
-        }
+        fs::read(&resolved).map_err(fs_error_from_std)
     }
 
     fn write(&self, path: &str, bytes: &[u8]) -> FsResult<()> {
-        if !self.writable {
+        if !matches!(self.access, Access::ReadWrite) {
             return Err(FsError::Forbidden);
         }
         let resolved = self.resolve(path)?;
@@ -121,24 +126,18 @@ impl FileAdapter for LocalFileAdapter {
             .to_string();
         tmp.set_file_name(format!("{existing}.tmp-{}", process::id()));
         fs::write(&tmp, bytes).map_err(|e| FsError::AdapterError(e.to_string()))?;
-        match fs::rename(&tmp, &resolved) {
-            Ok(()) => Ok(()),
-            Err(e) => {
-                let _ = fs::remove_file(&tmp);
-                Err(FsError::AdapterError(e.to_string()))
-            }
-        }
+        fs::rename(&tmp, &resolved).map_err(|e| {
+            let _ = fs::remove_file(&tmp);
+            FsError::AdapterError(e.to_string())
+        })
     }
 
     fn delete(&self, path: &str) -> FsResult<()> {
-        if !self.writable {
+        if !matches!(self.access, Access::ReadWrite) {
             return Err(FsError::Forbidden);
         }
         let resolved = self.resolve(path)?;
-        match fs::remove_file(&resolved) {
-            Ok(()) => Ok(()),
-            Err(e) => Err(fs_error_from_std(e)),
-        }
+        fs::remove_file(&resolved).map_err(fs_error_from_std)
     }
 
     fn list(&self, prefix: &str) -> FsResult<Vec<String>> {

--- a/crates/aether-capabilities/src/fs/config.rs
+++ b/crates/aether-capabilities/src/fs/config.rs
@@ -120,7 +120,7 @@ impl aether_substrate::FromArgvThenEnv for NamespaceRoots {
 /// treats it as unset (preserving the prior `env_or_default`'s
 /// `Ok(s) if !s.is_empty()` guard); any non-empty value is a path.
 #[cfg(feature = "runtime")]
-pub(super) fn parse_dir(s: &str) -> Result<PathBuf, EmptyDir> {
+fn parse_dir(s: &str) -> Result<PathBuf, EmptyDir> {
     if s.is_empty() {
         Err(EmptyDir)
     } else {
@@ -132,7 +132,7 @@ pub(super) fn parse_dir(s: &str) -> Result<PathBuf, EmptyDir> {
 /// confique's parse path (`Err` + empty → `None`).
 #[cfg(feature = "runtime")]
 #[derive(Debug)]
-pub(super) struct EmptyDir;
+struct EmptyDir;
 
 #[cfg(feature = "runtime")]
 impl fmt::Display for EmptyDir {

--- a/crates/aether-capabilities/src/fs/kinds.rs
+++ b/crates/aether-capabilities/src/fs/kinds.rs
@@ -18,6 +18,7 @@
 //! root; `..` and absolute prefixes are rejected at the adapter
 //! boundary as `FsError::Forbidden`.
 
+use aether_data::{KindId, TransformId};
 use serde::{Deserialize, Serialize};
 
 /// Structured failure reason for an I/O request (ADR-0041 §1).
@@ -238,7 +239,7 @@ pub enum ListResult {
 pub enum FsFoldError {
     /// No transform with this `TransformId` is registered in the
     /// link-time inventory.
-    UnknownTransform(aether_data::TransformId),
+    UnknownTransform(TransformId),
     /// The transform at `at_index` has more than one input slot —
     /// it cannot sit in a linear fold where only one input is
     /// available.
@@ -247,8 +248,8 @@ pub enum FsFoldError {
     /// match the input kind of the transform at `at_index`.
     KindMismatch {
         at_index: u64,
-        expected: aether_data::KindId,
-        found: aether_data::KindId,
+        expected: KindId,
+        found: KindId,
     },
 }
 
@@ -300,7 +301,7 @@ pub struct FsFetch {
     /// Ordered list of transforms to apply. Each `TransformId` names
     /// a link-time `#[transform]` entry (ADR-0048); the chain is
     /// validated for linear composition before any compute runs.
-    pub transforms: Vec<aether_data::TransformId>,
+    pub transforms: Vec<TransformId>,
 }
 
 /// Reply to `FsFetch`. Both arms echo `namespace` + `path` for
@@ -317,7 +318,7 @@ pub enum FsFetchResult {
         /// `None` when the transform list was empty (raw read);
         /// `Some(k)` is the output kind of the last transform in
         /// the chain.
-        output_kind: Option<aether_data::KindId>,
+        output_kind: Option<KindId>,
         /// Wire-encoded output: raw file bytes when `output_kind` is
         /// `None`, or the last transform's encoded output value.
         data: Vec<u8>,

--- a/crates/aether-capabilities/src/fs/mod.rs
+++ b/crates/aether-capabilities/src/fs/mod.rs
@@ -1,6 +1,6 @@
 //! `aether.fs` cap. Owns the full ADR-0041 stack — its mail kinds
-//! ([`kinds`], ADR-0121), the [`FileAdapter`] trait + [`LocalFileAdapter`]
-//! (`adapter`), the [`AdapterRegistry`] + env-driven [`NamespaceRoots`]
+//! ([`kinds`], ADR-0121), the [`FileAdapter`] trait + `LocalFileAdapter`
+//! (`adapter`), the `AdapterRegistry` + env-driven [`NamespaceRoots`]
 //! (`registry`), and the [`FsCapability`] itself. Chassis mains
 //! resolve a [`NamespaceRoots`] (typically via `NamespaceRoots::from_env`)
 //! and pass it through `with_actor::<FsCapability>(roots)` — `init`
@@ -21,7 +21,8 @@ mod registry;
 
 pub use kinds::*;
 
-pub use adapter::{FileAdapter, FsResult, LocalFileAdapter};
+pub(crate) use adapter::{Access, LocalFileAdapter};
+pub use adapter::{FileAdapter, FsResult};
 pub use config::NamespaceRoots;
 // The `Config` derive on `NamespaceRoots` emits these sibling types in
 // `config`; chassis CLI / boot wiring addresses them through the
@@ -30,7 +31,7 @@ pub use config::NamespaceRoots;
 // `into_layer`) ride the type and need no re-export.
 #[cfg(feature = "runtime")]
 pub use config::{NamespaceRootsLayer, NamespaceRootsOverlay};
-pub use registry::{AdapterRegistry, build_registry};
+pub(crate) use registry::{AdapterRegistry, build_registry};
 
 // Handler-signature kinds resolve at file root through the `pub use
 // kinds::*` re-export above — `#[actor]` emits the `impl HandlesKind<K>

--- a/crates/aether-capabilities/src/fs/registry.rs
+++ b/crates/aether-capabilities/src/fs/registry.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::io;
 use std::sync::Arc;
 
-use super::adapter::{FileAdapter, LocalFileAdapter};
+use super::adapter::{Access, FileAdapter, LocalFileAdapter};
 use super::config::NamespaceRoots;
 
 /// Namespace → adapter table built at chassis boot. The cap reads
@@ -36,11 +36,6 @@ impl AdapterRegistry {
     pub fn get(&self, namespace: &str) -> Option<Arc<dyn FileAdapter>> {
         self.adapters.get(namespace).map(Arc::clone)
     }
-
-    #[must_use]
-    pub fn has(&self, namespace: &str) -> bool {
-        self.adapters.contains_key(namespace)
-    }
 }
 
 impl Default for AdapterRegistry {
@@ -57,9 +52,18 @@ impl Default for AdapterRegistry {
 /// wired.
 pub fn build_registry(roots: NamespaceRoots) -> io::Result<(Arc<AdapterRegistry>, NamespaceRoots)> {
     let mut registry = AdapterRegistry::new();
-    let save = Arc::new(LocalFileAdapter::new(roots.save.clone(), true)?);
-    let assets = Arc::new(LocalFileAdapter::new(roots.assets.clone(), false)?);
-    let config = Arc::new(LocalFileAdapter::new(roots.config.clone(), true)?);
+    let save = Arc::new(LocalFileAdapter::new(
+        roots.save.clone(),
+        Access::ReadWrite,
+    )?);
+    let assets = Arc::new(LocalFileAdapter::new(
+        roots.assets.clone(),
+        Access::ReadOnly,
+    )?);
+    let config = Arc::new(LocalFileAdapter::new(
+        roots.config.clone(),
+        Access::ReadWrite,
+    )?);
     registry.register("save", save as Arc<dyn FileAdapter>);
     registry.register("assets", assets as Arc<dyn FileAdapter>);
     registry.register("config", config as Arc<dyn FileAdapter>);

--- a/crates/aether-capabilities/src/fs/runtime.rs
+++ b/crates/aether-capabilities/src/fs/runtime.rs
@@ -40,10 +40,10 @@ pub use aether_substrate::transform::{FoldError, TransformRegistry};
 /// `pub`-enough to satisfy the `NativeActor::State` interface without
 /// exposing it as crate-public API.
 pub struct FsCapabilityState {
-    pub(super) registry: Arc<AdapterRegistry>,
+    registry: Arc<AdapterRegistry>,
     /// Link-time native-transform registry (ADR-0048 §2). Built once
     /// at `init`; immutable thereafter.
-    pub(super) transforms: TransformRegistry,
+    transforms: TransformRegistry,
 }
 
 pub fn map_fold_error(e: &FoldError) -> FsFoldError {
@@ -95,7 +95,7 @@ impl FsCapabilityState {
     /// `Builder::with_actor::<FsCapability>(roots)` which calls the
     /// generated `Lifecycle::init`; handler-unit tests that want to drive
     /// a handler without a full chassis hand a pre-built registry directly.
-    pub(crate) fn from_registry(registry: Arc<AdapterRegistry>) -> Self {
+    fn from_registry(registry: Arc<AdapterRegistry>) -> Self {
         Self {
             registry,
             transforms: TransformRegistry::from_inventory(),
@@ -387,7 +387,7 @@ impl NativeActor for FsCapability {
 mod tests {
     use super::super::FsCapability;
     use super::super::{
-        AdapterRegistry, Copy, CopyResult, Delete, DeleteResult, FileAdapter, FsError,
+        Access, AdapterRegistry, Copy, CopyResult, Delete, DeleteResult, FileAdapter, FsError,
         LocalFileAdapter, NamespaceAddr, NamespaceRoots, Read, ReadResult, Write, WriteResult,
     };
     use super::FsCapabilityState;
@@ -455,7 +455,7 @@ mod tests {
     #[test]
     fn resolve_rejects_parent_traversal() {
         let root = scratch_root("resolve-parent");
-        let a = LocalFileAdapter::new(root.clone(), true)
+        let a = LocalFileAdapter::new(root.clone(), Access::ReadWrite)
             .expect("test setup: LocalFileAdapter constructs on scratch root");
         assert!(matches!(a.read("../etc/passwd"), Err(FsError::Forbidden)));
         assert!(matches!(
@@ -468,7 +468,7 @@ mod tests {
     #[test]
     fn resolve_rejects_absolute() {
         let root = scratch_root("resolve-abs");
-        let a = LocalFileAdapter::new(root.clone(), true)
+        let a = LocalFileAdapter::new(root.clone(), Access::ReadWrite)
             .expect("test setup: LocalFileAdapter constructs on scratch root");
         assert!(matches!(a.read("/etc/passwd"), Err(FsError::Forbidden)));
         cleanup(&root);
@@ -477,7 +477,7 @@ mod tests {
     #[test]
     fn resolve_permits_dot_segments() {
         let root = scratch_root("resolve-dot");
-        let a = LocalFileAdapter::new(root.clone(), true)
+        let a = LocalFileAdapter::new(root.clone(), Access::ReadWrite)
             .expect("test setup: LocalFileAdapter constructs on scratch root");
         assert!(matches!(a.read("./nonexistent"), Err(FsError::NotFound)));
         cleanup(&root);
@@ -486,7 +486,7 @@ mod tests {
     #[test]
     fn read_missing_file_returns_not_found() {
         let root = scratch_root("read-missing");
-        let a = LocalFileAdapter::new(root.clone(), true)
+        let a = LocalFileAdapter::new(root.clone(), Access::ReadWrite)
             .expect("test setup: LocalFileAdapter constructs on scratch root");
         assert!(matches!(a.read("slot.bin"), Err(FsError::NotFound)));
         cleanup(&root);
@@ -495,7 +495,7 @@ mod tests {
     #[test]
     fn write_creates_parent_directories() {
         let root = scratch_root("write-parents");
-        let a = LocalFileAdapter::new(root.clone(), true)
+        let a = LocalFileAdapter::new(root.clone(), Access::ReadWrite)
             .expect("test setup: LocalFileAdapter constructs on scratch root");
         a.write("deep/sub/dir/slot.bin", b"hi")
             .expect("test setup: adapter writes through deep path");
@@ -510,7 +510,7 @@ mod tests {
     #[test]
     fn write_is_atomic_no_tmp_left_behind() {
         let root = scratch_root("write-atomic");
-        let a = LocalFileAdapter::new(root.clone(), true)
+        let a = LocalFileAdapter::new(root.clone(), Access::ReadWrite)
             .expect("test setup: LocalFileAdapter constructs on scratch root");
         a.write("slot.bin", &[0u8; 16])
             .expect("test setup: adapter accepts atomic write");
@@ -529,7 +529,7 @@ mod tests {
     #[test]
     fn write_on_read_only_returns_forbidden() {
         let root = scratch_root("write-readonly");
-        let a = LocalFileAdapter::new(root.clone(), false)
+        let a = LocalFileAdapter::new(root.clone(), Access::ReadOnly)
             .expect("test setup: read-only LocalFileAdapter constructs on scratch root");
         assert!(matches!(a.write("x.bin", &[]), Err(FsError::Forbidden)));
         cleanup(&root);
@@ -538,7 +538,7 @@ mod tests {
     #[test]
     fn delete_missing_returns_not_found() {
         let root = scratch_root("delete-missing");
-        let a = LocalFileAdapter::new(root.clone(), true)
+        let a = LocalFileAdapter::new(root.clone(), Access::ReadWrite)
             .expect("test setup: LocalFileAdapter constructs on scratch root");
         assert!(matches!(a.delete("ghost.bin"), Err(FsError::NotFound)));
         cleanup(&root);
@@ -547,7 +547,7 @@ mod tests {
     #[test]
     fn delete_removes_file() {
         let root = scratch_root("delete-works");
-        let a = LocalFileAdapter::new(root.clone(), true)
+        let a = LocalFileAdapter::new(root.clone(), Access::ReadWrite)
             .expect("test setup: LocalFileAdapter constructs on scratch root");
         a.write("slot.bin", b"x")
             .expect("test setup: adapter accepts write");
@@ -560,7 +560,7 @@ mod tests {
     #[test]
     fn delete_on_read_only_returns_forbidden() {
         let root = scratch_root("delete-readonly");
-        let a = LocalFileAdapter::new(root.clone(), false)
+        let a = LocalFileAdapter::new(root.clone(), Access::ReadOnly)
             .expect("test setup: read-only LocalFileAdapter constructs on scratch root");
         assert!(matches!(a.delete("x.bin"), Err(FsError::Forbidden)));
         cleanup(&root);
@@ -569,7 +569,7 @@ mod tests {
     #[test]
     fn list_empty_root_returns_empty_vec() {
         let root = scratch_root("list-empty");
-        let a = LocalFileAdapter::new(root.clone(), true)
+        let a = LocalFileAdapter::new(root.clone(), Access::ReadWrite)
             .expect("test setup: LocalFileAdapter constructs on scratch root");
         assert_eq!(
             a.list("").expect("test setup: adapter lists empty root"),
@@ -581,7 +581,7 @@ mod tests {
     #[test]
     fn list_returns_sorted_names_at_root() {
         let root = scratch_root("list-root");
-        let a = LocalFileAdapter::new(root.clone(), true)
+        let a = LocalFileAdapter::new(root.clone(), Access::ReadWrite)
             .expect("test setup: LocalFileAdapter constructs on scratch root");
         a.write("c.bin", b"")
             .expect("test setup: adapter accepts c.bin write");
@@ -599,7 +599,7 @@ mod tests {
     #[test]
     fn list_under_subdirectory() {
         let root = scratch_root("list-sub");
-        let a = LocalFileAdapter::new(root.clone(), true)
+        let a = LocalFileAdapter::new(root.clone(), Access::ReadWrite)
             .expect("test setup: LocalFileAdapter constructs on scratch root");
         a.write("saves/slot1.bin", b"")
             .expect("test setup: adapter accepts saves/slot1.bin write");
@@ -617,7 +617,7 @@ mod tests {
     #[test]
     fn list_missing_directory_returns_not_found() {
         let root = scratch_root("list-missing");
-        let a = LocalFileAdapter::new(root.clone(), true)
+        let a = LocalFileAdapter::new(root.clone(), Access::ReadWrite)
             .expect("test setup: LocalFileAdapter constructs on scratch root");
         assert!(matches!(a.list("nope"), Err(FsError::NotFound)));
         cleanup(&root);
@@ -625,9 +625,9 @@ mod tests {
 
     use aether_data::{SessionToken, Uuid};
 
-    fn build_save_only_registry(root: &Path, writable: bool) -> Arc<AdapterRegistry> {
+    fn build_save_only_registry(root: &Path, access: Access) -> Arc<AdapterRegistry> {
         let adapter: Arc<dyn FileAdapter> = Arc::new(
-            LocalFileAdapter::new(root.to_path_buf(), writable)
+            LocalFileAdapter::new(root.to_path_buf(), access)
                 .expect("test setup: LocalFileAdapter constructs on supplied root"),
         );
         let mut r = AdapterRegistry::new();
@@ -687,7 +687,7 @@ mod tests {
     #[test]
     fn cap_read_ok_replies_with_bytes() {
         let root = scratch_root("cap-read");
-        let reg = build_save_only_registry(&root, true);
+        let reg = build_save_only_registry(&root, Access::ReadWrite);
         reg.get("save")
             .expect("test setup: save adapter is registered")
             .write("slot.bin", &[9, 9, 9])
@@ -720,7 +720,7 @@ mod tests {
     #[test]
     fn cap_read_unknown_namespace_replies_err() {
         let root = scratch_root("cap-ns");
-        let reg = build_save_only_registry(&root, true);
+        let reg = build_save_only_registry(&root, Access::ReadWrite);
         let mut fix = TestFixture::new(reg);
         let mut ctx = make_ctx(&fix.transport, session_sender());
         let result = FsCapability::on_read(
@@ -748,7 +748,7 @@ mod tests {
     #[test]
     fn cap_read_not_found_replies_err() {
         let root = scratch_root("cap-nf");
-        let reg = build_save_only_registry(&root, true);
+        let reg = build_save_only_registry(&root, Access::ReadWrite);
         let mut fix = TestFixture::new(reg);
         let mut ctx = make_ctx(&fix.transport, session_sender());
         let result = FsCapability::on_read(
@@ -772,7 +772,7 @@ mod tests {
     #[test]
     fn cap_write_ok_persists_bytes() {
         let root = scratch_root("cap-write");
-        let reg = build_save_only_registry(&root, true);
+        let reg = build_save_only_registry(&root, Access::ReadWrite);
         let reg_clone = Arc::clone(&reg);
         let mut fix = TestFixture::new(reg);
         let mut ctx = make_ctx(&fix.transport, session_sender());
@@ -806,7 +806,7 @@ mod tests {
     #[test]
     fn cap_write_read_only_namespace_replies_forbidden() {
         let root = scratch_root("cap-ro");
-        let reg = build_save_only_registry(&root, false);
+        let reg = build_save_only_registry(&root, Access::ReadOnly);
         let mut fix = TestFixture::new(reg);
         let mut ctx = make_ctx(&fix.transport, session_sender());
         let result = FsCapability::on_write(
@@ -831,7 +831,7 @@ mod tests {
     #[test]
     fn cap_delete_then_read_surfaces_not_found() {
         let root = scratch_root("cap-del");
-        let reg = build_save_only_registry(&root, true);
+        let reg = build_save_only_registry(&root, Access::ReadWrite);
         let reg_clone = Arc::clone(&reg);
         reg.get("save")
             .expect("test setup: save adapter is registered")
@@ -878,13 +878,13 @@ mod tests {
     // Reach for the in-bundle integration suite if a future change
     // wants the full WAT roundtrip back as targeted coverage.
 
-    fn build_two_namespace_registry(root: &Path, save_writable: bool) -> Arc<AdapterRegistry> {
+    fn build_two_namespace_registry(root: &Path, save_access: Access) -> Arc<AdapterRegistry> {
         let save_adapter: Arc<dyn FileAdapter> = Arc::new(
-            LocalFileAdapter::new(root.join("save"), save_writable)
+            LocalFileAdapter::new(root.join("save"), save_access)
                 .expect("test setup: save LocalFileAdapter constructs"),
         );
         let assets_adapter: Arc<dyn FileAdapter> = Arc::new(
-            LocalFileAdapter::new(root.join("assets"), false)
+            LocalFileAdapter::new(root.join("assets"), Access::ReadOnly)
                 .expect("test setup: assets LocalFileAdapter constructs"),
         );
         let mut r = AdapterRegistry::new();
@@ -893,7 +893,7 @@ mod tests {
         Arc::new(r)
     }
 
-    fn ensure_ns_dirs(root: &Path) {
+    fn ensure_namespace_dirs(root: &Path) {
         fs::create_dir_all(root.join("save")).expect("test setup: save dir creates");
         fs::create_dir_all(root.join("assets")).expect("test setup: assets dir creates");
     }
@@ -901,10 +901,10 @@ mod tests {
     #[test]
     fn cap_copy_host_to_save_roundtrip() {
         let root = scratch_root("cap-copy-ok");
-        ensure_ns_dirs(&root);
+        ensure_namespace_dirs(&root);
         let src = root.join("source.bin");
         fs::write(&src, b"\x0a\x14\x1e").expect("test setup: write source file");
-        let reg = build_save_only_registry(&root.join("save"), true);
+        let reg = build_save_only_registry(&root.join("save"), Access::ReadWrite);
         let reg_clone = Arc::clone(&reg);
         let mut fix = TestFixture::new(reg);
         let mut ctx = make_ctx(&fix.transport, session_sender());
@@ -941,10 +941,10 @@ mod tests {
     #[test]
     fn cap_copy_unknown_destination_namespace_replies_unknown_namespace() {
         let root = scratch_root("cap-copy-unknown-ns");
-        ensure_ns_dirs(&root);
+        ensure_namespace_dirs(&root);
         let src = root.join("source.bin");
         fs::write(&src, b"y").expect("test setup: write source file");
-        let reg = build_save_only_registry(&root.join("save"), true);
+        let reg = build_save_only_registry(&root.join("save"), Access::ReadWrite);
         let mut fix = TestFixture::new(reg);
         let mut ctx = make_ctx(&fix.transport, session_sender());
         let result = FsCapability::on_copy(
@@ -974,8 +974,8 @@ mod tests {
     #[test]
     fn cap_copy_missing_host_from_replies_not_found() {
         let root = scratch_root("cap-copy-missing-src");
-        ensure_ns_dirs(&root);
-        let reg = build_save_only_registry(&root.join("save"), true);
+        ensure_namespace_dirs(&root);
+        let reg = build_save_only_registry(&root.join("save"), Access::ReadWrite);
         let mut fix = TestFixture::new(reg);
         let mut ctx = make_ctx(&fix.transport, session_sender());
         let result = FsCapability::on_copy(
@@ -1008,10 +1008,10 @@ mod tests {
     #[test]
     fn cap_copy_to_path_traversal_replies_forbidden() {
         let root = scratch_root("cap-copy-traversal");
-        ensure_ns_dirs(&root);
+        ensure_namespace_dirs(&root);
         let src = root.join("source.bin");
         fs::write(&src, b"z").expect("test setup: write source file");
-        let reg = build_save_only_registry(&root.join("save"), true);
+        let reg = build_save_only_registry(&root.join("save"), Access::ReadWrite);
         let mut fix = TestFixture::new(reg);
         let mut ctx = make_ctx(&fix.transport, session_sender());
         let result = FsCapability::on_copy(
@@ -1124,7 +1124,7 @@ mod tests {
         let assets = root.join("assets");
         fs::create_dir_all(&assets).expect("test setup: assets dir creates");
         fs::write(assets.join("data.bin"), b"raw payload").expect("test setup: seed data.bin");
-        let reg = build_two_namespace_registry(&root, true);
+        let reg = build_two_namespace_registry(&root, Access::ReadWrite);
         let mut fix = TestFixture::new(reg);
         let mut ctx = make_ctx(&fix.transport, session_sender());
         let result = FsCapability::on_fetch(
@@ -1161,7 +1161,7 @@ mod tests {
     #[test]
     fn on_fetch_unknown_namespace_returns_unknown_namespace() {
         let root = scratch_root("fetch-ns-unknown");
-        let reg = build_save_only_registry(&root, true);
+        let reg = build_save_only_registry(&root, Access::ReadWrite);
         let mut fix = TestFixture::new(reg);
         let mut ctx = make_ctx(&fix.transport, session_sender());
         let result = FsCapability::on_fetch(
@@ -1199,7 +1199,7 @@ mod tests {
         let encoded = input.encode_into_bytes();
         fs::write(assets.join("number.bin"), &encoded).expect("test setup: seed number.bin");
 
-        let reg = build_two_namespace_registry(&root, true);
+        let reg = build_two_namespace_registry(&root, Access::ReadWrite);
         let mut fix = TestFixture::new(reg);
         let mut ctx = make_ctx(&fix.transport, session_sender());
         let double_id = double_fs_transform_id();
@@ -1245,7 +1245,7 @@ mod tests {
         let assets = root.join("assets");
         fs::create_dir_all(&assets).expect("test setup: assets dir creates");
         fs::write(assets.join("data.bin"), b"ignored").expect("test setup: seed data.bin");
-        let reg = build_two_namespace_registry(&root, true);
+        let reg = build_two_namespace_registry(&root, Access::ReadWrite);
         let mut fix = TestFixture::new(reg);
         let mut ctx = make_ctx(&fix.transport, session_sender());
 
@@ -1288,7 +1288,7 @@ mod tests {
         let assets = root.join("assets");
         fs::create_dir_all(&assets).expect("test setup: assets dir creates");
         fs::write(assets.join("garbage.bin"), [0xFF_u8]).expect("test setup: seed garbage.bin");
-        let reg = build_two_namespace_registry(&root, true);
+        let reg = build_two_namespace_registry(&root, Access::ReadWrite);
         let mut fix = TestFixture::new(reg);
         let mut ctx = make_ctx(&fix.transport, session_sender());
         let double_id = double_fs_transform_id();
@@ -1323,7 +1323,7 @@ mod tests {
         let input = TestNumber { value: 1, tag: 0 };
         let encoded = input.encode_into_bytes();
         fs::write(assets.join("number.bin"), &encoded).expect("test setup: seed number.bin");
-        let reg = build_two_namespace_registry(&root, true);
+        let reg = build_two_namespace_registry(&root, Access::ReadWrite);
         let mut fix = TestFixture::new(reg);
         let mut ctx = make_ctx(&fix.transport, session_sender());
         let boom_id = boom_fs_transform_id();

--- a/crates/aether-capabilities/src/gemini/runtime.rs
+++ b/crates/aether-capabilities/src/gemini/runtime.rs
@@ -16,7 +16,7 @@ use super::{
     GeminiCapability, GeminiError, GroundingMetadata, LyriaGenerate, LyriaGenerateResult,
     NanobananaGenerate, NanobananaGenerateResult, lyria, nanobanana,
 };
-use crate::fs::{FileAdapter, LocalFileAdapter};
+use crate::fs::{Access, FileAdapter, LocalFileAdapter};
 use crate::shared::contentgen::adapter::{
     AdapterUsage, GeminiAdapter, GeminiImageRequest, GeminiMusicRequest, GeminiResponse,
 };
@@ -268,8 +268,8 @@ pub fn read_reference_images(paths: &[String]) -> Result<Vec<Vec<u8>>, GeminiErr
         return Ok(Vec::new());
     }
     let root = gen_root();
-    let adapter =
-        LocalFileAdapter::new(root, true).map_err(|e| GeminiError::AdapterError(e.to_string()))?;
+    let adapter = LocalFileAdapter::new(root, Access::ReadWrite)
+        .map_err(|e| GeminiError::AdapterError(e.to_string()))?;
     let mut out = Vec::with_capacity(paths.len());
     for path in paths {
         let bytes = adapter

--- a/crates/aether-capabilities/src/shared/contentgen/staging.rs
+++ b/crates/aether-capabilities/src/shared/contentgen/staging.rs
@@ -11,13 +11,13 @@
 //! `save`-namespace root the `aether.fs` cap already resolves
 //! (`AETHER_SAVE_DIR` → `dirs::data_dir()/aether/save`). The staged
 //! file lands under `gen/` within that root and writes atomically via
-//! the existing [`LocalFileAdapter`] (tmp + rename), so a crash
+//! the existing `LocalFileAdapter` (tmp + rename), so a crash
 //! mid-write leaves no torn file.
 
 use std::env;
 use std::path::{Path, PathBuf};
 
-use crate::fs::FsError;
+use crate::fs::{Access, FsError};
 use uuid::Uuid;
 
 use crate::fs::{FileAdapter, LocalFileAdapter};
@@ -59,7 +59,7 @@ pub fn gen_root() -> PathBuf {
 
 /// Stage `bytes` as a fresh `gen/<uuid>.<ext>` file under the resolved
 /// [`gen_root`] and return the relative path the reply carries. Writes
-/// atomically via the `save`-namespace [`LocalFileAdapter`] (the same
+/// atomically via the `save`-namespace `LocalFileAdapter` (the same
 /// tmp + rename the `aether.fs` cap uses). `ext` is the extension
 /// without the dot (`"png"`, `"wav"`).
 ///
@@ -74,7 +74,7 @@ pub fn stage_gen_output(bytes: &[u8], ext: &str) -> Result<String, FsError> {
 /// env-resolving wrapper; tests pin a scratch root so they never touch
 /// the user's real save dir.
 pub fn stage_gen_output_under(root: &Path, bytes: &[u8], ext: &str) -> Result<String, FsError> {
-    let adapter = LocalFileAdapter::new(root.to_path_buf(), true)
+    let adapter = LocalFileAdapter::new(root.to_path_buf(), Access::ReadWrite)
         .map_err(|e| FsError::AdapterError(e.to_string()))?;
     let path = format!("{GEN_PREFIX}/{}.{ext}", Uuid::new_v4());
     adapter.write(&path, bytes)?;
@@ -84,7 +84,7 @@ pub fn stage_gen_output_under(root: &Path, bytes: &[u8], ext: &str) -> Result<St
 #[cfg(test)]
 mod tests {
     use super::{GEN_PREFIX, stage_gen_output_under};
-    use crate::fs::{FileAdapter, LocalFileAdapter};
+    use crate::fs::{Access, FileAdapter, LocalFileAdapter};
     use crate::test_chassis::{cleanup, scratch_dir};
     use std::path::PathBuf;
 
@@ -102,7 +102,7 @@ mod tests {
         assert_eq!(path.rsplit('.').next(), Some("png"));
         // Read it back through a fresh adapter on the same root — the
         // file exists and the bytes round-trip verbatim.
-        let adapter = LocalFileAdapter::new(root.clone(), true)
+        let adapter = LocalFileAdapter::new(root.clone(), Access::ReadWrite)
             .expect("test setup: adapter constructs on scratch root");
         assert_eq!(
             adapter


### PR DESCRIPTION
Closes #2445.

## Summary

Applies the confirmed `audit-quality` cleanups to the `fs` submodule of `aether-capabilities` (`src/fs/`) — non-mechanical, judgment-level fixes a lint can't decide, no behaviour change and no wire change. Control-flow `match` blocks over `std::fs` results collapse to `.map_err(fs_error_from_std)`; the `resolve` traversal loop becomes `path.split('/').any(|c| c == "..")`; the boolean-blind `writable: bool` on `LocalFileAdapter::new` becomes a two-variant `enum Access { ReadOnly, ReadWrite }`; over-broad `pub` is narrowed; and small naming/import tidies (`ensure_ns_dirs` → `ensure_namespace_dirs`, hoisted `aether_data` imports). Lands on top of #2444's `unreachable_pub` floor.

## Test plan

Workspace `cargo nextest run` (1898 passed) — the existing fs runtime tests exercise both access modes and pin the traversal behaviour (`resolve_rejects_parent_traversal` / `_rejects_absolute` / `_permits_dot_segments`). Full local validation green: fmt, clippy `-D warnings`, doc with strict rustdoc flags.

## Generated by

`/implement` — agent execution of scoped issue #2445.
