### PR TITLE
fix(substrate): make Lifecycle::new reject lengths past MAX_GROUPS in all profiles

### DIFF
--- a/crates/aether-substrate/src/actor/native/blob_lifecycle.rs
+++ b/crates/aether-substrate/src/actor/native/blob_lifecycle.rs
@@ -101,7 +101,7 @@ impl Lifecycle {
     /// A fresh blob with `initial_len` groups already published (the first
     /// flush's groups, written into the array before construction).
     pub fn new(initial_len: usize) -> Self {
-        debug_assert!(
+        assert!(
             initial_len <= MAX_GROUPS,
             "initial_len exceeds field ceiling"
         );
@@ -290,6 +290,16 @@ mod tests {
         assert!(lc.complete(), "the one claimed group retires the blob");
         // Second, unpaired completion: done (1) >= len (1) — guard fires.
         lc.complete();
+    }
+
+    // Tripwire: `Lifecycle::new` rejects an `initial_len` past `MAX_GROUPS`
+    // in every build profile, not just under `debug_assertions` — an
+    // oversized `initial_len` would otherwise overflow the packed word's
+    // 21-bit `len` field into the adjacent `done`/`seal` bits.
+    #[test]
+    #[should_panic(expected = "initial_len exceeds field ceiling")]
+    fn new_past_ceiling_panics() {
+        Lifecycle::new(MAX_GROUPS + 1);
     }
 
     #[test]


### PR DESCRIPTION
Closes #2498.

## Summary

`Lifecycle::new` only `debug_assert!`ed `initial_len <= MAX_GROUPS`, so a release build packed an oversized `initial_len` into the lifecycle word unchecked, overflowing the len bitfield into the adjacent cursor/done/sealed fields and corrupting the single-producer/many-worker state. The constructor now enforces the ceiling with a hard `assert!` in all build profiles — mirroring how `publish` already rejects the same ceiling with `Published::Full`. A fallible constructor was rejected at scope time: the sole production caller passes a compile-time constant, and all growth already goes through the ceiling-guarded `publish`, so a `Result` would spread a can't-happen branch.

## Test plan

- New ungated `#[should_panic]` test `new_past_ceiling_panics` (tripwire: the ceiling must hold in every profile).
- Full workspace preflight (fmt, clippy `-D warnings`, nextest, doc, wasm32 cross-build, qodana) green.

## Generated by

`/implement` — agent execution of [scoped issue #2498](https://github.com/iamacoffeepot/aether/issues/2498).
