### PR TITLE
refactor(capabilities): relocate mat4_apply to aether-kinds and test_echo under rpc::server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,6 @@ dependencies = [
  "aether-codec",
  "aether-data",
  "aether-kinds",
- "aether-math",
  "aether-substrate",
  "bytemuck",
  "clap",

--- a/crates/aether-capabilities/Cargo.toml
+++ b/crates/aether-capabilities/Cargo.toml
@@ -108,10 +108,6 @@ aether-actor = { path = "../aether-actor" }
 aether-codec = { path = "../aether-codec" }
 aether-data = { path = "../aether-data" }
 aether-kinds = { path = "../aether-kinds" }
-# Issue 1464: the `mat4_apply` first-party transform rebuilds a `Mat4`
-# / `Vec4` from the wire `[f32; N]` arrays. Always-on + target-agnostic
-# (no_std), so it rides the wasm-header-only build too.
-aether-math = { path = "../aether-math" }
 # `alloc` rides along for the `rpc::wire` + `trace_walk` modules (folded
 # in per ADR-0124), whose owned-`String`/`Vec` wire types need serde's
 # alloc impls even in the marker-only isolated build.

--- a/crates/aether-capabilities/src/engine/proxy/mod.rs
+++ b/crates/aether-capabilities/src/engine/proxy/mod.rs
@@ -121,9 +121,9 @@ mod tests {
         HeartbeatParams, ProxyReplySink,
     };
     use crate::engine::kinds::ForwardEnvelope;
+    use crate::rpc::server::test_echo::{TestEchoActor, TestEchoRequest};
     use crate::rpc::server::{RpcServerCapability, RpcServerConfig, RpcServerHandle};
     use crate::rpc::{HelloAck, PeerKind, WIRE_VERSION, WireFrame};
-    use crate::test_echo::{TestEchoActor, TestEchoRequest};
     use crate::trace::TraceDispatchCapability;
     use aether_actor::Addressable;
     use aether_codec::frame::{read_frame, write_frame};

--- a/crates/aether-capabilities/src/engine/proxy/sinks.rs
+++ b/crates/aether-capabilities/src/engine/proxy/sinks.rs
@@ -5,7 +5,7 @@
 //! its `mod` declaration), so none of it ships in the cap's surface.
 
 use crate::engine::kinds::{EngineAlive, EngineDied};
-use crate::test_echo::TestEchoReply;
+use crate::rpc::server::test_echo::TestEchoReply;
 use aether_actor::actor;
 use aether_substrate::actor::native::{NativeActor, NativeCtx, NativeInitCtx};
 use aether_substrate::chassis::error::BootError;

--- a/crates/aether-capabilities/src/lib.rs
+++ b/crates/aether-capabilities/src/lib.rs
@@ -67,12 +67,6 @@ pub mod render;
 pub mod rpc;
 pub mod tcp;
 pub mod test_bench;
-// Shared round-trip test scaffolding (echo actor + its kinds), used by the
-// `rpc::server` test modules and the `engine::proxy` test. Lives at the crate
-// root — not under `rpc` — because its consumers span families; a private
-// top-level `mod` is reachable crate-wide via module privacy.
-#[cfg(test)]
-mod test_echo;
 // `aether.text` cap (ADR-0105). CPU-only — composes the render texture
 // surface by mail — but feature-gated the two-layer way so a wasm
 // component can address it by type without pulling `fontdue` into the
@@ -83,17 +77,6 @@ pub mod trace;
 pub mod trampoline;
 #[cfg(feature = "ui")]
 pub mod ui;
-// First-party native `#[transform]`s (ADR-0048, issue 1464). The
-// link-time inventory submission populates both the headless
-// `TransformRegistry` and `describe_transforms` — both native. Native-
-// only: the `aether.fs` `fetch` verb that runs transforms is non-wasm,
-// and the `#[transform]` inventory entry is itself `cfg(not(wasm32))`-
-// gated, so on a wasm-header-only build the fn would be dead. No wasm
-// consumer runs transforms, so gate the whole module rather than carry
-// it dead.
-// Holds only the generic `mat4_apply`.
-#[cfg(not(target_family = "wasm"))]
-pub mod transforms;
 pub mod window;
 
 #[cfg(feature = "audio")]

--- a/crates/aether-capabilities/src/rpc/server/mod.rs
+++ b/crates/aether-capabilities/src/rpc/server/mod.rs
@@ -51,6 +51,14 @@ mod connection;
 #[cfg(test)]
 mod tests;
 
+// Round-trip test scaffolding (echo actor + its kinds) — the far-end
+// receiver of an RPC `Call`. `pub` so the sibling `engine::proxy` subtree
+// (which forwards onto this same `Call` path through a booted
+// `RpcServerCapability`) can reach it; `#[cfg(test)]`, so the `pub` never
+// reaches the cap's shipped surface.
+#[cfg(test)]
+pub mod test_echo;
+
 /// `aether.rpc.server` cap **identity** (ADR-0122 identity/runtime split,
 /// ADR-0123 struct-hosted form). A ZST carrying only the addressing —
 /// `Addressable` (`NAMESPACE`, `Resolver`), the per-handler `HandlesKind`

--- a/crates/aether-capabilities/src/rpc/server/test_echo.rs
+++ b/crates/aether-capabilities/src/rpc/server/test_echo.rs
@@ -1,14 +1,23 @@
-//! Shared test-support: a minimal echo actor plus its request / reply
-//! kinds, used by the `rpc::server` round-trip tests (the client half
-//! lives in `aether-rpc` per ADR-0102) and the `engine::proxy` test.
+//! Test-support for the RPC server round-trip path: a minimal echo actor
+//! plus its request / reply kinds — the far-end receiver of an RPC `Call`
+//! that actually replies. Used by the `rpc::server` round-trip tests
+//! (the client half lives in `aether-rpc` per ADR-0102) and by the
+//! `engine::proxy` test, which forwards onto this same `Call` path
+//! through a booted `RpcServerCapability`.
+//!
+//! Lives under `rpc::server` (not the crate root) because both consumers
+//! are RPC-server round-trips — `engine::proxy` already reaches into
+//! `crate::rpc::server` for the server cap. The whole module is
+//! `#[cfg(test)] pub mod` (gated at its `mod` declaration in the server
+//! `mod.rs`): `pub` only exists in test builds, so it is never part of
+//! the cap's shipped surface, and it stays reachable crate-wide from the
+//! sibling `engine::proxy` subtree.
 //!
 //! The kinds live at this module's root (not nested in a `mod tests`)
 //! so the `Kind` derive's inventory submission stays addressable from a
 //! path the linker keeps — and so the derive registers them in
 //! `aether_kinds::descriptors::all()` for the test substrate's registry
-//! walk. The whole module is `#[cfg(test)]` (gated at the `mod`
-//! declaration in `lib.rs`): it is test scaffolding, not part of
-//! the cap's shipped surface.
+//! walk.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/aether-capabilities/src/rpc/server/tests.rs
+++ b/crates/aether-capabilities/src/rpc/server/tests.rs
@@ -44,7 +44,7 @@ fn boot_with_rpc_server_only(timeout: Duration) -> (PassiveChassis<TestChassis>,
 /// handshake. Shared by the deferred-reply settlement tests. Returns
 /// `(chassis, stream)`; both must stay alive for the listener.
 fn boot_with_deferred_echo(timeout: Duration) -> (PassiveChassis<TestChassis>, TcpStream) {
-    use crate::test_echo::DeferredEchoActor;
+    use crate::rpc::server::test_echo::DeferredEchoActor;
     use crate::trace::TraceDispatchCapability;
 
     let (registry, mailer) = fresh_substrate();
@@ -157,8 +157,8 @@ fn ping_pong_roundtrip() {
 /// phase 2.
 #[test]
 fn call_echo_round_trip_event_then_end() {
+    use crate::rpc::server::test_echo::{TestEchoActor, TestEchoReply, TestEchoRequest};
     use crate::rpc::{MailEnvelope, MailboxAddress};
-    use crate::test_echo::{TestEchoActor, TestEchoReply, TestEchoRequest};
     use crate::trace::TraceDispatchCapability;
     use aether_actor::Addressable;
     use aether_data::{Kind, mailbox_id_from_name};
@@ -321,8 +321,10 @@ fn call_headless_window_set_mode_err_reaches_component_reply() {
 /// `ReplyEnd`, then the late reply dropped).
 #[test]
 fn call_deferred_echo_settles_after_reply() {
+    use crate::rpc::server::test_echo::{
+        DeferredEchoActor, DeferredEchoReply, DeferredEchoRequest,
+    };
     use crate::rpc::{MailEnvelope, MailboxAddress};
-    use crate::test_echo::{DeferredEchoActor, DeferredEchoReply, DeferredEchoRequest};
     use aether_actor::Addressable;
     use aether_data::{Kind, mailbox_id_from_name};
 
@@ -396,8 +398,10 @@ fn call_deferred_echo_settles_after_reply() {
 /// behind 50ms sleeps); the test pairs by `value`.
 #[test]
 fn dispatch_traced_with_deferred_replies_routes_each_event_then_settles() {
+    use crate::rpc::server::test_echo::{
+        DeferredEchoActor, DeferredEchoReply, DeferredEchoRequest,
+    };
     use crate::rpc::{MailEnvelope, MailboxAddress};
-    use crate::test_echo::{DeferredEchoActor, DeferredEchoReply, DeferredEchoRequest};
     use crate::trace::TraceDispatchCapability;
     use aether_actor::Addressable;
     use aether_data::{Kind, mailbox_id_from_name};
@@ -499,8 +503,8 @@ fn dispatch_traced_with_deferred_replies_routes_each_event_then_settles() {
 /// no stale `ReplyEvent` / `ReplyEnd` frames are in the way.
 #[test]
 fn call_without_cid_is_fire_and_forget() {
+    use crate::rpc::server::test_echo::{TestEchoActor, TestEchoRequest};
     use crate::rpc::{MailEnvelope, MailboxAddress};
-    use crate::test_echo::{TestEchoActor, TestEchoRequest};
     use aether_actor::Addressable;
     use aether_data::{Kind, mailbox_id_from_name};
 
@@ -670,8 +674,8 @@ fn client_peer_kind() -> PeerKind {
 /// ADR-0124; this integration test stays here, where the server lives).
 #[test]
 fn call_echo_round_trips_over_the_socket() {
+    use crate::rpc::server::test_echo::{TestEchoActor, TestEchoReply, TestEchoRequest};
     use crate::rpc::{MailEnvelope, MailboxAddress, RpcClient};
-    use crate::test_echo::{TestEchoActor, TestEchoReply, TestEchoRequest};
     use crate::trace::TraceDispatchCapability;
     use aether_actor::Addressable;
     use aether_data::{Kind, mailbox_id_from_name};

--- a/crates/aether-kinds/src/lib.rs
+++ b/crates/aether-kinds/src/lib.rs
@@ -17,6 +17,11 @@ pub mod descriptors;
 pub mod keycode;
 pub mod text_metrics;
 pub mod trace;
+// First-party native `#[transform]`s (ADR-0048, issue 1464). Native-only
+// (no wasm consumer runs transforms) and co-located with the `Mat4Apply`
+// kind the sole transform consumes. Holds only the generic `mat4_apply`.
+#[cfg(not(target_family = "wasm"))]
+pub mod transforms;
 
 pub use text_metrics::{CachedFontMetrics, scale_units};
 

--- a/crates/aether-kinds/src/transforms.rs
+++ b/crates/aether-kinds/src/transforms.rs
@@ -2,16 +2,19 @@
 //! `#[transform]` here links into both `aether-substrate-bundle` (the
 //! headless binary's `TransformRegistry::from_inventory`) and
 //! `aether-mcp` (`describe_transforms`), so the link-time inventory
-//! submission populates both surfaces with no extra wiring.
+//! submission populates both surfaces with no extra wiring. Co-located
+//! with the `Mat4Apply` kind it consumes.
 //!
-//! These ship in the production binaries — they are not `#[cfg(test)]`
-//! like the `aether.fs` fetch fixtures' `double_fs` / `seed_fs` transforms.
+//! Native-only: the `aether.fs` `fetch` verb that runs transforms is
+//! non-wasm, and no wasm consumer runs transforms, so the whole module
+//! is `#[cfg(not(target_family = "wasm"))]`-gated at its `mod`
+//! declaration rather than carried dead on the wasm-header-only build.
 //!
 //! `mat4_apply` is ADR-0048's first first-party transform — a generic
 //! linear-algebra node.
 
+use crate::Mat4Apply;
 use aether_data::transform;
-use aether_kinds::Mat4Apply;
 use aether_math::Vec4;
 
 /// Apply a 4×4 matrix to a 4-vector, `M · v` (ADR-0048's first
@@ -34,7 +37,7 @@ fn mat4_apply(input: Mat4Apply) -> Vec4 {
 #[cfg(test)]
 mod tests {
     use super::mat4_apply;
-    use aether_kinds::Mat4Apply;
+    use crate::Mat4Apply;
     use aether_math::{Mat4, Vec4};
 
     #[test]


### PR DESCRIPTION
Evicts the two non-capability residents from the `aether-capabilities` crate root.

## `mat4_apply` → `aether-kinds`

The sole first-party `#[transform]` isn't a capability — it's a generic `Mat4 · Vec4` node. It now lives in `aether-kinds`, next to the `Mat4Apply` kind it consumes. Both link consumers (`aether-substrate-bundle`, `aether-mcp`) already depend on `aether-kinds`, so the link-time inventory submission still populates the substrate `TransformRegistry` and `describe_transforms` — verified by building the headless bundle. The `#[cfg(not(target_family = "wasm"))]` gate is kept.

Bonus cleanup: `aether-capabilities` no longer needs its `aether-math` dependency — `mat4_apply` was its only user.

## `test_echo` → `crate::rpc::server::test_echo`

`test_echo` is the far-end receiver of an RPC `Call` — a real actor that replies, so the transport/settlement path can be exercised without coupling to a production cap. It sat at the crate root only because a second consumer (`engine::proxy`) appeared, but that isn't a genuinely separate consumer: the proxy round-trip test boots an `RpcServerCapability` and forwards onto the *same* `Call` path, and it already imports from `crate::rpc::server`.

So it moves under `rpc::server` as a `#[cfg(test)] pub mod`. The `pub` only exists in test builds — never part of the cap's shipped surface — while keeping it reachable from the sibling `engine::proxy` subtree (a private root `mod` gave that reach for free; a non-root private `mod` would not).

## Verification

- `aether-kinds` builds (transform macro is fine under `no_std`); the `mat4_apply` test passes.
- All 16 `rpc::server` + `engine::proxy` round-trip tests pass.
- `cargo clippy --all-targets -D warnings` clean on both crates.
- `aether-substrate-headless` links (confirms the transform still reaches the registry from inventory).

Both file moves are recorded as git renames, so history is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
