### PR TITLE
fix(actor-derive): wasm dispatch reports decode failures as handled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,7 @@ dependencies = [
  "signal-hook",
  "thiserror 2.0.18",
  "tracing",
+ "wasmtime",
  "wgpu",
  "winit",
 ]

--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -3412,9 +3412,13 @@ fn validate_fallback_sig(sig: &Signature) -> syn::Result<()> {
 /// handler method. Wire shape (cast vs structured) is picked at K's
 /// `Kind` derive site, not here — `Kind::decode_from_bytes` carries
 /// the per-K body — so this dispatcher never sees the wire choice.
-/// Returns `DISPATCH_HANDLED` on a match or when the `#[fallback]`
-/// ran; returns `DISPATCH_UNKNOWN_KIND` on strict-receiver miss so
-/// the substrate's scheduler logs the drop (issue #142).
+/// Returns `DISPATCH_HANDLED` only when a recognized kind decoded and
+/// its handler ran (or when the `#[fallback]` ran); a recognized kind
+/// whose payload fails to decode falls through to the tail, as does an
+/// unrecognized kind, yielding `DISPATCH_UNKNOWN_KIND` on a strict
+/// receiver so the substrate's scheduler logs the drop (issue #142).
+/// This mirrors the native arm, which routes a failed decode to the
+/// fallback / unknown-kind path (iamacoffeepot/aether#2455).
 fn build_dispatch_body(handlers: &[HandlerFn], fallback: Option<&FallbackFn>) -> TokenStream2 {
     let arms = handlers.iter().map(|h| {
         let k = &h.kind_ty;
@@ -3449,8 +3453,14 @@ fn build_dispatch_body(handlers: &[HandlerFn], fallback: Option<&FallbackFn>) ->
                     __aether_mail.decode_kind::<#k>()
                 {
                     #call
+                    return ::aether_actor::DISPATCH_HANDLED;
                 }
-                return ::aether_actor::DISPATCH_HANDLED;
+                // A recognized kind id whose payload fails to decode falls
+                // through to the tail (the `#[fallback]`, else
+                // `DISPATCH_UNKNOWN_KIND`), mirroring the native arm's
+                // `return Option::None` rather than reporting HANDLED for a
+                // handler that never ran (iamacoffeepot/aether#2455). No later
+                // arm matches, since the id already matched this one.
             }
         }
     });

--- a/crates/aether-substrate-bundle/Cargo.toml
+++ b/crates/aether-substrate-bundle/Cargo.toml
@@ -169,6 +169,11 @@ serde_json = { workspace = true }
 # tests; no `src/` consumer, so it rides dev-dependencies only.
 aether-codec = { path = "../aether-codec" }
 aether-test-fixtures-kinds = { path = "../aether-test-fixtures/aether-test-fixtures-kinds" }
+# iamacoffeepot/aether#2455: the dispatch-decode-failure regression test drives
+# the `Probe` fixture directly through the pub `Component::instantiate` / `deliver`
+# API, which needs `wasmtime::{Engine, Linker, Module}` in scope to build the
+# host engine + linker. Same workspace pin `aether-substrate` links against.
+wasmtime = { workspace = true }
 # iamacoffeepot/aether#1472: the FleetBench Transform-DAG test builds a
 # descriptor with `output_kind_id == Vec4::ID` and casts the observer's
 # surfaced 16 bytes back to a `Vec4` for the `M·v` assertion, so it names

--- a/crates/aether-substrate-bundle/tests/dispatch_decode_failure.rs
+++ b/crates/aether-substrate-bundle/tests/dispatch_decode_failure.rs
@@ -1,0 +1,67 @@
+//! iamacoffeepot/aether#2455 regression: the wasm `#[actor]` dispatch table must
+//! report a recognized kind id with an undecodable payload as
+//! `DISPATCH_UNKNOWN_KIND` (falling through to the strict-receiver tail), not
+//! `DISPATCH_HANDLED`. Pre-fix the macro returned `DISPATCH_HANDLED`
+//! unconditionally once the kind id matched, so a corrupt/truncated payload for a
+//! known kind reported success while the handler never ran and no reply was
+//! emitted — diverging from the native arm (which routes the same case to the
+//! fallback / unknown-kind path) and hanging a request-shaped caller to its
+//! settlement timeout with no diagnostic.
+//!
+//! Drives the strict `Probe` fixture (namespace `test_fixture_probe`, no
+//! `#[fallback]`, an `on_set_render(SetRender)` handler) directly through the pub
+//! `Component::instantiate` / `deliver` API: deliver a `Mail` carrying
+//! `SetRender::ID` (a `#[repr(C)]` 4-byte cast-shape kind) with a 2-byte payload,
+//! which the cast decoder rejects on its `len() == size_of` check, and assert the
+//! dispatch return code. Gated on `require_runtime` like the sibling integration
+//! tests, so it skips cleanly on a driverless / wasm-not-built box.
+
+use std::fs;
+use std::sync::Arc;
+
+use aether_data::Kind;
+use aether_substrate::actor::wasm::host_fns;
+use aether_substrate::{Component, ComponentCtx, HubOutbound, Mail, MailboxId, Mailer, Registry};
+use aether_substrate_bundle::test_bench::test_helpers::require_runtime;
+use aether_test_fixtures_kinds::SetRender;
+use wasmtime::{Engine, Linker, Module};
+
+#[test]
+fn known_kind_bad_payload_reports_unknown_kind_not_handled() {
+    let Some(wasm_path) = require_runtime("aether_test_fixtures_bundle") else {
+        return;
+    };
+    let wasm = fs::read(&wasm_path).expect("read fixture wasm");
+
+    let engine = Engine::default();
+    let mut linker: Linker<ComponentCtx> = Linker::new(&engine);
+    host_fns::register(&mut linker).expect("register host fns");
+    let module = Module::new(&engine, &wasm).expect("compile fixture module");
+
+    let registry = Arc::new(Registry::new());
+    let mailer = Arc::new(Mailer::new(Arc::clone(&registry)));
+    let ctx = ComponentCtx::new(MailboxId(0), registry, mailer, HubOutbound::disconnected());
+
+    // `type_tag = None` instantiates the module's entry actor — `Probe`, the
+    // strict (no-`#[fallback]`) receiver (export!(Probe, ProbeWithConfig) makes
+    // the first-listed `Probe` the entry).
+    let mut component = Component::instantiate(&engine, &linker, &module, ctx, &[], None)
+        .expect("instantiate Probe fixture");
+
+    // `SetRender` is a `#[repr(C)]` 4-byte cast-shape kind; a 2-byte payload
+    // fails `decode_cast`'s `len() == size_of` check, so the matched dispatch
+    // arm's `decode_kind::<SetRender>()` is `None`.
+    let mail = Mail::new(MailboxId(0), SetRender::ID, vec![0u8, 0u8], 1);
+    let rc = component.deliver(&mail).expect("deliver");
+
+    // Tripwire: pre-fix the arm returned `DISPATCH_HANDLED` (0) once the kind id
+    // matched, regardless of decode outcome; post-fix the failed decode falls
+    // through to the strict tail → `DISPATCH_UNKNOWN_KIND` (1).
+    assert_eq!(
+        rc,
+        aether_actor::DISPATCH_UNKNOWN_KIND,
+        "a recognized kind with an undecodable payload must fall through to the \
+         tail (DISPATCH_UNKNOWN_KIND), not report DISPATCH_HANDLED",
+    );
+    assert_ne!(rc, aether_actor::DISPATCH_HANDLED);
+}


### PR DESCRIPTION
Closes #2455.

## Summary

The `#[actor]` macro's wasm dispatch table treated "recognized kind id, undecodable payload" as a success: in `build_dispatch_body`, `return DISPATCH_HANDLED` sat *after* the decode `if let` rather than inside its `Some` arm, so a `None` decode still reported HANDLED to the scheduler — the handler never ran, no reply was emitted, and the `#[fallback]` / unknown-kind drop-log never fired, so a request-shaped caller hung to its settlement timeout with no diagnostic. The native arm routes the same case to fallback / unknown-kind accounting. This moves `return DISPATCH_HANDLED` inside the `Some` arm so a matched-kind/failed-decode falls through to the tail, restoring transport parity (a strict receiver yields `DISPATCH_UNKNOWN_KIND`, which the scheduler already warns).

## Test plan

New regression test `crates/aether-substrate-bundle/tests/dispatch_decode_failure.rs` drives the strict `Probe` fixture through the pub `Component::instantiate`/`deliver` API with a recognized kind id and a wrong-length payload, asserting `DISPATCH_UNKNOWN_KIND` not `DISPATCH_HANDLED`. Confirmed a true tripwire by reverting the codegen (pre-fix returns HANDLED, post-fix UNKNOWN_KIND). Workspace `cargo nextest run` (1901 passed). Full local validation green.

## Generated by

`/implement` — agent execution of scoped issue #2455.
