### PR TITLE
fix(substrate): stop dropping a second staged sibling spawn in one receive

### DIFF
--- a/crates/aether-capabilities/src/trampoline/runtime/mod.rs
+++ b/crates/aether-capabilities/src/trampoline/runtime/mod.rs
@@ -211,11 +211,11 @@ impl NativeActor for WasmTrampoline {
     /// dispatch shim do the rest.
     #[fallback]
     fn forward_to_wasm(state: &mut Self::State, ctx: &mut NativeCtx<'_>, env: &Envelope) -> bool {
-        // ADR-0097: deliver the inbound, then drain any sibling spawn
+        // ADR-0097: deliver the inbound, then drain every sibling spawn
         // the guest staged during `deliver`. The block scopes the
         // `&mut component` borrow so `spawn_sibling` can read the
         // trampoline's other fields afterward.
-        let pending = {
+        let pendings = {
             let Some(component) = state.component.as_mut() else {
                 tracing::warn!(
                     target: "aether_capabilities::trampoline",
@@ -263,9 +263,9 @@ impl NativeActor for WasmTrampoline {
                     state.mailbox, env.kind_name,
                 ));
             }
-            component.take_pending_spawn()
+            component.drain_pending_spawns()
         };
-        if let Some(pending) = pending {
+        for pending in pendings {
             state.spawn_sibling(ctx, pending);
         }
         true

--- a/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
+++ b/crates/aether-substrate-bundle/tests/test_bench_scenario.rs
@@ -438,6 +438,77 @@ fn multi_actor_sibling_spawn() {
     );
 }
 
+/// Issue iamacoffeepot/aether#2503: `RootManager` spawns two `Panel`
+/// siblings from a *single* `receive` (`Ping { seq: 2 }` drives two
+/// `ctx.spawn_child` calls before the handler returns). Both spawns
+/// must survive the post-`receive` drain — pre-fix, the ctx slot was
+/// `Option<PendingSpawn>` and a second stage overwrote the first, so
+/// only the last-staged sibling (Counter `1`) ever actually spawned:
+/// pinging Counter `0`'s predicted `MailboxId` warn-dropped with no
+/// broadcast, and this scenario observed `TICK_OBSERVED == 1` instead
+/// of `2`.
+#[test]
+fn multi_actor_sibling_spawn_twice_in_one_receive() {
+    let Some(wasm_path) = require_runtime("aether_test_fixtures_bundle") else {
+        return;
+    };
+    let mut bench = TestBench::start_with_size(64, 48).expect("boot");
+    let wasm = fs::read(&wasm_path).expect("read fixture wasm");
+    let loaded = bench
+        .execute(vec![(
+            "load",
+            BenchOp::send_and_await(
+                "aether.component",
+                &LoadComponent {
+                    wasm,
+                    name: None,
+                    config: Vec::new(),
+                    export: Some("ui.root".to_owned()),
+                },
+            ),
+        )])
+        .expect("load sequence");
+    let root_name = match loaded
+        .reply::<LoadResult>("load")
+        .expect("decode LoadResult")
+    {
+        LoadResult::Ok { name, .. } => name,
+        LoadResult::Err { error } => panic!("multi-actor load failed: {error}"),
+    };
+
+    // Both Panels nest under RootManager's lineage; the Counter
+    // discriminator advances once per spawn_child call, in guest call
+    // order, so the two staged within one receive predict "0" then "1".
+    let panel_0 = format!("{root_name}/aether.embedded:0");
+    let panel_1 = format!("{root_name}/aether.embedded:1");
+    bench
+        .execute(vec![
+            // RootManager spawns two Panel siblings (Counter 0 and 1)
+            // from this one Ping receive.
+            (
+                "spawn_two",
+                BenchOp::send_mail::<Ping>(root_name.as_str(), &Ping { seq: 2 }),
+            ),
+            (
+                "ping_panel_0",
+                BenchOp::send_mail::<Ping>(panel_0.as_str(), &Ping { seq: 1 }),
+            ),
+            (
+                "ping_panel_1",
+                BenchOp::send_mail::<Ping>(panel_1.as_str(), &Ping { seq: 1 }),
+            ),
+        ])
+        .expect("spawn-twice + ping-both sequence");
+
+    assert_eq!(
+        bench.count_observed(TICK_OBSERVED),
+        2,
+        "both siblings staged in the one receive should have spawned and broadcast; \
+         observed kinds: {:?}",
+        bench.observed_kinds(),
+    );
+}
+
 /// Dropping the probe stops further `tick_observed` broadcasts.
 /// Validates that `aether.component.drop` removes the
 /// mailbox from the input subscriber set so subsequent ticks don't

--- a/crates/aether-substrate/src/actor/wasm/component.rs
+++ b/crates/aether-substrate/src/actor/wasm/component.rs
@@ -11,6 +11,7 @@
 // module.
 
 use std::cell::Cell;
+use std::mem;
 use std::sync::Arc;
 
 use wasmtime::{Engine, Linker, Memory, Module, Store, TypedFunc};
@@ -167,13 +168,15 @@ pub struct ComponentCtx {
     /// `correlation_counter`: `prev_correlation_p32` reports a guest's
     /// own request correlations, and a reply is not one of them.
     reply_lineage_counter: Cell<u64>,
-    /// ADR-0097: a sibling-spawn request staged by the `spawn_sibling`
+    /// ADR-0097: sibling-spawn requests staged by the `spawn_sibling`
     /// host fn and drained by the trampoline after `receive_p32`
     /// returns — the same host-fn-stages / host-drains pattern as
-    /// `saved_state`. `None` outside an in-flight spawn. The trampoline
-    /// performs the actual `spawn_child::<WasmTrampoline>`; substrate
-    /// can't name that capabilities-layer type (ADR-0097 §4).
-    pub pending_spawn: Option<PendingSpawn>,
+    /// `saved_state`. Empty outside an in-flight spawn; a handler that
+    /// calls `spawn_child` more than once in one `receive` stages one
+    /// entry per call, in guest call order. The trampoline performs the
+    /// actual `spawn_child::<WasmTrampoline>`; substrate can't name that
+    /// capabilities-layer type (ADR-0097 §4).
+    pub pending_spawns: Vec<PendingSpawn>,
 }
 
 /// The mailbox-name prefix every wasm component (loaded or spawned)
@@ -236,7 +239,7 @@ impl ComponentCtx {
             in_flight_mail_id: Cell::new(MailId::NONE),
             in_flight_root: Cell::new(MailId::NONE),
             reply_lineage_counter: Cell::new(REPLY_LINEAGE_BASE),
-            pending_spawn: None,
+            pending_spawns: Vec::new(),
         }
     }
 
@@ -1234,13 +1237,13 @@ impl Component {
         self.store.data_mut().saved_state.take()
     }
 
-    /// ADR-0097: drain the sibling-spawn request the guest staged via
+    /// ADR-0097: drain every sibling-spawn request the guest staged via
     /// the `spawn_sibling` host fn during the just-returned `receive`.
-    /// The trampoline calls this after `deliver` and performs the
-    /// actual `spawn_child::<WasmTrampoline>`. Destructive — returns
-    /// `None` once drained, and `None` when the guest didn't spawn.
-    pub fn take_pending_spawn(&mut self) -> Option<PendingSpawn> {
-        self.store.data_mut().pending_spawn.take()
+    /// The trampoline calls this after `deliver` and performs one
+    /// `spawn_child::<WasmTrampoline>` per request. Destructive — empty
+    /// once drained, and empty when the guest didn't spawn.
+    pub fn drain_pending_spawns(&mut self) -> Vec<PendingSpawn> {
+        mem::take(&mut self.store.data_mut().pending_spawns)
     }
 
     /// Extract a failure recorded by `save_state` (size cap, OOB).

--- a/crates/aether-substrate/src/actor/wasm/host_fns.rs
+++ b/crates/aether-substrate/src/actor/wasm/host_fns.rs
@@ -201,7 +201,7 @@ pub fn register(linker: &mut Linker<ComponentCtx>) -> wasmtime::Result<()> {
                 aether_data::Tag::Mailbox,
                 aether_data::fold_lineage(trampoline_carry, sibling_node),
             );
-            caller.data_mut().pending_spawn = Some(PendingSpawn {
+            caller.data_mut().pending_spawns.push(PendingSpawn {
                 tag,
                 subname: full_subname,
                 config,

--- a/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/multi_actor.rs
+++ b/crates/aether-test-fixtures/aether-test-fixtures-bundle/src/multi_actor.rs
@@ -11,9 +11,11 @@
 //! Receive surfaces are deliberately distinct so a load test can prove
 //! which type was instantiated: `RootManager` is a strict receiver (one
 //! `Ping` handler, no fallback); `Panel` adds a `#[fallback]`. On `Ping`,
-//! `RootManager` spawns a `Panel` sibling and `Panel` broadcasts a
-//! `TickObserved` to the test-bench observer — so a scenario can confirm
-//! the spawned sibling is addressable and live.
+//! `RootManager` spawns `Ping.seq.max(1)` `Panel` siblings — from a
+//! single `receive` when `seq > 1`, covering issue iamacoffeepot/aether#2503's
+//! multi-spawn-per-receive path — and each spawned `Panel` broadcasts a
+//! `TickObserved` to the test-bench observer, so a scenario can confirm
+//! every spawned sibling is addressable and live.
 
 // `#[handler]` / `#[fallback]` methods take `&mut self` to match the
 // dispatch ABI even when stateless.
@@ -37,13 +39,18 @@ impl WasmActor for RootManager {
         Ok(RootManager)
     }
 
-    /// ADR-0097: on `Ping`, spawn a `Panel` sibling from the same
-    /// resident module. `Subname::Counter` gives it a bare counter
-    /// discriminator (`0`, `1`, …); the returned `MailboxId` is
+    /// ADR-0097: on `Ping`, spawn `seq.max(1)` `Panel` siblings from the
+    /// same resident module — `seq > 1` drives multiple `spawn_child`
+    /// calls within this one `receive`, which is exactly the shape
+    /// issue #2503 covers (a second staged sibling spawn must not be
+    /// dropped). `Subname::Counter` gives each spawn a bare counter
+    /// discriminator (`0`, `1`, …); the returned `MailboxId`s are
     /// fire-and-forget here.
     #[handler]
-    fn on_ping(&mut self, ctx: &mut WasmCtx<'_>, _ping: Ping) {
-        let _ = ctx.spawn_child::<Panel>(Subname::Counter, &());
+    fn on_ping(&mut self, ctx: &mut WasmCtx<'_>, ping: Ping) {
+        for _ in 0..ping.seq.max(1) {
+            let _ = ctx.spawn_child::<Panel>(Subname::Counter, &());
+        }
     }
 }
 


### PR DESCRIPTION
Closes #2503.

## Summary

`spawn_sibling_p32` staged a pending sibling spawn by assigning the component's single `pending_spawn: Option<PendingSpawn>` slot unconditionally, so a second `spawn_child` call within one `receive` silently overwrote the first — the first staged request was lost with no warning. The slot is now `pending_spawns: Vec<PendingSpawn>`: the host fn pushes, `drain_pending_spawns` (via `mem::take`) returns the whole batch, and the trampoline drains it in a loop — upholding ADR-0097's stage/drain contract instead of warning on the discarded request. The inline-child path (ADR-0114) registers alias routes synchronously and stages nothing on this slot, so no interaction there.

## Test plan

- New TestBench scenario `multi_actor_sibling_spawn_twice_in_one_receive`, driven through the `RootManager` fixture now spawning `seq.max(1)` panels. Verified the tripwire is real: with the fix reverted the test fails with `UnknownMailbox` (the pre-fix drop); with the fix it passes alongside the existing `multi_actor_sibling_spawn`.
- Agent validation: workspace clippy green; the full nextest/doc/wasm sweep was cut short by the disk-exhaustion incident, so CI's full re-run is the gate for this PR (CI-as-gate).

## Generated by

`/implement` — agent execution of [scoped issue #2503](https://github.com/iamacoffeepot/aether/issues/2503).
