### PR TITLE
fix(substrate): release parked SettlementHold on blocking-dispatch failure paths

### DIFF
--- a/crates/aether-substrate/src/actor/native/binding.rs
+++ b/crates/aether-substrate/src/actor/native/binding.rs
@@ -951,6 +951,25 @@ impl NativeBinding {
             .dispatch_take(id)
     }
 
+    /// Remove the named dispatch entry and hand back its parked
+    /// `(SettlementHold, Source)` without any downcast — the release path
+    /// for a worker that never armed. The spawn-error branch of
+    /// [`dispatch_blocking_resumed_with`](super::ctx::NativeCtx::dispatch_blocking_resumed_with)
+    /// calls this and drops the returned hold so the chain settles.
+    ///
+    /// # Panics
+    /// Panics if the in-flight ledger mutex is poisoned — fail-fast per
+    /// ADR-0063.
+    pub(crate) fn dispatch_abandon(
+        &self,
+        id: super::dispatch_blocking::DispatchId,
+    ) -> Option<(SettlementHold, Source)> {
+        self.inflight
+            .lock()
+            .expect("in-flight ledger poisoned; fail-fast per ADR-0063")
+            .dispatch_abandon(id)
+    }
+
     /// Non-consuming peek-then-take of the named dispatch entry: probe its
     /// boxed output + context against `O` / `C` and only remove + rebuild
     /// the [`TaskDone`](super::dispatch_blocking::TaskDone) on a match,

--- a/crates/aether-substrate/src/actor/native/ctx.rs
+++ b/crates/aether-substrate/src/actor/native/ctx.rs
@@ -498,6 +498,15 @@ impl<M: ReplyMode> NativeCtx<'_, M> {
                 error = %e,
                 "failed to spawn dispatch_blocking worker thread",
             );
+            // No worker will ever fill the output or push the completion
+            // wake, so the parked entry (hold + reply_to) would sit in the
+            // ledger forever and wedge the caller's chain to its timeout.
+            // Release the eagerly-acquired hold so the chain settles — the
+            // `TaskDone::Drop` "released hold, owed a reply that never went
+            // out" outcome. A thread-spawn failure is environmental (OS
+            // resource exhaustion), not a programmer bug, so it does not
+            // `debug_assert`.
+            drop(self.binding.dispatch_abandon(id));
         }
         id
     }

--- a/crates/aether-substrate/src/actor/native/dispatch_blocking.rs
+++ b/crates/aether-substrate/src/actor/native/dispatch_blocking.rs
@@ -377,14 +377,44 @@ impl InflightTable {
         }
     }
 
+    /// Remove the named entry and hand back its parked `(hold, reply_to)`
+    /// **without** any `O` / `C` downcast — the worker never ran, so there
+    /// is no output to type. The spawn-error branch calls this to release
+    /// the eagerly-acquired hold when arming failed: the caller drops the
+    /// returned hold, settling the chain the dispatch would otherwise wedge
+    /// forever. A no-op (`None`) for an unknown id.
+    fn abandon(&mut self, id: DispatchId) -> Option<(SettlementHold, Source)> {
+        let entry = self.entries.remove(&id)?;
+        Some((entry.hold, entry.reply_to))
+    }
+
     /// Remove the named entry and downcast its boxed `context` + filled
     /// `output` into a typed [`TaskDone`]. Returns `None` for an unknown
     /// id (cancelled / double-landed) or if the worker hasn't filled the
     /// output yet (the completion-wake must land after the fill, so this
-    /// is the unknown-id case in practice). A type mismatch on either
-    /// downcast also yields `None` — a wiring bug where the handler's
-    /// `O` / `C` don't match the dispatch's.
+    /// is the unknown-id case in practice) — leaving the entry intact on
+    /// either miss so a parked hold is never bare-dropped. A downcast
+    /// *mismatch* against a filled output is a genuine `O` / `C` wiring bug:
+    /// it `debug_assert`s loudly (distinct from the benign unfilled case)
+    /// and returns `None` with the entry retained.
     fn take<O: 'static, C: 'static>(&mut self, id: DispatchId) -> Option<TaskDone<O, C>> {
+        let entry = self.entries.get(&id)?;
+        // Peek-then-remove, the same discipline `try_take` uses: probe the
+        // boxed `output` + `context` without disturbing the entry. An
+        // unfilled output slot returns `None` quietly (a later wake completes
+        // the still-parked entry). A type mismatch against a *filled* output
+        // is a wiring bug — loud in debug, `None` in release — and never
+        // removes the entry, so the parked hold stays reclaimable.
+        let output = entry.output.as_deref()?;
+        if output.downcast_ref::<O>().is_none() || entry.context.downcast_ref::<C>().is_none() {
+            debug_assert!(
+                false,
+                "dispatch completion type mismatch: the task handler's (O, C) do not match the \
+                 dispatch's — a wiring bug (the entry is retained, not bare-dropped)"
+            );
+            return None;
+        }
+        // Both probes passed — safe to remove and rebuild.
         let entry = self.entries.remove(&id)?;
         let InflightEntry {
             hold,
@@ -455,6 +485,10 @@ impl InflightTable {
         id: DispatchId,
     ) -> Option<TaskDone<O, C>> {
         self.take(id)
+    }
+
+    pub(crate) fn dispatch_abandon(&mut self, id: DispatchId) -> Option<(SettlementHold, Source)> {
+        self.abandon(id)
     }
 
     pub(crate) fn dispatch_try_take<O: 'static, C: 'static>(
@@ -851,6 +885,87 @@ mod tests {
             counter.held_open(root),
             0,
             "an unresolved TaskDone releases its hold on drop"
+        );
+    }
+
+    /// The Site-1 release mechanism: `abandon` removes the entry and hands
+    /// back its parked hold + `reply_to` so the spawn-error branch can drop
+    /// the hold and settle the chain, rather than orphaning it in the
+    /// ledger.
+    #[test]
+    fn abandon_removes_entry_and_returns_hold() {
+        let (_registry, mailer) = fresh_substrate();
+        let counter = Arc::clone(mailer.trace_handle().settlement_counter());
+        let root = root_id(10);
+        let hold = mailer.acquire_settlement_hold(root);
+        assert_eq!(counter.held_open(root), 1, "hold acquired");
+
+        let mut table = InflightTable::new();
+        let id = table.dispatch_insert(hold, Source::NONE, Box::new(()));
+        assert!(table.entries.contains_key(&id), "entry parked");
+
+        let abandoned = table.dispatch_abandon(id);
+        assert!(abandoned.is_some(), "abandon hands back the parked hold");
+        drop(abandoned);
+        assert!(
+            !table.entries.contains_key(&id),
+            "abandon removes the entry"
+        );
+        assert_eq!(
+            counter.held_open(root),
+            0,
+            "dropping the abandoned hold releases the chain"
+        );
+    }
+
+    /// An unfilled entry is left intact by `take` — no bare drop of the
+    /// parked hold, no premature remove that an early/spurious wake could
+    /// otherwise destroy.
+    #[test]
+    fn take_leaves_entry_on_unfilled() {
+        let (_registry, mailer) = fresh_substrate();
+        let root = root_id(11);
+        let hold = mailer.acquire_settlement_hold(root);
+
+        let mut table = InflightTable::new();
+        let id = table.dispatch_insert(hold, Source::NONE, Box::new(()));
+        // Output was never filled: take returns None and retains the entry.
+        assert!(table.dispatch_take::<Answer, ()>(id).is_none());
+        assert!(
+            table.entries.contains_key(&id),
+            "an unfilled entry stays parked for a later wake"
+        );
+    }
+
+    /// Tripwire: a downcast *mismatch* against a filled output is a genuine
+    /// `O` / `C` wiring bug — loud (`debug_assert`) in debug, `None` in
+    /// release — and is distinct from the benign unfilled case. Either way
+    /// the entry is retained rather than bare-dropped.
+    #[test]
+    fn take_debug_asserts_on_type_mismatch() {
+        let (_registry, mailer) = fresh_substrate();
+        let root = root_id(12);
+        let hold = mailer.acquire_settlement_hold(root);
+
+        let mut table = InflightTable::new();
+        let id = table.dispatch_insert(hold, Source::NONE, Box::new(()));
+        // Fill with a wrong-typed output (u32) where take asks for Answer.
+        table.dispatch_fill_output(id, Box::new(7u32));
+
+        let outcome = catch_unwind(AssertUnwindSafe(|| table.dispatch_take::<Answer, ()>(id)));
+        #[cfg(debug_assertions)]
+        assert!(
+            outcome.is_err(),
+            "a type mismatch debug_asserts, distinct from the benign unfilled None"
+        );
+        #[cfg(not(debug_assertions))]
+        assert!(
+            matches!(outcome, Ok(None)),
+            "a type mismatch returns None in release"
+        );
+        assert!(
+            table.entries.contains_key(&id),
+            "a mismatched entry is retained, never bare-dropped"
         );
     }
 }


### PR DESCRIPTION
Closes #2499.

## Summary

Two sites in the native blocking-dispatch path dropped a parked `SettlementHold` / `reply_to` on failure branches, wedging the caller's settlement chain. Both now mirror the module's own `TaskDone::Drop` convention (release the hold so settlement is never wedged):

- `NativeCtx::dispatch_blocking_resumed_with` — an `Err` from `ThreadBuilder::spawn` previously logged but returned the same `DispatchId`/`Pending` as success, leaking the just-inserted ledger entry and its parked hold. The spawn-error branch now removes the entry via a new untyped `InflightTable::abandon` (exposed as `NativeBinding::dispatch_abandon`) and drops the hold to release it.
- `InflightTable::take` — a downcast failure let the destructured hold/`reply_to` fall out of scope bare, indistinguishable from the benign not-yet-filled case. It is restructured peek-then-remove (like the sibling `try_take`): the benign unfilled case returns a quiet `None` with the entry retained, while a type mismatch `debug_assert!`s distinctly with the entry intact — the wiring bug becomes loud and separable.

## Test plan

- Three new unit tests: `abandon_removes_entry_and_returns_hold`, `take_leaves_entry_on_unfilled`, `take_debug_asserts_on_type_mismatch`.
- Full workspace clippy/nextest (1910 passed)/doc ran green in agent validation.

## Generated by

`/implement` — agent execution of [scoped issue #2499](https://github.com/iamacoffeepot/aether/issues/2499).
