### PR TITLE
refactor(codec): drop the aether-capabilities dev-dep and its single junk test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,7 @@ dependencies = [
 name = "aether-codec"
 version = "0.3.0-alpha"
 dependencies = [
- "aether-capabilities",
  "aether-data",
- "aether-kinds",
  "bytemuck",
  "proptest",
  "serde",

--- a/crates/aether-codec/Cargo.toml
+++ b/crates/aether-codec/Cargo.toml
@@ -31,16 +31,8 @@ serde_json = { workspace = true }
 [dev-dependencies]
 # Round-trip tests in this crate encode JSON params via the schema
 # encoder, then decode the bytes back through `bytemuck::cast` (cast
-# kinds) or a `serde` deserialize. Decoder tests also reach for concrete
-# kinds (e.g. `SubscribeInput`) to assert tagged-id round-trips.
-# Production callers don't need any of this — only pulled in for
-# `cargo test`.
-aether-kinds = { path = "../aether-kinds" }
-# `SubscribeInput` moved to `aether-capabilities::input` (ADR-0121);
-# the decode round-trip test references it through the new path.
-# `default-features = false` skips the heavy native (wasmtime/wgpu)
-# deps — the test only needs the always-on kind types.
-aether-capabilities = { path = "../aether-capabilities", default-features = false }
+# kinds) or a `serde` deserialize. Production callers don't need any of
+# this — only pulled in for `cargo test`.
 aether-data = { path = "../aether-data", features = ["derive"] }
 bytemuck = { workspace = true, features = ["derive"] }
 # Issue 1561: the schema-driven round-trip property

--- a/crates/aether-codec/src/decode.rs
+++ b/crates/aether-codec/src/decode.rs
@@ -1059,46 +1059,6 @@ mod tests {
     }
 
     #[test]
-    fn subscribe_input_kind_round_trips_with_tagged_mailbox() {
-        // End-to-end through the `SubscribeInput` kind's actual
-        // schema — mirrors the worked example in ADR-0065's Context
-        // section. ADR-0068: the field is now `kind: KindId` (tagged
-        // string on the JSON side), keying subscriber sets by kind id
-        // directly. An agent receives the tagged ids from
-        // `load_component` / `describe_kinds`, drops them straight
-        // into `subscribe_input.{kind, mailbox}`, and the wire bytes
-        // match what the substrate expects.
-        use aether_capabilities::input::SubscribeInput;
-        use aether_data::Kind;
-        let mailbox = aether_data::MailboxId::from_name("aether.component");
-        let mailbox_str =
-            tagged_id::encode(mailbox.0).expect("test setup: encode tagged mailbox id");
-        let kind_id = aether_kinds::Tick::ID;
-        let kind_str = tagged_id::encode(kind_id.0).expect("test setup: encode tagged kind id");
-        let json_in = json!({ "kind": kind_str, "mailbox": mailbox_str });
-
-        let bytes = encode_schema(&json_in, &<SubscribeInput as aether_data::Schema>::SCHEMA)
-            .expect("encode subscribe_input via TypeId schema");
-
-        // Substrate decode path — the hub-encoded bytes are byte-identical
-        // to `SubscribeInput::encode_into_bytes` (the `wire` image).
-        let decoded = SubscribeInput::decode_from_bytes(&bytes)
-            .expect("wire decode subscribe_input from hub-encoded bytes");
-        assert_eq!(decoded.kind, kind_id);
-        assert_eq!(decoded.mailbox, mailbox);
-
-        // And the kind's id is sensitive to the typed identity —
-        // ADR-0065 phase 3 shifts it from the previous `u64`-shape
-        // hash. Cross-check it lands on a `Tag::Kind` value (the
-        // `with_tag` discipline holds through the schema-bytes
-        // change).
-        assert_eq!(
-            tagged_id::tag_of(SubscribeInput::ID.0),
-            Some(aether_data::Tag::Kind),
-        );
-    }
-
-    #[test]
     fn type_id_round_trip_of_sentinel_uses_back_compat_number() {
         // `MailboxId::NONE` (= 0) has reserved tag bits, so it
         // serialises as a JSON number. Round-trip preserves the


### PR DESCRIPTION
## What

`aether-codec` carried `aether-capabilities` (the largest crate in the workspace) plus `aether-kinds` as **dev-dependencies** — pulled in solely to feed one test, `subscribe_input_kind_round_trips_with_tagged_mailbox`.

That test was junk under the testing policy: a symmetric `decode(encode(x)) == x` roundtrip over a derive-shaped kind, plus a `tag_of` assertion that only restated `SubscribeInput`'s own `#[kind]` identity. It exercised no logic `aether-codec` owns that the derive/codec machinery's own tests don't already cover.

## Change

- Remove the test.
- Drop the now-unused `aether-capabilities` and `aether-kinds` dev-dependencies.
- Trim the stale dev-dep comment.

## Effect

The codec dev-graph drops from pulling in the workspace's largest crate to just `aether-data` + `bytemuck` + `proptest` + `serde_json`. The remaining 97 tests still exercise the schema-driven encode/decode this crate actually owns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)