### PR TITLE
fix(substrate-bundle): register the unregistered infra knobs in the config registry

### DIFF
--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -42,6 +42,7 @@ use aether_substrate::chassis::builder::Builder;
 use aether_substrate::config::{
     KnobKind, KnobRecord, KnownKeys, RingCapacities, dump_config, known_keys,
 };
+use aether_substrate::runtime::RUNTIME_KNOBS;
 use aether_substrate::runtime::lifecycle::FatalAborter;
 use aether_substrate::scheduler::SCHEDULER_KNOBS;
 use confique::Config as _;
@@ -51,19 +52,33 @@ use crate::desktop::driver::WindowConfigLayer;
 use crate::headless::driver::TickConfigLayer;
 
 /// Chassis-direct env knobs that aren't `#[derive(Config)]` fields —
-/// the remaining hand-registered knob the chassis bins read inline
-/// (`AETHER_RPC_PORT`). Registered as a [`KnobRecord`] so e1's
-/// unknown-`AETHER_*` sweep doesn't flag it and e2's `--config`
-/// dump lists it. ADR-0090 §1/§4. The scheduler hot-path knobs are
-/// registered separately by unit b2's `SCHEDULER_KNOBS`; the chassis
-/// boot / window / tick knobs are now covered by the derive-emitted
-/// `*Layer::META`s in [`chassis_registry`].
-pub const CHASSIS_KNOBS: &[KnobRecord] = &[KnobRecord {
-    env_key: "AETHER_RPC_PORT",
-    doc: "aether.rpc.server bind port (desktop/headless skip the server when unset).",
-    default: None,
-    kind: KnobKind::HandRegistered,
-}];
+/// the hand-registered knobs the chassis bins read inline
+/// (`AETHER_RPC_PORT`) plus the one orphaned codec knob that can't
+/// live substrate-side (`AETHER_MAX_FRAME_SIZE` — `aether-codec`
+/// cannot depend on `aether-substrate`, where `KnobRecord`/`KnobKind`
+/// live). Registered as [`KnobRecord`]s so e1's unknown-`AETHER_*`
+/// sweep doesn't flag them and e2's `--config` dump lists them.
+/// ADR-0090 §1/§4. The scheduler hot-path knobs are registered
+/// separately by unit b2's `SCHEDULER_KNOBS`, the runtime (log /
+/// panic-hook) knobs by `aether_substrate::runtime::RUNTIME_KNOBS`;
+/// the chassis boot / window / tick knobs are now covered by the
+/// derive-emitted `*Layer::META`s in [`chassis_registry`].
+pub const CHASSIS_KNOBS: &[KnobRecord] = &[
+    KnobRecord {
+        env_key: "AETHER_RPC_PORT",
+        doc: "aether.rpc.server bind port (desktop/headless skip the server when unset).",
+        default: None,
+        kind: KnobKind::HandRegistered,
+    },
+    KnobRecord {
+        env_key: "AETHER_MAX_FRAME_SIZE",
+        doc: "Maximum accepted wire-frame body size in bytes (see \
+              aether_codec::frame::max_frame_size); default mirrors \
+              aether_codec::frame::MAX_FRAME_SIZE (64 MiB) — keep the two in sync.",
+        default: Some("67108864"),
+        kind: KnobKind::HandRegistered,
+    },
+];
 
 /// Per-actor ring-capacity knob (issue 1990, ADR-0081 / ADR-0086). The
 /// `#[derive(aether_substrate::Config)]` emits the env-shaped
@@ -256,9 +271,12 @@ impl ChassisBootConfig {
 
 /// Assemble the chassis-wide [`KnownKeys`] set (ADR-0090 §4): every
 /// migrated `*Layer::META` (http / gemini / anthropic / audio / fs /
-/// chassis-boot / window / tick) plus the hand-registered chassis knob
-/// ([`CHASSIS_KNOBS`]) and scheduler hot-path knobs (b2's
-/// `aether_substrate::scheduler::SCHEDULER_KNOBS`). e1's
+/// chassis-boot / window / tick) plus the hand-registered chassis knobs
+/// ([`CHASSIS_KNOBS`] — the RPC port and the orphaned frame-size knob),
+/// the scheduler hot-path knobs (b2's
+/// `aether_substrate::scheduler::SCHEDULER_KNOBS`), and the runtime
+/// log-filter / panic-hook knobs
+/// (`aether_substrate::runtime::RUNTIME_KNOBS`). e1's
 /// [`validate_env`](aether_substrate::config::validate_env) sweeps the
 /// process env against this; e2's `--config` dump walks the same
 /// metas + records.
@@ -275,9 +293,10 @@ pub fn chassis_known_keys() -> KnownKeys {
 
 /// The chassis-wide config registry: the migrated cap layer `Meta`s
 /// plus the hand-registered knob records (`CHASSIS_KNOBS` + b2's
-/// `SCHEDULER_KNOBS`). Shared by [`chassis_known_keys`] (e1's sweep)
-/// and [`chassis_config_dump`] (e2's `--config`) so both read one
-/// source of truth.
+/// `SCHEDULER_KNOBS` + `aether_substrate::runtime::RUNTIME_KNOBS`).
+/// Shared by [`chassis_known_keys`] (e1's sweep) and
+/// [`chassis_config_dump`] (e2's `--config`) so both read one source
+/// of truth.
 fn chassis_registry() -> (&'static [&'static Meta], Vec<KnobRecord>) {
     const METAS: &[&Meta] = &[
         &HttpConfigLayer::META,
@@ -294,6 +313,7 @@ fn chassis_registry() -> (&'static [&'static Meta], Vec<KnobRecord>) {
     ];
     let mut records: Vec<KnobRecord> = CHASSIS_KNOBS.to_vec();
     records.extend_from_slice(SCHEDULER_KNOBS);
+    records.extend_from_slice(RUNTIME_KNOBS);
     (METAS, records)
 }
 
@@ -773,6 +793,24 @@ mod tests {
     }
 
     #[test]
+    fn chassis_known_keys_includes_infra_knobs() {
+        // Tripwire: catches a future registry refactor that drops the
+        // RUNTIME_KNOBS extend or the frame-size record, re-introducing
+        // the false `validate_env` "unknown key" warning for these five
+        // legitimately-documented process-level knobs.
+        let known = chassis_known_keys();
+        for key in [
+            "AETHER_LOG_FILTER",
+            "AETHER_BACKTRACE",
+            "AETHER_CRASH_LOG_DISABLE",
+            "AETHER_CRASH_LOG_DIR",
+            "AETHER_MAX_FRAME_SIZE",
+        ] {
+            assert!(known.contains(key), "chassis_known_keys missing {key}");
+        }
+    }
+
+    #[test]
     fn chassis_boot_config_keys_are_known() {
         // Guards the three `ChassisBootConfigLayer::META` keys joining
         // the chassis known-key set. `AETHER_LIFECYCLE_ADVANCE_TIMEOUT_MS`
@@ -839,6 +877,7 @@ mod tests {
         assert!(dump.contains("AETHER_AUDIO_DISABLE")); // audio cap
         assert!(dump.contains("AETHER_WORKERS")); // chassis-boot derive-Config knob
         assert!(dump.contains("AETHER_LOCAL_STICKY_MAX")); // scheduler knob
+        assert!(dump.contains("AETHER_LOG_FILTER")); // runtime knob
     }
 
     /// Regression guard for the enable / disable convention (#1791): a

--- a/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/mail_latency.rs
@@ -367,29 +367,6 @@ fn emit_settlement_settles_wide_fanout() {
     emit_settlement_settles_every_root(&fanout(8));
 }
 
-/// ADR-0087 Phase 3c: with the inline-demux chunk cap forced small
-/// (`K=2`), a wide fan-out splits into stealable sub-blobs that cascade
-/// across workers (`split_off` moves the mail handles — zero ring-byte
-/// copy). Settlement must stay **exact** across the split: the per-mail
-/// eager `Sent` (at buffer time) + dispatch-time `Finished` accounting is
-/// split-invariant, so a dropped or double-counted chunk mail would wedge
-/// `in_flight` and a root would never settle. Also drives the
-/// steal-mid-demux race (a sibling steals a remainder sub-blob while the
-/// producer runs its own chunk).
-#[test]
-#[allow(clippy::print_stderr)]
-fn emit_settlement_settles_under_chunked_demux() {
-    // Force chunking on for this process. SAFETY: set before any actor is
-    // booted (so before any blob flushes / `demux_chunk` is first read),
-    // and nextest isolates each test in its own process — the memoised
-    // first read picks up this value. No restore needed: the OnceLock is
-    // process-lived and the process ends with the test.
-    unsafe {
-        env::set_var("AETHER_BLOB_DEMUX_CHUNK", "2");
-    }
-    emit_settlement_settles_every_root(&fanout(8));
-}
-
 /// Hold path: a `spawn_inherit` worker keeps the root open past the
 /// handler's `Finished`, so settlement is gated on the worker's `Release`
 /// (ADR-0080 §12). Exercises the `HoldOpen` / `Release` producer hooks —

--- a/crates/aether-substrate/src/runtime/log_install.rs
+++ b/crates/aether-substrate/src/runtime/log_install.rs
@@ -18,6 +18,8 @@
 use aether_actor::Local;
 use aether_actor::log::{ActorLogRing, render_event};
 
+use crate::config::{KnobKind, KnobRecord};
+
 use super::now_unix_millis;
 use std::io;
 use tracing::{Event, Subscriber};
@@ -74,6 +76,16 @@ pub fn emit_host_event(level: u32, target: &str, message: &str) {
 }
 
 const FILTER_ENV: &str = "AETHER_LOG_FILTER";
+
+/// Registered so e1's unknown-`AETHER_*` boot sweep
+/// (`validate_env`) and e2's `--config` discovery dump
+/// (ADR-0090 §4) both cover `AETHER_LOG_FILTER`.
+pub const LOG_KNOBS: &[KnobRecord] = &[KnobRecord {
+    env_key: FILTER_ENV,
+    doc: "Tracing EnvFilter directive for the substrate subscriber stack (default \"info\").",
+    default: Some("info"),
+    kind: KnobKind::HandRegistered,
+}];
 
 /// Install the tracing subscriber stack: `EnvFilter` (reads
 /// `AETHER_LOG_FILTER`, default `info`) + `tsfmt::Layer` to stderr +

--- a/crates/aether-substrate/src/runtime/mod.rs
+++ b/crates/aether-substrate/src/runtime/mod.rs
@@ -12,7 +12,22 @@ pub mod trace;
 
 pub use panic_hook::init_panic_hook;
 
+use crate::config::KnobRecord;
+
 use std::time::{SystemTime, UNIX_EPOCH};
+
+/// The runtime tuning knobs registered for config discovery
+/// (ADR-0090 §4): the log-filter knob (`log_install::LOG_KNOBS`) and
+/// the three panic-hook knobs (`panic_hook::PANIC_KNOBS`), concatenated
+/// element-by-element (mirrors `scheduler::SCHEDULER_KNOBS`'s `const`
+/// concat shape) so the aggregate stays a `const`. `aether-substrate-bundle`
+/// folds this into `chassis_registry()` alongside `SCHEDULER_KNOBS`.
+pub const RUNTIME_KNOBS: &[KnobRecord] = &[
+    log_install::LOG_KNOBS[0],
+    panic_hook::PANIC_KNOBS[0],
+    panic_hook::PANIC_KNOBS[1],
+    panic_hook::PANIC_KNOBS[2],
+];
 
 pub(crate) fn now_unix_millis() -> u64 {
     SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| {

--- a/crates/aether-substrate/src/runtime/panic_hook.rs
+++ b/crates/aether-substrate/src/runtime/panic_hook.rs
@@ -44,6 +44,8 @@ use aether_actor::Local;
 use aether_actor::log::ActorLogRing;
 use aether_kinds::LogEntry;
 
+use crate::config::{KnobKind, KnobRecord};
+
 use super::now_unix_millis;
 
 /// Env var that forces backtrace capture without flipping
@@ -62,6 +64,34 @@ pub const ENV_CRASH_LOG_DISABLE: &str = "AETHER_CRASH_LOG_DISABLE";
 /// ADR-0081 §4 (`$XDG_DATA_HOME/aether/crash/`, falling back to
 /// `$HOME/.local/share/aether/crash/`).
 pub const ENV_CRASH_LOG_DIR: &str = "AETHER_CRASH_LOG_DIR";
+
+/// Registered so e1's unknown-`AETHER_*` boot sweep (`validate_env`)
+/// and e2's `--config` discovery dump (ADR-0090 §4) both cover the
+/// panic-hook's three env knobs.
+pub const PANIC_KNOBS: &[KnobRecord] = &[
+    KnobRecord {
+        env_key: ENV_BACKTRACE,
+        doc: "Forces backtrace capture on a substrate panic without flipping the process-wide \
+              RUST_BACKTRACE. Unset (derived from RUST_BACKTRACE via Backtrace::capture) by \
+              default.",
+        default: None,
+        kind: KnobKind::HandRegistered,
+    },
+    KnobRecord {
+        env_key: ENV_CRASH_LOG_DISABLE,
+        doc: "Disables the ADR-0081 §4 JSONL crash-dump path entirely. Anything truthy skips \
+              the file write; the tracing event still fires.",
+        default: Some("false"),
+        kind: KnobKind::HandRegistered,
+    },
+    KnobRecord {
+        env_key: ENV_CRASH_LOG_DIR,
+        doc: "Overrides the crash-dump base directory. Unset falls back to \
+              $XDG_DATA_HOME/aether/crash/, then $HOME/.local/share/aether/crash/.",
+        default: None,
+        kind: KnobKind::HandRegistered,
+    },
+];
 
 static INIT: OnceLock<()> = OnceLock::new();
 


### PR DESCRIPTION
Closes #2480.

## Summary

Five process-level env knobs the running substrate reads live — `AETHER_LOG_FILTER`, `AETHER_BACKTRACE`, `AETHER_CRASH_LOG_DISABLE`, `AETHER_CRASH_LOG_DIR`, `AETHER_MAX_FRAME_SIZE` — were absent from the ADR-0090 registry, so `validate_env` falsely warned "typo? stale export?" on legitimate exports and the `--config` dump omitted them.

Following the `SPIN_KNOBS` → `SCHEDULER_KNOBS` two-tier precedent: `LOG_KNOBS` lands adjacent to its read site in `runtime/log_install.rs`, `PANIC_KNOBS` (three records) adjacent to the `ENV_*` consts in `runtime/panic_hook.rs`, both aggregated as `RUNTIME_KNOBS` in `runtime/mod.rs` and folded into `chassis_registry()`. `AETHER_MAX_FRAME_SIZE` is the one exception to adjacent-to-read-site — `aether-codec` cannot depend on `aether-substrate` where `KnobRecord` lives — so it rides bundle-side in `CHASSIS_KNOBS` with a doc note naming its drift pair (`aether_codec::frame::MAX_FRAME_SIZE`).

Also deletes the dead `AETHER_BLOB_DEMUX_CHUNK` setter — with no reader (the ADR-0087 chunk cap was superseded by ADR-0094's in-place demux), `emit_settlement_settles_under_chunked_demux` was a byte-identical duplicate of its sibling with a false doc, so the whole test goes, not just the setter line.

## Test plan

`chassis_known_keys_includes_infra_knobs` tripwires all five keys against the assembled known-key set (fails if the `RUNTIME_KNOBS` extend or the frame-size record is dropped); the dump test additionally asserts `AETHER_LOG_FILTER` renders. Full workspace validation against the committed HEAD: clippy `-D warnings`, nextest (1906 passed), strict rustdoc.

## Generated by

`/implement` — agent execution of [scoped issue #2480](https://github.com/iamacoffeepot/aether/issues/2480).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
