### PR TITLE
refactor(capabilities): move the engine store root knob onto the engine config

### DIFF
--- a/crates/aether-capabilities/src/engine/server/config.rs
+++ b/crates/aether-capabilities/src/engine/server/config.rs
@@ -1,7 +1,8 @@
 //! Engines-cap configuration (ADR-0090) — the liveness-heartbeat
 //! tuning plus the hub binary store's layout dir, disk budget, and
-//! bootstrap list. Native-only: resolved by the hub chassis and handed
-//! into [`EngineServer::init`](super::EngineServer) via
+//! bootstrap list, and the per-engine spawn-dir parent. Native-only:
+//! resolved by the hub chassis and handed into
+//! [`EngineServer::init`](super::EngineServer) via
 //! `with_actor::<EngineServer>(cfg)`.
 
 use crate::engine::proxy::HeartbeatParams;
@@ -24,8 +25,8 @@ const DEFAULT_PROXY_CONNECT_BUDGET_SECS: u64 = 30;
 /// liveness-heartbeat tuning plus the hub binary store's layout dir,
 /// disk budget, and bootstrap list (ADR-0115, #1954 — these last three
 /// moved onto the config off their pre-ADR-0090 naked `env::var`
-/// readers). The inline `AETHER_ENGINE_STORE_ROOT` reader
-/// (`engine_store_root`) is a separate, still-inline knob.
+/// readers), plus the per-engine spawn-dir parent
+/// (`engine_store_root`, #2482 — the last of the sweep).
 ///
 /// `#[derive(aether_substrate::Config)]` emits the env-shaped
 /// `EngineConfigLayer`, the clap-shaped `EngineOverlay`, and the
@@ -36,9 +37,10 @@ const DEFAULT_PROXY_CONNECT_BUDGET_SECS: u64 = 30;
 /// directly. `env_prefix = "AETHER_HUB"` + the `heartbeat_*` /
 /// `binary_disk_budget_bytes` field names compose the
 /// `AETHER_HUB_HEARTBEAT_*` / `AETHER_HUB_BINARY_DISK_BUDGET_BYTES`
-/// env keys and `--hub-*` flags; `binary_store_dir` / `binary_bootstrap`
-/// pin the unprefixed `AETHER_BINARY_STORE_DIR` / `AETHER_BINARY_BOOTSTRAP`
-/// keys via per-field `env` overrides. `Default` (the test constructor)
+/// env keys and `--hub-*` flags; `binary_store_dir` / `engine_store_root`
+/// / `binary_bootstrap` pin the unprefixed `AETHER_BINARY_STORE_DIR` /
+/// `AETHER_ENGINE_STORE_ROOT` / `AETHER_BINARY_BOOTSTRAP` keys via
+/// per-field `env` overrides. `Default` (the test constructor)
 /// resolves the heartbeat to `0/0` (disabled) and the store fields to
 /// unset / `16 GiB`; production picks up the `default = 5/3` / `16 GiB`
 /// literals and the env layers through `from_argv_then_env`.
@@ -89,6 +91,18 @@ pub struct EngineConfig {
     /// joins the store's layout-version dir to a set override.
     #[config(env = "AETHER_BINARY_STORE_DIR")]
     pub binary_store_dir: Option<String>,
+    /// Parent-dir override for the per-engine spawn / handle-store
+    /// dirs (`AETHER_ENGINE_STORE_ROOT`, unprefixed — the ops escape
+    /// hatch and the fleet tests' per-process isolation knob, issue
+    /// 1274). Unset (`None`) → `dirs::data_dir().join("aether/engines")`,
+    /// falling back to `std::env::temp_dir().join("aether-engines")`
+    /// if no data dir is resolvable. A bare `Option<String>` (not a
+    /// `PathBuf`) keeps that runtime-computed fallback chain in
+    /// `init`, so `EngineConfig` needs no `skip_from_layer`;
+    /// `EngineServer::init` resolves it once into
+    /// `EngineServerState::engine_store_root`.
+    #[config(env = "AETHER_ENGINE_STORE_ROOT")]
+    pub engine_store_root: Option<String>,
     /// On-disk byte budget for the binary store
     /// (`AETHER_HUB_BINARY_DISK_BUDGET_BYTES`, derived from the
     /// `AETHER_HUB` prefix / `--hub-binary-disk-budget-bytes`). Default
@@ -129,6 +143,7 @@ impl Default for EngineConfig {
             // serially, so one attempt keeps the path deterministic.
             proxy_spawn_attempts: 1,
             binary_store_dir: None,
+            engine_store_root: None,
             binary_disk_budget_bytes: DEFAULT_DISK_BUDGET_BYTES,
             binary_bootstrap: HashSet::new(),
         }

--- a/crates/aether-capabilities/src/engine/server/fleet.rs
+++ b/crates/aether-capabilities/src/engine/server/fleet.rs
@@ -14,13 +14,6 @@ use std::net::TcpListener;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-/// Env override for the parent directory under which the cap
-/// allocates per-engine handle-store dirs (issue 1274). Absent →
-/// fall through to `dirs::data_dir().join("aether/engines")`, then
-/// to `std::env::temp_dir().join("aether-engines")` if no data dir
-/// is resolvable.
-const ENV_ENGINE_STORE_ROOT: &str = "AETHER_ENGINE_STORE_ROOT";
-
 /// Push a `CallSettled::Err` back to `target` (correlation
 /// preserved) so a routed call that the cap can't satisfy — bad
 /// `engine_id`, unknown engine — closes with a wire `ReplyEnd`
@@ -52,24 +45,17 @@ pub fn free_local_port() -> io::Result<u16> {
 /// Parent directory under which the cap allocates per-engine
 /// handle-store dirs (issue 1274). Priority:
 ///
-/// 1. `AETHER_ENGINE_STORE_ROOT` env override (ops escape hatch).
+/// 1. `override_dir`, an explicit override (`EngineConfig::engine_store_root`,
+///    resolved from `AETHER_ENGINE_STORE_ROOT` / `--hub-engine-store-root`
+///    at `EngineServer::init` — the ops escape hatch).
 /// 2. `dirs::data_dir().join("aether/engines")` (cross-platform
 ///    default — `~/Library/Application Support/aether/engines` on
 ///    macOS, `$XDG_DATA_HOME/aether/engines` on Linux, etc.).
 /// 3. `std::env::temp_dir().join("aether-engines")` if no data
 ///    dir is resolvable.
-// External ops escape hatch (AETHER_ENGINE_STORE_ROOT) for the per-engine
-// spawn-dir parent — the directory forked substrates and their handle
-// stores live under, resolved in a static spawn helper. #1968 deliberately
-// kept this knob inline (separate from the binary-artifact store, which it
-// moved onto EngineConfig); it is a process-level deployment override, not
-// a cap config field.
-#[allow(clippy::disallowed_methods)]
-pub fn engine_store_root() -> PathBuf {
-    if let Ok(raw) = env::var(ENV_ENGINE_STORE_ROOT)
-        && !raw.is_empty()
-    {
-        return PathBuf::from(raw);
+pub fn resolve_engine_store_root(override_dir: Option<&str>) -> PathBuf {
+    if let Some(dir) = override_dir.filter(|d| !d.is_empty()) {
+        return PathBuf::from(dir);
     }
     if let Some(data) = dirs::data_dir() {
         return data.join("aether").join("engines");

--- a/crates/aether-capabilities/src/engine/server/runtime.rs
+++ b/crates/aether-capabilities/src/engine/server/runtime.rs
@@ -46,7 +46,7 @@ pub use super::artifacts::{
     bootstrap_ingest, ingest_binary, ingest_component, realize_executable, resolve_component,
     resolve_selector,
 };
-pub use super::fleet::{engine_store_root, free_local_port, settle_err};
+pub use super::fleet::{free_local_port, resolve_engine_store_root, settle_err};
 
 /// How many recently-died engines [`EngineServer`](super::EngineServer)
 /// retains for `list_engines`' `recently_died` sidecar (issue 1906). A small
@@ -114,6 +114,12 @@ pub struct EngineServerState {
     /// exit on a fatal bind; a re-fork on a fresh port escapes it.
     /// Clamped to at least 1.
     pub spawn_attempts: u32,
+    /// Parent directory under which the cap allocates per-engine
+    /// spawn / handle-store dirs (issue 1274), resolved once from
+    /// `EngineConfig::engine_store_root` at init via
+    /// [`resolve_engine_store_root`]. `on_spawn` joins each freshly
+    /// minted `engine_id` onto this to get the engine's scratch dir.
+    pub engine_store_root: PathBuf,
     /// Bounded ring of the last [`RECENTLY_DIED_CAP`] engines that
     /// left the table and why (issue 1906). `on_terminate` /
     /// `on_engine_died` push a [`DeadRecord`] at the removal site;
@@ -208,6 +214,7 @@ impl NativeActor for EngineServer {
             heartbeat: config.heartbeat_params(),
             connect_budget: config.connect_budget(),
             spawn_attempts: config.spawn_attempts(),
+            engine_store_root: resolve_engine_store_root(config.engine_store_root.as_deref()),
             recently_died: VecDeque::new(),
             store,
         })
@@ -329,7 +336,9 @@ impl NativeActor for EngineServer {
             // hold its materialized executable.
             let engine_id = EngineId(Uuid::from_u128(state.next_engine_seq));
             state.next_engine_seq += 1;
-            let engine_store_dir = engine_store_root().join(engine_id.0.simple().to_string());
+            let engine_store_dir = state
+                .engine_store_root
+                .join(engine_id.0.simple().to_string());
 
             // Stored bytes are content-addressed and not directly
             // fork-exec'able, so materialize the resolved entry to an

--- a/crates/aether-substrate-bundle/tests/engines_cap.rs
+++ b/crates/aether-substrate-bundle/tests/engines_cap.rs
@@ -152,13 +152,20 @@ fn boot(engine_config: EngineConfig) -> (PassiveChassis<TestChassis>, Arc<Mailer
 
 /// Build the engines-cap config that isolates the hub binary store
 /// (ADR-0115) under `store_dir` and bootstraps it with the `headless` bin,
-/// so the cap resolves a `default` selector to that binary (issue 1954).
-/// The store dir / bootstrap list ride `EngineConfig` (ADR-0090) instead of
-/// the env side-channel; the heartbeat stays disabled (the `Default`).
-/// `EngineServer::init` forks `<headless> --describe` to ingest it.
-fn bootstrap_store_config(store_dir: &Path, headless: &str) -> EngineConfig {
+/// so the cap resolves a `default` selector to that binary (issue 1954),
+/// and isolates the per-engine spawn-dir parent (issue 1274) under
+/// `engine_root`. Both dirs ride `EngineConfig` (ADR-0090) instead of an
+/// env side-channel; the heartbeat stays disabled (the `Default`).
+/// `EngineServer::init` forks `<headless> --describe` to ingest the
+/// binary store and resolves `engine_root` into
+/// `EngineServerState::engine_store_root` — a per-run dir instead of the
+/// shared default (`~/.local/share/aether/engines`), which would collide
+/// with any sibling test, leaked orphan, or live MCP engine on id
+/// `0…01`.
+fn bootstrap_store_config(store_dir: &Path, engine_root: &Path, headless: &str) -> EngineConfig {
     EngineConfig {
         binary_store_dir: Some(store_dir.to_string_lossy().into_owned()),
+        engine_store_root: Some(engine_root.to_string_lossy().into_owned()),
         binary_bootstrap: HashSet::from([headless.to_owned()]),
         ..EngineConfig::default()
     }
@@ -267,17 +274,8 @@ mod tests {
         let store_dir =
             env::temp_dir().join(format!("aether-engcap-binstore-{}-{nanos}", process::id()));
         let root = env::temp_dir().join(format!("aether-engcap-store-{}-{nanos}", process::id()));
-        // SAFETY: nextest runs each test in its own process, so the env
-        // mutation here doesn't race sibling tests. `AETHER_ENGINE_STORE_ROOT`
-        // must be set before `boot()` so the cap's `engine_store_root()`
-        // resolves to this unique per-run dir instead of the shared default
-        // (`~/.local/share/aether/engines`), which would collide with any
-        // sibling test, leaked orphan, or live MCP engine on id 0…01.
-        unsafe {
-            env::set_var("AETHER_ENGINE_STORE_ROOT", &root);
-        }
 
-        let (_chassis, mailer, cells) = boot(bootstrap_store_config(&store_dir, headless));
+        let (_chassis, mailer, cells) = boot(bootstrap_store_config(&store_dir, &root, headless));
 
         // Spawn: the cap assigns a port, forks the substrate, and the
         // proxy retries the dial until the fresh process binds. Generous
@@ -410,17 +408,15 @@ mod tests {
 
         let store_dir = dir.join("store");
         let root = dir.join("engines");
-        // SAFETY: nextest runs each test in its own process, so this env
-        // mutation can't race a sibling. Must precede `boot()` so the
-        // cap's `engine_store_root()` resolves to this per-run dir.
-        unsafe {
-            env::set_var("AETHER_ENGINE_STORE_ROOT", &root);
-        }
 
         // A short connect budget so the doomed dial fails quickly rather
-        // than burning the default 30 s.
+        // than burning the default 30 s. `engine_store_root` isolates this
+        // run's per-engine spawn-dir parent (issue 1274) from the shared
+        // default, which would collide with any sibling test, leaked
+        // orphan, or live MCP engine on id `0…01`.
         let config = EngineConfig {
             binary_store_dir: Some(store_dir.to_string_lossy().into_owned()),
+            engine_store_root: Some(root.to_string_lossy().into_owned()),
             binary_bootstrap: HashSet::from([stand_in.to_string_lossy().into_owned()]),
             proxy_connect_budget_secs: 2,
             ..EngineConfig::default()

--- a/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
+++ b/crates/aether-substrate-bundle/tests/fleetbench/mod.rs
@@ -271,7 +271,7 @@ impl FleetBench {
     /// `TcpStream`, and complete the `Hello`/`HelloAck` handshake.
     pub fn start() -> Self {
         let store_root = isolate_store_root();
-        let (chassis, port) = boot_hub(&store_root.join("binaries"));
+        let (chassis, port) = boot_hub(&store_root.join("binaries"), &store_root);
         let stream = TcpStream::connect(format!("127.0.0.1:{port}"))
             .expect("test setup: connecting to the hub's bound RPC port succeeds");
         // The read timeout is the re-arm *interval*, not a deadline: every
@@ -1075,24 +1075,19 @@ impl Drop for FleetBench {
 /// Point this bench's forked substrates at a unique per-process scratch
 /// root for their per-engine executable materialization (ADR-0115), so a
 /// concurrent fork+exec test on the shared default
-/// `dirs::data_dir()/aether/engines` root can't collide. The cap reads
-/// `AETHER_ENGINE_STORE_ROOT` when it forks (priority over the default).
+/// `dirs::data_dir()/aether/engines` root can't collide. Threaded into
+/// `boot_hub` as `EngineConfig::engine_store_root` (ADR-0090) — not an
+/// env var — so the cap resolves it at `EngineServer::init`.
 fn isolate_store_root() -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| d.as_nanos());
-    let root = env::temp_dir().join(format!("aether-fleetbench-{}-{nanos}", process::id()));
-    // SAFETY: nextest runs each integration test in its own process, so
-    // this env mutation can't race a sibling test; each `FleetBench` in a
-    // process gets a fresh `nanos`-tagged root.
+    // Each `FleetBench` in a process gets a fresh `nanos`-tagged root, so
+    // a concurrent bench in the same process can't collide either.
     //
     // The hub's binary store (ADR-0115) is isolated under `root/binaries`
-    // too, but that dir rides `EngineConfig::binary_store_dir` (ADR-0090)
-    // now, threaded into `boot_hub` from the returned root — not an env var.
-    unsafe {
-        env::set_var("AETHER_ENGINE_STORE_ROOT", &root);
-    }
-    root
+    // too, but that dir rides `EngineConfig::binary_store_dir` (ADR-0090).
+    env::temp_dir().join(format!("aether-fleetbench-{}-{nanos}", process::id()))
 }
 
 /// Boot a hub-shaped passive chassis: a forwarding `RpcServerCapability`
@@ -1100,9 +1095,14 @@ fn isolate_store_root() -> PathBuf {
 /// cap, and `TraceDispatchCapability` so the `RpcServer`'s local Calls
 /// settle and close. Returns the chassis and the port the RPC server
 /// bound. Mirrors the seed's `boot_hub`. `binary_store_dir` isolates the
-/// hub's content-addressed store (ADR-0115) per-bench via `EngineConfig`
-/// (ADR-0090); the heartbeat stays disabled (the `Default`).
-fn boot_hub(binary_store_dir: &Path) -> (PassiveChassis<TestChassis>, u16) {
+/// hub's content-addressed store (ADR-0115) per-bench, and
+/// `engine_store_root` isolates the per-engine spawn-dir parent (issue
+/// 1274) per-bench — both via `EngineConfig` (ADR-0090); the heartbeat
+/// stays disabled (the `Default`).
+fn boot_hub(
+    binary_store_dir: &Path,
+    engine_store_root: &Path,
+) -> (PassiveChassis<TestChassis>, u16) {
     let registry = Arc::new(Registry::new());
     for d in descriptors::all() {
         let _ = registry.register_kind_with_descriptor(d);
@@ -1113,6 +1113,7 @@ fn boot_hub(binary_store_dir: &Path) -> (PassiveChassis<TestChassis>, u16) {
         .with_actor::<TraceDispatchCapability>(())
         .with_actor::<EngineServer>(EngineConfig {
             binary_store_dir: Some(binary_store_dir.to_string_lossy().into_owned()),
+            engine_store_root: Some(engine_store_root.to_string_lossy().into_owned()),
             ..EngineConfig::default()
         })
         .with_actor::<RpcServerCapability>(RpcServerConfig {

--- a/crates/aether-substrate-bundle/tests/rpc_engine_routing.rs
+++ b/crates/aether-substrate-bundle/tests/rpc_engine_routing.rs
@@ -232,20 +232,16 @@ mod tests {
             process::id()
         ));
         let root = env::temp_dir().join(format!("aether-rpcroute-store-{}-{nanos}", process::id()));
-        // SAFETY: nextest runs each test in its own process, so the env
-        // mutation here doesn't race sibling tests. `AETHER_ENGINE_STORE_ROOT`
-        // must be set before `boot_hub()` so the cap's `engine_store_root()`
-        // resolves to this unique per-run dir instead of the shared default
-        // (`~/.local/share/aether/engines`), which would collide with any
-        // sibling test, leaked orphan, or live MCP engine on id 0…01.
-        unsafe {
-            env::set_var("AETHER_ENGINE_STORE_ROOT", &root);
-        }
-        // The store dir / bootstrap list ride `EngineConfig` (ADR-0090)
-        // instead of the env side-channel; the heartbeat stays disabled
-        // (the `Default`).
+        // The store dir / engine-store-root / bootstrap list ride
+        // `EngineConfig` (ADR-0090) instead of an env side-channel; the
+        // heartbeat stays disabled (the `Default`). `engine_store_root`
+        // isolates this run's per-engine spawn-dir parent (issue 1274)
+        // from the shared default (`~/.local/share/aether/engines`),
+        // which would collide with any sibling test, leaked orphan, or
+        // live MCP engine on id `0…01`.
         let engine_config = EngineConfig {
             binary_store_dir: Some(bin_store.to_string_lossy().into_owned()),
+            engine_store_root: Some(root.to_string_lossy().into_owned()),
             binary_bootstrap: HashSet::from([headless.to_owned()]),
             ..EngineConfig::default()
         };


### PR DESCRIPTION
Closes #2482.

## Summary

The engines cap resolved its per-engine spawn / handle-store parent through a raw `env::var("AETHER_ENGINE_STORE_ROOT")` read in `fleet.rs` — the last raw env read in the cap after #1954 moved the three sibling binary-store knobs onto the derive-`Config` `EngineConfig`.

The knob now rides `EngineConfig` as `engine_store_root: Option<String>` with a per-field env override (key unchanged), mirroring `binary_store_dir` exactly. `EngineServer::init` resolves it once via the renamed `resolve_engine_store_root(Option<&str>)` — which keeps the `dirs::data_dir()` → `temp_dir()` fallback chain — into a new `EngineServerState::engine_store_root`, and `on_spawn` joins engine ids onto the resolved path. The `ENV_ENGINE_STORE_ROOT` const, the raw read, and its `#[allow(clippy::disallowed_methods)]` are gone; the knob gains the `--hub-engine-store-root` argv override and config-registry membership.

The three integration-test harnesses (`engines_cap.rs`, `rpc_engine_routing.rs`, `fleetbench/mod.rs`) now set the config field directly instead of `unsafe { env::set_var }`, preserving each run's store-root isolation without process-env mutation.

## Test plan

The three converted integration tests are the regression surface — they fork real substrates into the resolved root and stay green. Full workspace validation against the committed HEAD: clippy `-D warnings` (confirms the `#[allow]` removal left nothing behind), nextest (1906 passed; one unrelated `builder::tests` flake passed on clean re-run), strict rustdoc.

## Generated by

`/implement` — agent execution of [scoped issue #2482](https://github.com/iamacoffeepot/aether/issues/2482).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
