### PR TITLE
fix(substrate): use the canonical seqlock read pattern in SettlementTable::read_key

### DIFF
--- a/crates/aether-substrate/src/chassis/settlement_table.rs
+++ b/crates/aether-substrate/src/chassis/settlement_table.rs
@@ -82,7 +82,7 @@
 //! probe sweep as a fail-fast (it cannot happen at the occupancy the
 //! stress tests or realistic fleets reach).
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering, fence};
 
 use aether_data::{MailId, MailboxId};
 
@@ -204,7 +204,8 @@ impl SettlementTable {
         }
         let sender = slot.sender.load(Ordering::Relaxed);
         let correlation = slot.correlation.load(Ordering::Relaxed);
-        let sv2 = slot.sv.load(Ordering::Acquire);
+        fence(Ordering::Acquire);
+        let sv2 = slot.sv.load(Ordering::Relaxed);
         (sv1 == sv2).then_some((sender, correlation))
     }
 


### PR DESCRIPTION
Closes #2505.

## Summary

`SettlementTable::read_key` loaded `sv1` with `Acquire`, read the two key words `Relaxed`, then re-validated `sv2` with an `Acquire` *load* — which only bars later operations from hoisting above it and does not stop the two prior relaxed data loads from sinking below the version re-check, so a torn `(sender, correlation)` snapshot could pass `sv1 == sv2` under the abstract memory model. This switches to the canonical fence-based seqlock read: `sv1` stays `Acquire`, an `Acquire` fence sits between the data loads and the re-check, and `sv2` drops to `Relaxed`. The writer side (`publish`: relaxed key stores, `Release` OCCUPIED store) was verified already correct and is untouched.

## Test plan

Deliberately no new test: without `loom`, no test on our CI hardware can distinguish the orderings (x86 never reorders the relaxed loads), so an assertion would pass identically before and after. Existing settlement stress tests plus workspace clippy/nextest cover the change; agent validation ran the full workspace suite green.

## Generated by

`/implement` — agent execution of [scoped issue #2505](https://github.com/iamacoffeepot/aether/issues/2505).
