### PR TITLE
fix(substrate): thread a configurable teardown-patience cap into the instanced-actor close gate

### DIFF
--- a/crates/aether-substrate-bundle/src/bin/test-bench.rs
+++ b/crates/aether-substrate-bundle/src/bin/test-bench.rs
@@ -33,6 +33,7 @@ use aether_substrate::{Chassis, capture::CaptureQueue, chassis::frame_loop, mail
 /// before this cap, a genuine wedge exhausts it (issue #1305).
 const FRAME_SETTLEMENT_CAP: Duration = Duration::from_secs(30);
 use aether_substrate_bundle::chassis_root::next_chassis_correlation;
+use aether_substrate_bundle::resolve_teardown_cap;
 use aether_substrate_bundle::test_bench::{
     RenderSizeConfig, TestBenchBuild, TestBenchChassis, TestBenchEnv, WORKERS,
     events::{self, ChassisEvent},
@@ -62,6 +63,11 @@ fn main() -> anyhow::Result<()> {
         events_tx,
         capture_queue: capture_queue.clone(),
         namespace_roots: Some(namespace_roots),
+        // Issue #2509: the standalone binary is an env-reading edge, so
+        // its teardown gate honors `AETHER_SETTLEMENT_CAP_SECS` (including
+        // the `0 → wait forever` sentinel) — the same knob the settlement
+        // gates read.
+        teardown_cap: resolve_teardown_cap(),
     };
 
     let TestBenchBuild {

--- a/crates/aether-substrate-bundle/src/chassis_common.rs
+++ b/crates/aether-substrate-bundle/src/chassis_common.rs
@@ -302,6 +302,19 @@ impl SettlementConfig {
     }
 }
 
+/// Issue #2509: resolve the instanced-actor teardown close-done gate's
+/// cumulative-patience cap from the shared `AETHER_SETTLEMENT_CAP_SECS`
+/// knob (`SettlementConfig::to_cap`, including its `0 → Duration::MAX`
+/// "wait forever" sentinel). Each chassis threads the result into the
+/// substrate `Builder` via `with_teardown_cap`, so one knob covers both
+/// the settlement gates and the teardown gate. A crate-root re-export
+/// keeps it reachable from the chassis bins (which cannot see the private
+/// `SettlementConfig`).
+#[must_use]
+pub fn resolve_teardown_cap() -> Duration {
+    SettlementConfig::from_env().to_cap()
+}
+
 /// Default lifecycle advance timeout in milliseconds. The literal
 /// `default = 1000` on [`ChassisBootConfig`] must equal this;
 /// `chassis_boot_config_defaults_match` guards the pair.
@@ -579,6 +592,12 @@ pub struct CommonBoot {
     /// Issue 2485: scheduler hot-path tuning, resolved from the
     /// `SchedulerTuningConfig` derive-`Config` knob in the chassis main.
     pub scheduler_tuning: SchedulerTuning,
+    /// Issue #2509: cumulative patience for the instanced-actor teardown
+    /// close-done gate, resolved from the same `SettlementConfig`
+    /// (`AETHER_SETTLEMENT_CAP_SECS`) knob the settlement gates read (via
+    /// [`SettlementConfig::to_cap`]), so one knob covers both. Threaded
+    /// into the `Builder` via `with_teardown_cap`.
+    pub teardown_cap: Duration,
     pub input_config: InputConfig,
     pub component_host_config: ComponentHostConfig,
     pub namespace_roots: NamespaceRoots,
@@ -614,6 +633,7 @@ pub fn with_common_caps<C: Chassis>(builder: Builder<C>, boot: CommonBoot) -> Bu
         .with_workers(boot.workers)
         .with_ring_caps(boot.ring_caps)
         .with_scheduler_tuning(boot.scheduler_tuning)
+        .with_teardown_cap(boot.teardown_cap)
         .with_actor::<TraceDispatchCapability>(())
         .with_actor::<TrajectoryRecorderCapability>(())
         .with_actor::<InputCapability>(boot.input_config)

--- a/crates/aether-substrate-bundle/src/desktop/chassis.rs
+++ b/crates/aether-substrate-bundle/src/desktop/chassis.rs
@@ -39,7 +39,8 @@ use super::driver::{DesktopDriverCapability, WindowConfig};
 use crate::autoload::{AutoloadComponent, autoload_mail, boot_manifest_autoload};
 use crate::chassis_common::{
     ActorRingConfig, ChassisBootConfig, CommonBoot, SchedulerTuningConfig, chassis_known_keys,
-    frame_lifecycle_config, maybe_with_http_server, maybe_with_rpc_server, with_common_caps,
+    frame_lifecycle_config, maybe_with_http_server, maybe_with_rpc_server, resolve_teardown_cap,
+    with_common_caps,
 };
 use crate::cli::{CommonOverlay, DesktopCli};
 use crate::hub;
@@ -459,6 +460,10 @@ impl DesktopChassis {
             workers,
             ring_caps,
             scheduler_tuning,
+            // Issue #2509: the instanced-actor teardown gate honors the
+            // same `AETHER_SETTLEMENT_CAP_SECS` knob (including its
+            // `0 → wait forever` sentinel) as the settlement gates.
+            teardown_cap: resolve_teardown_cap(),
             input_config,
             component_host_config,
             namespace_roots,

--- a/crates/aether-substrate-bundle/src/headless/chassis.rs
+++ b/crates/aether-substrate-bundle/src/headless/chassis.rs
@@ -37,7 +37,8 @@ use super::driver::{HeadlessTimerDriverCapability, TickConfig};
 use crate::autoload::{AutoloadComponent, autoload_mail, boot_manifest_autoload};
 use crate::chassis_common::{
     ActorRingConfig, ChassisBootConfig, CommonBoot, SchedulerTuningConfig, chassis_known_keys,
-    maybe_with_http_server, maybe_with_rpc_server, tick_only_lifecycle_config, with_common_caps,
+    maybe_with_http_server, maybe_with_rpc_server, resolve_teardown_cap,
+    tick_only_lifecycle_config, with_common_caps,
 };
 use crate::cli::{CommonOverlay, HeadlessCli};
 use crate::hub;
@@ -345,6 +346,10 @@ impl HeadlessChassis {
             workers,
             ring_caps,
             scheduler_tuning,
+            // Issue #2509: the instanced-actor teardown gate honors the
+            // same `AETHER_SETTLEMENT_CAP_SECS` knob (including its
+            // `0 → wait forever` sentinel) as the settlement gates.
+            teardown_cap: resolve_teardown_cap(),
             input_config,
             component_host_config,
             namespace_roots,

--- a/crates/aether-substrate-bundle/src/hub/chassis.rs
+++ b/crates/aether-substrate-bundle/src/hub/chassis.rs
@@ -25,7 +25,9 @@ use aether_substrate::chassis::error::BootError;
 use aether_substrate::config::{ConfigError, validate_env};
 use aether_substrate::{Chassis, SubstrateBoot};
 
-use crate::chassis_common::{ActorRingConfig, SchedulerTuningConfig, hub_known_keys};
+use crate::chassis_common::{
+    ActorRingConfig, SchedulerTuningConfig, hub_known_keys, resolve_teardown_cap,
+};
 use crate::cli::HubCli;
 use crate::hub::DEFAULT_RPC_PORT;
 use std::thread;
@@ -138,10 +140,16 @@ impl HubChassis {
         // etc. like the full-stack chassis (which thread it via
         // `with_common_caps`).
         let scheduler_tuning = SchedulerTuningConfig::try_from_env()?.to_scheduler_tuning();
+        // Issue #2509: the instanced-actor teardown gate honors the same
+        // `AETHER_SETTLEMENT_CAP_SECS` knob (including its `0 → wait
+        // forever` sentinel) as the settlement gates, like the full-stack
+        // chassis (which thread it via `with_common_caps`).
+        let teardown_cap = resolve_teardown_cap();
 
         Builder::<Self>::new(registry, mailer)
             .with_ring_caps(ring_caps)
             .with_scheduler_tuning(scheduler_tuning)
+            .with_teardown_cap(teardown_cap)
             .with_actor::<TraceDispatchCapability>(())
             // Liveness-heartbeat tuning (issue 1339), resolved
             // argv-then-env in `HubEnv::from_env_with_argv`.

--- a/crates/aether-substrate-bundle/src/lib.rs
+++ b/crates/aether-substrate-bundle/src/lib.rs
@@ -29,6 +29,7 @@ pub mod bundle_pack;
 mod chassis_common;
 pub use chassis_common::{
     binary_manifest, chassis_config_dump, common_cap_namespaces, hub_config_dump, hub_known_keys,
+    resolve_teardown_cap,
 };
 pub mod chassis_root;
 pub mod cli;

--- a/crates/aether-substrate-bundle/src/test_bench/bench.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/bench.rs
@@ -429,6 +429,10 @@ impl TestBench {
             events_tx,
             capture_queue: capture_queue.clone(),
             namespace_roots,
+            // Issue #2509: the teardown gate honors the same resolved cap
+            // (env knob or programmatic override) as the settlement-await
+            // loops the bench stores this value for.
+            teardown_cap: settlement_cap,
         };
         let TestBenchBuild {
             passive,

--- a/crates/aether-substrate-bundle/src/test_bench/chassis.rs
+++ b/crates/aether-substrate-bundle/src/test_bench/chassis.rs
@@ -9,6 +9,7 @@
 //! `aether.control.platform_info` was deleted entirely (Phase 4).
 
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use aether_capabilities::LifecycleCapability;
 use aether_capabilities::{
@@ -153,6 +154,13 @@ pub struct TestBenchEnv {
     /// pre-issue-673 silent-skip semantics. When `None`, fs is not
     /// booted at all.
     pub namespace_roots: Option<NamespaceRoots>,
+    /// Issue #2509: cumulative patience for the instanced-actor teardown
+    /// close-done gate. The in-process `TestBench` resolves this from the
+    /// same `SettlementConfig` (`AETHER_SETTLEMENT_CAP_SECS`) knob its
+    /// settlement-await loops read (honoring a programmatic
+    /// `TestBench::settlement_cap` override), so a scenario's teardown
+    /// gate uses the same patience as its settlement gates.
+    pub teardown_cap: Duration,
 }
 
 /// Output of [`TestBenchChassis::build_passive`]. Bundles the
@@ -211,6 +219,7 @@ impl TestBenchChassis {
             events_tx,
             capture_queue,
             namespace_roots,
+            teardown_cap,
         } = env;
 
         let boot = SubstrateBoot::builder(&name, &version).build()?;
@@ -322,6 +331,7 @@ impl TestBenchChassis {
             .with_workers(pool_workers)
             .with_ring_caps(ring_caps)
             .with_scheduler_tuning(scheduler_tuning)
+            .with_teardown_cap(teardown_cap)
             .with_actor::<TraceDispatchCapability>(())
             .with_actor::<TrajectoryRecorderCapability>(())
             .with_actor::<InputCapability>(input_config)

--- a/crates/aether-substrate/src/actor/native/spawn.rs
+++ b/crates/aether-substrate/src/actor/native/spawn.rs
@@ -226,12 +226,16 @@ impl Spawner {
     /// cadence); `cumulative_cap` is the total patience per slot before
     /// declaring a wedge.
     pub(crate) fn shutdown_instanced(&self, round_budget: Duration, cumulative_cap: Duration) {
-        let entries: Vec<InstancedSlotEntry> = {
+        // Issue #2509: retain the slot's `MailboxId` alongside its entry
+        // (previously dropped as `_id`) so a genuine teardown wedge names
+        // the actor whose close cycle failed rather than a bare
+        // gate-name panic.
+        let entries: Vec<(MailboxId, InstancedSlotEntry)> = {
             let mut guard = self
                 .instanced_slots
                 .lock()
                 .expect("instanced_slots mutex poisoned; fail-fast per ADR-0063");
-            guard.drain().map(|(_id, entry)| entry).collect()
+            guard.drain().collect()
         };
         if entries.is_empty() {
             return;
@@ -244,7 +248,7 @@ impl Spawner {
         // by firing immediately, so there's no race window where the
         // close cycle ran without seeing the tx.
         let mut waiters: Vec<crossbeam_channel::Receiver<()>> = Vec::with_capacity(entries.len());
-        for entry in &entries {
+        for (_id, entry) in &entries {
             let (tx, rx) = crossbeam_channel::bounded::<()>(1);
             entry.slot.set_close_done_tx(tx);
             waiters.push(rx);
@@ -264,14 +268,13 @@ impl Spawner {
         } else {
             TerminalDisposition::Abort
         };
-        for rx in &waiters {
-            match await_internal_signal(
-                rx,
-                "shutdown_instanced.close_done",
-                round_budget,
-                cumulative_cap,
-                disposition,
-            ) {
+        for ((id, _entry), rx) in entries.iter().zip(&waiters) {
+            // Issue #2509: name the wedged slot in the gate label so a
+            // teardown wedge panic/abort points at the actor whose close
+            // cycle failed (e.g. `shutdown_instanced.close_done[mbx-…]`)
+            // rather than the bare `shutdown_instanced.close_done`.
+            let gate = format!("shutdown_instanced.close_done[{id}]");
+            match await_internal_signal(rx, &gate, round_budget, cumulative_cap, disposition) {
                 WaitOutcome::Settled => {}
                 WaitOutcome::Wedged(wedge) => {
                     // `Abort` disposition (release): the close cycle
@@ -739,5 +742,95 @@ impl<'ctx, A: Instanced + NativeActor> SpawnBuilder<'ctx, A> {
         } = self;
         let config = config.expect("SpawnBuilder::finish consumed exactly once");
         Spawner::spawn_actor::<A>(spawner, subname, config, after_init, sender, parent)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mail::mailer::Mailer;
+    use crate::mail::registry::Registry;
+    use crate::runtime::lifecycle::PanicAborter;
+    use crate::scheduler::{BatchBudget, CycleResult, Pool, PoolConfig, SlotState};
+    use std::any::Any;
+    use std::sync::{Arc, Mutex};
+
+    /// A `Drainable` that never runs its close cycle: it stashes the
+    /// close-done sender the teardown gate installs and holds it alive
+    /// without ever firing it. The gate's per-slot waiter therefore stays
+    /// connected but silent, so the wait exhausts its cumulative cap — the
+    /// starvation-shaped wedge (a healthy-but-slow / stuck close cycle)
+    /// #2509 guards, not an immediate channel disconnect.
+    struct NeverClosingSlot {
+        close_done: Mutex<Option<crossbeam_channel::Sender<()>>>,
+    }
+
+    impl Drainable for NeverClosingSlot {
+        fn run_cycle(&self, _budget: BatchBudget) -> CycleResult {
+            CycleResult::Idle
+        }
+        fn set_close_done_tx(&self, tx: crossbeam_channel::Sender<()>) {
+            *self
+                .close_done
+                .lock()
+                .expect("close_done mutex never poisoned in this single-threaded test") = Some(tx);
+        }
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    /// Tripwire (issue #2509): a wedged instanced-actor teardown gate
+    /// names the slot that failed to close. The `expected` substring pins
+    /// the gate label embedding the slot's `MailboxId` Display
+    /// (`shutdown_instanced.close_done[<id>]`) — a real tagged mailbox id
+    /// renders as `mbx-…`; this test's raw id falls back to the `{:#018x}`
+    /// hex form. If the label ever drops the id and reverts to the bare
+    /// `shutdown_instanced.close_done`, the substring stops matching and
+    /// this test fails.
+    ///
+    /// Fast by construction: the cumulative cap is injected directly as
+    /// `shutdown_instanced`'s parameter (20 ms), so the wedge fires in
+    /// milliseconds rather than blocking on the 300 s default.
+    #[test]
+    #[should_panic(expected = "shutdown_instanced.close_done[0x000000000000abcd]")]
+    fn shutdown_instanced_wedge_names_the_slot() {
+        let registry = Arc::new(Registry::new());
+        let mailer = Arc::new(Mailer::new(Arc::clone(&registry)));
+        let aborter: Arc<dyn FatalAborter> = Arc::new(PanicAborter);
+        let actor_registry = Arc::new(ActorRegistry::new());
+        // One worker is enough — the wedge comes from the close-done
+        // signal never firing, not from anything the pool drains.
+        let pool = Pool::start(
+            PoolConfig {
+                workers: 1,
+                ..PoolConfig::default()
+            },
+            Arc::clone(&aborter),
+        );
+        let spawner = Spawner::new(
+            Arc::clone(&registry),
+            actor_registry,
+            Arc::clone(&mailer),
+            Arc::clone(&aborter),
+            pool.wake_sink(),
+            RingCapacities::default(),
+        );
+
+        let slot: Arc<dyn Drainable> = Arc::new(NeverClosingSlot {
+            close_done: Mutex::new(None),
+        });
+        let wake = WakeHandle::new(
+            Arc::new(SlotState::new()),
+            Arc::downgrade(&slot),
+            pool.wake_sink(),
+        );
+        spawner
+            .instanced_slots
+            .lock()
+            .expect("instanced_slots mutex poisoned")
+            .insert(MailboxId(0xABCD), InstancedSlotEntry { slot, wake });
+
+        spawner.shutdown_instanced(Duration::from_millis(1), Duration::from_millis(20));
     }
 }

--- a/crates/aether-substrate/src/chassis/builder.rs
+++ b/crates/aether-substrate/src/chassis/builder.rs
@@ -747,6 +747,16 @@ fn make_driver_boot<D: DriverCapability>(driver: D) -> DriverBoot {
 /// (iamacoffeepot/aether#1295, iamacoffeepot/aether#1142).
 const PASSIVE_DEFAULT_WORKERS: usize = 2;
 
+/// Default cumulative patience for the instanced-actor teardown
+/// close-done gate ([`Builder::with_teardown_cap`]) when no override is
+/// set. Five minutes — matches the settlement gates'
+/// `DEFAULT_SETTLEMENT_CAP_SECS` (300s): the generous backstop #2062
+/// introduced so a healthy-but-slow close cycle on a saturated box is
+/// never declared wedged (issue #2509). The constant survives only as
+/// the default; the durable retune is the `AETHER_SETTLEMENT_CAP_SECS`
+/// knob the production chassis thread in.
+const DEFAULT_TEARDOWN_CAP: Duration = Duration::from_mins(5);
+
 /// Declarative chassis builder, parametric over the chassis kind `C`
 /// and a type-state `S` tracking whether a driver has been supplied.
 /// `Builder<C, NoDriver>` accepts [`Self::with_actor`] /
@@ -778,6 +788,16 @@ pub struct Builder<C: Chassis, S: BuilderState = NoDriver> {
     /// `SchedulerTuningConfig` derive-`Config` knob (env `AETHER_*`);
     /// tests / `TestBench` leave it [`SchedulerTuning::default`].
     scheduler_tuning: SchedulerTuning,
+    /// Issue #2509: cumulative patience the instanced-actor teardown
+    /// close-done gate (`Spawner::shutdown_instanced`) waits before
+    /// declaring a slot wedged. Defaults to the generous 300s backstop
+    /// (`DEFAULT_TEARDOWN_CAP`) — the settlement-cap analogue #2062
+    /// scoped out — so a healthy-but-slow close cycle on a saturated box
+    /// is never false-fired. Production chassis mains populate this from
+    /// the same `AETHER_SETTLEMENT_CAP_SECS` knob the settlement gates
+    /// read (via `SettlementConfig::to_cap`, including its `0 → MAX`
+    /// sentinel); tests / `TestBench` inherit the default.
+    teardown_cap: Duration,
     _chassis: PhantomData<fn() -> C>,
     _state: PhantomData<fn() -> S>,
 }
@@ -798,6 +818,7 @@ impl<C: Chassis> Builder<C, NoDriver> {
             workers: None,
             ring_caps: RingCapacities::default(),
             scheduler_tuning: SchedulerTuning::default(),
+            teardown_cap: DEFAULT_TEARDOWN_CAP,
             _chassis: PhantomData,
             _state: PhantomData,
         }
@@ -852,6 +873,22 @@ impl<C: Chassis> Builder<C, NoDriver> {
         self
     }
 
+    /// Issue #2509: override the instanced-actor teardown close-done
+    /// gate's cumulative patience cap. Default is `DEFAULT_TEARDOWN_CAP`
+    /// (the 300s backstop). Production chassis mains resolve the shared
+    /// `AETHER_SETTLEMENT_CAP_SECS` knob (`SettlementConfig::to_cap`,
+    /// including its `0 → Duration::MAX` "wait forever" sentinel) and pass
+    /// the lowered `Duration` here, so one knob covers both the settlement
+    /// gates and the teardown gate; `boot_passives` stores it on
+    /// `BootedPassives`, whose `shutdown_in_place` hands it to
+    /// `Spawner::shutdown_instanced`. The override can be applied either
+    /// before or after `.driver(_)`.
+    #[must_use]
+    pub fn with_teardown_cap(mut self, teardown_cap: Duration) -> Self {
+        self.teardown_cap = teardown_cap;
+        self
+    }
+
     /// Register a fallback router — a single-shot handler the
     /// substrate consults for envelopes whose mailbox name doesn't
     /// resolve. Multiple calls collapse to a `BootError` at
@@ -900,6 +937,7 @@ impl<C: Chassis> Builder<C, NoDriver> {
             workers: self.workers,
             ring_caps: self.ring_caps,
             scheduler_tuning: self.scheduler_tuning,
+            teardown_cap: self.teardown_cap,
             _chassis: PhantomData,
             _state: PhantomData,
         }
@@ -930,6 +968,7 @@ impl<C: Chassis> Builder<C, NoDriver> {
             workers,
             self.ring_caps,
             self.scheduler_tuning,
+            self.teardown_cap,
             self.passives,
         )?;
         // ADR-0081 retired the chassis-pushed `ConfigureLogDrain` mail
@@ -990,6 +1029,14 @@ impl<C: Chassis> Builder<C, HasDriver> {
         self
     }
 
+    /// Mirror of [`Builder::with_teardown_cap`][Builder<C, NoDriver>::with_teardown_cap]
+    /// for the post-driver state. Issue #2509.
+    #[must_use]
+    pub fn with_teardown_cap(mut self, teardown_cap: Duration) -> Self {
+        self.teardown_cap = teardown_cap;
+        self
+    }
+
     /// Boot every passive in declaration order, then boot the driver
     /// against a [`DriverCtx`]. Any failure aborts the build and
     /// shuts down the passives that already booted (via the
@@ -1010,6 +1057,7 @@ impl<C: Chassis> Builder<C, HasDriver> {
             workers,
             ring_caps,
             scheduler_tuning,
+            teardown_cap,
             ..
         } = self;
         let driver_boot = driver.expect("HasDriver state implies driver was supplied");
@@ -1021,6 +1069,7 @@ impl<C: Chassis> Builder<C, HasDriver> {
             workers,
             ring_caps,
             scheduler_tuning,
+            teardown_cap,
             passives,
         )?;
         // ADR-0081 retired the chassis-pushed `ConfigureLogDrain` mail
@@ -1090,6 +1139,11 @@ struct BootedPassives {
     /// [`Self::settlement_registry`] for PR 4 gate-site
     /// `subscribe_settlement` calls.
     settlement_registry: Arc<SettlementRegistry>,
+    /// Issue #2509: cumulative patience the instanced-actor teardown
+    /// close-done gate waits before declaring a slot wedged. Threaded from
+    /// [`Builder::with_teardown_cap`] and handed to
+    /// `Spawner::shutdown_instanced` in `Self::shutdown_in_place`.
+    teardown_cap: Duration,
 }
 
 impl BootedPassives {
@@ -1115,8 +1169,15 @@ impl BootedPassives {
         // cadence; the cumulative cap is generous (a healthy close
         // cycle resolves well before it; a genuine wedge exhausts it
         // and aborts/panics).
+        // Issue #2509: the cumulative cap is now the configured
+        // `teardown_cap` (default 300s, retunable via the shared
+        // `AETHER_SETTLEMENT_CAP_SECS` knob) rather than a hardcoded
+        // 30s, so a healthy-but-slow close cycle on a saturated box is
+        // never false-fired — the same starvation-vs-wedge fix #2062
+        // gave the settlement gates, on the gate it scoped out. The 2s
+        // round budget (the warn cadence) is unchanged.
         self.spawner
-            .shutdown_instanced(Duration::from_secs(2), Duration::from_secs(30));
+            .shutdown_instanced(Duration::from_secs(2), self.teardown_cap);
         while let Some(s) = self.shutdowns.pop() {
             s.shutdown_dyn();
         }
@@ -1135,6 +1196,10 @@ impl Drop for BootedPassives {
 // boot ordering — leaving it as one function keeps the chassis boot
 // sequence readable in one place.
 #[allow(clippy::too_many_lines)]
+// Issue #2509 added the teardown-cap arg; boot_passives already carries
+// the resolved chassis config values in argument position (mirroring the
+// `Builder` fields), so an extra `Duration` is the same shape.
+#[allow(clippy::too_many_arguments)]
 fn boot_passives(
     registry: &Arc<Registry>,
     mailer: &Arc<Mailer>,
@@ -1142,6 +1207,7 @@ fn boot_passives(
     workers: Option<usize>,
     ring_caps: RingCapacities,
     scheduler_tuning: SchedulerTuning,
+    teardown_cap: Duration,
     passives: Vec<Box<dyn PassiveBoot>>,
 ) -> Result<BootedPassives, BootError> {
     let mut shutdowns: Vec<Box<dyn DynShutdown>> = Vec::with_capacity(passives.len());
@@ -1390,6 +1456,7 @@ fn boot_passives(
         spawner,
         _pool: pool,
         settlement_registry,
+        teardown_cap,
     })
 }
 


### PR DESCRIPTION
Closes #2509.

## Summary

`resolve_actor_returns_none_on_type_mismatch` intermittently failed at ~30.2s under a saturated `cargo nextest run --workspace` and never in isolation. Its assertions complete instantly; the failure was entirely in the trailing `drop(chassis)`, which runs `shutdown_instanced` with a hardcoded 30s cumulative cap and panics (in test/debug) if a spawned instanced actor's close-done signal has not fired in time. Under OS saturation the 2-worker passive pool that must run the actor's close cycle was scheduled past 30s, so the gate false-fired — the same starvation-vs-wedge confusion the closed #2062 fixed for the settlement gates, on the one gate #2062 deliberately left out ("has no roots to enumerate").

This extends #2062's configurable-backstop pattern to the teardown gate: a `teardown_cap` threads down through `Builder` → `boot_passives` → `BootedPassives` (mirroring `with_workers`), defaulting to a generous 5-minute backstop so the in-crate unit test — which builds passively with no bundle involvement — stops false-firing. The bundle chassis (desktop / headless / hub / test-bench) resolve the existing `AETHER_SETTLEMENT_CAP_SECS` knob into the cap through one `resolve_teardown_cap()` helper (the `0 → wait-forever` sentinel preserved), so one knob now covers both the settlement gates and the teardown gate. When the gate genuinely wedges it names the actor that failed to close (`shutdown_instanced.close_done[<id>]`) instead of a bare gate name.

## Test plan

Added a `#[should_panic]` tripwire (`shutdown_instanced_wedge_names_the_slot`) that drives a deliberately-non-closing slot to a true timeout wedge with a 20ms injected cap (runs in ~0.035s) and asserts the panic names the slot. `cargo nextest run --workspace` green (1917 passed, 8 skipped) — the tripwire and `resolve_actor_returns_none_on_type_mismatch` both pass and both fast. `cargo clippy --workspace --all-targets -D warnings` and strict `cargo doc --workspace --no-deps` green. Only a `Duration` threads down into `aether-substrate`; no upward reach to the bundle's `SettlementConfig`, so the crate dependency direction holds.

## Generated by

`/implement` — agent execution of scoped issue #2509.
