### PR TITLE
refactor(substrate-bundle): move the wireframe knob onto the desktop config

### DIFF
--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -181,6 +181,10 @@ pub struct DesktopEnv {
     pub boot_mode: WindowMode,
     pub boot_size: Option<(u32, u32)>,
     pub boot_title: String,
+    /// Resolved `AETHER_WIREFRAME` config value (`WindowConfig::wireframe`,
+    /// argv > env > default), threaded to `Gpu::new` at window creation.
+    /// `WireframeMode::from_config_value` owns the tri-state parse.
+    pub boot_wireframe: Option<String>,
     /// Issue 1761: optional `aether.http.server` init config (ADR-0108).
     /// `Some` iff the cap's `enabled` flag is set (`AETHER_HTTP_SERVER_ENABLED`
     /// / `--http-server-enabled`); `None` (default) skips booting
@@ -298,6 +302,7 @@ impl DesktopEnv {
         // `None` / empty to `"aether"`.
         let (boot_mode, boot_size) = window_config.to_boot_mode();
         let boot_title = window_config.to_boot_title();
+        let boot_wireframe = window_config.wireframe;
 
         let rpc_addr = {
             use std::net::{IpAddr, Ipv4Addr};
@@ -324,6 +329,7 @@ impl DesktopEnv {
             boot_mode,
             boot_size,
             boot_title,
+            boot_wireframe,
             http_server,
             rpc_addr,
             workers,
@@ -356,6 +362,7 @@ impl DesktopChassis {
             boot_mode,
             boot_size,
             boot_title,
+            boot_wireframe,
             rpc_addr,
             workers,
             ring_caps,
@@ -419,6 +426,7 @@ impl DesktopChassis {
             boot_mode,
             boot_size,
             boot_title,
+            boot_wireframe,
         };
 
         // Boot order is declaration order — `with_common_caps` runs

--- a/crates/aether-substrate-bundle/src/desktop/driver.rs
+++ b/crates/aether-substrate-bundle/src/desktop/driver.rs
@@ -148,6 +148,10 @@ pub struct App {
     /// `set_window_title` mail overrides this but doesn't update the
     /// field — the current title lives on the `Window` itself.
     boot_title: String,
+    /// Resolved `AETHER_WIREFRAME` config value, threaded to `Gpu::new`
+    /// when `resumed` creates the window. `WireframeMode::from_config_value`
+    /// owns the tri-state parse.
+    boot_wireframe: Option<String>,
     /// Currently-applied window mode. Updated by `set_window_mode`
     /// and read by `platform_info`'s window-state field. Starts as
     /// `boot_mode`.
@@ -295,6 +299,15 @@ pub struct WindowConfig {
     /// `AETHER_WINDOW_TITLE=<text>` desktop window title at boot.
     /// Lowered via [`Self::to_boot_title`]; empty / unset → `"aether"`.
     pub title: Option<String>,
+    /// `AETHER_WIREFRAME=<value>` desktop GPU wireframe mode at boot:
+    /// `off` (default) / `line` / `overlay`. The env key is pinned back
+    /// to `AETHER_WIREFRAME` (not `AETHER_WINDOW_WIREFRAME`) and the
+    /// argv flag to `--wireframe` (not `--window-wireframe`) since the
+    /// knob predates joining `WindowConfig`. Threaded verbatim to
+    /// `render::WireframeMode::from_config_value`, which owns the
+    /// tri-state parse.
+    #[config(env = "AETHER_WIREFRAME", cli_long = "wireframe")]
+    pub wireframe: Option<String>,
 }
 
 impl WindowConfig {
@@ -1018,7 +1031,11 @@ impl ApplicationHandler<UserEvent> for App {
             }
         }
         let window = Arc::new(event_loop.create_window(attrs).expect("create_window"));
-        self.gpu = Some(Gpu::new(Arc::clone(&window), self.render_handles.clone()));
+        self.gpu = Some(Gpu::new(
+            Arc::clone(&window),
+            self.render_handles.clone(),
+            self.boot_wireframe.as_deref(),
+        ));
         window.request_redraw();
         let initial_size = window.inner_size();
         self.window = Some(window);
@@ -1341,6 +1358,7 @@ pub struct DesktopDriverCapability {
     pub boot_mode: WindowMode,
     pub boot_size: Option<(u32, u32)>,
     pub boot_title: String,
+    pub boot_wireframe: Option<String>,
 }
 
 pub struct DesktopDriverRunning {
@@ -1357,6 +1375,10 @@ pub struct DesktopDriverRunning {
 impl DriverCapability for DesktopDriverCapability {
     type Running = DesktopDriverRunning;
 
+    // One-shot boot wiring: kind-id lookups, mailbox claims, and the
+    // `App` construction all thread through a single flat sequence;
+    // splitting would just pass the same dozen fields through a helper.
+    #[allow(clippy::too_many_lines)]
     fn boot(self, ctx: &mut DriverCtx<'_>) -> Result<Self::Running, BootError> {
         let Self {
             event_loop,
@@ -1365,6 +1387,7 @@ impl DriverCapability for DesktopDriverCapability {
             boot_mode,
             boot_size,
             boot_title,
+            boot_wireframe,
         } = self;
 
         // Issue 629 / Phase A: render publishes its `RenderHandles`
@@ -1483,6 +1506,7 @@ impl DriverCapability for DesktopDriverCapability {
             boot_mode: boot_mode.clone(),
             boot_size,
             boot_title,
+            boot_wireframe,
             current_mode: boot_mode,
             window_inbox: window_claim.inbox,
             actor_slots: window_claim.actor_slots,
@@ -1563,6 +1587,7 @@ mod tests {
         let cfg = WindowConfig {
             mode: None,
             title: Some("my game".to_owned()),
+            wireframe: None,
         };
         assert_eq!(cfg.to_boot_title(), "my game");
     }

--- a/crates/aether-substrate-bundle/src/desktop/render.rs
+++ b/crates/aether-substrate-bundle/src/desktop/render.rs
@@ -24,7 +24,6 @@ use winit::window::Window;
 use crate::visual;
 
 pub use render::VERTEX_BUFFER_BYTES;
-use std::env;
 use std::iter;
 use std::slice;
 
@@ -108,11 +107,11 @@ enum WireframeMode {
 }
 
 impl WireframeMode {
-    // Process-level render debug toggle (AETHER_WIREFRAME), read at the desktop
-    // GPU layer — not cap config.
-    #[allow(clippy::disallowed_methods)]
-    fn from_env() -> Self {
-        match env::var("AETHER_WIREFRAME").ok().as_deref() {
+    /// `value` is the resolved `AETHER_WIREFRAME` config value (argv >
+    /// env > default via `WindowConfig::wireframe`), threaded in by the
+    /// caller — this no longer reads the env var itself.
+    fn from_config_value(value: Option<&str>) -> Self {
+        match value {
             None | Some("" | "0" | "off") => Self::Off,
             Some("line") => Self::Line,
             Some(_) => Self::Overlay, // "1", "overlay", etc.
@@ -144,7 +143,11 @@ impl Gpu {
     // takes a clone via `Arc::clone(&window)` for the surface; the
     // owning form mirrors the `RenderHandles` argument.
     #[allow(clippy::too_many_lines, clippy::needless_pass_by_value)]
-    pub fn new(window: Arc<Window>, render_handles: RenderHandles) -> Self {
+    pub fn new(
+        window: Arc<Window>,
+        render_handles: RenderHandles,
+        wireframe: Option<&str>,
+    ) -> Self {
         let instance =
             wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle_from_env());
         let surface = instance
@@ -167,7 +170,7 @@ impl Gpu {
         // feature (Metal supports it on modern macOS; some GLES-only
         // adapters don't). If unsupported we fall back to filled with
         // a warning rather than failing device creation.
-        let mut wireframe_mode = WireframeMode::from_env();
+        let mut wireframe_mode = WireframeMode::from_config_value(wireframe);
         if wireframe_mode.needs_polygon_mode_line()
             && !adapter
                 .features()
@@ -505,5 +508,20 @@ impl Gpu {
                 None
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WireframeMode;
+
+    // Tripwire: pins the soft-parse mapping `WireframeMode::from_config_value`
+    // owns (`AETHER_WIREFRAME`'s tri-state semantics threaded from
+    // `WindowConfig::wireframe`) — drifts if an arm changes.
+    #[test]
+    fn from_config_value_maps_the_tri_state() {
+        assert!(WireframeMode::from_config_value(None) == WireframeMode::Off);
+        assert!(WireframeMode::from_config_value(Some("line")) == WireframeMode::Line);
+        assert!(WireframeMode::from_config_value(Some("garbage")) == WireframeMode::Overlay);
     }
 }


### PR DESCRIPTION
Closes #2484.

## Summary

The desktop GPU boot read `AETHER_WIREFRAME` with a raw `env::var` inside `WireframeMode::from_env`, so the knob was invisible to the ADR-0090 registry: the boot sweep falsely warned on it, the `--config` dump omitted it, and it had no argv override.

The knob now rides the already-registered `WindowConfig` derive: a `wireframe: Option<String>` field with per-field overrides pinning the env key back to `AETHER_WIREFRAME` and the argv flag to `--wireframe`. The resolved value threads the same channel as `boot_title` (`WindowConfig` → `DesktopEnv` → `DesktopDriverCapability` → `App` → `Gpu::new`), and `WireframeMode::from_env` becomes `from_config_value(Option<&str>)` with the identical tri-state arms (`off`/`line`/`overlay`) and the `POLYGON_MODE_LINE` soft fallback untouched. Registration is automatic — `WindowConfigLayer::META` is already in `chassis_registry()`, and the per-field env override propagates into the collected known-key set.

Two clippy-driven touches beyond the plan text: the resolved value moves (rather than clones) out of `window_config`, and `DesktopDriverCapability::boot` gains a `#[allow(clippy::too_many_lines)]` with a stated reason (the threading pushed it just over the line limit; same allow pattern as `Gpu::new` in the same file).

## Test plan

New tripwire unit pins the tri-state parse (`None` → `Off`, `"line"` → `Line`, garbage → `Overlay`). Full workspace validation ran against the committed HEAD: clippy `-D warnings`, nextest (1907 passed), rustdoc with strict link lints.

## Generated by

`/implement` — agent execution of [scoped issue #2484](https://github.com/iamacoffeepot/aether/issues/2484).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
