### PR TITLE
fix(substrate): remove ReplyTable entries on resolve

### DIFF
--- a/crates/aether-actor/src/mail/mod.rs
+++ b/crates/aether-actor/src/mail/mod.rs
@@ -41,8 +41,9 @@ pub const NO_REPLY_HANDLE: u32 = u32::MAX;
 ///
 /// `Copy` because the handle is a `u32` underneath; cloning is free.
 /// Cloning is also fine for stashing across receives — the substrate
-/// guarantees the handle stays valid for the lifetime of the
-/// receiving component instance.
+/// guarantees the handle stays valid from receipt until it is
+/// answered. A handle is one-shot: the first `Ctx::reply` that uses
+/// it consumes it, and a later `reply` with the same handle fails.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct ReplyHandle {
     pub(crate) raw: u32,

--- a/crates/aether-substrate/src/actor/wasm/host_fns.rs
+++ b/crates/aether-substrate/src/actor/wasm/host_fns.rs
@@ -412,10 +412,15 @@ pub fn register(linker: &mut Linker<ComponentCtx>) -> wasmtime::Result<()> {
             };
             let payload = data[start..end].to_vec();
 
-            let ctx = caller.data();
-            let Some(entry) = ctx.reply_table.resolve(sender) else {
+            // A reply handle is one-shot: take (not resolve) so the
+            // entry is removed here, capping the table at in-flight
+            // replies rather than lifetime traffic. The mutable
+            // borrow ends with this statement, before the `&self`
+            // uses below.
+            let Some(entry) = caller.data_mut().reply_table.take(sender) else {
                 return REPLY_UNKNOWN_HANDLE;
             };
+            let ctx = caller.data();
             // ADR-0042: echo the inbound correlation on every reply
             // path so the originating actor's handler can match its
             // own reply to the request it sent out of a busy inbox.

--- a/crates/aether-substrate/src/actor/wasm/reply_table.rs
+++ b/crates/aether-substrate/src/actor/wasm/reply_table.rs
@@ -109,6 +109,19 @@ impl ReplyTable {
         }
         self.entries.get(&handle).copied()
     }
+
+    /// Look up and remove the entry for a guest-supplied handle. A
+    /// handle is one-shot: this is the production resolve path
+    /// (`reply_mail`), so answering caps the table at in-flight
+    /// replies rather than lifetime traffic. Returns `None` for
+    /// `NO_REPLY_HANDLE` and for handles that were never allocated
+    /// or already taken.
+    pub fn take(&mut self, handle: u32) -> Option<ReplyEntry> {
+        if handle == NO_REPLY_HANDLE {
+            return None;
+        }
+        self.entries.remove(&handle)
+    }
 }
 
 #[cfg(test)]
@@ -165,5 +178,18 @@ mod tests {
         let h = t.allocate(entry);
         let got = t.resolve(h).expect("resolves");
         assert_eq!(got.correlation_id, 0xCAFE_BABE);
+    }
+
+    #[test]
+    fn take_removes_entry() {
+        let mut t = ReplyTable::new();
+        let entry = ReplyEntry::session(token(9));
+        let h = t.allocate(entry);
+        // Tripwire: a handle is one-shot — the first `take` returns
+        // the entry and removes it, so a second take (or resolve)
+        // against the same handle sees nothing.
+        assert_eq!(t.take(h), Some(entry));
+        assert_eq!(t.take(h), None);
+        assert_eq!(t.resolve(h), None);
     }
 }


### PR DESCRIPTION
Closes #2504.

## Summary

`ReplyTable::allocate` inserts an entry for every mail a component receives, but the resolve path read it with `entries.get().copied()` and never removed it, so entries accumulated for the component's entire lifetime traffic. The type's own doc frames the lifecycle as one-shot — allocated on receive, resolved when the guest calls `reply_mail` — and that was verified against every in-tree consumer (no wasm guest replies twice to one inbound; ADR-0042 and ADR-0080 both assume a single reply). Resolution now goes through a consuming `ReplyTable::take` in `reply_mail_p32`, capping memory to in-flight replies; the read-only `resolve` stays for test introspection. The public `ReplyHandle` doc in `aether-actor` is tightened in the same change — it promised validity "for the lifetime of the receiving component instance", which over-stated what stashing needs and becomes false for an answered handle.

## Test plan

- New `take_removes_entry` tripwire test on the table.
- Full workspace clippy/nextest/doc plus the wasm32 component cross-build ran green in agent validation.

## Generated by

`/implement` — agent execution of [scoped issue #2504](https://github.com/iamacoffeepot/aether/issues/2504).
