### PR TITLE
chore(ci): guard against inline mod runtime blocks in aether-capabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,13 @@ jobs:
       - uses: actions/checkout@v4
       - run: scripts/check-no-scoped-visibility.sh
 
+  no-inline-runtime-mod:
+    name: No inline runtime mod
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: scripts/check-no-inline-runtime-mod.sh
+
   hook-tests:
     name: Guardrail hook tests
     runs-on: ubuntu-latest
@@ -356,7 +363,7 @@ jobs:
   ci-pass:
     name: CI pass
     if: always()
-    needs: [ changes, fmt, no-dividers, no-scoped-visibility, hook-tests, clippy, docs, test, desktop, qodana ]
+    needs: [ changes, fmt, no-dividers, no-scoped-visibility, no-inline-runtime-mod, hook-tests, clippy, docs, test, desktop, qodana ]
     runs-on: ubuntu-latest
     steps:
       - name: Verify required jobs
@@ -365,6 +372,7 @@ jobs:
           echo "fmt:     ${{ needs.fmt.result }}"
           echo "no-dividers: ${{ needs.no-dividers.result }}"
           echo "no-scoped-visibility: ${{ needs.no-scoped-visibility.result }}"
+          echo "no-inline-runtime-mod: ${{ needs.no-inline-runtime-mod.result }}"
           echo "hook-tests: ${{ needs.hook-tests.result }}"
           echo "clippy:  ${{ needs.clippy.result }}"
           echo "docs:    ${{ needs.docs.result }}"
@@ -376,6 +384,7 @@ jobs:
           [[ "${{ needs.fmt.result }}"     == "success" ]] || fail=1
           [[ "${{ needs.no-dividers.result }}" == "success" ]] || fail=1
           [[ "${{ needs.no-scoped-visibility.result }}" == "success" ]] || fail=1
+          [[ "${{ needs.no-inline-runtime-mod.result }}" == "success" ]] || fail=1
           [[ "${{ needs.hook-tests.result }}" == "success" ]] || fail=1
           [[ "${{ needs.clippy.result }}"  == "success" || "${{ needs.clippy.result }}" == "skipped" ]] || fail=1
           [[ "${{ needs.docs.result }}"    == "success" || "${{ needs.docs.result }}" == "skipped" ]] || fail=1

--- a/scripts/check-no-inline-runtime-mod.sh
+++ b/scripts/check-no-inline-runtime-mod.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# CI lint: fail on inline `mod runtime { ... }` blocks in aether-capabilities
+# (issue 2479). The convention lives in CLAUDE.md / the struct-hosted
+# actor-macro migration: a cap's runtime half is a sibling `runtime.rs`
+# (or `runtime/` directory) declared with a bare `mod runtime;` — never an
+# inline `mod runtime { ... }` block. The compiler is indifferent to the
+# difference, so nothing but this check stops the inline form from
+# regressing back in.
+#
+# The anchored regex matches only the inline block opener (`mod runtime {`)
+# and leaves the sanctioned bare declaration (`mod runtime;`) untouched,
+# since the sanctioned form ends in `;` not `{`. The leading-whitespace
+# anchor also excludes prose mentions of `mod runtime` inside comments and
+# doc lines.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+matches=$(git ls-files 'crates/aether-capabilities/src/*.rs' \
+  | xargs grep -nHE '^[[:space:]]*mod runtime[[:space:]]*\{' 2>/dev/null || true)
+
+if [[ -n "$matches" ]]; then
+  echo "inline \`mod runtime\` blocks are banned in aether-capabilities" >&2
+  echo "(CLAUDE.md conventions); use a \`runtime.rs\`/\`runtime/\` sibling behind a bare \`mod runtime;\`:" >&2
+  echo "$matches" >&2
+  exit 1
+fi
+echo "check-no-inline-runtime-mod: clean."


### PR DESCRIPTION
Closes #2479.

## Summary

The struct-hosted actor-macro migration replaced every inline `mod runtime { ... }` block in `aether-capabilities` with a sibling `runtime.rs` / `runtime/` declared by a bare `mod runtime;`, but nothing mechanical stops the inline form from creeping back — it still compiles fine. This adds the CI guard: `scripts/check-no-inline-runtime-mod.sh`, a structural twin of `check-no-scoped-visibility.sh`, failing on any inline `mod runtime {` opener under `crates/aether-capabilities/src` while leaving the sanctioned bare declaration untouched, wired into `ci.yml` as an always-run `no-inline-runtime-mod` job registered in the `ci-pass` aggregator.

## Test plan

- Script exits 0 on the current tree (all six inline blocks migrated away by #2474/#2475/#2476).
- Verified it exits 1 with the offending `file:line` list when a violating inline block is temporarily introduced.
- `bash -n` on the script; `ci.yml` YAML-parses.

## Generated by

`/implement` — agent execution of [scoped issue #2479](https://github.com/iamacoffeepot/aether/issues/2479).
