### PR TITLE
fix(actor-derive): sharpen handler-shape diagnostics

### DIFF
--- a/crates/aether-actor-derive/src/lib.rs
+++ b/crates/aether-actor-derive/src/lib.rs
@@ -568,29 +568,56 @@ fn is_vec_u8(ty: &Type) -> bool {
 /// `Vec<HashMap<String, String>>` and `Option<HashMap<...>>` are
 /// caught too — the nested case would otherwise pass through trait
 /// dispatch and emit a less actionable "trait `Schema` not
-/// implemented" error pointing at the inner `HashMap`.
+/// implemented" error pointing at the inner `HashMap`. The walk is
+/// total: it also recurses through array, slice, reference, tuple,
+/// paren, and group positions so a `HashMap` hidden inside `[_; N]`,
+/// `&[_]`, or `(_, _)` earns the same pointed error rather than the
+/// opaque downstream one. A set type (`HashSet`/`BTreeSet`) has no
+/// `Schema` impl at all, so it is rejected here too with a redirect to
+/// a sorted `Vec<T>`.
 fn reject_hashmap(ty: &Type) -> syn::Result<()> {
-    if let Type::Path(tp) = ty {
-        if let Some(seg) = tp.path.segments.last()
-            && seg.ident == "HashMap"
-        {
-            return Err(syn::Error::new_spanned(
-                ty,
-                "HashMap is not allowed in derived kind schemas — its iteration order is \
-                 platform-dependent and would diverge canonical schema bytes (and Kind::ID) \
-                 across builds. Use `std::collections::BTreeMap` instead, which sorts by key. \
-                 See https://github.com/iamacoffeepot/aether/issues/232",
-            ));
-        }
-        for seg in &tp.path.segments {
-            if let PathArguments::AngleBracketed(args) = &seg.arguments {
-                for arg in &args.args {
-                    if let GenericArgument::Type(inner) = arg {
-                        reject_hashmap(inner)?;
+    match ty {
+        Type::Path(tp) => {
+            if let Some(seg) = tp.path.segments.last() {
+                if seg.ident == "HashMap" {
+                    return Err(syn::Error::new_spanned(
+                        ty,
+                        "HashMap is not allowed in derived kind schemas — its iteration order is \
+                         platform-dependent and would diverge canonical schema bytes (and Kind::ID) \
+                         across builds. Use `std::collections::BTreeMap` instead, which sorts by key. \
+                         See https://github.com/iamacoffeepot/aether/issues/232",
+                    ));
+                }
+                if seg.ident == "HashSet" || seg.ident == "BTreeSet" {
+                    return Err(syn::Error::new_spanned(
+                        ty,
+                        "a set has no `Schema` impl and is not allowed in derived kind schemas — \
+                         model it as a sorted `Vec<T>`, which encodes deterministically. \
+                         See https://github.com/iamacoffeepot/aether/issues/232",
+                    ));
+                }
+            }
+            for seg in &tp.path.segments {
+                if let PathArguments::AngleBracketed(args) = &seg.arguments {
+                    for arg in &args.args {
+                        if let GenericArgument::Type(inner) = arg {
+                            reject_hashmap(inner)?;
+                        }
                     }
                 }
             }
         }
+        Type::Array(a) => reject_hashmap(&a.elem)?,
+        Type::Slice(s) => reject_hashmap(&s.elem)?,
+        Type::Reference(r) => reject_hashmap(&r.elem)?,
+        Type::Paren(p) => reject_hashmap(&p.elem)?,
+        Type::Group(g) => reject_hashmap(&g.elem)?,
+        Type::Tuple(t) => {
+            for elem in &t.elems {
+                reject_hashmap(elem)?;
+            }
+        }
+        _ => {}
     }
     Ok(())
 }
@@ -917,7 +944,7 @@ pub fn handler(_attr: TokenStream, _item: TokenStream) -> TokenStream {
     // macro expansion and so rust-analyzer doesn't redline it.
     syn::Error::new(
         proc_macro2::Span::call_site(),
-        "#[handler] may only appear inside a `#[actor] impl WasmActor for T` block",
+        "#[handler] may only appear inside a `#[actor]` impl block",
     )
     .to_compile_error()
     .into()
@@ -930,7 +957,7 @@ pub fn fallback(_attr: TokenStream, _item: TokenStream) -> TokenStream {
     // compile-time error.
     syn::Error::new(
         proc_macro2::Span::call_site(),
-        "#[fallback] may only appear inside a `#[actor] impl WasmActor for T` block",
+        "#[fallback] may only appear inside a `#[actor]` impl block",
     )
     .to_compile_error()
     .into()
@@ -2128,6 +2155,20 @@ fn expand_native_actor_trait(
                             });
                         }
                         HandlerVariant::Task => {
+                            // A task handler always dispatches with the `Single`
+                            // reply class — the completion reply rides `TaskDone`,
+                            // not the handler class — so the `NativeActorTaskHandlerFn`
+                            // carries no class field and any non-`Single` marker
+                            // (e.g. `#[handler::manual(task)]`) would be silently
+                            // discarded. Reject it at the boundary instead.
+                            if class != HandlerClass::Single {
+                                return Err(syn::Error::new_spanned(
+                                    &f,
+                                    "#[handler(task)] always uses the single reply class; \
+                                     drop the class marker — task replies go through \
+                                     `TaskDone`, not the handler class",
+                                ));
+                            }
                             let (output_ty, context_ty, is_borrow) =
                                 extract_task_handler_types(&f.sig, is_split)?;
                             let mode = classify_task_reply_mode(&f.sig, is_borrow)?;
@@ -3401,7 +3442,7 @@ fn extract_handler_kind_type(sig: &Signature) -> syn::Result<Type> {
     if !matches!(first, FnArg::Receiver(_)) {
         return Err(syn::Error::new_spanned(
             first,
-            "#[handler] first parameter must be `&mut self`",
+            "#[handler] first parameter must be `&self` or `&mut self`",
         ));
     }
     let third = &sig.inputs[2];
@@ -3411,6 +3452,21 @@ fn extract_handler_kind_type(sig: &Signature) -> syn::Result<Type> {
             "#[handler] third parameter must be a typed `arg: K`",
         ));
     };
+    // `&[K]` slice/batch handlers are native-only: the wasm dispatcher
+    // decodes a single `K` per mail, so an `impl HandlesKind<&[K]>` /
+    // `decode_kind::<&[K]>()` would be emitted and fail to compile.
+    // Reject at the boundary with a pointed message rather than letting
+    // the opaque codegen error surface. (The native extractor accepts
+    // this shape — see `extract_native_actor_handler_kind`.)
+    if let Type::Reference(type_ref) = &*pt.ty
+        && let Type::Slice(_) = &*type_ref.elem
+    {
+        return Err(syn::Error::new_spanned(
+            &pt.ty,
+            "`&[K]` slice/batch handlers are native-only; a wasm `#[handler]` \
+             takes a single `arg: K` per mail",
+        ));
+    }
     Ok((*pt.ty).clone())
 }
 
@@ -3489,7 +3545,7 @@ fn validate_fallback_sig(sig: &Signature) -> syn::Result<()> {
     if !matches!(first, FnArg::Receiver(_)) {
         return Err(syn::Error::new_spanned(
             first,
-            "#[fallback] first parameter must be `&mut self`",
+            "#[fallback] first parameter must be `&self` or `&mut self`",
         ));
     }
     let third = &sig.inputs[2];
@@ -4107,6 +4163,52 @@ mod tests {
     }
 
     #[test]
+    fn rejects_hashmap_in_array() {
+        let msg = err("[HashMap<String, u32>; 4]");
+        assert!(msg.contains("BTreeMap"));
+        assert!(msg.contains("232"));
+    }
+
+    #[test]
+    fn rejects_hashmap_in_tuple() {
+        let msg = err("(u32, HashMap<String, u32>)");
+        assert!(msg.contains("BTreeMap"));
+        assert!(msg.contains("232"));
+    }
+
+    #[test]
+    fn rejects_hashmap_behind_slice_ref() {
+        let msg = err("&[HashMap<String, u32>]");
+        assert!(msg.contains("BTreeMap"));
+        assert!(msg.contains("232"));
+    }
+
+    #[test]
+    fn rejects_hashmap_behind_ref() {
+        let msg = err("&HashMap<String, u32>");
+        assert!(msg.contains("BTreeMap"));
+        assert!(msg.contains("232"));
+    }
+
+    #[test]
+    fn rejects_hashset() {
+        let msg = err("HashSet<u64>");
+        assert!(
+            msg.contains("Vec"),
+            "error must redirect to a sorted Vec, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_btreeset() {
+        let msg = err("BTreeSet<u64>");
+        assert!(
+            msg.contains("Vec"),
+            "error must redirect to a sorted Vec, got: {msg}"
+        );
+    }
+
+    #[test]
     fn allows_btreemap_field() {
         let parsed: syn::Type =
             parse_str("BTreeMap<String, String>").expect("test setup: BTreeMap type parses");
@@ -4115,13 +4217,7 @@ mod tests {
 
     #[test]
     fn allows_plain_types() {
-        for ty in [
-            "u32",
-            "String",
-            "Vec<u8>",
-            "Option<String>",
-            "BTreeSet<u64>",
-        ] {
+        for ty in ["u32", "String", "Vec<u8>", "Option<String>"] {
             let parsed: syn::Type =
                 parse_str(ty).expect("test setup: candidate type parses as syn::Type");
             assert!(

--- a/crates/aether-actor-derive/tests/ui.rs
+++ b/crates/aether-actor-derive/tests/ui.rs
@@ -85,4 +85,12 @@ fn ui() {
     t.compile_fail("tests/ui/rejects_struct_no_handler.rs");
     t.compile_fail("tests/ui/rejects_struct_no_namespace.rs");
     t.compile_fail("tests/ui/rejects_struct_ambiguous_runtime.rs");
+    // Issue #2460: sharpen the handler-shape diagnostics. A `&[K]` slice
+    // handler is native-only (the wasm dispatcher decodes a single `K`),
+    // a non-`Single` class on a `#[handler(task)]` is discarded so it is
+    // rejected, and a wasm `#[handler]`'s non-`self` first param earns the
+    // generalized `&self` or `&mut self` diagnostic.
+    t.compile_fail("tests/ui/rejects_slice_handler_wasm.rs");
+    t.compile_fail("tests/ui/rejects_manual_task_handler_native.rs");
+    t.compile_fail("tests/ui/rejects_nonself_handler_wasm.rs");
 }

--- a/crates/aether-actor-derive/tests/ui/rejects_manual_task_handler_native.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_manual_task_handler_native.rs
@@ -1,0 +1,39 @@
+//! Issue #2460: a `#[handler(task)]` always dispatches with the single
+//! reply class — the completion reply rides `TaskDone`, not the handler
+//! class — so a non-`Single` marker like `#[handler::manual(task)]` would
+//! be silently discarded. The macro rejects it at the boundary instead of
+//! dropping the designation without a diagnostic.
+
+use aether_actor::actor;
+
+#[allow(dead_code)]
+struct Reply {
+    value: u32,
+}
+
+pub struct TaskCap;
+
+#[actor]
+impl aether_substrate::actor::native::NativeActor for TaskCap {
+    type Config = ();
+
+    const NAMESPACE: &'static str = "test.manual_task_cap";
+
+    fn init(
+        _config: (),
+        _ctx: &mut aether_substrate::actor::native::NativeInitCtx<'_>,
+    ) -> Result<Self, aether_actor::ActorInitError> {
+        Ok(TaskCap)
+    }
+
+    #[handler::manual(task)]
+    fn on_done(
+        &mut self,
+        ctx: &mut aether_substrate::actor::native::NativeCtx<'_>,
+        done: aether_substrate::actor::native::TaskDone<Reply>,
+    ) {
+        done.resolve(ctx);
+    }
+}
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/rejects_manual_task_handler_native.stderr
+++ b/crates/aether-actor-derive/tests/ui/rejects_manual_task_handler_native.stderr
@@ -1,0 +1,11 @@
+error: #[handler(task)] always uses the single reply class; drop the class marker — task replies go through `TaskDone`, not the handler class
+  --> tests/ui/rejects_manual_task_handler_native.rs:30:5
+   |
+30 | /     fn on_done(
+31 | |         &mut self,
+32 | |         ctx: &mut aether_substrate::actor::native::NativeCtx<'_>,
+33 | |         done: aether_substrate::actor::native::TaskDone<Reply>,
+34 | |     ) {
+35 | |         done.resolve(ctx);
+36 | |     }
+   | |_____^

--- a/crates/aether-actor-derive/tests/ui/rejects_nonself_handler_wasm.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_nonself_handler_wasm.rs
@@ -1,0 +1,38 @@
+//! Issue #2460: a wasm `#[handler]`'s first parameter must be a `self`
+//! receiver. The validator already accepts both `&self` and `&mut self`
+//! (it matches any `FnArg::Receiver`), so the diagnostic names both forms
+//! rather than the narrower `&mut self`. A non-`self` typed first param
+//! earns the generalized error here.
+
+use aether_actor::{WasmCtx, actor};
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.ping")]
+struct Ping {
+    seq: u32,
+}
+
+struct ReceiverProbe;
+
+#[actor]
+impl aether_actor::WasmActor for ReceiverProbe {
+    const NAMESPACE: &'static str = "receiver_probe";
+
+    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::ActorInitError>
+    {
+        Ok(ReceiverProbe)
+    }
+
+    #[handler]
+    fn on_ping(_state: u32, _ctx: &mut WasmCtx<'_>, _ping: Ping) {}
+}
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/rejects_nonself_handler_wasm.stderr
+++ b/crates/aether-actor-derive/tests/ui/rejects_nonself_handler_wasm.stderr
@@ -1,0 +1,13 @@
+error: #[handler] first parameter must be `&self` or `&mut self`
+  --> tests/ui/rejects_nonself_handler_wasm.rs:35:16
+   |
+35 |     fn on_ping(_state: u32, _ctx: &mut WasmCtx<'_>, _ping: Ping) {}
+   |                ^^^^^^^^^^^
+
+warning: unused import: `WasmCtx`
+ --> tests/ui/rejects_nonself_handler_wasm.rs:7:20
+  |
+7 | use aether_actor::{WasmCtx, actor};
+  |                    ^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/crates/aether-actor-derive/tests/ui/rejects_slice_handler_wasm.rs
+++ b/crates/aether-actor-derive/tests/ui/rejects_slice_handler_wasm.rs
@@ -1,0 +1,38 @@
+//! Issue #2460: a `&[K]` slice/batch handler is native-only — the wasm
+//! dispatcher decodes a single `K` per mail, so `impl HandlesKind<&[K]>`
+//! / `decode_kind::<&[K]>()` would be emitted and fail to compile. The
+//! macro rejects the slice shape at the boundary with a pointed message
+//! instead of letting the opaque codegen error surface.
+
+use aether_actor::{WasmCtx, actor};
+
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    aether_data::Kind,
+    aether_data::Schema,
+)]
+#[kind(name = "test.ping")]
+struct Ping {
+    seq: u32,
+}
+
+struct SliceProbe;
+
+#[actor]
+impl aether_actor::WasmActor for SliceProbe {
+    const NAMESPACE: &'static str = "slice_probe";
+
+    fn init(_ctx: &mut aether_actor::WasmInitCtx<'_>) -> Result<Self, aether_actor::ActorInitError>
+    {
+        Ok(SliceProbe)
+    }
+
+    #[handler]
+    fn on_ping(&mut self, _ctx: &mut WasmCtx<'_>, _mail: &[Ping]) {}
+}
+
+fn main() {}

--- a/crates/aether-actor-derive/tests/ui/rejects_slice_handler_wasm.stderr
+++ b/crates/aether-actor-derive/tests/ui/rejects_slice_handler_wasm.stderr
@@ -1,0 +1,13 @@
+error: `&[K]` slice/batch handlers are native-only; a wasm `#[handler]` takes a single `arg: K` per mail
+  --> tests/ui/rejects_slice_handler_wasm.rs:35:58
+   |
+35 |     fn on_ping(&mut self, _ctx: &mut WasmCtx<'_>, _mail: &[Ping]) {}
+   |                                                          ^^^^^^^
+
+warning: unused import: `WasmCtx`
+ --> tests/ui/rejects_slice_handler_wasm.rs:7:20
+  |
+7 | use aether_actor::{WasmCtx, actor};
+  |                    ^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/crates/aether-capabilities/src/audio/runtime/mod.rs
+++ b/crates/aether-capabilities/src/audio/runtime/mod.rs
@@ -799,7 +799,7 @@ impl NativeActor for AudioCapability {
     /// PCM into the track lane and reply `Ok`; on a decode failure
     /// reply `Err`. Either way `resolve_with` re-replies through the
     /// captured `play_track` caller and drops the hold.
-    #[handler::manual(task)]
+    #[handler(task)]
     fn on_track_decoded(
         state: &mut Self::State,
         ctx: &mut NativeCtx<'_>,
@@ -924,7 +924,7 @@ impl NativeActor for AudioCapability {
     /// and reply `Ok` with the id / name / resident bytes; on a decode
     /// failure reply `Err`. Either way `resolve_with` re-replies through
     /// the captured `load_instrument` caller and drops the hold.
-    #[handler::manual(task)]
+    #[handler(task)]
     fn on_instrument_assembled(
         state: &mut Self::State,
         ctx: &mut NativeCtx<'_>,


### PR DESCRIPTION
Closes #2460.

## Summary

Sharpens five handler/field-shape diagnostics in the `#[actor]` / `#[derive(Kind/Schema)]` macros, each replacing an opaque downstream failure with a pointed macro-boundary error:

1. `reject_hashmap` recurses through non-path positions (`[HashMap<..>; N]`, tuples, `&[HashMap<..>]`, references) instead of skipping them.
2. A set arm redirects `HashSet`/`BTreeSet` fields to a sorted `Vec<T>` (there is no set `Schema` impl); drops the misleading `BTreeSet<u64>` from the accept-list test.
3. The wasm extractor rejects `&[K]` slice/batch handlers as native-only rather than emitting an uncompilable `impl HandlesKind<&[K]>`.
4. A task handler with a non-`Single` class (`#[handler::manual(task)]`) is now a pointed error — the Task arm discards the class, so the marker was silently dropped. The two live uses in the audio runtime are cleaned to `#[handler(task)]` in the same commit (codegen-identical, since the class is discarded — no behaviour change).
5. Four narrow diagnostic messages generalized (the standalone shims name `#[actor]` impl blocks, not only `impl WasmActor`; the wasm receiver validators accept `&self` or `&mut self`, matching the native side).

## Test plan

Inline `reject_hashmap` unit tests for the new recursion + set arms; three new `compile_fail` trybuild fixtures (`rejects_slice_handler_wasm`, `rejects_manual_task_handler_native`, `rejects_nonself_handler_wasm`) with `.stderr` goldens. Workspace `cargo nextest run` (1900 passed) — the audio-runtime cleanup keeps the capabilities build green. Full local preflight green.

## Generated by

`/implement` — agent execution of scoped issue #2460.
