### PR TITLE
fix(actor-derive): vec<u8> bytes specialization misses qualified u8, forking kind id

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -524,6 +524,11 @@ fn field_type_schema_expr(ty: &Type) -> TokenStream2 {
     }
 }
 
+/// Returns `true` when `ty` is syntactically a `Vec<u8>` (or any qualified
+/// spelling whose outer type ends in `Vec` and whose element type's last
+/// segment is `u8`, e.g. `Vec<core::primitive::u8>`). The check is purely
+/// syntactic — a type alias (`type Blob = Vec<u8>`) is not resolved by the
+/// proc macro and falls through to the generic `Vec` schema.
 fn is_vec_u8(ty: &Type) -> bool {
     let Type::Path(tp) = ty else { return false };
     let Some(seg) = tp.path.segments.last() else {
@@ -538,7 +543,13 @@ fn is_vec_u8(ty: &Type) -> bool {
     let Some(GenericArgument::Type(Type::Path(inner))) = args.args.first() else {
         return false;
     };
-    inner.path.is_ident("u8")
+    // Match on the last segment so qualified spellings like
+    // `core::primitive::u8` are recognized alongside bare `u8`.
+    inner
+        .path
+        .segments
+        .last()
+        .is_some_and(|seg| seg.ident == "u8")
 }
 
 /// Walk a field-type syntactic tree and reject `HashMap` anywhere

--- a/crates/aether-actor-derive/tests/derive.rs
+++ b/crates/aether-actor-derive/tests/derive.rs
@@ -289,3 +289,45 @@ fn btreemap_kind_id_stable_across_invocations() {
     // sanity, not an exhaustive test of FNV-1a).
     assert_ne!(<Headers as Kind>::ID, <Lookup as Kind>::ID);
 }
+
+// Two structs that are wire-identical except for how `u8` is spelled —
+// bare `Vec<u8>` vs qualified `Vec<core::primitive::u8>`. Both must lower
+// to `SchemaType::Bytes` and hash to the same `Kind::ID`.
+#[derive(Serialize, Deserialize, aether_data::Kind, aether_data::Schema)]
+#[kind(name = "test.blob_bare")]
+#[allow(dead_code)]
+struct BlobBare {
+    data: Vec<u8>,
+}
+
+// `#[allow(...)]` is intentional: `core::primitive::u8` is the qualified
+// spelling the test exercises — removing the path would defeat the tripwire.
+#[allow(unused_qualifications, clippy::absolute_paths)]
+#[derive(Serialize, Deserialize, aether_data::Kind, aether_data::Schema)]
+#[kind(name = "test.blob_bare")]
+#[allow(dead_code)]
+struct BlobQualified {
+    data: Vec<core::primitive::u8>,
+}
+
+#[test]
+fn qualified_vec_u8_canonicalizes_to_bytes_and_matches_bare_kind_id() {
+    // Tripwire: qualified and bare `Vec<u8>` must canonicalize to the same
+    // Bytes schema, hence the same `Kind::ID`. Before the `is_vec_u8`
+    // last-segment fix, `Vec<core::primitive::u8>` fell through to
+    // `Vec(Scalar(U8))` and hashed to a different id — a silent wire-identity
+    // fork for any non-Rust peer that agrees by `(name, schema)`.
+    let SchemaType::Struct { fields, .. } = &<BlobQualified as Schema>::SCHEMA else {
+        panic!("expected Struct schema");
+    };
+    assert_eq!(
+        fields[0].ty,
+        SchemaType::Bytes,
+        "Vec<core::primitive::u8> field must lower to Bytes, not Vec(Scalar(U8))"
+    );
+    assert_eq!(
+        <BlobBare as Kind>::ID,
+        <BlobQualified as Kind>::ID,
+        "bare Vec<u8> and qualified Vec<core::primitive::u8> must share the same Kind::ID"
+    );
+}


### PR DESCRIPTION
Closes #2456.

## Summary

`#[derive(Schema, Kind)]` lowers a `Vec<u8>` field to `SchemaType::Bytes`, but the gate `is_vec_u8` recognized the element type only as a bare single-segment `u8` (`is_ident("u8")`), so a field typed `Vec<core::primitive::u8>` fell through to `Vec(Scalar(U8))` — and since `Kind::ID` is fnv1a over the canonical schema bytes, two wire-identical declarations forked their `KindId` purely on how `u8` was spelled. This relaxes the element check to a last-segment ident comparison (mirroring the outer `Vec` test the same function already uses), so qualified spellings match. A doc note records that the specialization keys on the syntactic `u8` token, so a type alias still falls through.

## Test plan

New tripwire test asserting a `Vec<core::primitive::u8>` field lowers to `SchemaType::Bytes` and that its `Kind::ID` equals the same struct written with bare `Vec<u8>` — fails pre-fix (different id), passes after. Workspace `cargo nextest run` (1899 passed, one new). Full local validation green.

## Generated by

`/implement` — agent execution of scoped issue #2456.
