### PR TITLE
refactor(substrate): resolve scheduler tuning through the config layer

### DIFF
--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -55,6 +55,9 @@ fn main() -> anyhow::Result<()> {
         // ring caps; the in-process `TestBench` builder is the surface
         // for tuning them (per-bench, no process env).
         ring_caps: aether_substrate::RingCapacities::default(),
+        // Issue 2485: the standalone binary keeps the built-in scheduler
+        // tuning (per-bench, no process env).
+        scheduler_tuning: aether_substrate::SchedulerTuning::default(),
         observed_kinds: None,
         events_tx,
         capture_queue: capture_queue.clone(),

--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -43,11 +43,10 @@ use aether_labyrinth::TrajectoryRecorderCapability;
 use aether_substrate::chassis::Chassis;
 use aether_substrate::chassis::builder::Builder;
 use aether_substrate::config::{
-    KnobKind, KnobRecord, KnownKeys, RingCapacities, dump_config, known_keys,
+    KnobKind, KnobRecord, KnownKeys, RingCapacities, SchedulerTuning, dump_config, known_keys,
 };
 use aether_substrate::runtime::RUNTIME_KNOBS;
 use aether_substrate::runtime::lifecycle::FatalAborter;
-use aether_substrate::scheduler::SCHEDULER_KNOBS;
 use confique::Config as _;
 use confique::meta::Meta;
 
@@ -61,10 +60,9 @@ use crate::headless::driver::TickConfigLayer;
 /// cannot depend on `aether-substrate`, where `KnobRecord`/`KnobKind`
 /// live). Registered as [`KnobRecord`]s so e1's unknown-`AETHER_*`
 /// sweep doesn't flag them and e2's `--config` dump lists them.
-/// ADR-0090 §1/§4. The scheduler hot-path knobs are registered
-/// separately by unit b2's `SCHEDULER_KNOBS`, the runtime (log /
-/// panic-hook) knobs by `aether_substrate::runtime::RUNTIME_KNOBS`;
-/// the chassis boot / window / tick knobs are now covered by the
+/// ADR-0090 §1/§4. The runtime (log / panic-hook) knobs are registered
+/// by `aether_substrate::runtime::RUNTIME_KNOBS`; the scheduler
+/// hot-path, chassis boot, window, and tick knobs are covered by the
 /// derive-emitted `*Layer::META`s in [`chassis_registry`].
 pub const CHASSIS_KNOBS: &[KnobRecord] = &[
     KnobRecord {
@@ -140,6 +138,113 @@ impl ActorRingConfig {
             log: self.log_ring_capacity,
             trace: self.trace_ring_capacity,
             trace_max: self.trace_ring_max_size,
+        }
+    }
+}
+
+/// The nine scheduler hot-path tuning knobs (issue 2485), resolved once
+/// at chassis boot and lowered via [`Self::to_scheduler_tuning`] to the
+/// `Copy` [`SchedulerTuning`] the chassis builder installs into the
+/// scheduler's process-global before the pool starts. The
+/// `#[derive(aether_substrate::Config)]` emits the env-shaped
+/// `SchedulerTuningConfigLayer`, the clap-shaped `SchedulerTuningOverlay`,
+/// the `FromArgvThenEnv` impl, and the inherent `from_env` /
+/// `from_argv_then_env` / `try_*` shims (ADR-0090 unit d/g) — replacing
+/// the nine hand-registered `KnobRecord`s the scheduler read directly from
+/// env. A garbage value for a concrete knob hard-errors at boot (ADR-0090
+/// §4); the `nonzero` knobs coerce a resolved `0` to their default; the
+/// three adaptive knobs are `Option` (unset / `< 1` → the measured /
+/// derived behaviour).
+///
+/// Each field pins its historical `AETHER_*` env key explicitly (the keys
+/// don't follow the `env_prefix` shape); the Rust identifiers spell the
+/// unit out (`micros` / `nanos`) while the env keys stay byte-for-byte.
+#[derive(Clone, Debug, aether_substrate::Config)]
+#[config(env_prefix = "AETHER", cli_prefix = "scheduler")]
+pub struct SchedulerTuningConfig {
+    /// `AETHER_SPIN_WINDOW_USEC=<micros>` route-to-spinner spin-window
+    /// before a worker parks (default `50`). A `0` is valid (no spin).
+    #[config(env = "AETHER_SPIN_WINDOW_USEC", default = 50)]
+    pub spin_window_micros: u64,
+    /// `AETHER_LOCAL_STICKY_MAX=<slots>` deque-length backstop (default
+    /// `256`; a resolved `0` coerces to the default).
+    #[config(env = "AETHER_LOCAL_STICKY_MAX", default = 256, nonzero)]
+    pub local_sticky_max: usize,
+    /// `AETHER_LOCAL_TIME_BUDGET_US=<micros>` keep-local time valve.
+    /// Unset → adaptive (derived from the measured handoff cost); `0`
+    /// disables the valve (pure inline-cascade).
+    #[config(env = "AETHER_LOCAL_TIME_BUDGET_US")]
+    pub time_budget_micros: Option<u64>,
+    /// `AETHER_PEER_STEAL=<bool>` whether idle workers may raid siblings'
+    /// deques (default `false` — owner-only). Accepts `1`/`true`/`yes`.
+    #[config(env = "AETHER_PEER_STEAL", default = false)]
+    pub peer_steal: bool,
+    /// `AETHER_LOCAL_CHAIN_BACKSTOP=<k>` every-K injector backstop for
+    /// keep-local chains (default `64`; a resolved `0` coerces to it).
+    #[config(env = "AETHER_LOCAL_CHAIN_BACKSTOP", default = 64, nonzero)]
+    pub local_chain_backstop: u32,
+    /// `AETHER_HANDOFF_COST_NS=<nanos>` pins the cross-worker handoff-cost
+    /// estimate and freezes live refinement. Unset / `< 1` → boot-probed
+    /// and live-refined ([`Self::to_scheduler_tuning`] filters `< 1` to
+    /// `None`).
+    #[config(env = "AETHER_HANDOFF_COST_NS")]
+    pub handoff_cost_nanos: Option<u64>,
+    /// `AETHER_BLOB_RECRUIT_MIN=<groups>` minimum fresh-group count for a
+    /// flush to broadcast-recruit siblings (default `9`; `0` coerces to
+    /// it).
+    #[config(env = "AETHER_BLOB_RECRUIT_MIN", default = 9, nonzero)]
+    pub blob_recruit_min: usize,
+    /// `AETHER_BLOB_RECRUIT_MAX=<copies>` cap on sibling copies a single
+    /// flush injects when recruiting (default `32`; `0` coerces to it).
+    #[config(env = "AETHER_BLOB_RECRUIT_MAX", default = 32, nonzero)]
+    pub blob_recruit_max: usize,
+    /// `AETHER_WAKE_COST_NANOS=<nanos>` pins the recruit wake break-even
+    /// and freezes live refinement. Unset / `< 1` → the box-measured
+    /// handoff cost ([`Self::to_scheduler_tuning`] filters `< 1` to
+    /// `None`).
+    #[config(env = "AETHER_WAKE_COST_NANOS")]
+    pub wake_cost_nanos: Option<u64>,
+}
+
+impl Default for SchedulerTuningConfig {
+    fn default() -> Self {
+        // These literals must equal `SchedulerTuning::default()`;
+        // `scheduler_tuning_defaults_match` guards the pair.
+        Self {
+            spin_window_micros: 50,
+            local_sticky_max: 256,
+            time_budget_micros: None,
+            peer_steal: false,
+            local_chain_backstop: 64,
+            handoff_cost_nanos: None,
+            blob_recruit_min: 9,
+            blob_recruit_max: 32,
+            wake_cost_nanos: None,
+        }
+    }
+}
+
+impl SchedulerTuningConfig {
+    /// Lower the resolved knob to the `Copy` [`SchedulerTuning`] the
+    /// chassis builder installs before `Pool::start`. The only logic this
+    /// crate owns is the `< 1 → None` filter on the two pin knobs
+    /// (`handoff_cost_nanos` / `wake_cost_nanos`): a `0` pin would disable
+    /// the gate it guards, so it falls through to the measured cost (the
+    /// concrete knobs' `< 1 → default` is handled by the `nonzero` hint;
+    /// `time_budget_micros`'s `0` is a meaningful "disable the valve" and
+    /// passes through).
+    #[must_use]
+    pub fn to_scheduler_tuning(&self) -> SchedulerTuning {
+        SchedulerTuning {
+            spin_window_micros: self.spin_window_micros,
+            local_sticky_max: self.local_sticky_max,
+            time_budget_micros: self.time_budget_micros,
+            peer_steal: self.peer_steal,
+            local_chain_backstop: self.local_chain_backstop,
+            handoff_cost_nanos: self.handoff_cost_nanos.filter(|&n| n >= 1),
+            blob_recruit_min: self.blob_recruit_min,
+            blob_recruit_max: self.blob_recruit_max,
+            wake_cost_nanos: self.wake_cost_nanos.filter(|&n| n >= 1),
         }
     }
 }
@@ -275,12 +380,10 @@ impl ChassisBootConfig {
 
 /// Assemble the chassis-wide [`KnownKeys`] set (ADR-0090 §4): every
 /// migrated `*Layer::META` (http / gemini / anthropic / audio / fs /
-/// chassis-boot / window / tick) plus the hand-registered chassis knobs
-/// ([`CHASSIS_KNOBS`] — the RPC port and the orphaned frame-size knob),
-/// the scheduler hot-path knobs (b2's
-/// `aether_substrate::scheduler::SCHEDULER_KNOBS`), and the runtime
-/// log-filter / panic-hook knobs
-/// (`aether_substrate::runtime::RUNTIME_KNOBS`). e1's
+/// actor-ring / scheduler-tuning / chassis-boot / window / tick) plus
+/// the hand-registered chassis knobs ([`CHASSIS_KNOBS`] — the RPC port
+/// and the orphaned frame-size knob) and the runtime log-filter /
+/// panic-hook knobs (`aether_substrate::runtime::RUNTIME_KNOBS`). e1's
 /// [`validate_env`](aether_substrate::config::validate_env) sweeps the
 /// process env against this; e2's `--config` dump walks the same
 /// metas + records.
@@ -296,11 +399,11 @@ pub fn chassis_known_keys() -> KnownKeys {
 }
 
 /// The chassis-wide config registry: the migrated cap layer `Meta`s
-/// plus the hand-registered knob records (`CHASSIS_KNOBS` + b2's
-/// `SCHEDULER_KNOBS` + `aether_substrate::runtime::RUNTIME_KNOBS`).
-/// Shared by [`chassis_known_keys`] (e1's sweep) and
-/// [`chassis_config_dump`] (e2's `--config`) so both read one source
-/// of truth.
+/// (including the scheduler hot-path knobs' `SchedulerTuningConfigLayer`)
+/// plus the hand-registered knob records (`CHASSIS_KNOBS` +
+/// `aether_substrate::runtime::RUNTIME_KNOBS`). Shared by
+/// [`chassis_known_keys`] (e1's sweep) and [`chassis_config_dump`] (e2's
+/// `--config`) so both read one source of truth.
 fn chassis_registry() -> (&'static [&'static Meta], Vec<KnobRecord>) {
     const METAS: &[&Meta] = &[
         &HttpConfigLayer::META,
@@ -311,13 +414,13 @@ fn chassis_registry() -> (&'static [&'static Meta], Vec<KnobRecord>) {
         &AudioConfigLayer::META,
         &NamespaceRootsLayer::META,
         &ActorRingConfigLayer::META,
+        &SchedulerTuningConfigLayer::META,
         &SettlementConfigLayer::META,
         &ChassisBootConfigLayer::META,
         &WindowConfigLayer::META,
         &TickConfigLayer::META,
     ];
     let mut records: Vec<KnobRecord> = CHASSIS_KNOBS.to_vec();
-    records.extend_from_slice(SCHEDULER_KNOBS);
     records.extend_from_slice(RUNTIME_KNOBS);
     (METAS, records)
 }
@@ -473,6 +576,9 @@ pub struct CommonBoot {
     /// Issue 1990: per-actor ring capacities, resolved from the
     /// `ActorRingConfig` derive-`Config` knob in the chassis main.
     pub ring_caps: RingCapacities,
+    /// Issue 2485: scheduler hot-path tuning, resolved from the
+    /// `SchedulerTuningConfig` derive-`Config` knob in the chassis main.
+    pub scheduler_tuning: SchedulerTuning,
     pub input_config: InputConfig,
     pub component_host_config: ComponentHostConfig,
     pub namespace_roots: NamespaceRoots,
@@ -507,6 +613,7 @@ pub fn with_common_caps<C: Chassis>(builder: Builder<C>, boot: CommonBoot) -> Bu
         .with_aborter(boot.aborter)
         .with_workers(boot.workers)
         .with_ring_caps(boot.ring_caps)
+        .with_scheduler_tuning(boot.scheduler_tuning)
         .with_actor::<TraceDispatchCapability>(())
         .with_actor::<TrajectoryRecorderCapability>(())
         .with_actor::<InputCapability>(boot.input_config)
@@ -613,11 +720,13 @@ mod tests {
     use super::ChassisBootConfigLayer;
     use super::DEFAULT_LIFECYCLE_ADVANCE_TIMEOUT_MS;
     use super::DEFAULT_SETTLEMENT_CAP_SECS;
+    use super::SchedulerTuningConfigLayer;
     use super::SettlementConfig;
     use super::chassis_known_keys;
     use aether_actor::log::DEFAULT_RING_CAP;
     use aether_actor::trace::{DEFAULT_TRACE_RING_CAP, DEFAULT_TRACE_RING_MAX_CAP};
     use aether_capabilities::LifecycleConfig;
+    use aether_substrate::SchedulerTuning;
     use std::env;
     use std::sync::Mutex;
     use std::sync::PoisonError;
@@ -702,6 +811,54 @@ mod tests {
         assert!(known.contains("AETHER_ACTOR_LOG_RING_SIZE"));
         assert!(known.contains("AETHER_ACTOR_TRACE_RING_SIZE"));
         assert!(known.contains("AETHER_ACTOR_TRACE_RING_MAX_SIZE"));
+    }
+
+    #[test]
+    fn scheduler_tuning_defaults_match() {
+        use confique::Config as _;
+        // Tripwire: the `SchedulerTuningConfigLayer` `default = ...`
+        // literals must equal `SchedulerTuning::default()` (issue 2485).
+        // The confique layer and the `Copy` `SchedulerTuning` carry the
+        // scheduler defaults independently; a change to one and not the
+        // other silently shifts the resolved-vs-installed behaviour. No
+        // `.env()` source: literal defaults only — env-free.
+        let _guard = RING_ENV_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
+        let layer = SchedulerTuningConfigLayer::builder()
+            .load()
+            .expect("defaults load");
+        let default = SchedulerTuning::default();
+        assert_eq!(layer.spin_window_micros, default.spin_window_micros);
+        assert_eq!(layer.local_sticky_max, default.local_sticky_max);
+        assert_eq!(layer.peer_steal, default.peer_steal);
+        assert_eq!(layer.local_chain_backstop, default.local_chain_backstop);
+        assert_eq!(layer.blob_recruit_min, default.blob_recruit_min);
+        assert_eq!(layer.blob_recruit_max, default.blob_recruit_max);
+        // The three adaptive knobs default unset (None → measured/derived).
+        assert_eq!(layer.time_budget_micros, None);
+        assert_eq!(layer.handoff_cost_nanos, None);
+        assert_eq!(layer.wake_cost_nanos, None);
+    }
+
+    #[test]
+    fn scheduler_tuning_keys_are_known() {
+        // The nine scheduler hot-path env keys join the chassis known-key
+        // set via `SchedulerTuningConfigLayer::META` (they rode
+        // `SCHEDULER_KNOBS` before issue 2485), so the unknown-AETHER_*
+        // sweep (e1) doesn't flag them and the `--config` dump lists them.
+        let known = chassis_known_keys();
+        for key in [
+            "AETHER_SPIN_WINDOW_USEC",
+            "AETHER_LOCAL_STICKY_MAX",
+            "AETHER_LOCAL_TIME_BUDGET_US",
+            "AETHER_PEER_STEAL",
+            "AETHER_LOCAL_CHAIN_BACKSTOP",
+            "AETHER_HANDOFF_COST_NS",
+            "AETHER_BLOB_RECRUIT_MIN",
+            "AETHER_BLOB_RECRUIT_MAX",
+            "AETHER_WAKE_COST_NANOS",
+        ] {
+            assert!(known.contains(key), "{key} must be a known scheduler key");
+        }
     }
 
     #[test]

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -38,12 +38,12 @@ use winit::event_loop::EventLoop;
 use super::driver::{DesktopDriverCapability, WindowConfig};
 use crate::autoload::{AutoloadComponent, autoload_mail, boot_manifest_autoload};
 use crate::chassis_common::{
-    ActorRingConfig, ChassisBootConfig, CommonBoot, chassis_known_keys, frame_lifecycle_config,
-    maybe_with_http_server, maybe_with_rpc_server, with_common_caps,
+    ActorRingConfig, ChassisBootConfig, CommonBoot, SchedulerTuningConfig, chassis_known_keys,
+    frame_lifecycle_config, maybe_with_http_server, maybe_with_rpc_server, with_common_caps,
 };
 use crate::cli::{CommonOverlay, DesktopCli};
 use crate::hub;
-use aether_substrate::config::{ConfigError, RingCapacities, validate_env};
+use aether_substrate::config::{ConfigError, RingCapacities, SchedulerTuning, validate_env};
 use aether_substrate::runtime::lifecycle::FatalAborter;
 use aether_substrate::runtime::lifecycle::OutboundFatalAborter;
 use std::path::Path;
@@ -208,6 +208,11 @@ pub struct DesktopEnv {
     /// `AETHER_ACTOR_TRACE_RING_SIZE`). Default is
     /// [`RingCapacities::default`] (the `aether-actor` const caps).
     pub ring_caps: RingCapacities,
+    /// Issue 2485: scheduler hot-path tuning resolved from the
+    /// `SchedulerTuningConfig` knob (`AETHER_SPIN_WINDOW_USEC` /
+    /// `AETHER_LOCAL_STICKY_MAX` / …). Default is
+    /// [`SchedulerTuning::default`] (the built-in scheduler literals).
+    pub scheduler_tuning: SchedulerTuning,
     /// Force-complete deadline (ms) for a pending lifecycle advance's
     /// `Settled` (issue 1048). Resolved from
     /// `AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS` via `ChassisBootConfig`;
@@ -324,6 +329,11 @@ impl DesktopEnv {
         // `AETHER_ACTOR_{LOG,TRACE}_RING_SIZE` (ADR-0090 §4 hard-error on
         // an unparseable known value, surfaced as `DesktopBootError::Config`).
         let ring_caps = ActorRingConfig::try_from_env()?.to_ring_capacities();
+        // Issue 2485: resolve the scheduler hot-path tuning from
+        // `AETHER_SPIN_WINDOW_USEC` / `AETHER_LOCAL_*` / `AETHER_BLOB_*` /
+        // `AETHER_*_COST_*` (ADR-0090 §4 hard-error on an unparseable
+        // known value, surfaced as `DesktopBootError::Config`).
+        let scheduler_tuning = SchedulerTuningConfig::try_from_env()?.to_scheduler_tuning();
 
         Ok(Self {
             event_loop,
@@ -342,6 +352,7 @@ impl DesktopEnv {
             rpc_addr,
             workers,
             ring_caps,
+            scheduler_tuning,
             lifecycle_advance_timeout_millis,
             autoload,
         })
@@ -375,6 +386,7 @@ impl DesktopChassis {
             rpc_addr,
             workers,
             ring_caps,
+            scheduler_tuning,
             lifecycle_advance_timeout_millis,
             autoload,
         } = env;
@@ -446,6 +458,7 @@ impl DesktopChassis {
             aborter,
             workers,
             ring_caps,
+            scheduler_tuning,
             input_config,
             component_host_config,
             namespace_roots,

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -36,12 +36,12 @@ use aether_substrate::{Chassis, SubstrateBoot};
 use super::driver::{HeadlessTimerDriverCapability, TickConfig};
 use crate::autoload::{AutoloadComponent, autoload_mail, boot_manifest_autoload};
 use crate::chassis_common::{
-    ActorRingConfig, ChassisBootConfig, CommonBoot, chassis_known_keys, maybe_with_http_server,
-    maybe_with_rpc_server, tick_only_lifecycle_config, with_common_caps,
+    ActorRingConfig, ChassisBootConfig, CommonBoot, SchedulerTuningConfig, chassis_known_keys,
+    maybe_with_http_server, maybe_with_rpc_server, tick_only_lifecycle_config, with_common_caps,
 };
 use crate::cli::{CommonOverlay, HeadlessCli};
 use crate::hub;
-use aether_substrate::config::{ConfigError, RingCapacities, validate_env};
+use aether_substrate::config::{ConfigError, RingCapacities, SchedulerTuning, validate_env};
 use aether_substrate::mail::registry::MailDispatch;
 use aether_substrate::runtime::lifecycle::FatalAborter;
 use aether_substrate::runtime::lifecycle::OutboundFatalAborter;
@@ -120,6 +120,11 @@ pub struct HeadlessEnv {
     /// `AETHER_ACTOR_TRACE_RING_SIZE`). Default is
     /// [`RingCapacities::default`] (the `aether-actor` const caps).
     pub ring_caps: RingCapacities,
+    /// Issue 2485: scheduler hot-path tuning resolved from the
+    /// `SchedulerTuningConfig` knob (`AETHER_SPIN_WINDOW_USEC` /
+    /// `AETHER_LOCAL_STICKY_MAX` / …). Default is
+    /// [`SchedulerTuning::default`] (the built-in scheduler literals).
+    pub scheduler_tuning: SchedulerTuning,
     /// `AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS` — timeout for one lifecycle
     /// advance step (Tick) before the scheduler logs a slow-frame warning.
     /// Resolved through `ChassisBootConfig`; default is 1000 ms.
@@ -215,6 +220,10 @@ impl HeadlessEnv {
         // `AETHER_ACTOR_{LOG,TRACE}_RING_SIZE` (ADR-0090 §4 hard-error on
         // an unparseable known value, surfaced as `ConfigError`).
         let ring_caps = ActorRingConfig::try_from_env()?.to_ring_capacities();
+        // Issue 2485: resolve the scheduler hot-path tuning (ADR-0090 §4
+        // hard-error on an unparseable known value, surfaced as
+        // `ConfigError`).
+        let scheduler_tuning = SchedulerTuningConfig::try_from_env()?.to_scheduler_tuning();
         Ok(Self {
             namespace_roots,
             http,
@@ -226,6 +235,7 @@ impl HeadlessEnv {
             rpc_addr,
             workers,
             ring_caps,
+            scheduler_tuning,
             lifecycle_advance_timeout_millis,
             autoload,
         })
@@ -252,6 +262,7 @@ impl HeadlessChassis {
             rpc_addr,
             workers,
             ring_caps,
+            scheduler_tuning,
             lifecycle_advance_timeout_millis,
             autoload,
         } = env;
@@ -333,6 +344,7 @@ impl HeadlessChassis {
             aborter,
             workers,
             ring_caps,
+            scheduler_tuning,
             input_config,
             component_host_config,
             namespace_roots,

--- a/crates/aether-substrate-bundle/src/hub/chassis.rs
+++ b/crates/aether-substrate-bundle/src/hub/chassis.rs
@@ -25,7 +25,7 @@ use aether_substrate::chassis::error::BootError;
 use aether_substrate::config::{ConfigError, validate_env};
 use aether_substrate::{Chassis, SubstrateBoot};
 
-use crate::chassis_common::{ActorRingConfig, hub_known_keys};
+use crate::chassis_common::{ActorRingConfig, SchedulerTuningConfig, hub_known_keys};
 use crate::cli::HubCli;
 use crate::hub::DEFAULT_RPC_PORT;
 use std::thread;
@@ -133,9 +133,15 @@ impl HubChassis {
         // chassis honours `AETHER_ACTOR_{LOG,TRACE}_RING_SIZE` like the
         // full-stack chassis (which thread it via `with_common_caps`).
         let ring_caps = ActorRingConfig::try_from_env()?.to_ring_capacities();
+        // Issue 2485: resolve the scheduler hot-path tuning so the hub
+        // chassis honours `AETHER_SPIN_WINDOW_USEC` / `AETHER_LOCAL_*` /
+        // etc. like the full-stack chassis (which thread it via
+        // `with_common_caps`).
+        let scheduler_tuning = SchedulerTuningConfig::try_from_env()?.to_scheduler_tuning();
 
         Builder::<Self>::new(registry, mailer)
             .with_ring_caps(ring_caps)
+            .with_scheduler_tuning(scheduler_tuning)
             .with_actor::<TraceDispatchCapability>(())
             // Liveness-heartbeat tuning (issue 1339), resolved
             // argv-then-env in `HubEnv::from_env_with_argv`.

--- a/crates/aether-substrate-bundle/src/lib.rs
+++ b/crates/aether-substrate-bundle/src/lib.rs
@@ -43,8 +43,8 @@ pub use aether_capabilities as capabilities;
 pub use aether_capabilities::{ComponentHostCapability, ComponentHostConfig};
 pub use aether_substrate::{
     Chassis, Component, ComponentCtx, HubOutbound, InboxHandler, InlineHandler, KindId, Mail,
-    MailKind, MailboxEntry, MailboxId, Mailer, OwnedDispatch, Registry, RingCapacities, Source,
-    SourceAddr, SubstrateBoot,
+    MailKind, MailboxEntry, MailboxId, Mailer, OwnedDispatch, Registry, RingCapacities,
+    SchedulerTuning, Source, SourceAddr, SubstrateBoot,
     actor::wasm::{component, host_fns, kind_manifest, reply_table},
     capture::{CaptureQueue, PendingCapture},
     chassis::frame_loop,

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -46,8 +46,8 @@ use aether_substrate::chassis::settlement::{
     TerminalDisposition, WaitOutcome, await_internal_signal,
 };
 use aether_substrate::{
-    EgressEvent, HubOutbound, Mailer, PassiveChassis, RecordingBackend, RingCapacities, Source,
-    SourceAddr, SubstrateBoot,
+    EgressEvent, HubOutbound, Mailer, PassiveChassis, RecordingBackend, RingCapacities,
+    SchedulerTuning, Source, SourceAddr, SubstrateBoot,
     capture::CaptureQueue,
     mail::{CapabilityRegistry, CostTable, Mail, MailId, MailboxId},
 };
@@ -424,6 +424,7 @@ impl TestBench {
             workers: WORKERS,
             pool_workers,
             ring_caps,
+            scheduler_tuning: SchedulerTuning::default(),
             observed_kinds: Some(Arc::clone(&observed_kinds)),
             events_tx,
             capture_queue: capture_queue.clone(),

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -26,7 +26,8 @@ use aether_labyrinth::TrajectoryRecorderCapability;
 use aether_substrate::chassis::builder::{Builder, BuiltChassis, NeverDriver, PassiveChassis};
 use aether_substrate::chassis::error::BootError;
 use aether_substrate::{
-    Chassis, RingCapacities, SubstrateBoot, capture::CaptureQueue, render::VERTEX_BUFFER_BYTES,
+    Chassis, RingCapacities, SchedulerTuning, SubstrateBoot, capture::CaptureQueue,
+    render::VERTEX_BUFFER_BYTES,
 };
 
 use super::cap::{TestBenchCapConfig, TestBenchCapability};
@@ -126,6 +127,10 @@ pub struct TestBenchEnv {
     /// `aether-actor` const caps; a `TestBench` eviction test pins a small
     /// trace cap to observe `truncated_before`. Per-bench, no process env.
     pub ring_caps: RingCapacities,
+    /// Issue 2485: scheduler hot-path tuning. `SchedulerTuning::default()`
+    /// keeps the built-in scheduler literals / adaptive knobs. Per-bench,
+    /// no process env.
+    pub scheduler_tuning: SchedulerTuning,
     /// Optional observation log: when `Some`, both render and
     /// camera dispatchers push every inbound mail's kind name to it.
     /// In-process API uses this to assert what the sinks have seen;
@@ -201,6 +206,7 @@ impl TestBenchChassis {
             workers,
             pool_workers,
             ring_caps,
+            scheduler_tuning,
             observed_kinds,
             events_tx,
             capture_queue,
@@ -315,6 +321,7 @@ impl TestBenchChassis {
         let mut builder = Builder::<Self>::new(Arc::clone(&boot.registry), Arc::clone(&boot.queue))
             .with_workers(pool_workers)
             .with_ring_caps(ring_caps)
+            .with_scheduler_tuning(scheduler_tuning)
             .with_actor::<TraceDispatchCapability>(())
             .with_actor::<TrajectoryRecorderCapability>(())
             .with_actor::<InputCapability>(input_config)

--- a/crates/aether-substrate-bundle/tests/headless_autoload.rs
+++ b/crates/aether-substrate-bundle/tests/headless_autoload.rs
@@ -86,6 +86,7 @@ mod tests {
             rpc_addr: None,
             workers: None,
             ring_caps: aether_substrate_bundle::RingCapacities::default(),
+            scheduler_tuning: aether_substrate_bundle::SchedulerTuning::default(),
             lifecycle_advance_timeout_millis: 1_000,
             autoload: decoded
                 .components
@@ -162,6 +163,7 @@ mod tests {
             rpc_addr: None,
             workers: None,
             ring_caps: aether_substrate_bundle::RingCapacities::default(),
+            scheduler_tuning: aether_substrate_bundle::SchedulerTuning::default(),
             lifecycle_advance_timeout_millis: 1_000,
             autoload,
         };

--- a/crates/aether-substrate-bundle/tests/http_serving.rs
+++ b/crates/aether-substrate-bundle/tests/http_serving.rs
@@ -130,6 +130,7 @@ mod tests {
             rpc_addr: None,
             workers: None,
             ring_caps: aether_substrate_bundle::RingCapacities::default(),
+            scheduler_tuning: aether_substrate_bundle::SchedulerTuning::default(),
             lifecycle_advance_timeout_millis: 1_000,
             autoload: vec![AutoloadComponent {
                 wasm,

--- a/crates/aether-substrate/src/actor/native/blob_work.rs
+++ b/crates/aether-substrate/src/actor/native/blob_work.rs
@@ -125,58 +125,23 @@
 
 use std::any::Any;
 use std::cell::UnsafeCell;
-use std::env;
 use std::hint::spin_loop;
 use std::mem;
 use std::mem::MaybeUninit;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, OnceLock};
 
 use aether_kinds::trace::Nanos;
 use rustc_hash::FxHashMap;
 
 use crate::actor::native::Envelope;
 use crate::actor::native::blob_lifecycle::{Lifecycle, MAX_GROUPS, Published};
-use crate::config::{KnobKind, KnobRecord};
 use crate::mail::cost::CostLookup;
 use crate::mail::mailer::Mailer;
 use crate::mail::{KindId, Mail, MailboxId};
 use crate::scheduler::{
-    BatchBudget, CycleResult, Drainable, SeizeHandle, WakeSink, handoff_cost_nanos,
+    BatchBudget, CycleResult, Drainable, SeizeHandle, WakeSink, handoff_cost_nanos, tuning,
 };
-
-/// Config-discovery records (ADR-0090 unit b2) for the blob recruiter's
-/// three `OnceLock`-cached env knobs — [`recruit_min`], [`recruit_cap`],
-/// and [`wake_cost_nanos`]. Referenced by
-/// [`crate::scheduler::SCHEDULER_KNOBS`] so the e1 unknown-key sweep and
-/// the e2 `--config` dump cover them; the getters' hot-path reads stay
-/// untouched. Pure `&'static` metadata, docs/defaults lifted from the
-/// getter doc-comments.
-pub const RECRUIT_KNOBS: &[KnobRecord] = &[
-    KnobRecord {
-        env_key: "AETHER_BLOB_RECRUIT_MIN",
-        doc: "Minimum fresh-group count for a flush to broadcast-recruit siblings \
-              (the width gate). Values < 1 / unparseable fall back to 9.",
-        default: Some("9"),
-        kind: KnobKind::HandRegistered,
-    },
-    KnobRecord {
-        env_key: "AETHER_BLOB_RECRUIT_MAX",
-        doc: "Cap on the number of sibling copies a single flush injects when \
-              recruiting, bounding injector churn for a very wide fan-out. Values \
-              < 1 / unparseable fall back to 32.",
-        default: Some("32"),
-        kind: KnobKind::HandRegistered,
-    },
-    KnobRecord {
-        env_key: "AETHER_WAKE_COST_NANOS",
-        doc: "Pins the recruit wake break-even (nanoseconds) and freezes live \
-              refinement. Values < 1 / unparseable fall back to the box-measured \
-              handoff cost. Unset → measured and live-refined.",
-        default: None,
-        kind: KnobKind::HandRegistered,
-    },
-];
 
 /// Floor for a fresh blob's group-array capacity — a little headroom so a
 /// couple of subsequent flushes to *new* recipients can accumulate before
@@ -188,41 +153,23 @@ pub const RECRUIT_KNOBS: &[KnobRecord] = &[
 const GROUP_CAP_MIN: usize = 4;
 
 /// Minimum fresh-group count for a flush to broadcast-recruit siblings.
-/// Read once from `AETHER_BLOB_RECRUIT_MIN`; values `< 1` and unparseable
-/// input fall back to the default. **Default 9** keeps narrow `<= 8`
+/// Resolved from `AETHER_BLOB_RECRUIT_MIN`; values `< 1` coerce to the
+/// default. **Default 9** keeps narrow `<= 8`
 /// fan-outs on the producer-local inline path (the
 /// iamacoffeepot/aether#1116 narrow-local win) and recruits only wider
 /// fan-outs. See the module doc on the width-vs-cost proxy limitation
 /// (iamacoffeepot/aether#1127).
-// Process-level scheduler tuning knob, read once at the substrate level — not cap config.
-#[allow(clippy::disallowed_methods)]
 fn recruit_min() -> usize {
-    static MIN: OnceLock<usize> = OnceLock::new();
-    *MIN.get_or_init(|| {
-        env::var("AETHER_BLOB_RECRUIT_MIN")
-            .ok()
-            .and_then(|v| v.parse::<usize>().ok())
-            .filter(|&k| k >= 1)
-            .unwrap_or(9)
-    })
+    tuning().blob_recruit_min
 }
 
 /// Cap on the number of sibling copies a single flush injects when
-/// recruiting. Read once from `AETHER_BLOB_RECRUIT_MAX`; bounds the
+/// recruiting. Resolved from `AETHER_BLOB_RECRUIT_MAX`; bounds the
 /// injector churn for a very wide fan-out (over-recruiting past the worker
 /// count just re-parks the extra workers — harmless but wasteful). Default
 /// 32.
-// Process-level scheduler tuning knob, read once at the substrate level — not cap config.
-#[allow(clippy::disallowed_methods)]
 fn recruit_cap() -> usize {
-    static CAP: OnceLock<usize> = OnceLock::new();
-    *CAP.get_or_init(|| {
-        env::var("AETHER_BLOB_RECRUIT_MAX")
-            .ok()
-            .and_then(|v| v.parse::<usize>().ok())
-            .filter(|&k| k >= 1)
-            .unwrap_or(32)
-    })
+    tuning().blob_recruit_max
 }
 
 /// High-MAD confidence threshold: a handler whose mean-absolute-deviation
@@ -246,21 +193,13 @@ const MAD_CONFIDENCE_DEN: u64 = 1;
 /// source ([`crate::scheduler::time_budget`]), so both consumers of the
 /// shared handoff-cost seam scale with the box. The conversion's saturating
 /// floor now lives in `handoff_cost_nanos`.
-// Process-level scheduler tuning knob (wake break-even override), read once at the
-// substrate level — not cap config.
-#[allow(clippy::disallowed_methods)]
 fn wake_cost_nanos() -> u64 {
-    static OVERRIDE: OnceLock<Option<u64>> = OnceLock::new();
-    if let Some(ns) = *OVERRIDE.get_or_init(|| {
-        env::var("AETHER_WAKE_COST_NANOS")
-            .ok()
-            .and_then(|v| v.parse::<u64>().ok())
-            // `>= 1`: a 0 override would disable the recruit wake gate
-            // entirely (every blob clears the break-even). Filter it out for
-            // consistency with `AETHER_HANDOFF_COST_NS` / `recruit_min` /
-            // `recruit_cap`; a rejected 0 falls through to the measured cost.
-            .filter(|&ns| ns >= 1)
-    }) {
+    // A `0` override would disable the recruit wake gate entirely (every
+    // blob clears the break-even); the resolution layer filters `< 1` to
+    // `None` for consistency with `AETHER_HANDOFF_COST_NS`, so a pinned
+    // value always exceeds the floor and an unset/rejected knob falls
+    // through to the measured cost.
+    if let Some(ns) = tuning().wake_cost_nanos {
         return ns;
     }
     handoff_cost_nanos()

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -39,6 +39,7 @@ use crate::runtime::lifecycle::{FatalAborter, PanicAborter};
 use crate::scheduler::Drainable;
 use crate::scheduler::SeizeHandle;
 use crate::scheduler::WakeHandle;
+use crate::scheduler::install_tuning;
 use crate::scheduler::log_handoff_calibration;
 use crate::scheduler::{Pool, PoolConfig, PoolHandle};
 #[cfg(test)]
@@ -52,7 +53,7 @@ use crate::mail::cost::CostCells;
 use aether_actor::log::ActorLogRing;
 use aether_actor::trace::ActorTraceRing;
 
-use crate::config::RingCapacities;
+use crate::config::{RingCapacities, SchedulerTuning};
 use aether_kinds::trace::Settled;
 use std::any::Any;
 use std::any::TypeId;
@@ -771,6 +772,12 @@ pub struct Builder<C: Chassis, S: BuilderState = NoDriver> {
     /// into the `Spawner` (instanced spawns) + the cap-claim slot path
     /// (singleton caps) + the chassis-host trace ring at boot.
     ring_caps: RingCapacities,
+    /// Scheduler hot-path tuning installed into the scheduler's
+    /// process-global immediately before `Pool::start` in `boot_passives`.
+    /// Production chassis mains populate this from the bundle-side
+    /// `SchedulerTuningConfig` derive-`Config` knob (env `AETHER_*`);
+    /// tests / `TestBench` leave it [`SchedulerTuning::default`].
+    scheduler_tuning: SchedulerTuning,
     _chassis: PhantomData<fn() -> C>,
     _state: PhantomData<fn() -> S>,
 }
@@ -790,6 +797,7 @@ impl<C: Chassis> Builder<C, NoDriver> {
             aborter: Arc::new(PanicAborter),
             workers: None,
             ring_caps: RingCapacities::default(),
+            scheduler_tuning: SchedulerTuning::default(),
             _chassis: PhantomData,
             _state: PhantomData,
         }
@@ -828,6 +836,19 @@ impl<C: Chassis> Builder<C, NoDriver> {
     #[must_use]
     pub fn with_ring_caps(mut self, ring_caps: RingCapacities) -> Self {
         self.ring_caps = ring_caps;
+        self
+    }
+
+    /// Override the scheduler hot-path tuning ([`SchedulerTuning`]).
+    /// Default is [`SchedulerTuning::default`] (the built-in literals /
+    /// adaptive knobs). Production chassis mains resolve the bundle-side
+    /// `SchedulerTuningConfig` derive-`Config` knob (env `AETHER_*`) and
+    /// pass the lowered `SchedulerTuning` here; `boot_passives` installs it
+    /// into the scheduler's process-global before `Pool::start`. The
+    /// override can be applied either before or after `.driver(_)`.
+    #[must_use]
+    pub fn with_scheduler_tuning(mut self, scheduler_tuning: SchedulerTuning) -> Self {
+        self.scheduler_tuning = scheduler_tuning;
         self
     }
 
@@ -878,6 +899,7 @@ impl<C: Chassis> Builder<C, NoDriver> {
             aborter: self.aborter,
             workers: self.workers,
             ring_caps: self.ring_caps,
+            scheduler_tuning: self.scheduler_tuning,
             _chassis: PhantomData,
             _state: PhantomData,
         }
@@ -907,6 +929,7 @@ impl<C: Chassis> Builder<C, NoDriver> {
             &self.aborter,
             workers,
             self.ring_caps,
+            self.scheduler_tuning,
             self.passives,
         )?;
         // ADR-0081 retired the chassis-pushed `ConfigureLogDrain` mail
@@ -959,6 +982,14 @@ impl<C: Chassis> Builder<C, HasDriver> {
         self
     }
 
+    /// Mirror of [`Builder::with_scheduler_tuning`][Builder<C, NoDriver>::with_scheduler_tuning]
+    /// for the post-driver state.
+    #[must_use]
+    pub fn with_scheduler_tuning(mut self, scheduler_tuning: SchedulerTuning) -> Self {
+        self.scheduler_tuning = scheduler_tuning;
+        self
+    }
+
     /// Boot every passive in declaration order, then boot the driver
     /// against a [`DriverCtx`]. Any failure aborts the build and
     /// shuts down the passives that already booted (via the
@@ -978,11 +1009,20 @@ impl<C: Chassis> Builder<C, HasDriver> {
             aborter,
             workers,
             ring_caps,
+            scheduler_tuning,
             ..
         } = self;
         let driver_boot = driver.expect("HasDriver state implies driver was supplied");
 
-        let mut booted = boot_passives(&registry, &mailer, &aborter, workers, ring_caps, passives)?;
+        let mut booted = boot_passives(
+            &registry,
+            &mailer,
+            &aborter,
+            workers,
+            ring_caps,
+            scheduler_tuning,
+            passives,
+        )?;
         // ADR-0081 retired the chassis-pushed `ConfigureLogDrain` mail
         // — each actor owns its own `ActorLogRing`.
         let driver_running = {
@@ -1101,6 +1141,7 @@ fn boot_passives(
     aborter: &Arc<dyn FatalAborter>,
     workers: Option<usize>,
     ring_caps: RingCapacities,
+    scheduler_tuning: SchedulerTuning,
     passives: Vec<Box<dyn PassiveBoot>>,
 ) -> Result<BootedPassives, BootError> {
     let mut shutdowns: Vec<Box<dyn DynShutdown>> = Vec::with_capacity(passives.len());
@@ -1123,6 +1164,13 @@ fn boot_passives(
         workers: n,
         ..PoolConfig::default()
     });
+    // Install the resolved scheduler tuning into the scheduler's
+    // process-global *before* the pool starts: `Pool::start` reads the
+    // spin window, and `log_handoff_calibration` below reads the handoff
+    // pin / time budget, all through the installed value. Installing first
+    // guarantees no getter reads a default before the real value lands (the
+    // install-before-`Pool::start` ordering invariant).
+    install_tuning(scheduler_tuning);
     let pool = Pool::start(pool_config, Arc::clone(aborter));
 
     // iamacoffeepot/aether#1182: calibrate this box's cross-worker handoff

--- a/crates/aether-substrate/src/config.rs
+++ b/crates/aether-substrate/src/config.rs
@@ -146,6 +146,74 @@ impl Default for RingCapacities {
     }
 }
 
+/// The nine scheduler hot-path tuning knobs resolved once at chassis boot
+/// and installed into the scheduler's process-global before the pool
+/// starts (`crate::scheduler::install_tuning`). `Copy` so it rides the
+/// builder seam as an ordinary value; the deep hot-path getters (the
+/// worker loop, the blob-flush recruiter, the handoff-EWMA seed) read the
+/// installed value rather than env. The chassis-bin `SchedulerTuningConfig`
+/// derive-`Config` knob lowers to this; substrate-core never reads env
+/// (issue 464), so the resolution lives bundle-side and only the resolved
+/// values reach here.
+///
+/// Six knobs carry concrete defaults; the three adaptive knobs
+/// ([`time_budget_micros`](Self::time_budget_micros),
+/// [`handoff_cost_nanos`](Self::handoff_cost_nanos),
+/// [`wake_cost_nanos`](Self::wake_cost_nanos)) are `Option` — `None`
+/// selects the measured/derived behaviour, `Some` pins the value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SchedulerTuning {
+    /// Route-to-spinner spin-window (microseconds) before a worker parks
+    /// (env `AETHER_SPIN_WINDOW_USEC`; default `50`).
+    pub spin_window_micros: u64,
+    /// Deque-length backstop: max slots a worker keeps on its own deque
+    /// before forcing a spill (env `AETHER_LOCAL_STICKY_MAX`; default
+    /// `256`).
+    pub local_sticky_max: usize,
+    /// Keep-local time valve (microseconds): `Some` pins/disables the
+    /// burst spill valve (`0` disables it), `None` derives it from the
+    /// measured handoff cost (env `AETHER_LOCAL_TIME_BUDGET_US`; default
+    /// `None`).
+    pub time_budget_micros: Option<u64>,
+    /// Whether idle workers may raid siblings' deques (peer-deque
+    /// stealing); default owner-only (env `AETHER_PEER_STEAL`; default
+    /// `false`).
+    pub peer_steal: bool,
+    /// Every-K injector backstop for keep-local chains (env
+    /// `AETHER_LOCAL_CHAIN_BACKSTOP`; default `64`).
+    pub local_chain_backstop: u32,
+    /// Pins the cross-worker handoff-cost estimate (nanoseconds) and
+    /// freezes live refinement; `None` boot-probes and live-refines (env
+    /// `AETHER_HANDOFF_COST_NS`; default `None`).
+    pub handoff_cost_nanos: Option<u64>,
+    /// Minimum fresh-group count for a flush to broadcast-recruit siblings
+    /// (env `AETHER_BLOB_RECRUIT_MIN`; default `9`).
+    pub blob_recruit_min: usize,
+    /// Cap on the number of sibling copies a single flush injects when
+    /// recruiting (env `AETHER_BLOB_RECRUIT_MAX`; default `32`).
+    pub blob_recruit_max: usize,
+    /// Pins the recruit wake break-even (nanoseconds) and freezes live
+    /// refinement; `None` uses the box-measured handoff cost (env
+    /// `AETHER_WAKE_COST_NANOS`; default `None`).
+    pub wake_cost_nanos: Option<u64>,
+}
+
+impl Default for SchedulerTuning {
+    fn default() -> Self {
+        Self {
+            spin_window_micros: 50,
+            local_sticky_max: 256,
+            time_budget_micros: None,
+            peer_steal: false,
+            local_chain_backstop: 64,
+            handoff_cost_nanos: None,
+            blob_recruit_min: 9,
+            blob_recruit_max: 32,
+            wake_cost_nanos: None,
+        }
+    }
+}
+
 /// Build a cap config by overlaying an argv-derived partial confique
 /// layer on top of the env layer (ADR-0090 unit d).
 ///

--- a/crates/aether-substrate/src/lib.rs
+++ b/crates/aether-substrate/src/lib.rs
@@ -90,8 +90,8 @@ pub use chassis::ctx::{
 pub use chassis::error::BootError;
 pub use chassis::inbox::{InboundMail, SettlingInbox};
 pub use config::{
-    ConfigError, FromArgvThenEnv, KnobKind, KnobRecord, KnownKeys, RingCapacities, dump_config,
-    known_keys, validate_env,
+    ConfigError, FromArgvThenEnv, KnobKind, KnobRecord, KnownKeys, RingCapacities, SchedulerTuning,
+    dump_config, known_keys, validate_env,
 };
 pub use mail::mailer::Mailer;
 pub use mail::outbound::{

--- a/crates/aether-substrate/src/scheduler/calibrate.rs
+++ b/crates/aether-substrate/src/scheduler/calibrate.rs
@@ -46,7 +46,6 @@
 //! reference iamacoffeepot/aether#1127's cost-aware recruiter needs, so it
 //! is measured once here and read by both consumers.
 
-use std::env;
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -54,21 +53,6 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::mail::cost::ewma_step;
-
-use crate::config::{KnobKind, KnobRecord};
-
-/// Discovery records for the handoff-cost calibration knob (ADR-0090
-/// unit b2). Describes the `AETHER_HANDOFF_COST_NS` override read in
-/// [`ensure_seeded`] so the e1 sweep / e2 dump cover it; the seed path
-/// stays untouched.
-pub const CALIBRATE_KNOBS: &[KnobRecord] = &[KnobRecord {
-    env_key: "AETHER_HANDOFF_COST_NS",
-    doc: "Pins the cross-worker handoff-cost estimate (nanoseconds) and freezes \
-          live refinement — deterministic tests / a known-good number on a noisy \
-          box. Unset → boot-probed and live-refined.",
-    default: None,
-    kind: KnobKind::HandRegistered,
-}];
 
 /// Round trips measured (after warmup). Even, so the median averages the
 /// two central samples; large enough to median out scheduler jitter,
@@ -162,21 +146,20 @@ static SEEDED: OnceLock<()> = OnceLock::new();
 /// are skipped so the pinned value can't drift.
 static PINNED: AtomicBool = AtomicBool::new(false);
 
-/// Seed [`HANDOFF`] exactly once: from `AETHER_HANDOFF_COST_NS` if set
-/// (and freeze live refinement), else from the boot probe.
-// Process-level scheduler tuning knob (the handoff-cost pin), read once at boot
-// at the substrate level — not cap config.
-#[allow(clippy::disallowed_methods)]
+/// Seed [`HANDOFF`] exactly once: from the installed
+/// [`SchedulerTuning`](crate::config::SchedulerTuning)'s
+/// `handoff_cost_nanos` if pinned (`AETHER_HANDOFF_COST_NS`; and freeze
+/// live refinement), else from the boot probe. The resolution layer
+/// filters a `< 1` value to `None`, so a pinned value is always a
+/// positive nanosecond count.
 fn ensure_seeded() {
-    SEEDED.get_or_init(
-        || match parse_cost_override(env::var("AETHER_HANDOFF_COST_NS").ok()) {
-            Some(pinned) => {
-                HANDOFF.seed(pinned);
-                PINNED.store(true, Ordering::Relaxed);
-            }
-            None => HANDOFF.seed(measure_handoff_cost_nanos()),
-        },
-    );
+    SEEDED.get_or_init(|| match super::tuning().handoff_cost_nanos {
+        Some(pinned) => {
+            HANDOFF.seed(pinned);
+            PINNED.store(true, Ordering::Relaxed);
+        }
+        None => HANDOFF.seed(measure_handoff_cost_nanos()),
+    });
 }
 
 /// The calibrated cross-worker handoff cost for this process: the boot
@@ -219,14 +202,6 @@ pub fn fold_handoff_sample(nanos: u64) {
 pub fn handoff_samples() -> u64 {
     ensure_seeded();
     HANDOFF.samples()
-}
-
-/// Parse the `AETHER_HANDOFF_COST_NS` override: a positive integer
-/// nanosecond count, else `None` (unset / unparseable / `< 1` all fall
-/// back to the live probe). Split out from the env read so the parse is
-/// unit-testable without mutating process env.
-fn parse_cost_override(raw: Option<String>) -> Option<u64> {
-    raw.and_then(|v| v.parse::<u64>().ok()).filter(|&n| n >= 1)
 }
 
 /// Log the calibrated handoff cost and the keep-local time budget now
@@ -375,18 +350,6 @@ mod tests {
             nanos >= 1,
             "the 1 ns floor in handoff_cost must carry through"
         );
-    }
-
-    #[test]
-    fn cost_override_parses_positive_only() {
-        assert_eq!(parse_cost_override(Some("5000".to_string())), Some(5000));
-        assert_eq!(
-            parse_cost_override(Some("0".to_string())),
-            None,
-            "zero falls back to the live probe",
-        );
-        assert_eq!(parse_cost_override(Some("nope".to_string())), None);
-        assert_eq!(parse_cost_override(None), None);
     }
 
     #[test]

--- a/crates/aether-substrate/src/scheduler/mod.rs
+++ b/crates/aether-substrate/src/scheduler/mod.rs
@@ -49,91 +49,34 @@ pub use slot::{
 pub use spin_park::{Acquired, SpinPark};
 pub use worker_deque::{burst_note_mail, pending_depth, time_budget};
 
-use crate::actor::native::blob_work::RECRUIT_KNOBS;
-use crate::config::KnobRecord;
+use std::sync::OnceLock;
 
-/// The scheduler hot-path tuning knobs registered for config discovery
-/// (ADR-0090 unit b2, iamacoffeepot/aether#1255). Concatenates the four
-/// deque / keep-local-valve knobs (`worker_deque::DEQUE_KNOBS`), the
-/// handoff-cost calibration knob (`calibrate::CALIBRATE_KNOBS`), the three
-/// blob-recruiter knobs (`blob_work::RECRUIT_KNOBS`), and the spin-window
-/// knob (`pool::SPIN_KNOBS`) into the single slice e1's
-/// `chassis_known_keys()` folds into the known-key set and e2's `--config`
-/// dump renders. Pure `&'static` metadata — there is no change to any
-/// hot-path `OnceLock` read.
-///
-/// `AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS` moved to `ChassisBootConfigLayer`
-/// in `aether-substrate-bundle` (issue 2230): its record now rides the
-/// derive-emitted `META` rather than a hand-written `KnobRecord` here.
-///
-/// The element-by-element array (rather than a runtime concat) keeps
-/// `SCHEDULER_KNOBS` a `const`: each record is still *defined* once in
-/// its owning module; this only *references* it.
-pub const SCHEDULER_KNOBS: &[KnobRecord] = &[
-    worker_deque::DEQUE_KNOBS[0],
-    worker_deque::DEQUE_KNOBS[1],
-    worker_deque::DEQUE_KNOBS[2],
-    worker_deque::DEQUE_KNOBS[3],
-    calibrate::CALIBRATE_KNOBS[0],
-    RECRUIT_KNOBS[0],
-    RECRUIT_KNOBS[1],
-    RECRUIT_KNOBS[2],
-    pool::SPIN_KNOBS[0],
-];
+use crate::config::SchedulerTuning;
 
-#[cfg(test)]
-mod knob_tests {
-    use super::SCHEDULER_KNOBS;
-    use crate::config::KnobKind;
+/// The process-global scheduler tuning, installed once at chassis boot by
+/// [`install_tuning`] before the pool starts. Replaces the nine per-knob
+/// `OnceLock`s the hot-path getters used to lazily seed from env: the
+/// getters now read this single installed value (defaulting when
+/// uninstalled) rather than reading `AETHER_*` env directly, so the
+/// resolution semantics (argv-then-env, hard-error on garbage) live
+/// bundle-side in the `SchedulerTuningConfig` derive-`Config` knob and
+/// substrate-core never reads env (issue 464, ADR-0090).
+static TUNING: OnceLock<SchedulerTuning> = OnceLock::new();
 
-    #[test]
-    fn scheduler_knobs_cover_all_hot_path_env_keys() {
-        let keys: Vec<&str> = SCHEDULER_KNOBS.iter().map(|r| r.env_key).collect();
-        for expected in [
-            "AETHER_LOCAL_STICKY_MAX",
-            "AETHER_LOCAL_TIME_BUDGET_US",
-            "AETHER_PEER_STEAL",
-            "AETHER_LOCAL_CHAIN_BACKSTOP",
-            "AETHER_HANDOFF_COST_NS",
-            "AETHER_BLOB_RECRUIT_MIN",
-            "AETHER_BLOB_RECRUIT_MAX",
-            "AETHER_WAKE_COST_NANOS",
-            "AETHER_SPIN_WINDOW_USEC",
-        ] {
-            assert!(
-                keys.contains(&expected),
-                "SCHEDULER_KNOBS missing {expected}; has {keys:?}",
-            );
-        }
-        assert_eq!(SCHEDULER_KNOBS.len(), 9);
-    }
+/// Install the resolved [`SchedulerTuning`] into the scheduler's
+/// process-global. Called once at chassis boot from `boot_passives`,
+/// **before** `Pool::start`, so no hot-path getter reads the default
+/// before the real value lands. Ignore-if-already-set: a second install
+/// (a nested boot in the same process) keeps the first.
+pub fn install_tuning(t: SchedulerTuning) {
+    let _ = TUNING.set(t);
+}
 
-    #[test]
-    fn scheduler_knobs_are_all_hand_registered() {
-        // None are confique fields — they ride OnceLock getters, so
-        // every record is HandRegistered (the discriminator e2's dump
-        // uses to know there's no Meta to walk).
-        assert!(
-            SCHEDULER_KNOBS
-                .iter()
-                .all(|r| matches!(r.kind, KnobKind::HandRegistered))
-        );
-    }
-
-    #[test]
-    fn adaptive_knobs_have_no_literal_default() {
-        // time_budget / wake_cost_nanos are adaptive with no single literal
-        // default (ADR-0090 unit b2): their record default is None
-        // ("derived/unset"), satisfied by the doc text.
-        for key in ["AETHER_LOCAL_TIME_BUDGET_US", "AETHER_WAKE_COST_NANOS"] {
-            let rec = SCHEDULER_KNOBS
-                .iter()
-                .find(|r| r.env_key == key)
-                .expect("knob present");
-            assert!(
-                rec.default.is_none(),
-                "{key} should have no literal default"
-            );
-        }
-    }
+/// Read the installed [`SchedulerTuning`], or [`SchedulerTuning::default`]
+/// when nothing was installed. An uninstalled path — `TestBench`, the
+/// `ctx.rs` test harnesses that start a pool directly, unit tests — sees
+/// the defaults transparently; a boot that installs first always wins the
+/// race (the install-before-`Pool::start` ordering invariant).
+pub(crate) fn tuning() -> SchedulerTuning {
+    TUNING.get().copied().unwrap_or_default()
 }

--- a/crates/aether-substrate/src/scheduler/pool.rs
+++ b/crates/aether-substrate/src/scheduler/pool.rs
@@ -29,15 +29,13 @@
 //! ADR.
 
 use std::any::Any;
-use std::env;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
 use crossbeam_deque::{Injector, Stealer, Worker};
 
-use crate::config::{KnobKind, KnobRecord};
-use crate::scheduler::spin_park::{Acquired, DEFAULT_SPIN_WINDOW_USEC, SpinPark};
+use crate::scheduler::spin_park::{Acquired, SpinPark};
 use crate::scheduler::worker_deque;
 
 use crate::runtime::lifecycle::FatalAborter;
@@ -199,7 +197,7 @@ impl Pool {
     #[allow(clippy::needless_pass_by_value)]
     pub fn start(config: PoolConfig, aborter: Arc<dyn FatalAborter>) -> PoolHandle {
         assert!(config.workers >= 1, "pool needs at least one worker");
-        let spin = Arc::new(SpinPark::with_spin_window(spin_window_from_env()));
+        let spin = Arc::new(SpinPark::with_spin_window(spin_window_from_tuning()));
         let injector = Arc::new(Injector::<Arc<dyn Drainable>>::new());
         // One LIFO deque per worker; collect every stealer so each worker
         // can steal from its siblings' tails when its own deque runs dry.
@@ -233,33 +231,14 @@ impl Pool {
     }
 }
 
-/// Config-discovery record (ADR-0090 unit b2) for the spin-window knob
-/// [`spin_window_from_env`] reads. Referenced by
-/// [`crate::scheduler::SCHEDULER_KNOBS`] so the e1 unknown-key sweep and
-/// the e2 `--config` dump cover it; the read path stays untouched. Pure
-/// `&'static` metadata.
-pub const SPIN_KNOBS: &[KnobRecord] = &[KnobRecord {
-    env_key: "AETHER_SPIN_WINDOW_USEC",
-    doc: "Route-to-spinner spin-window (microseconds) before a worker parks. The \
-          latency sweep retunes this without a recompile; malformed values fall \
-          back to 50.",
-    default: Some("50"),
-    kind: KnobKind::HandRegistered,
-}];
-
 /// Read the spin-window override (`AETHER_SPIN_WINDOW_USEC`) for the
-/// route-to-spinner coordinator, falling back to the default. The
-/// experiment's latency sweep retunes this without a recompile; a
-/// malformed value falls back rather than aborting boot.
-// Process-level scheduler tuning knob (hand-registered in the ADR-0090 config
-// dump above), read at the substrate level — not cap config.
-#[allow(clippy::disallowed_methods)]
-fn spin_window_from_env() -> Duration {
-    let usec = env::var("AETHER_SPIN_WINDOW_USEC")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(DEFAULT_SPIN_WINDOW_USEC);
-    Duration::from_micros(usec)
+/// route-to-spinner coordinator from the installed
+/// [`SchedulerTuning`](crate::config::SchedulerTuning). The experiment's
+/// latency sweep retunes this without a recompile; the resolved value
+/// defaults to 50 microseconds when the knob is unset (the
+/// `SchedulerTuning::default()` literal).
+fn spin_window_from_tuning() -> Duration {
+    Duration::from_micros(super::tuning().spin_window_micros)
 }
 
 // All arguments are taken by value so the spawned thread owns them

--- a/crates/aether-substrate/src/scheduler/worker_deque.rs
+++ b/crates/aether-substrate/src/scheduler/worker_deque.rs
@@ -51,61 +51,14 @@
 //! is a no-op spill and [`pop_local`] / [`steal_into_local`] yield nothing.
 
 use std::cell::{Cell, RefCell};
-use std::env;
 use std::sync::Arc;
-use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 use crossbeam_deque::{Injector, Steal, Stealer, Worker};
 
-use crate::config::{KnobKind, KnobRecord};
 use crate::scheduler::calibrate::handoff_cost;
 use crate::scheduler::slot::Drainable;
-
-/// Discovery records for the four deque / keep-local-valve hot-path
-/// tuning knobs (ADR-0090 unit b2, iamacoffeepot/aether#1255). These
-/// describe the `OnceLock` getters below ([`hard_cap`], [`time_budget`],
-/// [`peer_steal_enabled`], [`chain_backstop`]) so e1's
-/// unknown-`AETHER_*`
-/// sweep doesn't flag them and e2's `--config` dump lists them. The
-/// hot-path read stays exactly as-is — these are pure `&'static`
-/// metadata assembled once at boot, never on the dispatch path. Docs +
-/// defaults are lifted verbatim from the getter doc-comments;
-/// `time_budget` is adaptive with no literal default, so its `default`
-/// is `None` (rendered "derived/unset").
-pub const DEQUE_KNOBS: &[KnobRecord] = &[
-    KnobRecord {
-        env_key: "AETHER_LOCAL_STICKY_MAX",
-        doc: "Deque-length backstop: max slots a worker keeps on its own deque \
-              before forcing a spill (values < 1 / unparseable fall back).",
-        default: Some("256"),
-        kind: KnobKind::HandRegistered,
-    },
-    KnobRecord {
-        env_key: "AETHER_LOCAL_TIME_BUDGET_US",
-        doc: "Keep-local time valve (microseconds): pins/disables the burst spill \
-              valve. Unset → adaptive, derived from the measured handoff cost; \
-              0 disables the valve (pure inline-cascade).",
-        default: None,
-        kind: KnobKind::HandRegistered,
-    },
-    KnobRecord {
-        env_key: "AETHER_PEER_STEAL",
-        doc: "Whether idle workers may raid siblings' deques (peer-deque stealing). \
-              Default off (owner-only); set 1/true to opt the sibling raid back in.",
-        default: Some("off"),
-        kind: KnobKind::HandRegistered,
-    },
-    KnobRecord {
-        env_key: "AETHER_LOCAL_CHAIN_BACKSTOP",
-        doc: "Every-K injector backstop for keep-local chains: after K consecutive \
-              own-deque pops a worker probes the injector once before continuing \
-              its chain, bounding injector starvation at ~K cycles per worker \
-              (values < 1 / unparseable fall back).",
-        default: Some("64"),
-        kind: KnobKind::HandRegistered,
-    },
-];
+use crate::scheduler::tuning;
 
 /// The unit on the deques: a chassis-registered dispatcher slot. (Phase
 /// 3b makes the blob the unit; 3a keeps the slot.)
@@ -180,25 +133,15 @@ pub fn pending_depth() -> u32 {
 /// Deque-length backstop (iamacoffeepot/aether#1160, #1174) — the max slots a
 /// worker keeps on its own deque before [`try_push_local_budgeted`] is forced
 /// to spill, so a pathological unbounded local cascade can't grow the deque
-/// without bound. Read once from `AETHER_LOCAL_STICKY_MAX` (repurposed from
-/// the pre-#1160 stickiness cap); values `< 1` and unparseable input fall
-/// back to `256`. This is the deque-growth backstop, not the primary
+/// without bound. Resolved from `AETHER_LOCAL_STICKY_MAX` (repurposed from
+/// the pre-#1160 stickiness cap); values `< 1` coerce to `256`. This is the
+/// deque-growth backstop, not the primary
 /// governor — the per-burst time valve ([`time_budget`], default 12µs) is;
 /// for any realistic cascade (well under 256 blobs queued at once) `hard_cap`
 /// never trips.
 #[must_use]
-// Process-level scheduler tuning knob (deque-growth backstop), read once at the
-// substrate level — not cap config.
-#[allow(clippy::disallowed_methods)]
 pub fn hard_cap() -> usize {
-    static CAP: OnceLock<usize> = OnceLock::new();
-    *CAP.get_or_init(|| {
-        env::var("AETHER_LOCAL_STICKY_MAX")
-            .ok()
-            .and_then(|v| v.parse::<usize>().ok())
-            .filter(|&k| k >= 1)
-            .unwrap_or(256)
-    })
+    tuning().local_sticky_max
 }
 
 /// Adaptive keep-local budget: spend up to this many measured cross-worker
@@ -246,19 +189,10 @@ const MAX_ADAPTIVE_BUDGET: Duration = Duration::from_micros(60);
 /// atomic loads, negligible against the dispatch it gates. The wall clock
 /// is still sampled at decision time, not per mail (#1163).
 #[must_use]
-// Process-level scheduler tuning knob (keep-local time-budget override), read once
-// at the substrate level — not cap config.
-#[allow(clippy::disallowed_methods)]
 pub fn time_budget() -> Duration {
-    // An explicit env budget wins and is fixed within a run — pin or
-    // disable (0) the valve regardless of the measured handoff cost. Cached
-    // because the override never changes.
-    static OVERRIDE_US: OnceLock<Option<u64>> = OnceLock::new();
-    if let Some(us) = *OVERRIDE_US.get_or_init(|| {
-        env::var("AETHER_LOCAL_TIME_BUDGET_US")
-            .ok()
-            .and_then(|v| v.parse::<u64>().ok())
-    }) {
+    // An explicit budget wins and is fixed within a run — pin or disable
+    // (0) the valve regardless of the measured handoff cost.
+    if let Some(us) = tuning().time_budget_micros {
         return Duration::from_micros(us);
     }
     derive_budget(handoff_cost())
@@ -294,16 +228,8 @@ fn derive_budget(handoff: Duration) -> Duration {
 /// raising the stakes on the iamacoffeepot/aether#1128 cost classification;
 /// `AETHER_PEER_STEAL=1` restores the rescue.
 #[must_use]
-// Process-level scheduler tuning knob (peer-deque-steal opt-in), read once at the
-// substrate level — not cap config.
-#[allow(clippy::disallowed_methods)]
 pub fn peer_steal_enabled() -> bool {
-    static E: OnceLock<bool> = OnceLock::new();
-    *E.get_or_init(|| {
-        env::var("AETHER_PEER_STEAL")
-            .ok()
-            .is_some_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-    })
+    tuning().peer_steal
 }
 
 /// Every-K chain backstop (iamacoffeepot/aether#1535) — how many
@@ -313,21 +239,11 @@ pub fn peer_steal_enabled() -> bool {
 /// clock read (iamacoffeepot/aether#1174), so a *self-sustaining* chain
 /// would otherwise monopolise its worker forever; this bounds injector
 /// starvation at ~K × cycle-time per worker while the chain stays warm
-/// K−1 of K cycles. Read once from `AETHER_LOCAL_CHAIN_BACKSTOP`; values
-/// `< 1` and unparseable input fall back to `64`.
+/// K−1 of K cycles. Resolved from `AETHER_LOCAL_CHAIN_BACKSTOP`; values
+/// `< 1` coerce to `64`.
 #[must_use]
-// Process-level scheduler tuning knob (every-K chain backstop), read once at the
-// substrate level — not cap config.
-#[allow(clippy::disallowed_methods)]
 pub fn chain_backstop() -> u32 {
-    static K: OnceLock<u32> = OnceLock::new();
-    *K.get_or_init(|| {
-        env::var("AETHER_LOCAL_CHAIN_BACKSTOP")
-            .ok()
-            .and_then(|v| v.parse::<u32>().ok())
-            .filter(|&k| k >= 1)
-            .unwrap_or(64)
-    })
+    tuning().local_chain_backstop
 }
 
 /// Note one own-deque `pop_local` hit against the every-K chain backstop


### PR DESCRIPTION
Closes #2485.

## Summary

Nine scheduler hot-path knobs read `AETHER_*` env directly inside `aether-substrate` — contradicting `config.rs`'s "substrate-core never reads env" (issue 464) — each cached in a per-knob `OnceLock`, hand-registered as a `KnobRecord`, silently defaulting on garbage, and invisible to argv.

They now resolve through the ADR-0090 path. Substrate side: a `Copy` `SchedulerTuning` (six concrete-default fields plus three `Option` adaptive knobs — `time_budget_micros`, `wake_cost_nanos`, `handoff_cost_nanos`), one `OnceLock<SchedulerTuning>` install/read seam replacing the nine per-knob locks (getters read `.get().copied().unwrap_or_default()`, so uninstalled paths — TestBench, unit tests — transparently see defaults), and `Builder::with_scheduler_tuning` threaded into `boot_passives`, which installs the value immediately before `Pool::start` — the ordering invariant that guarantees no getter reads a default before the real value lands. Bundle side: a `SchedulerTuningConfig` derive-Config (env keys byte-for-byte unchanged; Rust field names spell units out per convention), resolved at the desktop/headless/hub entry points and threaded through `CommonBoot`; `chassis_registry()` swaps the deleted `SCHEDULER_KNOBS` records for the derive-emitted META. A known-but-unparseable value now hard-errors at boot instead of silently defaulting — the intended ADR-0090 §4 behavior change — and each knob gains an argv override.

`KnobKind::HandRegistered` / `KnobRecord` machinery is retained (live users remain and #2480 adds more); only `SCHEDULER_KNOBS`, its nine records, their `knob_tests`, and calibrate's now-dead `parse_cost_override` are deleted. Adaptive fall-through logic preserved verbatim, including `time_budget_micros = 0` passing through as "disable the valve" while the two pin knobs filter `<1 → None` — matching pre-migration semantics exactly.

## Test plan

`scheduler_tuning_defaults` pins the six pre-migration literals + three `None`s (drift = silent behavior change); `scheduler_tuning_defaults_match` pins the derive layer's defaults against `SchedulerTuning::default()`; `scheduler_tuning_keys_are_known` pins the nine env keys in the registry; the existing `--config` dump assertion now rides the META. Full workspace validation against the committed HEAD: clippy `-D warnings`, nextest (1904 passed), strict rustdoc.

## Generated by

`/implement` — agent execution of [scoped issue #2485](https://github.com/iamacoffeepot/aether/issues/2485).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
