### PR TITLE
fix(capabilities): same-pitch notes from one sender steal each other's voice

### DIFF
--- a/crates/aether-capabilities/src/audio/kinds.rs
+++ b/crates/aether-capabilities/src/audio/kinds.rs
@@ -19,9 +19,11 @@ use serde::{Deserialize, Serialize};
 /// `instrument_id` indexes the substrate-resident instrument registry
 /// — v1 ships a fixed set; future patch-based instruments (Phase 2
 /// follow-up) will extend the id space without a wire change. The
-/// substrate keys the allocated voice by `(sender_mailbox, instrument_id,
-/// pitch)` so same-pitch notes from different senders or different
-/// instruments don't stomp each other. Fire-and-forget; no reply.
+/// substrate allocates a new voice per `NoteOn`, keyed by
+/// `(sender_mailbox, instrument_id, pitch)` — several voices can share
+/// a key, so two concurrent same-pitch notes from one sender each sound
+/// independently instead of one stealing the other's voice.
+/// Fire-and-forget; no reply.
 #[repr(C)]
 #[derive(
     Copy,
@@ -44,10 +46,14 @@ pub struct NoteOn {
 
 /// Release a note previously started with `NoteOn`. The substrate
 /// matches on `(sender_mailbox, instrument_id, pitch)` — the sender
-/// is taken from the mail envelope, not carried in the payload. A
-/// `NoteOff` that doesn't match any live voice is silently ignored
-/// (normal during race windows between envelope release and late
-/// note-offs). Fire-and-forget; no reply.
+/// is taken from the mail envelope, not carried in the payload. When
+/// several voices share that key (concurrent same-pitch notes from one
+/// sender), `NoteOff` releases the oldest one still sounding, pairing
+/// oldest-note-on with oldest-note-off — a second `NoteOff` on the same
+/// key then releases the next-oldest survivor. A `NoteOff` that doesn't
+/// match any live voice is silently ignored (normal during race windows
+/// between envelope release and late note-offs). Fire-and-forget; no
+/// reply.
 #[repr(C)]
 #[derive(
     Copy,
@@ -103,9 +109,10 @@ pub enum SetMasterGainResult {
 
 /// One note action in a scheduled batch (ADR-0104). The payload
 /// mirrors `note_on` / `note_off` exactly — a scheduled note allocates
-/// from the same voice pool, obeys the same steal policy, and keys
-/// note-off matching by the scheduling sender, as if the equivalent
-/// mail had arrived at the event's due instant.
+/// from the same voice pool, obeys the same steal policy, and matches
+/// `Off` to the oldest still-sounding voice on the scheduling sender's
+/// key, as if the equivalent mail had arrived at the event's due
+/// instant.
 #[derive(aether_data::Schema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum ScheduledNote {
     On {

--- a/crates/aether-capabilities/src/audio/runtime/mod.rs
+++ b/crates/aether-capabilities/src/audio/runtime/mod.rs
@@ -1486,11 +1486,14 @@ mod tests {
         assert_eq!(synth.voice_count(), 1, "note never fired in its block");
     }
 
+    /// Tripwire: two concurrent note-ons sharing a `(sender_mailbox,
+    /// instrument_id, pitch)` key must each allocate their own voice —
+    /// the second must not steal the first's slot (issue 2524).
     #[test]
-    fn retrigger_same_key_replaces_voice() {
+    fn same_key_note_ons_stack_voices() {
         let (sender, queue) = new_event_channel();
         let mut synth = Synth::new(queue, 48_000.0);
-        for _ in 0..3 {
+        for _ in 0..2 {
             sender
                 .push(AudioEvent::NoteOn {
                     sender_mailbox: MailboxId(1),
@@ -1502,7 +1505,71 @@ mod tests {
         }
         let mut buf = vec![0.0f32; 128];
         synth.fill(&mut buf, 1);
-        assert_eq!(synth.voice_count(), 1);
+        assert_eq!(
+            synth.voice_count(),
+            2,
+            "two same-key note-ons must both sound as independent voices",
+        );
+    }
+
+    /// Tripwire: with two voices stacked on one key, `NoteOff` must
+    /// release the oldest still-sounding voice and leave its sibling
+    /// alone — pairing oldest-note-on with oldest-note-off. A second
+    /// `NoteOff` on the same key then releases the survivor (issue 2524).
+    #[test]
+    fn note_off_releases_oldest_unreleased_voice_on_shared_key() {
+        let (sender, queue) = new_event_channel();
+        let mut synth = Synth::new(queue, 48_000.0);
+        for _ in 0..2 {
+            sender
+                .push(AudioEvent::NoteOn {
+                    sender_mailbox: MailboxId(1),
+                    pitch: 60,
+                    velocity: 100,
+                    instrument_id: 0,
+                })
+                .unwrap();
+        }
+        let mut buf = vec![0.0f32; 64];
+        synth.fill(&mut buf, 1);
+        assert_eq!(synth.voice_count(), 2, "setup: both note-ons must sound");
+
+        sender
+            .push(AudioEvent::NoteOff {
+                sender_mailbox: MailboxId(1),
+                pitch: 60,
+                instrument_id: 0,
+            })
+            .unwrap();
+        // instrument 0 (sine_lead) releases in 0.18s; run well past that
+        // so the released voice finishes its release ramp and is pruned,
+        // while its never-released sibling (held in Sustain) stays
+        // resident regardless of how long we run.
+        let mut tail = vec![0.0f32; 12_000];
+        synth.fill(&mut tail, 1);
+        assert_eq!(
+            synth.voice_count(),
+            1,
+            "note-off must release exactly the oldest voice, leaving its sibling sounding",
+        );
+        assert!(
+            synth.has_voice_with_pitch(60),
+            "the un-released sibling must still be sounding",
+        );
+
+        sender
+            .push(AudioEvent::NoteOff {
+                sender_mailbox: MailboxId(1),
+                pitch: 60,
+                instrument_id: 0,
+            })
+            .unwrap();
+        synth.fill(&mut tail, 1);
+        assert_eq!(
+            synth.voice_count(),
+            0,
+            "second note-off must release the surviving voice",
+        );
     }
 
     #[test]
@@ -1579,22 +1646,30 @@ mod tests {
     }
 
     /// Voice-steal must evict the oldest note (lowest seq) even after
-    /// the pool has been reordered by `swap_remove` in the retrigger path.
+    /// the pool has been reordered by `swap_remove` inside the steal
+    /// path itself — scrambled via distinct-key note-ons (same-key
+    /// note-ons no longer replace, so they can't be used to shuffle the
+    /// pool; issue 2524).
     ///
-    /// Setup: fill to `MAX_VOICES - 1` with pitches `0..(MAX_VOICES - 1)`
-    /// (pitch 0 gets seq 0). Retrigger pitch 0 while below capacity so no
-    /// steal fires: `swap_remove` moves the last voice to index 0, making
-    /// pitch 1 (seq 1, the new oldest) sit at index 1, not index 0. Fill to
-    /// `MAX_VOICES`, then push one more and assert pitch 1 was evicted
-    /// rather than the arbitrary voice that ended up at index 0.
+    /// Setup: fill to exactly `MAX_VOICES` with distinct pitches
+    /// `0..MAX_VOICES` (pitch 0 -> seq 0, ..., pitch `MAX_VOICES - 1` ->
+    /// seq `MAX_VOICES - 1`; no steal fires yet, pool order == seq
+    /// order). Push one more distinct-pitch note: steal fires, evicting
+    /// pitch 0 (seq 0) at index 0 via `swap_remove`, which moves the
+    /// last-pushed voice (pitch `MAX_VOICES - 1`) into index 0 — so the
+    /// new oldest surviving voice (pitch 1, seq 1) now sits at index 1,
+    /// not index 0. Push one more distinct-pitch note: a naive "evict
+    /// index 0" bug would evict pitch `MAX_VOICES - 1`; seq-based steal
+    /// must evict pitch 1 instead.
     #[test]
     fn voice_steal_evicts_oldest_note() {
         let (sender, queue) = new_event_channel();
         let mut synth = Synth::new(queue, 48_000.0);
 
-        // Fill to MAX_VOICES - 1. Pitch 0 -> seq 0; pitch 1 -> seq 1.
-        // Pitch 1 will become the oldest surviving voice after the retrigger.
-        for pitch in 0..(MAX_VOICES - 1) {
+        // Fill to exactly MAX_VOICES with distinct pitches. Pitch 0 ->
+        // seq 0; pitch 1 -> seq 1. No steal fires (len < MAX_VOICES on
+        // every push), so pool order matches seq order.
+        for pitch in 0..MAX_VOICES {
             sender
                 .push(AudioEvent::NoteOn {
                     sender_mailbox: MailboxId(1),
@@ -1606,45 +1681,38 @@ mod tests {
         }
         let mut buf = vec![0.0f32; 64];
         synth.fill(&mut buf, 1);
-        assert_eq!(synth.voice_count(), MAX_VOICES - 1);
+        assert_eq!(synth.voice_count(), MAX_VOICES);
 
-        // Retrigger pitch=0 while below capacity (no steal fires).
-        // swap_remove moves the last voice to index 0; the oldest
-        // surviving voice (pitch=1, seq=1) is now at index 1, not index 0.
+        // One more distinct-pitch note-on at capacity: steal fires,
+        // evicting pitch=0 (seq=0) at index 0. swap_remove moves the
+        // last voice (pitch=MAX_VOICES-1) into index 0, scrambling the
+        // pool so pitch=1 (seq=1, the new oldest survivor) sits at
+        // index 1, not index 0.
         sender
             .push(AudioEvent::NoteOn {
                 sender_mailbox: MailboxId(1),
-                pitch: 0,
-                velocity: 100,
-                instrument_id: 0,
-            })
-            .unwrap();
-        synth.fill(&mut buf, 1);
-        assert_eq!(synth.voice_count(), MAX_VOICES - 1);
-        assert!(
-            synth.has_voice_with_pitch(1),
-            "pitch=1 (oldest after retrigger) must still be present",
-        );
-
-        // Fill the last slot — no steal yet.
-        sender
-            .push(AudioEvent::NoteOn {
-                sender_mailbox: MailboxId(1),
-                pitch: u8::try_from(MAX_VOICES - 1).unwrap(),
+                pitch: u8::try_from(MAX_VOICES).unwrap(),
                 velocity: 100,
                 instrument_id: 0,
             })
             .unwrap();
         synth.fill(&mut buf, 1);
         assert_eq!(synth.voice_count(), MAX_VOICES);
+        assert!(!synth.has_voice_with_pitch(0), "pitch=0 must be evicted");
+        assert!(
+            synth.has_voice_with_pitch(1),
+            "pitch=1 (new oldest after the first steal's scramble) must still be present",
+        );
 
-        // One more note — steal fires. The oldest voice is pitch=1 (seq=1),
-        // sitting at index 1 after the retrigger scramble. A naive remove(0)
-        // would evict the wrong voice; seq-based steal must evict pitch=1.
+        // One more distinct-pitch note — steal fires again. The oldest
+        // voice is pitch=1 (seq=1), sitting at index 1 after the
+        // scramble above. A naive "evict index 0" bug would instead
+        // evict pitch=MAX_VOICES-1 (the voice the first steal moved to
+        // index 0); seq-based steal must evict pitch=1.
         sender
             .push(AudioEvent::NoteOn {
                 sender_mailbox: MailboxId(1),
-                pitch: 100,
+                pitch: u8::try_from(MAX_VOICES + 1).unwrap(),
                 velocity: 100,
                 instrument_id: 0,
             })
@@ -1654,6 +1722,10 @@ mod tests {
         assert!(
             !synth.has_voice_with_pitch(1),
             "voice steal must evict the oldest note (pitch=1, seq=1), not an arbitrary one",
+        );
+        assert!(
+            synth.has_voice_with_pitch(u8::try_from(MAX_VOICES - 1).unwrap()),
+            "the voice the first steal scrambled to index 0 must survive the second steal",
         );
     }
 

--- a/crates/aether-capabilities/src/audio/runtime/synth.rs
+++ b/crates/aether-capabilities/src/audio/runtime/synth.rs
@@ -88,10 +88,12 @@ impl Synth {
     /// Admit a `note_on`: resolve its kernel (a built-in patch, or — when
     /// the id walks past the built-ins — a loaded sample bank's region
     /// selected by `(pitch, velocity)`), then steal the oldest voice if
-    /// at capacity, replace any voice already on the same key, and push.
-    /// A miss on both kernel sources (unknown id, or a bank with no
-    /// region covering the note) warn-drops without touching the pool
-    /// (ADR-0103 §6).
+    /// at capacity, and push. A second note-on on the same
+    /// `(sender_mailbox, instrument_id, pitch)` key stacks a new voice
+    /// rather than replacing the existing one, so concurrent same-pitch
+    /// notes from one sender each sound independently. A miss on both
+    /// kernel sources (unknown id, or a bank with no region covering the
+    /// note) warn-drops without touching the pool (ADR-0103 §6).
     pub fn trigger_note_on(
         &mut self,
         sender_mailbox: MailboxId,
@@ -140,13 +142,6 @@ impl Synth {
                 self.voices.swap_remove(oldest_idx);
             }
         }
-        if let Some(existing) = self.voices.iter().position(|v| {
-            v.sender_mailbox == sender_mailbox
-                && v.instrument_id == instrument_id
-                && v.pitch == pitch
-        }) {
-            self.voices.swap_remove(existing);
-        }
         let seq = self.next_seq;
         self.next_seq += 1;
         self.voices.push(Voice {
@@ -155,19 +150,34 @@ impl Synth {
             pitch,
             seq,
             kernel,
+            released: false,
         });
     }
 
-    /// Release the voice matching `(sender_mailbox, instrument_id,
-    /// pitch)`, if one is sounding. A miss is a silent no-op (a late or
-    /// unmatched note-off), matching the immediate `note_off` path.
-    /// Shared by the queue-drained note-off and the scheduled note-off.
+    /// Release the oldest unreleased voice matching `(sender_mailbox,
+    /// instrument_id, pitch)`, if one is sounding. Several voices can
+    /// share a key now that same-key note-ons stack (no more
+    /// steal-on-retrigger), so note-off pairs oldest-note-on with
+    /// oldest-note-off: among the matching voices, pick the
+    /// minimum-`seq` one that hasn't already been released. The
+    /// `!released` filter is load-bearing — without it, a second
+    /// note-off on the same key would re-release an already-fading
+    /// voice and strand its still-sounding sibling as a stuck note. A
+    /// miss (no matching unreleased voice) is a silent no-op (a late or
+    /// unmatched note-off), matching the previous behavior. Shared by
+    /// the queue-drained note-off and the scheduled note-off.
     pub fn trigger_note_off(&mut self, sender_mailbox: MailboxId, pitch: u8, instrument_id: u8) {
-        if let Some(v) = self.voices.iter_mut().find(|v| {
-            v.sender_mailbox == sender_mailbox
-                && v.instrument_id == instrument_id
-                && v.pitch == pitch
-        }) {
+        if let Some(v) = self
+            .voices
+            .iter_mut()
+            .filter(|v| {
+                v.sender_mailbox == sender_mailbox
+                    && v.instrument_id == instrument_id
+                    && v.pitch == pitch
+                    && !v.released
+            })
+            .min_by_key(|v| v.seq)
+        {
             v.note_off();
         }
     }

--- a/crates/aether-capabilities/src/audio/runtime/voice.rs
+++ b/crates/aether-capabilities/src/audio/runtime/voice.rs
@@ -462,7 +462,7 @@ pub enum VoiceKernel {
 /// Build the kernel for a built-in instrument patch (oscillator or
 /// partial bank). Split out of [`Voice`] so the `note_on` path can
 /// resolve a built-in or a loaded sample bank into a `VoiceKernel`
-/// before the steal / dedup bookkeeping, then stamp one `Voice`.
+/// before the steal bookkeeping, then stamp one `Voice`.
 pub fn build_builtin_kernel(
     sender_mailbox: MailboxId,
     instrument_id: u8,
@@ -501,6 +501,12 @@ pub fn build_builtin_kernel(
 /// `seq` is a monotonically increasing counter stamped at allocation,
 /// used by voice-steal to locate the oldest voice regardless of the
 /// pool's current order (which `swap_remove` scrambles).
+///
+/// `released` marks a voice whose `note_off` has already fired. Several
+/// voices can share the same `(sender_mailbox, instrument_id, pitch)`
+/// key now that same-key note-ons stack instead of stealing each
+/// other's slot; `released` lets note-off pick the oldest *unreleased*
+/// voice on that key rather than re-releasing one already fading out.
 #[derive(Clone, Debug)]
 pub struct Voice {
     pub sender_mailbox: MailboxId,
@@ -508,6 +514,7 @@ pub struct Voice {
     pub pitch: u8,
     pub seq: u64,
     pub kernel: VoiceKernel,
+    pub released: bool,
 }
 
 impl Voice {
@@ -517,6 +524,7 @@ impl Voice {
             VoiceKernel::PartialBank(v) => v.note_off(),
             VoiceKernel::Sample(v) => v.note_off(),
         }
+        self.released = true;
     }
 
     pub fn done(&self) -> bool {


### PR DESCRIPTION
Closes #2524.

## Summary

Fixes same-pitch note collision in the synth: two `note_on`s at the same key from one sender no longer steal each other's voice. `trigger_note_on` drops the same-key dedup so concurrent same-pitch voices coexist; `trigger_note_off` releases the oldest still-unreleased voice for that key (new `Voice.released` flag).

## Test plan

Reworked voice-keying tests covering concurrent same-key voices and oldest-unreleased note-off. fmt + clippy passed locally; full-workspace nextest/doc/wasm re-run by CI under CI-as-gate.

## Generated by

`/implement --sweep` — agent execution of scoped issue #2524.
