### PR TITLE
refactor(capabilities): apply audit-quality cleanups to the anthropic, audio, component and engine modules

### DIFF
--- a/crates/aether-capabilities/src/anthropic/api.rs
+++ b/crates/aether-capabilities/src/anthropic/api.rs
@@ -122,8 +122,7 @@ pub fn parse_messages_response(
                 .iter()
                 .filter(|b| b.get("type").and_then(Value::as_str) == Some("text"))
                 .filter_map(|b| b.get("text").and_then(Value::as_str))
-                .collect::<Vec<_>>()
-                .join("")
+                .collect::<String>()
         })
         .ok_or_else(|| "response missing content array".to_string())?;
 
@@ -133,12 +132,12 @@ pub fn parse_messages_response(
         .unwrap_or(fallback_model)
         .to_string();
 
-    let usage_obj = parsed.get("usage");
-    let input_tokens = usage_obj
+    let usage = parsed.get("usage");
+    let input_tokens = usage
         .and_then(|u| u.get("input_tokens"))
         .and_then(Value::as_u64)
         .unwrap_or(0);
-    let output_tokens = usage_obj
+    let output_tokens = usage
         .and_then(|u| u.get("output_tokens"))
         .and_then(Value::as_u64)
         .unwrap_or(0);
@@ -160,7 +159,7 @@ fn clamp_u32(v: u64) -> u32 {
 }
 
 fn elapsed_millis(started: Instant) -> u32 {
-    clamp_u32(u64::try_from(started.elapsed().as_millis()).unwrap_or_else(|_| u64::from(u32::MAX)))
+    u32::try_from(started.elapsed().as_millis()).unwrap_or(u32::MAX)
 }
 
 #[cfg(test)]

--- a/crates/aether-capabilities/src/anthropic/error.rs
+++ b/crates/aether-capabilities/src/anthropic/error.rs
@@ -23,7 +23,7 @@ pub const UNAUTHORIZED_SENTINEL: &str = "unauthorized";
 /// `UNAUTHORIZED_SENTINEL`, and the `status=<n>` prefix the Messages
 /// backend uses) and falls back to `AdapterError` for everything else.
 #[must_use]
-pub fn adapter_error_to_typed(raw: &str) -> AnthropicError {
+pub(super) fn adapter_error_to_typed(raw: &str) -> AnthropicError {
     if raw == CLI_NOT_FOUND {
         return AnthropicError::CliNotFound;
     }
@@ -57,7 +57,7 @@ pub fn adapter_error_to_typed(raw: &str) -> AnthropicError {
 /// - everything else non-2xx → `AdapterError` carrying the status +
 ///   body snippet
 #[must_use]
-pub fn status_to_error(status: u16, retry_after_millis: Option<u32>, body: &str) -> AnthropicError {
+fn status_to_error(status: u16, retry_after_millis: Option<u32>, body: &str) -> AnthropicError {
     match status {
         401 | 403 => AnthropicError::Unauthorized,
         429 => AnthropicError::RateLimited { retry_after_millis },

--- a/crates/aether-capabilities/src/anthropic/mod.rs
+++ b/crates/aether-capabilities/src/anthropic/mod.rs
@@ -26,6 +26,7 @@
 
 mod api;
 mod cli;
+mod config;
 mod error;
 mod kinds;
 pub use kinds::{
@@ -37,7 +38,7 @@ use std::time::Duration;
 use crate::shared::contentgen::adapter::{AnthropicAdapter, AnthropicRequest, AnthropicResponse};
 
 pub use api::UreqAnthropicAdapter;
-pub use cli::ClaudeCliAdapter;
+pub(crate) use cli::ClaudeCliAdapter;
 pub use config::{AnthropicConfig, AnthropicConfigLayer, AnthropicOverlay};
 
 /// Default per-cap concurrency bound when `AETHER_ANTHROPIC_MAX_IN_FLIGHT`
@@ -130,13 +131,9 @@ impl AnthropicAdapter for CombinedAnthropicAdapter {
     }
 }
 
-mod config;
-
 /// Convert an adapter error string into the typed `AnthropicError`.
 /// Shared by both result paths.
-fn map_adapter_error(raw: &str) -> AnthropicError {
-    error::adapter_error_to_typed(raw)
-}
+use error::adapter_error_to_typed as map_adapter_error;
 
 /// `aether.anthropic` mailbox cap **identity** (ADR-0122 identity/runtime
 /// split). A ZST carrying only the addressing — `Addressable`

--- a/crates/aether-capabilities/src/anthropic/runtime.rs
+++ b/crates/aether-capabilities/src/anthropic/runtime.rs
@@ -28,7 +28,7 @@ pub use aether_substrate::chassis::error::BootError;
 /// Which send path a request rode. The generate handler threads it
 /// into the worker closure to pick the blocking call + result kind.
 #[derive(Copy, Clone)]
-pub enum SendPath {
+enum SendPath {
     Messages,
     Cli,
 }
@@ -43,8 +43,8 @@ pub enum SendPath {
 /// private module keeps it `pub`-enough to satisfy the `NativeActor::State`
 /// interface without exposing it as crate-public API.
 pub struct AnthropicCapabilityState {
-    pub(super) adapter: Arc<dyn AnthropicAdapter>,
-    pub(super) tasks: TaskQueue,
+    adapter: Arc<dyn AnthropicAdapter>,
+    tasks: TaskQueue,
 }
 
 #[cfg(test)]
@@ -73,7 +73,7 @@ impl AnthropicCapabilityState {
     /// supported-model table rejects it; `true` to proceed. Empty
     /// `supported` = accept-any (disabled / CLI passthrough); the CLI
     /// path always passes through.
-    pub fn gate_model(
+    fn gate_model(
         &self,
         ctx: &mut NativeCtx<'_, Manual>,
         path: SendPath,
@@ -95,7 +95,7 @@ impl AnthropicCapabilityState {
 
     /// Reply an `Err` synchronously (model validation failure)
     /// before any dispatch.
-    pub fn reply_err(
+    fn reply_err(
         ctx: &mut NativeCtx<'_, Manual>,
         path: SendPath,
         request_id: u64,
@@ -341,7 +341,7 @@ mod tests {
         AnthropicRequest, AnthropicResponse, StubAnthropicAdapter,
     };
     use crate::test_chassis::{decode_session_reply, drive_task_completion, test_mailer_and_rx};
-    use aether_data::{Kind, MailboxId, SessionToken, Source, SourceAddr, Uuid};
+    use aether_data::{Kind, MailId, MailboxId, SessionToken, Source, SourceAddr, Uuid};
     use aether_substrate::actor::native::binding::NativeBinding;
     use aether_substrate::actor::native::ctx::NativeCtx;
     use aether_substrate::mail::mailer::Mailer;
@@ -403,12 +403,8 @@ mod tests {
             Arc::clone(&mailer),
             cap_mailbox,
         ));
-        let mut ctx = NativeCtx::new_dispatching(
-            &transport,
-            session_sender(),
-            aether_data::MailId::NONE,
-            aether_data::MailId::NONE,
-        );
+        let mut ctx =
+            NativeCtx::new_dispatching(&transport, session_sender(), MailId::NONE, MailId::NONE);
         AnthropicCapability::on_messages_send(
             &mut state,
             &mut ctx,
@@ -450,12 +446,8 @@ mod tests {
             Arc::clone(&mailer),
             cap_mailbox,
         ));
-        let mut ctx = NativeCtx::new_dispatching(
-            &transport,
-            session_sender(),
-            aether_data::MailId::NONE,
-            aether_data::MailId::NONE,
-        );
+        let mut ctx =
+            NativeCtx::new_dispatching(&transport, session_sender(), MailId::NONE, MailId::NONE);
         AnthropicCapability::on_messages_send(
             &mut state,
             &mut ctx,
@@ -501,12 +493,8 @@ mod tests {
             4,
         );
         let transport = Arc::new(NativeBinding::new_for_test(Arc::clone(mailer), cap_mailbox));
-        let mut ctx = NativeCtx::new_dispatching(
-            &transport,
-            session_sender(),
-            aether_data::MailId::NONE,
-            aether_data::MailId::NONE,
-        );
+        let mut ctx =
+            NativeCtx::new_dispatching(&transport, session_sender(), MailId::NONE, MailId::NONE);
         AnthropicCapability::on_cli_send(
             &mut state,
             &mut ctx,
@@ -611,12 +599,8 @@ mod tests {
             Arc::clone(&mailer),
             cap_mailbox,
         ));
-        let mut ctx = NativeCtx::new_dispatching(
-            &transport,
-            session_sender(),
-            aether_data::MailId::NONE,
-            aether_data::MailId::NONE,
-        );
+        let mut ctx =
+            NativeCtx::new_dispatching(&transport, session_sender(), MailId::NONE, MailId::NONE);
         AnthropicCapability::on_cli_send(
             &mut state,
             &mut ctx,
@@ -655,12 +639,8 @@ mod tests {
             Arc::clone(&mailer),
             cap_mailbox,
         ));
-        let mut ctx = NativeCtx::new_dispatching(
-            &transport,
-            session_sender(),
-            aether_data::MailId::NONE,
-            aether_data::MailId::NONE,
-        );
+        let mut ctx =
+            NativeCtx::new_dispatching(&transport, session_sender(), MailId::NONE, MailId::NONE);
         AnthropicCapability::on_messages_send(
             &mut state,
             &mut ctx,

--- a/crates/aether-capabilities/src/audio/runtime/decode.rs
+++ b/crates/aether-capabilities/src/audio/runtime/decode.rs
@@ -111,18 +111,28 @@ fn downmix_to_mono(interleaved: &[f32], channels: usize) -> Vec<f32> {
     if channels <= 1 {
         return interleaved.to_vec();
     }
-    let frame_count = interleaved.len() / channels;
     // Channel count is a small positive integer — the reciprocal is exact
     // enough for an average; the cast can't lose meaningful precision.
     #[allow(clippy::cast_precision_loss)]
     let inv = 1.0 / channels as f32;
-    let mut mono = Vec::with_capacity(frame_count);
-    for frame in 0..frame_count {
-        let start = frame * channels;
-        let sum: f32 = interleaved[start..start + channels].iter().sum();
-        mono.push(sum * inv);
+    interleaved
+        .chunks_exact(channels)
+        .map(|frame| frame.iter().sum::<f32>() * inv)
+        .collect()
+}
+
+/// Read a WAV asset's source sample rate from its header (ADR-0103 §6).
+/// Bank assembly needs it to scale a region's loop frame offsets by the
+/// load-time resample ratio; [`decode_wav_to_mono`] consumes the same
+/// header but only returns the resampled PCM. Parses the header chunk
+/// only — the sample data is not read.
+pub(super) fn wav_source_rate(bytes: &[u8]) -> Result<u32, String> {
+    let reader = hound::WavReader::new(Cursor::new(bytes)).map_err(|e| e.to_string())?;
+    let rate = reader.spec().sample_rate;
+    if rate == 0 {
+        return Err("zero sample rate".to_owned());
     }
-    mono
+    Ok(rate)
 }
 
 /// Linearly resample a mono stream from `source_rate` to `target_rate`.

--- a/crates/aether-capabilities/src/audio/runtime/instrument.rs
+++ b/crates/aether-capabilities/src/audio/runtime/instrument.rs
@@ -28,10 +28,10 @@ pub enum Wave {
 /// instantiation so the hot loop is add-only.
 #[derive(Copy, Clone, Debug)]
 pub struct Adsr {
-    pub attack_s: f32,
-    pub decay_s: f32,
+    pub attack_secs: f32,
+    pub decay_secs: f32,
     pub sustain: f32,
-    pub release_s: f32,
+    pub release_secs: f32,
 }
 
 /// Optional per-patch pitch envelope on the oscillator kernel — the
@@ -96,9 +96,9 @@ pub struct PartialBankDef {
     pub brightness_tilt: f32,
     /// Global attack ramp (seconds). Near-zero for a struck string,
     /// long for the pad's slow swell.
-    pub attack_s: f32,
+    pub attack_secs: f32,
     /// Global release ramp (seconds) on `note_off` — the damper.
-    pub release_s: f32,
+    pub release_secs: f32,
 }
 
 /// Voice kernel a patch selects. The five original patches stay
@@ -134,10 +134,10 @@ pub const BUILTINS: &[InstrumentDef] = &[
         voice: VoiceDef::Oscillator {
             wave: Wave::Sine,
             adsr: Adsr {
-                attack_s: 0.01,
-                decay_s: 0.08,
+                attack_secs: 0.01,
+                decay_secs: 0.08,
                 sustain: 0.7,
-                release_s: 0.18,
+                release_secs: 0.18,
             },
         },
         base_amp: 0.35,
@@ -148,10 +148,10 @@ pub const BUILTINS: &[InstrumentDef] = &[
         voice: VoiceDef::Oscillator {
             wave: Wave::Square,
             adsr: Adsr {
-                attack_s: 0.005,
-                decay_s: 0.12,
+                attack_secs: 0.005,
+                decay_secs: 0.12,
                 sustain: 0.6,
-                release_s: 0.12,
+                release_secs: 0.12,
             },
         },
         base_amp: 0.22,
@@ -162,10 +162,10 @@ pub const BUILTINS: &[InstrumentDef] = &[
         voice: VoiceDef::Oscillator {
             wave: Wave::Triangle,
             adsr: Adsr {
-                attack_s: 0.02,
-                decay_s: 0.1,
+                attack_secs: 0.02,
+                decay_secs: 0.1,
                 sustain: 0.7,
-                release_s: 0.2,
+                release_secs: 0.2,
             },
         },
         base_amp: 0.32,
@@ -176,10 +176,10 @@ pub const BUILTINS: &[InstrumentDef] = &[
         voice: VoiceDef::Oscillator {
             wave: Wave::Saw,
             adsr: Adsr {
-                attack_s: 0.01,
-                decay_s: 0.15,
+                attack_secs: 0.01,
+                decay_secs: 0.15,
                 sustain: 0.55,
-                release_s: 0.15,
+                release_secs: 0.15,
             },
         },
         base_amp: 0.2,
@@ -190,10 +190,10 @@ pub const BUILTINS: &[InstrumentDef] = &[
         voice: VoiceDef::Oscillator {
             wave: Wave::Saw,
             adsr: Adsr {
-                attack_s: 0.002,
-                decay_s: 0.35,
+                attack_secs: 0.002,
+                decay_secs: 0.35,
                 sustain: 0.0,
-                release_s: 0.05,
+                release_secs: 0.05,
             },
         },
         base_amp: 0.3,
@@ -211,8 +211,8 @@ pub const BUILTINS: &[InstrumentDef] = &[
             decay_spread: 0.6,
             detune: 0.000_8,
             brightness_tilt: 0.5,
-            attack_s: 0.002,
-            release_s: 0.15,
+            attack_secs: 0.002,
+            release_secs: 0.15,
         }),
         base_amp: 0.3,
         pitch_sweep: None,
@@ -229,8 +229,8 @@ pub const BUILTINS: &[InstrumentDef] = &[
             decay_spread: 0.4,
             detune: 0.001_2,
             brightness_tilt: 0.7,
-            attack_s: 0.003,
-            release_s: 0.1,
+            attack_secs: 0.003,
+            release_secs: 0.1,
         }),
         base_amp: 0.28,
         pitch_sweep: None,
@@ -247,8 +247,8 @@ pub const BUILTINS: &[InstrumentDef] = &[
             decay_spread: 0.0,
             detune: 0.000_6,
             brightness_tilt: 0.25,
-            attack_s: 0.8,
-            release_s: 0.6,
+            attack_secs: 0.8,
+            release_secs: 0.6,
         }),
         base_amp: 0.18,
         pitch_sweep: None,
@@ -262,10 +262,10 @@ pub const BUILTINS: &[InstrumentDef] = &[
         voice: VoiceDef::Oscillator {
             wave: Wave::Sine,
             adsr: Adsr {
-                attack_s: 0.001,
-                decay_s: 0.18,
+                attack_secs: 0.001,
+                decay_secs: 0.18,
                 sustain: 0.0,
-                release_s: 0.02,
+                release_secs: 0.02,
             },
         },
         base_amp: 0.9,
@@ -285,10 +285,10 @@ pub const BUILTINS: &[InstrumentDef] = &[
                 tone_mix: 0.0,
             },
             adsr: Adsr {
-                attack_s: 0.001,
-                decay_s: 0.04,
+                attack_secs: 0.001,
+                decay_secs: 0.04,
                 sustain: 0.0,
-                release_s: 0.02,
+                release_secs: 0.02,
             },
         },
         base_amp: 0.4,
@@ -305,10 +305,10 @@ pub const BUILTINS: &[InstrumentDef] = &[
                 tone_mix: 0.25,
             },
             adsr: Adsr {
-                attack_s: 0.001,
-                decay_s: 0.12,
+                attack_secs: 0.001,
+                decay_secs: 0.12,
                 sustain: 0.0,
-                release_s: 0.03,
+                release_secs: 0.03,
             },
         },
         base_amp: 0.5,
@@ -334,11 +334,10 @@ pub fn builtin_names() -> Vec<&'static str> {
 /// The first instrument id available to a loaded bank — one past the
 /// last compiled-in built-in. The cap's `next_instrument_id` starts
 /// here, the synth's bank table begins at the same offset.
+#[allow(clippy::cast_possible_truncation)]
 pub fn builtin_id_ceiling() -> u8 {
     // `BUILTINS` is a small fixed table (11 today); the length fits a
     // `u8` with room to spare, and a load count that overflowed `u8`
     // would be absurd.
-    #[allow(clippy::cast_possible_truncation)]
-    let n = BUILTINS.len() as u8;
-    n
+    BUILTINS.len() as u8
 }

--- a/crates/aether-capabilities/src/audio/runtime/mod.rs
+++ b/crates/aether-capabilities/src/audio/runtime/mod.rs
@@ -35,6 +35,7 @@ mod config;
 mod decode;
 mod event;
 mod instrument;
+mod pipeline;
 mod sample;
 mod schedule;
 mod sfz;
@@ -50,11 +51,11 @@ use super::AudioCapability;
 pub use self::config::{AudioConfig, AudioConfigLayer, AudioOverlay};
 use self::decode::decode_wav_to_mono;
 use self::event::AudioEventSender;
+use self::pipeline::{AudioBuildError, try_build_pipeline};
 use self::sample::{
     BankAssembly, SampleSlot, assemble_bank, bank_name_from_path, join_fs, sfz_dir,
 };
 use self::sfz::parse_sfz;
-use self::synth::{AudioBuildError, try_build_pipeline};
 use super::kinds::{
     LoadInstrument, LoadInstrumentResult, NoteOff, NoteOn, PlayTrack, PlayTrackResult, Schedule,
     ScheduleResult, SetMasterGain, SetMasterGainResult, StopTrack,
@@ -153,7 +154,11 @@ impl AudioCapabilityState {
     /// Pop the oldest `play_track` parked under `(namespace, path)` —
     /// the FIFO correlation for the `aether.fs.read` reply. Removes the
     /// key's queue when it empties.
-    pub(super) fn take_pending(&mut self, namespace: &str, path: &str) -> Option<PendingTrack> {
+    pub(super) fn take_pending_track(
+        &mut self,
+        namespace: &str,
+        path: &str,
+    ) -> Option<PendingTrack> {
         let key = (namespace.to_owned(), path.to_owned());
         let queue = self.pending_tracks.get_mut(&key)?;
         let pending = queue.pop_front();
@@ -164,7 +169,7 @@ impl AudioCapabilityState {
     }
 
     /// Pop the oldest `load_instrument` parked under the `.sfz`'s
-    /// `(namespace, path)`. Sibling of [`Self::take_pending`].
+    /// `(namespace, path)`. Sibling of [`Self::take_pending_track`].
     pub(super) fn take_pending_instrument(
         &mut self,
         namespace: &str,
@@ -203,7 +208,7 @@ impl AudioCapabilityState {
         path: String,
         bytes: Vec<u8>,
     ) {
-        let Some(target_rate_f32) = self.sample_rate else {
+        let Some(device_rate) = self.sample_rate else {
             ctx.reply_to(
                 pending.source,
                 &PlayTrackResult::Err {
@@ -218,7 +223,7 @@ impl AudioCapabilityState {
         // Device rates are small positive integers — the round trip back
         // through u32 is exact.
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-        let target_rate = target_rate_f32 as u32;
+        let target_rate = device_rate as u32;
 
         let context = TrackDecodeContext {
             sender_mailbox: pending.sender_mailbox,
@@ -358,7 +363,7 @@ impl AudioCapabilityState {
             .assemblies
             .remove(&assembly_id)
             .expect("assembly present — checked above");
-        let Some(target_rate_f32) = self.sample_rate else {
+        let Some(device_rate) = self.sample_rate else {
             ctx.reply_to(
                 assembly.source,
                 &LoadInstrumentResult::Err {
@@ -370,7 +375,7 @@ impl AudioCapabilityState {
             return;
         };
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-        let target_rate = target_rate_f32 as u32;
+        let target_rate = device_rate as u32;
 
         let BankAssembly {
             source,
@@ -636,7 +641,7 @@ impl NativeActor for AudioCapability {
         ctx: &mut NativeCtx<'_>,
         mail: Schedule,
     ) -> ScheduleResult {
-        let Some(s) = state.sender.as_ref() else {
+        let Some(sender) = state.sender.as_ref() else {
             return ScheduleResult::Err {
                 error: "audio pipeline not initialised on this desktop substrate".to_owned(),
             };
@@ -674,7 +679,7 @@ impl NativeActor for AudioCapability {
             sender_mailbox: sender_mailbox_id(ctx.reply_target()),
             events: mail.events,
         };
-        if s.push(ev).is_err() {
+        if sender.push(ev).is_err() {
             return ScheduleResult::Err {
                 error: "audio event queue full — schedule dropped".to_owned(),
             };
@@ -749,7 +754,7 @@ impl NativeActor for AudioCapability {
                 path,
                 bytes,
             } => {
-                if let Some(pending) = state.take_pending(&namespace, &path) {
+                if let Some(pending) = state.take_pending_track(&namespace, &path) {
                     state.start_track_decode(ctx, &pending, namespace, path, bytes);
                 } else if let Some(pending) = state.take_pending_instrument(&namespace, &path) {
                     state.on_sfz_loaded(ctx, &pending, namespace, path, &bytes);
@@ -764,7 +769,7 @@ impl NativeActor for AudioCapability {
                 error,
             } => {
                 let reason = format!("file read failed: {error:?}");
-                if let Some(pending) = state.take_pending(&namespace, &path) {
+                if let Some(pending) = state.take_pending_track(&namespace, &path) {
                     ctx.reply_to(
                         pending.source,
                         &PlayTrackResult::Err {
@@ -1183,10 +1188,10 @@ mod tests {
     /// sustain) so a kernel test reads the raw waveform without the
     /// envelope shaping the level.
     const HOLD_ADSR: Adsr = Adsr {
-        attack_s: 0.0,
-        decay_s: 0.0,
+        attack_secs: 0.0,
+        decay_secs: 0.0,
         sustain: 1.0,
-        release_s: 0.1,
+        release_secs: 0.1,
     };
 
     /// Build an oscillator voice and collect `n` samples at 48 kHz.
@@ -1530,13 +1535,13 @@ mod tests {
             .unwrap();
         let mut buf = vec![0.0f32; 64];
         synth.fill(&mut buf, 1);
-        assert!((synth.master_gain_value() - 1.0).abs() < f32::EPSILON);
+        assert!((synth.master_gain() - 1.0).abs() < f32::EPSILON);
 
         sender
             .push(AudioEvent::SetMasterGain { gain: -0.2 })
             .unwrap();
         synth.fill(&mut buf, 1);
-        assert!(synth.master_gain_value().abs() < f32::EPSILON);
+        assert!(synth.master_gain().abs() < f32::EPSILON);
     }
 
     #[test]

--- a/crates/aether-capabilities/src/audio/runtime/pipeline.rs
+++ b/crates/aether-capabilities/src/audio/runtime/pipeline.rs
@@ -1,0 +1,116 @@
+//! The cpal output pipeline (ADR-0039). Builds the device stream, hands its
+//! callback a [`Synth`], and surfaces the build failures the cap relays.
+
+use core::fmt;
+
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+
+use super::event::{AudioEventSender, new_event_channel};
+use super::instrument::{builtin_count, builtin_names};
+use super::synth::Synth;
+
+/// Handle to a running cpal pipeline. Lives on the audio worker
+/// thread for the entire run — `cpal::Stream` is `!Send` on macOS,
+/// so the stream is constructed on, owned by, and dropped from the
+/// same thread. Dropping the pipeline silences every voice and tears
+/// down the cpal stream.
+pub struct AudioPipeline {
+    pub sender: AudioEventSender,
+    /// The device output rate the synth runs at. The cap reads it back
+    /// (via the init channel) as the resample target for track decode
+    /// (ADR-0103 §1) — decode happens on the dispatcher, not here.
+    pub sample_rate: u32,
+    pub _stream: cpal::Stream,
+}
+
+#[derive(Debug)]
+pub enum AudioBuildError {
+    NoDevice,
+    RateUnsupported(u32),
+    ConfigQuery(String),
+    StreamBuild(String),
+    StreamPlay(String),
+}
+
+impl fmt::Display for AudioBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoDevice => write!(f, "no default audio output device"),
+            Self::RateUnsupported(r) => write!(f, "requested sample rate {r} Hz unsupported"),
+            Self::ConfigQuery(e) => write!(f, "config query failed: {e}"),
+            Self::StreamBuild(e) => write!(f, "stream build failed: {e}"),
+            Self::StreamPlay(e) => write!(f, "stream play failed: {e}"),
+        }
+    }
+}
+
+pub fn try_build_pipeline(
+    requested_sample_rate: Option<u32>,
+) -> Result<AudioPipeline, AudioBuildError> {
+    let host = cpal::default_host();
+    let device = host
+        .default_output_device()
+        .ok_or(AudioBuildError::NoDevice)?;
+
+    let config = match requested_sample_rate {
+        Some(rate) => {
+            find_config_for_rate(&device, rate).ok_or(AudioBuildError::RateUnsupported(rate))?
+        }
+        None => device
+            .default_output_config()
+            .map_err(|e| AudioBuildError::ConfigQuery(e.to_string()))?
+            .config(),
+    };
+
+    let sample_rate = config.sample_rate;
+    let channels = config.channels;
+
+    let (sender, queue) = new_event_channel();
+    // Audio sample rates are bounded well below 2^24 — exact in f32.
+    #[allow(clippy::cast_precision_loss)]
+    let mut synth = Synth::new(queue, sample_rate as f32);
+
+    let stream = device
+        .build_output_stream(
+            &config,
+            move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
+                synth.fill(data, channels as usize);
+            },
+            |err| {
+                tracing::warn!(
+                    target: "aether_substrate::audio",
+                    error = %err,
+                    "cpal stream error",
+                );
+            },
+            None,
+        )
+        .map_err(|e| AudioBuildError::StreamBuild(e.to_string()))?;
+
+    stream
+        .play()
+        .map_err(|e| AudioBuildError::StreamPlay(e.to_string()))?;
+
+    tracing::info!(
+        target: "aether_substrate::audio",
+        sample_rate,
+        channels,
+        instruments = builtin_count(),
+        builtin_names = ?builtin_names(),
+        "audio pipeline started",
+    );
+
+    Ok(AudioPipeline {
+        sender,
+        sample_rate,
+        _stream: stream,
+    })
+}
+
+pub fn find_config_for_rate(device: &cpal::Device, rate: u32) -> Option<cpal::StreamConfig> {
+    device
+        .supported_output_configs()
+        .ok()?
+        .find(|cfg| rate >= cfg.min_sample_rate() && rate <= cfg.max_sample_rate())
+        .map(|cfg| cfg.with_sample_rate(rate).config())
+}

--- a/crates/aether-capabilities/src/audio/runtime/sample.rs
+++ b/crates/aether-capabilities/src/audio/runtime/sample.rs
@@ -2,28 +2,27 @@
 //! repitched sample voice, and the off-realtime SFZ + WAV bank assembly the
 //! `load_instrument` loader runs.
 
-use std::io::Cursor;
 use std::sync::Arc;
 
 use aether_data::Source;
 
-use super::decode::decode_wav_to_mono;
+use super::decode::{decode_wav_to_mono, wav_source_rate};
 use super::sfz::{SfzLoop, SfzRegion};
 use super::voice::BankStage;
 
 /// Attack ramp (seconds) wrapping a sample voice — a short swell so a
 /// re-pitched recording doesn't click on at full level (ADR-0103 §6,
 /// the partial bank's ramp shape).
-pub const SAMPLE_ATTACK_SECS: f32 = 0.003;
+const SAMPLE_ATTACK_SECS: f32 = 0.003;
 
 /// Release ramp (seconds) on `note_off` for a sample voice — the
 /// damper that ends a held note faster than the sample's natural decay.
-pub const SAMPLE_RELEASE_SECS: f32 = 0.08;
+const SAMPLE_RELEASE_SECS: f32 = 0.08;
 
 /// Base amplitude of a sample voice before velocity scaling. Sampled
 /// recordings already carry their own level; this trims headroom so a
 /// dense chord doesn't clip past the soft-clip.
-pub const SAMPLE_BASE_AMP: f32 = 0.6;
+const SAMPLE_BASE_AMP: f32 = 0.6;
 
 /// A region's sustain loop in device-rate coordinates (ADR-0103 §6).
 /// The SFZ frame offsets are scaled at bank assembly by the load-time
@@ -92,28 +91,28 @@ impl SampleBank {
 pub struct SampleVoice {
     /// Device-rate mono PCM of the selected region, shared with the
     /// bank.
-    pub pcm: Arc<[f32]>,
+    pcm: Arc<[f32]>,
     /// Fractional read position into `pcm`, advanced by `rate` each
     /// output sample.
-    pub pos: f32,
+    pos: f32,
     /// Playback rate ratio `2^((pitch − pitch_keycenter) / 12)` — the
     /// repitch from the region's root note. The PCM is already at the
     /// device rate, so this is the only resampling the hot loop does.
-    pub rate: f32,
+    rate: f32,
     /// Velocity-scaled amplitude the interpolated sample is multiplied
     /// by.
-    pub amplitude: f32,
+    amplitude: f32,
     /// The sustain loop bounds (device-rate fractional positions), or
     /// `None` for an unlooped region.
-    pub loop_region: Option<SampleLoop>,
+    loop_region: Option<SampleLoop>,
     /// Attack / release ramp, the partial bank's shape.
-    pub stage: BankStage,
-    pub attack_s: f32,
-    pub release_s: f32,
+    stage: BankStage,
+    attack_secs: f32,
+    release_secs: f32,
     /// Set once an unlooped region's read position walks off the end of
     /// the PCM, or the release ramp completes. A looped voice never sets
     /// it from exhaustion — it ends through the release ramp.
-    pub finished: bool,
+    finished: bool,
 }
 
 impl SampleVoice {
@@ -133,14 +132,14 @@ impl SampleVoice {
             amplitude: SAMPLE_BASE_AMP * v,
             loop_region,
             stage: BankStage::Attack { t: 0.0 },
-            attack_s: SAMPLE_ATTACK_SECS,
-            release_s: SAMPLE_RELEASE_SECS,
+            attack_secs: SAMPLE_ATTACK_SECS,
+            release_secs: SAMPLE_RELEASE_SECS,
             finished: false,
         }
     }
 
     pub fn note_off(&mut self) {
-        self.stage.begin_release(self.attack_s);
+        self.stage.begin_release(self.attack_secs);
     }
 
     pub fn done(&self) -> bool {
@@ -150,8 +149,8 @@ impl SampleVoice {
     /// Advance the attack/release ramp one sample, returning its current
     /// level — the shared bank ramp over the sample voice's own
     /// attack/release times.
-    pub fn advance_ramp(&mut self, dt: f32) -> f32 {
-        self.stage.advance(dt, self.attack_s, self.release_s)
+    fn advance_ramp(&mut self, dt: f32) -> f32 {
+        self.stage.advance(dt, self.attack_secs, self.release_secs)
     }
 
     // Read position and PCM lengths are bounded well below 2^24 for any
@@ -181,7 +180,7 @@ impl SampleVoice {
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss
     )]
-    pub fn next_unlooped(&mut self, len: usize, ramp: f32) -> f32 {
+    fn next_unlooped(&mut self, len: usize, ramp: f32) -> f32 {
         let i = self.pos.floor() as usize;
         if i >= len {
             self.finished = true;
@@ -210,7 +209,7 @@ impl SampleVoice {
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss
     )]
-    pub fn next_looped(&mut self, lp: SampleLoop, len: usize, ramp: f32) -> f32 {
+    fn next_looped(&mut self, lp: SampleLoop, len: usize, ramp: f32) -> f32 {
         // `pos < loop_end <= len` holds going in, so `i` is in range.
         let i = (self.pos.floor() as usize).min(len - 1);
         let a = self.pcm[i];
@@ -350,20 +349,6 @@ pub fn assemble_bank(
     }))
 }
 
-/// Read a WAV asset's source sample rate from its header (ADR-0103 §6).
-/// Bank assembly needs it to scale a region's loop frame offsets by the
-/// load-time resample ratio; `decode_wav_to_mono` consumes the same
-/// header but only returns the resampled PCM. Parses the header chunk
-/// only — the sample data is not read.
-pub fn wav_source_rate(bytes: &[u8]) -> Result<u32, String> {
-    let reader = hound::WavReader::new(Cursor::new(bytes)).map_err(|e| e.to_string())?;
-    let rate = reader.spec().sample_rate;
-    if rate == 0 {
-        return Err("zero sample rate".to_owned());
-    }
-    Ok(rate)
-}
-
 /// Scale a region's source-frame loop bounds into device-rate fractional
 /// positions (ADR-0103 §6): multiply by the resample ratio
 /// `target_rate / source_rate` — the same ratio the PCM was resampled
@@ -371,7 +356,7 @@ pub fn wav_source_rate(bytes: &[u8]) -> Result<u32, String> {
 /// `None` when the resampled region is too short to loop or the bounds
 /// collapse after clamping, degrading the region to unlooped.
 #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
-pub fn scale_loop(
+fn scale_loop(
     lp: SfzLoop,
     source_rate: u32,
     target_rate: u32,
@@ -396,10 +381,7 @@ pub fn scale_loop(
 /// `/`), or `""` when the path has no directory. A bank's samples are
 /// addressed relative to the `.sfz`'s own directory (ADR-0103 §5).
 pub fn sfz_dir(path: &str) -> &str {
-    match path.rsplit_once('/') {
-        Some((dir, _)) => dir,
-        None => "",
-    }
+    path.rsplit_once('/').map_or("", |(dir, _)| dir)
 }
 
 /// Join a sample path onto the `.sfz`'s directory. An empty directory

--- a/crates/aether-capabilities/src/audio/runtime/synth.rs
+++ b/crates/aether-capabilities/src/audio/runtime/synth.rs
@@ -1,20 +1,18 @@
 //! The synth mixer aggregate (ADR-0039). `Synth` owns the voice pool, the
 //! track lanes, the loaded banks, and the scheduled heap, and renders the
-//! summed output the cpal callback drains; plus the cpal pipeline build.
+//! summed output the cpal callback drains.
 
-use core::fmt;
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::sync::Arc;
 
-use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use crossbeam_queue::ArrayQueue;
 
 use aether_data::MailboxId;
 
 use super::super::kinds::ScheduledNote;
-use super::event::{AudioEvent, AudioEventSender, new_event_channel};
-use super::instrument::{BUILTINS, builtin_count, builtin_names, instrument_by_id};
+use super::event::AudioEvent;
+use super::instrument::{BUILTINS, instrument_by_id};
 use super::sample::{SampleBank, SampleVoice};
 use super::schedule::{ScheduledEntry, millis_to_frames};
 use super::track::{TRACK_FADE_SECS, TrackVoice};
@@ -23,33 +21,33 @@ use super::voice::{MAX_VOICES, Voice, VoiceKernel, build_builtin_kernel};
 /// Whole-process synth state. Lives on the cpal callback thread;
 /// the cap communicates via the event queue.
 pub struct Synth {
-    pub events: Arc<ArrayQueue<AudioEvent>>,
-    pub voices: Vec<Voice>,
+    events: Arc<ArrayQueue<AudioEvent>>,
+    voices: Vec<Voice>,
     /// Track playback lane (ADR-0103 §3) — separate from `voices` so a
     /// track is never counted against `MAX_VOICES` nor voice-stolen.
-    pub tracks: Vec<TrackVoice>,
+    tracks: Vec<TrackVoice>,
     /// Loaded sampled-instrument banks (ADR-0103 §4), appended in load
     /// order. Index `i` is `instrument_id` `BUILTINS.len() + i`, so a
     /// `note_on` whose id walks past the built-ins indexes here. The cap
     /// assigns ids the same way, so the two stay in lockstep.
-    pub banks: Vec<Arc<SampleBank>>,
-    pub sample_rate: f32,
-    pub master_gain: f32,
+    banks: Vec<Arc<SampleBank>>,
+    sample_rate: f32,
+    master_gain: f32,
     /// Monotonically increasing counter stamped into each `Voice::seq`
     /// at allocation. Voice-steal uses the minimum value to locate the
     /// oldest voice regardless of pool order.
-    pub next_seq: u64,
+    next_seq: u64,
     /// Running output-frame counter (ADR-0104). Advanced by the frame
     /// count of every `fill`; the timebase scheduled events are placed
     /// against and fire from. Callback-owned, so no locking.
-    pub frame_clock: u64,
+    frame_clock: u64,
     /// Pending scheduled note events ordered by due frame (ADR-0104),
     /// a min-heap via `Reverse`. `fill` pops the events that fall on
     /// each frame and routes them through the note-on / note-off paths.
-    pub scheduled: BinaryHeap<Reverse<ScheduledEntry>>,
+    scheduled: BinaryHeap<Reverse<ScheduledEntry>>,
     /// Monotonic stamp threaded into each `ScheduledEntry::seq` so that
     /// events on the same due frame fire in batch-arrival order.
-    pub next_schedule_seq: u64,
+    next_schedule_seq: u64,
 }
 
 impl Synth {
@@ -101,21 +99,24 @@ impl Synth {
         velocity: u8,
         instrument_id: u8,
     ) {
-        let kernel = if let Some(def) = instrument_by_id(instrument_id) {
-            Some(build_builtin_kernel(
-                sender_mailbox,
-                instrument_id,
-                pitch,
-                velocity,
-                def,
-                self.sample_rate,
-            ))
-        } else {
-            self.bank_for(instrument_id).and_then(|bank| {
-                bank.select(pitch, velocity)
-                    .map(|region| VoiceKernel::Sample(SampleVoice::new(pitch, velocity, region)))
+        let kernel = instrument_by_id(instrument_id)
+            .map(|def| {
+                build_builtin_kernel(
+                    sender_mailbox,
+                    instrument_id,
+                    pitch,
+                    velocity,
+                    def,
+                    self.sample_rate,
+                )
             })
-        };
+            .or_else(|| {
+                self.bank_for(instrument_id).and_then(|bank| {
+                    bank.select(pitch, velocity).map(|region| {
+                        VoiceKernel::Sample(SampleVoice::new(pitch, velocity, region))
+                    })
+                })
+            });
         let Some(kernel) = kernel else {
             tracing::warn!(
                 target: "aether_substrate::audio",
@@ -324,11 +325,11 @@ impl Synth {
             // for the sample it falls on — sample-accurate by
             // construction (ADR-0104).
             let absolute = self.frame_clock + frame as u64;
-            loop {
-                match self.scheduled.peek() {
-                    Some(Reverse(top)) if top.due_frame <= absolute => {}
-                    _ => break,
-                }
+            while self
+                .scheduled
+                .peek()
+                .is_some_and(|Reverse(top)| top.due_frame <= absolute)
+            {
                 let Reverse(entry) = self
                     .scheduled
                     .pop()
@@ -354,22 +355,8 @@ impl Synth {
         // Advance the clock by this block so the next drain anchors
         // scheduled offsets against the right receipt frame (ADR-0104).
         self.frame_clock += frames as u64;
-        let mut i = 0;
-        while i < self.voices.len() {
-            if self.voices[i].done() {
-                self.voices.swap_remove(i);
-            } else {
-                i += 1;
-            }
-        }
-        let mut t = 0;
-        while t < self.tracks.len() {
-            if self.tracks[t].done() {
-                self.tracks.swap_remove(t);
-            } else {
-                t += 1;
-            }
-        }
+        self.voices.retain(|v| !v.done());
+        self.tracks.retain(|t| !t.done());
     }
 
     #[cfg(test)]
@@ -383,7 +370,7 @@ impl Synth {
     }
 
     #[cfg(test)]
-    pub fn master_gain_value(&self) -> f32 {
+    pub fn master_gain(&self) -> f32 {
         self.master_gain
     }
 
@@ -401,114 +388,4 @@ impl Synth {
     pub fn scheduled_count(&self) -> usize {
         self.scheduled.len()
     }
-}
-
-/// Handle to a running cpal pipeline. Lives on the audio worker
-/// thread for the entire run — `cpal::Stream` is `!Send` on macOS,
-/// so the stream is constructed on, owned by, and dropped from the
-/// same thread. Dropping the pipeline silences every voice and tears
-/// down the cpal stream.
-pub struct AudioPipeline {
-    pub sender: AudioEventSender,
-    /// The device output rate the synth runs at. The cap reads it back
-    /// (via the init channel) as the resample target for track decode
-    /// (ADR-0103 §1) — decode happens on the dispatcher, not here.
-    pub sample_rate: u32,
-    pub _stream: cpal::Stream,
-}
-
-#[derive(Debug)]
-pub enum AudioBuildError {
-    NoDevice,
-    RateUnsupported(u32),
-    ConfigQuery(String),
-    StreamBuild(String),
-    StreamPlay(String),
-}
-
-impl fmt::Display for AudioBuildError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::NoDevice => write!(f, "no default audio output device"),
-            Self::RateUnsupported(r) => write!(f, "requested sample rate {r} Hz unsupported"),
-            Self::ConfigQuery(e) => write!(f, "config query failed: {e}"),
-            Self::StreamBuild(e) => write!(f, "stream build failed: {e}"),
-            Self::StreamPlay(e) => write!(f, "stream play failed: {e}"),
-        }
-    }
-}
-
-pub fn try_build_pipeline(
-    requested_sample_rate: Option<u32>,
-) -> Result<AudioPipeline, AudioBuildError> {
-    let host = cpal::default_host();
-    let device = host
-        .default_output_device()
-        .ok_or(AudioBuildError::NoDevice)?;
-
-    let config = match requested_sample_rate {
-        Some(rate) => {
-            find_config_for_rate(&device, rate).ok_or(AudioBuildError::RateUnsupported(rate))?
-        }
-        None => device
-            .default_output_config()
-            .map_err(|e| AudioBuildError::ConfigQuery(e.to_string()))?
-            .config(),
-    };
-
-    let sample_rate = config.sample_rate;
-    let channels = config.channels;
-
-    let (sender, queue) = new_event_channel();
-    // Audio sample rates are bounded well below 2^24 — exact in f32.
-    #[allow(clippy::cast_precision_loss)]
-    let mut synth = Synth::new(queue, sample_rate as f32);
-
-    let stream = device
-        .build_output_stream(
-            &config,
-            move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
-                synth.fill(data, channels as usize);
-            },
-            |err| {
-                tracing::warn!(
-                    target: "aether_substrate::audio",
-                    error = %err,
-                    "cpal stream error",
-                );
-            },
-            None,
-        )
-        .map_err(|e| AudioBuildError::StreamBuild(e.to_string()))?;
-
-    stream
-        .play()
-        .map_err(|e| AudioBuildError::StreamPlay(e.to_string()))?;
-
-    tracing::info!(
-        target: "aether_substrate::audio",
-        sample_rate,
-        channels,
-        instruments = builtin_count(),
-        builtin_names = ?builtin_names(),
-        "audio pipeline started",
-    );
-
-    Ok(AudioPipeline {
-        sender,
-        sample_rate,
-        _stream: stream,
-    })
-}
-
-pub fn find_config_for_rate(device: &cpal::Device, rate: u32) -> Option<cpal::StreamConfig> {
-    let configs = device.supported_output_configs().ok()?;
-    for cfg in configs {
-        let min = cfg.min_sample_rate();
-        let max = cfg.max_sample_rate();
-        if rate >= min && rate <= max {
-            return Some(cfg.with_sample_rate(rate).config());
-        }
-    }
-    None
 }

--- a/crates/aether-capabilities/src/audio/runtime/track.rs
+++ b/crates/aether-capabilities/src/audio/runtime/track.rs
@@ -31,16 +31,16 @@ pub enum TrackFade {
 /// namespace, path)`, mirroring the voice key plus the caller-supplied
 /// `lane` that disambiguates senders sharing a source mailbox.
 pub struct TrackVoice {
-    pub sender_mailbox: MailboxId,
-    pub lane: Option<String>,
-    pub namespace: String,
-    pub path: String,
-    pub pcm: Arc<[f32]>,
-    pub position: usize,
-    pub gain: f32,
-    pub looping: bool,
-    pub fade: TrackFade,
-    pub done: bool,
+    sender_mailbox: MailboxId,
+    lane: Option<String>,
+    namespace: String,
+    path: String,
+    pcm: Arc<[f32]>,
+    position: usize,
+    gain: f32,
+    looping: bool,
+    fade: TrackFade,
+    done: bool,
 }
 
 impl TrackVoice {
@@ -134,23 +134,6 @@ impl TrackVoice {
     }
 }
 
-/// `aether.audio` mailbox cap. Holds the producer side of the synth
-/// event queue (the crate-internal `AudioEventSender`), the audio
-/// worker thread that owns the [`cpal::Stream`] (see module-level
-/// "per-cap audio worker" docs for the `!Send` rationale), and a
-/// shutdown channel that signals the worker to exit on drop.
-///
-/// `sender` is `None` when the cpal pipeline isn't running
-/// (`AETHER_AUDIO_DISABLE=1`, no audio device, init failure). In
-/// that mode `NoteOn` / `NoteOff` no-op and `SetMasterGain` replies
-/// `Err`.
-///
-/// Issue 629 / Phase B: `thread` and `shutdown` are
-/// plain fields. Pre-Phase-A they sat behind a `Mutex<AudioTeardown>`
-/// so `Drop::drop(&mut self)` could `.take()` them while handlers
-/// ran with `&self` (Arc-shared). Post-Phase-A the dispatcher owns
-/// the cap as `Box<A>` and `Drop` runs with exclusive `&mut self`,
-/// so the wrapping mutex retires.
 /// A `play_track` request parked while its `aether.fs.read` is in
 /// flight (ADR-0103 §2). Keyed in `AudioCapabilityState::pending_tracks`
 /// by the echoed `(namespace, path)` the `ReadResult` carries; the

--- a/crates/aether-capabilities/src/audio/runtime/voice.rs
+++ b/crates/aether-capabilities/src/audio/runtime/voice.rs
@@ -23,7 +23,7 @@ pub const MAX_VOICES: usize = 64;
 /// or mid-decay — the release ramp starts from that value, not from
 /// the sustain level.
 #[derive(Copy, Clone, Debug)]
-pub enum EnvelopeStage {
+enum EnvelopeStage {
     Attack { t: f32 },
     Decay { t: f32 },
     Sustain,
@@ -38,34 +38,34 @@ pub enum EnvelopeStage {
 pub struct OscVoice {
     /// Oscillator phase in turns (`[0.0, 1.0)`), incremented by
     /// `freq / sample_rate` per sample.
-    pub phase: f32,
+    phase: f32,
     /// Turns-per-sample step — precomputed so the per-sample path is
     /// add-only.
-    pub phase_step: f32,
+    phase_step: f32,
     /// Base amplitude after velocity scaling; envelope multiplies this.
-    pub amplitude: f32,
-    pub wave: Wave,
-    pub adsr: Adsr,
-    pub envelope: EnvelopeStage,
+    amplitude: f32,
+    wave: Wave,
+    adsr: Adsr,
+    envelope: EnvelopeStage,
     /// xorshift32 PRNG state for the `Noise` wave, seeded from the
     /// voice key. Unused (but harmless) for the periodic waves.
-    pub rng: u32,
+    rng: u32,
     /// One-pole lowpass memory for the `Noise` wave (the previous
     /// filtered output).
-    pub lp_prev: f32,
+    lp_prev: f32,
     /// Current pitch-sweep offset added to `1.0` to scale `phase_step`
     /// this sample. `0.0` when the patch has no sweep.
-    pub sweep_offset: f32,
+    sweep_offset: f32,
     /// Per-sample multiplier the sweep offset decays by. `1.0` (no
     /// decay) when the patch has no sweep — the offset is then `0.0`,
     /// so the ratio stays `1.0`.
-    pub sweep_decay: f32,
+    sweep_decay: f32,
 }
 
 /// One step of an xorshift32 PRNG, mapped to white noise in `[-1.0,
 /// 1.0)`. The state is per-voice so percussion voices are independent
 /// and a fixed seed is reproducible.
-pub fn next_noise(state: &mut u32) -> f32 {
+fn next_noise(state: &mut u32) -> f32 {
     let mut x = *state;
     x ^= x << 13;
     x ^= x >> 17;
@@ -141,15 +141,15 @@ impl OscVoice {
     pub fn note_off(&mut self) {
         let from_level = match self.envelope {
             EnvelopeStage::Attack { t } => {
-                if self.adsr.attack_s > 0.0 {
-                    (t / self.adsr.attack_s).clamp(0.0, 1.0)
+                if self.adsr.attack_secs > 0.0 {
+                    (t / self.adsr.attack_secs).clamp(0.0, 1.0)
                 } else {
                     1.0
                 }
             }
             EnvelopeStage::Decay { t } => {
-                if self.adsr.decay_s > 0.0 {
-                    let fall = (1.0 - self.adsr.sustain).mul_add(-(t / self.adsr.decay_s), 1.0);
+                if self.adsr.decay_secs > 0.0 {
+                    let fall = (1.0 - self.adsr.sustain).mul_add(-(t / self.adsr.decay_secs), 1.0);
                     fall.clamp(self.adsr.sustain.min(1.0), 1.0)
                 } else {
                     self.adsr.sustain
@@ -169,30 +169,30 @@ impl OscVoice {
         match &mut self.envelope {
             EnvelopeStage::Attack { t } => {
                 *t += dt;
-                if self.adsr.attack_s <= 0.0 || *t >= self.adsr.attack_s {
+                if self.adsr.attack_secs <= 0.0 || *t >= self.adsr.attack_secs {
                     self.envelope = EnvelopeStage::Decay { t: 0.0 };
                     1.0
                 } else {
-                    *t / self.adsr.attack_s
+                    *t / self.adsr.attack_secs
                 }
             }
             EnvelopeStage::Decay { t } => {
                 *t += dt;
-                if self.adsr.decay_s <= 0.0 || *t >= self.adsr.decay_s {
+                if self.adsr.decay_secs <= 0.0 || *t >= self.adsr.decay_secs {
                     self.envelope = EnvelopeStage::Sustain;
                     self.adsr.sustain
                 } else {
-                    (1.0 - self.adsr.sustain).mul_add(-(*t / self.adsr.decay_s), 1.0)
+                    (1.0 - self.adsr.sustain).mul_add(-(*t / self.adsr.decay_secs), 1.0)
                 }
             }
             EnvelopeStage::Sustain => self.adsr.sustain,
             EnvelopeStage::Release { t, from_level } => {
                 *t += dt;
-                if self.adsr.release_s <= 0.0 || *t >= self.adsr.release_s {
+                if self.adsr.release_secs <= 0.0 || *t >= self.adsr.release_secs {
                     self.envelope = EnvelopeStage::Done;
                     0.0
                 } else {
-                    *from_level * (1.0 - (*t / self.adsr.release_s))
+                    *from_level * (1.0 - (*t / self.adsr.release_secs))
                 }
             }
             EnvelopeStage::Done => 0.0,
@@ -253,11 +253,11 @@ impl OscVoice {
 /// each sample by `decay_mul = exp(-rate * dt)`, so the hot loop holds
 /// no transcendentals beyond the `sin`.
 #[derive(Copy, Clone, Debug)]
-pub struct Partial {
-    pub phase: f32,
-    pub phase_step: f32,
-    pub amp: f32,
-    pub decay_mul: f32,
+struct Partial {
+    phase: f32,
+    phase_step: f32,
+    amp: f32,
+    decay_mul: f32,
 }
 
 impl Partial {
@@ -338,13 +338,13 @@ impl BankStage {
 /// is `sin` + multiply-accumulate + decay multiply per partial.
 #[derive(Copy, Clone, Debug)]
 pub struct PartialBankVoice {
-    pub partials: [Partial; PARTIAL_COUNT],
+    partials: [Partial; PARTIAL_COUNT],
     /// Overall level after velocity scaling; the partial amps carry
     /// the (normalised) spectral shape, this carries the loudness.
-    pub amplitude: f32,
-    pub stage: BankStage,
-    pub attack_s: f32,
-    pub release_s: f32,
+    amplitude: f32,
+    stage: BankStage,
+    attack_s: f32,
+    release_secs: f32,
 }
 
 impl PartialBankVoice {
@@ -392,8 +392,8 @@ impl PartialBankVoice {
             partials,
             amplitude,
             stage: BankStage::Attack { t: 0.0 },
-            attack_s: def.attack_s,
-            release_s: def.release_s,
+            attack_s: def.attack_secs,
+            release_secs: def.release_secs,
         }
     }
 
@@ -406,7 +406,7 @@ impl PartialBankVoice {
     }
 
     pub fn advance_ramp(&mut self, dt: f32) -> f32 {
-        self.stage.advance(dt, self.attack_s, self.release_s)
+        self.stage.advance(dt, self.attack_s, self.release_secs)
     }
 
     pub fn next_sample(&mut self, dt: f32) -> f32 {
@@ -440,11 +440,7 @@ impl PartialBankVoice {
 
     #[cfg(test)]
     pub fn partial_amps(&self) -> [f32; PARTIAL_COUNT] {
-        let mut out = [0.0f32; PARTIAL_COUNT];
-        for (slot, p) in out.iter_mut().zip(self.partials.iter()) {
-            *slot = p.amp;
-        }
-        out
+        self.partials.map(|p| p.amp)
     }
 
     #[cfg(test)]

--- a/crates/aether-capabilities/src/component/runtime/load.rs
+++ b/crates/aether-capabilities/src/component/runtime/load.rs
@@ -7,7 +7,6 @@
 //! same access as an inline impl block would.
 
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
 
 use aether_actor::Addressable;
 use aether_kinds::{ComponentCapabilities, LoadComponent, LoadResult};
@@ -29,7 +28,7 @@ impl ComponentHostCapabilityState {
                   would thread the load payload + registry/engine handles through a helper \
                   for no clarity gain."
     )]
-    pub(in crate::component) fn handle_load(
+    pub(super) fn handle_load(
         &mut self,
         ctx: &mut NativeCtx<'_>,
         payload: LoadComponent,
@@ -107,18 +106,16 @@ impl ComponentHostCapabilityState {
         // default. A non-entry export defaults its mailbox name to
         // the selected type's namespace, the multi-actor analog of
         // the single-actor `aether.namespace` fallback.
-        let name = match payload.name {
+        let name = match payload.name.or(selected_namespace) {
             Some(n) => n,
-            None => match selected_namespace {
-                Some(ns) => ns,
-                None => match kind_manifest::read_namespace_from_bytes(&payload.wasm) {
-                    Ok(Some(declared)) => declared,
-                    Ok(None) => {
-                        let n = self.default_name_counter.fetch_add(1, Ordering::Relaxed);
-                        format!("component_{n}")
-                    }
-                    Err(error) => return LoadResult::Err { error },
-                },
+            None => match kind_manifest::read_namespace_from_bytes(&payload.wasm) {
+                Ok(Some(declared)) => declared,
+                Ok(None) => {
+                    let n = self.default_name_counter;
+                    self.default_name_counter += 1;
+                    format!("component_{n}")
+                }
+                Err(error) => return LoadResult::Err { error },
             },
         };
 

--- a/crates/aether-capabilities/src/component/runtime/mod.rs
+++ b/crates/aether-capabilities/src/component/runtime/mod.rs
@@ -32,26 +32,25 @@ use aether_kinds::{
     ListComponentsResult, LoadComponent, LoadResult, ReplaceComponent,
 };
 
-// Crate-local wiring the `#[actor] impl` handler bodies name (sibling caps it
-// mails, the unsubscribe kind, the `Kind` / `MailboxCategory` vocabulary),
-// re-exported so the parent reaches them through its `use runtime::*` glob.
-pub use crate::input::{InputCapability, UnsubscribeAll};
-pub use crate::lifecycle::LifecycleCapability;
-pub use aether_data::{Kind, MailboxCategory};
-pub use aether_kinds::LifecycleUnsubscribeAll;
+// Crate-local wiring the `#[runtime] impl` handler bodies name (sibling caps it
+// mails, the unsubscribe kind, the `Kind` / `MailboxCategory` vocabulary), the
+// state struct, and `forward_to_trampoline` — all used within this module.
+use crate::input::{InputCapability, UnsubscribeAll};
+use crate::lifecycle::LifecycleCapability;
+use aether_data::{Kind, MailboxCategory};
+use aether_kinds::LifecycleUnsubscribeAll;
 
-pub use std::sync::Arc;
-pub use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
 
-pub use wasmtime::{Engine, Linker};
+use wasmtime::{Engine, Linker};
 
-pub use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
-pub use aether_substrate::actor::wasm::component::ComponentCtx;
-pub use aether_substrate::chassis::error::BootError;
-pub use aether_substrate::mail::mailer::Mailer;
-pub use aether_substrate::mail::outbound::HubOutbound;
-pub use aether_substrate::mail::registry::Registry;
-pub use aether_substrate::mail::{KindId, MailboxId};
+use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
+use aether_substrate::actor::wasm::component::ComponentCtx;
+use aether_substrate::chassis::error::BootError;
+use aether_substrate::mail::mailer::Mailer;
+use aether_substrate::mail::outbound::HubOutbound;
+use aether_substrate::mail::registry::Registry;
+use aether_substrate::mail::{KindId, MailboxId};
 
 /// `aether.component` runtime state (ADR-0122 split). Holds the wasmtime
 /// `engine` + `linker` every load instantiates against, the mail `registry`,
@@ -77,7 +76,7 @@ pub struct ComponentHostCapabilityState {
     pub(in crate::component) outbound: Arc<HubOutbound>,
     /// Monotonic counter for `component_N` default names when an agent passes
     /// `name: None` and the wasm doesn't declare an `aether.namespace`.
-    pub(in crate::component) default_name_counter: AtomicU64,
+    pub(in crate::component) default_name_counter: u64,
 }
 
 /// Forward an arbitrary kind to a trampoline's mailbox, preserving the
@@ -96,7 +95,7 @@ pub struct ComponentHostCapabilityState {
 /// A free fn (no `self`) under the ADR-0122 split: the state-bearing struct
 /// holds no field this helper reads, so it stays stateless and the handlers
 /// reach it through the parent's `use runtime::*` glob.
-pub fn forward_to_trampoline<P>(
+fn forward_to_trampoline<P>(
     ctx: &mut NativeCtx<'_>,
     recipient: MailboxId,
     kind: KindId,
@@ -130,7 +129,7 @@ impl NativeActor for ComponentHostCapability {
             registry,
             mailer,
             outbound: config.hub_outbound,
-            default_name_counter: AtomicU64::new(0),
+            default_name_counter: 0,
         })
     }
 

--- a/crates/aether-capabilities/src/engine/kinds.rs
+++ b/crates/aether-capabilities/src/engine/kinds.rs
@@ -15,6 +15,7 @@
 //! are the MCP harness's RPC protocol, and `aether-mcp` consumes them
 //! while being barred from depending on `aether-capabilities`.
 
+use aether_data::{Kind, KindId, MailboxId, Schema};
 use aether_kinds::DeathReason;
 use serde::{Deserialize, Serialize};
 
@@ -31,11 +32,11 @@ use serde::{Deserialize, Serialize};
 /// Any reply streams back through the proxy and routes to whoever
 /// sent this `ForwardEnvelope` — the proxy keys reply correlation
 /// off the inbound mail's `Source`.
-#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[derive(Kind, Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.engine.forward")]
 pub struct ForwardEnvelope {
-    pub mailbox: aether_data::MailboxId,
-    pub kind: aether_data::KindId,
+    pub mailbox: MailboxId,
+    pub kind: KindId,
     pub payload: Vec<u8>,
 }
 
@@ -52,12 +53,12 @@ pub struct ForwardEnvelope {
 /// `ForwardEnvelope` at the right `aether.engine.proxy:<id>`,
 /// propagating the original reply-to so the substrate's reply
 /// streams back to the originating `RpcServerCapability`.
-#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[derive(Kind, Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.engine.route")]
 pub struct RouteEnvelope {
     pub engine_id: String,
-    pub mailbox: aether_data::MailboxId,
-    pub kind: aether_data::KindId,
+    pub mailbox: MailboxId,
+    pub kind: KindId,
     pub payload: Vec<u8>,
 }
 
@@ -75,7 +76,7 @@ pub struct RouteEnvelope {
 /// explicit terminal signal.) `Err` carries the wire `RpcError`
 /// rendered as a string — the structured variant doesn't survive
 /// the `aether-kinds` layer, which can't depend on the RPC crate.
-#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[derive(Kind, Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.engine.call_settled")]
 pub enum CallSettled {
     Ok,
@@ -90,7 +91,7 @@ pub enum CallSettled {
 /// uses for the reader sidecar. The handler pings the substrate and
 /// counts consecutive misses, evicting the engine once the miss
 /// limit is crossed.
-#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Kind, Schema, Serialize, Deserialize, Debug, Clone, Default)]
 #[kind(name = "aether.engine.heartbeat_tick")]
 pub struct EngineHeartbeatTick {}
 
@@ -104,7 +105,7 @@ pub struct EngineHeartbeatTick {}
 /// for an already-removed engine (e.g. one a concurrent
 /// `TerminateEngine` already dropped) is a no-op. `engine_id` is
 /// the plain UUID string, matching `TerminateEngine`.
-#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[derive(Kind, Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.engine.died")]
 pub struct EngineDied {
     pub engine_id: String,
@@ -122,7 +123,7 @@ pub struct EngineDied {
 /// last-seen-alive time so `ListEnginesResult` can report
 /// `last_heartbeat_age_millis`. Fire-and-forget; an `alive` for an
 /// unknown engine is a no-op. `engine_id` is the plain UUID string.
-#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[derive(Kind, Schema, Serialize, Deserialize, Debug, Clone)]
 #[kind(name = "aether.engine.alive")]
 pub struct EngineAlive {
     pub engine_id: String,

--- a/crates/aether-capabilities/src/engine/mod.rs
+++ b/crates/aether-capabilities/src/engine/mod.rs
@@ -1,23 +1,20 @@
 //! `aether.engine` — engine-management capability cluster (issue 763).
 //!
-//! - [`proxy::EngineProxy`] (P3) — the per-engine proxy actor that
+//! - [`EngineProxy`] (P3) — the per-engine proxy actor that
 //!   wraps one outbound RPC connection to a substrate; the bridge core
 //!   of the forward-model architecture.
-//! - [`server::EngineServer`] (P4) — the engines cap (`list` / `spawn`
+//! - [`EngineServer`] (P4) — the engines cap (`list` / `spawn`
 //!   / `terminate`) that supervises a fleet of proxies, fork+execing
 //!   substrates and connecting a proxy to each.
 //!
 //! See issue 763 for the full design.
 
-pub mod kinds;
-pub mod proxy;
-pub mod server;
+pub(crate) mod kinds;
+mod proxy;
+mod server;
 #[cfg(feature = "runtime")]
 mod store;
 
-pub use kinds::{
-    CallSettled, EngineAlive, EngineDied, EngineHeartbeatTick, ForwardEnvelope, RouteEnvelope,
-};
 pub use proxy::EngineProxy;
 #[cfg(not(target_family = "wasm"))]
 pub use proxy::EngineProxyConfig;

--- a/crates/aether-capabilities/src/engine/proxy/config.rs
+++ b/crates/aether-capabilities/src/engine/proxy/config.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 /// proxy doesn't manage.
 ///
 /// `heartbeat` is the liveness-probe tuning the cap resolved from
-/// its [`EngineConfig`](crate::engine::server) (issue 1339). `None`
+/// its [`EngineConfig`](crate::engine::EngineConfig) (issue 1339). `None`
 /// disables the heartbeat (the engine is then only evicted on a
 /// connection-close `Bye`, never on a wedge); `Some` arms the
 /// timer sidecar.

--- a/crates/aether-capabilities/src/engine/proxy/connect.rs
+++ b/crates/aether-capabilities/src/engine/proxy/connect.rs
@@ -18,7 +18,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 /// Pause between dial attempts within the connect budget.
-const PROXY_CONNECT_RETRY_INTERVAL: Duration = Duration::from_millis(50);
+const RETRY_INTERVAL: Duration = Duration::from_millis(50);
 
 /// Outcome distinctions [`connect_proxy`] surfaces to the proxy's
 /// `init` so the engines cap can tell a re-forkable startup death from
@@ -126,7 +126,7 @@ pub fn connect_proxy(
                 }
                 let within_budget = deadline.is_none_or(|d| Instant::now() < d);
                 if retry && is_transient_connect_error(&e) && within_budget {
-                    thread::sleep(PROXY_CONNECT_RETRY_INTERVAL);
+                    thread::sleep(RETRY_INTERVAL);
                     continue;
                 }
                 Err(ProxyConnectError::Dial(e))

--- a/crates/aether-capabilities/src/engine/server/artifacts.rs
+++ b/crates/aether-capabilities/src/engine/server/artifacts.rs
@@ -75,21 +75,21 @@ pub fn ingest_binary(
 /// logged and skipped — a bad bootstrap entry must not fail hub boot.
 /// Idempotent via content dedup.
 pub fn bootstrap_ingest(store: &mut ArtifactStore, paths: &HashSet<String>) {
-    for path_str in paths {
-        let name = Path::new(path_str)
+    for path in paths {
+        let name = Path::new(path)
             .file_stem()
             .and_then(|stem| stem.to_str())
             .map(str::to_owned);
-        match ingest_binary(store, path_str, name) {
+        match ingest_binary(store, path, name) {
             Ok(hash) => tracing::info!(
                 target: "aether_substrate::engine_server",
-                path = path_str.as_str(),
+                path = path.as_str(),
                 hash = %hash,
                 "binary bootstrap: ingested a chassis bin",
             ),
             Err(error) => tracing::warn!(
                 target: "aether_substrate::engine_server",
-                path = path_str.as_str(),
+                path = path.as_str(),
                 error = %error,
                 "binary bootstrap: skipping a bin that failed to ingest",
             ),

--- a/crates/aether-capabilities/src/engine/server/config.rs
+++ b/crates/aether-capabilities/src/engine/server/config.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 /// needs, comfortably under the `FleetBench` client's own spawn cap so
 /// the hub returns a clean `Err` first rather than the client
 /// tripping its backstop. `0` is the wait-forever sentinel.
-pub(super) const DEFAULT_PROXY_CONNECT_BUDGET_SECS: u64 = 30;
+const DEFAULT_PROXY_CONNECT_BUDGET_SECS: u64 = 30;
 
 /// Resolved engines-cap configuration (ADR-0090, issue 1339): the
 /// liveness-heartbeat tuning plus the hub binary store's layout dir,
@@ -139,14 +139,12 @@ impl EngineConfig {
     /// The [`HeartbeatParams`] to arm each proxy with, or `None`
     /// when the heartbeat is disabled (`0` interval or miss limit).
     pub(super) fn heartbeat_params(&self) -> Option<HeartbeatParams> {
-        if self.heartbeat_interval_secs == 0 || self.heartbeat_miss_limit == 0 {
-            None
-        } else {
-            Some(HeartbeatParams {
+        (self.heartbeat_interval_secs != 0 && self.heartbeat_miss_limit != 0).then(|| {
+            HeartbeatParams {
                 interval: Duration::from_secs(self.heartbeat_interval_secs),
                 miss_limit: self.heartbeat_miss_limit,
-            })
-        }
+            }
+        })
     }
 
     /// The startup-dial connect budget to arm each spawned proxy


### PR DESCRIPTION
Closes #2442.

## Summary

Applies the confirmed `audit-quality` cleanups to the `anthropic/`, `audio/`, `component/`, and `engine/` modules of `aether-capabilities` — non-mechanical, judgment-level fixes a lint can't decide, no behaviour change and no wire change. Five lens-passes: visibility tightening, internal `_s`→`_secs` naming, control-flow simplification (`retain`, `chunks_exact`, `map_or_else`), module-structure (split the cpal pipeline cluster into `audio/runtime/pipeline.rs`, relocate `wav_source_rate`, drop an orphaned 880-char doc-comment, hoist derive-path imports), and primitive-overuse (`AtomicU64`→`u64`, `.collect::<String>()`). The six wire `_ms`→`_millis` findings were carved out and already landed via #2446.

## Test plan

Workspace `cargo nextest run` (1898 passed / 8 skipped) — the audio/synth/decode/config tests pin the rewritten control-flow; the anthropic/audio unit tests recompile against the renamed internal fields. Full local validation green: fmt, clippy `-D warnings`, doc with strict rustdoc flags. Each visibility narrowing was gated on an empty out-of-crate `git grep`.

## Generated by

`/implement` — agent execution of scoped issue #2442.
