### PR TITLE
feat(capabilities): master reverb send on the audio mixer

### DIFF
--- a/crates/aether-capabilities/src/audio/kinds.rs
+++ b/crates/aether-capabilities/src/audio/kinds.rs
@@ -1,5 +1,5 @@
 //! The `aether.audio.*` mail vocabulary (ADR-0121: the capability owns
-//! its kinds). The 11 audio kinds — the cast-shaped real-time triggers
+//! its kinds). The 13 audio kinds — the cast-shaped real-time triggers
 //! (`NoteOn` / `NoteOff` / `SetMasterGain`) and the structured control
 //! plane (`SetMasterGain`'s reply, the ADR-0104 scheduled batch, the
 //! ADR-0103 track lane, and the ADR-0103 sampled-bank loader) — live
@@ -92,6 +92,36 @@ pub struct SetMasterGain {
 #[kind(name = "aether.audio.set_master_gain_result")]
 pub enum SetMasterGainResult {
     Ok { applied_gain: f32 },
+    Err { error: String },
+}
+
+/// Set the substrate's master reverb send (ADR-0126). `send` is a
+/// linear scalar applied to the mixer's summed dry output before it
+/// feeds a fixed-character Freeverb-style reverb; the wet signal is
+/// then added back into the mix. `0.0` is fully dry (the reverb inert
+/// by default), `1.0` sends the full mix through the reverb; values
+/// above `1.0` are clamped. Room size, damping, and wet gain are fixed
+/// substrate constants — no per-send tuning in v1 (ADR-0126).
+/// Desktop-only: headless and hub chassis reply with an
+/// `unsupported on <chassis>` error. Fire-and-forget in the happy path.
+#[repr(C)]
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Pod, Zeroable, aether_data::Kind, aether_data::Schema,
+)]
+#[kind(name = "aether.audio.set_reverb_send")]
+pub struct SetReverbSend {
+    pub send: f32,
+}
+
+/// Reply to `SetReverbSend` (ADR-0126). `Ok` echoes the send the
+/// substrate actually applied — values above `1.0` are clamped, so
+/// callers that sent `1.5` learn they got `1.0`. `Err` fires on
+/// chassis without an audio device (headless, hub) or when audio
+/// was disabled at boot via `AETHER_AUDIO_DISABLE`.
+#[derive(aether_data::Kind, aether_data::Schema, Serialize, Deserialize, Debug, Clone)]
+#[kind(name = "aether.audio.set_reverb_send_result")]
+pub enum SetReverbSendResult {
+    Ok { applied_send: f32 },
     Err { error: String },
 }
 

--- a/crates/aether-capabilities/src/audio/runtime/event.rs
+++ b/crates/aether-capabilities/src/audio/runtime/event.rs
@@ -41,6 +41,13 @@ pub enum AudioEvent {
     SetMasterGain {
         gain: f32,
     },
+    /// Set the master reverb send (ADR-0126): the linear scalar applied
+    /// to the mixer's summed dry output before it is fed into the
+    /// reverb, clamped `0.0..=1.0` by the handler before this event is
+    /// pushed.
+    SetReverbSend {
+        send: f32,
+    },
     /// Start (or restart) a track in the dedicated mixer lane. `pcm`
     /// is already mono and resampled to the device rate, so the
     /// callback walks it by index. Keyed by `(sender_mailbox, lane,

--- a/crates/aether-capabilities/src/audio/runtime/mod.rs
+++ b/crates/aether-capabilities/src/audio/runtime/mod.rs
@@ -29,13 +29,15 @@ use aether_actor::runtime;
 // event queue), schedule (the ADR-0104 heap entry), instrument (the built-in
 // registry), voice (the synthesis kernels), sample (the ADR-0103 sampled
 // banks), track (the ADR-0103 mixer lane), synth (the mixer aggregate + cpal
-// pipeline build), decode (the ADR-0103 §1 decode/resample core), and sfz (the
-// ADR-0103 §5 SFZ-subset parser).
+// pipeline build), decode (the ADR-0103 §1 decode/resample core), sfz (the
+// ADR-0103 §5 SFZ-subset parser), and reverb (the ADR-0126 master reverb
+// send DSP).
 mod config;
 mod decode;
 mod event;
 mod instrument;
 mod pipeline;
+mod reverb;
 mod sample;
 mod schedule;
 mod sfz;
@@ -58,7 +60,8 @@ use self::sample::{
 use self::sfz::parse_sfz;
 use super::kinds::{
     LoadInstrument, LoadInstrumentResult, NoteOff, NoteOn, PlayTrack, PlayTrackResult, Schedule,
-    ScheduleResult, SetMasterGain, SetMasterGainResult, StopTrack,
+    ScheduleResult, SetMasterGain, SetMasterGainResult, SetReverbSend, SetReverbSendResult,
+    StopTrack,
 };
 
 // The substrate-typed + native-only surface the parent's `#[actor] impl`
@@ -620,6 +623,35 @@ impl NativeActor for AudioCapability {
         }
     }
 
+    /// Set the master reverb send (ADR-0126).
+    ///
+    /// # Agent
+    /// Reply: `SetReverbSendResult`. `Ok { applied_send }` clamps to
+    /// `0.0..=1.0`; `Err` on chassis without audio.
+    #[handler]
+    fn on_set_reverb_send(
+        state: &mut Self::State,
+        _ctx: &mut NativeCtx<'_>,
+        mail: SetReverbSend,
+    ) -> SetReverbSendResult {
+        let applied = mail.send.clamp(0.0, 1.0);
+        let Some(s) = state.sender.as_ref() else {
+            return SetReverbSendResult::Err {
+                error: "audio pipeline not initialised on this desktop substrate".to_owned(),
+            };
+        };
+        let _ = s.push(AudioEvent::SetReverbSend { send: applied });
+        tracing::info!(
+            target: "aether_substrate::audio",
+            requested = mail.send,
+            applied,
+            "reverb send set",
+        );
+        SetReverbSendResult::Ok {
+            applied_send: applied,
+        }
+    }
+
     /// Schedule a batch of timed note events (ADR-0104).
     ///
     /// # Agent
@@ -1001,7 +1033,9 @@ mod tests {
     use super::sample::{SampleBank, SampleLoop, SampleRegion, SampleVoice, assemble_bank};
     use super::sfz::{SfzLoop, SfzRegion};
     use super::synth::Synth;
-    use super::voice::{MAX_VOICES, OscVoice, PartialBankVoice, voice_seed};
+    use super::voice::{
+        MAX_VOICES, OscVoice, PartialBankVoice, VoiceKernel, build_builtin_kernel, voice_seed,
+    };
     use super::*;
     use crate::fs::FsError;
     use aether_data::{MailId, MailboxId, SessionToken, Source, SourceAddr, Uuid};
@@ -1325,6 +1359,106 @@ mod tests {
         let mut tail = vec![0.0f32; release_samples];
         synth.fill(&mut tail, 1);
         assert_eq!(synth.voice_count(), 0);
+    }
+
+    // ADR-0126 master reverb send. `reverb_send` defaults to fully dry
+    // and only a `SetReverbSend` event changes it; these tests pin the
+    // inert-by-default invariant and the reverb tail's existence.
+
+    // Tripwire: with `reverb_send` at its default 0.0, `fill`'s output
+    // for a fixed note must exactly match an independent, reverb-free
+    // computation of the same voice — a regression that feeds the mix
+    // into the reverb regardless of `reverb_send`, or defaults the send
+    // to nonzero, would otherwise silently color every mix.
+    #[test]
+    fn reverb_send_zero_matches_pre_reverb_dry_mix_bit_for_bit() {
+        let (sender, queue) = new_event_channel();
+        let mut synth = Synth::new(queue, TEST_RATE);
+        sender
+            .push(AudioEvent::NoteOn {
+                sender_mailbox: MailboxId(1),
+                pitch: 60,
+                velocity: 100,
+                instrument_id: 0,
+            })
+            .unwrap();
+        assert_eq!(
+            synth.reverb_send(),
+            0.0,
+            "reverb send must default to fully dry",
+        );
+
+        let mut buf = vec![0.0f32; 480];
+        synth.fill(&mut buf, 1);
+
+        // Independent parallel computation of the dry mix: the exact
+        // same built-in kernel `trigger_note_on` would have built,
+        // stepped and mixed the same way `fill` does (master_gain at
+        // its 1.0 default), never touching the reverb.
+        let def = BUILTINS
+            .iter()
+            .find(|d| d.name == "sine_lead")
+            .expect("sine_lead is builtin id 0");
+        let mut kernel = build_builtin_kernel(MailboxId(1), 0, 60, 100, def, TEST_RATE);
+        let dt = 1.0 / TEST_RATE;
+        let expected: Vec<f32> = (0..480)
+            .map(|_| {
+                let dry = match &mut kernel {
+                    VoiceKernel::Oscillator(v) => v.next_sample(dt),
+                    VoiceKernel::PartialBank(v) => v.next_sample(dt),
+                    VoiceKernel::Sample(v) => v.next_sample(dt),
+                };
+                dry.tanh()
+            })
+            .collect();
+        assert_eq!(
+            buf, expected,
+            "reverb_send == 0.0 must not alter the dry mix",
+        );
+    }
+
+    #[test]
+    fn reverb_tail_persists_after_the_note_ends() {
+        let (sender, queue) = new_event_channel();
+        let mut synth = Synth::new(queue, TEST_RATE);
+        sender
+            .push(AudioEvent::SetReverbSend { send: 1.0 })
+            .unwrap();
+        sender
+            .push(AudioEvent::NoteOn {
+                sender_mailbox: MailboxId(1),
+                pitch: 60,
+                velocity: 100,
+                instrument_id: 0,
+            })
+            .unwrap();
+        let mut buf = vec![0.0f32; 480];
+        synth.fill(&mut buf, 1);
+        assert_eq!(synth.reverb_send(), 1.0);
+
+        sender
+            .push(AudioEvent::NoteOff {
+                sender_mailbox: MailboxId(1),
+                pitch: 60,
+                instrument_id: 0,
+            })
+            .unwrap();
+        // Drive well past the release so the voice fully frees.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let release_samples = (0.5 * TEST_RATE) as usize;
+        let mut tail = vec![0.0f32; release_samples];
+        synth.fill(&mut tail, 1);
+        assert_eq!(synth.voice_count(), 0, "voice should have released by now");
+
+        // Render a further block with no voices or tracks live — any
+        // energy here can only be the reverb's tail from the note that
+        // already ended.
+        let mut after = vec![0.0f32; 4_000];
+        synth.fill(&mut after, 1);
+        assert!(
+            after.iter().any(|s| s.abs() > 1.0e-6),
+            "expected a reverb tail after the note's voice had already ended",
+        );
     }
 
     // ADR-0104 scheduled note events. These drive `fill` with known
@@ -2278,6 +2412,89 @@ mod tests {
             ScheduleResult::Err { .. } => {}
             ScheduleResult::Ok { .. } => panic!("nop chassis must reply Err"),
         }
+    }
+
+    // `on_set_master_gain` / `on_set_reverb_send` — both a synchronous
+    // clamp-and-reply handler over a scalar. No prior coverage existed
+    // for the master-gain handler's nop-chassis `Err` / clamp behavior;
+    // backfilled alongside the new reverb-send handler.
+
+    #[test]
+    fn set_master_gain_on_nop_chassis_replies_err() {
+        let mut cap = AudioCapabilityState::nop();
+        let (mailer, _rx) = test_mailer_and_rx();
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            MailboxId(0),
+        ));
+        let mut ctx = load_ctx(&transport);
+        let result =
+            AudioCapability::on_set_master_gain(&mut cap, &mut ctx, SetMasterGain { gain: 0.5 });
+        match result {
+            SetMasterGainResult::Err { .. } => {}
+            SetMasterGainResult::Ok { .. } => panic!("nop chassis must reply Err"),
+        }
+    }
+
+    #[test]
+    fn set_master_gain_clamps_over_range_input() {
+        let (mut cap, queue) = live_cap();
+        let (mailer, _rx) = test_mailer_and_rx();
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            MailboxId(0),
+        ));
+        let mut ctx = load_ctx(&transport);
+        let result =
+            AudioCapability::on_set_master_gain(&mut cap, &mut ctx, SetMasterGain { gain: 1.5 });
+        match result {
+            SetMasterGainResult::Ok { applied_gain } => assert_eq!(applied_gain, 1.0),
+            SetMasterGainResult::Err { error } => panic!("expected Ok, got Err({error})"),
+        }
+        let event = queue.pop().expect("a set_master_gain event was queued");
+        assert!(
+            matches!(event, AudioEvent::SetMasterGain { gain } if gain == 1.0),
+            "expected SetMasterGain clamped to 1.0, got {event:?}",
+        );
+    }
+
+    #[test]
+    fn set_reverb_send_on_nop_chassis_replies_err() {
+        let mut cap = AudioCapabilityState::nop();
+        let (mailer, _rx) = test_mailer_and_rx();
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            MailboxId(0),
+        ));
+        let mut ctx = load_ctx(&transport);
+        let result =
+            AudioCapability::on_set_reverb_send(&mut cap, &mut ctx, SetReverbSend { send: 0.5 });
+        match result {
+            SetReverbSendResult::Err { .. } => {}
+            SetReverbSendResult::Ok { .. } => panic!("nop chassis must reply Err"),
+        }
+    }
+
+    #[test]
+    fn set_reverb_send_clamps_over_range_input() {
+        let (mut cap, queue) = live_cap();
+        let (mailer, _rx) = test_mailer_and_rx();
+        let transport = Arc::new(NativeBinding::new_for_test(
+            Arc::clone(&mailer),
+            MailboxId(0),
+        ));
+        let mut ctx = load_ctx(&transport);
+        let result =
+            AudioCapability::on_set_reverb_send(&mut cap, &mut ctx, SetReverbSend { send: 1.5 });
+        match result {
+            SetReverbSendResult::Ok { applied_send } => assert_eq!(applied_send, 1.0),
+            SetReverbSendResult::Err { error } => panic!("expected Ok, got Err({error})"),
+        }
+        let event = queue.pop().expect("a set_reverb_send event was queued");
+        assert!(
+            matches!(event, AudioEvent::SetReverbSend { send } if send == 1.0),
+            "expected SetReverbSend clamped to 1.0, got {event:?}",
+        );
     }
 
     /// Mono ramp samples for an in-memory WAV fixture.

--- a/crates/aether-capabilities/src/audio/runtime/reverb.rs
+++ b/crates/aether-capabilities/src/audio/runtime/reverb.rs
@@ -1,0 +1,173 @@
+//! Master reverb send DSP (ADR-0126). A mono Freeverb-style reverb —
+//! 8 damped comb filters in parallel feeding 4 series allpass filters —
+//! applied as a fixed-character send on the mixer's summed output. The
+//! room size, damping, and wet gain are fixed constants (ADR-0126); no
+//! per-instance tuning in v1.
+
+/// Comb filter tunings in samples at 44.1 kHz (the canonical Freeverb
+/// values). Each buffer is scaled to the actual device sample rate by
+/// [`Reverb::new`].
+const COMB_TUNINGS: [usize; 8] = [1116, 1188, 1277, 1356, 1422, 1491, 1557, 1617];
+
+/// Allpass filter tunings in samples at 44.1 kHz (the canonical
+/// Freeverb values), scaled the same way as the comb tunings.
+const ALLPASS_TUNINGS: [usize; 4] = [556, 441, 341, 225];
+
+/// The reference sample rate the tunings above are expressed against.
+const REFERENCE_SAMPLE_RATE: f32 = 44_100.0;
+
+/// Comb filter feedback (room size). Fixed (ADR-0126) rather than
+/// user-configurable in v1.
+const ROOM_SIZE: f32 = 0.84;
+
+/// Comb filter feedback low-pass coefficient (high-frequency damping).
+/// Fixed (ADR-0126).
+const DAMPING: f32 = 0.2;
+
+/// Allpass filter feedback. Fixed (ADR-0126), matching the canonical
+/// Freeverb value.
+const ALLPASS_FEEDBACK: f32 = 0.5;
+
+/// Fixed makeup gain applied to the summed, allpass-filtered wet
+/// signal before it is returned to the caller (ADR-0126). The caller
+/// mixes the wet output in proportion to its own `reverb_send` scalar;
+/// this constant only sets the reverb's own output level.
+const WET_GAIN: f32 = 0.35;
+
+/// One damped comb filter: a delay line whose feedback path is
+/// low-pass filtered before it re-enters the buffer, rolling off
+/// high frequencies as the tail decays (the standard Freeverb comb).
+struct Comb {
+    buffer: Vec<f32>,
+    index: usize,
+    feedback: f32,
+    damping: f32,
+    filterstore: f32,
+}
+
+impl Comb {
+    fn new(length: usize, feedback: f32, damping: f32) -> Self {
+        Self {
+            buffer: vec![0.0; length.max(1)],
+            index: 0,
+            feedback,
+            damping,
+            filterstore: 0.0,
+        }
+    }
+
+    fn tick(&mut self, input: f32) -> f32 {
+        let output = self.buffer[self.index];
+        self.filterstore = self
+            .filterstore
+            .mul_add(self.damping, output * (1.0 - self.damping));
+        self.buffer[self.index] = self.filterstore.mul_add(self.feedback, input);
+        self.index = (self.index + 1) % self.buffer.len();
+        output
+    }
+}
+
+/// One allpass filter: a delay line whose output combines the delayed
+/// sample with the negated input, passing all frequencies through at
+/// unity gain while diffusing the comb output into a smoother tail
+/// (the standard Freeverb allpass).
+struct Allpass {
+    buffer: Vec<f32>,
+    index: usize,
+    feedback: f32,
+}
+
+impl Allpass {
+    fn new(length: usize, feedback: f32) -> Self {
+        Self {
+            buffer: vec![0.0; length.max(1)],
+            index: 0,
+            feedback,
+        }
+    }
+
+    fn tick(&mut self, input: f32) -> f32 {
+        let buffered = self.buffer[self.index];
+        let output = -input + buffered;
+        self.buffer[self.index] = buffered.mul_add(self.feedback, input);
+        self.index = (self.index + 1) % self.buffer.len();
+        output
+    }
+}
+
+/// Mono Freeverb reverb (ADR-0126): 8 damped combs in parallel, summed
+/// and chained through 4 series allpass filters, scaled by a fixed wet
+/// gain. All delay buffers are allocated up front in [`Reverb::new`] —
+/// `process` never allocates.
+pub struct Reverb {
+    combs: Vec<Comb>,
+    allpasses: Vec<Allpass>,
+}
+
+impl Reverb {
+    /// Build a reverb tuned for `sample_rate`. Buffer lengths scale
+    /// from the 44.1 kHz reference tunings so the reverb character
+    /// stays consistent across device sample rates.
+    pub fn new(sample_rate: f32) -> Self {
+        let scale = |tuning: usize| -> usize {
+            // Tunings are small (< 2000) and sample rates are bounded
+            // well below 2^24, so the round-trip through f32 is exact
+            // and the rounded product is a small non-negative integer.
+            #[allow(
+                clippy::cast_precision_loss,
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss
+            )]
+            let scaled = ((tuning as f32) * sample_rate / REFERENCE_SAMPLE_RATE).round() as usize;
+            scaled
+        };
+        let combs = COMB_TUNINGS
+            .iter()
+            .map(|&t| Comb::new(scale(t), ROOM_SIZE, DAMPING))
+            .collect();
+        let allpasses = ALLPASS_TUNINGS
+            .iter()
+            .map(|&t| Allpass::new(scale(t), ALLPASS_FEEDBACK))
+            .collect();
+        Self { combs, allpasses }
+    }
+
+    /// Render one wet-only output sample for `input`. The 8 combs run
+    /// in parallel over the same input and sum; the sum then chains
+    /// through the 4 allpass filters in series; the result is scaled
+    /// by the fixed wet gain.
+    pub fn process(&mut self, input: f32) -> f32 {
+        let mut wet: f32 = self.combs.iter_mut().map(|c| c.tick(input)).sum();
+        for allpass in &mut self.allpasses {
+            wet = allpass.tick(wet);
+        }
+        wet * WET_GAIN
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Tripwire: an impulse's energy must still be audible several
+    // hundred samples later — a mis-wired comb/allpass (feedback
+    // dropped, buffer never delayed) would return the impulse
+    // unchanged or decay it to exact zero within one buffer pass.
+    #[test]
+    fn impulse_response_has_energy_several_hundred_samples_later() {
+        let mut reverb = Reverb::new(44_100.0);
+        reverb.process(1.0);
+        let mut found_late_energy = false;
+        for i in 0..2_000 {
+            let out = reverb.process(0.0);
+            if i >= 300 && out.abs() > 1.0e-6 {
+                found_late_energy = true;
+                break;
+            }
+        }
+        assert!(
+            found_late_energy,
+            "expected nonzero reverb tail several hundred samples after the impulse",
+        );
+    }
+}

--- a/crates/aether-capabilities/src/audio/runtime/synth.rs
+++ b/crates/aether-capabilities/src/audio/runtime/synth.rs
@@ -13,6 +13,7 @@ use aether_data::MailboxId;
 use super::super::kinds::ScheduledNote;
 use super::event::AudioEvent;
 use super::instrument::{BUILTINS, instrument_by_id};
+use super::reverb::Reverb;
 use super::sample::{SampleBank, SampleVoice};
 use super::schedule::{ScheduledEntry, millis_to_frames};
 use super::track::{TRACK_FADE_SECS, TrackVoice};
@@ -33,6 +34,14 @@ pub struct Synth {
     banks: Vec<Arc<SampleBank>>,
     sample_rate: f32,
     master_gain: f32,
+    /// Master reverb send (ADR-0126): the mono Freeverb-style DSP the
+    /// summed mix is fed through at `reverb_send` proportion.
+    reverb: Reverb,
+    /// Linear send scalar into `reverb`, clamped `0.0..=1.0`. `0.0`
+    /// (the default) is fully dry — the reverb only ever receives
+    /// silence, so its wet output stays exactly zero and the mix is
+    /// bit-for-bit identical to the pre-reverb dry sum.
+    reverb_send: f32,
     /// Monotonically increasing counter stamped into each `Voice::seq`
     /// at allocation. Voice-steal uses the minimum value to locate the
     /// oldest voice regardless of pool order.
@@ -59,6 +68,8 @@ impl Synth {
             banks: Vec::new(),
             sample_rate,
             master_gain: 1.0,
+            reverb: Reverb::new(sample_rate),
+            reverb_send: 0.0,
             next_seq: 0,
             frame_clock: 0,
             scheduled: BinaryHeap::new(),
@@ -205,6 +216,9 @@ impl Synth {
                 AudioEvent::SetMasterGain { gain } => {
                     self.master_gain = gain.clamp(0.0, 1.0);
                 }
+                AudioEvent::SetReverbSend { send } => {
+                    self.reverb_send = send.clamp(0.0, 1.0);
+                }
                 AudioEvent::TrackStart {
                     sender_mailbox,
                     lane,
@@ -345,6 +359,8 @@ impl Synth {
             for track in &mut self.tracks {
                 sample += track.next_sample();
             }
+            let wet = self.reverb.process(sample * self.reverb_send);
+            sample += wet;
             sample *= self.master_gain;
             sample = sample.tanh();
             let start = frame * channels;
@@ -372,6 +388,11 @@ impl Synth {
     #[cfg(test)]
     pub fn master_gain(&self) -> f32 {
         self.master_gain
+    }
+
+    #[cfg(test)]
+    pub fn reverb_send(&self) -> f32 {
+        self.reverb_send
     }
 
     #[cfg(test)]


### PR DESCRIPTION
Closes #2521.

## Summary

Adds a master reverb send to the audio mixer (Freeverb, ADR-0126). A new `reverb.rs` DSP module runs a wet return in `Synth::fill`; `SetReverbSend` / `SetReverbSendResult` kinds mirror the `SetMasterGain` set and drive the wet level through the existing event path.

## Test plan

New `on_set_reverb_send` handler tests. fmt + `cargo clippy --workspace --all-targets -D warnings` passed locally; full-workspace nextest/doc/wasm are re-run by CI (the local cold-rebuild validation was reclaimed under CI-as-gate — CI is the authoritative gate).

## Generated by

`/implement --sweep` — agent execution of scoped issue #2521.
