### PR TITLE
fix(substrate-bundle): give the hub chassis the env sweep and full knob dump

### DIFF
--- a/crates/aether-substrate-bundle/src/bin/hub.rs
+++ b/crates/aether-substrate-bundle/src/bin/hub.rs
@@ -10,31 +10,15 @@
 #![allow(clippy::print_stderr)]
 #![allow(clippy::print_stdout)]
 
-use aether_capabilities::EngineConfigLayer;
-use aether_substrate::config::{KnobKind, KnobRecord, dump_config};
 use aether_substrate_bundle::cli::HubCli;
 use aether_substrate_bundle::hub::{Chassis, HubChassis, HubEnv};
+use aether_substrate_bundle::hub_config_dump;
 use clap::Parser as _;
-use confique::Config as _;
-
-/// `AETHER_RPC_PORT` is the hub's chassis-special bind-port knob —
-/// resolved via `HubCli --rpc-port` rather than an `EngineConfig`
-/// field, so it cannot ride the `EngineConfigLayer::META` walk and
-/// stays a hand `KnobRecord`.
-const RPC_PORT_RECORD: KnobRecord = KnobRecord {
-    env_key: "AETHER_RPC_PORT",
-    doc: "aether.rpc.server bind port (default 8901).",
-    default: Some("8901"),
-    kind: KnobKind::HandRegistered,
-};
 
 fn main() -> anyhow::Result<()> {
     let cli = HubCli::parse();
     if cli.config {
-        print!(
-            "{}",
-            dump_config(&[&EngineConfigLayer::META], &[RPC_PORT_RECORD])
-        );
+        print!("{}", hub_config_dump());
         return Ok(());
     }
     // `--describe` (ADR-0115, issue 1953): print this binary's manifest —
@@ -47,7 +31,7 @@ fn main() -> anyhow::Result<()> {
         );
         return Ok(());
     }
-    let chassis = HubChassis::build(HubEnv::from_env_with_argv(&cli))?;
+    let chassis = HubChassis::build(HubEnv::from_env_with_argv(&cli)?)?;
     eprintln!(
         "aether-substrate-bundle: hub chassis initialised (profile={})",
         HubChassis::PROFILE,

--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -26,10 +26,10 @@ use aether_capabilities::lifecycle::LifecycleGraphData;
 use aether_capabilities::rpc::{PeerKind, RpcServerCapability, RpcServerConfig};
 use aether_capabilities::{
     AnthropicCapability, AnthropicConfig, ComponentHostCapability, ComponentHostConfig,
-    FsCapability, GeminiCapability, GeminiConfig, HttpCapability, HttpServerCapability,
-    HttpServerConfig, InputCapability, InputConfig, InventoryCapability, LifecycleConfig,
-    TcpCapability, TextCapability, UiCapability, fs::NamespaceRoots, http::HttpConfig,
-    trace::TraceDispatchCapability,
+    EngineConfigLayer, FsCapability, GeminiCapability, GeminiConfig, HttpCapability,
+    HttpServerCapability, HttpServerConfig, InputCapability, InputConfig, InventoryCapability,
+    LifecycleConfig, TcpCapability, TextCapability, UiCapability, fs::NamespaceRoots,
+    http::HttpConfig, trace::TraceDispatchCapability,
 };
 use aether_kinds::{BinaryManifest, Present, Render, Shutdown, Tick};
 // The `aether.trajectory` recorder cap moved to `aether-labyrinth` (issue
@@ -66,7 +66,8 @@ use crate::headless::driver::TickConfigLayer;
 pub const CHASSIS_KNOBS: &[KnobRecord] = &[
     KnobRecord {
         env_key: "AETHER_RPC_PORT",
-        doc: "aether.rpc.server bind port (desktop/headless skip the server when unset).",
+        doc: "aether.rpc.server bind port; desktop/headless skip the server when unset, hub always \
+              binds (default 8901).",
         default: None,
         kind: KnobKind::HandRegistered,
     },
@@ -325,6 +326,50 @@ fn chassis_registry() -> (&'static [&'static Meta], Vec<KnobRecord>) {
 pub fn chassis_config_dump() -> String {
     let (metas, records) = chassis_registry();
     dump_config(metas, &records)
+}
+
+/// The hub chassis config registry: the full shared [`chassis_registry`]
+/// plus the two hub-only additions — `EngineConfigLayer::META` (the
+/// engines-cap heartbeat / proxy / disk-budget knobs only the hub wires)
+/// and the `AETHER_ENGINE_STORE_ROOT` hand knob (the engines cap's
+/// inline ops override, issue 1968). The hub reads the *full fleet* set
+/// rather than only its own knobs because a hub-spawned substrate
+/// inherits the hub's process environment, so fleet-wide cap knobs
+/// legitimately sit in the hub's env destined for the spawned engine.
+/// Shared by [`hub_known_keys`] (e1's sweep) and [`hub_config_dump`]
+/// (e2's `--config`) so both read one source of truth (ADR-0090 §4).
+fn hub_chassis_registry() -> (Vec<&'static Meta>, Vec<KnobRecord>) {
+    let (metas, mut records) = chassis_registry();
+    let mut metas: Vec<&'static Meta> = metas.to_vec();
+    metas.push(&EngineConfigLayer::META);
+    records.push(KnobRecord {
+        env_key: "AETHER_ENGINE_STORE_ROOT",
+        doc: "Parent directory for the engines cap's per-engine handle-store dirs; ops escape \
+              hatch (unset falls back to the platform data dir, then the system temp dir).",
+        default: None,
+        kind: KnobKind::HandRegistered,
+    });
+    (metas, records)
+}
+
+/// Assemble the hub chassis [`KnownKeys`] set (ADR-0090 §4): the full
+/// fleet registry (`hub_chassis_registry`). The hub's boot sweep
+/// (`HubEnv::from_env_with_argv`) validates the process env against
+/// this, mirroring the desktop / headless sweeps.
+#[must_use]
+pub fn hub_known_keys() -> KnownKeys {
+    let (metas, records) = hub_chassis_registry();
+    known_keys(&metas, &records)
+}
+
+/// Render the `--config` discovery dump for the hub chassis
+/// (ADR-0090 §4): the full fleet registry plus the hub-only engine
+/// knobs, so an operator sees every knob that will take effect on the
+/// hub and the substrates it spawns.
+#[must_use]
+pub fn hub_config_dump() -> String {
+    let (metas, records) = hub_chassis_registry();
+    dump_config(&metas, &records)
 }
 
 /// Build the single-stage lifecycle config the headless chassis runs
@@ -808,6 +853,37 @@ mod tests {
         ] {
             assert!(known.contains(key), "chassis_known_keys missing {key}");
         }
+    }
+
+    #[test]
+    fn hub_known_keys_includes_engine_and_fleet_and_store_root() {
+        // The hub composition this crate owns: the shared registry
+        // unioned with the two hub-only additions — the engines-cap
+        // `EngineConfigLayer::META` keys, the `AETHER_ENGINE_STORE_ROOT`
+        // hand knob, and (because a hub-spawned substrate inherits the
+        // hub's env) the fleet cap keys the shared registry carries.
+        let known = super::hub_known_keys();
+        assert!(
+            known.contains("AETHER_HUB_HEARTBEAT_INTERVAL_SECS"),
+            "AETHER_HUB_HEARTBEAT_INTERVAL_SECS must be a known hub key",
+        );
+        assert!(
+            known.contains("AETHER_ENGINE_STORE_ROOT"),
+            "AETHER_ENGINE_STORE_ROOT must be a known hub key",
+        );
+        assert!(
+            known.contains("AETHER_AUDIO_DISABLE"),
+            "fleet cap keys must stay in the hub known-key set (spawned substrates inherit \
+             the hub's env)",
+        );
+    }
+
+    #[test]
+    fn hub_config_dump_lists_an_engine_knob() {
+        // e2's hub `--config` walks the same registry as e1's sweep, so
+        // the hub-only engine knobs render in the dump.
+        let dump = super::hub_config_dump();
+        assert!(dump.contains("AETHER_HUB_HEARTBEAT_INTERVAL_SECS"));
     }
 
     #[test]

--- a/crates/aether-substrate-bundle/src/hub/chassis.rs
+++ b/crates/aether-substrate-bundle/src/hub/chassis.rs
@@ -22,9 +22,10 @@ use aether_substrate::chassis::builder::{
     Builder, BuiltChassis, DriverCapability, DriverCtx, DriverRunning, RunError,
 };
 use aether_substrate::chassis::error::BootError;
+use aether_substrate::config::{ConfigError, validate_env};
 use aether_substrate::{Chassis, SubstrateBoot};
 
-use crate::chassis_common::ActorRingConfig;
+use crate::chassis_common::{ActorRingConfig, hub_known_keys};
 use crate::cli::HubCli;
 use crate::hub::DEFAULT_RPC_PORT;
 use std::thread;
@@ -79,8 +80,11 @@ impl HubEnv {
     /// [`DEFAULT_RPC_PORT`] when unset or unparseable. Binds on
     /// `127.0.0.1` — intentional for the current single-host
     /// development story.
-    #[must_use]
-    pub fn from_env() -> Self {
+    ///
+    /// # Errors
+    ///
+    /// See [`Self::from_env_with_argv`].
+    pub fn from_env() -> Result<Self, ConfigError> {
         Self::from_env_with_argv(&HubCli::default())
     }
 
@@ -93,17 +97,26 @@ impl HubEnv {
     /// `AETHER_HUB_HEARTBEAT_*` env beats the literal default). Takes
     /// `&HubCli`, cloning the overlay rather than consuming `cli` so the
     /// bin keeps it for the `--config` dump.
-    #[must_use]
-    pub fn from_env_with_argv(cli: &HubCli) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`ConfigError`] from the ADR-0090 §4 boot sweep
+    /// ([`validate_env`]) — today the sweep only warns, but the
+    /// `Result` keeps the hard-error half free to join without a
+    /// call-site change, matching desktop / headless.
+    pub fn from_env_with_argv(cli: &HubCli) -> Result<Self, ConfigError> {
         use std::net::{IpAddr, Ipv4Addr};
+        // ADR-0090 §4 (e1): warn on any unknown AETHER_ env var before
+        // resolving — a typo / stale export is loud but non-fatal.
+        validate_env(&hub_known_keys())?;
         let rpc_port = cli
             .rpc_port
             .or_else(super::rpc_port_from_env)
             .unwrap_or(DEFAULT_RPC_PORT);
-        Self {
+        Ok(Self {
             rpc_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), rpc_port),
             engine: EngineConfig::from_argv_then_env(cli.engine.clone().into_layer()),
-        }
+        })
     }
 }
 

--- a/crates/aether-substrate-bundle/src/lib.rs
+++ b/crates/aether-substrate-bundle/src/lib.rs
@@ -27,7 +27,9 @@
 pub mod autoload;
 pub mod bundle_pack;
 mod chassis_common;
-pub use chassis_common::{binary_manifest, chassis_config_dump, common_cap_namespaces};
+pub use chassis_common::{
+    binary_manifest, chassis_config_dump, common_cap_namespaces, hub_config_dump, hub_known_keys,
+};
 pub mod chassis_root;
 pub mod cli;
 pub mod desktop;


### PR DESCRIPTION
Closes #2481.

## Summary

The hub was the only chassis that skipped the ADR-0090 §4 boot-time unknown-`AETHER_*` sweep and shipped a truncated `--config` dump (`EngineConfigLayer::META` + a hand `RPC_PORT_RECORD` only) — even though the hub runs the same substrate scheduler and is the fleet's env entry point (a hub-spawned substrate inherits the hub's process environment).

The hub now gets its own registry composition in `chassis_common.rs`: `hub_chassis_registry()` = the full shared `chassis_registry()` plus the hub-only `EngineConfigLayer::META` and an `AETHER_ENGINE_STORE_ROOT` hand record, with `hub_known_keys()` / `hub_config_dump()` over it — one source of truth for both the sweep and the dump, per the ADR-0090 §4 invariant. `HubEnv::from_env_with_argv` / `from_env` become `Result<Self, ConfigError>` and run `validate_env(&hub_known_keys())` first, mirroring desktop/headless; `bin/hub.rs` swaps to `hub_config_dump()`, dropping the now-redundant `RPC_PORT_RECORD` (the shared `CHASSIS_KNOBS` record covers it, with its doc generalized for all three chassis).

The full-fleet key set is deliberate: fleet-wide cap knobs (`AETHER_AUDIO_DISABLE`, `AETHER_TICK_HZ`, …) legitimately sit in the hub's env destined for spawned engines, so the hub must accept them in the sweep and surface them in `--config`.

## Test plan

`hub_known_keys_includes_engine_and_fleet_and_store_root` pins the composition (engine, store-root, and a representative fleet key); `hub_config_dump_lists_an_engine_knob` pins the dump. Manual sanity: `aether-substrate-hub --config` renders the full 53-row registry. Full workspace validation against the committed HEAD: clippy `-D warnings`, nextest (1908 passed), strict rustdoc.

## Generated by

`/implement` — agent execution of [scoped issue #2481](https://github.com/iamacoffeepot/aether/issues/2481).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
