### PR TITLE
docs(adr): reconcile drifted and reversed adr statuses

### DIFF
--- a/docs/adr/0036-component-mail-handler-profiling.md
+++ b/docs/adr/0036-component-mail-handler-profiling.md
@@ -1,6 +1,6 @@
 # ADR-0036: Per-handler latency sampling and the `profile_component` MCP tool
 
-- **Status:** Superseded
+- **Status:** Superseded — `profile_component` was never built; the need is met by the `actor_cost` MCP tool / per-handler EWMA instrumentation (issue 1128, PR #1184)
 - **Date:** 2026-04-20
 
 > **Note (2026-06-09):** The `profile_component` design was never built; the need is met by the `actor_cost` MCP tool / per-handler EWMA instrumentation (issue 1128, PR #1184). No prior ADR recorded this; this status does.

--- a/docs/adr/0084-plato-content-generation-on-the-dag.md
+++ b/docs/adr/0084-plato-content-generation-on-the-dag.md
@@ -1,6 +1,6 @@
 # ADR-0084: Plato — content generation realized on the DAG
 
-- **Status:** Proposed
+- **Status:** Rejected — moot; the computation DAG this design builds on was removed (iamacoffeepot/aether#2136, ADR-0047 Superseded). Revisit only atop a new execution substrate.
 - **Date:** 2026-05-20
 - **Note (2026-06-21, iamacoffeepot/aether#2136):** moot — the computation DAG this design builds on was removed (ADR-0047 Superseded). The realization here would need a new execution substrate before it could proceed.
 

--- a/docs/adr/0107-immediate-mode-ui.md
+++ b/docs/adr/0107-immediate-mode-ui.md
@@ -1,6 +1,6 @@
 # ADR-0107: Immediate-mode UI
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — the `aether.ui` immediate-mode capability)
 - **Date:** 2026-06-13
 
 Amends **ADR-0105** (the text + textured-quad render surface): adds the one flat-fill render primitive a UI needs and a native UI capability that composes the surface — symmetric with `aether.text`, ADR-0105's own composing capability. References **ADR-0066** (the render/camera overlay pass UI draws on), **ADR-0021 / ADR-0068** (the input streams a click rides), and **ADR-0099** (the typed `ctx.actor::<Cap>()` addressing a component reaches the UI cap through).

--- a/docs/adr/0118-own-the-aether-wire-format.md
+++ b/docs/adr/0118-own-the-aether-wire-format.md
@@ -1,6 +1,6 @@
 # ADR-0118: Own the Aether Wire Format
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — the canonical wire format in `aether-data`: `wire/` + `canonical/`)
 - **Date:** 2026-06-16
 
 ## Context

--- a/docs/adr/0121-capabilities-own-their-kinds.md
+++ b/docs/adr/0121-capabilities-own-their-kinds.md
@@ -1,6 +1,6 @@
 # ADR-0121: Capabilities own their kinds
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — capability-owned kinds across `aether-capabilities`; see `docs/guide/capability-anatomy.md`)
 - **Date:** 2026-06-22
 
 ## Context

--- a/docs/adr/0122-split-actor-identity-from-runtime-state.md
+++ b/docs/adr/0122-split-actor-identity-from-runtime-state.md
@@ -1,6 +1,6 @@
 # ADR-0122: Split Actor Identity From Runtime State
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — the identity/runtime split across every capability in `aether-capabilities`; see `docs/guide/capability-anatomy.md`)
 - **Date:** 2026-06-23
 
 ## Context

--- a/docs/adr/0123-actor-macro-on-capability-runtime-impl-attribute.md
+++ b/docs/adr/0123-actor-macro-on-capability-runtime-impl-attribute.md
@@ -1,6 +1,6 @@
 # ADR-0123: Actor macro on the capability, runtime impl attribute
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — `#[actor]` on the capability with the runtime impl attribute in `aether-actor-derive`)
 - **Date:** 2026-06-24
 
 ## Context

--- a/docs/adr/0124-fold-the-rpc-wire-vocabulary-back-into-aether-capabilities.md
+++ b/docs/adr/0124-fold-the-rpc-wire-vocabulary-back-into-aether-capabilities.md
@@ -1,6 +1,6 @@
 # ADR-0124: Fold the RPC Wire Vocabulary Back into aether-capabilities
 
-- **Status:** Proposed
+- **Status:** Accepted (shipped — the RPC wire vocabulary folded into `aether_capabilities::rpc`, #2537)
 - **Date:** 2026-07-03
 
 ## Context

--- a/docs/adr/0125-dissolve-aether-codec.md
+++ b/docs/adr/0125-dissolve-aether-codec.md
@@ -1,6 +1,6 @@
 # ADR-0125: Dissolve aether-codec into aether-data and aether-capabilities
 
-- **Status:** Proposed
+- **Status:** Rejected (won't do) — the `aether-codec` dissolution is not being pursued; the crate stays as-is. ADR-0072 is therefore not superseded (it remains Accepted).
 - **Date:** 2026-07-03
 
 ## Context


### PR DESCRIPTION
Output of `/sweep adr` plus one decision reversal. All changes are single-line Status edits; no ADR bodies change.

## Proposed → Accepted (implementation landed, status never caught up)

| ADR | Shipped as | Evidence |
|-----|-----------|----------|
| 0107 immediate-mode UI | the `aether.ui` capability | `aether-capabilities/src/ui/` (6 files) |
| 0118 own the wire format | `aether-data` `wire/` + `canonical/` | 20 rust files |
| 0121 capabilities own their kinds | per-cap `kinds.rs` across the crate | 24 rust files; `capability-anatomy.md` live |
| 0122 split identity from runtime | `mod`/`runtime` split across every cap | 59 rust files |
| 0123 actor macro on the capability | `aether-actor-derive` runtime attribute | 12 rust files incl. trybuild UI tests |
| 0124 fold the rpc wire vocabulary | `aether_capabilities::rpc` | #2537 |

## Corrections

- **0036** carried a bare `Superseded` naming no successor. Its own body note already points at the `actor_cost` MCP tool / per-handler EWMA (issue 1128, #1184) — the status now says so.
- **0084** (Plato) → `Rejected (moot)`. The computation DAG it builds on was removed (#2136, ADR-0047 Superseded); the ADR body already flagged it moot.

## Withdrawn

- **0125** (dissolve aether-codec) → `Rejected (won't do)`. The dissolution is not being pursued; `aether-codec` stays as-is. Consequently ADR-0072 is **not** superseded and remains Accepted. Implementation issue #2538 is closed as not-planned.

Left correctly as-is: 0117 (widget compositing — its one citation is an explicit follow-up, genuinely still Proposed), and the pending/parked set (0025, 0046, 0092, 0044, 0059).

🤖 Generated with [Claude Code](https://claude.com/claude-code)